### PR TITLE
fix(agents): import the side-effect owner key from the module that exports it

### DIFF
--- a/src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts
@@ -1,5 +1,5 @@
 import { Type } from "typebox";
-import { getPluginToolSideEffectOwnerKey } from "../../../plugins/tools.js";
+import { getPluginToolSideEffectOwnerKey } from "../../../plugins/tool-metadata.js";
 import type { NestedToolActivity } from "../../../sessions/nested-tool-activity.js";
 import {
   attachInternalToolExecutionPreparer,


### PR DESCRIPTION
## What Problem This Solves

`main` does not type-check, so every open pull request goes red on `check-prod-types` and the checks that depend on it:

```
$ pnpm tsgo:core
src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts(2,10): error TS2305:
  Module '"../../../plugins/tools.js"' has no exported member 'getPluginToolSideEffectOwnerKey'.
[tsgo] FAILED (exit 1)
```

The failure is not in the branch that hits it. It reproduces on a clean checkout of `main` at `41dccabf179`.

## Why This Change Was Made

`getPluginToolSideEffectOwnerKey` is defined and exported in `src/plugins/tool-metadata.ts`. `src/plugins/tools.ts` never exported it — it only imports `copyPluginToolMeta` and `setPluginToolMeta` from that module, so it is not a barrel for this symbol.

`code-mode-reconciliation.ts` reached for it through `plugins/tools.js`. Its sibling in the same directory, `attempt-client-tools.ts`, already imports the same function from the module that owns it:

```ts
import {
  getPluginToolMeta,
  getPluginToolSideEffectOwnerKey,
} from "../../../plugins/tool-metadata.js";
```

This points the one wrong import at that same owner rather than adding a re-export, so the symbol keeps a single source and the two call sites in this directory agree.

## User Impact

`main` type-checks again, and pull requests stop inheriting a red `check-prod-types` that has nothing to do with their own changes. No runtime behavior changes: the imported function is the same one in both modules' object graph.

## Evidence

Broken on a clean `main` (`41dccabf179`), before any change:

```
$ git show origin/main:src/plugins/tools.ts | grep -c getPluginToolSideEffectOwnerKey
0
$ git grep -n "export function getPluginToolSideEffectOwnerKey" origin/main -- src/
origin/main:src/plugins/tool-metadata.ts:62:export function getPluginToolSideEffectOwnerKey(...
```

After this change, on the same checkout:

```
$ node scripts/run-tsgo.mjs -p tsconfig.core.json --noEmit
CORE_EXIT=0
```

`oxfmt --check` passes on the touched file.
