### PR TITLE
fix(memory): honor configured primary search result limits

### DIFF
--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -375,6 +375,11 @@ All under `memory.search.query`:
 | `maxResults` | `number` | `6`     | Max memory hits returned before injection |
 | `minScore`   | `number` | `0.35`  | Minimum relevance score to include a hit  |
 
+Without a per-call `maxResults`, primary-only `memory_search` calls use this
+configured limit, including `corpus=memory` and `corpus=sessions`. Wiki and
+combined searches (`corpus=wiki` or `corpus=all`) keep their separate default
+of 10 results. An explicit tool `maxResults` overrides the applicable default.
+
 Hybrid retrieval remains enabled. The builtin engine always applies a fixed
 30-day recency half-life to dated daily notes and a fixed importance
 multiplier after hybrid relevance, then applies MMR diversity ordering with a

--- a/extensions/memory-core/src/memory-tool-contract.ts
+++ b/extensions/memory-core/src/memory-tool-contract.ts
@@ -74,7 +74,9 @@ export function resolveMemoryToolContext(options: MemoryToolOptions) {
     agentId: options.agentId,
   });
   const settings = resolveMemorySearchConfig(cfg, agentId);
-  return settings ? { cfg, agentId, sources: resolveMemorySourceContract(settings) } : null;
+  return settings
+    ? { cfg, agentId, settings, sources: resolveMemorySourceContract(settings) }
+    : null;
 }
 
 const SEARCH_CORPUS_OUTCOME_GUIDANCE =

--- a/extensions/memory-core/src/tools.budget.test.ts
+++ b/extensions/memory-core/src/tools.budget.test.ts
@@ -1,0 +1,111 @@
+import {
+  clearMemoryPluginState,
+  registerMemoryCorpusSupplement,
+} from "openclaw/plugin-sdk/memory-host-core";
+import { beforeEach, expect, it } from "vitest";
+import { resetMemoryToolMockState, setMemorySearchImpl } from "./memory-tool-manager.test-mocks.js";
+import { testing } from "./tools.js";
+import { createMemorySearchToolOrThrow } from "./tools.test-helpers.js";
+
+type Scenario = {
+  name: string;
+  configured: number;
+  corpus?: "memory" | "wiki" | "all";
+  maxResults?: number;
+  memoryCount: number;
+  wikiCount: number;
+};
+
+const scenarios: Scenario[] = [
+  { name: "configured primary limit", configured: 12, memoryCount: 12, wikiCount: 0 },
+  {
+    name: "explicit memory corpus",
+    configured: 12,
+    corpus: "memory",
+    memoryCount: 12,
+    wikiCount: 0,
+  },
+  { name: "default primary limit", configured: 6, memoryCount: 6, wikiCount: 0 },
+  { name: "smaller tool override", configured: 12, maxResults: 4, memoryCount: 4, wikiCount: 0 },
+  { name: "larger tool override", configured: 6, maxResults: 12, memoryCount: 12, wikiCount: 0 },
+  { name: "wiki default", configured: 12, corpus: "wiki", memoryCount: 0, wikiCount: 10 },
+  {
+    name: "wiki tool override",
+    configured: 12,
+    corpus: "wiki",
+    maxResults: 3,
+    memoryCount: 0,
+    wikiCount: 3,
+  },
+  {
+    name: "balanced aggregate default",
+    configured: 12,
+    corpus: "all",
+    memoryCount: 5,
+    wikiCount: 5,
+  },
+  {
+    name: "aggregate backfills spare memory slots",
+    configured: 3,
+    corpus: "all",
+    memoryCount: 3,
+    wikiCount: 7,
+  },
+  {
+    name: "aggregate tool override",
+    configured: 6,
+    corpus: "all",
+    maxResults: 12,
+    memoryCount: 6,
+    wikiCount: 6,
+  },
+];
+
+beforeEach(() => {
+  clearMemoryPluginState();
+  testing.resetMemorySearchToolCooldowns();
+  resetMemoryToolMockState();
+});
+
+it.each(scenarios)("preserves the model-visible $name", async (scenario) => {
+  const memory = Array.from({ length: 20 }, (_, index) => ({
+    path: `memory/note-${index + 1}.md`,
+    startLine: 1,
+    endLine: 1,
+    score: 1 - index / 100,
+    snippet: `Memory ${index + 1}: café 🦞 日本語`,
+    source: "memory" as const,
+  }));
+  const wiki = Array.from({ length: 20 }, (_, index) => ({
+    corpus: "wiki",
+    path: `entities/note-${index + 1}.md`,
+    score: 50 - index,
+    snippet: `Wiki ${index + 1}: café 🦞 日本語`,
+  }));
+  setMemorySearchImpl(async (options) => memory.slice(0, options?.maxResults));
+  registerMemoryCorpusSupplement("memory-wiki", {
+    search: async ({ maxResults }) => wiki.slice(0, maxResults ?? 10),
+    get: async () => null,
+  });
+  const tool = createMemorySearchToolOrThrow({
+    config: {
+      memory: { citations: "off", search: { query: { maxResults: scenario.configured } } },
+      plugins: { entries: { "memory-core": { config: { dreaming: { enabled: false } } } } },
+    },
+  });
+
+  const result = await tool.execute("budget", {
+    query: "note",
+    ...(scenario.corpus ? { corpus: scenario.corpus } : {}),
+    ...(scenario.maxResults ? { maxResults: scenario.maxResults } : {}),
+  });
+  const text = result.content.find((part) => part.type === "text")?.text;
+  if (!text) {
+    throw new Error("memory_search returned no model-visible text");
+  }
+  const payload = JSON.parse(text) as { results: Array<{ path: string; snippet: string }> };
+  const expected = [...wiki.slice(0, scenario.wikiCount), ...memory.slice(0, scenario.memoryCount)];
+  expect(payload.results.map(({ path, snippet }) => ({ path, snippet }))).toEqual(
+    expected.map(({ path, snippet }) => ({ path, snippet })),
+  );
+});

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -62,7 +62,9 @@ export async function getMemoryManagerContextWithPurpose(params: {
 export function createMemoryTool(params: {
   options: MemoryToolOptions;
   contract: MemoryToolContract;
-  execute: (ctx: { cfg: OpenClawConfig; agentId: string }) => AnyAgentTool["execute"];
+  execute: (
+    ctx: NonNullable<ReturnType<typeof resolveMemoryToolContext>>,
+  ) => AnyAgentTool["execute"];
 }): AnyAgentTool | null {
   const ctx = resolveMemoryToolContext(params.options);
   if (!ctx) {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -11,7 +11,6 @@ import {
   readPositiveIntegerParam,
   readStringParam,
   resolveMemoryDreamingPluginConfig,
-  resolveMemorySearchConfig,
   type MemoryCorpusSearchResult,
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
@@ -66,7 +65,6 @@ type MemorySearchToolQueryDebug = NonNullable<
 >;
 type PrimaryMemorySearchValue = {
   results: Array<MemorySearchResult & { corpus: MemorySource }>;
-  rawResults: MemorySearchResult[];
   provider?: string;
   model?: string;
   fallback?: unknown;
@@ -200,8 +198,7 @@ function mergeMemorySearchCorpusResults(params: {
   maxResults: number;
   balanceCorpora: boolean;
 }): MemorySearchToolResult[] {
-  const memoryResults = params.memoryResults;
-  const supplementResults = params.supplementResults;
+  const { memoryResults, supplementResults } = params;
   if (!params.balanceCorpora || memoryResults.length === 0 || supplementResults.length === 0) {
     return mergeRankedMemorySearchToolStreams(memoryResults, supplementResults).slice(
       0,
@@ -278,7 +275,7 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
     options,
     contract: MEMORY_SEARCH_TOOL_CONTRACT,
     execute:
-      ({ cfg, agentId }) =>
+      ({ cfg, agentId, settings }) =>
       async (_toolCallId, params, callerSignal) => {
         const rawParams = asToolParamsRecord(params);
         if (callerSignal?.aborted) {
@@ -299,7 +296,7 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
         if (
           requestedCorpus === "sessions" &&
           !options.conversationRecall &&
-          !resolveMemorySearchConfig(cfg, agentId)?.searchSources.includes("sessions")
+          !settings.searchSources.includes("sessions")
         ) {
           return jsonResult(
             buildMemorySearchUnavailableResult("Session transcript search is not enabled.", {
@@ -355,11 +352,9 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
               if ("error" in memory) {
                 throw new Error(memory.error ?? "memory search unavailable");
               }
-              const settings = resolveMemorySearchConfig(cfg, agentId);
-              const defaultSources = settings?.searchSources;
               const explicitSources: MemorySource[] | undefined =
                 requestedCorpus === "sessions" &&
-                (options.conversationRecall || defaultSources?.includes("sessions"))
+                (options.conversationRecall || settings.searchSources.includes("sessions"))
                   ? ["sessions"]
                   : requestedCorpus === "memory"
                     ? ["memory"]
@@ -381,11 +376,11 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
                 },
                 query: {
                   text: query,
-                  resultLimit: maxResults ?? settings?.query.maxResults ?? 10,
+                  resultLimit: maxResults ?? settings.query.maxResults,
                   minScore,
                   explicitSources,
-                  defaultSources,
-                  indexedSources: settings?.sources,
+                  defaultSources: settings.searchSources,
+                  indexedSources: settings.sources,
                   requestedCorpus,
                   sessionKey: options.agentSessionKey,
                   activeProjectKeys: options.activeProjectKeys,
@@ -418,7 +413,6 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
               "memory",
               {
                 results: [],
-                rawResults: [],
                 unavailableResult: buildPausedMemoryIndexUnavailableResult(reason),
               },
               reason,
@@ -462,7 +456,6 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
               results: memoryResults.map((result) =>
                 Object.assign(result, { corpus: result.source }),
               ),
-              rawResults,
               provider: status.provider,
               model: status.model,
               fallback: status.fallback,
@@ -502,12 +495,15 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
                 );
               }
               const wikiResults = wiki?.outcome === "not-registered" ? [] : (wiki?.value ?? []);
-              const results = mergeMemorySearchCorpusResults({
-                memoryResults: memoryValue?.results ?? [],
-                supplementResults: wikiResults,
-                maxResults: Math.max(1, maxResults ?? 10),
-                balanceCorpora: requestedCorpus === "all",
-              });
+              // Primary results already own their configured limit; only wiki/all need aggregation.
+              const results = searchesWiki
+                ? mergeMemorySearchCorpusResults({
+                    memoryResults: memoryValue?.results ?? [],
+                    supplementResults: wikiResults,
+                    maxResults: maxResults ?? 10,
+                    balanceCorpora: requestedCorpus === "all",
+                  })
+                : (memoryValue?.results ?? []);
               const attempts = [
                 ...(requestedCorpus === "all" && memory ? [memory] : []),
                 ...(wiki ? [wiki] : []),


### PR DESCRIPTION
Closes #133253

## What Problem This Solves

Fixes an issue where operators who raised `memory.search.query.maxResults` above ten still received only ten primary-memory search hits when the model omitted a per-call limit. For example, a configured limit of 12 produced 12 eligible hits but serialized only ten to the model, with no truncation warning.

## Why This Change Was Made

Primary search already owns ranking, visibility filtering, and the configured result window. Return those results directly instead of passing them through the wiki aggregation cap. Reuse settings from the current tool context and remove unused raw-result copies; live configuration refresh and revocation remain unchanged.

Wiki and combined searches keep their independent ten-result default, explicit overrides, balancing, and backfill. This does not change configuration schemas, index/storage behavior, provider calls, or recall persistence. Production LOC: **+22/-22 (net 0)**; regression tests: **+111**.

## User Impact

Primary `memory_search` calls now honor the configured result limit without requiring the model to repeat it. Existing defaults and explicit limits remain intact. The configuration reference now explains the separate primary and aggregate budgets.

## Evidence

- The actual tool JSON regression table failed two configured-12 cases before the fix, while eight default/explicit/wiki/all controls passed. The same ten cases all pass after the fix, including Unicode snippets, combined-result balancing, and spare-slot backfill.
- All 42 existing search-tool tests pass, including live configuration changes and session-corpus filtering. The existing retained-tool configuration-disable control also passes.
- Proof uses the existing synthetic manager seam and the real tool execution, visibility/projection, aggregation, and JSON serialization path. No live provider, database, or index is involved; source hashes remained unchanged during each run.
- Validation commands: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/memory-core/src/tools.budget.test.ts`; the same wrapper for `extensions/memory-core/src/tools.test.ts`, and `extensions/memory-core/src/tools.citations.test.ts -t "revokes retained memory tools"`.
- The canonical five-file `node scripts/check-changed.mjs -- <changed files>` gate passed: production/test type checks, scoped lint with zero warnings/errors, formatting, shared plugin-contract tests, and repository guards. Fresh Codex autoreview found no actionable P0 issue; an independent source/artifact review found no actionable finding.
- Stable `v2026.7.1` source contains the same unconditional aggregate cap. The owner history distinguishes the primary window from the intentional wiki/all aggregation behavior.

Known follow-up, unchanged here: combined searches queue primary recall tracking before final corpus selection, so tracked hits may exceed surfaced hits. This is a source-level observation, not a verified persistence defect; changing that behavior requires separate review.

Maintainer review follow-through: [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33305832554) is green for `d0f764cfcd22ab704e64e397763b8986c194d878`. The current-main/release inspection gap in the ClawSweeper review is resolved by direct source inspection: `extensions/memory-core`, the primary configuration owner, and this documentation page are unchanged between the reproduction base and current main `d498334714d255a992232f8175be1065fde11627`. [Stable v2026.7.1 source](https://github.com/openclaw/openclaw/blob/v2026.7.1/extensions/memory-core/src/tools.ts#L687) also applies the unconditional ten-result aggregation cap; this is source evidence, not a live test of that release.

The automated stored-data classification is not a material data-model change: this diff changes only transient tool context and result projection. It does not change embedding metadata, schemas, indexes, stored records, or recall-write arguments. The removed `rawResults` fields were unused copies in the transient aggregation value; the actual raw results supplied to recall tracking remain intact. No migration or new persistence behavior is introduced.
