### PR TITLE
fix(qa): project legacy model runtime config

### DIFF
--- a/scripts/e2e/npm-telegram-live-runner.ts
+++ b/scripts/e2e/npm-telegram-live-runner.ts
@@ -52,7 +52,7 @@ const LEGACY_CONFIG_CUTOFF = "2026.7.2-beta.4";
 
 function projectExtendedStable2026_6_35QaConfig(cfg: OpenClawConfig): OpenClawConfig {
   const { entries, ...agents } = cfg.agents ?? {};
-  const { mediaModels, ...defaults } = agents.defaults ?? {};
+  const { mediaModels, modelPolicy: _modelPolicy, ...defaults } = agents.defaults ?? {};
 
   return {
     ...cfg,
@@ -76,6 +76,7 @@ function projectExtendedStable2026_6_35QaConfig(cfg: OpenClawConfig): OpenClawCo
 
 function projectLegacyPackageQaConfig(cfg: OpenClawConfig): OpenClawConfig {
   const { entries, ...agents } = cfg.agents ?? {};
+  const { modelPolicy: _modelPolicy, ...legacyDefaults } = agents.defaults ?? {};
   const memory = cfg.memory as
     | (Record<string, unknown> & {
         backend?: unknown;
@@ -88,6 +89,7 @@ function projectLegacyPackageQaConfig(cfg: OpenClawConfig): OpenClawConfig {
     ...cfg,
     agents: {
       ...agents,
+      defaults: legacyDefaults,
       ...(entries
         ? {
             list: Object.entries(entries).map(([id, agent]) => Object.assign({}, agent, { id })),

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -580,7 +580,16 @@ describe("package Telegram live Docker E2E", () => {
       });
       const config = {
         agents: {
-          defaults: { workspace: "/tmp/qa" },
+          defaults: {
+            workspace: "/tmp/qa",
+            models: {
+              "openai/gpt-5.6-luna": {
+                alias: "qa",
+                agentRuntime: { id: "openclaw" },
+              },
+            },
+            modelPolicy: { allow: ["openai/gpt-5.6-luna"] },
+          },
           entries: {
             qa: {
               default: true,
@@ -601,7 +610,15 @@ describe("package Telegram live Docker E2E", () => {
 
       expect(mutateConfig?.(config)).toEqual({
         agents: {
-          defaults: { workspace: "/tmp/qa" },
+          defaults: {
+            workspace: "/tmp/qa",
+            models: {
+              "openai/gpt-5.6-luna": {
+                alias: "qa",
+                agentRuntime: { id: "openclaw" },
+              },
+            },
+          },
           list: [
             {
               default: true,
@@ -649,6 +666,7 @@ describe("package Telegram live Docker E2E", () => {
             image: "mock-openai/image",
             audio: "mock-openai/audio",
           },
+          modelPolicy: { allow: ["mock-openai/qa"] },
           workspace: "/tmp/qa",
         },
         entries: {


### PR DESCRIPTION
## Summary

- Remove `agents.defaults.modelPolicy` only for package versions before `v2026.7.2-beta.4`.
- Retain model-level `agentRuntime` for every package.
- Keep current package configs unchanged.

## Root cause

The current QA base config adds `agents.defaults.modelPolicy`. Shipped `v2026.7.1-2` and `v2026.7.2-beta.3` reject that field. `v2026.7.2-beta.4` and later schemas accept it.

## Proof

- Red: release RTT run 33292019969 reached `openclaw@2026.7.1-2` and failed config validation at `agents.defaults`.
- Source contract: tagged schemas reject `modelPolicy` before beta.4 and accept it starting at beta.4.
- Green: 53 package Telegram tests pass with `modelPolicy` removed only below the existing exact cutoff.
- The historical test retains `agentRuntime`.
- Raw Oxlint and `git diff --check` pass.

The live release RTT workflow will rerun after merge.