### PR TITLE
fix(telegram): successful terminal reply no longer shows session as failed in Control UI

### DIFF
--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -21,6 +21,8 @@ import {
 import type { TelegramRuntime } from "./runtime.types.js";
 import { getTopicName, resolveTopicNameCacheScope } from "./topic-name-cache.js";
 
+const TELEGRAM_TEST_SENT_AT = 1_735_689_600_000;
+
 const originalTelegramActionRuntime = { ...telegramActionRuntime };
 
 function handleTelegramAction(
@@ -171,7 +173,8 @@ const sendDurableMessageBatch = vi.fn(
             index: 0,
           },
         ],
-        sentAt: Date.now(),
+        sentAt: TELEGRAM_TEST_SENT_AT,
+        ...(params.threadId == null ? {} : { threadId: String(params.threadId) }),
       },
     } as const;
   },
@@ -1059,6 +1062,43 @@ describe("handleTelegramAction", () => {
       ok: true,
       messageId: "789",
       chatId: "123",
+    });
+  });
+
+  it("preserves the durable receipt in terminal forum-topic sendMessage results", async () => {
+    const result = await handleTelegramAction(
+      {
+        action: "sendMessage",
+        to: "-1001234567890",
+        content: "Terminal forum reply",
+        threadId: 42,
+      },
+      telegramConfig(),
+      {
+        gatewayClientScopes: ["operator.write"],
+        sessionKey: "agent:main:telegram:group:-1001234567890:topic:42",
+      },
+    );
+    const details = result.details as {
+      ok: boolean;
+      messageId?: string;
+      chatId?: string;
+      receipt?: Record<string, unknown>;
+    };
+    expect(details.ok).toBe(true);
+    // Source-reply reconciliation reads `receipt.threadId` from the delivered
+    // payload to prove terminal delivery; dropping it makes the gateway fail
+    // closed and mark the completed session aborted (#133051). The projection
+    // must stay bounded: no multipart ids, parts, timestamps, or raw provider
+    // records may leak into model-visible tool content.
+    expect(details.receipt).toStrictEqual({ threadId: "42" });
+    const content = result.content as Array<{ type: string; text?: string }>;
+    const contentText = content[0]?.type === "text" ? (content[0].text ?? "") : "";
+    expect(JSON.parse(contentText)).toStrictEqual({
+      ok: true,
+      messageId: "789",
+      chatId: "123",
+      receipt: { threadId: "42" },
     });
   });
 

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -17,6 +17,7 @@ import {
   buildOutboundSessionContext,
   sendDurableMessageBatch,
   type DurableMessageBatchSendResult,
+  type MessageReceipt,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -376,9 +377,26 @@ function buildTelegramActionSendPayload(params: {
   };
 }
 
+function projectTelegramReceiptPlacement(
+  receipt: MessageReceipt,
+): { threadId?: string; replyToId?: string } | undefined {
+  // Reconciliation only reads thread/reply placement from the delivered
+  // receipt. Keep the model-visible tool result bounded: durable receipts
+  // also carry unbounded multipart data and raw provider records (#133051).
+  const placement = {
+    ...(receipt.threadId ? { threadId: receipt.threadId } : {}),
+    ...(receipt.replyToId ? { replyToId: receipt.replyToId } : {}),
+  };
+  return Object.keys(placement).length > 0 ? placement : undefined;
+}
+
 function getLastDurableTelegramActionResult(
   result: Extract<DurableMessageBatchSendResult, { status: "sent" }>,
-): { messageId?: string; chatId?: string } {
+): {
+  messageId?: string;
+  chatId?: string;
+  receipt?: { threadId?: string; replyToId?: string };
+} {
   const lastResult = result.results.at(-1);
   const receipt = result.receipt;
   return {
@@ -387,6 +405,10 @@ function getLastDurableTelegramActionResult(
       receipt.primaryPlatformMessageId ??
       receipt.platformMessageIds.at(-1),
     chatId: lastResult?.target?.kind === "chat" ? lastResult.target.id : undefined,
+    // Preserve the durable receipt placement so source-reply reconciliation
+    // can prove terminal delivery (including forum thread placement) instead
+    // of failing closed and marking the completed session as aborted.
+    receipt: projectTelegramReceiptPlacement(receipt),
   };
 }
 
@@ -748,6 +770,7 @@ export async function handleTelegramAction(
       ok: true,
       messageId: result.messageId,
       chatId: result.chatId,
+      ...(result.receipt ? { receipt: result.receipt } : {}),
       ...buildTelegramControlDegradation(droppedControls, Boolean(content.trim())),
     });
   }

--- a/src/infra/outbound/source-reply-mirror.test.ts
+++ b/src/infra/outbound/source-reply-mirror.test.ts
@@ -76,6 +76,60 @@ describe("reconcileTerminalSourceReplyDelivery", () => {
     expect(receiptMocks.cancel).not.toHaveBeenCalled();
     expect(receiptMocks.complete).not.toHaveBeenCalled();
   });
+
+  const telegramForumMirror = {
+    action: "send",
+    channel: "telegram",
+    actionParams: { to: "-1001234567890", message: "terminal forum reply" },
+    cfg: {},
+    sessionKey: "agent:main:telegram:group:-1001234567890:topic:42",
+    toolContext: {
+      currentChannelProvider: "telegram",
+      currentChannelId: "-1001234567890",
+      currentThreadTs: "42",
+    },
+  };
+
+  it("keeps terminal delivery fail-closed when the telegram result drops its receipt", async () => {
+    // Pre-fix Telegram sendMessage results carried only ok/messageId/chatId,
+    // so reconciliation could not prove forum-topic placement (#133051).
+    await expect(
+      reconcileTerminalSourceReplyDelivery({
+        deliveredPayload: {
+          result: { ok: true, messageId: "789", chatId: "-1001234567890" },
+        },
+        mirror: telegramForumMirror,
+        receipt: { ...receipt, sessionKey: telegramForumMirror.sessionKey },
+      }),
+    ).resolves.toBe("not-source");
+
+    expect(receiptMocks.complete).not.toHaveBeenCalled();
+    expect(receiptMocks.cancel).not.toHaveBeenCalled();
+  });
+
+  it("completes terminal delivery when the telegram result carries the forum-topic receipt", async () => {
+    const terminalReceipt = { ...receipt, sessionKey: telegramForumMirror.sessionKey };
+
+    await expect(
+      reconcileTerminalSourceReplyDelivery({
+        deliveredPayload: {
+          result: {
+            ok: true,
+            messageId: "789",
+            chatId: "-1001234567890",
+            receipt: {
+              threadId: "42",
+            },
+          },
+        },
+        mirror: telegramForumMirror,
+        receipt: terminalReceipt,
+      }),
+    ).resolves.toBe("delivered");
+
+    expect(receiptMocks.complete).toHaveBeenCalledWith(terminalReceipt);
+    expect(receiptMocks.cancel).not.toHaveBeenCalled();
+  });
 });
 
 describe("isDeliveredCurrentSourceReply", () => {


### PR DESCRIPTION
Closes #133051

## What Problem This Solves

Fixes an issue where users running Telegram forum topics would see the Control UI show the affected session as `Run failed: Unknown error` (persisted `status=failed`, `abortedLastRun=1`) even though the agent's terminal reply was delivered successfully. Delivery itself always succeeded; the false failed state made Control UI session status untrustworthy for operators, and restart recovery treated known delivery as unproven (`Terminal source reply receipt was not mirrored; restart recovery is fail-closed.`).

## Why This Change Was Made

`sendDurableMessageBatch()` returns a durable receipt with provider-confirmed message ids and the forum `threadId`, but the Telegram action adapter discarded it before returning the `sendMessage` tool result. Source-reply reconciliation (`resolveDeliveryReceipt()` in `src/infra/outbound/source-reply-mirror.ts`) reads `result.receipt` from the delivered payload to prove terminal delivery and thread placement, so the missing receipt made reconciliation fail closed. The fix preserves the already-created receipt through `getLastDurableTelegramActionResult()` into the `sendMessage` result (both content JSON and details), matching the Discord action runtime contract. Non-goals: this does not weaken fail-closed reconciliation or retry ambiguous deliveries.

## User Impact

Telegram forum-topic sessions whose terminal reply is a delivered `sendMessage` now finish as `done` with `abortedLastRun=0`; Control UI shows the true session status, and restart recovery keeps proof of delivery.

## Evidence

- Regression test `preserves the durable receipt in terminal forum-topic sendMessage results` fails on pre-fix code and passes with the fix (verified by stashing the production change and rerunning).
- `extensions/telegram/src/action-runtime.test.ts`: 126/126 pass.
- Full Telegram extension project: 3869/3870 pass; the single failure (`setup-surface.test.ts`) also fails on unmodified `main` (pre-existing, unrelated).
- `pnpm check:test-types`, `oxlint`, and `oxfmt --check` clean.
- `git diff --numstat`: production +7/-1 (net +4 logic lines, +3 comment), tests +50/-2.
