### PR TITLE
fix(outbound): skip markers for empty HTML formatting elements

### DIFF
--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -75,6 +75,51 @@ describe("sanitizeForPlainText", () => {
     );
   });
 
+  // --- empty formatting elements (#133077) -------------------------------
+
+  it.each([
+    ["<b></b>", { style: "markdown" as const }],
+    ["<strong></strong>", { style: "markdown" as const }],
+    ["<i></i>", { style: "markdown" as const }],
+    ["<em></em>", { style: "markdown" as const }],
+    ["<s></s>", { style: "markdown" as const }],
+    ["<strike></strike>", { style: "markdown" as const }],
+    ["<del></del>", { style: "markdown" as const }],
+    ["<code></code>", {}],
+    ["<h2></h2>", { style: "markdown" as const }],
+    ["<b>   </b>", { style: "markdown" as const }],
+    ["<b><span></span></b>", { style: "markdown" as const }],
+  ])("produces no markers for empty formatting element %s", (input, options) => {
+    expect(sanitizeForPlainText(input, options)).toBe("");
+  });
+
+  it("does not synthesize a thematic break from an empty bold element", () => {
+    const sanitized = sanitizeForPlainText("before\n<b></b>\nafter", {
+      style: "markdown",
+    });
+    expect(sanitized).toBe("before\n\nafter");
+    expect(sanitized).not.toContain("****");
+  });
+
+  it("suppresses a marker-only empty element between paragraphs", () => {
+    expect(sanitizeForPlainText("para one\n<b></b>\npara two", { style: "markdown" })).toBe(
+      "para one\n\npara two",
+    );
+  });
+
+  it("preserves formatting for non-empty elements alongside empty ones", () => {
+    expect(
+      sanitizeForPlainText("Hello<br><b>world</b> <b></b> <i>nice</i>", {
+        style: "markdown",
+      }),
+    ).toBe("Hello\n**world**  _nice_");
+  });
+
+  it("preserves non-empty headings and bold after the empty-element fix", () => {
+    expect(sanitizeForPlainText("<h3>Title</h3>", { style: "markdown" })).toBe("\n**Title**\n");
+    expect(sanitizeForPlainText("<b>text</b>", { style: "markdown" })).toBe("**text**");
+  });
+
   // --- tag stripping ------------------------------------------------------
 
   it("strips unknown/remaining tags", () => {

--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -75,11 +75,9 @@ describe("sanitizeForPlainText", () => {
     );
   });
 
-  // --- empty formatting elements (#133077) -------------------------------
-
   it.each([
     ["<b></b>", { style: "markdown" as const }],
-    ["<strong></strong>", { style: "markdown" as const }],
+    ["<strong></strong>", {}],
     ["<i></i>", { style: "markdown" as const }],
     ["<em></em>", { style: "markdown" as const }],
     ["<s></s>", { style: "markdown" as const }],
@@ -87,37 +85,22 @@ describe("sanitizeForPlainText", () => {
     ["<del></del>", { style: "markdown" as const }],
     ["<code></code>", {}],
     ["<h2></h2>", { style: "markdown" as const }],
+    ["<li></li>", { style: "markdown" as const }],
     ["<b>   </b>", { style: "markdown" as const }],
+    ["<strong title='empty'></strong>", { style: "markdown" as const }],
     ["<b><span></span></b>", { style: "markdown" as const }],
-  ])("produces no markers for empty formatting element %s", (input, options) => {
+    ["<i><b></b></i>", { style: "markdown" as const }],
+    ["<b><i></i></b>", { style: "markdown" as const }],
+  ])("does not create visible structure from %s", (input, options) => {
     expect(sanitizeForPlainText(input, options)).toBe("");
   });
 
-  it("does not synthesize a thematic break from an empty bold element", () => {
-    const sanitized = sanitizeForPlainText("before\n<b></b>\nafter", {
-      style: "markdown",
-    });
-    expect(sanitized).toBe("before\n\nafter");
-    expect(sanitized).not.toContain("****");
-  });
-
-  it("suppresses a marker-only empty element between paragraphs", () => {
-    expect(sanitizeForPlainText("para one\n<b></b>\npara two", { style: "markdown" })).toBe(
-      "para one\n\npara two",
-    );
-  });
-
-  it("preserves formatting for non-empty elements alongside empty ones", () => {
+  it("preserves visible content around an empty element", () => {
     expect(
-      sanitizeForPlainText("Hello<br><b>world</b> <b></b> <i>nice</i>", {
+      sanitizeForPlainText("before\n<b></b>\nafter", {
         style: "markdown",
       }),
-    ).toBe("Hello\n**world**  _nice_");
-  });
-
-  it("preserves non-empty headings and bold after the empty-element fix", () => {
-    expect(sanitizeForPlainText("<h3>Title</h3>", { style: "markdown" })).toBe("\n**Title**\n");
-    expect(sanitizeForPlainText("<b>text</b>", { style: "markdown" })).toBe("**text**");
+    ).toBe("before\n\nafter");
   });
 
   // --- tag stripping ------------------------------------------------------

--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -105,6 +105,21 @@ describe("sanitizeForPlainText", () => {
     ).toBe("before\n\nafter");
   });
 
+  it.each([
+    ["<b><br></b>", "\n"],
+    ["<b>\n</b>", "\n"],
+    ["<b>\r\n</b>", "\r\n"],
+    ["<p></p>", "\n\n"],
+    ["<div></div>", "\n\n"],
+    ["<p><br></p>", "\n\n"],
+  ])("preserves structural breaks in %s", (input, expected) => {
+    expect(sanitizeForPlainText(input)).toBe(expected);
+  });
+
+  it("preserves a wrapped line break between visible text", () => {
+    expect(sanitizeForPlainText("before<b>\n</b>after")).toBe("before\nafter");
+  });
+
   // --- tag stripping ------------------------------------------------------
 
   it("strips unknown/remaining tags", () => {

--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -89,6 +89,8 @@ describe("sanitizeForPlainText", () => {
     ["<b>   </b>", { style: "markdown" as const }],
     ["<strong title='empty'></strong>", { style: "markdown" as const }],
     ["<b><span></span></b>", { style: "markdown" as const }],
+    ["<b><img src='empty'/></b>", { style: "markdown" as const }],
+    ["<li><img src='empty'/></li>", { style: "markdown" as const }],
     ["<i><b></b></i>", { style: "markdown" as const }],
     ["<b><i></i></b>", { style: "markdown" as const }],
   ])("does not create visible structure from %s", (input, options) => {

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -16,57 +16,42 @@ const CODE_PLACEHOLDER = "\u0000p";
 // Quoted attribute values may contain `>`; normalize convertible openers without leaking attribute text.
 const CONVERTIBLE_HTML_OPEN_TAG_RE =
   /<(b|strong|i|em|s|strike|del|code|h[1-6]|li)(?=\s|>)(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
+const EMPTY_HTML_ELEMENT_RE =
+  /<([a-z][a-z0-9_.:-]*)(?=[\s>])(?:[^"'<>]|"[^"]*"|'[^']*')*>\s*<\/\1\s*>/gi;
 
-function stripRemainingHtmlTags(text: string): string {
+function removeMatchesUntilStable(text: string, pattern: RegExp): string {
   let previous: string;
   let current = text;
   do {
     previous = current;
-    current = current.replace(HTML_TAG_RE, "");
+    current = current.replace(pattern, "");
   } while (current !== previous);
   return current;
-}
-
-function hasVisibleContent(body: string): boolean {
-  return stripRemainingHtmlTags(body).trim().length > 0;
 }
 
 function convertHtmlOutsideCode(text: string, options: { style?: "markdown" }): string {
   const boldMarker = options.style === "markdown" ? "**" : "*";
   const strikeMarker = options.style === "markdown" ? "~~" : "~";
-  const converted = text
-    // Preserve angle-bracket autolinks as plain URLs before tag stripping.
-    .replace(/<((?:https?:\/\/|mailto:)[^<>\s]+)>/gi, "$1")
-    // Normalize attributes once; conversions below only need exact bare tag names.
-    .replace(CONVERTIBLE_HTML_OPEN_TAG_RE, "<$1>")
-    // Line breaks
+  // Remove inner elements first so an empty nested tree cannot synthesize markers.
+  const converted = removeMatchesUntilStable(
+    text
+      // Preserve angle-bracket autolinks as plain URLs before tag stripping.
+      .replace(/<((?:https?:\/\/|mailto:)[^<>\s]+)>/gi, "$1")
+      // Normalize attributes once; conversions below only need exact bare tag names.
+      .replace(CONVERTIBLE_HTML_OPEN_TAG_RE, "<$1>"),
+    EMPTY_HTML_ELEMENT_RE,
+  )
     .replace(/<br\s*\/?>/gi, "\n")
     // Block elements → newlines
     .replace(/<\/?(p|div)>/gi, "\n")
-    // Bold → selected lightweight markup (skip empty elements)
-    .replace(/<(b|strong)>(.*?)<\/\1>/gi, (_match, _tag, body: string) =>
-      hasVisibleContent(body) ? `${boldMarker}${body}${boldMarker}` : "",
-    )
-    // Italic → WhatsApp/Signal italic (skip empty elements)
-    .replace(/<(i|em)>(.*?)<\/\1>/gi, (_match, _tag, body: string) =>
-      hasVisibleContent(body) ? `_${body}_` : "",
-    )
-    // Strikethrough → selected lightweight markup (skip empty elements)
-    .replace(/<(s|strike|del)>(.*?)<\/\1>/gi, (_match, _tag, body: string) =>
-      hasVisibleContent(body) ? `${strikeMarker}${body}${strikeMarker}` : "",
-    )
-    // Inline code (skip empty elements)
-    .replace(/<code>(.*?)<\/code>/gi, (_match, body: string) =>
-      hasVisibleContent(body) ? `\`${body}\`` : "",
-    )
-    // Headings → bold text with newline (skip empty elements)
-    .replace(/<h[1-6]>(.*?)<\/h[1-6]>/gi, (_match, body: string) =>
-      hasVisibleContent(body) ? `\n${boldMarker}${body}${boldMarker}\n` : "",
-    )
-    // List items → bullet points
+    .replace(/<(b|strong)>(.*?)<\/\1>/gi, `${boldMarker}$2${boldMarker}`)
+    .replace(/<(i|em)>(.*?)<\/\1>/gi, "_$2_")
+    .replace(/<(s|strike|del)>(.*?)<\/\1>/gi, `${strikeMarker}$2${strikeMarker}`)
+    .replace(/<code>(.*?)<\/code>/gi, "`$1`")
+    .replace(/<h[1-6]>(.*?)<\/h[1-6]>/gi, `\n${boldMarker}$1${boldMarker}\n`)
     .replace(/<li>(.*?)<\/li>/gi, "• $1\n");
 
-  return stripRemainingHtmlTags(converted).replace(/\n{3,}/g, "\n\n");
+  return removeMatchesUntilStable(converted, HTML_TAG_RE).replace(/\n{3,}/g, "\n\n");
 }
 
 /**

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -16,8 +16,9 @@ const CODE_PLACEHOLDER = "\u0000p";
 // Quoted attribute values may contain `>`; normalize convertible openers without leaking attribute text.
 const CONVERTIBLE_HTML_OPEN_TAG_RE =
   /<(b|strong|i|em|s|strike|del|code|h[1-6]|li)(?=\s|>)(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
+// br, p, and div own line structure, so they stay outside the inert-tree removal pass.
 const EMPTY_HTML_ELEMENT_RE =
-  /<([a-z][a-z0-9_.:-]*)(?=[\s>])(?:[^"'<>]|"[^"]*"|'[^']*')*>(?:\s|<\/?[a-z][a-z0-9_.:-]*(?=[\s/>])(?:[^"'<>]|"[^"]*"|'[^']*')*>)*<\/\1\s*>/gi;
+  /<((?!(?:br|p|div)(?=[\s>]))[a-z][a-z0-9_.:-]*)(?=[\s>])(?:[^"'<>]|"[^"]*"|'[^']*')*>(?:[^\S\r\n\u2028\u2029]|<(?!\/?(?:br|p|div)(?=[\s/>]))\/?[a-z][a-z0-9_.:-]*(?=[\s/>])(?:[^"'<>]|"[^"]*"|'[^']*')*>)*<\/\1\s*>/gi;
 
 function removeMatchesUntilStable(text: string, pattern: RegExp): string {
   let previous: string;

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -27,6 +27,10 @@ function stripRemainingHtmlTags(text: string): string {
   return current;
 }
 
+function hasVisibleContent(body: string): boolean {
+  return stripRemainingHtmlTags(body).trim().length > 0;
+}
+
 function convertHtmlOutsideCode(text: string, options: { style?: "markdown" }): string {
   const boldMarker = options.style === "markdown" ? "**" : "*";
   const strikeMarker = options.style === "markdown" ? "~~" : "~";
@@ -39,16 +43,26 @@ function convertHtmlOutsideCode(text: string, options: { style?: "markdown" }): 
     .replace(/<br\s*\/?>/gi, "\n")
     // Block elements → newlines
     .replace(/<\/?(p|div)>/gi, "\n")
-    // Bold → selected lightweight markup
-    .replace(/<(b|strong)>(.*?)<\/\1>/gi, `${boldMarker}$2${boldMarker}`)
-    // Italic → WhatsApp/Signal italic
-    .replace(/<(i|em)>(.*?)<\/\1>/gi, "_$2_")
-    // Strikethrough → selected lightweight markup
-    .replace(/<(s|strike|del)>(.*?)<\/\1>/gi, `${strikeMarker}$2${strikeMarker}`)
-    // Inline code
-    .replace(/<code>(.*?)<\/code>/gi, "`$1`")
-    // Headings → bold text with newline
-    .replace(/<h[1-6]>(.*?)<\/h[1-6]>/gi, `\n${boldMarker}$1${boldMarker}\n`)
+    // Bold → selected lightweight markup (skip empty elements)
+    .replace(/<(b|strong)>(.*?)<\/\1>/gi, (_match, _tag, body: string) =>
+      hasVisibleContent(body) ? `${boldMarker}${body}${boldMarker}` : "",
+    )
+    // Italic → WhatsApp/Signal italic (skip empty elements)
+    .replace(/<(i|em)>(.*?)<\/\1>/gi, (_match, _tag, body: string) =>
+      hasVisibleContent(body) ? `_${body}_` : "",
+    )
+    // Strikethrough → selected lightweight markup (skip empty elements)
+    .replace(/<(s|strike|del)>(.*?)<\/\1>/gi, (_match, _tag, body: string) =>
+      hasVisibleContent(body) ? `${strikeMarker}${body}${strikeMarker}` : "",
+    )
+    // Inline code (skip empty elements)
+    .replace(/<code>(.*?)<\/code>/gi, (_match, body: string) =>
+      hasVisibleContent(body) ? `\`${body}\`` : "",
+    )
+    // Headings → bold text with newline (skip empty elements)
+    .replace(/<h[1-6]>(.*?)<\/h[1-6]>/gi, (_match, body: string) =>
+      hasVisibleContent(body) ? `\n${boldMarker}${body}${boldMarker}\n` : "",
+    )
     // List items → bullet points
     .replace(/<li>(.*?)<\/li>/gi, "• $1\n");
 

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -17,7 +17,7 @@ const CODE_PLACEHOLDER = "\u0000p";
 const CONVERTIBLE_HTML_OPEN_TAG_RE =
   /<(b|strong|i|em|s|strike|del|code|h[1-6]|li)(?=\s|>)(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
 const EMPTY_HTML_ELEMENT_RE =
-  /<([a-z][a-z0-9_.:-]*)(?=[\s>])(?:[^"'<>]|"[^"]*"|'[^']*')*>\s*<\/\1\s*>/gi;
+  /<([a-z][a-z0-9_.:-]*)(?=[\s>])(?:[^"'<>]|"[^"]*"|'[^']*')*>(?:\s|<\/?[a-z][a-z0-9_.:-]*(?=[\s/>])(?:[^"'<>]|"[^"]*"|'[^']*')*>)*<\/\1\s*>/gi;
 
 function removeMatchesUntilStable(text: string, pattern: RegExp): string {
   let previous: string;


### PR DESCRIPTION
Closes #133077

## What Problem This Solves

Empty HTML elements could create visible Markdown structure even though they contained no visible text.

Telegram's default outbound path converted `<b></b>` to `****`.
The Markdown renderer then displayed that generated text as a horizontal rule.

## Why This Change Was Made

The shared outbound sanitizer owns HTML-to-text conversion for Telegram, iMessage, Google Chat, IRC, WhatsApp, and direct text adapters.

The old conversion added formatting markers before it knew whether a nested HTML tree contained text.
The repair removes inert HTML trees to a fixed point before any marker conversion.
This covers self-closing children, empty list items, and either order of nested formatting tags while preserving structural tags and literal line breaks.

The delivery normalizer remains unchanged.
It already suppresses empty text while preserving media and other payload content.

## User Impact

Content with no visible text no longer creates horizontal rules, bullets, or marker-only messages.

Non-empty formatted text, Markdown code regions, links, headings, and list items keep their existing output.

## Evidence

### Telegram Test Server

- Red on exact main `ad7191bf17e72dfb8554d5b4c1ff28410f02f22c`: a real direct-message turn reached the provider once, the provider returned `<b></b>`, and Telegram displayed `───`.
- Green on exact head `3eb9473dafe78cd7916cc4b4352750b5841cf403`: the equivalent turn reached the provider once, and Telegram displayed the intentional no-reply notice with no horizontal rule or marker-only output.
- Both runs used the non-rich Telegram adapter and retained the Telegram event timeline, Gateway log, and provider request log.

### Focused validation

- Pre-fix regression: `node scripts/run-vitest.mjs src/infra/outbound/sanitize-text.test.ts` failed 16 cases for generated markers and bullets.
- Repaired sanitizer: the same command passed 75 tests.
- Delivery boundary: `node scripts/run-vitest.mjs src/infra/outbound/deliver.test.ts` passed 215 tests.
- Telegram adapter: `node scripts/run-vitest.mjs extensions/telegram/src/outbound-adapter.sanitize.test.ts` passed 5 tests.
- Targeted Oxlint, Oxfmt, and `git diff --check` passed.

## Change Shape

- Canonical owner: `src/infra/outbound/sanitize-text.ts`.
- Closed modes: visible HTML content keeps conversion; empty HTML trees emit no structure.
- Production delta: 15 additions and 15 removals, net `0` lines.
- Tests: 45 additions.
- No configuration, protocol, storage, or dependency changes.
