### PR TITLE
perf(test): reuse generated publisher Git fixtures

### DIFF
--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2,6 +2,8 @@
 import { execFileSync, spawn, spawnSync } from "node:child_process";
 import {
   chmodSync,
+  constants as fsConstants,
+  cpSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -20,7 +22,7 @@ import { fileURLToPath } from "node:url";
 import { runInNewContext } from "node:vm";
 import { expectDefined } from "@openclaw/normalization-core";
 import ts from "typescript";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import {
   detectChangedScope,
@@ -68,6 +70,8 @@ const AMBIGUOUS_MAIN_PUSH_GUARD = `if [ "$GITHUB_EVENT_NAME" = "push" ] && [[ "$
   exit 1
 fi`;
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const publisherTemplateDirs = useAutoCleanupTempDirTracker(afterAll);
+let generatedPublisherTemplate: string | undefined;
 const rootPackageManager = (
   JSON.parse(readFileSync("package.json", "utf8")) as {
     packageManager: string;
@@ -1465,6 +1469,38 @@ function runControlUiI18nSourceFixture(options: {
   }
 }
 
+function copyGeneratedPublisherFixture(root: string) {
+  if (!generatedPublisherTemplate) {
+    const templateRoot = publisherTemplateDirs.make("openclaw-generated-pr-template-");
+    const origin = path.join(templateRoot, "origin.git");
+    const worktree = path.join(templateRoot, "worktree");
+    const generatedDir = path.join(worktree, "generated");
+    const sourceDir = path.join(worktree, "source");
+    mkdirSync(generatedDir, { recursive: true });
+    mkdirSync(sourceDir);
+    runGit(templateRoot, ["init", "--bare", origin]);
+    runGit(templateRoot, ["init", "--initial-branch=main", worktree]);
+    runGit(worktree, ["config", "user.name", "Test Publisher"]);
+    runGit(worktree, ["config", "user.email", "publisher@example.com"]);
+    writeFileSync(path.join(generatedDir, "a.txt"), "old-a\n", "utf8");
+    writeFileSync(path.join(generatedDir, "b.txt"), "old-b\n", "utf8");
+    writeFileSync(path.join(sourceDir, "input.txt"), "old-input\n", "utf8");
+    runGit(worktree, ["add", "generated", "source"]);
+    runGit(worktree, ["commit", "-m", "base"]);
+    runGit(worktree, ["remote", "add", "origin", "../origin.git"]);
+    runGit(worktree, ["push", "-u", "origin", "main"]);
+    runGit(templateRoot, ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"]);
+    generatedPublisherTemplate = templateRoot;
+  }
+  // Relative origin follows each copied repository pair, isolating refs, hooks and config.
+  for (const name of ["origin.git", "worktree"]) {
+    cpSync(path.join(generatedPublisherTemplate, name), path.join(root, name), {
+      recursive: true,
+      mode: fsConstants.COPYFILE_FICLONE,
+    });
+  }
+}
+
 function runGeneratedPublisherScenario(
   baseChangePath: "a" | "b" | null,
   options: {
@@ -1488,7 +1524,6 @@ function runGeneratedPublisherScenario(
     const updater = path.join(root, "updater");
     const worktree = path.join(root, "worktree");
     const generatedDir = path.join(worktree, "generated");
-    const sourceDir = path.join(worktree, "source");
     const fakeBin = path.join(root, "bin");
     const runnerTemp = path.join(root, "runner-temp");
     const prState = path.join(root, "pr-open");
@@ -1497,8 +1532,7 @@ function runGeneratedPublisherScenario(
     const stalePrViewHeadOnce = path.join(root, "stale-pr-view-head-once");
     const summary = path.join(root, "summary.md");
 
-    mkdirSync(generatedDir, { recursive: true });
-    mkdirSync(sourceDir);
+    copyGeneratedPublisherFixture(root);
     mkdirSync(fakeBin);
     mkdirSync(runnerTemp);
     writeFileSync(summary, "", "utf8");
@@ -1508,18 +1542,6 @@ function runGeneratedPublisherScenario(
     if (options.stalePrViewHeadOnce) {
       writeFileSync(stalePrViewHeadOnce, "", "utf8");
     }
-    runGit(root, ["init", "--bare", origin]);
-    runGit(root, ["init", "--initial-branch=main", worktree]);
-    runGit(worktree, ["config", "user.name", "Test Publisher"]);
-    runGit(worktree, ["config", "user.email", "publisher@example.com"]);
-    writeFileSync(path.join(generatedDir, "a.txt"), "old-a\n", "utf8");
-    writeFileSync(path.join(generatedDir, "b.txt"), "old-b\n", "utf8");
-    writeFileSync(path.join(sourceDir, "input.txt"), "old-input\n", "utf8");
-    runGit(worktree, ["add", "generated", "source"]);
-    runGit(worktree, ["commit", "-m", "base"]);
-    runGit(worktree, ["remote", "add", "origin", origin]);
-    runGit(worktree, ["push", "-u", "origin", "main"]);
-    runGit(root, ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"]);
     if (options.existingPr) {
       runGit(worktree, ["switch", "-c", "automation/locale"]);
       writeFileSync(path.join(generatedDir, "a.txt"), "stale-pr-a\n", "utf8");


### PR DESCRIPTION
## What Problem This Solves

The generated-PR publisher integration tests rebuild the same initial Git history for every scenario. Across 13 tests and 14 scenario calls, that repeats nine bootstrap commands each time before exercising the actual publishing behavior.

## Why This Change Was Made

Create the initial bare origin and worktree once, lazily, then copy them into independent per-scenario directories. The relative origin follows each copied repository pair; mutable refs, hooks, config, index, and objects remain isolated. The existing temp tracker owns template cleanup, including partial initialization failures.

This removes 117 repeated bootstrap Git launches. All scenario-specific commits, updater clones, production fetch/push/lease operations, rejection and immediate-merge hooks, authorization-header cleanup assertions, and per-scenario cleanup remain. No assertions, test cases, mocks, timeouts, sharding, concurrency, production code, or dependencies change.

## User Impact

No product behavior changes. This reduces execution work in the publisher test subgroup without replacing real Git integration coverage. Production LOC: +0/-0. Test LOC: +38/-16.

## Evidence

All 13 existing publisher cases passed with identical expanded names in three alternating before/after pairs, using Node 26.5.0, Vitest 4.1.11 and one worker. Complete test-phase times, including template setup and cleanup:

| Pair | Before | After |
| --- | ---: | ---: |
| Initial | 12.62s | 13.43s |
| Warm 1 | 9.95s | 8.29s |
| Warm 2 | 11.23s | 9.38s |

The two warm pairs improved about 16%; the slower initial pair is retained above rather than hidden. These are local subgroup timings under variable host load, not whole-CI savings.

The complete workflow-guard file passed all 178 active cases, with its two existing skips, both normally and shuffled with seed 41. The shuffled order exercised immediate-merge and failed-push cases before later successful publishing cases. All 14 changed-file checks passed, and fresh independent Codex review found no blocking findings.

Source review covered the complete test module, full publisher action, temp-directory cleanup owner, Node copy semantics, and the existing independent Git fixture copying pattern in live-updater tests. Reusing mutable repository trees or replacing real Git publishing operations was rejected because it would weaken isolation or coverage. No live external publication is needed: only the existing local test fixture setup changes.
