### PR TITLE
fix(cli): reject conflicting TTS persona selectors

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -677,6 +677,7 @@ describe("capability cli", () => {
     mocks.transcribeAudioFile.mockClear();
     mocks.textToSpeech.mockClear();
     mocks.setTtsProvider.mockClear();
+    mocks.setTtsPersona.mockClear();
     mocks.getTtsProvider.mockReset().mockReturnValue("openai");
     mocks.listSpeechProviders.mockReset().mockReturnValue([]);
     mocks.resolveExplicitTtsOverrides.mockClear();
@@ -1667,6 +1668,35 @@ describe("capability cli", () => {
     expect(firstGatewayCall()?.method).toBe("tts.status");
     expect(firstJsonOutput()?.transport).toBe("gateway");
   });
+
+  it.each(
+    (["local", "gateway"] as const).flatMap((transport) => [
+      { order: "persona then off", selectorArgs: ["--persona", "work", "--off"], transport },
+      { order: "off then persona", selectorArgs: ["--off", "--persona", "work"], transport },
+    ]),
+  )(
+    "rejects conflicting TTS persona selectors via $transport ($order)",
+    async ({ selectorArgs, transport }) => {
+      const argv = ["infer", "tts", "set-persona", ...selectorArgs, `--${transport}`, "--json"];
+      const program = new Command().exitOverride().configureOutput({ writeErr: () => {} });
+      await registerCapabilityCli(program, ["node", "openclaw", ...argv]);
+
+      let error: unknown;
+      try {
+        await program.parseAsync(argv, { from: "user" });
+      } catch (cause) {
+        error = cause;
+      }
+
+      expect(mocks.callGateway).not.toHaveBeenCalled();
+      expect(mocks.setTtsPersona).not.toHaveBeenCalled();
+      expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
+      expect(error).toMatchObject({
+        code: "commander.conflictingOption",
+        message: "error: option '--persona <id>' cannot be used with option '--off'",
+      });
+    },
+  );
 
   it("routes image describe through media understanding, not generation", async () => {
     await runCapability("image", "describe", "--file", "photo.jpg", "--json");

--- a/src/cli/capability-cli/tts.ts
+++ b/src/cli/capability-cli/tts.ts
@@ -1,4 +1,4 @@
-import type { Command } from "commander";
+import { Option, type Command } from "commander";
 import { callGateway } from "../../gateway/call.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeSpeechProviderId } from "../../tts/provider-registry.js";
@@ -163,7 +163,7 @@ export function registerTtsCapabilityCommands(capability: Command): void {
     tts
       .command("set-persona")
       .description("Set the active TTS persona")
-      .option("--persona <id>", "TTS persona id")
+      .addOption(new Option("--persona <id>", "TTS persona id").conflicts("off"))
       .option("--off", "Disable the active TTS persona", false),
     "gateway",
     (opts, transport) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users passing both `--persona <id>` and `--off` to
`openclaw infer tts set-persona` would silently disable the active persona.
Local execution cleared the stored persona, while gateway execution sent an
`off` mutation.

## Why This Change Was Made

The two flags are contradictory selectors, so the command now declares their
conflict through Commander's option metadata. Commander rejects the invocation
before the action, transport selection, preference mutation, or gateway RPC.

An action-level guard was rejected because static option exclusivity belongs to
the parser and Commander already provides the canonical error contract.

Production LOC: +2/-2 (net 0) | Tests: +30/-0.

## User Impact

Contradictory persona selectors now fail clearly instead of silently disabling
the configured TTS persona. Valid `--persona` and `--off` invocations are
unchanged.

## Evidence

Exact head: `b9cf7088795c7b7f7657ad2e993a7272601a9953`.

Pre-fix, all four combinations of selector order and transport mutated state:

- Both local orders called `setTtsPersona(..., null)`.
- Both gateway orders sent `tts.setPersona` with `{ persona: "off" }`.

Post-fix:

- Four regression cases pass for both selector orders across local and gateway
  transport, asserting `commander.conflictingOption`, the exact error text, and
  zero local mutation, gateway RPC, or JSON output.
- Capability CLI owner and lazy-registration suites: 200/200 tests passed.
- `pnpm tsgo:core`: passed.
- Max-lines and assertion-safety ratchets: passed.
- Scoped repository oxlint, formatting, and `git diff --check`: passed.
- Autoreview: no accepted or actionable findings, overall 0.99.
- Independent exact-head review: no findings; best-fix verdict.

`pnpm tsgo:core:test` could not run in the linked sparse worktree because the
tracked `ui/config` inputs are absent. Full-checkout exact-head CI owns that
remaining proof.
