### PR TITLE
fix(ui): preview local attachments with dot-segment paths

### DIFF
--- a/ui/src/components/session-group-defaults-dialog.ts
+++ b/ui/src/components/session-group-defaults-dialog.ts
@@ -7,8 +7,9 @@ import type {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { t } from "../i18n/index.ts";
 import { formatUiError } from "../lib/format-error.ts";
+import { isAbsolutePath } from "../lib/local-path.ts";
 import { renderSessionMenuItem } from "../pages/new-session/cloud-target.ts";
-import { folderDisplayName, isAbsolutePath } from "../pages/new-session/path.ts";
+import { folderDisplayName } from "../pages/new-session/path.ts";
 import { renderPlaceBrowser } from "../pages/new-session/place-browser.ts";
 import "../styles/new-session.css";
 import { icons } from "./icons.ts";

--- a/ui/src/e2e/chat-flow.local-media-paths.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.local-media-paths.e2e.test.ts
@@ -7,15 +7,34 @@ import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-sup
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
-  it("allows tilde local media previews when the preview root home contains a literal $ pattern", async () => {
+  it.each([
+    { name: "dollar-home", source: "~/media/report-voice.mp3", root: "/home/us$&r/media" },
+    {
+      name: "posix-literal-backslash",
+      source: "/tmp/openclaw/..\\report.mp3",
+      root: "/tmp/openclaw",
+    },
+    {
+      name: "posix-dot-segments",
+      source: "/tmp/staging/../openclaw/report # 100%?.mp3",
+      root: "/tmp/openclaw",
+    },
+    {
+      name: "windows-dot-segments",
+      source: "C:/Temp/../Users/test/media/report # 100%?.mp3",
+      root: "c:/users/test/media",
+    },
+  ])("previews structured local audio with $name", async ({ name, source, root }) => {
     const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
+      ...(artifactDir
+        ? { recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } } }
+        : {}),
     });
     const page = await context.newPage();
-    const source = "~/media/report-voice.mp3";
     const requestedMediaUrls: URL[] = [];
 
     await page.route("**/__openclaw__/assistant-media?**", async (route) => {
@@ -27,7 +46,7 @@ suite.define(() => {
           contentType: "application/json",
           body: JSON.stringify({
             available: true,
-            mediaTicket: "ticket-dollar-home",
+            mediaTicket: "ticket-local-media",
             mediaTicketExpiresAt: new Date(Date.now() + 5 * 60_000).toISOString(),
           }),
         });
@@ -40,10 +59,10 @@ suite.define(() => {
     });
 
     await installMockGateway(page, {
-      localMediaPreviewRoots: ["/home/us$&r/media"],
+      localMediaPreviewRoots: [root],
       historyMessages: [
         {
-          id: "assistant-dollar-home-audio",
+          id: `assistant-${name}-audio`,
           role: "assistant",
           content: [
             { type: "text", text: "Your recording" },
@@ -74,14 +93,14 @@ suite.define(() => {
       expect(
         requestedMediaUrls
           .slice(1)
-          .some((url) => url.searchParams.get("mediaTicket") === "ticket-dollar-home"),
+          .some((url) => url.searchParams.get("mediaTicket") === "ticket-local-media"),
       ).toBe(true);
       const downloadHref = await attachment
         .locator(".chat-assistant-attachment-card__download")
         .getAttribute("href");
       expect(downloadHref).toBeTruthy();
       const downloadUrl = new URL(downloadHref ?? "", suite.server.baseUrl);
-      expect(downloadUrl.searchParams.get("mediaTicket")).toBe("ticket-dollar-home");
+      expect(downloadUrl.searchParams.get("mediaTicket")).toBe("ticket-local-media");
       expect(downloadUrl.searchParams.get("source")).toBe(source);
       await expect
         .poll(() =>
@@ -91,14 +110,11 @@ suite.define(() => {
         )
         .toBeGreaterThanOrEqual(1);
       expect(await page.getByText("Outside allowed folders").count()).toBe(0);
+    } finally {
       if (artifactDir) {
         await mkdir(artifactDir, { recursive: true });
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(artifactDir, "local-media-dollar-home-allowed.png"),
-        });
+        await page.screenshot({ fullPage: true, path: path.join(artifactDir, `${name}.png`) });
       }
-    } finally {
       await suite.closeBrowserContext(context);
     }
   });

--- a/ui/src/lib/local-path.ts
+++ b/ui/src/lib/local-path.ts
@@ -1,0 +1,29 @@
+export function isAbsolutePath(path: string): boolean {
+  return path.startsWith("/") || path.startsWith("\\") || /^[A-Za-z]:[\\/]/.test(path);
+}
+
+/** Lexical comparison only; the Gateway remains the realpath authority. */
+export function comparableAbsolutePath(value: string): string | null {
+  if (!isAbsolutePath(value)) {
+    return null;
+  }
+  const path = value.trim();
+  const parts: string[] = [];
+  // Keep drive/UNC roots at ".."; POSIX backslashes remain literal filename data.
+  const floor = /^[A-Za-z]:[\\/]/u.test(path) ? 1 : /^[\\/]{2}/u.test(path) ? 2 : 0;
+  for (const part of path.split(floor > 0 || path.startsWith("\\") ? /[\\/]/u : "/")) {
+    if (!part || part === ".") {
+      continue;
+    }
+    if (part === "..") {
+      if (parts.length > floor) {
+        parts.pop();
+      }
+      continue;
+    }
+    parts.push(part);
+  }
+  const prefix = floor === 2 ? "//" : /^[\\/]/u.test(path) ? "/" : "";
+  const normalized = `${prefix}${parts.join("/")}`.replace(/\/+$/u, "") || "/";
+  return floor > 0 ? normalized.toLowerCase() : normalized;
+}

--- a/ui/src/pages/chat/components/chat-message-local-media.test.ts
+++ b/ui/src/pages/chat/components/chat-message-local-media.test.ts
@@ -3,6 +3,57 @@ import { describe, expect, it } from "vitest";
 import { isLocalAttachmentPreviewAllowed } from "./chat-message-local-media.ts";
 
 describe("isLocalAttachmentPreviewAllowed", () => {
+  it.each([
+    ["POSIX return inside", "/tmp/other/../media/report.png", "/tmp/media", true],
+    ["POSIX escape", "/tmp/media/../other/report.png", "/tmp/media", false],
+    ["POSIX literal backslash", "/tmp/media/..\\report.png", "/tmp/media", true],
+    ["POSIX backslash directory", "/tmp/media\\one/report.png", "/tmp/media\\one", true],
+    ["POSIX backslash is not a child separator", "/tmp/media\\one/report.png", "/tmp/media", false],
+    ["root dot segments", "/tmp/media/report.png", "/tmp/other/../media", true],
+    ["literal URL punctuation", "/tmp/media/report # 100%?.png", "/tmp/media", true],
+    ["literal encoded dots", "/tmp/media/%2e%2e/report.png", "/tmp/media", true],
+    [
+      "file URL encoded literal dots",
+      "file:///tmp/media/%252e%252e/report.png",
+      "/tmp/media",
+      true,
+    ],
+    ["file URL encoded slash", "file:///tmp/media/sub%2freport.png", "/tmp/media", false],
+    ["file URL remote host", "file://remote/tmp/media/report.png", "/tmp/media", false],
+    [
+      "Windows return inside",
+      "C:/Temp/../Users/test/media/report.png",
+      "c:/users/test/media",
+      true,
+    ],
+    [
+      "Windows backslashes",
+      "C:\\Temp\\..\\Users\\test\\media\\report.png",
+      "c:/users/test/media",
+      true,
+    ],
+    [
+      "Windows file URL drive prefix",
+      "/C:/Temp/../Users/test/media/report.png",
+      "C:/Users/test/media",
+      true,
+    ],
+    ["Windows drive floor", "C:/../../Users/test/media/report.png", "c:/users/test/media", true],
+    ["different Windows drive", "D:/Users/test/media/report.png", "c:/users/test/media", false],
+    ["UNC return inside", "//server/share/tmp/../media/report.png", "//server/share/media", true],
+    ["UNC share floor", "//server/share/../../other/report.png", "//server/other", false],
+    [
+      "UNC file URL remains blocked",
+      "file://server/share/media/report.png",
+      "//server/share/media",
+      false,
+    ],
+    ["filesystem root remains blocked", "/tmp/media/report.png", "/", false],
+    ["POSIX case remains significant", "/tmp/Media/report.png", "/tmp/media", false],
+  ] as const)("compares %s", (_name, source, root, allowed) => {
+    expect(isLocalAttachmentPreviewAllowed(source, [root])).toBe(allowed);
+  });
+
   it("keeps literal $ patterns in home when expanding tilde sources", () => {
     const roots = ["/home/us$&r/media"];
     expect(isLocalAttachmentPreviewAllowed("~/media/report.png", roots)).toBe(true);

--- a/ui/src/pages/chat/components/chat-message-local-media.ts
+++ b/ui/src/pages/chat/components/chat-message-local-media.ts
@@ -1,4 +1,5 @@
 import { buildAssistantMediaUrl } from "../../../app/assistant-media.ts";
+import { comparableAbsolutePath } from "../../../lib/local-path.ts";
 
 export function isLocalAssistantAttachmentSource(source: string): boolean {
   const trimmed = source.trim();
@@ -74,14 +75,9 @@ function resolveHomeCandidatesFromRoots(localMediaPreviewRoots: readonly string[
 }
 
 function canonicalizeLocalPathForComparison(value: string): string {
-  let slashNormalized = value.replace(/\\/g, "/").replace(/\/+$/, "");
-  if (/^\/[a-zA-Z]:\//.test(slashNormalized)) {
-    slashNormalized = slashNormalized.slice(1);
-  }
-  if (/^[a-zA-Z]:\//.test(slashNormalized)) {
-    return slashNormalized.toLowerCase();
-  }
-  return slashNormalized;
+  // Preserve file-URL drive spellings and the media gate's filesystem-root rejection.
+  const withoutDriveSlash = value.replace(/^[\\/](?=[a-z]:[\\/])/iu, "");
+  return comparableAbsolutePath(withoutDriveSlash)?.replace(/\/$/u, "") ?? "";
 }
 
 export function isLocalAttachmentPreviewAllowed(

--- a/ui/src/pages/new-session/draft-place-browser.ts
+++ b/ui/src/pages/new-session/draft-place-browser.ts
@@ -14,8 +14,9 @@ import type { ApplicationContext } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { canCallGatewayMethod, isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
+import { isAbsolutePath } from "../../lib/local-path.ts";
 import type { DraftGatewayState } from "./draft-gateway-state.ts";
-import { folderDisplayName, isAbsolutePath, isKnownWorkspacePath } from "./path.ts";
+import { folderDisplayName, isKnownWorkspacePath } from "./path.ts";
 import { projectCloneInput, type DraftRemoteProject } from "./project-chip.ts";
 import { recentPlaces, type RecentPlaceSource } from "./recent-places.ts";
 

--- a/ui/src/pages/new-session/path.test.ts
+++ b/ui/src/pages/new-session/path.test.ts
@@ -9,6 +9,14 @@ import { isKnownWorkspacePath } from "./path.ts";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("isKnownWorkspacePath", () => {
+  it.each([
+    ["POSIX literal backslash", "/workspace", "/workspace/..\\folder", true],
+    ["Windows root-relative path", "\\workspace", "\\workspace\\sub\\..\\folder", true],
+    ["Windows root-relative escape", "\\workspace", "\\workspace\\..\\other", false],
+  ] as const)("compares %s", (_name, root, candidate, allowed) => {
+    expect(isKnownWorkspacePath([root], candidate)).toBe(allowed);
+  });
+
   it("accepts a canonical child after the Gateway approves a symlinked workspace root", async () => {
     const tempRoot = await fs.realpath(os.tmpdir());
     const container = tempDirs.make("openclaw-ui-workspace-alias-", tempRoot);

--- a/ui/src/pages/new-session/path.ts
+++ b/ui/src/pages/new-session/path.ts
@@ -1,3 +1,5 @@
+import { comparableAbsolutePath } from "../../lib/local-path.ts";
+
 /** Last path segment for the folder trigger label; preserves filesystem roots. */
 export function folderDisplayName(path: string): string {
   return path.split(/[\\/]/).findLast((segment) => segment.length > 0) ?? path;
@@ -11,35 +13,6 @@ export function parentFolderDisplayName(path: string): string | undefined {
   }
   const parent = separator === 0 ? trimmed.slice(0, 1) : trimmed.slice(0, separator);
   return folderDisplayName(parent) || undefined;
-}
-
-export function isAbsolutePath(path: string): boolean {
-  return path.startsWith("/") || path.startsWith("\\") || /^[A-Za-z]:[\\/]/.test(path);
-}
-
-function comparableAbsolutePath(value: string): string | null {
-  if (!isAbsolutePath(value)) {
-    return null;
-  }
-  const path = value.trim().replaceAll("\\", "/");
-  const windows = /^[A-Za-z]:\//u.test(path) || path.startsWith("//");
-  const parts: string[] = [];
-  const floor = /^[A-Za-z]:\//u.test(path) ? 1 : path.startsWith("//") ? 2 : 0;
-  for (const part of path.split("/")) {
-    if (!part || part === ".") {
-      continue;
-    }
-    if (part === "..") {
-      if (parts.length > floor) {
-        parts.pop();
-      }
-      continue;
-    }
-    parts.push(part);
-  }
-  const prefix = path.startsWith("//") ? "//" : path.startsWith("/") ? "/" : "";
-  const normalized = `${prefix}${parts.join("/")}`.replace(/\/+$/u, "") || "/";
-  return windows ? normalized.toLowerCase() : normalized;
 }
 
 /** Client-side affordance check; the Gateway remains the realpath authority. */


### PR DESCRIPTION
Closes #133217

## What Problem This Solves

Fixes an issue where users see “Outside allowed folders” instead of a playable local attachment when its absolute path contains dot segments that resolve back inside an advertised preview root. This affects structured attachment paths such as `/tmp/staging/../openclaw/report # 100%?.mp3` under `/tmp/openclaw`.

## Why This Change Was Made

The media UI compared raw path prefixes, while the Gateway resolves filesystem paths before authorizing them. Reuse the existing browser-safe lexical comparator from workspace selection, migrate workspace selection and session-group defaults to that shared owner, and delete the weaker media comparison. The media adapter retains its filesystem-root rejection and Windows file-URL drive spelling support. The shared comparator now preserves literal POSIX backslashes while reducing Windows paths with their native separator spelling.

Gateway authorization and ticket issuance are unchanged. Raw filename punctuation remains literal, file URLs decode once, and metadata/download requests retain the exact original source. The UI check remains an affordance; it cannot resolve filesystem symlinks.

## User Impact

Valid structured local attachments with POSIX or Windows dot-segment spellings can reach authenticated metadata verification and display the player when allowed by the Gateway. No new configuration, public API, or authorization policy is introduced.

## Evidence

- Before: 8 of 19 path-policy cases fail. The full Chromium application shows “Unavailable · Outside allowed folders” for both POSIX and Windows structured attachment fixtures; the existing dollar-sign home-path case passes.
- After: 38 focused tests pass across the media owner and workspace-selection siblings. A fresh production build and all four full-application Chromium cases pass, including a literal POSIX backslash filename. The complete eight-file changed-scope gate passes, including core-test/UI type checks, lint, styles, and all guards.
- A separate synthetic loopback proof exercised the actual Gateway HTTP handler: return-inside paths receive a ticket and serve generated bytes; outside, dot-escape, missing-leaf escape, and static symlink-escape cases return no outside bytes. Wrong-source tickets fail authentication. This is bounded path evidence, not a broad security certification.
- The first production build caught a missed dialog import, and independent review caught a literal-POSIX-backslash regression. Both are corrected and covered by the final browser run. Refreshed structured Codex review and both final independent source reviews found no actionable issue. Production LOC is +39/-39 (net 0), largely moving the existing comparator; regression tests are counted separately.

Before/after screenshots and recordings remain local. Public upload is withheld because work-device image sharing requires separate content-and-destination approval; no images were uploaded. Windows syntax is exercised in Chromium, not on a Windows-native filesystem. Original defect introduction is unknown: the weak comparator existed before its July 24 module move.

Landing is held until the required before/after image-publication gate is resolved. No public image upload has been authorized or performed.
