### PR TITLE
fix(slack): render authored presentation text once across sends and edits

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1135,7 +1135,6 @@ extensions/slack/src/approval-actions.ts	1
 extensions/slack/src/approval-handler.runtime.ts	1
 extensions/slack/src/approval-native-gates.ts	1
 extensions/slack/src/approval-native.ts	2
-extensions/slack/src/blocks-fallback.ts	2
 extensions/slack/src/blocks-input.ts	2
 extensions/slack/src/blocks-render.ts	1
 extensions/slack/src/channel-actions.ts	1

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1190,7 +1190,7 @@ extensions/slack/src/post-message-identity.ts	1
 extensions/slack/src/probe.ts	2
 extensions/slack/src/progress-blocks.ts	2
 extensions/slack/src/reply-action-ids.ts	1
-extensions/slack/src/reply-blocks.ts	9
+extensions/slack/src/reply-blocks.ts	8
 extensions/slack/src/resolve-channels.ts	1
 extensions/slack/src/resolve-users.ts	1
 extensions/slack/src/scopes.ts	2

--- a/extensions/slack/src/accounts.ts
+++ b/extensions/slack/src/accounts.ts
@@ -12,6 +12,7 @@ import {
   type ChannelDmPolicy,
 } from "openclaw/plugin-sdk/channel-config-helpers";
 import type { SlackAccountConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { resolveAccountEntry } from "openclaw/plugin-sdk/routing";
 import {
   asOptionalRecord,
@@ -85,6 +86,19 @@ const {
 });
 export const listSlackAccountIds = listAccountIds;
 export const resolveDefaultSlackAccountId = resolveDefaultAccountId;
+
+export function resolveSlackMarkdownOptions(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}) {
+  return {
+    tableMode: resolveMarkdownTableMode({
+      cfg: params.cfg,
+      channel: "slack",
+      accountId: params.accountId ?? resolveDefaultSlackAccountId(params.cfg),
+    }),
+  };
+}
 
 function resolveSlackAccountConfig(
   cfg: OpenClawConfig,

--- a/extensions/slack/src/action-runtime.ts
+++ b/extensions/slack/src/action-runtime.ts
@@ -75,6 +75,7 @@ export const slackActionRuntime = {
   deleteSlackMessage: createLazySlackAction("deleteSlackMessage"),
   downloadSlackFile: createLazySlackAction("downloadSlackFile"),
   editSlackMessage: createLazySlackAction("editSlackMessage"),
+  editSlackRenderedMessage: createLazySlackAction("editSlackRenderedMessage"),
   getSlackMemberInfo: createLazySlackAction("getSlackMemberInfo"),
   listSlackEmojis: createLazySlackAction("listSlackEmojis"),
   listSlackPins: createLazySlackAction("listSlackPins"),
@@ -126,6 +127,8 @@ export type SlackActionContext = {
   mediaReadFile?: (filePath: string) => Promise<Buffer>;
   /** Slack-private ordered delivery plan prepared after presentation normalization. */
   preparedMessages?: readonly SlackReplyDeliveryMessage[];
+  /** Slack-private final edit bytes; raw direct edits still accept Markdown. */
+  preparedEditText?: string;
 };
 
 function resolveThreadTsFromContext(
@@ -833,7 +836,11 @@ export async function handleSlackAction(
         }
         await assertReadTargetAllowed(target);
         const writeOpts = buildActionOpts("write", target.teamId);
-        await slackActionRuntime.editSlackMessage(channelId, messageId, content ?? "", {
+        const edit =
+          context?.preparedEditText === undefined
+            ? slackActionRuntime.editSlackMessage
+            : slackActionRuntime.editSlackRenderedMessage;
+        await edit(channelId, messageId, context?.preparedEditText ?? content ?? "", {
           ...writeOpts,
           blocks,
         });

--- a/extensions/slack/src/actions.blocks.test.ts
+++ b/extensions/slack/src/actions.blocks.test.ts
@@ -4,10 +4,16 @@ import {
   resetPluginRuntimeStateForTest,
   setActivePluginRegistry,
 } from "openclaw/plugin-sdk/channel-test-helpers";
-import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleSlackAction, slackActionRuntime } from "./action-runtime.js";
 import { createSlackEditTestClient, createSlackSendTestClient } from "./blocks.test-helpers.js";
 import { slackSetupPlugin } from "./channel.setup.js";
+import { handleSlackMessageAction } from "./message-action-dispatch.js";
+import { deliverReplies, deliverSlackSlashReplies } from "./monitor/replies.js";
+import { slackOutbound } from "./outbound-adapter.js";
+import { sendMessageSlack } from "./send.js";
 import { countSlackTextUtf8Bytes } from "./truncate.js";
 
 const { editSlackMessage, editSlackRenderedMessage, sendSlackMessage } =
@@ -145,6 +151,119 @@ describe("editSlackMessage blocks", () => {
     },
   );
 
+  it.each(
+    (["action", "outbound", "rendered outbound", "monitor", "slash"] as const).flatMap((path) =>
+      (["off", "code", "bullets"] as const).map((mode) => ({ path, mode })),
+    ),
+  )("preserves account table policy in $path ($mode)", async ({ path, mode }) => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        slack: {
+          botToken: "xoxb-test",
+          markdown: { tables: "off" },
+          accounts: { work: { markdown: { tables: mode } } },
+          channels: { C123: { allow: true } },
+        },
+      },
+    };
+    const payload: ReplyPayload = {
+      text: table,
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Continue", action: { type: "callback", value: "next" } }],
+          },
+        ],
+      },
+    };
+    const expected = mode === "code" ? codeTable : mode === "bullets" ? bulletTable : table;
+    const client = createSlackSendTestClient();
+    const sendSlack: typeof sendMessageSlack = (to, text, options) =>
+      sendMessageSlack(to, text, { ...options, client });
+    const send = vi
+      .spyOn(slackActionRuntime, "sendSlackMessage")
+      .mockImplementation((to, text, options) =>
+        sendSlackMessage(to, text, { ...options, client }),
+      );
+    const metadata = vi
+      .spyOn(slackActionRuntime, "resolveSlackConversationInfo")
+      .mockResolvedValue({ type: "channel" });
+    const respond = vi.fn(async (_message: unknown) => undefined);
+    try {
+      if (path === "action") {
+        await handleSlackMessageAction({
+          providerId: "slack",
+          ctx: {
+            channel: "slack",
+            action: "send",
+            cfg,
+            accountId: "work",
+            params: { to: "channel:C123", message: table, presentation: payload.presentation },
+          },
+          invoke: (action, config, context) =>
+            handleSlackAction(action, config, {
+              ...context,
+              conversationReadOrigin: "direct-operator",
+            }),
+        });
+      } else if (path === "monitor") {
+        await deliverReplies({
+          cfg,
+          replies: [payload],
+          target: "channel:C123",
+          token: "xoxb-test",
+          accountId: "work",
+          runtime: {},
+          textLimit: 4000,
+          replyToMode: "off",
+          eventScope: { teamId: "T123", client },
+        });
+      } else if (path === "slash") {
+        await deliverSlackSlashReplies({
+          replies: [payload],
+          respond,
+          ephemeral: true,
+          textLimit: 4000,
+          tableMode: mode,
+          accountId: "work",
+        });
+      } else {
+        const ctx = {
+          cfg,
+          accountId: "work",
+          to: "channel:C123",
+          text: table,
+          payload,
+          deps: { sendSlack },
+        };
+        let outgoing = payload;
+        if (path === "rendered outbound") {
+          const rendered = await slackOutbound.renderPresentation?.({
+            payload,
+            presentation: payload.presentation!,
+            ctx,
+          });
+          expect(rendered).toBeTruthy();
+          const { presentation: _presentation, ...prepared } = rendered!;
+          outgoing = prepared;
+        }
+        await slackOutbound.sendPayload?.({ ...ctx, payload: outgoing });
+      }
+      const calls = path === "slash" ? respond.mock.calls : client.chat.postMessage.mock.calls;
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.[0]).toMatchObject({
+        blocks: [
+          { type: "section", text: { type: "mrkdwn", text: expected } },
+          { type: "actions", elements: [{ type: "button", text: { text: "Continue" } }] },
+        ],
+      });
+    } finally {
+      send.mockRestore();
+      metadata.mockRestore();
+    }
+  });
+
   it("renders authored Markdown using the same mrkdwn dialect as sends", async () => {
     const client = createSlackEditTestClient();
 
@@ -159,6 +278,94 @@ describe("editSlackMessage blocks", () => {
       text: "*bold* and <https://example.com|OpenClaw>",
     });
   });
+
+  it.each([
+    {
+      name: "bold",
+      mode: "off" as const,
+      authored: "**Overview**",
+      presented: "*Overview*",
+      expected: "*Overview*",
+    },
+    ...(["off", "code", "bullets"] as const).map((mode) => ({
+      name: `${mode} table with literal presentation`,
+      mode,
+      authored: table,
+      presented: table,
+      expected: mode === "off" ? table : `${mode === "code" ? codeTable : bulletTable}\n\n${table}`,
+    })),
+    ...(["code", "bullets"] as const).map((mode) => ({
+      name: `${mode} table with matching presentation`,
+      mode,
+      authored: table,
+      presented: mode === "code" ? codeTable : bulletTable,
+      expected: mode === "code" ? codeTable : bulletTable,
+    })),
+  ])(
+    "preserves $name through a text-only presentation edit",
+    async ({ mode, authored, presented, expected }) => {
+      const client = createSlackEditTestClient();
+      const edit = vi
+        .spyOn(slackActionRuntime, "editSlackMessage")
+        .mockImplementation((channel, message, content, options) =>
+          editSlackMessage(channel, message, content, { ...options, client }),
+        );
+      const renderedEdit = vi
+        .spyOn(slackActionRuntime, "editSlackRenderedMessage")
+        .mockImplementation((channel, message, content, options) =>
+          editSlackRenderedMessage(channel, message, content, { ...options, client }),
+        );
+      const metadata = vi
+        .spyOn(slackActionRuntime, "resolveSlackConversationInfo")
+        .mockResolvedValue({ type: "channel" });
+      try {
+        await handleSlackMessageAction({
+          providerId: "slack",
+          ctx: {
+            action: "edit",
+            channel: "slack",
+            cfg: {
+              channels: {
+                slack: {
+                  botToken: "xoxb-test",
+                  markdown: { tables: mode },
+                  channels: { C123: { allow: true } },
+                },
+              },
+            },
+            params: {
+              channelId: "C123",
+              messageId: "171234.567",
+              message: authored,
+              presentation: {
+                blocks: [
+                  { type: "text", text: presented },
+                  {
+                    type: "buttons",
+                    buttons: [{ label: "Status", action: { type: "command", command: "/status" } }],
+                  },
+                ],
+              },
+            },
+          },
+          invoke: (action, cfg, context) =>
+            handleSlackAction(action, cfg, {
+              ...context,
+              conversationReadOrigin: "direct-operator",
+            }),
+        });
+        expect(client.chat.update).toHaveBeenCalledExactlyOnceWith({
+          channel: "C123",
+          ts: "171234.567",
+          text: `${expected}\n\n- Status: \`/status\``,
+        });
+      } finally {
+        edit.mockRestore();
+        renderedEdit.mockRestore();
+        metadata.mockRestore();
+      }
+    },
+  );
 
   it("preserves already-rendered Slack mrkdwn when finalizing a preview", async () => {
     const client = createSlackEditTestClient();

--- a/extensions/slack/src/actions.blocks.test.ts
+++ b/extensions/slack/src/actions.blocks.test.ts
@@ -162,7 +162,7 @@ describe("editSlackMessage blocks", () => {
           botToken: "xoxb-test",
           markdown: { tables: "off" },
           accounts: { work: { markdown: { tables: mode } } },
-          channels: { C123: { allow: true } },
+          channels: { C123: { enabled: true } },
         },
       },
     };
@@ -214,7 +214,7 @@ describe("editSlackMessage blocks", () => {
           target: "channel:C123",
           token: "xoxb-test",
           accountId: "work",
-          runtime: {},
+          runtime: { log: () => {}, error: () => {}, exit: () => {} },
           textLimit: 4000,
           replyToMode: "off",
           eventScope: { teamId: "T123", client },
@@ -329,7 +329,7 @@ describe("editSlackMessage blocks", () => {
                 slack: {
                   botToken: "xoxb-test",
                   markdown: { tables: mode },
-                  channels: { C123: { allow: true } },
+                  channels: { C123: { enabled: true } },
                 },
               },
             },

--- a/extensions/slack/src/authored-text.ts
+++ b/extensions/slack/src/authored-text.ts
@@ -1,31 +1,34 @@
-// Slack-private authored text placement after block compilation.
 import type { LegacyInteractiveReply } from "openclaw/plugin-sdk/interactive-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 export type SlackAuthoredTextPlacement = "none" | "blocks" | "outside-blocks";
+
+// Project producer plans the same way so trimmed chunk seams cannot duplicate authored text.
+function normalizeSlackAuthoredTextFragments(fragments: readonly string[]): string[] {
+  return fragments.map((fragment) => fragment.trim()).filter(Boolean);
+}
 
 function isSlackAuthoredTextRepresentedInFragments(
   text: string,
   rawFragments: readonly string[],
   authoredChunkPlans: readonly (readonly string[])[] = [],
 ): boolean {
-  const target = text.trim();
-  const fragments = rawFragments.map((fragment) => fragment.trim()).filter(Boolean);
-  if (
-    authoredChunkPlans.some(
-      (plan) =>
-        plan.length > 0 &&
-        fragments.some((_, start) =>
-          plan.every((fragment, index) => fragment === fragments[start + index]),
-        ),
-    )
-  ) {
-    return true;
+  const fragments = normalizeSlackAuthoredTextFragments(rawFragments);
+  for (const rawPlan of authoredChunkPlans) {
+    const plan = normalizeSlackAuthoredTextFragments(rawPlan);
+    if (
+      plan.length > 0 &&
+      fragments.some((_, start) =>
+        plan.every((fragment, index) => fragment === fragments[start + index]),
+      )
+    ) {
+      return true;
+    }
   }
   // Legacy inline controls may split authored whitespace at fragment boundaries.
   // Consume only those separators; code/literal interiors and chunk seams stay exact.
   for (let start = 0; start < fragments.length; start += 1) {
-    let remaining = target;
+    let remaining = text;
     for (const fragment of fragments.slice(start)) {
       if (!remaining.startsWith(fragment)) {
         break;

--- a/extensions/slack/src/authored-text.ts
+++ b/extensions/slack/src/authored-text.ts
@@ -4,9 +4,11 @@ import { slackMrkdwnTextBoundary } from "./format.js";
 
 export type SlackAuthoredTextPlacement = "none" | "blocks" | "outside-blocks";
 
-// Project producer plans the same way so trimmed chunk seams cannot duplicate authored text.
-function normalizeSlackAuthoredTextFragments(fragments: readonly string[]): string[] {
-  return fragments.map((fragment) => fragment.trim()).filter(Boolean);
+// Project producer plans alike; null barriers retain native content with no mrkdwn equivalent.
+function normalizeSlackAuthoredTextFragments(fragments: readonly (string | null)[]) {
+  return fragments
+    .map((fragment) => fragment?.trim() ?? null)
+    .filter((fragment) => fragment !== "");
 }
 
 /** Resolve placement from producer facts, before accessibility text changes the payload text. */
@@ -14,7 +16,7 @@ export function resolveSlackAuthoredTextPlacement(params: {
   text?: string;
   interactive?: LegacyInteractiveReply;
   renderedInBlocks?: boolean;
-  renderedTextFragments?: readonly string[];
+  renderedTextFragments?: readonly (string | null)[];
   authoredChunkPlans?: readonly (readonly string[])[];
 }): SlackAuthoredTextPlacement {
   const text = normalizeOptionalString(params.text);
@@ -47,7 +49,7 @@ export function resolveSlackAuthoredTextPlacement(params: {
   for (let start = 0; start < fragments.length; start += 1) {
     let remaining = text;
     for (const fragment of fragments.slice(start)) {
-      if (!remaining.startsWith(fragment)) {
+      if (fragment === null || !remaining.startsWith(fragment)) {
         break;
       }
       remaining = remaining.slice(fragment.length);

--- a/extensions/slack/src/authored-text.ts
+++ b/extensions/slack/src/authored-text.ts
@@ -1,49 +1,12 @@
 import type { LegacyInteractiveReply } from "openclaw/plugin-sdk/interactive-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { slackMrkdwnTextBoundary } from "./format.js";
 
 export type SlackAuthoredTextPlacement = "none" | "blocks" | "outside-blocks";
 
 // Project producer plans the same way so trimmed chunk seams cannot duplicate authored text.
 function normalizeSlackAuthoredTextFragments(fragments: readonly string[]): string[] {
   return fragments.map((fragment) => fragment.trim()).filter(Boolean);
-}
-
-function isSlackAuthoredTextRepresentedInFragments(
-  text: string,
-  rawFragments: readonly string[],
-  authoredChunkPlans: readonly (readonly string[])[] = [],
-): boolean {
-  const fragments = normalizeSlackAuthoredTextFragments(rawFragments);
-  for (const rawPlan of authoredChunkPlans) {
-    const plan = normalizeSlackAuthoredTextFragments(rawPlan);
-    if (
-      plan.length > 0 &&
-      fragments.some((_, start) =>
-        plan.every((fragment, index) => fragment === fragments[start + index]),
-      )
-    ) {
-      return true;
-    }
-  }
-  // Legacy inline controls may split authored whitespace at fragment boundaries.
-  // Consume only those separators; code/literal interiors and chunk seams stay exact.
-  for (let start = 0; start < fragments.length; start += 1) {
-    let remaining = text;
-    for (const fragment of fragments.slice(start)) {
-      if (!remaining.startsWith(fragment)) {
-        break;
-      }
-      remaining = remaining.slice(fragment.length);
-      if (!remaining) {
-        return true;
-      }
-      if (!/^\s/u.test(remaining)) {
-        break;
-      }
-      remaining = remaining.trimStart();
-    }
-  }
-  return false;
 }
 
 /** Resolve placement from producer facts, before accessibility text changes the payload text. */
@@ -58,13 +21,44 @@ export function resolveSlackAuthoredTextPlacement(params: {
   if (!text) {
     return "none";
   }
+  if (params.renderedInBlocks) {
+    return "blocks";
+  }
   // Rendered facts own placement; raw legacy text is only a pre-render metadata source.
-  const fragments =
+  const fragments = normalizeSlackAuthoredTextFragments(
     params.renderedTextFragments ??
-    params.interactive?.blocks.flatMap((block) => (block.type === "text" ? [block.text] : [])) ??
-    [];
-  const isRepresentedInBlocks =
-    params.renderedInBlocks ||
-    isSlackAuthoredTextRepresentedInFragments(text, fragments, params.authoredChunkPlans);
-  return isRepresentedInBlocks ? "blocks" : "outside-blocks";
+      params.interactive?.blocks.flatMap((block) => (block.type === "text" ? [block.text] : [])) ??
+      [],
+  );
+  for (const rawPlan of params.authoredChunkPlans ?? []) {
+    const plan = normalizeSlackAuthoredTextFragments(rawPlan);
+    if (
+      plan.length > 0 &&
+      fragments.some((_, start) =>
+        plan.every((fragment, index) => fragment === fragments[start + index]),
+      )
+    ) {
+      return "blocks";
+    }
+  }
+  // Legacy inline controls may split authored whitespace at fragment boundaries.
+  // Consume only separators outside complete native formatting spans and tokens.
+  const isBoundary = slackMrkdwnTextBoundary(text);
+  for (let start = 0; start < fragments.length; start += 1) {
+    let remaining = text;
+    for (const fragment of fragments.slice(start)) {
+      if (!remaining.startsWith(fragment)) {
+        break;
+      }
+      remaining = remaining.slice(fragment.length);
+      if (!remaining) {
+        return "blocks";
+      }
+      if (!/^\s/u.test(remaining) || !isBoundary(text.length - remaining.length)) {
+        break;
+      }
+      remaining = remaining.trimStart();
+    }
+  }
+  return "outside-blocks";
 }

--- a/extensions/slack/src/authored-text.ts
+++ b/extensions/slack/src/authored-text.ts
@@ -4,37 +4,40 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runti
 
 export type SlackAuthoredTextPlacement = "none" | "blocks" | "outside-blocks";
 
-function normalizeComparableSlackText(text: string): string {
-  return text.trim().replace(/\s+/g, " ");
-}
-
-function isSlackAuthoredTextRepresentedInInteractive(
-  text: string,
-  interactive?: LegacyInteractiveReply,
-): boolean {
-  return isSlackAuthoredTextRepresentedInFragments(
-    text,
-    interactive?.blocks.flatMap((block) => (block.type === "text" ? [block.text] : [])) ?? [],
-  );
-}
-
 function isSlackAuthoredTextRepresentedInFragments(
   text: string,
   rawFragments: readonly string[],
+  authoredChunkPlans: readonly (readonly string[])[] = [],
 ): boolean {
-  const target = normalizeComparableSlackText(text);
-  const fragments = rawFragments.map(normalizeComparableSlackText).filter(Boolean);
-  // Legacy inline controls split surrounding text into multiple interactive text blocks.
+  const target = text.trim();
+  const fragments = rawFragments.map((fragment) => fragment.trim()).filter(Boolean);
+  if (
+    authoredChunkPlans.some(
+      (plan) =>
+        plan.length > 0 &&
+        fragments.some((_, start) =>
+          plan.every((fragment, index) => fragment === fragments[start + index]),
+        ),
+    )
+  ) {
+    return true;
+  }
+  // Legacy inline controls may split authored whitespace at fragment boundaries.
+  // Consume only those separators; code/literal interiors and chunk seams stay exact.
   for (let start = 0; start < fragments.length; start += 1) {
-    let combined = "";
-    for (let end = start; end < fragments.length; end += 1) {
-      combined = normalizeComparableSlackText(`${combined} ${fragments[end]}`);
-      if (combined === target) {
-        return true;
-      }
-      if (combined.length > target.length) {
+    let remaining = target;
+    for (const fragment of fragments.slice(start)) {
+      if (!remaining.startsWith(fragment)) {
         break;
       }
+      remaining = remaining.slice(fragment.length);
+      if (!remaining) {
+        return true;
+      }
+      if (!/^\s/u.test(remaining)) {
+        break;
+      }
+      remaining = remaining.trimStart();
     }
   }
   return false;
@@ -46,14 +49,19 @@ export function resolveSlackAuthoredTextPlacement(params: {
   interactive?: LegacyInteractiveReply;
   renderedInBlocks?: boolean;
   renderedTextFragments?: readonly string[];
+  authoredChunkPlans?: readonly (readonly string[])[];
 }): SlackAuthoredTextPlacement {
   const text = normalizeOptionalString(params.text);
   if (!text) {
     return "none";
   }
+  // Rendered facts own placement; raw legacy text is only a pre-render metadata source.
+  const fragments =
+    params.renderedTextFragments ??
+    params.interactive?.blocks.flatMap((block) => (block.type === "text" ? [block.text] : [])) ??
+    [];
   const isRepresentedInBlocks =
     params.renderedInBlocks ||
-    isSlackAuthoredTextRepresentedInFragments(text, params.renderedTextFragments ?? []) ||
-    isSlackAuthoredTextRepresentedInInteractive(text, params.interactive);
+    isSlackAuthoredTextRepresentedInFragments(text, fragments, params.authoredChunkPlans);
   return isRepresentedInBlocks ? "blocks" : "outside-blocks";
 }

--- a/extensions/slack/src/blocks-fallback.ts
+++ b/extensions/slack/src/blocks-fallback.ts
@@ -14,35 +14,13 @@ import {
   renderSlackDataVisualizationMrkdwnFallbackText,
 } from "./data-visualization.js";
 import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
+import { renderSlackRichTextFragments } from "./rich-text.js";
 
 type SlackNativeDataFallbackFormat = "plain" | "mrkdwn-safe";
 
 type RenderSlackBlockFallbackOptions = {
   nativeDataFormat?: SlackNativeDataFallbackFormat;
   nativeReferenceFormat?: SlackNativeDataFallbackFormat;
-};
-
-type SlackBlockLike = {
-  type?: unknown;
-  text?: unknown;
-  title?: unknown;
-  alt_text?: unknown;
-  elements?: unknown;
-  fields?: unknown;
-  accessory?: unknown;
-};
-
-type SlackRichTextElement = {
-  type?: unknown;
-  text?: unknown;
-  url?: unknown;
-  user_id?: unknown;
-  channel_id?: unknown;
-  usergroup_id?: unknown;
-  name?: unknown;
-  range?: unknown;
-  fallback?: unknown;
-  elements?: unknown;
 };
 
 const SLACK_SELECT_ELEMENT_TYPES = new Set([
@@ -63,95 +41,17 @@ function readTextObject(
   options: RenderSlackBlockFallbackOptions = {},
 ): string | undefined {
   const record = asOptionalRecord(value);
-  if (!record) {
-    return undefined;
-  }
   const text = normalizeOptionalString(record?.text);
   if (!text) {
     return undefined;
   }
-  return record.type === "plain_text" && options.nativeDataFormat !== "plain"
+  return record?.type === "plain_text" && options.nativeDataFormat !== "plain"
     ? escapeSlackMrkdwn(text)
     : text;
 }
 
-function renderSlackRichTextElement(
-  value: unknown,
-  renderReference: (text: string) => string,
-): string {
-  const element = asOptionalRecord(value) as SlackRichTextElement | undefined;
-  if (!element) {
-    return "";
-  }
-  switch (element.type) {
-    case "rich_text_section":
-    case "rich_text_preformatted":
-    case "rich_text_quote":
-      return renderSlackRichTextElements(element.elements, "", renderReference);
-    case "rich_text_list":
-      return renderSlackRichTextElements(element.elements, "\n", renderReference);
-    case "text":
-      return typeof element.text === "string" ? escapeSlackMrkdwn(element.text) : "";
-    case "link":
-      return escapeSlackMrkdwn(
-        normalizeOptionalString(element.text) ?? normalizeOptionalString(element.url) ?? "",
-      );
-    case "user": {
-      const userId = normalizeOptionalString(element.user_id);
-      return userId ? renderReference(`<@${userId}>`) : "";
-    }
-    case "channel": {
-      const channelId = normalizeOptionalString(element.channel_id);
-      return channelId ? renderReference(`<#${channelId}>`) : "";
-    }
-    case "usergroup": {
-      const usergroupId = normalizeOptionalString(element.usergroup_id);
-      return usergroupId ? renderReference(`<!subteam^${usergroupId}>`) : "";
-    }
-    case "broadcast": {
-      const range = normalizeOptionalString(element.range);
-      return range ? renderReference(`<!${range}>`) : "";
-    }
-    case "emoji": {
-      const name = normalizeOptionalString(element.name);
-      return name ? `:${name}:` : "";
-    }
-    case "date":
-      return escapeSlackMrkdwn(normalizeOptionalString(element.fallback) ?? "");
-    default:
-      return "";
-  }
-}
-
-function renderSlackRichTextElements(
-  value: unknown,
-  separator: string,
-  renderReference: (text: string) => string,
-): string {
-  if (!Array.isArray(value)) {
-    return "";
-  }
-  return value
-    .map((element) => renderSlackRichTextElement(element, renderReference))
-    .filter(Boolean)
-    .join(separator);
-}
-
-function readImageText(block: SlackBlockLike): string | undefined {
-  const altText = normalizeOptionalString(block.alt_text);
-  return (altText ? escapeSlackMrkdwn(altText) : undefined) ?? readTextObject(block.title);
-}
-
-function readVideoText(
-  block: SlackBlockLike,
-  options: RenderSlackBlockFallbackOptions = {},
-): string | undefined {
-  const altText = normalizeOptionalString(block.alt_text);
-  return readTextObject(block.title, options) ?? (altText ? escapeSlackMrkdwn(altText) : undefined);
-}
-
 function readContextTextFragments(
-  block: SlackBlockLike,
+  block: Record<string, unknown>,
   options: RenderSlackBlockFallbackOptions = {},
 ): string[] {
   if (!Array.isArray(block.elements)) {
@@ -199,7 +99,7 @@ function readControlElementsText(
 }
 
 function readSectionTextFragments(
-  block: SlackBlockLike,
+  block: Record<string, unknown>,
   options: RenderSlackBlockFallbackOptions = {},
 ): string[] {
   const parts = [readTextObject(block.text, options)];
@@ -215,7 +115,7 @@ export function renderSlackBlockFallbackText(
   raw: unknown,
   options: RenderSlackBlockFallbackOptions = {},
 ): string | undefined {
-  const block = asOptionalRecord(raw) as SlackBlockLike | undefined;
+  const block = asOptionalRecord(raw);
   if (!block) {
     return undefined;
   }
@@ -224,20 +124,28 @@ export function renderSlackBlockFallbackText(
       // Inbound references must survive for name resolution; literal text stays escaped
       // so token-shaped text cannot become a native mention. Outbound remains escaped.
       return normalizeOptionalString(
-        renderSlackRichTextElements(
-          block.elements,
-          "\n",
-          options.nativeReferenceFormat === "plain" ? (text) => text : escapeSlackMrkdwn,
-        ),
+        renderSlackRichTextFragments(block.elements, {
+          format: "escaped",
+          preserveReferences: options.nativeReferenceFormat === "plain",
+        }).join("\n"),
       );
     case "header":
       return readTextObject(block.text, options);
     case "section":
       return readSectionTextFragments(block, options).join("\n") || undefined;
-    case "image":
-      return readImageText(block) ?? "Shared an image";
-    case "video":
-      return readVideoText(block, options) ?? "Shared a video";
+    case "image": {
+      const altText = normalizeOptionalString(block.alt_text);
+      return (
+        (altText ? escapeSlackMrkdwn(altText) : readTextObject(block.title)) ?? "Shared an image"
+      );
+    }
+    case "video": {
+      const altText = normalizeOptionalString(block.alt_text);
+      return (
+        readTextObject(block.title, options) ??
+        (altText ? escapeSlackMrkdwn(altText) : "Shared a video")
+      );
+    }
     case "file":
       return "Shared a file";
     case "context":
@@ -264,13 +172,16 @@ export function renderSlackBlockFallbackText(
 }
 
 // Each Slack text object owns its formatting; accessibility joins cannot prove equivalence.
-export function renderSlackBlockTextFragments(raw: unknown): string[] {
+export function renderSlackBlockTextFragments(raw: unknown): (string | null)[] {
   const block = asOptionalRecord(raw);
   if (block?.type === "context") {
     return readContextTextFragments(block);
   }
   if (block?.type === "section") {
     return readSectionTextFragments(block);
+  }
+  if (block?.type === "rich_text") {
+    return renderSlackRichTextFragments(block.elements, { format: "styled" });
   }
   const text = renderSlackBlockFallbackText(raw);
   return text ? [text] : [];

--- a/extensions/slack/src/blocks-fallback.ts
+++ b/extensions/slack/src/blocks-fallback.ts
@@ -75,13 +75,6 @@ function readTextObject(
     : text;
 }
 
-function readTextValue(
-  value: unknown,
-  options: RenderSlackBlockFallbackOptions = {},
-): string | undefined {
-  return normalizeOptionalString(value) ?? readTextObject(value, options);
-}
-
 function renderSlackRichTextElement(
   value: unknown,
   renderReference: (text: string) => string,
@@ -157,21 +150,20 @@ function readVideoText(
   return readTextObject(block.title, options) ?? (altText ? escapeSlackMrkdwn(altText) : undefined);
 }
 
-function readContextText(
+function readContextTextFragments(
   block: SlackBlockLike,
   options: RenderSlackBlockFallbackOptions = {},
-): string | undefined {
+): string[] {
   if (!Array.isArray(block.elements)) {
-    return undefined;
+    return [];
   }
-  const parts = block.elements
+  return block.elements
     .map((element) => {
       const record = asOptionalRecord(element);
       const altText = normalizeOptionalString(record?.alt_text);
       return readTextObject(record, options) ?? (altText ? escapeSlackMrkdwn(altText) : undefined);
     })
     .filter((part): part is string => Boolean(part));
-  return parts.length > 0 ? parts.join(" ") : undefined;
 }
 
 function readControlElementText(
@@ -181,7 +173,7 @@ function readControlElementText(
   const element = asOptionalRecord(value);
   const type = normalizeOptionalString(element?.type);
   if (type === "button" || type === "workflow_button") {
-    return readTextValue(element?.text, options);
+    return normalizeOptionalString(element?.text) ?? readTextObject(element?.text, options);
   }
   if (type && SLACK_SELECT_ELEMENT_TYPES.has(type)) {
     return readTextObject(element?.placeholder, options);
@@ -206,26 +198,16 @@ function readControlElementsText(
   return labels.length > 0 ? labels.join("\n") : undefined;
 }
 
-function readSectionText(
+function readSectionTextFragments(
   block: SlackBlockLike,
   options: RenderSlackBlockFallbackOptions = {},
-): string | undefined {
+): string[] {
   const parts = [readTextObject(block.text, options)];
   if (Array.isArray(block.fields)) {
     parts.push(...block.fields.map((field) => readTextObject(field, options)));
   }
   parts.push(readControlElementText(block.accessory, options));
-  const visibleParts = parts.filter((part): part is string => Boolean(part));
-  return visibleParts.length > 0 ? visibleParts.join("\n") : undefined;
-}
-
-function readActionsText(
-  block: SlackBlockLike,
-  options: RenderSlackBlockFallbackOptions = {},
-): string | undefined {
-  return Array.isArray(block.elements)
-    ? readControlElementsText(block.elements, options)
-    : undefined;
+  return parts.filter((part): part is string => Boolean(part));
 }
 
 /** Read only user-visible text from one Slack block. */
@@ -251,7 +233,7 @@ export function renderSlackBlockFallbackText(
     case "header":
       return readTextObject(block.text, options);
     case "section":
-      return readSectionText(block, options);
+      return readSectionTextFragments(block, options).join("\n") || undefined;
     case "image":
       return readImageText(block) ?? "Shared an image";
     case "video":
@@ -259,9 +241,11 @@ export function renderSlackBlockFallbackText(
     case "file":
       return "Shared a file";
     case "context":
-      return readContextText(block, options);
+      return readContextTextFragments(block, options).join(" ") || undefined;
     case "actions":
-      return readActionsText(block, options);
+      return Array.isArray(block.elements)
+        ? readControlElementsText(block.elements, options)
+        : undefined;
     case "data_visualization":
       return options.nativeDataFormat === "plain"
         ? renderSlackDataVisualizationFallbackText(block)
@@ -277,6 +261,19 @@ export function renderSlackBlockFallbackText(
     default:
       return undefined;
   }
+}
+
+// Each Slack text object owns its formatting; accessibility joins cannot prove equivalence.
+export function renderSlackBlockTextFragments(raw: unknown): string[] {
+  const block = asOptionalRecord(raw);
+  if (block?.type === "context") {
+    return readContextTextFragments(block);
+  }
+  if (block?.type === "section") {
+    return readSectionTextFragments(block);
+  }
+  const text = renderSlackBlockFallbackText(raw);
+  return text ? [text] : [];
 }
 
 export function buildSlackBlocksFallbackText(blocks: readonly unknown[]): string {

--- a/extensions/slack/src/data-table.ts
+++ b/extensions/slack/src/data-table.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
 import { renderSlackMessagePresentationTableFallbackText } from "./presentation-fallback.js";
+import { renderSlackRichTextFragments } from "./rich-text.js";
 
 const SLACK_DATA_TABLE_COLUMNS_MAX = 20;
 const SLACK_DATA_TABLE_ROWS_MAX = 100;
@@ -51,72 +52,6 @@ function countCharacters(value: string): number {
   return Array.from(value).length;
 }
 
-function readRichTextLeaf(record: Record<string, unknown>): string {
-  if (record.type === "text" && typeof record.text === "string") {
-    return record.text;
-  }
-  const text = readNonEmptyString(record.text);
-  if (text) {
-    return text;
-  }
-  switch (record.type) {
-    case "link":
-      return readNonEmptyString(record.url) ?? "";
-    case "user": {
-      const userId = readNonEmptyString(record.user_id);
-      return userId ? `<@${userId}>` : "";
-    }
-    case "channel": {
-      const channelId = readNonEmptyString(record.channel_id);
-      return channelId ? `<#${channelId}>` : "";
-    }
-    case "usergroup": {
-      const usergroupId = readNonEmptyString(record.usergroup_id);
-      return usergroupId ? `<!subteam^${usergroupId}>` : "";
-    }
-    case "broadcast": {
-      const range = readNonEmptyString(record.range);
-      return range ? `<!${range}>` : "";
-    }
-    case "emoji": {
-      const name = readNonEmptyString(record.name);
-      return name ? `:${name}:` : "";
-    }
-    case "date":
-      return readNonEmptyString(record.fallback) ?? "";
-    default:
-      return "";
-  }
-}
-
-function readRichTextElements(value: unknown, separator = ""): string {
-  if (!Array.isArray(value)) {
-    return "";
-  }
-  const parts: string[] = [];
-  for (const rawElement of value) {
-    const element = asOptionalRecord(rawElement);
-    if (!element) {
-      continue;
-    }
-    if (Array.isArray(element.elements)) {
-      const rendered = readRichTextElements(
-        element.elements,
-        element.type === "rich_text_list" ? "\n" : "",
-      );
-      if (rendered) {
-        parts.push(rendered);
-      }
-      continue;
-    }
-    const rendered = readRichTextLeaf(element);
-    if (rendered) {
-      parts.push(rendered);
-    }
-  }
-  return parts.join(separator);
-}
-
 function readSlackBasicTableCell(value: unknown): string {
   const cell = asOptionalRecord(value);
   if (!cell) {
@@ -134,7 +69,9 @@ function readSlackBasicTableCell(value: unknown): string {
     }
     return typeof cell.value === "string" ? cell.value : "";
   }
-  return cell.type === "rich_text" ? readRichTextElements(cell.elements, "\n") : "";
+  return cell.type === "rich_text"
+    ? renderSlackRichTextFragments(cell.elements, { format: "plain" }).join("\n")
+    : "";
 }
 
 function parseSlackBasicTableRows(value: unknown): string[][] | undefined {
@@ -179,7 +116,9 @@ function readSlackDataTableCell(value: unknown, allowRichText: boolean): string 
       : undefined;
   }
   if (allowRichText && cell.type === "rich_text") {
-    return readNonEmptyString(readRichTextElements(cell.elements));
+    return readNonEmptyString(
+      renderSlackRichTextFragments(cell.elements, { format: "plain" }).join(""),
+    );
   }
   return undefined;
 }

--- a/extensions/slack/src/format.test.ts
+++ b/extensions/slack/src/format.test.ts
@@ -53,6 +53,26 @@ describe("chunkSlackMrkdwnText", () => {
     expect(chunks.every((chunk) => chunk.length > marker.length * 2)).toBe(true);
     expect(chunks.map((chunk) => chunk.slice(marker.length, -marker.length)).join("")).toBe(token);
   });
+
+  it.each([1, 2, 3])("preserves pending whitespace within a %s-character limit", (limit) => {
+    const chunks = chunkSlackMrkdwnText(" \t\n*y*", limit);
+    expect(chunks.every((chunk) => chunk.length <= limit)).toBe(true);
+    expect(chunks.join("").replaceAll("*", "")).toBe(" \t\ny");
+  });
+
+  it("reserves style overhead after a full leading whitespace chunk", () => {
+    const chunks = chunkSlackMrkdwnText(" ".repeat(3_000) + "*y*", 3_000);
+    expect(chunks.every((chunk) => chunk.length <= 3_000)).toBe(true);
+    expect(chunks.join("")).toBe(" ".repeat(3_000) + "*y*");
+  });
+
+  it.each(["*", "_", "~", "`", "```"])(
+    "preserves empty native %s pairs as literal bytes",
+    (marker) => {
+      const text = "x".repeat(3_000) + marker + marker + "tail";
+      expect(chunkSlackMrkdwnText(text, 3_000).join("")).toBe(text);
+    },
+  );
 });
 
 describe("normalizeSlackOutboundText", () => {

--- a/extensions/slack/src/format.ts
+++ b/extensions/slack/src/format.ts
@@ -150,7 +150,7 @@ function isUnsafeSlackEmphasisBoundary(character: string): boolean {
   return SLACK_MRKDWN_SYMBOL_RE.test(character) || isSlackCjkPunctuation(character);
 }
 
-function makeSlackEmphasisStylesSafe(ir: MarkdownIR): MarkdownIR {
+export function makeSlackEmphasisStylesSafe(ir: MarkdownIR): MarkdownIR {
   const styles = ir.styles.filter((span) => {
     if (span.style !== "italic" && span.style !== "bold") {
       return true;
@@ -207,22 +207,15 @@ function tokenizeSlackMrkdwn(text: string): string[] {
         continue;
       }
     }
-    const codePoint = text.codePointAt(index);
-    if (codePoint === undefined) {
-      break;
-    }
-    const character = String.fromCodePoint(codePoint);
+    const character = getCodePointAt(text, index);
     index += character.length;
     if (character === "\\" && index < text.length) {
-      const escapedCodePoint = text.codePointAt(index);
-      if (escapedCodePoint !== undefined) {
-        const escapedCharacter = String.fromCodePoint(escapedCodePoint);
-        tokens.push(character + escapedCharacter);
-        index += escapedCharacter.length;
-        continue;
-      }
+      const escapedCharacter = getCodePointAt(text, index);
+      tokens.push(character + escapedCharacter);
+      index += escapedCharacter.length;
+    } else {
+      tokens.push(character);
     }
-    tokens.push(character);
   }
   return tokens;
 }
@@ -231,11 +224,8 @@ function resolveSlackCodeMarkerTransition(
   active: SlackCodeMarker | undefined,
   token: string,
 ): SlackCodeMarker | undefined | null {
-  if (token === "```" && active !== "`") {
-    return active === "```" ? undefined : "```";
-  }
-  if (token === "`" && active !== "```") {
-    return active === "`" ? undefined : "`";
+  if ((token === "```" && active !== "`") || (token === "`" && active !== "```")) {
+    return active === token ? undefined : token;
   }
   return null;
 }
@@ -266,7 +256,7 @@ function scanSlackMrkdwn(text: string) {
       const start = opened.get(token.text);
       if (start && eligible(before, after)) {
         ranges.push([start.offset, offset + token.text.length]);
-        start.token.marker = token.marker = true;
+        start.token.marker = token.marker = offset > start.offset + token.text.length;
         opened.delete(token.text);
       } else if (eligible(after, before)) {
         // A literal delimiter must not consume the opener of a later real span.
@@ -483,66 +473,71 @@ export function chunkSlackMrkdwnText(text: string, limit: number): string[] {
     return [text];
   }
   const { tokens } = scanSlackMrkdwn(text);
-  if (!tokens.some((token) => token.marker || token.text.length > 1)) {
-    return chunkTextForOutbound(text, limit, { preserveWhitespace: true });
-  }
-
   const chunks: string[] = [];
-  const opened = new Map<string, boolean>();
-  let active: string[] = [];
+  const opened = new Map<string, string>();
+  const active = () => [...opened.values()].filter(Boolean);
+  let rendered: string[] = [];
   let content = "";
-  const close = () => active.toReversed().join("");
+  let whitespace = "";
+  const close = (markers: string[]) => markers.toReversed().join("");
   const flush = () => {
-    if (content && content !== active.join("")) {
-      chunks.push(content + close());
+    if (content || whitespace) {
+      chunks.push(content + close(rendered) + whitespace);
     }
-    content = "";
+    content = whitespace = "";
+    rendered = [];
+  };
+  const pending = () => {
+    const next = active();
+    const mismatch = rendered.findIndex((marker, index) => marker !== next[index]);
+    const shared = mismatch < 0 ? rendered.length : mismatch;
+    return close(rendered.slice(shared)) + whitespace + next.slice(shared).join("");
   };
 
   for (const { text: token, marker } of tokens) {
-    let next = active;
-    const closing = marker && opened.has(token);
     if (marker) {
-      const enabled = closing
-        ? opened.get(token)
-        : (active.join("").length + token.length) * 2 < limit;
-      if (closing) {
+      if (opened.has(token)) {
         opened.delete(token);
       } else {
-        opened.set(token, Boolean(enabled));
+        opened.set(token, (active().join("").length + token.length) * 2 < limit ? token : "");
       }
-      if (!enabled) {
-        continue;
-      }
-      next = closing ? active.filter((value) => value !== token) : [...active, token];
-    }
-    const nextOverhead = next.join("").length;
-    if (content && content.length + token.length + nextOverhead > limit) {
-      flush();
-    }
-    const prefix = active.join("");
-    active = next;
-    if (!content && closing) {
       continue;
     }
-    const contentLimit = limit - prefix.length - nextOverhead;
+    const inCode = opened.has("`") || opened.has("```");
+    // Emit styles with content, keeping chunk-edge whitespace outside emphasis without losing bytes.
+    if (!inCode && /^\s+$/u.test(token)) {
+      if (content.length + close(rendered).length + whitespace.length + token.length > limit) {
+        flush();
+      }
+      whitespace += token;
+      continue;
+    }
+    if (
+      (content || whitespace) &&
+      content.length + pending().length + token.length + close(active()).length > limit
+    ) {
+      flush();
+    }
+    const markers = active();
+    const prefix = markers.join("");
+    const contentLimit = limit - prefix.length * 2;
     if (token.length > contentLimit) {
       flush();
-      const inCode = opened.has("`") || opened.has("```");
-      if (inCode && isAllowedSlackAngleToken(token)) {
-        const value = active.length ? token : escapeSlackMrkdwnSegment(token);
-        chunks.push(
-          ...chunkTextForOutbound(value, Math.max(1, Math.floor(contentLimit)), {
-            preserveWhitespace: true,
-          }).map((fragment) => prefix + fragment + close()),
-        );
-      } else {
-        chunks.push(...(token.length <= limit ? [token] : chunkTextForOutbound(token, limit)));
-      }
+      const codeAngle = inCode && isAllowedSlackAngleToken(token);
+      const value = codeAngle && !markers.length ? escapeSlackMrkdwnSegment(token) : token;
+      const fragments = chunkTextForOutbound(
+        value,
+        codeAngle ? Math.max(1, Math.floor(contentLimit)) : limit,
+        codeAngle ? { preserveWhitespace: true } : undefined,
+      );
+      chunks.push(
+        ...fragments.map((fragment) => (codeAngle ? prefix + fragment + close(markers) : fragment)),
+      );
       continue;
     }
-    content ||= prefix;
-    content += token;
+    content += pending() + token;
+    rendered = markers;
+    whitespace = "";
   }
   flush();
   return chunks;

--- a/extensions/slack/src/format.ts
+++ b/extensions/slack/src/format.ts
@@ -7,6 +7,7 @@ import {
   markdownToIR,
   type MarkdownIR,
   type MarkdownLinkSpan,
+  type MarkdownStyleSpan,
   renderMarkdownIRChunksWithinLimit,
   renderMarkdownWithMarkers,
 } from "openclaw/plugin-sdk/text-chunking";
@@ -139,30 +140,33 @@ function isSlackCjkPunctuation(character: string): boolean {
   );
 }
 
-function isUnsafeSlackEmphasisBoundary(character: string): boolean {
-  if (SLACK_MRKDWN_WORD_CHARACTER_RE.test(character)) {
-    return true;
-  }
-  const codePoint = character.codePointAt(0);
-  if (codePoint === undefined || codePoint <= 0x7f) {
+function isSlackEmphasisEdge(inside: string, outside: string, wordBounded: boolean): boolean {
+  const hasContent = inside.length > 0 && !/\s/u.test(inside);
+  if (!hasContent || (wordBounded && SLACK_MRKDWN_WORD_CHARACTER_RE.test(outside))) {
     return false;
   }
-  return SLACK_MRKDWN_SYMBOL_RE.test(character) || isSlackCjkPunctuation(character);
+  const codePoint = outside.codePointAt(0);
+  return (
+    !wordBounded ||
+    codePoint === undefined ||
+    codePoint <= 0x7f ||
+    (!SLACK_MRKDWN_SYMBOL_RE.test(outside) && !isSlackCjkPunctuation(outside))
+  );
 }
 
-export function makeSlackEmphasisStylesSafe(ir: MarkdownIR): MarkdownIR {
-  const styles = ir.styles.filter((span) => {
-    if (span.style !== "italic" && span.style !== "bold") {
-      return true;
-    }
-    // Slack's parser can expose markers accepted by the CJK-friendly Markdown parser.
-    // Drop only the affected style so transport syntax never leaks into visible text.
-    return (
-      !isUnsafeSlackEmphasisBoundary(getCodePointBefore(ir.text, span.start)) &&
-      !isUnsafeSlackEmphasisBoundary(getCodePointAt(ir.text, span.end))
-    );
-  });
-  return styles.length === ir.styles.length ? ir : { ...ir, styles };
+export function isSlackEmphasisStyleSafe(text: string, span: MarkdownStyleSpan): boolean {
+  const wordBounded = span.style === "bold" || span.style === "italic";
+  if (!wordBounded && span.style !== "strikethrough") {
+    return true;
+  }
+  // Slack requires both content and outside flanks to admit a native emphasis delimiter.
+  return [span.start, span.end].every((offset, index) =>
+    isSlackEmphasisEdge(
+      index === 0 ? getCodePointAt(text, offset) : getCodePointBefore(text, offset),
+      index === 0 ? getCodePointBefore(text, offset) : getCodePointAt(text, offset),
+      wordBounded,
+    ),
+  );
 }
 
 const SLACK_FORMAT_PROFILE = FormatCapabilityProfile.define({
@@ -249,10 +253,7 @@ function scanSlackMrkdwn(text: string) {
       const after = getCodePointAt(text, offset + token.text.length);
       const wordBounded = token.text === "*" || token.text === "_";
       const eligible = (inside: string, outside: string) =>
-        transition !== null ||
-        (inside.length > 0 &&
-          !/\s/u.test(inside) &&
-          (!wordBounded || !isUnsafeSlackEmphasisBoundary(outside)));
+        transition !== null || isSlackEmphasisEdge(inside, outside, wordBounded);
       const start = opened.get(token.text);
       if (start && eligible(before, after)) {
         ranges.push([start.offset, offset + token.text.length]);
@@ -445,16 +446,17 @@ export const SLACK_RENDER_OPTIONS = {
   buildLink: buildSlackLink,
 };
 function parseSlackMarkdown(markdown: string, options: SlackMarkdownOptions): MarkdownIR {
-  return makeSlackEmphasisStylesSafe(
-    markdownToIR(markdown ?? "", {
-      assistantTranscriptRoleHeaders: true,
-      linkify: false,
-      autolink: false,
-      headingStyle: "rich",
-      blockquotePrefix: "> ",
-      tableMode: options.tableMode,
-    }),
-  );
+  const ir = markdownToIR(markdown ?? "", {
+    assistantTranscriptRoleHeaders: true,
+    linkify: false,
+    autolink: false,
+    headingStyle: "rich",
+    blockquotePrefix: "> ",
+    tableMode: options.tableMode,
+  });
+  // Slack's parser can expose markers accepted by the CJK-friendly Markdown parser.
+  // Drop only the affected style so transport syntax never leaks into visible text.
+  return { ...ir, styles: ir.styles.filter((span) => isSlackEmphasisStyleSafe(ir.text, span)) };
 }
 
 export function normalizeSlackOutboundText(

--- a/extensions/slack/src/format.ts
+++ b/extensions/slack/src/format.ts
@@ -13,33 +13,21 @@ import {
 
 // Escape special characters for Slack mrkdwn format.
 // Preserve Slack's angle-bracket tokens so mentions and links stay intact.
-function escapeSlackMrkdwnSegment(text: string): string {
+export function escapeSlackMrkdwnSegment(text: string): string {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 const SLACK_ANGLE_TOKEN_RE = /<[^>\n]+>/g;
 
 function isAllowedSlackAngleToken(token: string): boolean {
-  if (!token.startsWith("<") || !token.endsWith(">")) {
-    return false;
-  }
-  const inner = token.slice(1, -1);
   return (
-    inner.startsWith("@") ||
-    inner.startsWith("#") ||
-    inner.startsWith("!") ||
-    inner.startsWith("mailto:") ||
-    inner.startsWith("tel:") ||
-    inner.startsWith("http://") ||
-    inner.startsWith("https://") ||
-    inner.startsWith("slack://")
+    token.startsWith("<") &&
+    token.endsWith(">") &&
+    /^(?:[@#!]|mailto:|tel:|https?:\/\/|slack:\/\/)/u.test(token.slice(1, -1))
   );
 }
 
 function escapeSlackMrkdwnContent(text: string): string {
-  if (!text) {
-    return "";
-  }
   if (!text.includes("&") && !text.includes("<") && !text.includes(">")) {
     return text;
   }
@@ -65,9 +53,6 @@ function escapeSlackMrkdwnContent(text: string): string {
 }
 
 function escapeSlackMrkdwnText(text: string): string {
-  if (!text) {
-    return "";
-  }
   if (!text.includes("&") && !text.includes("<") && !text.includes(">")) {
     return text;
   }
@@ -255,29 +240,51 @@ function resolveSlackCodeMarkerTransition(
   return null;
 }
 
-/** Native fields may separate only outside complete formatting spans or atomic tokens. */
-export function slackMrkdwnTextBoundary(text: string): (offset: number) => boolean {
+function scanSlackMrkdwn(text: string) {
   // Unmatched literal delimiters do not form spans; paired markers protect their entire content.
+  const tokens = tokenizeSlackMrkdwn(text).map((token) => ({ text: token, marker: false }));
   const ranges: Array<[number, number]> = [];
-  const opened = new Map<string, number>();
+  const opened = new Map<string, { offset: number; token: (typeof tokens)[number] }>();
   let activeCode: SlackCodeMarker | undefined;
   let offset = 0;
-  for (const token of tokenizeSlackMrkdwn(text)) {
-    const transition = resolveSlackCodeMarkerTransition(activeCode, token);
-    const marker = transition !== null || (!activeCode && ["*", "_", "~"].includes(token));
-    if (transition !== null) activeCode = transition;
+  for (const token of tokens) {
+    const transition = resolveSlackCodeMarkerTransition(activeCode, token.text);
+    const marker = transition !== null || (!activeCode && ["*", "_", "~"].includes(token.text));
+    if (transition !== null) {
+      activeCode = transition;
+      token.marker = true;
+    }
     if (marker) {
-      const start = opened.get(token);
-      if (start === undefined) opened.set(token, offset);
-      else {
-        ranges.push([start, offset + token.length]);
-        opened.delete(token);
+      const before = getCodePointBefore(text, offset);
+      const after = getCodePointAt(text, offset + token.text.length);
+      const wordBounded = token.text === "*" || token.text === "_";
+      const eligible = (inside: string, outside: string) =>
+        transition !== null ||
+        (inside.length > 0 &&
+          !/\s/u.test(inside) &&
+          (!wordBounded || !isUnsafeSlackEmphasisBoundary(outside)));
+      const start = opened.get(token.text);
+      if (start && eligible(before, after)) {
+        ranges.push([start.offset, offset + token.text.length]);
+        start.token.marker = token.marker = true;
+        opened.delete(token.text);
+      } else if (eligible(after, before)) {
+        // A literal delimiter must not consume the opener of a later real span.
+        opened.set(token.text, { offset, token });
       }
     }
-    if (token.length > 1) ranges.push([offset, offset + token.length]);
-    offset += token.length;
+    if (token.text.length > 1) {
+      ranges.push([offset, offset + token.text.length]);
+    }
+    offset += token.text.length;
   }
-  return (offset) => !ranges.some(([start, end]) => start < offset && offset < end);
+  return { tokens, ranges };
+}
+
+/** Native fields may separate only outside complete formatting spans or atomic tokens. */
+export function slackMrkdwnTextBoundary(text: string): (offset: number) => boolean {
+  const { ranges } = scanSlackMrkdwn(text);
+  return (boundary) => !ranges.some(([start, end]) => start < boundary && boundary < end);
 }
 
 type SlackVisibleProjection = {
@@ -429,32 +436,26 @@ function protectSlackAssistantTranscriptRoleHeaders(text: string): string {
   return `${SLACK_ASSISTANT_TRANSCRIPT_PREFIX}${text}`;
 }
 
-function buildSlackRenderOptions() {
-  return {
-    annotationMarkers: {
-      assistant_transcript_role: {
-        open: "`",
-        close: "`",
-        suppressNestedFormatting: true,
-      },
+export const SLACK_RENDER_OPTIONS = {
+  annotationMarkers: {
+    assistant_transcript_role: {
+      open: "`",
+      close: "`",
+      suppressNestedFormatting: true,
     },
-    styleMarkers: {
-      bold: { open: "*", close: "*" },
-      italic: { open: "_", close: "_" },
-      strikethrough: { open: "~", close: "~" },
-      code: { open: "`", close: "`" },
-      code_block: { open: "```\n", close: "```" },
-    },
-    escapeText: escapeSlackMrkdwnText,
-    buildLink: buildSlackLink,
-  };
-}
-
-export function normalizeSlackOutboundText(
-  markdown: string,
-  options: SlackMarkdownOptions = {},
-): string {
-  const ir = makeSlackEmphasisStylesSafe(
+  },
+  styleMarkers: {
+    bold: { open: "*", close: "*" },
+    italic: { open: "_", close: "_" },
+    strikethrough: { open: "~", close: "~" },
+    code: { open: "`", close: "`" },
+    code_block: { open: "```\n", close: "```" },
+  },
+  escapeText: escapeSlackMrkdwnText,
+  buildLink: buildSlackLink,
+};
+function parseSlackMarkdown(markdown: string, options: SlackMarkdownOptions): MarkdownIR {
+  return makeSlackEmphasisStylesSafe(
     markdownToIR(markdown ?? "", {
       assistantTranscriptRoleHeaders: true,
       linkify: false,
@@ -464,85 +465,83 @@ export function normalizeSlackOutboundText(
       tableMode: options.tableMode,
     }),
   );
+}
+
+export function normalizeSlackOutboundText(
+  markdown: string,
+  options: SlackMarkdownOptions = {},
+): string {
+  const ir = parseSlackMarkdown(markdown, options);
   return protectSlackAssistantTranscriptRoleHeaders(
-    renderMarkdownWithMarkers(ir, buildSlackRenderOptions(), SLACK_FORMAT_PROFILE),
+    renderMarkdownWithMarkers(ir, SLACK_RENDER_OPTIONS, SLACK_FORMAT_PROFILE),
   );
 }
 
-/** Chunk already-rendered Slack mrkdwn without splitting entities or code markers. */
+/** Chunk rendered Slack text with the same marker/atomic-token facts used for placement. */
 export function chunkSlackMrkdwnText(text: string, limit: number): string[] {
   if (text.length <= limit) {
     return [text];
   }
-  const hasProtectedToken =
-    text.includes("`") ||
-    text.includes("&amp;") ||
-    text.includes("&lt;") ||
-    text.includes("&gt;") ||
-    (text.match(/<[^>\n]+>/gu)?.some(isAllowedSlackAngleToken) ?? false) ||
-    /\\[\s\S]/u.test(text);
-  if (!hasProtectedToken) {
+  const { tokens } = scanSlackMrkdwn(text);
+  if (!tokens.some((token) => token.marker || token.text.length > 1)) {
     return chunkTextForOutbound(text, limit, { preserveWhitespace: true });
   }
 
   const chunks: string[] = [];
-  let activeMarker: SlackCodeMarker | undefined;
+  const opened = new Map<string, boolean>();
+  let active: string[] = [];
   let content = "";
-  const wrapper = (marker: SlackCodeMarker | undefined) =>
-    marker && limit > marker.length * 2 ? marker : undefined;
-  const capacity = (marker: SlackCodeMarker | undefined) => limit - (wrapper(marker)?.length ?? 0);
+  const close = () => active.toReversed().join("");
   const flush = () => {
-    const marker = wrapper(activeMarker);
-    if (content && content !== marker) {
-      chunks.push(marker ? `${content}${marker}` : content);
+    if (content && content !== active.join("")) {
+      chunks.push(content + close());
     }
     content = "";
   };
 
-  for (const token of tokenizeSlackMrkdwn(text)) {
-    const transition = resolveSlackCodeMarkerTransition(activeMarker, token);
-    const nextMarker = transition === null ? activeMarker : transition;
-    const sourceMarker = token === "`" || token === "```" ? token : undefined;
-    if (transition !== null && sourceMarker && !wrapper(sourceMarker)) {
-      activeMarker = nextMarker;
-      continue;
-    }
-    if (content && content.length + token.length > capacity(nextMarker)) {
-      flush();
-    }
-    activeMarker = nextMarker;
-    if (!content && transition === undefined) {
-      continue;
-    }
-    content ||= transition === null ? (wrapper(activeMarker) ?? "") : "";
-
-    const contentLimit = capacity(activeMarker) - (wrapper(activeMarker)?.length ?? 0);
-    if (token.length > contentLimit) {
-      flush();
-      const marker = wrapper(activeMarker);
-      if (activeMarker && isAllowedSlackAngleToken(token)) {
-        if (marker) {
-          chunks.push(
-            ...chunkTextForOutbound(token, Math.max(1, Math.floor(contentLimit)), {
-              preserveWhitespace: true,
-            }).map((fragment) => `${marker}${fragment}${marker}`),
-          );
-        } else {
-          chunks.push(
-            ...chunkTextForOutbound(
-              escapeSlackMrkdwnSegment(token),
-              Math.max(1, Math.floor(limit)),
-              {
-                preserveWhitespace: true,
-              },
-            ),
-          );
-        }
+  for (const { text: token, marker } of tokens) {
+    let next = active;
+    const closing = marker && opened.has(token);
+    if (marker) {
+      const enabled = closing
+        ? opened.get(token)
+        : (active.join("").length + token.length) * 2 < limit;
+      if (closing) {
+        opened.delete(token);
+      } else {
+        opened.set(token, Boolean(enabled));
+      }
+      if (!enabled) {
         continue;
       }
-      chunks.push(...(token.length <= limit ? [token] : chunkTextForOutbound(token, limit)));
+      next = closing ? active.filter((value) => value !== token) : [...active, token];
+    }
+    const nextOverhead = next.join("").length;
+    if (content && content.length + token.length + nextOverhead > limit) {
+      flush();
+    }
+    const prefix = active.join("");
+    active = next;
+    if (!content && closing) {
       continue;
     }
+    const contentLimit = limit - prefix.length - nextOverhead;
+    if (token.length > contentLimit) {
+      flush();
+      const inCode = opened.has("`") || opened.has("```");
+      if (inCode && isAllowedSlackAngleToken(token)) {
+        const value = active.length ? token : escapeSlackMrkdwnSegment(token);
+        chunks.push(
+          ...chunkTextForOutbound(value, Math.max(1, Math.floor(contentLimit)), {
+            preserveWhitespace: true,
+          }).map((fragment) => prefix + fragment + close()),
+        );
+      } else {
+        chunks.push(...(token.length <= limit ? [token] : chunkTextForOutbound(token, limit)));
+      }
+      continue;
+    }
+    content ||= prefix;
     content += token;
   }
   flush();
@@ -554,23 +553,13 @@ export function markdownToSlackMrkdwnChunks(
   limit: number,
   options: SlackMarkdownOptions = {},
 ): string[] {
-  const ir = makeSlackEmphasisStylesSafe(
-    markdownToIR(markdown ?? "", {
-      assistantTranscriptRoleHeaders: true,
-      linkify: false,
-      autolink: false,
-      headingStyle: "rich",
-      blockquotePrefix: "> ",
-      tableMode: options.tableMode,
-    }),
-  );
-  const renderOptions = buildSlackRenderOptions();
+  const ir = parseSlackMarkdown(markdown, options);
   return renderMarkdownIRChunksWithinLimit({
     ir,
     limit,
     renderChunk: (chunk) =>
       protectSlackAssistantTranscriptRoleHeaders(
-        renderMarkdownWithMarkers(chunk, renderOptions, SLACK_FORMAT_PROFILE),
+        renderMarkdownWithMarkers(chunk, SLACK_RENDER_OPTIONS, SLACK_FORMAT_PROFILE),
       ),
     measureRendered: (rendered) => rendered.length,
   }).map(({ rendered }) => rendered);

--- a/extensions/slack/src/format.ts
+++ b/extensions/slack/src/format.ts
@@ -105,7 +105,7 @@ function buildSlackLink(link: MarkdownLinkSpan, text: string) {
   };
 }
 
-type SlackMarkdownOptions = {
+export type SlackMarkdownOptions = {
   tableMode?: MarkdownTableMode;
 };
 
@@ -253,6 +253,31 @@ function resolveSlackCodeMarkerTransition(
     return active === "`" ? undefined : "`";
   }
   return null;
+}
+
+/** Native fields may separate only outside complete formatting spans or atomic tokens. */
+export function slackMrkdwnTextBoundary(text: string): (offset: number) => boolean {
+  // Unmatched literal delimiters do not form spans; paired markers protect their entire content.
+  const ranges: Array<[number, number]> = [];
+  const opened = new Map<string, number>();
+  let activeCode: SlackCodeMarker | undefined;
+  let offset = 0;
+  for (const token of tokenizeSlackMrkdwn(text)) {
+    const transition = resolveSlackCodeMarkerTransition(activeCode, token);
+    const marker = transition !== null || (!activeCode && ["*", "_", "~"].includes(token));
+    if (transition !== null) activeCode = transition;
+    if (marker) {
+      const start = opened.get(token);
+      if (start === undefined) opened.set(token, offset);
+      else {
+        ranges.push([start, offset + token.length]);
+        opened.delete(token);
+      }
+    }
+    if (token.length > 1) ranges.push([offset, offset + token.length]);
+    offset += token.length;
+  }
+  return (offset) => !ranges.some(([start, end]) => start < offset && offset < end);
 }
 
 type SlackVisibleProjection = {

--- a/extensions/slack/src/message-action-dispatch.test.ts
+++ b/extensions/slack/src/message-action-dispatch.test.ts
@@ -331,7 +331,10 @@ describe("handleSlackMessageAction", () => {
       });
       expect(firstAction(invoke)).toMatchObject({
         action: "editMessage",
-        content: paddedMarkdownTable,
+        content:
+          tables === "off"
+            ? paddedMarkdownTable
+            : Array.from({ length: 20 }, () => "*x*\n• Value: 2").join("\n\n"),
       });
     },
   );
@@ -731,8 +734,29 @@ describe("handleSlackMessageAction", () => {
     },
   );
 
+  it("measures native mrkdwn fallback bytes without a second Markdown escape", async () => {
+    const invoke = createInvokeSpy();
+    const text = `${"&".repeat(801)}${"x".repeat(2_200)}`;
+    await handleSlackMessageAction({
+      providerId: "slack",
+      ctx: {
+        action: "edit",
+        channel: "slack",
+        cfg: {},
+        params: {
+          channelId: "C1",
+          messageId: "171234.567",
+          presentation: { blocks: [{ type: "text", text }] },
+        },
+      },
+      invoke,
+    });
+    expect(firstAction(invoke)).toMatchObject({ content: text, blocks: undefined });
+    expect(firstInvokeCall(invoke)[2]).toMatchObject({ preparedEditText: text });
+  });
+
   it.each([
-    { name: "Slack markdown rendering", text: `${"&".repeat(801)}${"x".repeat(2_200)}` },
+    { name: "Slack entity bytes", text: `${"&amp;".repeat(801)}${"x".repeat(2_200)}` },
     { name: "UTF-8 expansion", text: "😀".repeat(1_501) },
   ])("rejects presentation fallback edits that overflow after $name", async ({ text }) => {
     const invoke = createInvokeSpy();

--- a/extensions/slack/src/message-action-dispatch.test.ts
+++ b/extensions/slack/src/message-action-dispatch.test.ts
@@ -12,8 +12,8 @@ import { renderSlackMessagePresentationFallbackText } from "./presentation-fallb
 
 function createInvokeSpy() {
   return vi.fn(async (action: Record<string, unknown>, _cfg?: unknown, _toolContext?: unknown) => ({
-    ok: true,
-    content: action,
+    content: [],
+    details: { ok: true, action },
   }));
 }
 
@@ -384,6 +384,34 @@ describe("handleSlackMessageAction", () => {
       content: `${title}\n\n- Status: \`/status\``,
       blocks: undefined,
     });
+  });
+
+  it.each(
+    ["text", "context"].flatMap((type) => [
+      { type, format: "plain", text: "x".repeat(3_001) },
+      { type, format: "inline code", text: `\`${"x".repeat(3_001)}\`` },
+      { type, format: "fenced code", text: `\`\`\`\n${"x".repeat(3_001)}\n\`\`\`` },
+    ]),
+  )("deduplicates chunked $format $type before the edit byte limit", async ({ type, text }) => {
+    const invoke = createInvokeSpy();
+    await handleSlackMessageAction({
+      providerId: "slack",
+      ctx: {
+        action: "edit",
+        channel: "slack",
+        params: {
+          channelId: "C123",
+          messageId: "123.456",
+          message: text,
+          presentation: { blocks: [{ type, text }] },
+        },
+        cfg: slackConfig(),
+      },
+      normalizeChannelId: (value) => value,
+      invoke,
+    });
+    expect(firstAction(invoke)).toMatchObject({ action: "editMessage", content: text });
+    expect(firstAction(invoke).blocks).toBeUndefined();
   });
 
   it("keeps oversized notification fallback for visibly rendered block edits", async () => {

--- a/extensions/slack/src/message-action-dispatch.test.ts
+++ b/extensions/slack/src/message-action-dispatch.test.ts
@@ -353,6 +353,39 @@ describe("handleSlackMessageAction", () => {
     expect(firstAction(invoke)).toMatchObject({ action: "editMessage", content: message });
   });
 
+  it("deduplicates represented fallback text before checking the edit byte limit", async () => {
+    const invoke = createInvokeSpy();
+    const title = "x".repeat(2_100);
+    await handleSlackMessageAction({
+      providerId: "slack",
+      ctx: {
+        action: "edit",
+        cfg: {},
+        params: {
+          channelId: "C1",
+          messageId: "171234.567",
+          message: title,
+          presentation: {
+            title,
+            blocks: [
+              {
+                type: "buttons",
+                buttons: [{ label: "Status", action: { type: "command", command: "/status" } }],
+              },
+            ],
+          },
+        },
+      } as never,
+      invoke: invoke as never,
+    });
+
+    expect(firstAction(invoke)).toMatchObject({
+      action: "editMessage",
+      content: `${title}\n\n- Status: \`/status\``,
+      blocks: undefined,
+    });
+  });
+
   it("keeps oversized notification fallback for visibly rendered block edits", async () => {
     const invoke = createInvokeSpy();
     const message = "x".repeat(4_001);

--- a/extensions/slack/src/message-action-dispatch.ts
+++ b/extensions/slack/src/message-action-dispatch.ts
@@ -14,6 +14,7 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveDefaultSlackAccountId, resolveSlackMarkdownOptions } from "./accounts.js";
+import type { SlackActionContext } from "./action-runtime.js";
 import { normalizeSlackOutboundText } from "./format.js";
 import { SLACK_EDIT_TEXT_MAX_BYTES } from "./limits.js";
 import { renderSlackMessagePresentationFallbackText } from "./presentation-fallback.js";
@@ -21,7 +22,6 @@ import { SLACK_SECTION_TEXT_MAX } from "./presentation.js";
 import {
   resolveSlackReplyBlockResolution,
   resolveSlackReplyDeliveryMessages,
-  type SlackReplyDeliveryMessage,
 } from "./reply-blocks.js";
 import { resolveSlackThreadTsValue } from "./thread-ts.js";
 import { countSlackTextUtf8Bytes } from "./truncate.js";
@@ -29,7 +29,7 @@ import { countSlackTextUtf8Bytes } from "./truncate.js";
 type SlackActionInvoke = (
   action: Record<string, unknown>,
   cfg: ChannelMessageActionContext["cfg"],
-  toolContext?: ChannelMessageActionContext["toolContext"],
+  toolContext?: SlackActionContext,
 ) => Promise<AgentToolResult<unknown>>;
 
 function readSlackForceDocument(params: Record<string, unknown>): boolean {
@@ -100,7 +100,7 @@ export async function handleSlackMessageAction(params: {
       preparedMessages.length > 0
         ? {
             ...ctx.toolContext,
-            preparedMessages: preparedMessages satisfies readonly SlackReplyDeliveryMessage[],
+            preparedMessages,
           }
         : ctx.toolContext;
     return await invoke(

--- a/extensions/slack/src/message-action-dispatch.ts
+++ b/extensions/slack/src/message-action-dispatch.ts
@@ -15,8 +15,6 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveDefaultSlackAccountId } from "./accounts.js";
-import { SLACK_MAX_BLOCKS } from "./blocks-input.js";
-import { buildSlackPresentationBlocks, canRenderSlackPresentation } from "./blocks-render.js";
 import { normalizeSlackOutboundText } from "./format.js";
 import { SLACK_EDIT_TEXT_MAX_BYTES } from "./limits.js";
 import { renderSlackMessagePresentationFallbackText } from "./presentation-fallback.js";
@@ -39,44 +37,6 @@ function readSlackForceDocument(params: Record<string, unknown>): boolean {
   return (
     readBooleanParam(params, "forceDocument") ?? readBooleanParam(params, "asDocument") ?? false
   );
-}
-
-function resolveSlackPresentationText(
-  content: string | undefined,
-  presentation: ReturnType<typeof normalizeMessagePresentation>,
-): string {
-  const hasStructuredData = presentation?.blocks.some(
-    (block) => block.type === "chart" || block.type === "table",
-  );
-  return hasStructuredData
-    ? renderSlackMessagePresentationFallbackText({ text: content, presentation })
-    : (content ?? "");
-}
-
-function renderSlackActionPresentation(
-  presentation: ReturnType<typeof normalizeMessagePresentation>,
-): {
-  blocks?: ReturnType<typeof buildSlackPresentationBlocks>;
-  usesPresentationTextFallback: boolean;
-} {
-  if (!presentation) {
-    return { usesPresentationTextFallback: false };
-  }
-  const needsCompleteTextFallback = presentation.blocks.some(
-    (block) =>
-      (block.type === "text" || block.type === "context") &&
-      block.text.trim().length > SLACK_SECTION_TEXT_MAX,
-  );
-  const renderedBlocks =
-    !needsCompleteTextFallback && canRenderSlackPresentation(presentation)
-      ? buildSlackPresentationBlocks(presentation)
-      : undefined;
-  const usesPresentationTextFallback = !renderedBlocks || renderedBlocks.length > SLACK_MAX_BLOCKS;
-  const blocks = usesPresentationTextFallback ? undefined : renderedBlocks;
-  return {
-    ...(blocks?.length ? { blocks } : {}),
-    usesPresentationTextFallback,
-  };
 }
 
 /** Translate generic channel action requests into Slack-specific tool invocations and payload shapes. */
@@ -224,15 +184,32 @@ export async function handleSlackMessageAction(params: {
     });
     const content = readStringParam(actionParams, "message", { allowEmpty: true });
     const presentation = normalizeMessagePresentation(actionParams.presentation);
-    const renderedPresentation = renderSlackActionPresentation(presentation);
+    const resolution = resolveSlackReplyBlockResolution({ text: content, presentation });
+    const nativeSegment = resolution.segments.length === 1 ? resolution.segments[0] : undefined;
+    // Edits retain their single-message fallback for oversized text, even though sends can chunk it.
+    const usesPresentationTextFallback = Boolean(
+      presentation &&
+      (nativeSegment?.kind !== "blocks" ||
+        presentation.blocks.some(
+          (block) =>
+            (block.type === "text" || block.type === "context") &&
+            block.text.trim().length > SLACK_SECTION_TEXT_MAX,
+        )),
+    );
     // Slack hides top-level text when blocks are present on updates. Keep an
     // unrenderable presentation text-only so its complete fallback stays visible.
-    const blocks = renderedPresentation.usesPresentationTextFallback
-      ? undefined
-      : renderedPresentation.blocks;
-    const accessibleContent = renderedPresentation.usesPresentationTextFallback
-      ? renderSlackMessagePresentationFallbackText({ text: content, presentation })
-      : resolveSlackPresentationText(content, presentation);
+    const blocks =
+      !usesPresentationTextFallback && nativeSegment?.kind === "blocks"
+        ? nativeSegment.blocks
+        : undefined;
+    const accessibleContent =
+      usesPresentationTextFallback ||
+      presentation?.blocks.some((block) => block.type === "chart" || block.type === "table")
+        ? renderSlackMessagePresentationFallbackText({
+            text: resolution.authoredTextPlacement === "blocks" ? undefined : content,
+            presentation,
+          })
+        : (content ?? "");
     const tableMode = resolveMarkdownTableMode({
       cfg,
       channel: "slack",
@@ -243,7 +220,7 @@ export async function handleSlackMessageAction(params: {
       countSlackTextUtf8Bytes(normalizeSlackOutboundText(accessibleContent, { tableMode })) >
         SLACK_EDIT_TEXT_MAX_BYTES
     ) {
-      const editSubject = renderedPresentation.usesPresentationTextFallback
+      const editSubject = usesPresentationTextFallback
         ? "Slack presentation fallback"
         : "Slack edit";
       throw new Error(

--- a/extensions/slack/src/message-action-dispatch.ts
+++ b/extensions/slack/src/message-action-dispatch.ts
@@ -8,13 +8,12 @@ import {
   normalizeLegacyInteractiveReply,
   normalizeMessagePresentation,
 } from "openclaw/plugin-sdk/interactive-runtime";
-import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { readPositiveIntegerParam, readStringParam } from "openclaw/plugin-sdk/param-readers";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { resolveDefaultSlackAccountId } from "./accounts.js";
+import { resolveDefaultSlackAccountId, resolveSlackMarkdownOptions } from "./accounts.js";
 import { normalizeSlackOutboundText } from "./format.js";
 import { SLACK_EDIT_TEXT_MAX_BYTES } from "./limits.js";
 import { renderSlackMessagePresentationFallbackText } from "./presentation-fallback.js";
@@ -73,7 +72,10 @@ export async function handleSlackMessageAction(params: {
         presentation,
         interactive,
       },
-      { materializeAuthoredText: hasStructuredContent },
+      {
+        ...resolveSlackMarkdownOptions({ cfg, accountId }),
+        materializeAuthoredText: hasStructuredContent,
+      },
     );
     const preparedMessages =
       resolution.segments.length > 0
@@ -184,7 +186,11 @@ export async function handleSlackMessageAction(params: {
     });
     const content = readStringParam(actionParams, "message", { allowEmpty: true });
     const presentation = normalizeMessagePresentation(actionParams.presentation);
-    const resolution = resolveSlackReplyBlockResolution({ text: content, presentation });
+    const markdownOptions = resolveSlackMarkdownOptions({ cfg, accountId });
+    const resolution = resolveSlackReplyBlockResolution(
+      { text: content, presentation },
+      markdownOptions,
+    );
     const nativeSegment = resolution.segments.length === 1 ? resolution.segments[0] : undefined;
     // Edits retain their single-message fallback for oversized text, even though sends can chunk it.
     const usesPresentationTextFallback = Boolean(
@@ -202,24 +208,17 @@ export async function handleSlackMessageAction(params: {
       !usesPresentationTextFallback && nativeSegment?.kind === "blocks"
         ? nativeSegment.blocks
         : undefined;
+    const renderedContent = normalizeSlackOutboundText(content ?? "", markdownOptions);
     const accessibleContent =
       usesPresentationTextFallback ||
       presentation?.blocks.some((block) => block.type === "chart" || block.type === "table")
         ? renderSlackMessagePresentationFallbackText({
-            text: resolution.authoredTextPlacement === "blocks" ? undefined : content,
+            text: resolution.authoredTextPlacement === "blocks" ? undefined : renderedContent,
             presentation,
           })
-        : (content ?? "");
-    const tableMode = resolveMarkdownTableMode({
-      cfg,
-      channel: "slack",
-      accountId: accountId ?? resolveDefaultSlackAccountId(cfg),
-    });
-    if (
-      !blocks &&
-      countSlackTextUtf8Bytes(normalizeSlackOutboundText(accessibleContent, { tableMode })) >
-        SLACK_EDIT_TEXT_MAX_BYTES
-    ) {
+        : renderedContent;
+    // Prepared edits already use Slack mrkdwn; size and transport share those exact bytes.
+    if (!blocks && countSlackTextUtf8Bytes(accessibleContent) > SLACK_EDIT_TEXT_MAX_BYTES) {
       const editSubject = usesPresentationTextFallback
         ? "Slack presentation fallback"
         : "Slack edit";
@@ -240,7 +239,7 @@ export async function handleSlackMessageAction(params: {
         accountId,
       },
       cfg,
-      ctx.toolContext,
+      { ...ctx.toolContext, preparedEditText: accessibleContent },
     );
   }
 

--- a/extensions/slack/src/monitor/message-handler/dispatch-helpers.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-helpers.ts
@@ -6,6 +6,7 @@ import { mergePairLoopGuardConfig } from "openclaw/plugin-sdk/pair-loop-guard-ru
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyDispatchKind, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import type { SlackMarkdownOptions } from "../../format.js";
 import { resolveSlackReplyRenderPlan } from "../../reply-blocks.js";
 import type { SlackMessageEvent } from "../../types.js";
 import { readSlackReplyBlocks, resolveSlackThreadTs } from "../replies.js";
@@ -147,13 +148,17 @@ function getSlackStreamRecipientTeamCache(client: object): Map<string, string> {
   return cache;
 }
 
-function buildSlackEventDeliveryKey(params: SlackEventDeliveryAttempt): string | null {
+function buildSlackEventDeliveryKey(
+  params: SlackEventDeliveryAttempt,
+  options: SlackMarkdownOptions,
+): string | null {
   const reply = resolveSendableOutboundReplyParts(params.payload, {
     text: params.textOverride,
   });
   const renderPlan = resolveSlackReplyRenderPlan(
     params.payload,
     params.textOverride ?? params.payload.text,
+    options,
   );
   const plannedBlocks =
     renderPlan.mode === "single" ? renderPlan.blocks : renderPlan.blockPart?.blocks;
@@ -214,15 +219,15 @@ function rememberSlackStreamRecipientTeam(params: {
   }
 }
 
-export function createSlackEventDeliveryTracker() {
+export function createSlackEventDeliveryTracker(options: SlackMarkdownOptions = {}) {
   const deliveredKeys = new Set<string>();
   return {
     hasDelivered(params: SlackEventDeliveryAttempt) {
-      const key = buildSlackEventDeliveryKey(params);
+      const key = buildSlackEventDeliveryKey(params, options);
       return key ? deliveredKeys.has(key) : false;
     },
     markDelivered(params: SlackEventDeliveryAttempt) {
-      const key = buildSlackEventDeliveryKey(params);
+      const key = buildSlackEventDeliveryKey(params, options);
       if (key) {
         deliveredKeys.add(key);
       }

--- a/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
@@ -17,6 +17,7 @@ import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveSlackMarkdownOptions } from "../../accounts.js";
 import { reactSlackMessage, removeSlackReaction } from "../../actions.js";
 import { formatSlackError } from "../../errors.js";
 import { resolveSlackStreamingConfig } from "../../stream-mode.js";
@@ -319,6 +320,7 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
     slackClient,
     slackStreamFallbackTeamId,
     cfg,
+    markdownOptions: resolveSlackMarkdownOptions({ cfg, accountId: account.accountId }),
     runtime,
     slackIdentity,
     forcedReplyThreadTs,

--- a/extensions/slack/src/monitor/message-handler/dispatch-streaming.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-streaming.ts
@@ -33,6 +33,7 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     forcedReplyThreadTs,
     isThreadReply,
     message,
+    markdownOptions,
     messageSentDeliveryHookContext,
     messageSentHookContext,
     messageSentHookTarget,
@@ -146,7 +147,7 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
       delivery.outcome = "success";
     }
   };
-  let deliveryTracker = createSlackEventDeliveryTracker();
+  let deliveryTracker = createSlackEventDeliveryTracker(markdownOptions);
   const markPreviewPayloadDelivered = (params: {
     kind: ReplyDispatchKind;
     payload: ReplyPayload;
@@ -357,7 +358,7 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
 
   const isStreamingEligible = (payload: ReplyPayload, options?: { maxTextBytes?: number }) => {
     const reply = resolveSendableOutboundReplyParts(payload);
-    const renderPlan = resolveSlackReplyRenderPlan(payload);
+    const renderPlan = resolveSlackReplyRenderPlan(payload, payload.text, markdownOptions);
     const plannedBlocks =
       renderPlan.mode === "single" ? renderPlan.blocks : renderPlan.blockPart?.blocks;
     return (
@@ -578,7 +579,7 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     markPreviewPayloadDelivered,
     rememberDeliveredThreadTs,
     resetDeliveryTracker: () => {
-      deliveryTracker = createSlackEventDeliveryTracker();
+      deliveryTracker = createSlackEventDeliveryTracker(markdownOptions);
     },
   });
 }

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -20,6 +20,9 @@ const deliverRepliesMock = vi.fn(
 );
 const finalizeSlackPreviewEditMock = vi.fn(async (_input: { blocks?: unknown }) => {});
 const normalizeSlackOutboundTextMock = vi.fn((value: string) => value.trim());
+const markdownToSlackMrkdwnChunksMock = vi.fn<
+  typeof import("../../format.js").markdownToSlackMrkdwnChunks
+>((value) => [value]);
 const postMessageMock = vi.fn(async () => ({ ok: true, ts: "171234.999" }));
 const chatUpdateMock = vi.fn(async () => ({ ok: true, ts: "171234.999" }));
 const recordSlackThreadParticipationMock = vi.fn();
@@ -912,7 +915,7 @@ vi.mock("../../draft-stream.js", () => ({
 
 vi.mock("../../format.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../format.js")>()),
-  markdownToSlackMrkdwnChunks: (value: string) => [value],
+  markdownToSlackMrkdwnChunks: markdownToSlackMrkdwnChunksMock,
   normalizeSlackOutboundText: normalizeSlackOutboundTextMock,
 }));
 
@@ -1195,6 +1198,65 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   afterEach(() => resetPluginRuntimeStateForTest());
+
+  it.each(["code", "bullets"] as const)(
+    "preserves account table policy in %s previews",
+    async (mode) => {
+      const actual = await vi.importActual<typeof import("../../format.js")>("../../format.js");
+      markdownToSlackMrkdwnChunksMock.mockImplementation(actual.markdownToSlackMrkdwnChunks);
+      normalizeSlackOutboundTextMock.mockImplementation(actual.normalizeSlackOutboundText);
+      try {
+        const table = "| Name | Value |\n| --- | --- |\n| Beta | 2 |";
+        const expected =
+          mode === "code"
+            ? "```\n| Name | Value |\n| ---- | ----- |\n| Beta | 2     |\n```"
+            : "*Beta*\n• Value: 2";
+        finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
+        mockedDispatchSequence = [
+          {
+            kind: "final",
+            payload: {
+              text: table,
+              presentation: {
+                blocks: [
+                  {
+                    type: "buttons",
+                    buttons: [{ label: "Continue", action: { type: "callback", value: "next" } }],
+                  },
+                ],
+              },
+            },
+          },
+        ];
+        await dispatchPreparedSlackMessage(
+          createPreparedSlackMessage({
+            cfg: {
+              channels: {
+                slack: {
+                  markdown: { tables: "off" },
+                  accounts: {
+                    default: { markdown: { tables: mode } },
+                  },
+                },
+              },
+            },
+          }),
+        );
+        expect(finalizeSlackPreviewEditMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            blocks: [
+              { type: "section", text: { type: "mrkdwn", text: expected, verbatim: true } },
+              expect.objectContaining({ type: "actions" }),
+            ],
+          }),
+        );
+        expect(deliverRepliesMock).not.toHaveBeenCalled();
+      } finally {
+        markdownToSlackMrkdwnChunksMock.mockImplementation((value) => [value]);
+        normalizeSlackOutboundTextMock.mockImplementation((value) => value.trim());
+      }
+    },
+  );
 
   it("forwards durable ingress ownership into reply options", async () => {
     const turnAdoptionLifecycle = {

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -910,7 +910,8 @@ vi.mock("../../draft-stream.js", () => ({
   createSlackDraftStream: createSlackDraftStreamMock,
 }));
 
-vi.mock("../../format.js", () => ({
+vi.mock("../../format.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../format.js")>()),
   markdownToSlackMrkdwnChunks: (value: string) => [value],
   normalizeSlackOutboundText: normalizeSlackOutboundTextMock,
 }));
@@ -1739,7 +1740,9 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       blocks: mockedSlackReplyBlocks,
       threadTs: THREAD_TS,
     });
-    expect(normalizeSlackOutboundTextMock).not.toHaveBeenCalled();
+    expect(
+      normalizeSlackOutboundTextMock.mock.calls.every(([text]) => text === "Quarterly results"),
+    ).toBe(true);
     expectMockCallArgFields(emitSlackMessageSentHooksMock, 0, "chart preview message_sent", {
       content: accessibleText,
       success: true,
@@ -1777,7 +1780,9 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
 
     await dispatchPreparedSlackMessage(createPreparedSlackMessage());
 
-    expect(normalizeSlackOutboundTextMock).toHaveBeenCalledTimes(1);
+    expect(
+      normalizeSlackOutboundTextMock.mock.calls.every(([text]) => text === "**Summary**"),
+    ).toBe(true);
     expect(normalizeSlackOutboundTextMock).toHaveBeenCalledWith("**Summary**", {
       tableMode: "code",
     });
@@ -5164,7 +5169,9 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       text: "Spoken answer\n\nRevenue (bar chart)\n- &lt;@U123&gt;: Q1: 12; Q2: 18",
       blocks: mockedSlackReplyBlocks,
     });
-    expect(normalizeSlackOutboundTextMock).not.toHaveBeenCalled();
+    expect(
+      normalizeSlackOutboundTextMock.mock.calls.every(([text]) => text === "Spoken answer"),
+    ).toBe(true);
 
     const delivered = requireRecord(
       requireMockCall(deliverRepliesMock, 0, "deliver replies")[0],

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -12,7 +12,6 @@ import {
   deliverWithFinalizableLivePreviewAdapter,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
-import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import {
   buildTtsSupplementMediaPayload,
   getReplyPayloadTtsSupplement,
@@ -56,6 +55,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     hasSlackCustomIdentity,
     hasRepliedRef,
     message,
+    markdownOptions,
     messageSentHookContext,
     messageSentHookTarget,
     onModelSelected,
@@ -220,7 +220,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     const reply = resolveSendableOutboundReplyParts(payload);
     const ttsSupplement = getReplyPayloadTtsSupplement(payload);
     const replySourceText = payload.text ?? ttsSupplement?.spokenText;
-    const replyRenderPlan = resolveSlackReplyRenderPlan(payload, replySourceText);
+    const replyRenderPlan = resolveSlackReplyRenderPlan(payload, replySourceText, markdownOptions);
     const plannedBlocks =
       replyRenderPlan.mode === "single"
         ? replyRenderPlan.blocks
@@ -234,13 +234,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     const previewFinalText =
       replyRenderPlan.mode === "single" && replyRenderPlan.textIsSlackMrkdwn
         ? trimmedFinalText
-        : normalizeSlackOutboundText((replySourceText ?? "").trim(), {
-            tableMode: resolveMarkdownTableMode({
-              cfg,
-              channel: "slack",
-              accountId: account.accountId,
-            }),
-          });
+        : normalizeSlackOutboundText((replySourceText ?? "").trim(), markdownOptions);
     const previewFinalTextFitsEdit =
       countSlackTextUtf8Bytes(previewFinalText) <= SLACK_EDIT_TEXT_MAX_BYTES;
     const shouldRestoreTtsSupplementTextForPreviewFallback =

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -1,4 +1,5 @@
 // Slack tests cover replies plugin behavior.
+import { WebClient } from "@slack/web-api";
 import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
 import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { createReplyDispatcher } from "openclaw/plugin-sdk/reply-runtime";
@@ -105,6 +106,20 @@ function requireSendCall(index = 0) {
   return call;
 }
 
+async function recordRealBlockSends() {
+  const client = new WebClient("xoxb-test");
+  const postMessage = vi
+    .spyOn(client.chat, "postMessage")
+    .mockResolvedValue({ ok: true, ts: "chart-ts", channel: "C123" });
+  const { sendMessageSlack } = await vi.importActual<typeof import("../send.js")>("../send.js");
+  sendMock.mockImplementation((target, text, options) =>
+    options.blocks
+      ? sendMessageSlack(target, text, { ...options, eventScope: { teamId: "T1", client } })
+      : Promise.resolve({ messageId: "media-ts", channelId: "C123" }),
+  );
+  return postMessage;
+}
+
 function acceptedSlackSendResult(messageId: string, kind: "media" | "text" = "media") {
   return {
     messageId,
@@ -181,7 +196,7 @@ describe("deliverReplies identity passthrough", () => {
   });
 
   it("routes non-native portable tables through complete Slack-safe text delivery", async () => {
-    sendMock.mockResolvedValue({ messageId: "table-ts", channelId: "C123" });
+    const postMessage = await recordRealBlockSends();
 
     await deliverReplies(
       baseParams({
@@ -210,8 +225,10 @@ describe("deliverReplies identity passthrough", () => {
     expect(textOptions.textIsSlackPlainText).toBe(true);
     expect(textOptions.blocks).toBeUndefined();
 
-    const [_blockTarget, blockText, blockOptions] = requireSendCall(1);
-    expect(blockText).toBe("");
+    const [_blockTarget, , blockOptions] = requireSendCall(1);
+    expect(postMessage).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ text: "Refresh", blocks: blockOptions.blocks }),
+    );
     expect(blockOptions.blocks).toEqual([
       expect.objectContaining({
         type: "actions",
@@ -222,9 +239,7 @@ describe("deliverReplies identity passthrough", () => {
 
   it("delivers media before native chart blocks with the same reply context", async () => {
     messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
-    sendMock
-      .mockResolvedValueOnce({ messageId: "media-ts", channelId: "C123" })
-      .mockResolvedValueOnce({ messageId: "chart-ts", channelId: "C123" });
+    const postMessage = await recordRealBlockSends();
     const identity = { username: "Bot", iconEmoji: ":chart_with_upwards_trend:" };
     const metadata = { event_type: "openclaw_test", event_payload: { source: "chart" } };
     const listenerClient = { chat: { postMessage: vi.fn() } } as never;
@@ -279,7 +294,7 @@ describe("deliverReplies identity passthrough", () => {
       identity,
       metadata,
     });
-    expect(sendMock).toHaveBeenNthCalledWith(2, "C123", "", {
+    expect(requireSendCall(1)[2]).toEqual({
       cfg: enterpriseCfg,
       token: "xoxb-test",
       threadTs: "thread-ts",
@@ -305,7 +320,13 @@ describe("deliverReplies identity passthrough", () => {
       identity,
       metadata,
     });
-    expect(result).toEqual({ messageId: "chart-ts", channelId: "C123" });
+    expect(postMessage).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        text: "Revenue mix (pie chart)\n- Product: 60\n- Services: 40",
+        blocks: requireSendCall(1)[2].blocks,
+      }),
+    );
+    expect(result).toMatchObject({ messageId: "chart-ts", channelId: "C123" });
     expect(messageHookRunner.runMessageSent).toHaveBeenCalledOnce();
     const event = messageHookRunner.runMessageSent.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(event).toMatchObject({
@@ -348,7 +369,7 @@ describe("deliverReplies identity passthrough", () => {
   });
 
   it("delivers block-only replies through to sendMessageSlack", async () => {
-    sendMock.mockResolvedValue(undefined);
+    const postMessage = await recordRealBlockSends();
     const blocks = [
       {
         type: "actions",
@@ -379,9 +400,11 @@ describe("deliverReplies identity passthrough", () => {
     );
 
     expect(sendMock).toHaveBeenCalledOnce();
-    const [target, text, options] = requireSendCall();
+    const [target, , options] = requireSendCall();
     expect(target).toBe("C123");
-    expect(text).toBe("");
+    expect(postMessage).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ text: "Option A", blocks }),
+    );
     expect(options.blocks).toStrictEqual(blocks);
   });
 

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -20,6 +20,7 @@ import {
 import { createReplyReferencePlanner } from "openclaw/plugin-sdk/reply-reference";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
+import { resolveSlackMarkdownOptions } from "../accounts.js";
 import { buildSlackBlocksFallbackText } from "../blocks-fallback.js";
 import { SLACK_MAX_BLOCKS } from "../blocks-input.js";
 import { markdownToSlackMrkdwnChunks } from "../format.js";
@@ -40,6 +41,7 @@ import {
   hasSlackReplyStructuredContent,
   resolveSlackReplyBlockResolution,
   resolveSlackReplyBlocks,
+  resolveSlackReplyDeliveryMessages,
 } from "../reply-blocks.js";
 import type { SlackEventScope } from "./event-scope.js";
 import {
@@ -162,6 +164,7 @@ export async function deliverReplies(params: {
   /** Validated non-serializable client scope for an enterprise listener turn. */
   eventScope?: SlackEventScope;
 }) {
+  const markdownOptions = resolveSlackMarkdownOptions(params);
   let latestResult: SlackSendResult | undefined;
   for (const payload of params.replies) {
     if (payload.isReasoning === true) {
@@ -179,6 +182,7 @@ export async function deliverReplies(params: {
         : undefined;
     const materializeAuthoredText = !reply.hasMedia && hasSlackReplyStructuredContent(payload);
     const { authoredTextPlacement, segments } = resolveSlackReplyBlockResolution(payload, {
+      ...markdownOptions,
       materializeAuthoredText,
     });
     if (!textRaw && !reply.hasMedia && segments.length === 0) {
@@ -290,45 +294,20 @@ export async function deliverReplies(params: {
         delivered ||= mediaDelivery !== "empty";
       }
 
-      for (const segment of segments) {
-        if (segment.kind === "text") {
-          const text = [outsideText, segment.text].filter(Boolean).join("\n\n");
-          outsideText = "";
-          if (!text) {
-            continue;
-          }
-          hookParts.push(text);
-          for (const chunk of chunkSlackTextAtHardLimit(text)) {
-            lastResult = await sendReply({ text: chunk, threadTs, textIsSlackPlainText: true });
-            delivered = true;
-          }
-          continue;
+      const messages = resolveSlackReplyDeliveryMessages({
+        authoredTextPlacement,
+        segments,
+        text: outsideText,
+      });
+      for (const message of messages) {
+        hookParts.push(message.text);
+        const chunks = message.textIsSlackPlainText
+          ? chunkSlackTextAtHardLimit(message.text)
+          : [message.text];
+        for (const text of chunks) {
+          lastResult = await sendReply({ ...message, text, threadTs });
+          delivered = true;
         }
-        const baseText = outsideText;
-        outsideText = "";
-        const accessibilityText =
-          buildSlackNativeDataAccessibilityText(baseText, segment.blocks) ||
-          buildSlackBlocksFallbackText(segment.blocks);
-        hookParts.push(accessibilityText);
-        const segmentPlacement = baseText
-          ? "outside-blocks"
-          : authoredTextPlacement === "blocks"
-            ? "blocks"
-            : "none";
-        lastResult = await sendReply({
-          text: baseText,
-          threadTs,
-          blocks: segment.blocks,
-          authoredTextPlacement: segmentPlacement,
-          ...(baseText ? { nativeDataFallbackBaseText: baseText } : {}),
-        });
-        delivered = true;
-      }
-
-      if (outsideText && !reply.hasMedia) {
-        hookParts.push(outsideText);
-        lastResult = await sendReply({ text: outsideText, threadTs });
-        delivered = true;
       }
     } catch (error) {
       const hookContent = hookParts.join("\n\n") || textRaw || spokenText || "";
@@ -511,6 +490,7 @@ export async function deliverSlackSlashReplies(params: {
     const materializeAuthoredText = hasSlackReplyStructuredContent(payload);
     const { authoredTextPlacement, segments } = resolveSlackReplyBlockResolution(payload, {
       materializeAuthoredText,
+      tableMode: params.tableMode,
     });
     let outsideText = authoredTextPlacement === "outside-blocks" ? (textRaw ?? "") : "";
     const messages: PlannedSlashReplyMessage[] = [];

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -22,7 +22,11 @@ import {
 } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { resolveSlackAccount, resolveSlackOperationToken } from "./accounts.js";
+import {
+  resolveSlackAccount,
+  resolveSlackMarkdownOptions,
+  resolveSlackOperationToken,
+} from "./accounts.js";
 import {
   resolveSlackAuthoredTextPlacement,
   type SlackAuthoredTextPlacement,
@@ -131,7 +135,10 @@ function resolveSlackSendIdentity(identity?: OutboundIdentity): SlackSendIdentit
   return { username, iconUrl, iconEmoji };
 }
 
-function resolveSlackOutboundBlockResolution(payload: ReplyPayload): SlackReplyBlockResolution {
+function resolveSlackOutboundBlockResolution(
+  payload: ReplyPayload,
+  ctx: ChannelOutboundContext,
+): SlackReplyBlockResolution {
   const slackData = payload.channelData?.slack as SlackOutboundChannelData | undefined;
   const presentation = normalizeMessagePresentation(payload.presentation);
   const hasStructuredContent = Boolean(
@@ -158,7 +165,7 @@ function resolveSlackOutboundBlockResolution(payload: ReplyPayload): SlackReplyB
         slack: preservedSlackData,
       },
     },
-    { materializeAuthoredText: true },
+    { ...resolveSlackMarkdownOptions(ctx), materializeAuthoredText: true },
   );
 }
 
@@ -257,9 +264,9 @@ export const slackOutbound: ChannelOutboundAdapter = {
   chunker: null,
   textChunkLimit: SLACK_TEXT_LIMIT,
   presentationCapabilities: SLACK_PRESENTATION_CAPABILITIES,
-  renderPresentation: ({ payload }) => {
+  renderPresentation: ({ payload, ctx }) => {
     const slackData = payload.channelData?.slack as SlackOutboundChannelData | undefined;
-    const resolution = resolveSlackOutboundBlockResolution(payload);
+    const resolution = resolveSlackOutboundBlockResolution(payload, ctx);
     return resolution.segments.length > 0
       ? withSlackRenderedPresentation(payload, slackData, resolution)
       : null;
@@ -290,7 +297,7 @@ export const slackOutbound: ChannelOutboundAdapter = {
     if (renderedResolution) {
       resolution = renderedResolution;
     } else {
-      resolution = resolveSlackOutboundBlockResolution(payload);
+      resolution = resolveSlackOutboundBlockResolution(payload, ctx);
     }
     if (resolution.segments.length === 0) {
       const sendPart = async (part: ChannelOutboundContext) =>
@@ -326,15 +333,7 @@ export const slackOutbound: ChannelOutboundAdapter = {
             sentResults.push(
               await send({
                 ...preparedCtx,
-                text: message.text,
-                ...(message.blocks ? { blocks: message.blocks } : {}),
-                ...(message.authoredTextPlacement
-                  ? { authoredTextPlacement: message.authoredTextPlacement }
-                  : {}),
-                ...(message.nativeDataFallbackBaseText
-                  ? { nativeDataFallbackBaseText: message.nativeDataFallbackBaseText }
-                  : {}),
-                ...(message.textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
+                ...message,
               }),
             );
           }

--- a/extensions/slack/src/outbound-payload.authored.test.ts
+++ b/extensions/slack/src/outbound-payload.authored.test.ts
@@ -297,6 +297,18 @@ describe("Slack authored presentation delivery", () => {
 
   it.each([
     {
+      name: "code link",
+      authored: "`<https://example.com|Overview>`",
+      elements: [
+        { type: "link", text: "Overview", url: "https://example.com", style: { code: true } },
+      ],
+    },
+    {
+      name: "code reference",
+      authored: "`<@U123>`",
+      elements: [{ type: "user", user_id: "U123", style: { code: true } }],
+    },
+    {
       name: "color",
       authored: "First Second",
       elements: [
@@ -350,6 +362,31 @@ describe("Slack authored presentation delivery", () => {
   });
 
   it.each([
+    ...[{}, { unicode: "1f44b-1f3ff" }, { url: "https://emoji.example.com/wave.gif" }].map(
+      (metadata, index) => ({
+        name: `emoji metadata ${index}`,
+        authored: ":wave:",
+        rendered: index > 0 ? ":wave:" : undefined,
+        elements: [
+          { type: "rich_text_section", elements: [{ type: "emoji", name: "wave", ...metadata }] },
+        ],
+      }),
+    ),
+    ...[
+      { style: "bold", marker: "*" },
+      { style: "italic", marker: "_" },
+      { style: "strike", marker: "~" },
+    ].map(({ style, marker }) => ({
+      name: `whitespace-bounded ${style}`,
+      authored: `\\${marker} Overview \\${marker}`,
+      rendered: `${marker} Overview ${marker}`,
+      elements: [
+        {
+          type: "rich_text_section",
+          elements: [{ type: "text", text: " Overview ", style: { [style]: true } }],
+        },
+      ],
+    })),
     {
       name: "nested intraword styles",
       authored: "\\*A\\_B\\_\\*",

--- a/extensions/slack/src/outbound-payload.authored.test.ts
+++ b/extensions/slack/src/outbound-payload.authored.test.ts
@@ -206,6 +206,252 @@ describe("Slack authored presentation delivery", () => {
     expect(sections?.join("")).toBe(text);
   });
 
+  it.each(
+    [
+      { name: "bold", authoredMarker: "**", marker: "*" },
+      { name: "italic", authoredMarker: "*", marker: "_" },
+      { name: "strike", authoredMarker: "~~", marker: "~" },
+    ].flatMap((style) => (["text", "context"] as const).map((type) => ({ style, type }))),
+  )(
+    "preserves long $style.name in portable $type chunks",
+    async ({ style: { authoredMarker, marker }, type }) => {
+      const content = "x".repeat(3_001);
+      const text = `${authoredMarker}${content}${authoredMarker}`;
+      const { client } = await sendThroughRealSlack({
+        payload: {
+          text,
+          presentation: { blocks: [{ type, text: `${marker}${content}${marker}` }] },
+        },
+        renderText: text,
+      });
+      expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
+      const blocks = postedSlackMessage(client, 0).blocks ?? [];
+      const fragments = blocks.flatMap((block) =>
+        block.type === "context"
+          ? (block.elements?.map((element) => element.text) ?? [])
+          : [block.text?.text],
+      );
+      expect(fragments).toHaveLength(2);
+      for (const fragment of fragments) {
+        expect(fragment?.startsWith(marker)).toBe(true);
+        expect(fragment?.endsWith(marker)).toBe(true);
+        expect(fragment?.length).toBeLessThanOrEqual(3_000);
+      }
+      expect(
+        fragments.map((fragment) => fragment?.slice(marker.length, -marker.length)).join(""),
+      ).toBe(content);
+    },
+  );
+
+  it.each([
+    { style: "bold", authored: "**Overview**" },
+    { style: "italic", authored: "*Overview*" },
+    { style: "strike", authored: "~~Overview~~" },
+    { style: "code", authored: "`Overview`" },
+  ])(
+    "recognizes native rich-text $style without duplicating authored text",
+    async ({ style, authored }) => {
+      const block = {
+        type: "rich_text",
+        elements: [
+          {
+            type: "rich_text_section",
+            elements: [{ type: "text", text: "Overview", style: { [style]: true } }],
+          },
+        ],
+      };
+      const { client } = await sendThroughRealSlack({
+        payload: { text: authored, channelData: { slack: { blocks: [block] } } },
+        renderText: authored,
+      });
+      expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
+      expect(postedSlackMessage(client, 0).blocks).toEqual([block]);
+    },
+  );
+
+  it.each(["*", "_"])("preserves literal native %s markers at chunk boundaries", async (marker) => {
+    const text = `prefix${marker}${"x".repeat(3_001)}${marker}suffix`;
+    const { client } = await sendThroughRealSlack({
+      payload: { presentation: { blocks: [{ type: "text", text }] } },
+    });
+    const fragments = postedSlackMessage(client, 0).blocks?.map((block) => block.text?.text);
+    expect(fragments?.join("")).toBe(text);
+  });
+
+  it("preserves a valid long span after a literal delimiter", async () => {
+    const prefix = "cost * 2 ";
+    const content = "x".repeat(3_001);
+    const { client } = await sendThroughRealSlack({
+      payload: { presentation: { blocks: [{ type: "text", text: `${prefix}*${content}*` }] } },
+    });
+    const fragments = postedSlackMessage(client, 0).blocks?.map((block) => block.text?.text) ?? [];
+    expect(fragments).toHaveLength(2);
+    expect(fragments[0]?.startsWith(prefix)).toBe(true);
+    const styled = [fragments[0]?.slice(prefix.length), fragments[1]];
+    for (const fragment of styled) {
+      expect(fragment?.startsWith("*")).toBe(true);
+      expect(fragment?.endsWith("*")).toBe(true);
+    }
+    expect(styled.map((fragment) => fragment?.slice(1, -1)).join("")).toBe(content);
+  });
+
+  it.each([
+    {
+      name: "color",
+      authored: "First Second",
+      elements: [
+        { type: "text", text: "First " },
+        { type: "color", value: "#00ff00" },
+        { type: "text", text: "Second" },
+      ],
+    },
+    {
+      name: "team",
+      authored: "First Second",
+      elements: [
+        { type: "text", text: "First " },
+        { type: "team", team_id: "T123" },
+        { type: "text", text: "Second" },
+      ],
+    },
+    {
+      name: "date",
+      authored: "First fallbackSecond",
+      elements: [
+        { type: "text", text: "First " },
+        { type: "date", timestamp: 1725019200, format: "{date_long}", fallback: "fallback" },
+        { type: "text", text: "Second" },
+      ],
+    },
+    {
+      name: "inline code delimiter",
+      authored: "`a`b`",
+      elements: [{ type: "text", text: "a`b", style: { code: true } }],
+    },
+    {
+      name: "fenced code delimiter",
+      authored: "```\na```b\n```",
+      type: "rich_text_preformatted",
+      elements: [{ type: "text", text: "a```b\n" }],
+    },
+  ])("retains authored text beside opaque native $name", async ({ authored, elements, type }) => {
+    const block = {
+      type: "rich_text",
+      elements: [{ type: type ?? "rich_text_section", elements }],
+    };
+    const { client } = await sendThroughRealSlack({
+      payload: { text: authored, channelData: { slack: { blocks: [block] } } },
+      renderText: authored,
+    });
+    expect(postedSlackMessage(client, 0).blocks).toEqual([
+      block,
+      { type: "section", text: { type: "mrkdwn", text: authored, verbatim: true } },
+    ]);
+  });
+
+  it.each([
+    {
+      name: "adjacent bold leaves",
+      authored: "**Overview**",
+      elements: [
+        {
+          type: "rich_text_section",
+          elements: [
+            { type: "text", text: "Over", style: { bold: true } },
+            { type: "text", text: "view", style: { bold: true } },
+          ],
+        },
+      ],
+    },
+    {
+      name: "mixed section styles",
+      authored: "See **Overview**",
+      elements: [
+        {
+          type: "rich_text_section",
+          elements: [
+            { type: "text", text: "See " },
+            { type: "text", text: "Overview", style: { bold: true } },
+          ],
+        },
+      ],
+    },
+    {
+      name: "combined styles",
+      authored: "***Overview***",
+      elements: [
+        {
+          type: "rich_text_section",
+          elements: [{ type: "text", text: "Overview", style: { bold: true, italic: true } }],
+        },
+      ],
+    },
+    {
+      name: "matching link",
+      authored: "[Overview](https://example.com)",
+      elements: [
+        {
+          type: "rich_text_section",
+          elements: [{ type: "link", text: "Overview", url: "https://example.com" }],
+        },
+      ],
+    },
+    {
+      name: "different link",
+      authored: "[Overview](https://other.example.com)",
+      rendered: "<https://other.example.com|Overview>",
+      elements: [
+        {
+          type: "rich_text_section",
+          elements: [{ type: "link", text: "Overview", url: "https://example.com" }],
+        },
+      ],
+    },
+    {
+      name: "literal markers",
+      authored: "**Overview**",
+      rendered: "*Overview*",
+      elements: [{ type: "rich_text_section", elements: [{ type: "text", text: "*Overview*" }] }],
+    },
+    {
+      name: "opaque style barrier",
+      authored: "First Second",
+      rendered: "First Second",
+      elements: [
+        { type: "rich_text_section", elements: [{ type: "text", text: "First" }] },
+        {
+          type: "rich_text_section",
+          elements: [{ type: "text", text: "hidden", style: { underline: true } }],
+        },
+        { type: "rich_text_section", elements: [{ type: "text", text: "Second" }] },
+      ],
+    },
+    {
+      name: "preformatted whitespace",
+      authored: "```\na  b\n```",
+      elements: [{ type: "rich_text_preformatted", elements: [{ type: "text", text: "a  b\n" }] }],
+    },
+    {
+      name: "native quote layout",
+      authored: "First",
+      rendered: "First",
+      elements: [{ type: "rich_text_quote", elements: [{ type: "text", text: "First" }] }],
+    },
+  ])("preserves structured rich-text $name", async ({ authored, rendered, elements }) => {
+    const block = { type: "rich_text", elements };
+    const { client } = await sendThroughRealSlack({
+      payload: { text: authored, channelData: { slack: { blocks: [block] } } },
+      renderText: authored,
+    });
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
+    expect(postedSlackMessage(client, 0).blocks).toEqual([
+      block,
+      ...(rendered
+        ? [{ type: "section", text: { type: "mrkdwn", text: rendered, verbatim: true } }]
+        : []),
+    ]);
+  });
+
   it.each([
     {
       name: "inline code",

--- a/extensions/slack/src/outbound-payload.authored.test.ts
+++ b/extensions/slack/src/outbound-payload.authored.test.ts
@@ -351,6 +351,49 @@ describe("Slack authored presentation delivery", () => {
 
   it.each([
     {
+      name: "nested intraword styles",
+      authored: "\\*A\\_B\\_\\*",
+      rendered: "*A_B_*",
+      elements: [
+        {
+          type: "rich_text_section",
+          elements: [
+            { type: "text", text: "A", style: { bold: true } },
+            { type: "text", text: "B", style: { bold: true, italic: true } },
+          ],
+        },
+      ],
+    },
+    {
+      name: "crossing style ranges",
+      authored: "\\*A\\_BC\\_",
+      rendered: "*A_BC_",
+      elements: [
+        {
+          type: "rich_text_section",
+          elements: [
+            { type: "text", text: "A", style: { bold: true } },
+            { type: "text", text: "B", style: { bold: true, italic: true } },
+            { type: "text", text: "C", style: { italic: true } },
+          ],
+        },
+      ],
+    },
+    {
+      name: "link label whitespace",
+      authored: "First[Second](https://example.com)",
+      rendered: "First<https://example.com|Second>",
+      elements: [
+        {
+          type: "rich_text_section",
+          elements: [
+            { type: "text", text: "First" },
+            { type: "link", text: " Second", url: "https://example.com" },
+          ],
+        },
+      ],
+    },
+    {
       name: "adjacent bold leaves",
       authored: "**Overview**",
       elements: [
@@ -451,6 +494,27 @@ describe("Slack authored presentation delivery", () => {
         : []),
     ]);
   });
+
+  it.each(["x".repeat(2_997) + " *y*", "*" + "x".repeat(2_997) + " y*"])(
+    "preserves valid native emphasis at a full chunk boundary %#",
+    async (text) => {
+      const { client } = await sendThroughRealSlack({
+        payload: { presentation: { blocks: [{ type: "text", text }] } },
+      });
+      const fragments =
+        postedSlackMessage(client, 0).blocks?.map((block) => block.text?.text ?? "") ?? [];
+      expect(fragments.map((fragment) => fragment.replaceAll("*", "")).join("")).toBe(
+        text.replaceAll("*", ""),
+      );
+      for (const fragment of fragments) {
+        expect(fragment.length).toBeLessThanOrEqual(3_000);
+        expect(fragment).not.toContain("**");
+        for (const span of fragment.matchAll(/\*([^*]*)\*/gu)) {
+          expect(span[1]?.trim()).toBe(span[1]);
+        }
+      }
+    },
+  );
 
   it.each([
     {

--- a/extensions/slack/src/outbound-payload.authored.test.ts
+++ b/extensions/slack/src/outbound-payload.authored.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it } from "vitest";
+import {
+  postedSlackMessage,
+  sendThroughRealSlack,
+  valueButtons,
+} from "./outbound-payload.test-helpers.js";
+
+describe("Slack authored presentation delivery", () => {
+  it.each([
+    {
+      name: "portable text",
+      text: "Overview",
+      presentation: { blocks: [{ type: "text" as const, text: "Overview" }] },
+      blockTypes: ["section"],
+      posts: 1,
+      authoredSection: undefined,
+    },
+    {
+      name: "equivalent rendered Markdown",
+      text: "**Overview**",
+      presentation: { blocks: [{ type: "text" as const, text: "*Overview*" }] },
+      blockTypes: ["section"],
+      posts: 1,
+      authoredSection: undefined,
+    },
+    ...[false, true].flatMap((fallback) =>
+      [true, false].map((escaped) => {
+        const title = fallback
+          ? "Overview with a title too long for Slack native chart rendering"
+          : "Overview";
+        return {
+          name: `${fallback ? "literal fallback" : "native chart"}, escaped list: ${String(escaped)}`,
+          text: `${title} (pie chart)\n${escaped ? "\\-" : "-"} Open: 5`,
+          presentation: {
+            blocks: [
+              {
+                type: "chart" as const,
+                chartType: "pie" as const,
+                title,
+                segments: [{ label: "Open", value: 5 }],
+              },
+            ],
+          },
+          blockTypes: [
+            ...(escaped ? [] : ["section"]),
+            ...(fallback ? [] : ["data_visualization"]),
+          ],
+          posts: fallback && !escaped ? 2 : 1,
+          authoredSection: escaped ? undefined : `${title} (pie chart)\n\n• Open: 5`,
+        };
+      }),
+    ),
+  ])(
+    "preserves authored rendering beside $name",
+    async ({ text, presentation, blockTypes, posts, authoredSection }) => {
+      const { client } = await sendThroughRealSlack({
+        payload: { text, presentation },
+        renderText: text,
+      });
+
+      expect(client.chat.postMessage).toHaveBeenCalledTimes(posts);
+      const messages = client.chat.postMessage.mock.calls.map((_, index) =>
+        postedSlackMessage(client, index),
+      );
+      expect(
+        messages
+          .map((message) => message.text)
+          .join("\n")
+          .match(/Overview/gu),
+      ).toHaveLength(authoredSection ? 2 : 1);
+      const blocks = messages.flatMap((message) => message.blocks ?? []);
+      expect(blocks.map((block) => block.type)).toEqual(blockTypes);
+      if (authoredSection) {
+        expect(blocks.find((block) => block.type === "section")?.text?.text).toBe(authoredSection);
+      }
+      const chart = presentation.blocks[0];
+      if (chart?.type === "chart") {
+        if (blockTypes.includes("data_visualization")) {
+          expect(blocks.at(-1)).toEqual({
+            type: "data_visualization",
+            title: chart.title,
+            chart: { type: "pie", segments: [{ label: "Open", value: 5 }] },
+          });
+        } else {
+          expect(messages.at(-1)).toMatchObject({
+            text: `${chart.title} (pie chart)\n- Open: 5`,
+            mrkdwn: false,
+          });
+        }
+      }
+    },
+  );
+
+  it("recognizes rendered authored Markdown split across native sections", async () => {
+    const text = "**First** Second";
+    const { client } = await sendThroughRealSlack({
+      payload: {
+        text,
+        channelData: {
+          slack: {
+            blocks: [
+              { type: "section", text: { type: "mrkdwn", text: "*First*" } },
+              { type: "section", text: { type: "mrkdwn", text: "Second" } },
+            ],
+          },
+        },
+      },
+      renderText: text,
+    });
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
+    expect(postedSlackMessage(client, 0).blocks?.map((block) => block.text?.text)).toEqual([
+      "*First*",
+      "Second",
+    ]);
+  });
+
+  it.each(
+    ["*", "**"].flatMap((marker) =>
+      [
+        [
+          {
+            name: `literal fallback (${marker})`,
+            payload: {
+              text: `**${"x".repeat(151)}**`,
+              presentation: { title: `${marker}${"x".repeat(151)}${marker}`, blocks: [] },
+            },
+            authoredSection: `*${"x".repeat(151)}*`,
+            posts: 2,
+          },
+          {
+            name: `plain_text header (${marker})`,
+            payload: {
+              text: "**Overview**",
+              presentation: { title: `${marker}Overview${marker}`, blocks: [] },
+            },
+            authoredSection: "*Overview*",
+            posts: 1,
+          },
+        ],
+        ["section", "context"].map((type) => ({
+          name: `plain_text ${type} (${marker})`,
+          payload: {
+            text: "**Overview**",
+            channelData: {
+              slack: {
+                blocks: [
+                  type === "section"
+                    ? { type, text: { type: "plain_text", text: `${marker}Overview${marker}` } }
+                    : {
+                        type,
+                        elements: [{ type: "plain_text", text: `${marker}Overview${marker}` }],
+                      },
+                ],
+              },
+            },
+          },
+          authoredSection: "*Overview*",
+          posts: 1,
+        })),
+        [false, true].map((represented) => ({
+          name: `mixed context with mrkdwn: ${String(represented)} (${marker})`,
+          payload: {
+            text: "Ready **Overview**",
+            channelData: {
+              slack: {
+                blocks: [
+                  {
+                    type: "context",
+                    elements: [
+                      { type: "plain_text", text: "Ready" },
+                      {
+                        type: represented ? "mrkdwn" : "plain_text",
+                        text: `${marker}Overview${marker}`,
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+          authoredSection: represented && marker === "*" ? undefined : "Ready *Overview*",
+          posts: 1,
+        })),
+      ].flat(),
+    ),
+  )("preserves authored formatting beside $name", async ({ payload, authoredSection, posts }) => {
+    const { client } = await sendThroughRealSlack({ payload, renderText: payload.text });
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(posts);
+    const sections = client.chat.postMessage.mock.calls.flatMap((_, index) =>
+      (postedSlackMessage(client, index).blocks ?? [])
+        .filter((block) => block.type === "section" && block.text?.type === "mrkdwn")
+        .map((block) => block.text?.text),
+    );
+    expect(sections).toEqual(authoredSection ? [authoredSection] : []);
+  });
+
+  it("recognizes whitespace at actual portable chunk boundaries", async () => {
+    const text = "a ".repeat(100) + "x".repeat(5_799) + " z";
+    const { client } = await sendThroughRealSlack({
+      payload: { text, presentation: { blocks: [{ type: "text", text }] } },
+      renderText: text,
+    });
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
+    const sections = postedSlackMessage(client, 0).blocks?.map((block) => block.text?.text);
+    expect(sections).toHaveLength(3);
+    expect(sections?.join("")).toBe(text);
+  });
+
+  it.each([
+    {
+      name: "inline code",
+      authored: "`printf 'a  b'`",
+      rendered: "`printf 'a  b'`",
+      fragments: ["`printf 'a", "b'`"],
+    },
+    {
+      name: "fenced code",
+      authored: "```\nprintf 'a  b'\n```",
+      rendered: "```\nprintf 'a  b'\n```",
+      fragments: ["```\nprintf 'a", "b'\n```"],
+    },
+    {
+      name: "bold",
+      authored: "**First Second**",
+      rendered: "*First Second*",
+      fragments: ["*First", "Second*"],
+    },
+    {
+      name: "italic",
+      authored: "*First Second*",
+      rendered: "_First Second_",
+      fragments: ["_First", "Second_"],
+    },
+    {
+      name: "strikethrough",
+      authored: "~~First Second~~",
+      rendered: "~First Second~",
+      fragments: ["~First", "Second~"],
+    },
+    {
+      name: "link",
+      authored: "[First Second](https://example.com)",
+      rendered: "<https://example.com|First Second>",
+      fragments: ["<https://example.com|First", "Second>"],
+    },
+    {
+      name: "closed code",
+      authored: "`code` Next",
+      rendered: undefined,
+      fragments: ["`code`", "Next"],
+    },
+    {
+      name: "unmatched literal",
+      authored: "cost * 2 Next",
+      rendered: undefined,
+      fragments: ["cost * 2", "Next"],
+    },
+  ])("respects native field boundaries for $name", async ({ authored, rendered, fragments }) => {
+    const { client } = await sendThroughRealSlack({
+      payload: {
+        text: authored,
+        presentation: { blocks: fragments.map((text) => ({ type: "text", text })) },
+      },
+      renderText: authored,
+    });
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
+    expect(postedSlackMessage(client, 0).blocks?.map((block) => block.text?.text)).toEqual([
+      ...(rendered ? [rendered] : []),
+      ...fragments,
+    ]);
+  });
+
+  it.each(["inline", "fenced"])("preserves distinct authored %s code whitespace", async (kind) => {
+    const wrap = (text: string) => (kind === "inline" ? `\`${text}\`` : `\`\`\`\n${text}\n\`\`\``);
+    const authored = wrap("printf 'a  b'");
+    const presented = wrap("printf 'a b'");
+    const { client } = await sendThroughRealSlack({
+      payload: { text: authored, presentation: { blocks: [{ type: "text", text: presented }] } },
+      renderText: authored,
+    });
+
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
+    expect(postedSlackMessage(client, 0).blocks?.map((block) => block.text?.text)).toEqual([
+      authored,
+      presented,
+    ]);
+  });
+
+  it("sends authored text represented by adjacent fallbacks once", async () => {
+    const title = "x".repeat(151);
+    const { client } = await sendThroughRealSlack({
+      payload: {
+        text: title,
+        presentation: {
+          title,
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [{ label: "Status", action: { type: "command", command: "/status" } }],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
+    expect(postedSlackMessage(client, 0)).toMatchObject({
+      text: `${title}\n\n- Status: \`/status\``,
+      mrkdwn: false,
+    });
+    expect(postedSlackMessage(client, 0).blocks).toBeUndefined();
+  });
+
+  it("packs represented authored text once at the native block limit", async () => {
+    const { client } = await sendThroughRealSlack({
+      payload: {
+        text: "Overview",
+        channelData: { slack: { blocks: Array.from({ length: 49 }, () => ({ type: "divider" })) } },
+        presentation: {
+          blocks: [{ type: "text", text: "Overview" }, valueButtons("Refresh", "refresh")],
+        },
+      },
+    });
+
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
+    expect(postedSlackMessage(client, 0).blocks).toHaveLength(50);
+    expect(postedSlackMessage(client, 1).blocks?.map((block) => block.type)).toEqual(["actions"]);
+    const text = client.chat.postMessage.mock.calls
+      .map((_, index) => postedSlackMessage(client, index).text ?? "")
+      .join("\n");
+    expect(text.match(/Overview/gu)).toHaveLength(1);
+  });
+});

--- a/extensions/slack/src/outbound-payload.authored.test.ts
+++ b/extensions/slack/src/outbound-payload.authored.test.ts
@@ -270,6 +270,68 @@ describe("Slack authored presentation delivery", () => {
     ]);
   });
 
+  it.each([
+    {
+      name: "context bold",
+      type: "context",
+      authored: "**First Second**",
+      rendered: "*First Second*",
+      fragments: ["*First", "Second*"],
+    },
+    {
+      name: "context code",
+      type: "context",
+      authored: "`a b`",
+      rendered: "`a b`",
+      fragments: ["`a", "b`"],
+    },
+    {
+      name: "section code",
+      type: "section",
+      authored: "```\na\nb\n```",
+      rendered: "```\na\nb\n```",
+      fragments: ["```\na", "b\n```"],
+    },
+    {
+      name: "section bold",
+      type: "section",
+      authored: "**First\nSecond**",
+      rendered: "*First\nSecond*",
+      fragments: ["*First", "Second*"],
+    },
+    {
+      name: "complete context formatting",
+      type: "context",
+      authored: "**First** Second",
+      rendered: undefined,
+      fragments: ["*First*", "Second"],
+    },
+    {
+      name: "complete section code",
+      type: "section",
+      authored: "`a`\nb",
+      rendered: undefined,
+      fragments: ["`a`", "b"],
+    },
+  ])(
+    "preserves text-object boundaries inside $name",
+    async ({ type, authored, rendered, fragments }) => {
+      const objects = fragments.map((text) => ({ type: "mrkdwn", text }));
+      const block = type === "context" ? { type, elements: objects } : { type, fields: objects };
+      const { client } = await sendThroughRealSlack({
+        payload: { text: authored, channelData: { slack: { blocks: [block] } } },
+        renderText: authored,
+      });
+      expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
+      expect(postedSlackMessage(client, 0).blocks).toEqual([
+        block,
+        ...(rendered
+          ? [{ type: "section", text: { type: "mrkdwn", text: rendered, verbatim: true } }]
+          : []),
+      ]);
+    },
+  );
+
   it.each(["inline", "fenced"])("preserves distinct authored %s code whitespace", async (kind) => {
     const wrap = (text: string) => (kind === "inline" ? `\`${text}\`` : `\`\`\`\n${text}\n\`\`\``);
     const authored = wrap("printf 'a  b'");

--- a/extensions/slack/src/outbound-payload.test-helpers.ts
+++ b/extensions/slack/src/outbound-payload.test-helpers.ts
@@ -1,0 +1,93 @@
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { slackOutbound } from "../test-api.js";
+import { createSlackSendTestClient } from "./blocks.test-helpers.js";
+import { sendMessageSlack } from "./send.js";
+
+type SlackTestBlock = {
+  block_id?: string;
+  elements?: Array<{ action_id?: string }>;
+  text?: { text?: string; type?: string };
+  type?: string;
+};
+
+export type SlackSendOptions = {
+  authoredTextPlacement?: "none" | "blocks" | "outside-blocks";
+  blocks?: SlackTestBlock[];
+  mediaUrl?: string;
+  nativeDataFallbackBaseText?: string;
+  textIsSlackPlainText?: boolean;
+};
+
+type PostedSlackMessage = Pick<SlackSendOptions, "blocks"> & {
+  mrkdwn?: boolean;
+  text?: string;
+};
+
+export function postedSlackMessage(
+  client: ReturnType<typeof createSlackSendTestClient>,
+  index: number,
+): PostedSlackMessage {
+  const message = client.chat.postMessage.mock.calls[index]?.[0];
+  if (!message) {
+    throw new Error(`expected Slack postMessage call ${index}`);
+  }
+  return message as PostedSlackMessage;
+}
+
+export async function renderPresentation(payload: ReplyPayload, text = ""): Promise<ReplyPayload> {
+  const rendered = await slackOutbound.renderPresentation?.({
+    payload,
+    presentation: payload.presentation!,
+    ctx: { cfg: {}, to: "C12345", text, payload },
+  });
+  if (!rendered) {
+    throw new Error("Expected rendered Slack presentation");
+  }
+  return rendered;
+}
+
+export async function renderPayloadForSend(
+  payload: ReplyPayload,
+  text = "",
+): Promise<ReplyPayload> {
+  const { presentation: _presentation, ...payloadForSend } = await renderPresentation(
+    payload,
+    text,
+  );
+  return payloadForSend;
+}
+
+export async function sendThroughRealSlack(params: {
+  payload: ReplyPayload;
+  rejectFirstNativeBlocks?: boolean;
+  renderText?: string;
+  deliveryQueueId?: string;
+  onPlatformSendDispatch?: () => Promise<void>;
+}) {
+  const payload = await renderPayloadForSend(params.payload, params.renderText);
+  const client = createSlackSendTestClient();
+  if (params.rejectFirstNativeBlocks) {
+    client.chat.postMessage.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
+  }
+  const cfg = { channels: { slack: { botToken: "xoxb-test" } } };
+  const capturedSendOptions: Array<NonNullable<Parameters<typeof sendMessageSlack>[2]>> = [];
+  const sendSlack: typeof sendMessageSlack = async (to, text, opts) => {
+    capturedSendOptions.push(opts);
+    return await sendMessageSlack(to, text, { ...opts, cfg, token: "xoxb-test", client });
+  };
+
+  await slackOutbound.sendPayload?.({
+    cfg,
+    to: "channel:C123",
+    text: "",
+    payload,
+    deps: { sendSlack },
+    deliveryQueueId: params.deliveryQueueId,
+    onPlatformSendDispatch: params.onPlatformSendDispatch,
+  });
+  return { capturedSendOptions, client };
+}
+
+export function valueButtons(label: string, value: string) {
+  return { type: "buttons" as const, buttons: [{ label, value }] };
+}

--- a/extensions/slack/src/outbound-payload.test-helpers.ts
+++ b/extensions/slack/src/outbound-payload.test-helpers.ts
@@ -5,7 +5,7 @@ import { sendMessageSlack } from "./send.js";
 
 type SlackTestBlock = {
   block_id?: string;
-  elements?: Array<{ action_id?: string }>;
+  elements?: Array<{ action_id?: string; text?: string }>;
   text?: { text?: string; type?: string };
   type?: string;
 };

--- a/extensions/slack/src/outbound-payload.test.ts
+++ b/extensions/slack/src/outbound-payload.test.ts
@@ -917,6 +917,18 @@ describe("slackOutbound sendPayload", () => {
     ]);
   });
 
+  it("recognizes whitespace at actual portable chunk boundaries", async () => {
+    const text = "a ".repeat(100) + "x".repeat(5_799) + " z";
+    const { client } = await sendThroughRealSlack({
+      payload: { text, presentation: { blocks: [{ type: "text", text }] } },
+      renderText: text,
+    });
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
+    const sections = postedSlackMessage(client, 0).blocks?.map((block) => block.text?.text);
+    expect(sections).toHaveLength(3);
+    expect(sections?.join("")).toBe(text);
+  });
+
   it.each(["inline", "fenced"])("preserves distinct authored %s code whitespace", async (kind) => {
     const wrap = (text: string) => (kind === "inline" ? `\`${text}\`` : `\`\`\`\n${text}\n\`\`\``);
     const authored = wrap("printf 'a  b'");

--- a/extensions/slack/src/outbound-payload.test.ts
+++ b/extensions/slack/src/outbound-payload.test.ts
@@ -12,7 +12,7 @@ type MockWithCalls = { mock: { calls: unknown[][] } };
 type SlackTestBlock = {
   block_id?: string;
   elements?: Array<{ action_id?: string }>;
-  text?: { text?: string };
+  text?: { text?: string; type?: string };
   type?: string;
 };
 
@@ -842,55 +842,82 @@ describe("slackOutbound sendPayload", () => {
       text: "Overview",
       presentation: { blocks: [{ type: "text" as const, text: "Overview" }] },
       blockTypes: ["section"],
+      posts: 1,
+      authoredSection: undefined,
     },
     {
       name: "equivalent rendered Markdown",
       text: "**Overview**",
       presentation: { blocks: [{ type: "text" as const, text: "*Overview*" }] },
       blockTypes: ["section"],
+      posts: 1,
+      authoredSection: undefined,
     },
-    {
-      name: "native chart data",
-      text: "Overview (pie chart)\n- Open: 5",
-      presentation: {
-        blocks: [
-          {
-            type: "chart" as const,
-            chartType: "pie" as const,
-            title: "Overview",
-            segments: [{ label: "Open", value: 5 }],
+    ...[false, true].flatMap((fallback) =>
+      [true, false].map((escaped) => {
+        const title = fallback
+          ? "Overview with a title too long for Slack native chart rendering"
+          : "Overview";
+        return {
+          name: `${fallback ? "literal fallback" : "native chart"}, escaped list: ${String(escaped)}`,
+          text: `${title} (pie chart)\n${escaped ? "\\-" : "-"} Open: 5`,
+          presentation: {
+            blocks: [
+              {
+                type: "chart" as const,
+                chartType: "pie" as const,
+                title,
+                segments: [{ label: "Open", value: 5 }],
+              },
+            ],
           },
-        ],
-      },
-      blockTypes: ["data_visualization"],
-    },
-    {
-      name: "literal chart fallback",
-      text: "Overview with a title too long for Slack native chart rendering (pie chart)\n- Open: 5",
-      presentation: {
-        blocks: [
-          {
-            type: "chart" as const,
-            chartType: "pie" as const,
-            title: "Overview with a title too long for Slack native chart rendering",
-            segments: [{ label: "Open", value: 5 }],
-          },
-        ],
-      },
-      blockTypes: [],
-    },
+          blockTypes: [
+            ...(escaped ? [] : ["section"]),
+            ...(fallback ? [] : ["data_visualization"]),
+          ],
+          posts: fallback && !escaped ? 2 : 1,
+          authoredSection: escaped ? undefined : `${title} (pie chart)\n\n• Open: 5`,
+        };
+      }),
+    ),
   ])(
-    "sends authored text represented by $name once",
-    async ({ text, presentation, blockTypes }) => {
+    "preserves authored rendering beside $name",
+    async ({ text, presentation, blockTypes, posts, authoredSection }) => {
       const { client } = await sendThroughRealSlack({
         payload: { text, presentation },
         renderText: text,
       });
 
-      expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
-      const message = postedSlackMessage(client, 0);
-      expect(message.text?.match(/Overview/gu)).toHaveLength(1);
-      expect(message.blocks?.map((block) => block.type) ?? []).toEqual(blockTypes);
+      expect(client.chat.postMessage).toHaveBeenCalledTimes(posts);
+      const messages = client.chat.postMessage.mock.calls.map((_, index) =>
+        postedSlackMessage(client, index),
+      );
+      expect(
+        messages
+          .map((message) => message.text)
+          .join("\n")
+          .match(/Overview/gu),
+      ).toHaveLength(authoredSection ? 2 : 1);
+      const blocks = messages.flatMap((message) => message.blocks ?? []);
+      expect(blocks.map((block) => block.type)).toEqual(blockTypes);
+      if (authoredSection) {
+        expect(blocks.find((block) => block.type === "section")?.text?.text).toBe(authoredSection);
+      }
+      const chart = presentation.blocks[0];
+      if (chart?.type === "chart") {
+        if (blockTypes.includes("data_visualization")) {
+          expect(blocks.at(-1)).toEqual({
+            type: "data_visualization",
+            title: chart.title,
+            chart: { type: "pie", segments: [{ label: "Open", value: 5 }] },
+          });
+        } else {
+          expect(messages.at(-1)).toMatchObject({
+            text: `${chart.title} (pie chart)\n- Open: 5`,
+            mrkdwn: false,
+          });
+        }
+      }
     },
   );
 
@@ -915,6 +942,82 @@ describe("slackOutbound sendPayload", () => {
       "*First*",
       "Second",
     ]);
+  });
+
+  it.each(
+    ["*", "**"].flatMap((marker) => [
+      {
+        name: `literal fallback (${marker})`,
+        payload: {
+          text: `**${"x".repeat(151)}**`,
+          presentation: { title: `${marker}${"x".repeat(151)}${marker}`, blocks: [] },
+        },
+        authoredSection: `*${"x".repeat(151)}*`,
+        posts: 2,
+      },
+      {
+        name: `plain_text header (${marker})`,
+        payload: {
+          text: "**Overview**",
+          presentation: { title: `${marker}Overview${marker}`, blocks: [] },
+        },
+        authoredSection: "*Overview*",
+        posts: 1,
+      },
+      ...["section", "context"].map((type) => ({
+        name: `plain_text ${type} (${marker})`,
+        payload: {
+          text: "**Overview**",
+          channelData: {
+            slack: {
+              blocks: [
+                type === "section"
+                  ? { type, text: { type: "plain_text", text: `${marker}Overview${marker}` } }
+                  : {
+                      type,
+                      elements: [{ type: "plain_text", text: `${marker}Overview${marker}` }],
+                    },
+              ],
+            },
+          },
+        },
+        authoredSection: "*Overview*",
+        posts: 1,
+      })),
+      ...[false, true].map((represented) => ({
+        name: `mixed context with mrkdwn: ${String(represented)} (${marker})`,
+        payload: {
+          text: "Ready **Overview**",
+          channelData: {
+            slack: {
+              blocks: [
+                {
+                  type: "context",
+                  elements: [
+                    { type: "plain_text", text: "Ready" },
+                    {
+                      type: represented ? "mrkdwn" : "plain_text",
+                      text: `${marker}Overview${marker}`,
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+        authoredSection: represented && marker === "*" ? undefined : "Ready *Overview*",
+        posts: 1,
+      })),
+    ]),
+  )("preserves authored formatting beside $name", async ({ payload, authoredSection, posts }) => {
+    const { client } = await sendThroughRealSlack({ payload, renderText: payload.text });
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(posts);
+    const sections = client.chat.postMessage.mock.calls.flatMap((_, index) =>
+      (postedSlackMessage(client, index).blocks ?? [])
+        .filter((block) => block.type === "section" && block.text?.type === "mrkdwn")
+        .map((block) => block.text?.text),
+    );
+    expect(sections).toEqual(authoredSection ? [authoredSection] : []);
   });
 
   it("recognizes whitespace at actual portable chunk boundaries", async () => {

--- a/extensions/slack/src/outbound-payload.test.ts
+++ b/extensions/slack/src/outbound-payload.test.ts
@@ -894,6 +894,45 @@ describe("slackOutbound sendPayload", () => {
     },
   );
 
+  it("recognizes rendered authored Markdown split across native sections", async () => {
+    const text = "**First** Second";
+    const { client } = await sendThroughRealSlack({
+      payload: {
+        text,
+        channelData: {
+          slack: {
+            blocks: [
+              { type: "section", text: { type: "mrkdwn", text: "*First*" } },
+              { type: "section", text: { type: "mrkdwn", text: "Second" } },
+            ],
+          },
+        },
+      },
+      renderText: text,
+    });
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
+    expect(postedSlackMessage(client, 0).blocks?.map((block) => block.text?.text)).toEqual([
+      "*First*",
+      "Second",
+    ]);
+  });
+
+  it.each(["inline", "fenced"])("preserves distinct authored %s code whitespace", async (kind) => {
+    const wrap = (text: string) => (kind === "inline" ? `\`${text}\`` : `\`\`\`\n${text}\n\`\`\``);
+    const authored = wrap("printf 'a  b'");
+    const presented = wrap("printf 'a b'");
+    const { client } = await sendThroughRealSlack({
+      payload: { text: authored, presentation: { blocks: [{ type: "text", text: presented }] } },
+      renderText: authored,
+    });
+
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
+    expect(postedSlackMessage(client, 0).blocks?.map((block) => block.text?.text)).toEqual([
+      authored,
+      presented,
+    ]);
+  });
+
   it("sends authored text represented by adjacent fallbacks once", async () => {
     const title = "x".repeat(151);
     const { client } = await sendThroughRealSlack({

--- a/extensions/slack/src/outbound-payload.test.ts
+++ b/extensions/slack/src/outbound-payload.test.ts
@@ -894,6 +894,31 @@ describe("slackOutbound sendPayload", () => {
     },
   );
 
+  it("sends authored text represented by adjacent fallbacks once", async () => {
+    const title = "x".repeat(151);
+    const { client } = await sendThroughRealSlack({
+      payload: {
+        text: title,
+        presentation: {
+          title,
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [{ label: "Status", action: { type: "command", command: "/status" } }],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
+    expect(postedSlackMessage(client, 0)).toMatchObject({
+      text: `${title}\n\n- Status: \`/status\``,
+      mrkdwn: false,
+    });
+    expect(postedSlackMessage(client, 0).blocks).toBeUndefined();
+  });
+
   it("packs represented authored text once at the native block limit", async () => {
     const { client } = await sendThroughRealSlack({
       payload: {

--- a/extensions/slack/src/outbound-payload.test.ts
+++ b/extensions/slack/src/outbound-payload.test.ts
@@ -836,6 +836,84 @@ describe("slackOutbound sendPayload", () => {
     expect(fallback.blocks?.filter((block) => block.text?.text === "Overview")).toHaveLength(1);
   });
 
+  it.each([
+    {
+      name: "portable text",
+      text: "Overview",
+      presentation: { blocks: [{ type: "text" as const, text: "Overview" }] },
+      blockTypes: ["section"],
+    },
+    {
+      name: "equivalent rendered Markdown",
+      text: "**Overview**",
+      presentation: { blocks: [{ type: "text" as const, text: "*Overview*" }] },
+      blockTypes: ["section"],
+    },
+    {
+      name: "native chart data",
+      text: "Overview (pie chart)\n- Open: 5",
+      presentation: {
+        blocks: [
+          {
+            type: "chart" as const,
+            chartType: "pie" as const,
+            title: "Overview",
+            segments: [{ label: "Open", value: 5 }],
+          },
+        ],
+      },
+      blockTypes: ["data_visualization"],
+    },
+    {
+      name: "literal chart fallback",
+      text: "Overview with a title too long for Slack native chart rendering (pie chart)\n- Open: 5",
+      presentation: {
+        blocks: [
+          {
+            type: "chart" as const,
+            chartType: "pie" as const,
+            title: "Overview with a title too long for Slack native chart rendering",
+            segments: [{ label: "Open", value: 5 }],
+          },
+        ],
+      },
+      blockTypes: [],
+    },
+  ])(
+    "sends authored text represented by $name once",
+    async ({ text, presentation, blockTypes }) => {
+      const { client } = await sendThroughRealSlack({
+        payload: { text, presentation },
+        renderText: text,
+      });
+
+      expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
+      const message = postedSlackMessage(client, 0);
+      expect(message.text?.match(/Overview/gu)).toHaveLength(1);
+      expect(message.blocks?.map((block) => block.type) ?? []).toEqual(blockTypes);
+    },
+  );
+
+  it("packs represented authored text once at the native block limit", async () => {
+    const { client } = await sendThroughRealSlack({
+      payload: {
+        text: "Overview",
+        channelData: { slack: { blocks: Array.from({ length: 49 }, () => ({ type: "divider" })) } },
+        presentation: {
+          blocks: [{ type: "text", text: "Overview" }, valueButtons("Refresh", "refresh")],
+        },
+      },
+    });
+
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
+    expect(postedSlackMessage(client, 0).blocks).toHaveLength(50);
+    expect(postedSlackMessage(client, 1).blocks?.map((block) => block.type)).toEqual(["actions"]);
+    const text = client.chat.postMessage.mock.calls
+      .map((_, index) => postedSlackMessage(client, index).text ?? "")
+      .join("\n");
+    expect(text.match(/Overview/gu)).toHaveLength(1);
+  });
+
   it("sends media before a separate interactive blocks message", async () => {
     const { run, sendMock, to } = createHarness({
       payload: {

--- a/extensions/slack/src/outbound-payload.test.ts
+++ b/extensions/slack/src/outbound-payload.test.ts
@@ -2,32 +2,18 @@
 import { installChannelOutboundPayloadContractSuite } from "openclaw/plugin-sdk/channel-contract-testing";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { describe, expect, it, vi } from "vitest";
-import { createSlackOutboundPayloadHarness as createHarness, slackOutbound } from "../test-api.js";
-import { createSlackSendTestClient } from "./blocks.test-helpers.js";
+import { createSlackOutboundPayloadHarness as createHarness } from "../test-api.js";
+import {
+  postedSlackMessage,
+  renderPresentation,
+  renderPayloadForSend,
+  sendThroughRealSlack,
+  valueButtons,
+  type SlackSendOptions,
+} from "./outbound-payload.test-helpers.js";
 import type { SlackReplyBlockSegment } from "./reply-blocks.js";
-import { sendMessageSlack } from "./send.js";
 
 type MockWithCalls = { mock: { calls: unknown[][] } };
-
-type SlackTestBlock = {
-  block_id?: string;
-  elements?: Array<{ action_id?: string }>;
-  text?: { text?: string; type?: string };
-  type?: string;
-};
-
-type SlackSendOptions = {
-  authoredTextPlacement?: "none" | "blocks" | "outside-blocks";
-  blocks?: SlackTestBlock[];
-  mediaUrl?: string;
-  nativeDataFallbackBaseText?: string;
-  textIsSlackPlainText?: boolean;
-};
-
-type PostedSlackMessage = Pick<SlackSendOptions, "blocks"> & {
-  mrkdwn?: boolean;
-  text?: string;
-};
 
 function sentSlackMessage(sendMock: MockWithCalls, index: number) {
   const call = sendMock.mock.calls[index];
@@ -45,17 +31,6 @@ function sentSlackMessage(sendMock: MockWithCalls, index: number) {
   };
 }
 
-function postedSlackMessage(
-  client: ReturnType<typeof createSlackSendTestClient>,
-  index: number,
-): PostedSlackMessage {
-  const message = client.chat.postMessage.mock.calls[index]?.[0];
-  if (!message) {
-    throw new Error(`expected Slack postMessage call ${index}`);
-  }
-  return message as PostedSlackMessage;
-}
-
 function renderedPresentationSegments(payload: ReplyPayload | null | undefined) {
   const value = (
     payload?.channelData?.slack as { renderedPresentationSegments?: unknown } | undefined
@@ -64,61 +39,6 @@ function renderedPresentationSegments(payload: ReplyPayload | null | undefined) 
     throw new Error("Expected rendered Slack presentation segments");
   }
   return value as SlackReplyBlockSegment[];
-}
-
-async function renderPresentation(payload: ReplyPayload, text = ""): Promise<ReplyPayload> {
-  const rendered = await slackOutbound.renderPresentation?.({
-    payload,
-    presentation: payload.presentation!,
-    ctx: { cfg: {}, to: "C12345", text, payload },
-  });
-  if (!rendered) {
-    throw new Error("Expected rendered Slack presentation");
-  }
-  return rendered;
-}
-
-async function renderPayloadForSend(payload: ReplyPayload, text = ""): Promise<ReplyPayload> {
-  const { presentation: _presentation, ...payloadForSend } = await renderPresentation(
-    payload,
-    text,
-  );
-  return payloadForSend;
-}
-
-async function sendThroughRealSlack(params: {
-  payload: ReplyPayload;
-  rejectFirstNativeBlocks?: boolean;
-  renderText?: string;
-  deliveryQueueId?: string;
-  onPlatformSendDispatch?: () => Promise<void>;
-}) {
-  const payload = await renderPayloadForSend(params.payload, params.renderText);
-  const client = createSlackSendTestClient();
-  if (params.rejectFirstNativeBlocks) {
-    client.chat.postMessage.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
-  }
-  const cfg = { channels: { slack: { botToken: "xoxb-test" } } };
-  const capturedSendOptions: Array<NonNullable<Parameters<typeof sendMessageSlack>[2]>> = [];
-  const sendSlack: typeof sendMessageSlack = async (to, text, opts) => {
-    capturedSendOptions.push(opts);
-    return await sendMessageSlack(to, text, { ...opts, cfg, token: "xoxb-test", client });
-  };
-
-  await slackOutbound.sendPayload?.({
-    cfg,
-    to: "channel:C123",
-    text: "",
-    payload,
-    deps: { sendSlack },
-    deliveryQueueId: params.deliveryQueueId,
-    onPlatformSendDispatch: params.onPlatformSendDispatch,
-  });
-  return { capturedSendOptions, client };
-}
-
-function valueButtons(label: string, value: string) {
-  return { type: "buttons" as const, buttons: [{ label, value }] };
 }
 
 function interactiveButtons(label: string, value: string) {
@@ -834,263 +754,6 @@ describe("slackOutbound sendPayload", () => {
     const fallback = postedSlackMessage(client, 1);
     expect(fallback.text?.match(/Overview/gu)).toHaveLength(1);
     expect(fallback.blocks?.filter((block) => block.text?.text === "Overview")).toHaveLength(1);
-  });
-
-  it.each([
-    {
-      name: "portable text",
-      text: "Overview",
-      presentation: { blocks: [{ type: "text" as const, text: "Overview" }] },
-      blockTypes: ["section"],
-      posts: 1,
-      authoredSection: undefined,
-    },
-    {
-      name: "equivalent rendered Markdown",
-      text: "**Overview**",
-      presentation: { blocks: [{ type: "text" as const, text: "*Overview*" }] },
-      blockTypes: ["section"],
-      posts: 1,
-      authoredSection: undefined,
-    },
-    ...[false, true].flatMap((fallback) =>
-      [true, false].map((escaped) => {
-        const title = fallback
-          ? "Overview with a title too long for Slack native chart rendering"
-          : "Overview";
-        return {
-          name: `${fallback ? "literal fallback" : "native chart"}, escaped list: ${String(escaped)}`,
-          text: `${title} (pie chart)\n${escaped ? "\\-" : "-"} Open: 5`,
-          presentation: {
-            blocks: [
-              {
-                type: "chart" as const,
-                chartType: "pie" as const,
-                title,
-                segments: [{ label: "Open", value: 5 }],
-              },
-            ],
-          },
-          blockTypes: [
-            ...(escaped ? [] : ["section"]),
-            ...(fallback ? [] : ["data_visualization"]),
-          ],
-          posts: fallback && !escaped ? 2 : 1,
-          authoredSection: escaped ? undefined : `${title} (pie chart)\n\n• Open: 5`,
-        };
-      }),
-    ),
-  ])(
-    "preserves authored rendering beside $name",
-    async ({ text, presentation, blockTypes, posts, authoredSection }) => {
-      const { client } = await sendThroughRealSlack({
-        payload: { text, presentation },
-        renderText: text,
-      });
-
-      expect(client.chat.postMessage).toHaveBeenCalledTimes(posts);
-      const messages = client.chat.postMessage.mock.calls.map((_, index) =>
-        postedSlackMessage(client, index),
-      );
-      expect(
-        messages
-          .map((message) => message.text)
-          .join("\n")
-          .match(/Overview/gu),
-      ).toHaveLength(authoredSection ? 2 : 1);
-      const blocks = messages.flatMap((message) => message.blocks ?? []);
-      expect(blocks.map((block) => block.type)).toEqual(blockTypes);
-      if (authoredSection) {
-        expect(blocks.find((block) => block.type === "section")?.text?.text).toBe(authoredSection);
-      }
-      const chart = presentation.blocks[0];
-      if (chart?.type === "chart") {
-        if (blockTypes.includes("data_visualization")) {
-          expect(blocks.at(-1)).toEqual({
-            type: "data_visualization",
-            title: chart.title,
-            chart: { type: "pie", segments: [{ label: "Open", value: 5 }] },
-          });
-        } else {
-          expect(messages.at(-1)).toMatchObject({
-            text: `${chart.title} (pie chart)\n- Open: 5`,
-            mrkdwn: false,
-          });
-        }
-      }
-    },
-  );
-
-  it("recognizes rendered authored Markdown split across native sections", async () => {
-    const text = "**First** Second";
-    const { client } = await sendThroughRealSlack({
-      payload: {
-        text,
-        channelData: {
-          slack: {
-            blocks: [
-              { type: "section", text: { type: "mrkdwn", text: "*First*" } },
-              { type: "section", text: { type: "mrkdwn", text: "Second" } },
-            ],
-          },
-        },
-      },
-      renderText: text,
-    });
-    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
-    expect(postedSlackMessage(client, 0).blocks?.map((block) => block.text?.text)).toEqual([
-      "*First*",
-      "Second",
-    ]);
-  });
-
-  it.each(
-    ["*", "**"].flatMap((marker) => [
-      {
-        name: `literal fallback (${marker})`,
-        payload: {
-          text: `**${"x".repeat(151)}**`,
-          presentation: { title: `${marker}${"x".repeat(151)}${marker}`, blocks: [] },
-        },
-        authoredSection: `*${"x".repeat(151)}*`,
-        posts: 2,
-      },
-      {
-        name: `plain_text header (${marker})`,
-        payload: {
-          text: "**Overview**",
-          presentation: { title: `${marker}Overview${marker}`, blocks: [] },
-        },
-        authoredSection: "*Overview*",
-        posts: 1,
-      },
-      ...["section", "context"].map((type) => ({
-        name: `plain_text ${type} (${marker})`,
-        payload: {
-          text: "**Overview**",
-          channelData: {
-            slack: {
-              blocks: [
-                type === "section"
-                  ? { type, text: { type: "plain_text", text: `${marker}Overview${marker}` } }
-                  : {
-                      type,
-                      elements: [{ type: "plain_text", text: `${marker}Overview${marker}` }],
-                    },
-              ],
-            },
-          },
-        },
-        authoredSection: "*Overview*",
-        posts: 1,
-      })),
-      ...[false, true].map((represented) => ({
-        name: `mixed context with mrkdwn: ${String(represented)} (${marker})`,
-        payload: {
-          text: "Ready **Overview**",
-          channelData: {
-            slack: {
-              blocks: [
-                {
-                  type: "context",
-                  elements: [
-                    { type: "plain_text", text: "Ready" },
-                    {
-                      type: represented ? "mrkdwn" : "plain_text",
-                      text: `${marker}Overview${marker}`,
-                    },
-                  ],
-                },
-              ],
-            },
-          },
-        },
-        authoredSection: represented && marker === "*" ? undefined : "Ready *Overview*",
-        posts: 1,
-      })),
-    ]),
-  )("preserves authored formatting beside $name", async ({ payload, authoredSection, posts }) => {
-    const { client } = await sendThroughRealSlack({ payload, renderText: payload.text });
-    expect(client.chat.postMessage).toHaveBeenCalledTimes(posts);
-    const sections = client.chat.postMessage.mock.calls.flatMap((_, index) =>
-      (postedSlackMessage(client, index).blocks ?? [])
-        .filter((block) => block.type === "section" && block.text?.type === "mrkdwn")
-        .map((block) => block.text?.text),
-    );
-    expect(sections).toEqual(authoredSection ? [authoredSection] : []);
-  });
-
-  it("recognizes whitespace at actual portable chunk boundaries", async () => {
-    const text = "a ".repeat(100) + "x".repeat(5_799) + " z";
-    const { client } = await sendThroughRealSlack({
-      payload: { text, presentation: { blocks: [{ type: "text", text }] } },
-      renderText: text,
-    });
-    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
-    const sections = postedSlackMessage(client, 0).blocks?.map((block) => block.text?.text);
-    expect(sections).toHaveLength(3);
-    expect(sections?.join("")).toBe(text);
-  });
-
-  it.each(["inline", "fenced"])("preserves distinct authored %s code whitespace", async (kind) => {
-    const wrap = (text: string) => (kind === "inline" ? `\`${text}\`` : `\`\`\`\n${text}\n\`\`\``);
-    const authored = wrap("printf 'a  b'");
-    const presented = wrap("printf 'a b'");
-    const { client } = await sendThroughRealSlack({
-      payload: { text: authored, presentation: { blocks: [{ type: "text", text: presented }] } },
-      renderText: authored,
-    });
-
-    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
-    expect(postedSlackMessage(client, 0).blocks?.map((block) => block.text?.text)).toEqual([
-      authored,
-      presented,
-    ]);
-  });
-
-  it("sends authored text represented by adjacent fallbacks once", async () => {
-    const title = "x".repeat(151);
-    const { client } = await sendThroughRealSlack({
-      payload: {
-        text: title,
-        presentation: {
-          title,
-          blocks: [
-            {
-              type: "buttons",
-              buttons: [{ label: "Status", action: { type: "command", command: "/status" } }],
-            },
-          ],
-        },
-      },
-    });
-
-    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
-    expect(postedSlackMessage(client, 0)).toMatchObject({
-      text: `${title}\n\n- Status: \`/status\``,
-      mrkdwn: false,
-    });
-    expect(postedSlackMessage(client, 0).blocks).toBeUndefined();
-  });
-
-  it("packs represented authored text once at the native block limit", async () => {
-    const { client } = await sendThroughRealSlack({
-      payload: {
-        text: "Overview",
-        channelData: { slack: { blocks: Array.from({ length: 49 }, () => ({ type: "divider" })) } },
-        presentation: {
-          blocks: [{ type: "text", text: "Overview" }, valueButtons("Refresh", "refresh")],
-        },
-      },
-    });
-
-    expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
-    expect(postedSlackMessage(client, 0).blocks).toHaveLength(50);
-    expect(postedSlackMessage(client, 1).blocks?.map((block) => block.type)).toEqual(["actions"]);
-    const text = client.chat.postMessage.mock.calls
-      .map((_, index) => postedSlackMessage(client, index).text ?? "")
-      .join("\n");
-    expect(text.match(/Overview/gu)).toHaveLength(1);
   });
 
   it("sends media before a separate interactive blocks message", async () => {

--- a/extensions/slack/src/reply-blocks.test.ts
+++ b/extensions/slack/src/reply-blocks.test.ts
@@ -319,30 +319,41 @@ describe("renderSlackMessagePresentationFallbackText", () => {
     expect(fallback).not.toContain("&lt;");
   });
 
-  it("recognizes authored text already carried by a fallback segment", () => {
-    const title = "This chart title is too long for Slack native chart rendering";
-    const text = `${title} (pie chart)\n- Open: 5`;
-    const resolution = resolveSlackReplyBlockResolution({
-      text,
-      presentation: {
-        blocks: [
-          {
-            type: "chart",
-            chartType: "pie",
-            title,
-            segments: [{ label: "Open", value: 5 }],
-          },
-        ],
-      },
-    });
+  it.each([true, false])(
+    "compares literal chart fallback formatting: escaped list %s",
+    (escaped) => {
+      const title = "This chart title is too long for Slack native chart rendering";
+      const text = `${title} (pie chart)\n- Open: 5`;
+      const resolution = resolveSlackReplyBlockResolution({
+        text: escaped ? text.replace("\n-", "\n\\-") : text,
+        presentation: {
+          blocks: [
+            {
+              type: "chart",
+              chartType: "pie",
+              title,
+              segments: [{ label: "Open", value: 5 }],
+            },
+          ],
+        },
+      });
 
-    expect(resolution.authoredTextPlacement).toBe("blocks");
-    expect(resolution.segments).toContainEqual({ kind: "text", text, mrkdwn: false });
-  });
+      expect(resolution.authoredTextPlacement).toBe(escaped ? "blocks" : "outside-blocks");
+      expect(resolution.segments).toContainEqual({ kind: "text", text, mrkdwn: false });
+    },
+  );
 
   it("keeps a represented literal fallback out of preview edits and native streams", () => {
+    const text = "x".repeat(151);
+    expect(
+      resolveSlackReplyRenderPlan({ text, presentation: { title: text, blocks: [] } }),
+    ).toEqual({ mode: "split", fallbackText: text });
+  });
+
+  it("preserves authored list and emphasis formatting beside a literal chart fallback", () => {
     const title = "This chart title is too long for Slack native chart rendering";
     const text = `${title} (pie chart)\n- *raw*: 5`;
+    const authored = `${title} (pie chart)\n\n• _raw_: 5`;
     expect(
       resolveSlackReplyRenderPlan({
         text,
@@ -352,7 +363,14 @@ describe("renderSlackMessagePresentationFallbackText", () => {
           ],
         },
       }),
-    ).toEqual({ mode: "split", fallbackText: text });
+    ).toEqual({
+      mode: "split",
+      fallbackText: `${authored}\n\n${text}`,
+      blockPart: {
+        text: authored,
+        blocks: [{ type: "section", text: { type: "mrkdwn", text: authored, verbatim: true } }],
+      },
+    });
   });
 
   it.each([
@@ -394,9 +412,10 @@ describe("renderSlackMessagePresentationFallbackText", () => {
     });
   });
 
-  it("recognizes authored text already represented by native chart data", () => {
+  it.each([true, false])("compares native chart summary formatting: escaped list %s", (escaped) => {
+    const text = "Revenue mix (pie chart)\n- Product: 60\n- Services: 40";
     const resolution = resolveSlackReplyBlockResolution({
-      text: "Revenue mix (pie chart)\n- Product: 60\n- Services: 40",
+      text: escaped ? text.replaceAll("\n-", "\n\\-") : text,
       presentation: {
         blocks: [
           {
@@ -413,7 +432,7 @@ describe("renderSlackMessagePresentationFallbackText", () => {
       },
     });
 
-    expect(resolution.authoredTextPlacement).toBe("blocks");
+    expect(resolution.authoredTextPlacement).toBe(escaped ? "blocks" : "outside-blocks");
   });
 
   it("preserves mixed chart, table, and control order across native and text segments", () => {

--- a/extensions/slack/src/reply-blocks.test.ts
+++ b/extensions/slack/src/reply-blocks.test.ts
@@ -355,6 +355,26 @@ describe("renderSlackMessagePresentationFallbackText", () => {
     ).toEqual({ mode: "split", fallbackText: text });
   });
 
+  it.each([
+    { text: "First\n\nSecond", placement: "blocks" },
+    { text: "FirstSecond", placement: "outside-blocks" },
+  ])(
+    "preserves actual authored separators across legacy text fragments: $placement",
+    ({ text, placement }) => {
+      const result = resolveSlackReplyBlockResolution({
+        text,
+        interactive: {
+          blocks: [
+            { type: "text", text: "First" },
+            { type: "buttons", buttons: [{ label: "Continue", value: "continue" }] },
+            { type: "text", text: "Second" },
+          ],
+        },
+      });
+      expect(result.authoredTextPlacement).toBe(placement);
+    },
+  );
+
   it("materializes authored text blocks as verbatim mrkdwn", () => {
     const resolution = resolveSlackReplyBlockResolution(
       {

--- a/extensions/slack/src/reply-blocks.test.ts
+++ b/extensions/slack/src/reply-blocks.test.ts
@@ -4,7 +4,7 @@ import {
 } from "openclaw/plugin-sdk/interactive-runtime";
 import { describe, expect, it } from "vitest";
 import { renderSlackMessagePresentationFallbackText } from "./presentation-fallback.js";
-import { resolveSlackReplyBlockResolution } from "./reply-blocks.js";
+import { resolveSlackReplyBlockResolution, resolveSlackReplyRenderPlan } from "./reply-blocks.js";
 
 describe("renderSlackMessagePresentationFallbackText", () => {
   it("includes complete portable table data in Slack accessibility text", () => {
@@ -338,6 +338,21 @@ describe("renderSlackMessagePresentationFallbackText", () => {
 
     expect(resolution.authoredTextPlacement).toBe("blocks");
     expect(resolution.segments).toContainEqual({ kind: "text", text, mrkdwn: false });
+  });
+
+  it("keeps a represented literal fallback out of preview edits and native streams", () => {
+    const title = "This chart title is too long for Slack native chart rendering";
+    const text = `${title} (pie chart)\n- *raw*: 5`;
+    expect(
+      resolveSlackReplyRenderPlan({
+        text,
+        presentation: {
+          blocks: [
+            { type: "chart", chartType: "pie", title, segments: [{ label: "*raw*", value: 5 }] },
+          ],
+        },
+      }),
+    ).toEqual({ mode: "split", fallbackText: text });
   });
 
   it("materializes authored text blocks as verbatim mrkdwn", () => {

--- a/extensions/slack/src/reply-blocks.ts
+++ b/extensions/slack/src/reply-blocks.ts
@@ -28,6 +28,7 @@ import {
   chunkSlackMrkdwnText,
   markdownToSlackMrkdwnChunks,
   normalizeSlackOutboundText,
+  type SlackMarkdownOptions,
 } from "./format.js";
 import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
 import {
@@ -35,7 +36,6 @@ import {
   buildSlackNativeDataAccessibilityText,
   hasSlackNativeDataBlock,
 } from "./native-data-blocks.js";
-import { renderSlackMessagePresentationFallbackText } from "./presentation-fallback.js";
 import { SLACK_SECTION_TEXT_MAX } from "./presentation.js";
 import {
   SLACK_APPROVAL_BUTTON_ACTION_ID,
@@ -131,13 +131,6 @@ export function resolveSlackReplyDeliveryMessages(params: {
   return messages;
 }
 
-function resolveSlackReplyText(payload: ReplyPayload, text = payload.text): string {
-  const presentation = normalizeMessagePresentation(payload.presentation);
-  return presentation
-    ? renderSlackMessagePresentationFallbackText({ text, presentation })
-    : (text ?? "");
-}
-
 type SlackReplyRenderPlan =
   | {
       mode: "single";
@@ -154,6 +147,7 @@ type SlackReplyRenderPlan =
 export function resolveSlackReplyRenderPlan(
   payload: ReplyPayload,
   text = payload.text,
+  options: SlackMarkdownOptions = {},
 ): SlackReplyRenderPlan {
   const hasStructuredContent = hasSlackReplyStructuredContent(payload);
   // Live preview/streaming still consumes this compact plan shape. Derive it
@@ -161,7 +155,7 @@ export function resolveSlackReplyRenderPlan(
   // without a second renderer.
   const resolution = resolveSlackReplyBlockResolution(
     { ...payload, text },
-    { materializeAuthoredText: hasStructuredContent },
+    { ...options, materializeAuthoredText: hasStructuredContent },
   );
   const messages = resolveSlackReplyDeliveryMessages({
     authoredTextPlacement: resolution.authoredTextPlacement,
@@ -174,9 +168,9 @@ export function resolveSlackReplyRenderPlan(
     const sourceText = text?.trim() ?? "";
     const blocks =
       message?.authoredTextPlacement === "blocks"
-        ? addPreviewVerbatimToAuthoredTextBlocks(message.blocks, sourceText)
+        ? addPreviewVerbatimToAuthoredTextBlocks(message.blocks, sourceText, options)
         : message?.blocks;
-    let renderedText = message?.text ?? resolveSlackReplyText(payload, text);
+    let renderedText = message?.text ?? text ?? "";
     let textIsSlackMrkdwn = Boolean(
       message &&
       !message.textIsSlackPlainText &&
@@ -232,26 +226,23 @@ function renderSlackAuthoredTextFragments(segments: readonly SlackReplyBlockSegm
     }
     return segment.blocks
       .filter((block) => block.type !== "actions")
-      .map((block) => renderSlackBlockFallbackText(block, { nativeDataFormat: "mrkdwn-safe" }))
-      .filter((text): text is string => Boolean(text));
+      .flatMap(
+        (block) => renderSlackBlockFallbackText(block, { nativeDataFormat: "mrkdwn-safe" }) ?? [],
+      );
   });
-}
-
-function buildSlackAuthoredTextBlocks(text: string) {
-  return markdownToSlackMrkdwnChunks(text, SLACK_SECTION_TEXT_MAX).map((chunk) => ({
-    type: "section" as const,
-    text: { type: "mrkdwn" as const, text: chunk, verbatim: true },
-  }));
 }
 
 function addPreviewVerbatimToAuthoredTextBlocks(
   blocks: SlackBlock[] | undefined,
   sourceText: string,
+  options: SlackMarkdownOptions,
 ): SlackBlock[] | undefined {
   if (!blocks?.length || !sourceText) {
     return blocks;
   }
-  const authoredChunks = new Set(markdownToSlackMrkdwnChunks(sourceText, SLACK_SECTION_TEXT_MAX));
+  const authoredChunks = new Set(
+    markdownToSlackMrkdwnChunks(sourceText, SLACK_SECTION_TEXT_MAX, options),
+  );
   return blocks.map((block) => {
     const text = (block as { text?: { text?: unknown; type?: unknown; verbatim?: unknown } }).text;
     if (
@@ -469,13 +460,18 @@ function compileSlackReplyBlockSegments(
  */
 export function resolveSlackReplyBlockResolution(
   payload: ReplyPayload,
-  options: { materializeAuthoredText?: boolean } = {},
+  options: SlackMarkdownOptions & { materializeAuthoredText?: boolean } = {},
 ): SlackReplyBlockResolution {
   const channelBlocks = readSlackChannelBlocks(payload);
   let segments = compileSlackReplyBlockSegments(payload, channelBlocks);
   const text = normalizeOptionalString(payload.text);
-  const textBlocks = text ? buildSlackAuthoredTextBlocks(text) : [];
-  const renderedText = text ? normalizeSlackOutboundText(text) : "";
+  const textBlocks = markdownToSlackMrkdwnChunks(text ?? "", SLACK_SECTION_TEXT_MAX, options).map(
+    (chunk) => ({
+      type: "section" as const,
+      text: { type: "mrkdwn" as const, text: chunk, verbatim: true },
+    }),
+  );
+  const renderedText = text ? normalizeSlackOutboundText(text, options) : "";
   let authoredTextPlacement = resolveSlackAuthoredTextPlacement({
     text: renderedText,
     // Native plain_text fields and literal fallback must not impersonate mrkdwn.

--- a/extensions/slack/src/reply-blocks.ts
+++ b/extensions/slack/src/reply-blocks.ts
@@ -486,7 +486,6 @@ export function resolveSlackReplyBlockResolution(
   });
   let authoredTextPlacement = resolveSlackAuthoredTextPlacement({
     text: payload.text,
-    interactive: payload.interactive,
     renderedTextFragments,
   });
   const text = normalizeOptionalString(payload.text);

--- a/extensions/slack/src/reply-blocks.ts
+++ b/extensions/slack/src/reply-blocks.ts
@@ -163,7 +163,8 @@ export function resolveSlackReplyRenderPlan(
     segments: resolution.segments,
     text,
   });
-  if (messages.length <= 1) {
+  // Preview edits and native streams interpret text as mrkdwn; literal fallback uses normal delivery.
+  if (messages.length <= 1 && !messages[0]?.textIsSlackPlainText) {
     const [message] = messages;
     const sourceText = text?.trim() ?? "";
     const blocks =
@@ -275,11 +276,7 @@ function appendTextSegment(segments: SlackReplyBlockSegment[], text: string): vo
   if (!trimmed) {
     return;
   }
-  const last = segments.at(-1);
-  if (last?.kind === "text") {
-    last.text = `${last.text}\n\n${trimmed}`;
-    return;
-  }
+  // Preserve rendered fragment boundaries until authored-text placement is decided.
   segments.push({ kind: "text", text: trimmed, mrkdwn: false });
 }
 
@@ -503,7 +500,17 @@ export function resolveSlackReplyBlockResolution(
     }
     authoredTextPlacement = "blocks";
   }
-  return { authoredTextPlacement, segments };
+  // All transports consume this compact shape, after placement has used the original fragments.
+  const compacted: SlackReplyBlockSegment[] = [];
+  for (const segment of segments) {
+    const last = compacted.at(-1);
+    if (segment.kind === "text" && last?.kind === "text") {
+      last.text = `${last.text}\n\n${segment.text}`;
+    } else {
+      compacted.push(segment);
+    }
+  }
+  return { authoredTextPlacement, segments: compacted };
 }
 
 /** Return the single-message native shape when no ordered text fallback is required. */

--- a/extensions/slack/src/reply-blocks.ts
+++ b/extensions/slack/src/reply-blocks.ts
@@ -427,42 +427,13 @@ function subtractMirroredSlackControlRows(params: {
   });
 }
 
-/**
- * Resolve reply content into transport-order segments. Each blocks segment is
- * one Slack message; text segments carry complete fallback content between it.
- */
-export function resolveSlackReplyBlockResolution(
+function compileSlackReplyBlockSegments(
   payload: ReplyPayload,
-  options: { materializeAuthoredText?: boolean } = {},
-): SlackReplyBlockResolution {
+  channelBlocks: SlackBlock[],
+): SlackReplyBlockSegment[] {
   const segments: SlackReplyBlockSegment[] = [];
-  const channelBlocks = readSlackChannelBlocks(payload);
-  let compiledChannelBlocks = channelBlocks;
-  let authoredTextKnownInBlocks = false;
-  if (options.materializeAuthoredText) {
-    const rawTextFragments = renderSlackAuthoredTextFragments(channelBlocks);
-    const initialPlacement = resolveSlackAuthoredTextPlacement({
-      text: payload.text,
-      interactive: payload.interactive,
-      renderedTextFragments: rawTextFragments,
-    });
-    authoredTextKnownInBlocks = initialPlacement === "blocks";
-    const text = normalizeOptionalString(payload.text);
-    if (text && initialPlacement === "outside-blocks") {
-      const textBlocks = buildSlackAuthoredTextBlocks(text);
-      const compiledText = renderSlackAuthoredTextFragments(textBlocks).join(" ");
-      const compiledPlacement = resolveSlackAuthoredTextPlacement({
-        text: compiledText,
-        renderedTextFragments: rawTextFragments,
-      });
-      if (compiledPlacement !== "blocks") {
-        compiledChannelBlocks = [...channelBlocks, ...textBlocks];
-      }
-      authoredTextKnownInBlocks = true;
-    }
-  }
-  if (compiledChannelBlocks.length > 0) {
-    appendBlockSegment(segments, compiledChannelBlocks);
+  if (channelBlocks.length > 0) {
+    appendBlockSegment(segments, channelBlocks);
   }
 
   const presentation = normalizeMessagePresentation(payload.presentation);
@@ -493,21 +464,46 @@ export function resolveSlackReplyBlockResolution(
       presentationBlocks: renderedPresentationBlocks,
     }),
   );
+  return segments;
+}
+
+/**
+ * Resolve reply content into transport-order segments. Each blocks segment is
+ * one Slack message; text segments carry complete fallback content between it.
+ */
+export function resolveSlackReplyBlockResolution(
+  payload: ReplyPayload,
+  options: { materializeAuthoredText?: boolean } = {},
+): SlackReplyBlockResolution {
+  const channelBlocks = readSlackChannelBlocks(payload);
+  let segments = compileSlackReplyBlockSegments(payload, channelBlocks);
   const renderedTextFragments = segments.flatMap((segment) => {
     if (segment.kind === "text") {
       return [segment.text];
     }
     return renderSlackAuthoredTextFragments(segment.blocks);
   });
-  const authoredTextPlacement = resolveSlackAuthoredTextPlacement({
+  let authoredTextPlacement = resolveSlackAuthoredTextPlacement({
     text: payload.text,
     interactive: payload.interactive,
     renderedTextFragments,
   });
-  return {
-    authoredTextPlacement: authoredTextKnownInBlocks ? "blocks" : authoredTextPlacement,
-    segments,
-  };
+  const text = normalizeOptionalString(payload.text);
+  if (options.materializeAuthoredText && text && authoredTextPlacement === "outside-blocks") {
+    const textBlocks = buildSlackAuthoredTextBlocks(text);
+    const compiledText = renderSlackAuthoredTextFragments(textBlocks).join(" ");
+    const compiledPlacement = resolveSlackAuthoredTextPlacement({
+      text: compiledText,
+      renderedTextFragments,
+    });
+    if (compiledPlacement !== "blocks") {
+      // Decide from rendered content, then repack missing text through the same
+      // compiler so authored ordering, native-data budgets, and control ids stay aligned.
+      segments = compileSlackReplyBlockSegments(payload, [...channelBlocks, ...textBlocks]);
+    }
+    authoredTextPlacement = "blocks";
+  }
+  return { authoredTextPlacement, segments };
 }
 
 /** Return the single-message native shape when no ordered text fallback is required. */

--- a/extensions/slack/src/reply-blocks.ts
+++ b/extensions/slack/src/reply-blocks.ts
@@ -24,7 +24,11 @@ import {
   type SlackBlock,
   type SlackBlockRenderOptions,
 } from "./blocks-render.js";
-import { markdownToSlackMrkdwnChunks } from "./format.js";
+import {
+  chunkSlackMrkdwnText,
+  markdownToSlackMrkdwnChunks,
+  normalizeSlackOutboundText,
+} from "./format.js";
 import {
   appendSlackNativeDataFallbackText,
   buildSlackNativeDataAccessibilityText,
@@ -486,19 +490,25 @@ export function resolveSlackReplyBlockResolution(
     renderedTextFragments,
   });
   const text = normalizeOptionalString(payload.text);
-  if (options.materializeAuthoredText && text && authoredTextPlacement === "outside-blocks") {
+  if (text && authoredTextPlacement === "outside-blocks") {
     const textBlocks = buildSlackAuthoredTextBlocks(text);
-    const compiledText = renderSlackAuthoredTextFragments(textBlocks).join(" ");
-    const compiledPlacement = resolveSlackAuthoredTextPlacement({
-      text: compiledText,
+    const renderedText = normalizeSlackOutboundText(text);
+    authoredTextPlacement = resolveSlackAuthoredTextPlacement({
+      text: renderedText,
       renderedTextFragments,
+      // Authored Markdown and portable mrkdwn have different code-fence chunkers.
+      // Compare their emitted plans exactly; joining them changes command bytes.
+      authoredChunkPlans: [
+        renderSlackAuthoredTextFragments(textBlocks),
+        chunkSlackMrkdwnText(renderedText, SLACK_SECTION_TEXT_MAX),
+      ],
     });
-    if (compiledPlacement !== "blocks") {
+    if (options.materializeAuthoredText && authoredTextPlacement === "outside-blocks") {
       // Decide from rendered content, then repack missing text through the same
       // compiler so authored ordering, native-data budgets, and control ids stay aligned.
       segments = compileSlackReplyBlockSegments(payload, [...channelBlocks, ...textBlocks]);
+      authoredTextPlacement = "blocks";
     }
-    authoredTextPlacement = "blocks";
   }
   // All transports consume this compact shape, after placement has used the original fragments.
   const compacted: SlackReplyBlockSegment[] = [];

--- a/extensions/slack/src/reply-blocks.ts
+++ b/extensions/slack/src/reply-blocks.ts
@@ -29,6 +29,7 @@ import {
   markdownToSlackMrkdwnChunks,
   normalizeSlackOutboundText,
 } from "./format.js";
+import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
 import {
   appendSlackNativeDataFallbackText,
   buildSlackNativeDataAccessibilityText,
@@ -224,20 +225,22 @@ export function hasSlackReplyStructuredContent(payload: ReplyPayload): boolean {
   );
 }
 
-function renderSlackAuthoredTextFragments(blocks: readonly SlackBlock[]): string[] {
-  return blocks.flatMap((block) => {
-    if ((block as { type?: unknown }).type === "actions") {
-      return [];
+function renderSlackAuthoredTextFragments(segments: readonly SlackReplyBlockSegment[]): string[] {
+  return segments.flatMap((segment) => {
+    if (segment.kind === "text") {
+      return [escapeSlackMrkdwn(segment.text)];
     }
-    const text = renderSlackBlockFallbackText(block, { nativeDataFormat: "plain" });
-    return text ? [text] : [];
+    return segment.blocks
+      .filter((block) => block.type !== "actions")
+      .map((block) => renderSlackBlockFallbackText(block, { nativeDataFormat: "mrkdwn-safe" }))
+      .filter((text): text is string => Boolean(text));
   });
 }
 
-function buildSlackAuthoredTextBlocks(text: string): SlackBlock[] {
+function buildSlackAuthoredTextBlocks(text: string) {
   return markdownToSlackMrkdwnChunks(text, SLACK_SECTION_TEXT_MAX).map((chunk) => ({
-    type: "section",
-    text: { type: "mrkdwn", text: chunk, verbatim: true },
+    type: "section" as const,
+    text: { type: "mrkdwn" as const, text: chunk, verbatim: true },
   }));
 }
 
@@ -273,15 +276,6 @@ function readLastBlockSegment(segments: SlackReplyBlockSegment[]): SlackBlock[] 
 
 function readAllNativeBlocks(segments: SlackReplyBlockSegment[]): SlackBlock[] {
   return segments.flatMap((segment) => (segment.kind === "blocks" ? segment.blocks : []));
-}
-
-function appendTextSegment(segments: SlackReplyBlockSegment[], text: string): void {
-  const trimmed = text.trim();
-  if (!trimmed) {
-    return;
-  }
-  // Preserve rendered fragment boundaries until authored-text placement is decided.
-  segments.push({ kind: "text", text: trimmed, mrkdwn: false });
 }
 
 function appendBlockSegment(
@@ -352,12 +346,13 @@ function appendPresentationPart(
     return;
   }
 
-  appendTextSegment(
-    segments,
-    // The caller sends fallback segments with mrkdwn disabled, so preserve
-    // authored tokens and command bytes instead of emitting visible entities.
-    renderMessagePresentationFallbackText({ presentation }),
-  );
+  // The caller sends fallback segments with mrkdwn disabled, so preserve
+  // authored tokens and command bytes instead of emitting visible entities.
+  const text = renderMessagePresentationFallbackText({ presentation }).trim();
+  if (text) {
+    // Preserve rendered fragment boundaries until authored-text placement is decided.
+    segments.push({ kind: "text", text, mrkdwn: false });
+  }
 }
 
 const SLACK_BUTTON_CONTROL_ACTION_IDS = [
@@ -478,36 +473,25 @@ export function resolveSlackReplyBlockResolution(
 ): SlackReplyBlockResolution {
   const channelBlocks = readSlackChannelBlocks(payload);
   let segments = compileSlackReplyBlockSegments(payload, channelBlocks);
-  const renderedTextFragments = segments.flatMap((segment) => {
-    if (segment.kind === "text") {
-      return [segment.text];
-    }
-    return renderSlackAuthoredTextFragments(segment.blocks);
-  });
-  let authoredTextPlacement = resolveSlackAuthoredTextPlacement({
-    text: payload.text,
-    renderedTextFragments,
-  });
   const text = normalizeOptionalString(payload.text);
-  if (text && authoredTextPlacement === "outside-blocks") {
-    const textBlocks = buildSlackAuthoredTextBlocks(text);
-    const renderedText = normalizeSlackOutboundText(text);
-    authoredTextPlacement = resolveSlackAuthoredTextPlacement({
-      text: renderedText,
-      renderedTextFragments,
-      // Authored Markdown and portable mrkdwn have different code-fence chunkers.
-      // Compare their emitted plans exactly; joining them changes command bytes.
-      authoredChunkPlans: [
-        renderSlackAuthoredTextFragments(textBlocks),
-        chunkSlackMrkdwnText(renderedText, SLACK_SECTION_TEXT_MAX),
-      ],
-    });
-    if (options.materializeAuthoredText && authoredTextPlacement === "outside-blocks") {
-      // Decide from rendered content, then repack missing text through the same
-      // compiler so authored ordering, native-data budgets, and control ids stay aligned.
-      segments = compileSlackReplyBlockSegments(payload, [...channelBlocks, ...textBlocks]);
-      authoredTextPlacement = "blocks";
-    }
+  const textBlocks = text ? buildSlackAuthoredTextBlocks(text) : [];
+  const renderedText = text ? normalizeSlackOutboundText(text) : "";
+  let authoredTextPlacement = resolveSlackAuthoredTextPlacement({
+    text: renderedText,
+    // Native plain_text fields and literal fallback must not impersonate mrkdwn.
+    renderedTextFragments: renderSlackAuthoredTextFragments(segments),
+    // Authored Markdown and portable mrkdwn have different code-fence chunkers.
+    // Compare their emitted plans exactly; joining them changes command bytes.
+    authoredChunkPlans: [
+      textBlocks.map((block) => block.text.text),
+      chunkSlackMrkdwnText(renderedText, SLACK_SECTION_TEXT_MAX),
+    ],
+  });
+  if (options.materializeAuthoredText && authoredTextPlacement === "outside-blocks") {
+    // Decide from rendered content, then repack missing text through the same
+    // compiler so authored ordering, native-data budgets, and control ids stay aligned.
+    segments = compileSlackReplyBlockSegments(payload, [...channelBlocks, ...textBlocks]);
+    authoredTextPlacement = "blocks";
   }
   // All transports consume this compact shape, after placement has used the original fragments.
   const compacted: SlackReplyBlockSegment[] = [];

--- a/extensions/slack/src/reply-blocks.ts
+++ b/extensions/slack/src/reply-blocks.ts
@@ -14,7 +14,7 @@ import {
   resolveSlackAuthoredTextPlacement,
   type SlackAuthoredTextPlacement,
 } from "./authored-text.js";
-import { buildSlackBlocksFallbackText, renderSlackBlockFallbackText } from "./blocks-fallback.js";
+import { buildSlackBlocksFallbackText, renderSlackBlockTextFragments } from "./blocks-fallback.js";
 import { parseSlackBlocksInput, SLACK_MAX_BLOCKS } from "./blocks-input.js";
 import {
   buildSlackInteractiveBlocks,
@@ -226,9 +226,7 @@ function renderSlackAuthoredTextFragments(segments: readonly SlackReplyBlockSegm
     }
     return segment.blocks
       .filter((block) => block.type !== "actions")
-      .flatMap(
-        (block) => renderSlackBlockFallbackText(block, { nativeDataFormat: "mrkdwn-safe" }) ?? [],
-      );
+      .flatMap(renderSlackBlockTextFragments);
   });
 }
 

--- a/extensions/slack/src/reply-blocks.ts
+++ b/extensions/slack/src/reply-blocks.ts
@@ -219,7 +219,9 @@ export function hasSlackReplyStructuredContent(payload: ReplyPayload): boolean {
   );
 }
 
-function renderSlackAuthoredTextFragments(segments: readonly SlackReplyBlockSegment[]): string[] {
+function renderSlackAuthoredTextFragments(
+  segments: readonly SlackReplyBlockSegment[],
+): (string | null)[] {
   return segments.flatMap((segment) => {
     if (segment.kind === "text") {
       return [escapeSlackMrkdwn(segment.text)];

--- a/extensions/slack/src/rich-text.ts
+++ b/extensions/slack/src/rich-text.ts
@@ -11,7 +11,7 @@ import {
 } from "openclaw/plugin-sdk/text-chunking";
 import {
   escapeSlackMrkdwnSegment,
-  makeSlackEmphasisStylesSafe,
+  isSlackEmphasisStyleSafe,
   SLACK_RENDER_OPTIONS,
 } from "./format.js";
 import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
@@ -39,24 +39,22 @@ function projectRichText(
   preformatted = false,
 ): MarkdownIR | undefined {
   const element = asNonArrayRecord(value);
-  const type = element.type;
+  const type = String(element.type);
+  const section = type === "rich_text_section" || type === "rich_text_preformatted";
   const styled = options.format === "styled";
   const read = options.format === "plain" ? readNonBlankString : normalizeOptionalString;
   const result: MarkdownIR = { text: "", styles: [], links: [] };
-  const style = asOptionalRecord(element.style);
-  const styleNames =
-    styled && !preformatted
-      ? Object.keys(style ?? {}).filter((name) => style?.[name] === true)
-      : [];
+  const style = styled && !preformatted ? asOptionalRecord(element.style) : undefined;
+  const styleNames = Object.keys(style ?? {}).filter((name) => style?.[name] === true);
   const supportedStyles = Object.entries(styles).filter(([name]) => styleNames.includes(name));
   const code = styled && (preformatted || styleNames.includes("code"));
   // Native layout, generated dates and unrepresentable styles remain barriers, not flattened facts.
+  // Code references and emoji metadata carry rendering facts that literal tokens cannot preserve.
   if (
     styled &&
-    ((!["rich_text_section", "rich_text_preformatted", "text", "link", "emoji"].includes(
-      String(type),
-    ) &&
-      !references[String(type)]) ||
+    ((!section && !["text", "link", "emoji"].includes(type) && !references[type]) ||
+      (code && type !== "text") ||
+      (type === "emoji" && (element.unicode || element.url)) ||
       supportedStyles.length !== styleNames.length ||
       (styleNames.includes("code") && styleNames.length > 1) ||
       (!preformatted && code && typeof element.text === "string" && element.text.includes("`")))
@@ -66,9 +64,9 @@ function projectRichText(
   if (
     Array.isArray(element.elements) &&
     (options.format === "plain" ||
-      ["rich_text_section", "rich_text_list", "rich_text_quote", "rich_text_preformatted"].includes(
-        String(type),
-      ))
+      section ||
+      type === "rich_text_list" ||
+      type === "rich_text_quote")
   ) {
     for (const child of element.elements) {
       const part = projectRichText(
@@ -128,7 +126,7 @@ function projectRichText(
   } else if (type === "date") {
     result.text = literal(read(element.fallback) ?? "");
   } else {
-    const [field, prefix] = references[String(type)] ?? [];
+    const [field, prefix] = references[type] ?? [];
     const id = field ? read(element[field]) : undefined;
     const token = id ? `<${prefix}${id}>` : "";
     result.text = styled || options.preserveReferences ? token : literal(token);
@@ -151,7 +149,7 @@ export function renderSlackRichTextFragments(
     // Native styles must satisfy Slack's flanks and the marker renderer's nested-span contract.
     if (
       !ir ||
-      makeSlackEmphasisStylesSafe(ir) !== ir ||
+      ir.styles.some((span) => !isSlackEmphasisStyleSafe(ir.text, span)) ||
       ir.styles.some((a) =>
         ir.styles.some((b) => a.start < b.start && b.start < a.end && a.end < b.end),
       )

--- a/extensions/slack/src/rich-text.ts
+++ b/extensions/slack/src/rich-text.ts
@@ -1,0 +1,161 @@
+import {
+  asNonArrayRecord,
+  asOptionalRecord,
+  normalizeOptionalString,
+  readNonBlankString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  renderMarkdownWithMarkers,
+  type MarkdownIR,
+  type MarkdownStyle,
+} from "openclaw/plugin-sdk/text-chunking";
+import { escapeSlackMrkdwnSegment, SLACK_RENDER_OPTIONS } from "./format.js";
+import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
+
+const styledRenderOptions = { ...SLACK_RENDER_OPTIONS, escapeText: (text: string) => text };
+
+type RichTextOptions = { format: "plain" | "escaped" | "styled"; preserveReferences?: boolean };
+const styles: Record<string, MarkdownStyle> = {
+  bold: "bold",
+  italic: "italic",
+  strike: "strikethrough",
+  code: "code",
+};
+
+const references: Record<string, readonly [string, string]> = {
+  user: ["user_id", "@"],
+  channel: ["channel_id", "#"],
+  usergroup: ["usergroup_id", "!subteam^"],
+  broadcast: ["range", "!"],
+};
+
+function appendRichText(target: MarkdownIR, value: MarkdownIR, separator = "") {
+  if (!value.text) {
+    return;
+  }
+  if (target.text) {
+    target.text += separator;
+  }
+  const offset = target.text.length;
+  target.text += value.text;
+  for (const span of value.styles) {
+    const previous = target.styles.findLast((candidate) => candidate.style === span.style);
+    if (previous?.end === offset + span.start) {
+      previous.end = offset + span.end;
+    } else {
+      target.styles.push({ ...span, start: span.start + offset, end: span.end + offset });
+    }
+  }
+}
+
+function projectRichText(
+  value: unknown,
+  options: RichTextOptions,
+  preformatted = false,
+): MarkdownIR | undefined {
+  const element = asNonArrayRecord(value);
+  const type = element.type;
+  const styled = options.format === "styled";
+  const read = options.format === "plain" ? readNonBlankString : normalizeOptionalString;
+  const result: MarkdownIR = { text: "", styles: [], links: [] };
+  const style = asOptionalRecord(element.style);
+  const styleNames =
+    styled && !preformatted
+      ? Object.keys(style ?? {}).filter((name) => style?.[name] === true)
+      : [];
+  const supportedStyles = Object.entries(styles).filter(([name]) => styleNames.includes(name));
+  const code = styled && (preformatted || styleNames.includes("code"));
+  // Native layout, generated dates and unrepresentable styles remain barriers, not flattened facts.
+  if (
+    styled &&
+    ((!["rich_text_section", "rich_text_preformatted", "text", "link", "emoji"].includes(
+      String(type),
+    ) &&
+      !references[String(type)]) ||
+      supportedStyles.length !== styleNames.length ||
+      (styleNames.includes("code") && styleNames.length > 1) ||
+      (!preformatted && code && typeof element.text === "string" && element.text.includes("`")))
+  ) {
+    return undefined;
+  }
+  if (
+    Array.isArray(element.elements) &&
+    (options.format === "plain" ||
+      ["rich_text_section", "rich_text_list", "rich_text_quote", "rich_text_preformatted"].includes(
+        String(type),
+      ))
+  ) {
+    for (const child of element.elements) {
+      const part = projectRichText(
+        child,
+        options,
+        preformatted || type === "rich_text_preformatted",
+      );
+      if (!part) {
+        return undefined;
+      }
+      appendRichText(result, part, type === "rich_text_list" ? "\n" : "");
+    }
+    if (styled && type === "rich_text_preformatted") {
+      if (result.text.includes("```")) {
+        return undefined;
+      }
+      result.styles = [{ start: 0, end: result.text.length, style: "code_block" }];
+    }
+    return result;
+  }
+
+  const literal =
+    options.format === "plain"
+      ? (text: string) => text
+      : code
+        ? escapeSlackMrkdwnSegment
+        : escapeSlackMrkdwn;
+  const reference =
+    options.format === "plain" || styled || options.preserveReferences
+      ? (text: string) => text
+      : escapeSlackMrkdwn;
+  const label = read(element.text);
+  if (type === "text" && typeof element.text === "string") {
+    result.text = literal(element.text);
+  } else if (options.format === "plain" && label) {
+    result.text = label;
+  } else if (type === "link") {
+    const url = read(element.url);
+    result.text =
+      styled && !preformatted && url
+        ? `<${escapeSlackMrkdwnSegment(url)}${label && label !== url ? `|${escapeSlackMrkdwnSegment(label)}` : ""}>`
+        : literal(label ?? url ?? "");
+  } else if (type === "emoji") {
+    const name = read(element.name);
+    result.text = name ? `:${name}:` : "";
+  } else if (type === "date") {
+    result.text = literal(read(element.fallback) ?? "");
+  } else {
+    const [field, prefix] = references[String(type)] ?? [];
+    const id = field ? read(element[field]) : undefined;
+    result.text = id ? reference(`<${prefix}${id}>`) : "";
+  }
+  result.styles = supportedStyles.map(([, kind]) => ({
+    start: 0,
+    end: result.text.length,
+    style: kind,
+  }));
+  return result;
+}
+
+/** One native traversal supplies table text, escaped accessibility, and styled comparison views. */
+export function renderSlackRichTextFragments(
+  value: unknown,
+  options: RichTextOptions,
+): (string | null)[] {
+  return (Array.isArray(value) ? value : []).flatMap((element) => {
+    const ir = projectRichText(element, options);
+    if (!ir) {
+      return [null];
+    }
+    const rendered =
+      options.format === "styled" ? renderMarkdownWithMarkers(ir, styledRenderOptions) : ir.text;
+    return rendered ? [rendered] : [];
+  });
+}

--- a/extensions/slack/src/rich-text.ts
+++ b/extensions/slack/src/rich-text.ts
@@ -9,7 +9,11 @@ import {
   type MarkdownIR,
   type MarkdownStyle,
 } from "openclaw/plugin-sdk/text-chunking";
-import { escapeSlackMrkdwnSegment, SLACK_RENDER_OPTIONS } from "./format.js";
+import {
+  escapeSlackMrkdwnSegment,
+  makeSlackEmphasisStylesSafe,
+  SLACK_RENDER_OPTIONS,
+} from "./format.js";
 import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
 
 const styledRenderOptions = { ...SLACK_RENDER_OPTIONS, escapeText: (text: string) => text };
@@ -28,25 +32,6 @@ const references: Record<string, readonly [string, string]> = {
   usergroup: ["usergroup_id", "!subteam^"],
   broadcast: ["range", "!"],
 };
-
-function appendRichText(target: MarkdownIR, value: MarkdownIR, separator = "") {
-  if (!value.text) {
-    return;
-  }
-  if (target.text) {
-    target.text += separator;
-  }
-  const offset = target.text.length;
-  target.text += value.text;
-  for (const span of value.styles) {
-    const previous = target.styles.findLast((candidate) => candidate.style === span.style);
-    if (previous?.end === offset + span.start) {
-      previous.end = offset + span.end;
-    } else {
-      target.styles.push({ ...span, start: span.start + offset, end: span.end + offset });
-    }
-  }
-}
 
 function projectRichText(
   value: unknown,
@@ -94,7 +79,22 @@ function projectRichText(
       if (!part) {
         return undefined;
       }
-      appendRichText(result, part, type === "rich_text_list" ? "\n" : "");
+      if (!part.text) {
+        continue;
+      }
+      if (result.text && type === "rich_text_list") {
+        result.text += "\n";
+      }
+      const offset = result.text.length;
+      result.text += part.text;
+      for (const span of part.styles) {
+        const previous = result.styles.findLast((candidate) => candidate.style === span.style);
+        if (previous?.end === offset + span.start) {
+          previous.end = offset + span.end;
+        } else {
+          result.styles.push({ ...span, start: span.start + offset, end: span.end + offset });
+        }
+      }
     }
     if (styled && type === "rich_text_preformatted") {
       if (result.text.includes("```")) {
@@ -111,11 +111,7 @@ function projectRichText(
       : code
         ? escapeSlackMrkdwnSegment
         : escapeSlackMrkdwn;
-  const reference =
-    options.format === "plain" || styled || options.preserveReferences
-      ? (text: string) => text
-      : escapeSlackMrkdwn;
-  const label = read(element.text);
+  const label = styled && typeof element.text === "string" ? element.text : read(element.text);
   if (type === "text" && typeof element.text === "string") {
     result.text = literal(element.text);
   } else if (options.format === "plain" && label) {
@@ -134,7 +130,8 @@ function projectRichText(
   } else {
     const [field, prefix] = references[String(type)] ?? [];
     const id = field ? read(element[field]) : undefined;
-    result.text = id ? reference(`<${prefix}${id}>`) : "";
+    const token = id ? `<${prefix}${id}>` : "";
+    result.text = styled || options.preserveReferences ? token : literal(token);
   }
   result.styles = supportedStyles.map(([, kind]) => ({
     start: 0,
@@ -151,7 +148,14 @@ export function renderSlackRichTextFragments(
 ): (string | null)[] {
   return (Array.isArray(value) ? value : []).flatMap((element) => {
     const ir = projectRichText(element, options);
-    if (!ir) {
+    // Native styles must satisfy Slack's flanks and the marker renderer's nested-span contract.
+    if (
+      !ir ||
+      makeSlackEmphasisStylesSafe(ir) !== ir ||
+      ir.styles.some((a) =>
+        ir.styles.some((b) => a.start < b.start && b.start < a.end && a.end < b.end),
+      )
+    ) {
       return [null];
     }
     const rendered =


### PR DESCRIPTION
Closes #133135

## What Problem This Solves

Slack could repeat authored text already contained in a presentation, hide distinct formatting or code whitespace, and reject valid edits because text was duplicated or rendered twice. Structured replies also ignored the account's Markdown table setting even when ordinary text replies used it.

## Why This Change Was Made

The Slack reply compiler renders presentation content first, then decides authored-text placement from its actual format-aware fragments. It compares both existing producer chunk plans without collapsing interior whitespace, inventing separators, or treating literal/plain-text fields as mrkdwn. Legacy separator matching respects complete formatting spans using the existing Slack tokenizer. Raw legacy metadata is used only before rendered facts exist; comparison never rewrites transport bytes.

Missing authored text is repacked through the same compiler, preserving raw-block → authored-text → presentation order, block limits, chart/table budgets, and control identifiers. Literal fallback fragments and individual context/section text objects remain separate until placement is decided; existing accessibility joins remain unchanged. Monitor and outbound delivery consume the same ordered message plan instead of duplicating assembly.

The existing channel/account Markdown policy now reaches that compiler from sends, edits, outbound presentation rendering, monitor replies, slash replies, previews, and stream eligibility/delivery tracking. Dispatch setup carries the prepared policy forward. Edits pass their prepared Slack text through private action context to the existing rendered-edit sender, so formatting and the 4,000-byte limit use exactly the bytes sent. Direct edit APIs still accept ordinary Markdown. The existing oversized-presentation fallback and native-block notification behavior are preserved.

The native scanner owns delimiter eligibility and complete formatting spans. One chunk writer keeps intended and emitted styles separate, emits transitions only with content, and reserves marker overhead plus pending whitespace. Chunk-edge spaces stay outside synthetic emphasis without losing bytes; empty native delimiters and intraword markers remain literal. A shared structured rich-text traversal records styles and link destinations for comparison while preserving prior plain table and escaped accessibility views. Native style spans must satisfy the shared content-edge/outside-flank policy and the renderer’s nesting contract. Native-only layouts/decorations, crossing or unrepresentable styles, opaque leaves, generated dates, and code containing an unrepresentable delimiter remain barriers: comparison cannot drop them or invent equivalent text. Styled link labels retain their exact whitespace. Code-styled links/references and metadata-bearing emoji are opaque comparison facts because literal tokens or aliases cannot preserve their native rendering. Ordinary alias-only emoji remains equivalent; accessibility/table fallback is unchanged. [Slack emoji contract](https://docs.slack.dev/tools/node-slack-sdk/reference/web-api/interfaces/RichTextEmoji/), [Slack link contract](https://docs.slack.dev/tools/node-slack-sdk/reference/web-api/interfaces/RichTextLink/).

Removed paths include premature raw-only materialization, a parallel edit renderer, post-render raw comparison, one-use fallback wrappers, duplicate monitor delivery assembly, duplicate rich-text readers, and the parallel plain-text native chunk path. Production: **+636/−638, net −2**. Tests and test support: **+1344/−131, net +1213** (including moved outbound test setup); assertion-safety bookkeeping is +1/−2. No new config, schema, protocol, public plugin SDK, dependency, or security-policy surface. Distinct authored text can require a second pure compilation to preserve one packing owner.

## User Impact

Structured sends and edits retain authored formatting, meaningful whitespace, and account table settings without adding duplicate visible text. Long native formatting remains balanced across transport chunks; rich-text content only suppresses authored text when its recorded formatting is equivalent.

## Evidence

- Exact candidate head: `f59c0692fa5d2ced0ff5ad3540d061711ac18645`.
- Frozen baseline: `3f1c84c706bf1e4c8bc7b2ab106ab96ff1fe6ddb`.
- Actual-sender regressions fail before the original repair. Every accepted subsequent source finding has an executed before reproduction; chunk and format failures were also reproduced through the compiled Gateway and recorded Slack HTTP boundary.
- Earlier native formatting proof: ten intended failures for long emphasis and rich-text styles, seven for opaque leaves/code delimiters/literal markers, and one mixed literal-prefix failure were captured before repair. The rich owner batch passes **163 tests across eight files**; the corresponding scanner batch passes **116 tests across three files**, with type-aware lint and the canonical assertion ratchet also green. These overlapping runs cover exact native transport bytes, rich-text style/link/layout boundaries, inbound mentions/accessibility, and data-table consumers.
- Earlier unchanged fragment-owner proof: **420 tests pass across eight files**, plus **46 action tests pass** after fixture typing corrections. Earlier account-policy proof passed **475 tests across eight files** and **111 action-runtime tests** in separate runs; moved outbound suites passed the same **64 cases** after splitting. These counts overlap and are not additive. These cover account policy, actions, actual outbound send/edit requests, compiler packing, formatting, monitor delivery, preview/stream fallback, and action admission.
- Account-policy regressions: ten intended failures across action send, direct/signed outbound, monitor, and slash delivery; five disabled-table controls. Two additional preview failures use the actual formatter. Four intended edit failures and two positive controls exercise the actual dispatcher → action runtime → `chat.update`. The repaired cases pass.
- Three monitor assembly controls now assert actual `chat.postMessage` text/blocks instead of an internal empty-text argument. They pass against both old and new assembly; media order, identity, metadata, threading, hooks, and receipts remain asserted.
- Original unescaped chart-list inputs remain negative equivalence cases: authored Markdown bullets differ from native/literal hyphens, so both remain visible. Escaped-list controls render equivalent bytes and deduplicate. Code whitespace, split formatting spans, plain-text headers/context, both long-code chunkers, and edit byte boundaries remain covered.
- Intra-block formatting regressions: four intended failures and two positive controls use the actual sender with raw context elements or section fields. Individually formatted text objects cannot be joined for equivalence; original blocks remain byte-identical while distinct authored text is preserved. [Slack text objects](https://docs.slack.dev/reference/block-kit/composition-objects/text-object/).
- Final 25-path changed-file gate: all 27 canonical stages pass in 336 seconds on this exact source, including production/test types, formatting, full plugin/script lint, dead exports, plugin boundaries, and runtime import cycles.
- Final writer regressions: four intended actual-sender failures cover empty/whitespace-edge emphasis, crossing styles, and exact link-label whitespace; a fifth covers nested intraword native styles. Empty native delimiter preservation also has three executed draft-regression failures and two literal controls. The repaired formatter/authored suites pass **103 tests**, including tiny limits and exact leading whitespace, plus scoped type-aware lint. These counts overlap earlier runs.
- Final native admission regressions: five intended actual-sender failures cover whitespace inside bold/italic/strike native spans and code styling on links/references; two further failures cover Unicode/custom-asset emoji metadata, with an ordinary alias control passing. The repaired eight-owner batch passes **186 tests** plus scoped type-aware lint. This is sender-boundary proof with dependency contract evidence, not live Slack UI rendering proof. Fresh whole-candidate autoreview and independent full-source challenge pass. The separate committed-head review is running against this exact commit.
- Canonical build and compiled 66-case Gateway `/tools/invoke` → message tool → Slack plugin → recorded mock Slack HTTP: pending final canonical build and execution; no prior artifact is counted as a pass for this head.
- Exact-head hosted CI: pending attachment to this pushed head.

**Not ready to merge:** separate committed-head review, canonical build, compiled Gateway proof, and required exact-head CI remain mandatory.

The Gateway fixture uses a mock provider and isolated state/workspace, with no live Slack credentials or operator Gateway. Crabline handles sends; a local `chat.update` extension validates the seeded channel/timestamp and records the real handler's text/blocks because the installed simulator lacks that endpoint. This is mock-Gateway proof, not a live Slack API claim. The final tool-flow cases cover default-code and account-bullets sends/edits; preview and stream decisions are exercised by the focused dispatcher suite.

A baseline source-Gateway attempt hit the strict 240-second startup cap before invoking the tool; it is not counted as a failed user action. Later source edit attempts were incomplete; a bounded loader profile identified synchronous source-import overhead. The canonical compiled flow uses the real CLI without a loader override or timeout increase. A malformed native-dialect fixture, an initial identity-chunker preview fixture, three invalid test fixture typings, and a leading-whitespace sender fixture above the existing presentation-normalization boundary were corrected; their failed artifacts are preserved separately and are not counted as product before-proof. The leading-whitespace assertion moved intact to the native chunker boundary; core normalization was not changed.

Hosted CI on an earlier head caught the same private callback type and invalid test fixtures as the local type gate; those are corrected without widening the public action context or weakening assertions.

ClawSweeper's recorded rank-ups require opaque crossing styles, exact link-label whitespace, no synthetic blank emphasis wrappers, and the final compiled send/edit trace. Those source repairs and the exact trailing-whitespace control are included; the current compiled trace and exact-head CI remain required before native preparation/merge. Introduction provenance is not inferred from shallow history.

Follow-ups: native-only rich-text layouts or decorations without a faithful mrkdwn projection remain opaque; broader semantic equivalence is not claimed. Native Block Kit edits intentionally retain authored top-level text as notification/accessibility content when it differs from visible blocks; the operator ambiguity merits separate product clarification. Slack's current table documentation allows 200 regular rows / 20,000 aggregate cell characters, while OpenClaw's conservative 100 / 10,000 limits remain unchanged. [Slack data-table contract](https://docs.slack.dev/reference/block-kit/blocks/data-table-block/).
