### PR TITLE
fix(gateway): retry failed observer preparation

### DIFF
--- a/src/gateway/session-observer-completion.ts
+++ b/src/gateway/session-observer-completion.ts
@@ -25,14 +25,24 @@ export function createSessionObserverCompletion(params: {
     if (!modelRef) {
       throw new Error("session observer utility model is unavailable");
     }
-    state.preparedPromise ??= params.prepareModel({
+    const preparedPromise = (state.preparedPromise ??= params.prepareModel({
       cfg: params.getConfig(),
       agentId: state.agentId,
       modelRef,
       useUtilityModel: true,
       allowMissingApiKeyModes: ["aws-sdk"],
-    });
-    return await state.preparedPromise;
+    }));
+    let failed = true;
+    try {
+      const prepared = await preparedPromise;
+      failed = "error" in prepared;
+      return prepared;
+    } finally {
+      // Pending and successful preparation remain shared; settled failures do not.
+      if (failed && state.preparedPromise === preparedPromise) {
+        state.preparedPromise = undefined;
+      }
+    }
   };
 
   return async (state: SessionObserverState, notes: readonly string[]) => {

--- a/src/gateway/session-observer-preparation.test.ts
+++ b/src/gateway/session-observer-preparation.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createHarness,
+  flushObserver,
+  preparedModel,
+  resetSessionObserverEventSequence,
+  startAndAddToolNotes,
+} from "./session-observer.test-utils.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  resetSessionObserverEventSequence();
+});
+
+describe("session observer model preparation", () => {
+  it("does not start completion after observation ends during model preparation", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    let resolvePreparation: ((value: ReturnType<typeof preparedModel>) => void) | undefined;
+    const prepareModel = vi.fn(
+      () =>
+        new Promise<ReturnType<typeof preparedModel>>((resolve) => {
+          resolvePreparation = resolve;
+        }),
+    );
+    const harness = createHarness({ prepareModel });
+    startAndAddToolNotes(harness.observer);
+    await vi.advanceTimersByTimeAsync(12_000);
+    expect(prepareModel).toHaveBeenCalledOnce();
+
+    harness.subscribers.unsubscribe("conn-1", "agent:main:session-1");
+    resolvePreparation?.(preparedModel());
+    await flushObserver();
+
+    expect(harness.completeModel).not.toHaveBeenCalled();
+    harness.observer.dispose();
+  });
+
+  it("times out stalled model preparation without starting another preparation", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const prepareModel = vi.fn(
+      () =>
+        new Promise<never>(() => {
+          // Intentionally unresolved: the observer timeout owns this test path.
+        }),
+    );
+    const harness = createHarness({ prepareModel });
+    startAndAddToolNotes(harness.observer);
+
+    await vi.advanceTimersByTimeAsync(34_000);
+    await flushObserver();
+
+    expect(prepareModel).toHaveBeenCalledOnce();
+    expect(harness.completeModel).not.toHaveBeenCalled();
+    harness.observer.dispose();
+  });
+
+  it.each([
+    {
+      failure: "a rejected promise",
+      firstPreparation: () => Promise.reject(new Error("temporary preparation failure")),
+    },
+    {
+      failure: "a resolved error",
+      firstPreparation: async () => ({ error: "temporary preparation failure" }),
+    },
+  ])("retries after $failure", async ({ firstPreparation }) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const prepareModel = vi
+      .fn()
+      .mockImplementationOnce(firstPreparation)
+      .mockResolvedValue(preparedModel());
+    const harness = createHarness({ prepareModel });
+    startAndAddToolNotes(harness.observer);
+
+    await vi.advanceTimersByTimeAsync(24_000);
+    await flushObserver();
+
+    expect(prepareModel).toHaveBeenCalledTimes(2);
+    expect(harness.completeModel).toHaveBeenCalledOnce();
+    expect(harness.broadcastToConnIds).toHaveBeenCalledOnce();
+    harness.observer.dispose();
+  });
+});

--- a/src/gateway/session-observer.test.ts
+++ b/src/gateway/session-observer.test.ts
@@ -7,7 +7,6 @@ import {
   event,
   flushObserver,
   modelMessage,
-  preparedModel,
   persistedLiveDigest,
   resetSessionObserverEventSequence,
   startAndAddToolNotes,
@@ -549,49 +548,6 @@ describe("session observer", () => {
     await vi.advanceTimersByTimeAsync(3_000);
     await flushObserver();
     expect(completeModel).toHaveBeenCalledTimes(2);
-    harness.observer.dispose();
-  });
-
-  it("does not start completion after observation ends during model preparation", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    let resolvePreparation: ((value: ReturnType<typeof preparedModel>) => void) | undefined;
-    const prepareModel = vi.fn(
-      () =>
-        new Promise<ReturnType<typeof preparedModel>>((resolve) => {
-          resolvePreparation = resolve;
-        }),
-    );
-    const harness = createHarness({ prepareModel });
-    startAndAddToolNotes(harness.observer);
-    await vi.advanceTimersByTimeAsync(12_000);
-    expect(prepareModel).toHaveBeenCalledOnce();
-
-    harness.subscribers.unsubscribe("conn-1", "agent:main:session-1");
-    resolvePreparation?.(preparedModel());
-    await flushObserver();
-
-    expect(harness.completeModel).not.toHaveBeenCalled();
-    harness.observer.dispose();
-  });
-
-  it("times out stalled model preparation", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    const prepareModel = vi.fn(
-      () =>
-        new Promise<never>(() => {
-          // Intentionally unresolved: the observer timeout owns this test path.
-        }),
-    );
-    const harness = createHarness({ prepareModel });
-    startAndAddToolNotes(harness.observer);
-
-    await vi.advanceTimersByTimeAsync(34_000);
-    await flushObserver();
-
-    expect(prepareModel).toHaveBeenCalledOnce();
-    expect(harness.completeModel).not.toHaveBeenCalled();
     harness.observer.dispose();
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a transient session-observer model preparation failure
would be replayed from cache on the next attempt. The same failure exhausted
the two-attempt budget without retrying preparation, silently disabling model
observation for the run and publishing no digest even when preparation could
subsequently recover.

## Why This Change Was Made

The repair lives at the `preparedPromise` cache owner. It retains the exact
preparation promise while it is pending or after it succeeds, but evicts that
same promise when it rejects or fulfills with `{ error }`. The identity check
prevents an older settled failure from clearing a newer preparation.

Caller-level guards were rejected because they would duplicate cache policy
outside its owner. Failure-budget or scheduler changes were also rejected:
they would mask the poisoned cache instead of allowing the existing retry to
perform a fresh preparation.

Production LOC: +13/-3 (net +10) | Tests: +87/-44

## User Impact

Session observation can recover after a transient preparation failure. Users
and operators no longer lose model-generated run status because one cached
failure was counted twice.

## Evidence

- Exact head: `23d82f1af1ff16e9d255fcb95137eeb634752d8c`
- Pre-fix reproduction: both rejected-promise and resolved-`{ error }` cases
  failed with one preparation call, zero completion calls, and zero broadcasts.
- Post-fix observer coverage: 11 files, 97 tests passed.
- `pnpm tsgo:core`: passed.
- Assertion-safety and max-lines ratchets: passed against the merge base.
- Targeted `oxfmt`, `oxlint`, and `git diff --check`: passed.
- Exact changed-file gate passed every lane through core typecheck. Its
  `tsgo:core:test` lane is locally blocked by shared `node_modules` drift:
  the worktree resolves root `pako@1.0.11` while `ui/package.json` declares
  `pako@3.0.1`. Full-checkout CI owns that dependency-hydrated proof.
- Final autoreview: no actionable findings, patch correct, confidence 0.98.
- Independent review: no findings; best-fix verdict confirmed the cache owner
  and exact-promise eviction rather than caller guards or budget changes.
