### PR TITLE
improve(cli): cut ordinary gateway status startup memory

### DIFF
--- a/src/cli/daemon-cli/lifecycle-context.ts
+++ b/src/cli/daemon-cli/lifecycle-context.ts
@@ -1,0 +1,35 @@
+import { readBestEffortConfig, resolveGatewayPort } from "../../config/config.js";
+import { createConfigIO } from "../../config/io.js";
+import { mergeGatewayServiceEnv } from "../../daemon/service-env-merge.js";
+import { resolveGatewayService } from "../../daemon/service.js";
+import { parseTcpPortFromArgs } from "../../infra/tcp-port.js";
+
+export async function resolveGatewayLifecycleContext(
+  service = resolveGatewayService(),
+  requireEffective = false,
+) {
+  const command = requireEffective
+    ? await service.readCommand(process.env, { requireEffective: true })
+    : await service.readCommand(process.env).catch(() => null);
+  if (requireEffective && !command) {
+    throw new Error(
+      "Updated gateway service could not be inspected; run `openclaw gateway status --deep`.",
+    );
+  }
+  const env = mergeGatewayServiceEnv(process.env, command);
+  const config = await createConfigIO({
+    env,
+    observe: false,
+    pluginValidation: "skip",
+    suppressFutureVersionWarning: true,
+  })
+    .readBestEffortConfig()
+    .catch(() => undefined);
+  const port = parseTcpPortFromArgs(command?.programArguments) ?? resolveGatewayPort(config, env);
+  return { port, env, command };
+}
+
+export async function resolveGatewayConfigPorts() {
+  const config = await readBestEffortConfig({ observe: false }).catch(() => undefined);
+  return { explicit: config?.gateway?.port, fallback: resolveGatewayPort(config, process.env) };
+}

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -48,6 +48,7 @@ import {
   appendGatewayLifecycleAudit,
   createGatewayLifecycleMutationAudit,
 } from "./lifecycle-audit.js";
+import { resolveGatewayConfigPorts, resolveGatewayLifecycleContext } from "./lifecycle-context.js";
 import {
   runServiceRestart,
   runServiceStart,
@@ -69,11 +70,7 @@ import {
   waitForGatewayHealthyListener,
   waitForGatewayHealthyRestart,
 } from "./restart-health.js";
-import {
-  resolveGatewayLifecycleContext,
-  resolveGatewayConfigPorts,
-  renderGatewayServiceStartHints,
-} from "./shared.js";
+import { renderGatewayServiceStartHints } from "./shared.js";
 import { repairLoadedGatewayServiceForStart } from "./start-repair.js";
 import type { DaemonLifecycleOptions } from "./types.js";
 

--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -1,7 +1,5 @@
 // Shared Gateway service CLI helpers: status styles, env filtering, port parsing, and hints.
 import { colorize, isRich, theme } from "../../../packages/terminal-core/src/theme.js";
-import { readBestEffortConfig, resolveGatewayPort } from "../../config/config.js";
-import { createConfigIO } from "../../config/io.js";
 import { resolveIsNixMode } from "../../config/paths.js";
 import {
   resolveGatewayLaunchAgentLabel,
@@ -14,9 +12,6 @@ import {
   buildPlatformRuntimeLogHints,
   buildPlatformServiceStartHints,
 } from "../../daemon/runtime-hints.js";
-import { mergeGatewayServiceEnv } from "../../daemon/service-env-merge.js";
-import { resolveGatewayService } from "../../daemon/service.js";
-import { parseTcpPortFromArgs } from "../../infra/tcp-port.js";
 import { formatCliCommand } from "../command-format.js";
 import { parsePort } from "../shared/parse-port.js";
 import { createDaemonActionContext } from "./response.js";
@@ -224,34 +219,4 @@ export function filterContainerGenericHints(
       !hint.includes("If you're in a container, run the gateway in the foreground instead of") &&
       !hint.includes("systemd user services are unavailable; install/enable systemd"),
   );
-}
-
-export async function resolveGatewayLifecycleContext(
-  service = resolveGatewayService(),
-  requireEffective = false,
-) {
-  const command = requireEffective
-    ? await service.readCommand(process.env, { requireEffective: true })
-    : await service.readCommand(process.env).catch(() => null);
-  if (requireEffective && !command) {
-    throw new Error(
-      "Updated gateway service could not be inspected; run `openclaw gateway status --deep`.",
-    );
-  }
-  const env = mergeGatewayServiceEnv(process.env, command);
-  const config = await createConfigIO({
-    env,
-    observe: false,
-    pluginValidation: "skip",
-    suppressFutureVersionWarning: true,
-  })
-    .readBestEffortConfig()
-    .catch(() => undefined);
-  const port = parseTcpPortFromArgs(command?.programArguments) ?? resolveGatewayPort(config, env);
-  return { port, env, command };
-}
-
-export async function resolveGatewayConfigPorts() {
-  const config = await readBestEffortConfig({ observe: false }).catch(() => undefined);
-  return { explicit: config?.gateway?.port, fallback: resolveGatewayPort(config, process.env) };
 }

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -21,6 +21,9 @@ type PortConnections = Awaited<
   ReturnType<typeof import("../../infra/ports-inspect.js").inspectPortConnections>
 >;
 
+const readFile = fs.readFile.bind(fs);
+let readFileSpy: ReturnType<typeof vi.spyOn>;
+
 const callGatewayStatusProbe = vi.fn<
   (opts?: unknown) => Promise<{
     ok: boolean;
@@ -180,6 +183,19 @@ let cliLoadedConfig: Record<string, unknown> = {
 };
 
 vi.mock("../../config/config.js", () => ({
+  getRuntimeConfig: () => cliLoadedConfig,
+  loadConfig: () => cliLoadedConfig,
+}));
+
+vi.mock("../../config/paths.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../config/paths.js")>()),
+  isDefaultInstallIdentity: (env?: NodeJS.ProcessEnv) => isDefaultInstallIdentity(env),
+  resolveConfigPath: (env: NodeJS.ProcessEnv, stateDir: string) => resolveConfigPath(env, stateDir),
+  resolveGatewayPort: (cfg?: unknown, env?: unknown) => resolveGatewayPort(cfg, env),
+  resolveStateDir: (env: NodeJS.ProcessEnv) => resolveStateDir(env),
+}));
+
+vi.mock("../../config/io.runtime.js", () => ({
   createConfigIO: ({
     configPath,
     observe,
@@ -212,16 +228,6 @@ vi.mock("../../config/config.js", () => ({
       },
     };
   },
-  getRuntimeConfig: () => cliLoadedConfig,
-  loadConfig: () => cliLoadedConfig,
-  resolveConfigPath: (env: NodeJS.ProcessEnv, stateDir: string) => resolveConfigPath(env, stateDir),
-  resolveGatewayPort: (cfg?: unknown, env?: unknown) => resolveGatewayPort(cfg, env),
-  resolveStateDir: (env: NodeJS.ProcessEnv) => resolveStateDir(env),
-}));
-
-vi.mock("../../config/paths.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../../config/paths.js")>()),
-  isDefaultInstallIdentity: (env?: NodeJS.ProcessEnv) => isDefaultInstallIdentity(env),
 }));
 
 vi.mock("../../daemon/diagnostics.js", () => ({
@@ -346,6 +352,15 @@ describe("gatherDaemonStatus", () => {
   let envSnapshot: ReturnType<typeof captureEnv>;
 
   beforeEach(() => {
+    readFileSpy = vi.spyOn(fs, "readFile").mockImplementation(async (filePath, options) => {
+      if (
+        filePath === "/tmp/openclaw-cli/openclaw.json" ||
+        filePath === "/tmp/openclaw-daemon/openclaw.json"
+      ) {
+        throw Object.assign(new Error("test config requires full IO"), { code: "EACCES" });
+      }
+      return await readFile(filePath, options);
+    });
     envSnapshot = captureEnv([
       "OPENCLAW_STATE_DIR",
       "OPENCLAW_CONFIG_PATH",
@@ -438,6 +453,7 @@ describe("gatherDaemonStatus", () => {
   });
 
   afterEach(() => {
+    readFileSpy.mockRestore();
     envSnapshot.restore();
   });
 
@@ -1101,6 +1117,7 @@ describe("gatherDaemonStatus", () => {
     try {
       const status = await gatherStatus({ probe: false });
 
+      expect(createConfigIOCalls).not.toHaveBeenCalled();
       expect(readConfigFileSnapshotCalls).not.toHaveBeenCalled();
       expect(loadConfigCalls).not.toHaveBeenCalled();
       expect(status.config?.cli.path).toBe(configPath);
@@ -1110,6 +1127,116 @@ describe("gatherDaemonStatus", () => {
       expect(status.config?.daemon).toBe(status.config?.cli);
       expect(status.gateway?.bindMode).toBe("custom");
       expect(status.gateway?.customBindHost).toBe("10.0.0.5");
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the fast config path when the config file is missing", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-status-config-"));
+    const configPath = path.join(tmp, "missing.json");
+    setTestEnvValue("OPENCLAW_STATE_DIR", tmp);
+    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+    serviceReadCommand.mockResolvedValueOnce({
+      programArguments: ["/bin/node", "cli", "gateway", "--port", "19001"],
+      environment: {
+        OPENCLAW_STATE_DIR: tmp,
+        OPENCLAW_CONFIG_PATH: configPath,
+      },
+    });
+
+    try {
+      const status = await gatherStatus({ probe: false });
+
+      expect(createConfigIOCalls).not.toHaveBeenCalled();
+      expect(status.config?.cli).toEqual({
+        path: configPath,
+        exists: false,
+        valid: true,
+      });
+      expect(status.config?.daemon).toBe(status.config?.cli);
+      expect(status.gateway).toMatchObject({
+        bindMode: "loopback",
+        port: 19001,
+      });
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps malformed JSON5 on the fast invalid-summary path", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-status-config-"));
+    const configPath = path.join(tmp, "openclaw.json");
+    await fs.writeFile(configPath, "{ gateway:");
+    setTestEnvValue("OPENCLAW_STATE_DIR", tmp);
+    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+    serviceReadCommand.mockResolvedValueOnce({
+      programArguments: ["/bin/node", "cli", "gateway", "--port", "19001"],
+      environment: {
+        OPENCLAW_STATE_DIR: tmp,
+        OPENCLAW_CONFIG_PATH: configPath,
+      },
+    });
+
+    try {
+      const status = await gatherStatus({ probe: false });
+
+      expect(createConfigIOCalls).not.toHaveBeenCalled();
+      expect(status.config?.cli).toMatchObject({
+        path: configPath,
+        exists: true,
+        valid: false,
+      });
+      expect(status.config?.cli.issues?.[0]?.message).toContain("JSON5 parse failed");
+      expect(status.config?.daemon).toBe(status.config?.cli);
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ["include", JSON.stringify({ $include: "./base.json" })],
+    ["substitution", JSON.stringify({ gateway: { auth: { token: "${STATUS_TOKEN}" } } })],
+    ["root env", JSON.stringify({ env: { STATUS_TOKEN: "value" } })],
+  ])("uses full config IO for %s config", async (_name, rawConfig) => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-status-config-"));
+    const configPath = path.join(tmp, "openclaw.json");
+    await fs.writeFile(configPath, rawConfig);
+    setTestEnvValue("OPENCLAW_STATE_DIR", tmp);
+    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+    serviceReadCommand.mockResolvedValueOnce({
+      programArguments: ["/bin/node", "cli", "gateway", "--port", "19001"],
+    });
+
+    try {
+      await gatherStatus({ probe: false });
+
+      expect(createConfigIOCalls).toHaveBeenCalledOnce();
+      expect(createConfigIOCalls).toHaveBeenCalledWith(configPath, "skip", false);
+      expect(readConfigFileSnapshotCalls).toHaveBeenCalledWith(configPath);
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("uses full config IO after a non-missing read failure", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-status-config-"));
+    const configPath = path.join(tmp, "openclaw.json");
+    await fs.writeFile(configPath, "{}");
+    setTestEnvValue("OPENCLAW_STATE_DIR", tmp);
+    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+    serviceReadCommand.mockResolvedValueOnce({
+      programArguments: ["/bin/node", "cli", "gateway", "--port", "19001"],
+    });
+    readFileSpy.mockRejectedValueOnce(
+      Object.assign(new Error("permission denied"), { code: "EACCES" }),
+    );
+
+    try {
+      await gatherStatus({ probe: false });
+
+      expect(createConfigIOCalls).toHaveBeenCalledOnce();
+      expect(createConfigIOCalls).toHaveBeenCalledWith(configPath, "skip", false);
     } finally {
       await fs.rm(tmp, { recursive: true, force: true });
     }

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -348,6 +348,36 @@ function gatherStatus(overrides: Partial<Parameters<typeof gatherDaemonStatus>[0
   return gatherDaemonStatus({ rpc: {}, probe: true, deep: false, ...overrides });
 }
 
+async function withStatusConfig<T>(
+  rawConfig: string | undefined,
+  run: (configPath: string) => Promise<T>,
+  includeServiceEnv = false,
+): Promise<T> {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-status-config-"));
+  const configPath = path.join(tmp, "openclaw.json");
+  if (rawConfig !== undefined) {
+    await fs.writeFile(configPath, rawConfig);
+  }
+  setTestEnvValue("OPENCLAW_STATE_DIR", tmp);
+  setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+  serviceReadCommand.mockResolvedValueOnce({
+    programArguments: ["/bin/node", "cli", "gateway", "--port", "19001"],
+    ...(includeServiceEnv
+      ? {
+          environment: {
+            OPENCLAW_STATE_DIR: tmp,
+            OPENCLAW_CONFIG_PATH: configPath,
+          },
+        }
+      : {}),
+  });
+  try {
+    return await run(configPath);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+}
+
 describe("gatherDaemonStatus", () => {
   let envSnapshot: ReturnType<typeof captureEnv>;
 
@@ -1092,10 +1122,7 @@ describe("gatherDaemonStatus", () => {
   });
 
   it("uses the fast config path for plain same-file status reads", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-status-config-"));
-    const configPath = path.join(tmp, "openclaw.json");
-    await fs.writeFile(
-      configPath,
+    await withStatusConfig(
       JSON.stringify({
         gateway: {
           bind: "custom",
@@ -1103,95 +1130,63 @@ describe("gatherDaemonStatus", () => {
           controlUi: { enabled: true },
         },
       }),
-    );
-    setTestEnvValue("OPENCLAW_STATE_DIR", tmp);
-    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
-    serviceReadCommand.mockResolvedValueOnce({
-      programArguments: ["/bin/node", "cli", "gateway", "--port", "19001"],
-      environment: {
-        OPENCLAW_STATE_DIR: tmp,
-        OPENCLAW_CONFIG_PATH: configPath,
+      async (configPath) => {
+        const status = await gatherStatus({ probe: false });
+
+        expect(createConfigIOCalls).not.toHaveBeenCalled();
+        expect(readConfigFileSnapshotCalls).not.toHaveBeenCalled();
+        expect(loadConfigCalls).not.toHaveBeenCalled();
+        expect(status.config?.cli.path).toBe(configPath);
+        expect(status.config?.cli.exists).toBe(true);
+        expect(status.config?.cli.valid).toBe(true);
+        expect(status.config?.cli.controlUi).toEqual({ enabled: true });
+        expect(status.config?.daemon).toBe(status.config?.cli);
+        expect(status.gateway?.bindMode).toBe("custom");
+        expect(status.gateway?.customBindHost).toBe("10.0.0.5");
       },
-    });
-
-    try {
-      const status = await gatherStatus({ probe: false });
-
-      expect(createConfigIOCalls).not.toHaveBeenCalled();
-      expect(readConfigFileSnapshotCalls).not.toHaveBeenCalled();
-      expect(loadConfigCalls).not.toHaveBeenCalled();
-      expect(status.config?.cli.path).toBe(configPath);
-      expect(status.config?.cli.exists).toBe(true);
-      expect(status.config?.cli.valid).toBe(true);
-      expect(status.config?.cli.controlUi).toEqual({ enabled: true });
-      expect(status.config?.daemon).toBe(status.config?.cli);
-      expect(status.gateway?.bindMode).toBe("custom");
-      expect(status.gateway?.customBindHost).toBe("10.0.0.5");
-    } finally {
-      await fs.rm(tmp, { recursive: true, force: true });
-    }
+      true,
+    );
   });
 
   it("uses the fast config path when the config file is missing", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-status-config-"));
-    const configPath = path.join(tmp, "missing.json");
-    setTestEnvValue("OPENCLAW_STATE_DIR", tmp);
-    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
-    serviceReadCommand.mockResolvedValueOnce({
-      programArguments: ["/bin/node", "cli", "gateway", "--port", "19001"],
-      environment: {
-        OPENCLAW_STATE_DIR: tmp,
-        OPENCLAW_CONFIG_PATH: configPath,
+    await withStatusConfig(
+      undefined,
+      async (configPath) => {
+        const status = await gatherStatus({ probe: false });
+
+        expect(createConfigIOCalls).not.toHaveBeenCalled();
+        expect(status.config?.cli).toEqual({
+          path: configPath,
+          exists: false,
+          valid: true,
+        });
+        expect(status.config?.daemon).toBe(status.config?.cli);
+        expect(status.gateway).toMatchObject({
+          bindMode: "loopback",
+          port: 19001,
+        });
       },
-    });
-
-    try {
-      const status = await gatherStatus({ probe: false });
-
-      expect(createConfigIOCalls).not.toHaveBeenCalled();
-      expect(status.config?.cli).toEqual({
-        path: configPath,
-        exists: false,
-        valid: true,
-      });
-      expect(status.config?.daemon).toBe(status.config?.cli);
-      expect(status.gateway).toMatchObject({
-        bindMode: "loopback",
-        port: 19001,
-      });
-    } finally {
-      await fs.rm(tmp, { recursive: true, force: true });
-    }
+      true,
+    );
   });
 
   it("keeps malformed JSON5 on the fast invalid-summary path", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-status-config-"));
-    const configPath = path.join(tmp, "openclaw.json");
-    await fs.writeFile(configPath, "{ gateway:");
-    setTestEnvValue("OPENCLAW_STATE_DIR", tmp);
-    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
-    serviceReadCommand.mockResolvedValueOnce({
-      programArguments: ["/bin/node", "cli", "gateway", "--port", "19001"],
-      environment: {
-        OPENCLAW_STATE_DIR: tmp,
-        OPENCLAW_CONFIG_PATH: configPath,
+    await withStatusConfig(
+      "{ gateway:",
+      async (configPath) => {
+        const status = await gatherStatus({ probe: false });
+
+        expect(createConfigIOCalls).not.toHaveBeenCalled();
+        expect(status.config?.cli).toMatchObject({
+          path: configPath,
+          exists: true,
+          valid: false,
+        });
+        expect(status.config?.cli.issues?.[0]?.message).toContain("JSON5 parse failed");
+        expect(status.config?.daemon).toBe(status.config?.cli);
       },
-    });
-
-    try {
-      const status = await gatherStatus({ probe: false });
-
-      expect(createConfigIOCalls).not.toHaveBeenCalled();
-      expect(status.config?.cli).toMatchObject({
-        path: configPath,
-        exists: true,
-        valid: false,
-      });
-      expect(status.config?.cli.issues?.[0]?.message).toContain("JSON5 parse failed");
-      expect(status.config?.daemon).toBe(status.config?.cli);
-    } finally {
-      await fs.rm(tmp, { recursive: true, force: true });
-    }
+      true,
+    );
   });
 
   it.each([
@@ -1199,88 +1194,56 @@ describe("gatherDaemonStatus", () => {
     ["substitution", JSON.stringify({ gateway: { auth: { token: "${STATUS_TOKEN}" } } })],
     ["root env", JSON.stringify({ env: { STATUS_TOKEN: "value" } })],
   ])("uses full config IO for %s config", async (_name, rawConfig) => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-status-config-"));
-    const configPath = path.join(tmp, "openclaw.json");
-    await fs.writeFile(configPath, rawConfig);
-    setTestEnvValue("OPENCLAW_STATE_DIR", tmp);
-    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
-    serviceReadCommand.mockResolvedValueOnce({
-      programArguments: ["/bin/node", "cli", "gateway", "--port", "19001"],
-    });
-
-    try {
+    await withStatusConfig(rawConfig, async (configPath) => {
       await gatherStatus({ probe: false });
 
       expect(createConfigIOCalls).toHaveBeenCalledOnce();
       expect(createConfigIOCalls).toHaveBeenCalledWith(configPath, "skip", false);
       expect(readConfigFileSnapshotCalls).toHaveBeenCalledWith(configPath);
-    } finally {
-      await fs.rm(tmp, { recursive: true, force: true });
-    }
+    });
   });
 
   it("uses full config IO after a non-missing read failure", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-status-config-"));
-    const configPath = path.join(tmp, "openclaw.json");
-    await fs.writeFile(configPath, "{}");
-    setTestEnvValue("OPENCLAW_STATE_DIR", tmp);
-    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
-    serviceReadCommand.mockResolvedValueOnce({
-      programArguments: ["/bin/node", "cli", "gateway", "--port", "19001"],
-    });
-    readFileSpy.mockRejectedValueOnce(
-      Object.assign(new Error("permission denied"), { code: "EACCES" }),
-    );
-
-    try {
+    await withStatusConfig("{}", async (configPath) => {
+      readFileSpy.mockRejectedValueOnce(
+        Object.assign(new Error("permission denied"), { code: "EACCES" }),
+      );
       await gatherStatus({ probe: false });
 
       expect(createConfigIOCalls).toHaveBeenCalledOnce();
       expect(createConfigIOCalls).toHaveBeenCalledWith(configPath, "skip", false);
-    } finally {
-      await fs.rm(tmp, { recursive: true, force: true });
-    }
+    });
   });
 
   it("uses full plugin-aware config validation for deep status", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-status-config-"));
-    const configPath = path.join(tmp, "openclaw.json");
-    await fs.writeFile(
-      configPath,
+    await withStatusConfig(
       JSON.stringify({
         gateway: {
           bind: "loopback",
         },
       }),
+      async (configPath) => {
+        cliLoadedConfig = {
+          gateway: {
+            bind: "loopback",
+          },
+        };
+        cliConfigWarnings = [
+          {
+            path: "plugins.entries.test-bad-plugin",
+            message:
+              "plugin test-bad-plugin: channel plugin manifest declares test-bad-plugin without channelConfigs metadata",
+          },
+        ];
+
+        const status = await gatherStatus({ probe: false, deep: true });
+
+        expect(createConfigIOCalls).toHaveBeenCalledWith(configPath, "full", false);
+        expect(readConfigFileSnapshotCalls).toHaveBeenCalledWith(configPath);
+        expect(status.config?.cli.warnings).toEqual(cliConfigWarnings);
+        expect(status.config?.daemon).toBe(status.config?.cli);
+      },
     );
-    setTestEnvValue("OPENCLAW_STATE_DIR", tmp);
-    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
-    cliLoadedConfig = {
-      gateway: {
-        bind: "loopback",
-      },
-    };
-    cliConfigWarnings = [
-      {
-        path: "plugins.entries.test-bad-plugin",
-        message:
-          "plugin test-bad-plugin: channel plugin manifest declares test-bad-plugin without channelConfigs metadata",
-      },
-    ];
-    serviceReadCommand.mockResolvedValueOnce({
-      programArguments: ["/bin/node", "cli", "gateway", "--port", "19001"],
-    });
-
-    try {
-      const status = await gatherStatus({ probe: false, deep: true });
-
-      expect(createConfigIOCalls).toHaveBeenCalledWith(configPath, "full", false);
-      expect(readConfigFileSnapshotCalls).toHaveBeenCalledWith(configPath);
-      expect(status.config?.cli.warnings).toEqual(cliConfigWarnings);
-      expect(status.config?.daemon).toBe(status.config?.cli);
-    } finally {
-      await fs.rm(tmp, { recursive: true, force: true });
-    }
   });
 
   it("resolves daemon gateway auth password SecretRef values before probing", async () => {

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -169,7 +169,7 @@ async function readFastStatusConfig(configPath: string): Promise<StatusConfigRea
   try {
     raw = await fs.readFile(configPath, "utf8");
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+    if (!(error && typeof error === "object" && "code" in error && error.code === "ENOENT")) {
       return null;
     }
     return {

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -5,12 +5,11 @@ import { uniqueStrings } from "@openclaw/normalization-core/string-normalization
 import JSON5 from "json5";
 import type { classifyGatewayConnectFailure } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import {
-  createConfigIO,
+  isDefaultInstallIdentity,
   resolveConfigPath,
   resolveGatewayPort,
   resolveStateDir,
-} from "../../config/config.js";
-import { isDefaultInstallIdentity } from "../../config/paths.js";
+} from "../../config/paths.js";
 import type {
   OpenClawConfig,
   ConfigFileSnapshot,
@@ -135,6 +134,7 @@ type CliStatusSummary = {
 type GatewayConnectFailureKind = ReturnType<typeof classifyGatewayConnectFailure>["kind"];
 
 const loadGatewayProbeAuthModule = createLazyPromise(() => import("../../gateway/probe-auth.js"));
+const loadConfigIoRuntime = createLazyPromise(() => import("../../config/io.runtime.js"));
 const loadDaemonInspectModule = createLazyPromise(() => import("../../daemon/inspect.js"));
 const loadLaunchdModule = createLazyPromise(() => import("../../daemon/launchd.js"));
 const loadServiceAuditModule = createLazyPromise(() => import("../../daemon/service-audit.js"));
@@ -168,8 +168,15 @@ async function readFastStatusConfig(configPath: string): Promise<StatusConfigRea
   let raw: string;
   try {
     raw = await fs.readFile(configPath, "utf8");
-  } catch {
-    return null;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      return null;
+    }
+    return {
+      summary: { path: configPath, exists: false, valid: true },
+      cfg: {},
+      mode: "fast",
+    };
   }
 
   let parsed: unknown;
@@ -210,6 +217,7 @@ async function readFullStatusConfig(params: {
   configPath: string;
   pluginValidation?: "full" | "skip";
 }): Promise<StatusConfigRead> {
+  const { createConfigIO } = await loadConfigIoRuntime();
   const io = createConfigIO({
     env: params.env,
     configPath: params.configPath,

--- a/src/cli/gateway-status-route-cold-imports.test.ts
+++ b/src/cli/gateway-status-route-cold-imports.test.ts
@@ -22,19 +22,26 @@ vi.mock("../config/io.runtime.js", async (importOriginal) => {
   return await importOriginal();
 });
 
-vi.mock("../daemon/service.js", () => ({
-  resolveGatewayService: () => ({
-    label: "Gateway",
-    loadedText: "loaded",
-    notLoadedText: "not loaded",
-  }),
-  readGatewayServiceState: vi.fn(async () => ({
-    command: null,
-    env: {},
-    loadState: { status: "not-loaded" as const },
-    runtime: { status: "stopped" as const },
-  })),
+const fakeServiceResolver = vi.fn(() => ({
+  label: "Gateway",
+  loadedText: "loaded",
+  notLoadedText: "not loaded",
 }));
+const fakeServiceStateReader = vi.fn(async () => ({
+  command: null,
+  env: {},
+  loadState: { status: "not-loaded" as const },
+  runtime: { status: "stopped" as const },
+}));
+
+vi.mock("../daemon/service.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../daemon/service.js")>();
+  return {
+    ...actual,
+    resolveGatewayService: fakeServiceResolver,
+    readGatewayServiceState: fakeServiceStateReader,
+  };
+});
 
 vi.mock("../gateway/control-ui-links.js", () => ({
   resolveAdvertisedControlUiLinks: vi.fn(async () => ({

--- a/src/cli/gateway-status-route-cold-imports.test.ts
+++ b/src/cli/gateway-status-route-cold-imports.test.ts
@@ -1,0 +1,114 @@
+// The routed Gateway status path must not initialize full config IO for a plain config.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, expect, it, vi } from "vitest";
+
+const testState = vi.hoisted(() => ({
+  loadedModules: new Set<string>(),
+  output: undefined as unknown,
+}));
+
+vi.mock("./command-execution-startup.js", () => ({
+  applyCliExecutionStartupPresentation: vi.fn(async () => {}),
+  ensureCliExecutionBootstrap: vi.fn(async () => {}),
+  resolveCliExecutionStartupContext: vi.fn(() => ({
+    startupPolicy: { loadPlugins: false, suppressDoctorStdout: true },
+  })),
+}));
+
+vi.mock("../config/io.runtime.js", async (importOriginal) => {
+  testState.loadedModules.add("config-io-runtime");
+  return await importOriginal();
+});
+
+vi.mock("../daemon/service.js", () => ({
+  resolveGatewayService: () => ({
+    label: "Gateway",
+    loadedText: "loaded",
+    notLoadedText: "not loaded",
+  }),
+  readGatewayServiceState: vi.fn(async () => ({
+    command: null,
+    env: {},
+    loadState: { status: "not-loaded" as const },
+    runtime: { status: "stopped" as const },
+  })),
+}));
+
+vi.mock("../gateway/control-ui-links.js", () => ({
+  resolveAdvertisedControlUiLinks: vi.fn(async () => ({
+    httpUrl: "http://127.0.0.1:18789/",
+    wsUrl: "ws://127.0.0.1:18789",
+  })),
+}));
+
+vi.mock("../gateway/desktop/host-source.js", () => ({
+  inspectHostDesktop: vi.fn(async () => ({
+    status: { enabled: false, state: "disabled", port: 5900 },
+    detail: "disabled",
+  })),
+}));
+
+vi.mock("../infra/network-discovery-display.js", () => ({
+  inspectBestEffortPrimaryTailnetIPv4: vi.fn(() => ({ tailnetIPv4: undefined })),
+  resolveBestEffortGatewayBindHostForDisplay: vi.fn(async () => ({
+    bindHost: "127.0.0.1",
+  })),
+}));
+
+vi.mock("../infra/ports-inspect.js", () => ({
+  inspectPortConnections: vi.fn(async (port: number) => ({ port, connections: [] })),
+  inspectPortUsage: vi.fn(async (port: number) => ({
+    port,
+    status: "free",
+    listeners: [],
+    hints: [],
+  })),
+  inspectPortUsages: vi.fn(async () => new Map()),
+}));
+
+vi.mock("../plugins/installed-plugin-index-record-reader.js", () => ({
+  loadInstalledPluginIndexInstallRecords: vi.fn(async () => ({})),
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: {
+    error: vi.fn(),
+    exit: vi.fn(),
+    log: vi.fn(),
+    writeJson: vi.fn((value: unknown) => {
+      testState.output = value;
+    }),
+    writeStdout: vi.fn(),
+  },
+}));
+
+import { tryRouteCli } from "./route.js";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-gateway-status-route-"));
+const configPath = path.join(tempRoot, "openclaw.json");
+fs.writeFileSync(configPath, JSON.stringify({ gateway: { bind: "loopback" } }));
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+});
+
+it("keeps plain-config status off the full config runtime", async () => {
+  vi.stubEnv("OPENCLAW_HOME", tempRoot);
+  vi.stubEnv("OPENCLAW_STATE_DIR", tempRoot);
+  vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
+
+  await expect(
+    tryRouteCli(["node", "openclaw", "gateway", "status", "--json", "--no-probe"]),
+  ).resolves.toBe(true);
+
+  expect(testState.output).toMatchObject({
+    config: {
+      cli: { path: configPath, exists: true, valid: true },
+    },
+    gateway: { bindMode: "loopback", port: 18789 },
+  });
+  expect(testState.loadedModules).not.toContain("config-io-runtime");
+});

--- a/src/config/io.runtime.ts
+++ b/src/config/io.runtime.ts
@@ -51,6 +51,8 @@ import {
 } from "./runtime-write-application.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "./types.js";
 
+export { createConfigIO };
+
 export function clearConfigCache(): void {
   // Compat shim: runtime snapshot is the only in-process cache now.
 }

--- a/src/daemon/future-config-guard.ts
+++ b/src/daemon/future-config-guard.ts
@@ -1,5 +1,4 @@
 /** Prevents daemon write actions when the config belongs to a newer OpenClaw. */
-import { readConfigFileSnapshot } from "../config/config.js";
 import {
   formatFutureConfigActionBlock,
   resolveFutureConfigActionBlock,
@@ -10,6 +9,7 @@ import {
 async function readFutureConfigActionBlock(
   action: string,
 ): Promise<FutureConfigActionBlock | null> {
+  const { readConfigFileSnapshot } = await import("../config/io.runtime.js");
   try {
     const snapshot = await readConfigFileSnapshot();
     return resolveFutureConfigActionBlock({ action, snapshot });

--- a/src/daemon/gateway-service-probe-hosts.test.ts
+++ b/src/daemon/gateway-service-probe-hosts.test.ts
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
   pickPrimaryTailnetIPv4: vi.fn<() => string | undefined>(() => undefined),
 }));
 
-vi.mock("../config/io.js", () => ({
+vi.mock("../config/io.runtime.js", () => ({
   createConfigIO: (options: unknown) => mocks.createConfigIO(options),
 }));
 

--- a/src/daemon/gateway-service-probe-hosts.ts
+++ b/src/daemon/gateway-service-probe-hosts.ts
@@ -1,4 +1,3 @@
-import { createConfigIO } from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { defaultGatewayBindMode, resolveGatewayRequiredListenHosts } from "../gateway/net.js";
 import { isContainerEnvironment } from "../infra/container-environment.js";
@@ -13,6 +12,7 @@ export async function resolveGatewayServiceProbeHosts(params: {
 }): Promise<readonly string[]> {
   const baseEnv = params.env ?? process.env;
   const mergedEnv = mergeGatewayServiceEnv(baseEnv, params.command ?? null);
+  const { createConfigIO } = await import("../config/io.runtime.js");
   const cfg = await createConfigIO({
     env: mergedEnv,
     pluginValidation: "skip",


### PR DESCRIPTION
Related: #132784

## What Problem This Solves

Fixes an issue where ordinary `openclaw gateway status` still loaded the full config runtime and generated schema graph on constrained hosts, even for a missing or plain same-file config. That unnecessary import closure added about 65 MB to cold-process RSS after the earlier duplicate-process fix.

## Why This Change Was Made

The status owner now reads missing and plain JSON5 configs through its existing bounded fast path and lazy-loads full config IO only for deep validation, includes, substitutions, root environment blocks, or non-`ENOENT` read failures.

Lifecycle-only config and service dependencies move out of the presentation helper imported by status. Two daemon helpers that still need full config IO load its runtime owner on demand. Deep status and lifecycle behavior remain unchanged.

## User Impact

Ordinary Gateway status checks use materially less transient memory on small hosts while preserving output, RPC probing, malformed-config diagnostics, and full plugin-aware validation for `--deep`.

## Evidence

- Exact same-clone A/B, five cold runs per config shape:
  - Missing config: median RSS 205.95 MB -> 140.44 MB, down 65.50 MB / 31.81%.
  - Plain config: median RSS 206.91 MB -> 140.41 MB, down 66.50 MB / 32.14%.
- V8 allocation profiles:
  - Missing config: 57.05 MiB -> 21.82 MiB sampled allocations.
  - Plain config: 56.75 MiB -> 21.29 MiB sampled allocations.
  - Generated schema attribution falls from about 23.5 MiB to 1.5 MiB.
- Static status import closure: 465 -> 288 built chunks; 4.84 -> 3.09 MiB.
- Semantic A/B covers missing, plain, include, substitution, root-env, malformed, and deep config paths; normalized status output and exit behavior match.
- Exact-head focused tests: 178 passed across CLI, daemon, service, lifecycle, status, and cold-import coverage.
- Exact-head full build: passed.
- Changed-file gates: all checks passed; the sparse-worktree dead-export scanner was rerun from the hydrated exact-head clone and passed all three scans.
- Autoreview: Codex Sol/high, no findings; patch rated correct with 0.98 confidence.
- Complete ARM64 constrained-host matrix: 6/6 passed with zero OOM and OOM-kill events.
  - 1 GB, no swap: 574.65 MB cgroup peak; 393,368 KiB Gateway max RSS; 188,688 KiB status max RSS; zero swap.
  - 1 GB, 2 GB swap: 572.78 MB cgroup peak; 388,988 KiB Gateway max RSS; 186,864 KiB status max RSS; 116.40 MB peak swap.
  - 2 GB, no swap: 1,287.30 MB cgroup peak; 458,132 KiB Gateway max RSS; 237,864 KiB status max RSS; zero swap.
  - 2 GB, 2 GB swap: 1,216.91 MB cgroup peak; 453,200 KiB Gateway max RSS; 239,876 KiB status max RSS; zero swap.
  - 4 GB, no swap: 2,224.07 MB cgroup peak; 557,736 KiB Gateway max RSS; 254,484 KiB status max RSS; zero swap.
  - 4 GB, 2 GB swap: 2,221.26 MB cgroup peak; 550,032 KiB Gateway max RSS; 256,612 KiB status max RSS; zero swap.
- 1 GB, no-swap soak: 20/20 sequential RPC status calls passed; status max RSS 178,220-209,812 KiB, median 206,390 KiB; zero OOM events and zero swap.
- ARM `gateway status --require-rpc` peak RSS fell from about 271 MiB on the prior landed build to 182-251 MiB across the complete matrix; Gateway RSS stayed within the expected host-dependent range.

Production LOC: +54/-47 (net +7) | Tests: +279/-68 (net +211)

The production growth is the lazy owner boundary plus explicit missing-file semantics. Thirty-five production lines are a direct move of lifecycle-only helpers out of the status import closure.

## Residual Limits

- Crabbox artifact transfers were intermittently slow, but all six guest workloads completed and every lease reached terminal cleanup.
- AWS ARM64 guests approximate Raspberry Pi memory pressure but do not reproduce Raspberry Pi storage latency or firmware exactly.
