### PR TITLE
perf(agents): reuse assistant and reply payload preparation

### DIFF
--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -3,20 +3,21 @@ import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-error-format.js";
 import {
-  BILLING_ERROR_USER_MESSAGE,
   classifyAssistantFailoverReason,
   formatBillingErrorMessage,
   formatAssistantErrorText,
   formatUserFacingAssistantErrorText,
   getApiErrorPayloadFingerprint,
   formatRawAssistantErrorForUi,
-  isRawApiErrorPayload,
 } from "./embedded-agent-helpers.js";
 import { sanitizeUserFacingText } from "./embedded-agent-helpers/sanitize-user-facing-text.js";
 import { renderUserFacingText } from "./embedded-agent-helpers/user-facing-text.js";
+import { isRawApiErrorPayload } from "./failover/user-copy.js";
 import { makeAssistantMessageFixture } from "./test-helpers/assistant-message-fixtures.js";
 
 describe("formatAssistantErrorText", () => {
+  const BILLING_ERROR_USER_MESSAGE =
+    "⚠️ API provider returned a billing error — your API key has run out of credits or has an insufficient balance. Check your provider's billing dashboard and top up or switch to a different API key.";
   const makeAssistantError = (errorMessage: string): AssistantMessage =>
     makeAssistantMessageFixture({
       errorMessage,

--- a/src/agents/embedded-agent-helpers.ts
+++ b/src/agents/embedded-agent-helpers.ts
@@ -28,12 +28,7 @@ export {
 } from "./embedded-agent-helpers/image-errors.js";
 export { classifyProviderRuntimeFailureKind } from "./embedded-agent-helpers/provider-runtime-failure.js";
 export type { ProviderRuntimeFailureKind } from "./embedded-agent-helpers/provider-runtime-failure.js";
-export {
-  BILLING_ERROR_USER_MESSAGE,
-  formatBillingErrorMessage,
-  getApiErrorPayloadFingerprint,
-  isRawApiErrorPayload,
-} from "./failover/user-copy.js";
+export { formatBillingErrorMessage, getApiErrorPayloadFingerprint } from "./failover/user-copy.js";
 export {
   formatRawAssistantErrorForUi,
   parseApiErrorInfo,

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -36,12 +36,8 @@ import {
 } from "../../../shared/text/assistant-visible-text.js";
 import { classifyOAuthRefreshFailure } from "../../auth-profiles/oauth-refresh-failure.js";
 import {
-  BILLING_ERROR_USER_MESSAGE,
   formatAssistantErrorText,
-  formatRawAssistantErrorForUi,
   formatUserFacingAssistantErrorText,
-  getApiErrorPayloadFingerprint,
-  isRawApiErrorPayload,
   normalizeTextForComparison,
 } from "../../embedded-agent-helpers.js";
 import { SYNTHESIZED_TIMEOUT_ERROR_TEXT } from "../../embedded-agent-helpers/error-text.js";
@@ -118,10 +114,6 @@ function resolveRawAssistantAnswerText(lastAssistant: AssistantMessage | undefin
       }),
     ) ?? ""
   );
-}
-
-function normalizeReplyTextForComparison(text: string): string {
-  return normalizeTextForComparison(parseReplyDirectives(text).text ?? "");
 }
 
 /**
@@ -250,21 +242,6 @@ export function buildEmbeddedRunPayloads(params: {
               authMode: params.authMode,
             })
       : undefined;
-  const rawErrorFingerprint = rawErrorMessage
-    ? getApiErrorPayloadFingerprint(rawErrorMessage)
-    : null;
-  const formattedRawErrorMessage = rawErrorMessage
-    ? formatRawAssistantErrorForUi(rawErrorMessage)
-    : null;
-  const normalizedFormattedRawErrorMessage = formattedRawErrorMessage
-    ? normalizeTextForComparison(formattedRawErrorMessage)
-    : null;
-  const normalizedRawErrorText = rawErrorMessage
-    ? normalizeTextForComparison(rawErrorMessage)
-    : null;
-  const normalizedErrorText = errorText ? normalizeTextForComparison(errorText) : null;
-  const normalizedGenericBillingErrorText = normalizeTextForComparison(BILLING_ERROR_USER_MESSAGE);
-  const genericErrorText = "The AI service returned an error. Please try again.";
   const deferAssistantTimeoutError =
     params.deferAssistantTimeoutError === true &&
     rawErrorMessage !== undefined &&
@@ -290,79 +267,38 @@ export function buildEmbeddedRunPayloads(params: {
     ? extractAssistantVisibleText(assistantForPayload)
     : "";
   const fallbackRawAnswerText = resolveRawAssistantAnswerText(assistantForPayload);
-  const shouldSuppressRawErrorText = (text: string) => {
-    if (!lastAssistantNeedsErrorSurface) {
-      return false;
-    }
-    const trimmed = text.trim();
-    if (!trimmed) {
-      return false;
-    }
-    if (errorText) {
-      const normalized = normalizeTextForComparison(trimmed);
-      if (normalized && normalizedErrorText && normalized === normalizedErrorText) {
-        return true;
-      }
-      if (trimmed === genericErrorText) {
-        return true;
-      }
-      if (
-        normalized &&
-        normalizedGenericBillingErrorText &&
-        normalized === normalizedGenericBillingErrorText
-      ) {
-        return true;
-      }
-    }
-    if (rawErrorMessage && trimmed === rawErrorMessage) {
-      return true;
-    }
-    if (formattedRawErrorMessage && trimmed === formattedRawErrorMessage) {
-      return true;
-    }
-    if (normalizedRawErrorText) {
-      const normalized = normalizeTextForComparison(trimmed);
-      if (normalized && normalized === normalizedRawErrorText) {
-        return true;
-      }
-    }
-    if (normalizedFormattedRawErrorMessage) {
-      const normalized = normalizeTextForComparison(trimmed);
-      if (normalized && normalized === normalizedFormattedRawErrorMessage) {
-        return true;
-      }
-    }
-    if (rawErrorFingerprint) {
-      const fingerprint = getApiErrorPayloadFingerprint(trimmed);
-      if (fingerprint && fingerprint === rawErrorFingerprint) {
-        return true;
-      }
-    }
-    return isRawApiErrorPayload(trimmed);
-  };
   const rawAnswerDirectiveState = fallbackRawAnswerText
     ? parseReplyDirectives(fallbackRawAnswerText)
     : null;
   const rawAnswerHasMedia =
     (rawAnswerDirectiveState?.mediaUrls?.length ?? 0) > 0 || rawAnswerDirectiveState?.audioAsVoice;
-  const assistantTextsHaveMedia = params.assistantTexts.some((text) => {
-    const parsed = parseReplyDirectives(text);
-    return (parsed.mediaUrls?.length ?? 0) > 0 || parsed.audioAsVoice;
-  });
-  const normalizedAssistantTexts = normalizeTextForComparison(nonEmptyAssistantTexts.join("\n\n"));
-  const normalizedRawAnswerText = normalizeTextForComparison(rawAnswerDirectiveState?.text ?? "");
+  const normalizedAssistantTexts =
+    rawAnswerHasMedia &&
+    nonEmptyAssistantTexts.length > 0 &&
+    !params.assistantTexts.some((text) => {
+      const parsed = parseReplyDirectives(text);
+      return (parsed.mediaUrls?.length ?? 0) > 0 || parsed.audioAsVoice;
+    })
+      ? normalizeTextForComparison(nonEmptyAssistantTexts.join("\n\n"))
+      : "";
   const shouldPreferRawAnswerText =
     rawAnswerHasMedia &&
     (!nonEmptyAssistantTexts.length ||
-      (!assistantTextsHaveMedia &&
-        normalizedAssistantTexts.length > 0 &&
-        normalizedAssistantTexts === normalizedRawAnswerText));
+      (normalizedAssistantTexts.length > 0 &&
+        normalizedAssistantTexts ===
+          normalizeTextForComparison(rawAnswerDirectiveState?.text ?? "")));
   // When streamed text lost media directives but the canonical assistant answer
   // still contains them, keep the raw answer so attachments are not dropped.
   const fallbackAnswerSourceText =
     shouldPreferRawAnswerText && fallbackRawAnswerText ? fallbackRawAnswerText : fallbackAnswerText;
-  const normalizedFallbackAnswerSourceText = fallbackAnswerSourceText
-    ? normalizeReplyTextForComparison(fallbackAnswerSourceText)
+  const fallbackAnswerDirectiveState =
+    fallbackAnswerSourceText === fallbackRawAnswerText
+      ? rawAnswerDirectiveState
+      : fallbackAnswerSourceText
+        ? parseReplyDirectives(fallbackAnswerSourceText)
+        : null;
+  const normalizedFallbackAnswerSourceText = fallbackAnswerDirectiveState
+    ? normalizeTextForComparison(fallbackAnswerDirectiveState.text)
     : "";
   const shouldUseCanonicalFinalAnswer =
     !lastAssistantNeedsErrorSurface &&
@@ -372,16 +308,19 @@ export function buildEmbeddedRunPayloads(params: {
   const answerTexts =
     suppressAssistantArtifacts || runAborted || lastAssistantNeedsErrorSurface
       ? []
-      : (shouldUseCanonicalFinalAnswer
-          ? [fallbackAnswerSourceText]
-          : shouldPreferRawAnswerText && fallbackRawAnswerText
-            ? [fallbackRawAnswerText]
-            : hasAssistantTextPayload
-              ? nonEmptyAssistantTexts
-              : fallbackAnswerText
-                ? [fallbackAnswerText]
-                : []
-        ).filter((text) => !shouldSuppressRawErrorText(text));
+      : shouldUseCanonicalFinalAnswer
+        ? [fallbackAnswerSourceText]
+        : shouldPreferRawAnswerText && fallbackRawAnswerText
+          ? [fallbackRawAnswerText]
+          : hasAssistantTextPayload
+            ? nonEmptyAssistantTexts
+            : fallbackAnswerText
+              ? [fallbackAnswerText]
+              : [];
+  const preparedAnswerDirectives =
+    shouldUseCanonicalFinalAnswer || shouldPreferRawAnswerText || !hasAssistantTextPayload
+      ? fallbackAnswerDirectiveState
+      : null;
   let hasUserFacingReply =
     Boolean(errorText) ||
     completedSourceReplyViaMessageTool ||
@@ -394,7 +333,7 @@ export function buildEmbeddedRunPayloads(params: {
       replyToId,
       replyToTag,
       replyToCurrent,
-    } = parseReplyDirectives(text);
+    } = preparedAnswerDirectives ?? parseReplyDirectives(text);
     const ttsFacts = shouldUseCanonicalFinalAnswer ? storedDelivery?.tts : undefined;
     const delivery = shouldUseCanonicalFinalAnswer
       ? {

--- a/src/agents/embedded-agent-utils.ts
+++ b/src/agents/embedded-agent-utils.ts
@@ -47,95 +47,85 @@ function finalizeAssistantExtraction(msg: AssistantMessage, extracted: string): 
     : sanitizeUserFacingText(extracted);
 }
 
-type AssistantTextExtractionResult = {
-  text: string;
-  hadRequestedPhase: boolean;
-};
-
 function extractEmbeddedAssistantTextForPhase(
   msg: AssistantMessage,
-  phase?: AssistantPhase,
-  options?: { unphasedSignedFinalAnswer?: boolean },
-): AssistantTextExtractionResult {
+  requestedPhase: AssistantPhase,
+): string {
   const messagePhase = normalizeAssistantPhase((msg as { phase?: unknown }).phase);
-  const shouldIncludeContent = (resolvedPhase?: AssistantPhase) => {
-    if (phase) {
-      return resolvedPhase === phase;
-    }
-    return resolvedPhase === undefined;
-  };
-
   if (typeof msg.content === "string") {
-    const hadRequestedPhase = phase ? messagePhase === phase : messagePhase === undefined;
-    return {
-      text: shouldIncludeContent(messagePhase)
-        ? finalizeAssistantExtraction(msg, sanitizeAssistantText(msg.content, messagePhase))
-        : "",
-      hadRequestedPhase,
-    };
+    const selectedPhase =
+      requestedPhase === "final_answer" && messagePhase !== "final_answer"
+        ? undefined
+        : requestedPhase;
+    if (messagePhase !== selectedPhase) {
+      return "";
+    }
+    const text = finalizeAssistantExtraction(msg, sanitizeAssistantText(msg.content, messagePhase));
+    return selectedPhase === "final_answer" && !text.trim() ? "" : text;
   }
-
   if (!Array.isArray(msg.content)) {
-    return { text: "", hadRequestedPhase: false };
+    return "";
   }
 
-  const hasExplicitPhasedTextBlocks = msg.content.some((block) => {
+  let hasExplicitPhasedTextBlocks = false;
+  let hasFinalAnswerText = false;
+  for (const block of msg.content) {
     if (!block || typeof block !== "object") {
-      return false;
+      continue;
     }
-    const record = block as { type?: unknown; textSignature?: unknown };
+    const record = block as { type?: unknown; text?: unknown; textSignature?: unknown };
     if (!isAssistantTextContentBlockType(record.type)) {
-      return false;
+      continue;
     }
-    return Boolean(parseAssistantTextSignature(record)?.phase);
-  });
-
-  let hadRequestedPhase = false;
-  const parts = msg.content
-    .map((block) => {
-      if (!block || typeof block !== "object") {
-        return null;
-      }
-      const record = block as { type?: unknown; text?: unknown; textSignature?: unknown };
-      if (!isAssistantTextContentBlockType(record.type) || typeof record.text !== "string") {
-        return null;
-      }
-      const signature = parseAssistantTextSignature(record);
-      const resolvedPhase =
-        signature?.phase ?? (hasExplicitPhasedTextBlocks ? undefined : messagePhase);
-      if (!shouldIncludeContent(resolvedPhase)) {
-        return null;
-      }
-      hadRequestedPhase = true;
-      const sanitizerPhase =
-        resolvedPhase ??
-        (options?.unphasedSignedFinalAnswer === true && signature?.id ? "final_answer" : undefined);
-      const text = sanitizeAssistantText(record.text, sanitizerPhase);
-      return text.trim() ? text : null;
-    })
-    .filter((value): value is string => typeof value === "string");
-  const extracted = parts.join("\n").trim();
-
-  return {
-    text: finalizeAssistantExtraction(msg, extracted),
-    hadRequestedPhase,
-  };
+    const phase = parseAssistantTextSignature(record)?.phase;
+    hasExplicitPhasedTextBlocks ||= Boolean(phase);
+    hasFinalAnswerText ||= phase === "final_answer" && typeof record.text === "string";
+    if (hasExplicitPhasedTextBlocks && (requestedPhase === "commentary" || hasFinalAnswerText)) {
+      break;
+    }
+  }
+  // An empty final text block still owns the answer; only absence allows unphased fallback.
+  const selectedPhase =
+    requestedPhase === "final_answer" &&
+    !hasFinalAnswerText &&
+    (hasExplicitPhasedTextBlocks || messagePhase !== "final_answer")
+      ? undefined
+      : requestedPhase;
+  const parts: string[] = [];
+  for (const block of msg.content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const record = block as { type?: unknown; text?: unknown; textSignature?: unknown };
+    if (!isAssistantTextContentBlockType(record.type) || typeof record.text !== "string") {
+      continue;
+    }
+    const signature = parseAssistantTextSignature(record);
+    const resolvedPhase =
+      signature?.phase ?? (hasExplicitPhasedTextBlocks ? undefined : messagePhase);
+    if (resolvedPhase !== selectedPhase) {
+      continue;
+    }
+    const sanitizerPhase =
+      resolvedPhase ??
+      (requestedPhase === "final_answer" && signature?.id ? "final_answer" : undefined);
+    const text = sanitizeAssistantText(record.text, sanitizerPhase);
+    if (text.trim()) {
+      parts.push(text);
+    }
+  }
+  const extracted = finalizeAssistantExtraction(msg, parts.join("\n").trim());
+  return selectedPhase === "final_answer" && !extracted.trim() ? "" : extracted;
 }
 
 /** Extract text intended for users, preferring explicit final-answer phase blocks. */
 export function extractAssistantVisibleText(msg: AssistantMessage): string {
-  const finalAnswerExtraction = extractEmbeddedAssistantTextForPhase(msg, "final_answer");
-  if (finalAnswerExtraction.hadRequestedPhase) {
-    return finalAnswerExtraction.text.trim() ? finalAnswerExtraction.text : "";
-  }
-
-  return extractEmbeddedAssistantTextForPhase(msg, undefined, { unphasedSignedFinalAnswer: true })
-    .text;
+  return extractEmbeddedAssistantTextForPhase(msg, "final_answer");
 }
 
 /** Extract the commentary/narration text of a commentary-phase assistant message. */
 export function extractAssistantCommentaryText(msg: AssistantMessage): string {
-  return extractEmbeddedAssistantTextForPhase(msg, "commentary").text;
+  return extractEmbeddedAssistantTextForPhase(msg, "commentary");
 }
 
 /** Extract sanitized assistant text across all text content blocks. */
@@ -158,33 +148,22 @@ export function extractAssistantThinking(msg: AssistantMessage): string {
   if (!Array.isArray(msg.content)) {
     return "";
   }
-  const blocks = msg.content
-    .map((block) => {
-      if (!block || typeof block !== "object") {
-        return "";
+  const blocks: string[] = [];
+  for (const block of msg.content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const type: unknown = Reflect.get(block, "type");
+    const rawThinking = Reflect.get(block, "thinking");
+    if (type === "thinking" && typeof rawThinking === "string") {
+      const thinking = rawThinking.trim();
+      // Empty signed summaries produce no bubble; the original block still owns API replay.
+      if (thinking) {
+        blocks.push(thinking);
       }
-      const type: unknown = Reflect.get(block, "type");
-      const rawThinking = Reflect.get(block, "thinking");
-      if (type === "thinking" && typeof rawThinking === "string") {
-        const thinking = rawThinking.trim();
-        if (thinking) {
-          return thinking;
-        }
-        // Signature-only thinking blocks carry a valid signature but no summary text
-        // (e.g. Anthropic display:"omitted" on Opus 4.7+/Fable 5, or OpenAI/codex reasoning
-        // items with encrypted_content and an empty summary). Surface nothing so the
-        // .filter(Boolean) below drops the bubble — a diagnostic placeholder is not reasoning
-        // content and must not be shown on any channel. The signed block stays on the message
-        // for API replay; this only governs display.
-        const thinkingSignature = Reflect.get(block, "thinkingSignature");
-        if (typeof thinkingSignature === "string" && thinkingSignature.trim()) {
-          return "";
-        }
-      }
-      return "";
-    })
-    .filter(Boolean);
-  return blocks.join("\n").trim();
+    }
+  }
+  return blocks.join("\n");
 }
 
 /** Format reasoning text for markdown-friendly channel surfaces. */

--- a/src/agents/failover/user-copy.test.ts
+++ b/src/agents/failover/user-copy.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  BILLING_ERROR_USER_MESSAGE,
   renderFormatErrorCopy,
   renderBillingReplyCopy,
   renderCliTimeoutReplyCopy,
@@ -83,7 +82,9 @@ describe("failover user copy", () => {
     ).toBe(
       "⚠️ Anthropic (claude) returned a billing error — check your account for subscription or usage limits, then try again.",
     );
-    expect(renderBillingReplyCopy({})).toBe(BILLING_ERROR_USER_MESSAGE);
+    expect(renderBillingReplyCopy({})).toBe(
+      "⚠️ API provider returned a billing error — your API key has run out of credits or has an insufficient balance. Check your provider's billing dashboard and top up or switch to a different API key.",
+    );
   });
 
   it("renders provider-safe missing-key guidance", () => {

--- a/src/agents/failover/user-copy.ts
+++ b/src/agents/failover/user-copy.ts
@@ -79,7 +79,7 @@ export function formatBillingErrorMessage(
     : "⚠️ API provider returned a billing error — your API key has run out of credits or has an insufficient balance. Check your provider's billing dashboard and top up or switch to a different API key.";
 }
 
-export const BILLING_ERROR_USER_MESSAGE = formatBillingErrorMessage();
+const BILLING_ERROR_USER_MESSAGE = formatBillingErrorMessage();
 
 /** Surface only bounded numeric limit facts, never arbitrary provider-controlled error text. */
 export function renderFormatErrorCopy(raw: string): string {

--- a/src/auto-reply/reply/agent-runner-execution-compaction.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-compaction.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { BILLING_ERROR_USER_MESSAGE } from "../../agents/failover/user-copy.js";
+import { formatBillingErrorMessage } from "../../agents/failover/user-copy.js";
 import { resetLogger, setLoggerOverride } from "../../logging/logger.js";
 import { loggingState } from "../../logging/state.js";
 import * as autoFallback from "./agent-runner-auto-fallback.js";
@@ -146,7 +146,7 @@ describe("executeAgentTurn: compaction events", () => {
       .mockImplementationOnce(async (params: EmbeddedAgentParams) => {
         params.onExecutionPhase?.({ phase: "model_call_started" });
         return {
-          payloads: [{ text: BILLING_ERROR_USER_MESSAGE, isError: true }],
+          payloads: [{ text: formatBillingErrorMessage(), isError: true }],
           meta: { error: { kind: "billing", message: "billing unavailable" } },
         };
       });
@@ -198,7 +198,7 @@ describe("executeAgentTurn: compaction events", () => {
     state.runCliAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
       params.onExecutionPhase?.({ phase: "process_spawned" });
       return {
-        payloads: [{ text: BILLING_ERROR_USER_MESSAGE, isError: true }],
+        payloads: [{ text: formatBillingErrorMessage(), isError: true }],
         meta: { error: { kind: "billing", message: "billing unavailable" } },
       };
     });

--- a/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 import { formatBillingErrorMessage } from "../../agents/embedded-agent-helpers.js";
 import { resolveMaxRunRetryIterations } from "../../agents/embedded-agent-runner/run/helpers.js";
 import { FailoverError } from "../../agents/failover-error.js";
-import { BILLING_ERROR_USER_MESSAGE } from "../../agents/failover/user-copy.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 import { ProviderAuthError } from "../../agents/model-auth.js";
 import { getReplyPayloadMetadata } from "../reply-payload.js";
@@ -1003,7 +1002,7 @@ describe("executeAgentTurn: provider failures", () => {
 
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
-      expect(result.payload.text).toBe(BILLING_ERROR_USER_MESSAGE);
+      expect(result.payload.text).toBe(formatBillingErrorMessage());
       expect(result.payload.text).not.toBe(GENERIC_RUN_FAILURE_TEXT);
     }
   });

--- a/src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { FailoverError } from "../../agents/failover-error.js";
 import {
-  BILLING_ERROR_USER_MESSAGE,
+  formatBillingErrorMessage,
   HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
 } from "../../agents/failover/user-copy.js";
 import { AgentHarnessSessionSupersededError } from "../../agents/harness/errors.js";
@@ -67,7 +67,7 @@ describe("executeAgentTurn: terminal failures", () => {
 
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
-      expect(result.payload.text).toBe(BILLING_ERROR_USER_MESSAGE);
+      expect(result.payload.text).toBe(formatBillingErrorMessage());
       expect(result.payload.text).not.toContain("All models failed");
       expect(result.payload.text).not.toContain("402 (billing)");
       expect(result.payload.text).not.toContain("Rate-limited");
@@ -219,7 +219,7 @@ describe("executeAgentTurn: terminal failures", () => {
 
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
-      expect(result.payload.text).toBe(BILLING_ERROR_USER_MESSAGE);
+      expect(result.payload.text).toBe(formatBillingErrorMessage());
     }
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.terminal-recovery.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.terminal-recovery.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { BILLING_ERROR_USER_MESSAGE } from "../../agents/failover/user-copy.js";
+import { formatBillingErrorMessage } from "../../agents/failover/user-copy.js";
 import { readAgentRunTerminalOutcome } from "../../channels/turn/agent-run-terminal-outcome.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { setReplyPayloadMetadata } from "../reply-payload.js";
@@ -105,7 +105,7 @@ describe("dispatchReplyFromConfig terminal visible admission recovery", () => {
   it("renders post-compaction context after dispatcher normalization", async () => {
     const dispatchParams = createVisibleDispatchParams(async () =>
       setReplyPayloadMetadata(
-        { text: BILLING_ERROR_USER_MESSAGE, isError: true },
+        { text: formatBillingErrorMessage(), isError: true },
         { postCompactionModelFailure: true },
       ),
     );
@@ -113,7 +113,7 @@ describe("dispatchReplyFromConfig terminal visible admission recovery", () => {
     await dispatchReplyFromConfig(dispatchParams);
 
     expect(dispatchParams.dispatcher.sendFinalReply).toHaveBeenCalledWith({
-      text: `⚠️ Context compaction succeeded, but the later model request still failed. ${BILLING_ERROR_USER_MESSAGE.replace(/^⚠️\s*/u, "")}`,
+      text: `⚠️ Context compaction succeeded, but the later model request still failed. ${formatBillingErrorMessage().replace(/^⚠️\s*/u, "")}`,
       isError: true,
     });
   });


### PR DESCRIPTION
## What Problem This Solves

Assistant text extraction projected unphased replies twice, while terminal payload preparation eagerly parsed streamed text, normalized error strings and assembled comparisons that could not affect the selected reply. This repeated work sits between completed provider output and channel delivery.

## Why This Change Was Made

Two measured changes simplify the existing owners:

- Select the requested assistant phase before collecting text. Preserve explicit empty final answers, block-phase precedence, signed unphased text, legacy string sanitization and fresh reads of mutable transport blocks. Collect thinking summaries directly; signature-only blocks remain intact for API replay.
- Remove the unreachable raw-error filter and its eager preparation, admit media comparison work only when the raw answer has media, and reuse parsed directives for the exact selected fallback answer. Canonical delivery/TTS facts, error/abort suppression, timeout recovery and message-tool duplicate handling remain authoritative.

Remove newly orphaned helper-barrel exports and keep the billing copy private to its owner. Existing integration tests use the canonical billing formatter; direct copy tests still assert the literal. No compatibility alias or parallel processing path is added.

Production **+110/−197 = net −87**; existing tests **+16/−15 = net +1**, with no test case added or removed. No dependency, config, schema, protocol, authorization or public API change.

## Measurements and Tradeoffs

Four complete source compositions were measured in fresh Node 26.8.1 processes with opposite starting orders, balanced warmups and all samples retained. Instrumentation and correctness checks were excluded from timed loops. The combined change improved all 28 terminal-payload workloads in both orders:

| Complete payload workload | Before → combined, two process medians |
| --- | --- |
| Ordinary current final | 8.545/8.638 → 4.610/4.580 µs |
| One streamed text | 6.137/6.263 → 2.988/2.957 µs |
| Matching media answer | 63.968/63.749 → 25.063/25.421 µs |
| Code-rich answer | 3.669/3.636 → 1.232/1.244 ms |

Isolated variants show payload preparation supplies most of these gains. Extraction alone improves the complete 64-block native-thinking subscriber workload from 74.365/73.121 to 66.364/67.568 µs. The combined short-final subscriber costs another 0.912/0.752 µs; the 64-block, 100-delta subscriber costs another 12.462/8.132 µs (about 1.2/0.8%). Final-at-last utility controls add 0.188/0.168 µs, and commentary/one-delta results are mixed. These costs are retained and accepted against the broader simplification and terminal preparation gains. No universal, provider/network, whole-turn or memory speedup is claimed.

## Contracts and Verification

The final composition is compared against unchanged main with four variants: baseline, extraction only, payload preparation only and both changes. All 73 source/dependency bindings match. Differential proofs cover 11,458 leaf inputs, 708 subscriber scenarios (including 36 with raw diagnostics enabled), 672 payload cases and 55 controls. The separate payload-owner matrix covers 9,655 cases, 28,965 comparisons and 27 controls; these are distinct proof units, not an aggregate canonical-test total. Coverage includes explicit and inherited phases, empty/malformed final blocks, signed text, in-place transport mutation, complete subscriber events, canonical finals, media directives, streamed text, stored delivery/TTS, billing/provider errors, timeouts, aborts and suppression metadata. Output bytes and relevant object identity remain unchanged.

All **1,236 canonical tests across 48 files** pass. The complete changed-file gate passes types, lint, import boundaries, dead exports and all other guards in 211.50 seconds. The initial gate exposed orphaned exports; removing them revealed four downstream test imports, which were migrated and rerun. Both failed receipts are retained. Fresh automated Codex review across P0–P3 and independent complete-owner review are clean.

The lead personally inspected the native Codex contracts in `codex-rs/protocol/src/models.rs` and `codex-rs/protocol/src/protocol.rs` in the sibling Codex checkout, alongside the OpenClaw extraction, subscriber and terminal owners. Optional message phases and separate reasoning/signature ownership remain unchanged. This is not a claim of live native Codex execution.

This is an internal performance refactor. Release-note context is recorded here; the release workflow owns the changelog. The separately recorded pre-existing literal-final-tag delivery defect remains outside this semantics-preserving scope.

At the published head `2c4ad2593df2f46f593900a95b72d9ea66700bc9`, a fresh build passed in 155.92 seconds and another P0–P3 automated review is clean. An isolated real OpenAI Gateway completed three turns and two actual `web_fetch` calls, passing 51 assertions over 18 RPCs. The new-connection reader recovered in-flight tool progress; final conversation/history/list/status and cleanup checks passed. Raw diagnostics were enabled, with 93 records correlated to the three exact run IDs, including text, thinking and terminal events. The owned Gateway stopped cleanly and both Node CPU profiles were retained. These are behavior proofs, not controlled network-latency measurements. Exact-head hosted CI remains the final landing gate.

## Landing Review

The completed ClawSweeper review found no introduced correctness or security defect. Its rank-up request for direct native-contract inspection is addressed: the lead personally inspected the sibling Codex checkout at `6478a751fde8884b2fdc76486fe23175a8e795d4`, including `codex-rs/protocol/src/models.rs:850–1060` (text content, optional message phase, and separate reasoning summary/encrypted content), `codex-rs/protocol/src/protocol.rs:2448–2538` (message/reasoning events), and `codex-rs/app-server-protocol/src/protocol/v2/item.rs:249–253,878–900` (app-server message projection). Absent phases remain unknown and retain the existing fallback.

OpenClaw's `textSignature` encoding is its own unchanged transport representation, not a new native Codex field. The lead also checked `src/shared/chat-message-content.ts:26–80`, the complete Codex conversation collector and assistant-message projector: native commentary filtering, unphased persisted narration and signed reasoning replay ownership remain unchanged. This direct source inspection resolves the review worker's missing-checkout limitation; it is not a claim of human review or live native Codex execution. The remaining rank-up request is completed exact-head CI; a queued review refresh does not replace that gate.

Exact-head [CI run 33307266738](https://github.com/openclaw/openclaw/actions/runs/33307266738) is now green. The long-running compact-small-35 shard passed without a retry. Both rank-up requests are addressed, and no accepted actionable finding remains. The final source review, 1,236 tests, full changed-file gate, build and real Gateway proof all cover the published head.
