### PR TITLE
fix(agents): enforce native MCP tool policy

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1708,7 +1708,7 @@ src/agents/cli-credentials.ts	10
 src/agents/cli-executable-identity.ts	3
 src/agents/cli-output-records.ts	1
 src/agents/cli-runner.ts	1
-src/agents/cli-runner/bundle-mcp-codex.ts	5
+src/agents/cli-runner/bundle-mcp-codex.ts	4
 src/agents/cli-runner/bundle-mcp-gemini.ts	4
 src/agents/cli-runner/bundle-mcp-runtime.ts	1
 src/agents/cli-runner/bundle-mcp.ts	6

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -343,6 +343,25 @@ When bundle MCP is enabled, OpenClaw:
 - loads enabled bundle-MCP servers for the current workspace and merges them with any existing backend MCP config/settings shape;
 - rewrites the launch config using the backend-owned integration mode from the owning plugin.
 
+`tools.allow` and `tools.deny` also constrain configured native MCP servers.
+OpenClaw lists each server through its session-scoped runtime, assigns the same
+provider-safe `<safe-server>__<safe-tool>` identities used by embedded tools,
+and applies the complete layered policy before process spawn or Codex
+`thread/start`/`thread/resume`. It then projects exact raw names into each
+backend's enforcement contract: Claude receives server omission plus bare
+`--disallowedTools` entries, Codex receives `enabled_tools` and
+`disabled_tools`, and Gemini receives `includeTools` and `excludeTools`.
+Configured server filters and session overrides remain additional
+restrictions. These backend fields are generated implementation details; keep
+operator policy in OpenClaw configuration.
+
+For example, `agents.entries.research.tools.allow: ["docs__read_docs"]`
+exposes only that tool from the safe `docs` namespace, while
+`deny: ["docs__delete_*"]` removes matching siblings. An empty intersection
+omits the affected MCP server. A server whose restrictive catalog cannot be
+established is also omitted and reported instead of being passed through
+unfiltered.
+
 Restricted runs such as cron jobs with `toolsAllow` require an exact
 backend-owned translation. The bundled `claude-cli` backend disables Claude's
 native tools and user, project, and local customizations, including hooks,

--- a/docs/tools/multi-agent-sandbox-tools.md
+++ b/docs/tools/multi-agent-sandbox-tools.md
@@ -238,6 +238,31 @@ The filtering order is:
 
 Tool policies support `group:*` shorthands that expand to multiple tools. See [Tool groups](/gateway/sandbox-vs-tool-policy-vs-elevated#tool-groups-shorthands) for the full list.
 
+Configured MCP tools use the same policy surface. Their canonical names are
+`<safe-server>__<safe-tool>`; globs can target a server namespace. For example:
+
+```json5
+{
+  agents: {
+    entries: {
+      research: {
+        tools: {
+          allow: ["docs__read_docs"],
+          deny: ["docs__delete_*"],
+        },
+      },
+    },
+  },
+}
+```
+
+Every restrictive layer intersects with the earlier layers, and deny always
+wins. OpenClaw projects the resulting raw tool set into native Claude, Codex,
+and Gemini MCP filters before their first model turn. Backend-native names and
+settings are implementation details, not a second operator policy surface. An
+MCP server with no allowed tool is omitted. A restrictive catalog failure also
+omits that server and records a diagnostic instead of failing open.
+
 Per-agent elevated overrides (`agents.entries.*.tools.elevated`) can further restrict elevated exec for specific agents. See [Elevated mode](/tools/elevated) for details.
 
 ---
@@ -385,6 +410,7 @@ After configuring multi-agent sandbox and tools:
     - Check the [full filtering order](#tool-restrictions): profile → provider profile → global policy → provider policy → agent policy → agent provider policy → sandbox → subagent.
     - Each level can only further restrict, not grant back.
     - See [Sandbox vs tool policy vs elevated](/gateway/sandbox-vs-tool-policy-vs-elevated) for step-by-step debugging.
+    - For MCP tools, use the provider-safe name shown by OpenClaw, such as `docs__read_docs` or `docs__*`; do not use a backend's raw config field name.
 
   </Accordion>
   <Accordion title="Container not isolated per agent">

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -309,10 +309,7 @@ describe("resolveClaudeCliExecutionArgs", () => {
           "--disallowedTools",
           "ScheduleWakeup,mcp__other__*",
         ],
-        toolAvailability: {
-          native: [],
-          openClaw: ["openclaw"],
-        },
+        toolAvailability: { native: [], openClaw: ["openclaw"] },
       }),
     ).toEqual([
       "-p",
@@ -333,6 +330,8 @@ describe("resolveClaudeCliExecutionArgs", () => {
       "",
       "--allowedTools",
       "mcp__openclaw__openclaw",
+      "--disallowedTools",
+      "ScheduleWakeup,mcp__other__*",
     ]);
   });
 
@@ -384,10 +383,7 @@ describe("resolveClaudeCliExecutionArgs", () => {
           "--disallowedTools",
           "ScheduleWakeup,mcp__other__*",
         ],
-        toolAvailability: {
-          native: [],
-          openClaw: ["message"],
-        },
+        toolAvailability: { native: [], openClaw: ["message"] },
       }),
     ).toEqual([
       "-p",
@@ -406,6 +402,8 @@ describe("resolveClaudeCliExecutionArgs", () => {
       "",
       "--allowedTools",
       "mcp__openclaw__message",
+      "--disallowedTools",
+      "ScheduleWakeup,mcp__other__*",
     ]);
   });
 
@@ -464,7 +462,7 @@ describe("resolveClaudeCliExecutionArgs", () => {
       "--tools",
       "",
       "--disallowedTools",
-      "mcp__*",
+      "mcp__*,mcp__other__*",
     ]);
   });
 

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -409,6 +409,21 @@ function resolveClaudeCliRestrictedExecutionArgs(
   baseArgs: readonly string[],
   availability: NonNullable<CliBackendResolveExecutionArgsContext["toolAvailability"]>,
 ): string[] {
+  const preservedDenials: string[] = [];
+  for (let i = 0; i < baseArgs.length; i += 1) {
+    const arg = baseArgs[i] ?? "";
+    if (arg === CLAUDE_DISALLOWED_TOOLS_ARG || arg === "--disallowed-tools") {
+      while (typeof baseArgs[i + 1] === "string" && !baseArgs[i + 1]?.startsWith("-")) {
+        i += 1;
+        preservedDenials.push(...(baseArgs[i] ?? "").split(","));
+      }
+    } else if (
+      arg.startsWith(`${CLAUDE_DISALLOWED_TOOLS_ARG}=`) ||
+      arg.startsWith("--disallowed-tools=")
+    ) {
+      preservedDenials.push(...arg.slice(arg.indexOf("=") + 1).split(","));
+    }
+  }
   const normalized = stripClaudeArgs(baseArgs, {
     bare: CLAUDE_RESTRICTED_BARE_ARGS,
     variadicValue: CLAUDE_RESTRICTED_VARIADIC_VALUE_ARGS,
@@ -433,8 +448,15 @@ function resolveClaudeCliRestrictedExecutionArgs(
       CLAUDE_ALLOWED_TOOLS_ARG,
       availability.openClaw.map((toolName) => `${OPENCLAW_MCP_TOOL_PREFIX}${toolName}`).join(","),
     );
-  } else {
-    normalized.push(CLAUDE_DISALLOWED_TOOLS_ARG, CLAUDE_DENY_MCP_TOOLS_VALUE);
+  }
+  const denials = [
+    ...new Set([
+      ...preservedDenials.map((entry) => entry.trim()).filter(Boolean),
+      ...(availability.openClaw.length === 0 ? [CLAUDE_DENY_MCP_TOOLS_VALUE] : []),
+    ]),
+  ].toSorted();
+  if (denials.length > 0) {
+    normalized.push(CLAUDE_DISALLOWED_TOOLS_ARG, denials.join(","));
   }
   return normalized;
 }

--- a/extensions/codex/src/app-server/thread-lifecycle-preflight.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-preflight.ts
@@ -3,7 +3,7 @@ import {
   formatErrorMessage,
   isHostScopedAgentToolActive,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { buildCodexUserMcpServersThreadConfigPatchForRuntime } from "openclaw/plugin-sdk/codex-mcp-projection";
+import { buildCodexUserMcpServersThreadConfigPatchForRun } from "openclaw/plugin-sdk/codex-mcp-projection";
 import { getCodexAppServerClientInstanceId } from "./client.js";
 import { assertCodexModelBackedReviewerEffectiveConfig } from "./config-reviewer.js";
 import {
@@ -76,11 +76,12 @@ export async function prepareCodexThreadLifecyclePreflight(params: CodexStartOrR
   const userMcpServersConfigPatch =
     params.userMcpServersEnabled === false
       ? undefined
-      : await buildCodexUserMcpServersThreadConfigPatchForRuntime(params.params.config, {
+      : await buildCodexUserMcpServersThreadConfigPatchForRun({
+          run: params.params,
+          cwd: params.cwd,
           agentId: params.agentId ?? params.params.agentId,
-          agentDir: params.params.agentDir,
           allowLiteralOAuthProjection: params.appServer.connectionClass !== "remote",
-          toolOverrides: params.params.toolOverrides,
+          warn: (message) => embeddedAgentLog.warn(message),
           onServerUnavailable: (serverName, error) =>
             embeddedAgentLog.warn("skipping unavailable MCP OAuth server", {
               serverName,

--- a/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
@@ -1,5 +1,6 @@
 // Codex tests cover thread lifecycle.user mcp servers plugin behavior.
 import fs from "node:fs/promises";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
@@ -21,6 +22,83 @@ import {
   threadStartResult,
 } from "./thread-lifecycle.test-fixtures.js";
 
+const activeHttpServers = new Set<http.Server>();
+
+async function startPolicyHttpServer(): Promise<string> {
+  const server = http.createServer((request, response) => {
+    void (async () => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.from(chunk));
+      }
+      const body = Buffer.concat(chunks).toString("utf8");
+      if (!body) {
+        response.writeHead(202).end();
+        return;
+      }
+      const message = JSON.parse(body) as {
+        id?: string | number;
+        method?: string;
+      };
+      if (message.id === undefined) {
+        response.writeHead(202).end();
+        return;
+      }
+      const result =
+        message.method === "initialize"
+          ? {
+              protocolVersion: "2024-11-05",
+              capabilities: { tools: {} },
+              serverInfo: { name: "policy-http-probe", version: "1" },
+            }
+          : message.method === "tools/list"
+            ? {
+                tools: [
+                  { name: "read_docs", description: "read", inputSchema: { type: "object" } },
+                ],
+              }
+            : {};
+      response
+        .writeHead(200, { "content-type": "application/json" })
+        .end(JSON.stringify({ jsonrpc: "2.0", id: message.id, result }));
+    })();
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  activeHttpServers.add(server);
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected loopback MCP server address");
+  }
+  return `http://127.0.0.1:${address.port}/mcp`;
+}
+
+async function writePolicyProbeServer(dir: string): Promise<string> {
+  const filePath = path.join(dir, "policy-probe.mjs");
+  await fs.writeFile(
+    filePath,
+    `import readline from "node:readline";
+import { appendFileSync } from "node:fs";
+if (process.env.OPENCLAW_POLICY_PROBE_STARTED) appendFileSync(process.env.OPENCLAW_POLICY_PROBE_STARTED, "started\\n");
+const lines = readline.createInterface({ input: process.stdin });
+const send = (id, result) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\\n");
+lines.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") send(message.id, { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: "policy-probe", version: "1" } });
+  if (message.method === "tools/list") send(message.id, { tools: [
+    { name: "read_docs", description: "read", inputSchema: { type: "object" } },
+    { name: "delete_docs", description: "delete", inputSchema: { type: "object" } },
+    { name: "task_docs", description: "task", inputSchema: { type: "object" }, execution: { taskSupport: "required" } },
+    { name: "app_docs", description: "app", inputSchema: { type: "object" }, _meta: { ui: { visibility: ["app"] } } }
+  ] });
+});
+`,
+    "utf-8",
+  );
+  return filePath;
+}
+
 describe("startOrResumeThread — user mcp.servers projection (regression: #80814)", () => {
   let tempDir = "";
 
@@ -33,6 +111,16 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
 
   afterEach(async () => {
     resetThreadLifecycleTestFixtures();
+    await Promise.all(
+      [...activeHttpServers].map(
+        (server) =>
+          new Promise<void>((resolve, reject) => {
+            server.closeAllConnections();
+            server.close((error) => (error ? reject(error) : resolve()));
+          }),
+      ),
+    );
+    activeHttpServers.clear();
     if (tempDir) {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
@@ -41,6 +129,7 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
   it("projects cfg.mcp.servers into the thread/start config patch under mcp_servers", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
+    const serverPath = await writePolicyProbeServer(tempDir);
     const request = vi.fn(async (method: string, _params: unknown) => {
       if (method === "thread/start") {
         return threadStartResult();
@@ -53,10 +142,10 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
       params: createParams(sessionFile, workspaceDir, {
         mcp: {
           servers: {
-            outlook: {
+            docs: {
               transport: "stdio",
-              command: "node",
-              args: ["/opt/outlook-mcp/dist/index.js"],
+              command: process.execPath,
+              args: [serverPath],
             },
           },
         },
@@ -70,14 +159,161 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
     const startParams = startCall?.[1] as { config?: { mcp_servers?: Record<string, unknown> } };
     expect(startParams?.config?.mcp_servers).toBeDefined();
     expect(startParams.config!.mcp_servers).toMatchObject({
-      outlook: { command: "node", args: ["/opt/outlook-mcp/dist/index.js"] },
+      docs: {
+        command: process.execPath,
+        args: [serverPath],
+        enabled_tools: ["delete_docs", "read_docs"],
+        disabled_tools: ["app_docs", "task_docs"],
+      },
     });
+  });
+
+  it("projects wildcard filters as exact names before thread/start and thread/resume", async () => {
+    const sessionFile = path.join(tempDir, "policy-session.jsonl");
+    registerCodexTestSessionIdentity(sessionFile, "session-1", "agent:main:session-1");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const serverPath = await writePolicyProbeServer(tempDir);
+    const config: EmbeddedRunAttemptParams["config"] = {
+      tools: { allow: ["docs__*"] },
+      mcp: {
+        servers: {
+          docs: {
+            transport: "stdio",
+            command: process.execPath,
+            args: [serverPath],
+            toolFilter: { exclude: ["delete_*"] },
+          },
+        },
+      },
+    };
+    const request = vi.fn(async (method: string, _params: unknown) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-policy");
+      }
+      if (method === "thread/resume") {
+        return threadResumeResult("thread-policy");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const run = async () =>
+      await startOrResumeThread({
+        client: { request } as never,
+        params: createParams(sessionFile, workspaceDir, config),
+        cwd: workspaceDir,
+        dynamicTools: [],
+        appServer: createAppServerOptions(),
+      });
+
+    await run();
+    await run();
+
+    for (const method of ["thread/start", "thread/resume"]) {
+      const call = request.mock.calls.find(([candidate]) => candidate === method);
+      const callParams = call?.[1] as {
+        config?: {
+          mcp_servers?: { docs?: { enabled_tools?: string[]; disabled_tools?: string[] } };
+        };
+      };
+      expect(callParams?.config?.mcp_servers?.docs).toMatchObject({
+        enabled_tools: ["read_docs"],
+        disabled_tools: ["app_docs", "delete_docs", "task_docs"],
+      });
+      expect(JSON.stringify(callParams?.config?.mcp_servers?.docs)).not.toContain("delete_*");
+    }
+  });
+
+  it("keeps session MCP denials additive in thread/start before the turn", async () => {
+    const sessionFile = path.join(tempDir, "policy-session-override.jsonl");
+    registerCodexTestSessionIdentity(
+      sessionFile,
+      "session-override",
+      "agent:main:session-override",
+    );
+    const workspaceDir = path.join(tempDir, "workspace-override");
+    const serverPath = await writePolicyProbeServer(tempDir);
+    const config: EmbeddedRunAttemptParams["config"] = {
+      tools: { allow: ["docs__*"] },
+      mcp: {
+        servers: {
+          docs: { transport: "stdio", command: process.execPath, args: [serverPath] },
+        },
+      },
+    };
+    const request = vi.fn(async (method: string, _params: unknown) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-session-override");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const run: EmbeddedRunAttemptParams = {
+      ...createParams(sessionFile, workspaceDir, config),
+      toolOverrides: { mcpToolsDeny: { docs: ["delete_docs"] } },
+    };
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params: run,
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createAppServerOptions(),
+    });
+
+    const callParams = request.mock.calls[0]?.[1] as {
+      config?: { mcp_servers?: { docs?: { enabled_tools?: string[]; disabled_tools?: string[] } } };
+    };
+    expect(callParams.config?.mcp_servers?.docs).toMatchObject({
+      enabled_tools: ["read_docs"],
+      disabled_tools: ["app_docs", "delete_docs", "task_docs"],
+    });
+  });
+
+  it("does not start an MCP server scoped to another Codex agent", async () => {
+    const sessionFile = path.join(tempDir, "agent-scope-session.jsonl");
+    registerCodexTestSessionIdentity(sessionFile, "scope-session", "agent:main:scope-session");
+    const workspaceDir = path.join(tempDir, "workspace-scope");
+    const serverPath = await writePolicyProbeServer(tempDir);
+    const startedPath = path.join(tempDir, "excluded-server-started");
+    const config: EmbeddedRunAttemptParams["config"] = {
+      tools: { deny: ["docs__delete_docs"] },
+      mcp: {
+        servers: {
+          docs: {
+            transport: "stdio",
+            command: process.execPath,
+            args: [serverPath],
+            env: { OPENCLAW_POLICY_PROBE_STARTED: startedPath },
+            codex: { agents: ["worker"] },
+          },
+        },
+      },
+    };
+    const request = vi.fn(async (method: string, _params: unknown) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-agent-scope");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params: createParams(sessionFile, workspaceDir, config),
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createAppServerOptions(),
+    });
+
+    await expect(fs.access(startedPath)).rejects.toMatchObject({ code: "ENOENT" });
+    const callParams = request.mock.calls[0]?.[1] as {
+      config?: { mcp_servers?: Record<string, unknown> };
+    };
+    expect(callParams.config?.mcp_servers?.docs).toBeUndefined();
   });
 
   it("stores large user MCP server fingerprints as bounded hashes", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     registerCodexTestSessionIdentity(sessionFile, "session-1", "agent:main:session-1");
     const workspaceDir = path.join(tempDir, "workspace");
+    const serverPath = await writePolicyProbeServer(tempDir);
     const request = vi.fn(async (method: string, _params: unknown) => {
       if (method === "thread/start") {
         return threadStartResult();
@@ -89,20 +325,13 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
       client: { request } as never,
       params: createParams(sessionFile, workspaceDir, {
         mcp: {
-          servers: Object.fromEntries(
-            Array.from({ length: 120 }, (_, index) => [
-              `server_${index}`,
-              {
-                transport: "stdio",
-                command: "node",
-                args: [
-                  `/opt/openclaw/mcp/server-${index}/dist/index.js`,
-                  "--description",
-                  "x".repeat(400),
-                ],
-              },
-            ]),
-          ),
+          servers: {
+            server_large: {
+              transport: "stdio",
+              command: process.execPath,
+              args: [serverPath, "--description", "x".repeat(60_000)],
+            },
+          },
         },
       } as unknown as EmbeddedRunAttemptParams["config"]),
       cwd: workspaceDir,
@@ -113,22 +342,23 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
     const binding = await readCodexAppServerBinding(sessionFile);
     expect(binding?.userMcpServersFingerprint).toMatch(/^sha256:[a-f0-9]{64}$/);
     expect(binding?.userMcpServersFingerprint?.length).toBe(71);
-    expect(binding?.userMcpServersFingerprint).not.toContain("server_119");
+    expect(binding?.userMcpServersFingerprint).not.toContain("x".repeat(100));
   });
 
   it.each(["raw", "doctor-hashed"] as const)(
-    "resumes beta5 user MCP bindings stored as %s fingerprints",
+    "restarts beta5 user MCP bindings stored as %s fingerprints before converging",
     async (legacyForm) => {
       const sessionFile = path.join(tempDir, "session.jsonl");
       registerCodexTestSessionIdentity(sessionFile, "session-1", "agent:main:session-1");
       const workspaceDir = path.join(tempDir, "workspace");
       const authorization = "Bearer beta5-access-token";
+      const url = await startPolicyHttpServer();
       const config = {
         mcp: {
           servers: {
             ducktape: {
               transport: "streamable-http",
-              url: "https://agents.ducktape.xyz/mcp",
+              url,
               headers: {
                 Authorization: authorization,
                 "x-tenant": "keep",
@@ -166,7 +396,7 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
               Authorization: authorization,
               "x-tenant": "keep",
             },
-            url: "https://agents.ducktape.xyz/mcp",
+            url,
           },
         },
       });
@@ -180,7 +410,7 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
 
       request.mockClear();
       await run();
-      expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);
+      expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/start"]);
       const convergedBinding = await readCodexAppServerBinding(sessionFile);
       expect(convergedBinding?.userMcpServersFingerprint).toMatch(/^sha256:[a-f0-9]{64}$/);
       expect(convergedBinding?.userMcpServersFingerprint).not.toContain("beta5-access-token");
@@ -199,6 +429,7 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
     const sessionFile = path.join(tempDir, "session.jsonl");
     registerCodexTestSessionIdentity(sessionFile, "session-1", "agent:atlas:session-1");
     const workspaceDir = path.join(tempDir, "workspace");
+    const url = await startPolicyHttpServer();
     const request = vi.fn(async (method: string, _params: unknown) => {
       if (method === "thread/start") {
         return threadStartResult();
@@ -214,7 +445,7 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
             servers: {
               atlas: {
                 transport: "streamable-http",
-                url: "https://atlas.example.com/mcp",
+                url,
                 codex: {
                   agents: ["atlas"],
                   defaultToolsApprovalMode: "approve",
@@ -222,7 +453,7 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
               },
               apolo: {
                 transport: "streamable-http",
-                url: "https://apolo.example.com/mcp",
+                url,
                 codex: {
                   agents: ["apolo"],
                   defaultToolsApprovalMode: "approve",
@@ -245,8 +476,9 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
     const startParams = startCall?.[1] as { config?: { mcp_servers?: Record<string, unknown> } };
     expect(startParams?.config?.mcp_servers).toStrictEqual({
       atlas: {
-        url: "https://atlas.example.com/mcp",
+        url,
         default_tools_approval_mode: "approve",
+        enabled_tools: ["read_docs"],
       },
     });
   });
@@ -312,6 +544,7 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
   it("starts a new thread when an existing binding lacks the matching user MCP fingerprint", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
+    const serverPath = await writePolicyProbeServer(tempDir);
 
     await writeCodexAppServerBinding(sessionFile, {
       threadId: "thread-existing",
@@ -334,8 +567,8 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
           servers: {
             notes: {
               transport: "stdio",
-              command: "node",
-              args: ["/opt/notes-mcp/dist/index.js"],
+              command: process.execPath,
+              args: [serverPath],
             },
           },
         },
@@ -352,7 +585,7 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
     };
     expect(startParams?.config?.mcp_servers).toBeDefined();
     expect(startParams.config!.mcp_servers).toMatchObject({
-      notes: { command: "node", args: ["/opt/notes-mcp/dist/index.js"] },
+      notes: { command: process.execPath, args: [serverPath] },
     });
   });
 
@@ -539,13 +772,14 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
     const sessionFile = path.join(tempDir, "session.jsonl");
     registerCodexTestSessionIdentity(sessionFile, "session-1", "agent:main:session-1");
     const workspaceDir = path.join(tempDir, "workspace");
+    const url = await startPolicyHttpServer();
     const createConfig = (authorization: string) =>
       ({
         mcp: {
           servers: {
             ducktape: {
               transport: "streamable-http",
-              url: "https://agents.ducktape.xyz/mcp",
+              url,
               headers: {
                 Authorization: authorization,
                 "x-tenant": "keep",
@@ -600,9 +834,21 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
     );
   });
 
-  it("omits MCP OAuth servers instead of sending bearers to a remote app-server", async () => {
+  it("omits MCP OAuth servers before policy discovery for a remote app-server", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
+    let mcpRequestCount = 0;
+    const mcpServer = http.createServer((_request, response) => {
+      mcpRequestCount += 1;
+      response.writeHead(401).end();
+    });
+    await new Promise<void>((resolve) => {
+      mcpServer.listen(0, "127.0.0.1", resolve);
+    });
+    const address = mcpServer.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected loopback MCP server address");
+    }
     const request = vi.fn(async (method: string, _params: unknown) => {
       if (method === "thread/start") {
         return threadStartResult("thread-without-oauth-mcp");
@@ -610,44 +856,58 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
       throw new Error(`unexpected method: ${method}`);
     });
 
-    await startOrResumeThread({
-      client: { request } as never,
-      params: createParams(sessionFile, workspaceDir, {
-        mcp: {
-          servers: {
-            ducktape: {
-              transport: "streamable-http",
-              url: "https://agents.ducktape.xyz/mcp",
-              auth: "oauth",
-              oauth: { authProfileId: "ducktape:mcp" },
+    try {
+      await startOrResumeThread({
+        client: { request } as never,
+        params: createParams(sessionFile, workspaceDir, {
+          tools: { deny: ["ducktape__restricted"] },
+          mcp: {
+            servers: {
+              ducktape: {
+                transport: "streamable-http",
+                url: `http://127.0.0.1:${address.port}/mcp`,
+                auth: "oauth",
+              },
             },
           },
+        } as unknown as EmbeddedRunAttemptParams["config"]),
+        cwd: workspaceDir,
+        dynamicTools: [],
+        appServer: {
+          ...createAppServerOptions(),
+          connectionClass: "remote",
         },
-      } as unknown as EmbeddedRunAttemptParams["config"]),
-      cwd: workspaceDir,
-      dynamicTools: [],
-      appServer: {
-        ...createAppServerOptions(),
-        connectionClass: "remote",
-      },
-    });
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        mcpServer.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    }
 
     const startParams = request.mock.calls[0]?.[1] as {
       config?: { mcp_servers?: Record<string, unknown> };
     };
     expect(startParams?.config?.mcp_servers).toBeUndefined();
+    expect(mcpRequestCount).toBe(0);
   });
 
   it("resends user MCP config when resuming a thread with the matching fingerprint", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
+    const serverPath = await writePolicyProbeServer(tempDir);
     const config = {
       mcp: {
         servers: {
           notes: {
             transport: "stdio",
-            command: "node",
-            args: ["/opt/notes-mcp/dist/index.js"],
+            command: process.execPath,
+            args: [serverPath],
           },
         },
       },
@@ -686,7 +946,7 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
     };
     expect(resumeCall).toBeDefined();
     expect(resumeParams?.config?.mcp_servers).toMatchObject({
-      notes: { command: "node", args: ["/opt/notes-mcp/dist/index.js"] },
+      notes: { command: process.execPath, args: [serverPath] },
     });
   });
 });

--- a/src/agents/agent-bundle-mcp-combined.ts
+++ b/src/agents/agent-bundle-mcp-combined.ts
@@ -16,6 +16,14 @@ type CombinedSessionMcpRuntime = SessionMcpRuntime & {
   managedParts: readonly SessionMcpRuntime[];
 };
 
+function compareCatalogTools(left: McpCatalogTool, right: McpCatalogTool): number {
+  return (
+    left.safeServerName.localeCompare(right.safeServerName) ||
+    left.toolName.localeCompare(right.toolName) ||
+    left.serverName.localeCompare(right.serverName)
+  );
+}
+
 export function isCombinedSessionMcpRuntime(
   runtime: SessionMcpRuntime,
 ): runtime is CombinedSessionMcpRuntime {
@@ -29,6 +37,7 @@ export function isCombinedSessionMcpRuntime(
 export function mergeMcpToolCatalogs(catalogs: readonly McpToolCatalog[]): McpToolCatalog {
   const servers: Record<string, McpServerCatalog> = {};
   const tools: McpCatalogTool[] = [];
+  const policyTools: McpCatalogTool[] = [];
   const sessionDeniedTools: McpCatalogTool[] = [];
   const diagnostics: McpToolCatalogDiagnostic[] = [];
 
@@ -39,6 +48,9 @@ export function mergeMcpToolCatalogs(catalogs: readonly McpToolCatalog[]): McpTo
       servers[serverName] = server;
     }
     tools.push(...catalog.tools);
+    policyTools.push(
+      ...(catalog.policyTools ?? [...catalog.tools, ...(catalog.sessionDeniedTools ?? [])]),
+    );
     if (catalog.sessionDeniedTools) {
       sessionDeniedTools.push(...catalog.sessionDeniedTools);
     }
@@ -46,30 +58,15 @@ export function mergeMcpToolCatalogs(catalogs: readonly McpToolCatalog[]): McpTo
       diagnostics.push(...catalog.diagnostics);
     }
   }
-  tools.sort((a, b) => {
-    const serverOrder = a.safeServerName.localeCompare(b.safeServerName);
-    if (serverOrder !== 0) {
-      return serverOrder;
-    }
-    const toolOrder = a.toolName.localeCompare(b.toolName);
-    if (toolOrder !== 0) {
-      return toolOrder;
-    }
-    return a.serverName.localeCompare(b.serverName);
-  });
-  sessionDeniedTools.sort((a, b) => {
-    const serverOrder = a.safeServerName.localeCompare(b.safeServerName);
-    return (
-      serverOrder ||
-      a.toolName.localeCompare(b.toolName) ||
-      a.serverName.localeCompare(b.serverName)
-    );
-  });
+  tools.sort(compareCatalogTools);
+  policyTools.sort(compareCatalogTools);
+  sessionDeniedTools.sort(compareCatalogTools);
   return {
     version: 1,
     generatedAt: Math.max(0, ...catalogs.map((catalog) => catalog.generatedAt)),
     servers,
     tools,
+    ...(policyTools.length > 0 ? { policyTools } : {}),
     ...(sessionDeniedTools.length > 0 ? { sessionDeniedTools } : {}),
     ...(diagnostics.length > 0 ? { diagnostics } : {}),
   };

--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -246,24 +246,34 @@ export function buildBundleMcpToolsFromCatalog(params: {
   createPromptListExecute?: (serverName: string) => AnyAgentTool["execute"];
   createPromptGetExecute?: (serverName: string) => AnyAgentTool["execute"];
   includeSessionDenied?: boolean;
+  includeAppOnlyInventory?: boolean;
 }): AnyAgentTool[] {
   const initialReservedNames = normalizeReservedToolNames(params.reservedToolNames);
   const sessionDeniedOnly = params.includeSessionDenied === true;
-  // Preserve executable IDs by allocating them before denied-only inventory rows.
-  const tools = sessionDeniedOnly
+  const appOnlyInventory = params.includeAppOnlyInventory === true;
+  // Preserve callable IDs by allocating them before hidden inventory rows.
+  const tools = appOnlyInventory
     ? buildBundleMcpToolsFromCatalog({
         ...params,
         reservedToolNames: initialReservedNames,
-        includeSessionDenied: false,
+        includeAppOnlyInventory: false,
       })
-    : [];
+    : sessionDeniedOnly
+      ? buildBundleMcpToolsFromCatalog({
+          ...params,
+          reservedToolNames: initialReservedNames,
+          includeSessionDenied: false,
+        })
+      : [];
   const reservedNames = normalizeReservedToolNames([
     ...initialReservedNames,
     ...tools.map((tool) => tool.name),
   ]);
-  const catalogTools = sessionDeniedOnly
-    ? (params.catalog.sessionDeniedTools ?? [])
-    : params.catalog.tools;
+  const catalogTools = appOnlyInventory
+    ? params.catalog.tools.filter(isAppOnlyTool)
+    : sessionDeniedOnly
+      ? (params.catalog.sessionDeniedTools ?? [])
+      : params.catalog.tools;
   const sortedCatalogTools = [...catalogTools].toSorted((a, b) => {
     const serverOrder = a.safeServerName.localeCompare(b.safeServerName);
     if (serverOrder !== 0) {
@@ -277,7 +287,8 @@ export function buildBundleMcpToolsFromCatalog(params: {
   });
 
   for (const tool of sortedCatalogTools) {
-    if (isAppOnlyTool(tool)) {
+    const appOnly = isAppOnlyTool(tool);
+    if (appOnly && !appOnlyInventory) {
       continue;
     }
     const originalName = tool.toolName.trim();
@@ -321,6 +332,9 @@ export function buildBundleMcpToolsFromCatalog(params: {
         safeServerName: tool.safeServerName,
         toolName: tool.toolName,
         operation: "tool",
+        ...(tool.excludedFromOpenClawCatalog || appOnly
+          ? { excludedFromOpenClawCatalog: true }
+          : {}),
         ...(tool.deniedBySession ? { deniedBySession: true } : {}),
         codexApproval: {
           mode: server?.codexApprovalMode ?? "auto",

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -2549,6 +2549,11 @@ process.on("SIGINT", shutdown);`,
     try {
       const catalog = await runtime.getCatalog();
       expect(catalog.tools.map((tool) => tool.toolName)).toEqual(["structured-1", "structured-2"]);
+      expect(
+        catalog.policyTools
+          ?.filter((tool) => tool.excludedFromOpenClawCatalog)
+          .map((tool) => tool.toolName),
+      ).toEqual(["task_only-1", "task_only-2"]);
       await expect(runtime.callTool("paged", "structured-1", {})).rejects.toThrow(
         "does not match the tool's output schema",
       );
@@ -4459,6 +4464,23 @@ describe("requester-scoped MCP connection resolution", () => {
               fallbackDescription: "send",
             },
           ],
+          policyTools: [
+            {
+              serverName,
+              safeServerName: safe,
+              toolName: "send",
+              inputSchema: { type: "object", properties: {} },
+              fallbackDescription: "send",
+            },
+            {
+              serverName,
+              safeServerName: safe,
+              toolName: "delete",
+              inputSchema: { type: "object", properties: {} },
+              fallbackDescription: "delete",
+              excludedFromOpenClawCatalog: true,
+            },
+          ],
         }),
       };
     };
@@ -4500,6 +4522,13 @@ describe("requester-scoped MCP connection resolution", () => {
     // Merge preserves precomputed names (no further re-suffix).
     const merged = testing.mergeMcpToolCatalogs([catalogA, catalogB]);
     expect(merged.servers["mail.prod"]?.safeServerName).toBe("mail-prod");
+    expect(
+      new Set(
+        merged.policyTools
+          ?.filter((tool) => tool.toolName === "delete")
+          .map((tool) => tool.safeServerName),
+      ),
+    ).toEqual(new Set(["mail-prod", "mail-prod-2"]));
 
     await manager.disposeAll();
   });

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -568,6 +568,9 @@ export function createSessionMcpRuntime(params: {
       const tools: McpCatalogTool[] = (retryBaseCatalog?.tools ?? []).filter(
         (tool) => !retryServerNames?.has(tool.serverName),
       );
+      const policyTools: McpCatalogTool[] = (retryBaseCatalog?.policyTools ?? []).filter(
+        (tool) => !retryServerNames?.has(tool.serverName),
+      );
       const sessionDeniedTools: McpCatalogTool[] = (
         retryBaseCatalog?.sessionDeniedTools ?? []
       ).filter((tool) => !retryServerNames?.has(tool.serverName));
@@ -637,6 +640,7 @@ export function createSessionMcpRuntime(params: {
           serverName: string;
           serverEntry: McpServerCatalog | null;
           toolEntries: McpCatalogTool[];
+          policyToolEntries: McpCatalogTool[];
           diagnostics: McpToolCatalogDiagnostic[];
         };
 
@@ -793,9 +797,13 @@ export function createSessionMcpRuntime(params: {
                   codexApprovalMode: resolveMcpCodexToolApprovalMode(serverName, rawServer),
                 };
                 const toolEntries: McpCatalogTool[] = [];
-                for (const [tool, deniedBySession] of [
-                  ...normalizedTools.tools.map((entry) => [entry, false] as const),
-                  ...normalizedTools.deniedTools.map((entry) => [entry, true] as const),
+                const policyToolEntries: McpCatalogTool[] = [];
+                for (const [tool, excludedFromOpenClawCatalog, deniedBySession] of [
+                  ...normalizedTools.tools.map((entry) => [entry, false, false] as const),
+                  ...normalizedTools.deniedTools.map((entry) => [entry, false, true] as const),
+                  ...normalizedTools.excludedTools.map(
+                    (entry) => [entry, true, deniedToolNames.has(entry.name)] as const,
+                  ),
                 ]) {
                   const toolName = tool.name;
                   const { _meta: metadata } = tool;
@@ -809,7 +817,7 @@ export function createSessionMcpRuntime(params: {
                       ? rawResourceUri
                       : undefined;
                   const uiVisibility = normalizeToolUiVisibility(uiMeta?.visibility);
-                  toolEntries.push({
+                  const entry: McpCatalogTool = {
                     serverName,
                     safeServerName,
                     toolName,
@@ -819,14 +827,22 @@ export function createSessionMcpRuntime(params: {
                     fallbackDescription: `Provided by bundle MCP server "${serverName}" (${launchDescription}).`,
                     ...(uiResourceUri ? { uiResourceUri } : {}),
                     ...(uiVisibility ? { uiVisibility } : {}),
+                    ...(excludedFromOpenClawCatalog
+                      ? { excludedFromOpenClawCatalog: true as const }
+                      : {}),
                     ...(deniedBySession ? { deniedBySession: true } : {}),
                     codexAnnotations: normalizeMcpCodexToolAnnotations(tool.annotations),
-                  });
+                  };
+                  policyToolEntries.push(entry);
+                  if (!entry.excludedFromOpenClawCatalog) {
+                    toolEntries.push(entry);
+                  }
                 }
                 return {
                   serverName,
                   serverEntry,
                   toolEntries,
+                  policyToolEntries,
                   diagnostics: [] as McpToolCatalogDiagnostic[],
                 };
               } catch (error) {
@@ -859,6 +875,7 @@ export function createSessionMcpRuntime(params: {
                   serverName,
                   serverEntry: null,
                   toolEntries: [],
+                  policyToolEntries: [],
                   diagnostics: diags,
                 } as ServerResult;
               }
@@ -877,7 +894,7 @@ export function createSessionMcpRuntime(params: {
           if (!result) {
             continue;
           }
-          const { serverEntry, toolEntries, diagnostics: serverDiags } = result;
+          const { serverEntry, toolEntries, policyToolEntries, diagnostics: serverDiags } = result;
           if (serverEntry) {
             servers[result.serverName] = serverEntry;
           }
@@ -888,6 +905,7 @@ export function createSessionMcpRuntime(params: {
               tools.push(tool);
             }
           }
+          policyTools.push(...policyToolEntries);
           diagnostics.push(...serverDiags);
         }
 
@@ -897,6 +915,7 @@ export function createSessionMcpRuntime(params: {
           generatedAt: Date.now(),
           servers,
           tools,
+          ...(policyTools.length > 0 ? { policyTools } : {}),
           ...(sessionDeniedTools.length > 0 ? { sessionDeniedTools } : {}),
           ...(diagnostics.length > 0 ? { diagnostics } : {}),
         };

--- a/src/agents/agent-bundle-mcp-types.ts
+++ b/src/agents/agent-bundle-mcp-types.ts
@@ -56,6 +56,8 @@ export type McpCatalogTool = {
   fallbackDescription: string;
   uiResourceUri?: string;
   uiVisibility?: Array<"app" | "model">;
+  /** Listed by the server but excluded from OpenClaw's callable tool catalog. */
+  excludedFromOpenClawCatalog?: true;
   deniedBySession?: true;
   codexAnnotations?: McpCodexToolAnnotations;
 };
@@ -66,6 +68,8 @@ export type McpToolCatalog = {
   generatedAt: number;
   servers: Record<string, McpServerCatalog>;
   tools: McpCatalogTool[];
+  /** Complete raw catalog used to project policy into native MCP clients. */
+  policyTools?: McpCatalogTool[];
   /** Listed tools hidden only by the session override, retained for read-only inventory. */
   sessionDeniedTools?: McpCatalogTool[];
   diagnostics?: readonly McpToolCatalogDiagnostic[];
@@ -77,6 +81,18 @@ export type RequesterMcpConnect = {
   authorizedServerNames: readonly string[];
   configFingerprint: string;
   createExecute: (serverName: string) => AnyAgentTool["execute"] | undefined;
+};
+
+type PreparedNativeMcpServerPolicy = {
+  serverName: string;
+  safeServerName: string;
+  allowedTools: string[];
+  deniedTools: string[];
+};
+
+/** Concrete raw/safe policy fact prepared once for native MCP adapters. */
+export type PreparedNativeMcpPolicy = {
+  servers: Record<string, PreparedNativeMcpServerPolicy>;
 };
 
 export type McpToolCatalogDiagnostic = {

--- a/src/agents/cli-runner/bundle-mcp-claude.ts
+++ b/src/agents/cli-runner/bundle-mcp-claude.ts
@@ -63,6 +63,12 @@ function mergeClaudeDisallowedTools(args: string[], deniedTools: string[]): stri
   return next;
 }
 
+function normalizeClaudeMcpIdentifierPart(value: string): string {
+  // Claude Code replaces punctuation before registering MCP permission names.
+  // Match that wire identity so a raw-name collision cannot bypass a denial.
+  return value.replaceAll(/[^a-zA-Z0-9_-]/g, "_");
+}
+
 export function injectClaudeWebSearchDisabledArgs(args: string[] | undefined): string[] {
   return mergeClaudeDisallowedTools(args ?? [], ["WebSearch"]);
 }
@@ -92,7 +98,10 @@ export function injectClaudeMcpConfigArgs(
   }
   next.push("--strict-mcp-config", "--mcp-config", mcpConfigPath);
   const deniedTools = Object.entries(mcpToolsDeny ?? {}).flatMap(([serverName, toolNames]) =>
-    toolNames.map((toolName) => `mcp__${serverName}__${toolName}`),
+    toolNames.map(
+      (toolName) =>
+        `mcp__${normalizeClaudeMcpIdentifierPart(serverName)}__${normalizeClaudeMcpIdentifierPart(toolName)}`,
+    ),
   );
   if (webSearchEnabled === false) {
     deniedTools.push("WebSearch");

--- a/src/agents/cli-runner/bundle-mcp-codex.ts
+++ b/src/agents/cli-runner/bundle-mcp-codex.ts
@@ -6,14 +6,20 @@ import type { SessionToolOverrides } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { BundleMcpConfig, BundleMcpServerConfig } from "../../plugins/bundle-mcp.js";
 import { isValidAgentId, normalizeAgentId } from "../../routing/session-key.js";
+import { getOrCreateSessionMcpRuntime } from "../agent-bundle-mcp-manager-api.js";
+import type { PreparedNativeMcpPolicy } from "../agent-bundle-mcp-types.js";
 import { isRecord } from "../bundle-mcp-adapter.js";
 import {
   applyCodexSessionMcpToolDenials,
   buildCodexMcpServersConfig,
   normalizeCodexMcpServerConfig,
 } from "../codex-mcp-config.js";
+import { resolveConversationCapabilityProfile } from "../conversation-capability-profile.js";
+import type { EmbeddedRunAttemptParams } from "../embedded-agent-runner/run/types.js";
 import { requiresMcpBearerProjection, resolveMcpBearerBundleConfig } from "../mcp-auth-profile.js";
 import { partitionMcpServersByConnectionScope } from "../mcp-connection-resolver.js";
+import { applyPreparedNativeMcpPolicy, prepareNativeMcpPolicy } from "../native-mcp-policy.js";
+import { resolveSandboxRuntimeStatus } from "../sandbox/runtime-status.js";
 import { serializeTomlInlineValue } from "./toml-inline.js";
 
 // Mutable JSON shape structurally compatible with the bundled Codex
@@ -36,6 +42,7 @@ type CodexUserMcpServersProjectionOptions = {
   allowLiteralOAuthProjection?: boolean;
   onServerUnavailable?: (serverName: string, error: unknown) => void;
   toolOverrides?: Pick<SessionToolOverrides, "mcpServers" | "mcpToolsDeny">;
+  preparedNativeMcpPolicy?: PreparedNativeMcpPolicy;
 };
 
 function normalizeAgentIds(value: unknown): string[] {
@@ -97,6 +104,39 @@ function readSessionMcpServerOverride(
   return overrides && Object.hasOwn(overrides, name) ? overrides[name] : undefined;
 }
 
+function selectCodexProjectableMcpServers(
+  cfg: OpenClawConfig | undefined,
+  options: CodexUserMcpServersProjectionOptions | undefined,
+): BundleMcpConfig["mcpServers"] {
+  const userServers = normalizeConfiguredMcpServers(cfg?.mcp?.servers);
+  // Fail-closed: requester-scoped servers never enter harness-native MCP config.
+  const { staticServers } = partitionMcpServersByConnectionScope(userServers);
+  return Object.fromEntries(
+    Object.entries(staticServers).filter(([serverName, server]) => {
+      const serverOverride = readSessionMcpServerOverride(options, serverName);
+      const allowed =
+        serverOverride !== false &&
+        (serverOverride === true || server.enabled !== false) &&
+        isCodexMcpServerAllowedForAgent(server as BundleMcpServerConfig, options);
+      if (!allowed) {
+        return false;
+      }
+      // Remote app servers cannot receive OpenClaw-managed bearer credentials.
+      // Omit these servers before catalog discovery can use that credential.
+      if (options?.allowLiteralOAuthProjection === false && requiresMcpBearerProjection(server)) {
+        options.onServerUnavailable?.(
+          serverName,
+          new Error(
+            `MCP OAuth bearer projection is only supported for local app-server connections.`,
+          ),
+        );
+        return false;
+      }
+      return true;
+    }),
+  ) as BundleMcpConfig["mcpServers"];
+}
+
 /** Returns Codex CLI args with TOML MCP server overrides injected. */
 export function injectCodexMcpConfigArgs(
   args: string[] | undefined,
@@ -122,10 +162,7 @@ export function buildCodexUserMcpServersThreadConfigPatch(
   cfg: OpenClawConfig | undefined,
   options?: CodexUserMcpServersProjectionOptions,
 ): { mcp_servers: CodexThreadConfigObject } | undefined {
-  const userServers = normalizeConfiguredMcpServers(cfg?.mcp?.servers);
-  // Fail-closed: requester-scoped servers never enter harness-native MCP config.
-  const { staticServers } = partitionMcpServersByConnectionScope(userServers);
-  const entries = Object.entries(staticServers);
+  const entries = Object.entries(selectCodexProjectableMcpServers(cfg, options));
   if (entries.length === 0) {
     return undefined;
   }
@@ -133,13 +170,6 @@ export function buildCodexUserMcpServersThreadConfigPatch(
   // prototype setter under plain assignment and vanish from the patch.
   const projected: [string, CodexThreadConfigObject][] = [];
   for (const [name, server] of entries) {
-    const serverOverride = readSessionMcpServerOverride(options, name);
-    if (serverOverride === false || (serverOverride !== true && server.enabled === false)) {
-      continue;
-    }
-    if (!isCodexMcpServerAllowedForAgent(server as BundleMcpServerConfig, options)) {
-      continue;
-    }
     projected.push([
       name,
       normalizeCodexMcpServerConfig(
@@ -160,41 +190,12 @@ export async function buildCodexUserMcpServersThreadConfigPatchForRuntime(
   cfg: OpenClawConfig | undefined,
   options?: CodexUserMcpServersProjectionOptions,
 ): Promise<{ mcp_servers: CodexThreadConfigObject } | undefined> {
-  const userServers = normalizeConfiguredMcpServers(cfg?.mcp?.servers);
-  // Fail-closed: requester-scoped servers never enter harness-native MCP config.
-  const { staticServers } = partitionMcpServersByConnectionScope(userServers);
-  const entries = Object.entries(staticServers);
-  if (entries.length === 0) {
-    return undefined;
-  }
-  let allowedServers = Object.fromEntries(
-    entries.filter(([name, server]) => {
-      const serverOverride = readSessionMcpServerOverride(options, name);
-      return (
-        serverOverride !== false &&
-        (serverOverride === true || server.enabled !== false) &&
-        isCodexMcpServerAllowedForAgent(server as BundleMcpServerConfig, options)
-      );
-    }),
-  ) as BundleMcpConfig["mcpServers"];
-  if (Object.keys(allowedServers).length === 0) {
-    return undefined;
-  }
-  if (options?.allowLiteralOAuthProjection === false) {
-    const remoteSafeServers: BundleMcpConfig["mcpServers"] = {};
-    for (const [serverName, server] of Object.entries(allowedServers)) {
-      if (requiresMcpBearerProjection(server)) {
-        options.onServerUnavailable?.(
-          serverName,
-          new Error(
-            `MCP OAuth bearer projection is only supported for local app-server connections.`,
-          ),
-        );
-        continue;
-      }
-      remoteSafeServers[serverName] = server;
-    }
-    allowedServers = remoteSafeServers;
+  let allowedServers = selectCodexProjectableMcpServers(cfg, options);
+  if (options?.preparedNativeMcpPolicy) {
+    allowedServers = applyPreparedNativeMcpPolicy(
+      { mcpServers: allowedServers },
+      options.preparedNativeMcpPolicy,
+    ).mcpServers;
   }
   if (Object.keys(allowedServers).length === 0) {
     return undefined;
@@ -217,4 +218,112 @@ export async function buildCodexUserMcpServersThreadConfigPatchForRuntime(
     ]),
   );
   return Object.keys(mcp_servers).length === 0 ? undefined : { mcp_servers };
+}
+
+/** Prepares canonical native MCP policy and projects it into Codex before thread creation. */
+export async function buildCodexUserMcpServersThreadConfigPatchForRun(params: {
+  run: Omit<EmbeddedRunAttemptParams, "admittedRunContext">;
+  cwd: string;
+  agentId?: string;
+  allowLiteralOAuthProjection?: boolean;
+  onServerUnavailable?: (serverName: string, error: unknown) => void;
+  warn?: (message: string) => void;
+}): Promise<{ mcp_servers: CodexThreadConfigObject } | undefined> {
+  const run = params.run;
+  const agentId = params.agentId ?? run.agentId;
+  const scopedToolOverrides = resolveCodexMcpToolOverridesForAgent(run.config, {
+    agentId,
+    toolOverrides: run.toolOverrides,
+  });
+  const policySessionKey = run.sandboxSessionKey ?? run.sessionKey;
+  const sandboxStatus = resolveSandboxRuntimeStatus({
+    cfg: run.config,
+    sessionKey: policySessionKey,
+    agentId,
+  });
+  const capabilityProfile = resolveConversationCapabilityProfile({
+    config: run.config,
+    sessionKey: policySessionKey,
+    runSessionKey:
+      run.sessionKey && run.sessionKey !== policySessionKey ? run.sessionKey : undefined,
+    sessionId: run.sessionId,
+    runId: run.runId,
+    agentId,
+    agentDir: run.agentDir,
+    agentAccountId: run.agentAccountId,
+    messageProvider: run.messageProvider ?? run.messageChannel,
+    messageChannel: run.messageChannel,
+    chatType: run.chatType,
+    messageTo: run.messageTo,
+    messageThreadId: run.messageThreadId,
+    currentChannelId: run.currentChannelId,
+    currentMessagingTarget: run.currentMessagingTarget,
+    currentThreadTs: run.currentThreadTs,
+    currentMessageId: run.currentMessageId,
+    groupId: run.groupId,
+    groupChannel: run.groupChannel,
+    groupSpace: run.groupSpace,
+    memberRoleIds: run.memberRoleIds,
+    spawnedBy: run.spawnedBy,
+    senderId: run.senderId,
+    senderName: run.senderName,
+    senderUsername: run.senderUsername,
+    senderE164: run.senderE164,
+    senderIsOwner: run.senderIsOwner,
+    modelProvider: run.provider,
+    modelId: run.modelId,
+    modelApi: run.model?.api,
+    modelContextWindowTokens: run.model?.contextWindow,
+    modelHasVision: run.model?.input?.includes("image") ?? false,
+    workspaceDir: run.workspaceDir,
+    cwd: params.cwd,
+    skillsSnapshot: run.skillsSnapshot,
+    sandboxToolPolicy: sandboxStatus.sandboxed ? sandboxStatus.toolPolicy : undefined,
+    runtimeToolAllowlist: run.toolsAllow,
+    inheritRuntimeToolAllowlist: true,
+    runtimePluginToolGrant: run.runtimePluginToolGrant,
+    inputProvenance: run.inputProvenance,
+    trustedInternalHandoff: run.trustedInternalHandoff,
+    scheduledToolPolicy: run.scheduledToolPolicy,
+  });
+  const configuredMcpServers = selectCodexProjectableMcpServers(run.config, {
+    agentId,
+    allowLiteralOAuthProjection: params.allowLiteralOAuthProjection,
+    onServerUnavailable: params.onServerUnavailable,
+    toolOverrides: scopedToolOverrides,
+  });
+  if (Object.keys(configuredMcpServers).length === 0) {
+    return undefined;
+  }
+  const projectionConfig: OpenClawConfig = {
+    ...run.config,
+    mcp: { ...run.config?.mcp, servers: configuredMcpServers },
+  };
+  const runtime = await getOrCreateSessionMcpRuntime({
+    sessionId: run.sessionId,
+    sessionKey: run.sessionKey,
+    workspaceDir: run.workspaceDir,
+    agentDir: run.agentDir,
+    cfg: projectionConfig,
+    requesterSenderId: run.senderId,
+    agentAccountId: run.agentAccountId,
+    messageChannel: run.messageChannel,
+    toolOverrides: scopedToolOverrides,
+  });
+  const preparedNativeMcpPolicy = await prepareNativeMcpPolicy({
+    runtime,
+    config: run.config,
+    workspaceDir: run.workspaceDir,
+    capabilityProfile,
+    runtimeToolsAllow: run.toolsAllow,
+    warn: params.warn ?? (() => {}),
+  });
+  return await buildCodexUserMcpServersThreadConfigPatchForRuntime(projectionConfig, {
+    agentId,
+    agentDir: run.agentDir,
+    allowLiteralOAuthProjection: params.allowLiteralOAuthProjection,
+    onServerUnavailable: params.onServerUnavailable,
+    toolOverrides: scopedToolOverrides,
+    preparedNativeMcpPolicy,
+  });
 }

--- a/src/agents/cli-runner/bundle-mcp-gemini.ts
+++ b/src/agents/cli-runner/bundle-mcp-gemini.ts
@@ -79,7 +79,7 @@ function normalizeGeminiServerConfig(
   server: BundleMcpServerConfig,
   inheritedEnv: Record<string, string> | undefined,
   deniedTools: readonly string[] | undefined,
-): Record<string, unknown> {
+): Record<string, unknown> | undefined {
   const next = normalizeBundleMcpServerConfig(server, GEMINI_MCP_SERVER_FIELDS);
   const headers = normalizeMcpStringRecord(server.headers);
   if (headers) {
@@ -90,11 +90,33 @@ function normalizeGeminiServerConfig(
       ]),
     );
   }
-  if (deniedTools?.length) {
+  const toolFilter = isRecord(server.toolFilter) ? server.toolFilter : {};
+  const included = Array.isArray(toolFilter.include)
+    ? toolFilter.include.filter((name): name is string => typeof name === "string")
+    : [];
+  if (included.length > 0) {
+    const existing = Array.isArray(server.includeTools)
+      ? server.includeTools.filter((name): name is string => typeof name === "string")
+      : [];
+    const finalIncluded =
+      existing.length > 0
+        ? included.filter((name) => existing.includes(name)).toSorted()
+        : [...new Set(included)].toSorted();
+    if (finalIncluded.length === 0) {
+      return undefined;
+    }
+    next.includeTools = finalIncluded;
+  }
+  const filteredDenied = Array.isArray(toolFilter.exclude)
+    ? toolFilter.exclude.filter((name): name is string => typeof name === "string")
+    : [];
+  if (deniedTools?.length || filteredDenied.length > 0) {
     const existing = Array.isArray(server.excludeTools)
       ? server.excludeTools.filter((name): name is string => typeof name === "string")
       : [];
-    next.excludeTools = [...new Set([...existing, ...deniedTools])].toSorted();
+    next.excludeTools = [
+      ...new Set([...existing, ...filteredDenied, ...(deniedTools ?? [])]),
+    ].toSorted();
   }
   return next;
 }
@@ -109,14 +131,14 @@ export async function writeGeminiSystemSettings(
   const base = await readGeminiBaseSettings(inheritedEnv);
   const normalizedConfig: BundleMcpConfig = {
     mcpServers: Object.fromEntries(
-      Object.entries(mergedConfig.mcpServers).map(([name, server]) => [
-        name,
-        normalizeGeminiServerConfig(
+      Object.entries(mergedConfig.mcpServers).flatMap(([name, server]) => {
+        const normalized = normalizeGeminiServerConfig(
           server,
           inheritedEnv,
           mcpToolsDeny && Object.hasOwn(mcpToolsDeny, name) ? mcpToolsDeny[name] : undefined,
-        ),
-      ]),
+        );
+        return normalized ? [[name, normalized]] : [];
+      }),
     ) as BundleMcpConfig["mcpServers"],
   };
   const settings = applyMergePatch(

--- a/src/agents/cli-runner/bundle-mcp.codex.test.ts
+++ b/src/agents/cli-runner/bundle-mcp.codex.test.ts
@@ -1,6 +1,15 @@
 /** Tests Codex CLI bundle-MCP config override generation. */
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { prepareCliBundleMcpConfig } from "./bundle-mcp.js";
+import {
+  cliBundleMcpHarness,
+  cliNativeMcpPolicyContext,
+  setupCliBundleMcpTestHarness,
+  writeCliMcpPolicyProbeServer,
+} from "./bundle-mcp.test-support.js";
+
+setupCliBundleMcpTestHarness();
 
 describe("prepareCliBundleMcpConfig codex", () => {
   it("disables Codex native web search without bundle MCP", async () => {
@@ -37,6 +46,54 @@ describe("prepareCliBundleMcpConfig codex", () => {
       'disabled_tools = ["delete_docs"]',
     );
     expect(prepared.backend.args).toContain('web_search="disabled"');
+  });
+
+  it("projects configured wildcard filters as exact Codex CLI overrides", async () => {
+    const serverPath = await writeCliMcpPolicyProbeServer();
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      tools: { allow: ["docs__*"] },
+      mcp: {
+        servers: {
+          docs: {
+            command: process.execPath,
+            args: [serverPath],
+            toolFilter: { exclude: ["delete_*"] },
+          },
+        },
+      },
+    };
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "codex-config-overrides",
+      backend: { command: "codex", args: ["exec"] },
+      workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+      config,
+      nativeMcpPolicy: cliNativeMcpPolicyContext(config, "codex-cli-policy"),
+    });
+    const override = prepared.backend.args?.find((arg) => arg.startsWith("mcp_servers="));
+    expect(override).toContain('enabled_tools = ["read_docs"]');
+    expect(override).toContain('disabled_tools = ["app_docs", "delete_docs", "task_docs"]');
+    expect(override).not.toContain("delete_*");
+  });
+
+  it("hides non-model MCP tools from Codex without an explicit policy", async () => {
+    const serverPath = await writeCliMcpPolicyProbeServer();
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      mcp: { servers: { docs: { command: process.execPath, args: [serverPath] } } },
+    };
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "codex-config-overrides",
+      backend: { command: "codex", args: ["exec"] },
+      workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+      config,
+      nativeMcpPolicy: cliNativeMcpPolicyContext(config, "codex-default-hidden"),
+    });
+    const override = prepared.backend.args?.find((arg) => arg.startsWith("mcp_servers="));
+    expect(override).toContain('enabled_tools = ["delete_docs", "read_docs"]');
+    expect(override).toContain('disabled_tools = ["app_docs", "task_docs"]');
   });
 
   it("injects codex MCP config overrides with env-backed loopback headers", async () => {

--- a/src/agents/cli-runner/bundle-mcp.gemini.test.ts
+++ b/src/agents/cli-runner/bundle-mcp.gemini.test.ts
@@ -3,7 +3,16 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { prepareCliBundleMcpCaptureAttempt, prepareCliBundleMcpConfig } from "./bundle-mcp.js";
+import {
+  cliBundleMcpHarness,
+  cliNativeMcpPolicyContext,
+  setupCliBundleMcpTestHarness,
+  writeCliMcpPolicyProbeServer,
+} from "./bundle-mcp.test-support.js";
+
+setupCliBundleMcpTestHarness();
 
 describe("prepareCliBundleMcpConfig gemini", () => {
   it("disables Gemini native web search without bundle MCP", async () => {
@@ -76,6 +85,81 @@ describe("prepareCliBundleMcpConfig gemini", () => {
     expect(raw.mcpServers?.openclaw?.excludeTools).toEqual(["delete_docs", "global_delete"]);
     expect(raw.tools?.exclude).toEqual(["google_web_search"]);
 
+    await prepared.cleanup?.();
+  });
+
+  it("projects canonical allow and deny sets into Gemini settings", async () => {
+    const serverPath = await writeCliMcpPolicyProbeServer();
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      tools: { allow: ["docs__read_docs"], deny: ["docs__delete_docs"] },
+      mcp: { servers: { docs: { command: process.execPath, args: [serverPath] } } },
+    };
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "gemini-system-settings",
+      backend: { command: "gemini" },
+      workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+      config,
+      nativeMcpPolicy: cliNativeMcpPolicyContext(config, "gemini-policy"),
+    });
+    const raw = JSON.parse(
+      await fs.readFile(prepared.env?.GEMINI_CLI_SYSTEM_SETTINGS_PATH as string, "utf-8"),
+    ) as { mcpServers?: { docs?: { includeTools?: string[]; excludeTools?: string[] } } };
+    expect(raw.mcpServers?.docs).toMatchObject({
+      includeTools: ["read_docs"],
+      excludeTools: ["app_docs", "delete_docs", "task_docs"],
+    });
+    await prepared.cleanup?.();
+  });
+
+  it("hides non-model MCP tools from Gemini without an explicit policy", async () => {
+    const serverPath = await writeCliMcpPolicyProbeServer();
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      mcp: { servers: { docs: { command: process.execPath, args: [serverPath] } } },
+    };
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "gemini-system-settings",
+      backend: { command: "gemini" },
+      workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+      config,
+      nativeMcpPolicy: cliNativeMcpPolicyContext(config, "gemini-default-hidden"),
+    });
+    const raw = JSON.parse(
+      await fs.readFile(prepared.env?.GEMINI_CLI_SYSTEM_SETTINGS_PATH as string, "utf-8"),
+    ) as { mcpServers?: { docs?: { includeTools?: string[]; excludeTools?: string[] } } };
+    expect(raw.mcpServers?.docs).toMatchObject({
+      includeTools: ["delete_docs", "read_docs"],
+      excludeTools: ["app_docs", "task_docs"],
+    });
+    await prepared.cleanup?.();
+  });
+
+  it("omits a server when configured and policy allowlists do not overlap", async () => {
+    const serverPath = await writeCliMcpPolicyProbeServer();
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "gemini-system-settings",
+      backend: { command: "gemini" },
+      workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+      exclusiveConfig: {
+        mcpServers: {
+          docs: {
+            command: process.execPath,
+            args: [serverPath],
+            includeTools: ["legacy_only"],
+            toolFilter: { include: ["read_docs"] },
+          },
+        },
+      },
+    });
+    const raw = JSON.parse(
+      await fs.readFile(prepared.env?.GEMINI_CLI_SYSTEM_SETTINGS_PATH as string, "utf-8"),
+    ) as { mcp?: { allowed?: string[] }; mcpServers?: Record<string, unknown> };
+    expect(raw.mcp?.allowed).not.toContain("docs");
+    expect(raw.mcpServers?.docs).toBeUndefined();
     await prepared.cleanup?.();
   });
 

--- a/src/agents/cli-runner/bundle-mcp.test-support.ts
+++ b/src/agents/cli-runner/bundle-mcp.test-support.ts
@@ -1,4 +1,5 @@
 /** Shared test harness for CLI runner bundle-MCP config preparation tests. */
+import fs from "node:fs/promises";
 import { afterAll, beforeAll } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
@@ -6,6 +7,7 @@ import {
   createBundleProbePlugin,
 } from "../../plugins/bundle-mcp.test-support.js";
 import { captureEnv, setTestEnvValue, withEnvAsync } from "../../test-utils/env.js";
+import { resolveConversationCapabilityProfile } from "../conversation-capability-profile.js";
 import { prepareCliBundleMcpConfig } from "./bundle-mcp.js";
 
 const tempHarness = createBundleMcpTempHarness();
@@ -55,6 +57,45 @@ export function setupCliBundleMcpTestHarness(): void {
     envSnapshot?.restore();
     await tempHarness.cleanup();
   });
+}
+
+export async function writeCliMcpPolicyProbeServer(): Promise<string> {
+  const filePath = `${cliBundleMcpHarness.bundleProbeWorkspaceDir}/policy-probe.mjs`;
+  await fs.writeFile(
+    filePath,
+    `import readline from "node:readline";
+const lines = readline.createInterface({ input: process.stdin });
+const send = (id, result) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\\n");
+lines.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") send(message.id, { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: "policy-probe", version: "1" } });
+  if (message.method === "tools/list") send(message.id, { tools: [
+    { name: "read_docs", description: "read", inputSchema: { type: "object" } },
+    { name: "delete_docs", description: "delete", inputSchema: { type: "object" } },
+    { name: "task_docs", description: "task", inputSchema: { type: "object" }, execution: { taskSupport: "required" } },
+    { name: "app_docs", description: "app", inputSchema: { type: "object" }, _meta: { ui: { visibility: ["app"] } } }
+  ] });
+});
+`,
+    "utf-8",
+  );
+  return filePath;
+}
+
+export function cliNativeMcpPolicyContext(config: OpenClawConfig, sessionId: string) {
+  return {
+    sessionId,
+    sessionKey: `agent:main:${sessionId}`,
+    capabilityProfile: resolveConversationCapabilityProfile({
+      config,
+      sessionKey: `agent:main:${sessionId}`,
+      sessionId,
+      agentId: "main",
+      modelProvider: "openai",
+      modelId: "gpt-5.4-codex",
+      workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+    }),
+  };
 }
 
 function createEnabledBundleProbeConfig(): OpenClawConfig {

--- a/src/agents/cli-runner/bundle-mcp.test.ts
+++ b/src/agents/cli-runner/bundle-mcp.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   resolveBundlePluginRoot,
   writeBundleTextFiles,
@@ -12,9 +13,11 @@ import { withEnvAsync } from "../../test-utils/env.js";
 import { prepareCliBundleMcpCaptureAttempt, prepareCliBundleMcpConfig } from "./bundle-mcp.js";
 import {
   cliBundleMcpHarness,
+  cliNativeMcpPolicyContext,
   prepareBundleProbeCliConfig,
   requireMcpConfigPath,
   setupCliBundleMcpTestHarness,
+  writeCliMcpPolicyProbeServer,
 } from "./bundle-mcp.test-support.js";
 
 setupCliBundleMcpTestHarness();
@@ -207,6 +210,211 @@ describe("prepareCliBundleMcpConfig", () => {
     });
 
     expect(prepared.backend.args).toContain("Bash(rm *),WebSearch,mcp__docs__delete_docs");
+    await prepared.cleanup?.();
+  });
+
+  it("matches Claude's normalized MCP permission identifiers", async () => {
+    const workspaceDir = await cliBundleMcpHarness.tempHarness.createTempDir(
+      "openclaw-cli-bundle-mcp-normalized-deny-",
+    );
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "claude-config-file",
+      backend: { command: "claude", args: ["--print"] },
+      workspaceDir,
+      config: { plugins: { enabled: false } },
+      exclusiveConfig: { mcpServers: { "docs.prod": { command: "node" } } },
+      toolOverrides: { mcpToolsDeny: { "docs.prod": ["read.value", "read:value"] } },
+    });
+
+    const args = prepared.backend.args?.join(",") ?? "";
+    expect(args.match(/mcp__docs_prod__read_value/g) ?? []).toHaveLength(1);
+    await prepared.cleanup?.();
+  });
+
+  it("projects durable policy into the first Claude process config and argv", async () => {
+    const serverPath = await writeCliMcpPolicyProbeServer();
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      tools: { allow: ["docs__*"], deny: ["docs__delete_docs"] },
+      mcp: { servers: { docs: { command: process.execPath, args: [serverPath] } } },
+    };
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "claude-config-file",
+      backend: { command: "claude", args: ["--print"] },
+      workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+      config,
+      additionalConfig: {
+        mcpServers: { openclaw: { url: "http://127.0.0.1:31783/mcp" } },
+      },
+      toolOverrides: { mcpToolsDeny: { openclaw: ["message"] } },
+      nativeMcpPolicy: cliNativeMcpPolicyContext(config, "claude-policy"),
+    });
+
+    const args = prepared.backend.args?.join(",") ?? "";
+    expect(args).toContain("mcp__docs__delete_docs");
+    expect(args).toContain("mcp__docs__task_docs");
+    expect(args).toContain("mcp__docs__app_docs");
+    expect(args).toContain("mcp__openclaw__message");
+    const raw = JSON.parse(
+      await fs.readFile(requireMcpConfigPath(prepared.backend.args), "utf-8"),
+    ) as { mcpServers?: Record<string, { toolFilter?: unknown }> };
+    expect(Object.keys(raw.mcpServers ?? {})).toEqual(["docs", "openclaw"]);
+    expect(raw.mcpServers?.docs?.toolFilter).toBeUndefined();
+    await prepared.cleanup?.();
+  });
+
+  it("hides non-model MCP tools from Claude without an explicit policy", async () => {
+    const serverPath = await writeCliMcpPolicyProbeServer();
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      mcp: { servers: { docs: { command: process.execPath, args: [serverPath] } } },
+    };
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "claude-config-file",
+      backend: { command: "claude", args: ["--print"] },
+      workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+      config,
+      nativeMcpPolicy: cliNativeMcpPolicyContext(config, "claude-default-hidden"),
+    });
+
+    const args = prepared.backend.args?.join(",") ?? "";
+    expect(args).toContain("mcp__docs__app_docs");
+    expect(args).toContain("mcp__docs__task_docs");
+    expect(args).not.toContain("mcp__docs__read_docs");
+    expect(args).not.toContain("mcp__docs__delete_docs");
+    await prepared.cleanup?.();
+  });
+
+  it("projects configured MCP filters into Claude denials without a global tool policy", async () => {
+    const serverPath = await writeCliMcpPolicyProbeServer();
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      mcp: {
+        servers: {
+          docs: {
+            command: process.execPath,
+            args: [serverPath],
+            toolFilter: { include: ["read_*"] },
+          },
+        },
+      },
+    };
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "claude-config-file",
+      backend: { command: "claude", args: ["--print"] },
+      workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+      config,
+      nativeMcpPolicy: cliNativeMcpPolicyContext(config, "claude-configured-filter"),
+    });
+
+    const args = prepared.backend.args?.join(",") ?? "";
+    expect(args).toContain("mcp__docs__delete_docs");
+    expect(args).toContain("mcp__docs__task_docs");
+    expect(args).toContain("mcp__docs__app_docs");
+    expect(args).not.toContain("mcp__docs__read_docs");
+    await prepared.cleanup?.();
+  });
+
+  it("projects an exact runtime cap into Claude before spawn", async () => {
+    const serverPath = await writeCliMcpPolicyProbeServer();
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      mcp: { servers: { docs: { command: process.execPath, args: [serverPath] } } },
+    };
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "claude-config-file",
+      backend: { command: "claude", args: ["--print"] },
+      workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+      config,
+      nativeMcpPolicy: {
+        ...cliNativeMcpPolicyContext(config, "claude-runtime-cap"),
+        runtimeToolsAllow: ["docs__read_docs"],
+      },
+    });
+
+    const args = prepared.backend.args?.join(",") ?? "";
+    expect(args).toContain("mcp__docs__delete_docs");
+    expect(args).toContain("mcp__docs__task_docs");
+    expect(args).toContain("mcp__docs__app_docs");
+    expect(args).not.toContain("mcp__docs__read_docs");
+    await prepared.cleanup?.();
+  });
+
+  it("omits a fully excluded server while retaining an allowed sibling server", async () => {
+    const serverPath = await writeCliMcpPolicyProbeServer();
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      tools: { allow: ["docs__read_docs"] },
+      mcp: {
+        servers: {
+          docs: { command: process.execPath, args: [serverPath] },
+          admin: { command: process.execPath, args: [serverPath] },
+        },
+      },
+    };
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "claude-config-file",
+      backend: { command: "claude", args: ["--print"] },
+      workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+      config,
+      nativeMcpPolicy: cliNativeMcpPolicyContext(config, "claude-server-omission"),
+    });
+    const raw = JSON.parse(
+      await fs.readFile(requireMcpConfigPath(prepared.backend.args), "utf-8"),
+    ) as { mcpServers?: Record<string, unknown> };
+
+    expect(Object.keys(raw.mcpServers ?? {})).toEqual(["docs"]);
+    await prepared.cleanup?.();
+  });
+
+  it("omits every configured MCP server removed by durable policy", async () => {
+    const serverPath = await writeCliMcpPolicyProbeServer();
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      tools: { allow: ["missing__tool"] },
+      mcp: { servers: { docs: { command: process.execPath, args: [serverPath] } } },
+    };
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "claude-config-file",
+      backend: { command: "claude", args: ["--print"] },
+      workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+      config,
+      nativeMcpPolicy: cliNativeMcpPolicyContext(config, "claude-policy-empty"),
+    });
+    const raw = JSON.parse(
+      await fs.readFile(requireMcpConfigPath(prepared.backend.args), "utf-8"),
+    ) as { mcpServers?: Record<string, unknown> };
+    expect(raw.mcpServers).toEqual({});
+    await prepared.cleanup?.();
+  });
+
+  it("omits a server whose restrictive policy catalog cannot be established", async () => {
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      tools: { deny: ["docs__delete_docs"] },
+      mcp: {
+        servers: { docs: { command: process.execPath, args: ["-e", "process.exit(1)"] } },
+      },
+    };
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "claude-config-file",
+      backend: { command: "claude", args: ["--print"] },
+      workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+      config,
+      nativeMcpPolicy: cliNativeMcpPolicyContext(config, "claude-policy-catalog-failure"),
+    });
+    const raw = JSON.parse(
+      await fs.readFile(requireMcpConfigPath(prepared.backend.args), "utf-8"),
+    ) as { mcpServers?: Record<string, unknown> };
+    expect(raw.mcpServers).toEqual({});
     await prepared.cleanup?.();
   });
 

--- a/src/agents/cli-runner/bundle-mcp.ts
+++ b/src/agents/cli-runner/bundle-mcp.ts
@@ -20,13 +20,20 @@ import {
 } from "../../plugins/bundle-mcp.js";
 import type { CliBackendConfig } from "../../plugins/cli-backend.types.js";
 import type { CliBundleMcpMode } from "../../plugins/types.js";
+import { getOrCreateSessionMcpRuntime } from "../agent-bundle-mcp-manager-api.js";
 import { isRecord } from "../bundle-mcp-adapter.js";
 import {
   loadMergedBundleMcpConfig,
   prepareOwnedBundleMcpDataDirs,
   toCliBundleMcpServerConfig,
 } from "../bundle-mcp-config.js";
+import type { ResolvedConversationCapabilityProfile } from "../conversation-capability-profile.js";
 import { resolveMcpBearerBundleConfig } from "../mcp-auth-profile.js";
+import {
+  applyPreparedNativeMcpPolicy,
+  prepareNativeMcpPolicy,
+  preparedNativeMcpDenials,
+} from "../native-mcp-policy.js";
 import {
   findClaudeMcpConfigPaths,
   injectClaudeMcpConfigArgs,
@@ -263,9 +270,17 @@ async function prepareModeSpecificBundleMcpConfig(params: {
     params.mergedConfig,
     params.env,
   ) as BundleMcpConfig;
+  const claudeConfig: BundleMcpConfig = {
+    mcpServers: Object.fromEntries(
+      Object.entries(runtimeConfig.mcpServers).map(([name, server]) => {
+        const { toolFilter: _toolFilter, ...nativeServer } = server;
+        return [name, nativeServer];
+      }),
+    ),
+  };
   const temporary = await writeTemporaryBundleMcpJson(
     "openclaw-cli-mcp-",
-    runtimeConfig,
+    claudeConfig,
     "mcp.json",
     false,
   );
@@ -322,6 +337,12 @@ export async function prepareCliBundleMcpConfig(params: {
   exclusiveConfig?: BundleMcpConfig;
   env?: Record<string, string>;
   warn?: (message: string) => void;
+  nativeMcpPolicy?: {
+    sessionId: string;
+    sessionKey?: string;
+    capabilityProfile: ResolvedConversationCapabilityProfile;
+    runtimeToolsAllow?: string[];
+  };
 }): Promise<PreparedCliBundleMcpConfig> {
   if (!params.enabled) {
     return params.toolOverrides?.webSearch === false
@@ -380,6 +401,7 @@ export async function prepareCliBundleMcpConfig(params: {
   }
   mergedConfig = applyMergePatch(mergedConfig, bundleConfig.config) as BundleMcpConfig;
   const prepareDataDirsByServer = { ...bundleConfig.prepareDataDirsByServer };
+  const additionalServerNames = new Set(Object.keys(params.additionalConfig?.mcpServers ?? {}));
   if (params.additionalConfig) {
     mergedConfig = applyMergePatch(mergedConfig, params.additionalConfig) as BundleMcpConfig;
     for (const serverName of Object.keys(params.additionalConfig.mcpServers)) {
@@ -406,12 +428,64 @@ export async function prepareCliBundleMcpConfig(params: {
     params.warn?.(`bundle MCP skipped for ${diagnostic.pluginId}: ${diagnostic.message}`);
   }
 
+  let effectiveConfig = preparedDataDirs.config;
+  let effectiveDenials = params.toolOverrides?.mcpToolsDeny;
+  const policyConfig: BundleMcpConfig = {
+    mcpServers: Object.fromEntries(
+      Object.entries(effectiveConfig.mcpServers).filter(
+        ([serverName]) => !additionalServerNames.has(serverName),
+      ),
+    ),
+  };
+  if (params.nativeMcpPolicy && Object.keys(policyConfig.mcpServers).length > 0) {
+    const runtimeConfig: OpenClawConfig = {
+      ...params.config,
+      mcp: { ...params.config?.mcp, servers: policyConfig.mcpServers },
+    };
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: params.nativeMcpPolicy.sessionId,
+      sessionKey: params.nativeMcpPolicy.sessionKey,
+      workspaceDir: params.workspaceDir,
+      agentDir: params.agentDir,
+      cfg: runtimeConfig,
+      toolOverrides: params.toolOverrides,
+    });
+    const policy = await prepareNativeMcpPolicy({
+      runtime,
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      capabilityProfile: params.nativeMcpPolicy.capabilityProfile,
+      runtimeToolsAllow: params.nativeMcpPolicy.runtimeToolsAllow,
+      warn: params.warn ?? (() => {}),
+    });
+    effectiveConfig = {
+      mcpServers: {
+        ...applyPreparedNativeMcpPolicy(policyConfig, policy).mcpServers,
+        ...Object.fromEntries(
+          Object.entries(effectiveConfig.mcpServers).filter(([serverName]) =>
+            additionalServerNames.has(serverName),
+          ),
+        ),
+      },
+    };
+    const preservedAdditionalDenials = Object.fromEntries(
+      Object.entries(params.toolOverrides?.mcpToolsDeny ?? {}).filter(([serverName]) =>
+        additionalServerNames.has(serverName),
+      ),
+    );
+    const combinedDenials = {
+      ...preparedNativeMcpDenials(policy),
+      ...preservedAdditionalDenials,
+    };
+    effectiveDenials = Object.keys(combinedDenials).length > 0 ? combinedDenials : undefined;
+  }
+
   return await prepareModeSpecificBundleMcpConfig({
     mode,
     backend: params.backend,
-    mergedConfig: preparedDataDirs.config,
+    mergedConfig: effectiveConfig,
     env: resolvedBearerConfig.env,
-    mcpToolsDeny: params.toolOverrides?.mcpToolsDeny,
+    mcpToolsDeny: effectiveDenials,
     webSearchEnabled: params.toolOverrides?.webSearch,
   });
 }

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -91,6 +91,7 @@ import {
 } from "../command/attempt-execution.helpers.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { resolveContextTokensForModel } from "../context.js";
+import { resolveConversationCapabilityProfile } from "../conversation-capability-profile.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import {
   resolvePromptBuildHookResult,
@@ -117,6 +118,7 @@ import { recordAdmittedModelRoutingDecision } from "../model-routing-decision.js
 import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
 import { collectRuntimeChannelCapabilities } from "../runtime-capabilities.js";
 import { ensureSandboxWorkspaceForSession } from "../sandbox.js";
+import { resolveSandboxRuntimeStatus } from "../sandbox/runtime-status.js";
 import { buildSystemPromptReport } from "../system-prompt-report.js";
 import { appendModelIdentitySystemPrompt, buildModelIdentityPromptLine } from "../system-prompt.js";
 import { expandToolGroups, normalizeToolPolicyName } from "../tool-policy.js";
@@ -1250,6 +1252,54 @@ export async function prepareCliRunContext(
     const loopbackServerConfig = mcpLoopbackRuntime
       ? prepareDeps.createMcpLoopbackServerConfig(mcpLoopbackRuntime.port)
       : undefined;
+    const policySessionKey = params.runtimePolicySessionKey ?? params.sessionKey;
+    const policyAgentId = resolveSessionAgentIds({
+      sessionKey: policySessionKey,
+      config: runtimeConfig,
+      agentId: params.runtimePolicySessionKey ? params.agentId : sessionAgentId,
+    }).sessionAgentId;
+    const sandboxStatus = resolveSandboxRuntimeStatus({
+      cfg: runtimeConfig,
+      sessionKey: policySessionKey,
+      agentId: policyAgentId,
+    });
+    const nativeMcpCapabilityProfile = resolveConversationCapabilityProfile({
+      config: runtimeConfig,
+      sessionKey: policySessionKey,
+      runSessionKey:
+        params.sessionKey && params.sessionKey !== policySessionKey ? params.sessionKey : undefined,
+      sessionId: params.sessionId,
+      runId: params.runId,
+      agentId: policyAgentId,
+      agentDir,
+      agentAccountId: params.agentAccountId,
+      messageProvider: params.messageProvider ?? params.messageChannel,
+      messageChannel: params.messageChannel,
+      chatType: runtimeChatType,
+      currentChannelId: params.currentChannelId,
+      currentThreadTs: params.currentThreadTs,
+      currentMessageId: params.currentMessageId,
+      groupId: params.groupId,
+      groupChannel: params.groupChannel,
+      groupSpace: params.groupSpace,
+      spawnedBy: params.spawnedBy,
+      senderId: params.senderId,
+      senderName: params.senderName,
+      senderUsername: params.senderUsername,
+      senderE164: params.senderE164,
+      senderIsOwner: params.senderIsOwner,
+      modelProvider,
+      modelId,
+      modelContextWindowTokens: contextWindowInfo.tokens,
+      workspaceDir,
+      cwd,
+      skillsSnapshot: params.skillsSnapshot,
+      sandboxToolPolicy: sandboxStatus.sandboxed ? sandboxStatus.toolPolicy : undefined,
+      runtimeToolAllowlist: runtimeToolsAllowPolicy,
+      inheritRuntimeToolAllowlist: true,
+      inputProvenance: params.inputProvenance,
+      scheduledToolPolicy: params.scheduledToolPolicy,
+    });
     const preparedBackend = await prepareCliBundleMcpConfig({
       enabled: bundleMcpEnabled || systemAgentMcpConfig !== undefined,
       mode: backendResolved.bundleMcpMode,
@@ -1274,6 +1324,18 @@ export async function prepareCliRunContext(
             }
           : undefined,
       warn: (message) => cliBackendLog.warn(message),
+      ...(!systemAgentMcpConfig && !restrictedLoopbackToolsAllow
+        ? {
+            nativeMcpPolicy: {
+              sessionId: params.sessionId,
+              ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+              capabilityProfile: nativeMcpCapabilityProfile,
+              ...(runtimeToolsAllowPolicy !== undefined
+                ? { runtimeToolsAllow: runtimeToolsAllowPolicy }
+                : {}),
+            },
+          }
+        : {}),
     });
     const cleanupPreparedBackend =
       preparedBackend.cleanup || cleanupMcpClientGrant

--- a/src/agents/mcp-tool-metadata.test.ts
+++ b/src/agents/mcp-tool-metadata.test.ts
@@ -28,6 +28,9 @@ describe("normalizeMcpToolCatalog", () => {
 
     expect(normalized.tools.map((entry) => entry.name)).toEqual(["healthy"]);
     expect(normalized.deniedTools).toEqual([]);
+    expect(normalized.excludedTools.map((entry) => entry.name)).toEqual(
+      colliding.map((entry) => entry.name.trim()),
+    );
     expect(normalized.metadata.validatorForCall(colliding[0]?.name.trim() ?? "")).toBeUndefined();
   });
 
@@ -44,12 +47,14 @@ describe("normalizeMcpToolCatalog", () => {
         tool("excluded", {
           outputSchema: { type: "object", $ref: "#/$defs/Missing" },
         }),
+        tool("task_only", { execution: { taskSupport: "required" } }),
       ],
       createMcpJsonSchemaValidator(),
       (toolName) => (toolName === "excluded" ? "exclude" : "include"),
     );
 
     expect(normalized.tools.map((entry) => entry.name)).toEqual(["healthy"]);
+    expect(normalized.excludedTools.map((entry) => entry.name)).toEqual(["excluded", "task_only"]);
     expect(normalized.metadata.validatorForCall("healthy")).toBeTypeOf("function");
     expect(normalized.metadata.validatorForCall("excluded")).toBeUndefined();
   });

--- a/src/agents/mcp-tool-metadata.ts
+++ b/src/agents/mcp-tool-metadata.ts
@@ -25,6 +25,7 @@ export function normalizeMcpToolCatalog(
 ): {
   tools: Tool[];
   deniedTools: Tool[];
+  excludedTools: Tool[];
   metadata: McpToolCatalogMetadata;
 } {
   const canonicalNames = tools.map((tool) => tool.name.trim());
@@ -37,23 +38,25 @@ export function normalizeMcpToolCatalog(
 
   const included: Tool[] = [];
   const deniedTools: Tool[] = [];
+  const excludedTools: Tool[] = [];
   const resultValidators = new Map<string, McpToolResultValidator>();
   for (const [index, sourceTool] of tools.entries()) {
     const toolName = canonicalNames[index] ?? "";
     // One wire name is one operation. Ambiguous aliases are safer omitted than
     // published under multiple model names with conflicting metadata.
-    if (
-      !toolName ||
-      nameCounts.get(toolName) !== 1 ||
-      sourceTool.execution?.taskSupport === "required"
-    ) {
+    if (!toolName) {
+      continue;
+    }
+    const tool = { ...sourceTool, name: toolName };
+    if (nameCounts.get(toolName) !== 1 || sourceTool.execution?.taskSupport === "required") {
+      excludedTools.push(tool);
       continue;
     }
     const disposition = classify(toolName);
     if (disposition === "exclude") {
+      excludedTools.push({ ...sourceTool, name: toolName });
       continue;
     }
-    const tool = { ...sourceTool, name: toolName };
     if (disposition === "include") {
       included.push(tool);
       if (tool.outputSchema) {
@@ -86,6 +89,7 @@ export function normalizeMcpToolCatalog(
 
   return {
     tools: included,
+    excludedTools,
     metadata: {
       validatorForCall(toolName) {
         return resultValidators.get(toolName);

--- a/src/agents/native-mcp-policy.test.ts
+++ b/src/agents/native-mcp-policy.test.ts
@@ -1,0 +1,255 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { getPluginToolMeta } from "../plugins/tool-metadata.js";
+import { buildBundleMcpToolsFromCatalog } from "./agent-bundle-mcp-materialize.js";
+import { assignSafeServerNames } from "./agent-bundle-mcp-names.js";
+import type { McpToolCatalog, SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
+import { resolveConversationCapabilityProfile } from "./conversation-capability-profile.js";
+import { prepareNativeMcpPolicy } from "./native-mcp-policy.js";
+
+function catalog(): McpToolCatalog {
+  const tools = [
+    {
+      serverName: "docs!",
+      safeServerName: "docs",
+      toolName: "read_docs",
+      inputSchema: Type.Object({}),
+      fallbackDescription: "read",
+    },
+    {
+      serverName: "docs!",
+      safeServerName: "docs",
+      toolName: "delete_docs",
+      inputSchema: Type.Object({}),
+      fallbackDescription: "delete",
+      excludedFromOpenClawCatalog: true as const,
+    },
+    {
+      serverName: "docs?",
+      safeServerName: "docs-2",
+      toolName: "read_docs",
+      inputSchema: Type.Object({}),
+      fallbackDescription: "other read",
+      deniedBySession: true as const,
+    },
+    {
+      serverName: "docs!",
+      safeServerName: "docs",
+      toolName: "app_only",
+      inputSchema: Type.Object({}),
+      fallbackDescription: "app only",
+      uiVisibility: ["app" as const],
+    },
+  ];
+  return {
+    version: 1,
+    generatedAt: 1,
+    servers: {
+      "docs!": { serverName: "docs!", safeServerName: "docs", launchSummary: "test", toolCount: 1 },
+      "docs?": {
+        serverName: "docs?",
+        safeServerName: "docs-2",
+        launchSummary: "test",
+        toolCount: 0,
+      },
+    },
+    tools: [tools[0]!],
+    sessionDeniedTools: [tools[2]!],
+    policyTools: tools,
+  };
+}
+
+function runtime(value: McpToolCatalog): SessionMcpRuntime {
+  return {
+    sessionId: "session-1",
+    workspaceDir: "/tmp/openclaw-native-mcp-policy",
+    configFingerprint: "test",
+    createdAt: 1,
+    lastUsedAt: 1,
+    getCatalog: async () => value,
+    peekCatalog: () => value,
+    markUsed: () => {},
+    callTool: async () => ({ content: [] }),
+    dispose: async () => {},
+  };
+}
+
+describe("prepareNativeMcpPolicy", () => {
+  it("keeps default callable tools while denying hidden native inventory", async () => {
+    const prepared = await prepareNativeMcpPolicy({
+      runtime: runtime(catalog()),
+      workspaceDir: "/tmp/openclaw-native-mcp-policy",
+      capabilityProfile: resolveConversationCapabilityProfile({}),
+      warn: () => {},
+    });
+
+    expect(prepared.servers["docs!"]).toMatchObject({
+      allowedTools: ["read_docs"],
+      deniedTools: ["app_only", "delete_docs"],
+    });
+    expect(prepared.servers["docs?"]).toMatchObject({
+      allowedTools: [],
+      deniedTools: ["read_docs"],
+    });
+  });
+
+  it("preserves raw/safe identities and intersects effective, configured, and session policy", async () => {
+    const config = { tools: { allow: ["docs__*"], deny: ["docs__delete_*"] } };
+    const prepared = await prepareNativeMcpPolicy({
+      runtime: runtime(catalog()),
+      config,
+      workspaceDir: "/tmp/openclaw-native-mcp-policy",
+      capabilityProfile: resolveConversationCapabilityProfile({ config }),
+      warn: () => {},
+    });
+
+    expect(prepared.servers["docs!"]).toMatchObject({
+      safeServerName: "docs",
+      allowedTools: ["read_docs"],
+      deniedTools: ["app_only", "delete_docs"],
+    });
+    expect(prepared.servers["docs?"]).toMatchObject({
+      safeServerName: "docs-2",
+      allowedTools: [],
+      deniedTools: ["read_docs"],
+    });
+  });
+
+  it("treats an empty runtime allowlist as an exact deny-all cap", async () => {
+    const prepared = await prepareNativeMcpPolicy({
+      runtime: runtime(catalog()),
+      workspaceDir: "/tmp/openclaw-native-mcp-policy",
+      capabilityProfile: resolveConversationCapabilityProfile({}),
+      runtimeToolsAllow: [],
+      warn: () => {},
+    });
+    expect(Object.values(prepared.servers).flatMap((server) => server.allowedTools)).toEqual([]);
+  });
+
+  it("preserves callable identities when an App-only raw name collides", async () => {
+    const serverNames = [
+      "docs.production.endpoint.with.a.long.shared.prefix.alpha",
+      "docs.production.endpoint.with.a.long.shared.prefix.beta",
+    ];
+    const safeNames = assignSafeServerNames(serverNames);
+    const rawTools = [
+      "read.docs.with.a.long.shared.prefix.alpha",
+      "read:docs:with:a:long:shared:prefix:alpha",
+    ];
+    const policyTools = [
+      ...rawTools.map((toolName, index) => ({
+        serverName: serverNames[1]!,
+        safeServerName: safeNames.get(serverNames[1]!)!,
+        toolName,
+        inputSchema: Type.Object({}),
+        fallbackDescription: toolName,
+        ...(index === 1 ? { uiVisibility: ["app" as const] } : {}),
+      })),
+      {
+        serverName: serverNames[1]!,
+        safeServerName: safeNames.get(serverNames[1]!)!,
+        toolName: "read_safe",
+        inputSchema: Type.Object({}),
+        fallbackDescription: "read safe",
+      },
+    ];
+    const collisionCatalog: McpToolCatalog = {
+      version: 1,
+      generatedAt: 1,
+      servers: Object.fromEntries(
+        serverNames.map((serverName) => [
+          serverName,
+          {
+            serverName,
+            safeServerName: safeNames.get(serverName)!,
+            launchSummary: "test",
+            toolCount: serverName === serverNames[1] ? policyTools.length : 0,
+          },
+        ]),
+      ),
+      tools: policyTools,
+      policyTools,
+    };
+    const callableTools = buildBundleMcpToolsFromCatalog({ catalog: collisionCatalog });
+    const visibleCollision = callableTools.find(
+      (tool) => getPluginToolMeta(tool)?.mcp?.toolName === rawTools[0],
+    );
+    expect(visibleCollision).toBeDefined();
+    const config = {
+      tools: {
+        allow: [`${safeNames.get(serverNames[1]!)}__*`],
+        deny: [visibleCollision!.name],
+      },
+    };
+    const prepared = await prepareNativeMcpPolicy({
+      runtime: runtime(collisionCatalog),
+      config,
+      workspaceDir: "/tmp/openclaw-native-mcp-policy",
+      capabilityProfile: resolveConversationCapabilityProfile({ config }),
+      warn: () => {},
+    });
+
+    expect(prepared.servers[serverNames[1]!]?.allowedTools).toEqual(["read_safe"]);
+    expect(prepared.servers[serverNames[1]!]?.deniedTools).toEqual(rawTools);
+    expect(safeNames.get(serverNames[0]!)).not.toBe(safeNames.get(serverNames[1]!));
+  });
+
+  it("reserves callable identities before every non-callable policy row", async () => {
+    const callableTool = {
+      serverName: "docs",
+      safeServerName: "docs",
+      toolName: "read:value",
+      inputSchema: Type.Object({}),
+      fallbackDescription: "callable",
+    };
+    const readTool = {
+      ...callableTool,
+      toolName: "read_safe",
+      fallbackDescription: "read safe",
+    };
+    const hiddenTools = ["read value", "read.value", "read.value", "read/value"].map(
+      (toolName) => ({
+        serverName: "docs",
+        safeServerName: "docs",
+        toolName,
+        inputSchema: Type.Object({}),
+        fallbackDescription: "hidden policy inventory",
+        excludedFromOpenClawCatalog: true as const,
+      }),
+    );
+    const collisionCatalog: McpToolCatalog = {
+      version: 1,
+      generatedAt: 1,
+      servers: {
+        docs: { serverName: "docs", safeServerName: "docs", launchSummary: "test", toolCount: 2 },
+      },
+      tools: [callableTool, readTool],
+      policyTools: [...hiddenTools, callableTool, readTool],
+    };
+    const callableProjection = buildBundleMcpToolsFromCatalog({ catalog: collisionCatalog });
+    const policyName = callableProjection.find(
+      (tool) => getPluginToolMeta(tool)?.mcp?.toolName === callableTool.toolName,
+    )?.name;
+    expect(policyName).toBeDefined();
+    if (!policyName) {
+      throw new Error("expected callable policy name");
+    }
+    const config = { tools: { allow: ["docs__*"], deny: [policyName] } };
+
+    const prepared = await prepareNativeMcpPolicy({
+      runtime: runtime(collisionCatalog),
+      config,
+      workspaceDir: "/tmp/openclaw-native-mcp-policy",
+      capabilityProfile: resolveConversationCapabilityProfile({ config }),
+      warn: () => {},
+    });
+
+    expect(prepared.servers.docs?.allowedTools).toEqual(["read_safe"]);
+    expect(prepared.servers.docs?.deniedTools).toEqual([
+      "read value",
+      "read.value",
+      "read/value",
+      "read:value",
+    ]);
+  });
+});

--- a/src/agents/native-mcp-policy.ts
+++ b/src/agents/native-mcp-policy.ts
@@ -1,0 +1,140 @@
+/** Projects the canonical conversation tool policy into raw native MCP identities. */
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { BundleMcpConfig } from "../plugins/bundle-mcp.js";
+import { getPluginToolMeta } from "../plugins/tool-metadata.js";
+import { buildBundleMcpToolsFromCatalog } from "./agent-bundle-mcp-materialize.js";
+import type {
+  McpToolCatalog,
+  PreparedNativeMcpPolicy,
+  SessionMcpRuntime,
+} from "./agent-bundle-mcp-types.js";
+import { isRecord } from "./bundle-mcp-adapter.js";
+import type { ResolvedConversationCapabilityProfile } from "./conversation-capability-profile.js";
+import { applyFinalEffectiveToolPolicy } from "./embedded-agent-runner/effective-tool-policy.js";
+import { applyEmbeddedAttemptToolsAllow } from "./embedded-agent-runner/run/attempt-tool-construction-plan.js";
+
+function buildPolicyProjectionTools(catalog: McpToolCatalog) {
+  // Callable names are policy identities. Reserve them before hidden inventory
+  // so catalog-only rows cannot retarget an existing allow or deny entry.
+  const callableTools = buildBundleMcpToolsFromCatalog({ catalog }).filter(
+    (tool) => getPluginToolMeta(tool)?.mcp?.operation === "tool",
+  );
+  const callableIdentities = new Set(
+    callableTools.flatMap((tool) => {
+      const mcp = getPluginToolMeta(tool)?.mcp;
+      return mcp?.operation === "tool" ? [JSON.stringify([mcp.serverName, mcp.toolName])] : [];
+    }),
+  );
+  const policyTools = catalog.policyTools ?? [
+    ...catalog.tools,
+    ...(catalog.sessionDeniedTools ?? []),
+  ];
+  const hiddenPolicyTools = policyTools.filter(
+    (tool) => !callableIdentities.has(JSON.stringify([tool.serverName, tool.toolName])),
+  );
+  const hiddenTools = buildBundleMcpToolsFromCatalog({
+    catalog: {
+      ...catalog,
+      tools: hiddenPolicyTools,
+      policyTools: undefined,
+      sessionDeniedTools: undefined,
+    },
+    reservedToolNames: callableTools.map((tool) => tool.name),
+    includeAppOnlyInventory: true,
+  }).filter((tool) => getPluginToolMeta(tool)?.mcp?.operation === "tool");
+  return [...callableTools, ...hiddenTools];
+}
+
+export async function prepareNativeMcpPolicy(params: {
+  runtime: SessionMcpRuntime;
+  config?: OpenClawConfig;
+  workspaceDir: string;
+  capabilityProfile: ResolvedConversationCapabilityProfile;
+  runtimeToolsAllow?: string[];
+  warn: (message: string) => void;
+}): Promise<PreparedNativeMcpPolicy> {
+  params.runtime.markUsed();
+  const catalog = await params.runtime.getCatalog();
+  const allTools = buildPolicyProjectionTools(catalog);
+  const runtimeAllowed = applyEmbeddedAttemptToolsAllow(allTools, params.runtimeToolsAllow, {
+    toolMeta: (tool) => getPluginToolMeta(tool),
+  });
+  const effectiveAllowed = applyFinalEffectiveToolPolicy({
+    bundledTools: runtimeAllowed,
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    conversationCapabilityProfile: params.capabilityProfile,
+    warn: params.warn,
+  });
+  const effectiveAllowedNames = new Set(effectiveAllowed.map((tool) => tool.name));
+  const servers: PreparedNativeMcpPolicy["servers"] = {};
+
+  for (const tool of allTools) {
+    const mcp = getPluginToolMeta(tool)?.mcp;
+    if (!mcp || mcp.operation !== "tool") {
+      continue;
+    }
+    const server = (servers[mcp.serverName] ??= {
+      serverName: mcp.serverName,
+      safeServerName: mcp.safeServerName,
+      allowedTools: [],
+      deniedTools: [],
+    });
+    const allowed =
+      !mcp.excludedFromOpenClawCatalog &&
+      !mcp.deniedBySession &&
+      effectiveAllowedNames.has(tool.name);
+    (allowed ? server.allowedTools : server.deniedTools).push(mcp.toolName);
+  }
+
+  for (const server of Object.values(servers)) {
+    server.allowedTools = [...new Set(server.allowedTools)].toSorted();
+    server.deniedTools = [...new Set(server.deniedTools)].toSorted();
+  }
+  return {
+    servers: Object.fromEntries(
+      Object.entries(servers).toSorted(([left], [right]) => left.localeCompare(right)),
+    ),
+  };
+}
+
+/** Applies one prepared policy to the provider-neutral MCP config shape. */
+export function applyPreparedNativeMcpPolicy(
+  config: BundleMcpConfig,
+  policy: PreparedNativeMcpPolicy,
+): BundleMcpConfig {
+  return {
+    mcpServers: Object.fromEntries(
+      Object.entries(config.mcpServers).flatMap(([serverName, server]) => {
+        const prepared = policy.servers[serverName];
+        if (!prepared || prepared.allowedTools.length === 0) {
+          return [];
+        }
+        const toolFilter = isRecord(server.toolFilter) ? server.toolFilter : {};
+        return [
+          [
+            serverName,
+            {
+              ...server,
+              toolFilter: {
+                ...toolFilter,
+                include: prepared.allowedTools,
+                exclude: prepared.deniedTools,
+              },
+            },
+          ],
+        ];
+      }),
+    ),
+  };
+}
+
+/** Returns raw per-server denials for backends that enforce a deny list. */
+export function preparedNativeMcpDenials(
+  policy: PreparedNativeMcpPolicy,
+): Record<string, string[]> | undefined {
+  const entries = Object.values(policy.servers)
+    .filter((server) => server.deniedTools.length > 0)
+    .map((server) => [server.serverName, server.deniedTools] as const);
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}

--- a/src/plugin-sdk/codex-mcp-projection.ts
+++ b/src/plugin-sdk/codex-mcp-projection.ts
@@ -31,6 +31,7 @@ export function resolveCodexScheduledToolProjectionFactory(
 export {
   buildCodexUserMcpServersThreadConfigPatch,
   buildCodexUserMcpServersThreadConfigPatchForRuntime,
+  buildCodexUserMcpServersThreadConfigPatchForRun,
   resolveCodexMcpToolOverridesForAgent,
 } from "../agents/cli-runner/bundle-mcp-codex.js";
 export {

--- a/src/plugins/tool-metadata.ts
+++ b/src/plugins/tool-metadata.ts
@@ -11,6 +11,7 @@ export type PluginToolMcpMeta = {
   safeServerName: string;
   toolName: string;
   operation: "tool" | "resources_list" | "resources_read" | "prompts_list" | "prompts_get";
+  excludedFromOpenClawCatalog?: true;
   deniedBySession?: true;
   codexApproval?: {
     mode: McpCodexToolApprovalMode;


### PR DESCRIPTION
Closes #119310.

## Problem

Per-agent `tools.allow` and `tools.deny` filtered OpenClaw-hosted tools but did not constrain configured MCP tools connected directly by native Claude, Codex, or Gemini runtimes. A denied tool could therefore remain visible and callable on the first turn and throughout one-shot sessions.

## Root cause

The native MCP adapters received only session-row overrides. The CLI and Codex thread preparation owners never materialized the configured MCP catalog against the canonical conversation policy before native startup.

## Fix

- Prepare one exact MCP policy fact from the canonical conversation capability profile and the real server catalog.
- Prepare that catalog for every configured native MCP server, including the default path with no explicit allow or deny entry.
- Apply Codex agent scoping before runtime creation so excluded servers never open a transport.
- Omit remote Codex OAuth servers before policy catalog discovery can use their credentials.
- Keep raw task-required and ambiguous tool names in a native-only policy inventory so native clients deny them while OpenClaw keeps them out of its callable catalog.
- Preserve App-only visibility in that inventory and deny App-only raw names to native model clients without changing the authorized App surface.
- Reserve every callable policy identity before task-required, duplicate, configured-filtered, session-denied, or App-only inventory can consume a collision suffix.
- Resolve configured MCP globs against the catalog before sending Codex exact tool filters.
- Preserve provider-safe policy names while projecting raw tool names into Claude denials, Codex `enabled_tools` / `disabled_tools`, and Gemini `includeTools` / `excludeTools`.
- Keep configured filters and session overrides additive.
- Omit a server when policy or catalog failure leaves no allowed MCP tool.
- Omit a Gemini server when its configured `includeTools` and policy-derived allowlist have no common tool.
- Preserve host-supplied loopback MCP servers under their existing per-run grant instead of treating them as native policy inputs.

## Proof

The same first-turn scenario ran with a real local stdio MCP server. Current main was red with Claude Code 2.1.246. The final proposed head was green with the same Claude Code version on an isolated local proof host.

| Revision | Agent policy | Downstream calls | Result |
| --- | --- | --- | --- |
| `b30cef73edae8daec41c0ba36bfbe24f02701325` | deny `policy_test__restricted_echo` | `safe_read(alpha-119310)`, `restricted_echo(omega-119310)` | red: denied tool executed |
| `e1e98d72ce8c34cc529dab743f24b5252d9b1862` | same | `safe_read(alpha-e1e9)` only | green: denied, task-required, and App-only tools were unavailable |
| `360cfffc0bb3c2633ef4f40fe68a814897c8e24c` | default policy | `safe_read(safe-360c)`, `restricted_echo(normal-360c)` | green: both normal tools ran; task-required and App-only tools were unavailable |

The distinct tokens prove the result came from real MCP calls rather than cached or hard-coded output. Both exact revisions used fresh sessions and disposable state. No proof process remained afterward.

The native clients also received equivalent unfiltered and exact filtered configurations:

| Native client | Version | Unfiltered result | Filtered result |
| --- | --- | --- | --- |
| Claude Code | 2.1.246 | denied tool reached MCP | denied tool unavailable; no MCP call |
| Codex | 0.150.1 | both tools reached MCP | allowed tool reached MCP; denied tool unavailable with no MCP call |
| Gemini CLI | 0.39.1 | forced denied-tool call reached MCP | same forced call returned `tool_not_registered`; no MCP call |

Sanitized native-client trace lines show the final effect at the server boundary:

```text
Codex baseline: mcp_tool_call restricted_echo(omega-codex-direct2) completed
Codex filtered: mcp_tool_call safe_read(alpha-codex-head) completed; restricted_echo unavailable
Codex filtered server log: safe_read(alpha-codex-head) only
Gemini baseline server log: restricted_echo(omega-gemini-proof)
Gemini filtered: restricted_echo -> tool_not_registered; server log empty
Claude filtered head: safe_read(alpha-e1e9); restricted_echo, task_required, and app_only unavailable; server log contains safe_read only
```

The remote Codex OAuth boundary also ran against a real loopback HTTP listener. The pre-repair code made one request while preparing the restricted policy. The final head produced no remote MCP patch and made zero requests. A separate authenticated control request proved the listener recorded traffic.

A second regression proved the hidden-tool case. Before the final repair, Claude's deny argument contained `delete_docs` but omitted the server's task-required `task_docs`. The final head adds both raw names to the native deny set while keeping `task_docs` out of OpenClaw's callable catalog.

The App-only regression used namespace allow `docs__*`. Before the final repair, that broad allow exposed `app_docs` to the native model. The final head preserves its App-only classification and places it in every native client's deny set while the normal App projection tests remain green.

A punctuation-collision regression proved Claude's real permission identity. Claude normalizes both raw `a.b` and raw `a:b` to `a_b`. Before the final repair, the hidden App-only `a:b` tool remained callable because OpenClaw sent the raw punctuation in `--disallowedTools`. The exact head normalizes the denial to Claude's identity; with `collision__a-b` denied, only `read_safe(safe-e1e9)` reached the server and neither colliding tool was callable.

Two exact pre-fix owner-boundary regressions covered the final review findings. A task-required, duplicate, or configured-filtered hidden row could take a callable safe ID before `c7b9723e`; Gemini could also retain a server after its final allowlist became empty. Both fail on `c7b9723e` and pass on the exact proposed head.

The final no-policy regressions fail on exact pre-fix head `e1e98d72` for Claude, Codex CLI, Codex app server, and Gemini. Exact head `360cfffc` deletes the skip predicate. Its real Claude run called both normal tools and made no task-required or App-only server call.

Final proposed head `bddcea465e07d4f8d5ef9f82e5755f9fb8e44229` is a patch-identical replay of `360cfffc0bb3c2633ef4f40fe68a814897c8e24c` onto current `main`. Both commits have stable patch ID `09904b8e91d41844a5c90cbc8a6625a46f32dba4`.

Codex used the real OpenAI model. Gemini used the real CLI and MCP client with a controlled loopback model endpoint that forced the same denied-tool call in both runs. This isolates native filter enforcement from model choice.

A Codex no-transport regression test also proved the scope ordering. Before the final repair, a server assigned to another agent wrote its startup marker. On the proposed head, it never started and wrote no marker.

Codex CLI and app-server regressions also proved wildcard projection. Before the final repair, `delete_*` reached Codex's exact-only filter and stopped startup. On the proposed head, both paths serialize only the resolved raw name `delete_docs`.

## Validation

- 342 focused Vitest tests passed across MCP catalog, native policy, Claude, Codex, Gemini, and CLI preparation owner paths.
- The original 216-test focused evidence remains covered by the larger final run.
- The preserved Anthropic focused suite passed 50 tests on the proposed head.
- Exact head `360cfffc` built successfully and passed build-time Plugin SDK export, CLI bootstrap, runtime post-build, and Control UI performance guards.
- Docs config examples and 7,015 internal links passed.
- Focused Oxfmt, Oxlint, max-lines, assertion-safety, coercion, SDK surface, deprecated API, database-first, import-cycle, and diff checks passed.

## Dependency contracts

- Claude Agent SDK 0.3.239 documents `disallowedTools` as removing tools from context and blocking use.
- Direct sibling Codex source at `4347f94d5539880e8583028a50a19df5b202d9fa` defines [`enabled_tools` and `disabled_tools`](https://github.com/openai/codex/blob/4347f94d5539880e8583028a50a19df5b202d9fa/codex-rs/config/src/mcp_types.rs#L229-L235) and [requires an enabled tool that is not disabled](https://github.com/openai/codex/blob/4347f94d5539880e8583028a50a19df5b202d9fa/codex-rs/codex-mcp/src/tools.rs#L63-L95).
- Gemini CLI v0.39.1 applies `excludeTools` before `includeTools`; configuration merge uses deny union and allow intersection.

## Maintainer and security owner acceptance

Owner decision: accept enforced policy. `@obviyus` explicitly directed this repair through merge under `docs/tools/multi-agent-sandbox-tools.md`: per-agent `tools.allow` and `tools.deny` must constrain configured native MCP tools. This selects the enforced-policy option and intentionally changes upgrade behavior: existing restrictive policies now remove native MCP tools that older versions leaked past policy.

The acting maintainer directly inspected sibling Codex source at `4347f94d5539880e8583028a50a19df5b202d9fa`: `codex-rs/config/src/mcp_types.rs:229-235` defines the allow-then-deny fields, and `codex-rs/codex-mcp/src/tools.rs:63-95` enforces raw tool names against them.

`@joshavant` is an active member of `@openclaw/openclaw-secops` and authored the same fail-closed repair direction in #119364. This branch incorporates that work and retains Josh as co-author.

## Change shape

- Owner: native MCP policy preparation before process or thread creation.
- Modes before: session overrides only.
- Modes after: canonical conversation policy, configured server filters, and session overrides intersect once, then each native backend serializes the same fact.
- Production and tooling: `+594/-103` lines, net `+491`.
- The positive production delta creates the missing cross-provider security owner, includes the Codex app-server run-context adapter, and preserves the App-only boundary in native inventory; provider-specific policy calculation is not duplicated.

Co-authored-by: Josh Avant <830519+joshavant@users.noreply.github.com>
