### PR TITLE
fix: read Windows PowerShell UTF-16 text files correctly

### DIFF
--- a/src/agents/agent-tools.read.windows.test.ts
+++ b/src/agents/agent-tools.read.windows.test.ts
@@ -1,17 +1,44 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { getWindowsPowerShellExePath } from "../infra/windows-install-roots.js";
 import "./test-helpers/fast-bash-tools.js";
 import "./test-helpers/fast-coding-tools.js";
 import "./test-helpers/fast-openclaw-tools.js";
 import { createOpenClawCodingTools } from "./agent-tools.js";
-import { expectReadWriteEditTools } from "./test-helpers/agent-tools-fs-helpers.js";
+import { expectReadWriteEditTools, getTextContent } from "./test-helpers/agent-tools-fs-helpers.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-describe("registered core read OS-home paths", () => {
+describe("registered core read on Windows", () => {
+  it.runIf(process.platform === "win32")(
+    "reads text produced by Windows PowerShell Out-File",
+    async () => {
+      const workspaceDir = tempDirs.make("openclaw-core-read-utf16-");
+      execFileSync(
+        getWindowsPowerShellExePath(),
+        [
+          "-NoLogo",
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          "@('first', 'second') | Out-File -LiteralPath 'utf16.txt'",
+        ],
+        { cwd: workspaceDir, timeout: 10_000, windowsHide: true },
+      );
+      const filePath = path.join(workspaceDir, "utf16.txt");
+      const bytes = await fs.readFile(filePath);
+      expect(bytes.subarray(0, 2)).toEqual(Buffer.from([0xff, 0xfe]));
+
+      const { readTool } = expectReadWriteEditTools(createOpenClawCodingTools({ workspaceDir }));
+      const result = await readTool.execute("tool-utf16-read", { path: filePath });
+      expect(getTextContent(result)).toBe("first\nsecond\n");
+    },
+  );
+
   it.runIf(process.platform === "win32")("reads a Windows-style home path", async () => {
     const homeDir = process.env.HOME ?? os.homedir();
     const homeTestDir = tempDirs.make("openclaw-core-read-home-", homeDir);

--- a/src/infra/windows-encoding.test.ts
+++ b/src/infra/windows-encoding.test.ts
@@ -302,12 +302,12 @@ describe("windows output encoding", () => {
   );
 
   it.each(["utf-8", "gbk"] as const)(
-    "decodes complete UTF-16 BOM output buffers with a %s console encoding",
+    "decodes complete UTF-16 BOM output and file buffers with a %s fallback encoding",
     (windowsEncoding) => {
       for (const [, raw] of UTF16_OUTPUT_CASES) {
-        expect(decodeWindowsOutputBuffer({ buffer: raw, platform: "win32", windowsEncoding })).toBe(
-          "hi\n",
-        );
+        for (const decode of [decodeWindowsOutputBuffer, decodeWindowsTextFileBuffer]) {
+          expect(decode({ buffer: raw, platform: "win32", windowsEncoding })).toBe("hi\n");
+        }
       }
     },
   );

--- a/src/infra/windows-encoding.ts
+++ b/src/infra/windows-encoding.ts
@@ -169,14 +169,6 @@ export function decodeWindowsOutputBuffer(params: {
   platform?: NodeJS.Platform;
   windowsEncoding?: string | null;
 }): string {
-  if ((params.platform ?? process.platform) !== "win32") {
-    return params.buffer.toString("utf8");
-  }
-  const [first, second] = params.buffer;
-  if ((first === 0xff && second === 0xfe) || (first === 0xfe && second === 0xff)) {
-    const decoder = createWindowsOutputDecoder(params);
-    return decoder.decode(params.buffer) + decoder.flush();
-  }
   return decodeWindowsBufferWithFallback({
     ...params,
     resolveFallbackEncoding: () => params.windowsEncoding ?? resolveWindowsConsoleEncoding(),
@@ -203,6 +195,13 @@ function decodeWindowsBufferWithFallback(params: {
   const platform = params.platform ?? process.platform;
   if (platform !== "win32") {
     return params.buffer.toString("utf8");
+  }
+
+  // Windows PowerShell files and command output can declare UTF-16 with a BOM;
+  // honor it before consulting either the system or console legacy code page.
+  const [first, second] = params.buffer;
+  if ((first === 0xff && second === 0xfe) || (first === 0xfe && second === 0xff)) {
+    return new TextDecoder(first === 0xff ? "utf-16le" : "utf-16be").decode(params.buffer);
   }
 
   const utf8 = decodeStrictUtf8(params.buffer);


### PR DESCRIPTION
Closes #133129

## What Problem This Solves

Fixes an issue where users reading UTF-16 text files on Windows would receive mojibake and NUL characters, including files generated by Windows PowerShell `Out-File` and redirection.

## Why This Change Was Made

BOM recognition belonged only to process output, although local file reads use the same complete-buffer decoding owner. Move UTF-16 BOM handling into that shared owner before UTF-8 and legacy code-page decoding. Console and system fallback selection remain distinct; streaming and non-Windows behavior stay unchanged. Production delta is +7/−8 lines; no configuration, persistence, or public schema changes.

## User Impact

Windows agents can read BOM-marked UTF-16LE and UTF-16BE files as normal text. Existing UTF-8 and legacy code-page text continue through their existing decoding paths.

## Evidence

The original file decoder produced `"ÿþh\u0000i\u0000\n\u0000"` from the UTF-16LE bytes for `hi\n`; the repaired decoder returns `"hi\n"`. The existing whole-buffer regression matrix was extended to cover file reads: it failed in two cases before the production change, then passed afterward.

Focused local proof: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/infra/windows-encoding.test.ts src/process/exec.windows.test.ts src/agents/agent-tools.read.windows.test.ts src/agents/sessions/tools/read.test.ts` — 96 tests passed. The two native Windows cases were skipped on macOS and are not counted as native proof.

A new case in the existing Windows CI target invokes real Windows PowerShell `Out-File`, verifies its UTF-16LE BOM, then calls the registered core read tool and asserts the exact decoded text. Native Windows proof passed on the exact candidate in [checks-windows-node-test-2](https://github.com/openclaw/openclaw/actions/runs/33297731700/job/99220243430): the real PowerShell-to-registered-read case passed in 346 ms, and the sibling Windows home-path read passed too. This is observed native execution, not a platform mock or skipped test.

[Microsoft's character-encoding documentation](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_character_encoding?view=powershell-5.1) confirms the Windows PowerShell file format. Independent source and explicit-platform before/after review found no actionable issue. Structured Codex autoreview completed scoped-clean at its P0 threshold for the exact committed patch. The canonical local changed gate passed (core/test types, lint, and guards), and [exact-head CI is green](https://github.com/openclaw/openclaw/actions/runs/33297731700). ClawSweeper’s sole remaining before-merge/rank-up request, observing the native Windows case, is satisfied by the passing job above.

Reviewed and tested head: `e83e7e89c14f65f9d2c9d83fc46b447f9f48292d`. A separate fresh read-only Codex CLI review of this head completed with no actionable material defects; it independently verified the complete-buffer owner, sibling semantics, native fixture, and Windows CI selection.
