### PR TITLE
fix(plugins): show package provenance in CLI and chat inspection

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -489,6 +489,8 @@ openclaw plugins inspect --all
 
 Inspect shows identity, load status, source, manifest capabilities, policy flags, diagnostics, install metadata, bundle capabilities, and any detected MCP or LSP server support without importing plugin runtime by default. JSON output includes the plugin manifest contracts, such as `contracts.agentToolResultMiddleware` and `contracts.trustedToolPolicies`, so operators can audit trusted-surface declarations before enabling or restarting a plugin. Add `--runtime` to load the plugin module and include registered hooks, tools, commands, services, gateway methods, and HTTP routes. Runtime inspection reports missing plugin dependencies directly; installs and repairs stay in `openclaw plugins install`, `openclaw plugins update`, and `openclaw doctor --fix`.
 
+For multi-entry packages, inspecting any child shows the shared package install metadata. `inspect --all --json` includes that same record for each child. If package ownership is missing or ambiguous, inspection omits install metadata rather than attributing an unrelated install record.
+
 Plugin-owned CLI commands are usually installed as root `openclaw` command groups, but plugins may also register nested commands under a core parent such as `openclaw nodes`. After `inspect --runtime` shows a command under `cliCommands`, run it at the listed path; for example a plugin that registers `demo-git` can be verified with `openclaw demo-git ping`.
 
 Each plugin is classified by what it actually registers at runtime:

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -514,6 +514,8 @@ the source and permits replacement of an existing install; it does not bypass
 are printed informationally; blocked releases remain non-installable.
 Marketplace, linked, and pinned installs remain shell-only.
 
+`/plugins inspect <child>` (also `show` or `get`) and `/plugins inspect all` include the shared package install metadata for multi-entry plugins. Inspection returns `install: null` when package ownership is missing or ambiguous, and preserves its runtime capability report.
+
 When `/plugins install` or `/plugins enable` requires capability consent, it
 returns the plugin's declared capabilities and an exact retry command. Review
 that reply, then rerun with `--accept-capabilities`:

--- a/src/auto-reply/reply/commands-plugins.test.ts
+++ b/src/auto-reply/reply/commands-plugins.test.ts
@@ -3,11 +3,14 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { PluginCapabilityConsentReview } from "../../plugins/capability-consent.js";
+import { recordInstalledPluginIndexInstallOwner } from "../../plugins/installed-plugin-index-install-owner.js";
 import { ManagedPluginLifecycleError } from "../../plugins/management-lifecycle-error.js";
+import { createInstalledPluginIndexSnapshot } from "../../plugins/status.test-fixtures.js";
 import { handlePluginsCommand } from "./commands-plugins.js";
 import { buildPluginsCommandParams, type ConfigSnapshotMock } from "./commands.test-harness.js";
 
 const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
+const loadPluginMetadataSnapshotMock = vi.hoisted(() => vi.fn());
 const validateConfigObjectWithPluginsMock = vi.hoisted(() => vi.fn());
 const replaceConfigFileMock = vi.hoisted(() => vi.fn(async (_params: unknown) => undefined));
 const buildPluginRegistrySnapshotReportMock = vi.hoisted(() => vi.fn());
@@ -107,10 +110,9 @@ vi.mock("../../plugins/install.js", () => ({
   installPluginFromPath: vi.fn(),
 }));
 
-vi.mock("../../plugins/installed-plugin-index-records.js", () => ({
-  loadInstalledPluginIndexInstallRecords: vi.fn(
-    async (params = {}) => params.config?.plugins?.installs ?? {},
-  ),
+vi.mock("../../plugins/plugin-metadata-snapshot.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../plugins/plugin-metadata-snapshot.js")>()),
+  loadPluginMetadataSnapshot: loadPluginMetadataSnapshotMock,
 }));
 
 vi.mock("../../plugins/status.js", () => ({
@@ -208,6 +210,9 @@ function expectLastRegistryRefresh(enabled: boolean) {
 describe("handlePluginsCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    loadPluginMetadataSnapshotMock.mockReturnValue({
+      index: createInstalledPluginIndexSnapshot([]),
+    });
     resolvePluginCapabilityConsentMock.mockReset().mockResolvedValue(undefined);
     resolvePendingPluginCapabilityReviewMock.mockReset();
     readConfigFileSnapshotMock.mockResolvedValue({
@@ -289,6 +294,120 @@ describe("handlePluginsCommand", () => {
     expect(inspectAllResult?.reply?.text).toContain('"compatibilityWarnings"');
     expect(inspectAllResult?.reply?.text).toContain('"superpowers"');
   });
+
+  it("reports package-owned provenance for child inspection and all aliases", async () => {
+    const install = {
+      source: "npm",
+      spec: "@example/pack@1.2.3",
+      version: "1.2.3",
+      installPath: "/plugins/pack",
+      integrity: "sha512-pack",
+    };
+    const reports = ["pack/one", "pack/two"].map((id) => ({
+      plugin: { id },
+      compatibility: [],
+      tools: [{ name: "runtime_tool" }],
+    }));
+    const index = {
+      ...createInstalledPluginIndexSnapshot(
+        reports.map(({ plugin }) =>
+          recordInstalledPluginIndexInstallOwner(
+            { pluginId: plugin.id, rootDir: install.installPath },
+            "pack",
+          ),
+        ),
+      ),
+      installRecords: { pack: install },
+    };
+    loadPluginMetadataSnapshotMock.mockReturnValue({ index });
+    buildAllPluginInspectReportsMock.mockReturnValue(reports);
+
+    for (const action of ["inspect", "show", "get"]) {
+      for (const report of reports) {
+        buildPluginInspectReportMock.mockReturnValue(report);
+        const result = await handlePluginsCommand(
+          buildPluginsParams(`/plugins ${action} ${report.plugin.id}`, buildCfg()),
+          true,
+        );
+        const payload = JSON.parse(
+          result?.reply?.text?.split("```json\n")[1]?.split("\n```")[0] ?? "null",
+        );
+        expect(payload).toEqual({ ...report, compatibilityWarnings: [], install });
+      }
+      const result = await handlePluginsCommand(
+        buildPluginsParams(`/plugin ${action} all`, buildCfg()),
+        true,
+      );
+      const payload = JSON.parse(
+        result?.reply?.text?.split("```json\n")[1]?.split("\n```")[0] ?? "null",
+      );
+      expect(payload).toEqual(
+        reports.map((inspect) => ({ inspect, compatibilityWarnings: [], install })),
+      );
+    }
+    expect(buildPluginDiagnosticsReportMock).toHaveBeenCalled();
+    expect(buildPluginRegistrySnapshotReportMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps bare inspection on the runtime report", async () => {
+    const result = await handlePluginsCommand(
+      buildPluginsParams("/plugins inspect", buildCfg()),
+      true,
+    );
+    expect(result?.reply?.text).toContain("superpowers");
+    expect(buildPluginDiagnosticsReportMock).toHaveBeenCalledTimes(1);
+    expect(buildPluginRegistrySnapshotReportMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["list", "inspect pack/one", "enable pack/one"])(
+    "rejects invalid config before loading plugin state for %s",
+    async (action) => {
+      readConfigFileSnapshotMock.mockResolvedValue({ valid: false, path: "/tmp/openclaw.json" });
+      const result = await handlePluginsCommand(
+        buildPluginsParams(`/plugins ${action}`, buildCfg(), {
+          gatewayClientScopes: WRITE_GATEWAY_SCOPES,
+        }),
+        true,
+      );
+      expect(result?.reply?.text).toBe("⚠️ Config file is invalid; fix it before using /plugins.");
+      expect(buildPluginDiagnosticsReportMock).not.toHaveBeenCalled();
+      expect(buildPluginRegistrySnapshotReportMock).not.toHaveBeenCalled();
+      expect(replaceConfigFileMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["missing", "ambiguous", "conflicting"])(
+    "does not attribute chat install metadata when ownership is %s",
+    async (ownership) => {
+      const inspect = { plugin: { id: "pack/one" }, compatibility: [] };
+      const index = {
+        ...createInstalledPluginIndexSnapshot([
+          recordInstalledPluginIndexInstallOwner(
+            { pluginId: inspect.plugin.id, rootDir: "/plugins/pack" },
+            ownership === "conflicting" ? "pack" : undefined,
+            ownership === "ambiguous",
+          ),
+        ]),
+        installRecords: {
+          pack: { source: "npm", installPath: "/plugins/pack" },
+          "pack/one": { source: "npm", installPath: "/plugins/unrelated" },
+        },
+      };
+      loadPluginMetadataSnapshotMock.mockReturnValue({ index });
+      buildPluginInspectReportMock.mockReturnValue(inspect);
+      buildAllPluginInspectReportsMock.mockReturnValue([inspect]);
+      for (const name of [inspect.plugin.id, "all"]) {
+        const result = await handlePluginsCommand(
+          buildPluginsParams(`/plugins inspect ${name}`, buildCfg()),
+          true,
+        );
+        const payload = JSON.parse(
+          result?.reply?.text?.split("```json\n")[1]?.split("\n```")[0] ?? "null",
+        );
+        expect(Array.isArray(payload) ? payload[0].install : payload.install).toBeNull();
+      }
+    },
+  );
 
   it("rejects internal writes without operator.admin", async () => {
     const params = buildPluginsParams("/plugins enable superpowers", buildCfg());

--- a/src/auto-reply/reply/commands-plugins.ts
+++ b/src/auto-reply/reply/commands-plugins.ts
@@ -3,7 +3,6 @@ import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/s
 import { resolvePluginCapabilityConsentCliOptions } from "../../cli/plugin-capability-consent.js";
 import { readConfigFileSnapshot, readConfigFileSnapshotForWrite } from "../../config/config.js";
 import { assertConfigWriteAllowedInCurrentMode } from "../../config/nix-mode-write-guard.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import {
   resolveInstallConfigMutationPreflights,

--- a/src/auto-reply/reply/commands-plugins.ts
+++ b/src/auto-reply/reply/commands-plugins.ts
@@ -4,15 +4,16 @@ import { resolvePluginCapabilityConsentCliOptions } from "../../cli/plugin-capab
 import { readConfigFileSnapshot, readConfigFileSnapshotForWrite } from "../../config/config.js";
 import { assertConfigWriteAllowedInCurrentMode } from "../../config/nix-mode-write-guard.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { PluginInstallRecord } from "../../config/types.plugins.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import {
   resolveInstallConfigMutationPreflights,
   selectInstallMutationWriteOptions,
   type ConfigSnapshotForInstallPersist,
 } from "../../plugins/install-persistence.js";
-import { loadInstalledPluginIndexInstallRecords } from "../../plugins/installed-plugin-index-records.js";
+import type { InstalledPluginIndex } from "../../plugins/installed-plugin-index.js";
+import { resolveInstalledPluginPackageOwnership } from "../../plugins/installed-plugin-package-ownership.js";
 import { withPluginLifecycleLease } from "../../plugins/plugin-lifecycle-lease.js";
+import { loadPluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
 import { refreshPluginRegistryAfterConfigMutation } from "../../plugins/registry-refresh.js";
 import type { PluginRecord } from "../../plugins/registry.js";
 import {
@@ -44,8 +45,9 @@ function renderJsonBlock(label: string, value: unknown): string {
 
 function buildPluginInspectJson(
   inspect: ReturnType<typeof buildAllPluginInspectReports>[number],
-  installRecords: Record<string, PluginInstallRecord>,
+  index: InstalledPluginIndex,
 ) {
+  const ownership = resolveInstalledPluginPackageOwnership(index, inspect.plugin.id);
   return {
     inspect,
     compatibilityWarnings: inspect.compatibility.map((warning) => ({
@@ -53,7 +55,7 @@ function buildPluginInspectJson(
       severity: warning.severity,
       message: formatPluginCompatibilityNotice(warning),
     })),
-    install: installRecords[inspect.plugin.id] ?? null,
+    install: ownership.ok ? ownership.value.installRecord : null,
   };
 }
 
@@ -115,38 +117,6 @@ function findPlugin(report: PluginStatusReport, rawName: string): PluginRecord |
       normalizeOptionalLowercaseString(plugin.id) === target ||
       normalizeOptionalLowercaseString(plugin.name) === target,
   );
-}
-
-async function loadPluginCommandState(
-  workspaceDir: string,
-  options?: { loadModules?: boolean },
-): Promise<
-  | {
-      ok: true;
-      path: string;
-      config: OpenClawConfig;
-      report: PluginStatusReport;
-    }
-  | { ok: false; path: string; error: string }
-> {
-  const snapshot = await readConfigFileSnapshot();
-  if (!snapshot.valid) {
-    return {
-      ok: false,
-      path: snapshot.path,
-      error: "Config file is invalid; fix it before using /plugins.",
-    };
-  }
-  const config = structuredClone(snapshot.resolved);
-  return {
-    ok: true,
-    path: snapshot.path,
-    config,
-    report:
-      options?.loadModules === true
-        ? buildPluginDiagnosticsReport({ config, workspaceDir })
-        : buildPluginRegistrySnapshotReport({ config, workspaceDir }),
-  };
 }
 
 async function loadPluginCommandConfig(): Promise<
@@ -247,37 +217,34 @@ export const handlePluginsCommand: CommandHandler = defineAuthorizedTextCommand(
     }
 
     const handleLoadedCommand = async () => {
-      const loaded = await loadPluginCommandState(params.workspaceDir, {
-        loadModules: pluginsCommand.action === "inspect",
-      });
-      if (!loaded.ok) {
-        return commandReply(`⚠️ ${loaded.error}`);
+      const snapshot = await readConfigFileSnapshot();
+      if (!snapshot.valid) {
+        return commandReply("⚠️ Config file is invalid; fix it before using /plugins.");
       }
-
-      if (pluginsCommand.action === "list") {
-        return commandReply(formatPluginsList(loaded.report));
-      }
+      const config = structuredClone(snapshot.resolved);
+      const reportParams = { config, workspaceDir: params.workspaceDir };
 
       if (pluginsCommand.action === "inspect") {
-        const installRecords = await loadInstalledPluginIndexInstallRecords();
+        const metadataSnapshot = loadPluginMetadataSnapshot(reportParams);
+        const report = buildPluginDiagnosticsReport({ ...reportParams, metadataSnapshot });
         if (!pluginsCommand.name) {
-          return commandReply(formatPluginsList(loaded.report));
+          return commandReply(formatPluginsList(report));
         }
         if (normalizeOptionalLowercaseString(pluginsCommand.name) === "all") {
-          const reports = buildAllPluginInspectReports(loaded).map((inspect) =>
-            buildPluginInspectJson(inspect, installRecords),
+          const reports = buildAllPluginInspectReports({ config, report }).map((inspect) =>
+            buildPluginInspectJson(inspect, metadataSnapshot.index),
           );
           return commandReply(renderJsonBlock("🔌 Plugins", reports));
         }
         const inspect = buildPluginInspectReport({
           id: pluginsCommand.name,
-          config: loaded.config,
-          report: loaded.report,
+          config,
+          report,
         });
         if (!inspect) {
           return commandReply(`🔌 No plugin named "${pluginsCommand.name}" found.`);
         }
-        const payload = buildPluginInspectJson(inspect, installRecords);
+        const payload = buildPluginInspectJson(inspect, metadataSnapshot.index);
         return commandReply(
           renderJsonBlock(`🔌 Plugin "${inspect.plugin.id}"`, {
             ...inspect,
@@ -287,7 +254,11 @@ export const handlePluginsCommand: CommandHandler = defineAuthorizedTextCommand(
         );
       }
 
-      const plugin = findPlugin(loaded.report, pluginsCommand.name);
+      const report = buildPluginRegistrySnapshotReport(reportParams);
+      if (pluginsCommand.action === "list") {
+        return commandReply(formatPluginsList(report));
+      }
+      const plugin = findPlugin(report, pluginsCommand.name);
       if (!plugin) {
         return commandReply(`🔌 No plugin named "${pluginsCommand.name}" found.`);
       }
@@ -329,7 +300,7 @@ export const handlePluginsCommand: CommandHandler = defineAuthorizedTextCommand(
       }
 
       return commandReply(
-        `🔌 Plugin "${plugin.id}" ${pluginsCommand.action}d in ${loaded.path}. Gateway reload will apply it to new agent turns.` +
+        `🔌 Plugin "${plugin.id}" ${pluginsCommand.action}d in ${snapshot.path}. Gateway reload will apply it to new agent turns.` +
           (registryWarning ? `\n${registryWarning}` : ""),
       );
     };

--- a/src/cli/plugins-cli-test-helpers.ts
+++ b/src/cli/plugins-cli-test-helpers.ts
@@ -142,7 +142,7 @@ export const loadPluginManifestRegistryMock: UnknownMock = vi.fn();
 export const buildPluginSnapshotReportMock: UnknownMock = vi.fn();
 export const buildPluginRegistrySnapshotReportMock: UnknownMock = vi.fn();
 export const buildPluginInspectReportMock: UnknownMock = vi.fn();
-const buildAllPluginInspectReports: UnknownMock = vi.fn();
+export const buildAllPluginInspectReportsMock: UnknownMock = vi.fn();
 export const buildPluginDiagnosticsReportMock: UnknownMock = vi.fn();
 export const buildPluginCompatibilityNoticesMock: UnknownMock = vi.fn();
 export const inspectPluginRegistryMock: AsyncUnknownMock = vi.fn();
@@ -495,7 +495,7 @@ vi.mock("../plugins/status.js", () => ({
       Parameters<(typeof import("../plugins/status.js"))["buildAllPluginInspectReports"]>,
       ReturnType<(typeof import("../plugins/status.js"))["buildAllPluginInspectReports"]>
     >(
-      buildAllPluginInspectReports,
+      buildAllPluginInspectReportsMock,
       ...args,
     )) as (typeof import("../plugins/status.js"))["buildAllPluginInspectReports"],
   buildPluginDiagnosticsReport: ((
@@ -894,6 +894,7 @@ export function resetPluginsCliTestState() {
   buildPluginSnapshotReportMock.mockReset();
   buildPluginRegistrySnapshotReportMock.mockReset();
   buildPluginInspectReportMock.mockReset();
+  buildAllPluginInspectReportsMock.mockReset();
   buildPluginDiagnosticsReportMock.mockReset();
   buildPluginCompatibilityNoticesMock.mockReset();
   inspectPluginRegistryMock.mockReset();

--- a/src/cli/plugins-cli.inspect.test.ts
+++ b/src/cli/plugins-cli.inspect.test.ts
@@ -1,7 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { createPluginRecord } from "../plugins/status.test-fixtures.js";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { recordInstalledPluginIndexInstallOwner } from "../plugins/installed-plugin-index-install-owner.js";
 import {
+  createInstalledPluginIndexSnapshot,
+  createPluginRecord,
+} from "../plugins/status.test-fixtures.js";
+import {
+  buildAllPluginInspectReportsMock,
   buildPluginDiagnosticsReportMock,
   buildPluginInspectReportMock,
   buildPluginSnapshotReportMock,
@@ -15,138 +21,252 @@ import {
 
 const workshopMocks = vi.hoisted(() => ({
   detectToolPolicyDiagnostic: vi.fn(),
+  loadMetadata: vi.fn(),
+}));
+
+vi.mock("../plugins/plugin-metadata-snapshot.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../plugins/plugin-metadata-snapshot.js")>()),
+  loadPluginMetadataSnapshot: workshopMocks.loadMetadata,
 }));
 
 vi.mock("../skills/workshop/tool-policy-diagnostic.js", () => ({
   detectSkillWorkshopToolPolicyDiagnostic: workshopMocks.detectToolPolicyDiagnostic,
 }));
 
+function setInspectInstallRecords(
+  records: Record<string, PluginInstallRecord>,
+  plugins = Object.entries(records).map(([pluginId, install]) =>
+    recordInstalledPluginIndexInstallOwner({ pluginId, rootDir: install.installPath }, pluginId),
+  ),
+) {
+  setInstalledPluginIndexInstallRecords(records);
+  const metadata = {
+    index: { ...createInstalledPluginIndexSnapshot(plugins), installRecords: records },
+  };
+  workshopMocks.loadMetadata.mockReturnValue(metadata);
+  return metadata;
+}
+
 describe("plugins cli inspect", () => {
   beforeEach(() => {
     resetPluginsCliTestState();
     workshopMocks.detectToolPolicyDiagnostic.mockReset();
+    workshopMocks.loadMetadata.mockReset();
+    workshopMocks.loadMetadata.mockReturnValue({ index: createInstalledPluginIndexSnapshot([]) });
   });
 
-  it("keeps inspect on the static snapshot and distinguishes disabled reasons from errors", async () => {
-    setInstalledPluginIndexInstallRecords({
-      "openclaw-mem0": {
-        source: "clawhub",
-        spec: "clawhub:openclaw-mem0",
-        installPath: "/plugins/openclaw-mem0",
-        version: "2026.5.1",
-        clawhubPackage: "openclaw-mem0",
-        clawhubChannel: "official",
-        artifactKind: "npm-pack",
-        artifactFormat: "tgz",
-        npmIntegrity: "sha512-clawpack",
-        npmShasum: "1".repeat(40),
-        npmTarballName: "openclaw-mem0-2026.5.1.tgz",
-        clawpackSha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        clawpackSpecVersion: 1,
-        clawpackManifestSha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        clawpackSize: 4096,
-      },
-    });
-    buildPluginSnapshotReportMock.mockReturnValue({
-      plugins: [createPluginRecord({ id: "openclaw-mem0", name: "Mem0" })],
-      diagnostics: [],
-    });
-    const inspectReport = {
-      workspaceDir: "/workspace",
-      plugin: createPluginRecord({ id: "openclaw-mem0", name: "Mem0" }),
-      shape: "hook-only",
-      capabilityMode: "plain",
-      capabilityCount: 1,
-      capabilities: [],
-      typedHooks: [{ name: "agent_end" }],
-      customHooks: [],
-      tools: [],
-      commands: [],
-      cliCommands: [],
-      services: ["mem0-background"],
-      gatewayDiscoveryServices: ["mem0-discovery", "mem0-discovery-secondary"],
-      mcpServers: [
-        { name: "local", hasStdioTransport: true },
-        { name: "remote", hasStdioTransport: false },
-        { name: "broken", hasStdioTransport: false, unsupported: true },
-      ],
-      lspServers: [],
-      httpRouteCount: 0,
-      bundleCapabilities: [],
-      diagnostics: [],
-      policy: {
-        allowConversationAccess: true,
-        allowedModels: [],
-        hasAllowedModelsConfig: false,
-      },
-      usesLegacyBeforeAgentStart: false,
-      compatibility: [],
-    };
-    buildPluginInspectReportMock.mockReturnValue(inspectReport);
+  it.each([false, true])(
+    "reports package-owned install provenance with runtime=%s",
+    async (runtime) => {
+      const install: PluginInstallRecord = {
+        source: "npm",
+        spec: "@example/pack@1.2.3",
+        installPath: "/plugins/pack",
+        version: "1.2.3",
+        integrity: "sha512-pack",
+        installedAt: "2026-08-01T00:00:00.000Z",
+      };
+      const plugins = ["pack/one", "pack/two"].map((id) =>
+        createPluginRecord({ id, rootDir: "/plugins/pack", origin: "global" }),
+      );
+      setInspectInstallRecords(
+        { pack: install },
+        plugins.map((plugin) =>
+          recordInstalledPluginIndexInstallOwner(
+            {
+              pluginId: plugin.id,
+              rootDir: plugin.rootDir,
+            },
+            "pack",
+          ),
+        ),
+      );
+      buildPluginSnapshotReportMock.mockReturnValue({ plugins, diagnostics: [] });
+      const reports = plugins.map((plugin) => ({ plugin }));
+      buildAllPluginInspectReportsMock.mockReturnValue(reports);
+      const runtimeArgs = runtime ? ["--runtime"] : [];
 
-    await runPluginsCommand(["plugins", "inspect", "openclaw-mem0"]);
-
-    expect(buildPluginDiagnosticsReportMock).not.toHaveBeenCalled();
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain("Policy");
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain("allowConversationAccess: true");
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain("Services:\nmem0-background");
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain(
-      "Gateway discovery:\nmem0-discovery\nmem0-discovery-secondary",
-    );
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain("ClawHub package: openclaw-mem0");
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain("Artifact kind: npm-pack");
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain("Npm integrity: sha512-clawpack");
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain(
-      "ClawPack sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    );
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain("ClawPack spec: 1");
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain("ClawPack size: 4096 bytes");
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain("remote");
-    expect(pluginsCliRuntimeLogs.join("\n")).not.toContain("remote (unsupported transport)");
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain("broken (unsupported transport)");
-
-    await runPluginsCommand(["plugins", "inspect", "openclaw-mem0", "--json"]);
-    expect(JSON.parse(pluginsCliRuntimeLogs.at(-1) ?? "null")).toMatchObject({
-      services: ["mem0-background"],
-      gatewayDiscoveryServices: ["mem0-discovery", "mem0-discovery-secondary"],
-    });
-
-    for (const { id, status, detail, label } of [
-      {
-        id: "workspace-disabled",
-        status: "disabled" as const,
-        detail: "workspace plugin (disabled by default)",
-        label: "Reason",
-      },
-      { id: "broken", status: "error" as const, detail: "missing plugin module", label: "Error" },
-    ]) {
-      const plugin = createPluginRecord({
-        id,
-        enabled: status !== "disabled",
-        status,
-        error: detail,
-        ...(status === "disabled" ? { activationReason: detail } : {}),
-      });
-      buildPluginSnapshotReportMock.mockReturnValue({ plugins: [plugin], diagnostics: [] });
-      buildPluginInspectReportMock.mockReturnValue({ ...inspectReport, plugin });
-
-      await runPluginsCommand(["plugins", "inspect", id]);
-
-      const inspectOutput = pluginsCliRuntimeLogs.at(-1) ?? "";
-      expect(inspectOutput).toContain(`Status: ${status}`);
-      expect(inspectOutput).toContain(`${label}: ${detail}`);
-      expect(inspectOutput).not.toContain(`${label === "Reason" ? "Error" : "Reason"}: ${detail}`);
-
-      if (status === "disabled") {
-        await runPluginsCommand(["plugins", "inspect", id, "--json"]);
-        expect(JSON.parse(pluginsCliRuntimeLogs.at(-1) ?? "null").plugin).toMatchObject({
-          status: "disabled",
-          error: detail,
-          activationReason: detail,
+      for (const report of reports) {
+        const { plugin } = report;
+        buildPluginInspectReportMock.mockReturnValue(report);
+        await runPluginsCommand(["plugins", "inspect", plugin.id, "--json", ...runtimeArgs]);
+        expect(JSON.parse(pluginsCliRuntimeLogs.at(-1) ?? "null")).toMatchObject({
+          plugin: { id: plugin.id },
+          install,
         });
       }
-    }
-  });
+      await runPluginsCommand(["plugins", "inspect", "--all", "--json", ...runtimeArgs]);
+      expect(JSON.parse(pluginsCliRuntimeLogs.at(-1) ?? "null")).toEqual(
+        reports.map(({ plugin }) => ({ plugin, install })),
+      );
+    },
+  );
+
+  it.each(["missing", "ambiguous", "conflicting"])(
+    "does not attribute a same-id install when package ownership is %s",
+    async (ownership) => {
+      const plugin = createPluginRecord({ id: "pack/one", rootDir: "/plugins/pack" });
+      setInspectInstallRecords(
+        {
+          pack: { source: "npm", installPath: "/plugins/pack" },
+          [plugin.id]: { source: "npm", installPath: "/plugins/unrelated" },
+        },
+        [
+          recordInstalledPluginIndexInstallOwner(
+            { pluginId: plugin.id, rootDir: plugin.rootDir },
+            ownership === "conflicting" ? "pack" : undefined,
+            ownership === "ambiguous",
+          ),
+        ],
+      );
+      buildPluginSnapshotReportMock.mockReturnValue({ plugins: [plugin], diagnostics: [] });
+      buildPluginInspectReportMock.mockReturnValue({ plugin });
+      buildAllPluginInspectReportsMock.mockReturnValue([{ plugin }]);
+
+      await runPluginsCommand(["plugins", "inspect", plugin.id, "--json"]);
+      expect(JSON.parse(pluginsCliRuntimeLogs.at(-1) ?? "null")).not.toHaveProperty("install");
+      await runPluginsCommand(["plugins", "inspect", "--all", "--json"]);
+      expect(JSON.parse(pluginsCliRuntimeLogs.at(-1) ?? "null")[0]).not.toHaveProperty("install");
+    },
+  );
+
+  it.each(["openclaw-mem0", "openclaw-mem0/core"])(
+    "keeps %s inspection static and distinguishes disabled reasons from errors",
+    async (pluginId) => {
+      setInspectInstallRecords(
+        {
+          "openclaw-mem0": {
+            source: "clawhub",
+            spec: "clawhub:openclaw-mem0",
+            installPath: "/plugins/openclaw-mem0",
+            version: "2026.5.1",
+            clawhubPackage: "openclaw-mem0",
+            clawhubChannel: "official",
+            artifactKind: "npm-pack",
+            artifactFormat: "tgz",
+            npmIntegrity: "sha512-clawpack",
+            npmShasum: "1".repeat(40),
+            npmTarballName: "openclaw-mem0-2026.5.1.tgz",
+            clawpackSha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            clawpackSpecVersion: 1,
+            clawpackManifestSha256:
+              "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            clawpackSize: 4096,
+          },
+        },
+        [
+          recordInstalledPluginIndexInstallOwner(
+            {
+              pluginId,
+              rootDir: "/plugins/openclaw-mem0",
+            },
+            "openclaw-mem0",
+          ),
+        ],
+      );
+      buildPluginSnapshotReportMock.mockReturnValue({
+        plugins: [createPluginRecord({ id: pluginId, name: "Mem0" })],
+        diagnostics: [],
+      });
+      const inspectReport = {
+        workspaceDir: "/workspace",
+        plugin: createPluginRecord({ id: pluginId, name: "Mem0" }),
+        shape: "hook-only",
+        capabilityMode: "plain",
+        capabilityCount: 1,
+        capabilities: [],
+        typedHooks: [{ name: "agent_end" }],
+        customHooks: [],
+        tools: [],
+        commands: [],
+        cliCommands: [],
+        services: ["mem0-background"],
+        gatewayDiscoveryServices: ["mem0-discovery", "mem0-discovery-secondary"],
+        mcpServers: [
+          { name: "local", hasStdioTransport: true },
+          { name: "remote", hasStdioTransport: false },
+          { name: "broken", hasStdioTransport: false, unsupported: true },
+        ],
+        lspServers: [],
+        httpRouteCount: 0,
+        bundleCapabilities: [],
+        diagnostics: [],
+        policy: {
+          allowConversationAccess: true,
+          allowedModels: [],
+          hasAllowedModelsConfig: false,
+        },
+        usesLegacyBeforeAgentStart: false,
+        compatibility: [],
+      };
+      buildPluginInspectReportMock.mockReturnValue(inspectReport);
+
+      await runPluginsCommand(["plugins", "inspect", pluginId]);
+
+      expect(buildPluginDiagnosticsReportMock).not.toHaveBeenCalled();
+      expect(pluginsCliRuntimeLogs.join("\n")).toContain("Policy");
+      expect(pluginsCliRuntimeLogs.join("\n")).toContain("allowConversationAccess: true");
+      expect(pluginsCliRuntimeLogs.join("\n")).toContain("Services:\nmem0-background");
+      expect(pluginsCliRuntimeLogs.join("\n")).toContain(
+        "Gateway discovery:\nmem0-discovery\nmem0-discovery-secondary",
+      );
+      expect(pluginsCliRuntimeLogs.join("\n")).toContain("ClawHub package: openclaw-mem0");
+      expect(pluginsCliRuntimeLogs.join("\n")).toContain("Artifact kind: npm-pack");
+      expect(pluginsCliRuntimeLogs.join("\n")).toContain("Npm integrity: sha512-clawpack");
+      expect(pluginsCliRuntimeLogs.join("\n")).toContain(
+        "ClawPack sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      );
+      expect(pluginsCliRuntimeLogs.join("\n")).toContain("ClawPack spec: 1");
+      expect(pluginsCliRuntimeLogs.join("\n")).toContain("ClawPack size: 4096 bytes");
+      expect(pluginsCliRuntimeLogs.join("\n")).toContain("remote");
+      expect(pluginsCliRuntimeLogs.join("\n")).not.toContain("remote (unsupported transport)");
+      expect(pluginsCliRuntimeLogs.join("\n")).toContain("broken (unsupported transport)");
+
+      await runPluginsCommand(["plugins", "inspect", pluginId, "--json"]);
+      expect(JSON.parse(pluginsCliRuntimeLogs.at(-1) ?? "null")).toMatchObject({
+        services: ["mem0-background"],
+        gatewayDiscoveryServices: ["mem0-discovery", "mem0-discovery-secondary"],
+      });
+
+      for (const { id, status, detail, label } of [
+        {
+          id: "workspace-disabled",
+          status: "disabled" as const,
+          detail: "workspace plugin (disabled by default)",
+          label: "Reason",
+        },
+        { id: "broken", status: "error" as const, detail: "missing plugin module", label: "Error" },
+      ]) {
+        const plugin = createPluginRecord({
+          id,
+          enabled: status !== "disabled",
+          status,
+          error: detail,
+          ...(status === "disabled" ? { activationReason: detail } : {}),
+        });
+        buildPluginSnapshotReportMock.mockReturnValue({ plugins: [plugin], diagnostics: [] });
+        buildPluginInspectReportMock.mockReturnValue({ ...inspectReport, plugin });
+
+        await runPluginsCommand(["plugins", "inspect", id]);
+
+        const inspectOutput = pluginsCliRuntimeLogs.at(-1) ?? "";
+        expect(inspectOutput).toContain(`Status: ${status}`);
+        expect(inspectOutput).toContain(`${label}: ${detail}`);
+        expect(inspectOutput).not.toContain(
+          `${label === "Reason" ? "Error" : "Reason"}: ${detail}`,
+        );
+
+        if (status === "disabled") {
+          await runPluginsCommand(["plugins", "inspect", id, "--json"]);
+          expect(JSON.parse(pluginsCliRuntimeLogs.at(-1) ?? "null").plugin).toMatchObject({
+            status: "disabled",
+            error: detail,
+            activationReason: detail,
+          });
+        }
+      }
+    },
+  );
 
   it("runtime-inspects exact plugin ids and display names without repairing deps", async () => {
     buildPluginSnapshotReportMock.mockReturnValue({
@@ -185,11 +305,13 @@ describe("plugins cli inspect", () => {
 
     for (const selector of ["openclaw-mem0", "Mem0"]) {
       await runPluginsCommand(["plugins", "inspect", selector, "--runtime"]);
-      expect(buildPluginDiagnosticsReportMock).toHaveBeenLastCalledWith({
-        config: {},
-        onlyPluginIds: ["openclaw-mem0"],
-        runtimeInspection: true,
-      });
+      expect(buildPluginDiagnosticsReportMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          config: {},
+          onlyPluginIds: ["openclaw-mem0"],
+          runtimeInspection: true,
+        }),
+      );
       expect(pluginsCliRuntimeLogs.at(-1)).toContain("Gateway discovery:\nmem0-runtime-discovery");
     }
   });
@@ -204,7 +326,9 @@ describe("plugins cli inspect", () => {
       "__exit__:1",
     );
 
-    expect(buildPluginSnapshotReportMock).toHaveBeenCalledWith({ config: {} });
+    expect(buildPluginSnapshotReportMock).toHaveBeenCalledWith(
+      expect.objectContaining({ config: {} }),
+    );
     expect(buildPluginDiagnosticsReportMock).not.toHaveBeenCalled();
     expect(runtimeErrors.at(-1)).toContain("Plugin not found: missing-plugin");
   });
@@ -238,6 +362,9 @@ describe("plugins cli inspect", () => {
     );
 
     const output = runtimeErrors.at(-1);
+    if (entries) {
+      expect(workshopMocks.loadMetadata).toHaveBeenCalledWith({ config, workspaceDir: undefined });
+    }
     expect(output).toContain("Skill Workshop is built into OpenClaw, not a plugin");
     expect(output).toContain('tools.profile: "messaging" does not include "skill_workshop".');
     expect(output).toContain('Add tools.alsoAllow: ["skill_workshop"].');

--- a/src/cli/plugins-inspect-command.ts
+++ b/src/cli/plugins-inspect-command.ts
@@ -4,10 +4,9 @@ import { theme } from "../../packages/terminal-core/src/theme.js";
 import { listAgentIds } from "../agents/agent-scope-config.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
-import {
-  tracePluginLifecyclePhase,
-  tracePluginLifecyclePhaseAsync,
-} from "../plugins/plugin-lifecycle-trace.js";
+import { resolvePluginControlPlaneWorkspace } from "../plugins/control-plane-workspace.js";
+import { resolveInstalledPluginPackageOwnership } from "../plugins/installed-plugin-package-ownership.js";
+import { tracePluginLifecyclePhase } from "../plugins/plugin-lifecycle-trace.js";
 import { defaultRuntime } from "../runtime.js";
 import { shortenHomeInString, shortenHomePath } from "../utils.js";
 import { formatMissingPluginMessage } from "./error-format.js";
@@ -128,21 +127,27 @@ export async function runPluginsInspectCommand(
     buildPluginSnapshotReport,
     formatPluginCompatibilityNotice,
   } = await import("../plugins/status.js");
-  const { loadInstalledPluginIndexInstallRecords } =
-    await import("../plugins/installed-plugin-index-records.js");
+  const { loadPluginMetadataSnapshot } = await import("../plugins/plugin-metadata-snapshot.js");
   const cfg = tracePluginLifecyclePhase("config read", () => getRuntimeConfig(), {
     command: "inspect",
   });
-  const installRecords = await tracePluginLifecyclePhaseAsync(
-    "install records load",
-    () => loadInstalledPluginIndexInstallRecords(),
+  const { workspaceDir } = resolvePluginControlPlaneWorkspace({ config: cfg });
+  const metadataSnapshot = tracePluginLifecyclePhase(
+    "plugin metadata load",
+    () => loadPluginMetadataSnapshot({ config: cfg, workspaceDir }),
     { command: "inspect" },
   );
+  const resolveInstallRecord = (pluginId: string) => {
+    // Runtime child ids need the package owner's record; ambiguous ownership
+    // must not borrow provenance from an unrelated same-id install.
+    const ownership = resolveInstalledPluginPackageOwnership(metadataSnapshot.index, pluginId);
+    return ownership.ok ? ownership.value.installRecord : undefined;
+  };
   const loggerParams = opts.json ? { logger: quietPluginJsonLogger } : {};
   const runtimeInspect = opts.runtime === true;
+  const reportParams = { config: cfg, metadataSnapshot, ...loggerParams };
   const runtimeReportParams = {
-    config: cfg,
-    ...loggerParams,
+    ...reportParams,
     runtimeInspection: true,
   };
   if (opts.all) {
@@ -158,11 +163,7 @@ export async function runPluginsInspectCommand(
         )
       : tracePluginLifecyclePhase(
           "plugin registry snapshot",
-          () =>
-            buildPluginSnapshotReport({
-              config: cfg,
-              ...loggerParams,
-            }),
+          () => buildPluginSnapshotReport(reportParams),
           { command: "inspect", all: true },
         );
     const inspectAll = buildAllPluginInspectReports({
@@ -172,7 +173,7 @@ export async function runPluginsInspectCommand(
     });
     const inspectAllWithInstall = inspectAll.map((inspect) => ({
       ...inspect,
-      install: installRecords[inspect.plugin.id],
+      install: resolveInstallRecord(inspect.plugin.id),
     }));
 
     if (opts.json) {
@@ -230,11 +231,7 @@ export async function runPluginsInspectCommand(
 
   const snapshotReport = tracePluginLifecyclePhase(
     "plugin registry snapshot",
-    () =>
-      buildPluginSnapshotReport({
-        config: cfg,
-        ...loggerParams,
-      }),
+    () => buildPluginSnapshotReport(reportParams),
     { command: "inspect" },
   );
   const targetPlugin =
@@ -291,7 +288,7 @@ export async function runPluginsInspectCommand(
     );
     return;
   }
-  const install = installRecords[inspect.plugin.id];
+  const install = resolveInstallRecord(inspect.plugin.id);
 
   if (opts.json) {
     defaultRuntime.writeJson({


### PR DESCRIPTION
## What Problem This Solves

Both the CLI and chat plugin inspectors looked up installation records by runtime child ID, although multi-entry packages persist one record under their package owner. Inspecting a child therefore lost its package provenance and could attribute an unrelated same-ID record when ownership was missing or conflicting.

## Why This Change Was Made

Both entry points now use the existing authoritative package-ownership resolver against the same metadata snapshot that builds the inspection report. The CLI removes its separate ledger read. The chat handler removes a single-caller state wrapper so runtime inspection owns its prepared snapshot while listing and toggles retain the existing cold report path.

Production LOC: **+45/-78, net −33**. Tests and test support: +370/-123, net +247; docs: +4. No configuration, persistence, schema, protocol, dependency, SDK, authorization, or plugin-write policy changes.

## User Impact

`plugins inspect <child>` and all-plugin JSON show the shared package source, version, path, and artifact metadata. Chat `/plugins inspect`, `show`, and `get` do the same for individual children and `all`.

Existing behavior stays intact: CLI inspection is static unless `--runtime` is requested; chat inspection still loads runtime diagnostics; chat single replies remain flat and all replies remain wrapped. Missing or ambiguous ownership produces no attributed provenance (`install: null` in chat). Both command references are updated.

## Evidence

- Regression-before: both CLI default/runtime cases failed on frozen main. Four chat cases then failed before the sibling repair: missing child provenance and unrelated same-ID attribution for missing, ambiguous, and conflicting ownership.
- Final focused proof: **69 tests pass** across CLI inspection, chat inspection/toggles, chat install, and ClawHub selectors. This covers both children, aliases, single/all/text/JSON output, runtime behavior, ownership failures, invalid config, bare inspection, and existing authorization/write controls. Another **28 ownership/persistence sibling tests** passed for the unchanged canonical resolver.
- **Whole Gateway before/after:** a real temporary Gateway and authenticated WebSocket client execute `chat.send` through command dispatch to final chat events. Enabled-child `inspect`, disabled-child `show`, singular `/plugin get`, and `inspect all` all return `install: null` before and the shared package record afterward. Single/all wire shapes and the runtime import/registration sequence match. Both Gateways and their process groups shut down cleanly.
- Independent no-mock CLI and chat probes use production metadata persistence. They reproduce and verify the repair, preserve disabled-child state and runtime boundaries, reject unauthorized readers and read-only plugin writes, and leave configuration unchanged. Independent source review found no actionable defect.
- [Packaged CLI proof](https://github.com/openclaw/openclaw/actions/runs/33297356730) built the canonical tarball, installed it in a fresh prefix, installed a two-child npm-pack plugin, and passed default/runtime/all JSON/text inspection. This proof applies to the unchanged CLI production source; the widened chat path is covered by the whole-Gateway proof above. The Testbox was stopped. Tarball SHA-256: `56c21b8f862e7d03603adfa2daee03b391cced6d0817bdb03c4066668c484a13`.

Closes #133138.

Separate follow-up: provider recovery installation also needs package-owner provenance for its source, version, and integrity. That installer-facing repair has its own investigation and proof lane; this PR keeps the CLI/chat inspection boundary coherent.

Exact widened head: `820e7819760558c5eca1fdc42820ab689680703f`. Fresh complete-diff Codex autoreview is scoped-clean at its default P0 threshold, and independent source/behavior review found no actionable defect. The separate read-only review found no actionable issue at `ea16dde`; the only later change deletes an unused type import caught by the broad typecheck, with its own clean autoreview. The complete original changed-gate plan now passes: the initial passing checks were retained, then both typechecks, lint, and all remaining guards completed successfully. The independent verifier has also bound its clean verdict to the final commit. Hosted CI and native landing must cover the final head; earlier green CI at `4d2c17f` is not the widened head's gate.
