### PR TITLE
fix(cli): honor profile selection before cached help

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -457,37 +457,29 @@ const resolvePrecomputedCommandHelpByName = (commandName) => {
 
 const resolvePrecomputedCommandHelp = (argv) => {
   const args = argv.slice(2);
-  let commandHelp = null;
-  let sawHelp = false;
-
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
     if (!arg || arg === "--") {
       return null;
     }
-    if (!commandHelp) {
-      const consumed = consumeLauncherRootOptionToken(args, index);
-      if (consumed > 0) {
-        index += consumed - 1;
-        continue;
-      }
-      if (arg.startsWith("-")) {
-        return null;
-      }
-      commandHelp = resolvePrecomputedCommandHelpByName(arg);
-      if (!commandHelp) {
-        return null;
-      }
+    // The runtime entry owns profile validation and config projection before cached help.
+    if (arg === "--dev" || arg === "--profile" || arg.startsWith("--profile=")) {
+      return null;
+    }
+    const consumed = consumeLauncherRootOptionToken(args, index);
+    if (consumed > 0) {
+      index += consumed - 1;
       continue;
     }
-    if (LAUNCHER_HELP_FLAGS.has(arg)) {
-      sawHelp = true;
-      continue;
-    }
-    return null;
+    const commandHelp = resolvePrecomputedCommandHelpByName(arg);
+    const helpFlags = args.slice(index + 1);
+    return commandHelp &&
+      helpFlags.length > 0 &&
+      helpFlags.every((flag) => LAUNCHER_HELP_FLAGS.has(flag))
+      ? commandHelp
+      : null;
   }
-
-  return commandHelp && sawHelp ? commandHelp : null;
+  return null;
 };
 
 const isHelpFastPathDisabled = () =>

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -454,7 +454,7 @@ describe("openclaw launcher", () => {
 
     const result = spawnSync(
       process.execPath,
-      [path.join(fixtureRoot, "openclaw.mjs"), "--profile", "work", "--no-color", "models", "-h"],
+      [path.join(fixtureRoot, "openclaw.mjs"), "--log-level", "warn", "--no-color", "models", "-h"],
       {
         cwd: fixtureRoot,
         env: launcherEnv(),
@@ -464,6 +464,43 @@ describe("openclaw launcher", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toBe("PRECOMPUTED models help\n");
+  });
+
+  it.each(
+    [
+      ["--profile", "work", "nodes", "--help"],
+      ["--profile=work", "nodes", "--help"],
+      ["--dev", "nodes", "--help"],
+      ["--profile", "default", "models", "--help"],
+      ["--profile=", "models", "--help"],
+      ["--profile", "bad profile", "models", "--help"],
+      ["--dev", "--profile", "work", "models", "--help"],
+      ["--profile", "work", "--dev", "models", "--help"],
+    ].map((args) => ({ args, invocation: args.join(" ") })),
+  )("passes profile selection to the runtime before cached help: $invocation", async ({ args }) => {
+    const fixtureRoot = await makeLauncherFixture(fixtureRoots);
+    await fs.writeFile(
+      path.join(fixtureRoot, "dist", "cli-startup-metadata.json"),
+      JSON.stringify({
+        nodesHelpText: "PRECOMPUTED nodes help\n",
+        subcommandHelpText: { models: "PRECOMPUTED models help\n" },
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(fixtureRoot, "dist", "entry.js"),
+      "process.stdout.write(JSON.stringify(process.argv.slice(2)));\n",
+      "utf8",
+    );
+
+    const result = spawnSync(process.execPath, [path.join(fixtureRoot, "openclaw.mjs"), ...args], {
+      cwd: fixtureRoot,
+      env: launcherEnv(),
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe(JSON.stringify(args));
   });
 
   it("defers precomputed subcommand help to the runtime entry when container env is set", async () => {


### PR DESCRIPTION
Closes #133145

## What Problem This Solves

Fixes an issue where users requesting help with a leading `--profile` or `--dev` selector would see cached commands from the wrong profile. For example, `openclaw --profile work nodes --help` advertised Canvas even when that profile disabled it, while the same selector after the command worked. Invalid or conflicting leading selectors also returned successful cached help instead of their normal errors.

## Why This Change Was Made

Profile validation and environment projection remain owned by the runtime entry. The launcher now delegates profile-bearing help to that existing flow before choosing cached output. Its help recognizer uses one leading-option scan and one help-only tail check, removing the parallel command/help state without changing the shared Gmail option parser.

## User Impact

Help reflects the selected profile's plugin availability, and malformed profile selections retain their normal diagnostics and exit status. Bare help, version, and passive root-option fast paths remain available. No configuration, dependency, persistent-state, protocol, or plugin SDK contract changes are introduced.

## Evidence

- Baseline package from `3f1c84c706bf1e4c8bc7b2ab106ab96ff1fe6ddb` built with the repository packer and installed with npm in a clean isolated Linux Testbox prefix/home. Eight cases reproduced stale plugin help or swallowed selector errors. Distinct custom config/state overrides and default/trailing-selector controls were checked separately.
- New launcher boundary regression: all eight cases failed before the repair because cached text bypassed the runtime entry.
- Final launcher and version files: 64 tests passed; one existing Bun-specific test was unavailable/skipped. Command: `node scripts/run-vitest.mjs test/openclaw-launcher.e2e.test.ts test/openclaw-launcher-version.e2e.test.ts`.
- Full `check:changed` passed all 24 stages on the exact committed head, including all production/test type checks, full lint, repository guards, and zero runtime import cycles. Targeted lint, formatting, JavaScript syntax, and whitespace checks also passed. Fresh autoreview reported scoped-clean; independent source review confirmed the canonical ownership boundary and unchanged sibling grammar.
- Production delta: +14/-22, net **-8** lines. Test delta: +38/-1.

- Final clean committed-ref package proof passed on Blacksmith Testbox: [run 33298420827](https://github.com/openclaw/openclaw/actions/runs/33298420827). The repository packer built and validated the tarball, npm installed it into a fresh prefix/home, and all 17 assertions passed: default/root help, named/default/dev selection, trailing selection, inherited canonical paths, distinct custom config/state overrides, static help, invalid/conflicting selectors, and version. Source HEAD and packaged build commit both equal `bf7364077f48366c3008b6634af2c3b3afd8c318`; source and installed launcher hashes match. Tarball SHA-256: `4c26f3304bddcf804aa7cc8f514b7a7b2c4dd8f18241f7c33faabbfe16948520`. The owned testbox was stopped after evidence collection.

Provenance: the defect is reachable in stable tag `v2026.7.1-2`; its introducing commit is unknown because available history is shallow. A separately observed environment-only `OPENCLAW_PROFILE` projection mismatch is outside this repair; this PR does not claim to fix it.

Hosted integration CI is now green; native landing gates remain. The original [CI run](https://github.com/openclaw/openclaw/actions/runs/33298546134) failed on an unrelated missing Code Mode metadata export in main. A subsequent draft-to-ready run reused that old merge tree, as verified from its actual preflight checkout; cancellation was requested for that obsolete run. The mechanical refresh is now `ad92a490ce2a9b2b17978608e4f7ca86b329c803`, directly based on the canonical repair `be5e79ca4713c33a11ccd56b2d728c19f0779f3d`. The source/test patch ID and both file blobs match the package-tested commit; the relevant entry/profile/config-owner files are also unchanged. Fresh exact-commit autoreview is clean. [New integration CI](https://github.com/openclaw/openclaw/actions/runs/33300057583) actually checked out merge `03290e3a3659a2b7bdc3438b4c9896d6618a2894`, whose parents include this refreshed head, so the repaired ancestry is verified. The full check watcher completed successfully with zero pending or failing checks. Native review, prepare, and merge gates remain before landing.

Suggested release note: CLI: honor profile and development selection before cached command help so plugin availability and selector errors match the normal runtime.

Latest ClawSweeper disposition: the exact-head review found no code or security findings and accepted the installed-package proof. Its incomplete-CI item is resolved by the green integration run; the linked issue remains open until this PR lands.
