### PR TITLE
fix(ui): large attachment batches fail before active-run steering

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -668,7 +668,9 @@ Queued attachments use binary Blobs in the browser's IndexedDB; the outbox keeps
 metadata and payload references in session storage. All attachments must be stored before the
 message is admitted, and all must be readable before sending. Failed admission leaves the draft
 unsent. Missing or unreadable queued payloads leave a visible row with recovery guidance; the
-browser never sends just the remaining attachments.
+browser never sends just the remaining attachments. Binary outbox storage requires browser
+storage access and Web Locks, available over HTTPS or localhost. Gateway attachment limits
+still apply.
 
 The outbox retains up to 25 MiB of attachments per message and 250 MiB across this browser origin,
 subject to the browser's own quota. Queued payloads have no age-based expiry. Delivery or discard

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -665,8 +665,9 @@ offline, except that **Stop** can queue an exact local run ID for replay. A sess
 is not replayed because newer work may start in that session before the connection returns.
 
 Queued attachments use binary Blobs in the browser's IndexedDB; the outbox keeps only delivery
-metadata and payload references in session storage. All attachments must be stored before the
-message is admitted, and all must be readable before sending. Failed admission leaves the draft
+metadata and payload references in session storage. Attachment bytes stay with the queued input
+when session aliases resolve or change; the queue metadata owns its destination. All attachments
+must be stored before the message is admitted, and all must be readable before sending. Failed admission leaves the draft
 unsent. Missing or unreadable queued payloads leave a visible row with recovery guidance; the
 browser never sends just the remaining attachments. Binary outbox storage requires browser
 storage access and Web Locks, available over HTTPS or localhost. Gateway attachment limits

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -664,6 +664,27 @@ automatically when the Gateway returns. Live controls and slash commands remain 
 offline, except that **Stop** can queue an exact local run ID for replay. A session-only stop
 is not replayed because newer work may start in that session before the connection returns.
 
+Queued attachments use binary Blobs in the browser's IndexedDB; the outbox keeps only delivery
+metadata and payload references in session storage. All attachments must be stored before the
+message is admitted, and all must be readable before sending. Failed admission leaves the draft
+unsent. Missing or unreadable queued payloads leave a visible row with recovery guidance; the
+browser never sends just the remaining attachments.
+
+The outbox retains up to 25 MiB of attachments per message and 250 MiB across this browser origin,
+subject to the browser's own quota. Queued payloads have no age-based expiry. Delivery or discard
+releases them; closing a tab or interrupting a tab copy or cleanup can leave orphaned payloads
+within that bound. If capacity remains
+full after sending or discarding your queues, save any needed drafts before clearing this site's
+browser storage. That also clears browser-local drafts and sign-in state. Outbox queues belong to
+the browser tab; they are distinct from restart-recoverable composer drafts. Incognito sessions
+keep their existing tab-only inline outbox and its smaller browser storage limit; they never
+store queued attachment Blobs in IndexedDB.
+
+Duplicating a tab copies the same submission IDs. Once opened, the duplicate claims its own
+payload copies and marks those submissions **Delivery unconfirmed**. Check the conversation
+before retrying. A duplicate first opened after the source discarded or delivered a message may
+instead report missing attachments. Independent tabs do not share newly authored outbox messages.
+
 After connecting, chat waits for account-scoped recovery before accepting or sending ordinary
 messages. During this brief check, submitted text and attachments stay in the composer. Offline
 queues resume once recovery is ready, unless the session still owns an unresolved initial turn;

--- a/src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts
@@ -1,5 +1,5 @@
 import { Type } from "typebox";
-import { getPluginToolSideEffectOwnerKey } from "../../../plugins/tools.js";
+import { getPluginToolSideEffectOwnerKey } from "../../../plugins/tool-metadata.js";
 import type { NestedToolActivity } from "../../../sessions/nested-tool-activity.js";
 import {
   attachInternalToolExecutionPreparer,

--- a/ui/src/app/app-host.deleted-session.test.ts
+++ b/ui/src/app/app-host.deleted-session.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { RouteId } from "../app-routes.ts";
+import { storageTargetForGateway } from "../lib/chat/outbox-store.ts";
 import { createSessionCapability } from "../lib/sessions/index.ts";
 import {
   createGatewayHarness,
@@ -231,7 +232,7 @@ describe("OpenClaw shell deleted-session recovery", () => {
       const storage = createStorageMock();
       vi.stubGlobal("sessionStorage", storage);
       const gatewayUrl = "ws://gateway.test";
-      const storageKey = `openclaw.control.chatComposer.v2:${encodeURIComponent(gatewayUrl)}`;
+      const storageKey = storageTargetForGateway(gatewayUrl).key;
       const replacement = { ...h.alpha, sessionId: "generation-b" };
       const { shell, replace } = createSessionRecoveryShell({
         activeSessionKey: h.alpha.key,
@@ -257,7 +258,7 @@ describe("OpenClaw shell deleted-session recovery", () => {
         storage.setItem(
           storageKey,
           JSON.stringify({
-            version: 2,
+            version: 3,
             gatewayOwner: gatewayUrl,
             sessions: {
               [`${h.alpha.key}\u0000agent:main`]: {
@@ -317,10 +318,11 @@ describe("OpenClaw shell deleted-session recovery", () => {
     const gatewayUrl = "ws://gateway.test";
     const storage = createStorageMock();
     vi.stubGlobal("sessionStorage", storage);
+    const storageKey = storageTargetForGateway(gatewayUrl).key;
     storage.setItem(
-      `openclaw.control.chatComposer.v2:${encodeURIComponent(gatewayUrl)}`,
+      storageKey,
       JSON.stringify({
-        version: 2,
+        version: 3,
         gatewayOwner: gatewayUrl,
         sessions: {
           [`${deletedKey}\u0000agent:main`]: {
@@ -360,17 +362,14 @@ describe("OpenClaw shell deleted-session recovery", () => {
       deletedSessions: [],
     });
     await import("../lib/chat/composer-draft-retirement.runtime.ts");
-    expect(
-      storage.getItem(`openclaw.control.chatComposer.v2:${encodeURIComponent(gatewayUrl)}`),
-    ).toContain("retire me");
+    expect(storage.getItem(storageKey)).toContain("retire me");
     shell.observeDeletedSessions(state);
     shell.observeDeletedSessions(state);
 
     await vi.waitFor(() => {
-      const stored = JSON.parse(
-        storage.getItem(`openclaw.control.chatComposer.v2:${encodeURIComponent(gatewayUrl)}`) ??
-          "{}",
-      ) as { sessions?: Record<string, { draft?: string; queue?: unknown[] }> };
+      const stored = JSON.parse(storage.getItem(storageKey) ?? "{}") as {
+        sessions?: Record<string, { draft?: string; queue?: unknown[] }>;
+      };
       expect(stored.sessions?.[`${deletedKey}\u0000agent:main`]).toEqual({
         draftRevision: expect.any(Number),
         updatedAt: expect.any(Number),

--- a/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
@@ -41,7 +41,12 @@ async function installDeferredAttachmentReader(page: Page): Promise<void> {
     ) as FileReader["readAsDataURL"];
     const abort = Reflect.get(FileReader.prototype, "abort") as FileReader["abort"];
     FileReader.prototype.readAsDataURL = function (blob: Blob) {
-      proof.finish = () => readAsDataURL.call(this, blob);
+      proof.finish = () => {
+        // Only the paste read is held; later outbox hydration uses native reads.
+        FileReader.prototype.readAsDataURL = readAsDataURL;
+        proof.finish = undefined;
+        readAsDataURL.call(this, blob);
+      };
     };
     FileReader.prototype.abort = function () {
       proof.aborts += 1;

--- a/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
@@ -2,6 +2,8 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import type { ApplicationContext } from "../app/context.ts";
+import type { ChatQueueItem } from "../lib/chat/chat-types.ts";
+import type { DurableComposerDraftAttachment } from "../lib/chat/composer-draft-store.runtime.ts";
 import {
   chatSessionListResponse,
   controlUiSessionUrl,
@@ -715,6 +717,7 @@ suite.define(() => {
       const sends = await waitForRequests(gateway, "chat.send", 2);
       const secondParams = requireRecord(sends[1]?.params);
       expect(secondParams.idempotencyKey).toBe(runId);
+      expect(secondParams.sessionKey).toBe(firstParams.sessionKey);
       expect(secondParams.message).toBe(prompt);
       await deliveryStatus.waitFor({ state: "detached", timeout: 10_000 });
     } finally {
@@ -884,50 +887,60 @@ suite.define(() => {
       expect(requestsBeforeReconnect).toHaveLength(0);
       const readStoredProof = () =>
         page.evaluate(
-          ({ expectedAttachmentName, expectedAttachmentDataUrl, expectedPrompt }) => {
-            const storedValues = Object.entries(sessionStorage)
-              .filter(([key]) => key.startsWith("openclaw.control.chatComposer.v2:"))
-              .map(([, value]) => value);
-            const stored = storedValues.join("\n");
-            let runId: string | null = null;
-            for (const value of storedValues) {
-              try {
+          async ({ expectedAttachmentName, expectedAttachmentDataUrl, expectedPrompt }) => {
+            const item = Object.entries(sessionStorage)
+              .filter(([key]) => key.startsWith("openclaw.control.chatComposer.v3:"))
+              .flatMap(([, value]) => {
                 const parsed = JSON.parse(value) as {
-                  sessions?: Record<
-                    string,
-                    {
-                      queue?: Array<{
-                        attachments?: Array<{ dataUrl?: unknown; fileName?: unknown }>;
-                        sendRunId?: unknown;
-                        text?: unknown;
-                      }>;
-                    }
-                  >;
+                  sessions: Record<string, { queue?: ChatQueueItem[] }>;
                 };
-                const item = Object.values(parsed.sessions ?? {})
-                  .flatMap((session) => session.queue ?? [])
-                  .find((entry) => entry.text === expectedPrompt);
-                if (typeof item?.sendRunId === "string") {
-                  runId = item.sendRunId;
-                  const attachment = item.attachments?.find(
-                    (entry) => entry.fileName === expectedAttachmentName,
+                return Object.values(parsed.sessions).flatMap((session) => session.queue ?? []);
+              })
+              .find((entry) => entry.text === expectedPrompt);
+            const attachment = item?.attachments?.find(
+              (entry) => entry.fileName === expectedAttachmentName,
+            );
+            const reference = item?.attachmentPayload;
+            let attachmentMatches = false;
+            if (reference && attachment) {
+              const database = await new Promise<IDBDatabase>((resolve, reject) => {
+                const request = indexedDB.open("openclaw-control-ui");
+                request.onsuccess = () => resolve(request.result);
+                request.addEventListener("error", () =>
+                  reject(request.error ?? new Error("IndexedDB request failed")),
+                );
+              });
+              try {
+                const record = await new Promise<
+                  { attachments: DurableComposerDraftAttachment[] } | undefined
+                >((resolve, reject) => {
+                  const request = database
+                    .transaction("outboxPayloads")
+                    .objectStore("outboxPayloads")
+                    .get(reference.key);
+                  request.onsuccess = () => resolve(request.result);
+                  request.addEventListener("error", () =>
+                    reject(request.error ?? new Error("IndexedDB request failed")),
                   );
-                  return {
-                    attachment: attachment?.dataUrl === expectedAttachmentDataUrl,
-                    prompt: true,
-                    runId,
-                    waitingReconnect: value.includes('"sendState":"waiting-reconnect"'),
-                  };
+                });
+                const storedAttachment = record?.attachments.find(
+                  (entry) => entry.fileName === expectedAttachmentName,
+                );
+                if (storedAttachment) {
+                  const bytes = new Uint8Array(await storedAttachment.blob.arrayBuffer());
+                  const dataUrl = `data:${storedAttachment.mimeType};base64,${btoa(String.fromCharCode(...bytes))}`;
+                  attachmentMatches =
+                    attachment.dataUrl === undefined && dataUrl === expectedAttachmentDataUrl;
                 }
-              } catch {
-                // Ignore unrelated malformed session storage in this focused proof.
+              } finally {
+                database.close();
               }
             }
             return {
-              attachment: false,
-              prompt: stored.includes(expectedPrompt),
-              runId,
-              waitingReconnect: stored.includes('"sendState":"waiting-reconnect"'),
+              attachment: attachmentMatches,
+              prompt: item !== undefined,
+              runId: item?.sendRunId ?? null,
+              waitingReconnect: item?.sendState === "waiting-reconnect",
             };
           },
           {

--- a/ui/src/e2e/chat-flow.queue-reorder.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.queue-reorder.e2e.test.ts
@@ -108,8 +108,10 @@ suite.define(() => {
       await page.locator(".chat-queue__item").nth(2).locator(".chat-queue__grip").focus();
       await page.keyboard.press("ArrowUp");
 
-      // Give the failed move a moment to settle, then confirm nothing moved.
-      await page.waitForTimeout(300);
+      await page
+        .getByRole("alert")
+        .filter({ hasText: "Could not store this message for reconnect." })
+        .waitFor();
       expect(await queueText()).toEqual([...QUEUED]);
       if (captureUiProofEnabled) {
         await page.screenshot({
@@ -127,7 +129,7 @@ suite.define(() => {
       const storedQueueOrder = () =>
         page.evaluate(() =>
           Object.entries(sessionStorage)
-            .filter(([key]) => key.startsWith("openclaw.control.chatComposer.v2:"))
+            .filter(([key]) => key.startsWith("openclaw.control.chatComposer.v3:"))
             .flatMap(([, value]) => {
               try {
                 const parsed = JSON.parse(value) as {

--- a/ui/src/e2e/chat-outbox-capacity.e2e.test.ts
+++ b/ui/src/e2e/chat-outbox-capacity.e2e.test.ts
@@ -1,0 +1,436 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { crc32, deflateSync } from "node:zlib";
+import type { Page } from "playwright";
+import { assert, expect, it } from "vitest";
+import type { StoredComposerState } from "../lib/chat/outbox-store.ts";
+import {
+  createChatFlowE2eSuite,
+  expectRequestCountStable,
+  installMockGateway,
+} from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+const proofDir = path.resolve(".artifacts/control-ui-e2e/outbox-capacity/after");
+const largePngBytes = 2_404_765;
+const smallPngBytes = 25_536;
+const storageError =
+  "Could not store this message for reconnect. Free browser storage or reconnect before sending.";
+
+function pngChunk(type: string, data: Buffer): Buffer {
+  const chunk = Buffer.alloc(data.length + 12);
+  chunk.writeUInt32BE(data.length, 0);
+  chunk.write(type, 4, "ascii");
+  data.copy(chunk, 8);
+  chunk.writeUInt32BE(crc32(chunk.subarray(4, -4)), chunk.length - 4);
+  return chunk;
+}
+
+function sizedPng(size: number, color: number): Buffer {
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(1, 0);
+  header.writeUInt32BE(1, 4);
+  header[8] = 8;
+  header[9] = 6;
+  const signature = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+  const ihdr = pngChunk("IHDR", header);
+  const idat = pngChunk("IDAT", deflateSync(Buffer.from([0, color, 100, 180, 255])));
+  const iend = pngChunk("IEND", Buffer.alloc(0));
+  // A CRC-covered tEXt ancillary chunk pads a decodable PNG, not trailing junk.
+  const padding = Buffer.alloc(
+    size - signature.length - ihdr.length - idat.length - iend.length - 12,
+    120,
+  );
+  padding.write("Padding\0", 0, "ascii");
+  return Buffer.concat([signature, ihdr, pngChunk("tEXt", padding), idat, iend]);
+}
+
+async function observeMockSends(page: Page) {
+  return page.evaluateHandle(() => {
+    const sends: Array<{
+      message: string;
+      queueMode?: string;
+      sessionKey: string;
+      runId: string;
+      durableBeforeSend: boolean;
+      storedSendState?: string;
+      attachments: Array<{ fileName: string; mimeType: string; sizeBytes: number }>;
+    }> = [];
+    // oxlint-disable-next-line typescript/unbound-method -- Preserve the mock method for call(this, raw) and restore it on teardown.
+    const send = WebSocket.prototype.send;
+    // Observe the existing mock transport synchronously; storage and admission
+    // remain native. Reading after chat.send alone cannot prove admission order.
+    WebSocket.prototype.send = function (raw) {
+      if (typeof raw === "string") {
+        const frame = JSON.parse(raw) as {
+          method?: string;
+          params: {
+            message: string;
+            queueMode?: string;
+            sessionKey: string;
+            idempotencyKey: string;
+            attachments?: Array<{ fileName: string; mimeType: string; content: string }>;
+          };
+        };
+        if (frame.method === "chat.send") {
+          const params = frame.params;
+          const queue = Object.keys(sessionStorage)
+            .filter((key) => key.startsWith("openclaw.control.chatComposer.v3:"))
+            .flatMap((key) => {
+              const stored = JSON.parse(sessionStorage.getItem(key)!) as StoredComposerState;
+              return Object.values(stored.sessions).flatMap((session) => session.queue ?? []);
+            });
+          const persisted = queue.find((item) => item.sendRunId === params.idempotencyKey);
+          const attachments = params.attachments ?? [];
+          sends.push({
+            message: params.message,
+            queueMode: params.queueMode,
+            sessionKey: params.sessionKey,
+            runId: params.idempotencyKey,
+            durableBeforeSend:
+              persisted?.text === params.message &&
+              persisted.queueMode === params.queueMode &&
+              persisted.attachments?.length === attachments.length &&
+              attachments.every((attachment, index) => {
+                const stored = persisted.attachments?.[index];
+                return (
+                  stored?.fileName === attachment.fileName &&
+                  stored.mimeType === attachment.mimeType &&
+                  !stored.dataUrl &&
+                  Boolean(persisted.attachmentPayload?.key)
+                );
+              }),
+            storedSendState: persisted?.sendState,
+            attachments: attachments.map((attachment) => ({
+              fileName: attachment.fileName,
+              mimeType: attachment.mimeType,
+              sizeBytes: atob(attachment.content).length,
+            })),
+          });
+        }
+      }
+      return send.call(this, raw);
+    };
+    return {
+      sends,
+      dispose: () => {
+        WebSocket.prototype.send = send;
+      },
+    };
+  });
+}
+
+suite.define(() => {
+  it.each([
+    { name: "one-large", sizes: [largePngBytes] },
+    { name: "large-and-small", sizes: [largePngBytes, smallPngBytes] },
+    { name: "two-large", sizes: [largePngBytes, largePngBytes] },
+  ])(
+    "durably admits $name PNG attachments before steering an active run (mock Gateway)",
+    async ({ name, sizes }) => {
+      await suite.withPage(
+        {
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport: { width: 1280, height: 900 },
+          recordVideo: { dir: path.join(proofDir, "video"), size: { width: 1280, height: 900 } },
+        },
+        async ({ page }) => {
+          const runId = "mock-active-capacity-run";
+          const activeText = "Mock Gateway: the active run is still working.";
+          const historyText = "Mock Gateway: inspect the attachment batch.";
+          const gateway = await installMockGateway(page, {
+            historyMessages: [{ role: "user", content: historyText }],
+            inFlightRun: { runId, text: activeText },
+            sessionInfo: { activeRunIds: [runId], hasActiveRun: true, key: "main" },
+            deferredMethods: ["chat.send"],
+          });
+          await page.goto(`${suite.server.baseUrl}settings/appearance`);
+          await page.locator("[data-settings-follow-up-mode]").selectOption("steer");
+          await gateway.waitForRequest("config.patch");
+          await page.goto(`${suite.server.baseUrl}chat`);
+          const pane = page.locator('openclaw-chat-pane[aria-hidden="false"]');
+          const composer = pane.locator(".agent-chat__composer-combobox textarea");
+          const steer = pane.getByRole("button", {
+            name: "Steer into the active run",
+            exact: true,
+          });
+          await pane.getByText(historyText, { exact: true }).waitFor();
+          await pane.getByText(activeText, { exact: true }).waitFor();
+          await pane.getByRole("button", { name: "Stop generating" }).waitFor();
+          const files = sizes.map((size, index) => ({
+            name: `mock-${name}-${index + 1}.png`,
+            mimeType: "image/png",
+            buffer: sizedPng(size, 60 + index * 100),
+          }));
+          expect(files.map((file) => file.buffer.length)).toEqual(sizes);
+          const message = `Mock Gateway: steer with ${name} PNG batch.`;
+          await composer.fill(message);
+          await pane.locator(".agent-chat__file-input").setInputFiles(files);
+          const previews = pane.locator(".chat-attachment-thumb img");
+          await expect.poll(() => previews.count()).toBe(files.length);
+          await expect
+            .poll(() =>
+              previews.evaluateAll((images) =>
+                images.every(
+                  (image) =>
+                    image instanceof HTMLImageElement && image.complete && image.naturalWidth > 0,
+                ),
+              ),
+            )
+            .toBe(true);
+          const acceptedBytes = await previews.evaluateAll(async (images) =>
+            Promise.all(
+              images.map(
+                async (image) => (await (await fetch((image as HTMLImageElement).src)).blob()).size,
+              ),
+            ),
+          );
+          expect(acceptedBytes).toEqual(sizes);
+          await expect.poll(() => steer.isEnabled()).toBe(true);
+          expect(await pane.locator(".chat-queue__item").count()).toBe(0);
+          expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+          const observation = await observeMockSends(page);
+          try {
+            await steer.click();
+            const outcomeHandle = await page.waitForFunction(
+              ({ proof, error }) => {
+                const errorVisible = [...document.querySelectorAll('[role="alert"]')].some(
+                  (alert) => alert.textContent?.includes(error),
+                );
+                return proof.sends.length > 0 ? "sent" : errorVisible ? "storage-rejected" : false;
+              },
+              { proof: observation, error: storageError },
+            );
+            const outcome = await outcomeHandle.jsonValue();
+            await outcomeHandle.dispose();
+            const sends = await observation.evaluate((proof) => proof.sends);
+            const requests = await gateway.getRequests("chat.send");
+            const sessionStorageUsage = await page.evaluate(() =>
+              Object.keys(sessionStorage).map((key) => ({
+                key,
+                utf16Bytes: 2 * (key.length + sessionStorage.getItem(key)!.length),
+              })),
+            );
+            const error = await pane.locator(".chat-error__summary strong").allTextContents();
+            const evidence = {
+              gateway: "mock; no provider or operator Gateway contacted",
+              browser: suite.browser.version(),
+              name,
+              acceptedBytes,
+              dataUrlUtf16Bytes: sizes.reduce(
+                (sum, size) => sum + 2 * (22 + 4 * Math.ceil(size / 3)),
+                0,
+              ),
+              sessionStorageUsage,
+              outcome,
+              error,
+              sends,
+              draft: await composer.inputValue(),
+              attachmentPreviews: await previews.count(),
+              queueRows: await pane.locator(".chat-queue__item").count(),
+            };
+            await mkdir(proofDir, { recursive: true });
+            await writeFile(
+              path.join(proofDir, `${name}.json`),
+              `${JSON.stringify(evidence, null, 2)}\n`,
+            );
+            // Failed admission must retain the entire draft, with no phantom queue
+            // entry or send. The success contract below still fails on that outcome.
+            if (outcome === "storage-rejected") {
+              expect(evidence.draft).toBe(message);
+              expect(evidence.attachmentPreviews).toBe(files.length);
+              expect(evidence.queueRows).toBe(0);
+              await expectRequestCountStable(gateway, "chat.send", 0);
+            }
+            const captureImages = pane.locator(".chat-attachment-thumb img, .chat-message-image");
+            await expect.poll(() => captureImages.count()).toBe(files.length);
+            await expect
+              .poll(() =>
+                captureImages.evaluateAll((images) =>
+                  images.every(
+                    (image) =>
+                      image instanceof HTMLImageElement && image.complete && image.naturalWidth > 0,
+                  ),
+                ),
+              )
+              .toBe(true);
+            await pane.getByText(historyText, { exact: true }).waitFor();
+            await pane.getByText(activeText, { exact: true }).waitFor();
+            await page.screenshot({
+              path: path.join(proofDir, `${name}-${outcome}.png`),
+              fullPage: true,
+              animations: "disabled",
+            });
+
+            expect(outcome, JSON.stringify(evidence)).toBe("sent");
+            const payloads = await page.evaluate(async () => {
+              const database = await new Promise<IDBDatabase>((resolve, reject) => {
+                const request = indexedDB.open("openclaw-control-ui");
+                request.onsuccess = () => resolve(request.result);
+                request.addEventListener("error", () =>
+                  reject(request.error ?? new Error("IndexedDB request failed")),
+                );
+              });
+              try {
+                const records = await new Promise<Array<{ attachments: Array<{ blob: Blob }> }>>(
+                  (resolve, reject) => {
+                    const request = database
+                      .transaction("outboxPayloads")
+                      .objectStore("outboxPayloads")
+                      .getAll();
+                    request.onsuccess = () => resolve(request.result);
+                    request.addEventListener("error", () =>
+                      reject(request.error ?? new Error("IndexedDB request failed")),
+                    );
+                  },
+                );
+                return Promise.all(
+                  records
+                    .flatMap((record) => record.attachments)
+                    .map(async ({ blob }) => {
+                      const bytes = new Uint8Array(await blob.arrayBuffer());
+                      let binary = "";
+                      for (const byte of bytes) {
+                        binary += String.fromCharCode(byte);
+                      }
+                      return btoa(binary);
+                    }),
+                );
+              } finally {
+                database.close();
+              }
+            });
+            expect(payloads).toEqual(files.map((file) => file.buffer.toString("base64")));
+            expect(requests[0]?.params).toEqual(
+              expect.objectContaining({
+                attachments: files.map((file) => ({
+                  type: "image",
+                  mimeType: file.mimeType,
+                  fileName: file.name,
+                  content: file.buffer.toString("base64"),
+                })),
+              }),
+            );
+            expect(sends).toEqual([
+              {
+                message,
+                queueMode: "steer",
+                sessionKey: "main",
+                runId: expect.any(String),
+                durableBeforeSend: true,
+                storedSendState: "waiting-reconnect",
+                attachments: files.map((file) => ({
+                  fileName: file.name,
+                  mimeType: file.mimeType,
+                  sizeBytes: file.buffer.length,
+                })),
+              },
+            ]);
+            await expect.poll(() => composer.inputValue()).toBe("");
+            await expect.poll(() => previews.count()).toBe(0);
+            await pane.locator(".chat-group.user", { hasText: message }).waitFor();
+            expect(await pane.locator(".chat-queue__item").count()).toBe(0);
+            await pane.getByRole("button", { name: "Stop generating" }).waitFor();
+            await expectRequestCountStable(gateway, "chat.send", 1);
+            const sent = sends[0];
+            assert(sent, "Expected the observed chat.send before emitting its terminal");
+            await gateway.resolveDeferred("chat.send", {
+              runId: sent.runId,
+              status: "started",
+            });
+            await pane.getByRole("button", { name: "Stop generating" }).waitFor();
+            await gateway.deferNext("chat.history");
+            await gateway.emitChatFinal({
+              runId: sent.runId,
+              text: "Mock Gateway: attachment delivery finished before history persisted.",
+            });
+            await expect
+              .poll(() =>
+                page.evaluate(
+                  (deliveredRunId) =>
+                    Object.keys(sessionStorage)
+                      .filter((key) => key.startsWith("openclaw.control.chatComposer.v3:"))
+                      .flatMap((key) =>
+                        Object.values(
+                          (JSON.parse(sessionStorage.getItem(key)!) as StoredComposerState)
+                            .sessions,
+                        ),
+                      )
+                      .flatMap((session) => session.queue ?? [])
+                      .filter((item) => item.sendRunId === deliveredRunId).length,
+                  sent.runId,
+                ),
+              )
+              .toBe(0);
+            const deliveredImages = pane
+              .locator(".chat-group.user", { hasText: message })
+              .locator(".chat-message-image");
+            await expect.poll(() => deliveredImages.count()).toBe(files.length);
+            await expect
+              .poll(() =>
+                deliveredImages.evaluateAll((images) =>
+                  images.every(
+                    (image) =>
+                      image instanceof HTMLImageElement && image.complete && image.naturalWidth > 0,
+                  ),
+                ),
+              )
+              .toBe(true);
+            const deliveredBytes = await deliveredImages.evaluateAll((images) =>
+              Promise.all(
+                images.map(async (image) => {
+                  const bytes = new Uint8Array(
+                    await (await fetch((image as HTMLImageElement).src)).arrayBuffer(),
+                  );
+                  let binary = "";
+                  for (const byte of bytes) {
+                    binary += String.fromCharCode(byte);
+                  }
+                  return btoa(binary);
+                }),
+              ),
+            );
+            expect(deliveredBytes).toEqual(files.map((file) => file.buffer.toString("base64")));
+            await expect
+              .poll(() =>
+                page.evaluate(async () => {
+                  const database = await new Promise<IDBDatabase>((resolve, reject) => {
+                    const request = indexedDB.open("openclaw-control-ui");
+                    request.onsuccess = () => resolve(request.result);
+                    request.addEventListener("error", () =>
+                      reject(request.error ?? new Error("IndexedDB request failed")),
+                    );
+                  });
+                  try {
+                    return await new Promise<number>((resolve, reject) => {
+                      const request = database
+                        .transaction("outboxPayloads")
+                        .objectStore("outboxPayloads")
+                        .count();
+                      request.onsuccess = () => resolve(request.result);
+                      request.addEventListener("error", () =>
+                        reject(request.error ?? new Error("IndexedDB request failed")),
+                      );
+                    });
+                  } finally {
+                    database.close();
+                  }
+                }),
+              )
+              .toBe(0);
+            await expectRequestCountStable(gateway, "chat.send", 1);
+            await page.screenshot({
+              path: path.join(proofDir, `${name}-terminal-handoff.png`),
+              fullPage: true,
+              animations: "disabled",
+            });
+          } finally {
+            await observation.evaluate((proof) => proof.dispose());
+            await observation.dispose();
+          }
+        },
+      );
+    },
+  );
+});

--- a/ui/src/e2e/chat-outbox-payloads.e2e.test.ts
+++ b/ui/src/e2e/chat-outbox-payloads.e2e.test.ts
@@ -1,4 +1,4 @@
-import { writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { assert, expect, it } from "vitest";
@@ -62,6 +62,42 @@ async function payloadCount(page: Page): Promise<number> {
       database.close();
     }
   });
+}
+
+async function readPayloadBytes(page: Page, key: string): Promise<string[] | null> {
+  return page.evaluate(async (payloadKey) => {
+    type StoredPayload = { attachments: Array<{ blob: Blob }> };
+    const database = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open("openclaw-control-ui");
+      request.onsuccess = () => resolve(request.result);
+      request.addEventListener("error", () =>
+        reject(request.error ?? new Error("IDB open failed")),
+      );
+    });
+    try {
+      const payload = await new Promise<StoredPayload | undefined>((resolve, reject) => {
+        const request = database
+          .transaction("outboxPayloads")
+          .objectStore("outboxPayloads")
+          .get(payloadKey);
+        request.onsuccess = () => resolve(request.result as StoredPayload | undefined);
+        request.addEventListener("error", () =>
+          reject(request.error ?? new Error("IDB read failed")),
+        );
+      });
+      if (!payload) {
+        return null;
+      }
+      return Promise.all(
+        payload.attachments.map(async ({ blob }) => {
+          const bytes = new Uint8Array(await blob.arrayBuffer());
+          return btoa(Array.from(bytes, (byte) => String.fromCharCode(byte)).join(""));
+        }),
+      );
+    } finally {
+      database.close();
+    }
+  }, key);
 }
 
 async function stage(page: Page, message: string) {
@@ -287,6 +323,194 @@ suite.define(() => {
       expect((await readQueue(lateDuplicate))[0]?.sendRunId).toBe(original.sendRunId);
     });
   });
+  it("keeps source Blob bytes when a duplicate removes its row before lock-confirmed adoption", async () => {
+    await suite.withPage(
+      { serviceWorkers: "block", locale: "en-US", viewport: { width: 1280, height: 900 } },
+      async ({ context, page }) => {
+        const gateway = await installMockGateway(page, {
+          historyMessages: history,
+          sessionInfo: { key: "main", hasActiveRun: false, status: "done" },
+          deferredMethods: ["chat.send"],
+        });
+        await page.goto(`${suite.server.baseUrl}chat`, { waitUntil: "domcontentloaded" });
+        await paneFor(page)
+          .getByText("Mock Gateway: payload lifecycle proof.", { exact: true })
+          .waitFor();
+        await gateway.setOnline(false);
+        await waitForControlUiGatewayReconnecting(page);
+        const message = "Mock Gateway: source keeps its pre-adoption bytes";
+        await stage(page, message);
+        await paneFor(page).getByRole("button", { name: "Send message", exact: true }).click();
+        await expect.poll(async () => (await readQueue(page)).length).toBe(1);
+        const original = (await readQueue(page))[0];
+        assert(
+          original?.attachmentPayload && original.sendRunId,
+          "Expected a durable source submission",
+        );
+        const reference = original.attachmentPayload;
+        const runId = original.sendRunId;
+        const sourceLockName = `openclaw-outbox:${reference.tabId}`;
+        const sourceOwnsLock = () =>
+          page.evaluate(
+            async (name) =>
+              (await navigator.locks.query()).held?.some((lock) => lock.name === name) ?? false,
+            sourceLockName,
+          );
+        expect(await sourceOwnsLock()).toBe(true);
+        expect(await readPayloadBytes(page, reference.key)).toEqual([
+          file.buffer.toString("base64"),
+        ]);
+        await expectRequestCountStable(gateway, "chat.send", 0);
+
+        const popup = context.waitForEvent("page");
+        await page.evaluate(() => window.open("about:blank"));
+        const duplicate = await popup;
+        const releaseEvent = "openclaw-test-release-outbox-claim";
+        await duplicate.addInitScript((eventName) => {
+          const manager = navigator.locks;
+          const nativeRequest = manager.request.bind(manager);
+          let release!: () => void;
+          let released = false;
+          const latch = new Promise<void>((resolve) => {
+            release = resolve;
+          });
+          window.addEventListener(
+            eventName,
+            () => {
+              released = true;
+              release();
+            },
+            { once: true },
+          );
+          function delay<T>(
+            name: string,
+            callback: LockGrantedCallback<T>,
+          ): LockGrantedCallback<T | Promise<T>> {
+            if (!name.startsWith("openclaw-outbox:")) {
+              return callback;
+            }
+            return (lock) => {
+              if (released) {
+                return callback(lock);
+              }
+              document.documentElement.dataset.outboxClaimName = name;
+              document.documentElement.dataset.outboxClaimGranted = String(lock !== null);
+              document.documentElement.dataset.outboxClaimState = "blocked";
+              // Native arbitration has already decided; delay only its callback delivery.
+              return latch.then(() => callback(lock));
+            };
+          }
+          function delayedRequest<T>(
+            name: string,
+            optionsOrCallback: LockOptions | LockGrantedCallback<T>,
+            callback?: LockGrantedCallback<T>,
+          ): Promise<Awaited<T>> {
+            if (typeof optionsOrCallback === "function") {
+              return nativeRequest(name, delay(name, optionsOrCallback));
+            }
+            if (!callback) {
+              throw new TypeError("A Web Lock request requires a callback");
+            }
+            return nativeRequest(name, optionsOrCallback, delay(name, callback));
+          }
+          // Only this duplicate's LockManager changes; source ownership stays native.
+          manager.request = delayedRequest;
+        }, releaseEvent);
+        const duplicateGateway = await installMockGateway(duplicate, {
+          historyMessages: history,
+          sessionInfo: { key: "main", hasActiveRun: false, status: "done" },
+        });
+        try {
+          await duplicate.goto(`${suite.server.baseUrl}chat`, { waitUntil: "domcontentloaded" });
+          await duplicateGateway.setOnline(true);
+          await waitForControlUiGatewayReady(duplicate);
+          await duplicate.waitForFunction(
+            () => document.documentElement.dataset.outboxClaimState === "blocked",
+          );
+          expect(
+            await duplicate.evaluate(() => ({
+              name: document.documentElement.dataset.outboxClaimName,
+              granted: document.documentElement.dataset.outboxClaimGranted,
+              marker: sessionStorage.getItem("openclaw.control.outboxTab.v1"),
+            })),
+          ).toEqual({ name: sourceLockName, granted: "false", marker: reference.tabId });
+          expect((await readQueue(duplicate))[0]?.attachmentPayload).toEqual(reference);
+          const row = paneFor(duplicate).locator(".chat-queue__item");
+          await expect.poll(() => row.count()).toBe(1);
+          await mkdir(proofDir, { recursive: true });
+          await duplicate.screenshot({
+            path: path.join(proofDir, "duplicate-before-claim-removal.png"),
+            fullPage: true,
+            animations: "disabled",
+          });
+          await row.getByRole("button", { name: "Remove queued message", exact: true }).click();
+          await expect.poll(async () => (await readQueue(duplicate)).length).toBe(0);
+          await expect.poll(() => row.count()).toBe(0);
+          await duplicate.evaluate(
+            (eventName) => window.dispatchEvent(new Event(eventName)),
+            releaseEvent,
+          );
+          await expect
+            .poll(() =>
+              duplicate.evaluate(async (sourceTab) => {
+                const tab = sessionStorage.getItem("openclaw.control.outboxTab.v1");
+                return Boolean(
+                  tab &&
+                  tab !== sourceTab &&
+                  (await navigator.locks.query()).held?.some(
+                    (lock) => lock.name === `openclaw-outbox:${tab}`,
+                  ),
+                );
+              }, reference.tabId),
+            )
+            .toBe(true);
+          await expectRequestCountStable(duplicateGateway, "chat.send", 0);
+          expect(await sourceOwnsLock()).toBe(true);
+          expect((await readQueue(page))[0]).toMatchObject({
+            id: original.id,
+            sendRunId: runId,
+            sendAttempts: 0,
+            attachmentPayload: reference,
+          });
+          await page.bringToFront();
+          await page.screenshot({
+            path: path.join(proofDir, "source-after-duplicate-removal.png"),
+            fullPage: true,
+            animations: "disabled",
+          });
+          const sourceBytes = await readPayloadBytes(page, reference.key);
+          assert(
+            sourceBytes !== null,
+            "Removing an unclaimed duplicate must not delete the source Blob",
+          );
+          expect(sourceBytes).toEqual([file.buffer.toString("base64")]);
+          await gateway.setOnline(true);
+          const sent = await gateway.waitForRequest("chat.send");
+          expect(sent.params).toEqual(
+            expect.objectContaining({
+              message,
+              idempotencyKey: runId,
+              attachments: [
+                {
+                  type: "file",
+                  mimeType: file.mimeType,
+                  fileName: file.name,
+                  content: file.buffer.toString("base64"),
+                },
+              ],
+            }),
+          );
+          await expectRequestCountStable(gateway, "chat.send", 1);
+          await expectRequestCountStable(duplicateGateway, "chat.send", 0);
+        } finally {
+          await duplicate
+            .evaluate((eventName) => window.dispatchEvent(new Event(eventName)), releaseEvent)
+            .catch(() => undefined);
+        }
+      },
+    );
+  });
+
   it("upgrades inline queues and the existing draft database, then edits and cancels without touching a newer composer", async () => {
     await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
       await page.route("**/outbox-upgrade", (route) =>

--- a/ui/src/e2e/chat-outbox-payloads.e2e.test.ts
+++ b/ui/src/e2e/chat-outbox-payloads.e2e.test.ts
@@ -1,0 +1,571 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { Page } from "playwright";
+import { assert, expect, it } from "vitest";
+import type { ChatQueueItem } from "../lib/chat/chat-types.ts";
+import {
+  waitForControlUiGatewayReady,
+  waitForControlUiGatewayReconnecting,
+} from "../test-helpers/control-ui-e2e-readiness.ts";
+import {
+  createChatFlowE2eSuite,
+  expectRequestCountStable,
+  installMockGateway,
+} from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+const proofDir = path.resolve(".artifacts/control-ui-e2e/outbox-capacity/after");
+const file = {
+  name: "mock-original.txt",
+  mimeType: "text/plain",
+  buffer: Buffer.from("Exact synthetic outbox bytes\n".repeat(1000)),
+};
+const history = [{ role: "assistant", content: "Mock Gateway: payload lifecycle proof." }];
+const paneFor = (page: Page) => page.locator('openclaw-chat-pane[aria-hidden="false"]');
+const composerFor = (page: Page) =>
+  paneFor(page).locator(".agent-chat__composer-combobox textarea");
+
+async function readQueue(page: Page): Promise<ChatQueueItem[]> {
+  return page.evaluate(() =>
+    Object.keys(sessionStorage)
+      .filter((key) => key.startsWith("openclaw.control.chatComposer.v3:"))
+      .flatMap((key) => {
+        const store = JSON.parse(sessionStorage.getItem(key)!) as {
+          sessions: Record<string, { queue?: ChatQueueItem[] }>;
+        };
+        return Object.values(store.sessions).flatMap((session) => session.queue ?? []);
+      }),
+  );
+}
+
+async function payloadCount(page: Page): Promise<number> {
+  return page.evaluate(async () => {
+    const database = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open("openclaw-control-ui");
+      request.onsuccess = () => resolve(request.result);
+      request.addEventListener("error", () =>
+        reject(request.error ?? new Error("IndexedDB request failed")),
+      );
+    });
+    try {
+      return await new Promise<number>((resolve, reject) => {
+        const request = database
+          .transaction("outboxPayloads")
+          .objectStore("outboxPayloads")
+          .count();
+        request.onsuccess = () => resolve(request.result);
+        request.addEventListener("error", () =>
+          reject(request.error ?? new Error("IndexedDB request failed")),
+        );
+      });
+    } finally {
+      database.close();
+    }
+  });
+}
+
+async function stage(page: Page, message: string) {
+  await composerFor(page).fill(message);
+  await paneFor(page).locator(".agent-chat__file-input").setInputFiles(file);
+  await expect.poll(() => paneFor(page).locator(".chat-attachment-thumb").count()).toBe(1);
+}
+
+suite.define(() => {
+  it("reloads an offline Blob queue with exact bytes and idempotency, and never replays a lost ACK", async () => {
+    await suite.withPage(
+      {
+        serviceWorkers: "block",
+        viewport: { width: 1280, height: 900 },
+        recordVideo: { dir: path.join(proofDir, "lifecycle-video") },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          historyMessages: history,
+          sessionInfo: { key: "main", hasActiveRun: false, status: "done" },
+          deferredMethods: ["chat.send"],
+        });
+        await page.goto(`${suite.server.baseUrl}chat`, { waitUntil: "domcontentloaded" });
+        await paneFor(page)
+          .getByText("Mock Gateway: payload lifecycle proof.", { exact: true })
+          .waitFor();
+        await gateway.setOnline(false);
+        await waitForControlUiGatewayReconnecting(page);
+        await stage(page, "Mock Gateway: offline binary submission");
+        await paneFor(page).getByRole("button", { name: "Send message", exact: true }).click();
+        await expect.poll(async () => (await readQueue(page)).length).toBe(1);
+        const queued = (await readQueue(page))[0]!;
+        expect(queued.attachmentPayload).toBeDefined();
+        expect(queued.sendAttempts).toBe(0);
+        await expect.poll(() => composerFor(page).inputValue()).toBe("");
+        await expectRequestCountStable(gateway, "chat.send", 0);
+        await page.reload();
+        await expect.poll(async () => (await readQueue(page))[0]?.sendRunId).toBe(queued.sendRunId);
+        await gateway.setOnline(true);
+        const sent = await gateway.waitForRequest("chat.send");
+        expect(sent.params).toEqual(
+          expect.objectContaining({
+            idempotencyKey: queued.sendRunId,
+            attachments: [
+              {
+                type: "file",
+                mimeType: file.mimeType,
+                fileName: file.name,
+                content: file.buffer.toString("base64"),
+              },
+            ],
+          }),
+        );
+        await expect.poll(() => payloadCount(page)).toBe(1);
+        // Reload destroys the pending ACK. The restored attempted row must require review.
+        await page.reload();
+        await paneFor(page).getByText("Delivery unconfirmed", { exact: true }).waitFor();
+        await expectRequestCountStable(gateway, "chat.send", 0);
+        expect((await readQueue(page))[0]?.sendRunId).toBe(queued.sendRunId);
+        await page.screenshot({
+          path: path.join(proofDir, "reload-unconfirmed.png"),
+          fullPage: true,
+          animations: "disabled",
+        });
+      },
+    );
+  });
+
+  it("queues complete attachment bytes while the browser and Gateway are offline", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ context, page }) => {
+      const gateway = await installMockGateway(page, {
+        historyMessages: history,
+        sessionInfo: { key: "main", hasActiveRun: false, status: "done" },
+        deferredMethods: ["chat.send"],
+      });
+      await page.goto(`${suite.server.baseUrl}chat`, { waitUntil: "domcontentloaded" });
+      await paneFor(page)
+        .getByText("Mock Gateway: payload lifecycle proof.", { exact: true })
+        .waitFor();
+      await waitForControlUiGatewayReady(page);
+      const message = "Mock Gateway: retain complete input while offline";
+      await stage(page, message);
+      await context.setOffline(true);
+      await gateway.setOnline(false);
+      await waitForControlUiGatewayReconnecting(page);
+      await paneFor(page).getByRole("button", { name: "Send message", exact: true }).click();
+      await expect.poll(async () => (await readQueue(page)).length).toBe(1);
+      const queued = (await readQueue(page))[0]!;
+      expect(queued.attachmentPayload).toBeDefined();
+      expect(queued.sendAttempts).toBe(0);
+      await expect.poll(() => payloadCount(page)).toBe(1);
+      await expect.poll(() => composerFor(page).inputValue()).toBe("");
+      await expectRequestCountStable(gateway, "chat.send", 0);
+      await context.setOffline(false);
+      await gateway.setOnline(true);
+      const sent = await gateway.waitForRequest("chat.send");
+      expect(sent.params).toEqual(
+        expect.objectContaining({
+          message,
+          idempotencyKey: queued.sendRunId,
+          attachments: [
+            {
+              type: "file",
+              mimeType: file.mimeType,
+              fileName: file.name,
+              content: file.buffer.toString("base64"),
+            },
+          ],
+        }),
+      );
+      await expectRequestCountStable(gateway, "chat.send", 1);
+    });
+  });
+
+  it("retains the full composer without sending when a real IndexedDB upgrade is blocked", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ context, page }) => {
+      const blocker = await context.newPage();
+      await blocker.route("**/outbox-blocker", (route) =>
+        route.fulfill({ contentType: "text/html", body: "Mock storage blocker" }),
+      );
+      await blocker.goto(`${suite.server.baseUrl}outbox-blocker`);
+      const connection = await blocker.evaluateHandle(
+        async () =>
+          new Promise<IDBDatabase>((resolve, reject) => {
+            const request = indexedDB.open("openclaw-control-ui", 1);
+            request.onupgradeneeded = () =>
+              request.result
+                .createObjectStore("composerDrafts", { keyPath: "key" })
+                .createIndex("ownerKey", "ownerKey");
+            request.onsuccess = () => resolve(request.result);
+            request.addEventListener("error", () =>
+              reject(request.error ?? new Error("IndexedDB request failed")),
+            );
+          }),
+      );
+      const gateway = await installMockGateway(page, {
+        historyMessages: history,
+        sessionInfo: { key: "main", hasActiveRun: false, status: "done" },
+      });
+      await page.goto(`${suite.server.baseUrl}chat`, { waitUntil: "domcontentloaded" });
+      await paneFor(page)
+        .getByText("Mock Gateway: payload lifecycle proof.", { exact: true })
+        .waitFor();
+      await stage(page, "Mock Gateway: retain on blocked storage");
+      await paneFor(page).getByRole("button", { name: "Send message", exact: true }).click();
+      await paneFor(page)
+        .locator(".chat-error__summary strong")
+        .filter({ hasText: "Browser attachment storage is unavailable" })
+        .waitFor();
+      expect(await composerFor(page).inputValue()).toBe("Mock Gateway: retain on blocked storage");
+      expect(await paneFor(page).locator(".chat-attachment-thumb").count()).toBe(1);
+      await expectRequestCountStable(gateway, "chat.send", 0);
+      expect(await readQueue(page)).toEqual([]);
+      await connection.evaluate((database) => database.close());
+      await connection.dispose();
+    });
+  });
+
+  it("isolates independent tabs and gives a duplicate its own bytes without replaying the logical submission", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ context, page }) => {
+      const gateway = await installMockGateway(page, {
+        historyMessages: history,
+        sessionInfo: { key: "main", hasActiveRun: false, status: "done" },
+      });
+      await page.goto(`${suite.server.baseUrl}chat`, { waitUntil: "domcontentloaded" });
+      await paneFor(page)
+        .getByText("Mock Gateway: payload lifecycle proof.", { exact: true })
+        .waitFor();
+      await gateway.setOnline(false);
+      await waitForControlUiGatewayReconnecting(page);
+      await stage(page, "Mock Gateway: one logical submission");
+      await paneFor(page).getByRole("button", { name: "Send message", exact: true }).click();
+      await expect.poll(async () => (await readQueue(page)).length).toBe(1);
+      const original = (await readQueue(page))[0]!;
+      const independent = await context.newPage();
+      const independentGateway = await installMockGateway(independent, {
+        historyMessages: history,
+        sessionInfo: { key: "main", hasActiveRun: false, status: "done" },
+      });
+      await independent.goto(`${suite.server.baseUrl}chat`, { waitUntil: "domcontentloaded" });
+      await paneFor(independent)
+        .getByText("Mock Gateway: payload lifecycle proof.", { exact: true })
+        .waitFor();
+      expect(await readQueue(independent)).toEqual([]);
+      await expectRequestCountStable(independentGateway, "chat.send", 0);
+      const popup = context.waitForEvent("page");
+      await page.evaluate(() => window.open("about:blank"));
+      const duplicate = await popup;
+      const duplicateGateway = await installMockGateway(duplicate, {
+        historyMessages: history,
+        sessionInfo: { key: "main", hasActiveRun: false, status: "done" },
+      });
+      await duplicate.goto(`${suite.server.baseUrl}chat`, { waitUntil: "domcontentloaded" });
+      await duplicateGateway.setOnline(true);
+      await expect.poll(async () => (await readQueue(duplicate))[0]?.sendState).toBe("unconfirmed");
+      await expectRequestCountStable(duplicateGateway, "chat.send", 0);
+      const copied = (await readQueue(duplicate))[0]!;
+      expect(copied.id).toBe(original.id);
+      expect(copied.sendRunId).toBe(original.sendRunId);
+      expect(copied.attachmentPayload?.key).not.toBe(original.attachmentPayload?.key);
+      await expect.poll(() => payloadCount(page)).toBe(2);
+      const latePopup = context.waitForEvent("page");
+      await page.evaluate(() => window.open("about:blank"));
+      const lateDuplicate = await latePopup;
+      // Retiring the source releases only its own bundle, preserving the live copy.
+      await paneFor(page)
+        .getByRole("button", { name: /Remove queued message/ })
+        .click();
+      await expect.poll(() => payloadCount(page)).toBe(1);
+      expect((await readQueue(duplicate))[0]?.attachmentPayload?.key).toBe(
+        copied.attachmentPayload?.key,
+      );
+      const lateGateway = await installMockGateway(lateDuplicate, {
+        historyMessages: history,
+        sessionInfo: { key: "main", hasActiveRun: false, status: "done" },
+      });
+      await lateDuplicate.goto(`${suite.server.baseUrl}chat`, { waitUntil: "domcontentloaded" });
+      await lateGateway.setOnline(true);
+      await expect
+        .poll(async () => (await readQueue(lateDuplicate))[0]?.attachmentStorageError)
+        .toBe("missing");
+      await expectRequestCountStable(lateGateway, "chat.send", 0);
+      expect((await readQueue(lateDuplicate))[0]?.sendRunId).toBe(original.sendRunId);
+    });
+  });
+  it("upgrades inline queues and the existing draft database, then edits and cancels without touching a newer composer", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      await page.route("**/outbox-upgrade", (route) =>
+        route.fulfill({ contentType: "text/html", body: "Mock upgrade seed" }),
+      );
+      await page.goto(`${suite.server.baseUrl}outbox-upgrade`);
+      await page.evaluate(async (content) => {
+        const gatewayOwner = `ws://${location.host}`;
+        const scopeKey = "global\u0000agent:main";
+        sessionStorage.setItem(
+          `openclaw.control.chatComposer.v2:${encodeURIComponent(gatewayOwner)}`,
+          JSON.stringify({
+            version: 2,
+            gatewayOwner,
+            sessions: {
+              [scopeKey]: {
+                updatedAt: Date.now(),
+                queue: [
+                  {
+                    id: "legacy-input",
+                    text: "Mock Gateway: upgrade this inline queue",
+                    createdAt: Date.now(),
+                    sendRunId: "legacy-idempotency",
+                    sendAttempts: 0,
+                    sendState: "waiting-reconnect",
+                    attachments: [
+                      {
+                        id: "legacy-file",
+                        mimeType: "text/plain",
+                        fileName: "mock-original.txt",
+                        dataUrl: `data:text/plain;base64,${content}`,
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          }),
+        );
+        const database = await new Promise<IDBDatabase>((resolve, reject) => {
+          const request = indexedDB.open("openclaw-control-ui", 1);
+          request.onupgradeneeded = () =>
+            request.result
+              .createObjectStore("composerDrafts", { keyPath: "key" })
+              .createIndex("ownerKey", "ownerKey");
+          request.onsuccess = () => resolve(request.result);
+          request.addEventListener("error", () =>
+            reject(request.error ?? new Error("IndexedDB request failed")),
+          );
+        });
+        const transaction = database.transaction("composerDrafts", "readwrite");
+        const ownerKey = JSON.stringify([gatewayOwner, "e2e-recovery-scope"]);
+        transaction.objectStore("composerDrafts").put({
+          key: JSON.stringify([gatewayOwner, "e2e-recovery-scope", scopeKey]),
+          ownerKey,
+          gatewayOwner,
+          recoveryScope: "e2e-recovery-scope",
+          scopeKey,
+          text: "Mock Gateway: old durable draft",
+          revision: Date.now(),
+          updatedAt: Date.now(),
+          writeId: "upgrade-draft",
+          attachments: [
+            {
+              blob: new Blob(["draft bytes"], { type: "text/plain" }),
+              mimeType: "text/plain",
+              fileName: "draft.txt",
+            },
+          ],
+        });
+        await new Promise<void>((resolve, reject) => {
+          transaction.oncomplete = () => resolve();
+          transaction.addEventListener("abort", () =>
+            reject(transaction.error ?? new Error("IndexedDB transaction failed")),
+          );
+        });
+        database.close();
+      }, file.buffer.toString("base64"));
+      const gateway = await installMockGateway(page, {
+        historyMessages: history,
+        sessionInfo: {
+          key: "main",
+          hasActiveRun: true,
+          activeRunIds: ["mock-held-run"],
+          status: "running",
+        },
+        inFlightRun: { runId: "mock-held-run", text: "Mock Gateway: keeping upgrade queue held." },
+      });
+      await page.goto(`${suite.server.baseUrl}chat`, { waitUntil: "domcontentloaded" });
+      await expect
+        .poll(() => composerFor(page).inputValue())
+        .toBe("Mock Gateway: old durable draft");
+      await expect.poll(() => paneFor(page).locator(".chat-attachment-thumb").count()).toBe(1);
+      expect((await readQueue(page))[0]?.sendRunId).toBe("legacy-idempotency");
+      await gateway.setOnline(false);
+      await waitForControlUiGatewayReconnecting(page);
+      await composerFor(page).fill("Mock Gateway: newer independent draft");
+      const row = paneFor(page).locator(".chat-queue__item");
+      await row.dblclick();
+      await row.locator(".chat-queue__edit-input").fill("cancel this edit");
+      await row.locator(".chat-queue__edit-cancel").click();
+      expect((await readQueue(page))[0]?.text).toBe("Mock Gateway: upgrade this inline queue");
+      await row.dblclick();
+      await row.locator(".chat-queue__edit-input").fill("Mock Gateway: edited with original bytes");
+      await row.locator(".chat-queue__edit-submit").click();
+      try {
+        await expect
+          .poll(async () => (await readQueue(page))[0]?.text)
+          .toBe("Mock Gateway: edited with original bytes");
+      } catch (error) {
+        const bodyText = await page.locator("body").textContent();
+        assert(bodyText !== null, "Expected a body for the failure capture");
+        await writeFile(path.join(proofDir, "upgrade-failure.txt"), bodyText);
+        await page.screenshot({ path: path.join(proofDir, "upgrade-failure.png"), fullPage: true });
+        throw error;
+      }
+      expect((await readQueue(page))[0]?.attachmentPayload).toBeDefined();
+      expect(await composerFor(page).inputValue()).toBe("Mock Gateway: newer independent draft");
+      expect(await paneFor(page).locator(".chat-attachment-thumb").count()).toBe(1);
+      await expect.poll(() => payloadCount(page)).toBe(1);
+      await row.getByRole("button", { name: "Remove queued message", exact: true }).click();
+      await expect.poll(() => payloadCount(page)).toBe(0);
+      expect(await composerFor(page).inputValue()).toBe("Mock Gateway: newer independent draft");
+      await expectRequestCountStable(gateway, "chat.send", 0);
+    });
+  });
+
+  it("does not clear newer composer input while native Blob admission is waiting", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        historyMessages: history,
+        sessionInfo: { key: "main", hasActiveRun: false, status: "done" },
+        deferredMethods: ["chat.send"],
+      });
+      await page.goto(`${suite.server.baseUrl}chat`, { waitUntil: "domcontentloaded" });
+      await paneFor(page)
+        .getByText("Mock Gateway: payload lifecycle proof.", { exact: true })
+        .waitFor();
+      await stage(page, "Mock Gateway: captured before storage wait");
+      const gate = await page.evaluateHandle(async () => {
+        const database = await new Promise<IDBDatabase>((resolve, reject) => {
+          const request = indexedDB.open("openclaw-control-ui", 2);
+          request.onsuccess = () => resolve(request.result);
+          request.addEventListener("error", () =>
+            reject(request.error ?? new Error("IndexedDB request failed")),
+          );
+        });
+        let hold = true;
+        const transaction = database.transaction("outboxPayloads", "readwrite");
+        const next = () => {
+          const request = transaction.objectStore("outboxPayloads").get("hold-native-transaction");
+          request.onsuccess = () => {
+            if (hold) {
+              next();
+            }
+          };
+        };
+        next();
+        transaction.oncomplete = () => database.close();
+        return {
+          release: () => {
+            hold = false;
+          },
+        };
+      });
+      await paneFor(page).getByRole("button", { name: "Send message", exact: true }).click();
+      await composerFor(page).fill("Mock Gateway: newer input must survive");
+      expect(await readQueue(page)).toEqual([]);
+      await expectRequestCountStable(gateway, "chat.send", 0);
+      await gate.evaluate((value) => value.release());
+      await gate.dispose();
+      const sent = await gateway.waitForRequest("chat.send");
+      expect(sent.params).toEqual(
+        expect.objectContaining({
+          message: "Mock Gateway: captured before storage wait",
+          attachments: [
+            {
+              type: "file",
+              mimeType: file.mimeType,
+              fileName: file.name,
+              content: file.buffer.toString("base64"),
+            },
+          ],
+        }),
+      );
+      expect(await composerFor(page).inputValue()).toBe("Mock Gateway: newer input must survive");
+      expect(await paneFor(page).locator(".chat-attachment-thumb").count()).toBe(1);
+    });
+  });
+  it("keeps another credential owner isolated and retains a corrupt bundle without sending partial content", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        historyMessages: history,
+        sessionInfo: { key: "main", hasActiveRun: false, status: "done" },
+      });
+      await page.goto(`${suite.server.baseUrl}chat`, { waitUntil: "domcontentloaded" });
+      await paneFor(page)
+        .getByText("Mock Gateway: payload lifecycle proof.", { exact: true })
+        .waitFor();
+      const hello = await page.evaluate(
+        () =>
+          (
+            document.querySelector("openclaw-app") as unknown as {
+              runtime: {
+                context: { gateway: { snapshot: { hello: { auth: Record<string, unknown> } } } };
+              };
+            }
+          ).runtime.context.gateway.snapshot.hello,
+      );
+      await gateway.setOnline(false);
+      await waitForControlUiGatewayReconnecting(page);
+      await stage(page, "Mock Gateway: credential-owned bytes");
+      await paneFor(page).getByRole("button", { name: "Send message", exact: true }).click();
+      await expect.poll(async () => (await readQueue(page)).length).toBe(1);
+      const original = (await readQueue(page))[0]!;
+      await gateway.setMethodResponse("connect", {
+        ...hello,
+        auth: { ...hello.auth, recoveryScope: "e2e-other-owner" },
+      });
+      await gateway.setOnline(true);
+      await waitForControlUiGatewayReady(page);
+      await expect
+        .poll(() =>
+          paneFor(page).evaluate(
+            (pane) =>
+              (pane as unknown as { state: { client: { recoveryScope: string } } }).state.client
+                .recoveryScope,
+          ),
+        )
+        .toBe("e2e-other-owner");
+      await expect.poll(() => paneFor(page).locator(".chat-queue__item").count()).toBe(0);
+      await expectRequestCountStable(gateway, "chat.send", 0);
+      expect((await readQueue(page))[0]?.sendRunId).toBe(original.sendRunId);
+      await page.evaluate(async () => {
+        const database = await new Promise<IDBDatabase>((resolve, reject) => {
+          const request = indexedDB.open("openclaw-control-ui");
+          request.addEventListener("success", () => resolve(request.result));
+          request.addEventListener("error", () =>
+            reject(request.error ?? new Error("IDB open failed")),
+          );
+        });
+        const transaction = database.transaction("outboxPayloads", "readwrite");
+        const store = transaction.objectStore("outboxPayloads");
+        const request = store.openCursor();
+        request.addEventListener("success", () => {
+          const cursor = request.result;
+          if (!cursor) {
+            return;
+          }
+          const record = cursor.value;
+          record.attachments[0].blob = "corrupt";
+          cursor.update(record);
+          cursor.continue();
+        });
+        await new Promise<void>((resolve, reject) => {
+          transaction.addEventListener("complete", () => resolve());
+          transaction.addEventListener("abort", () =>
+            reject(transaction.error ?? new Error("IDB abort")),
+          );
+        });
+        database.close();
+      });
+      await gateway.setOnline(false);
+      await waitForControlUiGatewayReconnecting(page);
+      await gateway.setMethodResponse("connect", hello);
+      await gateway.setOnline(true);
+      await expect
+        .poll(async () => (await readQueue(page))[0]?.attachmentStorageError)
+        .toBe("missing");
+      await expect
+        .poll(() => page.locator("body").textContent())
+        .toContain("Queued attachments are missing or unreadable");
+      await expectRequestCountStable(gateway, "chat.send", 0);
+      expect((await readQueue(page))[0]?.id).toBe(original.id);
+      await page.screenshot({
+        path: path.join(proofDir, "corrupt-payload-retained.png"),
+        animations: "disabled",
+        fullPage: true,
+      });
+    });
+  });
+});

--- a/ui/src/e2e/composer-draft-store.e2e.test.ts
+++ b/ui/src/e2e/composer-draft-store.e2e.test.ts
@@ -23,7 +23,7 @@ async function rawDraftRecords(page: Page, scopes: readonly TestDraftScope[], ex
           });
         });
       const database = await requestResult(
-        indexedDB.open("openclaw-control-ui", 1),
+        indexedDB.open("openclaw-control-ui"),
         "IndexedDB open failed",
       );
       const transaction = database.transaction(
@@ -683,7 +683,7 @@ suite.define(() => {
           );
           resetLineagePersistence.activateRoute(resetLineageScope.scopeKey);
           await waitFor(async () => resetLineageState.message === "cached predecessor");
-          const databaseRequest = indexedDB.open("openclaw-control-ui", 1);
+          const databaseRequest = indexedDB.open("openclaw-control-ui");
           const database = await new Promise<IDBDatabase>((resolve, reject) => {
             databaseRequest.addEventListener("success", () => resolve(databaseRequest.result), {
               once: true,

--- a/ui/src/e2e/session-management.delete.e2e.test.ts
+++ b/ui/src/e2e/session-management.delete.e2e.test.ts
@@ -52,14 +52,19 @@ suite.define(() => {
       const draftStore = await page.evaluateHandle<
         typeof import("../lib/chat/composer-draft-store.runtime.ts")
       >('import("/src/lib/chat/composer-draft-store.runtime.ts")');
+      const outboxStore = await page.evaluateHandle<typeof import("../lib/chat/outbox-store.ts")>(
+        'import("/src/lib/chat/outbox-store.ts")',
+      );
       const owner = await page.evaluate(
-        async ({ store, sessionKeys }) => {
+        async ({ store, outbox, sessionKeys }) => {
           const client = (document.querySelector("openclaw-app") as DraftDeletionTestApp).runtime
             ?.context.gateway.snapshot.client;
           if (!client?.recoveryScope) {
             throw new Error("Gateway recovery scope unavailable");
           }
-          const gatewayOwner = client.gatewayUrl.trim() || "default";
+          const { gatewayOwner, key: storageKey } = outbox.storageTargetForGateway(
+            client.gatewayUrl,
+          );
           const sessions = Object.fromEntries(
             sessionKeys.map((key, index) => [
               `${key}\u0000agent:main`,
@@ -72,8 +77,8 @@ suite.define(() => {
             ]),
           );
           sessionStorage.setItem(
-            `openclaw.control.chatComposer.v2:${encodeURIComponent(gatewayOwner)}`,
-            JSON.stringify({ version: 2, gatewayOwner, sessions }),
+            storageKey,
+            JSON.stringify({ version: 3, gatewayOwner, sessions }),
           );
           const recoveryScope = client.recoveryScope;
           await Promise.all(
@@ -89,9 +94,9 @@ suite.define(() => {
               ),
             ),
           );
-          return { gatewayOwner, recoveryScope };
+          return { gatewayOwner, recoveryScope, storageKey };
         },
-        { store: draftStore, sessionKeys: keys },
+        { store: draftStore, outbox: outboxStore, sessionKeys: keys },
       );
       const deleteFromRuntime = (sessionKeys: string[]) =>
         page.evaluate(async (targets) => {
@@ -125,7 +130,7 @@ suite.define(() => {
       await gateway.waitForRequest("sessions.delete", { after: requestsBeforeReplacement });
       const inFlightRevision = await page.evaluate(
         async ({ store, key, scopeOwner }) => {
-          const storageKey = `openclaw.control.chatComposer.v2:${encodeURIComponent(scopeOwner.gatewayOwner)}`;
+          const storageKey = scopeOwner.storageKey;
           const local = JSON.parse(sessionStorage.getItem(storageKey) ?? "{}") as {
             sessions: Record<string, unknown>;
           };
@@ -155,7 +160,7 @@ suite.define(() => {
         .poll(() =>
           page.evaluate(
             async ({ store, key, scopeOwner }) => {
-              const storageKey = `openclaw.control.chatComposer.v2:${encodeURIComponent(scopeOwner.gatewayOwner)}`;
+              const storageKey = scopeOwner.storageKey;
               const local = JSON.parse(sessionStorage.getItem(storageKey) ?? "{}") as {
                 sessions?: Record<string, { draft?: string; queue?: unknown[] }>;
               };
@@ -174,7 +179,7 @@ suite.define(() => {
 
       await page.evaluate(
         async ({ store, key, scopeOwner }) => {
-          const storageKey = `openclaw.control.chatComposer.v2:${encodeURIComponent(scopeOwner.gatewayOwner)}`;
+          const storageKey = scopeOwner.storageKey;
           const local = JSON.parse(sessionStorage.getItem(storageKey) ?? "{}") as {
             sessions: Record<string, { draft?: string; draftRevision?: number }>;
           };
@@ -209,11 +214,9 @@ suite.define(() => {
         .poll(() =>
           page.evaluate(
             async ({ store, sessionKeys, scopeOwner }) => {
-              const local = JSON.parse(
-                sessionStorage.getItem(
-                  `openclaw.control.chatComposer.v2:${encodeURIComponent(scopeOwner.gatewayOwner)}`,
-                ) ?? "{}",
-              ) as { sessions?: Record<string, { draft?: string; queue?: unknown[] }> };
+              const local = JSON.parse(sessionStorage.getItem(scopeOwner.storageKey) ?? "{}") as {
+                sessions?: Record<string, { draft?: string; queue?: unknown[] }>;
+              };
               return Object.fromEntries(
                 await Promise.all(
                   sessionKeys.map(async (key) => {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5339,6 +5339,14 @@ export const en: TranslationMap = {
         "{percent}% used · {free} free. New writes may fail and stop the agent. Delete unneeded files or stop the cloud worker before large writes.",
     },
     sendErrors: {
+      outboxPayloadCopied:
+        "This queued message was copied from another tab. Check the conversation and retry only if it has not arrived.",
+      outboxPayloadCapacity:
+        "Browser attachment storage is full. Try a smaller batch or send/discard queued messages to free space. No new message was sent; your input is retained.",
+      outboxPayloadUnavailable:
+        "Browser attachment storage is unavailable. Use HTTPS or localhost, allow browser storage, and close older dashboard tabs before reconnecting and retrying. No new message was sent.",
+      outboxPayloadMissing:
+        "Queued attachments are missing or unreadable. This may be a stale copy from another tab. Check the conversation, then discard this row and attach the files again if needed. No new message was sent.",
       activeLeafChanged: "The session switched branches — review and resend.",
     },
     waitingForApproval: "Waiting for approval…",

--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -82,6 +82,9 @@ export type ChatQueueItem = {
   createdAt: number;
   /** Operator-owned queue position; absent means "wherever arrival put it". */
   orderKey?: number;
+  /** Immutable binary bundle; metadata stays in this tab’s outbox. */
+  attachmentPayload?: { key: string; recoveryScope: string; scopeKey: string; tabId: string };
+  attachmentStorageError?: "capacity" | "unavailable" | "missing";
   attachments?: ChatAttachment[];
   refreshSessions?: boolean;
   /** Transcript id of the replied-to message; Gateway hydrates reply context. */

--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -82,8 +82,8 @@ export type ChatQueueItem = {
   createdAt: number;
   /** Operator-owned queue position; absent means "wherever arrival put it". */
   orderKey?: number;
-  /** Immutable binary bundle; metadata stays in this tab’s outbox. */
-  attachmentPayload?: { key: string; recoveryScope: string; scopeKey: string; tabId: string };
+  /** Immutable bytes belong to this queued input; routing belongs to the outbox metadata. */
+  attachmentPayload?: { key: string; recoveryScope: string; tabId: string };
   attachmentStorageError?: "capacity" | "unavailable" | "missing";
   attachments?: ChatAttachment[];
   refreshSessions?: boolean;

--- a/ui/src/lib/chat/composer-draft-retirement.runtime.ts
+++ b/ui/src/lib/chat/composer-draft-retirement.runtime.ts
@@ -5,7 +5,8 @@ import { retireSessionPaneHandoffs } from "../../pages/chat/chat-pane-shared.ts"
 import { deleteStoredChatSessionSnapshots } from "../../pages/chat/session-snapshot-invalidation.runtime.ts";
 import { showToast } from "../toast.ts";
 import { retireDurableComposerDrafts } from "./composer-draft-store.runtime.ts";
-import { retireStoredComposerDrafts, storedChatOutboxScopeKey } from "./outbox-store.ts";
+import { retireStoredComposerDrafts } from "./outbox-store-retirement.ts";
+import { storedChatOutboxScopeKey } from "./outbox-store.ts";
 
 type DeletedComposerDraftTarget = {
   key: string;

--- a/ui/src/lib/chat/composer-draft-store.runtime.ts
+++ b/ui/src/lib/chat/composer-draft-store.runtime.ts
@@ -1,9 +1,12 @@
 // Keep IndexedDB outside the startup graph; composers and session deletion load it on demand.
 import type { BrowserAnnotationAttachment, ChatGoalDraftMode } from "./chat-types.ts";
+import {
+  openControlUiDatabase,
+  requestResult,
+  transactionComplete,
+} from "./control-ui-database.runtime.ts";
 import { isChatGoalDraftMode } from "./goal-draft.ts";
 
-const DATABASE_NAME = "openclaw-control-ui";
-const DATABASE_VERSION = 1;
 const STORE_NAME = "composerDrafts";
 const OWNER_INDEX = "ownerKey";
 const DRAFT_EXPIRY_MS = 7 * 24 * 60 * 60 * 1_000;
@@ -54,8 +57,18 @@ type DurableComposerDraftWriteResult =
   | { status: "payload-too-large"; revision?: number; writeId?: string }
   | { status: "storage-failed" };
 
-let databasePromise: Promise<IDBDatabase> | null = null;
 let lastFenceRevision = 0;
+
+let sweptDatabase: IDBDatabase | null = null;
+async function openDraftDatabase(): Promise<IDBDatabase> {
+  const database = await openControlUiDatabase();
+  if (sweptDatabase !== database) {
+    sweptDatabase = database;
+    // Draft expiry never visits outbox payloads: live queues have no age limit.
+    globalThis.setTimeout(() => void sweepExpiredRecords(database).catch(() => undefined), 0);
+  }
+  return database;
+}
 
 function ownerKey(scope: DurableComposerDraftScope): string {
   return JSON.stringify([scope.gatewayOwner, scope.recoveryScope]);
@@ -69,96 +82,6 @@ function nextFenceRevision(baseline: number): number {
   const revision = Math.max(Date.now(), baseline + 1, lastFenceRevision + 1);
   lastFenceRevision = revision;
   return revision;
-}
-
-function indexedDbError(error: DOMException | null, message: string): Error {
-  return error ?? new Error(message);
-}
-
-function requestResult<T>(request: IDBRequest<T>): Promise<T> {
-  return new Promise((resolve, reject) => {
-    request.addEventListener("success", () => resolve(request.result), { once: true });
-    request.addEventListener(
-      "error",
-      () => reject(indexedDbError(request.error, "IndexedDB request failed")),
-      { once: true },
-    );
-  });
-}
-
-function transactionComplete(transaction: IDBTransaction): Promise<void> {
-  return new Promise((resolve, reject) => {
-    transaction.addEventListener("complete", () => resolve(), { once: true });
-    transaction.addEventListener(
-      "abort",
-      () => reject(indexedDbError(transaction.error, "IndexedDB transaction aborted")),
-      { once: true },
-    );
-    transaction.addEventListener(
-      "error",
-      () => reject(indexedDbError(transaction.error, "IndexedDB transaction failed")),
-      { once: true },
-    );
-  });
-}
-
-function openDatabase(): Promise<IDBDatabase> {
-  if (databasePromise) {
-    return databasePromise;
-  }
-  databasePromise = new Promise((resolve, reject) => {
-    if (typeof indexedDB === "undefined") {
-      reject(new Error("IndexedDB is unavailable"));
-      return;
-    }
-    const request = indexedDB.open(DATABASE_NAME, DATABASE_VERSION);
-    request.addEventListener(
-      "upgradeneeded",
-      () => {
-        const database = request.result;
-        const store = database.objectStoreNames.contains(STORE_NAME)
-          ? request.transaction?.objectStore(STORE_NAME)
-          : database.createObjectStore(STORE_NAME, { keyPath: "key" });
-        if (store && !store.indexNames.contains(OWNER_INDEX)) {
-          store.createIndex(OWNER_INDEX, OWNER_INDEX, { unique: false });
-        }
-      },
-      { once: true },
-    );
-    request.addEventListener(
-      "success",
-      () => {
-        const database = request.result;
-        database.addEventListener("versionchange", () => {
-          database.close();
-          databasePromise = null;
-        });
-        resolve(database);
-        // Expiry cleanup spans every owner and must not hold foreground draft reads
-        // behind a database-wide cursor scan. Start it in the next task so the
-        // operation that opened the database registers its transaction first.
-        globalThis.setTimeout(() => void sweepExpiredRecords(database).catch(() => undefined), 0);
-      },
-      { once: true },
-    );
-    request.addEventListener(
-      "error",
-      () => {
-        databasePromise = null;
-        reject(indexedDbError(request.error, "IndexedDB open failed"));
-      },
-      { once: true },
-    );
-    request.addEventListener(
-      "blocked",
-      () => {
-        databasePromise = null;
-        reject(new Error("IndexedDB upgrade was blocked"));
-      },
-      { once: true },
-    );
-  });
-  return databasePromise;
 }
 
 function isStoredAttachment(value: unknown): value is DurableComposerDraftAttachment {
@@ -286,7 +209,7 @@ export async function readDurableComposerDraft(
   scope: DurableComposerDraftScope,
 ): Promise<DurableComposerDraftReadResult> {
   try {
-    const database = await openDatabase();
+    const database = await openDraftDatabase();
     const transaction = database.transaction(STORE_NAME, "readwrite");
     const store = transaction.objectStore(STORE_NAME);
     const value = await requestResult(store.get(recordKey(scope)));
@@ -365,7 +288,7 @@ export async function writeDurableComposerDraft(
       : fallbackResult;
   }
   try {
-    const database = await openDatabase();
+    const database = await openDraftDatabase();
     const transaction = database.transaction(STORE_NAME, "readwrite");
     const store = transaction.objectStore(STORE_NAME);
     const key = recordKey(scope);
@@ -414,7 +337,7 @@ export async function retireDurableComposerDraft(
   retireBeforeRevision?: number,
 ): Promise<DurableComposerDraftWriteResult> {
   try {
-    const database = await openDatabase();
+    const database = await openDraftDatabase();
     const transaction = database.transaction(STORE_NAME, "readwrite");
     const store = transaction.objectStore(STORE_NAME);
     const now = Date.now();
@@ -475,7 +398,7 @@ export async function retireDurableComposerDrafts(
   }[],
 ): Promise<"completed" | "storage-failed"> {
   try {
-    const database = await openDatabase();
+    const database = await openDraftDatabase();
     const transaction = database.transaction(STORE_NAME, "readwrite");
     const store = transaction.objectStore(STORE_NAME);
     const now = Date.now();

--- a/ui/src/lib/chat/control-ui-database.runtime.ts
+++ b/ui/src/lib/chat/control-ui-database.runtime.ts
@@ -1,0 +1,102 @@
+const DATABASE_NAME = "openclaw-control-ui";
+const DATABASE_VERSION = 2;
+const STORE_NAME = "composerDrafts";
+const OWNER_INDEX = "ownerKey";
+let databasePromise: Promise<IDBDatabase> | null = null;
+
+function indexedDbError(error: DOMException | null, message: string): Error {
+  return error ?? new Error(message);
+}
+
+export function requestResult<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.addEventListener("success", () => resolve(request.result), { once: true });
+    request.addEventListener(
+      "error",
+      () => reject(indexedDbError(request.error, "IndexedDB request failed")),
+      { once: true },
+    );
+  });
+}
+
+export function transactionComplete(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.addEventListener("complete", () => resolve(), { once: true });
+    transaction.addEventListener(
+      "abort",
+      () => reject(indexedDbError(transaction.error, "IndexedDB transaction aborted")),
+      { once: true },
+    );
+    transaction.addEventListener(
+      "error",
+      () => reject(indexedDbError(transaction.error, "IndexedDB transaction failed")),
+      { once: true },
+    );
+  });
+}
+
+export function openControlUiDatabase(): Promise<IDBDatabase> {
+  if (databasePromise) {
+    return databasePromise;
+  }
+  databasePromise = new Promise((resolve, reject) => {
+    if (typeof indexedDB === "undefined") {
+      reject(new Error("IndexedDB is unavailable"));
+      return;
+    }
+    const request = indexedDB.open(DATABASE_NAME, DATABASE_VERSION);
+    request.addEventListener(
+      "upgradeneeded",
+      () => {
+        const database = request.result;
+        if (!database.objectStoreNames.contains("outboxPayloads")) {
+          database.createObjectStore("outboxPayloads", { keyPath: "key" });
+        }
+        const store = database.objectStoreNames.contains(STORE_NAME)
+          ? request.transaction?.objectStore(STORE_NAME)
+          : database.createObjectStore(STORE_NAME, { keyPath: "key" });
+        if (store && !store.indexNames.contains(OWNER_INDEX)) {
+          store.createIndex(OWNER_INDEX, OWNER_INDEX, { unique: false });
+        }
+      },
+      { once: true },
+    );
+    let blocked = false;
+    request.addEventListener(
+      "success",
+      () => {
+        const database = request.result;
+        if (blocked) {
+          database.close();
+          databasePromise = null;
+          return;
+        }
+        database.addEventListener("versionchange", () => {
+          database.close();
+          databasePromise = null;
+        });
+        resolve(database);
+      },
+      { once: true },
+    );
+    request.addEventListener(
+      "error",
+      () => {
+        databasePromise = null;
+        reject(indexedDbError(request.error, "IndexedDB open failed"));
+      },
+      { once: true },
+    );
+    request.addEventListener(
+      "blocked",
+      () => {
+        // Keep the rejected promise until this open finishes. A second open
+        // queues behind it and would otherwise wait forever without a blocked event.
+        blocked = true;
+        reject(new Error("IndexedDB upgrade was blocked"));
+      },
+      { once: true },
+    );
+  });
+  return databasePromise;
+}

--- a/ui/src/lib/chat/outbox-payload-store.runtime.ts
+++ b/ui/src/lib/chat/outbox-payload-store.runtime.ts
@@ -1,0 +1,205 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { getSafeSessionStorage } from "../../local-storage.ts";
+import type { ChatQueueItem } from "./chat-types.ts";
+import type { DurableComposerDraftAttachment } from "./composer-draft-store.runtime.ts";
+import {
+  openControlUiDatabase,
+  requestResult,
+  transactionComplete,
+} from "./control-ui-database.runtime.ts";
+
+const STORE_NAME = "outboxPayloads";
+const MAX_PAYLOAD_BYTES = 25 * 1024 * 1024;
+// Never evict a queued input to admit another one. The origin-wide bound also
+// bounds orphaned payloads after a tab closes without retiring its metadata.
+const MAX_RETAINED_BYTES = 250 * 1024 * 1024;
+const MAX_RETAINED_PAYLOADS = 1000;
+export type OutboxPayloadFailure = "capacity" | "unavailable" | "missing";
+type PayloadReference = NonNullable<ChatQueueItem["attachmentPayload"]>;
+type PayloadOwner = {
+  tabId: string;
+  gatewayOwner: string;
+  recoveryScope: string;
+  scopeKey: string;
+  queueId: string;
+};
+type PayloadResult<T> =
+  | { status: "ready"; value: T }
+  | { status: "failed"; reason: OutboxPayloadFailure };
+type StoredPayload = {
+  key: string;
+  owner: PayloadOwner;
+  bytes: number;
+  attachments: DurableComposerDraftAttachment[];
+};
+
+function storageFailure(error: unknown): { status: "failed"; reason: OutboxPayloadFailure } {
+  return {
+    status: "failed",
+    reason:
+      error instanceof DOMException && error.name === "QuotaExceededError"
+        ? "capacity"
+        : "unavailable",
+  };
+}
+
+export async function writeOutboxPayload(
+  owner: PayloadOwner,
+  attachments: DurableComposerDraftAttachment[],
+): Promise<PayloadResult<PayloadReference>> {
+  const bytes = attachments.reduce((total, attachment) => total + attachment.blob.size, 0);
+  if (bytes > MAX_PAYLOAD_BYTES) {
+    return { status: "failed", reason: "capacity" };
+  }
+  try {
+    const database = await openControlUiDatabase();
+    const transaction = database.transaction(STORE_NAME, "readwrite", { durability: "strict" });
+    const completed = transactionComplete(transaction);
+    const store = transaction.objectStore(STORE_NAME);
+    // IDB serializes this capacity check with every writer, including other tabs.
+    const records: unknown[] = await requestResult(store.getAll()).catch(async (error: unknown) => {
+      await completed;
+      throw error;
+    });
+    const retainedBytes = records.reduce<number>(
+      (total, value) =>
+        total +
+        (isRecord(value) &&
+        typeof value.bytes === "number" &&
+        Number.isSafeInteger(value.bytes) &&
+        value.bytes >= 0
+          ? value.bytes
+          : MAX_RETAINED_BYTES),
+      0,
+    );
+    if (records.length >= MAX_RETAINED_PAYLOADS || retainedBytes + bytes > MAX_RETAINED_BYTES) {
+      await completed;
+      return { status: "failed", reason: "capacity" };
+    }
+    const key = JSON.stringify([
+      owner.gatewayOwner,
+      owner.recoveryScope,
+      owner.scopeKey,
+      owner.queueId,
+      crypto.randomUUID(),
+    ]);
+    store.add({ key, owner, bytes, attachments } satisfies StoredPayload);
+    await completed;
+    return {
+      status: "ready",
+      value: {
+        key,
+        recoveryScope: owner.recoveryScope,
+        scopeKey: owner.scopeKey,
+        tabId: owner.tabId,
+      },
+    };
+  } catch (error) {
+    return storageFailure(error);
+  }
+}
+
+export async function readOutboxPayload(
+  owner: PayloadOwner,
+  reference: PayloadReference,
+): Promise<PayloadResult<DurableComposerDraftAttachment[]>> {
+  if (reference.recoveryScope !== owner.recoveryScope || reference.scopeKey !== owner.scopeKey) {
+    return { status: "failed", reason: "missing" };
+  }
+  try {
+    const database = await openControlUiDatabase();
+    const transaction = database.transaction(STORE_NAME);
+    const completed = transactionComplete(transaction);
+    const [value]: [unknown, void] = await Promise.all([
+      requestResult(transaction.objectStore(STORE_NAME).get(reference.key)),
+      completed,
+    ]);
+    if (
+      !isRecord(value) ||
+      !isRecord(value.owner) ||
+      value.key !== reference.key ||
+      value.owner.gatewayOwner !== owner.gatewayOwner ||
+      value.owner.recoveryScope !== owner.recoveryScope ||
+      value.owner.scopeKey !== owner.scopeKey ||
+      value.owner.queueId !== owner.queueId ||
+      value.owner.tabId !== reference.tabId ||
+      !Array.isArray(value.attachments) ||
+      !value.attachments.length
+    ) {
+      return { status: "failed", reason: "missing" };
+    }
+    const attachments: DurableComposerDraftAttachment[] = [];
+    for (const entry of value.attachments) {
+      if (
+        !isRecord(entry) ||
+        !(entry.blob instanceof Blob) ||
+        typeof entry.mimeType !== "string" ||
+        (entry.fileName !== undefined && typeof entry.fileName !== "string") ||
+        (entry.sizeBytes !== undefined && entry.sizeBytes !== entry.blob.size)
+      ) {
+        return { status: "failed", reason: "missing" };
+      }
+      attachments.push({
+        blob: entry.blob,
+        mimeType: entry.mimeType,
+        ...(typeof entry.fileName === "string" ? { fileName: entry.fileName } : {}),
+        ...(typeof entry.sizeBytes === "number" ? { sizeBytes: entry.sizeBytes } : {}),
+      });
+    }
+    if (
+      value.bytes !== attachments.reduce((total, attachment) => total + attachment.blob.size, 0)
+    ) {
+      return { status: "failed", reason: "missing" };
+    }
+    return { status: "ready", value: attachments };
+  } catch (error) {
+    return storageFailure(error);
+  }
+}
+
+export async function removeOutboxPayloads(references: readonly PayloadReference[]): Promise<void> {
+  try {
+    const database = await openControlUiDatabase();
+    const transaction = database.transaction(STORE_NAME, "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    for (const reference of references) {
+      store.delete(reference.key);
+    }
+    await transactionComplete(transaction);
+  } catch {
+    // Metadata retirement is authoritative. A failed cleanup consumes the bounded
+    // origin budget; it must not resurrect the row or turn an ACK into a retry.
+  }
+}
+
+const TAB_STORAGE_KEY = "openclaw.control.outboxTab.v1";
+let tabPromise: Promise<string> | null = null;
+export function outboxPayloadTab(): Promise<string> {
+  return (tabPromise ??= (async () => {
+    const storage = getSafeSessionStorage();
+    if (!storage || !globalThis.navigator?.locks) {
+      throw new Error("Outbox ownership unavailable");
+    }
+    const claim = (id: string) =>
+      new Promise<boolean>((resolve, reject) => {
+        void navigator.locks
+          .request(`openclaw-outbox:${id}`, { ifAvailable: true }, (lock) => {
+            resolve(Boolean(lock));
+            // A document holds its tab identity until the browser destroys it. A
+            // duplicated sessionStorage must claim a new identity before using bytes.
+            return lock ? new Promise<void>(() => {}) : undefined;
+          })
+          .catch(reject);
+      });
+    const previous = storage.getItem(TAB_STORAGE_KEY);
+    const id = previous && (await claim(previous)) ? previous : crypto.randomUUID();
+    if (id !== previous && !(await claim(id))) {
+      throw new Error("Outbox ownership unavailable");
+    }
+    storage.setItem(TAB_STORAGE_KEY, id);
+    return id;
+  })().catch((error: unknown) => {
+    tabPromise = null;
+    throw error;
+  }));
+}

--- a/ui/src/lib/chat/outbox-payload-store.runtime.ts
+++ b/ui/src/lib/chat/outbox-payload-store.runtime.ts
@@ -159,10 +159,17 @@ export async function readOutboxPayload(
 
 export async function removeOutboxPayloads(references: readonly PayloadReference[]): Promise<void> {
   try {
+    // Duplicated storage carries the source marker until adoption finishes. Only
+    // the document's held lock can authorize deletion, including cleanup callers.
+    const tabId = await outboxPayloadTab();
+    const owned = references.filter((reference) => reference.tabId === tabId);
+    if (!owned.length) {
+      return;
+    }
     const database = await openControlUiDatabase();
     const transaction = database.transaction(STORE_NAME, "readwrite");
     const store = transaction.objectStore(STORE_NAME);
-    for (const reference of references) {
+    for (const reference of owned) {
       store.delete(reference.key);
     }
     await transactionComplete(transaction);

--- a/ui/src/lib/chat/outbox-payload-store.runtime.ts
+++ b/ui/src/lib/chat/outbox-payload-store.runtime.ts
@@ -20,7 +20,6 @@ type PayloadOwner = {
   tabId: string;
   gatewayOwner: string;
   recoveryScope: string;
-  scopeKey: string;
   queueId: string;
 };
 type PayloadResult<T> =
@@ -79,7 +78,6 @@ export async function writeOutboxPayload(
     const key = JSON.stringify([
       owner.gatewayOwner,
       owner.recoveryScope,
-      owner.scopeKey,
       owner.queueId,
       crypto.randomUUID(),
     ]);
@@ -90,7 +88,6 @@ export async function writeOutboxPayload(
       value: {
         key,
         recoveryScope: owner.recoveryScope,
-        scopeKey: owner.scopeKey,
         tabId: owner.tabId,
       },
     };
@@ -103,7 +100,7 @@ export async function readOutboxPayload(
   owner: PayloadOwner,
   reference: PayloadReference,
 ): Promise<PayloadResult<DurableComposerDraftAttachment[]>> {
-  if (reference.recoveryScope !== owner.recoveryScope || reference.scopeKey !== owner.scopeKey) {
+  if (reference.recoveryScope !== owner.recoveryScope) {
     return { status: "failed", reason: "missing" };
   }
   try {
@@ -120,7 +117,6 @@ export async function readOutboxPayload(
       value.key !== reference.key ||
       value.owner.gatewayOwner !== owner.gatewayOwner ||
       value.owner.recoveryScope !== owner.recoveryScope ||
-      value.owner.scopeKey !== owner.scopeKey ||
       value.owner.queueId !== owner.queueId ||
       value.owner.tabId !== reference.tabId ||
       !Array.isArray(value.attachments) ||

--- a/ui/src/lib/chat/outbox-store-codec.ts
+++ b/ui/src/lib/chat/outbox-store-codec.ts
@@ -84,13 +84,11 @@ export function normalizeStoredQueueItem(value: unknown): ChatQueueItem | null {
       isRecord(payload) &&
       typeof payload.key === "string" &&
       typeof payload.recoveryScope === "string" &&
-      typeof payload.scopeKey === "string" &&
       typeof payload.tabId === "string"
     ) {
       item.attachmentPayload = {
         key: payload.key,
         recoveryScope: payload.recoveryScope,
-        scopeKey: payload.scopeKey,
         tabId: payload.tabId,
       };
     } else {

--- a/ui/src/lib/chat/outbox-store-codec.ts
+++ b/ui/src/lib/chat/outbox-store-codec.ts
@@ -63,7 +63,13 @@ export function normalizeStoredQueueItem(value: unknown): ChatQueueItem | null {
     typeof entry.createdAt === "number" && Number.isFinite(entry.createdAt)
       ? entry.createdAt
       : Date.now();
-  if (!id || (!text.trim() && !Array.isArray(entry.attachments))) {
+  if (
+    !id ||
+    (!text.trim() &&
+      !Array.isArray(entry.attachments) &&
+      entry.attachmentPayload === undefined &&
+      entry.attachmentStorageError === undefined)
+  ) {
     return null;
   }
   const attachments = Array.isArray(entry.attachments)
@@ -72,6 +78,39 @@ export function normalizeStoredQueueItem(value: unknown): ChatQueueItem | null {
         .filter((item): item is ChatAttachment => item !== null)
     : [];
   const item: ChatQueueItem = { id, text, createdAt };
+  if (entry.attachmentPayload !== undefined) {
+    const payload = entry.attachmentPayload;
+    if (
+      isRecord(payload) &&
+      typeof payload.key === "string" &&
+      typeof payload.recoveryScope === "string" &&
+      typeof payload.scopeKey === "string" &&
+      typeof payload.tabId === "string"
+    ) {
+      item.attachmentPayload = {
+        key: payload.key,
+        recoveryScope: payload.recoveryScope,
+        scopeKey: payload.scopeKey,
+        tabId: payload.tabId,
+      };
+    } else {
+      item.attachmentStorageError = "missing";
+    }
+  }
+  if (
+    entry.attachmentStorageError === "missing" ||
+    entry.attachmentStorageError === "unavailable" ||
+    entry.attachmentStorageError === "capacity"
+  ) {
+    item.attachmentStorageError = entry.attachmentStorageError;
+  }
+  if (Array.isArray(entry.attachments) && attachments.length !== entry.attachments.length) {
+    item.attachmentStorageError = "missing";
+  }
+  if (item.attachmentPayload && !attachments.length) {
+    item.attachmentStorageError = "missing";
+  }
+
   if (entry.intent !== undefined) {
     const intent = entry.intent;
     // Never restore a structured admission as ordinary text after losing its intent.

--- a/ui/src/lib/chat/outbox-store-projection.ts
+++ b/ui/src/lib/chat/outbox-store-projection.ts
@@ -102,6 +102,11 @@ export function listStoredChatOutboxes(state: ChatComposerScope): StoredChatOutb
               sessionKey: scope.conversationKey,
               ...(scope.routingAgentId ? { agentId: scope.routingAgentId } : {}),
               queue: session.queue
+                .filter(
+                  (item) =>
+                    !item.attachmentPayload ||
+                    item.attachmentPayload.recoveryScope === state.client?.recoveryScope,
+                )
                 .map((item) => applyStoredChatOutboxScope(item, scope))
                 .toSorted(compareChatQueueOrder),
             },

--- a/ui/src/lib/chat/outbox-store-retirement.ts
+++ b/ui/src/lib/chat/outbox-store-retirement.ts
@@ -1,0 +1,148 @@
+import { getSafeSessionStorage } from "../../local-storage.ts";
+import { normalizeStoredSession } from "./outbox-store-codec.ts";
+import {
+  nextDraftRevision,
+  rememberedDraftAttempt,
+  rememberedDraftRevision,
+  rememberDraftAttempt,
+  rememberDraftRevision,
+} from "./outbox-store-draft-state.ts";
+import {
+  storageTargetForGateway,
+  resolveComposerStorageScope,
+  resolveStoredComposerSession,
+  writeStoredOutboxStore,
+  readStoredOutboxStore,
+  notifyStoredChatOutboxChanges,
+  type ChatComposerScope,
+  type StoredChatOutboxScope,
+} from "./outbox-store.ts";
+type StoredComposerRetirementTarget = {
+  key: string;
+  agentId?: string;
+  retireBeforeRevision: number;
+};
+
+type StoredComposerRetirement = {
+  scope: StoredChatOutboxScope;
+  minimumRevision: number;
+  retireBeforeRevision: number;
+};
+
+export function retireStoredComposerDrafts(
+  state: ChatComposerScope,
+  targets: readonly StoredComposerRetirementTarget[],
+) {
+  const storageTarget = storageTargetForGateway(state.settings?.gatewayUrl);
+  if (targets.length === 0) {
+    return { gatewayOwner: storageTarget.gatewayOwner, retirements: [], storageFailed: false };
+  }
+  const storage = getSafeSessionStorage();
+  if (!storage) {
+    return {
+      gatewayOwner: storageTarget.gatewayOwner,
+      retirements: targets.flatMap((target) => {
+        if (!target.key.trim()) {
+          return [];
+        }
+        const resolved = resolveComposerStorageScope(state, target.key, target.agentId);
+        return [
+          {
+            scope: {
+              sessionKey: resolved.conversationKey,
+              ...(resolved.routingAgentId ? { agentId: resolved.routingAgentId } : {}),
+            },
+            minimumRevision: target.retireBeforeRevision,
+            retireBeforeRevision: target.retireBeforeRevision,
+          },
+        ];
+      }),
+      storageFailed: true,
+    };
+  }
+
+  const retirements: StoredComposerRetirement[] = [];
+  const written: Array<{ storeSessionKey: string; revision: number }> = [];
+  let visibleChanged = false;
+  try {
+    const store = readStoredOutboxStore(storage, storageTarget);
+    let changed = false;
+    for (const target of targets) {
+      if (!target.key.trim()) {
+        return { gatewayOwner: storageTarget.gatewayOwner, retirements, storageFailed: true };
+      }
+      const resolved = resolveComposerStorageScope(
+        state,
+        target.key,
+        target.agentId,
+        store.mainAlias,
+      );
+      const scope: StoredChatOutboxScope = {
+        sessionKey: resolved.conversationKey,
+        ...(resolved.routingAgentId ? { agentId: resolved.routingAgentId } : {}),
+      };
+      const resolvedSession = resolveStoredComposerSession(
+        store,
+        state,
+        scope.sessionKey,
+        scope.agentId,
+      );
+      changed ||= resolvedSession.migrated;
+      const storedRevision = resolvedSession.session?.draftRevision ?? 0;
+      const currentRevision = Math.max(
+        storedRevision,
+        rememberedDraftRevision(storage, storageTarget.key, resolvedSession.storeSessionKey),
+        rememberedDraftAttempt(storage, storageTarget.key, resolvedSession.storeSessionKey),
+      );
+      let minimumRevision = target.retireBeforeRevision;
+      if (storedRevision < target.retireBeforeRevision) {
+        minimumRevision = nextDraftRevision(Math.max(currentRevision, target.retireBeforeRevision));
+        rememberDraftAttempt(
+          storage,
+          storageTarget.key,
+          resolvedSession.storeSessionKey,
+          minimumRevision,
+        );
+        visibleChanged ||=
+          Boolean(resolvedSession.session?.draft) ||
+          Boolean(resolvedSession.session?.queue?.length);
+        store.sessions[resolvedSession.storeSessionKey] = {
+          draftRevision: minimumRevision,
+          updatedAt: Date.now(),
+        };
+        written.push({
+          storeSessionKey: resolvedSession.storeSessionKey,
+          revision: minimumRevision,
+        });
+        changed = true;
+      }
+      retirements.push({
+        scope,
+        minimumRevision,
+        retireBeforeRevision: target.retireBeforeRevision,
+      });
+    }
+    if (!changed) {
+      return { gatewayOwner: storageTarget.gatewayOwner, retirements, storageFailed: false };
+    }
+    writeStoredOutboxStore(storage, storageTarget, store);
+    const persisted = readStoredOutboxStore(storage, storageTarget);
+    for (const { storeSessionKey, revision } of written) {
+      const session = normalizeStoredSession(persisted.sessions[storeSessionKey]);
+      if (
+        session?.draftRevision !== revision ||
+        Boolean(session.draft) ||
+        Boolean(session.queue?.length)
+      ) {
+        return { gatewayOwner: storageTarget.gatewayOwner, retirements, storageFailed: true };
+      }
+      rememberDraftRevision(storage, storageTarget.key, storeSessionKey, revision);
+    }
+    if (visibleChanged) {
+      notifyStoredChatOutboxChanges();
+    }
+    return { gatewayOwner: storageTarget.gatewayOwner, retirements, storageFailed: false };
+  } catch {
+    return { gatewayOwner: storageTarget.gatewayOwner, retirements, storageFailed: true };
+  }
+}

--- a/ui/src/lib/chat/outbox-store.test.ts
+++ b/ui/src/lib/chat/outbox-store.test.ts
@@ -2,12 +2,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { listStoredChatOutboxes, summarizeStoredChatOutboxes } from "./outbox-store-projection.ts";
+import { retireStoredComposerDrafts } from "./outbox-store-retirement.ts";
 import {
   readProjectedOutboxStore,
+  readStoredOutboxStore,
   resolveStoredChatOutboxScope,
-  retireStoredComposerDrafts,
   storedChatOutboxScopeKey,
+  storageTargetForGateway,
   subscribeStoredChatOutboxChanges,
+  writeStoredOutboxStore,
 } from "./outbox-store.ts";
 
 beforeEach(() => {
@@ -23,15 +26,16 @@ describe("stored outbox summaries", () => {
   it("normalizes an unchanged projection once and refreshes after an external write", () => {
     const unsubscribe = subscribeStoredChatOutboxChanges(() => undefined);
     const gatewayUrl = "ws://gateway.test/control";
-    const storageKey = `openclaw.control.chatComposer.v2:${encodeURIComponent(gatewayUrl)}`;
+    const storageKey = `openclaw.control.chatComposer.v3:${encodeURIComponent(gatewayUrl)}`;
     sessionStorage.setItem(
       storageKey,
-      JSON.stringify({ version: 2, gatewayOwner: gatewayUrl, sessions: {} }),
+      JSON.stringify({ version: 3, gatewayOwner: gatewayUrl, sessions: {} }),
     );
     const target = {
       gatewayOwner: gatewayUrl,
       key: storageKey,
       legacyKey: "unused",
+      inlineKey: "unused-inline",
       legacyOwnerIsUnambiguous: true,
     };
     const first = readProjectedOutboxStore(sessionStorage, target);
@@ -40,7 +44,7 @@ describe("stored outbox summaries", () => {
     sessionStorage.setItem(
       storageKey,
       JSON.stringify({
-        version: 2,
+        version: 3,
         gatewayOwner: gatewayUrl,
         sessions: { "main\u0000agent:main": { draft: "new", updatedAt: 1 } },
       }),
@@ -52,13 +56,14 @@ describe("stored outbox summaries", () => {
     unsubscribe();
   });
 
-  it("refreshes a retained legacy projection after an external write", () => {
+  it.each([1, 2])("refreshes a retained v%i projection after an external write", (version) => {
     const unsubscribe = subscribeStoredChatOutboxChanges(() => undefined);
     const gatewayUrl = "ws://gateway.test/control";
-    const legacyKey = `openclaw.control.chatComposer.v1:${encodeURIComponent(gatewayUrl)}`;
+    const legacyKey = `openclaw.control.chatComposer.v${version}:${encodeURIComponent(gatewayUrl)}`;
     const stored = (ids: string[]) =>
       JSON.stringify({
-        version: 1,
+        version,
+        ...(version === 2 ? { gatewayOwner: gatewayUrl } : {}),
         sessions: {
           "thread\u0000agent:main": {
             queue: ids.map((id, createdAt) => ({ id, text: id, createdAt })),
@@ -67,8 +72,12 @@ describe("stored outbox summaries", () => {
         },
       });
     sessionStorage.setItem(legacyKey, stored(["first"]));
-    vi.spyOn(sessionStorage, "setItem").mockImplementationOnce(() => {
-      throw new DOMException("quota exceeded", "QuotaExceededError");
+    const write = sessionStorage.setItem.bind(sessionStorage);
+    vi.spyOn(sessionStorage, "setItem").mockImplementation((key, value) => {
+      if (key !== legacyKey) {
+        throw new DOMException("quota exceeded", "QuotaExceededError");
+      }
+      write(key, value);
     });
     const state = { settings: { gatewayUrl } };
     expect(summarizeStoredChatOutboxes(state).total).toBe(1);
@@ -83,15 +92,40 @@ describe("stored outbox summaries", () => {
     expect(refreshedTotal).toBe(2);
   });
 
+  it.each([1, 2])("retires the last v%i row when quota blocks its upgrade", (version) => {
+    const target = storageTargetForGateway("ws://gateway.test/control");
+    const sourceKey = version === 1 ? target.legacyKey : target.inlineKey;
+    const scopeKey = storedChatOutboxScopeKey({ sessionKey: "thread", agentId: "main" });
+    sessionStorage.setItem(
+      sourceKey,
+      JSON.stringify({
+        version,
+        ...(version === 2 ? { gatewayOwner: target.gatewayOwner } : {}),
+        sessions: {
+          [scopeKey]: { queue: [{ id: "queued", text: "retire me", createdAt: 1 }], updatedAt: 1 },
+        },
+      }),
+    );
+    vi.spyOn(sessionStorage, "setItem").mockImplementation(() => {
+      throw new DOMException("quota exceeded", "QuotaExceededError");
+    });
+    const store = readStoredOutboxStore(sessionStorage, target);
+    expect(store.sessions[scopeKey]?.queue).toHaveLength(1);
+    store.sessions = {};
+    writeStoredOutboxStore(sessionStorage, target, store);
+    expect(readStoredOutboxStore(sessionStorage, target).sessions).toEqual({});
+    expect(sessionStorage.getItem(sourceKey)).toBeNull();
+  });
+
   it("clears every retained projection after an external storage clear", () => {
     const listener = vi.fn();
     const unsubscribe = subscribeStoredChatOutboxChanges(listener);
     const gatewayUrls = ["ws://first.test/control", "ws://second.test/control"];
     for (const gatewayUrl of gatewayUrls) {
       sessionStorage.setItem(
-        `openclaw.control.chatComposer.v2:${encodeURIComponent(gatewayUrl)}`,
+        `openclaw.control.chatComposer.v3:${encodeURIComponent(gatewayUrl)}`,
         JSON.stringify({
-          version: 2,
+          version: 3,
           gatewayOwner: gatewayUrl,
           mainAlias: { key: "workspace", agentId: "work" },
           sessions: {
@@ -131,11 +165,11 @@ describe("stored outbox summaries", () => {
 
   it("keeps the exact aliased scope when sessionStorage retirement fails", () => {
     const gatewayUrl = "ws://gateway.test/control";
-    const storageKey = `openclaw.control.chatComposer.v2:${encodeURIComponent(gatewayUrl)}`;
+    const storageKey = `openclaw.control.chatComposer.v3:${encodeURIComponent(gatewayUrl)}`;
     sessionStorage.setItem(
       storageKey,
       JSON.stringify({
-        version: 2,
+        version: 3,
         gatewayOwner: gatewayUrl,
         mainAlias: { key: "workspace", agentId: "work" },
         sessions: {
@@ -171,11 +205,11 @@ describe("stored outbox summaries", () => {
 
   it("retires a batch with one write and notification while preserving newer replacements", () => {
     const gatewayUrl = "ws://gateway.test/control";
-    const storageKey = `openclaw.control.chatComposer.v2:${encodeURIComponent(gatewayUrl)}`;
+    const storageKey = `openclaw.control.chatComposer.v3:${encodeURIComponent(gatewayUrl)}`;
     sessionStorage.setItem(
       storageKey,
       JSON.stringify({
-        version: 2,
+        version: 3,
         gatewayOwner: gatewayUrl,
         sessions: {
           "older\u0000agent:main": {
@@ -221,9 +255,9 @@ describe("stored outbox summaries", () => {
   it("lists only non-empty drafts under the same scope used by sidebar sessions", () => {
     const gatewayUrl = "ws://gateway.test/control";
     sessionStorage.setItem(
-      `openclaw.control.chatComposer.v2:${encodeURIComponent(gatewayUrl)}`,
+      `openclaw.control.chatComposer.v3:${encodeURIComponent(gatewayUrl)}`,
       JSON.stringify({
-        version: 2,
+        version: 3,
         gatewayOwner: gatewayUrl,
         sessions: {
           "thread-draft\u0000agent:main": {
@@ -257,7 +291,7 @@ describe("stored outbox summaries", () => {
     expect(addEventListener).toHaveBeenCalledWith("storage", expect.any(Function));
 
     window.dispatchEvent(
-      new StorageEvent("storage", { key: "openclaw.control.chatComposer.v2:gateway" }),
+      new StorageEvent("storage", { key: "openclaw.control.chatComposer.v3:gateway" }),
     );
     expect(firstListener).toHaveBeenCalledTimes(1);
     expect(secondListener).toHaveBeenCalledTimes(1);
@@ -316,11 +350,11 @@ describe("stored outbox summaries", () => {
 
   it("refreshes custom-main ownership for a later offline reload", () => {
     const gatewayUrl = "ws://gateway.test/control";
-    const storageKey = `openclaw.control.chatComposer.v2:${encodeURIComponent(gatewayUrl)}`;
+    const storageKey = `openclaw.control.chatComposer.v3:${encodeURIComponent(gatewayUrl)}`;
     sessionStorage.setItem(
       storageKey,
       JSON.stringify({
-        version: 2,
+        version: 3,
         gatewayOwner: gatewayUrl,
         mainAlias: { key: "old-main", agentId: "previous" },
         sessions: {},
@@ -346,11 +380,11 @@ describe("stored outbox summaries", () => {
 
   it("resolves legacy bare-main rows through the persisted alias on an offline reload", () => {
     const gatewayUrl = "ws://gateway.test/control";
-    const storageKey = `openclaw.control.chatComposer.v2:${encodeURIComponent(gatewayUrl)}`;
+    const storageKey = `openclaw.control.chatComposer.v3:${encodeURIComponent(gatewayUrl)}`;
     sessionStorage.setItem(
       storageKey,
       JSON.stringify({
-        version: 2,
+        version: 3,
         gatewayOwner: gatewayUrl,
         mainAlias: { key: "main", agentId: "work" },
         sessions: {
@@ -390,11 +424,11 @@ describe("stored outbox summaries", () => {
 
   it("rejects a v2 store owned by another gateway", () => {
     const gatewayUrl = "ws://gateway.test/control";
-    const storageKey = `openclaw.control.chatComposer.v2:${encodeURIComponent(gatewayUrl)}`;
+    const storageKey = `openclaw.control.chatComposer.v3:${encodeURIComponent(gatewayUrl)}`;
     sessionStorage.setItem(
       storageKey,
       JSON.stringify({
-        version: 2,
+        version: 3,
         gatewayOwner: "ws://other.test/control",
         sessions: {
           "global\u0000agent:work": {
@@ -422,9 +456,9 @@ describe("stored outbox summaries", () => {
       ["ws://b.test/control", "workspace-b", "beta"],
     ] as const) {
       sessionStorage.setItem(
-        `openclaw.control.chatComposer.v2:${encodeURIComponent(gatewayUrl)}`,
+        `openclaw.control.chatComposer.v3:${encodeURIComponent(gatewayUrl)}`,
         JSON.stringify({
-          version: 2,
+          version: 3,
           gatewayOwner: gatewayUrl,
           mainAlias: { key, agentId },
           sessions: {},
@@ -450,9 +484,9 @@ describe("stored outbox summaries", () => {
   it("deduplicates item ids within a scope, not across scopes", () => {
     const gatewayUrl = "ws://gateway.test/control";
     sessionStorage.setItem(
-      `openclaw.control.chatComposer.v2:${encodeURIComponent(gatewayUrl)}`,
+      `openclaw.control.chatComposer.v3:${encodeURIComponent(gatewayUrl)}`,
       JSON.stringify({
-        version: 2,
+        version: 3,
         gatewayOwner: gatewayUrl,
         sessions: {
           "thread-a\u0000agent:main": {
@@ -483,9 +517,9 @@ describe("stored outbox summaries", () => {
       "waiting-reconnect",
     ] as const;
     sessionStorage.setItem(
-      `openclaw.control.chatComposer.v2:${encodeURIComponent(gatewayUrl)}`,
+      `openclaw.control.chatComposer.v3:${encodeURIComponent(gatewayUrl)}`,
       JSON.stringify({
-        version: 2,
+        version: 3,
         gatewayOwner: gatewayUrl,
         sessions: {
           "thread-a\u0000agent:main": {

--- a/ui/src/lib/chat/outbox-store.ts
+++ b/ui/src/lib/chat/outbox-store.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { getSafeSessionStorage } from "../../local-storage.ts";
 import {
   DEFAULT_AGENT_ID,
@@ -10,28 +11,24 @@ import {
 } from "../sessions/session-key.ts";
 import { compareChatQueueOrder } from "./chat-queue-order.ts";
 import type { ChatQueueItem } from "./chat-types.ts";
+import { removeOutboxPayloads } from "./outbox-payload-store.runtime.ts";
 import {
   MAX_RETAINED_QUEUE_ITEMS,
   MAX_STORED_SESSIONS,
   normalizeStoredSession,
   type StoredComposerSession,
 } from "./outbox-store-codec.ts";
-import {
-  nextDraftRevision,
-  observeDraftRevision,
-  rememberedDraftAttempt,
-  rememberedDraftRevision,
-  rememberDraftAttempt,
-  rememberDraftRevision,
-} from "./outbox-store-draft-state.ts";
+import { observeDraftRevision, rememberDraftRevision } from "./outbox-store-draft-state.ts";
 
 const LEGACY_STORAGE_KEY_PREFIX = "openclaw.control.chatComposer.v1:";
-const STORAGE_KEY_PREFIX = "openclaw.control.chatComposer.v2:";
+const INLINE_STORAGE_KEY_PREFIX = "openclaw.control.chatComposer.v2:";
+const STORAGE_KEY_PREFIX = "openclaw.control.chatComposer.v3:";
 export const UNRESOLVED_GLOBAL_AGENT_SCOPE = "@unresolved";
 const storedChatOutboxChangeListeners = new Set<() => void>();
 let storageChangeListenerInstalled = false;
 
 export type ChatComposerScope = {
+  client?: { recoveryScope?: string; recoveryScopeReady?: boolean } | null;
   settings?: { gatewayUrl?: string | null };
   assistantAgentId?: string | null;
   agentsList?: { defaultId?: string | null; mainKey?: string | null } | null;
@@ -46,6 +43,7 @@ type StoredComposerMainAlias = {
 type ComposerStorageTarget = {
   key: string;
   legacyKey: string;
+  inlineKey: string;
   gatewayOwner: string;
   legacyOwnerIsUnambiguous: boolean;
 };
@@ -62,20 +60,10 @@ export type StoredChatOutboxScope = {
   agentId?: string;
 };
 
-type StoredComposerRetirementTarget = {
-  key: string;
-  agentId?: string;
-  retireBeforeRevision: number;
-};
-
-type StoredComposerRetirement = {
-  scope: StoredChatOutboxScope;
-  minimumRevision: number;
-  retireBeforeRevision: number;
-};
-
 export type StoredComposerState = {
-  version: 2;
+  version: 3;
+  /** Upgrade source, removed only after its replacement commits. Never persisted. */
+  upgradeSourceKey?: string;
   gatewayOwner: string;
   sessions: Record<string, StoredComposerSession>;
   mainAlias?: StoredComposerMainAlias;
@@ -126,12 +114,16 @@ function handleStoredChatOutboxStorageChange(event: StorageEvent): void {
   }
   if (
     event.key?.startsWith(STORAGE_KEY_PREFIX) ||
+    event.key?.startsWith(INLINE_STORAGE_KEY_PREFIX) ||
     event.key?.startsWith(LEGACY_STORAGE_KEY_PREFIX)
   ) {
     if (event.storageArea) {
-      const projectedKey = event.key.startsWith(LEGACY_STORAGE_KEY_PREFIX)
-        ? `${STORAGE_KEY_PREFIX}${event.key.slice(LEGACY_STORAGE_KEY_PREFIX.length)}`
-        : event.key;
+      const previousPrefix = event.key.startsWith(LEGACY_STORAGE_KEY_PREFIX)
+        ? LEGACY_STORAGE_KEY_PREFIX
+        : INLINE_STORAGE_KEY_PREFIX;
+      const projectedKey = event.key.startsWith(STORAGE_KEY_PREFIX)
+        ? event.key
+        : `${STORAGE_KEY_PREFIX}${event.key.slice(previousPrefix.length)}`;
       projectedStoreByStorage.get(event.storageArea)?.delete(projectedKey);
     }
     notifyStoredChatOutboxChanges();
@@ -145,6 +137,7 @@ export function storageTargetForGateway(
   const encodedOwner = encodeURIComponent(gatewayOwner);
   return {
     key: `${STORAGE_KEY_PREFIX}${encodedOwner}`,
+    inlineKey: `${INLINE_STORAGE_KEY_PREFIX}${encodedOwner}`,
     legacyKey: `${LEGACY_STORAGE_KEY_PREFIX}${encodedOwner.slice(0, 240)}`,
     gatewayOwner,
     // Shipped v1 keys omitted the owner and truncated its encoded value. A
@@ -312,6 +305,29 @@ export function resolveStoredComposerSession(
   state: ChatComposerScope,
   sessionKey: string,
   agentIdOverride?: string,
+) {
+  const resolved = resolveComposerSessionAliases(store, state, sessionKey, agentIdOverride);
+  const scope = resolveComposerStorageScope(state, sessionKey, agentIdOverride, store.mainAlias);
+  const session = resolved.session;
+  // Legacy rows can already have the canonical bucket key while their items
+  // lack embedded routes. Normalize at migration, before edit/remove CAS reads.
+  if (
+    session?.queue?.some(
+      (item) => item.sessionKey !== scope.conversationKey || item.agentId !== scope.routingAgentId,
+    )
+  ) {
+    session.queue = session.queue.map((item) => applyStoredChatOutboxScope(item, scope));
+    store.sessions[resolved.storeSessionKey] = session;
+    resolved.migrated = true;
+  }
+  return resolved;
+}
+
+function resolveComposerSessionAliases(
+  store: StoredComposerState,
+  state: ChatComposerScope,
+  sessionKey: string,
+  agentIdOverride?: string,
 ): { session: StoredComposerSession | null; storeSessionKey: string; migrated: boolean } {
   let migrated = updateStoredMainAlias(store, state);
   const scope = resolveComposerStorageScope(state, sessionKey, agentIdOverride, store.mainAlias);
@@ -459,11 +475,11 @@ function parseStoredOutboxStore(
   storage: Storage,
   target: ComposerStorageTarget,
   raw: string,
-  version: 1 | 2,
+  version: 1 | 2 | 3,
 ): StoredComposerState | null {
-  let parsed: Partial<StoredComposerState>;
+  let parsed: Omit<Partial<StoredComposerState>, "version"> & { version?: number };
   try {
-    parsed = JSON.parse(raw) as Partial<StoredComposerState>;
+    parsed = JSON.parse(raw) as typeof parsed;
   } catch {
     return null;
   }
@@ -475,7 +491,7 @@ function parseStoredOutboxStore(
   ) {
     return null;
   }
-  if (version === 2 && parsed.gatewayOwner !== target.gatewayOwner) {
+  if (version !== 1 && parsed.gatewayOwner !== target.gatewayOwner) {
     // Never replace another Gateway's occupied bucket while deriving badges or
     // restoring a composer; its queued messages belong to a different owner.
     throw new Error("Chat outbox gateway owner mismatch");
@@ -505,7 +521,7 @@ function parseStoredOutboxStore(
         : undefined;
     rememberStoredMainAlias(storage, target.key, mainAlias);
     return {
-      version: 2,
+      version: 3,
       gatewayOwner: target.gatewayOwner,
       sessions,
       ...(mainAlias ? { mainAlias } : {}),
@@ -521,17 +537,24 @@ export function readStoredOutboxStore(
 ): StoredComposerState {
   const raw = storage.getItem(target.key);
   if (raw) {
-    const store = parseStoredOutboxStore(storage, target, raw, 2);
+    const store = parseStoredOutboxStore(storage, target, raw, 3);
     if (store) {
       return store;
     }
-  } else if (target.legacyOwnerIsUnambiguous) {
-    const legacyRaw = storage.getItem(target.legacyKey);
-    const store = legacyRaw ? parseStoredOutboxStore(storage, target, legacyRaw, 1) : null;
+  } else {
+    // New reference rows use a separate bucket; old binaries cannot rewrite them.
+    // Upgrade is copy-before-remove so quota failure preserves every inline input.
+    const inlineRaw = storage.getItem(target.inlineKey);
+    const legacyRaw = target.legacyOwnerIsUnambiguous ? storage.getItem(target.legacyKey) : null;
+    const sourceKey = inlineRaw ? target.inlineKey : target.legacyKey;
+    const source = inlineRaw ?? legacyRaw;
+    const store = source
+      ? parseStoredOutboxStore(storage, target, source, inlineRaw ? 2 : 1)
+      : null;
     if (store) {
+      store.upgradeSourceKey = sourceKey;
       try {
         writeStoredOutboxStore(storage, target, store);
-        storage.removeItem(target.legacyKey);
       } catch {
         // Keep readable shipped rows when browser quota blocks migration.
       }
@@ -539,7 +562,7 @@ export function readStoredOutboxStore(
     }
   }
   rememberStoredMainAlias(storage, target.key, undefined);
-  return { version: 2, gatewayOwner: target.gatewayOwner, sessions: {} };
+  return { version: 3, gatewayOwner: target.gatewayOwner, sessions: {} };
 }
 
 export function readProjectedOutboxStore(
@@ -563,6 +586,7 @@ export function writeStoredOutboxStore(
   target: ComposerStorageTarget,
   store: StoredComposerState,
 ): void {
+  const previous = storage.getItem(target.key);
   projectedStoreByStorage.get(storage)?.delete(target.key);
   const entries = Object.entries(store.sessions);
   const outboxes = entries.filter(([, session]) => session.queue?.length);
@@ -602,136 +626,57 @@ export function writeStoredOutboxStore(
   ];
   if (retained.length === 0 && !store.mainAlias) {
     storage.removeItem(target.key);
+    if (store.upgradeSourceKey) {
+      storage.removeItem(store.upgradeSourceKey);
+    }
     rememberStoredMainAlias(storage, target.key, undefined);
+    retireRemovedOutboxPayloads(previous, []);
     return;
   }
   storage.setItem(
     target.key,
     JSON.stringify({
-      version: 2,
+      version: 3,
       gatewayOwner: target.gatewayOwner,
       sessions: Object.fromEntries(retained),
       ...(store.mainAlias ? { mainAlias: store.mainAlias } : {}),
     }),
   );
+  if (store.upgradeSourceKey) {
+    storage.removeItem(store.upgradeSourceKey);
+  }
   rememberStoredMainAlias(storage, target.key, store.mainAlias);
+  retireRemovedOutboxPayloads(
+    previous,
+    retained.flatMap(([, session]) => session.queue ?? []),
+  );
 }
 
-export function retireStoredComposerDrafts(
-  state: ChatComposerScope,
-  targets: readonly StoredComposerRetirementTarget[],
-) {
-  const storageTarget = storageTargetForGateway(state.settings?.gatewayUrl);
-  if (targets.length === 0) {
-    return { gatewayOwner: storageTarget.gatewayOwner, retirements: [], storageFailed: false };
+function retireRemovedOutboxPayloads(previous: string | null, retained: ChatQueueItem[]): void {
+  if (!previous) {
+    return;
   }
-  const storage = getSafeSessionStorage();
-  if (!storage) {
-    return {
-      gatewayOwner: storageTarget.gatewayOwner,
-      retirements: targets.flatMap((target) => {
-        if (!target.key.trim()) {
-          return [];
-        }
-        const resolved = resolveComposerStorageScope(state, target.key, target.agentId);
-        return [
-          {
-            scope: {
-              sessionKey: resolved.conversationKey,
-              ...(resolved.routingAgentId ? { agentId: resolved.routingAgentId } : {}),
-            },
-            minimumRevision: target.retireBeforeRevision,
-            retireBeforeRevision: target.retireBeforeRevision,
-          },
-        ];
-      }),
-      storageFailed: true,
-    };
-  }
-
-  const retirements: StoredComposerRetirement[] = [];
-  const written: Array<{ storeSessionKey: string; revision: number }> = [];
-  let visibleChanged = false;
   try {
-    const store = readStoredOutboxStore(storage, storageTarget);
-    let changed = false;
-    for (const target of targets) {
-      if (!target.key.trim()) {
-        return { gatewayOwner: storageTarget.gatewayOwner, retirements, storageFailed: true };
-      }
-      const resolved = resolveComposerStorageScope(
-        state,
-        target.key,
-        target.agentId,
-        store.mainAlias,
+    const parsed: unknown = JSON.parse(previous);
+    if (!isRecord(parsed) || parsed.version !== 3 || !isRecord(parsed.sessions)) {
+      return;
+    }
+    const remaining = new Set(retained.map((item) => item.attachmentPayload?.key));
+    const removed = Object.values(parsed.sessions)
+      .flatMap((value) => normalizeStoredSession(value)?.queue ?? [])
+      .flatMap((item) =>
+        item.attachmentPayload &&
+        item.attachmentPayload.tabId ===
+          getSafeSessionStorage()?.getItem("openclaw.control.outboxTab.v1") &&
+        !remaining.has(item.attachmentPayload.key)
+          ? [item.attachmentPayload]
+          : [],
       );
-      const scope: StoredChatOutboxScope = {
-        sessionKey: resolved.conversationKey,
-        ...(resolved.routingAgentId ? { agentId: resolved.routingAgentId } : {}),
-      };
-      const resolvedSession = resolveStoredComposerSession(
-        store,
-        state,
-        scope.sessionKey,
-        scope.agentId,
-      );
-      changed ||= resolvedSession.migrated;
-      const storedRevision = resolvedSession.session?.draftRevision ?? 0;
-      const currentRevision = Math.max(
-        storedRevision,
-        rememberedDraftRevision(storage, storageTarget.key, resolvedSession.storeSessionKey),
-        rememberedDraftAttempt(storage, storageTarget.key, resolvedSession.storeSessionKey),
-      );
-      let minimumRevision = target.retireBeforeRevision;
-      if (storedRevision < target.retireBeforeRevision) {
-        minimumRevision = nextDraftRevision(Math.max(currentRevision, target.retireBeforeRevision));
-        rememberDraftAttempt(
-          storage,
-          storageTarget.key,
-          resolvedSession.storeSessionKey,
-          minimumRevision,
-        );
-        visibleChanged ||=
-          Boolean(resolvedSession.session?.draft) ||
-          Boolean(resolvedSession.session?.queue?.length);
-        store.sessions[resolvedSession.storeSessionKey] = {
-          draftRevision: minimumRevision,
-          updatedAt: Date.now(),
-        };
-        written.push({
-          storeSessionKey: resolvedSession.storeSessionKey,
-          revision: minimumRevision,
-        });
-        changed = true;
-      }
-      retirements.push({
-        scope,
-        minimumRevision,
-        retireBeforeRevision: target.retireBeforeRevision,
-      });
+    if (removed.length) {
+      void removeOutboxPayloads(removed);
     }
-    if (!changed) {
-      return { gatewayOwner: storageTarget.gatewayOwner, retirements, storageFailed: false };
-    }
-    writeStoredOutboxStore(storage, storageTarget, store);
-    const persisted = readStoredOutboxStore(storage, storageTarget);
-    for (const { storeSessionKey, revision } of written) {
-      const session = normalizeStoredSession(persisted.sessions[storeSessionKey]);
-      if (
-        session?.draftRevision !== revision ||
-        Boolean(session.draft) ||
-        Boolean(session.queue?.length)
-      ) {
-        return { gatewayOwner: storageTarget.gatewayOwner, retirements, storageFailed: true };
-      }
-      rememberDraftRevision(storage, storageTarget.key, storeSessionKey, revision);
-    }
-    if (visibleChanged) {
-      notifyStoredChatOutboxChanges();
-    }
-    return { gatewayOwner: storageTarget.gatewayOwner, retirements, storageFailed: false };
   } catch {
-    return { gatewayOwner: storageTarget.gatewayOwner, retirements, storageFailed: true };
+    // An unreadable previous bucket cannot authorize payload deletion.
   }
 }
 

--- a/ui/src/lib/chat/outbox-store.ts
+++ b/ui/src/lib/chat/outbox-store.ts
@@ -665,10 +665,7 @@ function retireRemovedOutboxPayloads(previous: string | null, retained: ChatQueu
     const removed = Object.values(parsed.sessions)
       .flatMap((value) => normalizeStoredSession(value)?.queue ?? [])
       .flatMap((item) =>
-        item.attachmentPayload &&
-        item.attachmentPayload.tabId ===
-          getSafeSessionStorage()?.getItem("openclaw.control.outboxTab.v1") &&
-        !remaining.has(item.attachmentPayload.key)
+        item.attachmentPayload && !remaining.has(item.attachmentPayload.key)
           ? [item.attachmentPayload]
           : [],
       );

--- a/ui/src/pages/chat/attachment-api.ts
+++ b/ui/src/pages/chat/attachment-api.ts
@@ -1,3 +1,4 @@
+import { t } from "../../i18n/index.ts";
 import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
 import { generateUUID } from "../../lib/uuid.ts";
 import { getChatAttachmentDataUrl } from "./attachment-payload-store.ts";
@@ -15,21 +16,19 @@ function dataUrlToBase64(dataUrl: string): { content: string; mimeType: string }
 /** Converts composer attachments into the base64 payload accepted by chat.send. */
 export function buildChatApiAttachments(attachments?: readonly ChatAttachment[]) {
   return attachments?.length
-    ? attachments
-        .map((attachment) => {
-          const dataUrl = getChatAttachmentDataUrl(attachment);
-          const parsed = dataUrl ? dataUrlToBase64(dataUrl) : null;
-          if (!parsed) {
-            return null;
-          }
-          return {
-            type: parsed.mimeType.startsWith("image/") ? "image" : "file",
-            mimeType: parsed.mimeType,
-            fileName: attachment.fileName,
-            content: parsed.content,
-          };
-        })
-        .filter((attachment): attachment is NonNullable<typeof attachment> => attachment !== null)
+    ? attachments.map((attachment) => {
+        const dataUrl = getChatAttachmentDataUrl(attachment);
+        const parsed = dataUrl ? dataUrlToBase64(dataUrl) : null;
+        if (!parsed) {
+          throw new Error(t("chat.sendErrors.outboxPayloadMissing"));
+        }
+        return {
+          type: parsed.mimeType.startsWith("image/") ? "image" : "file",
+          mimeType: parsed.mimeType,
+          fileName: attachment.fileName,
+          content: parsed.content,
+        };
+      })
     : undefined;
 }
 

--- a/ui/src/pages/chat/attachment-payload-store.ts
+++ b/ui/src/pages/chat/attachment-payload-store.ts
@@ -46,67 +46,9 @@ export function getChatAttachmentDataUrl(attachment: ChatAttachment): string | n
   return attachment.dataUrl ?? payloads.get(attachment.id)?.dataUrl ?? null;
 }
 
-function blobFromDataUrl(dataUrl: string): Blob | null {
-  const match = /^data:([^,]*),(.*)$/s.exec(dataUrl);
-  if (!match) {
-    return null;
-  }
-  const metadata = match[1] ?? "";
-  const payload = match[2] ?? "";
-  try {
-    if (metadata.toLowerCase().includes(";base64")) {
-      const binary = atob(payload.replace(/\s+/gu, ""));
-      const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
-      return new Blob([bytes], { type: metadata.split(";", 1)[0] });
-    }
-    return new Blob([decodeURIComponent(payload.replace(/\+/gu, "%20"))], {
-      type: metadata.split(";", 1)[0],
-    });
-  } catch {
-    return null;
-  }
-}
-
+// Startup handoffs share this registry; binary conversion stays with lazy persistence.
 export function getChatAttachmentBlob(attachment: ChatAttachment): Blob | null {
-  const stored = payloads.get(attachment.id)?.blob;
-  if (stored) {
-    return stored;
-  }
-  const dataUrl = getChatAttachmentDataUrl(attachment);
-  return dataUrl ? blobFromDataUrl(dataUrl) : null;
-}
-
-function readBlobAsDataUrl(blob: Blob): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.addEventListener("error", () => reject(reader.error ?? new Error("Blob read failed")), {
-      once: true,
-    });
-    reader.addEventListener(
-      "load",
-      () =>
-        typeof reader.result === "string"
-          ? resolve(reader.result)
-          : reject(new Error("Blob read returned no data")),
-      { once: true },
-    );
-    reader.readAsDataURL(blob);
-  });
-}
-
-export async function restoreChatAttachmentPayload(params: {
-  attachment: ChatAttachment;
-  blob: Blob;
-}): Promise<ChatAttachment> {
-  const blob =
-    params.blob.type === params.attachment.mimeType
-      ? params.blob
-      : params.blob.slice(0, params.blob.size, params.attachment.mimeType);
-  const dataUrl = await readBlobAsDataUrl(blob);
-  const file = new File([blob], params.attachment.fileName ?? "attachment", {
-    type: params.attachment.mimeType,
-  });
-  return registerChatAttachmentPayload({ attachment: params.attachment, dataUrl, file });
+  return payloads.get(attachment.id)?.blob ?? null;
 }
 
 // Stored data URLs keep previews available when this browser cannot create object URLs.

--- a/ui/src/pages/chat/chat-history-cursor.test.ts
+++ b/ui/src/pages/chat/chat-history-cursor.test.ts
@@ -1,12 +1,14 @@
 // @vitest-environment node
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
+import { createStorageMock } from "../../test-helpers/storage.ts";
 import { loadChatHistory } from "./chat-history.ts";
 import { makeChatHost } from "./chat-host.test-support.ts";
-import { preserveQueuedUserTurn } from "./chat-send-support.ts";
+import { retireDeliveredQueuedUserTurn } from "./chat-send-support.ts";
 import { buildChatItems } from "./chat-thread-build.ts";
+import { admitStoredChatComposerQueueItem } from "./composer-persistence.ts";
 import {
   getChatSessionProjection,
   readChatSessionProjectionScope,
@@ -74,9 +76,12 @@ async function loadHistoryWithBrowserTimers(state: ReturnType<typeof createState
 }
 
 describe("chat history cursor revalidation", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
   it.each(["live", "history-delta"] as const)(
     "retains an attributed pending steer across a leaf advance before %s persistence",
     async (delivery) => {
+      vi.stubGlobal("sessionStorage", createStorageMock());
       const sessionKey = "agent:main:participant-steer";
       const sendRunId = "bob-send";
       const aliceFinal = {
@@ -150,6 +155,7 @@ describe("chat history cursor revalidation", () => {
         sessionKey,
         sender: { id: "bob-profile", name: "Bob Proof" },
       };
+      expect(admitStoredChatComposerQueueItem(state, sessionKey, queued)).toBe(true);
       state.chatQueue = [queued];
       const renderedBobMessages = () =>
         buildChatItems({
@@ -173,8 +179,8 @@ describe("chat history cursor revalidation", () => {
       expect(renderedBobMessages()).toHaveLength(1);
 
       // Delivery retirement materializes the acknowledged turn before its durable row arrives.
-      preserveQueuedUserTurn(state, queued);
-      state.chatQueue = [];
+      expect(await retireDeliveredQueuedUserTurn(state, sendRunId, { sessionKey })).toBe("retired");
+      expect(state.chatQueue).toEqual([]);
       expect(renderedBobMessages()).toHaveLength(1);
       await loadChatHistory(state);
       expect(handler).toHaveBeenCalledWith(expect.objectContaining({ cursor: "cursor-3" }));

--- a/ui/src/pages/chat/chat-outbox-drain.ts
+++ b/ui/src/pages/chat/chat-outbox-drain.ts
@@ -688,9 +688,8 @@ export async function resumeStoredChatOutboxes(
   if (!host.connected || !host.client) {
     return;
   }
-  // Recovery can change credentials on the same client. Refresh the visible
-  // owner even when the new principal has no outboxes to drain.
-  syncVisibleChatQueueProjection(host);
+  // Refresh credential ownership; callers own frame-coalesced rendering.
+  syncVisibleChatQueueProjection(host, { requestUpdate: false });
   await Promise.allSettled(
     listStoredChatOutboxes(host).map((outbox) =>
       scheduleStoredChatOutboxDrain(host, outbox, dependencies),

--- a/ui/src/pages/chat/chat-outbox-drain.ts
+++ b/ui/src/pages/chat/chat-outbox-drain.ts
@@ -7,7 +7,6 @@ import {
   areUiSessionKeysEquivalent,
   isUiGlobalSessionKey,
 } from "../../lib/sessions/session-key.ts";
-import { releaseChatAttachmentPayloads } from "./attachment-payload-store.ts";
 import {
   captureChatCommandTarget,
   confirmConversationResetForCurrentSession,
@@ -25,9 +24,9 @@ import {
 } from "./chat-outbox-retry.ts";
 import {
   anyChatOutboxPaneMatches,
-  excludeComposerAttachments,
   readQueuedMessageById,
   removeQueuedMessageWithoutReleasing,
+  sameQueuedDeliveryVersion,
   syncVisibleChatQueueProjection,
   updateQueuedMessageForSession,
 } from "./chat-queue.ts";
@@ -36,7 +35,7 @@ import {
   chatMessagesContainQueuedSend,
   chatSendHoldReason,
   OFFLINE_QUEUE_STORAGE_ERROR,
-  preserveQueuedUserTurn,
+  retireDeliveredQueuedUserTurn,
   surfaceChatDeliveryFailure,
 } from "./chat-send-support.ts";
 import {
@@ -139,17 +138,6 @@ function readStoredChatOutbox(
   );
 }
 
-function sameQueuedDeliveryVersion(left: ChatQueueItem, right: ChatQueueItem): boolean {
-  return (
-    left.id === right.id &&
-    left.sendRunId === right.sendRunId &&
-    left.sendAttempts === right.sendAttempts &&
-    left.sendState === right.sendState &&
-    left.agentId === right.agentId &&
-    left.sessionKey === right.sessionKey
-  );
-}
-
 function sessionRunProvesQueuedDelivery(
   sessionInfo: ChatHistoryResult["sessionInfo"],
   item: ChatQueueItem,
@@ -235,13 +223,15 @@ async function readCurrentStoredChatHistory(
     chatMessagesContainQueuedSend(history.messages, item) ||
     sessionRunProvesQueuedDelivery(history.sessionInfo, item)
   ) {
-    // Materialize server history locally before removing the queue bubble.
-    preserveQueuedUserTurn(host, item);
-    const removed = removeQueuedMessageWithoutReleasing(host, item.id, outbox.sessionKey);
-    if (!removed) {
+    const retirement = await retireDeliveredQueuedUserTurn(host, item.sendRunId, outbox);
+    if (
+      retirement !== "retired" ||
+      host.client !== client ||
+      host.connectionEpoch !== connectionEpoch ||
+      !host.connected
+    ) {
       return "blocked";
     }
-    releaseChatAttachmentPayloads(excludeComposerAttachments(host, removed.attachments));
     if (visibleSessionMatches(host, outbox.sessionKey, outbox.agentId)) {
       void loadChatHistory(host);
     }
@@ -262,6 +252,7 @@ async function reconcileStoredChatOutboxHead(
   outbox: StoredChatOutbox,
   item: ChatQueueItem,
   dependencies: ChatOutboxDrainDependencies,
+  retryUnconfirmed = false,
 ): Promise<"blocked" | "continue" | "send"> {
   const client = host.client;
   const connectionEpoch = host.connectionEpoch;
@@ -276,7 +267,7 @@ async function reconcileStoredChatOutboxHead(
   // bubbles even mid-run; missing transcript and run proof falls through conservatively.
   const neverAttempted =
     (item.sendAttempts ?? 0) === 0 && item.sendRequestStartedAtMs === undefined;
-  if (neverAttempted && item.queueMode) {
+  if (neverAttempted && item.queueMode && item.sendState !== "unconfirmed") {
     return "send";
   }
   if (neverAttempted) {
@@ -292,8 +283,13 @@ async function reconcileStoredChatOutboxHead(
   }
   const historyArgs = [host, outbox, item, client, connectionEpoch, dependencies] as const;
   const history = await readCurrentStoredChatHistory(...historyArgs);
-  // Keyed unknown sends reach history only for exact proof; absence stays blocked.
-  if (history === "blocked" || history === "continue" || item.sendState === "unconfirmed") {
+  // Passive unknown sends need positive delivery proof; only an explicit retry
+  // may continue through idle reconciliation to the same idempotency key.
+  if (
+    history === "blocked" ||
+    history === "continue" ||
+    (item.sendState === "unconfirmed" && !retryUnconfirmed)
+  ) {
     return history === "continue" ? "continue" : "blocked";
   }
   if (visibleSessionMatches(host, outbox.sessionKey, outbox.agentId) && isChatBusy(host)) {
@@ -315,6 +311,9 @@ async function reconcileStoredChatOutboxHead(
     if (liveSendCurrent) {
       // Elapsed time cannot turn a current-connection send into reconnect uncertainty.
       return "blocked";
+    }
+    if (retryUnconfirmed) {
+      return "send";
     }
     const parked = updateQueuedMessageForSession(host, outbox.sessionKey, item.id, (entry) => ({
       ...entry,
@@ -569,8 +568,15 @@ async function drainStoredChatOutbox(
     // Consume provenance before await; restored/deferred rows reconcile history.
     const freshAdmission = lane.freshAdmissions.delete(item.id);
     const pendingOptions = lane.pendingOptions.get(item.id);
-    if (!freshAdmission) {
-      const reconciled = await reconcileStoredChatOutboxHead(host, outbox, item, dependencies);
+    const retryUnconfirmed = freshAdmission && item.sendState === "unconfirmed";
+    if (!freshAdmission || retryUnconfirmed) {
+      const reconciled = await reconcileStoredChatOutboxHead(
+        host,
+        outbox,
+        item,
+        dependencies,
+        retryUnconfirmed,
+      );
       if (reconciled === "blocked") {
         return "blocked";
       }
@@ -682,6 +688,9 @@ export async function resumeStoredChatOutboxes(
   if (!host.connected || !host.client) {
     return;
   }
+  // Recovery can change credentials on the same client. Refresh the visible
+  // owner even when the new principal has no outboxes to drain.
+  syncVisibleChatQueueProjection(host);
   await Promise.allSettled(
     listStoredChatOutboxes(host).map((outbox) =>
       scheduleStoredChatOutboxDrain(host, outbox, dependencies),

--- a/ui/src/pages/chat/chat-outbox-drain.ts
+++ b/ui/src/pages/chat/chat-outbox-drain.ts
@@ -364,11 +364,14 @@ async function drainStoredChatOutbox(
           entry.sendState !== "failed" ||
           entry.localCommandName,
       );
-    const freshItem = storedItem && lane.freshAdmissions.has(storedItem.id);
+    if (!storedItem) {
+      return "empty";
+    }
+    const freshItem = lane.freshAdmissions.has(storedItem.id);
     const item = freshItem
       ? (readQueuedMessageById(host, storedItem.id) ?? storedItem)
       : storedItem;
-    if (!item || (item.sendState === "failed" && !freshItem)) {
+    if (item.sendState === "failed" && !freshItem) {
       return "empty";
     }
     if (
@@ -570,10 +573,11 @@ async function drainStoredChatOutbox(
     const pendingOptions = lane.pendingOptions.get(item.id);
     const retryUnconfirmed = freshAdmission && item.sendState === "unconfirmed";
     if (!freshAdmission || retryUnconfirmed) {
+      // History reconciles canonical stored versions, not the live row's transport alias.
       const reconciled = await reconcileStoredChatOutboxHead(
         host,
         outbox,
-        item,
+        storedItem,
         dependencies,
         retryUnconfirmed,
       );

--- a/ui/src/pages/chat/chat-outbox-owner.ts
+++ b/ui/src/pages/chat/chat-outbox-owner.ts
@@ -2,13 +2,21 @@ import { compareChatQueueOrder } from "../../lib/chat/chat-queue-order.ts";
 import type { ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { subscribeStoredChatOutboxChanges } from "../../lib/chat/outbox-store.ts";
 import { getSafeSessionStorage } from "../../local-storage.ts";
+import { getChatAttachmentDataUrl } from "./attachment-payload-store.ts";
 import {
   listStoredChatOutboxes,
+  updateStoredChatComposerQueueItem,
   resolveStoredChatOutboxScope,
   storedChatOutboxScopeKey,
   type ChatComposerScope as Composer,
   type StoredChatOutboxScope as Scope,
 } from "./composer-persistence.ts";
+import {
+  captureOutboxPayloadOwner,
+  failOutboxPayload,
+  observeOutboxRecoveryOwner,
+  prepareOutboxPayload,
+} from "./outbox-payloads.ts";
 type Host = Composer & { chatQueue: ChatQueueItem[]; sessionKey: string; requestUpdate?(): void };
 type HostProjection = {
   byScope: Map<string, ChatQueueItem[]>;
@@ -33,6 +41,7 @@ class ChatOutboxGatewayOwner {
   private readonly hosts = new Map<Host, HostProjection>();
   private readonly panes = new Set<Host>();
   private readonly live = new Map<string, Map<string, LiveProjection>>();
+  private readonly hydrating = new Set<string>();
   private unsubscribe: (() => void) | null = null;
   constructor(readonly ownerGatewayKey: string) {}
   private state(host: Host): HostProjection {
@@ -44,7 +53,14 @@ class ChatOutboxGatewayOwner {
     const durableSeen = new Set(this.outbox(host, scope)?.queue.map((item) => item.id));
     const created: HostProjection = { byScope: new Map(), durableSeen, retryable: new Set() };
     if (host.chatQueue.length) {
-      created.byScope.set(storedChatOutboxScopeKey(scope), host.chatQueue);
+      created.byScope.set(
+        storedChatOutboxScopeKey(scope),
+        host.chatQueue.filter(
+          (item) =>
+            !item.attachmentPayload ||
+            item.attachmentPayload.recoveryScope === host.client?.recoveryScope,
+        ),
+      );
     }
     this.hosts.set(host, created);
     return created;
@@ -106,7 +122,73 @@ class ChatOutboxGatewayOwner {
     return visible.toSorted(compareChatQueueOrder);
   }
   syncHost(host: Host, options: { requestUpdate?: boolean } = {}): void {
+    if (this.ownerGatewayKey !== outboxOwnerKey(host)) {
+      chatOutboxOwner(host).syncHost(host, options);
+      return;
+    }
+    observeOutboxRecoveryOwner(host);
     host.chatQueue = this.snapshot(host, resolveStoredChatOutboxScope(host, host.sessionKey));
+    for (const item of host.chatQueue) {
+      const key = item.attachmentPayload?.key;
+      if (
+        !key ||
+        item.attachmentStorageError ||
+        this.hydrating.has(key) ||
+        item.attachments?.every((attachment) => getChatAttachmentDataUrl(attachment))
+      ) {
+        continue;
+      }
+      this.hydrating.add(key);
+      const isCurrent = captureOutboxPayloadOwner(host);
+      void prepareOutboxPayload(host, item)
+        .then((result) => {
+          if (!isCurrent()) {
+            return;
+          }
+          const outbox = this.durable(host, item.id);
+          const current = outbox?.queue.find((row) => row.id === item.id);
+          if (!outbox || current?.attachmentPayload?.key !== key) {
+            return;
+          }
+          if (result.status === "ready") {
+            if (result.item.attachmentPayload?.key !== key) {
+              // Copy adoption must not overwrite a retry that replaced the captured row.
+              if (
+                !updateStoredChatComposerQueueItem(
+                  host,
+                  outbox.sessionKey,
+                  item,
+                  result.item,
+                  outbox.agentId,
+                )
+              ) {
+                return;
+              }
+            }
+            this.keep(host, outbox, {
+              ...current,
+              attachments: result.item.attachments,
+              ...(result.item.attachmentPayload?.key !== key
+                ? {
+                    attachmentPayload: result.item.attachmentPayload,
+                    sendState: result.item.sendState,
+                    sendError: result.item.sendError,
+                  }
+                : {}),
+            });
+          } else {
+            updateStoredChatComposerQueueItem(
+              host,
+              outbox.sessionKey,
+              current,
+              failOutboxPayload(current, result.reason),
+              outbox.agentId,
+            );
+          }
+          this.publish(host);
+        })
+        .finally(() => this.hydrating.delete(key));
+    }
     if (options.requestUpdate !== false) {
       host.requestUpdate?.();
     }
@@ -124,18 +206,59 @@ class ChatOutboxGatewayOwner {
       }
     }
   }
-  subscribe(host: Host): () => void {
+  adoptSubscriptions(host: Composer): void {
+    const previous = subscriptions.get(host)?.owner;
+    if (!previous || previous === this) {
+      return;
+    }
+    // A shared client's credentials change before pane callbacks run. Move peers
+    // together so the first reconnect drain still observes every pane's edit hold.
+    for (const pane of previous.panes) {
+      if (outboxOwnerKey(pane) !== this.ownerGatewayKey) {
+        continue;
+      }
+      subscriptions.get(pane)!.owner = this;
+      previous.hosts.delete(pane);
+      for (const [key, live] of previous.live) {
+        for (const [id, projection] of live) {
+          if (projection.owner === pane) {
+            live.delete(id);
+          }
+        }
+        if (!live.size) {
+          previous.live.delete(key);
+        }
+      }
+      // Stored rows remain authoritative; old credential-local overlays do not.
+      pane.chatQueue = [];
+      previous.detach(pane);
+      this.attach(pane);
+    }
+  }
+  private attach(host: Host): void {
     this.panes.add(host);
     this.unsubscribe ??= subscribeStoredChatOutboxChanges(() => this.publish(undefined, true));
+  }
+  private detach(host: Host): void {
+    this.panes.delete(host);
+    if (!this.panes.size) {
+      this.unsubscribe?.();
+      this.unsubscribe = null;
+    }
+    this.prune(host);
+  }
+  subscribe(host: Host): () => void {
+    const subscription = { owner: this };
+    subscriptions.set(host, subscription);
+    this.attach(host);
     this.reconcile(host, this.state(host));
     this.syncHost(host, { requestUpdate: false });
     return () => {
-      this.panes.delete(host);
-      if (!this.panes.size) {
-        this.unsubscribe?.();
-        this.unsubscribe = null;
+      if (subscriptions.get(host) !== subscription) {
+        return;
       }
-      this.prune(host);
+      subscriptions.delete(host);
+      subscription.owner.detach(host);
     };
   }
   private reconcile(host: Host, state: HostProjection): void {
@@ -288,7 +411,12 @@ class ChatOutboxGatewayOwner {
     if (!this.unsubscribe && !this.live.size && !this.hosts.size) {
       // Defer eviction until a synchronous send transition can add its live overlay.
       queueMicrotask(() => {
-        if (!this.unsubscribe && !this.live.size && !this.hosts.size) {
+        if (
+          !this.unsubscribe &&
+          !this.live.size &&
+          !this.hosts.size &&
+          owners.get(this.ownerGatewayKey) === this
+        ) {
           owners.delete(this.ownerGatewayKey);
         }
       });
@@ -296,13 +424,19 @@ class ChatOutboxGatewayOwner {
   }
 }
 const owners = new Map<string, ChatOutboxGatewayOwner>();
-export function chatOutboxOwner(host: Composer): ChatOutboxGatewayOwner {
+const subscriptions = new WeakMap<Composer, { owner: ChatOutboxGatewayOwner }>();
+function outboxOwnerKey(host: Composer): string {
   const storage = getSafeSessionStorage();
   if (storage && !storageIds.has(storage)) {
     storageIds.set(storage, ++nextStorageId);
   }
-  const key = `${storage ? storageIds.get(storage) : 0}\u0000${host.settings?.gatewayUrl?.trim() || "default"}`;
+  const key = `${storage ? storageIds.get(storage) : 0}\u0000${host.settings?.gatewayUrl?.trim() || "default"}\u0000${host.client?.recoveryScope ?? ""}`;
+  return key;
+}
+export function chatOutboxOwner(host: Composer): ChatOutboxGatewayOwner {
+  const key = outboxOwnerKey(host);
   const owner = owners.get(key) ?? new ChatOutboxGatewayOwner(key);
   owners.set(key, owner);
+  owner.adoptSubscriptions(host);
   return owner;
 }

--- a/ui/src/pages/chat/chat-pending-inputs.test.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.test.ts
@@ -1,7 +1,11 @@
 /* @vitest-environment jsdom */
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatPendingInputsPage } from "../../../../packages/gateway-protocol/src/schema/logs-chat.js";
 import { createDeferred } from "../../../../test/helpers/promise.js";
+import type { ChatQueueItem } from "../../lib/chat/chat-types.ts";
+import * as outboxPayloadStore from "../../lib/chat/outbox-payload-store.runtime.ts";
+import { storageTargetForGateway } from "../../lib/chat/outbox-store.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { getChatHistoryLoadState, loadChatHistory } from "./chat-history.ts";
 import { makeChatHost } from "./chat-host.test-support.ts";
@@ -17,6 +21,10 @@ import type { ChatPageHost } from "./chat-state-host.ts";
 import { createPageState } from "./chat-state-page.ts";
 import { buildChatItems } from "./chat-thread-build.ts";
 import { resetChatThreadState } from "./chat-thread.ts";
+import { listStoredChatOutboxes, loadChatComposerSnapshot } from "./composer-persistence.ts";
+import { installOutboxBrowserStorage } from "./outbox-browser.test-support.ts";
+import { prepareOutboxPayload } from "./outbox-payloads.ts";
+import { buildLocalUserMessage } from "./user-message-content.ts";
 
 const sessionKey = "agent:main:accepted-inputs";
 const sessionId = "accepted-input-session";
@@ -54,6 +62,7 @@ beforeEach(() => {
 afterEach(() => {
   resetChatThreadState();
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("server-owned pending input display", () => {
@@ -181,49 +190,132 @@ describe("server-owned pending input display", () => {
     },
   );
 
-  it("retires browser retry custody while keeping accepted input separate from history", async () => {
-    const history = [
-      { role: "assistant", content: "Still working", __openclaw: { id: "reply-1", seq: 1 } },
-    ];
-    const host = makeChatHost({
-      sessionKey,
-      currentSessionId: sessionId,
-      requestHandlers: { "chat.history": { messages: history, sessionId, pendingInputs: page } },
-    });
-    const queued = {
-      id: "outbox-1",
-      text: "Keep my accepted input",
-      createdAt: 100,
-      sessionKey,
-      sendRunId: input.runId,
-      sendState: "waiting-reconnect" as const,
-    };
-    expect(admitQueuedMessageForSession(host, sessionKey, queued)).toBe(true);
-    await loadChatHistory(host);
-    expect(readChatQueueForScope(host, sessionKey)).toEqual([]);
-    expect(host.chatMessages).toEqual(history);
-    expect(getChatPendingInputs(host)?.page).toEqual(page);
-    const items = buildChatItems({
-      paneId: "pending-pane",
-      sessionKey,
-      messages: host.chatMessages,
-      pendingInputs: page.items,
-      queue: host.chatQueue,
-      toolMessages: [],
-      streamSegments: [],
-      stream: null,
-      streamStartedAt: null,
-      showToolCalls: true,
-    });
-    expect(items.filter((item) => item.kind === "group" && item.role === "user")).toHaveLength(1);
-    expect(items).toContainEqual(
-      expect.objectContaining({
-        kind: "notice",
-        text: expect.stringContaining("will not run automatically"),
-      }),
-    );
-    expect(host.request.mock.calls.some(([method]) => method === "chat.send")).toBe(false);
-  });
+  it.each(["text", "blob"])(
+    "retires browser retry custody while keeping accepted %s input separate from history",
+    async (kind) => {
+      if (kind === "blob") {
+        installOutboxBrowserStorage();
+      }
+      const history = [
+        { role: "assistant", content: "Still working", __openclaw: { id: "reply-1", seq: 1 } },
+      ];
+      const imageBase64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jh0cAAAAASUVORK5CYII=";
+      const imageBytes = Buffer.from(imageBase64, "base64");
+      const attachment = {
+        id: "custody-image",
+        mimeType: "image/png",
+        fileName: "custody.png",
+        sizeBytes: imageBytes.length,
+        dataUrl: `data:image/png;base64,${imageBase64}`,
+      };
+      let queued: ChatQueueItem = {
+        id: "outbox-1",
+        text: "Keep my accepted input",
+        createdAt: 100,
+        sessionKey,
+        sendRunId: input.runId,
+        sendState: "waiting-reconnect",
+        ...(kind === "blob" ? { attachments: [attachment] } : {}),
+      };
+      const message =
+        kind === "blob"
+          ? expectDefined(
+              buildLocalUserMessage({
+                text: queued.text,
+                attachments: [attachment],
+                createdAt: input.acceptedAt,
+                runId: input.runId,
+              }),
+              "complete accepted attachment message",
+            )
+          : input.message;
+      const acceptedPage: ChatPendingInputsPage = { ...page, items: [{ ...input, message }] };
+      const host = makeChatHost({
+        sessionKey,
+        currentSessionId: sessionId,
+        requestHandlers: {
+          "chat.history": { messages: history, sessionId, pendingInputs: acceptedPage },
+        },
+      });
+      const cleanup = vi.spyOn(outboxPayloadStore, "removeOutboxPayloads");
+      if (kind === "blob") {
+        const prepared = await prepareOutboxPayload(host, queued);
+        if (prepared.status !== "ready") {
+          throw new Error(`Could not prepare custody attachment: ${prepared.reason}`);
+        }
+        queued = prepared.item;
+        expect(queued.attachmentPayload).toBeDefined();
+      }
+      const reference = queued.attachmentPayload;
+      const payloadOwner = reference
+        ? {
+            tabId: reference.tabId,
+            gatewayOwner: storageTargetForGateway(host.settings.gatewayUrl).gatewayOwner,
+            recoveryScope: reference.recoveryScope,
+            scopeKey: reference.scopeKey,
+            queueId: queued.id,
+          }
+        : undefined;
+      if (reference && payloadOwner) {
+        sessionStorage.setItem("openclaw.control.outboxTab.v1", reference.tabId);
+        const stored = await outboxPayloadStore.readOutboxPayload(payloadOwner, reference);
+        if (stored.status !== "ready") {
+          throw new Error(`Expected stored custody bytes: ${stored.reason}`);
+        }
+        expect(stored.value).toHaveLength(1);
+        expect(Buffer.from(await stored.value[0]!.blob.arrayBuffer())).toEqual(imageBytes);
+      }
+      expect(admitQueuedMessageForSession(host, sessionKey, queued)).toBe(true);
+      expect(
+        loadChatComposerSnapshot(host, sessionKey)?.queue[0]?.attachments?.[0]?.dataUrl,
+      ).toBeUndefined();
+      await loadChatHistory(host);
+      expect(readChatQueueForScope(host, sessionKey)).toEqual([]);
+      expect(listStoredChatOutboxes(host)).toEqual([]);
+      expect(host.chatMessages).toEqual(history);
+      expect(getChatPendingInputs(host)?.page).toEqual(acceptedPage);
+      if (reference && payloadOwner) {
+        await vi.waitFor(async () => {
+          expect(await outboxPayloadStore.readOutboxPayload(payloadOwner, reference)).toEqual({
+            status: "failed",
+            reason: "missing",
+          });
+        });
+        expect(cleanup).toHaveBeenCalledTimes(1);
+        expect(cleanup).toHaveBeenCalledWith([reference]);
+      } else {
+        expect(cleanup).not.toHaveBeenCalled();
+      }
+      const items = buildChatItems({
+        paneId: "pending-pane",
+        sessionKey,
+        messages: host.chatMessages,
+        pendingInputs: acceptedPage.items,
+        queue: host.chatQueue,
+        toolMessages: [],
+        streamSegments: [],
+        stream: null,
+        streamStartedAt: null,
+        showToolCalls: true,
+      });
+      expect(items.filter((item) => item.kind === "group" && item.role === "user")).toHaveLength(1);
+      expect(items).toContainEqual(
+        expect.objectContaining({
+          kind: "group",
+          role: "user",
+          messages: [expect.objectContaining({ message })],
+        }),
+      );
+      expect(items).toContainEqual(
+        expect.objectContaining({
+          kind: "notice",
+          text: expect.stringContaining("will not run automatically"),
+        }),
+      );
+      expect(host.request.mock.calls.some(([method]) => method === "chat.send")).toBe(false);
+    },
+  );
 
   it("pages custody without replacing transcript or applying a stale physical-session response", async () => {
     let resolve!: (value: unknown) => void;

--- a/ui/src/pages/chat/chat-pending-inputs.test.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.test.ts
@@ -253,7 +253,6 @@ describe("server-owned pending input display", () => {
             tabId: reference.tabId,
             gatewayOwner: storageTargetForGateway(host.settings.gatewayUrl).gatewayOwner,
             recoveryScope: reference.recoveryScope,
-            scopeKey: reference.scopeKey,
             queueId: queued.id,
           }
         : undefined;

--- a/ui/src/pages/chat/chat-queue.ts
+++ b/ui/src/pages/chat/chat-queue.ts
@@ -416,6 +416,19 @@ export function removeDeliveredQueuedChatSendForRun(
   return removed;
 }
 
+export function sameQueuedDeliveryVersion(left: ChatQueueItem, right: ChatQueueItem): boolean {
+  return (
+    left.id === right.id &&
+    left.sendRunId === right.sendRunId &&
+    left.sendAttempts === right.sendAttempts &&
+    left.sendState === right.sendState &&
+    left.agentId === right.agentId &&
+    left.sessionKey === right.sessionKey &&
+    left.orderKey === right.orderKey &&
+    left.attachmentPayload?.key === right.attachmentPayload?.key
+  );
+}
+
 export function readDeliveredQueuedChatSendForRun(
   host: ChatQueueScopedSessionHost,
   runId: string | undefined,

--- a/ui/src/pages/chat/chat-reset-delivery.ts
+++ b/ui/src/pages/chat/chat-reset-delivery.ts
@@ -9,7 +9,8 @@ import { admitQueuedMessageForSession } from "./chat-queue.ts";
 import { cancelChatDelivery } from "./chat-send-composer.ts";
 import type { ChatHost } from "./chat-send-contract.ts";
 import {
-  enqueuePendingSendMessage,
+  createPendingSendMessage,
+  publishPendingSendMessage,
   reconnectSafeQueuedSendState,
   setChatError,
 } from "./chat-send-queue-state.ts";
@@ -25,7 +26,7 @@ export function createResetSlashCommandSender(
   deliverChatQueueItem: DeliverChatQueueItem,
 ): ChatOutboxDrainDependencies["sendResetSlashCommand"] {
   return async (host: ChatHost, message: string, options: ChatCommandResetOptions) => {
-    const item = enqueuePendingSendMessage(
+    const item = createPendingSendMessage(
       host,
       message,
       undefined,
@@ -33,6 +34,9 @@ export function createResetSlashCommandSender(
       undefined,
       reconnectSafeQueuedSendState(host),
     );
+    if (item) {
+      publishPendingSendMessage(host, item);
+    }
     if (!item || !admitQueuedMessageForSession(host, host.sessionKey, item)) {
       if (item) {
         cancelChatDelivery(host, item, { previousDraft: options.previousDraft });

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -2908,6 +2908,12 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         for (const width of [320, 560]) {
           await page.setViewportSize({ width, height: 852 });
           const failedCard = cards.filter({ hasText: "settings.toml" });
+          // The viewport ACK does not settle the retained pane's responsive geometry.
+          await failedCard.scrollIntoViewIfNeeded();
+          await waitForLayoutSettled(
+            page,
+            ".chat-main__conversation, .chat-assistant-attachment-card, .chat-assistant-attachment-card__status-reason",
+          );
           const mobileStatusLayout = await failedCard.evaluate((card) => {
             const badge = card.querySelector<HTMLElement>(
               ".chat-assistant-attachment-card__status-badge",

--- a/ui/src/pages/chat/chat-send-actions.ts
+++ b/ui/src/pages/chat/chat-send-actions.ts
@@ -110,19 +110,26 @@ function findStoredOutbox(host: ChatHost, id: string) {
 const resetRetryState = (
   entry: ChatQueueItem,
   sendState: ChatQueueItem["sendState"],
-): ChatQueueItem => ({
-  ...entry,
-  sendAttempts: 0,
-  // A failed delivery keeps its diagnostic while an explicit retry waits for
-  // run admission; the transcript uses it to retain the same optimistic row.
-  sendError: entry.sendState === "failed" ? entry.sendError : undefined,
-  sendRequestStartedAtMs: undefined,
-  sendRunId:
-    entry.sendState === "failed" && entry.queueMode !== "steer" && !entry.intent
-      ? generateUUID()
-      : entry.sendRunId,
-  sendState,
-});
+): ChatQueueItem => {
+  // An ID-less post-clear review barrier has no transport attempt to preserve.
+  const uncertain =
+    entry.sendState === "unconfirmed" && Boolean(entry.sendRunId) && !entry.localCommandName;
+  return {
+    ...entry,
+    // Local payload failure cannot erase an uncertain transport attempt. Keep its
+    // identity until the explicitly admitted retry actually reaches transport.
+    sendAttempts: uncertain ? entry.sendAttempts : 0,
+    // A failed delivery keeps its diagnostic while an explicit retry waits for
+    // run admission; the transcript uses it to retain the same optimistic row.
+    sendError: entry.sendState === "failed" ? entry.sendError : undefined,
+    sendRequestStartedAtMs: uncertain ? entry.sendRequestStartedAtMs : undefined,
+    sendRunId:
+      entry.sendState === "failed" && entry.queueMode !== "steer" && !entry.intent
+        ? generateUUID()
+        : entry.sendRunId,
+    sendState: uncertain ? "unconfirmed" : sendState,
+  };
+};
 
 export async function steerQueuedChatMessage(host: ChatHost, id: string): Promise<void> {
   if (readQueuedMessageById(host, id)?.intent) {
@@ -226,6 +233,8 @@ export function moveQueuedChatMessage(
 export async function retryQueuedChatMessage(host: ChatHost, id: string) {
   const item = host.chatQueue.find((entry) => entry.id === id);
   const retriesFailedDelivery = item?.sendState === "failed" && !item.localCommandName;
+  const retriesUnconfirmed =
+    item?.sendState === "unconfirmed" && Boolean(item.sendRunId) && !item.localCommandName;
   if (isQueuedMessageRetryBlocked(host, id)) {
     setChatError(host, QUEUED_MESSAGE_RETRY_CONFLICT_ERROR);
     return;
@@ -279,12 +288,13 @@ export async function retryQueuedChatMessage(host: ChatHost, id: string) {
     setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
     return;
   }
+  const explicitAdmission = retry.queueMode || retriesFailedDelivery || retriesUnconfirmed;
   const drain = scheduleStoredChatOutboxDrain(
     host,
     outbox,
     chatOutboxDrainDependencies,
-    retry.queueMode || retriesFailedDelivery ? retry.id : undefined,
-    retry.queueMode || retriesFailedDelivery
+    explicitAdmission ? retry.id : undefined,
+    explicitAdmission
       ? {
           routingSessionKey: host.sessionKey,
           ...(retriesFailedDelivery ? { allowActiveRunSend: true } : {}),

--- a/ui/src/pages/chat/chat-send-contract.ts
+++ b/ui/src/pages/chat/chat-send-contract.ts
@@ -43,6 +43,7 @@ export type ChatHost = ChatInputHistoryState &
     chatVerboseLevel: string | null;
     chatStreamStartedAt: number | null;
     chatAttachments: ChatAttachment[];
+    selectedChatSessionIncognito?: boolean;
     chatQueue: ChatQueueItem[];
     /** Pane-local row draft while a queued message remains held in the outbox. */
     chatQueuedEdit?: QueuedMessageEdit | null;

--- a/ui/src/pages/chat/chat-send-delivery.ts
+++ b/ui/src/pages/chat/chat-send-delivery.ts
@@ -35,6 +35,7 @@ import {
   finishChatDeliveryAdmission,
   finishScopedChatSending,
   reconnectSafeQueuedSendState,
+  prepareQueuedChatPayload,
   setChatError,
   updateQueuedSendItem,
 } from "./chat-send-queue-state.ts";
@@ -144,10 +145,20 @@ async function sendQueuedChatMessage(
   queuedSessionKey = host.sessionKey,
 ): Promise<QueuedChatSendResult> {
   const storageMode = options?.storageMode ?? "durable";
-  const queued = readQueuedMessageById(host, id);
+  let queued = readQueuedMessageById(host, id);
   const approvedReset = queued?.localCommandName === "reset" && Boolean(options?.target);
   if (!queued || queued.pendingRunId || (queued.localCommandName && !approvedReset)) {
     return "failed";
+  }
+  if (
+    storageMode === "durable" &&
+    (queued.attachments?.length || queued.attachmentPayload || queued.attachmentStorageError)
+  ) {
+    const prepared = await prepareQueuedChatPayload(host, queued, queuedSessionKey);
+    if (typeof prepared === "string") {
+      return prepared;
+    }
+    queued = prepared;
   }
   const queueSessionKey = queued.sessionKey ?? queuedSessionKey;
   const consumedSettings = new Set<Promise<boolean>>();
@@ -189,6 +200,9 @@ async function sendQueuedChatMessage(
     }
   }
   prepared = finishChatDeliveryAdmission(host, prepared, storageMode, queueSessionKey, options);
+  if (typeof prepared !== "string" && queued.attachmentPayload) {
+    prepared = { ...prepared, attachments: queued.attachments };
+  }
   if (typeof prepared === "string") {
     return prepared;
   }
@@ -216,7 +230,7 @@ async function sendQueuedChatMessage(
     };
   }
   const message = prepared.intent ? prepared.text : prepared.text.trim();
-  const attachments = prepared.attachments ?? [];
+  const attachments = (queued.attachmentPayload ? queued.attachments : prepared.attachments) ?? [];
   if (!message && attachments.length === 0) {
     removeQueuedMessageWithoutReleasing(host, id, prepared.sessionKey ?? host.sessionKey);
     return "sent";

--- a/ui/src/pages/chat/chat-send-queue-state.ts
+++ b/ui/src/pages/chat/chat-send-queue-state.ts
@@ -15,11 +15,22 @@ import {
   updateVolatileQueuedMessage,
 } from "./chat-queue.ts";
 import type { ChatHost } from "./chat-send-contract.ts";
-import { chatSendHoldReason, OFFLINE_QUEUE_STORAGE_ERROR } from "./chat-send-support.ts";
+import {
+  chatSendHoldReason,
+  surfaceChatDeliveryFailure,
+  OFFLINE_QUEUE_STORAGE_ERROR,
+} from "./chat-send-support.ts";
 import { recordChatSendTiming, schedulePendingSendPaintTiming } from "./chat-send-timing.ts";
 import { getPendingChatPickerPatch } from "./chat-session.ts";
 import { storedChatOutboxScopeKey, type StoredChatOutboxScope } from "./composer-persistence.ts";
+import {
+  captureOutboxPayloadOwner,
+  failOutboxPayload,
+  prepareOutboxPayload,
+  retireOutboxPayload,
+} from "./outbox-payloads.ts";
 import { controlUiNowMs } from "./performance.ts";
+import { isQueuedMessageBeingEdited } from "./queued-message-edit.ts";
 import { hasDirectSessionRun, isChatBusy } from "./run-lifecycle.ts";
 import { scheduleChatScroll } from "./scroll.ts";
 
@@ -32,7 +43,7 @@ export function setChatError(
   host.chatError = message;
 }
 
-export function enqueuePendingSendMessage(
+export function createPendingSendMessage(
   host: ChatHost,
   text: string,
   attachments?: ChatAttachment[],
@@ -74,16 +85,18 @@ export function enqueuePendingSendMessage(
     ...(sender ? { sender } : {}),
     ...(replyToId ? { replyToId } : {}),
   };
-  keepVolatileQueuedMessage(host, host.sessionKey, pending, pending.agentId);
+  return pending;
+}
+
+export function publishPendingSendMessage(host: ChatHost, pending: ChatQueueItem): void {
+  const submittedAtMs = pending.sendSubmittedAtMs ?? controlUiNowMs();
+  keepVolatileQueuedMessage(host, pending.sessionKey ?? host.sessionKey, pending, pending.agentId);
   recordChatSendTiming(host, pending, "pending-visible", submittedAtMs);
-  if (sendState === "waiting-model" || sendState === "waiting-reconnect") {
-    recordChatSendTiming(host, pending, sendState, submittedAtMs);
+  if (pending.sendState === "waiting-model" || pending.sendState === "waiting-reconnect") {
+    recordChatSendTiming(host, pending, pending.sendState, submittedAtMs);
   }
   schedulePendingSendPaintTiming(host, pending, submittedAtMs);
-  scheduleChatScroll(host, true, false, {
-    source: "manual",
-  });
-  return pending;
+  scheduleChatScroll(host, true, false, { source: "manual" });
 }
 
 export function reconnectSafeQueuedSendState(
@@ -202,4 +215,71 @@ export async function waitForPendingChatSettings(
     pending = nextPending;
   }
   return false;
+}
+
+export async function prepareQueuedChatPayload(
+  host: ChatHost,
+  queued: ChatQueueItem,
+  queuedSessionKey: string,
+): Promise<ChatQueueItem | QueuedChatSendResult> {
+  const id = queued.id;
+  const connectionIsCurrent = captureChatConnectionOwner(host);
+  const ownerIsCurrent = captureOutboxPayloadOwner(host);
+  const original = queued;
+  const payload = await prepareOutboxPayload(host, original);
+  const current = readQueuedMessageById(host, id);
+  if (
+    !connectionIsCurrent() ||
+    !ownerIsCurrent() ||
+    !current ||
+    current.sendRunId !== original.sendRunId ||
+    current.attachmentPayload?.key !== original.attachmentPayload?.key ||
+    current.sendAttempts !== original.sendAttempts ||
+    current.sendState !== original.sendState ||
+    isQueuedMessageBeingEdited(host, id)
+  ) {
+    if (payload.status === "ready" && !original.attachmentPayload) {
+      retireOutboxPayload(payload.item);
+    }
+    return "pending";
+  }
+  if (payload.status === "failed") {
+    const failed = failOutboxPayload(current, payload.reason);
+    updateQueuedMessageForSession(host, original.sessionKey ?? queuedSessionKey, id, () => failed);
+    surfaceChatDeliveryFailure(
+      host,
+      original.sessionKey ?? queuedSessionKey,
+      original.agentId,
+      failed.sendError,
+    );
+    return "failed";
+  }
+  const hydrated = payload.item;
+  if (
+    hydrated.attachmentPayload?.key !== original.attachmentPayload?.key &&
+    hydrated.sendState === "unconfirmed"
+  ) {
+    updateQueuedMessageForSession(
+      host,
+      original.sessionKey ?? queuedSessionKey,
+      id,
+      () => payload.item,
+    );
+    return "pending";
+  }
+  if (
+    (!original.attachmentPayload || original.attachmentStorageError) &&
+    !updateQueuedMessageForSession(
+      host,
+      original.sessionKey ?? queuedSessionKey,
+      id,
+      () => payload.item,
+    )
+  ) {
+    if (!original.attachmentPayload) {
+      retireOutboxPayload(payload.item);
+    }
+    return "pending";
+  }
+  return payload.item;
 }

--- a/ui/src/pages/chat/chat-send-submit.test.ts
+++ b/ui/src/pages/chat/chat-send-submit.test.ts
@@ -17,12 +17,14 @@ import { retryQueuedChatMessage, retryReconnectableQueuedChatSends } from "./cha
 import type { ChatHost } from "./chat-send-contract.ts";
 import { handleSendChat } from "./chat-send-submit.ts";
 import { getChatSessionProjection } from "./history-merge.ts";
+import { installOutboxBrowserStorage } from "./outbox-browser.test-support.ts";
 import { reconcileChatRunLifecycle } from "./run-lifecycle.ts";
 
 const attachmentsToRelease: ChatAttachment[] = [];
 const attachmentDataUrl = "data:application/pdf;base64,JVBERi0xLjQK";
 
 beforeEach(() => {
+  installOutboxBrowserStorage();
   vi.stubGlobal("sessionStorage", createStorageMock());
   vi.stubGlobal("requestAnimationFrame", () => 1);
   vi.stubGlobal("cancelAnimationFrame", () => undefined);
@@ -549,7 +551,7 @@ describe("handleSendChat browser annotation context", () => {
     });
 
     const send = handleSendChat(host);
-    await Promise.resolve();
+    await vi.waitFor(() => expect(host.chatQueue).toHaveLength(1));
     expect(host.chatQueue[0]?.text).toBe("Stable browser context\n\nUse the marked area");
 
     host.chatMessage = "New draft";

--- a/ui/src/pages/chat/chat-send-submit.ts
+++ b/ui/src/pages/chat/chat-send-submit.ts
@@ -42,7 +42,8 @@ import type { ChatHost } from "./chat-send-contract.ts";
 import { chatOutboxDrainDependencies, deliverChatQueueItem } from "./chat-send-delivery.ts";
 import {
   canSendVolatileQueueItem,
-  enqueuePendingSendMessage,
+  createPendingSendMessage,
+  publishPendingSendMessage,
   reconnectSafeQueuedSendState,
   setChatError,
   waitForPendingChatSettings,
@@ -61,6 +62,12 @@ import {
   recordNonTranscriptInputHistory,
   resetChatInputHistoryNavigation,
 } from "./input-history.ts";
+import {
+  captureOutboxPayloadOwner,
+  outboxPayloadError,
+  prepareOutboxPayload,
+  retireOutboxPayload,
+} from "./outbox-payloads.ts";
 import { controlUiNowMs } from "./performance.ts";
 import { activeQueuedMessageEdit, retireEditedQueuedMessageSource } from "./queued-message-edit.ts";
 import {
@@ -209,6 +216,9 @@ export async function handleSendChat(
   const userMessage = intent ? rawMessage : rawMessage.trim();
   const submittedAtMs = controlUiNowMs();
   const submittedSessionKey = host.sessionKey;
+  const submittedClient = host.client;
+  const submittedEpoch = host.connectionEpoch;
+  const submittedOwnerIsCurrent = captureOutboxPayloadOwner(host);
   let expectedLeafEntryId = resolveDisplayedLeafEntryId(host);
   const attachmentsToSend = snapshotChatAttachments(
     messageOverride == null ? host.chatAttachments : (opts?.attachmentsOverride ?? []),
@@ -544,21 +554,8 @@ export async function handleSendChat(
       setChatError(host, holdReason);
       return;
     }
-    const cleared =
-      messageOverride == null
-        ? clearSubmittedComposerState(
-            host,
-            previousDraft,
-            attachmentsToSend,
-            Boolean(rawParsedCommand),
-          )
-        : {};
-    if (messageOverride == null) {
-      recordNonTranscriptInputHistory(host, userMessage);
-    }
-
-    const pendingSettings = getPendingChatPickerPatch(host, submittedSessionKey);
-    const waitingForSettings = Boolean(pendingSettings);
+    let pendingSettings = getPendingChatPickerPatch(host, submittedSessionKey);
+    let waitingForSettings = Boolean(pendingSettings);
     const directRunActive = hasDirectSessionRun(host);
     // Only an explicit browser override replaces inherited Gateway policy.
     const followUpMode =
@@ -571,7 +568,7 @@ export async function handleSendChat(
     // store write, so a rejected write leaves the original queued and editable.
     const resumedEdit =
       requestedEditId && resumedEditCandidate?.id === requestedEditId ? resumedEditCandidate : null;
-    const queued = enqueuePendingSendMessage(
+    let queued = createPendingSendMessage(
       host,
       effectiveMessage,
       deliveredAttachments.length ? deliveredAttachments : undefined,
@@ -587,6 +584,54 @@ export async function handleSendChat(
     if (!queued) {
       return;
     }
+    if (queued.attachments?.length) {
+      const payload = await prepareOutboxPayload(host, queued);
+      const currentEdit = activeQueuedMessageEdit(host);
+      const stillOwnsSubmission =
+        submittedOwnerIsCurrent() &&
+        host.client === submittedClient &&
+        host.connectionEpoch === submittedEpoch &&
+        host.sessionKey === submittedSessionKey &&
+        visibleSessionMatches(host, submittedSessionKey, submittedAgentId) &&
+        (!isInlineEditSubmission ||
+          (currentEdit === inlineEdit && currentEdit.revision === submittedInlineEditRevision));
+      if (!stillOwnsSubmission) {
+        if (payload.status === "ready") {
+          retireOutboxPayload(payload.item);
+        }
+        return;
+      }
+      if (payload.status === "failed") {
+        setChatError(host, outboxPayloadError(payload.reason));
+        return;
+      }
+      queued = payload.item;
+      const hold = chatSendHoldReason(host, submittedSessionKey);
+      if (hold || (intent && (isChatBusy(host) || hasDirectSessionRun(host)))) {
+        retireOutboxPayload(queued);
+        setChatError(host, hold ?? t("chat.goals.busy"));
+        return;
+      }
+      // Retain a picker captured before storage, including its rejected result;
+      // delivery follows the latest picker tail before issuing the request.
+      pendingSettings ??= getPendingChatPickerPatch(host, submittedSessionKey);
+      waitingForSettings = Boolean(pendingSettings);
+      queued.sendState = waitingForSettings ? "waiting-model" : reconnectSafeQueuedSendState(host);
+    }
+    const cleared =
+      messageOverride == null
+        ? clearSubmittedComposerState(
+            host,
+            previousDraft,
+            attachmentsToSend,
+            Boolean(rawParsedCommand),
+          )
+        : {};
+    if (messageOverride == null) {
+      recordNonTranscriptInputHistory(host, userMessage);
+    }
+
+    publishPendingSendMessage(host, queued);
     const admittedDurably = admitQueuedMessageForSession(
       host,
       submittedSessionKey,
@@ -603,6 +648,7 @@ export async function handleSendChat(
     }
     const canSendFromMemory =
       !admittedDurably &&
+      !queued.attachments?.length &&
       (!resumedEdit || !resumedEdit.sourceWasDurable) &&
       // A still-open edit means its stored source outlived the rejected write;
       // sending the replacement from memory would strand the original as a duplicate.
@@ -610,6 +656,7 @@ export async function handleSendChat(
       !waitingForSettings &&
       canSendVolatileQueueItem(host, queued, submittedSessionKey);
     if (!admittedDurably && !canSendFromMemory) {
+      retireOutboxPayload(queued);
       cancelChatDelivery(host, queued, {
         previousDraft: cleared.previousDraft,
         previousAttachments: cleared.previousAttachments,

--- a/ui/src/pages/chat/chat-send-support.ts
+++ b/ui/src/pages/chat/chat-send-support.ts
@@ -12,10 +12,23 @@ import {
 } from "../../lib/sessions/session-key.ts";
 import { showToast } from "../../lib/toast.ts";
 import { getChatAttachmentDataUrl } from "./attachment-payload-store.ts";
+import {
+  readDeliveredQueuedChatSendForRun,
+  readQueuedMessageById,
+  removeDeliveredQueuedChatSendForRun,
+  sameQueuedDeliveryVersion,
+  updateQueuedMessageForSession,
+} from "./chat-queue.ts";
 import type { TerminalFailureChatSendAck } from "./chat-send-ack.ts";
 import type { ChatHost } from "./chat-send-contract.ts";
 import type { ChatState } from "./chat-state-contract.ts";
+import { storedChatOutboxScopeKey, type StoredChatOutboxScope } from "./composer-persistence.ts";
 import { readChatSessionProjectionScope, reduceChatSessionProjection } from "./history-merge.ts";
+import {
+  captureOutboxPayloadOwner,
+  failOutboxPayload,
+  prepareOutboxPayload,
+} from "./outbox-payloads.ts";
 import { appendChatMessageToCache, readChatMessagesFromCache } from "./session-message-cache.ts";
 import { buildLocalUserMessage } from "./user-message-content.ts";
 
@@ -85,24 +98,28 @@ function findQueuedSendMessageIndex(
 
 function durableDeliveredAttachments(
   attachments: readonly ChatAttachment[] | undefined,
-): ChatAttachment[] | undefined {
-  return attachments?.flatMap((attachment) => {
-    // Composer uploads keep their bytes in the payload store; queue rows carry
-    // metadata only. Resolve through the store before queue ownership ends.
+): ChatAttachment[] | null {
+  const pinned: ChatAttachment[] = [];
+  for (const attachment of attachments ?? []) {
     const dataUrl = getChatAttachmentDataUrl(attachment);
-    return dataUrl ? [{ ...attachment, dataUrl, previewUrl: dataUrl }] : [];
-  });
+    if (!dataUrl) {
+      return null;
+    }
+    pinned.push({ ...attachment, dataUrl, previewUrl: dataUrl });
+  }
+  return pinned;
 }
 
-export function preserveQueuedUserTurn(state: ChatSendSupportHost, item: ChatQueueItem): void {
+function preserveQueuedUserTurn(state: ChatSendSupportHost, item: ChatQueueItem): void {
   const runId = item.sendRunId;
   const sessionKey = item.sessionKey ?? state.sessionKey;
-  if (!runId) {
+  const attachments = durableDeliveredAttachments(item.attachments);
+  if (!runId || !attachments) {
     return;
   }
   const userMessage = buildLocalUserMessage({
     text: item.text,
-    attachments: durableDeliveredAttachments(item.attachments),
+    attachments,
     createdAt: item.createdAt,
     runId,
     ...(item.replyToId ? { replyToId: item.replyToId } : {}),
@@ -133,6 +150,120 @@ export function preserveQueuedUserTurn(state: ChatSendSupportHost, item: ChatQue
   if (!chatMessagesContainQueuedSend(cached, item, true)) {
     appendChatMessageToCache(state.chatMessagesBySession, state, target, userMessage);
   }
+}
+
+const MAX_REMEMBERED_DELIVERED_QUEUE_TURNS = 64;
+const deliveredQueueTurnsByClient = new WeakMap<object, Map<string, ChatQueueItem>>();
+type DeliveredTurnRetirement = "retired" | "retained" | "stale";
+
+/** Transfer every byte to the transcript/cache before retiring its durable owner. */
+export function retireDeliveredQueuedUserTurn(
+  host: ChatHost,
+  runId: string | undefined,
+  scope: StoredChatOutboxScope,
+): DeliveredTurnRetirement | Promise<DeliveredTurnRetirement> {
+  const client = host.client;
+  const owner = client ?? host;
+  const turns = deliveredQueueTurnsByClient.get(owner) ?? new Map<string, ChatQueueItem>();
+  deliveredQueueTurnsByClient.set(owner, turns);
+  const deliveryKey = JSON.stringify([
+    host.settings.gatewayUrl,
+    client?.recoveryScope,
+    storedChatOutboxScopeKey(scope),
+    runId,
+  ]);
+  const stored = readDeliveredQueuedChatSendForRun(host, runId, scope)?.item;
+  if (!stored) {
+    const remembered = turns.get(deliveryKey);
+    if (remembered) {
+      preserveQueuedUserTurn(host, remembered);
+    }
+    return "retired";
+  }
+  const connectionEpoch = host.connectionEpoch;
+  const connected = host.connected;
+  const payloadOwnerIsCurrent = captureOutboxPayloadOwner(host);
+  const isCurrent = () =>
+    host.connected === connected &&
+    host.connectionEpoch === connectionEpoch &&
+    payloadOwnerIsCurrent();
+  const currentItem = () => readDeliveredQueuedChatSendForRun(host, runId, scope)?.item;
+  const commit = (item: ChatQueueItem): DeliveredTurnRetirement => {
+    if (!isCurrent()) {
+      return "stale";
+    }
+    const current = currentItem();
+    if (!current) {
+      const remembered = turns.get(deliveryKey);
+      if (!remembered) {
+        return "stale";
+      }
+      preserveQueuedUserTurn(host, remembered);
+      return "retired";
+    }
+    if (!sameQueuedDeliveryVersion(current, stored)) {
+      return "stale";
+    }
+    preserveQueuedUserTurn(host, item);
+    // Every pane receives the terminal. Retain the complete, independent handoff
+    // before the first pane removes the queue and releases its Blob/preview URLs.
+    turns.delete(deliveryKey);
+    turns.set(deliveryKey, item);
+    if (turns.size > MAX_REMEMBERED_DELIVERED_QUEUE_TURNS) {
+      turns.delete(turns.keys().next().value!);
+    }
+    const beforeRemoval = currentItem();
+    if (!isCurrent() || !beforeRemoval || !sameQueuedDeliveryVersion(beforeRemoval, stored)) {
+      return "stale";
+    }
+    return removeDeliveredQueuedChatSendForRun(host, runId, scope) ? "retired" : "retained";
+  };
+  const live = readQueuedMessageById(host, stored.id);
+  const source =
+    live &&
+    live.attachmentPayload?.key === stored.attachmentPayload?.key &&
+    live.attachments?.length === stored.attachments?.length
+      ? live
+      : stored;
+  const attachments =
+    durableDeliveredAttachments(source.attachments) ??
+    durableDeliveredAttachments(stored.attachments);
+  if (
+    attachments &&
+    ((!stored.attachmentPayload && !stored.attachmentStorageError) || attachments.length > 0)
+  ) {
+    return commit({ ...stored, attachments, attachmentStorageError: undefined });
+  }
+  return prepareOutboxPayload(host, stored, "handoff").then((result): DeliveredTurnRetirement => {
+    if (!isCurrent()) {
+      return "stale";
+    }
+    if (result.status === "ready") {
+      const hydratedAttachments = durableDeliveredAttachments(result.item.attachments);
+      if (hydratedAttachments) {
+        return commit({
+          ...stored,
+          attachments: hydratedAttachments,
+          attachmentStorageError: undefined,
+        });
+      }
+    }
+    const current = currentItem();
+    if (!current || !sameQueuedDeliveryVersion(current, stored)) {
+      return "stale";
+    }
+    const reason = result.status === "failed" ? result.reason : "missing";
+    // Delivery proof must never become a fresh-send retry because local bytes
+    // were unavailable. Keep the same run identity and its no-replay barrier.
+    updateQueuedMessageForSession(
+      host,
+      scope.sessionKey,
+      stored.id,
+      (item) => failOutboxPayload({ ...item, sendState: "unconfirmed" }, reason),
+      scope.agentId,
+    );
+    return "retained";
+  });
 }
 
 type ChatDeliveryFailureHost = Parameters<typeof visibleSessionMatches>[0] & {

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -43,6 +43,7 @@ import { UNCONFIRMED_CHAT_SEND_ERROR } from "./chat-outbox-drain.ts";
 import { chatOutboxOwner } from "./chat-outbox-owner.ts";
 import { renderChatPaneComposerControls } from "./chat-pane-session-controls.ts";
 import type { ChatHost } from "./chat-send-contract.ts";
+import * as chatSendSupport from "./chat-send-support.ts";
 import {
   getPendingChatPickerPatch,
   switchChatFastMode,
@@ -73,6 +74,9 @@ import {
 
 type ExecuteSlashCommand = typeof executeSlashCommand;
 type TestChatHost = ReturnType<typeof makeChatHost>;
+type DeliveredTurnRetirement = Awaited<
+  ReturnType<typeof chatSendSupport.retireDeliveredQueuedUserTurn>
+>;
 
 function clientWithRequest(request: GatewayRequestHandler): NonNullable<ChatHost["client"]> {
   return createTestGatewayClient(request);
@@ -5699,7 +5703,7 @@ describe("handleSendChat", () => {
       let stopInactive = () => {};
       const hydration = createDeferred();
       const pendingReads: Array<ReturnType<typeof outboxPayloadStore.readOutboxPayload>> = [];
-      const pendingTerminals: Promise<void>[] = [];
+      const pendingRetirements: Promise<DeliveredTurnRetirement>[] = [];
       try {
         await handleSendChat(source);
         holdHistory = true;
@@ -5769,12 +5773,21 @@ describe("handleSendChat", () => {
             },
           },
         } as Parameters<typeof handlePageGatewayEvent>[1];
-        const first = handlePageGatewayEvent(asChatPageHost(inactive), event);
-        const second = handlePageGatewayEvent(asChatPageHost(visible), event);
-        pendingTerminals.push(Promise.resolve(first), Promise.resolve(second));
+        const retirementOwner = vi.spyOn(chatSendSupport, "retireDeliveredQueuedUserTurn");
+        expect(handlePageGatewayEvent(asChatPageHost(inactive), event)).toBeUndefined();
+        expect(handlePageGatewayEvent(asChatPageHost(visible), event)).toBeUndefined();
+        expect(retirementOwner).toHaveBeenCalledTimes(2);
+        // Dispatch registers its finish callback before this test observes owner completion.
+        for (const result of retirementOwner.mock.results) {
+          if (result.type !== "return") {
+            throw new Error("Expected the real retirement owner to return normally");
+          }
+          pendingRetirements.push(Promise.resolve(result.value));
+        }
         if (handoff === "live") {
-          expect(first).toBeUndefined();
-          expect(second).toBeUndefined();
+          // The inactive pane pins the handoff; the sending pane owns live retirement.
+          expect(retirementOwner).toHaveNthReturnedWith(1, "retained");
+          expect(retirementOwner).toHaveNthReturnedWith(2, "retired");
           expect(read).not.toHaveBeenCalled();
         } else {
           await waitForFast(() => expect(read).toHaveBeenCalled());
@@ -5805,7 +5818,7 @@ describe("handleSendChat", () => {
           visible.chatStream = "newer run is still streaming";
         }
         hydration.resolve();
-        await Promise.all(pendingTerminals);
+        await Promise.all(pendingRetirements);
         credential?.mockRestore();
         if (handoff === "new-credentials" || handoff === "new-attempt") {
           expect(cleanup).not.toHaveBeenCalled();
@@ -5839,7 +5852,7 @@ describe("handleSendChat", () => {
       } finally {
         hydration.resolve();
         history.resolve(idleChatHistory(sessionKey));
-        await Promise.all(pendingTerminals);
+        await Promise.all(pendingRetirements);
         await Promise.all(pendingReads);
         stopInactive();
         stopVisible();

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -13,13 +13,14 @@ import {
   subscribeChatMetadata,
   invalidateChatMetadataStore,
 } from "../../lib/chat/chat-metadata-store.ts";
-import type { ChatQueueItem } from "../../lib/chat/chat-types.ts";
+import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import {
   buildFallbackSlashCommands,
   buildSlashCommandsFromEntries,
   replaceSlashCommands,
 } from "../../lib/chat/commands.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
+import * as outboxPayloadStore from "../../lib/chat/outbox-payload-store.runtime.ts";
 import { createResolvedModelPatch } from "../../test-helpers/chat-model.ts";
 import {
   createTestGatewayClient,
@@ -58,9 +59,11 @@ import {
   removeStoredChatComposerQueueItem,
   resolveStoredChatOutboxScope,
   storedChatOutboxScopeKey,
+  updateStoredChatComposerQueueItem,
 } from "./composer-persistence.ts";
 import { getChatSessionProjection, setChatSessionProjection } from "./history-merge.ts";
 import { handleChatInputHistoryKey } from "./input-history.ts";
+import { installOutboxBrowserStorage } from "./outbox-browser.test-support.ts";
 import { handleChatScrollTakeover } from "./scroll.ts";
 import {
   cacheChatSessionSnapshot,
@@ -155,7 +158,57 @@ function registerChatAttachmentPayload(
   return attachment;
 }
 
+function createDeliveryAttachmentBatch() {
+  const sources = [
+    {
+      fileName: "pixel.png",
+      mimeType: "image/png",
+      content:
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jh0cAAAAASUVORK5CYII=",
+    },
+    { fileName: "brief.pdf", mimeType: "application/pdf", content: "JVBERi0xLjQK" },
+  ];
+  const dataUrls = sources.map(({ mimeType, content }) => `data:${mimeType};base64,${content}`);
+  const attachments = sources.map(({ fileName, mimeType, content }, index) => {
+    const file = new File([Buffer.from(content, "base64")], fileName, { type: mimeType });
+    return registerChatAttachmentPayload({
+      attachment: { id: `delivery-attachment-${index}`, mimeType, fileName, sizeBytes: file.size },
+      dataUrl: dataUrls[index]!,
+      file,
+    });
+  });
+  return { attachments, dataUrls };
+}
+
+function reloadChatDocumentStorage(attachments: readonly ChatAttachment[]): void {
+  const previous = sessionStorage;
+  const reloaded = createStorageMock();
+  for (let index = 0; index < previous.length; index += 1) {
+    const key = previous.key(index);
+    if (key !== null) {
+      reloaded.setItem(key, previous.getItem(key)!);
+    }
+  }
+  // A reload retains persisted metadata/IDB, not the old document's projections.
+  releaseChatAttachmentPayloads(attachments);
+  vi.stubGlobal("sessionStorage", reloaded);
+}
+
+function deliveredAttachmentUrls(message: unknown): unknown[] {
+  const content = requireRecord(message, "delivered user turn").content as Array<
+    Record<string, unknown>
+  >;
+  return content.flatMap((block) =>
+    block.type === "image"
+      ? [block.url]
+      : block.type === "attachment"
+        ? [requireRecord(block.attachment, "delivered attachment").url]
+        : [],
+  );
+}
+
 beforeEach(() => {
+  installOutboxBrowserStorage();
   executeSlashCommandMock.mockReset();
   vi.spyOn(chatCommandExecutor, "executeSlashCommand").mockImplementation((...args) => {
     const implementation = executeSlashCommandMock.getMockImplementation() as
@@ -175,6 +228,7 @@ afterEach(() => {
 let handleSendChat: typeof import("./chat-send-submit.ts").handleSendChat;
 let steerQueuedChatMessage: typeof import("./chat-send-actions.ts").steerQueuedChatMessage;
 let handleAbortChat: typeof import("./run-lifecycle.ts").handleAbortChat;
+let adoptStartedChatRun: typeof import("./run-lifecycle.ts").adoptStartedChatRun;
 let hasAbortableSessionRun: typeof import("./run-lifecycle.ts").hasAbortableSessionRun;
 let handlePageGatewayEvent: typeof import("./chat-state-events.ts").handlePageGatewayEvent;
 let loadChatBranches: typeof import("./chat-history.ts").loadChatBranches;
@@ -208,7 +262,8 @@ async function loadChatHelpers(): Promise<void> {
   ({ handlePageGatewayEvent } = await import("./chat-state-events.ts"));
   ({ refreshPageChat } = await import("./chat-state-refresh.ts"));
   ({ loadChatBranches, loadChatHistory } = await import("./chat-history.ts"));
-  ({ handleAbortChat, hasAbortableSessionRun } = await import("./run-lifecycle.ts"));
+  ({ handleAbortChat, hasAbortableSessionRun, adoptStartedChatRun } =
+    await import("./run-lifecycle.ts"));
   ({
     admitQueuedMessageForSession,
     clearPendingQueueItemsForRun,
@@ -2778,7 +2833,7 @@ describe("handleSendChat", () => {
     });
 
     const send = handleSendChat(host);
-    await Promise.resolve();
+    await waitForFast(() => expect(host.chatQueue).toHaveLength(1));
     host.chatMessage = "keep typing with the attachment";
 
     switchUpdate.resolve(true);
@@ -2832,7 +2887,7 @@ describe("handleSendChat", () => {
     });
 
     const send = handleSendChat(host);
-    await Promise.resolve();
+    await waitForFast(() => expect(host.chatQueue).toHaveLength(1));
     host.chatAttachments = [editedAttachment];
 
     switchUpdate.resolve(true);
@@ -2876,7 +2931,7 @@ describe("handleSendChat", () => {
     });
 
     const send = handleSendChat(host);
-    await Promise.resolve();
+    await waitForFast(() => expect(host.chatQueue).toHaveLength(1));
     host.chatAttachments = [];
     releaseChatAttachmentPayloads([attachment]);
 
@@ -3065,7 +3120,7 @@ describe("handleSendChat", () => {
     });
 
     const send = handleSendChat(host);
-    await Promise.resolve();
+    await waitForFast(() => expect(host.chatQueue).toHaveLength(1));
     host.chatMessage = "new unrelated draft";
 
     switchUpdate.resolve(false);
@@ -4405,6 +4460,7 @@ describe("handleSendChat", () => {
       dataUrl: "data:image/png;base64,AAA",
     };
     const host = makeChatHost({
+      requestHandlers: {},
       chatAttachments: [attachment],
       chatMessage: "queue after the active run",
       chatRunId: "run-1",
@@ -4854,36 +4910,50 @@ describe("handleSendChat", () => {
     expect(listStoredChatOutboxes(visibleHost)).toStrictEqual([]);
   });
 
-  it("holds a row being edited against a drain owned by another pane", async () => {
-    const request = makeRequestMock({ "chat.history": () => idleChatHistory() });
-    const client = clientWithRequest(request);
-    const item = {
-      id: "edited-across-panes",
-      text: "the text being rewritten",
-      createdAt: 1,
-      sessionKey: "agent:main",
-    };
-    // Two panes on one session: the composer holding the edit is pane-local, but
-    // the outbox and the drain lane are shared, and either pane can own the lane.
-    const editing = makeChatHost({ client, chatQueue: [item] });
-    const peer = makeChatHost({ client, chatQueue: [] });
-    const stopEditing = subscribeChatOutboxProjection(editing);
-    const stopPeer = subscribeChatOutboxProjection(peer);
-    expect(admitQueuedMessageForSession(editing, editing.sessionKey, item)).toBe(true);
-    expect(beginQueuedMessageEdit(editing, item.id)).toBe("started");
+  it.each(["unchanged", "replaced"])(
+    "holds a row being edited against a drain owned by another pane with %s credentials",
+    async (credentials) => {
+      const request = makeRequestMock({
+        "chat.history": () => idleChatHistory(),
+        "chat.send": { runId: "edited-across-panes-run", status: "started" },
+      });
+      const client = clientWithRequest(request);
+      const item = {
+        id: "edited-across-panes",
+        text: "the text being rewritten",
+        createdAt: 1,
+        sessionKey: "agent:main",
+      };
+      // Two panes on one session: the composer holding the edit is pane-local, but
+      // the outbox and the drain lane are shared, and either pane can own the lane.
+      const editing = makeChatHost({ client, chatQueue: [item] });
+      const peer = makeChatHost({ client, chatQueue: [] });
+      const stopEditing = subscribeChatOutboxProjection(editing);
+      const stopPeer = subscribeChatOutboxProjection(peer);
+      try {
+        expect(admitQueuedMessageForSession(editing, editing.sessionKey, item)).toBe(true);
+        expect(beginQueuedMessageEdit(editing, item.id)).toBe("started");
+        if (credentials === "replaced") {
+          vi.spyOn(client, "recoveryScope", "get").mockReturnValue("replacement-recovery-scope");
+        }
+        // The peer wakes first; the editing pane has not handled its reconnect yet.
+        await retryReconnectableQueuedChatSends(peer);
 
-    try {
-      await retryReconnectableQueuedChatSends(peer);
+        expect(request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(0);
+        expect(listStoredChatOutboxes(peer)[0]?.queue).toEqual([
+          expect.objectContaining({ id: item.id, text: item.text }),
+        ]);
 
-      expect(request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(0);
-      expect(listStoredChatOutboxes(peer)[0]?.queue).toEqual([
-        expect.objectContaining({ id: item.id, text: item.text }),
-      ]);
-    } finally {
-      stopPeer();
-      stopEditing();
-    }
-  });
+        // The original teardown must release the migrated edit hold, not its old owner.
+        stopEditing();
+        await retryReconnectableQueuedChatSends(peer);
+        expect(request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(1);
+      } finally {
+        stopPeer();
+        stopEditing();
+      }
+    },
+  );
 
   it("projects a running local command to panes that subscribe after execution starts", async () => {
     const command = createDeferred<{ content: string }>();
@@ -5438,18 +5508,20 @@ describe("handleSendChat", () => {
     expect(admitQueuedMessageForSession(host, selected.sessionKey, selected)).toBe(true);
     expect(admitQueuedMessageForSession(host, foreign.sessionKey, foreign)).toBe(true);
 
-    handlePageGatewayEvent(asChatPageHost(host), {
-      event: "chat",
-      payload: {
-        state: "final",
-        runId: foreign.sendRunId,
-        sessionKey: foreign.sessionKey,
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: "foreign reply" }],
+    expect(
+      handlePageGatewayEvent(asChatPageHost(host), {
+        event: "chat",
+        payload: {
+          state: "final",
+          runId: foreign.sendRunId,
+          sessionKey: foreign.sessionKey,
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "foreign reply" }],
+          },
         },
-      },
-    } as Parameters<typeof handlePageGatewayEvent>[1]);
+      } as Parameters<typeof handlePageGatewayEvent>[1]),
+    ).toBeUndefined();
 
     expect(host.chatMessages).toStrictEqual([]);
     expect(host.chatQueue).toEqual([expect.objectContaining({ id: selected.id })]);
@@ -5494,18 +5566,20 @@ describe("handleSendChat", () => {
     expect(admitQueuedMessageForSession(host, selected.sessionKey, selected)).toBe(true);
     expect(admitQueuedMessageForSession(host, defaultAgent.sessionKey, defaultAgent)).toBe(true);
 
-    handlePageGatewayEvent(asChatPageHost(host), {
-      event: "chat",
-      payload: {
-        state: "final",
-        runId,
-        sessionKey: "global",
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: "default agent reply" }],
+    expect(
+      handlePageGatewayEvent(asChatPageHost(host), {
+        event: "chat",
+        payload: {
+          state: "final",
+          runId,
+          sessionKey: "global",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "default agent reply" }],
+          },
         },
-      },
-    } as Parameters<typeof handlePageGatewayEvent>[1]);
+      } as Parameters<typeof handlePageGatewayEvent>[1]),
+    ).toBeUndefined();
 
     expect(host.chatMessages).toStrictEqual([]);
     expect(host.chatQueue).toEqual([expect.objectContaining({ id: selected.id })]);
@@ -5564,9 +5638,9 @@ describe("handleSendChat", () => {
       },
     } as Parameters<typeof handlePageGatewayEvent>[1];
 
-    handlePageGatewayEvent(asChatPageHost(inactive), event);
-    handlePageGatewayEvent(asChatPageHost(visible), event);
-    handlePageGatewayEvent(asChatPageHost(inactive), event);
+    expect(handlePageGatewayEvent(asChatPageHost(inactive), event)).toBeUndefined();
+    expect(handlePageGatewayEvent(asChatPageHost(visible), event)).toBeUndefined();
+    expect(handlePageGatewayEvent(asChatPageHost(inactive), event)).toBeUndefined();
 
     expect(
       visible.chatMessages.map((message) => requireRecord(message, "terminal transcript").role),
@@ -5595,94 +5669,184 @@ describe("handleSendChat", () => {
     expect(listStoredChatOutboxes(visible)).toStrictEqual([]);
   });
 
-  it("pins terminal attachment turns to durable data across split panes", () => {
-    const revokeObjectUrl = vi.fn();
-    vi.stubGlobal(
-      "URL",
-      class extends URL {
-        static override createObjectURL = vi.fn(() => "blob:terminal-attachment");
-        static override revokeObjectURL = revokeObjectUrl;
-      },
-    );
-    const dataUrl = "data:application/pdf;base64,JVBERi0xLjQK";
-    const file = new File(["%PDF-1.4\n"], "brief.pdf", { type: "application/pdf" });
-    const attachment = registerChatAttachmentPayload({
-      attachment: {
-        id: "terminal-attachment",
-        mimeType: "application/pdf",
-        fileName: "brief.pdf",
-        sizeBytes: file.size,
-      },
-      dataUrl,
-      file,
-    });
-    const item = {
-      id: "split-terminal-attachment-delivery",
-      text: "summarize",
-      attachments: [attachment],
-      createdAt: 1,
-      sendAttempts: 1,
-      sendRunId: "split-terminal-attachment-delivery-run",
-      sendState: "sending" as const,
-      sessionKey: "agent:main:visible",
-    };
-    const client = clientWithRequest(vi.fn());
-    const visible = makeChatHost({
-      chatQueue: [item],
-      chatRunId: item.sendRunId,
-      client,
-      sessionKey: item.sessionKey,
-    });
-    const inactive = makeChatHost({
-      chatQueue: [],
-      client,
-      sessionKey: "agent:main:inactive",
-    });
-    for (const host of [visible, inactive]) {
-      Object.assign(host, {
-        chatMessagesBySession: new Map(),
-        connectionEpoch: 1,
-        pendingSessionMessageReloadSessionKey: null,
-        requestUpdate: vi.fn(),
+  it.each(["live", "cold", "new-credentials", "new-attempt", "new-run"])(
+    "pins terminal attachment turns to durable data across split panes (%s)",
+    async (handoff) => {
+      const { attachments, dataUrls } = createDeliveryAttachmentBatch();
+      const sessionKey = "agent:main:visible";
+      const history = createDeferred<unknown>();
+      let holdHistory = false;
+      const request = makeRequestMock({
+        "chat.history": () => (holdHistory ? history.promise : idleChatHistory(sessionKey)),
+        "chat.send": (params: unknown) => ({
+          runId: requireRecord(params, "terminal attachment send").idempotencyKey,
+          status: "started",
+        }),
       });
-    }
-    cacheEmptyChatSnapshot(inactive, item.sessionKey);
-    expect(admitQueuedMessageForSession(visible, item.sessionKey, item)).toBe(true);
-    const event = {
-      event: "chat",
-      payload: {
-        state: "final",
-        runId: item.sendRunId,
-        sessionKey: item.sessionKey,
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: "terminal reply" }],
-          timestamp: 2,
-        },
-      },
-    } as Parameters<typeof handlePageGatewayEvent>[1];
+      const presentedAttachments =
+        handoff === "live"
+          ? attachments.map((attachment, index) => ({ ...attachment, dataUrl: dataUrls[index] }))
+          : attachments;
+      const source = makeChatHost({
+        client: clientWithRequest(request),
+        sessionKey,
+        chatMessage: "summarize",
+        chatAttachments: presentedAttachments,
+      });
+      sessionStorage.setItem("openclaw.control.outboxTab.v1", "test-outbox-tab");
+      const stopSource = subscribeChatOutboxProjection(source);
+      let stopVisible = () => {};
+      let stopInactive = () => {};
+      const hydration = createDeferred();
+      const pendingReads: Array<ReturnType<typeof outboxPayloadStore.readOutboxPayload>> = [];
+      const pendingTerminals: Promise<void>[] = [];
+      try {
+        await handleSendChat(source);
+        holdHistory = true;
+        const item = expectDefined(
+          loadChatComposerSnapshot(source, sessionKey)?.queue[0],
+          "Blob-backed terminal send",
+        );
+        expect(item.attachmentPayload).toBeDefined();
+        expect(item.attachments?.map(getChatAttachmentDataUrl)).toEqual([null, null]);
+        if (handoff !== "live") {
+          stopSource();
+          reloadChatDocumentStorage(attachments);
+        }
+        const client =
+          handoff === "live"
+            ? expectDefined(source.client, "live client")
+            : clientWithRequest(request);
+        const visible = handoff === "live" ? source : makeChatHost({ client, sessionKey });
+        const inactive = makeChatHost({ client, sessionKey: "agent:main:inactive" });
+        for (const host of [visible, inactive]) {
+          Object.assign(host, {
+            chatMessagesBySession: new Map(),
+            connectionEpoch: 1,
+            pendingSessionMessageReloadSessionKey: null,
+            requestUpdate: vi.fn(),
+          });
+        }
+        cacheEmptyChatSnapshot(inactive, sessionKey);
+        const readPayload = outboxPayloadStore.readOutboxPayload;
+        const read = vi
+          .spyOn(outboxPayloadStore, "readOutboxPayload")
+          .mockImplementation((...args) => {
+            const pending = hydration.promise.then(() => readPayload(...args));
+            pendingReads.push(pending);
+            return pending;
+          });
+        if (handoff !== "live") {
+          stopVisible = subscribeChatOutboxProjection(visible);
+          expect(visible.chatQueue[0]?.attachments?.map(getChatAttachmentDataUrl)).toEqual([
+            null,
+            null,
+          ]);
+        }
+        stopInactive = subscribeChatOutboxProjection(inactive);
+        const removePayloads = outboxPayloadStore.removeOutboxPayloads;
+        const cleanup = vi
+          .spyOn(outboxPayloadStore, "removeOutboxPayloads")
+          .mockImplementation(async (refs) => {
+            const cached = readChatMessagesFromCache(
+              inactive.chatMessagesBySession ?? new Map(),
+              inactive,
+              { sessionKey },
+            );
+            expect(deliveredAttachmentUrls(cached[0])).toEqual(dataUrls);
+            await removePayloads(refs);
+          });
+        const event = {
+          event: "chat",
+          payload: {
+            state: "final",
+            runId: item.sendRunId,
+            sessionKey,
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "terminal reply" }],
+              timestamp: Date.now(),
+            },
+          },
+        } as Parameters<typeof handlePageGatewayEvent>[1];
+        const first = handlePageGatewayEvent(asChatPageHost(inactive), event);
+        const second = handlePageGatewayEvent(asChatPageHost(visible), event);
+        pendingTerminals.push(Promise.resolve(first), Promise.resolve(second));
+        if (handoff === "live") {
+          expect(first).toBeUndefined();
+          expect(second).toBeUndefined();
+          expect(read).not.toHaveBeenCalled();
+        } else {
+          await waitForFast(() => expect(read).toHaveBeenCalled());
+          expect(listStoredChatOutboxes(visible)[0]?.queue[0]?.id).toBe(item.id);
+          expect(cleanup).not.toHaveBeenCalled();
+        }
+        const credential =
+          handoff === "new-credentials"
+            ? vi.spyOn(client, "recoveryScope", "get").mockReturnValue("different-credential")
+            : null;
+        if (handoff === "new-attempt") {
+          expect(
+            updateStoredChatComposerQueueItem(
+              visible,
+              sessionKey,
+              item,
+              {
+                ...item,
+                sendRunId: "replacement-attempt",
+                sendAttempts: 2,
+              },
+              item.agentId,
+            ),
+          ).toBe(true);
+        }
+        if (handoff === "new-run") {
+          adoptStartedChatRun(visible, "newer-run", Date.now());
+          visible.chatStream = "newer run is still streaming";
+        }
+        hydration.resolve();
+        await Promise.all(pendingTerminals);
+        credential?.mockRestore();
+        if (handoff === "new-credentials" || handoff === "new-attempt") {
+          expect(cleanup).not.toHaveBeenCalled();
+          expect(loadChatComposerSnapshot(visible, sessionKey)?.queue[0]).toMatchObject({
+            id: item.id,
+            attachmentPayload: item.attachmentPayload,
+            sendRunId: handoff === "new-attempt" ? "replacement-attempt" : item.sendRunId,
+          });
+          expect(visible.chatMessages).toEqual([]);
+          expect(request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(1);
+          return;
+        }
 
-    handlePageGatewayEvent(asChatPageHost(inactive), event);
-    handlePageGatewayEvent(asChatPageHost(visible), event);
-
-    const visibleUser = requireRecord(visible.chatMessages[0], "visible terminal user turn");
-    const visibleContent = visibleUser.content as Array<Record<string, unknown>>;
-    expect(requireRecord(visibleContent[1]?.attachment, "visible terminal attachment").url).toBe(
-      dataUrl,
-    );
-    const inactiveCached = readChatMessagesFromCache(
-      inactive.chatMessagesBySession ?? new Map(),
-      inactive,
-      { sessionKey: item.sessionKey },
-    );
-    const inactiveUser = requireRecord(inactiveCached[0], "inactive terminal user turn");
-    const inactiveContent = inactiveUser.content as Array<Record<string, unknown>>;
-    expect(requireRecord(inactiveContent[1]?.attachment, "inactive terminal attachment").url).toBe(
-      dataUrl,
-    );
-    expect(revokeObjectUrl).toHaveBeenCalledWith("blob:terminal-attachment");
-    expect(listStoredChatOutboxes(visible)).toStrictEqual([]);
-  });
+        expect(
+          visible.chatMessages.map((message) => requireRecord(message, "terminal transcript").role),
+        ).toEqual(["user", "assistant"]);
+        expect(deliveredAttachmentUrls(visible.chatMessages[0])).toEqual(dataUrls);
+        if (handoff === "new-run") {
+          expect(visible.chatRunId).toBe("newer-run");
+          expect(visible.chatStream).toBe("newer run is still streaming");
+        }
+        const inactiveCached = readChatMessagesFromCache(
+          inactive.chatMessagesBySession ?? new Map(),
+          inactive,
+          { sessionKey },
+        );
+        expect(deliveredAttachmentUrls(inactiveCached[0])).toEqual(dataUrls);
+        expect(listStoredChatOutboxes(visible)).toStrictEqual([]);
+        expect(cleanup).toHaveBeenCalledWith([item.attachmentPayload]);
+        expect(request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(1);
+      } finally {
+        hydration.resolve();
+        history.resolve(idleChatHistory(sessionKey));
+        await Promise.all(pendingTerminals);
+        await Promise.all(pendingReads);
+        stopInactive();
+        stopVisible();
+        stopSource();
+      }
+    },
+  );
 
   it("drains a queued reset without awaiting its own active outbox lane", async () => {
     executeSlashCommandMock.mockResolvedValue({ content: "Thinking level set." });
@@ -5889,6 +6053,7 @@ describe("handleSendChat", () => {
       sendState: "unconfirmed",
     });
     expect(host.chatQueue[0]?.sendError).toContain("preceding /clear may have completed");
+    expect(host.chatQueue[0]?.sendRunId).toBeUndefined();
 
     await retryReconnectableQueuedChatSends(host);
     await retryQueuedChatMessage(host, clear.id);
@@ -6671,7 +6836,7 @@ describe("handleSendChat", () => {
     expect(host.request).toHaveBeenCalledTimes(1);
   });
 
-  it("sends a connected attachment when browser quota rejects durable admission", async () => {
+  it("retains a connected attachment when browser quota rejects durable admission", async () => {
     const storage = createStorageMock();
     vi.spyOn(storage, "setItem").mockImplementation(() => {
       throw new DOMException("quota exceeded", "QuotaExceededError");
@@ -6698,31 +6863,302 @@ describe("handleSendChat", () => {
 
     await handleSendChat(host);
 
-    const sends = host.request.mock.calls.filter(([method]) => method === "chat.send");
-    expect(sends).toHaveLength(1);
-    const sendPayload = requireRecord(sends[0]?.[1], "volatile connected send payload");
-    expect(sendPayload).toMatchObject({
-      attachments: [
-        {
-          content: "JVBERi0xLjQ=",
-          fileName: "large.pdf",
-          mimeType: "application/pdf",
-        },
-      ],
-      message: "send the large file",
-    });
-    expect(host.chatAttachments).toStrictEqual([]);
-    expect(host.chatMessage).toBe("");
+    expect(host.request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(0);
+    expect(host.chatAttachments).toStrictEqual([attachment]);
+    expect(host.chatMessage).toBe("send the large file");
     expect(host.chatQueue).toStrictEqual([]);
-    expect(host.chatRunId).toEqual(expect.any(String));
-    expect(sendPayload.idempotencyKey).toBe(host.chatRunId);
-    expect(host.lastError).toBeNull();
-    expect(
-      host.chatMessages.map((message) => requireRecord(message, "volatile transcript").role),
-    ).toEqual(["user"]);
-    markQueuedChatSendsWaitingForReconnect(host);
-    expect(host.chatQueue).toStrictEqual([]);
+    expect(host.chatRunId).toBeNull();
+    expect(host.lastError).toBe(
+      "Could not store this message for reconnect. Free browser storage or reconnect before sending.",
+    );
   });
+
+  it.each(["unavailable", "capacity"] as const)(
+    "preserves inline bytes across a %s migration failure and reload before retry",
+    async (reason) => {
+      const { attachments, dataUrls } = createDeliveryAttachmentBatch();
+      const request = makeRequestMock({
+        "chat.history": () => idleChatHistory(),
+        "chat.send": (params: unknown) => ({
+          runId: requireRecord(params, "migrated attachment send").idempotencyKey,
+          status: "started",
+        }),
+      });
+      const source = makeChatHost({ client: clientWithRequest(request) });
+      const item: ChatQueueItem = {
+        id: "inline-payload-retry",
+        text: "migrate all attachments",
+        createdAt: 1,
+        attachments,
+        sendRunId: "inline-payload-run",
+        sendAttempts: 0,
+        sendState: "waiting-reconnect",
+        sessionKey: source.sessionKey,
+      };
+      const stopSource = subscribeChatOutboxProjection(source);
+      let stopRecovered = () => {};
+      try {
+        expect(admitQueuedMessageForSession(source, source.sessionKey, item)).toBe(true);
+        vi.spyOn(outboxPayloadStore, "writeOutboxPayload").mockResolvedValueOnce({
+          status: "failed",
+          reason,
+        });
+        await retryReconnectableQueuedChatSends(source);
+        expect(request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(0);
+        stopSource();
+        releaseChatAttachmentPayloads(attachments);
+        const readback = expectDefined(
+          loadChatComposerSnapshot(source, source.sessionKey),
+          "inline failed migration readback",
+        );
+        expect(readback.queue[0]?.attachmentStorageError).toBe(reason);
+        expect(readback.queue[0]?.attachmentPayload).toBeUndefined();
+        expect(readback.queue[0]?.attachments?.map((attachment) => attachment.dataUrl)).toEqual(
+          dataUrls,
+        );
+        const recovered = makeChatHost({
+          client: clientWithRequest(request),
+          chatQueue: readback.queue,
+        });
+        stopRecovered = subscribeChatOutboxProjection(recovered);
+        await retryQueuedChatMessage(recovered, item.id);
+        const stored = expectDefined(
+          loadChatComposerSnapshot(recovered, recovered.sessionKey)?.queue[0],
+          "retried migrated attachment row",
+        );
+        expect(stored.attachmentPayload).toBeDefined();
+        expect(stored.attachmentStorageError).toBeUndefined();
+        const sends = request.mock.calls.filter(([method]) => method === "chat.send");
+        expect(sends).toHaveLength(1);
+        expect(requireRecord(sends[0]?.[1], "migration retry payload").attachments).toEqual(
+          attachments.map((attachment, index) => ({
+            type: attachment.mimeType.startsWith("image/") ? "image" : "file",
+            mimeType: attachment.mimeType,
+            fileName: attachment.fileName,
+            content: dataUrls[index]!.split(",")[1],
+          })),
+        );
+      } finally {
+        stopRecovered();
+        stopSource();
+      }
+    },
+  );
+
+  it.each(["ready", "unavailable"] as const)(
+    "keeps a successor payload ref when a pending retry read settles as %s",
+    async (outcome) => {
+      const { attachments } = createDeliveryAttachmentBatch();
+      const request = makeRequestMock({
+        "chat.history": () => idleChatHistory(),
+        "chat.send": (params: unknown) => ({
+          runId: requireRecord(params, "stale hydration send").idempotencyKey,
+          status: "started",
+        }),
+      });
+      sessionStorage.setItem("openclaw.control.outboxTab.v1", "test-outbox-tab");
+      const source = makeChatHost({
+        client: clientWithRequest(request),
+        connected: false,
+        chatMessage: "do not replace newer attachment bytes",
+        chatAttachments: attachments,
+      });
+      const stopSource = subscribeChatOutboxProjection(source);
+      let stopRecovered = () => {};
+      const readStarted = createDeferred();
+      const releaseRead = createDeferred();
+      let retry: Promise<void> | undefined;
+      try {
+        await handleSendChat(source);
+        const original = expectDefined(
+          loadChatComposerSnapshot(source, source.sessionKey)?.queue[0],
+          "queued original payload",
+        );
+        expect(
+          updateStoredChatComposerQueueItem(
+            source,
+            source.sessionKey,
+            original,
+            {
+              ...original,
+              sendState: "failed",
+              attachmentStorageError: "unavailable",
+            },
+            original.agentId,
+          ),
+        ).toBe(true);
+        stopSource();
+        reloadChatDocumentStorage(attachments);
+        const host = makeChatHost({ client: clientWithRequest(request) });
+        stopRecovered = subscribeChatOutboxProjection(host);
+        const readPayload = outboxPayloadStore.readOutboxPayload;
+        vi.spyOn(outboxPayloadStore, "readOutboxPayload").mockImplementationOnce(
+          async (...args) => {
+            const result = await readPayload(...args);
+            readStarted.resolve();
+            await releaseRead.promise;
+            return outcome === "ready" ? result : { status: "failed", reason: "unavailable" };
+          },
+        );
+        retry = retryQueuedChatMessage(host, original.id);
+        await readStarted.promise;
+        const current = expectDefined(
+          loadChatComposerSnapshot(host, host.sessionKey)?.queue[0],
+          "captured retry row",
+        );
+        const oldRef = expectDefined(current.attachmentPayload, "captured retry ref");
+        const replacements = attachments.map((attachment) => {
+          const bytes = Buffer.alloc(attachment.sizeBytes!, 7);
+          return {
+            blob: new Blob([bytes], { type: attachment.mimeType }),
+            mimeType: attachment.mimeType,
+            fileName: attachment.fileName,
+            sizeBytes: bytes.length,
+          };
+        });
+        const written = await outboxPayloadStore.writeOutboxPayload(
+          {
+            tabId: oldRef.tabId,
+            gatewayOwner: "default",
+            recoveryScope: oldRef.recoveryScope,
+            scopeKey: oldRef.scopeKey,
+            queueId: current.id,
+          },
+          replacements,
+        );
+        const nextRef = expectDefined(
+          written.status === "ready" ? written.value : undefined,
+          "successor payload ref",
+        );
+        expect(
+          updateStoredChatComposerQueueItem(
+            host,
+            host.sessionKey,
+            current,
+            {
+              ...current,
+              attachmentPayload: nextRef,
+              attachmentStorageError: undefined,
+            },
+            current.agentId,
+          ),
+        ).toBe(true);
+        releaseRead.resolve();
+        await retry;
+        const successor = expectDefined(
+          loadChatComposerSnapshot(host, host.sessionKey)?.queue[0],
+          "retained successor row",
+        );
+        expect(successor.attachmentPayload).toEqual(nextRef);
+        expect(successor.sendRunId).toBe(current.sendRunId);
+        expect(successor.sendAttempts).toBe(current.sendAttempts);
+        expect(successor.sendState).toBe(current.sendState);
+        expect(successor.attachmentStorageError).toBeUndefined();
+        expect(request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(0);
+        const expectedUrls = attachments.map(
+          (attachment) =>
+            `data:${attachment.mimeType};base64,${Buffer.alloc(attachment.sizeBytes!, 7).toString("base64")}`,
+        );
+        await waitForFast(() =>
+          expect(host.chatQueue[0]?.attachments?.map(getChatAttachmentDataUrl)).toEqual(
+            expectedUrls,
+          ),
+        );
+      } finally {
+        releaseRead.resolve();
+        await retry;
+        stopRecovered();
+        stopSource();
+      }
+    },
+  );
+
+  it.each(["unavailable", "missing"] as const)(
+    "keeps an uncertain send id across repeated %s payload retries",
+    async (reason) => {
+      const { attachments, dataUrls } = createDeliveryAttachmentBatch();
+      let wireAttempts = 0;
+      const request = makeRequestMock({
+        "chat.history": () => idleChatHistory(),
+        "chat.send": (params: unknown) => {
+          wireAttempts += 1;
+          if (wireAttempts === 1) {
+            throw new Error("gateway disconnected");
+          }
+          return {
+            runId: requireRecord(params, "uncertain attachment retry").idempotencyKey,
+            status: "started",
+          };
+        },
+      });
+      const source = makeChatHost({
+        client: clientWithRequest(request),
+        chatMessage: "retain this uncertain attachment batch",
+        chatAttachments: attachments,
+      });
+      const stopSource = subscribeChatOutboxProjection(source);
+      let stopRecovered = () => {};
+      try {
+        await handleSendChat(source);
+        const original = expectDefined(
+          loadChatComposerSnapshot(source, source.sessionKey)?.queue[0],
+          "uncertain attachment send",
+        );
+        expect(original.sendAttempts).toBe(1);
+        expect(source.chatRunId).toBeNull();
+        stopSource();
+        reloadChatDocumentStorage(attachments);
+        const host = makeChatHost({ client: clientWithRequest(request) });
+        const read = vi
+          .spyOn(outboxPayloadStore, "readOutboxPayload")
+          .mockResolvedValue({ status: "failed", reason });
+        stopRecovered = subscribeChatOutboxProjection(host);
+        expect(host.chatQueue[0]?.attachments?.map(getChatAttachmentDataUrl)).toEqual([null, null]);
+        await waitForFast(() =>
+          expect(loadChatComposerSnapshot(host, host.sessionKey)?.queue[0]).toMatchObject({
+            attachmentStorageError: reason,
+            sendState: "unconfirmed",
+            sendRunId: original.sendRunId,
+          }),
+        );
+        await retryReconnectableQueuedChatSends(host);
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+          await retryQueuedChatMessage(host, original.id);
+          expect(loadChatComposerSnapshot(host, host.sessionKey)?.queue[0]).toMatchObject({
+            attachmentStorageError: reason,
+            sendState: "unconfirmed",
+            sendRunId: original.sendRunId,
+            sendAttempts: 1,
+          });
+          expect(wireAttempts).toBe(1);
+        }
+        read.mockRestore();
+        await retryQueuedChatMessage(host, original.id);
+        const stored = expectDefined(
+          loadChatComposerSnapshot(host, host.sessionKey)?.queue[0],
+          "recovered uncertain row",
+        );
+        expect(stored.attachmentStorageError).toBeUndefined();
+        expect(stored.sendRunId).toBe(original.sendRunId);
+        expect(stored.sendAttempts).toBe(2);
+        const sends = request.mock.calls.filter(([method]) => method === "chat.send");
+        expect(sends).toHaveLength(2);
+        const resent = requireRecord(sends[1]?.[1], "same-id recovered attachment payload");
+        expect(resent.idempotencyKey).toBe(original.sendRunId);
+        expect(resent.attachments).toEqual(
+          attachments.map((attachment, index) => ({
+            type: attachment.mimeType.startsWith("image/") ? "image" : "file",
+            mimeType: attachment.mimeType,
+            fileName: attachment.fileName,
+            content: dataUrls[index]!.split(",")[1],
+          })),
+        );
+      } finally {
+        stopRecovered();
+        stopSource();
+      }
+    },
+  );
 
   it("retries an unconfirmed volatile send with the same run id", async () => {
     const storage = createStorageMock();
@@ -7267,7 +7703,7 @@ describe("handleSendChat", () => {
     );
   });
 
-  it("retains offline attachments when browser storage rejects the queue", async () => {
+  it("retains cold-offline attachments until a recovery owner is known", async () => {
     const storage = createStorageMock();
     vi.spyOn(storage, "setItem").mockImplementation(() => {
       throw new DOMException("quota exceeded", "QuotaExceededError");
@@ -7291,7 +7727,7 @@ describe("handleSendChat", () => {
     expect(host.chatAttachments).toEqual([attachment]);
     expect(host.chatQueue).toStrictEqual([]);
     expect(host.lastError).toBe(
-      "Could not store this message for reconnect. Free browser storage or reconnect before sending.",
+      "Browser attachment storage is unavailable. Use HTTPS or localhost, allow browser storage, and close older dashboard tabs before reconnecting and retrying. No new message was sent.",
     );
   });
 
@@ -7626,52 +8062,122 @@ describe("handleSendChat", () => {
   );
 
   it.each([
-    {
-      proof: "active run",
-      sessionInfo: row("agent:main", {
-        hasActiveRun: true,
-        activeRunIds: ["admitted-run"],
-        status: "running",
-      }),
-    },
-    {
-      proof: "completed run",
-      sessionInfo: row("agent:main", {
-        hasActiveRun: false,
-        lastRunId: "admitted-run",
-        status: "done",
-      }),
-    },
+    { proof: "active run", active: true, retry: false },
+    { proof: "completed run", active: false, retry: false },
+    { proof: "completed run during explicit retry", active: false, retry: true },
   ])(
     "retires a reconnect send proved by its $proof before transcript persistence",
-    async ({ sessionInfo }) => {
-      const host = makeChatHost({
-        requestHandlers: {
-          "chat.history": () => ({ messages: [], sessionInfo }),
+    async ({ active, retry }) => {
+      const { attachments, dataUrls } = createDeliveryAttachmentBatch();
+      const history = createDeferred<unknown>();
+      const preview = createDeferred();
+      let pendingPreview: ReturnType<typeof outboxPayloadStore.readOutboxPayload> | undefined;
+      let runId = "";
+      let recovering = false;
+      let proved = false;
+      const request = makeRequestMock({
+        "chat.send": (params: unknown) => {
+          runId = String(requireRecord(params, "reconnect attachment send").idempotencyKey);
+          return { runId, status: "started" };
         },
-        chatQueue: [
-          {
-            id: "admitted-send",
-            text: "keep my admitted message visible",
-            createdAt: 1,
-            sendAttempts: 1,
-            sendRunId: "admitted-run",
-            sendState: "sending",
-            sessionKey: "agent:main",
-          },
-        ],
+        "chat.history": () => {
+          if (!recovering) {
+            return idleChatHistory();
+          }
+          if (proved) {
+            return history.promise;
+          }
+          proved = true;
+          return {
+            messages: [],
+            sessionInfo: row("agent:main", {
+              hasActiveRun: active,
+              status: active ? "running" : "done",
+              ...(active ? { activeRunIds: [runId] } : { lastRunId: runId }),
+            }),
+          };
+        },
       });
-      admitHostQueueItems(host);
-      markQueuedChatSendsWaitingForReconnect(host);
+      sessionStorage.setItem("openclaw.control.outboxTab.v1", "test-outbox-tab");
+      const source = makeChatHost({
+        client: clientWithRequest(request),
+        chatMessage: "keep my admitted message visible",
+        chatAttachments: attachments,
+      });
+      const stopSource = subscribeChatOutboxProjection(source);
+      let stopRecovered = () => {};
+      try {
+        await handleSendChat(source);
+        const stored = expectDefined(
+          loadChatComposerSnapshot(source, source.sessionKey)?.queue[0],
+          "Blob-backed reconnect send",
+        );
+        const reference = expectDefined(stored.attachmentPayload, "reconnect payload reference");
+        markQueuedChatSendsWaitingForReconnect(source);
+        if (retry) {
+          expect(
+            updateStoredChatComposerQueueItem(
+              source,
+              source.sessionKey,
+              stored,
+              {
+                ...stored,
+                sendState: "unconfirmed",
+              },
+              stored.agentId,
+            ),
+          ).toBe(true);
+        }
+        stopSource();
+        reloadChatDocumentStorage(attachments);
+        recovering = true;
+        const host = makeChatHost({
+          client: clientWithRequest(request),
+          chatMessagesBySession: new Map(),
+        });
+        const readPayload = outboxPayloadStore.readOutboxPayload;
+        const read = vi
+          .spyOn(outboxPayloadStore, "readOutboxPayload")
+          .mockImplementationOnce((...args) => {
+            pendingPreview = preview.promise.then(() => readPayload(...args));
+            return pendingPreview;
+          });
+        stopRecovered = subscribeChatOutboxProjection(host);
+        await waitForFast(() => expect(read).toHaveBeenCalledTimes(1));
+        // Delivery proof wins while preview hydration is still waiting. Retirement
+        // must acquire its own complete handoff, not depend on the preview callback.
+        if (retry) {
+          await retryQueuedChatMessage(host, stored.id);
+        } else {
+          await retryReconnectableQueuedChatSends(host);
+        }
 
-      await retryReconnectableQueuedChatSends(host);
-
-      expect(listStoredChatOutboxes(host)).toStrictEqual([]);
-      expect(host.chatQueue).toStrictEqual([]);
-      expect(host.chatMessages.map(extractText)).toContain("keep my admitted message visible");
-      expect(host.lastError).toBeNull();
-      expect(host.chatError).toBeNull();
-      expect(host.request).not.toHaveBeenCalledWith("chat.send", expect.anything());
+        expect(listStoredChatOutboxes(host)).toStrictEqual([]);
+        expect(host.chatQueue).toStrictEqual([]);
+        expect(host.chatMessages.map(extractText)).toContain("keep my admitted message visible");
+        expect(deliveredAttachmentUrls(host.chatMessages[0])).toEqual(dataUrls);
+        expect(host.lastError).toBeNull();
+        expect(host.chatError).toBeNull();
+        expect(request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(1);
+        await expect(
+          readPayload(
+            {
+              tabId: reference.tabId,
+              gatewayOwner: "default",
+              recoveryScope: "test-recovery-scope",
+              scopeKey: reference.scopeKey,
+              queueId: stored.id,
+            },
+            reference,
+          ),
+        ).resolves.toEqual({ status: "failed", reason: "missing" });
+      } finally {
+        preview.resolve();
+        history.resolve(idleChatHistory());
+        await pendingPreview;
+        stopRecovered();
+        stopSource();
+      }
     },
   );
 

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -65,6 +65,7 @@ import {
 import { getChatSessionProjection, setChatSessionProjection } from "./history-merge.ts";
 import { handleChatInputHistoryKey } from "./input-history.ts";
 import { installOutboxBrowserStorage } from "./outbox-browser.test-support.ts";
+import { prepareOutboxPayload } from "./outbox-payloads.ts";
 import { handleChatScrollTakeover } from "./scroll.ts";
 import {
   cacheChatSessionSnapshot,
@@ -6886,6 +6887,232 @@ describe("handleSendChat", () => {
     );
   });
 
+  it("keeps queued attachment bytes when a configured main alias changes their metadata scope", async () => {
+    const { attachments, dataUrls } = createDeliveryAttachmentBatch();
+    const request = makeRequestMock({
+      "chat.history": () => idleChatHistory("global"),
+      "chat.send": (params: unknown) => ({
+        runId: requireRecord(params, "resolved alias send").idempotencyKey,
+        status: "started",
+      }),
+    });
+    const write = vi.spyOn(outboxPayloadStore, "writeOutboxPayload");
+    const source = makeChatHost({
+      client: clientWithRequest(request),
+      connected: false,
+      sessionKey: "agent:work:workspace",
+      assistantAgentId: "work",
+      agentsList: { defaultId: "main", mainKey: "main" },
+      chatMessage: "keep these bytes with the queued input",
+      chatAttachments: attachments,
+    });
+    await handleSendChat(source);
+    const original = expectDefined(
+      listStoredChatOutboxes(source)[0]?.queue[0],
+      "admitted alias input",
+    );
+    const reference = expectDefined(original.attachmentPayload, "admitted alias payload");
+    const [payloadOwner] = expectDefined(write.mock.calls[0], "actual admitted payload owner");
+    expect(original).toMatchObject({
+      sessionKey: "agent:work:workspace",
+      agentId: "work",
+      sendAttempts: 0,
+    });
+    expect(request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(0);
+
+    reloadChatDocumentStorage(attachments);
+    expect(original.attachments?.map(getChatAttachmentDataUrl)).toEqual([null, null]);
+    const recovered = makeChatHost({
+      client: clientWithRequest(request),
+      sessionKey: source.sessionKey,
+      assistantAgentId: "work",
+      agentsList: { defaultId: "main", mainKey: "workspace" },
+    });
+    // Exercise today's alias migration without changing its transport-routing policy.
+    const moved = expectDefined(
+      listStoredChatOutboxes(recovered)[0]?.queue[0],
+      "resolved alias input",
+    );
+    expect(moved).toMatchObject({
+      id: original.id,
+      sendRunId: original.sendRunId,
+      sendAttempts: original.sendAttempts,
+      sendState: original.sendState,
+      sessionKey: "global",
+      agentId: "work",
+      attachmentPayload: reference,
+    });
+    const hydrated = await prepareOutboxPayload(recovered, moved);
+    const stored = await outboxPayloadStore.readOutboxPayload(payloadOwner, reference);
+    const storedAttachments = expectDefined(
+      stored.status === "ready" ? stored.value : undefined,
+      "original alias payload bytes",
+    );
+    expect(
+      await Promise.all(
+        storedAttachments.map(async (attachment) =>
+          Buffer.from(await attachment.blob.arrayBuffer()).toString("base64"),
+        ),
+      ),
+    ).toEqual(dataUrls.map((url) => url.split(",")[1]));
+    expect(hydrated).toMatchObject({ status: "ready", item: { attachmentPayload: reference } });
+    expect(write).toHaveBeenCalledTimes(1);
+
+    await retryReconnectableQueuedChatSends(recovered);
+    const sends = request.mock.calls.filter(([method]) => method === "chat.send");
+    expect(sends).toHaveLength(1);
+    expect(requireRecord(sends[0]?.[1], "resolved alias wire payload")).toMatchObject({
+      sessionKey: moved.sessionKey,
+      agentId: moved.agentId,
+      idempotencyKey: original.sendRunId,
+      attachments: attachments.map((attachment, index) => ({
+        type: attachment.mimeType.startsWith("image/") ? "image" : "file",
+        mimeType: attachment.mimeType,
+        fileName: attachment.fileName,
+        content: dataUrls[index]!.split(",")[1],
+      })),
+    });
+    expect(listStoredChatOutboxes(recovered)[0]?.queue[0]).toMatchObject({
+      id: original.id,
+      sendRunId: original.sendRunId,
+      sendAttempts: 1,
+      attachmentPayload: reference,
+    });
+  });
+
+  it.each([
+    { caller: "wrong queue", reason: "missing" },
+    { caller: "wrong source tab", reason: "missing" },
+    { caller: "wrong reference recovery scope", reason: "missing" },
+    { caller: "Incognito", reason: "unavailable" },
+    { caller: "unobserved owner", reason: "unavailable" },
+    { caller: "incomplete attachment metadata", reason: "missing" },
+    { caller: "wrong attachment MIME type", reason: "missing" },
+    { caller: "wrong attachment filename", reason: "missing" },
+    { caller: "wrong attachment size", reason: "missing" },
+    { caller: "matching owner", reason: null },
+    { caller: "remembered offline owner", reason: null },
+  ] as const)(
+    "validates a concurrent payload caller independently ($caller)",
+    async ({ caller, reason }) => {
+      const { attachments, dataUrls } = createDeliveryAttachmentBatch();
+      const request = makeRequestMock();
+      const client = clientWithRequest(request);
+      const source = makeChatHost({
+        client,
+        connected: false,
+        chatMessage: "one immutable attachment input",
+        chatAttachments: attachments,
+      });
+      const write = vi.spyOn(outboxPayloadStore, "writeOutboxPayload");
+      await handleSendChat(source);
+      const original = expectDefined(
+        listStoredChatOutboxes(source)[0]?.queue[0],
+        "admitted shared input",
+      );
+      const reference = expectDefined(original.attachmentPayload, "shared input reference");
+      const [payloadOwner] = expectDefined(write.mock.calls[0], "actual shared payload owner");
+      const other = makeChatHost({ client, connected: false });
+      const candidate: ChatQueueItem = {
+        ...original,
+        attachmentPayload: { ...reference },
+        attachments: original.attachments?.map((attachment) => ({ ...attachment })),
+      };
+      switch (caller) {
+        case "wrong queue":
+          candidate.id = `${original.id}-other`;
+          break;
+        case "wrong source tab":
+          candidate.attachmentPayload = { ...reference, tabId: "other-source-tab" };
+          break;
+        case "wrong reference recovery scope":
+          candidate.attachmentPayload = { ...reference, recoveryScope: "other-reference-owner" };
+          break;
+        case "Incognito":
+          other.selectedChatSessionIncognito = true;
+          break;
+        case "unobserved owner":
+          other.client = clientWithRequest(request);
+          vi.spyOn(other.client, "recoveryScopeReady", "get").mockReturnValue(false);
+          break;
+        case "incomplete attachment metadata":
+          candidate.attachments = candidate.attachments?.slice(0, 1);
+          break;
+        case "wrong attachment MIME type":
+          Object.assign(expectDefined(candidate.attachments?.[0], "first attachment metadata"), {
+            mimeType: "text/plain",
+          });
+          break;
+        case "wrong attachment filename":
+          Object.assign(expectDefined(candidate.attachments?.[0], "first attachment metadata"), {
+            fileName: "other-file.png",
+          });
+          break;
+        case "wrong attachment size":
+          Object.assign(expectDefined(candidate.attachments?.[0], "first attachment metadata"), {
+            sizeBytes: 1,
+          });
+          break;
+        case "remembered offline owner":
+          vi.spyOn(client, "recoveryScopeReady", "get").mockReturnValue(false);
+          break;
+        case "matching owner":
+          break;
+      }
+      const expected = reason ? { status: "failed", reason } : { status: "ready" };
+      expect(await prepareOutboxPayload(other, candidate)).toMatchObject(expected);
+
+      const readPayload = outboxPayloadStore.readOutboxPayload;
+      const readStarted = createDeferred();
+      const releaseRead = createDeferred();
+      const pending: Array<ReturnType<typeof prepareOutboxPayload>> = [];
+      const read = vi
+        .spyOn(outboxPayloadStore, "readOutboxPayload")
+        .mockImplementationOnce(async (...args) => {
+          const result = await readPayload(...args);
+          readStarted.resolve();
+          await releaseRead.promise;
+          return result;
+        });
+      try {
+        const first = prepareOutboxPayload(source, original);
+        pending.push(first);
+        await readStarted.promise;
+        const second = prepareOutboxPayload(other, candidate);
+        pending.push(second);
+        releaseRead.resolve();
+        const [valid, joined] = await Promise.all([first, second]);
+        expect(valid).toMatchObject({ status: "ready", item: { attachmentPayload: reference } });
+        expect(
+          valid.status === "ready" ? valid.item.attachments?.map(getChatAttachmentDataUrl) : [],
+        ).toEqual(dataUrls);
+        const stored = await readPayload(payloadOwner, reference);
+        const retained = expectDefined(
+          stored.status === "ready" ? stored.value : undefined,
+          "retained shared bytes",
+        );
+        expect(
+          await Promise.all(
+            retained.map(async (attachment) =>
+              Buffer.from(await attachment.blob.arrayBuffer()).toString("base64"),
+            ),
+          ),
+        ).toEqual(dataUrls.map((url) => url.split(",")[1]));
+        expect(request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(0);
+        expect(joined).toMatchObject(expected);
+        if (!reason) {
+          expect(read).toHaveBeenCalledTimes(1);
+          expect(
+            joined.status === "ready" ? joined.item.attachments?.map(getChatAttachmentDataUrl) : [],
+          ).toEqual(dataUrls);
+        }
+      } finally {
+        releaseRead.resolve();
+        await Promise.allSettled(pending);
+      }
+    },
+  );
+
   it.each(["unavailable", "capacity"] as const)(
     "preserves inline bytes across a %s migration failure and reload before retry",
     async (reason) => {
@@ -7034,7 +7261,6 @@ describe("handleSendChat", () => {
             tabId: oldRef.tabId,
             gatewayOwner: "default",
             recoveryScope: oldRef.recoveryScope,
-            scopeKey: oldRef.scopeKey,
             queueId: current.id,
           },
           replacements,
@@ -8178,7 +8404,6 @@ describe("handleSendChat", () => {
               tabId: reference.tabId,
               gatewayOwner: "default",
               recoveryScope: "test-recovery-scope",
-              scopeKey: reference.scopeKey,
               queueId: stored.id,
             },
             reference,

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -524,7 +524,7 @@ export function handlePageGatewayEvent(
   state: ChatPageHost,
   event: GatewayEventFrame,
   isPresented: ChatPanePresentation = () => true,
-): void | Promise<void> {
+): void {
   if (event.event === "session.approval") {
     const payload = asNullableRecord(event.payload);
     if (!payload || typeof payload.sessionKey !== "string") {
@@ -649,7 +649,8 @@ export function handlePageGatewayEvent(
       }
     };
     if (retirement instanceof Promise) {
-      return retirement.then(finish);
+      void retirement.then(finish);
+      return;
     }
     finish(retirement);
     return;

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -4,7 +4,6 @@ import type { SessionObserverDigest } from "../../../../packages/gateway-protoco
 import type { GatewayEventFrame } from "../../api/gateway.ts";
 import { fireFirstReplyConfetti } from "../../components/confetti.ts";
 import { invalidateChatMetadataStore } from "../../lib/chat/chat-metadata-store.ts";
-import type { ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
 import { pickFreshestObserverDigest } from "../../lib/observer-digest.ts";
 import {
@@ -33,13 +32,9 @@ import {
   pullRequestLinksIn,
   refreshPullRequestsForStreamedLinks,
 } from "./chat-pull-request-refresh.ts";
-import {
-  clearPendingQueueItemsForRun,
-  readDeliveredQueuedChatSendForRun,
-  removeDeliveredQueuedChatSendForRun,
-} from "./chat-queue.ts";
+import { clearPendingQueueItemsForRun } from "./chat-queue.ts";
 import { flushChatQueueForEvent, resumeStoredChatOutboxes } from "./chat-send-actions.ts";
-import { preserveQueuedUserTurn } from "./chat-send-support.ts";
+import { retireDeliveredQueuedUserTurn } from "./chat-send-support.ts";
 import { recordChatSendServerTiming } from "./chat-send-timing.ts";
 import { refreshCurrentChatSessionList } from "./chat-session.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
@@ -50,16 +45,13 @@ import {
   refreshSessionWorkspace,
   retireSessionWorkspaceCheckout,
 } from "./components/chat-session-workspace.ts";
-import {
-  resolveStoredChatOutboxScope,
-  storedChatOutboxScopeKey,
-  type StoredChatOutboxScope,
-} from "./composer-persistence.ts";
+import { resolveStoredChatOutboxScope } from "./composer-persistence.ts";
 import {
   getChatSessionProjection,
   readChatSessionProjectionScope,
   reduceChatSessionProjection,
 } from "./history-merge.ts";
+import { captureOutboxPayloadOwner } from "./outbox-payloads.ts";
 import {
   reconcileChatRunFromCurrentSessionRow,
   reconcileChatRunFromSessionRow,
@@ -532,7 +524,7 @@ export function handlePageGatewayEvent(
   state: ChatPageHost,
   event: GatewayEventFrame,
   isPresented: ChatPanePresentation = () => true,
-) {
+): void | Promise<void> {
   if (event.event === "session.approval") {
     const payload = asNullableRecord(event.payload);
     if (!payload || typeof payload.sessionKey !== "string") {
@@ -552,109 +544,114 @@ export function handlePageGatewayEvent(
   }
   if (event.event === "chat") {
     const payload = event.payload as ChatEventPayload | undefined;
-    const sessionMatches = Boolean(
-      payload && chatScopedEventSessionMatches(state, payload.sessionKey, payload.agentId),
-    );
-    const recoveryRunId =
-      payload?.state === "final" &&
-      (payload.message === undefined || payload.message === null) &&
-      sessionMatches &&
-      typeof payload.runId === "string" &&
-      (!state.chatRunId || state.chatRunId === payload.runId)
-        ? payload.runId
-        : null;
-    const recoveryScope = recoveryRunId ? readChatSessionProjectionScope(state) : null;
-    if (
-      payload?.state === "delta" &&
-      typeof payload.runId === "string" &&
-      sessionMatches &&
-      // Same-session background streams cannot clear the foreground run's status.
-      (!state.chatRunId || state.chatRunId === payload.runId) &&
-      state.observerDigest &&
-      state.observerDigest.runId !== payload.runId
-    ) {
-      state.observerDigest = null;
-    }
-    if (payload?.state === "delta" && typeof payload.deltaText === "string" && sessionMatches) {
-      refreshPullRequestsForStreamedLinks(state, payload, payload.deltaText);
-    }
-    const shouldCelebrateFirstReply = hasVisibleFinalAssistantReply(state, payload);
-    const shouldRefreshPullRequests =
-      shouldCelebrateFirstReply && finalAssistantReplyHasPullRequestLink(state, payload);
     const terminalPayload =
       payload &&
       (payload.state === "final" || payload.state === "aborted" || payload.state === "error")
         ? payload
         : undefined;
-    // Missing ownership must not fall back to correlation-only run IDs, which
-    // can collide across sessions.
-    const outboxScope =
-      terminalPayload &&
-      resolveStoredChatOutboxScope(
-        state,
-        terminalPayload.sessionKey,
-        isUiGlobalSessionKey(terminalPayload.sessionKey)
-          ? selectedGlobalEventAgentId(state, terminalPayload.agentId ?? null)
-          : terminalPayload.agentId,
+    const apply = () => {
+      const sessionMatches = Boolean(
+        payload && chatScopedEventSessionMatches(state, payload.sessionKey, payload.agentId),
       );
-    const delivered = outboxScope
-      ? rememberDeliveredQueuedUserTurn(state, terminalPayload.runId, outboxScope)
-      : null;
-    if (delivered) {
-      // The queued projection is the only local copy until history catches up.
-      // Materialize it before the terminal assistant to preserve transcript order.
-      preserveQueuedUserTurn(state, delivered);
-    }
-    const result = handleChatGatewayEvent(state, payload);
-    if (terminalPayload && sessionMatches) {
-      clearPendingQueueItemsForRun(state, terminalPayload.runId);
-    }
-    if (shouldCelebrateFirstReply && result === "final") {
-      fireFirstReplyConfetti();
-    }
-    if (shouldRefreshPullRequests) {
-      void state.refreshSessionPullRequests?.({ refresh: true });
-    }
-    const shouldRecoverMissingTerminal = Boolean(
-      recoveryRunId &&
-      recoveryScope &&
-      getChatSessionProjection(state, state.chatMessages, recoveryScope).runs[recoveryRunId]
-        ?.status === "completed",
-    );
-    const recoveryOwnership =
-      shouldRecoverMissingTerminal && payload
-        ? createTerminalRecoveryOwnership(state, payload)
-        : null;
-    const recoveryClaimed = recoveryOwnership
-      ? claimTerminalRecovery(state, recoveryOwnership)
-      : false;
-    if (recoveryOwnership && recoveryClaimed) {
-      state.pendingSessionMessageReloadSessionKey = null;
-      // The first owned message-less terminal recovers history even when an
-      // earlier snapshot already marked the run complete. Replays, yielded, or
-      // background-run terminals must not repeat I/O or disturb the foreground pane.
-      // Persistence can trail the terminal event, so retry bounded authoritative
-      // snapshots until the completed run's reply becomes visible.
-      void recoverMissingTerminalReply(state, recoveryOwnership, isPresented).catch(
-        () => undefined,
-      );
-    } else {
-      replayPendingSessionMessageReload(state, payload, isPresented);
-    }
-    if (terminalPayload) {
-      if (outboxScope) {
-        removeDeliveredQueuedChatSendForRun(state, terminalPayload.runId, outboxScope);
+      const recoveryRunId =
+        payload?.state === "final" &&
+        (payload.message === undefined || payload.message === null) &&
+        sessionMatches &&
+        typeof payload.runId === "string" &&
+        (!state.chatRunId || state.chatRunId === payload.runId)
+          ? payload.runId
+          : null;
+      const recoveryScope = recoveryRunId ? readChatSessionProjectionScope(state) : null;
+      if (
+        payload?.state === "delta" &&
+        typeof payload.runId === "string" &&
+        sessionMatches &&
+        // Same-session background streams cannot clear the foreground run's status.
+        (!state.chatRunId || state.chatRunId === payload.runId) &&
+        state.observerDigest &&
+        state.observerDigest.runId !== payload.runId
+      ) {
+        state.observerDigest = null;
       }
-      void resumeStoredChatOutboxes(state);
-      if (sessionMatches) {
-        if (isPresented()) {
-          refreshSessionWorkspace(state, isSidebarSlotVisible(state.sidebarLayout, "workspace"));
-        } else {
-          retireSessionWorkspaceCheckout(state);
+      if (payload?.state === "delta" && typeof payload.deltaText === "string" && sessionMatches) {
+        refreshPullRequestsForStreamedLinks(state, payload, payload.deltaText);
+      }
+      const shouldCelebrateFirstReply = hasVisibleFinalAssistantReply(state, payload);
+      const shouldRefreshPullRequests =
+        shouldCelebrateFirstReply && finalAssistantReplyHasPullRequestLink(state, payload);
+      const result = handleChatGatewayEvent(state, payload);
+      if (terminalPayload && sessionMatches) {
+        clearPendingQueueItemsForRun(state, terminalPayload.runId);
+      }
+      if (shouldCelebrateFirstReply && result === "final") {
+        fireFirstReplyConfetti();
+      }
+      if (shouldRefreshPullRequests) {
+        void state.refreshSessionPullRequests?.({ refresh: true });
+      }
+      const shouldRecoverMissingTerminal = Boolean(
+        recoveryRunId &&
+        recoveryScope &&
+        getChatSessionProjection(state, state.chatMessages, recoveryScope).runs[recoveryRunId]
+          ?.status === "completed",
+      );
+      const recoveryOwnership =
+        shouldRecoverMissingTerminal && payload
+          ? createTerminalRecoveryOwnership(state, payload)
+          : null;
+      const recoveryClaimed = recoveryOwnership
+        ? claimTerminalRecovery(state, recoveryOwnership)
+        : false;
+      if (recoveryOwnership && recoveryClaimed) {
+        state.pendingSessionMessageReloadSessionKey = null;
+        // The first owned message-less terminal recovers history even when an
+        // earlier snapshot already marked the run complete. Replays, yielded, or
+        // background-run terminals must not repeat I/O or disturb the foreground pane.
+        // Persistence can trail the terminal event, so retry bounded authoritative
+        // snapshots until the completed run's reply becomes visible.
+        void recoverMissingTerminalReply(state, recoveryOwnership, isPresented).catch(
+          () => undefined,
+        );
+      } else {
+        replayPendingSessionMessageReload(state, payload, isPresented);
+      }
+      if (terminalPayload) {
+        void resumeStoredChatOutboxes(state);
+        if (sessionMatches) {
+          if (isPresented()) {
+            refreshSessionWorkspace(state, isSidebarSlotVisible(state.sidebarLayout, "workspace"));
+          } else {
+            retireSessionWorkspaceCheckout(state);
+          }
         }
       }
+      requestChatPageUpdate(state, payload?.state === "delta" ? "animation-frame" : "immediate");
+    };
+    if (!terminalPayload) {
+      apply();
+      return;
     }
-    requestChatPageUpdate(state, payload?.state === "delta" ? "animation-frame" : "immediate");
+    // A cold Blob read may finish after another connection or retry takes over.
+    // Apply the terminal only after its complete user turn owns independent bytes.
+    const scope = resolveStoredChatOutboxScope(
+      state,
+      terminalPayload.sessionKey,
+      isUiGlobalSessionKey(terminalPayload.sessionKey)
+        ? selectedGlobalEventAgentId(state, terminalPayload.agentId ?? null)
+        : terminalPayload.agentId,
+    );
+    const connectionEpoch = state.connectionEpoch;
+    const ownerIsCurrent = captureOutboxPayloadOwner(state);
+    const retirement = retireDeliveredQueuedUserTurn(state, terminalPayload.runId, scope);
+    const finish = (outcome: Awaited<typeof retirement>) => {
+      if (outcome !== "stale" && state.connectionEpoch === connectionEpoch && ownerIsCurrent()) {
+        apply();
+      }
+    };
+    if (retirement instanceof Promise) {
+      return retirement.then(finish);
+    }
+    finish(retirement);
     return;
   }
   if (event.event === "session.observer") {
@@ -707,40 +704,4 @@ export function handlePageGatewayEvent(
   if (event.event === "task") {
     handleBackgroundTasksEvent(state, event.payload, isPresented());
   }
-}
-
-const MAX_REMEMBERED_DELIVERED_QUEUE_TURNS = 64;
-const deliveredQueueTurnsByClient = new WeakMap<object, Map<string, ChatQueueItem>>();
-
-function rememberDeliveredQueuedUserTurn(
-  state: ChatPageHost,
-  runId: string | undefined,
-  scope: StoredChatOutboxScope,
-): ChatQueueItem | null {
-  if (!runId) {
-    return null;
-  }
-  // Every split pane receives the same Gateway event. Keep a bounded delivery
-  // handoff so an inactive pane cannot retire the durable row before its owner
-  // converts the queued projection into a transcript message.
-  const owner = state.client ?? state;
-  let turns = deliveredQueueTurnsByClient.get(owner);
-  if (!turns) {
-    turns = new Map();
-    deliveredQueueTurnsByClient.set(owner, turns);
-  }
-  const deliveryKey = `${storedChatOutboxScopeKey(scope)}|${runId}`;
-  const stored = readDeliveredQueuedChatSendForRun(state, runId, scope)?.item;
-  if (stored) {
-    turns.delete(deliveryKey);
-    turns.set(deliveryKey, stored);
-    while (turns.size > MAX_REMEMBERED_DELIVERED_QUEUE_TURNS) {
-      const oldestRunId = turns.keys().next().value;
-      if (typeof oldestRunId !== "string") {
-        break;
-      }
-      turns.delete(oldestRunId);
-    }
-  }
-  return stored ?? turns.get(deliveryKey) ?? null;
 }

--- a/ui/src/pages/chat/composer-persistence.test.ts
+++ b/ui/src/pages/chat/composer-persistence.test.ts
@@ -21,7 +21,7 @@ type ComposerState = Parameters<typeof persistChatComposerState>[0] & {
 };
 
 const LEGACY_STORAGE_KEY_PREFIX = "openclaw.control.chatComposer.v1:";
-const STORAGE_KEY_PREFIX = "openclaw.control.chatComposer.v2:";
+const STORAGE_KEY_PREFIX = "openclaw.control.chatComposer.v3:";
 
 function gatewayOwner(gatewayUrl: string | null | undefined): string {
   return gatewayUrl?.trim() || "default";
@@ -138,7 +138,7 @@ describe("chat composer persistence", () => {
     sessionStorage.setItem(
       storageKeyForGateway(gatewayUrl),
       JSON.stringify({
-        version: 2,
+        version: 3,
         gatewayOwner: gatewayUrl,
         sessions: {
           [`${state.sessionKey}\u0000agent:lily`]: {
@@ -161,7 +161,7 @@ describe("chat composer persistence", () => {
     sessionStorage.setItem(
       storageKey,
       JSON.stringify({
-        version: 2,
+        version: 3,
         gatewayOwner: gatewayUrl,
         sessions: {
           [`${state.sessionKey}\u0000agent:lily`]: {
@@ -479,33 +479,53 @@ describe("chat composer persistence", () => {
     ).toBe(false);
   });
 
-  it("uses item versions to reject stale updates and deletes", () => {
-    const state = createState({ chatMessage: "keep this draft" });
-    persistChatComposerState(state);
-    const original = reconnectItem("versioned", 1);
-    const attempted = { ...original, sendAttempts: 1 };
-    expect(admitStoredChatComposerQueueItem(state, state.sessionKey, original)).toBe(true);
-    expect(updateStoredChatComposerQueueItem(state, state.sessionKey, original, attempted)).toBe(
-      true,
-    );
+  it.each(["send-attempt", "payload-reference"])(
+    "uses item versions to reject stale updates and deletes after a %s change",
+    (change) => {
+      const state = createState({
+        chatMessage: "keep this draft",
+        client: { recoveryScope: "versioned-owner", recoveryScopeReady: true },
+      });
+      persistChatComposerState(state);
+      const reference = {
+        key: "original-payload",
+        recoveryScope: "versioned-owner",
+        scopeKey: "versioned-scope",
+        tabId: "versioned-tab",
+      };
+      const original: ChatQueueItem = {
+        ...reconnectItem("versioned", 1),
+        attachments: [{ id: "versioned-file", mimeType: "image/png", sizeBytes: 3 }],
+        attachmentPayload: reference,
+      };
+      const successor =
+        change === "send-attempt"
+          ? { ...original, sendAttempts: 1 }
+          : { ...original, attachmentPayload: { ...reference, key: "replacement-payload" } };
+      expect(admitStoredChatComposerQueueItem(state, state.sessionKey, original)).toBe(true);
+      expect(updateStoredChatComposerQueueItem(state, state.sessionKey, original, successor)).toBe(
+        true,
+      );
 
-    expect(
-      updateStoredChatComposerQueueItem(state, state.sessionKey, original, {
-        ...original,
-        sendAttempts: 2,
-      }),
-    ).toBe(false);
-    expect(removeStoredChatComposerQueueItem(state, state.sessionKey, original.id, original)).toBe(
-      false,
-    );
-    expect(
-      removeStoredChatComposerQueueItem(state, state.sessionKey, attempted.id, attempted),
-    ).toBe(true);
-    expect(loadChatComposerSnapshot(state, state.sessionKey)).toEqual({
-      draft: "keep this draft",
-      queue: [],
-    });
-  });
+      expect(
+        updateStoredChatComposerQueueItem(state, state.sessionKey, original, {
+          ...original,
+          sendAttempts: 2,
+        }),
+      ).toBe(false);
+      expect(
+        removeStoredChatComposerQueueItem(state, state.sessionKey, original.id, original),
+      ).toBe(false);
+      expect(loadChatComposerSnapshot(state, state.sessionKey)?.queue[0]).toMatchObject(successor);
+      expect(
+        removeStoredChatComposerQueueItem(state, state.sessionKey, successor.id, successor),
+      ).toBe(true);
+      expect(loadChatComposerSnapshot(state, state.sessionKey)).toEqual({
+        draft: "keep this draft",
+        queue: [],
+      });
+    },
+  );
 
   it("keeps unresolved bare main and raw global independent until their owners resolve", () => {
     const offlineMain = createState({ agentsList: null, hello: null, sessionKey: "main" });
@@ -1315,7 +1335,7 @@ describe("chat composer persistence", () => {
     expect(listStoredChatOutboxes(otherGateway)).toEqual([]);
   });
 
-  it("isolates long same-prefix gateways in owner-tagged v2 buckets", () => {
+  it("isolates long same-prefix gateways in owner-tagged v3 buckets", () => {
     const sharedPrefix = `wss://gateway.test/${"a".repeat(260)}`;
     const firstGatewayUrl = `${sharedPrefix}?route=first`;
     const secondGatewayUrl = `${sharedPrefix}?route=second`;
@@ -1349,7 +1369,7 @@ describe("chat composer persistence", () => {
     });
     for (const gatewayUrl of [firstGatewayUrl, secondGatewayUrl]) {
       const stored = JSON.parse(sessionStorage.getItem(storageKeyForGateway(gatewayUrl)) ?? "{}");
-      expect(stored).toMatchObject({ gatewayOwner: gatewayUrl, version: 2 });
+      expect(stored).toMatchObject({ gatewayOwner: gatewayUrl, version: 3 });
     }
   });
 
@@ -1380,7 +1400,7 @@ describe("chat composer persistence", () => {
     }
   });
 
-  it("migrates an unambiguous shipped v1 bucket into owner-tagged v2", () => {
+  it("migrates an unambiguous shipped v1 bucket into owner-tagged v3", () => {
     const gatewayUrl = "ws://gateway.test/control";
     const legacyStorageKey = legacyStorageKeyForGateway(gatewayUrl);
     const storageKey = storageKeyForGateway(gatewayUrl);
@@ -1407,7 +1427,7 @@ describe("chat composer persistence", () => {
     expect(sessionStorage.getItem(legacyStorageKey)).toBeNull();
     expect(JSON.parse(sessionStorage.getItem(storageKey) ?? "{}")).toMatchObject({
       gatewayOwner: gatewayUrl,
-      version: 2,
+      version: 3,
     });
   });
 

--- a/ui/src/pages/chat/composer-persistence.test.ts
+++ b/ui/src/pages/chat/composer-persistence.test.ts
@@ -490,7 +490,6 @@ describe("chat composer persistence", () => {
       const reference = {
         key: "original-payload",
         recoveryScope: "versioned-owner",
-        scopeKey: "versioned-scope",
         tabId: "versioned-tab",
       };
       const original: ChatQueueItem = {

--- a/ui/src/pages/chat/composer-persistence.ts
+++ b/ui/src/pages/chat/composer-persistence.ts
@@ -129,13 +129,24 @@ function serializeChatAttachment(attachment: ChatAttachment): ChatAttachment | n
 function serializeQueueItem(item: ChatQueueItem): ChatQueueItem | null {
   if (
     !item.id?.trim() ||
-    (!item.text?.trim() && !item.attachments?.length) ||
+    (!item.text?.trim() &&
+      !item.attachments?.length &&
+      !item.attachmentPayload &&
+      !item.attachmentStorageError) ||
     item.pendingRunId ||
     (item.sendState === "sending" && !item.sendRunId)
   ) {
     return null;
   }
-  const attachments = item.attachments?.map(serializeChatAttachment) ?? [];
+  const attachments = (item.attachments ?? []).map((attachment) => {
+    const { dataUrl: _dataUrl, previewUrl: _previewUrl, ...metadata } = attachment;
+    // A failed migration owns no Blob yet: retain its inline bytes across reload.
+    // Only a payload reference permits removing bytes from the stored queue row.
+    if (item.attachmentPayload) {
+      return metadata;
+    }
+    return serializeChatAttachment(attachment) ?? (item.attachmentStorageError ? metadata : null);
+  });
   if (item.attachments?.length && attachments.some((attachment) => attachment === null)) {
     return null;
   }
@@ -187,7 +198,8 @@ function queueItemVersionMatches(
     stored.sendState === canonicalExpected.sendState &&
     stored.agentId === canonicalExpected.agentId &&
     stored.sessionKey === canonicalExpected.sessionKey &&
-    stored.orderKey === canonicalExpected.orderKey,
+    stored.orderKey === canonicalExpected.orderKey &&
+    stored.attachmentPayload?.key === canonicalExpected.attachmentPayload?.key,
   );
 }
 
@@ -291,7 +303,7 @@ export function loadChatComposerCommittedDraftRevision(
 export function loadChatComposerSnapshot(
   state: Pick<
     ChatComposerPersistenceState,
-    "settings" | "assistantAgentId" | "agentsList" | "hello"
+    "settings" | "assistantAgentId" | "agentsList" | "hello" | "client"
   >,
   sessionKey: string,
   agentIdOverride?: string,
@@ -359,6 +371,11 @@ export function loadChatComposerSnapshot(
       draft,
       ...(session.goalMode ? { goalMode: session.goalMode } : {}),
       queue: (session.queue ?? [])
+        .filter(
+          (item) =>
+            !item.attachmentPayload ||
+            item.attachmentPayload.recoveryScope === state.client?.recoveryScope,
+        )
         .map((item) => serializeQueueItemForScope(item, scope))
         .filter((item): item is ChatQueueItem => item !== null)
         .map((item) => Object.assign(item, { sessionKey })),
@@ -1101,10 +1118,18 @@ export class ChatComposerPersistence {
     if (!scope) {
       return;
     }
+    const previousOwner = this.durableOwner;
+    // Draft writes notify panes synchronously. Publish the new owner before
+    // clearing the old draft so reentrant persistence cannot repeat this transition.
+    this.durableOwner = {
+      client: state.client,
+      gatewayOwner: scope.gatewayOwner,
+      recoveryScope: scope.recoveryScope,
+    };
     if (
-      this.durableOwner &&
-      (this.durableOwner.gatewayOwner !== scope.gatewayOwner ||
-        this.durableOwner.recoveryScope !== scope.recoveryScope)
+      previousOwner &&
+      (previousOwner.gatewayOwner !== scope.gatewayOwner ||
+        previousOwner.recoveryScope !== scope.recoveryScope)
     ) {
       releaseChatAttachmentPayloads(state.chatAttachments);
       state.chatMessage = "";
@@ -1124,13 +1149,7 @@ export class ChatComposerPersistence {
       this.durableRestoreProtected = false;
       this.forceDurableOwnerRestore = true;
       this.durablePersistence.resetRestoreScope();
-      state.requestUpdate?.();
     }
-    this.durableOwner = {
-      client: state.client,
-      gatewayOwner: scope.gatewayOwner,
-      recoveryScope: scope.recoveryScope,
-    };
     if (this.durableRestoreProtected) {
       this.durableRestoreProtected = false;
       const snapshot = this.snapshot(

--- a/ui/src/pages/chat/durable-composer-persistence.ts
+++ b/ui/src/pages/chat/durable-composer-persistence.ts
@@ -6,8 +6,9 @@ import type {
 import {
   generateAttachmentId,
   getChatAttachmentBlob,
+  getChatAttachmentDataUrl,
+  registerChatAttachmentPayload,
   releaseChatAttachmentPayloads,
-  restoreChatAttachmentPayload,
 } from "./attachment-payload-store.ts";
 
 export type DurableChatComposerSnapshot = {
@@ -80,12 +81,67 @@ export function chatAttachmentDraftSignature(
   ]);
 }
 
+function blobFromDataUrl(dataUrl: string): Blob | null {
+  const match = /^data:([^,]*),(.*)$/s.exec(dataUrl);
+  if (!match) {
+    return null;
+  }
+  const metadata = match[1] ?? "";
+  const payload = match[2] ?? "";
+  try {
+    if (metadata.toLowerCase().includes(";base64")) {
+      const binary = atob(payload.replace(/\s+/gu, ""));
+      const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+      return new Blob([bytes], { type: metadata.split(";", 1)[0] });
+    }
+    return new Blob([decodeURIComponent(payload.replace(/\+/gu, "%20"))], {
+      type: metadata.split(";", 1)[0],
+    });
+  } catch {
+    return null;
+  }
+}
+
+export function readBlobAsDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener("error", () => reject(reader.error ?? new Error("Blob read failed")), {
+      once: true,
+    });
+    reader.addEventListener(
+      "load",
+      () =>
+        typeof reader.result === "string"
+          ? resolve(reader.result)
+          : reject(new Error("Blob read returned no data")),
+      { once: true },
+    );
+    reader.readAsDataURL(blob);
+  });
+}
+
+async function restoreChatAttachmentPayload(params: {
+  attachment: ChatAttachment;
+  blob: Blob;
+}): Promise<ChatAttachment> {
+  const blob =
+    params.blob.type === params.attachment.mimeType
+      ? params.blob
+      : params.blob.slice(0, params.blob.size, params.attachment.mimeType);
+  const dataUrl = await readBlobAsDataUrl(blob);
+  const file = new File([blob], params.attachment.fileName ?? "attachment", {
+    type: params.attachment.mimeType,
+  });
+  return registerChatAttachmentPayload({ attachment: params.attachment, dataUrl, file });
+}
+
 export function captureDurableChatAttachments(
   attachments: readonly ChatAttachment[],
 ): DurableComposerDraftAttachment[] | null {
   const stored: DurableComposerDraftAttachment[] = [];
   for (const attachment of attachments) {
-    const blob = getChatAttachmentBlob(attachment);
+    const dataUrl = getChatAttachmentDataUrl(attachment);
+    const blob = getChatAttachmentBlob(attachment) ?? (dataUrl ? blobFromDataUrl(dataUrl) : null);
     if (!blob) {
       return null;
     }

--- a/ui/src/pages/chat/outbox-browser.test-support.ts
+++ b/ui/src/pages/chat/outbox-browser.test-support.ts
@@ -1,18 +1,57 @@
 import { Blob as NodeBlob, File as NodeFile } from "node:buffer";
 import { IDBFactory } from "fake-indexeddb";
 import { afterEach, vi } from "vitest";
-import * as payloadStore from "../../lib/chat/outbox-payload-store.runtime.ts";
 import * as payloads from "./durable-composer-persistence.ts";
 
 let factory: IDBFactory | undefined;
+let restoreLocks: (() => void) | undefined;
 
-/** Node send tests exercise IDB transactions; native locks and FileReader live in E2E. */
+function createDocumentLocks() {
+  const held = new Set<string>();
+  return {
+    async request(
+      name: string,
+      options: LockOptions,
+      callback: (lock: Lock | null) => unknown,
+    ): Promise<unknown> {
+      if (!options.ifAvailable || (options.mode && options.mode !== "exclusive")) {
+        throw new Error("The outbox fixture supports exclusive ifAvailable locks only");
+      }
+      if (held.has(name)) {
+        return callback(null);
+      }
+      held.add(name);
+      try {
+        return await callback({ name, mode: "exclusive" });
+      } finally {
+        held.delete(name);
+      }
+    },
+  };
+}
+
+// The cached tab claim and its lock share the document's lifetime, even when a
+// test replaces storage. Reinstall the same manager for the same navigator.
+const documentLocks = new WeakMap<Navigator, ReturnType<typeof createDocumentLocks>>();
+
+/** Node send tests exercise IDB transactions and lock ownership; native FileReader lives in E2E. */
 export function installOutboxBrowserStorage(): void {
   factory = new IDBFactory();
   vi.stubGlobal("indexedDB", factory);
   vi.stubGlobal("Blob", NodeBlob);
   vi.stubGlobal("File", NodeFile);
-  vi.spyOn(payloadStore, "outboxPayloadTab").mockResolvedValue("test-outbox-tab");
+  const browserNavigator = navigator;
+  const descriptor = Object.getOwnPropertyDescriptor(browserNavigator, "locks");
+  const locks = documentLocks.get(browserNavigator) ?? createDocumentLocks();
+  documentLocks.set(browserNavigator, locks);
+  Object.defineProperty(browserNavigator, "locks", { configurable: true, value: locks });
+  restoreLocks = () => {
+    if (descriptor) {
+      Object.defineProperty(browserNavigator, "locks", descriptor);
+    } else {
+      Reflect.deleteProperty(browserNavigator, "locks");
+    }
+  };
   vi.spyOn(payloads, "readBlobAsDataUrl").mockImplementation(
     async (blob) =>
       `data:${blob.type};base64,${Buffer.from(await blob.arrayBuffer()).toString("base64")}`,
@@ -20,15 +59,20 @@ export function installOutboxBrowserStorage(): void {
 }
 
 afterEach(async () => {
-  if (!factory) {
-    return;
+  try {
+    if (!factory) {
+      return;
+    }
+    const request = factory.deleteDatabase("openclaw-control-ui");
+    await new Promise<void>((resolve, reject) => {
+      request.onsuccess = () => resolve();
+      request.addEventListener("error", () =>
+        reject(request.error ?? new Error("IndexedDB request failed")),
+      );
+    });
+    factory = undefined;
+  } finally {
+    restoreLocks?.();
+    restoreLocks = undefined;
   }
-  const request = factory.deleteDatabase("openclaw-control-ui");
-  await new Promise<void>((resolve, reject) => {
-    request.onsuccess = () => resolve();
-    request.addEventListener("error", () =>
-      reject(request.error ?? new Error("IndexedDB request failed")),
-    );
-  });
-  factory = undefined;
 });

--- a/ui/src/pages/chat/outbox-browser.test-support.ts
+++ b/ui/src/pages/chat/outbox-browser.test-support.ts
@@ -1,0 +1,34 @@
+import { Blob as NodeBlob, File as NodeFile } from "node:buffer";
+import { IDBFactory } from "fake-indexeddb";
+import { afterEach, vi } from "vitest";
+import * as payloadStore from "../../lib/chat/outbox-payload-store.runtime.ts";
+import * as payloads from "./durable-composer-persistence.ts";
+
+let factory: IDBFactory | undefined;
+
+/** Node send tests exercise IDB transactions; native locks and FileReader live in E2E. */
+export function installOutboxBrowserStorage(): void {
+  factory = new IDBFactory();
+  vi.stubGlobal("indexedDB", factory);
+  vi.stubGlobal("Blob", NodeBlob);
+  vi.stubGlobal("File", NodeFile);
+  vi.spyOn(payloadStore, "outboxPayloadTab").mockResolvedValue("test-outbox-tab");
+  vi.spyOn(payloads, "readBlobAsDataUrl").mockImplementation(
+    async (blob) =>
+      `data:${blob.type};base64,${Buffer.from(await blob.arrayBuffer()).toString("base64")}`,
+  );
+}
+
+afterEach(async () => {
+  if (!factory) {
+    return;
+  }
+  const request = factory.deleteDatabase("openclaw-control-ui");
+  await new Promise<void>((resolve, reject) => {
+    request.onsuccess = () => resolve();
+    request.addEventListener("error", () =>
+      reject(request.error ?? new Error("IndexedDB request failed")),
+    );
+  });
+  factory = undefined;
+});

--- a/ui/src/pages/chat/outbox-payloads.ts
+++ b/ui/src/pages/chat/outbox-payloads.ts
@@ -7,12 +7,7 @@ import {
   writeOutboxPayload,
   type OutboxPayloadFailure,
 } from "../../lib/chat/outbox-payload-store.runtime.ts";
-import {
-  resolveStoredChatOutboxScope,
-  storedChatOutboxScopeKey,
-  storageTargetForGateway,
-  type ChatComposerScope,
-} from "../../lib/chat/outbox-store.ts";
+import { storageTargetForGateway, type ChatComposerScope } from "../../lib/chat/outbox-store.ts";
 import {
   captureDurableChatAttachments,
   readBlobAsDataUrl,
@@ -103,9 +98,6 @@ async function preparePayload(
     tabId,
     gatewayOwner: storageTargetForGateway(host.settings?.gatewayUrl).gatewayOwner,
     recoveryScope,
-    scopeKey: storedChatOutboxScopeKey(
-      resolveStoredChatOutboxScope(host, item.sessionKey ?? "", item.agentId),
-    ),
     queueId: item.id,
   };
   if (item.attachmentPayload) {
@@ -191,8 +183,8 @@ async function preparePayload(
   };
 }
 
-// Preview and drain may request the same restored bundle in one turn. Share
-// that read/copy so a cloned tab cannot create two competing replacement refs.
+// Preview and drain share reads/copies so a cloned tab cannot create competing refs.
+// Check admission per caller; only equivalent bundle identities and metadata may join.
 const pendingPayloads = new Map<string, Promise<PayloadResult>>();
 export async function prepareOutboxPayload(
   host: Host,
@@ -200,14 +192,18 @@ export async function prepareOutboxPayload(
   purpose: "send" | "handoff" = "send",
 ): Promise<PayloadResult> {
   const reference = item.attachmentPayload;
-  if (!reference) {
+  if (!reference || host.selectedChatSessionIncognito || !observeOutboxRecoveryOwner(host)) {
     return preparePayload(host, item, purpose);
   }
   const key = JSON.stringify([
+    item.id,
     reference.key,
+    reference.tabId,
+    reference.recoveryScope,
     host.settings?.gatewayUrl,
     host.client?.recoveryScope,
     purpose,
+    item.attachments?.map(({ mimeType, fileName, sizeBytes }) => [mimeType, fileName, sizeBytes]),
   ]);
   const isCurrent = captureOutboxPayloadOwner(host);
   let pending = pendingPayloads.get(key);

--- a/ui/src/pages/chat/outbox-payloads.ts
+++ b/ui/src/pages/chat/outbox-payloads.ts
@@ -1,0 +1,242 @@
+import { t } from "../../i18n/index.ts";
+import type { ChatQueueItem } from "../../lib/chat/chat-types.ts";
+import {
+  outboxPayloadTab,
+  readOutboxPayload,
+  removeOutboxPayloads,
+  writeOutboxPayload,
+  type OutboxPayloadFailure,
+} from "../../lib/chat/outbox-payload-store.runtime.ts";
+import {
+  resolveStoredChatOutboxScope,
+  storedChatOutboxScopeKey,
+  storageTargetForGateway,
+  type ChatComposerScope,
+} from "../../lib/chat/outbox-store.ts";
+import {
+  captureDurableChatAttachments,
+  readBlobAsDataUrl,
+} from "./durable-composer-persistence.ts";
+
+type Host = ChatComposerScope & {
+  client?: { recoveryScope?: string; recoveryScopeReady?: boolean } | null;
+  selectedChatSessionIncognito?: boolean;
+};
+type PayloadResult =
+  | { status: "ready"; item: ChatQueueItem }
+  | { status: "failed"; reason: OutboxPayloadFailure };
+const knownOwners = new WeakMap<object, string>();
+
+export function outboxPayloadError(reason: OutboxPayloadFailure): string {
+  return t(
+    `chat.sendErrors.outboxPayload${reason === "capacity" ? "Capacity" : reason === "missing" ? "Missing" : "Unavailable"}`,
+  );
+}
+
+export function failOutboxPayload(item: ChatQueueItem, reason: OutboxPayloadFailure) {
+  const attempted =
+    (item.sendAttempts ?? 0) > 0 ||
+    item.sendRequestStartedAtMs !== undefined ||
+    item.sendState === "unconfirmed";
+  return {
+    ...item,
+    attachmentStorageError: reason,
+    sendState: attempted ? ("unconfirmed" as const) : ("failed" as const),
+    sendError: outboxPayloadError(reason),
+  };
+}
+
+export function observeOutboxRecoveryOwner(host: Host): string | undefined {
+  const client = host.client;
+  if (!client) {
+    return undefined;
+  }
+  if (client.recoveryScopeReady && client.recoveryScope) {
+    knownOwners.set(client, client.recoveryScope);
+  }
+  const remembered = knownOwners.get(client);
+  return remembered === client.recoveryScope ? remembered : undefined;
+}
+
+export function captureOutboxPayloadOwner(host: Host): () => boolean {
+  const client = host.client;
+  const gateway = host.settings?.gatewayUrl;
+  const recoveryScope = client?.recoveryScope;
+  const incognito = host.selectedChatSessionIncognito;
+  return () =>
+    host.client === client &&
+    host.settings?.gatewayUrl === gateway &&
+    host.client?.recoveryScope === recoveryScope &&
+    host.selectedChatSessionIncognito === incognito;
+}
+
+async function preparePayload(
+  host: Host,
+  item: ChatQueueItem,
+  purpose: "send" | "handoff",
+): Promise<PayloadResult> {
+  if (!item.attachments?.length && !item.attachmentPayload && !item.attachmentStorageError) {
+    return { status: "ready", item };
+  }
+  // Incognito keeps the existing tab-only inline outbox and its quota. It must
+  // never acquire restart-persistent Blob ownership or hydrate a regular row.
+  if (host.selectedChatSessionIncognito) {
+    return item.attachmentPayload
+      ? { status: "failed", reason: "unavailable" }
+      : { status: "ready", item };
+  }
+  const recoveryScope = observeOutboxRecoveryOwner(host);
+  if (!recoveryScope) {
+    return { status: "failed", reason: "unavailable" };
+  }
+  const isCurrent = captureOutboxPayloadOwner(host);
+  let tabId: string;
+  try {
+    tabId = await outboxPayloadTab();
+  } catch {
+    return { status: "failed", reason: "unavailable" };
+  }
+  if (!isCurrent()) {
+    return { status: "failed", reason: "unavailable" };
+  }
+  const owner = {
+    tabId,
+    gatewayOwner: storageTargetForGateway(host.settings?.gatewayUrl).gatewayOwner,
+    recoveryScope,
+    scopeKey: storedChatOutboxScopeKey(
+      resolveStoredChatOutboxScope(host, item.sessionKey ?? "", item.agentId),
+    ),
+    queueId: item.id,
+  };
+  if (item.attachmentPayload) {
+    const result = await readOutboxPayload(owner, item.attachmentPayload);
+    if (result.status === "failed") {
+      return result;
+    }
+    const metadata = item.attachments ?? [];
+    if (
+      result.value.length !== metadata.length ||
+      result.value.some((attachment, index) => {
+        const expected = metadata[index]!;
+        return (
+          attachment.mimeType !== expected.mimeType ||
+          attachment.fileName !== expected.fileName ||
+          attachment.sizeBytes !== expected.sizeBytes
+        );
+      })
+    ) {
+      return { status: "failed", reason: "missing" };
+    }
+    if (!isCurrent()) {
+      return { status: "failed", reason: "unavailable" };
+    }
+    try {
+      // Restore into isolated objects; no consumer sees a partially hydrated batch.
+      const attachments = await Promise.all(
+        result.value.map(async (attachment, index) => ({
+          ...metadata[index]!,
+          dataUrl: await readBlobAsDataUrl(attachment.blob),
+        })),
+      );
+      if (!isCurrent()) {
+        return { status: "failed", reason: "unavailable" };
+      }
+      if (purpose === "send" && item.attachmentPayload.tabId !== tabId) {
+        const copy = await writeOutboxPayload(owner, result.value);
+        if (copy.status === "failed") {
+          return copy;
+        }
+        if (!isCurrent()) {
+          await removeOutboxPayloads([copy.value]);
+          return { status: "failed", reason: "unavailable" };
+        }
+        // A duplicate tab carries the same submission, never a fresh send. It
+        // owns its copied bytes, but needs explicit review before retrying.
+        return {
+          status: "ready",
+          item: {
+            ...item,
+            attachments,
+            attachmentPayload: copy.value,
+            sendState: "unconfirmed",
+            sendError: t("chat.sendErrors.outboxPayloadCopied"),
+            attachmentStorageError: undefined,
+          },
+        };
+      }
+      return { status: "ready", item: { ...item, attachments, attachmentStorageError: undefined } };
+    } catch {
+      return { status: "failed", reason: "missing" };
+    }
+  }
+  // Delivery already happened: read existing bytes, never allocate a new bundle.
+  if (purpose === "handoff" || item.attachmentStorageError === "missing") {
+    return { status: "failed", reason: "missing" };
+  }
+  const attachments = captureDurableChatAttachments(item.attachments ?? []);
+  if (!attachments) {
+    return { status: "failed", reason: "missing" };
+  }
+  const result = await writeOutboxPayload(owner, attachments);
+  if (result.status === "failed") {
+    return result;
+  }
+  if (!isCurrent()) {
+    await removeOutboxPayloads([result.value]);
+    return { status: "failed", reason: "unavailable" };
+  }
+  return {
+    status: "ready",
+    item: { ...item, attachmentPayload: result.value, attachmentStorageError: undefined },
+  };
+}
+
+// Preview and drain may request the same restored bundle in one turn. Share
+// that read/copy so a cloned tab cannot create two competing replacement refs.
+const pendingPayloads = new Map<string, Promise<PayloadResult>>();
+export async function prepareOutboxPayload(
+  host: Host,
+  item: ChatQueueItem,
+  purpose: "send" | "handoff" = "send",
+): Promise<PayloadResult> {
+  const reference = item.attachmentPayload;
+  if (!reference) {
+    return preparePayload(host, item, purpose);
+  }
+  const key = JSON.stringify([
+    reference.key,
+    host.settings?.gatewayUrl,
+    host.client?.recoveryScope,
+    purpose,
+  ]);
+  const isCurrent = captureOutboxPayloadOwner(host);
+  let pending = pendingPayloads.get(key);
+  if (!pending) {
+    pending = preparePayload(host, item, purpose).finally(() => pendingPayloads.delete(key));
+    pendingPayloads.set(key, pending);
+  }
+  const result = await pending;
+  if (!isCurrent()) {
+    return { status: "failed", reason: "unavailable" };
+  }
+  if (result.status === "failed") {
+    return result;
+  }
+  const copied = result.item.attachmentPayload?.key !== reference.key;
+  return {
+    status: "ready",
+    item: {
+      ...item,
+      attachments: result.item.attachments,
+      attachmentPayload: result.item.attachmentPayload,
+      attachmentStorageError: undefined,
+      ...(copied ? { sendState: result.item.sendState, sendError: result.item.sendError } : {}),
+    },
+  };
+}
+
+export function retireOutboxPayload(item: ChatQueueItem): void {
+  if (item.attachmentPayload) {
+    void removeOutboxPayloads([item.attachmentPayload]);
+  }
+}

--- a/ui/src/pages/chat/queued-message-edit.test.ts
+++ b/ui/src/pages/chat/queued-message-edit.test.ts
@@ -6,6 +6,7 @@ import { createStorageMock } from "../../test-helpers/storage.ts";
 import {
   getChatAttachmentDataUrl,
   registerChatAttachmentPayload,
+  releaseChatAttachmentPayloads,
 } from "./attachment-payload-store.ts";
 import { makeChatHost } from "./chat-host.test-support.ts";
 import {
@@ -21,6 +22,7 @@ import {
 import { handleSendChat } from "./chat-send-submit.ts";
 import { OFFLINE_QUEUE_STORAGE_ERROR } from "./chat-send-support.ts";
 import { listStoredChatOutboxes } from "./composer-persistence.ts";
+import { installOutboxBrowserStorage } from "./outbox-browser.test-support.ts";
 import {
   beginQueuedMessageEdit,
   cancelQueuedMessageEdit,
@@ -33,24 +35,42 @@ import {
 } from "./queued-message-edit.ts";
 
 const SESSION_KEY = "agent:main";
+const outboxSubscriptions: Array<() => void> = [];
+const stagedAttachments: ChatAttachment[] = [];
 
 beforeEach(() => {
+  installOutboxBrowserStorage();
   vi.stubGlobal("sessionStorage", createStorageMock());
   vi.stubGlobal("requestAnimationFrame", () => 1);
   vi.stubGlobal("cancelAnimationFrame", () => undefined);
 });
 
 afterEach(() => {
+  for (const unsubscribe of outboxSubscriptions.splice(0)) {
+    unsubscribe();
+  }
+  releaseChatAttachmentPayloads(stagedAttachments.splice(0));
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
+
+function trackOutboxProjection(host: Parameters<typeof subscribeChatOutboxProjection>[0]) {
+  const unsubscribe = subscribeChatOutboxProjection(host);
+  outboxSubscriptions.push(unsubscribe);
+  return unsubscribe;
+}
 
 function queueHost(
   items: readonly Partial<ChatQueueItem>[],
   overrides: Parameters<typeof makeChatHost>[0] = {},
 ) {
-  const host = makeChatHost({ sessionKey: SESSION_KEY, connected: false, ...overrides });
-  const unsubscribe = subscribeChatOutboxProjection(host as never);
+  const host = makeChatHost({
+    sessionKey: SESSION_KEY,
+    connected: false,
+    requestHandlers: {},
+    ...overrides,
+  });
+  const unsubscribe = trackOutboxProjection(host as never);
   items.forEach((item, index) => {
     expect(
       admitQueuedMessageForSession(host as never, SESSION_KEY, {
@@ -85,11 +105,13 @@ function storedOutboxesByAgent(host: unknown): Record<string, string[]> {
 
 /** An image whose bytes live in the payload store, so releasing it is observable. */
 function stageQueuedImage(id: string): ChatAttachment {
-  return registerChatAttachmentPayload({
+  const attachment = registerChatAttachmentPayload({
     attachment: { id, mimeType: "image/png" },
-    dataUrl: `data:image/png;base64,iVB${id}`,
+    dataUrl: "data:image/png;base64,cG5n",
     file: new File(["png"], `${id}.png`, { type: "image/png" }),
   });
+  stagedAttachments.push(attachment);
+  return attachment;
 }
 
 /** A full store: any write that would grow it is rejected, exactly as quota does. */
@@ -216,7 +238,11 @@ describe("queued message edit round-trip", () => {
     const { host, unsubscribe } = queueHost([{}, {}]);
     beginQueuedMessageEdit(host as never, "queued-1");
     updateQueuedMessageEdit(host as never, "message 1, corrected");
-    const stalePane = makeChatHost({ connected: false, sessionKey: SESSION_KEY });
+    const stalePane = makeChatHost({
+      client: host.client,
+      connected: false,
+      sessionKey: SESSION_KEY,
+    });
     expect(
       updateQueuedMessage(stalePane as never, "queued-1", (item) => ({
         ...item,
@@ -333,7 +359,7 @@ describe("queued message edit round-trip", () => {
       requestHandlers: { "chat.send": sendRequest },
       sessionKey: SESSION_KEY,
     });
-    const stopPeer = subscribeChatOutboxProjection(peer as never);
+    const stopPeer = trackOutboxProjection(peer as never);
 
     try {
       beginQueuedMessageEdit(host as never, original.id);
@@ -355,8 +381,12 @@ describe("queued message edit round-trip", () => {
 
   it("reports when a peer reorder crosses the row another pane is editing", () => {
     const { host, unsubscribe } = queueHost([{}, {}, {}]);
-    const peer = makeChatHost({ connected: false, sessionKey: SESSION_KEY });
-    const stopPeer = subscribeChatOutboxProjection(peer as never);
+    const peer = makeChatHost({
+      client: host.client,
+      connected: false,
+      sessionKey: SESSION_KEY,
+    });
+    const stopPeer = trackOutboxProjection(peer as never);
 
     try {
       beginQueuedMessageEdit(host as never, "queued-2");
@@ -372,8 +402,12 @@ describe("queued message edit round-trip", () => {
 
   it("translates peer reorder indices within one side of an edited-row barrier", () => {
     const { host, unsubscribe } = queueHost([{}, {}, {}, {}]);
-    const peer = makeChatHost({ connected: false, sessionKey: SESSION_KEY });
-    const stopPeer = subscribeChatOutboxProjection(peer as never);
+    const peer = makeChatHost({
+      client: host.client,
+      connected: false,
+      sessionKey: SESSION_KEY,
+    });
+    const stopPeer = trackOutboxProjection(peer as never);
 
     try {
       beginQueuedMessageEdit(host as never, "queued-2");
@@ -423,7 +457,7 @@ describe("queued message edit round-trip", () => {
 
   it("cannot retire a row in the outbox a global agent switch left behind", async () => {
     const host = makeChatHost({ assistantAgentId: "lily", connected: false, sessionKey: "global" });
-    const unsubscribe = subscribeChatOutboxProjection(host as never);
+    const unsubscribe = trackOutboxProjection(host as never);
     expect(
       admitQueuedMessageForSession(host as never, "global", {
         id: "queued-1",

--- a/ui/src/pages/chat/queued-message-edit.ts
+++ b/ui/src/pages/chat/queued-message-edit.ts
@@ -2,7 +2,10 @@
 import { chatQueueOrderKey, isMovableChatQueueItem } from "../../lib/chat/chat-queue-order.ts";
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { scopedAgentIdForSession, visibleSessionMatches } from "../../lib/sessions/index.ts";
-import { releaseChatAttachmentPayloads } from "./attachment-payload-store.ts";
+import {
+  getChatAttachmentDataUrl,
+  releaseChatAttachmentPayloads,
+} from "./attachment-payload-store.ts";
 import {
   anyChatOutboxPaneMatches,
   isDurableQueuedMessage,
@@ -119,6 +122,8 @@ export function beginQueuedMessageEdit(
   if (
     !item ||
     !isMovableChatQueueItem(item) ||
+    Boolean(item.attachmentStorageError) ||
+    Boolean(item.attachments?.some((attachment) => !getChatAttachmentDataUrl(attachment))) ||
     item.localCommandName ||
     activeQueuedMessageEdit(host) ||
     isQueuedMessageBeingEdited(host, id)

--- a/ui/src/test-helpers/gateway-client.ts
+++ b/ui/src/test-helpers/gateway-client.ts
@@ -14,6 +14,10 @@ export function createGatewayRequestMock(
 export function createTestGatewayClient(request: GatewayRequestHandler): GatewayBrowserClient {
   const client = new GatewayBrowserClient({ url: "ws://test.invalid" });
   // Request stubs represent an authenticated client whose recovery scope has settled.
+  Object.defineProperty(client, "recoveryScope", {
+    configurable: true,
+    get: () => "test-recovery-scope",
+  });
   Object.defineProperty(client, "recoveryScopeReady", { configurable: true, get: () => true });
   client.request = async <T = unknown>(method: string, params?: unknown): Promise<T> =>
     (await request(method, params)) as T;


### PR DESCRIPTION
Closes #132833

**Landing coordination:** this bounded attachment repair is proceeding first after renewed maintainer direction. The [canonical Main/global session identity repair](https://github.com/openclaw/openclaw/pull/133067) remains unmerged; its owner has been notified to rebase that later migration onto this Blob-storage contract. Both branches independently introduced a `v3` browser metadata format and must not be merged without owner-level integration. Native preparation and merge completed at the verified head, landing as [`baef6e0ed070853d1a25b35bf7b57841c3a0b294`](https://github.com/openclaw/openclaw/commit/baef6e0ed070853d1a25b35bf7b57841c3a0b294), without an admin bypass.

Published head: `c2d2fc21b4703da17a95fafb177cca6e5c860b83`. Local, native-browser, build, review, and real-Gateway proof below apply to this candidate. [Exact-head CI run 33302931394](https://github.com/openclaw/openclaw/actions/runs/33302931394) and the required `openclaw/ci-gate` are green; native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run` completed without changing the head. The final rebase preserved main's stronger [selected-session/quota ownership repair](https://github.com/openclaw/openclaw/pull/133085) and dropped our redundant ten-line quota fixture; all original auth assertions remain. The six-line responsive correction waits for normal visibility and settled geometry without changing CSS, bounds, or timeouts; its pre-fix failure was CI-only, not reproduced locally.

An inherited main typecheck error required one additional, net-zero caller-import repair in Code Mode recovery: use the existing `plugins/tool-metadata` helper rather than its retired `plugins/tools` export. The exact failing typecheck now passes, as do all 15 existing recovery tests. No replay or ownership policy changed; the same correction is now canonically merged through the [metadata-leaf import repair](https://github.com/openclaw/openclaw/pull/133155).

## What Problem This Solves

Fixes an issue where users steering an active Control UI turn with two valid 2,404,765-byte PNGs would hit the reconnect-storage error before any `chat.send`. Both files fit the separate 25 MiB composer-draft limit, but their data URLs alone consume 12,825,512 bytes under Chromium's UTF-16 session-storage accounting, exceeding its 10,485,760-byte quota before JSON overhead. One large PNG and a large-plus-small batch already worked.

## Why This Change Was Made

Store immutable outbox-owned attachment Blobs in the existing browser IndexedDB database and keep delivery metadata/references in tab session storage. Commit the entire binary batch before admission, hydrate all bytes before transport, and transfer complete attachments into the local transcript/cache before retiring their outbox storage. This repairs the persistence owner instead of weakening active-run durability or borrowing editable, expiring draft records.

The explicitly approved browser schema upgrade preserves existing draft records and readable inline queues. Shared database opening, draft retirement, Blob conversion, and terminal/reconnect handoff reuse or replace existing paths rather than adding parallel implementations. Async operations retain exact credential, queue-attempt, and payload-reference ownership. Uncertain retries preserve their original idempotency key; failed inline migration preserves its original bytes. Credential transitions publish their new owner before synchronous pane notifications, and passive recovery respects the caller's frame-coalesced rendering. The event entrypoint keeps its existing void API.

The final review repair removes mutable conversation scope from the immutable Blob owner: bytes belong to the generated queued-input ID, exact opaque reference, Gateway, authenticated recovery owner, and source tab. Queue metadata still owns routing and strict attempt/reference CAS; physical deletion still requires the document's held Web Lock. Alias reclassification no longer strands readable bytes. Each preparation caller must establish recovery/Incognito eligibility before sharing work, and coalescing requires matching queue/reference identities and ordered attachment MIME/name/size metadata. Previously observed offline owners remain valid, and handoff never allocates a duplicate copy. This follow-up removes ten production lines and adds no schema version, migration, configuration, or fallback.

Independent of the merged [stored-image steering repair](https://github.com/openclaw/openclaw/pull/132429). No provider-behavior, Gateway protocol, SQLite, product configuration, dependency, or performance-budget changes; the sole non-UI production edit is the inherited caller-import repair described above. The original history-image report was a capture-timing false alarm: this adds only the complete-byte handoff required by the new outbox backing store, not a general history repair. Current main's [cloud pending-input custody](https://github.com/openclaw/openclaw/pull/132887) is preserved and covered by a Blob-backed custody-transfer regression.

## User Impact

Active-run attachment batches that fit the storage and Gateway limits can be sent without expanding binary data into session storage. The reproduced two-image batch now uses **2,156 bytes of queue metadata**, plus a 130-byte tab marker. Storage failures retain input or a visible recovery row; no partial attachment send or new volatile fallback is allowed. Lost acknowledgements do not trigger automatic replay.

Binary outbox storage requires IndexedDB and Web Locks over HTTPS or localhost. Retention is bounded at **25 MiB per message, 250 MiB and 1,000 bundles per browser origin**, with no age-based eviction of queued input. Delivery/discard retires owned bundles. Closed tabs or interrupted copies/cleanup can leave bounded unadopted bundles; the documented recovery is to preserve needed drafts before clearing site data, which also clears browser drafts and sign-in state. Incognito stays on its tab-only inline storage path. Duplicated tabs preserve submission IDs, copy their bytes, and require explicit delivery review; a late duplicate whose source already retired reports missing attachments. Independent tabs remain independent.

Documentation: https://docs.openclaw.ai/web/control-ui#chat-behavior

## Evidence

- **Before:** native Chromium reproduction failed for two large PNGs with the storage banner, intact draft/previews, no queue admission, and zero `chat.send`; the smaller control batches passed. Fixtures are generated CRC-valid PNGs, not committed binary assets. Native quota probing accepted 10,485,760 bytes and rejected 10,485,762.
- **After:** the full Control UI suite passes **12,013 tests across 780 files** (86 existing skipped tests across 20 skipped files), plus **44 native Chromium E2E tests across eight files**. Coverage includes complete-byte terminal/reconnect handoff, stale credentials/attempts/references, inline migration failure and reload, repeated uncertain retries, blocked upgrades, duplicate/independent tabs, corruption, editing, deletion, draft retention, pending-input custody, attachment-read lifecycle, and frame-coalesced rendering. Removing the exact-reference fence makes both delayed-read regressions fail for the intended reasons. The complete eight-test history/recovery file also passes after adding an explicit same-transport-route retry assertion.
- **Review/CI repairs:** ClawSweeper's P1 reproduced in native Chromium: while native arbitration denied the duplicate's copied lock and its callback was held, removing the duplicate row deleted the source's exact Blob key despite intact source metadata/lock. Cleanup now awaits the lock-confirmed document identity in the sole payload deleter; the same test passes and sends the source's exact bytes with its original ID. CI separately exposed a live-`main` versus stored-`global` comparison consuming manual retry admission. The unchanged ACK-lost E2E failed before and passed after canonical stored-row reconciliation, retaining the original idempotency key and transport route. Current-format storage readbacks, authenticated same-owner fixtures, unconditional teardown, and a one-shot FileReader fault were corrected without weakening production ownership, byte checks, or timeouts. One queue-reorder sleep was replaced by its asserted storage-error outcome.
- **Alias/coalescer red → green:** the established-client configured-alias regression prepares/adopts real PNG+PDF bytes under `agent:work:workspace`, clears the warm byte registry, then changes configured `mainKey` from `main` to `workspace`. Actual metadata normalization preserves queue/run/reference identity but old hydration returns `missing` while the original owner still reads both exact files. It now hydrates and sends both files once with the original run ID. Nine caller variants reject alone but were wrongly accepted concurrently: queue ID, reference tab/recovery owner, Incognito, never-observed client, attachment count, MIME, filename, and size. All now reject; matching and remembered-offline controls stay ready and share one read. All 403 focused owner tests pass. The review's ordinary before-first-hello unresolved-Blob producer was not established: defaults publish before recovery readiness and cold clients cannot prepare these bytes. No fabricated cold-start admission test was added; existing bare-main/raw-global metadata tests remain green. Routing policy itself is unchanged.
- **Real running surface:** isolated real Gateway with a local synthetic OpenAI-compatible provider, on both Main and a normally created new session. Each pass waits for an actual streaming model request before steering. Both 2,404,765-byte PNGs match their original SHA-256 values in outbound frames, receive successful Gateway ACKs, remain recoverable through reload before model release, and reach the provider as two image inputs of the original byte lengths. Reload issues no duplicate attachment send; both images appear in the completed conversation. No operator Gateway, credentials, or private conversation data used.
- Complete changed-file checks pass with no skips, including dead exports, core/UI typechecks, lint, styles, and i18n. Full `pnpm build` passes; startup JS is **345,628 B gzip**, below the existing **346,761 B** enforcement limit. No budget or baseline edits in this PR.
- Fresh isolated Codex autoreview is **scoped-clean at the requested P0 threshold**; it is not represented as a broader-priority certificate. Synthetic before/after pictures and a sanitized live-flow video were captured and inspected locally. **Media publication blocker:** the local GitHub CLI guard rejects both `gh pr comment --attach` and the authenticated REST upload to GitHub's user-attachments endpoint with `string rewrite protection blocked unsupported or unsafe input`. No guard bypass or alternate credentials were used. The proof comment records the verified flow and this publication gap; CI artifact links will be added if emitted.

**Size/ownership:** production +1,613/-569 (**net +1,044**, 28 files); tests/test support +2,674/-403 (**net +2,271**, 18 files); docs +24. The cleanup-authority and canonical-retry follow-ups each add only four net production lines. Raw churn includes moves/extractions. The production growth implements the approved immutable binary-persistence boundary, tab/credential ownership, complete-before-send admission, and complete-byte handoff; reusing mutable seven-day draft records or allowing volatile sends would not preserve the queued-input contract.

**Known separate follow-up:** Main-session outbox recovery stores a `global` conversation identity while foreground sends use `agent:main:main`, so recovery can query the wrong history and retain an already-delivered text row as unconfirmed. Source and isolated runtime evidence show this predates the repair; it is owned by the separate [Main/global identity issue](https://github.com/openclaw/openclaw/issues/133059) and [canonical repair](https://github.com/openclaw/openclaw/pull/133067). Both live attachment flows pass without changing that routing policy. Browser queued-followup receipt timing also remains unchanged; a startup ACK alone is not proof that a model is ready for direct injection.

**Related scope:** [Credential-replacement queue isolation](https://github.com/openclaw/openclaw/issues/129188) remains separate: this repair fences binary references and live ownership but does not introduce a general credential-identity policy for unreferenced text rows. [Recorded-idle queue wake-up](https://github.com/openclaw/openclaw/issues/131933) and its [draft repair](https://github.com/openclaw/openclaw/pull/131948) concern a different publication owner and are not claimed fixed here. The [disconnected steering-state report](https://github.com/openclaw/openclaw/issues/128700) is already closed via its [merged queue-state repair](https://github.com/openclaw/openclaw/pull/128701). Live states and pinned-main source were verified; no duplicate closure is warranted.

AI-assisted implementation and review. No agent transcripts included.

<details>
<summary>Exact local validation commands</summary>

```bash
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/vitest-cache-outbox-scope-full-ui OPENCLAW_VITEST_MAX_WORKERS=3 node scripts/run-vitest.mjs ui/src
```

```bash
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/vitest-cache-outbox-scope-native OPENCLAW_VITEST_MAX_WORKERS=3 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/e2e/chat-outbox-capacity.e2e.test.ts \
  ui/src/e2e/chat-outbox-payloads.e2e.test.ts \
  ui/src/e2e/composer-draft-store.e2e.test.ts \
  ui/src/e2e/session-management.delete.e2e.test.ts \
  ui/src/e2e/chat-flow.history-recovery.e2e.test.ts \
  ui/src/e2e/chat-flow.queue-reorder.e2e.test.ts \
  ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts \
  ui/src/e2e/chat-quota-pill-93041.e2e.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/code-mode-reconciliation.test.ts
```

```bash
node scripts/check-changed.mjs -- \
  docs/web/control-ui.md \
  src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts \
  ui/src/app/app-host.deleted-session.test.ts \
  ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts \
  ui/src/e2e/chat-flow.history-recovery.e2e.test.ts \
  ui/src/e2e/chat-flow.queue-reorder.e2e.test.ts \
  ui/src/e2e/chat-outbox-capacity.e2e.test.ts \
  ui/src/e2e/chat-outbox-payloads.e2e.test.ts \
  ui/src/e2e/composer-draft-store.e2e.test.ts \
  ui/src/e2e/session-management.delete.e2e.test.ts \
  ui/src/i18n/locales/en.ts \
  ui/src/lib/chat/chat-types.ts \
  ui/src/lib/chat/composer-draft-retirement.runtime.ts \
  ui/src/lib/chat/composer-draft-store.runtime.ts \
  ui/src/lib/chat/control-ui-database.runtime.ts \
  ui/src/lib/chat/outbox-payload-store.runtime.ts \
  ui/src/lib/chat/outbox-store-codec.ts \
  ui/src/lib/chat/outbox-store-projection.ts \
  ui/src/lib/chat/outbox-store-retirement.ts \
  ui/src/lib/chat/outbox-store.test.ts \
  ui/src/lib/chat/outbox-store.ts \
  ui/src/pages/chat/attachment-api.ts \
  ui/src/pages/chat/attachment-payload-store.ts \
  ui/src/pages/chat/chat-history-cursor.test.ts \
  ui/src/pages/chat/chat-outbox-drain.ts \
  ui/src/pages/chat/chat-outbox-owner.ts \
  ui/src/pages/chat/chat-pending-inputs.test.ts \
  ui/src/pages/chat/chat-queue.ts \
  ui/src/pages/chat/chat-reset-delivery.ts \
  ui/src/pages/chat/chat-responsive.browser.test.ts \
  ui/src/pages/chat/chat-send-actions.ts \
  ui/src/pages/chat/chat-send-contract.ts \
  ui/src/pages/chat/chat-send-delivery.ts \
  ui/src/pages/chat/chat-send-queue-state.ts \
  ui/src/pages/chat/chat-send-submit.test.ts \
  ui/src/pages/chat/chat-send-submit.ts \
  ui/src/pages/chat/chat-send-support.ts \
  ui/src/pages/chat/chat-send.test.ts \
  ui/src/pages/chat/chat-state-events.ts \
  ui/src/pages/chat/composer-persistence.test.ts \
  ui/src/pages/chat/composer-persistence.ts \
  ui/src/pages/chat/durable-composer-persistence.ts \
  ui/src/pages/chat/outbox-browser.test-support.ts \
  ui/src/pages/chat/outbox-payloads.ts \
  ui/src/pages/chat/queued-message-edit.test.ts \
  ui/src/pages/chat/queued-message-edit.ts \
  ui/src/test-helpers/gateway-client.ts
```

```bash
node scripts/run-tsgo.mjs -p tsconfig.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/ui.tsbuildinfo
```

```bash
pnpm build
```

</details>
