### PR TITLE
fix: closed browser Talk sessions admit new agent work

### DIFF
--- a/extensions/openai/realtime-quicksilver-delegation-controller.ts
+++ b/extensions/openai/realtime-quicksilver-delegation-controller.ts
@@ -29,6 +29,7 @@ type OpenAIQuicksilverDelegationControllerOptions = {
   getSocket: () => OpenAIQuicksilverSocket | undefined;
   isCanceledError?: (error: unknown) => boolean;
   logger: Pick<PluginLogger, "debug" | "warn">;
+  onError?: (error: Error) => void;
   onFatalError: (error: Error) => void;
   onSessionStarted?: (expiresAt: number | undefined) => void;
   onTranscript?: (role: "user" | "assistant", text: string, done: boolean) => void;
@@ -111,6 +112,8 @@ export class OpenAIQuicksilverDelegationController {
       this.options.logger.warn(error.message);
       if (event.fatalAuth) {
         this.options.onFatalError(error);
+      } else {
+        this.options.onError?.(error);
       }
       return;
     }

--- a/extensions/openai/realtime-quicksilver-gateway-bridge-lifecycle.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge-lifecycle.test.ts
@@ -9,15 +9,19 @@ import {
 
 function createBridge(params: {
   runAgentConsult: (request: { prompt: string; signal?: AbortSignal }) => Promise<{ text: string }>;
+  onError?: (error: Error) => void;
+  onTranscript?: (role: "user" | "assistant", text: string, done: boolean) => void;
 }) {
   let socket: FakeSocket | undefined;
   const bridge = new OpenAIQuicksilverGatewayBridge({
     providerConfig: {},
-    model: "gpt-live-1-boulder-alpha",
+    model: "gpt-live-test",
     voice: "marin",
     audioFormat: { encoding: "pcm16", sampleRateHz: 24_000, channels: 1 },
     onAudio: vi.fn(),
     onClearAudio: vi.fn(),
+    onError: params.onError,
+    onTranscript: params.onTranscript,
     runAgentConsult: params.runAgentConsult,
     logger: { debug: vi.fn(), warn: vi.fn() },
     resolveAuth: vi.fn(async () => ({
@@ -61,6 +65,35 @@ function emitDelegation(socket: FakeSocket, id: string, text: string): void {
 }
 
 describe("OpenAI Quicksilver gateway bridge lifecycle", () => {
+  it("reports recoverable provider errors to the relay while preserving its connection", async () => {
+    const onError = vi.fn();
+    const onTranscript = vi.fn();
+    const harness = createBridge({
+      runAgentConsult: vi.fn(async () => ({ text: "Done" })),
+      onError,
+      onTranscript,
+    });
+    try {
+      await harness.bridge.connect();
+      const socket = harness.getSocket();
+      emitSideband(socket, { type: "error", error: { message: "temporary voice failure" } });
+      emitSideband(socket, {
+        type: "turn.done",
+        turn: { role: "assistant", transcript: "Recovered" },
+      });
+
+      expect(onError).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          message: "OpenAI GPT-Live sideband error: temporary voice failure",
+        }),
+      );
+      expect(onTranscript).toHaveBeenCalledWith("assistant", "Recovered", true);
+      expect(harness.bridge.isConnected()).toBe(true);
+    } finally {
+      harness.bridge.close();
+    }
+  });
+
   it("aborts an accepted delegation when the bridge closes normally", async () => {
     let consultSignal: AbortSignal | undefined;
     const runAgentConsult = vi.fn(async ({ signal }: { prompt: string; signal?: AbortSignal }) => {

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.ts
@@ -128,6 +128,7 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
         getSocket: () => this.sideband?.socket,
         isCanceledError: isAbortLikeError,
         logger: config.logger,
+        onError: config.onError,
         onFatalError: (error) => this.fail(error),
         onSessionStarted: (expiresAt) => {
           if (expiresAt !== undefined) {

--- a/extensions/openai/realtime-quicksilver-session-lifecycle.test.ts
+++ b/extensions/openai/realtime-quicksilver-session-lifecycle.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createBroker,
+  createRequest,
+  createResponseHarness,
+  emitSideband,
+} from "./realtime-quicksilver.test-helpers.js";
+
+describe("GPT-Live browser session lifecycle", () => {
+  it("releases browser transport while accepted delegation work finishes without late delivery", async () => {
+    let finishConsult!: (value: { text: string }) => void;
+    let consultSignal: AbortSignal | undefined;
+    const result = new Promise<{ text: string }>((resolve) => {
+      finishConsult = resolve;
+    });
+    const runAgentConsult = vi.fn(async ({ signal }: { prompt: string; signal?: AbortSignal }) => {
+      consultSignal = signal;
+      return await result;
+    });
+    const { realtime, sockets } = createBroker({ runAgentConsult });
+    try {
+      const reservation = await realtime.broker.createBrowserSession(
+        { providerConfig: {}, model: "gpt-live-test", runAgentConsult },
+        { type: "api-key", token: "platform-key" },
+      );
+      if (reservation.transport !== "webrtc") {
+        throw new Error("Expected WebRTC reservation");
+      }
+      await realtime.handler(
+        createRequest({ token: reservation.clientSecret }),
+        createResponseHarness().res,
+      );
+      const socket = sockets[0];
+      if (!socket) {
+        throw new Error("Expected sideband socket");
+      }
+      const delegation = {
+        type: "delegation.created",
+        item: {
+          type: "delegation",
+          target: "client",
+          id: "accepted-delegation",
+          content: [{ type: "input_text", text: "Finish this task" }],
+        },
+      };
+      emitSideband(socket, delegation);
+      await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledOnce());
+
+      await realtime.broker.cancelBrowserSession(reservation);
+      expect(socket.closed).toBe(true);
+      expect(realtime.getSessionCounts()).toEqual({
+        pending: 0,
+        inFlight: 0,
+        active: 0,
+        reservations: 0,
+      });
+      expect(consultSignal?.aborted).toBe(false);
+      emitSideband(socket, { ...delegation, item: { ...delegation.item, id: "late-delegation" } });
+      finishConsult({ text: "Finished after browser close" });
+      await result;
+      await Promise.resolve();
+      expect(runAgentConsult).toHaveBeenCalledOnce();
+      expect(socket.sent.some((payload) => payload.includes("Finished after browser close"))).toBe(
+        false,
+      );
+    } finally {
+      finishConsult({ text: "Finished" });
+      await realtime.cleanup();
+    }
+  });
+});

--- a/extensions/openai/realtime-quicksilver-session.ts
+++ b/extensions/openai/realtime-quicksilver-session.ts
@@ -11,6 +11,7 @@ import type {
   RealtimeVoiceBridge,
   RealtimeVoiceBrowserSession,
   RealtimeVoiceBrowserSessionCreateRequest,
+  RealtimeVoiceCloseDisposition,
   RealtimeVoiceProviderCapabilities,
 } from "openclaw/plugin-sdk/realtime-voice";
 import {
@@ -82,6 +83,7 @@ type PendingOffer = {
 
 type ActiveSession = {
   closing?: Promise<void>;
+  detach?: () => void;
   dispose: () => Promise<void> | void;
   handleFrame?: (data: RawData, isBinary: boolean) => void;
   socket?: OpenAIQuicksilverSocket;
@@ -122,10 +124,15 @@ function createResponseDeliveryWaiter(
   return { result, cancel: () => settle(false) };
 }
 
-function respondText(res: ServerResponse, statusCode: number, body: string): void {
+function respondRealtimeOffer(
+  res: ServerResponse,
+  statusCode: number,
+  body: string,
+  contentType = "text/plain; charset=utf-8",
+): void {
   res.statusCode = statusCode;
   res.setHeader("cache-control", "no-store");
-  res.setHeader("content-type", "text/plain; charset=utf-8");
+  res.setHeader("content-type", contentType);
   res.setHeader("x-content-type-options", "nosniff");
   res.end(body);
 }
@@ -229,7 +236,10 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
       reserveOpenAIQuicksilverSession(token);
       return session;
     },
-    close: async (session: ActiveSession): Promise<void> => {
+    close: async (
+      session: ActiveSession,
+      disposition: RealtimeVoiceCloseDisposition = "abort",
+    ): Promise<void> => {
       if (session.closing) {
         return session.closing;
       }
@@ -241,6 +251,9 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
       clearTimeout(session.timer);
       // Publish closing before synchronous wire disposal can re-enter this method.
       session.closing = Promise.resolve();
+      if (disposition === "detach") {
+        session.detach?.();
+      }
       session.closing = Promise.resolve(session.dispose());
       return session.closing;
     },
@@ -366,7 +379,7 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
         ?.abort(new Error("OpenAI realtime session canceled"));
       const active = activeSessions.get(session.clientSecret);
       if (active) {
-        await activeSessionLease.close(active);
+        await activeSessionLease.close(active, "detach");
       } else {
         releaseReservation(session.clientSecret);
       }
@@ -375,11 +388,11 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
 
   const handleOffer = async (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {
     const corsAllowed = applyRealtimeOfferCorsHeaders(req, res, params.getConfig());
+    if (!corsAllowed) {
+      respondRealtimeOffer(res, 403, "Origin not allowed");
+      return true;
+    }
     if (req.method === "OPTIONS") {
-      if (!corsAllowed) {
-        respondText(res, 403, "Origin not allowed");
-        return true;
-      }
       res.statusCode = 204;
       res.setHeader("cache-control", "no-store");
       res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
@@ -395,24 +408,20 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
       res.end();
       return true;
     }
-    if (!corsAllowed) {
-      respondText(res, 403, "Origin not allowed");
-      return true;
-    }
     if (req.method !== "POST") {
-      respondText(res, 405, "Method not allowed");
+      respondRealtimeOffer(res, 405, "Method not allowed");
       return true;
     }
     const mediaType = req.headers["content-type"]?.split(";", 1)[0]?.trim().toLowerCase();
     if (mediaType !== "application/sdp") {
-      respondText(res, 415, "Expected application/sdp");
+      respondRealtimeOffer(res, 415, "Expected application/sdp");
       return true;
     }
     prunePendingOffers();
     const token = readBearerToken(req);
     const offer = token ? pendingOffers.get(token) : undefined;
     if (!token || !offer || offer.expiresAt <= Date.now()) {
-      respondText(res, 401, "Invalid or expired realtime session token");
+      respondRealtimeOffer(res, 401, "Invalid or expired realtime session token");
       return true;
     }
     // Offer credentials are single-use so a captured browser request cannot join twice.
@@ -436,11 +445,7 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
     let responseDeliveryWaiter: ResponseDeliveryWaiter | undefined;
     const deliverActiveAnswer = async (status: number, answerSdp: string): Promise<boolean> => {
       responseDeliveryWaiter = createResponseDeliveryWaiter(res, detachBrowserAbort);
-      res.statusCode = status;
-      res.setHeader("cache-control", "no-store");
-      res.setHeader("content-type", "application/sdp");
-      res.setHeader("x-content-type-options", "nosniff");
-      res.end(answerSdp);
+      respondRealtimeOffer(res, status, answerSdp, "application/sdp");
       const delivered = await responseDeliveryWaiter.result;
       responseDeliveryWaiter = undefined;
       return delivered;
@@ -452,7 +457,7 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
         timeoutMs: 15_000,
       });
       if (!sdp.trim()) {
-        respondText(res, 400, "SDP offer is required");
+        respondRealtimeOffer(res, 400, "SDP offer is required");
         return true;
       }
       const upstreamSignal = AbortSignal.any([
@@ -475,7 +480,11 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
         try {
           assertOpenAIRealtimeAudioOnlyOffer(sdp);
         } catch (error) {
-          respondText(res, 400, error instanceof Error ? error.message : "Invalid SDP offer");
+          respondRealtimeOffer(
+            res,
+            400,
+            error instanceof Error ? error.message : "Invalid SDP offer",
+          );
           return true;
         }
         if (offer.auth.type !== "api-key") {
@@ -568,11 +577,7 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
         fetchImpl: params.fetchImpl,
       });
       if (call.kind === "ga-realtime") {
-        res.statusCode = call.status;
-        res.setHeader("cache-control", "no-store");
-        res.setHeader("content-type", "application/sdp");
-        res.setHeader("x-content-type-options", "nosniff");
-        res.end(call.answerSdp);
+        respondRealtimeOffer(res, call.status, call.answerSdp, "application/sdp");
         return true;
       }
       const runAgentConsult = offer.request.runAgentConsult;
@@ -594,7 +599,9 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
       const delegations = new OpenAIQuicksilverDelegationController({
         getSocket: () => connected.socket,
         logger: params.logger,
-        onFatalError: () => {
+        onError: (error) => offer.request.gatewayControl?.onError?.(error),
+        onFatalError: (error) => {
+          offer.request.gatewayControl?.onError?.(error);
           if (session) {
             void activeSessionLease.close(session);
           }
@@ -612,6 +619,7 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
         signal: abortController.signal,
       });
       session = activeSessionLease.adopt(token, {
+        detach: () => delegations.detach(),
         dispose: () => {
           delegations.stop(new Error("GPT-Live delegation stopped"));
           abortController.abort(new Error("GPT-Live session closed"));
@@ -627,6 +635,7 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
           } catch {
             // Socket teardown is best effort after ownership has been released.
           }
+          offer.request.gatewayControl?.onClose?.("completed");
         },
         handleFrame: (data, isBinary) => delegations.handleFrame(data, isBinary),
         socket: connected.socket,
@@ -654,17 +663,17 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
       );
       return true;
     } catch (error) {
+      const sessionError =
+        error instanceof Error ? error : new Error("OpenAI realtime session failed");
+      offer.request.gatewayControl?.onError?.(sessionError);
       if (session) {
         await activeSessionLease.close(session);
       }
+      offer.request.gatewayControl?.onClose?.("error");
       if (browserDisconnected) {
         return true;
       }
-      respondText(
-        res,
-        502,
-        error instanceof Error ? error.message : "OpenAI realtime session failed",
-      );
+      respondRealtimeOffer(res, 502, sessionError.message);
       return true;
     } finally {
       responseDeliveryWaiter?.cancel();

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -179,10 +179,25 @@ async function createOpenAIRealtimeBrowserSession(
   }
 
   const model = req.model ?? config.model ?? OPENAI_REALTIME_DEFAULT_MODEL;
-  if (req.gatewayControl) {
-    if (isOpenAIGptLiveModel(model)) {
-      throw new Error("gateway-control-v1 supports OpenAI GA Realtime models only");
+  if (isOpenAIGptLiveModel(model)) {
+    if (!quicksilverBroker) {
+      throw new Error("OpenAI GPT-Live browser session broker is unavailable");
     }
+    const configuredVoice = normalizeOptionalString(rawConfig?.speakerVoice ?? rawConfig?.voice);
+    const quicksilverRequest = {
+      ...req,
+      model,
+      instructions: buildOpenAIQuicksilverInstructions(req.instructions),
+      ...(req.voice ? {} : configuredVoice ? { voice: configuredVoice } : {}),
+    };
+    const auth = await resolveOpenAIQuicksilverBridgeAuth({
+      configuredApiKey: config.apiKey,
+      cfg: req.cfg,
+      agentId: req.agentId,
+    });
+    return await quicksilverBroker.createBrowserSession(quicksilverRequest, auth);
+  }
+  if (req.gatewayControl) {
     if (!quicksilverBroker) {
       throw new Error("OpenAI realtime browser session broker is unavailable");
     }
@@ -252,24 +267,6 @@ async function createOpenAIRealtimeBrowserSession(
       },
       { type: "api-key", token: auth.value },
     );
-  }
-  if (isOpenAIGptLiveModel(model)) {
-    if (!quicksilverBroker) {
-      throw new Error("OpenAI GPT-Live browser session broker is unavailable");
-    }
-    const configuredVoice = normalizeOptionalString(rawConfig?.speakerVoice ?? rawConfig?.voice);
-    const quicksilverRequest = {
-      ...req,
-      model,
-      instructions: buildOpenAIQuicksilverInstructions(req.instructions),
-      ...(req.voice ? {} : configuredVoice ? { voice: configuredVoice } : {}),
-    };
-    const auth = await resolveOpenAIQuicksilverBridgeAuth({
-      configuredApiKey: config.apiKey,
-      cfg: req.cfg,
-      agentId: req.agentId,
-    });
-    return await quicksilverBroker.createBrowserSession(quicksilverRequest, auth);
   }
   const { session, voice } = buildOpenAIRealtimeBrowserSessionConfig(req, config, model);
   const auth = await resolveOpenAIRealtimePlatformAuth({

--- a/src/gateway/server-methods/talk-client-create.ts
+++ b/src/gateway/server-methods/talk-client-create.ts
@@ -44,7 +44,10 @@ import {
   resolveTalkAgentConsultAuthority,
 } from "../talk-client-gateway-control.js";
 import { formatForLog } from "../ws-log.js";
-import { rememberLegacyVoiceBinding } from "./talk-client-legacy-voice-bindings.js";
+import {
+  forgetLegacyVoiceBinding,
+  rememberLegacyVoiceBinding,
+} from "./talk-client-legacy-voice-bindings.js";
 import {
   buildRealtimeInstructions,
   buildRealtimeVoiceLaunchOptions,
@@ -221,15 +224,21 @@ export const createTalkClient: GatewayRequestHandler = async ({
           ? normalizeOptionalString(realtimeContext.instructions)
           : buildRealtimeInstructions(realtimeContext.instructions);
       const requestedVoiceSessionId = normalizeOptionalString(params.voiceSessionId);
-      let activeVoiceSessionId = wantsGatewayControl
+      const ownsProvider =
+        wantsGatewayControl || providerCapabilities?.handlesAgentConsult === true;
+      let activeVoiceSessionId = ownsProvider
         ? (requestedVoiceSessionId ?? randomUUID())
         : undefined;
+      let logicalSessionCreated = false;
       const ownerConnId = normalizeOptionalString(client?.connId);
-      if (wantsGatewayControl && !ownerConnId) {
+      if (ownsProvider && !ownerConnId) {
         respond(
           false,
           undefined,
-          errorShape(ErrorCodes.UNAVAILABLE, "gateway-control-v1 requires a connected client"),
+          errorShape(
+            ErrorCodes.UNAVAILABLE,
+            "Gateway-owned realtime sessions require a connected client",
+          ),
         );
         return;
       }
@@ -243,16 +252,21 @@ export const createTalkClient: GatewayRequestHandler = async ({
         getVoiceSessionId: () => activeVoiceSessionId,
         initialItems,
       });
-      const runAgentConsult: NonNullable<
-        InternalRealtimeVoiceBrowserSessionCreateRequest["runAgentConsult"]
-      > = consultRunner.runPrompt;
-      const gatewayControlOwner = wantsGatewayControl
+      const gatewayControlOwner = ownsProvider
         ? createTalkClientGatewayControlOwner({
             voiceSessionId: activeVoiceSessionId!,
             providerId: resolution.provider.id,
             sessionKey,
             connId: ownerConnId!,
             context,
+            assertConnectionOpen: () => {
+              const currentConnections = context.getClientConnIds?.(
+                (candidate) => candidate === client,
+              );
+              if (!currentConnections?.has(ownerConnId!)) {
+                throw new Error("Realtime voice client disconnected");
+              }
+            },
             runAgentConsult: consultRunner.runArgs,
             appendTranscript: ({ entryId, role, text }) =>
               appendClientVoiceTranscript({
@@ -270,12 +284,19 @@ export const createTalkClient: GatewayRequestHandler = async ({
                 voiceSessionId: activeVoiceSessionId!,
               }),
             closeLogicalSession: async () => {
-              await closeClientVoiceSession({
-                agentId,
-                sessionKey,
-                voiceSessionId: activeVoiceSessionId!,
-                config: runtimeConfig,
-              });
+              if (logicalSessionCreated) {
+                await closeClientVoiceSession({
+                  agentId,
+                  sessionKey,
+                  voiceSessionId: activeVoiceSessionId!,
+                  config: runtimeConfig,
+                });
+                forgetLegacyVoiceBinding(
+                  ownerConnId!,
+                  params.sessionKey?.trim() || sessionKey,
+                  activeVoiceSessionId!,
+                );
+              }
             },
           })
         : undefined;
@@ -287,21 +308,32 @@ export const createTalkClient: GatewayRequestHandler = async ({
         providerConfig: resolution.providerConfig,
         instructions,
         initialItems,
-        runAgentConsult,
+        runAgentConsult: gatewayControlOwner?.runAgentConsult ?? consultRunner.runPrompt,
         ...(gatewayControlOwner ? { gatewayControl: gatewayControlOwner.control } : {}),
         ...(tools.length > 0 ? { tools } : {}),
         ...launchOptions,
       };
-      const session = await resolution.provider.createBrowserSession(browserSessionRequest);
-      // Client-owned voice records are minted only for client-owned transports;
-      // relay sessions are created via talk.session.create and keyed by relaySessionId.
-      // Widening this guard would hand relay calls a mismatched voiceSessionId.
-      if (
-        (session.transport === "webrtc" || session.transport === "provider-websocket") &&
-        !isUnsupportedBrowserWebRtcSession(session) &&
-        (!transport || session.transport === transport)
-      ) {
-        try {
+      let session: Awaited<ReturnType<typeof resolution.provider.createBrowserSession>> | undefined;
+      let delivered = false;
+      try {
+        session = await resolution.provider.createBrowserSession(browserSessionRequest);
+        const createdSession = session;
+        await gatewayControlOwner?.adoptProvider(() =>
+          cancelInternalRealtimeVoiceBrowserSession({
+            provider: resolution.provider,
+            request: browserSessionRequest,
+            session: createdSession,
+          }),
+        );
+        gatewayControlOwner?.assertOpen();
+        // Client-owned voice records are minted only for client-owned transports;
+        // relay sessions are created via talk.session.create and keyed by relaySessionId.
+        // Widening this guard would hand relay calls a mismatched voiceSessionId.
+        if (
+          (session.transport === "webrtc" || session.transport === "provider-websocket") &&
+          !isUnsupportedBrowserWebRtcSession(session) &&
+          (!transport || session.transport === transport)
+        ) {
           const sessionEntryDeadlineAt =
             session.expiresAt === undefined
               ? undefined
@@ -317,88 +349,78 @@ export const createTalkClient: GatewayRequestHandler = async ({
             sessionKey,
             creation: resolveSandboxedSessionCreation(client, runtimeConfig),
             deadlineAt: sessionEntryDeadlineAt,
+            ...(gatewayControlOwner ? { assertCommitAllowed: gatewayControlOwner.assertOpen } : {}),
           });
-        } catch (error) {
-          try {
-            await cancelInternalRealtimeVoiceBrowserSession({
-              provider: resolution.provider,
-              request: browserSessionRequest,
-              session,
+          gatewayControlOwner?.assertOpen();
+          // Recovering 6h-abandoned calls (and retrying their digests) is not on the
+          // start path; running it inline would delay use of time-sensitive provider
+          // credentials behind slow channel sends. Fire it off the response path.
+          void closeStaleClientVoiceSessions({
+            agentId,
+            config: runtimeConfig,
+            excludeVoiceSessionId: normalizeOptionalString(params.voiceSessionId),
+            warn: (message) => context.logGateway.warn(`talk voice session recovery: ${message}`),
+          }).catch((error: unknown) =>
+            context.logGateway.warn(`talk voice session recovery failed: ${formatForLog(error)}`),
+          );
+          const voiceSessionId = createOrResumeClientVoiceSession({
+            agentId,
+            sessionKey,
+            provider: resolution.provider.id,
+            origin: "client",
+            // Deployed clients sent sessionKey before transcripts existed, so capability
+            // must be negotiated explicitly; declaring it turns the confirmation gate on.
+            transcriptCapable:
+              wantsGatewayControl || params.capabilities?.includes("voice-transcript") === true,
+            voiceSessionId: activeVoiceSessionId ?? requestedVoiceSessionId,
+          });
+          activeVoiceSessionId = voiceSessionId;
+          logicalSessionCreated = true;
+          const connId = ownerConnId;
+          if (connId) {
+            rememberLegacyVoiceBinding({
+              connId,
+              sessionKey: params.sessionKey?.trim() || sessionKey,
+              voiceSessionId,
             });
-          } catch (cancelError) {
-            context.logGateway.warn(
-              `talk browser session cleanup failed: ${formatForLog(cancelError)}`,
-            );
           }
-          throw error;
+          gatewayControlOwner?.activate();
+          respond(
+            true,
+            {
+              ...session,
+              voiceSessionId,
+              ...(wantsGatewayControl ? { clientControl: { owner: "gateway" as const } } : {}),
+            },
+            undefined,
+          );
+          delivered = true;
+          return;
         }
-        // Recovering 6h-abandoned calls (and retrying their digests) is not on the
-        // start path; running it inline would delay use of time-sensitive provider
-        // credentials behind slow channel sends. Fire it off the response path.
-        void closeStaleClientVoiceSessions({
-          agentId,
-          config: runtimeConfig,
-          excludeVoiceSessionId: normalizeOptionalString(params.voiceSessionId),
-          warn: (message) => context.logGateway.warn(`talk voice session recovery: ${message}`),
-        }).catch((error: unknown) =>
-          context.logGateway.warn(`talk voice session recovery failed: ${formatForLog(error)}`),
-        );
-        const voiceSessionId = createOrResumeClientVoiceSession({
-          agentId,
-          sessionKey,
-          provider: resolution.provider.id,
-          origin: "client",
-          // Deployed clients sent sessionKey before transcripts existed, so capability
-          // must be negotiated explicitly; declaring it turns the confirmation gate on.
-          transcriptCapable:
-            wantsGatewayControl || params.capabilities?.includes("voice-transcript") === true,
-          voiceSessionId: activeVoiceSessionId ?? requestedVoiceSessionId,
-        });
-        activeVoiceSessionId = voiceSessionId;
-        const connId = ownerConnId;
-        if (connId) {
-          rememberLegacyVoiceBinding({
-            connId,
-            sessionKey: params.sessionKey?.trim() || sessionKey,
-            voiceSessionId,
-          });
+        if (transport) {
+          rejectTalkClientRequest(
+            respond,
+            ErrorCodes.UNAVAILABLE,
+            `Realtime provider "${resolution.provider.id}" does not support requested browser transport "${transport}"`,
+          );
+          return;
         }
-        gatewayControlOwner?.activate(() =>
-          cancelInternalRealtimeVoiceBrowserSession({
-            provider: resolution.provider,
-            request: browserSessionRequest,
-            session,
-          }),
-        );
-        respond(
-          true,
-          {
-            ...session,
-            voiceSessionId,
-            ...(wantsGatewayControl ? { clientControl: { owner: "gateway" as const } } : {}),
-          },
-          undefined,
-        );
-        return;
-      }
-      try {
-        await cancelInternalRealtimeVoiceBrowserSession({
-          provider: resolution.provider,
-          request: browserSessionRequest,
-          session,
-        });
-      } catch (cancelError) {
-        context.logGateway.warn(
-          `talk browser session cleanup failed: ${formatForLog(cancelError)}`,
-        );
-      }
-      if (transport) {
-        rejectTalkClientRequest(
-          respond,
-          ErrorCodes.UNAVAILABLE,
-          `Realtime provider "${resolution.provider.id}" does not support requested browser transport "${transport}"`,
-        );
-        return;
+      } finally {
+        if (!delivered) {
+          try {
+            if (gatewayControlOwner) {
+              await gatewayControlOwner.close();
+            } else if (session) {
+              await cancelInternalRealtimeVoiceBrowserSession({
+                provider: resolution.provider,
+                request: browserSessionRequest,
+                session,
+              });
+            }
+          } catch (error) {
+            context.logGateway.warn(`talk browser session cleanup failed: ${formatForLog(error)}`);
+          }
+        }
       }
     }
     rejectTalkClientRequest(

--- a/src/gateway/server-methods/talk-client.test.ts
+++ b/src/gateway/server-methods/talk-client.test.ts
@@ -21,12 +21,89 @@ import {
 } from "../../talk/client-voice-session.js";
 import { clientVoiceSessionTesting } from "../../talk/client-voice-session.test-support.js";
 import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
+import { closeTalkClientGatewayControlSession } from "../talk-client-gateway-control.js";
+import { cleanupTalkConnection } from "../talk-session-registry.js";
+import { readLegacyVoiceBinding } from "./talk-client-legacy-voice-bindings.js";
 import { talkClientHandlers } from "./talk-client.js";
+
+const voiceMocks = vi.hoisted(() => ({
+  resolveConfiguredRealtimeVoiceProvider: vi.fn(),
+  consultRealtimeVoiceAgent: vi.fn(),
+}));
+
+vi.mock("../../talk/provider-resolver.js", () => ({
+  resolveConfiguredRealtimeVoiceProvider: voiceMocks.resolveConfiguredRealtimeVoiceProvider,
+  resolveRealtimeVoiceProviderCapabilities: ({
+    provider,
+  }: {
+    provider: { capabilities: unknown };
+  }) => provider.capabilities,
+}));
+vi.mock("../../talk/provider-registry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../talk/provider-registry.js")>()),
+  listRealtimeVoiceProviders: () => [],
+}));
+vi.mock("../../talk/agent-consult-runtime.js", () => ({
+  consultRealtimeVoiceAgent: voiceMocks.consultRealtimeVoiceAgent,
+}));
+vi.mock("../../plugins/runtime/index.js", () => ({
+  createPluginRuntime: () => ({ agent: {} }),
+}));
+vi.mock("../../agents/realtime-bootstrap-context.js", () => ({
+  resolveRealtimeBootstrapContextInstructions: async () => undefined,
+}));
 
 const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
 const sessionKey = "agent:main:main";
 const sessionId = "voice-transcript-session";
 let tempDir: string;
+let ownedVoiceSessionId: string | undefined;
+type BrowserRequest = Parameters<
+  NonNullable<import("../../plugins/types.js").RealtimeVoiceProviderPlugin["createBrowserSession"]>
+>[0];
+const browserSession = {
+  provider: "openai",
+  transport: "webrtc" as const,
+  clientSecret: "test-pending-offer",
+  offerUrl: "/plugins/openai/realtime/calls",
+};
+
+function configureDelegatedBrowserProvider(
+  createBrowserSession: (request: BrowserRequest) => Promise<typeof browserSession>,
+) {
+  const cancelBrowserSession = vi.fn(async () => undefined);
+  const provider = {
+    id: "openai",
+    capabilities: { transports: ["webrtc"], handlesAgentConsult: true, supportsToolCalls: false },
+    createBrowserSession,
+  };
+  Object.defineProperty(provider, Symbol.for("openclaw.internal.realtime-voice-provider.v1"), {
+    value: { isBrowserSessionConfigured: () => true, cancelBrowserSession },
+  });
+  voiceMocks.resolveConfiguredRealtimeVoiceProvider.mockReturnValue({
+    provider,
+    providerConfig: {},
+  });
+  const client = { connId: "conn-close" };
+  const clients = new Set([client]);
+  return {
+    cancelBrowserSession,
+    client,
+    clients,
+    context: {
+      getRuntimeConfig: () => ({}),
+      getClientConnIds: (filter?: (candidate: typeof client) => boolean) =>
+        new Set(
+          [...clients]
+            .filter((candidate) => !filter || filter(candidate))
+            .map((candidate) => candidate.connId),
+        ),
+      chatAbortControllers: new Map(),
+      logGateway: { warn: vi.fn() },
+      broadcastToConnIds: vi.fn(),
+    },
+  };
+}
 
 async function invokeTranscript(params: Record<string, unknown>) {
   const respond = vi.fn();
@@ -51,6 +128,8 @@ async function invokeClose(params: Record<string, unknown>) {
 
 describe("talk.client.transcript", () => {
   beforeEach(async () => {
+    vi.clearAllMocks();
+    ownedVoiceSessionId = undefined;
     tempDir = await fs.realpath(
       await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-talk-transcript-")),
     );
@@ -62,6 +141,14 @@ describe("talk.client.transcript", () => {
   });
 
   afterEach(async () => {
+    if (ownedVoiceSessionId) {
+      await closeTalkClientGatewayControlSession({
+        voiceSessionId: ownedVoiceSessionId,
+        sessionKey,
+        connId: "conn-close",
+      });
+    }
+    cleanupTalkConnection("conn-close", { warn: vi.fn() });
     clientVoiceSessionTesting.reset();
     resetClientVoiceConfirmationStateForTest();
     vi.useRealTimers();
@@ -188,6 +275,127 @@ describe("talk.client.transcript", () => {
 
     expect(await invokeClose(params)).toHaveBeenCalledWith(true, { ok: true }, undefined);
     expect(await invokeClose(params)).toHaveBeenCalledWith(true, { ok: true }, undefined);
+  });
+
+  it.each(["close", "disconnect"] as const)(
+    "revokes a delegated browser session on %s without abandoning accepted work",
+    async (ending) => {
+      const createBrowserSession = vi.fn(async (_request: BrowserRequest) => browserSession);
+      const { cancelBrowserSession, client, clients, context } =
+        configureDelegatedBrowserProvider(createBrowserSession);
+      let finishConsult!: (value: { text: string }) => void;
+      const acceptedResult = new Promise<{ text: string }>((resolve) => {
+        finishConsult = resolve;
+      });
+      voiceMocks.consultRealtimeVoiceAgent
+        .mockResolvedValue({ text: "Late task started" })
+        .mockReturnValueOnce(acceptedResult);
+      const respond = vi.fn();
+      await talkClientHandlers["talk.client.create"]?.({
+        params: { sessionKey, provider: "openai", model: "gpt-live-test" },
+        respond,
+        context,
+        client,
+      } as never);
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining(browserSession),
+        undefined,
+      );
+      const result = respond.mock.calls[0]?.[1] as { voiceSessionId: string };
+      ownedVoiceSessionId = result.voiceSessionId;
+      const runAgentConsult = createBrowserSession.mock.calls[0]?.[0].runAgentConsult;
+      expect(runAgentConsult).toBeTypeOf("function");
+      const acceptedSignal = new AbortController().signal;
+      const accepted = runAgentConsult!({
+        prompt: "Read the project status",
+        signal: acceptedSignal,
+      });
+      await vi.waitFor(() => expect(voiceMocks.consultRealtimeVoiceAgent).toHaveBeenCalledOnce());
+
+      try {
+        if (ending === "close") {
+          expect(
+            await invokeClose({ sessionKey, voiceSessionId: ownedVoiceSessionId }),
+          ).toHaveBeenCalledWith(true, { ok: true }, undefined);
+        } else {
+          clients.delete(client);
+          cleanupTalkConnection("conn-close", context.logGateway);
+        }
+        await expect(runAgentConsult!({ prompt: "Start another task" })).rejects.toThrow(
+          /closed|stopped/i,
+        );
+        await vi.waitFor(() => expect(cancelBrowserSession).toHaveBeenCalledOnce());
+        await vi.waitFor(() =>
+          expect(readLegacyVoiceBinding(client.connId, sessionKey)).toBeUndefined(),
+        );
+        const acceptedConsult = voiceMocks.consultRealtimeVoiceAgent.mock.calls[0]?.[0] as {
+          abortSignal: AbortSignal;
+        };
+        expect(acceptedConsult.abortSignal.aborted).toBe(false);
+        expect(voiceMocks.consultRealtimeVoiceAgent).toHaveBeenCalledOnce();
+      } finally {
+        finishConsult({ text: "Accepted work finished" });
+        await accepted;
+      }
+    },
+  );
+
+  it("cancels a provider that resolves after its browser disconnects without creating a chat", async () => {
+    let finishCreation!: (value: typeof browserSession) => void;
+    const created = new Promise<typeof browserSession>((resolve) => {
+      finishCreation = resolve;
+    });
+    const createBrowserSession = vi.fn(async (_request: BrowserRequest) => await created);
+    const { cancelBrowserSession, client, clients, context } =
+      configureDelegatedBrowserProvider(createBrowserSession);
+    const pendingSessionKey = "agent:main:pending-voice";
+    const respond = vi.fn();
+    const starting = talkClientHandlers["talk.client.create"]!({
+      params: { sessionKey: pendingSessionKey, provider: "openai", model: "gpt-live-test" },
+      respond,
+      context,
+      client,
+    } as never);
+    await vi.waitFor(() => expect(createBrowserSession).toHaveBeenCalledOnce());
+    const runAgentConsult = createBrowserSession.mock.calls[0]?.[0].runAgentConsult;
+    try {
+      await expect(runAgentConsult!({ prompt: "Too early" })).rejects.toThrow(/not active/);
+      clients.delete(client);
+      cleanupTalkConnection(client.connId, context.logGateway);
+    } finally {
+      finishCreation(browserSession);
+      await starting;
+    }
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringMatching(/closed|disconnected/) }),
+    );
+    expect(cancelBrowserSession).toHaveBeenCalledOnce();
+    expect(loadSessionEntry({ agentId: "main", sessionKey: pendingSessionKey })).toBeUndefined();
+    expect(voiceMocks.consultRealtimeVoiceAgent).not.toHaveBeenCalled();
+  });
+
+  it("does not create a provider after the browser disconnects during context preparation", async () => {
+    const createBrowserSession = vi.fn(async (_request: BrowserRequest) => browserSession);
+    const { client, clients, context } = configureDelegatedBrowserProvider(createBrowserSession);
+    const respond = vi.fn();
+    const starting = talkClientHandlers["talk.client.create"]!({
+      params: { sessionKey, provider: "openai", model: "gpt-live-test" },
+      respond,
+      context,
+      client,
+    } as never);
+    clients.delete(client);
+    cleanupTalkConnection(client.connId, context.logGateway);
+    await starting;
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("disconnected") }),
+    );
+    expect(createBrowserSession).not.toHaveBeenCalled();
   });
 
   it("truncates UTF-16 safely and writes assistant metadata", async () => {

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -94,6 +94,7 @@ const mocks = vi.hoisted(() => ({
   consultRealtimeVoiceAgent: vi.fn(async (_params?: unknown) => ({ text: "agent answer" })),
   closeTalkClientGatewayControlSession: vi.fn(async () => false),
   gatewayControlActivate: vi.fn(),
+  gatewayControlAdoptProvider: vi.fn(async () => undefined),
   gatewayControlClose: vi.fn(async () => undefined),
   gatewayControl: { bindBridge: vi.fn() },
   createTalkClientGatewayControlOwner: vi.fn(),
@@ -3031,11 +3032,19 @@ describe("talk.client.create handler", () => {
     mocks.createOrResumeClientVoiceSession.mockReturnValue("voice-test");
     mocks.resolveClientVoiceAgentSessionId.mockReturnValue("session-main");
     mocks.closeTalkClientGatewayControlSession.mockResolvedValue(false);
-    mocks.createTalkClientGatewayControlOwner.mockReturnValue({
-      activate: mocks.gatewayControlActivate,
-      close: mocks.gatewayControlClose,
-      control: mocks.gatewayControl,
-    });
+    mocks.createTalkClientGatewayControlOwner.mockImplementation(
+      (params: {
+        runAgentConsult: (args: unknown, signal?: AbortSignal) => Promise<{ text: string }>;
+      }) => ({
+        activate: mocks.gatewayControlActivate,
+        adoptProvider: mocks.gatewayControlAdoptProvider,
+        close: mocks.gatewayControlClose,
+        assertOpen: vi.fn(),
+        control: mocks.gatewayControl,
+        runAgentConsult: ({ prompt, signal }: { prompt: string; signal?: AbortSignal }) =>
+          params.runAgentConsult({ question: prompt }, signal),
+      }),
+    );
   });
 
   it("builds realtime launch defaults from talk.realtime", () => {
@@ -3308,7 +3317,8 @@ describe("talk.client.create handler", () => {
         transcriptCapable: true,
       }),
     );
-    expect(mocks.gatewayControlActivate).toHaveBeenCalledWith(expect.any(Function));
+    expect(mocks.gatewayControlAdoptProvider).toHaveBeenCalledWith(expect.any(Function));
+    expect(mocks.gatewayControlActivate).toHaveBeenCalledOnce();
     expectRespondOk(respond, {
       ...browserSession,
       voiceSessionId: "voice-gateway",

--- a/src/gateway/talk-client-gateway-control.test.ts
+++ b/src/gateway/talk-client-gateway-control.test.ts
@@ -47,7 +47,8 @@ describe("Talk client Gateway control owner", () => {
         flushTranscript: vi.fn(async () => undefined),
         closeLogicalSession,
       });
-      owner.activate(closeProvider);
+      await owner.adoptProvider(closeProvider);
+      owner.activate();
       owner.control.onEvent?.({
         direction: "server",
         type: "response.created",
@@ -115,7 +116,8 @@ describe("Talk client Gateway control owner", () => {
       closeLogicalSession,
     });
     owner.control.bindBridge(bridge);
-    owner.activate(closeProvider);
+    await owner.adoptProvider(closeProvider);
+    owner.activate();
 
     owner.control.onTranscript?.("user", "check the repository", true);
     owner.control.onToolCall?.({
@@ -173,7 +175,8 @@ describe("Talk client Gateway control owner", () => {
       closeLogicalSession: vi.fn(async () => undefined),
     });
     owner.control.bindBridge(bridge);
-    owner.activate(vi.fn(async () => undefined));
+    await owner.adoptProvider(vi.fn(async () => undefined));
+    owner.activate();
     owner.control.onToolCall?.({
       itemId: "item-status",
       callId: "call-status",
@@ -247,7 +250,8 @@ describe("Talk client Gateway control owner", () => {
       closeLogicalSession: vi.fn(async () => undefined),
     });
     owner.control.bindBridge(bridge);
-    owner.activate(vi.fn(async () => undefined));
+    await owner.adoptProvider(vi.fn(async () => undefined));
+    owner.activate();
     owner.control.onToolCall?.({
       itemId: "item-long",
       callId: "call-long",
@@ -293,7 +297,8 @@ describe("Talk client Gateway control owner", () => {
       flushTranscript: vi.fn(async () => undefined),
       closeLogicalSession,
     });
-    owner.activate(closeProvider);
+    await owner.adoptProvider(closeProvider);
+    owner.activate();
 
     cleanupTalkConnection("conn-disconnect", { warn: vi.fn() });
 
@@ -313,7 +318,8 @@ describe("Talk client Gateway control owner", () => {
       flushTranscript: vi.fn(async () => undefined),
       closeLogicalSession,
     });
-    owner.activate(vi.fn(() => Promise.reject(new Error("provider close failed"))));
+    await owner.adoptProvider(vi.fn(() => Promise.reject(new Error("provider close failed"))));
+    owner.activate();
 
     await expect(owner.close()).rejects.toThrow("provider close failed");
     expect(closeLogicalSession).toHaveBeenCalledOnce();
@@ -359,7 +365,8 @@ describe("Talk client Gateway control owner", () => {
     const closeSecond = vi.fn(async () => undefined);
     const first = createTalkClientGatewayControlOwner(common);
     first.control.bindBridge(firstBridge);
-    first.activate(closeFirst);
+    await first.adoptProvider(closeFirst);
+    first.activate();
     first.control.onTranscript?.("user", "first transport", true);
     first.control.onToolCall?.({
       itemId: "item-replacement",
@@ -371,7 +378,8 @@ describe("Talk client Gateway control owner", () => {
 
     const second = createTalkClientGatewayControlOwner(common);
     second.control.bindBridge(secondBridge);
-    second.activate(closeSecond);
+    await second.adoptProvider(closeSecond);
+    second.activate();
     await vi.waitFor(() => expect(closeFirst).toHaveBeenCalledOnce());
     first.control.onClose?.("completed");
     first.control.onTranscript?.("user", "stale transport", true);

--- a/src/gateway/talk-client-gateway-control.ts
+++ b/src/gateway/talk-client-gateway-control.ts
@@ -23,8 +23,12 @@ import {
   authorizeClientVoiceConfirmation,
   bindAuthorizedClientVoiceConfirmation,
 } from "../talk/client-voice-confirmation.js";
-import { registerClientVoiceConsultRun } from "../talk/client-voice-session.js";
+import {
+  assertClientVoiceSessionOpen,
+  registerClientVoiceConsultRun,
+} from "../talk/client-voice-session.js";
 import type {
+  RealtimeVoiceAgentConsultRunner,
   RealtimeVoiceBridge,
   RealtimeVoiceGatewayControl,
   RealtimeVoiceToolCallEvent,
@@ -41,7 +45,9 @@ import { formatError } from "./server-utils.js";
 import { registerTalkConnectionCleanup } from "./talk-session-registry.js";
 
 type GatewayControlOwner = {
-  activate: (closeProvider: () => Promise<void>) => void;
+  adoptProvider: (closeProvider: () => Promise<void>) => Promise<void>;
+  activate: () => void;
+  assertOpen: () => void;
   close: (options?: {
     preserveLogicalSession?: boolean;
     preserveRuns?: boolean;
@@ -49,10 +55,13 @@ type GatewayControlOwner = {
   }) => Promise<void>;
   connId: string;
   control: RealtimeVoiceGatewayControl;
+  runAgentConsult: RealtimeVoiceAgentConsultRunner;
   sessionKey: string;
+  voiceSessionId: string;
 };
 
 const owners = new Map<string, GatewayControlOwner>();
+const pendingOwners = new Set<GatewayControlOwner>();
 
 const REALTIME_VOICE_CONTEXT_MAX_UTF8_BYTES = 8_000;
 const REALTIME_CONTROL_MAX_PENDING = 8;
@@ -249,6 +258,15 @@ export function createTalkClientAgentConsultRunner(params: {
     if (!voiceSessionId) {
       throw new Error("Realtime browser voice session is not ready for agent consult");
     }
+    // Relays own admission before their lazy record registration. Browser callbacks
+    // must validate the durable call before accepting a new run.
+    if (!params.registerRun) {
+      assertClientVoiceSessionOpen({
+        agentId: params.agentId,
+        sessionKey: params.sessionKey,
+        voiceSessionId,
+      });
+    }
     const confirmationGrant = parsedArgs.confirmationId
       ? authorizeClientVoiceConfirmation({
           agentId: params.agentId,
@@ -326,6 +344,7 @@ export function createTalkClientGatewayControlOwner(params: {
   sessionKey: string;
   connId: string;
   context: Pick<GatewayRequestContext, "broadcastToConnIds" | "logGateway">;
+  assertConnectionOpen?: () => void;
   runAgentConsult: (args: unknown, signal: AbortSignal) => Promise<{ text: string }>;
   appendTranscript: (entry: {
     entryId: string;
@@ -343,7 +362,8 @@ export function createTalkClientGatewayControlOwner(params: {
   let bridge: RealtimeVoiceBridge | undefined;
   let closeProvider: (() => Promise<void>) | undefined;
   let closing: Promise<void> | undefined;
-  let closed = false;
+  const lifetime = new AbortController();
+  const { signal } = lifetime;
   let transcriptSequence = 0;
   const entryPrefix = `gateway-${randomUUID()}`;
   const consultQueue = createRealtimeControlQueue();
@@ -406,12 +426,12 @@ export function createTalkClientGatewayControlOwner(params: {
       controller.signal.throwIfAborted();
       await params.flushTranscript();
       const result = await params.runAgentConsult(event.args, controller.signal);
-      if (closed) {
+      if (signal.aborted) {
         return;
       }
       await submit(event.callId, { result: result.text });
     } catch (error) {
-      if (closed) {
+      if (signal.aborted) {
         return;
       }
       const result = controller.signal.aborted
@@ -433,7 +453,7 @@ export function createTalkClientGatewayControlOwner(params: {
   });
 
   const handleToolCall = (event: RealtimeVoiceToolCallEvent): void => {
-    if (closed) {
+    if (signal.aborted) {
       return;
     }
     if (event.name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
@@ -469,7 +489,7 @@ export function createTalkClientGatewayControlOwner(params: {
   };
 
   const handleTranscript = (role: "user" | "assistant", text: string, final: boolean): void => {
-    if (closed || !text.trim()) {
+    if (signal.aborted || !text.trim()) {
       return;
     }
     const turnId = harness.ensureTurn();
@@ -502,11 +522,28 @@ export function createTalkClientGatewayControlOwner(params: {
   const owner: GatewayControlOwner = {
     connId: params.connId,
     sessionKey: params.sessionKey,
+    voiceSessionId: params.voiceSessionId,
+    assertOpen: () => {
+      signal.throwIfAborted();
+      params.assertConnectionOpen?.();
+    },
+    runAgentConsult: async ({ prompt, signal: consultSignal = new AbortController().signal }) => {
+      owner.assertOpen();
+      if (owners.get(params.voiceSessionId) !== owner) {
+        throw new Error("Realtime voice session is not active");
+      }
+      // Admission ends here: transport closure fences future requests, while the
+      // provider's consult signal continues to own already accepted work.
+      return await params.runAgentConsult({ question: prompt }, consultSignal);
+    },
     control: {
       bindBridge: (nextBridge) => {
         bridge = nextBridge;
       },
       onEvent: (event) => {
+        if (signal.aborted) {
+          return;
+        }
         const legacyOutcome = handleRealtimeVoiceHarnessBridgeEvent(harness, event);
         if (
           legacyOutcome &&
@@ -527,13 +564,23 @@ export function createTalkClientGatewayControlOwner(params: {
       onTranscript: handleTranscript,
       onToolCall: handleToolCall,
       onResponseDone: (outcome) => {
+        if (signal.aborted) {
+          return;
+        }
         const terminal = harness.finishResponse(outcome);
         if (terminal.ok && (outcome.status === "failed" || outcome.status === "incomplete")) {
           warn(`talk Gateway control ${outcome.message}`);
         }
       },
-      onReady: () => harness.emit({ type: "session.ready", payload: talkPayload() }),
+      onReady: () => {
+        if (!signal.aborted) {
+          harness.emit({ type: "session.ready", payload: talkPayload() });
+        }
+      },
       onError: (error) => {
+        if (signal.aborted) {
+          return;
+        }
         warn(`talk Gateway control provider error: ${error.message}`);
         harness.emit({
           type: "session.error",
@@ -542,6 +589,9 @@ export function createTalkClientGatewayControlOwner(params: {
         });
       },
       onClose: () => {
+        if (signal.aborted) {
+          return;
+        }
         harness.emit({ type: "session.closed", payload: talkPayload(), final: true });
         harness.close();
         void owner.close({ skipProvider: true }).catch((error: unknown) => {
@@ -549,8 +599,17 @@ export function createTalkClientGatewayControlOwner(params: {
         });
       },
     },
-    activate: (nextCloseProvider) => {
+    adoptProvider: async (nextCloseProvider) => {
+      if (signal.aborted) {
+        await nextCloseProvider();
+        signal.throwIfAborted();
+      }
       closeProvider = nextCloseProvider;
+      owner.assertOpen();
+    },
+    activate: () => {
+      owner.assertOpen();
+      pendingOwners.delete(owner);
       const previous = owners.get(params.voiceSessionId);
       owners.set(params.voiceSessionId, owner);
       if (previous && previous !== owner) {
@@ -560,24 +619,15 @@ export function createTalkClientGatewayControlOwner(params: {
             warn(`talk replaced Gateway transport close failed: ${formatError(error)}`);
           });
       }
-      registerTalkConnectionCleanup(params.connId, "browser-control", () => {
-        for (const current of owners.values()) {
-          if (current.connId === params.connId) {
-            void current.close().catch((error: unknown) => {
-              warn(`talk disconnected Gateway control close failed: ${formatError(error)}`);
-            });
-          }
-        }
-      });
     },
     close: (options) => {
       if (closing) {
         return closing;
       }
-      // Defer teardown until after `closing` is assigned so provider callbacks
-      // can re-enter close without starting a second cleanup.
+      // Fence admission synchronously, then defer teardown so provider callbacks
+      // can re-enter close after the closing promise has been assigned.
       closing = Promise.resolve().then(async () => {
-        closed = true;
+        pendingOwners.delete(owner);
         harness.close();
         if (owners.get(params.voiceSessionId) === owner) {
           owners.delete(params.voiceSessionId);
@@ -604,9 +654,23 @@ export function createTalkClientGatewayControlOwner(params: {
           throw providerResult.reason;
         }
       });
+      lifetime.abort(new Error("Realtime voice session closed"));
       return closing;
     },
   };
+  // Track creation before the provider resolves. Replacement activates only after
+  // startup succeeds, so a failed new transport cannot evict the current one.
+  owner.assertOpen();
+  pendingOwners.add(owner);
+  registerTalkConnectionCleanup(params.connId, "browser-control", () => {
+    for (const current of [...pendingOwners, ...owners.values()]) {
+      if (current.connId === params.connId) {
+        void current.close().catch((error: unknown) => {
+          warn(`talk disconnected Gateway control close failed: ${formatError(error)}`);
+        });
+      }
+    }
+  });
   return owner;
 }
 
@@ -615,17 +679,18 @@ export async function closeTalkClientGatewayControlSession(params: {
   sessionKey: string;
   connId?: string;
 }): Promise<boolean> {
-  const owner = owners.get(params.voiceSessionId);
-  if (!owner) {
+  const matching = [...pendingOwners, ...owners.values()].filter(
+    (owner) => owner.voiceSessionId === params.voiceSessionId,
+  );
+  if (matching.length === 0) {
     return false;
   }
-  if (
-    owner.sessionKey !== params.sessionKey.trim() ||
-    !params.connId ||
-    owner.connId !== params.connId
-  ) {
+  const owned = matching.filter(
+    (owner) => owner.sessionKey === params.sessionKey.trim() && owner.connId === params.connId,
+  );
+  if (owned.length === 0) {
     throw new Error("Gateway-controlled voice session is not owned by this client");
   }
-  await owner.close();
+  await Promise.all(owned.map((owner) => owner.close()));
   return true;
 }

--- a/src/talk/client-voice-session.startup.test.ts
+++ b/src/talk/client-voice-session.startup.test.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { loadSessionEntry, patchSessionEntryCore } from "../config/sessions/session-accessor.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { ensureClientVoiceAgentSessionEntry } from "./client-voice-session.js";
+
+describe("client voice session startup", () => {
+  const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-voice-startup-")),
+    );
+    setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
+  });
+
+  afterEach(async () => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    envSnapshot.restore();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("does not create a chat when browser startup closes while its write is queued", async () => {
+    const entered = createDeferred();
+    const release = createDeferred();
+    const blocker = patchSessionEntryCore(
+      { agentId: "main", sessionKey: "agent:main:voice-write-blocker" },
+      async () => {
+        entered.resolve();
+        await release.promise;
+        return null;
+      },
+      { fallbackEntry: { sessionId: "voice-write-blocker", updatedAt: 1 } },
+    );
+    await entered.promise;
+    const target = { agentId: "main", sessionKey: "agent:main:voice-write-cancelled" };
+    const controller = new AbortController();
+    const creating = ensureClientVoiceAgentSessionEntry({
+      ...target,
+      assertCommitAllowed: () => controller.signal.throwIfAborted(),
+    });
+    controller.abort(new Error("browser disconnected"));
+    const rejected = expect(creating).rejects.toThrow("browser disconnected");
+    release.resolve();
+    await blocker;
+    await rejected;
+    expect(loadSessionEntry(target)).toBeUndefined();
+  });
+});

--- a/src/talk/client-voice-session.ts
+++ b/src/talk/client-voice-session.ts
@@ -238,16 +238,12 @@ export async function ensureClientVoiceAgentSessionEntry(params: {
   agentId: string;
   sessionKey: string;
   deadlineAt?: number;
+  assertCommitAllowed?: () => void;
   creation?: Pick<Parameters<typeof buildSessionCreationStamp>[0], "actor" | "sandbox">;
 }): Promise<string> {
   const created = await patchSessionEntryCore(
     params,
     (_entry, context) => {
-      // Browser credentials can be short-lived. Check at the authoritative
-      // write boundary so a queued write cannot create an unusable empty chat.
-      if (params.deadlineAt !== undefined && Date.now() >= params.deadlineAt) {
-        throw new Error("Realtime browser session expired during startup; try again");
-      }
       if (context.existingEntry?.sessionId) {
         return null;
       }
@@ -260,7 +256,17 @@ export async function ensureClientVoiceAgentSessionEntry(params: {
         sandbox: params.creation?.sandbox,
       });
     },
-    { fallbackEntry: mergeSessionEntry(undefined, {}) },
+    {
+      fallbackEntry: mergeSessionEntry(undefined, {}),
+      assertCommitAllowed: () => {
+        // Provider startup can end while this write is queued or being prepared.
+        // Revalidate at commit so it cannot leave an unusable empty chat.
+        params.assertCommitAllowed?.();
+        if (params.deadlineAt !== undefined && Date.now() >= params.deadlineAt) {
+          throw new Error("Realtime browser session expired during startup; try again");
+        }
+      },
+    },
   );
   if (!created?.sessionId) {
     throw new Error(`agent session could not be initialized (${params.sessionKey})`);


### PR DESCRIPTION
Closes #132993

## What Problem This Solves

Fixes an issue where a browser Talk session could admit new agent work after closing or disconnecting, while explicitly releasing a GPT-Live browser transport could abort work already accepted.

## Why This Change Was Made

Pending and active provider sessions now use the existing browser lifecycle owner. Admission checks exact connected-client and active-transport ownership, queued chat creation rechecks ownership at commit, and failed or late startup releases its provider resources. Replacement remains transactional: the old transport stays active until its replacement succeeds. Accepted GPT-Live work outlives an intentional transport release, but cannot send results back through that closed wire. Recoverable provider errors reach the owning client.

## User Impact

Closing Talk prevents new delegations without discarding an accepted task. Disconnects during startup do not leave provider sessions or empty chats behind. The existing client-control negotiation, GA behavior, config, and database schema remain unchanged.

## Evidence

Independent Codex review of the combined candidate completed clean at P0–P2; the PRs contain disjoint subsets of that reviewed patch.

- Before-fix regressions proved late admission after both close and disconnect, and an aborted accepted GPT-Live consult after browser cancellation.
- Focused regressions passed: 100 Gateway tests, the client-session suite and extracted queued-commit test, plus OpenAI session/delegation/bridge suites. The final broker cleanup passed all 55 session, cancellation-lifecycle, and GA OAuth cases. These cover pending creation, exact client membership, queued writes, replacement, accepted-work continuation, late-result suppression, recoverable errors, and existing GA/provider routes.
- Extension type checking and type-aware lint passed. Production LOC: +294/-191, net +103; tests: +401/-15, net +386. The added production state belongs to the existing lifecycle owner and covers pending startup, exact transport admission, and cancellation at commit; duplicate teardown and HTTP response policy were consolidated. Config/schema surface: unchanged.
- A live GA WebRTC call completed its broker exchange, authenticated sideband, and tool response on Blacksmith Testbox `tbx_01m185h6k7s0dnt939ehb0dtcg`: https://github.com/openclaw/openclaw/actions/runs/33286432360 . The GA speech smoke also passed.
- GPT-Live live verification remains infeasible with the available credentials: Platform model access was rejected and the hydrated OAuth token was expired. No GPT-Live live-success claim is made.
- Direct Codex source inspection at `63d213884daea50e4f74efc192cdc44f549b67d5` covered frameless delegation, sideband closure, and normal WebSocket shutdown. No provider auth policy or payload contract is changed.

Provenance: the failures were reproduced at `9d8bf3525072487320da72b6718ecf9c69dc3f4e`; the exact introducing commit is not established.

Follow-ups remain separate: GPT-Live audio-driven interruption needs a continuous-media ownership contract; a sideband transcript finishing does not prove its WebRTC media drained. Native phone tools and Discord forced-response/wake policies also need per-model capability follow-through. These limitations are documented, not silently treated as parity.

AI-assisted implementation and verification. Release-note context: bind browser Talk delegation admission and cleanup to its exact live transport while preserving accepted work.
