### PR TITLE
fix(gateway): send finalized text with required tool calls

### DIFF
--- a/docs/gateway/openai-http-api.md
+++ b/docs/gateway/openai-http-api.md
@@ -203,6 +203,8 @@ When the agent calls tools, the response uses:
 
 When `stream: true`, tool calls arrive as incremental SSE chunks: an initial assistant role delta, optional assistant commentary deltas, one or more `delta.tool_calls` chunks carrying tool identity and argument fragments, then a final chunk with `finish_reason: "tool_calls"` and `data: [DONE]`.
 
+For required or function-pinned tool choices, prose is held until the matching call is confirmed. When the run returns finalized prose, the stream uses that text instead of provisional deltas.
+
 If `stream_options.include_usage=true`, a trailing usage chunk is emitted before `[DONE]`.
 
 ### Tool follow-up loop

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2630,10 +2630,8 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         payloads: [],
         expected: "Working...",
       },
-    ].flatMap((scenario) =>
-      (["required", "pinned"] as const).map((choice) => ({ ...scenario, choice })),
-    ),
-  )("uses $name for $choice tool-stream terminal commentary", async (scenario) => {
+    ].flatMap((scenario) => (["required", "pinned"] as const).map((mode) => ({ scenario, mode }))),
+  )("uses $scenario.name for $mode tool-stream terminal commentary", async ({ scenario, mode }) => {
     agentCommandMock.mockClear();
     agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
       const runId = (opts as { runId: string }).runId;
@@ -2664,9 +2662,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       stream: true,
       tools: [{ type: "function", function: { name: "get_weather", parameters: {} } }],
       tool_choice:
-        scenario.choice === "required"
-          ? "required"
-          : { type: "function", function: { name: "get_weather" } },
+        mode === "required" ? "required" : { type: "function", function: { name: "get_weather" } },
     });
     let content = "";
     const finishReasons: string[] = [];

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2609,6 +2609,79 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     },
   );
 
+  it.each(
+    [
+      {
+        name: "the corrected final payload",
+        provisional: "Working...",
+        replacement: "Done.",
+        payloads: [{ text: "Done." }],
+        expected: "Done.",
+      },
+      {
+        name: "all finalized payloads",
+        provisional: "First.Second.",
+        payloads: [{ text: "First." }, { text: "Second." }],
+        expected: "First.\n\nSecond.",
+      },
+      {
+        name: "streamed commentary when the final payload is empty",
+        provisional: "Working...",
+        payloads: [],
+        expected: "Working...",
+      },
+    ].flatMap((scenario) =>
+      (["required", "pinned"] as const).map((choice) => ({ ...scenario, choice })),
+    ),
+  )("uses $name for $choice tool-stream terminal commentary", async (scenario) => {
+    agentCommandMock.mockClear();
+    agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId: string }).runId;
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: scenario.provisional, delta: scenario.provisional },
+      });
+      if (scenario.replacement) {
+        emitAgentEvent({
+          runId,
+          stream: "assistant",
+          data: { text: scenario.replacement, delta: "", replace: true, phase: "final_answer" },
+        });
+      }
+      return {
+        payloads: scenario.payloads,
+        meta: {
+          stopReason: "tool_calls",
+          pendingToolCalls: [{ id: "call_1", name: "get_weather", arguments: '{"city":"Taipei"}' }],
+        },
+      };
+    }) as never);
+
+    const stream = await createOpenAiChatClient(enabledPort).chat.completions.create({
+      model: "openclaw",
+      messages: [{ role: "user", content: "Check the weather." }],
+      stream: true,
+      tools: [{ type: "function", function: { name: "get_weather", parameters: {} } }],
+      tool_choice:
+        scenario.choice === "required"
+          ? "required"
+          : { type: "function", function: { name: "get_weather" } },
+    });
+    let content = "";
+    const finishReasons: string[] = [];
+    for await (const chunk of stream) {
+      for (const choice of chunk.choices) {
+        content += choice.delta.content ?? "";
+        if (choice.finish_reason) {
+          finishReasons.push(choice.finish_reason);
+        }
+      }
+    }
+    expect(content).toBe(scenario.expected);
+    expect(finishReasons).toEqual(["tool_calls"]);
+  });
+
   it.each([
     {
       name: "successful completion without a provider terminal",

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -1172,7 +1172,6 @@ export async function handleOpenAiHttpRequest(
 
   setSseHeaders(res);
 
-  let wroteRole = false;
   let wroteStopChunk = false;
   let sawAssistantDelta = false;
   let streamedAssistantText = "";
@@ -1287,11 +1286,6 @@ export async function handleOpenAiHttpRequest(
         return;
       }
 
-      if (!wroteRole) {
-        wroteRole = true;
-        writeAssistantRoleChunk(res, streamIdentity);
-      }
-
       sawAssistantDelta = true;
       writeAssistantContentChunk(res, {
         ...streamIdentity,
@@ -1348,7 +1342,6 @@ export async function handleOpenAiHttpRequest(
     releaseStreamRootWork();
   });
 
-  wroteRole = true;
   writeAssistantRoleChunk(res, streamIdentity);
 
   void (async () => {
@@ -1398,10 +1391,6 @@ export async function handleOpenAiHttpRequest(
       }
 
       if (stopReason === "tool_calls" && pendingToolCalls && pendingToolCalls.length > 0) {
-        if (!wroteRole) {
-          wroteRole = true;
-          writeAssistantRoleChunk(res, streamIdentity);
-        }
         if (!sawAssistantDelta) {
           // Final payloads own held prose; snapshots may replace provisional deltas.
           const commentary =
@@ -1425,11 +1414,6 @@ export async function handleOpenAiHttpRequest(
       }
 
       if (!sawAssistantDelta) {
-        if (!wroteRole) {
-          wroteRole = true;
-          writeAssistantRoleChunk(res, streamIdentity);
-        }
-
         const content =
           resolveAgentResponseCommentary(result) ||
           bufferedReplaceableAssistantContent ||

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -1176,7 +1176,6 @@ export async function handleOpenAiHttpRequest(
   let wroteStopChunk = false;
   let sawAssistantDelta = false;
   let streamedAssistantText = "";
-  let bufferedAssistantContent = "";
   let bufferedReplaceableAssistantContent = "";
   let finalUsage: OpenAiChatCompletionsUsage | undefined;
   let finalizeRequested = false;
@@ -1285,7 +1284,6 @@ export async function handleOpenAiHttpRequest(
       // If the provider ignores `tool_choice`, no partial text should leak
       // before the stream fails with an OpenAI-compatible error payload.
       if (toolChoiceConstraint) {
-        bufferedAssistantContent += content;
         return;
       }
 
@@ -1405,9 +1403,10 @@ export async function handleOpenAiHttpRequest(
           writeAssistantRoleChunk(res, streamIdentity);
         }
         if (!sawAssistantDelta) {
+          // Final payloads own held prose; snapshots may replace provisional deltas.
           const commentary =
-            bufferedAssistantContent ||
             resolveAgentResponseCommentary(result) ||
+            streamedAssistantText ||
             bufferedReplaceableAssistantContent;
           if (commentary) {
             sawAssistantDelta = true;


### PR DESCRIPTION
Closes #133205

## What Problem This Solves

Fixes an issue where clients requiring or pinning a function call received provisional text instead of the finalized assistant output from streaming Chat Completions. A run could finalize `Done.` but successfully stream `Working...` alongside its tool call. Multiple final payloads could also lose their paragraph separation.

## Why This Change Was Made

The HTTP finalizer now uses the canonical result before its provisional text fallback, matching non-streaming tool responses. It removes the duplicate constrained-text buffer and the redundant role flag: the initial role frame is already written before the agent starts, so all three later role guards were unreachable.

This keeps tool-choice enforcement, empty-payload fallback, item commentary, and the existing unbuffered append-only rejection unchanged. It introduces no protocol, configuration, persistence, or provider-policy changes. A global snapshot replacement rule would incorrectly conflate distinct commentary items, so this change stays at the owner of the final constrained flush.

## User Impact

Required and function-pinned tool streams now deliver finalized prose and preserve the canonical payload ordering and separation. Default streaming retains its current incremental behavior.

Production: **+2 / −19, net −17**. Tests: +69. Documentation: +2.

## Evidence

Reviewed head: `67359f6c73c57bf7be681f3c11cc0e115e5f967c`.

- Six new official-SDK/HTTP regression cases: four failed before the repair on stale text or missing paragraph separation; the two empty-payload fallback controls already passed.
- Final Chat and Responses suites: **148 tests passed**, including tool handoff, role/terminal frames, usage, append-only errors, client disconnect, and admission cleanup. Command: `node scripts/run-vitest.mjs src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts --maxWorkers 1`.
- An isolated real Gateway and official OpenAI SDK were exercised through the real Responses parser, agent loop, subscription, client-tool adapter, and final payload builder. Synthetic provider events retained one item identity while correcting its final text. Required/pinned output changed from `Working...` to `Done.`; default rejection and append-compatible controls stayed unchanged. This is synthetic provider evidence, not an externally observed provider correction. The later role-state deletion was independently checked as behavior-neutral and covered by the final 148-test run.
- Independent source/behavior verification accepted the final head. Fresh structured Codex autoreview found no accepted P0 findings. The changed gate passed core and test typechecks, then found a test-table object-spread lint issue; the table is corrected, targeted lint and its six regression cases pass. The complete changed gate now passes. A separate read-only Codex review of the exact head found no actionable P0–P3 findings. [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33303263945); the native prepare/merge flow also passed.

Named follow-ups outside this repair: an explicit empty final currently emits no clearing assistant event, and separate commentary items also produce an unkeyed combined preamble. Empty payloads also represent legitimate commentary or intentional silence, so this PR does not infer a new global retraction policy. Neither producer behavior is claimed fixed here.

ClawSweeper review disposition (reviewed exact head above): no supported correctness or security findings. Its SDK-source availability concern is resolved by direct inspection of installed OpenAI SDK 7.5.0, `src/core/streaming.ts:45–123` (ordered SSE decoding, completion sentinel, API errors) and `src/lib/ChatCompletionStream.ts:707–790` (role, appended content, tool-call accumulation), together with the actual official-SDK HTTP proof above. The suggested next step requires no additional repair lane; exact-head CI and native landing gates passed. The review has no separate `Rank-up moves:` list.
