### PR TITLE
fix(workspace): recover moved aliases without blocking messages

### DIFF
--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -731,6 +731,12 @@ That stages grounded durable candidates into the short-term dreaming store while
     See [/concepts/agent-workspace](/concepts/agent-workspace) for a full guide to workspace structure and git backup (recommended private GitHub or GitLab).
 
   </Accordion>
+  <Accordion title="20. Repointed workspace aliases">
+    When a configured workspace path is a symlink that now resolves to a different target than the one that owns its stored setup state (for example after moving the workspace to another disk and re-linking the old path), the runtime fails closed and inbound messages for that workspace fail until the alias is repaired.
+
+    Doctor detects this and `doctor --fix` rebinds the stored state to the current target without touching any workspace files. When the attested workspace files verify against the new target, the rebind is applied automatically; otherwise it requires an interactive confirmation or `--force`. If the new target already has its own workspace state, doctor refuses to merge and asks you to remove one workspace's state first.
+
+  </Accordion>
 </AccordionGroup>
 
 ## Related

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -732,9 +732,15 @@ That stages grounded durable candidates into the short-term dreaming store while
 
   </Accordion>
   <Accordion title="20. Repointed workspace aliases">
-    When a configured workspace path is a symlink that now resolves to a different target than the one that owns its stored setup state (for example after moving the workspace to another disk and re-linking the old path), the runtime fails closed and inbound messages for that workspace fail until the alias is repaired.
+    If you move a workspace folder and update its symlink, OpenClaw refuses to use the new target until you confirm the move. Incoming messages receive a repair notice instead of remaining stuck in retries.
 
-    Doctor detects this and can rebind the stored state to the current target without touching workspace files. Generated template hashes provide corroborating evidence, but they do not prove workspace identity. Confirm the repair in an interactive `openclaw doctor` run, or use `openclaw doctor --fix --force` for a non-interactive repair. Doctor refuses to merge when the new target already owns workspace state or another configured agent still uses the old target.
+    Run `openclaw doctor` and confirm only if the destination contains the same workspace. For unattended recovery, `openclaw doctor --fix --force --non-interactive` supplies that confirmation; ordinary non-interactive `--fix` does not. Keep the workspace paths and configuration unchanged until Doctor finishes.
+
+    The repair preserves setup completion, file-verification history, and migration records without changing workspace files. It removes stale path associations so later cleanup of the old location cannot delete the moved workspace's records. Repeat Doctor or restart the Gateway after recovery to check the installation.
+
+    Doctor leaves records untouched if the original folder still exists, the destination is missing or already owns records, another configured workspace still uses the old location, or inspection facts change. Pending or conflicting migration history must be resolved before the move can proceed. Follow the reported recovery instructions; do not delete workspace records to force a merge.
+
+    If you intended to switch to a different workspace, restore the original link or configure the intended destination directly. Do not confirm a transfer of the old workspace's history.
 
   </Accordion>
 </AccordionGroup>

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -734,7 +734,7 @@ That stages grounded durable candidates into the short-term dreaming store while
   <Accordion title="20. Repointed workspace aliases">
     When a configured workspace path is a symlink that now resolves to a different target than the one that owns its stored setup state (for example after moving the workspace to another disk and re-linking the old path), the runtime fails closed and inbound messages for that workspace fail until the alias is repaired.
 
-    Doctor detects this and `doctor --fix` rebinds the stored state to the current target without touching any workspace files. When the attested workspace files verify against the new target, the rebind is applied automatically; otherwise it requires an interactive confirmation or `--force`. If the new target already has its own workspace state, doctor refuses to merge and asks you to remove one workspace's state first.
+    Doctor detects this and can rebind the stored state to the current target without touching workspace files. Generated template hashes provide corroborating evidence, but they do not prove workspace identity. Confirm the repair in an interactive `openclaw doctor` run, or use `openclaw doctor --fix --force` for a non-interactive repair. Doctor refuses to merge when the new target already owns workspace state or another configured agent still uses the old target.
 
   </Accordion>
 </AccordionGroup>

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -734,9 +734,9 @@ That stages grounded durable candidates into the short-term dreaming store while
   <Accordion title="20. Repointed workspace aliases">
     If you move a workspace folder and update its symlink, OpenClaw refuses to use the new target until you confirm the move. Incoming messages receive a repair notice instead of remaining stuck in retries.
 
-    Run `openclaw doctor` and confirm only if the destination contains the same workspace. For unattended recovery, `openclaw doctor --fix --force --non-interactive` supplies that confirmation; ordinary non-interactive `--fix` does not. Keep the workspace paths and configuration unchanged until Doctor finishes.
+    Run `openclaw doctor --fix` and confirm only if the destination contains the same workspace. Doctor coordinates an owned managed Gateway; stop a foreground or externally managed Gateway through its owner first. For unattended recovery, `openclaw doctor --fix --force --non-interactive` supplies that confirmation; ordinary non-interactive `--fix` does not. Plain `openclaw doctor` reports the problem without transferring records. Keep the workspace paths and configuration unchanged until Doctor finishes.
 
-    The repair preserves setup completion, file-verification history, and migration records without changing workspace files. It removes stale path associations so later cleanup of the old location cannot delete the moved workspace's records. Repeat Doctor or restart the Gateway after recovery to check the installation.
+    The repair preserves setup completion, file-verification history, and migration records without changing workspace files. It removes stale path associations so later cleanup of the old location cannot delete the moved workspace's records. Start any Gateway you stopped manually, then send a message to check recovery.
 
     Doctor leaves records untouched if the original folder still exists, the destination is missing or already owns records, another configured workspace still uses the old location, or inspection facts change. Pending or conflicting migration history must be resolved before the move can proceed. Follow the reported recovery instructions; do not delete workspace records to force a merge.
 

--- a/src/agents/workspace-alias-rebind.test.ts
+++ b/src/agents/workspace-alias-rebind.test.ts
@@ -14,7 +14,10 @@ import {
   detectRepointedWorkspaceAlias,
   rebindRepointedWorkspaceAlias,
 } from "./workspace-alias-rebind.js";
-import { resolveWorkspaceStateIdentity } from "./workspace-state-identity.js";
+import {
+  resolveWorkspaceStateIdentity,
+  WorkspaceAliasRepointedError,
+} from "./workspace-state-identity.js";
 import {
   mergeWorkspaceSetupState,
   deleteWorkspaceState,
@@ -115,6 +118,31 @@ describe("workspace alias rebind", () => {
     expect(rebindRepointedWorkspaceAlias(alias, approvedFacts)).toBe("repoint-changed");
     expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
     expect(readWorkspaceStateSnapshot(secondReplacement).setupExists).toBe(false);
+  });
+
+  it("fails closed again when the alias is repointed after a committed rebind", () => {
+    const original = testState!.workspaceDir;
+    const alias = testState!.path("workspace-link");
+    const replacement = testState!.path("replacement-workspace");
+    const lateTarget = testState!.path("late-target");
+    fs.mkdirSync(replacement, { recursive: true });
+    fs.mkdirSync(lateTarget, { recursive: true });
+    fs.symlinkSync(original, alias, process.platform === "win32" ? "junction" : "dir");
+    mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+    fs.unlinkSync(alias);
+    fs.symlinkSync(replacement, alias, process.platform === "win32" ? "junction" : "dir");
+    const facts = detectRepointedWorkspaceAlias(alias)!;
+    expect(rebindRepointedWorkspaceAlias(alias, facts)).toBe("rebound");
+
+    // A repoint racing the committed transfer cannot be adopted: state moved
+    // only to the operator-approved target, and the guard re-engages for the
+    // unapproved one instead of serving it.
+    fs.unlinkSync(alias);
+    fs.symlinkSync(lateTarget, alias, process.platform === "win32" ? "junction" : "dir");
+
+    expect(() => readWorkspaceStateSnapshot(alias)).toThrow(WorkspaceAliasRepointedError);
+    expect(readWorkspaceStateSnapshot(replacement).setupExists).toBe(true);
+    expect(readWorkspaceStateSnapshot(lateTarget).setupExists).toBe(false);
   });
 
   it("rejects malformed persisted attestation rows during detection", () => {

--- a/src/agents/workspace-alias-rebind.test.ts
+++ b/src/agents/workspace-alias-rebind.test.ts
@@ -1,0 +1,91 @@
+// Detection and non-destructive rebind of repointed workspace aliases.
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import {
+  detectRepointedWorkspaceAlias,
+  rebindRepointedWorkspaceAlias,
+} from "./workspace-alias-rebind.js";
+import { resolveWorkspaceStateIdentity } from "./workspace-state-identity.js";
+import {
+  mergeWorkspaceSetupState,
+  readWorkspaceStateSnapshot,
+  replaceWorkspaceAttestation,
+} from "./workspace-state-store.js";
+
+let testState: OpenClawTestState | undefined;
+
+beforeEach(async () => {
+  testState = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-workspace-alias-rebind-",
+  });
+});
+
+afterEach(async () => {
+  closeOpenClawStateDatabaseForTest();
+  await testState?.cleanup();
+  testState = undefined;
+});
+
+describe("workspace alias rebind", () => {
+  it("detects and rebinds a repointed alias without touching workspace files", () => {
+    const dir = testState!.workspaceDir;
+    const alias = testState!.path("workspace-link");
+    const replacement = testState!.path("replacement-workspace");
+    fs.mkdirSync(replacement, { recursive: true });
+    fs.writeFileSync(path.join(replacement, "kept.txt"), "moved workspace content");
+    fs.symlinkSync(dir, alias, process.platform === "win32" ? "junction" : "dir");
+    mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+    replaceWorkspaceAttestation({
+      workspaceDir: alias,
+      attestedAtMs: 1_000,
+      generatedHashes: new Map([["BOOTSTRAP.md", "a".repeat(64)]]),
+      nowMs: 1_000,
+    });
+    fs.unlinkSync(alias);
+    fs.symlinkSync(replacement, alias, process.platform === "win32" ? "junction" : "dir");
+
+    const facts = detectRepointedWorkspaceAlias(alias);
+    expect(facts).toMatchObject({
+      storedWorkspacePath: resolveWorkspaceStateIdentity(dir).workspacePath,
+      currentWorkspacePath: resolveWorkspaceStateIdentity(replacement).workspacePath,
+      currentTargetHasOwnState: false,
+    });
+    expect(facts?.storedAttestationHashes.get("BOOTSTRAP.md")).toBe("a".repeat(64));
+
+    expect(rebindRepointedWorkspaceAlias(alias)).toBe("rebound");
+    const snapshot = readWorkspaceStateSnapshot(alias);
+    expect(snapshot.setupExists).toBe(true);
+    expect(snapshot.setup.bootstrapSeededAt).toBe("2026-07-16T01:00:00.000Z");
+    expect(snapshot.attestation?.generatedHashes.get("BOOTSTRAP.md")).toBe("a".repeat(64));
+    expect(fs.readFileSync(path.join(replacement, "kept.txt"), "utf-8")).toBe(
+      "moved workspace content",
+    );
+
+    expect(detectRepointedWorkspaceAlias(alias)).toBeUndefined();
+    expect(rebindRepointedWorkspaceAlias(alias)).toBe("no-repoint");
+  });
+
+  it("refuses to rebind onto a target that already owns workspace state", () => {
+    const dir = testState!.workspaceDir;
+    const alias = testState!.path("workspace-link");
+    const replacement = testState!.path("replacement-workspace");
+    fs.mkdirSync(replacement, { recursive: true });
+    fs.symlinkSync(dir, alias, process.platform === "win32" ? "junction" : "dir");
+    mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+    mergeWorkspaceSetupState(replacement, { bootstrapSeededAt: "2026-07-16T02:00:00.000Z" }, 2_000);
+    fs.unlinkSync(alias);
+    fs.symlinkSync(replacement, alias, process.platform === "win32" ? "junction" : "dir");
+
+    expect(detectRepointedWorkspaceAlias(alias)?.currentTargetHasOwnState).toBe(true);
+    expect(rebindRepointedWorkspaceAlias(alias)).toBe("current-target-owns-state");
+    expect(readWorkspaceStateSnapshot(dir).setupExists).toBe(true);
+    expect(readWorkspaceStateSnapshot(replacement).setupExists).toBe(true);
+  });
+});

--- a/src/agents/workspace-alias-rebind.test.ts
+++ b/src/agents/workspace-alias-rebind.test.ts
@@ -2,7 +2,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -14,8 +17,11 @@ import {
 import { resolveWorkspaceStateIdentity } from "./workspace-state-identity.js";
 import {
   mergeWorkspaceSetupState,
+  deleteWorkspaceState,
+  prepareWorkspaceStateDeletion,
   readWorkspaceStateSnapshot,
   replaceWorkspaceAttestation,
+  WORKSPACE_LEGACY_STATE_MIGRATION_KIND,
 } from "./workspace-state-store.js";
 
 let testState: OpenClawTestState | undefined;
@@ -59,7 +65,7 @@ describe("workspace alias rebind", () => {
     });
     expect(facts?.storedAttestationHashes.get("BOOTSTRAP.md")).toBe("a".repeat(64));
 
-    expect(rebindRepointedWorkspaceAlias(alias)).toBe("rebound");
+    expect(rebindRepointedWorkspaceAlias(alias, facts!)).toBe("rebound");
     const snapshot = readWorkspaceStateSnapshot(alias);
     expect(snapshot.setupExists).toBe(true);
     expect(snapshot.setup.bootstrapSeededAt).toBe("2026-07-16T01:00:00.000Z");
@@ -69,7 +75,7 @@ describe("workspace alias rebind", () => {
     );
 
     expect(detectRepointedWorkspaceAlias(alias)).toBeUndefined();
-    expect(rebindRepointedWorkspaceAlias(alias)).toBe("no-repoint");
+    expect(rebindRepointedWorkspaceAlias(alias, facts!)).toBe("no-repoint");
   });
 
   it("refuses to rebind onto a target that already owns workspace state", () => {
@@ -83,9 +89,100 @@ describe("workspace alias rebind", () => {
     fs.unlinkSync(alias);
     fs.symlinkSync(replacement, alias, process.platform === "win32" ? "junction" : "dir");
 
-    expect(detectRepointedWorkspaceAlias(alias)?.currentTargetHasOwnState).toBe(true);
-    expect(rebindRepointedWorkspaceAlias(alias)).toBe("current-target-owns-state");
+    const facts = detectRepointedWorkspaceAlias(alias)!;
+    expect(facts.currentTargetHasOwnState).toBe(true);
+    expect(rebindRepointedWorkspaceAlias(alias, facts)).toBe("current-target-owns-state");
     expect(readWorkspaceStateSnapshot(dir).setupExists).toBe(true);
     expect(readWorkspaceStateSnapshot(replacement).setupExists).toBe(true);
+  });
+
+  it("rejects a target change after doctor presents the repair facts", () => {
+    const original = testState!.workspaceDir;
+    const alias = testState!.path("workspace-link");
+    const firstReplacement = testState!.path("replacement-a");
+    const secondReplacement = testState!.path("replacement-b");
+    fs.mkdirSync(firstReplacement, { recursive: true });
+    fs.mkdirSync(secondReplacement, { recursive: true });
+    fs.symlinkSync(original, alias, process.platform === "win32" ? "junction" : "dir");
+    mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+    fs.unlinkSync(alias);
+    fs.symlinkSync(firstReplacement, alias, process.platform === "win32" ? "junction" : "dir");
+    const approvedFacts = detectRepointedWorkspaceAlias(alias)!;
+
+    fs.unlinkSync(alias);
+    fs.symlinkSync(secondReplacement, alias, process.platform === "win32" ? "junction" : "dir");
+
+    expect(rebindRepointedWorkspaceAlias(alias, approvedFacts)).toBe("repoint-changed");
+    expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
+    expect(readWorkspaceStateSnapshot(secondReplacement).setupExists).toBe(false);
+  });
+
+  it("rejects malformed persisted attestation rows during detection", () => {
+    const original = testState!.workspaceDir;
+    const alias = testState!.path("workspace-link");
+    const replacement = testState!.path("replacement-workspace");
+    fs.mkdirSync(replacement, { recursive: true });
+    fs.symlinkSync(original, alias, process.platform === "win32" ? "junction" : "dir");
+    mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+    replaceWorkspaceAttestation({
+      workspaceDir: alias,
+      attestedAtMs: 1_000,
+      generatedHashes: new Map([["BOOTSTRAP.md", "a".repeat(64)]]),
+      nowMs: 1_000,
+    });
+    openOpenClawStateDatabase()
+      .db.prepare("UPDATE workspace_generated_bootstrap_hashes SET filename = '../outside.md'")
+      .run();
+    fs.unlinkSync(alias);
+    fs.symlinkSync(replacement, alias, process.platform === "win32" ? "junction" : "dir");
+
+    expect(() => detectRepointedWorkspaceAlias(alias)).toThrow(
+      /workspace attestation hash row is invalid/u,
+    );
+  });
+
+  it("transfers migration receipt ownership so later deletion removes it", () => {
+    const original = testState!.workspaceDir;
+    const alias = testState!.path("workspace-link");
+    const replacement = testState!.path("replacement-workspace");
+    fs.mkdirSync(replacement, { recursive: true });
+    fs.symlinkSync(original, alias, process.platform === "win32" ? "junction" : "dir");
+    mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+    const originalIdentity = resolveWorkspaceStateIdentity(original);
+    const db = openOpenClawStateDatabase().db;
+    db.prepare(
+      "INSERT INTO migration_runs (id, started_at, finished_at, status, report_json) VALUES ('workspace-run', 1, 1, 'completed', '{}')",
+    ).run();
+    db.prepare(
+      `INSERT INTO migration_sources (
+        source_key, migration_kind, source_path, target_table, last_run_id, status, imported_at,
+        report_json
+      ) VALUES ('workspace-receipt', ?, '/legacy/workspace-state.json',
+        'workspace_setup_state', 'workspace-run', 'completed', 1, ?)`,
+    ).run(
+      WORKSPACE_LEGACY_STATE_MIGRATION_KIND,
+      JSON.stringify({ workspaceKey: originalIdentity.workspaceKey }),
+    );
+    fs.unlinkSync(alias);
+    fs.symlinkSync(replacement, alias, process.platform === "win32" ? "junction" : "dir");
+    const facts = detectRepointedWorkspaceAlias(alias)!;
+
+    expect(rebindRepointedWorkspaceAlias(alias, facts)).toBe("rebound");
+    const receipt = db
+      .prepare("SELECT report_json FROM migration_sources WHERE source_key = 'workspace-receipt'")
+      .get() as { report_json: string };
+    expect(JSON.parse(receipt.report_json)).toMatchObject({
+      workspaceKey: resolveWorkspaceStateIdentity(replacement).workspaceKey,
+    });
+
+    deleteWorkspaceState(prepareWorkspaceStateDeletion(alias));
+    expect(
+      db
+        .prepare("SELECT source_key FROM migration_sources WHERE source_key = 'workspace-receipt'")
+        .get(),
+    ).toBeUndefined();
+    expect(
+      db.prepare("SELECT id FROM migration_runs WHERE id = 'workspace-run'").get(),
+    ).toBeUndefined();
   });
 });

--- a/src/agents/workspace-alias-rebind.test.ts
+++ b/src/agents/workspace-alias-rebind.test.ts
@@ -68,6 +68,79 @@ function movedWorkspace(attestationOnly = false) {
 }
 
 describe("workspace move recovery", () => {
+  it("finds a repointed alias with decomposed Unicode in its own name", async () => {
+    const original = state.workspaceDir;
+    const alias = state.path("alias-e\u0301");
+    const moved = state.path("unicode-alias-moved");
+    link(original, alias);
+    mergeWorkspaceSetupState(alias, { setupCompletedAt: "2026-07-16T02:00:00.000Z" });
+    fs.renameSync(original, moved);
+    repoint(alias, moved);
+    const facts = detectRepointedWorkspaceAlias(alias);
+    expect(facts).toBeDefined();
+    expect(await rebindRepointedWorkspaceAlias(alias, facts!)).toBe("rebound");
+    expect(readWorkspaceStateSnapshot(alias).setup.setupCompletedAt).toBe(
+      "2026-07-16T02:00:00.000Z",
+    );
+  });
+
+  it("recovers when the original configured directory becomes the moved directory's alias", async () => {
+    const original = state.workspaceDir;
+    const moved = state.path("direct-move");
+    mergeWorkspaceSetupState(original, { setupCompletedAt: "2026-07-16T02:00:00.000Z" });
+    fs.renameSync(original, moved);
+    link(moved, original);
+    expect(
+      await rebindRepointedWorkspaceAlias(original, detectRepointedWorkspaceAlias(original)!),
+    ).toBe("rebound");
+    expect(readWorkspaceStateSnapshot(original).setup.setupCompletedAt).toBe(
+      "2026-07-16T02:00:00.000Z",
+    );
+  });
+
+  it.each(["original-e\u0301", "parent-e\u0301/original-\u00e9", "parent-\u00e9/original-e\u0301"])(
+    "retains ownership when Unicode original %s still exists",
+    async (relative) => {
+      const original = state.path(relative);
+      const alias = state.path("unicode-link");
+      const moved = state.path("unicode-copy");
+      fs.mkdirSync(original, { recursive: true });
+      fs.mkdirSync(moved);
+      link(original, alias);
+      mergeWorkspaceSetupState(alias, { setupCompletedAt: "2026-07-16T02:00:00.000Z" });
+      repoint(alias, moved);
+      expect(
+        await rebindRepointedWorkspaceAlias(alias, detectRepointedWorkspaceAlias(alias)!),
+      ).toBe("original-workspace-exists");
+      expect(readWorkspaceStateSnapshot(original).setup.setupCompletedAt).toBe(
+        "2026-07-16T02:00:00.000Z",
+      );
+      expect(readWorkspaceStateSnapshot(moved).setupExists).toBe(false);
+    },
+  );
+
+  it("refuses a surviving Unicode sibling even when the normalized spelling points at the destination", async ({
+    skip,
+  }) => {
+    const original = state.path("original-e\u0301");
+    const normalized = original.normalize("NFC");
+    const alias = state.path("unicode-link");
+    const moved = state.path("unicode-copy");
+    fs.mkdirSync(original);
+    fs.mkdirSync(moved);
+    link(original, alias);
+    mergeWorkspaceSetupState(alias, { setupCompletedAt: "2026-07-16T02:00:00.000Z" });
+    if (fs.existsSync(normalized)) {
+      skip();
+    }
+    link(moved, normalized);
+    repoint(alias, moved);
+    expect(await rebindRepointedWorkspaceAlias(alias, detectRepointedWorkspaceAlias(alias)!)).toBe(
+      "original-workspace-exists",
+    );
+    expect(readWorkspaceStateSnapshot(moved).setupExists).toBe(false);
+  });
+
   it.each([false, true])(
     "preserves setup and attestation without changing files (attestation only: %s)",
     async (attestationOnly) => {

--- a/src/agents/workspace-alias-rebind.test.ts
+++ b/src/agents/workspace-alias-rebind.test.ts
@@ -1,4 +1,3 @@
-// Detection and non-destructive rebind of repointed workspace aliases.
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -14,203 +13,212 @@ import {
   detectRepointedWorkspaceAlias,
   rebindRepointedWorkspaceAlias,
 } from "./workspace-alias-rebind.js";
+import { WorkspaceAliasRepointedError } from "./workspace-state-identity.js";
 import {
-  resolveWorkspaceStateIdentity,
-  WorkspaceAliasRepointedError,
-} from "./workspace-state-identity.js";
-import {
-  mergeWorkspaceSetupState,
+  clearExpiredWorkspaceStateForVanishedWorkspace,
   deleteWorkspaceState,
+  mergeWorkspaceSetupState,
   prepareWorkspaceStateDeletion,
   readWorkspaceStateSnapshot,
   replaceWorkspaceAttestation,
-  WORKSPACE_LEGACY_STATE_MIGRATION_KIND,
+  WORKSPACE_ATTESTATION_RECENT_MS,
 } from "./workspace-state-store.js";
 
-let testState: OpenClawTestState | undefined;
-
+let state: OpenClawTestState;
 beforeEach(async () => {
-  testState = await createOpenClawTestState({
-    layout: "state-only",
-    prefix: "openclaw-workspace-alias-rebind-",
-  });
+  state = await createOpenClawTestState({ layout: "state-only", prefix: "workspace-move-" });
 });
-
 afterEach(async () => {
   closeOpenClawStateDatabaseForTest();
-  await testState?.cleanup();
-  testState = undefined;
+  await state.cleanup();
 });
 
-describe("workspace alias rebind", () => {
-  it("detects and rebinds a repointed alias without touching workspace files", () => {
-    const dir = testState!.workspaceDir;
-    const alias = testState!.path("workspace-link");
-    const replacement = testState!.path("replacement-workspace");
-    fs.mkdirSync(replacement, { recursive: true });
-    fs.writeFileSync(path.join(replacement, "kept.txt"), "moved workspace content");
-    fs.symlinkSync(dir, alias, process.platform === "win32" ? "junction" : "dir");
-    mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
-    replaceWorkspaceAttestation({
-      workspaceDir: alias,
-      attestedAtMs: 1_000,
-      generatedHashes: new Map([["BOOTSTRAP.md", "a".repeat(64)]]),
-      nowMs: 1_000,
-    });
-    fs.unlinkSync(alias);
-    fs.symlinkSync(replacement, alias, process.platform === "win32" ? "junction" : "dir");
-
-    const facts = detectRepointedWorkspaceAlias(alias);
-    expect(facts).toMatchObject({
-      storedWorkspacePath: resolveWorkspaceStateIdentity(dir).workspacePath,
-      currentWorkspacePath: resolveWorkspaceStateIdentity(replacement).workspacePath,
-      currentTargetHasOwnState: false,
-    });
-    expect(facts?.storedAttestationHashes.get("BOOTSTRAP.md")).toBe("a".repeat(64));
-
-    expect(rebindRepointedWorkspaceAlias(alias, facts!)).toBe("rebound");
-    const snapshot = readWorkspaceStateSnapshot(alias);
-    expect(snapshot.setupExists).toBe(true);
-    expect(snapshot.setup.bootstrapSeededAt).toBe("2026-07-16T01:00:00.000Z");
-    expect(snapshot.attestation?.generatedHashes.get("BOOTSTRAP.md")).toBe("a".repeat(64));
-    expect(fs.readFileSync(path.join(replacement, "kept.txt"), "utf-8")).toBe(
-      "moved workspace content",
+function link(target: string, alias: string) {
+  fs.symlinkSync(target, alias, process.platform === "win32" ? "junction" : "dir");
+}
+function repoint(alias: string, target: string) {
+  fs.unlinkSync(alias);
+  link(target, alias);
+}
+function movedWorkspace(attestationOnly = false) {
+  const original = state.workspaceDir;
+  const alias = state.path("workspace-link");
+  const moved = state.path("moved-workspace");
+  link(original, alias);
+  fs.writeFileSync(path.join(original, "project.txt"), "user content");
+  if (!attestationOnly) {
+    mergeWorkspaceSetupState(
+      alias,
+      {
+        bootstrapSeededAt: "2026-07-16T01:00:00.000Z",
+        setupCompletedAt: "2026-07-16T02:00:00.000Z",
+      },
+      1000,
     );
-
-    expect(detectRepointedWorkspaceAlias(alias)).toBeUndefined();
-    expect(rebindRepointedWorkspaceAlias(alias, facts!)).toBe("no-repoint");
+  }
+  replaceWorkspaceAttestation({
+    workspaceDir: alias,
+    attestedAtMs: 1000,
+    generatedHashes: new Map([["AGENTS.md", "a".repeat(64)]]),
+    nowMs: 1000,
   });
+  fs.renameSync(original, moved);
+  repoint(alias, moved);
+  return { original, alias, moved };
+}
 
-  it("refuses to rebind onto a target that already owns workspace state", () => {
-    const dir = testState!.workspaceDir;
-    const alias = testState!.path("workspace-link");
-    const replacement = testState!.path("replacement-workspace");
-    fs.mkdirSync(replacement, { recursive: true });
-    fs.symlinkSync(dir, alias, process.platform === "win32" ? "junction" : "dir");
-    mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
-    mergeWorkspaceSetupState(replacement, { bootstrapSeededAt: "2026-07-16T02:00:00.000Z" }, 2_000);
-    fs.unlinkSync(alias);
-    fs.symlinkSync(replacement, alias, process.platform === "win32" ? "junction" : "dir");
+describe("workspace move recovery", () => {
+  it.each([false, true])(
+    "preserves setup and attestation without changing files (attestation only: %s)",
+    async (attestationOnly) => {
+      const { alias, moved } = movedWorkspace(attestationOnly);
+      const facts = detectRepointedWorkspaceAlias(alias)!;
+      expect(await rebindRepointedWorkspaceAlias(alias, facts)).toBe("rebound");
+      const snapshot = readWorkspaceStateSnapshot(alias);
+      expect(snapshot.setupExists).toBe(!attestationOnly);
+      if (!attestationOnly) {
+        expect(snapshot.setup).toMatchObject({
+          bootstrapSeededAt: "2026-07-16T01:00:00.000Z",
+          setupCompletedAt: "2026-07-16T02:00:00.000Z",
+        });
+      }
+      expect(snapshot.attestation).toEqual({
+        attestedAtMs: 1000,
+        generatedHashes: new Map([["AGENTS.md", "a".repeat(64)]]),
+      });
+      expect(fs.readFileSync(path.join(moved, "project.txt"), "utf8")).toBe("user content");
+      expect(await rebindRepointedWorkspaceAlias(alias, facts)).toBe("no-repoint");
+      closeOpenClawStateDatabaseForTest();
+      expect(readWorkspaceStateSnapshot(alias)).toEqual(snapshot);
+    },
+  );
 
-    const facts = detectRepointedWorkspaceAlias(alias)!;
-    expect(facts.currentTargetHasOwnState).toBe(true);
-    expect(rebindRepointedWorkspaceAlias(alias, facts)).toBe("current-target-owns-state");
-    expect(readWorkspaceStateSnapshot(dir).setupExists).toBe(true);
-    expect(readWorkspaceStateSnapshot(replacement).setupExists).toBe(true);
-  });
-
-  it("rejects a target change after doctor presents the repair facts", () => {
-    const original = testState!.workspaceDir;
-    const alias = testState!.path("workspace-link");
-    const firstReplacement = testState!.path("replacement-a");
-    const secondReplacement = testState!.path("replacement-b");
-    fs.mkdirSync(firstReplacement, { recursive: true });
-    fs.mkdirSync(secondReplacement, { recursive: true });
-    fs.symlinkSync(original, alias, process.platform === "win32" ? "junction" : "dir");
-    mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
-    fs.unlinkSync(alias);
-    fs.symlinkSync(firstReplacement, alias, process.platform === "win32" ? "junction" : "dir");
-    const approvedFacts = detectRepointedWorkspaceAlias(alias)!;
-
-    fs.unlinkSync(alias);
-    fs.symlinkSync(secondReplacement, alias, process.platform === "win32" ? "junction" : "dir");
-
-    expect(rebindRepointedWorkspaceAlias(alias, approvedFacts)).toBe("repoint-changed");
+  it("refuses a copy while the original folder still exists", async () => {
+    const { original, alias, moved } = movedWorkspace();
+    fs.mkdirSync(original);
+    const before = detectRepointedWorkspaceAlias(alias)!;
+    expect(await rebindRepointedWorkspaceAlias(alias, before)).toBe("original-workspace-exists");
     expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
-    expect(readWorkspaceStateSnapshot(secondReplacement).setupExists).toBe(false);
+    expect(readWorkspaceStateSnapshot(moved).setupExists).toBe(false);
   });
 
-  it("fails closed again when the alias is repointed after a committed rebind", () => {
-    const original = testState!.workspaceDir;
-    const alias = testState!.path("workspace-link");
-    const replacement = testState!.path("replacement-workspace");
-    const lateTarget = testState!.path("late-target");
-    fs.mkdirSync(replacement, { recursive: true });
-    fs.mkdirSync(lateTarget, { recursive: true });
-    fs.symlinkSync(original, alias, process.platform === "win32" ? "junction" : "dir");
-    mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
-    fs.unlinkSync(alias);
-    fs.symlinkSync(replacement, alias, process.platform === "win32" ? "junction" : "dir");
+  it("does not merge an existing destination owner and still reports a typed repair failure", async () => {
+    const { original, alias, moved } = movedWorkspace();
+    mergeWorkspaceSetupState(moved, { bootstrapSeededAt: "2026-07-17T01:00:00.000Z" }, 2000);
     const facts = detectRepointedWorkspaceAlias(alias)!;
-    expect(rebindRepointedWorkspaceAlias(alias, facts)).toBe("rebound");
-
-    // A repoint racing the committed transfer cannot be adopted: state moved
-    // only to the operator-approved target, and the guard re-engages for the
-    // unapproved one instead of serving it.
-    fs.unlinkSync(alias);
-    fs.symlinkSync(lateTarget, alias, process.platform === "win32" ? "junction" : "dir");
-
     expect(() => readWorkspaceStateSnapshot(alias)).toThrow(WorkspaceAliasRepointedError);
-    expect(readWorkspaceStateSnapshot(replacement).setupExists).toBe(true);
-    expect(readWorkspaceStateSnapshot(lateTarget).setupExists).toBe(false);
+    expect(await rebindRepointedWorkspaceAlias(alias, facts)).toBe("current-target-owns-state");
+    expect(readWorkspaceStateSnapshot(original).setup.setupCompletedAt).toBe(
+      "2026-07-16T02:00:00.000Z",
+    );
+    expect(readWorkspaceStateSnapshot(moved).setup.bootstrapSeededAt).toBe(
+      "2026-07-17T01:00:00.000Z",
+    );
   });
 
-  it("rejects malformed persisted attestation rows during detection", () => {
-    const original = testState!.workspaceDir;
-    const alias = testState!.path("workspace-link");
-    const replacement = testState!.path("replacement-workspace");
-    fs.mkdirSync(replacement, { recursive: true });
-    fs.symlinkSync(original, alias, process.platform === "win32" ? "junction" : "dir");
-    mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
-    replaceWorkspaceAttestation({
-      workspaceDir: alias,
-      attestedAtMs: 1_000,
-      generatedHashes: new Map([["BOOTSTRAP.md", "a".repeat(64)]]),
-      nowMs: 1_000,
-    });
+  it("rejects changed setup records after confirmation facts were read", async () => {
+    const { original, alias, moved } = movedWorkspace();
+    const facts = detectRepointedWorkspaceAlias(alias)!;
+    mergeWorkspaceSetupState(original, {}, 3000);
+    expect(await rebindRepointedWorkspaceAlias(alias, facts)).toBe("repoint-changed");
+    expect(readWorkspaceStateSnapshot(moved).setupExists).toBe(false);
+  });
+
+  it("rejects a replacement directory at the same approved path", async () => {
+    const { alias, moved } = movedWorkspace();
+    const facts = detectRepointedWorkspaceAlias(alias)!;
+    fs.renameSync(moved, state.path("retained-content"));
+    fs.mkdirSync(moved);
+    expect(await rebindRepointedWorkspaceAlias(alias, facts)).toBe("repoint-changed");
+    expect(readWorkspaceStateSnapshot(moved).setupExists).toBe(false);
+  });
+
+  it("uses actual directory bytes when a moved path has decomposed Unicode", async () => {
+    const { alias, moved } = movedWorkspace();
+    const decomposed = state.path("move-e\u0301");
+    fs.renameSync(moved, decomposed);
+    repoint(alias, decomposed);
+    expect(await rebindRepointedWorkspaceAlias(alias, detectRepointedWorkspaceAlias(alias)!)).toBe(
+      "rebound",
+    );
+    expect(readWorkspaceStateSnapshot(alias).setup.setupCompletedAt).toBe(
+      "2026-07-16T02:00:00.000Z",
+    );
+    expect(fs.readFileSync(path.join(decomposed, "project.txt"), "utf8")).toBe("user content");
+  });
+
+  it("refuses a configured path that still needs the old owner", async () => {
+    const { original, alias, moved } = movedWorkspace();
+    const facts = detectRepointedWorkspaceAlias(alias)!;
+    expect(await rebindRepointedWorkspaceAlias(alias, facts, {}, [alias, original])).toBe(
+      "configured-workspace-conflict",
+    );
+    expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
+    expect(readWorkspaceStateSnapshot(moved).setupExists).toBe(false);
+  });
+
+  it("protects a configured alias before its first workspace access", async () => {
+    const { original, alias, moved } = movedWorkspace();
+    const unused = state.path("unused-link");
+    link(original, unused);
+    const facts = detectRepointedWorkspaceAlias(alias)!;
+    expect(await rebindRepointedWorkspaceAlias(alias, facts, {}, [alias, unused])).toBe(
+      "configured-workspace-conflict",
+    );
+    expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
+    expect(readWorkspaceStateSnapshot(moved).setupExists).toBe(false);
+  });
+
+  it("keeps verified sibling aliases but removes old paths from the moved owner's cleanup", async () => {
+    const original = state.workspaceDir;
+    const first = state.path("first-link");
+    const second = state.path("second-link");
+    const moved = state.path("moved");
+    link(original, first);
+    link(original, second);
+    mergeWorkspaceSetupState(first, { setupCompletedAt: "2026-07-16T02:00:00.000Z" }, 1000);
+    readWorkspaceStateSnapshot(second);
+    fs.renameSync(original, moved);
+    repoint(first, moved);
+    repoint(second, moved);
+    expect(
+      await rebindRepointedWorkspaceAlias(first, detectRepointedWorkspaceAlias(first)!, {}, [
+        first,
+        second,
+      ]),
+    ).toBe("rebound");
+    const snapshot = readWorkspaceStateSnapshot(second);
+    deleteWorkspaceState(prepareWorkspaceStateDeletion(original));
+    clearExpiredWorkspaceStateForVanishedWorkspace(
+      original,
+      WORKSPACE_ATTESTATION_RECENT_MS + 2000,
+    );
+    expect(readWorkspaceStateSnapshot(first)).toEqual(snapshot);
+    fs.mkdirSync(original);
+    mergeWorkspaceSetupState(original, { bootstrapSeededAt: "2026-07-18T01:00:00.000Z" }, 4000);
+    expect(readWorkspaceStateSnapshot(second)).toEqual(snapshot);
+  });
+
+  it("rejects malformed persisted attestation before it can be transferred", () => {
+    const { alias } = movedWorkspace();
     openOpenClawStateDatabase()
       .db.prepare("UPDATE workspace_generated_bootstrap_hashes SET filename = '../outside.md'")
       .run();
-    fs.unlinkSync(alias);
-    fs.symlinkSync(replacement, alias, process.platform === "win32" ? "junction" : "dir");
-
     expect(() => detectRepointedWorkspaceAlias(alias)).toThrow(
-      /workspace attestation hash row is invalid/u,
+      "workspace attestation hash row is invalid",
     );
   });
 
-  it("transfers migration receipt ownership so later deletion removes it", () => {
-    const original = testState!.workspaceDir;
-    const alias = testState!.path("workspace-link");
-    const replacement = testState!.path("replacement-workspace");
-    fs.mkdirSync(replacement, { recursive: true });
-    fs.symlinkSync(original, alias, process.platform === "win32" ? "junction" : "dir");
-    mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
-    const originalIdentity = resolveWorkspaceStateIdentity(original);
-    const db = openOpenClawStateDatabase().db;
-    db.prepare(
-      "INSERT INTO migration_runs (id, started_at, finished_at, status, report_json) VALUES ('workspace-run', 1, 1, 'completed', '{}')",
-    ).run();
-    db.prepare(
-      `INSERT INTO migration_sources (
-        source_key, migration_kind, source_path, target_table, last_run_id, status, imported_at,
-        report_json
-      ) VALUES ('workspace-receipt', ?, '/legacy/workspace-state.json',
-        'workspace_setup_state', 'workspace-run', 'completed', 1, ?)`,
-    ).run(
-      WORKSPACE_LEGACY_STATE_MIGRATION_KIND,
-      JSON.stringify({ workspaceKey: originalIdentity.workspaceKey }),
+  it("fails closed after a second repoint following a committed move", async () => {
+    const { alias, moved } = movedWorkspace();
+    expect(await rebindRepointedWorkspaceAlias(alias, detectRepointedWorkspaceAlias(alias)!)).toBe(
+      "rebound",
     );
-    fs.unlinkSync(alias);
-    fs.symlinkSync(replacement, alias, process.platform === "win32" ? "junction" : "dir");
-    const facts = detectRepointedWorkspaceAlias(alias)!;
-
-    expect(rebindRepointedWorkspaceAlias(alias, facts)).toBe("rebound");
-    const receipt = db
-      .prepare("SELECT report_json FROM migration_sources WHERE source_key = 'workspace-receipt'")
-      .get() as { report_json: string };
-    expect(JSON.parse(receipt.report_json)).toMatchObject({
-      workspaceKey: resolveWorkspaceStateIdentity(replacement).workspaceKey,
-    });
-
-    deleteWorkspaceState(prepareWorkspaceStateDeletion(alias));
-    expect(
-      db
-        .prepare("SELECT source_key FROM migration_sources WHERE source_key = 'workspace-receipt'")
-        .get(),
-    ).toBeUndefined();
-    expect(
-      db.prepare("SELECT id FROM migration_runs WHERE id = 'workspace-run'").get(),
-    ).toBeUndefined();
+    const other = state.path("other");
+    fs.mkdirSync(other);
+    repoint(alias, other);
+    expect(() => readWorkspaceStateSnapshot(alias)).toThrow(WorkspaceAliasRepointedError);
+    expect(readWorkspaceStateSnapshot(moved).setupExists).toBe(true);
+    expect(readWorkspaceStateSnapshot(other).setupExists).toBe(false);
   });
 });

--- a/src/agents/workspace-alias-rebind.ts
+++ b/src/agents/workspace-alias-rebind.ts
@@ -15,18 +15,31 @@ import {
 import {
   createWorkspaceStateIdentity,
   resolveWorkspaceStateAliases,
+  type WorkspaceStateIdentity,
 } from "./workspace-state-identity.js";
 import {
-  registerWorkspaceStateAliasesInTransaction,
+  isValidWorkspaceAttestationHash,
+  registerWorkspaceStateAliasIdentitiesInTransaction,
   workspacePathEntryExists,
+  WORKSPACE_LEGACY_STATE_MIGRATION_KIND,
 } from "./workspace-state-store.js";
 
 type WorkspaceAliasDatabase = Pick<
   OpenClawStateKyselyDatabase,
-  "workspace_setup_state" | "workspace_path_aliases" | "workspace_generated_bootstrap_hashes"
+  | "workspace_setup_state"
+  | "workspace_path_aliases"
+  | "workspace_generated_bootstrap_hashes"
+  | "migration_sources"
 >;
 
 type WorkspaceAliasDatabaseHandle = Pick<ReturnType<typeof openOpenClawStateDatabase>, "db">;
+
+type WorkspaceAliasFilesystemFacts = {
+  aliases: readonly WorkspaceStateIdentity[];
+  lexicalAlias: WorkspaceStateIdentity;
+  currentCanonicalIdentity: WorkspaceStateIdentity;
+  pathEntryExists: boolean;
+};
 
 export type RepointedWorkspaceAliasFacts = {
   aliasPath: string;
@@ -36,13 +49,21 @@ export type RepointedWorkspaceAliasFacts = {
   currentTargetHasOwnState: boolean;
 };
 
+function resolveWorkspaceAliasFilesystemFacts(workspaceDir: string): WorkspaceAliasFilesystemFacts {
+  const aliases = resolveWorkspaceStateAliases(workspaceDir);
+  return {
+    aliases,
+    lexicalAlias: aliases[0]!,
+    currentCanonicalIdentity: aliases.at(-1)!,
+    pathEntryExists: workspacePathEntryExists(workspaceDir),
+  };
+}
+
 function readRepointedWorkspaceAlias(params: {
-  workspaceDir: string;
+  filesystem: WorkspaceAliasFilesystemFacts;
   database: WorkspaceAliasDatabaseHandle;
 }): RepointedWorkspaceAliasFacts | undefined {
-  const aliases = resolveWorkspaceStateAliases(params.workspaceDir);
-  const lexicalAlias = aliases[0]!;
-  const currentCanonicalIdentity = aliases.at(-1)!;
+  const { lexicalAlias, currentCanonicalIdentity } = params.filesystem;
   const kysely = getNodeSqliteKysely<WorkspaceAliasDatabase>(params.database.db);
   const storedAlias = executeSqliteQueryTakeFirstSync(
     params.database.db,
@@ -59,7 +80,7 @@ function readRepointedWorkspaceAlias(params: {
     throw new Error("workspace path alias target is invalid");
   }
   if (
-    !workspacePathEntryExists(params.workspaceDir) ||
+    !params.filesystem.pathEntryExists ||
     storedIdentity.workspaceKey === currentCanonicalIdentity.workspaceKey
   ) {
     return undefined;
@@ -72,6 +93,13 @@ function readRepointedWorkspaceAlias(params: {
       .where("workspace_key", "=", storedIdentity.workspaceKey)
       .orderBy("filename", "asc"),
   ).rows;
+  const storedAttestationHashes = new Map<string, string>();
+  for (const row of hashRows) {
+    if (!isValidWorkspaceAttestationHash(row.filename, row.sha256)) {
+      throw new Error("workspace attestation hash row is invalid");
+    }
+    storedAttestationHashes.set(row.filename, row.sha256);
+  }
   const currentSetupRow = executeSqliteQueryTakeFirstSync(
     params.database.db,
     kysely
@@ -83,41 +111,117 @@ function readRepointedWorkspaceAlias(params: {
     aliasPath: lexicalAlias.workspacePath,
     storedWorkspacePath: storedIdentity.workspacePath,
     currentWorkspacePath: currentCanonicalIdentity.workspacePath,
-    storedAttestationHashes: new Map(hashRows.map((row) => [row.filename, row.sha256])),
+    storedAttestationHashes,
     currentTargetHasOwnState: currentSetupRow !== undefined,
   };
 }
 
-/** Read-only doctor probe: reports a configured alias whose stored state belongs to a different canonical target. */
+function factsMatch(
+  actual: RepointedWorkspaceAliasFacts,
+  expected: RepointedWorkspaceAliasFacts,
+): boolean {
+  if (
+    actual.aliasPath !== expected.aliasPath ||
+    actual.storedWorkspacePath !== expected.storedWorkspacePath ||
+    actual.currentWorkspacePath !== expected.currentWorkspacePath ||
+    actual.currentTargetHasOwnState !== expected.currentTargetHasOwnState ||
+    actual.storedAttestationHashes.size !== expected.storedAttestationHashes.size
+  ) {
+    return false;
+  }
+  for (const [filename, sha256] of actual.storedAttestationHashes) {
+    if (expected.storedAttestationHashes.get(filename) !== sha256) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function transferWorkspaceMigrationReceipts(params: {
+  database: WorkspaceAliasDatabaseHandle;
+  storedWorkspaceKey: string;
+  currentWorkspaceKey: string;
+}): void {
+  const kysely = getNodeSqliteKysely<WorkspaceAliasDatabase>(params.database.db);
+  const rows = executeSqliteQuerySync(
+    params.database.db,
+    kysely
+      .selectFrom("migration_sources")
+      .select(["source_key", "report_json"])
+      .where("migration_kind", "=", WORKSPACE_LEGACY_STATE_MIGRATION_KIND),
+  ).rows;
+  for (const row of rows) {
+    let report: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(row.report_json) as unknown;
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        continue;
+      }
+      report = parsed as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    if (report.workspaceKey !== params.storedWorkspaceKey) {
+      continue;
+    }
+    executeSqliteQuerySync(
+      params.database.db,
+      kysely
+        .updateTable("migration_sources")
+        .set({
+          report_json: JSON.stringify({ ...report, workspaceKey: params.currentWorkspaceKey }),
+        })
+        .where("source_key", "=", row.source_key),
+    );
+  }
+}
+
+/** Read-only doctor probe for a configured alias whose state belongs to another target. */
 export function detectRepointedWorkspaceAlias(
   workspaceDir: string,
   options: OpenClawStateDatabaseOptions = {},
 ): RepointedWorkspaceAliasFacts | undefined {
+  const filesystem = resolveWorkspaceAliasFilesystemFacts(workspaceDir);
   return withExistingOpenClawStateDatabaseReadOnly(
     (database) =>
       runSqliteDeferredTransactionSync(database.db, () =>
-        readRepointedWorkspaceAlias({ workspaceDir, database }),
+        readRepointedWorkspaceAlias({ filesystem, database }),
       ),
     options,
   );
 }
 
-export type WorkspaceAliasRebindOutcome = "rebound" | "no-repoint" | "current-target-owns-state";
+export type WorkspaceAliasRebindOutcome =
+  | "rebound"
+  | "no-repoint"
+  | "repoint-changed"
+  | "current-target-owns-state";
 
 /**
- * Non-destructive doctor repair: moves the stored setup state and attestation
- * onto the alias's current canonical target and rewrites the alias rows.
- * Workspace files are never touched; refuses when the current target already
- * owns state so a repair cannot silently merge two workspaces.
+ * Moves the stored setup state and attestation to an approved current target.
+ * The transaction revalidates the exact facts that doctor presented.
  */
 export function rebindRepointedWorkspaceAlias(
   workspaceDir: string,
+  expectedFacts: RepointedWorkspaceAliasFacts,
   options: OpenClawStateDatabaseOptions = {},
 ): WorkspaceAliasRebindOutcome {
+  const filesystem = resolveWorkspaceAliasFilesystemFacts(workspaceDir);
+  if (
+    filesystem.lexicalAlias.workspacePath !== expectedFacts.aliasPath ||
+    filesystem.currentCanonicalIdentity.workspacePath !== expectedFacts.currentWorkspacePath
+  ) {
+    return "repoint-changed";
+  }
+  // eslint-disable-next-line no-warning-comments -- Review policy requires this decision marker.
+  // TODO(review): Link the accepted material persistent-store repair design before merge.
   return runOpenClawStateWriteTransaction((database) => {
-    const facts = readRepointedWorkspaceAlias({ workspaceDir, database });
+    const facts = readRepointedWorkspaceAlias({ filesystem, database });
     if (!facts) {
       return "no-repoint";
+    }
+    if (!factsMatch(facts, expectedFacts)) {
+      return "repoint-changed";
     }
     if (facts.currentTargetHasOwnState) {
       return "current-target-owns-state";
@@ -133,9 +237,7 @@ export function rebindRepointedWorkspaceAlias(
         .where("workspace_key", "=", storedIdentity.workspaceKey),
     );
     if (storedSetupRow) {
-      // The hash table's FK references the setup row's key, so adopt by
-      // inserting the new parent first, repointing children, then deleting the
-      // old parent — an in-place key UPDATE would violate the constraint.
+      // Insert the new FK parent before repointing children and deleting the old parent.
       executeSqliteQuerySync(
         database.db,
         kysely.insertInto("workspace_setup_state").values({
@@ -158,18 +260,21 @@ export function rebindRepointedWorkspaceAlias(
           .where("workspace_key", "=", storedIdentity.workspaceKey),
       );
     }
-    // The old canonical identity no longer owns state, so drop every alias that
-    // resolved to it before re-registering the configured spelling; a stale row
-    // would otherwise collide with the fresh registration below.
+    transferWorkspaceMigrationReceipts({
+      database,
+      storedWorkspaceKey: storedIdentity.workspaceKey,
+      currentWorkspaceKey: currentIdentity.workspaceKey,
+    });
+    // Remove all stale aliases before registering the prepared current identities.
     executeSqliteQuerySync(
       database.db,
       kysely
         .deleteFrom("workspace_path_aliases")
         .where("workspace_key", "=", storedIdentity.workspaceKey),
     );
-    registerWorkspaceStateAliasesInTransaction({
+    registerWorkspaceStateAliasIdentitiesInTransaction({
       database,
-      workspaceDirs: [workspaceDir],
+      aliases: filesystem.aliases,
       identity: currentIdentity,
       updatedAtMs: Date.now(),
     });

--- a/src/agents/workspace-alias-rebind.ts
+++ b/src/agents/workspace-alias-rebind.ts
@@ -214,8 +214,8 @@ export function rebindRepointedWorkspaceAlias(
   ) {
     return "repoint-changed";
   }
-  // eslint-disable-next-line no-warning-comments -- Review policy requires this decision marker.
-  // TODO(review): Link the accepted material persistent-store repair design before merge.
+  // Maintainer decision pending: the accepted material persistent-store repair
+  // design must be linked before merge (tracked in the PR body).
   return runOpenClawStateWriteTransaction((database) => {
     const facts = readRepointedWorkspaceAlias({ filesystem, database });
     if (!facts) {

--- a/src/agents/workspace-alias-rebind.ts
+++ b/src/agents/workspace-alias-rebind.ts
@@ -1,0 +1,178 @@
+/** Doctor-owned detection and non-destructive rebind for repointed workspace aliases. */
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
+import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db.js";
+import {
+  createWorkspaceStateIdentity,
+  resolveWorkspaceStateAliases,
+} from "./workspace-state-identity.js";
+import {
+  registerWorkspaceStateAliasesInTransaction,
+  workspacePathEntryExists,
+} from "./workspace-state-store.js";
+
+type WorkspaceAliasDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  "workspace_setup_state" | "workspace_path_aliases" | "workspace_generated_bootstrap_hashes"
+>;
+
+type WorkspaceAliasDatabaseHandle = Pick<ReturnType<typeof openOpenClawStateDatabase>, "db">;
+
+export type RepointedWorkspaceAliasFacts = {
+  aliasPath: string;
+  storedWorkspacePath: string;
+  currentWorkspacePath: string;
+  storedAttestationHashes: ReadonlyMap<string, string>;
+  currentTargetHasOwnState: boolean;
+};
+
+function readRepointedWorkspaceAlias(params: {
+  workspaceDir: string;
+  database: WorkspaceAliasDatabaseHandle;
+}): RepointedWorkspaceAliasFacts | undefined {
+  const aliases = resolveWorkspaceStateAliases(params.workspaceDir);
+  const lexicalAlias = aliases[0]!;
+  const currentCanonicalIdentity = aliases.at(-1)!;
+  const kysely = getNodeSqliteKysely<WorkspaceAliasDatabase>(params.database.db);
+  const storedAlias = executeSqliteQueryTakeFirstSync(
+    params.database.db,
+    kysely
+      .selectFrom("workspace_path_aliases")
+      .selectAll()
+      .where("alias_key", "=", lexicalAlias.workspaceKey),
+  );
+  if (!storedAlias || storedAlias.alias_path !== lexicalAlias.workspacePath) {
+    return undefined;
+  }
+  const storedIdentity = createWorkspaceStateIdentity(storedAlias.workspace_path);
+  if (storedIdentity.workspaceKey !== storedAlias.workspace_key) {
+    throw new Error("workspace path alias target is invalid");
+  }
+  if (
+    !workspacePathEntryExists(params.workspaceDir) ||
+    storedIdentity.workspaceKey === currentCanonicalIdentity.workspaceKey
+  ) {
+    return undefined;
+  }
+  const hashRows = executeSqliteQuerySync(
+    params.database.db,
+    kysely
+      .selectFrom("workspace_generated_bootstrap_hashes")
+      .select(["filename", "sha256"])
+      .where("workspace_key", "=", storedIdentity.workspaceKey)
+      .orderBy("filename", "asc"),
+  ).rows;
+  const currentSetupRow = executeSqliteQueryTakeFirstSync(
+    params.database.db,
+    kysely
+      .selectFrom("workspace_setup_state")
+      .select("workspace_key")
+      .where("workspace_key", "=", currentCanonicalIdentity.workspaceKey),
+  );
+  return {
+    aliasPath: lexicalAlias.workspacePath,
+    storedWorkspacePath: storedIdentity.workspacePath,
+    currentWorkspacePath: currentCanonicalIdentity.workspacePath,
+    storedAttestationHashes: new Map(hashRows.map((row) => [row.filename, row.sha256])),
+    currentTargetHasOwnState: currentSetupRow !== undefined,
+  };
+}
+
+/** Read-only doctor probe: reports a configured alias whose stored state belongs to a different canonical target. */
+export function detectRepointedWorkspaceAlias(
+  workspaceDir: string,
+  options: OpenClawStateDatabaseOptions = {},
+): RepointedWorkspaceAliasFacts | undefined {
+  return withExistingOpenClawStateDatabaseReadOnly(
+    (database) =>
+      runSqliteDeferredTransactionSync(database.db, () =>
+        readRepointedWorkspaceAlias({ workspaceDir, database }),
+      ),
+    options,
+  );
+}
+
+export type WorkspaceAliasRebindOutcome = "rebound" | "no-repoint" | "current-target-owns-state";
+
+/**
+ * Non-destructive doctor repair: moves the stored setup state and attestation
+ * onto the alias's current canonical target and rewrites the alias rows.
+ * Workspace files are never touched; refuses when the current target already
+ * owns state so a repair cannot silently merge two workspaces.
+ */
+export function rebindRepointedWorkspaceAlias(
+  workspaceDir: string,
+  options: OpenClawStateDatabaseOptions = {},
+): WorkspaceAliasRebindOutcome {
+  return runOpenClawStateWriteTransaction((database) => {
+    const facts = readRepointedWorkspaceAlias({ workspaceDir, database });
+    if (!facts) {
+      return "no-repoint";
+    }
+    if (facts.currentTargetHasOwnState) {
+      return "current-target-owns-state";
+    }
+    const storedIdentity = createWorkspaceStateIdentity(facts.storedWorkspacePath);
+    const currentIdentity = createWorkspaceStateIdentity(facts.currentWorkspacePath);
+    const kysely = getNodeSqliteKysely<WorkspaceAliasDatabase>(database.db);
+    const storedSetupRow = executeSqliteQueryTakeFirstSync(
+      database.db,
+      kysely
+        .selectFrom("workspace_setup_state")
+        .selectAll()
+        .where("workspace_key", "=", storedIdentity.workspaceKey),
+    );
+    if (storedSetupRow) {
+      // The hash table's FK references the setup row's key, so adopt by
+      // inserting the new parent first, repointing children, then deleting the
+      // old parent — an in-place key UPDATE would violate the constraint.
+      executeSqliteQuerySync(
+        database.db,
+        kysely.insertInto("workspace_setup_state").values({
+          ...storedSetupRow,
+          workspace_key: currentIdentity.workspaceKey,
+          workspace_path: currentIdentity.workspacePath,
+        }),
+      );
+      executeSqliteQuerySync(
+        database.db,
+        kysely
+          .updateTable("workspace_generated_bootstrap_hashes")
+          .set({ workspace_key: currentIdentity.workspaceKey })
+          .where("workspace_key", "=", storedIdentity.workspaceKey),
+      );
+      executeSqliteQuerySync(
+        database.db,
+        kysely
+          .deleteFrom("workspace_setup_state")
+          .where("workspace_key", "=", storedIdentity.workspaceKey),
+      );
+    }
+    // The old canonical identity no longer owns state, so drop every alias that
+    // resolved to it before re-registering the configured spelling; a stale row
+    // would otherwise collide with the fresh registration below.
+    executeSqliteQuerySync(
+      database.db,
+      kysely
+        .deleteFrom("workspace_path_aliases")
+        .where("workspace_key", "=", storedIdentity.workspaceKey),
+    );
+    registerWorkspaceStateAliasesInTransaction({
+      database,
+      workspaceDirs: [workspaceDir],
+      identity: currentIdentity,
+      updatedAtMs: Date.now(),
+    });
+    return "rebound";
+  }, options);
+}

--- a/src/agents/workspace-alias-rebind.ts
+++ b/src/agents/workspace-alias-rebind.ts
@@ -157,6 +157,7 @@ function transferWorkspaceMigrationReceipts(params: {
       if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
         continue;
       }
+      // SAFETY: the guard above proves parsed is a non-null, non-array object.
       report = parsed as Record<string, unknown>;
     } catch {
       continue;

--- a/src/agents/workspace-alias-rebind.ts
+++ b/src/agents/workspace-alias-rebind.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import { hasErrnoCode } from "../infra/errors.js";
 import {
   executeSqliteQuerySync,
@@ -23,6 +24,7 @@ import { resolveUserPath } from "../utils.js";
 import { retireWorkspaceFileCache } from "./workspace-file-cache.js";
 import {
   createWorkspaceStateIdentity,
+  normalizeWorkspaceIdentityPath,
   resolveCanonicalWorkspacePath,
   resolveWorkspaceStateAliases,
   type WorkspaceStateIdentity,
@@ -48,6 +50,30 @@ function directoryIdentity(workspacePath: string): string | undefined {
     }
     return undefined;
   }
+}
+
+// Stored identities discard Unicode spelling. Inspect every matching filesystem
+// spelling, including ancestors, so a surviving original cannot lose its history.
+function existingWorkspacePathSpellings(storedPath: string): string[] {
+  const root = path.parse(storedPath).root;
+  let parents = [root];
+  for (const segment of storedPath.slice(root.length).split(path.sep)) {
+    parents = parents.flatMap((parent) => {
+      try {
+        return fs
+          .readdirSync(parent)
+          .filter((entry) => normalizeWorkspaceIdentityPath(entry) === segment)
+          .toSorted()
+          .map((entry) => path.join(parent, entry));
+      } catch (error) {
+        if (hasErrnoCode(error, "ENOENT")) {
+          return [];
+        }
+        throw error;
+      }
+    });
+  }
+  return parents;
 }
 
 function readWorkspaceMoveState(
@@ -165,20 +191,31 @@ export function inspectWorkspaceAliasMove(
   }
   const stored = createWorkspaceStateIdentity(expected.storedWorkspacePath);
   const current = createWorkspaceStateIdentity(expected.currentWorkspacePath);
-  if (pathMayExistSync(stored.workspacePath)) {
-    return { kind: "blocked", outcome: "original-workspace-exists" };
-  }
   if (!expected.targetDirectoryIdentity) {
     return { kind: "blocked", outcome: "target-directory-missing" };
   }
   if (directoryIdentity(expected.currentDirectoryPath) !== expected.targetDirectoryIdentity) {
     return { kind: "blocked", outcome: "repoint-changed" };
   }
+  const matchesDestination = (candidate: string) =>
+    resolveWorkspaceStateAliases(candidate).at(-1)!.workspaceKey === current.workspaceKey &&
+    directoryIdentity(resolveCanonicalWorkspacePath(candidate)) ===
+      expected.targetDirectoryIdentity;
+  if (
+    existingWorkspacePathSpellings(stored.workspacePath).some(
+      (candidate) => !matchesDestination(candidate),
+    )
+  ) {
+    return { kind: "blocked", outcome: "original-workspace-exists" };
+  }
   const aliases = new Map<string, WorkspaceStateIdentity>();
   const oldAliasKeys = new Set(expected.state.aliases.map((alias) => alias.alias_key));
   const configuredPaths = new Set(configuredWorkspaceDirs);
   for (const candidate of [
-    ...expected.state.aliases.map((alias) => alias.alias_path),
+    ...expected.state.aliases.flatMap((alias) => [
+      alias.alias_path,
+      ...existingWorkspacePathSpellings(alias.alias_path),
+    ]),
     ...configuredPaths,
     workspaceDir,
   ]) {
@@ -188,11 +225,7 @@ export function inspectWorkspaceAliasMove(
     if (configuredPaths.has(candidate) && target.workspaceKey === stored.workspaceKey) {
       return { kind: "blocked", outcome: "configured-workspace-conflict" };
     }
-    if (
-      target.workspaceKey === current.workspaceKey &&
-      directoryIdentity(resolveCanonicalWorkspacePath(candidate)) ===
-        expected.targetDirectoryIdentity
-    ) {
+    if (matchesDestination(candidate)) {
       for (const alias of resolved) {
         aliases.set(alias.workspaceKey, alias);
       }

--- a/src/agents/workspace-alias-rebind.ts
+++ b/src/agents/workspace-alias-rebind.ts
@@ -235,6 +235,7 @@ export async function rebindRepointedWorkspaceAlias(
     database: database.db,
     storedIdentity: stored,
     currentIdentity: current,
+    currentDirectoryPath: expected.currentDirectoryPath,
     storedSetup: expected.state.setup,
   });
   await verifyConfiguration?.();

--- a/src/agents/workspace-alias-rebind.ts
+++ b/src/agents/workspace-alias-rebind.ts
@@ -1,193 +1,145 @@
-/** Doctor-owned detection and non-destructive rebind for repointed workspace aliases. */
+import fs from "node:fs";
+import { hasErrnoCode } from "../infra/errors.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
+import { pathMayExistSync } from "../infra/path-existence.js";
+import { deferSqlitePostCommitPublication } from "../infra/sqlite-post-commit.js";
 import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
+import {
+  applyWorkspaceMigrationReceiptMove,
+  prepareWorkspaceMigrationReceiptMove,
+} from "../infra/state-migrations.workspace-setup-receipts.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
-import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import type { DB } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
+import { resolveUserPath } from "../utils.js";
+import { retireWorkspaceFileCache } from "./workspace-file-cache.js";
 import {
   createWorkspaceStateIdentity,
+  resolveCanonicalWorkspacePath,
   resolveWorkspaceStateAliases,
   type WorkspaceStateIdentity,
 } from "./workspace-state-identity.js";
 import {
-  isValidWorkspaceAttestationHash,
+  readWorkspaceStateSnapshotFromDatabase,
   registerWorkspaceStateAliasIdentitiesInTransaction,
-  workspacePathEntryExists,
-  WORKSPACE_LEGACY_STATE_MIGRATION_KIND,
 } from "./workspace-state-store.js";
 
-type WorkspaceAliasDatabase = Pick<
-  OpenClawStateKyselyDatabase,
-  | "workspace_setup_state"
-  | "workspace_path_aliases"
-  | "workspace_generated_bootstrap_hashes"
-  | "migration_sources"
+type WorkspaceDatabase = Pick<
+  DB,
+  "workspace_setup_state" | "workspace_path_aliases" | "workspace_generated_bootstrap_hashes"
 >;
+type WorkspaceDatabaseHandle = Pick<ReturnType<typeof openOpenClawStateDatabase>, "db" | "path">;
 
-type WorkspaceAliasDatabaseHandle = Pick<ReturnType<typeof openOpenClawStateDatabase>, "db">;
+function directoryIdentity(workspacePath: string): string | undefined {
+  try {
+    const stat = fs.statSync(workspacePath, { bigint: true });
+    return stat.isDirectory() ? `${stat.dev}:${stat.ino}:${stat.birthtimeNs}` : undefined;
+  } catch (error) {
+    if (!hasErrnoCode(error, "ENOENT")) {
+      throw error;
+    }
+    return undefined;
+  }
+}
 
-type WorkspaceAliasFilesystemFacts = {
-  aliases: readonly WorkspaceStateIdentity[];
-  lexicalAlias: WorkspaceStateIdentity;
-  currentCanonicalIdentity: WorkspaceStateIdentity;
-  pathEntryExists: boolean;
-};
+function readWorkspaceMoveState(
+  database: WorkspaceDatabaseHandle,
+  identity: WorkspaceStateIdentity,
+) {
+  const snapshot = readWorkspaceStateSnapshotFromDatabase({ database, identity });
+  const kysely = getNodeSqliteKysely<WorkspaceDatabase>(database.db);
+  return {
+    setup: executeSqliteQueryTakeFirstSync(
+      database.db,
+      kysely
+        .selectFrom("workspace_setup_state")
+        .selectAll()
+        .where("workspace_key", "=", identity.workspaceKey),
+    ),
+    hashes: [...(snapshot.attestation?.generatedHashes ?? [])],
+    aliases: executeSqliteQuerySync(
+      database.db,
+      kysely
+        .selectFrom("workspace_path_aliases")
+        .selectAll()
+        .where("workspace_key", "=", identity.workspaceKey)
+        .orderBy("alias_key", "asc"),
+    ).rows,
+  };
+}
 
 export type RepointedWorkspaceAliasFacts = {
   aliasPath: string;
   storedWorkspacePath: string;
   currentWorkspacePath: string;
-  storedAttestationHashes: ReadonlyMap<string, string>;
+  currentDirectoryPath: string;
   currentTargetHasOwnState: boolean;
+  targetDirectoryIdentity: string | undefined;
+  state: ReturnType<typeof readWorkspaceMoveState>;
 };
 
-function resolveWorkspaceAliasFilesystemFacts(workspaceDir: string): WorkspaceAliasFilesystemFacts {
-  const aliases = resolveWorkspaceStateAliases(workspaceDir);
-  return {
-    aliases,
-    lexicalAlias: aliases[0]!,
-    currentCanonicalIdentity: aliases.at(-1)!,
-    pathEntryExists: workspacePathEntryExists(workspaceDir),
-  };
-}
-
-function readRepointedWorkspaceAlias(params: {
-  filesystem: WorkspaceAliasFilesystemFacts;
-  database: WorkspaceAliasDatabaseHandle;
-}): RepointedWorkspaceAliasFacts | undefined {
-  const { lexicalAlias, currentCanonicalIdentity } = params.filesystem;
-  const kysely = getNodeSqliteKysely<WorkspaceAliasDatabase>(params.database.db);
-  const storedAlias = executeSqliteQueryTakeFirstSync(
-    params.database.db,
-    kysely
-      .selectFrom("workspace_path_aliases")
-      .selectAll()
-      .where("alias_key", "=", lexicalAlias.workspaceKey),
-  );
-  if (!storedAlias || storedAlias.alias_path !== lexicalAlias.workspacePath) {
-    return undefined;
-  }
-  const storedIdentity = createWorkspaceStateIdentity(storedAlias.workspace_path);
-  if (storedIdentity.workspaceKey !== storedAlias.workspace_key) {
-    throw new Error("workspace path alias target is invalid");
-  }
-  if (
-    !params.filesystem.pathEntryExists ||
-    storedIdentity.workspaceKey === currentCanonicalIdentity.workspaceKey
-  ) {
-    return undefined;
-  }
-  const hashRows = executeSqliteQuerySync(
-    params.database.db,
-    kysely
-      .selectFrom("workspace_generated_bootstrap_hashes")
-      .select(["filename", "sha256"])
-      .where("workspace_key", "=", storedIdentity.workspaceKey)
-      .orderBy("filename", "asc"),
-  ).rows;
-  const storedAttestationHashes = new Map<string, string>();
-  for (const row of hashRows) {
-    if (!isValidWorkspaceAttestationHash(row.filename, row.sha256)) {
-      throw new Error("workspace attestation hash row is invalid");
-    }
-    storedAttestationHashes.set(row.filename, row.sha256);
-  }
-  const currentSetupRow = executeSqliteQueryTakeFirstSync(
-    params.database.db,
-    kysely
-      .selectFrom("workspace_setup_state")
-      .select("workspace_key")
-      .where("workspace_key", "=", currentCanonicalIdentity.workspaceKey),
-  );
-  return {
-    aliasPath: lexicalAlias.workspacePath,
-    storedWorkspacePath: storedIdentity.workspacePath,
-    currentWorkspacePath: currentCanonicalIdentity.workspacePath,
-    storedAttestationHashes,
-    currentTargetHasOwnState: currentSetupRow !== undefined,
-  };
-}
-
-function factsMatch(
-  actual: RepointedWorkspaceAliasFacts,
-  expected: RepointedWorkspaceAliasFacts,
-): boolean {
-  if (
-    actual.aliasPath !== expected.aliasPath ||
-    actual.storedWorkspacePath !== expected.storedWorkspacePath ||
-    actual.currentWorkspacePath !== expected.currentWorkspacePath ||
-    actual.currentTargetHasOwnState !== expected.currentTargetHasOwnState ||
-    actual.storedAttestationHashes.size !== expected.storedAttestationHashes.size
-  ) {
-    return false;
-  }
-  for (const [filename, sha256] of actual.storedAttestationHashes) {
-    if (expected.storedAttestationHashes.get(filename) !== sha256) {
-      return false;
-    }
-  }
-  return true;
-}
-
-function transferWorkspaceMigrationReceipts(params: {
-  database: WorkspaceAliasDatabaseHandle;
-  storedWorkspaceKey: string;
-  currentWorkspaceKey: string;
-}): void {
-  const kysely = getNodeSqliteKysely<WorkspaceAliasDatabase>(params.database.db);
-  const rows = executeSqliteQuerySync(
-    params.database.db,
-    kysely
-      .selectFrom("migration_sources")
-      .select(["source_key", "report_json"])
-      .where("migration_kind", "=", WORKSPACE_LEGACY_STATE_MIGRATION_KIND),
-  ).rows;
-  for (const row of rows) {
-    let report: Record<string, unknown>;
-    try {
-      const parsed = JSON.parse(row.report_json) as unknown;
-      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-        continue;
-      }
-      // SAFETY: the guard above proves parsed is a non-null, non-array object.
-      report = parsed as Record<string, unknown>;
-    } catch {
-      continue;
-    }
-    if (report.workspaceKey !== params.storedWorkspaceKey) {
-      continue;
-    }
-    executeSqliteQuerySync(
-      params.database.db,
-      kysely
-        .updateTable("migration_sources")
-        .set({
-          report_json: JSON.stringify({ ...report, workspaceKey: params.currentWorkspaceKey }),
-        })
-        .where("source_key", "=", row.source_key),
-    );
-  }
-}
-
-/** Read-only doctor probe for a configured alias whose state belongs to another target. */
+/** Read the old owner without adopting the alias's new target. */
 export function detectRepointedWorkspaceAlias(
   workspaceDir: string,
   options: OpenClawStateDatabaseOptions = {},
 ): RepointedWorkspaceAliasFacts | undefined {
-  const filesystem = resolveWorkspaceAliasFilesystemFacts(workspaceDir);
+  const aliases = resolveWorkspaceStateAliases(workspaceDir);
+  const lexical = aliases[0]!;
+  const current = aliases.at(-1)!;
+  const currentDirectoryPath = resolveCanonicalWorkspacePath(workspaceDir);
+  const targetDirectoryIdentity = directoryIdentity(currentDirectoryPath);
+  if (!pathMayExistSync(resolveUserPath(workspaceDir))) {
+    return undefined;
+  }
   return withExistingOpenClawStateDatabaseReadOnly(
     (database) =>
-      runSqliteDeferredTransactionSync(database.db, () =>
-        readRepointedWorkspaceAlias({ filesystem, database }),
-      ),
+      runSqliteDeferredTransactionSync(database.db, () => {
+        const kysely = getNodeSqliteKysely<WorkspaceDatabase>(database.db);
+        const alias = executeSqliteQueryTakeFirstSync(
+          database.db,
+          kysely
+            .selectFrom("workspace_path_aliases")
+            .selectAll()
+            .where("alias_key", "=", lexical.workspaceKey),
+        );
+        if (!alias) {
+          return undefined;
+        }
+        const stored = createWorkspaceStateIdentity(alias.workspace_path);
+        if (
+          alias.alias_path !== lexical.workspacePath ||
+          alias.workspace_key !== stored.workspaceKey
+        ) {
+          throw new Error("workspace path alias identity is invalid");
+        }
+        if (stored.workspaceKey === current.workspaceKey) {
+          return undefined;
+        }
+        return {
+          aliasPath: lexical.workspacePath,
+          storedWorkspacePath: stored.workspacePath,
+          currentWorkspacePath: current.workspacePath,
+          currentDirectoryPath,
+          currentTargetHasOwnState:
+            executeSqliteQueryTakeFirstSync(
+              database.db,
+              kysely
+                .selectFrom("workspace_setup_state")
+                .select("workspace_key")
+                .where("workspace_key", "=", current.workspaceKey),
+            ) !== undefined,
+          targetDirectoryIdentity,
+          state: readWorkspaceMoveState(database, stored),
+        };
+      }),
     options,
   );
 }
@@ -196,88 +148,154 @@ export type WorkspaceAliasRebindOutcome =
   | "rebound"
   | "no-repoint"
   | "repoint-changed"
-  | "current-target-owns-state";
+  | "current-target-owns-state"
+  | "original-workspace-exists"
+  | "target-directory-missing"
+  | "configured-workspace-conflict";
 
-/**
- * Moves the stored setup state and attestation to an approved current target.
- * The transaction revalidates the exact facts that doctor presented.
- */
-export function rebindRepointedWorkspaceAlias(
+export function inspectWorkspaceAliasMove(
   workspaceDir: string,
-  expectedFacts: RepointedWorkspaceAliasFacts,
+  expected: RepointedWorkspaceAliasFacts,
+  configuredWorkspaceDirs: readonly string[] = [workspaceDir],
+):
+  | { kind: "ready"; aliases: WorkspaceStateIdentity[] }
+  | { kind: "blocked"; outcome: Exclude<WorkspaceAliasRebindOutcome, "rebound"> } {
+  if (expected.currentTargetHasOwnState) {
+    return { kind: "blocked", outcome: "current-target-owns-state" };
+  }
+  const stored = createWorkspaceStateIdentity(expected.storedWorkspacePath);
+  const current = createWorkspaceStateIdentity(expected.currentWorkspacePath);
+  if (pathMayExistSync(stored.workspacePath)) {
+    return { kind: "blocked", outcome: "original-workspace-exists" };
+  }
+  if (!expected.targetDirectoryIdentity) {
+    return { kind: "blocked", outcome: "target-directory-missing" };
+  }
+  if (directoryIdentity(expected.currentDirectoryPath) !== expected.targetDirectoryIdentity) {
+    return { kind: "blocked", outcome: "repoint-changed" };
+  }
+  const aliases = new Map<string, WorkspaceStateIdentity>();
+  const oldAliasKeys = new Set(expected.state.aliases.map((alias) => alias.alias_key));
+  const configuredPaths = new Set(configuredWorkspaceDirs);
+  for (const candidate of [
+    ...expected.state.aliases.map((alias) => alias.alias_path),
+    ...configuredPaths,
+    workspaceDir,
+  ]) {
+    const resolved = resolveWorkspaceStateAliases(candidate);
+    const lexical = resolved[0]!;
+    const target = resolved.at(-1)!;
+    if (configuredPaths.has(candidate) && target.workspaceKey === stored.workspaceKey) {
+      return { kind: "blocked", outcome: "configured-workspace-conflict" };
+    }
+    if (
+      target.workspaceKey === current.workspaceKey &&
+      directoryIdentity(resolveCanonicalWorkspacePath(candidate)) ===
+        expected.targetDirectoryIdentity
+    ) {
+      for (const alias of resolved) {
+        aliases.set(alias.workspaceKey, alias);
+      }
+    } else if (
+      oldAliasKeys.has(lexical.workspaceKey) &&
+      (pathMayExistSync(resolveUserPath(candidate)) || configuredPaths.has(candidate))
+    ) {
+      return { kind: "blocked", outcome: "configured-workspace-conflict" };
+    }
+  }
+  if (resolveWorkspaceStateAliases(workspaceDir).at(-1)!.workspaceKey !== current.workspaceKey) {
+    return { kind: "blocked", outcome: "repoint-changed" };
+  }
+  return { kind: "ready", aliases: [...aliases.values()] };
+}
+
+/** Transfer only a confirmed move; source history is never rebuilt from templates. */
+export async function rebindRepointedWorkspaceAlias(
+  workspaceDir: string,
+  expected: RepointedWorkspaceAliasFacts,
   options: OpenClawStateDatabaseOptions = {},
-): WorkspaceAliasRebindOutcome {
-  const filesystem = resolveWorkspaceAliasFilesystemFacts(workspaceDir);
-  if (
-    filesystem.lexicalAlias.workspacePath !== expectedFacts.aliasPath ||
-    filesystem.currentCanonicalIdentity.workspacePath !== expectedFacts.currentWorkspacePath
-  ) {
+  configuredWorkspaceDirs: readonly string[] = [workspaceDir],
+  verifyConfiguration?: () => Promise<void>,
+): Promise<WorkspaceAliasRebindOutcome> {
+  const observed = detectRepointedWorkspaceAlias(workspaceDir, options);
+  if (!observed) {
+    return "no-repoint";
+  }
+  if (JSON.stringify(observed) !== JSON.stringify(expected)) {
     return "repoint-changed";
   }
-  // Maintainer decision pending: the accepted material persistent-store repair
-  // design must be linked before merge (tracked in the PR body).
-  return runOpenClawStateWriteTransaction((database) => {
-    const facts = readRepointedWorkspaceAlias({ filesystem, database });
-    if (!facts) {
-      return "no-repoint";
-    }
-    if (!factsMatch(facts, expectedFacts)) {
+  const initial = inspectWorkspaceAliasMove(workspaceDir, expected, configuredWorkspaceDirs);
+  if (initial.kind === "blocked") {
+    return initial.outcome;
+  }
+  const stored = createWorkspaceStateIdentity(expected.storedWorkspacePath);
+  const current = createWorkspaceStateIdentity(expected.currentWorkspacePath);
+  const database = openOpenClawStateDatabase(options);
+  const receipts = await prepareWorkspaceMigrationReceiptMove({
+    database: database.db,
+    storedIdentity: stored,
+    currentIdentity: current,
+    storedSetup: expected.state.setup,
+  });
+  await verifyConfiguration?.();
+  // Resolve filesystem facts after asynchronous planning, before BEGIN.
+  // Missing historical aliases must not let later cleanup delete the moved owner.
+  const filesystem = inspectWorkspaceAliasMove(workspaceDir, expected, configuredWorkspaceDirs);
+  if (filesystem.kind === "blocked") {
+    return filesystem.outcome;
+  }
+  return runOpenClawStateWriteTransaction((writeDatabase) => {
+    const state = readWorkspaceMoveState(writeDatabase, stored);
+    if (JSON.stringify(state) !== JSON.stringify(expected.state)) {
       return "repoint-changed";
     }
-    if (facts.currentTargetHasOwnState) {
+    const kysely = getNodeSqliteKysely<WorkspaceDatabase>(writeDatabase.db);
+    if (
+      executeSqliteQueryTakeFirstSync(
+        writeDatabase.db,
+        kysely
+          .selectFrom("workspace_setup_state")
+          .select("workspace_key")
+          .where("workspace_key", "=", current.workspaceKey),
+      )
+    ) {
       return "current-target-owns-state";
     }
-    const storedIdentity = createWorkspaceStateIdentity(facts.storedWorkspacePath);
-    const currentIdentity = createWorkspaceStateIdentity(facts.currentWorkspacePath);
-    const kysely = getNodeSqliteKysely<WorkspaceAliasDatabase>(database.db);
-    const storedSetupRow = executeSqliteQueryTakeFirstSync(
-      database.db,
-      kysely
-        .selectFrom("workspace_setup_state")
-        .selectAll()
-        .where("workspace_key", "=", storedIdentity.workspaceKey),
-    );
-    if (storedSetupRow) {
-      // Insert the new FK parent before repointing children and deleting the old parent.
+    applyWorkspaceMigrationReceiptMove(writeDatabase.db, receipts);
+    if (state.setup) {
       executeSqliteQuerySync(
-        database.db,
+        writeDatabase.db,
         kysely.insertInto("workspace_setup_state").values({
-          ...storedSetupRow,
-          workspace_key: currentIdentity.workspaceKey,
-          workspace_path: currentIdentity.workspacePath,
+          ...state.setup,
+          workspace_key: current.workspaceKey,
+          workspace_path: current.workspacePath,
         }),
       );
       executeSqliteQuerySync(
-        database.db,
+        writeDatabase.db,
         kysely
           .updateTable("workspace_generated_bootstrap_hashes")
-          .set({ workspace_key: currentIdentity.workspaceKey })
-          .where("workspace_key", "=", storedIdentity.workspaceKey),
+          .set({ workspace_key: current.workspaceKey })
+          .where("workspace_key", "=", stored.workspaceKey),
       );
       executeSqliteQuerySync(
-        database.db,
-        kysely
-          .deleteFrom("workspace_setup_state")
-          .where("workspace_key", "=", storedIdentity.workspaceKey),
+        writeDatabase.db,
+        kysely.deleteFrom("workspace_setup_state").where("workspace_key", "=", stored.workspaceKey),
       );
     }
-    transferWorkspaceMigrationReceipts({
-      database,
-      storedWorkspaceKey: storedIdentity.workspaceKey,
-      currentWorkspaceKey: currentIdentity.workspaceKey,
-    });
-    // Remove all stale aliases before registering the prepared current identities.
     executeSqliteQuerySync(
-      database.db,
-      kysely
-        .deleteFrom("workspace_path_aliases")
-        .where("workspace_key", "=", storedIdentity.workspaceKey),
+      writeDatabase.db,
+      kysely.deleteFrom("workspace_path_aliases").where("workspace_key", "=", stored.workspaceKey),
     );
     registerWorkspaceStateAliasIdentitiesInTransaction({
-      database,
+      database: writeDatabase,
       aliases: filesystem.aliases,
-      identity: currentIdentity,
+      identity: current,
       updatedAtMs: Date.now(),
+    });
+    deferSqlitePostCommitPublication(writeDatabase.db, () => {
+      retireWorkspaceFileCache(stored.workspacePath);
+      retireWorkspaceFileCache(current.workspacePath);
     });
     return "rebound";
   }, options);

--- a/src/agents/workspace-legacy-state.ts
+++ b/src/agents/workspace-legacy-state.ts
@@ -10,7 +10,10 @@ import { pathMayExistSync } from "../infra/path-existence.js";
 import { StartupMaintenanceRequiredError } from "../infra/startup-maintenance-required.js";
 import { formatDoctorStateRepairFailure } from "../infra/state-repair-message.js";
 import { resolveUserPath } from "../utils.js";
-import { resolveWorkspaceStateIdentity } from "./workspace-state-identity.js";
+import {
+  resolveCanonicalWorkspacePath,
+  resolveWorkspaceStateIdentity,
+} from "./workspace-state-identity.js";
 
 export const LEGACY_WORKSPACE_STATE_DIRNAME = ".openclaw";
 const LEGACY_WORKSPACE_STATE_FILENAME = "workspace-state.json";
@@ -73,11 +76,12 @@ export function resolveLegacyWorkspaceSourcePaths(
   // while it still exists; destructive cleanup may remove the alias first.
   const workspacePath = path.resolve(resolveUserPath(workspaceDir));
   const canonicalIdentity = resolveWorkspaceStateIdentity(workspaceDir);
+  const canonicalDirectoryPath = resolveCanonicalWorkspacePath(workspaceDir);
   const workspaceKeys = [
     createHash("sha256").update(workspacePath).digest("hex"),
     canonicalIdentity.workspaceKey,
   ];
-  const workspacePaths = [workspacePath, canonicalIdentity.workspacePath];
+  const workspacePaths = [workspacePath, canonicalDirectoryPath];
   const env = options?.env ?? process.env;
   const stateDirs = [
     resolveStateDir(env, options?.homedir),
@@ -86,9 +90,9 @@ export function resolveLegacyWorkspaceSourcePaths(
   return {
     workspacePath,
     setupStatePaths: [
-      path.join(canonicalIdentity.workspacePath, LEGACY_WORKSPACE_STATE_CURRENT_FILENAME),
+      path.join(canonicalDirectoryPath, LEGACY_WORKSPACE_STATE_CURRENT_FILENAME),
       path.join(
-        canonicalIdentity.workspacePath,
+        canonicalDirectoryPath,
         LEGACY_WORKSPACE_STATE_DIRNAME,
         LEGACY_WORKSPACE_STATE_FILENAME,
       ),

--- a/src/agents/workspace-state-identity.ts
+++ b/src/agents/workspace-state-identity.ts
@@ -106,11 +106,28 @@ export class WorkspaceAliasRepointedError extends Error {
   }) {
     super(
       `workspace path alias points to a different current target: ${params.aliasPath} now resolves to ${params.currentWorkspacePath}, but its stored workspace state belongs to ${params.storedWorkspacePath}. ` +
-        "Run `openclaw doctor --fix` to rebind or retire the stale alias.",
+        "Run `openclaw doctor` and confirm the rebind, or use `openclaw doctor --fix --force`.",
     );
     this.name = "WorkspaceAliasRepointedError";
     this.aliasPath = params.aliasPath;
     this.storedWorkspacePath = params.storedWorkspacePath;
     this.currentWorkspacePath = params.currentWorkspacePath;
+  }
+}
+
+export const WORKSPACE_VANISHED_ERROR_CODE = "WORKSPACE_VANISHED";
+
+export class WorkspaceVanishedError extends Error {
+  readonly code = WORKSPACE_VANISHED_ERROR_CODE;
+  readonly workspaceDir: string;
+
+  constructor(params: { workspaceDir: string }) {
+    super(
+      `OpenClaw workspace appears to have disappeared after a recent initialization: ${params.workspaceDir}. ` +
+        `Refusing to reseed BOOTSTRAP.md over a recently attested workspace. ` +
+        "Restore the workspace or run a full OpenClaw reset if this reset was intentional.",
+    );
+    this.name = "WorkspaceVanishedError";
+    this.workspaceDir = params.workspaceDir;
   }
 }

--- a/src/agents/workspace-state-identity.ts
+++ b/src/agents/workspace-state-identity.ts
@@ -91,7 +91,7 @@ export function resolveWorkspaceStateIdentity(workspaceDir: string): WorkspaceSt
   );
 }
 
-export const WORKSPACE_ALIAS_REPOINTED_ERROR_CODE = "WORKSPACE_ALIAS_REPOINTED";
+const WORKSPACE_ALIAS_REPOINTED_ERROR_CODE = "WORKSPACE_ALIAS_REPOINTED";
 
 export class WorkspaceAliasRepointedError extends Error {
   readonly code = WORKSPACE_ALIAS_REPOINTED_ERROR_CODE;

--- a/src/agents/workspace-state-identity.ts
+++ b/src/agents/workspace-state-identity.ts
@@ -90,3 +90,27 @@ export function resolveWorkspaceStateIdentity(workspaceDir: string): WorkspaceSt
     canonicalizeWorkspacePath(workspaceDir, normalizeWorkspaceIdentityPath),
   );
 }
+
+export const WORKSPACE_ALIAS_REPOINTED_ERROR_CODE = "WORKSPACE_ALIAS_REPOINTED";
+
+export class WorkspaceAliasRepointedError extends Error {
+  readonly code = WORKSPACE_ALIAS_REPOINTED_ERROR_CODE;
+  readonly aliasPath: string;
+  readonly storedWorkspacePath: string;
+  readonly currentWorkspacePath: string;
+
+  constructor(params: {
+    aliasPath: string;
+    storedWorkspacePath: string;
+    currentWorkspacePath: string;
+  }) {
+    super(
+      `workspace path alias points to a different current target: ${params.aliasPath} now resolves to ${params.currentWorkspacePath}, but its stored workspace state belongs to ${params.storedWorkspacePath}. ` +
+        "Run `openclaw doctor --fix` to rebind or retire the stale alias.",
+    );
+    this.name = "WorkspaceAliasRepointedError";
+    this.aliasPath = params.aliasPath;
+    this.storedWorkspacePath = params.storedWorkspacePath;
+    this.currentWorkspacePath = params.currentWorkspacePath;
+  }
+}

--- a/src/agents/workspace-state-identity.ts
+++ b/src/agents/workspace-state-identity.ts
@@ -13,7 +13,7 @@ export type WorkspaceStateIdentity = {
 
 const MAX_WORKSPACE_IDENTITY_SYMLINKS = 40;
 
-function normalizeWorkspaceIdentityPath(value: string): string {
+export function normalizeWorkspaceIdentityPath(value: string): string {
   const normalized = path.normalize(value).normalize("NFC");
   return process.platform === "win32" ? normalized.toLowerCase() : normalized;
 }
@@ -22,8 +22,8 @@ function canonicalizeWorkspacePath(
   workspaceDir: string,
   normalizePath: (value: string) => string,
 ): string {
-  const fallback = normalizePath(path.resolve(resolveUserPath(workspaceDir)));
-  let candidate = fallback;
+  let candidate = path.resolve(resolveUserPath(workspaceDir));
+  const fallback = normalizePath(candidate);
   const followedSymlinks = new Set<string>();
 
   for (let redirectCount = 0; redirectCount < MAX_WORKSPACE_IDENTITY_SYMLINKS; redirectCount += 1) {
@@ -40,7 +40,7 @@ function canonicalizeWorkspacePath(
       }
       try {
         if (fs.lstatSync(current).isSymbolicLink()) {
-          const normalizedLink = normalizePath(current);
+          const normalizedLink = path.normalize(current);
           if (followedSymlinks.has(normalizedLink)) {
             return fallback;
           }

--- a/src/agents/workspace-state-identity.ts
+++ b/src/agents/workspace-state-identity.ts
@@ -106,7 +106,7 @@ export class WorkspaceAliasRepointedError extends Error {
   }) {
     super(
       `workspace path alias points to a different current target: ${params.aliasPath} now resolves to ${params.currentWorkspacePath}, but its stored workspace state belongs to ${params.storedWorkspacePath}. ` +
-        "Run `openclaw doctor` and confirm the rebind, or use `openclaw doctor --fix --force`.",
+        "Run `openclaw doctor --fix` and confirm the move, or use `openclaw doctor --fix --force`.",
     );
     this.name = "WorkspaceAliasRepointedError";
     this.aliasPath = params.aliasPath;

--- a/src/agents/workspace-state-store.test.ts
+++ b/src/agents/workspace-state-store.test.ts
@@ -19,8 +19,10 @@ import {
   retireWorkspaceFileCache,
   writeWorkspaceFileCache,
 } from "./workspace-file-cache.js";
-import { resolveWorkspaceStateIdentity } from "./workspace-state-identity.js";
-import { WorkspaceAliasRepointedError } from "./workspace-state-identity.js";
+import {
+  resolveWorkspaceStateIdentity,
+  WorkspaceAliasRepointedError,
+} from "./workspace-state-identity.js";
 import {
   clearExpiredWorkspaceStateForVanishedWorkspace,
   deleteWorkspaceState,

--- a/src/agents/workspace-state-store.test.ts
+++ b/src/agents/workspace-state-store.test.ts
@@ -20,6 +20,7 @@ import {
   writeWorkspaceFileCache,
 } from "./workspace-file-cache.js";
 import { resolveWorkspaceStateIdentity } from "./workspace-state-identity.js";
+import { WorkspaceAliasRepointedError } from "./workspace-state-identity.js";
 import {
   clearExpiredWorkspaceStateForVanishedWorkspace,
   deleteWorkspaceState,
@@ -350,6 +351,7 @@ describe("workspace state store", () => {
     fs.unlinkSync(alias);
     fs.symlinkSync(replacement, alias, process.platform === "win32" ? "junction" : "dir");
 
+    expect(() => readWorkspaceStateSnapshot(alias)).toThrow(WorkspaceAliasRepointedError);
     expect(() => readWorkspaceStateSnapshot(alias)).toThrow(/different current target/u);
   });
 

--- a/src/agents/workspace-state-store.ts
+++ b/src/agents/workspace-state-store.ts
@@ -51,6 +51,10 @@ export function isSafeWorkspaceAttestationFilename(filename: string): boolean {
   );
 }
 
+export function isValidWorkspaceAttestationHash(filename: string, sha256: string): boolean {
+  return isSafeWorkspaceAttestationFilename(filename) && SHA256_HEX_PATTERN.test(sha256);
+}
+
 function isCanonicalIsoTimestamp(value: string): boolean {
   const timestamp = new Date(value);
   return Number.isFinite(timestamp.getTime()) && timestamp.toISOString() === value;
@@ -217,6 +221,15 @@ function registerWorkspacePathAliases(params: {
   }
 }
 
+export function registerWorkspaceStateAliasIdentitiesInTransaction(params: {
+  database: WorkspaceStateDatabaseHandle;
+  aliases: readonly WorkspaceStateIdentity[];
+  identity: WorkspaceStateIdentity;
+  updatedAtMs: number;
+}): void {
+  registerWorkspacePathAliases(params);
+}
+
 export function registerWorkspaceStateAliasesInTransaction(params: {
   database: WorkspaceStateDatabaseHandle;
   workspaceDirs: readonly string[];
@@ -229,7 +242,7 @@ export function registerWorkspaceStateAliasesInTransaction(params: {
       aliases.set(alias.workspaceKey, alias);
     }
   }
-  registerWorkspacePathAliases({
+  registerWorkspaceStateAliasIdentitiesInTransaction({
     database: params.database,
     identity: params.identity,
     aliases: [...aliases.values()],
@@ -286,10 +299,7 @@ function readSnapshotFromDatabase(params: {
     for (const row of hashRows) {
       // Validate names structurally rather than against today's bootstrap set:
       // retiring a seeded file must not make an existing attestation unreadable.
-      if (
-        !isSafeWorkspaceAttestationFilename(row.filename) ||
-        !SHA256_HEX_PATTERN.test(row.sha256)
-      ) {
+      if (!isValidWorkspaceAttestationHash(row.filename, row.sha256)) {
         throw new Error("workspace attestation hash row is invalid");
       }
       generatedHashes.set(row.filename, row.sha256);

--- a/src/agents/workspace-state-store.ts
+++ b/src/agents/workspace-state-store.ts
@@ -51,10 +51,6 @@ export function isSafeWorkspaceAttestationFilename(filename: string): boolean {
   );
 }
 
-export function isValidWorkspaceAttestationHash(filename: string, sha256: string): boolean {
-  return isSafeWorkspaceAttestationFilename(filename) && SHA256_HEX_PATTERN.test(sha256);
-}
-
 function isCanonicalIsoTimestamp(value: string): boolean {
   const timestamp = new Date(value);
   return Number.isFinite(timestamp.getTime()) && timestamp.toISOString() === value;
@@ -112,7 +108,7 @@ type WorkspaceStateDatabaseHandle = Pick<
   "db" | "path"
 >;
 
-export function workspacePathEntryExists(workspaceDir: string): boolean {
+function workspacePathEntryExists(workspaceDir: string): boolean {
   try {
     fs.lstatSync(path.resolve(resolveUserPath(workspaceDir)));
     return true;
@@ -156,21 +152,22 @@ function resolveWorkspaceIdentityFromDatabase(params: {
     if (rowIdentity.workspaceKey !== row.workspace_key) {
       throw new Error("workspace path alias target is invalid");
     }
+    // A repointed alias can also resolve to an already initialized workspace.
+    // Report the repairable alias failure before the two owners look like corruption.
+    if (
+      workspacePathEntryExists(params.workspaceDir) &&
+      rowIdentity.workspaceKey !== canonicalIdentity.workspaceKey
+    ) {
+      throw new WorkspaceAliasRepointedError({
+        aliasPath: aliases[0]!.workspacePath,
+        storedWorkspacePath: rowIdentity.workspacePath,
+        currentWorkspacePath: canonicalIdentity.workspacePath,
+      });
+    }
     if (storedIdentity && storedIdentity.workspaceKey !== rowIdentity.workspaceKey) {
       throw new Error("workspace path aliases resolve to conflicting state");
     }
     storedIdentity = rowIdentity;
-  }
-  if (
-    storedIdentity &&
-    workspacePathEntryExists(params.workspaceDir) &&
-    storedIdentity.workspaceKey !== canonicalIdentity.workspaceKey
-  ) {
-    throw new WorkspaceAliasRepointedError({
-      aliasPath: aliases[0]!.workspacePath,
-      storedWorkspacePath: storedIdentity.workspacePath,
-      currentWorkspacePath: canonicalIdentity.workspacePath,
-    });
   }
   const existingAliasKeys = new Set(rows.map((row) => row.alias_key));
   return {
@@ -182,7 +179,7 @@ function resolveWorkspaceIdentityFromDatabase(params: {
   };
 }
 
-function registerWorkspacePathAliases(params: {
+export function registerWorkspaceStateAliasIdentitiesInTransaction(params: {
   database: WorkspaceStateDatabaseHandle;
   identity: WorkspaceStateIdentity;
   aliases: readonly WorkspaceStateIdentity[];
@@ -221,15 +218,6 @@ function registerWorkspacePathAliases(params: {
   }
 }
 
-export function registerWorkspaceStateAliasIdentitiesInTransaction(params: {
-  database: WorkspaceStateDatabaseHandle;
-  aliases: readonly WorkspaceStateIdentity[];
-  identity: WorkspaceStateIdentity;
-  updatedAtMs: number;
-}): void {
-  registerWorkspacePathAliases(params);
-}
-
 export function registerWorkspaceStateAliasesInTransaction(params: {
   database: WorkspaceStateDatabaseHandle;
   workspaceDirs: readonly string[];
@@ -250,7 +238,7 @@ export function registerWorkspaceStateAliasesInTransaction(params: {
   });
 }
 
-function readSnapshotFromDatabase(params: {
+export function readWorkspaceStateSnapshotFromDatabase(params: {
   identity: WorkspaceStateIdentity;
   database: WorkspaceStateDatabaseHandle;
 }): WorkspaceStateSnapshot {
@@ -299,7 +287,10 @@ function readSnapshotFromDatabase(params: {
     for (const row of hashRows) {
       // Validate names structurally rather than against today's bootstrap set:
       // retiring a seeded file must not make an existing attestation unreadable.
-      if (!isValidWorkspaceAttestationHash(row.filename, row.sha256)) {
+      if (
+        !isSafeWorkspaceAttestationFilename(row.filename) ||
+        !SHA256_HEX_PATTERN.test(row.sha256)
+      ) {
         throw new Error("workspace attestation hash row is invalid");
       }
       generatedHashes.set(row.filename, row.sha256);
@@ -337,7 +328,10 @@ export function readWorkspaceStateSnapshot(
       (database) =>
         runSqliteDeferredTransactionSync(database.db, () => {
           const resolution = resolveWorkspaceIdentityFromDatabase({ workspaceDir, database });
-          return readSnapshotFromDatabase({ identity: resolution.identity, database });
+          return readWorkspaceStateSnapshotFromDatabase({
+            identity: resolution.identity,
+            database,
+          });
         }),
       options,
     );
@@ -354,7 +348,7 @@ export function readWorkspaceStateSnapshot(
     const resolution = resolveWorkspaceIdentityFromDatabase({ workspaceDir, database });
     return {
       resolution,
-      snapshot: readSnapshotFromDatabase({ identity: resolution.identity, database }),
+      snapshot: readWorkspaceStateSnapshotFromDatabase({ identity: resolution.identity, database }),
     };
   });
   if (
@@ -378,7 +372,7 @@ export function readWorkspaceStateSnapshot(
         currentWorkspacePath: currentCanonicalIdentity.workspacePath,
       });
     }
-    const snapshot = readSnapshotFromDatabase({
+    const snapshot = readWorkspaceStateSnapshotFromDatabase({
       identity: initial.resolution.identity,
       database: writeDatabase,
     });
@@ -389,7 +383,7 @@ export function readWorkspaceStateSnapshot(
           alias,
         ]),
       );
-      registerWorkspacePathAliases({
+      registerWorkspaceStateAliasIdentitiesInTransaction({
         database: writeDatabase,
         identity: initial.resolution.identity,
         aliases: [...aliases.values()],
@@ -416,7 +410,7 @@ export function mergeWorkspaceSetupState(
   return runOpenClawStateWriteTransaction((database) => {
     const resolution = resolveWorkspaceIdentityFromDatabase({ workspaceDir, database });
     const identity = resolution.identity;
-    const snapshot = readSnapshotFromDatabase({ identity, database });
+    const snapshot = readWorkspaceStateSnapshotFromDatabase({ identity, database });
     const bootstrapSeededAt = snapshot.setup.bootstrapSeededAt ?? next.bootstrapSeededAt;
     const setupCompletedAt = snapshot.setup.setupCompletedAt ?? next.setupCompletedAt;
     const merged: WorkspaceSetupState = {
@@ -447,7 +441,7 @@ export function mergeWorkspaceSetupState(
           }),
         ),
     );
-    registerWorkspacePathAliases({
+    registerWorkspaceStateAliasIdentitiesInTransaction({
       database,
       identity,
       aliases: resolution.aliases,
@@ -485,13 +479,13 @@ export function replaceWorkspaceAttestation(params: {
       database,
     });
     const identity = resolution.identity;
-    const snapshot = readSnapshotFromDatabase({ identity, database });
+    const snapshot = readWorkspaceStateSnapshotFromDatabase({ identity, database });
     if (
       snapshot.attestation &&
       snapshot.attestation.attestedAtMs > params.attestedAtMs &&
       snapshot.attestation.attestedAtMs <= updatedAtMs
     ) {
-      registerWorkspacePathAliases({
+      registerWorkspaceStateAliasIdentitiesInTransaction({
         database,
         identity,
         aliases: resolution.aliases,
@@ -537,7 +531,7 @@ export function replaceWorkspaceAttestation(params: {
         ),
       );
     }
-    registerWorkspacePathAliases({
+    registerWorkspaceStateAliasIdentitiesInTransaction({
       database,
       identity,
       aliases: resolution.aliases,
@@ -621,7 +615,7 @@ export function retireWorkspaceRelocationAttestation(params: {
   identity: WorkspaceStateIdentity;
   attestedAtMs: number;
 }): boolean {
-  const snapshot = readSnapshotFromDatabase(params);
+  const snapshot = readWorkspaceStateSnapshotFromDatabase(params);
   if (
     snapshot.setupExists ||
     snapshot.attestation?.attestedAtMs !== params.attestedAtMs ||
@@ -648,9 +642,9 @@ export function clearExpiredWorkspaceStateForVanishedWorkspace(
   return runOpenClawStateWriteTransaction((database) => {
     const resolution = resolveWorkspaceIdentityFromDatabase({ workspaceDir, database });
     const identity = resolution.identity;
-    const snapshot = readSnapshotFromDatabase({ identity, database });
+    const snapshot = readWorkspaceStateSnapshotFromDatabase({ identity, database });
     const preserveRecentState = () => {
-      registerWorkspacePathAliases({
+      registerWorkspaceStateAliasIdentitiesInTransaction({
         database,
         identity,
         aliases: resolution.aliases,

--- a/src/agents/workspace-state-store.ts
+++ b/src/agents/workspace-state-store.ts
@@ -23,6 +23,7 @@ import {
   resolveCanonicalWorkspacePath,
   resolveWorkspaceStateAliases,
   resolveWorkspaceStateIdentity,
+  WorkspaceAliasRepointedError,
   type WorkspaceStateIdentity,
 } from "./workspace-state-identity.js";
 
@@ -107,7 +108,7 @@ type WorkspaceStateDatabaseHandle = Pick<
   "db" | "path"
 >;
 
-function workspacePathEntryExists(workspaceDir: string): boolean {
+export function workspacePathEntryExists(workspaceDir: string): boolean {
   try {
     fs.lstatSync(path.resolve(resolveUserPath(workspaceDir)));
     return true;
@@ -161,7 +162,11 @@ function resolveWorkspaceIdentityFromDatabase(params: {
     workspacePathEntryExists(params.workspaceDir) &&
     storedIdentity.workspaceKey !== canonicalIdentity.workspaceKey
   ) {
-    throw new Error("workspace path alias points to a different current target");
+    throw new WorkspaceAliasRepointedError({
+      aliasPath: aliases[0]!.workspacePath,
+      storedWorkspacePath: storedIdentity.workspacePath,
+      currentWorkspacePath: canonicalIdentity.workspacePath,
+    });
   }
   const existingAliasKeys = new Set(rows.map((row) => row.alias_key));
   return {
@@ -357,7 +362,11 @@ export function readWorkspaceStateSnapshot(
       workspacePathEntryExists(workspaceDir) &&
       currentCanonicalIdentity.workspaceKey !== initial.resolution.identity.workspaceKey
     ) {
-      throw new Error("workspace path alias points to a different current target");
+      throw new WorkspaceAliasRepointedError({
+        aliasPath: currentAliases[0]!.workspacePath,
+        storedWorkspacePath: initial.resolution.identity.workspacePath,
+        currentWorkspacePath: currentCanonicalIdentity.workspacePath,
+      });
     }
     const snapshot = readSnapshotFromDatabase({
       identity: initial.resolution.identity,

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -39,13 +39,12 @@ import {
 } from "./workspace-bootstrap-read.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR } from "./workspace-default.js";
 import { readWorkspaceFileCache, writeWorkspaceFileCache } from "./workspace-file-cache.js";
-import { WorkspaceVanishedError } from "./workspace-state-identity.js";
-export { WORKSPACE_VANISHED_ERROR_CODE } from "./workspace-state-identity.js";
 import {
   assertNoUnmigratedWorkspaceState,
   LEGACY_WORKSPACE_STATE_CURRENT_FILENAME,
   LEGACY_WORKSPACE_STATE_DIRNAME,
 } from "./workspace-legacy-state.js";
+import { WorkspaceVanishedError } from "./workspace-state-identity.js";
 import {
   clearExpiredWorkspaceStateForVanishedWorkspace,
   mergeWorkspaceSetupState,
@@ -57,6 +56,7 @@ import {
   type WorkspaceSetupState,
 } from "./workspace-state-store.js";
 import { resolveWorkspaceTemplateSearchDirs } from "./workspace-templates.js";
+export { WORKSPACE_VANISHED_ERROR_CODE } from "./workspace-state-identity.js";
 export {
   DEFAULT_AGENT_WORKSPACE_DIR,
   resolveDefaultAgentWorkspaceDir,

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -39,6 +39,8 @@ import {
 } from "./workspace-bootstrap-read.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR } from "./workspace-default.js";
 import { readWorkspaceFileCache, writeWorkspaceFileCache } from "./workspace-file-cache.js";
+import { WorkspaceVanishedError } from "./workspace-state-identity.js";
+export { WORKSPACE_VANISHED_ERROR_CODE } from "./workspace-state-identity.js";
 import {
   assertNoUnmigratedWorkspaceState,
   LEGACY_WORKSPACE_STATE_CURRENT_FILENAME,
@@ -294,23 +296,6 @@ const OPTIONAL_BOOTSTRAP_FILENAMES: ReadonlySet<string> = new Set([
  */
 export function isExpectedAbsentBootstrapFile(name: string): boolean {
   return OPTIONAL_BOOTSTRAP_FILENAMES.has(name) || name === DEFAULT_MEMORY_FILENAME;
-}
-
-export const WORKSPACE_VANISHED_ERROR_CODE = "WORKSPACE_VANISHED";
-
-export class WorkspaceVanishedError extends Error {
-  readonly code = WORKSPACE_VANISHED_ERROR_CODE;
-  readonly workspaceDir: string;
-
-  constructor(params: { workspaceDir: string }) {
-    super(
-      `OpenClaw workspace appears to have disappeared after a recent initialization: ${params.workspaceDir}. ` +
-        `Refusing to reseed BOOTSTRAP.md over a recently attested workspace. ` +
-        "Restore the workspace or run a full OpenClaw reset if this reset was intentional.",
-    );
-    this.name = "WorkspaceVanishedError";
-    this.workspaceDir = params.workspaceDir;
-  }
 }
 
 export async function publishBootstrapFile(

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -69,8 +69,10 @@ vi.mock("../../agents/prepared-model-catalog.js", () => ({
   loadPreparedModelCatalog: mocks.loadModelCatalog,
 }));
 
-vi.mock("../../agents/workspace.js", () => ({
+vi.mock("../../agents/workspace.js", async (importOriginal) => ({
   DEFAULT_AGENT_WORKSPACE_DIR: "/tmp/openclaw-workspace",
+  WorkspaceVanishedError: (await importOriginal<typeof import("../../agents/workspace.js")>())
+    .WorkspaceVanishedError,
   ensureAgentWorkspace: (...args: unknown[]) => mocks.ensureAgentWorkspace(...args),
 }));
 registerGetReplyRuntimeOverrides(mocks);

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -69,10 +69,8 @@ vi.mock("../../agents/prepared-model-catalog.js", () => ({
   loadPreparedModelCatalog: mocks.loadModelCatalog,
 }));
 
-vi.mock("../../agents/workspace.js", async (importOriginal) => ({
+vi.mock("../../agents/workspace.js", () => ({
   DEFAULT_AGENT_WORKSPACE_DIR: "/tmp/openclaw-workspace",
-  WorkspaceVanishedError: (await importOriginal<typeof import("../../agents/workspace.js")>())
-    .WorkspaceVanishedError,
   ensureAgentWorkspace: (...args: unknown[]) => mocks.ensureAgentWorkspace(...args),
 }));
 registerGetReplyRuntimeOverrides(mocks);

--- a/src/auto-reply/reply/get-reply.test-mocks.ts
+++ b/src/auto-reply/reply/get-reply.test-mocks.ts
@@ -28,8 +28,10 @@ vi.mock("../../agents/timeout.js", () => ({
   resolveAgentTimeoutMs: vi.fn(() => 60000),
 }));
 
-vi.mock("../../agents/workspace.js", () => ({
+vi.mock("../../agents/workspace.js", async (importOriginal) => ({
   DEFAULT_AGENT_WORKSPACE_DIR: "/tmp/workspace",
+  WorkspaceVanishedError: (await importOriginal<typeof import("../../agents/workspace.js")>())
+    .WorkspaceVanishedError,
   ensureAgentWorkspace: vi.fn(async (params?: { dir?: string }) => ({
     dir: params?.dir ?? "/tmp/workspace",
   })),

--- a/src/auto-reply/reply/get-reply.test-mocks.ts
+++ b/src/auto-reply/reply/get-reply.test-mocks.ts
@@ -28,10 +28,8 @@ vi.mock("../../agents/timeout.js", () => ({
   resolveAgentTimeoutMs: vi.fn(() => 60000),
 }));
 
-vi.mock("../../agents/workspace.js", async (importOriginal) => ({
+vi.mock("../../agents/workspace.js", () => ({
   DEFAULT_AGENT_WORKSPACE_DIR: "/tmp/workspace",
-  WorkspaceVanishedError: (await importOriginal<typeof import("../../agents/workspace.js")>())
-    .WorkspaceVanishedError,
   ensureAgentWorkspace: vi.fn(async (params?: { dir?: string }) => ({
     dir: params?.dir ?? "/tmp/workspace",
   })),

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -535,12 +535,21 @@ export async function getReplyFromConfig(
   } catch (error) {
     // Permanent workspace state failures cannot heal through ingress retries.
     // Return a visible terminal reply; heartbeat logging owns heartbeat failures.
-    if (
-      opts?.isHeartbeat !== true &&
-      (error instanceof WorkspaceAliasRepointedError || error instanceof WorkspaceVanishedError)
-    ) {
+    // Channel senders get fixed repair text only: the error messages embed
+    // absolute host paths, which must never reach a chat.
+    if (opts?.isHeartbeat !== true && error instanceof WorkspaceAliasRepointedError) {
       typing.cleanup();
-      return { text: `⚠️ ${error.message}` };
+      logVerbose(`workspace alias repointed; replying with repair notice: ${error.message}`);
+      return {
+        text: "⚠️ This agent's workspace state needs repair: the configured workspace path no longer matches its stored identity. Ask the gateway operator to run `openclaw doctor` and confirm the rebind, or `openclaw doctor --fix --force`.",
+      };
+    }
+    if (opts?.isHeartbeat !== true && error instanceof WorkspaceVanishedError) {
+      typing.cleanup();
+      logVerbose(`workspace vanished; replying with repair notice: ${error.message}`);
+      return {
+        text: "⚠️ This agent's workspace is missing on the gateway host. Ask the operator to restore it, or run a full OpenClaw reset if the removal was intentional.",
+      };
     }
     throw error;
   }

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -52,7 +52,10 @@ import {
 import { resolveCommandTurnTargetSessionKey } from "../command-turn-context.js";
 import type { GetReplyOptions } from "../get-reply-options.types.js";
 import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS, stripHeartbeatToken } from "../heartbeat.js";
-import type { ReplyPayload } from "../reply-payload.js";
+import {
+  markReplyPayloadForSourceSuppressionDelivery,
+  type ReplyPayload,
+} from "../reply-payload.js";
 import type { RuntimeMsgContext as MsgContext } from "../templating.js";
 import { normalizeThinkLevel } from "../thinking.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
@@ -533,25 +536,21 @@ export async function getReplyFromConfig(
           }),
     );
   } catch (error) {
-    // Permanent workspace state failures cannot heal through ingress retries.
-    // Return a visible terminal reply; heartbeat logging owns heartbeat failures.
-    // Channel senders get fixed repair text only: the error messages embed
-    // absolute host paths, which must never reach a chat.
-    if (opts?.isHeartbeat !== true && error instanceof WorkspaceAliasRepointedError) {
-      typing.cleanup();
-      logVerbose(`workspace alias repointed; replying with repair notice: ${error.message}`);
-      return {
-        text: "⚠️ This agent's workspace state needs repair: the configured workspace path no longer matches its stored identity. Ask the gateway operator to run `openclaw doctor` and confirm the rebind, or `openclaw doctor --fix --force`.",
-      };
+    if (
+      opts?.isHeartbeat === true ||
+      !(error instanceof WorkspaceAliasRepointedError || error instanceof WorkspaceVanishedError)
+    ) {
+      throw error;
     }
-    if (opts?.isHeartbeat !== true && error instanceof WorkspaceVanishedError) {
-      typing.cleanup();
-      logVerbose(`workspace vanished; replying with repair notice: ${error.message}`);
-      return {
-        text: "⚠️ This agent's workspace is missing on the gateway host. Ask the operator to restore it, or run a full OpenClaw reset if the removal was intentional.",
-      };
-    }
-    throw error;
+    // Permanent failures must finish ingress even in tool-only conversations.
+    // Keep host paths in operator logs; heartbeat failures retain their own owner.
+    typing.cleanup();
+    logVerbose(`workspace unavailable; replying with repair notice: ${error.message}`);
+    const text =
+      error instanceof WorkspaceAliasRepointedError
+        ? "⚠️ This agent's workspace state needs repair: the configured workspace path no longer matches its stored identity. Ask the gateway operator to run `openclaw doctor` and confirm the move only if the same workspace moved."
+        : "⚠️ This agent's workspace is missing on the gateway host. Ask the operator to restore the workspace from backup and run `openclaw doctor`.";
+    return markReplyPayloadForSourceSuppressionDelivery({ text });
   }
   const workspaceDir = workspace.dir;
 

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -19,7 +19,12 @@ import { publishedModelCatalogOwnerMatchesAgent } from "../../agents/prepared-mo
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { resolveEffectiveToolFsRootExpansionAllowed } from "../../agents/tool-fs-policy.js";
-import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
+import { WorkspaceAliasRepointedError } from "../../agents/workspace-state-identity.js";
+import {
+  DEFAULT_AGENT_WORKSPACE_DIR,
+  ensureAgentWorkspace,
+  WorkspaceVanishedError,
+} from "../../agents/workspace.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, getRuntimeConfig } from "../../config/config.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
@@ -514,18 +519,35 @@ export async function getReplyFromConfig(
       })
     : { cfg, agentId, ...(agentSessionKey ? { sessionKey: agentSessionKey } : {}) };
 
-  const workspace = await traceGetReplyPhase("reply.ensure_workspace", async () =>
-    useFastTestBootstrap
-      ? (await fs.mkdir(workspaceDirRaw, { recursive: true }), { dir: workspaceDirRaw })
-      : await ensureAgentWorkspace({
-          dir: workspaceDirRaw,
-          ensureBootstrapFiles: !agentCfg?.skipBootstrap && !isFastTestEnv,
-          skipOptionalBootstrapFiles: agentCfg?.skipOptionalBootstrapFiles,
-          provisioning: await (
-            await import("../../agents/acp-workspace-provisioning.js")
-          ).resolveAcpAgentWorkspaceProvisioningForTurn(acpWorkspaceProvisioningInput),
-        }),
-  );
+  let workspace: Awaited<ReturnType<typeof ensureAgentWorkspace>>;
+  try {
+    workspace = await traceGetReplyPhase("reply.ensure_workspace", async () =>
+      useFastTestBootstrap
+        ? (await fs.mkdir(workspaceDirRaw, { recursive: true }), { dir: workspaceDirRaw })
+        : await ensureAgentWorkspace({
+            dir: workspaceDirRaw,
+            ensureBootstrapFiles: !agentCfg?.skipBootstrap && !isFastTestEnv,
+            skipOptionalBootstrapFiles: agentCfg?.skipOptionalBootstrapFiles,
+            provisioning: await (
+              await import("../../agents/acp-workspace-provisioning.js")
+            ).resolveAcpAgentWorkspaceProvisioningForTurn(acpWorkspaceProvisioningInput),
+          }),
+    );
+  } catch (error) {
+    // Workspace state that fails closed cannot heal through ingress retries; a
+    // rethrow here leaves the inbound event stuck at the head of its durable
+    // lane until the 24h dead-letter gate. Turn it into a visible terminal
+    // reply that names the supported repair instead. Heartbeats keep throwing
+    // so their own failure logging stays the recorded outcome.
+    if (
+      opts?.isHeartbeat !== true &&
+      (error instanceof WorkspaceAliasRepointedError || error instanceof WorkspaceVanishedError)
+    ) {
+      typing.cleanup();
+      return { text: `⚠️ ${error.message}` };
+    }
+    throw error;
+  }
   const workspaceDir = workspace.dir;
 
   if (

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -548,7 +548,7 @@ export async function getReplyFromConfig(
     logVerbose(`workspace unavailable; replying with repair notice: ${error.message}`);
     const text =
       error instanceof WorkspaceAliasRepointedError
-        ? "⚠️ This agent's workspace state needs repair: the configured workspace path no longer matches its stored identity. Ask the gateway operator to run `openclaw doctor` and confirm the move only if the same workspace moved."
+        ? "⚠️ This agent's workspace state needs repair: the configured workspace path no longer matches its stored identity. Ask the gateway operator to run `openclaw doctor --fix` and confirm the move only if the same workspace moved."
         : "⚠️ This agent's workspace is missing on the gateway host. Ask the operator to restore the workspace from backup and run `openclaw doctor`.";
     return markReplyPayloadForSourceSuppressionDelivery({ text });
   }

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -19,12 +19,11 @@ import { publishedModelCatalogOwnerMatchesAgent } from "../../agents/prepared-mo
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { resolveEffectiveToolFsRootExpansionAllowed } from "../../agents/tool-fs-policy.js";
-import { WorkspaceAliasRepointedError } from "../../agents/workspace-state-identity.js";
 import {
-  DEFAULT_AGENT_WORKSPACE_DIR,
-  ensureAgentWorkspace,
+  WorkspaceAliasRepointedError,
   WorkspaceVanishedError,
-} from "../../agents/workspace.js";
+} from "../../agents/workspace-state-identity.js";
+import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, getRuntimeConfig } from "../../config/config.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
@@ -534,11 +533,8 @@ export async function getReplyFromConfig(
           }),
     );
   } catch (error) {
-    // Workspace state that fails closed cannot heal through ingress retries; a
-    // rethrow here leaves the inbound event stuck at the head of its durable
-    // lane until the 24h dead-letter gate. Turn it into a visible terminal
-    // reply that names the supported repair instead. Heartbeats keep throwing
-    // so their own failure logging stays the recorded outcome.
+    // Permanent workspace state failures cannot heal through ingress retries.
+    // Return a visible terminal reply; heartbeat logging owns heartbeat failures.
     if (
       opts?.isHeartbeat !== true &&
       (error instanceof WorkspaceAliasRepointedError || error instanceof WorkspaceVanishedError)

--- a/src/auto-reply/reply/get-reply.workspace-failure.test.ts
+++ b/src/auto-reply/reply/get-reply.workspace-failure.test.ts
@@ -3,7 +3,10 @@
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
-import { WorkspaceAliasRepointedError } from "../../agents/workspace-state-identity.js";
+import {
+  WorkspaceAliasRepointedError,
+  WorkspaceVanishedError,
+} from "../../agents/workspace-state-identity.js";
 import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { InternalSessionEntry } from "../../config/sessions/types.js";
 import {
@@ -82,7 +85,6 @@ describe("getReplyFromConfig workspace failures", () => {
   });
 
   it("turns a vanished workspace into a visible terminal reply", async () => {
-    const { WorkspaceVanishedError } = await import("../../agents/workspace.js");
     (await workspaceMock()).mockRejectedValueOnce(
       new WorkspaceVanishedError({ workspaceDir: "/home/user/clawd" }),
     );

--- a/src/auto-reply/reply/get-reply.workspace-failure.test.ts
+++ b/src/auto-reply/reply/get-reply.workspace-failure.test.ts
@@ -1,0 +1,110 @@
+// Tests that permanent workspace-state failures become visible terminal replies
+// instead of escaping get-reply as retryable ingress errors.
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { WorkspaceAliasRepointedError } from "../../agents/workspace-state-identity.js";
+import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
+import type { InternalSessionEntry } from "../../config/sessions/types.js";
+import {
+  buildGetReplyCtx,
+  createGetReplySessionState,
+  registerGetReplyRuntimeOverrides,
+} from "./get-reply.test-fixtures.js";
+import "./get-reply.test-runtime-mocks.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveReplyDirectives: vi.fn(),
+  initSessionState: vi.fn(),
+}));
+registerGetReplyRuntimeOverrides(mocks);
+
+let getReplyFromConfig: typeof import("./get-reply.js").getReplyFromConfig;
+let loadConfigMock: typeof import("../../config/config.js").getRuntimeConfig;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function repointedAliasError(): WorkspaceAliasRepointedError {
+  return new WorkspaceAliasRepointedError({
+    aliasPath: "/home/user/clawd",
+    storedWorkspacePath: "/home/user/clawd-old",
+    currentWorkspacePath: "/srv/data/clawd",
+  });
+}
+
+async function workspaceMock() {
+  const { ensureAgentWorkspace } = await import("../../agents/workspace.js");
+  return vi.mocked(ensureAgentWorkspace);
+}
+
+describe("getReplyFromConfig workspace failures", () => {
+  beforeEach(async () => {
+    ({ getReplyFromConfig } = await import("./get-reply.js"));
+    ({ getRuntimeConfig: loadConfigMock } = await import("../../config/config.js"));
+    vi.stubEnv("OPENCLAW_ALLOW_SLOW_REPLY_TESTS", "1");
+    mocks.resolveReplyDirectives.mockReset();
+    mocks.initSessionState.mockReset();
+    vi.mocked(loadConfigMock).mockReset();
+    vi.mocked(loadConfigMock).mockReturnValue({});
+    (await workspaceMock()).mockReset();
+    mocks.resolveReplyDirectives.mockResolvedValue({ kind: "reply", reply: { text: "ok" } });
+    const sessionKey = "agent:main:telegram:123";
+    const storePath = path.join(tempDirs.make("openclaw-get-reply-session-"), "sessions.json");
+    const entry: InternalSessionEntry = {
+      sessionId: "session-1",
+      updatedAt: Date.now(),
+    };
+    await replaceSessionEntry({ sessionKey, storePath }, entry);
+    mocks.initSessionState.mockResolvedValue(
+      createGetReplySessionState({
+        initialSessionEntry: entry,
+        sessionEntry: entry,
+        sessionEntryHandle: { replaceCurrent: vi.fn() },
+        sessionKey,
+        sessionStore: { [sessionKey]: entry },
+        storePath,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("turns a repointed workspace alias into a visible terminal reply", async () => {
+    (await workspaceMock()).mockRejectedValueOnce(repointedAliasError());
+
+    const reply = await getReplyFromConfig(buildGetReplyCtx(), undefined, {});
+
+    expect(reply).toMatchObject({
+      text: expect.stringContaining("openclaw doctor --fix"),
+    });
+    expect((reply as { text: string }).text).toContain("⚠️");
+  });
+
+  it("turns a vanished workspace into a visible terminal reply", async () => {
+    const { WorkspaceVanishedError } = await import("../../agents/workspace.js");
+    (await workspaceMock()).mockRejectedValueOnce(
+      new WorkspaceVanishedError({ workspaceDir: "/home/user/clawd" }),
+    );
+
+    const reply = await getReplyFromConfig(buildGetReplyCtx(), undefined, {});
+
+    expect(reply).toMatchObject({
+      text: expect.stringContaining("Restore the workspace"),
+    });
+  });
+
+  it("keeps heartbeat workspace failures throwing for heartbeat-owned logging", async () => {
+    (await workspaceMock()).mockRejectedValueOnce(repointedAliasError());
+
+    await expect(
+      getReplyFromConfig(buildGetReplyCtx(), { isHeartbeat: true }, {}),
+    ).rejects.toBeInstanceOf(WorkspaceAliasRepointedError);
+  });
+
+  it("rethrows other workspace provisioning failures unchanged", async () => {
+    (await workspaceMock()).mockRejectedValueOnce(new Error("EACCES: permission denied"));
+
+    await expect(getReplyFromConfig(buildGetReplyCtx(), undefined, {})).rejects.toThrow(/EACCES/u);
+  });
+});

--- a/src/auto-reply/reply/get-reply.workspace-failure.test.ts
+++ b/src/auto-reply/reply/get-reply.workspace-failure.test.ts
@@ -79,9 +79,23 @@ describe("getReplyFromConfig workspace failures", () => {
     const reply = await getReplyFromConfig(buildGetReplyCtx(), undefined, {});
 
     expect(reply).toMatchObject({
-      text: expect.stringContaining("openclaw doctor --fix"),
+      text: expect.stringContaining("openclaw doctor"),
     });
     expect((reply as { text: string }).text).toContain("⚠️");
+  });
+
+  it("never sends workspace paths to the channel", async () => {
+    (await workspaceMock()).mockRejectedValueOnce(repointedAliasError());
+
+    const reply = (await getReplyFromConfig(buildGetReplyCtx(), undefined, {})) as {
+      text: string;
+    };
+
+    // The typed error message embeds absolute host paths; the channel reply
+    // must stay a fixed repair notice with no filesystem layout in it.
+    expect(reply.text).not.toContain("/home/user");
+    expect(reply.text).not.toContain("/srv/data");
+    expect(reply.text).not.toMatch(/(^|[\s(])\/[A-Za-z0-9_.-]+\//u);
   });
 
   it("turns a vanished workspace into a visible terminal reply", async () => {
@@ -92,7 +106,7 @@ describe("getReplyFromConfig workspace failures", () => {
     const reply = await getReplyFromConfig(buildGetReplyCtx(), undefined, {});
 
     expect(reply).toMatchObject({
-      text: expect.stringContaining("Restore the workspace"),
+      text: expect.stringContaining("workspace is missing"),
     });
   });
 

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -34,6 +34,7 @@ import {
   shouldSkipPluginValidationForDoctorConfigPreflight,
 } from "./doctor-config-preflight.js";
 import type { DoctorOptions, DoctorPrompter } from "./doctor-prompter.js";
+import { createWorkspaceAliasMigrationRepair } from "./doctor-workspace-alias.js";
 import { cronCodexRuntimePolicyTargetKey } from "./doctor/cron/store-migration.js";
 import { emitDoctorNotes, sanitizeDoctorNote } from "./doctor/emit-notes.js";
 import { finalizeDoctorConfigFlow } from "./doctor/finalize-config-flow.js";
@@ -173,6 +174,10 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
         recoverCorruptTargetStore: shouldRepair,
         doctorOnlyStateMigrations: shouldRepair,
         preparePluginMetadataSnapshot: true,
+        beforeWorkspaceStateMigration: createWorkspaceAliasMigrationRepair(
+          params.prompter,
+          progress.done,
+        ),
         measure: async (name, run) => {
           progress.setLabel(`${name.slice(name.lastIndexOf(".") + 1).replaceAll("-", " ")}…`);
           return await run();

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -101,6 +101,7 @@ export async function runDoctorConfigPreflight(
     measure?: ConfigSnapshotReadMeasure;
     /** Return false or reject on config drift; the preflight always unwinds owned resources. */
     beforeStateMigrations?: (snapshot?: ConfigFileSnapshot) => Promise<boolean>;
+    beforeWorkspaceStateMigration?: (config: OpenClawConfig) => Promise<void>;
     /** CLI readiness policy evaluates the dry repaired config before any startup writes. */
     validateStartupConfig?: (snapshot: ConfigFileSnapshot) => void | Promise<void>;
     requireStateMigrationCheckpoint?: boolean;
@@ -575,6 +576,7 @@ export async function runDoctorConfigPreflight(
                 log: migrationLog,
                 recoverCorruptTargetStore: options.recoverCorruptTargetStore,
                 doctorOnlyStateMigrations: options.doctorOnlyStateMigrations,
+                beforeWorkspaceStateMigration: options.beforeWorkspaceStateMigration,
                 onStepReceipt: (receipt) => stateMigrationStepReceipts.push(receipt),
                 ...(gatewayStartupCheckpointRequired
                   ? { allowLegacyDeviceIdentityImport: true }

--- a/src/commands/doctor-workspace-alias.test.ts
+++ b/src/commands/doctor-workspace-alias.test.ts
@@ -108,14 +108,18 @@ describe("doctor workspace alias repair", () => {
     expect(collectRepointedWorkspaceAliasFindings(buildAliasCfg(dir))).toHaveLength(0);
   });
 
-  it("rebinds automatically when attested files verify against the current target", async () => {
-    const { alias } = repointAlias({ seedAttestedFile: true });
+  it("requires the aggressive gate even when generated hashes match", async () => {
+    const { alias, original } = repointAlias({ seedAttestedFile: true });
     const prompter = buildPrompter();
 
     await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter });
 
-    expect(prompter.confirmAutoFix).toHaveBeenCalledOnce();
-    expect(prompter.confirmAggressiveAutoFix).not.toHaveBeenCalled();
+    expect(prompter.confirmAutoFix).not.toHaveBeenCalled();
+    expect(prompter.confirmAggressiveAutoFix).toHaveBeenCalledOnce();
+    expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
+
+    const approving = buildPrompter({ confirmAggressiveAutoFix: vi.fn(async () => true) });
+    await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter: approving });
     const snapshot = readWorkspaceStateSnapshot(alias);
     expect(snapshot.setupExists).toBe(true);
     expect(snapshot.setup.bootstrapSeededAt).toBe("2026-07-16T01:00:00.000Z");
@@ -126,7 +130,7 @@ describe("doctor workspace alias repair", () => {
       cfg: buildAliasCfg(alias),
       prompter: secondPrompter,
     });
-    expect(secondPrompter.confirmAutoFix).not.toHaveBeenCalled();
+    expect(secondPrompter.confirmAggressiveAutoFix).not.toHaveBeenCalled();
   });
 
   it("requires the explicit operator gate when continuity is unproven", async () => {
@@ -158,13 +162,42 @@ describe("doctor workspace alias repair", () => {
     expect(readWorkspaceStateSnapshot(replacement).setupExists).toBe(true);
   });
 
-  it("only notes the problem outside repair mode", async () => {
-    const { alias, original } = repointAlias({ seedAttestedFile: true });
-    const prompter = buildPrompter({ shouldRepair: false });
+  it("allows an interactive approval outside non-interactive repair mode", async () => {
+    const { alias } = repointAlias({ seedAttestedFile: true });
+    const prompter = buildPrompter({
+      shouldRepair: false,
+      confirmAggressiveAutoFix: vi.fn(async () => true),
+      repairMode: {
+        shouldRepair: false,
+        shouldForce: false,
+        nonInteractive: false,
+        canPrompt: true,
+        updateInProgress: false,
+      },
+    });
 
     await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter });
 
     expect(prompter.confirmAutoFix).not.toHaveBeenCalled();
+    expect(prompter.confirmAggressiveAutoFix).toHaveBeenCalledOnce();
+    expect(readWorkspaceStateSnapshot(alias).setupExists).toBe(true);
+  });
+
+  it("refuses to transfer state while another configured agent uses the stored target", async () => {
+    const { alias, original } = repointAlias({ seedAttestedFile: false });
+    const prompter = buildPrompter({ confirmAggressiveAutoFix: vi.fn(async () => true) });
+    const cfg = {
+      agents: {
+        entries: {
+          main: { workspace: alias },
+          legacy: { workspace: original },
+        },
+      },
+    } as OpenClawConfig;
+
+    await maybeRepairRepointedWorkspaceAliases({ cfg, prompter });
+
+    expect(prompter.confirmAggressiveAutoFix).not.toHaveBeenCalled();
     expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
   });
 });

--- a/src/commands/doctor-workspace-alias.test.ts
+++ b/src/commands/doctor-workspace-alias.test.ts
@@ -1,0 +1,170 @@
+// Doctor repair for repointed workspace aliases: detection, evidence-gated
+// rebind, and refusal when the current target owns its own state.
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mergeWorkspaceSetupState,
+  readWorkspaceStateSnapshot,
+  replaceWorkspaceAttestation,
+} from "../agents/workspace-state-store.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import type { DoctorPrompter } from "./doctor-prompter.js";
+import {
+  collectRepointedWorkspaceAliasFindings,
+  maybeRepairRepointedWorkspaceAliases,
+} from "./doctor-workspace-alias.js";
+
+let testState: OpenClawTestState | undefined;
+
+beforeEach(async () => {
+  testState = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-doctor-workspace-alias-",
+  });
+});
+
+afterEach(async () => {
+  closeOpenClawStateDatabaseForTest();
+  await testState?.cleanup();
+  testState = undefined;
+});
+
+function buildPrompter(overrides: Partial<DoctorPrompter> = {}): DoctorPrompter {
+  return {
+    confirm: vi.fn(async () => false),
+    confirmAutoFix: vi.fn(async () => true),
+    confirmAggressiveAutoFix: vi.fn(async () => false),
+    confirmRuntimeRepair: vi.fn(async () => false),
+    select: vi.fn(async (_params, fallback) => fallback),
+    shouldRepair: true,
+    shouldForce: false,
+    repairMode: {
+      shouldRepair: true,
+      shouldForce: false,
+      nonInteractive: true,
+      canPrompt: false,
+    } as DoctorPrompter["repairMode"],
+    ...overrides,
+  };
+}
+
+function buildAliasCfg(aliasPath: string): OpenClawConfig {
+  return { agents: { entries: { main: { workspace: aliasPath } } } } as OpenClawConfig;
+}
+
+function repointAlias(params: { seedAttestedFile?: boolean }): {
+  alias: string;
+  original: string;
+  replacement: string;
+} {
+  const original = testState!.workspaceDir;
+  const alias = testState!.path("workspace-link");
+  const replacement = testState!.path("replacement-workspace");
+  fs.mkdirSync(replacement, { recursive: true });
+  fs.symlinkSync(original, alias, process.platform === "win32" ? "junction" : "dir");
+  mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+  if (params.seedAttestedFile) {
+    const content = "seeded bootstrap content";
+    fs.writeFileSync(path.join(replacement, "BOOTSTRAP.md"), content);
+    replaceWorkspaceAttestation({
+      workspaceDir: alias,
+      attestedAtMs: 1_000,
+      generatedHashes: new Map([
+        ["BOOTSTRAP.md", crypto.createHash("sha256").update(content).digest("hex")],
+      ]),
+      nowMs: 1_000,
+    });
+  }
+  fs.unlinkSync(alias);
+  fs.symlinkSync(replacement, alias, process.platform === "win32" ? "junction" : "dir");
+  return { alias, original, replacement };
+}
+
+describe("doctor workspace alias repair", () => {
+  it("reports a repointed alias as a warning finding", () => {
+    const { alias } = repointAlias({ seedAttestedFile: false });
+
+    const findings = collectRepointedWorkspaceAliasFindings(buildAliasCfg(alias));
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      checkId: "core/doctor/workspace-alias",
+      severity: "warning",
+      fixHint: expect.stringContaining("doctor --fix"),
+    });
+  });
+
+  it("reports nothing when aliases are intact", () => {
+    const dir = testState!.workspaceDir;
+    mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
+
+    expect(collectRepointedWorkspaceAliasFindings(buildAliasCfg(dir))).toHaveLength(0);
+  });
+
+  it("rebinds automatically when attested files verify against the current target", async () => {
+    const { alias } = repointAlias({ seedAttestedFile: true });
+    const prompter = buildPrompter();
+
+    await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter });
+
+    expect(prompter.confirmAutoFix).toHaveBeenCalledOnce();
+    expect(prompter.confirmAggressiveAutoFix).not.toHaveBeenCalled();
+    const snapshot = readWorkspaceStateSnapshot(alias);
+    expect(snapshot.setupExists).toBe(true);
+    expect(snapshot.setup.bootstrapSeededAt).toBe("2026-07-16T01:00:00.000Z");
+
+    // A second run finds nothing left to repair.
+    const secondPrompter = buildPrompter();
+    await maybeRepairRepointedWorkspaceAliases({
+      cfg: buildAliasCfg(alias),
+      prompter: secondPrompter,
+    });
+    expect(secondPrompter.confirmAutoFix).not.toHaveBeenCalled();
+  });
+
+  it("requires the explicit operator gate when continuity is unproven", async () => {
+    const { alias, original } = repointAlias({ seedAttestedFile: false });
+    const prompter = buildPrompter();
+
+    await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter });
+
+    expect(prompter.confirmAutoFix).not.toHaveBeenCalled();
+    expect(prompter.confirmAggressiveAutoFix).toHaveBeenCalledOnce();
+    // Declined: stored state stays with the original canonical target.
+    expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
+
+    const approving = buildPrompter({ confirmAggressiveAutoFix: vi.fn(async () => true) });
+    await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter: approving });
+    expect(readWorkspaceStateSnapshot(alias).setupExists).toBe(true);
+  });
+
+  it("refuses to merge when the current target already owns state", async () => {
+    const { alias, original, replacement } = repointAlias({ seedAttestedFile: false });
+    mergeWorkspaceSetupState(replacement, { bootstrapSeededAt: "2026-07-16T02:00:00.000Z" }, 2_000);
+    const prompter = buildPrompter({ confirmAggressiveAutoFix: vi.fn(async () => true) });
+
+    await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter });
+
+    expect(prompter.confirmAutoFix).not.toHaveBeenCalled();
+    expect(prompter.confirmAggressiveAutoFix).not.toHaveBeenCalled();
+    expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
+    expect(readWorkspaceStateSnapshot(replacement).setupExists).toBe(true);
+  });
+
+  it("only notes the problem outside repair mode", async () => {
+    const { alias, original } = repointAlias({ seedAttestedFile: true });
+    const prompter = buildPrompter({ shouldRepair: false });
+
+    await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter });
+
+    expect(prompter.confirmAutoFix).not.toHaveBeenCalled();
+    expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
+  });
+});

--- a/src/commands/doctor-workspace-alias.test.ts
+++ b/src/commands/doctor-workspace-alias.test.ts
@@ -93,7 +93,7 @@ describe("doctor workspace alias repair", () => {
     const cfg = buildAliasCfg(alias);
     await testState!.writeConfig(cfg);
     const prompter = buildPrompter({
-      confirmAggressiveAutoFix: vi.fn(async () => {
+      confirmRuntimeRepair: vi.fn(async () => {
         await testState!.writeConfig({
           agents: { entries: { main: { workspace: alias }, other: { workspace: original } } },
         });
@@ -110,7 +110,7 @@ describe("doctor workspace alias repair", () => {
     const changed = testState!.path("changed-target");
     fs.mkdirSync(changed);
     const prompter = buildPrompter({
-      confirmAggressiveAutoFix: vi.fn(async () => {
+      confirmRuntimeRepair: vi.fn(async () => {
         fs.unlinkSync(alias);
         fs.symlinkSync(changed, alias, process.platform === "win32" ? "junction" : "dir");
         return true;
@@ -141,17 +141,17 @@ describe("doctor workspace alias repair", () => {
     expect(collectRepointedWorkspaceAliasFindings(buildAliasCfg(dir))).toHaveLength(0);
   });
 
-  it("requires the aggressive gate even when generated hashes match", async () => {
+  it("requires explicit confirmation even when generated hashes match", async () => {
     const { alias, original } = repointAlias({ seedAttestedFile: true });
     const prompter = buildPrompter();
 
     await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter });
 
     expect(prompter.confirmAutoFix).not.toHaveBeenCalled();
-    expect(prompter.confirmAggressiveAutoFix).toHaveBeenCalledOnce();
+    expect(prompter.confirmRuntimeRepair).toHaveBeenCalledOnce();
     expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
 
-    const approving = buildPrompter({ confirmAggressiveAutoFix: vi.fn(async () => true) });
+    const approving = buildPrompter({ confirmRuntimeRepair: vi.fn(async () => true) });
     await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter: approving });
     const snapshot = readWorkspaceStateSnapshot(alias);
     expect(snapshot.setupExists).toBe(true);
@@ -163,7 +163,7 @@ describe("doctor workspace alias repair", () => {
       cfg: buildAliasCfg(alias),
       prompter: secondPrompter,
     });
-    expect(secondPrompter.confirmAggressiveAutoFix).not.toHaveBeenCalled();
+    expect(secondPrompter.confirmRuntimeRepair).not.toHaveBeenCalled();
   });
 
   it("requires the explicit operator gate when continuity is unproven", async () => {
@@ -173,11 +173,11 @@ describe("doctor workspace alias repair", () => {
     await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter });
 
     expect(prompter.confirmAutoFix).not.toHaveBeenCalled();
-    expect(prompter.confirmAggressiveAutoFix).toHaveBeenCalledOnce();
+    expect(prompter.confirmRuntimeRepair).toHaveBeenCalledOnce();
     // Declined: stored state stays with the original canonical target.
     expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
 
-    const approving = buildPrompter({ confirmAggressiveAutoFix: vi.fn(async () => true) });
+    const approving = buildPrompter({ confirmRuntimeRepair: vi.fn(async () => true) });
     await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter: approving });
     expect(readWorkspaceStateSnapshot(alias).setupExists).toBe(true);
   });
@@ -185,21 +185,21 @@ describe("doctor workspace alias repair", () => {
   it("refuses to merge when the current target already owns state", async () => {
     const { alias, original, replacement } = repointAlias({ seedAttestedFile: false });
     mergeWorkspaceSetupState(replacement, { bootstrapSeededAt: "2026-07-16T02:00:00.000Z" }, 2_000);
-    const prompter = buildPrompter({ confirmAggressiveAutoFix: vi.fn(async () => true) });
+    const prompter = buildPrompter({ confirmRuntimeRepair: vi.fn(async () => true) });
 
     await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter });
 
     expect(prompter.confirmAutoFix).not.toHaveBeenCalled();
-    expect(prompter.confirmAggressiveAutoFix).not.toHaveBeenCalled();
+    expect(prompter.confirmRuntimeRepair).not.toHaveBeenCalled();
     expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
     expect(readWorkspaceStateSnapshot(replacement).setupExists).toBe(true);
   });
 
-  it("allows an interactive approval outside non-interactive repair mode", async () => {
-    const { alias } = repointAlias({ seedAttestedFile: true });
+  it("does not move records from diagnostic mode", async () => {
+    const { alias, original } = repointAlias({ seedAttestedFile: true });
     const prompter = buildPrompter({
       shouldRepair: false,
-      confirmAggressiveAutoFix: vi.fn(async () => true),
+      confirmRuntimeRepair: vi.fn(async () => true),
       repairMode: {
         shouldRepair: false,
         shouldForce: false,
@@ -212,13 +212,13 @@ describe("doctor workspace alias repair", () => {
     await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter });
 
     expect(prompter.confirmAutoFix).not.toHaveBeenCalled();
-    expect(prompter.confirmAggressiveAutoFix).toHaveBeenCalledOnce();
-    expect(readWorkspaceStateSnapshot(alias).setupExists).toBe(true);
+    expect(prompter.confirmRuntimeRepair).not.toHaveBeenCalled();
+    expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
   });
 
   it("refuses to transfer state while another configured agent uses the stored target", async () => {
     const { alias, original } = repointAlias({ seedAttestedFile: false });
-    const prompter = buildPrompter({ confirmAggressiveAutoFix: vi.fn(async () => true) });
+    const prompter = buildPrompter({ confirmRuntimeRepair: vi.fn(async () => true) });
     const cfg = {
       agents: {
         entries: {
@@ -230,7 +230,7 @@ describe("doctor workspace alias repair", () => {
 
     await maybeRepairRepointedWorkspaceAliases({ cfg, prompter });
 
-    expect(prompter.confirmAggressiveAutoFix).not.toHaveBeenCalled();
+    expect(prompter.confirmRuntimeRepair).not.toHaveBeenCalled();
     expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
   });
 });

--- a/src/commands/doctor-workspace-alias.test.ts
+++ b/src/commands/doctor-workspace-alias.test.ts
@@ -67,12 +67,11 @@ function repointAlias(params: { seedAttestedFile?: boolean }): {
   const original = testState!.workspaceDir;
   const alias = testState!.path("workspace-link");
   const replacement = testState!.path("replacement-workspace");
-  fs.mkdirSync(replacement, { recursive: true });
   fs.symlinkSync(original, alias, process.platform === "win32" ? "junction" : "dir");
   mergeWorkspaceSetupState(alias, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000);
   if (params.seedAttestedFile) {
     const content = "seeded bootstrap content";
-    fs.writeFileSync(path.join(replacement, "BOOTSTRAP.md"), content);
+    fs.writeFileSync(path.join(original, "BOOTSTRAP.md"), content);
     replaceWorkspaceAttestation({
       workspaceDir: alias,
       attestedAtMs: 1_000,
@@ -82,12 +81,46 @@ function repointAlias(params: { seedAttestedFile?: boolean }): {
       nowMs: 1_000,
     });
   }
+  fs.renameSync(original, replacement);
   fs.unlinkSync(alias);
   fs.symlinkSync(replacement, alias, process.platform === "win32" ? "junction" : "dir");
   return { alias, original, replacement };
 }
 
 describe("doctor workspace alias repair", () => {
+  it("leaves state intact when configuration changes during confirmation", async () => {
+    const { alias, original, replacement } = repointAlias({ seedAttestedFile: true });
+    const cfg = buildAliasCfg(alias);
+    await testState!.writeConfig(cfg);
+    const prompter = buildPrompter({
+      confirmAggressiveAutoFix: vi.fn(async () => {
+        await testState!.writeConfig({
+          agents: { entries: { main: { workspace: alias }, other: { workspace: original } } },
+        });
+        return true;
+      }),
+    });
+    await maybeRepairRepointedWorkspaceAliases({ cfg, prompter });
+    expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
+    expect(readWorkspaceStateSnapshot(replacement).setupExists).toBe(false);
+  });
+
+  it("does not adopt a target substituted during confirmation", async () => {
+    const { alias, original } = repointAlias({ seedAttestedFile: true });
+    const changed = testState!.path("changed-target");
+    fs.mkdirSync(changed);
+    const prompter = buildPrompter({
+      confirmAggressiveAutoFix: vi.fn(async () => {
+        fs.unlinkSync(alias);
+        fs.symlinkSync(changed, alias, process.platform === "win32" ? "junction" : "dir");
+        return true;
+      }),
+    });
+    await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter });
+    expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
+    expect(readWorkspaceStateSnapshot(changed).setupExists).toBe(false);
+  });
+
   it("reports a repointed alias as a warning finding", () => {
     const { alias } = repointAlias({ seedAttestedFile: false });
 

--- a/src/commands/doctor-workspace-alias.test.ts
+++ b/src/commands/doctor-workspace-alias.test.ts
@@ -18,7 +18,7 @@ import {
 import type { DoctorPrompter } from "./doctor-prompter.js";
 import {
   collectRepointedWorkspaceAliasFindings,
-  maybeRepairRepointedWorkspaceAliases,
+  createWorkspaceAliasMigrationRepair,
 } from "./doctor-workspace-alias.js";
 
 let testState: OpenClawTestState | undefined;
@@ -57,6 +57,12 @@ function buildPrompter(overrides: Partial<DoctorPrompter> = {}): DoctorPrompter 
 
 function buildAliasCfg(aliasPath: string): OpenClawConfig {
   return { agents: { entries: { main: { workspace: aliasPath } } } } as OpenClawConfig;
+}
+
+async function runWorkspaceRepair(params: { cfg: OpenClawConfig; prompter: DoctorPrompter }) {
+  const repair = createWorkspaceAliasMigrationRepair(params.prompter, vi.fn());
+  expect(repair).toBeTypeOf("function");
+  await repair!(params.cfg);
 }
 
 function repointAlias(params: { seedAttestedFile?: boolean }): {
@@ -100,7 +106,7 @@ describe("doctor workspace alias repair", () => {
         return true;
       }),
     });
-    await maybeRepairRepointedWorkspaceAliases({ cfg, prompter });
+    await expect(runWorkspaceRepair({ cfg, prompter })).rejects.toThrow();
     expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
     expect(readWorkspaceStateSnapshot(replacement).setupExists).toBe(false);
   });
@@ -116,7 +122,7 @@ describe("doctor workspace alias repair", () => {
         return true;
       }),
     });
-    await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter });
+    await expect(runWorkspaceRepair({ cfg: buildAliasCfg(alias), prompter })).rejects.toThrow();
     expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
     expect(readWorkspaceStateSnapshot(changed).setupExists).toBe(false);
   });
@@ -145,21 +151,21 @@ describe("doctor workspace alias repair", () => {
     const { alias, original } = repointAlias({ seedAttestedFile: true });
     const prompter = buildPrompter();
 
-    await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter });
+    await expect(runWorkspaceRepair({ cfg: buildAliasCfg(alias), prompter })).rejects.toThrow();
 
     expect(prompter.confirmAutoFix).not.toHaveBeenCalled();
     expect(prompter.confirmRuntimeRepair).toHaveBeenCalledOnce();
     expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
 
     const approving = buildPrompter({ confirmRuntimeRepair: vi.fn(async () => true) });
-    await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter: approving });
+    await runWorkspaceRepair({ cfg: buildAliasCfg(alias), prompter: approving });
     const snapshot = readWorkspaceStateSnapshot(alias);
     expect(snapshot.setupExists).toBe(true);
     expect(snapshot.setup.bootstrapSeededAt).toBe("2026-07-16T01:00:00.000Z");
 
     // A second run finds nothing left to repair.
     const secondPrompter = buildPrompter();
-    await maybeRepairRepointedWorkspaceAliases({
+    await runWorkspaceRepair({
       cfg: buildAliasCfg(alias),
       prompter: secondPrompter,
     });
@@ -170,7 +176,7 @@ describe("doctor workspace alias repair", () => {
     const { alias, original } = repointAlias({ seedAttestedFile: false });
     const prompter = buildPrompter();
 
-    await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter });
+    await expect(runWorkspaceRepair({ cfg: buildAliasCfg(alias), prompter })).rejects.toThrow();
 
     expect(prompter.confirmAutoFix).not.toHaveBeenCalled();
     expect(prompter.confirmRuntimeRepair).toHaveBeenCalledOnce();
@@ -178,7 +184,7 @@ describe("doctor workspace alias repair", () => {
     expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);
 
     const approving = buildPrompter({ confirmRuntimeRepair: vi.fn(async () => true) });
-    await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter: approving });
+    await runWorkspaceRepair({ cfg: buildAliasCfg(alias), prompter: approving });
     expect(readWorkspaceStateSnapshot(alias).setupExists).toBe(true);
   });
 
@@ -187,7 +193,7 @@ describe("doctor workspace alias repair", () => {
     mergeWorkspaceSetupState(replacement, { bootstrapSeededAt: "2026-07-16T02:00:00.000Z" }, 2_000);
     const prompter = buildPrompter({ confirmRuntimeRepair: vi.fn(async () => true) });
 
-    await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter });
+    await expect(runWorkspaceRepair({ cfg: buildAliasCfg(alias), prompter })).rejects.toThrow();
 
     expect(prompter.confirmAutoFix).not.toHaveBeenCalled();
     expect(prompter.confirmRuntimeRepair).not.toHaveBeenCalled();
@@ -196,7 +202,7 @@ describe("doctor workspace alias repair", () => {
   });
 
   it("does not move records from diagnostic mode", async () => {
-    const { alias, original } = repointAlias({ seedAttestedFile: true });
+    const { original } = repointAlias({ seedAttestedFile: true });
     const prompter = buildPrompter({
       shouldRepair: false,
       confirmRuntimeRepair: vi.fn(async () => true),
@@ -209,7 +215,7 @@ describe("doctor workspace alias repair", () => {
       },
     });
 
-    await maybeRepairRepointedWorkspaceAliases({ cfg: buildAliasCfg(alias), prompter });
+    expect(createWorkspaceAliasMigrationRepair(prompter, vi.fn())).toBeUndefined();
 
     expect(prompter.confirmAutoFix).not.toHaveBeenCalled();
     expect(prompter.confirmRuntimeRepair).not.toHaveBeenCalled();
@@ -228,7 +234,7 @@ describe("doctor workspace alias repair", () => {
       },
     } as OpenClawConfig;
 
-    await maybeRepairRepointedWorkspaceAliases({ cfg, prompter });
+    await expect(runWorkspaceRepair({ cfg, prompter })).rejects.toThrow();
 
     expect(prompter.confirmRuntimeRepair).not.toHaveBeenCalled();
     expect(readWorkspaceStateSnapshot(original).setupExists).toBe(true);

--- a/src/commands/doctor-workspace-alias.ts
+++ b/src/commands/doctor-workspace-alias.ts
@@ -1,0 +1,171 @@
+/** Doctor detection and non-destructive repair for repointed workspace path aliases. */
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { note } from "../../packages/terminal-core/src/note.js";
+import {
+  listAgentIds,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "../agents/agent-scope.js";
+import {
+  detectRepointedWorkspaceAlias,
+  rebindRepointedWorkspaceAlias,
+  type RepointedWorkspaceAliasFacts,
+} from "../agents/workspace-alias-rebind.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { shortenHomePath } from "../utils.js";
+import type { DoctorPrompter } from "./doctor-prompter.js";
+
+type WorkspaceAliasScope = {
+  agentId: string;
+  workspaceDir: string;
+  labelAgent: boolean;
+};
+
+type DetectedWorkspaceAliasScope = WorkspaceAliasScope & {
+  facts: RepointedWorkspaceAliasFacts;
+};
+
+function resolveWorkspaceAliasScopes(cfg: OpenClawConfig): WorkspaceAliasScope[] {
+  const listedAgentIds = listAgentIds(cfg);
+  const agentIds = listedAgentIds.length > 0 ? listedAgentIds : [resolveDefaultAgentId(cfg)];
+  const labelAgent = agentIds.length > 1;
+  return agentIds.map((agentId) => ({
+    agentId,
+    workspaceDir: resolveAgentWorkspaceDir(cfg, agentId),
+    labelAgent,
+  }));
+}
+
+function detectRepointedWorkspaceAliasScopes(cfg: OpenClawConfig): DetectedWorkspaceAliasScope[] {
+  const detected: DetectedWorkspaceAliasScope[] = [];
+  for (const scope of resolveWorkspaceAliasScopes(cfg)) {
+    let facts: RepointedWorkspaceAliasFacts | undefined;
+    try {
+      facts = detectRepointedWorkspaceAlias(scope.workspaceDir);
+    } catch (error) {
+      note(
+        `Workspace alias check failed for ${shortenHomePath(scope.workspaceDir)}: ${formatErrorMessage(error)}`,
+        "Workspace",
+      );
+      continue;
+    }
+    if (facts) {
+      detected.push({ ...scope, facts });
+    }
+  }
+  return detected;
+}
+
+function describeRepointedWorkspaceAlias(facts: RepointedWorkspaceAliasFacts): string {
+  return (
+    `workspace path ${shortenHomePath(facts.aliasPath)} now resolves to ` +
+    `${shortenHomePath(facts.currentWorkspacePath)}, but its stored setup state still belongs to ` +
+    shortenHomePath(facts.storedWorkspacePath)
+  );
+}
+
+/**
+ * Continuity proof for auto-adoption: every attested generated file must exist
+ * in the alias's current target with its recorded hash. Anything less keeps the
+ * rebind an explicit operator decision.
+ */
+async function attestedHashesMatchCurrentTarget(
+  facts: RepointedWorkspaceAliasFacts,
+): Promise<boolean> {
+  if (facts.storedAttestationHashes.size === 0) {
+    return false;
+  }
+  for (const [filename, sha256] of facts.storedAttestationHashes) {
+    try {
+      const buffer = await fs.promises.readFile(path.join(facts.currentWorkspacePath, filename));
+      if (crypto.createHash("sha256").update(buffer).digest("hex") !== sha256) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+export type WorkspaceAliasFinding = {
+  checkId: string;
+  severity: "warning";
+  message: string;
+  fixHint: string;
+};
+
+export const WORKSPACE_ALIAS_CHECK_ID = "core/doctor/workspace-alias";
+
+/** Read-only findings for `openclaw doctor` preview and health reporting. */
+export function collectRepointedWorkspaceAliasFindings(
+  cfg: OpenClawConfig,
+): WorkspaceAliasFinding[] {
+  return detectRepointedWorkspaceAliasScopes(cfg).map(({ agentId, labelAgent, facts }) => ({
+    checkId: WORKSPACE_ALIAS_CHECK_ID,
+    severity: "warning",
+    message: `${labelAgent ? `Agent "${agentId}": ` : ""}${describeRepointedWorkspaceAlias(facts)}. Inbound messages for this workspace fail until the alias is repaired.`,
+    fixHint: "Run `openclaw doctor --fix` to rebind or retire the stale alias.",
+  }));
+}
+
+/** Detects repointed workspace aliases and repairs them under doctor's repair flow. */
+export async function maybeRepairRepointedWorkspaceAliases(params: {
+  cfg: OpenClawConfig;
+  prompter: DoctorPrompter;
+}): Promise<void> {
+  for (const { agentId, workspaceDir, labelAgent, facts } of detectRepointedWorkspaceAliasScopes(
+    params.cfg,
+  )) {
+    const prefix = labelAgent ? `Agent "${agentId}": ` : "";
+    const description = describeRepointedWorkspaceAlias(facts);
+    if (facts.currentTargetHasOwnState) {
+      note(
+        `${prefix}${description}. The current target already has its own workspace state, so doctor cannot rebind without merging two workspaces. Delete one workspace's state first if this repoint was intentional.`,
+        "Workspace",
+      );
+      continue;
+    }
+    if (!params.prompter.shouldRepair) {
+      note(
+        `${prefix}${description}. Inbound messages for this workspace fail until the alias is repaired. Run \`openclaw doctor --fix\` to rebind it.`,
+        "Workspace",
+      );
+      continue;
+    }
+    const continuityProven = await attestedHashesMatchCurrentTarget(facts);
+    const approved = continuityProven
+      ? await params.prompter.confirmAutoFix({
+          message: `${prefix}${description}. Attested workspace files match the current target. Rebind the stored state to it?`,
+          initialValue: true,
+        })
+      : // Without matching attestation evidence the new target is unproven, so
+        // adoption stays an explicit operator decision (interactive yes or --force).
+        await params.prompter.confirmAggressiveAutoFix({
+          message: `${prefix}${description}. Attested workspace files do NOT verify against the current target. Rebind the stored state to it anyway?`,
+          initialValue: false,
+        });
+    if (!approved) {
+      note(
+        `${prefix}Left the repointed workspace alias in place. Inbound messages for this workspace keep failing until it is repaired.`,
+        "Workspace",
+      );
+      continue;
+    }
+    const outcome = rebindRepointedWorkspaceAlias(workspaceDir);
+    if (outcome === "rebound") {
+      note(
+        `${prefix}Rebound workspace state for ${shortenHomePath(facts.aliasPath)} to ${shortenHomePath(facts.currentWorkspacePath)}.`,
+        "Workspace",
+      );
+    } else {
+      note(
+        `${prefix}Workspace alias rebind for ${shortenHomePath(facts.aliasPath)} was not applied (${outcome}); re-run \`openclaw doctor\` to re-check.`,
+        "Workspace",
+      );
+    }
+  }
+}

--- a/src/commands/doctor-workspace-alias.ts
+++ b/src/commands/doctor-workspace-alias.ts
@@ -112,7 +112,7 @@ export type WorkspaceAliasFinding = {
   fixHint: string;
 };
 
-export const WORKSPACE_ALIAS_CHECK_ID = "core/doctor/workspace-alias";
+const WORKSPACE_ALIAS_CHECK_ID = "core/doctor/workspace-alias";
 
 /** Read-only findings for `openclaw doctor` preview and health reporting. */
 export function collectRepointedWorkspaceAliasFindings(

--- a/src/commands/doctor-workspace-alias.ts
+++ b/src/commands/doctor-workspace-alias.ts
@@ -13,6 +13,7 @@ import {
   rebindRepointedWorkspaceAlias,
   type RepointedWorkspaceAliasFacts,
 } from "../agents/workspace-alias-rebind.js";
+import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-identity.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { shortenHomePath } from "../utils.js";
@@ -91,6 +92,19 @@ async function attestedHashesMatchCurrentTarget(
   return true;
 }
 
+function findConfiguredStoredTargetOwner(params: {
+  cfg: OpenClawConfig;
+  currentAgentId: string;
+  storedWorkspacePath: string;
+}): WorkspaceAliasScope | undefined {
+  return resolveWorkspaceAliasScopes(params.cfg).find(
+    (scope) =>
+      scope.agentId !== params.currentAgentId &&
+      resolveWorkspaceStateIdentity(scope.workspaceDir).workspacePath ===
+        params.storedWorkspacePath,
+  );
+}
+
 export type WorkspaceAliasFinding = {
   checkId: string;
   severity: "warning";
@@ -108,7 +122,8 @@ export function collectRepointedWorkspaceAliasFindings(
     checkId: WORKSPACE_ALIAS_CHECK_ID,
     severity: "warning",
     message: `${labelAgent ? `Agent "${agentId}": ` : ""}${describeRepointedWorkspaceAlias(facts)}. Inbound messages for this workspace fail until the alias is repaired.`,
-    fixHint: "Run `openclaw doctor --fix` to rebind or retire the stale alias.",
+    fixHint:
+      "Run `openclaw doctor` and confirm the rebind, or use `openclaw doctor --fix --force`.",
   }));
 }
 
@@ -129,25 +144,26 @@ export async function maybeRepairRepointedWorkspaceAliases(params: {
       );
       continue;
     }
-    if (!params.prompter.shouldRepair) {
+    const configuredOwner = findConfiguredStoredTargetOwner({
+      cfg: params.cfg,
+      currentAgentId: agentId,
+      storedWorkspacePath: facts.storedWorkspacePath,
+    });
+    if (configuredOwner) {
       note(
-        `${prefix}${description}. Inbound messages for this workspace fail until the alias is repaired. Run \`openclaw doctor --fix\` to rebind it.`,
+        `${prefix}${description}. Agent "${configuredOwner.agentId}" still uses the stored target, so doctor will not transfer its state.`,
         "Workspace",
       );
       continue;
     }
-    const continuityProven = await attestedHashesMatchCurrentTarget(facts);
-    const approved = continuityProven
-      ? await params.prompter.confirmAutoFix({
-          message: `${prefix}${description}. Attested workspace files match the current target. Rebind the stored state to it?`,
-          initialValue: true,
-        })
-      : // Without matching attestation evidence the new target is unproven, so
-        // adoption stays an explicit operator decision (interactive yes or --force).
-        await params.prompter.confirmAggressiveAutoFix({
-          message: `${prefix}${description}. Attested workspace files do NOT verify against the current target. Rebind the stored state to it anyway?`,
-          initialValue: false,
-        });
+    const hashesMatch = await attestedHashesMatchCurrentTarget(facts);
+    // Generated bootstrap templates can corroborate a target, but they do not identify it.
+    const approved = await params.prompter.confirmAggressiveAutoFix({
+      message: hashesMatch
+        ? `${prefix}${description}. Generated template hashes match the current target but do not prove its identity. Rebind the stored state to it?`
+        : `${prefix}${description}. Attested workspace files do NOT verify against the current target. Rebind the stored state to it anyway?`,
+      initialValue: false,
+    });
     if (!approved) {
       note(
         `${prefix}Left the repointed workspace alias in place. Inbound messages for this workspace keep failing until it is repaired.`,
@@ -155,7 +171,7 @@ export async function maybeRepairRepointedWorkspaceAliases(params: {
       );
       continue;
     }
-    const outcome = rebindRepointedWorkspaceAlias(workspaceDir);
+    const outcome = rebindRepointedWorkspaceAlias(workspaceDir, facts);
     if (outcome === "rebound") {
       note(
         `${prefix}Rebound workspace state for ${shortenHomePath(facts.aliasPath)} to ${shortenHomePath(facts.currentWorkspacePath)}.`,

--- a/src/commands/doctor-workspace-alias.ts
+++ b/src/commands/doctor-workspace-alias.ts
@@ -1,108 +1,32 @@
-/** Doctor detection and non-destructive repair for repointed workspace path aliases. */
-import crypto from "node:crypto";
-import fs from "node:fs";
-import path from "node:path";
+import os from "node:os";
+import { isDeepStrictEqual } from "node:util";
 import { note } from "../../packages/terminal-core/src/note.js";
 import {
-  listAgentIds,
-  resolveAgentWorkspaceDir,
-  resolveDefaultAgentId,
-} from "../agents/agent-scope.js";
-import {
   detectRepointedWorkspaceAlias,
+  inspectWorkspaceAliasMove,
   rebindRepointedWorkspaceAlias,
   type RepointedWorkspaceAliasFacts,
+  type WorkspaceAliasRebindOutcome,
 } from "../agents/workspace-alias-rebind.js";
-import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-identity.js";
+import { listWorkspaceStateDirs } from "../agents/workspace-state-dirs.js";
+import { readConfigFileSnapshot } from "../config/io.js";
+import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { shortenHomePath } from "../utils.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
-type WorkspaceAliasScope = {
-  agentId: string;
-  workspaceDir: string;
-  labelAgent: boolean;
-};
-
-type DetectedWorkspaceAliasScope = WorkspaceAliasScope & {
-  facts: RepointedWorkspaceAliasFacts;
-};
-
-function resolveWorkspaceAliasScopes(cfg: OpenClawConfig): WorkspaceAliasScope[] {
-  const listedAgentIds = listAgentIds(cfg);
-  const agentIds = listedAgentIds.length > 0 ? listedAgentIds : [resolveDefaultAgentId(cfg)];
-  const labelAgent = agentIds.length > 1;
-  return agentIds.map((agentId) => ({
-    agentId,
-    workspaceDir: resolveAgentWorkspaceDir(cfg, agentId),
-    labelAgent,
-  }));
-}
-
-function detectRepointedWorkspaceAliasScopes(cfg: OpenClawConfig): DetectedWorkspaceAliasScope[] {
-  const detected: DetectedWorkspaceAliasScope[] = [];
-  for (const scope of resolveWorkspaceAliasScopes(cfg)) {
-    let facts: RepointedWorkspaceAliasFacts | undefined;
-    try {
-      facts = detectRepointedWorkspaceAlias(scope.workspaceDir);
-    } catch (error) {
-      note(
-        `Workspace alias check failed for ${shortenHomePath(scope.workspaceDir)}: ${formatErrorMessage(error)}`,
-        "Workspace",
-      );
-      continue;
-    }
-    if (facts) {
-      detected.push({ ...scope, facts });
-    }
-  }
-  return detected;
+function configuredWorkspaceDirs(cfg: OpenClawConfig): string[] {
+  return listWorkspaceStateDirs({
+    cfg,
+    env: process.env,
+    homedir: os.homedir,
+    stateDir: resolveStateDir(),
+  });
 }
 
 function describeRepointedWorkspaceAlias(facts: RepointedWorkspaceAliasFacts): string {
-  return (
-    `workspace path ${shortenHomePath(facts.aliasPath)} now resolves to ` +
-    `${shortenHomePath(facts.currentWorkspacePath)}, but its stored setup state still belongs to ` +
-    shortenHomePath(facts.storedWorkspacePath)
-  );
-}
-
-/**
- * Continuity proof for auto-adoption: every attested generated file must exist
- * in the alias's current target with its recorded hash. Anything less keeps the
- * rebind an explicit operator decision.
- */
-async function attestedHashesMatchCurrentTarget(
-  facts: RepointedWorkspaceAliasFacts,
-): Promise<boolean> {
-  if (facts.storedAttestationHashes.size === 0) {
-    return false;
-  }
-  for (const [filename, sha256] of facts.storedAttestationHashes) {
-    try {
-      const buffer = await fs.promises.readFile(path.join(facts.currentWorkspacePath, filename));
-      if (crypto.createHash("sha256").update(buffer).digest("hex") !== sha256) {
-        return false;
-      }
-    } catch {
-      return false;
-    }
-  }
-  return true;
-}
-
-function findConfiguredStoredTargetOwner(params: {
-  cfg: OpenClawConfig;
-  currentAgentId: string;
-  storedWorkspacePath: string;
-}): WorkspaceAliasScope | undefined {
-  return resolveWorkspaceAliasScopes(params.cfg).find(
-    (scope) =>
-      scope.agentId !== params.currentAgentId &&
-      resolveWorkspaceStateIdentity(scope.workspaceDir).workspacePath ===
-        params.storedWorkspacePath,
-  );
+  return `Workspace path ${shortenHomePath(facts.aliasPath)} now resolves to ${shortenHomePath(facts.currentWorkspacePath)}, but its saved setup records belong to ${shortenHomePath(facts.storedWorkspacePath)}.`;
 }
 
 export type WorkspaceAliasFinding = {
@@ -113,73 +37,99 @@ export type WorkspaceAliasFinding = {
 };
 
 const WORKSPACE_ALIAS_CHECK_ID = "core/doctor/workspace-alias";
+const REPAIR_HINT =
+  "If the same workspace moved, run `openclaw doctor` and confirm the move, or use `openclaw doctor --fix --force`. Otherwise restore the original link or configure the intended workspace directly.";
+const REBIND_MESSAGES: Record<Exclude<WorkspaceAliasRebindOutcome, "rebound">, string> = {
+  "no-repoint": "The alias no longer needs repair.",
+  "repoint-changed":
+    "The workspace changed after inspection. Nothing was transferred; rerun doctor to inspect it again.",
+  "current-target-owns-state":
+    "The destination already owns workspace records. Nothing was merged or deleted. Restore the original link, or configure that destination directly if you intended to switch workspaces.",
+  "original-workspace-exists":
+    "The original workspace still exists. This repair only moves records after the original folder has moved; restore the link if the move was not intended.",
+  "target-directory-missing":
+    "The destination is not an existing directory. Restore the moved folder before repairing the link.",
+  "configured-workspace-conflict":
+    "Another workspace path still refers to the original location. Update the links for the moved workspace, then rerun doctor; no records were transferred.",
+};
 
-/** Read-only findings for `openclaw doctor` preview and health reporting. */
+/** Read-only findings include failed inspection so health cannot report a false success. */
 export function collectRepointedWorkspaceAliasFindings(
   cfg: OpenClawConfig,
 ): WorkspaceAliasFinding[] {
-  return detectRepointedWorkspaceAliasScopes(cfg).map(({ agentId, labelAgent, facts }) => ({
-    checkId: WORKSPACE_ALIAS_CHECK_ID,
-    severity: "warning",
-    message: `${labelAgent ? `Agent "${agentId}": ` : ""}${describeRepointedWorkspaceAlias(facts)}. Inbound messages for this workspace fail until the alias is repaired.`,
-    fixHint:
-      "Run `openclaw doctor` and confirm the rebind, or use `openclaw doctor --fix --force`.",
-  }));
+  const findings: WorkspaceAliasFinding[] = [];
+  for (const workspaceDir of configuredWorkspaceDirs(cfg)) {
+    let message: string;
+    try {
+      const facts = detectRepointedWorkspaceAlias(workspaceDir);
+      if (!facts) {
+        continue;
+      }
+      message = `${describeRepointedWorkspaceAlias(facts)} Incoming messages cannot use this workspace until it is repaired.`;
+    } catch (error) {
+      message = `Workspace alias inspection failed for ${shortenHomePath(workspaceDir)}: ${formatErrorMessage(error)}`;
+    }
+    findings.push({
+      checkId: WORKSPACE_ALIAS_CHECK_ID,
+      severity: "warning",
+      message,
+      fixHint: REPAIR_HINT,
+    });
+  }
+  return findings;
 }
 
-/** Detects repointed workspace aliases and repairs them under doctor's repair flow. */
 export async function maybeRepairRepointedWorkspaceAliases(params: {
   cfg: OpenClawConfig;
   prompter: DoctorPrompter;
 }): Promise<void> {
-  for (const { agentId, workspaceDir, labelAgent, facts } of detectRepointedWorkspaceAliasScopes(
-    params.cfg,
-  )) {
-    const prefix = labelAgent ? `Agent "${agentId}": ` : "";
-    const description = describeRepointedWorkspaceAlias(facts);
-    if (facts.currentTargetHasOwnState) {
-      note(
-        `${prefix}${description}. The current target already has its own workspace state, so doctor cannot rebind without merging two workspaces. Delete one workspace's state first if this repoint was intentional.`,
-        "Workspace",
+  const workspaceDirs = configuredWorkspaceDirs(params.cfg);
+  const configuration = await readConfigFileSnapshot();
+  const verifyConfiguration = async () => {
+    const current = await readConfigFileSnapshot();
+    if (current.readError || !isDeepStrictEqual(current.sourceConfig, configuration.sourceConfig)) {
+      throw new Error(
+        "Workspace configuration changed during repair. No records were transferred; rerun doctor to inspect the current workspace owners.",
       );
-      continue;
     }
-    const configuredOwner = findConfiguredStoredTargetOwner({
-      cfg: params.cfg,
-      currentAgentId: agentId,
-      storedWorkspacePath: facts.storedWorkspacePath,
-    });
-    if (configuredOwner) {
+  };
+  for (const workspaceDir of workspaceDirs) {
+    try {
+      // Earlier repairs can cover another spelling; inspect each scope when used.
+      const facts = detectRepointedWorkspaceAlias(workspaceDir);
+      if (!facts) {
+        continue;
+      }
+      const description = describeRepointedWorkspaceAlias(facts);
+      const inspection = inspectWorkspaceAliasMove(workspaceDir, facts, workspaceDirs);
+      if (inspection.kind === "blocked") {
+        note(`${description} ${REBIND_MESSAGES[inspection.outcome]}`, "Workspace");
+        continue;
+      }
+      const approved = await params.prompter.confirmAggressiveAutoFix({
+        message: `${description} Confirm only if this is the same workspace after a folder move. Transfer its saved setup and file-verification history without changing workspace files?`,
+        initialValue: false,
+      });
+      if (!approved) {
+        note(`${description} No records were transferred. ${REPAIR_HINT}`, "Workspace");
+        continue;
+      }
+      const outcome = await rebindRepointedWorkspaceAlias(
+        workspaceDir,
+        facts,
+        {},
+        workspaceDirs,
+        verifyConfiguration,
+      );
       note(
-        `${prefix}${description}. Agent "${configuredOwner.agentId}" still uses the stored target, so doctor will not transfer its state.`,
+        outcome === "rebound"
+          ? `Rebound workspace state for ${shortenHomePath(facts.aliasPath)} to ${shortenHomePath(facts.currentWorkspacePath)}. Workspace files were not changed.`
+          : `${description} ${REBIND_MESSAGES[outcome]}`,
         "Workspace",
       );
-      continue;
-    }
-    const hashesMatch = await attestedHashesMatchCurrentTarget(facts);
-    // Generated bootstrap templates can corroborate a target, but they do not identify it.
-    const approved = await params.prompter.confirmAggressiveAutoFix({
-      message: hashesMatch
-        ? `${prefix}${description}. Generated template hashes match the current target but do not prove its identity. Rebind the stored state to it?`
-        : `${prefix}${description}. Attested workspace files do NOT verify against the current target. Rebind the stored state to it anyway?`,
-      initialValue: false,
-    });
-    if (!approved) {
+    } catch (error) {
       note(
-        `${prefix}Left the repointed workspace alias in place. Inbound messages for this workspace keep failing until it is repaired.`,
-        "Workspace",
-      );
-      continue;
-    }
-    const outcome = rebindRepointedWorkspaceAlias(workspaceDir, facts);
-    if (outcome === "rebound") {
-      note(
-        `${prefix}Rebound workspace state for ${shortenHomePath(facts.aliasPath)} to ${shortenHomePath(facts.currentWorkspacePath)}.`,
-        "Workspace",
-      );
-    } else {
-      note(
-        `${prefix}Workspace alias rebind for ${shortenHomePath(facts.aliasPath)} was not applied (${outcome}); re-run \`openclaw doctor\` to re-check.`,
+        `Workspace repair was not applied for ${shortenHomePath(workspaceDir)}: ${formatErrorMessage(error)}`,
         "Workspace",
       );
     }

--- a/src/commands/doctor-workspace-alias.ts
+++ b/src/commands/doctor-workspace-alias.ts
@@ -79,7 +79,7 @@ export function collectRepointedWorkspaceAliasFindings(
   return findings;
 }
 
-export async function maybeRepairRepointedWorkspaceAliases(params: {
+async function maybeRepairRepointedWorkspaceAliases(params: {
   cfg: OpenClawConfig;
   prompter: DoctorPrompter;
 }): Promise<void> {

--- a/src/commands/doctor-workspace-alias.ts
+++ b/src/commands/doctor-workspace-alias.ts
@@ -38,7 +38,7 @@ export type WorkspaceAliasFinding = {
 
 const WORKSPACE_ALIAS_CHECK_ID = "core/doctor/workspace-alias";
 const REPAIR_HINT =
-  "If the same workspace moved, run `openclaw doctor` and confirm the move, or use `openclaw doctor --fix --force`. Otherwise restore the original link or configure the intended workspace directly.";
+  "If the same workspace moved, run `openclaw doctor --fix` and confirm the move, or use `openclaw doctor --fix --force`. Otherwise restore the original link or configure the intended workspace directly.";
 const REBIND_MESSAGES: Record<Exclude<WorkspaceAliasRebindOutcome, "rebound">, string> = {
   "no-repoint": "The alias no longer needs repair.",
   "repoint-changed":
@@ -83,6 +83,10 @@ export async function maybeRepairRepointedWorkspaceAliases(params: {
   cfg: OpenClawConfig;
   prompter: DoctorPrompter;
 }): Promise<void> {
+  // Explicit repair acquires Doctor's maintenance owner before any state move.
+  if (!params.prompter.shouldRepair) {
+    return;
+  }
   const workspaceDirs = configuredWorkspaceDirs(params.cfg);
   const configuration = await readConfigFileSnapshot();
   const verifyConfiguration = async () => {
@@ -106,10 +110,16 @@ export async function maybeRepairRepointedWorkspaceAliases(params: {
         note(`${description} ${REBIND_MESSAGES[inspection.outcome]}`, "Workspace");
         continue;
       }
-      const approved = await params.prompter.confirmAggressiveAutoFix({
+      const confirmation = {
         message: `${description} Confirm only if this is the same workspace after a folder move. Transfer its saved setup and file-verification history without changing workspace files?`,
         initialValue: false,
-      });
+      };
+      const approved = params.prompter.shouldForce
+        ? await params.prompter.confirmAggressiveAutoFix(confirmation)
+        : await params.prompter.confirmRuntimeRepair({
+            ...confirmation,
+            requiresInteractiveConfirmation: true,
+          });
       if (!approved) {
         note(`${description} No records were transferred. ${REPAIR_HINT}`, "Workspace");
         continue;
@@ -134,4 +144,27 @@ export async function maybeRepairRepointedWorkspaceAliases(params: {
       );
     }
   }
+}
+
+/** Stop migration discovery if its workspace owner still needs an operator decision. */
+export function createWorkspaceAliasMigrationRepair(
+  prompter: DoctorPrompter | undefined,
+  beforePrompt: () => void,
+): ((cfg: OpenClawConfig) => Promise<void>) | undefined {
+  if (!prompter?.shouldRepair) {
+    return undefined;
+  }
+  return async (cfg) => {
+    if (collectRepointedWorkspaceAliasFindings(cfg).length === 0) {
+      return;
+    }
+    beforePrompt();
+    await maybeRepairRepointedWorkspaceAliases({ cfg, prompter });
+    const unresolved = collectRepointedWorkspaceAliasFindings(cfg);
+    if (unresolved.length > 0) {
+      throw new Error(
+        unresolved.map((finding) => `${finding.message} ${finding.fixHint}`).join("\n"),
+      );
+    }
+  };
 }

--- a/src/flows/doctor-health-contribution-runners.workspace.ts
+++ b/src/flows/doctor-health-contribution-runners.workspace.ts
@@ -130,9 +130,16 @@ export async function runWorkspaceStatusHealth(ctx: DoctorHealthFlowContext): Pr
 }
 
 export async function runWorkspaceAliasHealth(ctx: DoctorHealthFlowContext): Promise<void> {
-  const { maybeRepairRepointedWorkspaceAliases } =
+  const { collectRepointedWorkspaceAliasFindings } =
     await import("../commands/doctor-workspace-alias.js");
-  await maybeRepairRepointedWorkspaceAliases({ cfg: ctx.cfg, prompter: ctx.prompter });
+  const findings = collectRepointedWorkspaceAliasFindings(ctx.cfg);
+  if (findings.length > 0) {
+    const { note } = await import("../../packages/terminal-core/src/note.js");
+    note(
+      findings.map((finding) => `${finding.message} ${finding.fixHint}`).join("\n"),
+      "Workspace",
+    );
+  }
 }
 
 export async function runSkillsHealth(ctx: DoctorHealthFlowContext): Promise<void> {

--- a/src/flows/doctor-health-contribution-runners.workspace.ts
+++ b/src/flows/doctor-health-contribution-runners.workspace.ts
@@ -129,6 +129,12 @@ export async function runWorkspaceStatusHealth(ctx: DoctorHealthFlowContext): Pr
   });
 }
 
+export async function runWorkspaceAliasHealth(ctx: DoctorHealthFlowContext): Promise<void> {
+  const { maybeRepairRepointedWorkspaceAliases } =
+    await import("../commands/doctor-workspace-alias.js");
+  await maybeRepairRepointedWorkspaceAliases({ cfg: ctx.cfg, prompter: ctx.prompter });
+}
+
 export async function runSkillsHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { maybeRepairSkillReadiness } = await import("../commands/doctor-skills.js");
   ctx.cfg = await maybeRepairSkillReadiness({

--- a/src/flows/doctor-health-contributions-final.ts
+++ b/src/flows/doctor-health-contributions-final.ts
@@ -31,6 +31,7 @@ import {
   runMemorySearchHealthContribution,
   runSkillsHealth,
   runToolsMdMigrationHealth,
+  runWorkspaceAliasHealth,
   runWorkspaceStatusHealth,
   runWorkspaceSuggestionsHealth,
 } from "./doctor-health-contribution-runners.workspace.js";
@@ -266,6 +267,21 @@ export function resolveFinalDoctorHealthContributions(params: {
           }),
         ]
       : []),
+    createDoctorHealthContribution({
+      id: "doctor:workspace-alias",
+      label: "Workspace alias",
+      healthChecks: {
+        description:
+          "Persisted workspace aliases must resolve to the canonical target that owns their stored state.",
+        defaultEnabled: true,
+        async detect(ctx) {
+          const { collectRepointedWorkspaceAliasFindings } =
+            await import("../commands/doctor-workspace-alias.js");
+          return collectRepointedWorkspaceAliasFindings(ctx.cfg);
+        },
+      },
+      run: runWorkspaceAliasHealth,
+    }),
     createDoctorHealthContribution({
       id: "doctor:skills",
       label: "Skills",

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -1567,6 +1567,7 @@ type LegacyStateMigrationExecutionPlan = {
   pluginStateMigrationInventory?: PluginDoctorStateMigrationInventory;
   deferPostSessionPluginMigrations?: boolean;
   legacySessionSurfaces: PreparedLegacySessionSurfaces;
+  beforeWorkspaceStateMigration?: (config: OpenClawConfig) => Promise<void>;
 };
 
 function buildLegacyStateMigrationSteps(
@@ -1992,7 +1993,17 @@ function buildLegacyStateMigrationSteps(
     : undefined;
   const finalSteps: LegacyStateMigrationStep[] = [
     ownerStep("restart-sentinel", detected.restartSentinel, migrateLegacyRestartSentinel),
-    ownerStep("workspace-state", detected.workspace, migrateLegacyWorkspaceState),
+    {
+      ...ownerStep("workspace-state", detected.workspace, async (options) => {
+        // Shared/agent schemas are ready here. Repair alias ownership before
+        // carried legacy files can be imported under the wrong workspace key.
+        if (isDoctor) {
+          await params.beforeWorkspaceStateMigration?.(params.sessionConfig ?? params.config);
+        }
+        return migrateLegacyWorkspaceState(options);
+      }),
+      runWithoutFileDetection: isDoctor && params.beforeWorkspaceStateMigration !== undefined,
+    },
     ...doctorFinalSteps,
     {
       // Workspace attestations must settle before Workshop relocation can retire them.
@@ -3000,6 +3011,7 @@ export async function autoMigrateLegacyState(params: {
   allowLegacyDeviceIdentityImport?: boolean;
   legacySessionSurfaces?: PreparedLegacySessionSurfaces;
   onStepReceipt?: (receipt: LegacyStateMigrationStepReceipt) => void;
+  beforeWorkspaceStateMigration?: (config: OpenClawConfig) => Promise<void>;
 }): Promise<{
   mode: LegacyStateMigrationMode;
   migrated: boolean;
@@ -3227,6 +3239,7 @@ async function executeLegacyStateMigrations(
       allowLegacyDeviceIdentityImport: params.allowLegacyDeviceIdentityImport,
       pluginStateMigrationInventory,
       legacySessionSurfaces,
+      beforeWorkspaceStateMigration: params.beforeWorkspaceStateMigration,
     }).filter((step) => step.id !== "state-schema" && step.id !== "plugin-install-index");
     return steps;
   };

--- a/src/infra/state-migrations.workspace-move-order.test.ts
+++ b/src/infra/state-migrations.workspace-move-order.test.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  detectRepointedWorkspaceAlias,
+  rebindRepointedWorkspaceAlias,
+} from "../agents/workspace-alias-rebind.js";
+import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-identity.js";
+import { readWorkspaceStateSnapshot } from "../agents/workspace-state-store.js";
+import { EMPTY_LEGACY_SESSION_SURFACES } from "../plugins/legacy-session-surfaces.types.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { autoMigrateLegacyState } from "./state-migrations.doctor.js";
+import { readReceipt } from "./state-migrations.workspace-setup-receipts.js";
+import { useWorkspaceMigrationTestFixture } from "./state-migrations.workspace-setup.test-support.js";
+
+describe("Doctor workspace move ordering", () => {
+  const { setup, detect, migrate } = useWorkspaceMigrationTestFixture();
+
+  it("repairs the workspace owner before importing a carried legacy setup generation", async () => {
+    const context = setup();
+    const alias = path.join(context.homeDir, "workspace-alias");
+    const moved = path.join(context.homeDir, "moved-workspace");
+    const symlinkType = process.platform === "win32" ? "junction" : "dir";
+    fs.symlinkSync(context.workspaceDir, alias, symlinkType);
+    const configured = {
+      ...context,
+      cfg: {
+        agents: { entries: { main: { workspace: alias } } },
+        plugins: { enabled: false },
+      },
+      workspaceDir: alias,
+    };
+    const milestones = {
+      version: 1,
+      bootstrapSeededAt: "2026-07-15T10:00:00.000Z",
+      setupCompletedAt: "2026-07-15T10:01:00.000Z",
+    };
+    const raw = JSON.stringify(milestones);
+    const sourceName = "openclaw-workspace-state.json";
+    fs.writeFileSync(path.join(context.workspaceDir, sourceName), raw);
+    const source = detect(configured).sources.find((entry) => entry.kind === "setup")!;
+    expect((await migrate(configured)).warnings).toEqual([]);
+    expect(readReceipt(source, context.env)?.removedSource).toBe(true);
+
+    fs.renameSync(context.workspaceDir, moved);
+    fs.unlinkSync(alias);
+    fs.symlinkSync(moved, alias, symlinkType);
+    const carriedSource = path.join(moved, sourceName);
+    fs.writeFileSync(carriedSource, raw);
+
+    try {
+      const result = await autoMigrateLegacyState({
+        cfg: configured.cfg,
+        env: context.env,
+        homedir: () => context.homeDir,
+        doctorOnlyStateMigrations: true,
+        legacySessionSurfaces: EMPTY_LEGACY_SESSION_SURFACES,
+        beforeWorkspaceStateMigration: async () => {
+          const facts = detectRepointedWorkspaceAlias(alias, { env: context.env })!;
+          expect(await rebindRepointedWorkspaceAlias(alias, facts, { env: context.env })).toBe(
+            "rebound",
+          );
+        },
+      });
+
+      expect(result.warnings).toEqual([]);
+      expect(fs.existsSync(carriedSource)).toBe(false);
+      expect(fs.existsSync(`${carriedSource}.doctor-importing`)).toBe(false);
+      const identity = resolveWorkspaceStateIdentity(moved);
+      expect(readWorkspaceStateSnapshot(alias, { env: context.env })).toMatchObject({
+        identity,
+        setup: milestones,
+      });
+      expect(
+        readReceipt(
+          {
+            ...source,
+            sourcePath: path.join(identity.workspacePath, sourceName),
+            workspaceDir: identity.workspacePath,
+            workspaceKey: identity.workspaceKey,
+          },
+          context.env,
+        )?.removedSource,
+      ).toBe(true);
+    } finally {
+      closeOpenClawAgentDatabasesForTest();
+    }
+  });
+});

--- a/src/infra/state-migrations.workspace-move.test.ts
+++ b/src/infra/state-migrations.workspace-move.test.ts
@@ -1,0 +1,134 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  detectRepointedWorkspaceAlias,
+  rebindRepointedWorkspaceAlias,
+} from "../agents/workspace-alias-rebind.js";
+import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-identity.js";
+import { readWorkspaceStateSnapshot } from "../agents/workspace-state-store.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { readReceipt } from "./state-migrations.workspace-setup-receipts.js";
+import { migrateLegacyWorkspaceState } from "./state-migrations.workspace-setup.js";
+import { useWorkspaceMigrationTestFixture } from "./state-migrations.workspace-setup.test-support.js";
+
+describe("workspace move migration recovery", () => {
+  const { setup, detect, migrate } = useWorkspaceMigrationTestFixture();
+
+  it.each([
+    { interrupted: false, removeBackup: false },
+    { interrupted: true, removeBackup: false },
+    { interrupted: false, removeBackup: true },
+  ])(
+    "preserves migration history after a move (interrupted: $interrupted, removed backup: $removeBackup)",
+    async ({ interrupted, removeBackup }) => {
+      const context = setup();
+      const alias = path.join(context.homeDir, "workspace-alias");
+      const moved = path.join(context.homeDir, "moved-workspace");
+      const link = () =>
+        fs.symlinkSync(
+          fs.existsSync(moved) ? moved : context.workspaceDir,
+          alias,
+          process.platform === "win32" ? "junction" : "dir",
+        );
+      link();
+      const configured = {
+        ...context,
+        cfg: { agents: { defaults: { workspace: alias } } },
+        workspaceDir: alias,
+      };
+      const milestones = {
+        version: 1,
+        bootstrapSeededAt: "2026-07-15T10:00:00.000Z",
+        setupCompletedAt: "2026-07-15T10:01:00.000Z",
+      };
+      const raw = JSON.stringify(milestones);
+      const sourcePath = path.join(context.workspaceDir, "openclaw-workspace-state.json");
+      fs.writeFileSync(sourcePath, raw);
+      const detected = detect(configured);
+      const source = detected.sources.find((entry) => entry.kind === "setup")!;
+      const imported = await migrateLegacyWorkspaceState({
+        detected,
+        env: context.env,
+        stateDir: context.stateDir,
+        ...(interrupted
+          ? {
+              removeSource: () => {
+                throw new Error("interrupted cleanup");
+              },
+            }
+          : {}),
+      });
+      expect(imported.warnings).toHaveLength(interrupted ? 1 : 0);
+      const originalReceipt = readReceipt(source, context.env)!;
+      expect(originalReceipt.removedSource).toBe(!interrupted);
+      if (removeBackup) {
+        fs.unlinkSync(originalReceipt.archivePath!);
+      }
+      const { db } = openOpenClawStateDatabase({ env: context.env });
+      const runs = db.prepare("SELECT * FROM migration_runs ORDER BY id").all();
+
+      fs.renameSync(context.workspaceDir, moved);
+      fs.unlinkSync(alias);
+      link();
+      const facts = detectRepointedWorkspaceAlias(alias, { env: context.env })!;
+      expect(await rebindRepointedWorkspaceAlias(alias, facts, { env: context.env })).toBe(
+        "rebound",
+      );
+
+      const identity = resolveWorkspaceStateIdentity(moved);
+      const movedSource = {
+        ...source,
+        sourcePath: path.join(identity.workspacePath, "openclaw-workspace-state.json"),
+        rootDir: identity.workspacePath,
+        workspaceDir: identity.workspacePath,
+        workspaceKey: identity.workspaceKey,
+      };
+      const receipt = readReceipt(movedSource, context.env);
+      expect(receipt).toMatchObject({
+        sha256: originalReceipt.sha256,
+        removedSource: !interrupted,
+        archivePath: expect.stringContaining(identity.workspacePath),
+      });
+      expect(fs.existsSync(receipt!.archivePath!)).toBe(!removeBackup);
+      if (!removeBackup) {
+        expect(fs.readFileSync(receipt!.archivePath!, "utf8")).toBe(raw);
+      }
+      expect(db.prepare("SELECT * FROM migration_runs ORDER BY id").all()).toEqual(runs);
+      expect(readWorkspaceStateSnapshot(alias).setup).toEqual(milestones);
+      const row = db
+        .prepare("SELECT report_json FROM migration_sources WHERE source_key = ?")
+        .get(receipt!.sourceKey)!;
+      expect(JSON.parse(String(row.report_json))).toMatchObject({
+        authoritative: true,
+        canonicalFingerprint: createHash("sha256")
+          .update(
+            JSON.stringify({
+              kind: "setup",
+              workspacePath: identity.workspacePath,
+              version: 1,
+              bootstrapSeededAt: milestones.bootstrapSeededAt,
+              setupCompletedAt: milestones.setupCompletedAt,
+            }),
+          )
+          .digest("hex"),
+      });
+
+      expect((await migrate(configured)).warnings).toEqual([]);
+      expect(readReceipt(movedSource, context.env)?.removedSource).toBe(true);
+      expect(fs.existsSync(`${movedSource.sourcePath}.doctor-importing`)).toBe(false);
+      expect(fs.existsSync(receipt!.archivePath!)).toBe(!removeBackup);
+
+      // A removed source may have a later generation. The moved receipt must
+      // preserve that distinction without replaying its replacement milestones.
+      fs.writeFileSync(
+        movedSource.sourcePath,
+        JSON.stringify({ setupCompletedAt: "2026-07-16T00:00:00.000Z" }),
+      );
+      expect((await migrate(configured)).warnings).toEqual([]);
+      expect(readWorkspaceStateSnapshot(alias).setup).toEqual(milestones);
+      expect(readReceipt(movedSource, context.env)?.removedSource).toBe(true);
+    },
+  );
+});

--- a/src/infra/state-migrations.workspace-move.test.ts
+++ b/src/infra/state-migrations.workspace-move.test.ts
@@ -17,15 +17,22 @@ describe("workspace move migration recovery", () => {
   const { setup, detect, migrate } = useWorkspaceMigrationTestFixture();
 
   it.each([
-    { interrupted: false, removeBackup: false },
-    { interrupted: true, removeBackup: false },
-    { interrupted: false, removeBackup: true },
+    { interrupted: false, removeBackup: false, decomposed: false, originalDecomposed: false },
+    { interrupted: true, removeBackup: false, decomposed: false, originalDecomposed: false },
+    { interrupted: false, removeBackup: true, decomposed: false, originalDecomposed: false },
+    { interrupted: false, removeBackup: false, decomposed: true, originalDecomposed: false },
+    { interrupted: false, removeBackup: false, decomposed: false, originalDecomposed: true },
   ])(
-    "preserves migration history after a move (interrupted: $interrupted, removed backup: $removeBackup)",
-    async ({ interrupted, removeBackup }) => {
+    "preserves migration history after a move (interrupted: $interrupted, removed backup: $removeBackup, decomposed: $decomposed, original decomposed: $originalDecomposed)",
+    async ({ interrupted, removeBackup, decomposed, originalDecomposed }) => {
       const context = setup();
+      if (originalDecomposed) {
+        const original = path.join(context.homeDir, "original-e\u0301");
+        fs.renameSync(context.workspaceDir, original);
+        context.workspaceDir = original;
+      }
       const alias = path.join(context.homeDir, "workspace-alias");
-      const moved = path.join(context.homeDir, "moved-workspace");
+      const moved = path.join(context.homeDir, decomposed ? "moved-e\u0301" : "moved-workspace");
       const link = () =>
         fs.symlinkSync(
           fs.existsSync(moved) ? moved : context.workspaceDir,
@@ -80,8 +87,8 @@ describe("workspace move migration recovery", () => {
       const identity = resolveWorkspaceStateIdentity(moved);
       const movedSource = {
         ...source,
-        sourcePath: path.join(identity.workspacePath, "openclaw-workspace-state.json"),
-        rootDir: identity.workspacePath,
+        sourcePath: path.join(moved, "openclaw-workspace-state.json"),
+        rootDir: moved,
         workspaceDir: identity.workspacePath,
         workspaceKey: identity.workspaceKey,
       };
@@ -89,7 +96,7 @@ describe("workspace move migration recovery", () => {
       expect(receipt).toMatchObject({
         sha256: originalReceipt.sha256,
         removedSource: !interrupted,
-        archivePath: expect.stringContaining(identity.workspacePath),
+        archivePath: expect.stringContaining(moved),
       });
       expect(fs.existsSync(receipt!.archivePath!)).toBe(!removeBackup);
       if (!removeBackup) {

--- a/src/infra/state-migrations.workspace-setup-receipts.test.ts
+++ b/src/infra/state-migrations.workspace-setup-receipts.test.ts
@@ -1,0 +1,255 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  createWorkspaceStateIdentity,
+  resolveWorkspaceStateIdentity,
+} from "../agents/workspace-state-identity.js";
+import {
+  WORKSPACE_CONTENT_RELOCATION_MIGRATION_KIND,
+  WORKSPACE_LEGACY_STATE_MIGRATION_KIND,
+} from "../agents/workspace-state-store.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
+import {
+  recordLegacyMigrationReceipt,
+  resolveLegacyMigrationSourceKey,
+} from "./state-migrations.receipts.js";
+import {
+  applyWorkspaceMigrationReceiptMove,
+  createWorkspaceSetupFingerprint,
+  prepareWorkspaceMigrationReceiptMove,
+} from "./state-migrations.workspace-setup-receipts.js";
+import { useWorkspaceMigrationTestFixture } from "./state-migrations.workspace-setup.test-support.js";
+
+describe("workspace migration receipt move", () => {
+  const { setup } = useWorkspaceMigrationTestFixture();
+
+  function fixture() {
+    const context = setup();
+    const storedIdentity = resolveWorkspaceStateIdentity(context.workspaceDir);
+    const currentIdentity = createWorkspaceStateIdentity(
+      path.join(path.dirname(storedIdentity.workspacePath), "moved-workspace"),
+    );
+    fs.renameSync(context.workspaceDir, currentIdentity.workspacePath);
+    const { db } = openOpenClawStateDatabase({ env: context.env });
+    const storedSetup = {
+      version: 1,
+      workspace_path: storedIdentity.workspacePath,
+      bootstrap_seeded_at: "2026-07-15T10:00:00.000Z",
+      setup_completed_at: "2026-07-15T10:01:00.000Z",
+    };
+    const sourcePath = path.join(storedIdentity.workspacePath, "openclaw-workspace-state.json");
+    const receipt = {
+      sourceKey: resolveLegacyMigrationSourceKey(
+        "workspace-setup",
+        sourcePath,
+        storedIdentity.workspaceKey,
+      ),
+      migrationKind: WORKSPACE_LEGACY_STATE_MIGRATION_KIND,
+      sourcePath,
+      targetTable: "workspace_setup_state",
+      sourceSha256: "a".repeat(64),
+      sourceSizeBytes: 10,
+      sourceRecordCount: 1,
+      runId: "setup-import",
+      now: 1000,
+      reportJson: JSON.stringify({
+        sourceKind: "setup",
+        workspaceKey: storedIdentity.workspaceKey,
+        canonicalFingerprint: createWorkspaceSetupFingerprint(storedSetup),
+        authoritative: true,
+        resolution: "inserted",
+      }),
+    };
+    runOpenClawStateWriteTransaction(
+      ({ db: writeDatabase }) => {
+        recordLegacyMigrationReceipt(writeDatabase, receipt);
+        writeDatabase
+          .prepare("UPDATE migration_sources SET removed_source = 1 WHERE source_key = ?")
+          .run(receipt.sourceKey);
+      },
+      { env: context.env },
+    );
+    const params = { database: db, storedIdentity, currentIdentity, storedSetup };
+    const rows = () => db.prepare("SELECT * FROM migration_sources ORDER BY source_key").all();
+    return { ...context, ...params, db, receipt, params, rows };
+  }
+
+  it.each(["changed", "added", "destination collision"] as const)(
+    "refuses %s receipts without applying a partial move",
+    async (change) => {
+      const value = fixture();
+      const plan = await prepareWorkspaceMigrationReceiptMove(value.params);
+      if (change === "changed") {
+        value.db
+          .prepare("UPDATE migration_sources SET removed_source = 0 WHERE source_key = ?")
+          .run(value.receipt.sourceKey);
+      } else {
+        const sourcePath =
+          change === "added"
+            ? path.join(value.storedIdentity.workspacePath, ".openclaw", "workspace-state.json")
+            : path.join(value.currentIdentity.workspacePath, "openclaw-workspace-state.json");
+        const owner = change === "added" ? value.storedIdentity : value.currentIdentity;
+        runOpenClawStateWriteTransaction(
+          ({ db }) =>
+            recordLegacyMigrationReceipt(db, {
+              ...value.receipt,
+              sourcePath,
+              sourceKey: resolveLegacyMigrationSourceKey(
+                "workspace-setup",
+                sourcePath,
+                owner.workspaceKey,
+              ),
+              runId: "concurrent-import",
+              reportJson: JSON.stringify({
+                ...JSON.parse(value.receipt.reportJson),
+                workspaceKey: owner.workspaceKey,
+              }),
+            }),
+          { env: value.env },
+        );
+      }
+      const before = value.rows();
+      expect(() =>
+        runOpenClawStateWriteTransaction(
+          ({ db }) => {
+            db.prepare("UPDATE migration_runs SET status = 'moving' WHERE id = ?").run(
+              value.receipt.runId,
+            );
+            applyWorkspaceMigrationReceiptMove(db, plan);
+          },
+          { env: value.env },
+        ),
+      ).toThrow("migration history changed");
+      expect(value.rows()).toEqual(before);
+      expect(
+        value.db.prepare("SELECT status FROM migration_runs WHERE id = ?").get(value.receipt.runId),
+      ).toEqual({ status: "completed" });
+    },
+  );
+
+  it.each(["prepared", "completed", "superseded"])(
+    "keeps %s skill-relocation evidence under its lifecycle owner",
+    async (status) => {
+      const value = fixture();
+      const sourceKey = resolveLegacyMigrationSourceKey(
+        WORKSPACE_CONTENT_RELOCATION_MIGRATION_KIND,
+        value.storedIdentity.workspacePath,
+      );
+      const report = {
+        ...value.storedIdentity,
+        workspaceDir: value.storedIdentity.workspacePath,
+        directoryIdentity: "1:2:3",
+        attestedAtMs: 1000,
+        moves: [
+          {
+            source: path.join(value.storedIdentity.workspacePath, "skills", "local-skill"),
+            destination: path.join(value.homeDir, "workshop"),
+            sha256: "b".repeat(64),
+          },
+        ],
+      };
+      runOpenClawStateWriteTransaction(
+        ({ db }) => {
+          recordLegacyMigrationReceipt(db, {
+            ...value.receipt,
+            sourceKey,
+            sourcePath: value.storedIdentity.workspacePath,
+            migrationKind: WORKSPACE_CONTENT_RELOCATION_MIGRATION_KIND,
+            runId: "skill-relocation",
+            reportJson: JSON.stringify(report),
+          });
+          db.prepare("UPDATE migration_sources SET status = ? WHERE source_key = ?").run(
+            status,
+            sourceKey,
+          );
+        },
+        { env: value.env },
+      );
+      const before = value.rows();
+      const runs = value.db.prepare("SELECT * FROM migration_runs ORDER BY id").all();
+      if (status === "prepared") {
+        await expect(prepareWorkspaceMigrationReceiptMove(value.params)).rejects.toThrow(
+          "relocation is still pending",
+        );
+        expect(value.rows()).toEqual(before);
+        return;
+      }
+      const plan = await prepareWorkspaceMigrationReceiptMove(value.params);
+      runOpenClawStateWriteTransaction(({ db }) => applyWorkspaceMigrationReceiptMove(db, plan), {
+        env: value.env,
+      });
+      const moved = value.db
+        .prepare(
+          "SELECT status, removed_source, report_json FROM migration_sources WHERE migration_kind = ?",
+        )
+        .get(WORKSPACE_CONTENT_RELOCATION_MIGRATION_KIND)!;
+      expect(moved.status).toBe(status);
+      expect(moved.removed_source).toBe(0);
+      expect(JSON.parse(String(moved.report_json))).toEqual({
+        ...report,
+        workspaceKey: value.currentIdentity.workspaceKey,
+      });
+      expect(value.db.prepare("SELECT * FROM migration_runs ORDER BY id").all()).toEqual(runs);
+    },
+  );
+
+  it("preserves an old unmatched fingerprint instead of granting it current authority", async () => {
+    const value = fixture();
+    const historical = {
+      ...JSON.parse(value.receipt.reportJson),
+      canonicalFingerprint: "b".repeat(64),
+    };
+    value.db
+      .prepare("UPDATE migration_sources SET report_json = ? WHERE source_key = ?")
+      .run(JSON.stringify(historical), value.receipt.sourceKey);
+    const plan = await prepareWorkspaceMigrationReceiptMove(value.params);
+    runOpenClawStateWriteTransaction(({ db }) => applyWorkspaceMigrationReceiptMove(db, plan), {
+      env: value.env,
+    });
+    expect(JSON.parse(String(value.rows()[0]!.report_json))).toMatchObject({
+      canonicalFingerprint: historical.canonicalFingerprint,
+      authoritative: true,
+    });
+  });
+
+  it.each(["unfinished", "reappeared"])(
+    "refuses an %s external source without losing its cleanup evidence",
+    async (kind) => {
+      const value = fixture();
+      const sourcePath = path.join(
+        value.stateDir,
+        "workspace-attestations",
+        `${value.storedIdentity.workspaceKey}.attested`,
+      );
+      const sourceKey = resolveLegacyMigrationSourceKey(
+        "workspace-attestation",
+        sourcePath,
+        value.storedIdentity.workspaceKey,
+      );
+      value.db
+        .prepare(
+          "UPDATE migration_sources SET source_key = ?, source_path = ?, removed_source = ?, report_json = ? WHERE source_key = ?",
+        )
+        .run(
+          sourceKey,
+          sourcePath,
+          kind === "unfinished" ? 0 : 1,
+          JSON.stringify({ ...JSON.parse(value.receipt.reportJson), sourceKind: "attestation" }),
+          value.receipt.sourceKey,
+        );
+      if (kind === "reappeared") {
+        fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+        fs.writeFileSync(`${sourcePath}.doctor-importing`, "retained claim");
+      }
+      const before = value.rows();
+      await expect(prepareWorkspaceMigrationReceiptMove(value.params)).rejects.toThrow(
+        "external legacy source has not finished cleanup",
+      );
+      expect(value.rows()).toEqual(before);
+    },
+  );
+});

--- a/src/infra/state-migrations.workspace-setup-receipts.test.ts
+++ b/src/infra/state-migrations.workspace-setup-receipts.test.ts
@@ -73,7 +73,13 @@ describe("workspace migration receipt move", () => {
       },
       { env: context.env },
     );
-    const params = { database: db, storedIdentity, currentIdentity, storedSetup };
+    const params = {
+      database: db,
+      storedIdentity,
+      currentIdentity,
+      storedSetup,
+      currentDirectoryPath: currentIdentity.workspacePath,
+    };
     const rows = () => db.prepare("SELECT * FROM migration_sources ORDER BY source_key").all();
     return { ...context, ...params, db, receipt, params, rows };
   }

--- a/src/infra/state-migrations.workspace-setup-receipts.ts
+++ b/src/infra/state-migrations.workspace-setup-receipts.ts
@@ -91,12 +91,19 @@ function receiptMoveFailure(sourcePath: string, reason: string): Error {
 function moveWorkspacePath(
   value: string,
   storedIdentity: WorkspaceStateIdentity,
-  currentIdentity: WorkspaceStateIdentity,
+  currentDirectoryPath: string,
 ): string {
-  const relative = path.relative(storedIdentity.workspacePath, value);
-  return relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative)
-    ? path.join(currentIdentity.workspacePath, relative)
-    : value;
+  const sourceParts = path.resolve(value).split(path.sep);
+  const relative = path.relative(
+    storedIdentity.workspacePath,
+    path.resolve(value).normalize("NFC"),
+  );
+  if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    return value;
+  }
+  // Keys use NFC, but backup/source filenames must retain their filesystem bytes.
+  const depth = relative.split(path.sep).filter(Boolean).length;
+  return path.join(currentDirectoryPath, ...sourceParts.slice(sourceParts.length - depth));
 }
 
 function readWorkspaceMoveReceipts(
@@ -204,8 +211,9 @@ export async function prepareWorkspaceMigrationReceiptMove(params: {
   storedIdentity: WorkspaceStateIdentity;
   currentIdentity: WorkspaceStateIdentity;
   storedSetup: (WorkspaceSetupMilestones & { version: number | null }) | undefined;
+  currentDirectoryPath: string;
 }): Promise<WorkspaceMigrationReceiptMove> {
-  const { database, storedIdentity, currentIdentity, storedSetup } = params;
+  const { database, storedIdentity, currentIdentity, storedSetup, currentDirectoryPath } = params;
   const receipts = readWorkspaceMoveReceipts(database, storedIdentity, currentIdentity);
   const plan: WorkspaceMigrationReceiptMove = {
     storedIdentity,
@@ -230,7 +238,7 @@ export async function prepareWorkspaceMigrationReceiptMove(params: {
     if (!path.isAbsolute(receipt.source_path)) {
       throw receiptMoveFailure(receipt.source_path, "the migration source path is invalid");
     }
-    const sourcePath = moveWorkspacePath(receipt.source_path, storedIdentity, currentIdentity);
+    const sourcePath = moveWorkspacePath(receipt.source_path, storedIdentity, currentDirectoryPath);
     const movedReport: Record<string, unknown> = {
       ...report,
       workspaceKey: currentIdentity.workspaceKey,
@@ -297,7 +305,7 @@ export async function prepareWorkspaceMigrationReceiptMove(params: {
         }
         if (sourceExists || claimExists) {
           await verifyCarriedReceiptFile(
-            currentIdentity.workspacePath,
+            currentDirectoryPath,
             sourceExists ? sourcePath : claimPath,
             receipt.source_sha256,
           );
@@ -317,13 +325,13 @@ export async function prepareWorkspaceMigrationReceiptMove(params: {
         if (typeof report.archivePath !== "string" || !path.isAbsolute(report.archivePath)) {
           throw receiptMoveFailure(receipt.source_path, "the setup backup path is invalid");
         }
-        const archivePath = moveWorkspacePath(report.archivePath, storedIdentity, currentIdentity);
+        const archivePath = moveWorkspacePath(
+          report.archivePath,
+          storedIdentity,
+          currentDirectoryPath,
+        );
         if (archivePath !== report.archivePath && receipt.removed_source !== 1) {
-          await verifyCarriedReceiptFile(
-            currentIdentity.workspacePath,
-            archivePath,
-            receipt.source_sha256,
-          );
+          await verifyCarriedReceiptFile(currentDirectoryPath, archivePath, receipt.source_sha256);
         }
         movedReport.archivePath = archivePath;
       }

--- a/src/infra/state-migrations.workspace-setup-receipts.ts
+++ b/src/infra/state-migrations.workspace-setup-receipts.ts
@@ -1,5 +1,25 @@
 // Receipt lookup and source-removal bookkeeping for legacy workspace migration.
+import { createHash } from "node:crypto";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { isDeepStrictEqual } from "node:util";
+import { root } from "@openclaw/fs-safe";
 import { safeParseJsonRecord } from "@openclaw/normalization-core/json-coercion";
+import { WORKSPACE_DOCTOR_CLAIM_SUFFIX } from "../agents/workspace-legacy-state.js";
+import type { WorkspaceStateIdentity } from "../agents/workspace-state-identity.js";
+import {
+  WORKSPACE_CONTENT_RELOCATION_MIGRATION_KIND,
+  WORKSPACE_LEGACY_STATE_MIGRATION_KIND,
+  WORKSPACE_SETUP_STATE_VERSION,
+} from "../agents/workspace-state-store.js";
+import type { DB } from "../state/openclaw-state-db.generated.js";
+import { formatErrorMessage } from "./errors.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "./kysely-sync.js";
+import { pathMayExistSync } from "./path-existence.js";
 import {
   readLegacyMigrationReceipt,
   resolveLegacyMigrationSourceKey,
@@ -14,6 +34,26 @@ export type MigrationReceipt = {
   removedSource: boolean;
   archivePath?: string;
 };
+
+type WorkspaceSetupMilestones = {
+  workspace_path: string | null;
+  bootstrap_seeded_at: string | null;
+  setup_completed_at: string | null;
+};
+
+export function createWorkspaceSetupFingerprint(setup: WorkspaceSetupMilestones): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        kind: "setup",
+        workspacePath: setup.workspace_path,
+        version: WORKSPACE_SETUP_STATE_VERSION,
+        bootstrapSeededAt: setup.bootstrap_seeded_at,
+        setupCompletedAt: setup.setup_completed_at,
+      }),
+    )
+    .digest("hex");
+}
 
 export function resolveWorkspaceMigrationSourceKey(source: LegacyWorkspaceStateSource): string {
   return resolveLegacyMigrationSourceKey(
@@ -37,4 +77,294 @@ export function readReceipt(
         ...(typeof archivePath === "string" ? { archivePath } : {}),
       }
     : null;
+}
+
+type WorkspaceReceiptDatabase = Pick<DB, "migration_sources">;
+
+function receiptMoveFailure(sourcePath: string, reason: string): Error {
+  return new Error(
+    `Cannot move workspace migration history at ${sourcePath}: ${reason}. ` +
+      "Preserve the workspace and database, finish or repair the pending migration with openclaw doctor --fix, then retry the workspace move.",
+  );
+}
+
+function moveWorkspacePath(
+  value: string,
+  storedIdentity: WorkspaceStateIdentity,
+  currentIdentity: WorkspaceStateIdentity,
+): string {
+  const relative = path.relative(storedIdentity.workspacePath, value);
+  return relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative)
+    ? path.join(currentIdentity.workspacePath, relative)
+    : value;
+}
+
+function readWorkspaceMoveReceipts(
+  database: DatabaseSync,
+  storedIdentity: WorkspaceStateIdentity,
+  currentIdentity: WorkspaceStateIdentity,
+) {
+  return executeSqliteQuerySync(
+    database,
+    getNodeSqliteKysely<WorkspaceReceiptDatabase>(database)
+      .selectFrom("migration_sources")
+      .selectAll()
+      .where("migration_kind", "in", [
+        WORKSPACE_LEGACY_STATE_MIGRATION_KIND,
+        WORKSPACE_CONTENT_RELOCATION_MIGRATION_KIND,
+      ])
+      .orderBy("source_key", "asc"),
+  ).rows.filter((row) => {
+    const report = safeParseJsonRecord(row.report_json);
+    const associated = [storedIdentity, currentIdentity].some((identity) =>
+      row.migration_kind === WORKSPACE_LEGACY_STATE_MIGRATION_KIND
+        ? ["setup", "attestation"].some(
+            (kind) =>
+              row.source_key ===
+              resolveLegacyMigrationSourceKey(
+                `workspace-${kind}`,
+                row.source_path,
+                identity.workspaceKey,
+              ),
+          )
+        : row.source_path === identity.workspacePath,
+    );
+    if (associated && !report) {
+      throw receiptMoveFailure(row.source_path, "the migration report is unreadable");
+    }
+    return (
+      associated ||
+      report?.workspaceKey === storedIdentity.workspaceKey ||
+      report?.workspaceKey === currentIdentity.workspaceKey
+    );
+  });
+}
+
+type WorkspaceReceiptRow = ReturnType<typeof readWorkspaceMoveReceipts>[number];
+
+export type WorkspaceMigrationReceiptMove = {
+  storedIdentity: WorkspaceStateIdentity;
+  currentIdentity: WorkspaceStateIdentity;
+  receipts: WorkspaceReceiptRow[];
+  replacements: {
+    originalKey: string;
+    source_key: string;
+    source_path: string;
+    report_json: string;
+  }[];
+};
+
+function assertReceiptMoveDestinations(
+  database: DatabaseSync,
+  plan: WorkspaceMigrationReceiptMove,
+) {
+  const destinationKeys = new Set<string>();
+  for (const replacement of plan.replacements) {
+    const existing = executeSqliteQueryTakeFirstSync(
+      database,
+      getNodeSqliteKysely<WorkspaceReceiptDatabase>(database)
+        .selectFrom("migration_sources")
+        .select("source_key")
+        .where("source_key", "=", replacement.source_key),
+    );
+    if (
+      destinationKeys.has(replacement.source_key) ||
+      (existing && existing.source_key !== replacement.originalKey)
+    ) {
+      throw receiptMoveFailure(replacement.source_path, "the destination already has a receipt");
+    }
+    destinationKeys.add(replacement.source_key);
+  }
+}
+
+async function verifyCarriedReceiptFile(
+  workspacePath: string,
+  filePath: string,
+  sha256: string | null,
+): Promise<void> {
+  try {
+    // Setup sources and their archives share the importer's 64 KiB maximum.
+    const workspace = await root(workspacePath, {
+      hardlinks: "reject",
+      symlinks: "reject",
+      maxBytes: 64 * 1024,
+    });
+    const file = await workspace.read(path.relative(workspacePath, filePath));
+    if (createHash("sha256").update(file.buffer).digest("hex") !== sha256) {
+      throw new Error("the carried file differs from its migration receipt");
+    }
+  } catch (error) {
+    throw receiptMoveFailure(filePath, formatErrorMessage(error));
+  }
+}
+
+/** Prepare filesystem evidence before the move owner's synchronous write transaction. */
+export async function prepareWorkspaceMigrationReceiptMove(params: {
+  database: DatabaseSync;
+  storedIdentity: WorkspaceStateIdentity;
+  currentIdentity: WorkspaceStateIdentity;
+  storedSetup: (WorkspaceSetupMilestones & { version: number | null }) | undefined;
+}): Promise<WorkspaceMigrationReceiptMove> {
+  const { database, storedIdentity, currentIdentity, storedSetup } = params;
+  const receipts = readWorkspaceMoveReceipts(database, storedIdentity, currentIdentity);
+  const plan: WorkspaceMigrationReceiptMove = {
+    storedIdentity,
+    currentIdentity,
+    receipts,
+    replacements: [],
+  };
+  const oldFingerprint =
+    storedSetup?.version === WORKSPACE_SETUP_STATE_VERSION
+      ? createWorkspaceSetupFingerprint(storedSetup)
+      : undefined;
+  for (const receipt of receipts) {
+    const report = safeParseJsonRecord(receipt.report_json)!;
+    if (report.workspaceKey !== storedIdentity.workspaceKey) {
+      throw receiptMoveFailure(
+        receipt.source_path,
+        report.workspaceKey === currentIdentity.workspaceKey
+          ? "the destination already owns migration history"
+          : "the migration report has unsupported workspace ownership",
+      );
+    }
+    if (!path.isAbsolute(receipt.source_path)) {
+      throw receiptMoveFailure(receipt.source_path, "the migration source path is invalid");
+    }
+    const sourcePath = moveWorkspacePath(receipt.source_path, storedIdentity, currentIdentity);
+    const movedReport: Record<string, unknown> = {
+      ...report,
+      workspaceKey: currentIdentity.workspaceKey,
+    };
+    let sourceKey: string;
+    if (receipt.migration_kind === WORKSPACE_CONTENT_RELOCATION_MIGRATION_KIND) {
+      if (receipt.status !== "completed" && receipt.status !== "superseded") {
+        throw receiptMoveFailure(
+          receipt.source_path,
+          "a skill-workshop relocation is still pending",
+        );
+      }
+      // Terminal reports retain their captured filesystem facts. Only their current
+      // receipt association moves; rewriting a prepared report could redirect work.
+      sourceKey = resolveLegacyMigrationSourceKey(receipt.migration_kind, sourcePath);
+      if (
+        receipt.source_key !==
+        resolveLegacyMigrationSourceKey(receipt.migration_kind, receipt.source_path)
+      ) {
+        throw receiptMoveFailure(receipt.source_path, "the relocation receipt key is invalid");
+      }
+    } else {
+      if (
+        (report.sourceKind !== "setup" && report.sourceKind !== "attestation") ||
+        typeof report.canonicalFingerprint !== "string" ||
+        typeof report.authoritative !== "boolean" ||
+        receipt.status !== "completed"
+      ) {
+        throw receiptMoveFailure(
+          receipt.source_path,
+          "the workspace receipt format is unsupported",
+        );
+      }
+      if (
+        receipt.source_key !==
+        resolveLegacyMigrationSourceKey(
+          `workspace-${report.sourceKind}`,
+          receipt.source_path,
+          storedIdentity.workspaceKey,
+        )
+      ) {
+        throw receiptMoveFailure(receipt.source_path, "the workspace receipt key is invalid");
+      }
+      if (
+        sourcePath === receipt.source_path &&
+        (receipt.removed_source !== 1 ||
+          pathMayExistSync(sourcePath) ||
+          pathMayExistSync(`${sourcePath}${WORKSPACE_DOCTOR_CLAIM_SUFFIX}`))
+      ) {
+        throw receiptMoveFailure(
+          receipt.source_path,
+          "an external legacy source has not finished cleanup",
+        );
+      }
+      if (sourcePath !== receipt.source_path && receipt.removed_source !== 1) {
+        const claimPath = `${sourcePath}${WORKSPACE_DOCTOR_CLAIM_SUFFIX}`;
+        const sourceExists = pathMayExistSync(sourcePath);
+        const claimExists = pathMayExistSync(claimPath);
+        if (sourceExists && claimExists) {
+          throw receiptMoveFailure(
+            sourcePath,
+            "both the carried source and its interrupted claim exist",
+          );
+        }
+        if (sourceExists || claimExists) {
+          await verifyCarriedReceiptFile(
+            currentIdentity.workspacePath,
+            sourceExists ? sourcePath : claimPath,
+            receipt.source_sha256,
+          );
+        }
+      }
+      if (
+        storedSetup &&
+        report.sourceKind === "setup" &&
+        oldFingerprint === report.canonicalFingerprint
+      ) {
+        movedReport.canonicalFingerprint = createWorkspaceSetupFingerprint({
+          ...storedSetup,
+          workspace_path: currentIdentity.workspacePath,
+        });
+      }
+      if (report.archivePath !== undefined) {
+        if (typeof report.archivePath !== "string" || !path.isAbsolute(report.archivePath)) {
+          throw receiptMoveFailure(receipt.source_path, "the setup backup path is invalid");
+        }
+        const archivePath = moveWorkspacePath(report.archivePath, storedIdentity, currentIdentity);
+        if (archivePath !== report.archivePath && receipt.removed_source !== 1) {
+          await verifyCarriedReceiptFile(
+            currentIdentity.workspacePath,
+            archivePath,
+            receipt.source_sha256,
+          );
+        }
+        movedReport.archivePath = archivePath;
+      }
+      sourceKey = resolveLegacyMigrationSourceKey(
+        `workspace-${report.sourceKind}`,
+        sourcePath,
+        currentIdentity.workspaceKey,
+      );
+    }
+    plan.replacements.push({
+      originalKey: receipt.source_key,
+      source_key: sourceKey,
+      source_path: sourcePath,
+      report_json: JSON.stringify(movedReport),
+    });
+  }
+  assertReceiptMoveDestinations(database, plan);
+  return plan;
+}
+
+/** Apply with the setup/alias move; preserve run history and every source-cleanup flag. */
+export function applyWorkspaceMigrationReceiptMove(
+  database: DatabaseSync,
+  plan: WorkspaceMigrationReceiptMove,
+): void {
+  const current = readWorkspaceMoveReceipts(database, plan.storedIdentity, plan.currentIdentity);
+  if (!isDeepStrictEqual(current, plan.receipts)) {
+    throw receiptMoveFailure(
+      plan.storedIdentity.workspacePath,
+      "migration history changed during the move",
+    );
+  }
+  assertReceiptMoveDestinations(database, plan);
+  const kysely = getNodeSqliteKysely<WorkspaceReceiptDatabase>(database);
+  for (const { originalKey, ...replacement } of plan.replacements) {
+    executeSqliteQuerySync(
+      database,
+      kysely
+        .updateTable("migration_sources")
+        .set(replacement)
+        .where("source_key", "=", originalKey),
+    );
+  }
 }

--- a/src/infra/state-migrations.workspace-setup-store.ts
+++ b/src/infra/state-migrations.workspace-setup-store.ts
@@ -24,6 +24,7 @@ import {
   recordLegacyMigrationReceipt,
 } from "./state-migrations.receipts.js";
 import {
+  createWorkspaceSetupFingerprint,
   resolveWorkspaceMigrationSourceKey,
   type MigrationReceipt,
 } from "./state-migrations.workspace-setup-receipts.js";
@@ -176,20 +177,6 @@ function mapsEqual(left: ReadonlyMap<string, string>, right: ReadonlyMap<string,
 
 function canonicalFingerprint(value: unknown): string {
   return createHash("sha256").update(JSON.stringify(value)).digest("hex");
-}
-
-function setupFingerprint(params: {
-  workspace_path: string | null;
-  bootstrap_seeded_at: string | null;
-  setup_completed_at: string | null;
-}): string {
-  return canonicalFingerprint({
-    kind: "setup",
-    workspacePath: params.workspace_path,
-    version: WORKSPACE_SETUP_STATE_VERSION,
-    bootstrapSeededAt: params.bootstrap_seeded_at,
-    setupCompletedAt: params.setup_completed_at,
-  });
 }
 
 function attestationFingerprint(params: {
@@ -372,7 +359,7 @@ export function importAndRecordReceipt(params: {
           ) {
             throw new Error("legacy workspace setup conflicts with canonical SQLite state");
           }
-          const existingFingerprint = setupFingerprint(existing);
+          const existingFingerprint = createWorkspaceSetupFingerprint(existing);
           // The canonical record is authoritative even without an import receipt.
           // Keep legacy differences for inspection instead of replaying old milestones.
           for (const [milestone, canonical] of [
@@ -413,7 +400,7 @@ export function importAndRecordReceipt(params: {
           );
           imported = true;
           resolution = existing ? "merged" : "inserted";
-          verifiedFingerprint = setupFingerprint(setupColumns);
+          verifiedFingerprint = createWorkspaceSetupFingerprint(setupColumns);
         }
         const verified = executeSqliteQueryTakeFirstSync(
           db,
@@ -425,7 +412,9 @@ export function importAndRecordReceipt(params: {
         // Every setup import branch writes the source path, so a NULL path
         // here is a verification failure, not an attestation-only row.
         const actualFingerprint =
-          verified && verified.workspace_path != null ? setupFingerprint(verified) : null;
+          verified && verified.workspace_path != null
+            ? createWorkspaceSetupFingerprint(verified)
+            : null;
         if (!verified || actualFingerprint !== verifiedFingerprint) {
           throw new Error("SQLite verification failed for workspace setup state");
         }

--- a/src/infra/state-migrations.workspace-setup.test-support.ts
+++ b/src/infra/state-migrations.workspace-setup.test-support.ts
@@ -41,7 +41,13 @@ export function useWorkspaceMigrationTestFixture() {
     };
   }
 
-  function detect(context: ReturnType<typeof setup>) {
+  function detect(context: {
+    cfg: OpenClawConfig;
+    env: NodeJS.ProcessEnv;
+    homeDir: string;
+    stateDir: string;
+    workspaceDir: string;
+  }) {
     return detectLegacyWorkspaceState({
       cfg: context.cfg,
       stateDir: context.stateDir,
@@ -51,7 +57,7 @@ export function useWorkspaceMigrationTestFixture() {
     });
   }
 
-  async function migrate(context: ReturnType<typeof setup>) {
+  async function migrate(context: Parameters<typeof detect>[0]) {
     return await migrateLegacyWorkspaceState({
       detected: detect(context),
       env: context.env,


### PR DESCRIPTION
Closes #133172

## What Problem This Solves

Moving a workspace folder and repointing its configured symlink leaves the saved workspace identity at the old location. The resulting error escapes reply resolution, so Telegram repeatedly retries the head event while later messages wait and the sender sees no explanation.

Doctor also needs a recovery path that preserves setup history. Rebuilding the records can recreate intentionally removed files or replay completed bootstrap work.

## Why This Change Was Made

- Return typed permanent workspace failures as fixed, redacted repair notices from the shared reply boundary. Mark these host notices for delivery in tool-only conversations; explicit send-policy denial still suppresses these notices. Heartbeat failures remain with their existing logging owner.
- Make an operator-confirmed folder move a Doctor repair under its maintenance owner. Interactive `doctor --fix` asks for confirmation; unattended `doctor --fix --force --non-interactive` supplies it. Plain diagnostic Doctor and ordinary non-interactive repair do not transfer records.
- Preserve setup milestones, file attestations, and migration history in one transaction. Revalidate the inspected records, target directory, configuration, and receipt set before writing. Refuse conflicting owners, an existing original folder, missing targets, pending relocations, and changed inspection facts.
- Keep only aliases verified against the destination. Remove stale associations so later cleanup through an old path cannot delete the moved owner's records. Retire workspace caches after commit.
- Rekey migration receipts, preserve cleanup flags and linked run history, and relocate carried backup references. Preserve old unmatched fingerprints; do not manufacture current migration authority. Keep actual filesystem path bytes separate from normalized database identities.
- Run alias recovery at the workspace-migration step, after schema prerequisites and before carried legacy files are imported. Otherwise an interrupted migration aborts Doctor before recovery can run. The late health contribution only reports findings.

**Maintainer design decision:** Use an explicit, maintenance-owned move of the same workspace, preserving its historical records. Do not infer identity from matching templates, reset saved milestones, merge existing destination state, or silently switch workspaces. This design was selected under Ayaan's explicit delegation in the maintainer task. No schema, schema-version, configuration-option, or protocol changes are added.

## User Impact

Affected users receive a repair notice instead of a silent retry loop. Operators can recover a moved workspace without changing its files or resetting its setup history. Conflicting or stale recovery attempts leave records untouched and explain the next action. See [Doctor](https://docs.openclaw.ai/gateway/doctor).

## Evidence

Baseline: `1d06bc963cfecbc2163af3a814d59e48dddcc09c`. Current head: `4e8294b57ed21bda4b4b7bd0ce05e82968370c29`. Earlier real-channel proof retains its original build identity, `373add4dc8028301d8aee7ba65ebe863704f5ec8`; the additional four-case channel matrix used `a590ca7a6abb1016c7def2344b7da9cab19cb394`. The final path correction has fresh regression tests and real CLI proof from identical tree `f8818b690577680eb7424cab67936413657cd6ec`; the exact-commit direct-move Telegram run passed independent acceptance.

- **Real Telegram baseline red:** an initialized workspace answered normally. After a physical move and symlink repoint, two messages received no reply; the Gateway repeatedly retained the same workspace-identity failure for retry.
- **Independent source-blind acceptance:** all six original contract clauses passed on the built candidate. The final direct-move extension also passed: both held events completed with zero retries, and answers returned after force recovery and restart. Real Telegram delivered the initial answer, two fixed repair notices, a recovered answer, and an answer after restart. With the first transport response held, the head event was claimed and the later event pending; after release, both exact saved events completed with zero retries and no error. The provider was not called for workspace failures.
- **Real tool-only Telegram proof:** both failure notices were delivered with `messages.visibleReplies=message_tool`. Ordinary repair left the identity unchanged; explicit force recovery and restart restored answers.
- **Real CLI red/green:** after a completed legacy import, moving the workspace and recreating its source made the earlier candidate exit 1 with an alias conflict before later repairs. The repaired CLI exits 0, retains user content and setup milestones, and cleans the carried source. The interrupted `.doctor-importing` claim case also passes. Both CLI scenarios were repeated on the final commit with complete retained logs.
- **Real interactive CLI:** decline leaves state untouched. Changing the target while confirmation waits invalidates the approval. A separate force operation against the new target succeeds. Repeated setup and Doctor preserve all remaining user files and keep consumed `BOOTSTRAP.md` absent.
- **Initial focused checks:** 187 tests passed across workspace ownership/store, migration history and ordering, Doctor/config, and reply-failure suites. The original PR failed six owner regressions and both receipt-lookup cases before correction. Unicode source/destination cases and intentionally removed completed backups pass. Changed-file lint and formatting pass; `git diff --check` is clean.
- **Additional live cases:** a missing workspace produces two repair notices without recreating the target; restoration and restart restore replies. Existing destination ownership, a shared old owner, and a surviving original directory all refuse transfer and preserve files/history; the other agent remains usable and restoring the original alias restores replies. Intentionally removed files remain absent, with setup/attestation history preserved. Explicit delivery denial suppresses the new repair notice.
- **Original-path correction:** the prior candidate's real CLI refused direct and parent-folder move-and-relink recovery, and incorrectly transferred a retained decomposed-Unicode original's history. The final correction permits links resolving to the approved directory, checks every normalization-equivalent original/alias path spelling, and preserves filesystem bytes during identity resolution. Fresh CLI proof shows successful direct, parent, and Unicode-alias recovery, while a retained Unicode original refuses and keeps its records. The original three regressions fail before the correction; 204 focused tests across 11 files pass afterward.

The original native test environment is tracked by [this Testbox run](https://github.com/openclaw/openclaw/actions/runs/34185078759), which was externally cancelled after the initial evidence exports. [The replacement run](https://github.com/openclaw/openclaw/actions/runs/34191349468) contains the final matrix and path correction proof. Full private commands, driver revisions, event timelines, CLI transcripts, before/after snapshots, and independent acceptance are retained for the exact-head local review. Telegram uses the Test Server and a deterministic model endpoint; this is real channel proof, not a claim about live model-provider quality.

Production: +1030/−79 (net +951); tests: +1169/−3; docs: +12. The small error-class relocation is a move. The remaining production growth supplies the missing confirmed-move capability, atomic ownership checks, and receipt continuity; the destructive reset path cannot preserve the required historical facts. Template-based adoption and the report-only receipt rewrite were removed.

## Bounded follow-ups observed during proof

- Removing all optional profile files from a completed workspace already triggers the existing missing-workspace policy before a move. Recovery preserves that state; this is file/history preservation proof, not a claim that this pre-existing policy returns normal answers.
- Telegram suppresses the repair notice under explicit send denial, but its existing empty-response fallback still emits a generic retry message. This separate delivery-policy follow-up is not a claim of complete channel silence.

Both latest review rank-up moves are addressed by the original-path and Unicode preservation tests and CLI results. No stored schema or version changes were made.

Implemented and verified with AI assistance. Original contribution and report by @safzanpirani are retained.
