### PR TITLE
fix: prevent cold image analysis from timing out during setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Image analysis startup:** prepare selected model providers and keep configuration reads independent of full runtime loading, avoiding unrelated discovery and redundant model resolution while preserving credentials and runtime cleanup.
 - **Browser extension relay:** route Runtime binding callbacks only to registered clients and preserve shared bindings during client cleanup, preventing raw callback payloads from reaching unrelated Playwright sessions.
 - **Control UI media playback:** restore inline audio and video rendition loading so readiness checks reach the Gateway instead of silently falling back to download cards. (#132832)
 - **Gateway cancellation:** route the first `chat.abort` directly to its cancellation handler without loading unrelated chat history and send workflows.

--- a/scripts/lib/tsgo-core-test-shards.mts
+++ b/scripts/lib/tsgo-core-test-shards.mts
@@ -12,6 +12,11 @@ export const TSGO_CORE_TEST_SHARDS = [
     config: "test/tsconfig/tsconfig.core.test.agents-other.json",
   },
   {
+    name: "agents-tools",
+    group: "src",
+    config: "test/tsconfig/tsconfig.core.test.agents-tools.json",
+  },
+  {
     name: "gateway-root",
     group: "src",
     config: "test/tsconfig/tsconfig.core.test.gateway-root.json",

--- a/src/agents/tools/image-tool.custom-provider-auth.regression.test.ts
+++ b/src/agents/tools/image-tool.custom-provider-auth.regression.test.ts
@@ -125,6 +125,7 @@ describe("image custom provider auth regression", () => {
       }),
       resolveAutoMediaKeyProviders: () => [],
       resolveDefaultMediaModel: () => undefined,
+      resolveRegisteredMediaUnderstandingProvider: () => undefined,
       resolveModelAsync: async () => ({
         model: {} as never,
         authStorage: {} as never,

--- a/src/agents/tools/image-tool.provider-loading.test.ts
+++ b/src/agents/tools/image-tool.provider-loading.test.ts
@@ -1,0 +1,166 @@
+// Image execution loads only the selected fallback owner, while prepared media
+// families and config-backed generic models keep their existing dispatch paths.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { buildMediaUnderstandingRegistry } from "../../media-understanding/provider-registry.js";
+import type { MediaUnderstandingProvider } from "../../media-understanding/types.js";
+import { createImageTool } from "./image-tool.js";
+import { testing } from "./image-tool.test-support.js";
+
+const genericDescribe = vi.hoisted(() => vi.fn());
+vi.mock("../../media-understanding/image-runtime.js", () => ({
+  describeImageWithModel: genericDescribe,
+  describeImagesWithModel: genericDescribe,
+  describeImageWithModelPayloadTransform: genericDescribe,
+  describeImagesWithModelPayloadTransform: genericDescribe,
+}));
+
+const resolveProvider =
+  vi.fn<
+    NonNullable<
+      NonNullable<
+        Parameters<typeof testing.setProviderDepsForTest>[0]
+      >["resolveRegisteredMediaUnderstandingProvider"]
+    >
+  >();
+const image = "data:image/png;base64,aW1hZ2U=";
+
+function provider(id: string, text = id): MediaUnderstandingProvider {
+  return { id, capabilities: ["image"], describeImage: vi.fn(async () => ({ text })) };
+}
+
+async function executeImage(params: {
+  primary?: string;
+  fallbacks?: string[];
+  preparedProviders?: MediaUnderstandingProvider[];
+  configuredProvider?: string;
+}) {
+  const config: OpenClawConfig = {
+    agents: {
+      defaults: {
+        imageModel: {
+          primary: params.primary ?? "selected/vision",
+          ...(params.fallbacks ? { fallbacks: params.fallbacks } : {}),
+        },
+      },
+    },
+    ...(params.configuredProvider
+      ? {
+          models: {
+            providers: {
+              [params.configuredProvider]: {
+                baseUrl: "https://example.invalid/v1",
+                models: [
+                  {
+                    id: "vision",
+                    name: "Vision",
+                    reasoning: false,
+                    input: ["text", "image"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 128_000,
+                    maxTokens: 4096,
+                  },
+                ],
+              },
+            },
+          },
+        }
+      : {}),
+  };
+  const tool = createImageTool({
+    config,
+    agentDir: "/image-provider-loading-test",
+    ...(params.preparedProviders
+      ? {
+          preparedModelRuntime: {
+            mediaCapabilityProviders: { mediaUnderstandingProviders: params.preparedProviders },
+          } as never,
+        }
+      : {}),
+  });
+  if (!tool) {
+    throw new Error("expected configured image tool");
+  }
+  return await tool.execute("image-loading", { path: image });
+}
+
+describe("image tool provider loading", () => {
+  beforeEach(() => {
+    genericDescribe.mockReset().mockResolvedValue({ text: "generic image" });
+    resolveProvider.mockReset();
+    testing.setProviderDepsForTest({
+      buildProviderRegistry: (overrides, cfg, preparedProviders) => {
+        // An unrelated plugin may fail or block during broad discovery. Keep the
+        // real registry hydration but make that unwanted cold path observable.
+        if (preparedProviders === undefined) {
+          throw new Error("unrelated media plugin failed to initialize");
+        }
+        return buildMediaUnderstandingRegistry(overrides, cfg, preparedProviders);
+      },
+      resolveRegisteredMediaUnderstandingProvider: resolveProvider,
+      resolveImageCompressionPolicy: async () => ({ imageCount: 1 }),
+      loadImageWebMediaRuntime: async () => ({
+        loadWebMedia: async () => {
+          throw new Error("expected inline image");
+        },
+        optimizeImageBufferForWebMedia: async ({ buffer, contentType }) => ({
+          buffer,
+          contentType,
+          kind: "image",
+        }),
+      }),
+    });
+  });
+
+  afterEach(() => testing.setProviderDepsForTest());
+
+  it("executes the selected provider without initializing unused fallbacks", async () => {
+    resolveProvider.mockReturnValue(provider("selected"));
+    const result = await executeImage({ fallbacks: ["unused/vision"] });
+    expect(result.content).toEqual([{ type: "text", text: "selected" }]);
+    expect(resolveProvider.mock.calls.map(([params]) => params.providerId)).toEqual(["selected"]);
+    expect(genericDescribe).not.toHaveBeenCalled();
+  });
+
+  it("loads the next fallback owner only after the primary fails", async () => {
+    const primary = provider("selected");
+    vi.mocked(primary.describeImage!).mockRejectedValue(new Error("rate limit"));
+    resolveProvider.mockImplementation(({ providerId }) =>
+      providerId === "selected" ? primary : provider(providerId),
+    );
+    const result = await executeImage({ fallbacks: ["fallback/vision", "unused/vision"] });
+    expect(result.content).toEqual([{ type: "text", text: "fallback" }]);
+    expect(resolveProvider.mock.calls.map(([params]) => params.providerId)).toEqual([
+      "selected",
+      "fallback",
+    ]);
+  });
+
+  it.each([false, true])("preserves owner aliases with prepared=%s", async (prepared) => {
+    const owner = { ...provider("owner"), aliases: ["selected"] };
+    resolveProvider.mockReturnValue(owner);
+    const result = await executeImage(prepared ? { preparedProviders: [owner] } : {});
+    expect(result.content).toEqual([{ type: "text", text: "owner" }]);
+    expect(resolveProvider).toHaveBeenCalledTimes(prepared ? 0 : 1);
+    expect(owner.describeImage).toHaveBeenCalledOnce();
+    expect(genericDescribe).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "unprepared", preparedProviders: undefined },
+    { name: "an empty prepared family", preparedProviders: [] },
+  ])("keeps config-backed generic image dispatch with $name", async ({ preparedProviders }) => {
+    const result = await executeImage({ configuredProvider: "selected", preparedProviders });
+    expect(result.content).toEqual([{ type: "text", text: "generic image" }]);
+    expect(genericDescribe).toHaveBeenCalledWith(expect.objectContaining({ provider: "selected" }));
+    expect(resolveProvider).toHaveBeenCalledTimes(preparedProviders ? 0 : 1);
+  });
+
+  it("surfaces the generic runtime error for an unknown provider", async () => {
+    genericDescribe.mockRejectedValue(new Error("Unknown model: unknown/vision"));
+    await expect(executeImage({ primary: "unknown/vision" })).rejects.toThrow(
+      "Unknown model: unknown/vision",
+    );
+    expect(resolveProvider.mock.calls.map(([params]) => params.providerId)).toEqual(["unknown"]);
+  });
+});

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -686,17 +686,29 @@ async function runImagePrompt(params: {
   const providerCfg: OpenClawConfig = effectiveCfg ?? {};
   const preparedProviders =
     params.preparedModelRuntime?.mediaCapabilityProviders?.mediaUnderstandingProviders;
-  const providerRegistry = imageToolProviderDeps.buildProviderRegistry(
-    undefined,
-    providerCfg,
-    preparedProviders,
-  );
 
   const result = await runWithImageModelFallback({
     cfg: effectiveCfg,
     modelOverride: params.modelOverride,
     abortSignal: params.signal,
     run: async (provider, modelId) => {
+      // The fallback candidate owns runtime loading; an unrelated media plugin must not
+      // block a selected image provider before its request timeout can start.
+      const selectedProvider = preparedProviders
+        ? findCapabilityProviderById({
+            providers: preparedProviders,
+            providerId: provider,
+            normalizeProviderId: normalizeMediaProviderId,
+          })
+        : imageToolProviderDeps.resolveRegisteredMediaUnderstandingProvider({
+            providerId: provider,
+            cfg: providerCfg,
+          });
+      const providerRegistry = imageToolProviderDeps.buildProviderRegistry(
+        selectedProvider ? { [provider]: selectedProvider } : undefined,
+        providerCfg,
+        preparedProviders ?? [],
+      );
       const timeoutMs = resolveImageToolTimeoutMs({
         cfg: providerCfg,
         provider,

--- a/src/media-understanding/image-model-runtime.ts
+++ b/src/media-understanding/image-model-runtime.ts
@@ -201,8 +201,6 @@ async function prepareResolvedImageRuntime(
 export async function resolveImageRuntime(
   params: ImageRuntimeParams,
 ): Promise<ResolvedImageRuntime> {
-  // Fast static resolution avoids provider runtime hooks during tool discovery. The bounded lease
-  // admits dynamic workspaces before attachment preprocessing reaches the embedded run boundary.
   const resolvedRef = normalizeModelRef(params.provider, params.model);
   const workspaceDir =
     params.workspaceDir ??
@@ -212,18 +210,30 @@ export async function resolveImageRuntime(
     ...(params.profile ? { authProfileId: params.profile } : {}),
     ...(params.preferredProfile ? { preferredProfile: params.preferredProfile } : {}),
   };
-  // Opaque media handles may lack model facts; resolveModelAsync then uses normal discovery.
+  // Borrow a supplied generation; only direct calls acquire and release a new lease.
   const preparedRuntimeLease = params.preparedModelRuntime
     ? {
         snapshot: params.preparedModelRuntime as PreparedModelRuntimeSnapshot,
         release: () => {},
       }
-    : await acquireAgentRunPreparedModelRuntime({
-        agentDir: params.agentDir,
-        ...(params.agentId ? { agentId: params.agentId } : {}),
-        config: params.cfg ?? {},
-        ...(runtimeParams.workspaceDir ? { workspaceDir: runtimeParams.workspaceDir } : {}),
-      });
+    : await acquireAgentRunPreparedModelRuntime(
+        {
+          agentDir: params.agentDir,
+          ...(params.agentId ? { agentId: params.agentId } : {}),
+          config: params.cfg ?? {},
+          ...(runtimeParams.workspaceDir ? { workspaceDir: runtimeParams.workspaceDir } : {}),
+          loadRuntimePlugins: true,
+          runtimePluginSelections: [
+            {
+              provider: resolvedRef.provider,
+              modelId: resolvedRef.model,
+              ...(params.agentId ? { agentId: params.agentId } : {}),
+            },
+          ],
+        },
+        // The request already chose a model; full inventory discovery must stay outside setup.
+        { catalogMode: "static" },
+      );
   let leaseRetained = false;
   const retainLease = (resolved: PreparedImageRuntime): ResolvedImageRuntime => {
     leaseRetained = true;
@@ -252,33 +262,6 @@ export async function resolveImageRuntime(
       ...(preparedParams.workspaceDir ? { workspaceDir: preparedParams.workspaceDir } : {}),
       ...authProfileOptions,
     };
-    const fastResolved = await resolveModelAsync(
-      resolvedRef.provider,
-      resolvedRef.model,
-      preparedParams.agentDir,
-      preparedParams.cfg,
-      { ...resolveOptions, skipProviderRuntimeHooks: true },
-    );
-    if (fastResolved.model?.input?.includes("image")) {
-      const normalizedResolved = await resolveModelAsync(
-        resolvedRef.provider,
-        resolvedRef.model,
-        preparedParams.agentDir,
-        preparedParams.cfg,
-        resolveOptions,
-      );
-      if (normalizedResolved.model?.input?.includes("image")) {
-        return retainLease(
-          await prepareResolvedImageRuntime(
-            preparedParams,
-            normalizedResolved.model,
-            normalizedResolved.authStorage,
-            normalizedResolved.modelRegistry,
-          ),
-        );
-      }
-    }
-
     const resolved = await resolveModelAsync(
       resolvedRef.provider,
       resolvedRef.model,

--- a/src/media-understanding/image.runtime-profile.test.ts
+++ b/src/media-understanding/image.runtime-profile.test.ts
@@ -396,7 +396,6 @@ describe("describeImageWithModelCore", () => {
     };
     resolveModelAsyncMock
       .mockResolvedValueOnce({ model: hintedModel, authStorage, modelRegistry })
-      .mockResolvedValueOnce({ model: hintedModel, authStorage, modelRegistry })
       .mockResolvedValueOnce({ model: authoritativeModel, authStorage, modelRegistry });
     getApiKeyForModelMock.mockResolvedValueOnce({
       [API_KEY_FIELD]: "test-token",
@@ -428,8 +427,8 @@ describe("describeImageWithModelCore", () => {
       timeoutMs: 1000,
     });
 
-    expect(resolveModelAsyncMock).toHaveBeenCalledTimes(3);
-    expect(resolveModelAsyncMock.mock.calls[2]?.[4]).toEqual(
+    expect(resolveModelAsyncMock).toHaveBeenCalledTimes(2);
+    expect(resolveModelAsyncMock.mock.calls[1]?.[4]).toEqual(
       expect.objectContaining({
         authStorage,
         modelRegistry,
@@ -773,7 +772,14 @@ describe("describeImageWithModelCore", () => {
     });
 
     expect(acquireAgentRunPreparedModelRuntimeMock).toHaveBeenCalledWith(
-      expect.objectContaining({ workspaceDir: "/tmp/openclaw-workspace" }),
+      expect.objectContaining({
+        workspaceDir: "/tmp/openclaw-workspace",
+        loadRuntimePlugins: true,
+        runtimePluginSelections: [
+          { provider: "google", modelId: "gemini-2.5-flash", agentId: "vision-agent" },
+        ],
+      }),
+      { catalogMode: "static" },
     );
     expect(resolveModelAsyncMock).toHaveBeenCalledWith(
       "google",

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -746,6 +746,7 @@ describe("describeImageWithModelCore", () => {
         agentDir: "/tmp/openclaw-agent",
         workspaceDir: "/tmp/openclaw-workspace",
       }),
+      { catalogMode: "static" },
     );
     expect(releasePreparedModelRuntimeMock).toHaveBeenCalledOnce();
     expect(resolveModelAsyncMock).toHaveBeenCalledWith(
@@ -762,7 +763,6 @@ describe("describeImageWithModelCore", () => {
           workspaceDir: "/tmp/openclaw-workspace",
         }),
         skipAgentDiscovery: true,
-        skipProviderRuntimeHooks: true,
         workspaceDir: "/tmp/openclaw-workspace",
       },
     );
@@ -779,29 +779,21 @@ describe("describeImageWithModelCore", () => {
     });
   });
 
-  it("applies provider normalization before using a fast image model match", async () => {
+  it("normalizes the image model once before provider dispatch", async () => {
     const authStorage = {
       [SET_RUNTIME_API_KEY_FIELD]: setRuntimeApiKeyMock,
     };
-    resolveModelAsyncMock
-      .mockResolvedValueOnce({
+    resolveModelAsyncMock.mockImplementation(
+      async (_provider, _modelId, _agentDir, _cfg, options) => ({
         authStorage,
         model: {
           provider: "openai",
           id: "gpt-5.4",
-          api: "openai-completions",
+          api: options?.skipProviderRuntimeHooks ? "openai-completions" : "openai-responses",
           input: ["text", "image"],
         },
-      })
-      .mockResolvedValueOnce({
-        authStorage,
-        model: {
-          provider: "openai",
-          id: "gpt-5.4",
-          api: "openai-responses",
-          input: ["text", "image"],
-        },
-      });
+      }),
+    );
     completeMock.mockResolvedValue({
       role: "assistant",
       api: "openai-responses",
@@ -829,23 +821,7 @@ describe("describeImageWithModelCore", () => {
       model: "gpt-5.4",
     });
     expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
-    expect(resolveModelAsyncMock).toHaveBeenNthCalledWith(
-      1,
-      "openai",
-      "gpt-5.4",
-      "/tmp/openclaw-agent",
-      {},
-      {
-        allowBundledStaticCatalogFallback: true,
-        authStorage: preparedAuthStorage,
-        modelRegistry: {},
-        preparedModelRuntime: expect.objectContaining({ agentDir: "/tmp/openclaw-agent" }),
-        skipAgentDiscovery: true,
-        skipProviderRuntimeHooks: true,
-      },
-    );
-    expect(resolveModelAsyncMock).toHaveBeenNthCalledWith(
-      2,
+    expect(resolveModelAsyncMock).toHaveBeenCalledExactlyOnceWith(
       "openai",
       "gpt-5.4",
       "/tmp/openclaw-agent",

--- a/src/plugins/loader-module-runtime.ts
+++ b/src/plugins/loader-module-runtime.ts
@@ -10,6 +10,7 @@ import { getCachedPluginModuleLoader } from "./plugin-module-loader-cache.js";
 import { installOpenClawPluginSdkNativeResolver } from "./plugin-sdk-native-resolver.js";
 import type { PluginRegistry } from "./registry-types.js";
 import { withPluginRegistrationContext } from "./runtime.js";
+import { createRuntimeConfig } from "./runtime/runtime-config.js";
 import { createRuntimeState } from "./runtime/runtime-state.js";
 import type {
   CreatePluginRuntimeOptions,
@@ -192,18 +193,23 @@ export function createLazyPluginRuntime(params: {
   };
 
   const cache = getPluginCache();
-  const state = createRuntimeState();
+  const initialRuntime = {
+    version: VERSION,
+    config: createRuntimeConfig(),
+    state: createRuntimeState(),
+  };
   let resolvedRuntime: PluginRuntime | null = null;
   const resolveRuntime = (): PluginRuntime => {
     resolvedRuntime ??= withPluginCache(cache, () =>
-      resolveCreatePluginRuntime()(params.runtimeOptions, state),
+      resolveCreatePluginRuntime()(params.runtimeOptions, initialRuntime),
     );
     return resolvedRuntime;
   };
   const getRuntimeProperty = (prop: PropertyKey, ...receiver: [] | [unknown]): unknown => {
-    // Reading prepared metadata must not initialize runtime services.
-    if (!resolvedRuntime && (prop === "state" || prop === "version")) {
-      return prop === "state" ? state : VERSION;
+    // Registration reads current config without importing every runtime service.
+    // Carry the same capability objects forward when execution materializes the runtime.
+    if (!resolvedRuntime && Object.hasOwn(initialRuntime, prop)) {
+      return Reflect.get(initialRuntime, prop);
     }
     return receiver.length === 0
       ? Reflect.get(resolveRuntime(), prop)

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 import { Command } from "commander";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createPluginMetadataSnapshot } from "../config/plugin-auto-enable.test-helpers.js";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { resetPluginStateStoreForTests } from "../plugin-state/plugin-state-store.js";
@@ -56,9 +60,10 @@ afterEach(() => {
   vi.restoreAllMocks();
   resetPluginStateStoreForTests();
   resetPluginLoaderTestStateForTest();
+  clearRuntimeConfigSnapshot();
 });
 
-it("initializes trusted state and executable CLI before resolving the broad runtime", async () => {
+it("initializes config, trusted state and executable CLI before resolving the broad runtime", async () => {
   const root = fs.realpathSync(makePluginLoaderTempDir());
   const bundledDir = path.join(root, "bundled");
   const observed = path.join(root, "observed.json");
@@ -70,7 +75,7 @@ it("initializes trusted state and executable CLI before resolving the broad runt
       const sync = api.runtime.state.openSyncKeyedStore({ namespace: "registration", maxEntries: 2 });
       const entries = sync.entries();
       const asyncStore = api.runtime.state.openKeyedStore({ namespace: "registration", maxEntries: 2 });
-      require("node:fs").writeFileSync(${JSON.stringify(observed)}, JSON.stringify(entries));
+      require("node:fs").writeFileSync(${JSON.stringify(observed)}, JSON.stringify({ entries, config: api.runtime.config.current() }));
       api.registerCli(({ program }) => program.command("state-proof").action(async () => {
         sync.register("before", { value: "retained" });
         const chunks = api.runtime.channel.text.chunkText("channel runtime works", 100);
@@ -117,6 +122,7 @@ it("initializes trusted state and executable CLI before resolving the broad runt
       const dispatchReplyFromConfig =
         vi.fn<PluginRuntime["channel"]["reply"]["dispatchReplyFromConfig"]>();
       const config = { plugins: { entries: { [plugin.id]: { enabled: true } } } };
+      setRuntimeConfigSnapshot(config);
       const metadata = await loadOpenClawPluginCliRegistry({ config, pluginSdkResolution: "src" });
       expect(metadata.plugins).toContainEqual(
         expect.objectContaining({
@@ -136,10 +142,15 @@ it("initializes trusted state and executable CLI before resolving the broad runt
       expect(registry.plugins).toContainEqual(
         expect.objectContaining({ id: plugin.id, status: "loaded" }),
       );
-      expect(JSON.parse(fs.readFileSync(observed, "utf8"))).toEqual([]);
+      expect(JSON.parse(fs.readFileSync(observed, "utf8"))).toEqual({ entries: [], config });
       expect(fs.existsSync(path.join(root, "state", "state", "openclaw.sqlite"))).toBe(false);
       expect(resolveRuntime).not.toHaveBeenCalled();
       const runtime = getPluginRegistryRuntime(registry)!;
+      const configApi = runtime.config;
+      const refreshedConfig = { ...config, agents: { defaults: { workspace: "/refreshed" } } };
+      setRuntimeConfigSnapshot(refreshedConfig);
+      expect(configApi.current()).toBe(refreshedConfig);
+      expect(Object.getOwnPropertyDescriptor(runtime, "config")?.get?.()).toBe(configApi);
       const state = runtime.state;
       const descriptor = Object.getOwnPropertyDescriptor(runtime, "state")!;
       expect(descriptor.get?.()).toBe(state);
@@ -163,6 +174,9 @@ it("initializes trusted state and executable CLI before resolving the broad runt
       expect(resolveRuntime).toHaveBeenCalledTimes(1);
       expect(factories).toHaveBeenCalledTimes(1);
       expect(runtime.state).toBe(state);
+      expect(runtime.config).toBe(configApi);
+      setRuntimeConfigSnapshot(config);
+      expect(configApi.current()).toBe(config);
       expect(runtime.hooks).toBe(hooks);
       expect(runtime.channel.reply.dispatchReplyFromConfig).toBe(dispatchReplyFromConfig);
       const replacement = { ...state };

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -258,7 +258,7 @@ function createRuntimeSandbox(agent: PluginRuntime["agent"]): PluginRuntime["san
 // Loaded by path from the plugin loader, so static export analysis cannot see this contract.
 export const createPluginRuntime: PluginRuntimeFactory = (
   _options = {},
-  state = createRuntimeState(),
+  initialRuntime = { config: createRuntimeConfig(), state: createRuntimeState() },
 ) => {
   const mediaUnderstanding = createRuntimeMediaUnderstandingFacade();
   const taskFlow = createRuntimeTaskFlow();
@@ -271,7 +271,7 @@ export const createPluginRuntime: PluginRuntimeFactory = (
     // always see the same version the CLI reports, avoiding API-version drift.
     version: VERSION,
     gateway: _options.gateway ?? createRuntimeGateway(),
-    config: createRuntimeConfig(),
+    config: initialRuntime.config,
     agent,
     hooks: _options.hooks ?? {
       dispatchHookAgentTurn: async () => {
@@ -295,7 +295,7 @@ export const createPluginRuntime: PluginRuntimeFactory = (
     ),
     events: createRuntimeEvents(),
     logging: createRuntimeLogging(),
-    state,
+    state: initialRuntime.state,
     tasks,
   } satisfies Omit<
     PluginRuntime,

--- a/src/plugins/runtime/runtime-config.test.ts
+++ b/src/plugins/runtime/runtime-config.test.ts
@@ -5,7 +5,7 @@ const getRuntimeConfigMock = vi.fn();
 const mutateConfigFileMock = vi.fn();
 const replaceConfigFileMock = vi.fn();
 
-vi.mock("../../config/config.js", () => ({
+vi.mock("../../config/io.runtime.js", () => ({
   getRuntimeConfig: () => getRuntimeConfigMock(),
 }));
 

--- a/src/plugins/runtime/runtime-config.ts
+++ b/src/plugins/runtime/runtime-config.ts
@@ -1,23 +1,17 @@
 // Runtime config helpers expose scoped OpenClaw config reads to plugin runtimes.
-import { getRuntimeConfig } from "../../config/config.js";
-import {
-  mutateConfigFile as mutateConfigFileInternal,
-  replaceConfigFile as replaceConfigFileInternal,
-} from "../../config/mutate.js";
+import { getRuntimeConfig } from "../../config/io.runtime.js";
 import type { PluginRuntime } from "./types.js";
 
 export function createRuntimeConfig(): PluginRuntime["config"] {
   return {
     current: getRuntimeConfig,
-    mutateConfigFile: async (params) =>
-      await mutateConfigFileInternal({
-        ...params,
-        writeOptions: params.writeOptions,
-      }),
-    replaceConfigFile: async (params) =>
-      await replaceConfigFileInternal({
-        ...params,
-        writeOptions: params.writeOptions,
-      }),
+    mutateConfigFile: async (params) => {
+      const { mutateConfigFile } = await import("../../config/mutate.js");
+      return await mutateConfigFile(params);
+    },
+    replaceConfigFile: async (params) => {
+      const { replaceConfigFile } = await import("../../config/mutate.js");
+      return await replaceConfigFile(params);
+    },
   };
 }

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -213,5 +213,5 @@ export type CreatePluginRuntimeOptions = {
 /** Checked contract for both the path-loaded factory and its implementation. */
 export type PluginRuntimeFactory = (
   options?: CreatePluginRuntimeOptions,
-  state?: PluginRuntime["state"],
+  initialRuntime?: Pick<PluginRuntime, "config" | "state">,
 ) => PluginRuntime;

--- a/test/tsconfig/tsconfig.core.test.agents-other.json
+++ b/test/tsconfig/tsconfig.core.test.agents-other.json
@@ -12,6 +12,8 @@
     "../../dist",
     "../../**/dist/**",
     "../../src/agents/*.test.ts",
-    "../../src/agents/*.test.tsx"
+    "../../src/agents/*.test.tsx",
+    "../../src/agents/tools/**/*.test.ts",
+    "../../src/agents/tools/**/*.test.tsx"
   ]
 }

--- a/test/tsconfig/tsconfig.core.test.agents-tools.json
+++ b/test/tsconfig/tsconfig.core.test.agents-tools.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.core.test.shard.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "../../.artifacts/tsgo-cache/core-test-agents-tools.tsbuildinfo"
+  },
+  "include": [
+    "../../src/agents/tools/**/*.test.ts",
+    "../../src/agents/tools/**/*.test.tsx"
+  ]
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the first image-analysis request could time out before reaching its vision provider. Full release verification exposed this in the large-image OpenAI test: both attempts exceeded its unchanged 180-second test deadline, while the following Anthropic test passed.

## Why This Change Was Made

Image setup was doing three kinds of unrelated startup work: constructing the entire media-provider registry, preparing a live model inventory despite already knowing the requested model, and loading the full host runtime when a plugin merely read the current configuration.

The image tool now resolves each selected provider inside its existing fallback attempt and acquires a static prepared generation for the selected model. The lazy plugin runtime serves configuration through the existing configuration owner, just as it already serves state and version. It preserves the same config and state capability objects when the full runtime is later needed. Config reads remain current after reload, and mutations retain their canonical owner and plugin scope.

The cleanup removes an unused preliminary model lookup, a duplicate resolution branch, and redundant mutation-argument copies. Runtime production changes total +60/-65 (net -5); tests total +203/-40. The follow-up test-tooling shard descriptor/configuration adds +18/-1, and one changelog line is separate. Provider and agent-harness policy, timeout values, retries, model defaults, public APIs, configuration, environment, and lifecycle guards are unchanged.

Provenance: the defect is verified at release-validation commit bee48f7f56808eff2f7aaa035509b8a39b3988e2. Its introducing commit is unknown: the available shallow boundary and raw parent contain identical original image-runtime code. The existing lazy state/version owner is extended; this is not a Codex protocol change.

## User Impact

The first image request no longer waits for unrelated runtime initialization. Vision validation, configured generic providers, aliases, credential-specific model metadata, fallbacks, supplied snapshots, and request-lifetime cleanup retain their contracts.

PDF behavior is deliberately unchanged. Its candidate chain can change when acquisition binds to a newer committed configuration, so narrowing that chain in advance could omit a required provider. Named follow-up: generation-bound PDF candidate planning across reload, with configuration-replacement and fallback coverage.

## Evidence

- Provider-loading regressions: six failures on the original owner, all seven cases passing after the fix; 123 related image-tool/custom-auth/registry tests passed.
- Final image runtime/profile/timeout coverage: 42 tests passed across three files, including API normalization, credential-specific metadata, vision rejection, workspace authority, supplied snapshots, and late cleanup. The revised normalization assertions were also captured failing before the redundant lookup was removed.
- Shared owner regression: the existing real plugin-registration fixture failed when `config.current()` requested an unavailable broad runtime. After the repair, 43 loader/config/scope tests passed, including real snapshot replacement before and after materialization, capability identity, state reflection, and plugin-scoped mutations.
- Exact Vitest diagnostic: fixture credentials, private state, and blocked transport reproduced a 329.402-second runtime-plugin preparation pause. CPU profiling placed 321.200 seconds in configuration access during plugin registration, which imported the full host runtime graph. With the repair, the same preparation took 2.461 seconds and both provider transport boundaries were reached within 18 seconds. These are diagnostic measurements, not authenticated provider or full-suite speed claims.
- Intermediate authenticated attempts remained red and were retained; they led to the shared owner repair rather than a timeout or assertion change.
- Fresh independent Codex P2 review of the final diff found no actionable defects.
- Final authenticated run of the unchanged `image-tool.providers.live.test.ts` passed both providers without skips: OpenAI `gpt-4.1-mini` in 6.102 seconds and Anthropic `claude-sonnet-4-6` in 2.342 seconds; total wrapper time 20.579 seconds. Source hashes stayed unchanged and all task processes were cleaned up.
- Final `pnpm build` passed in 4m15s; the full changed-file format, type, lint, dead-code and architecture guards passed. The built Codex plugin import profile passed in 3.991 seconds (import-only measurement, separate from registration and live proof).

Integration follow-up: hosted CI caught the merged tree at 721 agent-subtree test roots, above the unchanged 720-root guard. The prior `cli-runner` redistribution had been reverted on main. After rebasing once onto `49c7e9131ba408e92b81e7960ab028f01ce831cc`, the same boundary command reproduced that failure locally. The canonical descriptor now assigns the entire agent-tools subtree to its own 130-root shard; the remaining agent-subtree shard has 591 roots and the root-level shard has 667. All canonical roots still have exactly one owner, all 16 shards remain within budget, and the existing five CI stripes include the new shard without extra jobs.

The full boundary guard and 31 existing partition/sparse/runner tests passed. The rebased plugin-owner/config/scope suite passed all 45 tests, preserving main’s retirement coverage. Fresh P2 review of the final integrated candidate found no actionable issues. Runtime production files and the exact live test/harness/config are byte-identical to the successful authenticated run; only test graph metadata and main’s additional loader tests changed, so the live/build proof is retained without repeating provider requests. The final complete changed-file gate passed in 715.5 seconds, including all 16 core-test compiler graphs, scripts/core types, lint and architecture guards.

ClawSweeper review follow-through: its only P3 finding/rank-up move requested removing the changelog entry. The entry is retained under the maintainer’s task instructions to include user-facing changelog updates; release-note context is also included above. No runtime correctness finding remained. Named documentation follow-up: remove the stale numeric shard/stripe counts from the CI type-check comment; behavior and fanout are unchanged here.
