### PR TITLE
fix(agents): preserve keyed turns across compaction

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
@@ -15,6 +15,8 @@ import { submitEmbeddedAttemptPrompt } from "./attempt-prompt-submit.js";
 import type { RuntimeContextCustomMessage } from "./runtime-context-prompt.js";
 
 const sessionId = "attempt-prompt-submit-test";
+type PromptActiveSession = Parameters<typeof submitEmbeddedAttemptPrompt>[0]["promptActiveSession"];
+type PromptOptions = Parameters<PromptActiveSession>[1];
 
 function createSession() {
   const state = {
@@ -85,7 +87,9 @@ describe("submitEmbeddedAttemptPrompt", () => {
         target: async () => undefined,
       });
       recorder.markRuntimePersisted(persistedUser);
-      const promptActiveSession = vi.fn(async () => undefined);
+      const promptActiveSession = vi.fn(
+        async (_prompt: string, _options?: PromptOptions) => undefined,
+      );
 
       await submitEmbeddedAttemptPrompt({
         ...input,

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
@@ -1,6 +1,7 @@
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ImageContent } from "../../../llm/types.js";
+import { createUserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import {
   beginPromptCacheObservation,
@@ -65,6 +66,47 @@ afterEach(() => {
 });
 
 describe("submitEmbeddedAttemptPrompt", () => {
+  it.each([
+    { skipPreparedUserTurnMessage: false, expectedKey: "persisted-current-user" },
+    { skipPreparedUserTurnMessage: true, expectedKey: undefined },
+  ])(
+    "passes persisted user identity when prepared-user skipping is $skipPreparedUserTurnMessage",
+    async ({ skipPreparedUserTurnMessage, expectedKey }) => {
+      const { activeSession } = createSession();
+      const input = createBaseInput();
+      const persistedUser = {
+        role: "user" as const,
+        content: "transcript prompt",
+        idempotencyKey: "persisted-current-user",
+        timestamp: 1,
+      };
+      const recorder = createUserTurnTranscriptRecorder({
+        message: persistedUser,
+        target: async () => undefined,
+      });
+      recorder.markRuntimePersisted(persistedUser);
+      const promptActiveSession = vi.fn(async () => undefined);
+
+      await submitEmbeddedAttemptPrompt({
+        ...input,
+        attempt: {
+          sessionId,
+          skipPreparedUserTurnMessage,
+          userTurnTranscriptRecorder: recorder,
+        },
+        activeSession,
+        promptActiveSession,
+      });
+
+      const promptOptions = promptActiveSession.mock.calls[0]?.[1];
+      if (expectedKey) {
+        expect(promptOptions).toMatchObject({ persistedUserIdempotencyKey: expectedKey });
+      } else {
+        expect(promptOptions).not.toHaveProperty("persistedUserIdempotencyKey");
+      }
+    },
+  );
+
   it("submits runtime-only prompts without images and acknowledges steering", async () => {
     const { activeSession, baseStreamFn, originalTransformContext } = createSession();
     const input = createBaseInput();

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
@@ -49,10 +49,7 @@ type PromptSubmissionSession = {
 
 type PromptActiveSession = (
   prompt: string,
-  options?: {
-    images?: ImageContent[];
-    preflightResult?: (submitted: boolean) => void;
-  },
+  options?: Parameters<AgentSession["prompt"]>[1],
 ) => Promise<void>;
 
 type SteeringLease = {
@@ -65,7 +62,11 @@ type TrajectoryRecorder = ReturnType<typeof createTrajectoryRuntimeRecorder>;
 export async function submitEmbeddedAttemptPrompt(input: {
   attempt: Pick<
     EmbeddedRunAttemptParams,
-    "promptCacheKey" | "sessionId" | "sessionKey" | "userTurnTranscriptRecorder"
+    | "promptCacheKey"
+    | "sessionId"
+    | "sessionKey"
+    | "skipPreparedUserTurnMessage"
+    | "userTurnTranscriptRecorder"
   >;
   activeSession: PromptSubmissionSession;
   appendContext?: string;
@@ -89,6 +90,11 @@ export async function submitEmbeddedAttemptPrompt(input: {
   transcriptPrompt: string;
 }): Promise<void> {
   const { activeSession, attempt } = input;
+  const userTurnRecorder = attempt.userTurnTranscriptRecorder;
+  const persistedUserIdempotencyKey =
+    attempt.skipPreparedUserTurnMessage !== true && userTurnRecorder?.hasPersisted() === true
+      ? (userTurnRecorder.getPersistedMessage?.() ?? userTurnRecorder.message)?.idempotencyKey
+      : undefined;
   const normalizedReplayMessages = normalizeAssistantReplayContent(activeSession.messages);
   if (normalizedReplayMessages !== activeSession.messages) {
     activeSession.agent.state.messages = normalizedReplayMessages;
@@ -162,6 +168,7 @@ export async function submitEmbeddedAttemptPrompt(input: {
   try {
     if (input.runtimeOnly) {
       await input.promptActiveSession(input.transcriptPrompt, {
+        ...(persistedUserIdempotencyKey ? { persistedUserIdempotencyKey } : {}),
         preflightResult: armModelPromptTransform,
       });
     } else {
@@ -172,6 +179,7 @@ export async function submitEmbeddedAttemptPrompt(input: {
       try {
         await input.promptActiveSession(input.transcriptPrompt, {
           ...(input.images.length > 0 ? { images: input.images } : {}),
+          ...(persistedUserIdempotencyKey ? { persistedUserIdempotencyKey } : {}),
           preflightResult: armModelPromptTransform,
         });
       } finally {

--- a/src/agents/sessions/agent-session-compaction.test.ts
+++ b/src/agents/sessions/agent-session-compaction.test.ts
@@ -1,11 +1,15 @@
+import path from "node:path";
 import type {
   AssistantMessage,
   Context,
   Model,
   SimpleStreamOptions,
 } from "openclaw/plugin-sdk/llm";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
+import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import type { CompactionProvider } from "../../plugins/compaction-provider.js";
 import { requireActivePluginRegistry } from "../../plugins/runtime.js";
 import { MAX_OVERFLOW_COMPACTION_ATTEMPTS } from "../agent-compaction-constants.js";
@@ -15,6 +19,7 @@ import {
 } from "../agent-hooks/compaction-safeguard-runtime.js";
 import compactionSafeguardExtension from "../agent-hooks/compaction-safeguard.js";
 import { subscribeEmbeddedAgentSession } from "../embedded-agent-subscribe.js";
+import { guardSessionManager } from "../session-tool-result-guard-wrapper.js";
 import {
   agentSessionAutomaticCompaction,
   agentSessionSetContextReplacementHook,
@@ -41,6 +46,7 @@ import { SessionManager } from "./session-manager.js";
 import { SettingsManager } from "./settings-manager.js";
 
 registerAgentSessionLoopTestLifecycle();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function createStaleThinkingContent(): AssistantMessage["content"] {
   return [
@@ -399,6 +405,75 @@ describe("AgentSession compaction", () => {
     expect(subscription.getLastCompactionTokensAfter()).toEqual(expect.any(Number));
     expect(subscription.getLastCompactionTokensAfter()).toBeGreaterThan(0);
     subscription.unsubscribe();
+  });
+
+  it("sends a pre-persisted keyed user once after pre-prompt compaction", async () => {
+    const dir = tempDirs.make("openclaw-agent-session-compaction-keyed-user-");
+    const scope = {
+      agentId: "main",
+      sessionId: "sqlite-agent-session-compaction-keyed-user",
+      sessionKey: "agent:main:dashboard:sqlite-agent-session-compaction-keyed-user",
+      storePath: path.join(dir, "sessions.json"),
+    };
+    await upsertSessionEntryCore(scope, {
+      sessionFile: formatSqliteSessionFileMarker(scope),
+      sessionId: scope.sessionId,
+      updatedAt: 1,
+    });
+    const sessionManager = SessionManager.open(scope, dir);
+    sessionManager.appendMessage({ role: "user", content: "old prompt", timestamp: 1 });
+    sessionManager.appendMessage({
+      ...createAssistant(testModel, [{ type: "text", text: "old answer" }], "stop", 950),
+      timestamp: 2,
+    });
+    const currentUser = {
+      role: "user" as const,
+      content: "current question",
+      idempotencyKey: "agent-session-compaction-keyed-user:user",
+      timestamp: 3,
+    };
+    const currentUserId = sessionManager.appendMessage(currentUser);
+    guardSessionManager(sessionManager, { preparedUserTurnMessage: currentUser });
+    const requests: Context[] = [];
+    streamMocks.streamSimple.mockImplementation((activeModel: Model, context: Context) => {
+      requests.push(context);
+      return createAssistantResultStream(
+        createAssistant(activeModel, [{ type: "text", text: "complete answer" }]),
+      );
+    });
+    const { session } = await createTestSession({
+      sessionManager,
+      settingsManager: createAutoCompactionSettings(),
+      resourceLoader: createResourceLoader(createResultHandlers("condensed history")),
+    });
+    // Embedded attempt preparation removes the ingress-persisted user from model state.
+    // Pre-prompt compaction rebuilds it from the durable branch before prompt submission.
+    session.agent.state.messages = session.agent.state.messages.slice(0, -1);
+
+    await session.prompt(currentUser.content, {
+      persistedUserIdempotencyKey: currentUser.idempotencyKey,
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(
+      requests[0]?.messages.filter(
+        (message) =>
+          message.role === "user" && JSON.stringify(message.content).includes(currentUser.content),
+      ),
+    ).toHaveLength(1);
+    expect(
+      sessionManager
+        .getBranch()
+        .filter(
+          (entry) =>
+            entry.type === "message" &&
+            entry.message.role === "user" &&
+            "idempotencyKey" in entry.message &&
+            entry.message.idempotencyKey === currentUser.idempotencyKey,
+        ),
+    ).toHaveLength(1);
+    expect(sessionManager.getEntry(currentUserId)).toBeDefined();
+    expect(session.getLastAssistantText()).toBe("complete answer");
   });
 
   it("accounts every automatic compaction response before summary validation", async () => {

--- a/src/agents/sessions/agent-session-prompting.ts
+++ b/src/agents/sessions/agent-session-prompting.ts
@@ -238,6 +238,18 @@ export abstract class AgentSessionPrompting extends AgentSessionBase {
         await this.checkCompaction(lastAssistant, false);
       }
 
+      const persistedUserIdempotencyKey = options?.persistedUserIdempotencyKey;
+      const activeTail = this.agent.state.messages.at(-1);
+      if (
+        persistedUserIdempotencyKey &&
+        activeTail?.role === "user" &&
+        activeTail.idempotencyKey === persistedUserIdempotencyKey
+      ) {
+        // Compaction can restore the durable current user after the runner removed its replay.
+        // The prompt below supplies that exact turn, so keep one provider-visible copy.
+        this.agent.state.messages = this.agent.state.messages.slice(0, -1);
+      }
+
       // Build messages array (custom message if any, then user message)
       messages = [];
 

--- a/src/agents/sessions/agent-session-prompting.ts
+++ b/src/agents/sessions/agent-session-prompting.ts
@@ -243,6 +243,7 @@ export abstract class AgentSessionPrompting extends AgentSessionBase {
       if (
         persistedUserIdempotencyKey &&
         activeTail?.role === "user" &&
+        "idempotencyKey" in activeTail &&
         activeTail.idempotencyKey === persistedUserIdempotencyKey
       ) {
         // Compaction can restore the durable current user after the runner removed its replay.

--- a/src/agents/sessions/agent-session-types.ts
+++ b/src/agents/sessions/agent-session-types.ts
@@ -113,6 +113,8 @@ export interface PromptOptions {
   source?: InputSource;
   /** Internal RPC hook for prompt preflight acceptance or rejection. */
   preflightResult?: (success: boolean) => void;
+  /** Internal identity for a current user turn that is already durable. */
+  persistedUserIdempotencyKey?: string;
 }
 
 /** Result from cycling the active model. */

--- a/src/agents/sessions/session-manager-entries.ts
+++ b/src/agents/sessions/session-manager-entries.ts
@@ -76,7 +76,7 @@ export class SessionManagerEntries extends SessionManagerPersistence {
             : undefined;
         if (adoptedMessageId !== persistenceResult.adoptedMessageId) {
           throw new Error(
-            `Session transcript parent entry was not persisted: ${canonicalEntry.id}`,
+            `Session transcript keyed user is outside the current turn: ${persistenceResult.adoptedMessageId}`,
           );
         }
         this.pendingDeliberateAppend = false;
@@ -127,7 +127,13 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     }
     let parent = this.appendParentId ? this.byId.get(this.appendParentId) : undefined;
     let remainingAncestors = this.byId.size;
-    while (parent && remainingAncestors-- > 0 && isSessionContextMetadataEntry(parent)) {
+    // Compaction rewrites context without consuming the current user turn.
+    // Stop at message and reset boundaries so old keyed turns stay closed.
+    while (
+      parent &&
+      remainingAncestors-- > 0 &&
+      (isSessionContextMetadataEntry(parent) || parent.type === "compaction")
+    ) {
       parent = parent.parentId ? this.byId.get(parent.parentId) : undefined;
     }
     if (
@@ -158,8 +164,6 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     if (options?.idempotencyLookup !== "caller-checked") {
       const currentUserId = this.resolveCurrentKeyedUserId(message);
       if (currentUserId) {
-        // Session setup may insert context-free metadata after the ingress-persisted user.
-        // Keep that metadata as the append parent while adopting the canonical user once.
         const anchor = this.persistenceTarget
           ? readActiveTranscriptEntryAnchor({
               ...this.persistenceTarget,

--- a/src/agents/sessions/session-manager.user-idempotency.test.ts
+++ b/src/agents/sessions/session-manager.user-idempotency.test.ts
@@ -97,7 +97,7 @@ describe("SessionManager user idempotency", () => {
     const sessionManager = SessionManager.open(scope, dir);
 
     expect(() => sessionManager.appendMessage(userMessage)).toThrow(
-      "Session transcript parent entry was not persisted",
+      "Session transcript keyed user is outside the current turn",
     );
     expect(sessionManager.getLeafId()).toBe("persisted-assistant");
     expect(
@@ -222,6 +222,57 @@ describe("SessionManager user idempotency", () => {
     const events = await loadTranscriptEvents(scope);
     expect(events.find((event) => (event as { id?: string }).id === assistantId)).toMatchObject({
       parentId: metadataId,
+    });
+    expect(
+      events.filter(
+        (event) =>
+          (event as { message?: { role?: string; idempotencyKey?: string } }).message?.role ===
+            "user" &&
+          (event as { message?: { idempotencyKey?: string } }).message?.idempotencyKey ===
+            userMessage.idempotencyKey,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("adopts the current keyed user across a compaction boundary", async () => {
+    const dir = tempDirs.make("openclaw-session-manager-user-idempotency-");
+    const scope = {
+      agentId: "main",
+      sessionId: "sqlite-runtime-user-compaction",
+      sessionKey: "agent:main:dashboard:sqlite-runtime-user-compaction",
+      storePath: path.join(dir, "sessions.json"),
+    };
+    const userMessage = {
+      role: "user" as const,
+      content: "question",
+      idempotencyKey: "runtime-user-compaction:user",
+      timestamp: 1,
+    };
+    await upsertSessionEntryCore(scope, {
+      sessionFile: formatSqliteSessionFileMarker(scope),
+      sessionId: scope.sessionId,
+      updatedAt: 1,
+    });
+    await appendTranscriptMessage(scope, {
+      cwd: dir,
+      eventId: "pre-persisted-user",
+      message: userMessage,
+      now: 1,
+    });
+    const sessionManager = SessionManager.open(scope, dir);
+    const compactionId = sessionManager.appendCompaction(
+      "Compacted history",
+      "pre-persisted-user",
+      100,
+    );
+
+    expect(sessionManager.appendMessage(userMessage)).toBe("pre-persisted-user");
+    expect(sessionManager.getAppendParentId()).toBe(compactionId);
+
+    const assistantId = sessionManager.appendMessage(buildAssistantMessage("answer"));
+    const events = await loadTranscriptEvents(scope);
+    expect(events.find((event) => (event as { id?: string }).id === assistantId)).toMatchObject({
+      parentId: compactionId,
     });
     expect(
       events.filter(


### PR DESCRIPTION
## Summary

- keep the current keyed user active when compaction becomes its transcript child
- pass durable current-turn identity into prompt submission
- remove a restored duplicate before the same prompt reaches the provider

## Problem

After successful context compaction, a retry could reuse an already persisted keyed user turn. The session manager stopped its current-user lookup at the compaction entry, asked SQLite to append a new user, then rejected SQLite's correct idempotent adoption as a missing-parent persistence failure.

Allowing that adoption alone exposed a second bug: pre-prompt compaction restored the durable user into model state before prompt submission added the same user again.

## Root cause

Compaction changes the context prefix but does not consume the current user turn. The session manager treated it as a turn boundary, while prompt submission did not carry the durable user identity needed to remove the restored duplicate.

## Fix

- treat compaction as transparent only while resolving the current keyed user
- keep assistant, reset, and branch boundaries closed
- pass the persisted current-user key through the internal prompt options
- remove only an exact keyed tail before the same prompt is added
- replace the misleading local collision text with the actual current-turn error

## Proof

Exact `origin/main` `6104b10acf7a5ed745227aa911d886b809d7f910` completed a real OpenAI Responses compaction, then failed locally with `Session transcript parent entry was not persisted` before the next model request.

Exact behavior head `b4e40ae392a2b407a24236aef16bce50b7419a59` completed the same real OpenAI compaction and reused the keyed user successfully. Final head `54f99cc6a6bf5718d4aec5392038c1ef8ffc9b47` adds only the CI-required test mock type. The focused provider-bound regression also observed one current-user copy and one durable keyed row.

## Tests

- `node scripts/run-vitest.mjs src/agents/sessions/session-manager.user-idempotency.test.ts src/agents/sessions/session-manager.test.ts src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts src/agents/sessions/agent-session-compaction.test.ts`
- 60 focused tests passed
- exact-head CI run [33295326847](https://github.com/openclaw/openclaw/actions/runs/33295326847) passed
- targeted Oxfmt and Oxlint passed
- max-lines, assertion-safety, temp-directory, and diff checks passed

## Change shape

- production: +27 net lines
- tests: +172 net lines
- no schema, config, provider, retry, or fallback change
