### PR TITLE
refactor(scripts): share required option arguments

### DIFF
--- a/.github/workflows/docs-sync-publish.yml
+++ b/.github/workflows/docs-sync-publish.yml
@@ -10,6 +10,7 @@ on:
       - scripts/docs-sync-publish.mjs
       - scripts/check-docs-mdx.mjs
       - scripts/check-docs-mdx.mts
+      - scripts/lib/arg-utils.runtime.mjs
       - scripts/lib/mintlify-accordion.mjs
       - scripts/lib/tsx-cli-shim.mjs
       - scripts/lib/local-check-runtime.mts

--- a/scripts/check-docs-i18n-glossary.mts
+++ b/scripts/check-docs-i18n-glossary.mts
@@ -4,6 +4,7 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { requireOptionArgument } from "./lib/arg-utils.mts";
 
 const ROOT = process.cwd();
 const GLOSSARY_PATH = path.join(ROOT, "docs", ".i18n", "glossary.zh-CN.json");
@@ -20,24 +21,16 @@ type TermMatch = {
   term: string;
 };
 
-function readRefOptionValue(argv: string[], index: number, optionName: string) {
-  const value = argv[index + 1];
-  if (value === undefined || value === "" || value.startsWith("-")) {
-    throw new Error(`${optionName} requires a value`);
-  }
-  return value;
-}
-
 export function parseArgs(argv: string[]) {
   const args = { base: "", head: "" };
   for (let i = 0; i < argv.length; i += 1) {
     if (argv[i] === "--base") {
-      args.base = readRefOptionValue(argv, i, "--base");
+      args.base = requireOptionArgument(argv, i, "--base");
       i += 1;
       continue;
     }
     if (argv[i] === "--head") {
-      args.head = readRefOptionValue(argv, i, "--head");
+      args.head = requireOptionArgument(argv, i, "--head");
       i += 1;
     }
   }

--- a/scripts/check-docs-mdx.mts
+++ b/scripts/check-docs-mdx.mts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { compile } from "@mdx-js/mdx";
+import { requireOptionArgument } from "./lib/arg-utils.runtime.mjs";
 import {
   checkMintlifyAccordionIndentation,
   MINTLIFY_ACCORDION_INDENT_MESSAGE,
@@ -100,14 +101,6 @@ function parsePositiveIntegerArg(raw: string | undefined, label: string): number
   return value;
 }
 
-function readRequiredValue(argv: string[], index: number, label: string): string {
-  const value = argv[index + 1];
-  if (!value || value.startsWith("-")) {
-    throw new Error(`${label} requires a value`);
-  }
-  return value;
-}
-
 /**
  * Parses docs MDX check arguments.
  */
@@ -122,13 +115,13 @@ export function parseArgs(argv: string[]) {
       continue;
     }
     if (part === "--json-out") {
-      jsonOut = readRequiredValue(argv, index, "--json-out");
+      jsonOut = requireOptionArgument(argv, index, "--json-out");
       index += 1;
       continue;
     }
     if (part === "--max-errors") {
       maxErrors = parsePositiveIntegerArg(
-        readRequiredValue(argv, index, "--max-errors"),
+        requireOptionArgument(argv, index, "--max-errors"),
         "--max-errors",
       );
       index += 1;

--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -1,6 +1,7 @@
 // Determines CI scope from changed paths.
 import { execFileSync } from "node:child_process";
 import { appendFileSync, readFileSync, readdirSync } from "node:fs";
+import { requireOptionArgument } from "./lib/arg-utils.runtime.mjs";
 import { getChangedPathFacts } from "./lib/changed-path-facts.mjs";
 import { isDirectRunUrl } from "./lib/direct-run.mjs";
 import { resolveMergeHeadDiffBase } from "./lib/merge-head-diff-base.mjs";
@@ -728,32 +729,18 @@ function isDirectRun() {
 
 /**
  * @param {string[]} argv
- * @param {number} index
- * @param {string} optionName
- * @returns {string}
- */
-function readRefValue(argv, index, optionName) {
-  const value = argv[index + 1];
-  if (value === undefined || value === "" || value.startsWith("-")) {
-    throw new Error(`${optionName} requires a value`);
-  }
-  return value;
-}
-
-/**
- * @param {string[]} argv
  * @returns {{ base: string; head: string; mergeHeadFirstParent: boolean }}
  */
 export function parseArgs(argv) {
   const args = { base: "", head: "HEAD", mergeHeadFirstParent: false };
   for (let i = 0; i < argv.length; i += 1) {
     if (argv[i] === "--base") {
-      args.base = readRefValue(argv, i, "--base");
+      args.base = requireOptionArgument(argv, i, "--base");
       i += 1;
       continue;
     }
     if (argv[i] === "--head") {
-      args.head = readRefValue(argv, i, "--head");
+      args.head = requireOptionArgument(argv, i, "--head");
       i += 1;
       continue;
     }

--- a/scripts/code-mode-model-matrix.ts
+++ b/scripts/code-mode-model-matrix.ts
@@ -16,6 +16,7 @@ import {
   type QaEvidenceSummaryJson,
 } from "../extensions/qa-lab/api.js";
 import type { AgentExecEnvelope } from "../src/commands/agent-exec.ts";
+import { requireOptionArgument } from "./lib/arg-utils.mts";
 import { previewForDevToolLog, redactJsonValueForDevToolLog } from "./lib/dev-tooling-safety.ts";
 
 export { validateQaEvidenceSummaryJson };
@@ -164,14 +165,6 @@ Provider credentials are read from the environment and are never written to arti
 `;
 }
 
-function readOptionValue(argv: readonly string[], index: number, flag: string): string {
-  const value = argv[index + 1];
-  if (!value || value.startsWith("-")) {
-    throw new Error(`${flag} requires a value`);
-  }
-  return value;
-}
-
 function parseIntegerOption(raw: string, flag: string, max?: number): number {
   if (!/^\d+$/u.test(raw)) {
     throw new Error(`${flag} must be a positive integer`);
@@ -230,7 +223,7 @@ export function parseCodeModeMatrixOptions(
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === "--model") {
-      const value = readOptionValue(argv, index, arg).trim();
+      const value = requireOptionArgument(argv, index, arg).trim();
       if (!value.includes("/")) {
         throw new Error(
           `--model must use a provider/model reference; got ${JSON.stringify(value)}`,
@@ -241,36 +234,40 @@ export function parseCodeModeMatrixOptions(
       continue;
     }
     if (arg === "--mode") {
-      collectUnique(modes, parseMode(readOptionValue(argv, index, arg)), arg);
+      collectUnique(modes, parseMode(requireOptionArgument(argv, index, arg)), arg);
       index += 1;
       continue;
     }
     if (arg === "--task") {
-      collectUnique(tasks, parseTask(readOptionValue(argv, index, arg)), arg);
+      collectUnique(tasks, parseTask(requireOptionArgument(argv, index, arg)), arg);
       index += 1;
       continue;
     }
     if (arg === "--repetitions") {
       recordOnce(arg);
-      repetitions = parseIntegerOption(readOptionValue(argv, index, arg), arg, MAX_REPETITIONS);
+      repetitions = parseIntegerOption(
+        requireOptionArgument(argv, index, arg),
+        arg,
+        MAX_REPETITIONS,
+      );
       index += 1;
       continue;
     }
     if (arg === "--timeout") {
       recordOnce(arg);
-      timeoutSeconds = parseIntegerOption(readOptionValue(argv, index, arg), arg);
+      timeoutSeconds = parseIntegerOption(requireOptionArgument(argv, index, arg), arg);
       index += 1;
       continue;
     }
     if (arg === "--thinking") {
       recordOnce(arg);
-      thinking = readOptionValue(argv, index, arg).trim();
+      thinking = requireOptionArgument(argv, index, arg).trim();
       index += 1;
       continue;
     }
     if (arg === "--output-dir") {
       recordOnce(arg);
-      outputDir = readOptionValue(argv, index, arg);
+      outputDir = requireOptionArgument(argv, index, arg);
       index += 1;
       continue;
     }

--- a/scripts/debug-claude-usage.ts
+++ b/scripts/debug-claude-usage.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
 import { normalizeOptionalString } from "../packages/normalization-core/src/string-coerce.js";
+import { requireOptionArgument } from "./lib/arg-utils.mts";
 import { readBoundedResponseText as readBoundedResponseTextWithLimit } from "./lib/bounded-response.mjs";
 import {
   maskIdentifier,
@@ -47,7 +48,7 @@ const parseArgs = (args = process.argv.slice(2)): Args => {
   for (let i = 0; i < args.length; i++) {
     const arg = expectDefined(args[i], `Claude usage argument at index ${i}`);
     if (arg === "--agent") {
-      agentId = parseNonBlankArgValue(parseRequiredArgValue(args, i, "--agent"), "--agent");
+      agentId = parseNonBlankArgValue(requireOptionArgument(args, i, "--agent"), "--agent");
       i += 1;
       continue;
     }
@@ -65,7 +66,7 @@ const parseArgs = (args = process.argv.slice(2)): Args => {
     }
     if (arg === "--session-key") {
       sessionKey = parseNonBlankArgValue(
-        parseRequiredArgValue(args, i, "--session-key"),
+        requireOptionArgument(args, i, "--session-key"),
         "--session-key",
       );
       i += 1;
@@ -83,14 +84,6 @@ const parseArgs = (args = process.argv.slice(2)): Args => {
 
   return { agentId, help, reveal, sessionKey };
 };
-
-function parseRequiredArgValue(args: string[], index: number, label: string): string {
-  const value = args[index + 1];
-  if (!value || value.startsWith("-")) {
-    throw new Error(`${label} requires a value`);
-  }
-  return value;
-}
 
 function parseInlineArgValue(arg: string, label: string): string {
   const value = arg.slice(`${label}=`.length);

--- a/scripts/dependency-ownership-surface-report.mts
+++ b/scripts/dependency-ownership-surface-report.mts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { parse as parseYaml } from "yaml";
+import { requireOptionArgument } from "./lib/arg-utils.mts";
 import { pnpmLockfileDocuments } from "./lib/pnpm-lockfile-documents.mjs";
 import { collectRootDependencyOwnershipAudit } from "./root-dependency-ownership-audit.mts";
 
@@ -475,14 +476,6 @@ function printTextReport(report: DependencyOwnershipReport) {
   process.stdout.write(renderDependencyOwnershipSurfaceMarkdownReport(report));
 }
 
-function readArtifactPath(argv: string[], index: number, optionName: string) {
-  const value = argv[index + 1];
-  if (value === undefined || value === "" || value.startsWith("-")) {
-    throw new Error(`${optionName} requires a value`);
-  }
-  return value;
-}
-
 export function parseArgs(argv: string[]): ParseOptions {
   const options: ParseOptions = {
     asJson: false,
@@ -521,7 +514,7 @@ export function parseArgs(argv: string[]): ParseOptions {
       continue;
     }
     if (arg === "--markdown") {
-      setOnce(arg, "markdownPath", readArtifactPath(argv, index, arg));
+      setOnce(arg, "markdownPath", requireOptionArgument(argv, index, arg));
       index += 1;
       continue;
     }

--- a/scripts/docs-sync-publish.mjs
+++ b/scripts/docs-sync-publish.mjs
@@ -6,6 +6,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { renderDocsHeadingMap } from "./docs-list.js";
+import { requireOptionArgument } from "./lib/arg-utils.runtime.mjs";
 import { repairMintlifyAccordionIndentation } from "./lib/mintlify-accordion.mjs";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 
@@ -28,6 +29,10 @@ const SYNC_SUPPORT_FILES = [
   {
     source: path.join(ROOT, "scripts", "check-docs-mdx.mts"),
     target: path.join(".openclaw-sync", "check-docs-mdx.mts"),
+  },
+  {
+    source: path.join(ROOT, "scripts", "lib", "arg-utils.runtime.mjs"),
+    target: path.join(".openclaw-sync", "lib", "arg-utils.runtime.mjs"),
   },
   {
     source: path.join(ROOT, "scripts", "lib", "tsx-cli-shim.mjs"),
@@ -201,14 +206,6 @@ const GENERATED_LOCALES = [
   },
 ];
 
-function readOptionValue(argv, index, optionName) {
-  const value = argv[index + 1];
-  if (value === undefined || value === "" || value.startsWith("-")) {
-    throw new Error(`${optionName} requires a value`);
-  }
-  return value;
-}
-
 export function parseArgs(argv) {
   const args = {
     target: "",
@@ -224,27 +221,27 @@ export function parseArgs(argv) {
     const part = argv[index];
     switch (part) {
       case "--target":
-        args.target = readOptionValue(argv, index, part);
+        args.target = requireOptionArgument(argv, index, part);
         index += 1;
         break;
       case "--source-repo":
-        args.sourceRepo = readOptionValue(argv, index, part);
+        args.sourceRepo = requireOptionArgument(argv, index, part);
         index += 1;
         break;
       case "--source-sha":
-        args.sourceSha = readOptionValue(argv, index, part);
+        args.sourceSha = requireOptionArgument(argv, index, part);
         index += 1;
         break;
       case "--clawhub-repo":
-        args.clawhubRepo = readOptionValue(argv, index, part);
+        args.clawhubRepo = requireOptionArgument(argv, index, part);
         index += 1;
         break;
       case "--clawhub-source-repo":
-        args.clawhubSourceRepo = readOptionValue(argv, index, part);
+        args.clawhubSourceRepo = requireOptionArgument(argv, index, part);
         index += 1;
         break;
       case "--clawhub-source-sha":
-        args.clawhubSourceSha = readOptionValue(argv, index, part);
+        args.clawhubSourceSha = requireOptionArgument(argv, index, part);
         index += 1;
         break;
       default:

--- a/scripts/full-release-validation-at-sha.mts
+++ b/scripts/full-release-validation-at-sha.mts
@@ -18,6 +18,7 @@ import {
   MAX_RELEASE_ARTIFACT_BYTES,
   validateReleaseStateArtifact,
 } from "./full-release-validation-policy.mjs";
+import { requireOptionArgument } from "./lib/arg-utils.mts";
 import { execGhRead } from "./lib/plain-gh.mjs";
 import { classifyReleaseTrain, parseReleaseVersion } from "./lib/release-version.mjs";
 
@@ -160,14 +161,6 @@ function runStatus(command: string, args: string[], options: CommandOptions = {}
   });
 }
 
-function readOptionValue(argv: string[], index: number, optionName: string): string {
-  const value = argv[index + 1];
-  if (value === undefined || value === "" || value.startsWith("-")) {
-    throw new Error(`${optionName} requires a value`);
-  }
-  return value;
-}
-
 export function parseArgs(argv: string[]) {
   const inputs: ReleaseInputs = { ...DEFAULT_INPUTS };
   const args = {
@@ -187,22 +180,22 @@ export function parseArgs(argv: string[]) {
       process.exit(0);
     }
     if (arg === "--sha") {
-      args.sha = readOptionValue(argv, i, arg);
+      args.sha = requireOptionArgument(argv, i, arg);
       i += 1;
       continue;
     }
     if (arg === "--workflow-sha") {
-      args.workflowSha = readOptionValue(argv, i, arg);
+      args.workflowSha = requireOptionArgument(argv, i, arg);
       i += 1;
       continue;
     }
     if (arg === "--trusted-workflow-ref") {
-      args.trustedWorkflowRef = readOptionValue(argv, i, arg);
+      args.trustedWorkflowRef = requireOptionArgument(argv, i, arg);
       i += 1;
       continue;
     }
     if (arg === "--target-ref") {
-      args.targetRef = readOptionValue(argv, i, arg);
+      args.targetRef = requireOptionArgument(argv, i, arg);
       i += 1;
       continue;
     }
@@ -220,7 +213,7 @@ export function parseArgs(argv: string[]) {
         const extra = extras[extraIndex]!;
         let assignment;
         if (extra === "-f") {
-          assignment = readOptionValue(extras, extraIndex, extra);
+          assignment = requireOptionArgument(extras, extraIndex, extra);
           extraIndex += 1;
         } else {
           assignment = extra.startsWith("-f") ? extra.slice(2).trim() : extra;
@@ -234,7 +227,7 @@ export function parseArgs(argv: string[]) {
       break;
     }
     if (arg === "-f") {
-      const assignment = readOptionValue(argv, i, arg);
+      const assignment = requireOptionArgument(argv, i, arg);
       i += 1;
       const [key, ...valueParts] = assignment.split("=");
       if (!key || valueParts.length === 0) {

--- a/scripts/lib/arg-utils.runtime.d.mts
+++ b/scripts/lib/arg-utils.runtime.d.mts
@@ -32,6 +32,11 @@ export type BoundedUnsignedDecimalResult =
   | { kind: "value"; value: number };
 
 export function readFlagValue(args: readonly string[], name: string): string | undefined;
+export function requireOptionArgument(
+  argv: readonly string[],
+  index: number,
+  optionName: string,
+): string;
 export function stripLeadingPackageManagerSeparator(argv: string[]): string[];
 export function parseStrictBooleanArg(value: unknown, label: string): boolean;
 export function classifyBoundedUnsignedDecimal(

--- a/scripts/lib/arg-utils.runtime.mjs
+++ b/scripts/lib/arg-utils.runtime.mjs
@@ -85,6 +85,20 @@ export function readFlagValue(args, name) {
   return undefined;
 }
 /**
+ * Read the required value following a split CLI option.
+ * @param {readonly string[]} argv
+ * @param {number} index
+ * @param {string} optionName
+ * @returns {string}
+ */
+export function requireOptionArgument(argv, index, optionName) {
+  const value = argv[index + 1];
+  if (value === undefined || value === "" || value.startsWith("-")) {
+    throw new Error(`${optionName} requires a value`);
+  }
+  return value;
+}
+/**
  * Remove the leading `--` separator inserted by package-manager script invocations.
  * @internal Shared repository-script contract.
  * @param {string[]} argv

--- a/scripts/lib/merge-head-diff-base.mjs
+++ b/scripts/lib/merge-head-diff-base.mjs
@@ -1,6 +1,7 @@
 // Resolves the diff base for merge commits when first-parent comparison is requested.
 import { execFileSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
+import { requireOptionArgument } from "./arg-utils.runtime.mjs";
 
 const DEFAULT_GIT_OUTPUT_MAX_BUFFER = 16 * 1024 * 1024;
 
@@ -73,20 +74,6 @@ function resolveCommit({ ref, cwd, maxBuffer }) {
 }
 
 /**
- * @param {readonly string[]} argv
- * @param {number} index
- * @param {string} optionName
- * @returns {string}
- */
-function readRefValue(argv, index, optionName) {
-  const value = argv[index + 1];
-  if (value === undefined || value === "" || value.startsWith("-")) {
-    throw new Error(`${optionName} requires a value`);
-  }
-  return value;
-}
-
-/**
  * @internal Directly tested script implementation detail.
  * @param {readonly string[]} argv
  * @returns {{base: string, head: string, preferFirstParent: boolean}}
@@ -100,12 +87,12 @@ export function parseArgs(argv) {
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === "--base") {
-      args.base = readRefValue(argv, index, "--base");
+      args.base = requireOptionArgument(argv, index, "--base");
       index += 1;
       continue;
     }
     if (arg === "--head") {
-      args.head = readRefValue(argv, index, "--head");
+      args.head = requireOptionArgument(argv, index, "--head");
       index += 1;
       continue;
     }

--- a/scripts/openclaw-performance-source-summary.mts
+++ b/scripts/openclaw-performance-source-summary.mts
@@ -6,6 +6,7 @@ import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { requireOptionArgument } from "./lib/arg-utils.mts";
 import { collectSqliteQueryPlanEvidence } from "./lib/sqlite-query-plan-evidence.js";
 
 type JsonObject = { [key: string]: JsonValue };
@@ -62,14 +63,6 @@ function hasControlCharacters(value: string): boolean {
   return false;
 }
 
-function readOptionValue(argv: string[], index: number, optionName: string): string {
-  const value = argv[index + 1];
-  if (!value || value.startsWith("-")) {
-    throw new Error(`${optionName} requires a value`);
-  }
-  return value;
-}
-
 export function parseArgs(argv: string[]) {
   const options: Record<"baselineSourceDir" | "sourceDir" | "output", string | null> = {
     baselineSourceDir: null,
@@ -79,7 +72,7 @@ export function parseArgs(argv: string[]) {
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index] ?? "";
     const readValue = () => {
-      const value = readOptionValue(argv, index, arg);
+      const value = requireOptionArgument(argv, index, arg);
       index += 1;
       return value;
     };

--- a/scripts/package-openclaw-for-docker.mts
+++ b/scripts/package-openclaw-for-docker.mts
@@ -7,6 +7,7 @@ import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { requireOptionArgument } from "./lib/arg-utils.runtime.mjs";
 import { DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV } from "./lib/bundled-plugin-build-entries.mjs";
 import { toErrorObject } from "./lib/error-format.mts";
 import { terminateManagedChild } from "./lib/managed-child-process.mts";
@@ -181,14 +182,6 @@ function resolveOptionalTimerTimeoutMs(valueMs: unknown) {
   return resolvePackageBuildTimeoutMs(valueMs, 1);
 }
 
-function readOptionValue(argv: string[], index: number, optionName: string) {
-  const value = argv[index + 1];
-  if (value === undefined || value === "" || value.startsWith("-")) {
-    throw new Error(`${optionName} requires a value`);
-  }
-  return value;
-}
-
 function readEqualsOptionValue(value: string, optionName: string) {
   if (value === "" || value.startsWith("-")) {
     throw new Error(`${optionName} requires a value`);
@@ -253,14 +246,14 @@ export function parseArgs(argv: string[]) {
     if (arg === "--allow-unreleased-changelog") {
       setOnce(arg, "allowUnreleasedChangelog", true);
     } else if (arg === "--bundle-plugin") {
-      options.bundlePlugins.push(readOptionValue(args, index, arg));
+      options.bundlePlugins.push(requireOptionArgument(args, index, arg));
       index += 1;
     } else if (arg?.startsWith("--bundle-plugin=")) {
       options.bundlePlugins.push(
         readEqualsOptionValue(arg.slice("--bundle-plugin=".length), "--bundle-plugin"),
       );
     } else if (arg === "--output-dir") {
-      setOnce("--output-dir", "outputDir", readOptionValue(args, index, arg));
+      setOnce("--output-dir", "outputDir", requireOptionArgument(args, index, arg));
       index += 1;
     } else if (arg?.startsWith("--output-dir=")) {
       setOnce(
@@ -269,7 +262,7 @@ export function parseArgs(argv: string[]) {
         readEqualsOptionValue(arg.slice("--output-dir=".length), "--output-dir"),
       );
     } else if (arg === "--output-name") {
-      setOnce("--output-name", "outputName", readOptionValue(args, index, arg));
+      setOnce("--output-name", "outputName", requireOptionArgument(args, index, arg));
       index += 1;
     } else if (arg?.startsWith("--output-name=")) {
       setOnce(
@@ -278,7 +271,7 @@ export function parseArgs(argv: string[]) {
         readEqualsOptionValue(arg.slice("--output-name=".length), "--output-name"),
       );
     } else if (arg === "--pack-json") {
-      setOnce("--pack-json", "packJson", readOptionValue(args, index, arg));
+      setOnce("--pack-json", "packJson", requireOptionArgument(args, index, arg));
       index += 1;
     } else if (arg?.startsWith("--pack-json=")) {
       setOnce(
@@ -291,7 +284,7 @@ export function parseArgs(argv: string[]) {
     } else if (arg === "--skip-build") {
       setOnce(arg, "skipBuild", true);
     } else if (arg === "--source-dir") {
-      setOnce("--source-dir", "sourceDir", readOptionValue(args, index, arg));
+      setOnce("--source-dir", "sourceDir", requireOptionArgument(args, index, arg));
       index += 1;
     } else if (arg?.startsWith("--source-dir=")) {
       setOnce(

--- a/scripts/test-group-report.mts
+++ b/scripts/test-group-report.mts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import pMap from "p-map";
+import { requireOptionArgument } from "./lib/arg-utils.mts";
 import { coerceErrorMessage } from "./lib/error-format.mts";
 import {
   inspectManagedProcessGroup,
@@ -132,16 +133,8 @@ function usage() {
   ].join("\n");
 }
 
-function readRequiredValue(argv: string[], index: number, flag: string) {
-  const value = argv[index + 1];
-  if (!value || value.startsWith("-")) {
-    throw new Error(`${flag} requires a value`);
-  }
-  return value;
-}
-
 function readPositiveIntValue(argv: string[], index: number, flag: string) {
-  return parsePositiveInt(readRequiredValue(argv, index, flag), flag);
+  return parsePositiveInt(requireOptionArgument(argv, index, flag), flag);
 }
 
 /**
@@ -197,13 +190,13 @@ export function parseTestGroupReportArgs(argv: string[]) {
       continue;
     }
     if (arg === "--config") {
-      args.configs.push(readRequiredValue(argv, index, "--config"));
+      args.configs.push(requireOptionArgument(argv, index, "--config"));
       index += 1;
       continue;
     }
     if (arg === "--compare") {
-      const before = readRequiredValue(argv, index, "--compare");
-      const after = readRequiredValue(argv, index + 1, "--compare");
+      const before = requireOptionArgument(argv, index, "--compare");
+      const after = requireOptionArgument(argv, index + 1, "--compare");
       setSingleValueFlag(arg, () => {
         args.compare = { before, after };
       });
@@ -211,12 +204,12 @@ export function parseTestGroupReportArgs(argv: string[]) {
       continue;
     }
     if (arg === "--report") {
-      args.reports.push(readRequiredValue(argv, index, "--report"));
+      args.reports.push(requireOptionArgument(argv, index, "--report"));
       index += 1;
       continue;
     }
     if (arg === "--group-by") {
-      const value = readRequiredValue(argv, index, "--group-by");
+      const value = requireOptionArgument(argv, index, "--group-by");
       setSingleValueFlag(arg, () => {
         args.groupBy = value;
       });
@@ -224,7 +217,7 @@ export function parseTestGroupReportArgs(argv: string[]) {
       continue;
     }
     if (arg === "--output") {
-      const value = readRequiredValue(argv, index, "--output");
+      const value = requireOptionArgument(argv, index, "--output");
       setSingleValueFlag(arg, () => {
         args.output = value;
       });

--- a/scripts/verify-docker-attestations.mjs
+++ b/scripts/verify-docker-attestations.mjs
@@ -3,6 +3,7 @@
 // Verifies Docker image attestations cover required platforms and predicates.
 import { execFileSync } from "node:child_process";
 import process from "node:process";
+import { requireOptionArgument } from "./lib/arg-utils.runtime.mjs";
 import { isDirectRunUrl } from "./lib/direct-run.mjs";
 
 const ATTESTATION_REFERENCE_TYPE = "attestation-manifest";
@@ -174,21 +175,13 @@ export function inspectRaw(imageRef, params = {}) {
   });
 }
 
-function readOptionValue(argv, index, optionName) {
-  const value = argv[index + 1];
-  if (value === undefined || value === "" || value.startsWith("-")) {
-    throw new Error(`${optionName} requires a value`);
-  }
-  return value;
-}
-
 export function parseArgs(argv) {
   const imageRefs = [];
   const requiredPlatforms = [];
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--platform") {
-      requiredPlatforms.push(parsePlatform(readOptionValue(argv, i, arg)));
+      requiredPlatforms.push(parsePlatform(requireOptionArgument(argv, i, arg)));
       i += 1;
       continue;
     }

--- a/src/scripts/ci-changed-scope.test.ts
+++ b/src/scripts/ci-changed-scope.test.ts
@@ -982,6 +982,7 @@ describe("detectChangedScope", () => {
     execFileSync("git", ["config", "user.name", "CI"], { cwd: repoDir });
     for (const sourcePath of [
       "scripts/ci-changed-scope.mjs",
+      "scripts/lib/arg-utils.runtime.mjs",
       "scripts/lib/changed-path-facts.mjs",
       "scripts/lib/direct-run.mjs",
       "scripts/lib/merge-head-diff-base.mjs",

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -504,6 +504,7 @@ describe("package-openclaw-for-docker", () => {
       "scripts/npm-runner.mts",
       "scripts/pnpm-runner.mts",
       "scripts/windows-cmd-helpers.mjs",
+      "scripts/lib/arg-utils.runtime.mjs",
       "scripts/lib/bundled-plugin-build-entries.mjs",
       "scripts/lib/bundled-plugin-paths.mjs",
       "scripts/lib/error-format.mts",

--- a/test/scripts/arg-utils.test.ts
+++ b/test/scripts/arg-utils.test.ts
@@ -10,6 +10,7 @@ import {
   parsePermissiveBooleanToken,
   parseStrictBooleanArg,
   readFlagValue,
+  requireOptionArgument,
   stringFlag,
   stringListFlag,
 } from "../../scripts/lib/arg-utils.runtime.mjs";
@@ -57,6 +58,21 @@ describe("scripts/lib/arg-utils strict scalar grammars", () => {
     { input: "1ms", min: 0, max: 10, expected: { kind: "syntax" } },
   ])("classifies bounded unsigned decimal %#", ({ input, min, max, expected }) => {
     expect(classifyBoundedUnsignedDecimal(input, min, max)).toEqual(expected);
+  });
+});
+
+describe("scripts/lib/arg-utils required option arguments", () => {
+  it("returns the original split option value", () => {
+    expect(requireOptionArgument(["--output", "  report.json  "], 0, "--output")).toBe(
+      "  report.json  ",
+    );
+  });
+
+  it.each([undefined, "", "-", "-h", "--next"])("rejects missing value %#", (value) => {
+    const argv = value === undefined ? ["--output"] : ["--output", value];
+    expect(() => requireOptionArgument(argv, 0, "--output")).toThrow(
+      new Error("--output requires a value"),
+    );
   });
 });
 

--- a/test/scripts/docs-sync-publish.test.ts
+++ b/test/scripts/docs-sync-publish.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -35,6 +36,39 @@ function collectPages(entry: unknown, pages: string[] = []): string[] {
 }
 
 describe("docs-sync-publish", () => {
+  it("executes the copied MDX checker runtime closure", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-docs-sync-runtime-"));
+    const publishRoot = path.join(tempRoot, "publish");
+    const clawhubRoot = path.join(tempRoot, "clawhub");
+    const minimalMdx = path.join(tempRoot, "valid.mdx");
+
+    fs.mkdirSync(publishRoot, { recursive: true });
+    fs.mkdirSync(path.join(clawhubRoot, "docs"), { recursive: true });
+    fs.writeFileSync(path.join(publishRoot, "package.json"), "{}\n");
+    fs.writeFileSync(path.join(clawhubRoot, "docs", "index.md"), "# ClawHub\n");
+    fs.writeFileSync(minimalMdx, "# Valid MDX\n\nThis file is valid.\n");
+    fs.symlinkSync(
+      path.resolve("node_modules"),
+      path.join(publishRoot, "node_modules"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+
+    try {
+      execFileSync(
+        process.execPath,
+        ["scripts/docs-sync-publish.mjs", "--target", publishRoot, "--clawhub-repo", clawhubRoot],
+        { stdio: "pipe" },
+      );
+      execFileSync(
+        process.execPath,
+        [path.join(publishRoot, ".openclaw-sync", "check-docs-mdx.mjs"), minimalMdx],
+        { cwd: publishRoot, stdio: "pipe" },
+      );
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("materializes the public docs map only in the publish tree", () => {
     const targetDocsDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-docs-map-publish-"));
     try {

--- a/test/scripts/run-opengrep.test.ts
+++ b/test/scripts/run-opengrep.test.ts
@@ -19,10 +19,15 @@ function writeFile(filePath: string, content: string): void {
 function copyRunOpengrepFiles(repo: string): void {
   const scriptSource = path.resolve("scripts/run-opengrep.sh");
   const helperSource = path.resolve("scripts/lib/merge-head-diff-base.mjs");
+  const argUtilsSource = path.resolve("scripts/lib/arg-utils.runtime.mjs");
   writeFile(path.join(repo, "scripts/run-opengrep.sh"), fs.readFileSync(scriptSource, "utf8"));
   writeFile(
     path.join(repo, "scripts/lib/merge-head-diff-base.mjs"),
     fs.readFileSync(helperSource, "utf8"),
+  );
+  writeFile(
+    path.join(repo, "scripts/lib/arg-utils.runtime.mjs"),
+    fs.readFileSync(argUtilsSource, "utf8"),
   );
   fs.chmodSync(path.join(repo, "scripts/run-opengrep.sh"), 0o755);
 }


### PR DESCRIPTION
## What Problem This Solves

Thirteen scripts duplicated the same strict split-option invariant: read exactly the next argument and reject missing, empty, or dash-prefixed values. The local wrappers could drift independently, including inside copied runtime closures.

## Why This Change Was Made

The architectural owner is now `scripts/lib/arg-utils.runtime.mjs`, which exports `requireOptionArgument`; its declaration lives beside it. The thirteen exact local wrappers were removed and their callers now use the shared helper without migrating different-contract siblings.

All copied-runtime closures are complete:

- docs sync copies the argument runtime into `.openclaw-sync/lib/`, and its workflow path trigger includes the runtime source.
- Docker packaging's runtime fixture copies the argument runtime required by the packaged script.
- OpenGrep's isolated merge-base fixture copies the argument runtime required by the imported helper.

Existing caller behavior is preserved, including equals-form parsing in Docker packaging, downstream normalization in the Claude usage debugger, and downstream trimming and validation in the code-mode matrix. This is an internal behavior-preserving refactor with no Codex protocol or runtime involvement.

## User Impact

No user-visible behavior changes. Script option handling now has one owner, while existing diagnostics and caller-specific normalization remain unchanged.

Production/tooling: `+85/-160` (net `-75`). Tests/test support: `+57/-0`.

No changelog entry: this is an internal behavior-preserving refactor.

## Evidence

The two new tests meet the test-audit value bar:

- owner-boundary coverage proves the helper preserves whitespace and rejects undefined, empty, `-`, `-h`, and `--next` with the exact diagnostic.
- a real docs-sync boundary smoke runs the actual CLI into a temporary publish tree, then executes the copied MDX checker against valid minimal MDX. It uses no source-string assertions or test-only production export.

Validation:

```text
node scripts/run-vitest.mjs test/scripts/arg-utils.test.ts test/scripts/docs-sync-publish.test.ts
# post-rebase: 2 files passed; 85 tests passed

node scripts/run-vitest.mjs test/scripts/run-opengrep.test.ts
# 1 file passed; 6 tests passed; stale-base scan includes src/pr.ts and excludes src/main-only.ts

node scripts/run-vitest.mjs test/scripts/full-release-validation-at-sha.test.ts src/scripts/ci-changed-scope.test.ts
# 2 files passed; 139 tests passed

node scripts/run-vitest.mjs extensions/qa-lab/src/code-mode-model-matrix.test.ts test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
# 2 files passed; 75 tests passed; 3 platform tests skipped

node scripts/run-tsgo.mjs -p tsconfig.scripts.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/scripts.tsbuildinfo
# passed

node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.root.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-root.tsbuildinfo
# passed

node --import ./scripts/tsx.mjs scripts/run-oxlint-shards.mts --only=core
# passed

pnpm lint:scripts
# passed

git diff --check origin/main..HEAD
# passed
```

`node scripts/check-changed.mjs --dry-run -- <all 21 changed paths>` selected `coreTests`, `scripts`, `testRoot`, and `tooling`. The bounded changed gate passed after running its remaining checks directly in the sparse worktree.

The aggregate `node --import ./scripts/tsx.mjs scripts/check-workflows.mts` could not finish because its pinned `pre-commit==4.6.2` was unavailable from the configured package index. Its actionlint stage passed, and the equivalent remaining checks passed:

```text
uvx --from 'zizmor==1.29.0' zizmor --config .github/zizmor.yml --persona=regular --min-severity=medium --min-confidence=medium .github/workflows/docs-sync-publish.yml
# no findings

node scripts/generate-ci-git-owner.mts --check
# passed

python3 scripts/check-composite-action-input-interpolation.py
# passed
```

After rebasing onto `cfddfc2f700ea456c66b887d70716b83d3ac0ea2`, stable patch ID, changed-path hash, numstat hash, and `git range-diff` all confirmed the reviewed patch was unchanged.


