### PR TITLE
fix(ci): verify responsive viewport before layout assertions

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -2,6 +2,7 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { expect as expectBrowser } from "playwright/test";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { QueueMode } from "../../../../packages/gateway-protocol/src/schema/logs-chat.ts";
 import {
@@ -828,6 +829,19 @@ async function openFixture(width: number, height: number, opts: ChatFixtureOptio
   }
 }
 
+async function waitForViewportSize(page: Page, width: number, height: number) {
+  await expectBrowser
+    .poll(
+      () =>
+        page.evaluate(() => ({
+          width: window.innerWidth,
+          height: window.innerHeight,
+        })),
+      { timeout: 5_000 },
+    )
+    .toEqual({ width, height });
+}
+
 async function openBrowserPage(
   width: number,
   height: number,
@@ -837,15 +851,28 @@ async function openBrowserPage(
     executablePath: chromiumExecutablePath,
     headless: true,
   });
-  if (options.isolated) {
-    return await sharedBrowser.newPage({ hasTouch: options.hasTouch, viewport: { width, height } });
+  let page: Page | undefined;
+  try {
+    if (options.isolated) {
+      page = await sharedBrowser.newPage({
+        hasTouch: options.hasTouch,
+        viewport: { width, height },
+      });
+    } else {
+      // Static setContent fixtures do not mutate context-owned storage or routes,
+      // so they can share one context while their pages remain concurrent.
+      sharedLayoutContext ??= await sharedBrowser.newContext();
+      page = await sharedLayoutContext.newPage();
+      await page.setViewportSize({ width, height });
+    }
+    await waitForViewportSize(page, width, height);
+    return page;
+  } catch (error) {
+    if (page) {
+      await closeBrowserPage(page);
+    }
+    throw error;
   }
-  // Static setContent fixtures do not mutate context-owned storage or routes,
-  // so they can share one context while their pages remain concurrent.
-  sharedLayoutContext ??= await sharedBrowser.newContext();
-  const page = await sharedLayoutContext.newPage();
-  await page.setViewportSize({ width, height });
-  return page;
 }
 
 async function closeBrowserPage(page: Page): Promise<void> {
@@ -3700,6 +3727,10 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           };
         };
         return {
+          viewport: {
+            width: window.innerWidth,
+            height: window.innerHeight,
+          },
           controls: rectFor(".agent-chat__composer-controls"),
           footer: rectFor(".agent-chat__composer-footer"),
           input: rectFor(".agent-chat__input"),
@@ -3710,6 +3741,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         };
       });
 
+      expect(layout.viewport).toEqual({ width: 320, height: 568 });
       expect(layout.controls.scrollWidth).toBeLessThanOrEqual(layout.controls.clientWidth + 1);
       for (const control of [layout.status, layout.settings]) {
         expect(control.x).toBeGreaterThanOrEqual(layout.footer.x - 1);
@@ -3722,7 +3754,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         layout.input.x + layout.input.width + 1,
       );
       expect(layout.typing.x).toBeGreaterThanOrEqual(0);
-      expect(layout.typing.x + layout.typing.width).toBeLessThanOrEqual(320);
+      expect(layout.typing.x + layout.typing.width).toBeLessThanOrEqual(layout.viewport.width);
       expect(layout.settings.width).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN_PX);
       expect(layout.settings.height).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN_PX);
       for (const [left, right] of [


### PR DESCRIPTION
Closes #133250

## What Problem This Solves

The responsive browser layout fixture returned after requesting a viewport resize without verifying or recording the exact browser-observed dimensions. Full Release Validation then observed a typing-indicator right edge of `539` against the intended `320` width, but the failure could not distinguish a wrong effective viewport from genuine overflow at the intended viewport.

Failure: https://github.com/openclaw/openclaw/actions/runs/33301725215/job/99231140616

## Why This Change Was Made

The browser-page helper now verifies the exact viewport after both page-creation paths. Both allocation paths close an allocated page when viewport setup or verification fails, while preserving the original error. The affected mobile layout test atomically records viewport dimensions with element geometry, asserts the exact `320x568` contract, and bounds the typing indicator against the captured viewport width.

This keeps the assertion tied to the intended mobile viewport without weakening the protected layout behavior. A wrong viewport fails the postcondition, while genuine layout overflow fails the geometry bound.

## User Impact

No CSS or product behavior changes. This is a test-fixture repair that makes hosted Chromium viewport state explicit while preserving the mobile composer regression coverage.

## Evidence

- Frozen FRV target `43d259069c8314300cdf94c763826c9a3b5e6444`: focused/full test plus five additional full-file repeats passed during diagnosis.
- Current main: focused and full-file tests passed during diagnosis.
- Rebased exact head focused test: `1/1` passed.
- Rebased exact head full file: `111/111` passed.
- First post-fix stress proof: 10 serial full-file runs, `1110/1110` passed.
- Second post-fix stress proof after the cleanup guard: 10 serial full-file runs, `1110/1110` passed.
- ClawSweeper P2 resolved: both page allocation paths close an allocated page when `setViewportSize` or viewport verification fails, preserving the original error.
- P0-P2 autoreview after cleanup: scoped-clean.
- Format, typed oxlint, i18n, deadcode, ratchets, and `git diff --check`: passed.
- LOC: production `+0/-0`; tests/test support `+41/-9`.
- `check:changed` typecheck was blocked by the shared install missing `@types/pako`; no dependency install was performed in the linked worktree.
- Exact-head CI: pending.
