### PR TITLE
perf(gateway): reuse prepared display projections

### DIFF
--- a/src/gateway/server-chat-progress-snapshot.ts
+++ b/src/gateway/server-chat-progress-snapshot.ts
@@ -97,20 +97,23 @@ export function updateChatRunProgressSnapshot(
     next.byteLength = next.events.reduce((total, candidate) => total + jsonUtf8Bytes(candidate), 0);
   };
 
-  if (isStartupStatus) {
-    if (
-      next.events.some((candidate) => candidate.stream === "tool" || candidate.stream === "item")
-    ) {
-      return next;
-    }
-    removeWhere((candidate) => candidate.stream === "run_status");
-  } else if (isTool || isPreamble) {
-    removeWhere((candidate) => candidate.stream === "run_status");
+  if (
+    isStartupStatus &&
+    next.events.some((candidate) => candidate.stream === "tool" || candidate.stream === "item")
+  ) {
+    return next;
   }
 
-  if (isTool) {
+  if (isStartupStatus || isTool || isPreamble) {
+    // Remove superseded startup and item state together; recount retained mutable payloads once.
     removeWhere((candidate) => {
-      if (candidate.stream !== "tool" || candidate.data?.toolCallId !== toolCallId) {
+      if (candidate.stream === "run_status") {
+        return true;
+      }
+      if (isPreamble) {
+        return matchesPreamble(candidate);
+      }
+      if (!isTool || candidate.stream !== "tool" || candidate.data?.toolCallId !== toolCallId) {
         return false;
       }
       if (phase === "start") {
@@ -126,10 +129,7 @@ export function updateChatRunProgressSnapshot(
       // review ID so reconnect restores every still-relevant decision.
       return asNullableRecord(candidate.data.review)?.id === reviewId;
     });
-  } else if (isPreamble) {
-    const progressText = typeof data.progressText === "string" ? data.progressText.trim() : "";
-    removeWhere(matchesPreamble);
-    if (!progressText) {
+    if (isPreamble && !(typeof data.progressText === "string" && data.progressText.trim())) {
       return next;
     }
   } else if ((isStandaloneGuardian || resolvesStrictReview) && typeof data.reviewId === "string") {

--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -382,7 +382,9 @@ async function handleChatHistoryRequest({
     ? (capChatHistoryAroundMessage({
         messages: replaced.messages,
         messageId,
-        fits: (messages) => byteCounter.messagesBytes(messages) <= maxHistoryBytes,
+        // A nonempty JSON array costs one framing byte plus each message and its separator.
+        maxCost: maxHistoryBytes - 1,
+        messageCost: (message) => byteCounter.messageBytes(message) + 1,
       }) ?? capArrayByJsonBytes(replaced.messages, maxHistoryBytes, byteCounter.messageBytes).items)
     : capArrayByJsonBytes(replaced.messages, maxHistoryBytes, byteCounter.messageBytes).items;
   const historyBudgetPreserved =

--- a/src/gateway/server-methods/chat-history-pages.ts
+++ b/src/gateway/server-methods/chat-history-pages.ts
@@ -148,26 +148,31 @@ export function enrichChatHistoryCompactionMarkers(
 function resolveChatHistoryMessageGroup(
   messages: unknown[],
   index: number,
-): { start: number; end: number } {
+  messageCost: (message: unknown) => number,
+): { start: number; end: number; cost: number } {
   const seq = readChatHistoryMessageSeq(messages[index]);
-  if (seq === undefined) {
-    return { start: index, end: index + 1 };
-  }
   let start = index;
   let end = index + 1;
+  let cost = messageCost(messages[index]);
+  if (seq === undefined) {
+    return { start, end, cost };
+  }
   while (start > 0 && readChatHistoryMessageSeq(messages[start - 1]) === seq) {
     start -= 1;
+    cost += messageCost(messages[start]);
   }
   while (end < messages.length && readChatHistoryMessageSeq(messages[end]) === seq) {
+    cost += messageCost(messages[end]);
     end += 1;
   }
-  return { start, end };
+  return { start, end, cost };
 }
 
 export function capChatHistoryAroundMessage(params: {
   messages: unknown[];
   messageId: string;
-  fits: (messages: unknown[]) => boolean;
+  maxCost: number;
+  messageCost?: (message: unknown) => number;
 }): unknown[] | undefined {
   const anchorIndex = params.messages.findIndex(
     (message) => readChatHistoryMessageId(message) === params.messageId,
@@ -175,19 +180,21 @@ export function capChatHistoryAroundMessage(params: {
   if (anchorIndex === -1) {
     return undefined;
   }
-  const anchorGroup = resolveChatHistoryMessageGroup(params.messages, anchorIndex);
-  if (!params.fits(params.messages.slice(anchorGroup.start, anchorGroup.end))) {
+  const messageCost = params.messageCost ?? (() => 1);
+  const anchorGroup = resolveChatHistoryMessageGroup(params.messages, anchorIndex, messageCost);
+  if (!(anchorGroup.cost <= params.maxCost)) {
     return [params.messages[anchorIndex]];
   }
 
-  let { start, end } = anchorGroup;
+  let { start, end, cost } = anchorGroup;
   let canGrowOlder = start > 0;
   let canGrowNewer = end < params.messages.length;
   while (canGrowOlder || canGrowNewer) {
     if (canGrowOlder) {
-      const olderGroup = resolveChatHistoryMessageGroup(params.messages, start - 1);
-      if (params.fits(params.messages.slice(olderGroup.start, end))) {
+      const olderGroup = resolveChatHistoryMessageGroup(params.messages, start - 1, messageCost);
+      if (cost + olderGroup.cost <= params.maxCost) {
         start = olderGroup.start;
+        cost += olderGroup.cost;
       } else {
         canGrowOlder = false;
       }
@@ -195,9 +202,10 @@ export function capChatHistoryAroundMessage(params: {
     canGrowOlder &&= start > 0;
 
     if (canGrowNewer) {
-      const newerGroup = resolveChatHistoryMessageGroup(params.messages, end);
-      if (params.fits(params.messages.slice(start, newerGroup.end))) {
+      const newerGroup = resolveChatHistoryMessageGroup(params.messages, end, messageCost);
+      if (cost + newerGroup.cost <= params.maxCost) {
         end = newerGroup.end;
+        cost += newerGroup.cost;
       } else {
         canGrowNewer = false;
       }
@@ -321,7 +329,7 @@ export async function readChatHistoryPage(params: {
       ? (capChatHistoryAroundMessage({
           messages: projected,
           messageId,
-          fits: (messages) => messages.length <= max,
+          maxCost: max,
         }) ?? capOffsetChatHistoryProjectedMessages(projected, max))
       : projected;
     if (messageId) {

--- a/src/gateway/session-list-order.ts
+++ b/src/gateway/session-list-order.ts
@@ -36,9 +36,17 @@ function selectNewestLimitedEntries(
 ): SessionEntryPair[] {
   const selected: SessionEntryPair[] = [];
   for (const entry of entries) {
-    const insertAt = selected.findIndex(
-      (candidate) => compareSessionEntryPairs(entry, candidate, sortBy) < 0,
-    );
+    const first = selected[0];
+    const beforeFirst = first && compareSessionEntryPairs(entry, first, sortBy) < 0;
+    const worst = selected[limit - 1];
+    if (!beforeFirst && worst && compareSessionEntryPairs(entry, worst, sortBy) >= 0) {
+      continue;
+    }
+    const insertAt = beforeFirst
+      ? 0
+      : selected.findIndex(
+          (candidate, index) => index > 0 && compareSessionEntryPairs(entry, candidate, sortBy) < 0,
+        );
     if (insertAt >= 0) {
       selected.splice(insertAt, 0, entry);
       if (selected.length > limit) {

--- a/src/gateway/session-utils-contracts.ts
+++ b/src/gateway/session-utils-contracts.ts
@@ -20,7 +20,6 @@ export type SessionActorProfileIdentity = Extract<CurrentUserProfileDisplay, { k
 
 export type SessionListRowContext = {
   subagentRuns: SubagentRunReadIndex<SubagentRunReadRecord>;
-  storeChildSessionsByKey: Map<string, string[]>;
   selectedModelByOverrideRef: Map<string, ReturnType<typeof resolveSessionModelRef>>;
   thinkingMetadataByModelRef: Map<string, GatewayModelThinkingProfile>;
   displayModelIdentityByKey: Map<string, { provider?: string; model?: string }>;

--- a/src/gateway/session-utils-core.ts
+++ b/src/gateway/session-utils-core.ts
@@ -289,6 +289,7 @@ function rememberSingleRowChildSessionCandidateCacheEntry(
 
 function buildStoreChildSessionCandidateIndex(
   store: Record<string, SessionEntry> | null | undefined,
+  selectedParents?: ReadonlySet<string>,
 ): Map<string, string[]> {
   const childSessionsByKey = new Map<string, string[]>();
   if (!store) {
@@ -303,7 +304,9 @@ function buildStoreChildSessionCandidateIndex(
       normalizeOptionalString(entry.parentSessionKey),
     ].filter((value): value is string => Boolean(value) && value !== key);
     for (const parentKey of parentKeys) {
-      addChildSessionKey(childSessionsByKey, parentKey, key);
+      if (!selectedParents || selectedParents.has(parentKey)) {
+        addChildSessionKey(childSessionsByKey, parentKey, key);
+      }
     }
   }
   return childSessionsByKey;
@@ -412,92 +415,72 @@ export function isCurrentSessionChildOwner(params: {
   );
 }
 
-export function buildStoreChildSessionIndex(
-  store: Record<string, SessionEntry>,
-  now = Date.now(),
-  subagentRuns?: SessionListRowContext["subagentRuns"],
-): Map<string, string[]> {
-  const childSessionsByKey = new Map<string, string[]>();
-  for (const [key, entry] of Object.entries(store)) {
-    if (!entry) {
-      continue;
-    }
-    const parentKeys = [
-      normalizeOptionalString(entry.spawnedBy),
-      normalizeOptionalString(entry.parentSessionKey),
-    ].filter((value): value is string => Boolean(value) && value !== key);
-    if (parentKeys.length === 0) {
-      continue;
-    }
-    const latest = subagentRuns
-      ? subagentRuns.getDisplaySubagentRun(key)
-      : getSessionDisplaySubagentRunByChildSessionKey(key);
-    let latestControllerSessionKey: string | undefined;
-    if (latest) {
-      latestControllerSessionKey =
-        normalizeOptionalString(latest.controllerSessionKey) ||
-        normalizeOptionalString(latest.requesterSessionKey);
-      if (
-        !shouldKeepSubagentRunChildLink(latest, {
-          activeDescendants: subagentRuns
-            ? subagentRuns.countActiveDescendantRuns(key)
-            : countActiveDescendantRuns(key),
-          now,
-        })
-      ) {
-        continue;
-      }
-    } else if (!shouldKeepStoreOnlyChildLink(entry, now)) {
-      continue;
-    }
-    for (const parentKey of parentKeys) {
-      if (
-        latestControllerSessionKey &&
-        !isCurrentSessionChildOwner({
-          entry,
-          ownerSessionKey: parentKey,
-          controllerSessionKey: latestControllerSessionKey,
-        })
-      ) {
-        continue;
-      }
-      addChildSessionKey(childSessionsByKey, parentKey, key);
+/** Prepare only selected parents; a supplied candidate map retains exact-row cache ownership. */
+export function buildStoreChildSessionIndex(params: {
+  store: Record<string, SessionEntry>;
+  keys: readonly string[];
+  now: number;
+  subagentRuns?: SessionListRowContext["subagentRuns"];
+  candidates?: ReadonlyMap<string, readonly string[]>;
+  excludedChildKeys?: ReadonlySet<string>;
+  requireCurrentController?: boolean;
+}): Map<string, string[]> {
+  const children = new Map<string, string[]>();
+  if (params.keys.length === 0) {
+    return children;
+  }
+  const candidates =
+    params.candidates ?? buildStoreChildSessionCandidateIndex(params.store, new Set(params.keys));
+  for (const key of params.keys) {
+    const childKeys = resolveStoreChildSessionKeysFromCandidates({ ...params, key, candidates });
+    if (childKeys) {
+      children.set(key, childKeys);
     }
   }
-  return childSessionsByKey;
+  return children;
 }
 
-export function resolveStoreChildSessionKeysFromCandidates(params: {
+function resolveStoreChildSessionKeysFromCandidates(params: {
   store: Record<string, SessionEntry>;
   key: string;
   now: number;
   candidates: ReadonlyMap<string, readonly string[]>;
+  subagentRuns?: SessionListRowContext["subagentRuns"];
+  excludedChildKeys?: ReadonlySet<string>;
+  requireCurrentController?: boolean;
 }): string[] | undefined {
   const childSessionKeys: string[] = [];
   for (const childKey of params.candidates.get(params.key) ?? []) {
+    if (params.excludedChildKeys?.has(childKey)) {
+      continue;
+    }
     const entry = params.store[childKey];
     if (!entry) {
       continue;
     }
-    const latest = getSessionDisplaySubagentRunByChildSessionKey(childKey);
+    const latest = params.subagentRuns
+      ? params.subagentRuns.getDisplaySubagentRun(childKey)
+      : getSessionDisplaySubagentRunByChildSessionKey(childKey);
     if (latest) {
       const latestControllerSessionKey =
         normalizeOptionalString(latest.controllerSessionKey) ||
         normalizeOptionalString(latest.requesterSessionKey);
-      if (
-        !isCurrentSessionChildOwner({
-          entry,
-          ownerSessionKey: params.key,
-          controllerSessionKey: latestControllerSessionKey,
-        })
-      ) {
+      const matchesOwner = isCurrentSessionChildOwner({
+        entry,
+        ownerSessionKey: params.key,
+        controllerSessionKey: latestControllerSessionKey,
+      });
+      if (params.requireCurrentController && !matchesOwner) {
         continue;
       }
       if (
         !shouldKeepSubagentRunChildLink(latest, {
-          activeDescendants: countActiveDescendantRuns(childKey),
+          activeDescendants: params.subagentRuns
+            ? params.subagentRuns.countActiveDescendantRuns(childKey)
+            : countActiveDescendantRuns(childKey),
           now: params.now,
-        })
+        }) ||
+        (latestControllerSessionKey && !matchesOwner)
       ) {
         continue;
       }

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -48,16 +48,14 @@ import type {
 } from "./session-utils-contracts.js";
 import {
   deriveSessionTitle,
+  buildStoreChildSessionIndex,
+  getSingleRowChildSessionCandidates,
   isFinitePositiveTimestamp,
   isCurrentSessionChildOwner,
   shouldKeepStoreOnlyChildLink,
 } from "./session-utils-core.js";
 import { getSessionDefaults } from "./session-utils-model.js";
-import {
-  buildSessionListRowContext,
-  buildSessionListRowMetadataContext,
-  buildSingleRowStoreChildSessionsByKey,
-} from "./session-utils-projection.js";
+import { buildSessionListRowMetadataContext } from "./session-utils-projection.js";
 import { buildGatewaySessionRow } from "./session-utils-row.js";
 import {
   appendStoredSessionModelSearchFields,
@@ -452,7 +450,7 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
   const configuredAgentIds = new Set(listAgentIds(cfg));
   let rowContext: SessionListRowContext | undefined;
   const getRowContext = () => {
-    rowContext ??= buildSessionListRowContext({ store, now, userProfileIdentityById });
+    rowContext ??= buildSessionListRowMetadataContext({ now, userProfileIdentityById });
     return rowContext;
   };
   const hasSpawnedByFilter = typeof opts.spawnedBy === "string" && opts.spawnedBy.length > 0;
@@ -482,27 +480,29 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
     involvingActorId: params.involvingActorId,
     ownerFirstActorId: params.ownerFirstActorId,
   });
-  const fullRowContext =
-    rowContext ||
+  // The two registry caches can differ after an external worker write. Preserve
+  // live child reads where the existing short-list path did not prepare a snapshot.
+  const usePreparedChildReads =
+    Boolean(rowContext) ||
     hasSpawnedByFilter ||
     filteredSessionKeys.size > 0 ||
-    selection.entries.length > SESSIONS_LIST_YIELD_BATCH_SIZE
-      ? getRowContext()
-      : undefined;
-  if (fullRowContext && filteredSessionKeys.size > 0) {
-    // The predicate replaces a filtered-store object; keep its hidden child links out too.
-    for (const [parentKey, childKeys] of fullRowContext.storeChildSessionsByKey) {
-      fullRowContext.storeChildSessionsByKey.set(
-        parentKey,
-        childKeys.filter((key) => !filteredSessionKeys.has(key)),
-      );
-    }
-  }
+    selection.entries.length > SESSIONS_LIST_YIELD_BATCH_SIZE;
   const sharedRowContext =
-    fullRowContext ??
-    (selection.entries.length > 0
-      ? buildSessionListRowMetadataContext({ now, userProfileIdentityById })
-      : undefined);
+    usePreparedChildReads || selection.entries.length > 0 ? getRowContext() : undefined;
+  const storePath = hasIncognito ? params.storePath : (params.durableStorePath ?? params.storePath);
+  const childCandidates =
+    !usePreparedChildReads && selection.entries.length > 0
+      ? getSingleRowChildSessionCandidates({ storePath, store })
+      : undefined;
+  const storeChildSessionsByKey = buildStoreChildSessionIndex({
+    store,
+    keys: selection.entries.map(([key]) => key),
+    now,
+    subagentRuns: usePreparedChildReads ? sharedRowContext?.subagentRuns : undefined,
+    candidates: childCandidates,
+    excludedChildKeys: filteredSessionKeys,
+    requireCurrentController: !usePreparedChildReads,
+  });
   populateSessionListAcpMetadata({
     cfg,
     entries: selection.entries,
@@ -518,8 +518,8 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
     now,
     configuredAgentIds,
     rowContext: sharedRowContext,
-    storeChildSessionsByKey: fullRowContext?.storeChildSessionsByKey,
-    storePath: hasIncognito ? params.storePath : (params.durableStorePath ?? params.storePath),
+    storeChildSessionsByKey,
+    storePath,
   };
 }
 
@@ -628,14 +628,6 @@ export async function listSessionsFromStoreAsync(
         !parseAgentSessionKey(key) && typeof opts.agentId === "string"
           ? normalizeAgentId(opts.agentId)
           : undefined;
-      const storeChildSessionsByKey =
-        list.storeChildSessionsByKey ??
-        buildSingleRowStoreChildSessionsByKey({
-          store,
-          storePath: list.storePath,
-          key,
-          now: list.now,
-        });
       const row = buildGatewaySessionRow({
         cfg,
         storePath: list.storePath,
@@ -647,7 +639,7 @@ export async function listSessionsFromStoreAsync(
         now: list.now,
         includeDerivedTitles: false,
         includeLastMessage: false,
-        storeChildSessionsByKey,
+        storeChildSessionsByKey: list.storeChildSessionsByKey,
         rowContext: list.rowContext,
         configuredAgentIds: list.configuredAgentIds,
         skipTranscriptUsageFallback: true,

--- a/src/gateway/session-utils-projection.ts
+++ b/src/gateway/session-utils-projection.ts
@@ -18,30 +18,14 @@ import {
   resolveEstimatedSessionCostUsd,
   resolvePositiveNumber,
   resolveRuntimeChildSessionKeys,
-  resolveStoreChildSessionKeysFromCandidates,
 } from "./session-utils-core.js";
 
-export function buildSessionListRowContext(params: {
-  store: Record<string, SessionEntry>;
+export function buildSessionListRowMetadataContext(params: {
   now: number;
   userProfileIdentityById?: Map<string, SessionActorProfileIdentity | undefined>;
 }): SessionListRowContext {
-  const subagentRuns = buildSubagentSessionListReadIndex(params.now);
-  return buildSessionListRowContextFromParts({
-    subagentRuns,
-    storeChildSessionsByKey: buildStoreChildSessionIndex(params.store, params.now, subagentRuns),
-    userProfileIdentityById: params.userProfileIdentityById,
-  });
-}
-
-function buildSessionListRowContextFromParts(params: {
-  subagentRuns: SessionListRowContext["subagentRuns"];
-  storeChildSessionsByKey: Map<string, string[]>;
-  userProfileIdentityById?: Map<string, SessionActorProfileIdentity | undefined>;
-}): SessionListRowContext {
   return {
-    subagentRuns: params.subagentRuns,
-    storeChildSessionsByKey: params.storeChildSessionsByKey,
+    subagentRuns: buildSubagentSessionListReadIndex(params.now),
     selectedModelByOverrideRef: new Map(),
     thinkingMetadataByModelRef: new Map(),
     displayModelIdentityByKey: new Map(),
@@ -51,33 +35,22 @@ function buildSessionListRowContextFromParts(params: {
   };
 }
 
-export function buildSessionListRowMetadataContext(params: {
-  now: number;
-  userProfileIdentityById?: Map<string, SessionActorProfileIdentity | undefined>;
-}): SessionListRowContext {
-  return buildSessionListRowContextFromParts({
-    subagentRuns: buildSubagentSessionListReadIndex(params.now),
-    storeChildSessionsByKey: new Map(),
-    userProfileIdentityById: params.userProfileIdentityById,
-  });
-}
-
 export function buildSingleRowStoreChildSessionsByKey(params: {
   store: Record<string, SessionEntry>;
   storePath: string;
   key: string;
   now: number;
 }): Map<string, string[]> {
-  const storeChildSessions = resolveStoreChildSessionKeysFromCandidates({
+  return buildStoreChildSessionIndex({
     store: params.store,
-    key: params.key,
+    keys: [params.key],
     now: params.now,
     candidates: getSingleRowChildSessionCandidates({
       storePath: params.storePath,
       store: params.store,
     }),
+    requireCurrentController: true,
   });
-  return storeChildSessions ? new Map([[params.key, storeChildSessions]]) : new Map();
 }
 
 export function resolveSessionSelectedModelRef(params: {
@@ -136,9 +109,12 @@ export function resolveChildSessionKeys(
     now,
     subagentRuns,
   );
-  const storeChildSessions = buildStoreChildSessionIndex(store, now, subagentRuns).get(
-    controllerSessionKey,
-  );
+  const storeChildSessions = buildStoreChildSessionIndex({
+    store,
+    keys: [controllerSessionKey],
+    now,
+    subagentRuns,
+  }).get(controllerSessionKey);
   return mergeChildSessionKeys(runtimeChildSessions, storeChildSessions);
 }
 

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -77,7 +77,6 @@ import { isGroupOrChannelDisplaySession, parseGroupKey } from "./session-utils-s
 import type { GatewaySessionRow, SessionListModelCatalog } from "./session-utils.types.js";
 import { projectWorkerPlacementAgentRuntime } from "./worker-environments/placement-session-runtime.js";
 
-/** Adds current actor display data without persisting rename-prone metadata. */
 /** Opaque cache-busting revision for the channel-avatar route; never leaks the reference. */
 function channelAvatarRevision(reference: string): string {
   return createHash("sha256").update(reference).digest("base64url").slice(0, 12);

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -43,7 +43,7 @@ import {
   resolveGatewayModelSupportsImages,
 } from "./session-utils-model.js";
 import {
-  buildSessionListRowContext,
+  buildSessionListRowMetadataContext,
   buildSingleRowStoreChildSessionsByKey,
 } from "./session-utils-projection.js";
 import { buildGatewaySessionRow as buildGatewaySessionRowOwner } from "./session-utils-row.js";
@@ -265,8 +265,7 @@ function buildGatewaySessionRow(
   params: Parameters<typeof buildGatewaySessionRowOwner>[0],
 ): ReturnType<typeof buildGatewaySessionRowOwner> {
   const entry = params.entry ?? ({} as SessionEntry);
-  const rowContext = buildSessionListRowContext({
-    store: params.store,
+  const rowContext = buildSessionListRowMetadataContext({
     now: params.now ?? Date.now(),
   });
   // Row projection tests do not own ACP persistence. Mark the supplied fixture

--- a/src/status/summary.ts
+++ b/src/status/summary.ts
@@ -226,9 +226,16 @@ async function prepareSessionStatusDetails(cfg: OpenClawConfig, now: number) {
       allowAsyncLoad: false,
     }) ?? DEFAULT_CONTEXT_TOKENS;
 
+  // Aggregate rows reuse this request's completed agent projection, with independent DTOs.
+  const sessionRows = new Map<SessionEntrySummary, SessionStatus>();
   const buildSessionRows = async (candidates: SessionEntrySummary[]) =>
     Promise.all(
-      candidates.map(async ({ sessionKey: key, entry }) => {
+      candidates.map(async (candidate) => {
+        const cached = sessionRows.get(candidate);
+        if (cached) {
+          return { ...cached, flags: [...cached.flags] };
+        }
+        const { sessionKey: key, entry } = candidate;
         const agentId = parseAgentSessionKey(key)?.agentId;
         const updatedAt = entry.updatedAt ?? null;
         const age = updatedAt ? now - updatedAt : null;
@@ -316,7 +323,7 @@ async function prepareSessionStatusDetails(cfg: OpenClawConfig, now: number) {
           contextTokens && contextTokens > 0 && freshTotal !== undefined
             ? Math.min(999, Math.round((freshTotal / contextTokens) * 100))
             : null;
-        return {
+        const row = {
           agentId,
           key,
           kind: classifySessionKey(key, entry),
@@ -351,6 +358,8 @@ async function prepareSessionStatusDetails(cfg: OpenClawConfig, now: number) {
           contextTokens,
           flags: buildFlags(entry),
         } satisfies SessionStatus;
+        sessionRows.set(candidate, row);
+        return row;
       }),
     );
 


### PR DESCRIPTION
## What Problem This Solves

Gateway display requests repeatedly compute results they already have: bounded session ordering scans candidates that cannot enter the page, child-link projection evaluates parents outside the selected page, status builds the same completed row twice, anchored history repeatedly copies and recounts its growing window, and progress updates serialize retained events twice.

## Why This Change Was Made

Keep preparation at the existing owners and carry its results through the request:

- Reject out-of-window session candidates after checking the first and last selected rows; preserve stable ordering and the unbounded sort path.
- Use one child-link evaluator for selected parents, exact-row callers and row fallbacks. Delete the duplicate full-map/context builders and per-row sparse validation.
- Reuse completed status rows within one request, returning independent DTOs and flags for the aggregate view.
- Accumulate anchored-history group costs once. Both private callers use additive count or exact JSON-byte budgets; return one final slice.
- Combine superseded startup/item removal and recount retained progress payloads once. Mutable nested payloads still receive a full recount.

Production +146/−170, **net −24**; existing test-helper migration +2/−3, **net −1**, with its assertions retained. No config, schema, protocol, authorization or persistence change; no new dependency or process cache.

## Contracts and Tradeoffs

The child-link refactor preserves the two existing registry read policies. A real external SQLite writer demonstrated that the scalar and prepared registry caches can differ within their existing 500 ms lifetime. Short-list reads still use the scalar policy, including its stricter missing-controller behavior; prepared lists keep their snapshot. Hidden children, current controllers, explicit navigation parents, recent terminal links and active descendants remain covered.

Status now deliberately returns the same completed ACP/runtime projection in the per-agent and aggregate views of one summary, even if a backend changes between those phases. Later requests read again. It keeps the first scalar ACP read and its legacy-binding behavior; the batch ACP API is not substituted.

History retains exact sequence groups, first matching anchor, older-before-newer growth, independent blocked directions, oversized-group fallback and archive metadata. For a nonempty JSON array, its cost is one framing byte plus the sum of each message's bytes and separator. Progress keeps sequence rejection, first-seen preamble time, independent Guardian review IDs, strict-review resolution and whole-tool eviction. Native Codex Guardian contracts were checked directly; no approval behavior changes.

## Measurements and Verification

Fresh Node 26.8.1 processes, opposite starting orders, uninstrumented complete owners and retained raw samples:

| Workload | Observed change |
| --- | --- |
| 10,000 randomly ordered sessions, limit 100 | ~3.84 ms → 213–223 µs; comparisons 969,386 → 44,725 |
| 300 stored parents, 10 selected list rows | 2.68–2.97 ms → 1.56–1.72 ms (~42% lower) |
| Default status with one agent and 30 sessions | 56.48–58.44 ms → 29.07–30.31 ms (~48% lower) |
| 1,000-row anchored history including fresh byte preparation | 2.63–2.64 ms → 0.31–0.32 ms; growing-window reference copies 501,500 → 1,000 |
| Progress update with 49 retained 2 KB events | 184.98–190.41 µs → 94.04–97.44 µs (~49% lower) |

These are local owner/workload measurements, not whole-turn or network latency claims. Small controls are retained: already favorable top-N ordering is 1.7–4.1% slower; short/grouped history selections can cost an extra 0.03–0.08 µs; several tiny list/status/progress cases are noisy or slightly slower. No isolated memory saving is claimed.

Source-bound probes cover 4,960 top-N outputs, 52 complete SQLite-backed status comparisons with 652 identities, 6,768 anchor outputs with 61,391 identities, 189 child comparisons including 174 complete lists, and 8,461 progress comparisons with 25,352 snapshot identities. Mutable nested payloads, real external writer state and final DTO identity are explicitly exercised.

The baseline and initial candidate both passed 471 selected tests across 11 files, including real Gateway history tests for anchors, archives, rejected selectors and byte budgets. The initial changed-file gate passed all type/boundary/dead-export checks but rejected an invariant sequence condition in two loops; the final form restores the original early return without a suppression. Final local checks and live evidence follow; hosted CI must be green before landing.

Final local changed-file checks passed in 190.75 seconds, including core/test types, lint, boundary/dead-export/import and state guards. The 15 affected history checks passed again after the loop cleanup. Independent source review is clean; the fresh automated Codex review reported no actionable findings at its configured P0 threshold. The patch was rebased unchanged onto merged main `5cb702d464a7869e3a1dc4b6f85361d91f3e4291`; the published head is `28435c17c5a10bddae877fef233fd5e82e4a90a5`. All 471 selected tests passed again at that head, followed by a fresh build in 166.34 seconds.

At that exact published head, the isolated real-OpenAI Gateway completed a three-turn chat conversation with two actual `web_fetch` calls, then a separate native web-search turn. A newly connected read-only client recovered the active run and retained tool progress with the exact run/tool identity. Real transcript anchors at limits 1/3/100, bounded session ordering, matching aggregate/per-agent status, restricted status, terminal cleanup, and unchanged baseline previews/tool inventories/catalog passed **81 assertions across 32 RPC calls**. Node CPU profiles were retained and the owned Gateway stopped cleanly. The live run does not simulate child-controller concurrency or Guardian approvals; those retain the complete-owner and canonical test evidence above.

## Landing Review

The latest ClawSweeper review found no introduced code defect but could not obtain the sibling Codex checkout in its environment. The maintainer directly inspected the local public Codex checkout at `6478a751fde8884b2fdc76486fe23175a8e795d4`: [Guardian started/completed notifications](https://github.com/openai/codex/blob/6478a751fde8884b2fdc76486fe23175a8e795d4/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L1331) and [assessment lifecycle identity](https://github.com/openai/codex/blob/6478a751fde8884b2fdc76486fe23175a8e795d4/codex-rs/protocol/src/approvals.rs#L189). At that source version, stable review IDs, optional targets and multiple reviews per command match the retained projection behavior; the refactor still replaces only the matching review and preserves standalone/strict-review handling. A second independent reviewer checked the producer and notification mapping too. This resolves the source-inspection limitation. The rank-up request for exact-head Gateway validation is satisfied by the build/live proof above. Maintainer review accepts the scoped status-snapshot choice and disclosed small timing costs; exact-head CI run 33302579327 is now green.
