### PR TITLE
fix(agents): preserve oversized Bash final-line output

### DIFF
--- a/src/agents/sessions/tools/bash.test.ts
+++ b/src/agents/sessions/tools/bash.test.ts
@@ -1,3 +1,4 @@
+import { readFile, rm } from "node:fs/promises";
 import path from "node:path";
 // Bash tool helper tests cover conversion from model-facing timeout seconds to
 // timer-safe millisecond values.
@@ -60,6 +61,40 @@ describe("bash tool timeout helpers", () => {
 });
 
 describe("bash tool output lifecycle", () => {
+  it("reports a long final line's tail and size after its newline", async () => {
+    const text = `${"x".repeat(250_000)}END-MARKER\n`;
+    const operations: BashOperations = {
+      exec: async (_command, _cwd, { onData }) => {
+        onData(Buffer.from(text), "stdout");
+        return { exitCode: 0 };
+      },
+    };
+    const result = await createBashTool(process.cwd(), { operations }).execute("long-line", {
+      command: "ignored",
+    });
+    const details = result.details;
+    if (
+      !details ||
+      typeof details !== "object" ||
+      !("fullOutputPath" in details) ||
+      typeof details.fullOutputPath !== "string"
+    ) {
+      throw new Error("Expected a full output path for truncated Bash output");
+    }
+    const fullOutputPath = details.fullOutputPath;
+    try {
+      expect(result.content[0]).toMatchObject({
+        type: "text",
+        text: expect.stringContaining(
+          "END-MARKER\n\n[Showing last 50.0KB of line 1 (line is 244.2KB).",
+        ),
+      });
+      expect(await readFile(fullOutputPath, "utf8")).toBe(text);
+    } finally {
+      await rm(fullOutputPath, { force: true });
+    }
+  });
+
   it.runIf(process.platform !== "win32").each(nativeBashSpillScenarios)(
     "settles real Bash output for %s",
     async (scenario) => {

--- a/src/agents/sessions/tools/output-accumulator.test.ts
+++ b/src/agents/sessions/tools/output-accumulator.test.ts
@@ -7,6 +7,95 @@ import { spawnNodeEvalSync } from "../../../test-utils/node-process.js";
 import { OutputAccumulator } from "./output-accumulator.js";
 
 describe("OutputAccumulator", () => {
+  it.each([
+    {
+      name: "terminated final line",
+      chunks: ["a".repeat(40), Buffer.from([0xe7, 0x95]), Buffer.from([0x8c]), "\n"],
+      maxBytes: 8,
+      expected: "aaaaa界",
+      lastLineBytes: 43,
+      totalLines: 1,
+      partial: true,
+    },
+    {
+      name: "open final line",
+      chunks: ["a".repeat(40), "界"],
+      maxBytes: 8,
+      expected: "aaaaa界",
+      lastLineBytes: 43,
+      totalLines: 1,
+      partial: true,
+    },
+    {
+      name: "complete following line",
+      chunks: ["a".repeat(40) + "\n", "short\n"],
+      maxBytes: 8,
+      expected: "short",
+      lastLineBytes: 5,
+      totalLines: 2,
+      partial: false,
+    },
+    {
+      name: "small UTF-8 boundary",
+      chunks: ["A".repeat(20) + "😀ab\nc\n"],
+      maxBytes: 4,
+      expected: "c",
+      lastLineBytes: 1,
+      totalLines: 2,
+      partial: false,
+    },
+  ])(
+    "retains the canonical tail after rolling compaction: $name",
+    async ({ chunks, maxBytes, expected, lastLineBytes, totalLines, partial }) => {
+      const accumulator = new OutputAccumulator({
+        maxBytes,
+        tempFilePrefix: "openclaw-output-test",
+      });
+      const buffers = chunks.map((chunk) =>
+        typeof chunk === "string" ? Buffer.from(chunk) : chunk,
+      );
+      const fullOutput = Buffer.concat(buffers).toString("utf8");
+      for (const data of buffers) {
+        accumulator.append(data, "stdout");
+      }
+      accumulator.finish();
+      const snapshot = accumulator.snapshot({ persistIfTruncated: true });
+      await accumulator.closeTempFile();
+      try {
+        expect(snapshot.content).toBe(expected);
+        expect(snapshot.truncation).toMatchObject({
+          truncated: true,
+          truncatedBy: "bytes",
+          totalBytes: Buffer.byteLength(fullOutput),
+          totalLines,
+          outputBytes: Buffer.byteLength(expected),
+          outputLines: 1,
+          lastLinePartial: partial,
+        });
+        expect(accumulator.getLastLineBytes()).toBe(lastLineBytes);
+        expect(await readFile(snapshot.fullOutputPath!, "utf8")).toBe(fullOutput);
+      } finally {
+        await rm(snapshot.fullOutputPath!, { force: true });
+      }
+    },
+  );
+
+  it("counts completed line bytes until the next line starts", () => {
+    const accumulator = new OutputAccumulator();
+    for (const [text, lastLineBytes, totalLines] of [
+      ["ab界", 5, 1],
+      ["\n", 5, 1],
+      ["xy\n", 2, 2],
+      ["\n", 0, 3],
+      ["z", 1, 4],
+    ] as const) {
+      accumulator.append(Buffer.from(text), "stdout");
+      expect(accumulator.getLastLineBytes()).toBe(lastLineBytes);
+      expect(accumulator.snapshot().truncation.totalLines).toBe(totalLines);
+    }
+    accumulator.finish();
+  });
+
   it("stores spilled full output in an owner-only temp file", async () => {
     const accumulator = new OutputAccumulator({
       maxBytes: 8,

--- a/src/agents/sessions/tools/output-accumulator.ts
+++ b/src/agents/sessions/tools/output-accumulator.ts
@@ -4,6 +4,7 @@
  * Keeps bounded display tails in memory while spilling full output to private temp files when needed.
  */
 import { finished } from "node:stream/promises";
+import { truncateUtf8Suffix } from "../../../utils/utf8-truncate.js";
 import { createPrivateTempWriteStream } from "./private-temp-file.js";
 import {
   DEFAULT_MAX_BYTES,
@@ -60,12 +61,11 @@ export class OutputAccumulator {
   private spillChunks: Buffer[] = [];
   private tailText = "";
   private tailBytes = 0;
-  private tailStartsAtLineBoundary = true;
   private totalRawBytes = 0;
   private totalDecodedBytes = 0;
   private completedLines = 0;
   private totalLines = 0;
-  private currentLineBytes = 0;
+  private lastLineBytes = 0;
   private hasOpenLine = false;
   private finished = false;
 
@@ -76,7 +76,9 @@ export class OutputAccumulator {
   constructor(options: OutputAccumulatorOptions = {}) {
     this.maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
     this.maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
-    this.maxRollingBytes = Math.max(this.maxBytes * 2, 1);
+    // UTF-8 trimming can drop three bytes; truncateTail also ignores a final newline.
+    // Keep enough extra bytes that an incomplete leading line cannot fit the display.
+    this.maxRollingBytes = Math.max(this.maxBytes * 2, this.maxBytes + 5);
     this.tempFilePrefix = options.tempFilePrefix ?? "openclaw-output";
     this.createTextTransform = options.createTextTransform;
   }
@@ -142,7 +144,7 @@ export class OutputAccumulator {
   }
 
   snapshot(options: { persistIfTruncated?: boolean } = {}): OutputSnapshot {
-    const tailTruncation = truncateTail(this.getSnapshotText(), {
+    const tailTruncation = truncateTail(this.tailText, {
       maxLines: this.maxLines,
       maxBytes: this.maxBytes,
     });
@@ -182,7 +184,7 @@ export class OutputAccumulator {
   }
 
   getLastLineBytes(): number {
-    return this.currentLineBytes;
+    return this.lastLineBytes;
   }
 
   private appendDecodedText(text: string): void {
@@ -195,56 +197,23 @@ export class OutputAccumulator {
     this.tailText += text;
     this.tailBytes += bytes;
     if (this.tailBytes > this.maxRollingBytes * 2) {
-      this.trimTail();
+      this.tailText = truncateUtf8Suffix(this.tailText, this.maxRollingBytes);
+      this.tailBytes = byteLength(this.tailText);
     }
 
-    let newlines = 0;
-    let lastNewline = -1;
-    for (let i = text.indexOf("\n"); i !== -1; i = text.indexOf("\n", i + 1)) {
-      newlines++;
-      lastNewline = i;
-    }
-    if (newlines === 0) {
-      this.currentLineBytes += bytes;
-      this.hasOpenLine = true;
-    } else {
-      this.completedLines += newlines;
-      const tail = text.slice(lastNewline + 1);
-      this.currentLineBytes = byteLength(tail);
-      this.hasOpenLine = tail.length > 0;
+    // A terminator closes the last real line; its size still belongs in the footer.
+    for (let start = 0; start < text.length;) {
+      const newline = text.indexOf("\n", start);
+      const end = newline === -1 ? text.length : newline;
+      this.lastLineBytes =
+        (this.hasOpenLine ? this.lastLineBytes : 0) + byteLength(text.slice(start, end));
+      this.hasOpenLine = newline === -1;
+      if (!this.hasOpenLine) {
+        this.completedLines++;
+      }
+      start = end + 1;
     }
     this.totalLines = this.completedLines + (this.hasOpenLine ? 1 : 0);
-  }
-
-  private trimTail(): void {
-    const buffer = Buffer.from(this.tailText, "utf-8");
-    if (buffer.length <= this.maxRollingBytes) {
-      this.tailBytes = buffer.length;
-      return;
-    }
-
-    let start = buffer.length - this.maxRollingBytes;
-    while (start < buffer.length) {
-      const byte = buffer.at(start);
-      if (byte === undefined || (byte & 0xc0) !== 0x80) {
-        break;
-      }
-      start++;
-    }
-
-    this.tailStartsAtLineBoundary =
-      start === 0 ? this.tailStartsAtLineBoundary : buffer.at(start - 1) === 0x0a;
-    this.tailText = buffer.subarray(start).toString("utf-8");
-    this.tailBytes = byteLength(this.tailText);
-  }
-
-  private getSnapshotText(): string {
-    if (this.tailStartsAtLineBoundary) {
-      return this.tailText;
-    }
-
-    const firstNewline = this.tailText.indexOf("\n");
-    return firstNewline === -1 ? this.tailText : this.tailText.slice(firstNewline + 1);
   }
 
   private shouldUseTempFile(): boolean {


### PR DESCRIPTION
Closes #133213

## What Problem This Solves

Fixes an issue where users running a Bash command that prints an oversized newline-terminated final line would receive `(no output)` and an impossible `Showing lines 2-1 of 1` footer. Shorter truncated final lines also reported `line is 0B` after their terminator.

## Why This Change Was Made

The shared `OutputAccumulator` now lets the existing `truncateTail` owner select complete lines or an oversized final-line suffix. Removing its earlier partial-line filter and duplicate UTF-8 trimming avoids discarding the only visible line. The same owner retains the last completed line's byte size until the next line starts.

Rolling retention uses the existing UTF-8 suffix helper. A small internal floor accounts for up to three skipped continuation bytes and an ignored trailing newline, so even a four-byte display budget cannot mistake an incomplete leading line for a complete line. The default 50KB display limit and 100KB rolling compaction target are unchanged. No new configuration, dependency, persistence, or execution policy.

Production LOC: +22/-53 (**net -31**). Tests: +124/-0. Removed paths: private `trimTail`, private `getSnapshotText`, and `tailStartsAtLineBoundary` state. Full-output spill ownership and per-stream decoder/sanitizer behavior are unchanged.

## User Impact

Both the model-facing built-in Bash tool and interactive Bash executor keep the final output tail and report accurate line sizes. Full private output logs remain complete. Nonzero command exits remain errors and retain their output. Truncated complete-line output follows the shared truncator's newline formatting consistently instead of depending on whether rolling compaction ran.

## Evidence

Real process proof used isolated temporary homes and the actual production tool/executor with local Bash operations, `/bin/bash`, and Node. No model or external API was mocked or needed.

| Scenario | Before | After |
| --- | --- | --- |
| 250011-byte newline-terminated ASCII line | Empty tail; `(no output)`; lines 2-1 | 51200-byte tail including final marker; correct 244.2KB line size |
| Same line without newline | 51200-byte tail | Preserved |
| 240011-byte UTF-8 line | Same implicated owner | 51199-byte complete-character tail; correct 234.4KB line size |
| Oversized line followed by `short\n` | Compaction-dependent newline formatting | Complete final line and correct line 2-2 metadata |
| 100011-byte terminated line | Correct tail, line size 0B | Correct tail and 97.7KB line size |
| Exit code 7 after oversized output | Not separately run before | Output retained; executor code 7; tool throws with code 7 |

All twelve after executions (six scenarios through both callers) verified exact full-output log bytes and removed only their own private spill files. The before proof's affected owners are byte-identical to the current base.

Focused validation:

- Six new owner/tool regressions pass. The before run fails for the lost terminated-line tail and completed-line size; additional table cases protect canonical formatting and sibling paths.
- A separate floor-only counterfactual fails the small UTF-8 regression with `ab\nc` instead of `c`; restoring the canonical retention floor passes.
- 53 focused sibling tests pass across the accumulator, Bash tool/executor, UTF-8 suffix helper, and shared truncation tests. Eight pre-existing native fault/launch cases were deliberately excluded from this bounded no-fault-injection lane; actual healthy Bash execution was verified separately.
- Fresh Codex autoreview: scoped-clean at P0. Separate exact-head read-only Codex review: no actionable P0–P2 findings. An independent maintainer worker also verified the source, proof artifacts, and exact committed patch.
- Full three-path canonical changed gate passed (format, structural checks, production/test types, and changed-file lint). [Exact-head CI33303483916](https://github.com/openclaw/openclaw/actions/runs/33303483916) is green at the reviewed commit. Native landing validation follows.
- Reviewed commit: `13e509e62d8d33ab0619912e7202148b499f55b0`; patch SHA-256 `ff5f0b0568b18485bf2bcb84382e648fe743a093b5577467d95148ee0988fb8b`.

Before behavior was observed on aaf15b835184e563502050406cfb0391dd027782 with affected source unchanged through base039187abe40516ae796fa9cd85cab1494fe94399. Stable tag v2026.7.1 carries the same defective filtering/counting flow; first-introduction attribution is unknown. Related test-only coverage follow-up #103449 remains outside this PR's closure scope.

Proof scope: production Bash tool/executor and real child processes, not a full interactive TUI session or live model turn. No UI renderer, channel, or provider behavior changed.
