### PR TITLE
fix(memory): preserve wiki corpus in direct agent scopes

### DIFF
--- a/src/agents/runtime-plugins.memory-corpus.integration.test.ts
+++ b/src/agents/runtime-plugins.memory-corpus.integration.test.ts
@@ -1,0 +1,76 @@
+// Verifies direct agent registry scopes retain root-owned memory corpus sidecars.
+import { afterAll, afterEach, expect, it } from "vitest";
+import { loadAndActivateRootPluginRegistry } from "../plugins/loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  makePluginLoaderTempDir,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "../plugins/loader.test-fixtures.js";
+import { listMemoryCorpusSupplements } from "../plugins/memory-state.js";
+import { withAgentPluginRegistry } from "./runtime-plugins.js";
+
+afterEach(() => {
+  resetPluginLoaderTestStateForTest();
+});
+
+afterAll(() => {
+  cleanupPluginLoaderFixturesForTest();
+});
+
+it("keeps a root-owned memory corpus sidecar in a direct agent registry", async () => {
+  useNoBundledPlugins();
+  const pluginId = "memory-corpus-sidecar";
+  const plugin = writePlugin({
+    id: pluginId,
+    body: `module.exports = {
+  id: ${JSON.stringify(pluginId)},
+  register(api) {
+    api.registerMemoryCorpusSupplement({
+      search: async () => [],
+      get: async () => null,
+    });
+  },
+};\n`,
+  });
+  const config = {
+    plugins: {
+      allow: [pluginId],
+      entries: { [pluginId]: { enabled: true } },
+      load: { paths: [plugin.dir] },
+    },
+  };
+  const workspaceDir = makePluginLoaderTempDir();
+  const root = loadAndActivateRootPluginRegistry({
+    cache: false,
+    config,
+    onlyPluginIds: [pluginId],
+    workspaceDir,
+  });
+
+  expect(root.memoryCorpusSupplements.map((entry) => entry.pluginId)).toEqual([pluginId]);
+  const rootSupplement = root.memoryCorpusSupplements[0]?.supplement;
+  await withAgentPluginRegistry({
+    config,
+    workspaceDir,
+    run: async () => {
+      expect(listMemoryCorpusSupplements().map((entry) => entry.pluginId)).toEqual([pluginId]);
+      expect(listMemoryCorpusSupplements()[0]?.supplement).toBe(rootSupplement);
+    },
+  });
+  await withAgentPluginRegistry({
+    config,
+    workspaceDir: makePluginLoaderTempDir(),
+    run: async () => {
+      expect(listMemoryCorpusSupplements()).toEqual([]);
+    },
+  });
+  await withAgentPluginRegistry({
+    config: { plugins: { enabled: false } },
+    workspaceDir,
+    run: async () => {
+      expect(listMemoryCorpusSupplements()).toEqual([]);
+    },
+  });
+});

--- a/src/agents/runtime-plugins.memory-corpus.integration.test.ts
+++ b/src/agents/runtime-plugins.memory-corpus.integration.test.ts
@@ -1,5 +1,9 @@
 // Verifies direct agent registry scopes retain root-owned memory corpus sidecars.
+import fs from "node:fs";
+import path from "node:path";
 import { afterAll, afterEach, expect, it } from "vitest";
+import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loadAndActivateRootPluginRegistry } from "../plugins/loader.js";
 import {
   cleanupPluginLoaderFixturesForTest,
@@ -8,7 +12,11 @@ import {
   useNoBundledPlugins,
   writePlugin,
 } from "../plugins/loader.test-fixtures.js";
-import { listMemoryCorpusSupplements } from "../plugins/memory-state.js";
+import {
+  buildMemoryPromptSection,
+  listMemoryCorpusSupplements,
+  prepareMemoryPromptSection,
+} from "../plugins/memory-state.js";
 import { withAgentPluginRegistry } from "./runtime-plugins.js";
 
 afterEach(() => {
@@ -19,14 +27,22 @@ afterAll(() => {
   cleanupPluginLoaderFixturesForTest();
 });
 
-it("keeps a root-owned memory corpus sidecar in a direct agent registry", async () => {
+it("keeps root-owned memory sidecars in a direct agent registry", async () => {
   useNoBundledPlugins();
   const pluginId = "memory-corpus-sidecar";
+  const configSchema = {
+    type: "object",
+    additionalProperties: false,
+    properties: { source: { type: "string" } },
+  };
   const plugin = writePlugin({
     id: pluginId,
+    configSchema,
     body: `module.exports = {
   id: ${JSON.stringify(pluginId)},
   register(api) {
+    api.registerMemoryPromptSupplement(() => ["runtime wiki guidance"]);
+    api.registerMemoryPromptPreparation(async () => ["runtime wiki digest"]);
     api.registerMemoryCorpusSupplement({
       search: async () => [],
       get: async () => null,
@@ -34,17 +50,23 @@ it("keeps a root-owned memory corpus sidecar in a direct agent registry", async 
   },
 };\n`,
   });
+  fs.writeFileSync(
+    path.join(plugin.dir, "openclaw.plugin.json"),
+    JSON.stringify({ id: pluginId, configSchema, contracts: { tools: ["corpus_probe"] } }),
+    "utf8",
+  );
   const config = {
     plugins: {
-      allow: [pluginId],
-      entries: { [pluginId]: { enabled: true } },
+      entries: { [pluginId]: { config: { source: "runtime" } } },
       load: { paths: [plugin.dir] },
     },
-  };
+  } satisfies OpenClawConfig;
   const workspaceDir = makePluginLoaderTempDir();
+  const rootConfig = applyPluginAutoEnable({ config, env: process.env }).config;
+  expect(rootConfig.plugins?.entries?.[pluginId]?.enabled).toBe(true);
   const root = loadAndActivateRootPluginRegistry({
     cache: false,
-    config,
+    config: rootConfig,
     onlyPluginIds: [pluginId],
     workspaceDir,
   });
@@ -57,6 +79,12 @@ it("keeps a root-owned memory corpus sidecar in a direct agent registry", async 
     run: async () => {
       expect(listMemoryCorpusSupplements().map((entry) => entry.pluginId)).toEqual([pluginId]);
       expect(listMemoryCorpusSupplements()[0]?.supplement).toBe(rootSupplement);
+      const promptParams = { availableTools: new Set(["memory_search"]) };
+      const prepared = await prepareMemoryPromptSection(promptParams);
+      expect(buildMemoryPromptSection(promptParams, prepared)).toEqual([
+        "runtime wiki guidance",
+        "runtime wiki digest",
+      ]);
     },
   });
   await withAgentPluginRegistry({

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -8,10 +8,14 @@ import {
 import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { extractPluginInstallRecordsFromInstalledPluginIndex } from "../plugins/installed-plugin-index-install-records.js";
 import { loadPluginRegistryHandle } from "../plugins/loader.js";
+import { adoptRuntimeMemoryCorpusSupplementRegistrations } from "../plugins/memory-state.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
-import { getActivePluginRegistry } from "../plugins/runtime.js";
+import {
+  getActivePluginRegistry,
+  getActivePluginRegistryWorkspaceDir,
+} from "../plugins/runtime.js";
 import {
   getPluginRuntimeGatewayRequestScope,
   withPluginRuntimeRegistryScope,
@@ -151,5 +155,14 @@ export async function withAgentPluginRegistry<T>(params: {
     config: params.config,
     workspaceDir: params.workspaceDir,
   });
-  return await withPluginRuntimeRegistryScope(pluginRegistry, params.run);
+  const activeRegistry = getActivePluginRegistry();
+  const scopedRegistry =
+    activeRegistry && getActivePluginRegistryWorkspaceDir() === resolveUserPath(params.workspaceDir)
+      ? adoptRuntimeMemoryCorpusSupplementRegistrations(
+          pluginRegistry,
+          activeRegistry,
+          params.config,
+        )
+      : pluginRegistry;
+  return await withPluginRuntimeRegistryScope(scopedRegistry, params.run);
 }

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -1,3 +1,4 @@
+import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { adoptRuntimeContextEngineRegistrations } from "../context-engine/registry.js";
 import {
@@ -8,7 +9,7 @@ import {
 import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { extractPluginInstallRecordsFromInstalledPluginIndex } from "../plugins/installed-plugin-index-install-records.js";
 import { loadPluginRegistryHandle } from "../plugins/loader.js";
-import { adoptRuntimeMemoryCorpusSupplementRegistrations } from "../plugins/memory-state.js";
+import { adoptRuntimeMemoryRegistrations } from "../plugins/memory-state.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
@@ -150,18 +151,33 @@ export async function withAgentPluginRegistry<T>(params: {
   if (getPluginRuntimeGatewayRequestScope()?.pluginRegistry) {
     return await params.run();
   }
+  const metadataSnapshot = normalizePluginsConfig(params.config.plugins).enabled
+    ? loadPluginMetadataSnapshot({
+        config: params.config,
+        env: process.env,
+        workspaceDir: params.workspaceDir,
+      })
+    : undefined;
   const pluginRegistry = loadAgentRuntimePluginRegistryHandle({
     basePluginIds: [],
     config: params.config,
+    ...(metadataSnapshot ? { metadataSnapshot } : {}),
     workspaceDir: params.workspaceDir,
   });
   const activeRegistry = getActivePluginRegistry();
   const scopedRegistry =
-    activeRegistry && getActivePluginRegistryWorkspaceDir() === resolveUserPath(params.workspaceDir)
-      ? adoptRuntimeMemoryCorpusSupplementRegistrations(
+    activeRegistry &&
+    metadataSnapshot &&
+    getActivePluginRegistryWorkspaceDir() === resolveUserPath(params.workspaceDir)
+      ? adoptRuntimeMemoryRegistrations(
           pluginRegistry,
           activeRegistry,
-          params.config,
+          applyPluginAutoEnable({
+            config: params.config,
+            env: process.env,
+            discovery: metadataSnapshot.discovery,
+            manifestRegistry: metadataSnapshot.manifestRegistry,
+          }).config,
         )
       : pluginRegistry;
   return await withPluginRuntimeRegistryScope(scopedRegistry, params.run);

--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -1,7 +1,7 @@
 // Covers plugin-backed memory state registration and reset behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  adoptRuntimeMemoryCorpusSupplementRegistrations,
+  adoptRuntimeMemoryRegistrations,
   buildMemoryPromptSection,
   clearMemoryPluginState,
   getMemoryCapabilityRegistration,
@@ -423,20 +423,26 @@ describe("memory plugin state", () => {
     ).resolves.toEqual([{ corpus: "wiki", path: "sources/alpha.md", score: 1, snippet: "x" }]);
   });
 
-  it("does not adopt a corpus supplement across conflicting plugin owners", () => {
+  it("does not adopt memory sidecars across conflicting plugin owners", () => {
     const supplement = { search: async () => [], get: async () => null };
+    const prepare = async () => ["runtime wiki digest"];
+    const builder = () => ["runtime wiki guidance"];
     const root = createEmptyPluginRegistry();
     root.plugins.push(createPluginRecord({ id: "memory-wiki", source: "/root/wiki.js" }));
     root.memoryCorpusSupplements.push({ pluginId: "memory-wiki", supplement });
+    root.memoryPromptPreparations.push({ pluginId: "memory-wiki", prepare });
+    root.memoryPromptSupplements.push({ pluginId: "memory-wiki", builder });
     const scoped = createEmptyPluginRegistry();
     scoped.plugins.push(createPluginRecord({ id: "memory-wiki", source: "/shadow/wiki.js" }));
 
     expect(
-      adoptRuntimeMemoryCorpusSupplementRegistrations(scoped, root, {
+      adoptRuntimeMemoryRegistrations(scoped, root, {
         plugins: { allow: ["memory-wiki"], entries: { "memory-wiki": { enabled: true } } },
       }),
     ).toBe(scoped);
     expect(scoped.memoryCorpusSupplements).toEqual([]);
+    expect(scoped.memoryPromptPreparations).toEqual([]);
+    expect(scoped.memoryPromptSupplements).toEqual([]);
   });
 
   it("clearMemoryPluginState resets both registries", () => {

--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -1,6 +1,7 @@
 // Covers plugin-backed memory state registration and reset behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  adoptRuntimeMemoryCorpusSupplementRegistrations,
   buildMemoryPromptSection,
   clearMemoryPluginState,
   getMemoryCapabilityRegistration,
@@ -19,6 +20,7 @@ import {
 } from "./memory-state.test-fixtures.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import { withPluginRegistrationContext } from "./runtime.js";
+import { createPluginRecord } from "./status.test-helpers.js";
 
 function createMemoryRuntime() {
   return {
@@ -419,6 +421,22 @@ describe("memory plugin state", () => {
     await expect(
       listMemoryCorpusSupplements()[0]?.supplement.search({ query: "alpha" }),
     ).resolves.toEqual([{ corpus: "wiki", path: "sources/alpha.md", score: 1, snippet: "x" }]);
+  });
+
+  it("does not adopt a corpus supplement across conflicting plugin owners", () => {
+    const supplement = { search: async () => [], get: async () => null };
+    const root = createEmptyPluginRegistry();
+    root.plugins.push(createPluginRecord({ id: "memory-wiki", source: "/root/wiki.js" }));
+    root.memoryCorpusSupplements.push({ pluginId: "memory-wiki", supplement });
+    const scoped = createEmptyPluginRegistry();
+    scoped.plugins.push(createPluginRecord({ id: "memory-wiki", source: "/shadow/wiki.js" }));
+
+    expect(
+      adoptRuntimeMemoryCorpusSupplementRegistrations(scoped, root, {
+        plugins: { allow: ["memory-wiki"], entries: { "memory-wiki": { enabled: true } } },
+      }),
+    ).toBe(scoped);
+    expect(scoped.memoryCorpusSupplements).toEqual([]);
   });
 
   it("clearMemoryPluginState resets both registries", () => {

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -3,6 +3,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { filterStringEntries } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { normalizePluginsConfig, resolveEffectivePluginActivationState } from "./config-state.js";
 import type {
   MemoryCorpusSupplement,
   MemoryCorpusSupplementRegistration,
@@ -18,6 +19,7 @@ import type {
   MemoryPromptSupplementRegistration,
   PreparedMemoryPromptSection,
 } from "./registry-contribution-types.js";
+import type { PluginRegistry } from "./registry-types.js";
 import { requireActivePluginRegistry, resolveDirectPluginRegistrationOwner } from "./runtime.js";
 
 const log = createSubsystemLogger("plugins/memory-state");
@@ -99,6 +101,45 @@ export function getMemoryCapabilityRegistration(): MemoryPluginCapabilityRegistr
 
 export function listMemoryCorpusSupplements(): MemoryCorpusSupplementRegistration[] {
   return [...requireActivePluginRegistry().memoryCorpusSupplements];
+}
+
+/** Copies root-owned corpus supplements into a same-workspace scoped registry. */
+export function adoptRuntimeMemoryCorpusSupplementRegistrations(
+  targetRegistry: PluginRegistry,
+  runtimeRegistry: PluginRegistry,
+  config: OpenClawConfig,
+): PluginRegistry {
+  const normalizedConfig = normalizePluginsConfig(config.plugins);
+  const supplements = [...targetRegistry.memoryCorpusSupplements];
+  let changed = false;
+  for (const registration of runtimeRegistry.memoryCorpusSupplements) {
+    if (supplements.some((candidate) => candidate.pluginId === registration.pluginId)) {
+      continue;
+    }
+    const targetOwner = targetRegistry.plugins.find(
+      (plugin) => plugin.id === registration.pluginId,
+    );
+    const runtimeOwner = runtimeRegistry.plugins.find(
+      (plugin) => plugin.id === registration.pluginId,
+    );
+    if (
+      runtimeOwner?.status !== "loaded" ||
+      !resolveEffectivePluginActivationState({
+        id: runtimeOwner.id,
+        origin: runtimeOwner.origin,
+        config: normalizedConfig,
+        rootConfig: config,
+        enabledByDefault: runtimeOwner.activationSource === "default",
+      }).enabled ||
+      (targetOwner &&
+        (targetOwner.status !== "loaded" || targetOwner.source !== runtimeOwner.source))
+    ) {
+      continue;
+    }
+    supplements.push(registration);
+    changed = true;
+  }
+  return changed ? { ...targetRegistry, memoryCorpusSupplements: supplements } : targetRegistry;
 }
 export function registerMemoryPromptSupplement(
   requestedPluginId: string,

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -103,25 +103,36 @@ export function listMemoryCorpusSupplements(): MemoryCorpusSupplementRegistratio
   return [...requireActivePluginRegistry().memoryCorpusSupplements];
 }
 
-/** Copies root-owned corpus supplements into a same-workspace scoped registry. */
-export function adoptRuntimeMemoryCorpusSupplementRegistrations(
+function adoptEligibleRuntimeMemoryRegistrations<T extends { pluginId: string }>(
+  target: T[],
+  runtime: readonly T[],
+  canAdopt: (pluginId: string) => boolean,
+): T[] {
+  const pluginIds = new Set(target.map((registration) => registration.pluginId));
+  let adopted: T[] | undefined;
+  for (const registration of runtime) {
+    if (pluginIds.has(registration.pluginId) || !canAdopt(registration.pluginId)) {
+      continue;
+    }
+    (adopted ??= [...target]).push(registration);
+    pluginIds.add(registration.pluginId);
+  }
+  return adopted ?? target;
+}
+
+/**
+ * Discovery scopes cannot safely rerun full memory plugin setup.
+ * Reuse exact root sidecars only while activation and source ownership still match.
+ */
+export function adoptRuntimeMemoryRegistrations(
   targetRegistry: PluginRegistry,
   runtimeRegistry: PluginRegistry,
   config: OpenClawConfig,
 ): PluginRegistry {
   const normalizedConfig = normalizePluginsConfig(config.plugins);
-  const supplements = [...targetRegistry.memoryCorpusSupplements];
-  let changed = false;
-  for (const registration of runtimeRegistry.memoryCorpusSupplements) {
-    if (supplements.some((candidate) => candidate.pluginId === registration.pluginId)) {
-      continue;
-    }
-    const targetOwner = targetRegistry.plugins.find(
-      (plugin) => plugin.id === registration.pluginId,
-    );
-    const runtimeOwner = runtimeRegistry.plugins.find(
-      (plugin) => plugin.id === registration.pluginId,
-    );
+  const canAdopt = (pluginId: string) => {
+    const targetOwner = targetRegistry.plugins.find((plugin) => plugin.id === pluginId);
+    const runtimeOwner = runtimeRegistry.plugins.find((plugin) => plugin.id === pluginId);
     if (
       runtimeOwner?.status !== "loaded" ||
       !resolveEffectivePluginActivationState({
@@ -134,12 +145,35 @@ export function adoptRuntimeMemoryCorpusSupplementRegistrations(
       (targetOwner &&
         (targetOwner.status !== "loaded" || targetOwner.source !== runtimeOwner.source))
     ) {
-      continue;
+      return false;
     }
-    supplements.push(registration);
-    changed = true;
-  }
-  return changed ? { ...targetRegistry, memoryCorpusSupplements: supplements } : targetRegistry;
+    return true;
+  };
+  const memoryCorpusSupplements = adoptEligibleRuntimeMemoryRegistrations(
+    targetRegistry.memoryCorpusSupplements,
+    runtimeRegistry.memoryCorpusSupplements,
+    canAdopt,
+  );
+  const memoryPromptPreparations = adoptEligibleRuntimeMemoryRegistrations(
+    targetRegistry.memoryPromptPreparations,
+    runtimeRegistry.memoryPromptPreparations,
+    canAdopt,
+  );
+  const memoryPromptSupplements = adoptEligibleRuntimeMemoryRegistrations(
+    targetRegistry.memoryPromptSupplements,
+    runtimeRegistry.memoryPromptSupplements,
+    canAdopt,
+  );
+  return memoryCorpusSupplements === targetRegistry.memoryCorpusSupplements &&
+    memoryPromptPreparations === targetRegistry.memoryPromptPreparations &&
+    memoryPromptSupplements === targetRegistry.memoryPromptSupplements
+    ? targetRegistry
+    : {
+        ...targetRegistry,
+        memoryCorpusSupplements,
+        memoryPromptPreparations,
+        memoryPromptSupplements,
+      };
 }
 export function registerMemoryPromptSupplement(
   requestedPluginId: string,


### PR DESCRIPTION
## What Problem This Solves

Fixes #133196.

A direct agent turn could bind an empty-base request plugin registry while the active same-workspace Gateway registry still owned a healthy `memory-wiki` runtime. `memory_search` then reported `wiki: not-registered` even though the plugin, vault, and wiki CLI remained healthy.

The first submitted fix copied only the corpus registration. It still dropped the wiki prompt registrations and rejected plugins that canonical config processing had enabled automatically.

## Why This Change Was Made

Direct agent scopes now reuse the active root's exact memory sidecar objects without rerunning plugin registration code.

The handoff preserves all three sidecar types registered together by `memory-wiki`:

- synchronous prompt guidance;
- prepared prompt context;
- corpus search and read.

The boundary stays narrow:

- require the same resolved workspace;
- require a loaded root owner;
- honor canonical auto-enable, global disablement, allow/deny policy, entry disablement, workspace defaults, and bundled defaults;
- reject a conflicting scoped plugin source;
- preserve existing request-scoped registrations.

The direct binder carries its prepared metadata snapshot into the activation check. This avoids a second metadata lookup and keeps plugin policy in the existing activation owner.

## User Impact

Configured wiki search and wiki prompt guidance remain available in direct agent turns whenever the active same-workspace runtime owns the wiki sidecars. Explicitly disabled, differently scoped, or shadowed plugins remain unavailable.

There is no configuration, schema, SDK, vault-data, or migration change.

## Evidence

- **Current-main red:** exact `be67a8bdf62e04cd3ae4cc531371c5e8e582f390` loaded the real bundled `memory-wiki` owner and its corpus registration, then returned `wiki: not-registered` through the production direct-agent binder and Memory Core corpus consumer. Current main has no later behavior change in the four owner files.
- **Submitted-head gap:** exact `8aad0f8f5ceb9f990e09c416ae4d10698a0e33bf` fixed an explicitly enabled corpus, but a config-driven auto-enabled wiki still returned `not-registered` and the direct prompt omitted `Compiled Wiki`.
- **Exact-head green:** exact `760e505b29edb8b6c7a5aa11935d9a61777c0c20` returned `sources/runtime-proof.md` for a unique query and included `Compiled Wiki` in the direct prompt. Global plugin disablement and another workspace both remained `not-registered`.
- **Regression proof:** the owner integration test failed before the repair because the direct scope returned no wiki prompt lines. The final test covers config-driven auto-enablement, exact root object identity, all three sidecar types, workspace isolation, global disablement, and conflicting-source rejection.
- **Focused tests:** 39 test executions passed across `runtime-plugins.memory-corpus.integration.test.ts`, `runtime-plugins.test.ts`, and `memory-state.test.ts`.
- **Sibling proof:** context-engine and widget-presenter adoption suites passed before the final source-preserving simplification; the final runtime registry suite covers their composition calls.
- **Static checks:** Oxfmt, type-aware Oxlint, deprecated API, plugin boundary, coercion helper, runtime-sidecar loader, import-cycle, conflict-marker, and diff-integrity checks passed. Hosted CI owns the full build and TypeScript checks.
- **Production shape:** source `+106/-2` (net `+104`); tests `+128/-0`. The growth defines one exact owner handoff for three runtime-only sidecar classes plus canonical activation. An attempted reuse of the normal plugin load plan was rejected because it reran plugin registration and broke exact root-object identity.

AI-assisted: yes (Codex).
