### PR TITLE
fix(models): recover /models browse from a replaced prepared catalog

### DIFF
--- a/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
+++ b/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
@@ -3,7 +3,7 @@
 // against the same stale snapshot (openclaw#133166).
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { PreparedModelCatalogConfigReplacedError } from "../../agents/prepared-model-catalog.errors.js";
-import { loadModelsBrowseCatalogSnapshot } from "./commands-models.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
 const catalogMocks = vi.hoisted(() => ({
   loadSnapshot: vi.fn(),
@@ -15,16 +15,26 @@ vi.mock("../../agents/prepared-model-catalog.js", () => ({
   loadPublishedPreparedModelCatalogOwnerSnapshot: catalogMocks.loadPublishedOwner,
 }));
 
+const { buildPreparedModelsProviderData } = await import("./commands-models.js");
+
+const cfg = {
+  agents: { defaults: { model: { primary: "anthropic/claude-opus-4-5" } } },
+} as OpenClawConfig;
+
 afterEach(() => {
   vi.clearAllMocks();
 });
 
-describe("loadModelsBrowseCatalogSnapshot", () => {
+describe("/models browse catalog recovery", () => {
   it("returns the exact-config snapshot when the prepared owner matches", async () => {
-    const snapshot = { entries: [], routeVariants: [] };
-    catalogMocks.loadSnapshot.mockResolvedValueOnce(snapshot);
+    catalogMocks.loadSnapshot.mockResolvedValueOnce({
+      entries: [{ provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus" }],
+      routeVariants: [],
+    });
 
-    await expect(loadModelsBrowseCatalogSnapshot({ readOnly: true })).resolves.toBe(snapshot);
+    const data = await buildPreparedModelsProviderData(cfg);
+
+    expect(data.byProvider.get("anthropic")).toEqual(new Set(["claude-opus-4-5"]));
     expect(catalogMocks.loadPublishedOwner).not.toHaveBeenCalled();
   });
 
@@ -32,19 +42,24 @@ describe("loadModelsBrowseCatalogSnapshot", () => {
     catalogMocks.loadSnapshot.mockRejectedValueOnce(
       new PreparedModelCatalogConfigReplacedError("/tmp/agent-dir"),
     );
-    const publishedCatalog = { entries: [], routeVariants: [] };
-    catalogMocks.loadPublishedOwner.mockResolvedValueOnce({ modelCatalog: publishedCatalog });
+    catalogMocks.loadPublishedOwner.mockResolvedValueOnce({
+      modelCatalog: {
+        entries: [{ provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus" }],
+        routeVariants: [],
+      },
+    });
 
-    await expect(loadModelsBrowseCatalogSnapshot({ readOnly: true })).resolves.toBe(
-      publishedCatalog,
-    );
+    const data = await buildPreparedModelsProviderData(cfg);
+
+    expect(data.byProvider.get("anthropic")).toEqual(new Set(["claude-opus-4-5"]));
+    expect(catalogMocks.loadPublishedOwner).toHaveBeenCalledTimes(1);
   });
 
   it("does not mask unrelated failures", async () => {
     const error = new Error("boom");
     catalogMocks.loadSnapshot.mockRejectedValueOnce(error);
 
-    await expect(loadModelsBrowseCatalogSnapshot({ readOnly: true })).rejects.toBe(error);
+    await expect(buildPreparedModelsProviderData(cfg)).rejects.toBe(error);
     expect(catalogMocks.loadPublishedOwner).not.toHaveBeenCalled();
   });
 });

--- a/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
+++ b/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
@@ -1,0 +1,50 @@
+// Boundary proof for the /models browse catalog read recovering from a config hot-reload
+// replacing the prepared owner mid-read, instead of surfacing a retryable failure that repeats
+// against the same stale snapshot (openclaw#133166).
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PreparedModelCatalogConfigReplacedError } from "../../agents/prepared-model-catalog.errors.js";
+import { loadModelsBrowseCatalogSnapshot } from "./commands-models.js";
+
+const catalogMocks = vi.hoisted(() => ({
+  loadSnapshot: vi.fn(),
+  loadPublishedOwner: vi.fn(),
+}));
+
+vi.mock("../../agents/prepared-model-catalog.js", () => ({
+  loadPreparedModelCatalogSnapshot: catalogMocks.loadSnapshot,
+  loadPublishedPreparedModelCatalogOwnerSnapshot: catalogMocks.loadPublishedOwner,
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("loadModelsBrowseCatalogSnapshot", () => {
+  it("returns the exact-config snapshot when the prepared owner matches", async () => {
+    const snapshot = { entries: [], routeVariants: [] };
+    catalogMocks.loadSnapshot.mockResolvedValueOnce(snapshot);
+
+    await expect(loadModelsBrowseCatalogSnapshot({ readOnly: true })).resolves.toBe(snapshot);
+    expect(catalogMocks.loadPublishedOwner).not.toHaveBeenCalled();
+  });
+
+  it("recovers via the published owner when the prepared config was replaced mid-read", async () => {
+    catalogMocks.loadSnapshot.mockRejectedValueOnce(
+      new PreparedModelCatalogConfigReplacedError("/tmp/agent-dir"),
+    );
+    const publishedCatalog = { entries: [], routeVariants: [] };
+    catalogMocks.loadPublishedOwner.mockResolvedValueOnce({ modelCatalog: publishedCatalog });
+
+    await expect(loadModelsBrowseCatalogSnapshot({ readOnly: true })).resolves.toBe(
+      publishedCatalog,
+    );
+  });
+
+  it("does not mask unrelated failures", async () => {
+    const error = new Error("boom");
+    catalogMocks.loadSnapshot.mockRejectedValueOnce(error);
+
+    await expect(loadModelsBrowseCatalogSnapshot({ readOnly: true })).rejects.toBe(error);
+    expect(catalogMocks.loadPublishedOwner).not.toHaveBeenCalled();
+  });
+});

--- a/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
+++ b/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
@@ -65,6 +65,19 @@ describe("/models browse catalog recovery", () => {
     expect(catalogMocks.loadSnapshot.mock.calls[1]?.[0]).toMatchObject({ config: replacementCfg });
   });
 
+  it("reads the replacement owner read-only so recovery never starts a cold full catalog", async () => {
+    catalogMocks.loadSnapshot
+      .mockRejectedValueOnce(new PreparedModelCatalogConfigReplacedError("/tmp/agent-dir"))
+      .mockResolvedValueOnce({ entries: [], routeVariants: [] });
+    catalogMocks.loadPublishedOwner.mockResolvedValueOnce({ config: replacementCfg });
+
+    await buildPreparedModelsProviderData(staleCfg);
+
+    // readOnly: true keeps this owner read on the bounded browse path — it must never await
+    // loadFullModelCatalog() outside the browse timeout just to fetch the replacement config.
+    expect(catalogMocks.loadPublishedOwner.mock.calls[0]?.[0]).toMatchObject({ readOnly: true });
+  });
+
   it("does not mask unrelated failures", async () => {
     const error = new Error("boom");
     catalogMocks.loadSnapshot.mockRejectedValueOnce(error);

--- a/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
+++ b/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
@@ -1,6 +1,7 @@
 // Boundary proof for the /models browse catalog read recovering from a config hot-reload
 // replacing the prepared owner mid-read, instead of surfacing a retryable failure that repeats
-// against the same stale snapshot (openclaw#133166).
+// against the same stale snapshot (openclaw#133166). The recovery must rebuild the whole browse
+// result from the replacement owner's own config, not mix it with the stale caller-supplied cfg.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { PreparedModelCatalogConfigReplacedError } from "../../agents/prepared-model-catalog.errors.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -17,8 +18,12 @@ vi.mock("../../agents/prepared-model-catalog.js", () => ({
 
 const { buildPreparedModelsProviderData } = await import("./commands-models.js");
 
-const cfg = {
+const staleCfg = {
   agents: { defaults: { model: { primary: "anthropic/claude-opus-4-5" } } },
+} as OpenClawConfig;
+
+const replacementCfg = {
+  agents: { defaults: { model: { primary: "openai/gpt-5.6-luna" } } },
 } as OpenClawConfig;
 
 afterEach(() => {
@@ -32,34 +37,39 @@ describe("/models browse catalog recovery", () => {
       routeVariants: [],
     });
 
-    const data = await buildPreparedModelsProviderData(cfg);
+    const data = await buildPreparedModelsProviderData(staleCfg);
 
     expect(data.byProvider.get("anthropic")).toEqual(new Set(["claude-opus-4-5"]));
     expect(catalogMocks.loadPublishedOwner).not.toHaveBeenCalled();
   });
 
-  it("recovers via the published owner when the prepared config was replaced mid-read", async () => {
-    catalogMocks.loadSnapshot.mockRejectedValueOnce(
-      new PreparedModelCatalogConfigReplacedError("/tmp/agent-dir"),
-    );
-    catalogMocks.loadPublishedOwner.mockResolvedValueOnce({
-      modelCatalog: {
-        entries: [{ provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus" }],
+  it("rebuilds the whole browse result from the replacement owner's config, not the stale cfg", async () => {
+    catalogMocks.loadSnapshot
+      .mockRejectedValueOnce(new PreparedModelCatalogConfigReplacedError("/tmp/agent-dir"))
+      .mockResolvedValueOnce({
+        entries: [{ provider: "openai", id: "gpt-5.6-luna", name: "GPT-5.6 Luna" }],
         routeVariants: [],
-      },
-    });
+      });
+    catalogMocks.loadPublishedOwner.mockResolvedValueOnce({ config: replacementCfg });
 
-    const data = await buildPreparedModelsProviderData(cfg);
+    const data = await buildPreparedModelsProviderData(staleCfg);
 
-    expect(data.byProvider.get("anthropic")).toEqual(new Set(["claude-opus-4-5"]));
+    // The recovered menu reflects the replacement generation end-to-end: its catalog entry
+    // and its resolved default both come from replacementCfg, never staleCfg's stale anthropic
+    // default that the new config already removed.
+    expect(data.resolvedDefault).toEqual({ provider: "openai", model: "gpt-5.6-luna" });
+    expect(data.byProvider.get("anthropic")).toBeUndefined();
+    expect(data.byProvider.get("openai")).toEqual(new Set(["gpt-5.6-luna"]));
     expect(catalogMocks.loadPublishedOwner).toHaveBeenCalledTimes(1);
+    expect(catalogMocks.loadSnapshot).toHaveBeenCalledTimes(2);
+    expect(catalogMocks.loadSnapshot.mock.calls[1]?.[0]).toMatchObject({ config: replacementCfg });
   });
 
   it("does not mask unrelated failures", async () => {
     const error = new Error("boom");
     catalogMocks.loadSnapshot.mockRejectedValueOnce(error);
 
-    await expect(buildPreparedModelsProviderData(cfg)).rejects.toBe(error);
+    await expect(buildPreparedModelsProviderData(staleCfg)).rejects.toBe(error);
     expect(catalogMocks.loadPublishedOwner).not.toHaveBeenCalled();
   });
 });

--- a/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
+++ b/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
@@ -1,7 +1,3 @@
-// Boundary proof for the /models browse catalog read recovering from a config hot-reload
-// replacing the prepared owner mid-read, instead of surfacing a retryable failure that repeats
-// against the same stale snapshot (openclaw#133166). The recovery must rebuild the whole browse
-// result from the replacement owner's own config, not mix it with the stale caller-supplied cfg.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { PreparedModelCatalogConfigReplacedError } from "../../agents/prepared-model-catalog.errors.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -61,21 +57,25 @@ describe("/models browse catalog recovery", () => {
     expect(data.byProvider.get("anthropic")).toBeUndefined();
     expect(data.byProvider.get("openai")).toEqual(new Set(["gpt-5.6-luna"]));
     expect(catalogMocks.loadPublishedOwner).toHaveBeenCalledTimes(1);
+    expect(catalogMocks.loadPublishedOwner).toHaveBeenCalledWith(
+      expect.objectContaining({ readOnly: true }),
+    );
     expect(catalogMocks.loadSnapshot).toHaveBeenCalledTimes(2);
     expect(catalogMocks.loadSnapshot.mock.calls[1]?.[0]).toMatchObject({ config: replacementCfg });
+    expect(catalogMocks.loadSnapshot.mock.calls.map(([params]) => params.readOnly)).toEqual([
+      true,
+      true,
+    ]);
   });
 
-  it("reads the replacement owner read-only so recovery never starts a cold full catalog", async () => {
-    catalogMocks.loadSnapshot
-      .mockRejectedValueOnce(new PreparedModelCatalogConfigReplacedError("/tmp/agent-dir"))
-      .mockResolvedValueOnce({ entries: [], routeVariants: [] });
+  it("lets a second owner replacement escape", async () => {
+    const first = new PreparedModelCatalogConfigReplacedError("/tmp/agent-a");
+    const second = new PreparedModelCatalogConfigReplacedError("/tmp/agent-b");
+    catalogMocks.loadSnapshot.mockRejectedValueOnce(first).mockRejectedValueOnce(second);
     catalogMocks.loadPublishedOwner.mockResolvedValueOnce({ config: replacementCfg });
 
-    await buildPreparedModelsProviderData(staleCfg);
-
-    // readOnly: true keeps this owner read on the bounded browse path — it must never await
-    // loadFullModelCatalog() outside the browse timeout just to fetch the replacement config.
-    expect(catalogMocks.loadPublishedOwner.mock.calls[0]?.[0]).toMatchObject({ readOnly: true });
+    await expect(buildPreparedModelsProviderData(staleCfg)).rejects.toBe(second);
+    expect(catalogMocks.loadPublishedOwner).toHaveBeenCalledTimes(1);
   });
 
   it("does not mask unrelated failures", async () => {

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -18,7 +18,7 @@ import {
   resolveLogicalVisibleModelCatalog,
   type ModelCatalogAuthChecker,
 } from "../../agents/model-catalog-visibility.js";
-import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model-catalog.js";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import { createProviderAuthChecker } from "../../agents/model-provider-auth.js";
 import { isRetiredModelPickerProvider } from "../../agents/model-runtime-aliases.js";
 import {
@@ -39,7 +39,6 @@ import { PreparedModelCatalogConfigReplacedError } from "../../agents/prepared-m
 import {
   loadPreparedModelCatalogSnapshot,
   loadPublishedPreparedModelCatalogOwnerSnapshot,
-  type LoadPreparedModelCatalogParams,
 } from "../../agents/prepared-model-catalog.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
@@ -163,26 +162,34 @@ function addRuntimeChoice(
 
 /**
  * A config hot-reload can replace the prepared owner mid-read. Retrying the same exact read hits
- * the identical stale-owner mismatch forever (openclaw#133166), so recover via the published
- * owner: a browse view wants the current provider set, not a byte-identical config match.
+ * the identical stale-owner mismatch forever (openclaw#133166), so this rebuilds the whole browse
+ * result from the replacement owner's own config once: mixing the new catalog with the stale cfg's
+ * defaults/visibility/aliases could offer a model the new config already removed.
  */
-async function loadModelsBrowseCatalogSnapshot(
-  params: LoadPreparedModelCatalogParams,
-): Promise<ModelCatalogSnapshot> {
-  try {
-    return await loadPreparedModelCatalogSnapshot(params);
-  } catch (error) {
-    if (!(error instanceof PreparedModelCatalogConfigReplacedError)) {
-      throw error;
-    }
-    return (await loadPublishedPreparedModelCatalogOwnerSnapshot(params)).modelCatalog;
-  }
-}
-
 export async function buildPreparedModelsProviderData(
   cfg: OpenClawConfig,
   agentId?: string,
   options: { view?: "default" | "all"; workspaceDir?: string } = {},
+): Promise<PreparedModelsProviderData> {
+  try {
+    return await buildPreparedModelsProviderDataForConfig(cfg, agentId, options);
+  } catch (error) {
+    if (!(error instanceof PreparedModelCatalogConfigReplacedError)) {
+      throw error;
+    }
+    const owner = await loadPublishedPreparedModelCatalogOwnerSnapshot({
+      config: cfg,
+      ...(agentId ? { agentId, agentDir: resolveAgentDir(cfg, agentId) } : {}),
+      ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
+    });
+    return await buildPreparedModelsProviderDataForConfig(owner.config, agentId, options);
+  }
+}
+
+async function buildPreparedModelsProviderDataForConfig(
+  cfg: OpenClawConfig,
+  agentId: string | undefined,
+  options: { view?: "default" | "all"; workspaceDir?: string },
 ): Promise<PreparedModelsProviderData> {
   const runtimeNormalization = resolveRuntimeNormalization(cfg);
   const resolvedDefault = resolveDefaultModelForAgent({
@@ -204,7 +211,7 @@ export async function buildPreparedModelsProviderData(
     agentId,
     view: options.view ?? "default",
     loadCatalog: ({ readOnly }) =>
-      loadModelsBrowseCatalogSnapshot({
+      loadPreparedModelCatalogSnapshot({
         config: cfg,
         readOnly,
         ...(agentId ? { agentId, agentDir: resolveAgentDir(cfg, agentId) } : {}),

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -36,10 +36,7 @@ import { createModelVisibilityPolicy } from "../../agents/model-visibility-polic
 import { openAIModelCatalogRoutePolicy } from "../../agents/openai-model-routes.js";
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-routing.js";
 import { PreparedModelCatalogConfigReplacedError } from "../../agents/prepared-model-catalog.errors.js";
-import {
-  loadPreparedModelCatalogSnapshot,
-  loadPublishedPreparedModelCatalogOwnerSnapshot,
-} from "../../agents/prepared-model-catalog.js";
+import * as preparedModelCatalog from "../../agents/prepared-model-catalog.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -160,34 +157,22 @@ function addRuntimeChoice(
   return choices;
 }
 
-/**
- * A config hot-reload can replace the prepared owner mid-read. Retrying the same exact read hits
- * the identical stale-owner mismatch forever (openclaw#133166), so this rebuilds the whole browse
- * result from the replacement owner's own config once: mixing the new catalog with the stale cfg's
- * defaults/visibility/aliases could offer a model the new config already removed.
- */
 export async function buildPreparedModelsProviderData(
   cfg: OpenClawConfig,
   agentId?: string,
   options: { view?: "default" | "all"; workspaceDir?: string } = {},
 ): Promise<PreparedModelsProviderData> {
-  try {
-    return await buildPreparedModelsProviderDataForConfig(cfg, agentId, options);
-  } catch (error) {
-    if (!(error instanceof PreparedModelCatalogConfigReplacedError)) {
-      throw error;
-    }
-    // Only the replacement config is needed here; the rebuilt browse call below performs its
-    // own bounded catalog read, so this must not materialize a cold full catalog outside that
-    // timeout (openclaw#133221 review).
-    const owner = await loadPublishedPreparedModelCatalogOwnerSnapshot({
+  return buildPreparedModelsProviderDataForConfig(cfg, agentId, options).catch(async (error) => {
+    if (!(error instanceof PreparedModelCatalogConfigReplacedError)) throw error;
+    // Catalog, defaults, visibility, auth, aliases, and runtime choices share one config generation.
+    const { config } = await preparedModelCatalog.loadPublishedPreparedModelCatalogOwnerSnapshot({
       config: cfg,
       readOnly: true,
-      ...(agentId ? { agentId, agentDir: resolveAgentDir(cfg, agentId) } : {}),
-      ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
+      agentId,
+      workspaceDir: options.workspaceDir,
     });
-    return await buildPreparedModelsProviderDataForConfig(owner.config, agentId, options);
-  }
+    return buildPreparedModelsProviderDataForConfig(config, agentId, options);
+  });
 }
 
 async function buildPreparedModelsProviderDataForConfig(
@@ -215,7 +200,7 @@ async function buildPreparedModelsProviderDataForConfig(
     agentId,
     view: options.view ?? "default",
     loadCatalog: ({ readOnly }) =>
-      loadPreparedModelCatalogSnapshot({
+      preparedModelCatalog.loadPreparedModelCatalogSnapshot({
         config: cfg,
         readOnly,
         ...(agentId ? { agentId, agentDir: resolveAgentDir(cfg, agentId) } : {}),

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -162,8 +162,10 @@ export async function buildPreparedModelsProviderData(
   agentId?: string,
   options: { view?: "default" | "all"; workspaceDir?: string } = {},
 ): Promise<PreparedModelsProviderData> {
-  return buildPreparedModelsProviderDataForConfig(cfg, agentId, options).catch(async (error) => {
-    if (!(error instanceof PreparedModelCatalogConfigReplacedError)) throw error;
+  return buildPreparedDataForConfig(cfg, agentId, options).catch(async (error: unknown) => {
+    if (!(error instanceof PreparedModelCatalogConfigReplacedError)) {
+      throw error;
+    }
     // Catalog, defaults, visibility, auth, aliases, and runtime choices share one config generation.
     const { config } = await preparedModelCatalog.loadPublishedPreparedModelCatalogOwnerSnapshot({
       config: cfg,
@@ -171,11 +173,11 @@ export async function buildPreparedModelsProviderData(
       agentId,
       workspaceDir: options.workspaceDir,
     });
-    return buildPreparedModelsProviderDataForConfig(config, agentId, options);
+    return buildPreparedDataForConfig(config, agentId, options);
   });
 }
 
-async function buildPreparedModelsProviderDataForConfig(
+async function buildPreparedDataForConfig(
   cfg: OpenClawConfig,
   agentId: string | undefined,
   options: { view?: "default" | "all"; workspaceDir?: string },
@@ -186,7 +188,6 @@ async function buildPreparedModelsProviderDataForConfig(
     agentId,
     ...runtimeNormalization,
   });
-  const catalogWorkspaceDir = options.workspaceDir;
   const workspaceDir =
     options.workspaceDir ??
     (agentId ? resolveAgentWorkspaceDir(cfg, agentId) : undefined) ??
@@ -204,7 +205,7 @@ async function buildPreparedModelsProviderDataForConfig(
         config: cfg,
         readOnly,
         ...(agentId ? { agentId, agentDir: resolveAgentDir(cfg, agentId) } : {}),
-        ...(catalogWorkspaceDir ? { workspaceDir: catalogWorkspaceDir } : {}),
+        ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
       }),
   });
   const catalog = snapshot.entries;

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -18,7 +18,7 @@ import {
   resolveLogicalVisibleModelCatalog,
   type ModelCatalogAuthChecker,
 } from "../../agents/model-catalog-visibility.js";
-import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
+import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model-catalog.js";
 import { createProviderAuthChecker } from "../../agents/model-provider-auth.js";
 import { isRetiredModelPickerProvider } from "../../agents/model-runtime-aliases.js";
 import {
@@ -35,7 +35,12 @@ import {
 import { createModelVisibilityPolicy } from "../../agents/model-visibility-policy.js";
 import { openAIModelCatalogRoutePolicy } from "../../agents/openai-model-routes.js";
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-routing.js";
-import { loadPreparedModelCatalogSnapshot } from "../../agents/prepared-model-catalog.js";
+import { PreparedModelCatalogConfigReplacedError } from "../../agents/prepared-model-catalog.errors.js";
+import {
+  loadPreparedModelCatalogSnapshot,
+  loadPublishedPreparedModelCatalogOwnerSnapshot,
+  type LoadPreparedModelCatalogParams,
+} from "../../agents/prepared-model-catalog.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -156,6 +161,24 @@ function addRuntimeChoice(
   return choices;
 }
 
+/**
+ * A config hot-reload can replace the prepared owner mid-read. Retrying the same exact read hits
+ * the identical stale-owner mismatch forever (openclaw#133166), so recover via the published
+ * owner: a browse view wants the current provider set, not a byte-identical config match.
+ */
+export async function loadModelsBrowseCatalogSnapshot(
+  params: LoadPreparedModelCatalogParams,
+): Promise<ModelCatalogSnapshot> {
+  try {
+    return await loadPreparedModelCatalogSnapshot(params);
+  } catch (error) {
+    if (!(error instanceof PreparedModelCatalogConfigReplacedError)) {
+      throw error;
+    }
+    return (await loadPublishedPreparedModelCatalogOwnerSnapshot(params)).modelCatalog;
+  }
+}
+
 export async function buildPreparedModelsProviderData(
   cfg: OpenClawConfig,
   agentId?: string,
@@ -181,7 +204,7 @@ export async function buildPreparedModelsProviderData(
     agentId,
     view: options.view ?? "default",
     loadCatalog: ({ readOnly }) =>
-      loadPreparedModelCatalogSnapshot({
+      loadModelsBrowseCatalogSnapshot({
         config: cfg,
         readOnly,
         ...(agentId ? { agentId, agentDir: resolveAgentDir(cfg, agentId) } : {}),

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -177,8 +177,12 @@ export async function buildPreparedModelsProviderData(
     if (!(error instanceof PreparedModelCatalogConfigReplacedError)) {
       throw error;
     }
+    // Only the replacement config is needed here; the rebuilt browse call below performs its
+    // own bounded catalog read, so this must not materialize a cold full catalog outside that
+    // timeout (openclaw#133221 review).
     const owner = await loadPublishedPreparedModelCatalogOwnerSnapshot({
       config: cfg,
+      readOnly: true,
       ...(agentId ? { agentId, agentDir: resolveAgentDir(cfg, agentId) } : {}),
       ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
     });

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -166,7 +166,7 @@ function addRuntimeChoice(
  * the identical stale-owner mismatch forever (openclaw#133166), so recover via the published
  * owner: a browse view wants the current provider set, not a byte-identical config match.
  */
-export async function loadModelsBrowseCatalogSnapshot(
+async function loadModelsBrowseCatalogSnapshot(
   params: LoadPreparedModelCatalogParams,
 ): Promise<ModelCatalogSnapshot> {
   try {

--- a/test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts
@@ -1,8 +1,22 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import net from "node:net";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { withServer, withTempDir } from "openclaw/plugin-sdk/test-env";
 import { expect, test } from "vitest";
 import { createQaGatewayChild, writeJson } from "../../../../extensions/qa-lab/api.js";
+import {
+  createChannelIngressQueue,
+  getChannelIngressKysely,
+} from "../../../../src/channels/message/ingress-queue.js";
+import type { ModelDefinitionConfig } from "../../../../src/config/types.models.js";
+import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
+import { executeSqliteQuerySync } from "../../../../src/infra/kysely-sync.js";
+import { openExistingOpenClawStateDatabaseReadOnly } from "../../../../src/state/openclaw-state-db.js";
+import { withTestTimeout } from "../../../helpers/promise.js";
 import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
 
 type JsonObject = Record<string, unknown>;
@@ -12,6 +26,10 @@ const BOT_TOKEN = "424242:telegram-model-picker-proof";
 const CHAT_ID = 2468;
 const MESSAGE_ID = 9001;
 const PREPARED_MODEL = "prepared-model";
+const REPLACEMENT_MODEL = "replacement-model";
+const REPLACEMENT_PROVIDER = "qa-picker";
+const REPLACEMENT_MODEL_REF = `${REPLACEMENT_PROVIDER}/${REPLACEMENT_MODEL}`;
+const SOURCE_GATEWAY_TIMEOUT_MS = 120_000;
 
 async function readJson(req: IncomingMessage): Promise<JsonObject> {
   let text = "";
@@ -82,6 +100,295 @@ function keyboardCallbackData(call: TelegramCall): string[] {
 
 function hasCallback(call: TelegramCall, callbackData: string) {
   return keyboardCallbackData(call).includes(callbackData);
+}
+
+function configuredModel(id: string): ModelDefinitionConfig {
+  return {
+    id,
+    name: id,
+    api: "openai-responses",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 8192,
+    maxTokens: 256,
+  };
+}
+
+function pickerConfig(apiRoot: string, modelId: string): OpenClawConfig {
+  const modelRef = `${REPLACEMENT_PROVIDER}/${modelId}`;
+  return {
+    gateway: { mode: "local", bind: "loopback", auth: { mode: "token", token: "picker-token" } },
+    plugins: {
+      enabled: true,
+      allow: ["telegram"],
+      entries: { telegram: { enabled: true } },
+    },
+    channels: {
+      telegram: {
+        enabled: true,
+        defaultAccount: "picker",
+        accounts: {
+          picker: {
+            enabled: true,
+            botToken: BOT_TOKEN,
+            apiRoot,
+            dmPolicy: "open",
+            allowFrom: ["*"],
+            commands: { native: true },
+          },
+        },
+      },
+    },
+    agents: {
+      defaults: {
+        model: modelRef,
+        modelPolicy: { allow: [modelRef] },
+        models: { [modelRef]: {} },
+      },
+      entries: { main: { model: modelRef } },
+    },
+    models: {
+      mode: "merge",
+      providers: {
+        [REPLACEMENT_PROVIDER]: {
+          baseUrl: apiRoot,
+          api: "openai-responses",
+          apiKey: "picker-key",
+          request: { allowPrivateNetwork: true },
+          models: [configuredModel(modelId)],
+        },
+      },
+    },
+  };
+}
+
+async function readTelegramIngressStatuses(stateDir: string, eventIds: string[]) {
+  const database = await openExistingOpenClawStateDatabaseReadOnly({
+    env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+  });
+  if (!database) {
+    return [];
+  }
+  try {
+    return executeSqliteQuerySync(
+      database.db,
+      getChannelIngressKysely(database.db)
+        .selectFrom("channel_ingress_events")
+        .select([
+          "account_id as accountId",
+          "event_id as eventId",
+          "lane_key as laneKey",
+          "queue_name as queueName",
+          "status",
+        ])
+        .where("channel_id", "=", "telegram")
+        .where("event_id", "in", eventIds)
+        .orderBy("event_id", "asc"),
+    ).rows;
+  } finally {
+    database.walMaintenance.close();
+  }
+}
+
+async function reservePort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Could not reserve a source Gateway port");
+  }
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+  return address.port;
+}
+
+async function resolveBuiltModule(params: {
+  distDir: string;
+  prefix: string;
+  exportMarker: string;
+}): Promise<string> {
+  for (const name of await fs.readdir(params.distDir)) {
+    if (!name.startsWith(params.prefix) || !name.endsWith(".js")) continue;
+    const filePath = path.join(params.distDir, name);
+    if ((await fs.readFile(filePath, "utf8")).includes(params.exportMarker)) {
+      return pathToFileURL(filePath).href;
+    }
+  }
+  throw new Error(`Could not resolve built ${params.prefix} module`);
+}
+
+async function startControlledSourceGateway(params: {
+  configPath: string;
+  replacementConfigPath: string;
+  fixtureRoot: string;
+  repoRoot: string;
+}) {
+  const bootstrapPath = path.join(params.fixtureRoot, "source-gateway-control.mjs");
+  const port = await reservePort();
+  const distDir = path.join(params.repoRoot, "dist");
+  const [serverUrl, runtimeUrl] = await Promise.all([
+    resolveBuiltModule({
+      distDir,
+      prefix: "server-",
+      exportMarker: "resetPreparedModelCatalogForTest, startGatewayServer, truncateCloseReason",
+    }),
+    resolveBuiltModule({
+      distDir,
+      prefix: "prepared-model-runtime-",
+      exportMarker: "export { PreparedModelRuntimeOwnerNotPublishedError",
+    }),
+  ]);
+  await fs.writeFile(
+    bootstrapPath,
+    `
+import fs from "node:fs/promises";
+const [{ startGatewayServer }, preparedRuntime] = await Promise.all([
+  import(${JSON.stringify(serverUrl)}),
+  import(${JSON.stringify(runtimeUrl)}),
+]);
+const replacementConfig = JSON.parse(
+  await fs.readFile(process.env.OPENCLAW_QA_REPLACEMENT_CONFIG_PATH, "utf8"),
+);
+const server = await startGatewayServer(Number(process.env.OPENCLAW_GATEWAY_PORT), {
+  auth: { mode: "token", token: "picker-token" },
+  bind: "loopback",
+  controlUiEnabled: false,
+});
+await server.startupSettled;
+let replacementGate;
+process.send?.({ type: "ready" });
+process.on("message", async (message) => {
+  const id = message?.id;
+  try {
+    if (message?.action === "mark") {
+      replacementGate = preparedRuntime.markPreparedModelRuntimeSnapshotsStale(
+        "Telegram replacement proof",
+        { waitForReplacement: true },
+      );
+    } else if (message?.action === "replace") {
+      await preparedRuntime.refreshPreparedModelRuntimeSnapshots(replacementConfig, {
+        gatewayLifecycle: true,
+        catalogMode: "static",
+        allowGatewaySubagentBinding: true,
+      });
+    } else if (message?.action === "close") {
+      preparedRuntime.rejectPendingPreparedModelRuntimeReplacement(
+        replacementGate,
+        new Error("Telegram replacement proof cleanup"),
+      );
+      await server.close({ reason: "Telegram replacement proof complete" });
+    } else {
+      throw new Error("Unknown source Gateway control action");
+    }
+    process.send?.({ type: "result", id });
+    if (message?.action === "close") process.exit(0);
+  } catch (error) {
+    process.send?.({ type: "error", id, error: String(error?.stack ?? error) });
+  }
+});
+`,
+    "utf8",
+  );
+
+  const child = spawn(process.execPath, [bootstrapPath], {
+    cwd: params.repoRoot,
+    env: {
+      ...process.env,
+      HOME: params.fixtureRoot,
+      OPENCLAW_HOME: params.fixtureRoot,
+      OPENCLAW_CONFIG_PATH: params.configPath,
+      OPENCLAW_STATE_DIR: path.join(params.fixtureRoot, "state"),
+      OPENCLAW_QA_REPLACEMENT_CONFIG_PATH: params.replacementConfigPath,
+      OPENCLAW_GATEWAY_PORT: String(port),
+      OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+      OPENCLAW_SKIP_CRON: "1",
+      OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+      OPENCLAW_SKIP_CHANNELS: undefined,
+      OPENCLAW_SKIP_PROVIDERS: undefined,
+      OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+      TELEGRAM_BOT_TOKEN: undefined,
+    },
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+  });
+  let output = "";
+  child.stdout?.on("data", (chunk) => {
+    output += String(chunk);
+  });
+  child.stderr?.on("data", (chunk) => {
+    output += String(chunk);
+  });
+  const pending = new Map<number, { resolve: () => void; reject: (error: Error) => void }>();
+  let nextId = 1;
+  const ready = new Promise<void>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      reject(
+        new Error(
+          `Source Gateway exited before ready (${code ?? signal ?? "unknown"}):\n${output}`,
+        ),
+      );
+    });
+    child.on("message", (message: unknown) => {
+      if (!message || typeof message !== "object") return;
+      const value = message as { type?: string; id?: number; error?: string };
+      if (value.type === "ready") {
+        resolve();
+        return;
+      }
+      if (value.id === undefined) return;
+      const request = pending.get(value.id);
+      if (!request) return;
+      pending.delete(value.id);
+      if (value.type === "result") {
+        request.resolve();
+      } else if (value.type === "error") {
+        request.reject(new Error(value.error ?? "Source Gateway control failed"));
+      }
+    });
+  });
+  try {
+    await withTestTimeout(ready, SOURCE_GATEWAY_TIMEOUT_MS, "Source Gateway did not become ready");
+  } catch (error) {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGTERM");
+      await withTestTimeout(once(child, "exit"), 10_000, "Source Gateway did not stop");
+    }
+    throw new Error(`${String(error)}\n${output}`, { cause: error });
+  }
+
+  const request = async (action: "mark" | "replace" | "close") => {
+    const id = nextId++;
+    await withTestTimeout(
+      new Promise<void>((resolve, reject) => {
+        pending.set(id, { resolve, reject });
+        child.send({ id, action }, (error) => {
+          if (!error) return;
+          pending.delete(id);
+          reject(error);
+        });
+      }),
+      action === "close" ? 10_000 : SOURCE_GATEWAY_TIMEOUT_MS,
+      `Source Gateway ${action} control timed out`,
+    );
+  };
+  return {
+    request,
+    output: () => output,
+    close: async () => {
+      if (child.exitCode === null && child.signalCode === null) {
+        await request("close").catch(() => child.kill("SIGTERM"));
+      }
+      if (child.exitCode === null && child.signalCode === null) {
+        await withTestTimeout(once(child, "exit"), 10_000, "Source Gateway did not exit");
+      }
+    },
+  };
 }
 
 async function settleCleanup(...cleanups: Array<() => Promise<void>>) {
@@ -356,3 +663,163 @@ test("keeps Telegram model-picker callbacks on the prepared Gateway catalog", as
       }),
   );
 }, 120_000);
+
+test("recovers a replaced model catalog and drains the following Telegram callback", async () => {
+  const telegramCalls: TelegramCall[] = [];
+  const pendingUpdates: unknown[] = [];
+  const getUpdatesOffsets: Array<number | undefined> = [];
+  let telegramPolls = 0;
+
+  const queueCallback = (updateId: number, data: string) => {
+    pendingUpdates.push(callbackUpdate(updateId, `replacement-callback-${updateId}`, data));
+  };
+
+  const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
+    const pathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
+    const telegramMatch = pathname.match(/^\/bot([^/]+)\/([^/]+)$/);
+    if (!telegramMatch) {
+      writeJson(res, 404, { ok: false, error: "not found" });
+      return;
+    }
+    const [, token = "", method = ""] = telegramMatch;
+    const body = await readJson(req);
+    if (token !== BOT_TOKEN) {
+      writeJson(res, 401, { ok: false, error: "unexpected bot token" });
+      return;
+    }
+    if (method === "getMe") {
+      succeed(res, {
+        id: 424242,
+        is_bot: true,
+        first_name: "QA Picker",
+        username: "qa_picker_bot",
+      });
+      return;
+    }
+    if (method === "getUpdates") {
+      telegramPolls += 1;
+      getUpdatesOffsets.push(typeof body.offset === "number" ? body.offset : undefined);
+      succeed(res, pendingUpdates.splice(0));
+      return;
+    }
+    telegramCalls.push({ method, body });
+    succeed(res);
+  };
+
+  await withServer(
+    (req, res) => {
+      void handleRequest(req, res);
+    },
+    async (apiRoot) =>
+      await withTempDir("openclaw-telegram-model-picker-replacement-", async (fixtureRoot) => {
+        const repoRoot = path.resolve(import.meta.dirname, "../../../..");
+        const stateDir = path.join(fixtureRoot, "state");
+        const configPath = path.join(fixtureRoot, "openclaw.json");
+        const replacementConfigPath = path.join(fixtureRoot, "replacement-openclaw.json");
+        const initialConfig = pickerConfig(apiRoot, PREPARED_MODEL);
+        const replacementConfig = pickerConfig(apiRoot, REPLACEMENT_MODEL);
+        await fs.mkdir(stateDir, { recursive: true });
+        await fs.writeFile(configPath, `${JSON.stringify(initialConfig, null, 2)}\n`, "utf8");
+        await fs.writeFile(
+          replacementConfigPath,
+          `${JSON.stringify(replacementConfig, null, 2)}\n`,
+          "utf8",
+        );
+        const gateway = await startControlledSourceGateway({
+          configPath,
+          replacementConfigPath,
+          fixtureRoot,
+          repoRoot,
+        });
+        const queue = createChannelIngressQueue({
+          channelId: "telegram",
+          accountId: "picker",
+          stateDir,
+          access: "read-only",
+        });
+        const eventIds = ["0000000000000010", "0000000000000011"];
+
+        try {
+          try {
+            await expect
+              .poll(() => telegramPolls, { interval: 25, timeout: 30_000 })
+              .toBeGreaterThan(0);
+          } catch (error) {
+            throw new Error(`${String(error)}\n${gateway.output()}`, { cause: error });
+          }
+          await gateway.request("mark");
+          queueCallback(10, `mdl_list_${REPLACEMENT_PROVIDER}_1`);
+          queueCallback(11, "mdl_prov");
+          await expect
+            .poll(async () => await readTelegramIngressStatuses(stateDir, eventIds), {
+              interval: 5,
+              timeout: 600,
+            })
+            .toEqual([
+              {
+                accountId: "picker",
+                eventId: eventIds[0],
+                laneKey: `telegram:${CHAT_ID}`,
+                queueName: '["telegram","picker"]',
+                status: "claimed",
+              },
+              {
+                accountId: "picker",
+                eventId: eventIds[1],
+                laneKey: `telegram:${CHAT_ID}`,
+                queueName: '["telegram","picker"]',
+                status: "pending",
+              },
+            ]);
+
+          await gateway.request("replace");
+
+          await expect
+            .poll(
+              () =>
+                telegramCalls.filter(
+                  (call) => call.method === "editMessageText" && inlineKeyboard(call).length > 0,
+                ),
+              { interval: 50, timeout: 30_000 },
+            )
+            .toHaveLength(2);
+          const pickerEdits = telegramCalls.filter(
+            (call) => call.method === "editMessageText" && inlineKeyboard(call).length > 0,
+          );
+          expect(hasCallback(pickerEdits[0]!, `mdl_sel_${REPLACEMENT_MODEL_REF}`)).toBe(true);
+          expect(
+            telegramCalls
+              .filter((call) => call.method === "answerCallbackQuery")
+              .map((call) => call.body.callback_query_id)
+              .toSorted(),
+          ).toEqual(["replacement-callback-10", "replacement-callback-11"]);
+          expect(getUpdatesOffsets).toContain(12);
+
+          await expect
+            .poll(
+              async () => ({
+                claims: (await queue.listClaims()).length,
+                failed: (await queue.listFailed?.({ limit: "all" }))?.length ?? 0,
+                pending: (await queue.listPending({ limit: "all" })).length,
+                statuses: await readTelegramIngressStatuses(stateDir, eventIds),
+              }),
+              { interval: 50, timeout: 30_000 },
+            )
+            .toEqual({
+              claims: 0,
+              failed: 0,
+              pending: 0,
+              statuses: eventIds.map((eventId) => ({
+                accountId: "picker",
+                eventId,
+                laneKey: `telegram:${CHAT_ID}`,
+                queueName: '["telegram","picker"]',
+                status: "completed",
+              })),
+            });
+        } finally {
+          await settleCleanup(gateway.close);
+        }
+      }),
+  );
+}, 180_000);

--- a/test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts
@@ -202,9 +202,15 @@ async function reservePort(): Promise<number> {
     server.close();
     throw new Error("Could not reserve a source Gateway port");
   }
-  await new Promise<void>((resolve, reject) =>
-    server.close((error) => (error ? reject(error) : resolve())),
-  );
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
   return address.port;
 }
 
@@ -214,7 +220,9 @@ async function resolveBuiltModule(params: {
   exportMarker: string;
 }): Promise<string> {
   for (const name of await fs.readdir(params.distDir)) {
-    if (!name.startsWith(params.prefix) || !name.endsWith(".js")) continue;
+    if (!name.startsWith(params.prefix) || !name.endsWith(".js")) {
+      continue;
+    }
     const filePath = path.join(params.distDir, name);
     if ((await fs.readFile(filePath, "utf8")).includes(params.exportMarker)) {
       return pathToFileURL(filePath).href;
@@ -335,15 +343,21 @@ process.on("message", async (message) => {
       );
     });
     child.on("message", (message: unknown) => {
-      if (!message || typeof message !== "object") return;
+      if (!message || typeof message !== "object") {
+        return;
+      }
       const value = message as { type?: string; id?: number; error?: string };
       if (value.type === "ready") {
         resolve();
         return;
       }
-      if (value.id === undefined) return;
+      if (value.id === undefined) {
+        return;
+      }
       const request = pending.get(value.id);
-      if (!request) return;
+      if (!request) {
+        return;
+      }
       pending.delete(value.id);
       if (value.type === "result") {
         request.resolve();
@@ -368,7 +382,9 @@ process.on("message", async (message) => {
       new Promise<void>((resolve, reject) => {
         pending.set(id, { resolve, reject });
         child.send({ id, action }, (error) => {
-          if (!error) return;
+          if (!error) {
+            return;
+          }
           pending.delete(id);
           reject(error);
         });
@@ -783,15 +799,16 @@ test("recovers a replaced model catalog and drains the following Telegram callba
               { interval: 50, timeout: 30_000 },
             )
             .toHaveLength(2);
-          const pickerEdits = telegramCalls.filter(
+          const firstPickerEdit = telegramCalls.find(
             (call) => call.method === "editMessageText" && inlineKeyboard(call).length > 0,
           );
-          expect(hasCallback(pickerEdits[0]!, `mdl_sel_${REPLACEMENT_MODEL_REF}`)).toBe(true);
+          expect(firstPickerEdit).toBeDefined();
+          expect(hasCallback(firstPickerEdit!, `mdl_sel_${REPLACEMENT_MODEL_REF}`)).toBe(true);
           expect(
             telegramCalls
               .filter((call) => call.method === "answerCallbackQuery")
               .map((call) => call.body.callback_query_id)
-              .toSorted(),
+              .toSorted((a, b) => String(a).localeCompare(String(b))),
           ).toEqual(["replacement-callback-10", "replacement-callback-11"]);
           expect(getUpdatesOffsets).toContain(12);
 

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -175,7 +175,7 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       group.shard_name.startsWith("cache-warm:auto-reply-reply-commands-3:"),
     );
     expect(autoReplyGroups).toHaveLength(1);
-    expect(autoReplyGroups[0]?.includePatterns).toHaveLength(19);
+    expect(autoReplyGroups[0]?.includePatterns).toHaveLength(18);
     expect(autoReplyGroups[0]?.env).toBeUndefined();
   });
 

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -175,7 +175,7 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       group.shard_name.startsWith("cache-warm:auto-reply-reply-commands-3:"),
     );
     expect(autoReplyGroups).toHaveLength(1);
-    expect(autoReplyGroups[0]?.includePatterns).toHaveLength(18);
+    expect(autoReplyGroups[0]?.includePatterns).toHaveLength(19);
     expect(autoReplyGroups[0]?.env).toBeUndefined();
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #133166.

When a prepared model catalog owner is replaced during `/models` browsing, the exact-config read can raise `PreparedModelCatalogConfigReplacedError`. Telegram retries that callback on its durable ingress lane. Under the default attempt policy plus the age gate, the callback can block later work on the same lane for up to 24 hours, not forever.

## Fix

`buildPreparedModelsProviderData` remains the shared recovery owner:

- Catch only `PreparedModelCatalogConfigReplacedError`.
- Load the currently published owner read-only.
- Rebuild the entire browse projection once from `owner.config`.
- Let a second replacement or any unrelated error escape.

This keeps catalog entries, defaults, visibility, auth, aliases, and runtime choices on one config generation. It adds no Telegram-specific production branch and no retry, store, schema, config, environment, protocol, or SDK change.

Original implementation and issue repair are by @chelsealong. Maintainer commits were appended to the contributor branch.

## Evidence

The QA-lab test drives two real Telegram callback updates through a mock Telegram Bot API and an ephemeral Gateway. Callback 10 is claimed while the exact catalog read is held on owner A; callback 11 is queued on the same `telegram:2468` lane; owner B is then published.

Exact base `6ddd598683fa4db3186378034513bba47a6ae30b`:

```text
recovers a replaced model catalog and drains the following Telegram callback
FAIL after 35.43s
expected callback answers: 2
received callback answers: 0
```

Exact head `67263bb5758dbf5b33bf2d9e3500d45d15b970ba`:

```text
Test Files  1 passed (1)
Tests       2 passed (2)
recovery/drain case: 9.252s
```

```json
{
  "schema": "openclaw.mock-gateway-verdict.v1",
  "recordedAt": "2026-08-30",
  "baseSha": "6ddd598683fa4db3186378034513bba47a6ae30b",
  "headSha": "67263bb5758dbf5b33bf2d9e3500d45d15b970ba",
  "channel": "telegram",
  "gateway": "ephemeral",
  "telegramApi": "local-mock",
  "configTransition": "A->B",
  "sameLane": true,
  "firstRenderedGeneration": "B",
  "callbackAnswers": {
    "expected": 2,
    "actual": 2
  },
  "followerDrained": true,
  "sqliteQueue": {
    "claims": 0,
    "pending": 0,
    "failed": 0,
    "completedEventIds": [
      "10",
      "11"
    ]
  },
  "redacted": true,
  "verdict": "pass"
}
```

## Unit Coverage

- Exact owner: no published-owner fallback.
- A->B: result contains only B's projection.
- B->C: the second replacement escapes.
- Unrelated errors propagate unchanged.
- Published-owner lookup is read-only; both browse catalog reads remain bounded/read-only.

## Validation

- `pnpm test src/auto-reply/reply/commands-models.catalog-recovery.test.ts src/auto-reply/reply/commands-models.test.ts`: 41 passed.
- Full prepared-Gateway E2E file: 2 passed.
- Focused `oxfmt` and `oxlint`: passed.
- `pnpm tsgo:core`: passed.
- Mandatory Codex autoreview (`gpt-5.6-sol`, high): scoped clean, no accepted/actionable findings.
- Test audit: retained as owner-boundary unit contracts plus stronger callback/SQLite behavior proof; the E2E fails on exact base for the intended lane blockage and adds no production test seam.

The sparse maintainer worktree omits tracked Android release-script and Convex QA inputs. Because of those omissions, `tsgo:core:test`, `tsgo:test:root`, and `check-changed` dead-export analysis cannot resolve unrelated modules locally. `check-changed` passed every preceding gate; exact-head hosted CI is the authoritative full-checkout result.

## LOC

- Production: +24/-4, net +20.
- Tests/test support: +572/-0, net +572.
- Total: +596/-4.

## Related Work

#127284 and #128515 are related but distinct and remain open.

## AI assistance disclosure

The contributor disclosed autonomous AI assistance in the original implementation. Maintainer review, compression, behavioral proof, and landing work were performed on the contributor branch.
