### PR TITLE
fix(process): preserve arguments through Windows batch wrappers

### DIFF
--- a/src/hooks/gmail.windows.test.ts
+++ b/src/hooks/gmail.windows.test.ts
@@ -46,7 +46,7 @@ describe("resolveGogServeInvocation on Windows", () => {
           "/d",
           "/s",
           "/c",
-          '""C:\\Program Files\\gog\\gog.cmd" gmail watch serve --account me@example.com"',
+          '""C:\\Program Files\\gog\\gog.cmd" "gmail" "watch" "serve" "--account" "me@example.com""',
         ],
         windowsHide: true,
         windowsVerbatimArguments: true,
@@ -54,7 +54,7 @@ describe("resolveGogServeInvocation on Windows", () => {
     });
   });
 
-  it("escapes caret arguments for gog .cmd wrappers", async () => {
+  it("quotes caret arguments for gog .cmd wrappers", async () => {
     const { resolveGogServeInvocation } = await importGmailWithExecutable("gog.cmd");
 
     await withMockedWindowsPlatform(async () => {
@@ -70,7 +70,7 @@ describe("resolveGogServeInvocation on Windows", () => {
         "/d",
         "/s",
         "/c",
-        "gog.cmd gmail watch serve --label release/^^1",
+        '""gog.cmd" "gmail" "watch" "serve" "--label" "release/^1""',
       ]);
       expect(invocation.windowsVerbatimArguments).toBe(true);
     });

--- a/src/process/exec.windows.integration.test.ts
+++ b/src/process/exec.windows.integration.test.ts
@@ -1,11 +1,8 @@
 import { spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
-import { writeFile } from "node:fs/promises";
-import path from "node:path";
 import process from "node:process";
 import { describe, expect, it, vi } from "vitest";
-import { withTempDir } from "../test-utils/temp-dir.js";
-import { runCommandWithTimeout, runUtf8CommandWithTimeout } from "./exec.js";
+import { runUtf8CommandWithTimeout } from "./exec.js";
 import { killProcessTree } from "./kill-tree.js";
 
 describe("runUtf8CommandWithTimeout Windows integration", () => {
@@ -78,52 +75,5 @@ describe("runUtf8CommandWithTimeout Windows integration", () => {
       }
     },
     15_000,
-  );
-});
-
-describe.runIf(process.platform === "win32")("Windows batch argv preservation", () => {
-  const cases = [
-    { name: "ordinary arguments", args: ["alpha", "omega"] },
-    { name: "spaces", args: ["two words", "omega"] },
-    { name: "a leading empty argument", args: ["", "omega"] },
-    { name: "a middle empty argument", args: ["alpha", "", "omega"] },
-    { name: "a trailing empty argument", args: ["alpha", ""] },
-    { name: "an embedded tab", args: ["two\twords", "omega"] },
-    { name: "a tab-only argument", args: ["\t", "omega"] },
-    { name: "double quotes", args: ['say "hello"', "omega"] },
-    { name: "a caret", args: ["left^right", "omega"] },
-    { name: "a quoted trailing backslash", args: ["C:\\two words\\", "omega"] },
-  ];
-
-  it.each(cases)(
-    "preserves $name through a real .cmd wrapper",
-    async ({ args }) => {
-      await withTempDir("openclaw-batch-argv-", async (cwd) => {
-        const command = path.join(cwd, "argv.cmd");
-        await writeFile(
-          path.join(cwd, "argv.cjs"),
-          "process.stdout.write(JSON.stringify(process.argv.slice(2)))",
-        );
-        await writeFile(command, `@"${process.execPath}" "%~dp0argv.cjs" %*\r\n`);
-        const result = await runCommandWithTimeout([command, ...args], { cwd, timeoutMs: 5_000 });
-        expect(result.code).toBe(0);
-        expect(result.termination).toBe("exit");
-        expect(JSON.parse(result.stdout)).toEqual(args);
-      });
-    },
-    15_000,
-  );
-
-  it.each(["&", "|", "<", ">", "%", "\r", "\n"])(
-    "continues to reject unsafe batch argument character %j before launch",
-    async (character) => {
-      await withTempDir("openclaw-batch-argv-reject-", async (cwd) => {
-        const command = path.join(cwd, "argv.cmd");
-        await writeFile(command, "@exit /b 99\r\n");
-        await expect(
-          runCommandWithTimeout([command, `left${character}right`], { cwd, timeoutMs: 5_000 }),
-        ).rejects.toThrow("Unsafe Windows cmd.exe argument detected");
-      });
-    },
   );
 });

--- a/src/process/exec.windows.integration.test.ts
+++ b/src/process/exec.windows.integration.test.ts
@@ -1,8 +1,11 @@
 import { spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
 import process from "node:process";
 import { describe, expect, it, vi } from "vitest";
-import { runUtf8CommandWithTimeout } from "./exec.js";
+import { withTempDir } from "../test-utils/temp-dir.js";
+import { runCommandWithTimeout, runUtf8CommandWithTimeout } from "./exec.js";
 import { killProcessTree } from "./kill-tree.js";
 
 describe("runUtf8CommandWithTimeout Windows integration", () => {
@@ -75,5 +78,52 @@ describe("runUtf8CommandWithTimeout Windows integration", () => {
       }
     },
     15_000,
+  );
+});
+
+describe.runIf(process.platform === "win32")("Windows batch argv preservation", () => {
+  const cases = [
+    { name: "ordinary arguments", args: ["alpha", "omega"] },
+    { name: "spaces", args: ["two words", "omega"] },
+    { name: "a leading empty argument", args: ["", "omega"] },
+    { name: "a middle empty argument", args: ["alpha", "", "omega"] },
+    { name: "a trailing empty argument", args: ["alpha", ""] },
+    { name: "an embedded tab", args: ["two\twords", "omega"] },
+    { name: "a tab-only argument", args: ["\t", "omega"] },
+    { name: "double quotes", args: ['say "hello"', "omega"] },
+    { name: "a caret", args: ["left^right", "omega"] },
+    { name: "a quoted trailing backslash", args: ["C:\\two words\\", "omega"] },
+  ];
+
+  it.each(cases)(
+    "preserves $name through a real .cmd wrapper",
+    async ({ args }) => {
+      await withTempDir("openclaw-batch-argv-", async (cwd) => {
+        const command = path.join(cwd, "argv.cmd");
+        await writeFile(
+          path.join(cwd, "argv.cjs"),
+          "process.stdout.write(JSON.stringify(process.argv.slice(2)))",
+        );
+        await writeFile(command, `@"${process.execPath}" "%~dp0argv.cjs" %*\r\n`);
+        const result = await runCommandWithTimeout([command, ...args], { cwd, timeoutMs: 5_000 });
+        expect(result.code).toBe(0);
+        expect(result.termination).toBe("exit");
+        expect(JSON.parse(result.stdout)).toEqual(args);
+      });
+    },
+    15_000,
+  );
+
+  it.each(["&", "|", "<", ">", "%", "\r", "\n"])(
+    "continues to reject unsafe batch argument character %j before launch",
+    async (character) => {
+      await withTempDir("openclaw-batch-argv-reject-", async (cwd) => {
+        const command = path.join(cwd, "argv.cmd");
+        await writeFile(command, "@exit /b 99\r\n");
+        await expect(
+          runCommandWithTimeout([command, `left${character}right`], { cwd, timeoutMs: 5_000 }),
+        ).rejects.toThrow("Unsafe Windows cmd.exe argument detected");
+      });
+    },
   );
 });

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -258,7 +258,7 @@ describe("Windows command execution", () => {
         });
         const call = requireExecaCall(0);
         expect(call[0]).toBe(expectedTrustedCmdExe());
-        expect(call[1][3]).toContain(`${shimPath} --version`);
+        expect(call[1][3]).toContain(`"${shimPath}" "--version"`);
       });
     });
   });
@@ -289,11 +289,11 @@ describe("Windows command execution", () => {
     });
   });
 
-  it("escapes command arguments inside the trusted cmd.exe wrapper", async () => {
+  it("quotes carets inside the trusted cmd.exe wrapper", async () => {
     await withMockedWindowsPlatform(async () => {
       await runCommandWithTimeout(["pnpm", "run", "value^with^carets"], { timeoutMs: 1_000 });
       const commandLine = String(requireExecaCall(0)[1][3]);
-      expect(commandLine).toContain("value^^with^^carets");
+      expect(commandLine).toContain('"value^with^carets"');
     });
   });
 

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -880,7 +880,7 @@ describe("createChildAdapter", () => {
       "/d",
       "/s",
       "/c",
-      "pnpm.cmd --version",
+      '""pnpm.cmd" "--version""',
     ]);
     expect(spawnArgs.options?.detached).toBe(false);
     expect(spawnArgs.options?.windowsHide).toBe(true);

--- a/src/process/terminal-pty.test.ts
+++ b/src/process/terminal-pty.test.ts
@@ -214,7 +214,7 @@ describe("terminal PTY invocation", () => {
 
     expect(mocks.spawn).toHaveBeenCalledWith(
       expectedComSpec,
-      ["/d", "/s", "/c", `""C:\\Program Files\\Codex\\codex${extension}" resume "thread title""`],
+      `/d /s /c ""C:\\Program Files\\Codex\\codex${extension}" "resume" "thread title""`,
       expect.objectContaining({ cols: 80, rows: 24 }),
     );
   });

--- a/src/process/terminal-pty.ts
+++ b/src/process/terminal-pty.ts
@@ -49,9 +49,8 @@ function resolveTerminalPtyInvocation(params: {
   file: string;
   args: string[];
   platform?: NodeJS.Platform;
-  comSpec?: string;
   env: NodeJS.ProcessEnv;
-}): { file: string; args: string[] } {
+}): { file: string; args: string[] | string } {
   const platform = params.platform ?? process.platform;
   if (!isWindowsBatchCommand(params.file, platform)) {
     return { file: params.file, args: params.args };
@@ -73,8 +72,11 @@ function resolveTerminalPtyInvocation(params: {
     return { file: invocation.command, args: invocation.argv };
   }
   return {
-    file: params.comSpec?.trim() || resolveTrustedWindowsCmdExe(platform),
-    args: ["/d", "/s", "/c", buildWindowsCmdExeCommandLine(params.file, params.args)],
+    file:
+      resolveEnvironmentValue(params.env, "COMSPEC")?.trim() ||
+      resolveTrustedWindowsCmdExe(platform),
+    // node-pty preserves string tails verbatim; arrays would escape the prepared cmd quotes again.
+    args: `/d /s /c ${buildWindowsCmdExeCommandLine(params.file, params.args)}`,
   };
 }
 
@@ -92,12 +94,10 @@ export async function spawnTerminalPty(params: {
   // Passing it through makes interactive CLIs refuse to start in the web terminal.
   const terminalName = resolvePtyTerminalName(readPtyTerminalName(env, process.platform));
   setPtyTerminalName({ env, name: terminalName, platform: process.platform });
-  const comSpec = resolveEnvironmentValue(env, "COMSPEC");
   const invocation = resolveTerminalPtyInvocation({
     file: params.file,
     args: params.args,
     env,
-    ...(comSpec ? { comSpec } : {}),
   });
   const pty = spawn(invocation.file, invocation.args, {
     name: terminalName,

--- a/src/process/windows-command.test.ts
+++ b/src/process/windows-command.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { withTempDir } from "../test-utils/temp-dir.js";
 import { withMockedWindowsPlatform } from "../test-utils/vitest-spies.js";
+import { runCommandWithTimeout } from "./exec.js";
 import { resolveSafeChildProcessInvocation, resolveWindowsCommandShim } from "./windows-command.js";
 
 describe("Windows command helpers", () => {
@@ -174,4 +175,51 @@ describe("Windows command helpers", () => {
       });
     });
   });
+});
+
+describe.runIf(process.platform === "win32")("Windows batch argv preservation", () => {
+  const cases = [
+    { name: "ordinary arguments", args: ["alpha", "omega"] },
+    { name: "spaces", args: ["two words", "omega"] },
+    { name: "a leading empty argument", args: ["", "omega"] },
+    { name: "a middle empty argument", args: ["alpha", "", "omega"] },
+    { name: "a trailing empty argument", args: ["alpha", ""] },
+    { name: "an embedded tab", args: ["two\twords", "omega"] },
+    { name: "a tab-only argument", args: ["\t", "omega"] },
+    { name: "double quotes", args: ['say "hello"', "omega"] },
+    { name: "a caret", args: ["left^right", "omega"] },
+    { name: "a quoted trailing backslash", args: ["C:\\two words\\", "omega"] },
+  ];
+
+  it.each(cases)(
+    "preserves $name through a real .cmd wrapper",
+    async ({ args }) => {
+      await withTempDir("openclaw-batch-argv-", async (cwd) => {
+        const command = path.join(cwd, "argv.cmd");
+        await writeFile(
+          path.join(cwd, "argv.cjs"),
+          "process.stdout.write(JSON.stringify(process.argv.slice(2)))",
+        );
+        await writeFile(command, `@"${process.execPath}" "%~dp0argv.cjs" %*\r\n`);
+        const result = await runCommandWithTimeout([command, ...args], { cwd, timeoutMs: 5_000 });
+        expect(result.code).toBe(0);
+        expect(result.termination).toBe("exit");
+        expect(JSON.parse(result.stdout)).toEqual(args);
+      });
+    },
+    15_000,
+  );
+
+  it.each(["&", "|", "<", ">", "%", "\r", "\n"])(
+    "continues to reject unsafe batch argument character %j before launch",
+    async (character) => {
+      await withTempDir("openclaw-batch-argv-reject-", async (cwd) => {
+        const command = path.join(cwd, "argv.cmd");
+        await writeFile(command, "@exit /b 99\r\n");
+        await expect(
+          runCommandWithTimeout([command, `left${character}right`], { cwd, timeoutMs: 5_000 }),
+        ).rejects.toThrow("Unsafe Windows cmd.exe argument detected");
+      });
+    },
+  );
 });

--- a/src/process/windows-command.test.ts
+++ b/src/process/windows-command.test.ts
@@ -200,8 +200,8 @@ describe.runIf(process.platform === "win32")("Windows batch argv preservation", 
   ];
 
   it.each(
-    cases.flatMap((testCase) =>
-      ["argv.cmd", "argv with spaces.cmd", "argv^caret.cmd"].map((file) => ({ ...testCase, file })),
+    cases.flatMap(({ name, args }) =>
+      ["argv.cmd", "argv with spaces.cmd", "argv^caret.cmd"].map((file) => ({ name, args, file })),
     ),
   )(
     "preserves $name through $file",

--- a/src/process/windows-command.test.ts
+++ b/src/process/windows-command.test.ts
@@ -223,10 +223,13 @@ describe.runIf(process.platform === "win32")("Windows batch argv preservation", 
   );
 
   it.each(["argv.cmd", "argv with spaces.cmd", "argv^caret.cmd", "node.exe"])(
-    "preserves the argument matrix through a real PTY running %s",
+    "preserves literal arguments through a real PTY running %s",
     async (file) => {
       await withTempDir("openclaw-batch-argv-pty-", async (cwd) => {
-        const args = cases.flatMap((testCase) => testCase.args);
+        const args =
+          file === "node.exe"
+            ? ["alpha", "", "two words", "two\twords", "A&B", "100%", "left|right", "<in", ">out"]
+            : cases.flatMap((testCase) => testCase.args);
         const script = path.join(cwd, "argv.cjs");
         const output = path.join(cwd, "received.json");
         await writeFile(

--- a/src/process/windows-command.test.ts
+++ b/src/process/windows-command.test.ts
@@ -1,10 +1,11 @@
 // Windows command tests cover command quoting and shell resolution on Windows.
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-utils/temp-dir.js";
 import { withMockedWindowsPlatform } from "../test-utils/vitest-spies.js";
 import { runCommandWithTimeout } from "./exec.js";
+import { spawnTerminalPty } from "./terminal-pty.js";
 import { resolveSafeChildProcessInvocation, resolveWindowsCommandShim } from "./windows-command.js";
 
 describe("Windows command helpers", () => {
@@ -189,13 +190,24 @@ describe.runIf(process.platform === "win32")("Windows batch argv preservation", 
     { name: "double quotes", args: ['say "hello"', "omega"] },
     { name: "a caret", args: ["left^right", "omega"] },
     { name: "a quoted trailing backslash", args: ["C:\\two words\\", "omega"] },
+    { name: "a caret beside a quote", args: ['left^"right', "omega"] },
+    { name: "a backslash before a quote", args: ['left\\"right', "omega"] },
+    { name: "two backslashes before a quote", args: ['left\\\\"right', "omega"] },
+    {
+      name: "permitted cmd punctuation",
+      args: ["(round)", "[square]", "{curly}", "semi;colon", "eq=sign", "comma,value", "bang!"],
+    },
   ];
 
-  it.each(cases)(
-    "preserves $name through a real .cmd wrapper",
-    async ({ args }) => {
+  it.each(
+    cases.flatMap((testCase) =>
+      ["argv.cmd", "argv with spaces.cmd", "argv^caret.cmd"].map((file) => ({ ...testCase, file })),
+    ),
+  )(
+    "preserves $name through $file",
+    async ({ args, file }) => {
       await withTempDir("openclaw-batch-argv-", async (cwd) => {
-        const command = path.join(cwd, "argv.cmd");
+        const command = path.join(cwd, file);
         await writeFile(
           path.join(cwd, "argv.cjs"),
           "process.stdout.write(JSON.stringify(process.argv.slice(2)))",
@@ -205,6 +217,50 @@ describe.runIf(process.platform === "win32")("Windows batch argv preservation", 
         expect(result.code).toBe(0);
         expect(result.termination).toBe("exit");
         expect(JSON.parse(result.stdout)).toEqual(args);
+      });
+    },
+    15_000,
+  );
+
+  it.each(["argv.cmd", "argv with spaces.cmd", "argv^caret.cmd", "node.exe"])(
+    "preserves the argument matrix through a real PTY running %s",
+    async (file) => {
+      await withTempDir("openclaw-batch-argv-pty-", async (cwd) => {
+        const args = cases.flatMap((testCase) => testCase.args);
+        const script = path.join(cwd, "argv.cjs");
+        const output = path.join(cwd, "received.json");
+        await writeFile(
+          script,
+          'require("node:fs").writeFileSync(require("node:path").join(__dirname, "received.json"), JSON.stringify(process.argv.slice(2)))',
+        );
+        const command = file === "node.exe" ? process.execPath : path.join(cwd, file);
+        if (file !== "node.exe") {
+          await writeFile(command, `@"${process.execPath}" "%~dp0argv.cjs" %*\r\n`);
+        }
+        const pty = await spawnTerminalPty({
+          file: command,
+          args: file === "node.exe" ? [script, ...args] : args,
+          cwd,
+          env: Object.fromEntries(
+            Object.entries(process.env).filter(
+              (entry): entry is [string, string] => typeof entry[1] === "string",
+            ),
+          ),
+          cols: 120,
+          rows: 24,
+        });
+        let exitCode: number | undefined;
+        pty.onExit((event) => {
+          exitCode = event.exitCode;
+        });
+        try {
+          await vi.waitFor(() => expect(exitCode).toBe(0), { timeout: 5_000 });
+          expect(JSON.parse(await readFile(output, "utf8"))).toEqual(args);
+        } finally {
+          if (exitCode === undefined) {
+            pty.kill();
+          }
+        }
       });
     },
     15_000,

--- a/src/process/windows-command.ts
+++ b/src/process/windows-command.ts
@@ -172,24 +172,24 @@ export function isWindowsBatchCommand(
   return ext === ".cmd" || ext === ".bat";
 }
 
-function escapeForWindowsCmdExe(arg: string): string {
-  if (WINDOWS_UNSAFE_CMD_CHARS_RE.test(arg)) {
-    throw new Error(
-      `Unsafe Windows cmd.exe argument detected: ${JSON.stringify(arg)}. ` +
-        "Pass an explicit shell-wrapper argv at the call site instead.",
-    );
-  }
-  const escaped = arg.replace(/\^/g, "^^");
-  if (!escaped.includes(" ") && !escaped.includes('"')) {
-    return escaped;
-  }
-  return `"${escaped.replace(/"/g, '""')}"`;
-}
-
 export function buildWindowsCmdExeCommandLine(command: string, args: readonly string[]): string {
-  const escapedCommand = escapeForWindowsCmdExe(command);
-  const commandLine = [escapedCommand, ...args.map(escapeForWindowsCmdExe)].join(" ");
-  return escapedCommand.startsWith('"') ? `"${commandLine}"` : commandLine;
+  const escaped = [command, ...args].map((arg) => {
+    if (WINDOWS_UNSAFE_CMD_CHARS_RE.test(arg)) {
+      throw new Error(
+        `Unsafe Windows cmd.exe argument detected: ${JSON.stringify(arg)}. ` +
+          "Pass an explicit shell-wrapper argv at the call site instead.",
+      );
+    }
+    // Quote through cmd and the CRT; consume backslash runs once to avoid quadratic scans.
+    const quoted = arg
+      .replace(/\\+/g, (backslashes, offset) => {
+        const next = arg[offset + backslashes.length];
+        return next === '"' || next === undefined ? backslashes.repeat(2) : backslashes;
+      })
+      .replace(/"/g, '""');
+    return `"${quoted}"`;
+  });
+  return `"${escaped.join(" ")}"`;
 }
 
 export function resolveTrustedWindowsCmdExe(platform: NodeJS.Platform = process.platform): string {

--- a/src/tui/tui.local-auth.test.ts
+++ b/src/tui/tui.local-auth.test.ts
@@ -66,7 +66,7 @@ describe("resolveLocalAuthSpawnInvocation", () => {
       }),
     ).toEqual({
       command: "C:\\Windows\\System32\\cmd.exe",
-      args: ["/d", "/s", "/c", "C:\\Users\\me\\AppData\\Roaming\\npm\\codex.cmd login"],
+      args: ["/d", "/s", "/c", '""C:\\Users\\me\\AppData\\Roaming\\npm\\codex.cmd" "login""'],
       options: { windowsHide: true, windowsVerbatimArguments: true },
     });
   });
@@ -80,7 +80,7 @@ describe("resolveLocalAuthSpawnInvocation", () => {
       }),
     ).toEqual({
       command: "C:\\Windows\\System32\\cmd.exe",
-      args: ["/d", "/s", "/c", '""C:\\Program Files\\Codex\\codex.bat" login"'],
+      args: ["/d", "/s", "/c", '""C:\\Program Files\\Codex\\codex.bat" "login""'],
       options: { windowsHide: true, windowsVerbatimArguments: true },
     });
   });


### PR DESCRIPTION
## What Problem This Solves

Windows batch wrappers silently lose empty arguments, split tabs, remove carets, and merge an argument ending in a quoted backslash with the next argument. The child can exit successfully while receiving different input. A native Windows reproduction confirmed seven failures before this repair; ordinary arguments, spaces, quotes, and all seven unsafe-character rejection controls passed.

## Why This Change Was Made

`buildWindowsCmdExeCommandLine` owns the guarded batch serialization shared by process runners, supervisor fallback, Gmail watcher, TUI local authentication, and terminal PTYs. It previously quoted only spaces and double quotes, escaped carets outside the protected quote context, and omitted the CRT backslash rules.

The serializer now quotes every token and consumes each backslash run once before doubling embedded quotes. This preserves empty strings, tabs, carets, and trailing backslashes without a quadratic regex scan. The existing rejection of `&`, `|`, `<`, `>`, `%`, CR, and LF is unchanged. The single-use escape helper and conditional outer-quote path are removed.

Terminal PTYs pass the finished cmd argument tail through node-pty's documented preescaped string API, preventing a second layer of quote escaping. Direct executable and extracted npm Node entrypoint paths retain argument arrays. Redundant COMSPEC parameter forwarding is removed; its lookup and fallback semantics are unchanged.

## User Impact

Allowed arguments retain their exact values through Windows batch wrappers. No dependencies, configuration, environment options, permissions, or shell fallback policy change.

## Evidence

- [Native Windows before run](https://github.com/openclaw/openclaw/actions/runs/33301000626/job/99229156393) at `d2103056a350d438233c094fc2ca0888f9ea3430`: seven intended argument failures and ten passed controls. [Recorded outcomes](https://github.com/openclaw/openclaw/pull/133185#issuecomment-5467606217).
- Native candidate coverage includes 42 batch invocations across plain, spaced, and caret-containing wrapper paths; three real batch PTY cases covering the argument matrix; an ordinary direct Node control including literal shell metacharacters; and seven unchanged unsafe-character rejection controls. PTY proof reads the owned child's recorded argv independently of terminal display encoding.
- [First native after run](https://github.com/openclaw/openclaw/actions/runs/33301782405/job/99231347524) at `af04f67c8821fc93b4c71853ea928cd678bcbd3e`: all 42 batch cases, three batch PTY cases, and seven rejection controls passed. The direct executable matrix exposed the separate dependency limitation described below; the overall job failed.
- Local owner/caller tests: 109 passed, 58 Windows-only skips. The final test corrections separately passed 13 tests with 53 native skips. These skips are not native after proof. A test-table lint error and two obsolete Gmail Windows command-string expectations were corrected without production changes.
- Independent review inspected the actual Execa and pinned Windows node-pty serialization contracts. Microsoft documents the [CRT argument parsing rules](https://learn.microsoft.com/en-us/cpp/cpp/main-function-command-line-args?view=msvc-170).

**Final-head native Windows verification passed:** [Windows test-2](https://github.com/openclaw/openclaw/actions/runs/33302185389/job/99232415912), exact `93f45c768decd3a3946edc3c6e9e591872667a86`, passed all 53 added cases: 42 batch invocations, three batch PTY matrices, one ordinary direct-executable PTY control, and seven rejection controls. The process shard passed 114 tests with one unrelated skip; all 14 Windows job shards passed. The complete local eight-file `check-changed` gate also passed. [Final-head CI](https://github.com/openclaw/openclaw/actions/runs/33302185389) is green. The native landing workflow merged this repair as [1f017332a6528](https://github.com/openclaw/openclaw/commit/1f017332a65282225f510e066423a91a8add9a53); canonical main ancestry and the two production files were verified after landing.

The latest ClawSweeper rank-up move requested the owner repair plus passing exact-head native evidence; both are now supplied.

Named follow-up: **node-pty single-character whitespace argument loss**. The unchanged direct-executable array path drops a tab-only argument because pinned node-pty quotes whitespace only when the argument has more than one character. The failed direct matrix and exact native log above are preserved as before evidence for a separate dependency-owner repair proposal; no xfail/skip or dependency patch is included here. The direct control now states its actual ordinary-argument scope and verifies that shell metacharacters remain allowed. This PR does not claim that the full direct-executable matrix passes.

Production: +23/-23, net 0. Tests: +119/-12, net +107. The regression existed in the inspected stable release; introduction provenance is unknown. The earlier test-only integration-path CI selection omission is tracked separately and is not changed here.
