### PR TITLE
fix(release): reserve manual gateway ports through setup

### DIFF
--- a/scripts/lib/cross-os-release-checks/lanes.ts
+++ b/scripts/lib/cross-os-release-checks/lanes.ts
@@ -122,6 +122,9 @@ export async function runFreshLane(params: LaneBaseParams & { build: CandidateBu
 
     await installLaneCompanions({ ...params, lane, env });
 
+    // Own the configured port through setup; release only when the gateway can claim it.
+    const gatewayPortReservation = await reserveGatewayPortForLane(lane);
+    cleanup.push(() => gatewayPortReservation.release());
     await runTimedLanePhase(lane, "onboard", async () => {
       await runOnboard({
         lane,
@@ -140,13 +143,14 @@ export async function runFreshLane(params: LaneBaseParams & { build: CandidateBu
       });
     });
 
-    const gateway = await runTimedLanePhase(lane, "start-gateway", async () =>
-      startGateway({
+    const gateway = await runTimedLanePhase(lane, "start-gateway", async () => {
+      await gatewayPortReservation.release();
+      return startGateway({
         lane,
         env,
         logPath: join(params.logsDir, "fresh-gateway.log"),
-      }),
-    );
+      });
+    });
     gatewayHolder.current = gateway;
     cleanup.push(() => stopGateway(gatewayHolder.current));
 
@@ -348,6 +352,9 @@ export async function runUpgradeLane(
 
     await installLaneCompanions({ ...params, lane, env });
 
+    // Own the configured port through setup; release only when the gateway can claim it.
+    const gatewayPortReservation = await reserveGatewayPortForLane(lane);
+    cleanup.push(() => gatewayPortReservation.release());
     await runTimedLanePhase(lane, "onboard", async () => {
       await runOnboard({
         lane,
@@ -366,13 +373,14 @@ export async function runUpgradeLane(
       });
     });
 
-    const gateway = await runTimedLanePhase(lane, "start-gateway", async () =>
-      startGateway({
+    const gateway = await runTimedLanePhase(lane, "start-gateway", async () => {
+      await gatewayPortReservation.release();
+      return startGateway({
         lane,
         env,
         logPath: join(params.logsDir, "upgrade-gateway.log"),
-      }),
-    );
+      });
+    });
     gatewayHolder.current = gateway;
     cleanup.push(() => stopGateway(gatewayHolder.current));
 
@@ -791,6 +799,8 @@ export async function runDevUpdateSuite(
 
     await installLaneCompanions({ ...params, lane, env, cliPath: verifiedShell.cliPath });
 
+    const gatewayPortReservation = await reserveGatewayPortForLane(lane);
+    cleanup.push(() => gatewayPortReservation.release());
     logLanePhase(lane, "onboard");
     await runOnboardWithInstalledCli({
       lane,
@@ -799,6 +809,7 @@ export async function runDevUpdateSuite(
       providerConfig: params.providerConfig,
       installDaemon: false,
       logPath: join(params.logsDir, "dev-update-onboard.log"),
+      allocateGatewayPort: false,
     });
 
     logLanePhase(lane, "models-set");
@@ -810,6 +821,7 @@ export async function runDevUpdateSuite(
       logPath: join(params.logsDir, "dev-update-models-set.log"),
     });
 
+    await gatewayPortReservation.release();
     logLanePhase(lane, "gateway-start");
     const gateway = await startManualGatewayFromInstalledCli({
       lane,

--- a/scripts/lib/cross-os-release-checks/runtime.ts
+++ b/scripts/lib/cross-os-release-checks/runtime.ts
@@ -47,7 +47,6 @@ import {
   registerActiveChildProcessTree,
   runCommand,
   waitForGatewayWithStartupMigrationRestart,
-  withAllocatedGatewayPort,
 } from "./process.ts";
 import { logLanePhase } from "./reporting.ts";
 import { formatError, sleep } from "./shared.ts";
@@ -70,18 +69,16 @@ export async function runOpenClaw(params: {
 }
 
 export async function runOnboard(params: LaneCommandParams & { providerConfig: ProviderConfig }) {
-  await withAllocatedGatewayPort(params.lane, async () => {
-    await runOpenClaw({
-      lane: params.lane,
-      env: params.env,
-      args: buildReleaseOnboardArgs({
-        authChoice: params.providerConfig.authChoice,
-        gatewayPort: params.lane.gatewayPort,
-        skipHealth: true,
-      }),
-      logPath: params.logPath,
-      timeoutMs: 10 * 60 * 1000,
-    });
+  await runOpenClaw({
+    lane: params.lane,
+    env: params.env,
+    args: buildReleaseOnboardArgs({
+      authChoice: params.providerConfig.authChoice,
+      gatewayPort: params.lane.gatewayPort,
+      skipHealth: true,
+    }),
+    logPath: params.logPath,
+    timeoutMs: 10 * 60 * 1000,
   });
 }
 

--- a/test/scripts/openclaw-cross-os-release-checks-upgrade-lane.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks-upgrade-lane.test.ts
@@ -1,10 +1,12 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createScriptTestHarness } from "./test-helpers.js";
 
 const mocks = vi.hoisted(() => ({
   ensureLocalNpmShim: vi.fn(),
+  ensureDevUpdateGitInstall: vi.fn(),
   installPackageSpec: vi.fn(),
   installTarballPackage: vi.fn(),
   readInstalledMetadata: vi.fn(),
@@ -13,11 +15,15 @@ const mocks = vi.hoisted(() => ({
   runBundledPluginPostinstall: vi.fn(),
   runDashboardSmoke: vi.fn(),
   runModelsSet: vi.fn(),
-  runOnboard: vi.fn(),
+  runInstalledModelsSet: vi.fn(),
+  runInstallerSmoke: vi.fn(),
+  resolveInstallerTargetVersion: vi.fn(),
+  runCommand: vi.fn(),
   runOpenClaw: vi.fn(),
   startGateway: vi.fn(),
   stopGateway: vi.fn(),
   waitForGateway: vi.fn(),
+  verifyFreshShellCommand: vi.fn(),
 }));
 
 vi.mock("../../scripts/lib/cross-os-release-checks/install.ts", async (importOriginal) => ({
@@ -39,7 +45,6 @@ vi.mock("../../scripts/lib/cross-os-release-checks/runtime.ts", async (importOri
   runAgentTurn: mocks.runAgentTurn,
   runDashboardSmoke: mocks.runDashboardSmoke,
   runModelsSet: mocks.runModelsSet,
-  runOnboard: mocks.runOnboard,
   runOpenClaw: mocks.runOpenClaw,
   startGateway: mocks.startGateway,
   waitForGateway: mocks.waitForGateway,
@@ -50,11 +55,33 @@ vi.mock("../../scripts/lib/cross-os-release-checks/process.ts", async (importOri
     typeof import("../../scripts/lib/cross-os-release-checks/process.ts")
   >()),
   stopGateway: mocks.stopGateway,
+  runCommand: mocks.runCommand,
+  runCommandInvocation: (invocation: { command: string; args: string[] }, options: unknown) =>
+    mocks.runCommand(invocation.command, invocation.args, options),
 }));
 
-import { runUpgradeLane } from "../../scripts/lib/cross-os-release-checks/lanes.ts";
+vi.mock("../../scripts/lib/cross-os-release-checks/installed.ts", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../scripts/lib/cross-os-release-checks/installed.ts")
+  >()),
+  ensureDevUpdateGitInstall: mocks.ensureDevUpdateGitInstall,
+  resolveInstallerTargetVersion: mocks.resolveInstallerTargetVersion,
+  runInstalledAgentTurn: mocks.runAgentTurn,
+  runInstalledCli: mocks.runOpenClaw,
+  runInstalledModelsSet: mocks.runInstalledModelsSet,
+  runInstallerSmoke: mocks.runInstallerSmoke,
+  startManualGatewayFromInstalledCli: mocks.startGateway,
+  verifyFreshShellCommand: mocks.verifyFreshShellCommand,
+  waitForInstalledGateway: mocks.waitForGateway,
+}));
 
-const { createTempDir } = createScriptTestHarness();
+import {
+  runDevUpdateSuite,
+  runFreshLane,
+  runUpgradeLane,
+} from "../../scripts/lib/cross-os-release-checks/lanes.ts";
+
+const { createTempDir, trackTempDir } = createScriptTestHarness();
 
 const candidate = {
   candidateTgz: "/tmp/openclaw-candidate.tgz",
@@ -72,6 +99,9 @@ function upgradeParams() {
     baselineTgz: "",
     build: candidate,
     candidateUrl: "http://127.0.0.1:49951/openclaw-candidate.tgz",
+    ref: "main",
+    sourceSha: candidate.sourceSha,
+    runDiscordRoundtrip: false,
     companions: [],
     logsDir,
     providerConfig: {
@@ -84,7 +114,6 @@ function upgradeParams() {
     providerSecretValue: "secret",
   };
 }
-
 function arrangeSuccessfulLane() {
   mocks.installPackageSpec.mockResolvedValue(undefined);
   mocks.installTarballPackage.mockResolvedValue(undefined);
@@ -96,7 +125,12 @@ function arrangeSuccessfulLane() {
     commit: candidate.sourceSha,
   });
   mocks.runBundledPluginPostinstall.mockResolvedValue(undefined);
-  mocks.runOnboard.mockResolvedValue(undefined);
+  mocks.runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+  mocks.runOpenClaw.mockResolvedValue({ exitCode: 0, stdout: "{}", stderr: "" });
+  mocks.resolveInstallerTargetVersion.mockResolvedValue("2026.7.1");
+  mocks.runInstallerSmoke.mockImplementation(async ({ lane }) => trackTempDir(lane.rootDir));
+  mocks.verifyFreshShellCommand.mockResolvedValue({ cliPath: join(logsDir, "openclaw") });
+  mocks.ensureDevUpdateGitInstall.mockResolvedValue({ cliPath: join(logsDir, "openclaw") });
   mocks.runModelsSet.mockResolvedValue(undefined);
   mocks.startGateway.mockResolvedValue({
     child: {},
@@ -110,9 +144,10 @@ function arrangeSuccessfulLane() {
   mocks.runAgentTurn.mockResolvedValue({ exitCode: 0, stdout: "OK", stderr: "" });
 }
 
-describe("cross-OS packaged upgrade lane evidence", () => {
+describe("cross-OS manual gateway lane evidence", () => {
   beforeEach(() => {
     logsDir = createTempDir("openclaw-upgrade-lane-test-");
+    mocks.ensureLocalNpmShim.mockImplementation(({ rootDir }) => trackTempDir(rootDir));
   });
 
   afterEach(() => {
@@ -120,6 +155,75 @@ describe("cross-OS packaged upgrade lane evidence", () => {
     for (const mock of Object.values(mocks)) {
       mock.mockReset();
     }
+  });
+
+  describe.each([
+    ["fresh", runFreshLane],
+    ["upgrade", runUpgradeLane],
+    ["dev-update", runDevUpdateSuite],
+  ] as const)("%s gateway port ownership", (_name, runLane) => {
+    it.each(["success", "onboard", "models-set"] as const)(
+      "holds the configured port through setup and releases it after %s",
+      async (outcome) => {
+        arrangeSuccessfulLane();
+        let port = 0;
+        const phases: string[] = [];
+        mocks.runCommand.mockImplementation(async (_command, args: string[]) => {
+          if (args.includes("onboard")) {
+            port = Number(args[args.indexOf("--gateway-port") + 1]);
+            phases.push("onboard");
+            expect(await probeBind(port)).toBe("EADDRINUSE");
+            if (outcome === "onboard") {
+              throw new Error("injected onboard failure");
+            }
+          }
+          return { exitCode: 0, stdout: "", stderr: "" };
+        });
+        mocks.runModelsSet.mockImplementation(async ({ lane }) => {
+          expect(lane.gatewayPort).toBe(port);
+          phases.push("models-set");
+          expect(await probeBind(port)).toBe("EADDRINUSE");
+          if (outcome === "models-set") {
+            throw new Error("injected models-set failure");
+          }
+        });
+        mocks.runInstalledModelsSet.mockImplementation(() =>
+          mocks.runModelsSet({ lane: { gatewayPort: port } }),
+        );
+        mocks.startGateway.mockImplementation(async ({ lane }) => {
+          expect(lane.gatewayPort).toBe(port);
+          phases.push("start-gateway");
+          expect(await probeBind(port)).toBe("available");
+          return {
+            child: {},
+            closeLog: vi.fn(),
+            launchLogOffset: 0,
+            logPath: join(logsDir, "gateway.log"),
+            waitForClose: vi.fn(),
+          };
+        });
+
+        const result = await runLane(upgradeParams()).catch((error: unknown) => ({
+          status: "fail",
+          error: String(error),
+        }));
+
+        if (outcome === "success") {
+          expect(result, JSON.stringify(result)).toMatchObject({ status: "pass" });
+          expect(phases).toEqual(["onboard", "models-set", "start-gateway"]);
+        } else {
+          expect(result).toMatchObject({ status: "fail" });
+          expect(result, JSON.stringify(result)).toHaveProperty(
+            "error",
+            expect.stringContaining(`injected ${outcome} failure`),
+          );
+          expect(mocks.startGateway).not.toHaveBeenCalled();
+        }
+        // Failure cleanup and the spawn boundary both relinquish the same port.
+        expect(port).toBeGreaterThan(0);
+        expect(await probeBind(port)).toBe("available");
+      },
+    );
   });
 
   it("records bounded evidence when the supported Windows timeout fallback succeeds", async () => {
@@ -210,3 +314,11 @@ describe("cross-OS packaged upgrade lane evidence", () => {
     expect(JSON.stringify(result)).not.toContain("npm install");
   });
 });
+
+async function probeBind(port: number): Promise<string> {
+  const server = createServer();
+  return await new Promise((resolve) => {
+    server.once("error", (error: NodeJS.ErrnoException) => resolve(error.code ?? error.message));
+    server.listen(port, "127.0.0.1", () => server.close(() => resolve("available")));
+  });
+}


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where release checks leave the configured gateway port available for another process to claim during onboarding and model setup. Packaged fresh, packaged upgrade, and dev-update selected a port, released it, and only started the gateway after setup finished.

## Why This Change Was Made

The lane now owns the existing port reservation through setup and releases it immediately before starting the manual gateway. Failure cleanup releases the same reservation. This follows the existing manual installer lane and removes packaged onboarding's separate allocation/retry wrapper. Managed installer behavior, the gateway's force-port checks, timeouts, and retries are unchanged.

## User Impact

No product configuration or CLI changes. Release checks keep their chosen port reserved while preparing the gateway, reducing avoidable contention during long setup phases. This is a lifecycle repair, not a claim that Windows installation or gateway startup is faster.

## Evidence

- Nine lifecycle regressions cover packaged fresh, packaged upgrade, and dev-update: successful setup, onboarding failure, and model-setup failure. They use real competing TCP binds at the command boundaries. All failed before their owner changes because the configured port was available during onboarding; all pass after the repair, including release before spawn and failure cleanup.
- 145 focused owner and sibling tests passed, including existing npm diagnostic attribution, updater recovery, port reservations, command cleanup, and release-check contracts.
- Independent managed Codex review completed with no accepted/actionable P0 findings. The maintainer also reviewed the full owner modules and sibling lifecycle.
- The full changed-file gate passed: repository guards, formatting, script/test-root typechecks, script lint, and Docker/catalog boundaries.
- Tooling LOC: +30/-21 (net +9). Tests: +119/-7 (net +112). Product runtime: 0. The small tooling increase gives the three lane owners an explicit reservation lifetime while removing the onboarding-owned allocation/retry path.

The investigation began with [Windows packaged upgrade job 99188026203](https://github.com/openclaw/openclaw/actions/runs/33285444367/job/99188026203) on frozen `bee48f7f56808eff2f7aaa035509b8a39b3988e2`. Its updater passed, but the later gateway force-port probe rejected a port with no listener PID. That artifact does not retain the per-address bind error or socket table, so this PR does not claim to identify or fix that exact OS condition. The nine regressions prove the separate reservation-lifetime defect. No Windows release replay or workflow rerun was performed while the original full matrix was draining.
