### PR TITLE
fix: prevent duplicate commentary after tool handoffs

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1859,7 +1859,7 @@ src/agents/embedded-agent-runner/tool-result-context-guard.ts	13
 src/agents/embedded-agent-runner/tool-result-truncation.ts	23
 src/agents/embedded-agent-runner/tool-schema-runtime.ts	1
 src/agents/embedded-agent-runner/transcript-rewrite.ts	2
-src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts	6
+src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts	5
 src/agents/embedded-agent-subscribe.handlers.messages.stream.ts	6
 src/agents/embedded-agent-subscribe.handlers.messages.update.ts	6
 src/agents/embedded-agent-subscribe.handlers.tools.completion.ts	3

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -320,6 +320,9 @@ editable draft without becoming part of the final answer. This keeps
 multi-step tool turns visually alive instead of silent between the first
 thinking preview and the final answer.
 
+Responses commentary keeps each message item's identity through tool handoffs.
+Later tool updates do not replay earlier commentary as an extra combined preamble.
+
 Long-running tools may emit typed progress before they return. For example,
 `web_fetch` arms a five-second timer when it starts: if the fetch is still
 pending, the preview shows `Fetching page content...`; if the fetch finishes or

--- a/src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts
@@ -21,14 +21,13 @@ import {
 } from "./embedded-agent-subscribe.handlers.messages.replies.js";
 import {
   buildAssistantStreamData,
+  emitAssistantCommentaryStreamData,
   emitAssistantMessageStart,
   emitReasoningEnd,
   extractStandaloneMessageToolText,
   hasMessageToolOnlySourceDelivery,
   isOpenAiCompletionsAssistantMessage,
-  isResponsesApiAssistantMessage,
   isSubscribeTranscriptOnlyOpenClawAssistantMessage,
-  scopeAssistantMessageToStreamBlock,
   shouldSuppressDeterministicApprovalOutput,
 } from "./embedded-agent-subscribe.handlers.messages.stream.js";
 import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
@@ -36,7 +35,6 @@ import { appendRawStream } from "./embedded-agent-subscribe.raw-stream.js";
 import { warnIfAssistantEmittedSuspiciousText } from "./embedded-agent-subscribe.tool-text-diagnostics.js";
 import {
   createThinkingTagStreamState,
-  extractAssistantCommentaryText,
   extractAssistantThinking,
   extractAssistantVisibleText,
   extractEmbeddedAssistantText,
@@ -162,15 +160,6 @@ export function handleMessageEnd(
   ctx.recordAssistantUsage((assistantMessage as { usage?: unknown }).usage);
   ctx.commitAssistantUsage();
   if (suppressVisibleAssistantOutput) {
-    const isResponsesCommentary = isResponsesApiAssistantMessage(assistantMessage);
-    const commentaryMessage = isResponsesCommentary
-      ? scopeAssistantMessageToStreamBlock(
-          assistantMessage as AssistantMessage,
-          ctx.state.lastAssistantStreamContentIndex,
-          ctx.state.lastAssistantStreamItemId,
-        )
-      : assistantMessage;
-    const commentaryText = coerceChatContentText(extractAssistantCommentaryText(commentaryMessage));
     appendRawStream(() => ({
       ts: Date.now(),
       event: "assistant_message_end",
@@ -179,20 +168,7 @@ export function handleMessageEnd(
       rawText: coerceChatContentText(extractEmbeddedAssistantText(assistantMessage)),
       rawThinking: extractAssistantThinking(assistantMessage),
     }));
-    const commentaryAlreadyStreamed =
-      isResponsesCommentary &&
-      Boolean(ctx.state.deltaBuffer) &&
-      ctx.state.deltaBuffer === commentaryText;
-    if (commentaryText && !commentaryAlreadyStreamed) {
-      ctx.emitAssistantStreamData(
-        buildAssistantStreamData({
-          text: commentaryText,
-          replace: true,
-          phase: "commentary",
-          itemId: isResponsesCommentary ? ctx.state.lastAssistantStreamItemId : undefined,
-        }),
-      );
-    }
+    emitAssistantCommentaryStreamData(ctx, assistantMessage);
     // Commentary-tagged tool turns can still carry durable reasoning under /reasoning on.
     const suppressedTrimmedReasoning = ctx.state.includeReasoning
       ? extractAssistantThinking(assistantMessage).trim()

--- a/src/agents/embedded-agent-subscribe.handlers.messages.stream.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.stream.ts
@@ -21,6 +21,7 @@ import type {
   EmbeddedAgentSubscribeContext,
   EmbeddedAgentSubscribeState,
 } from "./embedded-agent-subscribe.handlers.types.js";
+import { extractAssistantCommentaryText } from "./embedded-agent-utils.js";
 import type { AgentMessage } from "./runtime/index.js";
 
 export function isSubscribeTranscriptOnlyOpenClawAssistantMessage(
@@ -179,6 +180,29 @@ export function scopeAssistantMessageToStreamBlock(
   // index becomes a logical reply boundary, downstream snapshots must be
   // cumulative only within that block or earlier text is replayed.
   return { ...message, content: [block] };
+}
+
+export function emitAssistantCommentaryStreamData(
+  ctx: EmbeddedAgentSubscribeContext,
+  message: AssistantMessage,
+) {
+  const isResponsesCommentary = isResponsesApiAssistantMessage(message);
+  const { lastAssistantStreamContentIndex: index, lastAssistantStreamItemId: itemId } = ctx.state;
+  // Non-text updates carry prior Responses items too; publish only the active item.
+  const commentaryMessage = isResponsesCommentary
+    ? scopeAssistantMessageToStreamBlock(message, index, itemId)
+    : message;
+  const text = extractAssistantCommentaryText(commentaryMessage);
+  if (text && (!isResponsesCommentary || ctx.state.deltaBuffer !== text)) {
+    ctx.emitAssistantStreamData(
+      buildAssistantStreamData({
+        text,
+        replace: true,
+        phase: "commentary",
+        itemId: isResponsesCommentary ? itemId : undefined,
+      }),
+    );
+  }
 }
 
 export function emitReasoningEnd(ctx: EmbeddedAgentSubscribeContext) {

--- a/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
@@ -20,6 +20,7 @@ import {
   appendBlockReplyChunk,
   buildAssistantStreamData,
   copyPartialBlockState,
+  emitAssistantCommentaryStreamData,
   emitAssistantMessageStart,
   emitReasoningEnd,
   hasMessageToolOnlySourceDelivery,
@@ -102,9 +103,7 @@ export function handleMessageUpdate(
         delta: "",
         content: commentaryText,
       }));
-      ctx.emitAssistantStreamData(
-        buildAssistantStreamData({ text: commentaryText, replace: true, phase: "commentary" }),
-      );
+      emitAssistantCommentaryStreamData(ctx, msg);
     }
     return;
   }

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.reasoning-delivery.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.reasoning-delivery.test.ts
@@ -10,6 +10,7 @@ import {
   emitAssistantTextEnd,
 } from "./embedded-agent-subscribe.e2e-harness.js";
 import { subscribeEmbeddedAgentSession } from "./embedded-agent-subscribe.js";
+import { createOpenAiResponsesTextBlock } from "./embedded-agent-subscribe.openai-responses.test-helpers.js";
 
 describe("reasoning block delivery", () => {
   function createReasoningBlockReplyHarness(params: { thinkingLevel?: "off" | "medium" } = {}) {
@@ -217,6 +218,125 @@ describe("subscribeEmbeddedAgentSession", () => {
     ]);
     expect(onBlockReply).not.toHaveBeenCalled();
     expect(onPartialReply).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "streamed", eventType: "text_delta", secondText: "Second." },
+    { name: "snapshot-only", eventType: "text_end", secondText: "Second." },
+    { name: "equal snapshot-only", eventType: "text_end", secondText: "First." },
+  ] as const)("keeps $name commentary item identity through tool handoff", async (scenario) => {
+    const onAgentEvent = vi.fn();
+    const onBlockReply = vi.fn();
+    const onPartialReply = vi.fn();
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run",
+      onAgentEvent,
+      onBlockReply,
+      onPartialReply,
+    });
+    const first = createOpenAiResponsesTextBlock({
+      id: "first",
+      phase: "commentary",
+      text: "First.",
+    });
+    const message = {
+      role: "assistant",
+      api: "openai-responses",
+      content: [first],
+    } as AssistantMessage;
+    emit({ type: "message_start", message });
+    emit({
+      type: "message_update",
+      message,
+      assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: first.text },
+    });
+    const completed = {
+      ...message,
+      content: [
+        first,
+        createOpenAiResponsesTextBlock({
+          id: "second",
+          phase: "commentary",
+          text: scenario.secondText,
+        }),
+      ],
+    } as AssistantMessage;
+    emit({
+      type: "message_update",
+      message: completed,
+      assistantMessageEvent: { type: "text_start", contentIndex: 1, partial: completed },
+    });
+    emit({
+      type: "message_update",
+      message: completed,
+      assistantMessageEvent: {
+        type: scenario.eventType,
+        contentIndex: 1,
+        ...(scenario.eventType === "text_delta"
+          ? { delta: scenario.secondText }
+          : { content: scenario.secondText }),
+        partial: completed,
+      },
+    });
+    const withTool = {
+      ...completed,
+      content: [
+        ...completed.content,
+        { type: "toolCall", id: "call", name: "read", arguments: {} },
+      ],
+    } as AssistantMessage;
+    emit({
+      type: "message_update",
+      message: withTool,
+      assistantMessageEvent: { type: "toolcall_start", contentIndex: 2, partial: withTool },
+    });
+    emit({ type: "message_end", message: withTool });
+    await subscription.waitForPendingEvents();
+
+    expect(onAgentEvent.mock.calls.map(([event]) => event)).toMatchObject([
+      { stream: "item", data: { kind: "preamble", itemId: "first", progressText: "First." } },
+      {
+        stream: "item",
+        data: { kind: "preamble", itemId: "second", progressText: scenario.secondText },
+      },
+    ]);
+    expect(onBlockReply).not.toHaveBeenCalled();
+    expect(onPartialReply).not.toHaveBeenCalled();
+    expect(subscription.assistantTexts).toEqual([]);
+  });
+
+  it("preserves aggregate commentary for providers without Responses item boundaries", async () => {
+    const onAgentEvent = vi.fn();
+    const { emit, subscription } = createSubscribedSessionHarness({ runId: "run", onAgentEvent });
+    const message = {
+      role: "assistant",
+      api: "anthropic-messages",
+      phase: "commentary",
+      content: [
+        { type: "text", text: "First." },
+        { type: "text", text: "Second." },
+      ],
+    } as AssistantMessageWithPhase;
+    emit({ type: "message_start", message });
+    emit({
+      type: "message_update",
+      message,
+      assistantMessageEvent: { type: "toolcall_start", contentIndex: 2, partial: message },
+    });
+    emit({ type: "message_end", message });
+    await subscription.waitForPendingEvents();
+
+    expect(onAgentEvent.mock.calls.map(([event]) => event)).toEqual([
+      {
+        stream: "item",
+        data: {
+          kind: "preamble",
+          title: "Preamble",
+          phase: "update",
+          progressText: "First. Second.",
+        },
+      },
+    ]);
   });
 
   it("suppresses commentary-phase assistant messages before tool use", () => {


### PR DESCRIPTION
Closes #133246

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled at creation. This is a same-repository maintainer branch.

</details>

## What Problem This Solves

Fixes an issue where users following an agent's progress would see an extra combined commentary preamble when a Responses tool call began. `First.` and `Second.` already arrived as separate items, then appeared again as an anonymous `First. Second.` item.

## Why This Change Was Made

The non-text update path projected the cumulative provider message without preserving item identity. Share the existing message-end item projection in the stream owner and use it from both boundaries; remove the duplicate projection. Gateway and UI consumers keep their existing identity rules, so independent equal-text items remain distinct.

Raw diagnostic callback payloads and generic non-Responses commentary remain unchanged. Current main's lazy diagnostic and phase cleanup are preserved. No new configuration, protocol, persistence or empty-final retraction policy is introduced. Production +28/−29 (**net −1**); tests +120; docs +3.

## User Impact

Tool handoffs retain the commentary items already shown, without adding a combined replay. Snapshot-only items still appear, strict extensions update the original live item, and commentary stays outside final answer text.

## Evidence

- Three regression cases fail before the repair; the generic-provider control passes. Final integrated owner/sibling batch: **69 tests passed**.
- Real isolated Gateway/official OpenAI SDK proof uses synthetic Responses wire data through the real parser, agent loop, subscription, client-tool adapter and payload builder. Authentic agent-bus events then pass through the actual Gateway progress snapshot and UI reducer: **8 scenarios passed** on source later committed byte-identically as `4553b0c4300957db63923b261a044e2a96ed1cc8`.
- Before: `item_0: First.`, `item_1: Second.`, anonymous `First. Second.` → three progress segments. After: exactly the two keyed segments. Snapshot-only distinct/equal items and same-index strict extensions retain their identities. Commentary followed by final answer still returns `Done.` over HTTP.
- Two empty-final scenarios remain unchanged characterizations. This proof is not a live browser screenshot, external-provider run, or full terminal-recovery test. The first added snapshot assertion used the wrong field name; that fixture-only mistake was retained in artifacts and corrected without a source change.
- Independent owner/dependency review, scoped autoreview, and a separate exact-head CLI review (P0–P3) are clean. The first canonical gate and CI caught a stale assertion-count baseline after the cast deletion. Its allowance is now reduced from6 to5. The final six-path canonical gate passed, including production/test types, lint, and all repository guards. [Fresh exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33305855046) passed on final headf351. Its actual merge checkout4a46de56 contains that head and current basee42bb23.

The regression is checked in at `src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.reasoning-delivery.test.ts`. Direct Codex dependency inspection confirmed item-scoped deltas and phase semantics; no Codex protocol change is proposed. Final patch SHA256: `b028ba4338483fa09c42e087db3f94d86f1a4493a005c20f5a70154302fafc63`. Final head `f3511ec92eb134eed9f9894cbd48f17626a1c6d4` adds only the required assertion baseline decrease (6→5); production, tests and docs remain byte-identical to the tested source.
