### PR TITLE
fix(cli): preserve Gateway run IDs in agent JSON failures

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2448,7 +2448,7 @@ src/cli/update-cli/update-command-plugins.ts	1
 src/cli/update-cli/update-command-post-update.ts	2
 src/cli/users-cli.ts	1
 src/commands/agent-exec.ts	6
-src/commands/agent-via-gateway.ts	11
+src/commands/agent-via-gateway.ts	7
 src/commands/agents.commands.bind.ts	5
 src/commands/agents.commands.identity.ts	1
 src/commands/agents.config.ts	1

--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -176,6 +176,20 @@ openclaw agent --agent ops --message "Run locally" --local
 - `SIGTERM`/`SIGINT` interrupt a waiting Gateway-backed request; if the Gateway already accepted the run, the CLI also sends `chat.abort` for that run id before exiting. `--local` runs receive the same signal but do not send `chat.abort`. A launcher child that terminates from the first forwarded `SIGINT` or `SIGTERM` exits with status 130 or 143, respectively. If the internal run-dedup key already has an active run for this session, the response reports `status: "in_flight"` and the non-JSON CLI prints a stderr diagnostic instead of an empty reply. For external cron/systemd wrappers, keep a hard-kill backstop such as `timeout -k 60 600 openclaw agent ...` so the supervisor can reap the process if shutdown cannot drain.
 - When this command triggers `models.json` regeneration, SecretRef-managed provider credentials are persisted as non-secret markers (for example env var names, `secretref-env:ENV_VAR_NAME`, or `secretref-managed`), never resolved secret plaintext. Marker writes come from the active source config snapshot, not from resolved runtime secret values.
 
+## JSON failures
+
+Failures keep the [CLI error envelope](/cli#json-failures): `ok: false` and
+`error.type: "cli_error"`. When the Gateway returned a run ID, the envelope also
+includes top-level `runId` and `origin: "gateway"`. This includes cached final
+errors without a fresh acceptance response, and a timeout or lost connection
+after acceptance.
+
+`origin` identifies the run's Gateway ownership; it does not prove the run failed
+or stopped. After transport loss, check the session transcript before retrying.
+Omitted provenance means the CLI observed no Gateway run identity, not that no
+run happened. Local errors and rejections without a Gateway run ID omit these
+fields. A locally generated idempotency key alone is not Gateway provenance.
+
 ## JSON delivery status
 
 With `--json --deliver`, the CLI JSON response includes top-level `deliveryStatus` so scripts can distinguish delivered, suppressed, partial, and failed sends:

--- a/packages/gateway-client/src/pending-request.ts
+++ b/packages/gateway-client/src/pending-request.ts
@@ -2,6 +2,7 @@ import type { ErrorShape, ResponseFrame } from "@openclaw/gateway-protocol";
 import {
   GatewayProtocolRequestError,
   GatewayProtocolRequestTimeoutError,
+  retainGatewayResponsePayload,
   type GatewayProtocolRequestOptions,
 } from "./protocol-request.js";
 import { resolveSafeTimeoutDelayMs } from "./timeouts.js";
@@ -156,7 +157,7 @@ export class GatewayPendingRequests {
       return;
     }
     const status = (frame.payload as { status?: unknown } | undefined)?.status;
-    if (pending.expectFinal && status === "accepted") {
+    if (frame.ok && pending.expectFinal && status === "accepted") {
       if (!pending.acceptedNotified) {
         pending.acceptedNotified = true;
         this.invoke("accepted", () => pending.onAccepted?.(frame.payload));
@@ -171,10 +172,11 @@ export class GatewayPendingRequests {
       return;
     }
     this.finishTiming(frame.id, pending, false, frame.error?.code);
-    pending.reject(
+    const error =
       this.opts.createRequestError?.(frame.error ?? {}) ??
-        new GatewayProtocolRequestError(frame.error ?? {}),
-    );
+      new GatewayProtocolRequestError(frame.error ?? {});
+    retainGatewayResponsePayload(error, frame.payload);
+    pending.reject(error);
   }
 
   flush(error: Error): void {

--- a/packages/gateway-client/src/protocol-client.request.test.ts
+++ b/packages/gateway-client/src/protocol-client.request.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewayProtocolClientOptions } from "./protocol-client-contract.js";
 import {
   GatewayProtocolClient,
   GatewayProtocolRequestError,
@@ -27,6 +28,7 @@ function createRequestHarness(options?: {
   onCallbackError?: (label: string, error: unknown) => void;
   send?: (frame: RequestFrame) => void;
   nowMs?: () => number;
+  createRequestError?: GatewayProtocolClientOptions<unknown>["createRequestError"];
 }) {
   const connections: RequestConnection[] = [];
   let nextRequestId = 0;
@@ -50,6 +52,7 @@ function createRequestHarness(options?: {
       };
     },
     createRequestId: options?.createRequestId ?? (() => `request-${++nextRequestId}`),
+    createRequestError: options?.createRequestError,
     buildConnectPlan: () => ({}),
     buildConnectParams: (plan) => plan,
     resolveClose: () => ({ retry: false, notify: false }),
@@ -89,6 +92,101 @@ afterEach(() => {
 });
 
 describe("GatewayProtocolClient requests", () => {
+  it.each([false, true])(
+    "retains correlated negative payloads with custom factory=%s",
+    async (custom) => {
+      const created: GatewayProtocolRequestError[] = [];
+      const { client, connections } = createRequestHarness({
+        createRequestError: custom
+          ? (fields) => {
+              const error = new GatewayProtocolRequestError(fields);
+              error.name = "CustomRequestError";
+              created.push(error);
+              return error;
+            }
+          : undefined,
+      });
+      try {
+        const connection = connections[0];
+        if (!connection) {
+          throw new Error("expected request connection");
+        }
+        const first = client.request("first", {}, { expectFinal: true });
+        const second = client.request("second", {}, { expectFinal: true });
+        const [firstFrame, secondFrame] = connection.frames;
+        if (!firstFrame || !secondFrame) {
+          throw new Error("expected concurrent request frames");
+        }
+        const fields = {
+          code: "UNAVAILABLE",
+          message: "failed",
+          details: { reason: "busy" },
+          retryable: true,
+          retryAfterMs: 250,
+        };
+        for (const [frame, payload] of [
+          [secondFrame, { runId: "second-run", privateResult: "not-for-logs" }],
+          [firstFrame, { runId: "first-run" }],
+        ] as const) {
+          connection.handlers.message(
+            JSON.stringify({ type: "res", id: frame.id, ok: false, payload, error: fields }),
+          );
+        }
+        const errors = await Promise.all([
+          first.catch((error: unknown) => error),
+          second.catch((error: unknown) => error),
+        ]);
+        for (const [index, error] of errors.entries()) {
+          expect(error).toBeInstanceOf(GatewayProtocolRequestError);
+          expect(error).toMatchObject({
+            ...fields,
+            gatewayCode: fields.code,
+            name: custom ? "CustomRequestError" : "GatewayProtocolRequestError",
+            responsePayload: { runId: index === 0 ? "first-run" : "second-run" },
+          });
+          expect(JSON.stringify(error)).not.toContain('"responsePayload":');
+          expect(JSON.stringify(error)).not.toContain("not-for-logs");
+        }
+        expect(created.map((error, index) => error === errors[1 - index])).toEqual(
+          custom ? [true, true] : [],
+        );
+        expect(client.hasPendingRequests).toBe(false);
+      } finally {
+        client.stop();
+      }
+    },
+  );
+
+  it("rejects a negative accepted-shaped response without notifying acceptance", async () => {
+    const { client, connections } = createRequestHarness();
+    const onAccepted = vi.fn();
+    const request = client.request("agent", {}, { expectFinal: true, onAccepted });
+    const outcome = request.catch((error: unknown) => error);
+    try {
+      const connection = connections[0];
+      if (!connection) {
+        throw new Error("expected request connection");
+      }
+      connection.handlers.message(
+        JSON.stringify({
+          type: "res",
+          id: latestFrame(connection).id,
+          ok: false,
+          payload: { status: "accepted" },
+          error: { code: "UNAVAILABLE", message: "rejected" },
+        }),
+      );
+      expect(onAccepted).not.toHaveBeenCalled();
+      expect(client.hasPendingRequests).toBe(false);
+      expect(await outcome).toMatchObject({
+        message: "rejected",
+        responsePayload: { status: "accepted" },
+      });
+    } finally {
+      client.stop();
+    }
+  });
+
   it.each([
     {
       label: "an explicit finite deadline",

--- a/packages/gateway-client/src/protocol-request.ts
+++ b/packages/gateway-client/src/protocol-request.ts
@@ -14,6 +14,7 @@ export class GatewayProtocolRequestError extends Error {
   readonly details?: unknown;
   readonly retryable: boolean;
   readonly retryAfterMs?: number;
+  declare readonly responsePayload?: unknown;
 
   constructor(error: Partial<ErrorShape>) {
     super(error.message ?? "request failed");
@@ -24,6 +25,18 @@ export class GatewayProtocolRequestError extends Error {
     this.retryable = error.retryable === true;
     this.retryAfterMs = error.retryAfterMs;
   }
+}
+
+/** Preserve response metadata after custom factories without adding it to error JSON. */
+export function retainGatewayResponsePayload(
+  error: GatewayProtocolRequestError,
+  payload: unknown,
+): void {
+  Object.defineProperty(error, "responsePayload", {
+    value: payload,
+    enumerable: false,
+    configurable: true,
+  });
 }
 
 /** A local transport deadline, distinct from a Gateway's authoritative rejection. */

--- a/src/cli/failure-output.ts
+++ b/src/cli/failure-output.ts
@@ -16,11 +16,22 @@ type CliFailureDebugOptions = Pick<FormatCliFailureOptions, "argv" | "env">;
 
 export type CliJsonFailure = {
   ok: false;
+  runId?: string;
+  origin?: "gateway";
   error: {
     type: "cli_error";
     message: string;
   };
 };
+
+const gatewayRunFailures = new WeakMap<Error, { runId: string; origin: "gateway" }>();
+
+/** Agent dispatch supplies observed Gateway IDs; error identity and human output stay intact. */
+export function recordCliGatewayRunFailure(error: unknown, runId: string | undefined): void {
+  if (error instanceof Error && runId) {
+    gatewayRunFailures.set(error, { runId, origin: "gateway" });
+  }
+}
 
 export class ExpectedCliError extends Error {
   readonly humanOutput: string;
@@ -92,6 +103,7 @@ export function formatCliJsonFailure(
     : formatCliOperatorError(error, options);
   return {
     ok: false,
+    ...(error instanceof Error ? gatewayRunFailures.get(error) : undefined),
     error: {
       type: "cli_error",
       message,

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -6,11 +6,14 @@ import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coerci
 // Agent via gateway tests cover gateway-backed agent command dispatch and session loading.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { GatewayPendingRequests } from "../../packages/gateway-client/src/pending-request.js";
+import { GatewayClientRequestError } from "../../packages/gateway-client/src/request-error.js";
 import {
   configureExecutionIdentityAdmissionSink,
   hasExecutionIdentityAdmissionSink,
 } from "../audit/execution-identity-admission.js";
 import { recordAgentRunTerminalOutcome } from "../channels/turn/agent-run-terminal-outcome.js";
+import { formatCliFailureLines, formatCliJsonFailure } from "../cli/failure-output.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { acquireGatewayLock, type GatewayLockOptions } from "../infra/gateway-lock.js";
@@ -2247,6 +2250,200 @@ describe("agentCliCommand", () => {
     });
   });
 
+  it.each([
+    {
+      label: "accepted negative final",
+      accepted: { status: "accepted", runId: "gateway-accepted" },
+      payload: { runId: "gateway-final", privateResult: "not-for-cli" },
+      runId: "gateway-final",
+    },
+    {
+      label: "cached final only",
+      accepted: undefined,
+      payload: { runId: "gateway-cached", privateResult: "not-for-cli" },
+      runId: "gateway-cached",
+    },
+    {
+      label: "accepted final without ID",
+      accepted: { status: "accepted", runId: "gateway-accepted" },
+      payload: { status: "error" },
+      runId: "gateway-accepted",
+    },
+    { label: "preadmission rejection", accepted: undefined, payload: undefined, runId: undefined },
+    { label: "blank final ID", accepted: undefined, payload: { runId: "   " }, runId: undefined },
+    {
+      label: "non-string final ID",
+      accepted: undefined,
+      payload: { runId: 123 },
+      runId: undefined,
+    },
+    {
+      label: "negative accepted shape",
+      accepted: undefined,
+      payload: { status: "accepted" },
+      runId: undefined,
+    },
+  ])(
+    "reports only observed Gateway run provenance for $label",
+    async ({ accepted, payload, runId }) => {
+      await withTempStore(async () => {
+        const error = new GatewayClientRequestError({
+          code: "UNAVAILABLE",
+          message: "turn failed",
+          details: { runId: "not-provenance", privateResult: "not-for-cli" },
+          retryable: true,
+          retryAfterMs: 250,
+        });
+        const signal = createSignalProcess();
+        const humanBefore = formatCliFailureLines({ title: "failed", error, env: {} });
+        callGateway.mockImplementation(
+          async (request: { onAccepted?: (payload: unknown) => void }) => {
+            const pending = new GatewayPendingRequests({
+              createRequestId: () => "request",
+              nowMs: Date.now,
+              createRequestError: () => error,
+            });
+            const result = pending.request(
+              { send: () => {} },
+              "agent",
+              {},
+              { expectFinal: true, onAccepted: request.onAccepted },
+            );
+            if (accepted) {
+              pending.handleResponse({ type: "res", id: "1:request", ok: true, payload: accepted });
+            }
+            pending.handleResponse({
+              type: "res",
+              id: "1:request",
+              ok: false,
+              payload,
+              error: { code: error.code, message: error.message },
+            });
+            // Bound the pre-fix negative-accepted regression without a wall-clock timeout.
+            pending.flush(error);
+            return await result;
+          },
+        );
+        await expect(
+          agentCliCommand(
+            {
+              message: "hi",
+              sessionKey: "agent:ops:run-proof",
+              runId: "local-idempotency",
+              json: true,
+            },
+            jsonRuntime,
+            { process: signal.processLike },
+          ),
+        ).rejects.toBe(error);
+        expect(formatCliJsonFailure(error, { env: {} })).toEqual({
+          ok: false,
+          error: { type: "cli_error", message: "turn failed" },
+          ...(runId ? { runId, origin: "gateway" } : {}),
+        });
+        expect(formatCliFailureLines({ title: "failed", error, env: {} })).toEqual(humanBefore);
+        expect(error).toMatchObject({
+          name: "GatewayClientRequestError",
+          code: "UNAVAILABLE",
+          retryable: true,
+          retryAfterMs: 250,
+          details: { runId: "not-provenance" },
+        });
+        expect(callGateway).toHaveBeenCalledOnce();
+        expect(agentCommand).not.toHaveBeenCalled();
+        expect(signal.listenerCount("SIGINT") + signal.listenerCount("SIGTERM")).toBe(0);
+      }, remoteGatewayConfig);
+    },
+  );
+
+  it.each([
+    {
+      label: "accepted timeout",
+      createError: createGatewayTimeoutError,
+      accepted: { status: "accepted", runId: "gateway-accepted" },
+      runId: "gateway-accepted",
+    },
+    {
+      label: "accepted close",
+      createError: createGatewayClosedError,
+      accepted: { status: "accepted", runId: "gateway-accepted" },
+      runId: "gateway-accepted",
+    },
+    {
+      label: "unacknowledged close",
+      createError: createGatewayClosedError,
+      accepted: undefined,
+      runId: undefined,
+    },
+    {
+      label: "accepted without ID",
+      createError: createGatewayTimeoutError,
+      accepted: { status: "accepted", sessionKey: "agent:ops:run-proof" },
+      runId: undefined,
+    },
+  ])(
+    "preserves error identity and uncertainty for $label",
+    async ({ createError, accepted, runId }) => {
+      await withTempStore(async () => {
+        const error = createError();
+        const signal = createSignalProcess();
+        const humanBefore = formatCliFailureLines({ title: "failed", error, env: {} });
+        callGateway.mockImplementation(
+          async (request: { onAccepted?: (payload: unknown) => void }) => {
+            if (accepted) {
+              request.onAccepted?.(accepted);
+            }
+            throw error;
+          },
+        );
+        await expect(
+          agentCliCommand(
+            {
+              message: "hi",
+              sessionKey: "agent:ops:run-proof",
+              runId: "local-idempotency",
+              json: true,
+            },
+            jsonRuntime,
+            { process: signal.processLike },
+          ),
+        ).rejects.toBe(error);
+        expect(formatCliJsonFailure(error, { env: {} })).toEqual({
+          ok: false,
+          error: { type: "cli_error", message: error.message },
+          ...(runId ? { runId, origin: "gateway" } : {}),
+        });
+        expect(formatCliFailureLines({ title: "failed", error, env: {} })).toEqual(humanBefore);
+        expect(callGateway).toHaveBeenCalledOnce();
+        expect(agentCommand).not.toHaveBeenCalled();
+        expect(mockMessages(jsonRuntime.error).join("\n")).toContain("may still be running");
+        expect(signal.listenerCount("SIGINT") + signal.listenerCount("SIGTERM")).toBe(0);
+      }, remoteGatewayConfig);
+    },
+  );
+
+  it("does not promote arbitrary thrown object fields into Gateway provenance", async () => {
+    await withTempStore(async () => {
+      const error = Object.assign(new Error("local failure"), {
+        runId: "forged",
+        origin: "gateway",
+        responsePayload: { runId: "forged" },
+        details: { runId: "forged" },
+      });
+      callGateway.mockRejectedValue(error);
+      await expect(
+        agentCliCommand(
+          { message: "hi", sessionKey: "agent:ops:run-proof", json: true },
+          jsonRuntime,
+        ),
+      ).rejects.toBe(error);
+      expect(formatCliJsonFailure(error)).toEqual({
+        ok: false,
+        error: { type: "cli_error", message: "local failure" },
+      });
+    }, remoteGatewayConfig);
+  });
+
   it("rejects gateway timeout errors unchanged with a local retry hint", async () => {
     await withTempStore(async () => {
       const error = createGatewayTimeoutError();
@@ -2351,12 +2548,17 @@ describe("agentCliCommand", () => {
     await withTempStore(async () => {
       const stop = vi.fn(async () => {});
       startOneShotDiagnosticsExporters.mockResolvedValue({ stop });
-      agentCommand.mockRejectedValueOnce(new Error("embedded run failed"));
+      const error = Object.assign(new Error("embedded run failed"), { runId: "local-run" });
+      agentCommand.mockRejectedValueOnce(error);
 
       await expect(
         agentCliCommand({ message: "hi", to: "+1555", local: true }, runtime),
       ).rejects.toThrow("embedded run failed");
 
+      expect(formatCliJsonFailure(error)).toEqual({
+        ok: false,
+        error: { type: "cli_error", message: "embedded run failed" },
+      });
       expect(stop).toHaveBeenCalledTimes(1);
     });
   });
@@ -2390,41 +2592,57 @@ describe("agentCliCommand", () => {
     });
   });
 
-  it("retries transient normal gateway closes before failing", async () => {
-    vi.useFakeTimers();
-    try {
-      await withTempStore(async () => {
-        const error = createGatewayNormalCloseError();
-        callGateway.mockRejectedValue(error);
+  it.each([false, true])(
+    "retains provenance across transient normal closes (accepted=%s)",
+    async (accepted) => {
+      vi.useFakeTimers();
+      try {
+        await withTempStore(async () => {
+          const error = createGatewayNormalCloseError();
+          callGateway.mockImplementation(
+            async (request: { onAccepted?: (payload: unknown) => void }) => {
+              if (accepted && callGateway.mock.calls.length === 1) {
+                request.onAccepted?.({ status: "accepted", runId: "gateway-before-retry" });
+                throw createGatewayNormalCloseError();
+              }
+              throw error;
+            },
+          );
 
-        const command = agentCliCommand({ message: "hi", to: "+1555" }, runtime);
-        const rejection = expect(command).rejects.toBe(error);
-        await vi.advanceTimersByTimeAsync(33_000);
-        await rejection;
+          const command = agentCliCommand({ message: "hi", to: "+1555" }, runtime);
+          const rejection = expect(command).rejects.toBe(error);
+          await vi.advanceTimersByTimeAsync(33_000);
+          await rejection;
 
-        expect(callGateway).toHaveBeenCalledTimes(6);
-        const idempotencyKeys = callGateway.mock.calls.map(
-          ([call]) => (call as { params?: { idempotencyKey?: unknown } }).params?.idempotencyKey,
-        );
-        expect(new Set(idempotencyKeys).size).toBe(1);
-        expect(agentCommand).not.toHaveBeenCalled();
-        expect(
-          mockMessages(runtime.error).filter((message) =>
-            message.includes("Gateway agent connection closed during handshake"),
-          ),
-        ).toHaveLength(5);
-        expect(
-          mockMessages(runtime.error).some(
-            (message) =>
-              message.includes("Gateway agent call connection closed") &&
-              message.includes("--local"),
-          ),
-        ).toBe(true);
-      });
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+          expect(callGateway).toHaveBeenCalledTimes(6);
+          const idempotencyKeys = callGateway.mock.calls.map(
+            ([call]) => (call as { params?: { idempotencyKey?: unknown } }).params?.idempotencyKey,
+          );
+          expect(new Set(idempotencyKeys).size).toBe(1);
+          expect(formatCliJsonFailure(error, { env: {} })).toEqual({
+            ok: false,
+            error: { type: "cli_error", message: error.message },
+            ...(accepted ? { runId: "gateway-before-retry", origin: "gateway" } : {}),
+          });
+          expect(agentCommand).not.toHaveBeenCalled();
+          expect(
+            mockMessages(runtime.error).filter((message) =>
+              message.includes("Gateway agent connection closed during handshake"),
+            ),
+          ).toHaveLength(5);
+          expect(
+            mockMessages(runtime.error).some(
+              (message) =>
+                message.includes("Gateway agent call connection closed") &&
+                message.includes("--local"),
+            ),
+          ).toBe(true);
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("rejects transport-closed errors unchanged with a local retry hint", async () => {
     await withTempStore(async () => {

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -5,7 +5,9 @@ import {
   parseStrictNonNegativeInteger,
   resolveTimerTimeoutMs,
 } from "@openclaw/normalization-core/number-coercion";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { GatewayProtocolRequestError } from "../../packages/gateway-client/src/protocol-request.js";
 import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
@@ -25,6 +27,7 @@ import { isExecutionIdentityCollectionEnabled } from "../audit/audit-config.js";
 import { readAgentRunTerminalOutcome } from "../channels/turn/agent-run-terminal-outcome.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { CliDeps } from "../cli/deps.types.js";
+import { recordCliGatewayRunFailure } from "../cli/failure-output.js";
 import { withProgress } from "../cli/progress.js";
 import {
   readGatewayDispatchConfig,
@@ -701,25 +704,15 @@ function isAbortError(err: unknown): boolean {
   return err instanceof Error && err.name === "AbortError";
 }
 
-function readAcceptedRunContext(payload: unknown): {
-  runId?: string;
-  sessionKey?: string;
-  agentId?: string;
-} {
-  if (!payload || typeof payload !== "object") {
-    return {};
-  }
-  const runId = (payload as { runId?: unknown }).runId;
-  const sessionKey = (payload as { sessionKey?: unknown }).sessionKey;
-  const agentId = (payload as { agentId?: unknown }).agentId;
-  const status = (payload as { status?: unknown }).status;
-  if (status !== "accepted") {
-    return {};
+function readAcceptedRunContext(payload: unknown) {
+  const accepted = asOptionalRecord(payload);
+  if (accepted?.status !== "accepted") {
+    return undefined;
   }
   return {
-    runId: typeof runId === "string" && runId.trim() ? runId.trim() : undefined,
-    sessionKey: typeof sessionKey === "string" && sessionKey.trim() ? sessionKey.trim() : undefined,
-    agentId: typeof agentId === "string" && agentId.trim() ? agentId.trim() : undefined,
+    runId: normalizeOptionalString(accepted.runId),
+    sessionKey: normalizeOptionalString(accepted.sessionKey),
+    agentId: normalizeOptionalString(accepted.agentId),
   };
 }
 
@@ -963,6 +956,7 @@ async function agentViaGatewayCommand(
   opts: AgentDispatchOpts,
   runtime: RuntimeEnv,
   signalBridge: ReturnType<typeof createAgentCliSignalBridge>,
+  runContext: { accepted?: ReturnType<typeof readAcceptedRunContext> },
 ) {
   const body = opts.message;
   const explicitSessionKey = opts.sessionKey?.trim();
@@ -1071,10 +1065,6 @@ async function agentViaGatewayCommand(
         ...(remoteGateway ? {} : { scopes: [ADMIN_SCOPE] }),
       };
 
-  let acceptedRunId: string | undefined = idempotencyKey;
-  let acceptedSessionKey: string | undefined = abortSessionKey;
-  let acceptedAgentId: string | undefined;
-  let acceptedGatewayRun = false;
   let activeConnectionAbortAttempted = false;
   let activeConnectionAbortSucceeded = false;
   let response: GatewayAgentResponse | undefined;
@@ -1113,18 +1103,14 @@ async function agentViaGatewayCommand(
           config: activeCfg,
           signal: signalBridge.signal,
           onAccepted: (payload) => {
-            acceptedGatewayRun = true;
-            const accepted = readAcceptedRunContext(payload);
-            acceptedRunId = accepted.runId ?? acceptedRunId;
-            acceptedSessionKey = accepted.sessionKey ?? acceptedSessionKey;
-            acceptedAgentId = accepted.agentId;
+            runContext.accepted = readAcceptedRunContext(payload);
           },
           onSignalAbort: async (request) => {
             activeConnectionAbortAttempted = true;
             activeConnectionAbortSucceeded = await abortAcceptedGatewayAgentRunOnActiveConnection({
-              runId: acceptedRunId,
-              sessionKey: acceptedSessionKey,
-              agentId: acceptedAgentId,
+              runId: runContext.accepted?.runId ?? idempotencyKey,
+              sessionKey: runContext.accepted?.sessionKey ?? abortSessionKey,
+              agentId: runContext.accepted?.agentId,
               signal: signalBridge.getReceivedSignal(),
               runtime,
               request,
@@ -1142,7 +1128,7 @@ async function agentViaGatewayCommand(
       break;
     } catch (err) {
       if (
-        !acceptedGatewayRun &&
+        !runContext.accepted &&
         shouldRetryGatewayDispatchWithShellEnvFallback(err) &&
         consumeShellEnvFallbackRetry()
       ) {
@@ -1152,18 +1138,27 @@ async function agentViaGatewayCommand(
       if (
         isAbortError(err) &&
         !activeConnectionAbortSucceeded &&
-        (acceptedGatewayRun || activeConnectionAbortAttempted)
+        (runContext.accepted || activeConnectionAbortAttempted)
       ) {
         await abortAcceptedGatewayAgentRunWithGatewayCall({
-          runId: acceptedRunId,
-          sessionKey: acceptedSessionKey,
-          agentId: acceptedAgentId,
+          runId: runContext.accepted?.runId ?? idempotencyKey,
+          sessionKey: runContext.accepted?.sessionKey ?? abortSessionKey,
+          agentId: runContext.accepted?.agentId,
           signal: signalBridge.getReceivedSignal(),
           runtime,
           gatewayIdentity,
           config: cfg,
         });
       }
+      const payload =
+        err instanceof GatewayProtocolRequestError
+          ? asOptionalRecord(err.responsePayload)
+          : undefined;
+      // Only Gateway responses establish provenance; the idempotency fallback is cancellation-only.
+      recordCliGatewayRunFailure(
+        err,
+        normalizeOptionalString(payload?.runId) ?? runContext.accepted?.runId,
+      );
       throw err;
     }
   }
@@ -1207,12 +1202,14 @@ async function agentViaGatewayCommandWithTransientRetries(
   runtime: RuntimeEnv,
   signalBridge: ReturnType<typeof createAgentCliSignalBridge>,
 ) {
+  // Retries reuse one idempotency key, so retain acceptance across connection attempts.
+  const runContext: { accepted?: ReturnType<typeof readAcceptedRunContext> } = {};
   for (const [attempt, retryDelayMs] of [
     ...GATEWAY_TRANSIENT_CONNECT_RETRY_DELAYS_MS,
     0,
   ].entries()) {
     try {
-      return await agentViaGatewayCommand(opts, runtime, signalBridge);
+      return await agentViaGatewayCommand(opts, runtime, signalBridge, runContext);
     } catch (err) {
       if (isAbortError(err)) {
         throw err;

--- a/src/gateway/server-in-process-dispatch.abort.test.ts
+++ b/src/gateway/server-in-process-dispatch.abort.test.ts
@@ -63,6 +63,35 @@ function registerPairedNode(): { registry: NodeRegistry; frames: string[] } {
 }
 
 describe("in-process paired-node invocation cancellation", () => {
+  it.each([true, false])(
+    "requires ok=true before waiting beyond an accepted-shaped response (ok=%s)",
+    async (ok) => {
+      const onAccepted = vi.fn();
+      const error = { code: "UNAVAILABLE", message: "rejected" };
+      const accepted = { status: "accepted", runId: "run-1" };
+      const final = { status: "ok", runId: "run-1" };
+      handleGatewayRequest.mockImplementation(async (options: GatewayRequestOptions) => {
+        options.respond(ok, accepted, ok ? undefined : error);
+        options.respond(true, final);
+      });
+      await expect(
+        dispatchGatewayRequestInProcessRaw(
+          "agent",
+          {},
+          {
+            client: null,
+            context: {} as GatewayRequestContext,
+            expectFinal: true,
+            onAccepted,
+          },
+        ),
+      ).resolves.toMatchObject(
+        ok ? { ok: true, payload: final } : { ok: false, payload: accepted, error },
+      );
+      expect(onAccepted.mock.calls).toEqual(ok ? [[accepted]] : []);
+    },
+  );
+
   it("cancels a real first-party paired-node invocation and removes its pending work", async () => {
     const { registry, frames } = registerPairedNode();
     const controller = new AbortController();

--- a/src/gateway/server-in-process-dispatch.error-cause.test.ts
+++ b/src/gateway/server-in-process-dispatch.error-cause.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { GatewayClientRequestError } from "../../packages/gateway-client/src/request-error.js";
 import { ErrorCodes, errorShape } from "../../packages/gateway-protocol/src/index.js";
 import { FailoverError } from "../agents/failover-error.js";
 import { unwrapGatewayMethodDispatchResponse } from "./server-in-process-dispatch.js";
@@ -11,17 +12,25 @@ describe("in-process gateway error causes", () => {
         { provider: "openai", model: "gpt-5.6", reason: "overloaded", error: "overloaded" },
       ],
     });
-    const error = errorShape(ErrorCodes.UNAVAILABLE, original.message);
+    const error = errorShape(ErrorCodes.UNAVAILABLE, original.message, {
+      details: { reason: "busy" },
+      retryable: true,
+      retryAfterMs: 250,
+    });
+    const payload = { runId: "in-process-run", privateResult: "not-for-logs" };
     Object.defineProperty(error, "cause", { value: original });
 
     let thrown: unknown;
     try {
-      unwrapGatewayMethodDispatchResponse("agent", { ok: false, error });
+      unwrapGatewayMethodDispatchResponse("agent", { ok: false, payload, error });
     } catch (caught) {
       thrown = caught;
     }
 
-    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown).toBeInstanceOf(GatewayClientRequestError);
     expect((thrown as Error).cause).toBe(original);
+    expect(thrown).toMatchObject({ ...error, gatewayCode: error.code, responsePayload: payload });
+    expect(JSON.stringify(thrown)).not.toContain('"cause":');
+    expect(JSON.stringify(thrown)).not.toContain("not-for-logs");
   });
 });

--- a/src/gateway/server-in-process-dispatch.ts
+++ b/src/gateway/server-in-process-dispatch.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { retainGatewayResponsePayload } from "../../packages/gateway-client/src/protocol-request.js";
 import { GatewayClientRequestError } from "../../packages/gateway-client/src/request-error.js";
 import type { ErrorShape } from "../../packages/gateway-protocol/src/schema/frames.js";
 import { createAbortError } from "../infra/abort-signal.js";
@@ -35,6 +36,7 @@ export function unwrapGatewayMethodDispatchResponse(
       retryable: response.error?.retryable,
       retryAfterMs: response.error?.retryAfterMs,
     });
+    retainGatewayResponsePayload(requestError, response.payload);
     const cause = (response.error as (ErrorShape & { cause?: unknown }) | undefined)?.cause;
     if (cause !== undefined) {
       Object.defineProperty(requestError, "cause", { value: cause });
@@ -207,7 +209,7 @@ export async function dispatchGatewayRequestInProcessRaw(
     options.onSignalAbort,
   );
   const firstPayload = firstResponse.payload as { status?: unknown } | undefined;
-  if (options.expectFinal !== true || firstPayload?.status !== "accepted") {
+  if (!firstResponse.ok || options.expectFinal !== true || firstPayload?.status !== "accepted") {
     return firstResponse;
   }
   options.onAccepted?.(firstResponse.payload);

--- a/ui/src/api/gateway.node.test.ts
+++ b/ui/src/api/gateway.node.test.ts
@@ -1035,7 +1035,7 @@ describe("GatewayBrowserClient", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
-  it("reports failed request timing without including request params", async () => {
+  it("retains negative response payloads without leaking them into timing or error JSON", async () => {
     const onRequestTiming = vi.fn();
     const client = new GatewayBrowserClient({
       url: "ws://127.0.0.1:18789",
@@ -1064,17 +1064,36 @@ describe("GatewayBrowserClient", () => {
       type: "res",
       id: frame.id,
       ok: false,
-      error: { code: "CONFIG_ERROR", message: "config failed" },
+      payload: { runId: "browser-run", privateResult: "not-for-logs" },
+      error: {
+        code: "CONFIG_ERROR",
+        message: "config failed",
+        details: { reason: "busy" },
+        retryable: true,
+        retryAfterMs: 250,
+      },
     });
 
     try {
       await request;
       throw new Error("expected config.get request to reject");
     } catch (error) {
-      expect((error as { gatewayCode?: string }).gatewayCode).toBe("CONFIG_ERROR");
+      expect(error).toBeInstanceOf(GatewayRequestError);
+      expect(error).toMatchObject({
+        name: "GatewayRequestError",
+        code: "CONFIG_ERROR",
+        gatewayCode: "CONFIG_ERROR",
+        message: "config failed",
+        details: { reason: "busy" },
+        retryable: true,
+        retryAfterMs: 250,
+        responsePayload: { runId: "browser-run", privateResult: "not-for-logs" },
+      });
+      expect(JSON.stringify(error)).not.toContain("not-for-logs");
     }
     expect(onRequestTiming).toHaveBeenCalledTimes(1);
     expect(requireFirstMockArg(onRequestTiming, "request timing")).not.toHaveProperty("params");
+    expect(JSON.stringify(onRequestTiming.mock.calls)).not.toContain("not-for-logs");
     expectLatestRequestTiming(onRequestTiming, {
       id: frame.id,
       method: "config.get",


### PR DESCRIPTION
Closes #133004

<details>
<summary>Additional instructions</summary>

This same-repository branch is editable by maintainers. AI-assisted implementation; the source, compatibility boundaries, and proof were reviewed.

</details>

## What Problem This Solves

Fixes an issue where users running `openclaw agent --json` could not correlate a failed accepted Gateway run because the failure output discarded the Gateway's run ID. The same `cli_error` shape also made an accepted-run failure look like a local pre-admission failure.

## Why This Change Was Made

Retain negative-response payload metadata non-enumerably on the existing typed Gateway error, at both the shared client and in-process dispatch boundary. The agent CLI projects only a Gateway-returned run ID into private error-bound reporting context; the root formatter adds `runId` and `origin: "gateway"` without replacing the error or leaking the raw payload.

One observed acceptance context replaces the parallel acceptance variables seeded from a local idempotency key. The local key remains an existing cancellation-routing fallback only; it is never reported as Gateway provenance. Both dispatchers require `ok: true` before treating an accepted-shaped payload as acceptance. Existing transient retry policy is unchanged, and observed identity survives those retries.

**Best-fix verdict: best owner-boundary repair.** A formatter-only fix cannot recover discarded final payloads; a callback-only fix misses cached final responses; error wrapping would change existing classification and retry behavior. Retaining generic response metadata at the conversion owners and interpreting run identity at the agent command preserves those boundaries. No wire-schema, config, storage, dependency, or provider-runtime change.

## User Impact

Failure JSON keeps `ok: false`, `error.type: "cli_error"`, and the existing sanitized message, with additive top-level provenance when a Gateway run ID was observed. This covers accepted negative finals, cached final-only errors, and connection loss or timeout after acceptance. Original error identity/class/codes/details/retry fields/cause, human output, successful JSON, exit codes, and signal cleanup stay compatible.

`origin: "gateway"` describes run ownership, not proof of a terminal outcome. Missing provenance means no Gateway run identity was observed, not proof that nothing ran. Scripts should still inspect the session before retrying an uncertain transport failure. The contract is documented in the [agent CLI reference](https://docs.openclaw.ai/cli/agent#json-failures).

Release-note context: Gateway-backed agent CLI JSON failures now preserve observed run IDs without inventing acceptance from local request keys or changing existing error fields.

## Evidence

**Observed before/after, real built CLI:** thirteen isolated fixture cases on each of Node 24.20.0 and Node 26.8.1 (macOS 27.0). Each matrix includes four concurrent accepted-negative clients, cached final-only rejection, accepted rejection without a final ID, accepted connection loss, a real 31-second accepted timeout, local and pre-admission rejection, acknowledgement without an ID, success, and human-output controls. Gateway fixture IDs deliberately differ from client idempotency keys. Fresh temporary homes/config/state, synthetic credentials, and a session-owned loopback mock WebSocket Gateway; no operator Gateway or live model/provider contact.

Before:

```json
{"ok":false,"error":{"type":"cli_error","message":"Synthetic accepted-run failure."}}
```

After:

```json
{"ok":false,"runId":"gateway-accepted-final-0","origin":"gateway","error":{"type":"cli_error","message":"Synthetic accepted-run failure."}}
```

All expected IDs survived after the repair, local/no-ID controls omitted provenance, hidden payload/details markers never reached root CLI JSON, and success/human/exit controls stayed unchanged. Every fixture process/socket/temp state was cleaned up. These are real CLI and mock-wire tests, not live-provider or Linux/runuser parity claims.

**Regression proof:** twelve intended failures recorded before production edits. Focused owner/sibling coverage passed 232 tests across six files with one existing macOS-inapplicable procfs skip. The full shared Gateway-client suite passed 306 tests across 23 files. Accounting for their 18-test overlap: 520 distinct passing tests across 28 files.

Commands used for final source proof:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs packages/gateway-client
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs packages/gateway-client/src/protocol-client.request.test.ts src/commands/agent-via-gateway.test.ts src/gateway/server-in-process-dispatch.abort.test.ts src/gateway/server-in-process-dispatch.error-cause.test.ts src/cli/failure-output.test.ts
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs packages/gateway-client/src/protocol-client.request.test.ts src/commands/agent-via-gateway.test.ts src/gateway/server-in-process-dispatch.abort.test.ts src/gateway/server-in-process-dispatch.error-cause.test.ts ui/src/api/gateway.node.test.ts
```

The focused files ran in serialized owner lanes. `pnpm build`, changed-scope checks over the twelve changed paths, targeted lint, formatting, and `git diff --check` passed. Fresh independent Codex autoreview before commit returned scoped-clean at its configured P0-only threshold. Exact publication head and hosted CI evidence will be recorded before merge.

Production LOC: +66/-40 (net +26). Tests: +413/-40 (net +373). Docs: +14. One assertion-baseline entry shrinks from 11 to 7 because the acceptance parser removes four assertions. The production growth implements the generic private metadata contract and JSON provenance projection, partly absorbed by simplifying acceptance state; no baseline or guard was expanded.

Historical scope: payload loss is also present in the inspected stable `v2026.7.1-2` client and cached-response path. The exact original introduction is not attributed here. This PR only repairs lost run provenance; it does not claim to resolve any underlying agent-runtime/process-inspection incident.
