### PR TITLE
fix(tasks): verify maintenance with Gateway authority

### DIFF
--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -299,7 +299,7 @@ openclaw tasks notify <lookup> state_changes
     - ACP tasks require a live in-process turn in the Gateway; subagent tasks check their backing child session.
     - Subagent tasks whose child session has a restart-recovery tombstone are marked lost instead of being treated as recoverable backing sessions.
     - Automation tasks check whether the automations runtime still owns the job, then recover terminal status from persisted run logs/job state before falling back to `lost`. Only the Gateway process is authoritative for the in-memory active-job set; offline CLI audit uses durable history but does not mark an automation task lost solely because that local set is empty.
-    - CLI tasks with run identity check the owning live run context, not just child-session or chat-session rows.
+    - CLI tasks with run identity check the owning live run context, not just child-session or chat-session rows. Only Gateway maintenance owns that liveness check; standalone CLI audit and maintenance retain active CLI tasks because their local run registry cannot prove that the Gateway run has ended.
 
     Completion cleanup is also runtime-aware:
 

--- a/docs/cli/tasks.md
+++ b/docs/cli/tasks.md
@@ -137,10 +137,11 @@ pruning, and stale cron run session registry cleanup.
 For cron tasks, reconciliation uses persisted run logs/job state before
 marking an old active task `lost`, so completed cron runs do not become
 false audit errors just because the in-memory Gateway runtime state is gone.
-Offline CLI audit is not authoritative for the Gateway's process-local cron
-active-job set. CLI tasks with a run id/source id are marked `lost` when
-their live Gateway run context is gone, even if an old child-session row
-remains.
+Offline CLI audit and maintenance are not authoritative for the Gateway's
+process-local cron, CLI, or ACP liveness. They retain active tasks of those
+kinds when the local runtime cannot prove completion. Gateway maintenance
+marks CLI tasks with a run id/source id `lost` when their live run context is
+gone, even if an old child-session row remains.
 
 When applied, maintenance also prunes `cron:<jobId>:run:<uuid>` session
 registry rows older than 7 days while preserving currently running cron

--- a/src/tasks/task-operations.e2e.test.ts
+++ b/src/tasks/task-operations.e2e.test.ts
@@ -21,6 +21,7 @@ import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { createRunningTaskRunCore, recordTaskRunProgressByRunIdCore } from "./task-executor.js";
 import { createTaskRecord, getTaskById, reloadTaskRegistryFromStore } from "./task-registry.js";
 import {
+  configureTaskRegistryMaintenance,
   resetTaskRegistryMaintenanceRuntimeForTests,
   stopTaskRegistryMaintenance,
 } from "./task-registry.maintenance.js";
@@ -159,6 +160,15 @@ describe("task operations product boundary", () => {
             notifyPolicy: "done_only",
           });
 
+          const standaloneList = createRuntime();
+          await tasksListCommand({}, standaloneList.runtime);
+          expect(standaloneList.logs.join("\n")).toContain(
+            "Task pressure: 0 queued · 2 running · 0 issues",
+          );
+          expect(requireTask(stale.taskId).status).toBe("running");
+
+          // Only the Gateway can reconcile CLI runs from process-local liveness.
+          configureTaskRegistryMaintenance({ runtimeAuthoritative: true });
           const list = createRuntime();
           await tasksListCommand({}, list.runtime);
           expect(list.logs.join("\n")).toContain("Background tasks: 3");


### PR DESCRIPTION
## What Problem This Solves

Resolves a failure in full release verification where the task-operations E2E test expected a standalone command to mark an old CLI task lost. Since #132602, standalone maintenance correctly preserves CLI tasks because it cannot observe the Gateway's live run registry.

## Why This Change Was Made

The fixture now checks standalone retention first, then enters the existing Gateway maintenance authority mode before exercising reconciliation. All existing persisted reload, CLI, chat, notification, audit, maintenance, and cancellation assertions remain. The task documentation now explains the same ownership boundary.

## User Impact

No production behavior, configuration, or storage changes. Release verification covers both authority modes instead of rejecting the safety rule that protects active Gateway work from standalone maintenance.

## Evidence

- The repo E2E job in [Full Release Validation](https://github.com/openclaw/openclaw/actions/runs/33284888538) and an unchanged local run both reported `0 queued · 2 running · 0 issues` where the old fixture expected `0 queued · 1 running · 1 issues`.
- The corrected persisted task-operations E2E passes through both modes. The test body took 1.31 seconds; the prepared-artifact run took 10.63 seconds.
- The complete required changed-file gate passed, including core-test typechecks, targeted lint, formatting, all guards, and all three Knip scans.
- Managed Codex P2 review: no actionable findings. Production LOC delta: zero; test delta: +10 lines; documentation: +6/-5.

Focused command, reusing the successfully prepared runtime artifacts:

```sh
OPENCLAW_E2E_USE_PREBUILT_DIST=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts --configLoader runner src/tasks/task-operations.e2e.test.ts
```
