### PR TITLE
fix(gateway): stop unpersistable session observer work

### DIFF
--- a/src/gateway/session-observer-model.test.ts
+++ b/src/gateway/session-observer-model.test.ts
@@ -1,0 +1,123 @@
+// Real-storage regression for defaultPersistDigest's tri-state contract.
+// The persister disables the utility model only when persistDigest returns
+// null (entry gone), advances the persistence clock only for true, and treats
+// false as a no-op — so the default adapter must actually be able to deliver
+// all three states against the real SQLite session store.
+import { describe, expect, it } from "vitest";
+import type { SessionObserverDigest } from "../../packages/gateway-protocol/src/schema/sessions.js";
+import {
+  loadSessionEntryReadOnly,
+  upsertSessionEntryCore,
+} from "../config/sessions/session-accessor.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { defaultPersistDigest } from "./session-observer-model.js";
+
+const agentId = "main";
+
+function makeDigest(sessionKey: string, revision: number): SessionObserverDigest {
+  return {
+    sessionKey,
+    runId: "run-1",
+    revision,
+    updatedAt: 0,
+    headline: "Checking files",
+    health: "on-track",
+  };
+}
+
+describe("defaultPersistDigest tri-state contract", () => {
+  it("returns null when the session row is gone (unpersistable)", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      // No seed: the store has no entry for this session key, so the SQLite
+      // owner skips the updater and the contract must surface null.
+      const sessionKey = "agent:main:persist-digest-missing";
+      const accepted = await defaultPersistDigest({
+        sessionKey,
+        agentId,
+        digest: makeDigest(sessionKey, 1),
+      });
+      expect(accepted).toBeNull();
+    });
+  });
+
+  it("returns true when the digest is applied", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const sessionKey = "agent:main:persist-digest-accept";
+      await upsertSessionEntryCore(
+        { sessionKey, agentId, env: process.env },
+        { sessionId: "sess-1", updatedAt: 1 },
+      );
+      const accepted = await defaultPersistDigest({
+        sessionKey,
+        agentId,
+        sessionId: "sess-1",
+        digest: makeDigest(sessionKey, 1),
+      });
+      expect(accepted).toBe(true);
+      // Side effect: the digest revision was actually written.
+      const entry = loadSessionEntryReadOnly({ sessionKey, agentId });
+      expect(entry?.observerDigest?.revision).toBe(1);
+    });
+  });
+
+  it.each([
+    // stale: seed revision outranks the incoming digest, so the updater rejects.
+    ["stale digest revision", { seedRevision: 2, digestRevision: 1, sessionId: "sess-1" }],
+    // mismatch: incoming digest outranks the seed (2 > 1), so it would apply —
+    // except the sessionId differs, which must reject before the write.
+    ["session id mismatch", { seedRevision: 1, digestRevision: 2, sessionId: "other" }],
+  ] as const)(
+    "returns false on rejected write (%s)",
+    async (_label, { seedRevision, digestRevision, sessionId }) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        const sessionKey = "agent:main:persist-digest-reject";
+        await upsertSessionEntryCore(
+          { sessionKey, agentId, env: process.env },
+          {
+            sessionId: "sess-1",
+            updatedAt: 1,
+            observerDigest: makeDigest(sessionKey, seedRevision),
+          },
+        );
+        const accepted = await defaultPersistDigest({
+          sessionKey,
+          agentId,
+          sessionId,
+          digest: makeDigest(sessionKey, digestRevision),
+        });
+        // The updater rejects (stale revision or sessionId mismatch); the store
+        // returns a clone of the existing entry, which must NOT be reported as
+        // persisted.
+        expect(accepted).toBe(false);
+        // Side effect: the existing digest was not overwritten.
+        const entry = loadSessionEntryReadOnly({ sessionKey, agentId });
+        expect(entry?.observerDigest?.revision).toBe(seedRevision);
+      });
+    },
+  );
+
+  it("returns false when stillCurrent reports the run is no longer active", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const sessionKey = "agent:main:persist-digest-stale-run";
+      await upsertSessionEntryCore(
+        { sessionKey, agentId, env: process.env },
+        {
+          sessionId: "sess-1",
+          updatedAt: 1,
+          observerDigest: makeDigest(sessionKey, 0),
+        },
+      );
+      const accepted = await defaultPersistDigest({
+        sessionKey,
+        agentId,
+        sessionId: "sess-1",
+        digest: makeDigest(sessionKey, 1),
+        stillCurrent: () => false,
+      });
+      expect(accepted).toBe(false);
+      // Side effect: the digest was not advanced by the superseded run.
+      const entry = loadSessionEntryReadOnly({ sessionKey, agentId });
+      expect(entry?.observerDigest?.revision).toBe(0);
+    });
+  });
+});

--- a/src/gateway/session-observer-model.ts
+++ b/src/gateway/session-observer-model.ts
@@ -270,14 +270,13 @@ export async function defaultPersistDigest(params: {
   digest: SessionObserverDigest;
   stillCurrent?: () => boolean;
 }): Promise<boolean | null> {
-  let missingEntry = false;
+  // No fallbackEntry is supplied, so the accessor returns null only when the
+  // row is gone (→ null) and a truthy clone on rejection — track acceptance
+  // separately since the result alone can't distinguish the three states.
+  let applied = false;
   const result = await patchSessionEntryCore(
     { sessionKey: params.sessionKey, agentId: params.agentId },
-    (entry, context) => {
-      if (!context.existingEntry) {
-        missingEntry = true;
-        return null;
-      }
+    (entry) => {
       if (params.stillCurrent?.() === false) {
         return null;
       }
@@ -287,14 +286,12 @@ export async function defaultPersistDigest(params: {
       if ((entry.observerDigest?.revision ?? 0) >= params.digest.revision) {
         return null;
       }
+      applied = true;
       return { observerDigest: params.digest };
     },
     { preserveActivity: true },
   );
-  if (result) {
-    return true;
-  }
-  return missingEntry ? null : false;
+  return result === null ? null : applied;
 }
 
 export async function synthesizeSessionObserverTerminalDigest(params: {

--- a/src/gateway/session-observer.terminal.test.ts
+++ b/src/gateway/session-observer.terminal.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionObserverDigest } from "../../packages/gateway-protocol/src/schema/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SessionObserverDeps } from "./session-observer-model.js";
 import {
   createHarness as createBaseHarness,
   event,
@@ -716,17 +717,33 @@ describe("session observer terminal, persistence, synthesis, and races", () => {
     expect(guard?.()).toBe(false);
   });
 
-  it("drops a completed digest when the session was reset mid-flight", async () => {
+  it.each(["deleted", "reset"])("disables model work after the session is %s", async (change) => {
     useFakeTime();
-    const readSession = vi.fn(() => ({ sessionId: "session-id", updatedAt: 0 }));
+    const readSession = vi.fn<NonNullable<SessionObserverDeps["readSession"]>>(() => ({
+      sessionId: "session-id",
+      updatedAt: 0,
+    }));
     const harness = createHarness({ readSession });
     startAndAddToolNotes(harness.observer);
-    readSession.mockReturnValue({ sessionId: "session-id-reset", updatedAt: 0 });
+    readSession.mockReturnValue(
+      change === "deleted" ? undefined : { sessionId: "session-id-reset", updatedAt: 0 },
+    );
     await advanceAndFlush(12_000);
     expect(harness.completeModel).toHaveBeenCalledOnce();
-    const broadcasts = observerBroadcasts(harness);
-    expect(broadcasts).toHaveLength(0);
+    expect(observerBroadcasts(harness)).toHaveLength(0);
     expect(harness.persistDigest).not.toHaveBeenCalled();
+
+    startAndAddToolNotes(harness.observer, { count: 4 });
+    await advanceAndFlush(24_000);
+    expect(harness.completeModel).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+
+    readSession.mockReturnValue({ sessionId: "session-id-next", updatedAt: 36_000 });
+    startAndAddToolNotes(harness.observer, { runId: "run-2" });
+    await advanceAndFlush(12_000);
+    expect(harness.completeModel).toHaveBeenCalledTimes(2);
+    expect(harness.persistDigest).toHaveBeenCalledOnce();
+    expect(observerBroadcasts(harness)).toHaveLength(1);
   });
 
   it("catches up durable persistence when the live digest already carried terminal health", async () => {

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -359,13 +359,13 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
           }
           return;
         }
-        // A session reset swaps sessionId under the same key; a digest accepted
-        // for the old session must not reach the replacement session's watchers.
+        // A deleted/reset session cannot accept this run's digest. Disable its
+        // model work so pending notes cannot keep scheduling unpersistable results.
         if (
           state.sessionId &&
           readSession(state.sessionKey, state.agentId)?.sessionId !== state.sessionId
         ) {
-          return;
+          return disableModelForRun(state);
         }
         preamblePublisher.clear(state);
         state.consecutiveFailures = 0;


### PR DESCRIPTION
Closes #133171

## What Problem This Solves

Session observer work can keep requesting utility-model summaries after its stored session identity disappears or is replaced, even though the resulting digest cannot be saved. Rejected digest writes were also incorrectly reported as successful, advancing the persistence clock without a write.

## Why This Change Was Made

The SQLite accessor skips the updater and returns `null` for an absent row. When an updater rejects a change, it returns the existing row instead. The observer adapter now distinguishes missing rows, rejected writes, and applied patches using the actual updater outcome. This removes the unreachable missing-entry branch while preserving the shared storage contract.

A second path rejected obsolete session identities before reaching persistence, then scheduled the same pending notes again. That existing guard now disables utility-model work for the obsolete run. A subsequent run can prepare, persist, and publish normally. The repair uses the existing disabled-run lifecycle; it adds no configuration, schema, or storage migration.

## User Impact

An observer whose session row is independently removed or replaced stops scheduling unpersistable utility work. Stale revisions, mismatched session identities, and superseded runs no longer count as successful writes.

Normal Gateway session deletion already drains authoritative active work before deleting the row. The reproduced failure concerns observer completion after independent row invalidation; it is not evidence that ordinary Control UI deletion always causes repeated model billing.

## Evidence

Reviewed source, callers, SQLite owner, terminal/preamble siblings, and history independently of the original PR description.

- Original storage implementation: four of five real SQLite adapter cases fail; only the accepted-write control passes.
- Original PR with an admitted row deleted or replaced: one initial completion grows to three, with zero persistence attempts and zero broadcasts.
- Final fixup: 50 focused owner tests and nine real SQLite boundary probes pass. Deletion/reset stays at one request, adds no observer timer, and a fresh run persists and broadcasts. Accepted/stale/missing outcomes preserve the expected persistence clock and missing-entry callback behavior.
- All four changed files pass formatting and type-aware lint. Independent review through P2 reports no actionable findings.
- Published head `7aa8a490d711c8c234a5b74813d026d7f1635fb6` has the exact tested tree, retains the contributor's original commit, and includes a credited maintainer fixup. [Fresh CI](https://github.com/openclaw/openclaw/actions/runs/33472011543) covers this head. The separate final-head Gateway proof passed.

A separate real-clock Gateway WebSocket flow passed: actual subscriptions, visibility and deletion RPCs, and canonical SQLite; synthetic agent events and a loopback HTTP completion stub. The obsolete run stayed at one request after another 25 seconds and more notes, emitted zero observer frames, and delivered deletion notifications. A fresh run made one additional request, persisted its digest, and delivered one observer frame. This is Gateway harness proof, not a browser recording or an authenticated provider billing measurement. Normal UI deletion drains real admitted work, so the independently invalidated-row race is exercised at its owning boundary instead of claiming that an ordinary UI deletion reproduces it. Production delta: +10/-13, net -3. Tests: +145/-5, net +140.
