### PR TITLE
refactor(voice-call): share replay pruning

### DIFF
--- a/extensions/voice-call/src/manager/replay-keys.ts
+++ b/extensions/voice-call/src/manager/replay-keys.ts
@@ -5,17 +5,7 @@ const MAX_MANAGER_REPLAY_KEYS = 10_000;
 /** Keep typical provider replay IDs near one raw persisted-record chunk. */
 export const MAX_CALL_REPLAY_KEYS = 500;
 
-function pruneOldestSetEntries(keys: Set<string>, maxEntries: number): void {
-  while (keys.size > maxEntries) {
-    const oldest = keys.values().next().value;
-    if (oldest === undefined) {
-      break;
-    }
-    keys.delete(oldest);
-  }
-}
-
-function pruneOldestMapEntries(keys: Map<string, symbol>, maxEntries: number): void {
+function pruneOldestEntries(keys: Set<string> | Map<string, symbol>, maxEntries: number): void {
   while (keys.size > maxEntries) {
     const oldest = keys.keys().next().value;
     if (oldest === undefined) {
@@ -32,7 +22,7 @@ export function rememberManagerReplayKey(
   maxEntries = MAX_MANAGER_REPLAY_KEYS,
 ): void {
   keys.add(key);
-  pruneOldestSetEntries(keys, maxEntries);
+  pruneOldestEntries(keys, maxEntries);
 }
 
 /** Append one per-call replay key and retain only the newest bounded suffix. */
@@ -67,7 +57,7 @@ export function reserveRejectedProviderCall(
   }
   const reservation = Symbol(providerCallId);
   calls.set(providerCallId, reservation);
-  pruneOldestMapEntries(calls, maxEntries);
+  pruneOldestEntries(calls, maxEntries);
   return reservation;
 }
 


### PR DESCRIPTION
## Summary

- replace the duplicate Set and Map replay-key pruning functions with one private exact-union helper
- preserve insertion-order FIFO eviction and the existing reservation-token behavior
- leave sibling webhook and media-stream retention owners unchanged

## Problem

`replay-keys.ts` encoded the same bounded oldest-entry eviction policy twice. The two implementations were behaviorally identical, so retaining both created an unnecessary drift point inside one owner.

## Root cause and fix

The replay-key owner split one invariant by collection type even though both collections expose the same ordered key iterator and deletion contract. The canonical fix is one private `pruneOldestEntries` helper over the exact collection union used by this module.

Removed paths:

- `pruneOldestSetEntries`
- `pruneOldestMapEntries`

No public API, config, protocol, persistence, or user-visible behavior changes.

## Validation

- focused Vitest: 4 files, 46 tests passed
- `pnpm tsgo:core`
- `oxfmt --check extensions/voice-call/src/manager/replay-keys.ts`
- `git diff --check`
- mandatory local autoreview: clean, correctness 0.99
- production delta: +3 / -13, net -10

`check-changed` passed every preceding guard and stopped only at the sparse-checkout dead-export scan because the task worktree does not contain tracked Control UI config modules. This draft remains blocked from ready/merge until the hydrated native review checkout completes the repository review gates.
