### PR TITLE
perf(agents): normalize tool inventories once

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1960,7 +1960,7 @@ src/agents/run-termination.ts	3
 src/agents/run-timeout-attribution.ts	1
 src/agents/run-wait.ts	8
 src/agents/runtime-plan/build.ts	4
-src/agents/runtime-plan/tools.ts	5
+src/agents/runtime-plan/tools.ts	4
 src/agents/runtime/proxy.ts	7
 src/agents/sandbox-paths.ts	1
 src/agents/sandbox-tool-policy.ts	1

--- a/src/agents/runtime-plan/tools.ts
+++ b/src/agents/runtime-plan/tools.ts
@@ -105,17 +105,19 @@ function preserveRuntimeToolMetadata<TSchemaType extends TSchema = TSchema, TRes
 export function normalizeAgentRuntimeTools<
   TSchemaType extends TSchema = TSchema,
   TResult = unknown,
->(params: AgentRuntimeToolPolicyParams<TSchemaType, TResult>): AgentTool<TSchemaType, TResult>[] {
+>(
+  params: Omit<AgentRuntimeToolPolicyParams<TSchemaType, TResult>, "tools"> & {
+    tools: readonly AgentTool<TSchemaType, TResult>[];
+  },
+): AgentTool<TSchemaType, TResult>[] {
   const planContext = runtimePlanToolContext(params);
   const normalizableToolProjection = filterProviderNormalizableTools(params.tools);
   params.onPreNormalizationSchemaDiagnostics?.(
     normalizableToolProjection.diagnostics,
     params.tools,
   );
-  const normalizableTools = [...normalizableToolProjection.tools] as AgentTool<
-    TSchemaType,
-    TResult
-  >[];
+  // Projection owns this fresh array, so normalizers can mutate it without changing raw input.
+  const normalizableTools = normalizableToolProjection.tools;
   const planNormalized = params.runtimePlan?.tools.normalize(normalizableTools, planContext);
   // Empty fallback input cannot gain provider-specific schema changes. Avoid loading a provider
   // runtime just to return the same empty list; runtime plans still receive their normal callback.

--- a/src/agents/tool-schema-projection.ts
+++ b/src/agents/tool-schema-projection.ts
@@ -21,7 +21,7 @@ export type RuntimeToolSchemaDiagnostic = {
 
 /** Runtime tool list split into compatible tools and schema diagnostics. */
 type RuntimeToolSchemaInspection<TTool extends Pick<AnyAgentTool, "name" | "parameters">> = {
-  readonly tools: readonly TTool[];
+  readonly tools: TTool[];
   readonly diagnostics: readonly RuntimeToolSchemaDiagnostic[];
 };
 

--- a/src/agents/tools-effective-inventory-build.ts
+++ b/src/agents/tools-effective-inventory-build.ts
@@ -11,7 +11,6 @@ import { buildPluginToolMetadataKey, getPluginToolMeta } from "../plugins/tools.
 import { getChannelAgentToolMeta } from "./channel-tools.js";
 import { normalizeAgentRuntimeTools } from "./runtime-plan/tools.js";
 import {
-  filterProviderNormalizableTools,
   filterRuntimeCompatibleTools,
   type RuntimeToolSchemaDiagnostic,
 } from "./tool-schema-projection.js";
@@ -161,8 +160,7 @@ function buildEffectiveToolInventoryEntries(
               summarizeEffectiveToolDescription(tool),
             rawDescription:
               normalizeOptionalString(metadata?.description) ??
-              resolveEffectiveToolRawDescription(tool) ??
-              summarizeEffectiveToolDescription(tool),
+              resolveEffectiveToolRawDescription(tool),
             ...(metadata?.risk ? { risk: metadata.risk } : {}),
             ...(metadata?.tags ? { tags: metadata.tags } : {}),
           },
@@ -188,14 +186,9 @@ export function buildRuntimeCompatibleToolInventory(params: {
   notices: EffectiveToolInventoryNotice[];
 } {
   const rawToolsByName = buildReadableToolsByName(params.tools);
-  const preNormalizationProjection = filterProviderNormalizableTools(params.tools);
-  const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [
-    ...preNormalizationProjection.diagnostics,
-  ];
+  const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [];
   const normalizedTools = normalizeAgentRuntimeTools({
-    // Schema normalization can replace tool definitions, so hand the runtime
-    // policy a mutable copy while keeping this inventory API readonly.
-    tools: [...preNormalizationProjection.tools],
+    tools: params.tools,
     provider: params.modelProvider ?? "",
     config: params.cfg,
     workspaceDir: params.workspaceDir,

--- a/src/agents/tools-effective-inventory.test.ts
+++ b/src/agents/tools-effective-inventory.test.ts
@@ -66,6 +66,7 @@ vi.mock("./agent-tools.js", () => ({
 }));
 
 vi.mock("../plugins/tools.js", () => ({
+  copyPluginToolMeta: vi.fn(),
   getPluginToolMeta: (tool: { name: string }) => effectiveInventoryState.pluginMeta[tool.name],
   buildPluginToolMetadataKey: (pluginId: string, toolName: string) =>
     JSON.stringify([pluginId, toolName]),
@@ -80,9 +81,10 @@ vi.mock("./agent-tools.policy.js", () => ({
   resolveEffectiveToolPolicy: () => effectiveInventoryState.effectivePolicy,
 }));
 
-vi.mock("./runtime-plan/tools.js", () => ({
-  normalizeAgentRuntimeTools: (options: { tools: AnyAgentTool[] }) =>
+vi.mock("./embedded-agent-runner/tool-schema-runtime.js", () => ({
+  normalizeProviderToolSchemas: (options: { tools: AnyAgentTool[] }) =>
     effectiveInventoryState.normalizeToolsMock(options),
+  logProviderToolSchemaDiagnostics: vi.fn(),
 }));
 
 vi.mock("./embedded-agent-runner/model.static-catalog.js", () => ({

--- a/src/agents/tools-effective-mcp-inventory.ts
+++ b/src/agents/tools-effective-mcp-inventory.ts
@@ -8,7 +8,6 @@ import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.typ
 import { getPluginToolMeta } from "../plugins/tools.js";
 import { normalizeAgentRuntimeTools } from "./runtime-plan/tools.js";
 import {
-  filterProviderNormalizableTools,
   filterRuntimeCompatibleTools,
   type RuntimeToolSchemaDiagnostic,
 } from "./tool-schema-projection.js";
@@ -80,12 +79,9 @@ export function buildRuntimeCompatibleMcpToolInventory(params: {
   entries: EffectiveToolInventoryEntry[];
   notices: EffectiveToolInventoryNotice[];
 } {
-  const preNormalizationProjection = filterProviderNormalizableTools(params.tools);
-  const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [
-    ...preNormalizationProjection.diagnostics,
-  ];
+  const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [];
   const normalizedTools = normalizeAgentRuntimeTools({
-    tools: [...preNormalizationProjection.tools],
+    tools: params.tools,
     provider: params.modelProvider ?? "",
     config: params.cfg,
     workspaceDir: params.workspaceDir,


### PR DESCRIPTION
## Why

Both effective-tool inventory builders filtered and serialized every schema, copied the array, then called the canonical runtime normalizer that repeated the same filter. Large tool catalogs paid for three full schema serializations instead of the required pre-provider and post-provider checks.

## Change

Let the normalizer own the pre-provider projection. Accept readonly input and give provider/runtime hooks the projection's already-fresh mutable array. Remove redundant passes in both general and MCP inventories and an unreachable description fallback. Keep the post-provider quarantine, raw diagnostics, metadata preservation and MCP no-cold-load behavior.

Production +13/-22 (net -9), tests +4/-2 (net +2). No config, persistence or protocol change. The mutable-array guarantee remains shallow: tool objects retain identity. Stateful getters/toJSON execute fewer times; invocation-count-dependent results are not a promised contract.

## Verification

- 1,107 exact owner comparisons cover full general/MCP inventories, runtime-plan results and real OpenAI/Gemini/DeepSeek/llama.cpp normalization hooks. Include malformed/cyclic/raw-JSON numeric-overflow schemas, frozen/sparse/proxy arrays, provider clones/reorders/drops/errors, metadata and quarantine. Nonthrowing fixtures explicitly require successful execution.
- Valid schemas serialize twice instead of three times. Two quiet fresh-process benchmark rounds at 100 tools × 40 properties measured general inventory 14.69→10.34 ms and 15.15→10.24 ms; MCP 14.83→10.10 ms and 15.07→10.26 ms. At 400 × 80, general inventory was 115.72→80.18 ms and 118.79→81.57 ms. Tiny/empty paths have no meaningful speedup; no memory or whole-turn claim.
- Independent review covers both builders, canonical projection, provider/runtime contracts, metadata ownership and native Codex dynamic-tool conversion. The acting maintainer directly inspected native dynamic_tools.rs, dynamic_tool.rs, spec_plan.rs:1364–1396, handlers/dynamic.rs:39–84 and json_schema.rs:189–216; its separate registration/sanitization contract is unchanged.
- 92 focused runtime/inventory/provider schema tests passed across eight files; formatting, targeted lint and structured Codex review are clean.
- Full build passed in 2m34.3s. 32 actual Gateway checks pass; both fixture sessions preserve complete inventory payloads across three calls and against baseline (SHA-256 `b7e5d82d3cb11bbb907ca9c637769c941749820ff49793756f2659b24b1545f0`). A real OpenAI turn completed one web-fetch call with no failures.
- The live fixture has no MCP catalog; real-owner MCP differential/provider-hook cases and focused tests cover that builder. Warm inventory RPCs prove wire behavior, not refresh CPU savings.

CI follow-up: the first run correctly required reducing the assertion-safety allowance for `src/agents/runtime-plan/tools.ts` from five to four after deleting the redundant cast. The baseline-only follow-up passes the ratchet and structured Codex review; runtime source and the test/build/live evidence above are unchanged. Fresh exact-head CI is required.
