### PR TITLE
fix: keep CLI table rows aligned with CRLF values

### DIFF
--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -448,6 +448,7 @@ describe("renderTable", () => {
       const link = `${openSeq}OpenClaw${closeSeq}`;
       const out = renderTable({
         width: 20,
+        border: "unicode",
         columns: [
           { key: "K", header: "K", minWidth: 3 },
           { key: "V", header: "V", flex: true, minWidth: 10 },
@@ -455,26 +456,15 @@ describe("renderTable", () => {
         rows: [{ K: "X", V: `before ${link} after` }],
       });
 
-      const lines = out
-        .split("\n")
-        .filter((line) => line.includes("before") || line.includes("after"));
-      // Every line that contains visible text should close any active link before
-      // the table border and reopen it at the start of the continuation.
-      for (const line of lines) {
-        const contentStart = Math.max(line.lastIndexOf("│"), line.lastIndexOf("|")) + 1;
-        const content = line.slice(contentStart);
-        // "after" must not be part of the hyperlink: it should appear after a
-        // close sequence on its line, or the line has no open sequence at all.
-        if (content.includes("after")) {
-          const afterIndex = content.indexOf("after");
-          const openIndex = content.indexOf(openSeq);
-          const closeIndex = content.indexOf(closeSeq);
-          expect(closeIndex).toBeGreaterThan(-1);
-          expect(closeIndex).toBeLessThan(afterIndex);
-          if (openIndex >= 0 && openIndex < afterIndex) {
-            expect(closeIndex).toBeGreaterThan(openIndex);
-          }
-        }
+      const afterLines = out.split("\n").filter((line) => line.includes("after"));
+      expect(afterLines.length).toBeGreaterThan(0);
+      for (const line of afterLines) {
+        const content = line.split("│")[2] ?? "";
+        expect(content).toContain("after");
+        // The link may have closed on a previous line. Any opener before the
+        // suffix on this line must also have closed before the suffix starts.
+        const prefix = content.slice(0, content.indexOf("after"));
+        expect(prefix.lastIndexOf(openSeq)).toBeLessThanOrEqual(prefix.lastIndexOf(closeSeq));
       }
     },
   );

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -2,7 +2,7 @@
 import path from "node:path";
 import { note as clackNote } from "@clack/prompts";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { stripAnsi, visibleWidth } from "./ansi.js";
+import { sanitizeForLog, stripAnsi, visibleWidth } from "./ansi.js";
 import {
   noteToStream,
   resolveNoteColumns,
@@ -513,22 +513,67 @@ describe("renderTable", () => {
     },
   );
 
-  it("respects explicit newlines in cell values", () => {
-    const out = renderTable({
-      width: 48,
-      columns: [
-        { key: "A", header: "A", minWidth: 6 },
-        { key: "B", header: "B", minWidth: 10, flex: true },
-      ],
-      rows: [{ A: "row", B: "line1\nline2" }],
-    });
+  it.each([
+    ["LF", "line1\n東京 line2", "", "", 0],
+    ["CR", "line1\r東京 line2", "", "", 0],
+    ["CRLF", "line1\r\n東京 line2", "", "", 0],
+    ["colored CRLF", "\x1b[31mline1\r\n東京 line2\x1b[39m", "\x1b[31m", "\x1b[39m", 0],
+    [
+      "linked CRLF",
+      "\x1b]8;;https://openclaw.ai\x07line1\r\n東京 line2\x1b]8;;\x07",
+      "\x1b]8;;https://openclaw.ai\x07",
+      "\x1b]8;;\x07",
+      0,
+    ],
+    ["CR/SGR/LF", "line1\r\x1b[31m\n東京 line2\x1b[39m", "\x1b[31m", "\x1b[39m", 1],
+    [
+      "CR/OSC-8/LF",
+      "line1\r\x1b]8;;https://openclaw.ai\x07\n東京 line2\x1b]8;;\x07",
+      "\x1b]8;;https://openclaw.ai\x07",
+      "\x1b]8;;\x07",
+      1,
+    ],
+    ["CR/CSI-HT/LF", "line1\r\x1b[31\tm\n東京 line2\x1b[39m", "\x1b[31\tm", "\x1b[39m", 1],
+    ["CR/CSI-BEL/LF", "line1\r\x1b[31\x07m\n東京 line2\x1b[39m", "\x1b[31\x07m", "\x1b[39m", 1],
+  ] as const)(
+    "respects explicit %s newlines in cell values",
+    (_name, value, open, close, styledStart) => {
+      const out = renderTable({
+        width: 48,
+        border: "unicode",
+        columns: [
+          { key: "A", header: "A", minWidth: 6 },
+          { key: "B", header: "B", minWidth: 10, flex: true },
+        ],
+        rows: [{ A: "row", B: value }],
+      });
 
-    const lines = out.trimEnd().split("\n");
-    const line1Index = lines.findIndex((line) => line.includes("line1"));
-    const line2Index = lines.findIndex((line) => line.includes("line2"));
-    expect(line1Index).toBeGreaterThan(-1);
-    expect(line2Index).toBe(line1Index + 1);
-  });
+      const lines = out.trimEnd().split("\n");
+      expect(lines).toHaveLength(6);
+      for (const line of lines) {
+        expect(visibleWidth(line)).toBe(48);
+      }
+      const dataLines = lines.slice(3, -1);
+      expect(
+        dataLines.map((line) =>
+          sanitizeForLog(line)
+            .split("│")
+            .slice(1, -1)
+            .map((cell) => cell.trim()),
+        ),
+      ).toEqual([
+        ["row", "line1"],
+        ["", "東京 line2"],
+      ]);
+      if (open) {
+        for (const line of dataLines.slice(styledStart)) {
+          expect(line).toContain(open);
+          expect(line).toContain(close);
+          expect(line.lastIndexOf(close)).toBeLessThan(line.lastIndexOf("│"));
+        }
+      }
+    },
+  );
 
   it("shortens only exact home paths and child paths in table cells", () => {
     const home = path.resolve("test-home", "alice");

--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -501,17 +501,14 @@ function wrapLine(text: string, width: number): string[] {
     }
 
     const ch = token.value;
-    if (skipNextLf) {
+    if (skipNextLf && ch === "\n") {
       skipNextLf = false;
-      if (ch === "\n") {
-        continue;
-      }
+      continue;
     }
-    if (ch === "\n" || ch === "\r") {
+    // CRLF is one grapheme; separated CR/LF may retain intervening ANSI controls.
+    skipNextLf = ch === "\r";
+    if (ch === "\n" || ch === "\r" || ch === "\r\n") {
       flushAt(buf.length);
-      if (ch === "\r") {
-        skipNextLf = true;
-      }
       continue;
     }
     const charWidth = visibleWidth(ch);


### PR DESCRIPTION
Closes #133242

## What Problem This Solves

Fixes an issue where operators reading CLI tables would see missing borders and shifted columns when a cell contains CRLF line endings. Hook descriptions reproduce the problem through the actual hooks-list formatter.

## Why This Change Was Made

The shared table wrapper consumes graphemes, and [Unicode UAX #29 rule GB3](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundary_Rules) keeps CRLF together. Its newline branch recognized only individual CR and LF, allowing the combined zero-width token to escape into a formatted physical row. Recognize CRLF at that existing boundary and simplify the state transition while retaining CR/ANSI/LF handling. ANSI payloads, width calculation, terminal-safe sanitization, and individual CLI callers are unchanged.

Provenance: confirmed on `8b7d685b2a9228a7aa98b5338b0ad8534777cace`; exact stable-release introduction is unknown.

## User Impact

Multiline table cells now keep their text inside aligned borders with LF, CR, or CRLF line endings, including colored and hyperlinked content. Production LOC: **+5/-8 (net -3)**. Tests: **+71/-36 (net +35)**.

## Evidence

- Before the fix, plain/colored/hyperlinked CRLF cases failed the existing newline regression; six LF/CR and ANSI-separated controls passed. Afterward, all **148** table, ANSI, and hooks CLI tests pass. Assertions check exact retained text, physical row widths, borders, and style closure; CSI controls between CR and LF remain covered.
- The same source-import probe invokes the actual table and hooks-list formatter before and after. A 40-column table changes from physical widths `40,40,40,14,26,40` to six 40-column rows. The hooks-list CRLF case changes from split 54/66-column rows to complete 120-column rows, matching the LF control. This is source formatter proof, not a packaged CLI, Gateway, or native Windows-terminal run.
- Focused command: `node scripts/run-vitest.mjs packages/terminal-core/src/table.test.ts packages/terminal-core/src/ansi.test.ts src/cli/hooks-cli.test.ts`.
- The full two-file changed gate passed: `node scripts/check-changed.mjs -- packages/terminal-core/src/table.ts packages/terminal-core/src/table.test.ts`. The subsequent test-only assertion cleanup also passed its full required test-file gate, including core-test type checking and lint; production bytes are unchanged.
- Corrected the adjacent embedded-hyperlink test to inspect its actual cell instead of the empty text after the final border. All three terminator variants pass; the assertion allows links already closed on a previous line.
- Independent owner/caller/dependency review found no actionable issue. Codex autoreview is scoped-clean at its default P0 threshold; a separate exact-head source review found no actionable P0–P2 issues. Both reviews and the independent peer binding cover `5d6510ce450718fe0928859de9d684da1573709b`.

Exact-head CI: [run 33305693555](https://github.com/openclaw/openclaw/actions/runs/33305693555).

Before:
```text
| row  | first
東京 second              |
```
After:
```text
| row  | first                         |
|      | 東京 second                   |
```
