### PR TITLE
fix: tool titles stop after transcript pruning

### DIFF
--- a/ui/src/e2e/tool-titles.e2e.test.ts
+++ b/ui/src/e2e/tool-titles.e2e.test.ts
@@ -19,7 +19,7 @@ const suite = createChatFlowE2eSuite();
 // Frozen proposal base 2d5228d4, built with startBundledControlUiE2eServer.
 const BASELINE_BUNDLE_SHA256 = "7970b72aaa5f99d8cf123fa61c96adec16359c8c473c33015f7a986e81ffa530";
 
-function createToolTitleFixture(count: number) {
+function createToolTitleFixture(count: number, options: { separateMessages?: boolean } = {}) {
   const items = Array.from({ length: count }, (_, index) => {
     const args = {
       task: `Inspect tool-title queue entry ${String(index + 1).padStart(3, "0")}`,
@@ -34,25 +34,44 @@ function createToolTitleFixture(count: number) {
       title: `Generated purpose ${String(index + 1).padStart(3, "0")}`,
     };
   });
-  return {
-    historyMessages: [
-      {
-        role: "assistant",
-        content: items.map((item) => ({
+  const toolMessages = items.flatMap((item, index) => [
+    {
+      role: "assistant",
+      content: [
+        {
           type: "toolCall",
           id: item.callId,
           name: "demo__show",
           arguments: item.args,
-        })),
-        timestamp: Date.UTC(2026, 7, 29, 12, 0),
-      },
-      ...items.map((item, index) => ({
-        role: "toolResult",
-        toolCallId: item.callId,
-        toolName: "demo__show",
-        content: [{ type: "text", text: `Completed fixture ${index + 1}` }],
-        timestamp: Date.UTC(2026, 7, 29, 12, 0, 1) + index,
-      })),
+        },
+      ],
+      timestamp: Date.UTC(2026, 7, 29, 12, 0) + index * 2,
+    },
+    {
+      role: "toolResult",
+      toolCallId: item.callId,
+      toolName: "demo__show",
+      content: [{ type: "text", text: `Completed fixture ${index + 1}` }],
+      timestamp: Date.UTC(2026, 7, 29, 12, 0) + index * 2 + 1,
+    },
+  ]);
+  return {
+    historyMessages: [
+      ...(options.separateMessages
+        ? toolMessages
+        : [
+            {
+              role: "assistant",
+              content: items.map((item) => ({
+                type: "toolCall",
+                id: item.callId,
+                name: "demo__show",
+                arguments: item.args,
+              })),
+              timestamp: Date.UTC(2026, 7, 29, 12, 0),
+            },
+            ...toolMessages.filter((message) => message.role === "toolResult"),
+          ]),
       {
         role: "assistant",
         content: [{ type: "text", text: "Tool-title stress fixture complete." }],
@@ -182,6 +201,56 @@ suite.define(() => {
           2,
         )}\n`,
       );
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("resumes after an off-screen retained cursor in a virtualized transcript", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    try {
+      const page = await context.newPage();
+      const initialTime = new Date("2026-08-30T12:00:00Z");
+      await page.clock.setFixedTime(initialTime);
+      const fixture = createToolTitleFixture(120, { separateMessages: true });
+      const gateway = await installMockGateway(page, {
+        historyMessages: fixture.historyMessages,
+        methodResponses: { "chat.toolTitles": { titles: fixture.titles } },
+        sessionKey: "main",
+      });
+
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await waitForRequests(gateway, "chat.toolTitles", 2);
+      await expectRequestCountStable(gateway, "chat.toolTitles", 2, 500);
+      expect(await page.locator(".chat-tool-row").count()).toBeLessThan(120);
+      expect(
+        await page.getByText("Inspect tool-title queue entry 048", { exact: true }).count(),
+      ).toBe(0);
+
+      await page.clock.setFixedTime(new Date(initialTime.getTime() + 5 * 60_000 + 1));
+      await gateway.setHistoryMessages(fixture.historyMessages);
+      const historyCount = (await gateway.getRequests("chat.history")).length;
+      await gateway.emitGatewayEvent("sessions.changed", {
+        key: "main",
+        phase: "message",
+        sessionId: "control-ui-e2e-session",
+        updatedAt: initialTime.getTime() + 5 * 60_000 + 1,
+      });
+      await gateway.waitForRequest("chat.history", { after: historyCount });
+      await waitForRequests(gateway, "chat.toolTitles", 4);
+
+      const requests = await gateway.getRequests("chat.toolTitles");
+      const resumedIds = requests.slice(2).flatMap((request) => {
+        const params = requireRecord(request.params);
+        return Array.isArray(params.items)
+          ? params.items.map((item) => requireString(requireRecord(item).id, "tool title id"))
+          : [];
+      });
+      expect(resumedIds).toEqual(fixture.items.slice(48, 96).map((item) => item.requestId));
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/e2e/tool-titles.e2e.test.ts
+++ b/ui/src/e2e/tool-titles.e2e.test.ts
@@ -39,6 +39,10 @@ function createToolTitleFixture(count: number, options: { separateMessages?: boo
       role: "assistant",
       content: [
         {
+          type: "text",
+          text: `Search marker ${String(index + 1).padStart(3, "0")}`,
+        },
+        {
           type: "toolCall",
           id: item.callId,
           name: "demo__show",
@@ -231,6 +235,11 @@ suite.define(() => {
         await page.getByText("Inspect tool-title queue entry 048", { exact: true }).count(),
       ).toBe(0);
 
+      await page.locator(".agent-chat__composer-combobox > textarea").focus();
+      await page.keyboard.press("Control+f");
+      const search = page.locator(".agent-chat__search-bar input");
+      await search.waitFor();
+      await search.fill("Search marker 001");
       await page.clock.setFixedTime(new Date(initialTime.getTime() + 5 * 60_000 + 1));
       await gateway.setHistoryMessages(fixture.historyMessages);
       const historyCount = (await gateway.getRequests("chat.history")).length;
@@ -241,6 +250,8 @@ suite.define(() => {
         updatedAt: initialTime.getTime() + 5 * 60_000 + 1,
       });
       await gateway.waitForRequest("chat.history", { after: historyCount });
+      await expectRequestCountStable(gateway, "chat.toolTitles", 2, 500);
+      await page.locator(".agent-chat__search-bar button").click();
       await waitForRequests(gateway, "chat.toolTitles", 4);
 
       const requests = await gateway.getRequests("chat.toolTitles");

--- a/ui/src/e2e/tool-titles.e2e.test.ts
+++ b/ui/src/e2e/tool-titles.e2e.test.ts
@@ -456,11 +456,6 @@ suite.define(() => {
       await expect.poll(() => rows.count()).toBe(119);
       await expectRequestCountStable(gateway, "chat.toolTitles", 2, 500);
 
-      await panes.nth(0).locator(".chat-pane__close-pane").click();
-      const survivingPane = page.locator("openclaw-chat-pane");
-      await expect.poll(() => survivingPane.count()).toBe(1);
-      await expectRequestCountStable(gateway, "chat.toolTitles", 2, 500);
-
       const secondHistoryCount = (await gateway.getRequests("chat.history")).length;
       await gateway.emitGatewayEvent("sessions.changed", {
         key: sessionKey,
@@ -469,11 +464,10 @@ suite.define(() => {
         updatedAt: initialTime.getTime() + 5 * 60_000 + 2,
       });
       await gateway.waitForRequest("chat.history", { after: secondHistoryCount });
-      const survivingRows = survivingPane.locator(".chat-tool-row");
-      if ((await survivingRows.count()) === 0) {
-        await survivingPane.locator(".chat-activity-group__summary").click();
+      if ((await allRows.count()) === 0) {
+        await summaries.nth(0).click();
       }
-      await expect.poll(() => survivingRows.count()).toBe(119);
+      await expect.poll(() => allRows.count()).toBe(238);
       await waitForRequests(gateway, "chat.toolTitles", 4);
       await expectRequestCountStable(gateway, "chat.toolTitles", 4, 500);
     } finally {

--- a/ui/src/e2e/tool-titles.e2e.test.ts
+++ b/ui/src/e2e/tool-titles.e2e.test.ts
@@ -1,0 +1,434 @@
+import { createHash } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { fnv1aUtf16 } from "../lib/fnv1a.ts";
+import { controlUiBundledSettingsStorageKey } from "../test-helpers/control-ui-e2e.ts";
+import {
+  chatSessionListResponse,
+  createChatFlowE2eSuite,
+  expectRequestCountStable,
+  installMockGateway,
+  requireRecord,
+  requireString,
+  waitForRequests,
+} from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+// Frozen proposal base 2d5228d4, built with startBundledControlUiE2eServer.
+const BASELINE_BUNDLE_SHA256 = "7970b72aaa5f99d8cf123fa61c96adec16359c8c473c33015f7a986e81ffa530";
+
+function createToolTitleFixture(count: number) {
+  const items = Array.from({ length: count }, (_, index) => {
+    const args = {
+      task: `Inspect tool-title queue entry ${String(index + 1).padStart(3, "0")}`,
+      payload: `${"x".repeat(140)}-${index}`,
+    };
+    const input = JSON.stringify(args);
+    const source = `demo__show\u0000${input}`;
+    return {
+      args,
+      callId: `tool-title-${index}`,
+      requestId: `t${fnv1aUtf16(source).toString(36)}${source.length.toString(36)}`,
+      title: `Generated purpose ${String(index + 1).padStart(3, "0")}`,
+    };
+  });
+  return {
+    historyMessages: [
+      {
+        role: "assistant",
+        content: items.map((item) => ({
+          type: "toolCall",
+          id: item.callId,
+          name: "demo__show",
+          arguments: item.args,
+        })),
+        timestamp: Date.UTC(2026, 7, 29, 12, 0),
+      },
+      ...items.map((item, index) => ({
+        role: "toolResult",
+        toolCallId: item.callId,
+        toolName: "demo__show",
+        content: [{ type: "text", text: `Completed fixture ${index + 1}` }],
+        timestamp: Date.UTC(2026, 7, 29, 12, 0, 1) + index,
+      })),
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Tool-title stress fixture complete." }],
+        timestamp: Date.UTC(2026, 7, 29, 12, 1),
+      },
+    ],
+    items,
+    titles: Object.fromEntries(items.map((item) => [item.requestId, item.title])),
+  };
+}
+
+function removeToolTitleFixtureItem(
+  fixture: ReturnType<typeof createToolTitleFixture>,
+  itemIndex: number,
+): unknown[] {
+  const removed = fixture.items[itemIndex];
+  if (!removed) {
+    throw new Error(`Missing tool-title fixture item ${itemIndex}`);
+  }
+  return fixture.historyMessages.flatMap((message): unknown[] => {
+    const record = message as Record<string, unknown>;
+    if (record.role === "toolResult" && record.toolCallId === removed.callId) {
+      return [];
+    }
+    if (record.role !== "assistant" || !Array.isArray(record.content)) {
+      return [message];
+    }
+    const content = record.content.filter((part) => {
+      const partRecord = part as Record<string, unknown>;
+      return partRecord.id !== removed.callId;
+    });
+    return content.length > 0 ? [{ ...record, content }] : [];
+  });
+}
+
+async function setToolTitleProofCue(page: Page, text: string): Promise<void> {
+  await page.evaluate((cueText) => {
+    const id = "tool-title-proof-cue";
+    let cue = document.getElementById(id);
+    if (!cue) {
+      cue = document.createElement("div");
+      cue.id = id;
+      Object.assign(cue.style, {
+        background: "#111827",
+        border: "1px solid #f9fafb",
+        color: "#f9fafb",
+        font: "600 14px/1.4 system-ui, sans-serif",
+        left: "16px",
+        maxWidth: "420px",
+        padding: "8px 10px",
+        position: "fixed",
+        top: "16px",
+        zIndex: "2147483647",
+      });
+      document.body.append(cue);
+    }
+    cue.textContent = cueText;
+  }, text);
+}
+
+suite.define(() => {
+  it("bounds a 240-row title burst and preserves overflow fallbacks", async () => {
+    const artifactDir =
+      process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim() ||
+      path.join(process.cwd(), ".artifacts", "ui-visual-proof", "tool-title-bounds", "executable");
+    await mkdir(artifactDir, { recursive: true });
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      recordVideo: { dir: artifactDir, size: { height: 900, width: 1440 } },
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    try {
+      const page = await context.newPage();
+      const fixture = createToolTitleFixture(240);
+      const gateway = await installMockGateway(page, {
+        historyMessages: fixture.historyMessages,
+        methodResponses: { "chat.toolTitles": { titles: fixture.titles } },
+      });
+
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const summary = page.locator(".chat-activity-group__summary").first();
+      await summary.waitFor();
+      await summary.click();
+      const rows = page.locator(".chat-tool-row");
+      await expect.poll(() => rows.count()).toBe(240);
+      await page.screenshot({ path: path.join(artifactDir, "expanded-initial.png") });
+      await waitForRequests(gateway, "chat.toolTitles", 2);
+      await expectRequestCountStable(gateway, "chat.toolTitles", 2, 750);
+
+      const requests = await gateway.getRequests("chat.toolTitles");
+      const requestedItems = requests.reduce((count, request) => {
+        const params = requireRecord(request.params);
+        return count + (Array.isArray(params.items) ? params.items.length : 0);
+      }, 0);
+      expect(requestedItems).toBe(48);
+      await expect.poll(() => rows.locator(".chat-tool-row__title").count()).toBe(48);
+      expect(await rows.locator(".chat-tool-msg-summary__label").count()).toBe(192);
+      const assetSrc = await page
+        .locator('script[type="module"][src*="assets/index-"]')
+        .first()
+        .getAttribute("src");
+      expect(assetSrc).toMatch(/assets\/index-.*\.js/u);
+      const assetBytes = Buffer.from(
+        await (
+          await fetch(new URL(requireString(assetSrc, "Control UI asset source"), page.url()))
+        ).arrayBuffer(),
+      );
+      const assetSha256 = createHash("sha256").update(assetBytes).digest("hex");
+      expect(assetSha256).not.toBe(BASELINE_BUNDLE_SHA256);
+      await page.screenshot({ path: path.join(artifactDir, "settled-boundary.png") });
+      await writeFile(
+        path.join(artifactDir, "metrics.json"),
+        `${JSON.stringify(
+          {
+            assetSha256,
+            assetSrc,
+            baselineAssetSha256: BASELINE_BUNDLE_SHA256,
+            exactHead: process.env.OPENCLAW_TOOL_TITLES_EXACT_HEAD?.trim() ?? null,
+            fallbackCount: 192,
+            generatedCount: 48,
+            requestCount: requests.length,
+            requestedItems,
+            rowCount: 240,
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("resumes title generation after transcript pruning removes the cursor", async () => {
+    const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+    if (artifactDir) {
+      await mkdir(artifactDir, { recursive: true });
+    }
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      ...(artifactDir
+        ? { recordVideo: { dir: artifactDir, size: { height: 900, width: 1440 } } }
+        : {}),
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    const video = page.video();
+    try {
+      const initialTime = new Date("2026-08-30T12:00:00Z");
+      await page.clock.setFixedTime(initialTime);
+      const fixture = createToolTitleFixture(120);
+      const retainedHistory = removeToolTitleFixtureItem(fixture, 47);
+      const gateway = await installMockGateway(page, {
+        historyMessages: fixture.historyMessages,
+        methodResponses: { "chat.toolTitles": { titles: fixture.titles } },
+        sessionKey: "main",
+      });
+
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const summary = page.locator(".chat-activity-group__summary").first();
+      await summary.waitFor();
+      await summary.click();
+      const rows = page.locator(".chat-tool-row");
+      await expect.poll(() => rows.count()).toBe(120);
+      await waitForRequests(gateway, "chat.toolTitles", 2);
+      await expectRequestCountStable(gateway, "chat.toolTitles", 2, 500);
+      await expect.poll(() => rows.locator(".chat-tool-row__title").count()).toBe(48);
+      await rows.nth(48).scrollIntoViewIfNeeded();
+      await setToolTitleProofCue(page, "Initial bound: 48 generated, 72 deterministic fallbacks");
+      if (artifactDir) {
+        await page.screenshot({ path: path.join(artifactDir, "01-initial-bound.png") });
+      }
+
+      await page.clock.setFixedTime(new Date(initialTime.getTime() + 5 * 60_000 + 1));
+      await gateway.setHistoryMessages(retainedHistory);
+      const firstHistoryCount = (await gateway.getRequests("chat.history")).length;
+      await gateway.emitGatewayEvent("sessions.changed", {
+        key: "main",
+        phase: "reset",
+        reason: "reset",
+        sessionId: "control-ui-e2e-session",
+        updatedAt: initialTime.getTime() + 5 * 60_000 + 1,
+      });
+      await gateway.waitForRequest("chat.history", { after: firstHistoryCount });
+      await expect.poll(() => rows.count()).toBe(119);
+      await expectRequestCountStable(gateway, "chat.toolTitles", 2, 500);
+      await expect.poll(() => rows.locator(".chat-tool-row__title").count()).toBe(47);
+      await rows.nth(47).scrollIntoViewIfNeeded();
+      await setToolTitleProofCue(
+        page,
+        "Cursor pruned: first complete retained render remains suppressed",
+      );
+      if (artifactDir) {
+        await page.screenshot({ path: path.join(artifactDir, "02-pruned-first-render.png") });
+      }
+
+      const secondHistoryCount = (await gateway.getRequests("chat.history")).length;
+      await gateway.emitGatewayEvent("sessions.changed", {
+        key: "main",
+        phase: "message",
+        sessionId: "control-ui-e2e-session",
+        updatedAt: initialTime.getTime() + 5 * 60_000 + 2,
+      });
+      await gateway.waitForRequest("chat.history", { after: secondHistoryCount });
+      await waitForRequests(gateway, "chat.toolTitles", 4);
+      await expectRequestCountStable(gateway, "chat.toolTitles", 4, 500);
+
+      const requests = await gateway.getRequests("chat.toolTitles");
+      const requestItems = requests.flatMap((request) => {
+        const params = requireRecord(request.params);
+        return Array.isArray(params.items) ? params.items.map((item) => requireRecord(item)) : [];
+      });
+      expect(
+        requests.every((request) => {
+          const params = requireRecord(request.params);
+          return Array.isArray(params.items) && params.items.length <= 24;
+        }),
+      ).toBe(true);
+      expect(
+        new Set(requestItems.map((item) => requireString(item.id, "tool title id"))).size,
+      ).toBe(96);
+      await expect.poll(() => rows.locator(".chat-tool-row__title").count()).toBe(95);
+      expect(await rows.locator(".chat-tool-msg-summary__label").count()).toBe(24);
+      await rows.nth(47).scrollIntoViewIfNeeded();
+      await setToolTitleProofCue(page, "Resumed: 96 unique requests, 95 visible generated titles");
+      if (artifactDir) {
+        await page.screenshot({ path: path.join(artifactDir, "03-pruned-resumed.png") });
+        await writeFile(
+          path.join(artifactDir, "metrics.json"),
+          `${JSON.stringify(
+            {
+              exactHead: process.env.OPENCLAW_TOOL_TITLES_EXACT_HEAD?.trim() ?? null,
+              finalFallbackCount: 24,
+              finalGeneratedCount: 95,
+              initialGeneratedCount: 48,
+              removedCursorRequestId: fixture.items[47]?.requestId ?? null,
+              requestBatchSizes: requests.map((request) => {
+                const params = requireRecord(request.params);
+                return Array.isArray(params.items) ? params.items.length : 0;
+              }),
+              uniqueRequestedIds: 96,
+              visibleRowsAfterPruning: 119,
+            },
+            null,
+            2,
+          )}\n`,
+        );
+      }
+    } finally {
+      await context.close();
+      if (artifactDir && video) {
+        await video.saveAs(path.join(artifactDir, "cursor-pruning-transition.webm"));
+      }
+    }
+  });
+
+  it("repaints both split panes after one shared pending title settles", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    await context.addInitScript((settingsKey) => {
+      localStorage.setItem(
+        settingsKey,
+        JSON.stringify({
+          chatSplitLayout: {
+            activePaneId: "p1",
+            columns: [
+              {
+                id: "c1",
+                panes: [{ id: "p1", sessionKey: "agent:main:session-a" }],
+                paneWeights: [1],
+              },
+              {
+                id: "c2",
+                panes: [{ id: "p2", sessionKey: "agent:main:session-a" }],
+                paneWeights: [1],
+              },
+            ],
+            columnWeights: [0.5, 0.5],
+          },
+        }),
+      );
+    }, controlUiBundledSettingsStorageKey(suite.server.baseUrl));
+
+    try {
+      const page = await context.newPage();
+      const fixture = createToolTitleFixture(1);
+      const gateway = await installMockGateway(page, {
+        heldMethods: ["chat.toolTitles"],
+        historyMessages: fixture.historyMessages,
+        methodResponses: { "sessions.list": chatSessionListResponse() },
+        sessionKey: "agent:main:session-a",
+      });
+
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const panes = page.locator("openclaw-chat-pane.chat-split-view__pane");
+      await expect.poll(() => panes.count()).toBe(2);
+      const rows = panes.locator(".chat-tool-row");
+      await expect.poll(() => rows.count()).toBe(2);
+      await expect.poll(() => rows.locator(".chat-tool-msg-summary__label").count()).toBe(2);
+      const [request] = await waitForRequests(gateway, "chat.toolTitles", 1);
+      await expectRequestCountStable(gateway, "chat.toolTitles", 1, 500);
+      const params = requireRecord(request?.params);
+      const requestItems = Array.isArray(params.items) ? params.items : [];
+      const requestId = requireRecord(requestItems[0]).id;
+      expect(typeof requestId).toBe("string");
+
+      await gateway.resolveDeferred("chat.toolTitles", {
+        titles: { [String(requestId)]: "Shared generated title" },
+      });
+      await expect
+        .poll(() => rows.locator(".chat-tool-row__title").allTextContents())
+        .toEqual(["Shared generated title", "Shared generated title"]);
+      expect(await gateway.getRequests("chat.toolTitles")).toHaveLength(1);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("invalidates a rendered title when the gateway client is replaced", async () => {
+    const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      ...(artifactDir
+        ? { recordVideo: { dir: artifactDir, size: { height: 900, width: 1440 } } }
+        : {}),
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    try {
+      const page = await context.newPage();
+      const fixture = createToolTitleFixture(1);
+      const requestId = fixture.items[0]?.requestId;
+      expect(requestId).toBeDefined();
+      const gateway = await installMockGateway(page, {
+        historyMessages: fixture.historyMessages,
+        methodResponses: {
+          "chat.toolTitles": { titles: { [String(requestId)]: "First gateway title" } },
+        },
+      });
+
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const row = page.locator(".chat-tool-row").first();
+      await row.locator(".chat-tool-row__title").getByText("First gateway title").waitFor();
+      if (artifactDir) {
+        await page.screenshot({ path: path.join(artifactDir, "replacement-before.png") });
+      }
+
+      const requestCount = (await gateway.getRequests("chat.toolTitles")).length;
+      const socketCount = await gateway.getSocketCount();
+      await gateway.setMethodResponse("chat.toolTitles", {
+        titles: { [String(requestId)]: "Replacement gateway title" },
+      });
+      await gateway.setOnline(false);
+      await gateway.closeLatest(1006, "tool-title replacement proof");
+      await row.locator(".chat-tool-msg-summary__label").waitFor();
+      expect(await row.locator(".chat-tool-row__title").count()).toBe(0);
+      if (artifactDir) {
+        await page.screenshot({ path: path.join(artifactDir, "replacement-fallback.png") });
+      }
+
+      await gateway.setOnline(true);
+      await expect.poll(() => gateway.getSocketCount()).toBeGreaterThan(socketCount);
+      await expect
+        .poll(async () => (await gateway.getRequests("chat.toolTitles")).length)
+        .toBeGreaterThan(requestCount);
+      await row.locator(".chat-tool-row__title").getByText("Replacement gateway title").waitFor();
+      if (artifactDir) {
+        await page.screenshot({ path: path.join(artifactDir, "replacement-after.png") });
+      }
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+});

--- a/ui/src/e2e/tool-titles.e2e.test.ts
+++ b/ui/src/e2e/tool-titles.e2e.test.ts
@@ -456,6 +456,11 @@ suite.define(() => {
       await expect.poll(() => rows.count()).toBe(119);
       await expectRequestCountStable(gateway, "chat.toolTitles", 2, 500);
 
+      await panes.nth(0).locator(".chat-pane__close-pane").click();
+      const survivingPane = page.locator("openclaw-chat-pane");
+      await expect.poll(() => survivingPane.count()).toBe(1);
+      await expectRequestCountStable(gateway, "chat.toolTitles", 2, 500);
+
       const secondHistoryCount = (await gateway.getRequests("chat.history")).length;
       await gateway.emitGatewayEvent("sessions.changed", {
         key: sessionKey,
@@ -464,10 +469,11 @@ suite.define(() => {
         updatedAt: initialTime.getTime() + 5 * 60_000 + 2,
       });
       await gateway.waitForRequest("chat.history", { after: secondHistoryCount });
-      if ((await allRows.count()) === 0) {
-        await summaries.nth(0).click();
+      const survivingRows = survivingPane.locator(".chat-tool-row");
+      if ((await survivingRows.count()) === 0) {
+        await survivingPane.locator(".chat-activity-group__summary").click();
       }
-      await expect.poll(() => allRows.count()).toBe(238);
+      await expect.poll(() => survivingRows.count()).toBe(119);
       await waitForRequests(gateway, "chat.toolTitles", 4);
       await expectRequestCountStable(gateway, "chat.toolTitles", 4, 500);
     } finally {

--- a/ui/src/e2e/tool-titles.e2e.test.ts
+++ b/ui/src/e2e/tool-titles.e2e.test.ts
@@ -525,18 +525,7 @@ suite.define(() => {
       await expect.poll(() => rows.count()).toBe(119);
       await expectRequestCountStable(gateway, "chat.toolTitles", 2, 500);
 
-      const secondHistoryCount = (await gateway.getRequests("chat.history")).length;
-      await gateway.emitGatewayEvent("sessions.changed", {
-        key: sessionKey,
-        phase: "message",
-        sessionId: "control-ui-e2e-session",
-        updatedAt: initialTime.getTime() + 5 * 60_000 + 2,
-      });
-      await gateway.waitForRequest("chat.history", { after: secondHistoryCount });
-      if ((await allRows.count()) === 0) {
-        await summaries.nth(0).click();
-      }
-      await expect.poll(() => allRows.count()).toBe(238);
+      await panes.nth(1).click({ position: { x: 20, y: 80 } });
       await waitForRequests(gateway, "chat.toolTitles", 4);
       await expectRequestCountStable(gateway, "chat.toolTitles", 4, 500);
     } finally {

--- a/ui/src/e2e/tool-titles.e2e.test.ts
+++ b/ui/src/e2e/tool-titles.e2e.test.ts
@@ -376,6 +376,105 @@ suite.define(() => {
     }
   });
 
+  it("keeps a same-session sibling pane inside the cursor-search render", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const sessionKey = "agent:main:session-a";
+    await context.addInitScript(
+      ({ settingsKey, selectedSessionKey }) => {
+        localStorage.setItem(
+          settingsKey,
+          JSON.stringify({
+            chatSplitLayout: {
+              activePaneId: "p1",
+              columns: [
+                {
+                  id: "c1",
+                  panes: [{ id: "p1", sessionKey: selectedSessionKey }],
+                  paneWeights: [1],
+                },
+                {
+                  id: "c2",
+                  panes: [{ id: "p2", sessionKey: selectedSessionKey }],
+                  paneWeights: [1],
+                },
+              ],
+              columnWeights: [0.5, 0.5],
+            },
+          }),
+        );
+      },
+      {
+        selectedSessionKey: sessionKey,
+        settingsKey: controlUiBundledSettingsStorageKey(suite.server.baseUrl),
+      },
+    );
+
+    try {
+      const page = await context.newPage();
+      const initialTime = new Date("2026-08-30T12:00:00Z");
+      await page.clock.setFixedTime(initialTime);
+      const fixture = createToolTitleFixture(120);
+      const retainedHistory = removeToolTitleFixtureItem(fixture, 47);
+      const gateway = await installMockGateway(page, {
+        historyMessages: fixture.historyMessages,
+        methodResponses: { "chat.toolTitles": { titles: fixture.titles } },
+        sessionKey,
+      });
+
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const panes = page.locator("openclaw-chat-pane.chat-split-view__pane");
+      await expect.poll(() => panes.count()).toBe(2);
+      const summaries = panes.locator(".chat-activity-group__summary");
+      await expect.poll(() => summaries.count()).toBe(2);
+      await summaries.nth(0).click();
+      const allRows = panes.locator(".chat-tool-row");
+      const rows = panes.nth(0).locator(".chat-tool-row");
+      await expect.poll(() => allRows.count()).toBe(240);
+      await expect.poll(() => rows.count()).toBe(120);
+      await waitForRequests(gateway, "chat.toolTitles", 2);
+      await expectRequestCountStable(gateway, "chat.toolTitles", 2, 500);
+
+      await page.clock.setFixedTime(new Date(initialTime.getTime() + 5 * 60_000 + 1));
+      await gateway.setHistoryMessages(retainedHistory);
+      const firstHistoryCount = (await gateway.getRequests("chat.history")).length;
+      await gateway.emitGatewayEvent("sessions.changed", {
+        key: sessionKey,
+        phase: "reset",
+        reason: "reset",
+        sessionId: "control-ui-e2e-session",
+        updatedAt: initialTime.getTime() + 5 * 60_000 + 1,
+      });
+      await gateway.waitForRequest("chat.history", { after: firstHistoryCount });
+      if ((await allRows.count()) === 0) {
+        await summaries.nth(0).click();
+      }
+      await expect.poll(() => allRows.count()).toBe(238);
+      await expect.poll(() => rows.count()).toBe(119);
+      await expectRequestCountStable(gateway, "chat.toolTitles", 2, 500);
+
+      const secondHistoryCount = (await gateway.getRequests("chat.history")).length;
+      await gateway.emitGatewayEvent("sessions.changed", {
+        key: sessionKey,
+        phase: "message",
+        sessionId: "control-ui-e2e-session",
+        updatedAt: initialTime.getTime() + 5 * 60_000 + 2,
+      });
+      await gateway.waitForRequest("chat.history", { after: secondHistoryCount });
+      if ((await allRows.count()) === 0) {
+        await summaries.nth(0).click();
+      }
+      await expect.poll(() => allRows.count()).toBe(238);
+      await waitForRequests(gateway, "chat.toolTitles", 4);
+      await expectRequestCountStable(gateway, "chat.toolTitles", 4, 500);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("invalidates a rendered title when the gateway client is replaced", async () => {
     const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
     const context = await suite.newBrowserContext({

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -198,6 +198,10 @@ export function retireChatBranchRequests(state: ChatState): void {
   getChatHistoryPaneRequests(state).branchVersion += 1;
 }
 
+export function getChatHistoryVersion(state: ChatState): number {
+  return getChatHistoryPaneRequests(state).historyVersion;
+}
+
 type ChatHistoryRequestOwnership = {
   version: number;
   client: GatewayBrowserClient;

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -87,7 +87,7 @@ import {
   resolveChatSnapshotKey,
 } from "./session-message-cache.ts";
 import { closeSlot, isSidebarSlotVisible, openSlot, type SidebarSlotId } from "./sidebar-layout.ts";
-import { subscribeToolTitleChanges } from "./tool-titles.ts";
+import { releaseToolTitleRenderSource, subscribeToolTitleChanges } from "./tool-titles.ts";
 
 const COMPOSER_PREFILL_ATTENTION_DURATION_MS = 600;
 const COMPOSER_PREFILL_ATTENTION_CLASS = "agent-chat__input--prefill-attention";
@@ -698,6 +698,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
   }
 
   override disconnectedCallback() {
+    releaseToolTitleRenderSource(this);
     if (this.state) {
       retireChatMetadataRequests(this.state);
       if (this.suppressStagedAttachmentHandoffOnDisconnect) {

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -87,7 +87,7 @@ import {
   resolveChatSnapshotKey,
 } from "./session-message-cache.ts";
 import { closeSlot, isSidebarSlotVisible, openSlot, type SidebarSlotId } from "./sidebar-layout.ts";
-import { releaseToolTitleRenderSource, subscribeToolTitleChanges } from "./tool-titles.ts";
+import { subscribeToolTitleChanges } from "./tool-titles.ts";
 
 const COMPOSER_PREFILL_ATTENTION_DURATION_MS = 600;
 const COMPOSER_PREFILL_ATTENTION_CLASS = "agent-chat__input--prefill-attention";
@@ -698,7 +698,6 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
   }
 
   override disconnectedCallback() {
-    releaseToolTitleRenderSource(this);
     if (this.state) {
       retireChatMetadataRequests(this.state);
       if (this.suppressStagedAttachmentHandoffOnDisconnect) {

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -87,6 +87,7 @@ import {
   resolveChatSnapshotKey,
 } from "./session-message-cache.ts";
 import { closeSlot, isSidebarSlotVisible, openSlot, type SidebarSlotId } from "./sidebar-layout.ts";
+import { subscribeToolTitleChanges } from "./tool-titles.ts";
 
 const COMPOSER_PREFILL_ATTENTION_DURATION_MS = 600;
 const COMPOSER_PREFILL_ATTENTION_CLASS = "agent-chat__input--prefill-attention";
@@ -297,14 +298,11 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
     });
   }
 
-  protected readonly handlePaneFocus = () => {
-    this.onFocusPane?.(this.paneId);
-  };
+  protected readonly handlePaneFocus = () => this.onFocusPane?.(this.paneId);
 
   /** Receives one complete browser annotation without mixing generated context into the user's draft. */
   protected receiveBrowserAnnotation(event: Event): void {
-    const accepted = admitBrowserAnnotation(this.state, this.active && this.presented, event);
-    if (!accepted) {
+    if (!admitBrowserAnnotation(this.state, this.active && this.presented, event)) {
       return;
     }
     // A null mount binds only when its first annotation ownership begins.
@@ -437,6 +435,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
     document.addEventListener("keydown", this.handleDocumentKeydown, true);
     document.addEventListener("pointerdown", this.handleDocumentPointerdown, true);
     const chatState = this.chatState;
+    chatState.addCleanup(subscribeToolTitleChanges(() => this.state?.requestUpdate?.()));
     chatState.addCleanup(() => {
       document.removeEventListener("keydown", this.handleDocumentKeydown, true);
       document.removeEventListener("pointerdown", this.handleDocumentPointerdown, true);

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -152,6 +152,7 @@ export class ChatPane extends ChatPaneLayoutRender {
       sessionKey: catalogKey ? null : state.sessionKey || null,
       agentId: currentAgentId || null,
       schedulingEnabled: this.active && this.presented,
+      historyOwner: state,
       historyVersion: getChatHistoryVersion(state),
     });
     const selectedAgent = this.context.agents.state.agentsList?.agents.find(

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -151,6 +151,7 @@ export class ChatPane extends ChatPaneLayoutRender {
       client: state.connected ? state.client : null,
       sessionKey: catalogKey ? null : state.sessionKey || null,
       agentId: currentAgentId || null,
+      renderSource: this,
     });
     const selectedAgent = this.context.agents.state.agentsList?.agents.find(
       (agent) => agent.id === currentAgentId,

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -29,7 +29,7 @@ import { buildAgentMainSessionKey } from "../../lib/sessions/session-key.ts";
 import { showToast } from "../../lib/toast.ts";
 import { generateUUID } from "../../lib/uuid.ts";
 import { mutateChatGoal, submitChatGoalDraft } from "./chat-goals.ts";
-import { clearChatHistory } from "./chat-history.ts";
+import { clearChatHistory, getChatHistoryVersion } from "./chat-history.ts";
 import { resolveChatMessageAccess } from "./chat-message-access.ts";
 import { requiresChatModelSetup } from "./chat-model-setup.ts";
 import { ChatPaneLayoutRender } from "./chat-pane-layout-render.ts";
@@ -151,7 +151,8 @@ export class ChatPane extends ChatPaneLayoutRender {
       client: state.connected ? state.client : null,
       sessionKey: catalogKey ? null : state.sessionKey || null,
       agentId: currentAgentId || null,
-      renderSource: this,
+      schedulingEnabled: this.active && this.presented,
+      historyVersion: getChatHistoryVersion(state),
     });
     const selectedAgent = this.context.agents.state.agentsList?.agents.find(
       (agent) => agent.id === currentAgentId,

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -151,7 +151,6 @@ export class ChatPane extends ChatPaneLayoutRender {
       client: state.connected ? state.client : null,
       sessionKey: catalogKey ? null : state.sessionKey || null,
       agentId: currentAgentId || null,
-      onTitlesChanged: () => state.requestUpdate?.(),
     });
     const selectedAgent = this.context.agents.state.agentsList?.agents.find(
       (agent) => agent.id === currentAgentId,

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -387,6 +387,19 @@ export function getExpandedUserMessages(sessionKey: string): Map<string, boolean
   return getOrCreateSessionCacheValue(expandedUserMessagesBySession, sessionKey, () => new Map());
 }
 
+export function collectToolTitleCandidates(items: readonly (ChatItem | MessageGroup)[]) {
+  return items.flatMap((item) =>
+    item.kind === "group"
+      ? item.messages.flatMap((entry) =>
+          extractToolCardsCached(entry.message, entry.key).map(({ args, name }) => ({
+            args,
+            name,
+          })),
+        )
+      : [],
+  );
+}
+
 export type AssistantMessageExpansionState =
   | { status: "loading"; revision: number }
   | { status: "error"; revision: number }

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -19,6 +19,7 @@ import {
   agentRunFrameGroups,
   assistantMessageExpansionSignature,
   buildCachedChatItems,
+  collectToolTitleCandidates,
   coalesceAgentRunFrames,
   coalesceActivityRuns,
   coalesceStreamRuns,
@@ -31,7 +32,7 @@ import {
   setExpansionState,
   syncToolCardExpansionState,
 } from "../chat-thread.ts";
-import { getToolTitlesVersion } from "../tool-titles.ts";
+import { getToolTitlesVersion, scheduleToolTitlesForTranscript } from "../tool-titles.ts";
 import { renderAgentRunFrame } from "./chat-agent-run-frame.ts";
 import { renderBackgroundTasksStatusRow } from "./chat-background-tasks-status.ts";
 import { renderChatDivider, renderChatNotice } from "./chat-divider.ts";
@@ -176,6 +177,9 @@ export function projectChatTranscript(
     searchOpen: state.searchOpen,
     searchQuery: state.searchQuery,
   });
+  if (props.showToolCalls) {
+    scheduleToolTitlesForTranscript(collectToolTitleCandidates(chatItems));
+  }
   const latestBrowserTabs =
     props.browserTabPreviewsActive === false
       ? latestBrowserTabCards([], [])

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -177,7 +177,7 @@ export function projectChatTranscript(
     searchOpen: state.searchOpen,
     searchQuery: state.searchQuery,
   });
-  if (props.showToolCalls) {
+  if (props.showToolCalls && !searchFiltering) {
     scheduleToolTitlesForTranscript(collectToolTitleCandidates(chatItems));
   }
   const latestBrowserTabs =

--- a/ui/src/pages/chat/tool-titles.test.ts
+++ b/ui/src/pages/chat/tool-titles.test.ts
@@ -172,50 +172,60 @@ describe("title fetch batching", () => {
     expect(requestedIds.size).toBe(commands.length);
   });
 
-  it("resumes when transcript retention removes the saturation cursor", async () => {
-    vi.useFakeTimers();
-    const requestedIds = new Set<string>();
-    const request = vi.fn(async (_method: string, params: unknown) => {
-      const items = (params as { items: Array<{ id: string; input: string }> }).items;
-      for (const item of items) {
-        requestedIds.add(item.id);
+  it.each(["release", "owner-switch"] as const)(
+    "resumes when transcript retention removes the saturation cursor after %s",
+    async (transition) => {
+      vi.useFakeTimers();
+      const requestedIds = new Set<string>();
+      const request = vi.fn(async (_method: string, params: unknown) => {
+        const items = (params as { items: Array<{ id: string; input: string }> }).items;
+        for (const item of items) {
+          requestedIds.add(item.id);
+        }
+        return { titles: Object.fromEntries(items.map((item) => [item.id, item.input])) };
+      });
+      const client = { request } as unknown as GatewayBrowserClient;
+      const firstPane = {};
+      const secondPane = {};
+      const commands = Array.from(
+        { length: 120 },
+        (_, index) => `printf 'retained-title-${index}'`,
+      );
+      const renderTranscript = (visibleCommands: string[], renderSource: object) => {
+        configureToolTitleFetcher({ client, sessionKey: "main", renderSource });
+        for (const command of visibleCommands) {
+          getToolCallTitle("bash", { command });
+        }
+      };
+
+      renderTranscript(commands, firstPane);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(requestedIds.size).toBe(48);
+
+      const retainedCommands = commands.filter((_, index) => index !== 47);
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+      renderTranscript(retainedCommands, firstPane);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(requestedIds.size).toBe(48);
+
+      renderTranscript(retainedCommands, secondPane);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(requestedIds.size).toBe(48);
+
+      if (transition === "release") {
+        releaseToolTitleRenderSource(firstPane);
+      } else {
+        configureToolTitleFetcher({
+          client,
+          sessionKey: "other-session",
+          renderSource: firstPane,
+        });
       }
-      return { titles: Object.fromEntries(items.map((item) => [item.id, item.input])) };
-    });
-    const client = { request } as unknown as GatewayBrowserClient;
-    const firstPane = {};
-    const secondPane = {};
-    const commands = Array.from({ length: 120 }, (_, index) => `printf 'retained-title-${index}'`);
-    const renderTranscript = (visibleCommands: string[], renderSource: object) => {
-      configureToolTitleFetcher({ client, sessionKey: "main", renderSource });
-      for (const command of visibleCommands) {
-        getToolCallTitle("bash", { command });
-      }
-    };
-
-    renderTranscript(commands, firstPane);
-    await vi.advanceTimersByTimeAsync(1_000);
-    expect(requestedIds.size).toBe(48);
-
-    const retainedCommands = commands.filter((_, index) => index !== 47);
-    await vi.advanceTimersByTimeAsync(5 * 60_000);
-    renderTranscript(retainedCommands, firstPane);
-    await vi.advanceTimersByTimeAsync(1_000);
-    expect(requestedIds.size).toBe(48);
-
-    renderTranscript(retainedCommands, secondPane);
-    await vi.advanceTimersByTimeAsync(1_000);
-    expect(requestedIds.size).toBe(48);
-
-    releaseToolTitleRenderSource(firstPane);
-    renderTranscript(retainedCommands, secondPane);
-    await vi.advanceTimersByTimeAsync(1_000);
-    expect(requestedIds.size).toBe(48);
-
-    renderTranscript(retainedCommands, secondPane);
-    await vi.advanceTimersByTimeAsync(1_000);
-    expect(requestedIds.size).toBe(96);
-  });
+      renderTranscript(retainedCommands, secondPane);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(requestedIds.size).toBe(96);
+    },
+  );
 
   it("evicts least-recently-used failures once retention is full", async () => {
     vi.useFakeTimers();

--- a/ui/src/pages/chat/tool-titles.test.ts
+++ b/ui/src/pages/chat/tool-titles.test.ts
@@ -316,9 +316,9 @@ describe("title fetch batching", () => {
     });
     const client = { request } as unknown as GatewayBrowserClient;
 
-    for (let sessionIndex = 0; sessionIndex < 3; sessionIndex++) {
+    for (let sessionIndex = 0; sessionIndex < 2; sessionIndex++) {
       configureToolTitleFetcher({ client, sessionKey: `session-${sessionIndex}` });
-      for (let itemIndex = 0; itemIndex < 32; itemIndex++) {
+      for (let itemIndex = 0; itemIndex < 48; itemIndex++) {
         getToolCallTitle("bash", {
           command: `printf 'global-title-${sessionIndex}-${itemIndex}'`,
         });

--- a/ui/src/pages/chat/tool-titles.test.ts
+++ b/ui/src/pages/chat/tool-titles.test.ts
@@ -6,7 +6,7 @@ import {
   configureToolTitleFetcher,
   getToolCallTitle,
   getToolTitlesVersion,
-  releaseToolTitleRenderSource,
+  scheduleToolTitlesForTranscript,
   subscribeToolTitleChanges,
 } from "./tool-titles.ts";
 
@@ -24,9 +24,14 @@ function requireFirstRequestParams(request: ReturnType<typeof vi.fn>): unknown {
   return call[1];
 }
 
+function renderToolTitle(name: string, args: unknown): string | undefined {
+  scheduleToolTitlesForTranscript([{ name, args }]);
+  return getToolCallTitle(name, args);
+}
+
 describe("getToolCallTitle", () => {
   it("returns undefined for eligible calls without a stored title", () => {
-    expect(getToolCallTitle("bash", { command: "git log --oneline -5" })).toBeUndefined();
+    expect(renderToolTitle("bash", { command: "git log --oneline -5" })).toBeUndefined();
   });
 });
 
@@ -42,10 +47,10 @@ describe("title fetch batching", () => {
       sessionKey: "main",
     });
 
-    getToolCallTitle("bash", { command: "short" });
-    getToolCallTitle("bash", { command: "git log --oneline -5" });
-    getToolCallTitle("demo__show", { value: "short" });
-    getToolCallTitle("demo__show", { value: "x".repeat(150) });
+    renderToolTitle("bash", { command: "short" });
+    renderToolTitle("bash", { command: "git log --oneline -5" });
+    renderToolTitle("demo__show", { value: "short" });
+    renderToolTitle("demo__show", { value: "x".repeat(150) });
     await vi.advanceTimersByTimeAsync(1_000);
 
     const items = (requireFirstRequestParams(request) as { items: unknown[] }).items;
@@ -60,12 +65,12 @@ describe("title fetch batching", () => {
       sessionKey: "main",
     });
 
-    getToolCallTitle("bash", { command: "12345678901" });
-    getToolCallTitle("bash", { command: "123456789012" });
-    getToolCallTitle("read", { path: `/${"x".repeat(500)}` });
-    getToolCallTitle("demo__show", "x".repeat(119));
-    getToolCallTitle("demo__show", "y".repeat(120));
-    getToolCallTitle("bash", { command: `${"z".repeat(1_999)}😀tail` });
+    renderToolTitle("bash", { command: "12345678901" });
+    renderToolTitle("bash", { command: "123456789012" });
+    renderToolTitle("read", { path: `/${"x".repeat(500)}` });
+    renderToolTitle("demo__show", "x".repeat(119));
+    renderToolTitle("demo__show", "y".repeat(120));
+    renderToolTitle("bash", { command: `${"z".repeat(1_999)}😀tail` });
     await vi.advanceTimersByTimeAsync(1_000);
 
     const items = (
@@ -89,8 +94,8 @@ describe("title fetch batching", () => {
       sessionKey: "main",
     });
     const args = { command: "pnpm test ui/src/pages/chat --reporter verbose" };
-    getToolCallTitle("bash", args);
-    getToolCallTitle("bash", { ...args });
+    renderToolTitle("bash", args);
+    renderToolTitle("bash", { ...args });
     await vi.advanceTimersByTimeAsync(1_000);
 
     expect((requireFirstRequestParams(request) as { items: unknown[] }).items).toHaveLength(1);
@@ -107,9 +112,9 @@ describe("title fetch batching", () => {
       sessionKey: "main",
     });
     const args = { command: "pnpm run build --filter ui --mode production" };
-    expect(getToolCallTitle("bash", args)).toBeUndefined();
+    expect(renderToolTitle("bash", args)).toBeUndefined();
     await vi.advanceTimersByTimeAsync(1_000);
-    expect(getToolCallTitle("bash", args)).toBe("Build the Control UI");
+    expect(renderToolTitle("bash", args)).toBe("Build the Control UI");
   });
 
   it("evicts least-recently-used successful titles once retention is full", async () => {
@@ -127,11 +132,11 @@ describe("title fetch batching", () => {
       (_, index) => `printf 'successful-title-${index}'`,
     );
     for (const command of commands) {
-      getToolCallTitle("bash", { command });
+      renderToolTitle("bash", { command });
       await vi.advanceTimersByTimeAsync(300);
     }
 
-    const retained = commands.map((command) => getToolCallTitle("bash", { command }));
+    const retained = commands.map((command) => renderToolTitle("bash", { command }));
     expect(retained[0]).toBeUndefined();
     expect(retained.at(-1)).toBe(commands.at(-1));
     expect(retained.filter((title) => title !== undefined).length).toBeLessThan(commands.length);
@@ -154,9 +159,9 @@ describe("title fetch batching", () => {
     );
     const renderTranscript = () => {
       configureToolTitleFetcher({ client, sessionKey: "main" });
-      for (const command of commands) {
-        getToolCallTitle("bash", { command });
-      }
+      scheduleToolTitlesForTranscript(
+        commands.map((command) => ({ name: "bash", args: { command } })),
+      );
     };
 
     renderTranscript();
@@ -172,60 +177,49 @@ describe("title fetch batching", () => {
     expect(requestedIds.size).toBe(commands.length);
   });
 
-  it.each(["release", "owner-switch"] as const)(
-    "resumes when transcript retention removes the saturation cursor after %s",
-    async (transition) => {
-      vi.useFakeTimers();
-      const requestedIds = new Set<string>();
-      const request = vi.fn(async (_method: string, params: unknown) => {
-        const items = (params as { items: Array<{ id: string; input: string }> }).items;
-        for (const item of items) {
-          requestedIds.add(item.id);
-        }
-        return { titles: Object.fromEntries(items.map((item) => [item.id, item.input])) };
-      });
-      const client = { request } as unknown as GatewayBrowserClient;
-      const firstPane = {};
-      const secondPane = {};
-      const commands = Array.from(
-        { length: 120 },
-        (_, index) => `printf 'retained-title-${index}'`,
-      );
-      const renderTranscript = (visibleCommands: string[], renderSource: object) => {
-        configureToolTitleFetcher({ client, sessionKey: "main", renderSource });
-        for (const command of visibleCommands) {
-          getToolCallTitle("bash", { command });
-        }
-      };
-
-      renderTranscript(commands, firstPane);
-      await vi.advanceTimersByTimeAsync(1_000);
-      expect(requestedIds.size).toBe(48);
-
-      const retainedCommands = commands.filter((_, index) => index !== 47);
-      await vi.advanceTimersByTimeAsync(5 * 60_000);
-      renderTranscript(retainedCommands, firstPane);
-      await vi.advanceTimersByTimeAsync(1_000);
-      expect(requestedIds.size).toBe(48);
-
-      renderTranscript(retainedCommands, secondPane);
-      await vi.advanceTimersByTimeAsync(1_000);
-      expect(requestedIds.size).toBe(48);
-
-      if (transition === "release") {
-        releaseToolTitleRenderSource(firstPane);
-      } else {
-        configureToolTitleFetcher({
-          client,
-          sessionKey: "other-session",
-          renderSource: firstPane,
-        });
+  it("resumes when transcript retention removes the saturation cursor", async () => {
+    vi.useFakeTimers();
+    const requestedIds = new Set<string>();
+    const request = vi.fn(async (_method: string, params: unknown) => {
+      const items = (params as { items: Array<{ id: string; input: string }> }).items;
+      for (const item of items) {
+        requestedIds.add(item.id);
       }
-      renderTranscript(retainedCommands, secondPane);
-      await vi.advanceTimersByTimeAsync(1_000);
-      expect(requestedIds.size).toBe(96);
-    },
-  );
+      return { titles: Object.fromEntries(items.map((item) => [item.id, item.input])) };
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const commands = Array.from({ length: 120 }, (_, index) => `printf 'retained-title-${index}'`);
+    let historyVersion = 0;
+    const renderTranscript = (visibleCommands: string[], version = ++historyVersion) => {
+      configureToolTitleFetcher({
+        client,
+        sessionKey: "main",
+        historyVersion: version,
+      });
+      scheduleToolTitlesForTranscript(
+        visibleCommands.map((command) => ({ name: "bash", args: { command } })),
+      );
+    };
+
+    renderTranscript(commands);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(requestedIds.size).toBe(48);
+
+    const retainedCommands = commands.filter((_, index) => index !== 47);
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    const retainedHistoryVersion = ++historyVersion;
+    renderTranscript(retainedCommands, retainedHistoryVersion);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(requestedIds.size).toBe(48);
+
+    renderTranscript(retainedCommands, retainedHistoryVersion);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(requestedIds.size).toBe(48);
+
+    renderTranscript(retainedCommands);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(requestedIds.size).toBe(96);
+  });
 
   it("evicts least-recently-used failures once retention is full", async () => {
     vi.useFakeTimers();
@@ -236,12 +230,12 @@ describe("title fetch batching", () => {
     });
     const commands = Array.from({ length: 240 }, (_, index) => `printf 'failed-title-${index}'`);
     for (const command of commands) {
-      getToolCallTitle("bash", { command });
+      renderToolTitle("bash", { command });
       await vi.advanceTimersByTimeAsync(300);
     }
 
-    getToolCallTitle("bash", { command: commands[0] });
-    getToolCallTitle("bash", { command: commands.at(-1) });
+    renderToolTitle("bash", { command: commands[0] });
+    renderToolTitle("bash", { command: commands.at(-1) });
     await vi.advanceTimersByTimeAsync(300);
 
     expect(request).toHaveBeenCalledTimes(commands.length + 1);
@@ -257,14 +251,14 @@ describe("title fetch batching", () => {
       sessionKey: "main",
     });
     const args = { command: "pnpm test ui/src/pages/chat --reporter verbose" };
-    getToolCallTitle("bash", args);
+    renderToolTitle("bash", args);
     await vi.advanceTimersByTimeAsync(300);
-    getToolCallTitle("bash", args);
+    renderToolTitle("bash", args);
     await vi.advanceTimersByTimeAsync(60_000);
     expect(request).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(4 * 60_000);
-    getToolCallTitle("bash", args);
+    renderToolTitle("bash", args);
     await vi.advanceTimersByTimeAsync(300);
     expect(request).toHaveBeenCalledTimes(2);
   });
@@ -286,11 +280,11 @@ describe("title fetch batching", () => {
     });
     const commands = Array.from({ length: 240 }, (_, index) => `printf 'queued-title-${index}'`);
     for (const command of commands.slice(0, 24)) {
-      getToolCallTitle("bash", { command });
+      renderToolTitle("bash", { command });
     }
     await vi.advanceTimersByTimeAsync(300);
     for (const command of commands.slice(24)) {
-      getToolCallTitle("bash", { command });
+      renderToolTitle("bash", { command });
     }
     await vi.advanceTimersByTimeAsync(5_000);
     expect(request).toHaveBeenCalledTimes(1);
@@ -310,7 +304,7 @@ describe("title fetch batching", () => {
     expect(requestedItems).toBe(48);
 
     for (const command of commands) {
-      getToolCallTitle("bash", { command });
+      renderToolTitle("bash", { command });
     }
     await vi.advanceTimersByTimeAsync(60_000);
     expect(request).toHaveBeenCalledTimes(2);
@@ -329,13 +323,13 @@ describe("title fetch batching", () => {
     for (let sessionIndex = 0; sessionIndex < 2; sessionIndex++) {
       configureToolTitleFetcher({ client, sessionKey: `session-${sessionIndex}` });
       for (let itemIndex = 0; itemIndex < 48; itemIndex++) {
-        getToolCallTitle("bash", {
+        renderToolTitle("bash", {
           command: `printf 'global-title-${sessionIndex}-${itemIndex}'`,
         });
       }
     }
     configureToolTitleFetcher({ client, sessionKey: "overflow-session" });
-    getToolCallTitle("bash", { command: "printf 'global-title-overflow'" });
+    renderToolTitle("bash", { command: "printf 'global-title-overflow'" });
     await vi.advanceTimersByTimeAsync(5_000);
 
     expect(
@@ -361,7 +355,7 @@ describe("title fetch batching", () => {
       client: { request } as unknown as GatewayBrowserClient,
       sessionKey: "main",
     });
-    getToolCallTitle("bash", { command: "pnpm test ui/src/pages/chat --reporter verbose" });
+    renderToolTitle("bash", { command: "pnpm test ui/src/pages/chat --reporter verbose" });
     await vi.advanceTimersByTimeAsync(1_000);
 
     expect(request).toHaveBeenCalledTimes(1);
@@ -391,7 +385,7 @@ describe("title fetch batching", () => {
         client: { request } as unknown as GatewayBrowserClient,
         sessionKey: "main",
       });
-      getToolCallTitle("bash", args);
+      renderToolTitle("bash", args);
       await vi.advanceTimersByTimeAsync(300);
 
       configureToolTitleFetcher({
@@ -407,7 +401,7 @@ describe("title fetch batching", () => {
       expect(dispatchEvent).not.toHaveBeenCalled();
       expect(vi.getTimerCount()).toBe(0);
       if (transition === "replace") {
-        getToolCallTitle("bash", args);
+        renderToolTitle("bash", args);
         await vi.advanceTimersByTimeAsync(300);
         expect(replacementRequest).toHaveBeenCalledOnce();
       }
@@ -433,9 +427,9 @@ describe("title fetch batching", () => {
       client: { request: firstRequest } as unknown as GatewayBrowserClient,
       sessionKey: "main",
     });
-    expect(getToolCallTitle("bash", args)).toBeUndefined();
+    expect(renderToolTitle("bash", args)).toBeUndefined();
     await vi.advanceTimersByTimeAsync(1_000);
-    expect(getToolCallTitle("bash", args)).toBe("First gateway title");
+    expect(renderToolTitle("bash", args)).toBe("First gateway title");
     const firstVersion = getToolTitlesVersion();
     dispatchEvent.mockClear();
 
@@ -444,12 +438,12 @@ describe("title fetch batching", () => {
       sessionKey: "main",
     });
     expect(getToolTitlesVersion()).toBe(firstVersion + 1);
-    expect(getToolCallTitle("bash", args)).toBeUndefined();
+    expect(renderToolTitle("bash", args)).toBeUndefined();
     expect(dispatchEvent).toHaveBeenCalledOnce();
     await vi.advanceTimersByTimeAsync(1_000);
 
     expect(replacementRequest).toHaveBeenCalledOnce();
-    expect(getToolCallTitle("bash", args)).toBe("Replacement gateway title");
+    expect(renderToolTitle("bash", args)).toBe("Replacement gateway title");
   });
 
   it("stops requesting once a disabled response settles queued backlog", async () => {
@@ -463,14 +457,14 @@ describe("title fetch batching", () => {
       agentId: "a",
     });
     for (let index = 0; index < 25; index++) {
-      getToolCallTitle("bash", {
+      renderToolTitle("bash", {
         command: `pnpm run build --filter ui --mode production-${index}`,
       });
     }
     await vi.advanceTimersByTimeAsync(250);
     expect(vi.getTimerCount()).toBe(0);
     // A different eligible call after the disabled response must not schedule.
-    getToolCallTitle("bash", { command: "pnpm test ui/src/pages/chat --runInBand" });
+    renderToolTitle("bash", { command: "pnpm test ui/src/pages/chat --runInBand" });
     await vi.advanceTimersByTimeAsync(1_000);
 
     expect(request).toHaveBeenCalledTimes(1);
@@ -508,7 +502,7 @@ describe("title fetch batching", () => {
         sessionKey: "agent:a:main",
       });
       for (let itemIndex = 0; itemIndex < 24; itemIndex++) {
-        getToolCallTitle("bash", {
+        renderToolTitle("bash", {
           command: `pnpm test ui/src/pages/chat --unusable-${caseIndex}-${itemIndex}`,
         });
       }
@@ -519,12 +513,12 @@ describe("title fetch batching", () => {
       const otherSessionArgs = {
         command: `pnpm test ui/src/pages/chat --unusable-${caseIndex}-other-session`,
       };
-      getToolCallTitle("bash", otherSessionArgs);
+      renderToolTitle("bash", otherSessionArgs);
       await vi.advanceTimersByTimeAsync(1_000);
       expect(
         request.mock.calls.map((call) => (call[1] as { sessionKey: string }).sessionKey),
       ).toEqual(["agent:a:main", "agent:b:main"]);
-      expect(getToolCallTitle("bash", otherSessionArgs)).toBe("Other session title");
+      expect(renderToolTitle("bash", otherSessionArgs)).toBe("Other session title");
       expect(vi.getTimerCount()).toBe(0);
       expect(request).toHaveBeenCalledTimes(2);
       configureToolTitleFetcher({ client: null, sessionKey: null });
@@ -549,13 +543,13 @@ describe("title fetch batching", () => {
       sessionKey: "global",
       agentId: "alice",
     });
-    getToolCallTitle("bash", { command: "pnpm run build --filter ui --mode development" });
+    renderToolTitle("bash", { command: "pnpm run build --filter ui --mode development" });
     configureToolTitleFetcher({
       client,
       sessionKey: "agent:b:main",
       agentId: "b",
     });
-    getToolCallTitle("bash", { command: "pnpm test ui/src/pages/chat --sequence.concurrent" });
+    renderToolTitle("bash", { command: "pnpm test ui/src/pages/chat --sequence.concurrent" });
     await vi.advanceTimersByTimeAsync(1_000);
 
     expect(requests).toEqual([

--- a/ui/src/pages/chat/tool-titles.test.ts
+++ b/ui/src/pages/chat/tool-titles.test.ts
@@ -177,49 +177,66 @@ describe("title fetch batching", () => {
     expect(requestedIds.size).toBe(commands.length);
   });
 
-  it("resumes when transcript retention removes the saturation cursor", async () => {
-    vi.useFakeTimers();
-    const requestedIds = new Set<string>();
-    const request = vi.fn(async (_method: string, params: unknown) => {
-      const items = (params as { items: Array<{ id: string; input: string }> }).items;
-      for (const item of items) {
-        requestedIds.add(item.id);
-      }
-      return { titles: Object.fromEntries(items.map((item) => [item.id, item.input])) };
-    });
-    const client = { request } as unknown as GatewayBrowserClient;
-    const commands = Array.from({ length: 120 }, (_, index) => `printf 'retained-title-${index}'`);
-    let historyVersion = 0;
-    const renderTranscript = (visibleCommands: string[], version = ++historyVersion) => {
-      configureToolTitleFetcher({
-        client,
-        sessionKey: "main",
-        historyVersion: version,
+  it.each(["new-version", "new-owner"] as const)(
+    "resumes when transcript retention removes the saturation cursor on %s",
+    async (transition) => {
+      vi.useFakeTimers();
+      const requestedIds = new Set<string>();
+      const request = vi.fn(async (_method: string, params: unknown) => {
+        const items = (params as { items: Array<{ id: string; input: string }> }).items;
+        for (const item of items) {
+          requestedIds.add(item.id);
+        }
+        return { titles: Object.fromEntries(items.map((item) => [item.id, item.input])) };
       });
-      scheduleToolTitlesForTranscript(
-        visibleCommands.map((command) => ({ name: "bash", args: { command } })),
+      const client = { request } as unknown as GatewayBrowserClient;
+      const commands = Array.from(
+        { length: 120 },
+        (_, index) => `printf 'retained-title-${index}'`,
       );
-    };
+      const firstHistoryOwner = {};
+      const secondHistoryOwner = {};
+      let historyVersion = 0;
+      const renderTranscript = (
+        visibleCommands: string[],
+        owner = firstHistoryOwner,
+        version = ++historyVersion,
+      ) => {
+        configureToolTitleFetcher({
+          client,
+          sessionKey: "main",
+          historyOwner: owner,
+          historyVersion: version,
+        });
+        scheduleToolTitlesForTranscript(
+          visibleCommands.map((command) => ({ name: "bash", args: { command } })),
+        );
+      };
 
-    renderTranscript(commands);
-    await vi.advanceTimersByTimeAsync(1_000);
-    expect(requestedIds.size).toBe(48);
+      renderTranscript(commands);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(requestedIds.size).toBe(48);
 
-    const retainedCommands = commands.filter((_, index) => index !== 47);
-    await vi.advanceTimersByTimeAsync(5 * 60_000);
-    const retainedHistoryVersion = ++historyVersion;
-    renderTranscript(retainedCommands, retainedHistoryVersion);
-    await vi.advanceTimersByTimeAsync(1_000);
-    expect(requestedIds.size).toBe(48);
+      const retainedCommands = commands.filter((_, index) => index !== 47);
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+      const retainedHistoryVersion = ++historyVersion;
+      renderTranscript(retainedCommands, firstHistoryOwner, retainedHistoryVersion);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(requestedIds.size).toBe(48);
 
-    renderTranscript(retainedCommands, retainedHistoryVersion);
-    await vi.advanceTimersByTimeAsync(1_000);
-    expect(requestedIds.size).toBe(48);
+      renderTranscript(retainedCommands, firstHistoryOwner, retainedHistoryVersion);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(requestedIds.size).toBe(48);
 
-    renderTranscript(retainedCommands);
-    await vi.advanceTimersByTimeAsync(1_000);
-    expect(requestedIds.size).toBe(96);
-  });
+      renderTranscript(
+        retainedCommands,
+        transition === "new-owner" ? secondHistoryOwner : firstHistoryOwner,
+        transition === "new-owner" ? retainedHistoryVersion : ++historyVersion,
+      );
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(requestedIds.size).toBe(96);
+    },
+  );
 
   it("evicts least-recently-used failures once retention is full", async () => {
     vi.useFakeTimers();

--- a/ui/src/pages/chat/tool-titles.test.ts
+++ b/ui/src/pages/chat/tool-titles.test.ts
@@ -182,25 +182,31 @@ describe("title fetch batching", () => {
       return { titles: Object.fromEntries(items.map((item) => [item.id, item.input])) };
     });
     const client = { request } as unknown as GatewayBrowserClient;
+    const firstPane = {};
+    const secondPane = {};
     const commands = Array.from({ length: 120 }, (_, index) => `printf 'retained-title-${index}'`);
-    const renderTranscript = (visibleCommands: string[]) => {
-      configureToolTitleFetcher({ client, sessionKey: "main" });
+    const renderTranscript = (visibleCommands: string[], renderSource: object) => {
+      configureToolTitleFetcher({ client, sessionKey: "main", renderSource });
       for (const command of visibleCommands) {
         getToolCallTitle("bash", { command });
       }
     };
 
-    renderTranscript(commands);
+    renderTranscript(commands, firstPane);
     await vi.advanceTimersByTimeAsync(1_000);
     expect(requestedIds.size).toBe(48);
 
     const retainedCommands = commands.filter((_, index) => index !== 47);
     await vi.advanceTimersByTimeAsync(5 * 60_000);
-    renderTranscript(retainedCommands);
+    renderTranscript(retainedCommands, firstPane);
     await vi.advanceTimersByTimeAsync(1_000);
     expect(requestedIds.size).toBe(48);
 
-    renderTranscript(retainedCommands);
+    renderTranscript(retainedCommands, secondPane);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(requestedIds.size).toBe(48);
+
+    renderTranscript(retainedCommands, firstPane);
     await vi.advanceTimersByTimeAsync(1_000);
     expect(requestedIds.size).toBe(96);
   });

--- a/ui/src/pages/chat/tool-titles.test.ts
+++ b/ui/src/pages/chat/tool-titles.test.ts
@@ -454,7 +454,7 @@ describe("title fetch batching", () => {
     expect(request).toHaveBeenCalledTimes(1);
   });
 
-  it("settles unusable title responses without draining queued backlog", async () => {
+  it("settles unusable title responses without discarding another session", async () => {
     vi.useFakeTimers();
     const responses: unknown[] = [
       undefined,
@@ -463,11 +463,22 @@ describe("title fetch batching", () => {
       new Error("gateway unavailable"),
     ];
     for (const [caseIndex, response] of responses.entries()) {
-      const request = vi.fn(async () => {
-        if (response instanceof Error) {
-          throw response;
+      const request = vi.fn(async (_method: string, params: unknown) => {
+        const requestParams = params as {
+          sessionKey: string;
+          items: Array<{ id: string }>;
+        };
+        if (requestParams.sessionKey === "agent:a:main") {
+          if (response instanceof Error) {
+            throw response;
+          }
+          return response;
         }
-        return response;
+        return {
+          titles: Object.fromEntries(
+            requestParams.items.map((item) => [item.id, "Other session title"]),
+          ),
+        };
       });
       const client = { request } as unknown as GatewayBrowserClient;
       configureToolTitleFetcher({
@@ -483,20 +494,17 @@ describe("title fetch batching", () => {
         client,
         sessionKey: "agent:b:main",
       });
-      getToolCallTitle("bash", {
+      const otherSessionArgs = {
         command: `pnpm test ui/src/pages/chat --unusable-${caseIndex}-other-session`,
-      });
-      await vi.advanceTimersByTimeAsync(250);
+      };
+      getToolCallTitle("bash", otherSessionArgs);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(
+        request.mock.calls.map((call) => (call[1] as { sessionKey: string }).sessionKey),
+      ).toEqual(["agent:a:main", "agent:b:main"]);
+      expect(getToolCallTitle("bash", otherSessionArgs)).toBe("Other session title");
       expect(vi.getTimerCount()).toBe(0);
-      configureToolTitleFetcher({
-        client,
-        sessionKey: "agent:b:main",
-      });
-      getToolCallTitle("bash", {
-        command: `pnpm test ui/src/pages/chat --unusable-follow-up-${caseIndex}`,
-      });
-      await vi.advanceTimersByTimeAsync(60_000);
-      expect(request).toHaveBeenCalledTimes(1);
+      expect(request).toHaveBeenCalledTimes(2);
       configureToolTitleFetcher({ client: null, sessionKey: null });
     }
   });

--- a/ui/src/pages/chat/tool-titles.test.ts
+++ b/ui/src/pages/chat/tool-titles.test.ts
@@ -6,6 +6,7 @@ import {
   configureToolTitleFetcher,
   getToolCallTitle,
   getToolTitlesVersion,
+  releaseToolTitleRenderSource,
   subscribeToolTitleChanges,
 } from "./tool-titles.ts";
 
@@ -206,7 +207,12 @@ describe("title fetch batching", () => {
     await vi.advanceTimersByTimeAsync(1_000);
     expect(requestedIds.size).toBe(48);
 
-    renderTranscript(retainedCommands, firstPane);
+    releaseToolTitleRenderSource(firstPane);
+    renderTranscript(retainedCommands, secondPane);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(requestedIds.size).toBe(48);
+
+    renderTranscript(retainedCommands, secondPane);
     await vi.advanceTimersByTimeAsync(1_000);
     expect(requestedIds.size).toBe(96);
   });

--- a/ui/src/pages/chat/tool-titles.test.ts
+++ b/ui/src/pages/chat/tool-titles.test.ts
@@ -2,10 +2,16 @@
 // Control UI tests cover tool-title request eligibility and the title store.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { configureToolTitleFetcher, getToolCallTitle } from "./tool-titles.ts";
+import {
+  configureToolTitleFetcher,
+  getToolCallTitle,
+  getToolTitlesVersion,
+  subscribeToolTitleChanges,
+} from "./tool-titles.ts";
 
 afterEach(() => {
-  configureToolTitleFetcher({ client: null, sessionKey: null, onTitlesChanged: null });
+  configureToolTitleFetcher({ client: null, sessionKey: null });
+  vi.unstubAllGlobals();
   vi.useRealTimers();
 });
 
@@ -33,7 +39,6 @@ describe("title fetch batching", () => {
     configureToolTitleFetcher({
       client: { request } as unknown as GatewayBrowserClient,
       sessionKey: "main",
-      onTitlesChanged: null,
     });
 
     getToolCallTitle("bash", { command: "short" });
@@ -52,7 +57,6 @@ describe("title fetch batching", () => {
     configureToolTitleFetcher({
       client: { request } as unknown as GatewayBrowserClient,
       sessionKey: "main",
-      onTitlesChanged: null,
     });
 
     getToolCallTitle("bash", { command: "12345678901" });
@@ -82,7 +86,6 @@ describe("title fetch batching", () => {
     configureToolTitleFetcher({
       client: { request } as unknown as GatewayBrowserClient,
       sessionKey: "main",
-      onTitlesChanged: null,
     });
     const args = { command: "pnpm test ui/src/pages/chat --reporter verbose" };
     getToolCallTitle("bash", args);
@@ -101,7 +104,6 @@ describe("title fetch batching", () => {
     configureToolTitleFetcher({
       client: { request } as unknown as GatewayBrowserClient,
       sessionKey: "main",
-      onTitlesChanged: null,
     });
     const args = { command: "pnpm run build --filter ui --mode production" };
     expect(getToolCallTitle("bash", args)).toBeUndefined();
@@ -109,39 +111,326 @@ describe("title fetch batching", () => {
     expect(getToolCallTitle("bash", args)).toBe("Build the Control UI");
   });
 
-  it("notifies every pane that contributed rows to a title batch", async () => {
+  it("evicts least-recently-used successful titles once retention is full", async () => {
     vi.useFakeTimers();
-    const client = {
-      request: vi.fn(async (_method: string, params: unknown) => {
-        const items = (params as { items: Array<{ id: string }> }).items;
-        return { titles: Object.fromEntries(items.map((item) => [item.id, "Titled"])) };
-      }),
-    } as unknown as GatewayBrowserClient;
-    const notifyA = vi.fn();
-    const notifyB = vi.fn();
-
-    // Two panes on the same session/agent enqueue into one batch.
-    configureToolTitleFetcher({
-      client,
-      sessionKey: "agent:a:main",
-      agentId: "a",
-      onTitlesChanged: notifyA,
+    const request = vi.fn(async (_method: string, params: unknown) => {
+      const items = (params as { items: Array<{ id: string; input: string }> }).items;
+      return { titles: Object.fromEntries(items.map((item) => [item.id, item.input])) };
     });
-    getToolCallTitle("bash", { command: "pnpm run build --filter ui --reporter append-only" });
     configureToolTitleFetcher({
-      client,
-      sessionKey: "agent:a:main",
-      agentId: "a",
-      onTitlesChanged: notifyB,
+      client: { request } as unknown as GatewayBrowserClient,
+      sessionKey: "main",
+    });
+    const commands = Array.from(
+      { length: 240 },
+      (_, index) => `printf 'successful-title-${index}'`,
+    );
+    for (const command of commands) {
+      getToolCallTitle("bash", { command });
+      await vi.advanceTimersByTimeAsync(300);
+    }
+
+    const retained = commands.map((command) => getToolCallTitle("bash", { command }));
+    expect(retained[0]).toBeUndefined();
+    expect(retained.at(-1)).toBe(commands.at(-1));
+    expect(retained.filter((title) => title !== undefined).length).toBeLessThan(commands.length);
+  });
+
+  it("continues admitting later titles after earlier successes are evicted", async () => {
+    vi.useFakeTimers();
+    const requestedIds = new Set<string>();
+    const request = vi.fn(async (_method: string, params: unknown) => {
+      const items = (params as { items: Array<{ id: string; input: string }> }).items;
+      for (const item of items) {
+        requestedIds.add(item.id);
+      }
+      return { titles: Object.fromEntries(items.map((item) => [item.id, item.input])) };
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const commands = Array.from(
+      { length: 240 },
+      (_, index) => `printf 'progressive-title-${index}'`,
+    );
+    const renderTranscript = () => {
+      configureToolTitleFetcher({ client, sessionKey: "main" });
+      for (const command of commands) {
+        getToolCallTitle("bash", { command });
+      }
+    };
+
+    renderTranscript();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(requestedIds.size).toBe(48);
+
+    for (let retry = 0; retry < 4; retry++) {
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+      renderTranscript();
+      await vi.advanceTimersByTimeAsync(1_000);
+    }
+
+    expect(requestedIds.size).toBe(commands.length);
+  });
+
+  it("resumes when transcript retention removes the saturation cursor", async () => {
+    vi.useFakeTimers();
+    const requestedIds = new Set<string>();
+    const request = vi.fn(async (_method: string, params: unknown) => {
+      const items = (params as { items: Array<{ id: string; input: string }> }).items;
+      for (const item of items) {
+        requestedIds.add(item.id);
+      }
+      return { titles: Object.fromEntries(items.map((item) => [item.id, item.input])) };
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const commands = Array.from({ length: 120 }, (_, index) => `printf 'retained-title-${index}'`);
+    const renderTranscript = (visibleCommands: string[]) => {
+      configureToolTitleFetcher({ client, sessionKey: "main" });
+      for (const command of visibleCommands) {
+        getToolCallTitle("bash", { command });
+      }
+    };
+
+    renderTranscript(commands);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(requestedIds.size).toBe(48);
+
+    const retainedCommands = commands.filter((_, index) => index !== 47);
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    renderTranscript(retainedCommands);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(requestedIds.size).toBe(48);
+
+    renderTranscript(retainedCommands);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(requestedIds.size).toBe(96);
+  });
+
+  it("evicts least-recently-used failures once retention is full", async () => {
+    vi.useFakeTimers();
+    const request = vi.fn(async () => ({ titles: {} }));
+    configureToolTitleFetcher({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessionKey: "main",
+    });
+    const commands = Array.from({ length: 240 }, (_, index) => `printf 'failed-title-${index}'`);
+    for (const command of commands) {
+      getToolCallTitle("bash", { command });
+      await vi.advanceTimersByTimeAsync(300);
+    }
+
+    getToolCallTitle("bash", { command: commands[0] });
+    getToolCallTitle("bash", { command: commands.at(-1) });
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(request).toHaveBeenCalledTimes(commands.length + 1);
+  });
+
+  it("retries gateway failures after the failure suppression window expires", async () => {
+    vi.useFakeTimers();
+    const request = vi.fn(async () => {
+      throw new Error("utility model unavailable");
+    });
+    configureToolTitleFetcher({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessionKey: "main",
+    });
+    const args = { command: "pnpm test ui/src/pages/chat --reporter verbose" };
+    getToolCallTitle("bash", args);
+    await vi.advanceTimersByTimeAsync(300);
+    getToolCallTitle("bash", args);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(request).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(4 * 60_000);
+    getToolCallTitle("bash", args);
+    await vi.advanceTimersByTimeAsync(300);
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds a 240-item session backlog and keeps one request in flight", async () => {
+    vi.useFakeTimers();
+    let resolveRequest: ((value: { titles: Record<string, string> }) => void) | undefined;
+    let requestedIds: string[] = [];
+    const request = vi.fn(
+      async (_method: string, params: unknown) =>
+        await new Promise<{ titles: Record<string, string> }>((resolve) => {
+          requestedIds = (params as { items: Array<{ id: string }> }).items.map((item) => item.id);
+          resolveRequest = resolve;
+        }),
+    );
+    configureToolTitleFetcher({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessionKey: "main",
+    });
+    const commands = Array.from({ length: 240 }, (_, index) => `printf 'queued-title-${index}'`);
+    for (const command of commands.slice(0, 24)) {
+      getToolCallTitle("bash", { command });
+    }
+    await vi.advanceTimersByTimeAsync(300);
+    for (const command of commands.slice(24)) {
+      getToolCallTitle("bash", { command });
+    }
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(request).toHaveBeenCalledTimes(1);
+
+    resolveRequest?.({
+      titles: Object.fromEntries(requestedIds.map((id) => [id, "Generated title"])),
+    });
+    await vi.advanceTimersByTimeAsync(10_000);
+    const requestedItems = request.mock.calls.reduce(
+      (count, call) => count + ((call[1] as { items: unknown[] }).items.length ?? 0),
+      0,
+    );
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(
+      request.mock.calls.every((call) => (call[1] as { items: unknown[] }).items.length <= 24),
+    ).toBe(true);
+    expect(requestedItems).toBe(48);
+
+    for (const command of commands) {
+      getToolCallTitle("bash", { command });
+    }
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds global admission across sessions", async () => {
+    vi.useFakeTimers();
+    const requestedInputs: string[] = [];
+    const request = vi.fn(async (_method: string, params: unknown) => {
+      const items = (params as { items: Array<{ id: string; input: string }> }).items;
+      requestedInputs.push(...items.map((item) => item.input));
+      return { titles: Object.fromEntries(items.map((item) => [item.id, item.input])) };
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+
+    for (let sessionIndex = 0; sessionIndex < 3; sessionIndex++) {
+      configureToolTitleFetcher({ client, sessionKey: `session-${sessionIndex}` });
+      for (let itemIndex = 0; itemIndex < 32; itemIndex++) {
+        getToolCallTitle("bash", {
+          command: `printf 'global-title-${sessionIndex}-${itemIndex}'`,
+        });
+      }
+    }
+    configureToolTitleFetcher({ client, sessionKey: "overflow-session" });
+    getToolCallTitle("bash", { command: "printf 'global-title-overflow'" });
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(
+      request.mock.calls.every((call) => (call[1] as { items: unknown[] }).items.length <= 24),
+    ).toBe(true);
+    expect(requestedInputs).toHaveLength(96);
+    expect(requestedInputs).not.toContain("printf 'global-title-overflow'");
+  });
+
+  it("emits one title-change event when a batch stores generated titles", async () => {
+    vi.useFakeTimers();
+    const events = new EventTarget();
+    vi.stubGlobal("addEventListener", events.addEventListener.bind(events));
+    vi.stubGlobal("removeEventListener", events.removeEventListener.bind(events));
+    vi.stubGlobal("dispatchEvent", events.dispatchEvent.bind(events));
+    const listener = vi.fn();
+    const unsubscribe = subscribeToolTitleChanges(listener);
+    const request = vi.fn(async (_method: string, params: unknown) => {
+      const [item] = (params as { items: Array<{ id: string }> }).items;
+      return { titles: item ? { [item.id]: "Generated title" } : {} };
+    });
+    configureToolTitleFetcher({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessionKey: "main",
     });
     getToolCallTitle("bash", { command: "pnpm test ui/src/pages/chat --reporter verbose" });
     await vi.advanceTimersByTimeAsync(1_000);
 
-    expect(notifyA).toHaveBeenCalled();
-    expect(notifyB).toHaveBeenCalled();
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledOnce();
+    unsubscribe();
   });
 
-  it("stops requesting for the session once the gateway reports titles disabled", async () => {
+  it("retires in-flight work when the fetcher lifecycle changes", async () => {
+    vi.useFakeTimers();
+    const dispatchEvent = vi.fn((_event: Event) => true);
+    vi.stubGlobal("dispatchEvent", dispatchEvent);
+    for (const transition of ["replace", "disconnect"] as const) {
+      let resolveRequest:
+        | ((value: { titles: Record<string, string>; disabled?: boolean }) => void)
+        | undefined;
+      let requestedId = "";
+      const replacementRequest = vi.fn(async () => ({ titles: {} }));
+      const request = vi.fn(
+        async (_method: string, params: unknown) =>
+          await new Promise<{ titles: Record<string, string>; disabled?: boolean }>((resolve) => {
+            requestedId = (params as { items: Array<{ id: string }> }).items[0]?.id ?? "";
+            resolveRequest = resolve;
+          }),
+      );
+      const args = { command: `pnpm test ui/src/pages/chat --mode ${transition}` };
+      configureToolTitleFetcher({
+        client: { request } as unknown as GatewayBrowserClient,
+        sessionKey: "main",
+      });
+      getToolCallTitle("bash", args);
+      await vi.advanceTimersByTimeAsync(300);
+
+      configureToolTitleFetcher({
+        client:
+          transition === "replace"
+            ? ({ request: replacementRequest } as unknown as GatewayBrowserClient)
+            : null,
+        sessionKey: transition === "replace" ? "replacement" : null,
+      });
+      resolveRequest?.({ titles: { [requestedId]: "Stale generated title" } });
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(dispatchEvent).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+      if (transition === "replace") {
+        getToolCallTitle("bash", args);
+        await vi.advanceTimersByTimeAsync(300);
+        expect(replacementRequest).toHaveBeenCalledOnce();
+      }
+      configureToolTitleFetcher({ client: null, sessionKey: null });
+    }
+  });
+
+  it("invalidates cached titles when the gateway client is replaced", async () => {
+    vi.useFakeTimers();
+    const dispatchEvent = vi.fn((_event: Event) => true);
+    vi.stubGlobal("dispatchEvent", dispatchEvent);
+    const firstRequest = vi.fn(async (_method: string, params: unknown) => {
+      const [item] = (params as { items: Array<{ id: string }> }).items;
+      return { titles: item ? { [item.id]: "First gateway title" } : {} };
+    });
+    const replacementRequest = vi.fn(async (_method: string, params: unknown) => {
+      const [item] = (params as { items: Array<{ id: string }> }).items;
+      return { titles: item ? { [item.id]: "Replacement gateway title" } : {} };
+    });
+    const args = { command: "pnpm test ui/src/pages/chat --reporter verbose" };
+
+    configureToolTitleFetcher({
+      client: { request: firstRequest } as unknown as GatewayBrowserClient,
+      sessionKey: "main",
+    });
+    expect(getToolCallTitle("bash", args)).toBeUndefined();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(getToolCallTitle("bash", args)).toBe("First gateway title");
+    const firstVersion = getToolTitlesVersion();
+    dispatchEvent.mockClear();
+
+    configureToolTitleFetcher({
+      client: { request: replacementRequest } as unknown as GatewayBrowserClient,
+      sessionKey: "main",
+    });
+    expect(getToolTitlesVersion()).toBe(firstVersion + 1);
+    expect(getToolCallTitle("bash", args)).toBeUndefined();
+    expect(dispatchEvent).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(replacementRequest).toHaveBeenCalledOnce();
+    expect(getToolCallTitle("bash", args)).toBe("Replacement gateway title");
+  });
+
+  it("stops requesting once a disabled response settles queued backlog", async () => {
     vi.useFakeTimers();
     const request = vi.fn(async () => ({ titles: {}, disabled: true }));
     const client = { request } as unknown as GatewayBrowserClient;
@@ -150,15 +439,66 @@ describe("title fetch batching", () => {
       client,
       sessionKey: "agent:a:main",
       agentId: "a",
-      onTitlesChanged: null,
     });
-    getToolCallTitle("bash", { command: "pnpm run build --filter ui --mode production" });
-    await vi.advanceTimersByTimeAsync(1_000);
+    for (let index = 0; index < 25; index++) {
+      getToolCallTitle("bash", {
+        command: `pnpm run build --filter ui --mode production-${index}`,
+      });
+    }
+    await vi.advanceTimersByTimeAsync(250);
+    expect(vi.getTimerCount()).toBe(0);
     // A different eligible call after the disabled response must not schedule.
     getToolCallTitle("bash", { command: "pnpm test ui/src/pages/chat --runInBand" });
     await vi.advanceTimersByTimeAsync(1_000);
 
     expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("settles unusable title responses without draining queued backlog", async () => {
+    vi.useFakeTimers();
+    const responses: unknown[] = [
+      undefined,
+      { titles: null },
+      { titles: {} },
+      new Error("gateway unavailable"),
+    ];
+    for (const [caseIndex, response] of responses.entries()) {
+      const request = vi.fn(async () => {
+        if (response instanceof Error) {
+          throw response;
+        }
+        return response;
+      });
+      const client = { request } as unknown as GatewayBrowserClient;
+      configureToolTitleFetcher({
+        client,
+        sessionKey: "agent:a:main",
+      });
+      for (let itemIndex = 0; itemIndex < 24; itemIndex++) {
+        getToolCallTitle("bash", {
+          command: `pnpm test ui/src/pages/chat --unusable-${caseIndex}-${itemIndex}`,
+        });
+      }
+      configureToolTitleFetcher({
+        client,
+        sessionKey: "agent:b:main",
+      });
+      getToolCallTitle("bash", {
+        command: `pnpm test ui/src/pages/chat --unusable-${caseIndex}-other-session`,
+      });
+      await vi.advanceTimersByTimeAsync(250);
+      expect(vi.getTimerCount()).toBe(0);
+      configureToolTitleFetcher({
+        client,
+        sessionKey: "agent:b:main",
+      });
+      getToolCallTitle("bash", {
+        command: `pnpm test ui/src/pages/chat --unusable-follow-up-${caseIndex}`,
+      });
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(request).toHaveBeenCalledTimes(1);
+      configureToolTitleFetcher({ client: null, sessionKey: null });
+    }
   });
 
   it("sends queued items with the session and agent captured at schedule time", async () => {
@@ -167,7 +507,8 @@ describe("title fetch batching", () => {
     const client = {
       request: vi.fn(async (_method: string, params: unknown) => {
         requests.push(params as { sessionKey: string; agentId?: string });
-        return { titles: {} };
+        const items = (params as { items: Array<{ id: string }> }).items;
+        return { titles: Object.fromEntries(items.map((item) => [item.id, "Generated title"])) };
       }),
     } as unknown as GatewayBrowserClient;
 
@@ -177,14 +518,12 @@ describe("title fetch batching", () => {
       client,
       sessionKey: "global",
       agentId: "alice",
-      onTitlesChanged: null,
     });
     getToolCallTitle("bash", { command: "pnpm run build --filter ui --mode development" });
     configureToolTitleFetcher({
       client,
       sessionKey: "agent:b:main",
       agentId: "b",
-      onTitlesChanged: null,
     });
     getToolCallTitle("bash", { command: "pnpm test ui/src/pages/chat --sequence.concurrent" });
     await vi.advanceTimersByTimeAsync(1_000);

--- a/ui/src/pages/chat/tool-titles.ts
+++ b/ui/src/pages/chat/tool-titles.ts
@@ -28,6 +28,7 @@ const MIN_COMMAND_CHARS_FOR_TITLE = 12;
 const MIN_GENERIC_INPUT_CHARS_FOR_TITLE = 120;
 
 const TOOL_TITLES_CHANGED_EVENT = "openclaw:tool-titles-changed";
+const DEFAULT_HISTORY_OWNER = {};
 
 export function subscribeToolTitleChanges(listener: () => void): () => void {
   globalThis.addEventListener(TOOL_TITLES_CHANGED_EVENT, listener);
@@ -61,6 +62,7 @@ type PendingItem = {
 type SaturatedSession = {
   expiresAt: number;
   resumeAfterKey: string | null;
+  cursorMissingHistoryOwner: object | null;
   cursorMissingHistoryVersion: number | null;
 };
 type ToolTitlesResult = { titles?: Record<string, string>; disabled?: boolean };
@@ -74,6 +76,7 @@ let activeClient: GatewayBrowserClient | null = null;
 let activeSessionKey: string | null = null;
 let activeAgentId: string | null = null;
 let activeSchedulingEnabled = true;
+let activeHistoryOwner = DEFAULT_HISTORY_OWNER;
 let activeHistoryVersion = 0;
 let fetcherGeneration = 0;
 let activeFlush: object | null = null;
@@ -163,6 +166,7 @@ function saturateSession(ownerKey: string, resumeAfterKey: string | null): void 
     {
       expiresAt: Date.now() + SATURATED_SESSION_RETRY_MS,
       resumeAfterKey,
+      cursorMissingHistoryOwner: null,
       cursorMissingHistoryVersion: null,
     },
     MAX_SATURATED_SESSIONS,
@@ -192,10 +196,14 @@ function resolveTranscriptStartIndex(
     return cursorIndex + 1;
   }
   if (saturation.cursorMissingHistoryVersion === null) {
+    saturation.cursorMissingHistoryOwner = activeHistoryOwner;
     saturation.cursorMissingHistoryVersion = activeHistoryVersion;
     return null;
   }
-  if (saturation.cursorMissingHistoryVersion === activeHistoryVersion) {
+  if (
+    saturation.cursorMissingHistoryOwner === activeHistoryOwner &&
+    saturation.cursorMissingHistoryVersion === activeHistoryVersion
+  ) {
     return null;
   }
   // The prior complete projection did not contain the cursor, so retention or
@@ -346,6 +354,7 @@ export function configureToolTitleFetcher(params: {
   /** Only the active presented pane schedules work; sibling panes read the shared cache. */
   schedulingEnabled?: boolean;
   /** History owner revision; duplicate renders of one request retain the same value. */
+  historyOwner?: object;
   historyVersion?: number;
 }): void {
   if (params.client !== activeClient) {
@@ -357,6 +366,7 @@ export function configureToolTitleFetcher(params: {
   activeSessionKey = params.sessionKey;
   activeAgentId = params.agentId ?? null;
   activeSchedulingEnabled = params.schedulingEnabled !== false;
+  activeHistoryOwner = params.historyOwner ?? DEFAULT_HISTORY_OWNER;
   activeHistoryVersion = params.historyVersion ?? 0;
 }
 

--- a/ui/src/pages/chat/tool-titles.ts
+++ b/ui/src/pages/chat/tool-titles.ts
@@ -199,20 +199,20 @@ function shouldSuppressSaturatedSession(ownerKey: string, requestKey: string): b
   return false;
 }
 
-function discardQueuedBurst(headOwnerKey: string): void {
-  if (queue.size === 0) {
+function discardQueuedOwner(ownerKey: string): void {
+  let discarded = false;
+  for (const [key, item] of queue) {
+    if (item.ownerKey === ownerKey) {
+      queue.delete(key);
+      discarded = true;
+    }
+  }
+  if (!discarded) {
     return;
   }
-  // Every discarded pane must share the cooldown. Otherwise its next ordinary
-  // repaint immediately reconstructs the backlog that this failure terminated.
-  const ownerKeys = new Set([headOwnerKey]);
-  for (const item of queue.values()) {
-    ownerKeys.add(item.ownerKey);
-  }
-  queue.clear();
-  for (const ownerKey of ownerKeys) {
-    saturateSession(ownerKey, null);
-  }
+  // Cool down only the failed owner. Other sessions can resolve through a
+  // different utility model and must retain their independently queued work.
+  saturateSession(ownerKey, null);
 }
 
 function countSessionWork(ownerKey: string): number {
@@ -424,7 +424,7 @@ async function flushTitleQueue(generation: number): Promise<void> {
       }
     }
     if (!changed) {
-      discardQueuedBurst(head.ownerKey);
+      discardQueuedOwner(head.ownerKey);
       return;
     }
     notifyTitlesChanged();
@@ -437,7 +437,7 @@ async function flushTitleQueue(generation: number): Promise<void> {
     for (const item of batch) {
       storeFailure(item.key);
     }
-    discardQueuedBurst(head.ownerKey);
+    discardQueuedOwner(head.ownerKey);
   } finally {
     for (const item of batch) {
       if (pendingKeys.get(item.key) === item) {

--- a/ui/src/pages/chat/tool-titles.ts
+++ b/ui/src/pages/chat/tool-titles.ts
@@ -28,6 +28,7 @@ const MIN_COMMAND_CHARS_FOR_TITLE = 12;
 const MIN_GENERIC_INPUT_CHARS_FOR_TITLE = 120;
 
 const TOOL_TITLES_CHANGED_EVENT = "openclaw:tool-titles-changed";
+const DEFAULT_RENDER_SOURCE = {};
 
 export function subscribeToolTitleChanges(listener: () => void): () => void {
   globalThis.addEventListener(TOOL_TITLES_CHANGED_EVENT, listener);
@@ -61,6 +62,7 @@ type PendingItem = {
 type SaturatedSession = {
   expiresAt: number;
   resumeAfterKey: string | null;
+  searchRenderSource: object | null;
   searchRenderEpoch: number | null;
 };
 type ToolTitlesResult = { titles?: Record<string, string>; disabled?: boolean };
@@ -73,8 +75,10 @@ let flushTimer: ReturnType<typeof setTimeout> | null = null;
 let activeClient: GatewayBrowserClient | null = null;
 let activeSessionKey: string | null = null;
 let activeAgentId: string | null = null;
+let activeRenderSource = DEFAULT_RENDER_SOURCE;
+let activeRenderEpoch = 0;
+const renderEpochs = new WeakMap<object, number>();
 let fetcherGeneration = 0;
-let fetcherRenderEpoch = 0;
 let activeFlush: object | null = null;
 
 /** FNV-1a over name + serialized args; stable across renders of one call. */
@@ -162,6 +166,7 @@ function saturateSession(ownerKey: string, resumeAfterKey: string | null): void 
     {
       expiresAt: Date.now() + SATURATED_SESSION_RETRY_MS,
       resumeAfterKey,
+      searchRenderSource: null,
       searchRenderEpoch: null,
     },
     MAX_SATURATED_SESSIONS,
@@ -187,10 +192,14 @@ function shouldSuppressSaturatedSession(ownerKey: string, requestKey: string): b
     return true;
   }
   if (saturation.searchRenderEpoch === null) {
-    saturation.searchRenderEpoch = fetcherRenderEpoch;
+    saturation.searchRenderSource = activeRenderSource;
+    saturation.searchRenderEpoch = activeRenderEpoch;
     return true;
   }
-  if (saturation.searchRenderEpoch === fetcherRenderEpoch) {
+  if (
+    saturation.searchRenderSource !== activeRenderSource ||
+    saturation.searchRenderEpoch === activeRenderEpoch
+  ) {
     return true;
   }
   // The prior complete render did not contain the cursor, so retention or
@@ -315,6 +324,8 @@ export function configureToolTitleFetcher(params: {
   sessionKey: string | null;
   /** Selected agent; required for global-session keys where the gateway would otherwise resolve the default agent. */
   agentId?: string | null;
+  /** Stable identity of the pane performing this render. */
+  renderSource?: object;
 }): void {
   if (params.client !== activeClient) {
     retireTransientState();
@@ -324,7 +335,9 @@ export function configureToolTitleFetcher(params: {
   activeClient = params.client;
   activeSessionKey = params.sessionKey;
   activeAgentId = params.agentId ?? null;
-  fetcherRenderEpoch += 1;
+  activeRenderSource = params.renderSource ?? DEFAULT_RENDER_SOURCE;
+  activeRenderEpoch = (renderEpochs.get(activeRenderSource) ?? 0) + 1;
+  renderEpochs.set(activeRenderSource, activeRenderEpoch);
 }
 
 function scheduleTitleRequest(name: string, request: { key: string; input: string }): void {

--- a/ui/src/pages/chat/tool-titles.ts
+++ b/ui/src/pages/chat/tool-titles.ts
@@ -28,25 +28,10 @@ const MIN_COMMAND_CHARS_FOR_TITLE = 12;
 const MIN_GENERIC_INPUT_CHARS_FOR_TITLE = 120;
 
 const TOOL_TITLES_CHANGED_EVENT = "openclaw:tool-titles-changed";
-const DEFAULT_RENDER_SOURCE = {};
 
 export function subscribeToolTitleChanges(listener: () => void): () => void {
   globalThis.addEventListener(TOOL_TITLES_CHANGED_EVENT, listener);
   return () => globalThis.removeEventListener(TOOL_TITLES_CHANGED_EVENT, listener);
-}
-
-export function releaseToolTitleRenderSource(renderSource: object): void {
-  renderEpochs.delete(renderSource);
-  renderOwners.delete(renderSource);
-  if (activeRenderSource === renderSource) {
-    activeRenderSource = DEFAULT_RENDER_SOURCE;
-    activeRenderEpoch = renderEpochs.get(DEFAULT_RENDER_SOURCE) ?? 0;
-  }
-  for (const [ownerKey, saturation] of saturatedSessions) {
-    if (saturation.searchRenderSource === renderSource) {
-      saturatedSessions.delete(ownerKey);
-    }
-  }
 }
 
 const titlesByKey = new Map<string, string>();
@@ -76,8 +61,7 @@ type PendingItem = {
 type SaturatedSession = {
   expiresAt: number;
   resumeAfterKey: string | null;
-  searchRenderSource: object | null;
-  searchRenderEpoch: number | null;
+  cursorMissingHistoryVersion: number | null;
 };
 type ToolTitlesResult = { titles?: Record<string, string>; disabled?: boolean };
 
@@ -89,10 +73,8 @@ let flushTimer: ReturnType<typeof setTimeout> | null = null;
 let activeClient: GatewayBrowserClient | null = null;
 let activeSessionKey: string | null = null;
 let activeAgentId: string | null = null;
-let activeRenderSource = DEFAULT_RENDER_SOURCE;
-let activeRenderEpoch = 0;
-const renderEpochs = new WeakMap<object, number>();
-const renderOwners = new WeakMap<object, string>();
+let activeSchedulingEnabled = true;
+let activeHistoryVersion = 0;
 let fetcherGeneration = 0;
 let activeFlush: object | null = null;
 
@@ -181,46 +163,45 @@ function saturateSession(ownerKey: string, resumeAfterKey: string | null): void 
     {
       expiresAt: Date.now() + SATURATED_SESSION_RETRY_MS,
       resumeAfterKey,
-      searchRenderSource: null,
-      searchRenderEpoch: null,
+      cursorMissingHistoryVersion: null,
     },
     MAX_SATURATED_SESSIONS,
   );
 }
 
-function shouldSuppressSaturatedSession(ownerKey: string, requestKey: string): boolean {
+function resolveTranscriptStartIndex(
+  ownerKey: string,
+  requests: readonly { key: string }[],
+): number | null {
   const saturation = readLru(saturatedSessions, ownerKey);
   if (!saturation) {
-    return false;
+    return 0;
   }
   if (saturation.expiresAt > Date.now()) {
-    return true;
+    return null;
   }
   if (saturation.resumeAfterKey === null) {
     saturatedSessions.delete(ownerKey);
-    return false;
+    return 0;
   }
-  if (requestKey === saturation.resumeAfterKey) {
+  const cursorIndex = requests.findIndex((request) => request.key === saturation.resumeAfterKey);
+  if (cursorIndex >= 0) {
     // Resume after the last admitted row. Re-admitting LRU-evicted rows before
     // this cursor would spend every later bounded window without making progress.
     saturatedSessions.delete(ownerKey);
-    return true;
+    return cursorIndex + 1;
   }
-  if (saturation.searchRenderEpoch === null) {
-    saturation.searchRenderSource = activeRenderSource;
-    saturation.searchRenderEpoch = activeRenderEpoch;
-    return true;
+  if (saturation.cursorMissingHistoryVersion === null) {
+    saturation.cursorMissingHistoryVersion = activeHistoryVersion;
+    return null;
   }
-  if (
-    saturation.searchRenderSource !== activeRenderSource ||
-    saturation.searchRenderEpoch === activeRenderEpoch
-  ) {
-    return true;
+  if (saturation.cursorMissingHistoryVersion === activeHistoryVersion) {
+    return null;
   }
-  // The prior complete render did not contain the cursor, so retention or
-  // compaction removed it. Resume from this render's first remaining row.
+  // The prior complete projection did not contain the cursor, so retention or
+  // compaction removed it. Resume from this projection's first remaining row.
   saturatedSessions.delete(ownerKey);
-  return false;
+  return 0;
 }
 
 function discardQueuedOwner(ownerKey: string): void {
@@ -321,17 +302,40 @@ export function getToolCallTitle(name: string, args: unknown): string | undefine
   if (!request) {
     return undefined;
   }
-  const admissionSuppressed =
-    activeSessionKey !== null &&
-    shouldSuppressSaturatedSession(queueOwnerKey(activeSessionKey, activeAgentId), request.key);
-  const cached = readLru(titlesByKey, request.key);
-  if (cached) {
-    return cached;
+  return readLru(titlesByKey, request.key);
+}
+
+export function scheduleToolTitlesForTranscript(
+  candidates: readonly { name: string; args: unknown }[],
+): void {
+  if (!activeSchedulingEnabled || titlesDisabledByGateway || !activeClient || !activeSessionKey) {
+    return;
   }
-  if (!admissionSuppressed) {
-    scheduleTitleRequest(name, request);
+  const requests: Array<{ key: string; input: string; name: string }> = [];
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    const request = resolveToolTitleRequest(candidate.name, candidate.args);
+    if (!request || seen.has(request.key)) {
+      continue;
+    }
+    seen.add(request.key);
+    requests.push({ ...request, name: candidate.name });
   }
-  return undefined;
+  const ownerKey = queueOwnerKey(activeSessionKey, activeAgentId);
+  const startIndex = resolveTranscriptStartIndex(ownerKey, requests);
+  if (startIndex === null) {
+    return;
+  }
+  for (let index = startIndex; index < requests.length; index++) {
+    const request = requests[index];
+    if (!request) {
+      continue;
+    }
+    scheduleTitleRequest(request.name, request);
+    if (saturatedSessions.has(ownerKey)) {
+      break;
+    }
+  }
 }
 
 export function configureToolTitleFetcher(params: {
@@ -339,30 +343,21 @@ export function configureToolTitleFetcher(params: {
   sessionKey: string | null;
   /** Selected agent; required for global-session keys where the gateway would otherwise resolve the default agent. */
   agentId?: string | null;
-  /** Stable identity of the pane performing this render. */
-  renderSource?: object;
+  /** Only the active presented pane schedules work; sibling panes read the shared cache. */
+  schedulingEnabled?: boolean;
+  /** History owner revision; duplicate renders of one request retain the same value. */
+  historyVersion?: number;
 }): void {
   if (params.client !== activeClient) {
     retireTransientState();
     titlesDisabledByGateway = false;
     clearRetainedTitleState();
   }
-  const renderSource = params.renderSource ?? DEFAULT_RENDER_SOURCE;
-  const agentId = params.agentId ?? null;
-  const ownerKey = params.sessionKey ? queueOwnerKey(params.sessionKey, agentId) : null;
-  const previousOwnerKey = renderOwners.get(renderSource);
-  if (previousOwnerKey && previousOwnerKey !== ownerKey) {
-    releaseToolTitleRenderSource(renderSource);
-  }
-  if (ownerKey) {
-    renderOwners.set(renderSource, ownerKey);
-  }
   activeClient = params.client;
   activeSessionKey = params.sessionKey;
-  activeAgentId = agentId;
-  activeRenderSource = renderSource;
-  activeRenderEpoch = (renderEpochs.get(activeRenderSource) ?? 0) + 1;
-  renderEpochs.set(activeRenderSource, activeRenderEpoch);
+  activeAgentId = params.agentId ?? null;
+  activeSchedulingEnabled = params.schedulingEnabled !== false;
+  activeHistoryVersion = params.historyVersion ?? 0;
 }
 
 function scheduleTitleRequest(name: string, request: { key: string; input: string }): void {

--- a/ui/src/pages/chat/tool-titles.ts
+++ b/ui/src/pages/chat/tool-titles.ts
@@ -16,13 +16,28 @@ import { fnv1aUtf16 } from "../../lib/fnv1a.ts";
 
 const MAX_TITLE_INPUT_CHARS = 2_000;
 const MAX_ITEMS_PER_REQUEST = 24;
+const MAX_RETAINED_TITLES = 128;
+const MAX_RETAINED_FAILURES = 128;
+const FAILURE_RETRY_MS = 5 * 60_000;
+const MAX_WORK_ITEMS_PER_SESSION = 48;
+const MAX_WORK_ITEMS_TOTAL = 96;
+const MAX_SATURATED_SESSIONS = MAX_WORK_ITEMS_TOTAL;
+const SATURATED_SESSION_RETRY_MS = 5 * 60_000;
 const REQUEST_DEBOUNCE_MS = 250;
 const MIN_COMMAND_CHARS_FOR_TITLE = 12;
 const MIN_GENERIC_INPUT_CHARS_FOR_TITLE = 120;
 
+const TOOL_TITLES_CHANGED_EVENT = "openclaw:tool-titles-changed";
+
+export function subscribeToolTitleChanges(listener: () => void): () => void {
+  globalThis.addEventListener(TOOL_TITLES_CHANGED_EVENT, listener);
+  return () => globalThis.removeEventListener(TOOL_TITLES_CHANGED_EVENT, listener);
+}
+
 const titlesByKey = new Map<string, string>();
-const pendingKeys = new Set<string>();
-const failedKeys = new Set<string>();
+const pendingKeys = new Map<string, PendingItem>();
+const failedKeys = new Map<string, number>();
+const saturatedSessions = new Map<string, SaturatedSession>();
 // Bumped whenever titles land; chat threads include it in their lit guard()
 // dependencies so cached row subtrees repaint with the new titles.
 let titlesVersion = 0;
@@ -36,24 +51,31 @@ export function getToolTitlesVersion(): number {
 // belong to a different pane than the one that queued the item.
 type PendingItem = {
   key: string;
+  ownerKey: string;
   name: string;
   input: string;
   sessionKey: string;
   agentId: string | null;
   client: GatewayBrowserClient;
-  notify: (() => void) | null;
+};
+type SaturatedSession = {
+  expiresAt: number;
+  resumeAfterKey: string | null;
+  searchRenderEpoch: number | null;
 };
 type ToolTitlesResult = { titles?: Record<string, string>; disabled?: boolean };
 
 // Set when the gateway reports the opt-in is off; cleared on a new client
 // (a different gateway may have titles enabled).
 let titlesDisabledByGateway = false;
-let queue = new Map<string, PendingItem>();
+const queue = new Map<string, PendingItem>();
 let flushTimer: ReturnType<typeof setTimeout> | null = null;
 let activeClient: GatewayBrowserClient | null = null;
 let activeSessionKey: string | null = null;
 let activeAgentId: string | null = null;
-let notifyUpdate: (() => void) | null = null;
+let fetcherGeneration = 0;
+let fetcherRenderEpoch = 0;
+let activeFlush: object | null = null;
 
 /** FNV-1a over name + serialized args; stable across renders of one call. */
 function digest(name: string, input: string): string {
@@ -75,6 +97,171 @@ function serializeArgs(args: unknown): string | null {
     return null;
   }
 }
+
+function readLru<T>(entries: Map<string, T>, key: string): T | undefined {
+  if (!entries.has(key)) {
+    return undefined;
+  }
+  const value = entries.get(key);
+  if (value === undefined) {
+    return undefined;
+  }
+  entries.delete(key);
+  entries.set(key, value);
+  return value;
+}
+
+function storeLru<T>(entries: Map<string, T>, key: string, value: T, limit: number): void {
+  entries.delete(key);
+  entries.set(key, value);
+  while (entries.size > limit) {
+    entries.delete(entries.keys().next().value!);
+  }
+}
+
+function hasUnexpired(entries: Map<string, number>, key: string): boolean {
+  const expiresAt = readLru(entries, key);
+  if (expiresAt === undefined) {
+    return false;
+  }
+  if (expiresAt <= Date.now()) {
+    entries.delete(key);
+    return false;
+  }
+  return true;
+}
+
+function storeFailure(key: string): void {
+  storeLru(failedKeys, key, Date.now() + FAILURE_RETRY_MS, MAX_RETAINED_FAILURES);
+}
+
+function notifyTitlesChanged(): void {
+  titlesVersion += 1;
+  if (typeof globalThis.dispatchEvent === "function") {
+    globalThis.dispatchEvent(new Event(TOOL_TITLES_CHANGED_EVENT));
+  }
+}
+
+function clearRetainedTitleState(): void {
+  const hadTitles = titlesByKey.size > 0;
+  titlesByKey.clear();
+  failedKeys.clear();
+  if (hadTitles) {
+    notifyTitlesChanged();
+  }
+}
+
+function queueOwnerKey(sessionKey: string, agentId: string | null): string {
+  return `${sessionKey}\u0000${agentId ?? ""}`;
+}
+
+function saturateSession(ownerKey: string, resumeAfterKey: string | null): void {
+  storeLru(
+    saturatedSessions,
+    ownerKey,
+    {
+      expiresAt: Date.now() + SATURATED_SESSION_RETRY_MS,
+      resumeAfterKey,
+      searchRenderEpoch: null,
+    },
+    MAX_SATURATED_SESSIONS,
+  );
+}
+
+function shouldSuppressSaturatedSession(ownerKey: string, requestKey: string): boolean {
+  const saturation = readLru(saturatedSessions, ownerKey);
+  if (!saturation) {
+    return false;
+  }
+  if (saturation.expiresAt > Date.now()) {
+    return true;
+  }
+  if (saturation.resumeAfterKey === null) {
+    saturatedSessions.delete(ownerKey);
+    return false;
+  }
+  if (requestKey === saturation.resumeAfterKey) {
+    // Resume after the last admitted row. Re-admitting LRU-evicted rows before
+    // this cursor would spend every later bounded window without making progress.
+    saturatedSessions.delete(ownerKey);
+    return true;
+  }
+  if (saturation.searchRenderEpoch === null) {
+    saturation.searchRenderEpoch = fetcherRenderEpoch;
+    return true;
+  }
+  if (saturation.searchRenderEpoch === fetcherRenderEpoch) {
+    return true;
+  }
+  // The prior complete render did not contain the cursor, so retention or
+  // compaction removed it. Resume from this render's first remaining row.
+  saturatedSessions.delete(ownerKey);
+  return false;
+}
+
+function discardQueuedBurst(headOwnerKey: string): void {
+  if (queue.size === 0) {
+    return;
+  }
+  // Every discarded pane must share the cooldown. Otherwise its next ordinary
+  // repaint immediately reconstructs the backlog that this failure terminated.
+  const ownerKeys = new Set([headOwnerKey]);
+  for (const item of queue.values()) {
+    ownerKeys.add(item.ownerKey);
+  }
+  queue.clear();
+  for (const ownerKey of ownerKeys) {
+    saturateSession(ownerKey, null);
+  }
+}
+
+function countSessionWork(ownerKey: string): number {
+  let count = 0;
+  for (const item of queue.values()) {
+    if (item.ownerKey === ownerKey) {
+      count += 1;
+    }
+  }
+  for (const item of pendingKeys.values()) {
+    if (item.ownerKey === ownerKey) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function clearFlushTimer(): void {
+  if (!flushTimer) {
+    return;
+  }
+  clearTimeout(flushTimer);
+  flushTimer = null;
+}
+
+function retireTransientState(): void {
+  fetcherGeneration += 1;
+  activeFlush = null;
+  queue.clear();
+  pendingKeys.clear();
+  saturatedSessions.clear();
+  clearFlushTimer();
+}
+
+function scheduleFlush(): void {
+  if (flushTimer || activeFlush !== null || queue.size === 0 || titlesDisabledByGateway) {
+    return;
+  }
+  const generation = fetcherGeneration;
+  flushTimer = setTimeout(() => {
+    flushTimer = null;
+    if (generation !== fetcherGeneration) {
+      scheduleFlush();
+      return;
+    }
+    void flushTitleQueue(generation);
+  }, REQUEST_DEBOUNCE_MS);
+}
+
 /**
  * Only calls where a purpose summary beats the deterministic label qualify:
  * shell commands and arg-heavy generic/MCP tools. File reads/edits/writes
@@ -110,11 +297,16 @@ export function getToolCallTitle(name: string, args: unknown): string | undefine
   if (!request) {
     return undefined;
   }
-  const cached = titlesByKey.get(request.key);
+  const admissionSuppressed =
+    activeSessionKey !== null &&
+    shouldSuppressSaturatedSession(queueOwnerKey(activeSessionKey, activeAgentId), request.key);
+  const cached = readLru(titlesByKey, request.key);
   if (cached) {
     return cached;
   }
-  scheduleTitleRequest(name, request);
+  if (!admissionSuppressed) {
+    scheduleTitleRequest(name, request);
+  }
   return undefined;
 }
 
@@ -123,26 +315,16 @@ export function configureToolTitleFetcher(params: {
   sessionKey: string | null;
   /** Selected agent; required for global-session keys where the gateway would otherwise resolve the default agent. */
   agentId?: string | null;
-  onTitlesChanged: (() => void) | null;
 }): void {
-  if (!params.client) {
-    titlesDisabledByGateway = false;
-    titlesByKey.clear();
-    pendingKeys.clear();
-    failedKeys.clear();
-    queue = new Map();
-    if (flushTimer) {
-      clearTimeout(flushTimer);
-      flushTimer = null;
-    }
-  }
   if (params.client !== activeClient) {
+    retireTransientState();
     titlesDisabledByGateway = false;
+    clearRetainedTitleState();
   }
   activeClient = params.client;
   activeSessionKey = params.sessionKey;
   activeAgentId = params.agentId ?? null;
-  notifyUpdate = params.onTitlesChanged;
+  fetcherRenderEpoch += 1;
 }
 
 function scheduleTitleRequest(name: string, request: { key: string; input: string }): void {
@@ -151,33 +333,49 @@ function scheduleTitleRequest(name: string, request: { key: string; input: strin
     !activeClient ||
     !activeSessionKey ||
     titlesByKey.has(request.key) ||
-    pendingKeys.has(request.key) ||
-    failedKeys.has(request.key) ||
-    queue.has(request.key)
+    hasUnexpired(failedKeys, request.key)
   ) {
+    return;
+  }
+  const existing = pendingKeys.get(request.key) ?? queue.get(request.key);
+  if (existing) {
+    return;
+  }
+  const ownerKey = queueOwnerKey(activeSessionKey, activeAgentId);
+  const sessionWork = countSessionWork(ownerKey);
+  if (
+    sessionWork >= MAX_WORK_ITEMS_PER_SESSION ||
+    pendingKeys.size + queue.size >= MAX_WORK_ITEMS_TOTAL
+  ) {
+    saturateSession(ownerKey, null);
     return;
   }
   queue.set(request.key, {
     key: request.key,
+    ownerKey,
     name,
     input: request.input,
     sessionKey: activeSessionKey,
     agentId: activeAgentId,
     client: activeClient,
-    notify: notifyUpdate,
   });
-  flushTimer ??= setTimeout(() => {
-    flushTimer = null;
-    void flushTitleQueue();
-  }, REQUEST_DEBOUNCE_MS);
+  if (
+    sessionWork + 1 >= MAX_WORK_ITEMS_PER_SESSION ||
+    pendingKeys.size + queue.size >= MAX_WORK_ITEMS_TOTAL
+  ) {
+    saturateSession(ownerKey, request.key);
+  }
+  scheduleFlush();
 }
 
-async function flushTitleQueue(): Promise<void> {
+async function flushTitleQueue(generation: number): Promise<void> {
+  if (generation !== fetcherGeneration || activeFlush !== null) {
+    return;
+  }
   // One request per scheduling pane (client + session + agent); other panes'
   // items stay queued for the follow-up flush.
   const head = queue.values().next().value;
   if (!head) {
-    queue = new Map();
     return;
   }
   const batch: PendingItem[] = [];
@@ -193,59 +391,62 @@ async function flushTitleQueue(): Promise<void> {
   }
   for (const item of batch) {
     queue.delete(item.key);
-    pendingKeys.add(item.key);
+    pendingKeys.set(item.key, item);
   }
-  const hasBacklog = queue.size > 0;
+  const flush = {};
+  activeFlush = flush;
   try {
     const result = await head.client.request<ToolTitlesResult>("chat.toolTitles", {
       sessionKey: head.sessionKey,
       ...(head.agentId ? { agentId: head.agentId } : {}),
       items: batch.map((item) => ({ id: item.key, name: item.name, input: item.input })),
     });
-    if (result?.disabled === true) {
-      titlesDisabledByGateway = true;
-      queue = new Map();
+    if (generation !== fetcherGeneration) {
       return;
     }
-    const titles = result?.titles ?? {};
+    if (result?.disabled === true) {
+      titlesDisabledByGateway = true;
+      queue.clear();
+      clearFlushTimer();
+      return;
+    }
+    const titles = asNullableRecord(result?.titles);
     let changed = false;
     for (const item of batch) {
-      const rawTitle = titles[item.key];
+      const rawTitle = titles?.[item.key];
       const title = typeof rawTitle === "string" ? rawTitle.trim() : "";
       if (title) {
-        titlesByKey.set(item.key, title);
+        failedKeys.delete(item.key);
+        storeLru(titlesByKey, item.key, title, MAX_RETAINED_TITLES);
         changed = true;
       } else {
-        failedKeys.add(item.key);
+        storeFailure(item.key);
       }
     }
-    if (changed) {
-      titlesVersion += 1;
-      // Split panes can contribute rows for the same session to one batch;
-      // every contributing pane must repaint, not just the head's.
-      const notified = new Set<() => void>();
-      for (const item of batch) {
-        if (item.notify && !notified.has(item.notify)) {
-          notified.add(item.notify);
-          item.notify();
-        }
-      }
+    if (!changed) {
+      discardQueuedBurst(head.ownerKey);
+      return;
     }
+    notifyTitlesChanged();
   } catch {
+    if (generation !== fetcherGeneration) {
+      return;
+    }
     // Gateway without the method, no usable cheap model, transient errors:
     // titles are decorative, so fail closed and keep deterministic labels.
     for (const item of batch) {
-      failedKeys.add(item.key);
+      storeFailure(item.key);
     }
+    discardQueuedBurst(head.ownerKey);
   } finally {
     for (const item of batch) {
-      pendingKeys.delete(item.key);
+      if (pendingKeys.get(item.key) === item) {
+        pendingKeys.delete(item.key);
+      }
     }
-    if (hasBacklog && !flushTimer) {
-      flushTimer = setTimeout(() => {
-        flushTimer = null;
-        void flushTitleQueue();
-      }, REQUEST_DEBOUNCE_MS);
+    if (activeFlush === flush) {
+      activeFlush = null;
     }
+    scheduleFlush();
   }
 }

--- a/ui/src/pages/chat/tool-titles.ts
+++ b/ui/src/pages/chat/tool-titles.ts
@@ -35,6 +35,20 @@ export function subscribeToolTitleChanges(listener: () => void): () => void {
   return () => globalThis.removeEventListener(TOOL_TITLES_CHANGED_EVENT, listener);
 }
 
+export function releaseToolTitleRenderSource(renderSource: object): void {
+  renderEpochs.delete(renderSource);
+  if (activeRenderSource === renderSource) {
+    activeRenderSource = DEFAULT_RENDER_SOURCE;
+    activeRenderEpoch = renderEpochs.get(DEFAULT_RENDER_SOURCE) ?? 0;
+  }
+  for (const saturation of saturatedSessions.values()) {
+    if (saturation.searchRenderSource === renderSource) {
+      saturation.searchRenderSource = null;
+      saturation.searchRenderEpoch = null;
+    }
+  }
+}
+
 const titlesByKey = new Map<string, string>();
 const pendingKeys = new Map<string, PendingItem>();
 const failedKeys = new Map<string, number>();

--- a/ui/src/pages/chat/tool-titles.ts
+++ b/ui/src/pages/chat/tool-titles.ts
@@ -37,14 +37,14 @@ export function subscribeToolTitleChanges(listener: () => void): () => void {
 
 export function releaseToolTitleRenderSource(renderSource: object): void {
   renderEpochs.delete(renderSource);
+  renderOwners.delete(renderSource);
   if (activeRenderSource === renderSource) {
     activeRenderSource = DEFAULT_RENDER_SOURCE;
     activeRenderEpoch = renderEpochs.get(DEFAULT_RENDER_SOURCE) ?? 0;
   }
-  for (const saturation of saturatedSessions.values()) {
+  for (const [ownerKey, saturation] of saturatedSessions) {
     if (saturation.searchRenderSource === renderSource) {
-      saturation.searchRenderSource = null;
-      saturation.searchRenderEpoch = null;
+      saturatedSessions.delete(ownerKey);
     }
   }
 }
@@ -92,6 +92,7 @@ let activeAgentId: string | null = null;
 let activeRenderSource = DEFAULT_RENDER_SOURCE;
 let activeRenderEpoch = 0;
 const renderEpochs = new WeakMap<object, number>();
+const renderOwners = new WeakMap<object, string>();
 let fetcherGeneration = 0;
 let activeFlush: object | null = null;
 
@@ -346,10 +347,20 @@ export function configureToolTitleFetcher(params: {
     titlesDisabledByGateway = false;
     clearRetainedTitleState();
   }
+  const renderSource = params.renderSource ?? DEFAULT_RENDER_SOURCE;
+  const agentId = params.agentId ?? null;
+  const ownerKey = params.sessionKey ? queueOwnerKey(params.sessionKey, agentId) : null;
+  const previousOwnerKey = renderOwners.get(renderSource);
+  if (previousOwnerKey && previousOwnerKey !== ownerKey) {
+    releaseToolTitleRenderSource(renderSource);
+  }
+  if (ownerKey) {
+    renderOwners.set(renderSource, ownerKey);
+  }
   activeClient = params.client;
   activeSessionKey = params.sessionKey;
-  activeAgentId = params.agentId ?? null;
-  activeRenderSource = params.renderSource ?? DEFAULT_RENDER_SOURCE;
+  activeAgentId = agentId;
+  activeRenderSource = renderSource;
   activeRenderEpoch = (renderEpochs.get(activeRenderSource) ?? 0) + 1;
   renderEpochs.set(activeRenderSource, activeRenderEpoch);
 }


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users viewing long, tool-heavy chats could see generated tool titles stop progressing after transcript retention removed the saved pagination cursor.

## Why This Change Was Made

The scheduler now receives the complete unfiltered tool-call sequence before transcript virtualization. It uses the history owner and request revision to distinguish duplicate renders, active-pane changes, retained cursors, and removed cursors; title settlement repaints every mounted chat pane through one lifecycle-owned subscription.

## User Impact

Generated tool titles continue appearing as long transcripts are pruned, without unbounded queue growth or repeated requests for older rows. Gateway failures and disabled title generation still retain deterministic fallback labels.

## Evidence

- Pre-fix unit regression: the cursor-removal scenario remained at 48 unique requests instead of reaching 96.
- Pre-fix mocked-browser regression: timed out waiting for the fourth `chat.toolTitles` request.
- Focused unit suite: 19/19 passed.
- Mocked-Gateway browser suite: 6/6 passed, including virtualized off-screen cursors, transcript search filtering, active split-pane changes, cross-session failure isolation, repaint, and gateway replacement.
- Bounded scheduling passed with four 24-item batches, 48 initial titles, 96 final unique requests, 95 visible generated titles, and 24 deterministic fallbacks.
- Equivalent 1440x900 before/after screenshots and the complete transition recording were inspected.
- Full remote `check:changed` passed: https://github.com/openclaw/openclaw/actions/runs/33291646427

The 48-item per-session and 96-item global limits are intentional bounds for decorative model work. Empty/error results cool down only their owning session; queued titles for other sessions remain eligible.

Runner infrastructure note: two earlier Testbox attempts completed checksum-full sync but then failed before repository checks because the prepared dependency tree was absent (`Cannot find module 'tsx'`):

- https://github.com/openclaw/openclaw/actions/runs/33290843437
- https://github.com/openclaw/openclaw/actions/runs/33291378088

No code workaround was applied for those runner failures. The later exact-patch Testbox run above completed successfully; the required `openclaw/ci-gate` PR check remains the authoritative landing gate.
