### PR TITLE
fix(workers): preserve offline errors during desktop preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Device workers:** preserve offline-runner classification and reconnect guidance when desktop preparation detects a disconnected device, without treating the disconnect as a model failure.
 - **Control UI global sessions:** preserve the selected agent's session in the composer so usage, goals, progress, and thinking options survive agent switches without reusing another agent's stale row.
 - **Image analysis startup:** prepare selected model providers and keep configuration reads independent of full runtime loading, avoiding unrelated discovery and redundant model resolution while preserving credentials and runtime cleanup.
 - **Browser extension relay:** route Runtime binding callbacks only to registered clients and preserve shared bindings during client cleanup, preventing raw callback payloads from reaching unrelated Playwright sessions.

--- a/src/gateway/worker-environments/computer-transport.test.ts
+++ b/src/gateway/worker-environments/computer-transport.test.ts
@@ -31,6 +31,7 @@ import {
   connectionIdentity,
   type Harness,
 } from "./computer-transport.test-support.js";
+import { WorkerRunnerUnavailableError } from "./tunnel-contract.js";
 import { createWorkerComputerRpc } from "./worker-turn-computer-rpc.js";
 
 function request(
@@ -127,6 +128,18 @@ describe("session computer transport", () => {
     resetAgentRunRegistryForTest();
     resetPluginRuntimeStateForTest();
   });
+
+  it.each([false, true])(
+    "reports an offline runner before preparing a disconnected desktop (shared host: %s)",
+    async (sharedHost) => {
+      const h = createHarness(sharedHost);
+      vi.spyOn(h.state.context!.nodeRegistry, "get").mockReturnValue(undefined);
+      await expect(h.prepare()).rejects.toBeInstanceOf(WorkerRunnerUnavailableError);
+      expect(h.privateInvoke).not.toHaveBeenCalled();
+      expect(h.publicInvoke).not.toHaveBeenCalled();
+      expect(h.options.placements.validateTurnClaim(h.claim)).toBe(true);
+    },
+  );
 
   it("routes snapshots and classified input to the exact private node without public fallback", async () => {
     const h = createHarness();

--- a/src/gateway/worker-environments/computer-transport.ts
+++ b/src/gateway/worker-environments/computer-transport.ts
@@ -18,6 +18,7 @@ import type { NodeWorkerSupervisorTransport } from "../node-registry-private.js"
 import type { GatewayContextResolver } from "../server-methods/types.js";
 import type { WorkerSessionPlacementStore, WorkerSessionTurnClaim } from "./placement-store.js";
 import type { WorkerEnvironmentStore } from "./store.js";
+import { WorkerRunnerUnavailableError } from "./tunnel-contract.js";
 import type { WorkerComputerExecutor } from "./worker-turn-computer-rpc.js";
 
 const COMPUTER_COMMANDS = ["screen.snapshot", "computer.act"] as const;
@@ -68,7 +69,7 @@ export function createWorkerComputerTransportOwner(options: {
     }
     const node = context.nodeRegistry.get(environment.nodeDeviceId);
     if (!node) {
-      throw new Error("Session desktop node is disconnected");
+      throw new WorkerRunnerUnavailableError();
     }
     const environmentIsCurrent = () => {
       const current = options.store.get(environment.environmentId);


### PR DESCRIPTION
## Problem

Full release verification caught a disconnected device failing with a generic desktop error before reaching the normal worker launch path. That loses the existing offline-runner identity, reconnect guidance, and coordination classification; trying another model cannot reconnect a device.

## Change

Desktop preparation now raises the existing `WorkerRunnerUnavailableError` when its selected node is absent. Missing Gateway context, stale authority, missing private protocol support, and mid-operation revocation remain distinct failures. Both old and new pre-handoff errors preserve the active placement; this change does not alter teardown or reconciliation.

Production delta: +1 net line (reuse the existing error import), with 13 test lines. No new branches, retries, timeouts, configuration, protocol, schema, or storage changes. Two shared/private-host cases cover the producer; existing transport, cleanup, failure-recovery, and model-fallback tests cover consumers and siblings.

## Validation

- Original hosted failure: [Gateway E2E 1/4](https://github.com/openclaw/openclaw/actions/runs/33301193903/job/99229705119), frozen `3ed6805a6f32ad8cdfd3c30dd94d7ae4d75bd667`; unchanged wire test rejects the generic disconnect error.
- Both added cases failed against the original producer and passed with the fix.
- 158 focused tests passed across five owner/sibling files.
- Codex review: no actionable findings.
- Full changed-file gate passed, including core and test typechecks, lint, schema/ownership guards, and import cycles.
- Unchanged wire lifecycle E2E passed on clean Linux Node 24.19.0: disconnect/reconnect, capacity, role removal, and local control; 1 test, 23.69 seconds (4m33s wrapper including clean build). The Testbox source receipt verified the production file against the reviewed patch. The lease was stopped after proof.
- Local wire proof stopped before tests because the shared dependency install lacked an Anthropic export; the clean Linux run above supplied the actual integration proof.
- One test-only lint correction changed an unbound method reference to `vi.spyOn`; the added cases and final review were rerun. The pre-rebase and rebased commits have identical range-diff patches.
- Exact PR CI remains required before merge.

## Final maintainer review

Exact-head CI [33303131403](https://github.com/openclaw/openclaw/actions/runs/33303131403) passed at `8bca4091ba7fcbdfb565a7883c8a71e64513cc31`, including `openclaw/ci-gate`.

Reviewed the latest ClawSweeper finding and all rank-up moves. The recommendation to remove the one-line changelog entry is intentionally declined: this maintainer-led release-verification repair follows the requested changelog handling for user-visible fixes. The PR remains the sole owner of the functional repair. Production growth is one import line needed to reuse the existing offline-runner error contract; no new error class, recovery path, retry, timeout, or placement teardown is added. The review identifies no runtime or security defect, and its repeated changelog/LOC checklist items are addressed by these decisions.
