### PR TITLE
perf(gateway): resolve labels without hydrating session rows

### DIFF
--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -82,7 +82,6 @@ const SESSIONS_LIST_YIELD_BATCH_SIZE = 10;
 
 const SESSIONS_LIST_DEFAULT_LIMIT = 100;
 const SESSIONS_LIST_TRANSCRIPT_FIELD_ROWS = 100;
-const SESSIONS_LIST_TRANSCRIPT_USAGE_MAX_BYTES = 64 * 1024;
 
 type ListSessionsFromStoreParams = {
   cfg: OpenClawConfig;
@@ -91,7 +90,6 @@ type ListSessionsFromStoreParams = {
   storePath: string;
   store: Record<string, SessionEntry>;
   modelCatalog?: SessionListModelCatalog | ModelCatalogEntry[];
-  lightweightListRows?: boolean;
   opts: SessionsListParams;
   involvingActorId?: string;
   ownerFirstActorId?: string;
@@ -535,7 +533,7 @@ function buildSessionsListResult(params: {
   const { list, sessions } = params;
   // The defaults projection uses the same agent identity as getSessionDefaults:
   // the requested agent when scoped, otherwise the legacy compatibility agent.
-  // Legacy plain-array catalogs (direct listSessionsFromStore callers) pass through
+  // Legacy plain-array catalogs (direct list callers) pass through
   // unchanged; per-agent maps resolve by the same identity.
   const preparedDefaultsCatalog =
     params.modelCatalog instanceof Map
@@ -578,69 +576,17 @@ function buildSessionsListResult(params: {
 
 export function filterAndSortSessionEntries(params: {
   cfg: OpenClawConfig;
+  entryFilter?: (key: string, entry: SessionEntry) => boolean;
   store: Record<string, SessionEntry>;
   opts: SessionsListParams;
   now: number;
+  getRowContext?: SessionListRowContextProvider;
   involvingActorId?: string;
 }): [string, SessionEntry][] {
   return selectSessionEntries(params).entries;
 }
 
-export function listSessionsFromStore(params: ListSessionsFromStoreParams): SessionsListResult {
-  const { cfg, store, opts } = params;
-  const list = prepareSessionList(params);
-  const sessions = list.entries.map(([key, entry], index) => {
-    const includeTranscriptFields = index < list.transcriptFieldRows;
-    const rowAgentId =
-      !parseAgentSessionKey(key) && typeof opts.agentId === "string"
-        ? normalizeAgentId(opts.agentId)
-        : undefined;
-    const storeChildSessionsByKey =
-      list.storeChildSessionsByKey ??
-      buildSingleRowStoreChildSessionsByKey({
-        store,
-        storePath: list.storePath,
-        key,
-        now: list.now,
-      });
-    return buildGatewaySessionRow({
-      cfg,
-      storePath: list.storePath,
-      store,
-      key,
-      entry,
-      agentId: rowAgentId,
-      modelCatalog: params.modelCatalog,
-      now: list.now,
-      includeDerivedTitles: includeTranscriptFields && list.includeDerivedTitles,
-      includeLastMessage: includeTranscriptFields && list.includeLastMessage,
-      transcriptUsageMaxBytes: SESSIONS_LIST_TRANSCRIPT_USAGE_MAX_BYTES,
-      storeChildSessionsByKey,
-      rowContext: list.rowContext,
-      configuredAgentIds: list.configuredAgentIds,
-      skipTranscriptUsageFallback: params.lightweightListRows === true,
-      lightweightListRow: params.lightweightListRows === true,
-    });
-  });
-  return buildSessionsListResult({
-    cfg,
-    list,
-    modelCatalog: params.modelCatalog,
-    sessions,
-    agentId: opts.agentId,
-  });
-}
-
-/**
- * Async version of listSessionsFromStore that yields to the event loop between
- * batches of session row builds. This prevents large session stores from
- * blocking the event loop during sessions.list requests.
- *
- * The synchronous file I/O in readSessionTitleFieldsFromTranscript (head/tail
- * reads for derived titles and last-message previews) is the dominant blocker.
- * By yielding every SESSIONS_LIST_YIELD_BATCH_SIZE rows, we keep the event
- * loop responsive for WebSocket heartbeats, channel I/O, and concurrent RPC.
- */
+/** Build rows in batches so session lists do not starve other Gateway work. */
 export async function listSessionsFromStoreAsync(
   params: ListSessionsFromStoreParams,
 ): Promise<SessionsListResult> {
@@ -701,9 +647,9 @@ export async function listSessionsFromStoreAsync(
         now: list.now,
         includeDerivedTitles: false,
         includeLastMessage: false,
-        transcriptUsageMaxBytes: SESSIONS_LIST_TRANSCRIPT_USAGE_MAX_BYTES,
         storeChildSessionsByKey,
         rowContext: list.rowContext,
+        configuredAgentIds: list.configuredAgentIds,
         skipTranscriptUsageFallback: true,
         lightweightListRow: true,
       });

--- a/src/gateway/session-utils-owners.test.ts
+++ b/src/gateway/session-utils-owners.test.ts
@@ -34,14 +34,14 @@ const getUserProfileDisplay = vi.hoisted(() =>
 
 vi.mock("../state/user-profiles.js", () => ({ getUserProfileDisplay }));
 
-import { listSessionsFromStore, listSessionsFromStoreAsync } from "./session-utils.js";
+import { listSessionsFromStoreAsync } from "./session-utils.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
   getUserProfileDisplay.mockClear();
 });
 
-it("lets configured agents win id-only owner facet collisions", () => {
+it("lets configured agents win id-only owner facet collisions", async () => {
   const actorOrders = [
     ["human", "agent"],
     ["agent", "human"],
@@ -61,7 +61,7 @@ it("lets configured agents win id-only owner facet collisions", () => {
         } satisfies SessionEntry,
       ]),
     );
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg: {
         agents: { list: [{ id: "shared-id", identity: { name: "Shared agent" } }] },
       } as OpenClawConfig,
@@ -81,7 +81,7 @@ it("lets configured agents win id-only owner facet collisions", () => {
   }
 });
 
-it("returns the complete deterministic owner facet independently of pagination", () => {
+it("returns the complete deterministic owner facet independently of pagination", async () => {
   const store: Record<string, SessionEntry> = {
     "agent:main:ada": {
       archivedAt: 3,
@@ -99,7 +99,7 @@ it("returns the complete deterministic owner facet independently of pagination",
     },
   };
 
-  const result = listSessionsFromStore({
+  const result = await listSessionsFromStoreAsync({
     cfg: {} as OpenClawConfig,
     storePath: "/tmp/openclaw-session-owners",
     store,
@@ -138,7 +138,7 @@ it("returns the complete deterministic owner facet independently of pagination",
   });
   expect(getUserProfileDisplay).toHaveBeenCalledTimes(2);
 
-  const filtered = listSessionsFromStore({
+  const filtered = await listSessionsFromStoreAsync({
     cfg: {} as OpenClawConfig,
     storePath: "/tmp/openclaw-session-owners",
     store,
@@ -148,7 +148,7 @@ it("returns the complete deterministic owner facet independently of pagination",
   expect(filtered.owners).toEqual(result.owners);
 });
 
-it("prepends an owner window without advancing shared-page pagination", () => {
+it("prepends an owner window without advancing shared-page pagination", async () => {
   const store: Record<string, SessionEntry> = {
     "agent:main:foreign-newest": {
       createdActor: { type: "human", source: "profile", id: "profile-ada" },
@@ -164,7 +164,7 @@ it("prepends an owner window without advancing shared-page pagination", () => {
     },
   };
 
-  const result = listSessionsFromStore({
+  const result = await listSessionsFromStoreAsync({
     cfg: {} as OpenClawConfig,
     storePath: "/tmp/openclaw-session-owner-first",
     store,
@@ -179,7 +179,7 @@ it("prepends an owner window without advancing shared-page pagination", () => {
   expect(result).toMatchObject({ count: 2, totalCount: 2, nextOffset: 1, hasMore: true });
 });
 
-it("projects only durable profiles and configured agents as effective owners", () => {
+it("projects only durable profiles and configured agents as effective owners", async () => {
   const cases = [
     {
       createdActor: { type: "human" as const, source: "profile" as const, id: "profile-ada" },
@@ -222,7 +222,7 @@ it("projects only durable profiles and configured agents as effective owners", (
       } satisfies SessionEntry,
     ]),
   );
-  const result = listSessionsFromStore({
+  const result = await listSessionsFromStoreAsync({
     cfg: {
       agents: {
         list: [
@@ -305,7 +305,7 @@ it("filters immutable creator and effective owner separately while preserving pr
       updatedAt: 0,
     },
   } satisfies Record<string, SessionEntry>;
-  const result = listSessionsFromStore({
+  const result = await listSessionsFromStoreAsync({
     cfg: {} as OpenClawConfig,
     storePath: "/tmp/openclaw-session-owners",
     store,
@@ -339,7 +339,7 @@ it("filters immutable creator and effective owner separately while preserving pr
       label: "Bob",
     },
   ]);
-  const creatorFiltered = listSessionsFromStore({
+  const creatorFiltered = await listSessionsFromStoreAsync({
     cfg: {} as OpenClawConfig,
     storePath: "/tmp/openclaw-session-owners",
     store,
@@ -355,7 +355,7 @@ it("filters immutable creator and effective owner separately while preserving pr
       owner: { actor: { id: "profile-bob", label: "Bob" } },
     },
   );
-  const ownerFiltered = listSessionsFromStore({
+  const ownerFiltered = await listSessionsFromStoreAsync({
     cfg: {} as OpenClawConfig,
     storePath: "/tmp/openclaw-session-owners",
     store,
@@ -403,7 +403,7 @@ it("filters immutable creator and effective owner separately while preserving pr
       opts: { creatorId: "profile-ada" },
     };
     expect
-      .soft(listSessionsFromStore(query).sessions.map((row) => row.key))
+      .soft((await listSessionsFromStoreAsync(query)).sessions.map((row) => row.key))
       .toEqual(["agent:main:shared", "agent:main:draft"]);
     const authorized = await listSessionsFromStoreAsync({ ...query, entryFilter });
     expect
@@ -416,7 +416,7 @@ it("filters immutable creator and effective owner separately while preserving pr
   }
 });
 
-it("deduplicates participants in order, excludes the owner, and filters sessions involving the viewer", () => {
+it("deduplicates participants in order, excludes the owner, and filters sessions involving the viewer", async () => {
   const store: Record<string, SessionEntry> = {
     "agent:main:owned": {
       createdActor: { type: "human", source: "profile", id: "profile-ada" },
@@ -480,7 +480,7 @@ it("deduplicates participants in order, excludes the owner, and filters sessions
   const cfg: OpenClawConfig = {
     agents: { list: [{ id: "research", identity: { name: "Research" } }] },
   };
-  const result = listSessionsFromStore({
+  const result = await listSessionsFromStoreAsync({
     cfg,
     storePath: "/tmp/openclaw-session-participants",
     store,
@@ -502,7 +502,7 @@ it("deduplicates participants in order, excludes the owner, and filters sessions
     participantCount: 5,
   });
 
-  const unfiltered = listSessionsFromStore({
+  const unfiltered = await listSessionsFromStoreAsync({
     cfg,
     storePath: "/tmp/openclaw-session-participants",
     store,
@@ -520,7 +520,7 @@ it("deduplicates participants in order, excludes the owner, and filters sessions
     expect(participant).not.toHaveProperty("label");
     expect(participant).not.toHaveProperty("avatarUrl");
   }
-  const selected = listSessionsFromStore({
+  const selected = await listSessionsFromStoreAsync({
     cfg,
     storePath: "/tmp/openclaw-session-participants",
     store,
@@ -535,7 +535,7 @@ it("deduplicates participants in order, excludes the owner, and filters sessions
 
 it.each(["spawn", "talk", "cron"] as const)(
   "associates a required %s creator without inventing profile contributions or promoting unqualified creators",
-  (via) => {
+  async (via) => {
     getUserProfileDisplay.mockImplementation((id) => ({
       id: id === "former" ? "current" : id,
       displayName: "Current",
@@ -593,7 +593,7 @@ it.each(["spawn", "talk", "cron"] as const)(
       store,
       opts: { archived: "all" as const, includePeople: true },
     };
-    const all = listSessionsFromStore(query);
+    const all = await listSessionsFromStoreAsync(query);
     const creator = {
       type: "human",
       id: "former",
@@ -615,7 +615,7 @@ it.each(["spawn", "talk", "cron"] as const)(
       });
       expect(row.owner).toBeUndefined();
     }
-    const involving = listSessionsFromStore({ ...query, involvingActorId: "current" });
+    const involving = await listSessionsFromStoreAsync({ ...query, involvingActorId: "current" });
     expect(involving.sessions.map((row) => row.key)).toEqual(["agent:main:historical", childKey]);
     expect(involving.sessions[0]?.participants).toEqual([
       { identity: { type: "profile", id: "current" }, label: "Current" },
@@ -623,7 +623,7 @@ it.each(["spawn", "talk", "cron"] as const)(
     expect(involving.people).toEqual([
       { identity: { type: "profile", id: "current" }, label: "Current", sessionCount: 2 },
     ]);
-    const ownerFirst = listSessionsFromStore({
+    const ownerFirst = await listSessionsFromStoreAsync({
       ...query,
       opts: { archived: "all", limit: 1 },
       ownerFirstActorId: "current",
@@ -632,7 +632,7 @@ it.each(["spawn", "talk", "cron"] as const)(
 
     // Reassignment must not erase the creator's Activity association or fabricate their input.
     child.owner = { actor: { type: "agent", id: "main" } };
-    const associated = listSessionsFromStore({
+    const associated = await listSessionsFromStoreAsync({
       ...query,
       opts: { ...query.opts, involvingProfileId: "former" },
     });
@@ -646,7 +646,7 @@ it.each(["spawn", "talk", "cron"] as const)(
   },
 );
 
-it("returns a canonical selected person and orders merged owners without borrowing remote identities", () => {
+it("returns a canonical selected person and orders merged owners without borrowing remote identities", async () => {
   getUserProfileDisplay.mockImplementation((id) => ({
     id: id === "former" ? "current" : id,
     displayName: id,
@@ -674,20 +674,20 @@ it("returns a canonical selected person and orders merged owners without borrowi
     store,
     opts: { archived: "all" as const, includePeople: true, involvingProfileId: "former", limit: 1 },
   };
-  const result = listSessionsFromStore(query);
+  const result = await listSessionsFromStoreAsync(query);
   expect(result).toMatchObject({
     involvingProfileId: "current",
     totalCount: 1,
     peopleIncomplete: true,
   });
   expect(result.people?.some((person) => person.identity.id === "current")).toBe(true);
-  const ordered = listSessionsFromStore({
+  const ordered = await listSessionsFromStoreAsync({
     ...query,
     opts: { archived: "all", limit: 1 },
     ownerFirstActorId: "current",
   });
   expect(ordered.sessions[0]?.key).toBe("agent:main:owned");
-  const involved = listSessionsFromStore({
+  const involved = await listSessionsFromStoreAsync({
     ...query,
     opts: { archived: "all" },
     involvingActorId: "current",
@@ -695,8 +695,8 @@ it("returns a canonical selected person and orders merged owners without borrowi
   expect(involved.sessions.map((row) => row.key)).toEqual(["agent:main:owned"]);
 });
 
-it("reports the authoritative admission bound even when the visible participant list is smaller", () => {
-  const result = listSessionsFromStore({
+it("reports the authoritative admission bound even when the visible participant list is smaller", async () => {
+  const result = await listSessionsFromStoreAsync({
     cfg: {},
     storePath: "/tmp/openclaw-session-bound",
     store: {
@@ -811,7 +811,7 @@ it("preserves list output across visibility, scope, owner, and search filters", 
   } as GatewayClient;
   const entryFilter = createSessionListEntryFilter({ client: viewer });
 
-  const project = async (opts: Parameters<typeof listSessionsFromStore>[0]["opts"]) => {
+  const project = async (opts: Parameters<typeof listSessionsFromStoreAsync>[0]["opts"]) => {
     const result = await listSessionsFromStoreAsync({
       cfg,
       ...(entryFilter ? { entryFilter } : {}),
@@ -898,9 +898,9 @@ it("preserves list output across visibility, scope, owner, and search filters", 
   );
 });
 
-it("keeps the serialized list response deterministic for the current filter path", () => {
+it("keeps the serialized list response deterministic for the current filter path", async () => {
   vi.spyOn(Date, "now").mockReturnValue(1_000_000);
-  const result = listSessionsFromStore({
+  const result = await listSessionsFromStoreAsync({
     cfg: {
       agents: {
         defaults: { model: { primary: "openai/gpt-5.4" } },
@@ -930,7 +930,7 @@ it("keeps the serialized list response deterministic for the current filter path
   const expectedSerializedResponse = [
     '{"ts":1000000,"path":"/tmp/openclaw-session-byte-parity","count":1,"totalCount":1,"limitApplied":100,"nextOffset":null,"hasMore":false,"owners":[]',
     ',"defaults":{"modelProvider":"openai","model":"gpt-5.4","contextTokens":200000,"agentRuntime":{"id":"codex","cloudPlacementSupported":false,"devicePlacementSupported":false,"source":"implicit"},"thinkingLevels":[{"id":"off","label":"off"},{"id":"minimal","label":"minimal"},{"id":"low","label":"low"},{"id":"medium","label":"medium"},{"id":"high","label":"high"},{"id":"xhigh","label":"xhigh"}],"thinkingOptions":["off","minimal","low","medium","high","xhigh"],"thinkingDefault":"off"}',
-    ',"sessions":[{"key":"global","visibility":"shared","createdActor":{"type":"system","id":"creator-b","identity":{"type":"legacy","actorType":"system","source":null,"id":"creator-b"}},"kind":"global","classification":"global","agentId":"main","isMain":false,"isBackground":false,"subject":"needle global","updatedAt":999999,"archived":false,"pinned":false,"unread":false,"sessionId":"session-global","thinkingLevels":[{"id":"off","label":"off"},{"id":"minimal","label":"minimal"},{"id":"low","label":"low"},{"id":"medium","label":"medium"},{"id":"high","label":"high"},{"id":"xhigh","label":"xhigh"}],"thinkingOptions":["off","minimal","low","medium","high","xhigh"],"thinkingDefault":"off","effectiveFastMode":false,"effectiveFastModeSource":"default","fastAutoOnSeconds":60,"totalTokens":1,"totalTokensFresh":true,"estimatedCostUsd":0,"effectiveResponseUsage":"off","effectiveQueueMode":"steer","modelProvider":"openai","model":"gpt-5.4","modelOverrideSource":null,"agentRuntime":{"id":"codex","cloudPlacementSupported":false,"devicePlacementSupported":false,"source":"implicit"},"contextTokens":100}]}',
+    ',"sessions":[{"key":"global","visibility":"shared","createdActor":{"type":"system","id":"creator-b","identity":{"type":"legacy","actorType":"system","source":null,"id":"creator-b"}},"kind":"global","classification":"global","agentId":"main","isMain":false,"isBackground":false,"subject":"needle global","updatedAt":999999,"archived":false,"pinned":false,"unread":false,"sessionId":"session-global","thinkingLevels":[{"id":"off","label":"off"},{"id":"minimal","label":"minimal"},{"id":"low","label":"low"},{"id":"medium","label":"medium"},{"id":"high","label":"high"}],"thinkingOptions":["off","minimal","low","medium","high"],"thinkingDefault":"off","effectiveFastMode":false,"effectiveFastModeSource":"default","fastAutoOnSeconds":60,"totalTokens":1,"totalTokensFresh":true,"estimatedCostUsd":0,"effectiveResponseUsage":"off","effectiveQueueMode":"steer","modelProvider":"openai","model":"gpt-5.4","modelOverrideSource":null,"agentRuntime":{"id":"codex","cloudPlacementSupported":false,"devicePlacementSupported":false,"source":"implicit"},"contextTokens":100}]}',
   ].join("");
 
   expect(JSON.stringify(result)).toBe(expectedSerializedResponse);

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -22,7 +22,7 @@ import * as titleReader from "./session-transcript-title-reader.js";
 import { resolveEstimatedSessionCostUsd } from "./session-utils-core.js";
 import { resolveGatewaySessionThinkingProjectionInternal } from "./session-utils-model.js";
 import { buildSessionListRowMetadataContext } from "./session-utils-projection.js";
-import { listSessionsFromStore, listSessionsFromStoreAsync } from "./session-utils.js";
+import { listSessionsFromStoreAsync } from "./session-utils.js";
 
 /**
  * Regression smoke for the per-list rowContext resolver cache. The bug we are
@@ -35,7 +35,7 @@ import { listSessionsFromStore, listSessionsFromStoreAsync } from "./session-uti
  * CI runners cannot give a stable wall-time signal, and call-count regressions
  * are the actual scaling failure mode we care about.
  */
-describe("listSessionsFromStore resolver cache", () => {
+describe("session list resolver cache", () => {
   test("collapses request-local resolver work to O(unique provider/model tuples)", () => {
     const cfg: OpenClawConfig = {
       agents: {
@@ -227,7 +227,7 @@ describe("listSessionsFromStore resolver cache", () => {
         expect(acpSelects).toBe(3);
 
         acpSelects = 0;
-        const result = listSessionsFromStore({
+        const result = await listSessionsFromStoreAsync({
           cfg,
           storePath: path.join(stateDir, "agents", "default", "sessions", "sessions.json"),
           store: {
@@ -235,7 +235,6 @@ describe("listSessionsFromStore resolver cache", () => {
             [missingKey]: missingEntry,
             [markerKey]: markerEntry,
           },
-          lightweightListRows: true,
           opts: { limit: 3 },
         });
         expect(result.sessions).toHaveLength(3);
@@ -298,7 +297,6 @@ describe("listSessionsFromStore resolver cache", () => {
           cfg,
           storePath,
           store,
-          lightweightListRows: true,
           ownerFirstActorId: ownerId,
           opts: { includeDerivedTitles: true, includeLastMessage: true, limit: scenario.limit },
         });
@@ -321,7 +319,6 @@ describe("listSessionsFromStore resolver cache", () => {
           cfg,
           storePath,
           store,
-          lightweightListRows: true,
           ownerFirstActorId: ownerId,
           opts: { includeDerivedTitles: false, includeLastMessage: false, limit: scenario.limit },
         });

--- a/src/gateway/session-utils.single-row-cache.test.ts
+++ b/src/gateway/session-utils.single-row-cache.test.ts
@@ -68,11 +68,7 @@ const subagentRegistryReadMock = vi.hoisted(() => {
 
 vi.mock("../agents/subagents/registry/subagent-registry-read.js", () => subagentRegistryReadMock);
 
-import {
-  listSessionsFromStore,
-  listSessionsFromStoreAsync,
-  loadGatewaySessionRow,
-} from "./session-utils.js";
+import { listSessionsFromStoreAsync, loadGatewaySessionRow } from "./session-utils.js";
 
 const MAIN_AGENT_ID = "main";
 const TEST_MODEL = "openai/gpt-5.4";
@@ -320,21 +316,6 @@ describe("single gateway session row child-session cache", () => {
             defaults: { model: { primary: TEST_MODEL } },
           },
         } as OpenClawConfig;
-
-        const syncListed = listSessionsFromStore({
-          cfg,
-          storePath,
-          store,
-          opts: { agentId: MAIN_AGENT_ID, limit: 1 },
-        });
-
-        expect(syncListed.sessions).toHaveLength(1);
-        expect(subagentRegistryReadMock.buildSubagentSessionListReadIndex).toHaveBeenCalledTimes(1);
-        expect(
-          subagentRegistryReadMock.getSessionDisplaySubagentRunByChildSessionKey,
-        ).not.toHaveBeenCalled();
-
-        vi.clearAllMocks();
 
         const asyncListed = await listSessionsFromStoreAsync({
           cfg,

--- a/src/gateway/session-utils.subagent.test.ts
+++ b/src/gateway/session-utils.subagent.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import * as subagentRegistryState from "../agents/subagents/registry/subagent-registry-state.js";
 import { canonicalSubagentRunFixtures } from "../agents/subagents/registry/subagent-registry.persistence.test-support.js";
 import type { SubagentRunFixture } from "../agents/subagents/registry/subagent-registry.persistence.test-support.js";
 import { saveSubagentRegistryToSqlite } from "../agents/subagents/registry/subagent-registry.store.sqlite.js";
@@ -25,10 +26,10 @@ import {
 } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
-import { withEnv } from "../test-utils/env.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { buildSingleRowStoreChildSessionsByKey } from "./session-utils-projection.js";
 import {
-  listSessionsFromStore,
+  listSessionsFromStoreAsync,
   loadCombinedSessionStoreForGatewayCore,
   resolveGatewayModelSupportsImages,
 } from "./session-utils.js";
@@ -46,7 +47,7 @@ async function seedSessionEntry(
   await replaceSessionEntry({ ...(agentId ? { agentId } : {}), sessionKey, storePath }, entry);
 }
 
-describe("listSessionsFromStore subagent metadata", () => {
+describe("session list subagent metadata", () => {
   afterEach(() => {
     resetAgentEventsForTest({ preserveListeners: true });
     closeOpenClawStateDatabaseForTest();
@@ -62,8 +63,8 @@ describe("listSessionsFromStore subagent metadata", () => {
     agents: { list: [{ id: "main", default: true }] },
   } as OpenClawConfig;
 
-  test("searches channel-derived display names before row enrichment", () => {
-    const result = listSessionsFromStore({
+  test("searches channel-derived display names before row enrichment", async () => {
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store: {
@@ -87,7 +88,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     expect(result.sessions[0]?.displayName).toBe("slack:g-general");
   });
 
-  test("applies limit before transcript enrichment", () => {
+  test("applies limit before transcript enrichment", async () => {
     const store: Record<string, SessionEntry> = {
       "agent:main:newest": {
         sessionId: "newest-session",
@@ -107,7 +108,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     };
     const existsSpy = vi.spyOn(fs, "existsSync").mockReturnValue(false);
     try {
-      const result = listSessionsFromStore({
+      const result = await listSessionsFromStoreAsync({
         cfg,
         storePath: "/tmp/sessions.json",
         store,
@@ -124,7 +125,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     }
   });
 
-  test("keeps persisted navigation lineage separate from live registry control", () => {
+  test("keeps persisted navigation lineage separate from live registry control", async () => {
     const now = Date.now();
     const childSessionKey = "agent:main:subagent:controlled-child";
     const entry = {
@@ -155,7 +156,7 @@ describe("listSessionsFromStore subagent metadata", () => {
       startedAt: now - 4_000,
     });
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store: { [childSessionKey]: entry },
@@ -181,7 +182,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     expect(row.previousSessionId).toBe("sess-previous");
   });
 
-  test("discovers controlled children through both navigation and runtime owners", () => {
+  test("discovers controlled children through both navigation and runtime owners", async () => {
     const now = Date.now();
     const navigationParentKey = "agent:main:dashboard:navigation-parent";
     const controlParentKey = "agent:main:subagent:runtime-controller";
@@ -216,24 +217,24 @@ describe("listSessionsFromStore subagent metadata", () => {
       startedAt: now - 4_000,
     });
 
-    const listForOwner = (ownerSessionKey: string) =>
-      listSessionsFromStore({
+    const listForOwner = async (ownerSessionKey: string) =>
+      await listSessionsFromStoreAsync({
         cfg,
         storePath: "/tmp/sessions.json",
         store,
         opts: { spawnedBy: ownerSessionKey },
       });
 
-    const navigationChildren = listForOwner(navigationParentKey).sessions;
+    const navigationChildren = (await listForOwner(navigationParentKey)).sessions;
     expect(navigationChildren.map((session) => session.key)).toEqual([childSessionKey]);
     expect(navigationChildren[0]?.parentSessionKey).toBe(navigationParentKey);
     expect(navigationChildren[0]?.controlOwnerSessionKey).toBe(controlParentKey);
-    expect(listForOwner(controlParentKey).sessions.map((session) => session.key)).toEqual([
+    expect((await listForOwner(controlParentKey)).sessions.map((session) => session.key)).toEqual([
       childSessionKey,
     ]);
-    expect(listForOwner(staleParentKey).sessions).toEqual([]);
+    expect((await listForOwner(staleParentKey)).sessions).toEqual([]);
 
-    const all = listSessionsFromStore({
+    const all = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -256,7 +257,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     ).toEqual([childSessionKey]);
   });
 
-  test("includes subagent status timing and direct child session keys", () => {
+  test("includes subagent status timing and direct child session keys", async () => {
     const now = Date.now();
     const store: Record<string, SessionEntry> = {
       "agent:main:main": {
@@ -330,7 +331,7 @@ describe("listSessionsFromStore subagent metadata", () => {
       model: "openai/gpt-5.4",
     });
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -369,7 +370,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     expect(failed?.runtimeMs).toBe(5_000);
   });
 
-  test("does not show stale registry-only subagent runs as actively running", () => {
+  test("does not show stale registry-only subagent runs as actively running", async () => {
     const now = Date.now();
     const childSessionKey = "agent:main:subagent:stale-display";
     const store: Record<string, SessionEntry> = {
@@ -397,7 +398,7 @@ describe("listSessionsFromStore subagent metadata", () => {
       model: "openai/gpt-5.4",
     });
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -412,7 +413,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     expect(row?.runtimeMs).toBe(3_500);
   });
 
-  test("does not keep childSessions attached to a stale older controller row", () => {
+  test("does not keep childSessions attached to a stale older controller row", async () => {
     const now = Date.now();
     const store: Record<string, SessionEntry> = {
       "agent:main:main": {
@@ -483,7 +484,7 @@ describe("listSessionsFromStore subagent metadata", () => {
       startedAt: now - 1_500,
     });
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -501,7 +502,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     expect(newParent?.childSessions).toEqual(["agent:main:subagent:shared-child"]);
   });
 
-  test("does not reattach moved children through stale spawnedBy store metadata", () => {
+  test("does not reattach moved children through stale spawnedBy store metadata", async () => {
     const now = Date.now();
     const store: Record<string, SessionEntry> = {
       "agent:main:main": {
@@ -572,7 +573,7 @@ describe("listSessionsFromStore subagent metadata", () => {
       startedAt: now - 1_500,
     });
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -590,7 +591,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     expect(newParent?.childSessions).toEqual(["agent:main:subagent:shared-child-store"]);
   });
 
-  test("does not return moved child sessions from stale spawnedBy filters", () => {
+  test("does not return moved child sessions from stale spawnedBy filters", async () => {
     const now = Date.now();
     const store: Record<string, SessionEntry> = {
       "agent:main:main": {
@@ -661,7 +662,7 @@ describe("listSessionsFromStore subagent metadata", () => {
       startedAt: now - 1_500,
     });
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -673,7 +674,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     expect(result.sessions.map((session) => session.key)).toStrictEqual([]);
   });
 
-  test("reports the newest run owner for moved child session rows", () => {
+  test("reports the newest run owner for moved child session rows", async () => {
     const now = Date.now();
     const childSessionKey = "agent:main:subagent:shared-child-owner";
     const store: Record<string, SessionEntry> = {
@@ -709,7 +710,7 @@ describe("listSessionsFromStore subagent metadata", () => {
       startedAt: now - 1_500,
     });
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -721,7 +722,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     expect(result.sessions[0]?.spawnedBy).toBe("agent:main:subagent:new-parent-owner");
   });
 
-  test("keeps the persisted parentSessionKey while reporting the newest runtime controller", () => {
+  test("keeps the persisted parentSessionKey while reporting the newest runtime controller", async () => {
     const now = Date.now();
     const childSessionKey = "agent:main:subagent:shared-child-parent";
     const store: Record<string, SessionEntry> = {
@@ -757,7 +758,7 @@ describe("listSessionsFromStore subagent metadata", () => {
       startedAt: now - 1_500,
     });
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -773,7 +774,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     );
   });
 
-  test("preserves original session timing across follow-up replacement runs", () => {
+  test("preserves original session timing across follow-up replacement runs", async () => {
     const now = Date.now();
     const store: Record<string, SessionEntry> = {
       "agent:main:subagent:followup": {
@@ -801,7 +802,7 @@ describe("listSessionsFromStore subagent metadata", () => {
       sessionKey: "agent:main:subagent:followup",
     });
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -816,7 +817,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     expect(followup?.runtimeMs).toBeGreaterThanOrEqual(150_000);
   });
 
-  test("uses the newest child-session row for stale/current replacement pairs", () => {
+  test("uses the newest child-session row for stale/current replacement pairs", async () => {
     const now = Date.now();
     const childSessionKey = "agent:main:subagent:stale-current";
     const store: Record<string, SessionEntry> = {
@@ -854,7 +855,7 @@ describe("listSessionsFromStore subagent metadata", () => {
       model: "openai/gpt-5.4",
     });
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -868,7 +869,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     expect(result.sessions[0]?.endedAt).toBe(now - 200);
   });
 
-  test("prefers persisted terminal session state when only stale active subagent snapshots remain", () => {
+  test("prefers persisted terminal session state when only stale active subagent snapshots remain", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-utils-subagent-"));
     const stateDir = path.join(tempRoot, "state");
     fs.mkdirSync(stateDir, { recursive: true });
@@ -906,14 +907,14 @@ describe("listSessionsFromStore subagent metadata", () => {
         ],
       ]);
 
-      const row = withEnv(
+      const row = await withEnvAsync(
         {
           OPENCLAW_STATE_DIR: stateDir,
           OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_SQLITE: "1",
         },
-        () => {
+        async () => {
           saveSubagentRegistryToSqlite(canonicalSubagentRunFixtures(persistedRuns));
-          const result = listSessionsFromStore({
+          const result = await listSessionsFromStoreAsync({
             cfg,
             storePath: "/tmp/sessions.json",
             store: {
@@ -944,12 +945,11 @@ describe("listSessionsFromStore subagent metadata", () => {
     }
   });
 
-  test("reuses one SQLite registry snapshot across sessions.list filtering and row enrichment", () => {
+  test("reuses one SQLite registry snapshot across sessions.list filtering and row enrichment", async () => {
     const tempRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), "openclaw-session-utils-subagent-cache-"),
     );
     const stateDir = path.join(tempRoot, "state");
-    const registryPath = path.join(stateDir, "subagents", "runs.json");
     const now = Date.now();
     const controllerSessionKey = "agent:main:main";
     const childKeys = [
@@ -995,16 +995,19 @@ describe("listSessionsFromStore subagent metadata", () => {
       } as SessionEntry,
     };
 
-    const statSpy = vi.spyOn(fs, "statSync");
+    const snapshotSpy = vi.spyOn(
+      subagentRegistryState,
+      "getSubagentSessionListRunsSnapshotForRead",
+    );
     try {
-      const result = withEnv(
+      const result = await withEnvAsync(
         {
           OPENCLAW_STATE_DIR: stateDir,
           OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_SQLITE: "1",
         },
-        () => {
+        async () => {
           saveSubagentRegistryToSqlite(canonicalSubagentRunFixtures(persistedRuns));
-          return listSessionsFromStore({
+          return await listSessionsFromStoreAsync({
             cfg,
             storePath: "/tmp/sessions.json",
             store,
@@ -1014,33 +1017,32 @@ describe("listSessionsFromStore subagent metadata", () => {
       );
 
       expect(result.sessions.map((session) => session.key)).toEqual(childKeys);
-      const registryStatCount = statSpy.mock.calls.filter(
-        ([pathname]) => path.normalize(String(pathname)) === path.normalize(registryPath),
-      ).length;
-      expect(registryStatCount).toBe(0);
+      expect(snapshotSpy).toHaveBeenCalledTimes(1);
     } finally {
-      statSpy.mockRestore();
+      snapshotSpy.mockRestore();
       closeOpenClawStateDatabaseForTest();
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }
   });
 
-  test("does not read the subagent registry when raw filters drop every session", () => {
+  test("does not read the subagent registry when raw filters drop every session", async () => {
     const tempRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), "openclaw-session-utils-subagent-cache-empty-"),
     );
     const stateDir = path.join(tempRoot, "state");
-    const registryPath = path.join(stateDir, "subagents", "runs.json");
 
-    const statSpy = vi.spyOn(fs, "statSync");
+    const snapshotSpy = vi.spyOn(
+      subagentRegistryState,
+      "getSubagentSessionListRunsSnapshotForRead",
+    );
     try {
-      const result = withEnv(
+      const result = await withEnvAsync(
         {
           OPENCLAW_STATE_DIR: stateDir,
           OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_SQLITE: "1",
         },
-        () =>
-          listSessionsFromStore({
+        async () =>
+          await listSessionsFromStoreAsync({
             cfg,
             storePath: "/tmp/sessions.json",
             store: {
@@ -1054,18 +1056,15 @@ describe("listSessionsFromStore subagent metadata", () => {
       );
 
       expect(result.sessions).toStrictEqual([]);
-      const registryStatCount = statSpy.mock.calls.filter(
-        ([pathname]) => path.normalize(String(pathname)) === path.normalize(registryPath),
-      ).length;
-      expect(registryStatCount).toBe(0);
+      expect(snapshotSpy).not.toHaveBeenCalled();
     } finally {
-      statSpy.mockRestore();
+      snapshotSpy.mockRestore();
       closeOpenClawStateDatabaseForTest();
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }
   });
 
-  test("includes explicit parentSessionKey relationships for dashboard child sessions", () => {
+  test("includes explicit parentSessionKey relationships for dashboard child sessions", async () => {
     resetSubagentRegistryForTests({ persist: false });
     const now = Date.now();
     const store: Record<string, SessionEntry> = {
@@ -1080,7 +1079,7 @@ describe("listSessionsFromStore subagent metadata", () => {
       } as SessionEntry,
     };
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -1093,7 +1092,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     expect(child?.parentSessionKey).toBe("agent:main:main");
   });
 
-  test("returns dashboard child sessions when filtering by parentSessionKey owner", () => {
+  test("returns dashboard child sessions when filtering by parentSessionKey owner", async () => {
     resetSubagentRegistryForTests({ persist: false });
     const now = Date.now();
     const store: Record<string, SessionEntry> = {
@@ -1108,7 +1107,7 @@ describe("listSessionsFromStore subagent metadata", () => {
       } as SessionEntry,
     };
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -1120,7 +1119,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     expect(result.sessions.map((session) => session.key)).toEqual(["agent:main:dashboard:child"]);
   });
 
-  test("does not reattach stale terminal store-only child links", () => {
+  test("does not reattach stale terminal store-only child links", async () => {
     resetSubagentRegistryForTests({ persist: false });
     const now = Date.now();
     const staleAt = now - 2 * 60 * 60_000;
@@ -1138,7 +1137,7 @@ describe("listSessionsFromStore subagent metadata", () => {
       } as SessionEntry,
     };
 
-    const all = listSessionsFromStore({
+    const all = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -1147,7 +1146,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     const main = all.sessions.find((session) => session.key === "agent:main:main");
     expect(main?.childSessions).toBeUndefined();
 
-    const filtered = listSessionsFromStore({
+    const filtered = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -1158,7 +1157,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     expect(filtered.sessions.map((session) => session.key)).toStrictEqual([]);
   });
 
-  test("does not reattach stale orphan store-only child links without lifecycle fields", () => {
+  test("does not reattach stale orphan store-only child links without lifecycle fields", async () => {
     resetSubagentRegistryForTests({ persist: false });
     const now = Date.now();
     const staleAt = now - 2 * 60 * 60_000;
@@ -1174,7 +1173,7 @@ describe("listSessionsFromStore subagent metadata", () => {
       } as SessionEntry,
     };
 
-    const all = listSessionsFromStore({
+    const all = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -1183,7 +1182,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     const main = all.sessions.find((session) => session.key === "agent:main:main");
     expect(main?.childSessions).toBeUndefined();
 
-    const filtered = listSessionsFromStore({
+    const filtered = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -1194,7 +1193,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     expect(filtered.sessions.map((session) => session.key)).toStrictEqual([]);
   });
 
-  test("does not keep old ended registry runs attached as child sessions", () => {
+  test("does not keep old ended registry runs attached as child sessions", async () => {
     const now = Date.now();
     const store: Record<string, SessionEntry> = {
       "agent:main:main": {
@@ -1222,7 +1221,7 @@ describe("listSessionsFromStore subagent metadata", () => {
       outcome: { status: "ok" },
     });
 
-    const all = listSessionsFromStore({
+    const all = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -1231,7 +1230,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     const main = all.sessions.find((session) => session.key === "agent:main:main");
     expect(main?.childSessions).toBeUndefined();
 
-    const filtered = listSessionsFromStore({
+    const filtered = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -1242,7 +1241,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     expect(filtered.sessions.map((session) => session.key)).toStrictEqual([]);
   });
 
-  test("keeps ended parents attached while live descendants are still running", () => {
+  test("keeps ended parents attached while live descendants are still running", async () => {
     const now = Date.now();
     const parentKey = "agent:main:subagent:ended-parent";
     const childKey = "agent:main:subagent:ended-parent:subagent:live-child";
@@ -1288,7 +1287,7 @@ describe("listSessionsFromStore subagent metadata", () => {
       startedAt: now - 900,
     });
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -1302,7 +1301,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     );
   });
 
-  test("falls back to persisted subagent timing after run archival", () => {
+  test("falls back to persisted subagent timing after run archival", async () => {
     const now = Date.now();
     const store: Record<string, SessionEntry> = {
       "agent:main:subagent:archived": {
@@ -1316,7 +1315,7 @@ describe("listSessionsFromStore subagent metadata", () => {
       } as SessionEntry,
     };
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -1332,7 +1331,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     expect(archived?.runtimeMs).toBe(15_000);
   });
 
-  test("maps timeout outcomes to timeout status and clamps negative runtime", () => {
+  test("maps timeout outcomes to timeout status and clamps negative runtime", async () => {
     const now = Date.now();
     const store: Record<string, SessionEntry> = {
       "agent:main:subagent:timeout": {
@@ -1357,7 +1356,7 @@ describe("listSessionsFromStore subagent metadata", () => {
       model: "openai/gpt-5.4",
     });
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store,

--- a/src/gateway/session-utils.telegram-recreate.test.ts
+++ b/src/gateway/session-utils.telegram-recreate.test.ts
@@ -18,7 +18,7 @@ import {
   deliveryContextFromSession,
   sessionDeliveryOrigin,
 } from "../utils/delivery-context.shared.js";
-import { listSessionsFromStore } from "./session-utils.js";
+import { listSessionsFromStoreAsync } from "./session-utils.js";
 
 const TELEGRAM_DIRECT_KEY = "agent:main:telegram:direct:7463849194";
 
@@ -107,7 +107,7 @@ describe("Telegram direct session recreation after delete", () => {
       session: { ...cfg.session, store: storePath },
     } satisfies OpenClawConfig;
     const loaded = loadCombinedSessionStoreForGatewayCore(runtimeCfg, { agentId: "main" });
-    const listed = listSessionsFromStore({
+    const listed = await listSessionsFromStoreAsync({
       cfg: runtimeCfg,
       storePath: loaded.storePath,
       store: loaded.store,

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -32,7 +32,7 @@ import { buildGatewaySessionEventFields } from "./session-event-payload.js";
 import { projectSessionActor } from "./session-identity-projection.js";
 import { resolveSessionStoreAgentId, resolveSessionStoreKey } from "./session-store-key.js";
 import { deriveSessionTitle } from "./session-utils-core.js";
-import { listSessionsFromStore, listSessionsFromStoreAsync } from "./session-utils-list.js";
+import { listSessionsFromStoreAsync } from "./session-utils-list.js";
 import {
   getSessionDefaults,
   projectSessionPatchResult,
@@ -584,7 +584,7 @@ describe("gateway session utils", () => {
     expect(listed.sessions.at(-1)?.key).toBe("session-99");
   });
 
-  test("session lists honor explicit caller limits", () => {
+  test("session lists honor explicit caller limits", async () => {
     const cfg = createModelDefaultsConfig({ primary: "openai/gpt-5.4" });
     const store = Object.fromEntries(
       Array.from({ length: 5 }, (_value, index) => [
@@ -596,7 +596,7 @@ describe("gateway session utils", () => {
       ]),
     );
 
-    const listed = listSessionsFromStore({
+    const listed = await listSessionsFromStoreAsync({
       cfg,
       storePath: "",
       store,
@@ -615,7 +615,7 @@ describe("gateway session utils", () => {
     expect(listed.hasMore).toBe(true);
   });
 
-  test("session lists separate archived rows and sort pinned sessions first", () => {
+  test("session lists separate archived rows and sort pinned sessions first", async () => {
     const cfg = createModelDefaultsConfig({ primary: "openai/gpt-5.4" });
     const store: Record<string, SessionEntry> = {
       recent: { sessionId: "recent", updatedAt: 30 },
@@ -623,7 +623,7 @@ describe("gateway session utils", () => {
       archived: { sessionId: "archived", updatedAt: 20, archivedAt: 50 },
     } satisfies Record<string, SessionEntry>;
 
-    const active = listSessionsFromStore({ cfg, storePath: "", store, opts: {} });
+    const active = await listSessionsFromStoreAsync({ cfg, storePath: "", store, opts: {} });
     expect(active.sessions.map((session) => session.key)).toEqual(["pinned", "recent"]);
     expect(active.sessions[0]).toMatchObject({
       pinned: true,
@@ -631,7 +631,7 @@ describe("gateway session utils", () => {
       archived: false,
     });
 
-    const archived = listSessionsFromStore({
+    const archived = await listSessionsFromStoreAsync({
       cfg,
       storePath: "",
       store,
@@ -641,7 +641,7 @@ describe("gateway session utils", () => {
       { key: "archived", archived: true, archivedAt: 50, pinned: false },
     ]);
 
-    const all = listSessionsFromStore({
+    const all = await listSessionsFromStoreAsync({
       cfg,
       storePath: "",
       store,
@@ -650,7 +650,7 @@ describe("gateway session utils", () => {
     expect(all.sessions.map((session) => session.key)).toEqual(["pinned", "recent", "archived"]);
   });
 
-  test("session lists page from an offset after filtering and sorting", () => {
+  test("session lists page from an offset after filtering and sorting", async () => {
     const cfg = createModelDefaultsConfig({ primary: "openai/gpt-5.4" });
     const store = Object.fromEntries(
       Array.from({ length: 6 }, (_value, index) => [
@@ -663,7 +663,7 @@ describe("gateway session utils", () => {
       ]),
     );
 
-    const listed = listSessionsFromStore({
+    const listed = await listSessionsFromStoreAsync({
       cfg,
       storePath: "",
       store,
@@ -679,7 +679,7 @@ describe("gateway session utils", () => {
     expect(listed.hasMore).toBe(true);
   });
 
-  test("session list search includes the session group name", () => {
+  test("session list search includes the session group name", async () => {
     const cfg = { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig;
     const store: Record<string, SessionEntry> = {
       "agent:main:roadmap": {
@@ -696,7 +696,7 @@ describe("gateway session utils", () => {
       },
     };
 
-    const listed = listSessionsFromStore({
+    const listed = await listSessionsFromStoreAsync({
       cfg,
       storePath: "",
       store,
@@ -706,7 +706,7 @@ describe("gateway session utils", () => {
     expect(listed.sessions.map((session) => session.key)).toEqual(["agent:main:roadmap"]);
   });
 
-  test("session list search includes direct-session origin display labels", () => {
+  test("session list search includes direct-session origin display labels", async () => {
     const cfg = { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig;
     const store: Record<string, SessionEntry> = {
       "agent:main:telegram:direct:42": {
@@ -729,7 +729,7 @@ describe("gateway session utils", () => {
       },
     };
 
-    const listed = listSessionsFromStore({
+    const listed = await listSessionsFromStoreAsync({
       cfg,
       storePath: "",
       store,
@@ -742,7 +742,7 @@ describe("gateway session utils", () => {
     expect(listed.sessions[0]?.displayName).toBe("openclaw-tui");
   });
 
-  test("session lists mark the final offset page without hasMore", () => {
+  test("session lists mark the final offset page without hasMore", async () => {
     const cfg = createModelDefaultsConfig({ primary: "openai/gpt-5.4" });
     const store = Object.fromEntries(
       Array.from({ length: 5 }, (_value, index) => [
@@ -754,7 +754,7 @@ describe("gateway session utils", () => {
       ]),
     );
 
-    const listed = listSessionsFromStore({
+    const listed = await listSessionsFromStoreAsync({
       cfg,
       storePath: "",
       store,
@@ -1226,7 +1226,7 @@ describe("gateway session utils", () => {
     expect(resolveThinkingProfile).toHaveBeenCalled();
   });
 
-  test("session list thinking cache preserves case-distinct model catalog entries", () => {
+  test("session list thinking cache preserves case-distinct model catalog entries", async () => {
     const cfg = createModelDefaultsConfig({ primary: "custom/CaseModel" });
     const modelCatalog = [
       {
@@ -1244,7 +1244,7 @@ describe("gateway session utils", () => {
         compat: { supportedReasoningEfforts: ["low", "medium", "high"] },
       },
     ];
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "",
       modelCatalog,
@@ -4023,7 +4023,7 @@ describe("gateway session utils", () => {
   });
 });
 
-describe("listSessionsFromStore selected model display", () => {
+describe("session list selected model display", () => {
   test("async list yields during bulk transcript title and last-message hydration", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sessions-list-yield-"));
     try {
@@ -4065,7 +4065,6 @@ describe("listSessionsFromStore selected model display", () => {
         store,
         opts: { includeDerivedTitles: true, includeLastMessage: true, limit: 11 },
       };
-      const expected = listSessionsFromStore(params);
       const listedPromise = listSessionsFromStoreAsync(params);
       let settled = false;
       void listedPromise.then(() => {
@@ -4076,14 +4075,18 @@ describe("listSessionsFromStore selected model display", () => {
 
       expect(settled).toBe(false);
       const listed = await listedPromise;
-      expect(listed.path).toBe(expected.path);
-      expect(listed.count).toBe(expected.count);
-      expect(listed.defaults).toEqual(expected.defaults);
-      expect(listed.sessions).toHaveLength(expected.sessions.length);
+      expect(listed.path).toBe(storePath);
+      expect(listed.count).toBe(11);
+      expect(listed.sessions).toHaveLength(11);
       expectFields(listed.sessions[0], {
         key: "agent:main:sess-yield-0",
         derivedTitle: "title 0",
         lastMessagePreview: "last 0",
+      });
+      expectFields(listed.sessions.at(-1), {
+        key: "agent:main:sess-yield-10",
+        derivedTitle: "title 10",
+        lastMessagePreview: "last 10",
       });
       expect(listed.sessions[0]?.agentRuntime).toEqual({
         id: "codex",
@@ -4153,7 +4156,7 @@ describe("listSessionsFromStore selected model display", () => {
     }
   });
 
-  test("uses bounded top-N selection for small limited lists", () => {
+  test("uses bounded top-N selection for small limited lists", async () => {
     const now = Date.now();
     const store: Record<string, SessionEntry> = {
       "agent:main:old": { sessionId: "old", updatedAt: now - 10_000 } as SessionEntry,
@@ -4162,7 +4165,7 @@ describe("listSessionsFromStore selected model display", () => {
       "agent:main:middle-b": { sessionId: "middle-b", updatedAt: now - 5_000 } as SessionEntry,
       "agent:main:newer": { sessionId: "newer", updatedAt: now - 1_000 } as SessionEntry,
     };
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg: createModelDefaultsConfig({ primary: "openai/gpt-5.4" }),
       storePath: "/tmp/sessions.json",
       store,
@@ -4177,9 +4180,9 @@ describe("listSessionsFromStore selected model display", () => {
     ]);
   });
 
-  test("keeps the scoped global row when filtering by agent", () => {
+  test("keeps the scoped global row when filtering by agent", async () => {
     const now = Date.now();
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg: {
         ...createModelDefaultsConfig({ primary: "openai/gpt-5.4" }),
         agents: {
@@ -4206,9 +4209,9 @@ describe("listSessionsFromStore selected model display", () => {
     });
   });
 
-  test("searches a selected agent's global row in an ownerless explicit fleet", () => {
+  test("searches a selected agent's global row in an ownerless explicit fleet", async () => {
     const now = Date.now();
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg: {
         agents: {
           ownership: "explicit",
@@ -4235,9 +4238,9 @@ describe("listSessionsFromStore selected model display", () => {
     });
   });
 
-  test("filters phantom agent store placeholder rows from session lists", () => {
+  test("filters phantom agent store placeholder rows from session lists", async () => {
     const now = Date.now();
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg: createModelDefaultsConfig({ primary: "openai/gpt-5.4" }),
       storePath: "/tmp/sessions.json",
       store: {
@@ -4250,12 +4253,12 @@ describe("listSessionsFromStore selected model display", () => {
     expect(result.sessions.map((session) => session.key)).toEqual(["agent:main:main"]);
   });
 
-  test("shows the selected override model even when a fallback runtime model exists", () => {
+  test("shows the selected override model even when a fallback runtime model exists", async () => {
     const cfg = createModelDefaultsConfig({
       primary: "anthropic/claude-opus-4-6",
     });
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store: {
@@ -4275,13 +4278,13 @@ describe("listSessionsFromStore selected model display", () => {
     expect(result.sessions[0]?.model).toBe("claude-opus-4-6");
   });
 
-  test("separates Claude CLI runtime metadata from canonical model identity", () => {
+  test("separates Claude CLI runtime metadata from canonical model identity", async () => {
     const cfg = createModelDefaultsConfig({
       primary: "anthropic/claude-opus-4-7",
       agentRuntime: { id: "claude-cli" },
     });
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store: {
@@ -4305,7 +4308,7 @@ describe("listSessionsFromStore selected model display", () => {
     });
   });
 
-  test("ignores bare CLI runtime metadata when the selected default differs", () => {
+  test("ignores bare CLI runtime metadata when the selected default differs", async () => {
     const cfg = createModelDefaultsConfig({
       primary: "openai/gpt-5.4",
       models: {
@@ -4314,7 +4317,7 @@ describe("listSessionsFromStore selected model display", () => {
       agentRuntime: { id: "claude-cli" },
     });
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store: {
@@ -4332,7 +4335,7 @@ describe("listSessionsFromStore selected model display", () => {
     expect(result.sessions[0]?.model).toBe("gpt-5.4");
   });
 
-  test("uses qualified selected defaults for rows without runtime model metadata", () => {
+  test("uses qualified selected defaults for rows without runtime model metadata", async () => {
     const cfg = {
       agents: {
         defaults: {
@@ -4352,7 +4355,7 @@ describe("listSessionsFromStore selected model display", () => {
       },
     } as OpenClawConfig;
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store: {
@@ -4381,7 +4384,7 @@ describe("listSessionsFromStore selected model display", () => {
     ]);
   });
 
-  test("uses selected defaults before persisted runtime model metadata", () => {
+  test("uses selected defaults before persisted runtime model metadata", async () => {
     const cfg = {
       agents: {
         defaults: { model: { primary: "openai/gpt-5.4" } },
@@ -4389,7 +4392,7 @@ describe("listSessionsFromStore selected model display", () => {
       },
     } as OpenClawConfig;
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store: {
@@ -4407,7 +4410,7 @@ describe("listSessionsFromStore selected model display", () => {
     expect(result.sessions[0]?.model).toBe("claude-sonnet-4-6");
   });
 
-  test("uses complete model overrides without default-model fallback", () => {
+  test("uses complete model overrides without default-model fallback", async () => {
     const cfg = {
       agents: {
         defaults: { model: { primary: "openai/gpt-5.4" } },
@@ -4415,7 +4418,7 @@ describe("listSessionsFromStore selected model display", () => {
       },
     } as OpenClawConfig;
 
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "/tmp/sessions.json",
       store: {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -29,5 +29,4 @@ export { loadGatewaySessionRow } from "./session-utils-search.js";
 export { loadGatewaySessionLifecycleSnapshot } from "./session-utils-search.js";
 export { buildGatewaySessionInfo } from "./session-utils-search.js";
 export { filterAndSortSessionEntries } from "./session-utils-list.js";
-export { listSessionsFromStore } from "./session-utils-list.js";
 export { listSessionsFromStoreAsync } from "./session-utils-list.js";

--- a/src/gateway/sessions-resolve.test.ts
+++ b/src/gateway/sessions-resolve.test.ts
@@ -1,11 +1,11 @@
 // Session resolve tests cover canonical/legacy key lookup, store migration,
 // agent scoping, listed-session selection, and protocol error mapping.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { ErrorCodes } from "../../packages/gateway-protocol/src/index.js";
 import type { SessionEntry } from "../config/sessions/types.js";
+import * as sessionRows from "./session-utils-row.js";
 
 const hoisted = vi.hoisted(() => ({
-  listSessionsFromStoreMock: vi.fn(),
   resolveGatewaySessionStoreTargetWithStoreMock: vi.fn(),
   loadCombinedSessionStoreForGatewayMock: vi.fn(),
   listAgentIdsMock: vi.fn(),
@@ -25,7 +25,6 @@ vi.mock("./session-utils.js", async () => {
   const actual = await vi.importActual<typeof import("./session-utils.js")>("./session-utils.js");
   return {
     ...actual,
-    listSessionsFromStore: hoisted.listSessionsFromStoreMock,
     resolveGatewaySessionStoreTargetWithStore:
       hoisted.resolveGatewaySessionStoreTargetWithStoreMock,
     loadCombinedSessionStoreForGatewayCore: hoisted.loadCombinedSessionStoreForGatewayMock,
@@ -60,11 +59,9 @@ describe("resolveSessionKeyFromResolveParams", () => {
       key: canonicalKey,
       agentId: "main",
     });
-    expect(hoisted.listSessionsFromStoreMock).not.toHaveBeenCalled();
   };
 
   beforeEach(() => {
-    hoisted.listSessionsFromStoreMock.mockReset();
     hoisted.resolveGatewaySessionStoreTargetWithStoreMock.mockReset();
     hoisted.loadCombinedSessionStoreForGatewayMock.mockReset();
     hoisted.listAgentIdsMock.mockReset();
@@ -83,7 +80,6 @@ describe("resolveSessionKeyFromResolveParams", () => {
     targetStore = {
       [canonicalKey]: { sessionId: "sess-1", updatedAt: 1 },
     };
-    hoisted.listSessionsFromStoreMock.mockReturnValue({ sessions: [] });
 
     await expect(
       resolveSessionKeyFromResolveParams({
@@ -246,29 +242,32 @@ describe("resolveSessionKeyFromResolveParams", () => {
     });
   });
 
-  it("resolves sessionId matches from raw store metadata without hydrating session rows", async () => {
+  it.each([
+    { sessionId: "sess-target", agentId: "main" },
+    { label: "target-label", agentId: "main" },
+  ])("resolves %j from raw metadata without hydrating session rows", async (p) => {
     hoisted.loadCombinedSessionStoreForGatewayMock.mockReturnValue({
       storePath,
       store: {
-        "agent:main:noisy": { sessionId: "sess-noisy", updatedAt: 2 },
-        "agent:main:target": { sessionId: "sess-target", updatedAt: 1 },
+        "agent:main:noisy": {
+          sessionId: "sess-noisy",
+          label: "target-label extra",
+          updatedAt: 2,
+        },
+        "agent:main:target": { sessionId: "sess-target", label: "target-label", updatedAt: 1 },
       },
     });
-    hoisted.listSessionsFromStoreMock.mockImplementation(() => {
-      throw new Error("session rows should not be materialized for exact sessionId lookup");
-    });
+    const rowSpy = vi.spyOn(sessionRows, "buildGatewaySessionRow");
+    onTestFinished(() => rowSpy.mockRestore());
 
     const cfg = {};
-    const result = await resolveSessionKeyFromResolveParams({
-      cfg,
-      p: { sessionId: "sess-target", agentId: "main" },
-    });
+    const result = await resolveSessionKeyFromResolveParams({ cfg, p });
 
     expect(result).toEqual({ ok: true, key: "agent:main:target", agentId: "main" });
     expect(hoisted.loadCombinedSessionStoreForGatewayMock).toHaveBeenCalledWith(cfg, {
       agentId: "main",
     });
-    expect(hoisted.listSessionsFromStoreMock).not.toHaveBeenCalled();
+    expect(rowSpy).not.toHaveBeenCalled();
   });
 
   it("resolves an archived session by its trailing UUID prefix", async () => {
@@ -459,23 +458,17 @@ describe("resolveSessionKeyFromResolveParams", () => {
       storePath,
       store: { [deletedAgentKey]: { sessionId: "sess-orphan", updatedAt: 1, label: "my-label" } },
     });
-    hoisted.listSessionsFromStoreMock.mockReturnValue({
-      sessions: [{ key: deletedAgentKey, sessionId: "sess-orphan", label: "my-label" }],
-    });
     hoisted.listAgentIdsMock.mockReturnValue(["main"]);
 
     const cfg = {};
     const result = await resolveSessionKeyFromResolveParams({
       cfg,
-      p: { label: "my-label", agentId: "main" },
+      p: { label: "my-label" },
     });
 
     expect(hoisted.loadCombinedSessionStoreForGatewayMock).toHaveBeenCalledWith(cfg, {
-      agentId: "main",
+      agentId: undefined,
     });
-    expect(hoisted.listSessionsFromStoreMock).toHaveBeenCalledWith(
-      expect.objectContaining({ lightweightListRows: true }),
-    );
     expect(result).toEqual({
       ok: false,
       error: {

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -17,17 +17,19 @@ import {
 import { listAgentIds } from "../agents/agent-scope.js";
 import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { parseAgentSessionKey } from "../routing/session-key.js";
+import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { resolveSessionIdMatchSelection } from "../sessions/session-id-resolution.js";
 import { parseSessionLabel } from "../sessions/session-label.js";
 import { hasOperatorBoundary } from "./operator-role-policy.js";
 import type { GatewayClient } from "./server-methods/types.js";
 import { resolveRequestedSessionAgentId } from "./session-request-agent.js";
 import { createSessionListEntryFilter } from "./session-sharing.js";
+import { resolveSessionStoreAgentId } from "./session-store-key.js";
+import type { SessionListRowContext } from "./session-utils-contracts.js";
+import { buildSessionListRowMetadataContext } from "./session-utils-projection.js";
 import {
   buildGatewaySessionInfo,
   filterAndSortSessionEntries,
-  listSessionsFromStore,
   loadCombinedSessionStoreForGatewayCore,
   resolveDeletedAgentIdFromSessionKey,
   resolveGatewaySessionStoreTargetWithStore,
@@ -394,30 +396,30 @@ export async function resolveSessionKeyFromResolveParams(params: {
     };
   }
 
-  const { storePath, store } = loadCombinedSessionStoreForGatewayCore(cfg, { agentId: p.agentId });
-  const list = listSessionsFromStore({
+  const { store } = loadCombinedSessionStoreForGatewayCore(cfg, { agentId: p.agentId });
+  const now = Date.now();
+  // Keep list-discovery snapshot semantics without hydrating display rows.
+  let rowContext: SessionListRowContext | undefined;
+  const matches = filterAndSortSessionEntries({
     cfg,
     ...(entryFilter ? { entryFilter } : {}),
-    storePath,
     store,
-    lightweightListRows: true,
+    now,
+    getRowContext: () => (rowContext ??= buildSessionListRowMetadataContext({ now })),
     opts: {
-      includeGlobal: p.includeGlobal === true,
-      includeUnknown: p.includeUnknown === true,
+      ...resolveSessionVisibilityFilterOptions(p),
       label: parsedLabel.label,
-      agentId: p.agentId,
-      spawnedBy: p.spawnedBy,
       limit: 2,
     },
   });
-  if (list.sessions.length === 0) {
+  if (matches.length === 0) {
     return noSessionFoundResult({
       p,
       message: `No session found with label: ${parsedLabel.label}`,
     });
   }
-  if (list.sessions.length > 1) {
-    const keys = list.sessions.map((session) => session.key).join(", ");
+  if (matches.length > 1) {
+    const keys = matches.map(([matchKey]) => matchKey).join(", ");
     return {
       ok: false,
       error: errorShape(
@@ -427,19 +429,18 @@ export async function resolveSessionKeyFromResolveParams(params: {
     };
   }
 
-  const labelKey = expectDefined(list.sessions[0], "sessions entry at 0").key;
-  const agentCheckLabel = validateSessionAgentExists(cfg, labelKey, store[labelKey]);
+  const [labelKey, labelEntry] = expectDefined(matches[0], "label session match at 0");
+  const agentCheckLabel = validateSessionAgentExists(cfg, labelKey, labelEntry);
   if (agentCheckLabel) {
     return agentCheckLabel;
   }
   return {
     ok: true,
     key: labelKey,
-    agentId: expectDefined(
-      expectDefined(list.sessions[0], "sessions entry at 0").agentId ??
-        parseAgentSessionKey(labelKey)?.agentId ??
-        p.agentId,
-      "label session agent",
+    agentId: normalizeAgentId(
+      parseAgentSessionKey(labelKey)?.agentId ??
+        p.agentId ??
+        resolveSessionStoreAgentId(cfg, labelKey),
     ),
   };
 }


### PR DESCRIPTION
## Why

Resolving a session by label built complete display rows, model metadata, child indexes and list defaults only to return a session key and agent ID. That was the last production consumer of a duplicate synchronous list implementation.

## Change

Select labels through the existing raw session selector and keep the canonical asynchronous list builder. Preserve the label path's lazy subagent snapshot, visibility predicate before collision detection, exact label matching, deterministic top-two ordering, missing/ambiguous results and deleted-agent checks. Forward the already-prepared configured-agent set to async rows.

Remove the synchronous row-building loop, unused lightweight option and unused transcript-usage cap. Existing tests now exercise the production async path; two obsolete JSON-file stat assertions now observe the real SQLite snapshot owner without mocking it.

Production +26/-80 (net -54); tests +181/-208 (net -27). No config, protocol, persistence schema or public SDK change. Release-note context: faster label resolution and less repeated session-list metadata work.

## Verification

- Actual-owner SQLite comparisons preserve complete responses for unique, ambiguous, missing and spawnedBy label selectors. With 100 rows, medians were 1.382→0.917 ms, 1.428→0.870 ms, 1.034→0.853 ms and 1.219→0.879 ms respectively (seven alternating rounds of ten calls).
- Six full async-list fixtures preserve exact JSON. Set reuse gave a small improvement at 24 agents/100 rows (7.781→7.466 ms); one-agent cases were within noise. These are local owner measurements, not model-turn latency claims.
- The initial draft omitted the shared subagent snapshot and slowed spawnedBy lookup. The corrected implementation retains its existing snapshot semantics; unrelated exact-key/ID/short-ID callers retain their existing freshness behavior.
- All 299 focused tests passed across ten files, including actual Gateway selector/privacy cases and real SQLite store/ACP ownership. The extended label no-hydration test fails on the original source (18 pass/1 fail), then passes with the repair.
- One migrated byte snapshot expected the removed synchronous builder's model metadata. Running the unchanged baseline async owner reproduced the same output as the candidate; only that row expectation changed, while default metadata remains intact.
- Independent source review covers sharing, ACP/deleted owners, store ownership, registry snapshot lifetime and all async test environment lifetimes. Structured Codex review and formatting/lint pass. Full build passed in 2m44.4s.
- 66 actual Gateway checks passed for unique/missing label resolution, duplicate-label rejection, filtered listing and pagination. Both temporary labels were restored through session-ID-fenced canonical mutations. Live ambiguity is intentionally not claimed: the one-agent fixture enforces label uniqueness; actual SQLite owner comparisons and existing cross-agent tests cover it.
