### PR TITLE
fix: realtime phone calls use the wrong audio format and stay open

### DIFF
--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -285,12 +285,23 @@ Current runtime behavior:
 - `inboundPolicy` must not be `"disabled"` when `realtime.enabled` is true; `validateProviderConfig` rejects that combination.
 - Consult session keys reuse the stored call session when available, then fall back to the configured `sessionScope` (`per-phone` by default, `per-call` for isolated calls, or `main` for the configured agent's main session).
 
+<Warning>
+GPT-Live uses agent delegation instead of native function tools. Its current
+Voice Call bridge cannot invoke `openclaw_end_call` or custom `realtime.tools`.
+Use an OpenAI GA realtime model or Google Gemini Live when the call needs those
+controls; selecting GPT-Live does not make them available through delegation.
+</Warning>
+
 ### Hangup detection
 
 Realtime calls normally end when the carrier sends a stream stop event or closes
 the media WebSocket. If an intermediary does not promptly forward that close,
 OpenClaw treats 30 seconds without inbound media as a disconnect, waits a
 2-second grace period for media to resume, and then ends the call.
+
+If the realtime provider ends its session first, OpenClaw also ends the carrier
+call, including when the provider reports a normal close. This prevents a silent
+phone connection from remaining open after its voice session has finished.
 
 The realtime model can also call `openclaw_end_call` when the caller asks to
 hang up. The model must speak any final words before calling the tool: a

--- a/extensions/openai/realtime-quicksilver-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-bridge.test.ts
@@ -40,15 +40,15 @@ class FakeSocket extends EventEmitter {
     if (this.deferClose) {
       return;
     }
-    this.finishClose();
+    this.finishClose(1000);
   }
 
-  finishClose(): void {
+  finishClose(code = 1006): void {
     if (this.readyState === 3) {
       return;
     }
     this.readyState = 3;
-    queueMicrotask(() => this.emit("close"));
+    queueMicrotask(() => this.emit("close", code, Buffer.alloc(0)));
   }
 
   serverEvent(event: unknown): void {
@@ -186,6 +186,20 @@ describe("OpenAIQuicksilverVoiceBridge", () => {
 
     await Promise.all([firstConnect, secondConnect]);
     expect(harness.onReady).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    [1000, "completed"],
+    [1006, "error"],
+  ] as const)("classifies an established session closing with code %s", async (code, reason) => {
+    const harness = createHarness();
+    await harness.bridge.connect();
+
+    harness.socket.finishClose(code);
+    await Promise.resolve();
+
+    expect(harness.onClose).toHaveBeenCalledExactlyOnceWith(reason);
+    expect(harness.bridge.isConnected()).toBe(false);
   });
 
   it("bounds queued audio by aggregate bytes before session readiness", async () => {
@@ -332,7 +346,10 @@ describe("OpenAIQuicksilverVoiceBridge", () => {
     expect(harness.onError).not.toHaveBeenCalled();
   });
 
-  it("reports a buffered terminal event that follows session readiness", async () => {
+  it.each([
+    [1000, "completed"],
+    [1006, "error"],
+  ] as const)("classifies a buffered close after readiness with code %s", async (code, reason) => {
     const harness = createHarness({
       autoStart: false,
       afterOpen: (socket) => {
@@ -340,18 +357,21 @@ describe("OpenAIQuicksilverVoiceBridge", () => {
           type: "session.started",
           session: { id: "live-1", expires_at: Math.floor(Date.now() / 1000) + 60 },
         });
-        socket.finishClose();
+        socket.finishClose(code);
       },
     });
 
     await harness.bridge.connect();
 
     expect(harness.onReady).toHaveBeenCalledOnce();
-    expect(harness.onError).toHaveBeenCalledWith(
-      new Error("GPT-Live WebSocket closed during startup"),
-    );
-    expect(harness.onClose).toHaveBeenCalledOnce();
-    expect(harness.onClose).toHaveBeenCalledWith("error");
+    if (reason === "error") {
+      expect(harness.onError).toHaveBeenCalledWith(
+        new Error("GPT-Live WebSocket closed during startup"),
+      );
+    } else {
+      expect(harness.onError).not.toHaveBeenCalled();
+    }
+    expect(harness.onClose).toHaveBeenCalledExactlyOnceWith(reason);
     expect(harness.bridge.isConnected()).toBe(false);
   });
 

--- a/extensions/openai/realtime-quicksilver-bridge.ts
+++ b/extensions/openai/realtime-quicksilver-bridge.ts
@@ -245,7 +245,7 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
         this.fail(connection, error);
       }
     });
-    connected.socket.on("close", () => {
+    connected.socket.on("close", (code) => {
       if (!this.lifecycle.isCurrent(connection) || this.socket !== connected.socket) {
         return;
       }
@@ -262,7 +262,7 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
         this.lifecycle.close(connection, "error");
         return;
       }
-      this.notifyClose(connection, "error");
+      this.notifyClose(connection, code === 1000 ? "completed" : "error");
     });
 
     const terminalEvent = connected.detachBuffer();
@@ -286,7 +286,9 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
           ? terminalEvent.error
           : new Error("GPT-Live WebSocket closed during startup");
       if (reachedReady) {
-        if (this.fail(connection, error, "startup terminal event")) {
+        if (terminalEvent.kind === "close" && terminalEvent.code === 1000) {
+          this.notifyClose(connection, "completed");
+        } else if (this.fail(connection, error, "startup terminal event")) {
           this.notifyClose(connection, "error");
         }
       } else {

--- a/extensions/voice-call/src/runtime.realtime-routing.test.ts
+++ b/extensions/voice-call/src/runtime.realtime-routing.test.ts
@@ -205,18 +205,16 @@ describe("voice-call realtime route ownership", () => {
       ).toEqual(["sales", "support"]);
 
       const hangupCall = vi.spyOn(runtime.provider, "hangupCall");
+      const closed = Promise.all(sockets.map((ws) => waitForClose(ws)));
       salesRequests[0]?.onClose?.("completed");
-      for (const ws of sockets) {
-        const closed = waitForClose(ws);
-        ws.close(1000);
-        await closed;
-      }
+      sockets[1]?.close(1000);
+      await closed;
       await vi.waitFor(() => expect(runtime?.manager.getActiveCalls()).toHaveLength(0), {
         timeout: 3_000,
       });
       expect(hangupCall).toHaveBeenCalledTimes(2);
       expect(hangupCall).toHaveBeenCalledWith(
-        expect.objectContaining({ providerCallId: "CA-sales", reason: "hangup-bot" }),
+        expect.objectContaining({ providerCallId: "CA-sales", reason: "completed" }),
       );
       expect(hangupCall).toHaveBeenCalledWith(
         expect.objectContaining({ providerCallId: "CA-support", reason: "hangup-bot" }),
@@ -224,9 +222,9 @@ describe("voice-call realtime route ownership", () => {
       await expect(runtime.manager.getCallHistory()).resolves.toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            endReason: "hangup-bot",
+            endReason: "completed",
             providerCallId: "CA-sales",
-            state: "hangup-bot",
+            state: "completed",
           }),
           expect.objectContaining({
             endReason: "hangup-bot",

--- a/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
@@ -771,65 +771,51 @@ describe("RealtimeCallHandler lifecycle", () => {
     }
   });
 
-  it("tolerates provider close during bridge creation", async () => {
-    const bridgeConnect = vi.fn(async () => {});
-    const createBridgeForCall = vi.fn(
-      (request: { onClose?: (reason: "completed" | "error") => void }) => {
-        request.onClose?.("completed");
-        return createBridge(vi.fn(), { connect: bridgeConnect });
-      },
-    );
-    const call: CallRecord = {
-      callId: "call-synchronous-close",
-      providerCallId: "CA-synchronous-close",
-      provider: "twilio",
-      direction: "inbound",
-      state: "ringing",
-      from: "+15550001111",
-      to: "+15550002222",
-      startedAt: Date.now(),
-      transcript: [],
-      processedEventIds: [],
-    };
-    const handler = new RealtimeCallHandler(
-      createRealtimeConfig(),
-      {
-        processEvent: vi.fn(),
-        endCall: vi.fn(async () => ({ success: true })),
-        getCallByProviderCallId: vi.fn(() => call),
-      } as unknown as CallManager,
-      makeCallRegistrationResolver(makeRealtimeProvider(createBridgeForCall)),
-      "/voice/webhook",
-      noOpStreamDisconnectLifecycle,
-    );
-    const { streamUrl } = handler.issueStreamSession();
-    const server = await startUpgradeWsServer({
-      urlPath: new URL(streamUrl).pathname,
-      onUpgrade: (request, socket, head) => {
-        handler.handleWebSocketUpgrade(request, socket, head);
-      },
-    });
-    const ws = await connectWs(server.url);
-
-    try {
-      ws.send(
-        JSON.stringify({
-          event: "start",
-          start: { streamSid: "MZ-synchronous-close", callSid: "CA-synchronous-close" },
-        }),
+  it.each(["completed", "error"] as const)(
+    "rejects a bridge closed during creation with %s",
+    async (reason) => {
+      const bridgeConnect = vi.fn(async () => {});
+      const bridgeClose = vi.fn();
+      const createBridgeForCall = vi.fn(
+        (request: { onClose?: (reason: "completed" | "error") => void }) => {
+          request.onClose?.(reason);
+          return createBridge(bridgeClose, { connect: bridgeConnect });
+        },
       );
-      await vi.waitFor(() => {
-        expect(createBridgeForCall).toHaveBeenCalledTimes(1);
-        expect(bridgeConnect).toHaveBeenCalledTimes(1);
-      });
-    } finally {
-      if (ws.readyState !== WebSocket.CLOSED) {
-        ws.terminate();
+      const { call, handler, hangupCall } = createCarrierLifecycleHarness(createBridgeForCall);
+      const { server, ws } = await connectCarrierStream(handler);
+
+      try {
+        const closed = waitForClose(ws);
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-synchronous-close", callSid: call.providerCallId },
+          }),
+        );
+        expect((await closed).code).toBe(reason === "completed" ? 1000 : 1011);
+        await vi.waitFor(() => {
+          expect(hangupCall).toHaveBeenCalledExactlyOnceWith({
+            callId: call.callId,
+            providerCallId: call.providerCallId,
+            reason,
+          });
+        });
+        expect(bridgeConnect).not.toHaveBeenCalled();
+        expect(bridgeClose).toHaveBeenCalledOnce();
+        expect(handler.speak(call.callId, "Do not revive this call")).toEqual({
+          success: false,
+          error: "No active realtime bridge for call",
+        });
+      } finally {
+        if (ws.readyState !== WebSocket.CLOSED) {
+          ws.terminate();
+        }
+        await handler.close();
+        await server.close();
       }
-      await handler.close();
-      await server.close();
-    }
-  });
+    },
+  );
 
   it("does not start a native consult after teardown during transcript settling", async () => {
     let onToolCall:

--- a/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
@@ -154,6 +154,53 @@ async function connectCarrierStream(handler: RealtimeCallHandler) {
 }
 
 describe("RealtimeCallHandler lifecycle", () => {
+  it.each(["completed", "error"] as const)(
+    "ends the carrier call when the provider closes with %s",
+    async (reason) => {
+      let onProviderClose: ((reason: "completed" | "error") => void) | undefined;
+      const closeBridge = vi.fn(() => onProviderClose?.("completed"));
+      const createBridgeForCall = vi.fn<RealtimeVoiceProviderPlugin["createBridge"]>((request) => {
+        onProviderClose = request.onClose;
+        return createBridge(closeBridge);
+      });
+      const { call, handler, hangupCall, processEvent } =
+        createCarrierLifecycleHarness(createBridgeForCall);
+      const { server, ws } = await connectCarrierStream(handler);
+
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-provider-close", callSid: call.providerCallId },
+          }),
+        );
+        await vi.waitFor(() => expect(createBridgeForCall).toHaveBeenCalledOnce());
+
+        const closed = waitForClose(ws);
+        onProviderClose?.(reason);
+
+        await vi.waitFor(() =>
+          expect(hangupCall).toHaveBeenCalledExactlyOnceWith({
+            callId: call.callId,
+            providerCallId: call.providerCallId,
+            reason,
+          }),
+        );
+        expect((await closed).code).toBe(reason === "completed" ? 1000 : 1011);
+        expect(closeBridge).toHaveBeenCalledOnce();
+        expect(
+          processEvent.mock.calls.filter(([event]) => event.type === "call.ended"),
+        ).toHaveLength(1);
+      } finally {
+        if (ws.readyState !== WebSocket.CLOSED) {
+          ws.terminate();
+        }
+        await handler.close();
+        await server.close();
+      }
+    },
+  );
+
   it("keeps a failed startup nonterminal until manager-owned carrier termination succeeds", async () => {
     const termination = createDeferred<{ success: boolean; error?: string }>();
     const endCall = vi.fn(() => termination.promise);

--- a/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
@@ -158,7 +158,11 @@ describe("RealtimeCallHandler lifecycle", () => {
     "ends the carrier call when the provider closes with %s",
     async (reason) => {
       let onProviderClose: ((reason: "completed" | "error") => void) | undefined;
-      const closeBridge = vi.fn(() => onProviderClose?.("completed"));
+      const bridgeClosed = createDeferred<void>();
+      const closeBridge = vi.fn(() => {
+        onProviderClose?.("completed");
+        bridgeClosed.resolve();
+      });
       const createBridgeForCall = vi.fn<RealtimeVoiceProviderPlugin["createBridge"]>((request) => {
         onProviderClose = request.onClose;
         return createBridge(closeBridge);
@@ -187,6 +191,7 @@ describe("RealtimeCallHandler lifecycle", () => {
           }),
         );
         expect((await closed).code).toBe(reason === "completed" ? 1000 : 1011);
+        await bridgeClosed.promise;
         expect(closeBridge).toHaveBeenCalledOnce();
         expect(
           processEvent.mock.calls.filter(([event]) => event.type === "call.ended"),

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -2412,100 +2412,118 @@ describe("RealtimeCallHandler path routing", () => {
     }
   });
 
-  it("preserves the predecessor when replacement closes with error during creation", async () => {
-    const callbacks: RealtimeBridgeRequest[] = [];
-    const oldTriggerGreeting = vi.fn();
-    const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
-      callbacks.push(request);
-      if (callbacks.length === 1) {
-        return makeBridge({ triggerGreeting: oldTriggerGreeting });
-      }
-      request.onTranscript?.("user", "Failed ", false);
-      request.onClose?.("error");
-      throw new Error("replacement bridge failed");
-    });
-    const processEvent = vi.fn();
-    const endCall = vi.fn(async () => ({ success: true }));
-    const sharedCallSid = "CA-transcript-rollback";
-    const call = makeCallRecord(sharedCallSid);
-    const handler = makeHandler(undefined, {
-      manager: {
-        getCallByProviderCallId: vi.fn(() => call),
-        processEvent,
-        endCall,
-      },
-      realtimeProvider: makeRealtimeProvider(createBridge),
-    });
-    const oldServer = await startRealtimeServer(handler);
-    let replacementServer: Awaited<ReturnType<typeof startRealtimeServer>> | undefined;
-    let oldWs: WebSocket | undefined;
-
-    try {
-      oldWs = await connectWs(oldServer.url);
-      oldWs.send(
-        JSON.stringify({
-          event: "start",
-          start: { streamSid: "MZ-transcript-rollback-old", callSid: sharedCallSid },
-        }),
-      );
-      await waitForRealtimeTest(() => {
-        expect(callbacks).toHaveLength(1);
+  it.each(["completed", "error", "throw"] as const)(
+    "keeps the predecessor after replacement creation closes: %s",
+    async (outcome) => {
+      const callbacks: RealtimeBridgeRequest[] = [];
+      const oldTriggerGreeting = vi.fn();
+      const replacementConnect = vi.fn(async () => {});
+      const replacementClose = vi.fn(() => {
+        callbacks[1]?.onTranscript?.("user", "Failed teardown transcript", true);
+        callbacks[1]?.onClose?.("error");
+        if (outcome === "error") {
+          throw new Error("replacement close failed");
+        }
       });
-      callbacks[0]?.onTranscript?.("user", "Old ", false);
+      const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
+        callbacks.push(request);
+        if (callbacks.length === 1) {
+          return makeBridge({ triggerGreeting: oldTriggerGreeting });
+        }
+        request.onTranscript?.("user", "Failed ", false);
+        request.onClose?.(outcome === "completed" ? "completed" : "error");
+        request.onTranscript?.("user", "Closed before adoption", true);
+        if (outcome === "throw") {
+          throw new Error("replacement bridge failed");
+        }
+        return makeBridge({ connect: replacementConnect, close: replacementClose });
+      });
+      const processEvent = vi.fn();
+      const endCall = vi.fn(async () => ({ success: true }));
+      const sharedCallSid = "CA-transcript-rollback";
+      const call = makeCallRecord(sharedCallSid);
+      const handler = makeHandler(undefined, {
+        manager: {
+          getCallByProviderCallId: vi.fn(() => call),
+          processEvent,
+          endCall,
+        },
+        realtimeProvider: makeRealtimeProvider(createBridge),
+      });
+      const oldServer = await startRealtimeServer(handler);
+      let replacementServer: Awaited<ReturnType<typeof startRealtimeServer>> | undefined;
+      let oldWs: WebSocket | undefined;
 
-      replacementServer = await startRealtimeServer(handler);
-      const replacementWs = await connectWs(replacementServer.url);
       try {
-        replacementWs.send(
+        oldWs = await connectWs(oldServer.url);
+        oldWs.send(
           JSON.stringify({
             event: "start",
-            start: { streamSid: "MZ-transcript-rollback-new", callSid: sharedCallSid },
+            start: { streamSid: "MZ-transcript-rollback-old", callSid: sharedCallSid },
           }),
         );
         await waitForRealtimeTest(() => {
-          expect(createBridge).toHaveBeenCalledTimes(2);
+          expect(callbacks).toHaveLength(1);
         });
+        callbacks[0]?.onTranscript?.("user", "Old ", false);
 
-        expect(handler.speak(call.callId, "Continue the existing call.")).toEqual({
-          success: true,
-        });
-        expect(oldTriggerGreeting).toHaveBeenCalledWith("Continue the existing call.");
-        expect(endCall).not.toHaveBeenCalled();
-        expect(
-          processEvent.mock.calls
-            .map(([event]) => event as NormalizedEvent)
-            .filter((event) => event.type === "call.ended"),
-        ).toHaveLength(0);
+        replacementServer = await startRealtimeServer(handler);
+        const replacementWs = await connectWs(replacementServer.url);
+        try {
+          const replacementClosed = waitForClose(replacementWs);
+          replacementWs.send(
+            JSON.stringify({
+              event: "start",
+              start: { streamSid: "MZ-transcript-rollback-new", callSid: sharedCallSid },
+            }),
+          );
+          await replacementClosed;
+          expect(replacementConnect).not.toHaveBeenCalled();
+          expect(replacementClose).toHaveBeenCalledTimes(outcome === "throw" ? 0 : 1);
+          callbacks[1]?.onClose?.("error");
+          callbacks[1]?.onTranscript?.("user", "Late failed replacement", true);
 
-        callbacks[0]?.onTranscript?.("user", "caller", true);
-        await waitForRealtimeTest(() => {
+          expect(handler.speak(call.callId, "Continue the existing call.")).toEqual({
+            success: true,
+          });
+          expect(oldTriggerGreeting).toHaveBeenCalledWith("Continue the existing call.");
+          expect(endCall).not.toHaveBeenCalled();
           expect(
             processEvent.mock.calls
               .map(([event]) => event as NormalizedEvent)
-              .filter((event) => event.type === "call.speech")
-              .map((event) => (event.type === "call.speech" ? event.transcript : undefined)),
-          ).toEqual(["Old caller"]);
-        });
+              .filter((event) => event.type === "call.ended"),
+          ).toHaveLength(0);
+
+          callbacks[0]?.onTranscript?.("user", "caller", true);
+          await waitForRealtimeTest(() => {
+            expect(
+              processEvent.mock.calls
+                .map(([event]) => event as NormalizedEvent)
+                .filter((event) => event.type === "call.speech")
+                .map((event) => (event.type === "call.speech" ? event.transcript : undefined)),
+            ).toEqual(["Old caller"]);
+          });
+        } finally {
+          if (
+            replacementWs.readyState !== WebSocket.CLOSED &&
+            replacementWs.readyState !== WebSocket.CLOSING
+          ) {
+            replacementWs.close();
+          }
+        }
       } finally {
         if (
-          replacementWs.readyState !== WebSocket.CLOSED &&
-          replacementWs.readyState !== WebSocket.CLOSING
+          oldWs &&
+          oldWs.readyState !== WebSocket.CLOSED &&
+          oldWs.readyState !== WebSocket.CLOSING
         ) {
-          replacementWs.close();
+          oldWs.close();
         }
+        await replacementServer?.close();
+        await oldServer.close();
       }
-    } finally {
-      if (
-        oldWs &&
-        oldWs.readyState !== WebSocket.CLOSED &&
-        oldWs.readyState !== WebSocket.CLOSING
-      ) {
-        oldWs.close();
-      }
-      await replacementServer?.close();
-      await oldServer.close();
-    }
-  });
+    },
+  );
 
   it("cleans provisional transcript state when initial bridge creation fails", async () => {
     const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
@@ -2550,7 +2568,7 @@ describe("RealtimeCallHandler path routing", () => {
     }
   });
 
-  it("keeps provisional transcript ownership across synchronous provider close", async () => {
+  it("discards provisional transcript ownership after synchronous provider close", async () => {
     let callbacks: RealtimeBridgeRequest | undefined;
     const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
       callbacks = request;
@@ -2570,6 +2588,7 @@ describe("RealtimeCallHandler path routing", () => {
     const ws = await connectWs(server.url);
 
     try {
+      const closed = waitForClose(ws);
       ws.send(
         JSON.stringify({
           event: "start",
@@ -2579,18 +2598,11 @@ describe("RealtimeCallHandler path routing", () => {
           },
         }),
       );
-      await waitForRealtimeTest(() => {
-        expect(createBridge).toHaveBeenCalledOnce();
-      });
+      await closed;
       callbacks?.onTranscript?.("user", "Still listening", true);
-      await waitForRealtimeTest(() => {
-        expect(processEvent).toHaveBeenCalledWith(
-          expect.objectContaining({
-            transcript: "Still listening",
-            type: "call.speech",
-          }),
-        );
-      });
+      expect(processEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: "call.speech" }),
+      );
     } finally {
       if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
         ws.close();

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -515,6 +515,11 @@ describe("RealtimeCallHandler path routing", () => {
         await waitForRealtimeTest(() => {
           expect(createBridge).toHaveBeenCalled();
         });
+        expect(createBridge.mock.calls[0]?.[0].audioFormat).toEqual({
+          encoding: "g711_ulaw",
+          sampleRateHz: 8000,
+          channels: 1,
+        });
         callbacks?.onReady?.();
         const event = requireFirstMockCall(processEvent.mock.calls, "processed event")[0] as
           | NormalizedEvent
@@ -608,6 +613,11 @@ describe("RealtimeCallHandler path routing", () => {
         );
         expect(createBridge.mock.calls[0]?.[0].instructions).toBe("instructions:support");
         expect(createBridge.mock.calls[0]?.[0].agentId).toBe("support");
+        expect(createBridge.mock.calls[0]?.[0].audioFormat).toEqual({
+          encoding: "g711_ulaw",
+          sampleRateHz: 8000,
+          channels: 1,
+        });
         callbacks?.onReady?.();
         expect(triggerGreeting).toHaveBeenCalledTimes(1);
         expect(triggerGreeting.mock.calls[0]?.[0]).toContain("hello");
@@ -824,6 +834,7 @@ describe("RealtimeCallHandler path routing", () => {
         }
       | undefined;
     const processEvent = vi.fn();
+    const endCall = vi.fn(async () => ({ success: true }));
     const close = vi.fn(() => {
       callbacks?.onTranscript?.("user", "last words", true);
       callbacks?.onClose?.("completed");
@@ -868,6 +879,7 @@ describe("RealtimeCallHandler path routing", () => {
     const handler = makeHandler(undefined, {
       manager: {
         processEvent,
+        endCall,
         getCallByProviderCallId,
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
@@ -895,6 +907,7 @@ describe("RealtimeCallHandler path routing", () => {
         const events = processEvent.mock.calls.map(([event]) => event as NormalizedEvent);
         expect(close).toHaveBeenCalledTimes(1);
         expect(disconnect).toHaveBeenCalledExactlyOnceWith("CA-complete", "MZ-complete");
+        expect(endCall).not.toHaveBeenCalled();
         const speechIndex = events.findIndex((event) => event.type === "call.speech");
         expect(speechIndex).toBeGreaterThanOrEqual(0);
         expect(events.some((event) => event.type === "call.ended")).toBe(false);
@@ -922,6 +935,7 @@ describe("RealtimeCallHandler path routing", () => {
         expect(
           processEvent.mock.calls.filter(([event]) => event.type === "call.ended"),
         ).toHaveLength(1);
+        expect(endCall).not.toHaveBeenCalled();
       } finally {
         if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
           ws.close();

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -19,6 +19,7 @@ import {
   readSpeakableRealtimeVoiceToolResult,
   type RealtimeVoiceForcedConsultHandle,
   type RealtimeVoiceBridgeSession,
+  type RealtimeVoiceCloseReason,
   type RealtimeVoiceProviderConfig,
   type RealtimeVoiceProviderPlugin,
   type RealtimeVoiceSessionHarness,
@@ -844,6 +845,7 @@ export class RealtimeCallHandler {
         : undefined;
     // Providers may close synchronously before createBridge returns; no consult can exist yet.
     const nativeConsultOwner: { current?: ActiveRealtimeVoiceBridge } = {};
+    let provisionalCloseReason: RealtimeVoiceCloseReason | undefined;
     let sessionClosed = false;
     // Provisional ownership accepts callbacks fired during createBridge. Commit
     // retires the predecessor only after creation succeeds; failure restores it.
@@ -886,6 +888,7 @@ export class RealtimeCallHandler {
       onTranscript: (role, text, isFinal) => {
         const owner = nativeConsultOwner.current;
         if (
+          provisionalCloseReason ||
           !this.getUserTranscriptState(callId, userTranscriptOwner) ||
           (owner && !this.isActiveBridgeOwner(callId, owner))
         ) {
@@ -1067,21 +1070,24 @@ export class RealtimeCallHandler {
         });
       },
       onClose: (reason) => {
-        const owner = nativeConsultOwner.current;
-        const ownsCallState = owner ? this.isActiveBridgeOwner(callId, owner) : false;
-        if (owner) {
-          this.clearActiveBridgeMappings(callId, callSid, owner);
-          this.cancelConsultSession(callId, owner);
-        }
-        if (ownsCallState) {
-          this.clearUserTranscriptState(callId, userTranscriptOwner);
-        }
         harness.finishOutputAudio(reason);
         harness.emit({
           type: "session.closed",
           payload: { reason },
           final: true,
         });
+        const owner = nativeConsultOwner.current;
+        if (!owner) {
+          // Settle terminal creation before adopting a bridge or retiring its predecessor.
+          provisionalCloseReason ??= reason;
+          return;
+        }
+        const ownsCallState = this.isActiveBridgeOwner(callId, owner);
+        this.clearActiveBridgeMappings(callId, callSid, owner);
+        this.cancelConsultSession(callId, owner);
+        if (ownsCallState) {
+          this.clearUserTranscriptState(callId, userTranscriptOwner);
+        }
         // Carrier teardown already owns its outcome; a provider-ended call still needs hangup.
         if (reason === "completed" && (!ownsCallState || sessionClosed)) {
           return;
@@ -1090,34 +1096,39 @@ export class RealtimeCallHandler {
         if (ws.readyState === WebSocket.OPEN) {
           ws.close(reason === "error" ? 1011 : 1000, "Bridge disconnected");
         }
-        // A provisional replacement may fail before its bridge owner is assigned.
-        // The active predecessor still owns call termination until creation succeeds.
-        if (
-          (owner && !ownsCallState) ||
-          (!owner && hadPredecessorOnAdmission && this.activeBridgesByCallId.has(callId))
-        ) {
-          return;
+        if (ownsCallState) {
+          void emitCallEnd(reason);
         }
-        void emitCallEnd(reason);
       },
     };
-    let session: ActiveRealtimeVoiceBridge;
+    let candidate: ActiveRealtimeVoiceBridge | undefined;
     try {
-      session = harness.createBridge(bridgeParams);
+      candidate = harness.createBridge(bridgeParams);
     } catch (error) {
+      console.error("[voice-call] Failed to create realtime bridge:", error);
+    }
+    if (!candidate || provisionalCloseReason) {
       this.rollbackUserTranscriptOwnerAdoption(callId, userTranscriptAdoption);
+      try {
+        candidate?.close();
+      } catch (error) {
+        console.warn(
+          `[voice-call] Failed to close realtime bridge ${callSid}: ${formatErrorMessage(error)}`,
+        );
+      }
       harness.close();
       audioPacer.close();
+      const reason = provisionalCloseReason ?? "error";
       // A failed provisional replacement must not terminate its active predecessor.
       if (!hadPredecessorOnAdmission || !this.activeBridgesByCallId.has(callId)) {
-        void emitCallEnd("error");
+        void emitCallEnd(reason);
       }
       if (ws.readyState === WebSocket.OPEN) {
-        ws.close(1011, "Failed to create realtime bridge");
+        ws.close(reason === "error" ? 1011 : 1000, "Failed to create realtime bridge");
       }
-      console.error("[voice-call] Failed to create realtime bridge:", error);
       return null;
     }
+    const session = candidate;
     this.commitUserTranscriptOwnerAdoption(callId, userTranscriptAdoption);
     nativeConsultOwner.current = session;
     providerHandlesInputAudioBargeIn =

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -14,6 +14,7 @@ import {
   createRealtimeVoiceSessionHarness,
   createSpeechThresholdGate,
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+  REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
   readRealtimeVoiceConsultQuestion,
   readSpeakableRealtimeVoiceToolResult,
   type RealtimeVoiceForcedConsultHandle,
@@ -312,7 +313,7 @@ type UserTranscriptOwnerAdoption = {
   previous?: UserTranscriptState;
 };
 
-type RealtimeCallEndCause = "disconnect" | "shutdown" | "inactivity" | "error";
+type RealtimeCallEndCause = "completed" | "disconnect" | "shutdown" | "inactivity" | "error";
 
 // Each socket keeps its exact binding; the call map only grants current-generation
 // record termination. Replacement can retire old audio without a late close killing its successor.
@@ -843,6 +844,7 @@ export class RealtimeCallHandler {
         : undefined;
     // Providers may close synchronously before createBridge returns; no consult can exist yet.
     const nativeConsultOwner: { current?: ActiveRealtimeVoiceBridge } = {};
+    let sessionClosed = false;
     // Provisional ownership accepts callbacks fired during createBridge. Commit
     // retires the predecessor only after creation succeeds; failure restores it.
     const userTranscriptAdoption = this.beginUserTranscriptOwnerAdoption(callId);
@@ -852,6 +854,7 @@ export class RealtimeCallHandler {
       cfg: this.coreConfig,
       agentId,
       providerConfig,
+      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
       interruptResponseOnInputAudio,
       instructions,
       tools: this.config.tools,
@@ -1079,12 +1082,13 @@ export class RealtimeCallHandler {
           payload: { reason },
           final: true,
         });
-        if (reason !== "error") {
+        // Carrier teardown already owns its outcome; a provider-ended call still needs hangup.
+        if (reason === "completed" && (!ownsCallState || sessionClosed)) {
           return;
         }
         this.streamDisconnectLifecycle.retire(callSid, streamSid);
         if (ws.readyState === WebSocket.OPEN) {
-          ws.close(1011, "Bridge disconnected");
+          ws.close(reason === "error" ? 1011 : 1000, "Bridge disconnected");
         }
         // A provisional replacement may fail before its bridge owner is assigned.
         // The active predecessor still owns call termination until creation succeeds.
@@ -1094,7 +1098,7 @@ export class RealtimeCallHandler {
         ) {
           return;
         }
-        void emitCallEnd("error");
+        void emitCallEnd(reason);
       },
     };
     let session: ActiveRealtimeVoiceBridge;
@@ -1142,7 +1146,6 @@ export class RealtimeCallHandler {
       sendAudioToSession(audio);
     };
     const closeSession = session.close.bind(session);
-    let sessionClosed = false;
     session.close = () => {
       if (sessionClosed) {
         return;


### PR DESCRIPTION
Closes #132992

## What Problem This Solves

Fixes an issue where realtime phone audio could be decoded with the wrong format when using GPT-Live, and where a provider ending its session could leave a silent carrier call open. A provider closing during bridge creation could also be connected again or replace a working predecessor.

## Why This Change Was Made

The phone media owner now supplies its existing G.711 μ-law/8 kHz/mono contract explicitly. Normal WebSocket closure is distinguished from failure, and provider-ended calls use the existing carrier termination path. The handler records a terminal callback received during creation and rejects that candidate before connecting it or adopting its bridge and transcript state. Constructor failure and terminal creation share cleanup; transcript ownership is rolled back before disposing the rejected candidate, including when disposal emits final callbacks or throws.

## User Impact

Twilio and Telnyx use the correct audio format. Finished provider sessions end their carrier call, including during startup. Failed replacements leave the working call and transcript intact. Local caller teardown, explicit end-call control, and stale transport callbacks retain their ownership rules. No configuration, schema, dependency, or wire-protocol change is required. Current native GPT-Live function-tool limitations are documented.

## Evidence

- Before-fix regressions captured missing carrier audioFormat, incorrect normal WebSocket closure, and carrier connections left open after provider completion.
- The accepted startup review finding reproduced five failures before the final owner repair: missing carrier closure, reconnecting terminal candidates, replacing a live predecessor, and accepting post-close provisional transcripts.
- All 65 phone handler, lifecycle, and runtime-routing tests pass, including both terminal reasons, first-call and replacement creation, disposal exceptions, late callbacks, explicit end-call, and caller disconnect grace. OpenAI bridge/session/delegation/routing suites also passed.
- Extension type checking, type-aware lint, formatting, and diff checks passed. Fresh independent Codex review of the complete phone patch against its original base found no actionable P0–P2 defects.
- Live GA backend audio and browser speech succeeded on Blacksmith Testbox `tbx_01m185h6k7s0dnt939ehb0dtcg`: https://github.com/openclaw/openclaw/actions/runs/33286432360 . These are GA sibling proofs, not GPT-Live or carrier-call claims.
- GPT-Live live proof was attempted: the Platform account lacked model access and the hydrated subscription token was expired. No live carrier call was placed. The change reuses the existing codec conversion and WebSocket close contract; no external API payload shape changes.
- Direct upstream inspection: OpenAI Codex `63d213884daea50e4f74efc192cdc44f549b67d5`, `codex-rs/codex-api/src/endpoint/realtime_websocket/protocol_frameless_bidi.rs:38` (PCM audio) and `methods.rs:548` (normal versus abnormal close).
- Production LOC: +45/-29, net +16; tests: +245/-163, net +82. Growth represents the explicit format contract and provisional terminal state with exception-safe disposal, while duplicated startup cleanup is consolidated.

CI follow-through: the first hosted run exposed an outdated routing expectation for provider completion and an assertion assuming client socket close implied server bridge disposal. Tests now verify distinct provider/caller end reasons in carrier calls and durable history, and wait for actual server disposal. ClawSweeper's synchronous-creation finding is addressed by the final admission repair and its failing/passing regressions.

Provenance: original failures reproduced at `9d8bf3525072487320da72b6718ecf9c69dc3f4e`; exact introducing commit is not established. Shared core bridge reconnection semantics remain unchanged.

AI-assisted implementation and verification. Release-note context: correct realtime phone codecs, close carrier calls when their provider ends, and preserve live calls when a replacement fails during creation.
