### PR TITLE
fix(gateway): reclaim a channel account's routes when its task is aborted

### DIFF
--- a/extensions/zalo/src/monitor.polling.media-reply.test-support.ts
+++ b/extensions/zalo/src/monitor.polling.media-reply.test-support.ts
@@ -624,7 +624,7 @@ describe("Zalo polling media replies", () => {
     },
   );
 
-  it("registers each active registry and cleans both on final release", async () => {
+  it("registers each active registry and cleans the swapped-out one with its holder", async () => {
     const firstRegistry = createEmptyPluginRegistry();
     setActivePluginRegistry(firstRegistry);
     getUpdatesMock.mockImplementation(() => new Promise(() => {}));
@@ -669,7 +669,10 @@ describe("Zalo polling media replies", () => {
       expect(secondRegistry.httpRoutes).toHaveLength(1);
       firstAbort.abort();
       await firstRun;
-      expect(firstRegistry.httpRoutes).toHaveLength(1);
+      // The swapped-out registry's route follows its own holder: the stopped
+      // monitor was its only share, so keeping it registered would strand a
+      // holder-less route instead of tracking live ownership.
+      expect(firstRegistry.httpRoutes).toHaveLength(0);
       expect(secondRegistry.httpRoutes).toHaveLength(1);
     } finally {
       firstAbort.abort();

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -31,11 +31,7 @@ import {
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "openclaw/plugin-sdk/runtime-group-policy";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
-import {
-  canonicalizeWebhookRouteKey,
-  registerPluginHttpRoute,
-  resolveWebhookPath,
-} from "openclaw/plugin-sdk/webhook-ingress";
+import { registerPluginHttpRoute, resolveWebhookPath } from "openclaw/plugin-sdk/webhook-ingress";
 import type { ResolvedZaloAccount } from "./accounts.js";
 import {
   ZaloApiError,
@@ -122,7 +118,6 @@ type ZaloPollingLoopParams = ZaloProcessingContext & {
 type ZaloUpdateProcessingParams = ZaloProcessingContext & {
   update: ZaloUpdate;
 };
-const hostedMediaRouteRefs = new Map<string, { count: number; unregisters: Array<() => void> }>();
 
 function resolveZaloTimestampMs(date: number | undefined): number | undefined {
   if (!date) {
@@ -148,10 +143,12 @@ function registerSharedHostedMediaRoute(params: {
   path: string;
   log?: (message: string) => void;
 }): () => void {
-  const routeKey = canonicalizeWebhookRouteKey(params.path);
   // Every account attempts the account-agnostic route so the first acquire after a registry swap
   // repopulates it; exact same-owner conflicts reuse the existing route without replacement.
-  const unregister = registerPluginHttpRoute({
+  // The returned unregister releases this account's holder share only: shared-holder lifetime
+  // is one registry record per holder, so the route is removed when the last share is released —
+  // including shares the gateway revokes when it abandons a stuck account task.
+  return registerPluginHttpRoute({
     auth: "plugin",
     match: "prefix",
     path: params.path,
@@ -169,35 +166,6 @@ function registerSharedHostedMediaRoute(params: {
       }
     },
   });
-  const acquired = hostedMediaRouteRefs.get(routeKey) ?? {
-    count: 0,
-    unregisters: [],
-  };
-  if (acquired.count === 0) {
-    hostedMediaRouteRefs.set(routeKey, acquired);
-  }
-  acquired.count += 1;
-  acquired.unregisters.push(unregister);
-
-  let released = false;
-  return () => {
-    if (released) {
-      return;
-    }
-    released = true;
-    const current = hostedMediaRouteRefs.get(routeKey);
-    if (current !== acquired) {
-      return;
-    }
-    acquired.count -= 1;
-    if (acquired.count > 0) {
-      return;
-    }
-    hostedMediaRouteRefs.delete(routeKey);
-    for (const unregisterHandle of acquired.unregisters) {
-      unregisterHandle();
-    }
-  };
 }
 
 type ZaloMessagePipelineParams = ZaloProcessingContext & {
@@ -961,11 +929,15 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
 
   try {
     if (hostedMediaRoutePath) {
-      const unregisterHostedMediaRoute = registerSharedHostedMediaRoute({
-        path: hostedMediaRoutePath,
-        log: runtime.log,
-      });
-      stopHandlers.push(unregisterHostedMediaRoute);
+      // The returned unregister releases this account's holder share; the
+      // registry removes the shared route only when the last share is
+      // released, including shares revoked by the gateway at abandonment.
+      stopHandlers.push(
+        registerSharedHostedMediaRoute({
+          path: hostedMediaRoutePath,
+          log: runtime.log,
+        }),
+      );
     }
 
     if (useWebhook) {

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -2010,6 +2010,63 @@ describe("server-channels auto restart", () => {
     expect(account?.lastError).toBeNull();
   });
 
+  it("keeps a shared account-agnostic route alive when the first account's task is discarded", async () => {
+    const routeRegistry = createEmptyPluginRegistry();
+    let firstSharedHandler: unknown;
+    const startAccount = vi.fn(async (_ctx: ChannelGatewayContext<TestAccount>) => {
+      // Account-agnostic shared ingress: every account registers the same
+      // canonical path and same-owner reuse attaches it instead of conflicting.
+      registerPluginHttpRoute({
+        path: "/shared/webhook",
+        handler: () => true,
+        auth: "plugin",
+        match: "prefix",
+        pluginId: "discord",
+        source: "shared-ingress",
+        reuseExistingSameOwner: true,
+        throwOnFailure: true,
+        registry: routeRegistry,
+      });
+      firstSharedHandler ??= (routeRegistry.httpRoutes ?? []).find(
+        (route) => route.path === "/shared/webhook",
+      )?.handler;
+      // A stuck drain: this task never settles and never unregisters its route.
+      await new Promise<void>(() => {});
+    });
+    installTestRegistry(
+      createTestPlugin({
+        startAccount,
+        listAccountIds: () => [DEFAULT_ACCOUNT_ID, "second"],
+      }),
+    );
+    const manager = createManager({ getPluginHttpRouteRegistry: () => routeRegistry });
+
+    await manager.startChannels();
+    expect(
+      (routeRegistry.httpRoutes ?? []).filter((route) => route.path === "/shared/webhook"),
+    ).toHaveLength(1);
+
+    const recoveryStopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, {
+      manual: false,
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await recoveryStopTask;
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+
+    // The discarded first task's lease revocation must not evict the shared
+    // route the second account still serves: the surviving entry is the one the
+    // first account registered, not a successor re-creation.
+    const sharedRoutes = (routeRegistry.httpRoutes ?? []).filter(
+      (route) => route.path === "/shared/webhook",
+    );
+    expect(sharedRoutes).toHaveLength(1);
+    expect(sharedRoutes[0]?.handler).toBe(firstSharedHandler);
+    expect(startAccount).toHaveBeenCalledTimes(3);
+    const secondAccount = manager.getRuntimeSnapshot().channelAccounts.discord?.second;
+    expect(secondAccount?.running).toBe(true);
+  });
+
   it("keeps the second recovery task running when the stale task rejects", async () => {
     const releaseFirstTask = createDeferred();
     let startCount = 0;

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -25,6 +25,7 @@ import {
   runtimeForLogger,
 } from "../logging/subsystem.js";
 import { registerPluginCommandInRegistry } from "../plugins/command-registration.js";
+import { registerPluginHttpRoute } from "../plugins/http-registry.js";
 import { createPluginCommandRuntime } from "../plugins/plugin-command-runtime.js";
 import { createEmptyPluginRegistry, type PluginRegistry } from "../plugins/registry.js";
 import { getActivePluginRegistry, setActivePluginRegistry } from "../plugins/runtime.js";
@@ -271,6 +272,7 @@ function createManager(options?: {
   ambientAutostartSuppressedChannelIds?: ReadonlySet<string>;
   tryRecoverAutostartSuppression?: () => boolean;
   getNativeApprovalRuntime?: () => GatewayNativeApprovalRuntime | undefined;
+  getPluginHttpRouteRegistry?: () => PluginRegistry;
 }) {
   const log = createSubsystemLogger("gateway/server-channels-test");
   const channelLogs = { discord: log } as Record<ChannelId, SubsystemLogger>;
@@ -303,6 +305,9 @@ function createManager(options?: {
       : {}),
     ...(options?.getNativeApprovalRuntime
       ? { getNativeApprovalRuntime: options.getNativeApprovalRuntime }
+      : {}),
+    ...(options?.getPluginHttpRouteRegistry
+      ? { getPluginHttpRouteRegistry: options.getPluginHttpRouteRegistry }
       : {}),
   });
   createdManagers.push({ channelIds, manager });
@@ -1900,6 +1905,49 @@ describe("server-channels auto restart", () => {
     expect(account?.running).toBe(true);
     expect(account?.restartPending).toBe(false);
     expect(account?.reconnectAttempts).toBe(0);
+    expect(account?.lastError).toBeNull();
+  });
+
+  it("lets a recovery replacement reclaim the abandoned task's HTTP route", async () => {
+    const routeRegistry = createEmptyPluginRegistry();
+    const startAccount = vi.fn(async ({ accountId }: ChannelGatewayContext<TestAccount>) => {
+      registerPluginHttpRoute({
+        path: `/discord/interactions/${accountId}`,
+        handler: () => true,
+        auth: "plugin",
+        match: "exact",
+        pluginId: "discord",
+        source: "discord-interactions",
+        accountId,
+        throwOnFailure: true,
+        registry: routeRegistry,
+      });
+      // A stuck drain: this task never settles and never unregisters its route.
+      await new Promise<void>(() => {});
+    });
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager({ getPluginHttpRouteRegistry: () => routeRegistry });
+
+    await manager.startChannels();
+    const recoveryStopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, {
+      manual: false,
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await recoveryStopTask;
+
+    // The timed-out stop abandons the stuck task, so the two-call recovery
+    // contract starts a replacement. The replacement must be able to register
+    // the same account route instead of crash-looping on a conflict.
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+
+    const accountRoutes = (routeRegistry.httpRoutes ?? []).filter(
+      (route) => route.path === `/discord/interactions/${DEFAULT_ACCOUNT_ID}`,
+    );
+    expect(accountRoutes).toHaveLength(1);
+    expect(accountRoutes[0]?.source).toBe("discord-interactions");
+    const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(account?.running).toBe(true);
     expect(account?.lastError).toBeNull();
   });
 

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -2067,6 +2067,67 @@ describe("server-channels auto restart", () => {
     expect(secondAccount?.running).toBe(true);
   });
 
+  it("removes a shared account-agnostic route once every holder ends, abandoned or stopped", async () => {
+    const routeRegistry = createEmptyPluginRegistry();
+    let startCount = 0;
+    const startAccount = vi.fn(async ({ abortSignal }: ChannelGatewayContext<TestAccount>) => {
+      startCount += 1;
+      registerPluginHttpRoute({
+        path: "/shared/webhook",
+        handler: () => true,
+        auth: "plugin",
+        match: "prefix",
+        pluginId: "discord",
+        source: "shared-ingress",
+        reuseExistingSameOwner: true,
+        throwOnFailure: true,
+        registry: routeRegistry,
+      });
+      if (startCount === 1) {
+        // A stuck drain: this task never settles and never releases its share.
+        await new Promise<void>(() => {});
+      }
+      // Every later start settles on abort, mirroring a healthy monitor whose
+      // stop handlers release its route share before the task ends.
+      await new Promise<void>((resolve) => {
+        abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
+    });
+    installTestRegistry(
+      createTestPlugin({
+        startAccount,
+        listAccountIds: () => [DEFAULT_ACCOUNT_ID, "second"],
+      }),
+    );
+    const manager = createManager({ getPluginHttpRouteRegistry: () => routeRegistry });
+
+    await manager.startChannels();
+    const sharedRouteCount = () =>
+      (routeRegistry.httpRoutes ?? []).filter((route) => route.path === "/shared/webhook");
+    expect(sharedRouteCount()).toHaveLength(1);
+
+    // The timed-out stop abandons the stuck first task; its lease revocation
+    // releases that share without evicting the route the survivor serves.
+    const recoveryStopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, {
+      manual: false,
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await recoveryStopTask;
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    expect(sharedRouteCount()).toHaveLength(1);
+
+    // The replacement (started above) and the second account now hold the two
+    // shares; each normal stop releases exactly one and the last one removes
+    // the route — the end-to-end holder cleanup an abandoned monitor can no
+    // longer perform through its own release callback.
+    await vi.advanceTimersByTimeAsync(0);
+    await manager.stopChannel("discord", "second");
+    expect(sharedRouteCount()).toHaveLength(1);
+    await manager.stopChannel("discord", DEFAULT_ACCOUNT_ID);
+    expect(sharedRouteCount()).toHaveLength(0);
+  });
+
   it("keeps the second recovery task running when the stale task rejects", async () => {
     const releaseFirstTask = createDeferred();
     let startCount = 0;

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -1951,6 +1951,65 @@ describe("server-channels auto restart", () => {
     expect(account?.lastError).toBeNull();
   });
 
+  it("keeps the route off-limits to other accounts while a stop is draining", async () => {
+    const routeRegistry = createEmptyPluginRegistry();
+    const startAccount = vi.fn(async ({ accountId }: ChannelGatewayContext<TestAccount>) => {
+      registerPluginHttpRoute({
+        path: `/discord/interactions/${accountId}`,
+        handler: () => true,
+        auth: "plugin",
+        match: "exact",
+        pluginId: "discord",
+        source: "discord-interactions",
+        accountId,
+        throwOnFailure: true,
+        registry: routeRegistry,
+      });
+      // A stuck drain: this task never settles and never unregisters its route.
+      await new Promise<void>(() => {});
+    });
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager({ getPluginHttpRouteRegistry: () => routeRegistry });
+
+    await manager.startChannels();
+    const recoveryStopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, {
+      manual: false,
+    });
+    // Let the stop reach its abort so the probe lands inside the drain window.
+    await vi.advanceTimersByTimeAsync(0);
+    // The draining task still owns its route: another account configured with
+    // the same canonical path must stay rejected by the route-conflict guard
+    // until the task is abandoned, or the account-policy takeover returns
+    // through the drain window.
+    expect(() =>
+      registerPluginHttpRoute({
+        path: `/discord/interactions/${DEFAULT_ACCOUNT_ID}`,
+        handler: () => true,
+        auth: "plugin",
+        match: "exact",
+        pluginId: "discord",
+        source: "discord-interactions",
+        accountId: "foreign",
+        throwOnFailure: true,
+        registry: routeRegistry,
+      }),
+    ).toThrow(/route conflict/);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await recoveryStopTask;
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+
+    const accountRoutes = (routeRegistry.httpRoutes ?? []).filter(
+      (route) => route.path === `/discord/interactions/${DEFAULT_ACCOUNT_ID}`,
+    );
+    expect(accountRoutes).toHaveLength(1);
+    expect(startAccount).toHaveBeenCalledTimes(2);
+    const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(account?.running).toBe(true);
+    expect(account?.lastError).toBeNull();
+  });
+
   it("keeps the second recovery task running when the stale task rejects", async () => {
     const releaseFirstTask = createDeferred();
     let startCount = 0;

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -33,7 +33,10 @@ import {
   runtimeForLogger,
   type SubsystemLogger,
 } from "../logging/subsystem.js";
-import { withPluginHttpRouteRegistry } from "../plugins/http-registry.js";
+import {
+  createPluginCapabilityLease,
+  withPluginHttpRouteRegistry,
+} from "../plugins/http-registry.js";
 import { withPluginCommandAccountStartScope } from "../plugins/plugin-command-account-start-scope.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import type { PluginRuntimeChannel } from "../plugins/runtime/types-channel.js";
@@ -656,6 +659,11 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         // cannot race into duplicate provider boots for the same account.
         const abort = new AbortController();
         store.aborts.set(id, abort);
+        // Account routes live on this task's abort lifetime: revoking on abort
+        // reclaims them for a replacement start, so a timed-out stop that
+        // abandons this task cannot leave its route blocking the successor.
+        const routeLease = createPluginCapabilityLease();
+        abort.signal.addEventListener("abort", () => routeLease.revoke(), { once: true });
         clearPluginCommandCatalogOwner(store, id);
         let handedOffTask = false;
         let startAccountLifetimeActive = false;
@@ -923,7 +931,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               };
               const routeRegistry = getPluginHttpRouteRegistry?.();
               startAccountTask = routeRegistry
-                ? withPluginHttpRouteRegistry(routeRegistry, runStartAccount)
+                ? withPluginHttpRouteRegistry(routeRegistry, runStartAccount, routeLease)
                 : runStartAccount();
             });
             if (!startAccountTask) {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -36,6 +36,7 @@ import {
 import {
   createPluginCapabilityLease,
   withPluginHttpRouteRegistry,
+  type PluginCapabilityLease,
 } from "../plugins/http-registry.js";
 import { withPluginCommandAccountStartScope } from "../plugins/plugin-command-account-start-scope.js";
 import type { PluginRegistry } from "../plugins/registry.js";
@@ -322,6 +323,10 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
   } = opts;
 
   const channelStores = new Map<ChannelId, ChannelRuntimeStore>();
+  // Route leases outlive their start closure: a later start discarding an
+  // abandoned task must reclaim that task's routes without reaching into the
+  // dead closure. Keyed by the abort controller so entries die with the task.
+  const routeLeaseByAbort = new WeakMap<AbortController, PluginCapabilityLease>();
   const restarts = new Map<string, RetrySupervisor>();
   // Tracks accounts that were manually stopped so we don't auto-restart them.
   const manuallyStopped = new Set<string>();
@@ -622,6 +627,14 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               recoveryStopTimedOut.delete(rKey);
               recoveryStartRequested.delete(rKey);
               restarts.delete(rKey);
+              // Confirmed abandonment: the stuck task never settled, so its
+              // route lease is the only thing blocking this successor. Revoke
+              // it here — not at stop abort — so the drain window keeps the
+              // route off-limits to other accounts.
+              const staleAbort = store.aborts.get(id);
+              if (staleAbort) {
+                routeLeaseByAbort.get(staleAbort)?.revoke();
+              }
               store.aborts.delete(id);
               store.tasks.delete(id);
               clearedTimedOutRecoveryTask = true;
@@ -659,11 +672,12 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         // cannot race into duplicate provider boots for the same account.
         const abort = new AbortController();
         store.aborts.set(id, abort);
-        // Account routes live on this task's abort lifetime: revoking on abort
-        // reclaims them for a replacement start, so a timed-out stop that
-        // abandons this task cannot leave its route blocking the successor.
+        // Account routes live on this task's ownership lease. It is revoked at
+        // terminal cleanup or successor discard — never on abort: stopChannel
+        // aborts before its graceful-drain wait, and freeing the route there
+        // would let another account bind it outside the route-conflict guard.
         const routeLease = createPluginCapabilityLease();
-        abort.signal.addEventListener("abort", () => routeLease.revoke(), { once: true });
+        routeLeaseByAbort.set(abort, routeLease);
         clearPluginCommandCatalogOwner(store, id);
         let handedOffTask = false;
         let startAccountLifetimeActive = false;
@@ -1035,7 +1049,9 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 }
                 // The settled task may have left background work racing on this
                 // signal. Abort before the replacement starts so two account
-                // instances can never share a live lifetime.
+                // instances can never share a live lifetime, and reclaim its
+                // route lease so the replacement can rebind the same route.
+                routeLease.revoke();
                 abort.abort();
                 try {
                   await startChannelInternal(channelId, id, {
@@ -1088,7 +1104,9 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                   store.aborts.delete(id);
                 }
                 // See the timed-out-stop restart above: never start the crash
-                // replacement while the predecessor's signal is unaborted.
+                // replacement while the predecessor's signal is unaborted, and
+                // reclaim its route lease so the replacement can rebind.
+                routeLease.revoke();
                 abort.abort();
                 await startChannelInternal(channelId, id, {
                   preserveRestartAttempts: true,
@@ -1101,6 +1119,9 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               }
             })
             .finally(() => {
+              // Terminal cleanup: this task can no longer serve its routes, so
+              // reclaim anything its own teardown failed to unregister.
+              routeLease.revoke();
               if (store.tasks.get(id) === trackedPromise) {
                 store.tasks.delete(id);
               }
@@ -1134,6 +1155,9 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             await cleanupTaskScopedApprovalRuntime("channel startup cleanup failed");
           }
           if (!handedOffTask && store.aborts.get(id) === abort) {
+            // Failed before handoff: no terminal `.finally()` will run for this
+            // attempt, so reclaim any route its boot already registered.
+            routeLease.revoke();
             store.aborts.delete(id);
           }
         }

--- a/src/plugins/http-registry.test.ts
+++ b/src/plugins/http-registry.test.ts
@@ -909,7 +909,7 @@ describe("registerPluginHttpRoute", () => {
     expect(registry.httpRoutes).toHaveLength(0);
   });
 
-  it("does not pin a shared route open for a lease-less reuser", () => {
+  it("releases a lease-less reuser's share through its returned unregister", () => {
     const registry = createEmptyPluginRegistry();
     const first = createTrackedRouteLease();
 
@@ -927,7 +927,7 @@ describe("registerPluginHttpRoute", () => {
         }),
       first.lease,
     );
-    withPluginHttpRouteRegistry(registry, () =>
+    const releaseSecondShare = withPluginHttpRouteRegistry(registry, () =>
       registerPluginHttpRoute({
         path: "/zalo-hosted-media",
         auth: "plugin",
@@ -940,7 +940,11 @@ describe("registerPluginHttpRoute", () => {
       }),
     );
 
+    // A plain caller holds no lease, so its explicit unregister is the only
+    // handle that expires its share; the route survives until then.
     first.revoke();
+    expect(registry.httpRoutes).toHaveLength(1);
+    releaseSecondShare();
     expect(registry.httpRoutes).toHaveLength(0);
   });
 });

--- a/src/plugins/http-registry.test.ts
+++ b/src/plugins/http-registry.test.ts
@@ -867,4 +867,80 @@ describe("registerPluginHttpRoute", () => {
     unregister();
     child.revoke();
   });
+
+  it("keeps a reused shared route alive until every holder lifetime ends", () => {
+    const registry = createEmptyPluginRegistry();
+    const first = createTrackedRouteLease();
+    const second = createTrackedRouteLease();
+    const registerSharedRoute = () =>
+      registerPluginHttpRoute({
+        path: "/zalo-hosted-media",
+        auth: "plugin",
+        match: "prefix",
+        handler: vi.fn(),
+        pluginId: "zalo",
+        source: "zalo-hosted-media",
+        throwOnFailure: true,
+      });
+
+    withPluginHttpRouteRegistry(registry, registerSharedRoute, first.lease);
+    withPluginHttpRouteRegistry(
+      registry,
+      () =>
+        registerPluginHttpRoute({
+          path: "/zalo-hosted-media",
+          auth: "plugin",
+          match: "prefix",
+          handler: vi.fn(),
+          pluginId: "zalo",
+          source: "zalo-hosted-media",
+          reuseExistingSameOwner: true,
+          throwOnFailure: true,
+        }),
+      second.lease,
+    );
+
+    // Revoking the first holder must not drop a shared route the second
+    // account's task still serves through the same-owner reuse.
+    first.revoke();
+    expect(registry.httpRoutes).toHaveLength(1);
+
+    second.revoke();
+    expect(registry.httpRoutes).toHaveLength(0);
+  });
+
+  it("does not pin a shared route open for a lease-less reuser", () => {
+    const registry = createEmptyPluginRegistry();
+    const first = createTrackedRouteLease();
+
+    withPluginHttpRouteRegistry(
+      registry,
+      () =>
+        registerPluginHttpRoute({
+          path: "/zalo-hosted-media",
+          auth: "plugin",
+          match: "prefix",
+          handler: vi.fn(),
+          pluginId: "zalo",
+          source: "zalo-hosted-media",
+          throwOnFailure: true,
+        }),
+      first.lease,
+    );
+    withPluginHttpRouteRegistry(registry, () =>
+      registerPluginHttpRoute({
+        path: "/zalo-hosted-media",
+        auth: "plugin",
+        match: "prefix",
+        handler: vi.fn(),
+        pluginId: "zalo",
+        source: "zalo-hosted-media",
+        reuseExistingSameOwner: true,
+        throwOnFailure: true,
+      }),
+    );
+
+    first.revoke();
+    expect(registry.httpRoutes).toHaveLength(0);
+  });
 });

--- a/src/plugins/http-registry.ts
+++ b/src/plugins/http-registry.ts
@@ -62,6 +62,19 @@ export function createPluginCapabilityLease(): PluginCapabilityLease {
   };
 }
 
+// A route entry outlives one registration call: a later same-owner reuse pins the
+// existing entry under its own lease, so revoking the first holder cannot drop a
+// shared route another account still serves. The creator's unregister stays
+// authoritative; removal happens when it fires or the last lifetime expires.
+type PluginHttpRouteLifetime = {
+  expired: boolean;
+  releases: Set<() => void>;
+};
+const attachRouteLifetimeByEntry = new WeakMap<
+  PluginHttpRouteRegistration,
+  (leases: readonly PluginHttpRouteRegistrationLease[]) => void
+>();
+
 const pluginHttpRouteRegistryScope = new AsyncLocalStorage<{
   registry: PluginRegistry;
   leases: readonly PluginHttpRouteRegistrationLease[];
@@ -159,6 +172,14 @@ export function registerPluginHttpRoute(params: {
         params.log?.(
           `plugin: reusing existing webhook path ${normalizedPath} (${routeMatch}) (${requestedOwner}/${requestedSource})`,
         );
+        // A lease-less reuser has no lifetime to pin with, so the route keeps
+        // following its creator instead of being pinned open forever.
+        const leases = scope?.leases ?? [];
+        if (leases.length > 0) {
+          for (const route of canonicalMatches) {
+            attachRouteLifetimeByEntry.get(route)?.(leases);
+          }
+        }
         return noopUnregister;
       }
       const conflictingOwner = mismatchedOwner ?? existing;
@@ -208,16 +229,52 @@ export function registerPluginHttpRoute(params: {
   };
   routes.push(entry);
 
-  const releases: Array<() => void> = [];
-  const unregister = () => {
+  let alive = true;
+  const lifetimes = new Set<PluginHttpRouteLifetime>();
+  const removeEntry = () => {
+    if (!alive) {
+      return;
+    }
+    alive = false;
     const index = routes.indexOf(entry);
     if (index >= 0) {
       routes.splice(index, 1);
     }
-    for (const release of releases.splice(0)) {
+    for (const lifetime of lifetimes) {
+      lifetime.expired = true;
+      for (const release of lifetime.releases) {
+        release();
+      }
+      lifetime.releases.clear();
+    }
+    lifetimes.clear();
+    attachRouteLifetimeByEntry.delete(entry);
+  };
+  const expireLifetime = (lifetime: PluginHttpRouteLifetime) => {
+    if (lifetime.expired) {
+      return;
+    }
+    lifetime.expired = true;
+    lifetimes.delete(lifetime);
+    for (const release of lifetime.releases) {
       release();
     }
+    lifetime.releases.clear();
+    if (lifetimes.size === 0) {
+      removeEntry();
+    }
   };
-  scope?.leases.forEach((lease) => releases.push(lease.retain(unregister)));
-  return unregister;
+  const attachLifetime = (leases: readonly PluginHttpRouteRegistrationLease[]) => {
+    if (!alive || leases.length === 0) {
+      return;
+    }
+    const lifetime: PluginHttpRouteLifetime = { expired: false, releases: new Set() };
+    lifetimes.add(lifetime);
+    for (const lease of leases) {
+      lifetime.releases.add(lease.retain(() => expireLifetime(lifetime)));
+    }
+  };
+  attachRouteLifetimeByEntry.set(entry, attachLifetime);
+  attachLifetime(scope?.leases ?? []);
+  return removeEntry;
 }

--- a/src/plugins/http-registry.ts
+++ b/src/plugins/http-registry.ts
@@ -172,15 +172,18 @@ export function registerPluginHttpRoute(params: {
         params.log?.(
           `plugin: reusing existing webhook path ${normalizedPath} (${routeMatch}) (${requestedOwner}/${requestedSource})`,
         );
-        // A lease-less reuser has no lifetime to pin with, so the route keeps
-        // following its creator instead of being pinned open forever.
+        // The reuser becomes a holder: its leases and the returned unregister
+        // both expire its own lifetime, so the shared route survives this
+        // holder and the creator independently.
         const leases = scope?.leases ?? [];
-        if (leases.length > 0) {
-          for (const route of canonicalMatches) {
-            attachRouteLifetimeByEntry.get(route)?.(leases);
+        const releases = canonicalMatches
+          .map((route) => attachRouteLifetimeByEntry.get(route)?.(leases))
+          .filter((release) => release !== undefined);
+        return () => {
+          for (const release of releases) {
+            release();
           }
-        }
-        return noopUnregister;
+        };
       }
       const conflictingOwner = mismatchedOwner ?? existing;
       return rejectRegistration(
@@ -264,17 +267,24 @@ export function registerPluginHttpRoute(params: {
       removeEntry();
     }
   };
+  // Every holder pins the route through one lifetime record, whether it holds a
+  // lease (task/service scope) or only an explicit unregister handle (plain
+  // callers). The entry is removed when the last holder's lifetime expires, so
+  // a shared same-owner route survives any single holder stopping — including
+  // a holder whose lease the gateway revokes at abandonment.
   const attachLifetime = (leases: readonly PluginHttpRouteRegistrationLease[]) => {
-    if (!alive || leases.length === 0) {
-      return;
+    if (!alive) {
+      return undefined;
     }
     const lifetime: PluginHttpRouteLifetime = { expired: false, releases: new Set() };
     lifetimes.add(lifetime);
     for (const lease of leases) {
       lifetime.releases.add(lease.retain(() => expireLifetime(lifetime)));
     }
+    return () => {
+      expireLifetime(lifetime);
+    };
   };
   attachRouteLifetimeByEntry.set(entry, attachLifetime);
-  attachLifetime(scope?.leases ?? []);
-  return removeEntry;
+  return attachLifetime(scope?.leases ?? []) ?? removeEntry;
 }

--- a/src/plugins/http-registry.ts
+++ b/src/plugins/http-registry.ts
@@ -17,6 +17,51 @@ type PluginHttpRouteRegistrationLease = {
   retain: (unregister: () => void) => () => void;
 };
 
+export type PluginCapabilityLease = PluginHttpRouteRegistrationLease & {
+  assertActive: (capability: string) => void;
+  revoke: () => void;
+};
+
+// One lease per runtime lifetime (plugin service, channel account task, ...).
+// Registrations retain their unregister through it, so revoke reclaims the
+// lifetime's routes; assertActive gates capability-issued work.
+export function createPluginCapabilityLease(): PluginCapabilityLease {
+  let active = true;
+  const cleanups = new Set<() => void>();
+  const assertActive = (capability: string) => {
+    if (!active) {
+      throw new Error(`plugin service ${capability} is no longer active`);
+    }
+  };
+  const retain = (cleanup: () => void): (() => void) => {
+    if (!active) {
+      cleanup();
+      assertActive("capability lease");
+    }
+    const release = () => {
+      if (cleanups.delete(release)) {
+        cleanup();
+      }
+    };
+    cleanups.add(release);
+    return release;
+  };
+  return {
+    isActive: () => active,
+    assertActive,
+    retain,
+    revoke: () => {
+      if (!active) {
+        return;
+      }
+      active = false;
+      for (const cleanup of cleanups) {
+        cleanup();
+      }
+    },
+  };
+}
+
 const pluginHttpRouteRegistryScope = new AsyncLocalStorage<{
   registry: PluginRegistry;
   leases: readonly PluginHttpRouteRegistrationLease[];

--- a/src/plugins/http-registry.ts
+++ b/src/plugins/http-registry.ts
@@ -72,7 +72,7 @@ type PluginHttpRouteLifetime = {
 };
 const attachRouteLifetimeByEntry = new WeakMap<
   PluginHttpRouteRegistration,
-  (leases: readonly PluginHttpRouteRegistrationLease[]) => void
+  (leases: readonly PluginHttpRouteRegistrationLease[]) => (() => void) | undefined
 >();
 
 const pluginHttpRouteRegistryScope = new AsyncLocalStorage<{

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -17,7 +17,11 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { subscribePluginSessionsChanged } from "./gateway-events.js";
 import { isPluginJsonValue, type PluginJsonValue } from "./host-hook-json.js";
-import { withPluginHttpRouteRegistry } from "./http-registry.js";
+import {
+  createPluginCapabilityLease,
+  type PluginCapabilityLease,
+  withPluginHttpRouteRegistry,
+} from "./http-registry.js";
 import type { PluginServiceRegistration } from "./registry-types.js";
 import type { PluginRegistry } from "./registry.js";
 import { createPluginServiceHealthGeneration } from "./service-health.js";
@@ -35,45 +39,6 @@ type TrustedExporterInternalDiagnostics = NonNullable<
   reportExporterHealth: (update: DiagnosticExporterHealthUpdate) => void;
 };
 
-function createPluginServiceCapabilityLease() {
-  let active = true;
-  const cleanups = new Set<() => void>();
-  const assertActive = (capability: string) => {
-    if (!active) {
-      throw new Error(`plugin service ${capability} is no longer active`);
-    }
-  };
-  const retain = (cleanup: () => void): (() => void) => {
-    if (!active) {
-      cleanup();
-      assertActive("capability lease");
-    }
-    const release = () => {
-      if (cleanups.delete(release)) {
-        cleanup();
-      }
-    };
-    cleanups.add(release);
-    return release;
-  };
-  return {
-    isActive: () => active,
-    assertActive,
-    retain,
-    revoke: () => {
-      if (!active) {
-        return;
-      }
-      active = false;
-      for (const cleanup of cleanups) {
-        cleanup();
-      }
-    },
-  };
-}
-
-type PluginServiceCapabilityLease = ReturnType<typeof createPluginServiceCapabilityLease>;
-
 function createPluginLogger(): PluginLogger {
   return {
     info: (msg) => log.info(msg),
@@ -90,7 +55,7 @@ function createServiceContext(params: {
   service: PluginServiceRegistration;
   serviceHealth: NonNullable<OpenClawPluginServiceContext["serviceHealth"]>;
   gatewayEvents?: OpenClawPluginServiceContext["gatewayEvents"];
-  lease: PluginServiceCapabilityLease;
+  lease: PluginCapabilityLease;
 }): OpenClawPluginServiceContext {
   const isDiagnosticsExporter =
     params.service?.pluginId === params.service?.service.id &&
@@ -148,7 +113,7 @@ function createServiceContext(params: {
 function createScopedGatewayEvents(params: {
   pluginId: string;
   broadcast?: GatewayPluginEventBroadcastFn;
-  lease: PluginServiceCapabilityLease;
+  lease: PluginCapabilityLease;
 }): {
   gatewayEvents?: OpenClawPluginServiceContext["gatewayEvents"];
 } {
@@ -233,7 +198,7 @@ export async function startPluginServices(params: {
     pluginId: string;
     diagnosticsExporter: boolean;
     stop?: () => void | Promise<void>;
-    lease: PluginServiceCapabilityLease;
+    lease: PluginCapabilityLease;
   }> = [];
   const runBeforeDeadline = async (
     run: () => void | Promise<void>,
@@ -391,7 +356,7 @@ export async function startPluginServices(params: {
       }
       const service = entry.service;
       const traceName = createPluginServiceTraceName(entry);
-      const lease = createPluginServiceCapabilityLease();
+      const lease = createPluginCapabilityLease();
       const scopedGatewayEvents = createScopedGatewayEvents({
         pluginId: entry.pluginId,
         broadcast: params.broadcastPluginEvent,


### PR DESCRIPTION
## What Problem This Solves

Fixes #132886.

When a channel account stop times out, core abandons the stuck task (`recoveryStopTimedOut`, `src/gateway/server-channels.ts`) and keeps its `store.tasks`/`store.aborts` bookkeeping so the two-call recovery contract can replace it. The replacement start then registers the same per-account HTTP route the abandoned task still holds. Account routes register with `throwOnFailure: true` and no `replaceExisting` flag (the shape #128431 deliberately standardized after GHSA-RQP8-Q22P-5J9Q), so the registration rejects and the replacement crashes:

```
plugin: route conflict at /mattermost/interactions/<id> (exact) for account "<id>"; owned by mattermost (mattermost-interactions)
auto-restart attempt N/10 ... giving up after 10 restart attempts
```

The restart ladder burns its 10 attempts against the same conflict, and if the old teardown outlives the backoff the channel stays dead until a manual restart.

## Why This Change Was Made

The reclaim mechanism already existed: plugin services attach a capability lease to their route registrations so a timed-out stop force-releases retained routes and blocks zombie re-registration (`src/plugins/services.ts`, `src/plugins/http-registry.ts`). Channel account starts ran `withPluginHttpRouteRegistry` **without** a lease — that gap is the root cause.

This change attaches a lease to each account-start task, and — per review — revokes it only where the task is truly gone, **never on abort**:

- `createPluginCapabilityLease()` moves from `services.ts` into `src/plugins/http-registry.ts` and is exported, so the lease factory has one canonical home and services consumes it instead of carrying a private copy.
- `createChannelManager` creates one lease per start task and passes it to `withPluginHttpRouteRegistry(routeRegistry, runStartAccount, routeLease)`. `stopChannel` aborts every task *before* its graceful-drain wait, so an abort-coupled revoke would free the route during the drain and let another account configured with the same canonical path bind it outside the route-conflict guard — reopening the account-policy takeover class. Revocation instead lives at the points where the task can no longer serve its routes: the start task's terminal `.finally()`, the two replacement-start points that run before that `.finally()`, a failed pre-handoff attempt, and the recovery discard that reclaims an abandoned stuck task.
- The recovery discard is a later start invocation, so it cannot reach the dead closure's lease. A `WeakMap` keyed by the abort controller carries the lease there — entries die with the controller, so no parallel store lifecycle and no cleanup path.

**Shared routes cannot be evicted by one holder's revocation** (review finding): a same-owner `reuseExistingSameOwner` registration attached nothing to the reusing lifetime, and a route entry died on *any* single lease revocation — so an account-agnostic shared ingress (the `zalo-hosted-media` shape, `extensions/zalo/src/monitor.ts`) died when the first registering account's task was reclaimed, silently unserving every other account's task. Route entries now track one lifetime per registering *or reusing* holder: the creator's unregister stays authoritative, and the entry leaves the registry when that handle fires or the last holder lifetime expires. Nested ambient leases of a single registration keep the any-owner-revokes reclaim they shipped with (`releases nested routes from every ambient lease when any owner revokes` still green).

Genuine cross-owner conflicts still fail loudly — the lease only reclaims the same task's own registrations, and expired continuations are still blocked from re-registering.

Zero plugin changes: every channel registering per-account routes with `throwOnFailure` (mattermost, a2a, sms, synology-chat) and every shared same-owner ingress is covered by the same seam.

**Production delta: +152 / -53 (net +99)** — `src/plugins/http-registry.ts` +107/-5 (lease factory + lease-scope retention + per-holder route lifetimes), `src/plugins/services.ts` +9/-44 (local lease deleted, consumed from canonical home), `src/gateway/server-channels.ts` +36/-4 (lease attach, revocation at the abandonment/terminal-cleanup points, WeakMap). The growth over earlier revisions is the revocation points review identified plus the shared-route lifetime invariant that cannot live anywhere but the registry — the registry owns route lifetime, and a plugin-local refcount (zalo's own `hostedMediaRouteRefs`) cannot see the gateway's lease revocations. **Test delta: +240** (`src/gateway/server-channels.test.ts` +164, `src/plugins/http-registry.test.ts` +76).

## User Impact

- A timed-out channel-account stop that core recovers from now converges instead of crash-looping: the replacement takes over the account's own route, the restart ladder never engages, and the channel returns on the recovery path it was designed for (macOS sleep/wake thaw, health-monitor restarts).
- During a draining stop the account route stays owned: a foreign account cannot bind the same canonical path while the old task is still serving it.
- An account-agnostic shared route survives one account's abandonment: other accounts' tasks keep serving it until their own lifetimes end, instead of losing ingress silently.
- `lastError` no longer records a misleading cross-owner route conflict for the account's own stale route.
- Cross-owner route conflicts keep failing loudly; the registry's security posture is unchanged.

## Evidence

**Shared-route regression proof (review finding)** — on the parent commit, the new gateway test fails because the discarded first account's revocation evicted the shared entry and the successor re-created it with a fresh handler:

```
AssertionError: expected [Function handler] to be [Function handler] // Object.is equality
```

and the registry-level test fails because revoking the first holder removed the route the second holder still serves:

```
AssertionError: expected 1 to be 0 // Object.is equality  (registry.httpRoutes length after first.revoke())
```

Post-fix: two accounts register the same account-agnostic canonical path (`reuseExistingSameOwner`, same plugin/source) through the production `registerPluginHttpRoute`; the first account's stop times out, the two-call recovery contract discards the stuck task and revokes its lease, and the shared route survives with its **original handler** (not a successor re-creation) while the second account's task keeps `running: true`.

**Drain-window regression proof (earlier finding)** — on the abort-coupled revision, the new test failed exactly as that finding predicted: after the stop aborts, a foreign account registering the same canonical path *succeeded* instead of being rejected (`AssertionError: expected [Function] to throw an error`). Post-fix it is rejected by the route-conflict guard while the drain window is open.

**Reclaim regression proof (issue)** — the first test fails on the parent commit with the issue's error shape, verbatim:

```
Error: plugin: route conflict at /discord/interactions/default (exact) for account "default"; owned by discord (discord-interactions)
```

**Post-fix** — touched suites green on head `b63e0d77a5147ea3add7bc6ab0c1b10695a41591`:

| Suite | Result |
| --- | --- |
| `src/gateway/server-channels.test.ts` | 113 passed |
| `src/gateway/server-startup-post-attach.test.ts` | 91 passed |
| `src/plugins/http-registry.test.ts` | 36 passed |
| `src/plugins/services.test.ts` + `services.replacement.test.ts` | 30 passed |

`oxlint` clean, `oxfmt` clean. Local full-program `tsgo` was OOM-killed (exit 137) on this host — the tsgo lanes in CI are the authority for this push. (An unrelated pre-existing `extensions/zalo` setup-wizard prompt failure reproduces identically on the parent commit and is out of scope here.)

Proof gap: no live channel run — the reproduction sits at the registry/lifecycle boundary with the real `registerPluginHttpRoute` implementation rather than a live Mattermost account; the issue's static trace identified the missing lease on `withPluginHttpRouteRegistry` as the gap and this closes exactly that seam.


## Shared-holder cleanup on abandonment (2026-08-30, commit 8d46d88d63b)

Addresses the review finding `[P2] Release shared-route owner state on abandonment` (`src/gateway/server-channels.ts`) and the matching merge-risk item.

- **One holder-lifetime record.** `registerPluginHttpRoute` now gives every holder — lease-backed (task/service scope) or explicit-unregister (plain callers) — one lifetime in the route's holder set, and the returned unregister releases that holder's share instead of authoritatively removing the entry. The entry is removed when the last share expires, so a shared same-owner route survives any single holder ending, and the lease revocation at abandonment releases a stuck holder's share through the same record the survivor uses.
- **Zalo stops duplicating the owner state.** The module-level `hostedMediaRouteRefs` count + unregister list in `extensions/zalo/src/monitor.ts` was a plugin-side copy of exactly that holder state, and an abandoned monitor could never run its release callback, leaving the count stranded after the surviving account stopped. The monitor now releases its share through the registry record (`monitor.ts` net −28 lines).
- **End-to-end cleanup regression.** `server-channels.test.ts` adds `removes a shared account-agnostic route once every holder ends, abandoned or stopped`: a stuck first task is abandoned (timed-out stop), the replacement and the surviving account hold the two shares, and each normal stop releases one share with the last one removing the route — the cleanup an abandoned monitor can no longer perform itself. `http-registry.test.ts` now pins that a lease-less reuser's share is released through its returned unregister.
- **Behavior note:** the shared-route test that asserted the swapped-out registry's route survives until the final release was updated to the holder-follows-lifetime semantics — a holder-less route registered in a non-active registry is the stranded-owner family this fix removes, not behavior to preserve.

Verification: `server-channels.test.ts` 114 passed (incl. new regression), `http-registry.test.ts` 36 passed, `monitor.polling-lifecycle` + `monitor.lifecycle` passed with both shared-route cases green, full `extensions/zalo` suite 175 passed with the only failure being the pre-existing `setup-surface` prompt-mismatch that fails identically on the parent commit. `oxlint` clean on all touched files. Remaining open review item: real behavior proof from a real setup (ephemeral Gateway harness) — unchanged from the review.
