### PR TITLE
perf(markdown): reduce CPU work in streamed and chunked replies

### DIFF
--- a/docs/concepts/markdown-formatting.md
+++ b/docs/concepts/markdown-formatting.md
@@ -20,18 +20,21 @@ splits formatting mid-span.
    ranges align with its API directly. Tables parse only when the channel
    opts into a table mode.
 2. **Chunk the IR** (`chunkMarkdownIR` / `renderMarkdownIRChunksWithinLimit`)
-   - splitting happens on IR text before rendering, so inline styles and
-     links are sliced per chunk instead of breaking across a boundary.
+   - style and link spans are sliced with the text. The rendered-size chunker
+     measures each candidate after channel escaping and link rewriting, and
+     returns the accepted source slice together with its rendered payload.
 3. **Render per channel** (`renderMarkdownWithMarkers`) - a style-marker map
    turns spans into the channel's native markup.
 
-| Channel                                                          | Renderer                                                                             | Notes                                                                                    |
-| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| Matrix                                                           | HTML tags, including native tables                                                   | Automatic replies, direct sends, and media captions use the same formatter               |
-| Slack                                                            | mrkdwn tokens (`*bold*`, `_italic_`, `` `code` ``, code fences)                      | Links become `<url\|label>`; autolink disabled during parse to avoid double-linking      |
-| Telegram                                                         | HTML tags (`<b>`, `<i>`, `<s>`, `<code>`, `<pre><code>`, `<a href>`, `<tg-spoiler>`) | Also supports rich-message tables and headings (`<h1>`-`<h6>`) when `richMessages` is on |
-| Signal                                                           | plain text + `text-style` ranges                                                     | Links render as `label (url)` when the label differs from the URL                        |
-| Discord, WhatsApp, iMessage, Microsoft Teams, and other channels | plain text                                                                           | No IR-based styling; Markdown table conversion still runs via `convertMarkdownTables`    |
+Examples of shared IR renderers:
+
+| Channel  | Renderer                                                                             | Notes                                                                                    |
+| -------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| Matrix   | HTML tags, including native tables                                                   | Automatic replies, direct sends, and media captions use the same formatter               |
+| Signal   | plain text + `text-style` ranges                                                     | Links render as `label (url)` when the label differs from the URL                        |
+| Slack    | mrkdwn tokens (`*bold*`, `_italic_`, `` `code` ``, code fences)                      | Links become `<url\|label>`; autolink disabled during parse to avoid double-linking      |
+| Telegram | HTML tags (`<b>`, `<i>`, `<s>`, `<code>`, `<pre><code>`, `<a href>`, `<tg-spoiler>`) | Also supports rich-message tables and headings (`<h1>`-`<h6>`) when `richMessages` is on |
+| WhatsApp | WhatsApp style markers                                                               | Uses shared IR; styled chunks are measured after rendering                               |
 
 ## IR example
 
@@ -82,8 +85,9 @@ channels:
 
 ## Chunking rules
 
-- Chunk limits come from channel adapters/config and apply to IR text, not
-  rendered output.
+- Chunk limits come from channel adapters/config. `chunkMarkdownIR` limits IR
+  text; `renderMarkdownIRChunksWithinLimit` measures the final payload in the
+  transport's size unit, including escaping and rewritten links.
 - Fenced code blocks are kept as one block with a trailing newline so
   channels render the closing fence correctly.
 - List and blockquote prefixes are part of the IR text, so chunking never
@@ -123,7 +127,8 @@ content is hidden or lost.
 2. **Render** with `renderMarkdownWithMarkers(...)` and a style-marker map (or
    custom style-range logic for transports like Signal).
 3. **Chunk** with `chunkMarkdownIR(...)` or
-   `renderMarkdownIRChunksWithinLimit(...)` before rendering each chunk.
+   `renderMarkdownIRChunksWithinLimit(...)`. The latter returns the measured
+   `rendered` payload; use it directly instead of rendering the source again.
 4. **Wire the adapter** to call the new chunker and renderer from the
    outbound send path.
 5. **Test** with format tests plus an outbound delivery test if the channel

--- a/packages/markdown-core/src/code-spans.ts
+++ b/packages/markdown-core/src/code-spans.ts
@@ -63,10 +63,14 @@ function parseInlineCodeSpans(
   let openStart = open ? 0 : -1;
 
   let i = 0;
+  // The scanner emits ordered, disjoint fences and the input cursor only advances.
+  // Retire each fence once instead of searching all prior fences at every character.
+  let fenceIndex = 0;
   while (i < text.length) {
-    const fence = findFenceSpanAtInclusive(fenceSpans, i);
-    if (fence) {
+    const fence = fenceSpans[fenceIndex];
+    if (fence && i >= fence.start) {
       i = fence.end;
+      fenceIndex += 1;
       continue;
     }
 
@@ -105,10 +109,6 @@ function parseInlineCodeSpans(
     spans,
     state: { open, ticks },
   };
-}
-
-function findFenceSpanAtInclusive(spans: FenceSpan[], index: number): FenceSpan | undefined {
-  return spans.find((span) => index >= span.start && index < span.end);
 }
 
 function isInsideFenceSpan(index: number, spans: FenceSpan[]): boolean {

--- a/packages/markdown-core/src/render-aware-chunking.test.ts
+++ b/packages/markdown-core/src/render-aware-chunking.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import type { MarkdownIR } from "./ir.js";
 import { markdownToIR } from "./ir.js";
+import { renderMarkdownWithAttributedRanges } from "./render-attributed.js";
 import { renderMarkdownIRChunksWithinLimit } from "./render-aware-chunking.js";
 import { renderMarkdownWithMarkers } from "./render.js";
 
@@ -96,6 +97,36 @@ describe("renderMarkdownIRChunksWithinLimit", () => {
 
     expect(chunks.map((chunk) => chunk.source.text)).toEqual(["a", "b", "c"]);
     expect(chunks.every((chunk) => chunk.rendered.length <= 1)).toBe(true);
+  });
+
+  it("drops temporary boundary annotations when whitespace is coalesced", () => {
+    const chunks = renderMarkdownIRChunksWithinLimit({
+      ir: {
+        text: `alpha${" ".repeat(19)}\nuser[t] ok`,
+        styles: [],
+        links: [{ start: 25, end: 32, href: "https://example.test" }],
+      },
+      limit: 20,
+      assistantTranscriptRoleMessageBoundaries: true,
+      renderChunk: (source) => ({
+        source,
+        ...renderMarkdownWithAttributedRanges(source, {
+          styleMap: {},
+          annotationStyleMap: { assistant_transcript_role: "MONOSPACE" },
+        }),
+      }),
+      measureRendered: (rendered) => rendered.text.length,
+    });
+
+    expect(chunks.map((chunk) => chunk.rendered.text)).toEqual([
+      `alpha${" ".repeat(15)}`,
+      "    \nuser[t] ok",
+    ]);
+    const final = chunks[1];
+    expect(final?.source.annotations).toBeUndefined();
+    expect(final?.source.links).toEqual([{ start: 5, end: 12, href: "https://example.test" }]);
+    expect(final?.rendered.ranges).toEqual([]);
+    expect(final?.rendered.source).toBe(final?.source);
   });
 
   it("keeps astral characters whole when a positive limit reaches their pair", () => {

--- a/packages/markdown-core/src/render-aware-chunking.ts
+++ b/packages/markdown-core/src/render-aware-chunking.ts
@@ -37,6 +37,11 @@ export type RenderMarkdownIRChunksWithinLimitOptions<TRendered> = {
   assistantTranscriptRoleMessageBoundaries?: boolean;
 };
 
+type RenderedCandidate<TRendered> = {
+  rawSource: MarkdownIR;
+  output: RenderedMarkdownChunk<TRendered>;
+};
+
 type RenderResolver<TRendered> = Pick<
   RenderMarkdownIRChunksWithinLimitOptions<TRendered>,
   "measureRendered" | "renderChunk"
@@ -49,6 +54,14 @@ function prepareChunkForMessageBoundary<TRendered>(
   return options.assistantTranscriptRoleMessageBoundaries === true
     ? annotateAssistantTranscriptRoleMessageBoundary(chunk)
     : chunk;
+}
+
+function renderCandidate<TRendered>(
+  options: RenderMarkdownIRChunksWithinLimitOptions<TRendered>,
+  rawSource: MarkdownIR,
+): RenderedCandidate<TRendered> {
+  const source = prepareChunkForMessageBoundary(options, rawSource);
+  return { rawSource, output: { source, rendered: options.renderChunk(source) } };
 }
 
 /** Chunks Markdown IR by rendered size while preserving styles, links, and whitespace. */
@@ -76,7 +89,7 @@ export function renderMarkdownIRChunksWithinLimit<TRendered>(
   // The initial reverse keeps the final order stable while avoiding shift/unshift
   // moving every remaining chunk for long messages.
   const pending = splitMarkdownIRPreserveWhitespace(options.ir, normalizedLimit).toReversed();
-  const finalized: MarkdownIR[] = [];
+  const finalized: RenderedCandidate<TRendered>[] = [];
 
   while (pending.length > 0) {
     const chunk = pending.pop();
@@ -84,16 +97,19 @@ export function renderMarkdownIRChunksWithinLimit<TRendered>(
       continue;
     }
 
-    const rendered = renderResolver.renderChunk(chunk);
-    if (renderResolver.measureRendered(rendered) <= normalizedLimit || chunk.text.length <= 1) {
-      finalized.push(chunk);
+    const candidate = renderCandidate(options, chunk);
+    if (
+      options.measureRendered(candidate.output.rendered) <= normalizedLimit ||
+      chunk.text.length <= 1
+    ) {
+      finalized.push(candidate);
       continue;
     }
 
     const split = splitMarkdownIRByRenderedLimit(chunk, normalizedLimit, renderResolver);
     if (split.length <= 1) {
       // Worst-case safety: avoid retry loops and keep the original chunk.
-      finalized.push(chunk);
+      finalized.push(candidate);
       continue;
     }
     for (let index = split.length - 1; index >= 0; index -= 1) {
@@ -104,11 +120,8 @@ export function renderMarkdownIRChunksWithinLimit<TRendered>(
     }
   }
 
-  return coalesceWhitespaceOnlyMarkdownIRChunks(finalized, normalizedLimit, renderResolver).map(
-    (chunk) => {
-      const source = prepareChunkForMessageBoundary(options, chunk);
-      return { source, rendered: options.renderChunk(source) };
-    },
+  return coalesceWhitespaceOnlyMarkdownIRChunks(finalized, normalizedLimit, options).map(
+    (chunk) => chunk.output,
   );
 }
 
@@ -337,11 +350,11 @@ function mergeMarkdownIRChunks(left: MarkdownIR, right: MarkdownIR): MarkdownIR 
 }
 
 function coalesceWhitespaceOnlyMarkdownIRChunks<TRendered>(
-  chunks: MarkdownIR[],
+  chunks: RenderedCandidate<TRendered>[],
   renderedLimit: number,
-  options: RenderResolver<TRendered>,
-): MarkdownIR[] {
-  const coalesced: MarkdownIR[] = [];
+  options: RenderMarkdownIRChunksWithinLimitOptions<TRendered>,
+): RenderedCandidate<TRendered>[] {
+  const coalesced: RenderedCandidate<TRendered>[] = [];
   let index = 0;
 
   while (index < chunks.length) {
@@ -350,7 +363,7 @@ function coalesceWhitespaceOnlyMarkdownIRChunks<TRendered>(
       index += 1;
       continue;
     }
-    if (chunk.text.trim().length > 0) {
+    if (chunk.rawSource.text.trim().length > 0) {
       coalesced.push(chunk);
       index += 1;
       continue;
@@ -358,14 +371,20 @@ function coalesceWhitespaceOnlyMarkdownIRChunks<TRendered>(
 
     const prev = coalesced.at(-1);
     const next = chunks[index + 1];
-    const chunkLength = chunk.text.length;
+    const chunkLength = chunk.rawSource.text.length;
 
-    const canMerge = (candidate: MarkdownIR) =>
-      options.measureRendered(options.renderChunk(candidate)) <= renderedLimit;
+    // Keep raw IR for merges: a new boundary annotation may no longer apply
+    // after whitespace joins neighbors. Retain the exact measured output pair.
+    const renderIfFits = (source: MarkdownIR) => {
+      const candidate = renderCandidate(options, source);
+      return options.measureRendered(candidate.output.rendered) <= renderedLimit
+        ? candidate
+        : undefined;
+    };
 
     if (prev) {
-      const mergedPrev = mergeMarkdownIRChunks(prev, chunk);
-      if (canMerge(mergedPrev)) {
+      const mergedPrev = renderIfFits(mergeMarkdownIRChunks(prev.rawSource, chunk.rawSource));
+      if (mergedPrev) {
         coalesced[coalesced.length - 1] = mergedPrev;
         index += 1;
         continue;
@@ -373,8 +392,8 @@ function coalesceWhitespaceOnlyMarkdownIRChunks<TRendered>(
     }
 
     if (next) {
-      const mergedNext = mergeMarkdownIRChunks(chunk, next);
-      if (canMerge(mergedNext)) {
+      const mergedNext = renderIfFits(mergeMarkdownIRChunks(chunk.rawSource, next.rawSource));
+      if (mergedNext) {
         chunks[index + 1] = mergedNext;
         index += 1;
         continue;
@@ -385,11 +404,12 @@ function coalesceWhitespaceOnlyMarkdownIRChunks<TRendered>(
       // Split pure whitespace between neighbors before dropping it so list,
       // paragraph, and quote spacing survives when both sides still fit.
       for (let prefixLength = chunkLength - 1; prefixLength >= 1; prefixLength -= 1) {
-        const prefix = sliceMarkdownIR(chunk, 0, prefixLength);
-        const suffix = sliceMarkdownIR(chunk, prefixLength, chunkLength);
-        const mergedPrev = mergeMarkdownIRChunks(prev, prefix);
-        const mergedNext = mergeMarkdownIRChunks(suffix, next);
-        if (canMerge(mergedPrev) && canMerge(mergedNext)) {
+        const prefix = sliceMarkdownIR(chunk.rawSource, 0, prefixLength);
+        const suffix = sliceMarkdownIR(chunk.rawSource, prefixLength, chunkLength);
+        const mergedPrev = renderIfFits(mergeMarkdownIRChunks(prev.rawSource, prefix));
+        const mergedNext =
+          mergedPrev && renderIfFits(mergeMarkdownIRChunks(suffix, next.rawSource));
+        if (mergedPrev && mergedNext) {
           coalesced[coalesced.length - 1] = mergedPrev;
           chunks[index + 1] = mergedNext;
           break;

--- a/src/agents/embedded-agent-subscribe.stream-rendering.ts
+++ b/src/agents/embedded-agent-subscribe.stream-rendering.ts
@@ -156,7 +156,10 @@ export function createStreamRendering({
     if (!scanText) {
       return "";
     }
-    const codeSpans = buildCodeSpanIndex(scanText, inlineStateStart, fenceStateStart);
+    const codeSpans =
+      scanText === fenceInput
+        ? initialCodeSpans
+        : buildCodeSpanIndex(scanText, inlineStateStart, fenceStateStart);
 
     let processed = "";
     THINKING_TAG_SCAN_RE.lastIndex = 0;
@@ -253,7 +256,10 @@ export function createStreamRendering({
     // If enforcement is disabled, we still strip the tags themselves to prevent
     // hallucinations (e.g. Minimax copying the style) from leaking, but we
     // do not enforce buffering/extraction logic.
-    const finalCodeSpans = buildCodeSpanIndex(processed, inlineStateStart, fenceStateStart);
+    const finalCodeSpans =
+      processed === scanText
+        ? codeSpans
+        : buildCodeSpanIndex(processed, inlineStateStart, fenceStateStart);
     if (!params.enforceFinalTag) {
       stateLocal.inlineCode = finalCodeSpans.inlineState;
       stateLocal.fence = finalCodeSpans.fenceState;

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -1,4 +1,3 @@
-import { expectDefined } from "@openclaw/normalization-core";
 import {
   scanReasoningTags,
   stripReasoningTagsFromMarkdown,
@@ -52,23 +51,16 @@ export function stripReasoningTagsFromText(
     return text;
   }
   if (matches.length > 0) {
-    const finalMatches: Array<{ start: number; length: number; inCode: boolean }> = [];
     const preCodeRegions = findCodeRegions(cleaned);
+    let visible = "";
+    let lastIndex = 0;
     for (const match of matches) {
-      const start = match.index;
-      finalMatches.push({
-        start,
-        length: match.text.length,
-        inCode: isInsideCode(start, preCodeRegions),
-      });
-    }
-
-    for (let i = finalMatches.length - 1; i >= 0; i--) {
-      const m = expectDefined(finalMatches[i], "final matches capture group i");
-      if (!m.inCode) {
-        cleaned = cleaned.slice(0, m.start) + cleaned.slice(m.start + m.length);
+      if (!isInsideCode(match.index, preCodeRegions)) {
+        visible += cleaned.slice(lastIndex, match.index);
+        lastIndex = match.index + match.text.length;
       }
     }
+    cleaned = visible + cleaned.slice(lastIndex);
   }
 
   return applyTrim(stripReasoningTagsFromMarkdown(cleaned, { mode, scope }), trimMode);


### PR DESCRIPTION
## What Problem This Solves

Streamed replies and channel-sized Markdown chunks repeat parsing and rendering work. Code-heavy replies scan earlier fences at every character, unchanged text is indexed several times within one tag-filter call, accepted chunks are rendered again before delivery, and final-tag cleanup repeatedly copies the changing string.

## Why This Change Was Made

Keep the existing parsing, rendering, and transport boundaries while carrying their prepared results forward:

- Advance once through the scanner's ordered, disjoint fences.
- Reuse a code index only for identical text and unchanged starting state within the same streaming call.
- Retain accepted rendered payloads with the exact source that produced them. Whitespace merging uses raw IR so temporary message-boundary annotations cannot survive after they stop applying.
- Assemble final-tag output once using the original tag offsets and code-region decisions.

No cross-call cache, provider policy, schema, configuration, persistence, or protocol change. The Markdown guide now distinguishes source-text and rendered-payload limits and removes an obsolete blanket claim about channels without IR styling.

## User Impact

The same visible text, formatting, links, and streaming state require less CPU work. Exact nonmonotonic rendered-size search, surrogate boundaries, whitespace behavior, single-character escape behavior, and the uncapped path are preserved.

Production LOC: +67/−49 (net +18). Tests: +31. Docs: +17/−12. The growth retains the raw/prepared source distinction and measured payload through coalescing; it does not add a persistent cache or a second rendering policy.

## Evidence

Paired, uninstrumented Node 26.8.1 measurements in two fresh processes with opposite starting orders; all raw samples and source hashes retained locally. Baseline owner source is `3afccb4e7f4bf5ef9737adb1edda2f3461d8dd58`; the affected Markdown/shared-text/subscriber sources were unchanged when integrated onto `357078cf7087534443dac92eb86e8aa32abb7b08`.

| Workload | Before | After |
| --- | ---: | ---: |
| Short plain streaming chunk | 1.72–1.74 µs | 0.64–0.65 µs |
| 1,000 plain streaming deltas | 1.161–1.162 ms | 0.583–0.586 ms |
| 10 KB reply with 64 fences | 1.071–1.081 ms | 0.0535–0.0537 ms |
| Short escaped-marker chunk rendering | 4.27–4.31 µs | 2.24–2.32 µs |
| Final-tag cleanup, 256 fragments / 20 KB | 0.593–0.615 ms | 0.202–0.203 ms |

Long plain rendering and overflow-heavy marker rendering are effectively unchanged. Empty streaming controls vary by a few nanoseconds. These are owner-level measurements, not a claim about provider/network latency or a memory reduction.

- Streaming differential: 5,740 scanner-state cases, 537,560 position checks, and 182,420 chunk transitions across 5,692 scenarios; exact output and carried state matched across both isolated optimizations and their combination.
- Rendering differential: 8,000 cases and 18,658 source-identity checks. Six real header-promotion/whitespace-demotion witnesses restore links and reject six prepared-source merge mutants. An initial plain-role-label fixture did not exercise the header grammar; that gap was corrected, and its old timing remains only an ordinary text control.
- Final-tag differential: 3,216 cases in each fresh process, covering strict/preserve, trim/scope, code literals, malformed tags, and mixed syntax.
- 363 unique tests passed across 16 owner/subscriber/channel files, including SMS, Signal, Google Chat, Slack, Telegram, and WhatsApp. The new durable test protects final text, restored links, attributed ranges, and exact source identity without asserting intermediate render calls.
- Changed production and test/docs gates passed, including core and test typechecks, lint, import-cycle/boundary guards, and dead exports. MDX, internal links, and glossary checks passed.
- Independent source reviews and fresh automated Codex review completed with no accepted findings at the configured P0 threshold. The reviewers' concrete header-proof gap was addressed before publication.

The fresh candidate build at `dae9afedf9d70617410d8abb394be5874277eb16` passed in 166.97 seconds. Its isolated real-OpenAI Gateway completed READY, sessions_list, web_fetch, and native web search; all 30 assertions across 14 read-only RPCs passed, including exact baseline titles/previews, tool inventories, and model catalog. CPU profiles and terminal/tool receipts were retained. These live timings are observational and do not establish a provider/network latency improvement.

A fifth live literal-tag check failed: final delivery removes `<final>` inside a code fence even though the raw assistant answer retains it. The delivery sanitizer and final-tag helper are byte-identical to the pre-PR baseline, and an actual-owner replay reproduces the loss. Named follow-up: preserve literal final tags through the final delivery sanitizer. This PR does not claim that existing behavior is fixed.

ClawSweeper’s current-main/latest-review refresh request was completed: all six touched files remain unchanged on main `41dccabf179` relative to the recorded base, and the latest review has no concrete source finding. The first hosted run inherited main’s stale side-effect-owner import. [#133155](https://github.com/openclaw/openclaw/pull/133155) is now merged as `be5e79ca4713c33a11ccd56b2d728c19f0779f3d`. The PR was rebased onto that repair as `576a7a2dfaebd511df00ffef6366e9acdb748de2`; its complete six-file patch is byte-identical to the locally tested/live-tested head above. Fresh exact-head CI is [run 33299554989](https://github.com/openclaw/openclaw/actions/runs/33299554989); landing remains gated on its result.


The current head `576a7a2dfaebd511df00ffef6366e9acdb748de2` has green exact-head CI ([run 33299554989](https://github.com/openclaw/openclaw/actions/runs/33299554989)). The refreshed ClawSweeper review found no actionable defect; its rank-up request to finish checks and obtain maintainer acceptance is satisfied. Accepted for landing under the maintainer-authorized performance campaign. Native prepare gates passed.
