### PR TITLE
fix(agents): repair dangling getPluginToolSideEffectOwnerKey import left by #132932 (red main)

### DIFF
--- a/src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts
@@ -1,5 +1,5 @@
 import { Type } from "typebox";
-import { getPluginToolSideEffectOwnerKey } from "../../../plugins/tools.js";
+import { getPluginToolSideEffectOwnerKey } from "../../../plugins/tool-metadata.js";
 import type { NestedToolActivity } from "../../../sessions/nested-tool-activity.js";
 import {
   attachInternalToolExecutionPreparer,


### PR DESCRIPTION
## What Problem This Solves

`main` (`aace96c6720e283f95d84921c15610b33c9d3171`) is red: `check-prod-types`, all `check-test-types*` cores, `check-test-types`, `check-lint`, `check-prompt-snapshots`, the `QA Smoke CI` profiles, and therefore `openclaw/ci-gate` fail on the current head.

Root cause: #132932 (`refactor(plugins): isolate tool metadata from runtime loading`, 87b71210c8d) moved `getPluginToolSideEffectOwnerKey` from `src/plugins/tools.ts` to `src/plugins/tool-metadata.ts` and updated the call sites it knew about, but missed `src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts`, which still imports the symbol from the old module.

## Why This Change Was Made

One-line import-path repair at the missed call site, matching the sibling call site that #132932 did update (`src/agents/embedded-agent-runner/run/attempt-client-tools.ts` imports the same symbol from `tool-metadata.js`).

## User Impact

None by itself — it restores the type/lint/snapshot gates on `main` so normal PR validation works again.

## Evidence

- **Pre-fix (main head, local):** `node --import tsx scripts/generate-prompt-snapshots.ts --check` crashes at module load — `SyntaxError: The requested module '../../../plugins/tools.js' does not provide an export named 'getPluginToolSideEffectOwnerKey'` (same module graph `check-prompt-snapshots` loads).
- **Pre-fix (CI):** `aace96c6720e283f95d84921c15610b33c9d3171` check-runs show `openclaw/ci-gate` failure with `check-prod-types`, `check-test-types` + `check-test-types-core-1..5`, `check-lint`, `check-prompt-snapshots`, and `QA Smoke CI (profiles 1-6/6)` red.
- **Post-fix:** the snapshot generator reports `Prompt snapshots are current (7 files)`; `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run` passes 1326/1326.
- Production LOC delta: `+1/-1` (import path only).

## ClawSweeper follow-up

None — landing-prep main-red repair.
