### PR TITLE
test: reuse immutable native PR bootstrap fixtures

### DIFF
--- a/test/scripts/pr-merge-outcome.test.ts
+++ b/test/scripts/pr-merge-outcome.test.ts
@@ -1,6 +1,8 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import {
   chmodSync,
+  constants as fsConstants,
+  cpSync,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -10,21 +12,19 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const temps = useAutoCleanupTempDirTracker(afterEach);
+const templateDirs = useAutoCleanupTempDirTracker(afterAll);
+let fixtureTemplate: ReturnType<typeof createFixtureTemplate> | undefined;
 const scripts = join(process.cwd(), "scripts");
 const outcomeRef = "refs/openclaw/pr-merge-outcomes/123";
 const lockRef = "refs/openclaw/pr-operation-locks/123";
 const describePosix = process.platform === "win32" ? describe.skip : describe;
 const unknownProjection = { mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" };
 
-function fixture(sourceMessage?: string, sourceVersions: Array<[string, string?]> = [["after\n"]]) {
-  const root = realpathSync(temps.make("pr-merge-outcome-"));
-  const remote = join(root, "remote.git");
-  const repo = join(root, "repo");
-  mkdirSync(repo);
+function createFixtureGit(repo: string) {
   const git = (args: string[], input?: string, cwd = repo) =>
     execFileSync("git", ["-c", "commit.gpgsign=false", "-c", "core.hooksPath=/dev/null", ...args], {
       cwd,
@@ -32,14 +32,6 @@ function fixture(sourceMessage?: string, sourceVersions: Array<[string, string?]
       encoding: "utf8",
       stdio: ["pipe", "pipe", "pipe"],
     }).trim();
-  git(["init", "-q", "-b", "main"]);
-  git(["config", "user.name", "Merge Fixture"]);
-  git(["config", "user.email", "fixture@example.invalid"]);
-  git(["init", "-q", "--bare", remote]);
-  git(["remote", "add", "origin", remote]);
-  // Production URLs still use the real Git transport, redirected only in this disposable repo.
-  git(["config", `url.${remote}.insteadOf`, "https://github.com/fixture/repo"]);
-  git(["config", "--add", `url.${remote}.insteadOf`, "https://github.com/fixture/repo.git"]);
   const tree = (owner: string, sibling = "stable\n") => {
     const a = git(["hash-object", "-w", "--stdin"], owner);
     const b = git(["hash-object", "-w", "--stdin"], sibling);
@@ -47,14 +39,48 @@ function fixture(sourceMessage?: string, sourceVersions: Array<[string, string?]
   };
   const commit = (contents: string, parents: string[], message = "Fixture commit\n") =>
     git(["commit-tree", contents, ...parents.flatMap((parent) => ["-p", parent])], message);
+  return { git, tree, commit };
+}
+
+function createFixtureTemplate(directory: string) {
+  const root = realpathSync(directory);
+  const repo = join(root, "repo");
+  const remote = join(root, "remote.git");
+  mkdirSync(repo);
+  const { git, tree, commit } = createFixtureGit(repo);
+  git(["init", "-q", "-b", "main"]);
+  git(["config", "user.name", "Merge Fixture"]);
+  git(["config", "user.email", "fixture@example.invalid"]);
+  git(["init", "-q", "--bare", remote]);
   const base = commit(tree("before\n"), []);
+  git(["update-ref", "refs/heads/main", base]);
+  return { repo, remote, base };
+}
+
+function fixture(sourceMessage?: string, sourceVersions: Array<[string, string?]> = [["after\n"]]) {
+  const root = realpathSync(temps.make("pr-merge-outcome-"));
+  const remote = join(root, "remote.git");
+  const repo = join(root, "repo");
+  const template = (fixtureTemplate ??= createFixtureTemplate(
+    templateDirs.make("pr-merge-outcome-template-"),
+  ));
+  // Only the common base is reused. Source commits stay fresh, loose and private
+  // so corruption, GC, attribution and multi-commit rebase cases keep their proof.
+  const copyOptions = { recursive: true, mode: fsConstants.COPYFILE_FICLONE };
+  cpSync(template.repo, repo, copyOptions);
+  cpSync(template.remote, remote, copyOptions);
+  const { base } = template;
+  const { git, tree, commit } = createFixtureGit(repo);
+  git(["remote", "add", "origin", remote]);
+  // Production URLs still use the real Git transport, redirected only in this disposable repo.
+  git(["config", `url.${remote}.insteadOf`, "https://github.com/fixture/repo"]);
+  git(["config", "--add", `url.${remote}.insteadOf`, "https://github.com/fixture/repo.git"]);
   const sourceCommits: string[] = [];
   let head = base;
   for (const [owner, sibling] of sourceVersions) {
     head = commit(tree(owner, sibling), [head], sourceMessage);
     sourceCommits.push(head);
   }
-  git(["update-ref", "refs/heads/main", base]);
   git(["update-ref", "refs/heads/topic", head]);
   git(["push", "-q", "origin", "main", "topic:refs/pull/123/head", "topic"]);
   const worktree = join(repo, ".worktrees/pr-123");

--- a/test/scripts/pr-operation-lock.test.ts
+++ b/test/scripts/pr-operation-lock.test.ts
@@ -30,6 +30,7 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 import { validReview, writeReviewArtifacts } from "./pr-review-artifact-fixture.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const freshMainTemplateDirs = useAutoCleanupTempDirTracker(afterAll);
 const escapedPipeHolderPidFiles = new Set<string>();
 afterEach(async () => {
   const failures: unknown[] = [];
@@ -55,6 +56,7 @@ const lockRef = "refs/openclaw/pr-operation-locks/42";
 const detachedChildren = new WeakSet<ChildProcess>();
 const goneProcessGroups = new Set<number>();
 let templateRepo = "";
+let freshMainTemplate: ReturnType<typeof createFreshMainTemplate> | undefined;
 
 // Direct preload affects only the supervisor; operation fixtures keep real clocks.
 // The source assertions below pin the production safety durations being accelerated.
@@ -276,6 +278,67 @@ function installPrCliFixture(repoDir: string, env?: NodeJS.ProcessEnv) {
     symlinkSync(resolved, join(binDir, command));
   }
   return { binDir, cli };
+}
+
+function createFreshMainTemplate() {
+  // Freeze only the committed wrapper/tool prefix. Origins, FETCH_HEAD,
+  // linked worktrees, and failure proxies are created in each private copy.
+  const repoDir = freshMainTemplateDirs.make("openclaw-pr-fresh-main-template-");
+  cpSync(templateRepo, repoDir, { recursive: true });
+  const stateDir = join(repoDir, "fixture-state");
+  const homeDir = join(stateDir, "home");
+  const tmpDir = join(stateDir, "tmp");
+  mkdirSync(homeDir, { recursive: true });
+  mkdirSync(tmpDir, { recursive: true });
+  const setupEnv = createPrFixtureEnv(homeDir, process.env.PATH ?? "");
+  const { binDir } = installPrCliFixture(repoDir, setupEnv);
+  const realGit = realpathSync(join(binDir, "git"));
+  // Only these real tools are reachable. rg/pnpm are required by the CLI
+  // preflight; these cases must stop before invoking either of them.
+  for (const command of [
+    "awk",
+    "cat",
+    "date",
+    "env",
+    "jq",
+    "mkdir",
+    "mktemp",
+    "mv",
+    "ps",
+    "rm",
+    "seq",
+    "sh",
+    "sleep",
+  ]) {
+    symlinkSync(
+      execFileSync("which", [command], { encoding: "utf8", env: setupEnv }).trim(),
+      join(binDir, command),
+    );
+  }
+  symlinkSync(process.execPath, join(binDir, "node"));
+  for (const command of ["rg", "pnpm"]) {
+    const stub = writeFixtureFile(binDir, command, [
+      "#!/bin/sh",
+      "echo 'unexpected command in review-init fixture' >&2",
+      "exit 99",
+    ]);
+    chmodSync(stub, 0o755);
+  }
+  const env: NodeJS.ProcessEnv = {
+    ...createPrFixtureEnv(homeDir, binDir),
+    TMPDIR: tmpDir,
+  };
+  const git = (...args: string[]) =>
+    execFileSync(realGit, args, { cwd: repoDir, env, encoding: "utf8", timeout: 5000 }).trim();
+  writeFileSync(
+    join(repoDir, ".git/info/exclude"),
+    "/.local/\n/.worktrees/\n/isolated-bin/\n/fixture-state/\n",
+  );
+  git("add", "scripts", ".github");
+  git("commit", "-qm", "test: unmodified public PR wrapper fixture");
+  const cachedMain = git("rev-parse", "HEAD");
+  const canonicalTree = git("rev-parse", "HEAD^{tree}");
+  return { repoDir, cachedMain, canonicalTree };
 }
 
 function installRequiredPrCommandStubs(binDir: string) {
@@ -738,60 +801,22 @@ describePosix("scripts/pr per-PR operation lock", () => {
   ])(
     "$command requires fresh main before replacing PR artifacts ($failure, existing=$existing)",
     async ({ command, failure, existing }) => {
-      const repoDir = createRepo();
+      const template = (freshMainTemplate ??= createFreshMainTemplate());
+      const repoDir = tempDirs.make("openclaw-pr-fresh-main-");
+      cpSync(template.repoDir, repoDir, { recursive: true });
+      const { cachedMain, canonicalTree } = template;
       const stateDir = join(repoDir, "fixture-state");
       const homeDir = join(stateDir, "home");
       const tmpDir = join(stateDir, "tmp");
-      mkdirSync(homeDir, { recursive: true });
-      mkdirSync(tmpDir, { recursive: true });
-      const setupEnv = createPrFixtureEnv(homeDir, process.env.PATH ?? "");
-      const { binDir, cli } = installPrCliFixture(repoDir, setupEnv);
+      const binDir = join(repoDir, "isolated-bin");
+      const cli = join(repoDir, "scripts/pr");
       const realGit = realpathSync(join(binDir, "git"));
-      // Only these real tools are reachable. rg/pnpm are required by the CLI
-      // preflight; these cases must stop before invoking either of them.
-      for (const command of [
-        "awk",
-        "cat",
-        "date",
-        "env",
-        "jq",
-        "mkdir",
-        "mktemp",
-        "mv",
-        "ps",
-        "rm",
-        "seq",
-        "sh",
-        "sleep",
-      ]) {
-        symlinkSync(
-          execFileSync("which", [command], { encoding: "utf8", env: setupEnv }).trim(),
-          join(binDir, command),
-        );
-      }
-      symlinkSync(process.execPath, join(binDir, "node"));
-      for (const command of ["rg", "pnpm"]) {
-        const stub = writeFixtureFile(binDir, command, [
-          "#!/bin/sh",
-          "echo 'unexpected command in review-init fixture' >&2",
-          "exit 99",
-        ]);
-        chmodSync(stub, 0o755);
-      }
       const env: NodeJS.ProcessEnv = {
         ...createPrFixtureEnv(homeDir, binDir),
         TMPDIR: tmpDir,
       };
       const git = (...args: string[]) =>
         execFileSync(realGit, args, { cwd: repoDir, env, encoding: "utf8", timeout: 5000 }).trim();
-      writeFileSync(
-        join(repoDir, ".git/info/exclude"),
-        "/.local/\n/.worktrees/\n/isolated-bin/\n/fixture-state/\n",
-      );
-      git("add", "scripts", ".github");
-      git("commit", "-qm", "test: unmodified public PR wrapper fixture");
-      const cachedMain = git("rev-parse", "HEAD");
-      const canonicalTree = git("rev-parse", "HEAD^{tree}");
       const newCommit = (message: string) =>
         execFileSync(realGit, ["commit-tree", canonicalTree, "-p", cachedMain], {
           cwd: repoDir,


### PR DESCRIPTION
## What Problem This Solves

Native PR tests repeatedly rebuild the same initial Git history and tool setup. Across 134 merge-outcome fixtures and 18 fresh-main lock cases, this adds execution time before the behavior under test begins.

## Why This Change Was Made

Reuse only immutable setup, with an independent repository copy for every case. Merge-outcome fixtures cache the base commit and empty bare remote; every source commit, attribution variant, push and linked worktree remains fresh. Fresh-main lock cases cache the committed wrapper/tool prefix before any origin, fetch, worktree or failure proxy exists.

The templates use the existing lifecycle-owned temporary-directory helper. Case copies retain separate files, refs, indexes, objects, configuration and cleanup. Partial initialization remains registered for cleanup. No shared mutable fixture, object alternates or hardlinks are introduced.

Production delta: **0**. Tests: **+110/-59**. All test cases, assertions, mocks, clocks, deadlines, process supervision, real Git transport, sharding and worker settings remain unchanged. Reusing live worktrees or parameterized source histories was rejected because it would weaken corruption, recovery and attribution coverage.

## User Impact

No product behavior changes. Repeated local measurements save about **nine seconds** across the affected test groups. This is a focused execution-time result, not a claim about total CI duration.

## Evidence

macOS, Node 26.5.0, Vitest 4.1.11; same one-worker runner settings for all measurements:

| Existing group | Before (seconds) | After (seconds) | Mean saving |
| --- | --- | --- | --- |
| Merge-outcome, all 140 cases | 195.48 / 197.38 | 190.96 / 187.38 | 7.26 s |
| Fresh-main lock matrix, 18 cases | 19.47 / 19.82 | 18.14 / 17.82 | 1.66 s |

Times are elapsed file spans or the serial matrix durations, not sums across concurrent cases. The full candidate pair passed **250 tests**, with the existing Linux-only zombie-process case skipped on macOS. The 18 fresh-main cases also passed shuffled with seed 93147.

Supplemental probes compare baseline/candidate trees, refs, indexes, configuration, working state, executable targets and path-bound environments. Deleting a copied source object or mutating one case's refs, config, index and proxy leaves siblings and templates unchanged. Successful and failed-bootstrap cleanup passed. Node's default copy resolves some host executable symlink aliases; the resolved executables remain identical.

`node scripts/check-changed.mjs -- test/scripts/pr-merge-outcome.test.ts test/scripts/pr-operation-lock.test.ts` passed locally, including test-root types and script lint. Required Codex autoreview completed with no accepted blocking findings. Hosted CI remains required before landing.

The first changed-file gate on an older main failed on an unrelated stale code-mode import. Refreshing to current main picked up the canonical repair in #133155; neither that fix nor its production lines are part of this diff. The affected test files, native PR owners, test runner and dependency lockfile were unchanged across the refresh.
