### PR TITLE
fix(ci): keep provider alias service ports distinct

### DIFF
--- a/src/agents/provider-local-service.test.ts
+++ b/src/agents/provider-local-service.test.ts
@@ -12,6 +12,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { mintSecretSentinel } from "../secrets/sentinel.js";
+import { getDeterministicFreePortBlock } from "../test-utils/ports.js";
 import { killPidIfAlive, readPidFile, waitForPidToExit } from "../test-utils/process-tree.js";
 import {
   attachModelProviderLocalService,
@@ -578,8 +579,8 @@ describe("provider local service", () => {
   });
 
   it("keeps configured provider aliases on different local endpoints independent", async () => {
-    const firstPort = await freePort();
-    const secondPort = await freePort();
+    const firstPort = await getDeterministicFreePortBlock({ offsets: [0, 1] });
+    const secondPort = firstPort + 1;
     const firstHealthUrl = `http://127.0.0.1:${firstPort}/v1/models`;
     const secondHealthUrl = `http://127.0.0.1:${secondPort}/v1/models`;
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-service-key-"));


### PR DESCRIPTION
## What Problem This Solves

Resolves an intermittent main CI failure where the provider alias service test could receive the same released ephemeral port twice, causing the runtime to correctly reuse one healthy service while the test expected two starts.

## Why This Change Was Made

The test now uses the existing deterministic free-port block helper and assigns adjacent ports to the two provider aliases. Runtime behavior is unchanged.

## User Impact

No user-facing runtime change. Main CI no longer depends on the operating system returning two different ports from sequential free-port probes.

## Evidence

- Regression reproduced with equal ports: expected two starts, received one.
- Focused regression: 1/1 passing.
- Full `src/agents/provider-local-service.test.ts`: 22/22 passing.
- Format, lint, ratchets, temp audit, and diff checks pass.
- Production LOC: 0. Test delta: +3/-2.
