### PR TITLE
fix(telegram): follow configured model runtime

### DIFF
--- a/extensions/telegram/src/bot-handlers.callback-router.ts
+++ b/extensions/telegram/src/bot-handlers.callback-router.ts
@@ -582,13 +582,13 @@ async function handleTelegramModelCallback(params: {
       totalPages,
       modelNames,
     });
-    const text = formatModelsAvailableHeader({
+    const text = `${formatModelsAvailableHeader({
       provider,
       total: models.length,
       cfg: runtimeCfg,
       agentDir: resolveAgentDir(runtimeCfg, sessionState.agentId),
       sessionEntry: sessionState.sessionEntry,
-    });
+    })}\nSelecting a model also applies its configured runtime.`;
     await retryModelAction(() => editMessageWithButtons(text, buttons));
     return true;
   }
@@ -666,7 +666,7 @@ async function handleTelegramModelCallback(params: {
           provider: selection.provider,
           model: selection.model,
           isDefault: isDefaultSelection,
-          runtime: { kind: "unchanged" },
+          runtime: { kind: "clear" },
         },
         markLiveSwitchPending: true,
       }),
@@ -687,13 +687,10 @@ async function handleTelegramModelCallback(params: {
     const actionText = isDefaultSelection
       ? "reset to default"
       : `changed to <b>${escapeHtml(selection.provider)}/${escapeHtml(selection.model)}</b>`;
-    const runtimeText =
-      applied.runtimeChange?.kind === "clear"
-        ? "Runtime reset to configured policy."
-        : "Runtime unchanged.";
+    const runtimeText = `Runtime set to <b>${escapeHtml(applied.agentRuntime)}</b> from configured policy.`;
     const scopeText = isDefaultSelection
       ? `Session model selection cleared.${defaultAuthProfileNotice ? ` ${defaultAuthProfileNotice}` : ""} ${runtimeText} New replies use the agent's configured default.`
-      : `Session-only model selection. ${runtimeText} Use /model ${escapeHtml(selection.provider)}/${escapeHtml(selection.model)} --runtime &lt;runtime&gt; -s to switch harnesses. The agent default in openclaw.json is unchanged. This chat keeps the model selection across /new and /reset; use /model default -s to clear the session model selection.`;
+      : `Session-only model selection. ${runtimeText} The agent default in openclaw.json is unchanged. This chat keeps the model selection across /new and /reset; use /model default -s to clear the session model selection.`;
     await editMessageWithButtons(`✅ Model ${actionText}\n\n${scopeText}`, [], {
       parse_mode: "HTML",
     });

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -5667,7 +5667,7 @@ describe("createTelegramBot", () => {
     expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
     const finalEditMessageText = editMessageTextSpy.mock.calls.at(-1)?.[2];
     expect(typeof finalEditMessageText === "string" ? finalEditMessageText : "").toContain(
-      "Session-only model selection. Runtime unchanged.",
+      "Session-only model selection. Runtime set to <b>codex</b> from configured policy.",
     );
     expect(
       editMessageTextSpy.mock.calls.some((call) =>

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -334,7 +334,7 @@ function makeModelPickerConfig(
   overrides: {
     config?: Omit<OpenClawConfig, "agents" | "channels" | "session">;
     defaultModel?: string;
-    models?: Record<string, Record<string, never>>;
+    models?: Record<string, { agentRuntime?: { id: string } }>;
     omitModels?: boolean;
     telegram?: TelegramChannelConfig;
   } = {},
@@ -2623,7 +2623,7 @@ describe("createTelegramBot", () => {
         `${CHECK_MARK_EMOJI} Model reset to default`,
       );
       expect(String(firstEditMessageTextArg(2))).toContain(
-        "Session model selection cleared. Runtime unchanged. New replies use the agent's configured default.",
+        "Session model selection cleared. Runtime set to <b>openclaw</b> from configured policy. New replies use the agent's configured default.",
       );
 
       const entry = readOnlySessionEntry(storePath);
@@ -2678,7 +2678,7 @@ describe("createTelegramBot", () => {
     expect(entry?.modelOverride).toBeUndefined();
     expect(entry?.agentRuntimeOverride).toBeUndefined();
     expect(String(firstEditMessageTextArg(2))).toBe(
-      `${CHECK_MARK_EMOJI} Model reset to default\n\nSession model selection cleared. Runtime reset to configured policy. New replies use the agent's configured default.`,
+      `${CHECK_MARK_EMOJI} Model reset to default\n\nSession model selection cleared. Runtime set to <b>openclaw</b> from configured policy. New replies use the agent's configured default.`,
     );
   });
 
@@ -2707,6 +2707,7 @@ describe("createTelegramBot", () => {
         defaultModel: "gpt-5",
         callbackData: "mdl_sel_openai/gpt-5",
         outcomeText: "Compatible auth profile retained.",
+        expectedRuntime: "codex",
         expectedProfile: "team:prod",
       },
       {
@@ -2716,6 +2717,7 @@ describe("createTelegramBot", () => {
         defaultModel: "claude-sonnet-4-5",
         callbackData: "mdl_sel_anthropic/claude-sonnet-4-5",
         outcomeText: "Incompatible auth profile cleared.",
+        expectedRuntime: "openclaw",
         expectedProfile: undefined,
       },
     ])(
@@ -2726,6 +2728,7 @@ describe("createTelegramBot", () => {
         defaultModel,
         callbackData,
         expectedProfile,
+        expectedRuntime,
         outcomeText,
       }) => {
         onSpy.mockClear();
@@ -2812,7 +2815,7 @@ describe("createTelegramBot", () => {
           expect(entry?.modelOverride).toBeUndefined();
           const confirmation = String(firstEditMessageTextArg(2));
           expect(confirmation).toBe(
-            `${CHECK_MARK_EMOJI} Model reset to default\n\nSession model selection cleared. ${outcomeText} Runtime unchanged. New replies use the agent's configured default.`,
+            `${CHECK_MARK_EMOJI} Model reset to default\n\nSession model selection cleared. ${outcomeText} Runtime set to <b>${expectedRuntime}</b> from configured policy. New replies use the agent's configured default.`,
           );
           expect(confirmation).not.toContain("team:prod");
         }
@@ -2856,6 +2859,9 @@ describe("createTelegramBot", () => {
 
     expect(replySpy).not.toHaveBeenCalled();
     expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
+    expect(firstEditMessageTextArg(2)).toContain(
+      "Selecting a model also applies its configured runtime.",
+    );
     const params = firstEditMessageTextArg(3);
     const inlineKeyboard = (
       params as {
@@ -2875,7 +2881,36 @@ describe("createTelegramBot", () => {
 
   it("formats non-default model selection confirmations with Telegram HTML parse mode", async () => {
     const storePath = createTelegramTestStorePath("model-html");
-    const config = makeModelPickerConfig(storePath);
+    const config = makeModelPickerConfig(storePath, {
+      models: {
+        "anthropic/claude-opus-4-6": {},
+        "openai/gpt-5.4": { agentRuntime: { id: "openclaw" } },
+      },
+    });
+    const route = resolveTelegramConversationRoute({
+      cfg: config,
+      accountId: "default",
+      chatId: 1234,
+      isGroup: false,
+      threadSpec: { scope: "none" },
+      senderId: 9,
+    }).route;
+    const sessionKey = resolveTelegramConversationBaseSessionKey({
+      cfg: config,
+      route,
+      chatId: 1234,
+      isGroup: false,
+      senderId: 9,
+    });
+    await upsertSessionEntry({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "model-html",
+        updatedAt: 1,
+        agentRuntimeOverride: "openclaw",
+      },
+    });
 
     loadConfig.mockReturnValue(config);
     createTelegramBot({
@@ -2898,7 +2933,7 @@ describe("createTelegramBot", () => {
     expect(editCall[0]).toBe(1234);
     expect(editCall[1]).toBe(17);
     expect(editCall[2]).toBe(
-      `${CHECK_MARK_EMOJI} Model changed to <b>openai/gpt-5.4</b>\n\nSession-only model selection. Runtime unchanged. Use /model openai/gpt-5.4 --runtime &lt;runtime&gt; -s to switch harnesses. The agent default in openclaw.json is unchanged. This chat keeps the model selection across /new and /reset; use /model default -s to clear the session model selection.`,
+      `${CHECK_MARK_EMOJI} Model changed to <b>openai/gpt-5.4</b>\n\nSession-only model selection. Runtime set to <b>openclaw</b> from configured policy. The agent default in openclaw.json is unchanged. This chat keeps the model selection across /new and /reset; use /model default -s to clear the session model selection.`,
     );
     expect(requireRecord(editCall[3], "edit params").parse_mode).toBe("HTML");
 
@@ -2906,6 +2941,7 @@ describe("createTelegramBot", () => {
     expect(entry?.providerOverride).toBe("openai");
     expect(entry?.modelOverride).toBe("gpt-5.4");
     expect(entry?.modelOverrideSource).toBe("user");
+    expect(entry?.agentRuntimeOverride).toBeUndefined();
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-model-html-1");
   });
 

--- a/src/model-picker/apply-session-model-selection.test.ts
+++ b/src/model-picker/apply-session-model-selection.test.ts
@@ -574,6 +574,7 @@ describe("applySessionModelSelection", () => {
       runtime: { kind: "set", runtime: "openclaw" } as const,
       expected: "openclaw",
       runtimeChange: { kind: "set", runtime: "openclaw" },
+      agentRuntime: "openclaw",
     },
     {
       name: "set idempotently",
@@ -581,6 +582,7 @@ describe("applySessionModelSelection", () => {
       runtime: { kind: "set", runtime: "openclaw" } as const,
       expected: "openclaw",
       runtimeChange: { kind: "set", runtime: "openclaw" },
+      agentRuntime: "openclaw",
     },
     {
       name: "clear",
@@ -588,6 +590,7 @@ describe("applySessionModelSelection", () => {
       runtime: { kind: "clear" } as const,
       expected: undefined,
       runtimeChange: { kind: "clear" },
+      agentRuntime: "codex",
     },
     {
       name: "clear idempotently",
@@ -595,6 +598,7 @@ describe("applySessionModelSelection", () => {
       runtime: { kind: "clear" } as const,
       expected: undefined,
       runtimeChange: { kind: "clear" },
+      agentRuntime: "codex",
     },
     {
       name: "unchanged",
@@ -602,22 +606,27 @@ describe("applySessionModelSelection", () => {
       runtime: { kind: "unchanged" } as const,
       expected: "openclaw",
       runtimeChange: undefined,
+      agentRuntime: "openclaw",
     },
-  ])("supports runtime $name", async ({ initial, runtime, expected, runtimeChange }) => {
-    const sessionEntry = createEntry({ agentRuntimeOverride: initial });
-    const result = await applySessionModelSelection(
-      createParams({
-        sessionEntry,
-        request: { provider: "openai", model: "gpt-4o", isDefault: false, runtime },
-      }),
-    );
+  ])(
+    "supports runtime $name",
+    async ({ initial, runtime, expected, runtimeChange, agentRuntime }) => {
+      const sessionEntry = createEntry({ agentRuntimeOverride: initial });
+      const result = await applySessionModelSelection(
+        createParams({
+          sessionEntry,
+          request: { provider: "openai", model: "gpt-4o", isDefault: false, runtime },
+        }),
+      );
 
-    expect(result.status).toBe("applied");
-    if (result.status === "applied") {
-      expect(result.runtimeChange).toEqual(runtimeChange);
-    }
-    expect(sessionEntry.agentRuntimeOverride).toBe(expected);
-  });
+      expect(result.status).toBe("applied");
+      if (result.status === "applied") {
+        expect(result.runtimeChange).toEqual(runtimeChange);
+        expect(result.agentRuntime).toBe(agentRuntime);
+      }
+      expect(sessionEntry.agentRuntimeOverride).toBe(expected);
+    },
+  );
 
   it("rejects an incompatible runtime without mutation or side effects", async () => {
     const sessionEntry = createEntry();

--- a/src/model-picker/apply-session-model-selection.ts
+++ b/src/model-picker/apply-session-model-selection.ts
@@ -76,6 +76,7 @@ export type ApplySessionModelSelectionResult =
       provider: string;
       model: string;
       effectiveModelRef: string;
+      agentRuntime: string;
       changed: boolean;
       contextTokens: number;
       configuredDefaultUpdate?: StickyModelSelectionDispatchOutcome;
@@ -300,6 +301,17 @@ export async function applySessionModelSelection(
     persistedEntry = params.sessionEntry;
   }
 
+  const agentRuntime = resolveEffectiveAgentRuntime({
+    cfg: params.cfg,
+    provider: request.provider,
+    modelId: request.model,
+    modelApi: selectedCatalogEntry?.api,
+    modelBaseUrl: selectedCatalogEntry?.baseUrl,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+    sessionEntry: persistedEntry,
+  });
+
   const provider = request.provider;
   const model = request.model;
   const effectiveModelRef = `${provider}/${model}`;
@@ -338,16 +350,7 @@ export async function applySessionModelSelection(
       nextThinking: {
         level: persistedEntry.thinkingLevel,
         catalog: [...thinkingCatalog],
-        agentRuntime: resolveEffectiveAgentRuntime({
-          cfg: params.cfg,
-          provider,
-          modelId: model,
-          modelApi: selectedCatalogEntry?.api,
-          modelBaseUrl: selectedCatalogEntry?.baseUrl,
-          agentId: params.agentId,
-          sessionKey: params.sessionKey,
-          sessionEntry: persistedEntry,
-        }),
+        agentRuntime,
       },
     });
   }
@@ -361,16 +364,7 @@ export async function applySessionModelSelection(
 
   const contextProvider = resolveContextConfigProviderForRuntime({
     provider,
-    runtimeId: resolveEffectiveAgentRuntime({
-      cfg: params.cfg,
-      provider,
-      modelId: model,
-      modelApi: selectedCatalogEntry?.api,
-      modelBaseUrl: selectedCatalogEntry?.baseUrl,
-      agentId: params.agentId,
-      sessionKey: params.sessionKey,
-      sessionEntry: persistedEntry,
-    }),
+    runtimeId: agentRuntime,
     config: params.cfg,
   });
   return {
@@ -378,6 +372,7 @@ export async function applySessionModelSelection(
     provider,
     model,
     effectiveModelRef,
+    agentRuntime,
     changed,
     contextTokens: resolveContextTokens({
       cfg: params.cfg,


### PR DESCRIPTION
## Problem

Telegram model-picker buttons preserved a compatible session runtime override. A selected model's configured runtime policy could not take effect, and the confirmation told the operator to run a second manual `/model --runtime` command.

## Root cause

The Telegram callback sent `runtime: unchanged` to the shared model-selection transaction. Session runtime overrides outrank configured model policy, so a prior compatible override stayed active.

## Product decision

Ayaan Zaidi approves a Telegram model-button click as the explicit operator action that adopts the selected model's configured runtime policy. The model list states this effect before the click. Explicit `/model --runtime` remains the override path.

## Fix

- State before the model buttons that selection also applies configured runtime.
- Clear the session runtime override when Telegram applies the selected model.
- Return and reuse the effective runtime from the shared transaction.
- Name that runtime in the Telegram confirmation.
- Keep explicit `/model --runtime` behavior unchanged.

## Shape

- Owner: shared model-selection transaction plus Telegram's picker policy.
- Before: picker model + prior session runtime.
- After: picker model + configured model/provider runtime policy.
- Explicit runtime choices remain available through `/model --runtime`.

## Production

- Production delta: 20 additions, 28 deletions.
- The shared owner now resolves the effective runtime twice instead of three times.
- No new config, persistence, fallback, or provider-specific path was added.

## Live proof

Real Telegram Test Server user and bot, same callback and isolated session state on both revisions:

- Main `5a1e1316e0a1a56362d6bf4124c983228fbfb1a4`: the callback completed, the bot said `Runtime unchanged`, and the session kept `agentRuntimeOverride: openclaw`.
- Proven head `b80fcaa17edc26af9654f6e7d6c70e34ba8fef91`: the picker stated the configured-runtime effect before the click; the callback completed; the bot said `Runtime set to openclaw from configured policy`; and the runtime override was absent.
- Current head `2507db42dc320fce8a6435b7de89bc0db8911be2` is a patch-identical rebase onto healed `main`. No owner file changed, and stable patch ID `022cbaa92e40a52c1c066fa8e76174b56042c224` matches the proven head.

The selected model was `openai/gpt-5.6-luna` with configured runtime `openclaw`. This exercises the generic picker/runtime-policy boundary without provider credentials.

## Validation

- `node scripts/run-vitest.mjs src/model-picker/apply-session-model-selection.test.ts` — 36 passed.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.test.ts` — 143 passed.
- Retry-path regression in `extensions/telegram/src/bot.create-telegram-bot.test.ts` — passed.
- Changed-scope format, Oxlint, plugin-boundary, dependency, database-first, import-cycle, and repository ratchets passed.
- TypeScript checks are deferred to hosted CI because this host prohibits them.

## Overlap

- #124222 moves the same Telegram callback block and may need conflict resolution if it lands first.
