### PR TITLE
fix: keep model-resolution tests inside owned state

### DIFF
--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -2,7 +2,7 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
 import type { ProviderResolveModelRoutesContext } from "../plugin-sdk/provider-model-types.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
@@ -15,14 +15,38 @@ import {
   resolveSecretSentinel,
 } from "../secrets/sentinel.js";
 import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { guardModelFixtureWorkspace } from "./embedded-agent-runner/model.fixture.test-support.js";
+import {
   createModelGenerationFixture,
-  GENERATION_WORKSPACE_DIR,
   publishCurrentModelGeneration,
   resetModelGenerationFixtureState,
 } from "./embedded-agent-runner/model.generation-scope.test-support.js";
 import type { AgentHarnessHostCapabilities } from "./harness/host-capability-types.js";
 import type { AgentHarness } from "./harness/types.js";
 import type { AgentRuntimeAuthPlan } from "./runtime-plan/types.js";
+
+let state: OpenClawTestState;
+let workspaceGuard: ReturnType<typeof guardModelFixtureWorkspace>;
+beforeAll(async () => {
+  state = await createOpenClawTestState({ label: "btw-model" });
+});
+beforeEach(() => {
+  workspaceGuard = guardModelFixtureWorkspace(state.root);
+});
+afterEach(() => {
+  try {
+    workspaceGuard.verify();
+  } finally {
+    workspaceGuard.spy.mockRestore();
+  }
+});
+afterAll(async () => {
+  defaultPluginMetadataSnapshot = undefined;
+  await state.cleanup();
+});
 
 const streamSimpleMock = vi.fn();
 const readFileMock = vi.fn();
@@ -728,11 +752,16 @@ describe("runBtwSideQuestion", () => {
     resolveProviderEntryApiKeyProfileReferenceMock.mockReset();
     resolveProviderEntryApiKeyProfileReferenceMock.mockReturnValue({ kind: "none" });
     clearAgentHarnesses();
-    defaultPluginMetadataSnapshot ??= resolvePluginMetadataSnapshot({
-      config: {},
-      workspaceDir: "/tmp/workspace",
-      allowCurrent: false,
-    });
+    if (!defaultPluginMetadataSnapshot) {
+      defaultPluginMetadataSnapshot = resolvePluginMetadataSnapshot({
+        config: {},
+        workspaceDir: state.workspaceDir,
+        allowCurrent: false,
+      });
+      expect(workspaceGuard.spy).toHaveBeenCalledWith(
+        expect.objectContaining({ workspaceDir: state.workspaceDir }),
+      );
+    }
     preparedRuntimeSnapshotState.snapshot = {
       metadataSnapshot: defaultPluginMetadataSnapshot,
     };
@@ -916,6 +945,8 @@ describe("runBtwSideQuestion", () => {
   it("keeps model, runtime auth, and stream selection on prepared A after current advances to B", async () => {
     const cfg = { agents: { entries: { main: { default: true } } } } as never;
     const generationA = createModelGenerationFixture({
+      agentDir: state.agentDir(),
+      workspaceDir: state.workspaceDir,
       config: cfg,
       label: "btw-a",
       provider: "local-proxy",
@@ -923,6 +954,8 @@ describe("runBtwSideQuestion", () => {
       modelId: "side-model",
     });
     const generationB = createModelGenerationFixture({
+      agentDir: state.agentDir(),
+      workspaceDir: state.workspaceDir,
       config: cfg,
       label: "btw-b",
       provider: "local-proxy",
@@ -931,7 +964,7 @@ describe("runBtwSideQuestion", () => {
     });
     preparedRuntimeSnapshotState.snapshot = generationA.preparedModelRuntime;
     preparedRuntimeSnapshotState.useSnapshotPluginRegistry = true;
-    resolveAgentWorkspaceDirMock.mockReturnValue(GENERATION_WORKSPACE_DIR);
+    resolveAgentWorkspaceDirMock.mockReturnValue(state.workspaceDir);
     publishCurrentModelGeneration(generationB);
     const runtimeAuthA = vi.fn(async () => ({ apiKey: "runtime-auth-a" }));
     const runtimeAuthB = vi.fn(async () => ({ apiKey: "runtime-auth-b" }));
@@ -953,7 +986,7 @@ describe("runBtwSideQuestion", () => {
     resolveModelWithRegistryMock.mockImplementation(() => {
       const snapshot = getCurrentPluginMetadataSnapshot({
         config: cfg,
-        workspaceDir: GENERATION_WORKSPACE_DIR,
+        workspaceDir: state.workspaceDir,
       });
       const label = snapshot === generationA.metadataSnapshot ? "A" : "B";
       return {

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
 import { CURRENT_SESSION_VERSION } from "openclaw/plugin-sdk/agent-sessions";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
@@ -119,13 +120,16 @@ function createPreparedRuntimeLease(input: {
   agentId?: string;
   workspaceDir?: string;
 }) {
-  const prepared = createModelGenerationFixture({ config: input.config, label: "cli" });
+  const prepared = createModelGenerationFixture({
+    config: input.config,
+    label: "cli",
+    agentDir: input.agentDir,
+    workspaceDir: expectDefined(input.workspaceDir, "compaction fixture workspace"),
+  });
   return {
     snapshot: {
       ...prepared.preparedModelRuntime,
       ...(input.agentId ? { agentId: input.agentId } : {}),
-      agentDir: input.agentDir,
-      ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
     },
     pluginGeneration: {
       configuredCatalogEntries: [],

--- a/src/agents/embedded-agent-runner/model.fixture.test-support.ts
+++ b/src/agents/embedded-agent-runner/model.fixture.test-support.ts
@@ -1,0 +1,35 @@
+import { expect, vi } from "vitest";
+import { isPathInside } from "../../infra/path-guards.js";
+import * as pluginDiscovery from "../../plugins/discovery.js";
+import * as authProfileStore from "../auth-profiles/store.js";
+
+export function guardModelFixtureAuth(root: string) {
+  const violations: Array<string | undefined> = [];
+  const ensureAuthProfileStore = authProfileStore.ensureAuthProfileStore;
+  const spy = vi
+    .spyOn(authProfileStore, "ensureAuthProfileStore")
+    .mockImplementation((dir, options) => {
+      // Discovery stores and prepared metadata do not bypass native auth reads.
+      // Record even swallowed violations before the owner can inspect the path.
+      if (!dir || !isPathInside(root, dir)) {
+        violations.push(dir);
+        throw new Error("Auth profile request escaped the model fixture");
+      }
+      return ensureAuthProfileStore(dir, options);
+    });
+  return { spy, verify: () => expect(violations).toEqual([]) };
+}
+
+export function guardModelFixtureWorkspace(root: string) {
+  const violations: string[] = [];
+  const discoverOpenClawPlugins = pluginDiscovery.discoverOpenClawPlugins;
+  const spy = vi.spyOn(pluginDiscovery, "discoverOpenClawPlugins").mockImplementation((params) => {
+    // This is before discovery's realpath/stat probes; bundled roots remain real.
+    if (params.workspaceDir && !isPathInside(root, params.workspaceDir)) {
+      violations.push(params.workspaceDir);
+      throw new Error("Workspace discovery escaped the model fixture");
+    }
+    return discoverOpenClawPlugins(params);
+  });
+  return { spy, verify: () => expect(violations).toEqual([]) };
+}

--- a/src/agents/embedded-agent-runner/model.forward-compat.test.ts
+++ b/src/agents/embedded-agent-runner/model.forward-compat.test.ts
@@ -1,11 +1,32 @@
 // Coverage for registry-backed model forward-compatibility fallbacks.
-import { describe, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import { guardModelFixtureAuth } from "./model.fixture.test-support.js";
 import {
   buildForwardCompatTemplate,
   expectResolvedForwardCompatFallbackWithRegistryResult,
 } from "./model.forward-compat.test-support.js";
 import { resolveModelWithRegistry } from "./model.js";
 import { createProviderRuntimeTestMock } from "./model.provider-runtime.test-support.js";
+
+let state: OpenClawTestState;
+let auth: ReturnType<typeof guardModelFixtureAuth>;
+beforeEach(async () => {
+  state = await createOpenClawTestState({ label: "model-forward-compat" });
+  auth = guardModelFixtureAuth(state.root);
+});
+afterEach(async () => {
+  try {
+    auth.verify();
+    expect(auth.spy).toHaveBeenCalled();
+  } finally {
+    auth.spy.mockRestore();
+    await state.cleanup();
+  }
+});
 
 vi.mock("../../plugins/provider-runtime.js", () => ({
   applyProviderResolvedTransportWithPlugin: () => undefined,
@@ -105,7 +126,7 @@ function runAnthropicOpusForwardCompatFallback() {
     result: resolveModelWithRegistry({
       provider: "anthropic",
       modelId: "claude-opus-4-6",
-      agentDir: "/tmp/agent",
+      agentDir: state.agentDir(),
       modelRegistry: createRegistry([
         {
           provider: "anthropic",
@@ -124,7 +145,7 @@ function runAnthropicSonnetForwardCompatFallback() {
     result: resolveModelWithRegistry({
       provider: "anthropic",
       modelId: "claude-sonnet-4-6",
-      agentDir: "/tmp/agent",
+      agentDir: state.agentDir(),
       modelRegistry: createRegistry([
         {
           provider: "anthropic",
@@ -145,7 +166,7 @@ function runClaudeCliSonnetForwardCompatFallback() {
     result: resolveModelWithRegistry({
       provider: "claude-cli",
       modelId: "claude-sonnet-4-6",
-      agentDir: "/tmp/agent",
+      agentDir: state.agentDir(),
       modelRegistry: createRegistry([
         {
           provider: "anthropic",
@@ -166,7 +187,7 @@ function runZaiForwardCompatFallback() {
   const result = resolveModelWithRegistry({
     provider: ZAI_GLM5_CASE.provider,
     modelId: ZAI_GLM5_CASE.id,
-    agentDir: "/tmp/agent",
+    agentDir: state.agentDir(),
     modelRegistry: createRegistry(
       ZAI_GLM5_CASE.registryEntries.map((entry) => ({
         provider: entry.provider,

--- a/src/agents/embedded-agent-runner/model.generation-scope.test-support.ts
+++ b/src/agents/embedded-agent-runner/model.generation-scope.test-support.ts
@@ -12,11 +12,12 @@ import { AuthStorage, ModelRegistry } from "../sessions/index.js";
 
 const GENERATION_MODEL_ID = "generation-model";
 const GENERATION_REQUEST_PROVIDER = "generation-alias";
-export const GENERATION_WORKSPACE_DIR = "/tmp/openclaw-model-generation-scope";
 
 type ImagePolicy = NonNullable<NonNullable<ProviderRuntimeModel["mediaInput"]>["image"]>;
 
 export function createModelGenerationFixture(params: {
+  agentDir: string;
+  workspaceDir: string;
   config: OpenClawConfig;
   createStores?: PreparedModelRuntimeSnapshot["createStores"];
   label: string;
@@ -73,7 +74,7 @@ export function createModelGenerationFixture(params: {
   const metadataSnapshot = createPluginMetadataSnapshot({
     config: params.config,
     manifestRegistry: { plugins: [plugin], diagnostics: [] },
-    workspaceDir: GENERATION_WORKSPACE_DIR,
+    workspaceDir: params.workspaceDir,
   });
   const pluginRegistry = createEmptyPluginRegistry();
   const resolveDynamicModel = vi.fn(() => ({
@@ -108,8 +109,8 @@ export function createModelGenerationFixture(params: {
     });
   const preparedModelRuntime = {
     catalogOwner: undefined,
-    agentDir: "/tmp/openclaw-model-generation-agent",
-    workspaceDir: GENERATION_WORKSPACE_DIR,
+    agentDir: params.agentDir,
+    workspaceDir: params.workspaceDir,
     activeProjectKeys: [],
     config: params.config,
     authModes: {},
@@ -139,13 +140,13 @@ export function publishCurrentModelGeneration(
 ): void {
   setCurrentPluginMetadataSnapshot(generation.metadataSnapshot, {
     config: generation.preparedModelRuntime.config,
-    workspaceDir: GENERATION_WORKSPACE_DIR,
+    workspaceDir: generation.preparedModelRuntime.workspaceDir,
   });
   setActivePluginRegistry(
     generation.pluginRegistry,
     `generation-${generation.provider}`,
     "default",
-    GENERATION_WORKSPACE_DIR,
+    generation.preparedModelRuntime.workspaceDir,
   );
 }
 

--- a/src/agents/embedded-agent-runner/model.generation-scope.test.ts
+++ b/src/agents/embedded-agent-runner/model.generation-scope.test.ts
@@ -2,13 +2,34 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
 import { AuthStorage, ModelRegistry } from "../sessions/index.js";
+import { guardModelFixtureAuth } from "./model.fixture.test-support.js";
 import {
   createModelGenerationFixture,
   publishCurrentModelGeneration,
   resetModelGenerationFixtureState,
 } from "./model.generation-scope.test-support.js";
 import { resolveModelAsync } from "./model.js";
+
+let state: OpenClawTestState;
+let auth: ReturnType<typeof guardModelFixtureAuth>;
+beforeEach(async () => {
+  state = await createOpenClawTestState({ label: "model-generation" });
+  auth = guardModelFixtureAuth(state.root);
+});
+afterEach(async () => {
+  try {
+    auth.verify();
+    expect(auth.spy).toHaveBeenCalled();
+  } finally {
+    auth.spy.mockRestore();
+    await state.cleanup();
+  }
+});
 
 async function resolveGeneration(generation: ReturnType<typeof createModelGenerationFixture>) {
   const { preparedModelRuntime } = generation;
@@ -44,7 +65,12 @@ describe("model runtime generation scope", () => {
     { auth: false, registry: true },
     { auth: false, registry: false },
   ])("fills only missing discovery stores (auth=$auth, registry=$registry)", async (supplied) => {
-    const generation = createModelGenerationFixture({ config: {}, label: "stores" });
+    const generation = createModelGenerationFixture({
+      agentDir: state.agentDir(),
+      workspaceDir: state.workspaceDir,
+      config: {},
+      label: "stores",
+    });
     const { preparedModelRuntime } = generation;
     const stores = preparedModelRuntime.createStores();
     stores.authStorage.setRuntimeApiKey(generation.provider, "fixture-runtime-key");
@@ -80,8 +106,19 @@ describe("model runtime generation scope", () => {
 
   it("keeps alias, suppression, static metadata, and runtime hooks on the prepared generation", async () => {
     const config = {} satisfies OpenClawConfig;
-    const generationA = createModelGenerationFixture({ config, label: "a" });
-    const generationB = createModelGenerationFixture({ config, label: "b", suppress: true });
+    const generationA = createModelGenerationFixture({
+      agentDir: state.agentDir(),
+      workspaceDir: state.workspaceDir,
+      config,
+      label: "a",
+    });
+    const generationB = createModelGenerationFixture({
+      agentDir: state.agentDir(),
+      workspaceDir: state.workspaceDir,
+      config,
+      label: "b",
+      suppress: true,
+    });
     publishCurrentModelGeneration(generationB);
 
     const result = await resolveGeneration(generationA);
@@ -111,42 +148,57 @@ describe("model runtime generation scope", () => {
       await gate;
     };
     const generationA = createModelGenerationFixture({
+      agentDir: state.agentDir(),
+      workspaceDir: state.workspaceDir,
       config,
       label: "a",
       prepareDynamicModel,
     });
     const generationB = createModelGenerationFixture({
+      agentDir: state.agentDir(),
+      workspaceDir: state.workspaceDir,
       config,
       label: "b",
       prepareDynamicModel,
     });
     publishCurrentModelGeneration(generationB);
 
-    const [resultA, resultB] = await Promise.all([
-      resolveGeneration(generationA),
-      resolveGeneration(generationB),
-    ]);
-
-    expect(resultA.model).toMatchObject({
-      provider: generationA.provider,
-      name: "Runtime A",
-      mediaInput: { image: generationA.staticImagePolicy },
-    });
-    expect(resultB.model).toMatchObject({
-      provider: generationB.provider,
-      name: "Runtime B",
-      mediaInput: { image: generationB.staticImagePolicy },
-    });
+    const resolutions = [resolveGeneration(generationA), resolveGeneration(generationB)] as const;
+    try {
+      const [resultA, resultB] = await Promise.all(resolutions);
+      expect(resultA.model).toMatchObject({
+        provider: generationA.provider,
+        name: "Runtime A",
+        mediaInput: { image: generationA.staticImagePolicy },
+      });
+      expect(resultB.model).toMatchObject({
+        provider: generationB.provider,
+        name: "Runtime B",
+        mediaInput: { image: generationB.staticImagePolicy },
+      });
+    } finally {
+      // A resolution can reject before both hooks arrive. Release its sibling
+      // and join both owners before afterEach deletes their fixture state.
+      release();
+      await Promise.allSettled(resolutions);
+    }
   });
 
   it("keeps metadata-only prepared generations from borrowing current runtime hooks", async () => {
     const config = {} satisfies OpenClawConfig;
     const generationA = createModelGenerationFixture({
+      agentDir: state.agentDir(),
+      workspaceDir: state.workspaceDir,
       config,
       label: "a",
       withRegistry: false,
     });
-    const generationB = createModelGenerationFixture({ config, label: "b" });
+    const generationB = createModelGenerationFixture({
+      agentDir: state.agentDir(),
+      workspaceDir: state.workspaceDir,
+      config,
+      label: "b",
+    });
     publishCurrentModelGeneration(generationB);
 
     const result = await resolveGeneration(generationA);

--- a/src/agents/embedded-agent-runner/model.provider-hooks.timeout.test.ts
+++ b/src/agents/embedded-agent-runner/model.provider-hooks.timeout.test.ts
@@ -1,9 +1,15 @@
 import { createServer, type Server } from "node:http";
 import { withFirstStreamEventTimeout } from "@openclaw/ai/internal/runtime";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import { withTestTimeout } from "../../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
 import type { StreamFn } from "../runtime/index.js";
+import { guardModelFixtureAuth } from "./model.fixture.test-support.js";
 import { resolveModelAsync } from "./model.js";
 import type { ProviderRuntimeHooks } from "./model.provider-hooks.js";
 import { createProviderRuntimeTestMock } from "./model.provider-runtime.test-support.js";
@@ -22,6 +28,22 @@ const HTTP_EVENT_DELAY_MS = 90;
 const SHORT_CONTROL_TIMEOUT_MS = 20;
 
 type RebuildingHookStage = "model" | "transport";
+
+let state: OpenClawTestState;
+
+beforeEach(async () => {
+  state = await createOpenClawTestState({ label: "provider-timeout" });
+  const auth = guardModelFixtureAuth(state.root);
+  return async () => {
+    try {
+      auth.verify();
+      expect(auth.spy).toHaveBeenCalled();
+    } finally {
+      auth.spy.mockRestore();
+      await state.cleanup();
+    }
+  };
+});
 
 function rebuildProviderModel(
   model: ProviderRuntimeModel,
@@ -88,13 +110,14 @@ async function resolveProviderModel(params: {
   const result = await resolveModelAsync(
     PROVIDER,
     MODEL_ID,
-    "/tmp/openclaw-provider-timeout-test-agent",
+    state.agentDir(),
     createProviderConfig(params.baseUrl ?? "http://127.0.0.1:8123/v1", params.timeoutSeconds),
     {
       authStorage: { mocked: true } as never,
       modelRegistry: { find: () => null } as never,
       runtimeHooks: params.runtimeHooks ?? createProviderRuntimeTestMock(),
       skipAgentDiscovery: true,
+      workspaceDir: state.workspaceDir,
     },
   );
   if (!result.model) {
@@ -127,30 +150,52 @@ async function listenForDelayedSse(): Promise<{ server: Server; url: string }> {
   return { server, url: `http://127.0.0.1:${address.port}/v1/stream` };
 }
 
-async function openHttpEventStream(url: string): Promise<AsyncIterable<string>> {
-  const response = await fetch(url);
+async function openHttpEventStream(url: string, signal: AbortSignal) {
+  const response = await fetch(url, { signal });
   if (!response.ok || !response.body) {
     throw new Error(`Expected an HTTP SSE response, received ${response.status}`);
   }
   const body = response.body;
-  return {
-    async *[Symbol.asyncIterator]() {
-      const reader = body.getReader();
-      const decoder = new TextDecoder();
-      try {
-        for (;;) {
-          const chunk = await reader.read();
-          if (chunk.done) {
-            return;
-          }
-          yield decoder.decode(chunk.value, { stream: true });
+  const source = (async function* () {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    try {
+      for (;;) {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          return;
         }
-      } finally {
-        await reader.cancel().catch(() => undefined);
-        reader.releaseLock();
+        yield decoder.decode(chunk.value, { stream: true });
       }
-    },
-  };
+    } finally {
+      await reader.cancel().catch(() => undefined);
+      reader.releaseLock();
+    }
+  })();
+  return { source, body };
+}
+
+async function nextGuardedHttpEvent(
+  url: string,
+  wrap: (source: AsyncIterable<string>) => AsyncIterable<unknown> | Promise<AsyncIterable<unknown>>,
+): Promise<IteratorResult<unknown>> {
+  const controller = new AbortController();
+  const { source, body } = await openHttpEventStream(url, controller.signal);
+  let iterator: AsyncIterator<unknown> | undefined;
+  try {
+    iterator = (await wrap(source))[Symbol.asyncIterator]();
+    return await iterator.next();
+  } finally {
+    // First-event return is fire-and-forget; idle timeout can leave next() pending.
+    // Abort the native read and join the source itself before server/state disposal.
+    controller.abort();
+    await withTestTimeout(
+      Promise.all([iterator?.return?.(), source.return(undefined)]),
+      CONFIGURED_TIMEOUT_MS,
+      "HTTP fixture source did not settle",
+    );
+    expect(body.locked).toBe(false);
+  }
 }
 
 async function nextIdleGuardedHttpEvent(params: {
@@ -158,13 +203,13 @@ async function nextIdleGuardedHttpEvent(params: {
   model: ProviderRuntimeModel;
   timeoutMs: number;
 }): Promise<IteratorResult<unknown>> {
-  const source = await openHttpEventStream(params.url);
-  const baseFn = (() => source) as unknown as StreamFn;
-  const stream = await streamWithIdleTimeout(baseFn, params.timeoutMs)(
-    params.model as Parameters<StreamFn>[0],
-    { messages: [] },
-  );
-  return await stream[Symbol.asyncIterator]().next();
+  return await nextGuardedHttpEvent(params.url, async (source) => {
+    const baseFn = (() => source) as unknown as StreamFn;
+    return await streamWithIdleTimeout(baseFn, params.timeoutMs)(
+      params.model as Parameters<StreamFn>[0],
+      { messages: [] },
+    );
+  });
 }
 
 describe("provider request timeout across rebuilding runtime hooks", () => {
@@ -212,13 +257,11 @@ describe("provider request timeout across rebuilding runtime hooks", () => {
         runtimeHooks: createRebuildingRuntimeHooks("model"),
       });
 
-      const shortFirstEventStream = await openHttpEventStream(url);
-      const shortFirstEventGuard = withFirstStreamEventTimeout(shortFirstEventStream, {
-        timeoutMs: SHORT_CONTROL_TIMEOUT_MS,
-      });
-      await expect(shortFirstEventGuard[Symbol.asyncIterator]().next()).rejects.toThrow(
-        /first-event timeout/,
-      );
+      await expect(
+        nextGuardedHttpEvent(url, (source) =>
+          withFirstStreamEventTimeout(source, { timeoutMs: SHORT_CONTROL_TIMEOUT_MS }),
+        ),
+      ).rejects.toThrow(/first-event timeout/);
 
       expect(model.requestTimeoutMs).toBe(CONFIGURED_TIMEOUT_MS);
       const firstEventTimeoutMs = resolveLlmFirstEventTimeoutMs({
@@ -232,11 +275,9 @@ describe("provider request timeout across rebuilding runtime hooks", () => {
       expect(firstEventTimeoutMs).toBe(CONFIGURED_TIMEOUT_MS);
       expect(idleTimeoutMs).toBe(CONFIGURED_TIMEOUT_MS);
 
-      const configuredFirstEventStream = await openHttpEventStream(url);
-      const configuredFirstEventGuard = withFirstStreamEventTimeout(configuredFirstEventStream, {
-        timeoutMs: firstEventTimeoutMs,
-      });
-      const firstEvent = await configuredFirstEventGuard[Symbol.asyncIterator]().next();
+      const firstEvent = await nextGuardedHttpEvent(url, (source) =>
+        withFirstStreamEventTimeout(source, { timeoutMs: firstEventTimeoutMs }),
+      );
       expect(firstEvent.value).toContain("provider event");
 
       await expect(

--- a/src/agents/embedded-agent-runner/model.skip-agent-discovery-hooks.test.ts
+++ b/src/agents/embedded-agent-runner/model.skip-agent-discovery-hooks.test.ts
@@ -1,5 +1,30 @@
 // Coverage for resolving models through provider hooks while discovery is skipped.
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import { guardModelFixtureAuth, guardModelFixtureWorkspace } from "./model.fixture.test-support.js";
+
+let state: OpenClawTestState;
+let auth: ReturnType<typeof guardModelFixtureAuth>;
+let workspace: ReturnType<typeof guardModelFixtureWorkspace>;
+beforeEach(async () => {
+  state = await createOpenClawTestState({ label: "skip-agent-discovery" });
+  auth = guardModelFixtureAuth(state.root);
+  workspace = guardModelFixtureWorkspace(state.root);
+});
+afterEach(async () => {
+  try {
+    auth.verify();
+    workspace.verify();
+    expect(auth.spy).toHaveBeenCalled();
+  } finally {
+    auth.spy.mockRestore();
+    workspace.spy.mockRestore();
+    await state.cleanup();
+  }
+});
 
 const mocks = vi.hoisted(() => ({
   // Discovery mocks throw/assert by call count so skipAgentDiscovery can prove it
@@ -59,12 +84,12 @@ function expectWorkspaceHookCall(mock: { mock: { calls: unknown[][] } }) {
     throw new Error("Expected runtime hook call argument");
   }
   const call = arg as { context?: unknown; workspaceDir?: unknown };
-  expect(call.workspaceDir).toBe("/tmp/workspace");
+  expect(call.workspaceDir).toBe(state.workspaceDir);
   if (!call.context || typeof call.context !== "object") {
     throw new Error("Expected runtime hook context");
   }
   const context = call.context as { workspaceDir?: unknown };
-  expect(context.workspaceDir).toBe("/tmp/workspace");
+  expect(context.workspaceDir).toBe(state.workspaceDir);
 }
 
 beforeAll(async () => {
@@ -77,10 +102,16 @@ beforeEach(() => {
 
 describe("resolveModelAsync skipAgentDiscovery runtime hooks", () => {
   it("uses only target-provider dynamic hooks", async () => {
-    const result = await resolveModelAsync("ollama", "llama3.2:latest", "/tmp/agent", undefined, {
-      skipAgentDiscovery: true,
-      workspaceDir: "/tmp/workspace",
-    });
+    const result = await resolveModelAsync(
+      "ollama",
+      "llama3.2:latest",
+      state.agentDir(),
+      undefined,
+      {
+        skipAgentDiscovery: true,
+        workspaceDir: state.workspaceDir,
+      },
+    );
 
     expect(result.error).toBeUndefined();
     if (!result.model) {

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -1,13 +1,14 @@
 // Broad coverage for embedded runner model resolution behavior.
 import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadBundledPluginPublicSurface } from "../../plugin-sdk/test-helpers/public-surface-loader.js";
 import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import type { ProviderPlugin } from "../../plugins/types.js";
-import { withEnvAsync } from "../../test-utils/env.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
 import { discoverAuthStorage, discoverModels } from "../agent-model-discovery.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
@@ -20,7 +21,24 @@ import {
   replacePersistedPluginModelCatalogs,
 } from "../plugin-model-catalog.js";
 import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.owner.js";
+import { guardModelFixtureAuth } from "./model.fixture.test-support.js";
 import { createProviderRuntimeTestMock } from "./model.provider-runtime.test-support.js";
+
+let state: OpenClawTestState;
+let auth: ReturnType<typeof guardModelFixtureAuth>;
+beforeEach(async () => {
+  state = await createOpenClawTestState({ label: "model-resolution" });
+  auth = guardModelFixtureAuth(state.root);
+});
+afterEach(async () => {
+  try {
+    auth.verify();
+  } finally {
+    auth.spy.mockRestore();
+    clearRuntimeAuthProfileStoreSnapshots();
+    await state.cleanup();
+  }
+});
 
 const resolveBundledStaticCatalogModelMock = vi.hoisted(() => vi.fn());
 const resolveBundledProviderStaticCatalogModelMock = vi.hoisted(() => vi.fn());
@@ -341,7 +359,7 @@ async function resolveModelForTest(
 ) {
   // Most tests use fixed auth storage to keep assertions focused on model
   // resolution rather than auth discovery.
-  const resolvedAgentDir = agentDir ?? "/tmp/agent";
+  const resolvedAgentDir = agentDir ?? state.agentDir();
   return await resolveModelAsync(provider, modelId, agentDir, cfg, {
     authStorage: { mocked: true } as never,
     modelRegistry: discoverModels({ mocked: true } as never, resolvedAgentDir),
@@ -381,7 +399,7 @@ function resolveModelAsyncForTest(
     skipAgentDiscovery?: boolean;
   },
 ) {
-  const resolvedAgentDir = agentDir ?? "/tmp/agent";
+  const resolvedAgentDir = agentDir ?? state.agentDir();
   return resolveModelAsync(provider, modelId, agentDir, cfg, {
     authStorage: { mocked: true } as never,
     modelRegistry: discoverModels({ mocked: true } as never, resolvedAgentDir),
@@ -594,7 +612,7 @@ describe("resolveModel", () => {
       headers: { "X-Tenant": "tenant-a" },
     });
 
-    const result = await resolveModelAsync("acme", "prepared-model", "/tmp/agent", cfg, {
+    const result = await resolveModelAsync("acme", "prepared-model", state.agentDir(), cfg, {
       runtimeHooks: {
         ...createRuntimeHooks(),
         prepareProviderDynamicModel,
@@ -669,7 +687,7 @@ describe("resolveModel", () => {
         ],
       });
 
-      const result = await resolveModelAsync("acme", "prepared-model", "/tmp/agent", cfg, {
+      const result = await resolveModelAsync("acme", "prepared-model", state.agentDir(), cfg, {
         runtimeHooks: {
           ...createRuntimeHooks(),
           prepareProviderDynamicModel,
@@ -693,10 +711,10 @@ describe("resolveModel", () => {
   it("reuses agent discovery stores while the agent model files are unchanged", async () => {
     mockModelDiscovery();
 
-    const first = await resolveModelAsync("openai", "gpt-5.5", "/tmp/agent", undefined, {
+    const first = await resolveModelAsync("openai", "gpt-5.5", state.agentDir(), undefined, {
       runtimeHooks: createRuntimeHooks(),
     });
-    const second = await resolveModelAsync("openai", "gpt-5.5", "/tmp/agent", undefined, {
+    const second = await resolveModelAsync("openai", "gpt-5.5", state.agentDir(), undefined, {
       runtimeHooks: createRuntimeHooks(),
     });
 
@@ -709,17 +727,17 @@ describe("resolveModel", () => {
   it("looks up the lifecycle owner before applying a derived workspace", async () => {
     mockModelDiscovery();
     const cfg = {
-      agents: { defaults: { workspace: "/tmp/config-derived-workspace" } },
+      agents: { defaults: { workspace: state.path("config-derived-workspace") } },
     } as OpenClawConfig;
 
-    const result = await resolveModelAsync("openai", "gpt-5.5", "/tmp/agent", cfg, {
+    const result = await resolveModelAsync("openai", "gpt-5.5", state.agentDir(), cfg, {
       agentId: "main",
       runtimeHooks: createRuntimeHooks(),
     });
 
     expectResolvedModel(result);
     expect(preparedSnapshotState.getInputs[0]).toEqual(
-      expect.objectContaining({ agentId: "main", agentDir: "/tmp/agent" }),
+      expect.objectContaining({ agentId: "main", agentDir: state.agentDir() }),
     );
     expect(preparedSnapshotState.getInputs[0]).not.toHaveProperty("workspaceDir");
   });
@@ -727,11 +745,11 @@ describe("resolveModel", () => {
   it("keeps prepared discovery generations separate for agents sharing directories", async () => {
     mockModelDiscovery();
 
-    const first = await resolveModelAsync("openai", "gpt-5.5", "/tmp/agent", undefined, {
+    const first = await resolveModelAsync("openai", "gpt-5.5", state.agentDir(), undefined, {
       agentId: "agent-a",
       runtimeHooks: createRuntimeHooks(),
     });
-    const second = await resolveModelAsync("openai", "gpt-5.5", "/tmp/agent", undefined, {
+    const second = await resolveModelAsync("openai", "gpt-5.5", state.agentDir(), undefined, {
       agentId: "agent-b",
       runtimeHooks: createRuntimeHooks(),
     });
@@ -760,14 +778,14 @@ describe("resolveModel", () => {
     const first = await resolveModelAsync(
       "openai",
       "gpt-5.5",
-      "/tmp/agent",
+      state.agentDir(),
       providerConfig("openai-responses"),
       { runtimeHooks: createRuntimeHooks() },
     );
     const second = await resolveModelAsync(
       "openai",
       "gpt-5.5",
-      "/tmp/agent",
+      state.agentDir(),
       providerConfig("openai-completions"),
       { runtimeHooks: createRuntimeHooks() },
     );
@@ -779,8 +797,7 @@ describe("resolveModel", () => {
   });
 
   it("does not poll generated plugin catalogs between lifecycle generations", async () => {
-    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-model-cache-plugin-"));
-    const agentDir = path.join(rootDir, "agent");
+    const agentDir = state.agentDir();
     fs.mkdirSync(agentDir, { recursive: true });
     mockDiscoveredModel(discoverModels, {
       provider: "zai",
@@ -813,9 +830,8 @@ describe("resolveModel", () => {
   });
 
   it("reuses inherited auth from one lifecycle generation", async () => {
-    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-model-cache-"));
-    const agentDir = path.join(rootDir, "agent");
-    const defaultAgentDir = path.join(rootDir, "default-agent");
+    const agentDir = state.agentDir("worker");
+    const defaultAgentDir = state.agentDir();
     fs.mkdirSync(agentDir, { recursive: true });
     fs.mkdirSync(defaultAgentDir, { recursive: true });
     const cfg = makeOpenClawConfigFixture({
@@ -850,9 +866,8 @@ describe("resolveModel", () => {
   });
 
   it("uses the resolved default agent workspace for prepared model discovery", async () => {
-    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-model-workspace-"));
-    const agentDir = path.join(rootDir, "agent");
-    const workspaceDir = path.join(rootDir, "workspace");
+    const agentDir = state.agentDir("workspace-agent");
+    const workspaceDir = state.workspaceDir;
     fs.mkdirSync(agentDir, { recursive: true });
     mockModelDiscovery();
     const cfg = makeOpenClawConfigFixture({
@@ -874,8 +889,8 @@ describe("resolveModel", () => {
   });
 
   it("passes config into model discovery when auth storage is prebuilt", async () => {
-    const agentDir = "/tmp/agent-configured";
-    const workspaceDir = "/tmp/workspace-configured";
+    const agentDir = state.agentDir("configured");
+    const workspaceDir = state.path("workspace-configured");
     const authStorage = { mocked: true } as never;
     const cfg = {
       models: {
@@ -905,38 +920,31 @@ describe("resolveModel", () => {
   });
 
   it("does not poll implicit main auth during request resolution", async () => {
-    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-model-cache-state-"));
-    const agentDir = path.join(rootDir, "agents", "worker", "agent");
-    const mainAgentDir = path.join(rootDir, "agents", "main", "agent");
+    const agentDir = state.agentDir("worker");
+    const mainAgentDir = state.agentDir();
     fs.mkdirSync(agentDir, { recursive: true });
     fs.mkdirSync(mainAgentDir, { recursive: true });
-    try {
-      await withEnvAsync({ OPENCLAW_STATE_DIR: rootDir }, async () => {
-        mockModelDiscovery();
+    mockModelDiscovery();
 
-        const first = await resolveModelAsync("openai", "gpt-5.5", agentDir, undefined, {
-          runtimeHooks: createRuntimeHooks(),
-        });
-        saveAuthProfileStore(
-          {
-            version: 1,
-            profiles: { "openai:default": { type: "api_key", provider: "openai", key: "one" } },
-          },
-          mainAgentDir,
-          { filterExternalAuthProfiles: false, syncExternalCli: false },
-        );
-        const second = await resolveModelAsync("openai", "gpt-5.5", agentDir, undefined, {
-          runtimeHooks: createRuntimeHooks(),
-        });
+    const first = await resolveModelAsync("openai", "gpt-5.5", agentDir, undefined, {
+      runtimeHooks: createRuntimeHooks(),
+    });
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: { "openai:default": { type: "api_key", provider: "openai", key: "one" } },
+      },
+      mainAgentDir,
+      { filterExternalAuthProfiles: false, syncExternalCli: false },
+    );
+    const second = await resolveModelAsync("openai", "gpt-5.5", agentDir, undefined, {
+      runtimeHooks: createRuntimeHooks(),
+    });
 
-        expectResolvedModel(first);
-        expectResolvedModel(second);
-        expect(discoverAuthStorage).toHaveBeenCalledTimes(1);
-        expect(discoverModels).toHaveBeenCalledTimes(1);
-      });
-    } finally {
-      fs.rmSync(rootDir, { recursive: true, force: true });
-    }
+    expectResolvedModel(first);
+    expectResolvedModel(second);
+    expect(discoverAuthStorage).toHaveBeenCalledTimes(1);
+    expect(discoverModels).toHaveBeenCalledTimes(1);
   });
 
   it("keeps runtime auth snapshots inside the lifecycle generation", async () => {
@@ -952,10 +960,10 @@ describe("resolveModel", () => {
     ]);
     mockModelDiscovery();
 
-    const first = await resolveModelAsync("openai", "gpt-5.5", "/tmp/agent", undefined, {
+    const first = await resolveModelAsync("openai", "gpt-5.5", state.agentDir(), undefined, {
       runtimeHooks: createRuntimeHooks(),
     });
-    const second = await resolveModelAsync("openai", "gpt-5.5", "/tmp/agent", undefined, {
+    const second = await resolveModelAsync("openai", "gpt-5.5", state.agentDir(), undefined, {
       runtimeHooks: createRuntimeHooks(),
     });
 
@@ -970,10 +978,10 @@ describe("resolveModel", () => {
     resolveRuntimeExternalAuthProviderRefsMock.mockReturnValue(["external-provider"]);
     mockModelDiscovery();
 
-    const first = await resolveModelAsync("openai", "gpt-5.5", "/tmp/agent", undefined, {
+    const first = await resolveModelAsync("openai", "gpt-5.5", state.agentDir(), undefined, {
       runtimeHooks: createRuntimeHooks(),
     });
-    const second = await resolveModelAsync("openai", "gpt-5.5", "/tmp/agent", undefined, {
+    const second = await resolveModelAsync("openai", "gpt-5.5", state.agentDir(), undefined, {
       runtimeHooks: createRuntimeHooks(),
     });
 
@@ -987,7 +995,7 @@ describe("resolveModel", () => {
     const result = await resolveModelAsync(
       "openrouter",
       "openrouter/auto",
-      "/tmp/agent",
+      state.agentDir(),
       undefined,
       {
         runtimeHooks: createRuntimeHooks(),
@@ -1009,7 +1017,7 @@ describe("resolveModel", () => {
     const result = await resolveModelAsync(
       "mistral",
       "mistral-medium-3-5",
-      "/tmp/agent",
+      state.agentDir(),
       undefined,
       {
         allowBundledStaticCatalogFallback: true,
@@ -1053,7 +1061,7 @@ describe("resolveModel", () => {
     const result = await resolveModelAsync(
       "mistral",
       "mistral-medium-3-5",
-      "/tmp/agent",
+      state.agentDir(),
       undefined,
       {
         allowBundledStaticCatalogFallback: true,
@@ -1079,7 +1087,7 @@ describe("resolveModel", () => {
     });
     const preparedModelRuntime = {
       catalogOwner: undefined,
-      agentDir: "/tmp/agent",
+      agentDir: state.agentDir(),
       activeProjectKeys: [],
       allowGatewaySubagentBinding: false,
       config: cfg,
@@ -1097,7 +1105,7 @@ describe("resolveModel", () => {
       createStores: () => ({ authStorage: {} as never, modelRegistry: {} as never }),
     } satisfies PreparedModelRuntimeSnapshot;
 
-    const result = await resolveModelAsync("deepseek", "deepseek-v4-pro", "/tmp/agent", cfg, {
+    const result = await resolveModelAsync("deepseek", "deepseek-v4-pro", state.agentDir(), cfg, {
       authStorage: { mocked: true } as never,
       modelRegistry: { find: vi.fn(() => null) } as never,
       preparedModelRuntime,
@@ -1121,7 +1129,7 @@ describe("resolveModel", () => {
 
     const preparedModelRuntime = {
       catalogOwner: undefined,
-      agentDir: "/tmp/agent",
+      agentDir: state.agentDir(),
       activeProjectKeys: [],
       allowGatewaySubagentBinding: false,
       config: {},
@@ -1135,7 +1143,7 @@ describe("resolveModel", () => {
     const result = await resolveModelAsync(
       "mistral",
       "mistral-medium-3-5",
-      "/tmp/agent",
+      state.agentDir(),
       undefined,
       {
         allowBundledStaticCatalogFallback: true,
@@ -1159,7 +1167,7 @@ describe("resolveModel", () => {
     const metadataSnapshot = createPluginMetadataSnapshotFixture();
     const preparedModelRuntime = {
       catalogOwner: undefined,
-      agentDir: "/tmp/agent",
+      agentDir: state.agentDir(),
       activeProjectKeys: [],
       allowGatewaySubagentBinding: false,
       config: {},
@@ -1186,7 +1194,7 @@ describe("resolveModel", () => {
     const result = await resolveModelAsync(
       "google",
       "gemini-3.1-pro-preview",
-      "/tmp/agent",
+      state.agentDir(),
       undefined,
       {
         allowBundledStaticCatalogFallback: true,
@@ -1252,7 +1260,7 @@ describe("resolveModel", () => {
     const prepareProviderDynamicModel = vi.fn(baseRuntimeHooks.prepareProviderDynamicModel);
     const runProviderDynamicModel = vi.fn(() => undefined);
 
-    const result = await resolveModelAsync("openai", "gpt-5.3-codex", "/tmp/agent", cfg, {
+    const result = await resolveModelAsync("openai", "gpt-5.3-codex", state.agentDir(), cfg, {
       allowBundledStaticCatalogFallback: true,
       preferBundledStaticCatalogTransport: true,
       runtimeHooks: {
@@ -1304,7 +1312,7 @@ describe("resolveModel", () => {
       models: [{ id: "gpt-5.3-codex", name: "GPT-5.3 Codex" }],
     });
 
-    const result = await resolveModelForTest("openai", "gpt-5.3-codex", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("openai", "gpt-5.3-codex", state.agentDir(), cfg);
 
     expectRecordFields(expectResolvedModel(result), {
       provider: "openai",
@@ -1333,7 +1341,7 @@ describe("resolveModel", () => {
     const result = await resolveModelAsync(
       "fireworks",
       "accounts/fireworks/models/kimi-k2p6",
-      "/tmp/agent",
+      state.agentDir(),
       undefined,
       {
         allowBundledStaticCatalogFallback: true,
@@ -1391,7 +1399,7 @@ describe("resolveModel", () => {
     const result = await resolveModelForTest(
       "fireworks",
       "accounts/fireworks/models/kimi-k2p6",
-      "/tmp/agent",
+      state.agentDir(),
       cfg,
     );
 
@@ -1439,7 +1447,7 @@ describe("resolveModel", () => {
     }));
     const shouldPreferProviderRuntimeResolvedModel = vi.fn(() => true);
 
-    const result = await resolveModelAsync("openai", "gpt-5.5-pro", "/tmp/agent", undefined, {
+    const result = await resolveModelAsync("openai", "gpt-5.5-pro", state.agentDir(), undefined, {
       allowBundledStaticCatalogFallback: true,
       runtimeHooks: {
         ...baseRuntimeHooks,
@@ -1478,7 +1486,7 @@ describe("resolveModel", () => {
           : "https://chatgpt.com/backend-api",
     }));
 
-    const result = await resolveModelAsync("openai", "gpt-5.5", "/tmp/agent", undefined, {
+    const result = await resolveModelAsync("openai", "gpt-5.5", state.agentDir(), undefined, {
       authProfileMode: "api_key",
       runtimeHooks: {
         ...baseRuntimeHooks,
@@ -1515,7 +1523,7 @@ describe("resolveModel", () => {
     const anthropicResult = await resolveModelAsync(
       "anthropic",
       "anthropic/claude-haiku-4-5",
-      "/tmp/agent",
+      state.agentDir(),
       undefined,
       {
         allowBundledStaticCatalogFallback: true,
@@ -1524,7 +1532,7 @@ describe("resolveModel", () => {
         skipProviderRuntimeHooks: true,
       },
     );
-    const openaiResult = await resolveModelAsync("openai", "gpt-4o", "/tmp/agent", undefined, {
+    const openaiResult = await resolveModelAsync("openai", "gpt-4o", state.agentDir(), undefined, {
       allowBundledStaticCatalogFallback: true,
       runtimeHooks: createRuntimeHooks(),
       skipAgentDiscovery: true,
@@ -1601,7 +1609,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelAsync("mistral", "mistral-medium-3-5", "/tmp/agent", cfg, {
+    const result = await resolveModelAsync("mistral", "mistral-medium-3-5", state.agentDir(), cfg, {
       allowBundledStaticCatalogFallback: true,
       runtimeHooks: createRuntimeHooks(),
       skipAgentDiscovery: true,
@@ -1655,10 +1663,10 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelAsync("openai", "gpt-5.5-pro", "/tmp/agent", undefined, {
+    const result = await resolveModelAsync("openai", "gpt-5.5-pro", state.agentDir(), undefined, {
       allowBundledStaticCatalogFallback: true,
       authStorage: { mocked: true } as never,
-      modelRegistry: discoverModels({ mocked: true } as never, "/tmp/agent"),
+      modelRegistry: discoverModels({ mocked: true } as never, state.agentDir()),
       runtimeHooks: createRuntimeHooks(),
       skipAgentDiscovery: true,
     });
@@ -1696,7 +1704,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("custom", "vision-model", "/tmp/agent", {
+    const result = await resolveModelForTest("custom", "vision-model", state.agentDir(), {
       models: {
         providers: {
           custom: {
@@ -1722,7 +1730,7 @@ describe("resolveModel", () => {
     const result = await resolveModelAsync(
       "mistral",
       "mistral-medium-3-5",
-      "/tmp/agent",
+      state.agentDir(),
       undefined,
       {
         runtimeHooks: createRuntimeHooks(),
@@ -1756,7 +1764,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("custom", "missing-input", "/tmp/agent", {
+    const result = await resolveModelForTest("custom", "missing-input", state.agentDir(), {
       models: {
         providers: {
           custom: {
@@ -1796,7 +1804,7 @@ describe("resolveModel", () => {
       },
     };
 
-    const result = await resolveModelForTest("openai", "gpt-5.5", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("openai", "gpt-5.5", state.agentDir(), cfg);
 
     expectRecordFields(expectResolvedModel(result), {
       provider: "openai",
@@ -1808,7 +1816,7 @@ describe("resolveModel", () => {
   it("includes provider baseUrl in fallback model", async () => {
     const cfg = makeProviderConfig("custom", { baseUrl: "http://localhost:9000" });
 
-    const result = await resolveModelForTest("custom", "missing-model", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("custom", "missing-model", state.agentDir(), cfg);
     const model = expectResolvedModel(result);
 
     expect(model.baseUrl).toBe("http://localhost:9000");
@@ -1822,7 +1830,12 @@ describe("resolveModel", () => {
       baseUrl: "https://generativelanguage.googleapis.com",
     });
 
-    const result = await resolveModelForTest("google", "gemini-2.5-flash-lite", "/tmp/agent", cfg);
+    const result = await resolveModelForTest(
+      "google",
+      "gemini-2.5-flash-lite",
+      state.agentDir(),
+      cfg,
+    );
     const model = expectResolvedModel(result);
 
     expect(model.provider).toBe("google");
@@ -1839,7 +1852,7 @@ describe("resolveModel", () => {
     const result = await resolveModelForTest(
       "google-vertex",
       "gemini-2.5-flash",
-      "/tmp/agent",
+      state.agentDir(),
       cfg,
     );
     const model = expectResolvedModel(result);
@@ -1879,7 +1892,7 @@ describe("resolveModel", () => {
     const result = await resolveModelForTest(
       "xiaomi-token-plan",
       "mimo-v2.5-pro",
-      "/tmp/agent",
+      state.agentDir(),
       cfg,
     );
     const model = expectResolvedModel(result);
@@ -1901,7 +1914,7 @@ describe("resolveModel", () => {
   it("preserves configured maxTokens provenance from model discovery", async () => {
     mockDiscoveredGroqModel("configured");
 
-    const result = await resolveModelForTest("groq", "llama-3.3-70b-versatile", "/tmp/agent");
+    const result = await resolveModelForTest("groq", "llama-3.3-70b-versatile", state.agentDir());
     const model = expectResolvedModel(result);
 
     expectRecordFields(model, {
@@ -1918,7 +1931,12 @@ describe("resolveModel", () => {
       maxTokens: 2_048,
     });
 
-    const result = await resolveModelForTest("groq", "llama-3.3-70b-versatile", "/tmp/agent", cfg);
+    const result = await resolveModelForTest(
+      "groq",
+      "llama-3.3-70b-versatile",
+      state.agentDir(),
+      cfg,
+    );
     const model = expectResolvedModel(result);
 
     expectRecordFields(model, {
@@ -1941,7 +1959,12 @@ describe("resolveModel", () => {
       ],
     });
 
-    const result = await resolveModelForTest("groq", "llama-3.3-70b-versatile", "/tmp/agent", cfg);
+    const result = await resolveModelForTest(
+      "groq",
+      "llama-3.3-70b-versatile",
+      state.agentDir(),
+      cfg,
+    );
     const model = expectResolvedModel(result);
 
     expectRecordFields(model, {
@@ -1964,7 +1987,7 @@ describe("resolveModel", () => {
       models: [{ id: "mimo-v2.5-pro", name: "mimo-v2.5-pro" }],
     });
 
-    const result = await resolveModelForTest("xiaomi", "mimo-v2.5-pro", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("xiaomi", "mimo-v2.5-pro", state.agentDir(), cfg);
     const model = expectResolvedModel(result);
 
     expect(model.id).toBe("mimo-v2.5-pro");
@@ -1978,7 +2001,7 @@ describe("resolveModel", () => {
     );
     const cfg = makeDeepSeekConfig({ compat: { supportsReasoningEffort: false } }, { baseUrl: "" });
 
-    const result = await resolveModelForTest("deepseek", "deepseek-v4-pro", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("deepseek", "deepseek-v4-pro", state.agentDir(), cfg);
     const model = expectResolvedModel(result);
 
     expectRecordFields(model, {
@@ -2016,7 +2039,7 @@ describe("resolveModel", () => {
       ...makeConfiguredDeepSeekModel(),
     }));
 
-    const result = await resolveModelAsync("deepseek", "deepseek-v4-pro", "/tmp/agent", cfg, {
+    const result = await resolveModelAsync("deepseek", "deepseek-v4-pro", state.agentDir(), cfg, {
       runtimeHooks: {
         ...baseRuntimeHooks,
         runProviderDynamicModel,
@@ -2048,7 +2071,7 @@ describe("resolveModel", () => {
     );
     const cfg = makeDeepSeekConfig({ thinkingLevelMap: { off: null } });
 
-    const result = await resolveModelAsync("deepseek", "deepseek-v4-pro", "/tmp/agent", cfg, {
+    const result = await resolveModelAsync("deepseek", "deepseek-v4-pro", state.agentDir(), cfg, {
       runtimeHooks: createRuntimeHooks(),
       skipAgentDiscovery: true,
     });
@@ -2088,7 +2111,7 @@ describe("resolveModel", () => {
       }),
     );
 
-    const result = await resolveModelAsync("deepseek", "deepseek-v4-pro", "/tmp/agent", cfg, {
+    const result = await resolveModelAsync("deepseek", "deepseek-v4-pro", state.agentDir(), cfg, {
       runtimeHooks: {
         ...baseRuntimeHooks,
         runProviderDynamicModel,
@@ -2120,7 +2143,7 @@ describe("resolveModel", () => {
       },
     );
 
-    const result = await resolveModelForTest("deepseek", "deepseek-v4-pro", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("deepseek", "deepseek-v4-pro", state.agentDir(), cfg);
     const model = expectResolvedModel(result);
 
     expectRecordFields(model, {
@@ -2140,7 +2163,7 @@ describe("resolveModel", () => {
       { api: "openai-completions" },
     );
 
-    const result = await resolveModelForTest("deepseek", "deepseek-v4-pro", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("deepseek", "deepseek-v4-pro", state.agentDir(), cfg);
     const model = expectResolvedModel(result);
 
     expectRecordFields(model, {
@@ -2183,7 +2206,7 @@ describe("resolveModel", () => {
     const result = await resolveModelForTest(
       "xiaomi-token-plan",
       "mimo-v2.5-pro",
-      "/tmp/agent",
+      state.agentDir(),
       cfg,
     );
     const model = expectResolvedModel(result);
@@ -2198,7 +2221,7 @@ describe("resolveModel", () => {
   it("does not synthesize unknown models from timeout-only provider overlays", async () => {
     const cfg = makeProviderConfig("openai", { timeoutSeconds: 300, baseUrl: "" });
 
-    const result = await resolveModelForTest("openai", "typo-model", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("openai", "typo-model", state.agentDir(), cfg);
 
     expect(result.model).toBeUndefined();
     expect(result.error).toBe("Unknown model: openai/typo-model");
@@ -2218,7 +2241,7 @@ describe("resolveModel", () => {
     const result = await resolveModelForTest(
       "typoProvider",
       "typoed-model",
-      "/tmp/agent",
+      state.agentDir(),
       makeOpenClawConfigFixture(cfg),
     );
 
@@ -2240,7 +2263,7 @@ describe("resolveModel", () => {
     const result = await resolveModelForTest(
       "openai",
       "typoed-model",
-      "/tmp/agent",
+      state.agentDir(),
       makeOpenClawConfigFixture(cfg),
     );
 
@@ -2277,13 +2300,18 @@ describe("resolveModel", () => {
       },
     } as unknown as OpenClawConfig;
 
-    const claude = await resolveModelForTest("my-router", "my-router/claude", "/tmp/agent", cfg);
+    const claude = await resolveModelForTest(
+      "my-router",
+      "my-router/claude",
+      state.agentDir(),
+      cfg,
+    );
     const claudeModel = expectResolvedModel(claude);
     expect(claudeModel.api).toBe("anthropic-messages");
     expect(claudeModel.baseUrl).toBe("http://localhost:8080");
     expect(claudeModel.maxTokens).toBeUndefined();
 
-    const gpt = await resolveModelForTest("my-router", "my-router/gpt", "/tmp/agent", cfg);
+    const gpt = await resolveModelForTest("my-router", "my-router/gpt", state.agentDir(), cfg);
     const gptModel = expectResolvedModel(gpt);
     expect(gptModel.api).toBe("openai-completions");
     expect(gptModel.baseUrl).toBe("http://localhost:8080/v1");
@@ -2303,7 +2331,7 @@ describe("resolveModel", () => {
       ],
     });
 
-    const result = await resolveModelForTest("my-gemini", "gemini-pro", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("my-gemini", "gemini-pro", state.agentDir(), cfg);
     const model = expectResolvedModel(result);
 
     expect(model.api).toBe("google-generative-ai");
@@ -2327,7 +2355,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("local-agent-proxy", "gpt-5.2", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("local-agent-proxy", "gpt-5.2", state.agentDir(), cfg);
     const model = expectResolvedModel(result);
 
     expectRecordFields(model, {
@@ -2352,7 +2380,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("ds4", "deepseek-v4-flash", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("ds4", "deepseek-v4-flash", state.agentDir(), cfg);
     const model = expectResolvedModel(result);
 
     expect(getModelProviderLocalService(model)).toEqual({
@@ -2386,7 +2414,7 @@ describe("resolveModel", () => {
       },
     } as unknown as OpenClawConfig;
 
-    const result = await resolveModelForTest("qwen", "qwen3.6-plus", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("qwen", "qwen3.6-plus", state.agentDir(), cfg);
 
     expectRecordFields(expectResolvedModel(result), {
       provider: "qwen",
@@ -2405,7 +2433,7 @@ describe("resolveModel", () => {
       api: "openai-completions",
     });
 
-    const result = await resolveModelForTest("qwen", "qwen3.6-plus", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("qwen", "qwen3.6-plus", state.agentDir(), cfg);
 
     expect(result.model).toBeUndefined();
     expect(result.error).toBe(
@@ -2433,7 +2461,7 @@ describe("resolveModel", () => {
       },
     } as unknown as OpenClawConfig;
 
-    const result = await resolveModelForTest("openai", "gpt-5.4-mini", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("openai", "gpt-5.4-mini", state.agentDir(), cfg);
 
     expectRecordFields(expectResolvedModel(result), {
       provider: "openai",
@@ -2450,7 +2478,7 @@ describe("resolveModel", () => {
       api: "google-generative-ai",
     });
 
-    const result = await resolveModelForTest("google-paid", "missing-model", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("google-paid", "missing-model", state.agentDir(), cfg);
 
     expect(expectResolvedModel(result).baseUrl).toBe(
       "https://generativelanguage.googleapis.com/v1beta",
@@ -2468,7 +2496,7 @@ describe("resolveModel", () => {
       models: [{ id: "gemini-2.5-pro", name: "gemini-2.5-pro" }],
     });
 
-    const result = await resolveModelForTest("google", "gemini-2.5-pro", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("google", "gemini-2.5-pro", state.agentDir(), cfg);
     const model = expectResolvedModel(result);
 
     expect(model.api).toBe("google-generative-ai");
@@ -2482,7 +2510,7 @@ describe("resolveModel", () => {
       models: [{ ...makeModel("gpt-5.4"), provider: "custom-openai" }],
     });
 
-    const result = await resolveModelForTest("custom-openai", "gpt-5.4", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("custom-openai", "gpt-5.4", state.agentDir(), cfg);
 
     expectRecordFields(expectResolvedModel(result), {
       provider: "custom-openai",
@@ -2499,7 +2527,7 @@ describe("resolveModel", () => {
       models: [{ ...makeModel("grok-4.1-fast"), provider: "custom-xai" }],
     });
 
-    const result = await resolveModelForTest("custom-xai", "grok-4.1-fast", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("custom-xai", "grok-4.1-fast", state.agentDir(), cfg);
 
     expectRecordFields(expectResolvedModel(result), {
       provider: "custom-xai",
@@ -2510,7 +2538,7 @@ describe("resolveModel", () => {
   });
 
   it("leaves dynamic GitHub Copilot request identity to runtime auth preparation", async () => {
-    const result = await resolveModelForTest("github-copilot", "gpt-5.5", "/tmp/agent");
+    const result = await resolveModelForTest("github-copilot", "gpt-5.5", state.agentDir());
     const model = expectResolvedModel(result) as unknown as { headers?: Record<string, string> };
 
     expect(model.headers).toBeUndefined();
@@ -2523,7 +2551,7 @@ describe("resolveModel", () => {
       models: [makeModel("gpt-5.5")],
     });
 
-    const result = await resolveModelForTest("github-copilot", "gpt-5.5", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("github-copilot", "gpt-5.5", state.agentDir(), cfg);
     const model = expectResolvedModel(result) as unknown as { headers?: Record<string, string> };
 
     expect(model.headers).toBeUndefined();
@@ -2537,7 +2565,7 @@ describe("resolveModel", () => {
     });
 
     // Requesting a non-listed model forces the providerCfg fallback branch.
-    const result = await resolveModelForTest("custom", "missing-model", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("custom", "missing-model", state.agentDir(), cfg);
     const model = expectResolvedModel(result) as unknown as { headers?: Record<string, string> };
 
     expect(model.headers).toEqual({
@@ -2556,7 +2584,7 @@ describe("resolveModel", () => {
       models: [makeModel("listed-model")],
     });
 
-    const result = await resolveModelForTest("custom", "missing-model", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("custom", "missing-model", state.agentDir(), cfg);
     const model = expectResolvedModel(result) as unknown as { headers?: Record<string, string> };
 
     expect(model.headers).toEqual({
@@ -2573,7 +2601,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("custom", "listed-model", "/tmp/agent");
+    const result = await resolveModelForTest("custom", "listed-model", state.agentDir());
     const model = expectResolvedModel(result) as unknown as { headers?: Record<string, string> };
 
     expect(model.headers).toEqual({
@@ -2590,7 +2618,7 @@ describe("resolveModel", () => {
       ],
     });
 
-    const result = await resolveModelForTest("custom", "model-b", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("custom", "model-b", state.agentDir(), cfg);
     const model = expectResolvedModel(result);
 
     expect(model.contextWindow).toBe(262144);
@@ -2626,7 +2654,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("ollama", "qwen3:32b", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("ollama", "qwen3:32b", state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expect((result.model as { params?: Record<string, unknown> } | undefined)?.params).toEqual({
@@ -2643,7 +2671,7 @@ describe("resolveModel", () => {
       params: { num_ctx: 65536, top_p: 0.9 },
     });
 
-    const result = await resolveModelForTest("ollama", "qwen3:32b", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("ollama", "qwen3:32b", state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expect((result.model as { params?: Record<string, unknown> } | undefined)?.params).toEqual({
@@ -2661,7 +2689,7 @@ describe("resolveModel", () => {
       models: [makeModel("qwen3:32b")],
     });
 
-    const result = await resolveModelForTest("ollama", "qwen3:32b", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("ollama", "qwen3:32b", state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expect((result.model as { requestTimeoutMs?: number } | undefined)?.requestTimeoutMs).toBe(
@@ -2684,7 +2712,7 @@ describe("resolveModel", () => {
     const result = await resolveModelForTest(
       "openai",
       "gpt-5.5",
-      "/tmp/agent",
+      state.agentDir(),
       makeOpenClawConfigFixture(cfg),
     );
 
@@ -2709,7 +2737,7 @@ describe("resolveModel", () => {
     const result = await resolveModelForTest(
       "openai",
       "gpt-5.5",
-      "/tmp/agent",
+      state.agentDir(),
       makeOpenClawConfigFixture(cfg),
     );
 
@@ -2732,7 +2760,7 @@ describe("resolveModel", () => {
       ],
     });
 
-    const result = await resolveModelForTest("ollama", "qwen3.5:9b", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("ollama", "qwen3.5:9b", state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expect(result.model?.contextWindow).toBe(8_192);
@@ -2758,7 +2786,7 @@ describe("resolveModel", () => {
       ],
     });
 
-    const result = await resolveModelForTest("ollama", "qwen3.5:9b", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("ollama", "qwen3.5:9b", state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expect(result.model?.contextWindow).toBe(16_384);
@@ -2779,7 +2807,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("ollama", "llama3.2", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("ollama", "llama3.2", state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expect((result.model as { params?: Record<string, unknown> } | undefined)?.params).toEqual({
@@ -2796,7 +2824,7 @@ describe("resolveModel", () => {
       ],
     });
 
-    const result = await resolveModelForTest("custom", "model-b", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("custom", "model-b", state.agentDir(), cfg);
 
     expect(result.model?.reasoning).toBe(true);
   });
@@ -2813,7 +2841,7 @@ describe("resolveModel", () => {
       ],
     });
 
-    const result = await resolveModelForTest("vllm", "Qwen/Qwen3-8B", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("vllm", "Qwen/Qwen3-8B", state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expect(result.model?.compat).toEqual(
@@ -2831,7 +2859,7 @@ describe("resolveModel", () => {
     });
     const cfg = makeVllmQwenConfig();
 
-    const result = await resolveModelForTest("vllm", "Qwen/Qwen3-8B", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("vllm", "Qwen/Qwen3-8B", state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expect(result.model?.reasoning).toBe(true);
@@ -2854,7 +2882,7 @@ describe("resolveModel", () => {
     });
     const cfg = makeVllmQwenConfig();
 
-    const result = await resolveModelForTest("vllm", "Qwen/Qwen3-8B", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("vllm", "Qwen/Qwen3-8B", state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expect(result.model?.reasoning).toBe(false);
@@ -2865,7 +2893,7 @@ describe("resolveModel", () => {
   it("infers reasoning for matching vLLM Qwen compat fallback models", async () => {
     const cfg = makeVllmQwenConfig();
 
-    const result = await resolveModelForTest("vllm", "Qwen/Qwen3-8B", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("vllm", "Qwen/Qwen3-8B", state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expect(result.model?.reasoning).toBe(true);
@@ -2880,7 +2908,7 @@ describe("resolveModel", () => {
       ],
     });
 
-    const result = await resolveModelForTest("custom", "model-b", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("custom", "model-b", state.agentDir(), cfg);
 
     expect(result.model?.input).toEqual(["text", "image"]);
   });
@@ -2892,7 +2920,7 @@ describe("resolveModel", () => {
       models: [{ ...makeModel("custom/vision-model"), input: ["text", "image"] }],
     });
 
-    const result = await resolveModelForTest("custom", "vision-model", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("custom", "vision-model", state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -2909,7 +2937,7 @@ describe("resolveModel", () => {
       models: [{ ...makeModel("volcengine/vision-model"), input: ["text", "image"] }],
     });
 
-    const result = await resolveModelForTest("bytedance", "vision-model", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("bytedance", "vision-model", state.agentDir(), cfg);
 
     expect(result.error).toBe("Unknown model: bytedance/vision-model");
   });
@@ -2921,7 +2949,7 @@ describe("resolveModel", () => {
       models: [{ ...makeModel("kimi-k2.6"), name: "Kimi K2.6", input: ["text", "image"] }],
     });
 
-    const result = await resolveModelForTest("moonshotai", "kimi-k2.6", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("moonshotai", "kimi-k2.6", state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -2937,7 +2965,7 @@ describe("resolveModel", () => {
       models: [makeModel("kimi-k2.6")],
     });
 
-    const result = await resolveModelForTest("moonshot-ai", "kimi-k2.6", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("moonshot-ai", "kimi-k2.6", state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -2967,7 +2995,7 @@ describe("resolveModel", () => {
     const result = await resolveModelForTest(
       "azure-openai-responses",
       "gpt-5.5",
-      "/tmp/agent",
+      state.agentDir(),
       cfg,
     );
 
@@ -3007,7 +3035,7 @@ describe("resolveModel", () => {
     const result = await resolveModelAsyncForTest(
       "azure-openai-responses",
       "gpt-5.5",
-      "/tmp/agent",
+      state.agentDir(),
       cfg,
       {
         allowBundledStaticCatalogFallback: true,
@@ -3067,7 +3095,7 @@ describe("resolveModel", () => {
     const result = await resolveModelAsyncForTest(
       "azure-openai-responses",
       "gpt-5.5",
-      "/tmp/agent",
+      state.agentDir(),
       cfg,
       {
         allowBundledStaticCatalogFallback: true,
@@ -3116,7 +3144,7 @@ describe("resolveModel", () => {
     const result = await resolveModelAsyncForTest(
       "azure-openai-responses",
       "gpt-5.5",
-      "/tmp/agent",
+      state.agentDir(),
       undefined,
       {
         allowBundledStaticCatalogFallback: true,
@@ -3162,7 +3190,7 @@ describe("resolveModel", () => {
     const result = await resolveModelAsyncForTest(
       "azure-openai-responses",
       "gpt-5.5",
-      "/tmp/agent",
+      state.agentDir(),
       undefined,
       {
         allowBundledStaticCatalogFallback: true,
@@ -3196,8 +3224,13 @@ describe("resolveModel", () => {
 
       const result =
         resolver === "sync"
-          ? await resolveModelForTest("azure-openai-responses", "gpt-5.5", "/tmp/agent", cfg)
-          : await resolveModelAsyncForTest("azure-openai-responses", "gpt-5.5", "/tmp/agent", cfg);
+          ? await resolveModelForTest("azure-openai-responses", "gpt-5.5", state.agentDir(), cfg)
+          : await resolveModelAsyncForTest(
+              "azure-openai-responses",
+              "gpt-5.5",
+              state.agentDir(),
+              cfg,
+            );
 
       expect(result.model).toBeUndefined();
       expect(result.error).toBe("Unknown model: azure-openai-responses/gpt-5.5");
@@ -3224,7 +3257,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("custom", "vision-model", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("custom", "vision-model", state.agentDir(), cfg);
 
     expect(result.model?.id).toBe("vision-model");
     expect(result.model?.input).toEqual(["text"]);
@@ -3256,7 +3289,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("mlx", modelId, "/tmp/agent", cfg);
+    const result = await resolveModelForTest("mlx", modelId, state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -3286,7 +3319,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("custom", "vision-model", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("custom", "vision-model", state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -3313,7 +3346,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("custom", "typoed-model", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("custom", "typoed-model", state.agentDir(), cfg);
 
     expect(result.model?.id).toBe("typoed-model");
     expect(result.model?.input).toEqual(["text"]);
@@ -3333,10 +3366,16 @@ describe("resolveModel", () => {
       },
     } as unknown as OpenClawConfig;
 
-    const result = await resolveModelAsync("microsoft-foundry", "Kimi-K2.6-1", "/tmp/agent", cfg, {
-      runtimeHooks: createRuntimeHooks(),
-      skipAgentDiscovery: true,
-    });
+    const result = await resolveModelAsync(
+      "microsoft-foundry",
+      "Kimi-K2.6-1",
+      state.agentDir(),
+      cfg,
+      {
+        runtimeHooks: createRuntimeHooks(),
+        skipAgentDiscovery: true,
+      },
+    );
 
     expect(result.error).toBe(
       'Unknown model: microsoft-foundry/Kimi-K2.6-1. Found agents.defaults.models["microsoft-foundry/Kimi-K2.6-1"], but no matching models.providers["microsoft-foundry"].models[] entry. Add { "id": "Kimi-K2.6-1", "name": "Kimi-K2.6-1" } to models.providers["microsoft-foundry"].models[] to register this provider model. For custom or proxy providers, also set api and baseUrl so requests route to the intended endpoint. See https://docs.openclaw.ai/concepts/model-providers.',
@@ -3372,7 +3411,7 @@ describe("resolveModel", () => {
     const result = await resolveModelAsync(
       "openai-codex",
       "gpt-5.4",
-      "/tmp/agent",
+      state.agentDir(),
       cfg as unknown as OpenClawConfig,
       {
         runtimeHooks: createRuntimeHooks(),
@@ -3396,7 +3435,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelAsync("custom-provider", "some-model", "/tmp/agent", cfg, {
+    const result = await resolveModelAsync("custom-provider", "some-model", state.agentDir(), cfg, {
       runtimeHooks: createRuntimeHooks(),
       skipAgentDiscovery: true,
     });
@@ -3419,7 +3458,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelAsync("openai", "gpt-5.3-codex", "/tmp/agent", cfg, {
+    const result = await resolveModelAsync("openai", "gpt-5.3-codex", state.agentDir(), cfg, {
       runtimeHooks: createRuntimeHooks(),
       skipAgentDiscovery: true,
     });
@@ -3449,7 +3488,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("microsoft-foundry", "gpt-5.4", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("microsoft-foundry", "gpt-5.4", state.agentDir(), cfg);
 
     expect(result.model?.input).toEqual(["text", "image"]);
   });
@@ -3474,7 +3513,12 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("anthropic", "claude-sonnet-4-5", "/tmp/agent", cfg);
+    const result = await resolveModelForTest(
+      "anthropic",
+      "claude-sonnet-4-5",
+      state.agentDir(),
+      cfg,
+    );
 
     expect(result.model?.input).toEqual(["text", "image"]);
   });
@@ -3516,7 +3560,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("microsoft-foundry", "gpt-5.4", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("microsoft-foundry", "gpt-5.4", state.agentDir(), cfg);
 
     expect(result.model?.input).toEqual(["text", "image"]);
   });
@@ -3539,7 +3583,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("microsoft-foundry", "gpt-5.4", "/tmp/agent");
+    const result = await resolveModelForTest("microsoft-foundry", "gpt-5.4", state.agentDir());
 
     expect(result.model?.input).toEqual(["text", "image"]);
   });
@@ -3588,7 +3632,11 @@ describe("resolveModel", () => {
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     });
 
-    const result = await resolveModelForTest("openrouter", "openrouter/healer-alpha", "/tmp/agent");
+    const result = await resolveModelForTest(
+      "openrouter",
+      "openrouter/healer-alpha",
+      state.agentDir(),
+    );
 
     expect(result.error).toBeUndefined();
     const resolvedModel = expectRecordFields(result.model, {
@@ -3608,7 +3656,11 @@ describe("resolveModel", () => {
   it("falls back to text-only when OpenRouter API cache is empty", async () => {
     mockGetOpenRouterModelCapabilities.mockReturnValue(undefined);
 
-    const result = await resolveModelForTest("openrouter", "openrouter/healer-alpha", "/tmp/agent");
+    const result = await resolveModelForTest(
+      "openrouter",
+      "openrouter/healer-alpha",
+      state.agentDir(),
+    );
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -3639,9 +3691,9 @@ describe("resolveModel", () => {
       }),
     );
 
-    const result = await resolveModelAsync("openrouter", modelId, "/tmp/agent", undefined, {
+    const result = await resolveModelAsync("openrouter", modelId, state.agentDir(), undefined, {
       authStorage: { mocked: true } as never,
-      modelRegistry: discoverModels({ mocked: true } as never, "/tmp/agent"),
+      modelRegistry: discoverModels({ mocked: true } as never, state.agentDir()),
       runtimeHooks: {
         ...baseRuntimeHooks,
         normalizeProviderResolvedModelWithPlugin,
@@ -3675,7 +3727,7 @@ describe("resolveModel", () => {
     const result = await resolveModelForTest(
       "huggingface",
       "huggingface/deepseek-ai/DeepSeek-R1",
-      "/tmp/agent",
+      state.agentDir(),
     );
 
     expect(result.error).toBeUndefined();
@@ -3704,7 +3756,7 @@ describe("resolveModel", () => {
     const result = await resolveModelAsyncForTest(
       "openrouter",
       "google/gemini-3.1-flash-image-preview",
-      "/tmp/agent",
+      state.agentDir(),
     );
 
     expect(mockLoadOpenRouterModelCapabilities).toHaveBeenCalledWith(
@@ -3742,7 +3794,7 @@ describe("resolveModel", () => {
     const result = await resolveModelAsyncForTest(
       "openrouter",
       "openrouter/healer-alpha",
-      "/tmp/agent",
+      state.agentDir(),
     );
 
     expect(mockLoadOpenRouterModelCapabilities).not.toHaveBeenCalled();
@@ -3774,9 +3826,9 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelAsync("openai", "gpt-5.5", "/tmp/agent", cfg, {
+    const result = await resolveModelAsync("openai", "gpt-5.5", state.agentDir(), cfg, {
       authStorage: { mocked: true } as never,
-      modelRegistry: discoverModels({ mocked: true } as never, "/tmp/agent"),
+      modelRegistry: discoverModels({ mocked: true } as never, state.agentDir()),
       runtimeHooks: {
         ...createRuntimeHooks(),
         normalizeProviderTransportWithPlugin,
@@ -3830,7 +3882,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("onehub", "glm-5", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("onehub", "glm-5", state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -3892,7 +3944,7 @@ describe("resolveModel", () => {
     const result = await resolveModelForTest(
       "bedrock",
       "bedrock-alias-exact-test",
-      "/tmp/agent",
+      state.agentDir(),
       cfg,
     );
 
@@ -3912,7 +3964,7 @@ describe("resolveModel", () => {
   it("builds an openai fallback for gpt-5.4", async () => {
     mockOpenAICodexTemplateModel(discoverModels);
 
-    const result = await resolveModelForTest("openai", "gpt-5.4", "/tmp/agent");
+    const result = await resolveModelForTest("openai", "gpt-5.4", state.agentDir());
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, buildOpenAICodexForwardCompatExpectation("gpt-5.4"));
@@ -3943,7 +3995,7 @@ describe("resolveModel", () => {
       }),
     } as unknown as ReturnType<typeof discoverModels>);
 
-    const result = await resolveModelForTest("openai", "gpt-5.4", "/tmp/agent");
+    const result = await resolveModelForTest("openai", "gpt-5.4", state.agentDir());
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -3972,7 +4024,7 @@ describe("resolveModel", () => {
       }),
     } as unknown as ReturnType<typeof discoverModels>);
 
-    const result = await resolveModelForTest("openai", "gpt-5.3-codex", "/tmp/agent");
+    const result = await resolveModelForTest("openai", "gpt-5.3-codex", state.agentDir());
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -3985,7 +4037,7 @@ describe("resolveModel", () => {
   it("canonicalizes the legacy openai gpt-5.4-codex alias at runtime", async () => {
     mockOpenAICodexTemplateModel(discoverModels);
 
-    const result = await resolveModelForTest("openai", "gpt-5.4-codex", "/tmp/agent");
+    const result = await resolveModelForTest("openai", "gpt-5.4-codex", state.agentDir());
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, buildOpenAICodexForwardCompatExpectation("gpt-5.4"));
@@ -4016,7 +4068,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("openai", "gpt-5.4-codex", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("openai", "gpt-5.4-codex", state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -4056,7 +4108,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("openai", "gpt-5.4-codex", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("openai", "gpt-5.4-codex", state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -4070,7 +4122,7 @@ describe("resolveModel", () => {
   it("builds an openai fallback for gpt-5.4-mini", async () => {
     mockOpenAICodexTemplateModel(discoverModels);
 
-    const result = await resolveModelForTest("openai", "gpt-5.4-mini", "/tmp/agent");
+    const result = await resolveModelForTest("openai", "gpt-5.4-mini", state.agentDir());
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -4083,7 +4135,7 @@ describe("resolveModel", () => {
   it("does not build an openai fallback for removed gpt-5.3-codex-spark", async () => {
     mockOpenAICodexTemplateModel(discoverModels);
 
-    const result = await resolveModelForTest("openai", "gpt-5.3-codex-spark", "/tmp/agent");
+    const result = await resolveModelForTest("openai", "gpt-5.3-codex-spark", state.agentDir());
 
     expect(result.model).toBeUndefined();
     expect(result.error).toBe(
@@ -4107,7 +4159,7 @@ describe("resolveModel", () => {
     const result = await resolveModelForTest(
       "xai",
       "grok-4.20-multi-agent-0309",
-      "/tmp/agent",
+      state.agentDir(),
       cfg,
     );
 
@@ -4120,7 +4172,7 @@ describe("resolveModel", () => {
   it("rejects stale openai gpt-5.3-codex-spark discovery rows", async () => {
     mockOpenAIForwardCompatDiscovery("gpt-5.3-codex-spark", { input: ["text"] });
 
-    const result = await resolveModelForTest("openai", "gpt-5.3-codex-spark", "/tmp/agent");
+    const result = await resolveModelForTest("openai", "gpt-5.3-codex-spark", state.agentDir());
 
     expect(result.model).toBeUndefined();
     expect(result.error).toBe(
@@ -4135,7 +4187,7 @@ describe("resolveModel", () => {
       input: ["text"],
     });
 
-    const result = await resolveModelForTest("openai", "gpt-5.4", "/tmp/agent");
+    const result = await resolveModelForTest("openai", "gpt-5.4", state.agentDir());
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -4175,7 +4227,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("openai", "gpt-5.5-pro", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("openai", "gpt-5.5-pro", state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -4238,7 +4290,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("openai", "gpt-5.5", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("openai", "gpt-5.5", state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -4257,7 +4309,7 @@ describe("resolveModel", () => {
       contextTokens: 32_000,
     });
 
-    const result = await resolveModelAsyncForTest("openai", "gpt-5.4", "/tmp/agent");
+    const result = await resolveModelAsyncForTest("openai", "gpt-5.4", state.agentDir());
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -4273,7 +4325,7 @@ describe("resolveModel", () => {
       baseUrl: "https://chatgpt.com/backend-api/v1",
     });
 
-    const result = await resolveModelForTest("openai", "gpt-5.4", "/tmp/agent");
+    const result = await resolveModelForTest("openai", "gpt-5.4", state.agentDir());
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -4302,7 +4354,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("openrouter", "openai/gpt-5.4", "/tmp/agent");
+    const result = await resolveModelForTest("openrouter", "openai/gpt-5.4", state.agentDir());
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -4316,7 +4368,7 @@ describe("resolveModel", () => {
   it("normalizes discovered openai metadata when api is missing", async () => {
     mockOpenAIForwardCompatDiscovery("gpt-5.4", { api: undefined });
 
-    const result = await resolveModelForTest("openai", "gpt-5.4", "/tmp/agent");
+    const result = await resolveModelForTest("openai", "gpt-5.4", state.agentDir());
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -4335,11 +4387,12 @@ describe("resolveModel", () => {
 
     const shouldPreferRuntimeResolvedModel = vi.fn(
       (params: { workspaceDir?: string; context: { agentDir?: string } }) =>
-        params.workspaceDir === "/tmp/workspace" && params.context.agentDir === "/tmp/agent-state",
+        params.workspaceDir === state.workspaceDir &&
+        params.context.agentDir === state.agentDir("state"),
     );
     const runProviderDynamicModel = vi.fn(
       (params: { workspaceDir?: string; context: { provider: string; modelId: string } }) =>
-        params.workspaceDir === "/tmp/workspace" &&
+        params.workspaceDir === state.workspaceDir &&
         params.context.provider === "openai" &&
         params.context.modelId === "gpt-5.4"
           ? ({
@@ -4356,33 +4409,33 @@ describe("resolveModel", () => {
     const cfg = {
       agents: {
         defaults: {
-          workspace: "/tmp/workspace",
+          workspace: state.workspaceDir,
         },
       },
     } as OpenClawConfig;
 
-    const result = await resolveModelAsync("openai", "gpt-5.4", "/tmp/agent-state", cfg, {
+    const result = await resolveModelAsync("openai", "gpt-5.4", state.agentDir("state"), cfg, {
       authStorage: { mocked: true } as never,
-      modelRegistry: discoverModels({ mocked: true } as never, "/tmp/agent-state"),
+      modelRegistry: discoverModels({ mocked: true } as never, state.agentDir("state")),
       runtimeHooks,
     });
 
     const preferInput = mockCallArg(shouldPreferRuntimeResolvedModel);
     expectRecordFields(preferInput, {
       provider: "openai",
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: state.workspaceDir,
     });
     expectRecordFields(preferInput.context, {
-      agentDir: "/tmp/agent-state",
-      workspaceDir: "/tmp/workspace",
+      agentDir: state.agentDir("state"),
+      workspaceDir: state.workspaceDir,
     });
     const dynamicInput = mockCallArg(runProviderDynamicModel);
     expectRecordFields(dynamicInput, {
       provider: "openai",
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: state.workspaceDir,
     });
     expectRecordFields(dynamicInput.context, {
-      agentDir: "/tmp/agent-state",
+      agentDir: state.agentDir("state"),
       modelId: "gpt-5.4",
       provider: "openai",
     });
@@ -4401,8 +4454,8 @@ describe("resolveModel", () => {
         workspaceDir?: string;
         context: { workspaceDir?: string; provider: string; modelId: string };
       }) =>
-        params.workspaceDir === "/tmp/workspace" &&
-        params.context.workspaceDir === "/tmp/workspace" &&
+        params.workspaceDir === state.workspaceDir &&
+        params.context.workspaceDir === state.workspaceDir &&
         params.context.provider === "openai" &&
         params.context.modelId === "gpt-5.4"
           ? ({
@@ -4418,7 +4471,7 @@ describe("resolveModel", () => {
     const cfg = {
       agents: {
         defaults: {
-          workspace: "/tmp/workspace",
+          workspace: state.workspaceDir,
         },
       },
     } as OpenClawConfig;
@@ -4426,19 +4479,19 @@ describe("resolveModel", () => {
     const result = resolveModelWithRegistry({
       provider: "openai",
       modelId: "gpt-5.4",
-      agentDir: "/tmp/agent-state",
+      agentDir: state.agentDir("state"),
       cfg,
-      modelRegistry: discoverModels({ mocked: true } as never, "/tmp/agent-state"),
+      modelRegistry: discoverModels({ mocked: true } as never, state.agentDir("state")),
       runtimeHooks,
     });
 
     const dynamicInput = mockCallArg(runProviderDynamicModel);
     expectRecordFields(dynamicInput, {
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: state.workspaceDir,
     });
     expectRecordFields(dynamicInput.context, {
-      workspaceDir: "/tmp/workspace",
-      agentDir: "/tmp/agent-state",
+      workspaceDir: state.workspaceDir,
+      agentDir: state.agentDir("state"),
       modelId: "gpt-5.4",
       provider: "openai",
     });
@@ -4454,7 +4507,7 @@ describe("resolveModel", () => {
       input: ["text"],
     });
 
-    const result = await resolveModelForTest("openai", "gpt-5.4-mini", "/tmp/agent");
+    const result = await resolveModelForTest("openai", "gpt-5.4-mini", state.agentDir());
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -4479,7 +4532,7 @@ describe("resolveModel", () => {
       }),
     });
 
-    const result = await resolveModelForTest("openai", "gpt-5.3-codex-spark", "/tmp/agent");
+    const result = await resolveModelForTest("openai", "gpt-5.3-codex-spark", state.agentDir());
 
     expect(result.model).toBeUndefined();
     expect(result.error).toBe(
@@ -4588,7 +4641,7 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("openai", "gpt-5.4", "/tmp/agent", cfg);
+    const result = await resolveModelForTest("openai", "gpt-5.4", state.agentDir(), cfg);
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -4624,7 +4677,12 @@ describe("resolveModel", () => {
       },
     });
 
-    const result = await resolveModelForTest("github-copilot", "gpt-5.4-mini", "/tmp/agent", cfg);
+    const result = await resolveModelForTest(
+      "github-copilot",
+      "gpt-5.4-mini",
+      state.agentDir(),
+      cfg,
+    );
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -4643,7 +4701,11 @@ describe("resolveModel", () => {
   });
 
   it("resolves github-copilot Claude dynamic models to anthropic-messages by default", async () => {
-    const result = await resolveModelForTest("github-copilot", "claude-sonnet-4.6", "/tmp/agent");
+    const result = await resolveModelForTest(
+      "github-copilot",
+      "claude-sonnet-4.6",
+      state.agentDir(),
+    );
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -4682,7 +4744,7 @@ describe("resolveModel", () => {
         },
       };
 
-      const result = await resolveModelForTest("github-copilot", modelId, "/tmp/agent", cfg);
+      const result = await resolveModelForTest("github-copilot", modelId, state.agentDir(), cfg);
 
       expect(result.error).toBeUndefined();
       expectRecordFields(result.model, {
@@ -4695,7 +4757,7 @@ describe("resolveModel", () => {
   );
 
   it("builds an openai fallback for gpt-5.5 when the live catalog cache is cold", async () => {
-    const result = await resolveModelForTest("openai", "gpt-5.5", "/tmp/agent");
+    const result = await resolveModelForTest("openai", "gpt-5.5", state.agentDir());
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -4731,7 +4793,7 @@ describe("resolveModel", () => {
       }),
     });
 
-    const result = await resolveModelForTest("openai", "gpt-5.4-mini", "/tmp/agent");
+    const result = await resolveModelForTest("openai", "gpt-5.4-mini", state.agentDir());
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -4763,7 +4825,7 @@ describe("resolveModel", () => {
       }),
     });
 
-    const result = await resolveModelForTest("openai", "gpt-5.4-nano", "/tmp/agent");
+    const result = await resolveModelForTest("openai", "gpt-5.4-nano", state.agentDir());
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -4791,7 +4853,7 @@ describe("resolveModel", () => {
       }),
     });
 
-    const result = await resolveModelForTest("openai", "gpt-5.4", "/tmp/agent");
+    const result = await resolveModelForTest("openai", "gpt-5.4", state.agentDir());
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -4815,7 +4877,7 @@ describe("resolveModel", () => {
       }),
     });
 
-    const result = await resolveModelForTest("openai", "gpt-5.4", "/tmp/agent");
+    const result = await resolveModelForTest("openai", "gpt-5.4", state.agentDir());
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -4839,7 +4901,7 @@ describe("resolveModel", () => {
       }),
     });
 
-    const result = await resolveModelForTest("xai", "grok-4.20-0309-reasoning", "/tmp/agent");
+    const result = await resolveModelForTest("xai", "grok-4.20-0309-reasoning", state.agentDir());
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -4863,9 +4925,9 @@ describe("resolveModel", () => {
       }),
     });
 
-    const result = await resolveModelAsync("xai", "grok-4.3-latest", "/tmp/agent", undefined, {
+    const result = await resolveModelAsync("xai", "grok-4.3-latest", state.agentDir(), undefined, {
       authStorage: { mocked: true } as never,
-      modelRegistry: discoverModels({ mocked: true } as never, "/tmp/agent"),
+      modelRegistry: discoverModels({ mocked: true } as never, state.agentDir()),
       runtimeHooks: {
         buildProviderUnknownModelHintWithPlugin: () => undefined,
         prepareProviderDynamicModel: async () => {},

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -27,6 +27,10 @@ import { mintSecretSentinel } from "../../secrets/sentinel.js";
 import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.types.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
 import { loadSqliteTrajectoryRuntimeEvents } from "../../trajectory/runtime-store.sqlite.js";
 import { createTrajectoryRuntimeRecorder } from "../../trajectory/runtime.js";
 import {
@@ -177,10 +181,15 @@ const mockCallGatewayTool = vi.mocked(callGatewayTool);
 
 const originalRuntime = process.env.OPENCLAW_AGENT_RUNTIME;
 const trajectoryTempDirs = createTempDirTracker();
+let generationState: OpenClawTestState;
 let selectionAdmission: PreparedAgentRunAdmission;
 let selectionAdmittedRunContext: AdmittedRunContext;
 
 beforeEach(async () => {
+  generationState = await createOpenClawTestState({
+    label: "harness-model-generation",
+    applyEnv: false,
+  });
   resetAgentRunRegistryForTest();
   resetModelGenerationFixtureState();
   selectionAdmission = prepareAgentRunAdmission({
@@ -237,7 +246,7 @@ beforeEach(async () => {
   });
 });
 
-afterEach(() => {
+afterEach(async () => {
   vi.unstubAllEnvs();
   clearRuntimeConfigSnapshot();
   closeOpenClawAgentDatabasesForTest();
@@ -261,6 +270,7 @@ afterEach(() => {
   } else {
     process.env.OPENCLAW_AGENT_RUNTIME = originalRuntime;
   }
+  await generationState.cleanup();
 });
 
 function createAttemptParams(config?: OpenClawConfig): EmbeddedRunAttemptParams {
@@ -475,6 +485,8 @@ function maybeCompactAgentHarnessSession(
   const preparedModelRuntime =
     options.preparedModelRuntime ??
     createModelGenerationFixture({
+      agentDir: generationState.agentDir(),
+      workspaceDir: generationState.workspaceDir,
       config: params.config ?? {},
       createStores: () => ({ authStorage: {} as never, modelRegistry: {} as never }),
       label: "harness-test",
@@ -3752,6 +3764,8 @@ describe("selectAgentHarness", () => {
     const cfg = {} as OpenClawConfig;
     const createStores = () => ({ authStorage: {} as never, modelRegistry: {} as never });
     const generationA = createModelGenerationFixture({
+      agentDir: generationState.agentDir(),
+      workspaceDir: generationState.workspaceDir,
       config: cfg,
       createStores,
       label: "compact-a",
@@ -3761,6 +3775,8 @@ describe("selectAgentHarness", () => {
       runtimeApi: "openai-responses",
     });
     const generationB = createModelGenerationFixture({
+      agentDir: generationState.agentDir(),
+      workspaceDir: generationState.workspaceDir,
       config: cfg,
       createStores,
       label: "compact-b",

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -17,6 +17,10 @@ import type {
 } from "../../plugin-sdk/media-understanding.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
 import type { AuthProfileCredential, AuthProfileStore } from "../auth-profiles/types.js";
 import {
   createModelGenerationFixture,
@@ -2700,21 +2704,24 @@ describe("image tool data URL support", () => {
 
 describe("image tool MiniMax VLM routing", () => {
   const priorFetch = global.fetch;
+  let state: OpenClawTestState;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ label: "minimax-vlm", applyEnv: false });
     installImageUnderstandingProviderStubs(minimaxProvider);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     global.fetch = priorFetch;
     imageProviderHarness.reset();
     testing.setProviderDepsForTest();
+    await state.cleanup();
   });
 
   async function createMinimaxVlmFixture(baseResp: { status_code: number; status_msg: string }) {
     const fetchMock = stubMinimaxFetch(baseResp, baseResp.status_code === 0 ? "ok" : "");
 
-    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-minimax-vlm-"));
+    const agentDir = state.agentDir();
     vi.stubEnv("MINIMAX_API_KEY", "minimax-test");
     const cfg = createMinimaxImageConfig();
     const tool = createRequiredImageTool({ config: cfg, agentDir });
@@ -3188,43 +3195,50 @@ describe("image compression policy", () => {
   });
 
   it("keeps runtime augmentation pinned to the prepared plugin generation", async () => {
-    const provider = "prepared-image-provider";
-    const model = "prepared-image-model";
-    const cfg = {} satisfies OpenClawConfig;
-    const generationA = createModelGenerationFixture({
-      config: cfg,
-      label: "image-a",
-      provider,
-      requestProvider: provider,
-      modelId: model,
-      runtimeAugment: true,
-      staticImagePolicy: {
-        maxBytes: 1_000_000,
-        preferredSidePx: 1_280,
-        tokenMode: "detail",
-      },
-      runtimeImagePolicy: { maxSidePx: 1_440 },
-    });
-    const generationB = createModelGenerationFixture({
-      config: cfg,
-      label: "image-b",
-      provider,
-      requestProvider: provider,
-      modelId: model,
-      runtimeAugment: true,
-      staticImagePolicy: {
-        maxBytes: 2_000_000,
-        preferredSidePx: 2_560,
-        tokenMode: "provider",
-      },
-      runtimeImagePolicy: { maxSidePx: 2_880 },
-    });
-    installImageUnderstandingProviderDeps([], {
-      useDefaultResolveModelAsync: true,
-    });
-    publishCurrentModelGeneration(generationB);
-
+    const state = await createOpenClawTestState({ label: "image-model-generation" });
     try {
+      const provider = "prepared-image-provider";
+      const model = "prepared-image-model";
+      const cfg = {} satisfies OpenClawConfig;
+      const generationA = createModelGenerationFixture({
+        agentDir: state.agentDir("prepared"),
+        workspaceDir: state.workspaceDir,
+        config: cfg,
+        label: "image-a",
+        provider,
+        requestProvider: provider,
+        modelId: model,
+        runtimeAugment: true,
+        staticImagePolicy: {
+          maxBytes: 1_000_000,
+          preferredSidePx: 1_280,
+          tokenMode: "detail",
+        },
+        runtimeImagePolicy: { maxSidePx: 1_440 },
+      });
+      const generationB = createModelGenerationFixture({
+        agentDir: state.agentDir("prepared"),
+        workspaceDir: state.workspaceDir,
+        config: cfg,
+        label: "image-b",
+        provider,
+        requestProvider: provider,
+        modelId: model,
+        runtimeAugment: true,
+        staticImagePolicy: {
+          maxBytes: 2_000_000,
+          preferredSidePx: 2_560,
+          tokenMode: "provider",
+        },
+        runtimeImagePolicy: { maxSidePx: 2_880 },
+      });
+      installImageUnderstandingProviderDeps([], {
+        useDefaultResolveModelAsync: true,
+      });
+      publishCurrentModelGeneration(generationB);
+
+      // Compression deliberately omits agentDir: real resolution uses the default
+      // agent, not the distinct "prepared" agent stored in the snapshot.
       await expect(
         testing.resolveImageCompressionPolicy({
           cfg,
@@ -3248,6 +3262,7 @@ describe("image compression policy", () => {
       expect(generationB.resolveDynamicModel).not.toHaveBeenCalled();
     } finally {
       resetModelGenerationFixtureState();
+      await state.cleanup();
     }
   });
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled. This branch is in the upstream repository.

</details>

Related: https://github.com/openclaw/openclaw/pull/133209 (shared embedded-run fixture ownership).

## What Problem This Solves

Resolves a problem where model-resolution tests could inspect auth or workspace data outside their owned fixtures even when model discovery was mocked. This affected the main resolver, forward compatibility, skipped discovery, prepared generation and timeout suites; BTW setup also performed a real workspace scan through a fixed path.

A failed concurrent-generation resolution could leave its sibling waiting while cleanup removed their state. Several model/image fixture allocations also lacked scoped disposal.

## Why This Change Was Made

Keep the repair at the fixture producers. Canonical `OpenClawTestState` now owns explicit paths and default-resolution state, and transparent lexical guards reject unowned requests before native auth or workspace discovery. Valid native calls and auth options still pass through unchanged. Discovery mocks are not broadened, and no env-only auth mode or production seam is added.

The generation helper takes explicit execution directories and publishes the supplied workspace across all five consumers. Omitted config/agent-directory arguments, distinct agent identities, A/B generation ownership and metadata-only plugin descriptors remain intact. Concurrent resolutions are released and both joined in `finally`; HTTP timeout fixtures abort their own fetch, join the actual source generator and verify body unlock before cleanup. Existing timeout values are unchanged.

## User Impact

No shipped runtime, provider, configuration, database schema, protocol or dependency behavior changes. Developers get isolated, reproducible model-resolution tests without reading unrelated temporary auth state or leaving fixture work alive after teardown.

**Production LOC: +0/-0. Tests and test support: +658/-347, net +311.** The eleven changed files comprise ten existing test/support files and one shared native-boundary guard. The guard replaces repeated setup rather than adding a production API. The nearby MiniMax fixture cleanup is included without changing its environment semantics.

## Evidence

Both the coding worker and the parent ran and verified the final fixture family: **652 passing case registrations across 13 files, zero failures or skips**. This covers all 500 cases in the nine affected runnable suites, plus the original 159-case timeout/inline/idle/abort/first-event matrix, with seven timeout cases counted once. Parameterized Vitest display names can repeat, so evidence uses each file's ordered registrations rather than treating display names as unique IDs. Separate native project reports avoid counting overwritten JSON or reruns twice.

Safe pre-fix guards captured four main-resolver failures, four synchronous forward-compatibility failures, five generation failures, BTW setup failure, and the skipped-discovery workspace/auth failures. Guards stopped those requests before native filesystem delegation. Identical fixed selections passed, followed by the complete suites. Filtered cases and setup failures are distinguished from executed passing assertions.

A temporary early-failure probe made generation A fail before the shared gate while B remained pending. Before the cleanup fix, only A had settled at the cleanup boundary; after release/join, both had settled. Both probe variants included an unconditional rescue join, and the probe was removed byte-for-byte before final validation. No duplicate permanent test was added.

The complete classified changed gate passed after removing one introduced unused import. Its earlier lint failure is retained. Fresh canonical isolated Codex autoreview found no actionable P0 issue, and an exact-byte source/consumer audit confirmed omission, generation, metadata lifetime and credential-acquisition boundaries. API-key-only synthetic seeds and explicit acquisition mocks do not reach external CLI/Keychain readers; this is not inferred merely from private HOME or `allowKeychainPrompt:false`.

Native test commands below ran with Node 24.15.0, pinned pnpm 12.1.0 and clean-whitelist private HOME/state/config/workspace/XDG/TMP namespaces outside Git. Reporter/output-path arguments are omitted here; exact launch receipts and separate native JSON reports are retained locally.

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/model.provider-hooks.timeout.test.ts src/agents/embedded-agent-runner/model.skip-agent-discovery-hooks.test.ts src/agents/embedded-agent-runner/model.test.ts src/agents/embedded-agent-runner/model.forward-compat.test.ts src/agents/embedded-agent-runner/model.generation-scope.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/btw.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/command/cli-compaction.test.ts src/agents/harness/selection.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/tools/image-tool.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts src/agents/embedded-agent-runner/run/llm-idle-timeout.abort.test.ts
```

```bash
node scripts/run-vitest.mjs packages/ai/src/utils/stream-first-event-timeout.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/model.inline-provider.test.ts
```

This is synthetic fixture and owned loopback HTTP proof, not live model, Codex, Gateway or channel verification. No live state or service operation is included.
