### PR TITLE
test: use prepared builds for agent-exec process proofs

### DIFF
--- a/src/commands/agent-exec-plugin.e2e.test.ts
+++ b/src/commands/agent-exec-plugin.e2e.test.ts
@@ -161,7 +161,7 @@ function buildChildEnv(stateDir: string): NodeJS.ProcessEnv {
 
 function buildCliSource(args: string[]): string {
   return `
-    import { runMainOrRootHelp } from "./src/entry.ts";
+    import { runMainOrRootHelp } from "./dist/entry.js";
     await runMainOrRootHelp(${JSON.stringify(["node", "openclaw", ...args])});
   `;
 }
@@ -176,7 +176,7 @@ describe("agent exec installed plugin isolation", () => {
 
     const { stdout, stderr } = await execFileAsync(
       process.execPath,
-      ["--import", "tsx", "--input-type=module", "--eval", source],
+      ["--input-type=module", "--eval", source],
       {
         cwd: path.resolve(import.meta.dirname, "../.."),
         encoding: "utf8",
@@ -199,8 +199,6 @@ describe("agent exec installed plugin isolation", () => {
       await execFileAsync(
         process.execPath,
         [
-          "--import",
-          "tsx",
           "--input-type=module",
           "--eval",
           buildCliSource([
@@ -253,7 +251,7 @@ describe("agent exec installed plugin isolation", () => {
     await writeConfig(stateDir, config);
     const source = `
       import fs from "node:fs";
-      import { agentCommandFromIngress } from "./src/plugin-sdk/agent-runtime.ts";
+      import { agentCommandFromIngress } from "openclaw/plugin-sdk/agent-runtime";
       const result = await agentCommandFromIngress({
         agentId: "main",
         sessionId: "ingress-one-shot-session",
@@ -272,16 +270,12 @@ describe("agent exec installed plugin isolation", () => {
       fs.writeFileSync(${JSON.stringify(outputPath)}, JSON.stringify(result));
     `;
     const [completion] = await Promise.allSettled([
-      execFileAsync(
-        process.execPath,
-        ["--import", "tsx", "--input-type=module", "--eval", source],
-        {
-          cwd: path.resolve(import.meta.dirname, "../.."),
-          encoding: "utf8",
-          env: buildChildEnv(stateDir),
-          timeout: 30_000,
-        },
-      ),
+      execFileAsync(process.execPath, ["--input-type=module", "--eval", source], {
+        cwd: path.resolve(import.meta.dirname, "../.."),
+        encoding: "utf8",
+        env: buildChildEnv(stateDir),
+        timeout: 30_000,
+      }),
     ]);
 
     // A completed result followed by a timeout identifies retained process resources.


### PR DESCRIPTION
The release E2E suite already builds the runtime before starting workers, but the agent-exec process tests loaded the whole TypeScript source graph again in each child. That work consumed most of their unchanged 30-second deadlines and obscured the installed-harness and process-exit behavior these tests are meant to exercise.

This imports the same CLI entry function from the prepared build and uses the public built agent-runtime SDK entrypoint. The child processes no longer start tsx. Plugin discovery, isolated rejection, retained-state checks, and natural one-shot termination keep their existing assertions and deadlines. No production code, dependency, configuration, or test selection changes.

On the same four-CPU Linux machine and prepared runtime, a paired run passed both tests in 30.76 seconds through source loading and 7.35 seconds through built artifacts. These are focused observed timings, not a full-release speedup claim. The original hosted run hit child deadlines; an unchanged replay of its complete 49-file partition passed 438 tests with the same two expected skips, so this PR does not claim a reproduced product defect.

Validation:

- Original full partition: 438 passed, 2 expected skips across 49 files.
- Paired source and built executions: 2/2 passed in both; all behavior assertions and 30-second deadlines unchanged.
- Final candidate: 438 passed, 2 expected skips across the complete 49-file shard, using canonical build preparation after source sync; 605.55 seconds in Vitest. The changed cases passed in 5.494 and 2.690 seconds.
- Full changed-file formatting/type/lint gate passed. Independent P2 review found no actionable findings.

An earlier candidate shard attempt incorrectly reused prebuilt output after a source-generation change and failed 169 CLI JSON cases with missing build artifacts. The final run above used canonical preparation at the synced candidate generation and passed; no test exclusions, retries, or timeout increases were added.

Production LOC: +0/-0. Test LOC: +9/-15 (net -6).
