### PR TITLE
fix(codex): stop accepted turns when session setup fails

### DIFF
--- a/extensions/codex/src/app-server/run-attempt-activation-cleanup.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-activation-cleanup.test.ts
@@ -1,0 +1,678 @@
+// Codex tests cover cleanup after native turn acceptance.
+import path from "node:path";
+import {
+  resolveActiveEmbeddedRunSessionId,
+  type EmbeddedRunAttemptParamsV2,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { readSessionTranscriptEvents } from "openclaw/plugin-sdk/session-transcript-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  answerInitialize,
+  createPairedAttemptRuntime,
+  readHarnessMessages,
+  waitForRequest,
+} from "./attempt-startup.test-support.js";
+import { CodexAppServerClient } from "./client.js";
+import { turnCompleted } from "./protocol.test-helpers.js";
+import {
+  createCodexRuntimePlanFixture,
+  createParams,
+  fastWait,
+  runCodexAppServerAttempt,
+  setupRunAttemptTestHooks,
+  tempDir,
+  threadStartResult,
+  turnStartResult,
+} from "./run-attempt-test-harness.js";
+import { createSandboxContext } from "./sandbox-exec-server.test-helpers.js";
+import { testCodexAppServerBindingStore } from "./session-binding.test-helpers.js";
+import {
+  captureExclusiveSharedCodexAppServerClient,
+  resetSharedCodexAppServerClientForTests,
+  retainSharedCodexAppServerClientIfCurrent,
+} from "./shared-client.js";
+import { createClientHarness } from "./test-support.js";
+import type { CodexThreadRouteReservation } from "./turn-router.js";
+import { CODEX_APP_SERVER_VERSION } from "./version.js";
+
+function createAttemptParams(sessionKey: string) {
+  const fixturePathSegment = sessionKey.replaceAll(":", "-");
+  const params = createParams(
+    path.join(tempDir, `${fixturePathSegment}.jsonl`),
+    path.join(tempDir, `${fixturePathSegment}-workspace`),
+    { sessionKey },
+  );
+  params.disableTools = true;
+  params.config = undefined;
+  delete params.contextTokenBudget;
+  delete params.contextWindowInfo;
+  delete params.observeToolTerminal;
+  return params;
+}
+
+async function requireRequest(harness: ReturnType<typeof createClientHarness>, method: string) {
+  const request = await waitForRequest(harness, method);
+  if (request.id === undefined) {
+    throw new Error(`Codex harness did not write ${method}`);
+  }
+  return { id: request.id, params: request.params };
+}
+
+async function answerTurnStart(
+  harness: ReturnType<typeof createClientHarness>,
+  beforeAcceptance: () => void = () => undefined,
+): Promise<void> {
+  const initialize = await requireRequest(harness, "initialize");
+  harness.send({
+    id: initialize.id,
+    result: { userAgent: `openclaw/${CODEX_APP_SERVER_VERSION} (macOS; test)` },
+  });
+  const threadStart = await requireRequest(harness, "thread/start");
+  harness.send({ id: threadStart.id, result: threadStartResult() });
+  const turnStart = await requireRequest(harness, "turn/start");
+  beforeAcceptance();
+  harness.send({ id: turnStart.id, result: turnStartResult() });
+}
+
+function requestMethods(harness: ReturnType<typeof createClientHarness>): string[] {
+  return readHarnessMessages(harness.writes).flatMap((message) =>
+    typeof message.method === "string" ? [message.method] : [],
+  );
+}
+
+async function installFailingRouteBinding(
+  failure: Error,
+  beforeFailure: (
+    route: CodexThreadRouteReservation,
+    turnId: string,
+  ) => Promise<void> | void = () => undefined,
+) {
+  const turnRouterModule = await import("./turn-router.js");
+  const readTurnRouter = turnRouterModule.getCodexAppServerTurnRouter;
+  return vi.spyOn(turnRouterModule, "getCodexAppServerTurnRouter").mockImplementation((client) => {
+    const router = readTurnRouter(client);
+    return {
+      reserveThread: (options) => {
+        const route = router.reserveThread(options);
+        return {
+          ...route,
+          bindTurn: async (turnId) => {
+            await beforeFailure(route, turnId);
+            throw failure;
+          },
+        };
+      },
+      watchNativeTurnCompletion: (options) => router.watchNativeTurnCompletion(options),
+    };
+  });
+}
+
+function configurePairedNodeAttempt(params: EmbeddedRunAttemptParamsV2) {
+  const runtimePlan = createCodexRuntimePlanFixture();
+  params.runtimePlan = {
+    ...runtimePlan,
+    auth: {
+      ...runtimePlan.auth,
+      providerForAuth: "openai",
+      authProfileProviderForAuth: "openai",
+      selectedAuthMode: "api-key",
+      modelRoute: {
+        provider: "openai",
+        modelId: "gpt-5.4-codex",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+        authRequirement: "api-key",
+        requestTransportOverrides: "none",
+      },
+    },
+  };
+  params.resolvedApiKey = "isolated-cleanup-test-key";
+  params.sandbox = Object.assign(createSandboxContext({}), {
+    backendId: "node",
+    backend: undefined,
+    fsBridge: undefined,
+    runtimeId: `paired-node-${params.runId}`,
+    placementExecutionMode: "remote-exec",
+    placementNodeId: "paired-device-1",
+    placementEnvironmentId: `environment-${params.runId}`,
+    placementSessionId: params.sessionId,
+    placementOwnerEpoch: 1,
+  });
+  return createPairedAttemptRuntime();
+}
+
+async function answerPairedNodeStartupUntilTurnStart(
+  harness: ReturnType<typeof createClientHarness>,
+) {
+  await answerInitialize(harness);
+  const login = await waitForRequest(harness, "account/login/start");
+  harness.send({ id: login.id, result: { type: "apiKey" } });
+  const environment = await waitForRequest(harness, "environment/add");
+  harness.send({ id: environment.id, result: {} });
+  const thread = await waitForRequest(harness, "thread/start");
+  harness.send({ id: thread.id, result: threadStartResult() });
+  return await waitForRequest(harness, "turn/start");
+}
+
+setupRunAttemptTestHooks();
+
+describe("Codex accepted-turn cleanup", () => {
+  beforeEach(() => {
+    resetSharedCodexAppServerClientForTests();
+  });
+
+  afterEach(() => {
+    resetSharedCodexAppServerClientForTests();
+  });
+
+  it("reclaims a route-bind failure after the exact native terminal", async () => {
+    const failure = new Error("injected route binding failure");
+    let routeSignal: AbortSignal | undefined;
+    const getTurnRouter = await installFailingRouteBinding(failure, (route) => {
+      routeSignal = route.signal;
+    });
+    const harness = createClientHarness();
+    const startClient = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockResolvedValueOnce(harness.client);
+    const sessionKey = "agent:main:dashboard:route-failure";
+    const params = createAttemptParams(sessionKey);
+    const upstreamAbort = new AbortController();
+    const addAbortListener = vi.spyOn(upstreamAbort.signal, "addEventListener");
+    const removeAbortListener = vi.spyOn(upstreamAbort.signal, "removeEventListener");
+    const onAttemptAbort = vi.fn();
+    params.abortSignal = upstreamAbort.signal;
+    params.onAttemptAbort = onAttemptAbort;
+    const observedFailure = runCodexAppServerAttempt(params).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    let settled = false;
+    void observedFailure.then(() => {
+      settled = true;
+    });
+
+    try {
+      await answerTurnStart(harness);
+      const interrupt = await requireRequest(harness, "turn/interrupt");
+      expect(interrupt.params).toEqual({ threadId: "thread-1", turnId: "turn-1" });
+      harness.send({ id: interrupt.id, result: {} });
+      harness.send({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-unrelated",
+          turn: { id: "turn-unrelated", status: "interrupted" },
+        },
+      });
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+
+      expect(settled).toBe(false);
+      expect(requestMethods(harness)).not.toContain("thread/unsubscribe");
+      const pendingProbe = retainSharedCodexAppServerClientIfCurrent(harness.client);
+      if (!pendingProbe) {
+        throw new Error("expected the accepted turn lease to remain pending");
+      }
+      expect(() => captureExclusiveSharedCodexAppServerClient(harness.client)).toThrow();
+      pendingProbe();
+
+      harness.send({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: { id: "turn-1", status: "interrupted" },
+        },
+      });
+      const unsubscribe = await requireRequest(harness, "thread/unsubscribe");
+      harness.send({ id: unsubscribe.id, result: {} });
+
+      await expect(observedFailure).resolves.toBe(failure);
+      if (!routeSignal) {
+        throw new Error("expected a reserved route signal");
+      }
+      expect(routeSignal.aborted).toBe(true);
+      const routeProbe = (await import("./turn-router.js"))
+        .getCodexAppServerTurnRouter(harness.client)
+        .reserveThread({ threadId: "thread-1" });
+      routeProbe.release();
+      expect(resolveActiveEmbeddedRunSessionId(sessionKey)).toBeUndefined();
+      const finalProbe = retainSharedCodexAppServerClientIfCurrent(harness.client);
+      if (!finalProbe) {
+        throw new Error("expected cleanup to preserve the safe shared client");
+      }
+      const assertExclusive = captureExclusiveSharedCodexAppServerClient(harness.client);
+      assertExclusive();
+      finalProbe();
+      const abortRegistration = addAbortListener.mock.calls.find(([type]) => type === "abort");
+      if (!abortRegistration) {
+        throw new Error("expected an upstream abort listener registration");
+      }
+      expect(removeAbortListener).toHaveBeenCalledWith("abort", abortRegistration[1]);
+      upstreamAbort.abort("late abort");
+      expect(onAttemptAbort).not.toHaveBeenCalled();
+      expect(startClient).toHaveBeenCalledOnce();
+    } finally {
+      addAbortListener.mockRestore();
+      removeAbortListener.mockRestore();
+      getTurnRouter.mockRestore();
+      startClient.mockRestore();
+    }
+  });
+
+  it("cleans active publication when active-run registration throws", async () => {
+    const failure = new Error("injected active-run registration failure");
+    const harnessRuntime = await import("openclaw/plugin-sdk/agent-harness-runtime");
+    const publishActiveRun = harnessRuntime.setActiveEmbeddedRun;
+    const setActiveRun = vi
+      .spyOn(harnessRuntime, "setActiveEmbeddedRun")
+      .mockImplementation((sessionId, handle, sessionKey, sessionFile) => {
+        publishActiveRun(sessionId, handle, sessionKey, sessionFile);
+        throw failure;
+      });
+    const harness = createClientHarness();
+    const startClient = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockResolvedValueOnce(harness.client);
+    const sessionKey = "agent:main:dashboard:reply-publication-failure";
+    const params = createAttemptParams(sessionKey);
+    const observedFailure = runCodexAppServerAttempt(params).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    try {
+      await answerTurnStart(harness);
+      const interrupt = await requireRequest(harness, "turn/interrupt");
+      harness.send({ id: interrupt.id, result: {} });
+      harness.send(turnCompleted({ id: "turn-1", status: "interrupted" }));
+      const unsubscribe = await requireRequest(harness, "thread/unsubscribe");
+      harness.send({ id: unsubscribe.id, result: {} });
+
+      await expect(observedFailure).resolves.toBe(failure);
+      expect(resolveActiveEmbeddedRunSessionId(sessionKey)).toBeUndefined();
+      expect(startClient).toHaveBeenCalledOnce();
+    } finally {
+      setActiveRun.mockRestore();
+      startClient.mockRestore();
+    }
+  });
+
+  it("checkpoints projected commentary when activation fails after route binding", async () => {
+    const failure = new Error("injected post-projection binding failure");
+    let routeBoundBeforeFailure = false;
+    const getTurnRouter = await installFailingRouteBinding(failure, async (route, turnId) => {
+      await route.bindTurn(turnId);
+      routeBoundBeforeFailure = true;
+    });
+    const harness = createClientHarness();
+    const startClient = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockResolvedValueOnce(harness.client);
+    const sessionKey = "agent:main:dashboard:partial-activation";
+    const params = createAttemptParams(sessionKey);
+    let releaseNotificationTail: () => void = () => undefined;
+    const notificationTailGate = new Promise<void>((resolve) => {
+      releaseNotificationTail = resolve;
+    });
+    let notificationTailBlocked = false;
+    params.onAssistantMessageStart = async () => {
+      notificationTailBlocked = true;
+      await notificationTailGate;
+    };
+    const storePath = path.join(tempDir, "partial-activation-sessions.json");
+    params.sessionTarget = {
+      agentId: "main",
+      sessionId: params.sessionId,
+      sessionKey,
+      storePath,
+    };
+    await upsertSessionEntry({
+      agentId: "main",
+      sessionKey,
+      storePath,
+      entry: {
+        sessionFile: params.sessionFile,
+        sessionId: params.sessionId,
+        updatedAt: Date.now(),
+      },
+    });
+    const observedFailure = runCodexAppServerAttempt(params).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    try {
+      const initialize = await requireRequest(harness, "initialize");
+      harness.send({
+        id: initialize.id,
+        result: { userAgent: `openclaw/${CODEX_APP_SERVER_VERSION} (macOS; test)` },
+      });
+      const threadStart = await requireRequest(harness, "thread/start");
+      harness.send({ id: threadStart.id, result: threadStartResult() });
+      const turnStart = await requireRequest(harness, "turn/start");
+      harness.send({ id: turnStart.id, result: turnStartResult() });
+      const interrupt = await requireRequest(harness, "turn/interrupt");
+      expect(interrupt.params).toEqual({ threadId: "thread-1", turnId: "turn-1" });
+      expect(routeBoundBeforeFailure).toBe(true);
+      harness.send({
+        method: "item/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            type: "agentMessage",
+            id: "partial-activation-commentary",
+            phase: "commentary",
+            text: "",
+          },
+        },
+      });
+      harness.send({
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "partial-activation-commentary",
+          delta: "Checkpoint this partial activation.",
+        },
+      });
+      await vi.waitFor(() => expect(notificationTailBlocked).toBe(true), fastWait);
+      harness.send({ id: interrupt.id, result: {} });
+      harness.send({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: { id: "turn-1", status: "interrupted" },
+        },
+      });
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(requestMethods(harness)).not.toContain("thread/unsubscribe");
+      releaseNotificationTail();
+      const unsubscribe = await requireRequest(harness, "thread/unsubscribe");
+      harness.send({ id: unsubscribe.id, result: {} });
+
+      await expect(observedFailure).resolves.toBe(failure);
+      const transcript = await readSessionTranscriptEvents({
+        agentId: "main",
+        sessionId: params.sessionId,
+        sessionKey,
+        storePath,
+      });
+      expect(JSON.stringify(transcript)).toContain("Checkpoint this partial activation.");
+      expect(startClient).toHaveBeenCalledOnce();
+    } finally {
+      releaseNotificationTail();
+      getTurnRouter.mockRestore();
+      startClient.mockRestore();
+    }
+  });
+
+  it("detaches the client before later cleanup after interruption is unconfirmed", async () => {
+    const failure = new Error("injected route binding failure");
+    const getTurnRouter = await installFailingRouteBinding(failure);
+    const harness = createClientHarness();
+    const startClient = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockResolvedValueOnce(harness.client);
+    let releaseBindingCleanup: () => void = () => undefined;
+    const bindingCleanupGate = new Promise<void>((resolve) => {
+      releaseBindingCleanup = resolve;
+    });
+    let holdBindingCleanup = false;
+    let bindingCleanupEntered = false;
+    let blockedMutation: Parameters<typeof testCodexAppServerBindingStore.mutate>[1] | undefined;
+    const bindingStore: typeof testCodexAppServerBindingStore = {
+      ...testCodexAppServerBindingStore,
+      mutate: async (identity, mutation, assertCurrent) => {
+        if (holdBindingCleanup) {
+          bindingCleanupEntered = true;
+          blockedMutation = mutation;
+          await bindingCleanupGate;
+          throw new Error("injected binding cleanup failure");
+        }
+        return await testCodexAppServerBindingStore.mutate(identity, mutation, assertCurrent);
+      },
+    };
+    const sessionKey = "agent:main:dashboard:incognito-unsafe-activation";
+    const params = createAttemptParams(sessionKey);
+    const run = runCodexAppServerAttempt(params, { bindingStore });
+    const observedFailure = run.then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    try {
+      await answerTurnStart(harness, () => {
+        holdBindingCleanup = true;
+      });
+      const interrupt = await requireRequest(harness, "turn/interrupt");
+      harness.send({
+        id: interrupt.id,
+        error: { code: -32_000, message: "injected interrupt failure" },
+      });
+      await vi.waitFor(() => expect(bindingCleanupEntered).toBe(true), {
+        interval: 1,
+        timeout: 5_000,
+      });
+
+      expect(blockedMutation).toEqual({ kind: "clear", threadId: "thread-1" });
+      expect(retainSharedCodexAppServerClientIfCurrent(harness.client)).toBeUndefined();
+      expect(requestMethods(harness)).not.toContain("thread/unsubscribe");
+      expect(resolveActiveEmbeddedRunSessionId(sessionKey)).toBeUndefined();
+      releaseBindingCleanup();
+
+      await expect(observedFailure).resolves.toBe(failure);
+      await vi.waitFor(() => expect(harness.stdinDestroyed).toBe(true), {
+        interval: 1,
+        timeout: 5_000,
+      });
+      expect(startClient).toHaveBeenCalledOnce();
+    } finally {
+      releaseBindingCleanup();
+      getTurnRouter.mockRestore();
+      startClient.mockRestore();
+    }
+  });
+
+  it("joins an unsafe isolated client exactly once during cleanup", async () => {
+    const failure = new Error("isolated route binding failed");
+    const getTurnRouter = await installFailingRouteBinding(failure);
+    const params = createAttemptParams("agent:main:dashboard:isolated-route-failure");
+    const pairedRuntime = configurePairedNodeAttempt(params);
+    const harness = createClientHarness();
+    const closeAndWait = vi.spyOn(harness.client, "closeAndWait");
+    const startClient = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockResolvedValueOnce(harness.client);
+
+    try {
+      const run = runCodexAppServerAttempt(params, {
+        bindingStore: testCodexAppServerBindingStore,
+        runtime: pairedRuntime.runtime,
+      });
+      const turn = await answerPairedNodeStartupUntilTurnStart(harness);
+      harness.send({ id: turn.id, result: turnStartResult() });
+      const interrupt = await waitForRequest(harness, "turn/interrupt");
+      harness.send({
+        id: interrupt.id,
+        error: { code: -32_000, message: "isolated interrupt failed" },
+      });
+
+      await expect(run).rejects.toBe(failure);
+      expect(closeAndWait).toHaveBeenCalledOnce();
+    } finally {
+      getTurnRouter.mockRestore();
+      startClient.mockRestore();
+    }
+  });
+
+  it("joins an indeterminate isolated startup client exactly once", async () => {
+    const params = createAttemptParams("agent:main:dashboard:isolated-startup-cancellation");
+    params.runId = "run-isolated-startup-cancellation";
+    const abort = new AbortController();
+    params.abortSignal = abort.signal;
+    const pairedRuntime = configurePairedNodeAttempt(params);
+    const harness = createClientHarness();
+    const closeAndWait = vi.spyOn(harness.client, "closeAndWait");
+    const startClient = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockResolvedValueOnce(harness.client);
+
+    try {
+      const run = runCodexAppServerAttempt(params, {
+        bindingStore: testCodexAppServerBindingStore,
+        runtime: pairedRuntime.runtime,
+      });
+      const turn = await answerPairedNodeStartupUntilTurnStart(harness);
+
+      abort.abort("cancelled");
+      const interrupt = await waitForRequest(harness, "turn/interrupt");
+      harness.send({ id: turn.id, result: turnStartResult() });
+      harness.send({
+        id: interrupt.id,
+        error: { code: -32_000, message: "isolated startup interrupt failed" },
+      });
+
+      await expect(run).rejects.toMatchObject({ message: "turn/start aborted" });
+      expect(closeAndWait).toHaveBeenCalledOnce();
+    } finally {
+      startClient.mockRestore();
+    }
+  });
+
+  it("joins an activated isolated client once when abort interruption is unconfirmed", async () => {
+    const params = createAttemptParams("agent:main:dashboard:isolated-activated-cancellation");
+    params.runId = "run-isolated-activated-interrupt-failure";
+    const abort = new AbortController();
+    params.abortSignal = abort.signal;
+    const pairedRuntime = configurePairedNodeAttempt(params);
+    const harness = createClientHarness();
+    const closeAndWait = vi.spyOn(harness.client, "closeAndWait");
+    const startClient = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockResolvedValueOnce(harness.client);
+
+    try {
+      const run = runCodexAppServerAttempt(params, {
+        bindingStore: testCodexAppServerBindingStore,
+        runtime: pairedRuntime.runtime,
+      });
+      const turn = await answerPairedNodeStartupUntilTurnStart(harness);
+      harness.send({ id: turn.id, result: turnStartResult() });
+      await vi.waitFor(
+        () =>
+          expect(resolveActiveEmbeddedRunSessionId(params.sessionKey ?? params.sessionId)).toBe(
+            params.sessionId,
+          ),
+        fastWait,
+      );
+
+      abort.abort("cancelled");
+      const interrupt = await waitForRequest(harness, "turn/interrupt");
+      harness.send({
+        id: interrupt.id,
+        error: { code: -32_000, message: "isolated activated interrupt failed" },
+      });
+
+      await expect(run).rejects.toThrow(
+        "Codex cancellation could not confirm the turn stopped; background terminals may still be running.",
+      );
+      expect(closeAndWait).toHaveBeenCalledOnce();
+    } finally {
+      startClient.mockRestore();
+    }
+  });
+
+  it("preserves activation failure when unsubscribe retirement rejects", async () => {
+    const failure = new Error("isolated activation failed before cleanup");
+    let routeSignal: AbortSignal | undefined;
+    const getTurnRouter = await installFailingRouteBinding(failure, (route) => {
+      routeSignal = route.signal;
+    });
+    const params = createAttemptParams("agent:main:dashboard:isolated-retirement-rejection");
+    params.runId = "run-isolated-activation-retirement-rejection";
+    const pairedRuntime = configurePairedNodeAttempt(params);
+    const harness = createClientHarness();
+    const transportExited = new Promise<void>((resolve) => {
+      harness.process.once("exit", () => resolve());
+    });
+    const closeClient = harness.client.close.bind(harness.client);
+    let routeReleasedBeforeFallback: boolean | undefined;
+    const close = vi.spyOn(harness.client, "close").mockImplementation(() => {
+      routeReleasedBeforeFallback ??= routeSignal?.aborted;
+      closeClient();
+    });
+    const closeAndWait = vi
+      .spyOn(harness.client, "closeAndWait")
+      .mockRejectedValue(new Error("isolated retirement rejected"));
+    const startClient = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockResolvedValueOnce(harness.client);
+
+    try {
+      const run = runCodexAppServerAttempt(params, {
+        bindingStore: testCodexAppServerBindingStore,
+        runtime: pairedRuntime.runtime,
+      });
+      const turn = await answerPairedNodeStartupUntilTurnStart(harness);
+      harness.send({ id: turn.id, result: turnStartResult() });
+      const interrupt = await waitForRequest(harness, "turn/interrupt");
+      harness.send({ id: interrupt.id, result: {} });
+      harness.send(turnCompleted({ id: "turn-1", status: "interrupted" }));
+      const unsubscribe = await waitForRequest(harness, "thread/unsubscribe");
+      harness.send({
+        id: unsubscribe.id,
+        error: { code: -32_000, message: "isolated unsubscribe failed" },
+      });
+
+      await expect(run).rejects.toBe(failure);
+      expect(closeAndWait).toHaveBeenCalledOnce();
+      expect(close).toHaveBeenCalled();
+      expect(routeReleasedBeforeFallback).toBe(false);
+      await transportExited;
+      expect(harness.stdinDestroyed).toBe(true);
+    } finally {
+      getTurnRouter.mockRestore();
+      startClient.mockRestore();
+    }
+  });
+
+  it("joins an isolated client once when a completed turn cannot unsubscribe", async () => {
+    const params = createAttemptParams("agent:main:dashboard:isolated-unsubscribe-failure");
+    params.runId = "run-isolated-unsubscribe-failure";
+    params.cleanupBundleMcpOnRunEnd = true;
+    const pairedRuntime = configurePairedNodeAttempt(params);
+    const harness = createClientHarness();
+    const closeAndWait = vi.spyOn(harness.client, "closeAndWait");
+    const startClient = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockResolvedValueOnce(harness.client);
+
+    try {
+      const run = runCodexAppServerAttempt(params, {
+        bindingStore: testCodexAppServerBindingStore,
+        runtime: pairedRuntime.runtime,
+      });
+      const turn = await answerPairedNodeStartupUntilTurnStart(harness);
+      harness.send({ id: turn.id, result: turnStartResult() });
+      harness.send(turnCompleted({ id: "turn-1", status: "completed" }));
+      const unsubscribe = await waitForRequest(harness, "thread/unsubscribe");
+      harness.send({
+        id: unsubscribe.id,
+        error: { code: -32_000, message: "isolated unsubscribe failed" },
+      });
+
+      await run;
+      expect(closeAndWait).toHaveBeenCalledOnce();
+    } finally {
+      startClient.mockRestore();
+    }
+  });
+});

--- a/extensions/codex/src/app-server/run-attempt-active-turn.ts
+++ b/extensions/codex/src/app-server/run-attempt-active-turn.ts
@@ -59,7 +59,6 @@ export async function activateCodexAttemptTurn(
     runAbortController,
     terminalState,
     abortExplicitly,
-    abortFromUpstream,
     bindingStore,
     bindingIdentity,
     sessionAgentId,
@@ -70,9 +69,21 @@ export async function activateCodexAttemptTurn(
   const { dynamicToolParams, compactionPlanState, computerContextEpoch, toolBridge } = attemptTools;
   const { state, userInputBridgeRef, steeringQueueRef, turnWatches, completeTurn, interruptTurn } =
     turnRuntime;
+  const { turnIdRef } = turnRuntime;
   const { emitExecutionPhaseOnce, emitLifecycleStart, maybeAnnounceFastModeAutoOff } = lifecycle;
   const { enqueueNotification } = notifications;
   const activeTurnId = turn.turn.id;
+  const authoritySourceRef = attemptTools.scheduledAppAuthoritySourceRef;
+  if (resourceState.thread.pluginAppPolicyContext) {
+    authoritySourceRef.current = {
+      client: resourceState.client,
+      threadId: resourceState.thread.threadId,
+      policyContext: resourceState.thread.pluginAppPolicyContext,
+      configCwd: effectiveCwd,
+    };
+  }
+  turnIdRef.current = activeTurnId;
+  resourceState.nativeSubagentMonitor?.bindTurn(activeTurnId);
   const progressCardTool = toolBridge.availableTools.find((tool) => tool.name === "progress_card");
   let nativePlanUpdateOrdinal = 0;
   const prepareNativeMcpAppResultDetails = createCodexNativeMcpAppResultDetailsPreparer({
@@ -411,15 +422,6 @@ export async function activateCodexAttemptTurn(
     cancel: () => abortExplicitly("cancelled"),
     abort: () => abortExplicitly("aborted"),
   };
-  params.replyOperation?.attachBackend(handle);
-  setActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
-  const freezeRunTerminalOutcome = () => {
-    if (terminalState.terminalOutcomeFrozen) {
-      return;
-    }
-    terminalState.terminalOutcomeFrozen = true;
-    params.abortSignal?.removeEventListener("abort", abortFromUpstream);
-  };
   const abortListener = () => {
     if (state.timedOut) {
       void (async () => {
@@ -463,18 +465,21 @@ export async function activateCodexAttemptTurn(
       completeTurn();
     });
   };
-  runAbortController.signal.addEventListener("abort", abortListener, { once: true });
-  if (runAbortController.signal.aborted) {
-    abortListener();
-  }
   return {
     activeTurnId,
     activeProjector,
     streamState,
     handle,
-    freezeRunTerminalOutcome,
     notifyUserMessagePersisted,
     abortListener,
+    publishActiveOwnership: () => {
+      params.replyOperation?.attachBackend(handle);
+      setActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
+      runAbortController.signal.addEventListener("abort", abortListener, { once: true });
+      if (runAbortController.signal.aborted) {
+        abortListener();
+      }
+    },
   };
 }
 

--- a/extensions/codex/src/app-server/run-attempt-cleanup.ts
+++ b/extensions/codex/src/app-server/run-attempt-cleanup.ts
@@ -2,7 +2,7 @@ import { clearActiveEmbeddedRun } from "openclaw/plugin-sdk/agent-harness-runtim
 import { isIncognitoSessionKey } from "../incognito-session.js";
 import {
   CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
-  closeCodexStartupClientBestEffort,
+  retireUnsafeCodexTurnClientBestEffort,
   unsubscribeCodexThreadBestEffort,
 } from "./attempt-client-cleanup.js";
 import { resolveCodexAppServerClientInstanceId } from "./client.js";
@@ -14,12 +14,16 @@ import type { prepareCodexAttemptTurnRequest } from "./run-attempt-turn-request.
 import type { CodexAttemptTurnState } from "./run-attempt-turn-state.js";
 import { retainCodexAppServerBindingSubscription } from "./thread-ownership.js";
 
+export type CodexAttemptOwnedTurn =
+  | { phase: "accepted"; turnId: string }
+  | { phase: "activated"; activeTurn: CodexAttemptActiveTurn };
+
 export async function cleanupCodexAttempt(
   resources: CodexAttemptResources,
   turnRuntime: CodexAttemptTurnState,
   lifecycle: CodexAttemptLifecycleController,
   requestRuntime: Awaited<ReturnType<typeof prepareCodexAttemptTurnRequest>>,
-  activeTurn: CodexAttemptActiveTurn,
+  ownedTurn: CodexAttemptOwnedTurn,
 ) {
   const {
     prompt,
@@ -33,6 +37,7 @@ export async function cleanupCodexAttempt(
   const { connection } = prompt.context.runtime;
   const { params, options, runAbortController, terminalState, bindingStore, bindingIdentity } =
     connection;
+  const { freezeRunTerminalOutcome } = connection;
   const { state, steeringQueueRef, userInputBridgeRef, turnWatches } = turnRuntime;
   const {
     maybeEmitFastModeAutoResetBestEffort,
@@ -40,16 +45,32 @@ export async function cleanupCodexAttempt(
     buildLifecycleTerminalMeta,
   } = lifecycle;
   const { codexModelCallDiagnostics } = requestRuntime;
-  const { activeTurnId, abortListener, handle, freezeRunTerminalOutcome } = activeTurn;
+  const activeTurn = ownedTurn.phase === "accepted" ? undefined : ownedTurn.activeTurn;
+  const activeTurnId =
+    ownedTurn.phase === "accepted" ? ownedTurn.turnId : ownedTurn.activeTurn.activeTurnId;
+  const rollbackTurn = ownedTurn.phase === "accepted" || !state.completed;
+  let subscriptionDisposition: "pending" | "detached" | "resolved" =
+    resourceState.startupClientUnsafe ? "detached" : "pending";
   // Exact-thread cron authority exists only while this creator turn owns the
   // live client/thread. Retained model callbacks must fail after cleanup begins.
   prompt.context.attemptTools.scheduledAppAuthoritySourceRef.current = undefined;
   // Finalization can throw before freezing. Close cancellation admission before
   // any teardown await so it cannot replace the cleanup promise being joined.
   freezeRunTerminalOutcome();
-  // Join late cancellation before releasing the subscription, but do not let a
-  // failed terminal RPC skip resource cleanup. Surface that failure below.
+  // Join late cancellation, then close admission before rollback; otherwise
+  // queued work can replace cleanup or a failed terminal RPC can skip teardown.
   await state.abortCleanup.catch(() => undefined);
+  if (rollbackTurn) {
+    turnRuntime.completeTurn();
+    const interrupted = await turnRuntime.interruptTurn(activeTurnId, {
+      locallyCompleted: true,
+      operation: "activation interrupt",
+    });
+    if (interrupted) {
+      await resourceState.turnRoute?.drain();
+    }
+    subscriptionDisposition = interrupted ? "pending" : "detached";
+  }
   try {
     steeringQueueRef.current?.cancel();
     if (params.isFinalFallbackAttempt !== false) {
@@ -123,19 +144,20 @@ export async function cleanupCodexAttempt(
             threadId: resourceState.thread.threadId,
           })
         : true;
-    // Only explicitly retained live threads may skip the next thread/resume.
-    if (!state.timedOut && !retainLiveThread) {
-      // Clear first: if a newer owner won the binding, its live subscription must remain intact.
-      if (bindingReleased) {
-        const released = await unsubscribeCodexThreadBestEffort(resourceState.client, {
-          threadId: resourceState.thread.threadId,
-          timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
-        });
-        if (!released) {
-          // Never reuse a client whose previous thread may still publish notifications.
-          await closeCodexStartupClientBestEffort(resourceState.client);
-        }
+    const timedOutWithActiveAbortOwner = ownedTurn.phase === "activated" && state.timedOut;
+    if (timedOutWithActiveAbortOwner || retainLiveThread || !bindingReleased) {
+      subscriptionDisposition = "resolved";
+    } else if (subscriptionDisposition === "pending") {
+      const released = await unsubscribeCodexThreadBestEffort(resourceState.client, {
+        threadId: resourceState.thread.threadId,
+        timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+      });
+      if (!released) {
+        // Never reuse a client whose previous thread may still publish notifications.
+        resourceState.startupClientUnsafe = true;
+        await retireUnsafeCodexTurnClientBestEffort(resourceState.client, "thread unsubscribe");
       }
+      subscriptionDisposition = "resolved";
     }
   } finally {
     await runCleanupStep("codex-user-input-cancel", () =>
@@ -153,10 +175,21 @@ export async function cleanupCodexAttempt(
       const cleanups = prompt.context.attemptTools.runCleanups.splice(0);
       await Promise.allSettled(cleanups.map(async (cleanup) => await cleanup(cleanupReason)));
     });
+    if (rollbackTurn) {
+      await runCleanupStep("codex-transcript-checkpoint", () =>
+        resources.projectorRef.current?.transcriptCheckpoint.flush(true),
+      );
+    }
     await runCleanupStep("codex-route-release", releaseCurrentRoute);
-    await runCleanupStep("codex-transcript-checkpoint", () =>
-      activeTurn.activeProjector.transcriptCheckpoint.flush(true),
-    );
+    if (activeTurn && !rollbackTurn) {
+      await runCleanupStep("codex-transcript-checkpoint", () =>
+        activeTurn.activeProjector.transcriptCheckpoint.flush(true),
+      );
+    }
+    if (subscriptionDisposition === "pending" && !resourceState.startupClientUnsafe) {
+      resourceState.startupClientUnsafe = true;
+      await retireUnsafeCodexTurnClientBestEffort(resourceState.client, "attempt cleanup");
+    }
     await runCleanupStep(
       "codex-shared-client-release",
       releaseSharedClientLeaseAndRetireOneShotClient,
@@ -184,16 +217,25 @@ export async function cleanupCodexAttempt(
     await runCleanupStep("codex-scheduled-mcp-dispose", () =>
       prompt.context.attemptTools.scheduledConfiguredMcp?.dispose(),
     );
-    await runCleanupStep("codex-abort-listener-remove", () => {
-      runAbortController.signal.removeEventListener("abort", abortListener);
-    });
+    if (activeTurn) {
+      await runCleanupStep("codex-abort-listener-remove", () => {
+        runAbortController.signal.removeEventListener("abort", activeTurn.abortListener);
+      });
+    }
     await runCleanupStep("codex-steering-cancel", () => steeringQueueRef.current?.cancel());
-    await runCleanupStep("codex-reply-backend-detach", () =>
-      params.replyOperation?.detachBackend(handle),
-    );
-    await runCleanupStep("codex-active-run-clear", () => {
-      clearActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
-    });
+    if (activeTurn) {
+      await runCleanupStep("codex-reply-backend-detach", () =>
+        params.replyOperation?.detachBackend(activeTurn.handle),
+      );
+      await runCleanupStep("codex-active-run-clear", () => {
+        clearActiveEmbeddedRun(
+          params.sessionId,
+          activeTurn.handle,
+          params.sessionKey,
+          params.sessionFile,
+        );
+      });
+    }
   }
   await state.abortCleanup;
 }

--- a/extensions/codex/src/app-server/run-attempt-connection.ts
+++ b/extensions/codex/src/app-server/run-attempt-connection.ts
@@ -400,6 +400,12 @@ export async function prepareCodexAttemptConnection({ params, options }: CodexRu
   const abortFromUpstream = () => {
     abortExplicitly(params.abortSignal?.reason ?? "upstream_abort");
   };
+  const freezeRunTerminalOutcome = () => {
+    if (!terminalState.terminalOutcomeFrozen) {
+      terminalState.terminalOutcomeFrozen = true;
+      params.abortSignal?.removeEventListener("abort", abortFromUpstream);
+    }
+  };
   if (params.abortSignal?.aborted) {
     abortFromUpstream();
   } else {
@@ -503,6 +509,7 @@ export async function prepareCodexAttemptConnection({ params, options }: CodexRu
     terminalState,
     abortExplicitly,
     abortFromUpstream,
+    freezeRunTerminalOutcome,
     resolveReviewerPolicyContext,
     resolveRuntimeOptionsForCurrentBinding,
     mutable,

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -62,6 +62,7 @@ export async function finalizeCodexAttempt(
   const {
     params,
     terminalState,
+    freezeRunTerminalOutcome,
     runAbortController,
     activeContextEngine,
     bindingStore,
@@ -88,13 +89,7 @@ export async function finalizeCodexAttempt(
   const { emitLifecycleTerminal, buildLifecycleTerminalMeta } = lifecycle;
   const { drainNotificationQueue } = notifications;
   const { codexModelCallDiagnostics } = requestRuntime;
-  const {
-    activeTurnId,
-    activeProjector,
-    streamState,
-    freezeRunTerminalOutcome,
-    notifyUserMessagePersisted,
-  } = activeTurn;
+  const { activeTurnId, activeProjector, streamState, notifyUserMessagePersisted } = activeTurn;
   await completion;
   await state.abortCleanup;
   // Timeout and Stop still join queued projections within the abort grace;

--- a/extensions/codex/src/app-server/run-attempt-resources.ts
+++ b/extensions/codex/src/app-server/run-attempt-resources.ts
@@ -144,8 +144,6 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
     }
     state.sharedCodexClientRetiredForOneShotCleanup = true;
     const retired = clearSharedCodexAppServerClientIfCurrentAndUnclaimed(state.client);
-    // Runs on every one-shot attempt teardown; routine retirement checks are
-    // diagnostic detail, not operator-facing info.
     embeddedAgentLog.debug("codex app-server one-shot cleanup checked shared client retirement", {
       runId: params.runId,
       sessionId: params.sessionId,
@@ -155,7 +153,8 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
       closed: retired.closed,
       matchedSharedClient: retired.found,
     });
-    if (retired.closed) {
+    // Unsafe retirement owns closure; one-shot lease teardown must not join it again.
+    if (retired.closed && !state.startupClientUnsafe) {
       await state.client.closeAndWait({ exitTimeoutMs: 2_000, forceKillDelayMs: 250 });
     }
   };
@@ -168,9 +167,10 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
   };
   const releaseSharedClientLeaseAndRetireOneShotClient = async () => {
     if (connection.attemptClientFactory === createIsolatedCodexAppServerClient) {
-      // Close the authorized node lease first; losing its socket first is a real disconnect.
+      // Release the node lease first; unsafe retirement owns closure and must not be joined again.
       await releaseSandboxExecEnvironment();
-      const ownedClient = state.releaseSharedClientLease ? state.client : undefined;
+      const ownedClient =
+        state.releaseSharedClientLease && !state.startupClientUnsafe ? state.client : undefined;
       releaseSharedClientLeaseOnce();
       await ownedClient?.closeAndWait({ exitTimeoutMs: 2_000, forceKillDelayMs: 250 });
       return;

--- a/extensions/codex/src/app-server/run-attempt-turn-request.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-request.ts
@@ -1,9 +1,5 @@
 import { embeddedAgentLog, formatErrorMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
-  interruptCodexTurnAndWaitBestEffort,
-  retireUnsafeCodexTurnClientBestEffort,
-} from "./attempt-client-cleanup.js";
-import {
   createCodexModelCallDiagnosticEmitter,
   utf8JsonByteLength,
 } from "./attempt-diagnostics.js";
@@ -42,7 +38,7 @@ export async function prepareCodexAttemptTurnRequest(
     appServer,
     runAbortController,
   } = connection;
-  const { state } = turnRuntime;
+  const { state, interruptTurn } = turnRuntime;
   const explicitSkillInputs = await resolveCodexExplicitSkillInputs({
     client: resourceState.client,
     cwd: resourceState.codexExecutionCwd,
@@ -155,13 +151,9 @@ export async function prepareCodexAttemptTurnRequest(
         // Codex serializes start/interrupt per thread; an empty id interrupts
         // the accepted native turn even when local cancellation hid its response.
         try {
-          resourceState.startupClientUnsafe = !(await interruptCodexTurnAndWaitBestEffort(
-            resourceState.client,
-            { threadId: resourceState.thread.threadId, turnId: acceptedTurnId ?? "" },
-          ));
-          if (resourceState.startupClientUnsafe) {
-            await retireUnsafeCodexTurnClientBestEffort(resourceState.client, "startup interrupt");
-          }
+          await interruptTurn(acceptedTurnId ?? "", {
+            operation: "startup interrupt",
+          });
         } finally {
           releaseCurrentRoute();
         }

--- a/extensions/codex/src/app-server/run-attempt-turn-start.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-start.ts
@@ -8,7 +8,7 @@ import {
 import { isIncognitoSessionKey } from "../incognito-session.js";
 import {
   CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
-  closeCodexStartupClientBestEffort,
+  retireUnsafeCodexTurnClientBestEffort,
   unsubscribeCodexThreadBestEffort,
 } from "./attempt-client-cleanup.js";
 import { classifyCodexModelCallFailureKind } from "./attempt-diagnostics.js";
@@ -68,7 +68,7 @@ export async function startCodexAttemptTurn(
     startupAuthProfileId,
     abortFromUpstream,
   } = connection;
-  const { state, turnIdRef } = turnRuntime;
+  const { state } = turnRuntime;
   const { waitForActiveNativeTurnCompletion } = notifications;
   const { codexModelCallDiagnostics, startCodexTurn, buildLlmInputEvent } = requestRuntime;
   let turn: CodexTurnStartResponse | undefined;
@@ -249,12 +249,13 @@ export async function startCodexAttemptTurn(
         });
         if (!released) {
           // Detach the unsafe client before releasing this lease, but let sibling leases finish.
+          resourceState.startupClientUnsafe = true;
           await runAgentCleanupStep({
             runId: params.runId,
             sessionId: params.sessionId,
             step: "codex-retire-unsafe-startup-client",
             log: embeddedAgentLog,
-            cleanup: async () => closeCodexStartupClientBestEffort(resourceState.client),
+            cleanup: () => retireUnsafeCodexTurnClientBestEffort(resourceState.client, "startup"),
           });
         }
       }
@@ -313,16 +314,5 @@ export async function startCodexAttemptTurn(
     await releaseSharedClientLeaseAndRetireOneShotClient();
     throw new Error("codex app-server turn/start failed without an error");
   }
-  const authoritySourceRef = context.attemptTools.scheduledAppAuthoritySourceRef;
-  if (resourceState.thread.pluginAppPolicyContext) {
-    authoritySourceRef.current = {
-      client: resourceState.client,
-      threadId: resourceState.thread.threadId,
-      policyContext: resourceState.thread.pluginAppPolicyContext,
-      configCwd: connection.effectiveCwd,
-    };
-  }
-  turnIdRef.current = turn.turn.id;
-  resourceState.nativeSubagentMonitor?.bindTurn(turn.turn.id);
   return { turn };
 }

--- a/extensions/codex/src/app-server/run-attempt-turn-state.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-state.ts
@@ -2,8 +2,8 @@ import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runti
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import {
   CODEX_APP_SERVER_INTERRUPT_TIMEOUT_MS,
-  closeCodexStartupClientBestEffort,
   interruptCodexTurnAndWaitBestEffort,
+  retireUnsafeCodexTurnClientBestEffort,
 } from "./attempt-client-cleanup.js";
 import { createCodexSteeringQueue } from "./attempt-steering.js";
 import {
@@ -123,7 +123,11 @@ export function createCodexAttemptTurnState(resources: CodexAttemptResources) {
   };
   const interruptTurn = async (
     turnId: string,
-    completionOptions?: { locallyCompleted?: boolean; timeoutMs?: number },
+    completionOptions?: {
+      locallyCompleted?: boolean;
+      operation?: string;
+      timeoutMs?: number;
+    },
   ) => {
     if (completionOptions?.locallyCompleted) {
       state.localCompletionRequested = true;
@@ -134,7 +138,11 @@ export function createCodexAttemptTurnState(resources: CodexAttemptResources) {
       timeoutMs: completionOptions?.timeoutMs,
     });
     if (!completed) {
-      await closeCodexStartupClientBestEffort(resourceState.client);
+      resourceState.startupClientUnsafe = true;
+      await retireUnsafeCodexTurnClientBestEffort(
+        resourceState.client,
+        completionOptions?.operation ?? "turn interrupt",
+      );
     }
     return completed;
   };

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1,8 +1,8 @@
-// Codex plugin module implements run attempt behavior.
+import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { EmbeddedRunAttemptParamsV2 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
 import { activateCodexAttemptTurn } from "./run-attempt-active-turn.js";
-import { cleanupCodexAttempt } from "./run-attempt-cleanup.js";
+import { cleanupCodexAttempt, type CodexAttemptOwnedTurn } from "./run-attempt-cleanup.js";
 import { prepareCodexAttemptConnection } from "./run-attempt-connection.js";
 import { prepareCodexAttemptContext } from "./run-attempt-context.js";
 import { finalizeCodexAttempt } from "./run-attempt-finalize.js";
@@ -58,16 +58,20 @@ export async function runCodexAppServerAttempt(
   if ("result" in turnStart) {
     return turnStart.result;
   }
-  const activeTurn = await activateCodexAttemptTurn(
-    resources,
-    turnRuntime,
-    lifecycle,
-    notifications,
-    turnStart.turn,
-  );
-
+  // turn/start has created native work; own it before activation so failures cannot leak it.
+  let ownedTurn: CodexAttemptOwnedTurn = { phase: "accepted", turnId: turnStart.turn.turn.id };
   let finalizedResult: EmbeddedRunAttemptResult;
   try {
+    const activeTurn = await activateCodexAttemptTurn(
+      resources,
+      turnRuntime,
+      lifecycle,
+      notifications,
+      turnStart.turn,
+    );
+    // Publication can partially acquire handles; cleanup must own the active turn first.
+    ownedTurn = { phase: "activated", activeTurn };
+    activeTurn.publishActiveOwnership();
     finalizedResult = await finalizeCodexAttempt(
       resources,
       turnRuntime,
@@ -76,11 +80,18 @@ export async function runCodexAppServerAttempt(
       turnRequest,
       activeTurn,
     );
-  } finally {
-    await cleanupCodexAttempt(resources, turnRuntime, lifecycle, turnRequest, activeTurn);
+  } catch (error) {
+    await cleanupCodexAttempt(resources, turnRuntime, lifecycle, turnRequest, ownedTurn).catch(
+      (cleanupError: unknown) => {
+        embeddedAgentLog.warn("codex app-server cleanup failed after attempt error", {
+          error: cleanupError,
+        });
+      },
+    );
+    throw error;
   }
-  // Cleanup retires the execution lease; only then can device loss no longer
-  // race the final result captured during asynchronous terminal processing.
+  await cleanupCodexAttempt(resources, turnRuntime, lifecycle, turnRequest, ownedTurn);
+  // Cleanup retires the execution lease before device loss can race the captured final result.
   if (
     resources.state.executionDisconnectError &&
     !connection.terminalState.explicitCancellationObserved

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -8,6 +8,7 @@ export function createExtensionCodexAppServerAttemptExtraVitestConfig(
     [
       "extensions/codex/src/app-server/run-attempt.agent-end-context.test.ts",
       "extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts",
+      "extensions/codex/src/app-server/run-attempt-activation-cleanup.test.ts",
       "extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts",
       "extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts",
       "extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts",


### PR DESCRIPTION
Related: #99271

## What Problem This Solves

Codex can accept `turn/start` and begin native work before OpenClaw finishes activating the local attempt. If activation then fails, the accepted native turn, its route or client ownership, partially published active-run state, and already-projected transcript work must all be reclaimed. Otherwise later work can inherit a contaminated client or a session can remain stuck behind leaked ownership.

## Why This Change Was Made

The attempt now records a closed `accepted | activated` ownership receipt immediately after native acceptance. Cleanup can therefore interrupt the exact accepted turn, wait for its matching terminal, drain serialized notification work, checkpoint any acquired projector, retire an unsafe client, and release route and lease ownership in order. Active ownership is promoted before fallible backend/registry/listener publication, so partial publication is also reclaimable. Existing dynamic-tool, cancellation, background-terminal, thread-retention, and successful-turn cleanup owners remain intact.

This is a bounded accepted-turn repair, not the broader disposer-stack refactor proposed in the issue.

## User Impact

When Codex session setup fails after native acceptance, OpenClaw now stops and reclaims that exact turn instead of leaving hidden work, stale routing, duplicated client joins, or partial session ownership behind. Commentary projected before the failure is durably checkpointed.

## Evidence

- Frozen base: `6b22716a81aa7a00f86933a339adec66bc1702ed`
- Exact PR head: `afe4d2615068c873f10db4a3a697441970c1a85a`
- Causal RED:
  - accepted-turn schedules fail on the frozen base because no post-accept `turn/interrupt` is emitted;
  - removing acquisition-aware checkpointing loses projected commentary;
  - three isolated close-once schedules fail only their one-join assertion on the frozen base (`2`, `3`, `2` calls).
- Exact-head green:
  - focused suite: `9/9`;
  - neighboring cleanup: `14/14`;
  - owner suite: `153/153`;
  - attempt-extra shard: `298/298` across `19` files;
  - Codex extension lane: `201` scheduled files, all `17` batches green;
  - exact eleven-path changed checks and build: passed;
  - production: `+149/-99`, net `+50`; tests/config: `+679/-0`;
  - forbidden-token, suppression, debug, whitespace, and import-cycle scans: clean;
  - autoreview: `scoped-clean`;
  - Standards/Coresee, Spec, and Test Audit: `APPROVE`, zero findings each.
- Current upstream preflight found no drift in the final eleven paths and a clean merge tree.
- Hosted CI: `PENDING`
- Maintainer acceptance: `PENDING`

No product-UI image is offered as causal proof. The deterministic failure occurs inside Codex attempt activation before Control UI active-run projection. Adding a product or configuration seam solely for media would expand the fix. The causal evidence is the exact app-server lifecycle regression test.

## AI Assistance

This change was implemented with AI assistance. The final diff was reviewed against OpenClaw repository rules, Coresee Engineering Conventions, issue #99271, the pinned Codex `0.150.1` source contract, causal pre-fix receipts, exact-head local verification, and independent Standards, Spec, and Test Audit axes. I reviewed and understand the ownership and cleanup behavior described above.
