### PR TITLE
fix(mcp): keep metadata and cleanup from eagerly loading runtimes

### DIFF
--- a/src/agents/agent-bundle-mcp-harness.test.ts
+++ b/src/agents/agent-bundle-mcp-harness.test.ts
@@ -70,8 +70,8 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock("./agent-bundle-mcp-runtime.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./agent-bundle-mcp-runtime.js")>();
+vi.mock("./agent-bundle-mcp-manager-api.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./agent-bundle-mcp-manager-api.js")>();
   return {
     ...actual,
     getOrCreateRequesterScopedMcpRuntime: mocks.getOrCreateRequesterScopedMcpRuntime,

--- a/src/agents/agent-bundle-mcp-harness.ts
+++ b/src/agents/agent-bundle-mcp-harness.ts
@@ -4,17 +4,17 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import {
-  buildBundleMcpToolsFromCatalog,
-  materializeBundleMcpToolsForRun,
-} from "./agent-bundle-mcp-materialize.js";
-import { mergeMcpConnectCatalog } from "./agent-bundle-mcp-requester-connect.js";
-import {
   getAdvertisedScopedMcpCatalog,
   getOrCreateRequesterScopedMcpRuntime,
   getOrCreateSessionMcpRuntime,
   rememberAdvertisedScopedMcpCatalog,
   retireSessionMcpRuntime,
-} from "./agent-bundle-mcp-runtime.js";
+} from "./agent-bundle-mcp-manager-api.js";
+import {
+  buildBundleMcpToolsFromCatalog,
+  materializeBundleMcpToolsForRun,
+} from "./agent-bundle-mcp-materialize.js";
+import { mergeMcpConnectCatalog } from "./agent-bundle-mcp-requester-connect.js";
 import type { McpToolCatalog, RequesterMcpConnect } from "./agent-bundle-mcp-types.js";
 import {
   resolveConversationCapabilityProfile,

--- a/src/agents/agent-bundle-mcp-manager-install.ts
+++ b/src/agents/agent-bundle-mcp-manager-install.ts
@@ -113,77 +113,55 @@ export function createSessionMcpRuntimeManagerInstall(
         safeServerNamesByServer: params.safeServerNamesByServer,
         toolOverrides: params.toolOverrides,
       }).fingerprint;
-    const existing = store.runtimesBySessionId.get(params.runtimeKey);
-    if (existing) {
-      if (
-        !matchesStaticReuse({
-          workspaceDir: params.workspaceDir,
-          agentDir: params.agentDir,
-          configFingerprint: nextFingerprint,
-          candidate: existing,
-        })
-      ) {
-        store.runtimesBySessionId.delete(params.runtimeKey);
-        store.connectionMetaByRuntimeKey.delete(params.runtimeKey);
-        await existing.dispose();
-      } else {
-        reconcileReusableRetirement(params.sessionId, existing);
-        existing.markUsed();
-        return existing;
-      }
-    }
-    const inFlight = store.createInFlight.get(params.runtimeKey);
-    if (inFlight) {
-      if (
-        matchesStaticReuse({
-          workspaceDir: params.workspaceDir,
-          agentDir: params.agentDir,
-          configFingerprint: nextFingerprint,
-          candidate: inFlight,
-        })
-      ) {
-        return inFlight.promise;
-      }
-      store.createInFlight.delete(params.runtimeKey);
-      const staleRuntime = await inFlight.promise.catch(() => undefined);
-      store.runtimesBySessionId.delete(params.runtimeKey);
-      store.connectionMetaByRuntimeKey.delete(params.runtimeKey);
-      await staleRuntime?.dispose();
-    }
-    const created = Promise.resolve(
-      store.createRuntime({
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        workspaceDir: params.workspaceDir,
-        agentDir: params.agentDir,
-        cfg: params.cfg,
-        manifestRegistry: params.manifestRegistry,
-        includeServerNames: params.includeServerNames,
-        excludeServerNames: params.excludeServerNames,
-        safeServerNamesByServer: params.safeServerNamesByServer,
-        connectionOverrides: params.connectionOverrides,
-        redactConnectionServerNames: params.redactConnectionServerNames,
-        requesterScope: params.requesterScope,
-        requesterConnect: params.requesterConnect,
-        configFingerprint: nextFingerprint,
-        toolOverrides: params.toolOverrides,
-      }),
-    ).then((runtime) => {
-      reconcileReusableRetirement(params.sessionId, runtime);
-      runtime.markUsed();
-      store.runtimesBySessionId.set(params.runtimeKey, runtime);
-      return runtime;
-    });
-    store.createInFlight.set(params.runtimeKey, {
-      promise: created,
+    const { runtimeKey, ...runtimeParams } = params;
+    const identity = {
       workspaceDir: params.workspaceDir,
       agentDir: params.agentDir,
       configFingerprint: nextFingerprint,
+    };
+    const inFlight = store.createInFlight.get(runtimeKey);
+    if (inFlight && matchesStaticReuse({ ...identity, candidate: inFlight })) {
+      return inFlight.promise;
+    }
+    const existing = store.runtimesBySessionId.get(runtimeKey);
+    if (!inFlight && existing && matchesStaticReuse({ ...identity, candidate: existing })) {
+      reconcileReusableRetirement(params.sessionId, existing);
+      existing.markUsed();
+      return existing;
+    }
+    store.runtimesBySessionId.delete(runtimeKey);
+    store.connectionMetaByRuntimeKey.delete(runtimeKey);
+    const isCurrent = (): boolean => store.createInFlight.get(runtimeKey)?.promise === created;
+    const superseded = () =>
+      new Error(`MCP runtime creation superseded for session ${params.sessionId}`);
+    // Claim replacement before awaiting cleanup or imports. Its producer owns late
+    // disposal; an obsolete producer must never publish or clear its successor.
+    const created: Promise<SessionMcpRuntime> = Promise.resolve().then(async () => {
+      await existing?.dispose();
+      await inFlight?.promise.catch(() => undefined);
+      if (!isCurrent()) {
+        throw superseded();
+      }
+      const runtime = await store.createRuntime({
+        ...runtimeParams,
+        configFingerprint: nextFingerprint,
+      });
+      if (!isCurrent()) {
+        await runtime.dispose();
+        throw superseded();
+      }
+      reconcileReusableRetirement(params.sessionId, runtime);
+      runtime.markUsed();
+      store.runtimesBySessionId.set(runtimeKey, runtime);
+      return runtime;
     });
+    store.createInFlight.set(runtimeKey, { ...identity, promise: created });
     try {
       return await created;
     } finally {
-      store.createInFlight.delete(params.runtimeKey);
+      if (isCurrent()) {
+        store.createInFlight.delete(runtimeKey);
+      }
     }
   };
 

--- a/src/agents/agent-bundle-mcp-manager-lifecycle.ts
+++ b/src/agents/agent-bundle-mcp-manager-lifecycle.ts
@@ -115,6 +115,7 @@ export type SessionMcpRuntimeManagerLifecycle = {
   ensureIdleSweepTimer: () => void;
   clearIdleSweepTimer: () => void;
   disposeRuntimeKeyNow: (runtimeKey: string) => Promise<void>;
+  disposeRuntimeKeys: (runtimeKeys: Iterable<string>) => Promise<void>;
   disposeManagedSession: (
     sessionId: string,
     opts?: { preserveRequiredRetirement?: boolean },
@@ -292,16 +293,29 @@ export function createSessionMcpRuntimeManagerLifecycle(
 
   const disposeRuntimeKeyNow = async (runtimeKey: string): Promise<void> => {
     const inFlight = store.createInFlight.get(runtimeKey);
+    const runtime = store.runtimesBySessionId.get(runtimeKey);
+    // Revoke publication before yielding. The captured producer disposes its own
+    // late result, while a newly admitted replacement keeps its maps and claim.
     store.createInFlight.delete(runtimeKey);
-    let runtime = store.runtimesBySessionId.get(runtimeKey);
-    if (!runtime && inFlight) {
-      runtime = await inFlight.promise.catch(() => undefined);
-    }
     store.runtimesBySessionId.delete(runtimeKey);
     store.connectionMetaByRuntimeKey.delete(runtimeKey);
-    if (runtime) {
-      await runtime.dispose();
+    try {
+      await runtime?.dispose();
+    } finally {
+      await inFlight?.promise.catch(() => undefined);
     }
+  };
+
+  const disposeRuntimeKeys = async (runtimeKeys: Iterable<string>): Promise<void> => {
+    // Keep requester chains owned until teardown runs; clearing them early lets
+    // replacement installs overlap the resolve/install work being drained.
+    await Promise.allSettled(
+      [...runtimeKeys].map((runtimeKey) =>
+        runtimeKey.startsWith("{")
+          ? runExclusiveOnRuntimeKey(runtimeKey, () => disposeRuntimeKeyNow(runtimeKey))
+          : disposeRuntimeKeyNow(runtimeKey),
+      ),
+    );
   };
 
   const disposeManagedSession = async (
@@ -324,15 +338,8 @@ export function createSessionMcpRuntimeManagerLifecycle(
         runtimeKeys.add(runtimeKey);
       }
     }
-    // Serialize disposal with in-flight requester work for composite keys.
-    await Promise.allSettled(
-      [...runtimeKeys].map((runtimeKey) =>
-        runtimeKey.startsWith("{")
-          ? runExclusiveOnRuntimeKey(runtimeKey, () => disposeRuntimeKeyNow(runtimeKey))
-          : disposeRuntimeKeyNow(runtimeKey),
-      ),
-    );
     forgetSessionKeysForSessionId(sessionId);
+    await disposeRuntimeKeys(runtimeKeys);
   };
 
   const rememberAdvertisedScopedCatalog = (
@@ -421,6 +428,7 @@ export function createSessionMcpRuntimeManagerLifecycle(
     ensureIdleSweepTimer,
     clearIdleSweepTimer,
     disposeRuntimeKeyNow,
+    disposeRuntimeKeys,
     disposeManagedSession,
     rememberAdvertisedScopedCatalog,
     getAdvertisedScopedCatalog,

--- a/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
+++ b/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
@@ -1,0 +1,277 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { createSessionMcpRuntimeManager } from "./agent-bundle-mcp-manager.js";
+import type { CreateSessionMcpRuntime } from "./agent-bundle-mcp-runtime-shared.js";
+import type { SessionMcpRuntime, SessionMcpRuntimeManager } from "./agent-bundle-mcp-types.js";
+import { testing as resolverTesting } from "./mcp-connection-resolver.js";
+
+vi.mock("./agent-bundle-mcp-runtime.js", () => {
+  throw new Error("Lifecycle-only MCP work must not import the transport runtime");
+});
+
+const managers: SessionMcpRuntimeManager[] = [];
+const releaseHeldWork: Array<() => void> = [];
+const params = {
+  sessionId: "lifecycle-session",
+  sessionKey: "agent:test:lifecycle-session",
+  workspaceDir: "/workspace",
+  agentDir: "/agents/test",
+  cfg: { mcp: { servers: {} } },
+  manifestRegistry: { plugins: [] },
+};
+
+function createRuntimeFixture(input: Parameters<CreateSessionMcpRuntime>[0]): SessionMcpRuntime {
+  let lastUsedAt = Date.now();
+  let activeLeases = 0;
+  return {
+    sessionId: input.sessionId,
+    sessionKey: input.sessionKey,
+    workspaceDir: input.workspaceDir,
+    agentDir: input.agentDir,
+    requesterScope: input.requesterScope,
+    configFingerprint: input.configFingerprint ?? "fixture",
+    createdAt: lastUsedAt,
+    get lastUsedAt() {
+      return lastUsedAt;
+    },
+    get activeLeases() {
+      return activeLeases;
+    },
+    acquireLease() {
+      activeLeases += 1;
+      let released = false;
+      return () => {
+        if (!released) {
+          released = true;
+          activeLeases -= 1;
+        }
+      };
+    },
+    markUsed: () => {
+      lastUsedAt = Date.now();
+    },
+    getCatalog: async () => ({ version: 1, generatedAt: 0, servers: {}, tools: [] }),
+    peekCatalog: () => null,
+    callTool: async () => ({ content: [] }),
+    dispose: vi.fn(async () => {}),
+  };
+}
+
+function createManager(createRuntime?: CreateSessionMcpRuntime) {
+  const manager = createSessionMcpRuntimeManager({ createRuntime, enableIdleSweepTimer: false });
+  managers.push(manager);
+  return manager;
+}
+
+function holdFactory() {
+  const started = createDeferred<SessionMcpRuntime>();
+  const released = createDeferred();
+  releaseHeldWork.push(() => released.resolve());
+  const createRuntime: CreateSessionMcpRuntime = async (input) => {
+    const runtime = createRuntimeFixture(input);
+    started.resolve(runtime);
+    await released.promise;
+    return runtime;
+  };
+  return { createRuntime, started: started.promise, release: () => released.resolve() };
+}
+
+function holdDisposal(runtime: SessionMcpRuntime) {
+  const started = createDeferred();
+  const released = createDeferred();
+  releaseHeldWork.push(() => released.resolve());
+  runtime.dispose = vi.fn(async () => {
+    started.resolve();
+    await released.promise;
+  });
+  return { started: started.promise, release: () => released.resolve() };
+}
+
+afterEach(async () => {
+  for (const release of releaseHeldWork.splice(0)) {
+    release();
+  }
+  await Promise.all(managers.splice(0).map((manager) => manager.disposeAll()));
+  resolverTesting.setMcpServerConnectionResolversForTest();
+});
+
+describe("MCP manager creation ownership", () => {
+  it("constructs and retires an empty manager without binding or importing transports", async () => {
+    const manager = createManager();
+
+    expect(manager.peekSession({ sessionId: params.sessionId })).toBeUndefined();
+    expect(manager.deferRetirement(params.sessionId)).toBe(false);
+    await expect(manager.completeDeferredRetirement(params.sessionId)).resolves.toBe(false);
+    await manager.disposeSession(params.sessionId);
+    await manager.disposeAll();
+
+    expect(manager.listRuntimeKeys()).toEqual([]);
+  });
+
+  it.each(["session", "all"] as const)(
+    "drains late creation during %s disposal without publishing or clearing a successor",
+    async (scope) => {
+      const first = holdFactory();
+      const next = holdFactory();
+      const createRuntime = vi
+        .fn<CreateSessionMcpRuntime>(createRuntimeFixture)
+        .mockImplementationOnce(first.createRuntime)
+        .mockImplementationOnce(next.createRuntime);
+      const manager = createManager(createRuntime);
+      const oldRequest = manager.getOrCreate(params);
+      const oldOutcome = oldRequest.catch((error: unknown) => error);
+      const oldRuntime = await first.started;
+      const closing = holdDisposal(oldRuntime);
+      let drained = false;
+      const disposal = (
+        scope === "session" ? manager.disposeSession(params.sessionId) : manager.disposeAll()
+      ).then(() => {
+        drained = true;
+      });
+
+      const nextRequest = manager.getOrCreate(params);
+      const nextRuntime = await next.started;
+      first.release();
+      await closing.started;
+      expect(drained).toBe(false);
+      expect(manager.peekSession({ sessionId: params.sessionId })).toBeUndefined();
+      closing.release();
+      await disposal;
+      expect(await oldOutcome).toMatchObject({ message: expect.stringContaining("superseded") });
+      expect(oldRuntime.dispose).toHaveBeenCalledOnce();
+
+      // The old producer's finally and teardown both ran while this claim was pending.
+      const concurrentRequest = manager.getOrCreate(params);
+      next.release();
+      const [created, concurrent] = await Promise.all([nextRequest, concurrentRequest]);
+      expect(created).toBe(nextRuntime);
+      expect(concurrent).toBe(nextRuntime);
+      expect(createRuntime).toHaveBeenCalledTimes(2);
+      expect(manager.peekSession({ sessionKey: params.sessionKey })).toBe(nextRuntime);
+      expect(nextRuntime.dispose).not.toHaveBeenCalled();
+      await expect(manager.getOrCreate(params)).resolves.toBe(nextRuntime);
+
+      await manager.disposeAll();
+      expect(nextRuntime.dispose).toHaveBeenCalledOnce();
+      const subsequent = await manager.getOrCreate(params);
+      expect(subsequent).not.toBe(nextRuntime);
+      expect(manager.peekSession({ sessionId: params.sessionId })).toBe(subsequent);
+    },
+  );
+
+  it.each([
+    { label: "workspace", update: { workspaceDir: "/other-workspace" } },
+    { label: "agent", update: { agentDir: "/agents/other" } },
+    { label: "config", update: { cfg: { mcp: { apps: { enabled: true }, servers: {} } } } },
+  ])("claims a $label replacement before awaiting old runtime disposal", async ({ update }) => {
+    const next = holdFactory();
+    const createRuntime = vi
+      .fn<CreateSessionMcpRuntime>(createRuntimeFixture)
+      .mockImplementationOnce(createRuntimeFixture)
+      .mockImplementationOnce(next.createRuntime);
+    const manager = createManager(createRuntime);
+    const oldRuntime = await manager.getOrCreate(params);
+    const closing = holdDisposal(oldRuntime);
+    const changed = { ...params, ...update };
+    const replacement = manager.getOrCreate(changed);
+    await closing.started;
+    const concurrent = manager.getOrCreate(changed);
+    // Join the public idle-sweep boundary while old disposal remains blocked.
+    await manager.sweepIdleRuntimes();
+    expect(createRuntime).toHaveBeenCalledOnce();
+
+    closing.release();
+    const nextRuntime = await next.started;
+    next.release();
+    await expect(replacement).resolves.toBe(nextRuntime);
+    await expect(concurrent).resolves.toBe(nextRuntime);
+    expect(createRuntime).toHaveBeenCalledTimes(2);
+    expect(oldRuntime.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("supersedes a pending factory without duplicating its replacement", async () => {
+    const first = holdFactory();
+    const next = holdFactory();
+    const createRuntime = vi
+      .fn<CreateSessionMcpRuntime>(createRuntimeFixture)
+      .mockImplementationOnce(first.createRuntime)
+      .mockImplementationOnce(next.createRuntime);
+    const manager = createManager(createRuntime);
+    const oldRequest = manager.getOrCreate(params).catch((error: unknown) => error);
+    const oldRuntime = await first.started;
+    const changed = { ...params, workspaceDir: "/replacement-workspace" };
+    const replacement = manager.getOrCreate(changed);
+    const concurrent = manager.getOrCreate(changed);
+    await manager.sweepIdleRuntimes();
+    first.release();
+
+    const nextRuntime = await next.started;
+    expect(await oldRequest).toMatchObject({ message: expect.stringContaining("superseded") });
+    expect(oldRuntime.dispose).toHaveBeenCalledOnce();
+    expect(manager.peekSession({ sessionId: params.sessionId })).toBeUndefined();
+    next.release();
+    await expect(replacement).resolves.toBe(nextRuntime);
+    await expect(concurrent).resolves.toBe(nextRuntime);
+    expect(createRuntime).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps required retirement armed across delayed creation and reuse", async () => {
+    const held = holdFactory();
+    const manager = createManager(held.createRuntime);
+    manager.deferRetirement(params.sessionId, { retainAcrossReuse: true });
+    const creating = manager.getOrCreate(params);
+    const runtime = await held.started;
+    held.release();
+    await creating;
+    const release = expectDefined(runtime.acquireLease, "fixture runtime lease")();
+
+    expect(runtime.mcpAppModelContextRevoked).toBe(true);
+    await expect(manager.getOrCreate(params)).resolves.toBe(runtime);
+    await expect(manager.completeDeferredRetirement(params.sessionId, runtime)).resolves.toBe(
+      false,
+    );
+    release();
+    await expect(manager.completeDeferredRetirement(params.sessionId, runtime)).resolves.toBe(true);
+    expect(runtime.dispose).toHaveBeenCalledOnce();
+    expect(manager.listRuntimeKeys()).toEqual([]);
+  });
+
+  it("serializes requester replacement behind global disposal instead of clearing its lock", async () => {
+    resolverTesting.setMcpServerConnectionResolversForTest([
+      { serverName: "scoped", resolve: async () => ({ url: "https://mcp.example.test/scoped" }) },
+    ]);
+    const first = holdFactory();
+    const next = holdFactory();
+    const createRuntime = vi
+      .fn<CreateSessionMcpRuntime>(createRuntimeFixture)
+      .mockImplementationOnce(first.createRuntime)
+      .mockImplementationOnce(next.createRuntime);
+    const manager = createManager(createRuntime);
+    const scoped = {
+      ...params,
+      requesterSenderId: "sender",
+      cfg: { mcp: { servers: { scoped: { transport: "streamable-http" as const } } } },
+    };
+    const firstRequest = manager.getOrCreateRequesterScoped(scoped);
+    const oldRuntime = await first.started;
+    const closing = holdDisposal(oldRuntime);
+    const disposal = manager.disposeAll();
+    const nextRequest = manager.getOrCreateRequesterScoped(scoped);
+    first.release();
+    await closing.started;
+    expect(createRuntime).toHaveBeenCalledOnce();
+    closing.release();
+    await disposal;
+    await firstRequest;
+
+    const nextRuntime = await next.started;
+    next.release();
+    expect((await nextRequest)?.runtime).toBe(nextRuntime);
+    expect(createRuntime).toHaveBeenCalledTimes(2);
+    expect(oldRuntime.dispose).toHaveBeenCalledOnce();
+    expect(nextRuntime.dispose).not.toHaveBeenCalled();
+    expect(manager.listSessionIds()).toEqual([params.sessionId]);
+    expect(manager.resolveSessionId(params.sessionKey)).toBe(params.sessionId);
+  });
+});

--- a/src/agents/agent-bundle-mcp-manager.ts
+++ b/src/agents/agent-bundle-mcp-manager.ts
@@ -1,6 +1,7 @@
 /** Session MCP runtime manager: get-or-create and requester-scoped install orchestration. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { BundleMcpServerConfig } from "../plugins/bundle-mcp.js";
+import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import {
   createCombinedSessionMcpRuntime,
   isCombinedSessionMcpRuntime,
@@ -21,30 +22,20 @@ import {
   partitionMcpServersByConnectionScope,
 } from "./mcp-connection-resolver.js";
 
-/** Bound from agent-bundle-mcp-runtime.ts to avoid an import cycle with the facade. */
-let defaultCreateSessionMcpRuntime: CreateSessionMcpRuntime | undefined;
+const sessionMcpRuntimeLoader = createLazyImportLoader(
+  () => import("./agent-bundle-mcp-runtime.js"),
+);
 
-export function setDefaultCreateSessionMcpRuntime(fn: CreateSessionMcpRuntime): void {
-  defaultCreateSessionMcpRuntime = fn;
-}
-
-function resolveCreateSessionMcpRuntime(
-  createRuntime?: CreateSessionMcpRuntime,
-): CreateSessionMcpRuntime {
-  const resolved = createRuntime ?? defaultCreateSessionMcpRuntime;
-  if (!resolved) {
-    throw new Error("Session MCP runtime factory is not bound");
-  }
-  return resolved;
-}
+// Peeking and retiring sessions need the manager, not its transport implementation.
+const createSessionMcpRuntimeLazy: CreateSessionMcpRuntime = async (params) => {
+  const runtime = await sessionMcpRuntimeLoader.load();
+  return runtime.createSessionMcpRuntime(params);
+};
 
 export function createSessionMcpRuntimeManager(
   opts: SessionMcpRuntimeManagerOpts = {},
 ): SessionMcpRuntimeManager {
-  const store = createSessionMcpRuntimeManagerStore(
-    opts,
-    resolveCreateSessionMcpRuntime(opts.createRuntime),
-  );
+  const store = createSessionMcpRuntimeManagerStore(opts, createSessionMcpRuntimeLazy);
   const lifecycle = createSessionMcpRuntimeManagerLifecycle(store);
   const install = createSessionMcpRuntimeManagerInstall(lifecycle);
   const materializeRequesterScopedRuntime = async (
@@ -359,29 +350,16 @@ export function createSessionMcpRuntimeManager(
     },
     async disposeAll() {
       lifecycle.clearIdleSweepTimer();
-      // Drain all requester chains before clearing maps.
-      const chains = Array.from(store.requesterWorkChains.values());
-      store.requesterWorkChains.clear();
-      await Promise.allSettled(chains);
-      const inFlightRuntimes = Array.from(store.createInFlight.values());
-      store.createInFlight.clear();
-      const runtimes = Array.from(store.runtimesBySessionId.values());
-      store.runtimesBySessionId.clear();
+      const runtimeKeys = new Set([
+        ...store.runtimesBySessionId.keys(),
+        ...store.createInFlight.keys(),
+        ...store.requesterWorkChains.keys(),
+      ]);
       store.sessionIdBySessionKey.clear();
       store.deferredRetirementSessionIds.clear();
       store.requiredRetirementSessionIds.clear();
-      store.connectionMetaByRuntimeKey.clear();
       store.advertisedScopedCatalogBySessionId.clear();
-      const lateRuntimes = await Promise.all(
-        inFlightRuntimes.map(async ({ promise }) => await promise.catch(() => undefined)),
-      );
-      const allRuntimes = new Set<SessionMcpRuntime>(runtimes);
-      for (const runtime of lateRuntimes) {
-        if (runtime) {
-          allRuntimes.add(runtime);
-        }
-      }
-      await Promise.allSettled(Array.from(allRuntimes, (runtime) => runtime.dispose()));
+      await lifecycle.disposeRuntimeKeys(runtimeKeys);
     },
     sweepIdleRuntimes: lifecycle.sweepIdleRuntimes,
     listSessionIds() {

--- a/src/agents/agent-bundle-mcp-runtime-shared.ts
+++ b/src/agents/agent-bundle-mcp-runtime-shared.ts
@@ -47,4 +47,4 @@ export type CreateSessionMcpRuntime = (params: {
   requesterConnect?: RequesterMcpConnect;
   configFingerprint?: string;
   toolOverrides?: Pick<SessionToolOverrides, "mcpServers" | "mcpToolsDeny">;
-}) => SessionMcpRuntime;
+}) => SessionMcpRuntime | Promise<SessionMcpRuntime>;

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -4,7 +4,7 @@ import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult, ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTestTimeout } from "../../test/helpers/promise.js";
@@ -15,9 +15,9 @@ import {
 } from "../../test/helpers/temp-dir.js";
 import { createCombinedSessionMcpRuntime } from "./agent-bundle-mcp-combined.js";
 import { materializeRequesterScopedMcpToolsForHarnessRunCore } from "./agent-bundle-mcp-harness.js";
+import { completeDeferredSessionMcpRuntimeRetirement } from "./agent-bundle-mcp-manager-api.js";
 import { runWithSessionMcpRequestSignal } from "./agent-bundle-mcp-request-context.js";
 import {
-  completeDeferredSessionMcpRuntimeRetirement,
   createBundleMcpJsonSchemaValidator,
   createSessionMcpRuntime,
   testing,
@@ -32,6 +32,8 @@ import {
 import type { SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
 import { writeExecutable } from "./bundle-mcp-shared.test-harness.js";
 import { updateMcpAppModelContext } from "./mcp-app-model-context.js";
+import { fetchMcpAppView, getMcpAppViewLease } from "./mcp-ui-resource.js";
+import { testing as mcpUiResourceTesting } from "./mcp-ui-resource.test-support.js";
 
 const pluginToolMetadata = vi.hoisted(() => new WeakMap<object, unknown>());
 
@@ -137,6 +139,7 @@ async function writeListToolsMcpServer(params: {
   resourcePageCursors?: Array<string | null>;
   resourceListJsonRpcError?: boolean;
   resourceReadJsonRpcError?: boolean;
+  resourceReadResult?: ReadResourceResult;
   promptPageDelayMs?: number;
   promptPageCursors?: Array<string | null>;
 }): Promise<void> {
@@ -187,6 +190,7 @@ const resourcePageCount = ${params.resourcePageCount ?? 1};
 const resourcePageCursors = ${JSON.stringify(params.resourcePageCursors)};
 const resourceListJsonRpcError = ${params.resourceListJsonRpcError === true};
 const resourceReadJsonRpcError = ${params.resourceReadJsonRpcError === true};
+const resourceReadResult = ${JSON.stringify(params.resourceReadResult)};
 const promptPageDelayMs = ${params.promptPageDelayMs ?? 0};
 const promptPageCursors = ${JSON.stringify(params.promptPageCursors)};
 
@@ -420,7 +424,7 @@ function handle(message) {
     send({
       jsonrpc: "2.0",
       id: message.id,
-      result: { contents: [{ uri: message.params?.uri, text: "resource ok" }] },
+      result: resourceReadResult ?? { contents: [{ uri: message.params?.uri, text: "resource ok" }] },
     });
   }
 }
@@ -3175,69 +3179,118 @@ process.on("SIGINT", shutdown);`,
     expect(testing.getCachedSessionIds()).not.toContain("session-run-lease");
   });
 
-  it("keeps an active MCP child and its database lock until deferred retirement completes", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-deferred-run-"));
-    const serverPath = path.join(tempDir, "server.mjs");
-    const logPath = path.join(tempDir, "server.log");
-    const pidPath = path.join(tempDir, "server.pid");
-    const databasePath = path.join(tempDir, "locked.sqlite");
-    await writeListToolsMcpServer({ filePath: serverPath, logPath, pidPath, databasePath });
-    let materialized: Awaited<ReturnType<typeof materializeBundleMcpToolsForRun>> | undefined;
-    let lockProbe: DatabaseSync | undefined;
+  it.each(["run", "app"] as const)(
+    "keeps an active MCP child and database lock until its %s lease retires",
+    async (retirementPath) => {
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-deferred-run-"));
+      const serverPath = path.join(tempDir, "server.mjs");
+      const logPath = path.join(tempDir, "server.log");
+      const pidPath = path.join(tempDir, "server.pid");
+      const databasePath = path.join(tempDir, "locked.sqlite");
+      const appRetirement = retirementPath === "app";
+      await writeListToolsMcpServer({
+        filePath: serverPath,
+        logPath,
+        pidPath,
+        databasePath,
+        capabilities: { tools: {}, resources: {} },
+        resourceReadResult: {
+          contents: [
+            {
+              uri: "ui://fixture/app",
+              mimeType: "text/html;profile=mcp-app",
+              text: "<html><body>lease fixture</body></html>",
+            },
+          ],
+        },
+      });
+      let materialized: Awaited<ReturnType<typeof materializeBundleMcpToolsForRun>> | undefined;
+      let lockProbe: DatabaseSync | undefined;
 
-    try {
-      const runtime = await getOrCreateSessionMcpRuntime({
-        sessionId: "session-run-child",
-        sessionKey: "agent:test:session-run-child",
-        workspaceDir: "/workspace",
-        cfg: {
-          mcp: {
-            servers: {
-              child: { command: process.execPath, args: [serverPath] },
+      try {
+        const runtime = await getOrCreateSessionMcpRuntime({
+          sessionId: "session-run-child",
+          sessionKey: "agent:test:session-run-child",
+          workspaceDir: "/workspace",
+          cfg: {
+            mcp: {
+              apps: { enabled: appRetirement },
+              servers: {
+                child: { command: process.execPath, args: [serverPath] },
+              },
             },
           },
-        },
-      });
-      materialized = await materializeBundleMcpToolsForRun({ runtime });
-      await waitForFileText(pidPath, "", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
-      const pid = Number.parseInt((await fs.readFile(pidPath, "utf8")).trim(), 10);
-      const { DatabaseSync } = await import("node:sqlite");
-      const database = new DatabaseSync(databasePath);
-      lockProbe = database;
-      database.exec("PRAGMA busy_timeout = 0");
-      expect(() => database.exec("BEGIN IMMEDIATE")).toThrow(/database is locked|SQLITE_BUSY/iu);
+        });
+        materialized = await materializeBundleMcpToolsForRun({ runtime });
+        const appView = appRetirement
+          ? await fetchMcpAppView({
+              runtime,
+              serverName: "child",
+              toolName: "slow_tool",
+              uiResourceUri: "ui://fixture/app",
+              toolInput: {},
+              toolResult: { content: [] },
+            })
+          : undefined;
+        if (appRetirement) {
+          expect(appView).toBeDefined();
+        }
+        await waitForFileText(pidPath, "", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
+        const pid = Number.parseInt((await fs.readFile(pidPath, "utf8")).trim(), 10);
+        const { DatabaseSync } = await import("node:sqlite");
+        const database = new DatabaseSync(databasePath);
+        lockProbe = database;
+        database.exec("PRAGMA busy_timeout = 0");
+        expect(() => database.exec("BEGIN IMMEDIATE")).toThrow(/database is locked|SQLITE_BUSY/iu);
 
-      await retireSessionMcpRuntime({
-        sessionId: "session-run-child",
-        reason: "gateway-session-cleanup",
-        preserveActiveLeases: true,
-      });
-      expect(() => process.kill(pid, 0)).not.toThrow();
-      expect(testing.getCachedSessionIds()).toContain("session-run-child");
+        await retireSessionMcpRuntime({
+          sessionId: "session-run-child",
+          reason: "gateway-session-cleanup",
+          preserveActiveLeases: true,
+        });
+        expect(() => process.kill(pid, 0)).not.toThrow();
+        expect(testing.getCachedSessionIds()).toContain("session-run-child");
 
-      await materialized.dispose();
-      materialized = undefined;
-      await waitForPredicate(
-        () => {
+        await materialized.dispose();
+        materialized = undefined;
+        if (appView) {
+          expect(() => process.kill(pid, 0)).not.toThrow();
+          expect(() => database.exec("BEGIN IMMEDIATE")).toThrow(
+            /database is locked|SQLITE_BUSY/iu,
+          );
+          const view = expectDefined(getMcpAppViewLease(appView.viewId, runtime), "MCP App view");
+          // Exercise the real expiry/deletion owner, not a manual retirement completion.
+          const clock = vi.spyOn(Date, "now").mockReturnValue(view.expiresAtMs);
           try {
-            process.kill(pid, 0);
-            return false;
-          } catch {
-            return true;
+            expect(getMcpAppViewLease(appView.viewId, runtime)).toBeUndefined();
+          } finally {
+            clock.mockRestore();
           }
-        },
-        "deferred MCP child process exit",
-        LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
-      );
-      expect(testing.getCachedSessionIds()).not.toContain("session-run-child");
-      expect(() => database.exec("BEGIN IMMEDIATE")).not.toThrow();
-      database.exec("ROLLBACK");
-    } finally {
-      lockProbe?.close();
-      await materialized?.dispose();
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
-  });
+        }
+        await waitForPredicate(
+          () => {
+            try {
+              process.kill(pid, 0);
+              return false;
+            } catch {
+              return true;
+            }
+          },
+          "deferred MCP child process exit",
+          LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
+        );
+        expect(testing.getCachedSessionIds()).not.toContain("session-run-child");
+        expect(() => database.exec("BEGIN IMMEDIATE")).not.toThrow();
+        database.exec("ROLLBACK");
+      } finally {
+        mcpUiResourceTesting.clearViewStore();
+        await retireSessionMcpRuntime({ sessionId: "session-run-child", reason: "test-cleanup" });
+        lockProbe?.close();
+        await materialized?.dispose();
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("keeps a run-mode subagent runtime alive for an approved follow-up turn", async () => {
     const sessionId = "session-subagent-followup";

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -20,27 +20,13 @@ import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import { mergeMcpToolCatalogs } from "./agent-bundle-mcp-combined.js";
 import {
-  completeDeferredSessionMcpRuntimeRetirement,
   disposeAllSessionMcpRuntimes,
-  getAdvertisedScopedMcpCatalog,
-  getOrCreateRequesterScopedMcpRuntime,
-  getOrCreateSessionMcpRuntime,
   getSessionMcpRuntimeManagerForTesting,
-  peekSessionMcpRuntime,
-  rememberAdvertisedScopedMcpCatalog,
-  retireSessionMcpRuntime,
-  retireSessionMcpRuntimeForSessionKey,
 } from "./agent-bundle-mcp-manager-api.js";
-import {
-  createSessionMcpRuntimeManager,
-  setDefaultCreateSessionMcpRuntime,
-} from "./agent-bundle-mcp-manager.js";
+import { createSessionMcpRuntimeManager } from "./agent-bundle-mcp-manager.js";
 import { assignSafeServerNames, sanitizeServerName } from "./agent-bundle-mcp-names.js";
 import { getSessionMcpRequestSignal } from "./agent-bundle-mcp-request-context.js";
-import {
-  loadSessionMcpConfig,
-  resolveSessionMcpConfigSummary,
-} from "./agent-bundle-mcp-runtime-config.js";
+import { loadSessionMcpConfig } from "./agent-bundle-mcp-runtime-config.js";
 import type {
   McpCatalogTool,
   McpRequestOptions,
@@ -1097,23 +1083,6 @@ export function createSessionMcpRuntime(params: {
   };
   return runtime;
 }
-
-setDefaultCreateSessionMcpRuntime(createSessionMcpRuntime);
-
-export {
-  completeDeferredSessionMcpRuntimeRetirement,
-  disposeAllSessionMcpRuntimes,
-  getAdvertisedScopedMcpCatalog,
-  getOrCreateRequesterScopedMcpRuntime,
-  getOrCreateSessionMcpRuntime,
-  peekSessionMcpRuntime,
-  rememberAdvertisedScopedMcpCatalog,
-  resolveSessionMcpConfigSummary,
-  retireSessionMcpRuntime,
-  retireSessionMcpRuntimeForSessionKey,
-};
-export { createSessionMcpRuntimeManager };
-export { mergeMcpToolCatalogs };
 
 export const testing = {
   buildMcpClientCapabilities,

--- a/src/agents/agent-bundle-mcp-tools.ts
+++ b/src/agents/agent-bundle-mcp-tools.ts
@@ -3,10 +3,10 @@ export {
   disposeAllSessionMcpRuntimes,
   getOrCreateSessionMcpRuntime,
   peekSessionMcpRuntime,
-  resolveSessionMcpConfigSummary,
   retireSessionMcpRuntime,
   retireSessionMcpRuntimeForSessionKey,
-} from "./agent-bundle-mcp-runtime.js";
+} from "./agent-bundle-mcp-manager-api.js";
+export { resolveSessionMcpConfigSummary } from "./agent-bundle-mcp-runtime-config.js";
 export {
   buildBundleMcpToolsFromCatalog,
   createBundleMcpToolRuntime,

--- a/src/agents/mcp-auth-profile.integration.test-support.ts
+++ b/src/agents/mcp-auth-profile.integration.test-support.ts
@@ -145,10 +145,36 @@ async function createHttpFixture() {
       }
       requests.push({ method: request.method, headers: request.headers, body });
       order.push("mcp");
-      const message = body ? (JSON.parse(body) as { id?: number }) : undefined;
+      const message = body
+        ? (JSON.parse(body) as {
+            id?: number;
+            method?: string;
+            params?: { protocolVersion: string };
+          })
+        : undefined;
+      // This JSON-only endpoint declines the SDK's optional SSE stream.
+      if (request.method === "GET" && request.headers.accept === "text/event-stream") {
+        response.statusCode = 405;
+        response.setHeader("allow", "POST");
+        response.end();
+        return;
+      }
+      if (message?.method && message.id === undefined) {
+        response.statusCode = 202;
+        response.end();
+        return;
+      }
+      const result =
+        message?.method === "initialize"
+          ? {
+              protocolVersion: message.params?.protocolVersion,
+              capabilities: {},
+              serverInfo: { name: "mcp-proof", version: "1.0.0" },
+            }
+          : {};
       response.end(
         JSON.stringify(
-          message?.id === undefined ? { ok: true } : { jsonrpc: "2.0", id: message.id, result: {} },
+          message?.id === undefined ? { ok: true } : { jsonrpc: "2.0", id: message.id, result },
         ),
       );
     })().catch((error: unknown) => {
@@ -327,6 +353,7 @@ async function runRefreshScenario(root: string): Promise<void> {
   const { loadPersistedAuthProfileStore } = await import("./auth-profiles/persisted.js");
   const { resolveMcpBearerBundleConfig, withMcpAuthProfileBearer } =
     await import("./mcp-auth-profile.js");
+  const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
   const { StreamableHTTPClientTransport } =
     await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
   const endpoint = await createHttpFixture();
@@ -370,26 +397,27 @@ async function runRefreshScenario(root: string): Promise<void> {
     fetch: wrapped,
     requestInit: { headers: { "X-Request": "keep", Authorization: "Bearer stale-sdk-not-real" } },
   });
-  const received: unknown[] = [];
-  // MCP transports use callback properties, not EventTarget listeners.
-  // oxlint-disable-next-line unicorn/prefer-add-event-listener
-  transport.onmessage = (message) => received.push(message);
+  const client = new Client({ name: "mcp-auth-proof", version: "1.0.0" });
+  // Optional SSE GETs are independent of the ordered RPC POSTs under test.
+  const mcpPosts = () => endpoint.requests.filter((request) => request.method === "POST");
   try {
-    await transport.start();
-    await transport.send({ jsonrpc: "2.0", id: 1, method: "ping" });
-    await transport.send({ jsonrpc: "2.0", id: 2, method: "ping" });
+    await client.connect(transport);
+    assert.deepEqual(await client.ping(), {});
+    assert.deepEqual(await client.ping(), {});
     assert.deepEqual(endpoint.refreshInputs, ["stored-refresh-not-real"]);
-    assert.deepEqual(endpoint.order, ["refresh", "mcp", "mcp"]);
-    assert.deepEqual(received, [
-      { jsonrpc: "2.0", id: 1, result: {} },
-      { jsonrpc: "2.0", id: 2, result: {} },
-    ]);
+    assert.equal(endpoint.order[0], "refresh");
+    assert.deepEqual(
+      mcpPosts().map((request) => (JSON.parse(request.body) as { method: string }).method),
+      ["initialize", "notifications/initialized", "ping", "ping"],
+    );
     for (const request of endpoint.requests) {
-      assert.equal(request.method, "POST");
       assert.equal(request.headers.authorization, "Bearer rotated-access-not-real");
       assert.equal(request.headers["x-trace"], "keep");
       assert.equal(request.headers["x-request"], "keep");
-      assert.equal(request.headers.accept, "application/json, text/event-stream");
+      assert.equal(
+        request.headers.accept,
+        request.method === "POST" ? "application/json, text/event-stream" : "text/event-stream",
+      );
     }
     const stored = loadPersistedAuthProfileStore(fixture.agentDir)?.profiles[STORED_PROFILE];
     assert(stored?.type === "oauth");
@@ -440,9 +468,9 @@ async function runRefreshScenario(root: string): Promise<void> {
     }
     seed();
     endpoint.behavior.rejectRefresh = true;
-    const sent = endpoint.requests.length;
+    const sent = mcpPosts().length;
     await assert.rejects(
-      () => transport.send({ jsonrpc: "2.0", id: 3, method: "ping" }),
+      () => client.ping(),
       (error: unknown) => {
         assert(error instanceof Error);
         assert.match(error.message, /fixture refresh denied/u);
@@ -451,11 +479,11 @@ async function runRefreshScenario(root: string): Promise<void> {
         return true;
       },
     );
-    assert.equal(endpoint.requests.length, sent);
+    assert.equal(mcpPosts().length, sent);
     assert(providerEvents.some((event) => event.kind === "refresh"));
     assert(providerEvents.some((event) => event.kind === "refreshed"));
   } finally {
-    await transport.close();
+    await client.close();
     await endpoint.close();
   }
 }

--- a/src/agents/mcp-auth-profile.integration.test-support.ts
+++ b/src/agents/mcp-auth-profile.integration.test-support.ts
@@ -1,0 +1,624 @@
+// Fresh-process fixture: value imports stay outside OpenClaw until each scenario demands them.
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { createServer, type IncomingHttpHeaders } from "node:http";
+import { registerHooks } from "node:module";
+import path from "node:path";
+import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { AuthProfileStore, OAuthCredential } from "./auth-profiles/types.js";
+
+const PLUGIN_ID = "mcp-proof-owner";
+const PROVIDER_ID = "mcp-proof-provider";
+const EXTERNAL_PROFILE = `${PROVIDER_ID}:external`;
+const STORED_PROFILE = `${PROVIDER_ID}:stored`;
+const OBSERVER_KEY: unique symbol = Symbol.for("openclaw.mcpAuthIntegrationObserver");
+type HookContext = { config?: OpenClawConfig; agentDir?: string };
+type ProviderEvent = { kind: string; owner: string };
+type FixtureGlobal = typeof globalThis & {
+  [OBSERVER_KEY]?: (kind: string, owner: string, context?: HookContext) => void;
+};
+const providerEvents: ProviderEvent[] = [];
+let inspectHook: ((owner: string, context?: HookContext) => void) | undefined;
+let authRuntimeEntered = false;
+
+function observe(kind: string, owner: string, context?: HookContext): void {
+  providerEvents.push({ kind, owner });
+  if (kind !== "evaluated" && kind !== "registered") {
+    inspectHook?.(owner, context);
+  }
+}
+
+function writeProvider(root: string, owner: string, tokenUrl: string, enabled = true) {
+  const pluginDir = path.join(root, "plugins", owner);
+  const agentDir = path.join(root, "state", "agents", "main", "agent");
+  const workspaceDir = path.join(root, "workspaces", owner);
+  for (const dir of [pluginDir, agentDir, workspaceDir]) {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o755 });
+  }
+  const credentialPath = path.join(root, `external-${owner}.txt`);
+  fs.writeFileSync(credentialPath, "first");
+  fs.writeFileSync(
+    path.join(pluginDir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: PLUGIN_ID,
+      providers: [PROVIDER_ID],
+      contracts: { externalAuthProviders: [PROVIDER_ID] },
+      configSchema: { type: "object", additionalProperties: false, properties: {} },
+    }),
+  );
+  const source = path.join(pluginDir, "index.cjs");
+  fs.writeFileSync(
+    source,
+    `const fs = require("node:fs");
+const observe = (kind, context) => globalThis[Symbol.for("openclaw.mcpAuthIntegrationObserver")](kind, ${JSON.stringify(owner)}, context);
+observe("evaluated");
+module.exports = {
+  id: ${JSON.stringify(PLUGIN_ID)},
+  register(api) {
+    observe("registered");
+    api.registerProvider({
+      id: ${JSON.stringify(PROVIDER_ID)},
+      label: "MCP proof provider",
+      auth: [],
+      resolveExternalAuthProfiles(context) {
+        observe("overlay", { config: context.config, agentDir: context.agentDir });
+        const file = ${JSON.stringify(credentialPath)};
+        if (!fs.existsSync(file)) return [];
+        return [{
+          profileId: ${JSON.stringify(EXTERNAL_PROFILE)},
+          credential: {
+            type: "oauth",
+            provider: ${JSON.stringify(PROVIDER_ID)},
+            accountId: "fixture-account",
+            access: ${JSON.stringify(`${owner}:`)} + fs.readFileSync(file, "utf8"),
+            refresh: "external-refresh-not-real",
+            expires: Date.now() + 3_600_000,
+          },
+        }];
+      },
+      formatApiKey(credential) {
+        observe("formatted");
+        return JSON.stringify({ token: credential.access, formatterOnly: "must-not-project" });
+      },
+      async refreshOAuth(credential) {
+        observe("refresh");
+        const response = await fetch(${JSON.stringify(tokenUrl)}, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ refresh: credential.refresh }),
+        });
+        if (!response.ok) {
+          await response.body?.cancel();
+          throw new Error("fixture refresh denied");
+        }
+        const rotated = await response.json();
+        observe("refreshed");
+        return { ...credential, ...rotated };
+      },
+    });
+  },
+};
+`,
+  );
+  const config: OpenClawConfig = {
+    plugins: {
+      allow: [PLUGIN_ID],
+      load: { paths: [source] },
+      entries: { [PLUGIN_ID]: { enabled } },
+      slots: { memory: "none" },
+    },
+  };
+  return { config, agentDir, workspaceDir, credentialPath };
+}
+
+type ProviderFixture = ReturnType<typeof writeProvider>;
+type HttpRequest = { method?: string; headers: IncomingHttpHeaders; body: string };
+
+async function createHttpFixture() {
+  const requests: HttpRequest[] = [];
+  const refreshInputs: string[] = [];
+  const order: string[] = [];
+  const errors: unknown[] = [];
+  const behavior = { rejectRefresh: false };
+  const server = createServer((request, response) => {
+    void (async () => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      const body = Buffer.concat(chunks).toString("utf8");
+      response.setHeader("content-type", "application/json");
+      if (request.url === "/token") {
+        const input = JSON.parse(body) as { refresh: string };
+        refreshInputs.push(input.refresh);
+        order.push("refresh");
+        response.statusCode = behavior.rejectRefresh ? 503 : 200;
+        response.end(
+          JSON.stringify({
+            access: "rotated-access-not-real",
+            refresh: "rotated-refresh-not-real",
+            expires: Date.now() + 3_600_000,
+          }),
+        );
+        return;
+      }
+      requests.push({ method: request.method, headers: request.headers, body });
+      order.push("mcp");
+      const message = body ? (JSON.parse(body) as { id?: number }) : undefined;
+      response.end(
+        JSON.stringify(
+          message?.id === undefined ? { ok: true } : { jsonrpc: "2.0", id: message.id, result: {} },
+        ),
+      );
+    })().catch((error: unknown) => {
+      errors.push(error);
+      response.statusCode = 500;
+      response.end();
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  assert(address && typeof address !== "string");
+  const origin = `http://127.0.0.1:${address.port}`;
+  return {
+    url: `${origin}/mcp`,
+    tokenUrl: `${origin}/token`,
+    requests,
+    refreshInputs,
+    order,
+    behavior,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+        server.closeAllConnections();
+      });
+      assert.deepEqual(errors, []);
+    },
+  };
+}
+
+async function consumeFetch(fetchFn: FetchLike, url: string | URL, init?: RequestInit) {
+  const response = await fetchFn(url, init);
+  assert.equal(response.status, 200);
+  await response.arrayBuffer();
+}
+
+function bundleConfig(url: string, profileId = STORED_PROFILE) {
+  return {
+    mcpServers: {
+      proof: {
+        url,
+        auth: "oauth",
+        oauth: { authProfileId: profileId },
+        headers: { Authorization: "Bearer stale-config-not-real", "X-Trace": "keep" },
+      },
+    },
+  };
+}
+
+function isCredentialModule(value: string): boolean {
+  return /(?:^|\/)(?:auth-profiles\/(?:oauth|store)|mcp-auth-profile\.runtime)\.[cm]?[jt]s(?:$|[?#])/u.test(
+    value.replaceAll("\\", "/"),
+  );
+}
+
+async function runExternalScenario(root: string): Promise<void> {
+  const endpoint = await createHttpFixture();
+  const foreign = await createHttpFixture();
+  const fixture = writeProvider(root, "external", endpoint.tokenUrl);
+  const moduleAttempts: string[] = [];
+  const moduleLoads: string[] = [];
+  const observeModuleAttempt = (specifier: string) => {
+    if (isCredentialModule(specifier)) {
+      moduleAttempts.push(specifier);
+      assert(
+        authRuntimeEntered,
+        `credential module requested before MCP bearer demand: ${specifier}`,
+      );
+    }
+  };
+  const hooks = registerHooks({
+    resolve(specifier, context, nextResolve) {
+      observeModuleAttempt(specifier);
+      const resolved = nextResolve(specifier, context);
+      if (!isCredentialModule(specifier)) {
+        observeModuleAttempt(resolved.url);
+      }
+      return resolved;
+    },
+    load(url, context, nextLoad) {
+      // Source loading is not evaluation; the real plugin records evaluation separately.
+      const loaded = nextLoad(url, context);
+      if (isCredentialModule(url)) {
+        moduleLoads.push(url);
+      }
+      return loaded;
+    },
+  });
+  try {
+    const { resolveMcpBearerBundleConfig, withMcpAuthProfileBearer } =
+      await import("./mcp-auth-profile.js");
+    const calls: Array<{ url: string | URL; init?: RequestInit }> = [];
+    const wrapped = withMcpAuthProfileBearer({
+      fetchFn: async (url, init) => {
+        calls.push({ url, init });
+        return fetch(url, init);
+      },
+      serverName: "proof",
+      resourceUrl: endpoint.url,
+      authProfileId: EXTERNAL_PROFILE,
+      cfg: fixture.config,
+      agentDir: fixture.agentDir,
+      headers: { Authorization: "Bearer stale-config-not-real", "X-Trace": "keep" },
+    });
+    const plain = { mcpServers: { plain: { url: endpoint.url } } };
+    assert.deepEqual(await resolveMcpBearerBundleConfig({ config: plain }), {
+      config: plain,
+      env: undefined,
+    });
+    const foreignInit = { headers: { Authorization: "Bearer caller-owned-not-real" } };
+    await consumeFetch(wrapped, foreign.url, foreignInit);
+    assert.equal(calls[0]?.init, foreignInit);
+    // Assert a completed phase, not the live recorders the next request populates.
+    const beforeDemand = {
+      moduleAttempts: [...moduleAttempts],
+      moduleLoads: [...moduleLoads],
+      providerEvents: [...providerEvents],
+    };
+    assert.deepEqual(beforeDemand, { moduleAttempts: [], moduleLoads: [], providerEvents: [] });
+
+    authRuntimeEntered = true;
+    const signal = new AbortController().signal;
+    await consumeFetch(wrapped, new URL(endpoint.url), {
+      headers: { Authorization: "Bearer stale-request-not-real", Accept: "application/json" },
+      signal,
+    });
+    assert.equal(calls.at(-1)?.init?.signal, signal);
+    assert.equal(endpoint.requests.at(-1)?.headers.authorization, "Bearer external:first");
+    assert.equal(endpoint.requests.at(-1)?.headers["x-trace"], "keep");
+    assert.equal(endpoint.requests.at(-1)?.headers.accept, "application/json");
+    assert(moduleAttempts.some((entry) => entry.includes("auth-profiles")));
+    assert(moduleLoads.some((entry) => entry.includes("auth-profiles")));
+    for (const kind of ["evaluated", "registered", "overlay", "formatted"]) {
+      assert(
+        providerEvents.some((event) => event.kind === kind),
+        `missing provider event: ${kind}`,
+      );
+    }
+
+    fs.writeFileSync(fixture.credentialPath, "rotated");
+    await consumeFetch(wrapped, endpoint.url);
+    assert.equal(endpoint.requests.at(-1)?.headers.authorization, "Bearer external:rotated");
+    fs.rmSync(fixture.credentialPath);
+    const sent = endpoint.requests.length;
+    await assert.rejects(() => wrapped(endpoint.url), /profile was not found/u);
+    assert.equal(endpoint.requests.length, sent);
+    const eventsAfterRemoval = providerEvents.length;
+    await consumeFetch(wrapped, new URL(foreign.url), foreignInit);
+    assert.equal(calls.at(-1)?.init, foreignInit);
+    assert.equal(providerEvents.length, eventsAfterRemoval);
+    for (const request of foreign.requests) {
+      assert.equal(request.headers.authorization, "Bearer caller-owned-not-real");
+      assert.equal(request.headers["x-trace"], undefined);
+    }
+    const { loadPersistedAuthProfileStore } = await import("./auth-profiles/persisted.js");
+    assert.equal(
+      loadPersistedAuthProfileStore(fixture.agentDir)?.profiles[EXTERNAL_PROFILE],
+      undefined,
+    );
+    console.log(JSON.stringify({ moduleAttempts, moduleLoads, providerEvents }));
+  } finally {
+    hooks.deregister();
+    await Promise.all([endpoint.close(), foreign.close()]);
+  }
+}
+
+async function runRefreshScenario(root: string): Promise<void> {
+  authRuntimeEntered = true;
+  const { filterStringRecord } = await import("@openclaw/normalization-core/record-coerce");
+  const { saveAuthProfileStore } = await import("./auth-profiles/store.js");
+  const { loadPersistedAuthProfileStore } = await import("./auth-profiles/persisted.js");
+  const { resolveMcpBearerBundleConfig, withMcpAuthProfileBearer } =
+    await import("./mcp-auth-profile.js");
+  const { StreamableHTTPClientTransport } =
+    await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+  const endpoint = await createHttpFixture();
+  const fixture = writeProvider(root, "refresh", endpoint.tokenUrl);
+  const expired: OAuthCredential = {
+    type: "oauth",
+    provider: PROVIDER_ID,
+    accountId: "fixture-account",
+    access: "expired-access-not-real",
+    refresh: "stored-refresh-not-real",
+    expires: 1,
+  };
+  const seed = () => {
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        [STORED_PROFILE]: expired,
+        [`${PROVIDER_ID}:static`]: {
+          type: "token",
+          provider: PROVIDER_ID,
+          token: "static-not-real",
+        },
+      },
+    };
+    saveAuthProfileStore(store, fixture.agentDir, {
+      filterExternalAuthProfiles: false,
+      syncExternalCli: false,
+    });
+  };
+  seed();
+  const wrapped = withMcpAuthProfileBearer({
+    fetchFn: fetch,
+    serverName: "proof",
+    resourceUrl: endpoint.url,
+    authProfileId: STORED_PROFILE,
+    cfg: fixture.config,
+    agentDir: fixture.agentDir,
+    headers: { "X-Trace": "keep", Authorization: "Bearer stale-config-not-real" },
+  });
+  const transport = new StreamableHTTPClientTransport(new URL(endpoint.url), {
+    fetch: wrapped,
+    requestInit: { headers: { "X-Request": "keep", Authorization: "Bearer stale-sdk-not-real" } },
+  });
+  const received: unknown[] = [];
+  // MCP transports use callback properties, not EventTarget listeners.
+  // oxlint-disable-next-line unicorn/prefer-add-event-listener
+  transport.onmessage = (message) => received.push(message);
+  try {
+    await transport.start();
+    await transport.send({ jsonrpc: "2.0", id: 1, method: "ping" });
+    await transport.send({ jsonrpc: "2.0", id: 2, method: "ping" });
+    assert.deepEqual(endpoint.refreshInputs, ["stored-refresh-not-real"]);
+    assert.deepEqual(endpoint.order, ["refresh", "mcp", "mcp"]);
+    assert.deepEqual(received, [
+      { jsonrpc: "2.0", id: 1, result: {} },
+      { jsonrpc: "2.0", id: 2, result: {} },
+    ]);
+    for (const request of endpoint.requests) {
+      assert.equal(request.method, "POST");
+      assert.equal(request.headers.authorization, "Bearer rotated-access-not-real");
+      assert.equal(request.headers["x-trace"], "keep");
+      assert.equal(request.headers["x-request"], "keep");
+      assert.equal(request.headers.accept, "application/json, text/event-stream");
+    }
+    const stored = loadPersistedAuthProfileStore(fixture.agentDir)?.profiles[STORED_PROFILE];
+    assert(stored?.type === "oauth");
+    assert.equal(stored.access, "rotated-access-not-real");
+    assert.equal(stored.refresh, "rotated-refresh-not-real");
+    assert.equal(stored.accountId, "fixture-account");
+
+    for (const tokenProjection of ["env", "literal"] as const) {
+      const projected = await resolveMcpBearerBundleConfig({
+        config: bundleConfig(endpoint.url),
+        cfg: fixture.config,
+        agentDir: fixture.agentDir,
+        tokenProjection,
+      });
+      const server = projected.config.mcpServers.proof;
+      assert(server);
+      const headers = filterStringRecord(server.headers);
+      const authorization = headers?.Authorization;
+      assert.equal(typeof authorization, "string");
+      if (tokenProjection === "literal") {
+        assert.equal(authorization, "Bearer rotated-access-not-real");
+        assert.equal(projected.env, undefined);
+      } else {
+        const envKey = /^Bearer \$\{([^}]+)\}$/u.exec(String(authorization))?.[1];
+        assert(envKey);
+        assert.equal(projected.env?.[envKey], "rotated-access-not-real");
+      }
+      assert.equal(headers?.["X-Trace"], "keep");
+      assert.equal(server.auth, undefined);
+      assert.equal(server.oauth, undefined);
+      const serialized = JSON.stringify(projected);
+      assert(!serialized.includes("rotated-refresh-not-real"));
+      assert(!serialized.includes("formatterOnly"));
+    }
+    for (const [profileId, error] of [
+      [`${PROVIDER_ID}:missing`, /profile was not found/u],
+      [`${PROVIDER_ID}:static`, /profiles are not refreshable/u],
+    ] as const) {
+      await assert.rejects(
+        () =>
+          resolveMcpBearerBundleConfig({
+            config: bundleConfig(endpoint.url, profileId),
+            cfg: fixture.config,
+            agentDir: fixture.agentDir,
+          }),
+        error,
+      );
+    }
+    seed();
+    endpoint.behavior.rejectRefresh = true;
+    const sent = endpoint.requests.length;
+    await assert.rejects(
+      () => transport.send({ jsonrpc: "2.0", id: 3, method: "ping" }),
+      (error: unknown) => {
+        assert(error instanceof Error);
+        assert.match(error.message, /fixture refresh denied/u);
+        assert(!error.message.includes(expired.access));
+        assert(!error.message.includes(expired.refresh));
+        return true;
+      },
+    );
+    assert.equal(endpoint.requests.length, sent);
+    assert(providerEvents.some((event) => event.kind === "refresh"));
+    assert(providerEvents.some((event) => event.kind === "refreshed"));
+  } finally {
+    await transport.close();
+    await endpoint.close();
+  }
+}
+
+async function runScopeScenario(root: string): Promise<void> {
+  authRuntimeEntered = true;
+  const { createPluginCache, withPluginCache } = await import("../plugins/plugin-cache.js");
+  const { loadPluginMetadataSnapshot } = await import("../plugins/plugin-metadata-snapshot.js");
+  const { loadPluginRegistryHandle } = await import("../plugins/loader.js");
+  const { createEmptyPluginRegistry } = await import("../plugins/registry-empty.js");
+  const { getPluginRegistryState } = await import("../plugins/runtime-state.js");
+  const { setActivePluginRegistry } = await import("../plugins/runtime.js");
+  const { getPluginRuntimeGenerationRegistry, withPluginRuntimeGenerationScope } =
+    await import("../plugins/runtime/generation-scope.js");
+  const { getPluginRuntimeGatewayRequestScope, withPluginRuntimeGatewayRequestScope } =
+    await import("../plugins/runtime/gateway-request-scope.js");
+  const { withMcpAuthProfileBearer } = await import("./mcp-auth-profile.js");
+  const prepare = (fixture: ProviderFixture) =>
+    withPluginCache(createPluginCache(), () => {
+      const metadataSnapshot = loadPluginMetadataSnapshot({
+        config: fixture.config,
+        env: process.env,
+        workspaceDir: fixture.workspaceDir,
+        preferPersisted: false,
+      });
+      const pluginRegistry = loadPluginRegistryHandle({
+        config: fixture.config,
+        env: process.env,
+        workspaceDir: fixture.workspaceDir,
+        manifestRegistry: metadataSnapshot.manifestRegistry,
+        installRecords: {},
+        onlyPluginIds: [PLUGIN_ID],
+        cache: false,
+      });
+      return { config: fixture.config, metadataSnapshot, pluginRegistry };
+    });
+  const endpoint = await createHttpFixture();
+  try {
+    const fixtures = ["first", "second", "disabled"].map((owner) =>
+      writeProvider(root, owner, endpoint.tokenUrl, owner !== "disabled"),
+    );
+    const owners = fixtures.map((fixture, index) => {
+      const generation = prepare(fixture);
+      const request = {
+        pluginId: `requester-${index}`,
+        isWebchatConnect: () => false,
+        resolveGatewayContext: () => undefined,
+      };
+      return { fixture, generation, request };
+    });
+    type ScopedOwner = (typeof owners)[number];
+    const [first, second, disabled] = owners;
+    assert(first && second && disabled);
+    assert.equal(first.generation.pluginRegistry.providers.length, 1);
+    assert.equal(second.generation.pluginRegistry.providers.length, 1);
+    assert.equal(disabled.generation.pluginRegistry.providers.length, 0);
+    const checkScope = (owner: ScopedOwner, context?: HookContext) => {
+      assert.deepEqual(getPluginRuntimeGatewayRequestScope(), {
+        ...owner.request,
+        pluginRegistry: owner.generation.pluginRegistry,
+      });
+      assert.equal(getPluginRuntimeGenerationRegistry(), owner.generation.pluginRegistry);
+      if (context) {
+        assert.equal(context.config, owner.fixture.config);
+        assert.equal(context.agentDir, owner.fixture.agentDir);
+      }
+    };
+    inspectHook = (name, context) => checkScope(name === "first" ? first : second, context);
+    const bind = (owner: ScopedOwner) => {
+      const wrapped = withMcpAuthProfileBearer({
+        fetchFn: async (url, init) => {
+          checkScope(owner);
+          return fetch(url, init);
+        },
+        serverName: "proof",
+        resourceUrl: endpoint.url,
+        authProfileId: EXTERNAL_PROFILE,
+        cfg: owner.fixture.config,
+        agentDir: owner.fixture.agentDir,
+      });
+      return () =>
+        withPluginRuntimeGatewayRequestScope(owner.request, () =>
+          withPluginRuntimeGenerationScope(owner.generation, () =>
+            consumeFetch(wrapped, endpoint.url),
+          ),
+        );
+    };
+    const firstRequest = bind(first);
+    const secondRequest = bind(second);
+    setActivePluginRegistry(createEmptyPluginRegistry(), "empty-root");
+    const pendingFirst = firstRequest();
+    setActivePluginRegistry(
+      second.generation.pluginRegistry,
+      "replacement-root",
+      "default",
+      second.fixture.workspaceDir,
+    );
+    await Promise.all([pendingFirst, secondRequest()]);
+    const authorizations = endpoint.requests.map((request) => {
+      const authorization = request.headers.authorization;
+      assert(authorization, "missing Authorization header on a scoped MCP request");
+      return authorization;
+    });
+    assert.deepEqual(
+      authorizations.toSorted((left, right) => left.localeCompare(right)),
+      ["Bearer first:first", "Bearer second:first"],
+    );
+    fs.writeFileSync(first.fixture.credentialPath, "rotated");
+    await firstRequest();
+    assert.equal(endpoint.requests.at(-1)?.headers.authorization, "Bearer first:rotated");
+    const sent = endpoint.requests.length;
+    await assert.rejects(bind(disabled), /profile was not found/u);
+    assert.equal(endpoint.requests.length, sent);
+    assert(!providerEvents.some((event) => event.owner === "disabled"));
+    assert.equal(getPluginRuntimeGatewayRequestScope(), undefined);
+    assert.equal(getPluginRuntimeGenerationRegistry(), undefined);
+    assert.equal(getPluginRegistryState()?.activeRegistry, second.generation.pluginRegistry);
+  } finally {
+    inspectHook = undefined;
+    await endpoint.close();
+  }
+}
+
+async function main(): Promise<void> {
+  const [scenario, root] = process.argv.slice(2);
+  assert(root);
+  const globals = globalThis as FixtureGlobal;
+  globals[OBSERVER_KEY] = observe;
+  try {
+    switch (scenario) {
+      case "external":
+        await runExternalScenario(root);
+        break;
+      case "refresh":
+        await runRefreshScenario(root);
+        break;
+      case "scopes":
+        await runScopeScenario(root);
+        break;
+      default:
+        throw new Error(`Unknown MCP auth proof scenario: ${scenario}`);
+    }
+  } finally {
+    try {
+      // A rejected cold import must not load auth owners merely to clean them up.
+      if (authRuntimeEntered) {
+        const { closeAuthProfileReadPool } = await import("./auth-profiles/sqlite.js");
+        const { closeOpenClawAgentDatabasesForTest } =
+          await import("../state/openclaw-agent-db.js");
+        const { closeOpenClawStateDatabaseForTest } = await import("../state/openclaw-state-db.js");
+        closeAuthProfileReadPool();
+        // Agent closure releases leases through shared state; close that owner last.
+        closeOpenClawAgentDatabasesForTest();
+        closeOpenClawStateDatabaseForTest();
+      }
+    } finally {
+      delete globals[OBSERVER_KEY];
+    }
+  }
+  console.log(`MCP_AUTH_PROOF_OK ${scenario}`);
+}
+
+void main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/agents/mcp-auth-profile.integration.test.ts
+++ b/src/agents/mcp-auth-profile.integration.test.ts
@@ -1,0 +1,66 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+
+const execFileAsync = promisify(execFile);
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const fixturePath = fileURLToPath(
+  new URL("./mcp-auth-profile.integration.test-support.ts", import.meta.url),
+);
+
+function createChildEnv(root: string): NodeJS.ProcessEnv {
+  const home = path.join(root, "home");
+  const state = path.join(root, "state");
+  const temporary = path.join(root, "tmp");
+  for (const dir of [home, state, temporary]) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  const configPath = path.join(state, "openclaw.json");
+  fs.writeFileSync(configPath, "{}\n");
+  // A fresh process must not inherit operator credentials, test mocks, or Node preloads.
+  return {
+    PATH: process.env.PATH,
+    SystemRoot: process.env.SystemRoot,
+    WINDIR: process.env.WINDIR,
+    HOME: home,
+    USERPROFILE: home,
+    OPENCLAW_HOME: home,
+    OPENCLAW_STATE_DIR: state,
+    OPENCLAW_CONFIG_PATH: configPath,
+    TMPDIR: temporary,
+    TMP: temporary,
+    TEMP: temporary,
+  };
+}
+
+describe("MCP profile auth through real credential owners", () => {
+  it.each([
+    ["external", "stays cold until demand and observes external rotation, removal, and origins"],
+    ["refresh", "refreshes persisted OAuth through the SDK and projects only raw access tokens"],
+    ["scopes", "retains request bindings and exact plugin generations across deferred auth"],
+  ])(
+    "%s: %s",
+    async (scenario) => {
+      const root = tempDirs.make("openclaw-mcp-auth-demand-");
+      // Child isolation also keeps neighboring suites' store/provider mocks out of this proof.
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        ["--import", "tsx", fixturePath, scenario, root],
+        {
+          cwd: repoRoot,
+          env: createChildEnv(root),
+          timeout: 30_000,
+          killSignal: "SIGKILL",
+          maxBuffer: 1024 * 1024,
+        },
+      );
+      expect(stdout).toContain(`MCP_AUTH_PROOF_OK ${scenario}`);
+    },
+    40_000,
+  );
+});

--- a/src/agents/mcp-auth-profile.runtime.ts
+++ b/src/agents/mcp-auth-profile.runtime.ts
@@ -1,0 +1,49 @@
+/** Demand-loaded auth-profile resolution for MCP bearer injection and projection. */
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveApiKeyForProfile } from "./auth-profiles/oauth.js";
+import { loadAuthProfileStoreForSecretsRuntime } from "./auth-profiles/store.js";
+
+export async function resolveMcpAuthProfileBearerToken(params: {
+  serverName: string;
+  profileId: string;
+  cfg?: OpenClawConfig;
+  agentDir?: string;
+}): Promise<string> {
+  const store = loadAuthProfileStoreForSecretsRuntime(params.agentDir, {
+    config: params.cfg,
+    externalCliProfileIds: [params.profileId],
+  });
+  const credential = store.profiles[params.profileId];
+  if (!credential) {
+    throw new Error(
+      `MCP server "${params.serverName}" references auth profile "${params.profileId}", but that profile was not found.`,
+    );
+  }
+  if (credential.type !== "oauth") {
+    throw new Error(
+      `MCP server "${params.serverName}" references auth profile "${params.profileId}", but ${credential.type} profiles are not refreshable. Use a refresh-capable OAuth profile.`,
+    );
+  }
+  const resolved = await resolveApiKeyForProfile({
+    cfg: params.cfg,
+    store,
+    profileId: params.profileId,
+    agentDir: params.agentDir,
+  });
+  if (!resolved || resolved.profileType !== "oauth" || !resolved.apiKey) {
+    throw new Error(
+      `MCP server "${params.serverName}" could not resolve refreshable OAuth auth profile "${params.profileId}". Re-authenticate the profile and retry.`,
+    );
+  }
+  if (
+    !resolved.credential ||
+    resolved.credential.type !== "oauth" ||
+    typeof resolved.credential.access !== "string" ||
+    resolved.credential.access.trim().length === 0
+  ) {
+    throw new Error(
+      `MCP server "${params.serverName}" resolved OAuth auth profile "${params.profileId}", but no raw access token was available for bearer projection.`,
+    );
+  }
+  return resolved.credential.access;
+}

--- a/src/agents/mcp-auth-profile.ts
+++ b/src/agents/mcp-auth-profile.ts
@@ -6,8 +6,7 @@ import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { filterStringRecord, isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { BundleMcpConfig, BundleMcpServerConfig } from "../plugins/bundle-mcp.js";
-import { resolveApiKeyForProfile } from "./auth-profiles/oauth.js";
-import { loadAuthProfileStoreForSecretsRuntime } from "./auth-profiles/store.js";
+import { createLazyRuntimeMethod } from "../shared/lazy-runtime.js";
 import {
   buildMcpHttpFetch,
   withoutMcpAuthorizationHeader,
@@ -41,50 +40,11 @@ export function requiresMcpBearerProjection(rawServer: unknown): boolean {
   return Boolean(resolveMcpAuthProfileId(rawServer) || typeof rawServer.url === "string");
 }
 
-async function resolveMcpAuthProfileBearerToken(
-  params: {
-    serverName: string;
-    profileId: string;
-  } & McpAuthProfileOptions,
-): Promise<string> {
-  const store = loadAuthProfileStoreForSecretsRuntime(params.agentDir, {
-    config: params.cfg,
-    externalCliProfileIds: [params.profileId],
-  });
-  const credential = store.profiles[params.profileId];
-  if (!credential) {
-    throw new Error(
-      `MCP server "${params.serverName}" references auth profile "${params.profileId}", but that profile was not found.`,
-    );
-  }
-  if (credential.type !== "oauth") {
-    throw new Error(
-      `MCP server "${params.serverName}" references auth profile "${params.profileId}", but ${credential.type} profiles are not refreshable. Use a refresh-capable OAuth profile.`,
-    );
-  }
-  const resolved = await resolveApiKeyForProfile({
-    cfg: params.cfg,
-    store,
-    profileId: params.profileId,
-    agentDir: params.agentDir,
-  });
-  if (!resolved || resolved.profileType !== "oauth" || !resolved.apiKey) {
-    throw new Error(
-      `MCP server "${params.serverName}" could not resolve refreshable OAuth auth profile "${params.profileId}". Re-authenticate the profile and retry.`,
-    );
-  }
-  if (
-    !resolved.credential ||
-    resolved.credential.type !== "oauth" ||
-    typeof resolved.credential.access !== "string" ||
-    resolved.credential.access.trim().length === 0
-  ) {
-    throw new Error(
-      `MCP server "${params.serverName}" resolved OAuth auth profile "${params.profileId}", but no raw access token was available for bearer projection.`,
-    );
-  }
-  return resolved.credential.access;
-}
+// Keep profile discovery on credential demand; never memoize the store or bearer.
+const resolveMcpAuthProfileBearerToken = createLazyRuntimeMethod(
+  () => import("./mcp-auth-profile.runtime.js"),
+  (runtime) => runtime.resolveMcpAuthProfileBearerToken,
+);
 
 async function resolveMcpBearerToken(params: {
   serverName: string;

--- a/src/agents/mcp-ui-resource.import-boundary.test.ts
+++ b/src/agents/mcp-ui-resource.import-boundary.test.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { expect, it } from "vitest";
+import {
+  formatCliProcessFailure,
+  runCliProcessChild,
+} from "../cli/cli-process-child.test-helpers.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+
+it("projects MCP App metadata without loading session runtime management", async () => {
+  await withOpenClawTestState({ label: "mcp-app-import", applyEnv: false }, async (state) => {
+    const entry = state.path("app-import.mjs");
+    const temporaryDir = state.path("tmp");
+    await fs.mkdir(temporaryDir);
+    await state.writeConfig({ logging: { file: state.path("runtime.log") } });
+    await fs.writeFile(
+      entry,
+      `import assert from "node:assert/strict";
+import { registerHooks } from "node:module";
+assert.equal(process.env.VITEST, undefined);
+assert.equal(process.env.NODE_ENV, undefined);
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (/agent-bundle-mcp-(?:runtime|manager(?:-api)?)\\.[jt]s(?:[?#]|$)/.test(specifier)) {
+      throw new Error("MCP App metadata imported runtime management: " + specifier + " from " + context.parentURL);
+    }
+    return nextResolve(specifier, context);
+  },
+});
+const { buildMcpAppCanvasPayload, readMcpAppChannelView } = await import(${JSON.stringify(pathToFileURL(path.resolve("src/agents/mcp-ui-resource.ts")).href)});
+const preview = buildMcpAppCanvasPayload({
+  viewId: "mcp-app-fixture", title: "Fixture", serverName: "fixture", toolName: "show", uiResourceUri: "ui://fixture/app",
+});
+assert.equal(preview.kind, "canvas");
+assert.deepEqual(readMcpAppChannelView({ details: { mcpAppPreview: preview } }), { viewId: "mcp-app-fixture" });
+console.log("mcp-app-import-boundary-ok");
+`,
+    );
+    const result = await runCliProcessChild({
+      nodeArgs: ["--import", "tsx", entry],
+      env: {
+        PATH: process.env.PATH,
+        SystemRoot: process.env.SystemRoot,
+        ...state.envVars,
+        TMPDIR: temporaryDir,
+        TMP: temporaryDir,
+        TEMP: temporaryDir,
+      },
+      timeoutMs: 30_000,
+    });
+    expect(
+      result.code,
+      formatCliProcessFailure({ reason: "MCP App cold import failed", ...result }),
+    ).toBe(0);
+    expect(result.signal).toBeNull();
+    expect(result.stdout).toContain("mcp-app-import-boundary-ok");
+  });
+});

--- a/src/agents/mcp-ui-resource.ts
+++ b/src/agents/mcp-ui-resource.ts
@@ -4,11 +4,16 @@ import { asOptionalRecord as asRecord } from "@openclaw/normalization-core/recor
 import { formatErrorMessage } from "../infra/errors.js";
 import { logWarn } from "../logger.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
+import { createLazyRuntimeMethod } from "../shared/lazy-runtime.js";
 import { getSessionMcpRequestSignal } from "./agent-bundle-mcp-request-context.js";
-import { completeDeferredSessionMcpRuntimeRetirement } from "./agent-bundle-mcp-runtime.js";
 import type { SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
 import { clearMcpAppModelContextForView } from "./mcp-app-model-context.js";
 import { type McpAppCsp, normalizeMcpAppCsp } from "./mcp-app-sandbox.js";
+
+const completeDeferredSessionMcpRuntimeRetirement = createLazyRuntimeMethod(
+  () => import("./agent-bundle-mcp-manager-api.js"),
+  (runtime) => runtime.completeDeferredSessionMcpRuntimeRetirement,
+);
 
 const MCP_APP_RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
 const MCP_APP_RESOURCE_MAX_BYTES = 2 * 1024 * 1024;

--- a/src/cli/mcp-cli.oauth-integration.test.ts
+++ b/src/cli/mcp-cli.oauth-integration.test.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { createServer } from "node:http";
 import { Command } from "commander";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import {
   operatorMcpOAuthIdentity,
   requesterMcpOAuthIdentity,
@@ -244,7 +245,14 @@ describe("mcp login OAuth integration", () => {
       const fixture = await startOAuthFixture(oauthPort);
       const redirectUrl = `http://127.0.0.1:${callbackPort}/oauth/callback`;
       const logs: string[] = [];
-      vi.spyOn(defaultRuntime, "log").mockImplementation((line) => logs.push(String(line)));
+      const authorizationUrl = createDeferred<string>();
+      vi.spyOn(defaultRuntime, "log").mockImplementation((line) => {
+        const text = String(line);
+        logs.push(text);
+        if (text.startsWith(`${fixture.issuer}/authorize`)) {
+          authorizationUrl.resolve(text);
+        }
+      });
       const program = new Command().exitOverride();
       registerMcpCli(program);
       try {
@@ -264,18 +272,19 @@ describe("mcp login OAuth integration", () => {
         );
         logs.length = 0;
 
-        const login = program.parseAsync(["mcp", "login", "fixture"], { from: "user" });
-        await vi.waitFor(() => {
-          expect(logs.some((line) => line.includes("Waiting for the browser"))).toBe(true);
+        // Drive the browser from the published URL, not a polling deadline that
+        // can abandon login while discovery still owns the temporary state.
+        const browser = authorizationUrl.promise.then(async (url) => {
+          const response = await fetch(url);
+          return { status: response.status, body: await response.text() };
         });
-        const authorizationUrl = logs.find((line) =>
-          line.startsWith(`${fixture.issuer}/authorize`),
-        );
-        expect(authorizationUrl).toBeDefined();
-        const browserResponse = await fetch(authorizationUrl!);
+        const [browserResponse] = await Promise.all([
+          browser,
+          program.parseAsync(["mcp", "login", "fixture"], { from: "user" }),
+        ]);
+        expect(logs.some((line) => line.includes("Waiting for the browser"))).toBe(true);
         expect(browserResponse.status).toBe(200);
-        await expect(browserResponse.text()).resolves.toContain("Authorization received");
-        await login;
+        expect(browserResponse.body).toContain("Authorization received");
 
         await expect(
           readMcpOAuthCredentialsStatus(
@@ -289,9 +298,7 @@ describe("mcp login OAuth integration", () => {
           tokenVerifier: expect.any(String),
         });
         expect(logs).toContain('MCP OAuth credentials saved for "fixture".');
-        await vi.waitFor(async () => {
-          await expect(fetch(redirectUrl)).rejects.toThrow();
-        });
+        await expect(fetch(redirectUrl)).rejects.toThrow();
       } finally {
         await fixture.close();
       }

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -11,10 +11,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { Command } from "commander";
 import { buildBundleMcpToolsFromCatalog } from "../agents/agent-bundle-mcp-materialize.js";
-import {
-  createSessionMcpRuntime,
-  disposeAllSessionMcpRuntimes,
-} from "../agents/agent-bundle-mcp-runtime.js";
+import type { McpToolCatalog } from "../agents/agent-bundle-mcp-types.js";
 import {
   setConfiguredMcpServer,
   unsetConfiguredMcpServer,
@@ -43,11 +40,21 @@ import {
 } from "../infra/oauth-loopback-callback.js";
 import { resolveEnvironmentValue } from "../infra/process-env.js";
 import { defaultRuntime } from "../runtime.js";
+import { createLazyRuntimeMethod } from "../shared/lazy-runtime.js";
 import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import { formatCliCommand } from "./command-format.js";
 import { resolveGatewayAuthOptions } from "./gateway-secret-options.js";
 import { requestExitAfterOneShotOutput } from "./one-shot-exit.js";
 import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
+
+const createSessionMcpRuntime = createLazyRuntimeMethod(
+  () => import("../agents/agent-bundle-mcp-runtime.js"),
+  (runtime) => runtime.createSessionMcpRuntime,
+);
+const disposeAllSessionMcpRuntimes = createLazyRuntimeMethod(
+  () => import("../agents/agent-bundle-mcp-manager-api.js"),
+  (runtime) => runtime.disposeAllSessionMcpRuntimes,
+);
 
 function fail(message: string): never {
   defaultRuntime.error(message);
@@ -397,7 +404,7 @@ async function probeMcpServerIssues(params: {
   name: string;
   server: Record<string, unknown>;
 }): Promise<McpDoctorIssue[]> {
-  const runtime = createSessionMcpRuntime({
+  const runtime = await createSessionMcpRuntime({
     sessionId: "openclaw-cli-mcp-doctor",
     workspaceDir: process.cwd(),
     cfg: buildMcpProbeConfig({
@@ -492,9 +499,7 @@ async function buildMcpStatusEntries(
   );
 }
 
-function formatMcpProbeResult(
-  catalog: Awaited<ReturnType<ReturnType<typeof createSessionMcpRuntime>["getCatalog"]>>,
-) {
+function formatMcpProbeResult(catalog: McpToolCatalog) {
   const projectedTools = buildBundleMcpToolsFromCatalog({
     catalog,
     createResourceListExecute: () => async () => {
@@ -622,7 +627,7 @@ async function probeMcpServersOrFail(params: {
       applyMcpProbeInitializeTimeout(server),
     ]),
   );
-  const runtime = createSessionMcpRuntime({
+  const runtime = await createSessionMcpRuntime({
     sessionId: "openclaw-cli-mcp-probe",
     workspaceDir: process.cwd(),
     cfg: buildMcpProbeConfig({ config: params.config, servers: probeServers }),
@@ -842,7 +847,7 @@ export function registerMcpCli(program: Command) {
         );
         return;
       }
-      const runtime = createSessionMcpRuntime({
+      const runtime = await createSessionMcpRuntime({
         sessionId: "openclaw-cli-mcp-probe",
         workspaceDir: process.cwd(),
         cfg: buildMcpProbeConfig({ config: loaded.config, servers }),

--- a/src/gateway/mcp-app-channel-action.test.ts
+++ b/src/gateway/mcp-app-channel-action.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
   peekRuntime: vi.fn(),
 }));
 
-vi.mock("../agents/agent-bundle-mcp-runtime.js", () => ({
+vi.mock("../agents/agent-bundle-mcp-manager-api.js", () => ({
   peekSessionMcpRuntime: mocks.peekRuntime,
 }));
 vi.mock("../agents/mcp-ui-resource.js", () => ({

--- a/src/gateway/mcp-app-channel-action.ts
+++ b/src/gateway/mcp-app-channel-action.ts
@@ -1,4 +1,4 @@
-import { peekSessionMcpRuntime } from "../agents/agent-bundle-mcp-runtime.js";
+import { peekSessionMcpRuntime } from "../agents/agent-bundle-mcp-manager-api.js";
 import type { McpAppChannelView } from "../agents/mcp-ui-resource.js";
 import { getMcpAppViewLease } from "../agents/mcp-ui-resource.js";
 import type { MessagePresentation } from "../interactive/payload.js";

--- a/src/gateway/mcp-app-operations.ts
+++ b/src/gateway/mcp-app-operations.ts
@@ -11,11 +11,11 @@ import {
   ReadResourceRequestSchema,
   type Tool,
 } from "@modelcontextprotocol/sdk/types.js";
-import { getSessionMcpRequestSignal } from "../agents/agent-bundle-mcp-request-context.js";
 import {
   completeDeferredSessionMcpRuntimeRetirement,
   peekSessionMcpRuntime,
-} from "../agents/agent-bundle-mcp-runtime.js";
+} from "../agents/agent-bundle-mcp-manager-api.js";
+import { getSessionMcpRequestSignal } from "../agents/agent-bundle-mcp-request-context.js";
 import type { McpCatalogTool, SessionMcpRuntime } from "../agents/agent-bundle-mcp-types.js";
 import {
   acquireMcpAppViewRequest,

--- a/src/gateway/mcp-app-reconstruction.test.ts
+++ b/src/gateway/mcp-app-reconstruction.test.ts
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => ({
   visitSessionMessagesAsync: vi.fn(),
 }));
 
-vi.mock("../agents/agent-bundle-mcp-runtime.js", () => ({
+vi.mock("../agents/agent-bundle-mcp-manager-api.js", () => ({
   getOrCreateSessionMcpRuntime: mocks.getOrCreateSessionMcpRuntime,
 }));
 vi.mock("../agents/agent-scope.js", () => ({

--- a/src/gateway/mcp-app-reconstruction.ts
+++ b/src/gateway/mcp-app-reconstruction.ts
@@ -2,7 +2,7 @@ import { type CallToolResult, ContentBlockSchema } from "@modelcontextprotocol/s
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { BoardMcpAppDescriptor } from "../../packages/gateway-protocol/src/index.js";
-import { getOrCreateSessionMcpRuntime } from "../agents/agent-bundle-mcp-runtime.js";
+import { getOrCreateSessionMcpRuntime } from "../agents/agent-bundle-mcp-manager-api.js";
 import type { SessionMcpRuntime } from "../agents/agent-bundle-mcp-types.js";
 import { resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import {

--- a/src/gateway/mcp-app-standalone.http.test-support.ts
+++ b/src/gateway/mcp-app-standalone.http.test-support.ts
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
   peekSessionMcpRuntime: vi.fn(),
 }));
 
-vi.mock("../agents/agent-bundle-mcp-runtime.js", () => ({
+vi.mock("../agents/agent-bundle-mcp-manager-api.js", () => ({
   completeDeferredSessionMcpRuntimeRetirement: mocks.completeRetirement,
   peekSessionMcpRuntime: mocks.peekSessionMcpRuntime,
 }));

--- a/src/gateway/mcp-app-standalone.ts
+++ b/src/gateway/mcp-app-standalone.ts
@@ -1,7 +1,7 @@
 import { createHash, createHmac, randomBytes } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { peekSessionMcpRuntime } from "../agents/agent-bundle-mcp-manager-api.js";
 import { runWithSessionMcpRequestSignal } from "../agents/agent-bundle-mcp-request-context.js";
-import { peekSessionMcpRuntime } from "../agents/agent-bundle-mcp-runtime.js";
 import { buildMcpAppSandboxPath, resolveMcpAppSandboxPort } from "../agents/mcp-app-sandbox.js";
 import { getMcpAppViewLease, type McpAppViewLease } from "../agents/mcp-ui-resource.js";
 import { formatErrorMessage } from "../infra/errors.js";

--- a/src/gateway/server-methods/mcp-app.test.ts
+++ b/src/gateway/server-methods/mcp-app.test.ts
@@ -20,7 +20,7 @@ vi.mock("../../agents/mcp-ui-resource.js", () => ({
 vi.mock("../../agents/mcp-app-sandbox.js", () => ({
   buildMcpAppSandboxPath: () => "mcp-app-sandbox",
 }));
-vi.mock("../../agents/agent-bundle-mcp-runtime.js", () => ({
+vi.mock("../../agents/agent-bundle-mcp-manager-api.js", () => ({
   completeDeferredSessionMcpRuntimeRetirement: mocks.completeDeferredSessionMcpRuntimeRetirement,
   peekSessionMcpRuntime: mocks.peekSessionMcpRuntime,
 }));

--- a/test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts
+++ b/test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts
@@ -5,11 +5,11 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
-import { materializeBundleMcpToolsForRun } from "../../../../dist/agents/agent-bundle-mcp-materialize.js";
 import {
   disposeAllSessionMcpRuntimes,
   getOrCreateSessionMcpRuntime,
-} from "../../../../dist/agents/agent-bundle-mcp-runtime.js";
+} from "../../../../dist/agents/agent-bundle-mcp-manager-api.js";
+import { materializeBundleMcpToolsForRun } from "../../../../dist/agents/agent-bundle-mcp-materialize.js";
 import { resolveConversationCapabilityProfile } from "../../../../dist/agents/conversation-capability-profile.js";
 import { applyFinalEffectiveToolPolicy } from "../../../../dist/agents/embedded-agent-runner/effective-tool-policy.js";
 import { splitSdkTools } from "../../../../dist/agents/embedded-agent-runner/tool-split.js";

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -378,6 +378,8 @@ function buildCoreDistEntries(): Record<string, string> {
     "cli/daemon-cli": "src/cli/daemon-cli.ts",
     // Keep long-lived lazy runtime boundaries on stable filenames so rebuilt
     // dist/ trees do not strand already-running gateways on stale hashed chunks.
+    "agents/agent-bundle-mcp-runtime": "src/agents/agent-bundle-mcp-runtime.ts",
+    "agents/mcp-auth-profile.runtime": "src/agents/mcp-auth-profile.runtime.ts",
     "agents/auth-profiles.runtime": "src/agents/auth-profiles.runtime.ts",
     "agents/model-catalog.runtime": "src/agents/model-catalog.runtime.ts",
     "agents/models-config.runtime": "src/agents/models-config.runtime.ts",
@@ -442,8 +444,8 @@ function buildCoreDistEntries(): Record<string, string> {
 function buildDockerE2eHarnessEntries(): Record<string, string> {
   return {
     // Mounted Docker harnesses need stable package dist entries for asserted internal modules.
+    "agents/agent-bundle-mcp-manager-api": "src/agents/agent-bundle-mcp-manager-api.ts",
     "agents/agent-bundle-mcp-materialize": "src/agents/agent-bundle-mcp-materialize.ts",
-    "agents/agent-bundle-mcp-runtime": "src/agents/agent-bundle-mcp-runtime.ts",
     "agents/conversation-capability-profile": "src/agents/conversation-capability-profile.ts",
     "agents/embedded-agent-runner/effective-tool-policy":
       "src/agents/embedded-agent-runner/effective-tool-policy.ts",

--- a/ui/src/e2e/mcp-app-conformance.e2e.test.ts
+++ b/ui/src/e2e/mcp-app-conformance.e2e.test.ts
@@ -8,11 +8,11 @@ import os from "node:os";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext, type Frame } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { materializeBundleMcpToolsForRun } from "../../../src/agents/agent-bundle-mcp-materialize.js";
 import {
   disposeAllSessionMcpRuntimes,
   getOrCreateSessionMcpRuntime,
-} from "../../../src/agents/agent-bundle-mcp-runtime.js";
+} from "../../../src/agents/agent-bundle-mcp-manager-api.js";
+import { materializeBundleMcpToolsForRun } from "../../../src/agents/agent-bundle-mcp-materialize.js";
 import { getMcpAppViewLease } from "../../../src/agents/mcp-ui-resource.js";
 import {
   clearConfigCache,


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/132932 — independently owned tool-metadata extraction; this PR does not duplicate it.

## What Problem This Solves

Resolves a problem where MCP metadata and cleanup operations initialized runtime dependencies they did not need, while creating a session through the lifecycle manager depended on another module having bound its factory first. Genuinely lazy creation also needs teardown to own pending work so a late result cannot resurrect a disposed runtime or clear its successor.

This repairs MCP-owned import paths. It does not claim every CLI path is loader-free, equate module loading with plugin activation, or attribute historical MCP deadline failures to import timing.

## Why This Change Was Made

Profile resolution loads at the existing asynchronous bearer-demand boundary and still uses canonical profile stores, external overlays, OAuth refresh, and raw access tokens on every use. Lifecycle consumers use the manager API; the manager loads its real factory on demand instead of depending on an import-time setter. Exact pending-promise ownership fences publication and cleanup, preserves requester serialization and aliases, and retains required retirement across creation and reuse.

App view deletion still releases its lease before deferred retirement. Internal, UI-conformance, and packaged-test callers use the canonical manager API. Factory/auth modules use the existing stable build-entry mechanism for deferred imports during live dist replacement. No compatibility reexports or alternate stores were added.

Connected test repairs keep the real boundaries intact: OAuth CLI login is driven from its emitted authorization URL and joined before cleanup; auth fixtures close acquired database owners in the right order and use the SDK Client for initialization/ping response correlation. The temporary quota fixture repair is no longer in this diff: current main already supplies its provider-tagged history and improved selection/response handling, so the duplicate ten-line commit was dropped during conflict resolution.

## User Impact

MCP metadata inspection and empty cleanup no longer require the transport factory or profile-auth implementation first. Discovery, tool execution, refresh, requester isolation, and App lease retirement continue through their existing owners. Gateway action/approval bodies, configuration, dependencies, schema, persistence semantics, and permission policy are unchanged by this PR.

Production/build LOC: **+172/-218, net -46**. Tests/test support: **+1198/-84, net +1114**. Twenty-nine files; test-only support is counted separately from production.

## Evidence

Current candidate: `8ab596daab8eedffb5b05c6f0a50f2eee7893d08`, tree `f69808937d4223349ed4627e334558d8d0d3391d`, rebased onto `6425f8f16a27d1f941cc3c99d964c330e8e2e53a`.

- **Current-main refresh:** all 29 remaining file patches are byte-for-byte identical before and after the required conflict rebase. The sole upstream overlap was the now-redundant quota fixture. The fetched base passed [main CI run 33296353305](https://github.com/openclaw/openclaw/actions/runs/33296353305). Direct caller/callee review found no incompatible MCP owner drift; the plugin loader and runtime factory carry the same config/state capability objects through lazy materialization, and the embedded caller still awaits creation and captures App policy. This addresses ClawSweeper's current-main inspection/rank-up request.
- **Before/after import proof:** cold-import regressions failed against original production for the intended profile-implementation and App-runtime import edges, then passed with the candidate restored. These are forbidden-import failures, not timeout-based evidence.
- **Current-head MCP/auth proof:** 17 focused cases passed: four suppression-ratchet cases plus thirteen auth/import/manager cases. Real local store/provider owners and SDK HTTP requests cover external rotation/removal, persisted refresh, raw-token projection, request/generation isolation, and delayed creation/disposal. The refresh fixture performs normal SDK Client initialization and validated ping responses; the original 30-second child guards remain unchanged.
- **Current-head quota composition:** the complete upstream five-case quota E2E file passed in its original order after dropping our duplicate fixture. Current main's provider input, normal sidebar selection, held-response handling, and stale-auth/account/plan assertions are retained unchanged. There is no quota-test or production UI diff in this PR.
- **Current-head App bridge conformance:** the functional authenticated-Control-UI/ticketed-standalone case passed. It uses a real source-mounted component, Gateway, stdio, and official MCP App, not a full normal dashboard. The separate composed-operation/cancellation case was intentionally filtered out.
- **Current-head native CLI:** after a fresh build, the isolated built CLI completed list → normal add with its default probe → verbose status → reload → probe → unset → empty list against `https://mcp.context7.com/mcp`, returning two server tools and no diagnostics. Build commit `8ab596daab8eedffb5b05c6f0a50f2eee7893d08` was checked explicitly. Every command retained its 30-second guard; no credentials or startup bypasses were supplied, and temporary state was removed.
- **Current-head build/review:** fresh `pnpm build` and `git diff --check` passed, with no ineffective-dynamic-import diagnostic. Fresh complete-candidate Codex autoreview is scoped-clean at the configured **P0-only** threshold, confidence 0.97. A broader-priority review is not claimed.
- **Sibling coverage:** an earlier 338-case cohort across 20 files passed: 95 Gateway/App, 42 CLI, 170 agents-core, 19 agents-support, and 12 agents-core-isolated. Later fixture refinements and the rebase are covered by the current focused runs; the earlier cohort is not represented as a new all-current suite.
- **Lifecycle proof:** a fresh manager-API-first process performed empty cleanup, real stdio creation, discovery/call, disposal/child exit, and recreation/teardown. V8 recorded zero factory calls before demand and one per creation. Real stdio-child/SQLite-lock tests cover run disposal and clock-controlled App-view retirement.
- **Package runtime:** `pnpm test:docker:agent-bundle-mcp-tools` passed on Blacksmith Testbox `tbx_01m187vbsdxxrgthrmcn4b0r36`, [Actions run 33287999441](https://github.com/openclaw/openclaw/actions/runs/33287999441), wrapper exit 0. It tested earlier implementation snapshot `af0f09ea7635cf34dcde3d876123581652769d00`, tree `c8e0ca01f55826feed8f6f9d77d2528b49b7c5aa`; remote synthetic head `cb18521b677c437a6a47ad8c1f1e78d4582f72d8` had that exact whole tree and clean status before/after. Profile/tool gating and MCP App preview passed. The lease was stopped and independently confirmed completed. The MCP production patch remains identical; this is not a claim that the entire later base tree was packaged in that earlier run.
- **Static checks:** the original complete classified format/type/lint/architecture gate passed, including zero runtime import cycles. Both subsequent test-only repairs passed their scoped changed checks; current-head hosted CI is tracked below.
- **Dependency contract:** the MCP SDK remains 1.30.0. For current main's separate Codex package update, direct sibling-source inspection checked MCP configuration and [bearer resolution](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/codex-mcp/src/rmcp_client.rs#L831-L855), plus [explicit HTTP bearer construction](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/rmcp-client/src/rmcp_client.rs#L1024-L1164), at `rust-v0.151.0`. This supports the unchanged projection contract, not a broader Codex-upgrade verdict.

**Exact-head CI passed:** [CI run 33297440085](https://github.com/openclaw/openclaw/actions/runs/33297440085), attempt 1, completed successfully on `8ab596daab8eedffb5b05c6f0a50f2eee7893d08`. The native watcher and typed run metadata both verified this result. The latest ClawSweeper review at this exact head found no repair findings; its CI-completion rank-up move is satisfied.

**Merged:** [e620c4f556a45](https://github.com/openclaw/openclaw/commit/e620c4f556a45756412590f5d9c4cc173aec7069) through the native prepare/merge workflow; [completion receipt](https://github.com/openclaw/openclaw/pull/133028#issuecomment-5467300132). The exact reviewed head was merged, the retained receipt is complete, and the native PR worktree was cleaned up. One earlier admission stopped before intent/dispatch when the final PR/main snapshot changed; its task-owned lock was recovered only after process cleanup and the no-dispatch state were verified. No credential reset, policy change, or GitHub-rule bypass was used.

### Post-merge composition

The independent metadata extraction landed immediately before this PR. Its four overlapping edits were metadata import/test/build-entry migrations, and the initial combined MCP cohort passed all 143 cases. A fresh main build then caught a separate stale Code Mode import of `getPluginToolSideEffectOwnerKey` from the old runtime module; three existing recovery tests reproduced the same defect.

Eden (@edenfunf) independently landed [the canonical one-line caller repair in PR 133155](https://github.com/openclaw/openclaw/pull/133155), commit [be5e79ca4713](https://github.com/openclaw/openclaw/commit/be5e79ca4713c33a11ccd56b2d728c19f0779f3d). Raw-parent comparison verified that its patch is byte-for-byte identical to the local repair validated here, so no duplicate PR was published and no obsolete export was restored.

Final canonical-main verification at `bed5daf176f6d7552b27b7c87d33e7d201dd82f6`, containing both landed repairs, passed **159 tests across seven files**: 143 MCP runtime/harness/auth/lifecycle cases, 15 Code Mode recovery cases, and one full-attempt recovery boundary. The checkout is clean at that synced main snapshot.

Additional composed build/runtime proof passed on public base `41dccabf17967bcc64d6caf7a40334e6f5dca363` plus the exact now-landed caller patch (local verification tree `c2d821bfb52ec6b28f63a97763f034b58b58a7a2`): fresh build; the compiled MCP client with isolated HOME/config/state; and the real public Context7 CLI flow. The compiled client verified shared tool metadata, coding/messaging tool counts of 3, minimal/denied counts of 0, matching SDK custom-tool filtering, and an MCP App preview. This extra smoke used freshly built local dist, not Docker or a new npm-install transaction; it is not represented as a full build of every later main commit.

### CI failures repaired

[Initial CI run 33288382089](https://github.com/openclaw/openclaw/actions/runs/33288382089) rejected the auth fixture's new inline lint suppression. The fixture now lets the SDK Client own transport callbacks instead of expanding the suppression allowlist. All four exact ratchet cases and thirteen auth/lifecycle cases pass.

[Next CI run 33290675386](https://github.com/openclaw/openclaw/actions/runs/33290675386) exposed a quota-test data gap after main's current-provider filter landed. The unchanged five-case suite reproduced it on the actual executed merge `5d6990c332684e071ed0d0b916ae267cc9792675`: Work's main session was active, but the mock supplied only a global roster row and empty history. Provider-tagged history fixed that exact merge and the PR branch without changing assertions, filtering or deadlines. Newer current main independently includes that input and improved scenario handling, so the duplicate test commit was dropped; the whole current-main file passes on this candidate.

Earlier failed local attempts remain in the record: an incomplete installed OpenAI SDK required a lockfile-preserving pnpm reinstall, and some cold-source/native-CLI attempts exhausted unchanged guards. Later focused and public CLI runs passed without increasing bounds. No exact latency benefit or explanation of historical deadlines is claimed.

Proof limits: OAuth credentials are synthetic with real local protocol/store owners, not live vendor OAuth. App expiry is clock-controlled. Functional Docker proof is tarball-backed runtime execution, not a complete npm install/upgrade transaction. No production visual UI change is introduced by this PR, and no operator state or another active worktree was changed.

<details>
<summary>Focused current-head commands</summary>

```bash
node scripts/run-vitest.mjs test/scripts/lint-suppressions.test.ts src/agents/mcp-auth-profile.integration.test.ts src/agents/mcp-ui-resource.import-boundary.test.ts src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
```

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-quota-pill-93041.e2e.test.ts
```

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/mcp-app-conformance.e2e.test.ts -t 'drives the authenticated Control UI and ticketed standalone bridges'
```

```bash
pnpm build
```

```bash
git diff --check 6425f8f16a27d1f941cc3c99d964c330e8e2e53a HEAD
```

Native CLI commands ran from a neutral temporary workspace with isolated HOME/config/state and a fixed per-command process guard. The prior complete changed gate used all 29 original candidate paths explicitly; later auth-fixture and quota repairs also passed their scoped `node scripts/check-changed.mjs -- <path>` checks.

</details>

Follow-up recorded separately: align provider-normalization architecture documentation with current manifest/runtime ownership; no provider-wide loader rewrite is included here.

AI-assisted implementation and validation.
