### PR TITLE
fix(code-mode): recovery fails after tool metadata extraction

### DIFF
--- a/src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts
@@ -1,5 +1,5 @@
 import { Type } from "typebox";
-import { getPluginToolSideEffectOwnerKey } from "../../../plugins/tools.js";
+import { getPluginToolSideEffectOwnerKey } from "../../../plugins/tool-metadata.js";
 import type { NestedToolActivity } from "../../../sessions/nested-tool-activity.js";
 import {
   attachInternalToolExecutionPreparer,


### PR DESCRIPTION
Related: #132932. Unblocks the shared build failures observed in #131441, #133143, and #133151.

## What Problem This Solves

Resolves a problem where builds from current main fail with a missing export and Code Mode recovery throws when preparing normal tools. Unrelated PRs also fail build, typecheck, and QA jobs when CI combines their branches with the affected main.

## Why This Change Was Made

The tool metadata extraction in #132932 moved the side-effect ownership helper into the dependency-light metadata owner but left one recovery import behind. Route that final reader to the same canonical owner already used by the client-tool path and public SDK; do not restore the obsolete runtime export or create another store. The metadata behavior and recovery policy are unchanged.

Provenance: verified the raw parent of 87b71210c8d1f1107e80548d9b9fb582bb849bd0 and its patch: the helper moved out of `src/plugins/tools.ts` while the reconciliation import stayed unchanged. No containing stable tag was found in the local tag set.

## User Impact

Developers can build current main again, and bounded Code Mode recovery can prepare normal tools without the missing-function exception. No configuration, protocol, schema, or public SDK change.

## Evidence

- Frozen baseline: `aace96c6720e283f95d84921c15610b33c9d3171`.
- Before: production core typecheck fails with TS2305 at `code-mode-reconciliation.ts:2`. Existing recovery tests fail 3/15 with `getPluginToolSideEffectOwnerKey is not a function` at the real recovery preparation boundary.
- After: the same core typecheck passes; all 15 existing recovery tests and 13 client-tool preparation tests pass.
- Commands: `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`; `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/code-mode-reconciliation.test.ts src/agents/embedded-agent-runner/run/attempt-client-tools.test.ts`.
- Formatting and `git diff --check` pass. Production LOC: +1/-1, net zero; test LOC: +0/-0. Existing tests provide the regression proof, so no duplicate test was added.
- Exact reviewed head: `d4172019980394296eb9dc6c64ed4ebd79c18bda`. Fresh autoreview and separate read-only Codex review found no actionable findings. Independent source review confirms the sole stale importer, shared WeakMap owner, migrated sibling callers, and unchanged upstream dynamic-tool request/response contract.
- Build and exact-head CI results will be recorded before landing.

Original shared failures: [browser production types](https://github.com/openclaw/openclaw/actions/runs/33298457330/job/99222128047), [QA build](https://github.com/openclaw/openclaw/actions/runs/33298447673/job/99222103442), and [TUI build](https://github.com/openclaw/openclaw/actions/runs/33298623128/job/99222576617).
