### PR TITLE
fix(media): decode file URLs at the native reply boundary

### DIFF
--- a/src/auto-reply/reply/reply-directives.ts
+++ b/src/auto-reply/reply/reply-directives.ts
@@ -1,4 +1,5 @@
 /** Parses inline reply directives such as media, reply targets, audio, and silence. */
+import { trySafeFileURLToPath } from "../../infra/local-file-access.js";
 import { splitMediaFromOutput } from "../../media/parse.js";
 import {
   parseInlineDirectives,
@@ -48,14 +49,12 @@ export function parseReplyDirectives(
 
   const silentToken = options.silentToken ?? SILENT_REPLY_TOKEN;
   const isSilent = isSilentReplyPayloadText(text, silentToken);
-  if (isSilent) {
-    // Silent payloads must not leak the control token into channel delivery.
-    text = "";
-  }
 
   return {
-    text,
-    mediaUrls: split.mediaUrls,
+    // Silent payloads must not leak the control token into channel delivery.
+    text: isSilent ? "" : text,
+    // Keep native path conversion outside the browser-shared parser and before reply policy.
+    mediaUrls: split.mediaUrls?.map((source) => trySafeFileURLToPath(source) ?? source),
     replyToId: replyParsed.replyToId,
     replyToCurrent: replyParsed.replyToCurrent || undefined,
     replyToTag: replyParsed.hasReplyTag,

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HostReadMediaTypeError, LocalMediaAccessError } from "../../media/local-media-access.js";
 import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
@@ -24,6 +25,7 @@ vi.mock("../../media/read-capability.js", () => ({
   resolveAgentScopedOutboundMediaAccess,
 }));
 
+import { parseReplyDirectives } from "./reply-directives.js";
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
 
 type NormalizedReply = {
@@ -133,6 +135,28 @@ describe("createReplyMediaPathNormalizer", () => {
     ]);
   });
 
+  it.each([
+    { name: "plain", fileName: "photo.png", prefix: "file://" },
+    { name: "encoded", fileName: "café 100% image.png", prefix: "file://" },
+    { name: "localhost", fileName: "café 100% image.png", prefix: "file://localhost" },
+    { name: "uppercase single-slash", fileName: "café 100% image.png", prefix: "FILE:" },
+  ])("stages $name file URL directives without allowing raw host file URLs", async (testCase) => {
+    const workspaceDir = path.resolve("agent-workspace");
+    const filePath = path.join(workspaceDir, testCase.fileName);
+    const fileUrl = pathToFileURL(filePath).href.replace(/^file:\/\//u, testCase.prefix);
+    const normalize = createReplyMediaPathNormalizer({ cfg: {}, workspaceDir });
+
+    const result = await normalize(parseReplyDirectives(`Caption\nMEDIA:${fileUrl}`));
+
+    const stagedPath = path.join("/tmp/outbound-media", testCase.fileName);
+    expectMedia(result, stagedPath, [stagedPath]);
+    expect(result.text).toBe("Caption");
+    expectOutboundAttachmentCall(0, filePath, 5 * 1024 * 1024);
+
+    expectNoMedia(await normalize({ mediaUrls: [fileUrl] }));
+    expect(resolveOutboundAttachmentFromUrl).toHaveBeenCalledTimes(1);
+  });
+
   it("does not grant local-media trust to remote-only replies", async () => {
     const normalize = createTestReplyMediaNormalizer();
 
@@ -182,14 +206,19 @@ describe("createReplyMediaPathNormalizer", () => {
         containerWorkdir,
       });
       const normalize = createTestReplyMediaNormalizer();
+      const fileUrl = `file://${containerWorkdir}/screens/final%20image.png`;
 
       const result = await normalize({
-        mediaUrls: ["./out/photo.png", `file://${containerWorkdir}/screens/final.png`],
+        mediaUrls: [
+          "./out/photo.png",
+          fileUrl,
+          ...(parseReplyDirectives(`MEDIA:${fileUrl}`).mediaUrls ?? []),
+        ],
       });
 
       expectMedia(result, "/tmp/outbound-media/photo.png", [
         "/tmp/outbound-media/photo.png",
-        "/tmp/outbound-media/final.png",
+        "/tmp/outbound-media/final image.png",
       ]);
       expectOutboundAttachmentCall(
         0,
@@ -198,7 +227,7 @@ describe("createReplyMediaPathNormalizer", () => {
       );
       expectOutboundAttachmentCall(
         1,
-        path.join("/tmp/sandboxes/session-1", "screens", "final.png"),
+        path.join("/tmp/sandboxes/session-1", "screens", "final image.png"),
         5 * 1024 * 1024,
       );
     },

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -1,5 +1,7 @@
 // Covers outbound payload normalization across text, media, presentation,
 // interactive blocks, mirror text, and suppressed relay status payloads.
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { describe, expect, it } from "vitest";
 import { markInboundContextLabel } from "../../auto-reply/reply/inbound-context-marker.js";
@@ -31,6 +33,18 @@ function resolveMirrorProjection(payloads: readonly ReplyPayload[]) {
 }
 
 describe("normalizeReplyPayloadsForDelivery", () => {
+  it.each(["photo.png", "café 100% image.png"])(
+    "deduplicates a file URL directive with its explicit local path: %s",
+    (fileName) => {
+      const filePath = path.resolve("media", fileName);
+      const [payload] = normalizeReplyPayloadsForDelivery([
+        { text: `Caption\nMEDIA:${pathToFileURL(filePath).href}`, mediaUrl: filePath },
+      ]);
+
+      expect(payload).toMatchObject({ text: "Caption", mediaUrl: filePath, mediaUrls: [filePath] });
+    },
+  );
+
   it("parses directives, merges media, and preserves reply metadata", () => {
     expect(
       normalizeReplyPayloadsForDelivery([

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -1,4 +1,6 @@
 // Media parse tests cover media reference parsing from text and payloads.
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import { splitMediaFromOutput } from "./parse.js";
 
@@ -88,13 +90,27 @@ describe("splitMediaFromOutput", () => {
       String.raw`MEDIA:/path/to/image.png\"}],\"details\":{\"provider\":\"openai\"}`,
     ],
     ["/tmp/render,final.png", "MEDIA:/tmp/render,final.png"],
-    ["/tmp/generated.png", "MEDIA:FILE:///tmp/generated.png"],
-    ["/tmp/generated.png", "MEDIA:FILE:/tmp/generated.png"],
-    ["/tmp/generated.png", "MEDIA:file:///tmp/generated.png"],
-    ["/Users/pete/My File.png", "MEDIA:FILE:///Users/pete/My File.png"],
-    ["/Users/pete/My File.png", "MEDIA:file:///Users/pete/My File.png"],
   ] as const)("accepts supported media path variant: %s", (expectedPath, input) => {
     expectAcceptedMediaPathCase(expectedPath, input);
+  });
+
+  const nativeFilePath = path.resolve("media", "café 100% image.png");
+  const nativeFileUrl = pathToFileURL(nativeFilePath).href;
+  it.each([
+    nativeFileUrl,
+    nativeFileUrl.replace(/^file:\/\//u, "FILE:"),
+    nativeFileUrl.replace(/^file:/u, "FILE:"),
+    nativeFileUrl.replace(/^file:\/\//u, "file://localhost"),
+    nativeFileUrl.replace(/%20/gu, " "),
+  ])("preserves file URLs for native media loading: %s", (fileUrl) => {
+    expectAcceptedMediaPathCase(fileUrl, `MEDIA:${fileUrl}`);
+  });
+
+  it.each([nativeFileUrl, nativeFilePath])("keeps file URL siblings separate from %s", (first) => {
+    const secondPath = path.resolve("media", "second image.png");
+    expectParsedMediaOutputCase(`MEDIA:${first} ${pathToFileURL(secondPath).href}`, {
+      mediaUrls: [first, pathToFileURL(secondPath).href],
+    });
   });
 
   it.each([
@@ -156,10 +172,6 @@ describe("splitMediaFromOutput", () => {
       "MEDIA:/tmp/project screenshots/shot.png media\\second.png",
       ["/tmp/project screenshots/shot.png", "media\\second.png"],
     ],
-    [
-      "MEDIA:/tmp/project screenshots/shot.png file:///tmp/second.png",
-      ["/tmp/project screenshots/shot.png", "/tmp/second.png"],
-    ],
     ["MEDIA:C:\\Users\\First Last\\..\\secret.png D:\\safe\\second.png", ["D:\\safe\\second.png"]],
     ["MEDIA:/tmp/project screenshots/../../.env /tmp/safe/second.png", ["/tmp/safe/second.png"]],
   ] as const)("keeps separate media items on one directive line: %s", (input, mediaUrls) => {
@@ -174,6 +186,7 @@ describe("splitMediaFromOutput", () => {
     "MEDIA:./foo/../../../etc/shadow",
     "MEDIA:C:\\Users\\First Last\\..\\secret.png",
     "MEDIA:/tmp/project screenshots/../../.env",
+    "MEDIA:file:///tmp/../secret.png",
   ] as const)("rejects traversal and unsupported home-dir path: %s", (input) => {
     expectRejectedMediaPathCase(input);
   });

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -18,7 +18,7 @@ import { parseAudioTag } from "./audio-tags.js";
 const MEDIA_TOKEN_RE = /\bMEDIA:\s*`?([^\n]+)`?/gi;
 
 const RENDERABLE_ASSISTANT_MEDIA_PREFIX_RE =
-  /^(?:https?:\/\/|data:(?:image|audio|video)\/|file:\/\/|~|\/|[a-z]:[\\/])/iu;
+  /^(?:https?:\/\/|data:(?:image|audio|video)\/|file:|~|\/|[a-z]:[\\/])/iu;
 
 export function isRelativeAssistantMediaReference(url: string): boolean {
   const trimmed = url.trim();
@@ -46,7 +46,7 @@ type SplitMediaFromOutputOptions = {
 
 const FILE_URL_PREFIX_RE = /^file:(?:\/\/)?/i;
 
-/** Converts file URLs into plain local paths before downstream media validation. */
+// Classify spelling only; preserve file URLs in output so native loaders own decoding and access.
 function normalizeMediaSource(src: string): string {
   return src.replace(FILE_URL_PREFIX_RE, "");
 }
@@ -177,6 +177,7 @@ function isValidMedia(
   candidate: string,
   opts?: { allowSpaces?: boolean; allowBareFilename?: boolean },
 ) {
+  candidate = normalizeMediaSource(candidate);
   if (!candidate) {
     return false;
   }
@@ -645,10 +646,9 @@ export function splitMediaFromOutput(
       const invalidParts: string[] = [];
       let hasValidMedia = false;
       for (const part of parts) {
-        const candidate = normalizeMediaSource(cleanCandidate(part));
-        if (
-          isValidMedia(candidate, unwrapped || /\s/.test(part) ? { allowSpaces: true } : undefined)
-        ) {
+        const candidate = cleanCandidate(part);
+        const allowSpaces = Boolean(unwrapped) || /\s/.test(candidate);
+        if (isValidMedia(candidate, { allowSpaces })) {
           media.push(candidate);
           hasValidMedia = true;
           foundMediaToken = true;
@@ -670,7 +670,7 @@ export function splitMediaFromOutput(
         looksLikeLocalPath
       ) {
         // A single valid split plus invalid leftovers can be one local path containing spaces.
-        const fallback = normalizeMediaSource(cleanCandidate(payloadValue));
+        const fallback = cleanCandidate(payloadValue);
         if (isValidMedia(fallback, { allowSpaces: true })) {
           media.splice(mediaStartIndex, media.length - mediaStartIndex, fallback);
           hasValidMedia = true;
@@ -680,7 +680,7 @@ export function splitMediaFromOutput(
       }
 
       if (!hasValidMedia && !unwrapped && /\s/.test(payloadValue)) {
-        const spacedFallback = normalizeMediaSource(cleanCandidate(payloadValue));
+        const spacedFallback = cleanCandidate(payloadValue);
         if (isValidMedia(spacedFallback, { allowSpaces: true, allowBareFilename: true })) {
           media.splice(mediaStartIndex, media.length - mediaStartIndex, spacedFallback);
           hasValidMedia = true;
@@ -690,7 +690,7 @@ export function splitMediaFromOutput(
       }
 
       if (!hasValidMedia) {
-        const fallback = normalizeMediaSource(cleanCandidate(payloadValue));
+        const fallback = cleanCandidate(payloadValue);
         if (isValidMedia(fallback, { allowSpaces: true, allowBareFilename: true })) {
           media.push(fallback);
           hasValidMedia = true;

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -174,10 +174,10 @@ function isAllowedRemoteMediaUrl(candidate: string): boolean {
 }
 
 function isValidMedia(
-  candidate: string,
+  source: string,
   opts?: { allowSpaces?: boolean; allowBareFilename?: boolean },
 ) {
-  candidate = normalizeMediaSource(candidate);
+  const candidate = normalizeMediaSource(source);
   if (!candidate) {
     return false;
   }

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -8,6 +8,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import JSZip from "jszip";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { createSolidPngBuffer } from "../../test/helpers/image-fixtures.js";
+import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
 import { resolveStateDir } from "../config/paths.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
@@ -275,6 +276,41 @@ describe("loadWebMedia", () => {
     expect(result.kind).toBe("image");
     expect(result.buffer.length).toBeGreaterThan(0);
   }
+
+  it.each(["local", "localhost"])(
+    "loads encoded %s file URLs from reply directives",
+    async (host) => {
+      const fileName = "café 100% image.png";
+      const filePath = path.join(fixtureRoot, fileName);
+      await fs.writeFile(filePath, TINY_PNG_BUFFER);
+      const fileUrl = pathToFileURL(filePath).href.replace(
+        /^file:\/\//u,
+        host === "localhost" ? "file://localhost" : "FILE:",
+      );
+      const reply = parseReplyDirectives(`Here is your image.\nMEDIA:${fileUrl}`);
+
+      expect(reply.text).toBe("Here is your image.");
+      expect(reply.mediaUrls).toHaveLength(1);
+      const mediaUrl = expectDefined(reply.mediaUrls?.[0], "parsed file URL attachment");
+      const media = await loadWebMedia(mediaUrl, createLocalWebMediaOptions());
+      expect(media.buffer).toEqual(TINY_PNG_BUFFER);
+      expect(media.fileName).toBe(fileName);
+      expect(media.contentType).toBe("image/png");
+    },
+  );
+
+  it.each([
+    "file://remote.example/share/image.png",
+    "file:///tmp/image%2Fname.png",
+    "file:///tmp/image%5Cname.png",
+    "file:///tmp/image%GG.png",
+  ])("keeps native file URL validation after reply parsing: %s", async (fileUrl) => {
+    const reply = parseReplyDirectives(`MEDIA:${fileUrl}`);
+    const mediaUrl = expectDefined(reply.mediaUrls?.[0], "parsed file URL attachment");
+    await expect(loadWebMedia(mediaUrl, createLocalWebMediaOptions())).rejects.toMatchObject({
+      code: "invalid-file-url",
+    });
+  });
 
   async function loadDocumentWithHostRead(fileName: string, body: Buffer | string) {
     const textFile = path.join(fixtureRoot, fileName);

--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -637,10 +637,16 @@ describe("message-normalizer", () => {
       ]);
     });
 
-    it("keeps valid local MEDIA paths as assistant attachments", () => {
+    it.each([
+      ["/tmp/openclaw/test-image.png", "test-image.png"],
+      ["file:///tmp/caf%C3%A9%20image.png", "caf%C3%A9%20image.png"],
+      ["FILE:///tmp/caf%C3%A9%20image.png", "caf%C3%A9%20image.png"],
+      ["FILE:/tmp/caf%C3%A9%20image.png", "caf%C3%A9%20image.png"],
+      ["file://localhost/tmp/caf%C3%A9%20image.png", "caf%C3%A9%20image.png"],
+    ])("keeps local MEDIA references as assistant attachments: %s", (url, label) => {
       const result = normalizeMessage({
         role: "assistant",
-        content: "Hello\nMEDIA:/tmp/openclaw/test-image.png\nWorld",
+        content: `Hello\nMEDIA:${url}\nWorld`,
       });
 
       expect(result.content).toEqual([
@@ -648,9 +654,9 @@ describe("message-normalizer", () => {
         {
           type: "attachment",
           attachment: {
-            url: "/tmp/openclaw/test-image.png",
+            url,
             kind: "image",
-            label: "test-image.png",
+            label,
             mimeType: "image/png",
           },
         },
@@ -673,23 +679,6 @@ describe("message-normalizer", () => {
             label: "clip.webm",
             mimeType: "video/webm",
           },
-        },
-      ]);
-    });
-
-    it.each([
-      "file:///tmp/caf%C3%A9%20image.png",
-      "FILE:///tmp/caf%C3%A9%20image.png",
-      "FILE:/tmp/caf%C3%A9%20image.png",
-      "file://localhost/tmp/caf%C3%A9%20image.png",
-    ])("keeps the original file URL in displayed attachments: %s", (url) => {
-      expect(
-        normalizeMessage({ role: "assistant", content: `Caption\nMEDIA:${url}` }).content,
-      ).toEqual([
-        { type: "text", text: "Caption" },
-        {
-          type: "attachment",
-          attachment: { url, kind: "image", label: "caf%C3%A9%20image.png", mimeType: "image/png" },
         },
       ]);
     });

--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -677,6 +677,23 @@ describe("message-normalizer", () => {
       ]);
     });
 
+    it.each([
+      "file:///tmp/caf%C3%A9%20image.png",
+      "FILE:///tmp/caf%C3%A9%20image.png",
+      "FILE:/tmp/caf%C3%A9%20image.png",
+      "file://localhost/tmp/caf%C3%A9%20image.png",
+    ])("keeps the original file URL in displayed attachments: %s", (url) => {
+      expect(
+        normalizeMessage({ role: "assistant", content: `Caption\nMEDIA:${url}` }).content,
+      ).toEqual([
+        { type: "text", text: "Caption" },
+        {
+          type: "attachment",
+          attachment: { url, kind: "image", label: "caf%C3%A9%20image.png", mimeType: "image/png" },
+        },
+      ]);
+    });
+
     it("keeps spaced local filenames together instead of leaking suffix text", () => {
       const result = normalizeMessage({
         role: "assistant",

--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -644,12 +644,9 @@ describe("message-normalizer", () => {
       ["FILE:/tmp/caf%C3%A9%20image.png", "caf%C3%A9%20image.png"],
       ["file://localhost/tmp/caf%C3%A9%20image.png", "caf%C3%A9%20image.png"],
     ])("keeps local MEDIA references as assistant attachments: %s", (url, label) => {
-      const result = normalizeMessage({
-        role: "assistant",
-        content: `Hello\nMEDIA:${url}\nWorld`,
-      });
-
-      expect(result.content).toEqual([
+      expect(
+        normalizeMessage({ role: "assistant", content: `Hello\nMEDIA:${url}\nWorld` }).content,
+      ).toEqual([
         { type: "text", text: "Hello" },
         {
           type: "attachment",


### PR DESCRIPTION
Closes #133144

## What Problem This Solves

Legacy final-reply attachments fail when a valid local file URL contains an encoded filename or a `localhost` authority. A file named `café 100% image.png` loads through the direct media loader, but prefix stripping turns its URL into a nonexistent percent-encoded filename or a relative `localhost/...` path.

## Why This Change Was Made

The shared parser now preserves file URL references. The existing native reply-directive producer converts valid local URLs with the canonical file URL helper before reply policy and attachment deduplication. That preserves the legacy directive-to-path contract without importing Node filesystem code into the browser or copying a decoder. Raw structured host file URLs retain their existing reply policy, and malformed URLs, remote hosts, and encoded separators still reach native rejection.

Production LOC is -1 (+15/-16): URL conversion moves to its native owner, and that owner's silent-text handling returns the conditional value directly with its explanatory comment retained. Test LOC is +95 (+116/-21). No new dependency, configuration, public API, persistent state, or security policy is introduced.

## User Impact

Legacy `MEDIA:` replies can load local files with spaces, Unicode, literal percent signs, and localhost file URLs. Captions, filenames, MIME types, and file bytes are preserved. Equivalent explicit local paths and directive URLs still produce one attachment. Existing structured-file-URL restrictions and sandbox mapping remain intact.

## Evidence

- Before: two real-file tests failed on main `3f1c84c706bf1e4c8bc7b2ab106ab96ff1fe6ddb`: encoded filenames produced `not-found`; localhost produced `path-not-allowed`. Direct URL loading succeeded.
- After: the nine-file owner/sibling suite passed 467 tests, with one Windows-only test skipped on macOS. It covers parsing, real media loading, reference comparison, reply policy, outbound deduplication, Docker/OpenShell/custom sandbox mapping, Windows drive mapping, and browser message normalization/local-media handling.
- An owned temporary PNG passed the actual reply producer → reply media normalizer → attachment staging flow for plain, encoded, localhost, and uppercase single-slash URLs. Each preserved caption, filename, `image/png`, and exact bytes; the same raw structured host URL remained blocked, and mixed explicit/directive references deduplicated to one attachment. No provider or channel credentials were used.
- The Control UI production build passed, including sidecar and performance gates. Its existing local-media renderer accepts opaque file URLs; no Node shim or browser decoder was added.
- All local changed-file checks passed across the initial run and its focused continuation: structural guards, core production/test type checking, formatting, exact-file lint, storage/media/import-cycle/auth guards. The initial run stopped at two lint issues; corrected lint and the eight remaining guards passed without repeating already-green type checks. The final cleanup also passed 198 parser/UI tests, the four-case real reply-staging probe, and fresh full-candidate autoreview. Exact-head hosted CI remains required before landing.
- Fresh structured autoreview is scoped-clean at its default P0 threshold. A separate read-only Codex review found no actionable P0–P2 issues. The lead independently inspected the owner boundary and reran the four-case real reply-staging proof successfully.
- Exact submitted head: `c2f67f402e9a41e3b5e2aa11443a9894bf174f0f`, a byte-for-byte patch-identical rebase onto repaired main `be5e79ca4713c33a11ccd56b2d728c19f0779f3d`. The refreshed head passed 213 focused parser/reply-policy/outbound tests, the four-case real attachment-staging proof, and fresh autoreview. An obsolete CI run was canceled after its preflight proved it still checked out the earlier broken-main merge tree; new-head hosted CI remains required.

Dependency behavior was checked directly in installed `@openclaw/fs-safe` 0.5.6. Stable `v2026.6.9` already distinguished legacy directive-to-path conversion from raw structured file URL policy; #121676 retained that distinction when broadening URL spelling. The original prefix-stripping introduction is unknown. Windows-native execution and an authenticated channel send were not run locally; the real proof covers the shared filesystem loading and reply staging boundary.

The latest ClawSweeper localhost-preview finding was checked through the actual exported UI policy and proxy helpers: local authorities normalize to an empty hostname before the existing guard. Lowercase/uppercase localhost inside allowed roots pass; remote hosts, outside paths, and encoded separators remain rejected. Proxy URLs retain the exact source and media ticket. The proposed production policy change is skipped as a false positive; the unchanged policy already satisfies that rank-up request.
