### PR TITLE
fix(qa): clean isolated Telegram state after successful scenarios

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1425,6 +1425,36 @@ jobs:
             exec sudo -n -- "$0" --root-terminate-uid
           fi
 
+          if [[ "${1:-}" == "--cleanup-temp-root" ]]; then
+            shift
+            exec sudo -n -- "$0" --root-cleanup-temp-root "$@"
+          fi
+
+          if [[ "${1:-}" == "--root-cleanup-temp-root" ]]; then
+            [[ "$EUID" == "0" && "$#" == "2" ]]
+            source /etc/openclaw-telegram-sut.conf
+            temp_root="$2"
+            case "$(dirname "$temp_root")" in
+              "$RUNTIME_ROOT/tmp" | "$RUNTIME_ROOT/tmp/openclaw-$RUNNER_UID") ;;
+              *) echo "SUT cleanup escaped the workflow runtime root." >&2; exit 1 ;;
+            esac
+            [[ "$(basename "$temp_root")" == openclaw-qa-suite-* ]]
+            if sut_uid_processes_alive; then
+              echo "SUT runtime cleanup requires isolated UID quiescence." >&2
+              exit 1
+            fi
+            [[ ! -L "$temp_root" ]]
+            if [[ ! -e "$temp_root" ]]; then
+              exit 0
+            fi
+            [[ -d "$temp_root" && "$(realpath -e "$temp_root")" == "$temp_root" ]]
+            [[ "$(stat -c '%u' "$temp_root")" == "$RUNNER_UID" ]]
+            # Preserve SUT-private modes until final shutdown. Unlink its tree
+            # without changing ownership or following links into other roots.
+            rm -rf --one-file-system -- "$temp_root"
+            exit 0
+          fi
+
           if [[ "${1:-}" == "--verify" ]]; then
             shift
             exec sudo -n -- "$0" --root-verify "$@"

--- a/extensions/qa-lab/src/gateway-child-artifacts.ts
+++ b/extensions/qa-lab/src/gateway-child-artifacts.ts
@@ -26,6 +26,7 @@ async function clearQaGatewayArtifactDir(dir: string) {
 export async function cleanupQaGatewayTempRoots(params: {
   tempRoot: string;
   stagedBundledPluginsRoot?: string | null;
+  cleanupTempRoot?: () => Promise<unknown>;
 }) {
   const errors: Error[] = [];
   for (const [label, root] of [
@@ -39,7 +40,11 @@ export async function cleanupQaGatewayTempRoots(params: {
       if (label === "tempRoot") {
         await closeQaRuntimeStores(root);
       }
-      await fs.rm(root, { recursive: true, force: true });
+      if (label === "tempRoot" && params.cleanupTempRoot) {
+        await params.cleanupTempRoot();
+      } else {
+        await fs.rm(root, { recursive: true, force: true });
+      }
     } catch (error) {
       // Attempt both roots. Read only the top-level message before redaction;
       // cause-aware formatting can expose arbitrary nested credentials.

--- a/extensions/qa-lab/src/gateway-child-lifecycle.test.ts
+++ b/extensions/qa-lab/src/gateway-child-lifecycle.test.ts
@@ -496,6 +496,59 @@ describe.skipIf(process.platform === "win32")("QA gateway lifetime ownership", (
     await expect(fs.stat(gateway.tempRoot)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("removes isolated runtime state through its boundary after shutdown and artifact preservation", async () => {
+    const { params, pids } = await fixture();
+    const preserveToDir = await makeArtifactDir();
+    const originalRm = fs.rm;
+    const cleanup = vi.fn(async (tempRoot: string) => {
+      expect(pids().every((pid) => !isQaPosixProcessGroupAlive(pid))).toBe(true);
+      expect((await readArtifacts(preserveToDir))[0]).toContain("QA_GATEWAY_ATTEMPT_1");
+      await originalRm(tempRoot, { recursive: true, force: true });
+    });
+    boundary.create.mockImplementation(async ({ tempRoot }: { tempRoot: string }) => ({
+      prepare: async ({ env }: { env: NodeJS.ProcessEnv }) => ({ env }),
+      accept: async () => ({}),
+      signal: async () => {},
+      markReady: async () => {},
+      markExited: async () => {},
+      cleanupTempRoot: () => cleanup(tempRoot),
+    }));
+    const owner = own({
+      ...params,
+      command: {
+        ...params.command,
+        processBoundary: {
+          kind: "linux-proc-v1",
+          evidenceDir: params.command.tempParentDir,
+          expectedGid: 1,
+          expectedUid: 1,
+          forwardedEnvKeys: [],
+          runtimeArgsPrefix: [],
+          runtimeExecutablePath: process.execPath,
+          terminationRetryTimeoutMs: 45_000,
+        },
+      },
+    });
+    const gateway = await owner.start();
+    pids();
+    const denied = vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
+      if (target === gateway.tempRoot) {
+        throw Object.assign(new Error("isolated state belongs to another UID"), { code: "EACCES" });
+      }
+      return originalRm(target, options);
+    });
+    try {
+      await expect(owner.stop({ preserveToDir })).resolves.toEqual({
+        process: "confirmed-stopped",
+        errors: [],
+      });
+      expect(cleanup).toHaveBeenCalledOnce();
+      await expect(fs.stat(gateway.tempRoot)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      denied.mockRestore();
+    }
+  });
+
   it("retries failed preservation after confirming process shutdown", async () => {
     const { params, pids } = await fixture();
     const owner = own(params);

--- a/extensions/qa-lab/src/gateway-child-lifecycle.ts
+++ b/extensions/qa-lab/src/gateway-child-lifecycle.ts
@@ -271,6 +271,9 @@ export class QaGatewayChildLifecycle {
         cleanupQaGatewayTempRoots({
           tempRoot,
           stagedBundledPluginsRoot: this.stagedBundledPluginsRoot,
+          // The isolation owner created private directories under another UID.
+          // Finalize them only after shutdown and sanitized log preservation.
+          cleanupTempRoot: this.controller?.cleanupTempRoot,
         }),
       );
     }

--- a/extensions/qa-lab/src/gateway-process-boundary.ts
+++ b/extensions/qa-lab/src/gateway-process-boundary.ts
@@ -778,6 +778,13 @@ export async function createQaGatewayProcessBoundaryController(params: {
     signal,
     markReady,
     markExited,
+    cleanupTempRoot: () =>
+      runBoundaryLauncherCommand({
+        args: ["--cleanup-temp-root", tempRoot],
+        label: "temp-root cleanup",
+        launcherPath: params.launcherPath,
+        timeoutMs: PROCESS_BOUNDARY_CONTROL_TIMEOUT_MS,
+      }),
     evidencePath,
     retainCredentialLeasePath,
     retainCredentialLease,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where full release verification stops after a successful Telegram canary because final cleanup cannot remove the isolated runtime's private state directory. In [Telegram run 33284935921](https://github.com/openclaw/openclaw/actions/runs/33284935921), the scenario passed (`passed=1 failed=0`), then cleanup failed with `EACCES`. The boundary evidence had already confirmed that the isolated runtime exited and its UID was quiescent.

## Why This Change Was Made

The launcher creates private directories under a separate UID, but the parent QA process previously tried to remove those directories itself. Final filesystem cleanup now belongs to that same isolation boundary. The lifecycle delegates removal only after confirmed shutdown and sanitized log preservation; it retains the existing store-close ordering from #132958 and still attempts independent staging cleanup if runtime removal fails.

The launcher accepts only canonical, runner-owned QA roots within this workflow's runtime directory, refuses live isolated processes and symlink roots, and removes the tree without changing permissions or following links. No credential policy, termination policy, timeout, retry, configuration, or success guard changes.

This is the owner-level fix: retaining temporary state would retain credentials across scenarios, changing ownership or permissions would weaken isolation, and ignoring cleanup errors would conceal the leak. No duplicate deletion path or compatibility shim is added.

## User Impact

Internal QA infrastructure only; no shipped product behavior changes. Successful Telegram scenarios can finish cleanup and allow subsequent release checks to proceed while retaining the isolated runtime's private filesystem permissions throughout execution. No changelog entry is needed.

## Evidence

- Captured the failing lifecycle regression before repair: confirmed process shutdown plus the original `EACCES` cleanup error. The same regression passes after repair and checks shutdown, sanitized log preservation, delegated removal, and the absence of the runtime directory.
- Fresh integrated focused run: **44 passed, 4 explicit platform/tool skips** across lifecycle, artifact cleanup, process-boundary, and Telegram workflow tests. This includes the already-landed store-close tests from #132958.
- Workflow validation and zizmor passed.
- Independent managed Codex review completed with no actionable findings at the requested P0 threshold.
- A separate Linux Testbox diagnostic exercised the actual generated launcher with two temporary UIDs: the original unprivileged removal failed with `EACCES`; privileged cleanup succeeded; outside symlink/hardlink targets retained their content and metadata; absent roots were idempotent; outside paths, symlink roots, and live isolated processes were rejected; cleanup succeeded after the exact child joined and before any child had launched. The one-shot lease completed and stopped.

The Linux diagnostic used the frozen `bee48f7f56808eff2f7aaa035509b8a39b3988e2` workflow ref and verified all five changed source hashes before and after execution. Its transport HEAD was `d60f2b24868ed6204cf10a4c61552723c7ea323c`; a complete remote tree/package/lock attestation was **not** captured. This is bounded launcher evidence, not proof of a complete packaged candidate. The change was subsequently integrated on `b3a8b2a4f3628c96ff96c6b846b09d2130f0667a`, preserving #132958, and the focused tests above were rerun on that integrated source. Fresh packaged Telegram/full release verification remains pending.

The full changed-file gate passed, including extension/test typechecks, lint, dead exports, storage ownership and cycle guards. Exact-head CI and latest ClawSweeper findings/rank-up moves will be checked before landing.

Scope: five files, **+45 net QA infrastructure/workflow lines** and **+53 test lines**; shipped product runtime delta is zero. The added infrastructure expresses the missing cross-UID cleanup authority and its confinement checks. No regression-introducing commit attribution is claimed; the frozen failing run and before/after owner regression establish the defect.
