### PR TITLE
fix(memory): report only failed index refreshes

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1590,7 +1590,6 @@ packages/memory-host-sdk/src/host/session-reset-recall.ts	3
 packages/memory-host-sdk/src/host/session-transcript-corpus.ts	1
 packages/memory-host-sdk/src/host/sqlite-vec.ts	3
 packages/memory-host-sdk/src/host/sqlite.ts	1
-packages/memory-host-sdk/src/host/types.ts	1
 packages/model-catalog-core/src/model-catalog-normalize.ts	6
 packages/model-catalog-core/src/model-catalog-types.ts	1
 packages/model-catalog-core/src/remote-catalog-bundle.ts	2

--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -80,11 +80,11 @@ openclaw memory search [query] [--query <text>] [--agent <id>] [--max-results <n
 - `--max-results <n>`: cap result count (positive integer).
 - `--min-score <n>`: filter out matches below this score.
 
-If the index remains dirty after the bounded search-time refresh, human output
-warns that matches may be incomplete. With `--json`, the response adds
-`stale: true`, plus `warning` and `action` fields describing how to rebuild the
-index. Treat an empty `results` array as authoritative only when `stale` is
-absent.
+Routine indexing can continue after search returns and does not add a warning.
+If automatic indexing failed, or the index identity is incompatible, human
+output warns that matches may be incomplete. With `--json`, the response adds
+`stale: true`, plus `warning` and `action` fields. Treat an empty `results`
+array as authoritative only when `stale` is absent.
 
 ## `memory forget`
 

--- a/extensions/memory-core/src/cli-status.runtime.ts
+++ b/extensions/memory-core/src/cli-status.runtime.ts
@@ -362,11 +362,6 @@ export async function runMemoryStatus(
       lines.push(`${label("Index identity")} ${warn(identityWarning.reason)}`);
       lines.push(`${label("Vector search")} ${warn("paused until memory is rebuilt")}`);
       lines.push(`${label("Fix")} ${muted(identityWarning.fix)}`);
-    } else if (status.lastSyncError) {
-      lines.push(`${label("Last sync error")} ${warn(status.lastSyncError)}`);
-      lines.push(
-        `${label("Fix")} ${muted(`Run: openclaw memory status --index --agent ${agentId}`)}`,
-      );
     }
     if (status.sourceCounts?.length) {
       lines.push(label("By source"));

--- a/extensions/memory-core/src/cli-status.runtime.ts
+++ b/extensions/memory-core/src/cli-status.runtime.ts
@@ -1,4 +1,7 @@
-import type { MemoryEmbeddingProbeResult } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import {
+  resolveMemoryIndexIdentityReason,
+  type MemoryEmbeddingProbeResult,
+} from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import {
   resolveMemoryLightDreamingConfig,
   resolveMemoryRemDreamingConfig,
@@ -62,12 +65,7 @@ function formatMemoryIndexIdentityWarning(
   reason: string;
   fix: string;
 } | null {
-  const indexIdentity = asNullableRecord(asNullableRecord(status.custom)?.indexIdentity);
-  const reason =
-    (indexIdentity?.status === "mismatched" || indexIdentity?.status === "missing") &&
-    typeof indexIdentity.reason === "string"
-      ? indexIdentity.reason
-      : undefined;
+  const reason = resolveMemoryIndexIdentityReason(status);
   if (!reason) {
     return null;
   }
@@ -364,6 +362,11 @@ export async function runMemoryStatus(
       lines.push(`${label("Index identity")} ${warn(identityWarning.reason)}`);
       lines.push(`${label("Vector search")} ${warn("paused until memory is rebuilt")}`);
       lines.push(`${label("Fix")} ${muted(identityWarning.fix)}`);
+    } else if (status.lastSyncError) {
+      lines.push(`${label("Last sync error")} ${warn(status.lastSyncError)}`);
+      lines.push(
+        `${label("Fix")} ${muted(`Run: openclaw memory status --index --agent ${agentId}`)}`,
+      );
     }
     if (status.sourceCounts?.length) {
       lines.push(label("By source"));

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -814,25 +814,6 @@ describe("memory cli", () => {
     expect(close).toHaveBeenCalled();
   });
 
-  it("prints the latest automatic sync failure", async () => {
-    const close = vi.fn(async () => {});
-    mockManager({
-      status: () =>
-        makeMemoryStatus({
-          dirty: true,
-          lastSyncError: "embedding request timed out",
-        }),
-      close,
-    });
-
-    const log = spyRuntimeLogs(defaultRuntime);
-    await runMemoryCli(["status"]);
-
-    expectLogged(log, "Last sync error: embedding request timed out");
-    expectLogged(log, "Fix: Run: openclaw memory status --index --agent main");
-    expect(close).toHaveBeenCalled();
-  });
-
   it("keeps plain status from probing vector or embeddings", async () => {
     const close = vi.fn(async () => {});
     const probeVectorAvailability = vi.fn(async () => {

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -814,6 +814,25 @@ describe("memory cli", () => {
     expect(close).toHaveBeenCalled();
   });
 
+  it("prints the latest automatic sync failure", async () => {
+    const close = vi.fn(async () => {});
+    mockManager({
+      status: () =>
+        makeMemoryStatus({
+          dirty: true,
+          lastSyncError: "embedding request timed out",
+        }),
+      close,
+    });
+
+    const log = spyRuntimeLogs(defaultRuntime);
+    await runMemoryCli(["status"]);
+
+    expectLogged(log, "Last sync error: embedding request timed out");
+    expectLogged(log, "Fix: Run: openclaw memory status --index --agent main");
+    expect(close).toHaveBeenCalled();
+  });
+
   it("keeps plain status from probing vector or embeddings", async () => {
     const close = vi.fn(async () => {});
     const probeVectorAvailability = vi.fn(async () => {
@@ -2076,7 +2095,7 @@ describe("memory cli", () => {
     });
   });
 
-  it("warns before reporting no matches from a dirty index", async () => {
+  it("does not warn before reporting no matches from routine pending work", async () => {
     const close = vi.fn(async () => {});
     mockManager({
       search: vi.fn(async () => []),
@@ -2088,9 +2107,7 @@ describe("memory cli", () => {
     const log = spyRuntimeLogs(defaultRuntime);
     await runMemoryCli(["search", "hidden codeword"]);
 
-    expect(error).toHaveBeenCalledWith(
-      "Memory index is dirty. Search results may be incomplete. Run: openclaw memory status --index --agent main",
-    );
+    expect(error).not.toHaveBeenCalled();
     expect(log).toHaveBeenCalledWith("No matches.");
   });
 

--- a/extensions/memory-core/src/memory-search-tool-query.ts
+++ b/extensions/memory-core/src/memory-search-tool-query.ts
@@ -1,13 +1,13 @@
 // Memory Core plugin module owns ranked search-window filtering and diagnostics.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import type {
-  MemorySearchManager,
-  MemorySearchRuntimeDebug,
-  MemorySource,
+import {
+  resolveMemoryIndexIdentityReason,
+  type MemorySearchManager,
+  type MemorySearchRuntimeDebug,
+  type MemorySource,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
-import { asNullableRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { filterMemorySearchHitsBySessionVisibility } from "./session-search-visibility.js";
 import { buildMemorySearchUnavailableResult } from "./tools.shared.js";
 
@@ -121,13 +121,7 @@ export async function executeMemorySearchToolQuery(params: {
   }
 
   const status = active.manager.status();
-  const indexIdentity = asNullableRecord(asNullableRecord(status.custom)?.indexIdentity);
-  const pausedIndexIdentityReason =
-    indexIdentity?.status === "mismatched" || indexIdentity?.status === "missing"
-      ? typeof indexIdentity.reason === "string" && indexIdentity.reason.trim()
-        ? indexIdentity.reason.trim()
-        : "memory index identity is missing or mismatched"
-      : undefined;
+  const pausedIndexIdentityReason = resolveMemoryIndexIdentityReason(status);
   if (pausedIndexIdentityReason) {
     return {
       status,

--- a/extensions/memory-core/src/memory-tool-manager.test-mocks.ts
+++ b/extensions/memory-core/src/memory-tool-manager.test-mocks.ts
@@ -27,7 +27,7 @@ type MemoryManagerParams = {
 
 let workspaceDir = "/workspace";
 let statusDirty = false;
-let pendingSyncSources: MemorySource[] | undefined;
+let lastSyncError: string | undefined;
 let customStatus: Record<string, unknown> | undefined;
 let sourceCounts: Array<{ source: MemorySource; files: number; chunks: number }> = [
   { source: "memory", files: 1, chunks: 1 },
@@ -57,7 +57,7 @@ const stubManager = {
     files: 1,
     chunks: 1,
     dirty: statusDirty,
-    pendingSyncSources,
+    lastSyncError,
     workspaceDir,
     dbPath: "/workspace/.memory/index.sqlite",
     provider: "builtin",
@@ -97,8 +97,8 @@ export function setMemoryStatusDirty(next: boolean): void {
   statusDirty = next;
 }
 
-export function setMemoryPendingSyncSources(next: MemorySource[] | undefined): void {
-  pendingSyncSources = next;
+export function setMemoryLastSyncError(next: string | undefined): void {
+  lastSyncError = next;
 }
 
 export function setMemorySourceCounts(
@@ -137,7 +137,7 @@ export function resetMemoryToolMockState(overrides?: {
 }): void {
   workspaceDir = "/workspace";
   statusDirty = false;
-  pendingSyncSources = undefined;
+  lastSyncError = undefined;
   customStatus = undefined;
   sourceCounts = [{ source: "memory", files: 1, chunks: 1 }];
   getManagerImpl = undefined;

--- a/extensions/memory-core/src/memory/manager-search-maintenance.ts
+++ b/extensions/memory-core/src/memory/manager-search-maintenance.ts
@@ -23,7 +23,7 @@ export async function runMemorySearchMaintenance<DirtyGeneration>(params: {
   }
   if (!manager) {
     params.restoreDirtyGeneration(dirtyGeneration);
-    return;
+    return undefined;
   }
 
   let maintenanceError: Error | undefined;

--- a/extensions/memory-core/src/memory/manager-search-maintenance.ts
+++ b/extensions/memory-core/src/memory/manager-search-maintenance.ts
@@ -3,7 +3,7 @@ import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 
 type MemorySearchMaintenanceManager = {
   sync(params: { reason: string; force: true }): Promise<void>;
-  status(): { dirty?: boolean };
+  status(): { dirty?: boolean; lastSyncError?: string };
   close(): Promise<void>;
 };
 
@@ -12,7 +12,7 @@ export async function runMemorySearchMaintenance<DirtyGeneration>(params: {
   takeDirtyGeneration: () => DirtyGeneration;
   restoreDirtyGeneration: (generation: DirtyGeneration) => void;
   acquireManager: () => Promise<MemorySearchMaintenanceManager | null>;
-}): Promise<void> {
+}): Promise<string | undefined> {
   const dirtyGeneration = params.takeDirtyGeneration();
   let manager: MemorySearchMaintenanceManager | null;
   try {
@@ -27,14 +27,17 @@ export async function runMemorySearchMaintenance<DirtyGeneration>(params: {
   }
 
   let maintenanceError: Error | undefined;
+  let incompleteReason: string | undefined;
   try {
     // The transient manager has no watcher state. Force every source represented
     // by the handed-off generation while the default manager serves published reads.
     await manager.sync({ reason: params.reason, force: true });
-    if (manager.status().dirty === true) {
+    const status = manager.status();
+    if (status.dirty === true) {
       // A provider fallback may deliberately resolve in keyword-only mode while
       // retaining retry state. Return that incomplete generation to its serving owner.
       params.restoreDirtyGeneration(dirtyGeneration);
+      incompleteReason = status.lastSyncError;
     }
   } catch (err) {
     params.restoreDirtyGeneration(dirtyGeneration);
@@ -48,4 +51,5 @@ export async function runMemorySearchMaintenance<DirtyGeneration>(params: {
   if (maintenanceError) {
     throw maintenanceError;
   }
+  return incompleteReason;
 }

--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -565,23 +565,6 @@ describe("memory index", () => {
     await pendingSync;
   });
 
-  it("reports session-only refreshes from the manager sync owner", async () => {
-    const manager = await getPersistentManager(
-      createCfg({ provider: "none", minScore: 0, onSearch: true, hybrid: { enabled: true } }),
-    );
-    await manager.sync({ reason: "test" });
-
-    Reflect.set(manager, "dirty", false);
-    Reflect.set(manager, "sessionsDirty", true);
-    Reflect.set(manager, "syncing", new Promise<void>(() => {}));
-    try {
-      expect(manager.status().pendingSyncSources).toEqual(["sessions"]);
-    } finally {
-      Reflect.set(manager, "syncing", null);
-      Reflect.set(manager, "sessionsDirty", false);
-    }
-  });
-
   it("keeps the published index searchable while dirty maintenance builds", async () => {
     providerFixture.forceNoProvider = true;
     const manager = await getPersistentManager(
@@ -624,10 +607,7 @@ describe("memory index", () => {
     try {
       const firstSearch = manager.search("zebra", { maxResults: 5, minScore: 0 });
       await maintenanceReady.promise;
-      expect(manager.status()).toMatchObject({
-        dirty: true,
-        pendingSyncSources: ["memory"],
-      });
+      expect(manager.status()).toMatchObject({ dirty: true });
 
       const publishedResults = await manager.search("zebra", { maxResults: 5, minScore: 0 });
       expect(publishedResults.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
@@ -764,6 +744,7 @@ describe("memory index", () => {
 
       expect(maintenance.sync).toHaveBeenCalledWith({ reason: "search", force: true });
       expect(maintenance.close).toHaveBeenCalledTimes(1);
+      expect(manager.status().lastSyncError).toContain("maintenance failed");
       expect(Reflect.get(manager, "dirty")).toBe(true);
       expect(Reflect.get(manager, "memoryFullRetryDirty")).toBe(true);
       expect(Reflect.get(manager, "sessionsDirty")).toBe(true);
@@ -771,6 +752,67 @@ describe("memory index", () => {
       expect(Reflect.get(manager, "sessionsReconcileDirty")).toBe(true);
       expect(Reflect.get(manager, "sessionsDirtyFiles")).toEqual(new Set(["session.jsonl"]));
     } finally {
+      getSpy.mockRestore();
+    }
+  });
+
+  it("clears a recorded sync failure after the next successful sync", async () => {
+    const manager = await getPersistentManager(
+      createCfg({ provider: "none", minScore: 0, onSearch: true, hybrid: { enabled: true } }),
+    );
+    await manager.sync({ reason: "baseline" });
+    const fields = manager as unknown as {
+      syncMemoryFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
+    };
+    const syncMemoryFiles = fields.syncMemoryFiles.bind(manager);
+    const syncSpy = vi
+      .spyOn(fields, "syncMemoryFiles")
+      .mockRejectedValueOnce(new Error("sync failed"));
+    Reflect.set(manager, "dirty", true);
+
+    await expect(manager.sync({ reason: "failure" })).rejects.toThrow("sync failed");
+    expect(manager.status().lastSyncError).toBe("sync failed");
+
+    syncSpy.mockImplementation(syncMemoryFiles);
+    await manager.sync({ reason: "recovery" });
+    expect(manager.status().lastSyncError).toBeUndefined();
+  });
+
+  it("does not let an older detached failure replace a newer sync success", async () => {
+    const manager = await getPersistentManager(
+      createCfg({ provider: "none", minScore: 0, onSearch: true, hybrid: { enabled: true } }),
+    );
+    await manager.sync({ reason: "baseline" });
+    const maintenanceStarted = createDeferred<void>();
+    const releaseMaintenance = createDeferred<void>();
+    const maintenance = {
+      sync: vi.fn(async () => {
+        maintenanceStarted.resolve();
+        await releaseMaintenance.promise;
+        throw new Error("older maintenance failed");
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const getSpy = vi.spyOn(MemoryIndexManager, "get").mockResolvedValue(maintenance as never);
+    Reflect.set(manager, "dirty", true);
+    const detachedSync = (
+      manager as unknown as {
+        syncPublishedIndexInBackground: (params: { reason: string }) => Promise<void>;
+      }
+    ).syncPublishedIndexInBackground({ reason: "search" });
+
+    try {
+      await maintenanceStarted.promise;
+      Reflect.set(manager, "dirty", true);
+      await manager.sync({ reason: "newer", force: true });
+      releaseMaintenance.resolve();
+      await expect(detachedSync).rejects.toThrow("older maintenance failed");
+
+      expect(manager.status().dirty).toBe(true);
+      expect(manager.status().lastSyncError).toBeUndefined();
+    } finally {
+      releaseMaintenance.resolve();
+      await detachedSync.catch(() => undefined);
       getSpy.mockRestore();
     }
   });
@@ -821,6 +863,7 @@ describe("memory index", () => {
       ).resolves.toBeUndefined();
 
       expect(manager.status().dirty).toBe(true);
+      expect(manager.status().lastSyncError).toContain("Local embedding worker exited");
       expect(Reflect.get(manager, "memoryFullRetryDirty")).toBe(true);
     } finally {
       providerFixture.providerNullResult = null;

--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -756,10 +756,14 @@ describe("memory index", () => {
     }
   });
 
-  it("clears a recorded sync failure after the next successful sync", async () => {
-    const manager = await getPersistentManager(
-      createCfg({ provider: "none", minScore: 0, onSearch: true, hybrid: { enabled: true } }),
-    );
+  it("keeps sync failures process-local and clears them after a successful sync", async () => {
+    const cfg = createCfg({
+      provider: "none",
+      minScore: 0,
+      onSearch: true,
+      hybrid: { enabled: true },
+    });
+    const manager = await getPersistentManager(cfg);
     await manager.sync({ reason: "baseline" });
     const fields = manager as unknown as {
       syncMemoryFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
@@ -772,6 +776,8 @@ describe("memory index", () => {
 
     await expect(manager.sync({ reason: "failure" })).rejects.toThrow("sync failed");
     expect(manager.status().lastSyncError).toBe("sync failed");
+    const statusManager = await getFreshManager(cfg, "status");
+    expect(statusManager.status().lastSyncError).toBeUndefined();
 
     syncSpy.mockImplementation(syncMemoryFiles);
     await manager.sync({ reason: "recovery" });

--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -784,7 +784,7 @@ describe("memory index", () => {
     expect(manager.status().lastSyncError).toBeUndefined();
   });
 
-  it("does not let an older detached failure replace a newer sync success", async () => {
+  it("does not let a no-op sync hide a later detached failure", async () => {
     const manager = await getPersistentManager(
       createCfg({ provider: "none", minScore: 0, onSearch: true, hybrid: { enabled: true } }),
     );
@@ -809,12 +809,15 @@ describe("memory index", () => {
 
     try {
       await maintenanceStarted.promise;
-      Reflect.set(manager, "dirty", true);
-      await manager.sync({ reason: "newer", force: true });
+      expect(manager.status().dirty).toBe(false);
+      await manager.sync({ reason: "interval" });
       releaseMaintenance.resolve();
       await expect(detachedSync).rejects.toThrow("older maintenance failed");
 
       expect(manager.status().dirty).toBe(true);
+      expect(manager.status().lastSyncError).toContain("older maintenance failed");
+
+      await manager.sync({ reason: "retry" });
       expect(manager.status().lastSyncError).toBeUndefined();
     } finally {
       releaseMaintenance.resolve();

--- a/extensions/memory-core/src/memory/manager-status-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-status-state.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, it } from "vitest";
 import {
   collectMemoryStatusAggregate,
   resolveInitialMemoryDirty,
-  resolveMemoryManagerSyncStatus,
   resolveStatusProviderInfo,
 } from "./manager-status-state.js";
 
@@ -40,22 +39,6 @@ describe("memory manager status state", () => {
     },
   ])("resolves $name", ({ params, expected }) => {
     expect(resolveInitialMemoryDirty(params)).toBe(expected);
-  });
-
-  it("reports detached maintenance as stale with every refreshed source", () => {
-    expect(
-      resolveMemoryManagerSyncStatus({
-        syncing: false,
-        memoryDirty: false,
-        sessionsDirty: false,
-        indexIdentityDirty: false,
-        backgroundMaintenance: true,
-        sources: ["memory", "sessions"],
-      }),
-    ).toEqual({
-      dirty: true,
-      pendingSyncSources: ["memory", "sessions"],
-    });
   });
 
   it.each([

--- a/extensions/memory-core/src/memory/manager-status-state.ts
+++ b/extensions/memory-core/src/memory/manager-status-state.ts
@@ -36,36 +36,6 @@ export function resolveInitialMemoryDirty(params: {
   );
 }
 
-export function resolveMemoryManagerSyncStatus(params: {
-  syncing: boolean;
-  memoryDirty: boolean;
-  sessionsDirty: boolean;
-  indexIdentityDirty: boolean;
-  backgroundMaintenance: boolean;
-  sources: Iterable<MemorySource>;
-}): { dirty: boolean; pendingSyncSources?: MemorySource[] } {
-  const pending = new Set<MemorySource>();
-  if (params.syncing && params.memoryDirty) {
-    pending.add("memory");
-  }
-  if (params.syncing && params.sessionsDirty) {
-    pending.add("sessions");
-  }
-  if (params.backgroundMaintenance) {
-    for (const source of params.sources) {
-      pending.add(source);
-    }
-  }
-  return {
-    dirty:
-      params.memoryDirty ||
-      params.sessionsDirty ||
-      params.indexIdentityDirty ||
-      params.backgroundMaintenance,
-    ...(pending.size > 0 ? { pendingSyncSources: Array.from(pending) } : {}),
-  };
-}
-
 export function resolveStatusProviderInfo(params: {
   provider: StatusProvider | null;
   providerInitialized: boolean;

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -135,8 +135,8 @@ export abstract class MemoryManagerSyncBase extends MemoryManagerDatabaseContext
   protected memoryWatchPressureStartupTimer: NodeJS.Timeout | null = null;
   protected closed = false;
   protected dirty = false;
-  // Direct and detached syncs can settle out of order. Keep their shared
-  // outcome owner beside the dirty state that consumes those results.
+  // A success clears only the failure visible when it started. This keeps a
+  // concurrent failure visible even when older or no-op work settles later.
   protected readonly syncOutcomes = new MemorySyncOutcomeLedger();
   protected memorySourceProvenanceRepairPending = false;
   // Failed full memory reindexes must retry as full rebuilds, not incremental

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -43,6 +43,7 @@ import {
   type MemoryIndexMeta,
   type MemoryIndexProviderIdentity,
 } from "./manager-reindex-state.js";
+import { MemorySyncOutcomeLedger } from "./manager-sync-outcome.js";
 import {
   markMemoryVectorRebuildRequired,
   memoryTableExists,
@@ -134,6 +135,9 @@ export abstract class MemoryManagerSyncBase extends MemoryManagerDatabaseContext
   protected memoryWatchPressureStartupTimer: NodeJS.Timeout | null = null;
   protected closed = false;
   protected dirty = false;
+  // Direct and detached syncs can settle out of order. Keep their shared
+  // outcome owner beside the dirty state that consumes those results.
+  protected readonly syncOutcomes = new MemorySyncOutcomeLedger();
   protected memorySourceProvenanceRepairPending = false;
   // Failed full memory reindexes must retry as full rebuilds, not incremental
   // dirty syncs that can skip unchanged files against the still-live index.
@@ -179,6 +183,7 @@ export abstract class MemoryManagerSyncBase extends MemoryManagerDatabaseContext
     deferIndex?: boolean;
     prefixIndexItems?: MemoryIndexWorkItem[];
   }): Promise<MemorySourceSyncPlan>;
+
   protected async indexFiles(items: MemoryIndexWorkItem[]): Promise<void> {
     for (const item of items) {
       await this.indexFile(item.entry, { source: item.source });

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -377,6 +377,7 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
         return;
       }
       if (!this.provider && this.fts.enabled && this.shouldFallbackOnError(err)) {
+        this.syncOutcomes.recordActiveFailure(err);
         log.warn(`memory embeddings unavailable; leaving memory index dirty: ${reason}`);
         return;
       }

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -305,6 +305,9 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
       });
       if (targetedSessionSync.handled) {
         this.sessionsDirty = targetedSessionSync.sessionsDirty;
+        if (targetedSessionSync.failure) {
+          this.syncOutcomes.recordActiveFailure(targetedSessionSync.failure.error);
+        }
         return;
       }
     }

--- a/extensions/memory-core/src/memory/manager-sync-outcome.ts
+++ b/extensions/memory-core/src/memory/manager-sync-outcome.ts
@@ -1,0 +1,54 @@
+// Memory Core owns admission-ordered sync outcome reporting.
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
+
+export class MemorySyncOutcomeLedger {
+  private nextGeneration = 0;
+  private latestSuccessfulGeneration = 0;
+  private latestFailure?: { generation: number; reason: string };
+  private activeGeneration?: number;
+
+  async track(operation: () => Promise<string | undefined | void>, active = false): Promise<void> {
+    const generation = ++this.nextGeneration;
+    if (active) {
+      this.activeGeneration = generation;
+    }
+    try {
+      const incompleteReason = await operation();
+      if (incompleteReason) {
+        this.recordFailure(generation, incompleteReason);
+      } else if (this.latestFailure?.generation !== generation) {
+        this.latestSuccessfulGeneration = Math.max(this.latestSuccessfulGeneration, generation);
+      }
+    } catch (error) {
+      this.recordFailure(generation, error);
+      throw error;
+    } finally {
+      if (this.activeGeneration === generation) {
+        this.activeGeneration = undefined;
+      }
+    }
+  }
+
+  recordActiveFailure(error: unknown): void {
+    if (this.activeGeneration !== undefined) {
+      this.recordFailure(this.activeGeneration, error);
+    }
+  }
+
+  get lastError(): string | undefined {
+    return this.latestFailure && this.latestFailure.generation > this.latestSuccessfulGeneration
+      ? this.latestFailure.reason
+      : undefined;
+  }
+
+  private recordFailure(generation: number, error: unknown): void {
+    if (generation <= (this.latestFailure?.generation ?? 0)) {
+      return;
+    }
+    this.latestFailure = {
+      generation,
+      reason: redactSensitiveText(formatErrorMessage(error), { mode: "tools" }),
+    };
+  }
+}

--- a/extensions/memory-core/src/memory/manager-sync-outcome.ts
+++ b/extensions/memory-core/src/memory/manager-sync-outcome.ts
@@ -1,53 +1,47 @@
-// Memory Core owns admission-ordered sync outcome reporting.
+// Memory Core owns process-local sync outcome reporting.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
 
 export class MemorySyncOutcomeLedger {
-  private nextGeneration = 0;
-  private latestSuccessfulGeneration = 0;
-  private latestFailure?: { generation: number; reason: string };
-  private activeGeneration?: number;
+  private failureRevision = 0;
+  private latestFailure?: { revision: number; reason: string };
+  private active = false;
 
   async track(operation: () => Promise<string | undefined | void>, active = false): Promise<void> {
-    const generation = ++this.nextGeneration;
+    const failureAtStart = this.latestFailure?.revision;
     if (active) {
-      this.activeGeneration = generation;
+      this.active = true;
     }
     try {
       const incompleteReason = await operation();
       if (incompleteReason) {
-        this.recordFailure(generation, incompleteReason);
-      } else if (this.latestFailure?.generation !== generation) {
-        this.latestSuccessfulGeneration = Math.max(this.latestSuccessfulGeneration, generation);
+        this.recordFailure(incompleteReason);
+      } else if (failureAtStart !== undefined && this.latestFailure?.revision === failureAtStart) {
+        this.latestFailure = undefined;
       }
     } catch (error) {
-      this.recordFailure(generation, error);
+      this.recordFailure(error);
       throw error;
     } finally {
-      if (this.activeGeneration === generation) {
-        this.activeGeneration = undefined;
+      if (active) {
+        this.active = false;
       }
     }
   }
 
   recordActiveFailure(error: unknown): void {
-    if (this.activeGeneration !== undefined) {
-      this.recordFailure(this.activeGeneration, error);
+    if (this.active) {
+      this.recordFailure(error);
     }
   }
 
   get lastError(): string | undefined {
-    return this.latestFailure && this.latestFailure.generation > this.latestSuccessfulGeneration
-      ? this.latestFailure.reason
-      : undefined;
+    return this.latestFailure?.reason;
   }
 
-  private recordFailure(generation: number, error: unknown): void {
-    if (generation <= (this.latestFailure?.generation ?? 0)) {
-      return;
-    }
+  private recordFailure(error: unknown): void {
     this.latestFailure = {
-      generation,
+      revision: ++this.failureRevision,
       reason: redactSensitiveText(formatErrorMessage(error), { mode: "tools" }),
     };
   }

--- a/extensions/memory-core/src/memory/manager-targeted-sync.test.ts
+++ b/extensions/memory-core/src/memory/manager-targeted-sync.test.ts
@@ -46,7 +46,11 @@ describe("memory targeted session sync", () => {
       targetArchiveFiles: ["/tmp/targeted-fallback.jsonl"],
       progress: undefined,
     });
-    expect(result).toEqual({ handled: true, sessionsDirty: true });
+    expect(result).toEqual({
+      handled: true,
+      sessionsDirty: true,
+      failure: { error: expect.objectContaining({ message: "embedding backend failed" }) },
+    });
     expect(sessionsDirtyFiles.has("/tmp/targeted-fallback.jsonl")).toBe(true);
     expect(sessionsDirtyFiles.has("/tmp/other-dirty.jsonl")).toBe(true);
   });

--- a/extensions/memory-core/src/memory/manager-targeted-sync.ts
+++ b/extensions/memory-core/src/memory/manager-targeted-sync.ts
@@ -50,7 +50,11 @@ export async function runMemoryTargetedSessionSync(params: {
   }) => Promise<void>;
   shouldFallbackOnError: (err: unknown) => boolean;
   activateFallbackProvider: (reason: string) => Promise<boolean>;
-}): Promise<{ handled: boolean; sessionsDirty: boolean }> {
+}): Promise<
+  | { handled: false; sessionsDirty: boolean }
+  | { handled: true; sessionsDirty: boolean; failure?: never }
+  | { handled: true; sessionsDirty: boolean; failure: { error: unknown } }
+> {
   const hasPendingSessionWork = (hasDirtyFiles = params.sessionsDirtyFiles.size > 0) =>
     params.sessionsFullRetryDirty || params.sessionsReconcileDirty || hasDirtyFiles;
   if (!params.hasSessionSource || !params.targetArchiveFiles) {
@@ -88,6 +92,7 @@ export async function runMemoryTargetedSessionSync(params: {
     return {
       handled: true,
       sessionsDirty: hasPendingSessionWork(remainingSessionsDirty),
+      failure: { error: err },
     };
   }
 }

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -49,7 +49,6 @@ import { MemorySearchOrchestration } from "./manager-search-orchestration.js";
 import {
   collectMemoryStatusAggregate,
   resolveInitialMemoryDirty,
-  resolveMemoryManagerSyncStatus,
   resolveStatusProviderInfo,
 } from "./manager-status-state.js";
 import {
@@ -297,18 +296,21 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
   }
 
   protected async syncPublishedIndexInBackground(params: { reason: string }): Promise<void> {
-    await runMemorySearchMaintenance({
-      reason: params.reason,
-      takeDirtyGeneration: () => this.takeReindexRetryStateForMaintenance(),
-      restoreDirtyGeneration: (generation) => this.restoreReindexRetryState(generation),
-      acquireManager: async () =>
-        await MemoryIndexManager.get({
-          cfg: this.cfg,
-          agentId: this.agentId,
-          purpose: "maintenance",
-          acquireLocalService: this.acquireLocalService,
+    await this.syncOutcomes.track(
+      async () =>
+        await runMemorySearchMaintenance({
+          reason: params.reason,
+          takeDirtyGeneration: () => this.takeReindexRetryStateForMaintenance(),
+          restoreDirtyGeneration: (generation) => this.restoreReindexRetryState(generation),
+          acquireManager: async () =>
+            await MemoryIndexManager.get({
+              cfg: this.cfg,
+              agentId: this.agentId,
+              purpose: "maintenance",
+              acquireLocalService: this.acquireLocalService,
+            }),
         }),
-    });
+    );
   }
 
   protected async syncAdmitted(
@@ -348,7 +350,7 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
         throw err;
       }
     }
-    this.syncing = (async () => {
+    const run = async () => {
       const hadBootstrapFailure = this.embeddingBootstrapFailure !== undefined;
       let forceFtsOnly =
         this.embeddingBootstrapFailure !== undefined &&
@@ -414,7 +416,8 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       ) {
         this.clearEmbeddingBootstrapFailureAfterRecovery();
       }
-    })().finally(() => {
+    };
+    this.syncing = this.syncOutcomes.track(run, true).finally(() => {
       this.syncing = null;
     });
     return this.syncing ?? Promise.resolve();
@@ -496,20 +499,16 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       requestedProvider: this.requestedProvider,
       configuredModel: this.settings.model || undefined,
     });
-    const syncStatus = resolveMemoryManagerSyncStatus({
-      syncing: this.syncing !== null,
-      memoryDirty: this.dirty,
-      sessionsDirty: this.sessionsDirty,
-      indexIdentityDirty: this.indexIdentityDirty,
-      backgroundMaintenance: this.activeBackgroundSearchSyncs.size > 0,
-      sources: this.sources,
-    });
-
     return {
       backend: "builtin",
       files: aggregateState.files,
       chunks: aggregateState.chunks,
-      ...syncStatus,
+      dirty:
+        this.dirty ||
+        this.sessionsDirty ||
+        this.indexIdentityDirty ||
+        this.activeBackgroundSearchSyncs.size > 0,
+      lastSyncError: this.syncOutcomes.lastError,
       workspaceDir: this.workspaceDir,
       dbPath: this.settings.store.databasePath,
       provider: providerInfo.provider,

--- a/extensions/memory-core/src/tools.real-manager.test.ts
+++ b/extensions/memory-core/src/tools.real-manager.test.ts
@@ -24,6 +24,91 @@ describe("memory_search real manager", () => {
     testing.resetMemorySearchToolCooldowns();
   });
 
+  it("keeps routine transcript refresh silent during memory_search", async () => {
+    const cfg = fixture.createConfig({
+      provider: "none",
+      sources: ["memory", "sessions"],
+      sessionMemory: true,
+      minScore: 0,
+      vectorEnabled: false,
+      onSearch: true,
+    });
+    const sessionKey = "agent:main:telegram:direct:refresh-proof";
+    await fixture.seedSessionTranscript({
+      sessionId: "refresh-proof",
+      sessionKey,
+      messages: [
+        {
+          role: "user",
+          content: "The transcript refresh marker is cobalt orchid.",
+          timestamp: "2026-08-30T09:00:00.000Z",
+        },
+      ],
+    });
+    const manager = await fixture.getFreshManager(cfg);
+    await manager.sync({ reason: "baseline", force: true });
+    await fixture.seedSessionTranscript({
+      sessionId: "refresh-proof",
+      sessionKey,
+      messages: [
+        {
+          role: "assistant",
+          content: "A second transcript write is waiting for indexing.",
+          timestamp: "2026-08-30T09:01:00.000Z",
+        },
+      ],
+    });
+    Reflect.set(manager, "sessionsDirty", true);
+
+    const maintenanceReady = createDeferred<void>();
+    const releaseMaintenance = createDeferred<void>();
+    const originalGet = MemoryIndexManager.get.bind(MemoryIndexManager);
+    const getSpy = vi.spyOn(MemoryIndexManager, "get").mockImplementation(async (params) => {
+      const acquired = await originalGet(params);
+      if (params.purpose !== "maintenance" || !acquired) {
+        return acquired;
+      }
+      const fields = acquired as unknown as {
+        syncArchiveFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
+      };
+      const syncArchiveFiles = fields.syncArchiveFiles.bind(acquired);
+      vi.spyOn(fields, "syncArchiveFiles").mockImplementation(async (syncParams) => {
+        const result = await syncArchiveFiles(syncParams);
+        maintenanceReady.resolve();
+        await releaseMaintenance.promise;
+        return result;
+      });
+      return acquired;
+    });
+
+    try {
+      const tool = createMemorySearchTool({
+        config: cfg,
+        agentId: "main",
+        agentSessionKey: "agent:main:telegram:direct:active-refresh-proof",
+      });
+      if (!tool) {
+        throw new Error("memory_search tool missing");
+      }
+      const execution = tool.execute("routine-refresh", {
+        query: "zebra",
+        corpus: "memory",
+      });
+      await maintenanceReady.promise;
+      const result = await execution;
+
+      expect(result.details).toMatchObject({
+        results: [expect.objectContaining({ snippet: expect.stringContaining("Zebra") })],
+      });
+      expect(result.details).not.toHaveProperty("stale");
+      expect(result.details).not.toHaveProperty("warning");
+      expect(result.details).not.toHaveProperty("action");
+    } finally {
+      releaseMaintenance.resolve();
+      getSpy.mockRestore();
+    }
+  });
+
   it("backfills visible sessions with one bounded query embedding", async () => {
     const baseConfig = fixture.createConfig({
       sources: ["sessions"],

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -12,7 +12,7 @@ import {
   resetMemoryToolMockState,
   setMemoryCloseImpl,
   setMemoryCustomStatus,
-  setMemoryPendingSyncSources,
+  setMemoryLastSyncError,
   setMemorySearchImpl,
   setMemorySearchManagerImpl,
   setMemorySourceCounts,
@@ -585,7 +585,7 @@ describe("memory_search unavailable payloads", () => {
     expect(getMemorySyncMockCalls()).toBe(0);
   });
 
-  it("qualifies empty results when the manager reports a dirty index", async () => {
+  it("does not qualify routine pending index work as a search failure", async () => {
     setMemoryStatusDirty(true);
     setMemorySearchImpl(async () => []);
     const tool = createMemorySearchToolOrThrow({
@@ -597,18 +597,16 @@ describe("memory_search unavailable payloads", () => {
 
     const result = await tool.execute("dirty-index", { query: "hidden codeword" });
 
-    expect(result.details).toMatchObject({
-      results: [],
-      stale: true,
-      warning: "Memory index is dirty. Search results may be incomplete.",
-      action: "Run: openclaw memory status --index --agent main",
-    });
+    expect(result.details).toMatchObject({ results: [] });
+    expect(result.details).not.toHaveProperty("stale");
+    expect(result.details).not.toHaveProperty("warning");
+    expect(result.details).not.toHaveProperty("action");
     expect(getMemorySyncMockCalls()).toBe(0);
   });
 
-  it("does not qualify results while session-only catch-up is in progress", async () => {
+  it("qualifies results after automatic indexing fails", async () => {
     setMemoryStatusDirty(true);
-    setMemoryPendingSyncSources(["sessions"]);
+    setMemoryLastSyncError("embedding request timed out");
     setMemorySearchImpl(async () => []);
     const tool = createMemorySearchToolOrThrow({
       config: {
@@ -617,12 +615,15 @@ describe("memory_search unavailable payloads", () => {
       },
     });
 
-    const result = await tool.execute("session-catch-up", { query: "hidden codeword" });
+    const result = await tool.execute("failed-index", { query: "hidden codeword" });
 
-    expect(result.details).toMatchObject({ results: [] });
-    expect(result.details).not.toHaveProperty("stale");
-    expect(result.details).not.toHaveProperty("warning");
-    expect(result.details).not.toHaveProperty("action");
+    expect(result.details).toMatchObject({
+      results: [],
+      stale: true,
+      warning:
+        "Memory index is stale: embedding request timed out. Search results may be incomplete.",
+      action: "Run: openclaw memory status --index --agent main",
+    });
   });
 
   it("surfaces embedding bootstrap degradation when keyword search has no hits", async () => {

--- a/packages/memory-host-sdk/src/engine-storage.ts
+++ b/packages/memory-host-sdk/src/engine-storage.ts
@@ -40,6 +40,7 @@ export { resolveMemoryBackendConfig } from "./host/backend-config.js";
 export {
   isAutomaticMemoryEntryEligible,
   isMemoryOriginEligibleForAutomaticInjection,
+  resolveMemoryIndexIdentityReason,
   resolveMemorySearchStaleness,
 } from "./host/types.js";
 export type { ResolvedMemoryBackendConfig } from "./host/backend-config.js";

--- a/packages/memory-host-sdk/src/host/types.test.ts
+++ b/packages/memory-host-sdk/src/host/types.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { resolveMemorySearchStaleness, type MemoryProviderStatus } from "./types.js";
+
+describe("memory search staleness", () => {
+  it("keeps routine pending index work silent", () => {
+    const status: MemoryProviderStatus = {
+      backend: "builtin",
+      provider: "none",
+      dirty: true,
+    };
+    expect(resolveMemorySearchStaleness(status)).toBeNull();
+  });
+
+  it("reports the latest automatic sync failure", () => {
+    expect(
+      resolveMemorySearchStaleness({ lastSyncError: "embedding request timed out" }, "main"),
+    ).toEqual({
+      stale: true,
+      warning:
+        "Memory index is stale: embedding request timed out. Search results may be incomplete.",
+      action: "Run: openclaw memory status --index --agent main",
+    });
+  });
+
+  it("gives an incompatible index identity precedence over a sync failure", () => {
+    expect(
+      resolveMemorySearchStaleness({
+        lastSyncError: "embedding request timed out",
+        custom: {
+          indexIdentity: { status: "mismatched", reason: "embedding model changed" },
+        },
+      }),
+    ).toMatchObject({ warning: expect.stringContaining("embedding model changed") });
+  });
+});

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -1,4 +1,5 @@
 // Public memory host contracts shared by runtime, builtin search, and package consumers.
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 export type MemorySource = "memory" | "sessions";
 
 export type MemoryOriginClass = "owner" | "agent" | "untrusted" | "system";
@@ -147,8 +148,8 @@ export type MemoryProviderStatus = {
   files?: number;
   chunks?: number;
   dirty?: boolean;
-  /** Sources currently being refreshed by an admitted sync. */
-  pendingSyncSources?: MemorySource[];
+  /** Redacted failure from the newest admitted sync without a newer successful sync. */
+  lastSyncError?: string;
   workspaceDir?: string;
   dbPath?: string;
   extraPaths?: MemoryExtraPath[];
@@ -187,28 +188,28 @@ export type MemoryProviderStatus = {
   custom?: Record<string, unknown>;
 };
 
+export function resolveMemoryIndexIdentityReason(
+  status: Pick<MemoryProviderStatus, "custom">,
+): string | undefined {
+  const identity = asNullableRecord(status.custom?.indexIdentity);
+  if (identity?.status !== "mismatched" && identity?.status !== "missing") {
+    return undefined;
+  }
+  const reason = typeof identity.reason === "string" ? identity.reason.trim() : "";
+  return reason || "memory index identity is missing or mismatched";
+}
+
 export function resolveMemorySearchStaleness(
-  status: Pick<MemoryProviderStatus, "dirty" | "pendingSyncSources" | "custom">,
+  status: Pick<MemoryProviderStatus, "custom" | "lastSyncError">,
   agentId?: string,
 ): { stale: true; warning: string; action: string } | null {
-  const identity = status.custom?.indexIdentity as Record<string, unknown> | undefined;
-  const identityReason =
-    (identity?.status === "mismatched" || identity?.status === "missing") &&
-    typeof identity.reason === "string"
-      ? identity.reason.trim()
-      : undefined;
-  const refreshingSessionsOnly =
-    status.dirty === true &&
-    status.pendingSyncSources?.length === 1 &&
-    status.pendingSyncSources[0] === "sessions";
-  if ((!status.dirty || refreshingSessionsOnly) && !identityReason) {
+  const reason = resolveMemoryIndexIdentityReason(status) ?? status.lastSyncError?.trim();
+  if (!reason) {
     return null;
   }
   return {
     stale: true,
-    warning: identityReason
-      ? `Memory index is stale: ${identityReason}. Search results may be incomplete.`
-      : "Memory index is dirty. Search results may be incomplete.",
+    warning: `Memory index is stale: ${reason}. Search results may be incomplete.`,
     action: `Run: openclaw memory status --index${agentId?.trim() ? ` --agent ${agentId.trim()}` : ""}`,
   };
 }

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -148,7 +148,7 @@ export type MemoryProviderStatus = {
   files?: number;
   chunks?: number;
   dirty?: boolean;
-  /** Redacted failure from the newest admitted sync without a newer successful sync. */
+  /** Process-local failure from the newest admitted sync without a newer successful sync. */
   lastSyncError?: string;
   workspaceDir?: string;
   dbPath?: string;

--- a/src/gateway/server-methods/memory-search.test.ts
+++ b/src/gateway/server-methods/memory-search.test.ts
@@ -259,13 +259,39 @@ describe("memory.search gateway method", () => {
     );
   });
 
-  it("qualifies results from a dirty index", async () => {
+  it("does not qualify routine pending index work as a search failure", async () => {
     const cfg = createConfig(testState.workspaceDir);
     const manager = createStubManager();
     manager.status.mockReturnValue({
       backend: "builtin",
       provider: "none",
       dirty: true,
+      custom: { searchMode: "fts-only" },
+    });
+    getActiveMemorySearchManagerCore.mockResolvedValue({ manager });
+
+    const respond = await invokeMemorySearch({ query: "hidden codeword" }, cfg);
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      {
+        agentId: "main",
+        provider: "none",
+        searchMode: "fts-only",
+        results: [],
+      },
+      undefined,
+    );
+  });
+
+  it("qualifies results after automatic indexing fails", async () => {
+    const cfg = createConfig(testState.workspaceDir);
+    const manager = createStubManager();
+    manager.status.mockReturnValue({
+      backend: "builtin",
+      provider: "none",
+      dirty: true,
+      lastSyncError: "embedding request timed out",
       custom: { searchMode: "fts-only" },
     });
     getActiveMemorySearchManagerCore.mockResolvedValue({ manager });
@@ -280,34 +306,9 @@ describe("memory.search gateway method", () => {
         searchMode: "fts-only",
         results: [],
         stale: true,
-        warning: "Memory index is dirty. Search results may be incomplete.",
+        warning:
+          "Memory index is stale: embedding request timed out. Search results may be incomplete.",
         action: "Run: openclaw memory status --index --agent main",
-      },
-      undefined,
-    );
-  });
-
-  it("does not qualify results while session-only catch-up is in progress", async () => {
-    const cfg = createConfig(testState.workspaceDir);
-    const manager = createStubManager();
-    manager.status.mockReturnValue({
-      backend: "builtin",
-      provider: "none",
-      dirty: true,
-      pendingSyncSources: ["sessions"],
-      custom: { searchMode: "fts-only" },
-    });
-    getActiveMemorySearchManagerCore.mockResolvedValue({ manager });
-
-    const respond = await invokeMemorySearch({ query: "hidden codeword" }, cfg);
-
-    expect(respond).toHaveBeenCalledWith(
-      true,
-      {
-        agentId: "main",
-        provider: "none",
-        searchMode: "fts-only",
-        results: [],
       },
       undefined,
     );

--- a/src/plugin-sdk/memory-core-host-engine-storage.ts
+++ b/src/plugin-sdk/memory-core-host-engine-storage.ts
@@ -51,6 +51,7 @@ export {
   remapChunkLines,
   requireNodeSqlite,
   resolveMemoryBackendConfig,
+  resolveMemoryIndexIdentityReason,
   resolveMemorySearchStaleness,
   runWithConcurrency,
   splitCuratedMarkdownEntries,


### PR DESCRIPTION
## Problem

`memory_search` treated the manager's `dirty` work signal as a failed index. Routine transcript or memory writes could therefore return valid published results together with `stale: true` and a manual reindex command. The model then repeated that command to the user even though automatic maintenance was already running.

## Root cause

`dirty` means that normal indexing work is pending. It does not record the outcome of automatic indexing. The shared staleness classifier inferred a failure from that boolean and used `pendingSyncSources` as a timing-based exception. That exception disappeared when a sync settled and did not cover mixed-source refreshes.

## Fix

- Keep `dirty` as an admin work signal and remove `pendingSyncSources`.
- Record direct and detached sync outcomes in an in-memory failure tracker.
- Clear only the failure visible when a successful retry started, so no-op or older work cannot hide a concurrent failure.
- Return targeted fallback failures to the tracker when dirty session work remains.
- Expose only the newest unsuperseded, redacted sync failure as `lastSyncError`.
- Make model-visible staleness depend on `lastSyncError` or an incompatible index identity.
- Keep failures process-local; `memory status --index` still reports its own retry failure, and identity blocks still show the repair command.
- Reuse one index-identity classifier across the tool, CLI, and shared host contract.

## Behavior proof

- Red on `6ddd598683fa4db3186378034513bba47a6ae30b`: the real built CLI searched a disposable SQLite-backed Memory Core index and returned the expected `cobalt-orchid-7391` marker, plus `stale: true`, `Memory index is dirty`, and the manual reindex action.
- Regression red on current main `8b7d685b2a9`: the real-manager tool test failed because a held transcript refresh produced `stale: true`.
- Green on exact head `5279f1067ba2ccb11af7c9e0e06c513fabe61912`: the production tool and real manager returned the indexed marker without `stale`, `warning`, or `action` during routine maintenance.
- Automatic sync failure, later recovery, incompatible identity precedence, and out-of-order direct/detached settlement have focused regression coverage.

## Validation

- 193 focused tests passed across Memory Core manager, targeted fallback, real tool, shared classifier, Gateway, and CLI surfaces.
- Docs checks passed across formatting, Markdown, MDX, links, localization glossary, and config examples.
- Assertion-safety, max-lines, plugin boundaries, dependency pins, deprecated API, dead exports, database-first, import-cycle, and related changed-surface guards passed.
- Source lint and `git diff --check` passed. Hosted CI owns type-aware lint and type-checking for this repository.

## Scope

- No timer, periodic indexing, config, SQLite schema, or persistence change.
- A later standalone `memory status` process does not inherit a live manager's failure; logs and the live search result own that diagnostic.
- No open issue or pull request overlaps this warning repair.
- Production: +125/-95, net +30. The new lines are the sync outcome tracker. The patch deletes the timing-based pending-source state and duplicate identity parsing.
- Tests: +228/-69, net +159.
