### PR TITLE
feat(browser): show attach-only mode in status

### DIFF
--- a/extensions/browser/src/cli/browser-cli-manage.test.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.test.ts
@@ -70,6 +70,7 @@ describe("browser manage output", () => {
 
     const output = lastRuntimeLog();
     expect(output).toContain("transport: chrome-mcp");
+    expect(output).toContain("attachOnly: true");
     expect(output).toContain("headless: false (default)");
     expect(output).not.toContain("cdpPort:");
     expect(output).not.toContain("cdpUrl:");
@@ -402,6 +403,7 @@ describe("browser manage output", () => {
     const program = createBrowserManageProgram();
     await program.parseAsync(["browser", "status"], { from: "user" });
 
+    expect(lastRuntimeLog()).toContain("attachOnly: false");
     expect(lastRuntimeLog()).toContain(
       "graphics: hardware; renderer ANGLE (Intel); backend (gl=angle,angle=metal)",
     );

--- a/extensions/browser/src/cli/browser-cli-manage.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.ts
@@ -369,6 +369,7 @@ export function registerBrowserManageCommands(
             `transport: ${
               usesChromeMcpTransport(status) ? "chrome-mcp" : (status.transport ?? "cdp")
             }`,
+            `attachOnly: ${status.attachOnly}`,
             ...(!usesChromeMcpTransport(status)
               ? [
                   `cdpPort: ${status.cdpPort ?? "(unset)"}`,


### PR DESCRIPTION
Closes #133179

## What Problem This Solves

The default `openclaw browser status` summary hides whether the selected profile is attach-only, even though the canonical status response already includes that fact. Operators using the normal human-readable diagnostic therefore cannot see why OpenClaw will not manage that browser's start/stop lifecycle without switching to machine-oriented JSON output.

## Why This Change Was Made

This projects the existing `status.attachOnly` boolean directly in the browser CLI's canonical status renderer and protects both values in the existing focused output tests. It does not infer lifecycle ownership from transport, add a parallel status path, or change browser configuration or behavior.

Existing-solutions preflight: `--json` exposes the fact but is a machine-readable workaround rather than a replacement for the default operator summary. A plugin or external library cannot fill a missing projection in this owner-local CLI renderer.

## User Impact

`openclaw browser status` now includes an explicit `attachOnly: true` or `attachOnly: false` line, so operators can see the selected profile's lifecycle mode in the same summary as its transport, running state, browser, and headless mode.

No configuration, defaults, browser lifecycle, protocol, persistence, migration, compatibility, or security behavior changes.

## Evidence

### Acceptance red

Before the production edit, the focused browser CLI suite reached the status command and failed only on the new human-output expectation:

```text
expected status output to contain 'attachOnly: true'
Test Files  1 failed (1)
Tests       1 failed | 21 passed (22)
```

### Acceptance green

PR head: `8b76fa91d2961e732caf83afb617601e2cbceb5f`

```text
node scripts/run-vitest.mjs extensions/browser/src/cli/browser-cli-manage.test.ts

Test Files  1 passed (1)
Tests       22 passed (22)
```

The run used Node 24.19.0 and a fresh Vitest module cache. Fresh `autoreview` for `upstream/main...HEAD`, through P1, returned `scoped-clean` with no accepted or actionable findings and 0.98 correctness confidence.

GitHub Actions run [33301171796](https://github.com/openclaw/openclaw/actions/runs/33301171796) completed successfully for this head, including `openclaw/ci-gate`, lint, production/test types, dependency checks, architecture checks, and the selected browser extension checks.

### Real Gateway and browser proof

The successful CI `dist-runtime-build` artifact was downloaded and unpacked into a detached checkout. GitHub built the artifact from synthetic merge candidate `6fae004f2bc45d9cdfdd16cfdeff7ea472852dff`, whose parents are base `c9476275b86cd7b037ac9a33d762d0c6032b5d2f` and this PR head `8b76fa91d2961e732caf83afb617601e2cbceb5f`; `dist/build-info.json` records that merge SHA, and the built browser renderer contains this PR's new line.

A production Gateway from that artifact reached `/readyz`, loaded the bundled browser plugin, started the real browser control service, and served `browser.request` over authenticated Gateway WebSocket calls. Two isolated Chrome 152 CDP endpoints returned protocol 1.3 and were read through the real status route. Local ports, tokens, browser UUIDs, and temp paths are redacted below.

```text
GET /readyz
{"ready":true,"failing":[]}

openclaw browser --port <gateway-port> --browser-profile attach-proof status
profile: attach-proof
enabled: true
running: true
transport: cdp
attachOnly: true
cdpPort: <attach-cdp-port>
cdpUrl: http://127.0.0.1:<attach-cdp-port>
headless: true (config)

openclaw browser --port <gateway-port> --browser-profile managed-proof status
profile: managed-proof
enabled: true
running: true
transport: cdp
attachOnly: false
cdpPort: <nonattach-cdp-port>
cdpUrl: http://127.0.0.1:<nonattach-cdp-port>
headless: true (profile)
```

The matching JSON status readbacks confirmed the live transport state rather than only echoing configuration:

```json
{
  "profile": "attach-proof",
  "running": true,
  "cdpReady": true,
  "cdpHttp": true,
  "pageReady": true,
  "attachOnly": true
}
```

```json
{
  "profile": "managed-proof",
  "running": true,
  "cdpReady": true,
  "cdpHttp": true,
  "pageReady": true,
  "attachOnly": false
}
```

The Gateway log independently recorded the production route:

```text
[plugins] loading browser from .../dist/extensions/browser/index.js
[gateway] ready
[browser/service] Browser control service ready
[ws] res OK browser.request
```

### Change size

- Production: +1 LOC
- Tests: +2 LOC
- Files: 2
- Generated files and lockfiles: none

### Known proof boundary

The real proof uses the successful GitHub CI merge-candidate artifact for this exact PR head, not a locally rebuilt pure-head binary. The artifact supplies the compiled root, browser plugin, and workspace package outputs. A fresh full-lock local hydration remains blocked by the repository's existing `minimumReleaseAgeStrict` check because two unrelated Microsoft Teams lock entries are absent from the registry manifest, so no policy or lockfile was changed to manufacture a local install.
