### PR TITLE
test: reuse native main-refresh Git fixture history

### DIFF
--- a/test/scripts/pr-main-refresh.test-support.ts
+++ b/test/scripts/pr-main-refresh.test-support.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import {
   chmodSync,
+  constants as fsConstants,
   cpSync,
   mkdirSync,
   readFileSync,
@@ -9,21 +10,18 @@ import {
   writeFileSync,
 } from "node:fs";
 import { delimiter, join } from "node:path";
+import { afterAll } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const templateDirs = useAutoCleanupTempDirTracker(afterAll);
+let fixtureTemplate: ReturnType<typeof createMainRefreshTemplate> | undefined;
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/gu, `'\\''`)}'`;
 }
 
-// Keep the complete wrapper/lock/entry/gate owners. Command resolution, Git
-// transport faults, and GitHub responses are synthetic.
-export function createMainRefreshFixture(directory: string) {
-  const root = realpathSync(directory);
-  const canonical = join(root, "canonical");
-  const origin = join(root, "origin.git");
-  const worktree = join(canonical, ".worktrees", "pr-42");
-  const bin = join(root, "bin");
+function createFixtureGit(root: string) {
   const home = join(root, "home");
-  mkdirSync(bin);
   mkdirSync(home);
   const env: NodeJS.ProcessEnv = {
     PATH: process.env.PATH,
@@ -43,6 +41,14 @@ export function createMainRefreshFixture(directory: string) {
     }
     return result.stdout.trim();
   }
+  return { env, realGit, git };
+}
+
+function createMainRefreshTemplate(directory: string) {
+  const root = realpathSync(directory);
+  const canonical = join(root, "canonical");
+  const origin = join(root, "origin.git");
+  const { git } = createFixtureGit(root);
   git(root, "init", "--bare", "-b", "main", origin);
   git(root, "init", "-b", "main", canonical);
   git(canonical, "config", "user.name", "OpenClaw Test");
@@ -82,15 +88,7 @@ export function createMainRefreshFixture(directory: string) {
   git(canonical, "add", ".");
   git(canonical, "commit", "-qm", "test: trusted native wrapper");
   const main = git(canonical, "rev-parse", "HEAD");
-  git(canonical, "remote", "add", "origin", origin);
-  git(canonical, "config", `url.${origin}.insteadOf`, "https://github.com/fixture/repo");
-  git(
-    canonical,
-    "config",
-    "--add",
-    `url.${origin}.insteadOf`,
-    "https://github.com/fixture/repo.git",
-  );
+  git(canonical, "remote", "add", "origin", "../origin.git");
   git(canonical, "push", "origin", "main");
   git(canonical, "checkout", "-qb", "topic");
   writeFileSync(join(canonical, "src", "subject.ts"), "export const subject = 'reviewed';\n");
@@ -109,6 +107,37 @@ export function createMainRefreshFixture(directory: string) {
   git(canonical, "push", "origin", `${gateMain}:refs/heads/gate-movement`);
   git(canonical, "push", "origin", `${movedMain}:refs/heads/movement`);
   git(canonical, "checkout", "--detach", main);
+  return { canonical, origin, main, head, sameTreeHead, movedMain, gateMain };
+}
+
+// Keep the complete wrapper/lock/entry/gate owners. Command resolution, Git
+// transport faults, and GitHub responses are synthetic.
+export function createMainRefreshFixture(directory: string) {
+  const template = (fixtureTemplate ??= createMainRefreshTemplate(
+    templateDirs.make("openclaw-pr-main-refresh-template-"),
+  ));
+  const root = realpathSync(directory);
+  const canonical = join(root, "canonical");
+  const origin = join(root, "origin.git");
+  const worktree = join(canonical, ".worktrees", "pr-42");
+  const bin = join(root, "bin");
+  mkdirSync(bin);
+  const { env, realGit, git } = createFixtureGit(root);
+  const { main, head, sameTreeHead, movedMain, gateMain } = template;
+  // Copy complete object stores (including sameTreeHead), never shared refs or
+  // hardlinks. Create worktrees afterward so their absolute back-links stay local.
+  const copyOptions = { recursive: true, mode: fsConstants.COPYFILE_FICLONE };
+  cpSync(template.canonical, canonical, copyOptions);
+  cpSync(template.origin, origin, copyOptions);
+  git(canonical, "remote", "set-url", "origin", origin);
+  git(canonical, "config", `url.${origin}.insteadOf`, "https://github.com/fixture/repo");
+  git(
+    canonical,
+    "config",
+    "--add",
+    `url.${origin}.insteadOf`,
+    "https://github.com/fixture/repo.git",
+  );
   git(canonical, "worktree", "add", "--detach", worktree, head);
   symlinkSync(join(process.cwd(), "node_modules"), join(canonical, "node_modules"), "dir");
   const local = join(worktree, ".local");


### PR DESCRIPTION
## What Problem This Solves

The native PR main-refresh tests repeatedly build identical Git history before exercising each checkpoint and recovery scenario. That setup adds roughly a second per case to an otherwise unchanged integration test.

## Why This Change Was Made

Prepare one file-owned history template, then independently copy its complete canonical and bare repositories for each fixture. Each case still installs its own origin and URL rewrites and creates a real linked worktree. Complete object stores preserve the intentionally unreferenced same-tree commit; no hardlinks, alternates, shared mutable refs, or cached worktree registrations are introduced. Template cleanup is registered before initialization, including partial failures.

The wrapper, Git transport, lock acquisition/recovery, interruption handshakes, hosted gates, merge receipt checks, and per-case cleanup remain unchanged. The existing fast path for uninstrumented Git commands is preserved.

## User Impact

Faster test execution only. No production behavior, sharding, worker configuration, test cases, assertions, mocks, clocks, or deadlines change. Production LOC: +0/-0. Test support: +47/-18. No changelog entry is needed for this internal test change.

## Evidence

On macOS with Node 26.5.0 and Vitest 4.1.11, the same 53-case command ran in **169.02s and 165.40s before**, versus **129.01s and 130.43s after** (before/after/after/before order). That saves about **37 seconds, or 22%**, for this focused pair. All 53 existing cases passed in all four runs. These are local measurements, not a claim about total CI duration.

```sh
env -u OPENCLAW_TESTBOX OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/pr-main-refresh.test.ts test/scripts/pr-merge-hosted.test.ts --reporter=verbose --reporter=json --outputFile=<report.json>
env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs -- test/scripts/pr-main-refresh.test-support.ts
```

A separate fixture probe compared baseline/candidate refs, heads, trees, indexes, config, metadata and the same-tree object. Mutating one candidate's origin refs, config, hook, worktree and remote-only object left its siblings and template unchanged; removing its worktree left the sibling registration valid. It also verified independent file identities, no alternates, and template cleanup. Repeated fixture setup fell from approximately 1.3s to 0.28s, including real worktree creation. The standalone probe supplies only Vitest hook registration and TypeScript source resolution; it is supplemental to the unchanged Vitest suites.

The full changed-file gate passed, including test-root typecheck, script lint, formatting and dependency/patch/temp-directory guards. Required Codex autoreview passed with no accepted findings. An injected bootstrap failure also confirmed that registered cleanup removes the partially initialized template.
