### PR TITLE
fix(ui): keep selected-agent collaboration on the right session

### DIFF
--- a/ui/src/pages/chat/chat-pane-sharing.test.ts
+++ b/ui/src/pages/chat/chat-pane-sharing.test.ts
@@ -2,6 +2,7 @@
 /* @vitest-environment-options {"url":"http://chat-pane-sharing.test/"} */
 
 import { describe, expect, it, vi } from "vitest";
+import type { SessionSuggestion } from "../../../../packages/gateway-protocol/src/index.js";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type {
@@ -152,6 +153,48 @@ const mutations = [
 ] as const;
 
 describe("chat pane sharing authorization", () => {
+  it.each(["draft", "shared"] as const)(
+    "loads selected-global Work suggestions after visibility changes to %s",
+    async (visibility) => {
+      const pending: SessionSuggestion = {
+        id: `pending-${visibility}`,
+        sessionKey: "agent:work:main",
+        agentId: "work",
+        author: { type: "human", id: "alice", label: "Alice" },
+        text: "still needs review",
+        createdAt: 1,
+        state: "pending",
+      };
+      const request = vi.fn(async () => ({ suggestions: [pending], role: "owner" as const }));
+      const { pane, state } = createTestChatPane({
+        client: createGatewayBrowserClientFixture({ request }),
+        sessions: {} as SessionCapability,
+      });
+      state.sessionKey = "agent:work:main";
+      state.assistantAgentId = "work";
+      state.agentsList = { defaultId: "main", mainKey: "main", scope: "global", agents: [] };
+      state.sessionsResultAgentId = "work";
+      state.sessionsResult = sharingSessionsResult({
+        ...sessionRow(),
+        key: "global",
+        kind: "global",
+        visibility,
+      });
+      pane.presencePayload = {
+        presence: [{ user: { id: "owner" } }, { user: { id: "alice" } }],
+      };
+
+      await pane.refreshSessionSuggestions();
+
+      expect(request).toHaveBeenCalledWith("session.suggestions.list", {
+        sessionKey: "agent:work:main",
+        agentId: "work",
+      });
+      expect(pane.sessionSuggestions).toEqual([pending]);
+      expect(pane.sessionSuggestionRole).toBe("owner");
+    },
+  );
+
   it("allows read-scoped owners to load sharing data but not mutate it", async () => {
     const row = sessionRow();
     const request = vi.fn(async (method: string) => {

--- a/ui/src/pages/chat/chat-pane-sharing.ts
+++ b/ui/src/pages/chat/chat-pane-sharing.ts
@@ -29,7 +29,7 @@ import {
   type ChatPaneConnectionScope,
 } from "./chat-pane-shared.ts";
 import { resetSessionCompanion } from "./chat-session-companion.ts";
-import { resolveChatAgentId } from "./chat-state-route.ts";
+import { resolveChatAgentId, selectedChatSessionRow } from "./chat-state-route.ts";
 import { clearTypingActorForSessionMessage } from "./chat-typing-presence.ts";
 import {
   canManageChatSessionSharing,
@@ -388,9 +388,7 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
   protected async loadSessionSuggestions(requestVersion: number): Promise<void> {
     const targetSignature = this.sessionSuggestionTargetSignature;
     const scope = this.captureConnectionScope();
-    const row = scope?.state.sessionsResult?.sessions.find((candidate) =>
-      areUiSessionKeysEquivalent(candidate.key, scope.state.sessionKey),
-    );
+    const row = scope ? selectedChatSessionRow(scope.state) : undefined;
     // Solo dormancy intentionally hides persisted rows too; when a second identity
     // returns, the presence transition below triggers a fresh authoritative list.
     if (
@@ -629,9 +627,7 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
   protected handleSessionTypingEvent(event: SessionTypingEvent): void {
     const selfId = this.context.gateway.snapshot.selfUser?.id;
     const state = this.state;
-    const selectedSession = state?.sessionsResult?.sessions.find((row) =>
-      areUiSessionKeysEquivalent(row.key, state.sessionKey),
-    );
+    const selectedSession = state ? selectedChatSessionRow(state) : undefined;
     if (
       !this.hasMultipleIdentities() ||
       event.actor.id === selfId ||
@@ -706,9 +702,7 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
       return;
     }
     const sessionKey = scope.state.sessionKey;
-    const sessionId = scope.state.sessionsResult?.sessions.find((row) =>
-      areUiSessionKeysEquivalent(row.key, sessionKey),
-    )?.sessionId;
+    const sessionId = selectedChatSessionRow(scope.state)?.sessionId;
     if (!sessionId) {
       return;
     }

--- a/ui/src/pages/chat/chat-pane-typing.test.ts
+++ b/ui/src/pages/chat/chat-pane-typing.test.ts
@@ -21,6 +21,10 @@ describe("chat pane typing presence", () => {
       client: { request: vi.fn() } as unknown as GatewayBrowserClient,
       sessions: {} as SessionCapability,
     });
+    state.sessionKey = "agent:work:main";
+    state.assistantAgentId = "work";
+    state.agentsList = { defaultId: "main", mainKey: "main", scope: "global", agents: [] };
+    state.sessionsResultAgentId = "work";
     const aliceId = "0d9f4c35-d221-49da-9a3f-b8c73921066b";
     pane.presencePayload = {
       presence: [{ user: { id: "owner" } }, { user: { id: aliceId } }, { user: { id: "bob" } }],
@@ -30,8 +34,8 @@ describe("chat pane typing presence", () => {
       path: "",
       sessions: [
         {
-          key: state.sessionKey,
-          kind: "direct",
+          key: "global",
+          kind: "global",
           sessionId: "session-a",
           updatedAt: 1,
         } as GatewaySessionRow,
@@ -130,17 +134,27 @@ describe("chat pane typing presence", () => {
       sessions: {} as SessionCapability,
     });
     pane.presencePayload = { presence: [{ user: { id: "owner" } }, { user: { id: "alice" } }] };
+    state.sessionKey = "agent:work:main";
+    state.assistantAgentId = "work";
+    state.agentsList = { defaultId: "main", mainKey: "main", scope: "global", agents: [] };
+    state.sessionsResultAgentId = "work";
     state.sessionsResult = {
       count: 1,
       path: "",
-      sessions: [{ key: state.sessionKey, kind: "direct", sessionId: "session-a", updatedAt: 1 }],
+      sessions: [{ key: "global", kind: "global", sessionId: "session-a", updatedAt: 1 }],
     } as never;
 
     pane.sendTypingState(true, `  prefix${"😀".repeat(300)}  `);
     expect(request).toHaveBeenNthCalledWith(
       1,
       "session.typing",
-      expect.objectContaining({ typing: true, preview: "😀".repeat(300) }),
+      expect.objectContaining({
+        sessionKey: "agent:work:main",
+        sessionId: "session-a",
+        agentId: "work",
+        typing: true,
+        preview: "😀".repeat(300),
+      }),
     );
 
     pane.sendTypingState(false, "must not leak");


### PR DESCRIPTION
Related: #133132

## What Problem This Solves

Fixes an issue where suggestions and typing state for a selected global agent could silently stop working because collaboration paths re-resolved the raw `global` key instead of using the owner-validated selected session.

## Why This Change Was Made

Suggestions, received typing state, and outgoing typing requests now use the canonical selected-session owner check. Existing wrong-agent guards remain intact.

## User Impact

After switching a global chat to another agent, suggestions and typing indicators remain bound to the selected agent's actual session.

## Evidence

- Four intended regressions reproduced before the fix.
- Focused collaboration tests: 36/36 passing.
- Independent review verification: 93 tests passing.
- `pnpm tsgo:ui`, full changed-file gate, format, lint, and diff checks pass.
- Production LOC: +4/-10 (net -6).

## Visual Proof

An isolated mock-Gateway browser run selected Work on a global route and verified:

- Suggestion request: `agent:work:main`, agent `work`.
- Outgoing typing: `agent:work:main`, session `session-work-global`, agent `work`.
- Work-owned suggestion and received typing preview visible in the Control UI.

Command: `pnpm exec tsx .artifacts/control-ui-e2e/selected-agent-collaboration/record-proof.ts`

Capture: three 1280x900 screenshots and a 3.44s video. The artifacts contain only synthetic data. Browser attachment is unavailable in this session, so the sanitized captures are retained locally and identified by SHA-256:

- Suggestion: `075e36fb25216b6c942949f12148011471176f8c30814a4b49d02003390a8c13`
- Typing + suggestion: `2fd51fcb022b6dbf62b01624e599bb722343c2f37fc0063ba096945e507ab452`
- Final state: `dddcbbb15197394ac72bc6c82e464f2e9734bfe39279aae6705274bb4860a904`
- Video: `ca46310f36c9e7b8151c7e7e038010834a18032ba2aef6b861a927ac4410d611`
