### PR TITLE
fix(computer): keep observations available during recovery

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -292,6 +292,10 @@ without another model turn. Cancellation, explicitly terminal tool outcomes,
 sandbox restrictions, approval requirements, and tool-policy denials retain
 their existing behavior.
 
+Computer observations, including window and cursor queries, cropped screenshots,
+browser state, and dialog inspection, do not spend that mutation attempt. Browser
+preparation, input, and dialog acceptance or dismissal still count as mutations.
+
 ### Verify the active surface
 
 To confirm the model payload shape while debugging, run the Gateway with

--- a/extensions/cua-computer/src/node-invoke-policy.test.ts
+++ b/extensions/cua-computer/src/node-invoke-policy.test.ts
@@ -52,6 +52,17 @@ describe("cua-computer node invoke policy", () => {
       level: "ordinary",
       family: "observation",
     });
+    expect(
+      classifyRisk({
+        action: "zoom",
+        windowRef: "window",
+        observationId: "observation",
+        x1: 0,
+        y1: 0,
+        x2: 100,
+        y2: 100,
+      }),
+    ).toEqual({ level: "ordinary", family: "observation" });
     expect(classifyRisk({ action: "type", text: "hello", windowRef: "window" })).toEqual({
       level: "ordinary",
       family: "input",

--- a/extensions/cua-computer/src/node-invoke-policy.ts
+++ b/extensions/cua-computer/src/node-invoke-policy.ts
@@ -29,6 +29,7 @@ const OBSERVATION_ACTIONS = new Set<ComputerActParams["action"]>([
   "get_accessibility_tree",
   "get_cursor_position",
   "get_window_state",
+  "zoom",
   "get_browser_state",
   "get_recording_state",
 ]);

--- a/src/acp/approval-classifier.test.ts
+++ b/src/acp/approval-classifier.test.ts
@@ -21,6 +21,17 @@ function classify(params: {
 }
 
 describe("classifyAcpToolApproval", () => {
+  it.each([
+    ["list_windows", "other"],
+    ["left_click", "mutating"],
+  ])("keeps computer %s behind approval", (action, approvalClass) => {
+    expect(classify({ title: "computer", rawInput: { name: "computer", action } })).toEqual({
+      toolName: "computer",
+      approvalClass,
+      autoApprove: false,
+    });
+  });
+
   it("auto-approves scoped readonly reads", () => {
     expect(
       classify({

--- a/src/agents/embedded-agent-runner/run/attempt.code-mode-reconciliation.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.code-mode-reconciliation.test.ts
@@ -91,6 +91,9 @@ describe("runEmbeddedAttempt Code Mode recovery boundary", () => {
     const sessionManager = SessionManager.inMemory();
     const appliedChanges: string[] = [];
     const read = fakeTool("read", "Inspect current file contents");
+    const computer = fakeTool("computer", "Observe the computer");
+    computer.catalogMode = "direct-only";
+    computer.parameters = { type: "object", properties: { action: { type: "string" } } };
     const applyPatch = pluginToolWithExecute("apply_patch", "Apply a patch", async () => {
       appliedChanges.push("first hunk applied");
       throw new Error("second hunk is ambiguous");
@@ -105,7 +108,7 @@ describe("runEmbeddedAttempt Code Mode recovery boundary", () => {
       serverName: "remote",
       toolName: "mutate",
     });
-    const coreTools = [read, applyPatch, write, message, shell, remoteMutation];
+    const coreTools = [read, computer, applyPatch, write, message, shell, remoteMutation];
     hoisted.createOpenClawCodingToolsMock.mockImplementation((rawOptions) => {
       const options = rawOptions as {
         includeToolSearchControls?: boolean;
@@ -172,7 +175,17 @@ describe("runEmbeddedAttempt Code Mode recovery boundary", () => {
             }
           }
           if (phase === "resume") {
-            if (turn === 0) {
+            if (turn === 0 || turn === 7) {
+              return streamAssistant([
+                {
+                  type: "toolCall",
+                  id: `computer-observe-${turn}`,
+                  name: "computer",
+                  arguments: { action: "list_windows" },
+                },
+              ]);
+            }
+            if (turn === 1) {
               return streamAssistant([
                 {
                   type: "toolCall",
@@ -182,7 +195,7 @@ describe("runEmbeddedAttempt Code Mode recovery boundary", () => {
                 },
               ]);
             }
-            if (turn === 1) {
+            if (turn === 2) {
               return streamAssistant([
                 {
                   type: "toolCall",
@@ -192,7 +205,7 @@ describe("runEmbeddedAttempt Code Mode recovery boundary", () => {
                 },
               ]);
             }
-            if (turn === 2) {
+            if (turn === 3) {
               return streamAssistant([
                 {
                   type: "toolCall",
@@ -202,7 +215,7 @@ describe("runEmbeddedAttempt Code Mode recovery boundary", () => {
                 },
               ]);
             }
-            if (turn === 3) {
+            if (turn === 4) {
               return streamAssistant([
                 {
                   type: "toolCall",
@@ -212,7 +225,7 @@ describe("runEmbeddedAttempt Code Mode recovery boundary", () => {
                 },
               ]);
             }
-            if (turn === 4) {
+            if (turn === 5) {
               return streamAssistant([
                 {
                   type: "toolCall",
@@ -222,7 +235,7 @@ describe("runEmbeddedAttempt Code Mode recovery boundary", () => {
                 },
               ]);
             }
-            if (turn === 5) {
+            if (turn === 6) {
               return streamAssistant([
                 {
                   type: "toolCall",
@@ -364,12 +377,13 @@ describe("runEmbeddedAttempt Code Mode recovery boundary", () => {
     });
     const resumeTools = providerContexts.at(-1)?.tools?.map((tool) => tool.name) ?? [];
     expect(resumeTools).toEqual(
-      expect.arrayContaining(["tool_search", "tool_describe", "tool_call"]),
+      expect.arrayContaining(["computer", "tool_search", "tool_describe", "tool_call"]),
     );
     expect(resumeTools).not.toContain("write");
     expect(resumeTools).not.toContain("apply_patch");
     expect(resumeTools).not.toContain("exec");
     expect(write.execute).toHaveBeenCalledOnce();
+    expect(computer.execute).toHaveBeenCalledTimes(2);
     expect(applyPatch.execute).toHaveBeenCalledOnce();
     expect(read.execute).toHaveBeenCalledTimes(2);
     expect(message.execute).not.toHaveBeenCalled();

--- a/src/agents/embedded-agent-runner/run/code-mode-reconciliation.test.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-reconciliation.test.ts
@@ -247,4 +247,64 @@ describe("Code Mode recovery", () => {
     prepared.dispose();
     expect(state.mutationAttempt).toBe("available");
   });
+
+  it.each([
+    ["get_cursor_position", false],
+    ["list_windows", true],
+  ])(
+    "keeps computer %s available around one input (observation error: %s)",
+    async (action, fails) => {
+      const unsafe = { action: "key", text: "ENTER" };
+      const state: Extract<CodeModeRecoveryState, { kind: "resume" }> = {
+        kind: "resume",
+        blockedActionKeys: new Set([hashToolCall("computer", unsafe)]),
+        mutationAttempt: "available",
+      };
+      const execute = vi.fn<Parameters<typeof pluginToolWithExecute>[2]>(async () =>
+        jsonResult({}),
+      );
+      const computer = applyCodeModeRecoveryToolSurface({
+        tools: [pluginToolWithExecute("computer", "Computer", execute)],
+        state,
+      })[0]!;
+      const observe = async () => {
+        const prepared = await prepare(computer, { action });
+        expect(prepared.kind).toBe("ready");
+        if (prepared.kind !== "ready") {
+          throw new Error("Observation was blocked");
+        }
+        try {
+          if (fails) {
+            execute.mockRejectedValueOnce(new Error("observation unavailable"));
+          }
+          const result = prepared.execute(() => undefined);
+          if (fails) {
+            await expect(result).rejects.toThrow("observation unavailable");
+          } else {
+            await result;
+          }
+        } finally {
+          prepared.dispose();
+        }
+      };
+      await observe();
+      expect(state.mutationAttempt).toBe("available");
+      expect((await prepare(computer, unsafe)).kind).toBe("immediate");
+      const input = await prepare(computer, { action: "key", text: "ESC" });
+      expect(input.kind).toBe("ready");
+      if (input.kind === "ready") {
+        await input.execute(() => undefined);
+        input.dispose();
+      }
+      expect(state.mutationAttempt).toBe("consumed");
+      await observe();
+      expect(state.mutationAttempt).toBe("consumed");
+      expect((await prepare(computer, { action: "type", text: "later" })).kind).toBe("immediate");
+      expect(execute.mock.calls.map(([, args]) => args)).toEqual([
+        { action },
+        { action: "key", text: "ESC" },
+        { action },
+      ]);
+    },
+  );
 });

--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -164,7 +164,18 @@ describe("tool mutation helpers", () => {
   });
 
   it("classifies computer observations as replay-safe and input as mutating", () => {
-    for (const action of ["screenshot", "wait"]) {
+    for (const action of [
+      "screenshot",
+      "wait",
+      "list_apps",
+      "list_windows",
+      "get_accessibility_tree",
+      "get_cursor_position",
+      "get_window_state",
+      "zoom",
+      "get_browser_state",
+      "get_recording_state",
+    ]) {
       const state = buildToolMutationState("computer", { action });
       expect(state.mutatingAction, action).toBe(false);
       expect(state.replaySafe, action).toBe(true);
@@ -183,6 +194,23 @@ describe("tool mutation helpers", () => {
       "type",
       "key",
       "hold_key",
+      "set_value",
+      "invoke_menu",
+      "bring_to_front",
+      "launch_app",
+      "kill_app",
+      "escalate_scope",
+      "browser_prepare",
+      "browser_navigate",
+      "browser_click",
+      "browser_pointer",
+      "browser_type",
+      "browser_set_input_files",
+      "browser_download",
+      "start_recording",
+      "stop_recording",
+      "replay_trajectory",
+      "future_action",
     ]) {
       const state = buildToolMutationState("computer", { action });
       expect(state.mutatingAction, action).toBe(true);
@@ -190,6 +218,24 @@ describe("tool mutation helpers", () => {
     }
     expect(isMutatingToolCall("computer", {})).toBe(true);
     expect(isReplaySafeToolCall("computer", {})).toBe(false);
+  });
+
+  it.each(["inspect", "accept", "dismiss", undefined, "future_action"])(
+    "classifies computer dialog %s without granting input replay",
+    (dialogAction) => {
+      expect(
+        buildToolMutationState("computer", { action: "browser_dialog", dialogAction }),
+      ).toEqual({
+        mutatingAction: dialogAction !== "inspect",
+        replaySafe: dialogAction === "inspect",
+      });
+    },
+  );
+
+  it("preserves declared side effects for a computer observation", () => {
+    expect(
+      buildToolMutationState("computer", { action: "list_windows" }, { ownerKey: "plugin-owner" }),
+    ).toEqual({ mutatingAction: true, replaySafe: false });
   });
 
   it("classifies mobile UI observation as replay-safe and act as mutating", () => {

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -5,6 +5,7 @@ import {
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
 import { isAutomationsToolName } from "./tools/automations-tool-name.js";
+import { isComputerObservationAction } from "./tools/computer-tool-shared.js";
 
 const READ_ONLY_ACTIONS = new Set([
   "get",
@@ -77,7 +78,6 @@ const REPLAY_SAFE_TOOL_NAMES = new Set([
 ]);
 
 const BROWSER_READ_ONLY_ACTIONS = new Set(["console", "profiles", "snapshot", "status", "tabs"]);
-const COMPUTER_REPLAY_SAFE_ACTIONS = new Set(["screenshot", "wait"]);
 const MOBILE_UI_REPLAY_SAFE_ACTIONS = new Set(["observe"]);
 const GATEWAY_REPLAY_SAFE_ACTIONS = new Set(["config.get", "config.schema.lookup"]);
 const NODES_REPLAY_SAFE_ACTIONS = new Set(["status", "describe", "pending"]);
@@ -290,7 +290,7 @@ export function isMutatingToolCall(toolName: string, args: unknown): boolean {
     case "sessions":
       return action !== "group_list";
     case "computer":
-      return action == null || !COMPUTER_REPLAY_SAFE_ACTIONS.has(action);
+      return !isComputerObservationAction(action, record?.dialogAction);
     case "mobile_ui":
       return action == null || !MOBILE_UI_REPLAY_SAFE_ACTIONS.has(action);
     case "subagents":
@@ -343,7 +343,7 @@ export function isReplaySafeToolCall(toolName: string, args: unknown): boolean {
     case "browser":
       return action != null && BROWSER_READ_ONLY_ACTIONS.has(action);
     case "computer":
-      return action != null && COMPUTER_REPLAY_SAFE_ACTIONS.has(action);
+      return isComputerObservationAction(action, record?.dialogAction);
     case "mobile_ui":
       return action != null && MOBILE_UI_REPLAY_SAFE_ACTIONS.has(action);
     case "skill_workshop":

--- a/src/agents/tool-terminal-outcome.test.ts
+++ b/src/agents/tool-terminal-outcome.test.ts
@@ -144,6 +144,21 @@ describe("tool terminal outcome observer", () => {
       state: "failed_no_effect",
     },
     {
+      name: "completed computer observation",
+      input: { toolName: "computer", arguments: { action: "list_windows" }, outcome: "success" },
+      state: "read_completed",
+    },
+    {
+      name: "failed computer observation",
+      input: {
+        toolName: "computer",
+        arguments: { action: "get_cursor_position" },
+        outcome: "failure",
+        failure: { error: "observation unavailable" },
+      },
+      state: "failed_no_effect",
+    },
+    {
       name: "owner-declared replay-safe failure",
       input: {
         toolName: "plugin_read",

--- a/src/agents/tools/computer-tool-request.ts
+++ b/src/agents/tools/computer-tool-request.ts
@@ -62,16 +62,6 @@ const ESCALATION_REASONS = new Set([
   "no_window_target",
   "other",
 ]);
-const READ_ONLY_COMPUTER_ACT_ACTIONS = new Set<ComputerUseV2ActionName>([
-  "list_apps",
-  "list_windows",
-  "get_accessibility_tree",
-  "get_cursor_position",
-  "get_window_state",
-  "zoom",
-  "get_browser_state",
-  "get_recording_state",
-]);
 const SCROLL_DIRECTIONS = ["up", "down", "left", "right"] as const;
 
 function isScrollDirection(value: string): value is (typeof SCROLL_DIRECTIONS)[number] {
@@ -80,10 +70,6 @@ function isScrollDirection(value: string): value is (typeof SCROLL_DIRECTIONS)[n
 
 export function isComputerActAction(action: ComputerToolAction): boolean {
   return INPUT_ACTIONS.has(action);
-}
-
-export function isReadOnlyComputerActAction(action: ComputerToolAction): boolean {
-  return READ_ONLY_COMPUTER_ACT_ACTIONS.has(action);
 }
 
 export function computerActionNeedsFrame(

--- a/src/agents/tools/computer-tool-shared.ts
+++ b/src/agents/tools/computer-tool-shared.ts
@@ -15,6 +15,32 @@ export const MODEL_OBSERVATION_MAX_ELEMENTS = 200;
 
 export type ComputerToolAction = ComputerUseV2ActionName;
 
+const COMPUTER_OBSERVATION_ACTIONS = new Set<string>([
+  "screenshot",
+  "wait",
+  "list_apps",
+  "list_windows",
+  "get_accessibility_tree",
+  "get_cursor_position",
+  "get_window_state",
+  "zoom",
+  "get_browser_state",
+  "get_recording_state",
+] satisfies ComputerToolAction[]);
+
+// Observations may refresh frame/ref caches, but do not perform setup or input.
+// Keep result handling and replay classification on the same action contract.
+export function isComputerObservationAction(
+  action: string | undefined,
+  dialogAction?: unknown,
+): boolean {
+  return (
+    action !== undefined &&
+    (COMPUTER_OBSERVATION_ACTIONS.has(action) ||
+      (action === "browser_dialog" && dialogAction === "inspect"))
+  );
+}
+
 /** The owner binds the execution target and revalidates its authority before every dispatch. */
 export type ComputerToolTransport = {
   readonly computerUse?: ComputerUseCapabilityDescriptor;

--- a/src/agents/tools/computer-tool.ts
+++ b/src/agents/tools/computer-tool.ts
@@ -15,11 +15,7 @@ import { resolveImageSanitizationLimits } from "../image-sanitization.js";
 import { type AnyAgentTool, readFiniteNumberParam, readToolStringParam } from "./common.js";
 import { buildComputerToolDescription } from "./computer-tool-guidance.js";
 import { ComputerToolSession } from "./computer-tool-node.js";
-import {
-  buildComputerActParams,
-  isComputerActAction,
-  isReadOnlyComputerActAction,
-} from "./computer-tool-request.js";
+import { buildComputerActParams, isComputerActAction } from "./computer-tool-request.js";
 import {
   computerActResultText,
   projectComputerActResult,
@@ -38,7 +34,11 @@ import type {
   ResolvedComputerTarget,
   ScreenshotCapture,
 } from "./computer-tool-shared.js";
-import { AFTER_ACTION_SCREENSHOT_DELAY_MS, MAX_WAIT_SECONDS } from "./computer-tool-shared.js";
+import {
+  AFTER_ACTION_SCREENSHOT_DELAY_MS,
+  isComputerObservationAction,
+  MAX_WAIT_SECONDS,
+} from "./computer-tool-shared.js";
 import { readGatewayCallOptions } from "./gateway.js";
 
 export type { ComputerContextEpoch, ComputerToolTransport } from "./computer-tool-shared.js";
@@ -229,7 +229,7 @@ export function createComputerTool(options?: {
           toolCallId,
           signal,
         });
-        if (actResult.observation || isReadOnlyComputerActAction(action)) {
+        if (actResult.observation || isComputerObservationAction(action, params.dialogAction)) {
           session.recordObservation(resolved, actResult);
           session.setTarget(resolved.target);
           return await projectComputerActResult({

--- a/src/agents/tools/computer-tool.v2.test.ts
+++ b/src/agents/tools/computer-tool.v2.test.ts
@@ -118,6 +118,34 @@ describe("createComputerTool v2 execution", () => {
     expect(callGatewayToolMock).not.toHaveBeenCalled();
   });
 
+  it.each(["inspect", "accept", "dismiss"])(
+    "captures an after-image only for a dialog mutation: %s",
+    async (dialogAction) => {
+      listNodesMock.mockResolvedValue([
+        macComputerNode({ computerUse: v2Descriptor(["browser_dialog"]) }),
+      ]);
+      callGatewayToolMock.mockImplementation(async (_method, _opts, body) =>
+        (body as ComputerActBody).command === COMPUTER_ACT_COMMAND
+          ? { payload: { ok: true, effect: "confirmed" } }
+          : screenshotPayload(),
+      );
+      await createVisionComputerTool().execute("dialog", {
+        action: "browser_dialog",
+        browserRef: "browser-1",
+        pageRef: "page-1",
+        dialogAction,
+        ...(dialogAction === "inspect" ? {} : { dialogRef: "dialog-1" }),
+      });
+      expect(
+        callGatewayToolMock.mock.calls.map((call) => (call[2] as ComputerActBody).command),
+      ).toEqual(
+        dialogAction === "inspect"
+          ? [COMPUTER_ACT_COMMAND]
+          : [COMPUTER_ACT_COMMAND, "screen.snapshot"],
+      );
+    },
+  );
+
   it("maps browser observations and opaque refs through the public tool", async () => {
     const actions: ComputerUseV2ActionName[] = ["get_browser_state", "browser_pointer"];
     listNodesMock.mockResolvedValue([macComputerNode({ computerUse: v2Descriptor(actions) })]);

--- a/src/talk/client-voice-confirmation.test.ts
+++ b/src/talk/client-voice-confirmation.test.ts
@@ -125,6 +125,31 @@ describe("client voice confirmation", () => {
     ).toBe(false);
   });
 
+  it("allows computer observation without consuming the next input confirmation", () => {
+    const confirmationId = block({
+      voiceSessionId: "voice-computer",
+      runId: "voice-run",
+      toolName: "computer",
+      toolParams: { action: "left_click", coordinate: [10, 20] },
+    });
+    expect(
+      checkClientVoiceToolConfirmationPolicy({
+        voiceSessionId: "voice-computer",
+        runId: "voice-run",
+        toolName: "computer",
+        toolParams: { action: "list_windows" },
+      }),
+    ).toEqual({ allowed: true });
+    expect(
+      block({
+        voiceSessionId: "voice-computer",
+        runId: "voice-run",
+        toolName: "computer",
+        toolParams: { action: "left_click", coordinate: [10, 20] },
+      }),
+    ).toBe(confirmationId);
+  });
+
   it("keeps pre-gate behavior for sessions that cannot report spoken approvals", () => {
     expect(
       checkClientVoiceToolConfirmationPolicy({


### PR DESCRIPTION
Related: #132374, #132583.

## What Problem This Solves

Fixes an issue where computer observations could use up the single mutation attempt allowed during Code Mode recovery. A window-list or cursor query could prevent the intended next action from running; after an input attempt, further observations could also be blocked.

## Why This Change Was Made

The mutation classifier still recognized only screenshot and wait, while the computer tool already had a separate set of read-only v2 actions. This change consolidates that observation contract in the existing lightweight shared owner and uses it for both result handling and mutation/replay classification. Dialog inspection is classified by its exact action, and the CUA plugin correctly reports capture/crop zoom as an ordinary observation.

The generic recovery gate is unchanged. Setup, input, dialog acceptance/dismissal, unknown actions and owner-declared side effects retain their existing restrictions. No configuration, schema, protocol, dependency or public SDK surface is added. Production changes total +37/-24 lines: the net 13 lines express the shared predicate and parameter-dependent dialog distinction while removing the two stale sets.

## User Impact

Agents can inspect the computer before and after their one permitted recovery mutation without spending another mutation attempt. Dialog inspection no longer takes an unnecessary after-screenshot. Actual input keeps its existing authorization, frame/ref checks and one-attempt recovery limit; ACP auto-approval remains disabled.

## Evidence

- Before the fix, the real recovery preparer consumed its allowance on both successful and failed observations. The embedded-attempt regression then showed the permitted write never executing after a window-list read. The CUA policy regression reported a valid crop request as input instead of observation.
- The repaired source passed 439 tests across 14 owner/sibling suites, including actual embedded recovery with Tool Search, computer frame/ref handling, dialog after-images, voice confirmation, ACP approval, terminal effect receipts, Codex dynamic tools and CUA lifecycle fixtures. Tests use model/native fixtures; they are not authenticated native-provider proof.
- Independent Codex review found no actionable P0–P2 findings. Direct source inspection covered the pinned CUA 0.21.0 implementation and Codex 0.151.0 tool/result contract.
- Composed repository checks passed: Git/source guards on the visible checkout, plus core/plugin production and test types and targeted lint on an exact source copy with a fresh frozen install. The initial checkout could not complete test types because its old UI dependency symlink resolved the wrong pako package; shared dependencies were left untouched. This is composed gate evidence, not a successful aggregate run in the stale checkout.
- Exact-head [CI33300869926](https://github.com/openclaw/openclaw/actions/runs/33300869926) passed (168 jobs successful, 17 skipped). The completed preflight log and immutable Git object identify CI checkout `345c041adf5db106b96f233775040ed2a44b7c18`, composed from main `a3b5ce6d2c7b3d806cfecc46e95a2c995f0bb6dc` and reviewed head `6c4550290bbb638b906411ee5ea1194b09903804`. Native prepare passed without changing the head.
- The canonical package built from exact reviewed head `6c4550290bbb638b906411ee5ea1194b09903804` passed full build, fresh Control UI construction and default strict integrity. All 35,425 Git source inputs remained unchanged. Tar SHA-256: `09d396131f527a4e2967326282a0e2a6ffb04a8310b7287530a0bb12955fe8ba`. This is a local canonical build, not downloaded CI bytes. Authenticated native proof passed on this exact repaired package with the OpenClaw runtime in a disposable Linux cloud session. Automatic bootstrap resolved the expected commit/build, canonical runtime pointer and same XFCE display; the CUA artifact doctor passed. Eight computer calls all succeeded: screenshot, window list, cursor read, fresh screenshot, one click, cursor read, window list and final screenshot. The input used the latest frame, returned its after-image, and WebVNC visibly changed Count0 to Count1. Passive native receipts recorded ten request/result/acknowledgement triplets, including one physical click and one execution close. The transcript ended successfully with no active run.
- Proof boundary: the native run exercises ordinary observations before/after input. The one-mutation recovery allowance is proven by the original-order owner and embedded-attempt RED-to-GREEN regressions; no live interruption was forced. Earlier broader cloud/WebVNC stress on main `357078cf7087` is not attributed to this patch. Local native/UI artifacts remain private.

Related follow-up: #126150 addresses local wait capability declarations, a separate issue from recovery classification; it is not included here.

ClawSweeper disposition: its exact-head review reported no correctness or security findings. We retain the net 13 production lines after direct maintainer review: they express the one shared observation contract and parameter-sensitive dialog distinction, remove both stale sets, and preserve the existing fail-closed input/unknown-action and owner-override behavior. No additional rank-up action was listed.
