### PR TITLE
fix(qa): cancellation is ignored during command cleanup

### DIFF
--- a/extensions/qa-lab/src/posix-command-settlement.ts
+++ b/extensions/qa-lab/src/posix-command-settlement.ts
@@ -43,16 +43,9 @@ export function createQaPosixCommandSettlement(params: QaPosixCommandSettlementP
   const windows = params.windowsCleanup;
 
   const schedule = (fn: () => void, delay: number) => {
-    const timer = setTimeout(() => {
-      fn();
-    }, delay);
+    const timer = setTimeout(fn, delay);
     timers.push(timer);
     return timer;
-  };
-  const cancel = (timer: NodeJS.Timeout | undefined) => {
-    if (timer) {
-      clearTimeout(timer);
-    }
   };
   // Cleanup owns only the original PGID; a descendant that calls setsid can escape it.
   const alive = () =>
@@ -162,7 +155,7 @@ export function createQaPosixCommandSettlement(params: QaPosixCommandSettlementP
   };
   const freeze = (nextPrimary: QaPosixCommandPrimary, initialSignal = params.initialSignal) => {
     primary ??= nextPrimary;
-    cancel(executionTimer);
+    clearTimeout(executionTimer);
     // Every terminal path needs a drain bound: an escaped descendant can retain
     // inherited stdio even after the original process group is gone.
     armDrainDeadline();
@@ -170,7 +163,7 @@ export function createQaPosixCommandSettlement(params: QaPosixCommandSettlementP
     settle();
   };
   const armIdle = () => {
-    cancel(drainIdle);
+    clearTimeout(drainIdle);
     drainIdle = schedule(startCleanup, 100);
   };
   const onOutput = () => {
@@ -204,7 +197,7 @@ export function createQaPosixCommandSettlement(params: QaPosixCommandSettlementP
   // `exit` freezes the leader tuple; only `close` can prove stdio drained.
   function onExit(exitCode: number | null, nextSignal: NodeJS.Signals | null) {
     primary ??= { type: "exit", exitCode, signal: nextSignal };
-    cancel(executionTimer);
+    clearTimeout(executionTimer);
     armDrainDeadline();
     armIdle();
     if (cleanupStarted && !cleanupDone && !alive()) {
@@ -213,8 +206,8 @@ export function createQaPosixCommandSettlement(params: QaPosixCommandSettlementP
   }
   function onClose() {
     stdioDrained = true;
-    cancel(drainIdle);
-    cancel(drainDeadline);
+    clearTimeout(drainIdle);
+    clearTimeout(drainDeadline);
     if (!cleanupStarted && windows) {
       cleanupDone = true;
     } else if (cleanupStarted && windows?.closeCompletesCleanup) {

--- a/extensions/qa-lab/src/posix-command-settlement.ts
+++ b/extensions/qa-lab/src/posix-command-settlement.ts
@@ -37,6 +37,7 @@ export function createQaPosixCommandSettlement(params: QaPosixCommandSettlementP
   let drainIdle: NodeJS.Timeout | undefined;
   let drainTimedOut = false;
   let executionTimer: NodeJS.Timeout | undefined;
+  let parentSignal: "SIGINT" | "SIGTERM" | undefined;
   let primary: QaPosixCommandPrimary | undefined;
   let stdioDrained = false;
   const windows = params.windowsCleanup;
@@ -92,7 +93,6 @@ export function createQaPosixCommandSettlement(params: QaPosixCommandSettlementP
     if (disposed || !primary || !cleanupDone || !stdioDrained) {
       return;
     }
-    const parentSignal = primary.type === "parent-signal" ? primary.signal : undefined;
     const settlementFailure =
       errors.length > 1 ? new AggregateError(errors, params.settlementFailureMessage) : errors[0];
     dispose();
@@ -238,6 +238,9 @@ export function createQaPosixCommandSettlement(params: QaPosixCommandSettlementP
       process.kill(process.pid, nextSignal);
       return;
     }
+    // The command outcome may already be frozen while descendants drain.
+    // Parent cancellation still has to be re-raised after cleanup.
+    parentSignal ??= nextSignal;
     freeze({ type: "parent-signal", signal: nextSignal }, nextSignal);
   };
   function onParentSigint() {

--- a/extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts
@@ -395,41 +395,64 @@ describe.skipIf(process.platform === "win32")("qa scenario command lifecycle", (
     expect(parentHandlers.size).toBe(0);
   });
 
-  it("forwards parent signals, cleans handlers, and preserves interruption details", async () => {
-    createChild();
-    setQaScenarioCommandCleanupTimings({ killGraceMs: 20, forceSettleMs: 10 });
-    let processGroupAlive = true;
-    processKill.mockImplementation((pid, signal) => {
-      if (pid === -42 && signal === "SIGKILL") {
-        processGroupAlive = false;
-      }
-      if (pid === -42 && signal === 0 && !processGroupAlive) {
-        throw Object.assign(new Error("gone"), { code: "ESRCH" });
-      }
-      return true;
-    });
+  it.each([
+    {
+      phase: "running",
+      result: {
+        exitCode: 1,
+        failureMessage: "scenario-command interrupted by SIGTERM",
+        signal: "SIGTERM",
+      },
+    },
+    { phase: "exited", result: { exitCode: 7, signal: null } },
+    {
+      phase: "timed out",
+      result: {
+        exitCode: 1,
+        failureMessage: "scenario-command timed out after 100ms",
+        signal: null,
+      },
+    },
+  ])(
+    "re-raises a parent signal when the command is $phase without changing its outcome",
+    async ({ phase, result }) => {
+      const child = createChild();
+      setQaScenarioCommandCleanupTimings({ killGraceMs: 20, forceSettleMs: 10 });
+      let processGroupAlive = true;
+      processKill.mockImplementation((pid, signal) => {
+        if (pid === -42 && signal === "SIGKILL") {
+          processGroupAlive = false;
+        }
+        if (pid === -42 && signal === 0 && !processGroupAlive) {
+          throw Object.assign(new Error("gone"), { code: "ESRCH" });
+        }
+        return true;
+      });
 
-    const resultPromise = runCommand();
-    const signalHandler = parentHandlers.get("SIGTERM") as
-      | ((signal: ParentSignal) => void)
-      | undefined;
-    expect(signalHandler).toBeDefined();
-    signalHandler?.("SIGTERM");
-    await vi.advanceTimersByTimeAsync(20);
-    const child = spawnMock.mock.results[0]?.value as ChildProcess;
-    child.emit("exit", null, "SIGKILL");
-    child.emit("close", null, "SIGKILL");
-    await vi.advanceTimersByTimeAsync(10);
+      const resultPromise = runCommand(100);
+      if (phase === "exited") {
+        child.emit("exit", 7, null);
+      } else if (phase === "timed out") {
+        await vi.advanceTimersByTimeAsync(100);
+      }
+      const signalHandler = parentHandlers.get("SIGTERM") as
+        | ((signal: ParentSignal) => void)
+        | undefined;
+      expect(signalHandler).toBeDefined();
+      signalHandler?.("SIGTERM");
+      await vi.advanceTimersByTimeAsync(20);
+      child.emit("exit", null, "SIGKILL");
+      child.emit("close", null, "SIGKILL");
+      await vi.advanceTimersByTimeAsync(10);
 
-    await expect(resultPromise).resolves.toEqual({
-      exitCode: 1,
-      failureMessage: "scenario-command interrupted by SIGTERM",
-      signal: "SIGTERM",
-      stdout: "",
-      stderr: "",
-    });
-    expect(processKill).toHaveBeenCalledWith(-42, "SIGTERM");
-    expect(processKill).toHaveBeenCalledWith(process.pid, "SIGTERM");
-    expect(parentHandlers.size).toBe(0);
-  });
+      await expect(resultPromise).resolves.toEqual({
+        ...result,
+        stdout: "",
+        stderr: "",
+      });
+      expect(processKill).toHaveBeenCalledWith(-42, "SIGTERM");
+      expect(processKill).toHaveBeenCalledWith(process.pid, "SIGTERM");
+      expect(parentHandlers.size).toBe(0);
+    },
+  );
 });


### PR DESCRIPTION
Closes #133142

## What Problem This Solves

Fixes an issue where QA operators canceling a native test command could see the command continue successfully when its leader had already exited but descendant cleanup was still pending. SIGINT and SIGTERM were also lost after a timeout entered cleanup.

## Why This Change Was Made

Record parent cancellation independently from the first command outcome in the shared POSIX settlement owner, then re-raise it after cleanup. Remove redundant timer forwarding and cancellation wrappers in that same owner. The leader exit code, timeout/error result, cleanup escalation, and Windows behavior remain unchanged. Replacing the frozen command outcome would lose the result consumed by the native, QA CLI, and Matrix CLI callers.

## User Impact

QA cancellation remains effective throughout command cleanup. This is internal QA tooling; no production gateway behavior, configuration, provider, plugin API, or persistent state changes.

## Evidence

- Before: the extended native lifecycle regression passed the running-command case but failed the exited and timed-out cases because the parent SIGTERM was never re-raised.
- After: 44 tests passed across the native command lifecycle, POSIX settlement/process-group owner, and Matrix CLI/stream-error sibling tests, including real child cleanup and Windows taskkill coverage.
- Real native wrapper process proof: after a leader exit, both SIGINT and SIGTERM previously produced controller exit 0 and executed the continuation. With the repair, both controllers terminate by the requested signal after owned process-group cleanup.
- Independent source and real-process verification covered active/finished commands, exit 0/7, spawn/pipe errors, timeout, and cancellation after timeout. Mandatory structured autoreview found no actionable findings.
- Full `check:changed` passed on the final source, including extension/test typechecks, lint, owner guards, and import-cycle checks. Formatting and `git diff --check` passed.
- Production LOC: +10/-14 (net -4; independently owned cancellation plus simpler timer lifecycle); tests: +59/-36 (existing case expanded into a table). No compatibility branch or new option.

Focused command:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts extensions/qa-lab/src/posix-command-settlement.test.ts extensions/qa-lab/src/posix-process-group.test.ts extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-cli.test.ts extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-cli-stream-error.test.ts
```

CI note: the first exact-head run ([33298447673](https://github.com/openclaw/openclaw/actions/runs/33298447673)) failed because the current main merge tree imported `getPluginToolSideEffectOwnerKey` from its former module. The canonical main repair [#133155](https://github.com/openclaw/openclaw/pull/133155) fixes that import. This branch is refreshed onto that repaired base at `fba60c7a091ee637f10e1ea62ceabe0075a787be`; the complete patch identity and source/test bytes are unchanged. All 44 focused tests and the real native SIGINT/SIGTERM before/after proof passed again, fresh structured autoreview is clean, and the independent verifier bound its verdict to this exact head. The final separate read-only review also found no actionable findings. Fresh exact-head CI [33299847607](https://github.com/openclaw/openclaw/actions/runs/33299847607) passed. Native preparation and merge gates passed without changing the reviewed head. Merged as [bed5daf176f6d7552b27b7c87d33e7d201dd82f6](https://github.com/openclaw/openclaw/commit/bed5daf176f6d7552b27b7c87d33e7d201dd82f6), verified on canonical main; the linked issue is closed.
