### PR TITLE
fix: voice smoke passes without receiving speech

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -1266,6 +1266,7 @@ Auto-join example:
 
 Notes:
 
+- The OpenAI `agent-proxy` response and wake-name policies below require a GA realtime model, such as `gpt-realtime-2.1`. GPT-Live currently responds to audio autonomously and does not enforce those policies; do not rely on wake-name gating with GPT-Live in a shared voice channel.
 - Discord voice is opt-in for text-only configs; set `channels.discord.voice.enabled=true` (or keep an existing `channels.discord.voice` block) to enable `/vc` commands, the voice runtime, and the `GuildVoiceStates` gateway intent. `channels.discord.intents.voiceStates` can explicitly override the intent subscription; leave it unset to follow effective voice enablement.
 - `voice.mode` controls the conversation path. The default is `agent-proxy`: a realtime voice front end handles turn timing, interruption, and playback, delegates substantive work to the routed OpenClaw agent through `openclaw_agent_consult`, and treats the result like a typed Discord prompt from that speaker. `stt-tts` keeps the older batch STT plus TTS flow. `bidi` lets the realtime model converse directly while exposing `openclaw_agent_consult` for the OpenClaw brain.
 - `voice.agentSession` controls which OpenClaw conversation receives voice turns. Leave it unset for the voice channel's own session, or set `{ mode: "target", target: "channel:<text-channel-id>" }` to make the voice channel act as the microphone/speaker extension of an existing Discord text channel session such as `#maintainers`.

--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -216,8 +216,14 @@ overloaded: an invalid voice returns the same response. The legacy
 | Gateway-relay Talk          | Supported with Gateway-owned WebRTC and sideband                        |
 | Discord bidirectional voice | Supported with the Platform-key backend WebSocket                       |
 | Voice Call and telephony    | Supported with the Platform-key backend WebSocket                       |
-| iOS client-owned Talk       | Pending                                                                 |
+| iOS client-owned Talk       | Implemented; GPT-Live device live verification pending                  |
 | Android realtime Talk       | Pending an Android device live-proof flip; Android stays on native Talk |
+
+These rows describe implemented transport paths, not account entitlement or a
+successful live call on every device. iOS implements frameless transcripts and
+the Gateway offer exchange; Android retains an explicit GPT-Live model gate.
+For model capability limits, see [Discord voice policies](/channels/discord#voice-channels)
+and [Voice Call tools](/plugins/voice-call#realtime-voice-conversations).
 
 The Gateway-owned WebRTC route keeps OAuth and Platform credentials away from
 relay clients. Backend WebSocket paths keep the Platform key on the Gateway;

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -167,16 +167,17 @@ explicit runtime config.
 | Embeddings                | memory embedding provider                                                                     | Yes                                                                      |
 
 <Note>
-GA OpenAI Realtime voice goes through the public **OpenAI Platform Realtime
-API** and requires a Platform API key. Browser and Gateway-relay GPT-Live are
-the exceptions: their native `api.openai.com/v1/live` route prefers a ChatGPT
+GA OpenAI Realtime backend voice bridges require a Platform API key. GA browser
+Talk can also use an OpenClaw ChatGPT OAuth profile when no Platform credential
+is configured. Browser and Gateway-relay GPT-Live use the native
+`api.openai.com/v1/live` route, which prefers a ChatGPT
 OAuth profile and falls back to Platform API-key auth when that account has
 waitlist-gated access. Other GPT-Live backend voice bridges use the Frameless
 Bidi WebSocket and require Platform API-key auth.
 
 Platform auth is resolved in this order: configured realtime API key, `openai`
-API-key profile, then `OPENAI_API_KEY`. ChatGPT OAuth does not configure GA
-Talk, Voice Call, Discord realtime voice, or realtime transcription.
+API-key profile, then `OPENAI_API_KEY`. Voice Call, Discord realtime voice,
+GA Gateway relay, and realtime transcription still require Platform auth.
 
 If API-key auth reports missing billing, top up Platform credits at
 [platform.openai.com/account/billing](https://platform.openai.com/account/billing)
@@ -909,12 +910,12 @@ value into `plugins.entries.openai.config.personality` when that key is unset.
 
     <Note>
     Set `OPENAI_TTS_BASE_URL` to override the TTS base URL without affecting
-    the chat API endpoint. OpenAI TTS and GA Realtime voice are configured
-    through an OpenAI Platform API key. OAuth-only installs can use
-    Codex-backed chat models plus GPT-Live and GA Realtime browser Talk over a
-    ChatGPT subscription (see the Realtime accordion). They cannot use OpenAI
-    TTS, iOS Realtime WebRTC, Voice Call, Gateway relay, or Discord realtime
-    voice without a Platform API key.
+    the chat API endpoint. OpenAI TTS requires an OpenAI Platform API key.
+    OAuth-only installs can use Codex-backed chat models, GPT-Live browser
+    and Gateway-relay Talk, and GA Realtime browser Talk over a ChatGPT
+    subscription when the account has access (see the Realtime accordion).
+    OpenAI TTS, Voice Call, GA Gateway relay, and Discord realtime voice still
+    require a Platform API key.
     </Note>
 
   </Accordion>
@@ -1100,8 +1101,14 @@ value into `plugins.entries.openai.config.personality` when that key is unset.
     | Gateway-relay Talk | Supported with Gateway-owned WebRTC and sideband |
     | Discord bidirectional voice | Supported with the Platform-key backend WebSocket |
     | Voice Call and telephony | Supported with the Platform-key backend WebSocket |
-    | iOS client-owned Talk | Pending |
+    | iOS client-owned Talk | Implemented; GPT-Live device live verification pending |
     | Android realtime Talk | Pending an Android device live-proof flip; Android stays on native Talk |
+
+    These rows describe implemented transports, not account entitlement or
+    complete model capability parity. See the [Discord voice policy limits](/channels/discord#voice-channels)
+    and [Voice Call tool limits](/plugins/voice-call#realtime-voice-conversations) before
+    selecting GPT-Live for those consumers.
+
     <Warning>
     Platform API-key access to `/v1/live` is waitlist-gated and commonly returns
     `400 model_not_found` without enrollment. Use a ChatGPT OAuth profile, or request Platform access with the

--- a/scripts/dev/realtime-talk-live-smoke.ts
+++ b/scripts/dev/realtime-talk-live-smoke.ts
@@ -22,6 +22,9 @@ const OPENAI_AUDIO_CHUNK_BYTES = 960;
 const OPENAI_AUDIO_CHUNK_DELAY_MS = 5;
 const OPENAI_AUDIO_ROUNDTRIP_TIMEOUT_MS = 60_000;
 const OPENAI_AUDIO_TRAILING_SILENCE_MS = 750;
+// Match the shared TalkAudioLevel meter's -50 dBFS floor (TalkPlaybackLevelMeters.swift).
+const OPENAI_BROWSER_SPEECH_MIN_RMS = 10 ** (-50 / 20);
+const OPENAI_BROWSER_SPEECH_MIN_SECONDS = 0.1;
 const GOOGLE_REALTIME_MODEL =
   process.env.OPENCLAW_REALTIME_GOOGLE_MODEL?.trim() || "gemini-3.1-flash-live-preview";
 const GOOGLE_REALTIME_VOICE = process.env.OPENCLAW_REALTIME_GOOGLE_VOICE?.trim() || "Kore";
@@ -320,6 +323,8 @@ async function createOpenAIClientSecret(
             type: "realtime",
             model: OPENAI_REALTIME_MODEL,
             audio: {
+              // Synthetic microphone input must not compete with the requested spoken marker.
+              input: { turn_detection: null },
               output: { voice: OPENAI_REALTIME_VOICE },
             },
           },
@@ -582,7 +587,14 @@ async function smokeOpenAIWebRtc(browser: Browser, apiKey: string): Promise<Smok
       await page.evaluate("globalThis.__name = (fn) => fn");
       await page.evaluate(openAIRealtimeBrowserResponseReaderInitScript());
       const result = await page.evaluate(
-        async ({ clientSecret: secret, sdpAnswerMaxBytes, timeoutMs }) => {
+        async ({
+          clientSecret: secret,
+          sdpAnswerMaxBytes,
+          timeoutMs,
+          audioTimeoutMs,
+          minSpeechRms,
+          minSpeechSeconds,
+        }) => {
           const readBoundedTextLocal = (globalThis as OpenAIWebRtcSmokeGlobal)
             .openclawReadBoundedRealtimeResponseText;
           if (!readBoundedTextLocal) {
@@ -591,15 +603,16 @@ async function smokeOpenAIWebRtc(browser: Browser, apiKey: string): Promise<Smok
           const withBrowserTimeout = async <T>(
             label: string,
             run: (signal: AbortSignal) => Promise<T>,
+            durationMs = timeoutMs,
           ): Promise<T> => {
             const controller = new AbortController();
             let timeout: number | undefined;
             const timeoutPromise = new Promise<T>((_resolve, reject) => {
               timeout = window.setTimeout(() => {
-                const error = new Error(`${label} exceeded timeout of ${timeoutMs}ms`);
+                const error = new Error(`${label} exceeded timeout of ${durationMs}ms`);
                 reject(error);
                 controller.abort(error);
-              }, timeoutMs);
+              }, durationMs);
             });
             try {
               return await Promise.race([run(controller.signal), timeoutPromise]);
@@ -611,37 +624,61 @@ async function smokeOpenAIWebRtc(browser: Browser, apiKey: string): Promise<Smok
           };
           let media: MediaStream | undefined;
           let peer: RTCPeerConnection | undefined;
+          let audioContext: AudioContext | undefined;
+          let oscillator: OscillatorNode | undefined;
+          const playback = new Audio();
+          let providerError: string | undefined;
+          let transcriptMarker = false;
+          let responseDone = false;
           try {
             if (navigator.mediaDevices?.getUserMedia) {
               media = await navigator.mediaDevices.getUserMedia({ audio: true });
             } else {
-              const audioContext = new AudioContext();
+              audioContext = new AudioContext();
               const destination = audioContext.createMediaStreamDestination();
-              const oscillator = audioContext.createOscillator();
+              oscillator = audioContext.createOscillator();
               oscillator.connect(destination);
               oscillator.start();
               media = destination.stream;
             }
             peer = new RTCPeerConnection();
+            peer.addEventListener("track", (event) => {
+              playback.srcObject = event.streams[0] ?? new MediaStream([event.track]);
+              void playback.play().catch((error: unknown) => {
+                providerError = error instanceof Error ? error.message : String(error);
+              });
+            });
             for (const track of media.getAudioTracks()) {
               peer.addTrack(track, media);
             }
             const channel = peer.createDataChannel("oai-events");
-            const connectionState = new Promise<string>((resolve) => {
-              const timeout = window.setTimeout(
-                () => resolve(peer?.connectionState ?? "timeout"),
-                12_000,
+            channel.addEventListener("open", () => {
+              channel.send(
+                JSON.stringify({
+                  type: "response.create",
+                  response: { instructions: "Say only the word glacier." },
+                }),
               );
-              peer?.addEventListener("connectionstatechange", () => {
-                if (peer?.connectionState === "connected" || peer?.connectionState === "failed") {
-                  window.clearTimeout(timeout);
-                  resolve(peer.connectionState);
+            });
+            channel.addEventListener("message", (event: MessageEvent<string>) => {
+              const message = JSON.parse(event.data) as {
+                type?: string;
+                transcript?: string;
+                response?: { status?: string };
+                error?: { message?: string };
+              };
+              if (message.type === "response.output_audio_transcript.done") {
+                transcriptMarker = /\bglacier\b/iu.test(message.transcript ?? "");
+              }
+              if (message.type === "response.done") {
+                responseDone = message.response?.status === "completed";
+                if (!responseDone) {
+                  providerError = `OpenAI browser response ${message.response?.status ?? "missing status"}`;
                 }
-              });
-              channel.addEventListener("open", () => {
-                window.clearTimeout(timeout);
-                resolve(peer?.connectionState || "data-channel-open");
-              });
+              }
+              if (message.type === "error") {
+                providerError = message.error?.message ?? "OpenAI browser realtime error";
+              }
             });
             const offer = await peer.createOffer();
             await peer.setLocalDescription(offer);
@@ -672,31 +709,114 @@ async function smokeOpenAIWebRtc(browser: Browser, apiKey: string): Promise<Smok
               },
             );
             await peer.setRemoteDescription({ type: "answer", sdp: answer });
-            const state = await connectionState;
+            let outputAudioBytes = 0;
+            let outputAudioEnergy = 0;
+            let outputAudioSamplesDuration = 0;
+            let outputAudioSpeechDuration = 0;
+            let outputAudioPeakRms = 0;
+            const mediaPeer = peer;
+            await withBrowserTimeout(
+              "OpenAI Realtime browser audio",
+              async (signal) => {
+                while (!signal.aborted) {
+                  if (providerError) {
+                    throw new Error(providerError);
+                  }
+                  if (["failed", "closed"].includes(mediaPeer.connectionState)) {
+                    return;
+                  }
+                  const stats = await mediaPeer.getStats();
+                  const previousEnergy = outputAudioEnergy;
+                  const previousDuration = outputAudioSamplesDuration;
+                  outputAudioBytes = 0;
+                  outputAudioEnergy = 0;
+                  outputAudioSamplesDuration = 0;
+                  stats.forEach((entry: RTCInboundRtpStreamStats) => {
+                    if (entry.type === "inbound-rtp" && entry.kind === "audio") {
+                      outputAudioBytes += entry.bytesReceived ?? 0;
+                      outputAudioEnergy += entry.totalAudioEnergy ?? 0;
+                      outputAudioSamplesDuration += entry.totalSamplesDuration ?? 0;
+                    }
+                  });
+                  const energyDelta = outputAudioEnergy - previousEnergy;
+                  const durationDelta = outputAudioSamplesDuration - previousDuration;
+                  if (energyDelta >= 0 && durationDelta > 0) {
+                    const rms = Math.sqrt(energyDelta / durationDelta);
+                    outputAudioPeakRms = Math.max(outputAudioPeakRms, rms);
+                    if (rms >= minSpeechRms) {
+                      outputAudioSpeechDuration += durationDelta;
+                    }
+                  }
+                  if (
+                    mediaPeer.connectionState === "connected" &&
+                    transcriptMarker &&
+                    responseDone &&
+                    outputAudioBytes > 512 &&
+                    outputAudioSpeechDuration >= minSpeechSeconds
+                  ) {
+                    return;
+                  }
+                  await new Promise((resolve) => {
+                    window.setTimeout(resolve, 50);
+                  });
+                }
+                signal.throwIfAborted();
+              },
+              audioTimeoutMs,
+            );
             return {
               answerHasAudio: answer.includes("m=audio"),
               remoteDescriptionApplied: peer.remoteDescription?.type === "answer",
-              connectionState: state,
+              connectionState: peer.connectionState,
+              transcriptMarker,
+              responseDone,
+              outputAudioBytes,
+              outputAudioEnergy,
+              outputAudioSamplesDuration,
+              outputAudioSpeechDuration,
+              outputAudioPeakRms,
             };
           } finally {
+            playback.pause();
+            playback.srcObject = null;
             peer?.close();
             media?.getTracks().forEach((track) => track.stop());
+            oscillator?.stop();
+            await audioContext?.close();
           }
         },
         {
           clientSecret,
           sdpAnswerMaxBytes: OPENAI_HTTP_RESPONSE_MAX_BYTES,
           timeoutMs: openAIHttpTimeoutMs,
+          audioTimeoutMs: OPENAI_AUDIO_ROUNDTRIP_TIMEOUT_MS,
+          minSpeechRms: OPENAI_BROWSER_SPEECH_MIN_RMS,
+          minSpeechSeconds: OPENAI_BROWSER_SPEECH_MIN_SECONDS,
         },
       );
       return {
         name: "openai-webrtc-browser",
-        ok: result.answerHasAudio && result.remoteDescriptionApplied,
+        ok:
+          result.answerHasAudio &&
+          result.remoteDescriptionApplied &&
+          result.connectionState === "connected" &&
+          result.transcriptMarker &&
+          result.responseDone &&
+          result.outputAudioBytes > 512 &&
+          result.outputAudioSpeechDuration >= OPENAI_BROWSER_SPEECH_MIN_SECONDS,
         details: {
           model: OPENAI_REALTIME_MODEL,
+          protocol: "ga-realtime",
           answerHasAudio: result.answerHasAudio,
           remoteDescriptionApplied: result.remoteDescriptionApplied,
           connectionState: result.connectionState,
+          transcriptMarker: result.transcriptMarker,
+          responseDone: result.responseDone,
+          outputAudioBytes: result.outputAudioBytes,
+          outputAudioEnergy: result.outputAudioEnergy,
+          outputAudioSamplesDuration: result.outputAudioSamplesDuration,
+          outputAudioSpeechDuration: result.outputAudioSpeechDuration,
+          outputAudioPeakRms: result.outputAudioPeakRms,
         },
       };
     } finally {

--- a/test/scripts/realtime-talk-live-smoke.test.ts
+++ b/test/scripts/realtime-talk-live-smoke.test.ts
@@ -1,0 +1,170 @@
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import type { RealtimeVoiceBridgeCreateRequest } from "../../src/talk/provider-types.js";
+
+const browser = vi.hoisted(() => ({
+  close: vi.fn(async () => {}),
+  contextClose: vi.fn(async () => {}),
+  evaluate: vi.fn(async () => ({
+    answerHasAudio: true,
+    remoteDescriptionApplied: true,
+    connectionState: "failed",
+    transcriptMarker: false,
+    responseDone: false,
+    outputAudioBytes: 0,
+    outputAudioEnergy: 0,
+    outputAudioSamplesDuration: 0,
+    outputAudioSpeechDuration: 0,
+    outputAudioPeakRms: 0,
+  })),
+}));
+
+vi.mock("playwright", () => ({
+  chromium: {
+    launch: async () => ({
+      close: browser.close,
+      newContext: async () => ({
+        close: browser.contextClose,
+        newPage: async () => ({ evaluate: browser.evaluate }),
+      }),
+    }),
+  },
+}));
+
+vi.mock("../../extensions/openai/realtime-voice-provider.ts", () => ({
+  buildOpenAIRealtimeVoiceProvider: () => ({
+    createBridge: (options: RealtimeVoiceBridgeCreateRequest) => {
+      let responded = false;
+      return {
+        connect: async () => {},
+        isConnected: () => true,
+        close: () => {},
+        sendAudio: () => {
+          if (responded) {
+            return;
+          }
+          responded = true;
+          options.onAudio(Buffer.alloc(1024));
+          options.onTranscript?.("user", "glacier", true);
+          options.onTranscript?.("assistant", "glacier", true);
+          options.onEvent?.({ direction: "server", type: "response.done" });
+        },
+      };
+    },
+  }),
+}));
+
+vi.mock("../../extensions/openai/speech-provider.ts", () => ({
+  buildOpenAISpeechProvider: () => ({
+    synthesizeTelephony: async () => ({
+      audioBuffer: Buffer.alloc(2),
+      outputFormat: "pcm",
+      sampleRate: 24_000,
+    }),
+  }),
+}));
+
+const originalArgv = process.argv;
+const originalExitCode = process.exitCode;
+
+afterEach(() => {
+  process.argv = originalArgv;
+  process.exitCode = originalExitCode;
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+it.each([
+  {
+    name: "failed browser media",
+    connectionState: "failed",
+    outputAudioEnergy: 0.002,
+    speechSeconds: 0.2,
+    transcriptMarker: true,
+    ok: false,
+  },
+  {
+    name: "silent browser audio",
+    connectionState: "connected",
+    outputAudioEnergy: 0,
+    speechSeconds: 0,
+    transcriptMarker: true,
+    ok: false,
+  },
+  {
+    name: "comfort noise despite a completed transcript",
+    connectionState: "connected",
+    outputAudioEnergy: 2.2539e-8,
+    speechSeconds: 0,
+    transcriptMarker: true,
+    ok: false,
+  },
+  {
+    name: "audio too brief to establish speech",
+    connectionState: "connected",
+    outputAudioEnergy: 0.002,
+    speechSeconds: 0.02,
+    transcriptMarker: true,
+    ok: false,
+  },
+  {
+    name: "unrelated browser audio",
+    connectionState: "connected",
+    outputAudioEnergy: 0.002,
+    speechSeconds: 0.2,
+    transcriptMarker: false,
+    ok: false,
+  },
+  {
+    name: "completed browser speech",
+    connectionState: "connected",
+    outputAudioEnergy: 0.002,
+    speechSeconds: 0.2,
+    transcriptMarker: true,
+    ok: true,
+  },
+])(
+  "reports $name through the smoke command",
+  async ({ connectionState, outputAudioEnergy, speechSeconds, transcriptMarker, ok }) => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    browser.evaluate.mockResolvedValue({
+      answerHasAudio: true,
+      remoteDescriptionApplied: true,
+      connectionState,
+      transcriptMarker,
+      responseDone: true,
+      outputAudioBytes: 1024,
+      outputAudioEnergy,
+      outputAudioSamplesDuration: 0.5,
+      outputAudioSpeechDuration: speechSeconds,
+      outputAudioPeakRms: Math.sqrt(outputAudioEnergy / 0.5),
+    });
+    vi.stubEnv("OPENAI_API_KEY", "test-key");
+    vi.stubEnv("OPENCLAW_REALTIME_OPENAI_MODEL", "gpt-realtime-2.1");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ value: "test-client-secret" })),
+    );
+    const output = vi.spyOn(console, "log").mockImplementation(() => {});
+    process.argv = [
+      process.execPath,
+      path.resolve("scripts/dev/realtime-talk-live-smoke.ts"),
+      "--openai-only",
+    ];
+    process.exitCode = undefined;
+
+    await import("../../scripts/dev/realtime-talk-live-smoke.ts");
+
+    expect(output).toHaveBeenCalledWith("openai-backend-bridge: ok", expect.any(Object));
+    expect(output).toHaveBeenCalledWith("openai-backend-audio-roundtrip: ok", expect.any(Object));
+    expect(output).toHaveBeenCalledWith(
+      `openai-webrtc-browser: ${ok ? "ok" : "failed"}`,
+      expect.objectContaining({ protocol: "ga-realtime" }),
+    );
+    expect(process.exitCode).toBe(ok ? undefined : 1);
+    expect(browser.contextClose).toHaveBeenCalledOnce();
+    expect(browser.close).toHaveBeenCalledOnce();
+  },
+);


### PR DESCRIPTION
Closes #132994

## What Problem This Solves

Fixes an issue where the realtime browser smoke reported success after SDP negotiation even if its media connection failed. It also corrects contradictory support notes for iOS and OAuth voice routes.

## Why This Change Was Made

The browser leg now requests one spoken marker and requires a connected peer, matching completed response, and at least 100 ms of received audio above Talk's existing -50 dBFS floor. It derives RMS from receiver energy/sample-duration deltas, so comfort noise alone cannot pass. Cleanup releases media, playback, and fallback audio resources. The report explicitly identifies the GA realtime protocol.

## User Impact

A failed connection, silent/comfort-noise-only stream, brief burst, or unrelated response now fails verification. This proves received speech energy; it does not claim full local playback drain or GPT-Live coverage. Docs distinguish implemented transports, model capability limits, and pending device proof.

## Evidence

Independent Codex review of the combined candidate completed clean at P0–P2; the PRs contain disjoint subsets of that reviewed patch.

- Original CLI regression failed because connectionState=failed was printed as successful.
- All six CLI regressions passed; type-aware lint and formatting passed. The regression table covers failed transport, silence, comfort noise, brief audio, unrelated speech, and successful speech.
- Live GA smoke passed on Blacksmith Testbox `tbx_01m185h6k7s0dnt939ehb0dtcg`: https://github.com/openclaw/openclaw/actions/runs/33286432360 . Browser: connected, matching marker, completed response, 1,547 RTP bytes, 0.100 seconds above floor, peak normalized RMS 0.220.
- The backend leg independently exercised synthesized input, final user/assistant transcripts, returned audio, response completion, and no post-close audio.
- RMS calculation follows the WebRTC statistics contract: https://www.w3.org/TR/webrtc-stats/#dom-rtcinboundrtpstreamstats-totalaudioenergy . The floor matches `TalkAudioLevel` in OpenClawKit.
- No production model, configuration, dependency, or protocol changes. Runtime production LOC: +0/-0; tests and test tooling: +311/-21, net +290; docs: +27/-13. The added smoke code observes actual media, verifies the requested response, and releases browser audio resources.

AI-assisted implementation and verification.
