### PR TITLE
fix(plugins): avoid loading CLI-only code at startup

### DIFF
--- a/extensions/memory-wiki/index.ts
+++ b/extensions/memory-wiki/index.ts
@@ -2,7 +2,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { definePluginEntry, type OpenClawConfig } from "./api.js";
-import { registerWikiCli } from "./src/cli.js";
 import {
   activateMemoryWikiCompiledCacheOwner,
   configureMemoryWikiCompiledCacheStore,
@@ -251,7 +250,8 @@ export default definePluginEntry({
       { name: "wiki_get" },
     );
     api.registerCli(
-      ({ program }) => {
+      async ({ program }) => {
+        const { registerWikiCli } = await import("./src/cli.js");
         registerWikiCli(program, { config, resolveConfig, getAppConfig });
       },
       {

--- a/extensions/plugin-entry.cli-laziness.test.ts
+++ b/extensions/plugin-entry.cli-laziness.test.ts
@@ -1,0 +1,27 @@
+import { expect, it, vi } from "vitest";
+
+vi.mock("./memory-wiki/src/cli.js", () => {
+  throw new Error("memory-wiki CLI loaded during plugin entry import");
+});
+vi.mock("./policy/src/cli.js", () => {
+  throw new Error("policy CLI loaded during plugin entry import");
+});
+vi.mock("./qa-lab/src/cli.js", () => {
+  throw new Error("qa-lab CLI loaded during plugin entry import");
+});
+vi.mock("./voice-call/src/cli.js", () => {
+  throw new Error("voice-call CLI loaded during plugin entry import");
+});
+
+const cases = [
+  { id: "memory-wiki", load: () => import("./memory-wiki/index.js") },
+  { id: "policy", load: () => import("./policy/index.js") },
+  { id: "qa-lab", load: () => import("./qa-lab/index.js") },
+  { id: "voice-call", load: () => import("./voice-call/index.js") },
+] as const;
+
+it.each(cases)("keeps the $id CLI cold while importing its plugin entry", async ({ id, load }) => {
+  const { default: plugin } = await load();
+
+  expect(plugin.id).toBe(id);
+});

--- a/extensions/plugin-entry.cli-laziness.test.ts
+++ b/extensions/plugin-entry.cli-laziness.test.ts
@@ -1,27 +1,23 @@
 import { expect, it, vi } from "vitest";
 
 vi.mock("./memory-wiki/src/cli.js", () => {
-  throw new Error("memory-wiki CLI loaded during plugin entry import");
+  throw new Error("memory-wiki CLI eagerly imported");
 });
 vi.mock("./policy/src/cli.js", () => {
-  throw new Error("policy CLI loaded during plugin entry import");
+  throw new Error("policy CLI eagerly imported");
 });
 vi.mock("./qa-lab/src/cli.js", () => {
-  throw new Error("qa-lab CLI loaded during plugin entry import");
+  throw new Error("qa-lab CLI eagerly imported");
 });
 vi.mock("./voice-call/src/cli.js", () => {
-  throw new Error("voice-call CLI loaded during plugin entry import");
+  throw new Error("voice-call CLI eagerly imported");
 });
 
-const cases = [
+it.each([
   { id: "memory-wiki", load: () => import("./memory-wiki/index.js") },
   { id: "policy", load: () => import("./policy/index.js") },
   { id: "qa-lab", load: () => import("./qa-lab/index.js") },
   { id: "voice-call", load: () => import("./voice-call/index.js") },
-] as const;
-
-it.each(cases)("keeps the $id CLI cold while importing its plugin entry", async ({ id, load }) => {
-  const { default: plugin } = await load();
-
-  expect(plugin.id).toBe(id);
+])("imports $id without evaluating its CLI", async ({ id, load }) => {
+  expect((await load()).default.id).toBe(id);
 });

--- a/extensions/policy/index.ts
+++ b/extensions/policy/index.ts
@@ -1,7 +1,6 @@
 // Policy plugin entrypoint registers its OpenClaw integration.
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { POLICY_CLI_DESCRIPTOR } from "./src/cli-output-mode.js";
-import { registerPolicyCli } from "./src/cli.js";
 import { registerPolicyDoctorChecks } from "./src/doctor/register.js";
 
 export default definePluginEntry({
@@ -11,6 +10,7 @@ export default definePluginEntry({
   register(api) {
     api.registerCli(
       async ({ program }) => {
+        const { registerPolicyCli } = await import("./src/cli.js");
         registerPolicyCli(program);
       },
       {

--- a/extensions/qa-lab/index.ts
+++ b/extensions/qa-lab/index.ts
@@ -3,7 +3,6 @@ import { setTimeout as sleep } from "node:timers/promises";
 // Keep plugin registration independent of private QA transports, which packaged runtimes omit.
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { jsonResult } from "openclaw/plugin-sdk/tool-results";
-import { registerQaLabCli } from "./src/cli.js";
 import { createQaLabWebSearchProvider } from "./src/qa-web-search-provider.js";
 import { createStaticSshWorkerProvider } from "./src/static-ssh-worker-provider.js";
 
@@ -47,6 +46,7 @@ export default definePluginEntry({
     api.registerWebSearchProvider(createQaLabWebSearchProvider());
     api.registerCli(
       async ({ program }) => {
+        const { registerQaLabCli } = await import("./src/cli.js");
         registerQaLabCli(program);
       },
       {

--- a/extensions/voice-call/index.test.ts
+++ b/extensions/voice-call/index.test.ts
@@ -207,6 +207,7 @@ async function registerVoiceCallCli(
   program: Command,
   pluginConfig: Record<string, unknown> = { provider: "mock" },
 ) {
+  let registrar: ((ctx: RegisterCliContext) => void | Promise<void>) | undefined;
   const { register } = plugin as unknown as {
     register: RegisterVoiceCall;
   };
@@ -223,15 +224,20 @@ async function registerVoiceCallCli(
     logger: noopLogger,
     registerGatewayMethod: () => {},
     registerTool: () => {},
-    registerCli: (fn: (ctx: RegisterCliContext) => void) =>
-      fn({
-        program,
-        config: {},
-        workspaceDir: undefined,
-        logger: noopLogger,
-      }),
+    registerCli: (fn: (ctx: RegisterCliContext) => void | Promise<void>) => {
+      registrar = fn;
+    },
     registerService: () => {},
     resolvePath: (p: string) => p,
+  });
+  if (!registrar) {
+    throw new Error("voice-call CLI registrar was not registered");
+  }
+  await registrar({
+    program,
+    config: {},
+    workspaceDir: undefined,
+    logger: noopLogger,
   });
 }
 

--- a/extensions/voice-call/index.test.ts
+++ b/extensions/voice-call/index.test.ts
@@ -207,7 +207,7 @@ async function registerVoiceCallCli(
   program: Command,
   pluginConfig: Record<string, unknown> = { provider: "mock" },
 ) {
-  let registrar: ((ctx: RegisterCliContext) => void | Promise<void>) | undefined;
+  const registerCli = vi.fn<(fn: (ctx: RegisterCliContext) => void | Promise<void>) => void>();
   const { register } = plugin as unknown as {
     register: RegisterVoiceCall;
   };
@@ -224,21 +224,15 @@ async function registerVoiceCallCli(
     logger: noopLogger,
     registerGatewayMethod: () => {},
     registerTool: () => {},
-    registerCli: (fn: (ctx: RegisterCliContext) => void | Promise<void>) => {
-      registrar = fn;
-    },
+    registerCli,
     registerService: () => {},
     resolvePath: (p: string) => p,
   });
+  const registrar = registerCli.mock.calls[0]?.[0];
   if (!registrar) {
     throw new Error("voice-call CLI registrar was not registered");
   }
-  await registrar({
-    program,
-    config: {},
-    workspaceDir: undefined,
-    logger: noopLogger,
-  });
+  await registrar({ program, config: {}, workspaceDir: undefined, logger: noopLogger });
 }
 
 describe("voice-call plugin", () => {

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -18,7 +18,6 @@ import {
 } from "./api.js";
 import { VOICE_CALL_CLI_DESCRIPTOR } from "./cli-output-mode.js";
 import { createVoiceCallRuntime, type VoiceCallRuntime } from "./runtime-entry.js";
-import { registerVoiceCallCli } from "./src/cli.js";
 import {
   createVoiceCallCommandService,
   VoiceCallCommandInputError,
@@ -547,14 +546,16 @@ export default definePluginEntry({
     }));
 
     api.registerCli(
-      ({ program }) =>
+      async ({ program }) => {
+        const { registerVoiceCallCli } = await import("./src/cli.js");
         registerVoiceCallCli({
           program,
           config,
           ensureRuntime,
           stateRuntime: api.runtime.state,
           logger: api.logger,
-        }),
+        });
+      },
       { commands: ["voicecall"], descriptors: [VOICE_CALL_CLI_DESCRIPTOR] },
     );
 


### PR DESCRIPTION
## What Problem This Solves

Loading the memory-wiki, policy, qa-lab and voice-call plugin entries also loads their CLI-only implementation graphs before a command is selected. The entries already provide lightweight command descriptors, and the shared CLI loader already awaits asynchronous registrars. Those eager imports cross the existing lazy-registration boundary.

Move each implementation import into its plugin's existing registrar. Descriptors, arguments and command implementations stay unchanged. This follows the existing workboard/file-transfer pattern and keeps ownership in each plugin. The voice-call test helper now captures the registrar during plugin registration and awaits it afterward, matching the real loader lifecycle.

## Evidence

Independent proof uses a trusted-main checkout with an independently authored equivalent; all six final candidate files match that proof byte for byte. Actual Node 24 source tracing loaded all four CLI modules before the repair and none afterward. All 4 cold-entry regressions and 57 existing voice-call command/lifecycle cases passed. Three baseline regressions failed at the intended import edge; the baseline voice-call case hit the unchanged 120-second cold-import limit, so that timeout is not counted as a successful negative control. The separate source trace proves the fourth eager import directly.

The canonical private-QA runtime build passed. All four commands below exited 0, printed their actual command trees and loaded exactly their selected plugin's CLI module. Executed entry and CLI artifact hashes are retained with the source/build binding.

| Built command | Observed CLI implementation |
| --- | --- |
| `node openclaw.mjs wiki --help` | memory-wiki only |
| `node openclaw.mjs policy --help` | policy only |
| `node openclaw.mjs qa --help` | qa-lab only |
| `node openclaw.mjs voicecall --help` | voice-call only |

This is import-boundary proof, not a startup-latency benchmark; root help can already use manifest-only metadata.

Full six-file Codex review completed without actionable P0 findings. All 25 canonical changed-file gate phases passed, including production and test typechecks, lint, all three Knip scopes with zero entries, plugin boundaries, and storage/media/sidecar/cycle guards. The doctor declaration and closure suite passed all 5 cases after a canonical rebuild replaced an incomplete artifact generation from an earlier interrupted local build. The initial missing-reference and partial-build failures remain recorded; no test deadline, assertion, gate or build budget was weakened. Final exact-head [CI33472300189](https://github.com/openclaw/openclaw/actions/runs/33472300189) passed on `84161c66d1bbc01ebae6c018d5ead750f0eacb68` (55 successful jobs,16 skipped). The final PR rollup has 74 successful and 44 skipped checks. The refreshed exact-head ClawSweeper review has no findings; its remaining CI rank-up move is satisfied.

Production is +8/-7 (net 1); tests are +30/-7 (net 23). That single production line comes from the plugin-local async callback block; a shared core wrapper would broaden the owner boundary. There is no new configuration, schema, dependency or public CLI option. The earlier ClawSweeper net-growth concern is addressed by this boundary justification. Contributor Windows proof remains attributed to the original PR; the checks above are independent.

Thanks @ly85206559.
