### PR TITLE
fix: honor embedding dimensions when memory search is disabled

### DIFF
--- a/docs/gateway/openai-http-api.md
+++ b/docs/gateway/openai-http-api.md
@@ -307,6 +307,8 @@ curl -sS http://127.0.0.1:18789/v1/embeddings \
 
 `/v1/embeddings` supports `input` as a string or array of strings.
 
+For models that support it, a positive integer `dimensions` requests the output vector size. It overrides the selected agent's active `memory.search.outputDimensionality` and also applies when memory search is disabled. Omitting it keeps the configured or provider default size.
+
 ## Related
 
 - [Configuration reference](/gateway/configuration-reference)

--- a/src/gateway/embeddings-http.test.ts
+++ b/src/gateway/embeddings-http.test.ts
@@ -40,6 +40,7 @@ let createEmbeddingProviderMock: ReturnType<
       provider: string;
       model: string;
       agentDir?: string;
+      dimensions?: number;
       acquireLocalService?: unknown;
     }) => Promise<{
       provider: {
@@ -168,6 +169,7 @@ beforeAll(async () => {
         provider: options.provider ?? "openai",
         model: options.model,
         agentDir: options.agentDir,
+        dimensions: options.dimensions,
         acquireLocalService: localServiceOptions.acquireLocalService,
       });
       return result;
@@ -362,6 +364,33 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
       resetConfigRuntimeState();
     }
   });
+
+  it.each([
+    { enabled: false, dimensions: 8, expected: 8 },
+    { enabled: true, dimensions: 8, expected: 8 },
+    { enabled: false, dimensions: undefined, expected: undefined },
+    { enabled: true, dimensions: undefined, expected: 16 },
+  ])(
+    "passes dimensions=$dimensions with memory search enabled=$enabled",
+    async ({ enabled, dimensions, expected }) => {
+      const configPath = createConfigIO().configPath;
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ memory: { search: { enabled, outputDimensionality: 16 } } }),
+      );
+      resetConfigRuntimeState();
+
+      const res = await postEmbeddings({
+        model: "openclaw/default",
+        input: "hello",
+        dimensions,
+      });
+
+      await expectDefaultEmbeddingResponse(res);
+      expect(createEmbeddingProviderMock.mock.calls.at(-1)?.[0].dimensions).toBe(expected);
+    },
+  );
 
   it("passes provider aliases and local-service acquisition to memory adapters", async () => {
     const configPath = createConfigIO().configPath;

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -63,7 +63,7 @@ const DEFAULT_MEMORY_EMBEDDING_PROVIDER = "openai";
 type EmbeddingProviderRequest = string;
 type MemorySearchEmbeddingConfig = Pick<
   NonNullable<ReturnType<typeof resolveMemorySearchConfig>>,
-  "local" | "remote" | "outputDimensionality" | "inputType" | "queryInputType" | "documentInputType"
+  "local" | "remote" | "inputType" | "queryInputType" | "documentInputType"
 >;
 
 const EMBEDDING_PROVIDER_RETIREMENTS = new Map<string, Set<MemoryEmbeddingProvider>>();
@@ -246,6 +246,7 @@ async function createConfiguredEmbeddingProvider(params: {
   agentDir: string;
   provider: EmbeddingProviderRequest;
   model: string;
+  dimensions?: number;
   memorySearch?: MemorySearchEmbeddingConfig;
 }): Promise<MemoryEmbeddingProvider> {
   const acquireLocalService = createConfiguredProviderLocalServiceAcquirer(() => params.cfg);
@@ -265,7 +266,7 @@ async function createConfiguredEmbeddingProvider(params: {
     inputType: params.memorySearch?.inputType,
     queryInputType: params.memorySearch?.queryInputType,
     documentInputType: params.memorySearch?.documentInputType,
-    dimensions: params.memorySearch?.outputDimensionality,
+    dimensions: params.dimensions,
     fallback: "none",
     acquireLocalService,
   };
@@ -408,12 +409,9 @@ export async function handleOpenAiEmbeddingsHttpRequest(
           agentDir,
           provider: target.provider,
           model: target.model,
-          memorySearch: memorySearch
-            ? {
-                ...memorySearch,
-                outputDimensionality: payload.dimensions ?? memorySearch.outputDimensionality,
-              }
-            : undefined,
+          // Request dimensions apply even when the agent has disabled memory search.
+          dimensions: payload.dimensions ?? memorySearch?.outputDimensionality,
+          memorySearch: memorySearch ?? undefined,
         }),
       (createdProvider) =>
         requestedProviderNeedsCleanup ||


### PR DESCRIPTION
Closes #133156

## What Problem This Solves

Fixes an issue where clients requesting a specific embedding size received the provider's default size when the selected agent had memory search disabled. With the bundled OpenAI provider, `dimensions: 8` silently returned 1,536 values.

## Why This Change Was Made

The HTTP request owner now resolves dimensions independently of the optional memory-search configuration and passes the result directly to the embedding adapter. This removes the temporary configuration overlay that lost the value when search was disabled. Configured sizes and provider defaults remain unchanged when the request omits dimensions; no configuration, authentication, storage, or protocol surface changes.

Production code is net **−2 lines** (+6/−8), with 29 test lines and 2 documentation lines added. The provider adapter remains the owner of upstream model support and wire encoding.

## User Impact

Clients can request supported embedding sizes whether or not memory search is enabled. The API documentation now states request precedence and the provider/model support requirement.

## Evidence

- Before production changes, an isolated real HTTP server running the Gateway handler, actual bundled OpenAI registration, and live OpenAI API returned HTTP 200 with **1,536** values for `dimensions: 8` when memory search was disabled; the same request returned **8** when enabled. This was actual handler/adapter/transport proof, not a complete Gateway bootstrap.
- The full Gateway regression failed before the repair only for disabled memory search plus explicit dimensions; the three enabled/default variants passed.
- After repair, all **58** tests passed across `src/gateway/embeddings-http.test.ts`, `extensions/openai/embedding-provider.test.ts`, and `extensions/openai/memory-embedding-adapter.test.ts`, including default sizes, generic providers, base64 encoding, validation, and cleanup.
- The identical live after-check returned **8** values with memory search both disabled and enabled, with HTTP 200 in both cases. The isolated port/state was cleaned up after both runs.
- The complete changed gate passed, including production/test type checking, typed lint, formatting, full-tree dead-export scans, dependency checks, and repository guards.
- Independent source and behavior verification and a separate review of commit `aaf15b835184e563502050406cfb0391dd027782` found no actionable issues. Fresh autoreview is scoped-clean at P0. The refresh onto repaired main preserves the exact patch and live-tested owner/dependency source. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33300175462) completed successfully on that head. Its actual checkout includes both the candidate and the repaired main baseline.

ClawSweeper disposition (latest review at 08:10 UTC): no actionable correctness or security issues. Its upstream-documentation limitation is resolved: the landing reviewer fetched the [official embeddings API reference](https://developers.openai.com/api/reference/resources/embeddings/methods/create), which documents optional output dimensions with a minimum of 1 for supported models. The actual direct API and Gateway-handler transport checks above independently prove the requested-size behavior. Its rank-up request for green exact-head CI is satisfied by the linked successful run; maintainer handling proceeds through the native landing workflow. The automated stored-data alert does not apply: the changed path returns request-local embeddings directly to HTTP clients; it changes no database schema, stored vector metadata, cache/index format, or migration behavior.

Release note: Gateway embeddings now honors requested dimensions when memory search is disabled.
