### PR TITLE
fix(ci): finish release E2E with bounded parallel shards

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1036,11 +1036,35 @@ jobs:
           done
 
   validate_repo_e2e:
+    name: Repo E2E (${{ matrix.name }})
     needs: validate_selected_ref
     if: inputs.include_repo_e2e && inputs.live_suite_filter == ''
     continue-on-error: ${{ inputs.advisory }}
     runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-32vcpu-ubuntu-2404' }}
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix:
+        include:
+          - name: Gateway 1/4
+            command: pnpm test:e2e:gateway --shard=1/4
+          - name: Gateway 2/4
+            command: pnpm test:e2e:gateway --shard=2/4
+          - name: Gateway 3/4
+            command: pnpm test:e2e:gateway --shard=3/4
+          - name: Gateway 4/4
+            command: pnpm test:e2e:gateway --shard=4/4
+          - name: UI 1/4
+            command: pnpm test:ui:e2e --shard=1/4
+          - name: UI 2/4
+            command: pnpm test:ui:e2e --shard=2/4
+          - name: UI 3/4
+            command: pnpm test:ui:e2e --shard=3/4
+          - name: UI 4/4
+            command: pnpm test:ui:e2e --shard=4/4
+          - name: Agent plugin Gateway
+            command: pnpm test:e2e:agent-plugin-gateway
     env:
       OPENCLAW_BUILD_PRIVATE_QA: "1"
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
@@ -1075,7 +1099,7 @@ jobs:
         env:
           OPENCLAW_E2E_WORKERS: "2"
           OPENCLAW_E2E_USE_PREBUILT_DIST: "1"
-        run: pnpm test:e2e
+        run: ${{ matrix.command }}
 
   validate_special_e2e:
     needs: validate_selected_ref

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -821,6 +821,21 @@ A lane heavier than its effective cap can still start from an empty pool, then r
 
 ### Reusable live/E2E workflow
 
+Repository E2E runs as nine independent jobs: four native Gateway shards, four
+duration-weighted Control UI shards, and the standalone agent-plugin Gateway
+test. At most six run concurrently, and a failure does not cancel the remaining
+jobs. Every job checks out the same selected source and prepares its own full
+private-QA build, Chromium, and sandbox image. Gateway shards retain the existing
+four fresh-process boundaries and two-worker limit; UI shards retain serial
+files within each process. No tests are filtered out, and the existing
+90-minute job deadline is unchanged. Local `pnpm test:e2e` remains sequential.
+
+This trades nine builds and eight additional jobs per invocation for a shorter
+critical path and complete results from every E2E surface. Release checks use
+GitHub-hosted runners, so this adds no Blacksmith registrations there. A
+standalone dispatch using Blacksmith can register nine runners per invocation;
+the six-job concurrency cap does not reduce that total registration budget.
+
 The reusable live/E2E workflow asks `scripts/test-docker-all.mjs --plan-json` which package, image kind, live image, lane, and credential coverage is required. `scripts/docker-e2e.mjs` then converts that plan into GitHub outputs and summaries. It either packs OpenClaw through `scripts/package-openclaw-for-docker.mjs`, downloads a current-run package artifact, or downloads a package artifact from `package_artifact_run_id`, then validates the tarball inventory. The default `no-push-artifact` path builds package-digest-tagged bare/functional images through Blacksmith's Docker layer cache, packs the exact image bytes into an immutable workflow artifact, and has each consumer verify and load that artifact. `existing-only` instead requires explicit `docker_e2e_bare_image`/`docker_e2e_functional_image` GHCR refs and never builds or pushes. Those registry pulls use a bounded 180-second per-attempt timeout so a stuck stream retries quickly instead of consuming most of the CI critical path. After successful scheduled validation, `openclaw-scheduled-live-checks.yml` passes the immutable tested-image manifest to the separate package-write publisher; read-only release and prerelease callers never traverse that writer.
 
 ### Release-path chunks

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4819,18 +4819,41 @@ server.listen(0, "127.0.0.1", () => {
     const releaseChecks = parse(
       readFileSync(".github/workflows/openclaw-live-and-e2e-checks-reusable.yml", "utf8"),
     );
-    expect(releaseChecks.jobs.validate_repo_e2e.env).toMatchObject({
+    const repoE2e = releaseChecks.jobs.validate_repo_e2e;
+    expect(repoE2e.env).toMatchObject({
       OPENCLAW_BUILD_PRIVATE_QA: "1",
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1",
+      OPENCLAW_VITEST_MAX_WORKERS: "2",
     });
-    expect(releaseChecks.jobs.validate_repo_e2e["timeout-minutes"]).toBe(90);
-    const repoE2eSteps = releaseChecks.jobs.validate_repo_e2e.steps as WorkflowStep[];
+    expect(repoE2e["timeout-minutes"]).toBe(90);
+    expect(repoE2e.strategy).toMatchObject({ "fail-fast": false, "max-parallel": 6 });
+    const repoE2eRows = repoE2e.strategy.matrix.include as Array<{
+      name: string;
+      command: string;
+    }>;
+    expect(repoE2eRows.map((row) => row.command)).toEqual([
+      ...Array.from({ length: 4 }, (_, index) => `pnpm test:e2e:gateway --shard=${index + 1}/4`),
+      ...Array.from({ length: 4 }, (_, index) => `pnpm test:ui:e2e --shard=${index + 1}/4`),
+      "pnpm test:e2e:agent-plugin-gateway",
+    ]);
+    expect(new Set(repoE2eRows.map((row) => row.name)).size).toBe(9);
+    expect(repoE2e.name).toBe("Repo E2E (${{ matrix.name }})");
+    expect(repoE2e.if).toBe("inputs.include_repo_e2e && inputs.live_suite_filter == ''");
+    expect(repoE2e["continue-on-error"]).toBe("${{ inputs.advisory }}");
+    const repoE2eSteps = repoE2e.steps as WorkflowStep[];
+    expect(repoE2eSteps.find((step) => step.name === "Checkout selected ref")?.with?.ref).toBe(
+      "${{ needs.validate_selected_ref.outputs.selected_sha }}",
+    );
     const sandboxSetupIndex = repoE2eSteps.findIndex(
       (step) => step.name === "Build sandbox image" && step.run === "scripts/sandbox-setup.sh",
     );
     const repoE2eIndex = repoE2eSteps.findIndex((step) => step.name === "Run repo E2E suite");
     expect(sandboxSetupIndex).toBeGreaterThanOrEqual(0);
     expect(repoE2eIndex).toBeGreaterThan(sandboxSetupIndex);
+    expect(repoE2eSteps[repoE2eIndex]).toMatchObject({
+      run: "${{ matrix.command }}",
+      env: { OPENCLAW_E2E_WORKERS: "2", OPENCLAW_E2E_USE_PREBUILT_DIST: "1" },
+    });
     const targetedGroupStep = releaseChecks.jobs.plan_docker_lane_groups.steps.find(
       (step: WorkflowStep) => step.name === "Build targeted Docker lane groups",
     );

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -4364,15 +4364,15 @@ describe("package artifact reuse", () => {
     );
     expect(workflow).toContain("bash .release-harness/scripts/ci-live-command-retry.sh");
     expect(workflow).toContain("use_github_hosted_runners:");
-    expect(workflow).toMatch(
-      /validate_repo_e2e:[\s\S]*?runs-on: \$\{\{ inputs\.use_github_hosted_runners && 'ubuntu-24\.04' \|\| 'blacksmith-8vcpu-ubuntu-2404' \}\}/u,
-    );
-    expect(workflow).toMatch(
-      /validate_special_e2e:[\s\S]*?runs-on: \$\{\{ inputs\.use_github_hosted_runners && 'ubuntu-24\.04' \|\| 'blacksmith-8vcpu-ubuntu-2404' \}\}/u,
-    );
-    expect(workflow).toMatch(
-      /validate_live_provider_suites:[\s\S]*?runs-on: \$\{\{ inputs\.use_github_hosted_runners && 'ubuntu-24\.04' \|\| 'blacksmith-8vcpu-ubuntu-2404' \}\}/u,
-    );
+    for (const [jobName, runner] of [
+      ["validate_repo_e2e", "blacksmith-32vcpu-ubuntu-2404"],
+      ["validate_special_e2e", "blacksmith-32vcpu-ubuntu-2404"],
+      ["validate_live_provider_suites", "blacksmith-8vcpu-ubuntu-2404"],
+    ] as const) {
+      expect(workflowJob(LIVE_E2E_WORKFLOW, jobName)["runs-on"]).toBe(
+        `\${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || '${runner}' }}`,
+      );
+    }
     expect(workflow).toContain("suite_id: native-live-src-gateway-core");
     expect(workflow).toContain("suite_id: native-live-src-gateway-backends");
     expect(workflow).toContain(


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where full release verification exhausted the repository E2E job's 90-minute deadline before completing Control UI coverage. In [the failed release-check run](https://github.com/openclaw/openclaw/actions/runs/33292222398/job/99205866204), setup took nine minutes and all four Gateway partitions passed over the next 49 minutes. The standalone agent-plugin Gateway test passed, then UI cases were still passing when GitHub cancelled the job. This was sequential workload exceeding the job budget, not a hung test.

## Why This Change Was Made

The reusable workflow now schedules the existing commands as nine matrix jobs: four native Gateway shards, four duration-weighted Control UI shards, and the standalone agent-plugin Gateway test. The matrix runs at most six jobs at once and drains every row after a failure. Each row retains the selected source SHA, full private-QA build, Chromium and sandbox prerequisites, existing worker limits, and 90-minute deadline. Local `pnpm test:e2e` is unchanged.

The workflow owns this scheduling problem. No product code, test assertions, exclusions, retries, or timeouts were weakened. Existing Vitest discovery and sequencers still own membership. Shared build artifacts were deliberately not introduced: the normal CI artifact profile is not interchangeable with this full private-QA build. The tradeoff is nine builds and eight additional jobs per invocation. Full release callers use GitHub-hosted runners, adding no Blacksmith registrations; standalone Blacksmith dispatches can register nine runners, with six concurrent. The live organization registration bucket had all 10,000 registrations available during this change.

Also fixes three adjacent runner assertions that could silently match a later job because their regex crossed job boundaries. They now inspect the parsed owning jobs and preserve the existing 32/32/8-core assignments.

## User Impact

No runtime or configuration behavior changes. Maintainers receive independent failures and complete E2E results without waiting for Gateway and UI suites to run sequentially. Actual elapsed-time improvement still needs the fresh full hosted run after landing; no speedup number is claimed yet.

## Evidence

- The prior terminal log records 1,776 passing Gateway tests across 199 files, the successful standalone agent-plugin test, and 909 passing UI case records before cancellation. The one observed UI quota failure was separately repaired in #133085.
- Using Vitest 4.1.11's actual discovered specifications and configured sequencers on frozen product commit `868d728005f3d0b3e5b7719d70ec205013ed086f`: Gateway partitions are 50/50/50/49 files and exactly match all four original hosted partitions. UI partitions are 81/82/82/82 files. Both unions equal their complete inventories with zero duplicate or omitted files. This was collection-only proof, not a full test pass.
- The existing workflow guard fails against the prior sequential job and passes with the matrix. It checks all shard commands, unique job names, failure draining, concurrency, selected source, worker limits, and prerequisites.
- 500 focused workflow, runner, and release evidence contract tests passed (two pre-existing skips). Workflow security/structure checks and the complete changed-file gate passed, including test-root typechecking and scripts lint. A private pnpm fixture also verified shard arguments reach the UI script's final Vitest command.
- Independent managed Codex review passed on the final four-file diff with no actionable P0/P1/P2 findings.
- Production runtime LOC: +0/-0. Workflow: +25/-1; tests: +36/-13; documentation: +15/-0. The workflow growth expresses the fixed matrix using native Actions scheduling; no new planner or runtime path.

Provenance: the sequential command is present in the frozen failing source. The original introduction of the timeout is not attributed to a commit; growth in aggregate suite time exposed it. The existing runner sizes are intentional and unchanged.

ClawSweeper disposition: no correctness or security findings. Its hosted-matrix rank-up move will be completed immediately after landing in a fresh all-group Full Release Validation pinned to the landed tooling commit and frozen product commit above. I am choosing the review's post-merge integration option under the operator's autonomous landing request, rather than running a duplicate full E2E matrix before the required main-lineage tooling pin exists. The exact-head PR CI gate remains required before merge; no release or publication is authorized or performed. Hosted nine-row completion and timing are still pending and will be attached when observed.

Landed as `00f8d76e573402e818a7bb67c73aa2a0c250fdab` after [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33296276601) and all 128 reported checks passed. The fresh [all-group full verification](https://github.com/openclaw/openclaw/actions/runs/33296701613) is now running with that tooling commit and product `868d728005f3d0b3e5b7719d70ec205013ed086f`; evidence reuse is disabled and all package/Telegram coverage is enabled. Its result and nine-row timings are pending.

Validation correction: the isolated `868d728` assembly was rejected by the unchanged source-Telegram trust gate before its Telegram build. Its diagnostic collector continues, but it cannot supply a green full result. The authoritative replacement is [full run 33297344670](https://github.com/openclaw/openclaw/actions/runs/33297344670), using the earliest existing main commit containing all landed repairs, `b7f745ced2b4562a456ef8757f556f2d100beaab`, and the same pinned tooling `00f8d76e573402e818a7bb67c73aa2a0c250fdab`. That source is not byte-equivalent to the isolated assembly; the replacement runs every group fresh with no evidence reuse. The unchanged Telegram provenance check passed before dispatch. A focused MiniMax run on the replacement also completed both model routes through prompt/read/exec/image after the earlier run saw explicit provider refusals; no prompt, assertion, retry, or timeout change was made.

Hosted matrix proof is complete: all nine rows in [release checks 33296719912](https://github.com/openclaw/openclaw/actions/runs/33296719912) passed on Code `868d728005f3d0b3e5b7719d70ec205013ed086f` and landed Tooling `00f8d76e573402e818a7bb67c73aa2a0c250fdab`. The complete six-concurrent wave ran from 06:23:32Z to 07:04:09Z: **40m37s**, versus the previous combined job cancelling at 90m14s while still executing UI coverage. This fulfills the nine-row rank-up proof; it is not a green full-release claim, since that parent independently failed the unchanged Telegram provenance gate. The replacement main-ancestor candidate still runs all groups fresh.

| Row | Result | Job duration |
| --- | --- | --- |
| [Agent plugin Gateway](https://github.com/openclaw/openclaw/actions/runs/33296719912/job/99217717910) | Passed | 7m59s |
| [Gateway 1/4](https://github.com/openclaw/openclaw/actions/runs/33296719912/job/99217717947) | Passed | 17m47s |
| [Gateway 2/4](https://github.com/openclaw/openclaw/actions/runs/33296719912/job/99217717981) | Passed | 20m10s |
| [Gateway 3/4](https://github.com/openclaw/openclaw/actions/runs/33296719912/job/99217717879) | Passed | 20m49s |
| [Gateway 4/4](https://github.com/openclaw/openclaw/actions/runs/33296719912/job/99217717884) | Passed | 18m55s |
| [UI 1/4](https://github.com/openclaw/openclaw/actions/runs/33296719912/job/99217717891) | Passed | 22m45s |
| [UI 2/4](https://github.com/openclaw/openclaw/actions/runs/33296719912/job/99217717888) | Passed | 22m19s |
| [UI 3/4](https://github.com/openclaw/openclaw/actions/runs/33296719912/job/99217717984) | Passed | 20m53s |
| [UI 4/4](https://github.com/openclaw/openclaw/actions/runs/33296719912/job/99217717918) | Passed | 21m29s |
