### PR TITLE
fix(status): group shared session stores by canonical owner

### DIFF
--- a/docs/gateway/health.md
+++ b/docs/gateway/health.md
@@ -26,6 +26,12 @@ read stored conversation state. A provider can reconnect and show healthy channe
 status before any new session row is materialized. Use the channel status and
 health commands above for live connectivity checks.
 
+Per-agent session counts and recent activity include only that agent's sessions,
+even when agents share a SQLite session store. Status counts each physical store
+once in its aggregate. The top-level health session summary represents the
+default agent, or the first configured agent when there is no default; it is not
+a fleet total.
+
 ## Deep diagnostics
 
 - Creds on disk: `ls -l ~/.openclaw/credentials/whatsapp/<accountId>/creds.json` (mtime should be recent).

--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -586,8 +586,8 @@ describe("collectGatewayHealthSnapshot", () => {
     testStore = {
       global: { updatedAt: Date.now() },
       unknown: { updatedAt: Date.now() },
-      main: { updatedAt: 1000 },
-      foo: { updatedAt: 2000 },
+      "agent:main:main": { updatedAt: 1000 },
+      "agent:main:foo": { updatedAt: 2000 },
     };
     vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
     vi.stubEnv("DISCORD_BOT_TOKEN", "");
@@ -602,7 +602,7 @@ describe("collectGatewayHealthSnapshot", () => {
     expect(telegram.configured).toBe(false);
     expect(telegram.probe).toBeUndefined();
     expect(snap.sessions.count).toBe(2);
-    expect(snap.sessions.recent[0]?.key).toBe("foo");
+    expect(snap.sessions.recent[0]?.key).toBe("agent:main:foo");
   });
 
   it("probes telegram getMe + webhook info when configured", async () => {

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -2,7 +2,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayClientRequestError } from "../../packages/gateway-client/src/index.js";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
+import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
 import { ExitError } from "../runtime.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
   buildCredentialsRequiredHealthDiagnostic,
   buildRateLimitedHealthDiagnostic,
@@ -290,41 +292,76 @@ describe("healthCommand", () => {
     expect(output).not.toContain("Matrix: ok");
   });
 
-  it("shows every agent when an explicit fleet has no default owner", async () => {
-    const sessions = (agentId: string) => ({
-      path: `/tmp/${agentId}/sessions.json`,
-      count: 0,
-      recent: [],
-    });
-    const snapshot = {
-      ...createHealthSummary({ channels: {}, channelOrder: [], channelLabels: {} }),
-      defaultAgentId: undefined,
-      agents: [
-        { ...createMainAgentSummary(sessions("alpha")), agentId: "alpha", isDefault: false },
-        { ...createMainAgentSummary(sessions("beta")), agentId: "beta", isDefault: false },
-      ],
-    };
-    callGatewayMock.mockResolvedValueOnce(snapshot);
+  it.each(["remote", "empty", "missing"] as const)(
+    "shows each explicit fleet owner's sessions with %s agent summaries",
+    async (agentSummaries) => {
+      await withOpenClawTestState({ layout: "state-only" }, async (state) => {
+        const storePath = state.statePath("shared.sqlite");
+        const updatedAt = Date.now();
+        for (const [agentId, key] of [
+          ["alpha", "first"],
+          ["alpha", "second"],
+          ["beta", "only"],
+        ] as const) {
+          await replaceSessionEntry(
+            { agentId, storePath, sessionKey: `agent:${agentId}:${key}` },
+            { sessionId: `${agentId}-${key}`, updatedAt },
+          );
+        }
+        const agent = (agentId: string, keys: string[]) => ({
+          ...createMainAgentSummary({
+            path: storePath,
+            count: keys.length,
+            recent: keys.map((key) => ({
+              key: `agent:${agentId}:${key}`,
+              updatedAt,
+              age: 0,
+            })),
+          }),
+          agentId,
+          isDefault: false,
+        });
+        const { agents: _agents, ...snapshot } = createHealthSummary({
+          channels: {},
+          channelOrder: [],
+          channelLabels: {},
+        });
+        callGatewayMock.mockResolvedValueOnce({
+          ...snapshot,
+          defaultAgentId: undefined,
+          ...(agentSummaries === "missing"
+            ? {}
+            : {
+                agents:
+                  agentSummaries === "empty"
+                    ? []
+                    : [agent("alpha", ["first", "second"]), agent("beta", ["only"])],
+              }),
+        });
 
-    await healthCommand(
-      {
-        json: false,
-        timeoutMs: 1000,
-        config: {
-          agents: {
-            ownership: "explicit",
-            entries: { alpha: {}, beta: {} },
+        await healthCommand(
+          {
+            json: false,
+            timeoutMs: 1_000,
+            config: {
+              session: { store: storePath },
+              agents: { ownership: "explicit", entries: { alpha: {}, beta: {} } },
+            },
           },
-        },
-      },
-      runtime as never,
-    );
+          runtime as never,
+        );
 
-    const output = stripAnsi(runtime.log.mock.calls.map((call) => String(call[0])).join("\n"));
-    expect(output).toContain("Session store (alpha): /tmp/alpha/sessions.json");
-    expect(output).toContain("Session store (beta): /tmp/beta/sessions.json");
-    expect(output).not.toContain("(default)");
-  });
+        const output = stripAnsi(runtime.log.mock.calls.map((call) => String(call[0])).join("\n"));
+        expect(output).toContain(
+          `Session store (alpha): ${storePath} (2 entries)\n- agent:alpha:first`,
+        );
+        expect(output).toContain(
+          `Session store (beta): ${storePath} (1 entries)\n- agent:beta:only`,
+        );
+        expect(output).not.toContain("(default)");
+      });
+    },
+  );
 
   it("prints persistent event-loop degradation duration in text output", async () => {
     const snapshot = {

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -6,7 +6,6 @@ import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { listReadOnlyChannelPluginsForConfig } from "../channels/plugins/read-only.js";
 import { probeGatewayStatus } from "../cli/daemon-cli/probe.js";
 import { withProgress } from "../cli/progress.js";
-import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   buildGatewayConnectionDetails,
@@ -20,10 +19,10 @@ import {
 import { isGatewaySecretRefUnavailableError } from "../gateway/credentials.js";
 import { resolveHealthAccountContext } from "../gateway/health/account-context.js";
 import {
-  buildHealthSessionSummary as buildSessionSummary,
+  buildHealthAgentSummaries,
   resolveHealthAgentOrder as resolveAgentOrder,
 } from "../gateway/health/collector.js";
-import type { AgentHealthSummary, HealthSummary } from "../gateway/health/types.js";
+import type { HealthSummary } from "../gateway/health/types.js";
 import { info } from "../globals.js";
 import { isDiagnosticFlagEnabled } from "../infra/diagnostic-flags.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -31,7 +30,6 @@ import {
   formatDurationCompact,
   formatDurationHuman,
 } from "../infra/format-time/format-duration.js";
-import { resolveHeartbeatSummaryForAgent } from "../infra/heartbeat-summary.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { buildChannelAccountBindings, resolvePreferredAccountId } from "../routing/bindings.js";
 import { ExitError, type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
@@ -232,9 +230,6 @@ export function formatConfigReloadHealthLine(summary: HealthSummary): string | n
   return "Config hot reload: disabled (watcher retries exhausted; restart the gateway to restore it)";
 }
 
-const resolveHeartbeatSummary = (cfg: OpenClawConfig, agentId: string) =>
-  resolveHeartbeatSummaryForAgent(cfg, agentId);
-
 /** Runs the `openclaw health` command against the gateway and renders JSON or text. */
 export async function healthCommand(
   opts: {
@@ -322,22 +317,7 @@ export async function healthCommand(
     const defaultAgentId = summary.defaultAgentId ?? localAgents.defaultAgentId;
     const agents = Array.isArray(summary.agents) ? summary.agents : [];
     const resolvedAgents =
-      agents.length > 0
-        ? agents
-        : await Promise.all(
-            localAgents.ordered.map(async (entry) => {
-              const storePath = resolveSessionStorePathCore(cfg.session?.store, {
-                agentId: entry.id,
-              });
-              return {
-                agentId: entry.id,
-                name: entry.name,
-                isDefault: entry.id === localAgents.defaultAgentId,
-                heartbeat: resolveHeartbeatSummary(cfg, entry.id),
-                sessions: await buildSessionSummary(storePath, entry.id),
-              } satisfies AgentHealthSummary;
-            }),
-          );
+      agents.length > 0 ? agents : await buildHealthAgentSummaries(cfg, localAgents);
     const displayAgents =
       opts.verbose || !defaultAgentId
         ? resolvedAgents

--- a/src/commands/status.agent-local.ts
+++ b/src/commands/status.agent-local.ts
@@ -3,12 +3,10 @@
 
 import path from "node:path";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
-import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
-import { listSessionEntriesReadOnly } from "../config/sessions/session-accessor.js";
-import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { listGatewayAgentsBasic, type GatewayAgentOwnership } from "../gateway/agent-list.js";
 import { pathExists } from "../infra/fs-safe.js";
+import { readStatusSessionStores } from "../status/session-stores.js";
 
 export type AgentLocalStatus = {
   id: string;
@@ -37,8 +35,9 @@ export async function getAgentLocalStatuses(
   const agentList = listGatewayAgentsBasic(cfg);
   const now = Date.now();
 
+  const sessionStores = readStatusSessionStores(cfg, agentList.agents);
   const statuses: AgentLocalStatus[] = [];
-  for (const agent of agentList.agents) {
+  for (const { agent, path: sessionsPath, sessions } of sessionStores.byAgent) {
     const agentId = agent.id;
     const workspaceDir = (() => {
       try {
@@ -52,14 +51,10 @@ export async function getAgentLocalStatuses(
     const bootstrapPath = workspaceDir != null ? path.join(workspaceDir, "BOOTSTRAP.md") : null;
     const bootstrapPending = bootstrapPath != null ? await pathExists(bootstrapPath) : null;
 
-    const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId });
-    const sessionsPath = resolveSqliteTargetFromSessionStorePath(storePath, { agentId }).path;
-    const sessions = listSessionEntriesReadOnly({ agentId, storePath })
-      // Global/unknown buckets are aggregate compatibility entries, not agent activity.
-      .filter(({ sessionKey }) => sessionKey !== "global" && sessionKey !== "unknown")
-      .map(({ entry }) => entry);
-    const sessionsCount = sessions.length;
-    const lastUpdatedAt = sessions.reduce((max, e) => Math.max(max, e?.updatedAt ?? 0), 0);
+    const lastUpdatedAt = sessions.reduce(
+      (max, session) => Math.max(max, session.entry.updatedAt ?? 0),
+      0,
+    );
     const resolvedLastUpdatedAt = lastUpdatedAt > 0 ? lastUpdatedAt : null;
     const lastActiveAgeMs = resolvedLastUpdatedAt ? now - resolvedLastUpdatedAt : null;
 
@@ -69,13 +64,12 @@ export async function getAgentLocalStatuses(
       workspaceDir,
       bootstrapPending,
       sessionsPath,
-      sessionsCount,
+      sessionsCount: sessions.length,
       lastUpdatedAt: resolvedLastUpdatedAt,
       lastActiveAgeMs,
     });
   }
 
-  const totalSessions = statuses.reduce((sum, s) => sum + s.sessionsCount, 0);
   const bootstrapPendingCount = statuses.reduce((sum, s) => sum + (s.bootstrapPending ? 1 : 0), 0);
   return {
     // The gateway keeps a projected first id for wire compatibility. Local status must
@@ -84,7 +78,7 @@ export async function getAgentLocalStatuses(
     ownership: agentList.ownership ?? (agentList.selectionRequired === true ? "explicit" : "sole"),
     selectionRequired: agentList.selectionRequired === true,
     agents: statuses,
-    totalSessions,
+    totalSessions: sessionStores.sessions.length,
     bootstrapPendingCount,
   };
 }

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -833,10 +833,10 @@ describe("getStatusSummary", () => {
     statusSummaryMocks.listSessionEntriesCore.mockImplementation((scope) =>
       scope?.agentId === "ops"
         ? toSessionEntrySummaries({
-            main: { sessionId: "ops-session", updatedAt: 2 },
+            "agent:ops:main": { sessionId: "ops-session", updatedAt: 2 },
           })
         : toSessionEntrySummaries({
-            main: { sessionId: "main-session", updatedAt: 1 },
+            "agent:main:main": { sessionId: "main-session", updatedAt: 1 },
           }),
     );
 
@@ -1070,7 +1070,7 @@ describe("getStatusSummary", () => {
       toSessionEntrySummaries({
         "agent:ops:main": { sessionId: "ops-session", updatedAt: 3 },
         "agent:research:main": { sessionId: "research-session", updatedAt: 2 },
-        main: { sessionId: "global-session", updatedAt: 1 },
+        "agent:main:main": { sessionId: "global-session", updatedAt: 1 },
       }),
     );
 
@@ -1078,5 +1078,8 @@ describe("getStatusSummary", () => {
     const selected = summary.sessions.recent.map(({ selectedModel }) => selectedModel);
 
     expect(selected).toEqual(["openai/ops", "openai/research", "openai/global"]);
+    expect(summary.sessions.count).toBe(3);
+    expect(summary.sessions.byAgent[0]?.count).toBe(1);
+    expect(summary.sessions.byAgent[0]?.recent.map(({ key }) => key)).toEqual(["agent:main:main"]);
   });
 });

--- a/src/gateway/health/collector.session-store-path.test.ts
+++ b/src/gateway/health/collector.session-store-path.test.ts
@@ -2,15 +2,24 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import * as configRuntime from "../../config/config.js";
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
-import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
+import * as sessionAccessor from "../../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../../config/sessions/session-sqlite-target.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   resolveOpenClawAgentSqlitePath,
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
-import { buildHealthSessionSummary } from "./collector.js";
+import { collectGatewayHealthSnapshot } from "./collector.js";
+
+async function summarizeStore(storePath: string, agentId: string) {
+  vi.spyOn(configRuntime, "getRuntimeConfig").mockReturnValue({
+    agents: { ownership: "explicit", entries: { [agentId]: {} } },
+    session: { store: storePath },
+  });
+  return (await collectGatewayHealthSnapshot({ audience: "admin", probe: false })).sessions;
+}
 
 describe("health session store paths", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -28,13 +37,13 @@ describe("health session store paths", () => {
     const storePath = resolveSessionStorePathCore(undefined, { agentId, env });
     const databasePath = resolveOpenClawAgentSqlitePath({ agentId, env });
 
-    await upsertSessionEntryCore(
+    await sessionAccessor.upsertSessionEntryCore(
       { agentId, env, sessionKey: `agent:${agentId}:main`, storePath },
       { sessionId: "session-1", updatedAt: 10 },
     );
     closeOpenClawAgentDatabasesForTest();
 
-    const summary = await buildHealthSessionSummary(storePath, agentId);
+    const summary = await summarizeStore(storePath, agentId);
 
     expect(summary.count).toBe(1);
     expect(summary.path).toBe(databasePath);
@@ -49,7 +58,7 @@ describe("health session store paths", () => {
     const now = vi.spyOn(Date, "now");
     for (const updatedAt of [30, 70, 10, 60, 40, 20, 50]) {
       now.mockReturnValue(updatedAt);
-      await upsertSessionEntryCore(
+      await sessionAccessor.upsertSessionEntryCore(
         { agentId, env, sessionKey: `agent:${agentId}:session-${updatedAt}`, storePath },
         {
           sessionId: `session-${updatedAt}`,
@@ -61,9 +70,11 @@ describe("health session store paths", () => {
     now.mockReturnValue(100);
     const clone = vi.spyOn(globalThis, "structuredClone");
 
-    const summary = await buildHealthSessionSummary(storePath, agentId);
+    const summary = await summarizeStore(storePath, agentId);
 
-    expect(clone).not.toHaveBeenCalled();
+    expect(clone).not.toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: expect.stringMatching(/^session-/) }),
+    );
     expect(summary).toMatchObject({
       count: 7,
       recent: [
@@ -76,50 +87,81 @@ describe("health session store paths", () => {
     });
   });
 
-  it("preserves configured store templates and reports empty agent targets", async () => {
-    const stateDir = tempDirs.make("openclaw-health-session-template-");
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    const storeTemplate = path.join(stateDir, "stores", "{agentId}", "sessions.json");
-    const populatedAgentId = "helper";
-    const populatedStorePath = resolveSessionStorePathCore(storeTemplate, {
-      agentId: populatedAgentId,
-      env,
-    });
-    const populatedDatabasePath = resolveSqliteTargetFromSessionStorePath(populatedStorePath, {
-      agentId: populatedAgentId,
-      env,
-    }).path;
-
-    expect(populatedStorePath).toBe(
-      path.join(stateDir, "stores", populatedAgentId, "sessions.json"),
-    );
-    await upsertSessionEntryCore(
-      {
+  it.each(["template", "shared"] as const)(
+    "scopes %s stores and recovers from transient reads",
+    async (layout) => {
+      const stateDir = tempDirs.make("openclaw-health-session-template-");
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      const storeTemplate = path.join(
+        stateDir,
+        "stores",
+        layout === "shared" ? "shared.sqlite" : "{agentId}/sessions.json",
+      );
+      const populatedAgentId = "helper";
+      const populatedStorePath = resolveSessionStorePathCore(storeTemplate, {
         agentId: populatedAgentId,
         env,
-        sessionKey: `agent:${populatedAgentId}:main`,
-        storePath: populatedStorePath,
-      },
-      { sessionId: "session-1", updatedAt: 10 },
-    );
-    closeOpenClawAgentDatabasesForTest();
+      });
+      const populatedDatabasePath = resolveSqliteTargetFromSessionStorePath(populatedStorePath, {
+        agentId: populatedAgentId,
+        env,
+      }).path;
 
-    const populated = await buildHealthSessionSummary(populatedStorePath, populatedAgentId);
-    const emptyAgentId = "third";
-    const emptyStorePath = resolveSessionStorePathCore(storeTemplate, {
-      agentId: emptyAgentId,
-      env,
-    });
-    const empty = await buildHealthSessionSummary(emptyStorePath, emptyAgentId);
+      await sessionAccessor.upsertSessionEntryCore(
+        {
+          agentId: populatedAgentId,
+          env,
+          sessionKey: `agent:${populatedAgentId}:main`,
+          storePath: populatedStorePath,
+        },
+        { sessionId: "session-1", updatedAt: 10 },
+      );
+      closeOpenClawAgentDatabasesForTest();
 
-    expect(populated).toMatchObject({ count: 1, path: populatedDatabasePath });
-    expect(fs.existsSync(populated.path)).toBe(true);
-    expect(empty).toMatchObject({
-      count: 0,
-      path: resolveSqliteTargetFromSessionStorePath(emptyStorePath, {
+      const populated = await summarizeStore(populatedStorePath, populatedAgentId);
+      const emptyAgentId = "third";
+      const emptyStorePath = resolveSessionStorePathCore(storeTemplate, {
         agentId: emptyAgentId,
         env,
-      }).path,
-    });
-  });
+      });
+      const empty = await summarizeStore(emptyStorePath, emptyAgentId);
+
+      expect(populated).toMatchObject({ count: 1, path: populatedDatabasePath });
+      expect(fs.existsSync(populated.path)).toBe(true);
+      expect(empty).toMatchObject({
+        count: 0,
+        path: resolveSqliteTargetFromSessionStorePath(emptyStorePath, {
+          agentId: emptyAgentId,
+          env,
+        }).path,
+      });
+
+      vi.spyOn(configRuntime, "getRuntimeConfig").mockReturnValue({
+        agents: { ownership: "explicit", entries: { helper: {}, third: {} } },
+        session: { store: storeTemplate },
+      });
+      const reads = vi.spyOn(sessionAccessor, "listSessionEntriesReadOnly");
+      const collect = () => collectGatewayHealthSnapshot({ audience: "admin", probe: false });
+      const summary = await collect();
+      expect(summary.agents.map((agent) => [agent.agentId, agent.sessions.count])).toEqual([
+        [populatedAgentId, 1],
+        [emptyAgentId, 0],
+      ]);
+      expect(summary.sessions).toEqual(summary.agents[0]?.sessions);
+      expect(reads).toHaveBeenCalledTimes(layout === "shared" ? 1 : 2);
+
+      reads.mockClear().mockImplementationOnce(() => {
+        throw Object.assign(new Error("database is locked"), { code: "SQLITE_BUSY" });
+      });
+      expect((await collect()).agents.map((agent) => agent.sessions.count)).toEqual([0, 0]);
+      expect(reads).toHaveBeenCalledTimes(layout === "shared" ? 1 : 2);
+      expect((await collect()).agents.map((agent) => agent.sessions.count)).toEqual([1, 0]);
+
+      const fatal = new Error("invalid session state");
+      reads.mockImplementationOnce(() => {
+        throw fatal;
+      });
+      await expect(collect()).rejects.toBe(fatal);
+    },
+  );
 });

--- a/src/gateway/health/collector.ts
+++ b/src/gateway/health/collector.ts
@@ -10,7 +10,7 @@ import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import type { ChannelAccountSnapshot } from "../../channels/plugins/types.public.js";
 import { tryResolveLegacyCompatibilityAgentId } from "../../config/legacy.default-agent-owner.js";
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
-import { resolveSqliteTargetFromSessionStorePath } from "../../config/sessions/session-sqlite-target.js";
+import type { SessionEntrySummary } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isDiagnosticFlagEnabled } from "../../infra/diagnostic-flags.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -108,33 +108,27 @@ export function resolveHealthAgentOrder(cfg: OpenClawConfig) {
   return { defaultAgentId, ordered };
 }
 
-export async function buildHealthSessionSummary(storePath: string, agentId?: string) {
-  const databasePath = resolveSqliteTargetFromSessionStorePath(storePath, { agentId }).path;
+async function createHealthSessionStoreReader() {
+  const { createStatusSessionStoreReader } = await import("../../status/session-stores.js");
   const { listSessionEntriesReadOnly } = await import("../../config/sessions/session-accessor.js");
   const { isTransientSqliteError } = await import("../../infra/unhandled-rejections.js");
-  let listed: ReturnType<typeof listSessionEntriesReadOnly>;
-  try {
-    listed = listSessionEntriesReadOnly({
-      ...(agentId ? { agentId } : {}),
-      clone: false,
-      projection: "list",
-      storePath,
-    });
-  } catch (error) {
-    if (!isTransientSqliteError(error)) {
-      throw error;
+  return createStatusSessionStoreReader((scope) => {
+    try {
+      return listSessionEntriesReadOnly({ ...scope, clone: false, projection: "list" });
+    } catch (error) {
+      if (!isTransientSqliteError(error)) {
+        throw error;
+      }
+      // Health is best-effort: one empty snapshot beats repeated transient lock failures.
+      return [];
     }
-    // Health is best-effort: an empty snapshot beats failing on a transient lock.
-    listed = [];
-  }
+  });
+}
+
+function projectHealthSessions(path: string, sessions: SessionEntrySummary[]) {
   const recentSessions: Array<{ key: string; updatedAt: number }> = [];
-  let sessionCount = 0;
-  for (const { sessionKey, entry } of listed) {
-    if (sessionKey === "global" || sessionKey === "unknown") {
-      continue;
-    }
-    sessionCount += 1;
-    const session = { key: sessionKey, updatedAt: entry?.updatedAt ?? 0 };
+  for (const { sessionKey: key, entry } of sessions) {
+    const session = { key, updatedAt: entry.updatedAt ?? 0 };
     const insertAt = recentSessions.findIndex(
       (recentSession) => session.updatedAt > recentSession.updatedAt,
     );
@@ -155,10 +149,37 @@ export async function buildHealthSessionSummary(storePath: string, agentId?: str
     age: session.updatedAt ? Date.now() - session.updatedAt : null,
   }));
   return {
-    path: databasePath,
-    count: sessionCount,
+    path,
+    count: sessions.length,
     recent,
   } satisfies HealthSummary["sessions"];
+}
+
+async function buildHealthSessionSummary(storePath: string, agentId?: string) {
+  const reader = await createHealthSessionStoreReader();
+  const store = reader.read(storePath, agentId);
+  return projectHealthSessions(store.path, store.sessions);
+}
+
+/** Projects borrowed rows synchronously before returning the owned health summaries. */
+export async function buildHealthAgentSummaries(
+  cfg: OpenClawConfig,
+  { defaultAgentId, ordered }: ReturnType<typeof resolveHealthAgentOrder>,
+): Promise<AgentHealthSummary[]> {
+  const reader = await createHealthSessionStoreReader();
+  return ordered.map((entry) => {
+    const store = reader.read(
+      resolveSessionStorePathCore(cfg.session?.store, { agentId: entry.id }),
+      entry.id,
+    );
+    return {
+      agentId: entry.id,
+      name: entry.name,
+      isDefault: entry.id === defaultAgentId,
+      heartbeat: resolveHeartbeatSummary(cfg, entry.id),
+      sessions: projectHealthSessions(store.path, store.sessions),
+    };
+  });
 }
 
 function buildPluginHealthSummary(): PluginHealthSummary | undefined {
@@ -503,18 +524,7 @@ export async function collectGatewayHealthSnapshot(params: {
   const cfg = await readRuntimeHealthConfig();
   const { defaultAgentId, ordered } = resolveHealthAgentOrder(cfg);
   const channelBindings = buildChannelAccountBindings(cfg);
-  const agents: AgentHealthSummary[] = [];
-  for (const entry of ordered) {
-    const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId: entry.id });
-    const sessions = await buildHealthSessionSummary(storePath, entry.id);
-    agents.push({
-      agentId: entry.id,
-      name: entry.name,
-      isDefault: entry.id === defaultAgentId,
-      heartbeat: resolveHeartbeatSummary(cfg, entry.id),
-      sessions,
-    });
-  }
+  const agents = await buildHealthAgentSummaries(cfg, { defaultAgentId, ordered });
   const summaryAgent = agents.find((agent) => agent.isDefault) ?? agents[0];
   const configuredHeartbeatAgentId = normalizeOptionalString(
     cfg.agents?.defaults?.heartbeat?.agentId,

--- a/src/status/session-stores.ts
+++ b/src/status/session-stores.ts
@@ -1,0 +1,69 @@
+import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
+import {
+  listSessionEntriesReadOnly,
+  type SessionEntrySummary,
+} from "../config/sessions/session-accessor.js";
+import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
+
+type StatusSessionStore = {
+  sessions: SessionEntrySummary[];
+  byAgent: Map<string, SessionEntrySummary[]>;
+};
+
+/** One collection owns the snapshot; borrowed read policies must finish before an await. */
+export function createStatusSessionStoreReader(
+  readEntries: typeof listSessionEntriesReadOnly = listSessionEntriesReadOnly,
+) {
+  const stores = new Map<string, StatusSessionStore>();
+  return {
+    stores,
+    read(storePath: string, agentId?: string) {
+      const path = resolveSqliteTargetFromSessionStorePath(storePath, { agentId }).path;
+      let store = stores.get(path);
+      if (!store) {
+        store = { sessions: [], byAgent: new Map() };
+        for (const row of readEntries({
+          ...(agentId ? { agentId } : {}),
+          storePath,
+        })) {
+          // The accessor validates canonical keys; only global/unknown buckets lack an agent.
+          const owner = parseAgentSessionKey(row.sessionKey)?.agentId;
+          if (!owner) {
+            continue;
+          }
+          store.sessions.push(row);
+          const agentSessions = store.byAgent.get(owner);
+          if (agentSessions) {
+            agentSessions.push(row);
+          } else {
+            store.byAgent.set(owner, [row]);
+          }
+        }
+        stores.set(path, store);
+      }
+      return { path, sessions: agentId ? (store.byAgent.get(agentId) ?? []) : store.sessions };
+    },
+  };
+}
+
+/** Reads each physical store once, retaining retired agent namespaces in the aggregate. */
+export function readStatusSessionStores(
+  cfg: OpenClawConfig,
+  agents: ReadonlyArray<{ id: string; name?: string }>,
+) {
+  const reader = createStatusSessionStoreReader();
+  const byAgent = agents.map((agent) => ({
+    agent,
+    ...reader.read(
+      resolveSessionStorePathCore(cfg.session?.store, { agentId: agent.id }),
+      agent.id,
+    ),
+  }));
+  return {
+    paths: [...reader.stores.keys()],
+    sessions: [...reader.stores.values()].flatMap((store) => store.sessions),
+    byAgent,
+  };
+}

--- a/src/status/summary.read-only.test.ts
+++ b/src/status/summary.read-only.test.ts
@@ -3,9 +3,14 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { getAgentLocalStatuses } from "../commands/status.agent-local.js";
 import { clearRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
 import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
-import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
+import * as sessionAccessor from "../config/sessions/session-accessor.js";
+import {
+  replaceSessionEntry,
+  upsertSessionEntryCore,
+} from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import { getActivePluginRegistry, setActivePluginRegistry } from "../plugins/runtime.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
@@ -95,46 +100,79 @@ describe("getStatusSummary read-only session access", () => {
     },
   );
 
-  it("reports and aggregates fixed logical stores by their physical SQLite targets", async () => {
-    const tempDir = tempDirs.make("openclaw-status-session-stores-");
-    const storePath = path.join(tempDir, "sessions.json");
-    const config = {
-      agents: {
-        defaults: { systemAgent: { agentId: "main" } },
-        list: [{ id: "main", default: true }, { id: "ops" }],
-      },
-      session: { store: storePath },
-    };
+  it.each(["sessions.json", "shared.sqlite"])(
+    "reports each agent's activity and reads each physical session store once for %s",
+    async (fileName) => {
+      const tempDir = tempDirs.make("openclaw-status-session-stores-");
+      const storePath = path.join(tempDir, fileName);
+      const config = {
+        agents: {
+          defaults: { systemAgent: { agentId: "main" } },
+          list: [{ id: "main", default: true }, { id: "ops" }],
+        },
+        session: { store: storePath },
+      };
 
-    try {
-      for (const agentId of ["main", "ops"]) {
-        const logicalPath = resolveSessionStorePathCore(config.session.store, { agentId });
-        await upsertSessionEntryCore(
-          { agentId, sessionKey: `agent:${agentId}:main`, storePath: logicalPath },
-          { sessionId: `${agentId}-session`, updatedAt: 10 },
+      try {
+        for (const agentId of ["main", "ops"]) {
+          const logicalPath = resolveSessionStorePathCore(config.session.store, { agentId });
+          await replaceSessionEntry(
+            { agentId, sessionKey: `agent:${agentId}:main`, storePath: logicalPath },
+            { sessionId: `${agentId}-session`, updatedAt: agentId === "main" ? 10 : 20 },
+          );
+        }
+        closeOpenClawAgentDatabasesForTest();
+
+        const expectedPaths = ["main", "ops"].map(
+          (agentId) => resolveSqliteTargetFromSessionStorePath(storePath, { agentId }).path,
         );
+        const uniquePaths = [...new Set(expectedPaths)];
+        const listEntries = vi.spyOn(sessionAccessor, "listSessionEntriesReadOnly");
+        const now = vi.spyOn(Date, "now").mockReturnValue(100);
+        try {
+          const summary = await getStatusSummary({ includeChannelSummary: false, config });
+
+          expect(summary.sessions.count).toBe(2);
+          expect(summary.sessions.paths).toEqual(uniquePaths);
+          expect(
+            summary.sessions.byAgent.map((agent) => [
+              agent.agentId,
+              agent.path,
+              agent.count,
+              agent.recent.map((session) => [session.agentId, session.key]),
+            ]),
+          ).toEqual([
+            ["main", expectedPaths[0], 1, [["main", "agent:main:main"]]],
+            ["ops", expectedPaths[1], 1, [["ops", "agent:ops:main"]]],
+          ]);
+          expect(listEntries).toHaveBeenCalledTimes(uniquePaths.length);
+
+          listEntries.mockClear();
+          const local = await getAgentLocalStatuses(config);
+          expect(local.totalSessions).toBe(2);
+          expect(
+            local.agents.map((agent) => [
+              agent.id,
+              agent.sessionsCount,
+              agent.lastUpdatedAt,
+              agent.lastActiveAgeMs,
+            ]),
+          ).toEqual([
+            ["main", 1, 10, 90],
+            ["ops", 1, 20, 80],
+          ]);
+          expect(listEntries).toHaveBeenCalledTimes(uniquePaths.length);
+          expect(uniquePaths.every((databasePath) => fs.existsSync(databasePath))).toBe(true);
+        } finally {
+          listEntries.mockRestore();
+          now.mockRestore();
+        }
+      } finally {
+        closeOpenClawAgentDatabasesForTest();
+        closeOpenClawStateDatabaseForTest();
       }
-      closeOpenClawAgentDatabasesForTest();
-
-      const summary = await getStatusSummary({ includeChannelSummary: false, config });
-      const expectedPaths = ["main", "ops"].map(
-        (agentId) => resolveSqliteTargetFromSessionStorePath(storePath, { agentId }).path,
-      );
-
-      expect(summary.sessions.count).toBe(2);
-      expect(summary.sessions.paths).toEqual(expectedPaths);
-      expect(
-        summary.sessions.byAgent.map((agent) => [agent.agentId, agent.path, agent.count]),
-      ).toEqual([
-        ["main", expectedPaths[0], 1],
-        ["ops", expectedPaths[1], 1],
-      ]);
-      expect(expectedPaths.every((databasePath) => fs.existsSync(databasePath))).toBe(true);
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
-    }
-  });
+    },
+  );
 
   it("does not reread ambient config while projecting prepared session runtime state", async () => {
     await withOpenClawTestState(

--- a/src/status/summary.ts
+++ b/src/status/summary.ts
@@ -11,12 +11,10 @@ import {
   hasSessionActiveAutoModelFallback,
   hasUserPinnedModelSelection,
 } from "../config/sessions/model-override-provenance.js";
-import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
 import {
-  listSessionEntriesReadOnly,
   loadExactSessionEntryReadOnly,
+  type SessionEntrySummary,
 } from "../config/sessions/session-accessor.js";
-import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import {
   resolveFreshSessionTotalTokens,
   resolveSessionTotalTokens,
@@ -45,6 +43,7 @@ import {
 } from "../tasks/task-registry.audit.js";
 import { deliveryContextFromSession } from "../utils/delivery-context.shared.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
+import { readStatusSessionStores } from "./session-stores.js";
 import type { HeartbeatStatus, SessionStatus, StatusSummary } from "./types.js";
 
 const RECENT_SESSION_LIMIT = 10;
@@ -128,21 +127,18 @@ function discountRetainedLostTaskFailures(
   };
 }
 
-type SessionCandidate = {
-  key: string;
-  entry: SessionEntry;
-  updatedAt: number | null;
-};
-
-function compareSessionCandidatesByUpdatedAt(left: SessionCandidate, right: SessionCandidate) {
-  return (right.updatedAt ?? 0) - (left.updatedAt ?? 0);
+function compareSessionCandidatesByUpdatedAt(
+  left: SessionEntrySummary,
+  right: SessionEntrySummary,
+) {
+  return (right.entry.updatedAt ?? 0) - (left.entry.updatedAt ?? 0);
 }
 
 function selectRecentSessionCandidates(
-  candidates: SessionCandidate[],
+  candidates: SessionEntrySummary[],
   limit: number,
-): SessionCandidate[] {
-  const selected: SessionCandidate[] = [];
+): SessionEntrySummary[] {
+  const selected: SessionEntrySummary[] = [];
   for (const candidate of candidates) {
     const insertAt = selected.findIndex(
       (selectedCandidate) => compareSessionCandidatesByUpdatedAt(candidate, selectedCandidate) < 0,
@@ -157,22 +153,6 @@ function selectRecentSessionCandidates(
     }
   }
   return selected;
-}
-
-function listSessionCandidates(storePath: string, agentId?: string) {
-  return (
-    listSessionEntriesReadOnly({
-      ...(agentId ? { agentId } : {}),
-      storePath,
-    })
-      // Compatibility aggregate buckets are not real user sessions.
-      .filter(({ sessionKey }) => sessionKey !== "global" && sessionKey !== "unknown")
-      .map(({ sessionKey, entry }) => ({
-        key: sessionKey,
-        entry,
-        updatedAt: entry?.updatedAt ?? null,
-      }))
-  );
 }
 
 async function prepareSessionStatusDetails(cfg: OpenClawConfig, now: number) {
@@ -246,15 +226,12 @@ async function prepareSessionStatusDetails(cfg: OpenClawConfig, now: number) {
       allowAsyncLoad: false,
     }) ?? DEFAULT_CONTEXT_TOKENS;
 
-  const buildSessionRows = async (
-    candidates: SessionCandidate[],
-    opts: { agentIdOverride?: string } = {},
-  ) =>
+  const buildSessionRows = async (candidates: SessionEntrySummary[]) =>
     Promise.all(
-      candidates.map(async ({ key, entry, updatedAt }) => {
+      candidates.map(async ({ sessionKey: key, entry }) => {
+        const agentId = parseAgentSessionKey(key)?.agentId;
+        const updatedAt = entry.updatedAt ?? null;
         const age = updatedAt ? now - updatedAt : null;
-        const parsedAgentId = parseAgentSessionKey(key)?.agentId;
-        const agentId = opts.agentIdOverride ?? parsedAgentId;
         const configuredForSession = resolveConfiguredStatusModelRef({
           cfg,
           defaultProvider: DEFAULT_PROVIDER,
@@ -481,70 +458,24 @@ export async function getStatusSummary(
 
   const sessionDetails = includeSensitive ? await prepareSessionStatusDetails(cfg, now) : undefined;
 
-  const candidateCache = new Map<string, SessionCandidate[]>();
-  const loadSessionCandidates = (storePath: string, agentId?: string) => {
-    const cacheKey = `${storePath}\0${agentId ?? ""}`;
-    const cached = candidateCache.get(cacheKey);
-    if (cached) {
-      return cached;
-    }
-    const candidates = listSessionCandidates(storePath, agentId);
-    candidateCache.set(cacheKey, candidates);
-    return candidates;
-  };
-  const storeSources = agentList.agents.map((agent) => {
-    const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId: agent.id });
-    return {
-      agentId: agent.id,
-      databasePath: resolveSqliteTargetFromSessionStorePath(storePath, {
-        agentId: agent.id,
-      }).path,
-      storePath,
-    };
-  });
-  const paths = new Set<string>();
-  const pathCounts = new Map<string, number>();
-  for (const source of storeSources) {
-    paths.add(source.databasePath);
-    pathCounts.set(source.databasePath, (pathCounts.get(source.databasePath) ?? 0) + 1);
-  }
-
+  const sessionStores = readStatusSessionStores(cfg, agentList.agents);
   const byAgent = await Promise.all(
-    storeSources.map(async ({ agentId, databasePath, storePath }) => {
-      const candidates = loadSessionCandidates(storePath, agentId);
-      const sessions = sessionDetails
+    sessionStores.byAgent.map(async ({ agent, path, sessions }) => ({
+      agentId: agent.id,
+      path: includeSensitive ? path : "[redacted]",
+      count: sessions.length,
+      recent: sessionDetails
         ? await sessionDetails.buildSessionRows(
-            selectRecentSessionCandidates(candidates, RECENT_SESSION_LIMIT),
-            { agentIdOverride: agentId },
+            selectRecentSessionCandidates(sessions, RECENT_SESSION_LIMIT),
           )
-        : [];
-      return {
-        agentId,
-        path: includeSensitive ? databasePath : "[redacted]",
-        count: candidates.length,
-        recent: sessions,
-      };
-    }),
+        : [],
+    })),
   );
-
-  const allSessions = storeSources
-    .filter((source, index, sources) => {
-      return (
-        sources.findIndex((candidate) => candidate.databasePath === source.databasePath) === index
-      );
-    })
-    .flatMap((source) =>
-      loadSessionCandidates(
-        source.storePath,
-        pathCounts.get(source.databasePath) === 1 ? source.agentId : undefined,
-      ),
-    );
   const recent = sessionDetails
     ? await sessionDetails.buildSessionRows(
-        selectRecentSessionCandidates(allSessions, RECENT_SESSION_LIMIT),
+        selectRecentSessionCandidates(sessionStores.sessions, RECENT_SESSION_LIMIT),
       )
     : [];
-  const totalSessions = allSessions.length;
   const hostDesktopStatus =
     options.hostDesktopStatus ??
     (
@@ -591,8 +522,8 @@ export async function getStatusSummary(
     taskAudit,
     ...(taskAuditRetainedLost.count > 0 ? { taskAuditRetainedLost } : {}),
     sessions: {
-      paths: includeSensitive ? Array.from(paths) : [],
-      count: totalSessions,
+      paths: includeSensitive ? sessionStores.paths : [],
+      count: sessionStores.sessions.length,
       defaults: sessionDetails?.defaults ?? { model: null, contextTokens: null },
       recent,
       byAgent,


### PR DESCRIPTION
## Why

An exact SQLite session locator intentionally shares one physical database across agent namespaces. Status and health treated selecting that database as if it filtered the returned rows. As a result, each agent could show everyone else's count/recent activity, the CLI counted a shared database repeatedly, and sensitive status could fail when its loop-agent override conflicted with a session's real owner.

## Change

Use one request-owned read-only snapshot per resolved physical database and group its canonical session keys by owner. Gateway status and local status reuse those groups; retired namespaces remain in the status aggregate. Gateway and CLI health share the same agent-summary builder, preserving their borrowed lightweight reads, synchronous projection, transient-error policy, stable top-five ordering, and default-or-first top-level summary. Delete the repeated read/filter/map loops and conflicting status owner override.

Production +155/-171 (net -16), tests +244/-124 (net +120), docs +6. No schema, migration, storage-write, authorization, config, or protocol change. Release-note context: correct and accelerate status/health for agents sharing a session database.

## Verification

- Before editing production, existing tests extended with real SQLite fixtures fail for the intended reasons: status owner mismatch, an empty health agent receiving another agent's row, and CLI fallback counts 3/3 instead of 2/1. The CLI fixture uses one current timestamp so ordinary retention cannot invalidate its seed. All 133 focused tests across 11 files pass, including read-only behavior, transient failure/recovery, fatal errors, legacy/explicit owner selection, channel deadlines, queue health, and CLI presentation.
- Actual-owner probes pass 60 status/local checks and six full health comparisons. Default/logical frozen-clock output is exact; shared status counts 605→121 and configured counts 30/30/30/30/0 instead of repeating the whole database. Shared health counts 10/10/10→7/2/0; top-level remains the selected agent, not the fleet total.
- Two-order local measurements with four populated agents ×30 sessions plus empty/retired rows: shared health 16.81–17.59→7.68–7.69 ms, local status 15.10–16.33→5.17–5.95 ms, restricted status 25.04–26.11→13.06–13.75 ms. Physical list calls fall 5/5/6→1. Sensitive shared status previously failed, so no error-versus-success speed comparison is claimed.
- Tradeoff: ordinary one-agent/30-session health adds 124–149 µs (3.8–4.3%); local/restricted status adds 9–30/23–45 µs. Other ordinary-store changes are small or mixed. A parallel-import experiment worsened the one-agent cost and was rejected. These are local owner timings, not model-turn or cross-host claims.
- Live fixture uses the isolated authenticated dev Gateway and canonical metadata-only creation: 90 checks confirm one main session, one ops session, an empty third agent, and no provider turn. Baseline shared proof passes 53 checks: restricted counts are wrong, admin status fails at the owner mismatch, and three fresh health collections all return 2/2/2 instead of 1/1/0. The full candidate build passes (2m43.9s). On the identical fixture, the candidate passes 212 checks across 20 real RPCs: restricted and admin status both succeed with aggregate 2 and per-agent counts 1/1/0; three fresh health collections return 1/1/0 with the top-level selected-agent count 1 and no ownership violations. The read-only proof changes neither configuration nor session data.
- The dead-export check found the old single-store helper had no remaining external production caller. It is now private; tests exercise the existing health collection API instead. The final migrated regression still fails original production for the intended shared-owner count, then passes the candidate; 46 affected/sibling tests pass again. Session-clone checks distinguish seeded session entries from unrelated plugin-metadata clones. Independent source review and structured Codex review are clean. The full changed-file gate passes, including core/test typechecks, lint, dead exports, import cycles, schema and storage guards.

## Named follow-ups and scope

An explicit fleet with no ambient system owner currently fails earlier in status while resolving queued system events (`src/status/summary.ts`, `resolveSystemMainSessionKey`). This is a separate existing issue, unchanged here. The live fixture sets the already-documented `agents.defaults.systemAgent.agentId` to reach the shared-store path; the original rejection is retained as evidence. A future repair must preserve ambient execution ownership while deciding how fleet diagnostics represent unavailable event ownership.

The existing sensitive status ACP metadata path can still open writable metadata; a read-only ACP projection remains a separate lifecycle follow-up. This PR introduces no session-store writes and does not claim all sensitive status work is side-effect-free.
