### PR TITLE
fix(memory-lancedb): avoid Proxy delete trap when stripping auto-added sort column

### DIFF
--- a/extensions/memory-lancedb/memory-cli.test.ts
+++ b/extensions/memory-lancedb/memory-cli.test.ts
@@ -1,3 +1,4 @@
+import { tableFromArrays } from "apache-arrow";
 import { Command } from "commander";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi } from "./api.js";
@@ -5,7 +6,11 @@ import type { Embeddings } from "./embeddings.js";
 import type { MemoryDB } from "./lancedb-store.js";
 import { registerMemoryCli } from "./memory-cli.js";
 
-function createHarness(params?: { embedError?: unknown; closeError?: Error }) {
+function createHarness(params?: {
+  embedError?: unknown;
+  closeError?: Error;
+  queryRows?: Record<string, unknown>[];
+}) {
   const registerCli = vi.fn();
   const closeError = params?.closeError;
   const close = closeError
@@ -24,9 +29,10 @@ function createHarness(params?: { embedError?: unknown; closeError?: Error }) {
     close,
   };
   const search = vi.fn(async () => []);
+  const query = vi.fn(async () => params?.queryRows ?? []);
   registerMemoryCli(
     { registerCli } as unknown as OpenClawPluginApi,
-    { search } as unknown as MemoryDB,
+    { search, query } as unknown as MemoryDB,
     embeddings,
     (rawAgentId) => (typeof rawAgentId === "string" ? rawAgentId : "main"),
     () => ({
@@ -133,4 +139,51 @@ describe("memory-lancedb CLI embedding lifecycle", () => {
     expect(rejection).toBeNull();
     expect(harness.close).toHaveBeenCalledTimes(1);
   });
+});
+
+describe("memory-lancedb CLI query output", () => {
+  it.each([
+    { columns: "id,text", order: "createdAt:asc", ids: ["first", "second"] },
+    { columns: "id,text", order: "createdAt:desc", ids: ["third", "second"] },
+    { columns: "id,text,createdAt", order: "createdAt:asc", ids: ["first", "second"] },
+  ])(
+    "projects $columns ordered by $order without mutating Arrow rows",
+    async ({ columns, order, ids }) => {
+      const table = tableFromArrays({
+        id: ["third", "first", "second"],
+        text: ["third memory", "first memory", "second memory"],
+        createdAt: [30, 10, 20],
+      });
+      const originalRows = table.toArray().map((row) => row.toJSON());
+      const harness = createHarness({ queryRows: table.toArray() });
+      let stdout = "";
+      const write = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+        stdout += String(chunk);
+        return true;
+      });
+      try {
+        await harness.program.parseAsync([
+          "node",
+          "openclaw",
+          "ltm",
+          "query",
+          "--cols",
+          columns,
+          "--order-by",
+          order,
+          "--limit",
+          "2",
+        ]);
+      } finally {
+        write.mockRestore();
+      }
+
+      const rows = JSON.parse(stdout) as Array<Record<string, unknown>>;
+      expect(rows.map((row) => row.id)).toEqual(ids);
+      expect(rows.map((row) => Object.keys(row))).toEqual(ids.map(() => columns.split(",")));
+      expect(rows.map((row) => row.text)).toEqual(ids.map((id) => `${id} memory`));
+      expect(table.toArray().map((row) => row.toJSON())).toEqual(originalRows);
+      expect(harness.embed).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/extensions/memory-lancedb/memory-cli.ts
+++ b/extensions/memory-lancedb/memory-cli.ts
@@ -213,9 +213,10 @@ export function registerMemoryCli(
             });
             rows = rows.slice(0, limit);
             if (!outputColumns.includes(order.column)) {
-              for (const row of rows) {
-                delete row[order.column];
-              }
+              rows = rows.map(row => {
+                const { [order.column]: _, ...rest } = row as Record<string, unknown>;
+                return rest as typeof row;
+              });
             }
           }
           defaultRuntime.writeJson(rows);

--- a/extensions/memory-lancedb/memory-cli.ts
+++ b/extensions/memory-lancedb/memory-cli.ts
@@ -212,14 +212,13 @@ export function registerMemoryCli(
               return 0;
             });
             rows = rows.slice(0, limit);
-            if (!outputColumns.includes(order.column)) {
-              rows = rows.map(row => {
-                const { [order.column]: _, ...rest } = row as Record<string, unknown>;
-                return rest as typeof row;
-              });
-            }
           }
-          defaultRuntime.writeJson(rows);
+          // Arrow rows are schema-backed proxies; project output without mutating them.
+          defaultRuntime.writeJson(
+            rows.map((row) =>
+              Object.fromEntries(outputColumns.map((column) => [column, row[column]])),
+            ),
+          );
         });
 
       memory


### PR DESCRIPTION
Closes #133115
Related: #127425 (unchanged ordering-performance work)

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers remains enabled.

</details>

## What Problem This Solves

Fixes an issue where users querying LanceDB memories with a narrow column list would get a CLI error instead of rows when sorting by an omitted column. For example, `openclaw ltm query --cols id,text --order-by createdAt:asc --limit 2` failed with a proxy `deleteProperty` error.

## Why This Change Was Made

LanceDB returns Arrow rows backed by schema-aware proxies, which reject property deletion. After the existing sort and limit, the CLI now constructs plain output objects from the requested columns instead of deleting the hidden sort field from database-owned rows. This also removes the separate hidden-column mutation branch and avoids redundant casts.

Storage, agent scope, filtering, ordering, and query-limit execution are unchanged. Provider-side ordering and the resource-bound concern in #127425 remain separate. Production LOC: +6/−6, net 0; tests: +55/−2, net +53. Existing documentation already describes this output contract.

Thanks to @BG3JKC for the reproduction and @MeGaurav4 for the original repair. This update retains the existing PR and contributor credit.

## User Impact

Ordered queries now return the requested rows and columns, whether or not the sort field was explicitly selected. Requested column order, default output, empty results, and agent isolation remain intact.

## Evidence

Trusted source and exact pinned `@lancedb/lancedb` 0.37.1 / `apache-arrow` 18.1.0 were exercised against isolated temporary stores, with no operator data or provider calls. This ran the actual registered Commander action and MemoryDB/native query path; it did not exercise global plugin installation.

Before: the reported command exited 1 with no stdout and `TypeError: 'deleteProperty' on proxy: trap returned falsish for property 'createdAt'`. Including `createdAt` in `--cols` exited 0 and returned two rows.

After: eight real native-query cases passed with no stderr or embedding calls: hidden sort column ascending/descending, requested sort column, unordered query, default columns, filter plus foreign-agent exclusion, empty result, and requested column order.

The regression uses actual Arrow row proxies through the real parser and JSON writer. Both hidden-column cases failed before the runtime edit; the included-column control passed. All 12 CLI and existing store tests pass after the fix:

```sh
node scripts/run-vitest.mjs extensions/memory-lancedb/memory-cli.test.ts extensions/memory-lancedb/lancedb-store.test.ts --maxWorkers=1
```

Full independent source/dependency/behavior review and structured autoreview found no actionable issues. The canonical two-path changed-file gate passed on trusted baseline a8c8c827. The final correction `eb4b4abc95f8b252267a43097007aad4b358323f` preserves the original contributor commit as its parent. The same 12 tests and eight native cases also pass on its exact source tree over trusted upstream parent `136eab023035dd5943818f791d3c3db7d92e4491`; these ran before commit creation, and every source byte was verified unchanged afterward. Required hosted [CI](https://github.com/openclaw/openclaw/actions/runs/33312365604) and `openclaw/ci-gate` passed on this exact head, without retries.

Actual after output from the registered Commander/native-store run (isolated fixture data):

```text
argv: ltm query --cols id,text --order-by createdAt:asc --limit 2
exit: 0
stderr: empty
```

```json
[
  {
    "id": "f1969b6b-2ae8-4add-a9db-861c9fc1b45e",
    "text": "first alpha memory"
  },
  {
    "id": "a8a93d97-0569-45d8-a80b-9ab2791fef86",
    "text": "second alpha memory"
  }
]
```

The requested `id,text` keys are the only emitted fields; `createdAt` remains available for sorting without mutating the returned Arrow rows. Both existing rank-up requests (real proxy regression and native after output) are addressed above. The pinned Arrow source also confirms that its StructRow proxy rejects deletion; no dependency or storage changes were needed.
