### PR TITLE
fix(cua-computer): return zoom images to the model

### DIFF
--- a/extensions/cua-computer/src/commands.test.ts
+++ b/extensions/cua-computer/src/commands.test.ts
@@ -1,4 +1,6 @@
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { resizeToJpeg } from "openclaw/plugin-sdk/media-runtime";
+import { createSolidPngBuffer } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi } from "vitest";
 import { createCuaComputerProvider } from "./commands.js";
 import {
@@ -502,6 +504,13 @@ describe("cua-computer provider", () => {
 
   it("maps window pixels, app lifecycle, menu, zoom, and escalation tools", async () => {
     const { session, callTool, escalateScope } = driver();
+    const zoomImage = (
+      await resizeToJpeg({
+        buffer: createSolidPngBuffer(300, 200, { r: 70, g: 125, b: 180 }),
+        maxSide: 300,
+        quality: 85,
+      })
+    ).toString("base64");
     callTool.mockImplementation(async (name) => {
       switch (name) {
         case "list_apps":
@@ -511,7 +520,10 @@ describe("cua-computer provider", () => {
         case "get_window_state":
           return cuaToolResult(CUA_DRIVER_CONTRACT_FIXTURES.windowState, { image: true });
         case "zoom":
-          return cuaToolResult({ screenshot_width: 300, screenshot_height: 200 }, { image: true });
+          return {
+            ...cuaToolResult({ width: 300, height: 200, format: "jpeg", mime_type: "image/jpeg" }),
+            images: [{ mimeType: "image/jpeg", dataBase64: zoomImage }],
+          };
         default:
           return cuaToolResult(
             {},
@@ -554,6 +566,26 @@ describe("cua-computer provider", () => {
       ),
     ) as { observation: { observationId: string } };
     expect(zoomed.observation.observationId).not.toBe(observed.observation.observationId);
+    expect(zoomed.observation).toMatchObject({
+      base64: zoomImage,
+      format: "jpeg",
+      width: 300,
+      height: 200,
+    });
+    await computer.act(
+      JSON.stringify({
+        action: "left_click",
+        windowRef,
+        observationId: zoomed.observation.observationId,
+        x: 0,
+        y: 0,
+      }),
+    );
+    expect(callTool).toHaveBeenLastCalledWith(
+      "click",
+      { pid: 4242, window_id: 99, x: 0, y: 0, from_zoom: true, button: "left", count: 1 },
+      undefined,
+    );
     await computer.act(
       JSON.stringify({ action: "escalate_scope", reason: "background_delivery_failed" }),
     );

--- a/extensions/cua-computer/src/driver-result.test.ts
+++ b/extensions/cua-computer/src/driver-result.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  CUA_DRIVER_CONTRACT_FIXTURES,
+  cuaToolResult,
+} from "./cua-driver-contract.test-fixtures.js";
+import type { CuaToolResult } from "./driver-client.js";
+import { browserObservation, windowObservation } from "./driver-result.js";
+
+const observations = [
+  { kind: "window", mimeType: "image/png", fields: CUA_DRIVER_CONTRACT_FIXTURES.windowState },
+  { kind: "zoom", mimeType: "image/jpeg", fields: { width: 300, height: 200, format: "jpeg" } },
+  { kind: "browser", mimeType: "image/png", fields: CUA_DRIVER_CONTRACT_FIXTURES.browserSnapshot },
+] as const;
+
+function project(kind: (typeof observations)[number]["kind"], result: CuaToolResult) {
+  const state = { generation: "test-generation" };
+  return kind === "browser"
+    ? browserObservation(result, state, {
+        browserRef: "test-browser",
+        pageRef: "test-page",
+        targetId: CUA_DRIVER_CONTRACT_FIXTURES.browserSnapshot.target_id,
+        tabId: CUA_DRIVER_CONTRACT_FIXTURES.browserSnapshot.tab_id,
+      })
+    : windowObservation(result, state, "test-window", { fromZoom: kind === "zoom" });
+}
+
+describe.each(observations)("CUA $kind observation images", ({ kind, mimeType, fields }) => {
+  it("keeps an observation without inventing an image when capture is absent", () => {
+    const result = project(kind, cuaToolResult(fields));
+    expect(result.observation?.observationId).toMatch(/^cua:v2:observation:/);
+    expect(result.observation).not.toHaveProperty("base64");
+    expect(result.observation).not.toHaveProperty("format");
+  });
+
+  it("rejects malformed base64 for the supported image format", () => {
+    const result = cuaToolResult(fields);
+    result.images = [{ mimeType, dataBase64: "invalid base64!" }];
+    expect(() => project(kind, result)).toThrow("COMPUTER_DRIVER_ERROR");
+  });
+});

--- a/extensions/cua-computer/src/driver-result.ts
+++ b/extensions/cua-computer/src/driver-result.ts
@@ -354,6 +354,27 @@ export function projectProcesses(value: unknown): Record<string, unknown> {
   };
 }
 
+function observationImage(
+  result: CuaToolResult,
+  width: unknown,
+  height: unknown,
+): Pick<NonNullable<ComputerActResult["observation"]>, "base64" | "format" | "width" | "height"> {
+  const image = result.images.find(
+    (entry) => entry.mimeType === "image/png" || entry.mimeType === "image/jpeg",
+  );
+  const base64 = image ? canonicalizeBase64(image.dataBase64) : undefined;
+  if (image && !base64) {
+    throw new Error(
+      "COMPUTER_DRIVER_ERROR: CUA Driver returned malformed observation image base64",
+    );
+  }
+  return {
+    ...(base64 ? { base64, format: image?.mimeType === "image/jpeg" ? "jpeg" : "png" } : {}),
+    ...(typeof width === "number" && width >= 1 ? { width: Math.trunc(width) } : {}),
+    ...(typeof height === "number" && height >= 1 ? { height: Math.trunc(height) } : {}),
+  };
+}
+
 export function windowObservation(
   result: CuaToolResult,
   state: CuaFrameState,
@@ -392,19 +413,6 @@ export function windowObservation(
       },
     ];
   });
-  const image = result.images.find((entry) => entry.mimeType === "image/png");
-  const base64 = image ? canonicalizeBase64(image.dataBase64) : undefined;
-  if (image && !base64) {
-    throw new Error("COMPUTER_DRIVER_ERROR: CUA Driver returned malformed window PNG base64");
-  }
-  const width =
-    typeof structured.screenshot_width === "number" && structured.screenshot_width > 0
-      ? Math.trunc(structured.screenshot_width)
-      : undefined;
-  const height =
-    typeof structured.screenshot_height === "number" && structured.screenshot_height > 0
-      ? Math.trunc(structured.screenshot_height)
-      : undefined;
   const details: Record<string, unknown> = {
     ...(typeof structured.total_element_count === "number"
       ? { totalElementCount: structured.total_element_count }
@@ -424,9 +432,12 @@ export function windowObservation(
     ...action,
     observation: {
       kind: "window",
-      ...(base64 ? { base64, format: "png" as const } : {}),
-      ...(width ? { width } : {}),
-      ...(height ? { height } : {}),
+      // CUA zoom returns JPEG with width/height; window snapshots use screenshot_* fields.
+      ...observationImage(
+        result,
+        structured[options.fromZoom ? "width" : "screenshot_width"],
+        structured[options.fromZoom ? "height" : "screenshot_height"],
+      ),
       observationId: observation.id,
       ...(elements.length ? { elements } : {}),
     },
@@ -539,19 +550,6 @@ export function browserObservation(
     ];
   });
   const boundedElements = elements.slice(0, MAX_BROWSER_ELEMENTS);
-  const image = result.images.find((entry) => entry.mimeType === "image/png");
-  const base64 = image ? canonicalizeBase64(image.dataBase64) : undefined;
-  if (image && !base64) {
-    throw new Error("COMPUTER_DRIVER_ERROR: CUA Driver returned malformed browser PNG base64");
-  }
-  const width =
-    typeof structured.screenshot_width === "number" && structured.screenshot_width > 0
-      ? Math.trunc(structured.screenshot_width)
-      : undefined;
-  const height =
-    typeof structured.screenshot_height === "number" && structured.screenshot_height > 0
-      ? Math.trunc(structured.screenshot_height)
-      : undefined;
   const page =
     structured.page && typeof structured.page === "object" && !Array.isArray(structured.page)
       ? (structured.page as Record<string, unknown>)
@@ -560,9 +558,7 @@ export function browserObservation(
     ok: true,
     observation: {
       kind: "browser",
-      ...(base64 ? { base64, format: "png" as const } : {}),
-      ...(width ? { width } : {}),
-      ...(height ? { height } : {}),
+      ...observationImage(result, structured.screenshot_width, structured.screenshot_height),
       observationId: observation.id,
     },
     details: {


### PR DESCRIPTION
Closes #133265

## What Problem This Solves

Fixes an issue where agents receive no zoomed image after a successful CUA Computer zoom. The plugin issued a fresh observation ID but discarded the JPEG and its dimensions before the result reached the model.

## Why This Change Was Made

CUA Driver 0.21.0 returns JPEG zoom images with `width`/`height`, while ordinary window and browser snapshots use PNG and `screenshot_width`/`screenshot_height`. One shared observation-image projection now retains both supported formats, keeps the existing base64 validation, and selects dimensions using the existing zoom flag. This removes the duplicated PNG-only extraction without changing the observation schema, authorization, driver lifecycle, or coordinate handling.

## User Impact

Agents can see the zoomed image and its correct format and dimensions. Ordinary window/browser screenshots, observation references, zoom state, and malformed/no-image handling retain their existing behavior.

## Evidence

A generated 300×200 JPEG matching the exact tagged CUA zoom response failed before the repair through the real observation producer and core model-result projection: no image or dimensions, zero model image blocks. The same proof now preserves exact JPEG bytes, MIME, dimensions, and one model image block. Window and browser PNG controls also preserve exact bytes and dimensions.

The existing provider regression failed before the production change and passes after it with the real JPEG response shape. Current focused evidence covers 62 provider, action, browser, and image-control cases. Fresh structured autoreview, a distinct read-only Codex review, and independent source/dependency review found no actionable issue.

Production LOC: +28/−32 (net −4); tests: +73/−1 (net +72). No dependency, public configuration, persistence, protocol-version, or authorization change. The first introducing commit is not established.

The canonical three-file changed gate passed on the final source. Reviewed head: `242e168305db067e8e54e0854309d20e451f79bb`.

The supported filtered bundled-plugin runtime build passed. Its actual emitted default entry was then registered and exercised through `computer.act` over a task-owned synthetic Unix MCP proxy: window PNG, zoom JPEG, and browser PNG all retained exact bytes, format, and 300×200 dimensions. The new zoom observation ID and canonical session cleanup passed; no unexpected methods were requested. The ordinary safe-temp-root metadata stayed unchanged, and all fixture state was removed. This used no source injection, native driver initialization, real capture, desktop input, or provider upload.

Exact-head [CI run 33307445165](https://github.com/openclaw/openclaw/actions/runs/33307445165) and the required gate passed. Native review artifacts and main/PR guards validate for the reviewed head; preparation/merge guards remain. At the latest pre-landing review check, ClawSweeper had published only a review-started placeholder and no findings or Rank-up moves to apply. The separate large-image coordinate-mapping investigation is not repaired by this PR.

Dependency contract: [CUA Driver 0.21.0 ZoomTool](https://github.com/trycua/cua/blob/70db98d1bcd92890d778f4978e0eb107a4b66c1b/libs/cua-driver/rust/crates/platform-macos/src/tools/zoom.rs). Release-note context: CUA Computer zoom results now include the JPEG observation image instead of silently omitting it.
