### PR TITLE
fix(gateway): honor configured systemAgent for unfiltered sessions.search

### DIFF
--- a/src/gateway/server-methods/sessions-search-scope.ts
+++ b/src/gateway/server-methods/sessions-search-scope.ts
@@ -3,6 +3,11 @@ import {
   errorShape,
   type SessionsSearchParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import {
+  AgentSelectionRequiredError,
+  listAgentIds,
+  tryResolveAmbientOwnerAgentId,
+} from "../../agents/agent-scope-config.js";
 import { isConfiguredSessionStoreAgentId } from "../../config/sessions.js";
 import { resolvePersistedSessionStoreOwnerForKey } from "../../config/sessions/session-store-owner.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -63,13 +68,21 @@ export function resolveSessionSearchScope(cfg: OpenClawConfig, params: SessionsS
       error: errorShape(ErrorCodes.INVALID_REQUEST, "sessions.search supports one agent per call"),
     };
   }
-  let agentId = requestedAgentId ?? agentIds.values().next().value;
+  // Unfiltered search with no explicit agentId: fall back to the configured
+  // ambient owner (agents.defaults.systemAgent.agentId), matching skills.list /
+  // models.list. The prior fallback passed the literal "main" to
+  // resolveRequestedSessionAgentId as a session key, so explicit multi-agent
+  // rosters without a legacy `default: true` marker rejected it with a
+  // misleading 'session key "main" has no explicit owner' error (same
+  // owner-loss class as the Talk path in #126730).
+  const agentId =
+    requestedAgentId ?? agentIds.values().next().value ?? tryResolveAmbientOwnerAgentId(cfg);
   if (!agentId) {
-    const fallbackAgent = resolveRequestedSessionAgentId(cfg, "main");
-    if (!fallbackAgent.ok) {
-      return { ok: false as const, error: fallbackAgent.error };
-    }
-    agentId = fallbackAgent.agentId;
+    const selection = new AgentSelectionRequiredError(listAgentIds(cfg), {
+      surface: "sessions.search",
+      hint: "Pass an explicit agentId or configure agents.defaults.systemAgent.agentId.",
+    });
+    return { ok: false as const, error: errorShape(ErrorCodes.INVALID_REQUEST, selection.message) };
   }
   return {
     ok: true as const,

--- a/src/gateway/server-methods/sessions-search.test.ts
+++ b/src/gateway/server-methods/sessions-search.test.ts
@@ -282,6 +282,55 @@ describe("sessions.search gateway method", () => {
     });
   });
 
+  it("resolves the configured systemAgent for an unfiltered search under explicit multi-agent ownership", async () => {
+    // Regression (#126730 sessions.search sibling): agents.ownership "explicit"
+    // with an `entries` roster and no legacy `default: true` marker. The pre-fix
+    // fallback passed the literal "main" to resolveRequestedSessionAgentId as a
+    // session key, which rejected it with 'session key "main" has no explicit
+    // owner'. agents.defaults.systemAgent.agentId must own an unfiltered search.
+    cfg = {
+      agents: {
+        ownership: "explicit",
+        defaults: { systemAgent: { agentId: "main" } },
+        entries: { main: {}, alpha: {}, beta: {}, gamma: {} },
+      },
+    };
+
+    const respond = await callSearch({ query: "needle" });
+
+    expect(respond).not.toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("has no explicit owner") }),
+    );
+    expect(searchSessionTranscriptsMock).toHaveBeenCalledWith({
+      agentId: "main",
+      query: "needle",
+      limit: undefined,
+      storePath: expect.any(String),
+    });
+  });
+
+  it("resolves the configured systemAgent for an unfiltered search under global session scope", async () => {
+    cfg = {
+      session: { scope: "global" },
+      agents: {
+        ownership: "explicit",
+        defaults: { systemAgent: { agentId: "main" } },
+        entries: { main: {}, alpha: {}, beta: {} },
+      },
+    };
+
+    await callSearch({ query: "needle" });
+
+    expect(searchSessionTranscriptsMock).toHaveBeenCalledWith({
+      agentId: "main",
+      query: "needle",
+      limit: undefined,
+      storePath: expect.any(String),
+    });
+  });
+
   it("does not allow agentId to widen an unfiltered search", async () => {
     const respond = await callSearch({ agentId: "work", query: "needle" });
 


### PR DESCRIPTION
### What Problem This Solves

An unfiltered `sessions.search` RPC (no `agentId`, no `sessionKeys`) fails on any `agents.ownership: "explicit"` fleet with:

> Multiple agents are configured, but session key "main" has no explicit owner. Pass agentId or use an agent-prefixed session key.

even when `agents.defaults.systemAgent.agentId` is configured. `resolveSessionSearchScope`'s no-`agentId`/no-`sessionKeys` fallback passed the literal `"main"` to `resolveRequestedSessionAgentId` **as a session key**. Under explicit ownership with an `entries` roster and no legacy `default: true` marker, bare keys are correctly rejected, so the call dies and the error blames a key the caller never sent. The configured `systemAgent` is never consulted.

Same ambient owner-loss class as #128637 / #126360 (and the Talk path in #126730 / #126732), a distinct caller: the `sessions.search` tool always threads `agentId`, so the broken caller is the raw RPC plus the scope resolver's own hard-coded `"main"` fallback.

### Why This Change Was Made

`skills.list` and `models.list` already resolve the ambient owner through `tryResolveAmbientOwnerAgentId(cfg)`, which honors `agents.defaults.systemAgent.agentId` (and sole/legacy defaults). `sessions.search` should use the same primitive rather than re-implementing a fallback that treats an agent id as a session key. When there is genuinely no ambient owner, the caller should get a real `AgentSelectionRequiredError` scoped to `sessions.search`, not a fabricated session-key error. This matches the fix shape already accepted in #126234 and proposed in #132469.

### User Impact

- Explicit multi-agent fleets with a configured `systemAgent`: unfiltered `sessions.search` now resolves to that agent and works.
- Sole-agent / legacy `default: true` fleets: unchanged (already resolved via the same primitive).
- Genuinely ambiguous fleets (no `systemAgent`, multiple agents): still rejected, now with an accurate `surface: "sessions.search"` `AgentSelectionRequiredError` instead of a misleading session-key message.
- No change to `agents.ownership`, the agent roster, session-key parsing, or any config surface. No new option.

### Evidence

`src/gateway/server-methods/sessions-search.test.ts` (+49): two regression tests covering `agents.ownership: "explicit"` and `session.scope: "global"`.

**Pre-fix (fix reverted, tests present):** `node scripts/run-vitest.mjs src/gateway/server-methods/sessions-search.test.ts` -> 2 failed | 14 passed. Both new tests fail with the exact reported error:
```
expected StringContaining "has no explicit owner"
received "Multiple agents are configured, but session key \"main\" has no explicit owner. Pass agentId or use an agent-prefixed session key."
```

**Post-fix:**
- `sessions-search.test.ts`: 16/16 pass
- related suites (sessions-search, sessions-read, memory-search, session-request-agent, agent-scope-config, sessions-search-tool): 101/101 pass
- `tsgo --noEmit -p tsconfig.json`: clean
- `oxfmt --check`: clean

Rebased onto `main` (was `release/2026.9.1`); the touched files are byte-identical between the two bases apart from the follow-up below.

**Follow-up after rebase:** `main` tightened `AgentSelectionContext` to require `hint` (was optional in the type). Added a `hint` string to the `sessions.search` `AgentSelectionRequiredError` call to satisfy `tsgo` (`TS2741`). No behavior change — the constructor already defaulted `hint` when omitted.

### Real Gateway RPC proof (after-fix, redacted)

Ran against a live gateway that carries this fix. Real setup, not mocks.

- **Build:** `OpenClaw 2026.9.1-beta.2` + this patch.
- **Config (redacted excerpt):**
  ```
  agents.ownership              = "explicit"
  agents.list                   = []            (none)
  agents.entries                = { main, <several more> }   // multi-agent roster, no `default: true` marker
  agents.defaults.systemAgent   = { agentId: "main" }
  ```
  This is exactly the shape from the bug report (#132834): explicit ownership + `entries` roster + configured `systemAgent`, no legacy default.

- **Unfiltered RPC (no `agentId`, no `sessionKeys`):**
  ```
  $ openclaw gateway call sessions.search --params '{"query":"<redacted>","limit":2}' --json
  {
    "results": [
      { "sessionKey": "agent:main:explicit:<redacted>", "role": "user", "snippet": "<redacted>", "score": 7.72 },
      { "sessionKey": "agent:main:explicit:<redacted>", "role": "user", "snippet": "<redacted>", "score": 7.72 }
    ],
    "truncated": true
  }
  ```
  The call returns transcript hits instead of the `AgentSelectionRequiredError` / `has no explicit owner` failure, and every hit comes from the `agent:main:*` session store — i.e. the resolver selected `agents.defaults.systemAgent.agentId` (`main`), matching `skills.list` / `models.list`.

- **Pre-fix behavior on the same config** is the error quoted at the top of this PR and in #132834 (which this PR closes).
