### PR TITLE
fix(gateway): make defaultPersistDigest report its actual tri-state outcome

### DIFF
--- a/src/gateway/session-observer-model.test.ts
+++ b/src/gateway/session-observer-model.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import type { SessionObserverDigest } from "../../packages/gateway-protocol/src/schema/sessions.js";
+import {
+  loadSessionEntryReadOnly,
+  upsertSessionEntryCore,
+} from "../config/sessions/session-accessor.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { defaultPersistDigest } from "./session-observer-model.js";
+
+function digest(overrides: Partial<SessionObserverDigest> = {}): SessionObserverDigest {
+  return {
+    sessionKey: "agent:main:persist-digest",
+    runId: "run-1",
+    revision: 1,
+    updatedAt: 1,
+    headline: "Reviewing changes",
+    health: "on-track",
+    ...overrides,
+  };
+}
+
+describe("defaultPersistDigest", () => {
+  it("returns null for an unpersistable session whose entry no longer exists", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const sessionKey = "agent:main:persist-digest-missing";
+      const result = await defaultPersistDigest({
+        sessionKey,
+        agentId: "main",
+        digest: digest({ sessionKey }),
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  it("returns false without persisting when the mutator rejects a stale revision", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const sessionKey = "agent:main:persist-digest-stale";
+      await upsertSessionEntryCore(
+        { sessionKey, agentId: "main" },
+        {
+          sessionId: "session-1",
+          updatedAt: 1,
+          observerDigest: digest({ sessionKey, revision: 5 }),
+        },
+      );
+
+      const result = await defaultPersistDigest({
+        sessionKey,
+        sessionId: "session-1",
+        agentId: "main",
+        digest: digest({ sessionKey, revision: 1 }),
+      });
+
+      expect(result).toBe(false);
+      const entry = loadSessionEntryReadOnly({ sessionKey, agentId: "main" });
+      expect(entry?.observerDigest?.revision).toBe(5);
+    });
+  });
+
+  it("returns true and persists when the digest is accepted", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const sessionKey = "agent:main:persist-digest-accept";
+      await upsertSessionEntryCore(
+        { sessionKey, agentId: "main" },
+        { sessionId: "session-1", updatedAt: 1 },
+      );
+
+      const result = await defaultPersistDigest({
+        sessionKey,
+        sessionId: "session-1",
+        agentId: "main",
+        digest: digest({ sessionKey, revision: 2 }),
+      });
+
+      expect(result).toBe(true);
+      const entry = loadSessionEntryReadOnly({ sessionKey, agentId: "main" });
+      expect(entry?.observerDigest?.revision).toBe(2);
+    });
+  });
+});

--- a/src/gateway/session-observer-model.ts
+++ b/src/gateway/session-observer-model.ts
@@ -270,14 +270,14 @@ export async function defaultPersistDigest(params: {
   digest: SessionObserverDigest;
   stillCurrent?: () => boolean;
 }): Promise<boolean | null> {
-  let missingEntry = false;
+  // No fallbackEntry is supplied below, so the accessor returns null only when
+  // the session row is gone; it never invokes this mutator in that case. Track
+  // acceptance separately, since a rejecting mutator still yields a truthy
+  // (unchanged) result from the accessor.
+  let accepted = false;
   const result = await patchSessionEntryCore(
     { sessionKey: params.sessionKey, agentId: params.agentId },
-    (entry, context) => {
-      if (!context.existingEntry) {
-        missingEntry = true;
-        return null;
-      }
+    (entry) => {
       if (params.stillCurrent?.() === false) {
         return null;
       }
@@ -287,14 +287,12 @@ export async function defaultPersistDigest(params: {
       if ((entry.observerDigest?.revision ?? 0) >= params.digest.revision) {
         return null;
       }
+      accepted = true;
       return { observerDigest: params.digest };
     },
     { preserveActivity: true },
   );
-  if (result) {
-    return true;
-  }
-  return missingEntry ? null : false;
+  return result === null ? null : accepted;
 }
 
 export async function synthesizeSessionObserverTerminalDigest(params: {

--- a/src/gateway/session-observer.test.ts
+++ b/src/gateway/session-observer.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionObserverDigest } from "../../packages/gateway-protocol/src/schema/sessions.js";
+import { loadSessionEntryReadOnly } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { defaultPersistDigest } from "./session-observer-model.js";
 import {
   createHarness,
   declareObserverVisibility,
@@ -620,6 +623,37 @@ describe("session observer", () => {
       headline: "Continuing without model",
     });
     harness.observer.dispose();
+  });
+
+  it("stops calling the utility model once the real session store reports the row missing", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      const completeModel = vi.fn(async () =>
+        modelMessage({ headline: "Checking files", health: "on-track" }),
+      );
+      const harness = createHarness({ completeModel, persistDigest: defaultPersistDigest });
+      startAndAddToolNotes(harness.observer);
+
+      await vi.advanceTimersByTimeAsync(12_000);
+      await flushObserver();
+      expect(completeModel).toHaveBeenCalledOnce();
+      // No entry was ever written for this sessionKey in the real SQLite store,
+      // so defaultPersistDigest returned null and disableModelForRun fired.
+      expect(
+        loadSessionEntryReadOnly({ sessionKey: "agent:main:session-1", agentId: "main" }),
+      ).toBeUndefined();
+
+      for (let index = 0; index < 4; index += 1) {
+        harness.observer.handleEvent(
+          event({ stream: "tool", data: { phase: "start", name: "read", args: { index } } }),
+        );
+      }
+      await vi.advanceTimersByTimeAsync(12_000);
+      await flushObserver();
+      expect(completeModel).toHaveBeenCalledOnce();
+      harness.observer.dispose();
+    });
   });
 
   it("does not observe without subscribers and stops after unsubscribe", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes #133171.

`defaultPersistDigest` (`src/gateway/session-observer-model.ts`) documents a
tri-state contract for the session observer's default persistence adapter:
return `true` when the digest was actually persisted, `null` when the
session store entry is gone ("unpersistable"), `false` otherwise. The
implementation could never deliver `null`, and silently mis-reported
rejected writes as `true`:

- Missing-entry detection lived inside the mutator callback passed to
  `patchSessionEntryCore`. But `patchSqliteSessionEntrySnapshot` resolves
  `writeBase = existing ?? options.fallbackEntry` and returns `{ result: null }`
  **without ever invoking the mutator** when both are absent.
  `defaultPersistDigest` passes no `fallbackEntry`, so when the session row is
  missing the mutator never runs, the `missingEntry` flag never gets set, and
  the function falls through to returning `false` — the documented `null` is
  unreachable through the only code path that meant it.
- In the opposite direction, every in-mutator rejection (`stillCurrent()`
  going false, a session id mismatch, a stale digest revision) returns `null`
  from the mutator. That makes the accessor treat the patch as a no-op and
  return `cloneSessionEntry(writeBase)` — a truthy value — so `if (result)
  return true;` reported rejected writes as successfully persisted.

The consumer (`src/gateway/session-observer-persistence.ts`) trusts this
tri-state as authoritative: `null` calls `onMissingEntry`, which disables the
utility model for that run so an unpersistable session stops re-billing it
every persist interval. Because `null` was unreachable, a session whose row
was deleted or reset mid-run kept claiming the utility model and taking a
doomed SQLite write lock every cycle, with no log and no demotion. Separately,
`true` on a rejected write advanced `lastPersistedAt` even though nothing was
written.

## Why This Change Was Made

The fix follows the issue's suggested direction: make `defaultPersistDigest`
observe what the mutator actually did via a mutator-scoped `accepted` flag
(the pattern sibling callers in this file already use), and treat the
accessor's `null` result as the missing-entry signal — which is unambiguous
here since no `fallbackEntry` is ever supplied. This keeps the generic
`patchSessionEntryCore`/SQLite accessor contract untouched and confines the
repair to the one adapter that misreads it.

Net production diff is -2 lines (18 changed, 8 insertions / 10 deletions).

## Evidence

Regression test added: `src/gateway/session-observer-model.test.ts`, three
cases covering all three tri-state outcomes against the real SQLite session
store (via `withOpenClawTestState`), not a mock.

Confirmed the two new cases that exercise the bug fail on the pre-fix code
(`git checkout HEAD~1 -- src/gateway/session-observer-model.ts`, rerun, then
restore):

```
 × defaultPersistDigest > returns null for an unpersistable session whose entry no longer exists
   → expected false to be null
 × defaultPersistDigest > returns false without persisting when the mutator rejects a stale revision
   → expected true to be false // Object.is equality
 ✓ defaultPersistDigest > returns true and persists when the digest is accepted

 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
```

With the fix applied, all three pass, plus the full sibling suite:

```
$ pnpm test src/gateway/session-observer-model.test.ts src/gateway/session-observer-persistence.test.ts src/gateway/session-observer.test.ts

 Test Files  3 passed (3)
      Tests  35 passed (35)
```

Typecheck (`pnpm tsgo`) and lint (`node scripts/run-oxlint.mjs
src/gateway/session-observer-model.ts src/gateway/session-observer-model.test.ts`)
both pass clean. `pnpm check:changed -- <changed files>` passes except for
the `max-lines suppression ratchet` step, which fails because it always
diffs against `origin/main` and this fork's `origin/main` has diverged
heavily from `upstream/main`; running the same check with
`--base upstream/main` directly passes (`max-lines ratchet OK: 882
grandfathered suppressions.`), confirming the failure is environmental to
this fork and unrelated to this change.

AI assistance disclosure: this change was authored by an autonomous Claude
Code agent (root-cause investigation and fix already scoped by a prior
ClawSweeper review comment on the issue).


## Update: real-observer proof of the missing-entry disable

Per review, added `src/gateway/session-observer.test.ts` > "stops calling
the utility model once the real session store reports the row missing":
a real `createSessionObserver` instance wired to the real
`defaultPersistDigest` against a real (empty) SQLite session store inside
`withOpenClawTestState`, with only `completeModel`/`prepareModel` stubbed
(no live model provider is available in this environment). No session
entry is ever written for the run's `sessionKey`, so the real SQLite
accessor reports the row missing, `defaultPersistDigest` returns `null`,
and the observer's own `onMissingEntry` → `disableModelForRun` path runs
end-to-end. The test then feeds four more tool-note events into the same
observer instance and asserts `completeModel` is still only called once,
i.e. the running observer actually stopped scheduling utility-model work
for that run.

Confirmed this fails on pre-fix `session-observer-model.ts`
(`git checkout HEAD~1 -- src/gateway/session-observer-model.ts`): the old
`false` (instead of `null`) return skips `onMissingEntry`, so the model
keeps getting called — `completeModel` was called twice instead of once:

```
× session observer > stops calling the utility model once the real session store reports the row missing
  → expected "vi.fn()" to be called once, but got 2 times
```

Restored the fix; full suite now green:

```
$ pnpm test src/gateway/session-observer.test.ts src/gateway/session-observer-model.test.ts src/gateway/session-observer-persistence.test.ts

 Test Files  3 passed (3)
      Tests  36 passed (36)
```

`pnpm tsgo` and `node scripts/run-oxlint.mjs src/gateway/session-observer.test.ts` both pass clean.

This does not cover a live utility-model call or an active row actually
being deleted mid-run (no delete API is exposed for session entries, and
this environment has no live model provider credentials); it does prove
the real Gateway observer, wired to the real production persistence
adapter and a real SQLite-backed session store, receives the missing-row
result and stops utility-model work for that run.
