### PR TITLE
fix(qa-lab): retain gateway logs when a retry passes

### DIFF
--- a/extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts
+++ b/extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QaGatewayChildLifecycle } from "./gateway-child-lifecycle.js";
 import type { QaLabServerHandle } from "./lab-server.types.js";
 import { runQaFlowSuiteStandard } from "./suite-run-standard.js";
 import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
@@ -8,6 +11,7 @@ import type {
   QaSuiteScenarioRunner,
 } from "./suite-types.js";
 import type { runQaFlowSuiteCleanupPlan } from "./suite.js";
+import { createTempDirHarness } from "./temp-dir.test-helper.js";
 
 const mocks = vi.hoisted(() => ({
   captureRuntimeParityCell: vi.fn(async (params: { runtime: "codex"; wallClockMs: number }) => ({
@@ -36,6 +40,7 @@ const mocks = vi.hoisted(() => ({
     getProcessRssBytes: () => null,
     stop: vi.fn(async () => {}),
   })),
+  stopQaGatewayChild: vi.fn<QaGatewayChildLifecycle["stop"]>(),
   writeQaSuiteArtifacts: vi.fn(async () => ({
     evidence: undefined,
     evidencePath: "/qa-output/qa-evidence.json",
@@ -55,7 +60,7 @@ vi.mock("openclaw/plugin-sdk/agent-harness", () => ({
 vi.mock("./gateway-child.js", () => ({
   createQaGatewayChild: () => ({
     start: (params: unknown) => mocks.startQaGatewayChild(params),
-    stop: async () => ({ process: "confirmed-stopped", errors: [] }),
+    stop: mocks.stopQaGatewayChild,
   }),
 }));
 vi.mock("./providers/server-runtime.js", () => ({
@@ -132,9 +137,20 @@ function makeRetryTestResult(status: "pass" | "fail"): QaSuiteScenarioResult {
   };
 }
 
+const tempDirs = createTempDirHarness();
+
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.runQaFlowSuiteCleanupPlan.mockResolvedValue([]);
+  mocks.stopQaGatewayChild.mockReset().mockResolvedValue({
+    process: "confirmed-stopped",
+    errors: [],
+  });
+  mocks.runQaFlowSuiteCleanupPlan.mockReset().mockResolvedValue([]);
+});
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await tempDirs.cleanup();
 });
 
 describe("QA suite Control UI ownership", () => {
@@ -308,20 +324,61 @@ describe("QA runtime parity scenario retry isolation", () => {
     });
   });
 
-  it("preserves the existing single flake retry outside runtime parity", async () => {
-    const runScenario = vi
-      .fn<QaSuiteScenarioRunner>()
-      .mockResolvedValueOnce(makeRetryTestResult("fail"))
-      .mockResolvedValueOnce(makeRetryTestResult("pass"));
+  it.each(["pass", "fail"] as const)(
+    "retains sanitized logs after an initial %s only when the scenario retried",
+    async (firstStatus) => {
+      vi.stubEnv("OPENCLAW_QA_KEEP_TEMP", undefined);
+      const root = await tempDirs.makeTempDir("qa-retry-artifacts-");
+      const tempRoot = path.join(root, "runtime");
+      await fs.mkdir(tempRoot);
+      const stderrPath = path.join(tempRoot, "gateway.stderr.log");
+      const gateway = new QaGatewayChildLifecycle();
+      gateway.repoRoot = root;
+      gateway.tempRoot = tempRoot;
+      mocks.stopQaGatewayChild.mockImplementation((options) => gateway.stop(options));
+      mocks.runQaFlowSuiteCleanupPlan.mockImplementation(async ({ stopGateway }) => {
+        const stopped = await stopGateway();
+        return stopped.errors.map((error) => ({ phase: "gateway stop", error }));
+      });
+      let attempts = 0;
+      const runScenario = vi.fn<QaSuiteScenarioRunner>().mockImplementation(async () => {
+        attempts += 1;
+        await fs.appendFile(
+          stderrPath,
+          attempts === 1
+            ? "FIRST_ATTEMPT apiKey=synthetic-fixture-secret\n"
+            : "SECOND_ATTEMPT_PASS\n",
+        );
+        return makeRetryTestResult(attempts === 1 ? firstStatus : "pass");
+      });
+      const context = {
+        ...makeRetryTestContext(),
+        repoRoot: root,
+        outputDir: path.join(root, "output"),
+      };
 
-    const result = await runQaFlowSuiteStandard(
-      { lab: makeRetryTestLab() },
-      makeRetryTestContext(),
-      runScenario,
-    );
+      const result = await runQaFlowSuiteStandard(
+        { lab: makeRetryTestLab() },
+        context,
+        runScenario,
+      );
 
-    expect(runScenario).toHaveBeenCalledTimes(2);
-    expect(result.scenarios[0]).toMatchObject({ status: "pass" });
-    expect(mocks.captureRuntimeParityCell).not.toHaveBeenCalled();
-  });
+      expect(runScenario).toHaveBeenCalledTimes(firstStatus === "fail" ? 2 : 1);
+      expect(result.scenarios[0]).toMatchObject({ status: "pass" });
+      expect(mocks.captureRuntimeParityCell).not.toHaveBeenCalled();
+      await expect(fs.stat(tempRoot)).rejects.toMatchObject({ code: "ENOENT" });
+      const artifactDir = path.join(context.outputDir, "artifacts", "gateway-runtime");
+      if (firstStatus === "fail") {
+        expect(result.scenarios[0]?.details).toContain(
+          "passed on retry; first attempt: expected 100 persisted user turns, got 101",
+        );
+        const log = await fs.readFile(path.join(artifactDir, "gateway.stderr.log"), "utf8");
+        expect(log).toContain("FIRST_ATTEMPT apiKey=<redacted>");
+        expect(log).toContain("SECOND_ATTEMPT_PASS");
+        expect(log).not.toContain("synthetic-fixture-secret");
+      } else {
+        await expect(fs.stat(artifactDir)).rejects.toMatchObject({ code: "ENOENT" });
+      }
+    },
+  );
 });

--- a/extensions/qa-lab/src/suite-run-standard.ts
+++ b/extensions/qa-lab/src/suite-run-standard.ts
@@ -281,12 +281,15 @@ export async function runQaFlowSuiteStandard(
       let scenarioResult: QaSuiteScenarioResult =
         params?.captureRuntimeParityCell || scenarioRetryCount === 0
           ? await runSelectedScenario()
-          : await runQaScenarioWithFlakeRetry(runSelectedScenario, () =>
+          : await runQaScenarioWithFlakeRetry(runSelectedScenario, () => {
+              // Both attempts share append-only Gateway logs. Retain the failed
+              // attempt through final cleanup even when its retry passes.
+              preserveGatewayRuntimeDir = path.join(outputDir, "artifacts", "gateway-runtime");
               writeQaSuiteProgress(
                 progressEnabled,
                 `scenario retry (${index + 1}/${selectedScenarios.length}): ${scenarioIdForLog}`,
-              ),
-            );
+              );
+            });
       if (scenarioResult.status === "pass" && params?.roundTripProbe?.scenarioId === scenario.id) {
         const probeResult = await runQaSuiteRoundTripProbe({
           probe: params.roundTripProbe,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where release-verification investigators lose the Gateway logs for a failed QA scenario when its existing retry passes. In [hosted run 33302278628](https://github.com/openclaw/openclaw/actions/runs/33302278628/job/99232612848), the baseline ultimately reported 12 passing scenarios, but `config-restart-capability-flip` passed only on retry after a transcript-projection error. Its first-error summary survived; the Gateway trace needed to identify the caller did not.

## Why This Change Was Made

Both attempts use the same Gateway and append-only log files. The suite previously requested log preservation only from the final scenario status, so a passing retry let final cleanup delete the failed attempt's trace. The existing retry callback now records preservation intent when the first failure occurs. The existing lifecycle still stops the Gateway, closes its log sinks, exports sanitized debug artifacts, and removes private runtime state.

This reuses the current artifact destination and redaction pipeline. It does not add another retry, alter assertions or deadlines, or change configuration or persistent stores. Production LOC is +6/-3 (net +3, including two comment lines); tests are +74/-17. The added assignment records a fact at the owner that observes the failure, without introducing a separate snapshot or export path.

## User Impact

Release-verification maintainers can inspect both attempts' sanitized Gateway logs even when the final verdict passes on retry. Scenarios passing on their first attempt keep the existing behavior and do not retain a Gateway artifact directory. This is an internal QA harness fix with no end-user behavior change or changelog entry.

The underlying transcript-projection race remains unresolved. This PR preserves the evidence needed to diagnose it; it does not claim to fix that race or make full release verification green.

## Evidence

The regression drives the real suite and Gateway cleanup lifecycle with a controlled scenario runner and temporary log files. It checks both attempt markers, retained first-error details, synthetic credential redaction, private runtime removal, and the absence of retained artifacts after a first-attempt success. It does not use live provider credentials or claim a hosted post-fix result.

- Before the production fix: 11 tests passed and the new fail-then-pass case failed with `ENOENT` reading the missing `gateway.stderr.log` artifact.
- After the fix: all 12 owner tests passed.
- Final owner and lifecycle siblings: **29/29 passed**, including startup/replacement failure preservation, shutdown, and cleanup retry behavior.
- Existing sanitized-artifact contract: **1/1 selected test passed**; 94 unrelated cases were intentionally filtered.
- Formatting and `git diff --check` passed. Independent review found no actionable issues. The full changed-file gate passed, including extension and extension-test typechecks, lint, and ownership/import guards. Exact-head CI [33303708849](https://github.com/openclaw/openclaw/actions/runs/33303708849) passed at `79536619821592cc7e3bd7d3dd786c2cb0966055`.

```sh
node scripts/run-vitest.mjs extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts extensions/qa-lab/src/gateway-child-lifecycle.test.ts
node scripts/run-vitest.mjs extensions/qa-lab/src/gateway-child.test.ts -t 'preserves only sanitized gateway debug artifacts'
```

The focused tests ran on base `3483c892e22ec5c77f2c9464b59f2740860c9f11` plus this two-file patch. A new hosted diagnostic will use an exact pinned target that includes this retention fix and the separately reviewed diagnostic instrumentation; that instrumentation is not part of this PR.

## Final maintainer review

Read the latest ClawSweeper review: no actionable findings, security issues, or rank-up moves. Its production-LOC checklist is resolved by retaining the failure fact in the existing retry callback: the three net lines are one assignment and its invariant comments, with no separate export mechanism. Both attempts continue through the existing sanitized cleanup path.
