### PR TITLE
perf(agents): avoid repeated turn and tool preparation

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1798,7 +1798,7 @@ src/agents/embedded-agent-runner/run/attempt-client-tools.ts	2
 src/agents/embedded-agent-runner/run/attempt-context-summary.ts	2
 src/agents/embedded-agent-runner/run/attempt-execution-phase.ts	1
 src/agents/embedded-agent-runner/run/attempt-finalize.ts	3
-src/agents/embedded-agent-runner/run/attempt-history.ts	19
+src/agents/embedded-agent-runner/run/attempt-history.ts	17
 src/agents/embedded-agent-runner/run/attempt-llm-boundary.ts	19
 src/agents/embedded-agent-runner/run/attempt-normalization.ts	1
 src/agents/embedded-agent-runner/run/attempt-prompt-build.ts	2

--- a/src/agents/agent-tools.schema.ts
+++ b/src/agents/agent-tools.schema.ts
@@ -48,19 +48,6 @@ function schemaHasRequiredParams(schema: Record<string, unknown>): boolean {
   return false;
 }
 
-function addEmptyObjectArgumentPreparation(tool: AnyAgentTool, parameters: unknown): AnyAgentTool {
-  if (!isObjectSchemaWithNoRequiredParams(parameters)) {
-    return tool;
-  }
-  return {
-    ...tool,
-    prepareArguments: (args: unknown) => {
-      const prepared = tool.prepareArguments ? tool.prepareArguments(args) : args;
-      return prepared === null || prepared === undefined ? {} : prepared;
-    },
-  };
-}
-
 /** Normalize a tool's parameter schema for the selected provider/model. */
 export function normalizeToolParameters(
   tool: AnyAgentTool,
@@ -74,9 +61,12 @@ export function normalizeToolParameters(
     return tool;
   }
   const parameters = normalizeToolParameterSchema(schema, options);
-  return copyAgentToolMetadata(tool, {
-    ...tool,
-    ...addEmptyObjectArgumentPreparation(tool, parameters),
-    parameters,
-  });
+  const normalized = { ...tool, parameters };
+  if (isObjectSchemaWithNoRequiredParams(parameters)) {
+    normalized.prepareArguments = (args: unknown) => {
+      const prepared = tool.prepareArguments ? tool.prepareArguments(args) : args;
+      return prepared === null || prepared === undefined ? {} : prepared;
+    };
+  }
+  return copyAgentToolMetadata(tool, normalized);
 }

--- a/src/agents/embedded-agent-runner/run/attempt-history.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-history.ts
@@ -105,39 +105,68 @@ export function resolveUserTranscriptMessages(
   messages: AgentMessage[],
   contexts: readonly UserTranscriptContext[] | undefined,
   override: CurrentUserTimestampMatch | undefined,
-): Array<AgentMessage | undefined> {
+): Array<AgentMessage | undefined> | undefined {
+  if (!contexts?.length) {
+    return undefined;
+  }
   const resolved = Array.from(
     { length: messages.length },
     () => undefined as AgentMessage | undefined,
   );
-  if (!contexts?.length) {
-    return resolved;
-  }
-  const activeUserMessageIndex = findActiveUserMessageIndex(messages);
   const unusedContexts = new Set(contexts);
+  const byRuntimeMessage = new Map<AgentMessage, UserTranscriptContext[]>();
+  for (const context of unusedContexts) {
+    const bucket = byRuntimeMessage.get(context.runtimeMessage);
+    if (bucket) {
+      bucket.push(context);
+    } else {
+      byRuntimeMessage.set(context.runtimeMessage, [context]);
+    }
+  }
   // Reserve object-identity matches before structural fallback so duplicate
   // timestamp/text turns cannot consume a later message's exact pairing.
   for (const [index, message] of messages.entries()) {
     if (message.role !== "user") {
       continue;
     }
-    const context = [...unusedContexts].find((candidate) => candidate.runtimeMessage === message);
+    const context = byRuntimeMessage.get(message)?.shift();
     if (!context) {
       continue;
     }
     resolved[index] = context.transcriptMessage;
     unusedContexts.delete(context);
   }
+  if (unusedContexts.size === 0) {
+    return resolved;
+  }
+  const byTimestamp = new Map<number, UserTranscriptContext[]>();
+  for (const context of unusedContexts) {
+    const timestamp = context.runtimeMessage.timestamp;
+    if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) {
+      continue;
+    }
+    const bucket = byTimestamp.get(timestamp);
+    if (bucket) {
+      bucket.push(context);
+    } else {
+      byTimestamp.set(timestamp, [context]);
+    }
+  }
+  const activeUserMessageIndex = findActiveUserMessageIndex(messages);
   for (const [index, message] of messages.entries()) {
     if (message.role !== "user" || resolved[index]) {
       continue;
     }
-    const context = [...unusedContexts].find((candidate) =>
-      userMessageMatchesTranscriptContext(
-        message,
-        candidate,
-        index === activeUserMessageIndex ? override : undefined,
-      ),
+    const timestamp = message.timestamp;
+    const candidates = typeof timestamp === "number" ? byTimestamp.get(timestamp) : undefined;
+    const context = candidates?.find(
+      (candidate) =>
+        unusedContexts.has(candidate) &&
+        userMessageMatchesTranscriptContext(
+          message,
+          candidate,
+          index === activeUserMessageIndex ? override : undefined,
+        ),
     );
     if (!context) {
       continue;
@@ -156,8 +185,8 @@ function userMessageMatchesTranscriptContext(
   if (message === context.runtimeMessage) {
     return true;
   }
-  const messageTimestamp = (message as { timestamp?: unknown }).timestamp;
-  const runtimeTimestamp = (context.runtimeMessage as { timestamp?: unknown }).timestamp;
+  const messageTimestamp = message.timestamp;
+  const runtimeTimestamp = context.runtimeMessage.timestamp;
   if (
     typeof messageTimestamp !== "number" ||
     !Number.isFinite(messageTimestamp) ||

--- a/src/agents/embedded-agent-runner/run/attempt-llm-boundary.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-llm-boundary.ts
@@ -468,9 +468,7 @@ function stripHistoricalInboundMetadataFromUserMessages(
       return message;
     }
     const content = (message as { content?: unknown }).content;
-    const injectMediaText = hasPersistedMedia(message) && !hasNonBlankUserText(content);
-    // #111204: restore marked path lines here, never in UI-visible transcript storage.
-    const mediaOnlyText = buildLateMediaAttachedProjection(message).text ?? MEDIA_ONLY_USER_TEXT;
+    const injectMediaText = !hasNonBlankUserText(content) && hasPersistedMedia(message);
     const isActive = index === activeUserMessageIndex;
     const override = options?.currentUserTimestampOverride;
     const runtimeTimestamp = (message as { timestamp?: unknown }).timestamp;
@@ -495,7 +493,11 @@ function stripHistoricalInboundMetadataFromUserMessages(
     // keeps such messages byte-stable across current↔historical (the envelope is
     // present in both forms) and avoids double-stamping.
     const transformText = (raw: string): string => {
-      const sourceText = injectMediaText && !raw.trim() ? mediaOnlyText : raw;
+      // Restore late-media paths only for blank media turns, never into transcript storage.
+      const sourceText =
+        injectMediaText && !raw.trim()
+          ? (buildLateMediaAttachedProjection(message).text ?? MEDIA_ONLY_USER_TEXT)
+          : raw;
       const { body, envelope } = splitLeadingTimestampEnvelope(sourceText);
       if (envelope || sourceText.includes(BOUNDARY_CRON_TIME_MARKER)) {
         if (isActive) {


### PR DESCRIPTION
## What Problem This Solves

Turn preparation repeats work whose results are already available or never consumed. Historical captioned media is normalized and projected even though its caption wins. Transcript context matching repeatedly copies and scans the remaining context set. Schema normalization creates an intermediate tool wrapper that is immediately spread into another wrapper.

## Why This Change Was Made

- Project late-media markers only when filling a blank media turn. Preserve captions, timestamp envelopes, and transcript-storage ownership.
- Reserve exact runtime-message identities first, then match the remaining contexts within timestamp buckets in the original order. Skip the placeholder result array when there are no contexts; the sole caller already accepts an absent projection.
- Build one normalized tool wrapper and preserve the existing original-receiver argument preparer and canonical identity-metadata copy.

No persistent cache, provider policy, prompt format, runtime config, protocol, or storage change. The assertion-safety baseline decreases after removing redundant timestamp casts; it is tooling metadata, not a runtime configuration change.

Production +57/−36, **net +21**: context ownership/indexing +29, lazy media projection +2, wrapper deletion −10. Tooling baseline +1/−1. No new tests duplicate the existing behavior suites; existing tests plus complete-owner differential probes cover the changed paths.

## Evidence

Two fresh Node 26.8.1 processes with opposite starting orders, uninstrumented runtime owners, paired samples, exact output checks, and retained source hashes:

| Workload | Measured change |
| --- | --- |
| 100 captioned historical media messages | 21–23% less preparation time; late-media variant about 40% less |
| 500 turns with 32 cloned contexts | 5.8–9% less complete-boundary time |
| One plain user message | 6.9–8.5% less complete-boundary time |
| Normalize 100 optional-parameter tools | 42.23–42.60 µs → 19.37–19.55 µs |
| Normalize 100 required-parameter tools | 24.72–24.88 µs → 17.28–17.38 µs |

The blank-media control is effectively unchanged. Isolated lookup-only one-clone work regresses by 0.06–0.13 µs, and isolated blank-media-only work by 5.3–11.1 µs; the complete measured boundary compositions improve. These are preparation measurements, not provider/network latency or memory claims.

Operation witnesses: 1,000 messages/32 cloned contexts reduce 32,000 identity comparisons, 31,008 structural comparisons, and 2,000 Set-to-array copies to 1,000 identity lookups, 32 structural comparisons, and no Set copies. Captioned-media normalization and unused marker projection drop from 100 each to zero. The optional tool path removes one intermediate object allocation and spread.

Correctness evidence includes 3,203 complete-boundary cases across seven compositions, 815 identity cases, and 864 argument comparisons across 108 schema/provider/preparer combinations. Output bytes, object/content identity, nonmutation, duplicate-context ordering, active-turn overrides, original preparer receiver, and action metadata remain covered. Other metadata families continue through the unchanged canonical copy helper and existing tests.

119 tests across four boundary/cache-stability/context-registry/schema suites pass, including a fresh run after rebasing onto merged main (21.39 seconds wall time). The complete changed-file gate passed core and test types, lint, assertion/boundary/import/dead-export guards. Initial assertion-ratchet failures were corrected by deleting unnecessary casts and lowering the baseline, not suppressing the guard. Independent source review and fresh complete automated Codex review reported no accepted findings at the configured P0 threshold. The rebase preserves the exact patch apart from Git blob-index lines.

At head `1cb67e30521b5805edc1f530f9e5f282df166d81`, a fresh build passed in 166.56 seconds. An isolated real-OpenAI Gateway completed nine turns: seven in one conversation, including web fetch, plus session listing and native web search. Tool and terminal receipts passed, as did 30 assertions across 14 read-only RPCs, including unchanged baseline titles/previews, tool inventories, and model catalog. CPU profiles were retained and the task Gateway stopped cleanly. Live history was text and web-tool history; historical-media variants are proved by the complete-owner probes and canonical boundary suites. Live timings are observational.

## Landing Review

Exact-head CI run 33300641780 is green at `1cb67e30521b5805edc1f530f9e5f282df166d81`. The latest ClawSweeper review found no actionable code defect; its rank-up move was to finish the remaining exact-head checks, now satisfied. Maintainer landing review accepts the scoped indexing/lazy-projection tradeoff and the disclosed small isolated controls. The independent owner reviews, full changed-file checks, fresh automated review, build and live Gateway evidence above are complete.
