### PR TITLE
fix(protocol): protocol:check passes when the published schema drifts

### DIFF
--- a/docs/concepts/typebox.md
+++ b/docs/concepts/typebox.md
@@ -61,7 +61,7 @@ The authoritative advertised **discovery** inventory lives in `src/gateway/serve
 - `pnpm protocol:gen:swift` generates the Swift gateway models.
 - `pnpm protocol:check:swift` verifies the committed Swift models without rewriting them.
 - `pnpm protocol:gen:kotlin` generates the Android protocol models and constants.
-- `pnpm protocol:check` checks the registry structure, runs all three generators, and verifies the committed Swift and Kotlin output (the JSON Schema output is a gitignored build artifact).
+- `pnpm protocol:check` checks the registry structure, runs all three generators, and verifies the committed Swift and Kotlin output. The JSON Schema output is a gitignored build artifact with no committed baseline to diff against, so `pnpm protocol:gen` instead asserts the published-document contract (required frame definitions, frame ordering, `type` discriminator mapping, non-empty method metadata) and fails the check when the generated schema drifts from it.
 
 When a gateway schema affects native clients, run `pnpm protocol:gen:swift`, review the generated diff, then run `pnpm protocol:check:swift`. Commit the schema and `GatewayModels.swift` update together. Stable decoding behavior belongs in the focused `GatewayModelsCompatibilityTests.swift` regressions rather than in handwritten model copies.
 

--- a/package.json
+++ b/package.json
@@ -1764,7 +1764,7 @@
     "prompt:snapshots:check": "node --import ./scripts/tsx.mjs scripts/generate-prompt-snapshots.ts --check",
     "prompt:snapshots:gen": "node --import ./scripts/tsx.mjs scripts/generate-prompt-snapshots.ts --write",
     "prompt:snapshots:sync-codex-model": "node --import ./scripts/tsx.mjs scripts/sync-codex-model-prompt-fixture.ts",
-    "protocol:check": "pnpm protocol-registry:check && pnpm protocol:gen && pnpm protocol:check:swift && pnpm protocol:gen:kotlin && node --import ./scripts/tsx.mjs scripts/check-protocol-since.mts && git diff --exit-code -- dist/protocol.schema.json apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt apps/android/app/src/main/java/ai/openclaw/app/protocol/OpenClawProtocolConstants.kt",
+    "protocol:check": "pnpm protocol-registry:check && pnpm protocol:gen && pnpm protocol:check:swift && pnpm protocol:gen:kotlin && node --import ./scripts/tsx.mjs scripts/check-protocol-since.mts && git diff --exit-code -- apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt apps/android/app/src/main/java/ai/openclaw/app/protocol/OpenClawProtocolConstants.kt",
     "protocol:check:kotlin": "pnpm protocol:gen:kotlin && git diff --exit-code -- apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt apps/android/app/src/main/java/ai/openclaw/app/protocol/OpenClawProtocolConstants.kt",
     "protocol:check:swift": "node --import ./scripts/tsx.mjs scripts/protocol-gen-swift.ts --check",
     "protocol:gen": "node --import ./scripts/tsx.mjs scripts/protocol-gen.ts",

--- a/scripts/lib/protocol-schema-document.mts
+++ b/scripts/lib/protocol-schema-document.mts
@@ -1,0 +1,101 @@
+// Canonical published Gateway protocol schema document. The generator that
+// writes protocol.schema.json and the verifier that inspects the packed tarball
+// both build the envelope here; a second copy is how the shipped machine-readable
+// contract drifts without any lane noticing.
+
+export type ProtocolMethodMetadata = {
+  name: string;
+  scope: string;
+  since?: string;
+};
+
+export type ProtocolSchemaDocument = {
+  $id: string;
+  $schema: string;
+  definitions: Record<string, unknown>;
+  description: string;
+  discriminator: {
+    mapping: Record<string, string>;
+    propertyName: string;
+  };
+  methods: Record<string, { scope: string; since?: string }>;
+  oneOf: { $ref: string }[];
+  title: string;
+};
+
+/** Frame definitions every consumer of the published schema resolves by name. */
+export const REQUIRED_PROTOCOL_DEFINITIONS = [
+  "ConnectParams",
+  "RequestFrame",
+  "ResponseFrame",
+  "EventFrame",
+] as const;
+
+// Frame order is part of the published contract: generated clients select the
+// oneOf branch positionally before reading the discriminator, so req/res/event
+// must stay in this order across regenerations.
+const FRAME_DEFINITIONS_BY_TYPE = [
+  ["req", "RequestFrame"],
+  ["res", "ResponseFrame"],
+  ["event", "EventFrame"],
+] as const;
+
+const definitionRef = (definition: string) => `#/definitions/${definition}`;
+const FRAME_REFS = FRAME_DEFINITIONS_BY_TYPE.map(([, definition]) => definitionRef(definition));
+const FRAME_DISCRIMINATOR_MAPPING = Object.fromEntries(
+  FRAME_DEFINITIONS_BY_TYPE.map(([frameType, definition]) => [
+    frameType,
+    definitionRef(definition),
+  ]),
+);
+
+/** Builds the JSON document published as protocol.schema.json. */
+export function buildProtocolSchemaDocument(params: {
+  methods: readonly ProtocolMethodMetadata[];
+  schemas: Record<string, unknown>;
+}): ProtocolSchemaDocument {
+  const document = {
+    $schema: "http://json-schema.org/draft-07/schema#",
+    $id: "https://openclaw.ai/protocol.schema.json",
+    title: "OpenClaw Gateway Protocol",
+    description: "Handshake, request/response, and event frames for the Gateway WebSocket.",
+    oneOf: FRAME_REFS.map((ref) => ({ $ref: ref })),
+    discriminator: {
+      propertyName: "type",
+      mapping: FRAME_DISCRIMINATOR_MAPPING,
+    },
+    methods: Object.fromEntries(
+      // Omit an absent `since` instead of carrying undefined so the document
+      // equals the JSON the artifact ships.
+      params.methods.map(({ name, scope, since }) => [
+        name,
+        since === undefined ? { scope } : { since, scope },
+      ]),
+    ),
+    definitions: params.schemas,
+  };
+  // TypeBox schemas carry symbol keys that never reach JSON; cloning them away
+  // lets the producer and the published-artifact verifier compare one document.
+  return structuredClone(document) as ProtocolSchemaDocument;
+}
+
+/** Rejects a published document that lost the frame contract clients decode by. */
+export function assertProtocolSchemaDocument(document: ProtocolSchemaDocument): void {
+  const problems = REQUIRED_PROTOCOL_DEFINITIONS.filter(
+    (definition) => !Object.hasOwn(document.definitions, definition),
+  ).map((definition) => `definition ${definition} is missing`);
+  if (JSON.stringify(document.oneOf.map((entry) => entry.$ref)) !== JSON.stringify(FRAME_REFS)) {
+    problems.push(`frame oneOf must list ${FRAME_REFS.join(", ")}`);
+  }
+  if (
+    JSON.stringify(document.discriminator.mapping) !== JSON.stringify(FRAME_DISCRIMINATOR_MAPPING)
+  ) {
+    problems.push(`type discriminator must map ${JSON.stringify(FRAME_DISCRIMINATOR_MAPPING)}`);
+  }
+  if (Object.keys(document.methods).length === 0) {
+    problems.push("method metadata is empty");
+  }
+  if (problems.length > 0) {
+    throw new Error(`published protocol schema contract violated: ${problems.join("; ")}`);
+  }
+}

--- a/scripts/prepush-ci.sh
+++ b/scripts/prepush-ci.sh
@@ -14,26 +14,6 @@ run_step() {
   "$@"
 }
 
-run_protocol_ci_mirror() {
-  local targets=(
-    "dist/protocol.schema.json"
-    "apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift"
-  )
-  local before after
-  before="$(git diff --no-ext-diff -- "${targets[@]}" || true)"
-
-  run_step pnpm protocol:gen
-  run_step pnpm protocol:check:swift
-
-  after="$(git diff --no-ext-diff -- "${targets[@]}" || true)"
-  if [[ "$before" != "$after" ]]; then
-    echo "Protocol generation changed tracked outputs beyond the pre-run worktree." >&2
-    echo "Refresh generated protocol files and include the updated outputs before pushing." >&2
-    git --no-pager diff -- "${targets[@]}"
-    return 1
-  fi
-}
-
 has_native_swift_changes() {
   local native_paths=(
     apps/macos
@@ -71,7 +51,8 @@ run_linux_ci_mirror() {
   run_step pnpm check
   run_step pnpm build:strict-smoke
   run_step pnpm lint:ui:no-raw-window-open
-  run_protocol_ci_mirror
+  run_step pnpm protocol:gen
+  run_step pnpm protocol:check:swift
   run_step pnpm plugins:assets:build
   run_step node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts --maxWorkers=1
   run_step env CI=true node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts --maxWorkers=1

--- a/scripts/protocol-gen.ts
+++ b/scripts/protocol-gen.ts
@@ -1,9 +1,13 @@
 // Protocol Gen script supports OpenClaw repository automation.
-import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { ProtocolSchemas } from "../packages/gateway-protocol/src/schema/protocol-schemas.js";
 import { listCoreGatewayMethodMetadata } from "../src/gateway/methods/core-descriptors.js";
+import { writeGeneratedOutput } from "./lib/generated-output-utils.mts";
+import {
+  assertProtocolSchemaDocument,
+  buildProtocolSchemaDocument,
+} from "./lib/protocol-schema-document.mts";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
@@ -31,48 +35,32 @@ function resolveOutputPath(args: string[]): string {
   return outputPath;
 }
 
-async function writeJsonSchema(jsonSchemaPath: string) {
-  const definitions: Record<string, unknown> = {};
-  for (const [name, schema] of Object.entries(ProtocolSchemas)) {
-    definitions[name] = schema;
-  }
-  const methods = Object.fromEntries(
-    listCoreGatewayMethodMetadata().map(({ name, scope, since }) => [name, { since, scope }]),
+function main() {
+  const document = buildProtocolSchemaDocument({
+    methods: listCoreGatewayMethodMetadata(),
+    schemas: ProtocolSchemas,
+  });
+  // The artifact is a build output with no committed baseline, so this contract
+  // check is the only guard between a degraded registry and the published
+  // schema; a regenerate-then-diff guard on it can never fail.
+  assertProtocolSchemaDocument(document);
+  const result = writeGeneratedOutput({
+    check: false,
+    next: JSON.stringify(document, null, 2),
+    outputPath: resolveOutputPath(process.argv.slice(2)),
+    repoRoot,
+  });
+  const displayPath = path.relative(repoRoot, result.outputPath);
+  console.log(
+    result.wrote
+      ? `[protocol-gen] wrote ${displayPath}`
+      : `[protocol-gen] unchanged ${displayPath}`,
   );
-
-  const rootSchema = {
-    $schema: "http://json-schema.org/draft-07/schema#",
-    $id: "https://openclaw.ai/protocol.schema.json",
-    title: "OpenClaw Gateway Protocol",
-    description: "Handshake, request/response, and event frames for the Gateway WebSocket.",
-    oneOf: [
-      { $ref: "#/definitions/RequestFrame" },
-      { $ref: "#/definitions/ResponseFrame" },
-      { $ref: "#/definitions/EventFrame" },
-    ],
-    discriminator: {
-      propertyName: "type",
-      mapping: {
-        req: "#/definitions/RequestFrame",
-        res: "#/definitions/ResponseFrame",
-        event: "#/definitions/EventFrame",
-      },
-    },
-    methods,
-    definitions,
-  };
-
-  await fs.mkdir(path.dirname(jsonSchemaPath), { recursive: true });
-  await fs.writeFile(jsonSchemaPath, JSON.stringify(rootSchema, null, 2));
-  console.log(`wrote ${jsonSchemaPath}`);
-  return { jsonSchemaPath, schemaString: JSON.stringify(rootSchema) };
 }
 
-async function main() {
-  await writeJsonSchema(resolveOutputPath(process.argv.slice(2)));
-}
-
-main().catch((err: unknown) => {
+try {
+  main();
+} catch (err: unknown) {
   console.error(err);
   process.exit(1);
-});
+}

--- a/test/e2e/qa-lab/runtime/gateway-protocol-artifacts.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-protocol-artifacts.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { buildProtocolSchemaDocument } from "../../../../scripts/lib/protocol-schema-document.mts";
 import {
   assertPublishedProtocolSchema,
-  buildCanonicalProtocolSchema,
   buildInstalledProtocolInspectionScript,
   buildPortableSwiftAnyCodableSource,
   buildSwiftProtocolCompatibilityHarness,
@@ -22,23 +22,6 @@ describe("Gateway protocol artifact producer", () => {
     ).toThrow("--artifact-base was provided more than once");
   });
 
-  it("builds the same schema envelope as the protocol generator", () => {
-    const request = { type: "object", properties: { type: { const: "req" } } };
-    const canonical = buildCanonicalProtocolSchema(
-      {
-        ConnectParams: { type: "object" },
-        EventFrame: { type: "object" },
-        RequestFrame: request,
-        ResponseFrame: { type: "object" },
-      },
-      [{ name: "health", scope: "operator.read", since: "2026.7" }],
-    );
-
-    expect(canonical.definitions.RequestFrame).toEqual(request);
-    expect(canonical.methods.health).toEqual({ scope: "operator.read", since: "2026.7" });
-    expect(canonical.discriminator.mapping.req).toBe("#/definitions/RequestFrame");
-  });
-
   it("requires the published schema and built registry to match canonical definitions", () => {
     const definitions = {
       ConnectParams: { type: "object" },
@@ -46,7 +29,10 @@ describe("Gateway protocol artifact producer", () => {
       RequestFrame: { type: "object" },
       ResponseFrame: { type: "object" },
     };
-    const canonical = buildCanonicalProtocolSchema(definitions, []);
+    const canonical = buildProtocolSchemaDocument({
+      methods: [{ name: "health", scope: "operator.read", since: "2026.7" }],
+      schemas: definitions,
+    });
 
     expect(() =>
       assertPublishedProtocolSchema({

--- a/test/e2e/qa-lab/runtime/gateway-protocol-artifacts.ts
+++ b/test/e2e/qa-lab/runtime/gateway-protocol-artifacts.ts
@@ -12,30 +12,20 @@ import {
 } from "../../../../extensions/qa-lab/api.js";
 import { ProtocolSchemas } from "../../../../packages/gateway-protocol/src/schema/protocol-schemas.js";
 import { coerceErrorMessage as formatErrorMessage } from "../../../../scripts/lib/error-format.mts";
+import {
+  assertProtocolSchemaDocument,
+  buildProtocolSchemaDocument,
+  type ProtocolSchemaDocument,
+  REQUIRED_PROTOCOL_DEFINITIONS,
+} from "../../../../scripts/lib/protocol-schema-document.mts";
 import { listCoreGatewayMethodMetadata } from "../../../../src/gateway/methods/core-descriptors.js";
 import { createQaScriptEvidenceWriter } from "./script-evidence.js";
 
 const SOURCE_PATH = "test/e2e/qa-lab/runtime/gateway-protocol-artifacts.ts";
-const REQUIRED_DEFINITIONS = [
-  "ConnectParams",
-  "RequestFrame",
-  "ResponseFrame",
-  "EventFrame",
-] as const;
 
 type ProducerOptions = {
   artifactBase: string;
   repoRoot: string;
-};
-
-type ProtocolSchemaDocument = {
-  definitions: Record<string, unknown>;
-  discriminator: {
-    mapping: Record<string, string>;
-    propertyName: string;
-  };
-  methods: Record<string, { scope: string; since: number }>;
-  oneOf: Array<{ $ref: string }>;
 };
 
 type ProtocolArtifactSummary = {
@@ -217,49 +207,13 @@ export function parseGatewayProtocolArtifactOptions(
   };
 }
 
-export function buildCanonicalProtocolSchema(
-  schemas: Record<string, unknown> = ProtocolSchemas,
-  methodMetadata = listCoreGatewayMethodMetadata(),
-): ProtocolSchemaDocument {
-  return structuredClone({
-    $schema: "http://json-schema.org/draft-07/schema#",
-    $id: "https://openclaw.ai/protocol.schema.json",
-    title: "OpenClaw Gateway Protocol",
-    description: "Handshake, request/response, and event frames for the Gateway WebSocket.",
-    oneOf: [
-      { $ref: "#/definitions/RequestFrame" },
-      { $ref: "#/definitions/ResponseFrame" },
-      { $ref: "#/definitions/EventFrame" },
-    ],
-    discriminator: {
-      propertyName: "type",
-      mapping: {
-        req: "#/definitions/RequestFrame",
-        res: "#/definitions/ResponseFrame",
-        event: "#/definitions/EventFrame",
-      },
-    },
-    methods: Object.fromEntries(
-      // Omit undefined `since` so structuredClone matches the prior JSON
-      // round-trip byte shape and the document satisfies the schema type.
-      methodMetadata.map(({ name, scope, since }) => [
-        name,
-        { ...(since === undefined ? {} : { since }), scope },
-      ]),
-    ),
-    definitions: schemas,
-    // The runtime consumers validate this JSON document; the literal cannot
-    // structurally satisfy ProtocolSchemaDocument's stricter schema shapes.
-  }) as unknown as ProtocolSchemaDocument;
-}
-
 export function assertPublishedProtocolSchema(params: {
   builtSchemas: Record<string, unknown>;
   canonical: ProtocolSchemaDocument;
   published: ProtocolSchemaDocument;
 }) {
   assert.deepEqual(
-    structuredClone(params.builtSchemas),
+    params.builtSchemas,
     params.canonical.definitions,
     "built package schema registry differs from the canonical TypeBox registry",
   );
@@ -268,16 +222,7 @@ export function assertPublishedProtocolSchema(params: {
     params.canonical,
     "published protocol.schema.json differs from the canonical TypeBox registry",
   );
-  for (const definition of REQUIRED_DEFINITIONS) {
-    assert.ok(
-      Object.hasOwn(params.published.definitions, definition),
-      `published protocol schema is missing ${definition}`,
-    );
-  }
-  assert.deepEqual(
-    params.published.oneOf.map((entry) => entry.$ref),
-    ["#/definitions/RequestFrame", "#/definitions/ResponseFrame", "#/definitions/EventFrame"],
-  );
+  assertProtocolSchemaDocument(params.published);
 }
 
 async function runCommand(params: {
@@ -429,7 +374,10 @@ async function packAndInspectProtocol(params: {
       await fs.rm(consumerRoot, { force: true, recursive: true });
     }
   })();
-  const canonical = buildCanonicalProtocolSchema();
+  const canonical = buildProtocolSchemaDocument({
+    methods: listCoreGatewayMethodMetadata(),
+    schemas: ProtocolSchemas,
+  });
   assertPublishedProtocolSchema({
     builtSchemas: inspection.schemas,
     canonical,
@@ -451,7 +399,7 @@ async function packAndInspectProtocol(params: {
       packageSpecifier: "@openclaw/gateway-protocol",
       schemaSpecifier: "@openclaw/gateway-protocol/schema",
     },
-    definitions: REQUIRED_DEFINITIONS.filter((definition) =>
+    definitions: REQUIRED_PROTOCOL_DEFINITIONS.filter((definition) =>
       Object.hasOwn(published.definitions, definition),
     ),
     package: {

--- a/test/scripts/protocol-schema-artifact.test.ts
+++ b/test/scripts/protocol-schema-artifact.test.ts
@@ -1,0 +1,134 @@
+// Protocol schema artifact tests cover the published document contract and the
+// regenerate-then-diff guards that verify the committed generator outputs.
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  assertProtocolSchemaDocument,
+  buildProtocolSchemaDocument,
+  type ProtocolSchemaDocument,
+} from "../../scripts/lib/protocol-schema-document.mts";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const GIT_DIFF_GUARD = "git diff --exit-code --";
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function readPackageScripts(): Record<string, string> {
+  const manifest = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8")) as {
+    scripts: Record<string, string>;
+  };
+  return manifest.scripts;
+}
+
+function readGitDiffGuardPaths(script: string): string[] {
+  return script
+    .split("&&")
+    .map((command) => command.trim())
+    .filter((command) => command.startsWith(GIT_DIFF_GUARD))
+    .flatMap((command) => command.slice(GIT_DIFF_GUARD.length).trim().split(/\s+/u));
+}
+
+function buildValidDocument(): ProtocolSchemaDocument {
+  return buildProtocolSchemaDocument({
+    methods: [{ name: "health", scope: "operator.read", since: "<=2026.7" }],
+    schemas: {
+      ConnectParams: { type: "object" },
+      RequestFrame: { type: "object" },
+      ResponseFrame: { type: "object" },
+      EventFrame: { type: "object" },
+    },
+  });
+}
+
+describe("regenerate-then-diff protocol guards", () => {
+  it("guards only git-tracked generator outputs", () => {
+    const guardedScripts = Object.entries(readPackageScripts())
+      .map(([name, script]) => ({ name, paths: readGitDiffGuardPaths(script) }))
+      .filter(({ paths }) => paths.length > 0);
+
+    expect(guardedScripts.length).toBeGreaterThan(0);
+    for (const { name, paths } of guardedScripts) {
+      // An untracked path makes `git diff --exit-code` succeed unconditionally,
+      // so the guard reads as verification while it can never fail.
+      const tracked = execFileSync("git", ["ls-files", "--", ...paths], {
+        cwd: repoRoot,
+        encoding: "utf8",
+      })
+        .split("\n")
+        .filter(Boolean);
+      expect({ script: name, tracked: [...tracked].sort() }).toEqual({
+        script: name,
+        tracked: [...paths].sort(),
+      });
+    }
+  });
+});
+
+describe("published protocol schema document", () => {
+  it("accepts the canonical document", () => {
+    expect(() => assertProtocolSchemaDocument(buildValidDocument())).not.toThrow();
+  });
+
+  it("rejects a document that lost a required frame definition", () => {
+    const document = buildValidDocument();
+    delete document.definitions.ConnectParams;
+
+    expect(() => assertProtocolSchemaDocument(document)).toThrow(
+      "definition ConnectParams is missing",
+    );
+  });
+
+  it("rejects reordered frame branches", () => {
+    const document = buildValidDocument();
+    document.oneOf = [...document.oneOf].reverse();
+
+    expect(() => assertProtocolSchemaDocument(document)).toThrow("frame oneOf must list");
+  });
+
+  it("rejects a rewritten type discriminator", () => {
+    const document = buildValidDocument();
+    document.discriminator.mapping.req = "#/definitions/EventFrame";
+
+    expect(() => assertProtocolSchemaDocument(document)).toThrow("type discriminator must map");
+  });
+
+  it("rejects an empty method catalog", () => {
+    const document = buildValidDocument();
+    document.methods = {};
+
+    expect(() => assertProtocolSchemaDocument(document)).toThrow("method metadata is empty");
+  });
+});
+
+describe("protocol-gen artifact", () => {
+  it("writes the canonical document the contract check guards", () => {
+    const outputPath = path.join(tempDirs.make("openclaw-protocol-gen-"), "protocol.schema.json");
+    execFileSync(
+      process.execPath,
+      ["--import", "./scripts/tsx.mjs", "scripts/protocol-gen.ts", "--out", outputPath],
+      { cwd: repoRoot, encoding: "utf8", stdio: "pipe" },
+    );
+
+    const written = fs.readFileSync(outputPath, "utf8");
+    const document = JSON.parse(written) as ProtocolSchemaDocument;
+    expect(() => assertProtocolSchemaDocument(document)).not.toThrow();
+    // Rebuilding the envelope from the artifact's own parts fails the moment
+    // the generator stops emitting exactly what the shared owner produces.
+    expect(
+      JSON.stringify(
+        buildProtocolSchemaDocument({
+          methods: Object.entries(document.methods).map(([name, metadata]) => ({
+            name,
+            ...metadata,
+          })),
+          schemas: document.definitions,
+        }),
+        null,
+        2,
+      ),
+    ).toBe(written);
+  }, 120_000);
+});


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where `pnpm protocol:check` reported success even when the published
Gateway protocol schema had drifted. Its final guard ended with:

```
git diff --exit-code -- dist/protocol.schema.json apps/shared/.../GatewayModels.swift ...
```

`dist/protocol.schema.json` is gitignored (`.gitignore:169`) and never committed, so
`git diff --exit-code` on that path exits 0 unconditionally — verified by writing garbage
into the file and watching the guard still pass. The Swift and Kotlin halves work because
those files are tracked; the JSON half read as verification while it could not fail.

`scripts/prepush-ci.sh` carried the same dead guard a second time. `run_protocol_ci_mirror`
snapshotted `git diff` over `dist/protocol.schema.json` plus `GatewayModels.swift`, ran
`protocol:gen` and `protocol:check:swift`, then compared before/after. That comparison also
could never fail: `protocol:gen` writes only the untracked JSON and `protocol:check:swift`
writes nothing at all.

The consequence was that JSON-schema drift only surfaced in the QA-lab scenario
`qa/scenarios/runtime/gateway-protocol-artifacts.yaml`, never in the fast
`checks-fast-bundled-protocol` lane — and that scenario built its own hand-copied
duplicate of the generator's root envelope, so it was largely comparing one of our copies
against the other rather than the tarball against a canonical document.

## Why This Change Was Made

The artifact is deliberately a build output with no committed baseline, so a
regenerate-then-diff guard has nothing to diff against. Tracking a 3.3 MB generated file
inside the ignored `dist/` tree contradicts both the gitignore comment and
`docs/concepts/typebox.md`, and a `--check` mode like `protocol-gen-swift.ts` has no honest
baseline either: `protocol:check` regenerates the file in the same command (so
gen-then-check is tautological), and the fast CI lane runs `pnpm test:bundled && pnpm
protocol:check` with no build, so a fresh checkout would fail on a missing artifact.

So the JSON artifact gets a contract check instead of a diff. New
`scripts/lib/protocol-schema-document.mts` owns the published document:
`buildProtocolSchemaDocument` builds the envelope (one copy), and
`assertProtocolSchemaDocument` rejects a document that lost a required frame definition,
reordered the frame `oneOf` branches, rewrote the `type` discriminator mapping, or shipped
an empty method catalog. `scripts/protocol-gen.ts` builds through that owner, asserts
before writing, and writes via the shared `writeGeneratedOutput` helper the Swift generator
already uses. The QA-lab verifier imports the same owner, so its tarball comparison is
finally canonical-vs-published, and its duplicate envelope is gone.

The dead paths are removed: the untrackable path leaves the `protocol:check` diff list, and
`run_protocol_ci_mirror` collapses into the two `run_step` calls that were doing the real
work.

Scope note: this deliberately does not add a `--check` mode to `protocol-gen.ts`. Doing so
would add a third guard to the same family — one that either always passes (run after
generation) or always fails (fresh checkout with no `dist/`).

## User Impact

Maintainers and contributors get a `protocol:check` that actually fails on published-schema
drift, in the fast CI lane rather than only in the slow QA-lab scenario, with an actionable
message naming what the document lost. The generated `dist/protocol.schema.json` is
byte-identical to before, so there is no wire-format or artifact change; `prepack` gains the
same contract check, so a degraded registry can no longer be published in the
`@openclaw/gateway-protocol` tarball.

Line delta, judged: production/tooling `-19` in `prepush-ci.sh`, `-12` in the generator,
`+103` in the new owner (of which roughly 60 is envelope and types moved out of
`protocol-gen.ts` and the QA-lab producer); test and test-support `-52` in the QA-lab
producer, `-14` in its unit test, `+134` in the new regression test. Net-neutral on
production once the moves are discounted, with the growth being the contract owner that
replaces a guard which could never fail.

## Evidence

**The bug, reproduced**

```
$ printf 'GARBAGE' > dist/protocol.schema.json
$ git diff --exit-code -- dist/protocol.schema.json; echo "exit=$?"
exit=0
```

**Regression test fails on pre-fix code.** `test/scripts/protocol-schema-artifact.test.ts`
asserts every path in every `git diff --exit-code --` guard in `package.json` is git-tracked.
Restoring the pre-fix `protocol:check` fails it, naming the exact path:

```
- Expected
+ Received
    "tracked": [
      "apps/android/.../GatewayProtocol.kt",
      "apps/android/.../OpenClawProtocolConstants.kt",
      "apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift",
-     "dist/protocol.schema.json",
    ]
```

**The new guard fails on drift.** Injecting a dropped `ConnectParams` into the generator
and running the real command:

```
$ pnpm protocol:check
$ node --import ./scripts/tsx.mjs scripts/protocol-gen.ts
Error: published protocol schema contract violated: definition ConnectParams is missing
[ELIFECYCLE] Command failed with exit code 1.
```

That is the exact drift the old guard waved through. Reverted afterwards.

**Test coverage.** Seven tests in `test/scripts/protocol-schema-artifact.test.ts`: the
tracked-guard-path regression, four drift cases against the contract assertion, and a
boundary test that spawns the real generator to a temp `--out` and proves the bytes it
writes are exactly what the shared owner produces.

**Artifact unchanged.** The regenerated `dist/protocol.schema.json` is byte-identical to the
pre-refactor output (`diff -q` against a snapshot taken before the change).

**Commands run locally**

- `pnpm protocol:check` — exit 0
- `node scripts/check-changed.mjs` — exit 0 (format, `tsgo` scripts + test-root, scripts
  lint, script erasability, boundaries, coercion guard, SDK surface)
- `node scripts/run-vitest.mjs run test/scripts/protocol-schema-artifact.test.ts
  test/e2e/qa-lab/runtime/gateway-protocol-artifacts.test.ts` — 17 tests passed
- Full QA-lab producer end to end:
  `node --import ./scripts/tsx.mjs test/e2e/qa-lab/runtime/gateway-protocol-artifacts.ts
  --artifact-base .artifacts/protocol-artifacts-proof` — packs the tarball, installs a fresh
  consumer, deep-compares the published schema against the shared canonical builder, and
  compiles/runs the Swift generated models. Result: `status: pass`, definitions
  `ConnectParams, RequestFrame, ResponseFrame, EventFrame`, both AJV validators green.

No UI surface changes, so no screenshots apply.
