### PR TITLE
fix: remove repeated installer finalization delays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Installer finalization:** cancel and reap watchdog sleeps after completed probes, removing repeated five-second delays without shortening probe timeouts.
 - **Control UI global sessions:** preserve the selected agent's session in the composer so usage, goals, progress, and thinking options survive agent switches without reusing another agent's stale row.
 - **Image analysis startup:** prepare selected model providers and keep configuration reads independent of full runtime loading, avoiding unrelated discovery and redundant model resolution while preserving credentials and runtime cleanup.
 - **Browser extension relay:** route Runtime binding callbacks only to registered clients and preserve shared bindings during client cleanup, preventing raw callback payloads from reaching unrelated Playwright sessions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Installer finalization:** cancel and reap watchdog sleeps after completed probes, removing repeated five-second delays without shortening probe timeouts.
 - **Control UI global sessions:** preserve the selected agent's session in the composer so usage, goals, progress, and thinking options survive agent switches without reusing another agent's stale row.
 - **Image analysis startup:** prepare selected model providers and keep configuration reads independent of full runtime loading, avoiding unrelated discovery and redundant model resolution while preserving credentials and runtime cleanup.
 - **Browser extension relay:** route Runtime binding callbacks only to registered clients and preserve shared bindings during client cleanup, preventing raw callback payloads from reaching unrelated Playwright sessions.

--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -111,7 +111,7 @@ Recommended for most interactive installs on macOS/Linux/WSL.
   </Step>
   <Step title="Post-install tasks">
     - Resolves the just-installed `openclaw` binary for follow-up commands
-    - npm-prefix and daemon-status probes use a five-second timeout; completed probes return without waiting for that deadline.
+    - npm-prefix and daemon-status probes use a default five-second timeout; completed probes return without waiting for that deadline.
     - For an unconfigured install, starts onboarding before doctor or gateway probes. With `--no-onboard` or no TTY, it prints the command to finish setup later.
     - For a configured install, refreshes and restarts a loaded gateway service best-effort and runs repair Doctor. Upgrade repair failures are fatal; plugin update failures remain warnings.
     - When `--verify` runs, it checks the installed version and checks gateway health only after configuration exists.

--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -111,6 +111,7 @@ Recommended for most interactive installs on macOS/Linux/WSL.
   </Step>
   <Step title="Post-install tasks">
     - Resolves the just-installed `openclaw` binary for follow-up commands
+    - npm-prefix and daemon-status probes use a five-second timeout; completed probes return without waiting for that deadline.
     - For an unconfigured install, starts onboarding before doctor or gateway probes. With `--no-onboard` or no TTY, it prints the command to finish setup later.
     - For a configured install, refreshes and restarts a loaded gateway service best-effort and runs repair Doctor. Upgrade repair failures are fatal; plugin update failures remain warnings.
     - When `--verify` runs, it checks the installed version and checks gateway health only after configuration exists.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3086,11 +3086,23 @@ bounded_probe_output() {
     pid="$!"
 
     (
-        sleep "$timeout_seconds"
+        local sleeper
+        # Builtin wait lets TERM interrupt the watchdog; a foreground sleep
+        # would outlive it and hold the caller's command-substitution pipe open.
+        trap 'exit' TERM
+        trap '
+            for sleeper in $(jobs -p); do
+                kill "$sleeper" 2>/dev/null || true
+                wait "$sleeper" 2>/dev/null || true
+            done
+        ' EXIT
+        sleep "$timeout_seconds" &
+        wait "$!"
         if kill -0 "$pid" 2>/dev/null; then
             printf '1' >"$timeout_file"
             kill "$pid" 2>/dev/null || true
-            sleep 0.1
+            sleep 0.1 &
+            wait "$!"
             kill -9 "$pid" 2>/dev/null || true
             printf 'timeout' >"$status_file"
         fi

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -2545,6 +2545,56 @@ EOF
     expect(result.stdout).not.toContain("[4/3] Verifying installation");
   });
 
+  it.each([0, 17])("joins the finalization watchdog after probe exit %s", (probeExit) => {
+    const root = mkdtempSync(join(tmpdir(), "openclaw-install-watchdog-"));
+    const sleep = join(root, "sleep");
+    // Synchronize on the real watchdog sleep without shortening its deadline
+    // or making the assertion depend on host timing.
+    writeFileSync(
+      sleep,
+      '#!/bin/bash\nprintf "%s\\n" "$$" > "$WATCHDOG_PID"\nprintf "ready\\n" > "$WATCHDOG_READY"\nexec /bin/sleep "$@"\n',
+      { mode: 0o755 },
+    );
+
+    try {
+      const result = runInstallShell(
+        `
+          source "${SCRIPT_PATH}"
+          mkfifo "$WATCHDOG_READY"
+          fast_probe() {
+            IFS= read -r ready < "$WATCHDOG_READY"
+            printf 'probe-output'
+            return "$PROBE_EXIT"
+          }
+          output="$(
+            probe_status=0
+            bounded_probe_output fixture fast_probe || probe_status=$?
+            watchdog_pid="$(cat "$WATCHDOG_PID")"
+            if kill -0 "$watchdog_pid" 2>/dev/null; then
+              printf ':watchdog-alive'
+            fi
+            printf ':status=%s' "$probe_status"
+            cleanup_tmpfiles
+          )"
+          printf '%s\\n' "$output"
+        `,
+        {
+          PATH: `${root}:${process.env.PATH ?? ""}`,
+          PROBE_EXIT: String(probeExit),
+          WATCHDOG_PID: join(root, "sleep.pid"),
+          WATCHDOG_READY: join(root, "ready"),
+          OPENCLAW_INSTALL_PROBE_TIMEOUT_SECONDS: undefined,
+        },
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toBe(`probe-output:status=${probeExit}\n`);
+      expect(result.stderr).toBe("");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("bounds installer npm prefix probes during finalization helpers", () => {
     const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-npm-probe-"));
     const npm = join(tmp, "npm");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users finishing installation would wait an extra five seconds for each already-completed npm-prefix or daemon-status probe. The same defect makes the existing installer rollback test take about 15 seconds despite its three probes returning immediately.

## Why This Change Was Made

The watchdog shell was terminated while its foreground sleep survived, retaining the pipe used by command substitution. The watchdog now installs cleanup before launching either sleep, waits through Bash's interruptible builtin, and cancels and joins its own children on exit. This preserves the existing command wrapper, statuses, warning, five-second default, and 0.1-second escalation.

This is confined to watchdog ownership. No process-group, dependency, configuration, sharding, concurrency, mock or existing assertion changes. Production delta is +14/-2: the additional lines explicitly own cancellation and reaping of both sleeps without introducing another helper or a PID-assignment race. Tests add two cases; installer documentation describes the corrected completion behavior. Release-note context stays in this PR body.

## User Impact

Completed probes return promptly instead of paying the watchdog deadline. The unchanged rollback test fell from 15.323 seconds to 0.270 seconds locally (0.230 seconds with stock macOS Bash 3.2). These are focused execution measurements, not a claim about total CI duration.

Two separately reproduced lifecycle follow-ups remain outside this fix: **probe command descendants after timeout** (the original wrapper can exit while its command survives), and **probe temporary-file ownership inside command substitution** (registrations do not reach the outer cleanup). Neither is claimed repaired. A broader process-group rewrite was rejected here because it would require separately proven interruption forwarding across nested command substitutions.

## Evidence

- Both new FIFO-synchronized regression cases failed on the original owner with an actual live watchdog child after probe return; both pass after the fix for exit statuses 0 and 17. They inspect liveness before command-substitution EOF and do not assert elapsed thresholds or shorten the real sleep.
- All 273 installer, CLI-installer and website-sync workflow tests passed. The five focused rollback/watchdog/timeout cases also passed using stock macOS Bash 3.2.
- Real installed npm-prefix probes through the actual installer helper, in isolated homes: 5.055s to 0.149s on Bash 3.2; 5.064s to 0.146s on Bash 5. Output and exit status were unchanged. No package installation or user configuration mutation was needed for this read-only operator path.
- Shell syntax, ShellCheck and the full changed-file gate passed. Required Codex autoreview was scoped-clean; independent lifecycle review found no actionable issue in this narrow change.
- Direct Apple Bash source inspection confirms asynchronous subshell job tables exclude sibling jobs and background children are registered before `$!` is assigned. Separate Bash 3.2/5 cancellation probes covered cancellation before and during sleep without killing a sibling.

Addressed the ClawSweeper finding and Rank-up move: removed the release-owned changelog hunk and clarified that five seconds is the default. The production script and test are byte-identical to initial head `5e70082`, whose [CI](https://github.com/openclaw/openclaw/actions/runs/33301353225) and [real installer workflow](https://github.com/openclaw/openclaw/actions/runs/33301342022) both passed. The updated head will be checked again before landing.
