### PR TITLE
refactor(zalouser): share directory user projection

### DIFF
--- a/extensions/zalouser/src/channel.ts
+++ b/extensions/zalouser/src/channel.ts
@@ -23,7 +23,7 @@ import {
   zalouserSecurityAdapter,
   zalouserThreadingAdapter,
 } from "./channel.adapters.js";
-import { listZalouserDirectoryGroupMembers } from "./directory.js";
+import { listZalouserDirectoryGroupMembers, mapZalouserDirectoryUser } from "./directory.js";
 import type { ZalouserProbeResult } from "./probe.js";
 import { createZalouserSetupWizardProxy, zalouserSetupContract } from "./setup-core.js";
 import { createZalouserPluginBase } from "./shared.js";
@@ -33,21 +33,6 @@ const loadZalouserChannelRuntime = createLazyRuntimeModule(() => import("./chann
 const zalouserSetupWizardProxy = createZalouserSetupWizardProxy(
   async () => (await import("./setup-surface.js")).zalouserSetupWizard,
 );
-
-function mapUser(params: {
-  id: string;
-  name?: string | null;
-  avatarUrl?: string | null;
-  raw?: unknown;
-}): ChannelDirectoryEntry {
-  return {
-    kind: "user",
-    id: params.id,
-    name: params.name ?? undefined,
-    avatarUrl: params.avatarUrl ?? undefined,
-    raw: params.raw,
-  };
-}
 
 function mapGroup(params: {
   id: string;
@@ -80,7 +65,7 @@ export const zalouserPlugin: ChannelPlugin<ResolvedZalouserAccount, ZalouserProb
           if (!parsed?.userId) {
             return null;
           }
-          return mapUser({
+          return mapZalouserDirectoryUser({
             id: parsed.userId,
             name: parsed.displayName ?? null,
             avatarUrl: parsed.avatar ?? null,
@@ -92,7 +77,7 @@ export const zalouserPlugin: ChannelPlugin<ResolvedZalouserAccount, ZalouserProb
           const account = resolveZalouserAccountSync({ cfg, accountId });
           const friends = await listZaloFriendsMatching(account.profile, query);
           const rows = friends.map((friend) =>
-            mapUser({
+            mapZalouserDirectoryUser({
               id: friend.userId,
               name: friend.displayName ?? null,
               avatarUrl: friend.avatar ?? null,

--- a/extensions/zalouser/src/directory.ts
+++ b/extensions/zalouser/src/directory.ts
@@ -17,7 +17,7 @@ type ZalouserDirectoryDeps = {
   >;
 };
 
-function mapUser(params: {
+export function mapZalouserDirectoryUser(params: {
   id: string;
   name?: string | null;
   avatarUrl?: string | null;
@@ -45,7 +45,7 @@ export async function listZalouserDirectoryGroupMembers(
   const normalizedGroupId = parseZalouserDirectoryGroupId(params.groupId);
   const members = await deps.listZaloGroupMembers(account.profile, normalizedGroupId);
   const rows = members.map((member) =>
-    mapUser({
+    mapZalouserDirectoryUser({
       id: member.userId,
       name: member.displayName,
       avatarUrl: member.avatar ?? null,


### PR DESCRIPTION
## Summary

- make the Zalouser directory module own the canonical user projection
- reuse it for self, peer, and group-member directory results
- keep the group projection local because its identity and shape differ

## Problem

Zalouser projected the same provider user shape into `ChannelDirectoryEntry` through two identical helpers. The channel copy served self and peer lookup while the directory copy served group members, leaving one directory invariant split across two implementations.

## Root cause and fix

The original user mapper landed with the Zalouser channel, then directory extraction introduced a second copy instead of reusing the directory-owned projection. `channel.ts` already imports group-member directory behavior from `directory.ts`, so the canonical fix is to export that module's mapper internally and route all three user paths through it.

Removed path:

- duplicate private `mapUser` in `channel.ts`

`mapGroup` remains separate because it emits a different kind and group-specific identifier shape. No public API, config, protocol, persistence, or user-visible behavior changes.

## Validation

- focused Vitest: 2 files, 18 tests passed
- `pnpm tsgo:core`
- `oxfmt --check extensions/zalouser/src/channel.ts extensions/zalouser/src/directory.ts`
- `git diff --check`
- mandatory local autoreview: clean, correctness 0.99
- production delta: +5 / -20, net -15

`check-changed` passed every preceding guard and stopped only at the sparse-checkout dead-export scan because the task worktree does not contain tracked Control UI config modules. This draft remains blocked from ready/merge until the hydrated native review checkout completes the repository review gates.
