### PR TITLE
refactor(cli): share completion metadata helpers

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -7,6 +7,8 @@ import { routeLogsToStderr } from "../logging/console.js";
 import { formatConsoleDiagnosticLine } from "../logging/json-console-line.js";
 import {
   collectShellCompletionCommandTree,
+  commandNameVariants,
+  completionFlags,
   type ShellCompletionContext,
 } from "./completion-command-tree.js";
 import {
@@ -41,22 +43,12 @@ export function getCompletionScript(shell: CompletionShell, program: Command): s
   return generateFishCompletion(program);
 }
 
-function completionFlags(option: Option): string[] {
-  return [option.short, option.long].filter((flag): flag is string => Boolean(flag));
-}
-
 function preferredCompletionFlag(option: Option): string {
   return option.long ?? option.short ?? option.flags;
 }
 
 function fishWords(values: readonly string[]): string {
   return values.join(" ");
-}
-
-// Aliases are typeable command words; every completion surface must offer them
-// alongside the canonical name or advertised commands appear nonexistent.
-function commandNameVariants(cmd: Command): string[] {
-  return [cmd.name(), ...cmd.aliases()];
 }
 
 function generateFishPathHelper(rootCmd: string, contexts: ShellCompletionContext[]): string {

--- a/src/cli/completion-command-tree.ts
+++ b/src/cli/completion-command-tree.ts
@@ -19,11 +19,13 @@ type ShellCompletionCommandTree = {
   descendants: ShellCompletionContext[];
 };
 
-function completionFlags(option: Option): string[] {
+export function completionFlags(option: Option): string[] {
   return [option.short, option.long].filter((flag): flag is string => Boolean(flag));
 }
 
-function commandNameVariants(command: Command): string[] {
+// Aliases are typeable command words; every completion surface must offer them
+// alongside the canonical name or advertised commands appear nonexistent.
+export function commandNameVariants(command: Command): string[] {
   return [command.name(), ...command.aliases()];
 }
 


### PR DESCRIPTION
## What Problem This Solves

Shell completion generation maintained separate copies of Commander command-name and option-flag projection logic. That duplication made it possible for the command tree and shell-specific generators to drift.

## Why This Change Was Made

This makes the completion command-tree module the single owner of both metadata helpers and reuses them from the shell generators. The existing alias invariant comment moves with the canonical helper.

## User Impact

No user-visible completion behavior changes. Maintainers get one implementation for command aliases and parsed short/long flags, with six fewer production lines.

## Evidence

- `pnpm test src/cli/completion-command-tree.test.ts src/cli/completion-cli.aliases.test.ts src/cli/completion-cli.test.ts src/cli/program/root-command-descriptions.test.ts` (`65` passed; environment-dependent shell cases skipped)
- focused Oxlint and Oxfmt checks for both changed files
- `git diff --check`
- lead autoreview: no accepted or actionable findings
- native hydrated review: `READY FOR /prepare-pr`, zero findings
- exact-head CI: all required checks passed on `15b2552c1d9e525471f6e3ec42ff82da4e2c3f56` ([run](https://github.com/openclaw/openclaw/actions/runs/33290260338))
- `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 133046`

AI-assisted: yes. I reviewed the implementation and understand the completion metadata flow.
