### PR TITLE
fix: restore replacement run progress after UI reconnect

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -663,6 +663,8 @@ current tab's gateway/session-scoped browser storage, shown as waiting for recon
 automatically when the Gateway returns. Live controls and slash commands remain unavailable while
 offline, except that **Stop** can queue an exact local run ID for replay. A session-only stop
 is not replayed because newer work may start in that session before the connection returns.
+If the previous turn finished and another began while offline, reconnect restores the current
+turn's progress and directs **Stop** to that turn once the Gateway confirms the replacement.
 
 Queued attachments use binary Blobs in the browser's IndexedDB; the outbox keeps only delivery
 metadata and payload references in session storage. Attachment bytes stay with the queued input

--- a/ui/src/e2e/chat-active-turn-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-active-turn-recovery.e2e.test.ts
@@ -341,6 +341,58 @@ suite.define(() => {
     }
   });
 
+  it("adopts a replacement run that started while the socket was offline", async () => {
+    const { context, page, gateway } = await openActiveTurn();
+    try {
+      const previousPrompt = "Start the first task.";
+      const previousText = "The first task is streaming.";
+      const previousRun = await startActiveTurn(page, gateway, previousPrompt, previousText);
+      await capture(page, "09-turnover-before");
+      const startupCount = (await gateway.getRequests("chat.startup")).length;
+      const subscriptionCount = (await gateway.getRequests("sessions.messages.subscribe")).length;
+      await gateway.setOnline(false);
+
+      const nextRun = "run-offline-replacement";
+      const nextPrompt = "Start the second task.";
+      const nextText = "The second task is streaming.";
+      await installActiveRunSnapshot(gateway, nextRun, nextPrompt, nextText, {
+        messages: [
+          ...activeRunSnapshot(previousRun, previousPrompt, previousText).messages,
+          {
+            __openclaw: { idempotencyKey: previousRun },
+            role: "assistant",
+            content: "The first task completed while offline.",
+            timestamp: 950,
+          },
+          ...activeRunSnapshot(nextRun, nextPrompt, nextText).messages,
+        ],
+      });
+      await gateway.setOnline(true);
+      await gateway.waitForRequest("chat.startup", { after: startupCount });
+      await gateway.waitForRequest("sessions.messages.subscribe", { after: subscriptionCount });
+      await waitForGatewayConnected(page);
+      await assertActiveTurnVisible(page, nextText);
+      await expect(
+        page.locator(".chat-thread").getByText(previousText, { exact: true }),
+      ).toHaveCount(0);
+
+      const liveText = `${nextText} New live progress.`;
+      await gateway.emitGatewayEvent("chat", {
+        runId: nextRun,
+        sessionKey: "main",
+        state: "delta",
+        message: { role: "assistant", content: liveText },
+      });
+      await assertActiveTurnVisible(page, liveText);
+      await capture(page, "10-turnover-after");
+      await page.getByRole("button", { name: "Stop generating" }).click();
+      const abort = await gateway.waitForRequest("chat.abort");
+      expect(abort.params).toMatchObject({ sessionKey: "main", runId: nextRun });
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("restores the active assistant and tool after a full reload", async () => {
     const { context, page, gateway } = await openActiveTurn();
     try {

--- a/ui/src/e2e/chat-active-turn-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-active-turn-recovery.e2e.test.ts
@@ -367,23 +367,53 @@ suite.define(() => {
           ...activeRunSnapshot(nextRun, nextPrompt, nextText).messages,
         ],
       });
+      await gateway.deferNext("chat.startup");
       await gateway.setOnline(true);
       await gateway.waitForRequest("chat.startup", { after: startupCount });
-      await gateway.waitForRequest("sessions.messages.subscribe", { after: subscriptionCount });
       await waitForGatewayConnected(page);
+      await gateway.emitGatewayEvent("agent", {
+        runId: nextRun,
+        seq: 2,
+        stream: "compaction",
+        ts: 1_100,
+        sessionKey: "main",
+        data: { phase: "start" },
+      });
+      const compaction = page.locator(".compaction-indicator--active");
+      await expect(compaction).toBeVisible();
+      await gateway.resolveDeferred("chat.startup");
+      await gateway.waitForRequest("sessions.messages.subscribe", { after: subscriptionCount });
       await assertActiveTurnVisible(page, nextText);
+      await expect(compaction).toBeVisible();
       await expect(
         page.locator(".chat-thread").getByText(previousText, { exact: true }),
       ).toHaveCount(0);
 
-      const liveText = `${nextText} New live progress.`;
+      const nextProgress = "New live progress.";
+      const liveText = `${nextText} ${nextProgress}`;
       await gateway.emitGatewayEvent("chat", {
         runId: nextRun,
         sessionKey: "main",
         state: "delta",
         message: { role: "assistant", content: liveText },
       });
-      await assertActiveTurnVisible(page, liveText);
+      await assertActiveTurnVisible(page, nextProgress);
+      // Replayed tool activity separates the recovered prefix from later cumulative deltas.
+      const visibleOrder = await page.locator(".chat-thread-inner").evaluate(
+        (element, texts) =>
+          Array.from(element.querySelectorAll(".chat-bubble")).flatMap((bubble) => {
+            const text = bubble.textContent?.trim();
+            if (text === texts.prefix) {
+              return ["prefix"];
+            }
+            if (bubble.querySelector(".chat-tool-row--running")) {
+              return ["tool"];
+            }
+            return text === texts.tail ? ["tail"] : [];
+          }),
+        { prefix: nextText, tail: nextProgress },
+      );
+      expect(visibleOrder).toEqual(["prefix", "tool", "tail"]);
       await capture(page, "10-turnover-after");
       await page.getByRole("button", { name: "Stop generating" }).click();
       const abort = await gateway.waitForRequest("chat.abort");

--- a/ui/src/pages/chat/chat-history.inflight.test-support.ts
+++ b/ui/src/pages/chat/chat-history.inflight.test-support.ts
@@ -1,0 +1,70 @@
+import { vi } from "vitest";
+import { extractText } from "../../lib/chat/message-extract.ts";
+import type { ChatHistoryResult, ChatState } from "./chat-history.ts";
+import { makeChatHost } from "./chat-host.test-support.ts";
+import { buildChatItems } from "./chat-thread-build.ts";
+import type { handleAgentEvent, ToolStreamEntry } from "./tool-stream.ts";
+
+export type TestState = ChatState & Parameters<typeof handleAgentEvent>[0];
+type TestSessions = NonNullable<ChatState["sessions"]> &
+  Parameters<typeof handleAgentEvent>[0]["sessions"];
+
+export function createState(result: ChatHistoryResult): TestState {
+  const host = makeChatHost({
+    requestHandlers: { "chat.history": result },
+    sessionKey: "main",
+  });
+  const sessions: TestSessions = {
+    refreshReplacement: vi.fn(async () => undefined),
+    reconcileRunTerminal: vi.fn(),
+  };
+  return {
+    ...host,
+    chatToolMessages: host.chatToolMessages ?? [],
+    chatStreamSegments: host.chatStreamSegments ?? [],
+    connectionEpoch: 1,
+    chatThinkingLevel: null,
+    chatVerboseLevel: null,
+    chatStreamStartedAt: null,
+    sessions,
+    toolStreamById: host.toolStreamById ?? new Map<string, ToolStreamEntry>(),
+    toolStreamOrder: host.toolStreamOrder ?? [],
+    toolStreamSyncTimer: host.toolStreamSyncTimer ?? null,
+    requestUpdate: vi.fn(),
+  };
+}
+
+export function renderedText(state: TestState) {
+  return buildChatItems({
+    paneId: "steer-regression",
+    sessionKey: state.sessionKey,
+    runId: state.chatRunId,
+    messages: state.chatMessages,
+    toolMessages: state.chatToolMessages,
+    streamSegments: state.chatStreamSegments,
+    stream: state.chatStream,
+    streamStartedAt: state.chatStreamStartedAt,
+    showToolCalls: true,
+  }).flatMap((item) =>
+    item.kind === "group"
+      ? item.messages.map(({ message }) => extractText(message)?.trim())
+      : item.kind === "stream"
+        ? [item.text.trim()]
+        : [],
+  );
+}
+
+export function activeHistory(runId: string): ChatHistoryResult {
+  return {
+    messages: [],
+    sessionInfo: {
+      key: "main",
+      kind: "direct",
+      updatedAt: 1,
+      hasActiveRun: true,
+      activeRunIds: [runId],
+      status: "running",
+    },
+    inFlightRun: { runId, text: "" },
+  };
+}

--- a/ui/src/pages/chat/chat-history.inflight.test-support.ts
+++ b/ui/src/pages/chat/chat-history.inflight.test-support.ts
@@ -3,9 +3,12 @@ import { extractText } from "../../lib/chat/message-extract.ts";
 import type { ChatHistoryResult, ChatState } from "./chat-history.ts";
 import { makeChatHost } from "./chat-host.test-support.ts";
 import { buildChatItems } from "./chat-thread-build.ts";
+import type { reconcileChatRunLifecycle } from "./run-lifecycle.ts";
 import type { handleAgentEvent, ToolStreamEntry } from "./tool-stream.ts";
 
-export type TestState = ChatState & Parameters<typeof handleAgentEvent>[0];
+export type TestState = ChatState &
+  Parameters<typeof handleAgentEvent>[0] &
+  Parameters<typeof reconcileChatRunLifecycle>[0];
 type TestSessions = NonNullable<ChatState["sessions"]> &
   Parameters<typeof handleAgentEvent>[0]["sessions"];
 

--- a/ui/src/pages/chat/chat-history.inflight.test.ts
+++ b/ui/src/pages/chat/chat-history.inflight.test.ts
@@ -1,18 +1,20 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
-import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { createInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
 import { handleChatGatewayEvent } from "./chat-gateway.ts";
 import {
+  activeHistory,
+  createState,
+  renderedText,
+  type TestState,
+} from "./chat-history.inflight.test-support.ts";
+import {
   isHiddenAssistantStreamText,
   loadChatHistory,
   type ChatHistoryResult,
-  type ChatState,
 } from "./chat-history.ts";
-import { makeChatHost } from "./chat-host.test-support.ts";
-import { buildChatItems } from "./chat-thread-build.ts";
 import {
   admitInitialUserMessageHandoff,
   getChatSessionProjection,
@@ -23,36 +25,6 @@ import {
 import { prepareInitialUserMessageHandoff } from "./initial-turn-handoff.ts";
 import { applySessionMessagePayload } from "./session-message-apply.ts";
 import { visibleCurrentAssistantStreamTail } from "./stream-reconciliation.ts";
-import { handleAgentEvent, type ToolStreamEntry } from "./tool-stream.ts";
-
-type TestState = ChatState & Parameters<typeof handleAgentEvent>[0];
-type TestSessions = NonNullable<ChatState["sessions"]> &
-  Parameters<typeof handleAgentEvent>[0]["sessions"];
-
-function createState(result: ChatHistoryResult): TestState {
-  const host = makeChatHost({
-    requestHandlers: { "chat.history": result },
-    sessionKey: "main",
-  });
-  const sessions: TestSessions = {
-    refreshReplacement: vi.fn(async () => undefined),
-    reconcileRunTerminal: vi.fn(),
-  };
-  return {
-    ...host,
-    chatToolMessages: host.chatToolMessages ?? [],
-    chatStreamSegments: host.chatStreamSegments ?? [],
-    connectionEpoch: 1,
-    chatThinkingLevel: null,
-    chatVerboseLevel: null,
-    chatStreamStartedAt: null,
-    sessions,
-    toolStreamById: host.toolStreamById ?? new Map<string, ToolStreamEntry>(),
-    toolStreamOrder: host.toolStreamOrder ?? [],
-    toolStreamSyncTimer: host.toolStreamSyncTimer ?? null,
-    requestUpdate: vi.fn(),
-  };
-}
 
 async function loadHistoryWithBrowserTimers(state: TestState): Promise<void> {
   const globalWithWindow = globalThis as typeof globalThis & {
@@ -70,41 +42,6 @@ async function loadHistoryWithBrowserTimers(state: TestState): Promise<void> {
       Reflect.deleteProperty(globalWithWindow, "window");
     }
   }
-}
-
-function renderedText(state: TestState) {
-  return buildChatItems({
-    paneId: "steer-regression",
-    sessionKey: state.sessionKey,
-    runId: state.chatRunId,
-    messages: state.chatMessages,
-    toolMessages: state.chatToolMessages,
-    streamSegments: state.chatStreamSegments,
-    stream: state.chatStream,
-    streamStartedAt: state.chatStreamStartedAt,
-    showToolCalls: true,
-  }).flatMap((item) =>
-    item.kind === "group"
-      ? item.messages.map(({ message }) => extractText(message)?.trim())
-      : item.kind === "stream"
-        ? [item.text.trim()]
-        : [],
-  );
-}
-
-function activeHistory(runId: string): ChatHistoryResult {
-  return {
-    messages: [],
-    sessionInfo: {
-      key: "main",
-      kind: "direct",
-      updatedAt: 1,
-      hasActiveRun: true,
-      activeRunIds: [runId],
-      status: "running",
-    },
-    inFlightRun: { runId, text: "" },
-  };
 }
 
 function failedHistory(): ChatHistoryResult {
@@ -365,159 +302,6 @@ describe("chat history in-flight assistant recovery", () => {
     expect(state.chatStream).toBe("The response survived the reconnect.");
     expect(state.chatStreamStartedAt).toEqual(expect.any(Number));
     expect(state.chatRunStartup).toEqual({ state: "activity", runId: "run-reconnected" });
-  });
-
-  it.each(
-    (["full", "delta"] as const).flatMap((kind) => [
-      {
-        kind,
-        activeRunIds: ["run-next"],
-        expectedRunId: "run-next",
-        evidence: "replacement",
-        liveBeforeSnapshot: false,
-      },
-      {
-        kind,
-        activeRunIds: ["run-next"],
-        expectedRunId: "run-next",
-        evidence: "replacement with live progress",
-        liveBeforeSnapshot: true,
-      },
-      {
-        kind,
-        activeRunIds: ["run-previous", "run-next"],
-        expectedRunId: "run-previous",
-        evidence: "both active",
-        liveBeforeSnapshot: false,
-      },
-      {
-        kind,
-        activeRunIds: undefined,
-        expectedRunId: "run-previous",
-        evidence: "unknown active identities",
-        liveBeforeSnapshot: false,
-      },
-    ]),
-  )(
-    "reconciles a retained run from $kind history with $evidence",
-    async ({ kind, activeRunIds, expectedRunId, liveBeforeSnapshot }) => {
-      const initial = activeHistory("run-previous");
-      initial.sessionId = "retained-session";
-      initial.inFlightRun!.text = "Previous run text.";
-      initial.deltaCursor = kind === "delta" ? "cursor-previous" : undefined;
-      const state = createState(initial);
-      state.chatMessagesBySession = new Map();
-      const request = vi.fn().mockResolvedValue(initial);
-      state.client = { request } as unknown as GatewayBrowserClient;
-      await loadChatHistory(state);
-      state.chatStreamSegments = [{ runId: "run-previous", text: "Earlier commentary.", ts: 1 }];
-
-      const next = activeHistory("run-next");
-      next.sessionId = "retained-session";
-      next.sessionInfo!.activeRunIds = activeRunIds;
-      next.inFlightRun!.text = "Next run text.";
-      const response = {
-        ...next,
-        ...(kind === "delta" ? { kind: "delta", deltaCursor: "cursor-next" } : {}),
-      };
-      const pending = createDeferred<typeof response>();
-      request.mockReturnValue(pending.promise);
-      const loading = loadChatHistory(state);
-      expect(request).toHaveBeenLastCalledWith(
-        "chat.history",
-        expect.objectContaining(
-          kind === "delta" ? { cursor: "cursor-previous" } : { sessionKey: "main" },
-        ),
-      );
-      if (liveBeforeSnapshot) {
-        handleChatGatewayEvent(state, {
-          runId: "run-next",
-          sessionKey: "main",
-          state: "delta",
-          message: { role: "assistant", content: "Next run text. Earlier live progress." },
-        });
-      }
-      pending.resolve(response);
-      await loading;
-
-      expect(state.chatRunId).toBe(expectedRunId);
-      if (expectedRunId === "run-previous") {
-        expect(state.chatStream).toBe("Previous run text.");
-        return;
-      }
-      expect(state.chatStream).toBe(
-        liveBeforeSnapshot ? "Next run text. Earlier live progress." : "Next run text.",
-      );
-      expect(state.chatStreamSegments).toEqual([]);
-      handleChatGatewayEvent(state, {
-        runId: "run-next",
-        sessionKey: "main",
-        state: "delta",
-        message: { role: "assistant", content: "Next run text. Continuing live." },
-      });
-      expect(state.chatStream).toBe("Next run text. Continuing live.");
-      expect(renderedText(state)).not.toContain("Earlier commentary.");
-    },
-  );
-
-  it("does not replace a retained run that progressed while its history was pending", async () => {
-    const response = createDeferred<ChatHistoryResult>();
-    const state = createState(activeHistory("run-next"));
-    state.client = { request: vi.fn(() => response.promise) } as unknown as GatewayBrowserClient;
-    handleChatGatewayEvent(state, {
-      runId: "run-previous",
-      sessionKey: "main",
-      state: "delta",
-      deltaText: "Still working.",
-    });
-    const loading = loadChatHistory(state);
-    handleChatGatewayEvent(state, {
-      runId: "run-previous",
-      sessionKey: "main",
-      state: "delta",
-      message: { role: "assistant", content: "Still working. Newer live progress." },
-    });
-    response.resolve(activeHistory("run-next"));
-    await loading;
-    expect(state.chatRunId).toBe("run-previous");
-    expect(state.chatStream).toBe("Still working. Newer live progress.");
-  });
-
-  it("preserves replacement-run tool progress newer than its recovery snapshot", async () => {
-    const response = createDeferred<ChatHistoryResult>();
-    const history = activeHistory("run-next");
-    const toolEvent = {
-      runId: "run-next",
-      seq: 1,
-      stream: "tool",
-      ts: 1,
-      sessionKey: "main",
-      data: { toolCallId: "next-tool", name: "read", phase: "result", result: "Earlier output" },
-    };
-    history.inFlightRun!.events = [toolEvent];
-    const state = createState(history);
-    state.client = { request: vi.fn(() => response.promise) } as unknown as GatewayBrowserClient;
-    handleChatGatewayEvent(state, {
-      runId: "run-previous",
-      sessionKey: "main",
-      state: "delta",
-      deltaText: "Previous run text.",
-    });
-    const loading = loadChatHistory(state);
-    handleAgentEvent(state, {
-      ...toolEvent,
-      seq: 2,
-      data: { ...toolEvent.data, result: "Newer output" },
-    });
-    response.resolve(history);
-    await loading;
-    expect(state.chatRunId).toBe("run-next");
-    expect(state.chatToolMessages).toHaveLength(1);
-    expect(state.chatToolMessages[0]).toMatchObject({
-      runId: "run-next",
-      toolCallId: "next-tool",
-      content: expect.arrayContaining([expect.objectContaining({ text: "Newer output" })]),
-    });
   });
 
   it("restores the authoritative run start even before assistant text exists", async () => {

--- a/ui/src/pages/chat/chat-history.inflight.test.ts
+++ b/ui/src/pages/chat/chat-history.inflight.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { createInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
@@ -364,6 +365,159 @@ describe("chat history in-flight assistant recovery", () => {
     expect(state.chatStream).toBe("The response survived the reconnect.");
     expect(state.chatStreamStartedAt).toEqual(expect.any(Number));
     expect(state.chatRunStartup).toEqual({ state: "activity", runId: "run-reconnected" });
+  });
+
+  it.each(
+    (["full", "delta"] as const).flatMap((kind) => [
+      {
+        kind,
+        activeRunIds: ["run-next"],
+        expectedRunId: "run-next",
+        evidence: "replacement",
+        liveBeforeSnapshot: false,
+      },
+      {
+        kind,
+        activeRunIds: ["run-next"],
+        expectedRunId: "run-next",
+        evidence: "replacement with live progress",
+        liveBeforeSnapshot: true,
+      },
+      {
+        kind,
+        activeRunIds: ["run-previous", "run-next"],
+        expectedRunId: "run-previous",
+        evidence: "both active",
+        liveBeforeSnapshot: false,
+      },
+      {
+        kind,
+        activeRunIds: undefined,
+        expectedRunId: "run-previous",
+        evidence: "unknown active identities",
+        liveBeforeSnapshot: false,
+      },
+    ]),
+  )(
+    "reconciles a retained run from $kind history with $evidence",
+    async ({ kind, activeRunIds, expectedRunId, liveBeforeSnapshot }) => {
+      const initial = activeHistory("run-previous");
+      initial.sessionId = "retained-session";
+      initial.inFlightRun!.text = "Previous run text.";
+      initial.deltaCursor = kind === "delta" ? "cursor-previous" : undefined;
+      const state = createState(initial);
+      state.chatMessagesBySession = new Map();
+      const request = vi.fn().mockResolvedValue(initial);
+      state.client = { request } as unknown as GatewayBrowserClient;
+      await loadChatHistory(state);
+      state.chatStreamSegments = [{ runId: "run-previous", text: "Earlier commentary.", ts: 1 }];
+
+      const next = activeHistory("run-next");
+      next.sessionId = "retained-session";
+      next.sessionInfo!.activeRunIds = activeRunIds;
+      next.inFlightRun!.text = "Next run text.";
+      const response = {
+        ...next,
+        ...(kind === "delta" ? { kind: "delta", deltaCursor: "cursor-next" } : {}),
+      };
+      const pending = createDeferred<typeof response>();
+      request.mockReturnValue(pending.promise);
+      const loading = loadChatHistory(state);
+      expect(request).toHaveBeenLastCalledWith(
+        "chat.history",
+        expect.objectContaining(
+          kind === "delta" ? { cursor: "cursor-previous" } : { sessionKey: "main" },
+        ),
+      );
+      if (liveBeforeSnapshot) {
+        handleChatGatewayEvent(state, {
+          runId: "run-next",
+          sessionKey: "main",
+          state: "delta",
+          message: { role: "assistant", content: "Next run text. Earlier live progress." },
+        });
+      }
+      pending.resolve(response);
+      await loading;
+
+      expect(state.chatRunId).toBe(expectedRunId);
+      if (expectedRunId === "run-previous") {
+        expect(state.chatStream).toBe("Previous run text.");
+        return;
+      }
+      expect(state.chatStream).toBe(
+        liveBeforeSnapshot ? "Next run text. Earlier live progress." : "Next run text.",
+      );
+      expect(state.chatStreamSegments).toEqual([]);
+      handleChatGatewayEvent(state, {
+        runId: "run-next",
+        sessionKey: "main",
+        state: "delta",
+        message: { role: "assistant", content: "Next run text. Continuing live." },
+      });
+      expect(state.chatStream).toBe("Next run text. Continuing live.");
+      expect(renderedText(state)).not.toContain("Earlier commentary.");
+    },
+  );
+
+  it("does not replace a retained run that progressed while its history was pending", async () => {
+    const response = createDeferred<ChatHistoryResult>();
+    const state = createState(activeHistory("run-next"));
+    state.client = { request: vi.fn(() => response.promise) } as unknown as GatewayBrowserClient;
+    handleChatGatewayEvent(state, {
+      runId: "run-previous",
+      sessionKey: "main",
+      state: "delta",
+      deltaText: "Still working.",
+    });
+    const loading = loadChatHistory(state);
+    handleChatGatewayEvent(state, {
+      runId: "run-previous",
+      sessionKey: "main",
+      state: "delta",
+      message: { role: "assistant", content: "Still working. Newer live progress." },
+    });
+    response.resolve(activeHistory("run-next"));
+    await loading;
+    expect(state.chatRunId).toBe("run-previous");
+    expect(state.chatStream).toBe("Still working. Newer live progress.");
+  });
+
+  it("preserves replacement-run tool progress newer than its recovery snapshot", async () => {
+    const response = createDeferred<ChatHistoryResult>();
+    const history = activeHistory("run-next");
+    const toolEvent = {
+      runId: "run-next",
+      seq: 1,
+      stream: "tool",
+      ts: 1,
+      sessionKey: "main",
+      data: { toolCallId: "next-tool", name: "read", phase: "result", result: "Earlier output" },
+    };
+    history.inFlightRun!.events = [toolEvent];
+    const state = createState(history);
+    state.client = { request: vi.fn(() => response.promise) } as unknown as GatewayBrowserClient;
+    handleChatGatewayEvent(state, {
+      runId: "run-previous",
+      sessionKey: "main",
+      state: "delta",
+      deltaText: "Previous run text.",
+    });
+    const loading = loadChatHistory(state);
+    handleAgentEvent(state, {
+      ...toolEvent,
+      seq: 2,
+      data: { ...toolEvent.data, result: "Newer output" },
+    });
+    response.resolve(history);
+    await loading;
+    expect(state.chatRunId).toBe("run-next");
+    expect(state.chatToolMessages).toHaveLength(1);
+    expect(state.chatToolMessages[0]).toMatchObject({
+      runId: "run-next",
+      toolCallId: "next-tool",
+      content: expect.arrayContaining([expect.objectContaining({ text: "Newer output" })]),
+    });
   });
 
   it("restores the authoritative run start even before assistant text exists", async () => {

--- a/ui/src/pages/chat/chat-history.replacement-run.test.ts
+++ b/ui/src/pages/chat/chat-history.replacement-run.test.ts
@@ -1,0 +1,280 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { handleChatGatewayEvent } from "./chat-gateway.ts";
+import { activeHistory, createState, renderedText } from "./chat-history.inflight.test-support.ts";
+import { loadChatHistory, type ChatHistoryResult } from "./chat-history.ts";
+import { handleAgentEvent } from "./tool-stream.ts";
+
+describe("chat history replacement-run recovery", () => {
+  it.each(
+    (["full", "delta"] as const).flatMap((kind) => [
+      {
+        kind,
+        activeRunIds: ["run-next"],
+        expectedRunId: "run-next",
+        evidence: "replacement",
+        liveBeforeSnapshot: false,
+      },
+      {
+        kind,
+        activeRunIds: ["run-next"],
+        expectedRunId: "run-next",
+        evidence: "replacement with live progress",
+        liveBeforeSnapshot: true,
+      },
+      {
+        kind,
+        activeRunIds: ["run-previous", "run-next"],
+        expectedRunId: "run-previous",
+        evidence: "both active",
+        liveBeforeSnapshot: false,
+      },
+      {
+        kind,
+        activeRunIds: undefined,
+        expectedRunId: "run-previous",
+        evidence: "unknown active identities",
+        liveBeforeSnapshot: false,
+      },
+    ]),
+  )(
+    "reconciles a retained run from $kind history with $evidence",
+    async ({ kind, activeRunIds, expectedRunId, liveBeforeSnapshot }) => {
+      const initial = activeHistory("run-previous");
+      initial.sessionId = "retained-session";
+      initial.sessionInfo!.activeLeafEntryId = "previous-leaf";
+      initial.inFlightRun!.text = "Previous run text.";
+      initial.deltaCursor = kind === "delta" ? "cursor-previous" : undefined;
+      const state = createState(initial);
+      state.chatMessagesBySession = new Map();
+      const request = vi.fn().mockResolvedValue(initial);
+      state.client = { request } as unknown as GatewayBrowserClient;
+      await loadChatHistory(state);
+      state.chatStreamSegments = [{ runId: "run-previous", text: "Earlier commentary.", ts: 1 }];
+
+      const next = activeHistory("run-next");
+      next.sessionId = "retained-session";
+      next.sessionInfo!.activeLeafEntryId = kind === "full" ? "next-leaf" : "previous-leaf";
+      next.sessionInfo!.activeRunIds = activeRunIds;
+      next.inFlightRun!.text = "Next run text.";
+      const response = {
+        ...next,
+        ...(kind === "delta" ? { kind: "delta", deltaCursor: "cursor-next" } : {}),
+      };
+      const pending = createDeferred<typeof response>();
+      request.mockReturnValue(pending.promise);
+      const loading = loadChatHistory(state);
+      expect(request).toHaveBeenLastCalledWith(
+        "chat.history",
+        expect.objectContaining(
+          kind === "delta" ? { cursor: "cursor-previous" } : { sessionKey: "main" },
+        ),
+      );
+      if (liveBeforeSnapshot) {
+        handleChatGatewayEvent(state, {
+          runId: "run-next",
+          sessionKey: "main",
+          state: "delta",
+          message: { role: "assistant", content: "Next run text. Earlier live progress." },
+        });
+      }
+      pending.resolve(response);
+      await loading;
+
+      expect(state.chatRunId).toBe(expectedRunId);
+      if (expectedRunId === "run-previous") {
+        expect(state.chatStream).toBe("Previous run text.");
+        return;
+      }
+      expect(state.chatStream).toBe(
+        liveBeforeSnapshot ? "Next run text. Earlier live progress." : "Next run text.",
+      );
+      expect(state.chatStreamSegments).toEqual([]);
+      handleChatGatewayEvent(state, {
+        runId: "run-next",
+        sessionKey: "main",
+        state: "delta",
+        message: { role: "assistant", content: "Next run text. Continuing live." },
+      });
+      expect(state.chatStream).toBe("Next run text. Continuing live.");
+      expect(renderedText(state)).not.toContain("Earlier commentary.");
+    },
+  );
+
+  it("does not replace a retained run that progressed while its history was pending", async () => {
+    const response = createDeferred<ChatHistoryResult>();
+    const state = createState(activeHistory("run-next"));
+    state.client = { request: vi.fn(() => response.promise) } as unknown as GatewayBrowserClient;
+    handleChatGatewayEvent(state, {
+      runId: "run-previous",
+      sessionKey: "main",
+      state: "delta",
+      deltaText: "Still working.",
+    });
+    const loading = loadChatHistory(state);
+    handleChatGatewayEvent(state, {
+      runId: "run-previous",
+      sessionKey: "main",
+      state: "delta",
+      message: { role: "assistant", content: "Still working. Newer live progress." },
+    });
+    response.resolve(activeHistory("run-next"));
+    await loading;
+    expect(state.chatRunId).toBe("run-previous");
+    expect(state.chatStream).toBe("Still working. Newer live progress.");
+  });
+
+  it.each(["before", "during"] as const)(
+    "does not revive a replacement that completed %s history when its leaf advances",
+    async (timing) => {
+      const initial = activeHistory("run-previous");
+      initial.sessionId = "retained-session";
+      initial.sessionInfo!.activeLeafEntryId = "previous-leaf";
+      initial.inFlightRun!.text = "Previous run text.";
+      const state = createState(initial);
+      const request = vi.fn().mockResolvedValue(initial);
+      state.client = { request } as unknown as GatewayBrowserClient;
+      await loadChatHistory(state);
+
+      const next = activeHistory("run-next");
+      next.sessionId = "retained-session";
+      next.sessionInfo!.activeLeafEntryId = "next-leaf";
+      next.inFlightRun!.text = "Stale replacement progress.";
+      const response = createDeferred<ChatHistoryResult>();
+      request.mockReturnValue(response.promise);
+      const finishReplacement = () =>
+        handleChatGatewayEvent(state, {
+          runId: "run-next",
+          sessionKey: "main",
+          state: "final",
+          message: { role: "assistant", content: "Replacement completed." },
+        });
+      if (timing === "before") {
+        finishReplacement();
+      }
+      const loading = loadChatHistory(state);
+      if (timing === "during") {
+        finishReplacement();
+      }
+      response.resolve(next);
+      await loading;
+
+      expect(state.chatDisplayedLeafEntryId).toBe("next-leaf");
+      expect(state.chatRunId).toBe("run-previous");
+      expect(state.chatStream).toBe("Previous run text.");
+
+      await loadChatHistory(state);
+      expect(state.chatRunId).toBe("run-previous");
+      expect(state.chatStream).toBe("Previous run text.");
+
+      const latest = activeHistory("run-latest");
+      latest.sessionId = "retained-session";
+      latest.sessionInfo!.activeLeafEntryId = "latest-leaf";
+      latest.inFlightRun!.text = "Latest run progress.";
+      request.mockResolvedValue(latest);
+      await loadChatHistory(state);
+      expect(state.chatRunId).toBe("run-latest");
+
+      request.mockResolvedValue(next);
+      await loadChatHistory(state);
+      expect(state.chatRunId).toBe("run-latest");
+      expect(state.chatStream).toBe("Latest run progress.");
+      finishReplacement();
+      handleChatGatewayEvent(state, {
+        runId: "run-next",
+        sessionKey: "main",
+        state: "error",
+        errorMessage: "Old branch diagnostic.",
+      });
+      expect(renderedText(state)).not.toContain("Replacement completed.");
+      expect(state.chatRunError).toBeNull();
+    },
+  );
+
+  it("preserves replacement-run tool progress newer than its recovery snapshot", async () => {
+    const response = createDeferred<ChatHistoryResult>();
+    const history = activeHistory("run-next");
+    const toolEvent = {
+      runId: "run-next",
+      seq: 1,
+      stream: "tool",
+      ts: 1,
+      sessionKey: "main",
+      data: { toolCallId: "next-tool", name: "read", phase: "result", result: "Earlier output" },
+    };
+    history.inFlightRun!.events = [toolEvent];
+    const state = createState(history);
+    state.client = { request: vi.fn(() => response.promise) } as unknown as GatewayBrowserClient;
+    handleChatGatewayEvent(state, {
+      runId: "run-previous",
+      sessionKey: "main",
+      state: "delta",
+      deltaText: "Previous run text.",
+    });
+    const loading = loadChatHistory(state);
+    handleAgentEvent(state, {
+      ...toolEvent,
+      seq: 2,
+      data: { ...toolEvent.data, result: "Newer output" },
+    });
+    response.resolve(history);
+    await loading;
+    expect(state.chatRunId).toBe("run-next");
+    expect(state.chatToolMessages).toHaveLength(1);
+    expect(state.chatToolMessages[0]).toMatchObject({
+      runId: "run-next",
+      toolCallId: "next-tool",
+      content: expect.arrayContaining([expect.objectContaining({ text: "Newer output" })]),
+    });
+  });
+
+  it.each([
+    { runId: "run-previous", phase: "start", retained: false },
+    { runId: "run-next", phase: "start", retained: true },
+    { runId: "run-next", phase: "end", retained: true },
+  ])("scopes pending-history compaction $phase from $runId", async ({ runId, phase, retained }) => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    vi.stubGlobal("window", globalThis);
+    try {
+      const response = createDeferred<ChatHistoryResult>();
+      const history = activeHistory("run-next");
+      history.inFlightRun!.events = [];
+      const event = {
+        runId,
+        seq: 1,
+        stream: "compaction",
+        ts: 1,
+        sessionKey: "main",
+        data: { phase: "start" },
+      };
+      const state = createState(history);
+      state.client = { request: vi.fn(() => response.promise) } as unknown as GatewayBrowserClient;
+      handleChatGatewayEvent(state, {
+        runId: "run-previous",
+        sessionKey: "main",
+        state: "delta",
+        deltaText: "Previous run text.",
+      });
+      const loading = loadChatHistory(state);
+      handleAgentEvent(state, { ...event, seq: 2, data: { phase, completed: phase === "end" } });
+      const indicator = state.compactionStatus;
+      const timer = state.compactionClearTimer;
+      expect(indicator?.runId).toBe(runId);
+      expect(timer).not.toBeNull();
+      response.resolve(history);
+      await loading;
+
+      expect(state.chatRunId).toBe("run-next");
+      expect(state.compactionStatus).toBe(retained ? indicator : null);
+      expect(state.compactionClearTimer).toBe(retained ? timer : null);
+      vi.advanceTimersByTime(phase === "end" ? 5_000 : 5 * 60_000);
+      expect(state.compactionStatus).toBeNull();
+      expect(state.compactionClearTimer).toBeNull();
+    } finally {
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -435,11 +435,8 @@ function runProjectionsUnchanged(
   current: ReturnType<typeof getChatSessionProjection>["runs"],
   continuingRunId?: string,
 ): boolean {
-  const previousEntries = Object.entries(previous).filter(([runId]) => runId !== continuingRunId);
-  return (
-    previousEntries.length ===
-      Object.keys(current).filter((runId) => runId !== continuingRunId).length &&
-    previousEntries.every(([runId, run]) => current[runId] === run)
+  return [...new Set([...Object.keys(previous), ...Object.keys(current)])].every(
+    (runId) => runId === continuingRunId || previous[runId] === current[runId],
   );
 }
 
@@ -584,7 +581,7 @@ function applyHistoryRunSnapshot(params: {
   const snapshotStartedAt =
     typeof run.startedAt === "number" && Number.isFinite(run.startedAt) ? run.startedAt : null;
   const liveText = mergeInFlightAssistantText(
-    resolveInFlightAssistantText(extractText(projectedInFlightRun?.message)),
+    resolveInFlightAssistantText(extractText(runProjectionsBeforeApply[inFlightRunId]?.message)),
     retainsLiveStream ? activeStreamBeforeReset : null,
   );
   state.chatStream = mergeInFlightAssistantText(resolveInFlightAssistantText(run.text), liveText);
@@ -2050,8 +2047,8 @@ async function loadChatHistoryUncached(
       throw new Error("chat history page request returned a cursor reset");
     }
     const res = response;
-    // Fence concurrent run lifecycle before applying the response. A remount
-    // may replace the map itself, so compare its canonical run entries.
+    // Capture live run facts before history can reseed a different leaf.
+    // Compare canonical identities to fence concurrent lifecycle changes.
     const runProjectionsBeforeApply = readChatRunProjections(state, sessionKey, requestAgentId);
     const messages = Array.isArray(res.messages) ? res.messages : [];
     const nextPagination = resolveChatHistoryPagination(res);

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -430,31 +430,15 @@ function resolveInFlightAssistantText(bufferedText: unknown): string | null {
     : null;
 }
 
-function onlyInFlightRunProjectionChanged(
-  previous: ReturnType<typeof getChatSessionProjection>["runs"],
-  current: ReturnType<typeof getChatSessionProjection>["runs"],
-  runId: string,
-): boolean {
-  for (const [previousRunId, run] of Object.entries(previous)) {
-    if (previousRunId !== runId && current[previousRunId] !== run) {
-      return false;
-    }
-  }
-  for (const [currentRunId, run] of Object.entries(current)) {
-    if (currentRunId !== runId && previous[currentRunId] !== run) {
-      return false;
-    }
-  }
-  return true;
-}
-
 function runProjectionsUnchanged(
   previous: ReturnType<typeof getChatSessionProjection>["runs"],
   current: ReturnType<typeof getChatSessionProjection>["runs"],
+  continuingRunId?: string,
 ): boolean {
-  const previousEntries = Object.entries(previous);
+  const previousEntries = Object.entries(previous).filter(([runId]) => runId !== continuingRunId);
   return (
-    previousEntries.length === Object.keys(current).length &&
+    previousEntries.length ===
+      Object.keys(current).filter((runId) => runId !== continuingRunId).length &&
     previousEntries.every(([runId, run]) => current[runId] === run)
   );
 }
@@ -558,7 +542,7 @@ function applyHistoryRunSnapshot(params: {
   const sameRunContinued =
     state.chatRunId === inFlightRunId &&
     projectedInFlightRun?.status === "streaming" &&
-    onlyInFlightRunProjectionChanged(previousRunProjections, currentRunProjections, inFlightRunId);
+    runProjectionsUnchanged(previousRunProjections, currentRunProjections, inFlightRunId);
   const retainsLiveStream =
     sameRunContinued ||
     (state.chatRunId === inFlightRunId &&
@@ -574,13 +558,23 @@ function applyHistoryRunSnapshot(params: {
   const canAdoptInFlightRun =
     inFlightRunIsActive &&
     ((resetStream &&
-      !state.chatRunId &&
-      runProjectionsUnchanged(previousRunProjections, runProjectionsBeforeApply)) ||
+      (!state.chatRunId ||
+        (Array.isArray(activeRunIds) && !activeRunIds.includes(state.chatRunId))) &&
+      runProjectionsUnchanged(previousRunProjections, runProjectionsBeforeApply, inFlightRunId)) ||
       sameRunContinued);
   if (canAdoptInFlightRun) {
     // Canonical run projections change on every live delta or terminal.
     // Their identity fences ABA races where a run starts and finishes while
     // history is pending; deltas from this same live run must still merge.
+    if (state.chatRunId && state.chatRunId !== inFlightRunId) {
+      // Only a complete active-run set can retire the retained owner; omitted IDs are unknown.
+      reconcileChatRunLifecycle(state, {
+        clearLocalRun: true,
+        clearChatStream: true,
+        clearToolStreamForRun: true,
+        requestUpdate: false,
+      });
+    }
     adoptStartedChatRun(state, inFlightRunId, Date.now());
     state.chatRunSessionAbortable = run?.sessionAbortable === true;
   }
@@ -589,12 +583,10 @@ function applyHistoryRunSnapshot(params: {
   }
   const snapshotStartedAt =
     typeof run.startedAt === "number" && Number.isFinite(run.startedAt) ? run.startedAt : null;
-  const liveText = sameRunContinued
-    ? mergeInFlightAssistantText(
-        resolveInFlightAssistantText(extractText(projectedInFlightRun?.message)),
-        activeStreamBeforeReset,
-      )
-    : activeStreamBeforeReset;
+  const liveText = mergeInFlightAssistantText(
+    resolveInFlightAssistantText(extractText(projectedInFlightRun?.message)),
+    retainsLiveStream ? activeStreamBeforeReset : null,
+  );
   state.chatStream = mergeInFlightAssistantText(resolveInFlightAssistantText(run.text), liveText);
   state.chatStreamStartedAt = snapshotStartedAt ?? state.chatStreamStartedAt ?? Date.now();
   // A retained pane gets its boundary from session.message. Only fresh adoption

--- a/ui/src/pages/chat/history-merge.test.ts
+++ b/ui/src/pages/chat/history-merge.test.ts
@@ -304,11 +304,17 @@ describe("pane-owned canonical session projection", () => {
   it.each([
     {
       name: "session",
-      previous: { sessionKey: "agent:main:previous", sessionId: "previous-session" },
-      next: { sessionKey: "agent:main:next", sessionId: "next-session" },
+      previous: { sessionKey: "agent:main:previous", sessionId: "shared-session" },
+      next: { sessionKey: "agent:main:next", sessionId: "shared-session" },
+    },
+    {
+      name: "session identity",
+      previous: { sessionKey: "main", sessionId: "previous-session" },
+      next: { sessionKey: "main", sessionId: "next-session" },
     },
     {
       name: "active branch",
+      retainsTerminal: true,
       previous: {
         sessionKey: "agent:main:shared",
         sessionId: "shared-session",
@@ -322,6 +328,7 @@ describe("pane-owned canonical session projection", () => {
     },
     {
       name: "cleared branch",
+      retainsTerminal: true,
       previous: {
         sessionKey: "agent:main:shared",
         sessionId: "shared-session",
@@ -343,37 +350,89 @@ describe("pane-owned canonical session projection", () => {
       previous: { sessionKey: "main", agentId: "first" },
       next: { sessionKey: "main", agentId: "second" },
     },
-  ])("drops stale live and run provenance when the $name changes", ({ previous, next }) => {
-    const owner = {};
-    const liveUser = createHistoryMessage("user", "obsolete turn", {
-      id: "obsolete-user",
-      seq: 1,
-    });
-    const running = reduceSessionProjection(projectLiveMessage(owner, liveUser, previous), {
-      type: "runDelta",
-      runId: "obsolete-run",
-      scope: previous,
-    });
-    setChatSessionProjection(owner, running);
-    setChatRunOwner(owner, "obsolete-run");
+  ])(
+    "resets transcript and live ownership when the $name changes",
+    ({ previous, next, retainsTerminal }) => {
+      const owner = {};
+      const liveUser = createHistoryMessage("user", "obsolete turn", {
+        id: "obsolete-user",
+        seq: 1,
+      });
+      const running = reduceSessionProjection(projectLiveMessage(owner, liveUser, previous), {
+        type: "runDelta",
+        runId: "obsolete-run",
+        scope: previous,
+      });
+      const pending = reduceSessionProjection(running, {
+        type: "sendPending",
+        runId: "pending-run",
+        message: createHistoryMessage("user", "pending old branch input", {
+          idempotencyKey: "pending-run:user",
+        }),
+        scope: previous,
+      });
+      const terminal = reduceSessionProjection(pending, {
+        type: "runTerminal",
+        runId: "retired-run",
+        status: "completed",
+        message: createHistoryMessage("assistant", "old branch reply"),
+        scope: previous,
+      });
+      setChatSessionProjection(owner, terminal);
+      setChatRunOwner(owner, "obsolete-run");
 
-    const projection = getChatSessionProjection(owner, [], next);
+      const projection = getChatSessionProjection(owner, [], next);
 
-    expect(projection.messages).toEqual([]);
-    expect(projection.runs).toEqual({});
-    expect(projection.scope).toEqual(next);
-    expect(getChatRunOwner(owner)).toBeUndefined();
-  });
+      expect(projection.messages).toEqual([]);
+      expect(projection.entries).toEqual([]);
+      expect(projection.runs).toEqual(
+        retainsTerminal ? { "retired-run": terminal.runs["retired-run"] } : {},
+      );
+      if (retainsTerminal) {
+        expect(projection.runs["retired-run"]).toBe(terminal.runs["retired-run"]);
+      }
+      expect(projection.scope).toEqual(next);
+      expect(getChatRunOwner(owner)).toBeUndefined();
+    },
+  );
 
   it("retires run display ownership when the same session is reset", () => {
     const owner = { sessionKey: "agent:main:shared", chatMessages: [] as unknown[] };
     reduceChatSessionProjection(owner, { type: "runDelta", runId: "before-reset" });
+    reduceChatSessionProjection(owner, {
+      type: "runTerminal",
+      runId: "retired-before-reset",
+      status: "completed",
+    });
     setChatRunOwner(owner, "before-reset");
 
     reduceChatSessionProjection(owner, { type: "sessionReset" });
 
     expect(getChatRunOwner(owner)).toBeUndefined();
     expect(getChatSessionProjection(owner, owner.chatMessages).runs).toEqual({});
+  });
+
+  it("retains known lifecycle scope through a leaf advance before a later lifecycle reset", () => {
+    const owner = {};
+    const previous = { sessionKey: "main", lifecycleRevision: 1, activeLeafEntryId: "old-leaf" };
+    setChatSessionProjection(
+      owner,
+      reduceSessionProjection(getChatSessionProjection(owner, [], previous), {
+        type: "runTerminal",
+        runId: "retired-run",
+        status: "completed",
+        scope: previous,
+      }),
+    );
+    const advanced = getChatSessionProjection(owner, [], {
+      sessionKey: "main",
+      activeLeafEntryId: "new-leaf",
+    });
+    expect(advanced.scope.lifecycleRevision).toBe(1);
+    expect(advanced.runs["retired-run"]?.status).toBe("completed");
+    expect(
+      getChatSessionProjection(owner, [], { ...advanced.scope, lifecycleRevision: 2 }).runs,
+    ).toEqual({});
   });
 
   it("retains a proven live branch when another consumer omits optional scope", () => {

--- a/ui/src/pages/chat/history-merge.ts
+++ b/ui/src/pages/chat/history-merge.ts
@@ -68,10 +68,14 @@ export function readChatSessionProjectionScope(
 function chatProjectionScopeChanged(
   previous: SessionProjectionScope,
   scope: SessionProjectionScope,
+  ignoredKey?: (typeof CHAT_PROJECTION_SCOPE_KEYS)[number],
 ) {
   return CHAT_PROJECTION_SCOPE_KEYS.some(
     (key) =>
-      Object.hasOwn(scope, key) && previous[key] !== undefined && previous[key] !== scope[key],
+      key !== ignoredKey &&
+      Object.hasOwn(scope, key) &&
+      previous[key] !== undefined &&
+      previous[key] !== scope[key],
   );
 }
 
@@ -82,9 +86,16 @@ export function getChatSessionProjection(
   scope: SessionProjectionScope = {},
 ): SessionProjectionState {
   const current = chatSessionProjections.get(owner);
-  const scopeChanged = current !== undefined && chatProjectionScopeChanged(current.scope, scope);
-  if (!current || scopeChanged) {
+  if (!current || chatProjectionScopeChanged(current.scope, scope)) {
     const projection = createSessionProjection(scope, messages);
+    // A new leaf drops transcript/live provenance. Retired runs remain replay
+    // fences within this session lifecycle, without reclaiming display ownership.
+    if (current && !chatProjectionScopeChanged(current.scope, scope, "activeLeafEntryId")) {
+      projection.scope = { ...current.scope, ...scope };
+      projection.runs = Object.fromEntries(
+        Object.entries(current.runs).filter(([, run]) => run.status !== "streaming"),
+      );
+    }
     setChatSessionProjection(owner, projection);
     return projection;
   }

--- a/ui/src/pages/chat/run-lifecycle.test.ts
+++ b/ui/src/pages/chat/run-lifecycle.test.ts
@@ -332,6 +332,44 @@ describe("reconcileChatRunLifecycle yielded parent", () => {
 });
 
 describe("reconcileChatRunLifecycle indicators", () => {
+  it.each([
+    { indicatorRunId: "r1", clearToolStream: false, retained: false },
+    { indicatorRunId: null, clearToolStream: false, retained: false },
+    { indicatorRunId: "r2", clearToolStream: false, retained: true },
+    { indicatorRunId: "session-operation", clearToolStream: false, retained: true },
+    { indicatorRunId: "r2", clearToolStream: true, retained: false },
+    { indicatorRunId: "session-operation", clearToolStream: true, retained: false },
+  ])(
+    "scopes compaction $indicatorRunId with full cleanup $clearToolStream",
+    ({ indicatorRunId, clearToolStream, retained }) => {
+      vi.useFakeTimers();
+      try {
+        const expire = vi.fn();
+        const timer = setTimeout(expire, 5_000);
+        const indicator = {
+          phase: "active" as const,
+          runId: indicatorRunId,
+          startedAt: 1,
+          completedAt: null,
+        };
+        const host = makeHost({
+          chatRunId: "r1",
+          compactionStatus: indicator,
+          compactionClearTimer: timer,
+        });
+
+        reconcileChatRunLifecycle(host, { runId: "r1", clearToolStream });
+
+        expect(host.compactionStatus).toBe(retained ? indicator : null);
+        expect(host.compactionClearTimer).toBe(retained ? timer : null);
+        vi.advanceTimersByTime(5_000);
+        expect(expire).toHaveBeenCalledTimes(retained ? 1 : 0);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
   it("clears run-owned transient indicators on terminal run end", () => {
     const host = makeHost({
       chatRunId: "r1",

--- a/ui/src/pages/chat/run-lifecycle.ts
+++ b/ui/src/pages/chat/run-lifecycle.ts
@@ -415,9 +415,9 @@ function clearRunIndicators(host: RunLifecycleHost, runId?: string | null) {
   if (!runId || host.chatRunStartup?.runId === runId) {
     host.chatRunStartup = null;
   }
-  clearTimer(host.compactionClearTimer);
-  host.compactionClearTimer = null;
-  if (host.compactionStatus) {
+  if (!runId || !host.compactionStatus?.runId || host.compactionStatus.runId === runId) {
+    clearTimer(host.compactionClearTimer);
+    host.compactionClearTimer = null;
     host.compactionStatus = null;
   }
   clearTimer(host.fallbackClearTimer);
@@ -507,7 +507,7 @@ export function reconcileChatRunLifecycle(host: RunLifecycleHost, options: Recon
   const sessionKey = toSessionKey(options.sessionKey) ?? host.sessionKey;
 
   if (options.clearIndicators ?? true) {
-    clearRunIndicators(host, runId);
+    clearRunIndicators(host, options.clearToolStream ? null : runId);
   }
   if (options.clearChatStream) {
     host.chatStream = null;


### PR DESCRIPTION
Closes #133262

## What Problem This Solves

After a socket interruption, Control UI could keep displaying run A even when the Gateway reported that A had ended and replacement run B was active. The pane ignored B’s subsequent progress and kept Stop bound to A.

## Why This Change Was Made

The history owner now retires A through the canonical run lifecycle before adopting B, only when a complete active-run list excludes A. Omitted identities remain unknown, both-active snapshots preserve A, and other live-run changes retain the existing request and projection identity guards.

Full history can advance the transcript leaf during this handover. The pane projection owner now preserves only canonical retired-run records across a leaf change within the same session, agent and lifecycle. Those records fence delayed terminal replays without retaining old transcript entries, pending sends, live streams or display ownership. Explicit reset and known session/agent/lifecycle changes still clear everything. Current terminal status controls admission; exact B text captured before history application preserves live progress across leaf replacement.

Cleanup now scopes compaction status and its expiry timer to the retired run, as it already does for tool and approval state. A newer B compaction indicator survives A’s retirement. Existing full-pane cleanup still clears all indicators. No new cache, configuration, protocol, dependency or persistence surface is added.

Production LOC is **+40/−40 (net 0)** across the history, projection and run-lifecycle owners. Tests/support are **+559/−89** and documentation is **+2/−0**; the test figures include a fixture/case move. Regression cases were split into a focused replacement-run test file using shared fixtures so the existing owner suite stays within the repository’s file-size limit.

## Evidence

The original actual Chromium/mock-Gateway reproduction retained A after authoritative B history and hid B’s delta. The repaired source-server flow displays B and its new progress with no page errors. All test data are synthetic; no operator Gateway or live provider was used.

Four original owner regressions failed before the fix. Additional before tests demonstrated terminal loss on a leaf change, second and alternating stale replays, and lost B live text during a leaf change. The expanded seven-suite owner/sibling batch passed 338 cases; after the live-text correction both in-flight suites passed 63. Authentic compaction regressions failed four cases before canonical cleanup and then all 95 replacement/lifecycle/compaction-fallback cases passed.

Initial hosted CI exposed two issues in the new test code: the original combined file exceeded the line limit, and the E2E wrongly expected cumulative text in one bubble despite a tool boundary. The split preserves existing fixtures and assertions. An exact browser diagnostic proved the correct prefix/tool/fresh-tail order, and the E2E now asserts that order, absence of A’s stale text, and Stop targeting B. An extra local compaction-replay fixture was discarded only after checking that the Gateway never puts compaction events in history snapshots; the authentic live-event race remains covered.

The ClawSweeper finding and rank-up move about replacement compaction status and timer are addressed by the canonical cleanup change and regression coverage.

Two additional review suggestions were not applied. One proposed inventing a terminal fence for displaced A to reject a later snapshot offering A again. The other proposed another adoption guard for a later offer of locally completed B. Neither supplied a reachable ordering for that later authoritative offer: after its last await, `chat-history-handler.ts` reads active identities and the in-flight snapshot from current registries and responds synchronously; `resolveInFlightRunSnapshot` excludes inactive/aborted entries. Client shared history retains only pending work, deletes resolved requests, and starts fresh work for overlapping requests from the same pane; request versions reject the superseded response. Adoption of another live run while a request is pending also changes a non-snapshot projection and blocks takeover. A mock returning contradictory older snapshots as subsequent fresh responses does not demonstrate those producer prerequisites. No terminal outcome is fabricated from missing membership. The real terminal events, leaf transitions, and live progress during an admitted request remain covered.

Final Codex autoreview is clean at P0–P2, and independent source review verified the owner changes and regression evidence. The production-built E2E now also holds reconnect startup, observes live B compaction, and checks that its indicator survives recovery. The production-built scenario passed on `267801fb1b3f6fd6df9744d4cc2492c843dad309`, including compaction survival and Stop B. Local and hosted type checks then found missing compaction fields on the test fixture type; the correction reuses the canonical lifecycle host type through a type-only import. Its focused review is clean, with production and browser-scenario bytes unchanged. The canonical ten-file changed gate now passes on `bfa1ed5594b294ed0f839687a12ab46cf4c4c3d2`, including core-test/UI type checks, policy checks, formatting, lint and styles. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33309999318) is green, including `openclaw/ci-gate`, with no failed or pending checks. The latest ClawSweeper review on this exact head has no actionable findings; its remaining rank-up request for completed checks is satisfied.

Before/after images were inspected locally and contain synthetic data only. Public image publication remains blocked pending explicit approval of the content and public PR destination under the capture policy. No images have been uploaded.

The original defect was observed at `8b7d685b2a9228a7aa98b5338b0ad8534777cace`; its affected owner is unchanged in implementation base `6549b0a7c534750d9d6cbef305233b162704b291`. The introducing commit and affected release range are not established.
