### PR TITLE
fix(state): stamp unset application versions after canonical repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Upgrade state metadata:** record the current application version after repairing older databases with an unset version marker, allowing CLI commands to use the running Gateway without attempting another schema repair.
 - **Device workers:** preserve offline-runner classification and reconnect guidance when desktop preparation detects a disconnected device, without treating the disconnect as a model failure.
 - **Control UI global sessions:** preserve the selected agent's session in the composer so usage, goals, progress, and thinking options survive agent switches without reusing another agent's stale row.
 - **Image analysis startup:** prepare selected model providers and keep configuration reads independent of full runtime loading, avoiding unrelated discovery and redundant model resolution while preserving credentials and runtime cleanup.

--- a/src/state/openclaw-state-db-binding-targets.test.ts
+++ b/src/state/openclaw-state-db-binding-targets.test.ts
@@ -3,6 +3,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { VERSION } from "../version.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -66,7 +67,7 @@ function createVersion14Bindings() {
       CREATE INDEX idx_current_conversation_bindings_target
         ON current_conversation_bindings(target_agent_id, target_session_key, updated_at DESC, binding_key);
       PRAGMA user_version = 14;
-      UPDATE schema_meta SET schema_version = 14 WHERE meta_key = 'primary';
+      UPDATE schema_meta SET schema_version = 14, app_version = NULL WHERE meta_key = 'primary';
     `);
     const insert = legacy.prepare(`
       INSERT INTO current_conversation_bindings (
@@ -200,8 +201,8 @@ describe("conversation binding target migration", () => {
   });
 
   it.each(migrationPaths)(
-    "preserves bindings and additive data through %s and reopen",
-    (migrationPath) => {
+    "preserves bindings and additive data through %s and cold reopen under a Gateway",
+    async (migrationPath) => {
       const { options, databasePath, before } = createVersion14Bindings();
       if (migrationPath === "doctor repair") {
         expect(repairOpenClawStateDatabaseSchema(options).warnings).toEqual([]);
@@ -221,9 +222,9 @@ describe("conversation binding target migration", () => {
       });
       expect(
         migrated.db
-          .prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'")
+          .prepare("SELECT schema_version, app_version FROM schema_meta WHERE meta_key = 'primary'")
           .get(),
-      ).toEqual({ schema_version: OPENCLAW_STATE_SCHEMA_VERSION });
+      ).toEqual({ schema_version: OPENCLAW_STATE_SCHEMA_VERSION, app_version: VERSION });
       expect(
         migrated.db
           .prepare(
@@ -251,8 +252,13 @@ describe("conversation binding target migration", () => {
 
       const after = readMigrationSnapshot(migrated.db);
       closeOpenClawStateDatabaseForTest();
-      expect(readMigrationSnapshot(openOpenClawStateDatabase(options).db)).toEqual(after);
-      closeOpenClawStateDatabaseForTest();
+      const holder = await holdGatewayLifecycle(databasePath);
+      try {
+        expect(readMigrationSnapshot(openOpenClawStateDatabase(options).db)).toEqual(after);
+      } finally {
+        closeOpenClawStateDatabaseForTest();
+        await holder.release();
+      }
       expect(repairOpenClawStateDatabaseSchema(options).warnings).toEqual([]);
       const repaired = openNodeSqliteDatabase(databasePath, { readOnly: true });
       try {

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -468,7 +468,7 @@ function ensureSchema(
                   .where((eb) =>
                     eb.or([
                       eb("schema_meta.schema_version", "!=", OPENCLAW_STATE_SCHEMA_VERSION),
-                      eb("schema_meta.app_version", "!=", VERSION),
+                      eb("schema_meta.app_version", "is not", VERSION),
                       eb("schema_meta.role", "!=", "global"),
                     ]),
                   ),


### PR DESCRIPTION
## Why

The full release check failed its Linux and macOS packaged-upgrade agent turns after the update, onboarding, Gateway readiness, and dashboard checks had all succeeded. The agent CLI refused shared-state schema mutation because the Gateway already owned that state directory.

The upgraded database was structurally current, but `schema_meta.primary.app_version` was `NULL`. Canonical initialization attempted to publish the current version with an upsert whose change predicate used `app_version != VERSION`. In SQLite that comparison evaluates to `NULL`, so an otherwise current row never receives its completion marker. A later cold CLI open therefore attempts schema repair and correctly hits the Gateway ownership fence.

## Change

Use the null-safe `is not` comparison in the existing canonical initialization upsert. The marker is still published only after the existing repairs, inside the same transaction and subject to the same final validation. An unchanged version still leaves `updated_at` untouched.

There is no schema, layout, version, locking, or ownership-fence change. Doctor's completion semantics are unchanged: its narrower repair can leave legacy cron conversion for canonical initialization, so publishing the marker early in Doctor would be incorrect.

The agent database's similar-looking predicate was inspected but is not the same reachable failure. Its current-version path returns before that upsert; migrations have a differing schema version that makes the existing change predicate true. Agent database opens do not use `app_version` as the shared-state fast-path completion marker.

Production delta: one line changed, net zero. The regression extends existing migration cases and their existing cross-process Gateway holder; it adds no production test seam.

## Verification

- Captured the original failures from [Linux packaged upgrade](https://github.com/openclaw/openclaw/actions/runs/33301741049/job/99231387882) and [macOS packaged upgrade](https://github.com/openclaw/openclaw/actions/runs/33301741049/job/99231387905), frozen source `3ed6805a6f32ad8cdfd3c30dd94d7ae4d75bd667`.
- Reproduced the failure locally with the canonical `runUpgradeLane`, actual published `openclaw@2026.7.1-2` baseline, the exact sealed candidate package and companions, and a loopback mock provider. No provider request occurred before the failure. Candidate tarball SHA-256: `36f40c37abca2f747f29cd4d82c2157700456d9f0c7a35bd1f2332ad23c62fb1`.
- On copies of the actual failed database, unchanged initialization retained the NULL marker and a separate process's cold open failed under a Gateway owner. The fixed initialization published the current version; the next open preserved the timestamp and the same cold open succeeded. The original database was retained unchanged.
- After fixed canonical initialization prepared a copy of the failed home, the **unmodified sealed package** passed Gateway readiness, dashboard smoke, and the actual agent CLI turn with `status: ok` and `OK`. Exactly one loopback mock-provider request was observed. This 8.853-second continuation proves the repaired producer's effect against the real package; it is not a rebuilt-candidate or full cross-OS replay claim.
- Applied the regression before the production fix: **6 passed, 1 failed**, with the Doctor migration case receiving `app_version: null` instead of the current version. After the fix: **239 passed, 1 existing skip** across eight files in 39.89 seconds, including the exact published-version database fixture, runtime and Doctor migrations, cold opens under a separate Gateway owner, unchanged metadata, rollback, corruption, read-only access, and ownership/transaction coverage.
- Inspected the installed Kysely operator/parser/compiler contract and executed SQLite NULL comparison checks. `is not` binds the version normally, handles NULL, and remains false for an unchanged version.

Focused proof, using Node 24 and the repository harness:

```sh
node scripts/run-vitest.mjs \
  src/state/openclaw-state-db-binding-targets.test.ts \
  src/state/openclaw-state-db.test.ts \
  src/state/openclaw-state-db.runtime-fence.test.ts \
  src/state/openclaw-state-ownership.test.ts \
  src/infra/state-database-coordinator.test.ts \
  src/state/openclaw-state-db-readonly.test.ts \
  src/state/openclaw-state-db.corruption-recovery.test.ts \
  src/infra/sqlite-transaction.test.ts
```

Formatting and `git diff --check` pass. Independent Codex review found no actionable issues. The full changed-file gate passed, including core and core-test typechecks, lint, schema-version and ownership/import guards. Exact-head CI and rebuilt-candidate packaged Linux/macOS upgrade replay passed; the original full release run is not claimed green.

## Rebuilt package proof

The canonical rebuilt-package replay is now green: [run 33303947433](https://github.com/openclaw/openclaw/actions/runs/33303947433), using trusted workflow source `3ed6805a6f32ad8cdfd3c30dd94d7ae4d75bd667` and candidate `1828d123f3bec18f52495646c6656f0f568b8d4f`. Both downloaded proof artifacts report that exact candidate as `ref`, `sourceSha`, and `installedCommit`. Their SHA-256 digests match GitHub artifact metadata.

[Linux packaged upgrade](https://github.com/openclaw/openclaw/actions/runs/33303947433/job/99238570887) and [macOS packaged upgrade](https://github.com/openclaw/openclaw/actions/runs/33303947433/job/99238570850) both passed the actual `2026.7.1-2` → candidate upgrade, companion installation, onboarding, models setup, Gateway readiness, dashboard HTTP 200 with nine assets, and first live agent turn returning `status: ok` and `OK`. The agent phases took 3.803s and 4.315s respectively, with no agent retry. Both runners used Node 24.19.0.

The full focused replay took 17m43s, including 10m50s preparing the release package. Linux and macOS jobs took 2m43s and 3m44s. These are observed run timings, not a controlled performance comparison. Windows was not selected in this focused replay, and the full release matrix is not claimed green.

## Final maintainer review

Exact-head [CI33303944851](https://github.com/openclaw/openclaw/actions/runs/33303944851) passed at `1828d123f3bec18f52495646c6656f0f568b8d4f`, including `openclaw/ci-gate` (170 successful jobs,16 skipped).

Read the latest ClawSweeper findings and both rank-up moves. The changelog-removal recommendation is intentionally declined for this maintainer-led release-verification repair, following the requested changelog handling for user-visible fixes. The Kysely proof gap is resolved: the exact installed0.29.5 operator/parser contract was personally inspected, the239-test owner/sibling run exercises the generated statement, exact-head CI is green, and both canonical packaged upgrade lanes passed against the exact rebuilt commit. No schema, migration design, or ownership guard was relaxed.
