### PR TITLE
perf(plugins): consolidate provider discovery planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Provider discovery:** prepare manifest catalogs once and recover discarded discovery entries through the existing scoped loader, so a static catalog cannot hide another selected or credentialed provider after an entry fails.
 - **Image analysis startup:** prepare selected model providers and keep configuration reads independent of full runtime loading, avoiding unrelated discovery and redundant model resolution while preserving credentials and runtime cleanup.
 - **Browser extension relay:** route Runtime binding callbacks only to registered clients and preserve shared bindings during client cleanup, preventing raw callback payloads from reaching unrelated Playwright sessions.
 - **Control UI media playback:** restore inline audio and video rendition loading so readiness checks reach the Gateway instead of silently falling back to download cards. (#132832)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Provider discovery:** prepare manifest catalogs once and recover discarded discovery entries through the existing scoped loader, so a static catalog cannot hide another selected or credentialed provider after an entry fails.
 - **Image analysis startup:** prepare selected model providers and keep configuration reads independent of full runtime loading, avoiding unrelated discovery and redundant model resolution while preserving credentials and runtime cleanup.
 - **Browser extension relay:** route Runtime binding callbacks only to registered clients and preserve shared bindings during client cleanup, preventing raw callback payloads from reaching unrelated Playwright sessions.
 - **Control UI media playback:** restore inline audio and video rendition loading so readiness checks reach the Gateway instead of silently falling back to download cards. (#132832)

--- a/extensions/memory-core/src/memory/manager-index-generation-lease.test.ts
+++ b/extensions/memory-core/src/memory/manager-index-generation-lease.test.ts
@@ -266,8 +266,8 @@ describe("memory index generation lease", () => {
       expect(events).toEqual([]);
 
       await stopChild(firstReader);
+      // Publication releases its lease before resolving, so the reader may already be done.
       await publication;
-      expect(events).toEqual(["published"]);
       await nextReaderAcquired;
       expect(events).toEqual(["published", "next-reader"]);
     } finally {

--- a/src/plugins/provider-discovery.runtime.test.ts
+++ b/src/plugins/provider-discovery.runtime.test.ts
@@ -885,6 +885,64 @@ describe("resolvePluginDiscoveryProvidersRuntime", () => {
     },
   );
 
+  it.each(
+    [
+      { scope: "selected", expectedFullIds: ["broken", "healthy"] },
+      { scope: "unscoped", expectedFullIds: ["healthy"] },
+      { scope: "entries-only", expectedFullIds: [] },
+    ].flatMap((scenario) =>
+      ["first", "last"].map((failurePosition) => ({ ...scenario, failurePosition })),
+    ),
+  )(
+    "recovers discarded discovery entries with $scope scope when failure is $failurePosition",
+    ({ scope, expectedFullIds, failurePosition }) => {
+      const healthy = {
+        ...createManifestPlugin("healthy"),
+        setup: { providers: [{ id: "healthy", envVars: ["HEALTHY_API_KEY"] }] },
+      };
+      const broken = createManifestPlugin("broken");
+      mocks.resolveDiscoveredProviderPluginIds.mockReturnValue(["static", "healthy", "broken"]);
+      mocks.loadPluginMetadataSnapshot.mockReturnValue({
+        index: { plugins: [] },
+        manifestRegistry: {
+          plugins: [
+            createManifestPluginWithModelCatalog("static"),
+            ...(failurePosition === "first" ? [broken, healthy] : [healthy, broken]),
+          ],
+          diagnostics: [],
+        },
+      });
+      mocks.loadSource.mockImplementation((modulePath: string) => {
+        if (modulePath === broken.providerDiscoverySource) {
+          throw new Error("discovery entry unavailable");
+        }
+        return { ...createProvider({ id: "healthy", mode: "catalog" }), label: "entry" };
+      });
+      const fullProviders = expectedFullIds.map((id) => ({
+        ...createProvider({ id, mode: "catalog" }),
+        label: `full:${id}`,
+      }));
+      mocks.resolvePluginProvidersCore.mockReturnValue(fullProviders);
+
+      const providers = resolvePluginDiscoveryProvidersRuntime({
+        env: { HEALTHY_API_KEY: "catalog-test-key" },
+        ...(scope === "unscoped" ? {} : { onlyPluginIds: ["static", "healthy", "broken"] }),
+        discoveryEntriesOnly: scope === "entries-only",
+      });
+
+      expect(providers.map(({ id, label }) => [id, label])).toEqual([
+        ["static", "static"],
+        ...fullProviders.map(({ id, label }) => [id, label]),
+      ]);
+      if (expectedFullIds.length === 0) {
+        expect(mocks.resolvePluginProvidersCore).not.toHaveBeenCalled();
+      } else {
+        expect(mocks.resolvePluginProvidersCore).toHaveBeenCalledOnce();
+        expect(requireResolvePluginProvidersParams().onlyPluginIds).toEqual(expectedFullIds);
+      }
+    },
+  );
+
   it("does not fall back to full plugin loading when discovery entries are requested only", () => {
     mocks.loadPluginMetadataSnapshot.mockReturnValue({
       index: { plugins: [] },

--- a/src/plugins/provider-discovery.runtime.test.ts
+++ b/src/plugins/provider-discovery.runtime.test.ts
@@ -890,8 +890,8 @@ describe("resolvePluginDiscoveryProvidersRuntime", () => {
       { scope: "selected", expectedFullIds: ["broken", "healthy"] },
       { scope: "unscoped", expectedFullIds: ["healthy"] },
       { scope: "entries-only", expectedFullIds: [] },
-    ].flatMap((scenario) =>
-      ["first", "last"].map((failurePosition) => ({ ...scenario, failurePosition })),
+    ].flatMap(({ scope, expectedFullIds }) =>
+      ["first", "last"].map((failurePosition) => ({ scope, expectedFullIds, failurePosition })),
     ),
   )(
     "recovers discarded discovery entries with $scope scope when failure is $failurePosition",

--- a/src/plugins/provider-discovery.runtime.ts
+++ b/src/plugins/provider-discovery.runtime.ts
@@ -28,7 +28,6 @@ type ProviderDiscoveryEntryResult = {
   complete: boolean;
   pluginRecords: PluginManifestRecord[];
   entryPluginIds: Set<string>;
-  manifestEntryPluginIds: Set<string>;
   runtimeManifestCatalogPluginIds: Set<string>;
 };
 
@@ -156,22 +155,40 @@ function providerConfigFromManifestRows(
   };
 }
 
-function resolveManifestModelCatalogProviders(
+function prepareManifestCatalogDiscovery(
   pluginRecords: readonly PluginManifestRecord[],
   config: OpenClawConfig,
-): ProviderPlugin[] {
+  includeProviders: boolean,
+): Pick<ProviderDiscoveryEntryResult, "providers" | "runtimeManifestCatalogPluginIds"> {
   const providers: ProviderPlugin[] = [];
+  const runtimeManifestCatalogPluginIds = new Set<string>();
   for (const plugin of pluginRecords) {
-    if (!plugin.modelCatalog?.providers) {
+    if (!plugin.modelCatalog) {
       continue;
     }
+    const ownedProviders = new Set(
+      plugin.providers.map((provider) => normalizeProviderId(provider)),
+    );
+    if (
+      Object.entries(plugin.modelCatalog.discovery ?? {}).some(
+        ([provider, discovery]) =>
+          (discovery === "runtime" || discovery === "refreshable") &&
+          ownedProviders.has(normalizeProviderId(provider)),
+      )
+    ) {
+      runtimeManifestCatalogPluginIds.add(plugin.id);
+    }
+    if (!plugin.modelCatalog.providers) {
+      continue;
+    }
+    // Static rows and runtime coverage must come from the same effective catalog.
     const plan = planEffectiveModelCatalogRows({ registry: { plugins: [plugin] }, config });
     for (const entry of plan.entries) {
-      if (
-        entry.rows.length === 0 ||
-        entry.discovery === "runtime" ||
-        entry.discovery === "refreshable"
-      ) {
+      if (entry.discovery === "runtime" || entry.discovery === "refreshable") {
+        runtimeManifestCatalogPluginIds.add(plugin.id);
+        continue;
+      }
+      if (!includeProviders || entry.rows.length === 0) {
         continue;
       }
       const providerConfig = providerConfigFromManifestRows(entry.rows);
@@ -190,40 +207,7 @@ function resolveManifestModelCatalogProviders(
       });
     }
   }
-  return providers;
-}
-
-function resolveRuntimeManifestCatalogPluginIds(
-  pluginRecords: readonly PluginManifestRecord[],
-  config: OpenClawConfig,
-): Set<string> {
-  const pluginIds = new Set<string>();
-  for (const plugin of pluginRecords) {
-    const ownedProviders = new Set(
-      plugin.providers.map((provider) => normalizeProviderId(provider)),
-    );
-    const ownsRuntimeDiscovery = Object.entries(plugin.modelCatalog?.discovery ?? {}).some(
-      ([provider, discovery]) =>
-        (discovery === "runtime" || discovery === "refreshable") &&
-        ownedProviders.has(normalizeProviderId(provider)),
-    );
-    if (ownsRuntimeDiscovery) {
-      pluginIds.add(plugin.id);
-    }
-
-    if (!plugin.modelCatalog?.providers) {
-      continue;
-    }
-    const plan = planEffectiveModelCatalogRows({ registry: { plugins: [plugin] }, config });
-    if (
-      plan.entries.some(
-        (entry) => entry.discovery === "runtime" || entry.discovery === "refreshable",
-      )
-    ) {
-      pluginIds.add(plugin.id);
-    }
-  }
-  return pluginIds;
+  return { providers, runtimeManifestCatalogPluginIds };
 }
 
 function resolveProviderDiscoveryEntryPlugins(params: {
@@ -253,17 +237,14 @@ function resolveProviderDiscoveryEntryPlugins(params: {
   });
   const pluginIdSet = new Set(pluginIds);
   const pluginRecords = manifestRegistry.plugins.filter((plugin) => pluginIdSet.has(plugin.id));
-  const config = params.config ?? {};
-  const runtimeManifestCatalogPluginIds = resolveRuntimeManifestCatalogPluginIds(
-    pluginRecords,
-    config,
-  );
+  const { providers: manifestProviders, runtimeManifestCatalogPluginIds } =
+    prepareManifestCatalogDiscovery(
+      pluginRecords,
+      params.config ?? {},
+      params.includeManifestModelCatalogProviders !== false,
+    );
   const entryRecords = pluginRecords.filter((plugin) => plugin.providerDiscoverySource);
   const entryPluginIds = new Set(entryRecords.map((plugin) => plugin.id));
-  const manifestProviders =
-    params.includeManifestModelCatalogProviders === false
-      ? []
-      : resolveManifestModelCatalogProviders(pluginRecords, config);
   const manifestEntryPluginIds = new Set<string>();
   for (const pluginId of manifestProviders.map((provider) => provider.pluginId)) {
     if (pluginId) {
@@ -276,30 +257,23 @@ function resolveProviderDiscoveryEntryPlugins(params: {
     }
   }
   const complete = entryPluginIds.size === pluginIdSet.size;
+  const result = {
+    providers: manifestProviders,
+    complete,
+    pluginRecords,
+    entryPluginIds,
+    runtimeManifestCatalogPluginIds,
+  };
   const entriesOnlyComplete =
     new Set([...entryPluginIds, ...manifestEntryPluginIds]).size === pluginIdSet.size;
   if (entryRecords.length === 0) {
-    return {
-      providers: manifestProviders,
-      complete,
-      pluginRecords,
-      entryPluginIds,
-      manifestEntryPluginIds,
-      runtimeManifestCatalogPluginIds,
-    };
+    return result;
   }
   if (
     params.requireCompleteDiscoveryEntryCoverage &&
     !(params.discoveryEntriesOnly === true ? entriesOnlyComplete : complete)
   ) {
-    return {
-      providers: [],
-      complete: false,
-      pluginRecords,
-      entryPluginIds,
-      manifestEntryPluginIds,
-      runtimeManifestCatalogPluginIds,
-    };
+    return { ...result, providers: [], complete: false };
   }
   const providers: ProviderPlugin[] = [];
   for (const manifest of entryRecords) {
@@ -315,51 +289,12 @@ function resolveProviderDiscoveryEntryPlugins(params: {
         ),
       );
     } catch {
-      // Discovery fast path is optional. Fall back to the full plugin loader
-      // below so existing plugin diagnostics/load behavior remains canonical.
-      return {
-        providers: manifestProviders,
-        complete: false,
-        pluginRecords,
-        entryPluginIds,
-        manifestEntryPluginIds,
-        runtimeManifestCatalogPluginIds,
-      };
+      // Entry loading is all-or-nothing: discarded results no longer cover their owners.
+      // Keep static manifest coverage for the scope-aware full-loader fallback.
+      return { ...result, complete: false, entryPluginIds: manifestEntryPluginIds };
     }
   }
-  return {
-    providers: [...manifestProviders, ...providers],
-    complete,
-    pluginRecords,
-    entryPluginIds,
-    manifestEntryPluginIds,
-    runtimeManifestCatalogPluginIds,
-  };
-}
-
-function resolveSelectiveFullPluginIds(params: {
-  entryResult: ProviderDiscoveryEntryResult;
-  env: NodeJS.ProcessEnv;
-}): string[] {
-  const missingEntryCredentialPluginIds = params.entryResult.pluginRecords
-    .filter((plugin) => !params.entryResult.entryPluginIds.has(plugin.id))
-    .filter((plugin) => hasProviderAuthEnvCredential(plugin, params.env))
-    .map((plugin) => plugin.id);
-  const runtimeManifestCatalogPluginIds = listRuntimeManifestCatalogPluginIds(params.entryResult);
-  return sortUniqueStrings([
-    ...missingEntryCredentialPluginIds,
-    ...runtimeManifestCatalogPluginIds,
-  ]);
-}
-
-function listRuntimeManifestCatalogPluginIds(entryResult: ProviderDiscoveryEntryResult): string[] {
-  return [...entryResult.runtimeManifestCatalogPluginIds];
-}
-
-function resolveMissingEntryPluginIds(entryResult: ProviderDiscoveryEntryResult): string[] {
-  return entryResult.pluginRecords
-    .filter((plugin) => !entryResult.entryPluginIds.has(plugin.id))
-    .map((plugin) => plugin.id);
+  return { ...result, providers: [...manifestProviders, ...providers] };
 }
 
 function resolveRuntimeEntryProviders(entryResult: ProviderDiscoveryEntryResult): ProviderPlugin[] {
@@ -373,17 +308,6 @@ function resolveRuntimeEntryProviders(entryResult: ProviderDiscoveryEntryResult)
       typeof provider.staticCatalog?.run === "function",
     );
   });
-}
-
-function withoutFullLoadedPluginEntries(
-  providers: ProviderPlugin[],
-  pluginIds: readonly string[],
-): ProviderPlugin[] {
-  if (pluginIds.length === 0) {
-    return providers;
-  }
-  const pluginIdSet = new Set(pluginIds);
-  return providers.filter((provider) => !provider.pluginId || !pluginIdSet.has(provider.pluginId));
 }
 
 export function resolvePluginDiscoveryProvidersRuntime(params: {
@@ -418,45 +342,42 @@ export function resolvePluginDiscoveryProvidersRuntime(params: {
   ) {
     return runtimeEntryProviders;
   }
+  let fullPluginIds = params.onlyPluginIds;
+  let retainedProviders: ProviderPlugin[] | undefined;
   if (runtimeEntryProviders.length > 0 || entryResult.runtimeManifestCatalogPluginIds.size > 0) {
     // Runtime manifest owners do not cover siblings without discovery entries.
     // Preserve the selected scope; unscoped discovery stays credential-bounded.
-    const fullPluginIds =
-      params.onlyPluginIds === undefined
-        ? resolveSelectiveFullPluginIds({ entryResult, env })
-        : sortUniqueStrings([
-            ...resolveMissingEntryPluginIds(entryResult),
-            ...listRuntimeManifestCatalogPluginIds(entryResult),
-          ]);
-    const fullProviders =
-      fullPluginIds.length > 0
-        ? resolvePluginProvidersCore({
-            ...params,
-            env,
-            onlyPluginIds: fullPluginIds,
-          })
-        : [];
-    return [
-      ...withoutFullLoadedPluginEntries(runtimeEntryProviders, fullPluginIds),
-      ...fullProviders,
-    ];
-  }
-  if (entryProviders.length > 0) {
-    const fullPluginIds = sortUniqueStrings(
+    fullPluginIds = sortUniqueStrings([
+      ...entryResult.pluginRecords
+        .filter(
+          (plugin) =>
+            !entryResult.entryPluginIds.has(plugin.id) &&
+            (params.onlyPluginIds !== undefined || hasProviderAuthEnvCredential(plugin, env)),
+        )
+        .map((plugin) => plugin.id),
+      ...entryResult.runtimeManifestCatalogPluginIds,
+    ]);
+    if (fullPluginIds.length === 0) {
+      return [...runtimeEntryProviders];
+    }
+    const fullPluginIdSet = new Set(fullPluginIds);
+    retainedProviders = runtimeEntryProviders.filter(
+      (provider) => !provider.pluginId || !fullPluginIdSet.has(provider.pluginId),
+    );
+  } else if (entryProviders.length > 0) {
+    const entryPluginIds = sortUniqueStrings(
       entryProviders
         .map((provider) => provider.pluginId)
         .filter((pluginId): pluginId is string => typeof pluginId === "string" && pluginId !== ""),
     );
-    if (fullPluginIds.length > 0) {
-      return resolvePluginProvidersCore({
-        ...params,
-        env,
-        onlyPluginIds: fullPluginIds,
-      });
+    if (entryPluginIds.length > 0) {
+      fullPluginIds = entryPluginIds;
     }
   }
-  return resolvePluginProvidersCore({
+  const fullProviders = resolvePluginProvidersCore({
     ...params,
     env,
+    ...(fullPluginIds ? { onlyPluginIds: fullPluginIds } : {}),
   });
+  return retainedProviders ? [...retainedProviders, ...fullProviders] : fullProviders;
 }


### PR DESCRIPTION
## What Problem This Solves

Provider discovery planned each effective manifest catalog twice, repeating overlay lookup, normalization, sorting and provider construction. Its outer resolver also repeated full-loader scope selection and dispatch.

The same owner could silently omit providers after a discovery entry failed: it discarded all executable entry results but still marked their owners covered. A retained static catalog then prevented the selected or credentialed discarded owners from reaching canonical registration. A direct full-registration control proves their full modules can recover.

## Why This Change Was Made

Prepare static providers and runtime-owner IDs together from one effective catalog plan per selected plugin. Carry those facts into one full-loader decision. Delete three private scope wrappers, a single-use filter wrapper, an unused result field and repeated result assembly. Existing metadata, catalog planner and plugin loader remain the owners; no new cache or freshness mechanism.

At the existing all-or-nothing catch, retain only independently valid manifest coverage. The existing scoped loader can then recover discarded executable entries. Static-only owners remain covered even if their optional entry fails; mixed runtime/refreshable owners still load and replace their static descriptors. Successful empty exports retain their existing meaning. This repair adds no production lines to the refactor.

## User Impact

Less repeated work in provider discovery, and missing providers recover after a sibling discovery failure. Explicit selection, registration ordering, synthetic auth, input ownership and entries-only behavior remain intact. Selective partial-coverage discovery remains credential-bounded when unscoped; the pre-existing all-empty/no-runtime path still delegates to the ordinary full loader unchanged. No configuration, schema, SDK or protocol change. Release-note context is included below for the release-owned changelog.

One failure-path timing change is deliberate: duplicate planning could incidentally retry a caught local overlay-read failure within the same invocation. One preparation uses the manifest row for that invocation; the unchanged overlay owner clears its failed cache and retries on the next invocation. Recovered content is identical. There is no new retry, network refresh policy or persistent-state change; the failing invocation is not claimed to return identical content.

## Evidence

- Before production edits, the new six-case regression fails four selected/credentialed cases with missing providers; both entries-only controls pass. With the change, all **211 tests across eleven suites** pass, including the six regressions, synthetic auth, current snapshots, real catalog workers, auth provenance, planner and overlay behavior. A final test-table lint cleanup preserves every case; its complete 38-test owner suite and the full changed-file gate pass again.
- Complete-owner real-loader proof rerun at final head `76bdb3566dab1439aa97eaa9ad5cc7e449995dc1`: **1,280 cases**, with **1,125 unchanged and 155 repaired omissions**, plus nine unique direct registration controls. Covers failure first/middle/last, partial/discarded entries, explicit empty and unscoped requests, independent credentials, static/runtime/refreshable and mixed owners, same-owner static plus failed entry, and successful empty/invalid exports. Unchanged cases retain ordered payload equality; repaired cases use an independent scope/ownership oracle. All observations match the original evidence; 52 root inputs (including six tests) and 87 installed loader-package files stayed unchanged. No lightweight retry is introduced. This addresses ClawSweeper's requested exact-head real-loader rank-up proof.
- The performance-only precursor passed 2,444 differential comparisons and 136 real-loader comparisons. Those establish the consolidation separately; they are not claimed as final equality counts for the intentional recovery fix.
- Independent full-owner review and structured Codex review found no unresolved issue; the structured review uses its configured P0 threshold. Native model contracts were read directly from the pinned Codex source. Current main's thirteen direct discovery dependencies match the measured baseline.
- Production **+72/−151 = −79 lines**; meaningful regression tests **+58**; no root changelog change. No generated/lockfile changes.

Two fresh final-source benchmark processes used opposite starting orders, seven alternating samples per workload, and all raw samples. Imports, fixture preparation, warmup and calibration were outside timing; complete uninstrumented owners used the actual planner and normalizer. All 20 recorded source/dependency/package hashes stayed unchanged.

| Warm static discovery | Before-first: before → final | Candidate-first: before → final |
| --- | ---: | ---: |
| 1 plugin × 4 models | 14.407 → 9.628 µs | 14.878 → 9.147 µs |
| 1 plugin × 128 models | 0.23622 → 0.12704 ms | 0.23549 → 0.12563 ms |
| 32 plugins × 16 models | 1.08881 → 0.60410 ms | 1.08037 → 0.59909 ms |
| 32 plugins × 64 models | 4.10367 → 2.25962 ms | 4.17557 → 2.28497 ms |

That is 1.50–1.87× across these fixtures, with more variability in the smallest case. The separate final-source overlay probe also passes, including the disclosed next-invocation recovery. These measurements exclude cold startup, discovery-entry/full-runtime loading, network/model latency and memory behavior; no universal latency or memory improvement is claimed.

The full build passes (165.5 s) at `903af4fdb1680204ea31acbb7422f5cf90092b5a`; later follow-ups change only one memory test and release-note placement, leaving production byte-identical. The built isolated Gateway passes 12 assertions across five RPCs, exactly matching baseline titles/previews, tool inventories and model catalog. Four fresh real OpenAI sessions return READY and execute sessions_list, web_fetch and native web search; terminal receipts and the native search completion event confirm execution without rerouting. The owned Gateway exits cleanly. Live timings are observational, not speedup evidence.

Hosted CI exposed an existing cross-process memory-test observation race: after publication releases its lease, a later reader may already have completed before the test checks an intermediate snapshot. The observed event order was correctly published then next-reader. Remove only that invalid intermediate assertion and explain the release ordering; initial contention, pre-release empty events, final exact ordering and cleanup remain. The seven-test canonical suite passes. An independent actual-process probe reproduces the old failure, passes 24 corrected runs (12 ordinary and 12 late observations), and detects a deliberately broken writer-intent implementation through the retained contention check. This is +1/−1 test lines, with no production, timer or lock change.

The final memory-only changed-file gate also passes. An earlier local attempt failed the topology guard while a native review checkout was changing; rerunning with checkout operations idle passed without relaxing the guard. A separate real-native fixture reproduces this failure mechanism, but the original invocation's complete before/after topology was not retained. The separate build-cache namespace issue is retained as a follow-up; no speculative exclusion is included here.

The reviewed fallback is accepted on this evidence: retain valid static rows, recover discarded selected/credentialed owners through existing canonical registration, and preserve the entries-only boundary. The exact-head real-loader matrix, synthetic-auth and prepared-worker suites, and real Gateway receipts cover the requested activation, ordering and authentication boundaries.

## Changelog

Provider discovery prepares manifest catalogs once and recovers discarded discovery entries through the existing scoped loader, so a static catalog cannot hide another selected or credentialed provider after an entry fails.

The native landing workflow reserves root CHANGELOG.md edits for release automation; this ordinary PR carries the release note here. The initial prepare attempt correctly refused the root entry, which was removed without any production or test change. No release-only override is used.
