### PR TITLE
fix(qa): isolate live Telegram bots in the shared test group

### DIFF
--- a/.agents/skills/telegram-e2e-userbot/scripts/telegram-test-api-proxy.mjs
+++ b/.agents/skills/telegram-e2e-userbot/scripts/telegram-test-api-proxy.mjs
@@ -58,7 +58,9 @@ async function drainTelegramTestUpdates(apiRoot, token) {
     });
     const payload = await response.json();
     if (!response.ok || payload?.ok !== true || !Array.isArray(payload.result)) {
-      throw new Error("Telegram Test Bot API getUpdates failed while draining stale updates.");
+      throw new Error(
+        `Telegram Test Bot API getUpdates failed while draining stale updates (HTTP ${response.status}).`,
+      );
     }
     if (payload.result.length === 0) return;
     const updateId = payload.result.at(-1)?.update_id;

--- a/.agents/skills/telegram-e2e-userbot/scripts/telegram-test-api-proxy.test.mjs
+++ b/.agents/skills/telegram-e2e-userbot/scripts/telegram-test-api-proxy.test.mjs
@@ -84,6 +84,23 @@ test("drains every pending Test Server update", async () => {
   await new Promise((resolve) => upstreamServer.close(resolve));
 });
 
+test("reports the drain HTTP status without leaking the upstream response", async () => {
+  const proxy = await startTelegramTestApiProxy({
+    fetchImpl: async () =>
+      new Response(JSON.stringify({ ok: false, description: "private bot identity and token" }), {
+        status: 409,
+        headers: { "content-type": "application/json" },
+      }),
+  });
+  try {
+    await assert.rejects(proxy.drainUpdates("123:ABC"), {
+      message: "Telegram Test Bot API getUpdates failed while draining stale updates (HTTP 409).",
+    });
+  } finally {
+    await proxy.close();
+  }
+});
+
 test("holds one upstream-accepted method response until explicit release", async () => {
   const upstreamServer = http.createServer((_request, response) => {
     response.writeHead(200, { "content-type": "application/json" });

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -536,7 +536,9 @@ pnpm openclaw qa telegram
 Targets one shared private group on Telegram's Test Server. One Convex lease
 contains the SUT bot plus one independent TDLib authorization for the QA user.
 That user sends test messages and observes SUT messages and edits through one
-long-lived TDLib process.
+long-lived TDLib process. The shared live group requires a mention of the leased
+bot or a reply to that bot; scenarios use `@openclaw`, which the adapter replaces
+with the leased bot username. Native commands are addressed to that same bot.
 
 Required env:
 

--- a/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.test.ts
@@ -98,13 +98,12 @@ describe("Telegram QA transport adapter", () => {
     mocks.shouldRetainQaGatewayCredentialLease.mockResolvedValue(false);
   });
 
-  it("leases a Test Server userbot and configures the SUT proxy", async () => {
+  it("leases a Test Server userbot and isolates its shared group by default", async () => {
     const adapter = await createTelegramQaTransportAdapter({
       adapterOptions: {
         credentialSource: "convex",
         credentialRole: "ci",
         repoRoot: "/checkout",
-        transportPolicy: { requireGroupMention: true },
       },
       messages: {},
     } as never);

--- a/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
@@ -270,7 +270,6 @@ export async function createTelegramQaTransportAdapter(
         sutToken: credentialLease.payload.sutToken,
         testerUserId: credentialLease.payload.testerUserId,
         sutAccountId: accountId,
-        requireMention: options.transportPolicy?.requireGroupMention === true,
       }),
     waitReady: async ({ gateway, timeoutMs, pollIntervalMs }) =>
       await waitForTelegramChannelRunning(gateway, accountId, {

--- a/extensions/qa-lab/src/live-transports/telegram/telegram-api.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/telegram-api.runtime.test.ts
@@ -11,11 +11,11 @@ describe("Telegram QA API boundary", () => {
         sutToken: "placeholder",
         testerUserId: "1",
         sutAccountId: "sut",
-        requireMention: true,
       },
     );
 
     expect(config.plugins?.allow).toEqual(["qa-lab", "telegram"]);
+    expect(config.channels?.telegram?.groups).toBeUndefined();
     expect(config.channels?.telegram).toMatchObject({
       enabled: true,
       defaultAccount: "sut",
@@ -32,29 +32,6 @@ describe("Telegram QA API boundary", () => {
             },
           },
         },
-      },
-    });
-  });
-
-  it("disables mention gating only inside the leased group", () => {
-    const config = buildTelegramQaConfig(
-      {},
-      {
-        apiRoot: "http://127.0.0.1:8080",
-        groupId: "-100123",
-        sutToken: "placeholder",
-        testerUserId: "1",
-        sutAccountId: "sut",
-        requireMention: false,
-      },
-    );
-
-    expect(config.channels?.telegram?.groups).toBeUndefined();
-    expect(config.channels?.telegram?.accounts?.sut?.groups).toEqual({
-      "-100123": {
-        groupPolicy: "allowlist",
-        allowFrom: ["1"],
-        requireMention: false,
       },
     });
   });

--- a/extensions/qa-lab/src/live-transports/telegram/telegram-api.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/telegram-api.runtime.ts
@@ -25,7 +25,6 @@ export function buildTelegramQaConfig(
   params: {
     apiRoot: string;
     groupId: string;
-    requireMention: boolean;
     sutAccountId: string;
     sutToken: string;
     testerUserId: string;
@@ -77,7 +76,9 @@ export function buildTelegramQaConfig(
               [params.groupId]: {
                 groupPolicy: "allowlist",
                 allowFrom: [params.testerUserId],
-                requireMention: params.requireMention,
+                // Concurrent leases share this group and QA sender. Only this
+                // bot's mentions or reply chain may trigger an agent turn.
+                requireMention: true,
               },
             },
           },

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -812,28 +812,31 @@ describe("qa mock openai server", () => {
     expect(outputItems(body).some((item) => item.type === "function_call")).toBe(false);
   });
 
-  it("keeps final-only marker preview deltas separate from the final answer", async () => {
-    const server = await startMockServer({ finalOnlyMarkerPauseMs: 1 });
-    const response = await expectStreamingResponses(server, {
-      input: [
-        makeUserInput(
-          "Final-only marker streaming QA check. Reply exactly: QA-FINAL-ONLY-STREAMING-OK",
-        ),
-      ],
-    });
+  it.each(["", "@openclaw ", "@sut_bot "])(
+    "keeps final-only marker preview deltas separate from the final answer with prefix %j",
+    async (prefix) => {
+      const server = await startMockServer({ finalOnlyMarkerPauseMs: 1 });
+      const response = await expectStreamingResponses(server, {
+        input: [
+          makeUserInput(
+            `${prefix}Final-only marker streaming QA check. Reply exactly: QA-FINAL-ONLY-STREAMING-OK`,
+          ),
+        ],
+      });
 
-    const responseBody = await response.text();
-    const deltaText = responseBody
-      .split("\n")
-      .filter((line) => line.startsWith("data: {"))
-      .map((line) => JSON.parse(line.slice("data: ".length)) as { type?: string; delta?: string })
-      .filter((event) => event.type === "response.output_text.delta")
-      .map((event) => event.delta ?? "")
-      .join("");
-    expect(deltaText).toBe("QA streaming preview in progress");
-    expect(deltaText).not.toContain("QA-FINAL-ONLY-STREAMING-OK");
-    expect(responseBody).toContain('"text":"QA-FINAL-ONLY-STREAMING-OK"');
-  });
+      const responseBody = await response.text();
+      const deltaText = responseBody
+        .split("\n")
+        .filter((line) => line.startsWith("data: {"))
+        .map((line) => JSON.parse(line.slice("data: ".length)) as { type?: string; delta?: string })
+        .filter((event) => event.type === "response.output_text.delta")
+        .map((event) => event.delta ?? "")
+        .join("");
+      expect(deltaText).toBe("QA streaming preview in progress");
+      expect(deltaText).not.toContain("QA-FINAL-ONLY-STREAMING-OK");
+      expect(responseBody).toContain('"text":"QA-FINAL-ONLY-STREAMING-OK"');
+    },
+  );
 
   it("plans sessions_send for the A2A message-tool mirror proof scenario", async () => {
     const server = await startMockServer();

--- a/qa/scenarios/channels/channel-message-flows.yaml
+++ b/qa/scenarios/channels/channel-message-flows.yaml
@@ -39,7 +39,7 @@ scenario:
       conversationId: "-1001234567890"
       senderId: "100001"
       finalMarker: QA-CHANNEL-STREAMING-PREVIEW-FINAL-OK-1234567890
-      prompt: "Final-only marker streaming QA check. Reply exactly: QA-CHANNEL-STREAMING-PREVIEW-FINAL-OK-1234567890"
+      prompt: "@openclaw Final-only marker streaming QA check. Reply exactly: QA-CHANNEL-STREAMING-PREVIEW-FINAL-OK-1234567890"
 
 flow:
   steps:


### PR DESCRIPTION
## What Problem This Solves

Full release Telegram QA was receiving replies to another bot's latency probes in the shared Test Server group. The streaming check correctly rejected fifteen final messages when it expected one. Other scenarios could pass while retaining that unrelated traffic.

## Why This Change Was Made

Convex leases separate SUT bots and user authorizations, but share the QA user and group. The live adapter previously disabled mention gating unless a scenario explicitly requested it, so an allowed sender's messages addressed to another bot still started turns. Require a mention of the leased bot or a reply to it in the live group's canonical config, and remove the unused boolean plumbing. Address the one live-eligible streaming prompt that lacked a mention. Generic QA Channel and Crabline policies remain unchanged.

A separate startup failure hid the HTTP status from getUpdates. Include that numeric status without upstream response text or credentials. This supplies evidence for the remaining startup failure; it does not claim to fix it or add retries.

## User Impact

QA-only change. Product Telegram defaults and routing are unchanged. Native commands and owned reply chains still work. The strict final-message assertion, provider failures, test deadlines and scenario coverage are preserved.

## Evidence

- Baseline source release run: https://github.com/openclaw/openclaw/actions/runs/33297396322 (18 passed, 2 failed in each attempt). Native Gateway logs confirm fresh foreign addressed inputs and newly generated SUT replies; this was not solely observer history replay.
- Default adapter regression failed before the change and passed afterward. All 291 targeted adapter/config/mock-provider tests passed.
- Real local HTTP proxy regression failed before the diagnostic change and passed afterward; all 7 proxy tests passed. The exact error assertion proves upstream private response text is omitted.
- Managed Codex review: P0–P2 scoped-clean, no actionable findings.
- Production QA group config net 0 lines; proxy diagnostic +2 lines for actionable, non-secret failure evidence. Test and documentation changes remove obsolete false-policy coverage and retain account confinement plus plain/addressed streaming cases.
- Full changed gate passed, including all typecheck lanes, full lint and import-cycle checks. One clean rebase preserved the reviewed patch. [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33300510534) at `113084262e3bf792b787b0b0952ca1f0c3b7bc1a`.

The separate getUpdates startup failure did not recur in the live proof. Its original status-code cause remains unknown; no retry or credential repair is claimed.

## Live proof and review follow-through

[Focused packaged Telegram Test Server proof passed](https://github.com/openclaw/openclaw/actions/runs/33300864229): all four selected scenarios passed, zero failures or skips. The run used the exact reviewed harness head with the byte-identical frozen candidate package from successful producer 33297916603. Both partial-failure recovery steps observed one response; the streaming final contained the exact marker, and the tool-only response retained its marker and usage footer. No RTT marker contaminated either final response. The suite ran from 08:10:55 to 08:12:07 UTC, and workflow cleanup succeeded.

The earlier proof dispatch stopped before scenarios because its package producer had completed unsuccessfully. The corrected dispatch used the verified artifact retained by the successful candidate check; no provenance gate was changed.

ClawSweeper's exact-head validation request is satisfied. The diagnostic remains limited to numeric HTTP status, with a passing boundary regression that excludes private response text. Its optional foreign-message trace rank-up is not claimed: this focused run does not deliberately inject a competing bot's addressed input, so clean output alone is not negative isolation proof. The pre-fix native trace and failing/passing owner regression establish that boundary; the forthcoming full run also exercises source and package Telegram lanes together. No assertions, deadlines, or retries were weakened.
