### PR TITLE
feat(vault): show selected provider alias in status

### DIFF
--- a/extensions/onepassword/src/secret-ref-cli.test.ts
+++ b/extensions/onepassword/src/secret-ref-cli.test.ts
@@ -45,6 +45,14 @@ async function runStatus(
   return JSON.parse(output()) as Record<string, unknown>;
 }
 
+async function runStatusOutput(config: OpenClawConfig, args: string[] = []): Promise<string> {
+  const output = captureStdout();
+  await createProgram(config).parseAsync(["onepassword", "secretref", "status", ...args], {
+    from: "user",
+  });
+  return output();
+}
+
 async function runSetup(planPath: string, args: string[]): Promise<string> {
   const output = captureStdout();
   await createProgram().parseAsync(
@@ -297,6 +305,26 @@ describe("1Password readiness", () => {
 });
 
 describe("1Password CLI status", () => {
+  it("shows the selected provider alias in human-readable output", async () => {
+    const output = await runStatusOutput(
+      {
+        secrets: {
+          providers: Object.fromEntries(
+            ["corp-onepassword", "prod-onepassword"].map((alias) => [
+              alias,
+              {
+                source: "exec",
+                pluginIntegration: { pluginId: "onepassword", integrationId: "onepassword" },
+              },
+            ]),
+          ),
+        },
+      },
+      ["--provider-alias", "corp-onepassword"],
+    );
+    expect(output).toContain("Provider alias: corp-onepassword");
+  });
+
   it("discovers a configured custom provider alias", async () => {
     const result = await runStatus({
       secrets: {

--- a/extensions/onepassword/src/secret-ref-cli.ts
+++ b/extensions/onepassword/src/secret-ref-cli.ts
@@ -159,6 +159,7 @@ async function runStatus(
   writeLine(
     `1Password provider: ${providerReady ? "ready" : provider.configured ? "misconfigured" : "not configured"}`,
   );
+  writeLine(`Provider alias: ${providerAlias}`);
   if (provider.source) {
     writeLine(`Source: ${provider.source}`);
   }

--- a/extensions/vault/src/cli.test.ts
+++ b/extensions/vault/src/cli.test.ts
@@ -52,19 +52,26 @@ async function runSetup(planPath: string, args: string[]): Promise<string> {
   }
 }
 
+async function runStatusOutput(
+  config: Record<string, unknown>,
+  args: string[] = [],
+): Promise<string> {
+  const stdout = captureStdout();
+  try {
+    await createProgram(config).parseAsync(["vault", "status", ...args], {
+      from: "user",
+    });
+    return stdout.output();
+  } finally {
+    stdout.restore();
+  }
+}
+
 async function runStatus(
   config: Record<string, unknown>,
   args: string[] = [],
 ): Promise<Record<string, unknown>> {
-  const stdout = captureStdout();
-  try {
-    await createProgram(config).parseAsync(["vault", "status", "--json", ...args], {
-      from: "user",
-    });
-    return JSON.parse(stdout.output()) as Record<string, unknown>;
-  } finally {
-    stdout.restore();
-  }
+  return JSON.parse(await runStatusOutput(config, ["--json", ...args])) as Record<string, unknown>;
 }
 
 afterEach(() => {
@@ -227,6 +234,26 @@ describe("vault CLI setup plan", () => {
 });
 
 describe("vault CLI status", () => {
+  it("shows the selected provider alias in human-readable output", async () => {
+    const output = await runStatusOutput(
+      {
+        secrets: {
+          providers: Object.fromEntries(
+            ["corp-vault", "prod-vault"].map((alias) => [
+              alias,
+              {
+                source: "exec",
+                pluginIntegration: { pluginId: "vault", integrationId: "vault" },
+              },
+            ]),
+          ),
+        },
+      },
+      ["--provider-alias", "corp-vault"],
+    );
+    expect(output).toContain("Provider alias: corp-vault");
+  });
+
   it("discovers a configured custom Vault provider alias", async () => {
     const result = await runStatus({
       secrets: {

--- a/extensions/vault/src/cli.ts
+++ b/extensions/vault/src/cli.ts
@@ -100,6 +100,7 @@ async function runStatus(config: OpenClawConfig, options: StatusOptions): Promis
     return;
   }
   writeLine(`Vault provider: ${provider.configured ? "configured" : "not configured"}`);
+  writeLine(`Provider alias: ${providerAlias}`);
   if (provider.source) {
     writeLine(`Source: ${provider.source}`);
   }


### PR DESCRIPTION
Closes #133227

## What Problem This Solves

Vault and 1Password human-readable SecretRef status commands did not confirm the selected provider alias. Operators with custom or multiple aliases had to repeat the command with --json to inspect that existing canonical field.

## Why This Change Was Made

Each plugin now prints the providerAlias already returned by the shared inspectProvider owner, after its JSON early return. Both Commander tests configure two providers and explicitly select a non-default alias. Shared selection, ambiguity checks, readiness inspection, and credential handling remain unchanged.

Existing-solutions preflight: JSON exposes the field but does not make the documented default text command self-confirming. No additional plugin, configuration, or library is needed. The existing Vault --provider-alias documentation remains accurate.

## User Impact

Vault status prints `Provider alias: corp-vault`; 1Password SecretRef status prints `Provider alias: corp-onepassword` when those aliases are selected. This is one additive text line in each owner. JSON, defaults, protocol, persistence, authentication, resolver execution, and redaction do not change. No secret value is printed.

## Evidence

- Current PR head: `8623840d4a8dce0ebfe7ef881c7eea48a1959061`; frozen rebase baseline: `c4052ca628ac0e1026b82c10d7d80a5ebd8aaff9`.
- Scope: 4 files. Production +2/-0; tests +59/-4. No generated, lockfile, config, or schema changes.
- The original Vault test-only acceptance-red failed because the selected-alias line was absent. Its after-fix status suite passed 5 tests. Those original receipts refer to `f325a5919d8ff2ec1db77bf69edae946260b2766`, not the latest rebased head.
- Both current command-level tests exercise the real Commander registration. Latest durable review found no code findings and identified only the missing sibling 1Password CLI proof and stale scope description.
- [CI run 33935750549](https://github.com/openclaw/openclaw/actions/runs/33935750549) completed successfully for PR head `8623840d4a8dce0ebfe7ef881c7eea48a1959061`.

### 1Password Production CLI Readback, September 5

Artifact provenance: that CI run produced `dist-runtime-build`, artifact `9960201353`. Embedded build metadata is the CI merge/build commit `bd8191ae1e989c4e274011894618d258630ee796`, not the PR commit. This is a CI merge-build receipt for the submitted head, not an independently rebuilt exact-head package.

The runtime artifact was restored beside the tracked launcher. Node 24.15.0 ran the normal launcher with isolated OPENCLAW_HOME, OPENCLAW_STATE_DIR, and OPENCLAW_CONFIG_PATH. The fixture enabled onepassword and configured two exec/pluginIntegration providers, corp-onepassword and backup-onepassword. It contained no credentials. The final launcher run did not disable native filesystem safety.

```text
node <isolated-package>/openclaw.mjs --no-color onepassword secretref status --provider-alias corp-onepassword

1Password provider: ready
Provider alias: corp-onepassword
Source: exec
Plugin integration: onepassword:onepassword
op command: op
op status: untrusted
token file: missing-or-unsafe
prerequisites ready: no
ready: no
```

Exit status: 0. The provider configuration was recognized and the explicitly selected alias was read back. Missing trusted op/credentials correctly kept operational readiness false. This proves the CLI display change, not secret resolution or a live 1Password account. No resolver, provider request, real channel message, or production configuration change occurred. No proof asset was committed.

### Historical Vault CLI Receipt

The August 30 normal-launcher proof used CI run `33304782698`, artifact `9730136270`, for historical head `f325a5919d8ff2ec1db77bf69edae946260b2766`. With two isolated providers and no Vault credentials or endpoints, it exited 0 and printed:

```text
Vault provider: configured
Provider alias: corp-vault
Source: exec
Plugin integration: vault:vault
VAULT_ADDR: not set
VAULT_TOKEN: not set
VAULT_TOKEN_FILE: not set
```

This existing receipt remains historical; no current-head Vault rerun is claimed. Known limitation: this PR adds alias display in these two text status commands only; it does not establish either provider's operational readiness. AI assistance was used for implementation, review, and verification.


<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":2,"user":1,"assistant":1,"toolCalls":0,"toolOutputsDropped":0,"web":0,"redactions":1,"omittedUnsafe":0,"rawEntries":7}

[user]
[instructions recap omitted; policy/config text, not task dialogue]

[assistant]
我先按贡献工作流加载 `contrib-playbook`，并因任务涉及 OpenClaw issue/PR 全状态核验加载 `openclaw-pr-maintainer`。本轮严格只读；会避开被禁止的两个编号，也不会写文件或 GitHub。

目标仓库当前有两处既存未跟踪缓存，且 checkout 落后；任务指定的 `upstream/main` 正好是 `039187abe`。因“不得写文件”优先，我不会执行 playbook 要求的 pull/sync，只读取现有规则和该固定提交；候选检索会用本地 Gitcrawl 后再以 live `gh` 只读核验。接下来补读 `gitcrawl` 与 `clawdtributor`，后者直接覆盖全状态发现和贡献者重叠检查。

本次归入“预排/探索线”：只做候选发现与去重，不认领、不实现。skill 的战场同步会改状态库，已按只读约束跳过；我改用现有 candidates/tracks、固定 SHA 代码、Gitcrawl 缓存和 live GitHub 四层交叉核验。

四个样本已抽象出共同形状：事实已由 canonical owner 产生，JSON/协议/持久化路径可读，缺口仅在既有 CLI/UI projection；修复点通常 1–2 行，测试落在同一 owner。现在我会从固定 SHA 的 status/list/info renderers 反向找“输入类型字段有、默认文本未消费”的差集，再逐个淘汰需要新契约或产品选择的项。

初筛剩下三个可继续取证的差集：Vault status 未显示实际 provider alias；Fleet status 未显示已解析的 container runtime；Memory Wiki status 收到 `obsidianCli.enabled` 却只显示 binary availability/requested，禁用时可把“可用”误读为“已启用”。我正在做最后的全状态 issue/PR/claim 与 Leon/Alix 文件 footprint 核验；任一已有 claim 或 owner outcome 不够强就降级，不为凑数保留。

A 级通过：1 个。

- **Vault status 显示实际 provider alias**
  - Gap：`extensions/vault/src/cli.ts:77` 已由 `inspectProvider` 得到 canonical `providerAlias`，JSON 在 `extensions/vault/src/cli.ts:82` 保留它；默认文本从 `extensions/vault/src/cli.ts:102` 起完全丢弃。多 Vault provider 时 CLI 甚至要求 `--provider-alias`，但回显不确认选中了哪个 alias。
  - 形状：`extensions/vault/src/cli.ts`、`extensions/vault/src/cli.test.ts`，2 files；预计 production +1 行，test 小幅增加。无 config/protocol/schema/default/persistence/permission/security 变化。
  - Acceptance-red：现有真实 Commander harness 配置 `corp-vault`，执行非 JSON `vault status --provider-alias corp-vault`，断言输出包含 alias；当前必红，`--json` 同场景已读回 `providerAlias: "corp-vault"`。
  - Real readback：隔离配置运行真实 `openclaw vault status
...[truncated 916 chars]
````

</details>
<!-- agent-transcript:end -->