### PR TITLE
test(agents): isolate archive browser cleanup dependency

### DIFF
--- a/src/agents/subagents/registry/subagent-registry.archive.e2e.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.archive.e2e.test.ts
@@ -115,6 +115,7 @@ describe("subagent registry archive behavior", () => {
   ) => {
     mod.testing.setDepsForTest({
       callGateway,
+      cleanupBrowserSessionsForLifecycleEnd: vi.fn(async () => {}),
       getRuntimeConfig:
         loadConfigMock as typeof import("../../../config/config.js").getRuntimeConfig,
       loadAgentRuntimePluginRegistryHandle: vi.fn(),


### PR DESCRIPTION
## Summary

Full release verification exposed 16 cascading archive-test failures after a passing queued-collector case. The archive fixture supplied its own registry dependencies but left browser cleanup real. After an earlier test activated the browser plugin, terminal cleanup loaded the built browser facade and a second registry module; the global test helpers then reset a different registry from the source-backed readers.

Supply the existing browser-cleanup dependency in the archive fixture, as the shared registry test fixture already does. This keeps archive coverage within its intended boundary and preserves every retention, deletion retry, delivery, cancellation, replacement and attachment assertion. Production behavior, state storage, timeouts and assertions are unchanged.

## Validation

- Original predecessor-then-archive order: reproduced the retry failure and all 16 archive failures (17 failed, 10 passed).
- Archive fix alone, with the predecessor unchanged: all 26 archive tests passed; the known predecessor timing assertion still failed.
- Archive fix plus the independently owned retry fixture repair: 27 passed in 12.89 seconds, with 168 unrelated tests deliberately filtered out. The sibling patch is not included in this PR.

- Archive, lifecycle retry grace and nested suites: 46/46 passed.
- Browser lifecycle cleanup and browser maintenance facade: 16/16 passed.
- Managed Codex P2 autoreview: scoped-clean, no actionable findings.
- Full changed gate passed: guards, formatting, all three Knip scans, core-test typechecks and targeted lint.

The temporary diagnostic patch traced the second registry load through the archive lifecycle browser-cleanup callback; it is not included here. The full release failure is recorded in [Full Release Validation](https://github.com/openclaw/openclaw/actions/runs/33284888538).

Production LOC: 0. Test LOC: +1/-0. No changelog entry because this is an internal test-fixture repair.

