### PR TITLE
fix(agents): settle owned orphan transcript repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Docs: https://docs.openclaw.ai
 - **Browser extension relay:** route Runtime binding callbacks only to registered clients and preserve shared bindings during client cleanup, preventing raw callback payloads from reaching unrelated Playwright sessions.
 - **Control UI media playback:** restore inline audio and video rendition loading so readiness checks reach the Gateway instead of silently falling back to download cards. (#132832)
 - **Gateway cancellation:** route the first `chat.abort` directly to its cancellation handler without loading unrelated chat history and send workflows.
+- **Agent transcript repair:** persist repaired orphan-turn cursors and finish their projection before continuing the attempt, avoiding stale transcript failures while preserving cancellation and writer ownership checks.
 - **Persisted agent runtimes:** prepare the trusted harness and provider selected by an existing session before Gateway, channel, and cron execution, while keeping plugin generations isolated and closed leases unusable.
 
 - **Grok web search startup:** avoid loading the full agent runtime before the first search, while preserving agent-scoped credentials and OAuth fallback behavior.

--- a/src/agents/embedded-agent-runner/run/attempt-session-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-boundary.test.ts
@@ -16,7 +16,10 @@ import {
   waitForSessionTranscriptIndexReconcile,
 } from "../../../config/sessions/session-transcript-reconcile.js";
 import type { SessionTranscriptReconcileWorkerMessage } from "../../../config/sessions/session-transcript-reconcile.worker.js";
-import { SessionTranscriptWriterClaimReboundError } from "../../../config/sessions/transcript-write-context.js";
+import {
+  SessionTranscriptWriterClaimReboundError,
+  withOwnedSessionTranscriptWrites,
+} from "../../../config/sessions/transcript-write-context.js";
 import { buildTimestampPrefix } from "../../../gateway/server-methods/agent-timestamp.js";
 import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
 import type { AgentMessage } from "../../runtime/index.js";
@@ -109,13 +112,19 @@ describe("prepareEmbeddedAttemptSessionBoundary", () => {
           input.attempt.onUserMessagePersistenceInvalidated = invalidated;
           if (reason === "aborted") {
             input.abortSignal = AbortSignal.abort(new Error("cancel before repair"));
-          } else {
-            input.sessionManager = SessionManager.openBounded(
-              { ...target, expectedWriterRunId: "replaced-owner" },
-              { maxBytes: 4096, maxEvents: 20 },
-            ) as ReturnType<typeof guardSessionManager>;
           }
-          await expect(prepareEmbeddedAttemptSessionBoundary(input)).rejects.toThrow(
+          const prepare = () => prepareEmbeddedAttemptSessionBoundary(input);
+          const preparing =
+            reason === "rebound-writer"
+              ? withOwnedSessionTranscriptWrites(
+                  {
+                    sessionTarget: { ...target, expectedWriterRunId: "replaced-owner" },
+                    withTranscriptWrite: async (operation) => await operation(),
+                  },
+                  prepare,
+                )
+              : prepare();
+          await expect(preparing).rejects.toThrow(
             reason === "aborted"
               ? "cancel before repair"
               : SessionTranscriptWriterClaimReboundError,

--- a/src/agents/embedded-agent-runner/run/attempt-session-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-boundary.test.ts
@@ -1,8 +1,28 @@
+import path from "node:path";
+import { Worker } from "node:worker_threads";
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import {
+  appendTranscriptMessageSync,
+  loadTranscriptEventsSync,
+  upsertSessionEntryCore,
+} from "../../../config/sessions/session-accessor.js";
+import {
+  resolveSqliteTranscriptScope,
+  toDatabaseOptions,
+} from "../../../config/sessions/session-accessor.sqlite-scope.js";
+import {
+  startSessionTranscriptIndexReconcile,
+  waitForSessionTranscriptIndexReconcile,
+} from "../../../config/sessions/session-transcript-reconcile.js";
+import type { SessionTranscriptReconcileWorkerMessage } from "../../../config/sessions/session-transcript-reconcile.worker.js";
+import { SessionTranscriptWriterClaimReboundError } from "../../../config/sessions/transcript-write-context.js";
 import { buildTimestampPrefix } from "../../../gateway/server-methods/agent-timestamp.js";
+import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import type { AgentSession } from "../../sessions/index.js";
+import { SessionManager } from "../../sessions/session-manager.js";
 import { prepareEmbeddedAttemptSessionBoundary } from "./attempt-session-prepare.js";
 
 function createActiveSession(messages: AgentMessage[] = []) {
@@ -23,16 +43,187 @@ function createSessionManager(
 ): ReturnType<typeof guardSessionManager> {
   return {
     getLeafEntry: () => undefined,
+    getSessionTarget: () => undefined,
     ...overrides,
   } as unknown as ReturnType<typeof guardSessionManager>;
 }
 
+async function withPersistedOrphanBoundary(
+  options: { parent: boolean; metadata: boolean },
+  run: (fixture: {
+    input: Parameters<typeof prepareEmbeddedAttemptSessionBoundary>[0];
+    manager: SessionManager;
+    orphanId: string;
+    target: NonNullable<ReturnType<SessionManager["getSessionTarget"]>>;
+  }) => Promise<void>,
+) {
+  await withOpenClawTestState({ label: "orphan-projection" }, async (state) => {
+    const target = {
+      agentId: "main",
+      sessionId: "orphan-projection",
+      sessionKey: "agent:main:orphan-projection",
+      storePath: path.join(state.sessionsDir(), "sessions.json"),
+    };
+    await upsertSessionEntryCore(target, { sessionId: target.sessionId, updatedAt: 1 });
+    const seed = SessionManager.open(target, state.workspaceDir);
+    if (options.parent) {
+      seed.appendModelChange("openai", "gpt-5.5");
+    }
+    const orphanId = seed.appendMessage({ role: "user", content: "orphan wake", timestamp: 1 });
+    if (options.metadata) {
+      seed.appendThinkingLevelChange("low");
+      seed.appendModelChange("openai", "gpt-5.5");
+    }
+    const manager = SessionManager.openBounded(target, {
+      cwd: state.workspaceDir,
+      maxBytes: 4096,
+      maxEvents: 20,
+    });
+    const { activeSession } = createActiveSession(manager.buildSessionContext().messages);
+    await run({
+      input: {
+        activeSession,
+        attempt: { prompt: "new request", trigger: "user" },
+        getUserTranscriptContexts: () => undefined,
+        isRawModelRun: false,
+        preparedUserTurnMessage: undefined,
+        sessionManager: manager as ReturnType<typeof guardSessionManager>,
+        setActiveSessionSystemPrompt: vi.fn(),
+      },
+      manager,
+      orphanId,
+      target,
+    });
+  });
+}
+
 describe("prepareEmbeddedAttemptSessionBoundary", () => {
+  it.each(["aborted", "rebound-writer"] as const)(
+    "does not persist orphan repair for an unavailable owner: %s",
+    async (reason) => {
+      await withPersistedOrphanBoundary(
+        { parent: true, metadata: true },
+        async ({ input, target }) => {
+          const before = loadTranscriptEventsSync(target);
+          const invalidated = vi.fn();
+          input.attempt.onUserMessagePersistenceInvalidated = invalidated;
+          if (reason === "aborted") {
+            input.abortSignal = AbortSignal.abort(new Error("cancel before repair"));
+          } else {
+            input.sessionManager = SessionManager.openBounded(
+              { ...target, expectedWriterRunId: "replaced-owner" },
+              { maxBytes: 4096, maxEvents: 20 },
+            ) as ReturnType<typeof guardSessionManager>;
+          }
+          await expect(prepareEmbeddedAttemptSessionBoundary(input)).rejects.toThrow(
+            reason === "aborted"
+              ? "cancel before repair"
+              : SessionTranscriptWriterClaimReboundError,
+          );
+          expect(loadTranscriptEventsSync(target)).toEqual(before);
+          expect(invalidated).not.toHaveBeenCalled();
+        },
+      );
+    },
+  );
+
+  it("cancels its projection wait before publishing repaired prompt state", async () => {
+    await withPersistedOrphanBoundary(
+      { parent: true, metadata: true },
+      async ({ input, target }) => {
+        const claimed = createDeferred();
+        const databaseOptions = toDatabaseOptions(resolveSqliteTranscriptScope(target));
+        let releaseWorker: (() => void) | undefined;
+        startSessionTranscriptIndexReconcile({
+          ...databaseOptions,
+          createWorker: (filename, options) => {
+            const worker = new Worker(filename, options);
+            const postMessage = worker.postMessage.bind(worker);
+            let claiming = false;
+            worker.on("message", (message: SessionTranscriptReconcileWorkerMessage) => {
+              claiming = message.type === "plan-start";
+            });
+            // Hold the real worker after the owner claims the dirty projection.
+            // No fixture sleeps or database mutation decides the ordering.
+            worker.postMessage = (message: unknown, transferList) => {
+              if (claiming && !releaseWorker) {
+                releaseWorker = () => postMessage(message, transferList);
+                claimed.resolve();
+                return;
+              }
+              postMessage(message, transferList);
+            };
+            return worker;
+          },
+        });
+        const controller = new AbortController();
+        input.abortSignal = controller.signal;
+        const messages = input.activeSession.agent.state.messages;
+        const invalidated = vi.fn();
+        input.attempt.onUserMessagePersistenceInvalidated = invalidated;
+        const preparing = prepareEmbeddedAttemptSessionBoundary(input);
+        const outcome = preparing.then(
+          () => ({ kind: "resolved" as const }),
+          (error: unknown) => ({ kind: "rejected" as const, error }),
+        );
+        try {
+          await Promise.race([
+            claimed.promise,
+            outcome.then(() => {
+              throw new Error("repair settled before its projection was claimed");
+            }),
+          ]);
+          const abortReason = new Error("cancel owned projection wait");
+          controller.abort(abortReason);
+          await expect(outcome).resolves.toMatchObject({
+            kind: "rejected",
+            error: { name: "AbortError", cause: abortReason },
+          });
+          expect(input.activeSession.agent.state.messages).toBe(messages);
+          expect(invalidated).not.toHaveBeenCalled();
+        } finally {
+          releaseWorker?.();
+          await Promise.all([outcome, waitForSessionTranscriptIndexReconcile(databaseOptions)]);
+        }
+      },
+    );
+  });
+
+  it.each([
+    { parent: true, metadata: true },
+    { parent: true, metadata: false },
+    { parent: false, metadata: true },
+    { parent: false, metadata: false },
+  ])("settles its orphan repair before subsequent parent adoption: %j", async (options) => {
+    await withPersistedOrphanBoundary(options, async ({ input, manager, orphanId, target }) => {
+      const boundary = await prepareEmbeddedAttemptSessionBoundary(input);
+      expect(boundary.orphanRepair?.removeLeaf).toBe(true);
+      const reopened = SessionManager.openBounded(target, { maxBytes: 4096, maxEvents: 20 });
+      expect(reopened.getBranch().map((entry) => entry.id)).not.toContain(orphanId);
+      expect(loadTranscriptEventsSync(target)).toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: orphanId })]),
+      );
+      expect(
+        appendTranscriptMessageSync(target, {
+          eventId: "out-of-band",
+          message: { role: "assistant", content: "external continuation", timestamp: 2 },
+        }).ok,
+      ).toBe(true);
+      const appended = manager.appendMessageWithTranscriptAnchor({
+        role: "user",
+        content: "replacement",
+        timestamp: 3,
+      });
+      expect(appended.anchor?.effectiveParentId).toBe("out-of-band");
+      expect(manager.getEntry(appended.entryId)?.parentId).toBe("out-of-band");
+    });
+  });
+
   it("resets restored state and preserves exact prompt bytes for raw model probes", async () => {
     const { activeSession, reset } = createActiveSession();
     const setActiveSessionSystemPrompt = vi.fn();
 
-    const boundary = prepareEmbeddedAttemptSessionBoundary({
+    const boundary = await prepareEmbeddedAttemptSessionBoundary({
       activeSession,
       attempt: { prompt: "exact probe" },
       getUserTranscriptContexts: () => undefined,
@@ -72,7 +263,7 @@ describe("prepareEmbeddedAttemptSessionBoundary", () => {
         message: { role: "user", content: "old" },
       }),
     });
-    const boundary = prepareEmbeddedAttemptSessionBoundary({
+    const boundary = await prepareEmbeddedAttemptSessionBoundary({
       activeSession,
       attempt: {
         operation: "settled-tool-finalization",
@@ -106,7 +297,7 @@ describe("prepareEmbeddedAttemptSessionBoundary", () => {
   it("applies the prepared current-turn timestamp at the LLM boundary", async () => {
     const { activeSession } = createActiveSession();
     const preparedTimestamp = 1_717_570_800_000;
-    const boundary = prepareEmbeddedAttemptSessionBoundary({
+    const boundary = await prepareEmbeddedAttemptSessionBoundary({
       activeSession,
       attempt: {
         config: { agents: { defaults: { userTimezone: "UTC" } } },
@@ -150,7 +341,7 @@ describe("prepareEmbeddedAttemptSessionBoundary", () => {
       __openclaw: { senderId: "alice-id", senderName: "Alice" },
     } as AgentMessage;
     const { activeSession } = createActiveSession();
-    prepareEmbeddedAttemptSessionBoundary({
+    await prepareEmbeddedAttemptSessionBoundary({
       activeSession,
       attempt: { prompt: "The launch is Friday", trigger: "user" },
       getUserTranscriptContexts: () => [{ runtimeMessage, transcriptMessage }],
@@ -177,7 +368,7 @@ describe("prepareEmbeddedAttemptSessionBoundary", () => {
       timestamp: 2,
     } as AgentMessage;
     const { activeSession } = createActiveSession();
-    prepareEmbeddedAttemptSessionBoundary({
+    await prepareEmbeddedAttemptSessionBoundary({
       activeSession,
       attempt: { prompt: "The launch is Friday", trigger: "user" },
       getUserTranscriptContexts: () => [
@@ -224,7 +415,7 @@ describe("prepareEmbeddedAttemptSessionBoundary", () => {
       timestamp: 1,
     } as AgentMessage;
     const { activeSession } = createActiveSession();
-    prepareEmbeddedAttemptSessionBoundary({
+    await prepareEmbeddedAttemptSessionBoundary({
       activeSession,
       attempt: { prompt: "same", trigger: "user" },
       getUserTranscriptContexts: () => [
@@ -261,7 +452,7 @@ describe("prepareEmbeddedAttemptSessionBoundary", () => {
 
   it.each([false, true])(
     "preserves the admitted current user with persistence suppression set to %s",
-    (suppressNextUserMessagePersistence) => {
+    async (suppressNextUserMessagePersistence) => {
       const currentUser = {
         role: "user" as const,
         content: "current prompt",
@@ -293,7 +484,7 @@ describe("prepareEmbeddedAttemptSessionBoundary", () => {
         >[0]["attempt"]["userTurnTranscriptRecorder"]
       >;
 
-      const boundary = prepareEmbeddedAttemptSessionBoundary({
+      const boundary = await prepareEmbeddedAttemptSessionBoundary({
         activeSession,
         attempt: {
           onUserMessagePersistenceInvalidated,
@@ -318,174 +509,78 @@ describe("prepareEmbeddedAttemptSessionBoundary", () => {
     },
   );
 
-  it("preserves the admitted current user when its active-session copy is absent", () => {
-    const currentUser = {
-      role: "user" as const,
-      content: "current prompt",
-      idempotencyKey: "current-run:user",
-      timestamp: 1,
-    };
-    const { activeSession } = createActiveSession([]);
-    const branch = vi.fn();
-    const resetLeaf = vi.fn();
-    const clearNextUserMessagePersistenceSuppression = vi.fn();
-    const onUserMessagePersistenceInvalidated = vi.fn();
-    const sessionManager = createSessionManager({
-      branch,
-      resetLeaf,
-      clearNextUserMessagePersistenceSuppression,
-      getLeafEntry: () => ({
-        id: "current-user",
-        parentId: "previous-assistant",
-        timestamp: "2026-07-13T00:00:00.000Z",
-        type: "message",
-        message: currentUser,
-      }),
-    });
-    const recorder = {
-      hasPersisted: () => true,
-    } as NonNullable<
-      Parameters<
-        typeof prepareEmbeddedAttemptSessionBoundary
-      >[0]["attempt"]["userTurnTranscriptRecorder"]
-    >;
+  it.each([
+    { name: "the active-session copy is absent", prepared: true, recorded: false, persisted: true },
+    {
+      name: "only the recorder owns the durable user",
+      prepared: false,
+      recorded: true,
+      persisted: true,
+    },
+    {
+      name: "recorder state is lost on restart",
+      prepared: true,
+      recorded: false,
+      persisted: false,
+    },
+  ])(
+    "preserves the admitted current user when $name",
+    async ({ prepared, recorded, persisted }) => {
+      const currentUser = {
+        role: "user" as const,
+        content: "current prompt",
+        idempotencyKey: "current-run:user",
+        timestamp: 1,
+      };
+      const { activeSession } = createActiveSession([]);
+      const branch = vi.fn();
+      const resetLeaf = vi.fn();
+      const clearNextUserMessagePersistenceSuppression = vi.fn();
+      const onUserMessagePersistenceInvalidated = vi.fn();
+      const sessionManager = createSessionManager({
+        branch,
+        resetLeaf,
+        clearNextUserMessagePersistenceSuppression,
+        getLeafEntry: () => ({
+          id: "current-user",
+          parentId: "previous-assistant",
+          timestamp: "2026-07-13T00:00:00.000Z",
+          type: "message",
+          message: currentUser,
+        }),
+      });
+      const recorder = {
+        hasPersisted: () => persisted,
+        ...(recorded ? { getPersistedMessage: () => currentUser } : {}),
+      } as NonNullable<
+        Parameters<
+          typeof prepareEmbeddedAttemptSessionBoundary
+        >[0]["attempt"]["userTurnTranscriptRecorder"]
+      >;
+      const boundary = await prepareEmbeddedAttemptSessionBoundary({
+        activeSession,
+        attempt: {
+          onUserMessagePersistenceInvalidated,
+          prompt: "current prompt",
+          trigger: "user",
+          userTurnTranscriptRecorder: recorder,
+        },
+        getUserTranscriptContexts: () => undefined,
+        isRawModelRun: false,
+        preparedUserTurnMessage: prepared ? currentUser : undefined,
+        sessionManager,
+        setActiveSessionSystemPrompt: vi.fn(),
+      });
+      expect(boundary.orphanRepair).toBeUndefined();
+      expect(activeSession.agent.state.messages).toEqual([]);
+      expect(branch).not.toHaveBeenCalled();
+      expect(resetLeaf).not.toHaveBeenCalled();
+      expect(clearNextUserMessagePersistenceSuppression).not.toHaveBeenCalled();
+      expect(onUserMessagePersistenceInvalidated).not.toHaveBeenCalled();
+    },
+  );
 
-    const boundary = prepareEmbeddedAttemptSessionBoundary({
-      activeSession,
-      attempt: {
-        onUserMessagePersistenceInvalidated,
-        prompt: "current prompt",
-        trigger: "user",
-        userTurnTranscriptRecorder: recorder,
-      },
-      getUserTranscriptContexts: () => undefined,
-      isRawModelRun: false,
-      preparedUserTurnMessage: currentUser,
-      sessionManager,
-      setActiveSessionSystemPrompt: vi.fn(),
-    });
-
-    expect(boundary.orphanRepair).toBeUndefined();
-    expect(activeSession.agent.state.messages).toEqual([]);
-    expect(branch).not.toHaveBeenCalled();
-    expect(resetLeaf).not.toHaveBeenCalled();
-    expect(clearNextUserMessagePersistenceSuppression).not.toHaveBeenCalled();
-    expect(onUserMessagePersistenceInvalidated).not.toHaveBeenCalled();
-  });
-
-  it("preserves a recorder-owned durable user when the prepared message is unavailable", () => {
-    const currentUser = {
-      role: "user" as const,
-      content: "current prompt",
-      idempotencyKey: "current-run:user",
-      timestamp: 1,
-    };
-    const { activeSession } = createActiveSession([]);
-    const branch = vi.fn();
-    const resetLeaf = vi.fn();
-    const clearNextUserMessagePersistenceSuppression = vi.fn();
-    const onUserMessagePersistenceInvalidated = vi.fn();
-    const sessionManager = createSessionManager({
-      branch,
-      resetLeaf,
-      clearNextUserMessagePersistenceSuppression,
-      buildSessionContext: () => ({ messages: [] }),
-      getLeafEntry: () => ({
-        id: "current-user",
-        parentId: "previous-assistant",
-        timestamp: "2026-07-13T00:00:00.000Z",
-        type: "message",
-        message: currentUser,
-      }),
-    });
-    const recorder = {
-      getPersistedMessage: () => currentUser,
-      hasPersisted: () => true,
-    } as unknown as NonNullable<
-      Parameters<
-        typeof prepareEmbeddedAttemptSessionBoundary
-      >[0]["attempt"]["userTurnTranscriptRecorder"]
-    >;
-
-    const boundary = prepareEmbeddedAttemptSessionBoundary({
-      activeSession,
-      attempt: {
-        onUserMessagePersistenceInvalidated,
-        prompt: "current prompt",
-        trigger: "user",
-        userTurnTranscriptRecorder: recorder,
-      },
-      getUserTranscriptContexts: () => undefined,
-      isRawModelRun: false,
-      preparedUserTurnMessage: undefined,
-      sessionManager,
-      setActiveSessionSystemPrompt: vi.fn(),
-    });
-
-    expect(boundary.orphanRepair).toBeUndefined();
-    expect(activeSession.agent.state.messages).toEqual([]);
-    expect(branch).not.toHaveBeenCalled();
-    expect(resetLeaf).not.toHaveBeenCalled();
-    expect(clearNextUserMessagePersistenceSuppression).not.toHaveBeenCalled();
-    expect(onUserMessagePersistenceInvalidated).not.toHaveBeenCalled();
-  });
-
-  it("adopts an exact durable user leaf after recorder state is lost on restart", () => {
-    const currentUser = {
-      role: "user" as const,
-      content: "current prompt",
-      idempotencyKey: "current-run:user",
-      timestamp: 1,
-    };
-    const { activeSession } = createActiveSession([]);
-    const branch = vi.fn();
-    const resetLeaf = vi.fn();
-    const clearNextUserMessagePersistenceSuppression = vi.fn();
-    const onUserMessagePersistenceInvalidated = vi.fn();
-    const sessionManager = createSessionManager({
-      getLeafEntry: () => ({
-        id: "unconfirmed-user",
-        parentId: "previous-assistant",
-        timestamp: "2026-07-13T00:00:00.000Z",
-        type: "message",
-        message: currentUser,
-      }),
-      branch,
-      resetLeaf,
-      clearNextUserMessagePersistenceSuppression,
-    });
-    const recorder = {
-      hasPersisted: () => false,
-    } as NonNullable<
-      Parameters<
-        typeof prepareEmbeddedAttemptSessionBoundary
-      >[0]["attempt"]["userTurnTranscriptRecorder"]
-    >;
-
-    const boundary = prepareEmbeddedAttemptSessionBoundary({
-      activeSession,
-      attempt: {
-        onUserMessagePersistenceInvalidated,
-        prompt: "current prompt",
-        trigger: "user",
-        userTurnTranscriptRecorder: recorder,
-      },
-      getUserTranscriptContexts: () => undefined,
-      isRawModelRun: false,
-      preparedUserTurnMessage: currentUser,
-      sessionManager,
-      setActiveSessionSystemPrompt: vi.fn(),
-    });
-
-    expect(boundary.orphanRepair).toBeUndefined();
-    expect(branch).not.toHaveBeenCalled();
-    expect(resetLeaf).not.toHaveBeenCalled();
-    expect(clearNextUserMessagePersistenceSuppression).not.toHaveBeenCalled();
-    expect(onUserMessagePersistenceInvalidated).not.toHaveBeenCalled();
-    expect(activeSession.agent.state.messages).toEqual([]);
-  });
-
-  it("repairs a durable user leaf that does not match the admitted current user", () => {
+  it("repairs a durable user leaf that does not match the admitted current user", async () => {
     const currentUser = {
       role: "user" as const,
       content: "current prompt",
@@ -523,7 +618,7 @@ describe("prepareEmbeddedAttemptSessionBoundary", () => {
       >[0]["attempt"]["userTurnTranscriptRecorder"]
     >;
 
-    const boundary = prepareEmbeddedAttemptSessionBoundary({
+    const boundary = await prepareEmbeddedAttemptSessionBoundary({
       activeSession,
       attempt: {
         onUserMessagePersistenceInvalidated,
@@ -545,7 +640,7 @@ describe("prepareEmbeddedAttemptSessionBoundary", () => {
     expect(activeSession.agent.state.messages).toBe(repairedMessages);
   });
 
-  it("repairs an orphaned user leaf before rebuilding active session messages", () => {
+  it("repairs an orphaned user leaf before rebuilding active session messages", async () => {
     const repairedMessages: AgentMessage[] = [
       { role: "user", content: [{ type: "text", text: "repaired" }], timestamp: 2 },
     ];
@@ -568,7 +663,7 @@ describe("prepareEmbeddedAttemptSessionBoundary", () => {
       buildSessionContext: () => ({ messages: repairedMessages }),
     });
 
-    const boundary = prepareEmbeddedAttemptSessionBoundary({
+    const boundary = await prepareEmbeddedAttemptSessionBoundary({
       activeSession,
       attempt: {
         onUserMessagePersistenceInvalidated,

--- a/src/agents/embedded-agent-runner/run/attempt-session-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-prepare.ts
@@ -296,7 +296,8 @@ type LlmBoundaryOptions = NonNullable<Parameters<typeof normalizeMessagesForLlmB
 
 type CurrentUserTimestampOverride = NonNullable<LlmBoundaryOptions["currentUserTimestampOverride"]>;
 
-export function prepareEmbeddedAttemptSessionBoundary(input: {
+export async function prepareEmbeddedAttemptSessionBoundary(input: {
+  abortSignal?: AbortSignal;
   activeSession: Pick<AgentSession, "agent">;
   attempt: SessionBoundaryAttempt;
   getUserTranscriptContexts: () => LlmBoundaryOptions["userTranscriptContexts"];
@@ -304,12 +305,12 @@ export function prepareEmbeddedAttemptSessionBoundary(input: {
   preparedUserTurnMessage: AgentMessage | undefined;
   sessionManager: ReturnType<typeof guardSessionManager>;
   setActiveSessionSystemPrompt: (systemPrompt: string) => void;
-}): {
+}): Promise<{
   boundaryTimezone: string | undefined;
   includeBoundaryTimestamp: boolean;
   orphanRepair: ReturnType<typeof resolveOrphanRepairPlan>;
   setCurrentUserTimestampOverride: (override: CurrentUserTimestampOverride | undefined) => void;
-} {
+}> {
   const { activeSession, attempt, isRawModelRun, sessionManager } = input;
   const preserveExactPrompt = isRawModelRun || attempt.operation === "settled-tool-finalization";
   if (isRawModelRun) {
@@ -340,12 +341,28 @@ export function prepareEmbeddedAttemptSessionBoundary(input: {
     });
   const orphanRepair = reconciledCurrentUser ? undefined : orphanRepairCandidate;
   if (orphanRepair?.removeLeaf) {
+    input.abortSignal?.throwIfAborted();
     if (orphanRepair.messageEntry.parentId) {
       sessionManager.branch(orphanRepair.messageEntry.parentId);
     } else {
       sessionManager.resetLeaf();
     }
+    const target = sessionManager.getSessionTarget();
+    if (target) {
+      // Commit the repaired cursor even when no metadata follows the orphan.
+      // Its owning attempt must settle the projection before the next append adopts it.
+      sessionManager.appendLeafControl({
+        targetId: sessionManager.getLeafId(),
+        appendParentId: sessionManager.getAppendParentId(),
+      });
+    }
     replayTrailingEntriesForOrphanRepair(sessionManager, orphanRepair.trailingEntries);
+    if (target) {
+      const { waitForSessionTranscriptProjection } =
+        await import("../../../config/sessions/session-transcript-reconcile.js");
+      await waitForSessionTranscriptProjection(target, input.abortSignal);
+      input.abortSignal?.throwIfAborted();
+    }
     // The old canonical user turn is gone. Its persistence suppression must not
     // discard the merged replacement prompt.
     sessionManager.clearNextUserMessagePersistenceSuppression?.();

--- a/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.test.ts
@@ -170,7 +170,10 @@ function createFixture() {
       resolveActiveContextEnginePluginId: vi.fn(),
       sessionAgentId: "main",
       transcriptLifecycle: {},
-      withOwnedTranscriptWrite: vi.fn(),
+      withOwnedTranscriptWrite: vi.fn(async (operation: () => unknown) => {
+        order.push("owned-boundary");
+        return await operation();
+      }),
     },
     agentSession: {
       agentCoreThinkingLevel: "medium",
@@ -228,6 +231,7 @@ describe("prepareEmbeddedAttemptSessionRuntime", () => {
       "own-manager",
       "agent-session",
       "own-session",
+      "owned-boundary",
       "boundary",
       "prompt-state",
       "settle-tracker",
@@ -263,6 +267,7 @@ describe("prepareEmbeddedAttemptSessionRuntime", () => {
     });
     expect(mocks.prepareSessionBoundary).toHaveBeenCalledWith(
       expect.objectContaining({
+        abortSignal: fixture.input.agentSession.runAbortSignal,
         getUserTranscriptContexts: fixture.getUserTranscriptContexts,
         preparedUserTurnMessage: { role: "user", content: "hello" },
       }),

--- a/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.ts
@@ -145,14 +145,17 @@ export async function prepareEmbeddedAttemptSessionRuntime(input: {
     state.currentTurnImageFailureCount = Math.max(state.currentTurnImageFailureCount, count);
   };
   await attempt.userTurnTranscriptRecorder?.waitForRuntimePersistence();
-  const boundary = prepareEmbeddedAttemptSessionBoundary({
-    activeSession,
-    attempt,
-    ...preparedSessionManager.userMessageBoundary,
-    isRawModelRun: input.isRawModelRun,
-    sessionManager,
-    setActiveSessionSystemPrompt,
-  });
+  const boundary = await input.sessionManager.withOwnedTranscriptWrite(() =>
+    prepareEmbeddedAttemptSessionBoundary({
+      abortSignal: input.agentSession.runAbortSignal,
+      activeSession,
+      attempt,
+      ...preparedSessionManager.userMessageBoundary,
+      isRawModelRun: input.isRawModelRun,
+      sessionManager,
+      setActiveSessionSystemPrompt,
+    }),
+  );
   state.prePromptMessageCount = activeSession.messages.length;
 
   // Session-owned projections survive attempt teardown so already-sent tool results

--- a/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
@@ -67,6 +67,7 @@ function normalizeMockProviderId(providerId?: string): string {
 }
 
 type SessionManagerMocks = {
+  getSessionTarget: Mock<() => undefined>;
   getLeafEntry: UnknownMock;
   getEntry: UnknownMock;
   getBoundaryCount: UnknownMock;
@@ -271,6 +272,7 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
   const embeddedSystemPromptInputs: unknown[] = [];
   const trajectoryEvents: CapturedTrajectoryEvent[] = [];
   const sessionManager = {
+    getSessionTarget: vi.fn(() => undefined),
     getLeafEntry: vi.fn(() => null),
     getEntry: vi.fn(() => undefined),
     getBoundaryCount: vi.fn(() => 0),
@@ -1134,6 +1136,7 @@ export function resetEmbeddedAttemptHarness(
   hoisted.systemPromptTexts.length = 0;
   hoisted.embeddedSystemPromptInputs.length = 0;
   hoisted.trajectoryEvents.length = 0;
+  hoisted.sessionManager.getSessionTarget.mockReset().mockReturnValue(undefined);
   hoisted.sessionManager.getLeafEntry.mockReset().mockReturnValue(null);
   hoisted.sessionManager.getEntry.mockReset().mockReturnValue(undefined);
   hoisted.sessionManager.getBoundaryCount.mockReset().mockReturnValue(0);


### PR DESCRIPTION
## Problem and repair

Full release QA parity failed while an embedded attempt repaired an orphaned user turn. The repair rewound its in-memory cursor and replayed trailing metadata, leaving the persisted active projection dirty. A subsequent append adopted the canonical storage parent and synchronously reopened the bounded transcript before that projection was ready, throwing `SessionTranscriptProjectionUnavailableError`. Without trailing metadata, the cursor change was never persisted at all.

The embedded attempt boundary now uses the existing fenced leaf-control append to record its repaired cursor, replays metadata, and joins the projection work already scheduled for that target. Its already-asynchronous caller runs this preparation inside the existing owned transcript-write lifecycle and passes the run's abort signal. Cancellation is checked before repair and after the wait. The next append sees the canonical repaired path; the historical orphan remains in the append-only record.

This changes the mutation owner rather than retrying fresh reads. Generic synchronous SessionManager APIs and fail-fast bounded reads remain unchanged. There are no new SQL statements, schemas, migrations, indexes, configuration settings, transaction boundaries, retention policies, or recovery mechanisms. The existing leaf-control contract is also used when withdrawing rejected assistant drafts.

Production is net +20 lines across two modules. That growth records the previously missing durable cursor update and joins its asynchronous projection under the existing lifecycle; the competing unowned synchronous preparation call is removed. Tests and test-support changes are net +112 lines, separately from one changelog line.

## Verification

Four real-SQLite branch/reset cases, each with and without trailing metadata, failed before the fix. They now verify that a fresh bounded reader excludes the orphan while raw history retains it, and that a real out-of-band append is adopted with the correct transcript anchor.

Cancellation coverage holds an actual reconcile worker at its existing acknowledgement boundary, aborts the wait, and verifies that repaired prompt state is not published. Pre-abort and stale-writer cases reject without changing durable rows. Existing raw-probe, settled-finalization, current-user preservation, branch/idempotency, fresh dirty-read, and reconciliation-lifecycle checks are included in the focused proof.

All 74 tests passed across nine files (83.33 seconds wrapper time). Managed Codex review passed through P2 with no actionable findings. The first full changed-file gate caught a test-fixture type mismatch: the writer fence belongs in the owned context, not the runtime target. The test now uses that canonical context; all 23 owner tests and the affected test typecheck pass. The final complete changed-file gate passed, including core and all core-test typechecks, lint, schema and ownership guards, and import-cycle checks. This follow-up changes only the test file; production is byte-identical to the [fresh hosted QA parity target](https://github.com/openclaw/openclaw/actions/runs/33305374796). Exact PR CI and hosted results are recorded below. This PR does not claim that the failed full release run is green; a fresh complete verification is still required after the repairs land.

## Hosted proof and review disposition

[Focused release checks 33305374796](https://github.com/openclaw/openclaw/actions/runs/33305374796) passed on the unchanged production fix at `9a0793a25a435890800895847773226ff7f95781`, using frozen trusted tooling `3ed6805a6f32ad8cdfd3c30dd94d7ae4d75bd667`. Baseline and candidate each passed 12/12 without retries, including the formerly failing capability-change scenario. Runtime core passed 25/25, soak 2/2, and explicit restart 1/1. Both artifact digests were verified. The existing nested Codex compaction harness-gap skip remains; this focused run is not the subsequent full/all verification.

The latest ClawSweeper review judged the runtime repair canonical and its +20 production lines justified. Its only finding and Rank-up move requests changelog removal. That request is explicitly declined: this maintainer-directed release-validation task carries a standing instruction to include changelog entries for user-visible fixes. No additional runtime change is needed for that policy preference.

The corrected-head PR CI exposed seven older context-engine fixtures whose shared test double omitted the existing SessionManager method now used by the repair. A three-line fixture correction declares, initializes, and resets `getSessionTarget` to return `undefined`, matching the real in-memory manager. All 94 tests across the ten shared-harness files pass, including all seven original failures with unchanged assertions; affected test types and formatting pass. Managed Codex review is clean through P2. Production remains byte-identical to the hosted proof target. [Exact-head CI 33306869917](https://github.com/openclaw/openclaw/actions/runs/33306869917) passed for `586f3464b7d66ee0e79f4c286e2a2a86ed19ff6f`; all 185 jobs are terminal with no failed jobs.
