### PR TITLE
test: reuse immutable worktree containment history

### DIFF
--- a/test/scripts/pr-worktree-containment.test.ts
+++ b/test/scripts/pr-worktree-containment.test.ts
@@ -2,6 +2,8 @@ import { spawnSync } from "node:child_process";
 import {
   existsSync,
   chmodSync,
+  constants as fsConstants,
+  cpSync,
   mkdirSync,
   readFileSync,
   realpathSync,
@@ -10,10 +12,13 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const templateDirs = useAutoCleanupTempDirTracker(afterAll);
+let fixtureTemplate: ReturnType<typeof createFixtureTemplate> | undefined;
+let reviewFixtureTemplate: ReturnType<typeof createReviewFixtureTemplate> | undefined;
 const repoRoot = process.cwd();
 const commonScript = join(repoRoot, "scripts/pr-lib/common.sh");
 const worktreeScript = join(repoRoot, "scripts/pr-lib/worktree.sh");
@@ -38,8 +43,8 @@ function git(root: string, ...args: string[]) {
   return result.stdout.trim();
 }
 
-function createFixture(): Fixture {
-  const root = tempDirs.make("openclaw-pr-worktree-containment-");
+function createFixtureTemplate() {
+  const root = templateDirs.make("openclaw-pr-worktree-containment-template-");
   git(root, "init", "--initial-branch=main");
   git(root, "config", "user.name", "OpenClaw Test");
   git(root, "config", "user.email", "test@openclaw.invalid");
@@ -47,6 +52,15 @@ function createFixture(): Fixture {
   git(root, "add", "fixture.txt");
   git(root, "commit", "-m", "main fixture");
   const mainSha = git(root, "rev-parse", "HEAD");
+  return { root, mainSha };
+}
+
+function createFixture(): Fixture {
+  const template = (fixtureTemplate ??= createFixtureTemplate());
+  const root = tempDirs.make("openclaw-pr-worktree-containment-");
+  // Copy complete history before worktrees exist; each case owns its fetch and refs.
+  cpSync(template.root, root, { recursive: true, mode: fsConstants.COPYFILE_FICLONE });
+  const { mainSha } = template;
   git(root, "remote", "add", "origin", root);
   git(root, "fetch", "origin");
   git(root, "checkout", "-b", "sibling/work");
@@ -60,8 +74,8 @@ function createFixture(): Fixture {
   };
 }
 
-function createReviewFixture(): ReviewFixture {
-  const root = tempDirs.make("openclaw-pr-review-transition-");
+function createReviewFixtureTemplate() {
+  const root = templateDirs.make("openclaw-pr-review-transition-template-");
   git(root, "init", "--initial-branch=main");
   git(root, "config", "user.name", "OpenClaw Test");
   git(root, "config", "user.email", "test@openclaw.invalid");
@@ -90,6 +104,14 @@ function createReviewFixture(): ReviewFixture {
   git(root, "add", "main-only.txt");
   git(root, "commit", "-m", "advance main fixture");
   const mainSha = git(root, "rev-parse", "HEAD");
+  return { root, mainSha, prASha, prBSha };
+}
+
+function createReviewFixture(): ReviewFixture {
+  const template = (reviewFixtureTemplate ??= createReviewFixtureTemplate());
+  const root = tempDirs.make("openclaw-pr-review-transition-");
+  cpSync(template.root, root, { recursive: true, mode: fsConstants.COPYFILE_FICLONE });
+  const { mainSha, prASha, prBSha } = template;
   git(root, "remote", "add", "origin", root);
   git(root, "fetch", "origin");
 


### PR DESCRIPTION
## What Problem This Solves

The 38 native worktree-containment tests repeatedly rebuild the same two Git histories before each scenario. That startup work adds execution time without adding a new state transition to the tests.

## Why This Change Was Made

Build each immutable history once, then copy the complete repository into an independently owned case directory. Both templates stop before origin configuration or fetching; each case retains its original origin, real fetch, sibling branch and commit, and all subsequent worktree, failure, recovery and foreign-state operations.

Templates have separate after-all cleanup, while cases retain their existing after-each cleanup. Initialization is registered before it starts, and only successful templates are cached. Full copies retain every Git object and ref without hardlinks, alternates, linked worktrees or relocated fetch metadata. This removes 414 repeated bootstrap Git launches.

## User Impact

Internal tests only. Four full-file runs passed all 38 cases: before 32.244s, after 28.093s, after 30.797s, before 31.508s. Mean elapsed execution fell from 31.876s to 29.445s: about 2.43 seconds, or 7.6%. Template creation is included. This is a focused local result, not a claim about total CI duration.

Production delta is zero; test support is +27/-5. All test cases, assertions and bytes from the first scenario helper onward are unchanged. No sharding, concurrency, clocks, mocks, dependency or product changes. No changelog entry is needed for this internal test change.

## Evidence

- All 38 cases passed in every before/after run and in shuffled order with seed 93190.
- An actual-helper probe compared baseline, cold and warm repositories: configuration, fetch metadata, refs, HEAD, index, trees and status match after normalizing temporary paths and commit identities.
- File identity checks prove independent copies. Ref/config/hook mutations and real worktree creation/removal in one case leave the other cases and template unchanged. A later copy still matches the baseline.
- Injected Git bootstrap failures leave both caches unpublished and all partial directories registered for cleanup. Registered cleanup removed every case and template directory.
- Current-main preflight found the tested native owners, runner, dependency lockfile and containment test unchanged from the measured baseline.
- Full changed-file gate and required Codex autoreview passed. Independent source review found no actionable ownership, cleanup or relocation issue.

Hosted CI will be checked at the published head before ordinary native landing.
