### PR TITLE
fix(test): reject unexpected SQLite fixture failures

### DIFF
--- a/src/node-host/node-worker-supervisor.lifetime.test.ts
+++ b/src/node-host/node-worker-supervisor.lifetime.test.ts
@@ -1,9 +1,12 @@
+import { once } from "node:events";
 import fs from "node:fs";
+import { createConnection } from "node:net";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WORKER_PROTOCOL_MAX_INFERENCE_PAYLOAD_BYTES } from "../../packages/gateway-protocol/src/schema/worker-inference.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
+import * as processTree from "../process/kill-tree.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { completeWorkerLaunchDescriptor } from "../worker/launch-descriptor.js";
 import {
@@ -14,6 +17,7 @@ import { NodeWorkerLaunchStore } from "./node-worker-launch-store.js";
 import {
   inspectNodeWorkerProcessIdentity,
   requireNodeWorkerProcessIdentity,
+  type NodeWorkerProcessIdentity,
 } from "./node-worker-process-identity.js";
 import {
   createNodeWorkerSupervisorFixture,
@@ -50,6 +54,61 @@ function launchInput(workspaceDir: string, launchId: string, prompt = "success")
   return input;
 }
 
+async function observeBackgroundConnection(url: string) {
+  const address = new URL(url);
+  const socket = createConnection({ host: address.hostname, port: Number(address.port) });
+  let error: NodeJS.ErrnoException | undefined;
+  let didClose = false;
+  socket.on("error", (value) => {
+    error = value;
+  });
+  const closed = new Promise<void>((resolve) => {
+    socket.once("close", () => {
+      didClose = true;
+      resolve();
+    });
+  });
+  const dispose = async () => {
+    socket.destroy();
+    await closed;
+  };
+  try {
+    await once(socket, "connect");
+    socket.resume();
+  } catch (cause) {
+    await dispose();
+    throw cause;
+  }
+  return {
+    socket,
+    closed,
+    dispose,
+    get didClose() {
+      return didClose;
+    },
+    get error() {
+      return error;
+    },
+  };
+}
+
+type BackgroundConnection = Awaited<ReturnType<typeof observeBackgroundConnection>>;
+
+function expectBackgroundRetired(
+  connection: BackgroundConnection,
+  ...owners: NodeWorkerProcessIdentity[]
+) {
+  // A freed listening port may belong to a replacement. This connection remains
+  // bound to the original server, and unknown process identity is not death.
+  expect(connection.didClose).toBe(true);
+  if (connection.error && connection.error.code !== "ECONNRESET") {
+    throw connection.error;
+  }
+  for (const owner of owners) {
+    expect(inspectNodeWorkerProcessIdentity(owner)).toMatch(/^(dead|reused)$/u);
+  }
+}
+
 describe("node worker environment lifetime", () => {
   it("reuses a retained worker at capacity across turns and cancellation until its environment stops", async () => {
     const capacitySnapshots: Array<{ total: number; available: number }> = [];
@@ -72,6 +131,7 @@ describe("node worker environment lifetime", () => {
     };
     const environment = testNodeWorkerEnvironmentIdentity(first);
     const store = new NodeWorkerLaunchStore({ env });
+    let connection: BackgroundConnection | undefined;
 
     try {
       const running = await supervisor.launch(first, TEST_WORKER_ENDPOINT);
@@ -80,6 +140,7 @@ describe("node worker environment lifetime", () => {
         fs.readFileSync(path.join(workspaceDir, `${first.launchId}.background.json`), "utf8"),
       ) as { pid: number; url: string };
       const server = requireNodeWorkerProcessIdentity(background.pid);
+      connection = await observeBackgroundConnection(background.url);
       expect(completed.state).toBe("completed");
       expect(store.get(first.launchId)).toMatchObject({ state: "running", worker: running.worker });
       expect(capacitySnapshots.at(-1)).toEqual({ total: 1, available: 0 });
@@ -151,22 +212,23 @@ describe("node worker environment lifetime", () => {
         expect(inspectNodeWorkerProcessIdentity(running.worker!)).toBe("live");
       }
       await supervisor.stopEnvironment(environment);
-      await vi.waitFor(() => {
-        expect(inspectNodeWorkerProcessIdentity(running.worker!)).not.toBe("live");
-        expect(inspectNodeWorkerProcessIdentity(server)).not.toBe("live");
-      });
-      await expect(fetch(background.url)).rejects.toThrow();
+      await vi.waitFor(() => expectBackgroundRetired(connection!, running.worker!, server));
       expect(capacitySnapshots.at(-1)).toEqual({ total: 1, available: 1 });
       expect(await supervisor.status(first.launchId)).toEqual(completed);
       expect((await supervisor.status(waiting.launchId))?.state).toBe("cancelled");
     } finally {
-      await supervisor.close();
+      try {
+        await supervisor.close();
+      } finally {
+        await connection?.dispose();
+      }
     }
   });
 
   it("closes a retained worker and its server after its turn receipt is already complete", async () => {
     const { supervisor, workspaceDir } = fixture({ capacity: 1 });
     const input = testWorkerLaunchInput(workspaceDir, "preview-close", "background-start");
+    let connection: BackgroundConnection | undefined;
     try {
       const running = await supervisor.launch(input, TEST_WORKER_ENDPOINT);
       const completed = await waitForTerminal(supervisor, input.launchId);
@@ -174,18 +236,19 @@ describe("node worker environment lifetime", () => {
         fs.readFileSync(path.join(workspaceDir, `${input.launchId}.background.json`), "utf8"),
       ) as { pid: number; url: string };
       const server = requireNodeWorkerProcessIdentity(background.pid);
+      connection = await observeBackgroundConnection(background.url);
       expect(await (await fetch(background.url)).text()).toBe("preview-ready");
 
       await supervisor.close();
 
       expect(await supervisor.status(input.launchId)).toEqual(completed);
-      await vi.waitFor(() => {
-        expect(inspectNodeWorkerProcessIdentity(running.worker!)).not.toBe("live");
-        expect(inspectNodeWorkerProcessIdentity(server)).not.toBe("live");
-      });
-      await expect(fetch(background.url)).rejects.toThrow();
+      await vi.waitFor(() => expectBackgroundRetired(connection!, running.worker!, server));
     } finally {
-      await supervisor.close();
+      try {
+        await supervisor.close();
+      } finally {
+        await connection?.dispose();
+      }
     }
   });
 
@@ -287,6 +350,7 @@ describe("node worker environment lifetime", () => {
         break;
       }
     }
+    let connection: BackgroundConnection | undefined;
     try {
       const original = await supervisor.launch(first, TEST_WORKER_ENDPOINT);
       const completed = await waitForTerminal(supervisor, first.launchId);
@@ -294,22 +358,143 @@ describe("node worker environment lifetime", () => {
         fs.readFileSync(path.join(workspaceDir, `${first.launchId}.background.json`), "utf8"),
       ) as { pid: number; url: string };
       const server = requireNodeWorkerProcessIdentity(background.pid);
+      connection = await observeBackgroundConnection(background.url);
+      next.descriptor.assignment.prompt = `background-start:${new URL(background.url).port}`;
 
       const replacement = await supervisor.launch(next, TEST_WORKER_ENDPOINT);
       expect(replacement.worker).not.toEqual(original.worker);
       expect((await waitForTerminal(supervisor, next.launchId)).state).toBe("completed");
-      await vi.waitFor(() => {
-        expect(inspectNodeWorkerProcessIdentity(original.worker!)).not.toBe("live");
-        expect(inspectNodeWorkerProcessIdentity(server)).not.toBe("live");
-      });
-      await expect(fetch(background.url)).rejects.toThrow();
+      await vi.waitFor(() => expectBackgroundRetired(connection!, original.worker!, server));
+      const replacementBackground = JSON.parse(
+        fs.readFileSync(
+          path.join(next.descriptor.assignment.workspaceDir, `${next.launchId}.background.json`),
+          "utf8",
+        ),
+      ) as { pid: number; url: string };
+      expect(replacementBackground.url).toBe(background.url);
+      expect(inspectNodeWorkerProcessIdentity(replacement.worker!)).toBe("live");
+      expect(
+        inspectNodeWorkerProcessIdentity(
+          requireNodeWorkerProcessIdentity(replacementBackground.pid),
+        ),
+      ).toBe("live");
+      expect(await (await fetch(background.url)).text()).toBe("preview-ready");
       expect(await supervisor.status(first.launchId)).toEqual(completed);
       if (binding === "owner epoch" || binding === "session") {
         await supervisor.stopEnvironment(testNodeWorkerEnvironmentIdentity(first));
         expect(inspectNodeWorkerProcessIdentity(replacement.worker!)).toBe("live");
       }
     } finally {
-      await supervisor.close();
+      try {
+        await supervisor.close();
+      } finally {
+        await connection?.dispose();
+      }
+    }
+  });
+
+  it("does not observe retirement before teardown, connection close, and definitive identity", async () => {
+    const { supervisor, workspaceDir } = fixture({ capacity: 1 });
+    const first = testWorkerLaunchInput(workspaceDir, "held-first", "background-start");
+    const next = structuredClone(first);
+    next.launchId = next.descriptor.assignment.turnId = "held-next";
+    next.descriptor.admission.ownerEpoch += 1;
+    const signalTree = processTree.signalProcessTree;
+    const heldSignals: Array<Parameters<typeof signalTree>> = [];
+    let connection: BackgroundConnection | undefined;
+    let restoreSignals: (() => void) | undefined;
+    let restoreClose: (() => void) | undefined;
+    let restoreIdentity: (() => void) | undefined;
+    let releaseClose: (() => void) | undefined;
+    let replacement: ReturnType<NodeWorkerSupervisor["launch"]> | undefined;
+    const releaseSignals = () => {
+      restoreSignals?.();
+      restoreSignals = undefined;
+      for (const args of heldSignals.splice(0)) {
+        signalTree(...args);
+      }
+    };
+    try {
+      const original = await supervisor.launch(first, TEST_WORKER_ENDPOINT);
+      await waitForTerminal(supervisor, first.launchId);
+      const background = JSON.parse(
+        fs.readFileSync(path.join(workspaceDir, `${first.launchId}.background.json`), "utf8"),
+      ) as { pid: number; url: string };
+      const server = requireNodeWorkerProcessIdentity(background.pid);
+      connection = await observeBackgroundConnection(background.url);
+      next.descriptor.assignment.prompt = `background-start:${new URL(background.url).port}`;
+      const socket = connection.socket;
+      const emit = socket.emit.bind(socket);
+      // Withhold only this owned socket's close delivery, after the real OS close.
+      const close = vi.spyOn(socket, "emit").mockImplementation((event, ...args) => {
+        if (event === "close") {
+          releaseClose = () => emit(event, ...args);
+          return true;
+        }
+        return emit(event, ...args);
+      });
+      restoreClose = () => close.mockRestore();
+      const signals = vi.spyOn(processTree, "signalProcessTree").mockImplementation((...args) => {
+        if (args[0] !== original.worker!.pid) {
+          signalTree(...args);
+          return;
+        }
+        heldSignals.push(args);
+      });
+      restoreSignals = () => signals.mockRestore();
+      const assertRetired = () => expectBackgroundRetired(connection!, original.worker!, server);
+      replacement = supervisor.launch(next, TEST_WORKER_ENDPOINT);
+      void replacement.catch(() => undefined);
+      await vi.waitFor(() => expect(heldSignals.length).toBeGreaterThan(0));
+      expect(await (await fetch(background.url)).text()).toBe("preview-ready");
+      expect(inspectNodeWorkerProcessIdentity(original.worker!)).toBe("live");
+      expect(inspectNodeWorkerProcessIdentity(server)).toBe("live");
+      expect(socket.closed).toBe(false);
+      expect(assertRetired).toThrow();
+
+      releaseSignals();
+      await vi.waitFor(() => expect(releaseClose).toBeDefined());
+      await replacement;
+      await waitForTerminal(supervisor, next.launchId);
+      await vi.waitFor(() => {
+        expect(inspectNodeWorkerProcessIdentity(original.worker!)).toMatch(/^(dead|reused)$/u);
+        expect(inspectNodeWorkerProcessIdentity(server)).toMatch(/^(dead|reused)$/u);
+      });
+      expect(assertRetired).toThrow();
+
+      const identity = await import("./node-worker-process-identity.js");
+      const inspect = identity.inspectNodeWorkerProcessIdentity;
+      const unknown = vi
+        .spyOn(identity, "inspectNodeWorkerProcessIdentity")
+        .mockImplementation((owner) =>
+          owner.pid === server.pid && owner.startTime === server.startTime
+            ? "unknown"
+            : inspect(owner),
+        );
+      restoreIdentity = () => unknown.mockRestore();
+      restoreClose();
+      restoreClose = undefined;
+      releaseClose!();
+      releaseClose = undefined;
+      await connection.closed;
+      expect(await (await fetch(background.url)).text()).toBe("preview-ready");
+      expect(inspectNodeWorkerProcessIdentity(server)).toBe("unknown");
+      expect(assertRetired).toThrow();
+
+      restoreIdentity();
+      restoreIdentity = undefined;
+      assertRetired();
+    } finally {
+      restoreIdentity?.();
+      releaseSignals();
+      restoreClose?.();
+      releaseClose?.();
+      try {
+        await supervisor.close();
+      } finally {
+        await connection?.dispose();
+        await Promise.allSettled([replacement]);
+      }
     }
   });
 

--- a/src/node-host/node-worker-supervisor.test-support.ts
+++ b/src/node-host/node-worker-supervisor.test-support.ts
@@ -125,13 +125,14 @@ if (mode === "admission-rearm") {
 } else if (mode === "tree") {
   grandchild = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
   fs.writeFileSync(path.join(descriptor.assignment.workspaceDir, "grandchild.pid"), String(grandchild.pid));
-} else if (mode === "background-start") {
+} else if (mode === "background-start" || mode.startsWith("background-start:")) {
+  const port = mode === "background-start" ? 0 : Number(mode.slice("background-start:".length));
   grandchild = spawn(process.execPath, ["-e", [
     "const server = require('node:http').createServer((req, res) => res.end('preview-ready'));",
-    "server.listen(0, '127.0.0.1', () => process.stdout.write(JSON.stringify({",
+    "server.listen(Number(process.argv[1]), '127.0.0.1', () => process.stdout.write(JSON.stringify({",
     "pid: process.pid, url: 'http://127.0.0.1:' + server.address().port,",
     "}) + '\\n'));",
-  ].join("\n")], { stdio: ["ignore", "pipe", "inherit"] });
+  ].join("\n"), String(port)], { stdio: ["ignore", "pipe", "inherit"] });
   background = await new Promise((resolve, reject) => {
     grandchild.once("error", reject);
     const output = createInterface({ input: grandchild.stdout });

--- a/test/scripts/run-vitest-state-cleanup.test.ts
+++ b/test/scripts/run-vitest-state-cleanup.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { promisify } from "node:util";
 import { afterEach, expect, it, vi } from "vitest";
+import type { JsonTestResults } from "vitest/reporters";
 import packageJson from "../../package.json" with { type: "json" };
 import { spawnOwnedVitestProcess } from "../../scripts/lib/vitest-process.mts";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
@@ -12,6 +13,75 @@ const execFileAsync = promisify(execFile);
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const repoRoot = path.resolve(import.meta.dirname, "../..");
 const posixIt = process.platform === "win32" ? it.skip : it;
+
+const intentionalFailure = "intentional failure after SQLite allocation";
+const counterfactualFailure = "counterfactual first-file failure after allocation receipt";
+const fixtureTests = [
+  [
+    "tui-pty-harness.e2e.test.ts",
+    "opens actual fallback SQLite and retains it until the worker finishes",
+  ],
+  [
+    "tui-pty-local.e2e.test.ts",
+    "keeps the same worker namespace alive across files and module resets",
+  ],
+] as const;
+
+function expectFixtureResults(
+  report: JsonTestResults,
+  testRoot: string,
+  failRun: boolean,
+  failFirstFile = false,
+) {
+  expect(report.testResults.map((file) => file.name)).toEqual(
+    fixtureTests.map(([filename]) => path.join(testRoot, filename)),
+  );
+  for (const [index, [, title]] of fixtureTests.entries()) {
+    const file = report.testResults[index]!;
+    const failure =
+      index === 0
+        ? failFirstFile
+          ? counterfactualFailure
+          : undefined
+        : failRun
+          ? intentionalFailure
+          : undefined;
+    const expectedStatus = failure ? "failed" : "passed";
+    expect(file.status, file.name).toBe(expectedStatus);
+    expect(file.message, file.name).toBe("");
+    expect(
+      file.assertionResults.map(({ ancestorTitles, fullName, title, status, failureMessages }) => ({
+        ancestorTitles,
+        fullName,
+        title,
+        status,
+        failureMessages: failureMessages?.map((message) => message.split("\n")[0]),
+      })),
+      file.name,
+    ).toEqual([
+      {
+        ancestorTitles: [],
+        fullName: title,
+        title,
+        status: expectedStatus,
+        failureMessages: failure ? [`AssertionError: ${failure}`] : [],
+      },
+    ]);
+  }
+  const failed = Number(failRun) + Number(failFirstFile);
+  expect(report).toMatchObject({
+    numTotalTests: 2,
+    numPassedTests: 2 - failed,
+    numFailedTests: failed,
+    numPendingTests: 0,
+    numTodoTests: 0,
+    numTotalTestSuites: 2,
+    numPassedTestSuites: 2 - failed,
+    numFailedTestSuites: failed,
+    numPendingTestSuites: 0,
+    success: failed === 0,
+  });
+}
 
 const cleanupCases = [
   { route: "main", pool: "threads", failRun: false },
@@ -29,9 +99,18 @@ const cleanupCases = [
 ].map((testCase) => ({ ...testCase, pauseAfterAck: false }));
 cleanupCases.push({ route: "profile-runner", pool: "forks", failRun: true, pauseAfterAck: true });
 
-posixIt.each(cleanupCases)(
-  "$route cleans its namespace after $pool completion (failed run: $failRun, paused after acknowledgement: $pauseAfterAck)",
-  async ({ route, pool, failRun, pauseAfterAck }) => {
+posixIt.each([
+  ...cleanupCases.map((testCase) => ({ ...testCase, failFirstFile: false })),
+  ...["threads", "forks"].map((pool) => ({
+    route: "main",
+    pool,
+    failRun: true,
+    pauseAfterAck: false,
+    failFirstFile: true,
+  })),
+])(
+  "$route cleans its namespace after $pool completion (failed run: $failRun, paused after acknowledgement: $pauseAfterAck, first-file failure: $failFirstFile)",
+  async ({ route, pool, failRun, pauseAfterAck, failFirstFile }) => {
     const root = tempDirs.make("oc-vt-state-");
     const tmp = path.join(root, "tmp");
     const home = path.join(root, "home");
@@ -89,13 +168,13 @@ export async function allocateResources() {
 `,
     );
     fs.writeFileSync(
-      path.join(testRoot, "tui-pty-harness.e2e.test.ts"),
+      path.join(testRoot, fixtureTests[0][0]),
       `import fs from "node:fs";
 import { expect, it } from "vitest";
 import { openOpenClawStateDatabase, closeOpenClawStateDatabaseForTest } from ${databaseModule};
 import { allocateResources } from "../../resources.ts";
 const resources = await allocateResources();
-it("opens actual fallback SQLite and retains it until the worker finishes", () => {
+it(${JSON.stringify(fixtureTests[0][1])}, () => {
   const first = openOpenClawStateDatabase();
   expect(first.db.prepare("SELECT count(*) AS count FROM sqlite_schema").get().count).toBeGreaterThan(0);
   closeOpenClawStateDatabaseForTest();
@@ -104,11 +183,12 @@ it("opens actual fallback SQLite and retains it until the worker finishes", () =
   const explicit = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: ${JSON.stringify(path.dirname(path.dirname(explicitPath)))} } });
   globalThis[Symbol.for("openclaw.stateLeakFixture")] = { reopened, explicit, resources, pid: process.pid };
   fs.writeFileSync(${JSON.stringify(receiptPath)}, JSON.stringify({ path: reopened.path }));
+  ${failFirstFile ? `expect.fail(${JSON.stringify(counterfactualFailure)});` : ""}
 });
 `,
     );
     fs.writeFileSync(
-      path.join(testRoot, "tui-pty-local.e2e.test.ts"),
+      path.join(testRoot, fixtureTests[1][0]),
       `import fs from "node:fs";
 import { expect, it, vi } from "vitest";
 const previous = globalThis[Symbol.for("openclaw.stateLeakFixture")];
@@ -116,7 +196,7 @@ vi.resetModules();
 const { openOpenClawStateDatabase } = await import(${databaseModule});
 const { allocateResources } = await import("../../resources.ts");
 const resources = await allocateResources();
-it("keeps the same worker namespace alive across files and module resets", () => {
+it(${JSON.stringify(fixtureTests[1][1])}, () => {
   expect(process.pid).toBe(previous.pid);
   expect(previous.reopened.db.isOpen).toBe(true);
   expect(previous.explicit.db.isOpen).toBe(true);
@@ -128,7 +208,7 @@ it("keeps the same worker namespace alive across files and module resets", () =>
   expect(resources.roots).not.toEqual(previous.resources.roots);
   fs.writeFileSync(${JSON.stringify(receiptPath)}, JSON.stringify({ path: current.path, resetVerified: true, resources: [previous.resources, resources] }));
   if (process.env.OPENCLAW_TUI_PTY_MIRROR_PATH) fs.appendFileSync(process.env.OPENCLAW_TUI_PTY_MIRROR_PATH, "namespace fixture frame\\n");
-  ${failRun ? 'expect.fail("intentional failure after SQLite allocation");' : ""}
+  ${failRun ? `expect.fail(${JSON.stringify(intentionalFailure)});` : ""}
 });
 `,
     );
@@ -147,6 +227,8 @@ export default {
   cacheDir: ${JSON.stringify(path.join(root, ".vite"))},
   test: {
     include: ["src/tui/*.e2e.test.ts"],
+    reporters: ["default", "json"],
+    outputFile: ${JSON.stringify(path.join(root, "report.json"))},
     pool: ${JSON.stringify(pool)}, isolate: false, fileParallelism: false, maxWorkers: 1,
     sequence: { sequencer: AlphabeticalSequencer },
     runner: ${JSON.stringify(path.join(repoRoot, "test/non-isolated-runner.ts"))},
@@ -231,6 +313,9 @@ process.exitCode = await runVitestBatch({ config: ${JSON.stringify(configPath)},
                   "--mirror-path",
                   mirrorPath,
                   "--",
+                  // The watcher supplies --reporter=dot, overriding config reporters.
+                  "--reporter=default",
+                  "--reporter=json",
                   ...vitestArgs,
                 ]
               : [
@@ -250,7 +335,7 @@ process.exitCode = await runVitestBatch({ config: ${JSON.stringify(configPath)},
         }),
       );
       expect(result.code, result.output).toBe(failRun ? 1 : 0);
-      if (failRun) expect(result.output).toContain("intentional failure after SQLite allocation");
+      if (failRun) expect(result.output).toContain(intentionalFailure);
       if (pauseAfterAck) {
         expect(JSON.parse(fs.readFileSync(pauseReceipt, "utf8"))).toEqual({
           paused: true,
@@ -305,6 +390,24 @@ process.exitCode = await runVitestBatch({ config: ${JSON.stringify(configPath)},
         ).toBeGreaterThan(0);
       } finally {
         explicit.close();
+      }
+      // Receipts can be written before Vitest marks a callback failed. Require its verdict,
+      // independently of the paused-worker control's separately asserted forced teardown.
+      const report = JSON.parse(
+        fs.readFileSync(path.join(root, "report.json"), "utf8"),
+      ) as JsonTestResults;
+      if (failFirstFile) {
+        // Both failures must be exact before testing rejection by the normal matrix validator.
+        expectFixtureResults(report, testRoot, failRun, true);
+        expect(() => expectFixtureResults(report, testRoot, failRun)).toThrowError(
+          expect.objectContaining({
+            actual: "failed",
+            expected: "passed",
+            message: expect.stringContaining(path.join(testRoot, fixtureTests[0][0])),
+          }),
+        );
+      } else {
+        expectFixtureResults(report, testRoot, failRun);
       }
     } finally {
       sibling.close();


### PR DESCRIPTION
Related: [#131313 — clean fallback SQLite state after test runs](https://github.com/openclaw/openclaw/pull/131313), already merged. This follows up its failure-control assertions, not the cleanup implementation. It also repairs the worker-retirement test observation that blocked this PR's CI.

<details>
<summary>Additional instructions</summary>

This upstream branch remains editable by repository maintainers.

</details>

## What Problem This Solves

The SQLite cleanup checks could accept an expected-failure run even when the allocation test also failed. Aggregate exit1, intentional-error text, and successful cleanup receipts did not distinguish the intended failure from an additional hidden failure.

During CI, a retained-worker test also demanded that a freed URL refuse connections after starting a replacement HTTP server. The replacement may legitimately reuse that port. The test must observe the original owner retiring, not permanent unavailability of its former address.

## Why This Change Was Made

The SQLite fixture now uses Vitest's built-in JSON reporter to require the exact two files, test identities, statuses, failure messages, and totals after the existing lifecycle assertions. The first test must pass; the second must pass or fail with precisely its intentional error. The PTY route explicitly forwards the reporters because its watcher supplies a CLI reporter override. Two fault-injection cases prove the same normal validator rejects an extra first-file failure in both pools.

The worker lifetime tests establish a TCP connection to the original server before teardown, then require that connection's close observation and definitive dead/reused process identities. Unknown identity is not death. The same observation applies to environment stop, supervisor close, and all eight retained-binding replacements. Fixture-only port selection forces the replacement onto the old port while retaining replacement liveness, completed receipts, capacity, stale-owner and binding coverage. A three-stage negative control withholds the old tree signal, owned close-event delivery, and definitive identity in turn; the same assertion rejects each state. Bounded waits and finally blocks preserve cleanup.

## User Impact

No product runtime, configuration, SQLite schema, persistence, dependency, or production seam changes. These tests stop reporting false greens for extra inner failures and false failures for valid listener replacement. No timeout values, worker settings, environment masks, sleeps, or retry loops were added to hide a failure.

## Evidence

Current head: [`1077d234361bb9612fb684b32f6f5063d0a6b019`](https://github.com/openclaw/openclaw/commit/1077d234361bb9612fb684b32f6f5063d0a6b019). The worker-test commit is a child of the already-tested SQLite head [`265bedd0c4e5ce3ddf422408fe0794aa9aa0d9d8`](https://github.com/openclaw/openclaw/commit/265bedd0c4e5ce3ddf422408fe0794aa9aa0d9d8), on base [`eb3e09b47bce8b7ddeba9e48e2f7737c264205ce`](https://github.com/openclaw/openclaw/commit/eb3e09b47bce8b7ddeba9e48e2f7737c264205ce).

**Production LOC: 0. Tests/test support: +319/-30, net +289 across three files.** A fresh managed Codex review of the complete combined delta was scoped-clean at P0, with no actionable findings. Node24.20.0, pnpm12.1.0 and Vitest4.1.11 were used locally.

### SQLite regression and dependency contract

Original reproduction base: [`136eab023035dd5943818f791d3c3db7d92e4491`](https://github.com/openclaw/openclaw/commit/136eab023035dd5943818f791d3c3db7d92e4491).

- Before the repair, both selected parent cases passed despite native reports containing two failed inner tests; all original receipts and cleanup assertions still passed.
- With the repaired validator, the same scenarios failed specifically because the first file was expected to pass but had failed.
- Original proof:107 passes across four files. Refreshed proof at265bedd0:136 passes across seven files, including all23 SQLite target cases and Code Mode recovery/attempt/client-tool siblings. These are separate runs, not additive counts.

Installed Vitest4.1.11 was inspected directly: `@vitest/runner/dist/chunk-artifact.js:2261-2317` checks elapsed time after synchronous callback completion; `vitest/dist/chunks/index.UpGiHP7g.js:3513-3629` implements JsonReporter; `vitest/dist/chunks/reporters.d.DtoKVV2s.d.ts:2295-2335` defines its public result types. Native JSON omits some global unhandled errors; exact fixture outcomes remain separate from process/teardown checks. The SQLite test bytes remain unchanged by the worker-test follow-up.

### Worker-retirement counterfactual and final proof

The forced-reuse RED retained the old fresh-fetch rejection. Both original process identities were dead, their established connection had closed, and different replacement processes listened on the same port. HTTP200 then made the old assertion fail. This proves the test observation defect; it does **not** identify the historical CI responder or establish a production leak.

The repaired tests and negative control passed. After a final simplification that routes missing close/marker events through existing bounded assertions, **103 tests passed across four files**: lifetime16, supervisor36, recovery10, child adapter41. The proportional coreTests gate passed formatting, guards, core test types, targeted lint, and diff-check. Every final command joined. Initial authoring type/lint failures were corrected before this final run; no dependency/config changes or unchanged retries were used.

The Node24.19 [TCP listen contract](https://github.com/nodejs/node/blob/v24.19.0/doc/api/net.md#L651) documents that port0 selects an unused address. Its [child close contract](https://github.com/nodejs/node/blob/v24.19.0/doc/api/child_process.md#L1439) distinguishes process exit from closed stdio. The actual supervisor, process-identity, PID, observation and child-adapter owners were inspected. Local proof uses real workers, HTTP listeners and sockets, but does not recreate the original160-file Linux scheduling order.

Final worker-test commands (Node24 on PATH):

```bash
node scripts/run-vitest.mjs src/node-host/node-worker-supervisor.lifetime.test.ts src/node-host/node-worker-supervisor.test.ts src/node-host/node-worker-supervisor.recovery.test.ts src/process/supervisor/adapters/child.test.ts
```

```bash
node scripts/check-changed.mjs --base 265bedd0c4e5ce3ddf422408fe0794aa9aa0d9d8 --head 265bedd0c4e5ce3ddf422408fe0794aa9aa0d9d8 -- src/node-host/node-worker-supervisor.lifetime.test.ts src/node-host/node-worker-supervisor.test-support.ts
```

The explicit paths selected the dirty working source before commit; equal frozen refs avoided classifying unrelated base drift. The final committed postimages match those tested bytes.

Earlier unchanged-runtime/SQLite commands at265bedd0:

```bash
node --import ./scripts/tsx.mjs scripts/build-all.mts ciArtifacts
```

```bash
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
```

```bash
node scripts/run-vitest.mjs test/scripts/run-vitest-state-cleanup.test.ts test/scripts/run-vitest-profile.test.ts test/scripts/vitest-process-group.test.ts test/scripts/vitest-fork-shutdown.test.ts src/agents/embedded-agent-runner/run/code-mode-reconciliation.test.ts src/agents/embedded-agent-runner/run/attempt.code-mode-reconciliation.test.ts src/agents/embedded-agent-runner/run/attempt-client-tools.test.ts
```

```bash
node scripts/check-changed.mjs --base eb3e09b47bce8b7ddeba9e48e2f7737c264205ce --head 265bedd0c4e5ce3ddf422408fe0794aa9aa0d9d8 -- test/scripts/run-vitest-state-cleanup.test.ts
```

```bash
git diff --check
```

The ordinary CI-artifact build and core types passed before this test-only follow-up. No production bytes changed afterward. Existing intentional forced-teardown controls remain; no operator-state mutation or shared-namespace cleanup sweep occurred.

### CI provenance and remaining gates

[CI33299134111/attempt1](https://github.com/openclaw/openclaw/actions/runs/33299134111/attempts/1) remains failed: its merge base inherited a stale `getPluginToolSideEffectOwnerKey` import. [#133155 — import the side-effect owner key from its owning module](https://github.com/openclaw/openclaw/pull/133155) already supplied the canonical fix; the earlier mechanical rebase included it without duplicating production code.

[CI33303074055/attempt1](https://github.com/openclaw/openclaw/actions/runs/33303074055/attempts/1) remains failed: job99234781058 failed the worker workspace-binding assertion described above, plus the aggregate gate. Its run metadata binds head265bedd0/base3483c892, but the exact checkout merge SHA and historical HTTP responder remain unestablished. One earlier local15-test pass did not clear that failure.

[CI 33306235431/attempt 1](https://github.com/openclaw/openclaw/actions/runs/33306235431/attempts/1) completed **SUCCESS** for exact head1077d234, including required gate99244787265. Saved Linux logs explicitly confirm all16 worker-lifetime and23 SQLite cleanup cases passed. The actual checkout was merge revisionaa854b8634443ebc93a6540d05d26bad8f732a46, with parents6549b0a7c534750d9d6cbef305233b162704b291 and1077d234. The [refreshed 10:28 UTC ClawSweeper review](https://github.com/openclaw/openclaw/pull/133160#issuecomment-5467405783) covers this head and finds no code/security defect; its CI/rank-up request is fulfilled, and its installed-dependency limitation is covered by the direct inspection and subprocess proof above. Its stored-data heuristic matches test-only fixture text: no production store, result shape, or schema changed, so no migration applies. Native prepare/merge gates still own the landing.

The historical5000ms SQLite timeout and generic worker exit remain unexplained. These test repairs do not establish OOM, clear those incidents, or claim full release validation. An initial misfiltered SQLite counterfactual selected no tests and is not counted.
