### PR TITLE
refactor(config): share JSON schema issue path parsing

### DIFF
--- a/src/channels/plugins/config-schema.ts
+++ b/src/channels/plugins/config-schema.ts
@@ -6,9 +6,11 @@
 import { z, type ZodRawShape, type ZodTypeAny } from "zod";
 import { ToolPolicySchema } from "../../config/zod-schema.agent-runtime.js";
 import { DmPolicySchema } from "../../config/zod-schema.core.js";
-import { validateJsonSchemaValue } from "../../plugins/schema-validator.js";
+import {
+  parseJsonSchemaIssuePath,
+  validateJsonSchemaValue,
+} from "../../plugins/schema-validator.js";
 import type { JsonSchemaObject } from "../../shared/json-schema.types.js";
-import { parseConfigPathArrayIndex } from "../../shared/path-array-index.js";
 import type {
   ChannelConfigRuntimeIssue,
   ChannelConfigRuntimeParseResult,
@@ -192,15 +194,6 @@ function safeParseRuntimeSchema(
   };
 }
 
-function toIssuePath(path: string): Array<string | number> {
-  if (!path || path === "<root>") {
-    return [];
-  }
-  return path.split(".").map((segment) => {
-    return parseConfigPathArrayIndex(segment) ?? segment;
-  });
-}
-
 function safeParseJsonSchema(
   schema: JsonSchemaObject,
   cacheKey: string,
@@ -218,7 +211,7 @@ function safeParseJsonSchema(
   return {
     success: false,
     issues: result.errors.map((issue) => ({
-      path: toIssuePath(issue.path),
+      path: parseJsonSchemaIssuePath(issue.path),
       message: issue.message,
     })),
   };

--- a/src/plugins/config-schema.ts
+++ b/src/plugins/config-schema.ts
@@ -1,9 +1,8 @@
 // Builds plugin config schemas from manifest metadata.
 import { z, type ZodTypeAny } from "zod";
 import type { JsonSchemaObject } from "../shared/json-schema.types.js";
-import { parseConfigPathArrayIndex } from "../shared/path-array-index.js";
 import type { PluginConfigUiHint } from "./manifest-types.js";
-import { validateJsonSchemaValue } from "./schema-validator.js";
+import { parseJsonSchemaIssuePath, validateJsonSchemaValue } from "./schema-validator.js";
 import type { OpenClawPluginConfigSchema } from "./types.js";
 
 type Issue = { path: Array<string | number>; message: string };
@@ -88,15 +87,6 @@ function normalizeJsonSchema(schema: unknown): unknown {
   return record;
 }
 
-function toIssuePath(path: string): Array<string | number> {
-  if (!path || path === "<root>") {
-    return [];
-  }
-  return path.split(".").map((segment) => {
-    return parseConfigPathArrayIndex(segment) ?? segment;
-  });
-}
-
 function safeParseJsonSchema(
   schema: JsonSchemaObject,
   cacheKey: string,
@@ -115,7 +105,7 @@ function safeParseJsonSchema(
     success: false,
     error: {
       issues: result.errors.map((issue) => ({
-        path: toIssuePath(issue.path),
+        path: parseJsonSchemaIssuePath(issue.path),
         message: issue.message,
       })),
     },

--- a/src/plugins/schema-validator.test.ts
+++ b/src/plugins/schema-validator.test.ts
@@ -1,7 +1,7 @@
 /** Covers plugin schema validation for manifests and exported config schemas. */
 import { Format } from "typebox/format";
 import { describe, expect, it, vi } from "vitest";
-import { validateJsonSchemaValue } from "./schema-validator.js";
+import { parseJsonSchemaIssuePath, validateJsonSchemaValue } from "./schema-validator.js";
 
 // Config validation is a CLI startup dependency; codecs and value transforms are not.
 vi.mock("typebox/compile", () => {
@@ -79,6 +79,14 @@ function expectUriValidationCase(params: {
 }
 
 describe("schema validator", () => {
+  it.each([
+    ["<root>", []],
+    ["items.0.enabled", ["items", 0, "enabled"]],
+    ["items.100001.enabled", ["items", "100001", "enabled"]],
+  ])("parses JSON Schema issue path %s", (path, expected) => {
+    expect(parseJsonSchemaIssuePath(path)).toEqual(expected);
+  });
+
   it("can apply JSON Schema defaults while validating", () => {
     const value = {};
     const result = validateJsonSchemaValue({

--- a/src/plugins/schema-validator.ts
+++ b/src/plugins/schema-validator.ts
@@ -11,6 +11,7 @@ import {
   findJsonSchemaShapeError,
 } from "../shared/json-schema-defaults.js";
 import type { JsonSchemaObject } from "../shared/json-schema.types.js";
+import { parseConfigPathArrayIndex } from "../shared/path-array-index.js";
 import { PluginLruCache } from "./plugin-cache-primitives.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
 
@@ -189,6 +190,15 @@ export type JsonSchemaValidationError = {
   allowedValues?: string[];
   allowedValuesHiddenCount?: number;
 };
+
+export function parseJsonSchemaIssuePath(
+  path: JsonSchemaValidationError["path"],
+): Array<string | number> {
+  if (!path || path === "<root>") {
+    return [];
+  }
+  return path.split(".").map((segment) => parseConfigPathArrayIndex(segment) ?? segment);
+}
 
 function normalizeErrorPath(instancePath: string | undefined): string {
   const path = instancePath?.replace(/^\//, "").replace(/\//g, ".");


### PR DESCRIPTION
## What Problem This Solves

The channel and plugin config adapters duplicated the same conversion from validator issue paths into structured path segments, leaving one contract maintained in two places.

## Why This Change Was Made

Moves the conversion to its owning `schema-validator` boundary and has both adapters reuse it. Behavior is deliberately unchanged; the refactor removes the duplicate implementations without adding configuration or default surfaces.

The existing dotted-path representation remains lossy for property names containing `.` or `/` and bounded numeric object keys. A separate compatibility-reviewed change should move structured path ownership into validator results.

## User Impact

No user-visible behavior change. Config/default surface metrics: 0 added, 0 changed, 0 removed. No changelog entry is needed for this behavior-neutral refactor.

Production LOC: +17/-24 (net -7)  
Tests: +9/-1

## Evidence

- Focused Vitest: 4 files, 63 tests passed.
- Targeted Oxfmt and `git diff --check`: passed.
- Import-cycle guard: 0 runtime value cycles.
- Core and extension production/test typechecks: passed.
- Changed-file lint: passed.
- Mandatory autoreview: no accepted/actionable findings; patch correct at 0.99 confidence.
- `pnpm check:changed` is blocked only by an unrelated pre-existing lint finding at `extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts:201`, which is identical to `origin/main`. The initial sparse-worktree dead-export scan could not resolve omitted UI modules; the documented `OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1` workaround allowed the remaining checks to run.
