### PR TITLE
perf(chat): reuse parser and history projection work

### DIFF
--- a/packages/markdown-core/src/ir.test.ts
+++ b/packages/markdown-core/src/ir.test.ts
@@ -11,6 +11,25 @@ function expectWellFormedUtf16(text: string): void {
   expect(new TextDecoder().decode(new TextEncoder().encode(text))).toBe(text);
 }
 
+describe("Markdown parser calls", () => {
+  it("keeps document references and changed options local to each parse", () => {
+    const options = { linkify: false };
+    expect(
+      markdownToIR("[ref]: https://example.org/doc\n\n[ref]", options).links.map(
+        (link) => link.href,
+      ),
+    ).toEqual(["https://example.org/doc"]);
+    expect(markdownToIR("[ref] example.org", options).links).toEqual([]);
+
+    options.linkify = true;
+    expect(markdownToIR("[ref] example.org", options).links.map((link) => link.href)).toEqual([
+      "http://example.org",
+    ]);
+    options.linkify = false;
+    expect(markdownToIR("[ref] example.org", options).links).toEqual([]);
+  });
+});
+
 describe("sliceMarkdownIR surrogate pair boundaries", () => {
   it("expands start boundary backward when it lands on a low surrogate", () => {
     // "a😀b" — UTF-16: [a] [\uD83D] [\uDE00] [b], indices 0-3

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -293,7 +293,23 @@ function appendHeadingSeparator(state: RenderState, nextBlockStart: number | und
   state.headingLineEnd = undefined;
 }
 
+// These seven parser switches bound the prepared configurations to 128 entries.
+// Parse state and rendered options remain local to each markdownToIRWithMeta call.
+const markdownParsers = new Map<number, MarkdownItParser>();
+
 function createMarkdownIt(options: MarkdownParseOptions): MarkdownItParser {
+  const key =
+    ((options.linkify ?? true) ? 1 : 0) |
+    (options.preserveDunderIdentifiers ? 2 : 0) |
+    (options.enableTaskLists ? 4 : 0) |
+    (options.enableHtmlUnderline ? 8 : 0) |
+    (options.enableSpoilers ? 16 : 0) |
+    (options.tableMode && options.tableMode !== "off" ? 32 : 0) |
+    (options.autolink === false ? 64 : 0);
+  const prepared = markdownParsers.get(key);
+  if (prepared) {
+    return prepared;
+  }
   const md = new MarkdownIt({
     html: false,
     linkify: options.linkify ?? true,
@@ -333,6 +349,7 @@ function createMarkdownIt(options: MarkdownParseOptions): MarkdownItParser {
   if (options.autolink === false) {
     md.disable("autolink");
   }
+  markdownParsers.set(key, md);
   return md;
 }
 

--- a/src/chat/canvas-render.ts
+++ b/src/chat/canvas-render.ts
@@ -287,10 +287,17 @@ export function extractCanvasShortcodes(text: string | undefined): {
   const blockRe = /\[embed\s+([^\]]*?[^\]/]|)\]([\s\S]*?)\[\/embed\]/gi;
   const selfClosingRe = /\[embed\s+([^\]]*?)\/\]/gi;
   for (const re of [blockRe, selfClosingRe]) {
+    // Each regex starts a new ascending pass over the ordered fence spans.
+    let fenceIndex = 0;
     let match: RegExpExecArray | null;
     while ((match = re.exec(text))) {
       const start = match.index ?? 0;
-      if (fenceSpans.some((span) => start >= span.start && start < span.end)) {
+      let fence = fenceSpans[fenceIndex];
+      while (fence && start >= fence.end) {
+        fenceIndex += 1;
+        fence = fenceSpans[fenceIndex];
+      }
+      if (fence && start >= fence.start) {
         // Literal embed examples in code blocks must remain visible text.
         continue;
       }

--- a/src/gateway/chat-display-projection.history.ts
+++ b/src/gateway/chat-display-projection.history.ts
@@ -26,13 +26,11 @@ import {
   type RoleContentMessage,
 } from "./chat-display-projection.helpers.js";
 
-function digestTtsSupplementText(text: string): string {
-  return createHash("sha256").update(text.trim()).digest("hex");
-}
+type TtsSupplementMarker = { textSha256?: string; spokenText?: string };
 
 function readTtsSupplementMarker(
   message: Record<string, unknown>,
-): { textSha256?: string; spokenText?: string } | undefined {
+): TtsSupplementMarker | undefined {
   const marker = readRecord(message.openclawTtsSupplement);
   if (!marker) {
     return undefined;
@@ -48,16 +46,16 @@ function readTtsSupplementMarker(
   return textSha256 || spokenText ? { textSha256, spokenText } : undefined;
 }
 
-function isAssistantTtsSupplementMessage(message: Record<string, unknown>): boolean {
-  if (asRoleContentMessage(message)?.role !== "assistant") {
-    return false;
-  }
-  if (!readTtsSupplementMarker(message)) {
-    return false;
+function readAssistantTtsSupplementMarker(
+  message: Record<string, unknown>,
+): TtsSupplementMarker | undefined {
+  const marker = readTtsSupplementMarker(message);
+  if (!marker || asRoleContentMessage(message)?.role !== "assistant") {
+    return undefined;
   }
   const content = message.content;
   if (!Array.isArray(content)) {
-    return false;
+    return undefined;
   }
   let hasSupplementBlock = false;
   for (const block of content) {
@@ -71,33 +69,18 @@ function isAssistantTtsSupplementMessage(message: Record<string, unknown>): bool
     }
     const text = typeof record.text === "string" ? record.text.trim() : "";
     if (text && text !== "Audio reply") {
-      return false;
+      return undefined;
     }
   }
-  return hasSupplementBlock;
+  return hasSupplementBlock ? marker : undefined;
 }
 
-function ttsSupplementMatchesAssistant(
-  marker: { textSha256?: string; spokenText?: string },
-  message: Record<string, unknown>,
-): boolean {
-  if (asRoleContentMessage(message)?.role !== "assistant") {
-    return false;
-  }
-  if (isProjectedSessionsSendForwardedMessage(message)) {
-    return false;
-  }
-  if (readTtsSupplementMarker(message)) {
-    return false;
-  }
-  const text = extractProjectedText(message.content ?? message.text).trim();
-  if (!text) {
-    return false;
-  }
-  if (marker.textSha256 && digestTtsSupplementText(text) === marker.textSha256) {
-    return true;
-  }
-  return Boolean(marker.spokenText && text === marker.spokenText);
+function readTtsSupplementTargetText(message: Record<string, unknown>): string {
+  return asRoleContentMessage(message)?.role === "assistant" &&
+    !isProjectedSessionsSendForwardedMessage(message) &&
+    !readTtsSupplementMarker(message)
+    ? extractProjectedText(message.content ?? message.text).trim()
+    : "";
 }
 
 function mergeTtsSupplementContent(
@@ -127,18 +110,30 @@ function mergeTtsSupplementContent(
 export function mergeTtsSupplementMessages(
   messages: Array<Record<string, unknown>>,
 ): Array<Record<string, unknown>> {
-  if (!messages.some(isAssistantTtsSupplementMessage)) {
+  if (!messages.some(readAssistantTtsSupplementMarker)) {
     return messages;
   }
+  const targetTexts: Array<string | undefined> = [];
+  const targetHashes: Array<string | undefined> = [];
   const merged: Array<Record<string, unknown>> = [];
   let changed = false;
   for (const message of messages) {
-    const marker = readTtsSupplementMarker(message);
-    if (marker && isAssistantTtsSupplementMessage(message)) {
+    const marker = readAssistantTtsSupplementMarker(message);
+    if (marker) {
       let targetIndex = -1;
       for (let i = merged.length - 1; i >= 0; i--) {
         const candidate = merged[i];
-        if (candidate && ttsSupplementMatchesAssistant(marker, candidate)) {
+        if (!candidate) {
+          continue;
+        }
+        const text = (targetTexts[i] ??= readTtsSupplementTargetText(candidate));
+        if (
+          text &&
+          ((marker.textSha256 &&
+            (targetHashes[i] ??= createHash("sha256").update(text).digest("hex")) ===
+              marker.textSha256) ||
+            (marker.spokenText && text === marker.spokenText))
+        ) {
           targetIndex = i;
           break;
         }
@@ -148,6 +143,9 @@ export function mergeTtsSupplementMessages(
           expectDefined(merged[targetIndex], "merged entry at target index"),
           message,
         );
+        // Appended media can carry text. Only this replaced position loses its
+        // prepared facts; other positions still refer to their original messages.
+        targetTexts[targetIndex] = targetHashes[targetIndex] = undefined;
         changed = true;
         continue;
       }

--- a/src/gateway/chat-display-projection.test.ts
+++ b/src/gateway/chat-display-projection.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { createNoisyPngBuffer } from "../../test/helpers/image-fixtures.js";
@@ -927,5 +928,39 @@ describe("chat display message-tool projection", () => {
         }),
       }),
     );
+  });
+});
+
+describe("TTS supplement matching", () => {
+  it("matches later audio against the text left by an earlier supplement", () => {
+    const marker = { textSha256: createHash("sha256").update("same").digest("hex") };
+    const firstAudio = { type: "audio", url: "https://example.test/first.mp3" };
+    const secondAudio = { type: "audio", url: "https://example.test/second.mp3" };
+    const caption = { type: "input_text", text: "caption" };
+    const messages = [
+      { role: "assistant", content: [{ type: "text", text: "same" }], timestamp: 1 },
+      { role: "assistant", content: [{ type: "text", text: "same" }], timestamp: 2 },
+      {
+        role: "assistant",
+        content: [caption, firstAudio],
+        openclawTtsSupplement: marker,
+      },
+      { role: "assistant", content: [secondAudio], openclawTtsSupplement: marker },
+    ];
+    const original = structuredClone(messages);
+
+    expect(projectChatDisplayMessages(messages)).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "same" }, secondAudio],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "same" }, caption, firstAudio],
+        timestamp: 2,
+      },
+    ]);
+    expect(messages).toEqual(original);
   });
 });

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -587,9 +587,16 @@ export function splitMediaFromOutput(
   const keptLines: string[] = [];
 
   let lineOffset = 0; // Track character offset for fence checking
+  // Line offsets and scanner spans advance in source order.
+  let fenceIndex = 0;
   for (const line of lines) {
     // Fenced examples must remain text; extracting their MEDIA tokens would mutate transcripts.
-    if (fenceSpans.some((span) => lineOffset >= span.start && lineOffset < span.end)) {
+    let fence = fenceSpans[fenceIndex];
+    while (fence && lineOffset >= fence.end) {
+      fenceIndex += 1;
+      fence = fenceSpans[fenceIndex];
+    }
+    if (fence && lineOffset >= fence.start) {
       keptLines.push(line);
       pushTextSegment(line);
       lineOffset += line.length + 1; // +1 for newline

--- a/src/sessions/nested-tool-activity.ts
+++ b/src/sessions/nested-tool-activity.ts
@@ -1,5 +1,8 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { z } from "zod";
 import { boundedJsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
+
+const NESTED_TOOL_ACTIVITY_CUSTOM_TYPE = "openclaw.nested-tool.v1";
 
 const correlationId = z.string().min(1).max(1024);
 const activityDetails = z
@@ -20,7 +23,7 @@ const activityDetails = z
   .strict();
 const activitySchema = z.object({
   role: z.literal("custom"),
-  customType: z.literal("openclaw.nested-tool.v1"),
+  customType: z.literal(NESTED_TOOL_ACTIVITY_CUSTOM_TYPE),
   display: z.literal(true),
   excludeFromContext: z.literal(true),
   content: z.literal(""),
@@ -32,6 +35,9 @@ export type NestedToolActivity = z.infer<typeof activitySchema>;
 
 /** Validate correlation slots separately from the payloads that always require redaction. */
 export function readNestedToolActivity(value: unknown): NestedToolActivity | undefined {
+  if (asOptionalRecord(value)?.customType !== NESTED_TOOL_ACTIVITY_CUSTOM_TYPE) {
+    return undefined;
+  }
   const parsed = activitySchema.safeParse(value);
   return parsed.success ? parsed.data : undefined;
 }
@@ -48,7 +54,7 @@ export function createNestedToolActivity(
     : { content: [{ type: "text", text: "[Nested tool output omitted: exceeds display limit]" }] };
   return activitySchema.parse({
     role: "custom",
-    customType: "openclaw.nested-tool.v1",
+    customType: NESTED_TOOL_ACTIVITY_CUSTOM_TYPE,
     display: true,
     excludeFromContext: true,
     content: "",


### PR DESCRIPTION
## What Problem This Solves

Chat history validates every ordinary row against the nested-tool schema, repeatedly extracts and hashes earlier replies while matching TTS supplements, and rescans all code fences for each media line or canvas match. Markdown IR parsing also reconstructs the same configured parser and linkifier on every call.

## Why This Change Was Made

Four measured changes keep preparation with the existing owners:

- Reject non-nested rows by the existing exact tag before full schema validation. The producer and schema share that tag; every tagged row still receives full validation.
- Prepare TTS target text and hashes lazily by position within one merge. Preserve closest-first matching and invalidate the replaced position because appended content can change its text. Remove duplicate marker reads and forwarding helpers.
- Advance through ordered fence spans as media lines and canvas matches advance. Each canvas regex starts its own cursor. Arbitrary-offset fence APIs remain unchanged.
- Retain configured Markdown parsers in a private map bounded by seven boolean switches (128 possible configurations). Document state, references, tokens, rendering options and output remain fresh for each parse. No input or output is cached.

Production **+77/−42 = net +35**; tests **+54**. The growth implements bounded parser preparation and ordered fence traversal; TTS matching removes two production lines. No new dependency, config, schema, protocol, authorization or public API surface.

## Measurements and Tradeoffs

Complete owners were measured in two fresh Node 26.8.1 processes with opposite starting orders, balanced warmups and all samples retained. These are local processing measurements, not provider, network or whole-turn latency claims.

| Workload | Before → candidate |
| --- | --- |
| Full display, 30 ordinary 2 KB rows | 995/967 → 601/574 µs |
| Full display, 300 replies and 30 delayed TTS supplements | 20.74/21.13 → 15.19/15.10 ms |
| Actual UI normalization, 256 mixed code fences | 2.309–2.377× faster |
| Complete canvas extraction, 1,024 fences | 3.330–3.805× faster |
| Complete warm Markdown IR, short plain text | 109.21/109.74 → 3.30/2.89 µs |
| Complete warm Markdown IR, styled 8 KB text | 1.636/1.639 → 1.429/1.427 ms |

Controls are retained: tagged-only nested histories are noisy, immediate raw TTS matching can be slower despite full display improvements, ordinary fence workloads are mostly neutral, and cold Markdown configuration construction is not accelerated. No universal speedup is claimed.

Prepared parsers trade bounded memory for CPU: warming all 128 configurations retained about **12.1–12.2 MiB more heap** in isolated processes. A separate default-configuration control observed approximately 97–344 KiB more, including JIT/dependency allocation variance. These are whole-owner heap deltas after explicit GC, not exact object sizes or application RSS predictions. The map never retains document text, tokens, references or output. The lead and independent reviewer inspected the installed MarkdownIt, linkify-it and CJK state ownership and accepted this bounded tradeoff.

## Contracts and Verification

Exact-output/identity proofs cover 2,778 nested activity cases, 3,656 TTS comparisons, 10,616 media and 1,327 canvas cases, 884 actual UI normalizations, and 4,698 complete Markdown IR comparisons including non-enumerable metadata. These are distinct proof units, not a summed test total. All 128 parser configurations are exercised in both orders, including mutable options, reference isolation, CJK, code, tables, links and UTF-16 edge text. Invalidated TTS positions preserve closest-match behavior after an earlier supplement adds text. Fence start/end semantics and separate regex passes remain intact.

All **707 canonical tests across 38 files** pass, including actual UI message normalization. The complete changed-file gate passes types, lint, boundaries, dead exports and all other guards (245.20 seconds). Fresh automated Codex review across P0–P3 and independent complete-owner reviews are clean. The reviewed patch rebased byte-for-byte unchanged onto current main. Fresh build, live real OpenAI Gateway/web verification and exact-head hosted CI are being completed before landing.

This changes internal processing only. Release-note context is recorded here; the release workflow owns the changelog. The separately recorded pre-existing literal-final-tag delivery defect remains outside this semantics-preserving scope.

At the published head `694c45f9b2187d399eef847533107f8c7b6002b4`, all707 selected tests passed again (17.73 seconds) and a fresh build passed (166.36 seconds). An isolated real OpenAI Gateway completed three chat turns and two actual web fetches. Fresh-client tool-progress recovery, history/list/status and terminal cleanup passed51 assertions over18 RPCs. Additional synthetic TTS/nested/fence records, persisted with the canonical SQLite accessor and read through that same running Gateway, passed16 assertions over2 history RPCs and the actual UI normalizer/Markdown parser. That fixture proof covers display behavior, not live TTS synthesis or nested tool execution. The initial fixture checker assumed every content value was an array; its corrected shape guard passed without production changes, and the failed harness receipt is retained. The owned Gateway stopped cleanly and its main/worker CPU profiles were retained.

The labeling job initially failed while fetching its configuration from GitHub due to a network error; rerunning that job succeeded. Published-head P0–P3 autoreview is clean, alongside independent final-source reviews. The completed ClawSweeper review reports no introduced correctness/security defect. Its two remaining checks are exact-head CI and dependency source access; the latter is addressed below.

## Landing Review

The latest ClawSweeper comment and its rank-up list have been read. Its dependency-source limitation is resolved by direct lead inspection and a separate independent review of the installed **MarkdownIt15.0.0** source map: `markdownit.ts` parse/parseInline, ParserCore, ParserBlock and ParserInline construct fresh state/environment/token ownership for each call. The installed **linkify-it6.1.0** test/match implementation resets search state and retains no input text; the CJK plugin and OpenClaw transcript plugin likewise keep document state in the current parse. The installed MarkdownIt ESM distribution has SHA-256 `bd98121df5a0c316ac5b2a85f650acd0d3b0c1aff35e3f2994914b14376729a5`; source maps and all dependency bindings are retained with the4,698-case isolation proof. This is direct dependency inspection, not an assumption based on wrapper tests.

The cache remains keyed only by parser-affecting options, with no parser escaping its private owner. The documented finite memory tradeoff is accepted for the measured CPU reduction. Fresh independent source review, two P0–P3 autoreviews, published-head tests/build and real Gateway proof leave no accepted actionable finding. Exact-head [CI run33305499711](https://github.com/openclaw/openclaw/actions/runs/33305499711) is now green, and every current check is complete with no failure. The rank-up request for completed CI and latest-comment review is addressed; no accepted actionable finding remains.
