### PR TITLE
fix(normalization-core): support Date, RegExp, Set, and Map in stableStringify

### DIFF
--- a/packages/normalization-core/src/stable-stringify.test.ts
+++ b/packages/normalization-core/src/stable-stringify.test.ts
@@ -69,6 +69,32 @@ describe("stableStringify", () => {
     expect(stableStringify(malformed, sanitizeSurrogates)).toBe('{"b":1,"ba":2}');
   });
 
+  it("serializes Date instances to ISO 8601 strings and handles Invalid Date", () => {
+    const validDate = new Date("2026-01-01T00:00:00.000Z");
+    const invalidDate = new Date(Number.NaN);
+    expect(stableStringify(validDate)).toBe('"2026-01-01T00:00:00.000Z"');
+    expect(stableStringify(invalidDate)).toBe("null");
+    expect(stableStringify({ date: validDate })).toBe('{"date":"2026-01-01T00:00:00.000Z"}');
+    expect(stableStringify({ date: invalidDate })).toBe('{"date":null}');
+  });
+
+  it("serializes RegExp, Set, and Map collections deterministically", () => {
+    expect(stableStringify(/abc/gi)).toBe('"/abc/gi"');
+
+    const set1 = new Set([3, 1, 2]);
+    const set2 = new Set([1, 2, 3]);
+    expect(stableStringify(set1)).toBe("[1,2,3]");
+    expect(stableStringify(set1)).toBe(stableStringify(set2));
+
+    const map = new Map<unknown, unknown>([
+      [1, "number-one"],
+      ["1", "string-one"],
+      ["z", 2],
+      ["a", 1],
+    ]);
+    expect(stableStringify(map)).toBe('[["1","string-one"],["a",1],["z",2],[1,"number-one"]]');
+  });
+
   it("serializes cache-trace edge types deterministically", () => {
     const error = new Error("boom");
     error.stack = "Error: boom\n    at test";
@@ -76,6 +102,7 @@ describe("stableStringify", () => {
     expect(
       stableStringify({
         bytes: new Uint8Array([1, 2, 3]),
+        date: new Date("2026-01-01T00:00:00.000Z"),
         error,
         finite: 1,
         infinity: Infinity,
@@ -85,7 +112,7 @@ describe("stableStringify", () => {
         undef: undefined,
       }),
     ).toBe(
-      '{"bytes":{"data":"AQID","type":"Uint8Array"},"error":{"message":"boom","name":"Error","stack":"Error: boom\\n    at test"},"finite":1,"infinity":"Infinity","nan":"NaN","nil":null,"token":"123","undef":undefined}',
+      '{"bytes":{"data":"AQID","type":"Uint8Array"},"date":"2026-01-01T00:00:00.000Z","error":{"message":"boom","name":"Error","stack":"Error: boom\\n    at test"},"finite":1,"infinity":"Infinity","nan":"NaN","nil":null,"token":"123","undef":undefined}',
     );
   });
 });

--- a/packages/normalization-core/src/stable-stringify.ts
+++ b/packages/normalization-core/src/stable-stringify.ts
@@ -1,7 +1,7 @@
 /**
  * Stable stringify helper.
  * Serializes arbitrary values with deterministic key ordering and explicit
- * handling for errors, binary data, bigint, non-finite numbers, and cycles.
+ * handling for dates, errors, binary data, collections, bigint, non-finite numbers, and cycles.
  */
 
 type StableStringNormalizer = (value: string) => string;
@@ -53,6 +53,14 @@ function stringifyObjectValue(
   stack: WeakSet<object>,
   normalizeString: StableStringNormalizer,
 ): string {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime())
+      ? "null"
+      : JSON.stringify(normalizeString(value.toISOString()));
+  }
+  if (value instanceof RegExp) {
+    return JSON.stringify(normalizeString(value.toString()));
+  }
   if (value instanceof Error) {
     return stringifyStableValue(
       {
@@ -80,6 +88,32 @@ function stringifyObjectValue(
       serializedEntries.push(stringifyStableValue(entry, stack, normalizeString));
     }
     return `[${serializedEntries.join(",")}]`;
+  }
+  if (value instanceof Set) {
+    const serializedEntries: string[] = [];
+    for (const entry of value) {
+      serializedEntries.push(stringifyStableValue(entry, stack, normalizeString));
+    }
+    serializedEntries.sort(compareStableStrings);
+    return `[${serializedEntries.join(",")}]`;
+  }
+  if (value instanceof Map) {
+    const entries: Array<{ keySerialized: string; valueSerialized: string }> = [];
+    for (const [k, v] of value.entries()) {
+      entries.push({
+        keySerialized: stringifyStableValue(k, stack, normalizeString),
+        valueSerialized: stringifyStableValue(v, stack, normalizeString),
+      });
+    }
+    entries.sort(
+      (left, right) =>
+        compareStableStrings(left.keySerialized, right.keySerialized) ||
+        compareStableStrings(left.valueSerialized, right.valueSerialized),
+    );
+    const serializedPairs = entries.map(
+      ({ keySerialized, valueSerialized }) => `[${keySerialized},${valueSerialized}]`,
+    );
+    return `[${serializedPairs.join(",")}]`;
   }
   const record = value as Record<string, unknown>;
   if (normalizeString === preserveString) {


### PR DESCRIPTION
Fixes #133231

## What Problem This Solves
Fixes an edge-case defect where `stableStringify()` in `@openclaw/normalization-core` collapsed `Date`, `RegExp`, `Set`, and `Map` instances to empty objects `{}`.

Because `Object.keys()` on non-plain objects like `Date` or `RegExp` returns `[]`, passing any `Date` instance to `stableStringify` caused it to serialize as `{}`. This resulted in:
- Silent collisions in cache keys, session idempotency tokens, and configuration digests across different timestamps.
- Loss of ISO 8601 formatting consistency with standard `JSON.stringify()`.
- Invalid dates (`new Date(NaN)`) serializing as `{}` instead of `"null"`.
- `Set` and `Map` collections collapsing to `{}`.

### Changes & Review Findings Addressed
1. **`packages/normalization-core/src/stable-stringify.ts`**:
   - **Date Serialization**: Returns ISO 8601 string (`normalizeString(value.toISOString())`) for valid timestamps, `"null"` for `Invalid Date`.
   - **RegExp Serialization**: Returns regex literal string notation.
   - **Set Canonicalization**: Serializes elements and sorts their canonical string representations (`compareStableStrings`), ensuring equal-member Sets constructed in different insertion orders produce identical fingerprints.
   - **Map Type-Preserving Serialization**: Serializes entries as sorted `[[key, value], ...]` pairs with full type fidelity, preventing key coercion collisions (e.g. numeric `1` vs string `"1"`).
2. **`packages/normalization-core/src/stable-stringify.test.ts`**:
   - Added regression tests for valid and invalid `Date` instances.
   - Added regression test for `RegExp`.
   - Added regression test for opposite-order `Set` construction equality (`new Set([3, 1, 2])` vs `new Set([1, 2, 3])`).
   - Added regression test for type-preserving `Map` keys containing both numeric `1` and string `"1"`.
3. **Clean Refactor & Scope Boundary**:
   - Rebased cleanly atop `main`.
   - Removed all unrelated diffs (including workflow and test fixtures outside this component) so the PR strictly touches only `@openclaw/normalization-core`.

## Evidence
- **Public Serializer Output (`@openclaw/normalization-core` export)**:
  ```
  $ node --input-type=module -e '
  import { stableStringify } from "./packages/normalization-core/dist/stable-stringify.mjs";

  console.log("=== @openclaw/normalization-core: stableStringify ===");
  console.log("1. Valid Date:       ", stableStringify(new Date("2026-01-01T00:00:00.000Z")));
  console.log("2. Invalid Date:     ", stableStringify(new Date(NaN)));
  console.log("3. RegExp:           ", stableStringify(/foo/gi));
  console.log("4. Set canonicalized:", stableStringify(new Set([3, 1, 2])));
  console.log("5. Set order equality:", stableStringify(new Set([3, 1, 2])) === stableStringify(new Set([1, 2, 3])));
  console.log("6. Map type-preserved:", stableStringify(new Map([[1, "numeric"], ["1", "string"], ["z", 2], ["a", 1]])));
  '
  === @openclaw/normalization-core: stableStringify ===
  1. Valid Date:        "2026-01-01T00:00:00.000Z"
  2. Invalid Date:      null
  3. RegExp:            "/foo/gi"
  4. Set canonicalized: [1,2,3]
  5. Set order equality: true
  6. Map type-preserved: [["1","string"],["a",1],["z",2],[1,"numeric"]]
  ```

- **Linter Output**:
  ```
  $ npx oxlint packages/normalization-core
  Found 0 warnings and 0 errors.
  Finished in 1.1s on 45 files with 230 rules using 8 threads.
  ```

- **Vitest Suite**:
  ```
  $ pnpm test packages/normalization-core/src/stable-stringify.test.ts
  ✓ packages/normalization-core/src/stable-stringify.test.ts (11 tests) 11 passed
  Test Files  1 passed (1)
       Tests  11 passed (11)
  ```
