### PR TITLE
fix(changelog): retain explicitly marked breaking changes in release notes

### DIFF
--- a/.agents/skills/openclaw-changelog-update/SKILL.md
+++ b/.agents/skills/openclaw-changelog-update/SKILL.md
@@ -167,10 +167,12 @@ every human `Thanks @...` attribution.
      prose but are never rendered as a public `#### Direct commits` dump. Add
      direct-commit credit to a grouped bullet only when it shares an explicit
      closing issue reference or at least two distinctive subject terms
-   - the verifier rejects `docs`, `test`, `refactor`, `ci`, `build`, `chore`,
-     and `style` PRs in Highlights, Changes, or Fixes. Keep those internal
-     contributions in the complete PR record, but do not give them editorial
-     release-note space
+   - the verifier rejects ordinary `docs`, `test`, `refactor`, `ci`, `build`,
+     `chore`, and `style` PRs in Highlights, Changes, or Fixes. An explicit
+     Conventional Commits `!` marker makes any type editorial-eligible; include
+     its verified user-facing breaking change and migration guidance with the
+     original PR ref and credit. Keep other internal contributions only in the
+     complete PR record
    - classify internal-only work from conventional prefixes and clear title
      signals such as `QA`, `test`, `docs`, `refactor`, `lint`, or `CI`; an
      untyped title is not automatically editorial

--- a/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
+++ b/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
@@ -269,9 +269,7 @@ function gitCommit(ref, required = false) {
 
 function fetchGithubApi(args) {
   try {
-    return JSON.parse(
-      run("ghx", ["api", ...args], { env: { GHX_NO_CACHE: "1" } }).replace(ansiEscapePattern, ""),
-    );
+    return JSON.parse(run("gh", ["api", ...args]).replace(ansiEscapePattern, ""));
   } catch (error) {
     if (typeof error.stdout === "string" && error.stdout.trim() !== "") {
       return JSON.parse(error.stdout.replace(ansiEscapePattern, ""));
@@ -436,12 +434,16 @@ function githubHandleFromNoreply(email) {
 }
 
 function editorialClassification(subject) {
-  const type = subject.match(/^\s*([a-z]+)(?:\([^)]*\))?!?:/i)?.[1]?.toLowerCase();
+  const conventional = subject.match(/^\s*([a-z]+)(?:\([^)]*\))?(!)?:/i);
+  const type = conventional?.[1]?.toLowerCase();
   return {
+    // A declared breaking API change needs migration notes even when its
+    // conventional type describes a refactor or other internal work.
     editorialEligible:
-      (Boolean(type) || editorialTitlePattern.test(subject)) &&
-      !nonEditorialTypes.has(type) &&
-      !nonEditorialTitlePattern.test(subject),
+      Boolean(conventional?.[2]) ||
+      ((Boolean(type) || editorialTitlePattern.test(subject)) &&
+        !nonEditorialTypes.has(type) &&
+        !nonEditorialTitlePattern.test(subject)),
     type: type ?? "other",
   };
 }

--- a/test/scripts/release-notes-ledger.test.ts
+++ b/test/scripts/release-notes-ledger.test.ts
@@ -53,6 +53,47 @@ function contributionLedger({
 }
 
 describe("renderContributionRecordEntry", () => {
+  it.each([
+    ["refactor(plugins)!: remove a bundled workflow plugin", "refactor", true],
+    ["refactor!: remove the legacy setup command", "refactor", true],
+    ["REFACTOR(cli)!: rename the setup command", "refactor", true],
+    ["build!: require a supported runtime", "build", true],
+    ["refactor(plugins): simplify loader internals", "refactor", false],
+    ["test: cover breaking plugin changes!", "test", false],
+    ["fix: preserve message delivery", "fix", true],
+  ])("classifies declared breaking changes for release prose: %s", (title, type, eligible) => {
+    const nodes = new Map([
+      [
+        123,
+        {
+          __typename: "PullRequest",
+          author: { __typename: "User", login: "alice" },
+          closingIssuesReferences: { nodes: [] },
+          mergedAt: "2026-08-04T00:00:00Z",
+          title,
+        },
+      ],
+    ]);
+    const result = contributionLedger({ nodes, sourcePullRequests: [123] });
+    expect(result.pullRequests).toMatchObject([
+      { number: 123, type, editorialEligible: eligible, thanks: ["alice"] },
+    ]);
+    const source = [
+      "## 2026.8.1",
+      "### Highlights",
+      ...[1, 2, 3, 4, 5].map((value) => `- Highlight ${value}.`),
+      "### Changes",
+      "- Explain the user impact. (#123) Thanks @alice.",
+      "### Fixes",
+      result.ledger,
+    ].join("\n");
+    expect(ledgerChecks({ source }, result.pullRequests, nodes, [])).toEqual(
+      eligible
+        ? []
+        : [`editorial release prose references non-editorial ${type} PR #123 (${type})`],
+    );
+  });
+
   it("keeps external and linked issue references without repeating PR title references", () => {
     expect(
       renderContributionRecordEntry({


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where release-note validation rejects a user-facing migration note when its source PR uses an internal conventional type with an explicit breaking-change marker. The 2026.8.1 audit found `refactor(plugins)!: remove OpenProse` (#128494): the plugin and `/prose` command exist in v2026.7.1-2, and their removal has a documented upstream-skill migration, but the verifier classified the PR as non-editorial.

## Why This Change Was Made

Preserve the original conventional type and recognize the explicit `!` marker before applying ordinary internal-work filters. [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) allows a breaking API change with any type. Ordinary refactors, tests, and other internal work remain excluded; PR provenance, contributor credit, and complete-record validation are unchanged. The skill text now describes the same rule.

The canonical collector also invokes standard `gh` directly instead of requiring the unavailable private `ghx` command. Its existing exact-query snapshot and response handling remain unchanged.

## User Impact

Operators can see genuine breaking changes and migration instructions in release notes without relabeling merged history or removing source references to satisfy the validator.

## Evidence

- Four breaking-change fixtures fail against the original classifier; three ordinary positive/negative cases already pass.
- All 61 release-note verification and ledger tests pass after the repair. The table exercises the real ledger producer and validation, preserves the original type and human credit, and covers scoped/unscoped/case-insensitive markers and a non-marker exclamation mark.
- Targeted type-aware lint, formatting, diff checks, and independent structured review passed.
- Current source and shipped-tag comparison confirm the OpenProse migration example. A real `gh api graphql` request successfully returned the unchanged merged PR title.
- No product runtime or release identity changes. The production classifier/API adapter changes by +2 net lines; tests add 41 lines. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33295145725) passed, and native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 133104` completed against the unchanged head.

The latest ClawSweeper review found no actionable source issue; its requested exact-head CI is now green. No SQLite or persisted manifest/snapshot schema changed: existing records retain their shape, and only the derived editorial eligibility of an explicitly marked breaking change differs.
