### PR TITLE
fix(telegram): preserve durable receipt in sendMessage action result

### DIFF
--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -171,6 +171,8 @@ const sendDurableMessageBatch = vi.fn(
             index: 0,
           },
         ],
+        threadId: params.threadId == null ? undefined : String(params.threadId),
+        replyToId: params.reply?.replyToId ?? params.replyToId,
         sentAt: Date.now(),
       },
     } as const;
@@ -1017,6 +1019,7 @@ describe("handleTelegramAction", () => {
         action: "sendMessage",
         to: "@testchannel",
         content: "Hello, Telegram!",
+        messageThreadId: 77,
       },
       telegramConfig(),
       {
@@ -1036,12 +1039,14 @@ describe("handleTelegramAction", () => {
     const options = requireRecord(call[2], "text message options");
     expect(options.token).toBe("tok");
     expect(options.mediaUrl).toBeUndefined();
+    expect(options.messageThreadId).toBe(77);
     const durableCall = mockCall(sendDurableMessageBatch, 0, "durable text message");
     expect(requireRecord(durableCall[0], "durable text message params")).toMatchObject({
       channel: "telegram",
       to: "@testchannel",
       durability: "required",
       gatewayClientScopes: ["operator.write"],
+      threadId: 77,
       // The gateway-owned plugin send must inherit the caller's retry ownership,
       // or the failed row stays replay-eligible and duplicates (#124279).
       deliveryRetryOwner: "caller",
@@ -1049,17 +1054,21 @@ describe("handleTelegramAction", () => {
       reply: { replyToId: "456", source: "implicit", mode: "first" },
       payloads: [{ text: "Hello, Telegram!" }],
     });
-    expect(result.content).toStrictEqual([
-      {
-        type: "text",
-        text: '{\n  "ok": true,\n  "messageId": "789",\n  "chatId": "123"\n}',
-      },
-    ]);
-    expect(result.details).toStrictEqual({
+    const details = resultDetails(result);
+    // Source-reply reconciliation reads `receipt` off this result (#133051); dropping it
+    // makes a successfully delivered Telegram reply look unconfirmed and fail closed.
+    expect(details).toStrictEqual({
       ok: true,
       messageId: "789",
       chatId: "123",
+      receipt: {
+        threadId: "77",
+        replyToId: "456",
+      },
     });
+    expect(result.content).toStrictEqual([
+      { type: "text", text: JSON.stringify(details, null, 2) },
+    ]);
   });
 
   it("persists sendMessage action deliveries before Telegram platform send", async () => {

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -378,7 +378,7 @@ function buildTelegramActionSendPayload(params: {
 
 function getLastDurableTelegramActionResult(
   result: Extract<DurableMessageBatchSendResult, { status: "sent" }>,
-): { messageId?: string; chatId?: string } {
+) {
   const lastResult = result.results.at(-1);
   const receipt = result.receipt;
   return {
@@ -387,6 +387,7 @@ function getLastDurableTelegramActionResult(
       receipt.primaryPlatformMessageId ??
       receipt.platformMessageIds.at(-1),
     chatId: lastResult?.target?.kind === "chat" ? lastResult.target.id : undefined,
+    receipt: { threadId: receipt.threadId, replyToId: receipt.replyToId },
   };
 }
 
@@ -748,6 +749,7 @@ export async function handleTelegramAction(
       ok: true,
       messageId: result.messageId,
       chatId: result.chatId,
+      receipt: result.receipt,
       ...buildTelegramControlDegradation(droppedControls, Boolean(content.trim())),
     });
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes #133051.

Telegram can confirm a terminal `sendMessage` delivery while its action adapter drops the durable delivery receipt from the tool result. Source-reply recovery then cannot prove the delivered topic placement.

## Root cause

`getLastDurableTelegramActionResult()` read the receipt to derive `messageId`, but returned only `messageId` and `chatId`. The final Telegram `jsonResult(...)` repeated that reduced shape. The shared source-reply reconciler reads `result.receipt` or `receipt`, so the Telegram projection discarded the exact proof that its consumer requires.

## Fix

The Telegram action owner now projects only the existing `threadId` and `replyToId` placement facts from `getLastDurableTelegramActionResult()` and includes that bounded receipt in the successful `sendMessage` tool result. This adds no state, retry, fallback, raw transport data, or second delivery path.

## Evidence

Tested through a real Telegram Test Server forum with a Convex-leased QA user and bot. Both revisions used the same topic-qualified terminal `message.send`, controlled model response, Gateway restart, and post-restart session inspection.

### Exact main: `ecdc8b95dbdcae479ec89099a72de3c1c88f27e6`

- Telegram delivered the marker in forum topic `1`.
- `chat.history` recorded a successful tool result with `messageId` and `chatId`, but no `receipt`.
- Gateway logged `Terminal source reply receipt was not mirrored; restart recovery is fail-closed.`
- Restart recovery ran the source action again and caused a second Telegram delivery.
- Current main returned the session to `done`; this is newer behavior than the issue's original failed/aborted projection, but the missing receipt still left recovery unable to trust the confirmed first delivery.

Sanitized trace:

```text
tool result: {"ok":true,"messageId":"<redacted>","chatId":"<redacted>"}
Gateway: Terminal source reply receipt was not mirrored; restart recovery is fail-closed.
provider requests after restart: 4
Telegram sendMessage deliveries after restart: 2
```

### Exact head: `3d01f8a4f8bc80f88def5f15abcb3de1e5709bf1`

- Telegram delivered the marker once in forum topic `1`.
- The successful tool result included only the bounded placement receipt `{"threadId":"1"}`.
- Gateway restart did not replay the source action.
- Post-restart Gateway and persisted session views showed `status: "done"`, `abortedLastRun: false`, and no run error.
- The separate transcript-mirror warning still appeared even though terminal recovery was reconciled; this patch does not change transcript append behavior.

Sanitized trace:

```text
tool result: {"ok":true,"messageId":"<redacted>","chatId":"<redacted>","receipt":{"threadId":"1"}}
provider requests after restart: 2
Telegram sendMessage deliveries after restart: 1
post-restart session: {"status":"done","abortedLastRun":false,"lastRunError":null}
```

Sanitized exact-head Telegram Test Server events and restart output:

```json
{
  "revision": "3d01f8a4f8bc80f88def5f15abcb3de1e5709bf1",
  "events": [
    { "kind": "message", "sender": "qa-user", "topicId": 1 },
    { "kind": "message", "sender": "sut", "topicId": 1, "text": "DELIVERY_RECEIPT_PROOF_133083" }
  ],
  "toolResult": {
    "ok": true,
    "messageId": "<redacted>",
    "chatId": "<redacted>",
    "receipt": { "threadId": "1" }
  },
  "restartRecovery": {
    "gatewayRestart": "completed",
    "providerRequestCount": 2,
    "telegramSendCount": 1,
    "session": { "status": "done", "abortedLastRun": false, "lastRunError": null }
  }
}
```

## Validation

- Focused receipt regression: passed.
- Full `extensions/telegram/src/action-runtime.test.ts`: 125 passed.
- `src/infra/outbound/source-reply-mirror.test.ts`: 12 passed.
- Changed files: format and extension lint passed.
- `git diff --check`: passed.
- Production delta: `+2`; tests: `+9`.

This change was prepared with autonomous coding assistance and verified against the real Telegram boundary.
