### PR TITLE
fix: show gateway restart progress instead of tool failure

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -571,20 +571,24 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
-  it("renders an intentional Gateway restart as status instead of tool failure", () => {
-    const payloads = buildPayloads({
-      lastToolError: {
-        toolName: "gateway_exec",
-        error: "OpenClaw dynamic tool call aborted.",
-        executionStarted: true,
-      },
-      runAborted: true,
-      runStopReason: "restart",
-      toolResultFormat: "markdown",
-    });
+  it.each([undefined, true])(
+    "renders an intentional Gateway restart as status with suppressToolErrors=$s",
+    (suppressToolErrors) => {
+      const payloads = buildPayloads({
+        config: { messages: { suppressToolErrors } },
+        lastToolError: {
+          toolName: "gateway_exec",
+          error: "OpenClaw dynamic tool call aborted.",
+          executionStarted: true,
+        },
+        runAborted: true,
+        runStopReason: "restart",
+        toolResultFormat: "markdown",
+      });
 
-    expect(payloads).toEqual([{ text: "Gateway restarting…" }]);
-  });
+      expect(payloads).toEqual([{ text: "Gateway restarting…" }]);
+    },
+  );
 
   it("keeps timed-out cron exec failures compact when verbose mode is off", () => {
     const payloads = buildPayloads({

--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -562,12 +562,28 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
         mutatingAction: true,
       },
       runAborted: true,
+      runStopReason: "aborted",
     });
 
     expectSingleToolErrorPayload(payloads, {
       title: "Bash",
       absentDetail: "codex native tool blocked",
     });
+  });
+
+  it("renders an intentional Gateway restart as status instead of tool failure", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "gateway_exec",
+        error: "OpenClaw dynamic tool call aborted.",
+        executionStarted: true,
+      },
+      runAborted: true,
+      runStopReason: "restart",
+      toolResultFormat: "markdown",
+    });
+
+    expect(payloads).toEqual([{ text: "Gateway restarting…" }]);
   });
 
   it("keeps timed-out cron exec failures compact when verbose mode is off", () => {

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -160,6 +160,7 @@ export function buildEmbeddedRunPayloads(params: {
   agentId?: string;
   runId?: string;
   runAborted?: boolean;
+  runStopReason?: string;
   deferAssistantTimeoutError?: boolean;
   didSendDeterministicApprovalPrompt?: boolean;
   heartbeatToolResponse?: HeartbeatToolResponse;
@@ -431,7 +432,11 @@ export function buildEmbeddedRunPayloads(params: {
       useMarkdown,
     });
     if (failureWarning) {
-      const normalizedWarning = normalizeTextForComparison(failureWarning.text);
+      // A restart intentionally aborts the active tool while the Gateway takes over.
+      // Present that lifecycle transition without converting it into a tool failure.
+      const isRestartStatus = params.runStopReason === "restart";
+      const warningText = isRestartStatus ? "Gateway restarting…" : failureWarning.text;
+      const normalizedWarning = normalizeTextForComparison(warningText);
       const duplicateWarning = normalizedWarning
         ? replyItems.some((item) => {
             if (!item.text) {
@@ -443,10 +448,14 @@ export function buildEmbeddedRunPayloads(params: {
         : false;
       if (!duplicateWarning) {
         replyItems.push({
-          text: failureWarning.text,
-          isError: true,
-          nonTerminalToolErrorWarning:
-            hasUserFacingReply && failureWarning.nonTerminalToolErrorWarning,
+          text: warningText,
+          ...(!isRestartStatus
+            ? {
+                isError: true,
+                nonTerminalToolErrorWarning:
+                  hasUserFacingReply && failureWarning.nonTerminalToolErrorWarning,
+              }
+            : {}),
         });
       }
     }

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -423,20 +423,21 @@ export function buildEmbeddedRunPayloads(params: {
     hasUserFacingReply = true;
   }
   if (params.lastToolError) {
-    const failureWarning = buildFailureWarning({
-      lastToolError: params.lastToolError,
-      hasUserFacingReply,
-      suppressToolErrors: Boolean(params.config?.messages?.suppressToolErrors),
-      suppressToolErrorWarnings: params.suppressToolErrorWarnings,
-      verboseLevel: params.verboseLevel,
-      useMarkdown,
-    });
+    // A restart intentionally aborts the active tool while the Gateway takes over.
+    // Keep that lifecycle status independent from tool-error suppression.
+    const isRestartStatus = params.runStopReason === "restart";
+    const failureWarning = isRestartStatus
+      ? { text: "Gateway restarting…", nonTerminalToolErrorWarning: false }
+      : buildFailureWarning({
+          lastToolError: params.lastToolError,
+          hasUserFacingReply,
+          suppressToolErrors: Boolean(params.config?.messages?.suppressToolErrors),
+          suppressToolErrorWarnings: params.suppressToolErrorWarnings,
+          verboseLevel: params.verboseLevel,
+          useMarkdown,
+        });
     if (failureWarning) {
-      // A restart intentionally aborts the active tool while the Gateway takes over.
-      // Present that lifecycle transition without converting it into a tool failure.
-      const isRestartStatus = params.runStopReason === "restart";
-      const warningText = isRestartStatus ? "Gateway restarting…" : failureWarning.text;
-      const normalizedWarning = normalizeTextForComparison(warningText);
+      const normalizedWarning = normalizeTextForComparison(failureWarning.text);
       const duplicateWarning = normalizedWarning
         ? replyItems.some((item) => {
             if (!item.text) {
@@ -448,7 +449,7 @@ export function buildEmbeddedRunPayloads(params: {
         : false;
       if (!duplicateWarning) {
         replyItems.push({
-          text: warningText,
+          text: failureWarning.text,
           ...(!isRestartStatus
             ? {
                 isError: true,

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
@@ -357,6 +357,25 @@ describe("prepareEmbeddedRunTerminal", () => {
       expect.objectContaining({ lastAssistant: yieldedAssistant, currentAssistant: null }),
     );
   });
+
+  it("carries the canonical restart reason into terminal payload rendering", async () => {
+    await prepareAttempt({
+      attempt: attemptResult({
+        lastToolError: {
+          toolName: "gateway_exec",
+          error: "OpenClaw dynamic tool call aborted.",
+        },
+      }),
+      terminalState: {
+        outcome: { reason: "cancelled", status: "error", stopReason: "restart" },
+        signalOwnedInterruption: true,
+      },
+    });
+
+    expect(payloadMocks.buildEmbeddedRunPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({ runAborted: true, runStopReason: "restart" }),
+    );
+  });
 });
 
 describe("prepareEmbeddedRunTerminal run stats", () => {

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.ts
@@ -217,6 +217,7 @@ export function prepareEmbeddedRunTerminal(input: {
     agentId: runParams.agentId,
     runId: runParams.runId,
     runAborted: isEmbeddedRunTerminalInterrupted(input.terminalState.outcome),
+    runStopReason: input.terminalState.outcome.stopReason,
     deferAssistantTimeoutError:
       timedOutDuringPrompt &&
       (!hasMessagingToolDeliveryEvidence(attempt) ||


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users asking an agent to restart its Gateway would see `Gateway Exec failed` even though the intentional restart was proceeding normally.

## Why This Change Was Made

The terminal payload renderer now receives the canonical run stop reason and reports `Gateway restarting…` only for intentional restart interruptions. Ordinary tool failures and unrelated aborts keep their existing warning behavior.

## User Impact

Gateway self-restarts now produce a calm, accurate progress message instead of a scary false failure.

## Evidence

- Base reproduction at `eea8f9615e68b10c693c040cf60b149151beb87e`: `[{"text":"⚠️ 🧩 Gateway Exec failed","isError":true}]`
- Proposed head: `[{"text":"Gateway restarting…"}]`
- Focused Vitest: 74 tests passed across `payloads.test.ts` and `terminal-preparation.test.ts`
- Source-blind behavior validation: 6 passed, covering restart, restart with tool-error suppression, ordinary failure, unrelated abort, an existing assistant reply, and an alternate tool name
- Autoreview: no blocking findings, 0.99 confidence
- `node scripts/check-changed.mjs`: all completed checks passed; core-test typechecking stops on the pre-existing missing `pako` declaration in `ui/vite.config.ts`, reproduced unchanged on pristine `origin/main`. Post-typecheck policy checks passed when run directly.
- An authenticated Discord green run was not performed because it would require deploying unmerged code to a credentialed live Gateway and intentionally restarting it. The payload classification is channel-independent and is covered at its terminal owner boundary.
- ClawSweeper rank-up move skipped: no Telegram Test Server restart event was recorded for the same reason. The change has no Telegram-specific code; its shared terminal payload contract is covered directly.
