### PR TITLE
fix(codex): avoid startup failures from unrelated unreadable processes

### DIFF
--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -92,14 +92,21 @@ or discover descendants that independently reparented before inspection.
 
 Linux reads process identities directly from `/proc`, including the boot ID
 and process start ticks, so Alpine/BusyBox installations do not need `procps`.
-macOS uses its native `ps` with a fixed locale and timezone.
+macOS uses its native `ps` with a fixed locale and timezone. Registration checks
+inspect only the observer and the relevant parent and child processes; an
+unrelated unreadable process does not block those checks. Destructive cleanup
+still requires full process-tree inspection and fresh identity checks before
+signaling.
 
-If process inspection or bounded cleanup cannot confirm that the registered
-orphan is gone, the new stdio connection fails instead of spawning another
-child. Follow the reported action: check `/proc` access on Linux or `ps` on
-macOS, or verify and stop
-the reported orphan process, then retry. If the cleanup budget expires, retry
-to finish the remaining registrations.
+If a required process cannot be inspected or bounded cleanup cannot confirm that
+the registered orphan is gone, the new stdio connection fails instead of spawning
+another child. Follow the reported reason: a deadline failure calls for checking
+host load and Gateway logs, while an access-denied failure calls for checking
+`/proc` access on Linux or `ps` permissions on macOS. Other inspection failures
+require checking that the process-inspection facility is available and returning
+usable data. Do not broaden permissions to address a timeout. If cleanup cannot
+stop a verified orphan, inspect and stop that process before retrying. If the
+cleanup budget expires, retry to finish the remaining registrations.
 
 This recovery requires a spawn-time registration. It does not discover
 unregistered children left by an older OpenClaw version or scan command names

--- a/extensions/codex/src/app-server/attempt-startup-retry.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup-retry.test.ts
@@ -250,7 +250,7 @@ describe("Codex app-server startup retry", () => {
           expect(exited).toBe(true);
           expect(exitDelivered).toBe(false);
           expect(firstChild.exitCode).toBeNull();
-          return undefined;
+          throw new processSnapshot.ProcessInspectionError("unavailable");
         });
       try {
         const result = await startFixtureAttempt(fixture, factory);
@@ -402,7 +402,7 @@ describe("Codex app-server startup retry", () => {
           expect(error).toBeInstanceOf(Error);
           expect(isCodexAppServerConnectionClosedError(error)).toBe(false);
           expect((error as Error).message).toContain(
-            failure === "commit" ? "512-row limit" : "Cannot register the Codex child process",
+            failure === "commit" ? "512-row limit" : "Process inspection exceeded its deadline",
           );
           expect((error as Error).message).toContain("startup diagnostic: inspection probe");
           expect(await fs.readFile(fixture.spawnCountPath, "utf8")).toBe("1");

--- a/extensions/codex/src/app-server/transport-orphan.test.ts
+++ b/extensions/codex/src/app-server/transport-orphan.test.ts
@@ -135,7 +135,7 @@ describe.skipIf(process.platform === "win32")("Codex stdio crash recovery", () =
 
       if (process.platform !== "linux") {
         await expect(start(stateDir, unavailablePs)).rejects.toThrow(
-          "Cannot inspect registered Codex processes",
+          "Cannot inspect Codex processes. Process identity is unavailable or invalid.",
         );
         expect(isAlive(old.tree.child)).toBe(true);
       }

--- a/extensions/codex/src/app-server/transport-process-containment.ts
+++ b/extensions/codex/src/app-server/transport-process-containment.ts
@@ -38,7 +38,9 @@ export async function terminateCodexAppServerOrphan(
   let gone = false;
   try {
     if (contained) {
-      const current = await readCodexAppServerProcess(expected.pid, deadline);
+      const current = await readCodexAppServerProcess(expected.pid, deadline).catch(
+        () => undefined,
+      );
       if (current && isSameLiveRoot(current, contained.root, true)) {
         // Keep the verified leader stopped until its whole group is killed;
         // a QA-owned child may share its parent's group and must use its PID.
@@ -46,7 +48,7 @@ export async function terminateCodexAppServerOrphan(
       }
     }
     while (Date.now() < deadline) {
-      const snapshot = await readCodexAppServerProcessSnapshot(deadline);
+      const snapshot = await readCodexAppServerProcessSnapshot(deadline).catch(() => undefined);
       if (!snapshot?.some((row) => row.pid === process.pid)) {
         return false;
       }
@@ -82,7 +84,8 @@ async function containDescendants(
   if (process.platform === "win32" || !rootPid || !child.kill) {
     return undefined;
   }
-  const snapshot = await readCodexAppServerProcessSnapshot(deadline);
+  // Inspection failures never grant containment or signal authority.
+  const snapshot = await readCodexAppServerProcessSnapshot(deadline).catch(() => undefined);
   if (!snapshot || Date.now() >= deadline) {
     return undefined;
   }
@@ -177,7 +180,7 @@ async function quiesceDescendants(
     if (Date.now() >= deadline) {
       return undefined;
     }
-    const snapshot = await readCodexAppServerProcessSnapshot(deadline);
+    const snapshot = await readCodexAppServerProcessSnapshot(deadline).catch(() => undefined);
     if (!snapshot || Date.now() >= deadline) {
       return undefined;
     }
@@ -325,7 +328,7 @@ async function signalSameRoot(
   signal: NodeJS.Signals,
   deadline: number,
 ): Promise<boolean> {
-  const current = await readCodexAppServerProcess(root.pid, deadline);
+  const current = await readCodexAppServerProcess(root.pid, deadline).catch(() => undefined);
   return Boolean(current && isSameLiveRoot(current, root) && signalProcess(current.pid, signal));
 }
 
@@ -358,7 +361,7 @@ async function signalSameProcess(
 ): Promise<boolean> {
   // Portable Node POSIX signals are PID-based, so never retain numeric authority:
   // take this final identity snapshot synchronously immediately before every signal.
-  const current = await readCodexAppServerProcess(expected.pid, deadline);
+  const current = await readCodexAppServerProcess(expected.pid, deadline).catch(() => undefined);
   return Boolean(
     current && isSameLiveProcess(current, expected) && signalProcess(current.pid, signal),
   );

--- a/extensions/codex/src/app-server/transport-process-registration.procfs.test.ts
+++ b/extensions/codex/src/app-server/transport-process-registration.procfs.test.ts
@@ -1,0 +1,225 @@
+import { ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import { PassThrough } from "node:stream";
+import { createPluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-store-runtime";
+import { createOpenClawTestState } from "openclaw/plugin-sdk/test-state";
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
+import { terminateCodexAppServerOrphan } from "./transport-process-containment.js";
+import { prepareCodexAppServerProcessRegistration } from "./transport-process-registration.js";
+import { readCodexAppServerProcessSnapshot } from "./transport-process-snapshot.js";
+
+const procfs = vi.hoisted(() => ({ files: new Map<string, string | Error>() }));
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...original,
+    readFile: (...args: Parameters<typeof original.readFile>) => {
+      const file = args[0];
+      if (typeof file !== "string" || !file.startsWith("/proc/")) {
+        return original.readFile(...args);
+      }
+      const value = procfs.files.get(file);
+      return typeof value === "string"
+        ? Promise.resolve(value)
+        : Promise.reject(value ?? Object.assign(new Error("gone"), { code: "ENOENT" }));
+    },
+    readdir: (...args: Parameters<typeof original.readdir>) =>
+      args[0] === "/proc"
+        ? Promise.resolve(
+            [...procfs.files.keys()].flatMap(
+              (file) => /^\/proc\/(\d+)\/stat$/.exec(file)?.[1] ?? [],
+            ),
+          )
+        : original.readdir(...args),
+  };
+});
+
+const bootId = "00000000-0000-0000-0000-000000000001";
+const identity = (pid: number) => ({ pid, pgid: pid, startedAt: `${bootId}:12345` });
+const parent = identity(500001);
+const child = identity(500002);
+const neighbor = 500003;
+const command = "/opt/codex app-server --listen stdio://";
+const commandFingerprint = createHash("sha256").update(command).digest("hex");
+
+function addProcess(pid: number, ppid: number) {
+  procfs.files.set(
+    `/proc/${pid}/stat`,
+    `${pid} (worker) S ${ppid} ${pid}${" 0".repeat(16)} 12345\n`,
+  );
+  procfs.files.set(`/proc/${pid}/cmdline`, command.replaceAll(" ", "\0"));
+}
+
+describe("Codex registration procfs boundary", () => {
+  let state: Awaited<ReturnType<typeof createOpenClawTestState>>;
+  let store: ReturnType<
+    typeof createPluginStateSyncKeyedStore<{
+      parent: ReturnType<typeof identity>;
+      child: ReturnType<typeof identity> & { commandFingerprint: string };
+    }>
+  >;
+  let kill: MockInstance<typeof process.kill>;
+
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ prefix: "codex-registration-procfs-" });
+    store = createPluginStateSyncKeyedStore("codex", {
+      namespace: "app-server-processes",
+      maxEntries: 512,
+      overflowPolicy: "reject-new",
+    });
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    // Synthetic PIDs must never reach the real signal syscall, even on regression.
+    kill = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw new Error("unexpected signal");
+    });
+    procfs.files.set("/proc/sys/kernel/random/boot_id", bootId);
+    addProcess(process.pid, process.ppid);
+    addProcess(parent.pid, 1);
+    addProcess(child.pid, parent.pid);
+    procfs.files.set(
+      `/proc/${neighbor}/stat`,
+      Object.assign(new Error("unreadable neighbor"), { code: "EACCES" }),
+    );
+  });
+
+  afterEach(async () => {
+    store.clear();
+    vi.restoreAllMocks();
+    procfs.files.clear();
+    await state.cleanup();
+  });
+
+  it("preserves a live owner's registration despite an unreadable unrelated process", async () => {
+    const registration = { parent, child: { ...child, commandFingerprint } };
+    store.register("owned", registration);
+
+    await expect(
+      Promise.all([
+        prepareCodexAppServerProcessRegistration(),
+        prepareCodexAppServerProcessRegistration(),
+      ]),
+    ).resolves.toHaveLength(2);
+
+    expect(store.lookup("owned")).toEqual(registration);
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it.for(["readable", "permission", "malformed", "deadline", "missing-observer"])(
+    "registers a direct child despite an unreadable unrelated process only with usable ownership: %s",
+    async (mode, ctx) => {
+      addProcess(child.pid, process.pid);
+      const stdin = new PassThrough();
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const spawned = Object.assign(new ChildProcess(), {
+        pid: child.pid,
+        stdin,
+        stdout,
+        stderr,
+        stdio: [stdin, stdout, stderr, null, null] as [
+          PassThrough,
+          PassThrough,
+          PassThrough,
+          null,
+          null,
+        ],
+      });
+      ctx.onTestFinished(() => {
+        stdin.destroy();
+        stdout.destroy();
+        stderr.destroy();
+        spawned.removeAllListeners();
+      });
+      const register = await prepareCodexAppServerProcessRegistration();
+      if (mode === "missing-observer") {
+        procfs.files.delete(`/proc/${process.pid}/stat`);
+      } else if (mode !== "readable") {
+        procfs.files.set(
+          `/proc/${child.pid}/stat`,
+          mode === "malformed"
+            ? ""
+            : Object.assign(new Error("child inspection failed"), {
+                code: mode === "deadline" ? "ABORT_ERR" : "EACCES",
+              }),
+        );
+      }
+      const registered = register(spawned);
+      spawned.emit("spawn");
+
+      if (mode !== "readable") {
+        await expect(registered).rejects.toMatchObject({
+          reason: mode === "permission" || mode === "deadline" ? mode : "unavailable",
+        });
+        expect(store.entries()).toEqual([]);
+        expect(kill).not.toHaveBeenCalled();
+        return;
+      }
+      await registered;
+
+      expect(store.entries().map((entry) => entry.value)).toEqual([
+        { parent: identity(process.pid), child: { ...child, commandFingerprint } },
+      ]);
+      expect(kill).not.toHaveBeenCalled();
+      spawned.emit("exit", 0, null);
+      expect(store.entries()).toEqual([]);
+    },
+  );
+
+  it.for([
+    ["permission", "EACCES"],
+    ["unavailable", "EIO"],
+    ["deadline", "ABORT_ERR"],
+    ["unavailable", "empty"],
+    ["unavailable", "group-zero"],
+    ["unavailable", "missing-observer"],
+  ] as const)(
+    "retains registrations when required identity inspection fails: %s/%s",
+    async ([reason, fault]) => {
+      const registration = { parent, child: { ...child, commandFingerprint } };
+      store.register("owned", registration);
+      if (fault === "missing-observer") {
+        procfs.files.delete(`/proc/${process.pid}/stat`);
+      } else {
+        procfs.files.set(
+          `/proc/${parent.pid}/stat`,
+          fault === "empty"
+            ? ""
+            : fault === "group-zero"
+              ? `${parent.pid} (worker) S 1 0${" 0".repeat(16)} 12345\n`
+              : Object.assign(new Error("required inspection failed"), { code: fault }),
+        );
+      }
+
+      await expect(prepareCodexAppServerProcessRegistration()).rejects.toMatchObject({ reason });
+      expect(store.lookup("owned")).toEqual(registration);
+      expect(kill).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps full-tree inspection fail-closed with the same unreadable neighbor", async () => {
+    await expect(readCodexAppServerProcessSnapshot()).rejects.toMatchObject({
+      reason: "permission",
+    });
+    await expect(terminateCodexAppServerOrphan(child)).resolves.toBe(false);
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it.for(["ENOENT", "ESRCH"])(
+    "retires verified disappeared identities only after full containment inspection: %s",
+    async (code) => {
+      store.register("orphan", { parent, child: { ...child, commandFingerprint } });
+      for (const pid of [parent.pid, child.pid]) {
+        procfs.files.set(`/proc/${pid}/stat`, Object.assign(new Error("gone"), { code }));
+      }
+      // Selected identities are gone, but an unreadable full tree still blocks retirement.
+      await expect(prepareCodexAppServerProcessRegistration()).rejects.toThrow(
+        "Cannot reap registered Codex process",
+      );
+      expect(store.lookup("orphan")).toBeDefined();
+      procfs.files.delete(`/proc/${neighbor}/stat`);
+      await prepareCodexAppServerProcessRegistration();
+      expect(store.lookup("orphan")).toBeUndefined();
+      expect(kill).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/extensions/codex/src/app-server/transport-process-registration.test.ts
+++ b/extensions/codex/src/app-server/transport-process-registration.test.ts
@@ -12,7 +12,7 @@ import {
   prepareCodexAppServerProcessRegistration,
 } from "./transport-process-registration.js";
 import {
-  readCodexAppServerProcess,
+  ProcessInspectionError,
   readCodexAppServerProcessCommand,
   readCodexAppServerProcessSnapshot,
   type PosixProcess,
@@ -21,7 +21,6 @@ import {
 vi.mock("./transport-process-snapshot.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./transport-process-snapshot.js")>()),
   readCodexAppServerProcessSnapshot: vi.fn(),
-  readCodexAppServerProcess: vi.fn(),
   readCodexAppServerProcessCommand: vi.fn(),
 }));
 
@@ -107,10 +106,15 @@ describe("Codex process registration", () => {
     "lets containment settle a %s child after command inspection fails",
     async (mode) => {
       store.register("orphan", { parent, child: { ...child, commandFingerprint } });
-      vi.mocked(readCodexAppServerProcessCommand).mockResolvedValue(undefined);
-      vi.mocked(readCodexAppServerProcess).mockResolvedValue(
-        mode === "gone" ? undefined : { ...liveChild, startedAt: "a later start" },
+      vi.mocked(readCodexAppServerProcessCommand).mockRejectedValue(
+        new ProcessInspectionError("permission"),
       );
+      vi.mocked(readCodexAppServerProcessSnapshot)
+        .mockResolvedValueOnce([observer, liveChild])
+        .mockResolvedValue([
+          observer,
+          ...(mode === "gone" ? [] : [{ ...liveChild, startedAt: "a later start" }]),
+        ]);
 
       await expect(prepareCodexAppServerProcessRegistration()).resolves.toBeTypeOf("function");
 
@@ -122,19 +126,28 @@ describe("Codex process registration", () => {
     },
   );
 
-  it("refuses a spawn and retains the row when the matching child's command is unreadable", async () => {
-    const registration = { parent, child: { ...child, commandFingerprint } };
-    store.register("orphan", registration);
-    vi.mocked(readCodexAppServerProcessCommand).mockResolvedValue(undefined);
-    vi.mocked(readCodexAppServerProcess).mockResolvedValue(liveChild);
+  it.for(["live", "unknown"])(
+    "retains an unreadable-command registration when the child is %s",
+    async (mode) => {
+      const registration = { parent, child: { ...child, commandFingerprint } };
+      store.register("orphan", registration);
+      vi.mocked(readCodexAppServerProcessCommand).mockRejectedValue(
+        new ProcessInspectionError("permission"),
+      );
+      if (mode === "unknown") {
+        vi.mocked(readCodexAppServerProcessSnapshot)
+          .mockResolvedValueOnce([observer, liveChild])
+          .mockRejectedValue(new ProcessInspectionError("unavailable"));
+      }
 
-    await expect(prepareCodexAppServerProcessRegistration()).rejects.toThrow(
-      `Cannot inspect registered Codex process ${child.pid} command. Check process command inspection permissions (/proc on Linux, ps on macOS), then retry.`,
-    );
+      await expect(prepareCodexAppServerProcessRegistration()).rejects.toMatchObject({
+        reason: mode === "live" ? "permission" : "unavailable",
+      });
 
-    expect(store.lookup("orphan")).toEqual(registration);
-    expect(terminateCodexAppServerOrphan).not.toHaveBeenCalled();
-  });
+      expect(store.lookup("orphan")).toEqual(registration);
+      expect(terminateCodexAppServerOrphan).not.toHaveBeenCalled();
+    },
+  );
 
   it.for(["gone", "zombie", "replaced"])(
     "skips command inspection when the snapshot child is %s",
@@ -211,7 +224,10 @@ describe("Codex process registration", () => {
           Object.defineProperty(spawned, "exitCode", { value: 0, configurable: true });
           spawned.emit("exit", 0, null);
         }
-        return mode === "unreadable command" ? undefined : command;
+        if (mode === "unreadable command") {
+          throw new ProcessInspectionError("permission");
+        }
+        return command;
       });
       const register = await prepareCodexAppServerProcessRegistration();
       const registered = register(spawned);
@@ -237,7 +253,11 @@ describe("Codex process registration", () => {
         spawned.emit("exit", 0, null);
         expect(store.entries()).toEqual([]);
       } else {
-        await expect(registered).rejects.toThrow("Cannot register the Codex child process command");
+        await expect(registered).rejects.toThrow(
+          mode === "unreadable command"
+            ? "Cannot inspect Codex processes"
+            : "Cannot register the Codex child process command",
+        );
         expect(store.entries()).toEqual([]);
       }
     },

--- a/extensions/codex/src/app-server/transport-process-registration.ts
+++ b/extensions/codex/src/app-server/transport-process-registration.ts
@@ -5,7 +5,7 @@ import type { OpenClawPluginService } from "openclaw/plugin-sdk/plugin-entry";
 import { z } from "zod";
 import { terminateCodexAppServerOrphan } from "./transport-process-containment.js";
 import {
-  readCodexAppServerProcess,
+  ProcessInspectionError,
   readCodexAppServerProcessCommand,
   readCodexAppServerProcessSnapshot,
 } from "./transport-process-snapshot.js";
@@ -51,12 +51,10 @@ async function reapRegisteredCodexAppServerOrphans(requestedDeadline?: number): 
       throw new Error("Codex orphan cleanup exceeded its startup budget. Retry to finish cleanup.");
     }
     const registration = registrationSchema.parse(entry.value);
-    const snapshot = await readCodexAppServerProcessSnapshot();
-    if (!snapshot?.some((row) => row.pid === process.pid)) {
-      throw new Error(
-        "Cannot inspect registered Codex processes. Check process inspection permissions (/proc on Linux, ps on macOS), then retry.",
-      );
-    }
+    const snapshot = await readCodexAppServerProcessSnapshot(undefined, [
+      registration.parent.pid,
+      registration.child.pid,
+    ]);
     const parent = snapshot.find((row) => row.pid === registration.parent.pid);
     if (parent?.startedAt === registration.parent.startedAt && !parent.state.startsWith("Z")) {
       continue;
@@ -67,15 +65,22 @@ async function reapRegisteredCodexAppServerOrphans(requestedDeadline?: number): 
       child?.startedAt === registration.child.startedAt &&
       !child.state.startsWith("Z")
     ) {
-      const command = await readCodexAppServerProcessCommand(registration.child.pid, deadline);
-      if (command === undefined) {
-        const current = await readCodexAppServerProcess(registration.child.pid, deadline);
+      let command: string | undefined;
+      try {
+        command = await readCodexAppServerProcessCommand(registration.child.pid, deadline);
+      } catch (error) {
+        // Only a successful inspection may revoke the fingerprint obligation.
+        const current = (
+          await readCodexAppServerProcessSnapshot(deadline, [registration.child.pid])
+        ).find((row) => row.pid === registration.child.pid);
         if (current?.startedAt === registration.child.startedAt) {
-          throw new Error(
-            `Cannot inspect registered Codex process ${registration.child.pid} command. Check process command inspection permissions (/proc on Linux, ps on macOS), then retry.`,
-          );
+          throw error;
         }
-      } else if (fingerprintProcessCommand(command) !== registration.child.commandFingerprint) {
+      }
+      if (
+        command !== undefined &&
+        fingerprintProcessCommand(command) !== registration.child.commandFingerprint
+      ) {
         // macOS lstart has second granularity: a replacement can inherit pid +
         // startedAt. A different command revokes kill authority; Linux already
         // uses tick-granular start identities.
@@ -125,18 +130,21 @@ export async function prepareCodexAppServerProcessRegistration(): Promise<
   const store = await openProcessRegistrationStore();
   return async (child) => {
     await once(child, "spawn");
-    const snapshot = await readCodexAppServerProcessSnapshot();
-    const parent = snapshot?.find((row) => row.pid === process.pid);
-    const spawned = snapshot?.find((row) => row.pid === child.pid);
+    if (!child.pid) {
+      throw new ProcessInspectionError("unavailable");
+    }
+    const snapshot = await readCodexAppServerProcessSnapshot(undefined, [child.pid]);
+    const parent = snapshot.find((row) => row.pid === process.pid);
+    const spawned = snapshot.find((row) => row.pid === child.pid);
     if (!parent || !spawned || spawned.ppid !== process.pid) {
       throw new Error(
-        "Cannot register the Codex child process. Check process inspection permissions (/proc on Linux, ps on macOS), then retry.",
+        "Cannot register the Codex child process: its direct-parent identity is unavailable. Retry.",
       );
     }
     const command = await readCodexAppServerProcessCommand(spawned.pid, Date.now() + 2_000);
-    if (command === undefined || child.exitCode !== null || child.signalCode !== null) {
+    if (child.exitCode !== null || child.signalCode !== null) {
       throw new Error(
-        "Cannot register the Codex child process command. Check process command inspection permissions (/proc on Linux, ps on macOS), then retry.",
+        "Cannot register the Codex child process command: the child exited during inspection. Retry.",
       );
     }
     const key = randomUUID();

--- a/extensions/codex/src/app-server/transport-process-snapshot.test.ts
+++ b/extensions/codex/src/app-server/transport-process-snapshot.test.ts
@@ -38,11 +38,12 @@ describe("Codex procfs command inspector", () => {
       input: "/opt/codex\0app-server\0--listen\0stdio://\0",
       expected: "/opt/codex app-server --listen stdio://",
     },
-    { input: "", expected: undefined },
-    { input: "\0", expected: undefined },
-    { code: "ENOENT", expected: undefined },
-    { code: "ESRCH", expected: undefined },
-    { code: "EACCES", expected: undefined },
+    { input: "", reason: "unavailable" },
+    { input: "\0", reason: "unavailable" },
+    { code: "ENOENT", reason: "unavailable" },
+    { code: "ESRCH", reason: "unavailable" },
+    { code: "EACCES", reason: "permission" },
+    { code: "ABORT_ERR", reason: "deadline" },
   ])(
     "reads command identity without authorizing absent or unreadable processes: %j",
     async (fixture, ctx) => {
@@ -59,24 +60,37 @@ describe("Codex procfs command inspector", () => {
         return fixture.input!;
       });
 
-      expect(await readCodexAppServerProcessCommand(process.pid, Date.now() + 1_000)).toBe(
-        fixture.expected,
-      );
+      const inspected = readCodexAppServerProcessCommand(process.pid, Date.now() + 1_000);
+      if (fixture.reason) {
+        await expect(inspected).rejects.toMatchObject({ reason: fixture.reason });
+        if (fixture.reason !== "permission") {
+          await expect(inspected).rejects.not.toThrow("permissions");
+        }
+        if (fixture.reason === "deadline") {
+          await expect(inspected).rejects.toThrow("deadline");
+        }
+      } else {
+        await expect(inspected).resolves.toBe(fixture.expected);
+      }
       procfs.readFile.mockClear();
-      expect(await readCodexAppServerProcessCommand(process.pid, Date.now() - 1)).toBeUndefined();
+      await expect(
+        readCodexAppServerProcessCommand(process.pid, Date.now() - 1),
+      ).rejects.toMatchObject({ reason: "deadline" });
       expect(procfs.readFile).not.toHaveBeenCalled();
     },
   );
 });
 
-describe.skipIf(process.platform !== "linux")("Codex procfs process inspector", () => {
+describe("Codex procfs process inspector", () => {
   it.for(["ENOENT", "ESRCH", "EACCES"] as const)(
     "distinguishes a vanished neighbor from unreadable state: %s",
     async (code, ctx) => {
       ctx.onTestFinished(() => {
         procfs.readFile.mockReset();
         procfs.readdir.mockReset();
+        vi.restoreAllMocks();
       });
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
       const bootId = "00000000-0000-0000-0000-000000000001";
       const neighborPid = process.pid + 1;
       procfs.readdir.mockResolvedValue([String(process.pid), String(neighborPid)]);
@@ -93,20 +107,20 @@ describe.skipIf(process.platform !== "linux")("Codex procfs process inspector", 
         }
         throw new Error(`Unexpected procfs read: ${file}`);
       });
-      const snapshot = await readCodexAppServerProcessSnapshot();
-      expect(snapshot).toEqual(
-        code === "EACCES"
-          ? undefined
-          : [
-              {
-                pid: process.pid,
-                ppid: process.ppid,
-                pgid: process.pid,
-                state: "S",
-                startedAt: `${bootId}:12345`,
-              },
-            ],
-      );
+      const snapshot = readCodexAppServerProcessSnapshot();
+      if (code === "EACCES") {
+        await expect(snapshot).rejects.toMatchObject({ reason: "permission" });
+      } else {
+        await expect(snapshot).resolves.toEqual([
+          {
+            pid: process.pid,
+            ppid: process.ppid,
+            pgid: process.pid,
+            state: "S",
+            startedAt: `${bootId}:12345`,
+          },
+        ]);
+      }
     },
   );
 });
@@ -114,6 +128,36 @@ describe.skipIf(process.platform !== "linux")("Codex procfs process inspector", 
 describe.skipIf(process.platform === "win32" || process.platform === "linux")(
   "Codex POSIX process inspector",
   () => {
+    it.for(["gone", "missing observer", "malformed"])(
+      "requires complete selected ps evidence when the target is %s",
+      async (mode, ctx) => {
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-ps-selected-"));
+        ctx.onTestFinished(() => fs.rm(tempDir, { recursive: true, force: true }));
+        await fs.writeFile(
+          path.join(tempDir, "ps"),
+          `#!/usr/bin/env node
+const selected = process.argv[process.argv.indexOf("-p") + 1]?.split(",");
+if (selected?.includes("${process.pid}") && ${JSON.stringify(mode)} !== "missing observer") {
+  console.log("${process.pid} ${process.ppid} ${process.pid} S Sat Aug 29 10:00:00 2026");
+}
+if (${JSON.stringify(mode)} === "malformed") console.log("unusable selected process");
+`,
+          { mode: 0o755 },
+        );
+        await withEnvAsync(
+          { PATH: `${tempDir}${path.delimiter}${process.env.PATH ?? ""}` },
+          async () => {
+            const inspected = readCodexAppServerProcessSnapshot(undefined, [process.pid + 1]);
+            if (mode === "gone") {
+              await expect(inspected).resolves.toMatchObject([{ pid: process.pid }]);
+            } else {
+              await expect(inspected).rejects.toMatchObject({ reason: "unavailable" });
+            }
+          },
+        );
+      },
+    );
+
     it.for([
       ["snapshot", "unavailable"],
       ["snapshot", "hung"],
@@ -158,12 +202,14 @@ ${mode === "unavailable" ? "process.exit(1);" : "setInterval(() => {}, 1000);"}
             const budgetMs = 1_000;
             const result =
               kind === "command"
-                ? await readCodexAppServerProcessCommand(process.pid, startedAt + budgetMs)
-                : await readCodexAppServerProcessSnapshot(startedAt + budgetMs);
+                ? readCodexAppServerProcessCommand(process.pid, startedAt + budgetMs)
+                : readCodexAppServerProcessSnapshot(startedAt + budgetMs);
+            await expect(result).rejects.toMatchObject({
+              reason: mode === "hung" ? "deadline" : "unavailable",
+            });
             const pid = Number(await fs.readFile(pidPath, "utf8"));
             inspectorPid = pid;
             expect(pid).toBeGreaterThan(0);
-            expect(result).toBeUndefined();
             // Allow scheduler jitter, but not the inspector's unbounded event loop.
             expect(Date.now() - startedAt).toBeLessThan(budgetMs + 500);
             await expect.poll(() => isPidAlive(pid)).toBe(false);

--- a/extensions/codex/src/app-server/transport-process-snapshot.ts
+++ b/extensions/codex/src/app-server/transport-process-snapshot.ts
@@ -13,12 +13,53 @@ const PROCESS_COLUMNS = "pid=,ppid=,pgid=,stat=,lstart=";
 const MAX_PROCESS_CONTAINMENT_MS = 2_000;
 const PROCESS_INSPECTION_MAX_BYTES = 8 * 1024 * 1024;
 
+export class ProcessInspectionError extends Error {
+  constructor(readonly reason: "deadline" | "permission" | "unavailable") {
+    const detail = {
+      deadline: "Process inspection exceeded its deadline. Retry when the host is responsive.",
+      permission: "Check process inspection permissions (/proc on Linux, ps on macOS), then retry.",
+      unavailable:
+        "Process identity is unavailable or invalid. Check /proc on Linux or ps on macOS, then retry.",
+    }[reason];
+    super(`Cannot inspect Codex processes. ${detail}`);
+    this.name = "ProcessInspectionError";
+  }
+}
+
+function inspectionFailure(error: unknown): ProcessInspectionError {
+  if (error instanceof ProcessInspectionError) {
+    return error;
+  }
+  const code = error && typeof error === "object" && "code" in error ? error.code : undefined;
+  // Every abort signal in this reader is owned by its inspection deadline.
+  return new ProcessInspectionError(
+    code === "ABORT_ERR"
+      ? "deadline"
+      : code === "EACCES" || code === "EPERM" || code === "ERR_ACCESS_DENIED"
+        ? "permission"
+        : "unavailable",
+  );
+}
+
 export async function readCodexAppServerProcessSnapshot(
   deadline = Date.now() + MAX_PROCESS_CONTAINMENT_MS,
-): Promise<PosixProcess[] | undefined> {
-  return process.platform === "linux"
-    ? await readLinuxProcesses(undefined, deadline)
-    : await readProcesses(["-axo", PROCESS_COLUMNS], deadline);
+  pids?: readonly number[],
+): Promise<PosixProcess[]> {
+  // Registration proves only known owners. Containment still needs the full tree.
+  // Include the observer so an empty selected ps result cannot prove disappearance.
+  const selected = pids === undefined ? undefined : [...new Set([process.pid, ...pids])];
+  const rows =
+    process.platform === "linux"
+      ? await readLinuxProcesses(selected, deadline)
+      : await readProcesses(
+          selected ? ["-o", PROCESS_COLUMNS, "-p", selected.join(",")] : ["-axo", PROCESS_COLUMNS],
+          deadline,
+          selected !== undefined,
+        );
+  if (selected && !rows.some((row) => row.pid === process.pid)) {
+    throw new ProcessInspectionError("unavailable");
+  }
+  return rows;
 }
 
 export async function readCodexAppServerProcess(
@@ -27,58 +68,72 @@ export async function readCodexAppServerProcess(
 ): Promise<PosixProcess | undefined> {
   const rows =
     process.platform === "linux"
-      ? await readLinuxProcesses(pid, deadline)
+      ? await readLinuxProcesses([pid], deadline)
       : await readProcesses(["-o", PROCESS_COLUMNS, "-p", String(pid)], deadline);
-  return rows?.find((row) => row.pid === pid);
+  return rows.find((row) => row.pid === pid);
 }
 
-// Absent processes and failed inspection both return undefined. Neither grants
-// callers authority to signal a process.
 export async function readCodexAppServerProcessCommand(
   pid: number,
   deadline: number,
-): Promise<string | undefined> {
+): Promise<string> {
+  let output: string;
   if (process.platform === "linux") {
     const remainingMs = deadline - Date.now();
     if (remainingMs <= 0) {
-      return undefined;
+      throw new ProcessInspectionError("deadline");
     }
     try {
       const command = await readFile(`/proc/${pid}/cmdline`, {
         encoding: "utf8",
         signal: AbortSignal.timeout(remainingMs),
       });
-      return command.split("\0").join(" ").trim() || undefined;
-    } catch {
-      return undefined;
+      output = command.split("\0").join(" ").trim();
+    } catch (error) {
+      throw inspectionFailure(error);
     }
+  } else {
+    output =
+      (await readProcessOutput(["-o", "command=", "-p", String(pid)], deadline))
+        .split("\n")[0]
+        ?.trim() ?? "";
   }
-  const output = await readProcessOutput(["-o", "command=", "-p", String(pid)], deadline);
-  return output?.split("\n")[0]?.trim() || undefined;
+  if (Date.now() >= deadline) {
+    throw new ProcessInspectionError("deadline");
+  }
+  if (!output) {
+    throw new ProcessInspectionError("unavailable");
+  }
+  return output;
 }
 
 async function readProcesses(
   args: string[],
   deadline: number,
-): Promise<PosixProcess[] | undefined> {
+  selected = false,
+): Promise<PosixProcess[]> {
   const output = await readProcessOutput(args, deadline);
-  return output === undefined ? undefined : parseProcesses(output);
+  return parseProcesses(output, selected);
 }
 
-async function readProcessOutput(args: string[], deadline: number): Promise<string | undefined> {
+async function readProcessOutput(args: string[], deadline: number): Promise<string> {
   const remainingMs = deadline - Date.now();
   if (remainingMs <= 0) {
-    return undefined;
+    throw new ProcessInspectionError("deadline");
   }
-  return await new Promise<string | undefined>((resolve) => {
+  return await new Promise<string>((resolve, reject) => {
     let settled = false;
-    const settle = (output: string | undefined) => {
+    const settle = (output: string | ProcessInspectionError) => {
       if (settled) {
         return;
       }
       settled = true;
       clearTimeout(timer);
-      resolve(output);
+      if (output instanceof ProcessInspectionError) {
+        reject(output);
+      } else {
+        resolve(output);
+      }
     };
     const inspector = execFile(
       "ps",
@@ -89,12 +144,18 @@ async function readProcessOutput(args: string[], deadline: number): Promise<stri
         env: { ...process.env, LC_ALL: "C", TZ: "UTC" },
       },
       (error, stdout) => {
-        settle(error ? undefined : stdout);
+        settle(
+          Date.now() >= deadline
+            ? new ProcessInspectionError("deadline")
+            : error
+              ? inspectionFailure(error)
+              : stdout,
+        );
       },
     );
     const timer = setTimeout(
       () => {
-        settle(undefined);
+        settle(new ProcessInspectionError("deadline"));
         inspector.stdout?.destroy();
         inspector.stderr?.destroy();
         inspector.kill("SIGKILL");
@@ -106,11 +167,14 @@ async function readProcessOutput(args: string[], deadline: number): Promise<stri
   });
 }
 
-function parseProcesses(output: string): PosixProcess[] {
+function parseProcesses(output: string, selected: boolean): PosixProcess[] {
   const rows: PosixProcess[] = [];
   for (const line of output.split("\n")) {
     const match = /^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\S+)\s+(.+?)\s*$/.exec(line);
     if (!match) {
+      if (selected && line.trim()) {
+        throw new ProcessInspectionError("unavailable");
+      }
       continue;
     }
     const pid = Number(match[1] ?? "");
@@ -124,6 +188,9 @@ function parseProcesses(output: string): PosixProcess[] {
       pgid <= 0 ||
       !startedAt
     ) {
+      if (selected) {
+        throw new ProcessInspectionError("unavailable");
+      }
       continue;
     }
     rows.push({ pid, ppid, pgid, state: match[4] ?? "", startedAt });
@@ -134,20 +201,20 @@ function parseProcesses(output: string): PosixProcess[] {
 // Linux exposes stronger start identities in procfs; BusyBox ps on supported
 // Alpine installs has no lstart. Boot identity prevents reuse across reboots.
 async function readLinuxProcesses(
-  pid: number | undefined,
+  selected: readonly number[] | undefined,
   deadline: number,
-): Promise<PosixProcess[] | undefined> {
+): Promise<PosixProcess[]> {
   const remainingMs = deadline - Date.now();
   if (remainingMs <= 0) {
-    return undefined;
+    throw new ProcessInspectionError("deadline");
   }
   const options = { encoding: "utf8" as const, signal: AbortSignal.timeout(remainingMs) };
   try {
     const bootId = (await readFile("/proc/sys/kernel/random/boot_id", options)).trim();
     if (!/^[a-f0-9-]{36}$/.test(bootId)) {
-      return undefined;
+      throw new ProcessInspectionError("unavailable");
     }
-    const pids = pid === undefined ? await readdir("/proc") : [String(pid)];
+    const pids = selected === undefined ? await readdir("/proc") : selected.map(String);
     const rows: PosixProcess[] = [];
     let bytes = 0;
     for (const entry of pids) {
@@ -155,7 +222,7 @@ async function readLinuxProcesses(
         continue;
       }
       if (Date.now() >= deadline) {
-        return undefined;
+        throw new ProcessInspectionError("deadline");
       }
       const stat = await readFile(`/proc/${entry}/stat`, options).catch((error: unknown) => {
         // A process may exit between enumeration and read. Other failures must
@@ -175,7 +242,7 @@ async function readLinuxProcesses(
       }
       bytes += stat.length;
       if (bytes > PROCESS_INSPECTION_MAX_BYTES) {
-        return undefined;
+        throw new ProcessInspectionError("unavailable");
       }
       // comm can contain spaces, newlines and ')'; fields 3..N follow its last ')'.
       const commEnd = stat.lastIndexOf(")");
@@ -189,9 +256,10 @@ async function readLinuxProcesses(
       if (
         commEnd < 0 ||
         ![ppid, pgid].every(Number.isSafeInteger) ||
+        (selected !== undefined && (pgid <= 0 || ppid < 0)) ||
         !/^\d+$/.test(startTicks ?? "")
       ) {
-        return undefined;
+        throw new ProcessInspectionError("unavailable");
       }
       if (pgid > 0) {
         rows.push({
@@ -203,8 +271,11 @@ async function readLinuxProcesses(
         });
       }
     }
+    if (Date.now() >= deadline) {
+      throw new ProcessInspectionError("deadline");
+    }
     return rows;
-  } catch {
-    return undefined;
+  } catch (error) {
+    throw inspectionFailure(error);
   }
 }

--- a/extensions/codex/src/app-server/transport-startup.test.ts
+++ b/extensions/codex/src/app-server/transport-startup.test.ts
@@ -138,7 +138,10 @@ child.on("exit", (code, signal) => {
             }
           }
           inspected();
-          return failure === "inspection" ? undefined : command;
+          if (failure === "inspection") {
+            throw new processSnapshot.ProcessInspectionError("unavailable");
+          }
+          return command;
         },
       );
       const started = CodexAppServerClient.start({
@@ -174,9 +177,7 @@ child.on("exit", (code, signal) => {
         expect(error).toBeInstanceOf(Error);
         expect(isCodexAppServerConnectionClosedError(error)).toBe(false);
         expect((error as Error).message).toContain(
-          failure === "inspection"
-            ? "Cannot register the Codex child process command"
-            : "512-row limit",
+          failure === "inspection" ? "Cannot inspect Codex processes" : "512-row limit",
         );
         expect((error as Error).message).toContain("launcher startup diagnostic");
         expect(

--- a/extensions/codex/src/app-server/transport.process.test.ts
+++ b/extensions/codex/src/app-server/transport.process.test.ts
@@ -326,13 +326,14 @@ process.stdin.on("end", () => process.exit(0));
       };
       const snapshots = scenarios[mode];
       let inspection = 0;
-      const readSnapshot = async (
-        inspectionDeadline: number,
-      ): Promise<PosixProcess[] | undefined> => {
+      const readSnapshot = async (inspectionDeadline: number): Promise<PosixProcess[]> => {
         const rows = snapshots[Math.min(inspection++, snapshots.length - 1)];
         if (rows === "deadline") {
           await delay(Math.max(1, inspectionDeadline - Date.now()));
-          return undefined;
+          throw new processSnapshot.ProcessInspectionError("deadline");
+        }
+        if (!rows) {
+          throw new processSnapshot.ProcessInspectionError("unavailable");
         }
         return rows;
       };


### PR DESCRIPTION
Closes #133101.

## What Problem This Solves

Fixes an issue where starting a Codex-backed session could fail because an unrelated host process was unreadable, even though the registered parent and child identities were available. Inspection deadline failures also incorrectly told operators to change process-inspection permissions.

This is a reproduced registration-boundary defect, not a claim that the exact syscall or CPU cause of the original concurrent-host incident has been identified.

## Why This Change Was Made

The canonical process inspector now supports inspecting the observer and known parent/child PIDs for non-destructive registration decisions. Destructive containment still requires a full process-tree snapshot, command fingerprint validation, and fresh identity checks immediately before signals; unreadable required identities remain fail-closed and keep their registrations.

The inspector distinguishes deadline, access-denied, and unavailable/invalid identity failures. An unreadable command can lose its fingerprint obligation only after a **successful** subsequent identity inspection proves disappearance or replacement. This keeps uncertainty distinct from absence.

No permission expansion, additional retries, larger deadlines, dependency/configuration changes, store/schema changes, or alternate inspection/cache path. Existing Windows behavior and natural startup-exit, cancellation, and owner-revocation precedence are preserved.

## User Impact

Unrelated unreadable processes no longer prevent known-PID registration on Linux. Operators get an actionable failure reason rather than a misleading permission diagnosis for a timeout. Recovery guidance is updated at https://docs.openclaw.ai/plugins/codex-harness-runtime.

macOS still uses native `ps`; this does not claim that its kernel implementation avoids global enumeration. Full cleanup can still refuse to proceed when the process tree cannot be inspected safely. Synchronous database blocking is not removed by this patch.

## Evidence

- Before/after: the two real-registration regressions in `transport-process-registration.procfs.test.ts` failed against unchanged production, then passed with the fix. The test uses the real registration owner and isolated plugin-state store; only the procfs I/O boundary is faulted.
- Local Node 24.20.0: six process/registration/containment/startup suites passed **70/70**, including real native orphan recovery. The adjacent startup-retry suite passed **14/14** after migrating its old inspection-failure mock and diagnostic expectation.
- Required-PID failures, malformed identities, missing observer, verified disappearance, fingerprint mismatch, PID reuse, descendants, shared/isolated clients, cancellation, and revoked ownership remain covered. Full-tree inspection still fails with the same unrelated unreadable neighbor.
- `pnpm build` passed. Fresh Codex autoreview of the final diff was scoped-clean at the default P0 threshold.
- `node scripts/check-changed.mjs --staged` passed, including production/test typechecks, lint, plugin boundaries, doctor-contract tests, and runtime import-cycle checks.
- Exact-head Linux/Node 26.7.0: **77 passed, 7 macOS-only skipped** across all seven suites. Real 2.2-second SQLite-lock/child-exit ordering still refuses an expired inspection with `ProcessInspectionError.reason = "deadline"`; the non-overlapping control passes. No deadline weakening.
- Source-bound Docker + real Gateway/CLI + managed Codex 0.151.0: a separate **serial functional smoke passed 6/6 turns**, including a real `apply_patch` file write and exact `bash` readback from a different session. All active-phase health samples passed. Every turn has the expected provider/model/runtime, one successful attempt, and a non-rerouted terminal receipt; no application fallback. Startup pressure is recorded separately.
- Concurrent control: **4/4 exact-marker responses on both parent and candidate**, each using three `openai/gpt-5.6-sol`/Codex sessions and one direct `anthropic/claude-sonnet-4-6` session. Both runs hit the unchanged transient CPU-health guard (parent delay max 112.3 ms; candidate 118.9 ms), stayed ready, and recovered without restart. Both load probes therefore remain **incomplete**, and neither submitted write/recall followups. The passing serial smoke is not substituted for a passing stress test.
- All live-run children joined; no supervisor-forced cleanup signals; private auth/state directories were deleted and containers removed. API keys came from the standard repository CI test profile, with only the two selected keys supplied over private stdin. No host home, Git checkout, Docker socket, or unrelated credentials were mounted into model containers.
- Remote proof: `blacksmith-testbox`, lease `tbx_01m18n4t3beaf6sbm49wah9hs5`, [Testbox run 33296622700](https://github.com/openclaw/openclaw/actions/runs/33296622700). [Exact-head CI run 33296687827 passed](https://github.com/openclaw/openclaw/actions/runs/33296687827), including `openclaw/ci-gate`.

Proof limits: Docker/Debian and API-key auth are not original Ubuntu/ClawRouter/account-auth parity; source/dist/Node hashes and immutable image IDs were verified before keys were supplied. The first fixture launch omitted explicit multi-agent ownership and stopped before submitting turns; it was corrected and its failed evidence retained. The minimal fixture also logged a pre-wave memory-core reconciliation warning because no system agent was assigned while cron was disabled; memory/dreaming behavior is not certified by this proof. The historical failure's exact errno/CPU cause and the original full stress sequence remain unproven.

Direct dependency inspection: Codex `rust-v0.151.0`, peeled commit `78c290807ce710180111df227df3b7a4fe845452`; initialize gating in `codex-rs/app-server/src/message_processor.rs:835-899`, stdio EOF in `codex-rs/app-server-transport/src/transport/stdio.rs`, and single-client shutdown in `codex-rs/app-server/src/lib.rs:1004-1024,1165-1174`. Registration happens before that native protocol boundary; no upstream behavior is patched.

Production LOC: **+143/-61 (net +82)** across the three existing owner modules. The growth provides scoped inspection, typed diagnostics, and explicit fail-closed consumers; it does not introduce a second reader or a store redesign. Tests: **+349/-56 (net +293)**; docs: **+15/-8**. Regression provenance of the original historical incident remains unknown; this PR makes no author/introduction attribution.

The operator's Stable Gateway and the protected Usage patch were not modified or exercised. No release or advisory operation is part of this PR.
