### PR TITLE
fix: keep embedded-run tests inside owned state

### DIFF
--- a/src/agents/embedded-agent-runner/run.before-agent-finalize.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.before-agent-finalize.test-support.ts
@@ -1,10 +1,11 @@
 // Full-entry coverage for before_agent_finalize revision handling in embedded runs.
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   mockedGlobalHookRunner,
   mockedRunEmbeddedAttempt,
-  overflowBaseRunParams,
+  createOverflowRunParams,
   resetSharedRunIntegrationHarnessMocks,
   useOpenAIPlatformAuthFixture,
 } from "./run.overflow-compaction.harness.js";
@@ -14,6 +15,7 @@ import type { EmbeddedRunAttemptResult } from "./run/types.js";
 const REASONING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn recorded reasoning but did not produce a user-visible answer. Continue from that partial turn and produce the visible answer now. Do not restate the reasoning or restart from scratch.";
 
+let state: OpenClawTestState;
 let runEmbeddedAgent: Awaited<ReturnType<typeof loadSharedRunIntegrationHarness>>;
 
 function finalAnswerAttempt(
@@ -59,12 +61,18 @@ describe("runEmbeddedAgent before_agent_finalize", () => {
     runEmbeddedAgent = await loadSharedRunIntegrationHarness();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetSharedRunIntegrationHarnessMocks();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "run.before-agent-finalize" });
     useOpenAIPlatformAuthFixture();
     mockedGlobalHookRunner.hasHooks.mockImplementation(
       (hookName: string) => hookName === "before_agent_finalize",
     );
+  });
+
+  afterEach(async () => {
+    await state?.cleanup();
   });
 
   it("turns a revise decision into one more hidden continuation", async () => {
@@ -80,7 +88,7 @@ describe("runEmbeddedAgent before_agent_finalize", () => {
       .mockResolvedValueOnce(finalAnswerAttempt("Revised answer."));
 
     await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "openai",
       model: "gpt-5.5",
       runId: "run-before-finalize-revise",
@@ -121,7 +129,7 @@ describe("runEmbeddedAgent before_agent_finalize", () => {
       .mockResolvedValueOnce(finalAnswerAttempt("Revised recovered answer."));
 
     await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "openai",
       model: "gpt-5.5",
       runId: "run-before-finalize-after-incomplete-turn",
@@ -151,7 +159,7 @@ describe("runEmbeddedAgent before_agent_finalize", () => {
     );
 
     await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "openai",
       model: "gpt-5.5",
       runId: "run-before-finalize-timeout",

--- a/src/agents/embedded-agent-runner/run.before-agent-reply-cron.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.before-agent-reply-cron.test-support.ts
@@ -1,14 +1,16 @@
 // Full-entry coverage for before_agent_reply hook handling before embedded attempts.
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   mockedGlobalHookRunner,
   mockedRunEmbeddedAttempt,
-  overflowBaseRunParams,
+  createOverflowRunParams,
   resetSharedRunIntegrationHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 
+let state: OpenClawTestState;
 let runEmbeddedAgent: Awaited<ReturnType<typeof loadSharedRunIntegrationHarness>>;
 
 function firstBeforeAgentReplyCall() {
@@ -48,8 +50,14 @@ describe("runEmbeddedAgent before_agent_reply seam", () => {
     runEmbeddedAgent = await loadSharedRunIntegrationHarness();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetSharedRunIntegrationHarnessMocks();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "run.before-agent-reply-cron" });
+  });
+
+  afterEach(async () => {
+    await state?.cleanup();
   });
 
   it("lets before_agent_reply claim cron runs before the embedded attempt starts", async () => {
@@ -65,7 +73,7 @@ describe("runEmbeddedAgent before_agent_reply seam", () => {
     const onExecutionPhase = vi.fn();
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       trigger: "cron",
       jobId: "cron-job-123",
       prompt: "__openclaw_memory_core_short_term_promotion_dream__",
@@ -83,8 +91,8 @@ describe("runEmbeddedAgent before_agent_reply seam", () => {
     expect(hookContext?.jobId).toBe("cron-job-123");
     expect(hookContext?.agentId).toBe("main");
     expect(hookContext?.sessionId).toBe("test-session");
-    expect(hookContext?.sessionKey).toBe(overflowBaseRunParams.sessionKey);
-    expect(hookContext?.workspaceDir).toBe("/tmp/workspace");
+    expect(hookContext?.sessionKey).toBe(createOverflowRunParams(state).sessionKey);
+    expect(hookContext?.workspaceDir).toBe(state.workspaceDir);
     expect(hookContext?.trigger).toBe("cron");
     expect(hookContext?.senderId).toBeUndefined();
     expect(hookContext?.chatId).toBeUndefined();
@@ -102,7 +110,7 @@ describe("runEmbeddedAgent before_agent_reply seam", () => {
     const onExecutionPhase = vi.fn();
 
     await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       trigger: "cron",
       onExecutionPhase,
     });
@@ -125,7 +133,7 @@ describe("runEmbeddedAgent before_agent_reply seam", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult());
 
     await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       trigger: "user",
       toolBindings,
       disableTrajectory: true,
@@ -144,7 +152,7 @@ describe("runEmbeddedAgent before_agent_reply seam", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult());
 
     await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       cleanupBundleMcpOnRunEnd: true,
     });
 

--- a/src/agents/embedded-agent-runner/run.code-mode-reconciliation.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.code-mode-reconciliation.test-support.ts
@@ -1,15 +1,17 @@
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { buildEmbeddedRunnerAssistant } from "../test-helpers/embedded-agent-runner-e2e-fixtures.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   mockedClassifyFailoverReason,
   mockedRunEmbeddedAttempt,
-  overflowBaseRunParams,
+  createOverflowRunParams,
   resetSharedRunIntegrationHarnessMocks,
   useOpenAIPlatformAuthFixture,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 
+let state: OpenClawTestState;
 let runEmbeddedAgent: Awaited<ReturnType<typeof loadSharedRunIntegrationHarness>>;
 
 describe("runEmbeddedAgent Code Mode reconciliation", () => {
@@ -17,10 +19,16 @@ describe("runEmbeddedAgent Code Mode reconciliation", () => {
     runEmbeddedAgent = await loadSharedRunIntegrationHarness();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetSharedRunIntegrationHarnessMocks();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "run.code-mode-reconciliation" });
     mockedClassifyFailoverReason.mockReturnValue(null);
     useOpenAIPlatformAuthFixture();
+  });
+
+  afterEach(async () => {
+    await state?.cleanup();
   });
 
   it("continues a settled partial mutation through inspection and bounded recovery", async () => {
@@ -71,7 +79,7 @@ describe("runEmbeddedAgent Code Mode reconciliation", () => {
       .mockResolvedValueOnce(makeAttemptResult({ assistantTexts: ["Recovery completed."] }));
 
     await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       config: {
         agents: {
           defaults: {
@@ -132,7 +140,7 @@ describe("runEmbeddedAgent Code Mode reconciliation", () => {
       );
 
     await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       config: {
         agents: {
           defaults: {

--- a/src/agents/embedded-agent-runner/run.codex-app-server-recovery.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.codex-app-server-recovery.test-support.ts
@@ -1,19 +1,21 @@
 // Full-entry coverage for replay-safe Codex app-server recovery retries.
 
 import { expectDefined } from "@openclaw/normalization-core";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeModelFallbackCfg } from "../test-helpers/model-fallback-config-fixture.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   mockedClassifyFailoverReason,
   mockedMarkAuthProfileFailure,
   mockedRunEmbeddedAttempt,
-  overflowBaseRunParams,
+  createOverflowRunParams,
   resetSharedRunIntegrationHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./run/types.js";
 
+let state: OpenClawTestState;
 let runEmbeddedAgent: Awaited<ReturnType<typeof loadSharedRunIntegrationHarness>>;
 
 const CODEX_MISSING_TERMINAL_MESSAGE =
@@ -96,9 +98,15 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
     runEmbeddedAgent = await loadSharedRunIntegrationHarness();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetSharedRunIntegrationHarnessMocks();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "run.codex-app-server-recovery" });
     mockedClassifyFailoverReason.mockReturnValue(null);
+  });
+
+  afterEach(async () => {
+    await state?.cleanup();
   });
 
   it("keeps shared abort ownership open through a replay-safe retry", async () => {
@@ -121,7 +129,7 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
       });
 
     await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "codex",
       model: "gpt-5.5",
       runId: "run-codex-freeze-after-retry",
@@ -140,7 +148,7 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
 
     await expect(
       runEmbeddedAgent({
-        ...overflowBaseRunParams,
+        ...createOverflowRunParams(state),
         provider: "codex",
         model: "gpt-5.5",
         runId: "run-codex-cancel-before-retry",
@@ -161,7 +169,7 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
 
     await expect(
       runEmbeddedAgent({
-        ...overflowBaseRunParams,
+        ...createOverflowRunParams(state),
         provider: "codex",
         model: "gpt-5.5",
         runId: "run-codex-cancel-ordinary-failure",
@@ -190,7 +198,7 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
 
     await expect(
       runEmbeddedAgent({
-        ...overflowBaseRunParams,
+        ...createOverflowRunParams(state),
         provider: "codex",
         model: "gpt-5.5",
         runId: "run-codex-cancel-before-model-fallback",
@@ -225,7 +233,7 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
 
     await expect(
       runEmbeddedAgent({
-        ...overflowBaseRunParams,
+        ...createOverflowRunParams(state),
         provider: "codex",
         model: "gpt-5.5",
         runId: "run-codex-upstream-cancel-before-model-fallback",
@@ -245,7 +253,7 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
       .mockResolvedValueOnce(successAttempt());
 
     await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "codex",
       model: "gpt-5.5",
       runId: "run-codex-client-close-retry-mirror",
@@ -269,7 +277,7 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
       .mockResolvedValueOnce(codexTurnCompletionIdleTimeoutAttempt());
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "codex",
       model: "gpt-5.5",
       runId: "run-codex-turn-completion-idle-timeout-retry-exhausted",
@@ -296,7 +304,7 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
       .mockResolvedValueOnce(codexTurnCompletionIdleTimeoutAttempt());
 
     await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "codex",
       model: "gpt-5.5",
       runId: "run-codex-turn-completion-outer-fallback",
@@ -331,7 +339,7 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
     );
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "codex",
       model: "gpt-5.5",
       runId: "run-codex-turn-completion-idle-timeout-fallback",

--- a/src/agents/embedded-agent-runner/run.codex-server-error-fallback.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.codex-server-error-fallback.test-support.ts
@@ -1,5 +1,6 @@
 // Full-entry coverage for handing Codex server_error turns to model fallback.
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
 import { makeModelFallbackCfg } from "../test-helpers/model-fallback-config-fixture.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
@@ -10,12 +11,13 @@ import {
   mockedGlobalHookRunner,
   mockedIsFailoverAssistantError,
   mockedRunEmbeddedAttempt,
-  overflowBaseRunParams,
+  createOverflowRunParams,
   resetSharedRunIntegrationHarnessMocks,
   useOpenAIPlatformAuthFixture,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 
+let state: OpenClawTestState;
 let runEmbeddedAgent: Awaited<ReturnType<typeof loadSharedRunIntegrationHarness>>;
 
 describe("runEmbeddedAgent Codex server_error fallback handoff", () => {
@@ -23,10 +25,16 @@ describe("runEmbeddedAgent Codex server_error fallback handoff", () => {
     runEmbeddedAgent = await loadSharedRunIntegrationHarness();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetSharedRunIntegrationHarnessMocks();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "run.codex-server-error-fallback" });
     useOpenAIPlatformAuthFixture();
     mockedGlobalHookRunner.hasHooks.mockImplementation(() => false);
+  });
+
+  afterEach(async () => {
+    await state?.cleanup();
   });
 
   it("throws FailoverError for Codex server_error when model fallbacks are configured", async () => {
@@ -55,7 +63,7 @@ describe("runEmbeddedAgent Codex server_error fallback handoff", () => {
     );
 
     const promise = runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       runId: "run-codex-server-error-fallback",
       agentHarnessRuntimeOverride: "openclaw",
       config: makeModelFallbackCfg({

--- a/src/agents/embedded-agent-runner/run.compaction-loop-guard.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.compaction-loop-guard.test-support.ts
@@ -1,10 +1,12 @@
 // Full-entry coverage for wiring the post-compaction loop guard into embedded runs.
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import type {
   diagnosticSessionStates as DiagnosticSessionStatesType,
   getDiagnosticSessionState as GetDiagnosticSessionStateType,
   SessionState,
 } from "../../logging/diagnostic-session-state.js";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import type {
   ToolOutcomeObserver,
   wrapToolWithBeforeToolCallHook as WrapToolWithBeforeToolCallHookType,
@@ -20,7 +22,7 @@ import {
   makeOverflowError,
 } from "./run.overflow-compaction.fixture.js";
 import {
-  overflowBaseRunParams as baseParams,
+  createOverflowRunParams,
   mockedCompactDirect,
   mockedIsCompactionFailureError,
   mockedIsLikelyContextOverflowError,
@@ -29,6 +31,8 @@ import {
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 
+let state: OpenClawTestState;
+let baseParams: ReturnType<typeof createOverflowRunParams>;
 let runEmbeddedAgent: Awaited<ReturnType<typeof loadSharedRunIntegrationHarness>>;
 // Import after the shared harness loads so these references point at the
 // same module instances as the re-imported runner graph.
@@ -45,7 +49,7 @@ let PostCompactionLoopPersistedError: typeof PostCompactionLoopPersistedErrorTyp
 const HISTORY_TRIM_CAP = 30;
 
 function recordToolOutcome(
-  state: SessionState,
+  diagnosticState: SessionState,
   toolName: string,
   toolParams: unknown,
   result: unknown,
@@ -53,9 +57,9 @@ function recordToolOutcome(
 ): void {
   // Seed diagnostic history directly for cases that inspect persisted loop
   // state without running a wrapped tool.
-  const toolCallId = `${toolName}-${state.toolCallHistory?.length ?? 0}`;
+  const toolCallId = `${toolName}-${diagnosticState.toolCallHistory?.length ?? 0}`;
   const scope = runId ? { runId } : undefined;
-  recordToolCall(state, toolName, toolParams, toolCallId, undefined, scope);
+  recordToolCall(diagnosticState, toolName, toolParams, toolCallId, undefined, scope);
   const outcome: Parameters<typeof recordToolCallOutcome>[1] = {
     toolName,
     toolParams,
@@ -65,7 +69,7 @@ function recordToolOutcome(
   if (runId) {
     outcome.runId = runId;
   }
-  recordToolCallOutcome(state, outcome);
+  recordToolCallOutcome(diagnosticState, outcome);
 }
 
 let liveToolCallSeq = 0;
@@ -97,6 +101,9 @@ async function executeWrappedToolOutcome(
 }
 
 describe("post-compaction loop guard wired into runEmbeddedAgent", () => {
+  let queuedTasks: Promise<unknown>[];
+  let pendingTasks: Set<Promise<unknown>>;
+  let restoreQueueObserver: (() => void) | undefined;
   beforeAll(async () => {
     runEmbeddedAgent = await loadSharedRunIntegrationHarness();
     // Re-import after the harness reset so we share module instances with
@@ -108,10 +115,36 @@ describe("post-compaction loop guard wired into runEmbeddedAgent", () => {
     ({ PostCompactionLoopPersistedError } = await import("./post-compaction-loop-guard.js"));
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     liveToolCallSeq = 0;
     diagnosticSessionStates.clear();
     resetSharedRunIntegrationHarnessMocks();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "run.compaction-loop-guard" });
+    baseParams = createOverflowRunParams(state);
+    const queue = await import("../../process/command-queue.js");
+    const enqueue = queue.enqueueCommandInLane;
+    queuedTasks = [];
+    pendingTasks = new Set();
+    // Observe the callback, not the caller's timeout race. Delegate unchanged so
+    // the real queue still owns scheduling, errors and AsyncLocalStorage capture.
+    const observe: typeof enqueue = (lane, task, options) =>
+      enqueue(
+        lane,
+        (marker) => {
+          const work = task(marker);
+          queuedTasks.push(work);
+          pendingTasks.add(work);
+          void work.then(
+            () => pendingTasks.delete(work),
+            () => pendingTasks.delete(work),
+          );
+          return work;
+        },
+        options,
+      );
+    const spy = vi.spyOn(queue, "enqueueCommandInLane").mockImplementation(observe);
+    restoreQueueObserver = () => spy.mockRestore();
     mockedIsCompactionFailureError.mockImplementation((msg?: string) => {
       if (!msg) {
         return false;
@@ -131,6 +164,21 @@ describe("post-compaction loop guard wired into runEmbeddedAgent", () => {
         lower.includes("prompt too large")
       );
     });
+  });
+
+  afterEach(async () => {
+    // The ignored backend must settle before canonical cleanup removes its files.
+    // If this join fails, leave the fixture owned by the proof process.
+    try {
+      await Promise.allSettled(queuedTasks);
+      expect(queuedTasks.length, "post-reset queue observer captured actual work").toBeGreaterThan(
+        0,
+      );
+      expect(pendingTasks.size).toBe(0);
+      await state?.cleanup();
+    } finally {
+      restoreQueueObserver?.();
+    }
   });
 
   it("aborts the attempt out-of-band when identical (tool, args, result) repeats windowSize times after compaction", async () => {
@@ -190,7 +238,8 @@ describe("post-compaction loop guard wired into runEmbeddedAgent", () => {
 
   it("releases the lane after a post-compaction abort when the backend ignores cancellation", async () => {
     vi.useFakeTimers();
-    let settleIgnoredAttempt: ((value: ReturnType<typeof makeAttemptResult>) => void) | undefined;
+    const ignoredAttempt = createDeferred<ReturnType<typeof makeAttemptResult>>();
+    let run: ReturnType<typeof runEmbeddedAgent> | undefined;
     let resolveAttemptAborted: (() => void) | undefined;
     const attemptAbortedPromise = new Promise<void>((resolve) => {
       resolveAttemptAborted = resolve;
@@ -218,9 +267,7 @@ describe("post-compaction loop guard wired into runEmbeddedAgent", () => {
         }
         attemptAborted = abortSignal?.aborted ?? false;
         resolveAttemptAborted?.();
-        return await new Promise((resolve) => {
-          settleIgnoredAttempt = resolve;
-        });
+        return await ignoredAttempt.promise;
       });
       mockedCompactDirect.mockResolvedValueOnce(
         makeCompactionSuccess({
@@ -230,7 +277,7 @@ describe("post-compaction loop guard wired into runEmbeddedAgent", () => {
         }),
       );
 
-      const run = runEmbeddedAgent({
+      run = runEmbeddedAgent({
         ...baseParams,
         runId: "run-post-compaction-abort-lane-release",
         timeoutMs: 48 * 60 * 60 * 1000,
@@ -247,16 +294,19 @@ describe("post-compaction loop guard wired into runEmbeddedAgent", () => {
       await vi.advanceTimersByTimeAsync(30_001);
 
       expect(settled).toBe(true);
+      expect(pendingTasks.size, "backend still runs after the outer timeout").toBeGreaterThan(0);
       await expect(run).rejects.toMatchObject({ name: "CommandLaneTaskTimeoutError" });
     } finally {
-      settleIgnoredAttempt?.(makeAttemptResult());
+      ignoredAttempt.resolve(makeAttemptResult());
+      await run?.catch(() => undefined);
       vi.useRealTimers();
     }
   });
 
   it("keeps a native lane alive while a tool is still running", async () => {
     vi.useFakeTimers();
-    let settleAttempt: ((value: ReturnType<typeof makeAttemptResult>) => void) | undefined;
+    const heldAttempt = createDeferred<ReturnType<typeof makeAttemptResult>>();
+    let run: ReturnType<typeof runEmbeddedAgent> | undefined;
     let resolveAttemptStarted: (() => void) | undefined;
     const attemptStarted = new Promise<void>((resolve) => {
       resolveAttemptStarted = resolve;
@@ -268,12 +318,10 @@ describe("post-compaction loop guard wired into runEmbeddedAgent", () => {
         };
         resolveAttemptStarted?.();
         onAttemptTimeoutArmed?.();
-        return await new Promise((resolve) => {
-          settleAttempt = resolve;
-        });
+        return await heldAttempt.promise;
       });
 
-      const run = runEmbeddedAgent({
+      run = runEmbeddedAgent({
         ...baseParams,
         runId: "run-native-tool-heartbeat",
         timeoutMs: 1,
@@ -291,16 +339,19 @@ describe("post-compaction loop guard wired into runEmbeddedAgent", () => {
       await vi.advanceTimersByTimeAsync(30_001);
 
       expect(settled).toBe(false);
-      settleAttempt?.(makeAttemptResult());
+      heldAttempt.resolve(makeAttemptResult());
       await expect(run).resolves.toMatchObject({ meta: { aborted: false } });
     } finally {
+      heldAttempt.resolve(makeAttemptResult());
+      await run?.catch(() => undefined);
       vi.useRealTimers();
     }
   });
 
   it("releases a native lane when a timed-out attempt ignores cancellation", async () => {
     vi.useFakeTimers();
-    let settleAttempt: ((value: ReturnType<typeof makeAttemptResult>) => void) | undefined;
+    const heldAttempt = createDeferred<ReturnType<typeof makeAttemptResult>>();
+    let run: ReturnType<typeof runEmbeddedAgent> | undefined;
     let resolveAttemptStarted: (() => void) | undefined;
     const attemptStarted = new Promise<void>((resolve) => {
       resolveAttemptStarted = resolve;
@@ -314,12 +365,10 @@ describe("post-compaction loop guard wired into runEmbeddedAgent", () => {
         resolveAttemptStarted?.();
         onAttemptTimeoutArmed?.();
         onAttemptTimeout?.(new Error("attempt timed out"));
-        return await new Promise((resolve) => {
-          settleAttempt = resolve;
-        });
+        return await heldAttempt.promise;
       });
 
-      const run = runEmbeddedAgent({
+      run = runEmbeddedAgent({
         ...baseParams,
         runId: "run-native-timeout-lane-release",
         timeoutMs: 48 * 60 * 60 * 1000,
@@ -337,16 +386,19 @@ describe("post-compaction loop guard wired into runEmbeddedAgent", () => {
       await vi.advanceTimersByTimeAsync(30_001);
 
       expect(settled).toBe(true);
+      expect(pendingTasks.size, "backend still runs after the outer timeout").toBeGreaterThan(0);
       await expect(run).rejects.toMatchObject({ name: "CommandLaneTaskTimeoutError" });
     } finally {
-      settleAttempt?.(makeAttemptResult());
+      heldAttempt.resolve(makeAttemptResult());
+      await run?.catch(() => undefined);
       vi.useRealTimers();
     }
   });
 
   it("releases a native lane when an explicit abort ignores cancellation", async () => {
     vi.useFakeTimers();
-    let settleAttempt: ((value: ReturnType<typeof makeAttemptResult>) => void) | undefined;
+    const heldAttempt = createDeferred<ReturnType<typeof makeAttemptResult>>();
+    let run: ReturnType<typeof runEmbeddedAgent> | undefined;
     let resolveAttemptStarted: (() => void) | undefined;
     const attemptStarted = new Promise<void>((resolve) => {
       resolveAttemptStarted = resolve;
@@ -360,12 +412,10 @@ describe("post-compaction loop guard wired into runEmbeddedAgent", () => {
         resolveAttemptStarted?.();
         onAttemptTimeoutArmed?.();
         onAttemptAbort?.();
-        return await new Promise((resolve) => {
-          settleAttempt = resolve;
-        });
+        return await heldAttempt.promise;
       });
 
-      const run = runEmbeddedAgent({
+      run = runEmbeddedAgent({
         ...baseParams,
         runId: "run-native-abort-lane-release",
         timeoutMs: 48 * 60 * 60 * 1000,
@@ -383,9 +433,11 @@ describe("post-compaction loop guard wired into runEmbeddedAgent", () => {
       await vi.advanceTimersByTimeAsync(30_001);
 
       expect(settled).toBe(true);
+      expect(pendingTasks.size, "backend still runs after the outer timeout").toBeGreaterThan(0);
       await expect(run).rejects.toMatchObject({ name: "CommandLaneTaskTimeoutError" });
     } finally {
-      settleAttempt?.(makeAttemptResult());
+      heldAttempt.resolve(makeAttemptResult());
+      await run?.catch(() => undefined);
       vi.useRealTimers();
     }
   });

--- a/src/agents/embedded-agent-runner/run.cross-provider-fallback-error-context.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.cross-provider-fallback-error-context.test-support.ts
@@ -1,5 +1,6 @@
 // Full-entry coverage for current-attempt error context across model fallback.
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
 import { makeModelFallbackCfg } from "../test-helpers/model-fallback-config-fixture.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
@@ -14,13 +15,14 @@ import {
   mockedIsRateLimitAssistantError,
   mockedRunEmbeddedAttempt,
   mockedResolveAuthProfileOrder,
-  overflowBaseRunParams,
+  createOverflowRunParams,
   resetSharedRunIntegrationHarnessMocks,
   warmRunOverflowCompactionHarness,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
+let state: OpenClawTestState;
 let runEmbeddedAgent: Awaited<ReturnType<typeof loadSharedRunIntegrationHarness>>;
 const DEEPSEEK_ERROR_MESSAGE = "429 insufficient quota";
 const COMPACTION_REMOVED_ERROR_MESSAGE = "current candidate model unavailable";
@@ -136,9 +138,9 @@ function setupCompactionRemovedFallbackAttempt() {
   );
 }
 
-function runCompactionRemovedFallbackAttempt() {
+function runCompactionRemovedFallbackAttempt(ownedState: OpenClawTestState) {
   return runEmbeddedAgent({
-    ...overflowBaseRunParams,
+    ...createOverflowRunParams(ownedState),
     runId: "run-compaction-fallback-error-context",
     config: makeCrossProviderFallbackConfig(),
     agentHarnessRuntimeOverride: "openclaw",
@@ -165,20 +167,29 @@ async function expectDeepseekFallbackError(
 describe("runEmbeddedAgent cross-provider fallback error handling", () => {
   beforeAll(async () => {
     runEmbeddedAgent = await loadSharedRunIntegrationHarness();
-    await warmRunOverflowCompactionHarness(runEmbeddedAgent, {
-      config: makeCrossProviderFallbackConfig(),
-      agentHarnessRuntimeOverride: "openclaw",
-      provider: "deepseek",
-      model: "deepseek-chat",
+    const { withOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    await withOpenClawTestState({ label: "cross-provider-warmup" }, async (warmupState) => {
+      await warmRunOverflowCompactionHarness(runEmbeddedAgent, warmupState, {
+        config: makeCrossProviderFallbackConfig(),
+        agentHarnessRuntimeOverride: "openclaw",
+        provider: "deepseek",
+        model: "deepseek-chat",
+      });
+      setupCompactionRemovedFallbackAttempt();
+      await runCompactionRemovedFallbackAttempt(warmupState).catch(() => undefined);
     });
-    setupCompactionRemovedFallbackAttempt();
-    await runCompactionRemovedFallbackAttempt().catch(() => undefined);
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetSharedRunIntegrationHarnessMocks();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "run.cross-provider-fallback-error-context" });
     useCrossProviderAuthFixture();
     mockedGlobalHookRunner.hasHooks.mockImplementation(() => false);
+  });
+
+  afterEach(async () => {
+    await state?.cleanup();
   });
 
   it("uses the current attempt assistant for fallback errors instead of stale session history", async () => {
@@ -205,7 +216,7 @@ describe("runEmbeddedAgent cross-provider fallback error handling", () => {
     );
 
     const promise = runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       runId: "run-cross-provider-fallback-error-context",
       config: makeCrossProviderFallbackConfig(),
       agentHarnessRuntimeOverride: "openclaw",
@@ -222,7 +233,7 @@ describe("runEmbeddedAgent cross-provider fallback error handling", () => {
   it("falls back to the session assistant when compaction removes the current attempt slice", async () => {
     const getLastFormattedAssistant = captureFormattedAssistant();
     setupCompactionRemovedFallbackAttempt();
-    const promise = runCompactionRemovedFallbackAttempt();
+    const promise = runCompactionRemovedFallbackAttempt(state);
 
     await expect(promise).rejects.toBeInstanceOf(MockedFailoverError);
     await expect(promise).rejects.toThrow(
@@ -256,7 +267,7 @@ describe("runEmbeddedAgent cross-provider fallback error handling", () => {
     );
 
     const promise = runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       runId: "run-stale-session-assistant-timeout",
       config: makeCrossProviderFallbackConfig(),
       agentHarnessRuntimeOverride: "openclaw",
@@ -294,7 +305,7 @@ describe("runEmbeddedAgent cross-provider fallback error handling", () => {
     );
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       runId: "run-stale-session-assistant-non-timeout",
       config: makeCrossProviderFallbackConfig(),
       agentHarnessRuntimeOverride: "openclaw",

--- a/src/agents/embedded-agent-runner/run.empty-error-retry.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.test-support.ts
@@ -1,17 +1,19 @@
 // Full-entry coverage for retrying empty errored assistant turns.
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   mockedClassifyAssistantFailoverReason,
   mockedClassifyFailoverReason,
   mockedGlobalHookRunner,
   mockedRunEmbeddedAttempt,
-  overflowBaseRunParams,
+  createOverflowRunParams,
   resetSharedRunIntegrationHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
+let state: OpenClawTestState;
 let runEmbeddedAgent: Awaited<ReturnType<typeof loadSharedRunIntegrationHarness>>;
 
 type AssistantContent = NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>["content"];
@@ -62,10 +64,16 @@ describe("runEmbeddedAgent silent-error retry", () => {
     runEmbeddedAgent = await loadSharedRunIntegrationHarness();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetSharedRunIntegrationHarnessMocks();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "run.empty-error-retry" });
     mockedGlobalHookRunner.hasHooks.mockImplementation(() => false);
     mockedClassifyFailoverReason.mockReturnValue(null);
+  });
+
+  afterEach(async () => {
+    await state?.cleanup();
   });
 
   it("retries when a turn ends with stopReason=error and zero output tokens", async () => {
@@ -73,7 +81,7 @@ describe("runEmbeddedAgent silent-error retry", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(successAttempt("ollama", "glm-5.1:cloud"));
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "ollama",
       model: "glm-5.1:cloud",
       runId: "run-empty-error-retry-basic",
@@ -91,7 +99,7 @@ describe("runEmbeddedAgent silent-error retry", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(successAttempt("anthropic", "claude-opus-4-8"));
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "anthropic",
       model: "claude-opus-4-8",
       runId: "run-empty-error-retry-server-error",
@@ -120,7 +128,7 @@ describe("runEmbeddedAgent silent-error retry", () => {
     );
 
     await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "anthropic",
       model: "missing-model",
       runId: "run-empty-error-retry-non-transient",
@@ -136,7 +144,7 @@ describe("runEmbeddedAgent silent-error retry", () => {
     }
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "ollama",
       model: "glm-5.1:cloud",
       runId: "run-empty-error-retry-exhausted",
@@ -165,7 +173,7 @@ describe("runEmbeddedAgent silent-error retry", () => {
     );
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "anthropic",
       model: "claude-opus-4-8",
       runId: "run-terminal-heartbeat-not-fallback-safe",

--- a/src/agents/embedded-agent-runner/run.fast-mode-auto.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.fast-mode-auto.test-support.ts
@@ -1,22 +1,22 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
-import {
-  onAgentEvent,
-  resetAgentEventsForTest,
-  type AgentEventPayload,
-} from "../../infra/agent-events.js";
+import type { AgentEventPayload } from "../../infra/agent-events.js";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   mockedClassifyFailoverReason,
   mockedGlobalHookRunner,
   mockedRunEmbeddedAttempt,
-  overflowBaseRunParams,
+  createOverflowRunParams,
   resetSharedRunIntegrationHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
+let state: OpenClawTestState;
 let runEmbeddedAgent: Awaited<ReturnType<typeof loadSharedRunIntegrationHarness>>;
+let onAgentEvent: typeof import("../../infra/agent-events.js").onAgentEvent;
+let resetAgentEventsForTest: typeof import("../../infra/agent-events.js").resetAgentEventsForTest;
 
 function successAttempt(provider: string, model: string): EmbeddedRunAttemptResult {
   return makeAttemptResult({
@@ -54,17 +54,21 @@ function resolveAttemptFastMode(params: unknown): void {
 describe("runEmbeddedAgent fast auto progress", () => {
   beforeAll(async () => {
     runEmbeddedAgent = await loadSharedRunIntegrationHarness();
+    ({ onAgentEvent, resetAgentEventsForTest } = await import("../../infra/agent-events.js"));
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetSharedRunIntegrationHarnessMocks();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "run.fast-mode-auto" });
     mockedGlobalHookRunner.hasHooks.mockImplementation(() => false);
     mockedClassifyFailoverReason.mockReturnValue(null);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.useRealTimers();
     resetAgentEventsForTest();
+    await state?.cleanup();
   });
 
   it("uses the selected model's auto cutoff when the caller omits one", async () => {
@@ -76,7 +80,7 @@ describe("runEmbeddedAgent fast auto progress", () => {
     });
 
     await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "ollama",
       model: "glm-5.1:cloud",
       config: {
@@ -130,7 +134,7 @@ describe("runEmbeddedAgent fast auto progress", () => {
     });
 
     const resultPromise = runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "ollama",
       model: "glm-5.1:cloud",
       runId: "run-fast-auto-retry",
@@ -143,63 +147,72 @@ describe("runEmbeddedAgent fast auto progress", () => {
         toolResults.push(payload);
       },
     });
+    try {
+      await vi.advanceTimersByTimeAsync(0);
+      await attemptStarted.promise;
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(31_000);
 
-    await vi.advanceTimersByTimeAsync(0);
-    await attemptStarted.promise;
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
-    await vi.advanceTimersByTimeAsync(31_000);
+      expect(events.map((event) => event.data?.summary).filter(Boolean)).toHaveLength(0);
+      expect(toolResults).toHaveLength(0);
+      expect(globalSummaries).toHaveLength(0);
 
-    expect(events.map((event) => event.data?.summary).filter(Boolean)).toHaveLength(0);
-    expect(toolResults).toHaveLength(0);
-    expect(globalSummaries).toHaveLength(0);
+      attemptParams?.onRunProgress?.({ reason: "model-progress" });
+      await vi.advanceTimersByTimeAsync(2);
+      expect(events).toHaveLength(0);
+      expect(toolResults).toHaveLength(0);
+      expect(globalSummaries).toHaveLength(0);
 
-    attemptParams?.onRunProgress?.({ reason: "model-progress" });
-    await vi.advanceTimersByTimeAsync(2);
-    expect(events).toHaveLength(0);
-    expect(toolResults).toHaveLength(0);
-    expect(globalSummaries).toHaveLength(0);
+      await attemptParams?.onToolResult?.({ text: "🛠️ Exec: still running" });
+      await vi.advanceTimersByTimeAsync(2);
+      expect(events.map((event) => event.data?.summary).filter(Boolean)).toHaveLength(0);
+      expect(toolResults.map((payload) => payload.text)).toEqual(["🛠️ Exec: still running"]);
+      expect(globalSummaries).toHaveLength(0);
 
-    await attemptParams?.onToolResult?.({ text: "🛠️ Exec: still running" });
-    await vi.advanceTimersByTimeAsync(2);
-    expect(events.map((event) => event.data?.summary).filter(Boolean)).toHaveLength(0);
-    expect(toolResults.map((payload) => payload.text)).toEqual(["🛠️ Exec: still running"]);
-    expect(globalSummaries).toHaveLength(0);
+      await attemptParams?.onAgentEvent?.({
+        stream: "tool",
+        data: { phase: "start", name: "exec" },
+      });
+      await vi.advanceTimersByTimeAsync(2);
 
-    await attemptParams?.onAgentEvent?.({
-      stream: "tool",
-      data: { phase: "start", name: "exec" },
-    });
-    await vi.advanceTimersByTimeAsync(2);
+      expect(events.map((event) => event.data?.summary).filter(Boolean)).toHaveLength(0);
+      expect(toolResults.map((payload) => payload.text)).toEqual(["🛠️ Exec: still running"]);
+      expect(globalSummaries).toHaveLength(0);
 
-    expect(events.map((event) => event.data?.summary).filter(Boolean)).toHaveLength(0);
-    expect(toolResults.map((payload) => payload.text)).toEqual(["🛠️ Exec: still running"]);
-    expect(globalSummaries).toHaveLength(0);
+      await attemptParams?.onAgentEvent?.({
+        stream: "tool",
+        data: { phase: "result", name: "exec" },
+      });
+      await vi.advanceTimersByTimeAsync(2);
 
-    await attemptParams?.onAgentEvent?.({
-      stream: "tool",
-      data: { phase: "result", name: "exec" },
-    });
-    await vi.advanceTimersByTimeAsync(2);
+      expect(events.map((event) => event.data?.summary).filter(Boolean)).toHaveLength(0);
+      expect(globalSummaries).toHaveLength(0);
 
-    expect(events.map((event) => event.data?.summary).filter(Boolean)).toHaveLength(0);
-    expect(globalSummaries).toHaveLength(0);
+      await attemptParams?.onToolStreamBoundary?.();
+      await vi.advanceTimersByTimeAsync(2);
 
-    await attemptParams?.onToolStreamBoundary?.();
-    await vi.advanceTimersByTimeAsync(2);
+      const summaries = events.map((event) => event.data?.summary).filter(Boolean);
+      expect(summaries).toContain("💨Fast: auto-off(31s>=30s)");
+      expect(globalSummaries).toContain("💨Fast: auto-off(31s>=30s)");
+      expect(toolResults.some((payload) => payload.text === "💨Fast: auto-off(31s>=30s)")).toBe(
+        true,
+      );
+      expect(toolResults.at(-1)?.channelData?.openclawProgressKind).toBe("fast-mode-auto");
 
-    const summaries = events.map((event) => event.data?.summary).filter(Boolean);
-    expect(summaries).toContain("💨Fast: auto-off(31s>=30s)");
-    expect(globalSummaries).toContain("💨Fast: auto-off(31s>=30s)");
-    expect(toolResults.some((payload) => payload.text === "💨Fast: auto-off(31s>=30s)")).toBe(true);
-    expect(toolResults.at(-1)?.channelData?.openclawProgressKind).toBe("fast-mode-auto");
+      completeAttempt?.();
+      await resultPromise;
 
-    completeAttempt?.();
-    await resultPromise;
-
-    expect(events.map((event) => event.data?.summary)).toContain("💨Fast: auto-on");
-    expect(toolResults.map((payload) => payload.text)).toContain("💨Fast: auto-on");
-    expect(globalSummaries).toContain("💨Fast: auto-on");
-    stopGlobalCapture();
+      expect(events.map((event) => event.data?.summary)).toContain("💨Fast: auto-on");
+      expect(toolResults.map((payload) => payload.text)).toContain("💨Fast: auto-on");
+      expect(globalSummaries).toContain("💨Fast: auto-on");
+    } finally {
+      completeAttempt?.();
+      try {
+        await resultPromise;
+      } finally {
+        stopGlobalCapture();
+      }
+    }
   });
 
   it("emits one auto-off notice at the first completed boundary past the threshold", async () => {
@@ -228,7 +241,7 @@ describe("runEmbeddedAgent fast auto progress", () => {
     });
 
     const resultPromise = runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "ollama",
       model: "glm-5.1:cloud",
       runId: "run-fast-auto-single-off",
@@ -241,41 +254,45 @@ describe("runEmbeddedAgent fast auto progress", () => {
         toolResults.push(payload);
       },
     });
+    try {
+      await vi.advanceTimersByTimeAsync(0);
+      await attemptStarted.promise;
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(31_000);
+      await attemptParams?.onAgentEvent?.({
+        stream: "tool",
+        data: { phase: "result", name: "exec" },
+      });
+      await attemptParams?.onToolStreamBoundary?.();
 
-    await vi.advanceTimersByTimeAsync(0);
-    await attemptStarted.promise;
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
-    await vi.advanceTimersByTimeAsync(31_000);
-    await attemptParams?.onAgentEvent?.({
-      stream: "tool",
-      data: { phase: "result", name: "exec" },
-    });
-    await attemptParams?.onToolStreamBoundary?.();
+      await vi.advanceTimersByTimeAsync(14_000);
+      await attemptParams?.onAgentEvent?.({
+        stream: "tool",
+        data: { phase: "result", name: "exec" },
+      });
+      await attemptParams?.onToolStreamBoundary?.();
+      await attemptParams?.onToolResult?.({ text: "🛠️ Exec: later tool summary" });
 
-    await vi.advanceTimersByTimeAsync(14_000);
-    await attemptParams?.onAgentEvent?.({
-      stream: "tool",
-      data: { phase: "result", name: "exec" },
-    });
-    await attemptParams?.onToolStreamBoundary?.();
-    await attemptParams?.onToolResult?.({ text: "🛠️ Exec: later tool summary" });
+      completeAttempt?.();
+      await resultPromise;
 
-    completeAttempt?.();
-    await resultPromise;
+      const autoOffEvents = events
+        .map((event) => event.data?.summary)
+        .filter((summary) => typeof summary === "string" && summary.includes("Fast: auto-off"));
+      const autoOffToolResults = toolResults
+        .map((payload) => payload.text)
+        .filter((text) => typeof text === "string" && text.includes("Fast: auto-off"));
 
-    const autoOffEvents = events
-      .map((event) => event.data?.summary)
-      .filter((summary) => typeof summary === "string" && summary.includes("Fast: auto-off"));
-    const autoOffToolResults = toolResults
-      .map((payload) => payload.text)
-      .filter((text) => typeof text === "string" && text.includes("Fast: auto-off"));
-
-    expect(autoOffEvents).toEqual(["💨Fast: auto-off(31s>=30s)"]);
-    expect(autoOffToolResults).toEqual(["💨Fast: auto-off(31s>=30s)"]);
-    expect(attemptParams?.fastModeAutoProgressState).toMatchObject({
-      offAnnounced: true,
-      resetAnnounced: true,
-    });
+      expect(autoOffEvents).toEqual(["💨Fast: auto-off(31s>=30s)"]);
+      expect(autoOffToolResults).toEqual(["💨Fast: auto-off(31s>=30s)"]);
+      expect(attemptParams?.fastModeAutoProgressState).toMatchObject({
+        offAnnounced: true,
+        resetAnnounced: true,
+      });
+    } finally {
+      completeAttempt?.();
+      await resultPromise;
+    }
   });
 
   it.each(["agent-event", "tool-result"] as const)(
@@ -306,7 +323,7 @@ describe("runEmbeddedAgent fast auto progress", () => {
       });
 
       const resultPromise = runEmbeddedAgent({
-        ...overflowBaseRunParams,
+        ...createOverflowRunParams(state),
         provider: "ollama",
         model: "glm-5.1:cloud",
         runId: `run-fast-auto-off-${failureTarget}`,
@@ -330,27 +347,31 @@ describe("runEmbeddedAgent fast auto progress", () => {
           }
         },
       });
+      try {
+        await vi.advanceTimersByTimeAsync(0);
+        await attemptStarted.promise;
+        expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+        await vi.advanceTimersByTimeAsync(61_000);
+        await attemptParams?.onAgentEvent?.({
+          stream: "tool",
+          data: { phase: "result", name: "exec" },
+        });
+        await attemptParams?.onToolStreamBoundary?.();
 
-      await vi.advanceTimersByTimeAsync(0);
-      await attemptStarted.promise;
-      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
-      await vi.advanceTimersByTimeAsync(61_000);
-      await attemptParams?.onAgentEvent?.({
-        stream: "tool",
-        data: { phase: "result", name: "exec" },
-      });
-      await attemptParams?.onToolStreamBoundary?.();
+        completeAttempt?.();
+        await expect(resultPromise).resolves.toBeTruthy();
 
-      completeAttempt?.();
-      await expect(resultPromise).resolves.toBeTruthy();
-
-      expect(events.map((event) => event.data?.summary).filter(Boolean)).toContainEqual(
-        expect.stringMatching(/^💨Fast: auto-off\(/u),
-      );
-      if (failureTarget === "tool-result") {
-        expect(toolResults.map((payload) => payload.text)).toContainEqual(
+        expect(events.map((event) => event.data?.summary).filter(Boolean)).toContainEqual(
           expect.stringMatching(/^💨Fast: auto-off\(/u),
         );
+        if (failureTarget === "tool-result") {
+          expect(toolResults.map((payload) => payload.text)).toContainEqual(
+            expect.stringMatching(/^💨Fast: auto-off\(/u),
+          );
+        }
+      } finally {
+        completeAttempt?.();
+        await resultPromise;
       }
     },
   );
@@ -383,7 +404,7 @@ describe("runEmbeddedAgent fast auto progress", () => {
       });
 
       const resultPromise = runEmbeddedAgent({
-        ...overflowBaseRunParams,
+        ...createOverflowRunParams(state),
         provider: "ollama",
         model: "glm-5.1:cloud",
         runId: `run-fast-auto-reset-${failureTarget}`,
@@ -402,27 +423,31 @@ describe("runEmbeddedAgent fast auto progress", () => {
           }
         },
       });
+      try {
+        await vi.advanceTimersByTimeAsync(0);
+        await attemptStarted.promise;
+        expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+        await vi.advanceTimersByTimeAsync(61_000);
+        await attemptParams?.onAgentEvent?.({
+          stream: "tool",
+          data: { phase: "result", name: "exec" },
+        });
+        await attemptParams?.onToolStreamBoundary?.();
 
-      await vi.advanceTimersByTimeAsync(0);
-      await attemptStarted.promise;
-      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
-      await vi.advanceTimersByTimeAsync(61_000);
-      await attemptParams?.onAgentEvent?.({
-        stream: "tool",
-        data: { phase: "result", name: "exec" },
-      });
-      await attemptParams?.onToolStreamBoundary?.();
+        expect(events.map((event) => event.data?.summary).filter(Boolean)).toContainEqual(
+          expect.stringMatching(/^💨Fast: auto-off\(/u),
+        );
 
-      expect(events.map((event) => event.data?.summary).filter(Boolean)).toContainEqual(
-        expect.stringMatching(/^💨Fast: auto-off\(/u),
-      );
+        completeAttempt?.();
+        await expect(resultPromise).resolves.toBeTruthy();
 
-      completeAttempt?.();
-      await expect(resultPromise).resolves.toBeTruthy();
-
-      expect(events.map((event) => event.data?.summary)).toContain("💨Fast: auto-on");
-      if (failureTarget === "tool-result") {
-        expect(toolResults.map((payload) => payload.text)).toContain("💨Fast: auto-on");
+        expect(events.map((event) => event.data?.summary)).toContain("💨Fast: auto-on");
+        if (failureTarget === "tool-result") {
+          expect(toolResults.map((payload) => payload.text)).toContain("💨Fast: auto-on");
+        }
+      } finally {
+        completeAttempt?.();
+        await resultPromise;
       }
     },
   );

--- a/src/agents/embedded-agent-runner/run.harness-auth-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run.harness-auth-failover.test.ts
@@ -1,22 +1,24 @@
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
+  mockedAcquireAgentRunPreparedModelRuntime,
   mockedBuildEmbeddedRunPayloads,
   mockedEnsureAuthProfileStore,
   mockedGetApiKeyForModel,
   mockedMarkAuthProfileFailure,
   mockedResolveAuthProfileOrder,
   mockedRunEmbeddedAttempt,
-  overflowBaseRunParams,
+  createOverflowRunParams,
   resetSharedRunIntegrationHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
+import { guardRunWorkspaceOwnership } from "./run.workspace-ownership.test-support.js";
 
 let runHarness: Awaited<ReturnType<typeof loadRunOverflowCompactionHarness>>;
 beforeAll(async () => {
   runHarness = await loadRunOverflowCompactionHarness();
 });
-beforeEach(resetSharedRunIntegrationHarnessMocks);
 
 const failedProfile = "openai:failed";
 const backupProfile = "openai:backup";
@@ -66,6 +68,21 @@ function prepareAuthFailoverRun() {
 }
 
 describe("native harness auth failover", () => {
+  let state: OpenClawTestState;
+  let guard: Awaited<ReturnType<typeof guardRunWorkspaceOwnership>>;
+  beforeEach(async () => {
+    resetSharedRunIntegrationHarnessMocks();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "harness-auth-failover" });
+    guard = await guardRunWorkspaceOwnership(state);
+  });
+  afterEach(async () => {
+    try {
+      guard?.verifyAndRestore();
+    } finally {
+      await state?.cleanup();
+    }
+  });
   it("retries a permanent harness auth failure with the next automatic profile", async () => {
     const runEmbeddedAgent = prepareAuthFailoverRun();
     mockedBuildEmbeddedRunPayloads.mockReturnValue([{ text: "OK" }]);
@@ -75,7 +92,7 @@ describe("native harness auth failover", () => {
 
     await expect(
       runEmbeddedAgent({
-        ...overflowBaseRunParams,
+        ...createOverflowRunParams(state),
         provider: "openai",
         model: "gpt-5.6-luna",
         authProfileId: failedProfile,
@@ -90,6 +107,16 @@ describe("native harness auth failover", () => {
     expect(mockedMarkAuthProfileFailure).toHaveBeenCalledWith(
       expect.objectContaining({ profileId: failedProfile, reason: "auth_permanent" }),
     );
+    // Omitting config and agentDir must still choose the configless lifetime and
+    // resolve auth/session ownership beneath this fixture, not a caller override.
+    expect(mockedAcquireAgentRunPreparedModelRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentDir: state.agentDir(),
+        inheritedAuthDir: state.agentDir(),
+        workspaceDir: state.workspaceDir,
+      }),
+      expect.objectContaining({ retainIdleRunOwner: true }),
+    );
   });
 
   it("keeps an explicit user profile strict", async () => {
@@ -99,7 +126,7 @@ describe("native harness auth failover", () => {
 
     await expect(
       runEmbeddedAgent({
-        ...overflowBaseRunParams,
+        ...createOverflowRunParams(state),
         provider: "openai",
         model: "gpt-5.6-luna",
         authProfileId: failedProfile,
@@ -121,7 +148,7 @@ describe("native harness auth failover", () => {
 
     await expect(
       runEmbeddedAgent({
-        ...overflowBaseRunParams,
+        ...createOverflowRunParams(state),
         provider: "openai",
         model: "gpt-5.6-luna",
         authProfileId: failedProfile,
@@ -142,7 +169,7 @@ describe("native harness auth failover", () => {
 
     await expect(
       runEmbeddedAgent({
-        ...overflowBaseRunParams,
+        ...createOverflowRunParams(state),
         provider: "openai",
         model: "gpt-5.6-luna",
         runId: "run-native-harness-non-auth-failure",

--- a/src/agents/embedded-agent-runner/run.inherited-auth-owner.test.ts
+++ b/src/agents/embedded-agent-runner/run.inherited-auth-owner.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { listAgentIds } from "../agent-scope-config.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
@@ -8,7 +9,7 @@ import {
   mockedAcquireAgentRunPreparedModelRuntime,
   mockedBuildEmbeddedRunPayloads,
   mockedRunEmbeddedAttempt,
-  overflowBaseRunParams,
+  createOverflowRunParams,
   resetSharedRunIntegrationHarnessMocks,
   useOpenAIPlatformAuthFixture,
 } from "./run.overflow-compaction.harness.js";
@@ -28,12 +29,20 @@ function projectSetupExecutionConfig(source: OpenClawConfig): OpenClawConfig {
   };
 }
 
+let state: OpenClawTestState;
+
 describe("embedded setup inference inherited auth owner", () => {
   // Provider-pinned runs stay on the mocked plugin harness, so no host-route
-  // warmup is needed here; see overflowBaseRunParams for the route trap.
-  beforeEach(() => {
+  // warmup is needed here; see createOverflowRunParams for the route trap.
+  beforeEach(async () => {
     resetSharedRunIntegrationHarnessMocks();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "run.inherited-auth-owner" });
     useOpenAIPlatformAuthFixture();
+  });
+
+  afterEach(async () => {
+    await state?.cleanup();
   });
 
   it.each([
@@ -49,7 +58,7 @@ describe("embedded setup inference inherited auth owner", () => {
       mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ assistantTexts: ["OK"] }));
 
       await runEmbeddedAgent({
-        ...overflowBaseRunParams,
+        ...createOverflowRunParams(state),
         // Auth-owner resolution is provider-agnostic. Route through the mocked
         // plugin harness so this shard does not compile the bundled Anthropic
         // provider policy from source just to assert an agent directory.

--- a/src/agents/embedded-agent-runner/run.midturn-precheck-retry.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.midturn-precheck-retry.test-support.ts
@@ -1,5 +1,6 @@
 // Full-entry coverage for retrying an already-capped mid-turn transcript.
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { buildEmbeddedRunnerAssistant } from "../test-helpers/embedded-agent-runner-e2e-fixtures.js";
 import {
   makeAttemptResult,
@@ -9,7 +10,7 @@ import {
 import {
   mockedCompactDirect,
   mockedRunEmbeddedAttempt,
-  overflowBaseRunParams,
+  createOverflowRunParams,
   resetSharedRunIntegrationHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
@@ -28,6 +29,7 @@ const settledExecResult = {
   timestamp: 2,
 };
 
+let state: OpenClawTestState;
 let runEmbeddedAgent: Awaited<ReturnType<typeof loadSharedRunIntegrationHarness>>;
 
 function requireAttemptCall(index: number): {
@@ -52,7 +54,7 @@ function expectRetryContinuesFromTranscript(): void {
   const retry = requireAttemptCall(1);
   expect(retry.prompt).toContain("Continue from the current transcript");
   expect(retry.suppressNextUserMessagePersistence).toBe(true);
-  expect(retry.prompt).not.toBe(overflowBaseRunParams.prompt);
+  expect(retry.prompt).not.toBe(createOverflowRunParams(state).prompt);
 }
 
 function makeReplayUnsafeMidTurnOverflow(params?: {
@@ -101,8 +103,14 @@ describe("runEmbeddedAgent mid-turn precheck retry", () => {
     runEmbeddedAgent = await loadSharedRunIntegrationHarness();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetSharedRunIntegrationHarnessMocks();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "run.midturn-precheck-retry" });
+  });
+
+  afterEach(async () => {
+    await state?.cleanup();
   });
 
   it("continues once when persisted truncation is already a no-op", async () => {
@@ -122,7 +130,7 @@ describe("runEmbeddedAgent mid-turn precheck retry", () => {
       .mockResolvedValueOnce(makeAttemptResult());
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       runId: "run-midturn-precheck-noop",
       promptCacheKey: "stable-cache-key",
     });
@@ -162,7 +170,7 @@ describe("runEmbeddedAgent mid-turn precheck retry", () => {
     );
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       runId: "run-midturn-precheck-provider-overflow",
     });
 
@@ -185,7 +193,7 @@ describe("runEmbeddedAgent mid-turn precheck retry", () => {
     );
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       runId: "run-midturn-settled-unsafe",
     });
 
@@ -216,7 +224,7 @@ describe("runEmbeddedAgent mid-turn precheck retry", () => {
     );
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       runId: "run-midturn-waiting-exec",
     });
 
@@ -250,7 +258,7 @@ describe("runEmbeddedAgent mid-turn precheck retry", () => {
       );
 
       const result = await runEmbeddedAgent({
-        ...overflowBaseRunParams,
+        ...createOverflowRunParams(state),
         runId: `run-midturn-waiting-exec-rotated-${activeCount}`,
       });
 
@@ -273,7 +281,7 @@ describe("runEmbeddedAgent mid-turn precheck retry", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeReplayUnsafeMidTurnOverflow(attemptParams));
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       runId: `run-midturn-fail-closed-${_label.replaceAll(" ", "-")}`,
     });
 
@@ -297,7 +305,7 @@ describe("runEmbeddedAgent mid-turn precheck retry", () => {
     });
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       runId: "run-midturn-settled-compaction-failure",
     });
 

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -19,6 +19,7 @@ import type {
   PluginHookBeforePromptBuildResult,
 } from "../../plugins/types.js";
 import { resetCommandQueueStateForTest } from "../../process/command-queue.test-support.js";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { extractObservedOverflowTokenCount } from "../embedded-agent-helpers/context-overflow-observation.js";
 import type { FailoverReason } from "../failover/signal.js";
@@ -447,15 +448,17 @@ const mockedShouldPreferExplicitConfigApiKeyAuth = vi.fn(() => false);
 // the mocked codex harness does not claim: such runs select the built-in openclaw
 // host harness and pay its one-time source-compile cost. Suites proving plugin
 // harness behavior must pin provider "openai" (see run.session-permissions.test.ts).
-export const overflowBaseRunParams = {
-  agentId: "main",
-  sessionId: "test-session",
-  sessionKey: "agent:main:test-key",
-  workspaceDir: "/tmp/workspace",
-  prompt: "hello",
-  timeoutMs: 30000,
-  runId: "run-1",
-} as const;
+export function createOverflowRunParams(state: Pick<OpenClawTestState, "workspaceDir">) {
+  return {
+    agentId: "main",
+    sessionId: "test-session",
+    sessionKey: "agent:main:test-key",
+    workspaceDir: state.workspaceDir,
+    prompt: "hello",
+    timeoutMs: 30000,
+    runId: "run-1",
+  } as const;
+}
 
 function resetMockAgentHarness(): void {
   clearAgentHarnesses();
@@ -463,7 +466,7 @@ function resetMockAgentHarness(): void {
     id: "codex",
     label: "Codex",
     supports: (ctx) =>
-      ctx.provider === "codex" || ctx.provider === "openai" || ctx.provider === "openai"
+      ctx.provider === "codex" || ctx.provider === "openai"
         ? { supported: true, priority: 100 }
         : { supported: false },
     runAttempt: async (params) => await mockedRunEmbeddedAttempt(params),
@@ -483,7 +486,8 @@ function resetMockAgentHarness(): void {
 
 /** Reset every mocked runner dependency to the default successful no-op state. */
 function resetRunOverflowCompactionHarnessMocks(): void {
-  vi.unstubAllEnvs();
+  // Loading and warmup can run inside an already-owned environment. Only the
+  // per-test reset restores stubbed env, before the next fixture applies it.
   resetCommandQueueStateForTest();
   resetMockAgentHarness();
   mockedGlobalHookRunner.hasHooks.mockReset();
@@ -1149,6 +1153,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
 /** Move one-time runner compilation out of individual behavior timings. */
 export async function warmRunOverflowCompactionHarness(
   runEmbeddedAgent: TestRunEmbeddedAgent,
+  state: Pick<OpenClawTestState, "workspaceDir">,
   params?: Partial<Parameters<typeof runEmbeddedAgent>[0]>,
 ): Promise<void> {
   resetRunOverflowCompactionHarnessMocks();
@@ -1156,7 +1161,7 @@ export async function warmRunOverflowCompactionHarness(
   mockedBuildEmbeddedRunPayloads.mockReturnValue([{ text: "warmup" }]);
   mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ assistantTexts: ["warmup"] }));
   await runEmbeddedAgent({
-    ...overflowBaseRunParams,
+    ...createOverflowRunParams(state),
     ...params,
     runId: params?.runId ?? "run-overflow-compaction-harness-warmup",
   });

--- a/src/agents/embedded-agent-runner/run.prepared-harness-credentials.test.ts
+++ b/src/agents/embedded-agent-runner/run.prepared-harness-credentials.test.ts
@@ -1,12 +1,15 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
   mockedBuildEmbeddedRunPayloads,
   mockedGetApiKeyForModel,
   mockedRunEmbeddedAttempt,
-  overflowBaseRunParams,
+  createOverflowRunParams,
 } from "./run.overflow-compaction.harness.js";
+
+let state: OpenClawTestState;
 
 describe("prepared plugin harness credentials", () => {
   let runEmbeddedAgent: Awaited<
@@ -29,7 +32,9 @@ describe("prepared plugin harness credentials", () => {
       actual.shouldPreferExplicitConfigApiKeyAuth,
     );
   });
-  beforeEach(() => {
+  beforeEach(async () => {
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "run.prepared-harness-credentials" });
     registerPreparedAgentHarness({
       id: "test-byok",
       label: "Test BYOK",
@@ -48,11 +53,15 @@ describe("prepared plugin harness credentials", () => {
     mockedBuildEmbeddedRunPayloads.mockReturnValue([{ text: "OK" }]);
   });
 
+  afterEach(async () => {
+    await state?.cleanup();
+  });
+
   it.each([true, false])(
     "forwards a configured direct key with authHeader=%s",
     async (authHeader) => {
       await runEmbeddedAgent({
-        ...overflowBaseRunParams,
+        ...createOverflowRunParams(state),
         provider: "custom-proof",
         model: "gpt-5.6-luna",
         config: {
@@ -96,7 +105,7 @@ describe("prepared plugin harness credentials", () => {
 
   it("does not discover a credential for an implicit harness auth attempt", async () => {
     await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "custom-proof",
       model: "gpt-5.6-luna",
     });

--- a/src/agents/embedded-agent-runner/run.prepared-harness-source-delivery.integration.test.ts
+++ b/src/agents/embedded-agent-runner/run.prepared-harness-source-delivery.integration.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { settleReplyDispatcher } from "../../auto-reply/dispatch-dispatcher.js";
 import {
   createFollowupRun,
@@ -30,6 +30,7 @@ import { buildTestCtx } from "../../auto-reply/reply/test-ctx.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../../auto-reply/types.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import type { FailoverReason } from "../failover/signal.js";
 import { registerAgentHarness } from "../harness/registry.js";
 import {
@@ -44,7 +45,7 @@ import {
   mockedBuildEmbeddedRunPayloads,
   mockedGlobalHookRunner,
   mockedRunEmbeddedAttempt,
-  overflowBaseRunParams,
+  createOverflowRunParams,
   useOpenAIPlatformAuthFixture,
 } from "./run.overflow-compaction.harness.js";
 import type { RunEmbeddedAgentInternalParams } from "./run/internal-params.js";
@@ -72,6 +73,16 @@ function runAdmittedAttempt(
 beforeAll(globalBeforeAll0);
 
 describe("prepared harness source delivery", () => {
+  let state: OpenClawTestState;
+  async function loadSourceDeliveryHarness() {
+    const loaded = await loadRunOverflowCompactionHarness();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "prepared-source-delivery" });
+    return loaded;
+  }
+  afterEach(async () => {
+    await state?.cleanup();
+  });
   beforeEach(describe2BeforeEach0);
 
   it.each([
@@ -151,8 +162,7 @@ describe("prepared harness source delivery", () => {
         params as Parameters<typeof createBlockReplyDeliveryHandler>[0],
       ),
     );
-    const { runEmbeddedAgent, registerPreparedAgentHarness } =
-      await loadRunOverflowCompactionHarness();
+    const { runEmbeddedAgent, registerPreparedAgentHarness } = await loadSourceDeliveryHarness();
     mockedGlobalHookRunner.hasHooks.mockImplementation(
       (hookName: string) => hookName === "before_model_resolve",
     );
@@ -160,6 +170,7 @@ describe("prepared harness source delivery", () => {
       providerOverride: "openai",
       modelOverride: "gpt-5.4",
     });
+    const followupRun = createFollowupRun();
     const emittedStreamingCallbacks: string[] = [];
     let modelVisiblePrompt = "";
     const recordModelVisiblePrompt = (attemptParams: {
@@ -168,7 +179,7 @@ describe("prepared harness source delivery", () => {
       sourceReplyDeliveryMode?: "automatic" | "message_tool_only";
     }) => {
       modelVisiblePrompt = buildEmbeddedSystemPrompt({
-        workspaceDir: "/tmp/workspace",
+        workspaceDir: followupRun.run.workspaceDir,
         reasoningTagHint: false,
         extraSystemPrompt: attemptParams.extraSystemPrompt,
         sourceReplyDeliveryMode: attemptParams.sourceReplyDeliveryMode,
@@ -324,7 +335,6 @@ describe("prepared harness source delivery", () => {
         modeTransitions.push(mode);
         outerModeCallback?.(mode);
       };
-      const followupRun = createFollowupRun();
       // These candidate facts precede the hook-selected route inside embedded execution.
       followupRun.run.thinkingCatalog = [
         { provider: "custom", id: "plugin-fallback", api: "messages", input: ["text"] },
@@ -481,8 +491,7 @@ describe("prepared harness source delivery", () => {
   });
 
   it("prepares a Codex primary without pinning a plugin-owned fallback", async () => {
-    const { runEmbeddedAgent, registerPreparedAgentHarness } =
-      await loadRunOverflowCompactionHarness();
+    const { runEmbeddedAgent, registerPreparedAgentHarness } = await loadSourceDeliveryHarness();
     registerPreparedAgentHarness({
       id: "fallback-owner",
       label: "Fallback owner",
@@ -500,7 +509,7 @@ describe("prepared harness source delivery", () => {
     const runParams: RunEmbeddedAgentInternalParams = {
       agentId: "worker",
       sessionId: "runtime-preparation-hint",
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: state.workspaceDir,
       prompt: "hello",
       runId: "runtime-preparation-hint",
       timeoutMs: 30_000,
@@ -545,13 +554,13 @@ describe("prepared harness source delivery", () => {
   });
 
   it("completes an admitted turn on A after plugin-runtime generation B publishes", async () => {
-    const { runEmbeddedAgent } = await loadRunOverflowCompactionHarness();
+    const { runEmbeddedAgent } = await loadSourceDeliveryHarness();
     const config = {};
-    const workspaceDir = "/tmp/workspace";
+    const workspaceDir = state.workspaceDir;
     const pluginRegistry = createEmptyPluginRegistry();
     const baseLease = await mockedAcquireAgentRunPreparedModelRuntime({
       agentId: "main",
-      agentDir: "/tmp/agent",
+      agentDir: state.agentDir(),
       workspaceDir,
     });
     const admittedMetadataSnapshot = {
@@ -614,7 +623,7 @@ describe("prepared harness source delivery", () => {
       admittedGeneration,
       async () =>
         await runEmbeddedAgent({
-          ...overflowBaseRunParams,
+          ...createOverflowRunParams(state),
           config,
           provider: "openai",
           model: "gpt-5.4",
@@ -635,12 +644,12 @@ describe("prepared harness source delivery", () => {
   });
 
   it("starts an isolated probe outside its caller's admitted generation", async () => {
-    const { runEmbeddedAgent } = await loadRunOverflowCompactionHarness();
+    const { runEmbeddedAgent } = await loadSourceDeliveryHarness();
     const config = {};
-    const workspaceDir = "/tmp/isolated-probe-workspace";
+    const workspaceDir = state.workspaceDir;
     const baseLease = await mockedAcquireAgentRunPreparedModelRuntime({
       agentId: "openclaw",
-      agentDir: "/tmp/isolated-probe-agent",
+      agentDir: state.agentDir("openclaw"),
       workspaceDir,
     });
     const admittedGeneration: PreparedModelRuntimePluginGeneration = {
@@ -676,9 +685,9 @@ describe("prepared harness source delivery", () => {
     const abortSignal = new AbortController().signal;
 
     const isolatedProbeParams: RunEmbeddedAgentInternalParams = {
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       agentId: "openclaw",
-      agentDir: "/tmp/isolated-probe-agent",
+      agentDir: state.agentDir("openclaw"),
       config,
       provider: "openai",
       model: "gpt-5.4",
@@ -705,7 +714,7 @@ describe("prepared harness source delivery", () => {
     ["agentHarnessId", { agentHarnessId: "codex" }],
     ["agentHarnessRuntimeOverride", { agentHarnessRuntimeOverride: "codex" }],
   ] as const)("keeps %s authoritative across fallback preparation", async (_label, override) => {
-    const { runEmbeddedAgent } = await loadRunOverflowCompactionHarness();
+    const { runEmbeddedAgent } = await loadSourceDeliveryHarness();
     mockedGlobalHookRunner.hasHooks.mockReturnValue(false);
     mockedBuildEmbeddedRunPayloads.mockReturnValue([{ text: "primary" }]);
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
@@ -716,7 +725,7 @@ describe("prepared harness source delivery", () => {
     await runEmbeddedAgent({
       agentId: "worker",
       sessionId: `authoritative-${_label}`,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: state.workspaceDir,
       prompt: "hello",
       runId: `authoritative-${_label}`,
       timeoutMs: 30_000,

--- a/src/agents/embedded-agent-runner/run.projection-retry.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.projection-retry.test-support.ts
@@ -1,17 +1,17 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeAttemptResult, makeCompactionSuccess } from "./run.overflow-compaction.fixture.js";
 import {
   mockedCompactDirect,
   mockedRunEmbeddedAttempt,
-  overflowBaseRunParams,
+  createOverflowRunParams,
   resetSharedRunIntegrationHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-
+let state: OpenClawTestState;
 let runEmbeddedAgent: Awaited<ReturnType<typeof loadSharedRunIntegrationHarness>>;
 let agentDatabase: typeof import("../../state/openclaw-agent-db.js");
 let sessionAccessor: typeof import("../../config/sessions/session-accessor.js");
@@ -29,14 +29,26 @@ describe("runEmbeddedAgent transcript projection retry", () => {
     reconcile = await import("../../config/sessions/session-transcript-reconcile.js");
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetSharedRunIntegrationHarnessMocks();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "run.projection-retry" });
+  });
+
+  afterEach(async () => {
+    await state?.cleanup();
+    expect(
+      agentDatabase
+        .listOpenClawAgentDatabasesForTest()
+        .filter((database) => database.path.startsWith(`${state.stateDir}${path.sep}`)),
+    ).toEqual([]);
+    await expect(fs.stat(state.root)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("settles an owned compacted retry before durable reopen while ordinary reads stay fail-fast", async () => {
     const sessionId = "projection-retry-session";
     const sessionKey = "agent:main:projection-retry";
-    const storePath = path.join(tempDirs.make("openclaw-projection-retry-"), "sessions.json");
+    const storePath = state.statePath("alternate", "sessions.json");
     const sessionTarget = { agentId: "main", sessionId, sessionKey, storePath };
     await sessionAccessor.persistSessionTranscriptTurn(sessionTarget, {
       messages: [
@@ -114,7 +126,7 @@ describe("runEmbeddedAgent transcript projection retry", () => {
       });
 
       await runEmbeddedAgent({
-        ...overflowBaseRunParams,
+        ...createOverflowRunParams(state),
         runId: "run-owned-projection-retry",
         sessionId,
         sessionKey,
@@ -126,10 +138,18 @@ describe("runEmbeddedAgent transcript projection retry", () => {
       expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
       expect(waitForProjection).toHaveBeenCalledOnce();
       expect(waitForProjection).toHaveBeenCalledWith(sessionTarget, controller.signal);
+      agentDatabase.closeOpenClawAgentDatabaseByPath(
+        agentDatabase.resolveOpenClawAgentSqlitePath(databaseOptions),
+      );
+      expect(
+        activeEvents.readSessionTranscriptMessageEventPage(sessionTarget, {
+          maxMessages: 1,
+          offset: 0,
+        }).totalMessages,
+      ).toBe(1);
     } finally {
       waitForProjection.mockRestore();
       await reconcile.waitForSessionTranscriptIndexReconcile(databaseOptions);
-      agentDatabase.closeOpenClawAgentDatabasesForTest();
     }
   });
 });

--- a/src/agents/embedded-agent-runner/run.prompt-timeout-fallback.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.prompt-timeout-fallback.test-support.ts
@@ -1,5 +1,6 @@
 // Full-entry coverage for handing replay-safe prompt timeouts to model fallback.
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeModelFallbackCfg } from "../test-helpers/model-fallback-config-fixture.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
@@ -8,12 +9,13 @@ import {
   mockedClassifyFailoverReason,
   mockedGetApiKeyForModel,
   mockedRunEmbeddedAttempt,
-  overflowBaseRunParams,
+  createOverflowRunParams,
   resetSharedRunIntegrationHarnessMocks,
   useOpenAIPlatformAuthFixture,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 
+let state: OpenClawTestState;
 let runEmbeddedAgent: Awaited<ReturnType<typeof loadSharedRunIntegrationHarness>>;
 
 describe("runEmbeddedAgent prompt timeout fallback handoff", () => {
@@ -21,9 +23,15 @@ describe("runEmbeddedAgent prompt timeout fallback handoff", () => {
     runEmbeddedAgent = await loadSharedRunIntegrationHarness();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetSharedRunIntegrationHarnessMocks();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "run.prompt-timeout-fallback" });
     useOpenAIPlatformAuthFixture();
+  });
+
+  afterEach(async () => {
+    await state?.cleanup();
   });
 
   it("throws FailoverError for replay-safe harness-owned prompt timeouts when model fallbacks are configured", async () => {
@@ -40,7 +48,7 @@ describe("runEmbeddedAgent prompt timeout fallback handoff", () => {
     );
 
     const promise = runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "openai",
       model: "gpt-5.4",
       runId: "run-prompt-timeout-fallback",
@@ -130,7 +138,7 @@ describe("runEmbeddedAgent prompt timeout fallback handoff", () => {
       .mockReturnValueOnce([{ text: "The note was written once." }]);
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "openai",
       model: "gpt-5.4",
       runId: "run-post-tool-idle-finalization",

--- a/src/agents/embedded-agent-runner/run.retry-limit.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.retry-limit.test-support.ts
@@ -1,14 +1,16 @@
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   mockedBuildAgentRuntimePlan,
   mockedRunEmbeddedAttempt,
-  overflowBaseRunParams,
+  createOverflowRunParams,
   resetSharedRunIntegrationHarnessMocks,
   useOpenAIPlatformAuthFixture,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 
+let state: OpenClawTestState;
 let runEmbeddedAgent: Awaited<ReturnType<typeof loadSharedRunIntegrationHarness>>;
 
 describe("runEmbeddedAgent retry-limit metadata", () => {
@@ -16,9 +18,15 @@ describe("runEmbeddedAgent retry-limit metadata", () => {
     runEmbeddedAgent = await loadSharedRunIntegrationHarness();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetSharedRunIntegrationHarnessMocks();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "run.retry-limit" });
     useOpenAIPlatformAuthFixture();
+  });
+
+  afterEach(async () => {
+    await state?.cleanup();
   });
 
   it("reports the latest physical attempt after ordinary retry-budget exhaustion", async () => {
@@ -59,7 +67,7 @@ describe("runEmbeddedAgent retry-limit metadata", () => {
     );
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "openai",
       model: "gpt-5.6-luna",
       runId: "run-retry-limit-physical-attempt-meta",

--- a/src/agents/embedded-agent-runner/run.session-permissions.test.ts
+++ b/src/agents/embedded-agent-runner/run.session-permissions.test.ts
@@ -1,9 +1,10 @@
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
   mockedRunEmbeddedAttempt,
-  overflowBaseRunParams,
+  createOverflowRunParams,
   resetSharedRunIntegrationHarnessMocks,
   type TestRunEmbeddedAgent,
   useOpenAIPlatformAuthFixture,
@@ -13,31 +14,44 @@ import {
 // The mocked harness only supports the OpenAI route, so these params keep the
 // plugin harness selected. Falling back to the built-in host harness would drag
 // the whole OpenClaw tool graph into this shard and prove the wrong owner.
-const pluginHarnessRunParams = {
-  ...overflowBaseRunParams,
-  provider: "openai",
-  model: "gpt-5.6-luna",
-  sessionRoot: "/tmp/openclaw-plugin-session-root",
-} as const;
+function createPluginHarnessRunParams(state: OpenClawTestState) {
+  return {
+    ...createOverflowRunParams(state),
+    provider: "openai",
+    model: "gpt-5.6-luna",
+    sessionRoot: state.sessionsDir(),
+  } as const;
+}
+
+let state: OpenClawTestState;
 
 describe("embedded run session permissions", () => {
   let runEmbeddedAgent: TestRunEmbeddedAgent;
 
   beforeAll(async () => {
     ({ runEmbeddedAgent } = await loadRunOverflowCompactionHarness());
-    await warmRunOverflowCompactionHarness(runEmbeddedAgent);
+    const { withOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    await withOpenClawTestState({ label: "session-permissions-warmup" }, async (warmupState) => {
+      await warmRunOverflowCompactionHarness(runEmbeddedAgent, warmupState);
+    });
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetSharedRunIntegrationHarnessMocks();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "run.session-permissions" });
     useOpenAIPlatformAuthFixture();
+  });
+
+  afterEach(async () => {
+    await state?.cleanup();
   });
 
   it("prepares the exec mode with plugin-owned permission facts", async () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ assistantTexts: ["OK"] }));
 
     await runEmbeddedAgent({
-      ...pluginHarnessRunParams,
+      ...createPluginHarnessRunParams(state),
       permissionMode: "workspace",
       runId: "run-plugin-session-permissions",
     });
@@ -47,7 +61,7 @@ describe("embedded run session permissions", () => {
         agentHarnessId: "codex",
         execOverrides: expect.objectContaining({ mode: "auto" }),
         permissionMode: "workspace",
-        sessionRoot: "/tmp/openclaw-plugin-session-root",
+        sessionRoot: state.sessionsDir(),
       }),
     );
   });
@@ -63,7 +77,7 @@ describe("embedded run session permissions", () => {
     });
 
     await runEmbeddedAgent({
-      ...pluginHarnessRunParams,
+      ...createPluginHarnessRunParams(state),
       permissionMode: "full",
       execOverrides,
       runId: "run-plugin-clamped-session-permissions",

--- a/src/agents/embedded-agent-runner/run.shared-integration-harness.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.shared-integration-harness.test-support.ts
@@ -3,6 +3,7 @@ import {
   warmRunOverflowCompactionHarness,
   type TestRunEmbeddedAgent,
 } from "./run.overflow-compaction.harness.js";
+import { guardRunWorkspaceOwnership } from "./run.workspace-ownership.test-support.js";
 
 let sharedRunEmbeddedAgent: Promise<TestRunEmbeddedAgent> | undefined;
 
@@ -14,7 +15,15 @@ let sharedRunEmbeddedAgent: Promise<TestRunEmbeddedAgent> | undefined;
 export function loadSharedRunIntegrationHarness(): Promise<TestRunEmbeddedAgent> {
   sharedRunEmbeddedAgent ??= (async () => {
     const { runEmbeddedAgent } = await loadRunOverflowCompactionHarness();
-    await warmRunOverflowCompactionHarness(runEmbeddedAgent);
+    const { withOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    await withOpenClawTestState({ label: "shared-run-warmup" }, async (state) => {
+      const guard = await guardRunWorkspaceOwnership(state);
+      try {
+        await warmRunOverflowCompactionHarness(runEmbeddedAgent, state);
+      } finally {
+        guard.verifyAndRestore();
+      }
+    });
     return runEmbeddedAgent;
   })();
   return sharedRunEmbeddedAgent;

--- a/src/agents/embedded-agent-runner/run.terminal-timeout-delivery.integration.test.ts
+++ b/src/agents/embedded-agent-runner/run.terminal-timeout-delivery.integration.test.ts
@@ -1,18 +1,20 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { settleReplyDispatcher } from "../../auto-reply/dispatch-dispatcher.js";
 import type { ReplyDispatchRuntimeInfo } from "../../auto-reply/reply/reply-dispatcher.types.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   mockedBuildEmbeddedRunPayloads,
   mockedRunEmbeddedAttempt,
-  overflowBaseRunParams,
+  createOverflowRunParams,
   resetSharedRunIntegrationHarnessMocks,
   useOpenAIPlatformAuthFixture,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 
+let state: OpenClawTestState;
 const GENERIC_TIMEOUT = "LLM request timed out.";
 const AUTHORITATIVE_TIMEOUT =
   "Provider timed out after the request started. Retry the turn, or increase its configured timeout.";
@@ -29,11 +31,15 @@ beforeAll(async () => {
   ({ createReplyDispatcher } = await import("../../auto-reply/reply/reply-dispatcher.js"));
 });
 
-beforeEach(() => {
-  resetSharedRunIntegrationHarnessMocks();
-});
-
 describe("provider timeout final delivery", () => {
+  beforeEach(async () => {
+    resetSharedRunIntegrationHarnessMocks();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "terminal-timeout-delivery" });
+  });
+  afterEach(async () => {
+    await state?.cleanup();
+  });
   it.each([
     {
       label: "one final timeout",
@@ -83,7 +89,7 @@ describe("provider timeout final delivery", () => {
       useOpenAIPlatformAuthFixture();
 
       const result = await runEmbeddedAgent({
-        ...overflowBaseRunParams,
+        ...createOverflowRunParams(state),
         provider: "openai",
         model: "gpt-5.4",
         runId: "provider-idle-timeout-single-final-delivery",

--- a/src/agents/embedded-agent-runner/run.timeout-triggered-compaction.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.timeout-triggered-compaction.test-support.ts
@@ -1,4 +1,5 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import type { AgentHarness } from "../harness/types.js";
 import { makeAttemptResult, makeCompactionSuccess } from "./run.overflow-compaction.fixture.js";
 import {
@@ -7,11 +8,12 @@ import {
   mockedGetApiKeyForModel,
   mockedResolveAuthProfileOrder,
   mockedRunEmbeddedAttempt,
-  overflowBaseRunParams,
+  createOverflowRunParams,
   resetSharedRunIntegrationHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 
+let state: OpenClawTestState;
 let runEmbeddedAgent: Awaited<ReturnType<typeof loadSharedRunIntegrationHarness>>;
 
 type CompactParams = {
@@ -34,8 +36,14 @@ describe("runEmbeddedAgent timeout recovery composition", () => {
     runEmbeddedAgent = await loadSharedRunIntegrationHarness();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetSharedRunIntegrationHarnessMocks();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "run.timeout-triggered-compaction" });
+  });
+
+  afterEach(async () => {
+    await state?.cleanup();
   });
 
   it("adopts a compacted transcript and retries with a continuation prompt", async () => {
@@ -70,7 +78,7 @@ describe("runEmbeddedAgent timeout recovery composition", () => {
     );
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       messageChannel: "slack",
       currentThreadTs: "thread-1",
     });
@@ -84,7 +92,7 @@ describe("runEmbeddedAgent timeout recovery composition", () => {
       "Continue from the current transcript",
     );
     expect(mockedRunEmbeddedAttempt.mock.calls[1]?.[0]?.prompt).not.toBe(
-      overflowBaseRunParams.prompt,
+      createOverflowRunParams(state).prompt,
     );
     const compactParams = mockedCompactDirect.mock.calls[0]?.[0] as CompactParams | undefined;
     expect(compactParams).toMatchObject({
@@ -128,7 +136,7 @@ describe("runEmbeddedAgent timeout recovery composition", () => {
     });
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       provider: "openai",
       model: "gpt-5.5",
       config: { agents: { defaults: { agentRuntime: { id: "codex" } } } },
@@ -163,7 +171,7 @@ describe("runEmbeddedAgent timeout recovery composition", () => {
       reason: "nothing to compact",
     });
 
-    const result = await runEmbeddedAgent(overflowBaseRunParams);
+    const result = await runEmbeddedAgent(createOverflowRunParams(state));
 
     expect(mockedCompactDirect).toHaveBeenCalledTimes(2);
     expect(
@@ -187,7 +195,7 @@ describe("runEmbeddedAgent timeout recovery composition", () => {
       )
       .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
 
-    const result = await runEmbeddedAgent(overflowBaseRunParams);
+    const result = await runEmbeddedAgent(createOverflowRunParams(state));
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(mockedCompactDirect).not.toHaveBeenCalled();

--- a/src/agents/embedded-agent-runner/run.workspace-ownership.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.workspace-ownership.test-support.ts
@@ -1,0 +1,57 @@
+import { expect, vi } from "vitest";
+import { isPathInside } from "../../infra/path-guards.js";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+
+/** Guard the real consumers before discovery can touch an unowned workspace. */
+export async function guardRunWorkspaceOwnership(
+  state: Pick<OpenClawTestState, "root" | "home" | "stateDir">,
+) {
+  // Import after the harness reset so the spies intercept the runner's graph.
+  const metadata = await import("../../plugins/plugin-metadata-snapshot.js");
+  const repository = await import("../system-prompt-params.js");
+  const requests: string[] = [];
+  const forbidden: string[] = [];
+  const check = (workspaceDir: string | undefined) => {
+    if (workspaceDir === undefined) {
+      return;
+    }
+    requests.push(workspaceDir);
+    expect(process.env.HOME, "fixture home survives runner reset/warmup").toBe(state.home);
+    expect(process.env.OPENCLAW_STATE_DIR, "fixture state survives runner reset/warmup").toBe(
+      state.stateDir,
+    );
+    if (!isPathInside(state.root, workspaceDir)) {
+      // Discovery can swallow filesystem errors; retain independent evidence.
+      forbidden.push(workspaceDir);
+      throw new Error("embedded-run fixture requested an unowned workspace");
+    }
+  };
+  const loadMetadata = metadata.loadPluginMetadataSnapshot;
+  const resolveRepository = repository.resolveSystemPromptRepoRoot;
+  const metadataSpy = vi
+    .spyOn(metadata, "loadPluginMetadataSnapshot")
+    .mockImplementation((params) => {
+      check(params?.workspaceDir);
+      return loadMetadata(params);
+    });
+  const repositorySpy = vi
+    .spyOn(repository, "resolveSystemPromptRepoRoot")
+    .mockImplementation((params) => {
+      check(params.workspaceDir);
+      check(params.cwd);
+      check(params.config?.agents?.defaults?.repoRoot);
+      return resolveRepository(params);
+    });
+  return {
+    verifyAndRestore() {
+      const metadataCalls = metadataSpy.mock.calls.length;
+      const repositoryCalls = repositorySpy.mock.calls.length;
+      metadataSpy.mockRestore();
+      repositorySpy.mockRestore();
+      expect(requests.length, "real workspace consumer was exercised").toBeGreaterThan(0);
+      expect(forbidden, "unowned workspace requests blocked before filesystem access").toEqual([]);
+      expect(metadataCalls, "real metadata consumer was exercised").toBeGreaterThan(0);
+      expect(repositoryCalls, "real repository consumer was exercised").toBeGreaterThan(0);
+    },
+  };
+}

--- a/src/agents/embedded-agent-runner/sessions-yield.orchestration.test-support.ts
+++ b/src/agents/embedded-agent-runner/sessions-yield.orchestration.test-support.ts
@@ -1,15 +1,17 @@
 /** Full-entry coverage for sessions_yield terminal projection. */
 import { expectDefined } from "@openclaw/normalization-core";
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   mockedGlobalHookRunner,
   mockedRunEmbeddedAttempt,
-  overflowBaseRunParams,
+  createOverflowRunParams,
   resetSharedRunIntegrationHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 
+let state: OpenClawTestState;
 let runEmbeddedAgent: Awaited<ReturnType<typeof loadSharedRunIntegrationHarness>>;
 
 describe("sessions_yield orchestration", () => {
@@ -17,9 +19,15 @@ describe("sessions_yield orchestration", () => {
     runEmbeddedAgent = await loadSharedRunIntegrationHarness();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetSharedRunIntegrationHarnessMocks();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "sessions-yield.orchestration" });
     mockedGlobalHookRunner.hasHooks.mockImplementation(() => false);
+  });
+
+  afterEach(async () => {
+    await state?.cleanup();
   });
 
   it("yield ends the turn without pending tool calls", async () => {
@@ -30,7 +38,7 @@ describe("sessions_yield orchestration", () => {
     );
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       runId: "run-yield-orchestration",
     });
 
@@ -48,7 +56,7 @@ describe("sessions_yield orchestration", () => {
     );
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       runId: "run-yield-vs-client-tool",
     });
 
@@ -75,7 +83,7 @@ describe("sessions_yield orchestration", () => {
     );
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       runId: "run-multi-client-tool",
     });
 
@@ -106,7 +114,7 @@ describe("sessions_yield orchestration", () => {
       );
 
       const result = await runEmbeddedAgent({
-        ...overflowBaseRunParams,
+        ...createOverflowRunParams(state),
         runId: "run-yield-accepted-spawn-suppressed",
       });
 
@@ -127,7 +135,7 @@ describe("sessions_yield orchestration", () => {
       );
 
       const result = await runEmbeddedAgent({
-        ...overflowBaseRunParams,
+        ...createOverflowRunParams(state),
         runId: "run-yield-async-tool-suppressed",
       });
 
@@ -147,7 +155,7 @@ describe("sessions_yield orchestration", () => {
       );
 
       const result = await runEmbeddedAgent({
-        ...overflowBaseRunParams,
+        ...createOverflowRunParams(state),
         runId: "run-yield-runtime-continuation-suppressed",
       });
 
@@ -162,7 +170,7 @@ describe("sessions_yield orchestration", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult());
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       runId: "run-no-yield",
     });
 
@@ -180,7 +188,7 @@ describe("sessions_yield orchestration", () => {
     );
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       runId: "run-yield-no-continuation",
     });
 
@@ -207,7 +215,7 @@ describe("sessions_yield orchestration", () => {
     );
 
     const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...createOverflowRunParams(state),
       runId: "run-yield-empty-spawn",
     });
 

--- a/src/agents/embedded-agent-runner/usage-reporting.test-support.ts
+++ b/src/agents/embedded-agent-runner/usage-reporting.test-support.ts
@@ -1,7 +1,8 @@
 // Full-entry usage reporting coverage spans metadata attribution, runtime plugin
 // bootstrap inputs, and forwarding fields into embedded attempts.
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   mockedAcquireAgentRunPreparedModelRuntime,
@@ -12,6 +13,7 @@ import {
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
+let state: OpenClawTestState;
 let runEmbeddedAgent: Awaited<ReturnType<typeof loadSharedRunIntegrationHarness>>;
 
 function makeAssistantMessage(
@@ -47,8 +49,14 @@ describe("runEmbeddedAgent usage reporting", () => {
     runEmbeddedAgent = await loadSharedRunIntegrationHarness();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetSharedRunIntegrationHarnessMocks();
+    const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
+    state = await createOpenClawTestState({ label: "usage-reporting" });
+  });
+
+  afterEach(async () => {
+    await state?.cleanup();
   });
 
   it("bootstraps runtime plugins with the resolved workspace before running", async () => {
@@ -72,7 +80,7 @@ describe("runEmbeddedAgent usage reporting", () => {
       sessionId: "test-session",
       sessionKey: "test-key",
       sessionFile: "test-key",
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: state.workspaceDir,
       prompt: "hello",
       timeoutMs: 30000,
       runId: "run-plugin-bootstrap",
@@ -82,7 +90,7 @@ describe("runEmbeddedAgent usage reporting", () => {
     expect(mockedAcquireAgentRunPreparedModelRuntime).toHaveBeenCalledWith(
       expect.objectContaining({
         config,
-        workspaceDir: "/tmp/workspace",
+        workspaceDir: state.workspaceDir,
         runtimePluginSelections: expect.arrayContaining([
           expect.objectContaining({ provider: "openai", modelId: "gpt-5.5" }),
         ]),
@@ -112,7 +120,7 @@ describe("runEmbeddedAgent usage reporting", () => {
       sessionKey: "agent:support:test-key",
       sessionFile: "agent:support:test-key",
       agentId: "support",
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: state.workspaceDir,
       prompt: "hello",
       timeoutMs: 30000,
       runId: "run-agent-fallback-plugin-bootstrap",
@@ -149,7 +157,7 @@ describe("runEmbeddedAgent usage reporting", () => {
       sessionId: "test-session",
       sessionKey: "test-key",
       sessionFile: "test-key",
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: state.workspaceDir,
       prompt: "hello",
       timeoutMs: 30000,
       runId: "run-pinned-fallback-plugin-bootstrap",
@@ -182,7 +190,7 @@ describe("runEmbeddedAgent usage reporting", () => {
       sessionId: "test-session",
       sessionKey: "test-key",
       sessionFile: "test-key",
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: state.workspaceDir,
       prompt: "hello",
       timeoutMs: 30000,
       runId: "run-gateway-bind",
@@ -193,7 +201,7 @@ describe("runEmbeddedAgent usage reporting", () => {
     expect(mockedAcquireAgentRunPreparedModelRuntime).toHaveBeenCalledWith(
       expect.objectContaining({
         config: {},
-        workspaceDir: "/tmp/workspace",
+        workspaceDir: state.workspaceDir,
         allowGatewaySubagentBinding: true,
       }),
       expect.anything(),
@@ -212,7 +220,7 @@ describe("runEmbeddedAgent usage reporting", () => {
       sessionId: "test-session",
       sessionKey: "test-key",
       sessionFile: "test-key",
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: state.workspaceDir,
       prompt: "hello",
       timeoutMs: 30000,
       runId: "run-sender-forwarding",
@@ -240,7 +248,7 @@ describe("runEmbeddedAgent usage reporting", () => {
       sessionId: "test-session",
       sessionKey: "test-key",
       sessionFile: "test-key",
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: state.workspaceDir,
       prompt: "hello",
       timeoutMs: 30000,
       runId: "run-message-action-capability",
@@ -261,7 +269,7 @@ describe("runEmbeddedAgent usage reporting", () => {
       sessionId: "test-session",
       sessionKey: "test-key",
       sessionFile: "test-key",
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: state.workspaceDir,
       prompt: "flush",
       timeoutMs: 30000,
       runId: "run-memory-forwarding",
@@ -307,7 +315,7 @@ describe("runEmbeddedAgent usage reporting", () => {
       sessionId: "test-session",
       sessionKey: "test-key",
       sessionFile: "test-key",
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: state.workspaceDir,
       prompt: "hello",
       timeoutMs: 30000,
       runId: "run-anthropic-multi-call-usage",
@@ -357,7 +365,7 @@ describe("runEmbeddedAgent usage reporting", () => {
       sessionId: "test-session",
       sessionKey: "test-key",
       sessionFile: "test-key",
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: state.workspaceDir,
       prompt: "hello",
       provider: "openrouter",
       model: "openai/gpt-5.4",


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled. This branch is in the upstream repository.

</details>

Related: https://github.com/openclaw/openclaw/pull/133131 (prepared-model fixture ownership).

## What Problem This Solves

Resolves a problem where running the shared embedded-agent tests could inspect a fixed workspace outside the test's temporary state, despite downstream runtime work being mocked. Timeout cases also treated the caller's timeout rejection as completion even when an ignored-cancellation backend was still using the fixture.

This is a maintainer-requested test-isolation repair, not a change to shipped agent behavior.

## Why This Change Was Made

Replace the path-bearing module constant with `createOverflowRunParams(state)` and migrate the complete consumer family to canonical `OpenClawTestState` lifetimes. Keep config, agent-directory and session-file omissions, stable logical IDs, generation identity, real SQLite/reopen assertions and the original sixteen-module aggregate order. Warmup owns disposable state without resetting its environment, and the shared loader retains only the loaded runner.

Cleanup now joins actual queued callbacks after an early timeout, releases held attempts in `finally`, and settles deferred fast-mode work before removing state. Lexical guards reject unowned paths before native metadata/repository readers and retain violations even when discovery swallows an exception. No broader filesystem/auth mock, production drain API, new runtime flag, or larger timeout is introduced. Nearby cleanup removes an exact duplicate provider predicate and reuses canonical lexical containment.

## User Impact

No production behavior, configuration, database schema, protocol or dependency changes. Developers can run these tests without the shared fixture selecting an unrelated workspace or deleting state beneath still-running test work. Synthetic harness assertions remain synthetic; this PR makes no live provider, Codex, Gateway or channel verification claim.

Production LOC: **+0/-0**. All changed lines are tests or test support, including the `.harness.ts` file that the automated lane classifier treats as core production. The growth is fixture acquisition/cleanup, failure-safe `finally` blocks and boundary regression evidence, not new runtime machinery.

## Evidence

- Safe pre-fix regression: the existing auth-failover case failed at the real workspace boundary and independently recorded the rejected path before filesystem delegation. Shared-loader warmup also failed in `beforeAll`; its 79 cases were not executed in that RED run. A diagnostic run with an incorrect old-signature argument is retained separately and is not counted as intended regression evidence.
- Final parent-run proof: **104 unique passing tests across all seven entrypoints, zero failures or skips**. The aggregate contributed **79 cases in the original sixteen-suite order**. The same complete entrypoint family also passed in the coding worker before final cleanup.
- The timeout cases assert that actual backend work remains pending after the early outer timeout, then release and join it before state cleanup. Projection retry retains real SQLite reconciliation, durable reopen, scoped handle closure and fixture-removal checks.
- Complete classified changed checks passed, including core types, every core-test type shard, all scoped lint batches and applicable guards. After three bounded cleanup edits, the parent reran all 104 cases, final scoped lint and whitespace checks.
- Fresh canonical isolated Codex autoreview: exit 0, no actionable P0 findings. A separate source-only consumer check found no missing migration or changed omission/identity contract. Neither review is claimed as execution proof.

Native test targets, all run with Node 24.15.0, pinned pnpm 12.1.0 and clean-whitelist private HOME/state/config/XDG/TMP roots outside Git. Reporter/output-path arguments are omitted here; separate native JSON reports and exact launch receipts are retained locally.

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.harness-auth-failover.test.ts src/agents/embedded-agent-runner/run.session-permissions.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.shared-integration.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.inherited-auth-owner.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.prepared-harness-credentials.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.prepared-harness-source-delivery.integration.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.terminal-timeout-delivery.integration.test.ts
```

The parent's first formatter launch failed during package-manager version preflight because it inherited a different checkout's working directory. Binding the launcher to this task checkout fixed the preflight; no source formatter or test ran in that failed attempt. It is not a product failure or a dependency change.
