### PR TITLE
fix(ui): refresh selected agent roster immediately

### DIFF
--- a/ui/src/lib/sessions/connection-hydration.test.ts
+++ b/ui/src/lib/sessions/connection-hydration.test.ts
@@ -115,7 +115,7 @@ const targetedSessionReconciliationCases = [
 ];
 
 describe("session connection hydration", () => {
-  it("subscribes and hydrates the owner-first roster in one bootstrap request", async () => {
+  it("lets a queued foreground refresh supersede an owner-first bootstrap roster", async () => {
     const roster: SessionsListResult = {
       ...emptySessionsResult(),
       count: 3,
@@ -141,6 +141,11 @@ describe("session connection hydration", () => {
       ],
     };
     const bootstrap = createDeferred<{ subscribed: true; list: SessionsListResult }>();
+    const queuedResult: SessionsListResult = {
+      ...emptySessionsResult(),
+      count: 1,
+      sessions: [{ key: "agent:other:queued", kind: "direct", updatedAt: 4 }],
+    };
     const queuedList = createDeferred<SessionsListResult>();
     const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
       if (method === "sessions.subscribe") {
@@ -194,20 +199,16 @@ describe("session connection hydration", () => {
 
     bootstrap.resolve({ subscribed: true, list: roster });
     await waitForFast(() =>
-      expect(sessions.state.result?.sessions.map((row) => row.key)).toEqual([
-        "agent:main:mine-new",
-        "agent:main:mine-old",
-        "agent:main:theirs",
-      ]),
-    );
-    await waitForFast(() =>
       expect(request.mock.calls.filter(([method]) => method === "sessions.list")).toHaveLength(1),
     );
+    expect(sessions.state.result).toBeNull();
     expect(request.mock.calls.at(-1)?.[1]).toEqual(
       expect.objectContaining({ agentId: "other", search: "queued" }),
     );
-    queuedList.resolve(emptySessionsResult());
+    queuedList.resolve(queuedResult);
     await queuedRefresh;
+    expect(sessions.state.agentId).toBe("other");
+    expect(sessions.state.result).toBe(queuedResult);
     sessions.dispose();
   });
 

--- a/ui/src/lib/sessions/index.event-refresh.test.ts
+++ b/ui/src/lib/sessions/index.event-refresh.test.ts
@@ -803,85 +803,107 @@ describe("event-driven session list refresh", () => {
     {
       timing: "after the append is queued",
       eventBeforeAppend: false,
-      queueReplacementFirst: false,
+      queueForeground: false,
+      eventDuringForeground: false,
+      expectedCalls: 3,
     },
     {
       timing: "before the append is queued",
       eventBeforeAppend: true,
-      queueReplacementFirst: false,
+      queueForeground: false,
+      eventDuringForeground: false,
+      expectedCalls: 3,
     },
     {
-      timing: "before a queued replacement is replaced by the append",
+      timing: "before a queued foreground replacement",
       eventBeforeAppend: true,
-      queueReplacementFirst: true,
+      queueForeground: true,
+      eventDuringForeground: false,
+      expectedCalls: 2,
     },
-  ])("keeps event invalidation $timing", async ({ eventBeforeAppend, queueReplacementFirst }) => {
-    vi.useFakeTimers();
-    const firstList = deferred<SessionsListResult>();
-    const secondList = deferred<SessionsListResult>();
-    const secondListStarted = deferred<void>();
-    let listCalls = 0;
-    const request = vi.fn(async (method: string, _params?: unknown) => {
-      if (method !== "sessions.list") {
-        throw new Error(`Unexpected request: ${method}`);
-      }
-      listCalls += 1;
-      if (listCalls === 1) {
-        return await firstList.promise;
-      }
-      if (listCalls === 2) {
-        secondListStarted.resolve();
-        return await secondList.promise;
-      }
-      return sessionsResult([], listCalls);
-    });
-    const { sessions, emitEvent } = createSessionCapabilityHarness(
-      request as unknown as GatewayBrowserClient["request"],
-    );
-
-    try {
-      const initialRefresh = sessions.refresh({ agentId: "main", limit: 25, force: true });
-      if (eventBeforeAppend) {
-        emitEvent(sessionChangedEvent("agent:main:later-event"));
-      }
-      if (queueReplacementFirst) {
-        void sessions.refresh({ agentId: "discarded", force: true });
-      }
-      const appendRefresh = sessions.refresh({
-        agentId: "main",
-        limit: 25,
-        offset: 25,
-        append: true,
-        force: true,
+    {
+      timing: "before and during a queued foreground replacement",
+      eventBeforeAppend: true,
+      queueForeground: true,
+      eventDuringForeground: true,
+      expectedCalls: 3,
+    },
+  ])(
+    "keeps event invalidation $timing",
+    async ({ eventBeforeAppend, queueForeground, eventDuringForeground, expectedCalls }) => {
+      vi.useFakeTimers();
+      const firstList = deferred<SessionsListResult>();
+      const secondList = deferred<SessionsListResult>();
+      const secondListStarted = deferred<void>();
+      let listCalls = 0;
+      const request = vi.fn(async (method: string, _params?: unknown) => {
+        if (method !== "sessions.list") {
+          throw new Error(`Unexpected request: ${method}`);
+        }
+        listCalls += 1;
+        if (listCalls === 1) {
+          return await firstList.promise;
+        }
+        if (listCalls === 2) {
+          secondListStarted.resolve();
+          return await secondList.promise;
+        }
+        return sessionsResult([], listCalls);
       });
-      if (!eventBeforeAppend) {
-        emitEvent(sessionChangedEvent("agent:main:later-event"));
+      const { sessions, emitEvent } = createSessionCapabilityHarness(
+        request as unknown as GatewayBrowserClient["request"],
+      );
+
+      try {
+        const initialRefresh = sessions.refresh({ agentId: "main", limit: 25, force: true });
+        if (eventBeforeAppend) {
+          emitEvent(sessionChangedEvent("agent:main:earlier-event"));
+        }
+        const foregroundRefresh = queueForeground
+          ? sessions.refresh({ agentId: "research", limit: 25, force: true })
+          : Promise.resolve();
+        const appendRefresh = sessions.refresh({
+          agentId: "main",
+          limit: 25,
+          offset: 25,
+          append: true,
+          force: true,
+        });
+        if (!eventBeforeAppend) {
+          emitEvent(sessionChangedEvent("agent:main:later-event"));
+        }
+        await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
+
+        firstList.resolve(sessionsResult([], 1));
+        await secondListStarted.promise;
+        expect(request.mock.calls[1]?.[1]).toMatchObject({
+          agentId: queueForeground ? "research" : "main",
+          limit: 25,
+          ...(queueForeground ? {} : { offset: 25 }),
+        });
+
+        if (eventDuringForeground) {
+          emitEvent(sessionChangedEvent("agent:research:during-refresh"));
+          await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
+        }
+        secondList.resolve(sessionsResult([], 2));
+        await Promise.all([initialRefresh, foregroundRefresh, appendRefresh]);
+        expect(request).toHaveBeenCalledTimes(expectedCalls);
+        if (expectedCalls === 3) {
+          expect(request.mock.calls[2]?.[1]).toMatchObject({
+            agentId: queueForeground ? "research" : "main",
+            limit: 25,
+          });
+          expect(request.mock.calls[2]?.[1]).not.toHaveProperty("offset");
+        }
+      } finally {
+        firstList.resolve(sessionsResult([], 1));
+        secondList.resolve(sessionsResult([], 2));
+        sessions.dispose();
+        vi.useRealTimers();
       }
-      await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
-
-      firstList.resolve(sessionsResult([], 1));
-      await secondListStarted.promise;
-      expect(request.mock.calls[1]?.[1]).toMatchObject({
-        agentId: "main",
-        limit: 25,
-        offset: 25,
-      });
-
-      secondList.resolve(sessionsResult([], 2));
-      await Promise.all([initialRefresh, appendRefresh]);
-      expect(request).toHaveBeenCalledTimes(3);
-      expect(request.mock.calls[2]?.[1]).toMatchObject({
-        agentId: "main",
-        limit: 25,
-      });
-      expect(request.mock.calls[2]?.[1]).not.toHaveProperty("offset");
-    } finally {
-      firstList.resolve(sessionsResult([], 1));
-      secondList.resolve(sessionsResult([], 2));
-      sessions.dispose();
-      vi.useRealTimers();
-    }
-  });
+    },
+  );
 
   it("queues one trailing refresh for an event during an in-flight refresh", async () => {
     vi.useFakeTimers();

--- a/ui/src/lib/sessions/session-roster-refresh.test.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.test.ts
@@ -12,7 +12,142 @@ import {
 } from "./session-capability.test-support.ts";
 
 describe("session roster refresh completion", () => {
-  it("settles coalesced refresh callers after their snapshot without waiting for later work", async () => {
+  it.each([
+    { weakKind: "append", weakOptions: { offset: 25, append: true }, outcome: "rows" },
+    { weakKind: "append", weakOptions: { offset: 25, append: true }, outcome: "error" },
+    { weakKind: "background", weakOptions: { backgroundHydrate: true }, outcome: "rows" },
+    { weakKind: "background", weakOptions: { backgroundHydrate: true }, outcome: "error" },
+  ] as const)(
+    "keeps a queued Research replacement ahead of a later Work $weakKind after stale Work $outcome",
+    async ({ weakOptions, outcome }) => {
+      const workList = createDeferred<SessionsListResult>();
+      const researchList = createDeferred<SessionsListResult>();
+      const workResult = sessionsResult(
+        [{ key: "agent:work:main", kind: "direct", updatedAt: 1 }],
+        1,
+      );
+      const researchResult = sessionsResult(
+        [{ key: "agent:research:main", kind: "direct", updatedAt: 2 }],
+        2,
+      );
+      const request = vi.fn(async (method: string, params?: { agentId?: string }) => {
+        expect(method).toBe("sessions.list");
+        if (params?.agentId === "work") {
+          return await workList.promise;
+        }
+        if (params?.agentId === "research") {
+          return await researchList.promise;
+        }
+        throw new Error(`Unexpected refresh: ${params?.agentId}`);
+      });
+      const { sessions } = createSessionCapabilityHarness(
+        request as unknown as GatewayBrowserClient["request"],
+      );
+      const observed: Array<{
+        result: SessionsListResult | null;
+        error: string | null;
+      }> = [];
+      const unsubscribe = sessions.subscribe(({ result, error }) => {
+        observed.push({ result, error });
+      });
+      const workSettled = vi.fn();
+      const researchSettled = vi.fn();
+      const weakSettled = vi.fn();
+      const work = sessions.refresh({ agentId: "work", force: true }).then(workSettled);
+      const research = sessions.refresh({ agentId: "research", force: true }).then(researchSettled);
+      const weak = sessions
+        .refresh({ agentId: "work", limit: 25, force: true, ...weakOptions })
+        .then(weakSettled);
+
+      try {
+        if (outcome === "rows") {
+          workList.resolve(workResult);
+        } else {
+          workList.reject(new Error("stale Work failure"));
+        }
+        await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+        await waitForFast(() => expect(workSettled).toHaveBeenCalledOnce());
+
+        expect(researchSettled).not.toHaveBeenCalled();
+        expect(weakSettled).not.toHaveBeenCalled();
+        expect(request.mock.calls[1]?.[1]).toMatchObject({ agentId: "research" });
+        expect(
+          observed.some(({ result }) =>
+            result?.sessions.some((row) => row.key === "agent:work:main"),
+          ),
+        ).toBe(false);
+        expect(observed.some(({ error }) => error === "stale Work failure")).toBe(false);
+
+        researchList.resolve(researchResult);
+        await Promise.all([research, weak]);
+        expect(researchSettled).toHaveBeenCalledOnce();
+        expect(weakSettled).toHaveBeenCalledOnce();
+        expect(sessions.state.agentId).toBe("research");
+        expect(sessions.state.result).toBe(researchResult);
+        expect(sessions.state.error).toBeNull();
+      } finally {
+        workList.resolve(workResult);
+        researchList.resolve(researchResult);
+        unsubscribe();
+        sessions.dispose();
+        await Promise.all([work, research, weak]);
+      }
+    },
+  );
+
+  it.each([
+    { weakKind: "append", weakOptions: { offset: 25, append: true } },
+    { weakKind: "background", weakOptions: { backgroundHydrate: true } },
+  ] as const)(
+    "lets a foreground replacement supersede an already queued $weakKind",
+    async ({ weakOptions }) => {
+      const activeList = createDeferred<SessionsListResult>();
+      const researchList = createDeferred<SessionsListResult>();
+      const researchResult = sessionsResult(
+        [{ key: "agent:research:main", kind: "direct", updatedAt: 2 }],
+        2,
+      );
+      const request = vi.fn(async (method: string, params?: { agentId?: string }) => {
+        expect(method).toBe("sessions.list");
+        if (params?.agentId === "work") {
+          return await activeList.promise;
+        }
+        if (params?.agentId === "research") {
+          return await researchList.promise;
+        }
+        throw new Error(`Unexpected refresh: ${params?.agentId}`);
+      });
+      const { sessions } = createSessionCapabilityHarness(
+        request as unknown as GatewayBrowserClient["request"],
+      );
+      const active = sessions.refresh({ agentId: "work", force: true });
+      const weak = sessions.refresh({
+        agentId: "work",
+        limit: 25,
+        force: true,
+        ...weakOptions,
+      });
+      const research = sessions.refresh({ agentId: "research", force: true });
+
+      try {
+        activeList.resolve(sessionsResult([], 1));
+        await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+        expect(request.mock.calls[1]?.[1]).toMatchObject({ agentId: "research" });
+
+        researchList.resolve(researchResult);
+        await Promise.all([active, weak, research]);
+        expect(sessions.state.agentId).toBe("research");
+        expect(sessions.state.result).toBe(researchResult);
+      } finally {
+        activeList.resolve(sessionsResult([], 1));
+        researchList.resolve(researchResult);
+        sessions.dispose();
+        await Promise.all([active, weak, research]);
+      }
+    },
+  );
+
+  it("settles coalesced refresh callers without waiting for a later replacement", async () => {
     const initialList = createDeferred<SessionsListResult>();
     const coalescedList = createDeferred<SessionsListResult>();
     const laterList = createDeferred<SessionsListResult>();
@@ -51,7 +186,7 @@ describe("session roster refresh completion", () => {
       coalescedList.resolve(sessionsResult([], 2));
       await waitForFast(() => expect(coalescedSettled).toHaveBeenCalledTimes(2));
 
-      expect(sessions.state.result?.ts).toBe(2);
+      expect(sessions.state.result).toBeNull();
       expect(sessions.state.loading).toBe(true);
       expect(request.mock.calls.map(([, params]) => params?.search)).toEqual([
         "initial",

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -156,8 +156,15 @@ function retainSessionPaginationWindow(
   };
 }
 
+function isForegroundReplacement(options: SessionRefreshOptions): boolean {
+  return options.append !== true && options.backgroundHydrate !== true;
+}
+
 export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
   let requestRevision = 0;
+  // A queued foreground replacement owns the next visible roster immediately.
+  // Older loads may finish for their callers, but must not publish across that boundary.
+  let foregroundPublicationGeneration = 0;
   let inFlight: Promise<void> | null = null;
   let queuedExplicitRefresh: {
     options: SessionRefreshOptions;
@@ -317,6 +324,9 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     if (!scope) {
       return null;
     }
+    const publicationGeneration = foregroundPublicationGeneration;
+    const isCurrent = () =>
+      host.connection.isCurrent(scope) && publicationGeneration === foregroundPublicationGeneration;
     const { append = false, force: _force, backgroundHydrate = false, ...requestOptions } = options;
     // Every canonical roster replaces visible session names, so omitted title
     // enrichment must inherit the UI default instead of publishing fallback ids.
@@ -342,7 +352,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       const listParams = buildSessionListParams(requestOptions);
       let issuedRevision = ++requestRevision;
       let result = bootstrap ? await host.bootstrap(scope, listParams) : null;
-      if (bootstrap && !host.connection.isCurrent(scope)) {
+      if (bootstrap && !isCurrent()) {
         return null;
       }
       if (!result) {
@@ -352,7 +362,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
         }
         result = await requestSessionListParams(scope.client, listParams);
       }
-      if (!host.connection.isCurrent(scope)) {
+      if (!isCurrent()) {
         return null;
       }
       result = host.reconcileList(result, issuedRevision, requestOptions.agentId);
@@ -410,7 +420,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       );
       return result;
     } catch (error) {
-      if (host.connection.isCurrent(scope)) {
+      if (isCurrent()) {
         const state = host.readState();
         host.publish(
           {
@@ -480,10 +490,17 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     if (!host.connection.capture()) {
       return Promise.resolve();
     }
+    const foregroundReplacement = isForegroundReplacement(options);
     if (inFlight) {
+      if (foregroundReplacement) {
+        foregroundPublicationGeneration += 1;
+      }
       return new Promise<void>((complete) => {
         if (queuedExplicitRefresh) {
-          queuedExplicitRefresh.options = options;
+          // Once queued, a foreground owner stays authoritative over weaker refreshes.
+          if (foregroundReplacement || !isForegroundReplacement(queuedExplicitRefresh.options)) {
+            queuedExplicitRefresh.options = options;
+          }
           queuedExplicitRefresh.completions.push(complete);
         } else {
           queuedExplicitRefresh = { options, completions: [complete] };
@@ -495,6 +512,9 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     );
     if (host.readState().result && !options.force && !hasListOverrides) {
       return Promise.resolve();
+    }
+    if (foregroundReplacement) {
+      foregroundPublicationGeneration += 1;
     }
     if (options.append !== true) {
       absorbPendingEventRefresh();
@@ -673,6 +693,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       }
     },
     reset() {
+      foregroundPublicationGeneration += 1;
       primaryList = { scope: primaryList.scope };
       eventRefreshCoordinator.reset();
       inFlight = null;
@@ -693,6 +714,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       }
     },
     dispose() {
+      foregroundPublicationGeneration += 1;
       eventRefreshCoordinator.dispose();
       if (observesPageLifecycle) {
         updatePageLifecycleListeners(false);

--- a/ui/src/pages/chat/chat-pane-identity.test.ts
+++ b/ui/src/pages/chat/chat-pane-identity.test.ts
@@ -83,6 +83,7 @@ describe("chat pane assistant identity snapshots", () => {
         groupSettings: [],
         sectionOrder: [],
       },
+      refresh: vi.fn().mockResolvedValue(undefined),
       subscribe: () => () => undefined,
       subscribeMessages,
       unsubscribeMessages,

--- a/ui/src/pages/chat/chat-state-refresh.ts
+++ b/ui/src/pages/chat/chat-state-refresh.ts
@@ -93,6 +93,7 @@ export function applySelectedChatAgent(
     return;
   }
   applyChatAgentOwnerTransition(host, selectedAgentId);
+  void refreshCurrentChatSessionList(host);
 }
 
 export function applyChatAgentOwnerTransition(

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -3497,7 +3497,7 @@ describe("loadPageAssistantIdentity", () => {
       },
       gateway: { snapshot: { client, connected: true, hello: null } },
       initialUserMessage: createInitialUserMessageHandoff(),
-      sessions: {},
+      sessions: { refresh: vi.fn().mockResolvedValue(undefined) },
     } as unknown as ApplicationContext;
     const state = createPageState(
       context,
@@ -3968,6 +3968,7 @@ describe("refreshChatModelAuthStatus", () => {
       });
       const staleMainStatus = { ts: 1, providers: [] };
       const workStatus = { ts: 2, providers: [] };
+      const refreshSessions = vi.fn().mockResolvedValue(undefined);
       const state = {
         client: { request },
         connected: true,
@@ -3987,6 +3988,7 @@ describe("refreshChatModelAuthStatus", () => {
         sessions: {
           state: { modelOverrides: {} },
           retireModelOverride: vi.fn(),
+          refresh: refreshSessions,
         },
       } as unknown as ChatPageHost;
 
@@ -4000,6 +4002,9 @@ describe("refreshChatModelAuthStatus", () => {
         ["models.authStatus", { agentId: "main" }],
         ["models.authStatus", { agentId: "work" }],
       ]);
+      expect(refreshSessions).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: "work", force: true }),
+      );
 
       workResponse.resolve(workStatus);
       await vi.waitFor(() => expect(state.modelAuthStatusResult).toBe(workStatus));


### PR DESCRIPTION
Related: #133132

## What Problem This Solves

Fixes an issue where selecting a different agent for a global Control UI chat updated the visible owner but did not immediately refresh that agent's session roster. It also prevents an older in-flight roster request from publishing rows or errors after a newer foreground replacement is queued.

## Why This Change Was Made

The agent-selection path now refreshes sessions immediately after the owner transition, when the selected agent is authoritative. The roster controller owns a foreground publication generation so queued replacements invalidate older publications without delaying their callers. Fixed-session, append, background, and event transitions remain unchanged.

The production growth is confined to the roster lifecycle owner: it replaces a caller-specific selection fence with one canonical publication boundary shared by bootstrap, queued refresh, reset, and dispose. No compatibility path or downstream fallback was added.

## User Impact

The session list and agent-scoped state update immediately after switching agents instead of waiting for a later connection or identity event.

## Evidence

- Pre-fix regression: 2/2 selected-global cases made zero roster-refresh calls.
- Pre-fix concurrency regressions: 6/6 failed across stale success/error, append/background priority, and bootstrap publication.
- Focused roster and event regressions: 53/53 passing.
- Sibling session tests: 40/40 passing.
- `chat-pane-identity.test.ts`: 4/4 passing.
- `chat-state.test.ts`: 106/106 passing.
- Full Control UI suite: 12,633 passing, 1 skipped.
- `pnpm tsgo:ui`, changed-file gate, format, lint, and diff checks pass.
- Independent P0-P2 autoreview: scoped-clean.
- Production LOC: +27/-4 (net +23). Tests: +244/-80.

## Visual Proof

An isolated mock-Gateway browser run used the real agent selector and verified:

- Main roster visible before selection.
- `sessions.list` requested with `agentId: "work"`.
- Work roster visible after selection.
- Main roster removed after selection.

Command: `node --import tsx .artifacts/control-ui-e2e/selected-agent-roster-refresh/record.mts`

Capture: three 1440x900 screenshots and a 5.44s video. The artifacts contain only synthetic data. Browser attachment is unavailable in this session, so the sanitized captures are retained locally and identified by SHA-256:

- Before: `ac5fc16740cfcf7029d0780dd9de60743856a537384e8c7015179333d0c9b579`
- Selector: `2294923171af8c815fdcf9ee02dba68e3000447c320927dadeb32e144c5985c6`
- After: `6d4393f966e3dbf6e986cab2bf7eb895f7fff3f3e0b0daf0712cce35a51b8a8c`
- Video: `c79369f6f73b07f5e86f2c430c6771319ea923bf235267fa6bdc579e5c59278f`
