### PR TITLE
test(plugins): reuse loader metadata fixtures

### DIFF
--- a/src/plugins/loader.cli-metadata.test.ts
+++ b/src/plugins/loader.cli-metadata.test.ts
@@ -16,6 +16,7 @@ import {
   resetPluginLoaderTestStateForTest,
   useNoBundledPlugins,
   writePlugin,
+  writePluginMetadata,
 } from "./loader.test-fixtures.js";
 
 afterEach(() => {
@@ -286,31 +287,16 @@ module.exports = { id: "packaged-cli-metadata", register() {} };`,
     const modeMarker = path.join(pluginDir, "registration-mode.txt");
     const runtimeMarker = path.join(pluginDir, "runtime-set.txt");
 
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify(
-        {
-          name: "@openclaw/cli-metadata-channel",
-          openclaw: { extensions: ["./index.cjs"], setupEntry: "./setup-entry.cjs" },
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "cli-metadata-channel",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-          channels: ["cli-metadata-channel"],
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
+    writePluginMetadata({
+      dir: pluginDir,
+      id: "cli-metadata-channel",
+      configSchema: EMPTY_PLUGIN_SCHEMA,
+      channels: ["cli-metadata-channel"],
+      packageJson: {
+        name: "@openclaw/cli-metadata-channel",
+        openclaw: { extensions: ["./index.cjs"], setupEntry: "./setup-entry.cjs" },
+      },
+    });
     fs.writeFileSync(
       path.join(pluginDir, "index.cjs"),
       `${inlineChannelPluginEntryFactorySource()}
@@ -393,31 +379,16 @@ module.exports = {
     fs.mkdirSync(pluginDir, { recursive: true });
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledRoot;
 
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify(
-        {
-          name: "@openclaw/bundled-skip-channel",
-          openclaw: { extensions: ["./index.cjs"] },
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "bundled-skip-channel",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-          channels: ["bundled-skip-channel"],
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
+    writePluginMetadata({
+      dir: pluginDir,
+      id: "bundled-skip-channel",
+      configSchema: EMPTY_PLUGIN_SCHEMA,
+      channels: ["bundled-skip-channel"],
+      packageJson: {
+        name: "@openclaw/bundled-skip-channel",
+        openclaw: { extensions: ["./index.cjs"] },
+      },
+    });
     fs.writeFileSync(
       path.join(pluginDir, "index.cjs"),
       `require("node:fs").writeFileSync(${JSON.stringify(fullMarker)}, "loaded", "utf-8");
@@ -461,31 +432,16 @@ module.exports = {
     fs.mkdirSync(pluginDir, { recursive: true });
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledRoot;
 
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify(
-        {
-          name: "@openclaw/bundled-cli-channel",
-          openclaw: { extensions: ["./index.cjs"] },
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "bundled-cli-channel",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-          channels: ["bundled-cli-channel"],
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
+    writePluginMetadata({
+      dir: pluginDir,
+      id: "bundled-cli-channel",
+      configSchema: EMPTY_PLUGIN_SCHEMA,
+      channels: ["bundled-cli-channel"],
+      packageJson: {
+        name: "@openclaw/bundled-cli-channel",
+        openclaw: { extensions: ["./index.cjs"] },
+      },
+    });
     fs.writeFileSync(
       path.join(pluginDir, "index.cjs"),
       `require("node:fs").writeFileSync(${JSON.stringify(fullMarker)}, "loaded", "utf-8");
@@ -552,30 +508,15 @@ module.exports = {
     fs.mkdirSync(pluginDir, { recursive: true });
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledRoot;
 
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify(
-        {
-          name: "@openclaw/bundled-skip-provider",
-          openclaw: { extensions: ["./index.cjs"] },
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "bundled-skip-provider",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
+    writePluginMetadata({
+      dir: pluginDir,
+      id: "bundled-skip-provider",
+      configSchema: EMPTY_PLUGIN_SCHEMA,
+      packageJson: {
+        name: "@openclaw/bundled-skip-provider",
+        openclaw: { extensions: ["./index.cjs"] },
+      },
+    });
     fs.writeFileSync(
       path.join(pluginDir, "index.cjs"),
       `require("node:fs").writeFileSync(${JSON.stringify(fullMarker)}, "loaded", "utf-8");
@@ -616,31 +557,16 @@ module.exports = {
     const modeMarker = path.join(pluginDir, "registration-mode.txt");
     const fullMarker = path.join(pluginDir, "full-loaded.txt");
 
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify(
-        {
-          name: "@openclaw/full-cli-metadata-channel",
-          openclaw: { extensions: ["./index.cjs"] },
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "full-cli-metadata-channel",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-          channels: ["full-cli-metadata-channel"],
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
+    writePluginMetadata({
+      dir: pluginDir,
+      id: "full-cli-metadata-channel",
+      configSchema: EMPTY_PLUGIN_SCHEMA,
+      channels: ["full-cli-metadata-channel"],
+      packageJson: {
+        name: "@openclaw/full-cli-metadata-channel",
+        openclaw: { extensions: ["./index.cjs"] },
+      },
+    });
     fs.writeFileSync(
       path.join(pluginDir, "index.cjs"),
       `${inlineChannelPluginEntryFactorySource()}
@@ -713,31 +639,16 @@ module.exports = {
     const fullMarker = path.join(pluginDir, "full-loaded.txt");
     const runtimeMarker = path.join(pluginDir, "runtime-set.txt");
 
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify(
-        {
-          name: "@openclaw/discovery-cli-metadata-channel",
-          openclaw: { extensions: ["./index.cjs"] },
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "discovery-cli-metadata-channel",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-          channels: ["discovery-cli-metadata-channel"],
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
+    writePluginMetadata({
+      dir: pluginDir,
+      id: "discovery-cli-metadata-channel",
+      configSchema: EMPTY_PLUGIN_SCHEMA,
+      channels: ["discovery-cli-metadata-channel"],
+      packageJson: {
+        name: "@openclaw/discovery-cli-metadata-channel",
+        openclaw: { extensions: ["./index.cjs"] },
+      },
+    });
     fs.writeFileSync(
       path.join(pluginDir, "index.cjs"),
       `${inlineChannelPluginEntryFactorySource()}
@@ -819,31 +730,16 @@ module.exports = {
     const modeMarker = path.join(pluginDir, "registration-mode.txt");
     const setupMarker = path.join(pluginDir, "setup-loaded.txt");
 
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify(
-        {
-          name: "@openclaw/force-runtime-cli-channel",
-          openclaw: { extensions: ["./index.cjs"], setupEntry: "./setup-entry.cjs" },
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "force-runtime-cli-channel",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-          channels: ["force-runtime-cli-channel"],
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
+    writePluginMetadata({
+      dir: pluginDir,
+      id: "force-runtime-cli-channel",
+      configSchema: EMPTY_PLUGIN_SCHEMA,
+      channels: ["force-runtime-cli-channel"],
+      packageJson: {
+        name: "@openclaw/force-runtime-cli-channel",
+        openclaw: { extensions: ["./index.cjs"], setupEntry: "./setup-entry.cjs" },
+      },
+    });
     fs.writeFileSync(
       path.join(pluginDir, "index.cjs"),
       `${inlineChannelPluginEntryFactorySource()}

--- a/src/plugins/loader.test-fixtures.ts
+++ b/src/plugins/loader.test-fixtures.ts
@@ -80,6 +80,35 @@ export function makePluginLoaderTempDir() {
   return dir;
 }
 
+export function writePluginMetadata(params: {
+  dir: string;
+  id: string;
+  configSchema?: Record<string, unknown>;
+  channels?: string[];
+  packageJson?: Record<string, unknown>;
+}): void {
+  if (params.packageJson) {
+    fs.writeFileSync(
+      path.join(params.dir, "package.json"),
+      JSON.stringify(params.packageJson, null, 2),
+      "utf-8",
+    );
+  }
+  fs.writeFileSync(
+    path.join(params.dir, "openclaw.plugin.json"),
+    JSON.stringify(
+      {
+        id: params.id,
+        configSchema: params.configSchema ?? EMPTY_PLUGIN_SCHEMA,
+        ...(params.channels ? { channels: params.channels } : {}),
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+}
+
 export function writePlugin(params: {
   id: string;
   body: string;
@@ -92,18 +121,7 @@ export function writePlugin(params: {
   mkdirSafe(dir);
   const file = path.join(dir, filename);
   fs.writeFileSync(file, params.body, "utf-8");
-  fs.writeFileSync(
-    path.join(dir, "openclaw.plugin.json"),
-    JSON.stringify(
-      {
-        id: params.id,
-        configSchema: params.configSchema ?? EMPTY_PLUGIN_SCHEMA,
-      },
-      null,
-      2,
-    ),
-    "utf-8",
-  );
+  writePluginMetadata({ dir, id: params.id, configSchema: params.configSchema });
   return { dir, file, id: params.id };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Seven CLI metadata fixtures duplicate package and plugin-manifest writing, making their actual registration differences harder to see. This is maintainer-requested test cleanup, not a runtime bug fix.

## Why This Change Was Made

Extract the manifest emitter already inside `writePlugin` into `writePluginMetadata` in the same test-support module, then reuse it from the seven CLI fixtures. Their serialized fields and values, key order, two-space indentation, UTF-8 encoding, optional `setupEntry`, and omitted `channels` in the non-channel case are preserved; package metadata is still written before the plugin manifest.

The existing `writePlugin` contract is unchanged: filename/schema defaults, directory creation and permissions, module-before-manifest write order, and return shape all remain intact. It still does not write `package.json`. Generated module bodies, test cases, assertions, registration-mode distinctions, and fixture cleanup remain unchanged.

## User Impact

No user-visible or production behavior change. Two test/test-support files remove 86 net lines: Myers +99/−185 (histogram +100/−186); production +0/−0. The JSON files are temporary test inputs, not persisted application state; this change adds no schema, migration, configuration, or storage behavior.

## Evidence

Proof is bound to signed commit `ad898bdc068907d2d5dae7178dff92d3685ace05`, parent `30f26e5c7e0f6ddfa668f9630e94f305534479f4`.

- Baseline and candidate each passed the same 64 cases, with identical case identities and within-suite order, no skips or retries: CLI metadata 20, runtime registry 27, node-host commands 1, metadata lifetime 16.
- The complete canonical changed-file gate passed all 29 stages for the exact two-file scope.
- Normal Codex precommit review and separate exact-commit review both completed scoped-clean with no findings at the selected P0 threshold. These were static reviews; they did not independently rerun the test or gate evidence.
- Postcommit source checks and the committed review's before/after checks preserved the reviewed source, clean index, dependency and generated-output inventories.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33305970463) completed successfully. Its sole watcher finished normally.

Static composition against main `8c74ad9dd7654d0cb548d615550c2533bfb550e7` preserves both original file preimages and produces exactly that main tree plus the two reviewed afterimages. Subsequent native review fetched `ba1be2f427aeb8731a1026d02b84af865b7712e2`; both fixture preimages, the 13 inspected context files, and 51 fixture callers remain unchanged. Current-main runtime-registry tests have additional config-snapshot coverage; the local 64-case result above belongs to the signed source commit, not a rerun of that later revision.

The [completed ClawSweeper review and Rank-up moves](https://github.com/openclaw/openclaw/pull/133256#issuecomment-5468111922) were read. No actionable correctness or security finding remains. The latest-review availability check is satisfied by reading the actual completed comment, and exact-head CI is now green. Its generic serialized-state caution does not describe a runtime migration here: the changed owner writes only test fixtures.

Native hosted preparation and ordinary merge both passed without rebasing or pushing a different head. [Merged as efe07d162641](https://github.com/openclaw/openclaw/commit/efe07d162641c30ab7584b58288d880593707d4c). An independent actual-parent audit verified the complete landed tree, both reviewed afterimages and unchanged preimages, byte-identical patch, exact Myers +99/−185, and ancestry in main. Native mainline-infrastructure drift was reported as advisory; the affected fixture owners, inspected callers and landing-tool closure were unchanged. No live-provider, composed-runtime or release proof is claimed.
