### PR TITLE
fix(channels): keep deeper queued messages alive through long turns

### DIFF
--- a/docs/plugins/sdk-channel-outbound.md
+++ b/docs/plugins/sdk-channel-outbound.md
@@ -79,6 +79,31 @@ classification, and persisted payload shape in the plugin. Webhook transports
 should acknowledge only after `admit` resolves; non-replay transports should
 surface durable append exhaustion rather than silently dispatching.
 
+### Deferred claim heartbeats
+
+Forward both `onDeferredHeartbeat` and `deferredHeartbeatIntervalMs` when a
+plugin wraps the ingress lifecycle or maps it to `turnAdoptionLifecycle`.
+`bindIngressLifecycleToReplyOptions(...)` forwards both fields. They let the
+core follow-up queue renew a deferred claim's adoption watchdog while the turn
+waits behind other work; a heartbeat does not adopt or complete the claim.
+
+`deferredHeartbeatIntervalMs` is an optional requested cadence in milliseconds.
+The queue starts renewal only when the callback and a positive, finite cadence
+are present and the queue owns the lifecycle. It renews immediately, then at
+the requested interval rounded down to whole milliseconds, with a 1 ms minimum.
+`fanInChannelIngressLifecycles(...)` forwards heartbeats to every source and
+uses the shortest positive, finite source cadence; invalid or absent cadences
+do not participate in that minimum.
+
+Renewal stops after successful adoption, lifecycle completion, loss of queue
+ownership, or a thrown heartbeat callback. Callback failure leaves the watchdog
+unrenewed so it can recover the claim. Plugins must not run an independent timer
+that keeps abandoned work alive.
+
+Older wrappers that omit the optional cadence remain valid, but do not enable
+queue-owned periodic renewal. Forwarding only the callback is insufficient;
+deferred work can still reach the existing adoption watchdog timeout.
+
 ## Adapter
 
 Most plugins define one `message` adapter:

--- a/extensions/feishu/src/bot-broadcast.ts
+++ b/extensions/feishu/src/bot-broadcast.ts
@@ -183,6 +183,7 @@ export function createFeishuBroadcastIngressSettlement(params: {
             defer();
           },
           onDeferredHeartbeat: () => params.lifecycle?.onDeferredHeartbeat?.(),
+          deferredHeartbeatIntervalMs: params.lifecycle?.deferredHeartbeatIntervalMs,
           onAdoptionFinalizing: beginFinalizing,
           onAbandoned: async () => {
             if (

--- a/extensions/feishu/src/feishu-ingress.ts
+++ b/extensions/feishu/src/feishu-ingress.ts
@@ -317,6 +317,7 @@ export function buildFeishuFlushIngressLifecycle(
         transportLifecycle.onDeferred();
       },
       onDeferredHeartbeat: () => transportLifecycle.onDeferredHeartbeat?.(),
+      deferredHeartbeatIntervalMs: transportLifecycle.deferredHeartbeatIntervalMs,
       onAdoptionFinalizing: () => {
         transportLifecycle.onAdoptionFinalizing();
       },

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -285,6 +285,13 @@ export function createSlackMessageHandler(params: {
                     return;
                   }
                   await turnAdoptionLifecycle?.onSessionRouted?.(prepared.route.sessionKey);
+                  const deferredHeartbeatIntervals = [
+                    turnAdoptionLifecycle?.deferredHeartbeatIntervalMs,
+                    admissionLifecycle.deferredHeartbeatIntervalMs,
+                  ].filter(
+                    (interval): interval is number =>
+                      interval !== undefined && Number.isFinite(interval) && interval > 0,
+                  );
                   // Commit at adoption (durable turn ownership), release on abandonment;
                   // deferred turns hand settlement to the reply lane with the claim held.
                   prepared.turnAdoptionLifecycle = {
@@ -311,6 +318,9 @@ export function createSlackMessageHandler(params: {
                       turnAdoptionLifecycle?.onDeferredHeartbeat?.();
                       admissionLifecycle.onDeferredHeartbeat?.();
                     },
+                    ...(deferredHeartbeatIntervals.length > 0
+                      ? { deferredHeartbeatIntervalMs: Math.min(...deferredHeartbeatIntervals) }
+                      : {}),
                     onAbandoned: () => {
                       settlementHandedOff = true;
                       releaseClaims();

--- a/extensions/telegram/src/bot-message-dispatch-turn.ts
+++ b/extensions/telegram/src/bot-message-dispatch-turn.ts
@@ -158,6 +158,8 @@ export async function runTelegramDispatchTurn(turn: Turn) {
                   onAdopted: turn.turnAdoptionLifecycle.onAdopted,
                   onDeferred: turn.turnAdoptionLifecycle.onDeferred,
                   onDeferredHeartbeat: turn.turnAdoptionLifecycle.onDeferredHeartbeat,
+                  deferredHeartbeatIntervalMs:
+                    turn.turnAdoptionLifecycle.deferredHeartbeatIntervalMs,
                   onAbandoned: turn.turnAdoptionLifecycle.onAbandoned,
                   abortSignal: turn.turnAdoptionLifecycle.abortSignal,
                 }

--- a/extensions/telegram/src/bot-message-dispatch.types.ts
+++ b/extensions/telegram/src/bot-message-dispatch.types.ts
@@ -50,6 +50,7 @@ export type DispatchTelegramMessageParams = {
     onAdopted: () => void | Promise<void>;
     onDeferred?: () => void;
     onDeferredHeartbeat?: () => void;
+    deferredHeartbeatIntervalMs?: number;
     onAbandoned?: () => void;
     abortSignal?: AbortSignal;
   };

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -277,6 +277,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
         onAdopted: () => void | Promise<void>;
         onDeferred?: () => void;
         onDeferredHeartbeat?: () => void;
+        deferredHeartbeatIntervalMs?: number;
         onAbandoned?: () => void;
         abortSignal?: AbortSignal;
       };
@@ -438,6 +439,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
               drainLifecycle?.onDeferred();
             },
             onDeferredHeartbeat: () => drainLifecycle?.onDeferredHeartbeat?.(),
+            deferredHeartbeatIntervalMs: drainLifecycle?.deferredHeartbeatIntervalMs,
             onAbandoned: () => {
               if (!adopted) {
                 void settle({ kind: "failed-retryable", error: "turn-abandoned" }, "terminal");

--- a/extensions/telegram/src/bot-processing-outcome.ts
+++ b/extensions/telegram/src/bot-processing-outcome.ts
@@ -15,6 +15,7 @@ type TelegramSpooledReplayLifecycle = {
   onAdopted: () => void | Promise<void>;
   onDeferred: () => void;
   onDeferredHeartbeat?: () => void;
+  deferredHeartbeatIntervalMs?: number;
   /** Clears pre-adoption stall while durable adoption finalization is held. */
   onAdoptionFinalizing?: () => void;
   onAbandoned: () => void | Promise<void>;

--- a/extensions/twitch/src/twitch-ingress.ts
+++ b/extensions/twitch/src/twitch-ingress.ts
@@ -139,6 +139,7 @@ export function createTwitchIngress(options: {
             lifecycle.onDeferred();
           },
           onDeferredHeartbeat: () => lifecycle.onDeferredHeartbeat?.(),
+          deferredHeartbeatIntervalMs: lifecycle.deferredHeartbeatIntervalMs,
           onAbandoned: async () => {
             handedOff = true;
             await lifecycle.onAbandoned();

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -94,6 +94,8 @@ export type TurnAdoptionLifecycle = {
   onDeferred?: () => boolean | void;
   /** Reports that a deferred turn is still queued behind an active turn. */
   onDeferredHeartbeat?: () => void;
+  /** Requested cadence for queue-owned deferred heartbeats. */
+  deferredHeartbeatIntervalMs?: number;
   /** Deferred turn finished without owning the reply lane. */
   onAbandoned?: () => void;
   /** Always fires when the followup ownership cycle ends (admitted or not). Gateway cleanup. */

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -47,6 +47,7 @@ type InboundDebounceAdmissionLifecycleInput = {
   onAdopted?: () => void | Promise<void>;
   onDeferred?: () => boolean | void;
   onDeferredHeartbeat?: () => void;
+  deferredHeartbeatIntervalMs?: number;
   onAdoptionFinalizing?: () => void;
   onFailed?: (error: unknown) => void | Promise<void>;
   onAbandoned?: () => void | Promise<void>;
@@ -58,6 +59,7 @@ type InboundDebounceAdmissionLifecycle = {
   onAdopted: () => Promise<void>;
   onDeferred: () => boolean | void;
   onDeferredHeartbeat?: () => void;
+  deferredHeartbeatIntervalMs?: number;
   onAdoptionFinalizing: () => void;
   onFailed?: (error: unknown) => Promise<void>;
   onAbandoned: () => Promise<void>;
@@ -98,6 +100,7 @@ function createInboundDebounceFlush(params: {
       return accepted;
     },
     onDeferredHeartbeat: () => source?.onDeferredHeartbeat?.(),
+    deferredHeartbeatIntervalMs: source?.deferredHeartbeatIntervalMs,
     onAdoptionFinalizing: () => source?.onAdoptionFinalizing?.(),
     onFailed: source?.onFailed
       ? async (error) => {

--- a/src/auto-reply/reply/dispatch-from-config.ingress-retry.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ingress-retry.test.ts
@@ -103,6 +103,13 @@ describe("dispatch retry after queued ingress abandonment", () => {
             ),
           ).toBe(true);
           if (abandonment === "watchdog-after-commit") {
+            if (!run.turnAdoptionLifecycle) {
+              throw new Error("dispatch did not bind its ingress lifecycle");
+            }
+            // Lose renewal after enqueue; a healthy queue-owned wait must not time out.
+            vi.spyOn(run.turnAdoptionLifecycle, "onDeferredHeartbeat").mockImplementation(() => {
+              throw new Error("deferred heartbeat owner failed");
+            });
             expect(
               enqueueFollowupRun(
                 key,

--- a/src/auto-reply/reply/queue.in-flight.test.ts
+++ b/src/auto-reply/reply/queue.in-flight.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import {
+  admitFollowupRunLifecycle,
   completeFollowupRunLifecycle,
   enqueueFollowupRun,
   FollowupRunDeferredError,
@@ -21,6 +22,7 @@ describe("followup queue in-flight ownership", () => {
       clearFollowupQueue(key);
     }
     keys.clear();
+    vi.useRealTimers();
   });
 
   const createKey = (suffix: string) => {
@@ -160,6 +162,112 @@ describe("followup queue in-flight ownership", () => {
     }
 
     await expect.poll(() => getExistingFollowupQueue(key)).toBeUndefined();
+  });
+
+  it("heartbeats a pending lifecycle while an earlier delivery is in flight", async () => {
+    vi.useFakeTimers();
+    const key = createKey("deferred-heartbeat-behind-active");
+    const entered = createDeferred();
+    const release = createDeferred();
+    const onDeferredHeartbeat = vi.fn();
+    const active = createRun({ prompt: "active" });
+    const pending = {
+      ...createRun({ prompt: "pending" }),
+      turnAdoptionLifecycle: {
+        onAdopted: async () => {},
+        onDeferredHeartbeat,
+        deferredHeartbeatIntervalMs: 1_000,
+      },
+    };
+    const runFollowup = async (run: FollowupRun) => {
+      if (run === active) {
+        entered.resolve();
+        await release.promise;
+      }
+      completeFollowupRunLifecycle(run);
+    };
+
+    try {
+      expect(enqueueFollowupRun(key, active, createSettings("old"), "none", runFollowup)).toBe(
+        true,
+      );
+      await entered.promise;
+      expect(enqueueFollowupRun(key, pending, createSettings("old"), "none")).toBe(true);
+      expect(onDeferredHeartbeat).toHaveBeenCalledOnce();
+
+      await vi.advanceTimersByTimeAsync(3_000);
+
+      expect(onDeferredHeartbeat).toHaveBeenCalledTimes(4);
+      expect(getExistingFollowupQueue(key)?.items).toEqual([active, pending]);
+    } finally {
+      release.resolve();
+    }
+
+    await vi.runAllTimersAsync();
+    expect(getExistingFollowupQueue(key)).toBeUndefined();
+  });
+
+  it("stops deferred heartbeats after queue ownership is lost", async () => {
+    vi.useFakeTimers();
+    const key = createKey("deferred-heartbeat-owner-loss");
+    const onDeferredHeartbeat = vi.fn();
+    const onAbandoned = vi.fn();
+    const pending: FollowupRun = {
+      ...createRun({ prompt: "pending" }),
+      turnAdoptionLifecycle: {
+        onAdopted: async () => {},
+        onDeferredHeartbeat,
+        deferredHeartbeatIntervalMs: 1_000,
+        onAbandoned,
+      },
+    };
+
+    expect(enqueueFollowupRun(key, pending, createSettings("old"), "none", undefined, false)).toBe(
+      true,
+    );
+    expect(onDeferredHeartbeat).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(onDeferredHeartbeat).toHaveBeenCalledTimes(3);
+
+    getExistingFollowupQueue(key)?.items.splice(0, 1);
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(onDeferredHeartbeat).toHaveBeenCalledTimes(3);
+    completeFollowupRunLifecycle(pending);
+    expect(onAbandoned).toHaveBeenCalledOnce();
+  });
+
+  it("keeps deferred heartbeats alive until adoption succeeds", async () => {
+    vi.useFakeTimers();
+    const key = createKey("deferred-heartbeat-adoption-retry");
+    const onDeferredHeartbeat = vi.fn();
+    const onAdopted = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("adoption failed"))
+      .mockResolvedValueOnce();
+    const pending: FollowupRun = {
+      ...createRun({ prompt: "pending" }),
+      turnAdoptionLifecycle: {
+        onAdopted,
+        onDeferredHeartbeat,
+        deferredHeartbeatIntervalMs: 1_000,
+      },
+    };
+
+    expect(enqueueFollowupRun(key, pending, createSettings("old"), "none", undefined, false)).toBe(
+      true,
+    );
+    expect(onDeferredHeartbeat).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onDeferredHeartbeat).toHaveBeenCalledTimes(2);
+
+    await expect(admitFollowupRunLifecycle(pending)).rejects.toThrow("adoption failed");
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onDeferredHeartbeat).toHaveBeenCalledTimes(3);
+
+    await expect(admitFollowupRunLifecycle(pending)).resolves.toBeUndefined();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onDeferredHeartbeat).toHaveBeenCalledTimes(3);
   });
 
   it("protects a collect group and counts only active identities still present", async () => {

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -37,6 +37,7 @@ import {
   isFollowupRunAborted,
   markFollowupRunEnqueued,
   resolveFollowupAbortSignal,
+  startFollowupRunDeferredHeartbeat,
   type EnqueueFollowupRunOptions,
   type FollowupRun,
   type QueueDedupeMode,
@@ -115,6 +116,23 @@ function appendQueueItem(params: {
   params.queue.lastRun = params.run.run;
   params.run.queueAbortSignal = params.queue.abortController.signal;
   params.queue.items[params.front ? "unshift" : "push"](params.run);
+  const lifecycle = params.run.turnAdoptionLifecycle;
+  startFollowupRunDeferredHeartbeat(params.run, () => {
+    if (!lifecycle) {
+      return false;
+    }
+    const queue = FOLLOWUP_QUEUES.get(params.key);
+    if (!queue) {
+      return false;
+    }
+    const ownsLifecycle = (run: FollowupRun) => run.turnAdoptionLifecycle === lifecycle;
+    return (
+      queue.items.some(ownsLifecycle) ||
+      [...queue.inFlight].some(ownsLifecycle) ||
+      queue.summarySources.some(ownsLifecycle) ||
+      queue.summaryElisions.some((entry) => entry.sources.some(ownsLifecycle))
+    );
+  });
   if (params.recentMessageIdKey) {
     recordRecentQueueMessageId(params.run, params.recentMessageIdKey);
   }
@@ -123,7 +141,6 @@ function appendQueueItem(params: {
     rememberFollowupDrainCallback(params.key, runFollowup);
   }
   const signal = params.run.abortSignal;
-  const lifecycle = params.run.turnAdoptionLifecycle;
   if (signal && lifecycle && runFollowup) {
     const onAbort = () => {
       const queue = getExistingFollowupQueue(params.key);

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -293,8 +293,67 @@ const admittingTurnAdoptionLifecycles = new WeakMap<TurnAdoptionLifecycle, Promi
 const retiredTurnAdoptionCancellationLifecycles = new WeakSet<TurnAdoptionLifecycle>();
 const completedTurnAdoptionLifecycles = new WeakSet<TurnAdoptionLifecycle>();
 const completedTurnAdoptionLifecycleCallbacks = new WeakSet<TurnAdoptionLifecycle>();
+const deferredHeartbeatTimers = new WeakMap<
+  TurnAdoptionLifecycle,
+  ReturnType<typeof setInterval>
+>();
 
 type FollowupLifecycleRun = Pick<FollowupRun, "steerPending" | "turnAdoptionLifecycle">;
+
+function stopFollowupRunDeferredHeartbeat(lifecycle: TurnAdoptionLifecycle | undefined): void {
+  if (!lifecycle) {
+    return;
+  }
+  const timer = deferredHeartbeatTimers.get(lifecycle);
+  if (!timer) {
+    return;
+  }
+  clearInterval(timer);
+  deferredHeartbeatTimers.delete(lifecycle);
+}
+
+export function startFollowupRunDeferredHeartbeat(
+  run: FollowupLifecycleRun,
+  isQueueOwner: () => boolean,
+): void {
+  const lifecycle = run.turnAdoptionLifecycle;
+  const requestedIntervalMs = lifecycle?.deferredHeartbeatIntervalMs;
+  if (
+    !lifecycle?.onDeferredHeartbeat ||
+    requestedIntervalMs === undefined ||
+    !Number.isFinite(requestedIntervalMs) ||
+    requestedIntervalMs <= 0 ||
+    deferredHeartbeatTimers.has(lifecycle)
+  ) {
+    return;
+  }
+  if (!isQueueOwner()) {
+    return;
+  }
+  try {
+    lifecycle.onDeferredHeartbeat();
+  } catch {
+    // A broken liveness callback must not take down the queue. Leave the
+    // watchdog unrenewed so it can recover the orphaned claim.
+    return;
+  }
+  const intervalMs = Math.max(1, Math.floor(requestedIntervalMs));
+  const timer = setInterval(() => {
+    if (!isQueueOwner()) {
+      stopFollowupRunDeferredHeartbeat(lifecycle);
+      return;
+    }
+    try {
+      lifecycle.onDeferredHeartbeat?.();
+    } catch {
+      // A broken liveness callback must not take down the queue. Stop renewing
+      // so the ingress watchdog can recover the orphaned claim.
+      stopFollowupRunDeferredHeartbeat(lifecycle);
+    }
+  }, intervalMs);
+  timer.unref?.();
+  deferredHeartbeatTimers.set(lifecycle, timer);
+}
 
 export function markFollowupRunEnqueued(run: FollowupLifecycleRun): boolean {
   const lifecycle = run.turnAdoptionLifecycle;
@@ -334,6 +393,7 @@ export async function admitFollowupRunLifecycle(run: FollowupLifecycleRun): Prom
     if (!admittedTurnAdoptionLifecycles.has(lifecycle)) {
       await lifecycle.onAdopted();
       admittedTurnAdoptionLifecycles.add(lifecycle);
+      stopFollowupRunDeferredHeartbeat(lifecycle);
     }
   });
 
@@ -351,6 +411,7 @@ export function completeFollowupRunLifecycle(
 ): void {
   run.steerPending?.settle(false);
   const lifecycle = run.turnAdoptionLifecycle;
+  stopFollowupRunDeferredHeartbeat(lifecycle);
 
   const finish = () => {
     if (!lifecycle || completedTurnAdoptionLifecycleCallbacks.has(lifecycle)) {

--- a/src/channels/message/ingress-drain-lifecycle.test.ts
+++ b/src/channels/message/ingress-drain-lifecycle.test.ts
@@ -22,6 +22,10 @@ describe("channel ingress drain lifecycle", () => {
       onDeferred: () => {
         calls.push("deferred");
       },
+      onDeferredHeartbeat: () => {
+        calls.push("heartbeat");
+      },
+      deferredHeartbeatIntervalMs: 1_234,
       onAbandoned: () => {
         calls.push("abandoned");
       },
@@ -30,14 +34,16 @@ describe("channel ingress drain lifecycle", () => {
     expect(bound.turnAdoptionLifecycle).toMatchObject({
       admission: "exclusive",
       abortSignal: abort.signal,
+      deferredHeartbeatIntervalMs: 1_234,
     });
     expect("onFailed" in bound.turnAdoptionLifecycle).toBe(false);
     expect("onCancelled" in bound.turnAdoptionLifecycle).toBe(false);
     expect("onAdopted" in bound).toBe(false);
     expect(Object.keys(bound)).toEqual(["turnAdoptionLifecycle"]);
     bound.turnAdoptionLifecycle.onDeferred();
+    bound.turnAdoptionLifecycle.onDeferredHeartbeat?.();
     await bound.turnAdoptionLifecycle.onAbandoned();
-    expect(calls).toEqual(["deferred", "abandoned"]);
+    expect(calls).toEqual(["deferred", "heartbeat", "abandoned"]);
     calls.length = 0;
     bound.turnAdoptionLifecycle.onDeferred();
     await bound.turnAdoptionLifecycle.onAdopted();

--- a/src/channels/message/ingress-drain-lifecycle.ts
+++ b/src/channels/message/ingress-drain-lifecycle.ts
@@ -14,6 +14,8 @@ export type ChannelIngressDispatchLifecycle = {
   onDeferred: () => void;
   /** Deferred reply-lane admission is still waiting behind an active turn. */
   onDeferredHeartbeat?: () => void;
+  /** Requested cadence for queue-owned deferred heartbeats. */
+  deferredHeartbeatIntervalMs?: number;
   /**
    * Durable adoption finalization is in progress (e.g. settlement hold while
    * committing dedupe). Clears the pre-adoption stall watchdog so a timeout
@@ -39,6 +41,7 @@ export function bindIngressLifecycleToReplyOptions(lifecycle: ChannelIngressDisp
     onAdopted: () => void | Promise<void>;
     onDeferred: () => void;
     onDeferredHeartbeat?: () => void;
+    deferredHeartbeatIntervalMs?: number;
     onAbandoned: () => void | Promise<void>;
     abortSignal: AbortSignal;
   };
@@ -49,6 +52,7 @@ export function bindIngressLifecycleToReplyOptions(lifecycle: ChannelIngressDisp
       onAdopted: lifecycle.onAdopted,
       onDeferred: lifecycle.onDeferred,
       onDeferredHeartbeat: lifecycle.onDeferredHeartbeat,
+      deferredHeartbeatIntervalMs: lifecycle.deferredHeartbeatIntervalMs,
       onAbandoned: lifecycle.onAbandoned,
       abortSignal: lifecycle.abortSignal,
     },

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -366,6 +366,7 @@ export function createChannelIngressDrain<
           armStallWatchdog(state);
         }
       },
+      deferredHeartbeatIntervalMs: Math.max(1, Math.floor(adoptionStallTimeoutMs / 3)),
       onAdoptionFinalizing: () => {
         if (state.phase !== "dispatching" && state.phase !== "deferred") {
           return;

--- a/src/channels/message/ingress-drain.watchdog.test.ts
+++ b/src/channels/message/ingress-drain.watchdog.test.ts
@@ -98,6 +98,7 @@ describe("channel ingress drain watchdog", () => {
       const queue = createTestIngressQueue(stateDir, { now: () => clock });
       await queue.enqueue("evt-def-stall", { text: "x" }, { laneKey: "l1" });
       let heartbeat: (() => void) | undefined;
+      let heartbeatIntervalMs: number | undefined;
 
       const drain = createChannelIngressDrain<Payload>({
         queue,
@@ -106,6 +107,7 @@ describe("channel ingress drain watchdog", () => {
         dispatchClaimedEvent: async (_event, lifecycle) => {
           lifecycle.onDeferred();
           heartbeat = lifecycle.onDeferredHeartbeat;
+          heartbeatIntervalMs = lifecycle.deferredHeartbeatIntervalMs;
           // Stay deferred without adoption -- watchdog must still fire.
           await new Promise(() => {});
         },
@@ -113,6 +115,7 @@ describe("channel ingress drain watchdog", () => {
 
       await drain.drainOnce();
       expect(await queue.listClaims()).toHaveLength(1);
+      expect(heartbeatIntervalMs).toBe(1_666);
       clock += 4_000;
       await vi.advanceTimersByTimeAsync(4_000);
       heartbeat?.();

--- a/src/channels/message/ingress-monitor-types.ts
+++ b/src/channels/message/ingress-monitor-types.ts
@@ -13,6 +13,7 @@ export type ChannelIngressMonitorLifecycle = {
   onAdopted: () => void | Promise<void>;
   onDeferred: () => void;
   onDeferredHeartbeat?: () => void;
+  deferredHeartbeatIntervalMs?: number;
   onAdoptionFinalizing: () => void;
   onFailed?: (error: unknown) => void | Promise<void>;
   onCancelled?: () => void | Promise<void>;

--- a/src/plugin-sdk/channel-ingress-runtime.test.ts
+++ b/src/plugin-sdk/channel-ingress-runtime.test.ts
@@ -44,6 +44,7 @@ describe("plugin-sdk/channel-ingress-runtime", () => {
       abortSignal: new AbortController().signal,
       onAdopted: vi.fn(async () => {}),
       onDeferred: vi.fn(),
+      deferredHeartbeatIntervalMs: 3_000,
       onAdoptionFinalizing: vi.fn(),
       onFailed: vi.fn(async () => {}),
       onCancelled: vi.fn(async () => {}),
@@ -51,9 +52,12 @@ describe("plugin-sdk/channel-ingress-runtime", () => {
     });
     const first = createLifecycle();
     const second = createLifecycle();
+    second.deferredHeartbeatIntervalMs = 1_000;
     const cancellation = fanInChannelIngressLifecycles([first, second]);
     await cancellation.lifecycle?.onCancelled?.();
     const combined = fanInChannelIngressLifecycles([undefined, first, second]);
+
+    expect(combined.lifecycle?.deferredHeartbeatIntervalMs).toBe(1_000);
 
     combined.lifecycle?.onAdoptionFinalizing();
     await combined.lifecycle?.onAdopted();

--- a/src/plugin-sdk/channel-ingress-runtime.ts
+++ b/src/plugin-sdk/channel-ingress-runtime.ts
@@ -165,6 +165,12 @@ export function fanInChannelIngressLifecycles(
       lifecycle.onFailed ? lifecycle.onFailed(error) : lifecycle.onAbandoned(),
     );
   const supportsCancellation = lifecycles.every((lifecycle) => lifecycle.onCancelled !== undefined);
+  const deferredHeartbeatIntervals = lifecycles
+    .map((lifecycle) => lifecycle.deferredHeartbeatIntervalMs)
+    .filter(
+      (interval): interval is number =>
+        interval !== undefined && Number.isFinite(interval) && interval > 0,
+    );
   // Omit aggregate cancellation unless every durable source supports it. Callers
   // can then use settle/abandon without an acknowledged-but-unsettled claim.
   const cancelAll = () =>
@@ -192,6 +198,9 @@ export function fanInChannelIngressLifecycles(
           lifecycle.onDeferredHeartbeat?.();
         }
       },
+      ...(deferredHeartbeatIntervals.length > 0
+        ? { deferredHeartbeatIntervalMs: Math.min(...deferredHeartbeatIntervals) }
+        : {}),
       onAdoptionFinalizing: () => {
         for (const lifecycle of lifecycles) {
           lifecycle.onAdoptionFinalizing();

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -31,6 +31,7 @@ export const createTestInboundDebounceFlush: InboundDebounceFlushFactory = (para
     onAdopted: async () => await source?.onAdopted?.(),
     onDeferred: () => source?.onDeferred?.(),
     onDeferredHeartbeat: () => source?.onDeferredHeartbeat?.(),
+    deferredHeartbeatIntervalMs: source?.deferredHeartbeatIntervalMs,
     onAdoptionFinalizing: () => source?.onAdoptionFinalizing?.(),
     onFailed: source?.onFailed ? async (error) => await source.onFailed?.(error) : undefined,
     onAbandoned: async () => await source?.onAbandoned?.(),


### PR DESCRIPTION
## Contributor description — original implementation

The contributor’s original description follows. Historical heads, scope and open decisions in this section refer to that implementation; the reviewed current implementation, compatibility decision and proof are recorded in the maintainer update below.

Closes #133245.

Related: #127950. This supersedes the current-main-incompatible queue-owned approach in #125385 while preserving today's canonical timeout retry disposition.

## What Problem This Solves

A durably claimed channel message can wait behind another follow-up turn for longer than the five-minute claim-to-adoption watchdog. Existing liveness renewal covers queue-head active-run admission checks, but not an ingress-backed lifecycle waiting deeper in the follow-up queue. The claim can therefore be retired before the message reaches the model.

## Why This Change Was Made

The follow-up queue now owns periodic deferred heartbeats for the exact ingress lifecycle while it remains in pending items, in-flight delivery, summary sources, or compacted summary elisions.

Ingress supplies a cadence derived from one third of its adoption-stall timeout. Debounce, Plugin SDK fan-in, and channel lifecycle wrappers preserve the shortest applicable cadence. Queue ownership triggers an immediate renewal, then periodic renewal; it stops after successful adoption, completion, ownership loss, or callback failure. A rejected adoption callback keeps renewal alive for the supported retry path.

The existing watchdog and canonical timeout retry policy remain unchanged, so silent handlers and orphaned claims still recover normally.

## User Impact

Messages accepted by durable channel ingress remain adoptable while they wait behind long-running work instead of silently disappearing before model execution. No setting or migration is required.

## Evidence

SDK documentation polish (2026-09-10, head `76097fef9397a04c10637e06dfaf64ebb6ca104a`): the public channel SDK guide now documents forwarding both heartbeat fields, the shortest-positive-finite fan-in cadence, renewal termination, and compatibility when older wrappers omit the optional cadence. The documentation-only addition passed changed-page formatting, MDX sanity, and `git diff --check`; production code and the previously tested runtime head below are unchanged. Current-head hosted CI has completed successfully; the final exact-head ClawSweeper review accepts the implementation and proof, leaving only SDK-owner acceptance of the documented contract.

Refreshed on 2026-09-08 for exact head `57c4faff0ed7bb2d9b4fd308aa46b19ae4095e61`, rebased onto `1ff45cad5ae`.

- Preserved upstream's ingress-monitor type extraction and gateway-suspension repair; the optional cadence field follows its new type owner.
- Repaired the retry integration fixture: after real enqueue and initial renewal, only the abandoned message's heartbeat callback fails. The real watchdog then recovers it. Retry delivery, healthy sibling cleanup, and true duplicate assertions remain intact; no production behavior or timeout changed for this repair.
- 102 focused tests pass: dispatch ingress retry, queue in-flight/dedupe, ingress lifecycle/watchdog, Plugin SDK fan-in, Discord queue handling, and Slack handler.
- Changed-file gates pass: core/core-test/extension typechecks, formatting, changed core/extension lint, SDK boundaries/exports, dead-export scans, and repository guards.
- Fresh independent source review found no actionable P0–P2 defects. The standalone autoreview CLI failed at startup without a verdict and is not counted as review coverage.
- Current-head CI run [34520397963](https://github.com/openclaw/openclaw/actions/runs/34520397963) completed successfully. The earlier startup subprocess timeout is historical, not a current failing gate. Exact-head ClawSweeper review (September 10, 20:00 UTC) reports no actionable correctness or proof findings; explicit SDK-owner acceptance remains required before merge.
- Existing regressions cover immediate renewal after late handoff, periodic deeper-queue renewal, stopping after owner loss, and continuing across a rejected adoption callback.

Exact-head durable-ingress boundary proof used isolated SQLite with the production ingress drain/lifecycle binder, follow-up queue, and canonical adoption helper. The model callback was synthetic; this is not live Telegram or Discord transport proof. No production Gateway, channel state, or configuration was touched. Temporary state and queue ownership were cleaned up.

```json
{
  "schema": "openclaw.pr133248.durable-ingress-proof.v1",
  "exactHead": "57c4faff0ed7bb2d9b4fd308aa46b19ae4095e61",
  "setup": {
    "durableStore": "isolated OpenClaw SQLite state",
    "executor": "production follow-up queue with synthetic model callback",
    "transportLifecycle": "production ingress drain lifecycle",
    "adoptionStallTimeoutMs": 180
  },
  "queuedBehindLongTurn": {
    "heldMs": 620,
    "formerDeadlineCrossed": true,
    "heartbeatCount": 11,
    "claimStillOwnedAtCheckpoint": [
      "queued-event"
    ],
    "retryRowsAtCheckpoint": 0,
    "failedRowsAtCheckpoint": 0,
    "executionCount": 1,
    "duplicateAfterAdoption": "completed"
  },
  "orphanRecovery": {
    "status": "released-for-retry",
    "attempts": 1,
    "lastErrorContainsHandlerTimeout": true
  },
  "productionTouched": false
}
```

Owner acceptance:
- Intended behavior: accepted messages remain adoptable while their exact lifecycle is owned by the queue; ownerless claims retain canonical timeout recovery.
- Boundary: one optional cadence field propagated through existing shared lifecycle and channel wrappers; no configuration, schema, or migration change.
- Maintainer decision remains open: accept the additive public Plugin SDK lifecycle field and its queue-owned cadence semantics. Bot review is not that acceptance.
- Rollback: revert the renewal fix and its companion retry-fixture adjustment.
- Scope: 23 files, +273/-2. The width is required lifecycle forwarding; renewal policy stays in the queue and ingress drain.

AI-assisted.

---

## Maintainer update — reviewed head `9325ad501aa4`

## What Problem This Solves

Messages accepted while a long reply is running can expire in the follow-up queue and consume a retry. The reproduction confirmed expiry and retry; all three messages eventually arrived. It did not reproduce the older permanent-loss report in #133245.

## Fix and impact

The queue starts one heartbeat when it accepts a lifecycle and stops it on adoption, completion, cancellation, or callback failure. Heartbeats no longer scan queue collections or copy the in-flight set. Ingress remains responsible for the watchdog and retry settlement, and a heartbeat cannot undo the watchdog pause during adoption finalization.

Ingress derives the cadence from its adoption timeout. The optional lifecycle metadata remains necessary because wrappers rebuild callbacks and combine abort signals, losing the original timeout. No channel setting, schema, migration, dependency, or protocol change is added.

The simplification removes 110 lines net from the initial implementation plus main merge. Total production growth is 40 lines. Existing lifecycle types are reused, and the queue cases share the existing lifecycle test fixtures.

## Evidence

- Real Gateway and Discord: three marked messages on one route, with a queued reply held for 330 seconds. Main expired the third claim after 300.004 seconds. This head retained the same claim at 322.257 seconds with zero attempts; replies arrived once, in order, at 17.804, 349.201, and 350.223 seconds.
- Real SQLite/drain/binder/queue controls: explicit abandonment releases the claim; callback failure stops renewal and lets the watchdog retry without model execution.
- 191 core owner/sibling tests and 190 channel tests passed. All five new regression cases failed on plain main for the intended reasons.
- The local preflight passed core/extension type-aware lint, production and test types, script types, and protocol checks in an isolated checkout of this head.
- External consumers compiled and ran against published 2026.9.4 and this head, including omitted metadata, forwarding, optional return fields, and asynchronous abandonment.

## Consumers

Shared ingress binding, batching, reply dispatch, and the Feishu, Slack, Telegram, and Twitch wrappers preserve the source cadence. The fan-in uses the shortest valid cadence. Legacy wrappers that omit the optional field retain their existing head-only heartbeat behavior. Adoption, queue clearing, overflow, cancellation, summaries, and drain replacement retain or finish the same lifecycle owner.

Closes #133245.

Original implementation and report by @PollyBot13 (#133245). The contributor's commits and authorship are retained.

AI-assisted.
