### PR TITLE
fix(github-copilot): device login no longer leaves plaintext tokens

### DIFF
--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -206,6 +206,32 @@ catalog, API-key auth, and dynamic model resolution.
     `openclaw onboard --acme-ai-api-key <key>` and select
     `acme-ai/acme-large` as their model.
 
+    A custom interactive auth method that mints a static token or API key can
+    request protected persistence on its returned profile:
+
+    ```typescript
+    return {
+      profiles: [
+        {
+          profileId: "acme-ai:device",
+          credential: { type: "token", provider: "acme-ai", token },
+          secretStorage: {
+            kind: "store",
+            namePrefix: "ACME_AI_TOKEN",
+          },
+        },
+      ],
+    };
+    ```
+
+    OpenClaw keeps the inline value only while staged validation runs. At the
+    final persistence boundary it writes the value to the protected local store
+    and saves a `tokenRef` or `keyRef` in the auth profile. `namePrefix` must be
+    an uppercase environment-style name. OpenClaw adds a stable suffix derived
+    from the provider and final profile id so multiple profiles remain separate.
+    Use this only for provider-minted static credentials, not rotating OAuth
+    credentials or values already supplied as SecretRefs.
+
     ### Live model discovery
 
     If your provider exposes an OpenAI-compatible `/models` API, opt the

--- a/docs/providers/github-copilot.md
+++ b/docs/providers/github-copilot.md
@@ -15,10 +15,11 @@ provider or agent runtime in three different ways.
 
 <Tabs>
   <Tab title="Built-in provider (github-copilot)">
-    Use the native device-login flow to obtain and store a GitHub token. When
-    OpenClaw runs, it validates Copilot access and resolves the account-specific
-    Copilot API endpoint. This is the **default** and simplest path because it does
-    not require VS Code.
+    Use the native device-login flow to obtain a GitHub token. By default,
+    OpenClaw puts the token in its protected local secret store and saves only a
+    `tokenRef` in the auth profile. When OpenClaw runs, it validates Copilot access
+    and resolves the account-specific Copilot API endpoint. This is the **default**
+    and simplest path because it does not require VS Code.
 
     <Steps>
       <Step title="Run the login command">
@@ -322,16 +323,28 @@ configured default model is never replaced.
     | 3        | `GITHUB_TOKEN`        | Standard GitHub token (lowest)   |
 
     When multiple variables are set, OpenClaw uses the highest-priority one.
-    The device-login flow (`openclaw models auth login-github-copilot`) stores
-    its token in the auth profile store and takes precedence over all environment
-    variables.
+    The device-login flow (`openclaw models auth login-github-copilot`) stores a
+    protected-store `tokenRef` in the auth profile and takes precedence over all
+    environment variables.
 
   </Accordion>
 
   <Accordion title="Token storage">
-    The login stores a GitHub token in the auth profile store (profile id
-    `github-copilot:github`). At runtime, OpenClaw validates Copilot access,
-    resolves the account-specific API endpoint, and uses the stored GitHub token
+    By default, device login stores the GitHub token in OpenClaw's protected local
+    secret store and writes only a `tokenRef` to the auth profile (profile id
+    `github-copilot:github`). The built-in store does not require a configured
+    external secret provider. If OpenClaw cannot write the store, login stops
+    before replacing the auth profile and reports that the state-directory or
+    database permissions need repair.
+
+    Interactive onboarding honors an explicit `--secret-input-mode plaintext`
+    choice for compatibility. That mode stores the token inline, reports the
+    choice, and remains visible to `openclaw secrets audit --check`.
+
+    The protected store is write-only through OpenClaw's user-facing secret APIs,
+    but it is not encrypted at rest; its SQLite file relies on state-directory
+    permissions. At runtime, OpenClaw resolves the reference, validates Copilot
+    access, resolves the account-specific API endpoint, and uses the GitHub token
     for Copilot requests. You do not need to manage runtime authentication
     manually.
 

--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -1397,6 +1397,10 @@ describe("github-copilot plugin", () => {
         provider: "github-copilot",
         token: "refreshed-token",
       });
+      expect(result.profiles[0]?.secretStorage).toBeUndefined();
+      expect(result.notes).toContain(
+        "Plaintext secret input mode was selected, so the GitHub Copilot token will remain inline in the auth profile and openclaw secrets audit --check will report it.",
+      );
     } finally {
       vi.unstubAllGlobals();
       if (isTtyDescriptor) {
@@ -1488,7 +1492,6 @@ describe("github-copilot plugin", () => {
           prompter,
           runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
           opts: {},
-          secretInputMode: "plaintext",
           allowSecretRefPrompt: false,
           isRemote: false,
           openUrl,
@@ -1506,6 +1509,10 @@ describe("github-copilot plugin", () => {
       type: "token",
       provider: "github-copilot",
       token: "public-fresh-token",
+    });
+    expect(result.profiles[0]?.secretStorage).toEqual({
+      kind: "store",
+      namePrefix: "GITHUB_COPILOT_TOKEN",
     });
     const params = (
       result.configPatch as {
@@ -1544,7 +1551,6 @@ describe("github-copilot plugin", () => {
           prompter,
           runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
           opts: {},
-          secretInputMode: "plaintext",
           allowSecretRefPrompt: false,
           isRemote: false,
           openUrl,
@@ -1561,6 +1567,10 @@ describe("github-copilot plugin", () => {
       type: "token",
       provider: "github-copilot",
       token: "tenant-fresh-token",
+    });
+    expect(result.profiles[0]?.secretStorage).toEqual({
+      kind: "store",
+      namePrefix: "GITHUB_COPILOT_TOKEN",
     });
     const params = (
       result.configPatch as {

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -49,6 +49,7 @@ const COPILOT_ENV_VARS: [string, string, string] = [
   "GITHUB_TOKEN",
 ];
 const DEFAULT_COPILOT_PROFILE_ID = "github-copilot:github";
+const COPILOT_SECRET_STORE_NAME_PREFIX = "GITHUB_COPILOT_TOKEN";
 
 type GithubCopilotPluginConfig = {
   discovery?: {
@@ -605,6 +606,15 @@ export default definePluginEntry({
         githubToken: result.accessToken,
         githubDomain: normalizedDomain,
       });
+      const persistInline = ctx.secretInputMode === "plaintext";
+      const notes = [
+        ...(starter.notes ?? []),
+        ...(persistInline
+          ? [
+              "Plaintext secret input mode was selected, so the GitHub Copilot token will remain inline in the auth profile and openclaw secrets audit --check will report it.",
+            ]
+          : []),
+      ];
       return {
         profiles: [
           {
@@ -614,9 +624,18 @@ export default definePluginEntry({
               provider: PROVIDER_ID,
               token: result.accessToken,
             },
+            ...(!persistInline
+              ? {
+                  secretStorage: {
+                    kind: "store" as const,
+                    namePrefix: COPILOT_SECRET_STORE_NAME_PREFIX,
+                  },
+                }
+              : {}),
           },
         ],
-        ...starter,
+        ...(starter.defaultModel ? { defaultModel: starter.defaultModel } : {}),
+        ...(notes.length > 0 ? { notes } : {}),
         ...(configPatch ? { configPatch } : {}),
       };
     }

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -17,7 +17,6 @@ import {
 import {
   buildPortableAuthProfileStoreForAgentCopy,
   ensureAuthProfileStore,
-  persistAuthProfileBatch,
   type AuthProfileStore,
 } from "../agents/auth-profiles.js";
 import { AuthProfileStoreUnreadableError } from "../agents/auth-profiles/legacy-source-diagnostic.js";
@@ -38,6 +37,8 @@ import {
   transformConfigWithPendingPluginInstalls,
 } from "../plugins/install-record-commit.js";
 import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
+import { persistProviderAuthProfileBatch } from "../plugins/provider-auth-persistence.js";
+import type { ProviderAuthProfile } from "../plugins/types.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { resolveUserPath, shortenHomePath } from "../utils.js";
@@ -285,9 +286,7 @@ export async function agentsAddCommand(
       workspace: workspaceDir,
       agentDir,
     });
-    const stagedAuthProfiles: Array<
-      Parameters<typeof persistAuthProfileBatch>[0]["profiles"][number]
-    > = [];
+    const stagedAuthProfiles: Array<ProviderAuthProfile & { replaceExisting?: boolean }> = [];
     let stagedAuthOrder: AuthProfileStore["order"];
     let reportPortableAuthCopy: (() => Promise<void>) | undefined;
 
@@ -484,6 +483,7 @@ export async function agentsAddCommand(
             profiles: stagedAuthProfiles,
             ...(stagedAuthOrder ? { order: stagedAuthOrder } : {}),
             agentDir,
+            config: nextConfig,
           }
         : undefined;
 
@@ -495,7 +495,7 @@ export async function agentsAddCommand(
         skipOptionalBootstrapFiles: nextConfig.agents?.defaults?.skipOptionalBootstrapFiles,
       });
       const authPersistence = stagedAuthBatch
-        ? await persistAuthProfileBatch(stagedAuthBatch)
+        ? await persistProviderAuthProfileBatch(stagedAuthBatch)
         : undefined;
       try {
         nextConfig = await channelSetup.commit(nextConfig, async (configToCommit) => {
@@ -528,7 +528,7 @@ export async function agentsAddCommand(
           ...(stagedAuthBatch
             ? {
                 prepareConfigCommit: async () =>
-                  (await persistAuthProfileBatch(stagedAuthBatch)).rollback,
+                  (await persistProviderAuthProfileBatch(stagedAuthBatch)).rollback,
               }
             : {}),
         });

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -25,6 +25,8 @@ type UpsertAuthProfileCall = {
   agentDir?: string;
   credential?: {
     provider?: string;
+    token?: string;
+    tokenRef?: unknown;
     type?: string;
   };
   profileId?: string;
@@ -66,6 +68,18 @@ const mocks = vi.hoisted(() => ({
   callGateway: vi.fn(),
   resolvePluginSetupProviderCore: vi.fn(),
   resolvePluginSetupRegistry: vi.fn(),
+  readSecretStoreValue: vi.fn(() => ({
+    ok: false as const,
+    error: { code: "SECRET_STORE_NOT_FOUND", message: "missing" },
+  })),
+  writeSecretStoreEntry: vi.fn(),
+  deleteSecretStoreEntry: vi.fn(),
+}));
+
+vi.mock("../../secrets/store/secret-store.js", () => ({
+  readSecretStoreValue: mocks.readSecretStoreValue,
+  writeSecretStoreEntry: mocks.writeSecretStoreEntry,
+  deleteSecretStoreEntry: mocks.deleteSecretStoreEntry,
 }));
 
 vi.mock("../../agents/auth-profiles/profiles.js", () => ({
@@ -482,6 +496,85 @@ describe("modelsAuthLoginCommand", () => {
       params: { refresh: true, agentId: "main" },
       timeoutMs: 3000,
     });
+  });
+
+  it("persists a provider-minted Copilot token through the protected store", async () => {
+    const runtime = createRuntime();
+    runProviderAuth.mockResolvedValueOnce({
+      profiles: [
+        {
+          profileId: "github-copilot:github",
+          credential: {
+            type: "token",
+            provider: "github-copilot",
+            token: "synthetic-device-token",
+          },
+          secretStorage: {
+            kind: "store",
+            namePrefix: "GITHUB_COPILOT_TOKEN",
+          },
+        },
+      ],
+    });
+    mocks.resolvePluginProvidersCore.mockReturnValue([
+      createProvider({
+        id: "github-copilot",
+        label: "GitHub Copilot",
+        run: runProviderAuth as ProviderPlugin["auth"][number]["run"],
+      }),
+    ]);
+
+    await modelsAuthLoginCommand({ provider: "github-copilot" }, runtime);
+
+    expect(mocks.writeSecretStoreEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ value: "synthetic-device-token" }),
+    );
+    const upsertCall = readMockCallArg(
+      mocks.upsertAuthProfileAfterLoginWithLock,
+    ) as UpsertAuthProfileCall;
+    expect(upsertCall.credential).not.toHaveProperty("token");
+    expect(upsertCall.credential?.tokenRef).toEqual({
+      source: "store",
+      provider: "default",
+      id: expect.stringMatching(/^GITHUB_COPILOT_TOKEN_[A-F0-9]{24}$/),
+    });
+  });
+
+  it("keeps the prior auth profile when protected storage is unavailable", async () => {
+    const runtime = createRuntime();
+    runProviderAuth.mockResolvedValueOnce({
+      profiles: [
+        {
+          profileId: "github-copilot:github",
+          credential: {
+            type: "token",
+            provider: "github-copilot",
+            token: "synthetic-device-token",
+          },
+          secretStorage: {
+            kind: "store",
+            namePrefix: "GITHUB_COPILOT_TOKEN",
+          },
+        },
+      ],
+    });
+    mocks.resolvePluginProvidersCore.mockReturnValue([
+      createProvider({
+        id: "github-copilot",
+        label: "GitHub Copilot",
+        run: runProviderAuth as ProviderPlugin["auth"][number]["run"],
+      }),
+    ]);
+    mocks.writeSecretStoreEntry.mockImplementationOnce(() => {
+      throw new Error("read-only database");
+    });
+
+    await expect(modelsAuthLoginCommand({ provider: "github-copilot" }, runtime)).rejects.toThrow(
+      "Could not write the protected secret store",
+    );
+
+    expect(mocks.upsertAuthProfileAfterLoginWithLock).not.toHaveBeenCalled();
+    expect(mocks.promoteAuthProfileInOrder).not.toHaveBeenCalled();
   });
 
   it("keeps login successful when the running gateway cannot refresh auth state", async () => {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -42,6 +42,7 @@ import {
   resolveProviderMatch,
 } from "../../plugins/provider-auth-choice-helpers.js";
 import { applyAuthProfileConfig } from "../../plugins/provider-auth-helpers.js";
+import { prepareProviderAuthProfilesForPersistence } from "../../plugins/provider-auth-persistence.js";
 import { createVpsAwareOAuthHandlers } from "../../plugins/provider-oauth-flow.js";
 import { resolvePluginProvidersCore } from "../../plugins/providers.runtime.js";
 import {
@@ -410,25 +411,47 @@ async function persistProviderAuthResult(params: {
   runtime: RuntimeEnv;
   prompter: WizardPrompter;
   setDefault?: boolean;
-}) {
+  env?: NodeJS.ProcessEnv;
+}): Promise<ProviderAuthResult["profiles"]> {
   const defaultModel = params.result.defaultModel
     ? normalizeAgentModelRefForConfig(params.result.defaultModel)
     : undefined;
   const profiles = params.profiles ?? params.result.profiles;
+  const persistedProfiles: ProviderAuthResult["profiles"] = [];
   const shouldUpdateConfig = Boolean(
     params.result.configPatch || (params.setDefault && defaultModel),
   );
 
-  for (const profile of profiles) {
+  for (const candidate of profiles) {
+    const prepared = prepareProviderAuthProfilesForPersistence({
+      profiles: [candidate],
+      config: params.config,
+      env: params.env,
+    });
+    const profile = expectDefined(prepared.profiles[0], "prepared auth profile");
     const configuredSelection = resolveConfiguredAuthSelectionForProvider(
       params.config,
       profile.credential.provider,
     );
-    await upsertAuthProfileAfterLoginWithLockOrThrow({
-      profileId: profile.profileId,
-      credential: profile.credential,
-      agentDir: params.agentDir,
-    });
+    try {
+      await upsertAuthProfileAfterLoginWithLockOrThrow({
+        profileId: profile.profileId,
+        credential: profile.credential,
+        agentDir: params.agentDir,
+      });
+    } catch (error) {
+      try {
+        prepared.rollback();
+      } catch (rollbackError) {
+        throw new AggregateError(
+          [error, rollbackError],
+          "Provider auth persistence failed and protected-store rollback could not be confirmed.",
+          { cause: rollbackError },
+        );
+      }
+      throw error;
+    }
+    persistedProfiles.push(profile);
     await promoteAuthProfileInOrder({
       agentDir: params.agentDir,
       provider: profile.credential.provider,
@@ -478,7 +501,7 @@ async function persistProviderAuthResult(params: {
 
   await refreshRunningGatewayAuthState(params.agentId);
 
-  for (const profile of profiles) {
+  for (const profile of persistedProfiles) {
     params.runtime.log(
       `Auth profile: ${profile.profileId} (${profile.credential.provider}/${credentialMode(profile.credential)})`,
     );
@@ -493,6 +516,7 @@ async function persistProviderAuthResult(params: {
   if (params.result.notes && params.result.notes.length > 0) {
     await params.prompter.note(params.result.notes.join("\n"), "Provider notes");
   }
+  return persistedProfiles;
 }
 
 function resolveConfiguredAuthSelectionForProvider(
@@ -562,7 +586,7 @@ async function runProviderAuthMethod(params: {
     requestedProfileId: params.profileId,
   });
 
-  await persistProviderAuthResult({
+  const persistedProfiles = await persistProviderAuthResult({
     result,
     profiles,
     config: params.config,
@@ -571,9 +595,10 @@ async function runProviderAuthMethod(params: {
     runtime: params.runtime,
     prompter: params.prompter,
     setDefault: params.setDefault,
+    env: params.env ?? process.env,
   });
 
-  return { result, profiles };
+  return { result, profiles: persistedProfiles };
 }
 
 /** Runs an interactive provider setup-token auth flow. */

--- a/src/plugin-sdk/test-helpers/provider-auth-contract.ts
+++ b/src/plugin-sdk/test-helpers/provider-auth-contract.ts
@@ -507,6 +507,10 @@ export function describeGithubCopilotProviderAuthContract(
               provider: "github-copilot",
               token: "github-device-token",
             },
+            secretStorage: {
+              kind: "store",
+              namePrefix: "GITHUB_COPILOT_TOKEN",
+            },
           },
         ],
         defaultModel,
@@ -558,6 +562,10 @@ export function describeGithubCopilotProviderAuthContract(
               type: "token",
               provider: "github-copilot",
               token: "rpc-client-token",
+            },
+            secretStorage: {
+              kind: "store",
+              namePrefix: "GITHUB_COPILOT_TOKEN",
             },
           },
         ]);

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -5,7 +5,6 @@ import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
 } from "../agents/agent-scope.js";
-import { persistAuthProfileBatch } from "../agents/auth-profiles.js";
 import { formatLiteralProviderPrefixedModelRef } from "../agents/model-ref-shared.js";
 import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace.js";
 import { normalizeAgentModelRefForConfig } from "../config/model-input.js";
@@ -24,6 +23,7 @@ import {
   type ProviderAuthChoiceMetadata,
 } from "./provider-auth-choices.js";
 import { applyAuthProfileConfig } from "./provider-auth-helpers.js";
+import { persistProviderAuthProfileBatch } from "./provider-auth-persistence.js";
 import { resolveProviderInstallCatalogEntry } from "./provider-install-catalog.js";
 import { createVpsAwareOAuthHandlers } from "./provider-oauth-flow.js";
 import type {
@@ -383,10 +383,12 @@ async function prepareProviderPluginAuthMethod(
       return;
     }
     await params.beforePersistentEffect?.();
-    await persistAuthProfileBatch({
+    await persistProviderAuthProfileBatch({
       profiles,
+      config: nextConfig,
       agentDir,
-      stateDir: params.env?.OPENCLAW_STATE_DIR,
+      ...(params.env ? { env: params.env } : {}),
+      ...(params.env?.OPENCLAW_STATE_DIR ? { stateDir: params.env.OPENCLAW_STATE_DIR } : {}),
     });
     profilesPersisted = true;
   };

--- a/src/plugins/provider-auth-persistence.test.ts
+++ b/src/plugins/provider-auth-persistence.test.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { ensureAuthProfileStore } from "../agents/auth-profiles/store.js";
+import { runSecretsAudit } from "../secrets/audit.js";
+import { readSecretStoreValue } from "../secrets/store/secret-store.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { persistProviderAuthProfileBatch } from "./provider-auth-persistence.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+describe("provider auth protected persistence", () => {
+  it("stores a provider-minted token behind a resolvable ref without an audit finding", async () => {
+    const rootDir = tempDirs.make("openclaw-provider-auth-store-");
+    const stateDir = path.join(rootDir, "state");
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const configPath = path.join(rootDir, "openclaw.json");
+    await fs.writeFile(configPath, "{}\n", "utf8");
+    const env = {
+      ...process.env,
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_STATE_DIR: stateDir,
+    };
+
+    await withEnvAsync(
+      { OPENCLAW_CONFIG_PATH: configPath, OPENCLAW_STATE_DIR: stateDir },
+      async () => {
+        const persisted = await persistProviderAuthProfileBatch({
+          profiles: [
+            {
+              profileId: "github-copilot:github",
+              credential: {
+                type: "token",
+                provider: "github-copilot",
+                token: "synthetic-device-token",
+              },
+              secretStorage: {
+                kind: "store",
+                namePrefix: "GITHUB_COPILOT_TOKEN",
+              },
+            },
+          ],
+          config: {},
+          env,
+          stateDir,
+          agentDir,
+        });
+
+        const profile = ensureAuthProfileStore(agentDir, {
+          readOnly: true,
+          syncExternalCli: false,
+        }).profiles["github-copilot:github"];
+        expect(profile).toEqual(persisted.profiles[0]?.credential);
+        expect(profile).not.toHaveProperty("token");
+        expect(profile).toMatchObject({
+          type: "token",
+          provider: "github-copilot",
+          tokenRef: {
+            source: "store",
+            provider: "default",
+            id: expect.stringMatching(/^GITHUB_COPILOT_TOKEN_[A-F0-9]{24}$/),
+          },
+        });
+        if (!profile || profile.type !== "token" || !profile.tokenRef) {
+          throw new Error("Expected persisted Copilot tokenRef");
+        }
+        expect(
+          readSecretStoreValue({
+            scope: { kind: "team" },
+            name: profile.tokenRef.id,
+            database: { env },
+          }),
+        ).toEqual({ ok: true, value: "synthetic-device-token" });
+
+        const audit = await runSecretsAudit({ env });
+        expect(
+          audit.findings.some(
+            (finding) =>
+              finding.code === "PLAINTEXT_FOUND" &&
+              finding.jsonPath === "profiles.github-copilot:github.token",
+          ),
+        ).toBe(false);
+      },
+    );
+  });
+});

--- a/src/plugins/provider-auth-persistence.ts
+++ b/src/plugins/provider-auth-persistence.ts
@@ -1,0 +1,256 @@
+import { createHash } from "node:crypto";
+import { persistAuthProfileBatch } from "../agents/auth-profiles.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isValidEnvSecretRefId, type SecretRef } from "../config/types.secrets.js";
+import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
+import { resolveDefaultSecretProviderAlias } from "../secrets/ref-contract.js";
+import {
+  deleteSecretStoreEntry,
+  readSecretStoreValue,
+  writeSecretStoreEntry,
+} from "../secrets/store/secret-store.js";
+import type { ProviderAuthProfile } from "./provider-authentication.types.js";
+
+const STORE_SCOPE = { kind: "team" } as const;
+const STORE_NAME_DIGEST_LENGTH = 24;
+
+type StoreRollback = {
+  name: string;
+  previousValue?: string;
+};
+
+type PreparedProviderAuthProfiles = {
+  profiles: ProviderAuthProfile[];
+  rollback: () => void;
+};
+
+type PersistProviderAuthProfileBatchParams = Omit<
+  Parameters<typeof persistAuthProfileBatch>[0],
+  "profiles"
+> & {
+  profiles: readonly ProviderAuthProfile[];
+  config: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+};
+
+function resolveStoreName(profile: ProviderAuthProfile): string {
+  const storage = profile.secretStorage;
+  if (!storage) {
+    throw new Error("Provider auth profile does not request protected secret storage.");
+  }
+  const namePrefix = storage.namePrefix.trim();
+  // Stable per final profile so relogin replaces one owned entry instead of accumulating
+  // secrets; provider identity prevents different owners from sharing that entry.
+  const digest = createHash("sha256")
+    .update(profile.credential.provider)
+    .update("\0")
+    .update(profile.profileId)
+    .digest("hex")
+    .slice(0, STORE_NAME_DIGEST_LENGTH)
+    .toUpperCase();
+  const name = `${namePrefix}_${digest}`;
+  if (!isValidEnvSecretRefId(name)) {
+    throw new Error(
+      "Provider auth secret-store name prefix must produce a valid environment-style name.",
+    );
+  }
+  return name;
+}
+
+function buildStoredCredential(profile: ProviderAuthProfile, ref: SecretRef) {
+  const credential = profile.credential;
+  if (credential.type === "token" && typeof credential.token === "string") {
+    const { token: _token, ...withoutToken } = credential;
+    return { ...withoutToken, tokenRef: ref };
+  }
+  if (credential.type === "api_key" && typeof credential.key === "string") {
+    const { key: _key, ...withoutKey } = credential;
+    return { ...withoutKey, keyRef: ref };
+  }
+  throw new Error(
+    `Provider auth profile "${profile.profileId}" requested protected storage without an inline static credential.`,
+  );
+}
+
+function rollbackStoreWrites(
+  writes: readonly StoreRollback[],
+  database: { env: NodeJS.ProcessEnv } | undefined,
+): void {
+  const errors: unknown[] = [];
+  for (const write of writes.toReversed()) {
+    try {
+      if (write.previousValue === undefined) {
+        deleteSecretStoreEntry({ scope: STORE_SCOPE, name: write.name, database });
+      } else {
+        writeSecretStoreEntry({
+          scope: STORE_SCOPE,
+          name: write.name,
+          value: write.previousValue,
+          kind: "secret",
+          updatedBy: "provider-auth-rollback",
+          database,
+        });
+      }
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(
+      errors,
+      "Could not confirm rollback of protected provider credentials; run openclaw doctor --fix before retrying.",
+    );
+  }
+}
+
+/** Materializes provider-minted static credentials only when their final persistence begins. */
+export function prepareProviderAuthProfilesForPersistence(params: {
+  profiles: readonly ProviderAuthProfile[];
+  config: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): PreparedProviderAuthProfiles {
+  const database = params.env ? { env: params.env } : undefined;
+  const writes: StoreRollback[] = [];
+  let rolledBack = false;
+  const rollback = () => {
+    if (rolledBack) {
+      return;
+    }
+    rollbackStoreWrites(writes, database);
+    rolledBack = true;
+  };
+
+  try {
+    const profiles = params.profiles.map((profile): ProviderAuthProfile => {
+      if (!profile.secretStorage) {
+        return profile;
+      }
+      const name = resolveStoreName(profile);
+      const existing = readSecretStoreValue({ scope: STORE_SCOPE, name, database });
+      if (!existing.ok && existing.error.code !== "SECRET_STORE_NOT_FOUND") {
+        throw new Error(
+          "The protected secret store is unavailable. Check the OpenClaw state-directory permissions and retry; the auth profile was not changed.",
+          { cause: existing.error },
+        );
+      }
+      const credential = profile.credential;
+      const value =
+        credential.type === "token"
+          ? credential.token
+          : credential.type === "api_key"
+            ? credential.key
+            : undefined;
+      if (typeof value !== "string") {
+        throw new Error(
+          `Provider auth profile "${profile.profileId}" requested protected storage without an inline static credential.`,
+        );
+      }
+      registerSecretValueForRedaction(value);
+      try {
+        writeSecretStoreEntry({
+          scope: STORE_SCOPE,
+          name,
+          value,
+          kind: "secret",
+          updatedBy: "provider-auth",
+          database,
+        });
+      } catch (error) {
+        throw new Error(
+          "Could not write the protected secret store. Check the OpenClaw state-directory permissions and retry; the auth profile was not changed.",
+          { cause: error },
+        );
+      }
+      writes.push({ name, ...(existing.ok ? { previousValue: existing.value } : {}) });
+      const ref: SecretRef = {
+        source: "store",
+        provider: resolveDefaultSecretProviderAlias(params.config, "store", {
+          preferFirstProviderForSource: true,
+        }),
+        id: name,
+      };
+      const { secretStorage: _secretStorage, ...persistentProfile } = profile;
+      return {
+        ...persistentProfile,
+        credential: buildStoredCredential(profile, ref),
+      };
+    });
+    return { profiles, rollback };
+  } catch (error) {
+    try {
+      rollback();
+    } catch (rollbackError) {
+      throw new AggregateError(
+        [error, rollbackError],
+        "Provider credential persistence failed and protected-store rollback could not be confirmed.",
+        { cause: rollbackError },
+      );
+    }
+    throw error;
+  }
+}
+
+/** Persists a provider-auth batch and couples its rollback to protected-store materialization. */
+export async function persistProviderAuthProfileBatch(
+  params: PersistProviderAuthProfileBatchParams,
+): Promise<{ profiles: ProviderAuthProfile[]; rollback: () => void }> {
+  const env = params.stateDir
+    ? { ...(params.env ?? process.env), OPENCLAW_STATE_DIR: params.stateDir }
+    : params.env;
+  const prepared = prepareProviderAuthProfilesForPersistence({
+    profiles: params.profiles,
+    config: params.config,
+    ...(env ? { env } : {}),
+  });
+  let persisted: Awaited<ReturnType<typeof persistAuthProfileBatch>>;
+  try {
+    persisted = await persistAuthProfileBatch({
+      profiles: prepared.profiles,
+      ...(params.order ? { order: params.order } : {}),
+      ...(params.agentDir ? { agentDir: params.agentDir } : {}),
+      ...(params.stateDir ? { stateDir: params.stateDir } : {}),
+    });
+  } catch (error) {
+    try {
+      prepared.rollback();
+    } catch (rollbackError) {
+      throw new AggregateError(
+        [error, rollbackError],
+        "Provider auth persistence failed and protected-store rollback could not be confirmed.",
+        { cause: rollbackError },
+      );
+    }
+    throw error;
+  }
+  let rolledBack = false;
+  return {
+    profiles: prepared.profiles,
+    rollback: () => {
+      if (rolledBack) {
+        return;
+      }
+      let profileError: Error | undefined;
+      try {
+        persisted.rollback();
+      } catch (error) {
+        profileError = error instanceof Error ? error : new Error(String(error), { cause: error });
+      }
+      try {
+        prepared.rollback();
+      } catch (error) {
+        if (profileError) {
+          throw new AggregateError(
+            [profileError, error],
+            "Could not confirm rollback of provider auth profiles and protected credentials.",
+            { cause: error },
+          );
+        }
+        throw error;
+      }
+      if (profileError) {
+        throw profileError;
+      }
+      rolledBack = true;
+    },
+  };
+}

--- a/src/plugins/provider-authentication.types.ts
+++ b/src/plugins/provider-authentication.types.ts
@@ -10,9 +10,23 @@ import type { createVpsAwareOAuthHandlers } from "./provider-oauth-flow.js";
 
 export type ProviderAuthKind = "oauth" | "api_key" | "token" | "device_code" | "custom";
 
+type ProviderAuthSecretStorage = {
+  /** Final persistence target. The inline credential remains available for staged validation. */
+  kind: "store";
+  /** Environment-style prefix used for the host-owned secret-store entry. */
+  namePrefix: string;
+};
+
+export type ProviderAuthProfile = {
+  profileId: string;
+  credential: AuthProfileCredential;
+  /** Request host-owned SecretRef materialization at the final persistence boundary. */
+  secretStorage?: ProviderAuthSecretStorage;
+};
+
 /** Standard result payload returned by provider auth methods. */
 export type ProviderAuthResult = {
-  profiles: Array<{ profileId: string; credential: AuthProfileCredential }>;
+  profiles: ProviderAuthProfile[];
   /**
    * Optional config patch to merge after credentials are written.
    *

--- a/src/system-agent/setup-inference-activate-persist.ts
+++ b/src/system-agent/setup-inference-activate-persist.ts
@@ -198,6 +198,7 @@ export async function persistActivatedSetupInference(input: {
       profiles: plan.manualAuth.profiles,
       agentDir: resolvedRoute.agentDir,
       deps,
+      secretStorage: { config: initialCandidate, env: process.env },
     });
     if (persistedManualAuth.status === "unknown") {
       const rolledBack = await rollbackManualAuthProfiles(persistedManualAuth.receipt, deps);

--- a/src/system-agent/setup-inference-persist.ts
+++ b/src/system-agent/setup-inference-persist.ts
@@ -22,6 +22,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { enablePluginInConfig } from "../plugins/enable.js";
+import { prepareProviderAuthProfilesForPersistence } from "../plugins/provider-auth-persistence.js";
 import type { ProviderAuthResult } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
@@ -278,6 +279,7 @@ export type ManualAuthPersistenceReceipt = {
   }>;
   /** Profiles created by this activation; rollback must not delete prior identical entries. */
   insertedProfileIds: ReadonlySet<string>;
+  rollbackProtectedSecretStorage: () => void;
 };
 
 type ManualAuthProfilesReadback = "present" | "absent" | "mismatch" | "unknown";
@@ -364,13 +366,26 @@ export async function persistManualAuthProfiles(params: {
   profiles: ProviderAuthResult["profiles"];
   agentDir: string;
   deps: ActivateSetupInferenceDeps;
+  secretStorage?: { config: OpenClawConfig; env?: NodeJS.ProcessEnv };
 }): Promise<ManualAuthPersistenceResult> {
-  const profiles = params.profiles.map((profile) => ({
+  const prepared = params.secretStorage
+    ? prepareProviderAuthProfilesForPersistence({
+        profiles: params.profiles,
+        config: params.secretStorage.config,
+        ...(params.secretStorage.env ? { env: params.secretStorage.env } : {}),
+      })
+    : { profiles: [...params.profiles], rollback: () => {} };
+  const profiles = prepared.profiles.map((profile) => ({
     profileId: profile.profileId,
     credential: normalizeAuthProfileCredential(profile.credential),
   }));
   const insertedProfileIds = new Set<string>();
-  const receipt = { agentDir: params.agentDir, profiles, insertedProfileIds };
+  const receipt = {
+    agentDir: params.agentDir,
+    profiles,
+    insertedProfileIds,
+    rollbackProtectedSecretStorage: prepared.rollback,
+  };
   let collision = false;
   const update = params.deps.updateAuthProfileStoreWithLock ?? updateAuthProfileStoreWithLock;
   const updated = await update({
@@ -394,6 +409,7 @@ export async function persistManualAuthProfiles(params: {
     },
   });
   if (collision) {
+    prepared.rollback();
     return { status: "not-persisted" };
   }
   // The store helper can report a post-commit chmod failure as null. Read back
@@ -402,7 +418,20 @@ export async function persistManualAuthProfiles(params: {
   if (updated !== null || readback === "present") {
     return { status: "persisted", receipt };
   }
-  return readback === "absent" ? { status: "not-persisted" } : { status: "unknown", receipt };
+  if (readback === "absent") {
+    prepared.rollback();
+    return { status: "not-persisted" };
+  }
+  return { status: "unknown", receipt };
+}
+
+function rollbackManualAuthSecretStorage(receipt: ManualAuthPersistenceReceipt): boolean {
+  try {
+    receipt.rollbackProtectedSecretStorage();
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export async function rollbackManualAuthProfiles(
@@ -410,7 +439,7 @@ export async function rollbackManualAuthProfiles(
   deps: ActivateSetupInferenceDeps,
 ): Promise<boolean> {
   if (receipt.insertedProfileIds.size === 0) {
-    return true;
+    return rollbackManualAuthSecretStorage(receipt);
   }
   const update = deps.updateAuthProfileStoreWithLock ?? updateAuthProfileStoreWithLock;
   for (let attempt = 0; attempt < 3; attempt += 1) {
@@ -446,7 +475,7 @@ export async function rollbackManualAuthProfiles(
           updated.profiles[profile.profileId] === undefined,
       )
     ) {
-      return true;
+      return rollbackManualAuthSecretStorage(receipt);
     }
     let persistedStore: ReturnType<typeof loadPersistedAuthProfileStore>;
     try {
@@ -464,7 +493,7 @@ export async function rollbackManualAuthProfiles(
           persistedStore.profiles[profile.profileId] === undefined,
       )
     ) {
-      return true;
+      return rollbackManualAuthSecretStorage(receipt);
     }
   }
   return false;

--- a/src/system-agent/setup-inference-verify.ts
+++ b/src/system-agent/setup-inference-verify.ts
@@ -321,7 +321,7 @@ export async function verifySetupInferenceConfig(params: {
         if (!credential) {
           throw new Error("staged profile missing after verification");
         }
-        return { profileId: profile.profileId, credential };
+        return { ...profile, credential };
       });
     };
     const retainStagedAuthProfiles = () => {


### PR DESCRIPTION
Related: #106724

## What Problem This Solves

Fixes an issue where users completing GitHub Copilot device login would have the resulting GitHub token stored inline in the agent auth profile. `openclaw secrets audit --check` then correctly reported the durable plaintext credential, even though noninteractive onboarding could already persist an environment-backed `tokenRef`.

## Why This Change Was Made

GitHub Copilot device login now requests host-owned protected persistence by default. OpenClaw keeps the token inline only while staged validation runs, then writes it to the built-in local secret store and persists a stable `tokenRef` at the final auth commit boundary. Public and enterprise login use the same path.

An explicit `--secret-input-mode plaintext` choice remains supported and visible to the audit. If the protected store cannot be written, login fails with repair guidance before replacing the previous auth profile; it never silently falls back to plaintext. Existing ref-backed profiles and noninteractive onboarding are unchanged.

The built-in store requires no external secret-provider configuration. It is write-only through OpenClaw's user-facing secret APIs, but it is not encrypted at rest and continues to rely on state-directory permissions.

## User Impact

Interactive GitHub Copilot login no longer leaves a durable access token inline by default. Existing installations without an external secret provider still get protected-store persistence automatically, while operators who explicitly select plaintext mode keep the previous compatibility behavior and audit warning.

## Evidence

- Red on unmodified production at `c40316696968e53571c1432026fe8f281e58c000`: the focused device-token persistence test expected a protected-store write and observed zero writes; the synthetic auth profile produced `PLAINTEXT_FOUND` at `profiles.github-copilot:github.token`.
- Green on the proposed patch: the same focused reproduction passes and the SQLite integration proves the auth profile contains only a resolvable store ref, the backing value exists, and the plaintext audit finding is absent.
- Negative control: an unavailable protected store reports actionable state-directory repair guidance, preserves the prior ref-backed profile, and writes no inline fallback.
- Explicit plaintext control: the profile remains inline and `openclaw secrets audit --check` continues to report it.
- Public/enterprise device-login guards, noninteractive onboarding, auth-choice, agent-add, system-agent inference, plugin contracts, typechecks, lint, docs formatting, database/schema guards, and plugin-boundary checks pass.
- Source-blind behavior validation passed all five contract checks. No live credentials or existing installations were accessed.

Focused command:

```text
node scripts/run-vitest.mjs src/commands/models/auth.test.ts -t "persists a provider-minted Copilot token through the protected store"
```

Production LOC: +374/-28 (net +346) | Tests/test support: +207/-2 | Docs: +49/-10. The production growth establishes the generic provider-auth storage and compensation boundary; it adds no config or schema surface.
