### PR TITLE
fix(changelog): classify declared types and scopes before title prose

### DIFF
--- a/.agents/skills/openclaw-changelog-update/SKILL.md
+++ b/.agents/skills/openclaw-changelog-update/SKILL.md
@@ -173,9 +173,11 @@ every human `Thanks @...` attribution.
      its verified user-facing breaking change and migration guidance with the
      original PR ref and credit. Keep other internal contributions only in the
      complete PR record
-   - classify internal-only work from conventional prefixes and clear title
-     signals such as `QA`, `test`, `docs`, `refactor`, `lint`, or `CI`; an
-     untyped title is not automatically editorial
+   - classify conventional titles from their declared type and scope, not
+     incidental words such as `doc` or `build` in their descriptions. For
+     untyped titles, retain internal-work signals such as `QA`, `test`, `docs`,
+     `refactor`, `lint`, or `CI`; eligibility never replaces the source audit
+     that establishes a user-visible outcome
    - do not add GHSA references, advisory IDs, or security advisory slugs to
      changelog entries or GitHub release-note text unless explicitly requested
    - never thank bots, `@claude`, `@codex`, `@openclaw`, `@clawsweeper`, or `@steipete`

--- a/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
+++ b/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
@@ -434,16 +434,16 @@ function githubHandleFromNoreply(email) {
 }
 
 function editorialClassification(subject) {
-  const conventional = subject.match(/^\s*([a-z]+)(?:\([^)]*\))?(!)?:/i);
+  const conventional = subject.match(/^\s*([a-z]+)(?:\(([^)]*)\))?(!)?:/i);
   const type = conventional?.[1]?.toLowerCase();
   return {
-    // A declared breaking API change needs migration notes even when its
-    // conventional type describes a refactor or other internal work.
+    // Declared type/scope outrank ambiguous prose such as "doc" or "build".
+    // Breaking changes still need migration notes even for internal scopes.
     editorialEligible:
-      Boolean(conventional?.[2]) ||
+      Boolean(conventional?.[3]) ||
       ((Boolean(type) || editorialTitlePattern.test(subject)) &&
         !nonEditorialTypes.has(type) &&
-        !nonEditorialTitlePattern.test(subject)),
+        !nonEditorialTitlePattern.test(conventional ? (conventional[2] ?? "") : subject)),
     type: type ?? "other",
   };
 }

--- a/test/scripts/release-notes-ledger.test.ts
+++ b/test/scripts/release-notes-ledger.test.ts
@@ -61,7 +61,18 @@ describe("renderContributionRecordEntry", () => {
     ["refactor(plugins): simplify loader internals", "refactor", false],
     ["test: cover breaking plugin changes!", "test", false],
     ["fix: preserve message delivery", "fix", true],
-  ])("classifies declared breaking changes for release prose: %s", (title, type, eligible) => {
+    ["feat(fleet): add resource controls and operator docs", "feat", true],
+    ["feat(sessions): add creator attribution and multi-user docs", "feat", true],
+    ["fix(feishu): stop repeated doc child pagination", "fix", true],
+    ["fix: Git update reports success while Web UI serves an old build", "fix", true],
+    ["fix(provider): keep connection test errors readable", "fix", true],
+    ["fix(qa-matrix): preserve shared reply previews", "fix", false],
+    ["feat(ci): add artifact reuse", "feat", false],
+    ["fix(docs): repair setup links", "fix", false],
+    ["fix(build): preserve generated outputs", "fix", false],
+    ["Add operator docs", "other", false],
+    ["Improve provider discovery", "other", true],
+  ])("classifies release prose from declared type and scope: %s", (title, type, eligible) => {
     const nodes = new Map([
       [
         123,


### PR DESCRIPTION
## What Problem This Solves

Release-note validation rejects real features and runtime fixes when their descriptions happen to contain words such as `doc`, `docs`, `test`, or `build`. The 2026.8.1 audit found creator attribution with multi-user docs (#112658), Feishu document pagination (#121124), stale Web UI builds after Git updates (#130957), and Fleet controls with operator docs (#104814).

## Why This Change Was Made

Classify a Conventional Commit title by its declared type and scope. Keep the existing whole-title heuristic for untyped titles. Explicit breaking markers still take precedence, ordinary internal types and internally scoped changes stay out of editorial prose, and eligibility still requires a separate source audit establishing user impact. The original source title, attribution, ledger shape, and provenance checks remain unchanged.

This repairs the shared classifier used for PRs and direct commits without per-PR exceptions, title edits, or dropping legitimate contributor references. It follows the breaking-marker repair in #133104.

## Evidence

- Five positive regression cases fail on the previous classifier; 26 other ledger tests pass before the change.
- All 72 ledger and verifier tests pass through the canonical two-project test runner after the change. Controls retain internal QA, CI, documentation and build scopes, ordinary internal types, explicit breaking markers, and untyped-title heuristics.
- Type-aware lint, formatting, diff checks, and independent structured review pass.
- Production tooling is net zero lines; tests add 11 lines and skill guidance adds two. No product runtime, SQLite schema, serialized manifest, or release identity change.

Hosted exact-head CI [33296642724](https://github.com/openclaw/openclaw/actions/runs/33296642724) passed, including the required gate. Workflow Sanity also passed. The full scratch release-note validation now passes with zero errors for 16,785 PR records, including complete editorial credit; final release acceptance will rerun from the landed trusted tooling pin.

ClawSweeper disposition (06:23 UTC): no correctness/security findings. Its remaining request is explicit maintainer handling after exact-head CI. This is the release owner’s scoped repair under the authorized 2026.8.1 release; current main rules require the CI gate and linear history, with no independent review rule. Proceed through native prepare/merge after those gates pass.
