### PR TITLE
fix(worker): reject malformed protocol records

### DIFF
--- a/src/worker/launch-descriptor.test.ts
+++ b/src/worker/launch-descriptor.test.ts
@@ -346,6 +346,17 @@ describe("worker launch descriptor", () => {
     descriptor.assignment.toolAuthority.allowedToolNames = ["computer"];
     descriptor.assignment.prompt = [{ type: "image", data: "AA==", mimeType: "image/png" }];
     expect(parseWorkerLaunchDescriptor(descriptor)).toEqual(descriptor);
+    const { computer, ...assignmentFields } = descriptor.assignment;
+    const inheritedComputerAssignment = Object.assign(
+      Object.create({ computer }),
+      assignmentFields,
+    );
+    expect(() =>
+      parseWorkerLaunchDescriptor({
+        ...descriptor,
+        assignment: inheritedComputerAssignment,
+      }),
+    ).toThrow("invalid worker launch descriptor");
     const { nodeId, ...computerFields } = descriptor.assignment.computer;
     const inheritedNodeIdComputer = Object.assign(Object.create({ nodeId }), computerFields);
     for (const computer of [

--- a/src/worker/launch-descriptor.test.ts
+++ b/src/worker/launch-descriptor.test.ts
@@ -359,7 +359,7 @@ describe("worker launch descriptor", () => {
     ).toThrow("invalid worker launch descriptor");
     const { nodeId, ...computerFields } = descriptor.assignment.computer;
     const inheritedNodeIdComputer = Object.assign(Object.create({ nodeId }), computerFields);
-    for (const computer of [
+    for (const candidateComputer of [
       undefined,
       { ...descriptor.assignment.computer, gatewayUrl: "ws://other" },
       { ...descriptor.assignment.computer, nodeId: "" },
@@ -368,7 +368,7 @@ describe("worker launch descriptor", () => {
       expect(() =>
         parseWorkerLaunchDescriptor({
           ...descriptor,
-          assignment: { ...descriptor.assignment, computer },
+          assignment: { ...descriptor.assignment, computer: candidateComputer },
         }),
       ).toThrow("invalid worker launch descriptor");
     }

--- a/src/worker/launch-descriptor.test.ts
+++ b/src/worker/launch-descriptor.test.ts
@@ -106,6 +106,19 @@ describe("worker launch descriptor", () => {
     });
   });
 
+  it("rejects a launch version inherited from the prototype", () => {
+    const descriptor = launchDescriptor();
+    const { version, ...ownFields } = descriptor;
+    const candidate = Object.assign(
+      Object.create({ version }) as Record<string, unknown>,
+      ownFields,
+    );
+
+    expect(() => parseWorkerLaunchDescriptor(candidate)).toThrow(
+      "invalid worker launch descriptor",
+    );
+  });
+
   it("accepts the permission context pair only when both fields are present", () => {
     const descriptor = launchDescriptor();
     const {
@@ -333,10 +346,13 @@ describe("worker launch descriptor", () => {
     descriptor.assignment.toolAuthority.allowedToolNames = ["computer"];
     descriptor.assignment.prompt = [{ type: "image", data: "AA==", mimeType: "image/png" }];
     expect(parseWorkerLaunchDescriptor(descriptor)).toEqual(descriptor);
+    const { nodeId, ...computerFields } = descriptor.assignment.computer;
+    const inheritedNodeIdComputer = Object.assign(Object.create({ nodeId }), computerFields);
     for (const computer of [
       undefined,
       { ...descriptor.assignment.computer, gatewayUrl: "ws://other" },
       { ...descriptor.assignment.computer, nodeId: "" },
+      inheritedNodeIdComputer,
     ]) {
       expect(() =>
         parseWorkerLaunchDescriptor({

--- a/src/worker/launch-descriptor.ts
+++ b/src/worker/launch-descriptor.ts
@@ -34,6 +34,7 @@ import {
   ComputerUseCapabilityDescriptorSchema,
   type ComputerUseCapabilityDescriptor,
 } from "../plugins/computer-use-contract.js";
+import { hasExactOwnKeys } from "./protocol-record.js";
 import { isWorkerToolName, type WorkerToolAuthority } from "./tool-authority.js";
 import { isWorkerTranscriptMessageFrameSafe } from "./transcript-message.js";
 import {
@@ -99,13 +100,6 @@ export type WorkerLaunchDescriptor = WorkerLaunchPlan & {
   connectionEndpoint: WorkerConnectionEndpoint;
 };
 
-function hasExactKeys(value: Record<string, unknown>, required: string[], optional: string[] = []) {
-  const allowed = new Set([...required, ...optional]);
-  return (
-    required.every((key) => key in value) && Object.keys(value).every((key) => allowed.has(key))
-  );
-}
-
 function isIdentifier(value: unknown): value is string {
   return (
     typeof value === "string" &&
@@ -130,7 +124,7 @@ function isInferenceOptions(value: unknown): value is WorkerInferenceOptions {
 function parseToolAuthority(value: unknown): WorkerToolAuthority | undefined {
   if (
     !isRecord(value) ||
-    !hasExactKeys(value, ["allowedToolNames"]) ||
+    !hasExactOwnKeys(value, ["allowedToolNames"]) ||
     !Array.isArray(value.allowedToolNames) ||
     !value.allowedToolNames.every(isWorkerToolName) ||
     new Set(value.allowedToolNames).size !== value.allowedToolNames.length
@@ -143,7 +137,7 @@ function parseToolAuthority(value: unknown): WorkerToolAuthority | undefined {
 function parseBrowserLaunchDescriptor(value: unknown): WorkerBrowserLaunchDescriptor | undefined {
   if (
     !isRecord(value) ||
-    !hasExactKeys(value, ["cdpUrl", "launcherPath"]) ||
+    !hasExactOwnKeys(value, ["cdpUrl", "launcherPath"]) ||
     typeof value.cdpUrl !== "string" ||
     typeof value.launcherPath !== "string" ||
     !isAbsoluteHostPath(value.launcherPath)
@@ -181,7 +175,7 @@ function parseBrowserLaunchDescriptor(value: unknown): WorkerBrowserLaunchDescri
 function parseAssignment(value: unknown): WorkerLaunchAssignment | undefined {
   if (
     !isRecord(value) ||
-    !hasExactKeys(
+    !hasExactOwnKeys(
       value,
       [
         "agentId",
@@ -257,7 +251,7 @@ function parseAssignment(value: unknown): WorkerLaunchAssignment | undefined {
     toolAuthority.allowedToolNames.includes("computer") !== (value.computer !== undefined) ||
     (value.computer !== undefined &&
       (!isRecord(value.computer) ||
-        !hasExactKeys(value.computer, ["nodeId", "computerUse"]) ||
+        !hasExactOwnKeys(value.computer, ["nodeId", "computerUse"]) ||
         !isIdentifier(value.computer.nodeId) ||
         !Value.Check(ComputerUseCapabilityDescriptorSchema, value.computer.computerUse)))
   ) {
@@ -271,7 +265,7 @@ function parseAssignment(value: unknown): WorkerLaunchAssignment | undefined {
   }
   if (
     !isRecord(value.transcript) ||
-    !hasExactKeys(value.transcript, ["baseLeafId", "nextSeq"]) ||
+    !hasExactOwnKeys(value.transcript, ["baseLeafId", "nextSeq"]) ||
     (value.transcript.baseLeafId !== null && !isIdentifier(value.transcript.baseLeafId)) ||
     !isSafeSequence(value.transcript.nextSeq, 1)
   ) {
@@ -279,7 +273,7 @@ function parseAssignment(value: unknown): WorkerLaunchAssignment | undefined {
   }
   if (
     !isRecord(value.liveEvents) ||
-    !hasExactKeys(value.liveEvents, ["ackedSeq", "nextSeq"]) ||
+    !hasExactOwnKeys(value.liveEvents, ["ackedSeq", "nextSeq"]) ||
     !isSafeSequence(value.liveEvents.ackedSeq, 0) ||
     !isSafeSequence(value.liveEvents.nextSeq, 1) ||
     value.liveEvents.nextSeq !== value.liveEvents.ackedSeq + 1
@@ -345,7 +339,7 @@ function validateWorkerLaunchPlan(candidate: WorkerLaunchPlan): WorkerLaunchPlan
 export function parseWorkerLaunchPlan(value: unknown): WorkerLaunchPlan {
   if (
     !isRecord(value) ||
-    !hasExactKeys(value, ["version", "admission", "assignment"]) ||
+    !hasExactOwnKeys(value, ["version", "admission", "assignment"]) ||
     value.version !== LAUNCH_VERSION
   ) {
     throw new Error("invalid worker launch descriptor");
@@ -376,7 +370,7 @@ export function completeWorkerLaunchDescriptor(
 export function parseWorkerLaunchDescriptor(value: unknown): WorkerLaunchDescriptor {
   if (
     !isRecord(value) ||
-    !hasExactKeys(value, ["version", "connectionEndpoint", "admission", "assignment"])
+    !hasExactOwnKeys(value, ["version", "connectionEndpoint", "admission", "assignment"])
   ) {
     throw new Error("invalid worker launch descriptor");
   }

--- a/src/worker/node-desktop-protocol.ts
+++ b/src/worker/node-desktop-protocol.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { WorkerDesktopApp } from "../plugins/capability-provider.types.js";
 import { NODE_DESKTOP_ATTACH_PATH } from "../shared/node-desktop-stream.js";
+import { hasExactOwnKeys } from "./protocol-record.js";
 
 const REQUEST_MAX_BYTES = 16 * 1024;
 const PATH_MAX_BYTES = 4 * 1024;
@@ -23,18 +24,6 @@ function parseJson(raw?: string | null): unknown {
   } catch {
     throw new Error("INVALID_REQUEST: malformed node worker desktop request");
   }
-}
-
-function hasExactKeys(
-  value: Record<string, unknown>,
-  required: readonly string[],
-  optional: readonly string[] = [],
-): boolean {
-  const allowed = new Set([...required, ...optional]);
-  return (
-    required.every((key) => Object.hasOwn(value, key)) &&
-    Object.keys(value).every((key) => allowed.has(key))
-  );
 }
 
 function isValidPort(value: unknown): value is number {
@@ -59,7 +48,7 @@ export function parseNodeWorkerDesktopStreamInput(
   const value = parseJson(raw);
   if (
     !isRecord(value) ||
-    !hasExactKeys(value, ["ticket", "attachPath", "port"], ["passwordFilePath"])
+    !hasExactOwnKeys(value, ["ticket", "attachPath", "port"], ["passwordFilePath"])
   ) {
     throw new Error("INVALID_REQUEST: invalid node worker desktop stream request");
   }
@@ -92,12 +81,12 @@ export function parseNodeWorkerDesktopLaunchInput(raw?: string | null): WorkerDe
   }
   const executablePath = requireAbsolutePath(value.executablePath, "executablePath");
   if (value.id === "terminal") {
-    if (!hasExactKeys(value, ["id", "executablePath"])) {
+    if (!hasExactOwnKeys(value, ["id", "executablePath"])) {
       throw new Error("INVALID_REQUEST: invalid node worker terminal descriptor");
     }
     return { id: "terminal", executablePath };
   }
-  if (!hasExactKeys(value, ["id", "executablePath", "cdpPort"]) || !isValidPort(value.cdpPort)) {
+  if (!hasExactOwnKeys(value, ["id", "executablePath", "cdpPort"]) || !isValidPort(value.cdpPort)) {
     throw new Error("INVALID_REQUEST: invalid node worker browser descriptor");
   }
   return { id: "browser", executablePath, cdpPort: value.cdpPort };

--- a/src/worker/node-supervisor-protocol.ts
+++ b/src/worker/node-supervisor-protocol.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { stableStringify } from "@openclaw/normalization-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { parseWorkerLaunchPlan, type WorkerLaunchPlan } from "./launch-descriptor.js";
+import { hasExactOwnKeys } from "./protocol-record.js";
 
 const IDENTIFIER_MAX_CHARS = 256;
 const GATEWAY_NAMESPACE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
@@ -60,12 +61,6 @@ export type NodeWorkerConnectionFailureMessage = {
   type: typeof NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE;
   cause: string | null;
 };
-
-function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
-  return (
-    Object.keys(value).length === keys.length && keys.every((key) => Object.hasOwn(value, key))
-  );
-}
 
 function isIdentifier(value: unknown): value is string {
   return (
@@ -129,7 +124,7 @@ export function parseNodeWorkerLaunchInput(raw?: string | null): NodeWorkerLaunc
 export function validateNodeWorkerLaunchInput(value: unknown): NodeWorkerLaunchInput {
   if (
     !isRecord(value) ||
-    !hasExactKeys(value, [
+    !hasExactOwnKeys(value, [
       "environmentSession",
       "launchId",
       "gatewayNamespace",
@@ -178,7 +173,7 @@ export function validateNodeWorkerLaunchInput(value: unknown): NodeWorkerLaunchI
 
 export function parseNodeWorkerLookupInput(raw?: string | null): { launchId: string } {
   const value = decodeRequest(raw);
-  if (!isRecord(value) || !hasExactKeys(value, ["launchId"])) {
+  if (!isRecord(value) || !hasExactOwnKeys(value, ["launchId"])) {
     throw new Error("INVALID_REQUEST: invalid node worker lookup request");
   }
   return { launchId: requireIdentifier(value.launchId, "launchId") };
@@ -191,7 +186,7 @@ export function parseNodeWorkerCancelInput(raw?: string | null): NodeWorkerSuper
   const value = decodeRequest(raw);
   if (
     !isRecord(value) ||
-    !hasExactKeys(value, [
+    !hasExactOwnKeys(value, [
       "launchId",
       "planHash",
       "environmentId",
@@ -229,7 +224,7 @@ export function parseNodeWorkerEnvironmentStopInput(
   const value = decodeRequest(raw);
   if (
     !isRecord(value) ||
-    !hasExactKeys(value, ["gatewayNamespace", "environmentId", "sessionId", "ownerEpoch"])
+    !hasExactOwnKeys(value, ["gatewayNamespace", "environmentId", "sessionId", "ownerEpoch"])
   ) {
     throw new Error("INVALID_REQUEST: invalid node worker environment stop request");
   }
@@ -325,7 +320,7 @@ export function parseNodeWorkerConnectionFailureMessage(
 ): NodeWorkerConnectionFailureMessage | null {
   if (
     !isRecord(value) ||
-    !hasExactKeys(value, ["type", "cause"]) ||
+    !hasExactOwnKeys(value, ["type", "cause"]) ||
     value.type !== NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE ||
     (value.cause !== null &&
       (typeof value.cause !== "string" ||
@@ -351,18 +346,18 @@ export function parseNodeWorkerSupervisorReceipt(
     return null;
   }
   if (value.state === "pending" || value.state === "running") {
-    return hasExactKeys(value, [...RECEIPT_IDENTITY_KEYS, "state"])
+    return hasExactOwnKeys(value, [...RECEIPT_IDENTITY_KEYS, "state"])
       ? { ...identity, state: value.state }
       : null;
   }
   if (value.state === "completed") {
-    return hasExactKeys(value, [...RECEIPT_IDENTITY_KEYS, "state", "resultJson"]) &&
+    return hasExactOwnKeys(value, [...RECEIPT_IDENTITY_KEYS, "state", "resultJson"]) &&
       isBoundedResultJson(value.resultJson)
       ? { ...identity, state: value.state, resultJson: value.resultJson }
       : null;
   }
   if (value.state === "failed" || value.state === "interrupted" || value.state === "cancelled") {
-    return hasExactKeys(value, [...RECEIPT_IDENTITY_KEYS, "state", "errorText"]) &&
+    return hasExactOwnKeys(value, [...RECEIPT_IDENTITY_KEYS, "state", "errorText"]) &&
       isBoundedErrorText(value.errorText)
       ? { ...identity, state: value.state, errorText: value.errorText }
       : null;

--- a/src/worker/node-workspace-protocol.ts
+++ b/src/worker/node-workspace-protocol.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { SpawnResult } from "../process/exec.js";
 import type { NodeWorkerWorkspaceTransferInput } from "./node-workspace-transfer-protocol.js";
+import { hasExactOwnKeys } from "./protocol-record.js";
 
 const IDENTIFIER_MAX_CHARS = 256;
 const GATEWAY_NAMESPACE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
@@ -34,14 +35,6 @@ export type NodeWorkerWorkspaceExecInput = {
 
 export type NodeWorkerWorkspaceExecResult = SpawnResult & { workspaceDir: string };
 
-function hasExactKeys(value: Record<string, unknown>, required: string[], optional: string[] = []) {
-  const allowed = new Set([...required, ...optional]);
-  return (
-    required.every((key) => Object.hasOwn(value, key)) &&
-    Object.keys(value).every((key) => allowed.has(key))
-  );
-}
-
 function parseJson(raw?: string | null): unknown {
   if (!raw || Buffer.byteLength(raw, "utf8") > REQUEST_MAX_BYTES) {
     throw new Error("INVALID_REQUEST: invalid node worker workspace request");
@@ -72,7 +65,7 @@ export function parseNodeWorkerWorkspaceExecInput(
   const value = parseJson(raw);
   if (
     !isRecord(value) ||
-    !hasExactKeys(
+    !hasExactOwnKeys(
       value,
       ["gatewayNamespace", "environmentId", "sessionId", "generation", "argv"],
       ["input", "timeoutMs", "resetWorkspace", "transfer", "seed"],
@@ -139,11 +132,11 @@ export function parseNodeWorkerWorkspaceExecInput(
       throw new Error("INVALID_REQUEST: workspace seed key must be a SHA-256 hex digest");
     }
     const { action, key, maxAgeMs } = value.seed;
-    if (action === "apply" && hasExactKeys(value.seed, ["action", "key"])) {
+    if (action === "apply" && hasExactOwnKeys(value.seed, ["action", "key"])) {
       seed = { action, key };
     } else if (
       action === "store" &&
-      hasExactKeys(value.seed, ["action", "key", "maxAgeMs"]) &&
+      hasExactOwnKeys(value.seed, ["action", "key", "maxAgeMs"]) &&
       typeof maxAgeMs === "number" &&
       Number.isSafeInteger(maxAgeMs) &&
       maxAgeMs >= 0
@@ -170,11 +163,15 @@ export function parseNodeWorkerWorkspaceExecInput(
       token.length > 1_024 ||
       token.includes("\0") ||
       (direction === "download"
-        ? !hasExactKeys(value.transfer, ["direction", "token", "manifestRef"], ["attachments"]) ||
+        ? !hasExactOwnKeys(
+            value.transfer,
+            ["direction", "token", "manifestRef"],
+            ["attachments"],
+          ) ||
           !validRef(manifestRef) ||
           (value.transfer.attachments !== undefined && value.transfer.attachments !== true)
         : direction === "upload"
-          ? !hasExactKeys(value.transfer, ["direction", "token", "baseManifestRef"]) ||
+          ? !hasExactOwnKeys(value.transfer, ["direction", "token", "baseManifestRef"]) ||
             !validRef(baseManifestRef)
           : true)
     ) {
@@ -217,7 +214,7 @@ export function parseNodeWorkerWorkspaceExecResult(
 ): NodeWorkerWorkspaceExecResult | null {
   if (
     !isRecord(value) ||
-    !hasExactKeys(
+    !hasExactOwnKeys(
       value,
       ["workspaceDir", "stdout", "stderr", "code", "signal", "killed", "termination"],
       [

--- a/src/worker/protocol-record.ts
+++ b/src/worker/protocol-record.ts
@@ -6,6 +6,7 @@ export function hasExactOwnKeys(
   const allowed = new Set([...required, ...optional]);
   return (
     required.every((key) => Object.hasOwn(value, key)) &&
+    optional.every((key) => Object.hasOwn(value, key) || !Reflect.has(value, key)) &&
     Object.keys(value).every((key) => allowed.has(key))
   );
 }

--- a/src/worker/protocol-record.ts
+++ b/src/worker/protocol-record.ts
@@ -1,0 +1,11 @@
+export function hasExactOwnKeys(
+  value: Record<string, unknown>,
+  required: readonly string[],
+  optional: readonly string[] = [],
+): boolean {
+  const allowed = new Set([...required, ...optional]);
+  return (
+    required.every((key) => Object.hasOwn(value, key)) &&
+    Object.keys(value).every((key) => allowed.has(key))
+  );
+}

--- a/src/worker/protocol-record.ts
+++ b/src/worker/protocol-record.ts
@@ -1,5 +1,5 @@
 export function hasExactOwnKeys(
-  value: Record<string, unknown>,
+  value: object,
   required: readonly string[],
   optional: readonly string[] = [],
 ): boolean {

--- a/src/worker/worker-command.runtime.test.ts
+++ b/src/worker/worker-command.runtime.test.ts
@@ -220,6 +220,60 @@ describe("worker command lifetime gate", () => {
     expect(diagnostics).toContain("worker state diagnostic");
   });
 
+  it("rejects an internal worker IPC start type inherited from the prototype", async () => {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const originalConsole = globalThis.console;
+    const previousLogging = { ...loggingState };
+    const originalProperties = new Map(
+      ["connected", "channel", "send", "disconnect", "stdin", "stdout", "stderr"].map((key) => [
+        key,
+        Object.getOwnPropertyDescriptor(process, key),
+      ]),
+    );
+    Object.defineProperties(process, {
+      connected: { configurable: true, value: true },
+      channel: { configurable: true, value: {} },
+      send: { configurable: true, value: vi.fn() },
+      disconnect: { configurable: true, value: vi.fn() },
+      stdin: { configurable: true, value: commandInput() },
+      stdout: { configurable: true, value: stdout },
+      stderr: { configurable: true, value: stderr },
+    });
+    globalThis.console = new Console({ stdout, stderr });
+    loggingState.consolePatched = false;
+    loggingState.forceConsoleToStderr = false;
+    loggingState.rawConsole = null;
+    loggingState.streamErrorHandlersInstalled = false;
+    const invalidStart = Object.assign(
+      Object.create({ type: "openclaw-worker-start-v1" }) as Record<string, unknown>,
+      { unexpected: true },
+    );
+
+    try {
+      const running = runWorkerProcess({ internalWorkerIpc: true });
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+      process.emit("message", invalidStart);
+
+      await expect(running).rejects.toThrow("invalid internal worker IPC start message");
+      expect(runWorkerDescriptor).not.toHaveBeenCalled();
+    } finally {
+      for (const [key, propertyDescriptor] of originalProperties) {
+        if (propertyDescriptor) {
+          Object.defineProperty(process, key, propertyDescriptor);
+        } else {
+          Reflect.deleteProperty(process, key);
+        }
+      }
+      globalThis.console = originalConsole;
+      Object.assign(loggingState, previousLogging);
+      stdout.destroy();
+      stderr.destroy();
+    }
+  });
+
   it("passes the build-composed Browser runtime into the worker boundary", async () => {
     const output = new PassThrough();
     const browserRuntime = {

--- a/src/worker/worker-connection-contract.ts
+++ b/src/worker/worker-connection-contract.ts
@@ -10,6 +10,7 @@ import type {
 } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 import type { BackoffPolicy } from "../infra/backoff.js";
 import { redactSensitiveText } from "../logging/redact.js";
+import { hasExactOwnKeys } from "./protocol-record.js";
 import type { WorkerConnectionEndpoint } from "./worker-connection-endpoint.js";
 
 const FENCED_CLOSE_REASONS = new Set<WorkerProtocolCloseReason>([
@@ -100,7 +101,7 @@ export function parseWorkerAdmissionDeadlineResult(
 ): WorkerAdmissionDeadlineResult | undefined {
   if (
     isRecord(value) &&
-    Object.keys(value).length === 3 &&
+    hasExactOwnKeys(value, ["status", "reason", "errorText"]) &&
     value.status === "not-started" &&
     value.reason === "admission-deadline" &&
     typeof value.errorText === "string" &&

--- a/src/worker/worker-connection-endpoint.test.ts
+++ b/src/worker/worker-connection-endpoint.test.ts
@@ -72,12 +72,19 @@ describe("worker connection endpoint", () => {
     });
   });
 
-  it("rejects endpoint kinds inherited from the prototype", () => {
+  it("rejects endpoint fields inherited from the prototype", () => {
     const endpoint = Object.assign(Object.create({ kind: "unix" }) as Record<string, unknown>, {
       socketPath: "/tmp/openclaw-worker/gateway.sock",
     });
 
     expect(parseWorkerConnectionEndpoint(endpoint)).toBeUndefined();
+
+    const websocketEndpoint = Object.assign(Object.create({ tlsFingerprint: fingerprint }), {
+      kind: "websocket",
+      url: "wss://gateway.example/__openclaw__/worker",
+    });
+
+    expect(parseWorkerConnectionEndpoint(websocketEndpoint)).toBeUndefined();
   });
 
   it.each([

--- a/src/worker/worker-connection-endpoint.test.ts
+++ b/src/worker/worker-connection-endpoint.test.ts
@@ -72,6 +72,14 @@ describe("worker connection endpoint", () => {
     });
   });
 
+  it("rejects endpoint kinds inherited from the prototype", () => {
+    const endpoint = Object.assign(Object.create({ kind: "unix" }) as Record<string, unknown>, {
+      socketPath: "/tmp/openclaw-worker/gateway.sock",
+    });
+
+    expect(parseWorkerConnectionEndpoint(endpoint)).toBeUndefined();
+  });
+
   it.each([
     `sha256:${fingerprint.toUpperCase()}`,
     fingerprint.toUpperCase(),

--- a/src/worker/worker-connection-endpoint.ts
+++ b/src/worker/worker-connection-endpoint.ts
@@ -12,6 +12,7 @@ import {
 } from "../../packages/gateway-client/src/websocket-transport.js";
 import { WORKER_PUBLIC_INGRESS_PATH } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 import { WORKER_PROTOCOL_MAX_IDENTIFIER_LENGTH } from "../../packages/gateway-protocol/src/schema/worker-protocol-primitives.js";
+import { hasExactOwnKeys } from "./protocol-record.js";
 
 const ENDPOINT_FIELD_MAX_LENGTH = 4_096;
 // JSON needs at most six bytes per UTF-16 code unit (control/lone-surrogate escapes).
@@ -52,16 +53,9 @@ export type WorkerConnectionEndpoint =
       cloudflareAccess?: CloudflareAccessCredentials;
     };
 
-function hasExactKeys(value: Record<string, unknown>, required: string[], optional: string[] = []) {
-  const allowed = new Set([...required, ...optional]);
-  return (
-    required.every((key) => key in value) && Object.keys(value).every((key) => allowed.has(key))
-  );
-}
-
 function parseUnixEndpoint(value: Record<string, unknown>): WorkerConnectionEndpoint | undefined {
   if (
-    !hasExactKeys(value, ["kind", "socketPath"]) ||
+    !hasExactOwnKeys(value, ["kind", "socketPath"]) ||
     value.kind !== "unix" ||
     typeof value.socketPath !== "string" ||
     value.socketPath.length > WORKER_PROTOCOL_MAX_IDENTIFIER_LENGTH ||
@@ -81,7 +75,7 @@ function parseWebSocketEndpoint(
       ? normalizeTlsFingerprint(value.tlsFingerprint)
       : undefined;
   if (
-    !hasExactKeys(value, ["kind", "url"], ["tlsFingerprint", "cloudflareAccess"]) ||
+    !hasExactOwnKeys(value, ["kind", "url"], ["tlsFingerprint", "cloudflareAccess"]) ||
     value.kind !== "websocket" ||
     typeof value.url !== "string" ||
     value.url.length > ENDPOINT_FIELD_MAX_LENGTH ||
@@ -125,7 +119,7 @@ function parseCloudflareAccessCredentials(value: unknown): CloudflareAccessCrede
   }
   if (
     !isRecord(value) ||
-    !hasExactKeys(value, ["clientId", "clientSecret"]) ||
+    !hasExactOwnKeys(value, ["clientId", "clientSecret"]) ||
     typeof value.clientId !== "string" ||
     value.clientId.trim().length === 0 ||
     value.clientId.length > ENDPOINT_FIELD_MAX_LENGTH ||

--- a/src/worker/worker-process-protocol.test.ts
+++ b/src/worker/worker-process-protocol.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseWorkerProcessRequest,
+  parseWorkerProcessResult,
+  parseWorkerRuntimeResult,
+} from "./worker-process-protocol.js";
+
+function inheritedRecord(
+  prototype: Record<string, unknown>,
+  ownFields: Record<string, unknown>,
+): Record<string, unknown> {
+  return Object.assign(Object.create(prototype) as Record<string, unknown>, ownFields);
+}
+
+describe("worker process protocol", () => {
+  it("rejects request discriminators inherited alongside the wrong own keys", () => {
+    const request = inheritedRecord({ type: "cancel" }, { turnId: "turn-1", unexpected: true });
+
+    expect(() => parseWorkerProcessRequest(request)).toThrow("invalid managed worker request");
+  });
+
+  it.each([
+    {
+      name: "fenced result",
+      value: inheritedRecord(
+        { status: "fenced" },
+        { reason: "credential-replaced", unexpected: true },
+      ),
+    },
+    {
+      name: "admission deadline result",
+      value: inheritedRecord(
+        { status: "not-started", reason: "admission-deadline" },
+        { errorText: "worker admission timed out", unexpected: true, ignored: true },
+      ),
+    },
+    {
+      name: "completed result",
+      value: inheritedRecord(
+        { status: "completed" },
+        { transcriptLeafId: null, transcriptNextSeq: 1, unexpected: true },
+      ),
+    },
+    {
+      name: "failed result",
+      value: inheritedRecord(
+        { status: "failed", reason: "turn-failed" },
+        {
+          transcriptLeafId: null,
+          transcriptNextSeq: 1,
+          unexpected: true,
+          ignored: true,
+        },
+      ),
+    },
+  ])("rejects an inherited discriminator for a $name", ({ value }) => {
+    expect(parseWorkerRuntimeResult(value)).toBeNull();
+  });
+
+  it("rejects process-result types inherited alongside the wrong own keys", () => {
+    const result = inheritedRecord(
+      { type: "result" },
+      {
+        turnId: "turn-1",
+        result: { status: "completed", transcriptLeafId: null, transcriptNextSeq: 1 },
+        retainWorker: false,
+        unexpected: true,
+      },
+    );
+
+    expect(parseWorkerProcessResult(result)).toBeNull();
+  });
+});

--- a/src/worker/worker-process-protocol.ts
+++ b/src/worker/worker-process-protocol.ts
@@ -6,6 +6,7 @@ import {
   type WorkerLaunchDescriptor,
   type WorkerLaunchPlan,
 } from "./launch-descriptor.js";
+import { hasExactOwnKeys } from "./protocol-record.js";
 import { parseWorkerAdmissionDeadlineResult } from "./worker-connection-contract.js";
 import { WORKER_CONNECTION_ENDPOINT_MAX_JSON_BYTES } from "./worker-connection-endpoint.js";
 import type { WorkerRuntimeResult } from "./worker.runtime.js";
@@ -55,10 +56,10 @@ export function parseWorkerProcessRequest(value: unknown): WorkerProcessInput {
   ) {
     throw new Error("invalid managed worker request");
   }
-  if (value.type === "cancel" && Object.keys(value).length === 2) {
+  if (value.type === "cancel" && hasExactOwnKeys(value, ["type", "turnId"])) {
     return { type: "cancel", turnId: value.turnId };
   }
-  if (value.type === "turn" && Object.keys(value).length === 3) {
+  if (value.type === "turn" && hasExactOwnKeys(value, ["type", "turnId", "descriptor"])) {
     const descriptor = parseWorkerLaunchDescriptor(value.descriptor);
     if (descriptor.assignment.turnId !== value.turnId) {
       throw new Error("managed worker request disagrees with its assigned turn");
@@ -79,7 +80,7 @@ export function parseWorkerRuntimeResult(value: unknown): WorkerRuntimeResult | 
   if (
     value.status === "fenced" &&
     (value.reason === "credential-replaced" || value.reason === "owner-epoch-mismatch") &&
-    Object.keys(value).length === 2
+    hasExactOwnKeys(value, ["status", "reason"])
   ) {
     return { status: value.status, reason: value.reason };
   }
@@ -93,13 +94,16 @@ export function parseWorkerRuntimeResult(value: unknown): WorkerRuntimeResult | 
       transcriptLeafId: value.transcriptLeafId,
       transcriptNextSeq: value.transcriptNextSeq,
     };
-    if (value.status === "completed" && Object.keys(value).length === 3) {
+    if (
+      value.status === "completed" &&
+      hasExactOwnKeys(value, ["status", "transcriptLeafId", "transcriptNextSeq"])
+    ) {
       return { status: value.status, ...transcript };
     }
     if (
       value.status === "failed" &&
       value.reason === "turn-failed" &&
-      Object.keys(value).length === 4
+      hasExactOwnKeys(value, ["status", "reason", "transcriptLeafId", "transcriptNextSeq"])
     ) {
       return { status: value.status, reason: value.reason, ...transcript };
     }
@@ -110,7 +114,7 @@ export function parseWorkerRuntimeResult(value: unknown): WorkerRuntimeResult | 
 export function parseWorkerProcessResult(value: unknown): WorkerProcessResult | null {
   if (
     !isRecord(value) ||
-    Object.keys(value).length !== 4 ||
+    !hasExactOwnKeys(value, ["type", "turnId", "result", "retainWorker"]) ||
     value.type !== "result" ||
     typeof value.turnId !== "string" ||
     !value.turnId.trim() ||

--- a/src/worker/worker-process.ts
+++ b/src/worker/worker-process.ts
@@ -15,7 +15,7 @@ function isWorkerStartMessage(value: unknown): boolean {
     typeof value === "object" &&
     value !== null &&
     !Array.isArray(value) &&
-    hasExactOwnKeys(value as Record<string, unknown>, ["type"]) &&
+    hasExactOwnKeys(value, ["type"]) &&
     (value as { type?: unknown }).type === WORKER_START_MESSAGE_TYPE
   );
 }

--- a/src/worker/worker-process.ts
+++ b/src/worker/worker-process.ts
@@ -5,6 +5,7 @@ import {
   NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE,
   type NodeWorkerConnectionFailureMessage,
 } from "./node-supervisor-protocol.js";
+import { hasExactOwnKeys } from "./protocol-record.js";
 import { runWorkerCommand, type WorkerCommandLifetime } from "./worker-command.runtime.js";
 
 const WORKER_START_MESSAGE_TYPE = "openclaw-worker-start-v1";
@@ -14,7 +15,7 @@ function isWorkerStartMessage(value: unknown): boolean {
     typeof value === "object" &&
     value !== null &&
     !Array.isArray(value) &&
-    Object.keys(value).length === 1 &&
+    hasExactOwnKeys(value as Record<string, unknown>, ["type"]) &&
     (value as { type?: unknown }).type === WORKER_START_MESSAGE_TYPE
   );
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where malformed worker protocol objects could satisfy closed-record validation with required or optional fields inherited from their prototype. Some parsers then normalized those objects as valid, materialized inherited transport settings, or returned assignments whose authority no longer matched their own fields.

## Why This Change Was Made

Worker-owned protocol parsers now share one exact-own-key validator. It requires every mandatory field to be an own string key, rejects inherited optional fields, and rejects unknown own fields, replacing prototype-inclusive and count-only checks across the worker protocol boundary.

This does not change valid protocol payloads, the public protocol schema, configuration, or protocol versions.

## User Impact

Workers reject malformed in-memory protocol records consistently instead of accepting inherited authority, identity, endpoint, transport, or lifecycle fields.

Production LOC: +63/-76 (net -13) | Tests: +171/-2

## Evidence

- Pre-fix regressions failed for inherited launch versions, assignment computer descriptors, nested computer node IDs, endpoint kinds and TLS fingerprints, process request/result discriminators, admission-deadline results, and IPC start messages.
- Post-fix focused and sibling tests:

  `node scripts/run-vitest.mjs src/worker/launch-descriptor.test.ts src/worker/worker-connection-endpoint.test.ts src/worker/node-workspace-protocol.test.ts src/worker/worker-process-protocol.test.ts src/worker/worker-command.runtime.test.ts src/worker/worker.runtime.test.ts`

  Result: 6 files, 173 tests passed.
- `pnpm check:assertion-safety --base origin/main`: passed.
- `pnpm check:max-lines-ratchet --base origin/main`: passed.
- `pnpm tsgo:core`: passed.
- Scoped oxlint, formatting, import-cycle, and diff checks: passed.
- CLI bootstrap tests: 9 passed.
- Mandatory structured autoreview: no actionable findings, correctness 0.99.
- Independent exact-head review of `f10bdc4944ee8d74560dc703994c6984f1ae1b02`: no findings; best-fix verdict.

The aggregate local build reached the sparse worktree's absent `ui/config/*` inputs after worker/core bundle phases completed. Exact-head CI runs from a full checkout.
