### PR TITLE
perf(agents): reuse streamed-turn projections

### DIFF
--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -51,22 +51,27 @@ function stripInternalPlaceholderLines(text: string): string {
   return result;
 }
 
-function stripVerifiedConversationContext(
-  text: string,
-  conversationContext?: string,
-  streaming = false,
-): string {
-  const source = conversationContext?.trim();
-  if (
-    !source ||
-    (!source.includes(HISTORY_CONTEXT_MARKER) && !source.includes(CURRENT_MESSAGE_MARKER))
-  ) {
-    return text;
-  }
-  const containsConversationMarker =
-    text.includes(HISTORY_CONTEXT_MARKER) || text.includes(CURRENT_MESSAGE_MARKER);
-  if (!streaming && !containsConversationMarker) {
-    return text;
+const MARKDOWN_LINE_PREFIX =
+  "[ \\t]*(?:(?:>|[-+*](?=[ \\t])|#{1,6}(?=[ \\t])|\\d{1,9}[.)](?=[ \\t]))[ \\t]*)*";
+
+type VerifiedConversationContext = {
+  readonly normalizedSource: string;
+  sourceLines?: string[];
+  firstSourceLine?: string;
+  copiedPrompt?: RegExp;
+  markdownWrapper?: RegExp;
+  incompleteMarkdownWrapper?: RegExp;
+};
+
+function hasConversationContextMarker(text: string): boolean {
+  return text.includes(HISTORY_CONTEXT_MARKER) || text.includes(CURRENT_MESSAGE_MARKER);
+}
+
+function prepareVerifiedConversationContext(
+  source: string | undefined,
+): VerifiedConversationContext | undefined {
+  if (!source || !hasConversationContextMarker(source)) {
+    return undefined;
   }
   const sourceCodeRegions = findCodeRegions(source);
   const ownsConversationContext = [HISTORY_CONTEXT_MARKER, CURRENT_MESSAGE_MARKER].some(
@@ -86,42 +91,53 @@ function stripVerifiedConversationContext(
     },
   );
   if (!ownsConversationContext) {
-    return text;
+    return undefined;
   }
 
-  const normalizedSource = source.replace(/\r\n?/gu, "\n");
-  const markdownLinePrefix =
-    "[ \\t]*(?:(?:>|[-+*](?=[ \\t])|#{1,6}(?=[ \\t])|\\d{1,9}[.)](?=[ \\t]))[ \\t]*)*";
+  return { normalizedSource: source.replace(/\r\n?/gu, "\n") };
+}
+
+function stripVerifiedConversationContext(
+  text: string,
+  context: VerifiedConversationContext | undefined,
+  streaming = false,
+): string {
+  if (!context) {
+    return text;
+  }
+  const { normalizedSource } = context;
   let result = text;
-  if (containsConversationMarker) {
-    const promptPattern = normalizedSource
-      .split("\n")
-      .map(escapeRegExp)
-      .join(`(?:\\r\\n?|\\n)${markdownLinePrefix}`);
-    const copiedPrompt = new RegExp(`(?:^${markdownLinePrefix})?${promptPattern}`, "gmu");
+  if (hasConversationContextMarker(text)) {
+    if (!context.copiedPrompt) {
+      const promptPattern = (context.sourceLines ??= normalizedSource.split("\n"))
+        .map(escapeRegExp)
+        .join(`(?:\\r\\n?|\\n)${MARKDOWN_LINE_PREFIX}`);
+      context.copiedPrompt = new RegExp(`(?:^${MARKDOWN_LINE_PREFIX})?${promptPattern}`, "gmu");
+    }
     // Markdown formatting does not make an exact owner-bound private prompt safe to disclose.
-    result = text.replace(copiedPrompt, "");
+    result = text.replace(context.copiedPrompt, "");
   }
   if (!streaming) {
     return result;
   }
 
-  const sourceStart = normalizedSource[0];
-  if (!sourceStart) {
-    return result;
-  }
-  const firstSourceLine = normalizedSource.split("\n", 1)[0] ?? normalizedSource;
+  const sourceStart = normalizedSource.charAt(0);
+  const firstSourceLine = (context.firstSourceLine ??=
+    normalizedSource.split("\n", 1)[0] ?? normalizedSource);
   const completedSourceStart = result.indexOf(firstSourceLine);
   // Anchor every completed prompt start; wrappers can be arbitrarily wide and markers can repeat.
   const searchStart =
     completedSourceStart === -1
       ? Math.max(0, result.length - normalizedSource.length * 2)
       : completedSourceStart;
-  const markdownWrapper = new RegExp(`^${markdownLinePrefix}$`, "u");
-  const incompleteMarkdownWrapper = new RegExp(
-    `^${markdownLinePrefix}(?:[-+*]|#{1,6}|\\d{1,9}[.)]?)?$`,
+  const markdownWrapper = (context.markdownWrapper ??= new RegExp(
+    `^${MARKDOWN_LINE_PREFIX}$`,
     "u",
-  );
+  ));
+  const incompleteMarkdownWrapper = (context.incompleteMarkdownWrapper ??= new RegExp(
+    `^${MARKDOWN_LINE_PREFIX}(?:[-+*]|#{1,6}|\\d{1,9}[.)]?)?$`,
+    "u",
+  ));
   let candidateStart = result.indexOf(sourceStart, searchStart);
   let completedCandidates = 0;
   while (candidateStart !== -1) {
@@ -139,7 +155,7 @@ function stripVerifiedConversationContext(
       return result.slice(0, searchStart);
     }
     const suffix = result.slice(candidateStart).replace(/\r\n?/gu, "\n");
-    const sourceLines = normalizedSource.split("\n");
+    const sourceLines = (context.sourceLines ??= normalizedSource.split("\n"));
     let lineIndex = 0;
     const unwrappedSuffix = suffix.replace(/\n([^\n]*)/gu, (_match, line: string) => {
       const sourceLine = sourceLines[++lineIndex];
@@ -178,12 +194,26 @@ export function createVerifiedConversationContextStreamFilter(
 ): (delta: string) => string {
   let accumulatedText = "";
   let releasedText: string | null = "";
+  let conversationContextSource: string | undefined;
+  let preparedConversationContext: VerifiedConversationContext | undefined;
   return (delta) => {
     accumulatedText += delta;
     const conversationContext = getConversationContext?.();
-    const safeText = stripVerifiedConversationContext(accumulatedText, conversationContext, true);
-    // Already delivered stream text cannot be retracted if its safe projection changes.
-    if (releasedText === null || !safeText.startsWith(releasedText)) {
+    const sourceChanged = conversationContext !== conversationContextSource;
+    if (sourceChanged) {
+      preparedConversationContext = prepareVerifiedConversationContext(conversationContext?.trim());
+      conversationContextSource = conversationContext;
+    }
+    const safeText = stripVerifiedConversationContext(
+      accumulatedText,
+      preparedConversationContext,
+      true,
+    );
+    // An unchanged unowned source keeps the known prefix; changing ownership must recheck it.
+    if (
+      releasedText === null ||
+      ((sourceChanged || preparedConversationContext) && !safeText.startsWith(releasedText))
+    ) {
       releasedText = null;
       return "";
     }
@@ -223,11 +253,15 @@ export function sanitizeUserFacingText(
   if (!raw) {
     return raw;
   }
-  const withoutConversationContext = stripVerifiedConversationContext(
-    raw,
-    opts?.conversationContext,
-    opts?.streaming,
-  );
+  const conversationContext = opts?.conversationContext?.trim();
+  const withoutConversationContext =
+    conversationContext && (opts?.streaming || hasConversationContextMarker(raw))
+      ? stripVerifiedConversationContext(
+          raw,
+          prepareVerifiedConversationContext(conversationContext),
+          opts?.streaming,
+        )
+      : raw;
   const stripped = stripInboundMetadata(
     stripInternalRuntimeContext(stripFinalTagsFromText(withoutConversationContext)),
   );

--- a/src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts
@@ -29,7 +29,6 @@ import {
   isResponsesApiAssistantMessage,
   isSubscribeTranscriptOnlyOpenClawAssistantMessage,
   scopeAssistantMessageToStreamBlock,
-  shouldSuppressAssistantVisibleOutput,
   shouldSuppressDeterministicApprovalOutput,
 } from "./embedded-agent-subscribe.handlers.messages.stream.js";
 import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
@@ -137,8 +136,6 @@ export function handleMessageStart(
   emitAssistantMessageStart(ctx);
 }
 
-/** Handles assistant message deltas, reasoning, directives, and block replies. */
-
 export function handleMessageEnd(
   ctx: EmbeddedAgentSubscribeContext,
   evt: AgentEvent & { message: AgentMessage },
@@ -153,7 +150,7 @@ export function handleMessageEnd(
   ctx.state.assistantTurnCount += 1;
   const assistantMessage = preservePendingAssistantUsage(msg, ctx.state.pendingAssistantUsage);
   const assistantPhase = resolveAssistantMessagePhase(assistantMessage);
-  const suppressVisibleAssistantOutput = shouldSuppressAssistantVisibleOutput(assistantMessage);
+  const suppressVisibleAssistantOutput = assistantPhase === "commentary";
   const suppressDeterministicApprovalOutput = shouldSuppressDeterministicApprovalOutput(ctx.state);
   const suppressMessageToolOnlySourceReplyOutput = hasMessageToolOnlySourceDelivery(ctx);
   // Provider completion can omit thinking_end; close the visible lane before final output.
@@ -174,14 +171,14 @@ export function handleMessageEnd(
         )
       : assistantMessage;
     const commentaryText = coerceChatContentText(extractAssistantCommentaryText(commentaryMessage));
-    appendRawStream({
+    appendRawStream(() => ({
       ts: Date.now(),
       event: "assistant_message_end",
       runId: ctx.params.runId,
       sessionId: (ctx.params.session as { id?: string }).id,
       rawText: coerceChatContentText(extractEmbeddedAssistantText(assistantMessage)),
       rawThinking: extractAssistantThinking(assistantMessage),
-    });
+    }));
     const commentaryAlreadyStreamed =
       isResponsesCommentary &&
       Boolean(ctx.state.deltaBuffer) &&
@@ -216,16 +213,18 @@ export function handleMessageEnd(
   }
   promoteThinkingTagsToBlocks(assistantMessage);
 
-  const rawText = coerceChatContentText(extractEmbeddedAssistantText(assistantMessage));
+  let rawText: string | undefined;
+  const getRawText = () =>
+    (rawText ??= coerceChatContentText(extractEmbeddedAssistantText(assistantMessage)));
   const rawVisibleText = coerceChatContentText(extractAssistantVisibleText(assistantMessage));
-  appendRawStream({
+  appendRawStream(() => ({
     ts: Date.now(),
     event: "assistant_message_end",
     runId: ctx.params.runId,
     sessionId: (ctx.params.session as { id?: string }).id,
-    rawText,
+    rawText: getRawText(),
     rawThinking: extractAssistantThinking(assistantMessage),
-  });
+  }));
   warnIfAssistantEmittedSuspiciousText(ctx, assistantMessage);
   const visibleText =
     extractStandaloneMessageToolText(rawVisibleText, {
@@ -244,7 +243,7 @@ export function handleMessageEnd(
   const text = finalVisibleText;
   const rawThinking =
     ctx.state.includeReasoning || ctx.state.streamReasoning
-      ? extractAssistantThinking(assistantMessage) || extractThinkingFromTaggedText(rawText)
+      ? extractAssistantThinking(assistantMessage) || extractThinkingFromTaggedText(getRawText())
       : "";
   const trimmedReasoning = rawThinking ? rawThinking.trim() : "";
   const trimmedText = text.trim();

--- a/src/agents/embedded-agent-subscribe.handlers.messages.stream.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.stream.ts
@@ -12,7 +12,6 @@ import { splitTrailingDirective } from "../auto-reply/reply/streaming-directives
 import type { AssistantMessage } from "../llm/types.js";
 import {
   parseAssistantTextSignature,
-  resolveAssistantMessagePhase,
   type AssistantPhase,
 } from "../shared/chat-message-content.js";
 import { normalizeTextForComparison } from "./embedded-agent-helpers.js";
@@ -23,10 +22,6 @@ import type {
   EmbeddedAgentSubscribeState,
 } from "./embedded-agent-subscribe.handlers.types.js";
 import type { AgentMessage } from "./runtime/index.js";
-
-export function shouldSuppressAssistantVisibleOutput(message: AgentMessage | undefined): boolean {
-  return resolveAssistantMessagePhase(message) === "commentary";
-}
 
 export function isSubscribeTranscriptOnlyOpenClawAssistantMessage(
   message: AgentMessage | undefined,
@@ -77,7 +72,14 @@ export function extractStandaloneMessageToolText(
   params: { allowCurrentSourceReply?: boolean; allowRoutedReply?: boolean } = {},
 ): string | undefined {
   try {
-    const record = asRecord(JSON.parse(text.trim()) as unknown);
+    if (!params.allowCurrentSourceReply && !params.allowRoutedReply) {
+      return undefined;
+    }
+    const trimmed = text.trim();
+    if (!trimmed.startsWith("{")) {
+      return undefined;
+    }
+    const record = asRecord(JSON.parse(trimmed) as unknown);
     const args = asRecord(record?.arguments);
     const hasRoute = Boolean(
       normalizeOptionalString(args?.target) ||
@@ -237,7 +239,9 @@ export function resolveCurrentSourceMessagingToolPartial(
     held && params.evtType === "text_delta" && !params.text.startsWith(held)
       ? `${held}${params.visibleDelta || params.text}`
       : params.text;
-  const normalized = normalizeTextForComparison(text);
+  const normalized = state.currentSourceMessagingToolSentTextsNormalized.length
+    ? normalizeTextForComparison(text)
+    : "";
   if (!normalized) {
     state.currentSourceMessagingToolHeldPartial = undefined;
     return { hold: false, text };
@@ -409,8 +413,6 @@ export function resolveStreamingReplyText(params: {
   );
 }
 
-/** Records parsed reply directives until a sendable reply payload is built. */
-
 export function buildAssistantStreamData(params: {
   text?: string;
   delta?: string;
@@ -440,5 +442,3 @@ export function buildAssistantStreamData(params: {
     itemId: params.itemId,
   };
 }
-
-/** Handles assistant message-start boundaries for streaming state. */

--- a/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
@@ -37,7 +37,6 @@ import {
   resolveStreamingReplyText,
   resolveTextAppendDelta,
   scopeAssistantMessageToStreamBlock,
-  shouldSuppressAssistantVisibleOutput,
   shouldSuppressDeterministicApprovalOutput,
 } from "./embedded-agent-subscribe.handlers.messages.stream.js";
 import type {
@@ -89,11 +88,12 @@ export function handleMessageUpdate(
   const isResponsesTextEvent =
     isResponsesApiAssistantMessage(eventAssistantMessage) &&
     (evtType === "text_start" || evtType === "text_delta" || evtType === "text_end");
-  const suppressVisibleAssistantOutput = shouldSuppressAssistantVisibleOutput(msg);
+  const assistantPhase = resolveAssistantMessagePhase(msg);
+  const suppressVisibleAssistantOutput = assistantPhase === "commentary";
   if (suppressVisibleAssistantOutput && !isResponsesTextEvent) {
     const commentaryText = coerceChatContentText(extractAssistantCommentaryText(msg));
     if (commentaryText) {
-      appendRawStream({
+      appendRawStream(() => ({
         ts: Date.now(),
         event: "assistant_text_stream",
         runId: ctx.params.runId,
@@ -101,7 +101,7 @@ export function handleMessageUpdate(
         evtType: "commentary_update",
         delta: "",
         content: commentaryText,
-      });
+      }));
       ctx.emitAssistantStreamData(
         buildAssistantStreamData({ text: commentaryText, replace: true, phase: "commentary" }),
       );
@@ -110,8 +110,6 @@ export function handleMessageUpdate(
   }
   const suppressDeterministicApprovalOutput = shouldSuppressDeterministicApprovalOutput(ctx.state);
   const suppressMessageToolOnlySourceReplyOutput = hasMessageToolOnlySourceDelivery(ctx);
-
-  const assistantPhase = resolveAssistantMessagePhase(msg);
 
   if (evtType === "text_end" || evtType === "done" || evtType === "error") {
     capturePendingAssistantUsage(ctx, evt);
@@ -130,7 +128,7 @@ export function handleMessageUpdate(
     const thinkingDelta = typeof assistantRecord?.delta === "string" ? assistantRecord.delta : "";
     const thinkingContent =
       typeof assistantRecord?.content === "string" ? assistantRecord.content : "";
-    appendRawStream({
+    appendRawStream(() => ({
       ts: Date.now(),
       event: "assistant_thinking_stream",
       runId: ctx.params.runId,
@@ -138,7 +136,7 @@ export function handleMessageUpdate(
       evtType,
       delta: thinkingDelta,
       content: thinkingContent,
-    });
+    }));
     // Emit-always: emitReasoningStream always reaches the bus/archive; the
     // streamReasoning rendering hook and message_tool_only source suppression
     // are gated downstream (dispatch wrapProgressCallback, #92738), so emission
@@ -166,7 +164,7 @@ export function handleMessageUpdate(
   const delta = typeof assistantRecord?.delta === "string" ? assistantRecord.delta : "";
   const content = typeof assistantRecord?.content === "string" ? assistantRecord.content : "";
 
-  appendRawStream({
+  appendRawStream(() => ({
     ts: Date.now(),
     event: "assistant_text_stream",
     runId: ctx.params.runId,
@@ -174,7 +172,7 @@ export function handleMessageUpdate(
     evtType,
     delta,
     content,
-  });
+  }));
 
   const chunk = resolveAssistantTextChunk({
     evtType,

--- a/src/agents/embedded-agent-subscribe.raw-stream.test.ts
+++ b/src/agents/embedded-agent-subscribe.raw-stream.test.ts
@@ -42,17 +42,19 @@ describe("appendRawStream", () => {
     fs.mkdirSync(directoryTarget);
     vi.stubEnv("OPENCLAW_RAW_STREAM_PATH", directoryTarget);
 
-    expect(() => appendRawStream({ event: "test", ts: 1 })).not.toThrow();
+    expect(() => appendRawStream(() => ({ event: "test", ts: 1 }))).not.toThrow();
     await drainAsyncWrites();
 
     expect(unhandledRejections).toHaveLength(0);
   });
 
-  it("appends exact JSONL through the real dependency", async () => {
+  it("snapshots the factory result before appending exact JSONL", async () => {
     const rawStreamPath = path.join(tmpDir, "raw.jsonl");
     vi.stubEnv("OPENCLAW_RAW_STREAM_PATH", rawStreamPath);
 
-    appendRawStream({ event: "test", ts: 1 });
+    const payload = { event: "test", ts: 1 };
+    appendRawStream(() => payload);
+    payload.ts = 2;
     // The async writer creates the file before its append completes.
     await vi.waitFor(() => {
       expect(fs.readFileSync(rawStreamPath, "utf8")).toBe('{"event":"test","ts":1}\n');
@@ -65,20 +67,31 @@ describe("appendRawStream", () => {
     vi.stubEnv("OPENCLAW_RAW_STREAM", "");
     vi.stubEnv("OPENCLAW_RAW_STREAM_PATH", rawStreamPath);
 
-    appendRawStream({ event: "test", ts: 1 });
+    let evaluated = false;
+    appendRawStream(() => {
+      evaluated = true;
+      return { event: "test", ts: 1 };
+    });
     await drainAsyncWrites();
+
+    expect(evaluated).toBe(false);
 
     expect(fs.existsSync(rawStreamPath)).toBe(false);
     expect(unhandledRejections).toHaveLength(0);
   });
 
-  it("contains synchronous JSON serialization failures", () => {
+  it("contains synchronous factory and JSON serialization failures", () => {
     const rawStreamPath = path.join(tmpDir, "cyclic.jsonl");
     const payload: Record<string, unknown> = {};
     payload.self = payload;
     vi.stubEnv("OPENCLAW_RAW_STREAM_PATH", rawStreamPath);
 
-    expect(() => appendRawStream(payload)).not.toThrow();
+    expect(() => appendRawStream(() => payload)).not.toThrow();
+    expect(() =>
+      appendRawStream(() => {
+        throw new Error("payload unavailable");
+      }),
+    ).not.toThrow();
     expect(fs.existsSync(rawStreamPath)).toBe(false);
     expect(unhandledRejections).toHaveLength(0);
   });

--- a/src/agents/embedded-agent-subscribe.raw-stream.ts
+++ b/src/agents/embedded-agent-subscribe.raw-stream.ts
@@ -20,7 +20,7 @@ function resolveRawStreamPath(): string {
   );
 }
 
-export function appendRawStream(payload: Record<string, unknown>) {
+export function appendRawStream(createPayload: () => Record<string, unknown>) {
   if (!isRawStreamEnabled()) {
     return;
   }
@@ -34,9 +34,10 @@ export function appendRawStream(payload: Record<string, unknown>) {
     }
   }
   try {
+    // Evaluate and serialize before the async append while the message snapshot is current.
     void appendRegularFile({
       filePath: rawStreamPath,
-      content: `${JSON.stringify(payload)}\n`,
+      content: `${JSON.stringify(createPayload())}\n`,
       rejectSymlinkParents: true,
     }).catch(() => {
       // Raw diagnostics are best-effort; filesystem failures must not terminate agent runs.

--- a/src/agents/embedded-agent-subscribe.reply-delivery.ts
+++ b/src/agents/embedded-agent-subscribe.reply-delivery.ts
@@ -202,14 +202,14 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
     state.deferredBlockReplies.length = 0;
   };
 
-  const rememberAssistantText = (text: string) => {
+  const rememberAssistantText = (text: string, normalizedText?: string) => {
     state.lastAssistantTextMessageIndex = state.assistantMessageIndex;
     state.lastAssistantTextTrimmed = text.trimEnd();
-    const normalized = normalizeTextForComparison(text);
+    const normalized = normalizedText ?? normalizeTextForComparison(text);
     state.lastAssistantTextNormalized = normalized.length > 0 ? normalized : undefined;
   };
 
-  const shouldSkipAssistantText = (text: string) => {
+  const shouldSkipAssistantText = (text: string, normalizedText?: string) => {
     if (state.lastAssistantTextMessageIndex !== state.assistantMessageIndex) {
       return false;
     }
@@ -217,25 +217,25 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
     if (trimmed && trimmed === state.lastAssistantTextTrimmed) {
       return true;
     }
-    const normalized = normalizeTextForComparison(text);
+    const normalized = normalizedText ?? normalizeTextForComparison(text);
     if (normalized.length > 0 && normalized === state.lastAssistantTextNormalized) {
       return true;
     }
     return false;
   };
 
-  const pushAssistantText = (text: string) => {
+  const pushAssistantText = (text: string, normalizedText?: string) => {
     if (!text) {
       return;
     }
     if (params.silentExpected && !shouldAllowSilentTurnText(text)) {
       return;
     }
-    if (shouldSkipAssistantText(text)) {
+    if (shouldSkipAssistantText(text, normalizedText)) {
       return;
     }
     assistantTexts.push(text);
-    rememberAssistantText(text);
+    rememberAssistantText(text, normalizedText);
   };
 
   const replaceCurrentAssistantText = (text: string) => {

--- a/src/agents/embedded-agent-subscribe.stream-rendering.ts
+++ b/src/agents/embedded-agent-subscribe.stream-rendering.ts
@@ -93,8 +93,8 @@ type StreamRenderingParams = {
   blockChunker: EmbeddedAgentSubscribeContext["blockChunker"];
   emitBlockReply: EmbeddedAgentSubscribeContext["emitBlockReply"];
   pendingBlockReplyTasks: Set<Promise<void>>;
-  pushAssistantText: (text: string) => void;
-  shouldSkipAssistantText: (text: string) => boolean;
+  pushAssistantText: (text: string, normalizedText?: string) => void;
+  shouldSkipAssistantText: (text: string, normalizedText?: string) => boolean;
 };
 
 export function createStreamRendering({
@@ -429,7 +429,7 @@ export function createStreamRendering({
       return;
     }
 
-    if (shouldSkipAssistantText(chunk)) {
+    if (shouldSkipAssistantText(chunk, normalizedChunk)) {
       if (slicedPrefixReplay) {
         markBlockReplyTextHandled();
       }
@@ -437,7 +437,7 @@ export function createStreamRendering({
     }
 
     if (!params.onBlockReply) {
-      pushAssistantText(chunk);
+      pushAssistantText(chunk, normalizedChunk);
       markBlockReplyTextHandled();
       return;
     }
@@ -462,7 +462,7 @@ export function createStreamRendering({
       }
       return;
     }
-    pushAssistantText(chunk);
+    pushAssistantText(chunk, normalizedChunk);
     emitBlockReply(
       {
         text: cleanedText,

--- a/src/agents/embedded-agent-subscribe.tool-text-diagnostics.ts
+++ b/src/agents/embedded-agent-subscribe.tool-text-diagnostics.ts
@@ -38,15 +38,6 @@ function hasStructuredToolInvocation(message: AssistantMessage): boolean {
   });
 }
 
-function extractAssistantTextForDiagnostics(message: AssistantMessage): string {
-  return (
-    extractTextFromChatContent(message.content, {
-      joinWith: "\n",
-      normalizeText: (text) => text.trim(),
-    }) ?? ""
-  );
-}
-
 function isRegisteredToolName(
   toolName: string | undefined,
   registeredToolNames: ReadonlySet<string> | undefined,
@@ -63,45 +54,38 @@ function isRegisteredToolName(
   return false;
 }
 
-/** Log a diagnostic when assistant text resembles a tool call but is not structured. */
-function warnIfAssistantEmittedToolText(
+/** Log safe metadata for suspicious assistant-authored text shapes. */
+export function warnIfAssistantEmittedSuspiciousText(
   ctx: EmbeddedAgentSubscribeContext,
   assistantMessage: AssistantMessage,
 ) {
-  if (hasStructuredToolInvocation(assistantMessage)) {
-    return;
+  const structuredToolInvocation = hasStructuredToolInvocation(assistantMessage);
+  const text =
+    extractTextFromChatContent(assistantMessage.content, {
+      joinWith: "\n",
+      normalizeText: (chunk) => chunk.trim(),
+    }) ?? "";
+  const toolDetection = structuredToolInvocation ? null : detectToolCallShapedText(text);
+  if (toolDetection) {
+    const provider = normalizeOptionalString((assistantMessage as { provider?: unknown }).provider);
+    const model = normalizeOptionalString((assistantMessage as { model?: unknown }).model);
+    const registeredTool = isRegisteredToolName(toolDetection.toolName, ctx.builtinToolNames);
+    const sessionId = normalizeOptionalString((ctx.params.session as { id?: unknown }).id);
+    ctx.log.warn(
+      "Assistant reply looks like a tool call, but no structured tool invocation was emitted; treating it as text.",
+      {
+        runId: ctx.params.runId,
+        ...(sessionId ? { sessionId } : {}),
+        ...(provider ? { provider } : {}),
+        ...(model ? { model } : {}),
+        pattern: toolDetection.kind,
+        ...(toolDetection.toolName ? { toolName: toolDetection.toolName } : {}),
+        ...(registeredTool !== undefined ? { registeredTool } : {}),
+      },
+    );
   }
-  const detection = detectToolCallShapedText(extractAssistantTextForDiagnostics(assistantMessage));
-  if (!detection) {
-    return;
-  }
-  const provider = normalizeOptionalString((assistantMessage as { provider?: unknown }).provider);
-  const model = normalizeOptionalString((assistantMessage as { model?: unknown }).model);
-  const registeredTool = isRegisteredToolName(detection.toolName, ctx.builtinToolNames);
-  const sessionId = normalizeOptionalString((ctx.params.session as { id?: unknown }).id);
-  ctx.log.warn(
-    "Assistant reply looks like a tool call, but no structured tool invocation was emitted; treating it as text.",
-    {
-      runId: ctx.params.runId,
-      ...(sessionId ? { sessionId } : {}),
-      ...(provider ? { provider } : {}),
-      ...(model ? { model } : {}),
-      pattern: detection.kind,
-      ...(detection.toolName ? { toolName: detection.toolName } : {}),
-      ...(registeredTool !== undefined ? { registeredTool } : {}),
-    },
-  );
-}
-
-/** Log a diagnostic when assistant text resembles a fresh transcript role turn. */
-function warnIfAssistantEmittedTranscriptRoleHeader(
-  ctx: EmbeddedAgentSubscribeContext,
-  assistantMessage: AssistantMessage,
-) {
-  const detection = detectAssistantTranscriptRoleHeaderText(
-    extractAssistantTextForDiagnostics(assistantMessage),
-  );
-  if (!detection) {
+  const roleDetection = detectAssistantTranscriptRoleHeaderText(text);
+  if (!roleDetection) {
     return;
   }
   const provider = normalizeOptionalString((assistantMessage as { provider?: unknown }).provider);
@@ -114,17 +98,8 @@ function warnIfAssistantEmittedTranscriptRoleHeader(
       ...(sessionId ? { sessionId } : {}),
       ...(provider ? { provider } : {}),
       ...(model ? { model } : {}),
-      pattern: detection.kind,
-      role: detection.role,
+      pattern: roleDetection.kind,
+      role: roleDetection.role,
     },
   );
-}
-
-/** Log safe metadata for suspicious assistant-authored text shapes. */
-export function warnIfAssistantEmittedSuspiciousText(
-  ctx: EmbeddedAgentSubscribeContext,
-  assistantMessage: AssistantMessage,
-) {
-  warnIfAssistantEmittedToolText(ctx, assistantMessage);
-  warnIfAssistantEmittedTranscriptRoleHeader(ctx, assistantMessage);
 }

--- a/src/auto-reply/reply/acp-projector.test.ts
+++ b/src/auto-reply/reply/acp-projector.test.ts
@@ -204,7 +204,7 @@ describe("createAcpReplyProjector", () => {
   });
 
   it.each(["live", "final_only"] as const)(
-    "uses finalized owner context to redact split private prompts in %s mode",
+    "uses finalized and refreshed owner context to redact split private prompts in %s mode",
     async (deliveryMode) => {
       const marker = "[Current message - respond to this]";
       let conversationContext = "";
@@ -218,7 +218,8 @@ describe("createAcpReplyProjector", () => {
       conversationContext = `${marker}\nPrivate secret. Keep hidden.`;
 
       await emitText(projector, "Visible answer before. ");
-      await emitText(projector, `${marker}\nPrivate secret. `);
+      conversationContext = `${marker}\nPrivate updated context. Keep hidden.`;
+      await emitText(projector, `${marker}\nPrivate updated context. `);
       await emitText(projector, "Keep hidden. Visible answer after.");
       await projector.flush(true);
 

--- a/src/shared/chat-message-content.ts
+++ b/src/shared/chat-message-content.ts
@@ -89,7 +89,7 @@ export function resolveAssistantMessagePhase(message: unknown): AssistantPhase |
   if (!Array.isArray(entry.content)) {
     return undefined;
   }
-  const explicitPhases = new Set<AssistantPhase>();
+  let explicitPhase: AssistantPhase | undefined;
   for (const block of entry.content) {
     if (!block || typeof block !== "object") {
       continue;
@@ -100,10 +100,13 @@ export function resolveAssistantMessagePhase(message: unknown): AssistantPhase |
     }
     const phase = parseAssistantTextSignature(record)?.phase;
     if (phase) {
-      explicitPhases.add(phase);
+      if (explicitPhase && explicitPhase !== phase) {
+        return undefined;
+      }
+      explicitPhase = phase;
     }
   }
-  return explicitPhases.size === 1 ? [...explicitPhases][0] : undefined;
+  return explicitPhase;
 }
 
 /** Finds assistant phase metadata on event payloads that may wrap message-like records. */

--- a/src/shared/text/assistant-transcript-role-headers.ts
+++ b/src/shared/text/assistant-transcript-role-headers.ts
@@ -9,6 +9,10 @@ type AssistantTranscriptRoleHeaderDetection = {
 export function detectAssistantTranscriptRoleHeaderText(
   text: string,
 ): AssistantTranscriptRoleHeaderDetection | null {
+  // Parsed headers need a bracket or angle delimiter, written literally or as an entity.
+  if (!text.includes("[") && !text.includes("<") && !text.includes("&")) {
+    return null;
+  }
   const annotation = markdownToIR(text, {
     assistantTranscriptRoleHeaders: true,
     enableSpoilers: true,


### PR DESCRIPTION
## What Problem This Solves

Streamed replies repeatedly project the same assistant message, reparse unchanged private conversation context, normalize chunks without a source-delivery comparison to make, and construct disabled diagnostic payloads. Plain terminal replies also take a failing JSON parse and a complete Markdown diagnostic parse.

## Why This Change Was Made

Keep prepared facts with their existing owners and remove duplicate work through six related mechanisms:

- Make the internal raw-stream API factory-only across all five callers. Disabled diagnostics do not construct payloads; enabled diagnostics synchronously evaluate and serialize before asynchronous filesystem append. Extract complete assistant text only when diagnostics or the existing reasoning fallback needs it.
- Resolve message phase once at each lifecycle/update boundary; replace the temporary phase set with scalar agreement detection and remove the forwarding suppression helper.
- Prepare verified conversation context per exact owner-source value. Reuse its lazily built line/regular-expression facts and avoid repeated prefix comparisons only when unchanged, unowned context makes them unnecessary.
- Admit terminal message JSON only when the existing display policy allows it and the text can be an object. Keep canonical parsing and routing checks for admitted text.
- Skip source-reply normalization when there are no confirmed source replies to compare, and carry normalized immutable chunks through the existing deduplication flow.
- Extract diagnostic text once, remove forwarding wrappers, and reject impossible role-header strings before the canonical Markdown parser.

Production **+163/−149 = net +14**; existing test extensions **+22/−8 = net +14**. Prepared context accounts for the growth; the other owners net −20 lines. No config, schema, protocol, tool execution, authorization, dependency or process-cache change. The raw logging API is internal and has no compatibility branch.

## Contracts and Tradeoffs

Context still reads its owner getter on every delta, refreshes when its exact raw value changes, protects Markdown-wrapped private prompt fragments, and permanently stops release after an unretractable prefix divergence. Snapshot presentation retains its separate scalar path. Native reasoning, commentary/final phases, Responses item boundaries, source-delivery suppression and directive ordering remain intact.

Diagnostics preserve tool-warning-before-role-warning ordering, independent role detection for structured tool messages, and safe metadata without reply bodies. The role-header prefilter is only a necessary-condition check: every canonical grammar requires a bracket or angle delimiter, whose encoded form retains an ampersand. Admitted input still goes through the existing parser. The installed Markdown/entity/escape/CJK implementations and native Codex optional-phase/content contracts were inspected directly.

Raw payloads are serialized before the filesystem dependency sees them. Diagnostic timestamps now follow path preparation, and factory exceptions are contained by the existing best-effort boundary. There is no new flush or cross-call append-order guarantee.

## Measurements and Verification

Final integrated source was measured in fresh Node 26.8.1 processes with opposite starting orders, balanced warmups, uninstrumented complete owners and all raw samples retained:

| Complete workload | Before → candidate, two medians |
| --- | --- |
| Short default subscriber | 60.24/64.63 → 39.45/35.33 µs |
| Subscriber, 100 deltas | 1.669/1.644 → 0.795/0.763 ms |
| Subscriber, 32 KB across 100 deltas | 14.167/13.958 → 6.640/6.899 ms |
| Native reasoning stream | 10.5% / 18.2% lower |
| 64 signed-block streams | 28.7–30.7% lower |
| Default ACP, final-only delivery | 247.13/256.97 → 20.09/19.74 µs |
| Default ACP, live delivery | 308.27/317.38 → 82.58/83.96 µs |

These are local processing measurements, not provider/network or whole-turn speedups. Ordinary scalar context controls add about 2–17 ns; the owned snapshot sibling adds about 2 µs across 100 snapshots. An isolated enabled double-warning path is 13–14% slower, while complete subscriber warning controls vary by run order. All such controls and rejected earlier context experiments remain recorded; no universal or memory-saving claim.

The final 24-module compositions pass exact output/state checks across 468 subscriber boundaries and 5,988 lifecycle transitions, all five raw call sites, 14,532 terminal JSON cases, 2,772 partial-delivery states, 4,228 role-header inputs, 1,438 warning sequences, and 1,658 context streams containing 105,568 deltas. Full ACP and snapshot siblings are covered too. Thirty-six raw-enabled runs per variant produce the same 216 records; all 216 candidate factories execute synchronously. Counts describe different proof units, not a summed test total.

All **345 canonical tests across 15 files** passed before and after integration. The strengthened real-filesystem snapshot test failed against the old raw owner and passes with the factory API. The full changed-file gate passed types, boundaries, dead exports and other guards, then found one shadowed callback parameter; that lexical rename passed the canonical lint rerun. Fresh automated Codex review across P0–P3 and independent complete-owner review are clean. The patch rebased unchanged onto current main. Exact-head hosted CI, fresh build and real OpenAI Gateway verification are being completed before landing.


At the published head `ecbc4e9b8b052acca4db20c500eff1f59bb14c9b`, all 345 selected tests passed again and a fresh build completed in 154.95 seconds. An isolated real OpenAI Gateway completed three chat turns with two actual `web_fetch` calls and a separate native web-search turn. Recovery from a fresh read-only connection, exact in-flight tool identity, history/list/status projections, terminal cleanup and unchanged baseline previews/tools/catalog passed 81 assertions over 32 RPCs. A second isolated Gateway with raw diagnostics enabled returned the exact requested READY response and wrote four valid JSONL records, including the exact terminal payload. Both owned Gateways stopped cleanly and CPU profiles were retained. These live timings are observational, not a controlled provider-latency comparison.

The native Codex source check used public commit `6478a751fde8884b2fdc76486fe23175a8e795d4`: [optional message phases](https://github.com/openai/codex/blob/6478a751fde8884b2fdc76486fe23175a8e795d4/codex-rs/protocol/src/models.rs#L875) and [message/content contracts](https://github.com/openai/codex/blob/6478a751fde8884b2fdc76486fe23175a8e795d4/codex-rs/protocol/src/models.rs#L970). This PR does not change or claim a live run of the native Codex runtime.


## Landing Review

The latest ClawSweeper review found no introduced correctness or security defect but could not access the required sibling Codex source. The lead agent personally checked the public checkout at the commit linked above, including `MessagePhase` and `ResponseItem::Message`, and read the complete OpenClaw conversation-turn collector. Absent or conflicting phase remains unknown; only explicit commentary is suppressed. The existing collector likewise excludes explicit commentary and retains unknown-phase text. The rank-up request for direct contract verification is therefore addressed without changing protocol behavior.

The automated “serialized state” surface warning does not identify a data-model change here: terminal JSON is parsed display text, and raw JSONL remains the existing diagnostic log artifact with the same payload fields. No runtime store, schema version, durable record shape or migration changes. The timestamp/factory-error differences are disclosed above.

Exact-head [CI run 33304193653](https://github.com/openclaw/openclaw/actions/runs/33304193653) is green, and all current checks are complete without failures. Fresh P0–P3 automated review, independent owner review, published-head tests/build and real Gateway proof are complete. No accepted actionable finding remains.
