### PR TITLE
feat(models): show active auth subscription blocks

### DIFF
--- a/src/commands/models/auth-list.test.ts
+++ b/src/commands/models/auth-list.test.ts
@@ -289,7 +289,13 @@ describe("modelsAuthListCommand", () => {
     });
     expect(byId["openai:profile-wide"]).not.toHaveProperty("blockedModel");
     for (const id of ["openai:expired", "openai:invalid"]) {
-      expect(Object.keys(byId[id]).filter((key) => key.startsWith("blocked"))).toEqual([]);
+      const profile = byId[id];
+      expect(profile).toBeDefined();
+      expect(profile).not.toHaveProperty("blockedUntil");
+      expect(profile).not.toHaveProperty("blockedReason");
+      expect(profile).not.toHaveProperty("blockedSource");
+      expect(profile).not.toHaveProperty("blockedScope");
+      expect(profile).not.toHaveProperty("blockedModel");
     }
     expect(JSON.stringify(jsonRuntime.jsonPayloads[0])).not.toMatch(
       /secret|legacy-model-must-not-leak/u,

--- a/src/commands/models/auth-list.test.ts
+++ b/src/commands/models/auth-list.test.ts
@@ -289,13 +289,13 @@ describe("modelsAuthListCommand", () => {
     });
     expect(byId["openai:profile-wide"]).not.toHaveProperty("blockedModel");
     for (const id of ["openai:expired", "openai:invalid"]) {
-      const profile = byId[id];
-      expect(profile).toBeDefined();
-      expect(profile).not.toHaveProperty("blockedUntil");
-      expect(profile).not.toHaveProperty("blockedReason");
-      expect(profile).not.toHaveProperty("blockedSource");
-      expect(profile).not.toHaveProperty("blockedScope");
-      expect(profile).not.toHaveProperty("blockedModel");
+      const profileEntry = byId[id];
+      expect(profileEntry).toBeDefined();
+      expect(profileEntry).not.toHaveProperty("blockedUntil");
+      expect(profileEntry).not.toHaveProperty("blockedReason");
+      expect(profileEntry).not.toHaveProperty("blockedSource");
+      expect(profileEntry).not.toHaveProperty("blockedScope");
+      expect(profileEntry).not.toHaveProperty("blockedModel");
     }
     expect(JSON.stringify(jsonRuntime.jsonPayloads[0])).not.toMatch(
       /secret|legacy-model-must-not-leak/u,

--- a/src/commands/models/auth-list.test.ts
+++ b/src/commands/models/auth-list.test.ts
@@ -1,5 +1,5 @@
 // Model auth-list tests cover provider auth listing and output formatting.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthProfileStore } from "../../agents/auth-profiles.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { OutputRuntimeEnv } from "../../runtime.js";
@@ -37,6 +37,8 @@ vi.mock("./shared.js", () => ({
   resolveModelsTargetAgent: mocks.resolveModelsTargetAgent,
 }));
 
+const NOW = Date.parse("2026-08-30T00:00:00.000Z");
+
 function createRuntime(): OutputRuntimeEnv & { logs: string[]; jsonPayloads: unknown[] } {
   const logs: string[] = [];
   const jsonPayloads: unknown[] = [];
@@ -67,6 +69,10 @@ describe("modelsAuthListCommand", () => {
       .mockReset()
       .mockImplementation((agentDir: string) => `${agentDir}/openclaw-agent.sqlite`);
     mocks.resolveModelsTargetAgent.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("filters profiles by provider and redacts credential material in JSON output", async () => {
@@ -204,6 +210,90 @@ describe("modelsAuthListCommand", () => {
         }),
       ],
     });
+  });
+
+  it("projects only active subscription blocks in text and JSON", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+    const profile = { type: "api_key", provider: "openai", key: "credential-secret" } as const;
+    mocks.ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {
+        "openai:profile-wide": profile,
+        "openai:model-scoped": profile,
+        "openai:expired": profile,
+        "openai:invalid": profile,
+      },
+      usageStats: {
+        "openai:profile-wide": {
+          blockedUntil: NOW + 60_000,
+          blockedReason: "subscription_limit",
+          blockedSource: "codex_rate_limits",
+          blockedModel: "legacy-model-must-not-leak",
+        },
+        "openai:model-scoped": {
+          blockedUntil: NOW + 120_000,
+          blockedReason: "subscription_limit",
+          blockedSource: "wham",
+          blockedScope: "model",
+          blockedModel: "gpt-5.5",
+        },
+        "openai:expired": {
+          blockedUntil: NOW - 1,
+          blockedReason: "subscription_limit",
+          blockedSource: "codex_rate_limits",
+          blockedScope: "model",
+          blockedModel: "gpt-expired",
+        },
+        "openai:invalid": {
+          blockedUntil: 8_700_000_000_000_000,
+          blockedReason: "subscription_limit",
+          blockedSource: "wham",
+          blockedScope: "model",
+          blockedModel: "gpt-invalid",
+        },
+      },
+    } satisfies AuthProfileStore);
+
+    const textRuntime = createRuntime();
+    await modelsAuthListCommand({}, textRuntime);
+    expect(textRuntime.logs.find((line) => line.includes("openai:profile-wide"))).toContain(
+      "blocked:subscription_limit via codex_rate_limits for profile until 2026-08-30T00:01:00.000Z",
+    );
+    expect(textRuntime.logs.find((line) => line.includes("openai:model-scoped"))).toContain(
+      "blocked:subscription_limit via wham for model gpt-5.5 until 2026-08-30T00:02:00.000Z",
+    );
+    for (const id of ["openai:expired", "openai:invalid"]) {
+      expect(textRuntime.logs.find((line) => line.includes(id))).not.toContain("blocked:");
+    }
+
+    const jsonRuntime = createRuntime();
+    await modelsAuthListCommand({ json: true }, jsonRuntime);
+    const profiles = (
+      jsonRuntime.jsonPayloads[0] as {
+        profiles: Array<Record<string, unknown> & { id: string }>;
+      }
+    ).profiles;
+    const byId = Object.fromEntries(profiles.map((entry) => [entry.id, entry]));
+    expect(byId["openai:model-scoped"]).toMatchObject({
+      blockedUntil: "2026-08-30T00:02:00.000Z",
+      blockedReason: "subscription_limit",
+      blockedSource: "wham",
+      blockedScope: "model",
+      blockedModel: "gpt-5.5",
+    });
+    expect(byId["openai:profile-wide"]).toMatchObject({
+      blockedUntil: "2026-08-30T00:01:00.000Z",
+      blockedReason: "subscription_limit",
+      blockedSource: "codex_rate_limits",
+      blockedScope: "profile",
+    });
+    expect(byId["openai:profile-wide"]).not.toHaveProperty("blockedModel");
+    for (const id of ["openai:expired", "openai:invalid"]) {
+      expect(Object.keys(byId[id]).filter((key) => key.startsWith("blocked"))).toEqual([]);
+    }
+    expect(JSON.stringify(jsonRuntime.jsonPayloads[0])).not.toMatch(
+      /secret|legacy-model-must-not-leak/u,
+    );
   });
 
   it("routes legacy Gemini CLI cooldowns to supported Google API-key setup", async () => {

--- a/src/commands/models/auth-list.test.ts
+++ b/src/commands/models/auth-list.test.ts
@@ -220,6 +220,7 @@ describe("modelsAuthListCommand", () => {
       profiles: {
         "openai:profile-wide": profile,
         "openai:model-scoped": profile,
+        "openai:model-scope-without-model": profile,
         "openai:expired": profile,
         "openai:invalid": profile,
       },
@@ -236,6 +237,12 @@ describe("modelsAuthListCommand", () => {
           blockedSource: "wham",
           blockedScope: "model",
           blockedModel: "gpt-5.5",
+        },
+        "openai:model-scope-without-model": {
+          blockedUntil: NOW + 180_000,
+          blockedReason: "subscription_limit",
+          blockedSource: "wham",
+          blockedScope: "model",
         },
         "openai:expired": {
           blockedUntil: NOW - 1,
@@ -262,6 +269,9 @@ describe("modelsAuthListCommand", () => {
     expect(textRuntime.logs.find((line) => line.includes("openai:model-scoped"))).toContain(
       "blocked:subscription_limit via wham for model gpt-5.5 until 2026-08-30T00:02:00.000Z",
     );
+    expect(
+      textRuntime.logs.find((line) => line.includes("openai:model-scope-without-model")),
+    ).toContain("blocked:subscription_limit via wham for profile until 2026-08-30T00:03:00.000Z");
     for (const id of ["openai:expired", "openai:invalid"]) {
       expect(textRuntime.logs.find((line) => line.includes(id))).not.toContain("blocked:");
     }
@@ -288,6 +298,13 @@ describe("modelsAuthListCommand", () => {
       blockedScope: "profile",
     });
     expect(byId["openai:profile-wide"]).not.toHaveProperty("blockedModel");
+    expect(byId["openai:model-scope-without-model"]).toMatchObject({
+      blockedUntil: "2026-08-30T00:03:00.000Z",
+      blockedReason: "subscription_limit",
+      blockedSource: "wham",
+      blockedScope: "profile",
+    });
+    expect(byId["openai:model-scope-without-model"]).not.toHaveProperty("blockedModel");
     for (const id of ["openai:expired", "openai:invalid"]) {
       const profileEntry = byId[id];
       expect(profileEntry).toBeDefined();

--- a/src/commands/models/auth-list.ts
+++ b/src/commands/models/auth-list.ts
@@ -10,6 +10,7 @@ import {
   type ProfileUsageStats,
 } from "../../agents/auth-profiles.js";
 import { buildAuthProfileUnusableHint } from "../../agents/auth-profiles/oauth-refresh-failure.js";
+import { isActiveUnusableWindow } from "../../agents/auth-profiles/usage-state.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { shortenHomePath } from "../../utils.js";
@@ -24,6 +25,11 @@ type AuthProfileSummary = {
   email?: string;
   displayName?: string;
   expiresAt?: string;
+  blockedUntil?: string;
+  blockedReason?: ProfileUsageStats["blockedReason"];
+  blockedSource?: ProfileUsageStats["blockedSource"];
+  blockedScope?: ProfileUsageStats["blockedScope"] | "profile";
+  blockedModel?: string;
   cooldownUntil?: string;
   disabledUntil?: string;
   cooldownReason?: ProfileUsageStats["cooldownReason"];
@@ -68,6 +74,8 @@ function summarizeProfile(params: {
   usage?: ProfileUsageStats;
 }): AuthProfileSummary {
   const expiresAt = resolveProfileExpiry(params.profile);
+  const blockedActive = isActiveUnusableWindow(params.usage?.blockedUntil, Date.now());
+  const blockedUntil = blockedActive ? formatTimestamp(params.usage?.blockedUntil) : undefined;
   const cooldownUntil = formatTimestamp(params.usage?.cooldownUntil);
   const disabledUntil = formatTimestamp(params.usage?.disabledUntil);
   const disabledActive = Boolean(disabledUntil);
@@ -97,6 +105,17 @@ function summarizeProfile(params: {
     ...(params.profile.email ? { email: params.profile.email } : {}),
     ...(params.profile.displayName ? { displayName: params.profile.displayName } : {}),
     ...(expiresAt ? { expiresAt } : {}),
+    ...(blockedUntil
+      ? {
+          blockedUntil,
+          ...(params.usage?.blockedReason ? { blockedReason: params.usage.blockedReason } : {}),
+          ...(params.usage?.blockedSource ? { blockedSource: params.usage.blockedSource } : {}),
+          blockedScope: params.usage?.blockedScope === "model" ? "model" : "profile",
+          ...(params.usage?.blockedScope === "model" && params.usage.blockedModel
+            ? { blockedModel: params.usage.blockedModel }
+            : {}),
+        }
+      : {}),
     ...(cooldownUntil ? { cooldownUntil } : {}),
     ...(disabledUntil ? { disabledUntil } : {}),
     ...(params.usage?.cooldownReason ? { cooldownReason: params.usage.cooldownReason } : {}),
@@ -112,6 +131,15 @@ function formatProfileLine(profile: AuthProfileSummary): string {
   const details = [`${profile.provider}/${profile.type}`];
   if (profile.expiresAt) {
     details.push(`expires ${profile.expiresAt}`);
+  }
+  if (profile.blockedUntil) {
+    const reason = profile.blockedReason ? `:${profile.blockedReason}` : "";
+    const source = profile.blockedSource ? ` via ${profile.blockedSource}` : "";
+    const scope =
+      profile.blockedScope === "model"
+        ? ` for model${profile.blockedModel ? ` ${profile.blockedModel}` : ""}`
+        : " for profile";
+    details.push(`blocked${reason}${source}${scope} until ${profile.blockedUntil}`);
   }
   if (profile.cooldownUntil) {
     const diagnostic = profile.cooldownClassification ?? profile.cooldownReason;

--- a/src/commands/models/auth-list.ts
+++ b/src/commands/models/auth-list.ts
@@ -76,6 +76,8 @@ function summarizeProfile(params: {
   const expiresAt = resolveProfileExpiry(params.profile);
   const blockedActive = isActiveUnusableWindow(params.usage?.blockedUntil, Date.now());
   const blockedUntil = blockedActive ? formatTimestamp(params.usage?.blockedUntil) : undefined;
+  const blockedModel =
+    params.usage?.blockedScope === "model" ? params.usage.blockedModel : undefined;
   const cooldownUntil = formatTimestamp(params.usage?.cooldownUntil);
   const disabledUntil = formatTimestamp(params.usage?.disabledUntil);
   const disabledActive = Boolean(disabledUntil);
@@ -110,10 +112,8 @@ function summarizeProfile(params: {
           blockedUntil,
           ...(params.usage?.blockedReason ? { blockedReason: params.usage.blockedReason } : {}),
           ...(params.usage?.blockedSource ? { blockedSource: params.usage.blockedSource } : {}),
-          blockedScope: params.usage?.blockedScope === "model" ? "model" : "profile",
-          ...(params.usage?.blockedScope === "model" && params.usage.blockedModel
-            ? { blockedModel: params.usage.blockedModel }
-            : {}),
+          blockedScope: blockedModel ? "model" : "profile",
+          ...(blockedModel ? { blockedModel } : {}),
         }
       : {}),
     ...(cooldownUntil ? { cooldownUntil } : {}),


### PR DESCRIPTION
Closes #133065

## What Problem This Solves

openclaw models auth list reports expiry, cooldown, and disabled windows, but it omits the canonical active subscription-block state already used by auth-profile selection. An unavailable profile can therefore look usable unless an operator inspects private state or infers the cause from a failed run.

Issue triage confirmed the omission is source-reproducible and owner-local: active block facts reach the shared auth-list summary input but are discarded before both human and JSON output.

## Why This Change Was Made

The existing shared auth-profile summary now projects an active, Date-valid blockedUntil together with its closed blockedReason and blockedSource facts. It emits an explicit blockedScope and includes blockedModel only for an explicit model-scoped block with a model name. Human output renders the same sanitized facts.

The implementation reuses the canonical isActiveUnusableWindow predicate and matches selection semantics by treating explicit model scope without a model name as profile-wide. Expired or Date-invalid windows remain omitted, and legacy unscoped model values do not leak into a profile-wide diagnostic.

This is a read-only projection. It does not change auth selection, quota probing, block creation or clearing, cooldowns, retries, persistence, config, or provider behavior.

Existing-solutions preflight: direct inspection of the private auth state is the only complete workaround. models status does not expose these canonical block facts, and a plugin or external library cannot repair the missing core CLI projection. Draft #125573 changes adjacent selection semantics and does not implement this display outcome.

## User Impact

Operators can see why a saved credential is currently unavailable, whether the block applies to the whole profile or one model, which canonical detector supplied it, and when it expires. They can distinguish subscription blocks from transient cooldowns and disabled credentials before retrying or rotating profiles.

## Evidence

Acceptance red, captured before the production edit:

- An isolated store supplied active profile-wide and model-scoped subscription blocks to modelsAuthListCommand.
- The focused acceptance assertion failed because the human output contained none of the block facts.

Acceptance green on exact head 66eb0ca94bb83375507e8605da2035895f2ea53b (Node 24.18.0):

    OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs src/commands/models/auth-list.test.ts
    Test Files  1 passed (1)
    Tests       9 passed (9)

The focused matrix covers active profile and model scope, reason/source, expired and Date-invalid windows, suppression of legacy unscoped model data, normalization of model scope without a model name to profile scope, text/JSON alignment, and credential redaction.

Production-path readback used an isolated OPENCLAW_STATE_DIR, persisted a sanitized credential and block through saveAuthProfileStore into the normal SQLite owner, then invoked the production modelsAuthListCommand:

    stored block source=wham scope=model model=gpt-5.5
    models auth list readback=- openai:proof [openai/api_key; blocked:subscription_limit via wham for model gpt-5.5 until 2026-08-30T05:02:40.209Z]
    credential redaction=pass

Exact-head edge-state readback persisted an explicit model scope without a model name through the same SQLite owner and invoked the production command:

    models auth list readback=- openai:proof [openai/api_key; blocked:subscription_limit via wham for profile until 2026-08-30T05:58:14.697Z]
    scope alignment=pass
    credential redaction=pass

Additional checks:

    node_modules/.bin/oxfmt --check src/commands/models/auth-list.ts src/commands/models/auth-list.test.ts
    All matched files use the correct format.

    node_modules/.bin/oxlint src/commands/models/auth-list.ts src/commands/models/auth-list.test.ts
    (clean)

    git diff --check
    (clean)

    .agents/skills/autoreview/scripts/autoreview --mode local
    autoreview scoped-clean: no accepted/actionable findings
    overall: patch is correct (0.99)

Change size:

- Production: +28 LOC
- Tests: +114 / -1 LOC
- Files: 2
- Generated/lock files: none

Compatibility and risk:

- No config, default, protocol, schema, persistence, provider-routing, or mutation changes.
- Credential values and raw provider responses remain excluded from output.
- Existing expiry, cooldown, and disabled projections remain unchanged.
- Known limit: this reports the canonical stored block window; it does not invent quota remaining, reset semantics, or provider-specific guidance.

AI-assisted discovery and implementation. Source owners, callers, selection consumers, sibling diagnostic surfaces, history, tests, dependency contracts, and live competing PRs were reviewed. No secrets or personal data are included.
