### PR TITLE
fix(cli): complete remote onboarding after Gateway restarts

### DIFF
--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -198,6 +198,20 @@ state:
   onboarding or OpenClaw. On a configured install, reach OpenClaw with
   `/openclaw` inside the TUI or `openclaw setup`.
 
+Remote setup reuses device pairing for the selected Gateway, including a
+configured remote connection forwarded through loopback. Its readiness probes
+do not create new device pairings. Setup chat keeps a stable authenticated
+caller across replies, including on loopback connections.
+
+When interactive remote setup activates inference and the Gateway requires a
+restart, onboarding waits up to 45 seconds for a new Gateway boot and a successful
+inference check before opening setup chat. A healthy connection to the old
+Gateway does not count. If the restart wait expires or boot identity is missing,
+onboarding reports that the settings were saved and stops rather than trying
+another provider. Check the remote Gateway, then rerun bare `openclaw` in the
+connected terminal. If the error says the Gateway did not provide a boot identity,
+update and restart that Gateway first.
+
 Plaintext `ws://` is accepted for loopback, private IP literals, `.local`, and Tailnet `*.ts.net` gateway URLs. For other trusted private-DNS names, set `OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1` in the onboarding process environment.
 
 ## Reset

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -143,12 +143,9 @@ const runTuiCliActionMock = vi.hoisted(() =>
   vi.fn<(target: string | undefined, opts: unknown) => Promise<void>>(async () => {}),
 );
 const probeGatewayConfiguredModelMock = vi.hoisted(() =>
-  vi.fn<
-    () => Promise<{
-      kind: "configured" | "missing-configured-model" | "reachable-unverified" | "unreachable";
-      detail?: string;
-    }>
-  >(async () => ({ kind: "configured" })),
+  vi.fn<typeof import("../commands/onboard-helpers.js").probeGatewayConfiguredModel>(async () => ({
+    kind: "configured",
+  })),
 );
 const readActiveGatewayLockPortMock = vi.hoisted(() =>
   vi.fn(async (): Promise<number | undefined> => undefined),
@@ -3929,40 +3926,47 @@ describe("runCli exit behavior", () => {
     });
   });
 
-  it("configures missing inference on the selected remote Gateway", async () => {
-    const sourceConfig = {
-      agents: { defaults: { model: { primary: "openai/local-only-model" } } },
-      gateway: {
-        mode: "remote",
-        remote: {
-          url: "wss://gateway.example/ws",
-          token: "missing-inference-remote-auth",
-          tlsFingerprint: `sha256:${TLS_FINGERPRINT.toUpperCase()}`,
+  it.each(["wss://gateway.example/ws", "ws://127.0.0.1:18789"])(
+    "configures missing inference on the selected remote Gateway: %s",
+    async (url) => {
+      const sourceConfig = {
+        agents: { defaults: { model: { primary: "openai/local-only-model" } } },
+        gateway: {
+          mode: "remote",
+          remote: {
+            url,
+            token: "missing-inference-remote-auth",
+            tlsFingerprint: `sha256:${TLS_FINGERPRINT.toUpperCase()}`,
+          },
         },
-      },
-    };
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig,
-    });
-    probeGatewayConfiguredModelMock.mockResolvedValueOnce({
-      kind: "missing-configured-model",
-      detail: "Gateway default agent has no configured model",
-    });
+      };
+      readConfigFileSnapshotMock.mockResolvedValueOnce({
+        exists: true,
+        valid: true,
+        sourceConfig,
+      });
+      probeGatewayConfiguredModelMock.mockImplementationOnce(async (options) =>
+        options.url === "ws://127.0.0.1:18789" && !options.originScopedDeviceAuth
+          ? { kind: "reachable-unverified", detail: "missing scope: operator.read" }
+          : {
+              kind: "missing-configured-model",
+              detail: "Gateway default agent has no configured model",
+            },
+      );
 
-    await runBareCli();
+      await runBareCli();
 
-    expect(setupWizardCommandMock).not.toHaveBeenCalled();
-    expect(readLocalOnboardingStateMock).not.toHaveBeenCalled();
-    expect(runRemoteGatewayInferenceOnboardingMock).toHaveBeenCalledWith({
-      config: sourceConfig,
-      gatewayUrl: "wss://gateway.example/ws",
-      token: "missing-inference-remote-auth",
-      tlsFingerprint: TLS_FINGERPRINT,
-    });
-    expect(runTuiMock).not.toHaveBeenCalled();
-  });
+      expect(setupWizardCommandMock).not.toHaveBeenCalled();
+      expect(readLocalOnboardingStateMock).not.toHaveBeenCalled();
+      expect(runRemoteGatewayInferenceOnboardingMock).toHaveBeenCalledWith({
+        config: sourceConfig,
+        gatewayUrl: url,
+        token: "missing-inference-remote-auth",
+        tlsFingerprint: TLS_FINGERPRINT,
+      });
+      expect(runTuiMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("keeps missing inference setup local for a local Gateway", async () => {
     primeBareRootConfig({
@@ -4420,6 +4424,7 @@ describe("runCli exit behavior", () => {
 
     expect(probeGatewayConfiguredModelMock).toHaveBeenCalledWith({
       url,
+      originScopedDeviceAuth: true,
       token: "loopback-remote-auth",
     });
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
@@ -4444,6 +4449,7 @@ describe("runCli exit behavior", () => {
 
     expect(probeGatewayConfiguredModelMock).toHaveBeenCalledWith({
       url,
+      originScopedDeviceAuth: true,
       config,
       token: "test-token",
     });
@@ -4468,6 +4474,7 @@ describe("runCli exit behavior", () => {
 
     expect(probeGatewayConfiguredModelMock).toHaveBeenCalledWith({
       url,
+      originScopedDeviceAuth: true,
       password: "configured-remote-password",
     });
     expectBoundTui({ url, password: "configured-remote-password" });
@@ -4506,7 +4513,10 @@ describe("runCli exit behavior", () => {
       },
     );
 
-    expect(probeGatewayConfiguredModelMock).toHaveBeenCalledWith({ url });
+    expect(probeGatewayConfiguredModelMock).toHaveBeenCalledWith({
+      url,
+      originScopedDeviceAuth: true,
+    });
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
     expectBoundTui({ url });
   });
@@ -4529,6 +4539,7 @@ describe("runCli exit behavior", () => {
 
     expect(probeGatewayConfiguredModelMock).toHaveBeenCalledWith({
       url,
+      originScopedDeviceAuth: true,
       token: "private-remote-auth",
     });
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
@@ -4551,6 +4562,7 @@ describe("runCli exit behavior", () => {
 
     expect(probeGatewayConfiguredModelMock).toHaveBeenCalledWith({
       url: "wss://gateway.example.com:18789",
+      originScopedDeviceAuth: true,
       token: "tls-remote-auth",
       tlsFingerprint: TLS_FINGERPRINT,
     });

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -510,14 +510,11 @@ async function resolveReachableGateway(
     if (options.hasConfiguredGateway && !configuredGateway) {
       configuredGateway = toReachableGateway(target, auth);
     }
-    const probeOptions: {
-      url: string;
-      config?: OpenClawConfig;
-      token?: string;
-      password?: string;
-      tlsFingerprint?: string;
-      preauthHandshakeTimeoutMs?: number;
-    } = { url: target.url };
+    const probeOptions: Parameters<typeof probeGatewayConfiguredModel>[0] = {
+      url: target.url,
+      // A configured remote origin stays remote through a loopback tunnel.
+      ...(target.scope === "remote" ? { originScopedDeviceAuth: true } : {}),
+    };
     if (config.gateway?.remote?.edgeAuth) {
       probeOptions.config = config;
     }

--- a/src/commands/configure.wizard.gateway.test.ts
+++ b/src/commands/configure.wizard.gateway.test.ts
@@ -245,7 +245,11 @@ describe("runConfigureWizard", () => {
     await runConfigureWizard({ command: "configure", sections: ["health"] }, createRuntime());
 
     expect(mocks.waitForGatewayReachable).toHaveBeenCalledWith(
-      expect.objectContaining({ url: remoteConfig.gateway?.remote?.url, config: remoteConfig }),
+      expect.objectContaining({
+        url: remoteConfig.gateway?.remote?.url,
+        config: remoteConfig,
+        originScopedDeviceAuth: true,
+      }),
     );
     expect(mocks.healthCommand).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -374,6 +378,7 @@ describe("runConfigureWizard", () => {
       expect(localProbe?.timeoutMs).toBe(300);
       expect(remoteProbe).toEqual({
         url: "wss://gateway.example.test",
+        originScopedDeviceAuth: true,
         config: expect.objectContaining({
           gateway: expect.objectContaining({
             remote: expect.objectContaining({

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -161,7 +161,7 @@ async function runGatewayHealthCheck(params: {
   try {
     const gatewayProbe = await waitForGatewayReachable({
       url: wsUrl,
-      ...(probeMode === "remote" ? { config: params.cfg } : {}),
+      ...(probeMode === "remote" ? { config: params.cfg, originScopedDeviceAuth: true } : {}),
       token,
       password,
       ...(params.daemonSetupOutcome === "succeeded"
@@ -520,6 +520,7 @@ export async function runConfigureWizard(
             return probeGatewayReachable({
               url: remoteUrl,
               config: baseConfig,
+              originScopedDeviceAuth: true,
               token: remoteProbeAuth.auth.token,
               ...(remoteProbeAuth.auth.password ? { password: remoteProbeAuth.auth.password } : {}),
               timeoutMs: GATEWAY_HINT_PROBE_TIMEOUT_MS,

--- a/src/commands/onboard-helpers.remote-probe.test.ts
+++ b/src/commands/onboard-helpers.remote-probe.test.ts
@@ -64,11 +64,15 @@ describe("probeGatewayReachable", () => {
       },
     };
 
-    await expect(probe({ url: "wss://gateway.example", config })).resolves.toEqual({
-      ok: true,
-    });
+    await expect(
+      probe({ url: "wss://gateway.example", config, originScopedDeviceAuth: true }),
+    ).resolves.toEqual({ ok: true });
     expect(mocks.probeGateway).toHaveBeenCalledWith(
-      expect.objectContaining({ url: "wss://gateway.example", config }),
+      expect.objectContaining({
+        url: "wss://gateway.example",
+        config,
+        originScopedDeviceAuth: true,
+      }),
     );
   });
 
@@ -177,13 +181,14 @@ describe("probeGatewayReachable", () => {
     await expect(
       probeGatewayConfiguredModel({
         url: "ws://127.0.0.1:18789",
+        originScopedDeviceAuth: true,
       }),
     ).resolves.toEqual({
       kind: "missing-configured-model",
       detail: "Gateway default agent has no configured model",
     });
-    expect(mocks.probeGateway).toHaveBeenCalledWith(
-      expect.objectContaining({ detailLevel: "config" }),
+    expect(mocks.probeGateway).toHaveBeenLastCalledWith(
+      expect.objectContaining({ detailLevel: "config", originScopedDeviceAuth: true }),
     );
   });
 

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -308,6 +308,7 @@ function throwIfResetFailed(failures: string[]): void {
 type OnboardingGatewayProbeParams = {
   url: string;
   config?: OpenClawConfig;
+  originScopedDeviceAuth?: boolean;
   token?: string;
   password?: string;
   tlsFingerprint?: string;
@@ -324,6 +325,7 @@ function runOnboardingGatewayProbe(
   return probeGateway({
     url,
     ...(params.config ? { config: params.config } : {}),
+    ...(params.originScopedDeviceAuth ? { originScopedDeviceAuth: true } : {}),
     timeoutMs,
     auth: {
       token: params.token,

--- a/src/commands/onboard-remote-gateway.test.ts
+++ b/src/commands/onboard-remote-gateway.test.ts
@@ -1,11 +1,22 @@
 import { describe, expect, it, vi } from "vitest";
+import type { HelloOk } from "../../packages/gateway-protocol/src/schema/frames.js";
 import { createWizardPrompter } from "../../test/helpers/wizard-prompter.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { CallGatewayCliOptions } from "../gateway/call.js";
+import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { WizardCancelledError } from "../wizard/prompts.js";
 import type { GuidedOnboardingDeps } from "./onboard-guided.js";
 import { runRemoteGatewayInferenceOnboarding } from "./onboard-remote-gateway.js";
+
+vi.mock("../infra/device-identity.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/device-identity.js")>()),
+  loadOrCreateDeviceIdentity: vi.fn(() => ({
+    deviceId: "remote-onboarding-device",
+    publicKeyPem: "test-public-key",
+    privateKeyPem: "test-private-key",
+  })),
+}));
 
 type RemoteGatewayInferenceTarget = Parameters<typeof runRemoteGatewayInferenceOnboarding>[0];
 type RemoteGatewayInferenceOnboardingDeps = NonNullable<
@@ -122,6 +133,18 @@ function exerciseGuidedAdapters(): RunGuidedOnboarding {
     }
   };
   return vi.fn(run);
+}
+
+function gatewayHello(bootId?: string): HelloOk {
+  return {
+    type: "hello-ok",
+    protocol: 1,
+    server: { version: "test", connId: "test-connection", ...(bootId ? { bootId } : {}) },
+    features: { methods: [], events: [] },
+    snapshot: { presence: [], health: {}, stateVersion: { presence: 0, health: 0 }, uptimeMs: 0 },
+    auth: { role: "operator", scopes: [] },
+    policy: { maxPayload: 1, maxBufferedBytes: 1, tickIntervalMs: 1 },
+  };
 }
 
 function asGatewayCall(mock: ReturnType<typeof vi.fn>): GatewayCall {
@@ -260,6 +283,10 @@ describe("runRemoteGatewayInferenceOnboarding", () => {
     const methods: string[] = [];
     let verifyAttempts = 0;
     const callGatewayMock = vi.fn(async (options: CallGatewayCliOptions): Promise<unknown> => {
+      options.onHelloOk?.(
+        gatewayHello(options.method === "openclaw.setup.verify" ? "new-boot" : "old-boot"),
+      );
+      options.signal?.throwIfAborted();
       methods.push(options.method);
       if (options.method === "openclaw.setup.detect") {
         return detectResult();
@@ -313,9 +340,91 @@ describe("runRemoteGatewayInferenceOnboarding", () => {
     ]);
   });
 
+  it.for([
+    "replacement",
+    "missing activation identity",
+    "missing verification identity",
+    "restart timeout",
+  ])("gates inference and chat on replacement boot: %s", async (mode, ctx) => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(0);
+    ctx.onTestFinished(() => now.mockRestore());
+    const sent: string[] = [];
+    const verifiedBoots: string[] = [];
+    let verificationConnections = 0;
+    let bootId: string | undefined = "old-boot";
+    const callGatewayMock = vi.fn(async (options: CallGatewayCliOptions): Promise<unknown> => {
+      if (options.method === "openclaw.setup.activate" && mode === "missing activation identity") {
+        bootId = undefined;
+      }
+      if (options.method === "openclaw.setup.verify") {
+        if (mode === "restart timeout") {
+          now.mockReturnValue(45_000);
+        } else if (verificationConnections++ > 0) {
+          bootId = mode === "missing verification identity" ? undefined : "new-boot";
+        }
+      }
+      options.onHelloOk?.(gatewayHello(bootId));
+      options.signal?.throwIfAborted();
+      sent.push(options.method);
+      if (options.method === "openclaw.setup.detect") {
+        return detectResult();
+      }
+      if (options.method === "openclaw.setup.activate") {
+        return {
+          ok: true,
+          modelRef: "claude-cli/opus",
+          latencyMs: 250,
+          lines: ["Saved inference settings"],
+          gatewayRestartRequired: true,
+        };
+      }
+      if (options.method === "openclaw.setup.verify") {
+        verifiedBoots.push(bootId ?? "unidentified");
+        return { ok: true, modelRef: "claude-cli/opus", latencyMs: 100 };
+      }
+      if (options.method === "openclaw.chat") {
+        expect(bootId).toBe("new-boot");
+        return { sessionId: "test-session", reply: "Ready.", action: "exit" };
+      }
+      throw new Error(`unexpected Gateway method ${options.method}`);
+    });
+
+    const onboarding = runRemoteGatewayInferenceOnboarding(
+      makeTarget(makeLocalConfig(), { token: "selected-token" }),
+      makeRuntime(),
+      {
+        callGateway: asGatewayCall(callGatewayMock),
+        createPrompter: () => createWizardPrompter(),
+        runGuidedOnboarding: exerciseGuidedAdapters(),
+      },
+    );
+    if (mode !== "replacement") {
+      await expect(onboarding).rejects.toThrow(
+        mode === "restart timeout"
+          ? "Inference settings were saved, but the Gateway did not finish restarting"
+          : "Inference settings were saved, but the Gateway did not provide a boot identity",
+      );
+      expect(verifiedBoots).toEqual([]);
+      expect(sent).toEqual(["openclaw.setup.detect", "openclaw.setup.activate"]);
+      return;
+    }
+    await onboarding;
+    expect(verifiedBoots).toEqual(["new-boot"]);
+    expect(sent).toEqual([
+      "openclaw.setup.detect",
+      "openclaw.setup.activate",
+      "openclaw.setup.verify",
+      "openclaw.chat",
+    ]);
+  });
+
   it("bounds a late restart verification call by the remaining deadline", async () => {
     const now = vi.spyOn(Date, "now").mockReturnValue(45_500).mockReturnValueOnce(1_000);
     const callGatewayMock = vi.fn(async (options: CallGatewayCliOptions): Promise<unknown> => {
+      options.onHelloOk?.(
+        gatewayHello(options.method === "openclaw.setup.verify" ? "new-boot" : "old-boot"),
+      );
+      options.signal?.throwIfAborted();
       if (options.method === "openclaw.setup.detect") {
         return detectResult();
       }
@@ -499,58 +608,81 @@ describe("runRemoteGatewayInferenceOnboarding", () => {
     expect(runTui).not.toHaveBeenCalled();
   });
 
-  it("treats a cancelled remote OpenClaw conversation as a pause without opening the agent", async () => {
-    const methods: string[] = [];
-    const callGatewayMock = vi.fn(async (options: CallGatewayCliOptions): Promise<unknown> => {
-      methods.push(options.method);
-      if (options.method === "openclaw.setup.detect") {
-        return detectResult();
+  it.each(["device", "profile"])(
+    "keeps remote chat ownership across replies and cancellation: %s",
+    async (identity) => {
+      if (identity === "profile") {
+        vi.mocked(loadOrCreateDeviceIdentity).mockImplementationOnce(() => {
+          throw new Error("read-only client state");
+        });
       }
-      if (options.method === "openclaw.setup.activate") {
-        return {
-          ok: true,
-          modelRef: "claude-cli/opus",
-          latencyMs: 250,
-          lines: ["Default model: claude-cli/opus"],
-        };
-      }
-      if (options.method === "openclaw.setup.verify") {
-        return { ok: true, modelRef: "claude-cli/opus", latencyMs: 100 };
-      }
-      if (options.method === "openclaw.chat") {
-        return {
-          sessionId: (options.params as { sessionId: string }).sessionId,
-          reply: "Which channel should I configure?",
-          action: "none",
-        };
-      }
-      throw new Error(`unexpected Gateway method ${options.method}`);
-    });
-    const prompter = createWizardPrompter({
-      text: vi.fn(async () => {
-        throw new WizardCancelledError("cancelled");
-      }),
-    });
-    const runTui = vi.fn();
+      const methods: string[] = [];
+      let chatOwner: string | undefined;
+      let connections = 0;
+      const callGatewayMock = vi.fn(async (options: CallGatewayCliOptions): Promise<unknown> => {
+        methods.push(options.method);
+        if (options.method === "openclaw.setup.detect") {
+          return detectResult();
+        }
+        if (options.method === "openclaw.setup.activate") {
+          return {
+            ok: true,
+            modelRef: "claude-cli/opus",
+            latencyMs: 250,
+            lines: ["Default model: claude-cli/opus"],
+          };
+        }
+        if (options.method === "openclaw.setup.verify") {
+          return { ok: true, modelRef: "claude-cli/opus", latencyMs: 100 };
+        }
+        if (options.method === "openclaw.chat") {
+          // The Gateway falls back to connection ownership when there is no
+          // authenticated profile or device; one-shot calls use new connections.
+          const owner =
+            identity === "profile"
+              ? "authenticated-profile"
+              : (options.deviceIdentity?.deviceId ?? `connection:${++connections}`);
+          if (chatOwner && chatOwner !== owner) {
+            throw new Error("OpenClaw session belongs to another caller.");
+          }
+          chatOwner = owner;
+          return {
+            sessionId: (options.params as { sessionId: string }).sessionId,
+            reply: "Which channel should I configure?",
+            action: "none",
+          };
+        }
+        throw new Error(`unexpected Gateway method ${options.method}`);
+      });
+      const prompter = createWizardPrompter({
+        text: vi
+          .fn(async (): Promise<string> => {
+            throw new WizardCancelledError("cancelled");
+          })
+          .mockResolvedValueOnce("Keep the existing configuration."),
+      });
+      const runTui = vi.fn();
 
-    await runRemoteGatewayInferenceOnboarding(
-      makeTarget(makeLocalConfig(), { token: "selected-token" }),
-      makeRuntime(),
-      {
-        callGateway: asGatewayCall(callGatewayMock),
-        createPrompter: () => prompter,
-        runGuidedOnboarding: exerciseGuidedAdapters(),
-        runTui,
-      },
-    );
+      await runRemoteGatewayInferenceOnboarding(
+        makeTarget(makeLocalConfig(), { token: "selected-token" }),
+        makeRuntime(),
+        {
+          callGateway: asGatewayCall(callGatewayMock),
+          createPrompter: () => prompter,
+          runGuidedOnboarding: exerciseGuidedAdapters(),
+          runTui,
+        },
+      );
 
-    expect(methods).toEqual([
-      "openclaw.setup.detect",
-      "openclaw.setup.activate",
-      "openclaw.setup.verify",
-      "openclaw.chat",
-    ]);
-    expect(prompter.outro).toHaveBeenCalledWith("OpenClaw setup paused.");
-    expect(runTui).not.toHaveBeenCalled();
-  });
+      expect(methods).toEqual([
+        "openclaw.setup.detect",
+        "openclaw.setup.activate",
+        "openclaw.setup.verify",
+        "openclaw.chat",
+        "openclaw.chat",
+      ]);
+      expect(prompter.outro).toHaveBeenCalledWith("OpenClaw setup paused.");
+      expect(runTui).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/commands/onboard-remote-gateway.ts
+++ b/src/commands/onboard-remote-gateway.ts
@@ -11,6 +11,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   isGatewayClientRequestError,
   isGatewayTransportError,
+  resolveDeviceIdentityForGatewayCall,
   type CallGatewayCliOptions,
 } from "../gateway/call.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
@@ -30,6 +31,8 @@ const GATEWAY_CODEX_SETUP_ACTIVATE_TIMEOUT_MS = 480_000;
 const GATEWAY_SETUP_VERIFY_TIMEOUT_MS = 30_000;
 const GATEWAY_SYSTEM_AGENT_CHAT_TIMEOUT_MS = 190_000;
 const GATEWAY_RESTART_WAIT_TIMEOUT_MS = 45_000;
+const GATEWAY_RESTART_IDENTITY_ERROR =
+  "Inference settings were saved, but the Gateway did not provide a boot identity. Update and restart the remote Gateway, then run onboarding again.";
 
 type CallGateway = <T>(options: CallGatewayCliOptions) => Promise<T>;
 
@@ -213,12 +216,14 @@ export async function runRemoteGatewayInferenceOnboarding(
   const explicitAuth = Boolean(target.token || target.password);
   let gatewayWorkspace: string | undefined;
 
-  const request = async <T>(params: {
-    method: string;
-    payload: unknown;
-    timeoutMs: number;
-  }): Promise<T> =>
+  const request = async <T>(
+    params: Pick<
+      CallGatewayCliOptions,
+      "method" | "params" | "onHelloOk" | "signal" | "deviceIdentity"
+    > & { timeoutMs: number },
+  ): Promise<T> =>
     await callGateway<T>({
+      ...params,
       config: boundConfig,
       // Authenticated calls can pin the URL directly. Auth-free loopback
       // Gateways use the equivalently pinned config target because URL
@@ -228,15 +233,12 @@ export async function runRemoteGatewayInferenceOnboarding(
       ...(target.password ? { password: target.password } : {}),
       ...(target.tlsFingerprint ? { tlsFingerprint: target.tlsFingerprint } : {}),
       ignoreEnvUrlOverride: true,
-      method: params.method,
-      params: params.payload,
-      timeoutMs: params.timeoutMs,
     });
 
   const detect = async (): Promise<SetupInferenceDetection> => {
     const result = await request<SystemAgentSetupDetectResult>({
       method: "openclaw.setup.detect",
-      payload: {},
+      params: {},
       timeoutMs: GATEWAY_SETUP_DETECT_TIMEOUT_MS,
     });
     const detection = toSetupInferenceDetection(result);
@@ -247,9 +249,10 @@ export async function runRemoteGatewayInferenceOnboarding(
   const activate = async (
     params: ActivateSetupInferenceParams,
   ): Promise<ActivateSetupInferenceResult> => {
+    let activationBootId: string | undefined;
     const result = await request<SystemAgentSetupActivateResult>({
       method: "openclaw.setup.activate",
-      payload: {
+      params: {
         kind: params.kind,
         ...(params.modelRef !== undefined ? { modelRef: params.modelRef } : {}),
         ...(params.authChoice !== undefined ? { authChoice: params.authChoice } : {}),
@@ -257,63 +260,76 @@ export async function runRemoteGatewayInferenceOnboarding(
         ...(gatewayWorkspace ? { workspace: gatewayWorkspace } : {}),
       },
       timeoutMs: activationTimeoutMs(params.kind),
+      onHelloOk: (hello) => {
+        activationBootId = hello.server.bootId?.trim();
+      },
     });
     const activation = toSetupInferenceActivationResult(result);
     if (!activation.ok) {
       return activation;
     }
+    const restartBootId = activation.gatewayRestartRequired ? activationBootId : undefined;
+    if (activation.gatewayRestartRequired && !restartBootId) {
+      throw new Error(GATEWAY_RESTART_IDENTITY_ERROR);
+    }
     const restartDeadline = Date.now() + GATEWAY_RESTART_WAIT_TIMEOUT_MS;
     let retryDelayMs = 250;
-    let verification: SystemAgentSetupVerifyResult | undefined;
     for (;;) {
       const remainingBeforeAttemptMs = restartDeadline - Date.now();
-      if (activation.gatewayRestartRequired === true && remainingBeforeAttemptMs <= 0) {
-        break;
+      if (restartBootId && remainingBeforeAttemptMs <= 0) {
+        throw new Error(
+          "Inference settings were saved, but the Gateway did not finish restarting and verifying inference. Check the remote Gateway, then run onboarding again.",
+        );
       }
+      const restartWait = new AbortController();
+      let requestedDelay = retryDelayMs;
       try {
-        verification = await request<SystemAgentSetupVerifyResult>({
+        const verification = await request<SystemAgentSetupVerifyResult>({
           method: "openclaw.setup.verify",
-          payload: {},
-          timeoutMs:
-            activation.gatewayRestartRequired === true
-              ? Math.min(GATEWAY_SETUP_VERIFY_TIMEOUT_MS, remainingBeforeAttemptMs)
-              : GATEWAY_SETUP_VERIFY_TIMEOUT_MS,
+          params: {},
+          timeoutMs: restartBootId
+            ? Math.min(GATEWAY_SETUP_VERIFY_TIMEOUT_MS, remainingBeforeAttemptMs)
+            : GATEWAY_SETUP_VERIFY_TIMEOUT_MS,
+          signal: restartWait.signal,
+          onHelloOk: (hello) => {
+            if (!restartBootId) {
+              return;
+            }
+            const bootId = hello.server.bootId?.trim();
+            // Verification runs inference. Cancel at hello so an old healthy
+            // listener cannot bill another completion or satisfy the restart.
+            if (!bootId || bootId === restartBootId) {
+              restartWait.abort(bootId ? "unchanged-boot" : "missing-boot");
+            }
+          },
         });
-        const retryableResult =
-          activation.gatewayRestartRequired === true &&
-          !verification.ok &&
-          verification.status === "unavailable";
-        const remainingMs = restartDeadline - Date.now();
-        if (!retryableResult || remainingMs <= 0) {
-          break;
+        if (!restartBootId || verification.ok || verification.status !== "unavailable") {
+          assertVerifiedActivation({
+            activation,
+            verification,
+            ...(params.modelRef ? { requestedModelRef: params.modelRef } : {}),
+          });
+          return activation;
         }
-        await delay(Math.min(retryDelayMs, remainingMs));
-        retryDelayMs = Math.min(retryDelayMs * 2, 2_000);
       } catch (error) {
+        if (restartWait.signal.reason === "missing-boot") {
+          throw new Error(GATEWAY_RESTART_IDENTITY_ERROR, { cause: error });
+        }
         const retryable =
-          activation.gatewayRestartRequired === true &&
-          (isGatewayTransportError(error) ||
+          restartBootId &&
+          (restartWait.signal.reason === "unchanged-boot" ||
+            isGatewayTransportError(error) ||
             (isGatewayClientRequestError(error) && error.retryable));
-        const remainingMs = restartDeadline - Date.now();
-        if (!retryable || remainingMs <= 0) {
+        if (!retryable) {
           throw error;
         }
-        const requestedDelay = isGatewayClientRequestError(error)
-          ? (error.retryAfterMs ?? retryDelayMs)
-          : retryDelayMs;
-        await delay(Math.min(requestedDelay, remainingMs));
-        retryDelayMs = Math.min(retryDelayMs * 2, 2_000);
+        if (isGatewayClientRequestError(error)) {
+          requestedDelay = error.retryAfterMs ?? retryDelayMs;
+        }
       }
+      await delay(Math.min(requestedDelay, Math.max(0, restartDeadline - Date.now())));
+      retryDelayMs = Math.min(retryDelayMs * 2, 2_000);
     }
-    if (!verification) {
-      throw new Error("Gateway did not finish restarting before inference verification.");
-    }
-    assertVerifiedActivation({
-      activation,
-      verification,
-      ...(params.modelRef ? { requestedModelRef: params.modelRef } : {}),
-    });
-    return activation;
   };
 
   await runGuidedOnboarding({}, runtime, {
@@ -330,10 +346,14 @@ export async function runRemoteGatewayInferenceOnboarding(
           createClackPrompter(),
         ));
       await prompter.intro("OpenClaw");
+      // One-shot RPCs have different connections. Preserve a signed device
+      // owner across chat replies even when loopback shared auth needs no device.
+      const deviceIdentity = resolveDeviceIdentityForGatewayCall();
       const sessionId = randomUUID();
       let reply = await request<SystemAgentChatResult>({
         method: "openclaw.chat",
-        payload: { sessionId, welcomeVariant: "onboarding" },
+        deviceIdentity,
+        params: { sessionId, welcomeVariant: "onboarding" },
         timeoutMs: GATEWAY_SYSTEM_AGENT_CHAT_TIMEOUT_MS,
       });
 
@@ -357,7 +377,8 @@ export async function runRemoteGatewayInferenceOnboarding(
           });
           reply = await request<SystemAgentChatResult>({
             method: "openclaw.chat",
-            payload: { sessionId, message },
+            deviceIdentity,
+            params: { sessionId, message },
             timeoutMs: GATEWAY_SYSTEM_AGENT_CHAT_TIMEOUT_MS,
           });
         }

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -2541,6 +2541,27 @@ describe("callGateway error details", () => {
     expect(stopStarted).toBe(true);
   });
 
+  it("does not dispatch a request when its hello observer aborts the connection", async () => {
+    setLocalLoopbackGatewayConfig();
+    const controller = new AbortController();
+    const onSignalAbort = vi.fn();
+    const stop = vi.fn(async () => {});
+    gatewayClientStopAndWait = stop;
+
+    await expect(
+      callGateway({
+        method: "agent",
+        signal: controller.signal,
+        onHelloOk: () => controller.abort(),
+        onSignalAbort,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+
+    expect(lastRequestOptions).toBeNull();
+    expect(onSignalAbort).not.toHaveBeenCalled();
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
   it("skips the signal abort hook before the primary request starts", async () => {
     setLocalLoopbackGatewayConfig();
 

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -499,7 +499,9 @@ function shouldOmitDeviceIdentityForGatewayCall(params: {
   return isLocalBackendSharedAuth || isLocalCliSharedAuth;
 }
 
-function resolveDeviceIdentityForGatewayCall(sharedStateMode?: "read-only"): DeviceIdentity | null {
+export function resolveDeviceIdentityForGatewayCall(
+  sharedStateMode?: "read-only",
+): DeviceIdentity | null {
   try {
     return sharedStateMode === "read-only"
       ? loadDeviceIdentityIfPresent()
@@ -983,6 +985,10 @@ async function executeGatewayRequestWithScopes<T>(params: {
         try {
           opts.onHelloOk?.(hello);
         } catch {}
+        // An observer may cancel after inspecting hello, before any RPC is sent.
+        if (settled) {
+          return;
+        }
         void (async () => {
           try {
             ensureGatewaySupportsRequiredMethods({

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -504,14 +504,18 @@ describe("probeGateway", () => {
     expect(deviceIdentityState.tokenParams).toEqual([]);
   });
 
-  it("does not create or attach a device identity for first-time authenticated probes", async () => {
-    deviceIdentityState.cachedToken = null;
+  it.each([false, true])(
+    "does not attach a first-time authenticated probe identity (origin-scoped=%s)",
+    async (originScopedDeviceAuth) => {
+      deviceIdentityState.cachedToken = null;
+      deviceIdentityState.cachedOriginToken = null;
 
-    await runTokenProbe();
+      await runTokenProbe({ originScopedDeviceAuth });
 
-    expect(gatewayClientState.options?.deviceIdentity).toBeNull();
-    expect(gatewayClientState.options?.scopes).toEqual(["operator.read"]);
-  });
+      expect(gatewayClientState.options?.deviceIdentity).toBeNull();
+      expect(gatewayClientState.options?.scopes).toEqual(["operator.read"]);
+    },
+  );
 
   it("reuses cached device identity for unauthenticated loopback probes", async () => {
     await probeGateway({
@@ -522,16 +526,21 @@ describe("probeGateway", () => {
     expect(gatewayClientState.options?.deviceIdentity).toEqual(deviceIdentityState.value);
   });
 
-  it("keeps device identity disabled for first-time unauthenticated loopback probes", async () => {
-    deviceIdentityState.cachedToken = null;
+  it.each([false, true])(
+    "does not attach a first-time unauthenticated probe identity (origin-scoped=%s)",
+    async (originScopedDeviceAuth) => {
+      deviceIdentityState.cachedToken = null;
+      deviceIdentityState.cachedOriginToken = null;
 
-    await probeGateway({
-      url: "ws://127.0.0.1:18789",
-      timeoutMs: 1_000,
-    });
+      await probeGateway({
+        url: "ws://127.0.0.1:18789",
+        timeoutMs: 1_000,
+        originScopedDeviceAuth,
+      });
 
-    expect(gatewayClientState.options?.deviceIdentity).toBeNull();
-  });
+      expect(gatewayClientState.options?.deviceIdentity).toBeNull();
+    },
+  );
 
   it("skips detail RPCs for lightweight reachability probes", async () => {
     const result = await probeGateway({

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -1047,6 +1047,7 @@ describe("runSetupWizard", () => {
       }
 
       expect(probeGatewayReachable).toHaveBeenCalledWith({
+        originScopedDeviceAuth: true,
         url: "wss://flag.example.com:18789",
         config: expect.any(Object),
         token: remoteKey === "token" ? remoteCredential : undefined,
@@ -1096,6 +1097,7 @@ describe("runSetupWizard", () => {
     );
 
     expect(probeGatewayReachable).toHaveBeenCalledWith({
+      originScopedDeviceAuth: true,
       url: "wss://gateway.example.test",
       config: expect.any(Object),
       token: undefined,
@@ -1124,6 +1126,7 @@ describe("runSetupWizard", () => {
       );
 
       expect(probeGatewayReachable).toHaveBeenCalledWith({
+        originScopedDeviceAuth: true,
         url: "wss://gateway.example.test",
         config: expect.objectContaining({
           gateway: config.gateway,
@@ -1160,6 +1163,7 @@ describe("runSetupWizard", () => {
     }
 
     expect(probeGatewayReachable).toHaveBeenCalledWith({
+      originScopedDeviceAuth: true,
       url: "wss://gateway.example.test",
       config: expect.any(Object),
       token: "resolved-remote-token",
@@ -1195,6 +1199,7 @@ describe("runSetupWizard", () => {
     }
 
     expect(probeGatewayReachable).toHaveBeenCalledWith({
+      originScopedDeviceAuth: true,
       url: "wss://gateway.example.test",
       config: expect.any(Object),
       token: "ambient-token",
@@ -1243,6 +1248,7 @@ describe("runSetupWizard", () => {
     }
 
     expect(probeGatewayReachable).toHaveBeenCalledWith({
+      originScopedDeviceAuth: true,
       url: "wss://flag.example.com:18789",
       config: expect.objectContaining({
         gateway: expect.objectContaining({

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -424,6 +424,7 @@ async function runSetupWizardOnce(
     ? await onboardHelpers.probeGatewayReachable({
         url: remoteUrl,
         config: baseConfig,
+        originScopedDeviceAuth: true,
         token: remoteProbeAuth?.auth.token,
         ...(remoteProbeAuth?.auth.password ? { password: remoteProbeAuth.auth.password } : {}),
       })


### PR DESCRIPTION
Closes #133229 ([remote CLI declares readiness before a required Gateway restart](https://github.com/openclaw/openclaw/issues/133229)).

## What Problem This Solves

Fixes an issue where users configuring a remote Gateway from the CLI could enter setup chat before a required Gateway restart had completed. A successful same-model response from the old listener was incorrectly accepted as replacement readiness.

Real-flow validation exposed two connected blockers: a paired remote loopback connection could miss its origin-scoped device token and skip inference setup, and the first chat reply could fail with “OpenClaw session belongs to another caller” because each one-shot RPC used a new connection without retaining a stable caller identity.

## Why This Change Was Made

The CLI now carries the already-known remote origin into its probes, uses the activation connection’s existing boot identity to reject old or unidentified verification connections before they can run inference, and retains the canonical client identity across chat replies. Gateway ownership checks and authentication policy are unchanged. The existing best-effort identity resolver also preserves profile-owned chat when local identity storage is unavailable.

The retry loop has one delay path and no retained stale verification result. The request adapter no longer renames payload fields or duplicates call-option forwarding, and the bare-CLI probe uses its owning parameter type rather than a second option definition. No new configuration option, protocol field/version, dependency, or database schema is introduced.

## User Impact

Configured remote connections keep their own pairing even through loopback tunnels. Restart-required activation waits for a replacement Gateway and successful inference before chat; timeout or missing boot identity reports that settings were saved and stops rather than switching providers. Chat remains usable across replies and still pauses cleanly on cancellation. The existing 45-second restart budget is unchanged.

Release-note context: remote CLI onboarding now preserves target pairing, confirms actual Gateway replacement when required, and keeps the authenticated chat caller stable.

## Evidence

**Before/after regressions:** the old-boot handoff, post-hello cancellation dispatch, lost remote-origin probe flag, and cross-connection chat rejection each failed before their repair. Existing tests were extended for missing boot identity, exhausted restart budget, read-only profile-owned chat, and first-time probes that must not create device identity.

**Local validation:** 573 tests passed across seven affected/sibling suites; the complete classified changed-check plan and full build passed; fresh isolated Codex autoreview was scoped-clean through P1. Production: +86/−58, net +28 (including two formatting lines for the existing resolver export). Tests/support: +300/−110, net +190. Docs: +14. The production growth carries the two facts the old flow lacked—replacement boot and stable caller—while removing duplicate retries and adapters.

```bash
node scripts/run-vitest.mjs src/cli/run-main.exit.test.ts src/commands/onboard-helpers.remote-probe.test.ts src/commands/configure.wizard.gateway.test.ts src/commands/onboard-remote-gateway.test.ts src/wizard/setup.test.ts src/gateway/call.test.ts src/gateway/probe.test.ts
```

```bash
node scripts/check-changed.mjs -- docs/cli/onboard.md src/cli/run-main.ts src/cli/run-main.exit.test.ts src/commands/onboard-helpers.ts src/commands/onboard-helpers.remote-probe.test.ts src/commands/configure.wizard.ts src/commands/configure.wizard.gateway.test.ts src/commands/onboard-remote-gateway.ts src/commands/onboard-remote-gateway.test.ts src/wizard/setup.ts src/wizard/setup.test.ts src/gateway/call.ts src/gateway/call.test.ts src/gateway/probe.test.ts
```

```bash
pnpm build
```

**Real user flow:** a built bare CLI ran in a real PTY against an isolated real Gateway, with private client/server state and a live Anthropic key entered through the normal masked manual picker. The actual activation returned `gatewayRestartRequired: true`. Three connections to the old boot were cancelled without sending an inference-verification request. A different Gateway boot received the sole verification request, returned the selected model, and then handled both the welcome and an actual model reply successfully. Cancellation exited with code 0. Neither the provider key nor Gateway credential appeared in terminal output. An initially detected optional login was rejected for missing authentication; the manual key path then succeeded. No operator Gateway or live operator state was touched.

```json
{"realGateway":true,"realBuiltBareCli":true,"realPty":true,"manualMaskedCredentialEntry":true,"restartRequired":true,"replacementBootObserved":true,"oldBootConnectionsCancelled":3,"oldBootInferenceRequests":0,"newBootInferenceRequests":1,"actualReplyMarker":true,"exitCode":0}
```

The live build was frozen at base `6b68a4a42a011514487ebfdae9016f5010eee8e2` plus patch SHA-256 `216b6106cfb83a049d0eed933bb4f09a576377d3880958c560dc6d2eb9f60a59`; its source bytes match commit `5a11b84089f8d64f457098227e2cc8db6447a9f9`. Separate real-PTY/WebSocket tests with a controlled mock Gateway captured the old-boot failure and repaired behavior; those are not labeled real-provider proof. The readiness screenshot below was captured from the real Gateway after the manual restart/chat flow and inspected for sensitive content. It demonstrates final health, not the restart sequence by itself. Raw agent transcripts are intentionally omitted. All owned services and temporary credential/state copies were removed afterward.

**Scope and follow-ups:** this is the CLI owner-boundary repair, following [Model Setup recovery #133106](https://github.com/openclaw/openclaw/pull/133106). Web first-run receipt recovery and macOS setup reconciliation have separate source-level restart-confirmation gaps queued for their owning surfaces; this PR does not claim to repair or live-verify those clients. Their stronger reproduction and UI/native proof remain follow-up work. The initial unrelated missing-export check failure was already repaired on main by [#133155 — tool-metadata import correction](https://github.com/openclaw/openclaw/pull/133155), which was fast-forwarded before final validation.

Hosted exact-head CI and native landing verification will be recorded before merge. Documentation: https://docs.openclaw.ai/cli/onboard

![Real Gateway readiness after manual remote CLI onboarding and restart](https://github.com/user-attachments/assets/a2022e37-e8e9-49c3-bee9-abca63b9dd0c)