### PR TITLE
fix(outbound): deliver media through sendFormattedMedia-only adapters

### DIFF
--- a/src/infra/outbound/deliver-channel.ts
+++ b/src/infra/outbound/deliver-channel.ts
@@ -315,7 +315,10 @@ function createPluginHandler(
         cfg: params.cfg,
         accountId: params.accountId,
       }) === true,
-    supportsMedia: Boolean(messageMedia ?? sendMedia),
+    // sendFormattedMedia is a first-class media sender (deliver-core prefers it
+    // over sendMedia), so leaving it out here silently drops media for
+    // formatted-only adapters and records the fallback as a plain sent text.
+    supportsMedia: Boolean(messageMedia ?? sendMedia ?? outbound?.sendFormattedMedia),
     sanitizeText: outbound?.sanitizeText
       ? (payload) =>
           outbound.sanitizeText!({

--- a/src/infra/outbound/deliver-core.ts
+++ b/src/infra/outbound/deliver-core.ts
@@ -423,23 +423,18 @@ export async function deliverOutboundPayloadsCore(
           overrides: sendOverrides,
           consumeReplyTo: applySendReplyToConsumption,
         });
+        const sendMedia = deliveryHandler.sendFormattedMedia ?? deliveryHandler.sendMedia;
         for (const unit of mediaUnits) {
           if (unit.kind !== "media") {
             continue;
           }
           throwIfAborted(abortSignal);
           const resultIndex = results.length;
-          const delivery = deliveryHandler.sendFormattedMedia
-            ? await deliveryHandler.sendFormattedMedia(
-                unit.caption ?? "",
-                unit.mediaUrl,
-                withPreparedTarget(unit.overrides),
-              )
-            : await deliveryHandler.sendMedia(
-                unit.caption ?? "",
-                unit.mediaUrl,
-                withPreparedTarget(unit.overrides),
-              );
+          const delivery = await sendMedia(
+            unit.caption ?? "",
+            unit.mediaUrl,
+            withPreparedTarget(unit.overrides),
+          );
           const recorded = await recordIdentifiedDeliveryResult(delivery);
           adoptSuccessfulResultsSince(resultIndex);
           if (recorded) {

--- a/src/infra/outbound/deliver-core.ts
+++ b/src/infra/outbound/deliver-core.ts
@@ -398,7 +398,7 @@ export async function deliverOutboundPayloadsCore(
         }
       } else if (!deliveryHandler.supportsMedia) {
         log.warn(
-          "Plugin outbound adapter does not implement sendMedia; media URLs will be dropped and text fallback will be used",
+          "Plugin outbound adapter does not implement sendMedia or sendFormattedMedia; media URLs will be dropped and text fallback will be used",
           {
             channel,
             to,
@@ -408,7 +408,7 @@ export async function deliverOutboundPayloadsCore(
         const fallbackText = payloadSummary.text.trim();
         if (!fallbackText) {
           throw new Error(
-            "Plugin outbound adapter does not implement sendMedia and no text fallback is available for media payload",
+            "Plugin outbound adapter does not implement sendMedia or sendFormattedMedia and no text fallback is available for media payload",
           );
         }
         await sendTextChunks(deliveryHandler, fallbackText, sendOverrides);

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -3728,104 +3728,113 @@ describe("deliverOutboundPayloads", () => {
     ]);
   });
 
-  it("uses adapter-provided formatted senders and scoped media roots when available", async () => {
-    const sendText = vi.fn(async ({ text }: { text: string }) => ({
-      channel: "line" as const,
-      messageId: `fallback:${text}`,
-    }));
-    const sendMedia = vi.fn(async ({ text }: { text: string }) => ({
-      channel: "line" as const,
-      messageId: `media:${text}`,
-    }));
-    const sendFormattedText = vi.fn(async ({ text }: { text: string }) => [
-      { channel: "line" as const, messageId: `fmt:${text}:1` },
-      { channel: "line" as const, messageId: `fmt:${text}:2` },
-    ]);
-    const sendFormattedMedia = vi.fn(
-      async ({ text }: { text: string; mediaLocalRoots?: readonly string[] }) => ({
+  it.each([
+    { ordinaryMedia: true, caption: "photo", mediaUrls: ["file:///tmp/f.png"] },
+    { ordinaryMedia: false, caption: "photo", mediaUrls: ["file:///tmp/f.png"] },
+    { ordinaryMedia: false, caption: "", mediaUrls: ["file:///tmp/f.png"] },
+    {
+      ordinaryMedia: false,
+      caption: "album",
+      mediaUrls: ["file:///tmp/f.png", "file:///tmp/g.png"],
+    },
+  ])(
+    "uses formatted senders and scoped roots ($ordinaryMedia, $caption)",
+    async ({ ordinaryMedia, caption, mediaUrls }) => {
+      const sendText = vi.fn(async ({ text }: { text: string }) => ({
         channel: "line" as const,
-        messageId: `fmt-media:${text}`,
-      }),
-    );
-    setTestOutbound({ sendText, sendMedia, sendFormattedText, sendFormattedMedia }, "line");
+        messageId: `fallback:${text}`,
+      }));
+      const sendMedia = vi.fn(async ({ text }: { text: string }) => ({
+        channel: "line" as const,
+        messageId: `media:${text}`,
+      }));
+      const sendFormattedText = vi.fn(async ({ text }: { text: string }) => [
+        { channel: "line" as const, messageId: `fmt:${text}:1` },
+        { channel: "line" as const, messageId: `fmt:${text}:2` },
+      ]);
+      const sendFormattedMedia = vi.fn(
+        async ({
+          text,
+          mediaUrl,
+        }: {
+          text: string;
+          mediaUrl: string;
+          mediaLocalRoots?: readonly string[];
+        }) => ({
+          channel: "line" as const,
+          messageId: `fmt-media:${mediaUrl}:${text}`,
+        }),
+      );
+      setTestOutbound(
+        {
+          sendText,
+          ...(ordinaryMedia ? { sendMedia } : {}),
+          sendFormattedText,
+          sendFormattedMedia,
+        },
+        "line",
+      );
 
-    const textResults = await deliverOutboundPayloads({
-      cfg: { channels: { line: {} } } as OpenClawConfig,
-      channel: "line",
-      to: "U123",
-      accountId: "default",
-      payloads: [{ text: "hello **boss**" }],
-    });
+      const textResults = await deliverOutboundPayloads({
+        cfg: { channels: { line: {} } } as OpenClawConfig,
+        channel: "line",
+        to: "U123",
+        accountId: "default",
+        payloads: [{ text: "hello **boss**" }],
+      });
 
-    expect(sendFormattedText).toHaveBeenCalledTimes(1);
-    const formattedTextOptions = requireMockCallArg(sendFormattedText, "sendFormattedText") as
-      | { accountId?: unknown; text?: unknown; to?: unknown }
-      | undefined;
-    expect(formattedTextOptions?.to).toBe("U123");
-    expect(formattedTextOptions?.text).toBe("hello **boss**");
-    expect(formattedTextOptions?.accountId).toBe("default");
-    expect(sendText).not.toHaveBeenCalled();
-    expect(textResults.map((entry) => entry.messageId)).toEqual([
-      "fmt:hello **boss**:1",
-      "fmt:hello **boss**:2",
-    ]);
+      expect(sendFormattedText).toHaveBeenCalledTimes(1);
+      const formattedTextOptions = requireMockCallArg(sendFormattedText, "sendFormattedText") as
+        | { accountId?: unknown; text?: unknown; to?: unknown }
+        | undefined;
+      expect(formattedTextOptions?.to).toBe("U123");
+      expect(formattedTextOptions?.text).toBe("hello **boss**");
+      expect(formattedTextOptions?.accountId).toBe("default");
+      expect(sendText).not.toHaveBeenCalled();
+      expect(textResults.map((entry) => entry.messageId)).toEqual([
+        "fmt:hello **boss**:1",
+        "fmt:hello **boss**:2",
+      ]);
 
-    const cfg = { channels: { line: {} } } as OpenClawConfig;
-    await deliverOutboundPayloads({
-      cfg,
-      channel: "line",
-      to: "U123",
-      payloads: [{ text: "photo", mediaUrl: "file:///tmp/f.png" }],
-      session: { agentId: "work" },
-    });
+      const cfg = { channels: { line: {} } } as OpenClawConfig;
+      const onDeliveredPayload = vi.fn();
+      const mediaResults = await deliverOutboundPayloads({
+        cfg,
+        channel: "line",
+        to: "U123",
+        payloads: [{ text: caption, mediaUrls }],
+        session: { agentId: "work" },
+        onDeliveredPayload,
+      });
 
-    expect(sendFormattedMedia).toHaveBeenCalledTimes(1);
-    const sendFormattedMediaCall = requireMockCallArg(sendFormattedMedia, "sendFormattedMedia") as
-      | { mediaLocalRoots?: string[]; mediaUrl?: unknown; text?: unknown; to?: unknown }
-      | undefined;
-    expect(sendFormattedMediaCall?.to).toBe("U123");
-    expect(sendFormattedMediaCall?.text).toBe("photo");
-    expect(sendFormattedMediaCall?.mediaUrl).toBe("file:///tmp/f.png");
-    expect(sendFormattedMediaCall?.mediaLocalRoots).toContain(expectedPreferredTmpRoot);
-    expect(
-      sendFormattedMediaCall?.mediaLocalRoots?.some((root) =>
-        root.endsWith(path.join(".openclaw", "workspace-work")),
-      ),
-    ).toBe(true);
-    expect(sendMedia).not.toHaveBeenCalled();
-  });
-
-  it("keeps media delivery when the adapter implements only sendFormattedMedia", async () => {
-    const sendText = vi.fn(async ({ text }: { text: string }) => ({
-      channel: "matrix" as const,
-      messageId: `fallback:${text}`,
-    }));
-    const sendFormattedMedia = vi.fn(
-      async ({ text, mediaUrl }: { text: string; mediaUrl: string }) => ({
-        channel: "matrix" as const,
-        messageId: `fmt-media:${mediaUrl}:${text}`,
-      }),
-    );
-    setTestOutbound({ sendText, sendFormattedMedia });
-
-    const results = await deliverMatrix({
-      payloads: [{ text: "caption", mediaUrl: "https://example.com/file.png" }],
-    });
-
-    expect(sendFormattedMedia).toHaveBeenCalledTimes(1);
-    const mediaCall = requireMockCallArg(sendFormattedMedia, "sendFormattedMedia") as {
-      text?: unknown;
-      mediaUrl?: unknown;
-      to?: unknown;
-    };
-    expect(mediaCall.text).toBe("caption");
-    expect(mediaCall.mediaUrl).toBe("https://example.com/file.png");
-    expect(mediaCall.to).toBe("!room:example");
-    expect(sendText).not.toHaveBeenCalled();
-    expect(results.map((entry) => entry.messageId)).toEqual([
-      "fmt-media:https://example.com/file.png:caption",
-    ]);
-  });
+      expect(sendFormattedMedia).toHaveBeenCalledTimes(mediaUrls.length);
+      const sendFormattedMediaCall = requireMockCallArg(
+        sendFormattedMedia,
+        "sendFormattedMedia",
+      ) as
+        | { mediaLocalRoots?: string[]; mediaUrl?: unknown; text?: unknown; to?: unknown }
+        | undefined;
+      expect(sendFormattedMediaCall?.to).toBe("U123");
+      expect(sendFormattedMediaCall?.text).toBe(caption);
+      expect(sendFormattedMediaCall?.mediaUrl).toBe(mediaUrls[0]);
+      expect(sendFormattedMedia.mock.calls.map(([call]) => [call.text, call.mediaUrl])).toEqual(
+        mediaUrls.map((mediaUrl, index) => [index === 0 ? caption : "", mediaUrl]),
+      );
+      expect(mediaResults.map((entry) => entry.messageId)).toEqual(
+        mediaUrls.map((mediaUrl, index) => `fmt-media:${mediaUrl}:${index === 0 ? caption : ""}`),
+      );
+      expect(onDeliveredPayload).toHaveBeenCalledWith(
+        expect.objectContaining({ text: caption, mediaUrls }),
+      );
+      expect(sendFormattedMediaCall?.mediaLocalRoots).toContain(expectedPreferredTmpRoot);
+      expect(
+        sendFormattedMediaCall?.mediaLocalRoots?.some((root) =>
+          root.endsWith(path.join(".openclaw", "workspace-work")),
+        ),
+      ).toBe(true);
+      expect(sendMedia).not.toHaveBeenCalled();
+    },
+  );
 
   it("persists formatted sub-send results before a later adapter chunk fails", async () => {
     const firstResult = { channel: "line" as const, messageId: "fmt-1" };

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -3795,6 +3795,38 @@ describe("deliverOutboundPayloads", () => {
     expect(sendMedia).not.toHaveBeenCalled();
   });
 
+  it("keeps media delivery when the adapter implements only sendFormattedMedia", async () => {
+    const sendText = vi.fn(async ({ text }: { text: string }) => ({
+      channel: "matrix" as const,
+      messageId: `fallback:${text}`,
+    }));
+    const sendFormattedMedia = vi.fn(
+      async ({ text, mediaUrl }: { text: string; mediaUrl: string }) => ({
+        channel: "matrix" as const,
+        messageId: `fmt-media:${mediaUrl}:${text}`,
+      }),
+    );
+    setTestOutbound({ sendText, sendFormattedMedia });
+
+    const results = await deliverMatrix({
+      payloads: [{ text: "caption", mediaUrl: "https://example.com/file.png" }],
+    });
+
+    expect(sendFormattedMedia).toHaveBeenCalledTimes(1);
+    const mediaCall = requireMockCallArg(sendFormattedMedia, "sendFormattedMedia") as {
+      text?: unknown;
+      mediaUrl?: unknown;
+      to?: unknown;
+    };
+    expect(mediaCall.text).toBe("caption");
+    expect(mediaCall.mediaUrl).toBe("https://example.com/file.png");
+    expect(mediaCall.to).toBe("!room:example");
+    expect(sendText).not.toHaveBeenCalled();
+    expect(results.map((entry) => entry.messageId)).toEqual([
+      "fmt-media:https://example.com/file.png:caption",
+    ]);
+  });
+
   it("persists formatted sub-send results before a later adapter chunk fails", async () => {
     const firstResult = { channel: "line" as const, messageId: "fmt-1" };
     const sendFormattedText = vi.fn(
@@ -6046,7 +6078,7 @@ describe("deliverOutboundPayloads", () => {
     });
     const warnCall = requireMockCall(logMocks.warn, "warn");
     expect(warnCall[0]).toBe(
-      "Plugin outbound adapter does not implement sendMedia; media URLs will be dropped and text fallback will be used",
+      "Plugin outbound adapter does not implement sendMedia or sendFormattedMedia; media URLs will be dropped and text fallback will be used",
     );
     const warnContext = warnCall[1] as { channel?: unknown; mediaCount?: unknown } | undefined;
     expect(warnContext?.channel).toBe("matrix");
@@ -6071,7 +6103,7 @@ describe("deliverOutboundPayloads", () => {
     expect(requireMockCallArg(sendText, "sendText").text).toBe("caption");
     const warnCall = requireMockCall(logMocks.warn, "warn");
     expect(warnCall[0]).toBe(
-      "Plugin outbound adapter does not implement sendMedia; media URLs will be dropped and text fallback will be used",
+      "Plugin outbound adapter does not implement sendMedia or sendFormattedMedia; media URLs will be dropped and text fallback will be used",
     );
     const warnContext = warnCall[1] as { channel?: unknown; mediaCount?: unknown } | undefined;
     expect(warnContext?.channel).toBe("matrix");
@@ -6091,13 +6123,13 @@ describe("deliverOutboundPayloads", () => {
         payloads: [{ text: "   ", mediaUrl: "https://example.com/file.png" }],
       }),
     ).rejects.toThrow(
-      "Plugin outbound adapter does not implement sendMedia and no text fallback is available for media payload",
+      "Plugin outbound adapter does not implement sendMedia or sendFormattedMedia and no text fallback is available for media payload",
     );
 
     expect(sendText).not.toHaveBeenCalled();
     const warnCall = requireMockCall(logMocks.warn, "warn");
     expect(warnCall[0]).toBe(
-      "Plugin outbound adapter does not implement sendMedia; media URLs will be dropped and text fallback will be used",
+      "Plugin outbound adapter does not implement sendMedia or sendFormattedMedia; media URLs will be dropped and text fallback will be used",
     );
     const warnContext = warnCall[1] as { channel?: unknown; mediaCount?: unknown } | undefined;
     expect(warnContext?.channel).toBe("matrix");


### PR DESCRIPTION
Closes #133167.

## What Problem This Solves

Fixes an issue where users sending attachments through a channel adapter that provides `sendFormattedMedia` without `sendMedia` would receive only the caption, even though delivery was reported as successful. Attachments without captions failed instead.

## Why This Change Was Made

The channel handler advertised media support using only the ordinary and message-adapter senders, omitting the independently supported formatted sender. The capability predicate now includes that sender. Media dispatch selects the preferred bound sender once and uses one invocation, preserving formatted-media precedence, reply handling, and queue handoff guards while removing duplicated argument handling.

The existing no-media fallback remains unchanged apart from diagnostics that correctly name both outbound media senders. No plugin SDK signature, configuration, persistence, or authorization contract changes.

## User Impact

Formatted-only adapters deliver captioned, captionless, and multiple attachments. Delivery observers retain the media that was actually sent. Ordinary adapters and adapters offering both sender variants keep their existing behavior.

## Evidence

- The existing formatted-sender regression fixture now covers mixed and formatted-only adapters, including captionless and multiple attachments, scoped media access, returned identities, and delivered-payload media. Before the repair: three intended failures and one passing mixed-sender control. After: all cases pass.
- The complete delivery owner and message-planning suites pass: 225 tests across two files (10.34 seconds on the final reconstructed baseline).
- A temporary configured adapter was exercised through the real durable sender, preparation, SQLite queue, media staging, handler, and loopback recipient. Five cases cover formatted-only captioned, captionless, and multiple attachments, plus ordinary-only and mixed-sender controls. Before: three formatted-only failures and two passing controls. After: all five pass, with six actual image deliveries.
- Final baseline: the two original owners were loaded from trusted parent `aace96c6720e283f95d84921c15610b33c9d3171`, then the exact accepted candidate source was restored (tree `0816b9e96326f10e62a06dde2a46cb968648d4b1`). The before proof took 4.52 seconds and the after proof 3.84 seconds. All source hashes and temporary-state cleanup were verified.
- The image fixture was generated with Rastermill and validated by a forced Photon decode/re-encode: exact 70-byte PNG, 1×1 pixels, SHA-256 `44a9461db5ad9f59748d699b4a2485a14eaa7a20023df53e2c82debce6fbd5a3`. The recipient verifies bytes, MIME type, filename and caption; returned receipts, progress callbacks and the actual delivered-payload observer are checked against those deliveries. All files, state and the recipient were temporary and isolated.
- This proves the configured-adapter delivery boundary; it does not claim a physical channel, full Gateway process, or optional session-transcript mirror run.
- Source review and fresh independent reviews found no actionable issue. Production LOC: +12/−14 (net −2); tests: +107/−66 (net +41), primarily extending the existing fixture.
- The complete canonical changed-file gate passes, including core/core-test typechecks, lint, formatting, import-cycle checks, and repository guards. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33314078044) passed for follow-up commit `eaedfb70c25d60caa4343b043be006246fbe5d37`, including the required `openclaw/ci-gate`. The run checked the actual merge of that head into main `f46f9b5aa39feaec7eda5d9d480972566b6aabf5`.

## ClawSweeper Follow-up

The latest ClawSweeper review of the corrected head found no actionable issue and accepted the configured-adapter evidence. Its remaining check and rank-up request, successful exact-head CI, is now satisfied. The narrower proof scope remains explicit; no external channel credentials or provider calls were used.

Thanks @ruel225 for the original repair. The original commit and credit are preserved; the follow-up consolidates dispatch and extends the regression coverage.
