### PR TITLE
refactor(doctor): share count label formatter

### DIFF
--- a/src/commands/doctor-heartbeat-main-session-repair.ts
+++ b/src/commands/doctor-heartbeat-main-session-repair.ts
@@ -14,6 +14,7 @@ import type { SessionEntry } from "../config/sessions/types.js";
 import { updateLegacySessionStore } from "../infra/state-migrations.legacy-session-store.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { clearTuiLastSessionPointers } from "../tui/tui-last-session.js";
+import { countLabel } from "./doctor-state-integrity-format.js";
 
 /** Chunk size for sync transcript scans. */
 const TRANSCRIPT_SCAN_CHUNK_BYTES = 64 * 1024;
@@ -52,10 +53,6 @@ type HeartbeatMainSessionRepairDeclined = {
   declineReason: "record-too-large";
   reason?: undefined;
 };
-
-function countLabel(count: number, singular: string, plural = `${singular}s`): string {
-  return `${count} ${count === 1 ? singular : plural}`;
-}
 
 function sessionEntryHasSyntheticHeartbeatOwnership(entry: SessionEntry): boolean {
   return (

--- a/src/commands/doctor-session-state-providers.ts
+++ b/src/commands/doctor-session-state-providers.ts
@@ -23,6 +23,7 @@ import { listPluginDoctorSessionRouteStateOwners } from "../plugins/doctor-contr
 import type { DoctorSessionRouteStateOwner } from "../plugins/doctor-session-route-state-owner-types.js";
 import { isValidAgentHarnessSessionStoreEntry } from "../sessions/agent-harness-session-key.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
+import { countLabel } from "./doctor-state-integrity-format.js";
 
 type DoctorPrompterLike = {
   confirmRuntimeRepair: (params: {
@@ -32,10 +33,6 @@ type DoctorPrompterLike = {
   }) => Promise<boolean>;
   note?: typeof note;
 };
-
-function countLabel(count: number, singular: string, plural = `${singular}s`): string {
-  return `${count} ${count === 1 ? singular : plural}`;
-}
 
 function normalizeIdSet(values: readonly string[] | undefined): Set<string> {
   return new Set((values ?? []).map((value) => normalizeProviderId(value)));


### PR DESCRIPTION
## What Problem This Solves

Doctor session repairs maintained three identical implementations of count-aware singular/plural labels. Separate copies could drift and produce inconsistent operator-facing repair messages.

## Why This Change Was Made

This reuses the existing state-integrity formatter from the heartbeat main-session and plugin session-state repair modules. The domain-specific `countSessionLabel` wrapper remains local.

## User Impact

No user-visible behavior changes. Doctor keeps the same repair messages while maintainers get one production implementation of the count-label rule.

## Evidence

- `pnpm test src/commands/doctor-session-state-providers.test.ts src/commands/doctor-state-integrity.transcripts.test.ts src/commands/doctor-state-integrity.test.ts src/commands/doctor-main-session-recovery.test.ts` (`55` passed)
- focused Oxlint and Oxfmt checks for both changed files
- `pnpm check:import-cycles` and `pnpm check:madge-import-cycles` (zero cycles)
- `git diff --check`
- lead autoreview: no accepted or actionable findings
- native hydrated review: `READY FOR /prepare-pr`, zero findings, `55` focused tests passed
- exact-head CI: all required checks passed on `125c09ce2d28269de000073562b896890715af9d` ([run](https://github.com/openclaw/openclaw/actions/runs/33291298116))
- `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 133056`

AI-assisted: yes. I reviewed the implementation and understand the doctor formatting flow.
