### PR TITLE
improve: speed up large history upgrades and Doctor checks

### DIFF
--- a/src/commands/doctor-session-sqlite-transcript-readers.ts
+++ b/src/commands/doctor-session-sqlite-transcript-readers.ts
@@ -1,31 +1,20 @@
 /** Read-only transcript detection; positive repairs retain exact snapshots. */
-import fs from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { SqliteTranscriptStorageRow } from "../config/sessions/session-accessor.sqlite-read.js";
-import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 
 // Schema-tolerant session enumeration for transcript-label migration (avoids post-ship columns).
 // Queries transcript_events table (schema-stable) instead of sessions table.
 // Returns read-only view of all distinct session IDs with events.
-export function readOnlySqliteTranscriptSessionIds(sqlitePath: string): string[] {
-  if (!fs.existsSync(sqlitePath)) {
+export function readOnlySqliteTranscriptSessionIds(database: DatabaseSync): string[] {
+  if (!tableExists(database, "transcript_events")) {
     return [];
   }
-  let database: DatabaseSync | undefined;
-  try {
-    database = openNodeSqliteDatabase(sqlitePath, { readOnly: true });
-    if (!tableExists(database, "transcript_events")) {
-      return [];
-    }
-    const rows = database
-      .prepare("SELECT DISTINCT session_id FROM transcript_events ORDER BY session_id ASC")
-      .all();
-    return rows.flatMap((row) => (typeof row.session_id === "string" ? [row.session_id] : []));
-  } finally {
-    database?.close();
-  }
+  const rows = database
+    .prepare("SELECT DISTINCT session_id FROM transcript_events ORDER BY session_id ASC")
+    .all();
+  return rows.flatMap((row) => (typeof row.session_id === "string" ? [row.session_id] : []));
 }
 
 function iterateTranscriptRows(database: DatabaseSync, sessionId: string, firstRowOnly = false) {
@@ -47,16 +36,11 @@ type ReadOnlyTranscriptSnapshot =
   | { ok: false; error: unknown };
 
 export function readOnlySqliteTranscriptRepairSnapshot(
-  sqlitePath: string,
+  database: DatabaseSync,
   sessionId: string,
   needsRepair: (event: unknown) => boolean,
 ): ReadOnlyTranscriptSnapshot {
-  if (!fs.existsSync(sqlitePath)) {
-    return { ok: false, error: new Error(`SQLite database not found: ${sqlitePath}`) };
-  }
-  let database: DatabaseSync | undefined;
   try {
-    database = openNodeSqliteDatabase(sqlitePath, { readOnly: true });
     // Unchanged histories retain one payload. Re-read positive candidates in full so
     // malformed siblings and exact-snapshot guards still govern the surgical repair.
     for (const row of iterateTranscriptRows(database, sessionId)) {
@@ -83,24 +67,17 @@ export function readOnlySqliteTranscriptRepairSnapshot(
     return { ok: true, rows: [] };
   } catch (error) {
     return { ok: false, error };
-  } finally {
-    database?.close();
   }
 }
 
 /** Reads exact row metadata for a guarded transcript replacement without opening a writer. */
 export function readOnlySqliteHeaderlessTranscriptSnapshot(
-  sqlitePath: string,
+  database: DatabaseSync,
   sessionId: string,
 ):
   | { ok: true; rows: SqliteTranscriptStorageRow[]; sessionKey?: string }
   | { ok: false; error: unknown } {
-  if (!fs.existsSync(sqlitePath)) {
-    return { ok: false, error: new Error(`SQLite database not found: ${sqlitePath}`) };
-  }
-  let database: DatabaseSync | undefined;
   try {
-    database = openNodeSqliteDatabase(sqlitePath, { readOnly: true });
     // Headers can live at nonzero seq. A current header needs no whole-history read;
     // possible headerless repairs still take and validate the complete exact snapshot.
     for (const row of iterateTranscriptRows(database, sessionId, true)) {
@@ -147,7 +124,5 @@ export function readOnlySqliteHeaderlessTranscriptSnapshot(
     };
   } catch (error) {
     return { ok: false, error };
-  } finally {
-    database?.close();
   }
 }

--- a/src/commands/doctor-session-transcript-headers.ts
+++ b/src/commands/doctor-session-transcript-headers.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import type { DatabaseSync } from "node:sqlite";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { isIndexedSessionEntry } from "../agents/sessions/session-manager-codec.js";
@@ -18,6 +19,7 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { executeSqliteQueryTakeFirstSync } from "../infra/kysely-sync.js";
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import {
   resolveOpenClawAgentSqlitePath,
@@ -210,9 +212,13 @@ export async function noteSessionTranscriptHeaderHealth(params: {
       continue;
     }
     seenPaths.add(sqlitePath);
+    let readDatabase: DatabaseSync | undefined;
     try {
-      for (const sessionId of readOnlySqliteTranscriptSessionIds(sqlitePath)) {
-        const snapshot = readOnlySqliteHeaderlessTranscriptSnapshot(sqlitePath, sessionId);
+      // Each snapshot exhausts or closes its iterators before repair, so this read-only
+      // connection holds no read transaction across a guarded writer transaction.
+      readDatabase = openNodeSqliteDatabase(sqlitePath, { readOnly: true });
+      for (const sessionId of readOnlySqliteTranscriptSessionIds(readDatabase)) {
+        const snapshot = readOnlySqliteHeaderlessTranscriptSnapshot(readDatabase, sessionId);
         if (!snapshot.ok) {
           const detail = formatErrorMessage(snapshot.error).replace(/\s+/g, " ").trim();
           note(
@@ -303,6 +309,8 @@ export async function noteSessionTranscriptHeaderHealth(params: {
         `- Failed to inspect transcript headers for ${target.agentId} (${sqlitePath}): ${detail}`,
         NOTE_TITLE,
       );
+    } finally {
+      readDatabase?.close();
     }
   }
 

--- a/src/commands/doctor-session-transcript-labels.test.ts
+++ b/src/commands/doctor-session-transcript-labels.test.ts
@@ -324,6 +324,41 @@ describe("doctor SQLite session transcript label migration", () => {
     );
   });
 
+  it("observes later sessions changed while an earlier session is repaired", async () => {
+    const databaseOptions = { agentId: AGENT_ID, env: state.env };
+    const database = seedLegacyLabelTranscript(databaseOptions);
+    const laterSessionId = "z-later-session";
+    seedMessageTranscript(databaseOptions, [{ id: "later-user", content: "unchanged" }], {
+      sessionId: laterSessionId,
+      sessionKey: `agent:main:${laterSessionId}`,
+    });
+    const legacyContent = "Conversation info (untrusted metadata):\n```json\n{}\n```";
+    const transaction = agentDatabase.runOpenClawAgentWriteTransaction;
+    vi.spyOn(agentDatabase, "runOpenClawAgentWriteTransaction").mockImplementationOnce(
+      (write, options, transactionOptions) => {
+        transaction((db) => {
+          db.db
+            .prepare("UPDATE transcript_events SET event_json = ? WHERE session_id = ? AND seq = 1")
+            .run(
+              JSON.stringify(createMessageEvent({ id: "later-user", content: legacyContent })),
+              laterSessionId,
+            );
+        }, databaseOptions);
+        return transaction(write, options, transactionOptions);
+      },
+    );
+
+    await runTranscriptLabelHealth(state, true);
+
+    expect(
+      findMessageContent(readTranscriptSnapshot(database, laterSessionId).events, "later-user"),
+    ).toContain(`Conversation info: ${INBOUND_CONTEXT_MARKER}`);
+    expect(note).toHaveBeenCalledWith(
+      "- Rewrote legacy inbound-context labels in 2 sessions (2 events).",
+      "Session transcript labels",
+    );
+  });
+
   it("preserves the bare Context header when migrating active-memory blocks", async () => {
     const databaseOptions = { agentId: AGENT_ID, env: state.env };
     const legacyContent = [

--- a/src/commands/doctor-session-transcript-labels.ts
+++ b/src/commands/doctor-session-transcript-labels.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import type { DatabaseSync } from "node:sqlite";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { INBOUND_CONTEXT_MARKER } from "../auto-reply/reply/inbound-context-marker.js";
 import type { TranscriptEvent } from "../config/sessions/session-accessor.js";
@@ -10,6 +11,7 @@ import { updateSqliteTranscriptEventJsonInTransaction } from "../config/sessions
 import { resolveAllAgentSessionStoreTargetsSync } from "../config/sessions/targets.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import {
   resolveOpenClawAgentSqlitePath,
   runOpenClawAgentWriteTransaction,
@@ -203,15 +205,17 @@ export async function noteSessionTranscriptLabelHealth(params: {
     seenPaths.add(sqlitePath);
     const { agentId } = target;
 
+    let readDatabase: DatabaseSync | undefined;
     try {
+      readDatabase = openNodeSqliteDatabase(sqlitePath, { readOnly: true });
       // Detect read-only, then repair each session in its own transaction as it is found, so a large
       // store never buffers every plan at once. Enumerate from transcript_events, not sessions: the
       // latter gained its columns post-ship and is not safe to assume on old databases.
-      const sessionIds = readOnlySqliteTranscriptSessionIds(sqlitePath);
+      const sessionIds = readOnlySqliteTranscriptSessionIds(readDatabase);
       for (const sessionId of sessionIds) {
         // Read transcript in read-only mode (detection phase).
         const readResult = readOnlySqliteTranscriptRepairSnapshot(
-          sqlitePath,
+          readDatabase,
           sessionId,
           normalizeLegacyInboundContextLabels,
         );
@@ -285,6 +289,8 @@ export async function noteSessionTranscriptLabelHealth(params: {
         `- Failed to inspect or rewrite labels for ${agentId} (${sqlitePath}): ${detail}`,
         NOTE_TITLE,
       );
+    } finally {
+      readDatabase?.close();
     }
   }
 

--- a/src/config/sessions/session-accessor.sqlite-import.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-import.test.ts
@@ -43,7 +43,7 @@ function observeStages() {
     );
 }
 
-it.each(["prepare", "commit"])(
+it.each(["prepare", "append", "commit"])(
   "leaves canonical rows unchanged and removes private staging after %s failure",
   async (phase) => {
     await withOpenClawTestState({ label: "import-rollback" }, async (state) => {
@@ -60,6 +60,13 @@ it.each(["prepare", "commit"])(
       const entriesBefore = database.db.prepare("SELECT * FROM session_nodes").all();
       const stages = observeStages();
       const exec = database.db.exec.bind(database.db);
+      if (phase === "append") {
+        database.db.exec(`
+          CREATE TRIGGER fail_second_import BEFORE INSERT ON transcript_events
+          WHEN NEW.session_id = 'second'
+          BEGIN SELECT RAISE(ABORT, 'injected append failure'); END;
+        `);
+      }
       if (phase === "commit") {
         vi.spyOn(database.db, "exec").mockImplementation((sql) => {
           if (sql === "COMMIT") {
@@ -135,19 +142,26 @@ it("deduplicates existing and incoming bytes and identities, preserves aliases, 
       sessionKey: "agent:main:ALIAS",
       preserveExactStoredKey: true,
     };
-    const opaque = { custom: "no identity" };
+    const first = { ...message, timestamp: 10 };
+    const second = { ...message, id: "two", parentId: "one", timestamp: 30 };
+    const opaque = { custom: "no identity", timestamp: 25 };
     const readTranscriptEvents = (append: (event: unknown) => void) => {
       for (const event of [
-        message,
-        message,
-        { ...message, message: { role: "user", content: "same id loses" } },
+        first,
+        first,
+        { ...first, timestamp: 20, message: { role: "user", content: "same id loses" } },
         opaque,
         opaque,
+        second,
+        { ...second, timestamp: 99 },
       ]) {
         append(event);
       }
     };
     const stages = observeStages();
+    await importSqliteSessionRows({ ...params, readTranscriptEvents: (append) => append(first) });
+    const db = openOpenClawAgentDatabase({ agentId: "main", env: state.env }).db;
+    const generation = db.prepare("SELECT generation FROM transcript_rewrite_watermarks").get();
     expect(await importSqliteSessionRows({ ...params, readTranscriptEvents })).toMatchObject({
       transcriptEvents: 2,
       sessionKey: params.sessionKey,
@@ -155,17 +169,26 @@ it("deduplicates existing and incoming bytes and identities, preserves aliases, 
     expect(await importSqliteSessionRows({ ...params, readTranscriptEvents })).toMatchObject({
       transcriptEvents: 0,
     });
-    const db = openOpenClawAgentDatabase({ agentId: "main", env: state.env }).db;
     expect(db.prepare("SELECT session_key FROM session_nodes").all()).toEqual([
       { session_key: params.sessionKey },
     ]);
-    expect(db.prepare("SELECT event_json FROM transcript_events ORDER BY seq").all()).toEqual(
-      [message, opaque].map((event) => ({ event_json: JSON.stringify(event) })),
+    expect(
+      db.prepare("SELECT seq, created_at, event_json FROM transcript_events ORDER BY seq").all(),
+    ).toEqual(
+      [first, opaque, second].map((event, seq) => ({
+        seq,
+        created_at: event.timestamp,
+        event_json: JSON.stringify(event),
+      })),
     );
-    expect(db.prepare("SELECT event_id FROM transcript_event_identities").all()).toEqual([
-      { event_id: "one" },
-    ]);
-    expect(stages()).toHaveLength(2);
+    expect(
+      db.prepare("SELECT event_id FROM transcript_event_identities ORDER BY seq").all(),
+    ).toEqual([{ event_id: "one" }, { event_id: "two" }]);
+    expect(db.prepare("SELECT updated_at FROM session_windows").get()).toEqual({ updated_at: 99 });
+    expect(db.prepare("SELECT generation FROM transcript_rewrite_watermarks").get()).toEqual(
+      generation,
+    );
+    expect(stages()).toHaveLength(3);
     expect(stages().every((dir) => !fs.existsSync(dir))).toBe(true);
   });
 });

--- a/src/config/sessions/session-accessor.sqlite-import.ts
+++ b/src/config/sessions/session-accessor.sqlite-import.ts
@@ -30,7 +30,7 @@ import {
   ensureTranscriptSessionRoot,
   touchTranscriptMutationInTransaction,
 } from "./session-accessor.sqlite-transcript-state.js";
-import { appendTranscriptEventInTransaction } from "./session-accessor.sqlite-transcript-store.js";
+import { appendTranscriptEventsInTransaction } from "./session-accessor.sqlite-transcript-store.js";
 import { reconcileSessionTranscriptIndexInTransaction } from "./session-transcript-index.js";
 import type { SessionEntry } from "./types.js";
 
@@ -167,23 +167,23 @@ function importSqliteSessionRowsInTransaction(
     )) {
       stage.addSeen(row.event_json);
     }
-    for (const row of stage.rows(source)) {
-      if (stage.hasSeen(row.eventJson)) {
-        continue;
-      }
-      // SAFETY: staging serialized the caller's TranscriptEvent without transforming its contents.
-      const event = JSON.parse(row.eventJson) as TranscriptEvent;
-      if (
-        appendTranscriptEventInTransaction(database, transcriptScope, event, {
-          allowStoredAlias: true,
-          scheduleProjectionReconcile: false,
-          touchMutation: false,
-        })
-      ) {
-        stage.addSeen(row.eventJson);
-        transcriptEvents += 1;
-      }
-    }
+    transcriptEvents = appendTranscriptEventsInTransaction(
+      database,
+      transcriptScope,
+      (function* (): Generator<TranscriptEvent, void, boolean> {
+        for (const row of stage.rows(source)) {
+          if (stage.hasSeen(row.eventJson)) {
+            continue;
+          }
+          // SAFETY: staging serialized the caller's TranscriptEvent without transforming its contents.
+          const inserted = yield JSON.parse(row.eventJson) as TranscriptEvent;
+          if (inserted) {
+            stage.addSeen(row.eventJson);
+          }
+        }
+      })(),
+      { allowStoredAlias: true, scheduleProjectionReconcile: false, touchMutation: false },
+    );
     // Doctor imports run outside gateway requests and must finish with a complete projection.
     reconcileSessionTranscriptIndexInTransaction(database.db, params.entry.sessionId);
     publishSessionEntryCacheInvalidation(database);

--- a/src/config/sessions/session-accessor.sqlite-transcript-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-state.ts
@@ -181,6 +181,15 @@ export function ensureTranscriptSessionRoot(
     );
     publishSessionEntryCacheInvalidation(database);
   }
+  upsertTranscriptSessionWindowInTransaction(database, scope, updatedAt);
+}
+
+export function upsertTranscriptSessionWindowInTransaction(
+  database: OpenClawAgentDatabase,
+  scope: ResolvedTranscriptScope,
+  updatedAt: number,
+): void {
+  const db = getSessionKysely(database.db);
   executeSqliteQuerySync(
     database.db,
     db

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -32,6 +32,7 @@ import {
   readNextTranscriptSeq,
   rotateTranscriptGenerationInTransaction,
   touchTranscriptMutationInTransaction,
+  upsertTranscriptSessionWindowInTransaction,
 } from "./session-accessor.sqlite-transcript-state.js";
 import {
   deleteSessionTranscriptIndexInTransaction,
@@ -48,25 +49,48 @@ import {
 } from "./transcript-tree.js";
 import { resolveVisibleTranscriptAppendParentId } from "./transcript-visible-events.js";
 
+type TranscriptAppendOptions = {
+  allowStoredAlias?: boolean;
+  dedupeByMessageIdempotency?: boolean;
+  onProjectionReconcileNeeded?: () => void;
+  scheduleProjectionReconcile?: boolean;
+  touchMutation?: boolean;
+};
+
+type TranscriptAppendCursor = { initialized: boolean; nextSeq?: number };
+
 export function appendTranscriptEventInTransaction(
   database: OpenClawAgentDatabase,
   scope: ResolvedTranscriptScope,
   event: TranscriptEvent,
-  options: {
-    allowStoredAlias?: boolean;
-    dedupeByMessageIdempotency?: boolean;
-    onProjectionReconcileNeeded?: () => void;
-    scheduleProjectionReconcile?: boolean;
-    touchMutation?: boolean;
-  } = {},
+  options: TranscriptAppendOptions = {},
+): boolean {
+  return appendTranscriptEvent(database, scope, event, options);
+}
+
+function appendTranscriptEvent(
+  database: OpenClawAgentDatabase,
+  scope: ResolvedTranscriptScope,
+  event: TranscriptEvent,
+  options: TranscriptAppendOptions,
+  cursor?: TranscriptAppendCursor,
 ): boolean {
   const persistedEvent = canonicalizeTranscriptEventMedia(event);
   const db = getSessionKysely(database.db);
   const createdAt = readEventTimestamp(persistedEvent) ?? Date.now();
-  ensureTranscriptSessionRoot(database, scope, createdAt, {
-    allowStoredAlias: options.allowStoredAlias === true,
-  });
-  ensureTranscriptGenerationInTransaction(database, scope.sessionId);
+  if (cursor?.initialized) {
+    // Even rejected identities update window recency. Only root/generation setup
+    // is shared by the synchronous batch; per-attempt writes stay in order.
+    upsertTranscriptSessionWindowInTransaction(database, scope, createdAt);
+  } else {
+    ensureTranscriptSessionRoot(database, scope, createdAt, {
+      allowStoredAlias: options.allowStoredAlias === true,
+    });
+    ensureTranscriptGenerationInTransaction(database, scope.sessionId);
+    if (cursor) {
+      cursor.initialized = true;
+    }
+  }
   const identity = readTranscriptEventIdentity(persistedEvent);
   if (identity && readTranscriptIdentityByEventId(database, scope.sessionId, identity.eventId)) {
     return false;
@@ -82,7 +106,7 @@ export function appendTranscriptEventInTransaction(
   ) {
     return false;
   }
-  const seq = readNextTranscriptSeq(database, scope.sessionId);
+  const seq = cursor?.nextSeq ?? readNextTranscriptSeq(database, scope.sessionId);
   executeSqliteQuerySync(
     database.db,
     db.insertInto("transcript_events").values({
@@ -92,6 +116,9 @@ export function appendTranscriptEventInTransaction(
       created_at: createdAt,
     }),
   );
+  if (cursor) {
+    cursor.nextSeq = seq + 1;
+  }
   if (options.touchMutation !== false) {
     touchTranscriptMutationInTransaction(database, scope.sessionId);
   }
@@ -105,42 +132,35 @@ export function appendTranscriptEventInTransaction(
   if (projectionNeedsRebuild) {
     options.onProjectionReconcileNeeded?.();
   }
-  if (!identity) {
-    scheduleTranscriptProjectionReconcile(
-      database,
-      scope.sessionId,
-      projectionNeedsRebuild,
-      options,
+  if (identity) {
+    // Caller-checked appends may retain a duplicate key in the payload, but the
+    // identity index can point at only one row.
+    const indexedMessageIdempotencyKey =
+      identity.messageIdempotencyKey &&
+      !options.dedupeByMessageIdempotency &&
+      readTranscriptIdentityByMessageIdempotencyKey(
+        database,
+        scope.sessionId,
+        identity.messageIdempotencyKey,
+      )
+        ? undefined
+        : identity.messageIdempotencyKey;
+    executeSqliteQuerySync(
+      database.db,
+      db
+        .insertInto("transcript_event_identities")
+        .values({
+          session_id: scope.sessionId,
+          event_id: identity.eventId,
+          seq,
+          event_type: identity.eventType,
+          parent_id: identity.parentId,
+          message_idempotency_key: indexedMessageIdempotencyKey,
+          created_at: createdAt,
+        })
+        .onConflict((conflict) => conflict.columns(["session_id", "event_id"]).doNothing()),
     );
-    return true;
   }
-  // Caller-checked appends may retain a duplicate key in the payload, but the
-  // identity index can point at only one row.
-  const indexedMessageIdempotencyKey =
-    identity.messageIdempotencyKey &&
-    !options.dedupeByMessageIdempotency &&
-    readTranscriptIdentityByMessageIdempotencyKey(
-      database,
-      scope.sessionId,
-      identity.messageIdempotencyKey,
-    )
-      ? undefined
-      : identity.messageIdempotencyKey;
-  executeSqliteQuerySync(
-    database.db,
-    db
-      .insertInto("transcript_event_identities")
-      .values({
-        session_id: scope.sessionId,
-        event_id: identity.eventId,
-        seq,
-        event_type: identity.eventType,
-        parent_id: identity.parentId,
-        message_idempotency_key: indexedMessageIdempotencyKey,
-        created_at: createdAt,
-      })
-      .onConflict((conflict) => conflict.columns(["session_id", "event_id"]).doNothing()),
-  );
   scheduleTranscriptProjectionReconcile(database, scope.sessionId, projectionNeedsRebuild, options);
   return true;
 }
@@ -167,26 +187,50 @@ function scheduleTranscriptProjectionReconcile(
 export function appendTranscriptEventsInTransaction(
   database: OpenClawAgentDatabase,
   scope: ResolvedTranscriptScope,
-  events: readonly TranscriptEvent[],
+  events: Iterable<TranscriptEvent, unknown, boolean>,
+  options: Omit<TranscriptAppendOptions, "onProjectionReconcileNeeded"> = {},
 ): number {
   let appended = 0;
   let projectionNeedsRebuild = false;
-  for (const event of events) {
-    if (
-      appendTranscriptEventInTransaction(database, scope, event, {
-        onProjectionReconcileNeeded: () => {
-          projectionNeedsRebuild = true;
-        },
-        scheduleProjectionReconcile: false,
-        touchMutation: false,
-      })
-    ) {
-      appended += 1;
+  const cursor: TranscriptAppendCursor = { initialized: false };
+  const iterator = events[Symbol.iterator]();
+  const appendOptions = {
+    ...options,
+    onProjectionReconcileNeeded: () => {
+      projectionNeedsRebuild = true;
+    },
+    scheduleProjectionReconcile: false,
+    touchMutation: false,
+  };
+  try {
+    let next = iterator.next();
+    while (!next.done) {
+      const inserted = appendTranscriptEvent(database, scope, next.value, appendOptions, cursor);
+      if (inserted) {
+        appended += 1;
+      }
+      // Streaming imports acknowledge only inserted rows in their byte-dedupe
+      // spool; ordinary array iterators ignore this feedback.
+      next = iterator.next(inserted);
     }
+  } catch (error) {
+    try {
+      iterator.return?.();
+    } catch {
+      // Preserve the append error if iterator cleanup also fails.
+    }
+    throw error;
   }
   if (appended > 0) {
-    touchTranscriptMutationInTransaction(database, scope.sessionId);
-    scheduleTranscriptProjectionReconcile(database, scope.sessionId, projectionNeedsRebuild, {});
+    if (options.touchMutation !== false) {
+      touchTranscriptMutationInTransaction(database, scope.sessionId);
+    }
+    scheduleTranscriptProjectionReconcile(
+      database,
+      scope.sessionId,
+      projectionNeedsRebuild,
+      options,
+    );
   }
   return appended;
 }


### PR DESCRIPTION
## What Problem This Solves

Large stable-to-main upgrades spend unnecessary time importing transcript events and checking already healthy histories. Doctor opens SQLite twice per session across its header and label passes; the importer repeats session-root, generation and next-sequence setup for every event even inside one synchronous batch.

## Why This Change Was Made

Doctor now owns one read-only connection per agent store and pass. Each session's iterators finish before the existing guarded repair transaction, so later reads see newly committed data. Detection still parses every required event, retains full snapshots for positive repairs, rejects concurrent changes and isolates malformed histories.

The transcript store owns a private cursor for the existing synchronous batch append. Root/generation setup and the first sequence lookup happen once; successful inserts advance the cursor. The importer streams its staged events through that same owner and records byte deduplication only after an insertion succeeds. Each attempted event still updates window recency before identity rejection. Single appends retain their existing callback behavior.

No schema, index, config, transaction boundary, locking, retention or recovery contract changes. Exact SQLite handoffs remain separate and preserve original bytes. Existing array-based fork/reset/recovery callers share the batch owner. Production delta is +42 lines; tests +58. The growth provides bounded streaming insertion feedback and private batch state, avoiding a second importer-specific write path or an escaping appender callback. Duplicate projection scheduling branches were folded into one common tail.

## User Impact

Large upgrades and repeated Doctor checks complete faster with the same migration checks, archives, timestamps, duplicate handling and runtime history. No new setting or operator action is required.

## Evidence

Focused reader benchmark, 20,000 sessions / 500,000 events, same canonical SQLite schema and data, three runs (median):

| Pass | Before | After |
| --- | ---: | ---: |
| Header detection | 9.048 s | 0.519 s |
| Label detection | 9.349 s | 1.293 s |

These isolate the readers; they are not whole-upgrade timings. The label probe parses all events with a no-repair predicate, so it measures connection/query/parsing costs without the normalizer's extra work.

A real 10,001-event import executes 160,033 SQL operations before and 120,033 after. The 40,000 eliminated operations are repeated root/generation/sequence setup; all 10,001 window updates remain. Quiet, interleaved fresh-process measurements (three pairs per scenario, Node 26.8.1) show:

| Real importer scenario | Rows | Before median | After median | Time reduction |
| --- | ---: | ---: | ---: | ---: |
| Deep linear | 10,001 | 1.785 s | 1.425 s | 20.2% |
| Wide | 10,100 | 1.818 s | 1.519 s | 16.5% |
| Branched | 10,200 | 2.471 s | 2.042 s | 17.4% |

Every paired candidate run was faster; these are focused importer timings, not whole-upgrade timings.

Focused verification: 176 tests passed across seven files: importer, active/context projections, Doctor headers/labels, migration memory and the broader session accessor suite (including concurrent writers, reset/lifecycle and recovery). Coverage includes an append-abort rollback, source revalidation, mixed existing/duplicate/new events, exact bytes and timestamps, unchanged generation, final rejected-duplicate recency, later-session visibility, malformed histories, Unicode-escaped labels and shared stores. Existing batch and 100,000-event branched imports completed under a 256 MiB JavaScript heap with exact-byte, projection and rerun checks.

Matched Docker proof on the same Blacksmith Testbox (`tbx_01m18cvvdk3kn4wsp9vpwab35v`, [holder run](https://github.com/openclaw/openclaw/actions/runs/33291317208)): published stable `2026.7.1-2` to baseline `5d07c11ccef2755ca569082b7c278f5eeb5bf67b`, then that same baseline plus this exact reviewed patch. The full source diff SHA-256 was checked before packaging. Both runs passed with **20,000 sessions, 497,750 events, 10,000 cron jobs and 512 released SDK state records**.

| Docker measurement | Before | After |
| --- | ---: | ---: |
| Complete lane, excluding package build | 401 s | 329 s |
| Update command | 178.868 s | 139.773 s |
| Repeated Doctor invocation | 31 s | 20 s |
| Gateway startup | 8 s | 8 s |

The complete lane used 18% less time; the update command used 22% less, and repeated Doctor used 35% less. These are one paired end-to-end run, not a universal latency guarantee. Automatic migration is asserted before any standalone Doctor or fixture capability consent. Full row checks run five times, including after repeated Doctor and restart. Eight real Gateway session/history samples (144 messages) retain identical hashes across all four before/after/restart probes. Integrity, archives, pairing/workspace data and budgets are unchanged. Fixture plugin capability consent remains explicit; this does not claim background stable-to-main channel switching.

Reproduction uses `OPENCLAW_DOCKER_ALL_LANES=published-upgrade-survivor`, `OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPECS=2026.7.1-2`, `OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS=sqlite-volume`, and volume knobs `SESSIONS=20000`, `EVENTS_PER_SESSION=25`, `CRON_JOBS=10000` under the `OPENCLAW_UPGRADE_SURVIVOR_VOLUME_` prefix with `node scripts/test-docker-all.mjs`.

Committed-head deep Docker proof also passed: **4,800 sessions / 1,227,946 events / 10,000 cron jobs / 512 released SDK records in 562 seconds**, with five exhaustive row checks. Repeated Doctor took 40 seconds (unchanged 60-second budget), startup 11 seconds. Eight Gateway samples (600 messages, bounded to the normal history page size) retained identical hashes across restart; API probe times were 6.619 and 6.745 seconds. The packed build-info commit is exactly `c6ebf69c94eb4415f5a2120fb92567456e203acc`. Blacksmith Testbox `tbx_01m18ebmqmzkjdxfbxfw3hwap8`, [holder run](https://github.com/openclaw/openclaw/actions/runs/33292277617); same Docker command with volume settings 4800/257/10000. Both Testbox leases were stopped after evidence capture. [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33292291438) completed successfully on `c6ebf69c94eb4415f5a2120fb92567456e203acc`, including all production/test types, tests and required CI gate.

Local production typecheck and repository guards passed. The aggregate test typecheck encountered the pre-existing shared dependency mismatch in `ui/vite.config.ts` (installed `pako` lacks the expected declarations); no dependency workaround was added. Fresh hosted CI subsequently passed the production and test typechecks and aggregate CI gate on the PR head.

After the final scheduling simplification, the 22 importer/active-projection tests and a fresh review passed again.

Independent Codex autoreview: no accepted/actionable P0 findings. This is a P0-scoped review, not a broader correctness certificate.

Separate follow-up: branch-heavy FTS rebuilds still scan their unindexed session field. This change does not alter index design or claim to resolve #119884's planner-statistics report. Existing native stable auth-credential retention work in #129689 also remains outside this change.

ClawSweeper review and Rank-up moves addressed: the declared committed-head million-event upgrade and exact-head hosted CI both passed. The review found no actionable correctness/security issue; maintainer-requested landing proceeds with the existing schema and persistence contracts unchanged.
