### PR TITLE
fix(gateway): accept nullable plugin approval metadata

### DIFF
--- a/packages/gateway-protocol/src/plugin-approvals-validators.test.ts
+++ b/packages/gateway-protocol/src/plugin-approvals-validators.test.ts
@@ -1,6 +1,23 @@
 import { describe, expect, it } from "vitest";
 import { validatePluginApprovalRequestParams } from "./index.js";
 
+const nullableMetadataFields = [
+  "pluginId",
+  "detail",
+  "severity",
+  "scope",
+  "toolName",
+  "toolCallId",
+  "allowedDecisions",
+  "agentId",
+  "sessionKey",
+  "approvalReviewerDeviceIds",
+  "turnSourceChannel",
+  "turnSourceTo",
+  "turnSourceAccountId",
+  "turnSourceThreadId",
+] as const;
+
 describe("plugin approval protocol validators", () => {
   it("validates bounded reviewer-only detail independently from the description", () => {
     const request = {
@@ -19,5 +36,15 @@ describe("plugin approval protocol validators", () => {
     expect(validatePluginApprovalRequestParams({ ...request, description: "d".repeat(513) })).toBe(
       false,
     );
+  });
+
+  it.each(nullableMetadataFields)("accepts explicit null for optional %s metadata", (field) => {
+    expect(
+      validatePluginApprovalRequestParams({
+        title: "Apply workspace skill proposal",
+        description: "Apply the pending proposal",
+        [field]: null,
+      }),
+    ).toBe(true);
   });
 });

--- a/packages/gateway-protocol/src/schema/plugin-approvals.ts
+++ b/packages/gateway-protocol/src/schema/plugin-approvals.ts
@@ -1,4 +1,4 @@
-import type { Static } from "typebox";
+import type { Static, TSchema } from "typebox";
 // Gateway Protocol schema module defines protocol validation shapes.
 import { Type } from "typebox";
 import { ApprovalChannelReviewerSchema, ApprovalScopeSchema } from "./approvals.js";
@@ -16,40 +16,65 @@ const MAX_PLUGIN_APPROVAL_TIMEOUT_MS = 600_000;
 const PLUGIN_APPROVAL_TITLE_MAX_LENGTH = 80;
 const PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH = 512;
 
+type SingleTypeSchema = TSchema & { type: string; enum?: readonly (string | null)[] };
+
+// A JSON Schema type array preserves concrete generated client types while
+// accepting explicit null as the same optional-metadata state as omission.
+function nullableMetadata<T extends SingleTypeSchema>(schema: T) {
+  return Type.Unsafe<Static<T> | null>({
+    ...schema,
+    type: [schema.type, "null"],
+    ...(schema.enum ? { enum: [...schema.enum, null] } : {}),
+  });
+}
+
 /** Approval request raised by a plugin before a sensitive tool action proceeds. */
 export const PluginApprovalRequestParamsSchema = closedObject({
-  pluginId: Type.Optional(NonEmptyString),
+  pluginId: Type.Optional(nullableMetadata(NonEmptyString)),
   title: Type.String({ minLength: 1, maxLength: PLUGIN_APPROVAL_TITLE_MAX_LENGTH }),
   description: Type.String({ minLength: 1, maxLength: PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH }),
   detail: Type.Optional(
-    Type.String({
-      minLength: 1,
-      maxLength: 16_384,
-      description: "Reviewer-surface-only detail; not delivered to channels or push notifications.",
+    nullableMetadata(
+      Type.String({
+        minLength: 1,
+        maxLength: 16_384,
+        description:
+          "Reviewer-surface-only detail; not delivered to channels or push notifications.",
+      }),
+    ),
+  ),
+  severity: Type.Optional(nullableMetadata(Type.String({ enum: ["info", "warning", "critical"] }))),
+  scope: Type.Optional(
+    Type.Unsafe<Static<typeof ApprovalScopeSchema> | null>({
+      ...ApprovalScopeSchema,
+      type: ["object", "null"],
+      anyOf: [...ApprovalScopeSchema.anyOf, Type.Null()],
     }),
   ),
-  severity: Type.Optional(Type.String({ enum: ["info", "warning", "critical"] })),
-  scope: Type.Optional(ApprovalScopeSchema),
-  toolName: Type.Optional(Type.String()),
-  toolCallId: Type.Optional(Type.String()),
+  toolName: Type.Optional(nullableMetadata(Type.String())),
+  toolCallId: Type.Optional(nullableMetadata(Type.String())),
   allowedDecisions: Type.Optional(
-    Type.Array(Type.String({ enum: ["allow-once", "allow-always", "deny"] }), {
-      minItems: 1,
-      maxItems: 3,
-    }),
+    nullableMetadata(
+      Type.Array(Type.String({ enum: ["allow-once", "allow-always", "deny"] }), {
+        minItems: 1,
+        maxItems: 3,
+      }),
+    ),
   ),
-  agentId: Type.Optional(Type.String()),
-  sessionKey: Type.Optional(Type.String()),
+  agentId: Type.Optional(nullableMetadata(Type.String())),
+  sessionKey: Type.Optional(nullableMetadata(Type.String())),
   approvalReviewerDeviceIds: Type.Optional(
-    Type.Array(NonEmptyString, {
-      description:
-        "Trusted approval-runtime metadata naming operator devices that may review this approval; ordinary Gateway clients may send the field, but the Gateway only binds it for internal approval-runtime requests.",
-    }),
+    nullableMetadata(
+      Type.Array(NonEmptyString, {
+        description:
+          "Trusted approval-runtime metadata naming operator devices that may review this approval; ordinary Gateway clients may send the field, but the Gateway only binds it for internal approval-runtime requests.",
+      }),
+    ),
   ),
-  turnSourceChannel: Type.Optional(Type.String()),
-  turnSourceTo: Type.Optional(Type.String()),
-  turnSourceAccountId: Type.Optional(Type.String()),
-  turnSourceThreadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
+  turnSourceChannel: Type.Optional(nullableMetadata(Type.String())),
+  turnSourceTo: Type.Optional(nullableMetadata(Type.String())),
+  turnSourceAccountId: Type.Optional(nullableMetadata(Type.String())),
+  turnSourceThreadId: Type.Optional(Type.Union([Type.String(), Type.Number(), Type.Null()])),
   timeoutMs: Type.Optional(Type.Integer({ minimum: 1, maximum: MAX_PLUGIN_APPROVAL_TIMEOUT_MS })),
   twoPhase: Type.Optional(Type.Boolean()),
 });

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -17,7 +17,7 @@ type JsonSchema = {
   properties?: Record<string, JsonSchema>;
   required?: string[];
   items?: JsonSchema;
-  enum?: string[];
+  enum?: Array<string | null>;
   patternProperties?: Record<string, JsonSchema>;
   anyOf?: JsonSchema[];
   oneOf?: JsonSchema[];
@@ -177,10 +177,29 @@ function namedSchema(schema: JsonSchema, allowStructuralFallback = false): strin
 }
 
 function swiftType(schema: JsonSchema, required: boolean, allowStructuralNamed = false): string {
-  const t = schema.type;
+  const schemaTypes = schema.type;
+  const normalizedSchema =
+    !required &&
+    Array.isArray(schemaTypes) &&
+    schemaTypes.length === 2 &&
+    schemaTypes.includes("null")
+      ? {
+          ...schema,
+          type: schemaTypes.find((type) => type !== "null"),
+          enum: schema.enum?.filter((value): value is string => value !== null),
+          anyOf: schema.anyOf?.filter((branch) => branch.type !== "null"),
+          oneOf: schema.oneOf?.filter((branch) => branch.type !== "null"),
+        }
+      : schema;
+  const nullableTypeArray = normalizedSchema !== schema;
+  const t = normalizedSchema.type;
   const isOptional = !required;
   let base: string;
-  const named = namedSchema(schema, allowStructuralNamed);
+  let named = namedSchema(normalizedSchema, allowStructuralNamed);
+  if (!named && nullableTypeArray && (normalizedSchema.anyOf || normalizedSchema.oneOf)) {
+    const { type: _normalizedType, ...normalizedStructuralSchema } = normalizedSchema;
+    named = namedSchema(normalizedStructuralSchema, allowStructuralNamed);
+  }
   if (named) {
     base = named;
   } else if (t === "string") {
@@ -192,8 +211,8 @@ function swiftType(schema: JsonSchema, required: boolean, allowStructuralNamed =
   } else if (t === "boolean") {
     base = "Bool";
   } else if (t === "array") {
-    base = `[${swiftType(schema.items ?? { type: "Any" }, true, true)}]`;
-  } else if (schema.enum) {
+    base = `[${swiftType(normalizedSchema.items ?? { type: "Any" }, true, true)}]`;
+  } else if (normalizedSchema.enum) {
     base = "String";
   } else if (schema.patternProperties) {
     base = "[String: AnyCodable]";
@@ -207,7 +226,8 @@ function swiftType(schema: JsonSchema, required: boolean, allowStructuralNamed =
 
 function stringEnumCases(schema: JsonSchema): string[] | undefined {
   if (schema.type === "string" && schema.enum) {
-    return schema.enum.every((value) => typeof value === "string") ? schema.enum : undefined;
+    const cases = schema.enum.filter((value): value is string => typeof value === "string");
+    return cases.length === schema.enum.length ? cases : undefined;
   }
 
   const variants = schema.oneOf ?? schema.anyOf;
@@ -227,8 +247,8 @@ function swiftInitializerParam(params: {
   required: boolean;
   allowStructuralNamed?: boolean;
 }): string {
-  const type = swiftType(params.schema, true, params.allowStructuralNamed ?? true);
-  return params.required ? `${params.name}: ${type}` : `${params.name}: ${type}? = nil`;
+  const type = swiftType(params.schema, params.required, params.allowStructuralNamed ?? true);
+  return params.required ? `${params.name}: ${type}` : `${params.name}: ${type} = nil`;
 }
 
 function emitEnum(name: string, schema: JsonSchema): string {

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -89,13 +89,13 @@ export function createPluginApprovalHandlers(
         description: string;
         detail?: string | null;
         severity?: string | null;
-        scope?: ApprovalScope;
+        scope?: ApprovalScope | null;
         toolName?: string | null;
         toolCallId?: string | null;
         allowedDecisions?: string[] | null;
         agentId?: string | null;
         sessionKey?: string | null;
-        approvalReviewerDeviceIds?: string[];
+        approvalReviewerDeviceIds?: string[] | null;
         turnSourceChannel?: string | null;
         turnSourceTo?: string | null;
         turnSourceAccountId?: string | null;


### PR DESCRIPTION
## Problem

`plugin.approval.request` accepted omitted optional metadata but rejected the same fields when callers serialized them as `null`. Validation returned `INVALID_REQUEST` before the Gateway handler could register the approval.

## Root cause

The plugin approval payload owner and Gateway handler model descriptive and routing metadata as nullable. The public protocol schema allowed only omission. That left two representations of the same absent-metadata state with different behavior.

## Fix

- Accept explicit null for the 14 optional metadata fields already owned as nullable.
- Keep title, description, timeout, and decision validation unchanged.
- Preserve the existing concrete Swift and Kotlin client types while generating the expanded JSON Schema.
- Cover each nullable field at the protocol validator boundary.

## Proof

- Exact main `eea8f9615e68b10c693c040cf60b149151beb87e`: a real authenticated Gateway accepted the omitted-metadata control request, rejected the explicit-null request, and listed only the control record.
- Exact head `2ed9c34941115e2d86558c85c00ff80af51cfea5`: the same Gateway flow accepted both requests and listed two distinct pending records.
- `node scripts/run-vitest.mjs packages/gateway-protocol/src/plugin-approvals-validators.test.ts src/gateway/server-methods/plugin-approval.test.ts`: 50 tests passed.
- `pnpm protocol:check`: passed; generated Swift and Kotlin files remain unchanged.
- Focused format, Oxlint, repository ratchets, and `git diff --check`: passed.

## Change shape

- Owner: Gateway plugin approval protocol schema and handler.
- Modes: omitted only → omitted or explicit null for absent optional metadata.
- Production delta: +45 lines. A direct union was smaller but widened concrete Swift client fields to `AnyCodable`; the added schema/generator support preserves that public client contract.

## ClawSweeper items

- The exact-head protocol generation check passed, and generated Swift and Kotlin client files remain unchanged. This resolves the production-growth compatibility risk.
- No separate automated repair lane is needed because this active maintainer pull request owns the linked issue repair.

Closes #98403
