### PR TITLE
improve: speed up transcript migration and Doctor scans

### DIFF
--- a/src/commands/doctor-session-sqlite-transcript-readers.test.ts
+++ b/src/commands/doctor-session-sqlite-transcript-readers.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { ReadOnlySqliteTranscriptReader } from "./doctor-session-sqlite-transcript-readers.js";
+
+describe("read-only SQLite transcript readers", () => {
+  it.each([
+    { stage: "label detection", header: false, failingSeq: 0 },
+    { stage: "nested label snapshot", header: false, failingSeq: 1 },
+    { stage: "header snapshot", header: true, failingSeq: 1 },
+    { stage: "first header row", header: true, failingSeq: 0 },
+  ])("isolates a $stage step failure from the next session", ({ header, failingSeq }) => {
+    const database = openNodeSqliteDatabase(":memory:");
+    try {
+      // json() fails during native stepping. The primary key lets the first row
+      // reach detection before a later row fails in the complete snapshot.
+      database.exec(`
+        CREATE TABLE source_rows (
+          session_id TEXT,
+          seq INTEGER,
+          created_at INTEGER,
+          event_json TEXT,
+          PRIMARY KEY (session_id, seq)
+        );
+        CREATE VIEW transcript_events AS
+          SELECT session_id, seq, created_at, json(event_json) AS event_json FROM source_rows;
+        CREATE TABLE session_windows (session_id TEXT PRIMARY KEY, session_key TEXT);
+        INSERT INTO session_windows VALUES
+          ('broken', 'agent:main:broken'), ('healthy', 'agent:main:healthy');
+      `);
+      const insert = database.prepare("INSERT INTO source_rows VALUES (?, ?, ?, ?)");
+      insert.run("broken", 0, 10, failingSeq === 0 ? "{" : '{"type":"message","id":"first"}');
+      if (failingSeq === 1) {
+        insert.run("broken", 1, 11, "{");
+      }
+      const healthyEvents = [
+        '{"type":"message","id":"healthy-first"}',
+        '{"type":"message","id":"healthy-second"}',
+      ];
+      for (const [seq, eventJson] of healthyEvents.entries()) {
+        insert.run("healthy", seq, 20 + seq, eventJson);
+      }
+
+      const reader = new ReadOnlySqliteTranscriptReader(database);
+      const read = (sessionId: string) =>
+        header
+          ? reader.headerlessSnapshot(sessionId)
+          : reader.repairSnapshot(sessionId, () => true);
+      expect(read("broken")).toMatchObject({
+        ok: false,
+        error: { message: expect.stringMatching(/malformed JSON/iu) },
+      });
+      expect(read("healthy")).toEqual({
+        ok: true,
+        rows: healthyEvents.map((eventJson, seq) =>
+          header ? { eventJson, seq, createdAt: 20 + seq } : { eventJson, seq },
+        ),
+        ...(header ? { sessionKey: "agent:main:healthy" } : {}),
+      });
+    } finally {
+      database.close();
+    }
+  });
+});

--- a/src/commands/doctor-session-sqlite-transcript-readers.ts
+++ b/src/commands/doctor-session-sqlite-transcript-readers.ts
@@ -1,33 +1,12 @@
 /** Read-only transcript detection; positive repairs retain exact snapshots. */
-import type { DatabaseSync } from "node:sqlite";
+import type { DatabaseSync, StatementSync } from "node:sqlite";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { SqliteTranscriptStorageRow } from "../config/sessions/session-accessor.sqlite-read.js";
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 
-// Schema-tolerant session enumeration for transcript-label migration (avoids post-ship columns).
-// Queries transcript_events table (schema-stable) instead of sessions table.
-// Returns read-only view of all distinct session IDs with events.
-export function readOnlySqliteTranscriptSessionIds(database: DatabaseSync): string[] {
-  if (!tableExists(database, "transcript_events")) {
-    return [];
-  }
-  const rows = database
-    .prepare("SELECT DISTINCT session_id FROM transcript_events ORDER BY session_id ASC")
-    .all();
-  return rows.flatMap((row) => (typeof row.session_id === "string" ? [row.session_id] : []));
-}
+const LABEL_ROWS_SQL =
+  "SELECT event_json, seq FROM transcript_events WHERE session_id = ? ORDER BY seq ASC";
 
-function iterateTranscriptRows(database: DatabaseSync, sessionId: string, firstRowOnly = false) {
-  return database
-    .prepare(
-      `SELECT created_at, event_json, seq FROM transcript_events WHERE session_id = ? ORDER BY seq ASC${firstRowOnly ? " LIMIT 1" : ""}`,
-    )
-    .iterate(sessionId);
-}
-
-// Read-only transcript snapshot reader for dry-run detection phase.
-// Avoids opening writable database lifecycle (lease/WAL/schema-ensure).
-// Returns rows only; migration parses per-row during repair.
 type ReadOnlyTranscriptSnapshot =
   | {
       ok: true;
@@ -35,94 +14,141 @@ type ReadOnlyTranscriptSnapshot =
     }
   | { ok: false; error: unknown };
 
-export function readOnlySqliteTranscriptRepairSnapshot(
-  database: DatabaseSync,
-  sessionId: string,
-  needsRepair: (event: unknown) => boolean,
-): ReadOnlyTranscriptSnapshot {
-  try {
-    // Unchanged histories retain one payload. Re-read positive candidates in full so
-    // malformed siblings and exact-snapshot guards still govern the surgical repair.
-    for (const row of iterateTranscriptRows(database, sessionId)) {
-      if (typeof row.event_json !== "string" || typeof row.seq !== "number") {
-        continue;
+export class ReadOnlySqliteTranscriptReader {
+  private labelDetection?: StatementSync;
+  private labelSnapshot?: StatementSync;
+  private firstHeaderRow?: StatementSync;
+  private headerSnapshot?: StatementSync;
+  private sessionKey?: StatementSync;
+
+  // Statements belong to one read-only pass, but no cursor survives a snapshot call.
+  // Prepare lazily so older databases need only the schema used by that detection path.
+  constructor(private readonly database: DatabaseSync) {}
+
+  sessionIds(): string[] {
+    if (!tableExists(this.database, "transcript_events")) {
+      return [];
+    }
+    // Enumerate the schema-stable events table, not post-ship sessions columns.
+    // Materialize IDs so enumeration cannot hold a read transaction across repairs.
+    const rows = this.database
+      .prepare("SELECT DISTINCT session_id FROM transcript_events ORDER BY session_id ASC")
+      .all();
+    return rows.flatMap((row) => (typeof row.session_id === "string" ? [row.session_id] : []));
+  }
+
+  repairSnapshot(
+    sessionId: string,
+    needsRepair: (event: unknown) => boolean,
+  ): ReadOnlyTranscriptSnapshot {
+    let iterator: ReturnType<StatementSync["iterate"]> | undefined;
+    try {
+      // Unchanged histories retain one payload. Re-read positive candidates in full so
+      // malformed siblings and exact-snapshot guards still govern the surgical repair.
+      this.labelDetection ??= this.database.prepare(LABEL_ROWS_SQL);
+      iterator = this.labelDetection.iterate(sessionId);
+      for (const row of iterator) {
+        if (typeof row.event_json !== "string" || typeof row.seq !== "number") {
+          continue;
+        }
+        let event: unknown;
+        try {
+          event = JSON.parse(row.event_json);
+        } catch {
+          continue;
+        }
+        if (!needsRepair(event)) {
+          continue;
+        }
+        const rows: Array<{ eventJson: string; seq: number }> = [];
+        // Detection is still iterating: its nested exact snapshot needs a distinct statement.
+        this.labelSnapshot ??= this.database.prepare(LABEL_ROWS_SQL);
+        iterator = this.labelSnapshot.iterate(sessionId);
+        for (const candidate of iterator) {
+          if (typeof candidate.event_json === "string" && typeof candidate.seq === "number") {
+            rows.push({ eventJson: candidate.event_json, seq: candidate.seq });
+          }
+        }
+        return { ok: true, rows };
       }
-      let event: unknown;
+      return { ok: true, rows: [] };
+    } catch (error) {
+      // A throwing next() does not close its iterator; reset before the next session.
       try {
-        event = JSON.parse(row.event_json);
+        iterator?.return?.();
       } catch {
-        continue;
+        // Preserve the original read error if cleanup fails.
       }
-      if (!needsRepair(event)) {
-        continue;
-      }
-      const rows: Array<{ eventJson: string; seq: number }> = [];
-      for (const candidate of iterateTranscriptRows(database, sessionId)) {
-        if (typeof candidate.event_json === "string" && typeof candidate.seq === "number") {
-          rows.push({ eventJson: candidate.event_json, seq: candidate.seq });
+      return { ok: false, error };
+    }
+  }
+
+  /** Reads exact row metadata for a guarded transcript replacement without opening a writer. */
+  headerlessSnapshot(
+    sessionId: string,
+  ):
+    | { ok: true; rows: SqliteTranscriptStorageRow[]; sessionKey?: string }
+    | { ok: false; error: unknown } {
+    let iterator: ReturnType<StatementSync["iterate"]> | undefined;
+    try {
+      // Headers can live at nonzero seq. A current header needs no whole-history read;
+      // possible headerless repairs still take and validate the complete exact snapshot.
+      this.firstHeaderRow ??= this.database.prepare(
+        "SELECT event_json FROM transcript_events WHERE session_id = ? ORDER BY seq ASC LIMIT 1",
+      );
+      const firstRow = this.firstHeaderRow.get(sessionId);
+      if (typeof firstRow?.event_json === "string") {
+        let first: unknown;
+        try {
+          first = JSON.parse(firstRow.event_json);
+        } catch {
+          return { ok: true, rows: [] };
+        }
+        if (!isRecord(first) || first.type === "session") {
+          return { ok: true, rows: [] };
         }
       }
-      return { ok: true, rows };
-    }
-    return { ok: true, rows: [] };
-  } catch (error) {
-    return { ok: false, error };
-  }
-}
-
-/** Reads exact row metadata for a guarded transcript replacement without opening a writer. */
-export function readOnlySqliteHeaderlessTranscriptSnapshot(
-  database: DatabaseSync,
-  sessionId: string,
-):
-  | { ok: true; rows: SqliteTranscriptStorageRow[]; sessionKey?: string }
-  | { ok: false; error: unknown } {
-  try {
-    // Headers can live at nonzero seq. A current header needs no whole-history read;
-    // possible headerless repairs still take and validate the complete exact snapshot.
-    for (const row of iterateTranscriptRows(database, sessionId, true)) {
-      if (typeof row.event_json !== "string") {
-        break;
+      this.sessionKey ??= this.database.prepare(
+        "SELECT session_key FROM session_windows WHERE session_id = ? LIMIT 1",
+      );
+      const sessionKeyRow = this.sessionKey.get(sessionId);
+      const storageRows: SqliteTranscriptStorageRow[] = [];
+      this.headerSnapshot ??= this.database.prepare(
+        "SELECT created_at, event_json, seq FROM transcript_events WHERE session_id = ? ORDER BY seq ASC",
+      );
+      iterator = this.headerSnapshot.iterate(sessionId);
+      for (const row of iterator) {
+        if (
+          typeof row.created_at !== "number" ||
+          typeof row.event_json !== "string" ||
+          typeof row.seq !== "number"
+        ) {
+          return {
+            ok: false,
+            error: new Error(`Invalid transcript row metadata for session ${sessionId}`),
+          };
+        }
+        storageRows.push({
+          createdAt: row.created_at,
+          eventJson: row.event_json,
+          seq: row.seq,
+        });
       }
-      let first: unknown;
+      return {
+        ok: true,
+        rows: storageRows,
+        ...(typeof sessionKeyRow?.session_key === "string"
+          ? { sessionKey: sessionKeyRow.session_key }
+          : {}),
+      };
+    } catch (error) {
+      // A throwing next() does not close its iterator; reset before the next session.
       try {
-        first = JSON.parse(row.event_json);
+        iterator?.return?.();
       } catch {
-        return { ok: true, rows: [] };
+        // Preserve the original read error if cleanup fails.
       }
-      if (!isRecord(first) || first.type === "session") {
-        return { ok: true, rows: [] };
-      }
+      return { ok: false, error };
     }
-    const sessionKeyRow = database
-      .prepare("SELECT session_key FROM session_windows WHERE session_id = ? LIMIT 1")
-      .get(sessionId);
-    const storageRows: SqliteTranscriptStorageRow[] = [];
-    for (const row of iterateTranscriptRows(database, sessionId)) {
-      if (
-        typeof row.created_at !== "number" ||
-        typeof row.event_json !== "string" ||
-        typeof row.seq !== "number"
-      ) {
-        return {
-          ok: false,
-          error: new Error(`Invalid transcript row metadata for session ${sessionId}`),
-        };
-      }
-      storageRows.push({
-        createdAt: row.created_at,
-        eventJson: row.event_json,
-        seq: row.seq,
-      });
-    }
-    return {
-      ok: true,
-      rows: storageRows,
-      ...(typeof sessionKeyRow?.session_key === "string"
-        ? { sessionKey: sessionKeyRow.session_key }
-        : {}),
-    };
-  } catch (error) {
-    return { ok: false, error };
   }
 }

--- a/src/commands/doctor-session-transcript-headers.ts
+++ b/src/commands/doctor-session-transcript-headers.ts
@@ -27,10 +27,7 @@ import {
   type OpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
 import { resolveTargetSqliteOptions } from "./doctor-session-sqlite-readers.js";
-import {
-  readOnlySqliteTranscriptSessionIds,
-  readOnlySqliteHeaderlessTranscriptSnapshot,
-} from "./doctor-session-sqlite-transcript-readers.js";
+import { ReadOnlySqliteTranscriptReader } from "./doctor-session-sqlite-transcript-readers.js";
 
 const NOTE_TITLE = "Session transcript headers";
 
@@ -217,8 +214,9 @@ export async function noteSessionTranscriptHeaderHealth(params: {
       // Each snapshot exhausts or closes its iterators before repair, so this read-only
       // connection holds no read transaction across a guarded writer transaction.
       readDatabase = openNodeSqliteDatabase(sqlitePath, { readOnly: true });
-      for (const sessionId of readOnlySqliteTranscriptSessionIds(readDatabase)) {
-        const snapshot = readOnlySqliteHeaderlessTranscriptSnapshot(readDatabase, sessionId);
+      const reader = new ReadOnlySqliteTranscriptReader(readDatabase);
+      for (const sessionId of reader.sessionIds()) {
+        const snapshot = reader.headerlessSnapshot(sessionId);
         if (!snapshot.ok) {
           const detail = formatErrorMessage(snapshot.error).replace(/\s+/g, " ").trim();
           note(

--- a/src/commands/doctor-session-transcript-labels.ts
+++ b/src/commands/doctor-session-transcript-labels.ts
@@ -17,10 +17,7 @@ import {
   runOpenClawAgentWriteTransaction,
 } from "../state/openclaw-agent-db.js";
 import { resolveTargetSqliteOptions } from "./doctor-session-sqlite-readers.js";
-import {
-  readOnlySqliteTranscriptSessionIds,
-  readOnlySqliteTranscriptRepairSnapshot,
-} from "./doctor-session-sqlite-transcript-readers.js";
+import { ReadOnlySqliteTranscriptReader } from "./doctor-session-sqlite-transcript-readers.js";
 
 const NOTE_TITLE = "Session transcript labels";
 
@@ -214,17 +211,13 @@ export async function noteSessionTranscriptLabelHealth(params: {
     let readDatabase: DatabaseSync | undefined;
     try {
       readDatabase = openNodeSqliteDatabase(sqlitePath, { readOnly: true });
+      const reader = new ReadOnlySqliteTranscriptReader(readDatabase);
       // Detect read-only, then repair each session in its own transaction as it is found, so a large
       // store never buffers every plan at once. Enumerate from transcript_events, not sessions: the
       // latter gained its columns post-ship and is not safe to assume on old databases.
-      const sessionIds = readOnlySqliteTranscriptSessionIds(readDatabase);
-      for (const sessionId of sessionIds) {
+      for (const sessionId of reader.sessionIds()) {
         // Read transcript in read-only mode (detection phase).
-        const readResult = readOnlySqliteTranscriptRepairSnapshot(
-          readDatabase,
-          sessionId,
-          normalizeLegacyInboundContextLabels,
-        );
+        const readResult = reader.repairSnapshot(sessionId, normalizeLegacyInboundContextLabels);
         if (!readResult.ok) {
           const detail = formatErrorMessage(readResult.error).replace(/\s+/g, " ").trim();
           note(

--- a/src/config/sessions/session-accessor.sqlite-active-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.test.ts
@@ -747,8 +747,14 @@ describe("SQLite active transcript event projection", () => {
       expect(
         appendTranscriptEventsInTransaction(writeDatabase, scope, [
           { type: "leaf", id: "batch-leaf", parentId: "root", targetId: "root" },
+          {
+            type: "message",
+            id: "batch-tail",
+            parentId: "root",
+            message: { role: "assistant", content: "after branch selection" },
+          },
         ]),
-      ).toBe(1);
+      ).toBe(2);
     }, databaseOptions);
     database.db
       .prepare("UPDATE transcript_events SET event_json = ? WHERE session_id = ? AND seq = 1")
@@ -760,7 +766,7 @@ describe("SQLite active transcript event projection", () => {
         .get(scope.sessionId),
     ).toEqual({ needs_rebuild: 1 });
     await waitForSessionTranscriptIndexReconcile(databaseOptions);
-    expect(readSessionTranscriptMessageEventCount(scope)).toBe(1);
+    expect(readSessionTranscriptMessageEventCount(scope)).toBe(2);
   });
 
   it("keeps 100k-message reads bounded while rebuilds yield to live writes", async () => {

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -35,8 +35,8 @@ import {
   upsertTranscriptSessionWindowInTransaction,
 } from "./session-accessor.sqlite-transcript-state.js";
 import {
+  createTranscriptIndexAppenderInTransaction,
   deleteSessionTranscriptIndexInTransaction,
-  indexAppendedTranscriptEventInTransaction,
   markSessionTranscriptIndexDirtyInTransaction,
   reconcileSessionTranscriptIndexInTransaction,
   shouldRebuildSessionTranscriptIndexSynchronously,
@@ -57,7 +57,11 @@ type TranscriptAppendOptions = {
   touchMutation?: boolean;
 };
 
-type TranscriptAppendCursor = { initialized: boolean; nextSeq?: number };
+type TranscriptAppendCursor = {
+  initialized?: boolean;
+  nextSeq?: number;
+  appendToIndex?: ReturnType<typeof createTranscriptIndexAppenderInTransaction>;
+};
 
 export function appendTranscriptEventInTransaction(
   database: OpenClawAgentDatabase,
@@ -73,12 +77,12 @@ function appendTranscriptEvent(
   scope: ResolvedTranscriptScope,
   event: TranscriptEvent,
   options: TranscriptAppendOptions,
-  cursor?: TranscriptAppendCursor,
+  cursor: TranscriptAppendCursor = {},
 ): boolean {
   const persistedEvent = canonicalizeTranscriptEventMedia(event);
   const db = getSessionKysely(database.db);
   const createdAt = readEventTimestamp(persistedEvent) ?? Date.now();
-  if (cursor?.initialized) {
+  if (cursor.initialized) {
     // Even rejected identities update window recency. Only root/generation setup
     // is shared by the synchronous batch; per-attempt writes stay in order.
     upsertTranscriptSessionWindowInTransaction(database, scope, createdAt);
@@ -87,9 +91,7 @@ function appendTranscriptEvent(
       allowStoredAlias: options.allowStoredAlias === true,
     });
     ensureTranscriptGenerationInTransaction(database, scope.sessionId);
-    if (cursor) {
-      cursor.initialized = true;
-    }
+    cursor.initialized = true;
   }
   const identity = readTranscriptEventIdentity(persistedEvent);
   if (identity && readTranscriptIdentityByEventId(database, scope.sessionId, identity.eventId)) {
@@ -106,7 +108,7 @@ function appendTranscriptEvent(
   ) {
     return false;
   }
-  const seq = cursor?.nextSeq ?? readNextTranscriptSeq(database, scope.sessionId);
+  const seq = cursor.nextSeq ?? readNextTranscriptSeq(database, scope.sessionId);
   executeSqliteQuerySync(
     database.db,
     db.insertInto("transcript_events").values({
@@ -116,14 +118,12 @@ function appendTranscriptEvent(
       created_at: createdAt,
     }),
   );
-  if (cursor) {
-    cursor.nextSeq = seq + 1;
-  }
+  cursor.nextSeq = seq + 1;
   if (options.touchMutation !== false) {
     touchTranscriptMutationInTransaction(database, scope.sessionId);
   }
-  const projectionNeedsRebuild = indexAppendedTranscriptEventInTransaction(database.db, {
-    sessionId: scope.sessionId,
+  cursor.appendToIndex ??= createTranscriptIndexAppenderInTransaction(database.db, scope.sessionId);
+  const projectionNeedsRebuild = cursor.appendToIndex({
     seq,
     event: persistedEvent,
     eventId: identity?.eventId ?? null,
@@ -192,7 +192,9 @@ export function appendTranscriptEventsInTransaction(
 ): number {
   let appended = 0;
   let projectionNeedsRebuild = false;
-  const cursor: TranscriptAppendCursor = { initialized: false };
+  // Prepared arrays and the import spool cannot mutate the destination between
+  // rows. Sequence and projection facts belong only to this synchronous batch.
+  const cursor: TranscriptAppendCursor = {};
   const iterator = events[Symbol.iterator]();
   const appendOptions = {
     ...options,
@@ -259,8 +261,8 @@ function appendTranscriptEventRowInTransaction(
       created_at: createdAt,
     }),
   );
-  indexAppendedTranscriptEventInTransaction(database.db, {
-    sessionId: scope.sessionId,
+  const appendToIndex = createTranscriptIndexAppenderInTransaction(database.db, scope.sessionId);
+  appendToIndex({
     seq,
     event: persistedEvent,
     eventId: identity?.eventId ?? null,

--- a/src/config/sessions/session-transcript-context-eligibility.test.ts
+++ b/src/config/sessions/session-transcript-context-eligibility.test.ts
@@ -85,7 +85,9 @@ it("converges an older current-watermark rebuild and a following append without 
       sessionId,
       sessionKey: "agent:main:eligibility",
     };
-    await replaceTranscriptEvents(scope, [...entries]);
+    runOpenClawAgentWriteTransaction((database) => {
+      expect(appendTranscriptEventsInTransaction(database, scope, entries)).toBe(entries.length);
+    }, scope);
     const { db } = openOpenClawAgentDatabase(scope);
     const expectedRows = projectionRows(db);
     expect(expectedRows.map((row) => row.context_eligible)).toEqual([1, 1, 0, 1]);
@@ -114,12 +116,14 @@ it("converges an older current-watermark rebuild and a following append without 
     );
     runOpenClawAgentWriteTransaction((database) => {
       appendTranscriptEventsInTransaction(database, scope, [
+        entries[3],
         {
           type: "message",
           id: "new",
           parentId: "answer",
           message: { role: "user", content: "next" },
         },
+        entries[3],
       ]);
       expect(
         db

--- a/src/config/sessions/session-transcript-index.ts
+++ b/src/config/sessions/session-transcript-index.ts
@@ -56,6 +56,13 @@ export type SessionTranscriptProjectionState = {
   needsRebuild: boolean;
 };
 
+type TranscriptIndexAppend = {
+  seq: number;
+  event: unknown;
+  eventId: string | null;
+  createdAt: number;
+};
+
 // FTS rebuilds cost about 60 ms per 1,000 events/1 MiB on dev hardware; cap synchronous
 // work near a 250 ms event-loop stall and leave larger projections to the reconcile worker.
 export const SYNC_REBUILD_MAX_ROWS = 4_000;
@@ -156,7 +163,7 @@ function writeWatermark(
   sessionId: string,
   watermark: SessionTranscriptProjectionState,
   now: number,
-): void {
+): SessionTranscriptProjectionState {
   executeSqliteQuerySync(
     db,
     getIndexKysely(db)
@@ -181,6 +188,7 @@ function writeWatermark(
         }),
       ),
   );
+  return watermark;
 }
 
 function insertActiveEventRow(
@@ -239,99 +247,92 @@ function deleteFtsRows(db: DatabaseSync, sessionId: string): void {
 }
 
 /**
- * In-transaction append hook. Forward-indexes the event when it
+ * In-transaction batch appender. Forward-indexes the event when it
  * unambiguously extends the active branch and marks the session for rebuild
  * otherwise. Runs inside the same write transaction as the event insert, so
  * the index can never lag or tear relative to committed transcript rows.
+ * Retain only within a synchronous batch whose source cannot mutate this session.
  */
-export function indexAppendedTranscriptEventInTransaction(
+export function createTranscriptIndexAppenderInTransaction(
   db: DatabaseSync,
-  params: {
-    sessionId: string;
-    seq: number;
-    event: unknown;
-    eventId: string | null;
-    createdAt: number;
-  },
-): boolean {
-  const watermark = readSessionTranscriptProjectionState(db, params.sessionId);
-  if (!watermark) {
-    if (params.seq !== 0) {
-      // Pre-existing rows without index state (e.g. doctor-migrated
-      // transcripts): stay unindexed until reconcile rebuilds the session.
+  sessionId: string,
+): (params: TranscriptIndexAppend) => boolean {
+  let watermark = readSessionTranscriptProjectionState(db, sessionId);
+  let hasUnclassifiedEvents: boolean | undefined;
+  return (params) => {
+    if (!watermark) {
+      if (params.seq !== 0) {
+        // Pre-existing rows without index state (e.g. doctor-migrated
+        // transcripts): stay unindexed until reconcile rebuilds the session.
+        return true;
+      }
+      watermark = applyForwardIndex(db, sessionId, params, {
+        activeEventCount: 0,
+        activeMessageCount: 0,
+        indexedSeq: -1,
+        leafEventId: null,
+        needsRebuild: false,
+      });
+      return false;
+    }
+    if (watermark.needsRebuild) {
       return true;
     }
-    applyForwardIndex(db, params, {
-      activeEventCount: 0,
-      activeMessageCount: 0,
-      indexedSeq: -1,
-      leafEventId: null,
-      needsRebuild: false,
-    });
+    if (
+      params.seq !== watermark.indexedSeq + 1 ||
+      (hasUnclassifiedEvents ??= hasUnclassifiedSessionTranscriptEvents(db, sessionId))
+    ) {
+      // Out-of-band or older writers left incomplete projection facts. Once checked,
+      // this batch's own forward rows all carry an explicit context classification.
+      watermark = markSessionTranscriptIndexDirtyInTransaction(db, sessionId);
+      return true;
+    }
+    if (
+      isSessionTranscriptLeafControl(params.event) ||
+      isSessionTranscriptSideAppendEntry(params.event)
+    ) {
+      // Leaf controls repoint the active branch and side appends attach off
+      // the main chain; the visible path must be re-resolved rather than
+      // guessed at append time.
+      watermark = markSessionTranscriptIndexDirtyInTransaction(db, sessionId);
+      return true;
+    }
+    const isCanonicalEvent = isCanonicalSessionTranscriptEntry(params.event);
+    if (isCanonicalEvent && watermark.leafEventId === null && watermark.activeEventCount > 0) {
+      // A canonical tree supersedes legacy flat message rows. Re-resolve once
+      // instead of retaining rows that are no longer on the selected path.
+      watermark = markSessionTranscriptIndexDirtyInTransaction(db, sessionId);
+      return true;
+    }
+    const treeEntry = parseSessionTranscriptTreeEntry(params.event);
+    if (
+      !isCanonicalEvent &&
+      watermark.leafEventId !== null &&
+      shouldProjectActiveEvent(params.event)
+    ) {
+      // A noncanonical row after a tracked tree cursor may be a flat fallback or
+      // an opaque append ancestor. Only the full resolver can decide visibility.
+      watermark = markSessionTranscriptIndexDirtyInTransaction(db, sessionId);
+      return true;
+    }
+    if (treeEntry && treeEntry.parentId !== watermark.leafEventId) {
+      watermark = markSessionTranscriptIndexDirtyInTransaction(db, sessionId);
+      return true;
+    }
+    watermark = applyForwardIndex(db, sessionId, params, watermark);
     return false;
-  }
-  if (watermark.needsRebuild) {
-    return true;
-  }
-  if (
-    params.seq !== watermark.indexedSeq + 1 ||
-    hasUnclassifiedSessionTranscriptEvents(db, params.sessionId)
-  ) {
-    // Out-of-band or older writers left incomplete projection facts.
-    // Reconcile owns convergence even when their sequence watermark is current.
-    markSessionTranscriptIndexDirtyInTransaction(db, params.sessionId);
-    return true;
-  }
-  if (
-    isSessionTranscriptLeafControl(params.event) ||
-    isSessionTranscriptSideAppendEntry(params.event)
-  ) {
-    // Leaf controls repoint the active branch and side appends attach off
-    // the main chain; the visible path must be re-resolved rather than
-    // guessed at append time.
-    markSessionTranscriptIndexDirtyInTransaction(db, params.sessionId);
-    return true;
-  }
-  const isCanonicalEvent = isCanonicalSessionTranscriptEntry(params.event);
-  if (isCanonicalEvent && watermark.leafEventId === null && watermark.activeEventCount > 0) {
-    // A canonical tree supersedes legacy flat message rows. Re-resolve once
-    // instead of retaining rows that are no longer on the selected path.
-    markSessionTranscriptIndexDirtyInTransaction(db, params.sessionId);
-    return true;
-  }
-  const treeEntry = parseSessionTranscriptTreeEntry(params.event);
-  if (
-    !isCanonicalEvent &&
-    watermark.leafEventId !== null &&
-    shouldProjectActiveEvent(params.event)
-  ) {
-    // A noncanonical row after a tracked tree cursor may be a flat fallback or
-    // an opaque append ancestor. Only the full resolver can decide visibility.
-    markSessionTranscriptIndexDirtyInTransaction(db, params.sessionId);
-    return true;
-  }
-  if (treeEntry && treeEntry.parentId !== watermark.leafEventId) {
-    markSessionTranscriptIndexDirtyInTransaction(db, params.sessionId);
-    return true;
-  }
-  applyForwardIndex(db, params, watermark);
-  return false;
+  };
 }
 
 function applyForwardIndex(
   db: DatabaseSync,
-  params: {
-    sessionId: string;
-    seq: number;
-    event: unknown;
-    eventId: string | null;
-    createdAt: number;
-  },
+  sessionId: string,
+  params: TranscriptIndexAppend,
   watermark: SessionTranscriptProjectionState,
-): void {
+): SessionTranscriptProjectionState {
   const entry = extractTranscriptIndexEntry(params.event, params.createdAt);
   if (entry) {
-    insertFtsRow(db, params.sessionId, entry);
+    insertFtsRow(db, sessionId, entry);
   }
   const projectsActiveEvent = shouldProjectActiveEvent(params.event);
   const projectsMessage = projectsActiveEvent && hasTranscriptMessage(params.event);
@@ -341,16 +342,16 @@ function applyForwardIndex(
       contextEligible: transcriptEventContextEligibility(params.event),
       eventSeq: params.seq,
       messagePosition: projectsMessage ? watermark.activeMessageCount : null,
-      sessionId: params.sessionId,
+      sessionId,
     });
   }
   // Mirror scanSessionTranscriptTree's leaf advancement: canonical entries
   // (parent-linked or parentless) become the tip the next append chains to;
   // headers and unknown control rows leave the tip untouched.
   const advancesLeaf = params.eventId !== null && isCanonicalSessionTranscriptEntry(params.event);
-  writeWatermark(
+  return writeWatermark(
     db,
-    params.sessionId,
+    sessionId,
     {
       activeEventCount: watermark.activeEventCount + (projectsActiveEvent ? 1 : 0),
       activeMessageCount: watermark.activeMessageCount + (projectsMessage ? 1 : 0),
@@ -366,10 +367,10 @@ function applyForwardIndex(
 export function markSessionTranscriptIndexDirtyInTransaction(
   db: DatabaseSync,
   sessionId: string,
-): void {
+): SessionTranscriptProjectionState {
   const now = Date.now();
   const watermark = readSessionTranscriptProjectionState(db, sessionId);
-  writeWatermark(
+  return writeWatermark(
     db,
     sessionId,
     {


### PR DESCRIPTION
## What Problem This Solves

Large upgrades still spent avoidable time importing transcript events and scanning already-current session histories during Doctor. This follows the earlier profiling work in #133068 and #133100.

## Why This Change Was Made

The existing synchronous transcript batch now carries forward the projection facts it just persisted, removing redundant reads and query construction between events. Single appends and replacement writes still start with fresh facts. Doctor reuses prepared read statements within its existing read-only database pass, without caching results or retaining a cursor across repairs.

Statement reuse also requires clearing a native SQLite iterator error before reading the next session. A real SQLite regression reproduced that failure in three iterator paths before the cleanup fix; the original read error remains visible. No schema, indexes, durability settings, transaction boundaries, configuration, or persisted data contracts change.

## User Impact

Imports and repeated Doctor checks do less work while preserving transcript contents, deduplication, active branches, search projections, recency, and restart behavior. This does not change background update channel selection or plugin capability consent.

## Evidence

Matched Node profiling and fresh-process import runs against main `63f265c0ddb9ec80dd0c54bf7b6c76f3c005f6f6`, three interleaved runs per variant and shape:

| Fixture | Before median | After median | Less elapsed time |
| --- | ---: | ---: | ---: |
| Deep history, 100,001 events | 15.383 s | 12.426 s | 19.2% |
| 100 short histories, 10,100 events | 1.298 s | 1.072 s | 17.4% |
| 100 branched histories, 10,200 events | 1.875 s | 1.715 s | 8.5% |

These are local synthetic measurements with timing noise, not a guarantee for every machine. A separate 10,001-event trace removed 19,999 queries (120,033 → 100,034); all twelve reported write shapes retained identical counts, including every per-event watermark write.

On a separate unchanged 20,000-session / 500,000-event fixture, full Doctor header detection fell from 404.63 to 203.58 ms (49.7%) and label detection from 1,043.50 to 882.67 ms (15.4%). Each side has nine observations across three fresh processes. Initial label measurements overlapped local review scanning and are retained separately; the reported label result is the quiet confirmation. The database SHA-256 stayed identical.

Native SQLite error isolation: three iterator regressions failed before cleanup, then all four cases passed. All 102 focused tests passed across 11 files, covering imports, active projections, classification convergence, replacements, message cuts, recovery, parent forks, and Doctor repairs. The exact-head packaged Docker lane passed on its first attempt: stable `2026.7.1-2` → candidate tarball at `2ef1cee326e2aa3a3fa8689b9e9582733a364e81`, with 4,800 sessions, 1,227,946 transcript events, and 10,000 cron jobs. Five exhaustive volume assertions passed, including automatic migration immediately after the update command and before standalone Doctor/plugin consent. Eight Gateway history samples (600 returned messages) were identical across restart. Repeat Doctor took 39 seconds against a 60-second budget; the complete lane took 533 seconds, excluding package build.

[Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33297638044), including production/test types, Windows, and SQLite lifecycle. [Docker proof run](https://github.com/openclaw/openclaw/actions/runs/33297621102) returned wrapper exit 0; its delegated lease was stopped after evidence collection. Local aggregate test typing encountered the existing shared-install `pako` mismatch, which the clean CI install did not reproduce. Final changed-file lint, core typing, and focused reruns passed.

Reproduction: run `node scripts/test-docker-all.mjs` in Testbox with `OPENCLAW_DOCKER_ALL_LANES=published-upgrade-survivor`, `OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPECS=2026.7.1-2`, `OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS=sqlite-volume`, `OPENCLAW_UPGRADE_SURVIVOR_VOLUME_SESSIONS=4800`, `OPENCLAW_UPGRADE_SURVIVOR_VOLUME_EVENTS_PER_SESSION=257`, and `OPENCLAW_UPGRADE_SURVIVOR_VOLUME_CRON_JOBS=10000`. This explicitly selects the candidate package; it proves automatic migration during update, not unattended stable-to-main channel switching. Fixture plugin capability consent remains explicit.

The latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/133127#issuecomment-5467254153) found no actionable or security defect and listed no Rank-up moves. Its remaining exact-head CI/maintainer-review step is satisfied by the linked CI, local owner review, and fresh committed-patch Codex autoreview.

Production LOC: +238/-218 (net +20). Tests: +76/-3 (net +73). The growth gives the existing batch a bounded projection-fact owner and gives reused read statements explicit native-error cleanup; there is no second index/repair path or persistent cache. Codex autoreview of the complete owner/caller/test evidence found no actionable findings.

The change is bounded query/read reuse under the existing owners. It adds no persistent representation and does not alter the operating model described in `docs/reference/database-schemas.md`. Planner-statistics work (#119884) and credential-retention work (#129689) remain separately owned; this PR does not claim to resolve them.
