### PR TITLE
fix(markdown): preserve overlapping formatting in channel replies

### DIFF
--- a/extensions/googlechat/src/format.test.ts
+++ b/extensions/googlechat/src/format.test.ts
@@ -150,6 +150,25 @@ describe("formatGoogleChatText", () => {
     expect(formatGoogleChatText("https://example.com/a_b_c")).toBe("https://example.com/a_b_c");
   });
 
+  it.each([
+    ["**a**[**b** c](https://example.com)", "*ab* c (https://example.com)"],
+    ["[**label**](https://example.com)", "*label* (https://example.com)"],
+    ["[**label**](https://example.com)_tail_", "*label* (https://example.com)_tail_"],
+    ["**before [label](https://example.com) after**", "*before label (https://example.com) after*"],
+  ])("appends terminal link text once in %s", (markdown, expected) => {
+    expect(formatGoogleChatText(markdown)).toBe(expected);
+  });
+
+  it("counts terminal link text when chunking a crossed label", () => {
+    const chunks = formatGoogleChatTextChunks(
+      "**a**[**b** c](https://example.com) trailing text",
+      40,
+    );
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => new TextEncoder().encode(chunk).byteLength <= 40)).toBe(true);
+    expect(chunks.join(" ").match(/https:\/\/example\.com/g)).toHaveLength(1);
+  });
+
   it("handles newline-heavy messages without changing their content", () => {
     const text = "a\n".repeat(16_000);
     expect(formatGoogleChatText(text)).toBe(text.trimEnd());

--- a/extensions/googlechat/src/format.ts
+++ b/extensions/googlechat/src/format.ts
@@ -309,7 +309,7 @@ function renderGoogleChatIR(ir: MarkdownIR, markers: GoogleChatMarkers): string 
           (span) => span.start < link.end && span.end > link.start,
         );
         return /[<>|]/u.test(href) || /[<>|*_~`]/u.test(label) || labelHasStyles
-          ? { start: link.start, end: link.end, open: "", close: ` (${href})` }
+          ? { start: link.end, end: link.end, open: "", close: ` (${href})` }
           : { start: link.start, end: link.end, open: `<${href}|`, close: ">" };
       },
     },

--- a/extensions/telegram/src/rich-blocks.test.ts
+++ b/extensions/telegram/src/rich-blocks.test.ts
@@ -275,6 +275,16 @@ describe("markdownToTelegramRichBlocks", () => {
   });
 
   it.each([
+    { href: "https://example.com", target: { type: "url", url: "https://example.com" } },
+    { href: "#section", target: { type: "anchor_link", anchor_name: "section" } },
+  ])("preserves authored $href links with code-only labels", ({ href, target }) => {
+    const { blocks } = markdownToTelegramRichBlocks("[`foo`](" + href + ")");
+    expect(blocks).toEqual([
+      { type: "paragraph", text: { ...target, text: { type: "code", text: "foo" } } },
+    ]);
+  });
+
+  it.each([
     {
       markdown: "**A ||B** C|| D",
       text: [

--- a/extensions/telegram/src/rich-blocks.test.ts
+++ b/extensions/telegram/src/rich-blocks.test.ts
@@ -22,21 +22,23 @@ function tableMarkdown(columns: number): string {
   ].join("\n");
 }
 
-function collectUrls(text: RichText, out: string[] = []): string[] {
+function collectLinkTargets(text: RichText, out: string[] = []): string[] {
   if (typeof text === "string") {
     return out;
   }
   if (Array.isArray(text)) {
     for (const part of text) {
-      collectUrls(part, out);
+      collectLinkTargets(part, out);
     }
     return out;
   }
   if (text.type === "url") {
     out.push(text.url);
+  } else if (text.type === "anchor_link") {
+    out.push(`#${text.anchor_name}`);
   }
   if ("text" in text) {
-    collectUrls(text.text, out);
+    collectLinkTargets(text.text, out);
   }
   return out;
 }
@@ -229,7 +231,7 @@ describe("markdownToTelegramRichBlocks", () => {
       return;
     }
     expect(hasStyle(paragraph.text, "bold")).toBe(true);
-    expect(collectUrls(paragraph.text)).toEqual(["https://example.com"]);
+    expect(collectLinkTargets(paragraph.text)).toEqual(["https://example.com"]);
   });
 
   it("degrades native lists beyond 16 nesting levels", () => {
@@ -264,24 +266,40 @@ describe("markdownToTelegramRichBlocks", () => {
     expect(hasStyle(text, "strikethrough")).toBe(true);
     expect(hasStyle(text, "spoiler")).toBe(true);
     expect(hasStyle(text, "code")).toBe(true);
-    expect(collectUrls(text)).toEqual(["https://example.com"]);
+    expect(collectLinkTargets(text)).toEqual(["https://example.com"]);
   });
 
   it("handles overlapping bold and autolink", () => {
     const { blocks } = markdownToTelegramRichBlocks("**start https://example.com** end");
     const text = blocks[0] && blocks[0].type === "paragraph" ? blocks[0].text : "";
     expect(hasStyle(text, "bold")).toBe(true);
-    expect(collectUrls(text)).toEqual([]);
+    expect(collectLinkTargets(text)).toEqual([]);
   });
 
-  it.each([
-    { href: "https://example.com", target: { type: "url", url: "https://example.com" } },
-    { href: "#section", target: { type: "anchor_link", anchor_name: "section" } },
-  ])("preserves authored $href links with code-only labels", ({ href, target }) => {
-    const { blocks } = markdownToTelegramRichBlocks("[`foo`](" + href + ")");
-    expect(blocks).toEqual([
-      { type: "paragraph", text: { ...target, text: { type: "code", text: "foo" } } },
-    ]);
+  it.each(["https://example.com", "#section"])(
+    "preserves authored %s links with code-only labels",
+    (href) => {
+      for (const [prefix, suffix] of [
+        ["", ""],
+        ["", "bar"],
+        ["a", "z"],
+      ]) {
+        const markdown = `${prefix ? `\`${prefix}\`` : ""}[\`foo\`](${href})${suffix ? `\`${suffix}\`` : ""}`;
+        const { blocks, plainText } = markdownToTelegramRichBlocks(markdown);
+        const text = blocks[0]?.type === "paragraph" ? blocks[0].text : "";
+        expect(collectLinkTargets(text), markdown).toEqual([href]);
+        expect(hasStyle(text, "code"), markdown).toBe(true);
+        expect(plainText).toBe(`${prefix}foo${suffix}`);
+      }
+    },
+  );
+
+  it("preserves independently authored bold inside merged adjacent code spans", () => {
+    const { blocks, plainText } = markdownToTelegramRichBlocks("`a`**`b`**`c`");
+    const text = blocks[0]?.type === "paragraph" ? blocks[0].text : "";
+    expect(hasStyle(text, "code")).toBe(true);
+    expect(hasStyle(text, "bold")).toBe(true);
+    expect(plainText).toBe("abc");
   });
 
   it.each([
@@ -444,7 +462,7 @@ describe("markdownToTelegramRichBlocks", () => {
       skipEntityDetection: true,
     });
     const text = blocks[0] && blocks[0].type === "paragraph" ? blocks[0].text : "";
-    expect(collectUrls(text)).toEqual([]);
+    expect(collectLinkTargets(text)).toEqual([]);
   });
 
   it("keeps explicit markdown links when entity detection is skipped", () => {
@@ -452,7 +470,7 @@ describe("markdownToTelegramRichBlocks", () => {
       skipEntityDetection: true,
     });
     const text = blocks[0] && blocks[0].type === "paragraph" ? blocks[0].text : "";
-    expect(collectUrls(text)).toEqual(["https://example.com"]);
+    expect(collectLinkTargets(text)).toEqual(["https://example.com"]);
   });
 
   it("keeps unsupported local links as visible text and wraps file refs as code", () => {
@@ -463,20 +481,20 @@ describe("markdownToTelegramRichBlocks", () => {
     expect(plain).toContain("scripts/yougile.py");
     expect(plain).toContain("config");
     const text = blocks[0] && blocks[0].type === "paragraph" ? blocks[0].text : "";
-    expect(collectUrls(text)).toEqual([]);
+    expect(collectLinkTargets(text)).toEqual([]);
   });
 
   it("wraps auto-linked file refs as code so Telegram does not re-linkify them", () => {
     const { blocks } = markdownToTelegramRichBlocks("see README.md for details");
     const text = blocks[0] && blocks[0].type === "paragraph" ? blocks[0].text : "";
-    expect(collectUrls(text)).toEqual([]);
+    expect(collectLinkTargets(text)).toEqual([]);
     expect(hasStyle(text, "code")).toBe(true);
   });
 
   it("preserves authored file-style links while wrapping bare file refs as code", () => {
     const { blocks } = markdownToTelegramRichBlocks("README.md [README.md](https://README.md)");
     const text = blocks[0] && blocks[0].type === "paragraph" ? blocks[0].text : "";
-    expect(collectUrls(text)).toEqual(["https://README.md"]);
+    expect(collectLinkTargets(text)).toEqual(["https://README.md"]);
     expect(hasStyle(text, "code")).toBe(true);
   });
 
@@ -577,7 +595,7 @@ describe("splitTelegramRichBlocks", () => {
     const chunks = splitTelegramRichBlocks(blocks, { textLimit: 64 });
     const urls = chunks
       .flat()
-      .flatMap((block) => (block.type === "paragraph" ? collectUrls(block.text) : []));
+      .flatMap((block) => (block.type === "paragraph" ? collectLinkTargets(block.text) : []));
     expect(urls.length).toBeGreaterThan(0);
     expect(urls.every((url) => url.startsWith("https://example.com/"))).toBe(true);
   });

--- a/extensions/telegram/src/rich-blocks.test.ts
+++ b/extensions/telegram/src/rich-blocks.test.ts
@@ -274,6 +274,61 @@ describe("markdownToTelegramRichBlocks", () => {
     expect(collectUrls(text)).toEqual([]);
   });
 
+  it.each([
+    {
+      markdown: "**A ||B** C|| D",
+      text: [
+        { type: "bold", text: ["A ", { type: "spoiler", text: "B" }] },
+        { type: "spoiler", text: " C" },
+        " D",
+      ],
+    },
+    {
+      markdown: "||A **B|| C** D",
+      text: [
+        { type: "spoiler", text: ["A ", { type: "bold", text: "B" }] },
+        { type: "bold", text: " C" },
+        " D",
+      ],
+    },
+    {
+      markdown: "[A ||B](https://example.com) C|| D",
+      text: [
+        {
+          type: "url",
+          url: "https://example.com",
+          text: ["A ", { type: "spoiler", text: "B" }],
+        },
+        { type: "spoiler", text: " C" },
+        " D",
+      ],
+    },
+  ])("preserves crossing inline ranges in $markdown", ({ markdown, text }) => {
+    const result = markdownToTelegramRichBlocks(markdown);
+    expect(result.blocks).toEqual([{ type: "paragraph", text }]);
+    expect(result.plainText).toBe("A B C D");
+  });
+
+  it.each([
+    {
+      markdown: "**user[Thu] trailing**",
+      trailing: { type: "bold", text: " trailing" },
+    },
+    {
+      markdown: "[user[Thu] trailing](https://example.com)",
+      trailing: { type: "url", url: "https://example.com", text: " trailing" },
+    },
+  ])(
+    "preserves formatting outside a transcript annotation in $markdown",
+    ({ markdown, trailing }) => {
+      const result = markdownToTelegramRichBlocks(markdown);
+      expect(result.blocks).toEqual([
+        { type: "paragraph", text: [{ type: "code", text: "user[Thu]" }, trailing] },
+      ]);
+      expect(result.plainText).toBe("user[Thu] trailing");
+    },
+  );
+
   it("leaves bare URL query separators to Telegram entity detection", () => {
     const url = "https://example.com/wp-admin/post.php?post=100&action=edit";
     const { blocks } = markdownToTelegramRichBlocks(url);

--- a/extensions/telegram/src/rich-blocks.ts
+++ b/extensions/telegram/src/rich-blocks.ts
@@ -156,161 +156,76 @@ function irRangeToRichText(ir: MarkdownIR, rangeStart: number, rangeEnd: number)
     return "";
   }
 
-  const dominantAnnotationRanges = (slice.annotations ?? [])
-    .filter((span) => span.type === "assistant_transcript_role")
-    .map((span) => ({ start: span.start, end: span.end }));
-
-  const suppressed = (start: number, end: number) =>
-    dominantAnnotationRanges.some((range) => start < range.end && end > range.start);
-
-  const styleSpans = slice.styles.filter(
-    (span) => isInlineStyle(span.style) && !suppressed(span.start, span.end),
+  type Active = { start: number; end: number } & (
+    | { kind: "style"; style: InlineStyleKind }
+    | { kind: "annotation" }
+    | { kind: "link"; target: { kind: "url"; href: string } | { kind: "anchor"; name: string } }
   );
-  const annotationSpans = (slice.annotations ?? []).filter(
-    (span) => span.type === "assistant_transcript_role",
+  const spans: Active[] = [];
+  for (const span of slice.styles) {
+    if (isInlineStyle(span.style)) {
+      spans.push({ start: span.start, end: span.end, kind: "style", style: span.style });
+    }
+  }
+  for (const span of slice.annotations ?? []) {
+    spans.push({ start: span.start, end: span.end, kind: "annotation" });
+  }
+  for (const link of collectTelegramLinkActions(slice)) {
+    spans.push(
+      link.action.kind === "code"
+        ? { start: link.start, end: link.end, kind: "style", style: "code" }
+        : { start: link.start, end: link.end, kind: "link", target: link.action },
+    );
+  }
+  const rank = (span: Active) =>
+    span.kind === "style" ? INLINE_STYLE_RANK[span.style] : span.kind === "link" ? 50 : 0;
+  spans.sort(
+    (left, right) => left.start - right.start || right.end - left.end || rank(left) - rank(right),
   );
-  const links = collectTelegramLinkActions({
-    text,
-    styles: [],
-    links: slice.links.filter((link) => !suppressed(link.start, link.end)),
-  });
-
-  const boundaries = new Set<number>([0, text.length]);
-  for (const span of styleSpans) {
-    boundaries.add(span.start);
-    boundaries.add(span.end);
-  }
-  for (const span of annotationSpans) {
-    boundaries.add(span.start);
-    boundaries.add(span.end);
-  }
-  for (const link of links) {
-    boundaries.add(link.start);
-    boundaries.add(link.end);
-  }
-  const points = [...boundaries].toSorted((a, b) => a - b);
-
-  type Active =
-    | { kind: "style"; style: InlineStyleKind; end: number }
-    | { kind: "annotation"; end: number }
-    | {
-        kind: "link";
-        target: { kind: "url"; href: string } | { kind: "anchor"; name: string };
-        end: number;
-      };
-
+  const points = [
+    ...new Set([0, text.length, ...spans.flatMap((span) => [span.start, span.end])]),
+  ].toSorted((left, right) => left - right);
   const stack: Active[] = [];
   const root: RichText[] = [];
   const frameStack: RichText[][] = [root];
 
-  const pushNode = (node: RichText) => {
-    frameStack.at(-1)?.push(node);
-  };
-
-  const openStyleNode = (style: InlineStyleKind, end: number) => {
-    const container: RichText[] = [];
-    pushNode({ type: style, text: container });
-    stack.push({ kind: "style", style, end });
-    frameStack.push(container);
-  };
-
-  const openAnnotationNode = (end: number) => {
-    const container: RichText[] = [];
-    pushNode({ type: "code", text: container });
-    stack.push({ kind: "annotation", end });
-    frameStack.push(container);
-  };
-
-  const openLinkNode = (
-    target: { kind: "url"; href: string } | { kind: "anchor"; name: string },
-    end: number,
-  ) => {
-    const container: RichText[] = [];
-    pushNode(
-      target.kind === "url"
-        ? { type: "url", text: container, url: target.href }
-        : { type: "anchor_link", text: container, anchor_name: target.name },
-    );
-    stack.push({ kind: "link", target, end });
-    frameStack.push(container);
-  };
-
   for (let i = 0; i < points.length - 1; i += 1) {
     const start = points[i] ?? 0;
     const end = points[i + 1] ?? start;
-    while (stack.length > 0 && (stack.at(-1)?.end ?? 0) <= start) {
-      stack.pop();
-      frameStack.pop();
+    const covering = spans.filter((span) => span.start <= start && span.end > start);
+    const annotation = covering.find((span) => span.kind === "annotation");
+    const codeIndex = covering.findIndex((span) => span.kind === "style" && span.style === "code");
+    // Dominance applies only to the covered range. Surrounding formatting resumes
+    // after a transcript header or code span instead of being discarded wholesale.
+    const active = annotation
+      ? [annotation]
+      : codeIndex === -1
+        ? covering
+        : covering.slice(0, codeIndex + 1);
+    let shared = 0;
+    while (shared < stack.length && stack[shared] === active[shared]) {
+      shared += 1;
     }
-
-    const opening: Active[] = [];
-    for (const span of annotationSpans) {
-      if (span.start === start) {
-        opening.push({ kind: "annotation", end: span.end });
-      }
+    // Retain unchanged containers; rebuild the suffix when an ancestor expires,
+    // even if its child continues, so crossed ranges cannot leak formatting.
+    stack.length = shared;
+    frameStack.length = shared + 1;
+    for (const item of active.slice(shared)) {
+      const container: RichText[] = [];
+      const node: RichText =
+        item.kind === "link"
+          ? item.target.kind === "url"
+            ? { type: "url", text: container, url: item.target.href }
+            : { type: "anchor_link", text: container, anchor_name: item.target.name }
+          : { type: item.kind === "annotation" ? "code" : item.style, text: container };
+      frameStack.at(-1)?.push(node);
+      stack.push(item);
+      frameStack.push(container);
     }
-    for (const link of links) {
-      if (link.start !== start) {
-        continue;
-      }
-      if (link.action.kind === "url" || link.action.kind === "anchor") {
-        opening.push({ kind: "link", target: link.action, end: link.end });
-      } else {
-        opening.push({ kind: "style", style: "code", end: link.end });
-      }
-    }
-    for (const span of styleSpans) {
-      if (span.start === start && isInlineStyle(span.style)) {
-        opening.push({ kind: "style", style: span.style, end: span.end });
-      }
-    }
-    opening.sort((left, right) => {
-      if (left.end !== right.end) {
-        return right.end - left.end;
-      }
-      const leftRank =
-        left.kind === "style"
-          ? (INLINE_STYLE_RANK[left.style] ?? 99)
-          : left.kind === "link"
-            ? 50
-            : 0;
-      const rightRank =
-        right.kind === "style"
-          ? (INLINE_STYLE_RANK[right.style] ?? 99)
-          : right.kind === "link"
-            ? 50
-            : 0;
-      return leftRank - rightRank;
-    });
-
-    const inCode =
-      stack.some((entry) => entry.kind === "style" && entry.style === "code") ||
-      stack.some((entry) => entry.kind === "annotation");
-
-    for (const item of opening) {
-      if (item.kind === "annotation") {
-        openAnnotationNode(item.end);
-      } else if (item.kind === "link") {
-        if (!inCode && !stack.some((entry) => entry.kind === "link")) {
-          openLinkNode(item.target, item.end);
-        }
-      } else if (!inCode || item.style === "code") {
-        if (!(item.style === "code" && inCode)) {
-          openStyleNode(item.style, item.end);
-        }
-      }
-    }
-
     if (end > start) {
-      // Unlike Bot API html mode, blocks preserve bare `\n` inside paragraph
-      // RichText verbatim (live-verified 2026-07-15 via sendRichMessage echo).
-      pushNode(text.slice(start, end));
+      // Unlike Bot API HTML mode, rich paragraphs preserve bare newlines verbatim.
+      frameStack.at(-1)?.push(text.slice(start, end));
     }
-  }
-
-  while (stack.length > 0) {
-    stack.pop();
-    frameStack.pop();
   }
 
   return normalizeRichText(applyInlineHtmlIslands(root));

--- a/extensions/telegram/src/rich-blocks.ts
+++ b/extensions/telegram/src/rich-blocks.ts
@@ -43,7 +43,8 @@ const INLINE_STYLE_RANK: Record<string, number> = {
   bold: 1,
   italic: 2,
   strikethrough: 3,
-  code: 4,
+  // Authored links (rank 50) enclose equal-range code labels and remain clickable.
+  code: 51,
 };
 
 const TELEGRAM_RICH_LINK_HREF_RE = /^(?:https?:\/\/|tg:\/\/|mailto:|tel:)/i;

--- a/extensions/telegram/src/rich-blocks.ts
+++ b/extensions/telegram/src/rich-blocks.ts
@@ -38,7 +38,7 @@ const TELEGRAM_RICH_FORMAT_PROFILE = FormatCapabilityProfile.define({
   chunk: { limit: 32_768, unit: "chars" },
 });
 
-const INLINE_STYLE_RANK: Record<string, number> = {
+const INLINE_STYLE_RANK: Record<InlineStyleKind, number> = {
   spoiler: 0,
   bold: 1,
   italic: 2,

--- a/extensions/telegram/src/rich-blocks.ts
+++ b/extensions/telegram/src/rich-blocks.ts
@@ -43,8 +43,7 @@ const INLINE_STYLE_RANK: Record<string, number> = {
   bold: 1,
   italic: 2,
   strikethrough: 3,
-  // Authored links (rank 50) enclose equal-range code labels and remain clickable.
-  code: 51,
+  code: 4,
 };
 
 const TELEGRAM_RICH_LINK_HREF_RE = /^(?:https?:\/\/|tg:\/\/|mailto:|tel:)/i;
@@ -195,14 +194,10 @@ function irRangeToRichText(ir: MarkdownIR, rangeStart: number, rangeEnd: number)
     const end = points[i + 1] ?? start;
     const covering = spans.filter((span) => span.start <= start && span.end > start);
     const annotation = covering.find((span) => span.kind === "annotation");
-    const codeIndex = covering.findIndex((span) => span.kind === "style" && span.style === "code");
     // Dominance applies only to the covered range. Surrounding formatting resumes
-    // after a transcript header or code span instead of being discarded wholesale.
-    const active = annotation
-      ? [annotation]
-      : codeIndex === -1
-        ? covering
-        : covering.slice(0, codeIndex + 1);
+    // after a transcript header. Code is already literal in IR; its merged range
+    // may contain independently authored styles and clickable links.
+    const active = annotation ? [annotation] : covering;
     let shared = 0;
     while (shared < stack.length && stack[shared] === active[shared]) {
       shared += 1;

--- a/packages/markdown-core/src/render.crossing.test.ts
+++ b/packages/markdown-core/src/render.crossing.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { markdownToIR } from "./ir.js";
+import { renderMarkdownWithMarkers } from "./render.js";
+
+describe("renderMarkdownWithMarkers crossing spans", () => {
+  it.each([
+    {
+      name: "a style ending inside a spoiler",
+      markdown: "**A ||B** C|| D",
+      html: "<b>A <tg-spoiler>B</tg-spoiler></b><tg-spoiler> C</tg-spoiler> D",
+    },
+    {
+      name: "a spoiler ending inside a style",
+      markdown: "||A **B|| C** D",
+      html: "<tg-spoiler>A <b>B</b></tg-spoiler><b> C</b> D",
+    },
+    {
+      name: "a link ending inside a spoiler",
+      markdown: "[A ||B](https://example.com) C|| D",
+      html: '<a href="https://example.com">A <tg-spoiler>B</tg-spoiler></a><tg-spoiler> C</tg-spoiler> D',
+    },
+    {
+      name: "multiple styles ending inside a spoiler",
+      markdown: "**_A ||B_** C|| D",
+      html: "<b><i>A <tg-spoiler>B</tg-spoiler></i></b><tg-spoiler> C</tg-spoiler> D",
+    },
+  ])("preserves the text and formatting of $name", ({ markdown, html }) => {
+    const ir = markdownToIR(markdown, { enableSpoilers: true });
+    expect(
+      renderMarkdownWithMarkers(ir, {
+        styleMarkers: {
+          bold: { open: "<b>", close: "</b>" },
+          italic: { open: "<i>", close: "</i>" },
+          spoiler: { open: "<tg-spoiler>", close: "</tg-spoiler>" },
+        },
+        escapeText: (text) => text,
+        buildLink: (link) => ({
+          start: link.start,
+          end: link.end,
+          open: `<a href="${link.href}">`,
+          close: "</a>",
+        }),
+      }),
+    ).toBe(html);
+  });
+});

--- a/packages/markdown-core/src/render.ts
+++ b/packages/markdown-core/src/render.ts
@@ -306,7 +306,7 @@ export function renderMarkdownWithMarkers(
 
   const points = [...boundaries].toSorted((a, b) => a - b);
   // Links and styles share one stack so equal-end spans close in exact reverse open order.
-  const stack: { close: string; end: number }[] = [];
+  const stack: { open: string; close: string; end: number }[] = [];
   type OpeningItem =
     | { end: number; open: string; close: string; kind: "annotation"; index: number }
     | { end: number; open: string; close: string; kind: "link"; index: number }
@@ -321,11 +321,19 @@ export function renderMarkdownWithMarkers(
   let out = "";
 
   for (const [i, pos] of points.entries()) {
-    // Close all elements at this boundary before opening replacements at the same offset.
-    while (stack.length && stack[stack.length - 1]?.end === pos) {
-      const item = stack.pop();
-      if (item) {
+    // Range spans may cross (for example, a spoiler can outlive bold text).
+    // Close the ending ancestor and reopen its live children to keep valid nesting.
+    const firstClosingIndex = stack.findIndex((item) => item.end === pos);
+    if (firstClosingIndex !== -1) {
+      const closing = stack.splice(firstClosingIndex);
+      for (const item of closing.toReversed()) {
         out += item.close;
+      }
+      for (const item of closing) {
+        if (item.end > pos) {
+          out += item.open;
+          stack.push(item);
+        }
       }
     }
 
@@ -401,7 +409,7 @@ export function renderMarkdownWithMarkers(
       // Open outer spans first (larger end) so LIFO closes stay valid for same-start overlaps.
       for (const item of openingItems) {
         out += item.open;
-        stack.push({ close: item.close, end: item.end });
+        stack.push({ open: item.open, close: item.close, end: item.end });
       }
     }
 

--- a/packages/markdown-core/src/render.ts
+++ b/packages/markdown-core/src/render.ts
@@ -359,6 +359,12 @@ export function renderMarkdownWithMarkers(
     const openingLinks = linkStarts.get(pos);
     if (openingLinks && openingLinks.length > 0) {
       for (const [index, link] of openingLinks.entries()) {
+        // A renderer can collapse a link to terminal text. Emit the insertion
+        // before new spans open; it must never enter the reopenable marker stack.
+        if (link.start === link.end) {
+          out += link.open + link.close;
+          continue;
+        }
         openingItems.push({
           end: link.end,
           open: link.open,


### PR DESCRIPTION
Closes #133159.

## What Problem This Solves

Fixes an issue where Telegram replies with overlapping spoiler, bold, italic, or link ranges produce malformed HTML or carry formatting past its authored end. For `**A ||B** C||`, the HTML formatter left `<b>` unclosed and the rich renderer incorrectly kept `C` bold. Rich messages also dropped formatting outside a transcript header when the same style or link crossed that header.

## Why This Change Was Made

The Markdown IR describes flat ranges, which can legitimately cross. Both marker emission and Telegram's typed inline tree assumed an expired range would always be the top stack item. The shared marker owner now closes the affected suffix and reopens only ranges that continue; the rich owner derives each interval's active ranges and retains unchanged containers. This removes the obsolete opening helpers and whole-span annotation suppression, so annotations dominate only the text they cover. The rich renderer preserves authored links and styles even when adjacent code spans merge. Google Chat projects its terminal URL text to a zero-width marker insertion, so temporary style closure cannot repeat the URL; no SDK shape is added.

Parser normalization was rejected because flat ranges are valid IR and Signal already consumes them directly; Matrix has its own normalization. Telegram-only HTML repair was rejected because Slack and WhatsApp also use the shared marker renderer. Existing annotation splitting remains because it owns marker ordering around annotation boundaries. HTML-island parsing, configuration, public API shapes, and chunk limits are unchanged.

## User Impact

Overlapping formatting retains exactly the authored text ranges in ordinary Telegram HTML replies and typed rich messages. A transcript header no longer strips styles or links from surrounding text. Code-only link labels remain clickable, including labels beside other code spans. Google Chat emits a styled link’s URL once at the end of its label.

## Evidence

Focused proof, reviews, all selected local `check:changed` gates, and [exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33300164119) are complete and green. Native prepare/merge passed; landed as `8423dcd6a17d775c4814625f2ba6497fec0d9148`, with fetched-main ancestry and all six landed blobs verified against the reviewed head. The final CI runner checked merge `6b2a062c717fd76301e7e69f916dc8cad17db154`, containing the reviewed head and the separately repaired main commit.

Baseline: `3f1c84c706bf1e4c8bc7b2ab106ab96ff1fe6ddb`. Candidate: `b6527f6f4999df4edf362515898f02d014f3073e`. Runtime proof commit: `56dfd587bd8f898ffa7f703cbde0e53868759318`.

- Nine parser/renderer regression cases failed on the original owners before repair: four shared marker crossings, three rich crossings, and two rich annotation-overlap cases. Additional review-driven regressions reproduced lost URL/fragment targets beside adjacent code, suppressed authored bold, and repeated Google Chat URL suffixes before the owning paths were repaired.
- Final owner/sibling run: **444 tests, 13 files, 8 shards pass**. Includes shared annotation and render-aware chunking tests, Telegram HTML/chunks/rich blocks/HTML islands, Signal attributed ranges, Slack, Google Chat, Teams, WhatsApp, and Markdown table conversion.
- Independent verification checked **3,528** range-membership cases plus actual Telegram HTML/chunks/rich output, UTF-16 offsets, annotations, links, and literal code. Follow-up probes verified 6 terminal insertion orderings and 10 rich range memberships, including URL/fragment code-only labels with adjacent code, nested authored styles, and annotations.
- Full owner review at the runtime proof commit: autoreview scoped-clean at its default **P0-only** threshold and a separate Codex review with no actionable **P0–P2** findings after inspecting all marker callers. The final type-only commit has fresh clean autoreview and mechanical Codex P0–P2 review, plus independent runtime-identity verification.
- All selected local `check:changed` gates passed across the initial run and the focused continuation after correcting the rank-map type: core/plugin typechecking, targeted lint, dependency/ownership guards, and schema/database/media/import/auth checks.

Reproduction before:

```text
markdown: **A ||B** C||
text: A B C
bold: [0,3), spoiler: [2,5)
HTML: <b>A <tg-spoiler>B C</tg-spoiler>
```

After:

```html
<b>A <tg-spoiler>B</tg-spoiler></b><tg-spoiler> C</tg-spoiler>
```

The same maintained mock-gateway scenario also ran against the frozen baseline. It completed with a `fail` verdict and all three exact payload comparisons failed: bold, spoiler, and link closing markers were missing. The baseline evidence's generic scenario-details sentence was overly optimistic; its actual verdict and per-step observed payloads are the failure evidence. The final harness description is neutral.

The user-visible delivery proof uses the maintained QA Lab runner, mock OpenAI provider, an isolated Gateway, the real Telegram plugin, and Crabline's local Bot API. It asserts exact wire HTML for both crossing directions and a crossed authored link, rather than only a generic reply marker. The native QA Lab verdict is `pass`, with 1 scenario and 3 exact payload assertions on the runtime proof commit:

```json
{"sourceHead":"56dfd587bd8f898ffa7f703cbde0e53868759318","status":"pass","providerMode":"mock-openai","channel":"telegram","driver":"crabline","richMessages":false,"scenarios":1,"exactPayloadChecks":3}
```

The final source correction only narrows the existing style-rank map to the exhaustive `InlineStyleKind` key union, correcting TS2532 found by the extensions type gate. JavaScript emitted before and after is byte-identical (SHA256 `85eb1dc22cc8af5d7b5dad974dfab04312fb048944d13970fe0dc4acf06a410b`); independent verification binds the existing behavior proof to the final head. The failing extensions typecheck passes after the correction. A necessary rebase onto the separately repaired main commit `be5e79ca4713c33a11ccd56b2d728c19f0779f3d` preserves the complete six-file binary patch and every changed source/test blob byte-for-byte (stable patch ID `91d11083988c4e0f5aa02ed933d3109ee4f2fb49`). The previous hosted merge snapshot lacked that repair; it was cancelled after checking the actual runner checkout, rather than bypassing its failures.

The recorded `sendMessage` requests all used `parse_mode: "HTML"` and matched the expected balanced markup byte-for-byte. One earlier proof attempt passed the scenario but failed artifact publication because `/tmp` is a symlink on macOS; the final run uses the canonical output directory and completed normally without weakening the path guard.

Telegram Test Server proof was unavailable: the authenticated Convex CLI and broker environment were absent. No production account or operator state was used. Google Chat is not a supported Crabline channel; its exact formatter/chunker cases cover the terminal insertion while the real mock-gateway proof exercises the shared owner through Telegram. Installed Crabline supports ordinary `sendMessage` observations but not `sendRichMessage`; typed rich behavior is covered by actual renderer tests and independent range/contract checks, not claimed as a live rich-channel test. Telegram's documented recursive [RichTextUrl](https://core.telegram.org/bots/api#richtexturl), [RichTextCode](https://core.telegram.org/bots/api#richtextcode), and [RichTextAnchorLink](https://core.telegram.org/bots/api#richtextanchorlink) contract supports a code label inside an authored link.

Owner evidence: `packages/markdown-core/src/ir.ts` produces the ranges; `render.ts` owns marker nesting. Telegram `telegram-text-delivery.ts` calls `format.ts` / `format-render.ts`; the rich path calls `rich-blocks.ts`. Signal uses attributed ranges, Matrix normalizes its own spoiler crossings, and Slack/WhatsApp use the shared marker owner. The shared stack behavior is present in stable `v2026.7.1`; introduction is unknown.

Production LOC: **+73 / -148 = -75** across the marker owner and the two channel projections. Tests: **+160 / -12 = +148**. All reductions are the same-owner active-range simplification; no unrelated offsets, schema changes, config changes, dependencies, or fallback paths.

## Maintainer Disposition

Accepted for normal native landing under the authorized maintainer repair workflow. The latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/133161#issuecomment-5467390843) found no actionable correctness or security defect. Its shared message-delivery scope is accepted with the cross-channel owner tests, independent range checks, and before/after Gateway evidence retained above; the documented Test Server and typed-rich harness limitations remain explicit. Native review artifacts and exact-head hosted prepare gates passed at `b6527f6f4999df4edf362515898f02d014f3073e`.
