### PR TITLE
fix: task lists duplicate or omit rows during activity changes

### DIFF
--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -37,6 +37,7 @@ export {
   SESSION_CREATE_IDEMPOTENCY_RETENTION_MS,
   SESSION_CREATE_RETRY_WINDOW_MS,
 } from "./schema/sessions-create.js";
+export { TASKS_LIST_CURSOR_MAX_LENGTH } from "./schema/tasks.js";
 export * from "./schema/projects.js";
 export * from "./migration-api.js";
 export * from "./restart-unavailable.js";

--- a/packages/gateway-protocol/src/schema/tasks.ts
+++ b/packages/gateway-protocol/src/schema/tasks.ts
@@ -77,18 +77,20 @@ export const TaskSummarySchema = closedObject({
 });
 
 /** Task list filters with bounded pagination. */
+export const TASKS_LIST_CURSOR_MAX_LENGTH = 512;
+
 export const TasksListParamsSchema = closedObject({
   status: Type.Optional(Type.Union([TaskLedgerStatusSchema, Type.Array(TaskLedgerStatusSchema)])),
   agentId: Type.Optional(NonEmptyString),
   sessionKey: Type.Optional(NonEmptyString),
   limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 500 })),
-  cursor: Type.Optional(Type.String()),
+  cursor: Type.Optional(Type.String({ maxLength: TASKS_LIST_CURSOR_MAX_LENGTH })),
 });
 
 /** Task list page response. */
 export const TasksListResultSchema = closedObject({
   tasks: Type.Array(TaskSummarySchema),
-  nextCursor: Type.Optional(Type.String()),
+  nextCursor: Type.Optional(Type.String({ maxLength: TASKS_LIST_CURSOR_MAX_LENGTH })),
 });
 
 /** Lookup request for one task id. */

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TASKS_LIST_CURSOR_MAX_LENGTH } from "../../../packages/gateway-protocol/src/index.js";
 import {
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
   INTERNAL_RUNTIME_CONTEXT_END,
@@ -84,6 +85,7 @@ afterEach(async () => {
 
 function identifiedClient(scopes: string[], profileId = "viewer@example.com"): GatewayClient {
   return {
+    connId: `conn-${profileId}-${scopes.join("-")}`,
     connect: {
       minProtocol: 1,
       maxProtocol: 1,
@@ -139,6 +141,7 @@ async function runTaskHandler(
   params: Record<string, unknown>,
   config: Record<string, unknown> = {},
   client: GatewayClient | null = null,
+  context = createContext(config),
 ) {
   const { calls, respond } = captureRespond();
   await expectDefined(
@@ -148,7 +151,7 @@ async function runTaskHandler(
     req: { type: "req", id: `req-${method}`, method },
     params,
     respond,
-    context: createContext(config),
+    context,
     client,
     isWebchatConnect: () => false,
   });
@@ -361,7 +364,7 @@ describe("tasks gateway handlers", () => {
     expect(byId.get("task-later-completion")?.updatedAt).toBe(base - 500);
   });
 
-  it("preserves activity ordering across cursor pages", async () => {
+  it("preserves activity ordering across unchanged cursor pages", async () => {
     const created = [500, 100, 700, 300, 500].map((lastEventAt, index) =>
       createTaskRecord({
         runtime: "cli",
@@ -384,19 +387,85 @@ describe("tasks gateway handlers", () => {
         return left.taskId < right.taskId ? -1 : left.taskId > right.taskId ? 1 : 0;
       })
       .map((task) => task.taskId);
+    const context = createContext();
+    const client = identifiedClient(["operator.read"]);
 
-    const page1 = await runTaskHandler("tasks.list", { limit: 2 });
-    expect(page1.calls[0]?.[0]).toBe(true);
+    const page1 = await runTaskHandler("tasks.list", { limit: 2 }, {}, client, context);
     expect(page1.payload?.tasks?.map((task) => task.id)).toEqual(expectedIds.slice(0, 2));
-    expect(page1.payload?.nextCursor).toBe("2");
+    expect(page1.payload?.nextCursor).toEqual(expect.any(String));
+    expect(page1.payload?.nextCursor?.length).toBeLessThanOrEqual(TASKS_LIST_CURSOR_MAX_LENGTH);
 
-    const page2 = await runTaskHandler("tasks.list", { limit: 2, cursor: "2" });
+    const page2 = await runTaskHandler(
+      "tasks.list",
+      { limit: 2, cursor: page1.payload?.nextCursor },
+      {},
+      client,
+      context,
+    );
     expect(page2.payload?.tasks?.map((task) => task.id)).toEqual(expectedIds.slice(2, 4));
-    expect(page2.payload?.nextCursor).toBe("4");
 
-    const page3 = await runTaskHandler("tasks.list", { limit: 2, cursor: "4" });
+    const page3 = await runTaskHandler(
+      "tasks.list",
+      { limit: 2, cursor: page2.payload?.nextCursor },
+      {},
+      client,
+      context,
+    );
     expect(page3.payload?.tasks?.map((task) => task.id)).toEqual(expectedIds.slice(4));
     expect(page3.payload?.nextCursor).toBeUndefined();
+
+    const priorContext = await runTaskHandler(
+      "tasks.list",
+      { limit: 2, cursor: page1.payload?.nextCursor },
+      {},
+      client,
+      createContext(),
+    );
+    expect(priorContext.calls[0]?.[2]?.code).toBe("INVALID_REQUEST");
+  });
+
+  it("rejects a continuation after task activity changes", async () => {
+    const created = [400, 300, 200, 100].map((lastEventAt, index) =>
+      createTaskRecord({
+        runtime: "cli",
+        requesterSessionKey: "agent:main:main",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: `run-stale-page-${index}`,
+        task: `Stale page task ${index}`,
+        status: "running",
+        deliveryStatus: "pending",
+        lastEventAt,
+      }),
+    );
+    const context = createContext();
+    const client = identifiedClient(["operator.read"]);
+    const page1 = await runTaskHandler("tasks.list", { limit: 2 }, {}, client, context);
+    expect(page1.payload?.tasks?.map((task) => task.id)).toEqual([
+      created[0]?.taskId,
+      created[1]?.taskId,
+    ]);
+
+    recordTaskProgressByRunId({
+      runId: created[3]?.runId ?? "",
+      lastEventAt: 500,
+    });
+
+    const page2 = await runTaskHandler(
+      "tasks.list",
+      { limit: 2, cursor: page1.payload?.nextCursor },
+      {},
+      client,
+      context,
+    );
+    expect(page2.calls[0]).toMatchObject([
+      false,
+      undefined,
+      {
+        code: "INVALID_REQUEST",
+        message: "invalid or expired tasks.list cursor; restart pagination without a cursor",
+      },
+    ]);
   });
 
   it("uses task id as the stable activity-order tie break", async () => {
@@ -443,7 +512,7 @@ describe("tasks gateway handlers", () => {
       const { payload } = await runTaskHandler("tasks.list", { limit: 2 });
 
       expect(payload?.tasks).toHaveLength(2);
-      expect(payload?.nextCursor).toBe("2");
+      expect(payload?.nextCursor).toEqual(expect.any(String));
       expect(cloneSpy).toHaveBeenCalledTimes(2);
     } finally {
       cloneSpy.mockRestore();
@@ -505,7 +574,7 @@ describe("tasks gateway handlers", () => {
       expect(list.payload?.tasks?.map((task) => task.taskId)).toEqual([
         visibleForeign ? taskId : own.taskId,
       ]);
-      expect(list.payload?.nextCursor).toBe(visibleForeign ? "1" : undefined);
+      expect(list.payload?.nextCursor).toEqual(visibleForeign ? expect.any(String) : undefined);
       const get = await runTaskHandler("tasks.get", { taskId }, config, viewer);
       if (visibleForeign) {
         expect(get.payload?.task?.taskId).toBe(taskId);

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -1,8 +1,10 @@
 // Task gateway methods expose detached task list/get/cancel operations with
 // bounded public summaries over the runtime task registry.
+import { createHash, randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   ErrorCodes,
+  TASKS_LIST_CURSOR_MAX_LENGTH,
   errorShape,
   type TaskSummary,
   type TasksListParams,
@@ -28,8 +30,20 @@ import { assertValidParams } from "./validation.js";
 const DEFAULT_TASKS_LIST_LIMIT = 100;
 const MAX_TASKS_LIST_LIMIT = 500;
 const TASKS_LIST_MAX_ATTEMPTS = 3;
+const TASKS_LIST_CURSOR_VERSION = "1";
+
+type TaskListCursor = {
+  offset: number;
+  taskRevision: number;
+  accessRevision: number;
+  binding: string;
+};
 
 type TaskLedgerStatus = TaskSummary["status"];
+
+// One request context is shared for a Gateway lifetime. Its weak identity
+// rejects prior-lifetime cursors without widening every request with bootId.
+const taskListGatewayIds = new WeakMap<object, string>();
 
 const LEDGER_STATUS_TO_TASK_STATUSES: Record<TaskLedgerStatus, TaskStatus[]> = {
   queued: ["queued"],
@@ -48,36 +62,90 @@ function normalizeTaskStatusFilter(status: TasksListParams["status"]): Set<TaskS
   return new Set(statuses.flatMap((value) => LEDGER_STATUS_TO_TASK_STATUSES[value] ?? []));
 }
 
-// Cursor strings are offsets, not opaque tokens; reject malformed values so a
-// client cannot silently restart pagination at the first page.
-function parseCursor(cursor: string | undefined): number | null {
-  if (!cursor) {
-    return 0;
+function taskListGatewayId(context: object): string {
+  const current = taskListGatewayIds.get(context);
+  if (current) {
+    return current;
   }
-  if (!/^\d+$/.test(cursor.trim())) {
+  const created = randomUUID();
+  taskListGatewayIds.set(context, created);
+  return created;
+}
+
+function taskListFingerprint(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("base64url");
+}
+
+function encodeTaskListCursor(cursor: TaskListCursor): string {
+  return [
+    TASKS_LIST_CURSOR_VERSION,
+    cursor.offset,
+    cursor.taskRevision,
+    cursor.accessRevision,
+    cursor.binding,
+  ].join(".");
+}
+
+function parseTaskListCursor(value: string | undefined): TaskListCursor | undefined | null {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!value || value.length > TASKS_LIST_CURSOR_MAX_LENGTH) {
     return null;
   }
-  const parsed = Number(cursor);
-  return Number.isSafeInteger(parsed) ? parsed : null;
+  const [version, rawOffset, rawTaskRevision, rawAccessRevision, binding] = value.split(".");
+  const cursor: TaskListCursor = {
+    offset: Number(rawOffset),
+    taskRevision: Number(rawTaskRevision),
+    accessRevision: Number(rawAccessRevision),
+    binding: binding ?? "",
+  };
+  if (
+    version !== TASKS_LIST_CURSOR_VERSION ||
+    !Number.isSafeInteger(cursor.offset) ||
+    cursor.offset < 0 ||
+    !Number.isSafeInteger(cursor.taskRevision) ||
+    cursor.taskRevision < 0 ||
+    !Number.isSafeInteger(cursor.accessRevision) ||
+    cursor.accessRevision < 0 ||
+    encodeTaskListCursor(cursor) !== value
+  ) {
+    return null;
+  }
+  return cursor;
+}
+
+function invalidTaskListCursor(
+  respond: Parameters<GatewayRequestHandlers["tasks.list"]>[0]["respond"],
+) {
+  respond(
+    false,
+    undefined,
+    errorShape(
+      ErrorCodes.INVALID_REQUEST,
+      "invalid or expired tasks.list cursor; restart pagination without a cursor",
+    ),
+  );
 }
 
 // Control UI task methods expose the stable gateway protocol shape; helpers
 // above keep runtime registry details out of the wire result.
 export const tasksHandlers: GatewayRequestHandlers = {
   "tasks.list": async ({ params, respond, context, client }) => {
+    if (typeof params.cursor === "string" && params.cursor.length > TASKS_LIST_CURSOR_MAX_LENGTH) {
+      invalidTaskListCursor(respond);
+      return;
+    }
     if (!assertValidParams(params, validateTasksListParams, "tasks.list", respond)) {
       return;
     }
-    const cursor = parseCursor(params.cursor);
+    const cursor = parseTaskListCursor(params.cursor);
     if (cursor === null) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "invalid tasks.list cursor"),
-      );
+      invalidTaskListCursor(respond);
       return;
     }
     const statusFilter = normalizeTaskStatusFilter(params.status);
+    const statuses = statusFilter ? [...statusFilter].toSorted() : undefined;
     const limit = Math.min(params.limit ?? DEFAULT_TASKS_LIST_LIMIT, MAX_TASKS_LIST_LIMIT);
     const requestedSessionKey = normalizeOptionalString(params.sessionKey);
     const cfg = context.getRuntimeConfig();
@@ -100,16 +168,40 @@ export const tasksHandlers: GatewayRequestHandlers = {
         sessionKey: requestedSessionKey,
       });
     }
+    const agentId = sessionKey ? undefined : normalizeOptionalString(params.agentId);
+    // Bind each carried offset to one live caller/query/revision view. If any
+    // field changes, the caller restarts instead of selecting another page.
+    const bindingFacts = [
+      taskListGatewayId(context),
+      client?.connId ?? null,
+      client?.authenticatedUserProfile?.profileId ?? null,
+      client?.authenticatedUserId ?? null,
+      client?.pairedClientId ?? null,
+      client?.connect.role ?? null,
+      client?.connect.scopes?.toSorted() ?? null,
+      statuses,
+      agentId,
+      sessionKey,
+      sessionAgentId,
+    ];
+    const bindCursor = (...fields: number[]) => taskListFingerprint([fields, ...bindingFacts]);
+    const cursorBinding =
+      cursor && bindCursor(cursor.offset, cursor.taskRevision, cursor.accessRevision);
+    if (cursor && cursor.binding !== cursorBinding) {
+      invalidTaskListCursor(respond);
+      return;
+    }
     // The ledger pages by last activity so an old long-running task that just
     // finished still surfaces first. Selection stays inside the registry so
     // only the bounded wire page pays for defensive record cloning.
     const canReadTask = (task: Readonly<TaskRecord>) =>
       canAccessTaskRequesterSession({ cfg, client, task });
     const pageParams = {
-      offset: cursor,
+      offset: cursor?.offset ?? 0,
       limit,
-      statuses: statusFilter ? [...statusFilter] : undefined,
-      agentId: sessionKey ? undefined : params.agentId,
+      expectedRevision: cursor?.taskRevision,
+      statuses,
+      agentId,
       sessionKey,
       sessionAgentId,
       cfg,
@@ -117,8 +209,16 @@ export const tasksHandlers: GatewayRequestHandlers = {
     };
     for (let attempt = 0; attempt < TASKS_LIST_MAX_ATTEMPTS; attempt += 1) {
       const accessRevision = readGatewayAccessRevision();
+      if (cursor && cursor.accessRevision !== accessRevision) {
+        invalidTaskListCursor(respond);
+        return;
+      }
       const pageResult = await listTaskRecordPage(pageParams);
       if (!pageResult.ok) {
+        if (pageResult.error === "cursor_stale") {
+          invalidTaskListCursor(respond);
+          return;
+        }
         respond(
           false,
           undefined,
@@ -133,12 +233,25 @@ export const tasksHandlers: GatewayRequestHandlers = {
         accessRevision !== readGatewayAccessRevision() ||
         page.tasks.some((task) => !canReadTask(task))
       ) {
+        if (cursor) {
+          invalidTaskListCursor(respond);
+          return;
+        }
         continue;
       }
-      const nextOffset = cursor + page.tasks.length;
+      const nextOffset = pageParams.offset + page.tasks.length;
       respond(true, {
         tasks: page.tasks.map((task) => mapTaskSummary(task)),
-        ...(page.hasMore ? { nextCursor: String(nextOffset) } : {}),
+        ...(page.hasMore
+          ? {
+              nextCursor: encodeTaskListCursor({
+                offset: nextOffset,
+                taskRevision: page.revision,
+                accessRevision,
+                binding: bindCursor(nextOffset, page.revision, accessRevision),
+              }),
+            }
+          : {}),
       });
       return;
     }

--- a/src/gateway/server.tasks-list-performance.test.ts
+++ b/src/gateway/server.tasks-list-performance.test.ts
@@ -1,6 +1,9 @@
 import path from "node:path";
 import { afterAll, describe, expect, test, vi } from "vitest";
-import type { TasksListResult } from "../../packages/gateway-protocol/src/index.js";
+import {
+  TASKS_LIST_CURSOR_MAX_LENGTH,
+  type TasksListResult,
+} from "../../packages/gateway-protocol/src/index.js";
 import { writeConfigFile } from "../config/config.js";
 import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
 import type { GatewayAuthConfig } from "../config/types.gateway.js";
@@ -54,6 +57,18 @@ function sendRpc<T extends Record<string, unknown>>(
   );
   ws.send(JSON.stringify({ type: "req", id, method, params }));
   return response;
+}
+
+async function expectCursorRejected(
+  ws: Awaited<ReturnType<typeof openWs>>,
+  id: string,
+  params: Record<string, unknown>,
+) {
+  const response = await sendRpc<Record<string, unknown>>(ws, id, "tasks.list", params);
+  expect(response).toMatchObject({
+    ok: false,
+    error: { code: "INVALID_REQUEST", message: expect.stringContaining("restart pagination") },
+  });
 }
 
 function taskUpdatedAt(task: TaskRecord): number {
@@ -249,23 +264,75 @@ describe("tasks.list Gateway performance", () => {
             });
           };
           const listPromise = sendRpc<TasksListResult>(admin, "tasks-list", "tasks.list", {
-            cursor: "13",
             limit: 7,
           });
           const list = await listPromise;
 
           const listMaxSortedInput = Math.max(0, ...sortedInputLengths);
           const currentTasks = listTaskRecordsUnsorted();
-          const adminExpected = expectedTaskIds(currentTasks, 13, 7);
+          const adminExpected = expectedTaskIds(currentTasks, 0, 7);
           expect(mutationsApplied).toBe(true);
           expect(list.ok, JSON.stringify(list.error)).toBe(true);
           expect(list.payload?.tasks.map((task) => task.id)).toEqual(adminExpected);
-          expect(list.payload?.nextCursor).toBe("20");
-          expect(listMaxSortedInput).toBeLessThanOrEqual(20);
+          expect(list.payload?.nextCursor).toEqual(expect.any(String));
+          expect(listMaxSortedInput).toBeLessThanOrEqual(7);
+          const cursor = list.payload?.nextCursor;
+          if (!cursor) {
+            throw new Error("expected an admin task cursor");
+          }
+          const tamperedCursor = cursor.split(".");
+          tamperedCursor[1] = "1";
+          await expectCursorRejected(admin, "tasks-offset-mismatch", {
+            cursor: tamperedCursor.join("."),
+            limit: 7,
+          });
+          expect(deleteTaskRecordById(updatedTask.taskId)).toBe(true);
+          const revisionCursor = cursor.split(".");
+          revisionCursor[2] = String(Number(revisionCursor[2]) + 1);
+          await expectCursorRejected(admin, "tasks-revision-mismatch", {
+            cursor: revisionCursor.join("."),
+            limit: 7,
+          });
+          await expectCursorRejected(admin, "tasks-status-mismatch", {
+            cursor,
+            limit: 7,
+            status: "running",
+          });
+          await expectCursorRejected(admin, "tasks-agent-mismatch", {
+            agentId: "worker",
+            cursor,
+            limit: 7,
+          });
+          await expectCursorRejected(viewer, "tasks-connection-mismatch", { cursor, limit: 7 });
+          await expectCursorRejected(admin, "tasks-noncanonical", {
+            cursor: `${cursor}=`,
+            limit: 7,
+          });
+          await expectCursorRejected(admin, "tasks-oversized", {
+            cursor: "x".repeat(TASKS_LIST_CURSOR_MAX_LENGTH + 1),
+            limit: 7,
+          });
+          const sessionPage = await sendRpc<TasksListResult>(
+            admin,
+            "tasks-session-page",
+            "tasks.list",
+            { limit: 1, sessionKey: OWNED_SESSION_KEY },
+          );
+          const sessionCursor = sessionPage.payload?.nextCursor;
+          if (!sessionCursor) {
+            throw new Error("expected a session task cursor");
+          }
+          await expectCursorRejected(admin, "tasks-session-mismatch", {
+            cursor: sessionCursor,
+            limit: 1,
+            sessionKey: FOREIGN_SESSION_KEY,
+          });
 
           const viewerExpected = expectedTaskIds(
-            currentTasks.filter((task) => task.requesterSessionKey === OWNED_SESSION_KEY),
-            10,
+            listTaskRecordsUnsorted().filter(
+              (task) => task.requesterSessionKey === OWNED_SESSION_KEY,
+            ),
+            0,
             25,
           );
           sortedInputLengths.length = 0;
@@ -290,7 +357,6 @@ describe("tasks.list Gateway performance", () => {
             },
           );
           const restrictedPromise = sendRpc<TasksListResult>(viewer, "tasks-owned", "tasks.list", {
-            cursor: "10",
             limit: 25,
           }).then((response) => {
             accessOrder.push("tasks.list");
@@ -307,9 +373,16 @@ describe("tasks.list Gateway performance", () => {
           expect(
             restricted.payload?.tasks.every((task) => task.sessionKey === OWNED_SESSION_KEY),
           ).toBe(true);
-          expect(restricted.payload?.nextCursor).toBe("35");
+          expect(restricted.payload?.nextCursor).toEqual(expect.any(String));
           expect(accessOrder[0]).toBe("visibility");
-          expect(Math.max(0, ...sortedInputLengths)).toBeLessThanOrEqual(35);
+          expect(Math.max(0, ...sortedInputLengths)).toBeLessThanOrEqual(25);
+          const accessCursor = sessionCursor.split(".");
+          accessCursor[3] = String(Number(accessCursor[3]) + 1);
+          await expectCursorRejected(admin, "tasks-access-revision", {
+            cursor: accessCursor.join("."),
+            limit: 1,
+            sessionKey: OWNED_SESSION_KEY,
+          });
 
           const churnTasks = createTaskSnapshot();
           const churnTaskId = churnTasks.keys().next().value;

--- a/src/tasks/task-registry-query.test.ts
+++ b/src/tasks/task-registry-query.test.ts
@@ -92,7 +92,7 @@ describe("listTaskRecordPage", () => {
 
       sortedInputLengths.length = 0;
       const emptyPage = await readTaskPage({ offset: total + 1, limit: 1 });
-      expect(emptyPage).toEqual({ tasks: [], hasMore: false });
+      expect(emptyPage).toMatchObject({ tasks: [], hasMore: false });
       expect(sortedInputLengths).toEqual([]);
     } finally {
       sortSpy.mockRestore();

--- a/src/tasks/task-registry-query.ts
+++ b/src/tasks/task-registry-query.ts
@@ -141,13 +141,19 @@ const TASK_PAGE_MAX_ATTEMPTS = 3;
 export async function listTaskRecordPage(params: {
   offset: number;
   limit: number;
+  expectedRevision?: number;
   statuses?: readonly TaskStatus[];
   agentId?: string;
   sessionKey?: string;
   sessionAgentId?: string;
   cfg?: OpenClawConfig;
   filter?: (task: Readonly<TaskRecord>) => boolean;
-}): Promise<Result<{ tasks: TaskRecord[]; hasMore: boolean }, "registry_changed">> {
+}): Promise<
+  Result<
+    { tasks: TaskRecord[]; hasMore: boolean; revision: number },
+    "cursor_stale" | "registry_changed"
+  >
+> {
   ensureTaskRegistryReady();
   const statuses = params.statuses ? new Set(params.statuses) : null;
   const agentId = normalizeOptionalString(params.agentId);
@@ -157,6 +163,9 @@ export async function listTaskRecordPage(params: {
   const windowSize = params.offset + params.limit;
   for (let attempt = 0; attempt < TASK_PAGE_MAX_ATTEMPTS; attempt += 1) {
     const revision = readTaskRegistryRevision();
+    if (params.expectedRevision !== undefined && params.expectedRevision !== revision) {
+      return err("cursor_stale");
+    }
     const scanLimit = tasks.size;
     const window: TaskRecord[] = [];
     let matchingCount = 0;
@@ -199,15 +208,19 @@ export async function listTaskRecordPage(params: {
       }
     }
     if (revision !== readTaskRegistryRevision()) {
+      if (params.expectedRevision !== undefined) {
+        return err("cursor_stale");
+      }
       continue;
     }
     if (params.offset >= matchingCount) {
-      return ok({ tasks: [], hasMore: false });
+      return ok({ tasks: [], hasMore: false, revision });
     }
     const selected = window.toSorted(compareTaskPageOrder).slice(params.offset);
     return ok({
       tasks: selected.map((task) => cloneTaskRecord(task)),
       hasMore: params.offset + selected.length < matchingCount,
+      revision,
     });
   }
   return err("registry_changed");

--- a/ui/src/pages/tasks/tasks-page.test.ts
+++ b/ui/src/pages/tasks/tasks-page.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.ts";
+import {
+  GatewayRequestError,
+  type GatewayBrowserClient,
+  type GatewayEventFrame,
+} from "../../api/gateway.ts";
 import { sessionRefFromPath } from "../../app-session-route-paths.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import type { TaskStatus, TaskSummary } from "../../lib/tasks/task-summary.ts";
@@ -20,10 +24,19 @@ type TasksPageTestElement = HTMLElement & {
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
+    reject = rejectPromise;
   });
-  return { promise, resolve };
+  return { promise, reject, resolve };
+}
+
+function staleCursorError() {
+  return new GatewayRequestError({
+    code: "INVALID_REQUEST",
+    message: "invalid or expired tasks.list cursor; restart pagination without a cursor",
+  });
 }
 
 function createGateway(
@@ -389,7 +402,207 @@ describe("TasksPage active pagination", () => {
     expect(page.tasks.filter((task) => task.id === "task-shared")).toEqual([sharedPageTwo]);
   });
 
-  it("fails visibly when an active page repeats its cursor", async () => {
+  it("retains rows while one stale continuation retries cursorlessly", async () => {
+    const stale = createTask("task-stale");
+    const completed = createTask("task-stale", "completed", { updatedAt: 200 });
+    const retry = deferred<{ tasks: TaskSummary[] }>();
+    let phase: "initial" | "pending" = "initial";
+    let continuationRejected = false;
+    let recentCalls = 0;
+    const request = vi.fn(
+      (
+        _method: string,
+        params?: { cursor?: string; status?: readonly string[] },
+      ): Promise<{ tasks: TaskSummary[]; nextCursor?: string }> => {
+        if (params?.status?.includes("completed")) {
+          recentCalls += 1;
+          return Promise.resolve({ tasks: continuationRejected ? [completed] : [] });
+        }
+        if (phase === "initial") {
+          return Promise.resolve({ tasks: [stale] });
+        }
+        if (params?.cursor) {
+          continuationRejected = true;
+          return Promise.reject(staleCursorError());
+        }
+        if (continuationRejected) {
+          return retry.promise;
+        }
+        return Promise.resolve({ tasks: [stale], nextCursor: "stale-cursor" });
+      },
+    );
+    const source = createGateway({ request } as unknown as GatewayBrowserClient);
+    const page = document.createElement("openclaw-tasks-page") as TasksPageTestElement;
+    page.context = createContext(source.gateway);
+    document.body.append(page);
+    await waitForFast(() => expect(page.tasks).toEqual([stale]));
+    const initialRecentCalls = recentCalls;
+
+    phase = "pending";
+    const pending = page.refreshTasks();
+    await vi.waitFor(() => {
+      const activeCalls = request.mock.calls.filter(([, params]) =>
+        (params as { status?: readonly string[] } | undefined)?.status?.includes("running"),
+      );
+      expect(activeCalls.slice(-3).map(([, params]) => params?.cursor)).toEqual([
+        undefined,
+        "stale-cursor",
+        undefined,
+      ]);
+    });
+    expect(page.tasks).toEqual([stale]);
+    expect(page.error).toBeNull();
+
+    retry.resolve({ tasks: [] });
+    await pending;
+
+    expect(recentCalls - initialRecentCalls).toBe(2);
+    expect(page.tasks).toEqual([completed]);
+    expect(page.error).toBeNull();
+  });
+
+  it("clears stale rows after the bounded retry also loses its continuation", async () => {
+    const stale = createTask("task-stale");
+    const fresh = createTask("task-fresh", "running", { updatedAt: 200 });
+    let continuationFailures = 0;
+    let phase: "initial" | "rejected" | "recovered" = "initial";
+    const request = vi.fn(
+      (
+        _method: string,
+        params?: { cursor?: string; status?: readonly string[] },
+      ): Promise<{ tasks: TaskSummary[]; nextCursor?: string }> => {
+        if (params?.status?.includes("completed")) {
+          return Promise.resolve({ tasks: [] });
+        }
+        if (phase === "initial") {
+          return Promise.resolve({ tasks: [stale] });
+        }
+        if (phase === "recovered") {
+          return Promise.resolve({ tasks: [fresh] });
+        }
+        if (params?.cursor) {
+          continuationFailures += 1;
+          return Promise.reject(staleCursorError());
+        }
+        return Promise.resolve({
+          tasks: [stale],
+          nextCursor: `stale-cursor-${continuationFailures + 1}`,
+        });
+      },
+    );
+    const source = createGateway({ request } as unknown as GatewayBrowserClient);
+    const page = document.createElement("openclaw-tasks-page") as TasksPageTestElement;
+    page.context = createContext(source.gateway);
+    document.body.append(page);
+    await waitForFast(() => expect(page.tasks).toEqual([stale]));
+
+    phase = "rejected";
+    await page.refreshTasks();
+
+    expect(continuationFailures).toBe(2);
+    expect(page.tasks).toEqual([]);
+    expect(page.error).toContain("restart pagination");
+    source.emitTask({ action: "upserted", task: createTask("task-event", "running") });
+    expect(page.tasks).toEqual([]);
+
+    phase = "recovered";
+    await page.refreshTasks();
+
+    expect(page.tasks).toEqual([fresh]);
+    expect(page.error).toBeNull();
+    expect(request.mock.calls.at(-2)?.[1]).toEqual({
+      agentId: "main",
+      limit: 500,
+      status: ["queued", "running"],
+    });
+  });
+
+  it("ignores a rejected continuation from a replaced gateway identity", async () => {
+    const stale = createTask("task-stale");
+    const fresh = createTask("task-fresh", "running", { updatedAt: 200 });
+    const continuation = deferred<{ tasks: TaskSummary[] }>();
+    let phase: "initial" | "pending" | "replacement" = "initial";
+    const request = vi.fn(
+      (_method: string, params?: { cursor?: string; status?: readonly string[] }) => {
+        if (params?.status?.includes("completed")) {
+          return Promise.resolve({ tasks: [] });
+        }
+        if (phase === "replacement") {
+          return Promise.resolve({ tasks: [fresh] });
+        }
+        if (phase === "pending" && params?.cursor) {
+          return continuation.promise;
+        }
+        return Promise.resolve({
+          tasks: [stale],
+          ...(phase === "pending" ? { nextCursor: "stale-cursor" } : {}),
+        });
+      },
+    );
+    const source = createGateway({ request } as unknown as GatewayBrowserClient);
+    const page = document.createElement("openclaw-tasks-page") as TasksPageTestElement;
+    page.context = createContext(source.gateway);
+    document.body.append(page);
+    await waitForFast(() => expect(page.tasks).toEqual([stale]));
+
+    phase = "pending";
+    const pending = page.refreshTasks();
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith(
+        "tasks.list",
+        expect.objectContaining({ cursor: "stale-cursor" }),
+        { signal: expect.any(AbortSignal) },
+      ),
+    );
+    phase = "replacement";
+    source.emitConnected(false);
+    source.emitConnected(true);
+    await waitForFast(() => expect(page.tasks).toEqual([fresh]));
+    continuation.reject(staleCursorError());
+    await pending;
+
+    expect(page.tasks).toEqual([fresh]);
+    expect(page.error).toBeNull();
+  });
+
+  it("retains populated rows and event updates after a cursorless list failure", async () => {
+    const current = createTask("task-current");
+    let rejectContinuation = false;
+    const request = vi.fn(
+      (_method: string, params?: { cursor?: string; status?: readonly string[] }) => {
+        if (params?.status?.includes("completed")) {
+          return Promise.resolve({ tasks: [] });
+        }
+        if (rejectContinuation && params?.cursor) {
+          return Promise.reject(
+            new GatewayRequestError({
+              code: "UNAVAILABLE",
+              message: "temporary task list failure",
+            }),
+          );
+        }
+        return Promise.resolve({
+          tasks: [current],
+          ...(rejectContinuation ? { nextCursor: "active-page-2" } : {}),
+        });
+      },
+    );
+    const source = createGateway({ request } as unknown as GatewayBrowserClient);
+    const page = document.createElement("openclaw-tasks-page") as TasksPageTestElement;
+    page.context = createContext(source.gateway);
+    document.body.append(page);
+    await waitForFast(() => expect(page.tasks).toEqual([current]));
+
+    rejectContinuation = true;
+    await page.refreshTasks();
+    expect(page.tasks).toEqual([current]);
+
+    const updated = { ...current, progressSummary: "Still running", updatedAt: 200 };
+    source.emitTask({ action: "upserted", task: updated });
+    expect(page.tasks).toEqual([updated]);
+  });
+
+  it("fails visibly when both active-page attempts repeat their cursor", async () => {
     let activeCalls = 0;
     const request = vi.fn((_method: string, params?: { status?: readonly string[] }) => {
       if (!params?.status || params.status.length !== 2) {
@@ -408,8 +621,8 @@ describe("TasksPage active pagination", () => {
 
     await waitForFast(() => expect(page.error).toBe("The gateway returned an invalid task list."));
 
-    expect(activeCalls).toBe(2);
-    expect(request).toHaveBeenCalledTimes(3);
+    expect(activeCalls).toBe(4);
+    expect(request).toHaveBeenCalledTimes(6);
   });
 
   it("replays buffered events after the final active page resolves", async () => {

--- a/ui/src/pages/tasks/tasks-page.ts
+++ b/ui/src/pages/tasks/tasks-page.ts
@@ -2,7 +2,7 @@ import { consume } from "@lit/context";
 import { initialState, Task, TaskStatus } from "@lit/task";
 import { html } from "lit";
 import { state } from "lit/decorators.js";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { hasOperatorReadAccess, hasOperatorWriteAccess } from "../../app/operator-access.ts";
@@ -59,7 +59,19 @@ type TaskRefreshEventBuffer = {
   events: TaskRefreshEvent[];
 };
 
-async function loadActiveTaskPages(params: {
+class TaskListContinuationError extends Error {
+  constructor(readonly reason: unknown) {
+    super("task list continuation failed");
+  }
+}
+
+function isTaskListContinuationRejection(error: unknown): boolean {
+  return error instanceof GatewayRequestError && error.gatewayCode === "INVALID_REQUEST";
+}
+
+const RECENT_TASK_STATUSES = ["completed", "failed", "timed_out", "cancelled"] as const;
+
+async function loadActiveTaskPagesOnce(params: {
   client: GatewayBrowserClient;
   agentId: string | undefined;
   signal: AbortSignal;
@@ -68,16 +80,23 @@ async function loadActiveTaskPages(params: {
   let cursor: string | undefined;
   const seenCursors = new Set<string>();
   while (true) {
-    const payload = await params.client.request(
-      "tasks.list",
-      {
-        status: ["queued", "running"],
-        limit: 500,
-        ...(params.agentId ? { agentId: params.agentId } : {}),
-        ...(cursor !== undefined ? { cursor } : {}),
-      },
-      { signal: params.signal },
-    );
+    let payload: unknown;
+    try {
+      payload = await params.client.request(
+        "tasks.list",
+        {
+          status: ["queued", "running"],
+          limit: 500,
+          ...(params.agentId ? { agentId: params.agentId } : {}),
+          ...(cursor !== undefined ? { cursor } : {}),
+        },
+        { signal: params.signal },
+      );
+    } catch (error) {
+      throw cursor !== undefined && isTaskListContinuationRejection(error)
+        ? new TaskListContinuationError(error)
+        : error;
+    }
     const page = normalizeTasksListResult(payload);
     if (!page) {
       throw new Error(t("tasksPage.invalidResponse"));
@@ -89,10 +108,45 @@ async function loadActiveTaskPages(params: {
     // Cursors are opaque, so revisiting any prior token is the only safe
     // client-side definition of a non-advancing page sequence.
     if (!page.nextCursor || seenCursors.has(page.nextCursor)) {
-      throw new Error(t("tasksPage.invalidResponse"));
+      throw new TaskListContinuationError(new Error(t("tasksPage.invalidResponse")));
     }
     seenCursors.add(page.nextCursor);
     cursor = page.nextCursor;
+  }
+}
+
+async function loadTaskSnapshotOnce(
+  params: Parameters<typeof loadActiveTaskPagesOnce>[0],
+): Promise<{ active: TaskSummary[]; recent: TaskSummary[] }> {
+  const [active, recentPayload] = await Promise.all([
+    loadActiveTaskPagesOnce(params),
+    params.client.request(
+      "tasks.list",
+      {
+        status: RECENT_TASK_STATUSES,
+        limit: 200,
+        ...(params.agentId ? { agentId: params.agentId } : {}),
+      },
+      { signal: params.signal },
+    ),
+  ]);
+  const recent = normalizeTasksListResult(recentPayload);
+  if (!recent) {
+    throw new Error(t("tasksPage.invalidResponse"));
+  }
+  return { active, recent: recent.tasks };
+}
+
+async function loadTaskSnapshot(
+  params: Parameters<typeof loadActiveTaskPagesOnce>[0],
+): Promise<{ active: TaskSummary[]; recent: TaskSummary[] }> {
+  try {
+    return await loadTaskSnapshotOnce(params);
+  } catch (error) {
+    if (!(error instanceof TaskListContinuationError)) {
+      throw error;
+    }
+    return await loadTaskSnapshotOnce(params);
   }
 }
 
@@ -106,11 +160,13 @@ class TasksPage extends OpenClawLightDomElement {
   @state() private cancellingTaskIds = new Set<string>();
 
   private taskRefreshEvents: TaskRefreshEventBuffer | null = null;
+  private taskSnapshotInvalidated = false;
   private copyResultAttempt = 0;
   private readonly gateway = new GatewayPageController(this, {
     getGateway: () => this.context?.gateway,
     onIdentityChange: () => {
       this.tasks = [];
+      this.taskSnapshotInvalidated = false;
       this.error = null;
       this.copyResultError = null;
     },
@@ -125,7 +181,7 @@ class TasksPage extends OpenClawLightDomElement {
   private readonly observeAgentScope = watchAgentScope(() => {
     this.gateway.invalidate();
     this.cancelGatewayWork();
-    this.tasks = [];
+    this.invalidateTaskSnapshot();
     if (this.gateway.connected) {
       void this.refreshTasks();
     }
@@ -144,6 +200,12 @@ class TasksPage extends OpenClawLightDomElement {
     ) {
       buffer.events.push(event);
     }
+  }
+
+  private invalidateTaskSnapshot() {
+    this.taskRefreshEvents = null;
+    this.taskSnapshotInvalidated = true;
+    this.tasks = [];
   }
 
   private readonly listTask = new Task(this, {
@@ -167,23 +229,8 @@ class TasksPage extends OpenClawLightDomElement {
       };
       this.taskRefreshEvents = buffer;
       const agentId = scopeId ?? undefined;
-      const [active, recentPayload] = await Promise.all([
-        loadActiveTaskPages({ client, agentId, signal }),
-        client.request(
-          "tasks.list",
-          {
-            status: ["completed", "failed", "timed_out", "cancelled"],
-            limit: 200,
-            ...(agentId ? { agentId } : {}),
-          },
-          { signal },
-        ),
-      ]);
-      const recent = normalizeTasksListResult(recentPayload);
-      if (!recent) {
-        throw new Error(t("tasksPage.invalidResponse"));
-      }
-      return { active, recent: recent.tasks, buffer };
+      const snapshot = await loadTaskSnapshot({ client, agentId, signal });
+      return { ...snapshot, buffer };
     },
     onComplete: ({ active, recent, buffer }) => {
       // The active query is issued first; a same-millisecond recent page
@@ -192,14 +239,22 @@ class TasksPage extends OpenClawLightDomElement {
       for (const event of buffer.events) {
         tasks = applyTaskEvent(tasks, event).tasks;
       }
+      this.taskSnapshotInvalidated = false;
       this.tasks = tasks;
       if (this.taskRefreshEvents === buffer) {
         this.taskRefreshEvents = null;
       }
     },
     onError: (error) => {
-      this.taskRefreshEvents = null;
-      this.error = formatUiError(error, t("tasksPage.loadFailed"));
+      if (error instanceof TaskListContinuationError) {
+        this.invalidateTaskSnapshot();
+      } else {
+        this.taskRefreshEvents = null;
+      }
+      this.error = formatUiError(
+        error instanceof TaskListContinuationError ? error.reason : error,
+        t("tasksPage.loadFailed"),
+      );
     },
   });
   private readonly subscriptions = new SubscriptionsController(this)
@@ -215,11 +270,6 @@ class TasksPage extends OpenClawLightDomElement {
           ) {
             return;
           }
-          const result = applyTaskEvent(this.tasks, event.payload);
-          if (result.refetch) {
-            void this.refreshTasks();
-            return;
-          }
           const scopeId = this.context.agentSelection.state.scopeId;
           const normalizedEvent = normalizeTaskEventPayload(event.payload);
           if (
@@ -228,6 +278,14 @@ class TasksPage extends OpenClawLightDomElement {
               taskMatchesAgentScope(normalizedEvent.task, scopeId))
           ) {
             this.bufferTaskRefreshEvent(normalizedEvent);
+          }
+          if (this.taskSnapshotInvalidated) {
+            return;
+          }
+          const result = applyTaskEvent(this.tasks, event.payload);
+          if (result.refetch) {
+            void this.refreshTasks();
+            return;
           }
           this.tasks = result.tasks.filter((task) => taskMatchesAgentScope(task, scopeId));
         });


### PR DESCRIPTION
Fixes #129207

## What Problem This Solves

Fixes an issue where task-list pagination could duplicate rows and omit other
tasks when activity or status changed between page requests.

## Why This Change Was Made

`tasks.list` now uses bounded opaque cursors tied to the requesting connection,
canonical filters, Gateway lifetime, task-registry revision, and access
revision. A changed snapshot fails visibly instead of applying an offset to a
new ordering.

The cursor contract is intentionally continuation-scoped: a cursor is valid
only for the same canonical query, requesting connection, live Gateway
request-context lifetime, task revision, and access revision. Callers restart
without a cursor after the explicit invalid-or-expired response.

Stable v2026.8.2 decimal cursors are intentionally rejected after a Gateway
upgrade. They do not carry task revision, access revision, Gateway lifetime, or
requesting-connection identity, so accepting them would preserve the same
duplicate-or-omit risk this repair removes. SDK and operator clients restart
without a cursor using the existing `INVALID_REQUEST` guidance.

**Maintainer decision:** the restart-on-upgrade contract is approved. Task-list
cursors are ephemeral continuations, not durable resume tokens. An in-flight
cursor does not survive a Gateway restart or upgrade; clients restart the
traversal without a cursor. A numeric compatibility bridge is intentionally
excluded because it cannot validate the snapshot or caller identity.

The Tasks page retries one stale continuation by reloading the complete active
and recent snapshot. Repeated churn stops after that bounded retry and shows
Refresh guidance. No traversal IDs are retained in process state.

The other in-tree paginated consumer was repaired separately and squash-landed
in #136619. This PR remains limited to the task-list protocol, Gateway owner,
registry query, and Tasks page.

The remaining direct Workboard full-scan consumer was repaired separately and
squash-landed in #136802 as
`a5b9955ec70a0ba31d148e3a73151b3f2b1cf682`. That repair keeps consumer
recovery in its shared Workboard owner and does not add Workboard code to this
patch.

## User Impact

Operators no longer receive silently incomplete task traversals. Transient
activity changes recover automatically once; repeated changes remain explicit
and recover with Refresh.

## Evidence

- Current-main reproduction: page one returns A,B; after D moves above the
  boundary, the old numeric cursor returns B,C. The new continuation rejects.
- Blacksmith Testbox run 33698538339: 121 focused assertions passed across
  Gateway, protocol, registry, and Tasks-page coverage.
- Exact-head hosted CI run 33698524484 passed: 171 passed, 41 skipped, 0 failed.
- Independent Workloop review passed with no actionable findings.
- Workboard stale-cursor recovery landed separately in #136619 with a
  Platinum exact-head ClawSweeper review.
- A proof-only integration combined this exact producer with #136802 and a real
  Gateway/Workboard harness. Blacksmith Testbox run 33705709668 passed 4/4:
  task-revision, access-revision, and Gateway-lifetime invalidation each
  restarted once, while a second stale continuation surfaced without a third
  scan. Synthetic integration tree:
  `fd5852d608837f23d65abf968d8ac57240f0d271`.
- Public head `1644524cb12f1dbd60af2f52afad9b9facb6b411` is byte-identical
  across the nine changed files to the live-tested candidate
  `d7b5fed812984e2cfe69069e31db61095b398c68`.
- Production LOC: +248/-61 (net +187). Tests: +382/-27 (net +355).
- Live isolated Gateway and rebuilt Control UI verified:
  - one stale continuation moves a completed task from Active to Recent;
  - a second stale continuation fails visibly without looping;
  - manual Refresh restores the current combined snapshot.

### Visual Evidence

| Before refresh | Automatic recovery |
| --- | --- |
| ![Four active tasks before pagination changes](https://github.com/user-attachments/assets/523433e0-22ea-4973-889a-933d3408302e) | ![Completed task moved from Active to Recent after automatic retry](https://github.com/user-attachments/assets/e12dd730-5998-4002-8fdd-2c65ae6ef6cc) |

| Repeated stale continuation | Manual recovery |
| --- | --- |
| ![Rows cleared with restart guidance after the bounded retry also becomes stale](https://github.com/user-attachments/assets/4cddf7c3-f1ed-4139-bf7b-41b531928106) | ![Current active and recent tasks restored after manual Refresh](https://github.com/user-attachments/assets/5a8075e0-91d5-452d-8a4b-fdb9927e76a2) |

### Recording

https://github.com/user-attachments/assets/26c5279e-fb94-4dc5-82cc-027431da2e5d

### Visual Verification

- Viewport: 1440x900
- Initial snapshot: 4 Active, 0 Recent
- Automatic recovery: 3 Active, 1 Recent
- Repeated-stale state: 0 rendered task rows with restart guidance
- Manual recovery: 3 Active, 1 Recent
