### PR TITLE
fix(cli): keep Doctor JSON reports complete when piped

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -277,7 +277,8 @@ const mocks = vi.hoisted(() => ({
   modelsAuthLoginCommand: vi.fn(),
 }));
 
-vi.mock("../runtime.js", () => ({
+vi.mock("../runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../runtime.js")>()),
   defaultRuntime: mocks.runtime,
   writeRuntimeJson: (runtime: { writeJson: (value: unknown) => void }, value: unknown) =>
     runtime.writeJson(value),

--- a/src/cli/cli-utils.test.ts
+++ b/src/cli/cli-utils.test.ts
@@ -1,7 +1,7 @@
 // CLI utility tests cover shared command helpers, option parsing, and output formatting.
 import { Command } from "commander";
 import { describe, expect, it, vi } from "vitest";
-import { defaultRuntime } from "../runtime.js";
+import { defaultRuntime, ExitError } from "../runtime.js";
 import { runCommandWithRuntime } from "./cli-utils.js";
 import { registerDnsCli } from "./dns-cli.js";
 import {
@@ -40,6 +40,33 @@ describe("waitForever", () => {
 });
 
 describe("runCommandWithRuntime", () => {
+  it.each(
+    [0, 1, 2].flatMap((code) =>
+      [false, true].map((customErrorHandler) => ({ code, customErrorHandler })),
+    ),
+  )(
+    "preserves completed exit $code with custom error handler $customErrorHandler",
+    async ({ code, customErrorHandler }) => {
+      const runtime = { error: vi.fn(), exit: vi.fn() };
+      const onError = vi.fn();
+      const outcome = new ExitError(code);
+
+      await expect(
+        runCommandWithRuntime(
+          runtime,
+          async () => {
+            throw outcome;
+          },
+          customErrorHandler ? onError : undefined,
+        ),
+      ).rejects.toBe(outcome);
+
+      expect(runtime.error).not.toHaveBeenCalled();
+      expect(runtime.exit).not.toHaveBeenCalled();
+      expect(onError).not.toHaveBeenCalled();
+    },
+  );
+
   it("keeps cause chains and error codes behind debug intent", async () => {
     const messages: string[] = [];
     const exits: number[] = [];

--- a/src/cli/cli-utils.ts
+++ b/src/cli/cli-utils.ts
@@ -1,6 +1,7 @@
 // Shared CLI execution wrappers and inherited Commander option lookup.
 import type { Command } from "commander";
 import { formatErrorMessage } from "../infra/errors.js";
+import { ExitError } from "../runtime.js";
 import { formatCliOperatorError, isExpectedCliError } from "./failure-output.js";
 import { isJsonOutputModeActive } from "./json-output-mode.js";
 
@@ -42,7 +43,12 @@ export async function runCommandWithRuntime(
   try {
     await action();
   } catch (err) {
-    if (isJsonOutputModeActive(process.argv) || isExpectedCliError(err)) {
+    // Completed commands unwind to the outer cleanup and output-drain owner.
+    if (
+      err instanceof ExitError ||
+      isJsonOutputModeActive(process.argv) ||
+      isExpectedCliError(err)
+    ) {
       throw err;
     }
     if (onError) {

--- a/src/cli/cli-utils.ts
+++ b/src/cli/cli-utils.ts
@@ -1,7 +1,6 @@
 // Shared CLI execution wrappers and inherited Commander option lookup.
 import type { Command } from "commander";
 import { formatErrorMessage } from "../infra/errors.js";
-import { ExitError } from "../runtime.js";
 import { formatCliOperatorError, isExpectedCliError } from "./failure-output.js";
 import { isJsonOutputModeActive } from "./json-output-mode.js";
 
@@ -43,7 +42,8 @@ export async function runCommandWithRuntime(
   try {
     await action();
   } catch (err) {
-    // Completed commands unwind to the outer cleanup and output-drain owner.
+    // Keep help imports lazy while completed commands reach the cleanup and output-drain owner.
+    const { ExitError } = await import("../runtime.js");
     if (
       err instanceof ExitError ||
       isJsonOutputModeActive(process.argv) ||

--- a/src/cli/doctor-output.process.test.ts
+++ b/src/cli/doctor-output.process.test.ts
@@ -1,0 +1,75 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { spawnNodeEvalSync } from "../test-utils/node-process.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("Doctor report process output", () => {
+  it.each([
+    { name: "advisory JSON", args: ["--json"], exitCode: 0 },
+    { name: "lint JSON", args: ["--lint", "--json"], exitCode: 1 },
+    { name: "post-upgrade JSON", args: ["--post-upgrade", "--json"], exitCode: 1 },
+  ])("drains the whole pipe before exiting for $name", ({ args, exitCode }) => {
+    const root = tempDirs.make("openclaw-doctor-output-");
+    const payload = { ok: false, findings: [{ level: "error", message: "x".repeat(1024 * 1024) }] };
+    const sourceUrl = (relative: string) => new URL(relative, import.meta.url).href;
+    // Keep the parser, runtime, and exit lifecycle real. Synthetic report
+    // producers exercise the output boundary without accessing operator state.
+    const script = `
+      import { registerHooks } from "node:module";
+      import { Command } from "commander";
+      registerHooks({
+        resolve(specifier, context, nextResolve) {
+          const producer = specifier.endsWith("/doctor-lint.js") ? "lint" :
+            specifier.endsWith("/doctor-post-upgrade.js") ? "post-upgrade" : undefined;
+          if (producer) {
+            const payload = '{ ok: false, findings: [{ level: "error", message: "x".repeat(1024 * 1024) }] }';
+            return {
+              shortCircuit: true,
+              url: "data:text/javascript," + encodeURIComponent(
+                producer === "lint"
+                  ? 'export async function runDoctorLintCli(runtime) { runtime.writeJson(' + payload + '); return 1; }'
+                  : 'export async function runPostUpgradeProbes() { return ' + payload + '; }'
+              ),
+            };
+          }
+          return nextResolve(specifier, context);
+        },
+      });
+      const { registerMaintenanceCommands } = await import(${JSON.stringify(sourceUrl("./program/register.maintenance.ts"))});
+      const { runCliWithExitFinalization } = await import(${JSON.stringify(sourceUrl("./one-shot-exit.ts"))});
+      process.argv = [process.execPath, "openclaw", "doctor", ...${JSON.stringify(args)}];
+      await runCliWithExitFinalization({
+        run: async () => {
+          const program = new Command().name("openclaw");
+          registerMaintenanceCommands(program);
+          await program.parseAsync(process.argv);
+        },
+        onError: error => { throw error; },
+      });
+    `;
+    const result = spawnNodeEvalSync(script, {
+      imports: ["tsx"],
+      env: {
+        PATH: path.dirname(process.execPath),
+        HOME: root,
+        USERPROFILE: root,
+        OPENCLAW_HOME: root,
+        OPENCLAW_STATE_DIR: path.join(root, "state"),
+        OPENCLAW_CONFIG_PATH: path.join(root, "openclaw.json"),
+        NO_COLOR: "1",
+      },
+      maxBuffer: 2 * 1024 * 1024,
+      timeout: 30_000,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.status, result.stderr).toBe(exitCode);
+    expect(result.stderr).toBe("");
+    const expected = `${JSON.stringify(payload, null, 2)}\n`;
+    expect(result.stdout.length).toBe(expected.length);
+    expect(result.stdout).toBe(expected);
+  });
+});

--- a/src/cli/program.test-mocks.ts
+++ b/src/cli/program.test-mocks.ts
@@ -83,7 +83,10 @@ vi.mock("../commands/onboard.js", () => ({
   onboardCommand: programMocks.onboardCommand,
   setupWizardCommand: programMocks.setupWizardCommand,
 }));
-vi.mock("../runtime.js", () => ({ defaultRuntime: programMocks.runtime }));
+vi.mock("../runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../runtime.js")>()),
+  defaultRuntime: programMocks.runtime,
+}));
 vi.mock("./channel-auth.js", () => ({
   runChannelLogin: programMocks.runChannelLogin,
   runChannelLogout: programMocks.runChannelLogout,

--- a/src/cli/program/message/helpers.test.ts
+++ b/src/cli/program/message/helpers.test.ts
@@ -62,7 +62,8 @@ const exitMock = vi.fn((_code: number): never => {
 });
 const errorMock = vi.fn();
 const runtimeMock = { log: vi.fn(), error: errorMock, exit: exitMock };
-vi.mock("../../../runtime.js", () => ({
+vi.mock("../../../runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../runtime.js")>()),
   defaultRuntime: runtimeMock,
 }));
 

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -70,7 +70,8 @@ vi.mock("../../global-state.js", () => ({
   setVerbose: mocks.setVerboseMock,
 }));
 
-vi.mock("../../runtime.js", () => ({
+vi.mock("../../runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../runtime.js")>()),
   defaultRuntime: mocks.runtime,
 }));
 

--- a/src/cli/program/register.configure.test.ts
+++ b/src/cli/program/register.configure.test.ts
@@ -22,7 +22,8 @@ vi.mock("../../commands/configure.commands.js", () => ({
   configureCommandFromSectionsArg: mocks.configureCommandFromSectionsArgMock,
 }));
 
-vi.mock("../../runtime.js", () => ({
+vi.mock("../../runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../runtime.js")>()),
   defaultRuntime: mocks.runtime,
 }));
 

--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -1,6 +1,7 @@
 // Register maintenance tests cover maintenance command registration in the CLI program.
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExitError } from "../../runtime.js";
 import { registerMaintenanceCommands } from "./register.maintenance.js";
 
 const mocks = vi.hoisted(() => ({
@@ -70,7 +71,8 @@ vi.mock("../../commands/doctor-lint.js", () => ({
   runDoctorLintCli: mocks.runDoctorLintCli,
 }));
 
-vi.mock("../../runtime.js", () => ({
+vi.mock("../../runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../runtime.js")>()),
   defaultRuntime: mocks.runtime,
 }));
 
@@ -90,7 +92,14 @@ describe("registerMaintenanceCommands doctor action", () => {
   async function runMaintenanceCli(args: string[]) {
     const program = new Command();
     registerMaintenanceCommands(program);
-    await program.parseAsync(args, { from: "user" });
+    try {
+      await program.parseAsync(args, { from: "user" });
+    } catch (error) {
+      if (!(error instanceof ExitError)) {
+        throw error;
+      }
+      runtime.exit(error.code);
+    }
   }
 
   beforeEach(() => {

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -7,6 +7,7 @@ import { formatErrorMessage as formatError, runCommandWithRuntime } from "../cli
 import { hasExplicitOptions } from "../command-options.js";
 import { isDoctorMachineOutput } from "../doctor-output-mode.js";
 import { formatCliJsonFailure } from "../failure-output.js";
+import { exitCliAfterOutput } from "../one-shot-exit.js";
 import { setCommandJsonMode } from "./json-mode.js";
 
 const STATE_SQLITE_CONFLICTING_OPTION_NAMES = [
@@ -32,13 +33,13 @@ const STATE_SQLITE_CONFLICTING_OPTION_NAMES = [
   "only",
 ] as const;
 
-function exitDoctorError(message: string, json: boolean): void {
+function exitDoctorError(message: string, json: boolean): never {
   if (json) {
     defaultRuntime.writeJson(formatCliJsonFailure(message));
   } else {
     defaultRuntime.error(message);
   }
-  defaultRuntime.exit(2);
+  exitCliAfterOutput(defaultRuntime, 2);
 }
 
 /** Register maintenance commands that inspect or mutate local OpenClaw state. */
@@ -151,7 +152,7 @@ export function registerMaintenanceCommands(program: Command) {
         );
       }
       if (lintMode) {
-        await runCommandWithRuntime(
+        return await runCommandWithRuntime(
           defaultRuntime,
           async () => {
             const { runDoctorLintCli } = await import("../../commands/doctor-lint.js");
@@ -164,11 +165,10 @@ export function registerMaintenanceCommands(program: Command) {
               allowExec: Boolean(opts.allowExec),
               deep: Boolean(opts.deep),
             });
-            defaultRuntime.exit(jsonImpliesLint ? 0 : exitCode);
+            exitCliAfterOutput(defaultRuntime, jsonImpliesLint ? 0 : exitCode);
           },
           (err) => exitDoctorError(formatError(err), opts.json === true || !process.stdout.isTTY),
         );
-        return;
       }
       await runCommandWithRuntime(
         defaultRuntime,
@@ -201,7 +201,7 @@ export function registerMaintenanceCommands(program: Command) {
             sessionSqliteGithubIssue: Boolean(opts.githubIssue),
             json: Boolean(opts.json),
           });
-          defaultRuntime.exit(0);
+          exitCliAfterOutput(defaultRuntime, 0);
         },
         opts.json ? (err: unknown) => exitDoctorError(formatError(err), true) : undefined,
       );
@@ -223,7 +223,7 @@ export function registerMaintenanceCommands(program: Command) {
       if (opts.json === true && opts.run === true) {
         return exitDoctorError("triage --json cannot be combined with --run.", true);
       }
-      await runCommandWithRuntime(
+      return await runCommandWithRuntime(
         defaultRuntime,
         async () => {
           const { triageCommand } = await import("../../commands/triage.js");
@@ -350,8 +350,7 @@ function parseDoctorStateSqliteMode(value: unknown, json: boolean): "compact" | 
   if (value === undefined || value === "compact") {
     return value;
   }
-  exitDoctorError("Invalid --state-sqlite mode. Use compact.", json);
-  throw new Error("unreachable");
+  return exitDoctorError("Invalid --state-sqlite mode. Use compact.", json);
 }
 
 function parseDoctorSessionSqliteMode(
@@ -370,9 +369,8 @@ function parseDoctorSessionSqliteMode(
   ) {
     return value;
   }
-  exitDoctorError(
+  return exitDoctorError(
     "Invalid --session-sqlite mode. Use dry-run, import, validate, inspect, compact, restore, or recover.",
     json,
   );
-  throw new Error("unreachable");
 }

--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -105,7 +105,8 @@ vi.mock("../../globals.js", () => ({
   setVerbose: mocks.setVerbose,
 }));
 
-vi.mock("../../runtime.js", () => ({
+vi.mock("../../runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../runtime.js")>()),
   defaultRuntime: mocks.runtime,
 }));
 

--- a/src/cli/program/register.tasks.test.ts
+++ b/src/cli/program/register.tasks.test.ts
@@ -43,7 +43,10 @@ vi.mock("../../commands/flows.js", () => {
     flowsCancelCommand: mocks.flowsCancelCommand,
   };
 });
-vi.mock("../../runtime.js", () => ({ defaultRuntime: mocks.runtime }));
+vi.mock("../../runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../runtime.js")>()),
+  defaultRuntime: mocks.runtime,
+}));
 
 const ownerHandlers = [
   mocks.tasksListCommand,

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -258,7 +258,8 @@ function primeCalendarUpdate(workspaceDir = "/tmp/workspace"): void {
   ]);
 }
 
-vi.mock("../runtime.js", () => ({
+vi.mock("../runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../runtime.js")>()),
   defaultRuntime: mocks.defaultRuntime,
 }));
 

--- a/src/cli/skills-cli.curator.test.ts
+++ b/src/cli/skills-cli.curator.test.ts
@@ -26,7 +26,10 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock("../runtime.js", () => ({ defaultRuntime: mocks.defaultRuntime }));
+vi.mock("../runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../runtime.js")>()),
+  defaultRuntime: mocks.defaultRuntime,
+}));
 vi.mock("../gateway/call.js", () => ({
   callGateway: mocks.callGateway,
   isGatewayClientRequestError: (error: unknown) =>

--- a/src/cli/skills-cli.workshop-cache.test.ts
+++ b/src/cli/skills-cli.workshop-cache.test.ts
@@ -39,7 +39,10 @@ const mocks = vi.hoisted(() => ({
   },
 }));
 
-vi.mock("../runtime.js", () => ({ defaultRuntime: mocks.defaultRuntime }));
+vi.mock("../runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../runtime.js")>()),
+  defaultRuntime: mocks.defaultRuntime,
+}));
 vi.mock("../gateway/call.js", () => ({
   callGateway: mocks.callGateway,
   isGatewayCredentialsRequiredError: (error: unknown) =>

--- a/src/cli/skills-cli.workshop.test.ts
+++ b/src/cli/skills-cli.workshop.test.ts
@@ -45,7 +45,8 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock("../runtime.js", () => ({
+vi.mock("../runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../runtime.js")>()),
   defaultRuntime: mocks.defaultRuntime,
 }));
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,4 +1,5 @@
 /** Top-level doctor command wrapper, including post-upgrade probe mode. */
+import { exitCliAfterOutput } from "../cli/one-shot-exit.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import { resolveSessionStoreTargets } from "../config/sessions/targets.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
@@ -45,8 +46,8 @@ function resolveExplicitSessionSqliteMaintenancePaths(options: DoctorOptions): s
 
 /** Runs doctor or the post-upgrade probe submode using the provided runtime. */
 export async function doctorCommand(runtime?: RuntimeEnv, options?: DoctorOptions): Promise<void> {
+  const outputRuntime = runtime ?? defaultRuntime;
   if (options?.stateSqlite) {
-    const outputRuntime = runtime ?? defaultRuntime;
     const { runDoctorStateSqliteCompact } = await import("./doctor-state-sqlite-compact.js");
     const report = await runDoctorStateSqliteCompact();
     if (options.json) {
@@ -62,11 +63,9 @@ export async function doctorCommand(runtime?: RuntimeEnv, options?: DoctorOption
       );
       outputRuntime.log(`- integrity-check=${report.integrityCheck}, path=${report.path}`);
     }
-    outputRuntime.exit(0);
-    return;
+    exitCliAfterOutput(outputRuntime, 0);
   }
   if (options?.sessionSqlite) {
-    const outputRuntime = runtime ?? defaultRuntime;
     const sessionSqliteMode = options.sessionSqlite;
     const { runDoctorSessionSqlite } = await import("./doctor-session-sqlite.js");
     const runSessionSqlite = async () =>
@@ -135,11 +134,9 @@ export async function doctorCommand(runtime?: RuntimeEnv, options?: DoctorOption
         }
       }
     }
-    outputRuntime.exit(report.totals.issues > 0 ? 1 : 0);
-    return;
+    exitCliAfterOutput(outputRuntime, report.totals.issues > 0 ? 1 : 0);
   }
   if (options?.postUpgrade) {
-    const outputRuntime = runtime ?? defaultRuntime;
     const report = await runPostUpgradeProbes({});
     if (options.json) {
       writeRuntimeJson(outputRuntime, report);
@@ -152,8 +149,7 @@ export async function doctorCommand(runtime?: RuntimeEnv, options?: DoctorOption
       }
     }
     const hasError = report.findings.some((f) => f.level === "error");
-    outputRuntime.exit(hasError ? 1 : 0);
-    return;
+    exitCliAfterOutput(outputRuntime, hasError ? 1 : 0);
   }
   const doctorHealth = await import("../flows/doctor-health.js");
   await doctorHealth.runDoctorHealthFlow(runtime, options);


### PR DESCRIPTION
Closes #133258

## What Problem This Solves

Fixes an issue where users piping `openclaw doctor --json` receive truncated, invalid JSON when a report exceeds the pipe buffer, even though Doctor exits successfully. Explicit `doctor --lint --json` has the same truncation with its normal threshold exit code.

## Why This Change Was Made

Completed Doctor reports called the synchronous runtime exit before queued stdout finished. Route the maintenance registrar and Doctor report modes through the existing one-shot output finalizer, and let the shared command wrapper propagate its typed completion outcome without rendering another error. The wrapper loads the completion class only on its error path, preserving lazy help registration. The finalizer keeps ownership of cleanup, stream draining, and process exit.

Repeated runtime selection and unreachable returns/throws are removed. Production LOC: **+21/-21, net 0**; test changes are separate. No new helper, configuration, schema, dependency, or repair policy is introduced. Returning status codes through the Doctor API would duplicate the established lifecycle contract; adding report-specific drain logic would create another output owner.

Provenance: original introduction unknown. The advisory JSON exit change in 6e5bf3ec55cb carried forward the immediate-exit pattern, verified against its raw parent. The existing finalizer from #131656 already provides the required drain behavior.

## User Impact

Piped Doctor reports complete before exit. Bare JSON remains advisory (exit 0); explicit lint retains its configured threshold result; usage failures remain exit 2. Report modes retain their existing status decisions, and injected runtimes keep their exit callback behavior.

Ordinary internal Doctor callers remain unchanged. Named follow-up: the ordinary health flow's config-write refusal and post-install advisory exits also need lifecycle work, but converting them requires checking nested updater catches and advisory exit 86. This PR does not claim every Doctor exit is repaired. The runtime-exception ownership reported in #127502 is separate and unchanged.

## Evidence

Before, on unchanged current source 039187abe40516ae796fa9cd85cab1494fe94399, the supported compiled CLI was run with an isolated synthetic HOME/state/config containing 1,500 invalid numeric provider base URLs. Config validation emits these findings before provider execution; no credentials, network calls, live service, or destructive maintenance operation was used.

| Actual CLI flow | Before pipe | After pipe | Exit, unchanged |
| --- | --- | --- | --- |
| `doctor --json` | 65,536 bytes; invalid JSON | 268,948 bytes; valid JSON, 1,500 findings | 0 |
| `doctor --lint --json` | 65,536 bytes; invalid JSON | 268,948 bytes; valid JSON, 1,500 findings | 1 |

The final normal sourcePerformance build stamps commit `4a6bc5e2a9b068292ed64fe83401c57f3a600d2a`. All four after controls (file and pipe for both modes) have empty stderr and identical output SHA256 `335dbc95a0214cdc382256f275b1209374e464eabfe600fa03e5a0e82f403be0`, matching the full before-file report. The compiled registrar/runtime/finalizer binding was inspected, including the lazy completion-class import. The final 41.1-second build and all four output controls include that correction; all 17 committed files match the reviewed content hashes.

Production LOC: **+21/-21**; tests/test support: **+144/-14**. The canonical changed-file gate passed. Its initial run caught three consistent-return lint findings; explicit returns corrected them, and 94 focused maintenance/process tests plus targeted lint passed before the complete gate rerun.

Focused coverage: 204 tests across the Doctor registrar, report commands, one-shot finalizer, invalid-config recovery and shared wrapper; 496 tests across ten direct caller/process suites. Initial subprocess and typed-exit regressions failed before the repair. Existing runtime mocks that omitted the real `ExitError` export now retain module exports with all assertions unchanged. A grouped run masked incomplete factories, so the remaining 12 relevant suites were checked in separate processes: 14 failures demonstrated four additional incomplete factories. Eight affected suites then passed 201 tests individually; four unaffected suites passed 61 tests unchanged. No test assertions or test-isolation policy were weakened. The subprocess tests use synthetic 1 MiB report producers with the real parser/runtime/finalizer; actual compiled CLI proof separately checks the production report writer.

Selected configure-help failed on the eager import and passes after correction, alongside all 60 shared-wrapper tests and three process regressions. Selected setup/onboard/agents help checks still load runtime through separate unchanged imports; all three failures reproduce with the original baseline wrapper. Their lazy-help and mock-cache isolation cleanup is a named follow-up, not part of this output repair.

Final source/peer review and separate exact-commit CLI review are clean at `4a6bc5e2a9b068292ed64fe83401c57f3a600d2a`; structured autoreview is scoped-clean at P0. The final 17-file changed gate and compiled proof passed. Exact-head [CI run 33306283992](https://github.com/openclaw/openclaw/actions/runs/33306283992) and the required `openclaw/ci-gate` passed on this commit.

The latest ClawSweeper review has no actionable findings; its sole rank-up move, waiting for exact-head CI, is complete. The data-model marker is a file-based false positive: this change only selects the existing output runtime and completion owner in Doctor report branches; no schema, storage operation, or persistence semantics change. The protected maintainer label requires normal maintainer handling, which this PR is following.
