### PR TITLE
improve(gateway): reduce idle worker startup memory

### DIFF
--- a/src/gateway/server-import-boundary.test.ts
+++ b/src/gateway/server-import-boundary.test.ts
@@ -256,6 +256,24 @@ describe("gateway startup import boundaries", () => {
     expect(workerStartup.match(/loadWorkerEnvironmentRuntimeModule\(\)/gu)).toHaveLength(3);
   });
 
+  it("keeps worker session tools out of idle worker startup", () => {
+    const workerStartup = readSource("src/gateway/server-worker-environment-startup.ts");
+    const startupFunction = workerStartup.indexOf(
+      "export async function createGatewayWorkerEnvironmentRuntime",
+    );
+    const eagerImportsStart = workerStartup.indexOf("const [", startupFunction);
+    const eagerImportsEnd = workerStartup.indexOf("]);", eagerImportsStart);
+    const eagerImports = workerStartup.slice(eagerImportsStart, eagerImportsEnd);
+
+    expect(eagerImports).not.toContain(
+      'import("./worker-environments/worker-session-tool-executor.js")',
+    );
+    expect(workerStartup).toContain(
+      "const loadWorkerSessionToolExecutorModule = createLazyRuntimeModule(",
+    );
+    expect(workerStartup).toContain("loadWorkerSessionToolExecutorModule().then(");
+  });
+
   it("fences config reload before gateway teardown and gateway_stop hooks", () => {
     const serverImpl = readServerImplementation();
     const closeStart = /close:\s*async\s*\([^)]*\)\s*=>/u.exec(serverImpl)?.index ?? -1;

--- a/src/gateway/server-worker-environment-startup.lazy.test.ts
+++ b/src/gateway/server-worker-environment-startup.lazy.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { createDesktopSessionRegistry } from "./desktop/session-registry.js";
+import type { WorkerConnectionIdentity } from "./worker-environments/connection-identity.js";
+
+type WorkerSessionToolExecutor = ReturnType<
+  typeof import("./worker-environments/worker-session-tool-executor.js").createWorkerSessionToolExecutor
+>;
+
+const mocks = vi.hoisted(() => {
+  const execute: WorkerSessionToolExecutor = vi.fn(async () => ({
+    resultJson: '{"ok":true}',
+  }));
+  return {
+    createExecutor: vi.fn(() => execute),
+    execute,
+    executeSessionTool: undefined as WorkerSessionToolExecutor | undefined,
+    service: { get: vi.fn() },
+  };
+});
+
+vi.mock("./worker-environments/service.js", () => ({
+  createWorkerEnvironmentService: vi.fn(
+    (options: { executeSessionTool?: typeof mocks.executeSessionTool }) => {
+      mocks.executeSessionTool = options.executeSessionTool;
+      return mocks.service;
+    },
+  ),
+}));
+
+vi.mock("./worker-environments/worker-session-tool-executor.js", () => ({
+  createWorkerSessionToolExecutor: mocks.createExecutor,
+}));
+
+import {
+  createGatewayWorkerEnvironmentRuntime,
+  loadGatewayWorkerEnvironmentStartupState,
+} from "./server-worker-environment-startup.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  mocks.executeSessionTool = undefined;
+  vi.clearAllMocks();
+});
+
+describe("gateway worker session-tool startup", () => {
+  it("creates one executor on concurrent first use", async () => {
+    const stateDir = tempDirs.make("openclaw-worker-session-tool-lazy-");
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      const startup = await loadGatewayWorkerEnvironmentStartupState();
+      await createGatewayWorkerEnvironmentRuntime({
+        getPluginRegistry: () => ({
+          workerProviders: new Map(),
+          plugins: [],
+          agentHarnesses: [],
+          nodeHostCommands: [],
+        }),
+        getPortalRuntime: () => undefined,
+        resolveGatewayContext: () => undefined,
+        desktopSessionRegistry: createDesktopSessionRegistry({ lingerMs: 1 }),
+        startup,
+        log: { child: () => ({ warn: () => {} }) },
+      });
+
+      expect(mocks.createExecutor).not.toHaveBeenCalled();
+      const executeSessionTool = mocks.executeSessionTool;
+      if (!executeSessionTool) {
+        throw new Error("worker session-tool callback was not composed");
+      }
+      const identity: WorkerConnectionIdentity = {
+        environmentId: "environment",
+        credentialHash: "credential",
+        bundleHash: "bundle",
+        sessionId: null,
+        runId: null,
+        turnClaim: null,
+        ownerEpoch: 1,
+        rpcSetVersion: 1,
+        protocolFeatures: [],
+        credentialExpiresAtMs: Date.now() + 60_000,
+      };
+      const request: Parameters<WorkerSessionToolExecutor>[0] = {
+        identity,
+        toolName: "sessions_send",
+        request: { toolCallId: "first", sessionKey: "agent:main:target", message: "hello" },
+      };
+
+      await expect(
+        Promise.all([executeSessionTool(request), executeSessionTool(request)]),
+      ).resolves.toEqual([{ resultJson: '{"ok":true}' }, { resultJson: '{"ok":true}' }]);
+      expect(mocks.createExecutor).toHaveBeenCalledOnce();
+      expect(mocks.execute).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/gateway/server-worker-environment-startup.ts
+++ b/src/gateway/server-worker-environment-startup.ts
@@ -43,6 +43,9 @@ type WorkerEnvironmentStore = ReturnType<
   typeof import("./worker-environments/store.js").createWorkerEnvironmentStore
 >;
 type WorkerEnvironmentRecord = ReturnType<WorkerEnvironmentStore["list"]>[number];
+type WorkerSessionToolExecutor = ReturnType<
+  typeof import("./worker-environments/worker-session-tool-executor.js").createWorkerSessionToolExecutor
+>;
 type WorkerEnvironmentLogger = {
   child: (name: string) => { warn: (message: string) => void };
 };
@@ -76,6 +79,9 @@ const loadWorkerEnvironmentRuntimeModule = createLazyRuntimeModule(
 );
 const loadWorkerInferenceRuntimeModule = createLazyRuntimeModule(
   () => import("./worker-environments/inference-runtime.js"),
+);
+const loadWorkerSessionToolExecutorModule = createLazyRuntimeModule(
+  () => import("./worker-environments/worker-session-tool-executor.js"),
 );
 
 export async function loadGatewayWorkerEnvironmentStartupState(): Promise<GatewayWorkerEnvironmentStartupState> {
@@ -139,7 +145,6 @@ export async function createGatewayWorkerEnvironmentRuntime(params: {
     { createNodeWorkerBundleTransferHttpCallback },
     { createNodeWorkspaceTransferService },
     { createNodeWorkspaceTransferHttpCallback },
-    { createWorkerSessionToolExecutor },
     { createWorkerNodeDesktopCarrier },
     { createWorkerNodePortalCarrier },
     { createWorkerComputerService },
@@ -158,7 +163,6 @@ export async function createGatewayWorkerEnvironmentRuntime(params: {
     import("./worker-environments/node-worker-bundle-transfer-http.js"),
     import("./worker-environments/node-workspace-transfer-service.js"),
     import("./worker-environments/node-workspace-transfer-http.js"),
-    import("./worker-environments/worker-session-tool-executor.js"),
     import("./worker-environments/node-desktop-carrier.js"),
     import("./worker-environments/portal-node-carrier.js"),
     import("./worker-environments/computer-transport.js"),
@@ -356,7 +360,7 @@ export async function createGatewayWorkerEnvironmentRuntime(params: {
       return await generation.producer.prepare(signal);
     },
   });
-  let executeSessionTool: ReturnType<typeof createWorkerSessionToolExecutor> = async () => {
+  let executeSessionTool: WorkerSessionToolExecutor = async () => {
     throw new Error("Worker session tools are unavailable");
   };
   let dispatchChild: WorkerPlacementDispatchContract["dispatch"] = async () => {
@@ -487,20 +491,28 @@ export async function createGatewayWorkerEnvironmentRuntime(params: {
     );
     return environmentIds;
   });
-  executeSessionTool = createWorkerSessionToolExecutor({
-    resolveGatewayContext: params.resolveGatewayContext,
-    placements: params.startup.placementStore,
-    environments: workerEnvironmentService,
-    dispatchChild: (request) => dispatchChild(request),
-    githubPublication: {
-      requestForClaim: (request) => githubPublication.requestForClaim(request),
-    },
-    portals: {
-      getService: () => params.getPortalRuntime()?.portalService,
-      carrier: workerNodePortalCarrier,
-      onChanged: notifyPortalChange,
-    },
-  });
+  let workerSessionToolExecutor: Promise<WorkerSessionToolExecutor> | undefined;
+  executeSessionTool = async (request) => {
+    const executor = await (workerSessionToolExecutor ??=
+      loadWorkerSessionToolExecutorModule().then(({ createWorkerSessionToolExecutor }) =>
+        createWorkerSessionToolExecutor({
+          resolveGatewayContext: params.resolveGatewayContext,
+          placements: params.startup.placementStore,
+          environments: workerEnvironmentService,
+          dispatchChild: (childRequest) => dispatchChild(childRequest),
+          githubPublication: {
+            requestForClaim: (publicationRequest) =>
+              githubPublication.requestForClaim(publicationRequest),
+          },
+          portals: {
+            getService: () => params.getPortalRuntime()?.portalService,
+            carrier: workerNodePortalCarrier,
+            onChanged: notifyPortalChange,
+          },
+        }),
+      ));
+    return await executor(request);
+  };
   const bindWorkerNodeDesktopControl =
     workerNodeDesktopCarrier && workerNodeDesktopStreamBroker
       ? (transport: NodeWorkerSupervisorTransport) =>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where every Gateway process paid the memory cost of worker session-tool execution even when no worker invoked `sessions_spawn`, `sessions_send`, or related tools. On memory-constrained devices, that idle import graph consumed roughly 20-27 MiB of avoidable resident memory.

## Why This Change Was Made

The worker session-tool executor is now loaded on first use through the existing lazy-runtime boundary. Executor construction is memoized per Gateway, so concurrent first calls share one initialization while the existing live dispatch, publication, portal, placement, and authority bindings remain unchanged.

## User Impact

Idle Gateway startup uses less memory. In an 11-pair real Gateway A/B run, ready-state RSS fell by 27.0 MiB and maximum RSS fell by 19.6 MiB. Operators who use worker session tools keep the same behavior; the first tool call pays the one-time module load.

## Evidence

- Real Gateway A/B, 11 paired cold runs:
  - ready RSS median: 587.4 MiB -> 560.4 MiB (-27.0 MiB)
  - maximum RSS median: 596.5 MiB -> 576.9 MiB (-19.6 MiB)
  - startup completion median: 5898.9 ms -> 5552 ms
  - all 22 health, readiness, and shutdown checks passed
- Exact-head focused tests: 63/63 passed across six Gateway files.
- Exact-head full build passed in a normal full checkout, including CLI import guards, runtime postbuild, plugin SDK exports, and Control UI.
- Exact-head QA Lab subagent-lineage scenario passed through real worker-hosted nested session spawn and communication.
- The lazy-init regression test proves concurrent first calls construct one executor.
- The static import-boundary test prevents worker session tools from returning to idle startup.
- Exact-head ARM64 1 GB/no-swap package proof passed on `t4g.micro`:
  - cgroup peak: 583,389,184 bytes
  - Gateway maximum RSS: 401,156 KiB
  - `gateway status` maximum RSS: 178,712 KiB
  - peak swap: 0 bytes
  - OOM / OOM kill / group OOM kill: 0 / 0 / 0
  - all install, CLI, Gateway, status RPC, and planned-shutdown phases passed
- Production delta: +29/-17 (net +12). Tests: +117.
