### PR TITLE
fix(config): honor environment-selected profile roots

### DIFF
--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -38,6 +38,8 @@ The variables below are the supported environment contract for operators. Undocu
 | `OPENCLAW_GIT_DIR`       | Override the source checkout used by development-channel updates. |
 | `OPENCLAW_INCLUDE_ROOTS` | Allow `$include` to resolve from additional roots.                |
 
+A named `OPENCLAW_PROFILE` uses `~/.openclaw-<profile>` for state and config defaults, including when that profile has no config file yet. Explicit `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` values still take precedence. An explicit CLI `--profile` selects the requested profile as described in [Global flags](/cli#global-flags).
+
 ### Gateway and authentication
 
 | Variable                    | Purpose                                                         |

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -534,7 +534,9 @@ const resolveLauncherConfigPaths = () => {
 };
 
 const shouldDeferRootHelpToRuntimeEntry = () => {
+  const profile = process.env.OPENCLAW_PROFILE?.trim();
   if (
+    (profile && profile.toLowerCase() !== "default") ||
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR?.trim() ||
     process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS?.trim()
   ) {

--- a/src/config/paths.test.ts
+++ b/src/config/paths.test.ts
@@ -183,7 +183,7 @@ describe("default install identity", () => {
           },
           () => home,
         ),
-      ).toBe(false);
+      ).toBe(true);
 
       await fs.mkdir(profileStateDir, { recursive: true });
       await fs.writeFile(path.join(profileStateDir, "openclaw.json"), "{}");
@@ -436,6 +436,44 @@ describe("gateway port resolution", () => {
 });
 
 describe("state + config path candidates", () => {
+  it.each(["work", "dev", " work "])(
+    "keeps environment profile %j state and config separate from default files",
+    async (profile) => {
+      await withTestDir({ prefix: "openclaw-env-profile-" }, async (home) => {
+        const defaultStateDir = path.join(home, ".openclaw");
+        const stateDir = path.join(home, `.openclaw-${profile.trim()}`);
+        const configPath = path.join(stateDir, "openclaw.json");
+        await fs.mkdir(defaultStateDir, { recursive: true });
+        await fs.writeFile(path.join(defaultStateDir, "openclaw.json"), "{}");
+        const env = { HOME: home, OPENCLAW_PROFILE: profile };
+
+        for (const profileConfigExists of [false, true]) {
+          if (profileConfigExists) {
+            await fs.mkdir(stateDir, { recursive: true });
+            await fs.writeFile(configPath, "{}");
+          }
+          expect(resolveStateDir(env)).toBe(stateDir);
+          expect(resolveConfigPathCandidate(env)).toBe(configPath);
+          expect(resolveConfigPath(env)).toBe(configPath);
+          expect(isDefaultStateDir(env)).toBe(false);
+          expect(allowsProcessHomeSessionScan(env, () => home)).toBe(false);
+        }
+      });
+    },
+  );
+
+  it("keeps a missing named config isolated when its state directory is explicit", async () => {
+    await withTestDir({ prefix: "openclaw-profile-config-missing-" }, async (home) => {
+      const defaultDir = path.join(home, ".openclaw");
+      await fs.mkdir(defaultDir, { recursive: true });
+      await fs.writeFile(path.join(defaultDir, "openclaw.json"), "{}");
+      const stateDir = path.join(home, ".openclaw-work");
+      const env = { HOME: home, OPENCLAW_PROFILE: "work", OPENCLAW_STATE_DIR: stateDir };
+      expect(resolveConfigPathCandidate(env)).toBe(path.join(stateDir, "openclaw.json"));
+      expect(resolveConfigPath(env)).toBe(path.join(stateDir, "openclaw.json"));
+    });
+  });
+
   function expectOpenClawHomeDefaults(env: NodeJS.ProcessEnv): void {
     const configuredHome = env.OPENCLAW_HOME;
     if (!configuredHome) {
@@ -501,6 +539,16 @@ describe("state + config path candidates", () => {
       expect(CONFIG_PATH).toBe(selectedConfigPath);
       expect(isNixMode).toBe(true);
       expect(STATE_DIR).toBe(selectedStateDir);
+
+      const profileHome = path.resolve("/tmp/openclaw-profile-runtime-home");
+      const profileStateDir = path.join(profileHome, ".openclaw-work");
+      const profileConfigPath = path.join(profileStateDir, "openclaw.json");
+      expect(pinRuntimePaths({ HOME: profileHome, OPENCLAW_PROFILE: "work" })).toEqual({
+        configPath: profileConfigPath,
+        stateDir: profileStateDir,
+      });
+      expect(CONFIG_PATH).toBe(profileConfigPath);
+      expect(STATE_DIR).toBe(profileStateDir);
     } finally {
       pinRuntimePaths({
         OPENCLAW_CONFIG_PATH: originalConfigPath,

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -77,26 +77,23 @@ export function resolveStateDir(
   if (override) {
     return resolveUserPath(override, env, effectiveHomedir);
   }
+  const profile = normalizeProfileName(env.OPENCLAW_PROFILE);
+  if (profile) {
+    return resolveProfileStateDir(profile, env, effectiveHomedir);
+  }
   const newDir = newStateDir(effectiveHomedir);
-  if (isFastTestRuntimeEnv(env)) {
+  if (isFastTestRuntimeEnv(env) || fs.existsSync(newDir)) {
     return newDir;
   }
-  const legacyDirs = legacyStateDirs(effectiveHomedir);
-  const hasNew = fs.existsSync(newDir);
-  if (hasNew) {
-    return newDir;
-  }
-  const existingLegacy = legacyDirs.find((dir) => {
-    try {
-      return fs.existsSync(dir);
-    } catch {
-      return false;
-    }
-  });
-  if (existingLegacy) {
-    return existingLegacy;
-  }
-  return newDir;
+  return (
+    legacyStateDirs(effectiveHomedir).find((dir) => {
+      try {
+        return fs.existsSync(dir);
+      } catch {
+        return false;
+      }
+    }) ?? newDir
+  );
 }
 
 function normalizePathForComparison(candidate: string): string {
@@ -116,8 +113,8 @@ export function isDefaultStateDir(
 ): boolean {
   const override = env.OPENCLAW_STATE_DIR?.trim();
   if (!override) {
-    // Preserve the default install path, including automatic legacy-state discovery.
-    return true;
+    // Named profiles do not inherit default-profile workspaces or personal skills.
+    return !normalizeProfileName(env.OPENCLAW_PROFILE);
   }
   const effectiveHomedir = () => resolveRequiredHomeDir(env, homedir);
   return (
@@ -381,6 +378,11 @@ export function resolveDefaultConfigCandidates(
     return [resolveUserPath(explicit, env, effectiveHomedir)];
   }
 
+  if (normalizeProfileName(env.OPENCLAW_PROFILE)) {
+    // A missing profile config must never select another profile's authored state.
+    const stateDir = resolveStateDir(env, effectiveHomedir);
+    return [CONFIG_FILENAME, ...LEGACY_CONFIG_FILENAMES].map((name) => path.join(stateDir, name));
+  }
   const candidates: string[] = [];
   const openclawStateDir = env.OPENCLAW_STATE_DIR?.trim();
   if (openclawStateDir) {
@@ -389,12 +391,11 @@ export function resolveDefaultConfigCandidates(
     candidates.push(...LEGACY_CONFIG_FILENAMES.map((name) => path.join(resolved, name)));
   }
 
-  const defaultDirs = [newStateDir(effectiveHomedir), ...legacyStateDirs(effectiveHomedir)];
-  for (const dir of defaultDirs) {
-    candidates.push(path.join(dir, CONFIG_FILENAME));
-    candidates.push(...LEGACY_CONFIG_FILENAMES.map((name) => path.join(dir, name)));
-  }
-  return candidates;
+  return candidates.concat(
+    [newStateDir(effectiveHomedir), ...legacyStateDirs(effectiveHomedir)].flatMap((dir) =>
+      [CONFIG_FILENAME, ...LEGACY_CONFIG_FILENAMES].map((name) => path.join(dir, name)),
+    ),
+  );
 }
 
 export const DEFAULT_GATEWAY_PORT = 18789;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -134,6 +134,19 @@ describe("normalizeE164", () => {
 });
 
 describe("resolveConfigDir", () => {
+  it.each([
+    { profile: "work", directory: ".openclaw-work" },
+    { profile: " work ", directory: ".openclaw-work" },
+    { profile: "dev", directory: ".openclaw-dev" },
+    { profile: "Default", directory: ".openclaw" },
+    { profile: "bad profile", directory: ".openclaw" },
+  ])("selects the configuration root for ambient profile '$profile'", ({ profile, directory }) => {
+    const home = path.resolve("/tmp/openclaw-config-home");
+    expect(resolveConfigDir({ HOME: home, OPENCLAW_PROFILE: profile })).toBe(
+      path.join(home, directory),
+    );
+  });
+
   it("prefers ~/.openclaw when legacy dir is missing", async () => {
     await withTestDir({ prefix: "openclaw-config-dir-" }, async (root) => {
       const newDir = path.join(root, ".openclaw");
@@ -147,6 +160,8 @@ describe("resolveConfigDir", () => {
     const env = {
       HOME: "/tmp/openclaw-home",
       OPENCLAW_STATE_DIR: "~/state",
+      OPENCLAW_CONFIG_PATH: "~/custom/config.json",
+      OPENCLAW_PROFILE: "work",
     } as NodeJS.ProcessEnv;
 
     expect(resolveConfigDir(env)).toBe(path.resolve("/tmp/openclaw-home", "state"));
@@ -156,6 +171,7 @@ describe("resolveConfigDir", () => {
     const env = {
       HOME: "/tmp/openclaw-home",
       OPENCLAW_CONFIG_PATH: "~/profiles/dev/openclaw.json",
+      OPENCLAW_PROFILE: "work",
     } as NodeJS.ProcessEnv;
 
     expect(resolveConfigDir(env)).toBe(path.resolve("/tmp/openclaw-home", "profiles", "dev"));
@@ -172,6 +188,10 @@ describe("resolveConfigDir", () => {
         }),
       ).toBe(selectedConfigDir);
       expect(CONFIG_DIR).toBe(selectedConfigDir);
+      const profileHome = path.resolve("/tmp/openclaw-profile-config-home");
+      const profileDir = path.join(profileHome, ".openclaw-work");
+      expect(pinConfigDir({ HOME: profileHome, OPENCLAW_PROFILE: "work" })).toBe(profileDir);
+      expect(CONFIG_DIR).toBe(profileDir);
     } finally {
       pinConfigDir({
         OPENCLAW_STATE_DIR: originalConfigDir,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,12 +2,9 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { normalizeProfileName, resolveProfileStateDir } from "./cli/profile-utils.js";
 import { pathExists as fsSafePathExists } from "./infra/fs-safe.js";
-import {
-  resolveEffectiveHomeDir,
-  resolveRequiredHomeDir,
-  resolveUserPath,
-} from "./infra/home-dir.js";
+import { resolveEffectiveHomeDir, resolveUserPath } from "./infra/home-dir.js";
 import { shortenPathWithHome } from "./infra/home-display.js";
 import { isPlainObject } from "./infra/plain-object.js";
 import { escapeRegExp as escapeRegExpValue } from "./shared/regexp.js";
@@ -73,16 +70,11 @@ export function resolveConfigDir(
   if (configPath) {
     return path.dirname(resolveUserPath(configPath, env, homedir));
   }
-  const newDir = path.join(resolveRequiredHomeDir(env, homedir), ".openclaw");
-  try {
-    const hasNew = fs.existsSync(newDir);
-    if (hasNew) {
-      return newDir;
-    }
-  } catch {
-    // best-effort
-  }
-  return newDir;
+  return resolveProfileStateDir(
+    normalizeProfileName(env.OPENCLAW_PROFILE) ?? "default",
+    env,
+    homedir,
+  );
 }
 
 /** Resolves the effective OpenClaw home directory, if one can be determined. */

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -444,6 +444,46 @@ describe("openclaw launcher", () => {
     },
   );
 
+  it.each([
+    { command: "", profile: "work", expected: "RUNTIME ENTRY\n" },
+    { command: "nodes", profile: "work", expected: "RUNTIME ENTRY\n" },
+    { command: "nodes", profile: "dev", expected: "RUNTIME ENTRY\n" },
+    { command: "nodes", profile: " work ", expected: "RUNTIME ENTRY\n" },
+    { command: "", profile: "default", expected: "PRECOMPUTED help\n" },
+    { command: "nodes", profile: "Default", expected: "PRECOMPUTED help\n" },
+    { command: "models", profile: "work", expected: "PRECOMPUTED help\n" },
+  ])(
+    "selects $command help with ambient profile '$profile'",
+    async ({ command, profile, expected }) => {
+      const fixtureRoot = await makeLauncherFixture(fixtureRoots);
+      await fs.writeFile(
+        path.join(fixtureRoot, "dist", "cli-startup-metadata.json"),
+        JSON.stringify({
+          rootHelpText: "PRECOMPUTED help\n",
+          nodesHelpText: "PRECOMPUTED help\n",
+          subcommandHelpText: { models: "PRECOMPUTED help\n" },
+        }),
+        "utf8",
+      );
+      await fs.writeFile(
+        path.join(fixtureRoot, "dist", "entry.js"),
+        "process.stdout.write('RUNTIME ENTRY\\n');\n",
+        "utf8",
+      );
+      const result = spawnSync(
+        process.execPath,
+        [path.join(fixtureRoot, "openclaw.mjs"), ...(command ? [command] : []), "--help"],
+        {
+          cwd: fixtureRoot,
+          env: launcherEnv({ HOME: fixtureRoot, OPENCLAW_PROFILE: profile }),
+          encoding: "utf8",
+        },
+      );
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe(expected);
+    },
+  );
+
   it("uses precomputed subcommand help with leading root options", async () => {
     const fixtureRoot = await makeLauncherFixture(fixtureRoots);
     await fs.writeFile(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting a named profile with `OPENCLAW_PROFILE` would read the default profile’s config and command help instead. A named profile with no config could also discover the default profile’s file. Managed skill roots had the same selection gap.

## Why This Change Was Made

Shared state/config root resolution now honors the existing environment profile contract, including the roots pinned after Gateway environment selection. Configuration-sensitive launcher help reaches that owner, while ordinary default and static cached help remain fast. The change removes a redundant filesystem branch and simplifies the existing default-directory lookup; production code is net −5 lines.

Explicit custom paths, argv profile parsing, container dispatch, service-ownership validation, and port defaults remain unchanged. This restores state/config/help isolation; it does not make every ambient-profile default identical to argv `--profile` or `--dev`. **User review is required before landing** because profile/config selection is a public contract. The resulting canonical profile selection also lets an otherwise valid named native-service identity remain canonical when its config file is absent, instead of resolving into the default profile. Existing custom-path and conflicting-service guards remain. No new options, environment variables, dependency, schema, or migration are introduced.

## User Impact

Operators can use `OPENCLAW_PROFILE=work` with the profile’s own state, config, and managed skill roots. A missing profile config stays within that profile instead of reading another profile’s authored configuration. Explicit `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` overrides continue to take precedence.

## Evidence

- Fresh Linux package build and npm installation at baseline `3483c892e22ec5c77f2c9464b59f2740860c9f11`: nine environment-only config/help assertions failed; 21 default, argv, custom-path, and canonical-bundle controls passed. Source/build/installed identities were verified and the Testbox was stopped.
- Regression-before evidence: five path/pinning failures, four launcher failures, and four CONFIG_DIR failures. After the repair, 305 focused owner/sibling tests passed with four existing platform/Bun skips. Coverage includes inherited service selectors, ambient-profile container dispatch, workspaces, and personal-skill isolation.
- Structured Codex review found no actionable P0 findings. Independent source/test review found no accepted blocking finding. All canonical changed checks passed (the first run stopped before the compiler on an abandoned build lock; after verifying process cleanup, the unchanged type-check, lint, and import-cycle stages passed). [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33305848701) passed, including `openclaw/ci-gate`; the actual checkout was merge revision `6c5ff8bb8af5cd4b3037fb0d3df7a3139d1ca8ab`, containing reviewed head `8e5f06f9bf8147829a6094d44f02ffb58e8e6af0`. No skipped draft check is counted as a pass.

- Fresh Linux package build/install at reviewed commit `8e5f06f9bf8147829a6094d44f02ffb58e8e6af0`: **32/32 behavior comparisons passed**, including the nine baseline failures, explicit override controls, and missing-profile config isolation. Three malformed-profile controls preserved exit code 1. [Package proof run](https://github.com/openclaw/openclaw/actions/runs/33305776714); source/build commit and source/installed launcher hashes matched, tarball SHA-256 `759872523bc332caac118bfdaf6408ad0b406b770b3057ccbbaa28cdaee25327`. The Testbox was stopped and independently confirmed completed. npm reported install-script approval warnings, so this proof makes no claim that every package lifecycle hook ran.

Suggested release note: Honor environment-selected profile state, config, and managed skill roots while preserving explicit path overrides and cached help.
