### PR TITLE
test: fix upgrade stress fixture boundary failures

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/sqlite-volume.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/sqlite-volume.mjs
@@ -551,8 +551,8 @@ export function assertUpgradeVolumeMigrated(stateDir, stage) {
       `unreferenced volume transcript was not archived: ${orphan}`,
     );
   }
-  for (const index of [0, 1, 2]) {
-    const fixture = getVolumeSessionFixture(index);
+  for (const fixture of fixtures.slice(0, 3)) {
+    const { index } = fixture;
     const archived = archivedTranscripts.get(fixture.agentId);
     const entry = archived?.transcriptsByName.get(`${fixture.sessionId}.jsonl`);
     assert(archived && entry, `archived volume transcript sample missing: ${index}`);

--- a/src/infra/update-managed-service-handoff-cross-process.test.ts
+++ b/src/infra/update-managed-service-handoff-cross-process.test.ts
@@ -842,7 +842,14 @@ childProcess.spawnSync = function(command, args, options) {
         commandArgv: [
           process.execPath,
           "-e",
-          `const fs=require("node:fs");fs.writeFileSync(${JSON.stringify(orphanPidPath)},String(process.pid));const timer=setInterval(()=>{if(fs.existsSync(${JSON.stringify(releaseOrphanPath)})){clearInterval(timer);process.exit(0)}},10);`,
+          [
+            'const fs = require("node:fs");',
+            `const pidPath = ${JSON.stringify(orphanPidPath)};`,
+            // File existence signals readiness; never expose an empty PID as a dead updater.
+            'fs.writeFileSync(pidPath + ".tmp", String(process.pid));',
+            'fs.renameSync(pidPath + ".tmp", pidPath);',
+            `const timer=setInterval(()=>{if(fs.existsSync(${JSON.stringify(releaseOrphanPath)})){clearInterval(timer);process.exit(0)}},10);`,
+          ].join("\n"),
         ],
       });
       const secondParamsPath = await writeConcurrentHandoffParams({
@@ -885,8 +892,12 @@ childProcess.spawnSync = function(command, args, options) {
           },
           { interval: 10, timeout: 5_000 },
         );
-        orphanPid = Number(await fs.readFile(orphanPidPath, "utf8"));
-        expect(isPidAlive(orphanPid)).toBe(true);
+        const orphanPidContents = await fs.readFile(orphanPidPath, "utf8");
+        orphanPid = Number(orphanPidContents);
+        expect(
+          isPidAlive(orphanPid),
+          `updater PID bytes: ${JSON.stringify(orphanPidContents)}`,
+        ).toBe(true);
         first.kill("SIGKILL");
         await new Promise<void>((resolve) => {
           first.once("close", () => resolve());


### PR DESCRIPTION
Related: #132975

## What Problem This Solves

Resolves two failures found while stress-testing stable-to-main upgrades: the SQLite volume verifier accepted one or two sessions but required a third archive, and a managed-update recovery test intermittently treated its running updater as dead.

## Why This Change Was Made

Archive samples now come from the seeded fixtures. The subprocess fixture publishes its completed PID file by a same-directory rename, so file existence cannot expose an empty PID. Diagnostic failures retain the observed PID bytes. Assertions and time budgets are unchanged.

## User Impact

No production behavior or database schema changes. Small upgrade fixtures and repeated process-recovery checks now exercise their intended paths reliably.

## Evidence

- Real Docker reproduction before the fix: stable `2026.7.1-2` to candidate commit `6f3ac10499543799811fe82c9ac1a5cfe6858d65`, two sessions, one event each, one cron job; failed with `archived volume transcript sample missing: 2` during `assert-automatic-migration`.
- Repeated recovery tests exposed the PID failure on round three. The second diagnostic rerun captured `updater PID bytes: ""` before any deliberate helper kill. After the producer fix, three fresh focused reruns and the original three-file suite passed (64 passed, one Windows-only skip on macOS).
- Docker wide-data stress passed: 20,000 sessions, 497,750 transcript events, 10,000 cron jobs, and 512 released plugin-state records; 414 seconds, unchanged budgets.
- Fixed two-session Docker upgrade passed in 117 seconds. Deep-data Docker stress passed in 626 seconds: 4,800 sessions, 1,227,946 events, 10,000 cron jobs, and 512 released plugin-state records. Both enforce automatic migration before standalone repair, full preservation checks, SQLite integrity/reopen, repeated Doctor, and live Gateway history before/after restart.
- Changed-file guards and all dead-code scans passed; targeted core/script lint and Docker boundary/catalog checks passed. Local aggregate typechecking is blocked by the pre-existing shared dependency mismatch (`pako` resolves to 1.0.11 while UI declares 3.0.1); [exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33288946092), including every core test typecheck and the required aggregate gate.
- One-session Docker boundary passed in 114 seconds (102 events, correct latest 100 messages before/after restart). Multi-Node Docker update passed in 43 seconds, preserving the installed runtime and service entrypoint after PATH/npm-prefix changes and proving post-update Gateway health.
- The deep run rechecked 600 public Gateway messages before and after restart with identical digests; repeated Doctor completed in 43 seconds under the unchanged 60-second budget, and startup took 11 seconds.
- Blacksmith Testbox `tbx_01m187by3tcz7m89ggph39yb9p`, [holder run](https://github.com/openclaw/openclaw/actions/runs/33287676724). Wrapper commands completed with exit 0; the deliberately failing pre-fix boundary reproduction exited 1.
- Structured Codex review: no blocking findings in the changed scope.

Production LOC: +0/-0. Test support: +2/-2. Tests: +14/-3. No new flags, config, schema, dependency, or test-only production seam.

The package updater must complete migration before the verifier allows any standalone repair. Plugin capability consent remains explicit. These runs do not prove background stable-to-main channel switching or native released SQLite credential retention.

Review follow-through: the latest ClawSweeper review found no code or security defects and requested completed exact-head CI plus maintainer acceptance. CI is now green; these focused test repairs are accepted for landing under the maintainer's explicit fix-and-land direction. No review item is being deferred.
