### PR TITLE
test: skip unused Parallels executable copies on POSIX

### DIFF
--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -154,7 +154,9 @@ function writeFakePrlctl(tempDir: string, posixScript: string, windowsBootstrap:
   const prlctlPath = join(tempDir, "prlctl");
   writeFileSync(prlctlPath, posixScript);
   chmodSync(prlctlPath, 0o755);
-  copyFileSync(process.execPath, join(tempDir, "prlctl.exe"));
+  if (process.platform === "win32") {
+    copyFileSync(process.execPath, join(tempDir, "prlctl.exe"));
+  }
   writeFileSync(join(tempDir, "prlctl-bootstrap.mjs"), windowsBootstrap);
 }
 


### PR DESCRIPTION
## Why

The Parallels smoke test helper copied the running Node executable to `prlctl.exe` for every fake CLI fixture, including POSIX hosts that execute the separate `prlctl` script. With the measured 145 MB Node binary, 13 cases copied about 1.89 GB of unused fixture data.

## Change

Create that executable copy only on Windows hosts. Windows keeps the identical copy operation. The POSIX script, bootstrap module, environment, command resolution and all 111 test cases are unchanged, including tests targeting Windows guests from a POSIX host.

Test support +3/-1; production zero. No new cache, hardlink, mock, dependency or helper. No assertion, subprocess, timeout, process-drain, concurrency, worker or sharding changes.

## Validation

All 111 cases passed in each before/after/after/before run: **9.034 / 7.407 / 7.520 / 8.950 seconds** of file execution. Mean **8.992 → 7.464 seconds**, saving **1.528 seconds (17.0%)** on the measured macOS host. This is a focused execution result, not a whole-CI or Windows speed claim.

All 111 cases also passed shuffled with seed 93210. Full changed-file checks passed. Required Codex autoreview and independent source review found no actionable findings in their reviewed scope. Source review confirms the injected Windows-platform resolver tests do not use these fixtures or change the actual host platform.

No changelog or product documentation update is needed for this internal fixture optimization.
