### PR TITLE
test(qa): use canonical exact marker in Telegram recovery

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -41,7 +41,7 @@ const QA_EMPTY_RESPONSE_RECOVERY_PROMPT =
 const QA_EMPTY_RESPONSE_EXHAUSTION_PROMPT =
   "Empty response exhaustion QA check: read QA_KICKOFF_TASK.md, then answer with exactly EMPTY-EXHAUSTED-OK.";
 const QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT =
-  "Empty response after write recovery QA check: write qa-empty-response-side-effect.txt, then answer with exactly TELEGRAM-EMPTY-WRITE-RECOVERED-OK.";
+  "Empty response after write recovery QA check: write qa-empty-response-side-effect.txt, then reply with exact marker: `TELEGRAM-EMPTY-WRITE-RECOVERED-OK`.";
 const QA_ANTHROPIC_THINKING_ERROR_RECOVERY_PROMPT =
   "Anthropic thinking error QA check: read QA_KICKOFF_TASK.md, then answer with exactly ANTHROPIC-THINKING-ERROR-RECOVERED-OK.";
 const QA_REASONING_ONLY_RETRY_INSTRUCTION =
@@ -8251,66 +8251,80 @@ Update and merge these partial structured summaries.`,
     expect(secondEmpty.output?.[0]?.content?.[0]?.text).toBe("");
   });
 
-  it("scripts settled continuation after an empty response from a side-effecting write", async () => {
-    const server = await startMockServer();
+  it.each([
+    { history: "fresh", precedingInput: [] },
+    {
+      history: "earlier reply directive",
+      precedingInput: [makeUserInput("Earlier check: exact marker: `PREVIOUS-SCENARIO-OK`.")],
+    },
+  ])(
+    "scripts settled continuation after a side-effecting write with $history",
+    async ({ precedingInput }) => {
+      const server = await startMockServer();
 
-    const toolPlan = await expectOpenAiStreamingResponsesText(server, {
-      input: [makeUserInput(QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT)],
-    });
-    expect(toolPlan).toContain('"name":"write"');
+      const toolPlan = await expectOpenAiStreamingResponsesText(server, {
+        input: [...precedingInput, makeUserInput(QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT)],
+      });
+      expect(toolPlan).toContain('"name":"write"');
 
-    const toolOutput = {
-      type: "function_call_output" as const,
-      output: "Successfully wrote 27 bytes to qa-empty-response-side-effect.txt",
-    };
-    const emptyPayload = await expectOpenAiNonStreamingResponsesJson<{
-      output?: Array<{ content?: Array<{ text?: string }> }>;
-    }>(server, {
-      input: [makeUserInput(QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT), toolOutput],
-    });
-    expect(emptyPayload.output?.[0]?.content?.[0]?.text).toBe("");
+      const toolOutput = {
+        type: "function_call_output" as const,
+        output: "Successfully wrote 27 bytes to qa-empty-response-side-effect.txt",
+      };
+      const emptyPayload = await expectOpenAiNonStreamingResponsesJson<{
+        output?: Array<{ content?: Array<{ text?: string }> }>;
+      }>(server, {
+        input: [
+          ...precedingInput,
+          makeUserInput(QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT),
+          toolOutput,
+        ],
+      });
+      expect(emptyPayload.output?.[0]?.content?.[0]?.text).toBe("");
 
-    const recoveredPayload = await expectOpenAiNonStreamingResponsesJson<{
-      output?: Array<{ content?: Array<{ text?: string }> }>;
-    }>(server, {
-      input: [
-        makeUserInput(QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT),
-        makeUserInput(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION),
-        toolOutput,
-      ],
-    });
-    expect(outputText(recoveredPayload)).toBe("TELEGRAM-EMPTY-WRITE-RECOVERED-OK");
+      const recoveredPayload = await expectOpenAiNonStreamingResponsesJson<{
+        output?: Array<{ content?: Array<{ text?: string }> }>;
+      }>(server, {
+        input: [
+          ...precedingInput,
+          makeUserInput(QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT),
+          makeUserInput(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION),
+          toolOutput,
+        ],
+      });
+      expect(outputText(recoveredPayload)).toBe("TELEGRAM-EMPTY-WRITE-RECOVERED-OK");
 
-    const cronRecoveredPayload = await expectOpenAiNonStreamingResponsesJson<{
-      output?: Array<{ content?: Array<{ text?: string }> }>;
-    }>(server, {
-      input: [
-        makeUserInput(
-          [
-            "Empty response after write recovery QA check: write once, then respond with exact marker: `CRON-EMPTY-WRITE-RECOVERED-OK`.",
-            "This is an unattended scheduled run. If nothing needs doing, reply exactly HEARTBEAT_OK.",
-          ].join("\n\n"),
-        ),
-        makeUserInput(
-          `${QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION}\nRead HEARTBEAT.md if it exists.`,
-        ),
-        toolOutput,
-      ],
-    });
-    expect(outputText(cronRecoveredPayload)).toBe("CRON-EMPTY-WRITE-RECOVERED-OK");
+      const cronRecoveredPayload = await expectOpenAiNonStreamingResponsesJson<{
+        output?: Array<{ content?: Array<{ text?: string }> }>;
+      }>(server, {
+        input: [
+          makeUserInput(
+            [
+              "Empty response after write recovery QA check: write once, then respond with exact marker: `CRON-EMPTY-WRITE-RECOVERED-OK`.",
+              "This is an unattended scheduled run. If nothing needs doing, reply exactly HEARTBEAT_OK.",
+            ].join("\n\n"),
+          ),
+          makeUserInput(
+            `${QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION}\nRead HEARTBEAT.md if it exists.`,
+          ),
+          toolOutput,
+        ],
+      });
+      expect(outputText(cronRecoveredPayload)).toBe("CRON-EMPTY-WRITE-RECOVERED-OK");
 
-    const laterHeartbeatPayload = await expectOpenAiNonStreamingResponsesJson<{
-      output?: Array<{ content?: Array<{ text?: string }> }>;
-    }>(server, {
-      input: [
-        makeUserInput(QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT),
-        makeUserInput(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION),
-        toolOutput,
-        makeUserInput("Read HEARTBEAT.md if it exists."),
-      ],
-    });
-    expect(outputText(laterHeartbeatPayload)).toBe("HEARTBEAT_OK");
-  });
+      const laterHeartbeatPayload = await expectOpenAiNonStreamingResponsesJson<{
+        output?: Array<{ content?: Array<{ text?: string }> }>;
+      }>(server, {
+        input: [
+          makeUserInput(QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT),
+          makeUserInput(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION),
+          toolOutput,
+          makeUserInput("Read HEARTBEAT.md if it exists."),
+        ],
+      });
+      expect(outputText(laterHeartbeatPayload)).toBe("HEARTBEAT_OK");
+    },
+  );
 
   it("reports a failed Code Mode read honestly through ordinary continuation", async () => {
     const server = await startMockServer();

--- a/qa/scenarios/channels/telegram-empty-response-after-write-recovery.yaml
+++ b/qa/scenarios/channels/telegram-empty-response-after-write-recovery.yaml
@@ -47,7 +47,7 @@ flow:
             conversation: { id: telegram-command-room, kind: channel }
             senderId: qa-command-operator
             senderName: QA Command Operator
-            text: "@openclaw Empty response after write recovery QA check: write qa-empty-response-side-effect.txt with the text side effect completed once, then answer exactly TELEGRAM-EMPTY-WRITE-RECOVERED-OK."
+            text: "@openclaw Empty response after write recovery QA check: write qa-empty-response-side-effect.txt with the text side effect completed once, then reply with exact marker: `TELEGRAM-EMPTY-WRITE-RECOVERED-OK`."
         - waitForOutbound:
             conversation: { id: telegram-command-room, kind: channel }
             sinceIndex: { ref: startIndex }


### PR DESCRIPTION
## Summary

The Telegram empty-response-after-write recovery fixture used `answer exactly`, which the deterministic mock provider does not recognize as an exact reply or marker directive. A fresh run happened to pass because the mock's fallback marker matched the scenario. If history contained an earlier recognized directive, the settled-write continuation could instead return that previous scenario's marker.

Use the existing `exact marker:` grammar in the scenario and its HTTP-level provider test. Parameterize the existing recovery case to cover both fresh input and an earlier reply directive in history. Keep the write/continuation, scheduled-run, and heartbeat assertions; no runtime code, parser behavior, timeout, or retry changes.

## Verification

- Before: the real mock HTTP recovery test passed fresh input but failed with preceding scenario history, returning `PREVIOUS-SCENARIO-OK`.
- After: both cases pass, and all 279 mock provider server tests pass.
- Full changed-file gate passed, including all typecheck lanes, lint, guards, three Knip scans, and runtime cycle checks. Format and whitespace checks pass.
- Independent managed Codex review passed through P2 with no findings.

Runtime production delta is zero. Changes are one scenario line and existing test coverage (+71/-57 including formatter indentation).

The frozen full release run reported a packaged Telegram recovery failure. Its retained artifacts do not include the provider request bodies, so this PR does not claim that exact hosted causality is proven. A fresh focused Package Acceptance run will test the frozen b111 product with this reviewed harness; its result will be recorded here. Source Telegram validation already passed at b111. The full release verdict remains blocked until all repairs receive a new frozen run.

## Hosted packaged proof

[Package Acceptance33294704059](https://github.com/openclaw/openclaw/actions/runs/33294704059) passed with product SHA `b111319fcd8ec27ae7e2436ca51dd7637287c62a`, harness SHA `ac1279fb04c7c547e91e642337a3244646f76e5e`, and the original trusted b111 workflow. The Telegram Test Server userbot delivered `TELEGRAM-EMPTY-WRITE-RECOVERED-OK` with three provider requests, exactly one write, exactly one continuation, and no skipped scenarios. Suite wall time was16.427seconds. This is focused real transport proof, not a replacement for the full release verdict.

Retained immutable proof artifact9727186452 has digest `e18e78c881ff6bb4b0576f0de8934d9e642f9761179539e78d511b199345fc8e`. Package and same-source plugin registry artifacts are9727143672 and9727143924; downloaded package bytes and registry-manifest hash match the recorded candidate metadata.
