### PR TITLE
fix(ci): tolerate elapsed node timeout budget

### DIFF
--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -310,9 +310,12 @@ describe("applyPluginNodeInvokePolicy", () => {
       });
 
       expect(result).toMatchObject({ ok: true });
-      expect(invoke).toHaveBeenCalledWith(
-        expect.objectContaining({ timeoutMs: 250, signal: controller.signal }),
-      );
+      const request = invoke.mock.calls[0]?.[0] as
+        | { timeoutMs?: number; signal?: AbortSignal }
+        | undefined;
+      expect(request?.signal).toBe(controller.signal);
+      expect(request?.timeoutMs).toBeGreaterThan(0);
+      expect(request?.timeoutMs).toBeLessThanOrEqual(250);
     },
   );
 


### PR DESCRIPTION
Closes #133235

## What Problem This Solves

The node invoke policy test required an exact forwarded timeout of `250ms`. The readiness wrapper legitimately recomputes the remaining deadline immediately before transport dispatch, so elapsed wall-clock time can reduce that value to `249ms` and fail CI while production remains correct.

## Why This Change Was Made

The test now asserts the actual owner invariant:

- the original abort signal is preserved;
- the forwarded timeout remains positive;
- the forwarded timeout does not exceed the `250ms` invocation budget.

Exact deadline accounting remains covered by the sibling fake-timer readiness tests.

## User Impact

No production behavior changes. This removes a confirmed timing race from normal CI without weakening timeout-budget coverage.

## Evidence

- Pre-fix proof: PR #133133 run 33302304863, job 99232718394 observed `249` while the test required `250`.
- Owner suite: 33/33 passed.
- Exact deadline sibling cases: 2/2 passed.
- Formatting, oxlint, boundary check, temp-dir check, and `git diff --check`: passed.
- P0-P2 autoreview: scoped-clean.
- Production LOC: +0/-0.
- Test LOC: +6/-3.
- Full changed gate: partial because the sparse worktree lacks `ui/config`, blocking dead-export and `tsgo:core:test`; exact-head CI is pending.
