### PR TITLE
fix: browser voice stays unavailable after OpenAI login

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -1015,6 +1015,13 @@ value into `plugins.entries.openai.config.personality` when that key is unset.
     ChatGPT OAuth profile created by
     `openclaw models auth login --provider openai`.
 
+    The enabled OpenAI plugin starts its browser session broker automatically,
+    including when you sign in after the Gateway has started. No separate Talk
+    provider configuration or Platform API key is required for this browser
+    path. The broker opens a provider session only when you start Talk; signing
+    in does not open the microphone or start a voice session. Returning to the
+    browser after sign-in refreshes the chat microphone's readiness.
+
     The two browser paths expose the same Talk session contract but keep
     credentials on different sides of the trust boundary. Platform auth mints
     an ephemeral client secret and the browser exchanges SDP directly with

--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openai",
   "activation": {
-    "onStartup": false
+    "onStartup": true
   },
   "enabledByDefault": true,
   "providers": ["openai"],

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -208,6 +208,7 @@ function createRepoBundledManifestRegistry(): PluginManifestRegistry {
       manifestPath: path.join(repoRoot, "extensions", dirName, "openclaw.plugin.json"),
       activation: manifest.activation,
       setup: manifest.setup,
+      modelCatalog: manifest.modelCatalog,
       hooks: [],
       contracts: manifest.contracts,
     })),
@@ -616,6 +617,33 @@ describe("bundled plugin metadata", () => {
         platform: "darwin",
       }),
     ).toContain("bonjour");
+  });
+
+  it.each([
+    { name: "before login", config: {} },
+    {
+      name: "with only an OpenAI login and chat model",
+      config: {
+        auth: { profiles: { "openai:default": { provider: "openai", mode: "oauth" as const } } },
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-5.6-sol" },
+            models: { "openai/gpt-5.6-sol": {} },
+          },
+        },
+      },
+    },
+  ])("starts the OpenAI browser broker $name without Talk configuration", ({ config }) => {
+    const manifestRegistry = createRepoBundledManifestRegistry();
+
+    expect(
+      resolveGatewayStartupPluginIdsFromRegistry({
+        config,
+        env: {},
+        index: createInstalledPluginIndexForManifests(manifestRegistry),
+        manifestRegistry,
+      }),
+    ).toContain("openai");
   });
 
   it("starts Bonjour when explicitly enabled", () => {

--- a/ui/src/pages/chat/composer-microphone-picker.test.ts
+++ b/ui/src/pages/chat/composer-microphone-picker.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { ComposerMicrophonePicker } from "./composer-microphone-picker.ts";
+
+function catalog(ready: boolean) {
+  return {
+    realtime: { ready, providers: [] },
+    transcription: { ready, providers: [] },
+  };
+}
+
+let picker: ComposerMicrophonePicker;
+
+afterEach(() => picker?.dispose());
+
+describe("composer voice readiness", () => {
+  it("refreshes after returning from login on the same Gateway connection", async () => {
+    const request = vi.fn().mockResolvedValueOnce(catalog(false)).mockResolvedValue(catalog(true));
+    const client = { request } as unknown as GatewayBrowserClient;
+    picker = new ComposerMicrophonePicker(vi.fn());
+    picker.syncCatalog(client, true);
+    await vi.waitFor(() => expect(picker.realtimeStatus).toBe("unavailable"));
+
+    window.dispatchEvent(new Event("focus"));
+
+    await vi.waitFor(() => expect(picker.realtimeStatus).toBe("ready"));
+    expect(picker.dictationStatus).toBe("ready");
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request).toHaveBeenLastCalledWith("talk.catalog", {});
+    expect(picker.open).toBe(false);
+  });
+
+  it("retires focus requests on disposal and reconnects a reused picker without stale results", async () => {
+    const stale = createDeferred<ReturnType<typeof catalog>>();
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(catalog(false))
+      .mockReturnValueOnce(stale.promise)
+      .mockResolvedValue(catalog(true));
+    const client = { request } as unknown as GatewayBrowserClient;
+    const requestUpdate = vi.fn();
+    picker = new ComposerMicrophonePicker(requestUpdate);
+    picker.syncCatalog(client, true);
+    await vi.waitFor(() => expect(picker.realtimeStatus).toBe("unavailable"));
+    window.dispatchEvent(new Event("focus"));
+    expect(request).toHaveBeenCalledTimes(2);
+
+    picker.dispose();
+    window.dispatchEvent(new Event("focus"));
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(picker.realtimeStatus).toBe("unknown");
+
+    picker.syncCatalog(client, true);
+    await vi.waitFor(() => expect(picker.realtimeStatus).toBe("ready"));
+    requestUpdate.mockClear();
+    stale.resolve(catalog(false));
+    await stale.promise;
+    await Promise.resolve();
+    expect(picker.realtimeStatus).toBe("ready");
+    expect(requestUpdate).not.toHaveBeenCalled();
+
+    window.dispatchEvent(new Event("focus"));
+    expect(request).toHaveBeenCalledTimes(4);
+    picker.syncCatalog(client, false);
+    window.dispatchEvent(new Event("focus"));
+    expect(request).toHaveBeenCalledTimes(4);
+  });
+});

--- a/ui/src/pages/chat/composer-microphone-picker.ts
+++ b/ui/src/pages/chat/composer-microphone-picker.ts
@@ -30,6 +30,8 @@ export class ComposerMicrophonePicker {
   private catalogRequest = 0;
   private realtimeStatusValue: ComposerTalkCapabilityStatus = "unknown";
   private dictationStatusValue: ComposerTalkCapabilityStatus = "unknown";
+  // Terminal login changes credentials without replacing the Gateway connection.
+  private readonly refreshOnFocus = (): void => this.loadCatalog();
 
   constructor(private readonly requestUpdate: () => void) {}
 
@@ -61,6 +63,7 @@ export class ComposerMicrophonePicker {
     if (client === this.catalogClient && connected === this.catalogConnected) {
       return;
     }
+    window.removeEventListener("focus", this.refreshOnFocus);
     this.catalogClient = client;
     this.catalogConnected = connected;
     this.catalogRequest++;
@@ -69,6 +72,7 @@ export class ComposerMicrophonePicker {
       this.dictationStatusValue = "unknown";
       return;
     }
+    window.addEventListener("focus", this.refreshOnFocus);
     this.loadCatalog(false);
   }
 
@@ -99,6 +103,7 @@ export class ComposerMicrophonePicker {
 
   /** Ends an in-flight discovery too, so a late result cannot revive the list. */
   dispose(): void {
+    window.removeEventListener("focus", this.refreshOnFocus);
     this.release();
     this.discoveryRequest++;
     this.catalogRequest++;


### PR DESCRIPTION
Closes #133047
Related: #126594

## What Problem This Solves

Fixes an issue where users signing in with OpenAI could still find browser Talk unavailable without manually configuring a Talk provider. The chat microphone could also retain its pre-login unavailable state on the same Gateway connection.

## Why This Change Was Made

The OpenAI plugin now declares startup ownership for its existing browser-session broker, including when login happens after Gateway boot. The composer refreshes Talk readiness when the user returns focus from sign-in, following the existing Talk Settings behavior. Listener disposal and stale-request fencing remain owned by the picker.

## User Impact

An enabled OpenAI plugin no longer needs unrelated Talk settings to provide its OAuth browser broker. Returning from sign-in refreshes the microphone's readiness. Plugin disable/deny/allow rules, microphone permissions, explicit session start, credentials, and model defaults are unchanged: GA Realtime remains the default, and GPT-Live remains an explicit model choice.

## Evidence

- Two real-manifest startup regressions failed before the manifest repair; afterward, 203 metadata/startup tests passed, including existing disable/deny/allowlist cases.
- Two composer focus/lifetime regressions failed before the UI repair; afterward, 39 owner/composer/new-session tests passed, covering disposal, reuse, and stale results.
- Independent Codex P0–P2 review of the complete patch found no actionable findings. Formatting and diff checks passed.
- Exact-head hosted CI is green. Full `pnpm build` passed in the native review worktree with its own `pnpm install --frozen-lockfile` (7m 1.8s, including UI budgets). The first build in the shared-dependency checkout failed because its workspace packages resolve to an unrelated branch; the clean native build removes that environment mismatch.
- Scoped `profile-extension-memory.mts --extension openai --skip-combined --concurrency 1` passed: 403.9 MiB peak RSS, 43.0 MiB empty-Node baseline, +360.9 MiB isolated-import delta; zero failures/timeouts. This includes shared SDK/runtime imports and is not incremental Gateway RSS. Earlier registration is an intentional startup cost for the existing broker capability; plugin opt-outs remain available. This addresses the latest ClawSweeper build/profile Rank-up move.
- No provider API payload changes. No successful live GPT-Live call is claimed. Signed-in dashboard verification is currently blocked because the browser relay does not expose the target dashboard tab; startup and browser owner tests are the available before/after evidence. No visual layout changes.
- Production TypeScript +5/-0; manifest +1/-1; tests +97/-0; docs +7/-0. Growth owns the focus listener's connected/disposed lifetime; no new configuration or database schema.

Separate follow-up: OAuth-only `agents.defaults.voiceModel` selection still checks backend/Platform readiness when no Talk provider is explicit (`src/gateway/server-methods/talk-shared.ts:247`). Explicit Talk provider/model selection is unaffected; this PR does not claim to repair that selector.

AI-assisted implementation and verification. Release-note context: OpenAI login activates browser voice without hidden provider setup, and the web microphone refreshes readiness after sign-in.
