### PR TITLE
test: reuse release plan fixture history

### DIFF
--- a/test/scripts/release-plan-producer.test.ts
+++ b/test/scripts/release-plan-producer.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import {
+  constants as fsConstants,
   cpSync,
   existsSync,
   linkSync,
@@ -14,7 +15,7 @@ import {
 } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join, relative, resolve } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { collectClawHubPublishablePluginPackages } from "../../scripts/lib/plugin-clawhub-release.ts";
 import { collectPublishablePluginPackages } from "../../scripts/lib/plugin-npm-release.ts";
@@ -40,6 +41,8 @@ import { writePublishablePluginFixture } from "../helpers/publishable-plugin-fix
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const templateDirs = useAutoCleanupTempDirTracker(afterAll);
+let defaultFixture: ReturnType<typeof buildFixtureRepo> | undefined;
 const TOOLING_CLOSURE = [
   "packages/normalization-core/src/record-coerce.ts",
   "packages/normalization-core/src/string-coerce.ts",
@@ -91,17 +94,31 @@ function copyToolingClosure(root: string) {
   }
 }
 
-function createFixtureRepo(
-  version = "2026.8.1-beta.2",
-  options: {
-    conflictingPlatformId?: boolean;
-    corePackageNameCollision?: boolean;
-    duplicateCrossTargetPackageName?: boolean;
-    malformedPlugin?: boolean;
-    malformedPluginJson?: boolean;
-  } = {},
-) {
+type FixtureOptions = {
+  conflictingPlatformId?: boolean;
+  corePackageNameCollision?: boolean;
+  duplicateCrossTargetPackageName?: boolean;
+  malformedPlugin?: boolean;
+  malformedPluginJson?: boolean;
+};
+
+function createFixtureRepo(version = "2026.8.1-beta.2", options: FixtureOptions = {}) {
   const root = tempDirs.make("openclaw-release-plan-");
+  if (version !== "2026.8.1-beta.2" || Object.keys(options).length > 0) {
+    return buildFixtureRepo(root, version, options);
+  }
+  const template = (defaultFixture ??= buildFixtureRepo(
+    templateDirs.make("openclaw-release-plan-template-"),
+    version,
+    options,
+  ));
+  // Copy both commits before any case adds YAML, tags, or mutated tooling.
+  // Independent files keep those authority and loader faults local to each case.
+  cpSync(template.root, root, { recursive: true, mode: fsConstants.COPYFILE_FICLONE });
+  return { ...template, root };
+}
+
+function buildFixtureRepo(root: string, version: string, options: FixtureOptions) {
   execFileSync("git", ["init", "-q", "-b", "tooling"], { cwd: root });
 
   writeFixture(


### PR DESCRIPTION
## Why

The release-plan suite rebuilds the same candidate and tooling commits for 34 cases. That immutable setup launches seven Git commands each time, before the case-specific trust-boundary checks begin.

## Change

Build that default history once and copy the complete repository into an independently owned directory for each case. The template has a separate after-all cleanup owner; case directories retain after-each cleanup. Nondefault option fixtures and the existing current-publisher inventory clone remain fresh.

Both distinct commits, their exact trees and absent tags remain intact. Every YAML package copy, mutation commit, loader/cache/symlink/hardlink fault, child process, remote-response shim and assertion is unchanged. No production, sharding, worker, concurrency, clock or timeout changes. Test support +28/-11; production zero. Existing filesystem and temporary-directory helpers suffice.

## Validation

All 43 cases passed in each before/after/after/before run: **28.034 / 21.385 / 21.663 / 24.169 seconds** of file execution. Mean **26.101 → 21.524 seconds**, saving **4.577 seconds (17.5%)** in this focused file, including template setup and cleanup. This is not a whole-CI speed claim.

- All 43 cases also passed shuffled with seed 93201.
- Actual-helper probes verified both commit trees and ancestry, independent files, mutation isolation, unchanged option fixtures, failed-bootstrap retry and complete registered cleanup.
- Full changed-file checks passed; required Codex autoreview and independent source review found no actionable findings in their reviewed scope.
- The original builder body and all scenario bodies remain byte-identical. The optimization removes 231 repeated bootstrap Git launches.

No changelog or product documentation change is needed for this internal test-fixture optimization.
