### PR TITLE
feat(sessions): include categories in JSON output

### DIFF
--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -61,9 +61,9 @@ for a smaller/larger window or `--limit all` when you intentionally need the
 full store. JSON responses include `totalCount`, `limitApplied`, and `hasMore`
 when callers need to show that more rows exist.
 
-JSON session rows include `color` when a session color is set (for example,
-`"color": "blue"`). Uncolored sessions and sessions whose color was cleared omit
-the field.
+JSON session rows include `color` and `category` when those values are set (for
+example, `"color": "blue"` and `"category": "Research"`). Sessions without those
+values omit the corresponding fields.
 
 RPC clients can pass `configuredAgentsOnly: true` to keep the broad combined
 discovery source but return only rows for agents currently present in config.

--- a/src/commands/sessions-table.ts
+++ b/src/commands/sessions-table.ts
@@ -30,6 +30,7 @@ export type SessionDisplayRow = {
   lastInteractionAt?: number;
   label?: string;
   color?: string;
+  category?: string;
   status?: SessionEntry["status"];
   visibility?: SessionEntry["visibility"];
   createdActor?: SessionEntry["createdActor"];
@@ -78,6 +79,7 @@ export function toSessionDisplayRow(key: string, entry: SessionEntry): SessionDi
     lastInteractionAt: entry?.lastInteractionAt,
     label: entry?.label,
     color: entry?.color,
+    category: entry?.category,
     status: entry?.status,
     visibility: entry?.visibility ?? "shared",
     createdActor: entry?.createdActor,

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -494,7 +494,7 @@ describe("sessionsCommand", () => {
     ]);
   });
 
-  it("exports session color and subagent lineage metadata in JSON output", async () => {
+  it("exports session color, category, and subagent lineage metadata in JSON output", async () => {
     const store = await writeStore({
       "agent:main:child": {
         sessionId: "child-session",
@@ -511,6 +511,7 @@ describe("sessionsCommand", () => {
         lastInteractionAt: Date.now() - 5 * 60_000,
         label: "research helper",
         color: "blue",
+        category: "Research",
         status: "done",
         model: "test:opus",
       },
@@ -542,6 +543,7 @@ describe("sessionsCommand", () => {
         lastInteractionAt?: number;
         label?: string;
         color?: string;
+        category?: string;
         status?: string;
       }>;
     }>(sessionsCommand, store);
@@ -560,6 +562,7 @@ describe("sessionsCommand", () => {
       lastInteractionAt: Date.now() - 5 * 60_000,
       label: "research helper",
       color: "blue",
+      category: "Research",
       status: "done",
     });
     expect(child).not.toHaveProperty("sessionFile");


### PR DESCRIPTION
Closes #133108

## What Problem This Solves

Session categories are canonical persisted metadata used by Gateway and Control UI grouping and by agent session tooling, but `openclaw sessions --json` drops `SessionEntry.category` from its shared display row. Offline scripts cannot group or filter the same stored sessions without opening private SQLite state or requiring a running Gateway.

Current `main` already projects adjacent stored metadata such as color, label, status, and subagent lineage through the same owner. Category is the bounded projection gap.

## Why This Change Was Made

The existing `SessionDisplayRow` / `toSessionDisplayRow` owner now carries the optional stored category. The existing sessions JSON behavior test covers the field alongside color and lineage, and the CLI reference documents that both optional fields are omitted when unset.

This keeps the behavior in the canonical shared projection used by the sessions CLI rather than adding a second read path, direct database query, new flag, or table-specific branch.

Existing-solutions preflight: Gateway and agent session tools expose category only when those runtimes are available; they do not replace offline CLI JSON. A plugin or external library cannot repair a core projection omission. Direct SQLite access is private-state coupling. Open PRs #124540 and #115808 touch the same mapper for archive/runtime and model-resolution projections respectively, but neither implements category output. Maintainer PR #132982 recently established the same owner, test, and documentation path for stored session color.

## User Impact

Operators and scripts using `openclaw sessions --json` can now read a stored category such as `Research` and apply the same grouping or filtering available on other session surfaces. Rows without a category keep omitting the field.

Human table output, sorting, filtering, limits, color, lineage, persistence, and mutation behavior are unchanged.

## Evidence

Acceptance red, captured before the production edit:

- A categorized SQLite-backed session was listed through the existing sessions JSON command path.
- The focused assertion failed with the sole relevant difference that `category: "Research"` was missing from the JSON row.

Acceptance green on exact head `88385b0e2e` (Node 24.18.0):

    OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs src/commands/sessions.test.ts -t 'exports session color, category, and subagent lineage metadata in JSON output'
    Test Files  1 passed (1)
    Tests       1 passed | 24 skipped (25)

The complete `src/commands/sessions.test.ts` file also passed 25/25 on the identical patch before the final rebase over an unrelated `main` commit; the three target files were unchanged by that rebase.

Exact-head production-owner readback used an isolated SQLite state directory, persisted a categorized session through `upsertSessionEntryCore`, read it through `listSessionEntriesReadOnly`, and serialized the production `toSessionDisplayRow` result:

    session key=agent:main:proof
    stored category=Research
    JSON row category=Research
    categoryPresent=true

Additional exact-head checks:

    node_modules/.bin/oxfmt --check docs/cli/sessions.md src/commands/sessions-table.ts src/commands/sessions.test.ts
    All matched files use the correct format.

    git diff --check upstream/main...HEAD
    (clean)

    .agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main
    autoreview scoped-clean: no accepted/actionable findings
    overall: patch is correct (0.99)

Documentation ownership was confirmed by the direct read-only index command:

    node scripts/docs-list.js
    cli/sessions.md - CLI reference for openclaw sessions

Change size:

- Production: +2 LOC
- Tests: +4 / -1 LOC
- Docs: +3 / -3 LOC
- Files: 3
- Generated/lock files: none

Compatibility and risk:

- Additive optional JSON property only.
- No config, default, protocol, schema, persistence, migration, security, provider, or network changes.
- Existing consumers that ignore unknown JSON fields are unaffected.
- Known local environment gap: the `pnpm docs:list` wrapper requested dependency reconciliation and stopped at the non-interactive purge guard; the underlying read-only docs index script passed. A full built CLI run was not claimed because the shared checkout dependency tree is stale. The production SQLite accessor-to-mapper behavior was exercised directly.

AI-assisted discovery and implementation. Source owners, callers, sibling projections, current `main`, history, tests, documentation, and live competing issues/PRs were reviewed. No secrets or personal data are included.
