### PR TITLE
fix(gateway): name root-request holders in active-work drain diagnostics

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -1540,7 +1540,7 @@ export async function processGatewayAllowlist(
           // Suspension must observe one side of this handoff at every instant.
           markBackgrounded(run.session);
           return { status: "started" as const, run };
-        });
+        }, "exec-host:approval");
       } catch (error) {
         if (
           error instanceof GatewayDrainingError ||

--- a/src/agents/embedded-agent-runner/compaction-successor.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor.ts
@@ -335,7 +335,7 @@ function emitCompactionSessionLifecycleHooks(params: {
     });
     void runWithGatewayIndependentRootWorkContinuation(async () => {
       await hookRunner.runSessionEnd(payload.event, payload.context);
-    }).catch((error: unknown) => {
+    }, "hooks:session-end").catch((error: unknown) => {
       logVerbose(`session_end hook failed: ${String(error)}`);
     });
   }
@@ -348,7 +348,7 @@ function emitCompactionSessionLifecycleHooks(params: {
     });
     void runWithGatewayIndependentRootWorkContinuation(async () => {
       await hookRunner.runSessionStart(payload.event, payload.context);
-    }).catch((error: unknown) => {
+    }, "hooks:session-start").catch((error: unknown) => {
       logVerbose(`session_start hook failed: ${String(error)}`);
     });
   }

--- a/src/agents/main-session-recovery/main-session-restart-recovery-runtime.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-runtime.ts
@@ -229,7 +229,7 @@ export function scheduleRestartAbortedMainSessionRecoveryAfterOwnerRelease(param
         storePath: params.storePath,
         gatewayRuntime,
       });
-    });
+    }, "main-session:restart-recovery");
   void runRecoveryRetries({
     initialDelayMs: 0,
     maxRetries: params.maxRetries ?? MAX_RECOVERY_RETRIES,
@@ -309,27 +309,29 @@ export function scheduleRestartAbortedMainSessionRecovery(params: {
         shouldContinue,
         gatewayRuntime: params.gatewayRuntime,
       });
-    });
+    }, "main-session:startup-recovery");
   };
   const reconcileExhaustedTargets = async (targets: Iterable<ExhaustedRestartRecoveryTarget>) => {
     const outcomes = await Promise.allSettled(
       [...targets].map((target) =>
-        runWithGatewayIndependentRootWorkAdmission(async () =>
-          recoverExpectedRestartRecovery({
-            cfg: params.getConfig(),
-            expectedTarget: {
-              canonicalSessionKey: target.canonicalSessionKey,
-              sessionId: target.sessionId,
+        runWithGatewayIndependentRootWorkAdmission(
+          async () =>
+            recoverExpectedRestartRecovery({
+              cfg: params.getConfig(),
+              expectedTarget: {
+                canonicalSessionKey: target.canonicalSessionKey,
+                sessionId: target.sessionId,
+                sessionKey: target.sessionKey,
+              },
+              lifecycleGeneration,
+              observationOnly: true,
               sessionKey: target.sessionKey,
-            },
-            lifecycleGeneration,
-            observationOnly: true,
-            sessionKey: target.sessionKey,
-            shouldContinue,
-            storePath: target.storePath,
-            stateDir: params.stateDir,
-            gatewayRuntime: params.gatewayRuntime,
-          }),
+              shouldContinue,
+              storePath: target.storePath,
+              stateDir: params.stateDir,
+              gatewayRuntime: params.gatewayRuntime,
+            }),
+          "main-session:target-recovery",
         ),
       ),
     );

--- a/src/agents/subagents/registry/subagent-registry-completion-runtime.ts
+++ b/src/agents/subagents/registry/subagent-registry-completion-runtime.ts
@@ -107,7 +107,7 @@ export function createSubagentRegistryCompletionRuntime(config: {
     try {
       await runWithGatewayIndependentRootWorkContinuation(async () => {
         await completeSubagentRunWithRecoveryAttempt(params, source);
-      });
+      }, "subagents:completion");
     } catch (error) {
       if (!isGatewayRestartDraining()) {
         throw error;

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-cleanup.ts
@@ -51,8 +51,8 @@ type BrowserCleanup = typeof cleanupBrowserSessionsForLifecycleEnd;
 function runWithSubagentCleanupWorkAdmission<T>(run: () => Promise<T>): Promise<T> {
   // Restart remains one-way; only suspension preserves an admitted cleanup owner.
   return isGatewayRestartDraining()
-    ? runWithGatewayIndependentRootWorkAdmission(run)
-    : runWithGatewayIndependentRootWorkContinuation(run);
+    ? runWithGatewayIndependentRootWorkAdmission(run, "subagents:lifecycle-cleanup")
+    : runWithGatewayIndependentRootWorkContinuation(run, "subagents:lifecycle-cleanup");
 }
 
 export function scheduleResumeSubagentRun(
@@ -80,7 +80,7 @@ export function scheduleResumeSubagentRun(
       }
       params.resumedRuns.delete(runId);
       params.resumeSubagentRun(runId);
-    }).catch((err: unknown) => {
+    }, "subagents:resume").catch((err: unknown) => {
       defaultRuntime.log(`[warn] subagent cleanup resume failed (${runId}): ${String(err)}`);
       const current = params.runs.get(runId);
       if (

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-wake.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-wake.ts
@@ -340,16 +340,18 @@ export function scheduleRequesterSettleWake(
   // Wake turns outlive their spawning attempt; clear its owner before both
   // dispatch and chained re-arms so transcript writes acquire a fresh lock.
   runWithoutOwnedSessionTranscriptWrites(() => {
-    void runWithGatewayIndependentRootWorkContinuation(() =>
-      params.maybeWakeRequesterAfterAllChildrenSettled({
-        requesterSessionKey,
-        requesterOrigin: entry.requesterOrigin,
-        settledEntry: entry,
-        transitionBatch: (runIds, state) =>
-          transitionRequesterSettleWakeBatch(context, runIds, state),
-        completeBatch: (runIds, rearmGeneration, outcome) =>
-          completeRequesterSettleWakeBatch(context, runIds, rearmGeneration, outcome),
-      }),
+    void runWithGatewayIndependentRootWorkContinuation(
+      () =>
+        params.maybeWakeRequesterAfterAllChildrenSettled({
+          requesterSessionKey,
+          requesterOrigin: entry.requesterOrigin,
+          settledEntry: entry,
+          transitionBatch: (runIds, state) =>
+            transitionRequesterSettleWakeBatch(context, runIds, state),
+          completeBatch: (runIds, rearmGeneration, outcome) =>
+            completeRequesterSettleWakeBatch(context, runIds, rearmGeneration, outcome),
+        }),
+      "subagents:lifecycle-wake",
     )
       .catch((error: unknown) => {
         params.warn("requester settle wake failed", {
@@ -385,11 +387,13 @@ export function completeCleanupBookkeeping(
   const runCleanupTail = (label: string, run: () => Promise<unknown>) => {
     // These best-effort tails can outlive the durable registry transition,
     // but they still mutate session-owned resources and must block snapshots.
-    void runWithGatewayIndependentRootWorkAdmission(run).catch((error: unknown) => {
-      defaultRuntime.log(
-        `[warn] subagent ${label} failed (${cleanupParams.runId}): ${String(error)}`,
-      );
-    });
+    void runWithGatewayIndependentRootWorkAdmission(run, "subagents:lifecycle-cleanup").catch(
+      (error: unknown) => {
+        defaultRuntime.log(
+          `[warn] subagent ${label} failed (${cleanupParams.runId}): ${String(error)}`,
+        );
+      },
+    );
   };
   const scheduleCleanupTails = (options: {
     allowRetiredRow: boolean;

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.ts
@@ -165,7 +165,7 @@ export class SubagentLifecycleController {
     // Callers can detach while retaining parent ALS, so nesting is intentional.
     await runWithGatewayIndependentRootWorkContinuation(async () => {
       await completeSubagentRunAttempt(this, completeParams);
-    });
+    }, "subagents:lifecycle-complete");
   };
 
   completeCleanupBookkeeping = (params: CleanupBookkeepingParams) => {

--- a/src/agents/subagents/registry/subagent-registry-listener.ts
+++ b/src/agents/subagents/registry/subagent-registry-listener.ts
@@ -55,7 +55,7 @@ export function createSubagentRegistryListener(config: {
             // terminal. Keep capture + persistence inside the suspension fence.
             await runWithGatewayIndependentRootWorkAdmission(async () => {
               await refreshFrozenResultFromSession(sessionKey);
-            });
+            }, "subagents:result-refresh");
           }
           return;
         }

--- a/src/agents/subagents/registry/subagent-registry-restore.ts
+++ b/src/agents/subagents/registry/subagent-registry-restore.ts
@@ -273,7 +273,7 @@ export function createSubagentRegistryRestorer(config: {
                 launchTerminationConfirmed = true;
                 throw error;
               }
-            });
+            }, "subagents:restore-launch");
           },
           onStartFailure: (error) => {
             if (error instanceof GatewayDrainingError) {
@@ -438,7 +438,7 @@ export function createSubagentRegistryRestorer(config: {
           return cleanupSettled && ownsCleanup();
         }
         return await cleanupCollectorLaunchResources(entry, { isCurrent: ownsCleanup });
-      }).catch((cleanupError: unknown) => {
+      }, "subagents:restore-cleanup").catch((cleanupError: unknown) => {
         warn("failed to clean restored collector after launch failure", {
           runId,
           childSessionKey: entry.childSessionKey,

--- a/src/agents/subagents/registry/subagent-registry-run-manager.ts
+++ b/src/agents/subagents/registry/subagent-registry-run-manager.ts
@@ -323,7 +323,7 @@ class SubagentRunManager extends SubagentLaunchManager {
               ? safeRemoveAttachmentsDir(entry)
               : Promise.resolve(),
           ]);
-        }).catch((err: unknown) => {
+        }, "subagents:session-finalize").catch((err: unknown) => {
           log.warn("failed to run killed subagent cleanup tail", {
             err,
             runId: entry.runId,

--- a/src/agents/subagents/registry/subagent-registry-sweeper.ts
+++ b/src/agents/subagents/registry/subagent-registry-sweeper.ts
@@ -152,7 +152,7 @@ export function createSubagentRegistrySweeper(params: {
       return;
     }
     try {
-      await runWithGatewayIndependentRootWorkAdmission(sweepOnce);
+      await runWithGatewayIndependentRootWorkAdmission(sweepOnce, "subagents:sweeper");
     } catch (error) {
       params.warn(
         `subagent run sweep failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -188,9 +188,11 @@ export function createSubagentRegistrySweeper(params: {
   });
 
   function runCleanupTail(runId: string, label: string, run: () => Promise<unknown>) {
-    void runWithGatewayIndependentRootWorkAdmission(run).catch((error: unknown) => {
-      params.warn(`subagent sweep ${label} failed`, { runId, error });
-    });
+    void runWithGatewayIndependentRootWorkAdmission(run, "subagents:sweeper-cleanup").catch(
+      (error: unknown) => {
+        params.warn(`subagent sweep ${label} failed`, { runId, error });
+      },
+    );
   }
 
   type FrozenSessionIdentity = {

--- a/src/agents/subagents/registry/subagent-registry-sweeper.ts
+++ b/src/agents/subagents/registry/subagent-registry-sweeper.ts
@@ -189,9 +189,7 @@ export function createSubagentRegistrySweeper(params: {
 
   function runCleanupTail(runId: string, label: string, run: () => Promise<unknown>) {
     void runWithGatewayIndependentRootWorkAdmission(run, "subagents:sweeper-cleanup").catch(
-      (error: unknown) => {
-        params.warn(`subagent sweep ${label} failed`, { runId, error });
-      },
+      (error: unknown) => params.warn(`subagent sweep ${label} failed`, { runId, error }),
     );
   }
 

--- a/src/agents/subagents/registry/subagent-registry.ts
+++ b/src/agents/subagents/registry/subagent-registry.ts
@@ -184,7 +184,7 @@ function scheduleSubagentDeliveryResumeRetry(
       }
       resumedRuns.delete(runId);
       resumeSubagentRun(runId);
-    }).catch((error: unknown) => {
+    }, "subagents:resume-retry").catch((error: unknown) => {
       log.warn("failed to resume subagent delivery retry", { runId, error });
       if (
         isGatewayRestartDraining() &&
@@ -212,7 +212,7 @@ function finalizeResumedAnnounceGiveUpInBackground(
 ) {
   void runWithGatewayIndependentRootWorkAdmission(async () => {
     await finalizeResumedAnnounceGiveUp({ runId, entry, reason });
-  }).catch((error: unknown) => {
+  }, "subagents:delivery-finalize").catch((error: unknown) => {
     log.warn("failed to finalize exhausted subagent delivery", { runId, reason, error });
     if (
       isGatewayRestartDraining() &&

--- a/src/agents/subagents/spawn/subagent-spawn.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.ts
@@ -639,7 +639,7 @@ export async function spawnSubagentDirect(
               throw error;
             }
             await emitSpawnLifecycleHooks(gatewayRunId);
-          });
+          }, "subagents:spawn");
         },
         onStartFailure: async (error) => {
           if (error instanceof GatewayDrainingError) {

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -1121,27 +1121,29 @@ export function createSessionsSendTool(opts?: {
                 : baselineReply;
             // This detached flow can outlive the tool request that launched it.
             // Own a fresh root so parent release cannot retire later nested turns.
-            void runWithGatewayIndependentRootWorkContinuation(() =>
-              runWithoutOwnedSessionTranscriptWrites(() =>
-                runSessionsSendA2AFlow({
-                  callGateway: gatewayCall,
-                  targetSessionKey: flowTargetSessionKey,
-                  targetAgentId,
-                  displayKey: flowDisplayKey,
-                  message,
-                  announceTimeoutMs,
-                  // Cron runs are isolated jobs; target replies must not become new
-                  // requester turns, but the target-side announce still runs.
-                  maxPingPongTurns: isIsolatedCronRequester ? 0 : maxPingPongTurns,
-                  requesterSessionKey: replyRequesterSessionKey,
-                  requesterAgentId,
-                  requesterChannel,
-                  baseline: flowBaseline,
-                  roundOneReply,
-                  waitRunId,
-                  notifyRequesterOnWaitFailure,
-                }),
-              ),
+            void runWithGatewayIndependentRootWorkContinuation(
+              () =>
+                runWithoutOwnedSessionTranscriptWrites(() =>
+                  runSessionsSendA2AFlow({
+                    callGateway: gatewayCall,
+                    targetSessionKey: flowTargetSessionKey,
+                    targetAgentId,
+                    displayKey: flowDisplayKey,
+                    message,
+                    announceTimeoutMs,
+                    // Cron runs are isolated jobs; target replies must not become new
+                    // requester turns, but the target-side announce still runs.
+                    maxPingPongTurns: isIsolatedCronRequester ? 0 : maxPingPongTurns,
+                    requesterSessionKey: replyRequesterSessionKey,
+                    requesterAgentId,
+                    requesterChannel,
+                    baseline: flowBaseline,
+                    roundOneReply,
+                    waitRunId,
+                    notifyRequesterOnWaitFailure,
+                  }),
+                ),
+              "session:a2a-send",
             ).catch((err: unknown) => {
               log.warn("sessions_send announce flow admission failed", {
                 runId: waitRunId ?? "unknown",

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -1658,8 +1658,9 @@ export function scheduleFollowupDrain(
   // Queued turns re-admit on the generation current at drain time: the detached
   // drain runs outside any ambient prepared-generation scope, so a parked turn
   // never inherits the predecessor run's replaced generation.
-  void runWithGatewayIndependentRootWorkContinuation(() =>
-    runOutsidePreparedModelRuntimePluginGenerationScope(drainQueuedFollowups),
+  void runWithGatewayIndependentRootWorkContinuation(
+    () => runOutsidePreparedModelRuntimePluginGenerationScope(drainQueuedFollowups),
+    "session:followup-drain",
   ).catch((err: unknown) => {
     if (FOLLOWUP_QUEUES.get(key) === queue && queue.drainOwner === drainOwner) {
       queue.draining = false;

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -1204,7 +1204,7 @@ async function initSessionStateAttemptLocked(
         onWarn: (message) => log.warn(message),
         onError: (error) => log.warn(`browser tab cleanup failed: ${String(error)}`),
       });
-    }).catch((error: unknown) => {
+    }, "session:browser-cleanup").catch((error: unknown) => {
       log.warn(`browser tab cleanup admission failed: ${String(error)}`);
     });
   }
@@ -1240,7 +1240,7 @@ async function initSessionStateAttemptLocked(
         });
         void runWithGatewayIndependentRootWorkContinuation(async () => {
           await hookRunner.runSessionEnd(payload.event, payload.context);
-        }).catch(() => {});
+        }, "hooks:session-end").catch(() => {});
       }
     }
 
@@ -1267,7 +1267,7 @@ async function initSessionStateAttemptLocked(
       });
       void runWithGatewayIndependentRootWorkContinuation(async () => {
         await hookRunner.runSessionStart(payload.event, payload.context);
-      }).catch(() => {});
+      }, "hooks:session-start").catch(() => {});
     }
   }
 

--- a/src/cron/service/ops-run.ts
+++ b/src/cron/service/ops-run.ts
@@ -519,54 +519,56 @@ export async function enqueueRun(
   const scheduleOwnershipAtMs = state.deps.nowMs();
   const runId = `manual:${id}:${scheduleOwnershipAtMs}:${nextManualRunId++}`;
   const terminalTracker: ManualRunTerminalTracker = { emitted: false };
-  void runWithGatewayIndependentRootWorkContinuation(() =>
-    enqueueCommandInLane(
-      CommandLane.Cron,
-      async (owningCronLaneTaskMarker) => {
-        const result = await run(state, id, mode, {
-          runId,
-          scheduleOwnershipAtMs,
-          terminalTracker,
-          owningCronLaneTaskMarker,
-          ...(opts?.commitGuard ? { commitGuard: opts.commitGuard } : {}),
-        });
-        if (result.ok && "ran" in result && !result.ran) {
-          if (result.reason !== "invalid-spec") {
-            const finishedAt = state.deps.nowMs();
-            const job = state.store?.jobs.find((entry) => entry.id === id);
-            emitCronRunFinished(
-              state,
-              {
-                jobId: id,
-                action: "finished",
-                job,
-                status: "skipped",
-                error: `queued manual run skipped before execution: ${result.reason}`,
-                runId,
-                runAtMs: finishedAt,
-                durationMs: 0,
-                nextRunAtMs: job?.state.nextRunAtMs,
-              },
-              terminalTracker,
+  void runWithGatewayIndependentRootWorkContinuation(
+    () =>
+      enqueueCommandInLane(
+        CommandLane.Cron,
+        async (owningCronLaneTaskMarker) => {
+          const result = await run(state, id, mode, {
+            runId,
+            scheduleOwnershipAtMs,
+            terminalTracker,
+            owningCronLaneTaskMarker,
+            ...(opts?.commitGuard ? { commitGuard: opts.commitGuard } : {}),
+          });
+          if (result.ok && "ran" in result && !result.ran) {
+            if (result.reason !== "invalid-spec") {
+              const finishedAt = state.deps.nowMs();
+              const job = state.store?.jobs.find((entry) => entry.id === id);
+              emitCronRunFinished(
+                state,
+                {
+                  jobId: id,
+                  action: "finished",
+                  job,
+                  status: "skipped",
+                  error: `queued manual run skipped before execution: ${result.reason}`,
+                  runId,
+                  runAtMs: finishedAt,
+                  durationMs: 0,
+                  nextRunAtMs: job?.state.nextRunAtMs,
+                },
+                terminalTracker,
+              );
+            }
+            state.deps.log.info(
+              { jobId: id, runId, reason: result.reason },
+              "cron: queued manual run skipped before execution",
             );
           }
-          state.deps.log.info(
-            { jobId: id, runId, reason: result.reason },
-            "cron: queued manual run skipped before execution",
-          );
-        }
-        return result;
-      },
-      {
-        warnAfterMs: 5_000,
-        onWait: (waitMs, queuedAhead) => {
-          state.deps.log.warn(
-            { jobId: id, runId, waitMs, queuedAhead },
-            "cron: queued manual run waiting for an execution slot",
-          );
+          return result;
         },
-      },
-    ),
+        {
+          warnAfterMs: 5_000,
+          onWait: (waitMs, queuedAhead) => {
+            state.deps.log.warn(
+              { jobId: id, runId, waitMs, queuedAhead },
+              "cron: queued manual run waiting for an execution slot",
+            );
+          },
+        },
+      ),
+    "cron:manual-run",
   ).catch((err: unknown) => {
     if (terminalTracker.emitted) {
       state.deps.log.error(

--- a/src/cron/service/timer-scheduler.ts
+++ b/src/cron/service/timer-scheduler.ts
@@ -149,7 +149,7 @@ export async function onTimer(state: CronServiceState) {
   try {
     // A restart signal can be rejected after temporarily closing admission.
     // Wait for that decision so the consumed timer is not silently lost.
-    admission = await beginGatewayRootWorkAdmissionWhenOpen();
+    admission = await beginGatewayRootWorkAdmissionWhenOpen("cron:timer-tick");
   } catch (err) {
     if (err instanceof GatewayDrainingError) {
       return;

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -328,7 +328,10 @@ function dispatchDetachedCronNotification(params: {
   logger: CronLogger;
   deliver: () => Promise<void>;
 }): void {
-  void runWithGatewayIndependentRootWorkContinuation(params.deliver).catch((err: unknown) => {
+  void runWithGatewayIndependentRootWorkContinuation(
+    params.deliver,
+    "cron:notification-delivery",
+  ).catch((err: unknown) => {
     params.logger.warn(
       { jobId: params.jobId, err: formatErrorMessage(err) },
       "cron: detached notification delivery failed",
@@ -340,7 +343,7 @@ function dispatchDetachedCronNotification(params: {
 export async function sendGatewayCronFailureAlert(params: CronFailureAlertParams): Promise<void> {
   await runWithGatewayIndependentRootWorkContinuation(async () => {
     await sendGatewayCronFailureAlertUnderAdmission(params);
-  });
+  }, "cron:failure-alert");
 }
 
 async function sendGatewayCronFailureAlertUnderAdmission(

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -627,7 +627,7 @@ export function buildGatewayCronService(params: {
     // Keep the whole plugin callback visible until its user-state effects settle.
     void runWithGatewayIndependentRootWorkAdmission(async () => {
       await hookRunner.runCronChanged(evt, hookCtx);
-    }).catch((err: unknown) => {
+    }, "cron:changed-hook").catch((err: unknown) => {
       cronLogger.warn(
         { err: formatErrorMessage(err), jobId: evt.jobId },
         "cron_changed hook failed",
@@ -1235,7 +1235,10 @@ export function buildGatewayCronService(params: {
           // preconditioned terminal write without admitting unrelated work.
           await persistCompletion();
         } else {
-          await runWithGatewayIndependentRootWorkAdmission(persistCompletion);
+          await runWithGatewayIndependentRootWorkAdmission(
+            persistCompletion,
+            "cron:persist-completion",
+          );
         }
         return () => {
           releaseCompletionToken();
@@ -1247,10 +1250,12 @@ export function buildGatewayCronService(params: {
       }
     },
     fireOnExit: async (job, exit) => {
-      await runWithGatewayIndependentRootWorkAdmission(async () =>
-        fireOnExitJob(job, exit, {
-          run: (jobId, payload) => cron.run(jobId, "force", payload ? { payload } : undefined),
-        }),
+      await runWithGatewayIndependentRootWorkAdmission(
+        async () =>
+          fireOnExitJob(job, exit, {
+            run: (jobId, payload) => cron.run(jobId, "force", payload ? { payload } : undefined),
+          }),
+        "cron:exit-hook",
       );
     },
     updateWatcherState: async (job, patch) =>
@@ -1272,7 +1277,7 @@ export function buildGatewayCronService(params: {
           // Stale watcher identity is a no-op, not an error to surface.
           return undefined;
         }
-      }),
+      }, "cron:watcher-state"),
     logger: cronLogger,
   } satisfies CronExitWatcherHandlers;
   exitWatchersRef.current = createCronExitWatchers(exitWatcherHandlers);
@@ -1294,19 +1299,21 @@ export function buildGatewayCronService(params: {
       });
     },
     fireBatch: (job, batch, streamScheduleKey, streamSourceIdentity) =>
-      runWithGatewayIndependentRootWorkAdmission(async () =>
-        fireStreamJob(job, {
-          run: async (jobId, onDisposition) => {
-            const result = await cron.run(jobId, "force", {
-              evaluateTrigger: true,
-              streamBatch: batch,
-              streamScheduleKey,
-              streamSourceIdentity,
-              onTriggerDisposition: onDisposition,
-            });
-            return { ...result, enabled: cron.getJob(jobId)?.enabled };
-          },
-        }),
+      runWithGatewayIndependentRootWorkAdmission(
+        async () =>
+          fireStreamJob(job, {
+            run: async (jobId, onDisposition) => {
+              const result = await cron.run(jobId, "force", {
+                evaluateTrigger: true,
+                streamBatch: batch,
+                streamScheduleKey,
+                streamSourceIdentity,
+                onTriggerDisposition: onDisposition,
+              });
+              return { ...result, enabled: cron.getJob(jobId)?.enabled };
+            },
+          }),
+        "cron:stream-batch",
       ),
     logger: cronLogger,
   });

--- a/src/gateway/server-idle-task.ts
+++ b/src/gateway/server-idle-task.ts
@@ -47,7 +47,7 @@ export function scheduleGatewayIdleTask(params: {
           return;
         }
         await params.run();
-      }).catch((error: unknown) => {
+      }, "idle-task").catch((error: unknown) => {
         if (!isGatewayRestartDrainError(error)) {
           params.log.warn(`${params.errorMessage}: ${String(error)}`);
         }

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -577,7 +577,7 @@ export async function runWithGatewayRequestEnvelope<T>(
     return await options.reject(preAdmissionRateLimitError);
   }
   const rootWorkAdmission =
-    tryBeginGatewayRootWorkAdmission() ??
+    tryBeginGatewayRootWorkAdmission(`ws:${method}`) ??
     (method === "gateway.restart.request" &&
     isTargetedNonSafeGatewayRestartRequest(options.requestParams)
       ? tryBeginGatewayPreparedRestartRootWorkAdmission()

--- a/src/gateway/server-methods/agent-cron-continuation.ts
+++ b/src/gateway/server-methods/agent-cron-continuation.ts
@@ -164,7 +164,7 @@ export function createCronContinuationController(params: {
       params.context.logGateway.warn(
         `cron continuation release recovery exhausted for ${params.runId}`,
       );
-    });
+    }, "cron:continuation-recovery");
     return false;
   };
 

--- a/src/gateway/server-methods/chat-send-background.ts
+++ b/src/gateway/server-methods/chat-send-background.ts
@@ -88,7 +88,7 @@ export function scheduleChatDashboardSessionTitle(params: {
     } finally {
       admission.release();
     }
-  }).catch((err: unknown) => {
+  }, "chat-send:background").catch((err: unknown) => {
     params.context.logGateway.warn(
       `dashboard session title generation failed: ${formatForLog(err)}`,
     );

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -202,17 +202,19 @@ function queueDelegatedApproval(params: {
     keepPendingWithoutRoute: true,
     requireDeliveryRoute: false,
     afterDecision: async (decision) =>
-      await runWithGatewayIndependentRootWorkContinuation(() =>
-        runSystemAgentGatewayTask(async () => {
-          // The original request has returned; keep approval, audit, and restart drain-visible.
-          if (params.sessions.get(params.sessionId) !== params.session) {
-            return;
-          }
-          if (params.session.pendingApproval?.id === record.id) {
-            params.session.pendingApproval = undefined;
-          }
-          await params.session.engine.resolveOperatorApproval(decision, params.proposal.hash);
-        }),
+      await runWithGatewayIndependentRootWorkContinuation(
+        () =>
+          runSystemAgentGatewayTask(async () => {
+            // The original request has returned; keep approval, audit, and restart drain-visible.
+            if (params.sessions.get(params.sessionId) !== params.session) {
+              return;
+            }
+            if (params.session.pendingApproval?.id === record.id) {
+              params.session.pendingApproval = undefined;
+            }
+            await params.session.engine.resolveOperatorApproval(decision, params.proposal.hash);
+          }),
+        "system-agent:task",
       ),
     afterDecisionErrorLabel: "OpenClaw approval apply failed",
   });

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -155,7 +155,7 @@ function dispatchNodeAgentCommand(
       return;
     }
     await dependencies.agentCommandFromIngress(input, dependencies.defaultRuntime, ctx.deps);
-  }).catch((err: unknown) => {
+  }, "node-events:agent-turn").catch((err: unknown) => {
     ctx.logGateway.warn(`agent failed node=${nodeId}: ${dependencies.formatForLog(err)}`);
   });
 }
@@ -344,7 +344,7 @@ function dispatchReservedVoiceAgentCommand(params: {
       return;
     }
     await admission.work;
-  }).catch((err: unknown) => {
+  }, "node-events:voice-turn").catch((err: unknown) => {
     params.reservation.reject();
     params.ctx.logGateway.warn(
       `agent failed node=${params.nodeId}: ${params.dependencies.formatForLog(err)}`,
@@ -483,7 +483,7 @@ function queueSessionStoreTouch(params: {
       now: params.now,
       dependencies: params.dependencies,
     });
-  }).catch((err: unknown) => {
+  }, "node-events:voice-persist").catch((err: unknown) => {
     params.ctx.logGateway.warn(
       "voice session-store update failed: " + params.dependencies.formatForLog(err),
     );
@@ -918,7 +918,7 @@ export const handleNodeEvent = async (
             to: deliveryTo,
             text: receiptText,
           });
-        }).catch((err: unknown) => {
+        }, "node-events:delivery").catch((err: unknown) => {
           ctx.logGateway.warn(`agent receipt failed node=${nodeId}: ${formatForLog(err)}`);
         });
       } else if (wantsReceipt) {

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -64,6 +64,7 @@ import {
 import {
   captureGatewayRootWorkAdmissionContinuationScope,
   getActiveGatewayRootWorkCount,
+  getActiveGatewayRootWorkHolders,
   isGatewayWorkAdmissionClosed,
   resetGatewayWorkAdmission,
   runWithGatewayIndependentRootWorkAdmission,
@@ -5771,6 +5772,7 @@ describe("gateway Gmail hot reload handlers", () => {
     );
     expect(await restartOutcome).toEqual({ status: "started" });
     expect(restartSignal?.aborted).toBe(false);
+    expect(getActiveGatewayRootWorkHolders()).toEqual(["reload:config"]);
 
     await reloader.stop();
 

--- a/src/gateway/server-reload-managed.ts
+++ b/src/gateway/server-reload-managed.ts
@@ -379,7 +379,7 @@ export function startManagedGatewayConfigReloader(
       ? { prepareConfigCandidate: params.prepareConfigCandidate }
       : {}),
     initialInternalWriteHash: params.initialInternalWriteHash,
-    runTransaction: runWithGatewayIndependentRootWorkAdmission,
+    runTransaction: (run) => runWithGatewayIndependentRootWorkAdmission(run, "reload:config"),
     readSnapshot: params.readSnapshot,
     promoteSnapshot: async (snapshot, _reason) => await params.promoteSnapshot(snapshot),
     subscribeToWrites: params.subscribeToWrites,

--- a/src/gateway/server-reload-restart.ts
+++ b/src/gateway/server-reload-restart.ts
@@ -371,7 +371,7 @@ class GatewayRestartTransaction {
         if (!emitResult || emitResult.status === "failed") {
           this.scheduleEmissionRetry(retry);
         }
-      }).catch((err: unknown) => {
+      }, "reload:restart").catch((err: unknown) => {
         if (this.isCurrentRequest(retry.requestGeneration)) {
           this.options.params.logReload.warn(
             `gateway restart recovery retry stopped: ${String(err)}`,

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -485,7 +485,7 @@ async function loadRestartSentinelStartupTask(params: {
               deps: params.deps,
               attempt: attempt + 1,
             });
-          }).catch((err: unknown) => {
+          }, "restart-sentinel:wake").catch((err: unknown) => {
             log.warn(`restart sentinel pending update retry failed: ${formatErrorMessage(err)}`);
           });
         }, CONTROL_PLANE_UPDATE_PENDING_RETRY_DELAY_MS);

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -74,7 +74,9 @@ export function startGatewayCronWithLogging(params: {
       // admission fence; restart and suspension cannot race past this point.
       params.onStartError?.(err);
     }
-  }).catch((err: unknown) => params.logCron.error(`failed to enter start root: ${String(err)}`));
+  }, "runtime:cron-start").catch((err: unknown) =>
+    params.logCron.error(`failed to enter start root: ${String(err)}`),
+  );
 }
 
 export async function clearGatewayMaintenanceHandles(
@@ -142,7 +144,7 @@ export function scheduleGatewayPostReadyMaintenance(params: {
       if (!params.isClosing()) {
         params.recordPostReadyMemory();
       }
-    }).catch((err: unknown) =>
+    }, "runtime:maintenance").catch((err: unknown) =>
       params.log.warn(`gateway post-ready maintenance deferred task failed: ${String(err)}`),
     );
   }, params.delayMs);
@@ -235,7 +237,9 @@ function startPendingOutboundDeliveryRecovery(params: {
         deliver: deliverWithCurrentConversationAuthority,
         selectEntry: () => ({ match: true, bypassBackoff: false }),
       });
-    }).catch((err: unknown) => params.log.error(`Delivery recovery failed: ${String(err)}`));
+    }, "runtime:delivery-recovery").catch((err: unknown) =>
+      params.log.error(`Delivery recovery failed: ${String(err)}`),
+    );
     const settled: Promise<void> = recovery.finally(() => {
       if (inFlight === settled) {
         inFlight = null;
@@ -323,7 +327,7 @@ function startPendingSessionDeliveryRuntime(params: {
         // recovery failure must not leave persisted rows without timers.
         await schedulePendingSessionDeliveries();
       }
-    }).catch((err: unknown) =>
+    }, "runtime:session-delivery-recovery").catch((err: unknown) =>
       params.log.error(`Session delivery recovery failed: ${String(err)}`),
     );
   }, 1_250);

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -3827,6 +3827,59 @@ describe("startGatewayPostAttachRuntime", () => {
     });
   });
 
+  it("does not retain root work when the configured ACP backend never becomes ready", async () => {
+    vi.useFakeTimers();
+    const trace = createStartupTraceRecorder();
+    hoisted.reconcilePendingSessionIdentities.mockImplementation(
+      async () => await new Promise<never>(() => {}),
+    );
+
+    try {
+      await startGatewaySidecars({
+        cfg: {
+          hooks: { internal: { enabled: false } },
+          acp: { enabled: true, backend: "acpx" },
+        } as never,
+        pluginRegistry: createPostAttachParams().pluginRegistry,
+        defaultWorkspaceDir: "/tmp/openclaw-workspace",
+        deps: {} as never,
+        startChannels: vi.fn(async () => {}),
+        log: { warn: vi.fn() },
+        logHooks: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        },
+        logChannels: {
+          info: vi.fn(),
+          error: vi.fn(),
+        },
+        startupTrace: trace.startupTrace,
+      });
+
+      await waitForGatewayTestState(() => {
+        expect(hoisted.getAcpRuntimeBackend).toHaveBeenCalledWith("acpx");
+      });
+      await vi.advanceTimersByTimeAsync(5_000);
+      await waitForGatewayTestState(() => {
+        expect(trace.details).toContainEqual({
+          name: "sidecars.acp.runtime-ready",
+          metrics: [
+            ["readyCount", 0],
+            ["backend", "acpx"],
+          ],
+        });
+      });
+      await waitForGatewayTestState(() => {
+        expect(getActiveGatewayRootWorkCount()).toBe(0);
+      });
+
+      expect(hoisted.reconcilePendingSessionIdentities).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("passes typed gateway_start context with config, workspace dir, and a live cron getter", async () => {
     const runGatewayStart = vi.fn<
       (event: PluginHookGatewayStartEvent, ctx: PluginHookGatewayContext) => Promise<void>

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -3827,59 +3827,6 @@ describe("startGatewayPostAttachRuntime", () => {
     });
   });
 
-  it("does not retain root work when the configured ACP backend never becomes ready", async () => {
-    vi.useFakeTimers();
-    const trace = createStartupTraceRecorder();
-    hoisted.reconcilePendingSessionIdentities.mockImplementation(
-      async () => await new Promise<never>(() => {}),
-    );
-
-    try {
-      await startGatewaySidecars({
-        cfg: {
-          hooks: { internal: { enabled: false } },
-          acp: { enabled: true, backend: "acpx" },
-        } as never,
-        pluginRegistry: createPostAttachParams().pluginRegistry,
-        defaultWorkspaceDir: "/tmp/openclaw-workspace",
-        deps: {} as never,
-        startChannels: vi.fn(async () => {}),
-        log: { warn: vi.fn() },
-        logHooks: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-        },
-        logChannels: {
-          info: vi.fn(),
-          error: vi.fn(),
-        },
-        startupTrace: trace.startupTrace,
-      });
-
-      await waitForGatewayTestState(() => {
-        expect(hoisted.getAcpRuntimeBackend).toHaveBeenCalledWith("acpx");
-      });
-      await vi.advanceTimersByTimeAsync(5_000);
-      await waitForGatewayTestState(() => {
-        expect(trace.details).toContainEqual({
-          name: "sidecars.acp.runtime-ready",
-          metrics: [
-            ["readyCount", 0],
-            ["backend", "acpx"],
-          ],
-        });
-      });
-      await waitForGatewayTestState(() => {
-        expect(getActiveGatewayRootWorkCount()).toBe(0);
-      });
-
-      expect(hoisted.reconcilePendingSessionIdentities).not.toHaveBeenCalled();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
   it("passes typed gateway_start context with config, workspace dir, and a live cron getter", async () => {
     const runGatewayStart = vi.fn<
       (event: PluginHookGatewayStartEvent, ctx: PluginHookGatewayContext) => Promise<void>

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -131,7 +131,7 @@ function schedulePostAttachUpdateSentinelRefresh(params: {
       await measureStartup(params.startupTrace, "post-attach.update-sentinel", async () => {
         await params.refreshLatestUpdateRestartSentinel();
       });
-    }).catch((err: unknown) => {
+    }, "startup:update-sentinel").catch((err: unknown) => {
       params.log.warn(`restart sentinel refresh failed: ${String(err)}`);
     });
   });
@@ -193,7 +193,7 @@ function scheduleProviderAuthStatePrewarm(params: {
             scheduleAuthMapRewarm(nextReason);
           }
         }
-      });
+      }, "runtime:provider-auth-rewarm");
     };
     const scheduleAuthMapRewarm = (reason: string) => {
       // Collapse repeated auth-profile failures into one rewarm turn while a
@@ -247,12 +247,16 @@ function scheduleProviderAuthStatePrewarm(params: {
           params.log.info(
             `provider auth state pre-warmed ${formatProviderAuthWarmMetrics(metrics)}`,
           );
-        }).catch((error: unknown) => logProviderAuthWarmFailure("pre-warm", error));
+        }, "startup:provider-auth-prewarm").catch((error: unknown) =>
+          logProviderAuthWarmFailure("pre-warm", error),
+        );
       },
       Math.max(0, delayMs),
     );
     startupTimer.unref?.();
-  }).catch((error: unknown) => logProviderAuthWarmFailure("pre-warm setup", error));
+  }, "startup:provider-auth").catch((error: unknown) =>
+    logProviderAuthWarmFailure("pre-warm setup", error),
+  );
   return {
     stop: () => {
       stopped = true;
@@ -289,7 +293,7 @@ function schedulePostReadySidecarTask(params: {
         await measureStartup(params.startupTrace, params.name, () =>
           params.run(isStopped, abortController.signal),
         );
-      });
+      }, `startup:${params.name}`);
     })().catch((err: unknown) => {
       params.log.warn(`${params.name} failed after gateway ready: ${String(err)}`);
     });
@@ -309,6 +313,7 @@ function schedulePostReadySidecarTask(params: {
 
 function scheduleGatewayGenerationTimer(params: {
   delayMs: number;
+  origin: string;
   run: (isStopped: () => boolean) => Awaitable<void>;
   onError: (err: unknown) => void;
 }): GatewayPostReadySidecarHandle {
@@ -322,7 +327,7 @@ function scheduleGatewayGenerationTimer(params: {
     }
     void runWithGatewayIndependentRootWorkAdmission(async () => {
       await params.run(isStopped);
-    }).catch((err: unknown) => {
+    }, params.origin).catch((err: unknown) => {
       if (!isStopped()) {
         params.onError(err);
       }
@@ -346,6 +351,7 @@ function scheduleRestartSentinelWakeAfterReady(params: {
 }): GatewayPostReadySidecarHandle {
   return scheduleGatewayGenerationTimer({
     delayMs: 750,
+    origin: "restart-sentinel:wake",
     run: async (isStopped) => {
       const { scheduleRestartSentinelWake } = await loadGatewayRestartSentinelModule();
       if (isStopped()) {
@@ -834,6 +840,7 @@ export async function startGatewaySidecars(params: {
     postReadySidecars.push(
       scheduleGatewayGenerationTimer({
         delayMs: 250,
+        origin: "hooks:gateway-startup",
         run: async (isStopped) => {
           const { createInternalHookEvent, triggerInternalHook } = await loadInternalHooksModule();
           if (isStopped()) {
@@ -860,9 +867,6 @@ export async function startGatewaySidecars(params: {
         ["readyCount", ready ? 1 : 0],
         ["backend", params.cfg.acp?.backend ?? "default"],
       ]);
-      if (!ready) {
-        return;
-      }
       await measureStartup(params.startupTrace, "sidecars.acp.identity-reconcile", async () => {
         const [{ getAcpSessionManager }, { ACP_SESSION_IDENTITY_RENDERER_VERSION }] =
           await Promise.all([
@@ -1126,6 +1130,7 @@ function createDeferredGatewayUpdateCheck(params: {
                 },
               }),
             ),
+          "startup:update-check",
         )
           .then((nextStop) => {
             if (stopped) {
@@ -1652,7 +1657,7 @@ export async function startGatewayPostAttachRuntime(
               },
             ),
           );
-        }).catch((err: unknown) => {
+        }, "hooks:gateway-start").catch((err: unknown) => {
           params.log.warn(`gateway_start hook failed: ${String(err)}`);
         });
       }

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -860,6 +860,9 @@ export async function startGatewaySidecars(params: {
         ["readyCount", ready ? 1 : 0],
         ["backend", params.cfg.acp?.backend ?? "default"],
       ]);
+      if (!ready) {
+        return;
+      }
       await measureStartup(params.startupTrace, "sidecars.acp.identity-reconcile", async () => {
         const [{ getAcpSessionManager }, { ACP_SESSION_IDENTITY_RENDERER_VERSION }] =
           await Promise.all([
@@ -876,7 +879,7 @@ export async function startGatewaySidecars(params: {
           `acp startup identity reconcile (renderer=${ACP_SESSION_IDENTITY_RENDERER_VERSION}): checked=${result.checked} resolved=${result.resolved} failed=${result.failed}`,
         );
       });
-    }).catch((err: unknown) => {
+    }, "startup:acp-identity-reconcile").catch((err: unknown) => {
       params.log.warn(`acp startup identity reconcile failed: ${String(err)}`);
     });
   }

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -412,7 +412,10 @@ export function createGatewayHookDispatcher(params: {
     try {
       dispatchCfg = getRuntimeConfig();
     } catch (err) {
-      void runWithGatewayIndependentRootWorkContinuation(async () => reportHookFailure(err));
+      void runWithGatewayIndependentRootWorkContinuation(
+        async () => reportHookFailure(err),
+        "hooks:failure-report",
+      );
       return createHookAdmissionFailure({ runId });
     }
     let acceptedValue: HookAgentDispatchPayload;
@@ -476,135 +479,139 @@ export function createGatewayHookDispatcher(params: {
 
     // Queue identity is fixed when accepted; the isolated runner still receives
     // the original session expression and fresh config, preserving hook routing.
-    void runWithGatewayIndependentRootWorkContinuation(() =>
-      enqueueHookAgentDispatch(queueKey, async () => {
-        // The admission deadline starts before this same-session queue. Expired
-        // work must never enter cron preparation after an HTTP 503 was returned.
-        if (startupAbortController.signal.aborted) {
-          return;
-        }
-        try {
-          const cfg = getRuntimeConfig();
-          try {
-            validateHookAgentDeliveryAccount({ cfg, value: acceptedValue });
-          } catch (err) {
-            settleAdmission({
-              ok: false,
-              statusCode: 400,
-              error: formatErrorMessage(err),
-              runId,
-            });
-            return;
-          }
-          // The accepted agent is the stable owner. Global scope stays global;
-          // other events keep that owner in their agent-qualified session key.
-          const eventTarget = resolveHookEventTarget({
-            cfg,
-            resolvedAgentId: agentId,
-          });
-          hookEventTarget = eventTarget;
-          const { runCronIsolatedAgentTurn } = await loadIsolatedAgentModule();
-          // Lazy module loading is the last Gateway-owned async boundary before
-          // cron preparation, so recheck the deadline after it settles.
+    void runWithGatewayIndependentRootWorkContinuation(
+      () =>
+        enqueueHookAgentDispatch(queueKey, async () => {
+          // The admission deadline starts before this same-session queue. Expired
+          // work must never enter cron preparation after an HTTP 503 was returned.
           if (startupAbortController.signal.aborted) {
             return;
           }
-          const runHookIsolatedTurn = async () =>
-            await runCronIsolatedAgentTurn({
-              cfg,
-              deps,
-              job,
-              message: acceptedValue.message,
-              sessionKey,
-              // Isolated runs derive their lifecycle key from random jobId (or an
-              // already-stable cron: key), so accepted agentId closes reload drift.
-              agentId,
-              // Only HTTP hooks own the opt-in reserved lane. Trusted plugin
-              // triggers share cron capacity even when the HTTP surface is off.
-              lane: pluginId ? CommandLane.CronNested : CommandLane.HookDispatch,
-              executionIdentity: {
-                ingress: pluginId
-                  ? {
-                      kind: "webhook",
-                      boundary: "gateway.hooks.plugin",
-                      state: "present",
-                      rawSourceRef: `${pluginId}:${safeName}`,
-                    }
-                  : {
-                      kind: "webhook",
-                      boundary: "gateway.hooks.agent",
-                      state: "present",
-                      ...(acceptedValue.mappingId ? { rawSourceRef: acceptedValue.mappingId } : {}),
-                    },
-              } satisfies CronExecutionIdentityAdmission,
-              abortSignal: startupAbortController.signal,
-              onLaneWait: (info) => {
-                if (info?.waiting === false) {
-                  settleSuccessfulAdmission();
-                }
-              },
-              onExecutionStarted: settleSuccessfulAdmission,
-            });
-          const result = await runWithScheduledGatewayContext({
-            ...(scheduledGatewayContextResolver
-              ? { resolveGatewayContext: scheduledGatewayContextResolver }
-              : {}),
-            run: runHookIsolatedTurn,
-          });
-          if (admissionTimedOut) {
-            return;
-          }
-          const summary = resolveHookRunSummary(result);
-          if (!admissionSettled) {
-            settleAdmission(
-              result.status === "ok" || result.executionStarted === true
-                ? { ok: true, runId }
-                : createHookAdmissionFailure({
-                    runId,
-                    disposition: result.admissionDisposition,
-                  }),
-            );
-          }
-          const prefix =
-            result.status === "ok" ? `Hook ${safeName}` : `Hook ${safeName} (${result.status})`;
-          const shouldAnnounce = shouldAnnounceHookRunResult({ deliver: value.deliver, result });
-          logHookRunTerminal(result);
-          if (shouldAnnounce) {
-            const eventSessionKey = eventTarget.eventSessionKey;
-            const isGlobalEvent = isUnscopedSessionKeySentinel(eventSessionKey);
-            let announceEventOptions = { sessionKey: eventSessionKey };
-            let heartbeatTarget: HookEventTarget["heartbeatTarget"];
-            if (isGlobalEvent) {
-              const globalTerminalAgentId = resolveGlobalTerminalAgentId(result.status);
-              if (!globalTerminalAgentId) {
-                return;
-              }
-              announceEventOptions = withSystemEventOwner(
-                announceEventOptions,
-                globalTerminalAgentId,
-              );
-              heartbeatTarget = { agentId: globalTerminalAgentId };
-            } else {
-              heartbeatTarget = eventTarget.heartbeatTarget;
-            }
-            enqueueSystemEvent(`${prefix}: ${summary}`.trim(), announceEventOptions);
-            if (value.wakeMode === "now") {
-              requestHeartbeat({
-                source: "hook",
-                intent: "immediate",
-                reason: `hook:${jobId}`,
-                ...heartbeatTarget,
+          try {
+            const cfg = getRuntimeConfig();
+            try {
+              validateHookAgentDeliveryAccount({ cfg, value: acceptedValue });
+            } catch (err) {
+              settleAdmission({
+                ok: false,
+                statusCode: 400,
+                error: formatErrorMessage(err),
+                runId,
               });
+              return;
             }
+            // The accepted agent is the stable owner. Global scope stays global;
+            // other events keep that owner in their agent-qualified session key.
+            const eventTarget = resolveHookEventTarget({
+              cfg,
+              resolvedAgentId: agentId,
+            });
+            hookEventTarget = eventTarget;
+            const { runCronIsolatedAgentTurn } = await loadIsolatedAgentModule();
+            // Lazy module loading is the last Gateway-owned async boundary before
+            // cron preparation, so recheck the deadline after it settles.
+            if (startupAbortController.signal.aborted) {
+              return;
+            }
+            const runHookIsolatedTurn = async () =>
+              await runCronIsolatedAgentTurn({
+                cfg,
+                deps,
+                job,
+                message: acceptedValue.message,
+                sessionKey,
+                // Isolated runs derive their lifecycle key from random jobId (or an
+                // already-stable cron: key), so accepted agentId closes reload drift.
+                agentId,
+                // Only HTTP hooks own the opt-in reserved lane. Trusted plugin
+                // triggers share cron capacity even when the HTTP surface is off.
+                lane: pluginId ? CommandLane.CronNested : CommandLane.HookDispatch,
+                executionIdentity: {
+                  ingress: pluginId
+                    ? {
+                        kind: "webhook",
+                        boundary: "gateway.hooks.plugin",
+                        state: "present",
+                        rawSourceRef: `${pluginId}:${safeName}`,
+                      }
+                    : {
+                        kind: "webhook",
+                        boundary: "gateway.hooks.agent",
+                        state: "present",
+                        ...(acceptedValue.mappingId
+                          ? { rawSourceRef: acceptedValue.mappingId }
+                          : {}),
+                      },
+                } satisfies CronExecutionIdentityAdmission,
+                abortSignal: startupAbortController.signal,
+                onLaneWait: (info) => {
+                  if (info?.waiting === false) {
+                    settleSuccessfulAdmission();
+                  }
+                },
+                onExecutionStarted: settleSuccessfulAdmission,
+              });
+            const result = await runWithScheduledGatewayContext({
+              ...(scheduledGatewayContextResolver
+                ? { resolveGatewayContext: scheduledGatewayContextResolver }
+                : {}),
+              run: runHookIsolatedTurn,
+            });
+            if (admissionTimedOut) {
+              return;
+            }
+            const summary = resolveHookRunSummary(result);
+            if (!admissionSettled) {
+              settleAdmission(
+                result.status === "ok" || result.executionStarted === true
+                  ? { ok: true, runId }
+                  : createHookAdmissionFailure({
+                      runId,
+                      disposition: result.admissionDisposition,
+                    }),
+              );
+            }
+            const prefix =
+              result.status === "ok" ? `Hook ${safeName}` : `Hook ${safeName} (${result.status})`;
+            const shouldAnnounce = shouldAnnounceHookRunResult({ deliver: value.deliver, result });
+            logHookRunTerminal(result);
+            if (shouldAnnounce) {
+              const eventSessionKey = eventTarget.eventSessionKey;
+              const isGlobalEvent = isUnscopedSessionKeySentinel(eventSessionKey);
+              let announceEventOptions = { sessionKey: eventSessionKey };
+              let heartbeatTarget: HookEventTarget["heartbeatTarget"];
+              if (isGlobalEvent) {
+                const globalTerminalAgentId = resolveGlobalTerminalAgentId(result.status);
+                if (!globalTerminalAgentId) {
+                  return;
+                }
+                announceEventOptions = withSystemEventOwner(
+                  announceEventOptions,
+                  globalTerminalAgentId,
+                );
+                heartbeatTarget = { agentId: globalTerminalAgentId };
+              } else {
+                heartbeatTarget = eventTarget.heartbeatTarget;
+              }
+              enqueueSystemEvent(`${prefix}: ${summary}`.trim(), announceEventOptions);
+              if (value.wakeMode === "now") {
+                requestHeartbeat({
+                  source: "hook",
+                  intent: "immediate",
+                  reason: `hook:${jobId}`,
+                  ...heartbeatTarget,
+                });
+              }
+            }
+          } catch (err) {
+            if (admissionTimedOut) {
+              return;
+            }
+            settleAdmission(createHookAdmissionFailure({ runId }));
+            reportHookFailure(err);
           }
-        } catch (err) {
-          if (admissionTimedOut) {
-            return;
-          }
-          settleAdmission(createHookAdmissionFailure({ runId }));
-          reportHookFailure(err);
-        }
-      }),
+        }),
+      "hooks:agent-dispatch",
     ).catch((err: unknown) => {
       if (admissionTimedOut) {
         return;

--- a/src/gateway/server/http-work-admission.ts
+++ b/src/gateway/server/http-work-admission.ts
@@ -7,10 +7,11 @@ import { tryBeginGatewayRootWorkAdmission } from "../../process/gateway-work-adm
 type GatewayBoundaryHandler = () => Promise<boolean> | boolean;
 
 async function runWithGatewayBoundaryWorkAdmission(
+  origin: string,
   reject: () => void,
   run: GatewayBoundaryHandler,
 ): Promise<boolean> {
-  const admission = tryBeginGatewayRootWorkAdmission();
+  const admission = tryBeginGatewayRootWorkAdmission(origin);
   if (!admission) {
     reject();
     return true;
@@ -28,6 +29,7 @@ export async function runWithGatewayHttpWorkAdmission(
   run: GatewayBoundaryHandler,
 ): Promise<boolean> {
   return await runWithGatewayBoundaryWorkAdmission(
+    "http:request",
     () => {
       res.statusCode = 503;
       res.setHeader("Content-Type", "application/json; charset=utf-8");
@@ -72,8 +74,12 @@ export async function runWithGatewayUpgradeWorkAdmission(
   socket: Duplex,
   run: GatewayBoundaryHandler,
 ): Promise<boolean> {
-  return await runWithGatewayBoundaryWorkAdmission(() => {
-    writeGatewayUpgradeServiceUnavailable(socket, "Gateway websocket admission closed");
-    socket.destroy();
-  }, run);
+  return await runWithGatewayBoundaryWorkAdmission(
+    "http:upgrade",
+    () => {
+      writeGatewayUpgradeServiceUnavailable(socket, "Gateway websocket admission closed");
+      socket.destroy();
+    },
+    run,
+  );
 }

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -166,7 +166,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
   const runDetachedConnectWork = (run: () => Promise<void>, onError: (error: unknown) => void) => {
     // Connect-triggered mutations outlive hello-ok. Give each tail its own
     // root lease so suspension cannot report ready while one is still active.
-    void runWithGatewayIndependentRootWorkAdmission(run).catch(onError);
+    void runWithGatewayIndependentRootWorkAdmission(run, "ws:preauth").catch(onError);
   };
 
   const handleMessage = async (data: RawData) => {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -470,7 +470,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
       await handleMessage(data);
       return;
     }
-    const admission = tryBeginGatewayRootWorkAdmission();
+    const admission = tryBeginGatewayRootWorkAdmission("ws:connect");
     if (!admission) {
       if (
         isGatewayRestartDraining() &&

--- a/src/gateway/server/ws-connection/worker-connection.ts
+++ b/src/gateway/server/ws-connection/worker-connection.ts
@@ -399,7 +399,7 @@ export function attachWorkerWsMessageHandler(params: WorkerWsMessageHandlerParam
         if (disposed || params.isClosed()) {
           return;
         }
-        const admission = tryBeginGatewayRootWorkAdmission();
+        const admission = tryBeginGatewayRootWorkAdmission("ws:worker-frame");
         if (!admission) {
           const client = params.getClient();
           const identity = client?.worker;

--- a/src/gateway/server/ws-connection/worker-connection.ts
+++ b/src/gateway/server/ws-connection/worker-connection.ts
@@ -359,8 +359,9 @@ export function attachWorkerWsMessageHandler(params: WorkerWsMessageHandlerParam
       sessionOperations.add(parsed.id);
       // Release the frame queue while retaining shutdown admission. Desktop input
       // belongs to this socket; durable session work survives response-transport loss.
-      void runWithGatewayIndependentRootWorkContinuation(() =>
-        dispatch(parsed.method === "worker.computer" ? computerLifetime.signal : undefined),
+      void runWithGatewayIndependentRootWorkContinuation(
+        () => dispatch(parsed.method === "worker.computer" ? computerLifetime.signal : undefined),
+        "worker:dispatch",
       )
         .catch(() => {
           respond(false, undefined, workerProtocolError("gateway-unavailable"));

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -255,7 +255,7 @@ export function emitGatewaySessionEndPluginHook(params: {
   });
   void runWithGatewayIndependentRootWorkContinuation(async () => {
     await hookRunner.runSessionEnd(payload.event, payload.context);
-  }).catch((err: unknown) => {
+  }, "hooks:session-end").catch((err: unknown) => {
     logVerbose(`session_end hook failed: ${String(err)}`);
   });
 }
@@ -300,7 +300,7 @@ export function emitGatewaySessionStartPluginHook(params: {
   });
   void runWithGatewayIndependentRootWorkContinuation(async () => {
     await hookRunner.runSessionStart(payload.event, payload.context);
-  }).catch((err: unknown) => {
+  }, "hooks:session-start").catch((err: unknown) => {
     logVerbose(`session_start hook failed: ${String(err)}`);
   });
 }

--- a/src/gateway/worker-environments/inference.ts
+++ b/src/gateway/worker-environments/inference.ts
@@ -372,8 +372,9 @@ export function createWorkerInferenceManager(options: {
       return;
     }
     entry.launched = true;
-    const operation = runWithGatewayIndependentRootWorkContinuation(() =>
-      executeEntry(entry),
+    const operation = runWithGatewayIndependentRootWorkContinuation(
+      () => executeEntry(entry),
+      "worker:dispatch",
     ).catch(() => {
       finish(entry, terminalError(entry.abortReason ?? "provider-error"));
     });

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -328,8 +328,9 @@ const saveSessionToMemory: HookHandler = (event) => {
       : ({ status: "available", content: null, originClass: "agent" } as const));
   const writePromise = isAutoReset
     ? saveSessionMemoryNow(event, agentId, transcript)
-    : runWithGatewayIndependentRootWorkContinuation(() =>
-        saveSessionMemoryNow(event, agentId, transcript),
+    : runWithGatewayIndependentRootWorkContinuation(
+        () => saveSessionMemoryNow(event, agentId, transcript),
+        "hooks:session-memory",
       );
   pendingSessionMemoryWrites.add(writePromise);
   void writePromise.finally(() => {

--- a/src/hooks/session-auto-reset.ts
+++ b/src/hooks/session-auto-reset.ts
@@ -67,9 +67,10 @@ export function emitSessionAutoResetHook(params: {
     previousSessionMemory: params.previousSessionMemory,
   });
 
-  void runWithGatewayIndependentRootWorkContinuation(() => triggerInternalHook(event)).catch(
-    (error: unknown) => {
-      logVerbose(`session:auto-reset hook failed: ${String(error)}`);
-    },
-  );
+  void runWithGatewayIndependentRootWorkContinuation(
+    () => triggerInternalHook(event),
+    "hooks:session-auto-reset",
+  ).catch((error: unknown) => {
+    logVerbose(`session:auto-reset hook failed: ${String(error)}`);
+  });
 }

--- a/src/infra/gateway-active-work.test.ts
+++ b/src/infra/gateway-active-work.test.ts
@@ -9,7 +9,10 @@ import {
   resetGatewayWorkAdmission,
   tryBeginGatewayRootWorkAdmission,
 } from "../process/gateway-work-admission.js";
-import { waitForGatewayActiveWork } from "./gateway-active-work.js";
+import {
+  createGatewayActiveWorkSnapshot,
+  waitForGatewayActiveWork,
+} from "./gateway-active-work.js";
 
 const activeRuns = new Map<string, EmbeddedAgentQueueHandle>();
 
@@ -46,7 +49,7 @@ describe("waitForGatewayActiveWork", () => {
 
   it("names active root request holders in deterministic order", async () => {
     const first = tryBeginGatewayRootWorkAdmission("ws:sessions.subscribe");
-    const second = tryBeginGatewayRootWorkAdmission("startup:acp-identity-reconcile");
+    const second = tryBeginGatewayRootWorkAdmission("cron:timer-tick");
     const third = tryBeginGatewayRootWorkAdmission("ws:sessions.subscribe");
 
     try {
@@ -55,13 +58,27 @@ describe("waitForGatewayActiveWork", () => {
       expect(result.snapshot.blockers).toContainEqual({
         kind: "root-request",
         count: 3,
-        message:
-          "3 active gateway request(s): startup:acp-identity-reconcile, ws:sessions.subscribe (2)",
+        message: "3 active gateway request(s): cron:timer-tick, ws:sessions.subscribe (2)",
       });
     } finally {
       first?.release();
       second?.release();
       third?.release();
+    }
+  });
+
+  it("does not mix default holders into an overridden root count", () => {
+    const admission = tryBeginGatewayRootWorkAdmission("ws:agent");
+    try {
+      const snapshot = createGatewayActiveWorkSnapshot({ getRootRequests: () => 1 });
+
+      expect(snapshot.blockers).toContainEqual({
+        kind: "root-request",
+        count: 1,
+        message: "1 active gateway request(s)",
+      });
+    } finally {
+      admission?.release();
     }
   });
 });

--- a/src/infra/gateway-active-work.test.ts
+++ b/src/infra/gateway-active-work.test.ts
@@ -5,6 +5,10 @@ import {
   clearActiveEmbeddedRun,
   setActiveEmbeddedRun,
 } from "../agents/embedded-agent-runner/runs.js";
+import {
+  resetGatewayWorkAdmission,
+  tryBeginGatewayRootWorkAdmission,
+} from "../process/gateway-work-admission.js";
 import { waitForGatewayActiveWork } from "./gateway-active-work.js";
 
 const activeRuns = new Map<string, EmbeddedAgentQueueHandle>();
@@ -14,6 +18,7 @@ afterEach(() => {
     clearActiveEmbeddedRun(sessionId, handle);
   }
   activeRuns.clear();
+  resetGatewayWorkAdmission();
 });
 
 describe("waitForGatewayActiveWork", () => {
@@ -37,5 +42,26 @@ describe("waitForGatewayActiveWork", () => {
       count: 1,
       message: "1 active embedded run(s)",
     });
+  });
+
+  it("names active root request holders in deterministic order", async () => {
+    const first = tryBeginGatewayRootWorkAdmission("ws:sessions.subscribe");
+    const second = tryBeginGatewayRootWorkAdmission("startup:acp-identity-reconcile");
+    const third = tryBeginGatewayRootWorkAdmission("ws:sessions.subscribe");
+
+    try {
+      const result = await waitForGatewayActiveWork(0);
+
+      expect(result.snapshot.blockers).toContainEqual({
+        kind: "root-request",
+        count: 3,
+        message:
+          "3 active gateway request(s): startup:acp-identity-reconcile, ws:sessions.subscribe (2)",
+      });
+    } finally {
+      first?.release();
+      second?.release();
+      third?.release();
+    }
   });
 });

--- a/src/infra/gateway-active-work.ts
+++ b/src/infra/gateway-active-work.ts
@@ -152,9 +152,8 @@ export function createGatewayActiveWorkSnapshot(
     `${counts.backgroundExecSessions} active background exec session(s)`,
   );
   add(counts.cronRuns, "cron-run", `${counts.cronRuns} active cron run(s)`);
-  const rootRequestHolders = inspectors.getRootRequestHolders
-    ? inspectors.getRootRequestHolders()
-    : inspectors.getRootRequests
+  const rootRequestHolders =
+    inspectors.getRootRequests && !inspectors.getRootRequestHolders
       ? []
       : (resolved.getRootRequestHolders?.() ?? []);
   const rootRequestHolderNames = rootRequestHolders.toSorted().slice(0, 8);

--- a/src/infra/gateway-active-work.ts
+++ b/src/infra/gateway-active-work.ts
@@ -5,7 +5,10 @@ import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.
 import { getActiveCronJobCount } from "../cron/active-jobs.js";
 import { getSuspensionVisibleCronTaskRunCount } from "../cron/service/active-run-cancellation.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
-import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
+import {
+  getActiveGatewayRootWorkCount,
+  getActiveGatewayRootWorkHolders,
+} from "../process/gateway-work-admission.js";
 import {
   getActiveSessionLifecycleMutationCount,
   getActiveSessionWorkAdmissionCount,
@@ -74,6 +77,7 @@ export type GatewayActiveWorkInspectors = {
   getActiveTasks: () => number;
   getTaskBlockers: () => ActiveTaskRestartBlocker[];
   getRootRequests: () => number;
+  getRootRequestHolders?: () => string[];
   getSessionAdmissions: () => number;
   getSessionMutations: () => number;
   getChatRuns: () => number;
@@ -91,6 +95,7 @@ const defaultInspectors: GatewayActiveWorkInspectors = {
   getActiveTasks: () => getInspectableActiveTaskRestartBlockers().length,
   getTaskBlockers: getInspectableActiveTaskRestartBlockers,
   getRootRequests: () => getActiveGatewayRootWorkCount({ excludeCurrent: true }),
+  getRootRequestHolders: () => getActiveGatewayRootWorkHolders({ excludeCurrent: true }),
   getSessionAdmissions: getActiveSessionWorkAdmissionCount,
   getSessionMutations: getActiveSessionLifecycleMutationCount,
   getChatRuns: () => 0,
@@ -147,7 +152,22 @@ export function createGatewayActiveWorkSnapshot(
     `${counts.backgroundExecSessions} active background exec session(s)`,
   );
   add(counts.cronRuns, "cron-run", `${counts.cronRuns} active cron run(s)`);
-  add(counts.rootRequests, "root-request", `${counts.rootRequests} active gateway request(s)`);
+  const rootRequestHolders = inspectors.getRootRequestHolders
+    ? inspectors.getRootRequestHolders()
+    : inspectors.getRootRequests
+      ? []
+      : (resolved.getRootRequestHolders?.() ?? []);
+  const rootRequestHolderNames = rootRequestHolders.toSorted().slice(0, 8);
+  if (rootRequestHolders.length > rootRequestHolderNames.length) {
+    rootRequestHolderNames.push(
+      `+${rootRequestHolders.length - rootRequestHolderNames.length} more`,
+    );
+  }
+  add(
+    counts.rootRequests,
+    "root-request",
+    `${counts.rootRequests} active gateway request(s)${rootRequestHolderNames.length > 0 ? `: ${rootRequestHolderNames.join(", ")}` : ""}`,
+  );
   add(
     counts.sessionAdmissions,
     "session-admission",

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -499,8 +499,9 @@ async function dispatchPendingWakeGroup(params: {
       let result: HeartbeatRunResult;
       try {
         // Admission spans the entire target turn so gateway drain can observe it.
-        result = await runWithGatewayIndependentRootWorkAdmission(async () =>
-          runAbortableHeartbeatWake(active, wakeOpts, abortSignal),
+        result = await runWithGatewayIndependentRootWorkAdmission(
+          async () => runAbortableHeartbeatWake(active, wakeOpts, abortSignal),
+          "heartbeat:wake",
         );
         wakeLog.debug(
           `completed: source=${pendingWake.source} intent=${pendingWake.intent} ` +

--- a/src/infra/restart-coordinator.test.ts
+++ b/src/infra/restart-coordinator.test.ts
@@ -129,8 +129,8 @@ describe("safe gateway restart coordinator", () => {
   });
 
   it("counts an admitted spawn handoff while excluding the preflight request", async () => {
-    const handoff = tryBeginGatewayRootWorkAdmission();
-    const request = tryBeginGatewayRootWorkAdmission();
+    const handoff = tryBeginGatewayRootWorkAdmission("subagents:spawn-handoff");
+    const request = tryBeginGatewayRootWorkAdmission("ws:gateway.restart");
     expect(handoff).not.toBeNull();
     expect(request).not.toBeNull();
 
@@ -151,7 +151,7 @@ describe("safe gateway restart coordinator", () => {
           {
             kind: "root-request",
             count: 1,
-            message: "1 active gateway request(s)",
+            message: "1 active gateway request(s): subagents:spawn-handoff",
           },
         ]);
       });

--- a/src/infra/restart-coordinator.ts
+++ b/src/infra/restart-coordinator.ts
@@ -1,4 +1,3 @@
-import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
 import {
   createGatewayActiveWorkSnapshot,
   type GatewayActiveWorkBlocker,
@@ -60,10 +59,6 @@ export function createSafeGatewayRestartPreflight(
 ): SafeGatewayRestartPreflight {
   const snapshot = createGatewayActiveWorkSnapshot({
     ...inspectors,
-    // Restart RPC preflight itself owns a root. Count every other admitted
-    // handoff so signal emission cannot split spawn from durable ownership.
-    getRootRequests:
-      inspectors.getRootRequests ?? (() => getActiveGatewayRootWorkCount({ excludeCurrent: true })),
     getSessionAdmissions: () => 0,
     getSessionMutations: () => 0,
     getChatRuns: () => 0,

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -671,7 +671,7 @@ async function emitPreparedGatewayRestart(
         }
         setFenceRollback?.(null);
       }
-    });
+    }, "restart:delayed");
   } catch (err) {
     if (!isGatewayRestartDraining()) {
       throw err;

--- a/src/plugin-sdk/delivery-queue-runtime.ts
+++ b/src/plugin-sdk/delivery-queue-runtime.ts
@@ -38,5 +38,5 @@ export async function drainPendingDeliveries(opts: DrainPendingDeliveriesOptions
           ? { match: false, bypassBackoff: false }
           : opts.selectEntry(entry, now),
     });
-  });
+  }, "delivery-queue:drain");
 }

--- a/src/plugin-sdk/webhook-request-guards.ts
+++ b/src/plugin-sdk/webhook-request-guards.ts
@@ -321,7 +321,7 @@ export function runDetachedWebhookWork<T>(run: () => Promise<T>): Promise<T> {
     // before any synchronous prefix in the detached callback can run.
     await Promise.resolve();
     return await run();
-  });
+  }, "webhook:detached");
 }
 
 /** Read a webhook request body with bounded size/time limits and translate failures into responses. */

--- a/src/process/gateway-work-admission.test-helpers.ts
+++ b/src/process/gateway-work-admission.test-helpers.ts
@@ -1,7 +1,7 @@
 import { beginGatewayRootWorkAdmissionWhenOpen } from "./gateway-work-admission.js";
 
 export async function runWithGatewayRootWorkAdmissionForTest<T>(run: () => Promise<T>): Promise<T> {
-  const admission = await beginGatewayRootWorkAdmissionWhenOpen();
+  const admission = await beginGatewayRootWorkAdmissionWhenOpen("test:root-work");
   try {
     return await admission.run(run);
   } finally {

--- a/src/process/gateway-work-admission.test.ts
+++ b/src/process/gateway-work-admission.test.ts
@@ -236,13 +236,13 @@ it("synchronously reserves a tracked continuation across a closed suspension fen
       "runtime:detached",
     );
     expect(getActiveGatewayRootWorkCount()).toBe(2);
-    expect(getActiveGatewayRootWorkHolders()).toEqual(["ws:agent", "ws:agent:continuation"]);
+    expect(getActiveGatewayRootWorkHolders()).toEqual(["runtime:detached", "ws:agent"]);
     expect(suspension?.rollback()).toBe(true);
   });
 
   root?.release();
   expect(getActiveGatewayRootWorkCount()).toBe(1);
-  expect(getActiveGatewayRootWorkHolders()).toEqual(["ws:agent:continuation"]);
+  expect(getActiveGatewayRootWorkHolders()).toEqual(["runtime:detached"]);
   releaseContinuation();
   await continuation;
   expect(getActiveGatewayRootWorkCount()).toBe(0);

--- a/src/process/gateway-work-admission.test.ts
+++ b/src/process/gateway-work-admission.test.ts
@@ -6,6 +6,7 @@ import {
   captureGatewayRootWorkAdmissionContinuationScope,
   GatewayDrainingError,
   getActiveGatewayRootWorkCount,
+  getActiveGatewayRootWorkHolders,
   getGatewayRestartDrainSignal,
   getGatewaySuspendAdmissionPhase,
   isGatewayRestartDrainError,
@@ -220,7 +221,7 @@ it("lets an admitted root cross only the reversible suspension fence", async () 
 });
 
 it("synchronously reserves a tracked continuation across a closed suspension fence", async () => {
-  const root = tryBeginGatewayRootWorkAdmission();
+  const root = tryBeginGatewayRootWorkAdmission("ws:agent");
   expect(root).not.toBeNull();
   let releaseContinuation = () => {};
   let continuation: Promise<void> | undefined;
@@ -232,16 +233,35 @@ it("synchronously reserves a tracked continuation across a closed suspension fen
         await new Promise<void>((resolve) => {
           releaseContinuation = resolve;
         }),
+      "runtime:detached",
     );
     expect(getActiveGatewayRootWorkCount()).toBe(2);
+    expect(getActiveGatewayRootWorkHolders()).toEqual(["ws:agent", "ws:agent:continuation"]);
     expect(suspension?.rollback()).toBe(true);
   });
 
   root?.release();
   expect(getActiveGatewayRootWorkCount()).toBe(1);
+  expect(getActiveGatewayRootWorkHolders()).toEqual(["ws:agent:continuation"]);
   releaseContinuation();
   await continuation;
   expect(getActiveGatewayRootWorkCount()).toBe(0);
+});
+
+it("uses the supplied origin when a continuation has no live parent", async () => {
+  let releaseContinuation = () => {};
+  const continuation = runWithGatewayIndependentRootWorkContinuation(
+    async () =>
+      await new Promise<void>((resolve) => {
+        releaseContinuation = resolve;
+      }),
+    "runtime:detached",
+  );
+
+  expect(getActiveGatewayRootWorkHolders()).toEqual(["runtime:detached"]);
+  releaseContinuation();
+  await continuation;
+  expect(getActiveGatewayRootWorkHolders()).toEqual([]);
 });
 
 it("retains an admitted request root across its handler return", async () => {

--- a/src/process/gateway-work-admission.ts
+++ b/src/process/gateway-work-admission.ts
@@ -383,8 +383,8 @@ export const runWithGatewayRootWorkReadmission = <T>(run: () => Promise<T>): Pro
 /**
  * Detaches required follow-up from the current admitted transaction.
  * A live parent synchronously reserves a tracked root even after restart or
- * suspension closes admission; callers without a live parent use the normal
- * independent-root fence.
+ * suspension closes admission. The detached root keeps its caller origin
+ * because it can outlive the parent; otherwise the normal fence applies.
  */
 export function runWithGatewayIndependentRootWorkContinuation<T>(
   run: () => Promise<T>,
@@ -394,7 +394,7 @@ export function runWithGatewayIndependentRootWorkContinuation<T>(
   if (!parent || parent.released) {
     return runWithGatewayIndependentRootWorkAdmission(run, origin);
   }
-  const admission = createGatewayRootWorkAdmission(`${parent.origin}:continuation`);
+  const admission = createGatewayRootWorkAdmission(origin);
   return admission.run(run).finally(admission.release);
 }
 

--- a/src/process/gateway-work-admission.ts
+++ b/src/process/gateway-work-admission.ts
@@ -16,6 +16,7 @@ export class GatewayDrainingError extends Error {
 }
 
 type GatewayRootWorkAdmission = {
+  origin: string;
   references: number;
   released: boolean;
   retiredByReset?: true;
@@ -81,8 +82,18 @@ export type GatewayRestartSignalAdmissionLease = {
   rollback: () => boolean;
 };
 
-function createGatewayRootWorkAdmission(): GatewayRootWorkAdmissionLease {
-  const admission: GatewayRootWorkAdmission = { references: 1, released: false };
+const GATEWAY_ROOT_WORK_ORIGIN_MAX_CHARS = 80;
+
+function createGatewayRootWorkAdmission(origin: string): GatewayRootWorkAdmissionLease {
+  const normalizedOrigin = origin
+    .trim()
+    .replaceAll(/\s+/g, " ")
+    .slice(0, GATEWAY_ROOT_WORK_ORIGIN_MAX_CHARS);
+  const admission: GatewayRootWorkAdmission = {
+    origin: normalizedOrigin || "gateway",
+    references: 1,
+    released: false,
+  };
   GATEWAY_WORK_ADMISSION_STATE.activeRootWork.add(admission);
   const release = createGatewayRootWorkRelease(admission);
   return {
@@ -255,7 +266,9 @@ export function rollbackGatewayRestartSignalFence(): boolean {
 }
 
 /** Root RPC/timer admission. Nested work in the same async chain counts once. */
-export function tryBeginGatewayRootWorkAdmission(): GatewayRootWorkAdmissionLease | null {
+export function tryBeginGatewayRootWorkAdmission(
+  origin = "gateway",
+): GatewayRootWorkAdmissionLease | null {
   const current = GATEWAY_WORK_ADMISSION_STATE.currentRootWork.getStore();
   if (current && !current.released) {
     return {
@@ -273,7 +286,7 @@ export function tryBeginGatewayRootWorkAdmission(): GatewayRootWorkAdmissionLeas
   ) {
     return null;
   }
-  return createGatewayRootWorkAdmission();
+  return createGatewayRootWorkAdmission(origin);
 }
 
 /**
@@ -288,7 +301,7 @@ export function tryBeginGatewayRestartStartupRootWorkAdmission(): GatewayRootWor
   ) {
     return null;
   }
-  return createGatewayRootWorkAdmission();
+  return createGatewayRootWorkAdmission("restart-startup");
 }
 
 /**
@@ -304,11 +317,13 @@ export function tryBeginGatewayPreparedRestartRootWorkAdmission(): GatewayRootWo
   ) {
     return null;
   }
-  return createGatewayRootWorkAdmission();
+  return createGatewayRootWorkAdmission("restart-prepared");
 }
 
 /** Independent detached work counts separately even when launched by an admitted parent. */
-function tryBeginGatewayIndependentRootWorkAdmission(): GatewayRootWorkAdmissionLease | null {
+function tryBeginGatewayIndependentRootWorkAdmission(
+  origin = "independent",
+): GatewayRootWorkAdmissionLease | null {
   if (
     GATEWAY_WORK_ADMISSION_STATE.restartDraining ||
     GATEWAY_WORK_ADMISSION_STATE.restartSignalPending ||
@@ -316,7 +331,7 @@ function tryBeginGatewayIndependentRootWorkAdmission(): GatewayRootWorkAdmission
   ) {
     return null;
   }
-  return createGatewayRootWorkAdmission();
+  return createGatewayRootWorkAdmission(origin);
 }
 
 /** Waits through a prepared lease, then joins the root-work set atomically. */
@@ -337,12 +352,13 @@ export async function beginGatewayRootWorkAdmissionWhenOpen(): Promise<GatewayRo
 
 export async function runWithGatewayIndependentRootWorkAdmission<T>(
   run: () => Promise<T>,
+  origin?: string,
 ): Promise<T> {
   while (true) {
     if (GATEWAY_WORK_ADMISSION_STATE.restartDraining) {
       throw new GatewayDrainingError("gateway is draining for restart");
     }
-    const admission = tryBeginGatewayIndependentRootWorkAdmission();
+    const admission = tryBeginGatewayIndependentRootWorkAdmission(origin);
     if (admission) {
       try {
         return await admission.run(run);
@@ -375,7 +391,7 @@ export function runWithGatewayIndependentRootWorkContinuation<T>(
   if (!parent || parent.released) {
     return runWithGatewayIndependentRootWorkAdmission(run);
   }
-  const admission = createGatewayRootWorkAdmission();
+  const admission = createGatewayRootWorkAdmission(`${parent.origin}:continuation`);
   return admission.run(run).finally(admission.release);
 }
 
@@ -453,6 +469,21 @@ export function getActiveGatewayRootWorkCount(opts?: { excludeCurrent?: boolean 
     count -= 1;
   }
   return Math.max(0, count);
+}
+
+/** Bounded, deterministic root-owner inventory for shutdown diagnostics. */
+export function getActiveGatewayRootWorkHolders(opts?: { excludeCurrent?: boolean }): string[] {
+  const current = GATEWAY_WORK_ADMISSION_STATE.currentRootWork.getStore();
+  const counts = new Map<string, number>();
+  for (const admission of GATEWAY_WORK_ADMISSION_STATE.activeRootWork) {
+    if (opts?.excludeCurrent === true && admission === current) {
+      continue;
+    }
+    counts.set(admission.origin, (counts.get(admission.origin) ?? 0) + 1);
+  }
+  return [...counts]
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([origin, count]) => (count > 1 ? `${origin} (${count})` : origin));
 }
 
 /** Atomically closes new suspension admission before synchronous inspection. */

--- a/src/process/gateway-work-admission.ts
+++ b/src/process/gateway-work-admission.ts
@@ -335,12 +335,14 @@ function tryBeginGatewayIndependentRootWorkAdmission(
 }
 
 /** Waits through a prepared lease, then joins the root-work set atomically. */
-export async function beginGatewayRootWorkAdmissionWhenOpen(): Promise<GatewayRootWorkAdmissionLease> {
+export async function beginGatewayRootWorkAdmissionWhenOpen(
+  origin = "gateway",
+): Promise<GatewayRootWorkAdmissionLease> {
   while (true) {
     if (GATEWAY_WORK_ADMISSION_STATE.restartDraining) {
       throw new GatewayDrainingError();
     }
-    const admission = tryBeginGatewayRootWorkAdmission();
+    const admission = tryBeginGatewayRootWorkAdmission(origin);
     if (admission) {
       return admission;
     }
@@ -375,7 +377,7 @@ export async function runWithGatewayIndependentRootWorkAdmission<T>(
 /** Re-admits preserved work whose inherited root was retired before it could run. */
 export const runWithGatewayRootWorkReadmission = <T>(run: () => Promise<T>): Promise<T> =>
   GATEWAY_WORK_ADMISSION_STATE.currentRootWork.getStore()?.retiredByReset
-    ? runWithGatewayIndependentRootWorkAdmission(run)
+    ? runWithGatewayIndependentRootWorkAdmission(run, "runtime:readmission")
     : run();
 
 /**
@@ -386,10 +388,11 @@ export const runWithGatewayRootWorkReadmission = <T>(run: () => Promise<T>): Pro
  */
 export function runWithGatewayIndependentRootWorkContinuation<T>(
   run: () => Promise<T>,
+  origin = "independent",
 ): Promise<T> {
   const parent = GATEWAY_WORK_ADMISSION_STATE.currentRootWork.getStore();
   if (!parent || parent.released) {
-    return runWithGatewayIndependentRootWorkAdmission(run);
+    return runWithGatewayIndependentRootWorkAdmission(run, origin);
   }
   const admission = createGatewayRootWorkAdmission(`${parent.origin}:continuation`);
   return admission.run(run).finally(admission.release);

--- a/src/skills/workshop/experience-review.ts
+++ b/src/skills/workshop/experience-review.ts
@@ -373,8 +373,9 @@ export async function runSkillExperienceReview(
   // inherited-context lane enqueue is refused as GatewayDrainingError on a
   // healthy gateway. Re-enter admission as independent root work; real
   // restart drain still refuses it.
-  await runWithGatewayIndependentRootWorkAdmission(() =>
-    runSkillExperienceReviewInner(candidate, deps),
+  await runWithGatewayIndependentRootWorkAdmission(
+    () => runSkillExperienceReviewInner(candidate, deps),
+    "skills:experience-review",
   );
 }
 

--- a/src/tasks/task-registry-delivery.ts
+++ b/src/tasks/task-registry-delivery.ts
@@ -203,7 +203,7 @@ async function runTaskDeliveryWithIndependentAdmission(
     return await runWithGatewayIndependentRootWorkContinuation(async () => {
       admitted = true;
       return await deliver();
-    });
+    }, "tasks:delivery");
   } catch (error) {
     // Late lifecycle callbacks must not leak a rejected detached promise after
     // restart closes admission. An already-admitted delivery still reports its

--- a/src/tasks/task-registry-mutation.ts
+++ b/src/tasks/task-registry-mutation.ts
@@ -124,7 +124,7 @@ function scheduleTaskFlowSyncRetry(task: TaskRecord, operation: string, attempt 
         });
         scheduleTaskFlowSyncRetry(current, operation, attempt + 1);
       }
-    }).catch((error: unknown) => {
+    }, "tasks:mutation").catch((error: unknown) => {
       taskRegistryLog.warn("Failed to admit parent flow sync retry from task", {
         operation,
         taskId,

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -1032,7 +1032,7 @@ function startScheduledSweep() {
     // Reversing this order can preserve phantom active work for another sweep.
     await sweepTaskRegistry();
     await runTaskFlowRegistryMaintenance();
-  }).then(clearSweepInProgress, clearSweepInProgress);
+  }, "tasks:maintenance").then(clearSweepInProgress, clearSweepInProgress);
 }
 
 export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintenanceSummary> {


### PR DESCRIPTION
## Summary

### High Level TLDR

Gateway shutdown and restart drains could wait the full 315-second budget and report only `1 active gateway request(s)`. This change records bounded semantic origins for root-work admissions and renders them in active-work diagnostics, so the next blocked drain names the lifecycle owner.

All 76 external production call sites of the independent-admission, independent-continuation, and wait-until-open helpers now supply an owner origin. Managed config reloads report `reload:config`; detached continuations preserve the child owner even while a parent root is live; safe-restart preflight preserves the canonical count/holder pair while excluding its own request.

### Root Cause

Gateway root admissions were anonymous records. Detached and waiting work therefore collapsed to generic `gateway` or `independent` labels, and the active-work snapshot had only a count. One indirect managed-reload function reference escaped the first call-site pass, and safe-restart preflight replaced only the root counter, which intentionally suppressed unmatched holder details.

The earlier ACP hypothesis was investigated and ruled out. The final base-to-head diff makes no ACP readiness or shutdown behavior change; it is diagnostic attribution only.

Origins are normalized and bounded to 80 characters. Holder summaries aggregate duplicate origins, sort deterministically, and display at most eight entries.

## What Problem This Solves

A blocked graceful shutdown or restart now identifies the root-work owners keeping the Gateway alive instead of ending with an anonymous count.

## Why This Change Was Made

The process-wide Gateway work-admission record is the architectural owner of root lifecycle state. Recording provenance there keeps one canonical count and holder inventory across WebSocket/HTTP requests, startup work, cron, tasks, hooks, workers, subagents, delivery, session maintenance, config reload, and exec-host work.

The complete PR is production +456/-354 (net +102) and tests/test support +71/-6 (net +65). Production growth provides bounded semantic attribution across 76 owner boundaries; it adds no config, protocol, persistence, timeout, migration, or fallback behavior.

## User Impact

On the next blocked drain, operators see actionable output such as:

```text
3 active gateway request(s): cron:timer-tick, ws:sessions.subscribe (2)
```

Safe-restart preflight shows the same holder detail, and continuation work reports its actual child owner rather than only the parent request.

## Evidence

- AST inventory: 76 external production call sites, 0 unlabeled.
- Regression proof failed before and passed after for:
  - managed config reload: `independent` -> `reload:config`;
  - safe-restart preflight: anonymous count -> named handoff;
  - live-parent continuation: parent-derived label -> supplied child owner.
- Focused Gateway run reached 485 tests: 480 passed; five unrelated cases were blocked by host-wide SQLite `/tmp` I/O errors. The new managed-reload assertion passed.
- `node scripts/check-changed.mjs` passed after refreshing the worktree dependency install, including max-lines, core/extension typechecks, lint, Plugin SDK surface, dead-code, database, and import-cycle guards.
- Mandatory branch Autoreview returned `scoped-clean` with no accepted/actionable findings.
- The earlier 28-plugin isolated no-client Gateway proof completed SIGUSR1 shutdown in 79ms and SIGTERM shutdown in 66ms, with no blocker in that idle scenario.

## What Was Not Tested

- The live operator Gateway was not stopped, restarted, rebuilt, or changed. Its original holder remains unknown until a real blocked drain emits the new diagnostic.
- Connected Android, macOS, and Control UI clients were not reproduced in the isolated run.
- Real channel credentials were not enabled.
- This is not presented as a fix for the underlying 315-second holder or as before/after proof that the drain itself is shorter.

## Verification

```bash
node scripts/run-vitest.mjs src/process/gateway-work-admission.test.ts \
  -t "synchronously reserves a tracked continuation across a closed suspension fence"

node scripts/run-vitest.mjs src/infra/restart-coordinator.test.ts \
  -t "counts an admitted spawn handoff while excluding the preflight request"

node scripts/run-vitest.mjs src/gateway/server-reload-handlers.test.ts \
  -t "aborts an in-flight managed Gmail restart when the reloader stops"

node scripts/run-vitest.mjs \
  src/process/gateway-work-admission.test.ts \
  src/infra/restart-coordinator.test.ts \
  src/gateway/config-reload.test.ts \
  src/gateway/server-reload-handlers.test.ts

node scripts/check-changed.mjs
.agents/skills/autoreview/scripts/autoreview --mode local --base 621ef9eaacec040daac334aefc935cd25112b929
```
