### PR TITLE
feat(channels): show restart recovery attempts in status

### DIFF
--- a/src/commands/channels.surfaces-signal-runtime-errors-channels-status-output.test.ts
+++ b/src/commands/channels.surfaces-signal-runtime-errors-channels-status-output.test.ts
@@ -152,4 +152,28 @@ describe("channels command", () => {
 
     expect(lines.join("\n")).toContain("transport:");
   });
+
+  it("surfaces positive integer channel restart attempts", () => {
+    const render = (reconnectAttempts?: unknown) =>
+      formatGatewayChannelsStatusLines({
+        channelLabels: { signal: "Signal" },
+        channelAccounts: {
+          signal: [
+            {
+              accountId: "default",
+              enabled: true,
+              configured: true,
+              running: false,
+              ...(reconnectAttempts === undefined ? {} : { reconnectAttempts }),
+            },
+          ],
+        },
+      }).join("\n");
+
+    expect(render(10)).toContain("restarts:10");
+    expect(render(2)).toContain("restarts:2");
+    for (const reconnectAttempts of [undefined, 0, -1, 1.5, "2", Number.NaN]) {
+      expect(render(reconnectAttempts)).not.toContain("restarts:");
+    }
+  });
 });

--- a/src/commands/channels/status.runtime.ts
+++ b/src/commands/channels/status.runtime.ts
@@ -105,6 +105,13 @@ export function formatGatewayChannelsStatusLines(payload: Record<string, unknown
       if (typeof account.connected === "boolean") {
         bits.push(account.connected ? "connected" : "disconnected");
       }
+      if (
+        typeof account.reconnectAttempts === "number" &&
+        Number.isInteger(account.reconnectAttempts) &&
+        account.reconnectAttempts > 0
+      ) {
+        bits.push(`restarts:${account.reconnectAttempts}`);
+      }
       const inboundAt =
         typeof account.lastInboundAt === "number" && Number.isFinite(account.lastInboundAt)
           ? account.lastInboundAt


### PR DESCRIPTION
Closes #133064

## What Problem This Solves

openclaw channels status shows whether each account is running and connected, but it drops the Gateway's existing reconnectAttempts fact. During recovery, a stopped account can therefore look unexplained unless the operator switches to JSON and inspects the raw snapshot.

Issue triage confirmed this is source-reproducible, owner-local, and queueable: the Gateway already returns the fact, while the human formatter never reads it.

## Why This Change Was Made

The existing channel-status formatter now appends restarts:<count> for finite positive integer attempt counts. Zero, absent, negative, fractional, and non-numeric values remain quiet.

This uses the Gateway snapshot as the sole source of truth. It does not change restart policy, retry budgets, account state, probing, persistence, JSON output, or plugin behavior.

Existing-solutions preflight: --json plus an external query is the only built-in workaround. A plugin or library cannot repair a missing projection in OpenClaw's core CLI formatter, so the narrow formatter owner is the appropriate boundary.

## User Impact

Operators can distinguish an ordinary stopped account from one actively progressing through channel recovery or carrying a terminal restart-attempt count, without leaving the normal status command.

The count describes the current snapshot's recovery attempts; it is not a lifetime total or a remaining-budget calculation.

## Evidence

### Exact-Head Real Gateway Recovery Proof (September 5, 2026)

Proved production head `9ace37e7d207cfd2641eb581cae3d073096cf8c1` without changing this PR head. [Public proof run 33972912723](https://github.com/Leon-SK668/openclaw/actions/runs/33972912723), [job 101324484706](https://github.com/Leon-SK668/openclaw/actions/runs/33972912723/job/101324484706): **success**. [Download receipt artifact 9971494874](https://github.com/Leon-SK668/openclaw/actions/runs/33972912723/artifacts/9971494874).

The secretless Ubuntu runner preserved the proof script, detached to the exact PR head, verified `git rev-parse HEAD`, installed its dependencies with the repository setup action and built `pnpm build qaRuntime` with private QA enabled. A separate real Gateway process then started the built-in QA channel against a loopback HTTP QA bus. Closing that HTTP server caused the production channel account task to fail. The Gateway supervisor, not the harness, produced `reconnectAttempts: 1` in `channels.status`; the real `channels status --channel qa-channel` command showed `restarts:1`.

```text
Checking channel status…
Gateway reachable.
- QA Channel default: enabled, configured, error:connect ECONNREFUSED 127.0.0.1:41129, stopped, disconnected, restarts:1, url:http://127.0.0.1:41129

Tip: https://docs.openclaw.ai/cli#status adds gateway health probes to status output (requires a reachable gateway).
```

```json
{
  "head": "9ace37e7d207cfd2641eb581cae3d073096cf8c1",
  "reconnectAttempts": 1,
  "cliReadback": "restarts:1"
}
```

[Complete executable proof script](https://github.com/Leon-SK668/openclaw/blob/c20322656169ecfa4ac79fd84a25065dd12df190/scripts/proof-133086-channel-restarts.mts) and [exact-head workflow](https://github.com/Leon-SK668/openclaw/blob/c20322656169ecfa4ac79fd84a25065dd12df190/.github/workflows/leon-133086-channel-status-proof.yml) are confined to a separate fork proof branch. That branch changes no production source; the target checkout is the SHA above. Fresh P0-P3 autoreview of the proof runner/workflow returned no accepted/actionable findings.

Scope: real process, loopback HTTP failure, production supervisor, real Gateway RPC and real CLI rendering. It does not simulate Signal/Telegram transport or assert lifetime restart totals, successful reconnection, retry policy changes, or behavior after a Gateway process restart. The local mock model is not called for this status-only scenario; no provider credential, paid service, production channel or user message is used.

AI-assisted maintenance transcript (sanitized): inspected the status formatter and Gateway recovery owner; replaced synthetic snapshot-only evidence with a real QA-channel disconnect; reviewed the proof runner; ran the public fork job; downloaded and checked the exact-head receipt; updated this body. No product-code change or review-trigger comment was needed.

### Original Implementation Evidence

Acceptance red, captured before the production edit:

- A focused acceptance case supplied reconnectAttempts: 10 to the production formatter.
- The case failed because the account line did not contain restarts:10.

Acceptance green on exact head 29ac28939dba317e1936d25434da67acfdf8b5d0 (Node 24.18.0):

    OPENCLAW_FS_SAFE_NATIVE_MODE=off node scripts/run-vitest.mjs src/commands/channels.surfaces-signal-runtime-errors-channels-status-output.test.ts
    Test Files  1 passed (1)
    Tests       7 passed (7)

Production-path readback using formatGatewayChannelsStatusLines through the repo TypeScript runtime:

    gateway payload reconnectAttempts=10
    channels status readback=- Signal default: enabled, configured, stopped, disconnected, restarts:10

Additional checks:

    node_modules/.bin/oxfmt --check src/commands/channels/status.runtime.ts src/commands/channels.surfaces-signal-runtime-errors-channels-status-output.test.ts
    All matched files use the correct format.

    git diff --check upstream/main...HEAD
    (clean)

    .agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main
    autoreview scoped-clean: no accepted/actionable findings
    overall: patch is correct (0.99)

Change size:

- Production: +7 LOC
- Tests: +24 LOC
- Files: 2
- Generated/lock files: none

Compatibility and risk:

- No config, default, protocol, schema, persistence, security, or restart-policy changes.
- Existing JSON shape is unchanged.
- Known limit: the display reflects only the count present in the current Gateway snapshot; it does not infer totals across process lifetimes.

AI-assisted discovery and implementation. Source owners, callers, sibling status surfaces, history, tests, dependency contracts, and live competing PRs were reviewed. No secrets or personal data are included.

### Rebase reconciliation (September 5, 2026)

- Current PR head: `9ace37e7d207cfd2641eb581cae3d073096cf8c1`
- Rebased onto frozen `upstream/main` at `c4052ca628ac0e1026b82c10d7d80a5ebd8aaff9`; upstream `main` advanced after this batch, so no later baseline is claimed here.
- The owner-level production/test change described above is preserved; this note records the new head after rebase and does not replace the original proof receipts.
- Current-head CI audit: no completed PR-owned failure was found at this rebase head.
- No new live proof is claimed by this reconciliation note.

<!-- leon-evidence-maintenance-20260919-aa0yfe -->
### Current-head evidence maintenance — September 19, 2026

The product head remains `9ace37e7d207cfd2641eb581cae3d073096cf8c1`. The current upstream [main CI run 33935595687](https://github.com/openclaw/openclaw/actions/runs/33935595687) is still **queued**, with no completed CI gate for that run in the retrieved checks. The fully paginated same-head workflow list contains no alternative successful main CI run. The earlier fork behavior proof is not a replacement for this upstream result. The queue requires upstream Actions intervention; no new product change or completed CI result is claimed here.
