### PR TITLE
perf(agents): prepare tool policy matchers per filtering operation

### DIFF
--- a/src/agents/agent-tools.policy.test.ts
+++ b/src/agents/agent-tools.policy.test.ts
@@ -12,7 +12,6 @@ import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.js";
 import {
-  filterToolsByPolicy,
   resolveEffectiveToolPolicy,
   resolveGroupToolPolicy,
   resolveInheritedToolPolicyForSession,
@@ -20,7 +19,7 @@ import {
   resolveTrustedGroupId,
 } from "./agent-tools.policy.js";
 import { createStubTool } from "./test-helpers/agent-tool-stubs.js";
-import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
+import { filterToolsByPolicy, isToolAllowedByPolicyName } from "./tool-policy-match.js";
 
 vi.mock("../channels/plugins/session-conversation.js", () => ({
   resolveSessionConversation: ({ rawId }: { rawId: string }) => ({

--- a/src/agents/agent-tools.policy.ts
+++ b/src/agents/agent-tools.policy.ts
@@ -39,7 +39,7 @@ import {
   type SessionCapabilityStore,
   type SubagentSessionRole,
 } from "./subagents/spawn/subagent-capabilities.js";
-import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
+import { createToolPolicyMatcher } from "./tool-policy-match.js";
 import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "./tool-policy.js";
 import { AUTOMATIONS_TOOL_NAME } from "./tools/automations-tool-name.js";
 
@@ -138,17 +138,6 @@ export function resolveInheritedToolPolicyForSession(
     ...(inheritedToolAllow.length > 0 ? { allow: inheritedToolAllow } : {}),
     ...(inheritedToolDeny.length > 0 ? { deny: inheritedToolDeny } : {}),
   };
-}
-
-/** Filter runtime tools by sandbox allow/deny policy. */
-export function filterToolsByPolicy<TTool extends { name: string }>(
-  tools: TTool[],
-  policy?: SandboxToolPolicy,
-): TTool[] {
-  if (!policy) {
-    return tools;
-  }
-  return tools.filter((tool) => isToolAllowedByPolicyName(tool.name, policy));
 }
 
 /** Resolve the shared profile, scope, extra, and sandbox policy layers. */
@@ -440,12 +429,11 @@ export function resolveEffectiveToolPolicy(params: {
         resolveToolProfilePolicy(profile),
         explicitProfileAlsoAllow,
       );
+      const matchesProfile = createToolPolicyMatcher(profilePolicy);
       const uncoveredEntries = implicitGrants.entries
         .map((entry) => ({
           section: entry.section,
-          grants: entry.grants.filter(
-            (toolName) => !isToolAllowedByPolicyName(toolName, profilePolicy),
-          ),
+          grants: entry.grants.filter((toolName) => !matchesProfile(toolName)),
         }))
         .filter((entry) => entry.grants.length > 0);
       const uncovered = uncoveredEntries.flatMap((entry) => entry.grants);

--- a/src/agents/delegation-capability.ts
+++ b/src/agents/delegation-capability.ts
@@ -1,5 +1,5 @@
 import { isCompletionReportInputProvenance } from "../sessions/input-provenance.js";
-import { isRuntimeToolAllowed } from "./tool-policy-match.js";
+import { createRuntimeToolMatcher } from "./tool-policy-match.js";
 import { normalizeToolPolicyName } from "./tool-policy.js";
 import { AUTOMATIONS_TOOL_NAME } from "./tools/automations-tool-name.js";
 import type { AnyAgentTool } from "./tools/common.js";
@@ -43,8 +43,8 @@ export function resolveDelegationCapability(params: {
 
   // Native harness delegation is outside the dynamic-tool allowlist, so carry
   // its actual launch authority through the shared attempt capability.
-  const delegationAllowed = [...NEW_DELEGATION_TOOL_NAMES].some((toolName) =>
-    isRuntimeToolAllowed(toolName, params.toolsAllow),
+  const delegationAllowed = [...NEW_DELEGATION_TOOL_NAMES].some(
+    createRuntimeToolMatcher(params.toolsAllow),
   );
   return delegationAllowed ? "full" : "report_only";
 }

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
@@ -8,7 +8,7 @@ import {
 } from "../../agent-bundle-mcp-tools.js";
 import { filterLocalModelLeanTools } from "../../local-model-lean.js";
 import { normalizeAgentRuntimeTools } from "../../runtime-plan/tools.js";
-import { isRuntimeToolAllowed } from "../../tool-policy-match.js";
+import { createRuntimeToolMatcher } from "../../tool-policy-match.js";
 import { replaceWithEffectiveToolAllowlist } from "../../tool-policy.js";
 import { filterRuntimeCompatibleTools } from "../../tool-schema-projection.js";
 import { logRuntimeToolSchemaQuarantine } from "../../tool-schema-quarantine.js";
@@ -78,12 +78,16 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
       : undefined;
   // Client functions share the attempt's authority; filter before their names
   // can reserve bundled tools or enter deferred catalogs and provider requests.
-  const clientTools =
-    providedClientTools && effectiveToolsAllow
-      ? providedClientTools.filter((definition) =>
-          isRuntimeToolAllowed(definition.function.name, effectiveToolsAllow),
-        )
-      : providedClientTools;
+  let clientTools = providedClientTools;
+  if (providedClientTools && effectiveToolsAllow) {
+    clientTools = [];
+    if (providedClientTools.length > 0) {
+      const matchesRuntime = createRuntimeToolMatcher(effectiveToolsAllow);
+      clientTools = providedClientTools.filter((definition) =>
+        matchesRuntime(definition.function.name),
+      );
+    }
+  }
   const bundleMetadataSnapshot = params.getCurrentAttemptPluginMetadataSnapshot();
   // Scoped registries are partial views; only complete snapshots can bypass bundle discovery.
   const bundleManifestRegistry =

--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts
@@ -9,10 +9,7 @@ import {
   resolveCoreToolFactoryFamily,
 } from "../../core-tool-factory-descriptors.js";
 import { mayMatchGlobWithPrefix } from "../../glob-pattern.js";
-import {
-  isRuntimeToolAllowed,
-  isRuntimeToolAllowedForConstruction,
-} from "../../tool-policy-match.js";
+import { createRuntimeToolMatcher } from "../../tool-policy-match.js";
 import {
   attachToolAllowlistIntersection,
   buildPluginToolGroups,
@@ -78,13 +75,17 @@ export function applyEmbeddedAttemptToolsAllow<T extends { name: string }>(
     if (hasWildcardToolAllowlist(restriction)) {
       return currentTools;
     }
+    if (currentTools.length === 0) {
+      return [];
+    }
     const pluginGroups = options?.toolMeta
       ? buildPluginToolGroups({ tools: currentTools, toolMeta: options.toolMeta })
       : undefined;
     const policy = pluginGroups
       ? expandPolicyWithPluginGroups({ allow: restriction }, pluginGroups)
       : { allow: expandShippedCoreToolPolicyNames(restriction) };
-    return currentTools.filter((tool) => isRuntimeToolAllowed(tool.name, policy?.allow));
+    const matches = createRuntimeToolMatcher(policy?.allow);
+    return currentTools.filter((tool) => matches(tool.name));
   }, tools);
 }
 
@@ -137,21 +138,15 @@ function resolveCodingToolConstructionPlanForAllowlist(
   const constructionEntries = restrictions?.flat() ?? toolsAllow;
   const expanded = expandToolGroups(expandShippedCoreToolPolicyNames(constructionEntries));
   const normalized = normalizeToolList(expanded);
-  const constructionRestrictions = restrictions ?? [toolsAllow];
+  // Construction must not select a shell factory only through write -> apply_patch.
+  const constructionMatchers = (restrictions ?? [toolsAllow]).map((restriction) =>
+    createRuntimeToolMatcher(expandShippedCoreToolPolicyNames(restriction), false),
+  );
   // Construct every family containing a tool that the final runtime policy can retain.
   // Otherwise a valid glob can survive filtering after its factory was never run.
   const coreFamilies = new Set<CoreToolFactoryFamily>(
     listCoreToolFactoryDescriptors()
-      .filter(({ name }) =>
-        constructionRestrictions.every(
-          (restriction) =>
-            restriction.length > 0 &&
-            isRuntimeToolAllowedForConstruction(
-              name,
-              expandShippedCoreToolPolicyNames(restriction),
-            ),
-        ),
-      )
+      .filter(({ name }) => constructionMatchers.every((matches) => matches(name)))
       .map(({ family }) => family),
   );
   let includePluginTools = false;

--- a/src/agents/embedded-agent-runner/run/attempt-tool-search-run-plan.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-search-run-plan.ts
@@ -2,7 +2,7 @@
  * Builds tool-search execution plans from allowlists and available controls.
  */
 import { getPluginToolMeta } from "../../../plugins/tools.js";
-import { isToolAllowedByPolicyName } from "../../tool-policy-match.js";
+import { createToolPolicyMatcher } from "../../tool-policy-match.js";
 import { normalizeToolPolicyName } from "../../tool-policy.js";
 import {
   collectUniqueCatalogToolNames,
@@ -36,14 +36,16 @@ function collectExplicitlyAllowedClientToolNames(params: {
   clientTools?: CollectAllowedToolNamesParams["clientTools"];
   explicitAllowlistSources: Array<{ entries: string[] }>;
 }): string[] {
-  return (params.clientTools ?? [])
+  const names = (params.clientTools ?? [])
     .map((tool) => tool.function?.name)
-    .filter((name): name is string => Boolean(name?.trim()))
-    .filter((name) =>
-      params.explicitAllowlistSources.some((source) =>
-        isToolAllowedByPolicyName(name, { allow: source.entries }),
-      ),
-    );
+    .filter((name): name is string => Boolean(name?.trim()));
+  if (names.length === 0) {
+    return [];
+  }
+  const matchers = params.explicitAllowlistSources.map((source) =>
+    createToolPolicyMatcher({ allow: source.entries }),
+  );
+  return names.filter((name) => matchers.some((matches) => matches(name)));
 }
 
 function collectOpenClawCapabilityToolNames(

--- a/src/agents/inherited-tool-deny.ts
+++ b/src/agents/inherited-tool-deny.ts
@@ -2,7 +2,7 @@
  * Normalizes inherited tool allow/deny lists and ACP compatibility errors.
  */
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
+import { createToolPolicyMatcher } from "./tool-policy-match.js";
 import { normalizeToolPolicyName } from "./tool-policy-shared.js";
 
 const ACP_UNSUPPORTED_INHERITED_TOOL_DENY = [
@@ -62,9 +62,8 @@ export function findAcpUnsupportedInheritedToolDeny(value: unknown): string | un
   if (inheritedToolDeny.length === 0) {
     return undefined;
   }
-  return ACP_UNSUPPORTED_INHERITED_TOOL_DENY.find(
-    (toolName) => !isToolAllowedByPolicyName(toolName, { deny: inheritedToolDeny }),
-  );
+  const matches = createToolPolicyMatcher({ deny: inheritedToolDeny });
+  return ACP_UNSUPPORTED_INHERITED_TOOL_DENY.find((toolName) => !matches(toolName));
 }
 
 export function findAcpUnsupportedInheritedToolAllow(value: unknown): string | undefined {
@@ -72,9 +71,8 @@ export function findAcpUnsupportedInheritedToolAllow(value: unknown): string | u
   if (inheritedToolAllow.length === 0) {
     return undefined;
   }
-  return ACP_REQUIRED_INHERITED_TOOL_ALLOW.find(
-    (toolName) => !isToolAllowedByPolicyName(toolName, { allow: inheritedToolAllow }),
-  );
+  const matches = createToolPolicyMatcher({ allow: inheritedToolAllow });
+  return ACP_REQUIRED_INHERITED_TOOL_ALLOW.find((toolName) => !matches(toolName));
 }
 
 export function formatAcpInheritedToolDenyError(toolName: string): string {

--- a/src/agents/openclaw-tools.media-factory-plan.ts
+++ b/src/agents/openclaw-tools.media-factory-plan.ts
@@ -11,7 +11,7 @@ import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot
 import { listProfilesForProvider } from "./auth-profiles/profile-list.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import type { PreparedModelRuntimeSnapshot } from "./prepared-model-runtime.js";
-import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
+import { createToolPolicyMatcher, isToolAllowedByPolicyName } from "./tool-policy-match.js";
 import { DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY } from "./tool-policy.js";
 import {
   hasSnapshotCapabilityAvailability,
@@ -62,17 +62,6 @@ function hasExplicitPdfModelConfig(config: OpenClawConfig | undefined): boolean 
   );
 }
 
-function isToolAllowedByFactoryPolicy(params: {
-  toolName: string;
-  allowlist?: string[];
-  denylist?: string[];
-}): boolean {
-  return isToolAllowedByPolicyName(params.toolName, {
-    allow: params.allowlist,
-    deny: params.denylist,
-  });
-}
-
 /** Returns true only when an allowlist explicitly enables the requested tool. */
 export function isToolExplicitlyAllowedByFactoryPolicy(params: {
   toolName: string;
@@ -82,7 +71,10 @@ export function isToolExplicitlyAllowedByFactoryPolicy(params: {
   if (!params.allowlist?.some((entry) => typeof entry === "string" && entry.trim().length > 0)) {
     return false;
   }
-  return isToolAllowedByFactoryPolicy(params);
+  return isToolAllowedByPolicyName(params.toolName, {
+    allow: params.allowlist,
+    deny: params.denylist,
+  });
 }
 
 /** Merges factory policy lists while preserving stable unique entries. */
@@ -229,26 +221,11 @@ export function resolveOptionalMediaToolFactoryPlan(params: {
     params.toolAllowlist,
   );
   const toolDenylist = mergeFactoryPolicyList(params.config?.tools?.deny, params.toolDenylist);
-  const allowImageGenerate = isToolAllowedByFactoryPolicy({
-    toolName: "image_generate",
-    allowlist: toolAllowlist,
-    denylist: toolDenylist,
-  });
-  const allowVideoGenerate = isToolAllowedByFactoryPolicy({
-    toolName: "video_generate",
-    allowlist: toolAllowlist,
-    denylist: toolDenylist,
-  });
-  const allowMusicGenerate = isToolAllowedByFactoryPolicy({
-    toolName: "music_generate",
-    allowlist: toolAllowlist,
-    denylist: toolDenylist,
-  });
-  const allowPdf = isToolAllowedByFactoryPolicy({
-    toolName: "pdf",
-    allowlist: toolAllowlist,
-    denylist: toolDenylist,
-  });
+  const matches = createToolPolicyMatcher({ allow: toolAllowlist, deny: toolDenylist });
+  const allowImageGenerate = matches("image_generate");
+  const allowVideoGenerate = matches("video_generate");
+  const allowMusicGenerate = matches("music_generate");
+  const allowPdf = matches("pdf");
   const explicitImageGeneration = hasExplicitToolModelConfig(defaults?.mediaModels?.image);
   const explicitVideoGeneration = hasExplicitToolModelConfig(defaults?.mediaModels?.video);
   const explicitMusicGeneration = hasExplicitToolModelConfig(defaults?.mediaModels?.music);

--- a/src/agents/tool-policy-audit.ts
+++ b/src/agents/tool-policy-audit.ts
@@ -6,7 +6,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
  */
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { SandboxConfig } from "./sandbox/types.js";
-import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
+import { createToolPolicyMatcher } from "./tool-policy-match.js";
 import { normalizeToolList, normalizeToolPolicyName, type ToolPolicyLike } from "./tool-policy.js";
 
 // Emits bounded audit logs when tool allow/deny policies remove or block tools.
@@ -46,6 +46,11 @@ function removedToolNamesByRule(params: {
     remainingCounts.set(name, (remainingCounts.get(name) ?? 0) + 1);
   }
 
+  let matchesDeny: ReturnType<typeof createToolPolicyMatcher> | undefined;
+  const fallbackRuleKind =
+    Array.isArray(params.policy.allow) && params.policy.allow.length > 0
+      ? "allow"
+      : toolPolicyRuleKind(params.policy);
   const removed = new Map<ToolPolicyRuleKind, Set<string>>();
   for (const name of normalizedToolNames(params.before)) {
     const remaining = remainingCounts.get(name) ?? 0;
@@ -53,7 +58,10 @@ function removedToolNamesByRule(params: {
       remainingCounts.set(name, remaining - 1);
       continue;
     }
-    const ruleKind = removedToolRuleKind(name, params.policy);
+    matchesDeny ??= createToolPolicyMatcher({
+      deny: Array.isArray(params.policy.deny) ? params.policy.deny : undefined,
+    });
+    const ruleKind = matchesDeny(name) ? fallbackRuleKind : "deny";
     const names = removed.get(ruleKind) ?? new Set<string>();
     names.add(name);
     removed.set(ruleKind, names);
@@ -61,31 +69,13 @@ function removedToolNamesByRule(params: {
   return new Map([...removed].map(([ruleKind, names]) => [ruleKind, [...names].toSorted()]));
 }
 
-function removedToolRuleKind(toolName: string, policy: ToolPolicyLike): ToolPolicyRuleKind {
-  if (
-    Array.isArray(policy.deny) &&
-    policy.deny.length > 0 &&
-    !isToolAllowedByPolicyName(toolName, { deny: policy.deny })
-  ) {
-    return "deny";
-  }
-  if (Array.isArray(policy.allow) && policy.allow.length > 0) {
-    return "allow";
-  }
-  return toolPolicyRuleKind(policy);
-}
-
-function matchedPolicyRuleForTool(params: {
-  toolName: string;
-  policy: ToolPolicyLike;
-  ruleKind: ToolPolicyRuleKind;
-}): string | undefined {
-  if (params.ruleKind === "deny" && Array.isArray(params.policy.deny)) {
-    return params.policy.deny.find(
-      (entry) => !isToolAllowedByPolicyName(params.toolName, { deny: [entry] }),
+function createMatchedPolicyRuleForTool(policy: ToolPolicyLike, ruleKind: ToolPolicyRuleKind) {
+  const rules = ruleKind === "deny" && Array.isArray(policy.deny) ? policy.deny : [];
+  const matchers: ReturnType<typeof createToolPolicyMatcher>[] = [];
+  return (toolName: string) =>
+    rules.find(
+      (entry, index) => !(matchers[index] ??= createToolPolicyMatcher({ deny: [entry] }))(toolName),
     );
-  }
-  return undefined;
 }
 
 function labelForRuleKind(stepLabel: string, ruleKind: ToolPolicyRuleKind): string {
@@ -152,12 +142,9 @@ function matchedPolicyRules(params: {
   tools: readonly string[];
 }): string[] {
   const rules = new Set<string>();
+  const matchRule = createMatchedPolicyRuleForTool(params.policy, params.ruleKind);
   for (const toolName of params.tools) {
-    const rule = matchedPolicyRuleForTool({
-      toolName,
-      policy: params.policy,
-      ruleKind: params.ruleKind,
-    });
+    const rule = matchRule(toolName);
     if (rule) {
       rules.add(sanitizeAuditField(rule));
     }
@@ -227,11 +214,7 @@ export function auditSandboxToolPolicyBlock(params: {
   const configKey = sanitizeAuditField(params.configKey);
   const matchedRule =
     params.policy && params.ruleType === "deny"
-      ? matchedPolicyRuleForTool({
-          toolName: normalizedToolName,
-          policy: params.policy,
-          ruleKind: "deny",
-        })
+      ? createMatchedPolicyRuleForTool(params.policy, "deny")(normalizedToolName)
       : undefined;
   const sanitizedMatchedRule = matchedRule ? sanitizeAuditField(matchedRule) : undefined;
   const matchedRuleSuffix = sanitizedMatchedRule ? `; matched ${sanitizedMatchedRule}` : "";

--- a/src/agents/tool-policy-match.ts
+++ b/src/agents/tool-policy-match.ts
@@ -4,10 +4,17 @@
  */
 import { compileGlobPatterns, matchesAnyGlobPattern } from "./glob-pattern.js";
 import type { SandboxToolPolicy } from "./sandbox/types.js";
-import { readToolAllowlistIntersection } from "./tool-policy-shared.js";
-import { expandToolGroups, normalizeToolPolicyName } from "./tool-policy.js";
+import {
+  expandToolGroups,
+  normalizeToolPolicyName,
+  readToolAllowlistIntersection,
+} from "./tool-policy-shared.js";
 
-function makeToolPolicyMatcher(policy: SandboxToolPolicy, writeAllowsApplyPatch = true) {
+/** Snapshot one synchronous filtering operation; execution checks must prepare current policy. */
+export function createToolPolicyMatcher(policy?: SandboxToolPolicy, writeAllowsApplyPatch = true) {
+  if (!policy) {
+    return () => true;
+  }
   const deny = compileGlobPatterns({
     raw: expandToolGroups(policy.deny ?? []),
     normalize: normalizeToolPolicyName,
@@ -45,10 +52,19 @@ export function isToolAllowedByPolicyName(name: string, policy?: SandboxToolPoli
   if (!policy) {
     return true;
   }
-  return makeToolPolicyMatcher(policy)(name);
+  return createToolPolicyMatcher(policy)(name);
 }
 
 /** Runtime caps deny empty lists and preserve every independently merged restriction. */
+export function createRuntimeToolMatcher(toolsAllow?: string[], writeAllowsApplyPatch = true) {
+  const matchers = (
+    toolsAllow === undefined ? [] : (readToolAllowlistIntersection(toolsAllow) ?? [toolsAllow])
+  ).map((allow) =>
+    allow.length > 0 ? createToolPolicyMatcher({ allow }, writeAllowsApplyPatch) : () => false,
+  );
+  return (name: string) => matchers.every((matches) => matches(name));
+}
+
 export function isRuntimeToolAllowed(name: string, toolsAllow?: string[]): boolean {
   return (
     toolsAllow === undefined ||
@@ -58,14 +74,19 @@ export function isRuntimeToolAllowed(name: string, toolsAllow?: string[]): boole
   );
 }
 
-/** Avoid selecting the shell factory solely through the `write` compatibility alias. */
-export function isRuntimeToolAllowedForConstruction(name: string, toolsAllow?: string[]): boolean {
-  return (
-    toolsAllow === undefined ||
-    (readToolAllowlistIntersection(toolsAllow) ?? [toolsAllow]).every(
-      (allow) => allow.length > 0 && makeToolPolicyMatcher({ allow }, false)(name),
-    )
-  );
+/** Filter runtime tools by policy without rebuilding its patterns for each tool. */
+export function filterToolsByPolicy<TTool extends { name: string }>(
+  tools: TTool[],
+  policy?: SandboxToolPolicy,
+): TTool[] {
+  if (!policy) {
+    return tools;
+  }
+  if (tools.length === 0) {
+    return [];
+  }
+  const matches = createToolPolicyMatcher(policy);
+  return tools.filter((tool) => matches(tool.name));
 }
 
 /** Return whether one tool name is allowed by every active sandbox policy. */

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -616,6 +616,34 @@ describe("tool-policy-pipeline", () => {
     expect(filtered.map((t) => (t as unknown as DummyTool).name)).toEqual(["exec"]);
   });
 
+  test("reads policy changes at each stage and each new filtering operation", () => {
+    const tools = [{ name: "read" }, { name: "write" }, { name: "exec" }];
+    const policy = { allow: ["read", "write"], deny: [] as string[] };
+    const run = (denied: string) =>
+      applyToolPolicyPipeline({
+        tools,
+        toolMeta: () => undefined,
+        warn: () => {},
+        steps: [
+          { policy: { allow: ["*"] }, label: "first" },
+          { policy, label: "second" },
+        ],
+        onFilter: ({ step }) => {
+          if (step.label === "first") {
+            policy.deny.splice(0, policy.deny.length, denied);
+          }
+        },
+      });
+
+    const first = run("write");
+    expect(first).toEqual([tools[0]]);
+    expect(first[0]).toBe(tools[0]);
+    const second = run("read");
+    expect(second).toEqual([tools[1]]);
+    expect(second[0]).toBe(tools[1]);
+    expect(tools.map((tool) => tool.name)).toEqual(["read", "write", "exec"]);
+  });
+
   test("applies deny filtering after allow filtering", () => {
     const tools = [{ name: "exec" }, { name: "process" }] as unknown as DummyTool[];
     const filtered = applyToolPolicyPipeline({

--- a/src/agents/tool-policy-pipeline.ts
+++ b/src/agents/tool-policy-pipeline.ts
@@ -4,10 +4,10 @@
  * expanded only after unknown core/plugin entries are classified.
  */
 import { isFrozenClawToolAllowPolicy } from "../claws/tool-policy-runtime.js";
-import { filterToolsByPolicy } from "./agent-tools.policy.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import { isKnownCoreToolId } from "./tool-catalog.js";
 import { auditToolPolicyFilter } from "./tool-policy-audit.js";
+import { filterToolsByPolicy } from "./tool-policy-match.js";
 import {
   analyzeAllowlistByToolType,
   buildPluginToolGroups,

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -9,7 +9,7 @@ import { isToolAllowed, resolveSandboxToolPolicyForAgent } from "./sandbox/tool-
 import type { SandboxToolPolicy } from "./sandbox/types.js";
 import {
   isRuntimeToolAllowed,
-  isRuntimeToolAllowedForConstruction,
+  createRuntimeToolMatcher,
   isToolAllowedByPolicyName,
 } from "./tool-policy-match.js";
 import {
@@ -218,7 +218,7 @@ describe("isToolAllowedByPolicyName — apply_patch / write deny decoupling (#76
 
   it("keeps runtime write compatibility out of construction planning", () => {
     expect(isRuntimeToolAllowed("apply_patch", ["write"])).toBe(true);
-    expect(isRuntimeToolAllowedForConstruction("apply_patch", ["write"])).toBe(false);
+    expect(createRuntimeToolMatcher(["write"], false)("apply_patch")).toBe(false);
     expect(isRuntimeToolAllowed("apply_patch", ["apply-patch"])).toBe(true);
     expect(isRuntimeToolAllowed("apply_patch", ["apply_*"])).toBe(true);
     expect(isRuntimeToolAllowed("apply_patch", ["group:fs"])).toBe(true);

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -21,8 +21,8 @@ import {
 } from "./agent-tools.before-tool-call.js";
 import { resetAdjustedParamsByToolCallIdForTests } from "./agent-tools.before-tool-call.state.js";
 import { finalizeAgentTools } from "./agent-tools.finalize.js";
-import { filterToolsByPolicy } from "./agent-tools.policy.js";
 import { normalizeAgentRuntimeTools } from "./runtime-plan/tools.js";
+import { filterToolsByPolicy } from "./tool-policy-match.js";
 import {
   formatToolExecutionErrorMessage,
   resolveToolExecutionErrorKind,

--- a/src/agents/tools/cron-tool-creator-cap.ts
+++ b/src/agents/tools/cron-tool-creator-cap.ts
@@ -1,6 +1,6 @@
 import { isRecord } from "../../utils.js";
 import { readCronScheduledToolProjection } from "../exec-tool-target-pinning.js";
-import { isToolAllowedByPolicyName } from "../tool-policy-match.js";
+import { createToolPolicyMatcher } from "../tool-policy-match.js";
 import {
   buildPluginToolGroups,
   expandPolicyWithPluginGroups,
@@ -265,14 +265,14 @@ function capCronJobToolsAllow(params: {
   const requestedToolsAllow = normalizeCronToolsAllow(
     requestedRaw.filter((entry): entry is string => typeof entry === "string"),
   );
-  if (requestedToolsAllow.length === 0) {
-    params.payload.toolsAllow = [];
-    delete params.payload.toolsAllowIsDefault;
-    return;
-  }
   if (requestedToolsAllow.includes("*")) {
     params.payload.toolsAllow = creatorToolNames;
     params.payload.toolsAllowIsDefault = true;
+    return;
+  }
+  if (requestedToolsAllow.length === 0 || creatorToolsAllow.length === 0) {
+    params.payload.toolsAllow = [];
+    delete params.payload.toolsAllowIsDefault;
     return;
   }
 
@@ -284,14 +284,12 @@ function capCronJobToolsAllow(params: {
     { allow: requestedToolsAllow },
     pluginGroups,
   );
+  const matches = createToolPolicyMatcher(requestedPolicy);
   // A creator tool matches under its canonical name or the runtime alias the
   // creating surface presented; the persisted cap always holds canonical names.
   params.payload.toolsAllow = creatorToolsAllow
     .filter(
-      (tool) =>
-        isToolAllowedByPolicyName(tool.name, requestedPolicy) ||
-        (tool.aliasName !== undefined &&
-          isToolAllowedByPolicyName(tool.aliasName, requestedPolicy)),
+      (tool) => matches(tool.name) || (tool.aliasName !== undefined && matches(tool.aliasName)),
     )
     .map((tool) => tool.name);
   delete params.payload.toolsAllowIsDefault;

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -9,7 +9,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { createHash, randomUUID } from "node:crypto";
 import { clampPositiveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
-import { isToolAllowedByPolicyName } from "../agents/tool-policy-match.js";
+import { createToolPolicyMatcher } from "../agents/tool-policy-match.js";
 import {
   attachToolAllowlistIntersection,
   expandToolGroups,
@@ -494,14 +494,10 @@ export function createHookRunner(
     if (normalizedRight.includes("*")) {
       return normalizedLeft;
     }
+    const matchesLeft = createToolPolicyMatcher({ allow: normalizedLeft });
+    const matchesRight = createToolPolicyMatcher({ allow: normalizedRight });
     return [...new Set(normalizeToolList([...normalizedLeft, ...normalizedRight]))].filter(
-      (name) => {
-        const normalized = normalizeToolPolicyName(name);
-        return (
-          isToolAllowedByPolicyName(normalized, { allow: normalizedLeft }) &&
-          isToolAllowedByPolicyName(normalized, { allow: normalizedRight })
-        );
-      },
+      (name) => matchesLeft(name) && matchesRight(name),
     );
   };
 


### PR DESCRIPTION
## What Problem This Solves

Turn preparation repeatedly expands and compiles the same permission patterns for every available tool. Layered policies and large tool catalogs multiply that local work, including audit reporting.

## Why This Change Was Made

Prepare matchers once per synchronous filtering operation, and move bulk filtering into the small matching owner. Construction, client/deferred tools, delegation, scheduled-task caps, optional media factories, hook intersections and audit reporting reuse it. Remove the duplicate construction matcher and media adapter; drop the bulk filter's dependency on the heavyweight policy resolver.

Deny precedence, independent restriction intersections, plugin groups, explicit empty runtime caps, and construction's write/apply_patch distinction remain unchanged. Single-tool checks still short-circuit against current policy. No matcher is cached across operations or awaits; empty tool/client lists do no preparation.

## User Impact

Less local turn-preparation work, especially for larger catalogs and layered policies. No configuration, provider, tool visibility, SDK, protocol or persistence change. This is an internal performance refactor, so no release-note entry is needed.

## Evidence

- Final source differential: 218,381 assertions, including full bundle/search owners, current-policy mutation, scalar early denial, empty-input identity, aliases, groups, glob intersections, audit output, construction/runtime differences, and 264 empty-creator create/update cases. Accepted outputs retain the original comparison digest.
- In the same 200-tool pipeline, pattern compilations fall from 722 to 6; construction with independent caps falls from 114 to 4; runtime filtering falls from 98 to 2. Absent/empty clients still prepare zero patterns.
- Focused repository suite: 441 tests across 14 files passed. Five affected suites were rerun after short-circuit corrections (156 tests), then the scheduled-job suite after its final correction (12 tests). Final changed-file gate and full build passed.
- Isolated built Gateway with real OpenAI credentials: nine completed turns covering sessions_list, cold/warm replies, CJK and Node.js web_fetch, and a fresh-session native web search confirmed by its completed SSE event. The earlier same-session search reused context and is not counted as search execution proof. After the last scheduled-job correction, rebuilt and repeated sessions_list, web_fetch and native search: all three passed. Both post-change RPC runs preserved baseline titles/previews, tool inventories and model catalog exactly (12 assertions across five calls per run).
- Independent source review caught three eager-preparation regressions in the draft; timing exposed another for empty scheduled-job caps. All were corrected and independently re-reviewed without losing the net reduction. Structured Codex review is scoped-clean at its configured P0 threshold; broader independent source review has no unresolved finding.
- Production +118/−156 = **−38 lines**; tests +32/−5 = **+27 lines**. No compatibility shim remains for either removed internal helper.

Final-source timings used complete uninstrumented owner copies, real dependencies, seven samples per workload and two reversed fresh-process orders. All 51 workload outputs and source/dependency hashes matched in both orders. Representative second-order medians:

| Local workload | Before | After |
| --- | ---: | ---: |
| Layered policy, 20 tools | 223.0 µs | 64.4 µs |
| Layered policy, 200 tools | 2.114 ms | 0.271 ms |
| Layered policy, 1,000 tools | 17.317 ms | 1.182 ms |
| Empty layered pipeline | 3.600 µs | 3.590 µs |
| One-tool layered pipeline | 6.096 µs | 6.011 µs |
| Empty scheduled-job creator cap | 0.587 µs | 0.261 µs |

Small costs remain visible: scalar first denial measured 0.174→0.194 µs, and an empty bundle cap 1.234→1.256 µs. Timings measure local computation, not model/network latency; no memory improvement is claimed.

Latest ClawSweeper review found no code or security issue and requested ordinary maintainer review plus completed exact-head CI. Independent source review and final verification are complete; [CI run 33292790660](https://github.com/openclaw/openclaw/actions/runs/33292790660) is green for `0e324654fb303da70bedcf260314a8c24e078cd7`. No additional repair or Rank-up move remains.
