### PR TITLE
fix: keep prepared-model tests inside owned state

### DIFF
--- a/src/agents/prepared-model-runtime-config-stamp.test.ts
+++ b/src/agents/prepared-model-runtime-config-stamp.test.ts
@@ -1,11 +1,16 @@
 // Preserve module setup before modules that consume it.
 // oxfmt-ignore
 import {
+  cleanupPreparedModelRuntimeHarness,
   getPreparedModelRuntimeMocks,
   resetPreparedModelRuntimeHarness,
 } from "./prepared-model-runtime.test-harness.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
 import { resolvePublishedModelCatalogOwner } from "./prepared-model-catalog-owner.js";
 import {
   getPreparedModelRuntimeAuthMaterializations,
@@ -21,10 +26,12 @@ import {
 } from "./prepared-model-runtime.js";
 
 const mocks = getPreparedModelRuntimeMocks();
+let state: OpenClawTestState;
 
 describe("prepared model runtime config stamps", () => {
-  beforeEach(() => {
-    resetPreparedModelRuntimeHarness();
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ label: "prepared-model-runtime" });
+    resetPreparedModelRuntimeHarness(state);
     mocks.configuredAgentIds = ["default"];
   });
 
@@ -34,8 +41,8 @@ describe("prepared model runtime config stamps", () => {
     await refreshPreparedModelRuntimeSnapshots(initialConfig, { gatewayLifecycle: true });
     const input = {
       agentId: "default",
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
       config: initialConfig,
     };
     const existingReader = await prepareModelRuntimeSnapshot(input);
@@ -92,8 +99,8 @@ describe("prepared model runtime config stamps", () => {
     await expect(
       prepareModelRuntimeSnapshot({
         agentId: "default",
-        agentDir: "/tmp/unused-agent",
-        inheritedAuthDir: "/tmp/unused-agent",
+        agentDir: state.agentDir("default"),
+        inheritedAuthDir: state.agentDir("default"),
         config: nextConfig,
       }),
     ).resolves.toMatchObject({ config: nextConfig });
@@ -106,26 +113,33 @@ describe("prepared model runtime config stamps", () => {
     const staleConfig = {};
     const nextConfig = { gateway: { reload: { mode: "hot" as const } } };
     const supplierReady = createDeferred();
-    const stalePublication = refreshPreparedModelRuntimeSnapshots(async () => {
-      await supplierReady.promise;
-      return staleConfig;
-    });
-    const nextPublication = refreshPreparedModelRuntimeSnapshots(nextConfig, {
-      gatewayLifecycle: true,
-    });
+    let stalePublication: ReturnType<typeof refreshPreparedModelRuntimeSnapshots> | undefined;
+    let nextPublication: ReturnType<typeof refreshPreparedModelRuntimeSnapshots> | undefined;
+    try {
+      stalePublication = refreshPreparedModelRuntimeSnapshots(async () => {
+        await supplierReady.promise;
+        return staleConfig;
+      });
+      nextPublication = refreshPreparedModelRuntimeSnapshots(nextConfig, {
+        gatewayLifecycle: true,
+      });
 
-    supplierReady.resolve();
-    await Promise.all([stalePublication, nextPublication]);
+      supplierReady.resolve();
+      await Promise.all([stalePublication, nextPublication]);
 
-    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
-    await expect(
-      prepareModelRuntimeSnapshot({
-        agentId: "default",
-        agentDir: "/tmp/unused-agent",
-        inheritedAuthDir: "/tmp/unused-agent",
-        config: nextConfig,
-      }),
-    ).resolves.toMatchObject({ config: nextConfig });
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
+      await expect(
+        prepareModelRuntimeSnapshot({
+          agentId: "default",
+          agentDir: state.agentDir("default"),
+          inheritedAuthDir: state.agentDir("default"),
+          config: nextConfig,
+        }),
+      ).resolves.toMatchObject({ config: nextConfig });
+    } finally {
+      supplierReady.resolve();
+      await Promise.allSettled([stalePublication, nextPublication]);
+    }
   });
 
   it("drops a publication whose lifecycle claim is lost during async config resolution", async () => {
@@ -136,76 +150,92 @@ describe("prepared model runtime config stamps", () => {
     const supplierStarted = createDeferred();
     const releaseSupplier = createDeferred();
     let claimCurrent = true;
-    const stalePublication = refreshPreparedModelRuntimeSnapshots(
-      async () => {
-        supplierStarted.resolve();
-        await releaseSupplier.promise;
-        return staleConfig;
-      },
-      {
-        gatewayLifecycle: true,
-        isPublicationCurrent: () => claimCurrent,
-      },
-    );
+    let stalePublication: ReturnType<typeof refreshPreparedModelRuntimeSnapshots> | undefined;
+    try {
+      stalePublication = refreshPreparedModelRuntimeSnapshots(
+        async () => {
+          supplierStarted.resolve();
+          await releaseSupplier.promise;
+          return staleConfig;
+        },
+        {
+          gatewayLifecycle: true,
+          isPublicationCurrent: () => claimCurrent,
+        },
+      );
 
-    await supplierStarted.promise;
-    const readerSettled = vi.fn();
-    const reader = prepareModelRuntimeSnapshot({
-      agentId: "default",
-      agentDir: "/tmp/unused-agent",
-      config: staleConfig,
-    }).then(readerSettled, readerSettled);
-    claimCurrent = false;
-    releaseSupplier.resolve();
-    await stalePublication;
-    // Losing the external claim must settle readers even if no replacement is scheduled.
-    await vi.waitFor(() => expect(readerSettled).toHaveBeenCalledWith(expect.any(Error)));
-    await reader;
-    await refreshPreparedModelRuntimeSnapshots(nextConfig, { gatewayLifecycle: true });
-
-    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
-    await expect(
-      prepareModelRuntimeSnapshot({
+      await supplierStarted.promise;
+      const readerSettled = vi.fn();
+      const reader = prepareModelRuntimeSnapshot({
         agentId: "default",
-        agentDir: "/tmp/unused-agent",
-        inheritedAuthDir: "/tmp/unused-agent",
-        config: nextConfig,
-      }),
-    ).resolves.toMatchObject({ config: nextConfig });
-    await expect(
-      loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
-    ).resolves.toMatchObject({ config: nextConfig });
+        agentDir: state.agentDir("default"),
+        config: staleConfig,
+      }).then(readerSettled, readerSettled);
+      claimCurrent = false;
+      releaseSupplier.resolve();
+      await stalePublication;
+      // Losing the external claim must settle readers even if no replacement is scheduled.
+      await vi.waitFor(() => expect(readerSettled).toHaveBeenCalledWith(expect.any(Error)));
+      await reader;
+      await refreshPreparedModelRuntimeSnapshots(nextConfig, { gatewayLifecycle: true });
+
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
+      await expect(
+        prepareModelRuntimeSnapshot({
+          agentId: "default",
+          agentDir: state.agentDir("default"),
+          inheritedAuthDir: state.agentDir("default"),
+          config: nextConfig,
+        }),
+      ).resolves.toMatchObject({ config: nextConfig });
+      await expect(
+        loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
+      ).resolves.toMatchObject({ config: nextConfig });
+    } finally {
+      claimCurrent = false;
+      releaseSupplier.resolve();
+      await Promise.allSettled([stalePublication]);
+    }
   });
 
   it("keeps an in-flight auth publication on the advanced stamp", async () => {
     const initialConfig = {};
     const nextConfig = { gateway: { reload: { mode: "hot" as const } } };
     await refreshPreparedModelRuntimeSnapshots(initialConfig, { gatewayLifecycle: true });
+    const finishAuthRefreshGate = createDeferred();
     let finishAuthRefresh: (() => void) | undefined;
-    mocks.ensureOpenClawModelsJson.mockImplementationOnce(
-      async () =>
-        await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
-          finishAuthRefresh = () => resolve({ agentDir: "/tmp/unused-agent", wrote: false });
-        }),
-    );
-
-    mocks.mutationListener?.({ affectsInheritedStores: true });
-    await vi.waitFor(() => expect(finishAuthRefresh).toBeDefined());
-    mocks.configuredAgentDirs.set("default", "/tmp/later-agent");
-    advancePreparedModelRuntimeConfig(nextConfig);
-    finishAuthRefresh?.();
-
-    const snapshot = await prepareModelRuntimeSnapshot({
-      agentId: "default",
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
-      config: nextConfig,
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(async (_config, agentDir) => {
+      finishAuthRefresh = () => finishAuthRefreshGate.resolve();
+      await finishAuthRefreshGate.promise;
+      return { agentDir: String(agentDir), wrote: false };
     });
-    expect(resolvePublishedModelCatalogOwner(snapshot)).toMatchObject({
-      agentId: "default",
-      workspaceDir: "/tmp/unused-workspace",
-      config: nextConfig,
-    });
-    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
+
+    try {
+      mocks.mutationListener?.({ affectsInheritedStores: true });
+      await vi.waitFor(() => expect(finishAuthRefresh).toBeDefined());
+      mocks.configuredAgentDirs.set("default", "/tmp/later-agent");
+      advancePreparedModelRuntimeConfig(nextConfig);
+      finishAuthRefreshGate.resolve();
+
+      const snapshot = await prepareModelRuntimeSnapshot({
+        agentId: "default",
+        agentDir: state.agentDir("default"),
+        inheritedAuthDir: state.agentDir("default"),
+        config: nextConfig,
+      });
+      expect(resolvePublishedModelCatalogOwner(snapshot)).toMatchObject({
+        agentId: "default",
+        workspaceDir: "/tmp/unused-workspace",
+        config: nextConfig,
+      });
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
+    } finally {
+      finishAuthRefreshGate.resolve();
+      await Promise.allSettled([loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" })]);
+    }
   });
+});
+
+afterEach(async ({ task }) => {
+  await cleanupPreparedModelRuntimeHarness(state, task.result?.state === "fail");
 });

--- a/src/agents/prepared-model-runtime.catalog-owner.test.ts
+++ b/src/agents/prepared-model-runtime.catalog-owner.test.ts
@@ -1,20 +1,33 @@
 // Preserve module setup before modules that consume it.
 // oxfmt-ignore
 import {
+  cleanupPreparedModelRuntimeHarness,
   getPreparedModelRuntimeMocks,
+  getPreparedModelRuntimeTestApi,
   resetPreparedModelRuntimeHarness,
 } from "./prepared-model-runtime.test-harness.js";
-import { beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import * as agentDatabase from "../state/openclaw-agent-db-readonly.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { resolveAgentDir } from "./agent-scope.js";
+import { loadPersistedPluginModelCatalogsReadOnly } from "./plugin-model-catalog.js";
 import {
   preparePublishedModelCatalogOwnerIdentity,
   resolvePublishedModelCatalogOwner,
 } from "./prepared-model-catalog-owner.js";
+import * as runtimeBuild from "./prepared-model-runtime.build.js";
 import {
   startSerializedSnapshotBuild,
   startSerializedSnapshotBuildBatch,
 } from "./prepared-model-runtime.build.js";
 import {
+  activateStandalonePreparedModelRuntime,
   loadPublishedGatewayReplyDispatchRuntime,
   prepareModelRuntimeSnapshot,
   publishPreparedModelRuntimeSnapshot,
@@ -24,14 +37,69 @@ import {
 
 const mocks = getPreparedModelRuntimeMocks();
 
-beforeEach(() => resetPreparedModelRuntimeHarness());
+let state: OpenClawTestState;
+beforeEach(async () => {
+  state = await createOpenClawTestState({ label: "prepared-model-runtime" });
+  resetPreparedModelRuntimeHarness(state);
+});
+afterEach(async ({ task }) => {
+  await cleanupPreparedModelRuntimeHarness(state, task.result?.state === "fail");
+});
+
+describe("prepared fixture containment", () => {
+  function assertOwnedPath(target: string) {
+    const relative = path.relative(state.root, path.resolve(target));
+    if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+      throw new Error(`PREPARED_FIXTURE_ESCAPE: ${target}`);
+    }
+  }
+
+  beforeEach(() => {
+    const readFileSync = fs.readFileSync;
+    vi.spyOn(fs, "readFileSync").mockImplementation((...args) => {
+      if (typeof args[0] === "string" && path.basename(args[0]) === "models.json") {
+        assertOwnedPath(args[0]);
+      }
+      return readFileSync(...args);
+    });
+    const readDatabase = agentDatabase.withOpenClawAgentDatabaseReadOnly;
+    vi.spyOn(agentDatabase, "withOpenClawAgentDatabaseReadOnly").mockImplementation(
+      (operation, options, behavior) => {
+        // Guard before delegation: the reader may reuse a handle before probing the file.
+        assertOwnedPath(options.path!);
+        return readDatabase(operation, options, behavior);
+      },
+    );
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it.each(["static", "live"] as const)("contains native %s model capture", async (catalogMode) => {
+    mocks.configuredAgentIds = ["default", "worker"];
+    await refreshPreparedModelRuntimeSnapshots({}, { catalogMode });
+    expect(mocks.discoverModels).toHaveBeenCalled();
+    for (const agentId of ["default", "worker"]) {
+      expect(fs.readFileSync).toHaveBeenCalledWith(
+        path.join(state.agentDir(agentId), "models.json"),
+        "utf8",
+      );
+    }
+  });
+
+  it("contains the native read-only catalog boundary", () => {
+    expect(loadPersistedPluginModelCatalogsReadOnly(resolveAgentDir({}, "default"))).toEqual([]);
+    expect(agentDatabase.withOpenClawAgentDatabaseReadOnly).toHaveBeenCalledWith(
+      expect.any(Function),
+      { agentId: "default", path: path.join(state.agentDir("default"), "openclaw-agent.sqlite") },
+    );
+  });
+});
 
 describe("prepared catalog owner lifecycle", () => {
   it.each([false, true])(
     "retains the current preparation across adopted auth (previous snapshot: %s)",
     async (previousSnapshot) => {
       mocks.configuredAgentIds = ["alpha"];
-      const agentDir = "/tmp/configured-alpha";
+      const agentDir = state.agentDir("alpha");
       if (previousSnapshot) {
         mocks.configuredWorkspaces.set("alpha", "/tmp/old-workspace");
         await refreshPreparedModelRuntimeSnapshots({}, { gatewayLifecycle: true });
@@ -109,7 +177,7 @@ describe("prepared catalog owner lifecycle", () => {
   );
 
   it("refreshes a newer beta preparation instead of the completed alpha snapshot", async () => {
-    const agentDir = "/tmp/rebound-catalog-agent";
+    const agentDir = state.agentDir("rebound-catalog-agent");
     const workspaceDir = "/tmp/rebound-catalog-workspace";
     const input = { agentDir, inheritedAuthDir: agentDir, workspaceDir, config: {} };
     mocks.configuredAgentIds = ["alpha"];
@@ -152,7 +220,7 @@ describe("prepared catalog owner lifecycle", () => {
   });
 
   it("retains known-unbound identity across auth refresh while runtime reads stay usable", async () => {
-    const input = { config: {}, agentDir: "/tmp/unbound-catalog-agent", readOnly: true };
+    const input = { config: {}, agentDir: state.agentDir("unbound-catalog-agent"), readOnly: true };
     mocks.configuredAgentIds = ["alpha"];
     const first = await publishPreparedModelRuntimeSnapshot(input);
     expect(() => resolvePublishedModelCatalogOwner(first)).toThrow(
@@ -174,10 +242,138 @@ describe("prepared catalog owner lifecycle", () => {
 });
 
 describe("prepared build candidate lifetime", () => {
+  it("fails a timed-out publication without overlapping its late build with a retry", async () => {
+    getPreparedModelRuntimeTestApi().setModelRuntimeBuildTimeoutMsForTest(1);
+    const source = createDeferred<{ agentDir: string; wrote: false }>();
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(async () => await source.promise);
+    const input = { config: {}, agentDir: state.agentDir("timeout") };
+    const builds = vi.spyOn(runtimeBuild, "startSerializedSnapshotBuild");
+    try {
+      await expect(publishPreparedModelRuntimeSnapshot(input)).rejects.toThrow(
+        "prepared model runtime publication timed out",
+      );
+      await expect(prepareModelRuntimeSnapshot(input)).rejects.toThrow(
+        "prepared model runtime publication timed out",
+      );
+      await expect(publishPreparedModelRuntimeSnapshot(input)).rejects.toThrow(
+        "prepared model runtime publication timed out",
+      );
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
+
+      source.resolve({ agentDir: input.agentDir, wrote: false });
+      // The timeout settles admission before capture finishes; join the native build, not discovery.
+      await builds.mock.results[0]!.value.completion;
+      expect(mocks.discoverModels).toHaveBeenCalledOnce();
+      await expect(publishPreparedModelRuntimeSnapshot(input)).resolves.toMatchObject({
+        agentDir: input.agentDir,
+      });
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
+    } finally {
+      source.resolve({ agentDir: input.agentDir, wrote: false });
+      await Promise.all(builds.mock.results.map((result) => result.value.completion));
+      builds.mockRestore();
+    }
+  });
+
+  it("serializes workspace replacements for one agent-owned catalog", async () => {
+    const finishFirstGate = createDeferred();
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(async (_config, targetDir) => {
+      await finishFirstGate.promise;
+      return { agentDir: String(targetDir), wrote: false };
+    });
+    const config = {};
+    const agentDir = state.agentDir("workspace-replacement");
+    let first: ReturnType<typeof publishPreparedModelRuntimeSnapshot> | undefined;
+    let requestDuringFirstGeneration: ReturnType<typeof prepareModelRuntimeSnapshot> | undefined;
+    let replacement: ReturnType<typeof publishPreparedModelRuntimeSnapshot> | undefined;
+    try {
+      first = publishPreparedModelRuntimeSnapshot({
+        config,
+        agentDir,
+        workspaceDir: "/tmp/workspace-old",
+      });
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce());
+      requestDuringFirstGeneration = prepareModelRuntimeSnapshot({
+        config,
+        agentDir,
+        workspaceDir: "/tmp/workspace-old",
+      });
+
+      replacement = publishPreparedModelRuntimeSnapshot({
+        config,
+        agentDir,
+        workspaceDir: "/tmp/workspace-new",
+      });
+      await Promise.resolve();
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
+
+      finishFirstGate.resolve();
+      const firstSnapshot = await first;
+      const replacementSnapshot = await replacement;
+      expect(await requestDuringFirstGeneration).toBe(firstSnapshot);
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenLastCalledWith(
+        config,
+        agentDir,
+        expect.objectContaining({ workspaceDir: "/tmp/workspace-new" }),
+      );
+      expect(
+        await prepareModelRuntimeSnapshot({
+          config,
+          agentDir,
+          workspaceDir: "/tmp/workspace-new",
+        }),
+      ).toBe(replacementSnapshot);
+    } finally {
+      finishFirstGate.resolve();
+      await Promise.allSettled([first, replacement, requestDuringFirstGeneration]);
+    }
+  });
+
+  it("serializes conflicting standalone activations for one owner", async () => {
+    const agentDir = state.agentDir("concurrent-standalone");
+    const firstConfig = {};
+    const secondConfig = {};
+    const finishFirstBuildGate = createDeferred();
+    let finishFirstBuild!: () => void;
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(async (_config, targetDir) => {
+      finishFirstBuild = () => finishFirstBuildGate.resolve();
+      await finishFirstBuildGate.promise;
+      return { agentDir: String(targetDir), wrote: false };
+    });
+
+    let firstActivation: ReturnType<typeof activateStandalonePreparedModelRuntime> | undefined;
+    let secondActivation: ReturnType<typeof activateStandalonePreparedModelRuntime> | undefined;
+    try {
+      firstActivation = activateStandalonePreparedModelRuntime({
+        config: firstConfig,
+        agentDir,
+      });
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce());
+      secondActivation = activateStandalonePreparedModelRuntime({
+        config: secondConfig,
+        agentDir,
+      });
+
+      await Promise.resolve();
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
+      finishFirstBuild();
+
+      const [first, second] = await Promise.all([firstActivation, secondActivation]);
+      expect(first?.config).toBe(firstConfig);
+      expect(second?.config).toBe(secondConfig);
+      expect(first).not.toBe(second);
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
+    } finally {
+      finishFirstBuildGate.resolve();
+      await Promise.allSettled([firstActivation, secondActivation]);
+    }
+  });
+
   it("allows a direct serialized build without a lifecycle generation guard", async () => {
     const input = {
       config: {},
-      agentDir: "/tmp/direct-prepared-model-runtime-build",
+      agentDir: state.agentDir("direct-prepared-model-runtime-build"),
       readOnly: true,
     };
     const build = startSerializedSnapshotBuild(
@@ -187,14 +383,17 @@ describe("prepared build candidate lifetime", () => {
       "static",
     );
 
-    await expect(build.pending).resolves.toMatchObject({
-      snapshot: {
-        agentDir: input.agentDir,
-        config: input.config,
-      },
-      pluginGeneration: expect.any(Object),
-    });
-    await expect(build.completion).resolves.toBeUndefined();
+    try {
+      await expect(build.pending).resolves.toMatchObject({
+        snapshot: {
+          agentDir: input.agentDir,
+          config: input.config,
+        },
+        pluginGeneration: expect.any(Object),
+      });
+    } finally {
+      await build.completion;
+    }
   });
 
   it.each([
@@ -239,7 +438,7 @@ describe("prepared build candidate lifetime", () => {
       callbacks: false,
     },
   ])("preserves $name semantics", async ({ single, generation, build, allowed, callbacks }) => {
-    const input = { config: {}, agentDir: "/tmp/candidate-lifetime", readOnly: true };
+    const input = { config: {}, agentDir: state.agentDir("candidate-lifetime"), readOnly: true };
     const candidate = {
       input,
       catalogOwner: preparePublishedModelCatalogOwnerIdentity(input),
@@ -270,7 +469,11 @@ describe("prepared build candidate lifetime", () => {
   it.each(["before", "after"] as const)(
     "checks supersession %s workspace preparation",
     async (checkpoint) => {
-      const input = { config: {}, agentDir: "/tmp/candidate-checkpoint", readOnly: true };
+      const input = {
+        config: {},
+        agentDir: state.agentDir("candidate-checkpoint"),
+        readOnly: true,
+      };
       const candidate = {
         input,
         catalogOwner: preparePublishedModelCatalogOwnerIdentity(input),

--- a/src/agents/prepared-model-runtime.inbound-registry.test.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.test.ts
@@ -1,11 +1,12 @@
 // Preserve module setup before modules that consume it.
 // oxfmt-ignore
 import {
+  cleanupPreparedModelRuntimeHarness,
   getPreparedModelRuntimeMocks,
   getPreparedModelRuntimeTestApi,
   resetPreparedModelRuntimeHarness,
 } from "./prepared-model-runtime.test-harness.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { createPluginMetadataSnapshot } from "../config/plugin-auto-enable.test-helpers.js";
@@ -13,6 +14,10 @@ import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { getPluginRuntimeGenerationRegistry } from "../plugins/runtime/generation-scope.js";
 import { getPluginRuntimeLoadContext } from "../plugins/runtime/load-context.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
 import type { DiscoverAuthStorageOptions } from "./agent-auth-discovery.js";
 import { withPreparedModelRuntimePluginGenerationScope } from "./prepared-model-runtime-generation-scope.js";
 import {
@@ -24,10 +29,12 @@ import {
 } from "./prepared-model-runtime.js";
 
 const mocks = getPreparedModelRuntimeMocks();
+let state: OpenClawTestState;
 
 describe("prepared reply dispatch runtime", () => {
-  beforeEach(() => {
-    resetPreparedModelRuntimeHarness();
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ label: "prepared-model-runtime" });
+    resetPreparedModelRuntimeHarness(state);
   });
 
   it("returns undefined while the Gateway lifecycle is inactive", async () => {
@@ -237,8 +244,8 @@ describe("prepared reply dispatch runtime", () => {
     });
     const input = {
       agentId: "default",
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
       config: firstConfig,
       workspaceDir: "/tmp/unused-workspace",
       allowGatewaySubagentBinding: true,
@@ -247,7 +254,7 @@ describe("prepared reply dispatch runtime", () => {
     const firstRuntime = await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
     expect(firstRuntime).toMatchObject({
       agentId: "default",
-      agentDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
       workspaceDir: "/tmp/unused-workspace",
       config: firstConfig,
       modelCatalog: firstSnapshot?.modelCatalog,
@@ -261,37 +268,42 @@ describe("prepared reply dispatch runtime", () => {
 
     const replacementCatalog = createDeferred<{ entries: [] }>();
     mocks.prepareStaticCatalog.mockImplementationOnce(async () => await replacementCatalog.promise);
-    const refresh = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
-      catalogMode: "static",
-      allowGatewaySubagentBinding: true,
-      pluginMetadataSnapshot: mocks.pluginMetadataSnapshot as never,
-    });
-    await vi.waitFor(() =>
-      expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(4),
-    );
-    expect(getPreparedModelRuntimeSnapshot(input)).toBeUndefined();
-    let resolvedRuntime: unknown;
-    const read = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }).then(
-      (runtime) => {
+    let refresh: ReturnType<typeof refreshPreparedModelRuntimeSnapshots> | undefined;
+    let read: ReturnType<typeof loadPublishedGatewayReplyDispatchRuntime> | undefined;
+    try {
+      refresh = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
+        catalogMode: "static",
+        allowGatewaySubagentBinding: true,
+        pluginMetadataSnapshot: mocks.pluginMetadataSnapshot as never,
+      });
+      await vi.waitFor(() =>
+        expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(4),
+      );
+      expect(getPreparedModelRuntimeSnapshot(input)).toBeUndefined();
+      let resolvedRuntime: unknown;
+      read = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }).then((runtime) => {
         resolvedRuntime = runtime;
         return runtime;
-      },
-    );
-    await Promise.resolve();
-    expect(resolvedRuntime).toBeUndefined();
+      });
+      await Promise.resolve();
+      expect(resolvedRuntime).toBeUndefined();
 
-    replacementCatalog.resolve({ entries: [] });
-    await expect(refresh).resolves.toBeUndefined();
-    const replacementRuntime = await read;
-    expect(replacementRuntime).toMatchObject({
-      agentId: "default",
-      agentDir: "/tmp/unused-agent",
-      workspaceDir: "/tmp/unused-workspace",
-      config: replacementConfig,
-      inboundPluginRegistry: replacementRegistry,
-    });
-    expect(replacementRuntime).not.toBe(firstRuntime);
-    expect(replacementRuntime?.modelCatalog).not.toBe(firstRuntime?.modelCatalog);
+      replacementCatalog.resolve({ entries: [] });
+      await expect(refresh).resolves.toBeUndefined();
+      const replacementRuntime = await read;
+      expect(replacementRuntime).toMatchObject({
+        agentId: "default",
+        agentDir: state.agentDir("default"),
+        workspaceDir: "/tmp/unused-workspace",
+        config: replacementConfig,
+        inboundPluginRegistry: replacementRegistry,
+      });
+      expect(replacementRuntime).not.toBe(firstRuntime);
+      expect(replacementRuntime?.modelCatalog).not.toBe(firstRuntime?.modelCatalog);
+    } finally {
+      replacementCatalog.resolve({ entries: [] });
+      await Promise.allSettled([refresh, read]);
+    }
   });
 
   it("resolves the configured inbound registry across a launch-workspace override", async () => {
@@ -305,8 +317,8 @@ describe("prepared reply dispatch runtime", () => {
     });
     const published = getPreparedModelRuntimeSnapshot({
       agentId: "default",
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
       config,
       workspaceDir: "/tmp/gateway-launch-workspace",
       allowGatewaySubagentBinding: true,
@@ -362,8 +374,8 @@ describe("prepared reply dispatch runtime", () => {
     }
     const configuredInput = {
       agentId: "default",
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
       config,
       workspaceDir: "/tmp/unused-workspace",
     };
@@ -436,7 +448,7 @@ describe("prepared reply dispatch runtime", () => {
     });
 
     mocks.mutationListener?.({
-      agentDir: "/tmp/configured-worker",
+      agentDir: state.agentDir("worker"),
       affectsInheritedStores: false,
     });
 
@@ -451,7 +463,7 @@ describe("prepared reply dispatch runtime", () => {
     const refreshedWorker = await loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
     expect(refreshedWorker).toMatchObject({
       agentId: "worker",
-      agentDir: "/tmp/configured-worker",
+      agentDir: state.agentDir("worker"),
       workspaceDir: "/tmp/workspace-worker",
     });
     expect(refreshedWorker).not.toBe(workerRuntime);
@@ -478,7 +490,7 @@ describe("prepared reply dispatch runtime", () => {
     });
 
     mocks.mutationListener?.({
-      agentDir: "/tmp/configured-worker",
+      agentDir: state.agentDir("worker"),
       affectsInheritedStores: false,
     });
     await refreshFailed.promise;
@@ -497,40 +509,53 @@ describe("prepared reply dispatch runtime", () => {
     const config = {};
     const input = {
       agentId: "default",
-      agentDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
       config,
       workspaceDir: "/tmp/dynamic-workspace",
     };
     await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
     const testApi = getPreparedModelRuntimeTestApi();
     expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
+    const finishAuthRefreshGate = createDeferred();
     let finishAuthRefresh: (() => void) | undefined;
-    mocks.ensureOpenClawModelsJson.mockImplementationOnce(
-      async () =>
-        await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
-          finishAuthRefresh = () => resolve({ agentDir: input.agentDir, wrote: false });
-        }),
-    );
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(async (_config, agentDir) => {
+      finishAuthRefresh = () => finishAuthRefreshGate.resolve();
+      await finishAuthRefreshGate.promise;
+      return { agentDir: String(agentDir), wrote: false };
+    });
 
-    mocks.mutationListener?.({ agentDir: input.agentDir, affectsInheritedStores: false });
-    await vi.waitFor(() => expect(finishAuthRefresh).toBeDefined());
-    const abort = new AbortController();
-    const admission = acquireAgentRunPreparedModelRuntime(input, { abortSignal: abort.signal });
-    const observed = admission.then(
-      () => "resolved",
-      () => "rejected",
-    );
-    await expect(Promise.race([observed, Promise.resolve("pending")])).resolves.toBe("pending");
-    abort.abort(new Error("request cancelled"));
-    await expect(admission).rejects.toMatchObject({ name: "AbortError" });
-    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
+    let admission: ReturnType<typeof acquireAgentRunPreparedModelRuntime> | undefined;
+    try {
+      mocks.mutationListener?.({ agentDir: input.agentDir, affectsInheritedStores: false });
+      await vi.waitFor(() => expect(finishAuthRefresh).toBeDefined());
+      const abort = new AbortController();
+      admission = acquireAgentRunPreparedModelRuntime(input, { abortSignal: abort.signal });
+      const observed = admission.then(
+        () => "resolved",
+        () => "rejected",
+      );
+      await expect(Promise.race([observed, Promise.resolve("pending")])).resolves.toBe("pending");
+      abort.abort(new Error("request cancelled"));
+      await expect(admission).rejects.toMatchObject({ name: "AbortError" });
+      expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
 
-    finishAuthRefresh?.();
-    await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
-    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
-    const lease = await acquireAgentRunPreparedModelRuntime(input);
-    expect(lease.snapshot).toMatchObject({ agentId: "default", agentDir: input.agentDir });
-    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(2);
-    lease.release();
+      finishAuthRefreshGate.resolve();
+      await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+      expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
+      const lease = await acquireAgentRunPreparedModelRuntime(input);
+      expect(lease.snapshot).toMatchObject({ agentId: "default", agentDir: input.agentDir });
+      expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(2);
+      lease.release();
+    } finally {
+      finishAuthRefreshGate.resolve();
+      await Promise.allSettled([
+        admission?.then((lease) => lease.release()),
+        loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
+      ]);
+    }
   });
+});
+
+afterEach(async ({ task }) => {
+  await cleanupPreparedModelRuntimeHarness(state, task.result?.state === "fail");
 });

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -1,12 +1,18 @@
 // Preserve module setup before modules that consume it.
 // oxfmt-ignore
 import {
+  cleanupPreparedModelRuntimeHarness,
   getPreparedModelRuntimeMocks,
   getPreparedModelRuntimeTestApi,
   resetPreparedModelRuntimeHarness,
 } from "./prepared-model-runtime.test-harness.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
 import {
   acquireAgentRunPreparedModelRuntime,
   acquireReadOnlyPreparedModelRuntime,
@@ -22,10 +28,12 @@ import {
 } from "./prepared-model-runtime.js";
 
 const mocks = getPreparedModelRuntimeMocks();
+let state: OpenClawTestState;
 
 describe("prepared model runtime snapshots", () => {
-  beforeEach(() => {
-    resetPreparedModelRuntimeHarness();
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ label: "prepared-model-runtime" });
+    resetPreparedModelRuntimeHarness(state);
   });
 
   it("does not discover missing owners from a gateway request", async () => {
@@ -63,8 +71,8 @@ describe("prepared model runtime snapshots", () => {
       if (event.phase === "published") {
         publishedOwner = getPreparedModelRuntimeSnapshot({
           agentId: "default",
-          agentDir: "/tmp/unused-agent",
-          inheritedAuthDir: "/tmp/unused-agent",
+          agentDir: state.agentDir("default"),
+          inheritedAuthDir: state.agentDir("default"),
           config: replacementConfig,
         });
       }
@@ -147,8 +155,8 @@ describe("prepared model runtime snapshots", () => {
     const activated = await activateStandalonePreparedModelRuntime({
       config: { agents: { defaults: { model: "openai/gpt-5.4" } } },
       agentId: "default",
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
       workspaceDir: "/tmp/gateway-launch-workspace",
       readOnly: true,
     });
@@ -158,8 +166,8 @@ describe("prepared model runtime snapshots", () => {
       prepareModelRuntimeSnapshot({
         config: configured,
         agentId: "default",
-        agentDir: "/tmp/unused-agent",
-        inheritedAuthDir: "/tmp/unused-agent",
+        agentDir: state.agentDir("default"),
+        inheritedAuthDir: state.agentDir("default"),
         workspaceDir: "/tmp/gateway-launch-workspace",
       }),
     ).resolves.toMatchObject({ config: configured });
@@ -170,7 +178,7 @@ describe("prepared model runtime snapshots", () => {
     const input = {
       config: {},
       agentId: "default",
-      agentDir: "/tmp/standalone-run-agent",
+      agentDir: state.agentDir("standalone-run-agent"),
       workspaceDir: "/tmp/one-off-run-workspace",
     };
     const lease = await acquireAgentRunPreparedModelRuntime(input);
@@ -187,7 +195,7 @@ describe("prepared model runtime snapshots", () => {
       {
         config: {},
         agentId: "default",
-        agentDir: "/tmp/static-run-agent",
+        agentDir: state.agentDir("static-run-agent"),
         workspaceDir: "/tmp/static-run-workspace",
       },
       { catalogMode: "static" },
@@ -202,7 +210,7 @@ describe("prepared model runtime snapshots", () => {
     const firstInput = {
       config: {},
       agentId: "default",
-      agentDir: "/tmp/standalone-retained-run-agent",
+      agentDir: state.agentDir("standalone-retained-run-agent"),
       workspaceDir: "/tmp/standalone-retained-run-workspace",
     };
     const firstLease = await acquireAgentRunPreparedModelRuntime(firstInput, {
@@ -245,8 +253,8 @@ describe("prepared model runtime snapshots", () => {
       acquireAgentRunPreparedModelRuntime({
         agentId: "default",
         config,
-        agentDir: "/tmp/unused-agent",
-        inheritedAuthDir: "/tmp/unused-agent",
+        agentDir: state.agentDir("default"),
+        inheritedAuthDir: state.agentDir("default"),
         workspaceDir,
       });
     const [firstLease, secondLease] = await Promise.all([
@@ -261,8 +269,8 @@ describe("prepared model runtime snapshots", () => {
     const retainedLease = await acquireAgentRunPreparedModelRuntime({
       agentId: "default",
       config,
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
       workspaceDir,
     });
     expect(retainedLease.snapshot).toBe(firstLease.snapshot);
@@ -274,33 +282,42 @@ describe("prepared model runtime snapshots", () => {
     mocks.configuredAgentIds = ["default"];
     const config = {};
     await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+    const finishDynamicGate = createDeferred();
     let finishDynamic!: () => void;
-    mocks.ensureOpenClawModelsJson.mockImplementationOnce(
-      async () =>
-        await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
-          finishDynamic = () => resolve({ agentDir: "/tmp/unused-agent", wrote: false });
-        }),
-    );
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(async (_config, targetDir) => {
+      finishDynamic = () => finishDynamicGate.resolve();
+      await finishDynamicGate.promise;
+      return { agentDir: String(targetDir), wrote: false };
+    });
     const input = {
       agentId: "default",
       config,
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
       workspaceDir: "/tmp/concurrent-dynamic-workspace",
     };
 
-    const firstPending = acquireAgentRunPreparedModelRuntime(input);
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
-    const secondPending = acquireAgentRunPreparedModelRuntime(input);
-    await Promise.resolve();
-    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
-    finishDynamic();
-    const [first, second] = await Promise.all([firstPending, secondPending]);
+    let firstPending: ReturnType<typeof acquireAgentRunPreparedModelRuntime> | undefined;
+    let secondPending: ReturnType<typeof acquireAgentRunPreparedModelRuntime> | undefined;
+    try {
+      firstPending = acquireAgentRunPreparedModelRuntime(input);
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+      secondPending = acquireAgentRunPreparedModelRuntime(input);
+      await Promise.resolve();
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
+      finishDynamic();
+      const [first, second] = await Promise.all([firstPending, secondPending]);
 
-    expect(second.snapshot).toBe(first.snapshot);
-    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
-    first.release();
-    second.release();
+      expect(second.snapshot).toBe(first.snapshot);
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
+      first.release();
+      second.release();
+    } finally {
+      finishDynamicGate.resolve();
+      await Promise.allSettled(
+        [firstPending, secondPending].map(async (pending) => (await pending)?.release()),
+      );
+    }
   });
 
   it("does not let a stale dynamic lease authorize a replacement generation", async () => {
@@ -310,8 +327,8 @@ describe("prepared model runtime snapshots", () => {
     const input = {
       agentId: "default",
       config,
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
       workspaceDir: "/tmp/stale-dynamic-workspace",
     };
     const firstLease = await acquireAgentRunPreparedModelRuntime(input);
@@ -330,12 +347,12 @@ describe("prepared model runtime snapshots", () => {
     const input = {
       agentId: "openclaw",
       config,
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
       workspaceDir: "/tmp/configless-workspace",
     };
     const lease = await acquireAgentRunPreparedModelRuntime(input);
-    expect(lease.snapshot.agentDir).toBe("/tmp/unused-agent");
+    expect(lease.snapshot.agentDir).toBe(state.agentDir("default"));
     lease.release();
   });
 
@@ -346,12 +363,12 @@ describe("prepared model runtime snapshots", () => {
     const input = {
       agentId: "openclaw",
       config,
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
       workspaceDir: "/tmp/configless-mixed-workspace",
     };
     const lease = await acquireAgentRunPreparedModelRuntime(input);
-    expect(lease.snapshot.agentDir).toBe("/tmp/unused-agent");
+    expect(lease.snapshot.agentDir).toBe(state.agentDir("default"));
     lease.release();
   });
 
@@ -365,7 +382,7 @@ describe("prepared model runtime snapshots", () => {
         agentId: "missing",
         config,
         agentDir: "/tmp/configured-missing",
-        inheritedAuthDir: "/tmp/unused-agent",
+        inheritedAuthDir: state.agentDir("default"),
         workspaceDir: "/tmp/workspace-missing",
       }),
     ).rejects.toThrow("prepared model runtime owner was not committed");
@@ -379,8 +396,8 @@ describe("prepared model runtime snapshots", () => {
     const dynamicInput = {
       agentId: "default",
       config: initialConfig,
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
       workspaceDir: "/tmp/rebased-dynamic-workspace",
     };
     const firstLease = await acquireAgentRunPreparedModelRuntime(dynamicInput);
@@ -409,14 +426,14 @@ describe("prepared model runtime snapshots", () => {
     const lease = await acquireAgentRunPreparedModelRuntime({
       agentId: "openclaw",
       config,
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
       workspaceDir: "/tmp/setup-probe-workspace",
     });
 
     expect(lease.snapshot).toMatchObject({
       agentId: "openclaw",
-      agentDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
       workspaceDir: "/tmp/setup-probe-workspace",
       config,
     });
@@ -431,14 +448,14 @@ describe("prepared model runtime snapshots", () => {
     const lease = await acquireAgentRunPreparedModelRuntime({
       agentId: "secondary",
       config,
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
       workspaceDir: "/tmp/secondary-probe-workspace",
     });
 
     expect(lease.snapshot).toMatchObject({
       agentId: "secondary",
-      agentDir: "/tmp/configured-secondary",
+      agentDir: state.agentDir("secondary"),
       workspaceDir: "/tmp/secondary-probe-workspace",
       config,
     });
@@ -451,8 +468,8 @@ describe("prepared model runtime snapshots", () => {
     const input = {
       agentId: "default",
       config,
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
       workspaceDir: "/tmp/unused-workspace",
     };
     const dynamicLease = await acquireAgentRunPreparedModelRuntime(input);
@@ -470,37 +487,44 @@ describe("prepared model runtime snapshots", () => {
     const initialConfig = {};
     const latestConfig = { agents: { defaults: { model: "openai/gpt-5.5" } } };
     await refreshPreparedModelRuntimeSnapshots(initialConfig, { gatewayLifecycle: true });
+    const finishReplacementGate = createDeferred();
     let finishReplacement!: () => void;
-    mocks.ensureOpenClawModelsJson.mockImplementationOnce(
-      async () =>
-        await new Promise<{ agentDir: string; wrote: boolean }>((resolve) => {
-          finishReplacement = () => resolve({ agentDir: "/tmp/unused-agent", wrote: false });
-        }),
-    );
-
-    markPreparedModelRuntimeSnapshotsStale("test lease replacement", {
-      waitForReplacement: true,
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(async (_config, targetDir) => {
+      finishReplacement = () => finishReplacementGate.resolve();
+      await finishReplacementGate.promise;
+      return { agentDir: String(targetDir), wrote: false };
     });
-    const leasePending = acquireAgentRunPreparedModelRuntime({
-      agentId: "default",
-      config: initialConfig,
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
-      workspaceDir: "/tmp/dynamic-replacement-workspace",
-    });
-    await Promise.resolve();
-    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(1);
 
-    const refresh = refreshPreparedModelRuntimeSnapshots(latestConfig);
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
-    finishReplacement();
-    await refresh;
-    const lease = await leasePending;
+    let leasePending: ReturnType<typeof acquireAgentRunPreparedModelRuntime> | undefined;
+    let refresh: ReturnType<typeof refreshPreparedModelRuntimeSnapshots> | undefined;
+    try {
+      markPreparedModelRuntimeSnapshotsStale("test lease replacement", {
+        waitForReplacement: true,
+      });
+      leasePending = acquireAgentRunPreparedModelRuntime({
+        agentId: "default",
+        config: initialConfig,
+        agentDir: state.agentDir("default"),
+        inheritedAuthDir: state.agentDir("default"),
+        workspaceDir: "/tmp/dynamic-replacement-workspace",
+      });
+      await Promise.resolve();
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(1);
 
-    expect(lease.snapshot.config).toBe(latestConfig);
-    expect(lease.snapshot.workspaceDir).toBe("/tmp/dynamic-replacement-workspace");
-    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3);
-    lease.release();
+      refresh = refreshPreparedModelRuntimeSnapshots(latestConfig);
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+      finishReplacement();
+      await refresh;
+      const lease = await leasePending;
+
+      expect(lease.snapshot.config).toBe(latestConfig);
+      expect(lease.snapshot.workspaceDir).toBe("/tmp/dynamic-replacement-workspace");
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3);
+      lease.release();
+    } finally {
+      finishReplacementGate.resolve();
+      await Promise.allSettled([refresh, leasePending?.then((lease) => lease.release())]);
+    }
   });
 
   it("rebases a stale dynamic run after the replacement gate has closed", async () => {
@@ -519,7 +543,7 @@ describe("prepared model runtime snapshots", () => {
     });
 
     expect(lease.snapshot.config).toBe(latestConfig);
-    expect(lease.snapshot.agentDir).toBe("/tmp/unused-agent");
+    expect(lease.snapshot.agentDir).toBe(state.agentDir("default"));
     expect(lease.snapshot.workspaceDir).toBe("/tmp/dynamic-post-reload-workspace");
     lease.release();
   });
@@ -546,7 +570,7 @@ describe("prepared model runtime snapshots", () => {
     const lease = await leasePending;
 
     expect(lease.snapshot.config).toBe(latestConfig);
-    expect(lease.snapshot.agentDir).toBe("/tmp/unused-agent");
+    expect(lease.snapshot.agentDir).toBe(state.agentDir("default"));
     expect(lease.snapshot.workspaceDir).toBe("/tmp/unused-workspace");
     expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
     lease.release();
@@ -563,8 +587,8 @@ describe("prepared model runtime snapshots", () => {
     const lease = await acquireAgentRunPreparedModelRuntime({
       agentId: "default",
       config,
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
     });
 
     expect(lease.snapshot.workspaceDir).toBe("/tmp/gateway-launch-workspace");
@@ -573,8 +597,8 @@ describe("prepared model runtime snapshots", () => {
       prepareModelRuntimeSnapshot({
         agentId: "default",
         config,
-        agentDir: "/tmp/unused-agent",
-        inheritedAuthDir: "/tmp/unused-agent",
+        agentDir: state.agentDir("default"),
+        inheritedAuthDir: state.agentDir("default"),
       }),
     ).resolves.toBe(lease.snapshot);
     expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
@@ -585,7 +609,7 @@ describe("prepared model runtime snapshots", () => {
     const input = {
       agentId: "default",
       config: {},
-      agentDir: "/tmp/prepared-model-runtime-metadata-agent",
+      agentDir: state.agentDir("metadata-agent"),
       workspaceDir: "/tmp/prepared-model-runtime-metadata-workspace",
     };
 
@@ -598,39 +622,9 @@ describe("prepared model runtime snapshots", () => {
     );
   });
 
-  it("fails a timed-out publication without overlapping its late build with a retry", async () => {
-    getPreparedModelRuntimeTestApi().setModelRuntimeBuildTimeoutMsForTest(1);
-    let finishTimedOutBuild: (() => void) | undefined;
-    mocks.ensureOpenClawModelsJson.mockImplementationOnce(
-      async () =>
-        await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
-          finishTimedOutBuild = () => resolve({ agentDir: "/tmp/agent", wrote: false });
-        }),
-    );
-    const input = { config: {}, agentDir: "/tmp/prepared-model-runtime-timeout" };
-
-    await expect(publishPreparedModelRuntimeSnapshot(input)).rejects.toThrow(
-      "prepared model runtime publication timed out",
-    );
-    await expect(prepareModelRuntimeSnapshot(input)).rejects.toThrow(
-      "prepared model runtime publication timed out",
-    );
-    await expect(publishPreparedModelRuntimeSnapshot(input)).rejects.toThrow(
-      "prepared model runtime publication timed out",
-    );
-    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
-
-    finishTimedOutBuild?.();
-    await vi.waitFor(() => expect(mocks.discoverModels).toHaveBeenCalledOnce());
-    await expect(publishPreparedModelRuntimeSnapshot(input)).resolves.toMatchObject({
-      agentDir: input.agentDir,
-    });
-    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
-  });
-
   it("rebuilds stale owners with the newly published config", async () => {
     mocks.configuredAgentIds = ["default"];
-    const agentDir = "/tmp/unused-agent";
+    const agentDir = state.agentDir("default");
     const firstConfig = {};
     const secondConfig = { agents: { defaults: { model: "openai/gpt-5.5" } } };
     const input = {
@@ -652,7 +646,7 @@ describe("prepared model runtime snapshots", () => {
 
   it("does not serve the old snapshot after lifecycle refresh fails", async () => {
     mocks.configuredAgentIds = ["default"];
-    const agentDir = "/tmp/unused-agent";
+    const agentDir = state.agentDir("default");
     const firstConfig = {};
     const secondConfig = { agents: { defaults: { model: "openai/gpt-5.5" } } };
     const input = {
@@ -681,14 +675,14 @@ describe("prepared model runtime snapshots", () => {
 
     await expect(refreshPreparedModelRuntimeSnapshots({})).rejects.toBe(refreshError);
     mocks.mutationListener?.({
-      agentDir: "/tmp/configured-removed",
+      agentDir: state.agentDir("removed"),
       affectsInheritedStores: false,
     });
     await expect(
       prepareModelRuntimeSnapshot({
         config: firstConfig,
-        agentDir: "/tmp/configured-removed",
-        inheritedAuthDir: "/tmp/unused-agent",
+        agentDir: state.agentDir("removed"),
+        inheritedAuthDir: state.agentDir("default"),
         workspaceDir: "/tmp/workspace-removed",
       }),
     ).rejects.toThrow("owner was not published");
@@ -701,23 +695,23 @@ describe("prepared model runtime snapshots", () => {
     await refreshPreparedModelRuntimeSnapshots(firstConfig);
     const refreshError = new Error("secondary refresh failed");
     mocks.ensureOpenClawModelsJson
-      .mockResolvedValueOnce({ agentDir: "/tmp/unused-agent", wrote: false })
+      .mockResolvedValueOnce({ agentDir: state.agentDir("default"), wrote: false })
       .mockRejectedValueOnce(refreshError);
 
     await expect(refreshPreparedModelRuntimeSnapshots({})).rejects.toBe(refreshError);
     await expect(
       prepareModelRuntimeSnapshot({
         config: {},
-        agentDir: "/tmp/unused-agent",
-        inheritedAuthDir: "/tmp/unused-agent",
+        agentDir: state.agentDir("default"),
+        inheritedAuthDir: state.agentDir("default"),
         workspaceDir: "/tmp/unused-workspace",
       }),
     ).rejects.toBe(refreshError);
     await expect(
       prepareModelRuntimeSnapshot({
         config: {},
-        agentDir: "/tmp/configured-secondary",
-        inheritedAuthDir: "/tmp/unused-agent",
+        agentDir: state.agentDir("secondary"),
+        inheritedAuthDir: state.agentDir("default"),
         workspaceDir: "/tmp/workspace-secondary",
       }),
     ).rejects.toBe(refreshError);
@@ -727,36 +721,42 @@ describe("prepared model runtime snapshots", () => {
     mocks.configuredAgentIds = ["default", "secondary"];
     await refreshPreparedModelRuntimeSnapshots({});
     const refreshError = new Error("queued auth refresh failed");
+    const finishConfigRefreshGate = createDeferred();
     let finishConfigRefresh!: () => void;
     mocks.ensureOpenClawModelsJson
-      .mockImplementationOnce(
-        async () =>
-          await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
-            finishConfigRefresh = () => resolve({ agentDir: "/tmp/unused-agent", wrote: false });
-          }),
-      )
-      .mockResolvedValueOnce({ agentDir: "/tmp/configured-secondary", wrote: false })
-      .mockResolvedValueOnce({ agentDir: "/tmp/unused-agent", wrote: false })
+      .mockImplementationOnce(async (_config, targetDir) => {
+        finishConfigRefresh = () => finishConfigRefreshGate.resolve();
+        await finishConfigRefreshGate.promise;
+        return { agentDir: String(targetDir), wrote: false };
+      })
+      .mockResolvedValueOnce({ agentDir: state.agentDir("secondary"), wrote: false })
+      .mockResolvedValueOnce({ agentDir: state.agentDir("default"), wrote: false })
       .mockRejectedValueOnce(refreshError);
 
-    const refresh = refreshPreparedModelRuntimeSnapshots({});
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(4));
-    mocks.mutationListener?.({ affectsInheritedStores: true });
-    finishConfigRefresh();
+    let refresh: ReturnType<typeof refreshPreparedModelRuntimeSnapshots> | undefined;
+    try {
+      refresh = refreshPreparedModelRuntimeSnapshots({});
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(4));
+      mocks.mutationListener?.({ affectsInheritedStores: true });
+      finishConfigRefresh();
 
-    await expect(refresh).rejects.toBe(refreshError);
-    for (const [agentDir, workspaceDir] of [
-      ["/tmp/unused-agent", "/tmp/unused-workspace"],
-      ["/tmp/configured-secondary", "/tmp/workspace-secondary"],
-    ] as const) {
-      await expect(
-        prepareModelRuntimeSnapshot({
-          config: {},
-          agentDir,
-          inheritedAuthDir: "/tmp/unused-agent",
-          workspaceDir,
-        }),
-      ).rejects.toBe(refreshError);
+      await expect(refresh).rejects.toBe(refreshError);
+      for (const [agentDir, workspaceDir] of [
+        [state.agentDir("default"), "/tmp/unused-workspace"],
+        [state.agentDir("secondary"), "/tmp/workspace-secondary"],
+      ] as const) {
+        await expect(
+          prepareModelRuntimeSnapshot({
+            config: {},
+            agentDir,
+            inheritedAuthDir: state.agentDir("default"),
+            workspaceDir,
+          }),
+        ).rejects.toBe(refreshError);
+      }
+    } finally {
+      finishConfigRefreshGate.resolve();
+      await Promise.allSettled([refresh]);
     }
   });
 
@@ -768,8 +768,8 @@ describe("prepared model runtime snapshots", () => {
       return { entries: [] };
     });
     mocks.ensureOpenClawModelsJson
-      .mockResolvedValueOnce({ agentDir: "/tmp/unused-agent", wrote: false })
-      .mockImplementationOnce(async () => await new Promise<never>(() => {}));
+      .mockResolvedValueOnce({ agentDir: state.agentDir("default"), wrote: false })
+      .mockRejectedValueOnce(new Error("unexpected auth replay"));
 
     await expect(
       refreshPreparedModelRuntimeSnapshots({}, { gatewayLifecycle: true, catalogMode: "static" }),
@@ -787,29 +787,39 @@ describe("prepared model runtime snapshots", () => {
     const unregister = registerPreparedModelRuntimePublicationListener((event) => {
       events.push(event.phase);
     });
+    const finishAuthRefreshGate = createDeferred();
     let finishAuthRefresh: (() => void) | undefined;
-    mocks.ensureOpenClawModelsJson.mockImplementationOnce(
-      async () =>
-        await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
-          finishAuthRefresh = () => resolve({ agentDir: "/tmp/unused-agent", wrote: false });
-        }),
-    );
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(async (_config, targetDir) => {
+      finishAuthRefresh = () => finishAuthRefreshGate.resolve();
+      await finishAuthRefreshGate.promise;
+      return { agentDir: String(targetDir), wrote: false };
+    });
 
-    mocks.mutationListener?.({ affectsInheritedStores: true });
-    await vi.waitFor(() => expect(finishAuthRefresh).toBeDefined());
-    const reload = refreshPreparedModelRuntimeSnapshots(
-      { agents: { defaults: { model: "openai/gpt-5.5" } } },
-      { gatewayLifecycle: true },
-    );
-    finishAuthRefresh?.();
-    await reload;
-    unregister();
+    let reload: ReturnType<typeof refreshPreparedModelRuntimeSnapshots> | undefined;
+    try {
+      mocks.mutationListener?.({ affectsInheritedStores: true });
+      await vi.waitFor(() => expect(finishAuthRefresh).toBeDefined());
+      reload = refreshPreparedModelRuntimeSnapshots(
+        { agents: { defaults: { model: "openai/gpt-5.5" } } },
+        { gatewayLifecycle: true },
+      );
+      finishAuthRefreshGate.resolve();
+      await reload;
+      unregister();
 
-    expect(events).not.toContain("failed");
-    expect(mocks.warn).not.toHaveBeenCalled();
-    await expect(
-      loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
-    ).resolves.toMatchObject({ agentId: "default" });
+      expect(events).not.toContain("failed");
+      expect(mocks.warn).not.toHaveBeenCalled();
+      await expect(
+        loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
+      ).resolves.toMatchObject({ agentId: "default" });
+    } finally {
+      finishAuthRefreshGate.resolve();
+      await Promise.allSettled([
+        reload,
+        loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
+      ]);
+      unregister();
+    }
   });
 
   it("does not announce an auth republication while a config replacement gate is pending", async () => {
@@ -822,8 +832,8 @@ describe("prepared model runtime snapshots", () => {
         publishedSnapshots.push(
           getPreparedModelRuntimeSnapshot({
             agentId: "default",
-            agentDir: "/tmp/unused-agent",
-            inheritedAuthDir: "/tmp/unused-agent",
+            agentDir: state.agentDir("default"),
+            inheritedAuthDir: state.agentDir("default"),
             config: replacementConfig,
           }),
         );
@@ -842,7 +852,7 @@ describe("prepared model runtime snapshots", () => {
 
   it("waits for the affected owner at auth publication", async () => {
     const config = {};
-    const agentDir = "/tmp/prepared-model-runtime-auth";
+    const agentDir = state.agentDir("auth");
     const first = await publishPreparedModelRuntimeSnapshot({ config, agentDir });
 
     mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
@@ -856,119 +866,136 @@ describe("prepared model runtime snapshots", () => {
 
   it("treats an auth refresh superseded by a newer mutation as control flow", async () => {
     const config = {};
-    const agentDir = "/tmp/prepared-model-runtime-auth-superseded";
+    const agentDir = state.agentDir("auth-superseded");
     await publishPreparedModelRuntimeSnapshot({ config, agentDir });
-    let finishFirstRefresh: (() => void) | undefined;
-    mocks.ensureOpenClawModelsJson.mockImplementationOnce(
-      async () =>
-        await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
-          finishFirstRefresh = () => resolve({ agentDir, wrote: false });
-        }),
-    );
-
-    mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
-    mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
-    finishFirstRefresh?.();
-
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
-    await expect(prepareModelRuntimeSnapshot({ config, agentDir })).resolves.toMatchObject({
-      agentDir,
+    const finishFirstRefreshGate = createDeferred();
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(async (_config, targetDir) => {
+      await finishFirstRefreshGate.promise;
+      return { agentDir: String(targetDir), wrote: false };
     });
-    expect(mocks.warn).not.toHaveBeenCalled();
+
+    try {
+      mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+      mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
+      finishFirstRefreshGate.resolve();
+
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
+      await expect(prepareModelRuntimeSnapshot({ config, agentDir })).resolves.toMatchObject({
+        agentDir,
+      });
+      expect(mocks.warn).not.toHaveBeenCalled();
+    } finally {
+      finishFirstRefreshGate.resolve();
+      await Promise.allSettled([prepareModelRuntimeSnapshot({ config, agentDir })]);
+    }
   });
 
   it("keeps one dispatch gate across overlapping auth mutations", async () => {
     mocks.configuredAgentIds = ["default"];
     const config = {};
-    const agentDir = "/tmp/unused-agent";
+    const agentDir = state.agentDir("default");
     await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
     const events: string[] = [];
     const unregister = registerPreparedModelRuntimePublicationListener((event) => {
       events.push(event.phase);
     });
-    let finishFirstRefresh: (() => void) | undefined;
-    let finishSecondRefresh: (() => void) | undefined;
+    const finishFirstRefreshGate = createDeferred();
+    const finishSecondRefreshGate = createDeferred();
     mocks.ensureOpenClawModelsJson
-      .mockImplementationOnce(
-        async () =>
-          await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
-            finishFirstRefresh = () => resolve({ agentDir, wrote: false });
-          }),
-      )
-      .mockImplementationOnce(
-        async () =>
-          await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
-            finishSecondRefresh = () => resolve({ agentDir, wrote: false });
-          }),
-      );
+      .mockImplementationOnce(async (_config, targetDir) => {
+        await finishFirstRefreshGate.promise;
+        return { agentDir: String(targetDir), wrote: false };
+      })
+      .mockImplementationOnce(async (_config, targetDir) => {
+        await finishSecondRefreshGate.promise;
+        return { agentDir: String(targetDir), wrote: false };
+      });
 
-    mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
-    const dispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
-    void dispatch.catch(() => undefined);
-    mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
-    finishFirstRefresh?.();
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
-    await expect(
-      Promise.race([dispatch.then(() => "settled"), Promise.resolve("pending")]),
-    ).resolves.toBe("pending");
+    let dispatch: ReturnType<typeof loadPublishedGatewayReplyDispatchRuntime> | undefined;
+    try {
+      mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+      dispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+      void dispatch.catch(() => undefined);
+      mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
+      finishFirstRefreshGate.resolve();
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
+      await expect(
+        Promise.race([dispatch.then(() => "settled"), Promise.resolve("pending")]),
+      ).resolves.toBe("pending");
 
-    finishSecondRefresh?.();
-    const runtime = await dispatch;
-    unregister();
+      finishSecondRefreshGate.resolve();
+      const runtime = await dispatch;
+      unregister();
 
-    expect(runtime).toBe(await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }));
-    expect(events.filter((phase) => phase === "published")).toHaveLength(1);
-    expect(events).not.toContain("failed");
-    expect(mocks.warn).not.toHaveBeenCalled();
+      expect(runtime).toBe(await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }));
+      expect(events.filter((phase) => phase === "published")).toHaveLength(1);
+      expect(events).not.toContain("failed");
+      expect(mocks.warn).not.toHaveBeenCalled();
+    } finally {
+      finishFirstRefreshGate.resolve();
+      finishSecondRefreshGate.resolve();
+      await Promise.allSettled([
+        dispatch,
+        loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
+      ]);
+      unregister();
+    }
   });
 
   it("does not let a superseded owner hide a genuine sibling refresh failure", async () => {
     const config = {};
-    const supersededDir = "/tmp/prepared-model-runtime-auth-superseded-sibling";
-    const failingDir = "/tmp/prepared-model-runtime-auth-failing-sibling";
+    const supersededDir = state.agentDir("auth-superseded-sibling");
+    const failingDir = state.agentDir("auth-failing-sibling");
     await publishPreparedModelRuntimeSnapshot({ config, agentDir: supersededDir });
     await publishPreparedModelRuntimeSnapshot({ config, agentDir: failingDir });
-    let finishSupersededRefresh: (() => void) | undefined;
+    const finishSupersededRefreshGate = createDeferred();
+    const siblingGate = createDeferred<{ agentDir: string; wrote: false }>();
     let failSiblingRefresh: (() => void) | undefined;
     mocks.ensureOpenClawModelsJson
-      .mockImplementationOnce(
-        async () =>
-          await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
-            finishSupersededRefresh = () => resolve({ agentDir: supersededDir, wrote: false });
-          }),
-      )
-      .mockImplementationOnce(
-        async () =>
-          await new Promise<{ agentDir: string; wrote: false }>((_resolve, reject) => {
-            failSiblingRefresh = () => reject(new Error("genuine sibling refresh failure"));
-          }),
+      .mockImplementationOnce(async (_config, targetDir) => {
+        await finishSupersededRefreshGate.promise;
+        return { agentDir: String(targetDir), wrote: false };
+      })
+      .mockImplementationOnce(async () => {
+        failSiblingRefresh = () => siblingGate.reject(new Error("genuine sibling refresh failure"));
+        return await siblingGate.promise;
+      });
+
+    try {
+      mocks.mutationListener?.({ affectsInheritedStores: true });
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(4));
+      mocks.mutationListener?.({ agentDir: supersededDir, affectsInheritedStores: false });
+      finishSupersededRefreshGate.resolve();
+      failSiblingRefresh?.();
+
+      await vi.waitFor(() =>
+        expect(mocks.warn).toHaveBeenCalledWith(
+          expect.stringContaining("genuine sibling refresh failure"),
+        ),
       );
-
-    mocks.mutationListener?.({ affectsInheritedStores: true });
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(4));
-    mocks.mutationListener?.({ agentDir: supersededDir, affectsInheritedStores: false });
-    finishSupersededRefresh?.();
-    failSiblingRefresh?.();
-
-    await vi.waitFor(() =>
-      expect(mocks.warn).toHaveBeenCalledWith(
-        expect.stringContaining("genuine sibling refresh failure"),
-      ),
-    );
-    expect(mocks.warn).toHaveBeenCalledOnce();
+      expect(mocks.warn).toHaveBeenCalledOnce();
+    } finally {
+      finishSupersededRefreshGate.resolve();
+      siblingGate.resolve({ agentDir: failingDir, wrote: false });
+      await Promise.allSettled([
+        prepareModelRuntimeSnapshot({ config, agentDir: supersededDir }),
+        prepareModelRuntimeSnapshot({ config, agentDir: failingDir }),
+      ]);
+    }
   });
 
   it("refreshes owners that inherit the mutated auth directory", async () => {
     const config = {};
-    const agentDir = "/tmp/prepared-model-runtime-custom-agent";
-    const inheritedAuthDir = "/tmp/prepared-model-runtime-main-agent";
+    const agentDir = state.agentDir("custom-agent");
+    const inheritedAuthDir = state.agentDir("main-agent");
     await publishPreparedModelRuntimeSnapshot({ config, agentDir, inheritedAuthDir });
 
     mocks.mutationListener?.({ agentDir: inheritedAuthDir, affectsInheritedStores: false });
 
     await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+    await prepareModelRuntimeSnapshot({ config, agentDir, inheritedAuthDir });
     expect(mocks.discoverAuthStorage).toHaveBeenLastCalledWith(
       agentDir,
       expect.objectContaining({ inheritedAuthDir }),
@@ -977,29 +1004,30 @@ describe("prepared model runtime snapshots", () => {
 
   it("tracks default auth inheritance when the owner omits the directory", async () => {
     const config = {};
-    const agentDir = "/tmp/prepared-model-runtime-implicit-inheritance";
+    const agentDir = state.agentDir("implicit-inheritance");
     await publishPreparedModelRuntimeSnapshot({ config, agentDir });
 
     mocks.mutationListener?.({
-      agentDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
       affectsInheritedStores: false,
     });
 
     await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+    await prepareModelRuntimeSnapshot({ config, agentDir });
     expect(mocks.discoverAuthStorage).toHaveBeenLastCalledWith(
       agentDir,
-      expect.objectContaining({ inheritedAuthDir: "/tmp/unused-agent" }),
+      expect.objectContaining({ inheritedAuthDir: state.agentDir("default") }),
     );
   });
 
   it("retains every owner until an explicit lifecycle invalidation", async () => {
     const config = {};
-    const firstAgentDir = "/tmp/prepared-model-runtime-concurrent-0";
+    const firstAgentDir = state.agentDir("concurrent-0");
     await Promise.all(
       Array.from({ length: 70 }, async (_, index) =>
         publishPreparedModelRuntimeSnapshot({
           config,
-          agentDir: `/tmp/prepared-model-runtime-concurrent-${index}`,
+          agentDir: state.agentDir(`concurrent-${index}`),
         }),
       ),
     );
@@ -1010,59 +1038,10 @@ describe("prepared model runtime snapshots", () => {
     expect(mocks.discoverModels).toHaveBeenCalledTimes(70);
   });
 
-  it("serializes workspace replacements for one agent-owned catalog", async () => {
-    let finishFirst: (() => void) | undefined;
-    mocks.ensureOpenClawModelsJson.mockImplementationOnce(
-      async () =>
-        await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
-          finishFirst = () => resolve({ agentDir: "/tmp/agent", wrote: false });
-        }),
-    );
-    const config = {};
-    const agentDir = "/tmp/prepared-model-runtime-workspace-replacement";
-    const first = publishPreparedModelRuntimeSnapshot({
-      config,
-      agentDir,
-      workspaceDir: "/tmp/workspace-old",
-    });
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce());
-    const requestDuringFirstGeneration = prepareModelRuntimeSnapshot({
-      config,
-      agentDir,
-      workspaceDir: "/tmp/workspace-old",
-    });
-
-    const replacement = publishPreparedModelRuntimeSnapshot({
-      config,
-      agentDir,
-      workspaceDir: "/tmp/workspace-new",
-    });
-    await Promise.resolve();
-    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
-
-    finishFirst?.();
-    const firstSnapshot = await first;
-    const replacementSnapshot = await replacement;
-    expect(await requestDuringFirstGeneration).toBe(firstSnapshot);
-    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
-    expect(mocks.ensureOpenClawModelsJson).toHaveBeenLastCalledWith(
-      config,
-      agentDir,
-      expect.objectContaining({ workspaceDir: "/tmp/workspace-new" }),
-    );
-    expect(
-      await prepareModelRuntimeSnapshot({
-        config,
-        agentDir,
-        workspaceDir: "/tmp/workspace-new",
-      }),
-    ).toBe(replacementSnapshot);
-  });
-
   it("preserves an authoritative workspace override across config refresh", async () => {
     mocks.configuredAgentIds = ["default"];
     const config = {};
-    const agentDir = "/tmp/unused-agent";
+    const agentDir = state.agentDir("default");
     await publishPreparedModelRuntimeSnapshot(
       {
         agentId: "default",
@@ -1093,4 +1072,8 @@ describe("prepared model runtime snapshots", () => {
       expect.objectContaining({ workspaceDir: "/tmp/explicit-workspace" }),
     );
   });
+});
+
+afterEach(async ({ task }) => {
+  await cleanupPreparedModelRuntimeHarness(state, task.result?.state === "fail");
 });

--- a/src/agents/prepared-model-runtime.owner-selection.test.ts
+++ b/src/agents/prepared-model-runtime.owner-selection.test.ts
@@ -1,16 +1,20 @@
 // Preserve module setup before modules that consume it.
 // oxfmt-ignore
 import {
+  cleanupPreparedModelRuntimeHarness,
   getPreparedModelRuntimeMocks,
   getPreparedModelRuntimeTestApi,
   resetPreparedModelRuntimeHarness,
 } from "./prepared-model-runtime.test-harness.js";
-import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
 import { withPreparedModelRuntimePluginGenerationScope } from "./prepared-model-runtime-generation-scope.js";
 import {
   acquireAgentRunPreparedModelRuntime,
@@ -24,63 +28,59 @@ import {
 } from "./prepared-model-runtime.js";
 
 const mocks = getPreparedModelRuntimeMocks();
+let state: OpenClawTestState;
 
 describe("prepared model runtime owner selection", () => {
-  beforeEach(() => {
-    resetPreparedModelRuntimeHarness();
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ label: "prepared-model-runtime" });
+    resetPreparedModelRuntimeHarness(state);
   });
 
   it("serializes live catalog sources for owners sharing one agent directory", async () => {
-    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-shared-catalog-source-"));
-    try {
-      const agentDir = path.join(rootDir, "agent");
-      fs.mkdirSync(agentDir);
-      mocks.configuredAgentIds = ["agent-a", "agent-b"];
-      mocks.configuredAgentDirs.set("agent-a", agentDir);
-      mocks.configuredAgentDirs.set("agent-b", agentDir);
-      mocks.configuredWorkspaces.set("agent-a", "/tmp/source-workspace-a");
-      mocks.configuredWorkspaces.set("agent-b", "/tmp/source-workspace-b");
-      let activeWrites = 0;
-      let peakActiveWrites = 0;
-      mocks.ensureOpenClawModelsJson.mockImplementation(async (_config, targetDir, options) => {
-        activeWrites += 1;
-        peakActiveWrites = Math.max(peakActiveWrites, activeWrites);
-        await new Promise<void>((resolve) => {
-          setImmediate(resolve);
-        });
-        const workspaceDir = (options as { workspaceDir?: string }).workspaceDir ?? "unknown";
-        fs.writeFileSync(
-          path.join(String(targetDir), "models.json"),
-          JSON.stringify({
-            providers: {
-              custom: {
-                api: "openai-completions",
-                baseUrl: "https://models.example/v1",
-                models: [{ id: path.basename(workspaceDir) }],
-              },
-            },
-          }),
-        );
-        activeWrites -= 1;
-        return { agentDir: String(targetDir), wrote: true };
+    const agentDir = state.agentDir("shared");
+    mocks.configuredAgentIds = ["agent-a", "agent-b"];
+    mocks.configuredAgentDirs.set("agent-a", agentDir);
+    mocks.configuredAgentDirs.set("agent-b", agentDir);
+    mocks.configuredWorkspaces.set("agent-a", "/tmp/source-workspace-a");
+    mocks.configuredWorkspaces.set("agent-b", "/tmp/source-workspace-b");
+    let activeWrites = 0;
+    let peakActiveWrites = 0;
+    mocks.ensureOpenClawModelsJson.mockImplementation(async (_config, targetDir, options) => {
+      activeWrites += 1;
+      peakActiveWrites = Math.max(peakActiveWrites, activeWrites);
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
       });
-
-      await refreshPreparedModelRuntimeSnapshots({});
-
-      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
-      expect(peakActiveWrites).toBe(1);
-      expect(
-        mocks.discoverModels.mock.calls.map((call) => {
-          const contents = (call[2] as { modelsJsonContents: string }).modelsJsonContents;
-          const parsed = JSON.parse(contents) as {
-            providers: { custom: { models: Array<{ id: string }> } };
-          };
-          return parsed.providers.custom.models[0]?.id;
+      const workspaceDir = (options as { workspaceDir?: string }).workspaceDir ?? "unknown";
+      await state.writeText(
+        path.relative(state.stateDir, path.join(String(targetDir), "models.json")),
+        JSON.stringify({
+          providers: {
+            custom: {
+              api: "openai-completions",
+              baseUrl: "https://models.example/v1",
+              models: [{ id: path.basename(workspaceDir) }],
+            },
+          },
         }),
-      ).toEqual(["source-workspace-a", "source-workspace-b"]);
-    } finally {
-      fs.rmSync(rootDir, { recursive: true, force: true });
-    }
+      );
+      activeWrites -= 1;
+      return { agentDir: String(targetDir), wrote: true };
+    });
+
+    await refreshPreparedModelRuntimeSnapshots({});
+
+    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
+    expect(peakActiveWrites).toBe(1);
+    expect(
+      mocks.discoverModels.mock.calls.map((call) => {
+        const contents = (call[2] as { modelsJsonContents: string }).modelsJsonContents;
+        const parsed = JSON.parse(contents) as {
+          providers: { custom: { models: Array<{ id: string }> } };
+        };
+        return parsed.providers.custom.models[0]?.id;
+      }),
+    ).toEqual(["source-workspace-a", "source-workspace-b"]);
   });
 
   it("finds the configured gateway owner when request config omits its launch workspace", async () => {
@@ -93,7 +93,7 @@ describe("prepared model runtime owner selection", () => {
     });
     const snapshot = await prepareModelRuntimeSnapshot({
       config,
-      agentDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
     });
 
     expect(snapshot.workspaceDir).toBe("/tmp/gateway-launch-workspace");
@@ -121,8 +121,8 @@ describe("prepared model runtime owner selection", () => {
     const request = {
       config,
       agentId: "default",
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
       workspaceDir: "/tmp/gateway-launch-workspace",
     };
 
@@ -148,8 +148,8 @@ describe("prepared model runtime owner selection", () => {
       prepareModelRuntimeSnapshot({
         config,
         agentId: "default",
-        agentDir: "/tmp/unused-agent",
-        inheritedAuthDir: "/tmp/unused-agent",
+        agentDir: state.agentDir("default"),
+        inheritedAuthDir: state.agentDir("default"),
         workspaceDir: "/tmp/gateway-launch-workspace",
         allowGatewaySubagentBinding: true,
       }),
@@ -167,11 +167,11 @@ describe("prepared model runtime owner selection", () => {
     const lease = await acquireReadOnlyPreparedModelRuntime({
       agentId: "default",
       config,
-      agentDir: "/tmp/isolated-probe-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("isolated-probe-agent"),
+      inheritedAuthDir: state.agentDir("default"),
       workspaceDir: "/tmp/isolated-probe-workspace",
     });
-    expect(lease.snapshot.agentDir).toBe("/tmp/isolated-probe-agent");
+    expect(lease.snapshot.agentDir).toBe(state.agentDir("isolated-probe-agent"));
     lease.release();
   });
 
@@ -211,7 +211,7 @@ describe("prepared model runtime owner selection", () => {
     });
     const configured = getPreparedModelRuntimeSnapshot({
       agentId: "default",
-      agentDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
       allowGatewaySubagentBinding: true,
       config,
       workspaceDir: "/tmp/unused-workspace",
@@ -219,7 +219,7 @@ describe("prepared model runtime owner selection", () => {
 
     const runInput = {
       agentId: "default",
-      agentDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
       allowGatewaySubagentBinding: true,
       config,
       runtimePluginSelections: [{ provider: "openai", modelId: "gpt-5.5", runtime: "codex" }],
@@ -258,48 +258,56 @@ describe("prepared model runtime owner selection", () => {
       ...generationA!,
       pluginMetadataSnapshot: { ...generationA!.pluginMetadataSnapshot },
     };
+    const finishGenerationAGate = createDeferred();
     let finishGenerationA!: () => void;
-    mocks.ensureOpenClawModelsJson.mockImplementationOnce(
-      async () =>
-        await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
-          finishGenerationA = () =>
-            resolve({ agentDir: "/tmp/dynamic-generation-agent", wrote: false });
-        }),
-    );
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(async (_config, agentDir) => {
+      finishGenerationA = () => finishGenerationAGate.resolve();
+      await finishGenerationAGate.promise;
+      return { agentDir: String(agentDir), wrote: false };
+    });
     const input = {
       config,
       agentId: "default",
-      agentDir: "/tmp/dynamic-generation-agent",
+      agentDir: state.agentDir("dynamic-generation"),
       workspaceDir: "/tmp/dynamic-generation-workspace",
     };
 
-    const pendingA = acquireAgentRunPreparedModelRuntime(input, {
-      pluginGeneration: generationA!,
-    });
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
-    const matchingPendingA = acquireAgentRunPreparedModelRuntime(input, {
-      pluginGeneration: generationA!,
-    });
-    const pendingB = acquireAgentRunPreparedModelRuntime(input, {
-      pluginGeneration: generationB,
-    }).catch((error: unknown) => error);
-    await Promise.resolve();
-    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
-    finishGenerationA();
-    const [leaseA, matchingLeaseA, rejectedGeneration] = await Promise.all([
-      pendingA,
-      matchingPendingA,
-      pendingB,
-    ]);
+    let pendingA: ReturnType<typeof acquireAgentRunPreparedModelRuntime> | undefined;
+    let matchingPendingA: ReturnType<typeof acquireAgentRunPreparedModelRuntime> | undefined;
+    try {
+      pendingA = acquireAgentRunPreparedModelRuntime(input, {
+        pluginGeneration: generationA!,
+      });
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+      matchingPendingA = acquireAgentRunPreparedModelRuntime(input, {
+        pluginGeneration: generationA!,
+      });
+      const pendingB = acquireAgentRunPreparedModelRuntime(input, {
+        pluginGeneration: generationB,
+      }).catch((error: unknown) => error);
+      await Promise.resolve();
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
+      finishGenerationA();
+      const [leaseA, matchingLeaseA, rejectedGeneration] = await Promise.all([
+        pendingA,
+        matchingPendingA,
+        pendingB,
+      ]);
 
-    expect(matchingLeaseA.snapshot).toBe(leaseA.snapshot);
-    expect(rejectedGeneration).toEqual(
-      expect.objectContaining({ message: expect.stringContaining("superseded") }),
-    );
-    expect(leaseA.snapshot.metadataSnapshot).toBe(generationA!.pluginMetadataSnapshot);
-    await expect(prepareModelRuntimeSnapshot(input)).resolves.toBe(leaseA.snapshot);
-    leaseA.release();
-    matchingLeaseA.release();
+      expect(matchingLeaseA.snapshot).toBe(leaseA.snapshot);
+      expect(rejectedGeneration).toEqual(
+        expect.objectContaining({ message: expect.stringContaining("superseded") }),
+      );
+      expect(leaseA.snapshot.metadataSnapshot).toBe(generationA!.pluginMetadataSnapshot);
+      await expect(prepareModelRuntimeSnapshot(input)).resolves.toBe(leaseA.snapshot);
+      leaseA.release();
+      matchingLeaseA.release();
+    } finally {
+      finishGenerationAGate.resolve();
+      await Promise.allSettled(
+        [pendingA, matchingPendingA].map(async (pending) => (await pending)?.release()),
+      );
+    }
   });
 
   it("keeps a committed gateway owner current when an admitted turn resumes on its older generation", async () => {
@@ -325,7 +333,7 @@ describe("prepared model runtime owner selection", () => {
     };
     const runInput = (config: typeof previousConfig) => ({
       agentId: "default",
-      agentDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
       allowGatewaySubagentBinding: true,
       config,
       runtimePluginSelections: [{ provider: "openai", modelId: "gpt-5", runtime: "openclaw" }],
@@ -403,6 +411,8 @@ describe("prepared model runtime owner selection", () => {
     } finally {
       outerLeaseActive = false;
       outerLease.release();
+      releaseDetachedAdmission();
+      await Promise.allSettled([detachedAdmission]);
     }
     releaseDetachedAdmission();
     await expect(detachedAdmission).rejects.toThrow("plugin generation was superseded");
@@ -426,13 +436,16 @@ describe("prepared model runtime owner selection", () => {
     const admitted = await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
     expect(admitted).toBeDefined();
 
-    mocks.mutationListener?.({ agentDir: "/tmp/unused-agent", affectsInheritedStores: false });
+    mocks.mutationListener?.({
+      agentDir: state.agentDir("default"),
+      affectsInheritedStores: false,
+    });
 
     await expect(
       acquireAgentRunPreparedModelRuntime(
         {
           agentId: "default",
-          agentDir: "/tmp/unused-agent",
+          agentDir: state.agentDir("default"),
           config,
           workspaceDir: "/tmp/unused-workspace",
         },
@@ -458,7 +471,7 @@ describe("prepared model runtime owner selection", () => {
     const acquire = async (modelId: string) => {
       const lease = await acquireAgentRunPreparedModelRuntime({
         agentId: "default",
-        agentDir: "/tmp/unused-agent",
+        agentDir: state.agentDir("default"),
         config,
         runtimePluginSelections: [{ provider: "openai", modelId, runtime: "codex" }],
         workspaceDir: "/tmp/unused-workspace",
@@ -487,7 +500,7 @@ describe("prepared model runtime owner selection", () => {
     });
     const configuredInput = {
       agentId: "default",
-      agentDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
       config,
       runtimePluginSelections: [{ provider: "openai", modelId: "gpt-5.5", runtime: "codex" }],
       workspaceDir: "/tmp/unused-workspace",
@@ -520,7 +533,7 @@ describe("prepared model runtime owner selection", () => {
     for (let index = 0; index < 3; index += 1) {
       const lease = await acquireAgentRunPreparedModelRuntime({
         agentId: "default",
-        agentDir: "/tmp/unused-agent",
+        agentDir: state.agentDir("default"),
         config,
         runtimePluginSelections: [
           { provider: "openai", modelId: `retained-model-${index}`, runtime: "codex" },
@@ -549,7 +562,7 @@ describe("prepared model runtime owner selection", () => {
     await expect(
       prepareModelRuntimeSnapshot({
         config,
-        agentDir: "/tmp/unused-agent",
+        agentDir: state.agentDir("default"),
         env: { ...process.env, OPENCLAW_PREPARED_RUNTIME_TEST_SCOPE: "different" },
       }),
     ).rejects.toThrow("prepared model runtime owner was not published");
@@ -567,7 +580,7 @@ describe("prepared model runtime owner selection", () => {
     await expect(
       prepareModelRuntimeSnapshot({
         config,
-        agentDir: "/tmp/unused-agent",
+        agentDir: state.agentDir("default"),
         workspaceDir: "/tmp/other-explicit-workspace",
       }),
     ).rejects.toThrow("prepared model runtime owner was not published");
@@ -575,7 +588,7 @@ describe("prepared model runtime owner selection", () => {
 
   it("does not choose between configured owners sharing one agent directory", async () => {
     const config = {};
-    const agentDir = "/tmp/shared-configured-agent";
+    const agentDir = state.agentDir("shared-configured-agent");
     await publishPreparedModelRuntimeSnapshot(
       { config, agentDir, workspaceDir: "/tmp/shared-workspace-a" },
       { provenance: "configured" },
@@ -592,7 +605,7 @@ describe("prepared model runtime owner selection", () => {
 
   it("selects a configured owner by agent id when directories are shared", async () => {
     const config = {};
-    const agentDir = "/tmp/shared-agent-id-directory";
+    const agentDir = state.agentDir("shared-agent-id-directory");
     await publishPreparedModelRuntimeSnapshot(
       { agentId: "agent-a", config, agentDir, workspaceDir: "/tmp/shared-agent-id-workspace" },
       { provenance: "configured" },
@@ -618,8 +631,8 @@ describe("prepared model runtime owner selection", () => {
     await expect(
       prepareModelRuntimeSnapshot({
         config,
-        agentDir: "/tmp/configured-removed",
-        inheritedAuthDir: "/tmp/unused-agent",
+        agentDir: state.agentDir("removed"),
+        inheritedAuthDir: state.agentDir("default"),
         workspaceDir: "/tmp/workspace-removed",
       }),
     ).rejects.toThrow("prepared model runtime owner was not published");
@@ -673,8 +686,8 @@ describe("prepared model runtime owner selection", () => {
     const snapshot = getPreparedModelRuntimeSnapshot({
       agentId: "agent-a",
       config,
-      agentDir: "/tmp/configured-agent-a",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("agent-a"),
+      inheritedAuthDir: state.agentDir("default"),
       workspaceDir: "/tmp/shared-prepared-runtime-workspace",
     });
     await snapshot?.loadFullModelCatalog?.();
@@ -720,8 +733,8 @@ describe("prepared model runtime owner selection", () => {
       const snapshot = getPreparedModelRuntimeSnapshot({
         agentId,
         config,
-        agentDir: `/tmp/configured-${agentId}`,
-        inheritedAuthDir: "/tmp/unused-agent",
+        agentDir: state.agentDir(agentId),
+        inheritedAuthDir: state.agentDir("default"),
         workspaceDir: "/tmp/shared-agent-model-workspace",
       });
       expect(snapshot?.configuredRuntimeModels.map(({ modelId }) => modelId)).toEqual([
@@ -736,121 +749,107 @@ describe("prepared model runtime owner selection", () => {
   });
 
   it("parses one static registry per exact agent catalog and credential generation", async () => {
-    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-prepared-registry-groups-"));
-    try {
-      mocks.configuredAgentIds = ["agent-a", "agent-b", "agent-c"];
-      for (const agentId of mocks.configuredAgentIds) {
-        const agentDir = path.join(rootDir, agentId);
-        fs.mkdirSync(agentDir, { recursive: true });
-        mocks.configuredAgentDirs.set(agentId, agentDir);
-        mocks.configuredWorkspaces.set(agentId, "/tmp/shared-prepared-runtime-workspace");
-      }
-      const sharedCatalog = JSON.stringify({
+    mocks.configuredAgentIds = ["agent-a", "agent-b", "agent-c"];
+    for (const agentId of mocks.configuredAgentIds) {
+      const agentDir = state.agentDir(agentId);
+      mocks.configuredAgentDirs.set(agentId, agentDir);
+      mocks.configuredWorkspaces.set(agentId, "/tmp/shared-prepared-runtime-workspace");
+    }
+    const sharedCatalog = JSON.stringify({
+      providers: {
+        custom: {
+          api: "openai-completions",
+          baseUrl: "https://models.example/v1",
+          models: [{ id: "shared-model" }],
+        },
+      },
+    });
+    await state.writeText("agents/agent-a/agent/models.json", sharedCatalog);
+    await state.writeText("agents/agent-b/agent/models.json", sharedCatalog);
+    await state.writeText(
+      "agents/agent-c/agent/models.json",
+      JSON.stringify({
         providers: {
           custom: {
             api: "openai-completions",
             baseUrl: "https://models.example/v1",
-            models: [{ id: "shared-model" }],
+            models: [{ id: "distinct-model" }],
           },
         },
-      });
-      fs.writeFileSync(path.join(rootDir, "agent-a", "models.json"), sharedCatalog);
-      fs.writeFileSync(path.join(rootDir, "agent-b", "models.json"), sharedCatalog);
-      fs.writeFileSync(
-        path.join(rootDir, "agent-c", "models.json"),
-        JSON.stringify({
-          providers: {
-            custom: {
-              api: "openai-completions",
-              baseUrl: "https://models.example/v1",
-              models: [{ id: "distinct-model" }],
-            },
-          },
-        }),
-      );
-      let runtimeRegistryCount = 0;
+      }),
+    );
+    let runtimeRegistryCount = 0;
 
-      await refreshPreparedModelRuntimeSnapshots(
-        { agents: { defaults: { model: "openai/gpt-5.5" } } },
-        {
-          gatewayLifecycle: true,
-          catalogMode: "static",
-          onBuildStats: (stats) => {
-            runtimeRegistryCount = stats.runtimeRegistryCount;
-          },
+    await refreshPreparedModelRuntimeSnapshots(
+      { agents: { defaults: { model: "openai/gpt-5.5" } } },
+      {
+        gatewayLifecycle: true,
+        catalogMode: "static",
+        onBuildStats: (stats) => {
+          runtimeRegistryCount = stats.runtimeRegistryCount;
         },
-      );
+      },
+    );
 
-      expect(mocks.discoverModels).toHaveBeenCalledTimes(2);
-      expect(runtimeRegistryCount).toBe(2);
-      expect(
-        mocks.discoverModels.mock.calls.map((call) => {
-          const options = call.length === 2 ? call[1] : call[2];
-          return (options as { modelsJsonContents?: string }).modelsJsonContents;
-        }),
-      ).toEqual(expect.arrayContaining([sharedCatalog, expect.stringContaining("distinct-model")]));
-    } finally {
-      fs.rmSync(rootDir, { recursive: true, force: true });
-    }
+    expect(mocks.discoverModels).toHaveBeenCalledTimes(2);
+    expect(runtimeRegistryCount).toBe(2);
+    expect(
+      mocks.discoverModels.mock.calls.map((call) => {
+        const options = call.length === 2 ? call[1] : call[2];
+        return (options as { modelsJsonContents?: string }).modelsJsonContents;
+      }),
+    ).toEqual(expect.arrayContaining([sharedCatalog, expect.stringContaining("distinct-model")]));
   });
 
   it("keeps registry parsing isolated across OAuth provider generations", async () => {
-    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-prepared-oauth-groups-"));
-    try {
-      mocks.configuredAgentIds = ["agent-a", "agent-b", "agent-c"];
-      const sharedCatalog = JSON.stringify({
-        providers: {
-          custom: {
-            api: "openai-completions",
-            baseUrl: "https://models.example/v1",
-            models: [{ id: "shared-model" }],
-          },
+    mocks.configuredAgentIds = ["agent-a", "agent-b", "agent-c"];
+    const sharedCatalog = JSON.stringify({
+      providers: {
+        custom: {
+          api: "openai-completions",
+          baseUrl: "https://models.example/v1",
+          models: [{ id: "shared-model" }],
         },
-      });
-      const sharedProvider = {
-        id: "custom",
-        name: "OAuth A",
-        login: vi.fn(),
-        refreshToken: vi.fn(),
-        getApiKey: vi.fn(),
-      };
-      const oauthProviders = {
-        "agent-a": sharedProvider,
-        "agent-b": { ...sharedProvider },
-        "agent-c": { ...sharedProvider, name: "OAuth B", modifyModels: vi.fn() },
-      };
-      for (const agentId of mocks.configuredAgentIds) {
-        const agentDir = path.join(rootDir, agentId);
-        fs.mkdirSync(agentDir, { recursive: true });
-        fs.writeFileSync(path.join(agentDir, "models.json"), sharedCatalog);
-        mocks.configuredAgentDirs.set(agentId, agentDir);
-        mocks.configuredWorkspaces.set(agentId, "/tmp/shared-prepared-runtime-workspace");
-      }
-      mocks.discoverAuthStorage.mockImplementation((agentDir: unknown) => {
-        const agentId = path.basename(String(agentDir)) as keyof typeof oauthProviders;
-        return {
-          getAll: () => ({ custom: { type: "api_key" as const, key: "shared-key" } }),
-          getOAuthProviders: () => [oauthProviders[agentId]],
-        };
-      });
-      let runtimeRegistryCount = 0;
-
-      await refreshPreparedModelRuntimeSnapshots(
-        { agents: { defaults: { model: "openai/gpt-5.5" } } },
-        {
-          gatewayLifecycle: true,
-          catalogMode: "static",
-          onBuildStats: (stats) => {
-            runtimeRegistryCount = stats.runtimeRegistryCount;
-          },
-        },
-      );
-
-      expect(mocks.discoverModels).toHaveBeenCalledTimes(2);
-      expect(runtimeRegistryCount).toBe(2);
-    } finally {
-      fs.rmSync(rootDir, { recursive: true, force: true });
+      },
+    });
+    const sharedProvider = {
+      id: "custom",
+      name: "OAuth A",
+      login: vi.fn(),
+      refreshToken: vi.fn(),
+      getApiKey: vi.fn(),
+    };
+    const distinctProvider = { ...sharedProvider, name: "OAuth B", modifyModels: vi.fn() };
+    const oauthProviders = new Map([
+      [state.agentDir("agent-a"), sharedProvider],
+      [state.agentDir("agent-b"), { ...sharedProvider }],
+      [state.agentDir("agent-c"), distinctProvider],
+    ]);
+    for (const agentId of mocks.configuredAgentIds) {
+      const agentDir = state.agentDir(agentId);
+      await state.writeText(`agents/${agentId}/agent/models.json`, sharedCatalog);
+      mocks.configuredAgentDirs.set(agentId, agentDir);
+      mocks.configuredWorkspaces.set(agentId, "/tmp/shared-prepared-runtime-workspace");
     }
+    mocks.discoverAuthStorage.mockImplementation((agentDir: unknown) => ({
+      getAll: () => ({ custom: { type: "api_key" as const, key: "shared-key" } }),
+      getOAuthProviders: () => [oauthProviders.get(String(agentDir))!],
+    }));
+    let runtimeRegistryCount = 0;
+
+    await refreshPreparedModelRuntimeSnapshots(
+      { agents: { defaults: { model: "openai/gpt-5.5" } } },
+      {
+        gatewayLifecycle: true,
+        catalogMode: "static",
+        onBuildStats: (stats) => {
+          runtimeRegistryCount = stats.runtimeRegistryCount;
+        },
+      },
+    );
+
+    expect(mocks.discoverModels).toHaveBeenCalledTimes(2);
+    expect(runtimeRegistryCount).toBe(2);
   });
 
   it("serializes on-demand full catalogs across prepared owners", async () => {
@@ -886,8 +885,8 @@ describe("prepared model runtime owner selection", () => {
       getPreparedModelRuntimeSnapshot({
         agentId,
         config,
-        agentDir: `/tmp/configured-${agentId}`,
-        inheritedAuthDir: "/tmp/unused-agent",
+        agentDir: state.agentDir(agentId),
+        inheritedAuthDir: state.agentDir("default"),
         workspaceDir: "/tmp/shared-prepared-runtime-workspace",
       })?.loadFullModelCatalog?.();
     await Promise.all([loadAgentCatalog("agent-a"), loadAgentCatalog("agent-b")]);
@@ -908,104 +907,128 @@ describe("prepared model runtime owner selection", () => {
     const snapshot = getPreparedModelRuntimeSnapshot({
       agentId: "agent-a",
       config: initialConfig,
-      agentDir: "/tmp/configured-agent-a",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("agent-a"),
+      inheritedAuthDir: state.agentDir("default"),
       workspaceDir: "/tmp/shared-prepared-runtime-workspace",
     });
+    const releaseLazyPlanGate = createDeferred();
     let releaseLazyPlan: (() => void) | undefined;
     mocks.runPreparedModelCatalogWorker.mockImplementation(async () => {
       if (!releaseLazyPlan) {
-        await new Promise<void>((resolve) => {
-          releaseLazyPlan = resolve;
-        });
+        releaseLazyPlan = releaseLazyPlanGate.resolve;
+        await releaseLazyPlanGate.promise;
       }
       return { entries: [], routeVariants: [] };
     });
 
+    let replacement: ReturnType<typeof refreshPreparedModelRuntimeSnapshots> | undefined;
     const staleCatalogLoad = snapshot?.loadFullModelCatalog?.();
-    await vi.waitFor(() => expect(releaseLazyPlan).toBeTypeOf("function"));
-    const replacement = refreshPreparedModelRuntimeSnapshots(
-      { agents: { defaults: { model: "openai/gpt-5.6" } } },
-      { gatewayLifecycle: true, catalogMode: "live" },
-    );
-    await Promise.resolve();
-    expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
-    expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
+    try {
+      await vi.waitFor(() => expect(releaseLazyPlan).toBeTypeOf("function"));
+      replacement = refreshPreparedModelRuntimeSnapshots(
+        { agents: { defaults: { model: "openai/gpt-5.6" } } },
+        { gatewayLifecycle: true, catalogMode: "live" },
+      );
+      await Promise.resolve();
+      expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
+      expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
 
-    releaseLazyPlan?.();
-    await expect(staleCatalogLoad).rejects.toThrow("superseded");
-    await replacement;
-    expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
-    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
+      releaseLazyPlanGate.resolve();
+      await expect(staleCatalogLoad).rejects.toThrow("superseded");
+      await replacement;
+      expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
+    } finally {
+      releaseLazyPlanGate.resolve();
+      await Promise.allSettled([staleCatalogLoad, replacement]);
+    }
   });
 
   it("stops a superseded same-directory batch before another catalog write", async () => {
     mocks.configuredAgentIds = ["agent-a", "agent-b"];
     for (const agentId of mocks.configuredAgentIds) {
-      mocks.configuredAgentDirs.set(agentId, "/tmp/shared-catalog-agent-dir");
+      mocks.configuredAgentDirs.set(agentId, state.agentDir("shared-catalog-agent-dir"));
       mocks.configuredWorkspaces.set(agentId, `/tmp/catalog-workspace-${agentId}`);
     }
     const staleConfig = { agents: { defaults: { model: "openai/gpt-5.5" } } };
     const latestConfig = { agents: { defaults: { model: "openai/gpt-5.6" } } };
+    const releaseStaleWriteGate = createDeferred();
     let releaseStaleWrite: (() => void) | undefined;
     mocks.ensureOpenClawModelsJson.mockImplementation(async (config) => {
       if (config === staleConfig && !releaseStaleWrite) {
-        await new Promise<void>((resolve) => {
-          releaseStaleWrite = resolve;
-        });
+        releaseStaleWrite = releaseStaleWriteGate.resolve;
+        await releaseStaleWriteGate.promise;
       }
-      return { agentDir: "/tmp/shared-catalog-agent-dir", wrote: false };
+      return { agentDir: state.agentDir("shared-catalog-agent-dir"), wrote: false };
     });
 
-    const stale = refreshPreparedModelRuntimeSnapshots(staleConfig);
-    await vi.waitFor(() => expect(releaseStaleWrite).toBeTypeOf("function"));
-    const latest = refreshPreparedModelRuntimeSnapshots(latestConfig);
-    releaseStaleWrite?.();
+    let stale: ReturnType<typeof refreshPreparedModelRuntimeSnapshots> | undefined;
+    let latest: ReturnType<typeof refreshPreparedModelRuntimeSnapshots> | undefined;
+    try {
+      stale = refreshPreparedModelRuntimeSnapshots(staleConfig);
+      await vi.waitFor(() => expect(releaseStaleWrite).toBeTypeOf("function"));
+      latest = refreshPreparedModelRuntimeSnapshots(latestConfig);
+      releaseStaleWriteGate.resolve();
 
-    await expect(stale).rejects.toThrow("superseded");
-    await latest;
-    expect(
-      mocks.ensureOpenClawModelsJson.mock.calls.filter(([config]) => config === staleConfig),
-    ).toHaveLength(1);
-    expect(
-      mocks.ensureOpenClawModelsJson.mock.calls.filter(([config]) => config === latestConfig),
-    ).toHaveLength(2);
+      await expect(stale).rejects.toThrow("superseded");
+      await latest;
+      expect(
+        mocks.ensureOpenClawModelsJson.mock.calls.filter(([config]) => config === staleConfig),
+      ).toHaveLength(1);
+      expect(
+        mocks.ensureOpenClawModelsJson.mock.calls.filter(([config]) => config === latestConfig),
+      ).toHaveLength(2);
+    } finally {
+      releaseStaleWriteGate.resolve();
+      await Promise.allSettled([stale, latest]);
+    }
   });
 
   it("publishes a current sibling when another auth owner is superseded", async () => {
     const config = {};
-    const supersededDir = "/tmp/prepared-model-runtime-auth-retry-superseded";
-    const siblingDir = "/tmp/prepared-model-runtime-auth-retry-sibling";
+    const supersededDir = state.agentDir("auth-retry-superseded");
+    const siblingDir = state.agentDir("auth-retry-sibling");
     await publishPreparedModelRuntimeSnapshot({ config, agentDir: supersededDir });
     const firstSibling = await publishPreparedModelRuntimeSnapshot({
       config,
       agentDir: siblingDir,
     });
-    let releaseSupersededRefresh: (() => void) | undefined;
+    const releaseSupersededRefreshGate = createDeferred();
     let blockedSupersededRefresh = true;
     mocks.ensureOpenClawModelsJson.mockImplementation(async (_config, agentDir) => {
       if (agentDir === supersededDir && blockedSupersededRefresh) {
         blockedSupersededRefresh = false;
-        await new Promise<void>((resolve) => {
-          releaseSupersededRefresh = resolve;
-        });
+        await releaseSupersededRefreshGate.promise;
       }
       return { agentDir: String(agentDir), wrote: false };
     });
 
-    mocks.mutationListener?.({ affectsInheritedStores: true });
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(4));
-    const siblingPending = publishPreparedModelRuntimeSnapshot({
-      config,
-      agentDir: siblingDir,
-    });
-    mocks.mutationListener?.({ agentDir: supersededDir, affectsInheritedStores: false });
-    releaseSupersededRefresh?.();
+    let siblingPending: ReturnType<typeof publishPreparedModelRuntimeSnapshot> | undefined;
+    try {
+      mocks.mutationListener?.({ affectsInheritedStores: true });
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(4));
+      siblingPending = publishPreparedModelRuntimeSnapshot({
+        config,
+        agentDir: siblingDir,
+      });
+      mocks.mutationListener?.({ agentDir: supersededDir, affectsInheritedStores: false });
+      releaseSupersededRefreshGate.resolve();
 
-    await expect(siblingPending).resolves.not.toBe(firstSibling);
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(6));
-    await expect(
-      prepareModelRuntimeSnapshot({ config, agentDir: supersededDir }),
-    ).resolves.toMatchObject({ agentDir: supersededDir });
+      await expect(siblingPending).resolves.not.toBe(firstSibling);
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(6));
+      await expect(
+        prepareModelRuntimeSnapshot({ config, agentDir: supersededDir }),
+      ).resolves.toMatchObject({ agentDir: supersededDir });
+    } finally {
+      releaseSupersededRefreshGate.resolve();
+      await Promise.allSettled([
+        siblingPending,
+        prepareModelRuntimeSnapshot({ config, agentDir: supersededDir }),
+      ]);
+    }
   });
+});
+
+afterEach(async ({ task }) => {
+  await cleanupPreparedModelRuntimeHarness(state, task.result?.state === "fail");
 });

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -1,11 +1,16 @@
 // Preserve module setup before modules that consume it.
 // oxfmt-ignore
 import {
+  cleanupPreparedModelRuntimeHarness,
   getPreparedModelRuntimeMocks,
   resetPreparedModelRuntimeHarness,
 } from "./prepared-model-runtime.test-harness.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
 import {
   acquireAgentRunPreparedModelRuntime,
   loadPublishedGatewayReplyDispatchRuntime,
@@ -15,10 +20,12 @@ import {
 import { PreparedReplyDispatchPublicationOwner } from "./prepared-reply-dispatch-runtime.js";
 
 const mocks = getPreparedModelRuntimeMocks();
+let state: OpenClawTestState;
 
 describe("prepared model runtime reload auth adoption", () => {
-  beforeEach(() => {
-    resetPreparedModelRuntimeHarness();
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ label: "prepared-model-runtime" });
+    resetPreparedModelRuntimeHarness(state);
   });
 
   it("commits auth invalidation inside the active lifecycle publication", async () => {
@@ -38,7 +45,7 @@ describe("prepared model runtime reload auth adoption", () => {
     });
     let defaultBuildCount = 0;
     mocks.ensureOpenClawModelsJson.mockImplementation(async (_config, agentDir) => {
-      if (agentDir !== "/tmp/unused-agent") {
+      if (agentDir !== state.agentDir("default")) {
         return { agentDir: String(agentDir), wrote: false };
       }
       defaultBuildCount += 1;
@@ -50,64 +57,77 @@ describe("prepared model runtime reload auth adoption", () => {
       return await authBuild.promise;
     });
 
-    const publication = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
-      gatewayLifecycle: true,
-    });
-    void publication.catch(() => undefined);
-    await vi.waitFor(() => expect(order).toContain("config-build-start"));
-    order.push("auth-mutation");
-    mocks.mutationListener?.({ agentDir: "/tmp/unused-agent", affectsInheritedStores: false });
-    const affectedRead = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }).then(
-      (runtime) => {
-        order.push("affected-dispatch-resolved");
-        return runtime;
-      },
-    );
-    const siblingRead = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
-    void affectedRead.catch(() => undefined);
-    void siblingRead.catch(() => undefined);
-    order.push("config-build-finish");
-    configBuild.resolve({ agentDir: "/tmp/unused-agent", wrote: false });
-    await vi.waitFor(() => expect(order).toContain("auth-drain-start"));
-    await expect(
-      Promise.race([publication.then(() => "settled"), Promise.resolve("pending")]),
-    ).resolves.toBe("pending");
-    await expect(
-      Promise.race([affectedRead.then(() => "settled"), Promise.resolve("pending")]),
-    ).resolves.toBe("pending");
+    let publication: ReturnType<typeof refreshPreparedModelRuntimeSnapshots> | undefined;
+    let affectedRead: ReturnType<typeof loadPublishedGatewayReplyDispatchRuntime> | undefined;
+    let siblingRead: ReturnType<typeof loadPublishedGatewayReplyDispatchRuntime> | undefined;
+    try {
+      publication = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
+        gatewayLifecycle: true,
+      });
+      void publication.catch(() => undefined);
+      await vi.waitFor(() => expect(order).toContain("config-build-start"));
+      order.push("auth-mutation");
+      mocks.mutationListener?.({
+        agentDir: state.agentDir("default"),
+        affectsInheritedStores: false,
+      });
+      affectedRead = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }).then(
+        (runtime) => {
+          order.push("affected-dispatch-resolved");
+          return runtime;
+        },
+      );
+      siblingRead = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
+      void affectedRead.catch(() => undefined);
+      void siblingRead.catch(() => undefined);
+      order.push("config-build-finish");
+      configBuild.resolve({ agentDir: state.agentDir("default"), wrote: false });
+      await vi.waitFor(() => expect(order).toContain("auth-drain-start"));
+      await expect(
+        Promise.race([publication.then(() => "settled"), Promise.resolve("pending")]),
+      ).resolves.toBe("pending");
+      await expect(
+        Promise.race([affectedRead.then(() => "settled"), Promise.resolve("pending")]),
+      ).resolves.toBe("pending");
 
-    order.push("auth-drain-finish");
-    authBuild.resolve({ agentDir: "/tmp/unused-agent", wrote: false });
-    await expect(publication).resolves.toBeUndefined();
-    const [affectedRuntime, siblingRuntime] = await Promise.all([affectedRead, siblingRead]);
-    unregister();
+      order.push("auth-drain-finish");
+      authBuild.resolve({ agentDir: state.agentDir("default"), wrote: false });
+      await expect(publication).resolves.toBeUndefined();
+      const [affectedRuntime, siblingRuntime] = await Promise.all([affectedRead, siblingRead]);
+      unregister();
 
-    expect(events.filter((phase) => phase === "published")).toHaveLength(1);
-    expect(events).not.toContain("failed");
-    expect(mocks.warn).not.toHaveBeenCalled();
-    expect(affectedRuntime?.config).toBe(replacementConfig);
-    expect(siblingRuntime?.config).toBe(replacementConfig);
-    expect(order).toEqual([
-      "config-build-start",
-      "auth-mutation",
-      "config-build-finish",
-      "auth-drain-start",
-      "auth-drain-finish",
-      "config-published",
-      "affected-dispatch-resolved",
-    ]);
-    const buildCountAfterPublication = mocks.ensureOpenClawModelsJson.mock.calls.length;
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(buildCountAfterPublication);
-    const lease = await acquireAgentRunPreparedModelRuntime({
-      agentId: "default",
-      agentDir: "/tmp/unused-agent",
-      config: replacementConfig,
-      workspaceDir: "/tmp/unused-workspace",
-    });
-    expect(lease.snapshot.config).toBe(replacementConfig);
-    lease.release();
+      expect(events.filter((phase) => phase === "published")).toHaveLength(1);
+      expect(events).not.toContain("failed");
+      expect(mocks.warn).not.toHaveBeenCalled();
+      expect(affectedRuntime?.config).toBe(replacementConfig);
+      expect(siblingRuntime?.config).toBe(replacementConfig);
+      expect(order).toEqual([
+        "config-build-start",
+        "auth-mutation",
+        "config-build-finish",
+        "auth-drain-start",
+        "auth-drain-finish",
+        "config-published",
+        "affected-dispatch-resolved",
+      ]);
+      const buildCountAfterPublication = mocks.ensureOpenClawModelsJson.mock.calls.length;
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(buildCountAfterPublication);
+      const lease = await acquireAgentRunPreparedModelRuntime({
+        agentId: "default",
+        agentDir: state.agentDir("default"),
+        config: replacementConfig,
+        workspaceDir: "/tmp/unused-workspace",
+      });
+      expect(lease.snapshot.config).toBe(replacementConfig);
+      lease.release();
+    } finally {
+      configBuild.resolve({ agentDir: state.agentDir("default"), wrote: false });
+      authBuild.resolve({ agentDir: state.agentDir("default"), wrote: false });
+      await Promise.allSettled([publication, affectedRead, siblingRead]);
+      unregister();
+    }
   });
 
   it("adopts an in-flight auth gate into a same-owner config reload", async () => {
@@ -125,29 +145,41 @@ describe("prepared model runtime reload auth adoption", () => {
       .mockImplementationOnce(async () => await authBuild.promise)
       .mockImplementationOnce(async () => await configBuild.promise);
 
-    mocks.mutationListener?.({ agentDir: "/tmp/unused-agent", affectsInheritedStores: false });
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
-    const authWaiter = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
-    void authWaiter.catch(() => undefined);
-    const reload = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
-      gatewayLifecycle: true,
-    });
-    void reload.catch(() => undefined);
-    authBuild.resolve({ agentDir: "/tmp/unused-agent", wrote: false });
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
-    await expect(
-      Promise.race([authWaiter.then(() => "settled"), Promise.resolve("pending")]),
-    ).resolves.toBe("pending");
+    let authWaiter: ReturnType<typeof loadPublishedGatewayReplyDispatchRuntime> | undefined;
+    let reload: ReturnType<typeof refreshPreparedModelRuntimeSnapshots> | undefined;
+    try {
+      mocks.mutationListener?.({
+        agentDir: state.agentDir("default"),
+        affectsInheritedStores: false,
+      });
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+      authWaiter = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+      void authWaiter.catch(() => undefined);
+      reload = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
+        gatewayLifecycle: true,
+      });
+      void reload.catch(() => undefined);
+      authBuild.resolve({ agentDir: state.agentDir("default"), wrote: false });
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
+      await expect(
+        Promise.race([authWaiter.then(() => "settled"), Promise.resolve("pending")]),
+      ).resolves.toBe("pending");
 
-    configBuild.resolve({ agentDir: "/tmp/unused-agent", wrote: false });
-    await expect(reload).resolves.toBeUndefined();
-    const runtime = await authWaiter;
-    unregister();
+      configBuild.resolve({ agentDir: state.agentDir("default"), wrote: false });
+      await expect(reload).resolves.toBeUndefined();
+      const runtime = await authWaiter;
+      unregister();
 
-    expect(runtime?.config).toBe(replacementConfig);
-    expect(events.filter((phase) => phase === "published")).toHaveLength(1);
-    expect(events).not.toContain("failed");
-    expect(mocks.warn).not.toHaveBeenCalled();
+      expect(runtime?.config).toBe(replacementConfig);
+      expect(events.filter((phase) => phase === "published")).toHaveLength(1);
+      expect(events).not.toContain("failed");
+      expect(mocks.warn).not.toHaveBeenCalled();
+    } finally {
+      authBuild.resolve({ agentDir: state.agentDir("default"), wrote: false });
+      configBuild.resolve({ agentDir: state.agentDir("default"), wrote: false });
+      await Promise.allSettled([authWaiter, reload]);
+      unregister();
+    }
   });
 
   it("adopts remaining auth work after another owner already published", async () => {
@@ -164,54 +196,68 @@ describe("prepared model runtime reload auth adoption", () => {
       events.push(event.phase);
     });
     mocks.ensureOpenClawModelsJson.mockImplementation(async (config, agentDir) => {
-      if (config === initialConfig && agentDir === "/tmp/configured-worker") {
+      if (config === initialConfig && agentDir === state.agentDir("worker")) {
         return await workerAuthBuild.promise;
       }
-      if (config === initialConfig && agentDir === "/tmp/configured-research") {
+      if (config === initialConfig && agentDir === state.agentDir("research")) {
         return await researchAuthBuild.promise;
       }
-      if (config === replacementConfig && agentDir === "/tmp/configured-worker") {
+      if (config === replacementConfig && agentDir === state.agentDir("worker")) {
         replacementWorkerStarted = true;
         return await replacementWorkerBuild.promise;
       }
       return { agentDir: String(agentDir), wrote: false };
     });
 
-    mocks.mutationListener?.({
-      agentDir: "/tmp/configured-worker",
-      affectsInheritedStores: false,
-    });
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(4));
-    const firstWorkerRead = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
-    mocks.mutationListener?.({
-      agentDir: "/tmp/configured-research",
-      affectsInheritedStores: false,
-    });
-    workerAuthBuild.resolve({ agentDir: "/tmp/configured-worker", wrote: false });
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(5));
-    await expect(firstWorkerRead).resolves.toMatchObject({ config: initialConfig });
+    let firstWorkerRead: ReturnType<typeof loadPublishedGatewayReplyDispatchRuntime> | undefined;
+    let adoptedWorkerRead: ReturnType<typeof loadPublishedGatewayReplyDispatchRuntime> | undefined;
+    let reload: ReturnType<typeof refreshPreparedModelRuntimeSnapshots> | undefined;
+    try {
+      mocks.mutationListener?.({
+        agentDir: state.agentDir("worker"),
+        affectsInheritedStores: false,
+      });
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(4));
+      firstWorkerRead = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
+      mocks.mutationListener?.({
+        agentDir: state.agentDir("research"),
+        affectsInheritedStores: false,
+      });
+      workerAuthBuild.resolve({ agentDir: state.agentDir("worker"), wrote: false });
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(5));
+      await expect(firstWorkerRead).resolves.toMatchObject({ config: initialConfig });
 
-    const reload = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
-      gatewayLifecycle: true,
-    });
-    const adoptedWorkerRead = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
-    let adoptedWorkerSettled = false;
-    void adoptedWorkerRead.then(() => {
-      adoptedWorkerSettled = true;
-    });
-    await Promise.resolve();
-    expect(adoptedWorkerSettled).toBe(false);
+      reload = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
+        gatewayLifecycle: true,
+      });
+      adoptedWorkerRead = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
+      let adoptedWorkerSettled = false;
+      void adoptedWorkerRead.then(
+        () => {
+          adoptedWorkerSettled = true;
+        },
+        () => undefined,
+      );
+      await Promise.resolve();
+      expect(adoptedWorkerSettled).toBe(false);
 
-    researchAuthBuild.resolve({ agentDir: "/tmp/configured-research", wrote: false });
-    await vi.waitFor(() => expect(replacementWorkerStarted).toBe(true));
-    expect(adoptedWorkerSettled).toBe(false);
-    replacementWorkerBuild.resolve({ agentDir: "/tmp/configured-worker", wrote: false });
-    await expect(reload).resolves.toBeUndefined();
-    await expect(adoptedWorkerRead).resolves.toMatchObject({ config: replacementConfig });
-    unregister();
+      researchAuthBuild.resolve({ agentDir: state.agentDir("research"), wrote: false });
+      await vi.waitFor(() => expect(replacementWorkerStarted).toBe(true));
+      expect(adoptedWorkerSettled).toBe(false);
+      replacementWorkerBuild.resolve({ agentDir: state.agentDir("worker"), wrote: false });
+      await expect(reload).resolves.toBeUndefined();
+      await expect(adoptedWorkerRead).resolves.toMatchObject({ config: replacementConfig });
+      unregister();
 
-    expect(events.filter((phase) => phase === "published")).toHaveLength(1);
-    expect(events).not.toContain("failed");
+      expect(events.filter((phase) => phase === "published")).toHaveLength(1);
+      expect(events).not.toContain("failed");
+    } finally {
+      workerAuthBuild.resolve({ agentDir: state.agentDir("worker"), wrote: false });
+      researchAuthBuild.resolve({ agentDir: state.agentDir("research"), wrote: false });
+      replacementWorkerBuild.resolve({ agentDir: state.agentDir("worker"), wrote: false });
+      await Promise.allSettled([firstWorkerRead, adoptedWorkerRead, reload]);
+      unregister();
+    }
   });
 
   it("rejects an adopted auth gate when config reload fails and permits recovery", async () => {
@@ -225,32 +271,42 @@ describe("prepared model runtime reload auth adoption", () => {
       .mockImplementationOnce(async () => await authBuild.promise)
       .mockRejectedValueOnce(reloadError);
 
-    mocks.mutationListener?.({ agentDir: "/tmp/unused-agent", affectsInheritedStores: false });
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
-    const authWaiter = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
-    void authWaiter.catch(() => undefined);
-    const reload = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
-      gatewayLifecycle: true,
-    });
-    void reload.catch(() => undefined);
-    authBuild.resolve({ agentDir: "/tmp/unused-agent", wrote: false });
+    let authWaiter: ReturnType<typeof loadPublishedGatewayReplyDispatchRuntime> | undefined;
+    let reload: ReturnType<typeof refreshPreparedModelRuntimeSnapshots> | undefined;
+    try {
+      mocks.mutationListener?.({
+        agentDir: state.agentDir("default"),
+        affectsInheritedStores: false,
+      });
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+      authWaiter = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+      void authWaiter.catch(() => undefined);
+      reload = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
+        gatewayLifecycle: true,
+      });
+      void reload.catch(() => undefined);
+      authBuild.resolve({ agentDir: state.agentDir("default"), wrote: false });
 
-    await expect(reload).rejects.toBe(reloadError);
-    await expect(authWaiter).rejects.toBe(reloadError);
-    await expect(loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" })).rejects.toThrow(
-      "prepared reply dispatch runtime owner was not published for default",
-    );
+      await expect(reload).rejects.toBe(reloadError);
+      await expect(authWaiter).rejects.toBe(reloadError);
+      await expect(
+        loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
+      ).rejects.toThrow("prepared reply dispatch runtime owner was not published for default");
 
-    await refreshPreparedModelRuntimeSnapshots(replacementConfig, { gatewayLifecycle: true });
-    await expect(
-      loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
-    ).resolves.toMatchObject({ config: replacementConfig });
+      await refreshPreparedModelRuntimeSnapshots(replacementConfig, { gatewayLifecycle: true });
+      await expect(
+        loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
+      ).resolves.toMatchObject({ config: replacementConfig });
+    } finally {
+      authBuild.resolve({ agentDir: state.agentDir("default"), wrote: false });
+      await Promise.allSettled([authWaiter, reload]);
+    }
   });
 
   it("continues with a corrective auth mutation after the earlier build fails", async () => {
     mocks.configuredAgentIds = ["default"];
     const config = {};
-    const agentDir = "/tmp/unused-agent";
+    const agentDir = state.agentDir("default");
     await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
     const firstBuild = createDeferred<{ agentDir: string; wrote: false }>();
     const secondBuild = createDeferred<{ agentDir: string; wrote: false }>();
@@ -259,20 +315,27 @@ describe("prepared model runtime reload auth adoption", () => {
       .mockImplementationOnce(async () => await firstBuild.promise)
       .mockImplementationOnce(async () => await secondBuild.promise);
 
-    mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
-    const dispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
-    void dispatch.catch(() => undefined);
-    mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
-    firstBuild.reject(firstError);
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
-    await expect(
-      Promise.race([dispatch.then(() => "settled"), Promise.resolve("pending")]),
-    ).resolves.toBe("pending");
+    let dispatch: ReturnType<typeof loadPublishedGatewayReplyDispatchRuntime> | undefined;
+    try {
+      mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+      dispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+      void dispatch.catch(() => undefined);
+      mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
+      firstBuild.reject(firstError);
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
+      await expect(
+        Promise.race([dispatch.then(() => "settled"), Promise.resolve("pending")]),
+      ).resolves.toBe("pending");
 
-    secondBuild.resolve({ agentDir, wrote: false });
-    await expect(dispatch).resolves.toMatchObject({ agentId: "default", agentDir });
-    expect(mocks.warn).not.toHaveBeenCalled();
+      secondBuild.resolve({ agentDir, wrote: false });
+      await expect(dispatch).resolves.toMatchObject({ agentId: "default", agentDir });
+      expect(mocks.warn).not.toHaveBeenCalled();
+    } finally {
+      firstBuild.resolve({ agentDir: state.agentDir("default"), wrote: false });
+      secondBuild.resolve({ agentDir: state.agentDir("default"), wrote: false });
+      await Promise.allSettled([dispatch]);
+    }
   });
 
   it.each([
@@ -285,8 +348,8 @@ describe("prepared model runtime reload auth adoption", () => {
       const config = {};
       await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
       const agentDirs = {
-        research: "/tmp/configured-research",
-        worker: "/tmp/configured-worker",
+        research: state.agentDir("research"),
+        worker: state.agentDir("worker"),
       } as const;
       const builds = {
         research: createDeferred<{ agentDir: string; wrote: false }>(),
@@ -305,49 +368,59 @@ describe("prepared model runtime reload auth adoption", () => {
           : { agentDir: String(agentDir), wrote: false };
       });
 
-      mocks.mutationListener?.({
-        agentDir: agentDirs.worker,
-        affectsInheritedStores: false,
-      });
-      mocks.mutationListener?.({
-        agentDir: agentDirs.research,
-        affectsInheritedStores: false,
-      });
-      const dispatches = {
-        research: loadPublishedGatewayReplyDispatchRuntime({ agentId: "research" }),
-        worker: loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" }),
-      };
-      void dispatches.research.catch(() => undefined);
-      void dispatches.worker.catch(() => undefined);
-      await vi.waitFor(() =>
-        expect(mocks.ensureOpenClawModelsJson.mock.calls.length).toBeGreaterThanOrEqual(4),
-      );
-      if (failedAgentId === "worker") {
-        builds.worker.reject(refreshError);
-      } else {
-        builds.worker.resolve({ agentDir: agentDirs.worker, wrote: false });
-      }
-      await vi.waitFor(() =>
-        expect(mocks.ensureOpenClawModelsJson.mock.calls.length).toBeGreaterThanOrEqual(5),
-      );
-      if (failedAgentId === "research") {
-        builds.research.reject(refreshError);
-      } else {
-        builds.research.resolve({ agentDir: agentDirs.research, wrote: false });
-      }
+      let dispatches:
+        | Record<keyof typeof builds, ReturnType<typeof loadPublishedGatewayReplyDispatchRuntime>>
+        | undefined;
+      try {
+        mocks.mutationListener?.({
+          agentDir: agentDirs.worker,
+          affectsInheritedStores: false,
+        });
+        mocks.mutationListener?.({
+          agentDir: agentDirs.research,
+          affectsInheritedStores: false,
+        });
+        dispatches = {
+          research: loadPublishedGatewayReplyDispatchRuntime({ agentId: "research" }),
+          worker: loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" }),
+        };
+        void dispatches.research.catch(() => undefined);
+        void dispatches.worker.catch(() => undefined);
+        await vi.waitFor(() =>
+          expect(mocks.ensureOpenClawModelsJson.mock.calls.length).toBeGreaterThanOrEqual(4),
+        );
+        if (failedAgentId === "worker") {
+          builds.worker.reject(refreshError);
+        } else {
+          builds.worker.resolve({ agentDir: agentDirs.worker, wrote: false });
+        }
+        await vi.waitFor(() =>
+          expect(mocks.ensureOpenClawModelsJson.mock.calls.length).toBeGreaterThanOrEqual(5),
+        );
+        if (failedAgentId === "research") {
+          builds.research.reject(refreshError);
+        } else {
+          builds.research.resolve({ agentDir: agentDirs.research, wrote: false });
+        }
 
-      await expect(dispatches[failedAgentId]).rejects.toBe(refreshError);
-      await expect(dispatches[successfulAgentId]).resolves.toMatchObject({
-        agentId: successfulAgentId,
-        agentDir: agentDirs[successfulAgentId],
-      });
-      await expect(
-        loadPublishedGatewayReplyDispatchRuntime({ agentId: failedAgentId }),
-      ).rejects.toThrow(
-        `prepared reply dispatch runtime owner was not published for ${failedAgentId}`,
-      );
-      expect(mocks.warn).toHaveBeenCalledOnce();
-      expect(mocks.warn).toHaveBeenCalledWith(expect.stringContaining(refreshError.message));
+        await expect(dispatches[failedAgentId]).rejects.toBe(refreshError);
+        await expect(dispatches[successfulAgentId]).resolves.toMatchObject({
+          agentId: successfulAgentId,
+          agentDir: agentDirs[successfulAgentId],
+        });
+        await expect(
+          loadPublishedGatewayReplyDispatchRuntime({ agentId: failedAgentId }),
+        ).rejects.toThrow(
+          `prepared reply dispatch runtime owner was not published for ${failedAgentId}`,
+        );
+        expect(mocks.warn).toHaveBeenCalledOnce();
+        expect(mocks.warn).toHaveBeenCalledWith(expect.stringContaining(refreshError.message));
+      } finally {
+        for (const agentId of Object.keys(builds) as Array<keyof typeof builds>) {
+          builds[agentId].resolve({ agentDir: agentDirs[agentId], wrote: false });
+        }
+        await Promise.allSettled(Object.values(dispatches ?? {}));
+      }
     },
   );
 
@@ -355,9 +428,9 @@ describe("prepared model runtime reload auth adoption", () => {
     mocks.configuredAgentIds = ["default", "worker", "research"];
     await refreshPreparedModelRuntimeSnapshots({}, { gatewayLifecycle: true });
     const agentDirs = {
-      default: "/tmp/unused-agent",
-      research: "/tmp/configured-research",
-      worker: "/tmp/configured-worker",
+      default: state.agentDir("default"),
+      research: state.agentDir("research"),
+      worker: state.agentDir("worker"),
     } as const;
     const builds = {
       default: createDeferred<{ agentDir: string; wrote: false }>(),
@@ -374,30 +447,43 @@ describe("prepared model runtime reload auth adoption", () => {
         : { agentDir: String(agentDir), wrote: false };
     });
 
-    mocks.mutationListener?.({ agentDir: agentDirs.worker, affectsInheritedStores: false });
-    mocks.mutationListener?.({ agentDir: agentDirs.research, affectsInheritedStores: false });
-    mocks.mutationListener?.({ affectsInheritedStores: true });
-    const dispatches = Object.fromEntries(
-      Object.keys(agentDirs).map((agentId) => [
-        agentId,
-        loadPublishedGatewayReplyDispatchRuntime({ agentId }),
-      ]),
-    ) as Record<keyof typeof agentDirs, Promise<unknown>>;
-    for (const dispatch of Object.values(dispatches)) {
-      void dispatch.catch(() => undefined);
+    let dispatches:
+      | Record<keyof typeof builds, ReturnType<typeof loadPublishedGatewayReplyDispatchRuntime>>
+      | undefined;
+    try {
+      mocks.mutationListener?.({ agentDir: agentDirs.worker, affectsInheritedStores: false });
+      mocks.mutationListener?.({ agentDir: agentDirs.research, affectsInheritedStores: false });
+      mocks.mutationListener?.({ affectsInheritedStores: true });
+      dispatches = Object.fromEntries(
+        Object.keys(agentDirs).map((agentId) => [
+          agentId,
+          loadPublishedGatewayReplyDispatchRuntime({ agentId }),
+        ]),
+      ) as Record<
+        keyof typeof agentDirs,
+        ReturnType<typeof loadPublishedGatewayReplyDispatchRuntime>
+      >;
+      for (const dispatch of Object.values(dispatches)) {
+        void dispatch.catch(() => undefined);
+      }
+      builds.default.resolve({ agentDir: agentDirs.default, wrote: false });
+      builds.worker.resolve({ agentDir: agentDirs.worker, wrote: false });
+      await vi.waitFor(() =>
+        expect(mocks.ensureOpenClawModelsJson.mock.calls.length).toBeGreaterThanOrEqual(6),
+      );
+
+      builds.research.reject(refreshError);
+
+      await expect(dispatches.default).rejects.toBe(refreshError);
+      await expect(dispatches.worker).rejects.toBe(refreshError);
+      await expect(dispatches.research).rejects.toBe(refreshError);
+      expect(mocks.warn).toHaveBeenCalledOnce();
+    } finally {
+      for (const agentId of Object.keys(builds) as Array<keyof typeof builds>) {
+        builds[agentId].resolve({ agentDir: agentDirs[agentId], wrote: false });
+      }
+      await Promise.allSettled(Object.values(dispatches ?? {}));
     }
-    builds.default.resolve({ agentDir: agentDirs.default, wrote: false });
-    builds.worker.resolve({ agentDir: agentDirs.worker, wrote: false });
-    await vi.waitFor(() =>
-      expect(mocks.ensureOpenClawModelsJson.mock.calls.length).toBeGreaterThanOrEqual(6),
-    );
-
-    builds.research.reject(refreshError);
-
-    await expect(dispatches.default).rejects.toBe(refreshError);
-    await expect(dispatches.worker).rejects.toBe(refreshError);
-    await expect(dispatches.research).rejects.toBe(refreshError);
-    expect(mocks.warn).toHaveBeenCalledOnce();
   });
 
   it("commits a successful owner when the final independent owner fails", async () => {
@@ -412,49 +498,61 @@ describe("prepared model runtime reload auth adoption", () => {
       events.push(event.phase);
     });
     mocks.ensureOpenClawModelsJson.mockImplementation(async (_config, agentDir) => {
-      if (agentDir === "/tmp/configured-worker") {
+      if (agentDir === state.agentDir("worker")) {
         return await workerBuild.promise;
       }
-      if (agentDir === "/tmp/configured-research") {
+      if (agentDir === state.agentDir("research")) {
         return await researchBuild.promise;
       }
       return { agentDir: String(agentDir), wrote: false };
     });
 
-    mocks.mutationListener?.({
-      agentDir: "/tmp/configured-worker",
-      affectsInheritedStores: false,
-    });
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(4));
-    const workerDispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
-    void workerDispatch.catch(() => undefined);
-    let workerSettled = false;
-    void workerDispatch.then(() => {
-      workerSettled = true;
-    });
-    mocks.mutationListener?.({
-      agentDir: "/tmp/configured-research",
-      affectsInheritedStores: false,
-    });
-    const researchDispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "research" });
-    void researchDispatch.catch(() => undefined);
-    workerBuild.resolve({ agentDir: "/tmp/configured-worker", wrote: false });
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(5));
-    await vi.waitFor(() => expect(workerSettled).toBe(true));
-    await expect(
-      Promise.race([researchDispatch.then(() => "settled"), Promise.resolve("pending")]),
-    ).resolves.toBe("pending");
-    expect(events).not.toContain("published");
-    researchBuild.reject(researchError);
+    let workerDispatch: ReturnType<typeof loadPublishedGatewayReplyDispatchRuntime> | undefined;
+    let researchDispatch: ReturnType<typeof loadPublishedGatewayReplyDispatchRuntime> | undefined;
+    try {
+      mocks.mutationListener?.({
+        agentDir: state.agentDir("worker"),
+        affectsInheritedStores: false,
+      });
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(4));
+      workerDispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
+      void workerDispatch.catch(() => undefined);
+      let workerSettled = false;
+      void workerDispatch.then(
+        () => {
+          workerSettled = true;
+        },
+        () => undefined,
+      );
+      mocks.mutationListener?.({
+        agentDir: state.agentDir("research"),
+        affectsInheritedStores: false,
+      });
+      researchDispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "research" });
+      void researchDispatch.catch(() => undefined);
+      workerBuild.resolve({ agentDir: state.agentDir("worker"), wrote: false });
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(5));
+      await vi.waitFor(() => expect(workerSettled).toBe(true));
+      await expect(
+        Promise.race([researchDispatch.then(() => "settled"), Promise.resolve("pending")]),
+      ).resolves.toBe("pending");
+      expect(events).not.toContain("published");
+      researchBuild.reject(researchError);
 
-    await expect(workerDispatch).resolves.toMatchObject({ agentId: "worker" });
-    await expect(researchDispatch).rejects.toBe(researchError);
-    await expect(loadPublishedGatewayReplyDispatchRuntime({ agentId: "research" })).rejects.toThrow(
-      "prepared reply dispatch runtime owner was not published for research",
-    );
-    expect(events).not.toContain("published");
-    expect(events.filter((phase) => phase === "failed")).toHaveLength(1);
-    unregister();
+      await expect(workerDispatch).resolves.toMatchObject({ agentId: "worker" });
+      await expect(researchDispatch).rejects.toBe(researchError);
+      await expect(
+        loadPublishedGatewayReplyDispatchRuntime({ agentId: "research" }),
+      ).rejects.toThrow("prepared reply dispatch runtime owner was not published for research");
+      expect(events).not.toContain("published");
+      expect(events.filter((phase) => phase === "failed")).toHaveLength(1);
+      unregister();
+    } finally {
+      workerBuild.resolve({ agentDir: state.agentDir("worker"), wrote: false });
+      researchBuild.resolve({ agentDir: state.agentDir("research"), wrote: false });
+      await Promise.allSettled([workerDispatch, researchDispatch]);
+      unregister();
+    }
   });
 
   it("isolates reply projection replacement failure to its component", async () => {
@@ -473,11 +571,11 @@ describe("prepared model runtime reload auth adoption", () => {
       });
 
     mocks.mutationListener?.({
-      agentDir: "/tmp/configured-worker",
+      agentDir: state.agentDir("worker"),
       affectsInheritedStores: false,
     });
     mocks.mutationListener?.({
-      agentDir: "/tmp/configured-research",
+      agentDir: state.agentDir("research"),
       affectsInheritedStores: false,
     });
     const workerDispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
@@ -488,7 +586,7 @@ describe("prepared model runtime reload auth adoption", () => {
     await expect(workerDispatch).rejects.toBe(projectionError);
     await expect(researchDispatch).resolves.toMatchObject({
       agentId: "research",
-      agentDir: "/tmp/configured-research",
+      agentDir: state.agentDir("research"),
     });
     await expect(loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" })).rejects.toThrow(
       "prepared reply dispatch runtime owner was not published for worker",
@@ -510,23 +608,38 @@ describe("prepared model runtime reload auth adoption", () => {
       .mockImplementationOnce(async () => await authBuild.promise)
       .mockImplementationOnce(async () => await configBuild.promise);
 
-    mocks.mutationListener?.({ agentDir: "/tmp/unused-agent", affectsInheritedStores: false });
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
-    const authWaiter = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
-    void authWaiter.catch(() => undefined);
-    const reload = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
-      gatewayLifecycle: true,
-    });
-    void reload.catch(() => undefined);
-    authBuild.reject(obsoleteAuthError);
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
-    await expect(
-      Promise.race([authWaiter.then(() => "settled"), Promise.resolve("pending")]),
-    ).resolves.toBe("pending");
+    let authWaiter: ReturnType<typeof loadPublishedGatewayReplyDispatchRuntime> | undefined;
+    let reload: ReturnType<typeof refreshPreparedModelRuntimeSnapshots> | undefined;
+    try {
+      mocks.mutationListener?.({
+        agentDir: state.agentDir("default"),
+        affectsInheritedStores: false,
+      });
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+      authWaiter = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+      void authWaiter.catch(() => undefined);
+      reload = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
+        gatewayLifecycle: true,
+      });
+      void reload.catch(() => undefined);
+      authBuild.reject(obsoleteAuthError);
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
+      await expect(
+        Promise.race([authWaiter.then(() => "settled"), Promise.resolve("pending")]),
+      ).resolves.toBe("pending");
 
-    configBuild.resolve({ agentDir: "/tmp/unused-agent", wrote: false });
-    await expect(reload).resolves.toBeUndefined();
-    await expect(authWaiter).resolves.toMatchObject({ config: replacementConfig });
-    expect(mocks.warn).not.toHaveBeenCalled();
+      configBuild.resolve({ agentDir: state.agentDir("default"), wrote: false });
+      await expect(reload).resolves.toBeUndefined();
+      await expect(authWaiter).resolves.toMatchObject({ config: replacementConfig });
+      expect(mocks.warn).not.toHaveBeenCalled();
+    } finally {
+      authBuild.resolve({ agentDir: state.agentDir("default"), wrote: false });
+      configBuild.resolve({ agentDir: state.agentDir("default"), wrote: false });
+      await Promise.allSettled([authWaiter, reload]);
+    }
   });
+});
+
+afterEach(async ({ task }) => {
+  await cleanupPreparedModelRuntimeHarness(state, task.result?.state === "fail");
 });

--- a/src/agents/prepared-model-runtime.reply-fallback.test.ts
+++ b/src/agents/prepared-model-runtime.reply-fallback.test.ts
@@ -1,6 +1,7 @@
 // Preserve module setup before modules that consume it.
 // oxfmt-ignore
 import {
+  cleanupPreparedModelRuntimeHarness,
   getPreparedModelRuntimeMocks,
   resetPreparedModelRuntimeHarness,
 } from "./prepared-model-runtime.test-harness.js";
@@ -16,6 +17,10 @@ import { listRuntimePluginIdsFromRegistry } from "../plugins/active-runtime-regi
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { createPluginRecord } from "../plugins/status.test-helpers.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
 import * as agentScope from "./agent-scope.js";
 import { resolveAgentRuntimePluginLoadPlan } from "./harness/runtime-plugin-load-plan.js";
 import { resolveModelCandidateChain } from "./model-fallback-candidates.js";
@@ -38,10 +43,12 @@ vi.mock("../auto-reply/reply/get-reply-run-execute.js", () => ({
 }));
 
 const mocks = getPreparedModelRuntimeMocks();
+let state: OpenClawTestState;
 
 describe("prepared reply fallback ownership", () => {
   beforeEach(async () => {
-    resetPreparedModelRuntimeHarness();
+    state = await createOpenClawTestState({ label: "prepared-model-runtime" });
+    resetPreparedModelRuntimeHarness(state);
     vi.clearAllMocks();
     const actual = await vi.importActual<typeof import("./agent-scope.js")>("./agent-scope.js");
     vi.spyOn(agentScope, "resolveAgentConfig").mockImplementation(actual.resolveAgentConfig);
@@ -187,4 +194,8 @@ describe("prepared reply fallback ownership", () => {
       expect(reply.execute).toHaveBeenCalledOnce();
     },
   );
+});
+
+afterEach(async ({ task }) => {
+  await cleanupPreparedModelRuntimeHarness(state, task.result?.state === "fail");
 });

--- a/src/agents/prepared-model-runtime.scoped-refresh.test.ts
+++ b/src/agents/prepared-model-runtime.scoped-refresh.test.ts
@@ -1,11 +1,16 @@
 // Preserve module setup before modules that consume it.
 // oxfmt-ignore
 import {
+  cleanupPreparedModelRuntimeHarness,
   getPreparedModelRuntimeMocks,
   resetPreparedModelRuntimeHarness,
 } from "./prepared-model-runtime.test-harness.js";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
 import { getPreparedModelRuntimeAuthStore } from "./prepared-model-runtime-auth.js";
 import {
   getPreparedModelRuntimeSnapshot,
@@ -13,9 +18,13 @@ import {
 } from "./prepared-model-runtime.js";
 
 const mocks = getPreparedModelRuntimeMocks();
+let state: OpenClawTestState;
 
 describe("prepared model runtime scoped refresh", () => {
-  beforeEach(() => resetPreparedModelRuntimeHarness());
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ label: "prepared-model-runtime" });
+    resetPreparedModelRuntimeHarness(state);
+  });
 
   it.each([false, true])(
     "retains catalog callbacks across scoped exec reloads (warmed: %s)",
@@ -39,14 +48,14 @@ describe("prepared model runtime scoped refresh", () => {
       const freeInput = {
         config: initialConfig,
         agentId: "free",
-        agentDir: "/tmp/configured-free",
-        inheritedAuthDir: "/tmp/unused-agent",
+        agentDir: state.agentDir("free"),
+        inheritedAuthDir: state.agentDir("default"),
         workspaceDir: "/tmp/workspace-free",
       };
       const proInput = {
         ...freeInput,
         agentId: "pro",
-        agentDir: "/tmp/configured-pro",
+        agentDir: state.agentDir("pro"),
         workspaceDir: "/tmp/workspace-pro",
       };
       // The harness stubs discovery, not the snapshot's catalog guards. Real worker retirement
@@ -156,10 +165,14 @@ describe("prepared model runtime scoped refresh", () => {
       getPreparedModelRuntimeSnapshot({
         config: nextConfig,
         agentId: "pro",
-        agentDir: "/tmp/configured-pro",
-        inheritedAuthDir: "/tmp/unused-agent",
+        agentDir: state.agentDir("pro"),
+        inheritedAuthDir: state.agentDir("default"),
         workspaceDir: "/tmp/workspace-pro",
       }),
     ).toMatchObject({ agentId: "pro", config: nextConfig });
   });
+});
+
+afterEach(async ({ task }) => {
+  await cleanupPreparedModelRuntimeHarness(state, task.result?.state === "fail");
 });

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -1,5 +1,6 @@
 import { vi } from "vitest";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import type { OpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import type { AuthStorageData } from "./sessions/auth-storage.js";
 
 type LoadStaticCatalog =
@@ -52,8 +53,8 @@ const preparedModelRuntimeMocks = vi.hoisted(() => ({
   createStaticCatalogResolver: vi.fn<CreateStaticCatalogResolver>(),
   discoverAuthStorage: vi.fn((..._args: unknown[]) => undefined as unknown),
   discoverModels: vi.fn(),
-  ensureOpenClawModelsJson: vi.fn(async (..._args: unknown[]) => ({
-    agentDir: "/tmp/agent",
+  ensureOpenClawModelsJson: vi.fn(async (...args: unknown[]) => ({
+    agentDir: String(args[1]),
     wrote: false,
   })),
   loadAgentRuntimePluginRegistryHandle: vi.fn(),
@@ -181,16 +182,14 @@ const agentScopeMocks = vi.hoisted(() => ({
     }
     return preparedModelRuntimeMocks.configuredAgentIds;
   },
-  resolveAgentDir: (_config: unknown, agentId: string) =>
-    preparedModelRuntimeMocks.configuredAgentDirs.get(agentId) ??
-    (agentId === "default" ? "/tmp/unused-agent" : `/tmp/configured-${agentId}`),
+  resolveAgentDir: vi.fn<(_config: unknown, agentId: string) => string>(),
   resolveAgentWorkspaceDir: (_config: unknown, agentId: string) =>
     preparedModelRuntimeMocks.configuredWorkspaces.get(agentId) ??
     (agentId === "default" ? "/tmp/unused-workspace" : `/tmp/workspace-${agentId}`),
   tryResolveConfiguredAgentWorkspaceDir: () => "/tmp/unused-workspace",
   tryResolveSystemAgentWorkspaceDir: () => "/tmp/unused-workspace",
   resolveAmbientOwnerAgentId: () => "default",
-  resolveDefaultAgentDir: () => "/tmp/unused-agent",
+  resolveDefaultAgentDir: vi.fn<() => string>(),
   resolveDefaultAgentId: () => "default",
   resolveAgentConfig: (config: { agents?: { list?: Array<{ id?: string }> } }, agentId: string) =>
     config.agents?.list?.find((entry) => entry.id === agentId),
@@ -214,7 +213,7 @@ vi.mock("./agent-scope-config.js", async (importOriginal) => ({
 }));
 
 vi.mock("./legacy-inherited-auth-dir.js", () => ({
-  resolveLegacyInheritedAuthDir: () => "/tmp/unused-agent",
+  resolveLegacyInheritedAuthDir: () => agentScopeMocks.resolveDefaultAgentDir(),
 }));
 
 vi.mock("./auth-profiles/runtime-materializations.js", () => ({
@@ -347,8 +346,17 @@ export function getPreparedModelRuntimeTestApi(): PreparedModelRuntimeTestApi {
   ] as PreparedModelRuntimeTestApi;
 }
 
-export function resetPreparedModelRuntimeHarness(): void {
+export function resetPreparedModelRuntimeHarness(state: OpenClawTestState): void {
   getPreparedModelRuntimeTestApi().resetPreparedModelRuntimeSnapshotsForTest();
+  agentScopeMocks.resolveAgentDir
+    .mockReset()
+    .mockImplementation(
+      (_config, agentId) =>
+        preparedModelRuntimeMocks.configuredAgentDirs.get(agentId) ?? state.agentDir(agentId),
+    );
+  agentScopeMocks.resolveDefaultAgentDir
+    .mockReset()
+    .mockImplementation(() => agentScopeMocks.resolveAgentDir(undefined, "default"));
   preparedModelRuntimeMocks.authStorage.getAll.mockReset().mockReturnValue({
     custom: { type: "api_key", key: "test-key" },
   });
@@ -369,7 +377,10 @@ export function resetPreparedModelRuntimeHarness(): void {
   preparedModelRuntimeMocks.discoverModels.mockReset();
   preparedModelRuntimeMocks.ensureOpenClawModelsJson
     .mockReset()
-    .mockResolvedValue({ agentDir: "/tmp/agent", wrote: false });
+    .mockImplementation(async (_config, agentDir) => ({
+      agentDir: String(agentDir),
+      wrote: false,
+    }));
   preparedModelRuntimeMocks.loadAgentRuntimePluginRegistryHandle
     .mockReset()
     .mockReturnValue(createEmptyPluginRegistry());
@@ -397,4 +408,19 @@ export function resetPreparedModelRuntimeHarness(): void {
   preparedModelRuntimeMocks.configuredAgentIdsError = undefined;
   preparedModelRuntimeMocks.configuredAgentDirs.clear();
   preparedModelRuntimeMocks.configuredWorkspaces.clear();
+}
+
+export async function cleanupPreparedModelRuntimeHarness(
+  state: OpenClawTestState,
+  failed: boolean,
+): Promise<void> {
+  // A failed assertion may precede an async owner's terminal join. Reset is not a drain;
+  // keep that namespace alive rather than deleting files a late build may still capture.
+  if (failed) {
+    state.restoreEnv();
+    console.warn(`Retained prepared-model fixture after failed test: ${state.root}`);
+    return;
+  }
+  getPreparedModelRuntimeTestApi().resetPreparedModelRuntimeSnapshotsForTest();
+  await state.cleanup();
 }

--- a/src/agents/prepared-model-runtime.test.ts
+++ b/src/agents/prepared-model-runtime.test.ts
@@ -1,14 +1,20 @@
 // Preserve module setup before modules that consume it.
 // oxfmt-ignore
 import {
+  cleanupPreparedModelRuntimeHarness,
   getPreparedModelRuntimeMocks,
   resetPreparedModelRuntimeHarness,
 } from "./prepared-model-runtime.test-harness.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { requireActivePluginRegistry } from "../plugins/runtime.js";
 import { getPluginRuntimeLoadContext } from "../plugins/runtime/load-context.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
 import { getPreparedModelRuntimeAuthStore } from "./prepared-model-runtime-auth.js";
 import { prepareWorkspacePluginRegistries } from "./prepared-model-runtime.inbound-registry.js";
 import {
@@ -25,10 +31,12 @@ import {
 } from "./prepared-model-runtime.js";
 
 const mocks = getPreparedModelRuntimeMocks();
+let state: OpenClawTestState;
 
 describe("prepared model runtime snapshots", () => {
-  beforeEach(() => {
-    resetPreparedModelRuntimeHarness();
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ label: "prepared-model-runtime" });
+    resetPreparedModelRuntimeHarness(state);
   });
 
   it("materializes Claude CLI thinking capabilities on the prepared logical row", async () => {
@@ -87,7 +95,7 @@ describe("prepared model runtime snapshots", () => {
     const snapshot = await publishPreparedModelRuntimeSnapshot({
       agentId: "main",
       config,
-      agentDir: "/tmp/prepared-model-runtime-claude-cli-capabilities",
+      agentDir: state.agentDir("claude-cli-capabilities"),
     });
     for (const modelId of modelIds) {
       expect(
@@ -106,7 +114,7 @@ describe("prepared model runtime snapshots", () => {
       {
         config: {},
         agentId: "main",
-        agentDir: "/tmp/selected-metadata-agent",
+        agentDir: state.agentDir("selected-metadata-agent"),
         workspaceDir: "/tmp/selected-metadata-workspace",
         loadRuntimePlugins: true,
         runtimePluginSelections: [{ provider: "selected", modelId: "model" }],
@@ -149,8 +157,8 @@ describe("prepared model runtime snapshots", () => {
     const leasePending = acquireReadOnlyPreparedModelRuntime({
       agentId: "openclaw",
       config: stagedConfig,
-      agentDir: "/tmp/setup-probe-agent",
-      inheritedAuthDir: "/tmp/setup-probe-agent",
+      agentDir: state.agentDir("setup-probe-agent"),
+      inheritedAuthDir: state.agentDir("setup-probe-agent"),
       workspaceDir: "/tmp/setup-probe-workspace",
       runtimePluginSelections: [{ provider: "openai", modelId: "gpt-5.6", runtime: "codex" }],
     });
@@ -164,7 +172,7 @@ describe("prepared model runtime snapshots", () => {
     expect(lease.snapshot).toMatchObject({
       agentId: "openclaw",
       config: stagedConfig,
-      agentDir: "/tmp/setup-probe-agent",
+      agentDir: state.agentDir("setup-probe-agent"),
       workspaceDir: "/tmp/setup-probe-workspace",
       pluginRegistry: expect.any(Object),
     });
@@ -201,7 +209,7 @@ describe("prepared model runtime snapshots", () => {
 
   it("reactivates a standalone read-only owner after a publication boundary", async () => {
     const input = {
-      agentDir: "/tmp/prepared-model-runtime-read-only-reactivation",
+      agentDir: state.agentDir("read-only-reactivation"),
       config: {},
       readOnly: true,
     };
@@ -219,26 +227,32 @@ describe("prepared model runtime snapshots", () => {
 
   it("never returns a standalone generation invalidated while it is building", async () => {
     const input = {
-      agentDir: "/tmp/prepared-model-runtime-standalone-build-race",
+      agentDir: state.agentDir("standalone-build-race"),
       config: {},
     };
+    const finishFirstBuildGate = createDeferred();
     let finishFirstBuild!: () => void;
-    mocks.ensureOpenClawModelsJson.mockImplementationOnce(
-      async () =>
-        await new Promise<{ agentDir: string; wrote: boolean }>((resolve) => {
-          finishFirstBuild = () => resolve({ agentDir: input.agentDir, wrote: false });
-        }),
-    );
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(async (_config, targetDir) => {
+      finishFirstBuild = () => finishFirstBuildGate.resolve();
+      await finishFirstBuildGate.promise;
+      return { agentDir: String(targetDir), wrote: false };
+    });
 
-    const activation = activateStandalonePreparedModelRuntime(input);
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce());
-    markPreparedModelRuntimeSnapshotsStale("test in-flight standalone publication");
-    finishFirstBuild();
+    let activation: ReturnType<typeof activateStandalonePreparedModelRuntime> | undefined;
+    try {
+      activation = activateStandalonePreparedModelRuntime(input);
+      await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce());
+      markPreparedModelRuntimeSnapshotsStale("test in-flight standalone publication");
+      finishFirstBuild();
 
-    const published = await activation;
-    expect(published).toBeDefined();
-    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
-    await expect(prepareModelRuntimeSnapshot(input)).resolves.toBe(published);
+      const published = await activation;
+      expect(published).toBeDefined();
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
+      await expect(prepareModelRuntimeSnapshot(input)).resolves.toBe(published);
+    } finally {
+      finishFirstBuildGate.resolve();
+      await Promise.allSettled([activation]);
+    }
   });
 
   it("loads runtime plugins before discovering an immutable generation", async () => {
@@ -249,7 +263,7 @@ describe("prepared model runtime snapshots", () => {
     });
     const snapshot = await publishPreparedModelRuntimeSnapshot({
       config: {},
-      agentDir: "/tmp/prepared-model-runtime-plugin-order",
+      agentDir: state.agentDir("plugin-order"),
       workspaceDir: "/tmp/prepared-model-runtime-plugin-workspace",
     });
 
@@ -271,7 +285,7 @@ describe("prepared model runtime snapshots", () => {
     const config = {};
     const snapshot = await publishPreparedModelRuntimeSnapshot({
       config,
-      agentDir: "/tmp/prepared-model-runtime-explicit-env",
+      agentDir: state.agentDir("explicit-env"),
       env,
     });
 
@@ -282,11 +296,11 @@ describe("prepared model runtime snapshots", () => {
 
     expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledWith(
       config,
-      "/tmp/prepared-model-runtime-explicit-env",
+      state.agentDir("explicit-env"),
       expect.objectContaining({ env }),
     );
     expect(mocks.discoverAuthStorage).toHaveBeenCalledWith(
-      "/tmp/prepared-model-runtime-explicit-env",
+      state.agentDir("explicit-env"),
       expect.objectContaining({ env }),
     );
     expect(mocks.buildPreparedModelCatalogSnapshot).toHaveBeenCalledWith(
@@ -303,12 +317,12 @@ describe("prepared model runtime snapshots", () => {
         }) => void;
       };
       options.onProviderCatalogOutcome?.({ provider: "openai", status: "auth-rejected" });
-      return { agentDir: "/tmp/provider-outcome-agent", wrote: false };
+      return { agentDir: state.agentDir("provider-outcome-agent"), wrote: false };
     });
 
     const snapshot = await publishPreparedModelRuntimeSnapshot({
       config: {},
-      agentDir: "/tmp/provider-outcome-agent",
+      agentDir: state.agentDir("provider-outcome-agent"),
     });
 
     expect(snapshot.modelCatalog.providerOutcomes).toEqual([
@@ -349,12 +363,12 @@ describe("prepared model runtime snapshots", () => {
     await publishPreparedModelRuntimeSnapshot({
       agentId: "selected",
       config,
-      agentDir: "/tmp/prepared-model-runtime-selected-provider-scope",
+      agentDir: state.agentDir("selected-provider-scope"),
     });
 
     expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledWith(
       config,
-      "/tmp/prepared-model-runtime-selected-provider-scope",
+      state.agentDir("selected-provider-scope"),
       expect.objectContaining({
         providerDiscoveryProviderIds: ["anthropic", "custom", "openai", "selected-runtime", "vllm"],
       }),
@@ -382,7 +396,7 @@ describe("prepared model runtime snapshots", () => {
 
     const snapshot = await publishPreparedModelRuntimeSnapshot({
       config: {},
-      agentDir: "/tmp/prepared-model-runtime-static-catalog",
+      agentDir: state.agentDir("static-catalog"),
       workspaceDir: "/tmp/prepared-model-runtime-static-workspace",
     });
 
@@ -442,7 +456,7 @@ describe("prepared model runtime snapshots", () => {
     const snapshot = await publishPreparedModelRuntimeSnapshot({
       agentId: "qa",
       config,
-      agentDir: "/tmp/prepared-model-runtime-manifest-qa",
+      agentDir: state.agentDir("manifest-qa"),
       workspaceDir: "/tmp/prepared-model-runtime-manifest-workspace",
     });
 
@@ -512,7 +526,7 @@ describe("prepared model runtime snapshots", () => {
 
     const snapshot = await publishPreparedModelRuntimeSnapshot({
       config: { agents: { defaults: { model: { primary: "nvidia/nemotron-static" } } } },
-      agentDir: "/tmp/prepared-model-runtime-configured-static",
+      agentDir: state.agentDir("configured-static"),
       workspaceDir: "/tmp/prepared-model-runtime-configured-static-workspace",
     });
 
@@ -556,7 +570,7 @@ describe("prepared model runtime snapshots", () => {
           },
         },
       },
-      agentDir: "/tmp/prepared-model-runtime-inline",
+      agentDir: state.agentDir("inline"),
     });
 
     expect(snapshot.inlineProviderModels).toMatchObject([
@@ -587,7 +601,7 @@ describe("prepared model runtime snapshots", () => {
 
     const snapshot = await publishPreparedModelRuntimeSnapshot({
       config: {},
-      agentDir: "/tmp/prepared-model-runtime-unsupported-api",
+      agentDir: state.agentDir("unsupported-api"),
     });
 
     expect(structuredClone(snapshot.modelCatalog.staticEntries)).toEqual([
@@ -604,7 +618,7 @@ describe("prepared model runtime snapshots", () => {
   });
 
   it("stales a published owner synchronously before replacement", async () => {
-    const input = { config: {}, agentDir: "/tmp/prepared-model-runtime-stale" };
+    const input = { config: {}, agentDir: state.agentDir("stale") };
     await publishPreparedModelRuntimeSnapshot(input);
 
     markPreparedModelRuntimeSnapshotsStale("test publication boundary");
@@ -619,8 +633,8 @@ describe("prepared model runtime snapshots", () => {
     const secondConfig = { agents: { defaults: { model: "openai/gpt-5.5" } } };
     const input = {
       agentId: "default",
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
       workspaceDir: "/tmp/unused-workspace",
     };
     await refreshPreparedModelRuntimeSnapshots(firstConfig);
@@ -653,8 +667,8 @@ describe("prepared model runtime snapshots", () => {
     });
     const read = loadPreparedModelRuntimeSnapshot({
       agentId: "default",
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
       workspaceDir: "/tmp/dynamic-read-only-workspace",
       config: initialConfig,
       readOnly: true,
@@ -665,8 +679,8 @@ describe("prepared model runtime snapshots", () => {
     expect(
       getPreparedModelRuntimeSnapshot({
         agentId: "default",
-        agentDir: "/tmp/unused-agent",
-        inheritedAuthDir: "/tmp/unused-agent",
+        agentDir: state.agentDir("default"),
+        inheritedAuthDir: state.agentDir("default"),
         config: latestConfig,
       }),
     ).toBeUndefined();
@@ -695,8 +709,8 @@ describe("prepared model runtime snapshots", () => {
     );
     const read = prepareModelRuntimeSnapshot({
       agentId: "default",
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
       workspaceDir: "/tmp/unused-workspace",
       config: latestConfig,
     });
@@ -712,13 +726,13 @@ describe("prepared model runtime snapshots", () => {
 
     await expect(
       activateStandalonePreparedModelRuntime({
-        agentDir: "/tmp/prepared-model-runtime-read-only-draft",
+        agentDir: state.agentDir("read-only-draft"),
         config: draftConfig,
         readOnly: true,
       }),
     ).resolves.toMatchObject({ config: draftConfig });
     expect(mocks.discoverAuthStorage).toHaveBeenCalledWith(
-      "/tmp/prepared-model-runtime-read-only-draft",
+      state.agentDir("read-only-draft"),
       expect.objectContaining({ readOnly: true }),
     );
     expect(mocks.discoverModels).toHaveBeenCalledOnce();
@@ -729,7 +743,7 @@ describe("prepared model runtime snapshots", () => {
 
   it("builds credential-free command owners separately from runtime owners", async () => {
     const config = {};
-    const agentDir = "/tmp/prepared-model-runtime-credential-free";
+    const agentDir = state.agentDir("credential-free");
     await publishPreparedModelRuntimeSnapshot({ config, agentDir });
 
     const credentialFree = await publishPreparedModelRuntimeSnapshot({
@@ -746,7 +760,7 @@ describe("prepared model runtime snapshots", () => {
 
   it("reuses one lifecycle-owned snapshot without rediscovering files", async () => {
     const config = {};
-    const input = { config, agentDir: "/tmp/prepared-model-runtime-reuse" };
+    const input = { config, agentDir: state.agentDir("reuse") };
 
     const first = await publishPreparedModelRuntimeSnapshot(input);
     const second = await prepareModelRuntimeSnapshot(input);
@@ -794,7 +808,7 @@ describe("prepared model runtime snapshots", () => {
 
       const snapshot = await publishPreparedModelRuntimeSnapshot({
         config,
-        agentDir: "/tmp/prepared-model-runtime-cli-startup",
+        agentDir: state.agentDir("cli-startup"),
       });
 
       const discoveryOptions = mocks.discoverAuthStorage.mock.calls[0]?.[1] as {
@@ -806,7 +820,7 @@ describe("prepared model runtime snapshots", () => {
   );
 
   it("ignores request config identity until lifecycle publication", async () => {
-    const agentDir = "/tmp/prepared-model-runtime-request-config";
+    const agentDir = state.agentDir("request-config");
     const initialConfig = {};
     const first = await publishPreparedModelRuntimeSnapshot({ config: initialConfig, agentDir });
 
@@ -817,7 +831,7 @@ describe("prepared model runtime snapshots", () => {
   });
 
   it("reuses read-only owners for equivalent config clones but rejects projections", async () => {
-    const agentDir = "/tmp/prepared-model-runtime-read-only-config";
+    const agentDir = state.agentDir("read-only-config");
     const config = { agents: { defaults: { model: "openai/gpt-5.5" } } };
     const first = await publishPreparedModelRuntimeSnapshot({ config, agentDir, readOnly: true });
 
@@ -845,7 +859,7 @@ describe("prepared model runtime snapshots", () => {
   });
 
   it("keeps synchronous read-only snapshots isolated by config", async () => {
-    const agentDir = "/tmp/prepared-model-runtime-sync-read-only-config";
+    const agentDir = state.agentDir("sync-read-only-config");
     const config = { agents: { defaults: { model: "openai/gpt-5.5" } } };
     const snapshot = await publishPreparedModelRuntimeSnapshot({
       config,
@@ -873,8 +887,8 @@ describe("prepared model runtime snapshots", () => {
     const input = {
       agentId: "worker",
       config: {},
-      agentDir: "/tmp/configured-worker",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("worker"),
+      inheritedAuthDir: state.agentDir("default"),
       workspaceDir: "/tmp/workspace-worker",
     };
     await publishPreparedModelRuntimeSnapshot(input, { provenance: "configured" });
@@ -896,7 +910,7 @@ describe("prepared model runtime snapshots", () => {
 
     const snapshot = await publishPreparedModelRuntimeSnapshot({
       config: explicitConfig,
-      agentDir: "/tmp/prepared-model-runtime-late-owner",
+      agentDir: state.agentDir("late-owner"),
     });
 
     expect(snapshot.config).toBe(explicitConfig);
@@ -908,7 +922,7 @@ describe("prepared model runtime snapshots", () => {
   });
 
   it("rebuilds a standalone owner when its explicit config changes", async () => {
-    const agentDir = "/tmp/prepared-model-runtime-standalone-config";
+    const agentDir = state.agentDir("standalone-config");
     const firstConfig = {};
     const secondConfig = { agents: { defaults: { model: "openai/gpt-5.5" } } };
 
@@ -926,7 +940,7 @@ describe("prepared model runtime snapshots", () => {
   });
 
   it("keeps each standalone activation bound to its published generation", async () => {
-    const agentDir = "/tmp/prepared-model-runtime-overlapping-standalone";
+    const agentDir = state.agentDir("overlapping-standalone");
     const firstConfig = {};
     const secondConfig = { agents: { defaults: { model: "openai/gpt-5.5" } } };
 
@@ -936,39 +950,6 @@ describe("prepared model runtime snapshots", () => {
     expect(first?.config).toBe(firstConfig);
     expect(second?.config).toBe(secondConfig);
     expect(first).not.toBe(second);
-  });
-
-  it("serializes conflicting standalone activations for one owner", async () => {
-    const agentDir = "/tmp/prepared-model-runtime-concurrent-standalone";
-    const firstConfig = {};
-    const secondConfig = {};
-    let finishFirstBuild!: () => void;
-    mocks.ensureOpenClawModelsJson.mockImplementationOnce(
-      async () =>
-        await new Promise<{ agentDir: string; wrote: boolean }>((resolve) => {
-          finishFirstBuild = () => resolve({ agentDir, wrote: false });
-        }),
-    );
-
-    const firstActivation = activateStandalonePreparedModelRuntime({
-      config: firstConfig,
-      agentDir,
-    });
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce());
-    const secondActivation = activateStandalonePreparedModelRuntime({
-      config: secondConfig,
-      agentDir,
-    });
-
-    await Promise.resolve();
-    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
-    finishFirstBuild();
-
-    const [first, second] = await Promise.all([firstActivation, secondActivation]);
-    expect(first?.config).toBe(firstConfig);
-    expect(second?.config).toBe(secondConfig);
-    expect(first).not.toBe(second);
-    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
   });
 
   it("does not discover a missing owner from a request lookup", async () => {
@@ -984,7 +965,7 @@ describe("prepared model runtime snapshots", () => {
   it("deduplicates standalone activation while publishing later owners", async () => {
     const input = {
       config: {},
-      agentDir: "/tmp/prepared-model-runtime-standalone",
+      agentDir: state.agentDir("standalone"),
       workspaceDir: "/tmp/prepared-model-runtime-standalone-workspace",
     };
 
@@ -992,7 +973,7 @@ describe("prepared model runtime snapshots", () => {
     await activateStandalonePreparedModelRuntime(input);
     await activateStandalonePreparedModelRuntime({
       ...input,
-      agentDir: "/tmp/prepared-model-runtime-standalone-second",
+      agentDir: state.agentDir("standalone-second"),
     });
     const replacementInput = { ...input, workspaceDir: "/tmp/standalone-replacement-workspace" };
     await activateStandalonePreparedModelRuntime(replacementInput);
@@ -1018,9 +999,9 @@ describe("prepared model runtime snapshots", () => {
     expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
     await expect(
       prepareModelRuntimeSnapshot({
-        agentDir: "/tmp/unused-agent",
+        agentDir: state.agentDir("default"),
         config: latestConfig,
-        inheritedAuthDir: "/tmp/unused-agent",
+        inheritedAuthDir: state.agentDir("default"),
         workspaceDir: "/tmp/unused-workspace",
       }),
     ).resolves.toMatchObject({ config: latestConfig });
@@ -1032,41 +1013,49 @@ describe("prepared model runtime snapshots", () => {
     const skippedConfig = { agents: { defaults: { model: "openai/gpt-5.4" } } };
     const latestConfig = { agents: { defaults: { model: "openai/gpt-5.5" } } };
     await refreshPreparedModelRuntimeSnapshots(initialConfig);
+    const finishLatestBuildGate = createDeferred();
     let finishLatestBuild: (() => void) | undefined;
-    mocks.ensureOpenClawModelsJson.mockImplementationOnce(
-      async () =>
-        await new Promise<{ agentDir: string; wrote: boolean }>((resolve) => {
-          finishLatestBuild = () => resolve({ agentDir: "/tmp/unused-agent", wrote: false });
-        }),
-    );
-
-    markPreparedModelRuntimeSnapshotsStale("test overlapping config commit", {
-      waitForReplacement: true,
-    });
-    const skipped = refreshPreparedModelRuntimeSnapshots(skippedConfig);
-    const latest = refreshPreparedModelRuntimeSnapshots(latestConfig);
-    const read = prepareModelRuntimeSnapshot({
-      agentId: "default",
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
-      workspaceDir: "/tmp/unused-workspace",
-      config: latestConfig,
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(async (_config, targetDir) => {
+      finishLatestBuild = () => finishLatestBuildGate.resolve();
+      await finishLatestBuildGate.promise;
+      return { agentDir: String(targetDir), wrote: false };
     });
 
-    await skipped;
-    await expect(
-      Promise.race([
-        read.then(
-          () => "settled",
-          () => "settled",
-        ),
-        Promise.resolve("pending"),
-      ]),
-    ).resolves.toBe("pending");
-    await vi.waitFor(() => expect(finishLatestBuild).toEqual(expect.any(Function)));
-    finishLatestBuild?.();
-    await latest;
-    await expect(read).resolves.toMatchObject({ config: latestConfig });
+    let skipped: ReturnType<typeof refreshPreparedModelRuntimeSnapshots> | undefined;
+    let latest: ReturnType<typeof refreshPreparedModelRuntimeSnapshots> | undefined;
+    let read: ReturnType<typeof prepareModelRuntimeSnapshot> | undefined;
+    try {
+      markPreparedModelRuntimeSnapshotsStale("test overlapping config commit", {
+        waitForReplacement: true,
+      });
+      skipped = refreshPreparedModelRuntimeSnapshots(skippedConfig);
+      latest = refreshPreparedModelRuntimeSnapshots(latestConfig);
+      read = prepareModelRuntimeSnapshot({
+        agentId: "default",
+        agentDir: state.agentDir("default"),
+        inheritedAuthDir: state.agentDir("default"),
+        workspaceDir: "/tmp/unused-workspace",
+        config: latestConfig,
+      });
+
+      await skipped;
+      await expect(
+        Promise.race([
+          read.then(
+            () => "settled",
+            () => "settled",
+          ),
+          Promise.resolve("pending"),
+        ]),
+      ).resolves.toBe("pending");
+      await vi.waitFor(() => expect(finishLatestBuild).toEqual(expect.any(Function)));
+      finishLatestBuildGate.resolve();
+      await latest;
+      await expect(read).resolves.toMatchObject({ config: latestConfig });
+    } finally {
+      finishLatestBuildGate.resolve();
+      await Promise.allSettled([skipped, latest, read]);
+    }
   });
 
   it("cancels a queued generation at an external publication boundary", async () => {
@@ -1078,4 +1067,8 @@ describe("prepared model runtime snapshots", () => {
 
     expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
   });
+});
+
+afterEach(async ({ task }) => {
+  await cleanupPreparedModelRuntimeHarness(state, task.result?.state === "fail");
 });

--- a/src/gateway/server-chat-metadata-lifecycle.integration.test.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.integration.test.ts
@@ -1,6 +1,7 @@
 // Preserve module setup before modules that consume it.
 // oxfmt-ignore
 import {
+  cleanupPreparedModelRuntimeHarness,
   getPreparedModelRuntimeMocks,
   resetPreparedModelRuntimeHarness,
 } from "../agents/prepared-model-runtime.test-harness.js";
@@ -20,6 +21,10 @@ import {
   setActivePluginRegistry,
 } from "../plugins/runtime.js";
 import { createDeferredCore } from "../shared/deferred.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
 import { createGatewayChatMetadataLifecycle } from "./server-chat-metadata-lifecycle.js";
 import {
   buildModelsListResult,
@@ -36,6 +41,7 @@ import {
 import type { GatewayPostReadySidecarHandle } from "./server-startup-post-attach.js";
 
 const mocks = getPreparedModelRuntimeMocks();
+let state: OpenClawTestState;
 const config = {
   agents: {
     defaults: {
@@ -59,9 +65,10 @@ const context = {
 } as unknown as GatewayRequestContext;
 let sidecars: GatewayPostReadySidecarHandle[] = [];
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.stubEnv("OPENAI_API_KEY", "");
-  resetPreparedModelRuntimeHarness();
+  state = await createOpenClawTestState({ label: "prepared-model-runtime" });
+  resetPreparedModelRuntimeHarness(state);
   mocks.configuredAgentIds = ["main"];
   mocks.authStorage.getAll.mockReturnValue({
     openai: {
@@ -134,11 +141,12 @@ function configureHarnessOwnedUnresolvedAuth() {
   };
 }
 
-afterEach(async () => {
-  vi.unstubAllEnvs();
+afterEach(async ({ task }) => {
   for (const sidecar of sidecars) {
     await sidecar.stop();
   }
+  await cleanupPreparedModelRuntimeHarness(state, task.result?.state === "fail");
+  vi.unstubAllEnvs();
 });
 
 async function createLifecycle(getConfig: () => OpenClawConfig = () => config) {
@@ -261,6 +269,7 @@ describe("gateway chat metadata lifecycle composition", () => {
       });
       const entered = createDeferredCore();
       const resume = createDeferredCore();
+      let result: ReturnType<typeof buildModelsListResult> | undefined;
       try {
         await publishOwner(nativeConfig);
         const owner = getPreparedModelCatalogOwnerSnapshot({
@@ -303,7 +312,7 @@ describe("gateway chat metadata lifecycle composition", () => {
           },
           catalogProjector: projector,
         };
-        const result = buildModelsListResult(request);
+        result = buildModelsListResult(request);
         await entered.promise;
         ready = !initialReady;
         resume.resolve();
@@ -332,6 +341,7 @@ describe("gateway chat metadata lifecycle composition", () => {
         expect(loadModelCatalog).not.toHaveBeenCalled();
       } finally {
         resume.resolve();
+        await Promise.allSettled([result]);
         restoreActivePluginRegistrySnapshot(previousRegistry);
       }
     },
@@ -376,7 +386,7 @@ describe("gateway chat metadata lifecycle composition", () => {
         expect(scope).toMatchObject({
           config: nativeConfig,
           agentId: "main",
-          agentDir: "/tmp/configured-main",
+          agentDir: state.agentDir("main"),
           workspaceDir: "/tmp/workspace-main",
           provider: "openai",
           modelId: "codex-latest",
@@ -620,7 +630,7 @@ describe("gateway chat metadata lifecycle composition", () => {
         },
       } as EmbeddedRunAttemptResult,
       provider: "openai",
-      agentDir: "/tmp/configured-main",
+      agentDir: state.agentDir("main"),
       modelId: "gpt-5.4",
       modelApi: "openai-chatgpt-responses",
       modelBaseUrl: "https://chatgpt.com/backend-api/codex",
@@ -647,7 +657,7 @@ describe("gateway chat metadata lifecycle composition", () => {
     await vi.waitFor(async () => await expectAvailable(lifecycle));
 
     revokeRuntimeAuthMaterializations({
-      agentDir: "/tmp/configured-main",
+      agentDir: state.agentDir("main"),
       provider: "openai",
       runtimeOwnerId: "codex",
     });
@@ -684,7 +694,7 @@ describe("gateway chat metadata lifecycle composition", () => {
       },
       attempt: {} as EmbeddedRunAttemptResult,
       provider: "openai",
-      agentDir: "/tmp/configured-main",
+      agentDir: state.agentDir("main"),
       modelId: "gpt-5.4",
       modelApi: "openai-responses",
       modelBaseUrl: "https://api.openai.com/v1",
@@ -713,7 +723,7 @@ describe("gateway chat metadata lifecycle composition", () => {
     );
 
     revokeRuntimeAuthMaterializations({
-      agentDir: "/tmp/configured-main",
+      agentDir: state.agentDir("main"),
       provider: "openai",
       runtimeOwnerId: "codex",
     });

--- a/src/tui/embedded-prepared-runtime.test.ts
+++ b/src/tui/embedded-prepared-runtime.test.ts
@@ -1,18 +1,25 @@
 // Preserve module setup before modules that consume it.
 // oxfmt-ignore
 import {
+  cleanupPreparedModelRuntimeHarness,
   getPreparedModelRuntimeMocks,
   resetPreparedModelRuntimeHarness,
 } from "../agents/prepared-model-runtime.test-harness.js";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { acquireAgentRunPreparedModelRuntime } from "../agents/prepared-model-runtime.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
 import { EmbeddedPreparedModelRuntimeHost } from "./embedded-prepared-runtime.js";
 
 const mocks = getPreparedModelRuntimeMocks();
+let state: OpenClawTestState;
 
 describe("EmbeddedPreparedModelRuntimeHost", () => {
-  beforeEach(() => {
-    resetPreparedModelRuntimeHarness();
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ label: "prepared-model-runtime" });
+    resetPreparedModelRuntimeHarness(state);
   });
 
   it("reuses its configured publication across two actual run admissions", async () => {
@@ -25,8 +32,8 @@ describe("EmbeddedPreparedModelRuntimeHost", () => {
     const input = {
       agentId: "default",
       config,
-      agentDir: "/tmp/unused-agent",
-      inheritedAuthDir: "/tmp/unused-agent",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
       workspaceDir: "/tmp/unused-workspace",
       runtimePluginSelections: [{ provider: "openai", modelId: "gpt-5.5", agentId: "default" }],
     };
@@ -38,4 +45,8 @@ describe("EmbeddedPreparedModelRuntimeHost", () => {
     expect(second.snapshot).toBe(first.snapshot);
     expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
   });
+});
+
+afterEach(async ({ task }) => {
+  await cleanupPreparedModelRuntimeHarness(state, task.result?.state === "fail");
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where prepared-model runtime tests could read shared temporary files even though model discovery was mocked. Native `models.json` capture and the read-only SQLite catalog reader still consumed fabricated agent-directory paths, allowing unrelated filesystem contents to influence tests. Fixture teardown could also run before a timed-out build actually finished.

This is a maintainer-requested test-isolation repair discovered during broader QA, not a production behavior change or an attempt to hide a failing assertion.

## Why This Change Was Made

The shared harness now takes the existing `OpenClawTestState` owner, and all eleven consuming suites use its canonical agent paths. This preserves the intentional `default` agent identity, explicit shared-directory cases, exact model-file bytes, and OAuth hook-generation identities. Deferred tests release and join their actual work before cleanup; timeout coverage waits for build completion rather than treating the public timeout rejection as a drain. Failed tests retain their fixture namespace conservatively.

The regression guards real native file capture and the read-only database entry point before delegation. Broader filesystem mocks and production guards would conceal the fixture producer defect, so neither was added. Existing lifetime cases were moved into the catalog-owner suite rather than adding line-limit suppressions.

## User Impact

No production, configuration, schema, protocol, dependency, or user-visible behavior changes. Developers can run the prepared-model test family without its agent-directory fixtures pointing at shared temporary locations.

Production LOC: **+0/-0**. Tests: **+1605/-1190**; test support: **+35/-9**. Much of the test churn is existing cases moved between suites and `try/finally` settlement around existing assertions. No test-only production API was introduced.

## Evidence

- **RED:** restoring the original fixture producer caused three intended containment failures, before any outside-path read or database-handle lookup. Static and live model capture attempted the unowned `models.json` path; the catalog case reached the unowned agent database path. The non-ENOENT `PREPARED_FIXTURE_ESCAPE` guard caused each failure.
- **GREEN:** all **171 tests across the eleven affected files passed**, with zero skipped, failed, or todo cases. This includes the eight-file shared-worker agent sequence, the configured isolated refresh lane, Gateway metadata lifecycle, and TUI integration.
- The existing real-SQLite case `reads only named catalog rows without running migration or repair` also passed (one selected case, 31 intentionally unselected), preserving actual catalog-content coverage without duplicating it.
- Complete classified changed checks passed: formatting, core and core-test typechecking, lint, dead exports, import cycles, and applicable repository guards. An initially incomplete worktree dependency installation caused formatter lookup and UI `pako` type-resolution failures. A normal frozen-lockfile install of the repository-pinned pnpm 12.1.0 resolved both; the aggregate and all 171 affected tests then passed again with the patch byte-identical.
- Independent isolated Codex autoreview completed with no P0 findings. This is scoped review evidence, not a claim that hosted CI or live-provider testing has completed.
- Tested base: `cfddfc2f700ea456c66b887d70716b83d3ac0ea2`. Changed files and relevant runtime owners were also compared with fetched main `136eab023035dd5943818f791d3c3db7d92e4491`; those source blobs were unchanged.

Commands below use the native repository wrappers. Local report-output arguments are omitted. Each invocation used Node 24.15.0, one worker, private fixture roots outside Git, and no live credentials or channel calls.

```bash
node scripts/run-vitest.mjs src/agents/prepared-model-runtime.inbound-registry.test.ts src/agents/prepared-model-runtime-config-stamp.test.ts src/agents/prepared-model-runtime.test.ts src/agents/prepared-model-runtime.lifecycle.test.ts src/agents/prepared-model-runtime.catalog-owner.test.ts src/agents/prepared-model-runtime.owner-selection.test.ts src/agents/prepared-model-runtime.reload-auth.test.ts src/agents/prepared-model-runtime.reply-fallback.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/prepared-model-runtime.scoped-refresh.test.ts
```

```bash
node scripts/run-vitest.mjs src/gateway/server-chat-metadata-lifecycle.integration.test.ts
```

```bash
node scripts/run-vitest.mjs src/tui/embedded-prepared-runtime.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/plugin-model-catalog.test.ts -t 'reads only named catalog rows without running migration or repair'
```

```bash
node scripts/check-changed.mjs -- src/agents/prepared-model-runtime-config-stamp.test.ts src/agents/prepared-model-runtime.catalog-owner.test.ts src/agents/prepared-model-runtime.inbound-registry.test.ts src/agents/prepared-model-runtime.lifecycle.test.ts src/agents/prepared-model-runtime.owner-selection.test.ts src/agents/prepared-model-runtime.reload-auth.test.ts src/agents/prepared-model-runtime.reply-fallback.test.ts src/agents/prepared-model-runtime.scoped-refresh.test.ts src/agents/prepared-model-runtime.test-harness.ts src/agents/prepared-model-runtime.test.ts src/gateway/server-chat-metadata-lifecycle.integration.test.ts src/tui/embedded-prepared-runtime.test.ts
```

Hosted exact-head CI remains a landing prerequisite. This test-only change does not claim a live runtime, provider, channel, or deployment verification.
