### PR TITLE
feat(telegram): expose update id and message date to interactive plugin handlers

### DIFF
--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -413,13 +413,13 @@ Telegram-specific; other channels keep their own interactive result contracts.
 The Telegram interactive handler context exposes two ingress metadata fields:
 
 - `updateId: number | null` — the Telegram update identity, taken verbatim from
-the incoming update's `update_id` (`resolveTelegramUpdateId(ctx.update)`). It is
-`null` when the update has no valid `update_id` (synthetic updates or malformed
-values); valid Bot API `callback_query` updates always provide a number. The
-value is never synthesized, hashed, or derived, and consumers must treat `null`
-fail-closed (no substitute value).
+  the incoming update's `update_id` (`resolveTelegramUpdateId(ctx.update)`). It is
+  `null` when the update has no valid `update_id` (synthetic updates or malformed
+  values); valid Bot API `callback_query` updates always provide a number. The
+  value is never synthesized, hashed, or derived, and consumers must treat `null`
+  fail-closed (no substitute value).
 - `messageDate: number` — the callback message's Unix timestamp in seconds,
-taken verbatim from `callback_query.message.date`. It is never synthesized.
+  taken verbatim from `callback_query.message.date`. It is never synthesized.
 
 ### Host hooks for workflow plugins
 

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -410,6 +410,17 @@ the callback button when inbound policy skips the text or processing fails, so
 the user can retry after the blocking condition changes. This result field is
 Telegram-specific; other channels keep their own interactive result contracts.
 
+The Telegram interactive handler context exposes two ingress metadata fields:
+
+- `updateId: number | null` — the Telegram update identity, taken verbatim from
+the incoming update's `update_id` (`resolveTelegramUpdateId(ctx.update)`). It is
+`null` when the update has no valid `update_id` (synthetic updates or malformed
+values); valid Bot API `callback_query` updates always provide a number. The
+value is never synthesized, hashed, or derived, and consumers must treat `null`
+fail-closed (no substitute value).
+- `messageDate: number` — the callback message's Unix timestamp in seconds,
+taken verbatim from `callback_query.message.date`. It is never synthesized.
+
 ### Host hooks for workflow plugins
 
 Host hooks are the SDK seams for plugins that need to participate in the host

--- a/extensions/telegram/src/bot-handlers.callback-router-controls.ts
+++ b/extensions/telegram/src/bot-handlers.callback-router-controls.ts
@@ -442,6 +442,8 @@ export async function handleTelegramInteractiveCallback(params: {
   callbackThreadId?: number;
   senderId: string;
   senderUsername: string;
+  updateId: number | null;
+  messageDate: number;
   isGroup: boolean;
   isForum: boolean;
   storeAllowFrom: string[];
@@ -460,6 +462,8 @@ export async function handleTelegramInteractiveCallback(params: {
     callbackThreadId,
     senderId,
     senderUsername,
+    updateId,
+    messageDate,
     isGroup,
     isForum,
     storeAllowFrom,
@@ -563,6 +567,8 @@ export async function handleTelegramInteractiveCallback(params: {
     ctx: {
       accountId,
       callbackId: callback.id,
+      updateId,
+      messageDate,
       conversationId: callbackConversationId,
       parentConversationId: callbackThreadId != null ? String(callbackMessage.chat.id) : undefined,
       senderId: senderId || undefined,

--- a/extensions/telegram/src/bot-handlers.callback-router.ts
+++ b/extensions/telegram/src/bot-handlers.callback-router.ts
@@ -39,6 +39,7 @@ import {
   isTelegramSpooledReplayUpdate,
   recordTelegramMessageProcessingResult,
 } from "./bot-processing-outcome.js";
+import { resolveTelegramUpdateId } from "./telegram-ingress-spool.js";
 import {
   resolveTelegramForumFlag,
   resolveTelegramBotHasTopicsEnabled,
@@ -328,6 +329,8 @@ export function createTelegramCallbackRouter({
           callbackThreadId,
           senderId,
           senderUsername,
+          updateId: resolveTelegramUpdateId(ctx.update),
+          messageDate: callbackMessage.date,
           isGroup,
           isForum,
           storeAllowFrom,

--- a/extensions/telegram/src/bot-handlers.callback-router.ts
+++ b/extensions/telegram/src/bot-handlers.callback-router.ts
@@ -39,7 +39,6 @@ import {
   isTelegramSpooledReplayUpdate,
   recordTelegramMessageProcessingResult,
 } from "./bot-processing-outcome.js";
-import { resolveTelegramUpdateId } from "./telegram-ingress-spool.js";
 import {
   resolveTelegramForumFlag,
   resolveTelegramBotHasTopicsEnabled,
@@ -69,6 +68,7 @@ import {
   parseTelegramQuestionCallbackData,
 } from "./question-callback-data.js";
 import { buildInlineKeyboard } from "./send.js";
+import { resolveTelegramUpdateId } from "./telegram-ingress-spool.js";
 import { buildTelegramConversationId } from "./topic-conversation.js";
 
 export function createTelegramCallbackRouter({

--- a/extensions/telegram/src/interactive-dispatch.ts
+++ b/extensions/telegram/src/interactive-dispatch.ts
@@ -15,6 +15,20 @@ export type TelegramInteractiveHandlerContext = {
   channel: "telegram";
   accountId: string;
   callbackId: string;
+  /**
+   * Telegram update identity, forwarded verbatim from the authoritative
+   * `ctx.update.update_id` of the incoming update (never synthesized).
+   * `null` for synthetic updates or any update lacking a valid `update_id`
+   * (missing, non-numeric, negative, or unsafe-integer values); valid Bot
+   * API callback_query updates always provide a number. Consumers must
+   * treat `null` fail-closed (no synthesis, no substitute value).
+   */
+  updateId: number | null;
+  /**
+   * Telegram message timestamp (Unix seconds), forwarded verbatim from the
+   * authoritative `callbackQuery.message.date` (never synthesized).
+   */
+  messageDate: number;
   conversationId: string;
   parentConversationId?: string;
   senderId?: string;

--- a/extensions/telegram/src/interactive-ingress-proof.loopback.integration.test.ts
+++ b/extensions/telegram/src/interactive-ingress-proof.loopback.integration.test.ts
@@ -1,0 +1,206 @@
+// Real behavior proof for PR #133267: Telegram callback_query -> real callback
+// router -> generic interactive dispatcher -> temporary handler, proving that
+// updateId and messageDate arrive verbatim from the authoritative ingress.
+//
+// The proof uses a real grammY Bot with a loopback HTTP Bot API (127.0.0.1, no
+// live Telegram), the real Telegram callback router, and the real generic
+// interactive dispatcher with a temporary registered handler. It never touches
+// owner approvals, the supervisor, or any live channel.
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Bot } from "grammy";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { afterEach, describe, expect, it } from "vitest";
+import { registerPluginInteractiveHandler } from "../../src/plugins/interactive.js";
+import { createEmptyPluginRegistry } from "../../src/plugins/registry.js";
+import {
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../../src/plugins/runtime.js";
+import { defaultTelegramBotDeps } from "./bot-deps.js";
+import type { TelegramCallbackMessageRuntime } from "./bot-handlers.callback-router-controls.js";
+import { createTelegramCallbackRouter } from "./bot-handlers.callback-router.js";
+import type { TelegramHandlerAuthorization } from "./bot-handlers.inbound-authorization.js";
+import type { RegisterTelegramHandlerParams } from "./bot-handlers.types.js";
+import { telegramBotInfoForTest } from "./bot.create-telegram-bot.test-support.js";
+import { resetTelegramClientOptionsCacheForTests, sendMessageTelegram } from "./send.js";
+
+const TOKEN = "123456…proof-token";
+const CHAT_ID = 1234;
+
+// Authoritative ingress values used by the proof.
+const EXPECTED_UPDATE_ID = 424242;
+const EXPECTED_MESSAGE_DATE = 1_710_000_000;
+
+type TelegramApiRequest = { method: string; payload: Record<string, unknown> };
+
+async function readJsonBody(request: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? Buffer.from(chunk) : Buffer.from(chunk));
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+}
+
+function sendJson(response: ServerResponse, result: unknown): void {
+  response.writeHead(200, { "content-type": "application/json" });
+  response.end(JSON.stringify({ ok: true, result }));
+}
+
+describe("Telegram interactive handler ingress metadata loopback proof", () => {
+  afterEach(() => {
+    resetTelegramClientOptionsCacheForTests();
+    resetPluginRuntimeStateForTest();
+  });
+
+  it("forwards updateId and messageDate verbatim through the real callback path", async () => {
+    // Temporary plugin registry with one registered generic interactive
+    // handler for namespace "proof".
+    const active = createEmptyPluginRegistry();
+    setActivePluginRegistry(active);
+    const received: Array<{ updateId: unknown; messageDate: unknown }> = [];
+    const registration = registerPluginInteractiveHandler("proof-plugin", {
+      channel: "telegram",
+      namespace: "proof",
+      handler: async (ctx: { updateId: unknown; messageDate: unknown }) => {
+        received.push({ updateId: ctx.updateId, messageDate: ctx.messageDate });
+        return { handled: true };
+      },
+    });
+    expect(registration.ok).toBe(true);
+
+    const stateDir = await mkdtemp(join(tmpdir(), "openclaw-telegram-proof-"));
+    const requests: TelegramApiRequest[] = [];
+
+    const handleApiRequest = async (request: IncomingMessage, response: ServerResponse) => {
+      const method = request.url?.split("/").at(-1) ?? "";
+      const payload = await readJsonBody(request);
+      requests.push({ method, payload });
+
+      if (method === "sendMessage") {
+        sendJson(response, {
+          message_id: 88,
+          date: EXPECTED_MESSAGE_DATE,
+          chat: { id: CHAT_ID, type: "private", first_name: "Operator" },
+          from: telegramBotInfoForTest,
+          text: payload.text,
+          reply_markup: payload.reply_markup,
+        });
+      } else if (method === "answerCallbackQuery") {
+        sendJson(response, true);
+      } else if (method === "editMessageText") {
+        sendJson(response, { ok: true });
+      } else {
+        response.writeHead(404, { "content-type": "application/json" });
+        response.end(JSON.stringify({ ok: false, error_code: 404, description: method }));
+      }
+    };
+
+    const server = createServer((request, response) => {
+      void handleApiRequest(request, response).catch((error: unknown) => {
+        response.destroy(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const apiRoot = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+      const storePath = join(stateDir, "sessions.json");
+      const config: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: "anthropic/claude-opus-4-6",
+            models: { "anthropic/claude-opus-4-6": {} },
+          },
+        },
+        channels: {
+          telegram: { apiRoot, botToken: TOKEN, dmPolicy: "open", allowFrom: ["*"] },
+        },
+        session: { store: storePath },
+      };
+      await sendMessageTelegram(String(CHAT_ID), "Proof prompt", {
+        cfg: config,
+        token: TOKEN,
+        buttons: [],
+      });
+
+      const bot = new Bot(TOKEN, { botInfo: telegramBotInfoForTest, client: { apiRoot } });
+      const telegramDeps = {
+        ...defaultTelegramBotDeps,
+        getRuntimeConfig: () => config,
+      };
+      const authorization = {
+        resolveTelegramEventAuthorizationContext: async () => ({
+          threadSpec: { scope: "none" },
+          dmThreadId: undefined,
+          storeAllowFrom: [],
+          groupConfig: undefined,
+        }),
+        authorizeTelegramEventSender: async () => true,
+        isTelegramModelCallbackAuthorized: async () => false,
+      } as unknown as TelegramHandlerAuthorization;
+      const message = {
+        buildSyntheticTextMessage: () => {
+          throw new Error("proof callback must not enter generic message dispatch");
+        },
+        buildSyntheticContext: () => {
+          throw new Error("proof callback must not enter generic message dispatch");
+        },
+        processMessageWithReplyChain: async () => {
+          throw new Error("proof callback must not enter generic message dispatch");
+        },
+        resolveTelegramSessionState: () => ({
+          agentId: "main",
+          sessionEntry: undefined,
+          sessionKey: "agent:main:telegram:direct:1234",
+          storePath,
+          model: undefined,
+        }),
+      } as unknown as TelegramCallbackMessageRuntime;
+      const router = createTelegramCallbackRouter({
+        params: {
+          accountId: "default",
+          bot,
+          runtime: {},
+          telegramDeps,
+          shouldSkipUpdate: () => false,
+        } as unknown as RegisterTelegramHandlerParams,
+        message,
+        authorization,
+      });
+      bot.on("callback_query", async (context) => {
+        await router.route(context);
+      });
+
+      // Real grammY ingress update with the authoritative values.
+      await bot.handleUpdate({
+        update_id: EXPECTED_UPDATE_ID,
+        callback_query: {
+          id: "proof-callback",
+          chat_instance: "proof-chat",
+          data: "proof:ingress-metadata",
+          from: { id: 9, is_bot: false, first_name: "Operator", username: "operator" },
+          message: {
+            message_id: 88,
+            date: EXPECTED_MESSAGE_DATE,
+            chat: { id: CHAT_ID, type: "private", first_name: "Operator" },
+            text: "Proof prompt",
+          },
+        },
+      });
+
+      // The temporary handler must have received the verbatim values.
+      expect(received).toHaveLength(1);
+      expect(received[0].updateId).toBe(EXPECTED_UPDATE_ID);
+      expect(received[0].messageDate).toBe(EXPECTED_MESSAGE_DATE);
+    } finally {
+      server.close();
+      await rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/telegram/src/interactive-ingress-proof.loopback.integration.test.ts
+++ b/extensions/telegram/src/interactive-ingress-proof.loopback.integration.test.ts
@@ -13,13 +13,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Bot } from "grammy";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { afterEach, describe, expect, it } from "vitest";
-import { registerPluginInteractiveHandler } from "../../src/plugins/interactive.js";
-import { createEmptyPluginRegistry } from "../../src/plugins/registry.js";
+import { registerPluginInteractiveHandler } from "openclaw/plugin-sdk/plugin-runtime";
 import {
+  createEmptyPluginRegistry,
   resetPluginRuntimeStateForTest,
   setActivePluginRegistry,
-} from "../../src/plugins/runtime.js";
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, describe, expect, it } from "vitest";
 import { defaultTelegramBotDeps } from "./bot-deps.js";
 import type { TelegramCallbackMessageRuntime } from "./bot-handlers.callback-router-controls.js";
 import { createTelegramCallbackRouter } from "./bot-handlers.callback-router.js";
@@ -65,8 +65,9 @@ describe("Telegram interactive handler ingress metadata loopback proof", () => {
     const registration = registerPluginInteractiveHandler("proof-plugin", {
       channel: "telegram",
       namespace: "proof",
-      handler: async (ctx: { updateId: unknown; messageDate: unknown }) => {
-        received.push({ updateId: ctx.updateId, messageDate: ctx.messageDate });
+      handler: async (ctx: unknown) => {
+        const ingress = ctx as { updateId: unknown; messageDate: unknown };
+        received.push({ updateId: ingress.updateId, messageDate: ingress.messageDate });
         return { handled: true };
       },
     });
@@ -196,8 +197,8 @@ describe("Telegram interactive handler ingress metadata loopback proof", () => {
 
       // The temporary handler must have received the verbatim values.
       expect(received).toHaveLength(1);
-      expect(received[0].updateId).toBe(EXPECTED_UPDATE_ID);
-      expect(received[0].messageDate).toBe(EXPECTED_MESSAGE_DATE);
+      expect(received[0]?.updateId).toBe(EXPECTED_UPDATE_ID);
+      expect(received[0]?.messageDate).toBe(EXPECTED_MESSAGE_DATE);
     } finally {
       server.close();
       await rm(stateDir, { recursive: true, force: true });

--- a/src/plugins/interactive-contract.test-helpers.ts
+++ b/src/plugins/interactive-contract.test-helpers.ts
@@ -17,6 +17,8 @@ type BaseInteractiveContext<TChannel extends string> = ConversationBindingHelper
 
 export type TelegramInteractiveHandlerContext = BaseInteractiveContext<"telegram"> & {
   callbackId: string;
+  updateId: number | null;
+  messageDate: number;
   senderUsername?: string;
   threadId?: number;
   isGroup?: boolean;

--- a/src/plugins/interactive.test.ts
+++ b/src/plugins/interactive.test.ts
@@ -71,6 +71,8 @@ function createTelegramDispatchParams(params: {
     ctx: {
       accountId: "default",
       callbackId: params.callbackId,
+      updateId: 424242,
+      messageDate: 1710000000,
       conversationId: "-10099:topic:77",
       parentConversationId: "-10099",
       senderId: "user-1",
@@ -470,6 +472,8 @@ describe("plugin interactive handlers", () => {
         const telegramCtx = ctx as TelegramInteractiveHandlerContext;
         expect(telegramCtx.channel).toBe("telegram");
         expect(telegramCtx.conversationId).toBe("-10099:topic:77");
+        expect(telegramCtx.updateId).toBe(424242);
+        expect(telegramCtx.messageDate).toBe(1710000000);
         expect(telegramCtx.callback.namespace).toBe("codex");
         expect(telegramCtx.callback.payload).toBe("resume:thread-1");
         expect(telegramCtx.callback.chatId).toBe("-10099");


### PR DESCRIPTION
## What Problem This Solves

Plugin authors building interactive Telegram handlers (namespace-scoped
callback flows such as confirmation or approval prompts) currently cannot
access the authoritative Telegram `update_id` or the callback message's
`date` inside the dispatched handler context. Both values already exist at
the ingress — the incoming update and the parsed callback message carry
them — but they are dropped before the plugin context object is built.
Handlers that need to correlate an interaction with its originating
Telegram update, or reason about the message timestamp, have no reliable
source and are forced to synthesize timestamps or correlation keys, which
is fragile and weakens auditability of Telegram-driven plugin flows.

## Why This Change Was Made

The Telegram ingress already resolves the authoritative `update_id` for its
own bookkeeping (`resolveTelegramUpdateId` in
`extensions/telegram/src/telegram-ingress-spool.ts`), and the callback
message carries its mandatory `date` field. This change forwards both
values verbatim into `TelegramInteractiveHandlerContext` as new required
fields `updateId` and `messageDate`. The change is purely additive: no
synthesis, no fallback, no transformation, and no change to callback
routing, `handled` semantics, agent fallback, authentication, or approval
logic.

## User Impact

Plugin authors of interactive Telegram handlers can now:

- correlate a callback interaction with the exact originating Telegram
  update via `updateId`. The field is `number | null` and is `null` only
  when no valid `update_id` is available (synthetic updates or malformed
  values); consumers must treat `null` fail-closed (no synthesis, no
  substitute value);
- read the callback message's Unix timestamp via `messageDate`
  (always a number, matching grammY's mandatory `Message.date`).

Existing handlers are unaffected: the fields are additive, and no existing
dispatch behavior changes.

## Proposed change

Forward the two authoritative values already present at the Telegram
ingress into `TelegramInteractiveHandlerContext`:

- `updateId` — resolved via the existing `resolveTelegramUpdateId(ctx.update)`
  helper (source: `ctx.update.update_id`), typed `number | null` to match
  the helper's actual return type under the repository's `strict`
  tsconfig;
- `messageDate` — taken directly from `callbackMessage.date`
  (source: `callback_query.message.date`), typed `number`.

Both values pass through the existing callback router into
`handleTelegramInteractiveCallback`, which forwards them into the
dispatched plugin context unchanged.

## Runtime changes

- `extensions/telegram/src/bot-handlers.callback-router.ts`: import
  `resolveTelegramUpdateId`; pass `updateId: resolveTelegramUpdateId(ctx.update)`
  and `messageDate: callbackMessage.date` into the existing
  `handleTelegramInteractiveCallback` call. No other routing logic
  changes.
- `extensions/telegram/src/bot-handlers.callback-router-controls.ts`:
  accept `updateId`/`messageDate` in the call parameters and forward them
  into the `ctx` object of `dispatchTelegramPluginInteractiveHandler`.
  No dispatch, `handled`, fallback, or authentication logic changes.

## Type changes

- `extensions/telegram/src/interactive-dispatch.ts`:
  `TelegramInteractiveHandlerContext` gains two required fields:
  - `updateId: number | null` — `null` for synthetic updates or any
    update lacking a valid `update_id` (missing, non-numeric, negative,
    or unsafe-integer values); valid Bot API `callback_query` updates
    always provide a number. Consumers must treat `null` fail-closed.
  - `messageDate: number` — Unix seconds from the authoritative
    `callbackQuery.message.date`.
- `src/plugins/interactive-contract.test-helpers.ts`: test-helper type
  mirrors the same two fields.
- No other public type is touched.

## Security / trust-boundary rationale

- No new secrets, credentials, identities, or sensitive fields are
  exposed: both values are public Telegram update metadata already
  present on the ingress path.
- No new network surface: no poller, no webhook, no new consumer, no
  outbound calls. Tests remain offline.
- Values are passed through verbatim from the authoritative source; no
  value is ever synthesized, hashed, derived, or replaced, and a missing
  or invalid `update_id` yields an explicit `null` (fail-closed) rather
  than a fabricated identifier. This preserves the trust boundary between
  the Telegram ingress and plugin handlers.
- No change to callback namespace matching, `handled` semantics, agent
  fallback, command handling, or authentication rules.

## Backward compatibility

- Additive only: new required fields are introduced on the context type
  that the Telegram extension itself constructs; existing handler
  registrations compile and run unchanged (they simply do not read the
  new fields).
- `dispatchTelegramInteractive`, `handled` semantics, namespace matching,
  auth, and agent fallback are untouched.
- OpenClaw's own tests are extended only in the shared test helper
  (`src/plugins/interactive-contract.test-helpers.ts`) and
  `src/plugins/interactive.test.ts` (fixed fixture values and
  value-equality assertions).

## Tests

- `src/plugins/interactive.test.ts`: fixture now includes
  `updateId: 424242` and `messageDate: 1710000000`, with value-equality
  assertions that the dispatched `TelegramInteractiveHandlerContext`
  receives both values verbatim.
- Existing interactive-handler tests continue to pass; no test asserts
  different routing, `handled`, fallback, or dedup behavior.
- Validation: `git apply --check` against current `main` is clean; the
  repository's standard lanes (`pnpm build && pnpm check && pnpm test`,
  and `pnpm test:extension telegram` for the extension surface) run in CI.

## Scope exclusions

- No changes to the Telegram ingress, polling, webhook handling, or
  spool/dedup logic.
- No changes to plugin SDK semantics, namespace matching, or agent
  fallback.
- No new dependencies, no new configuration, no database/schema changes,
  no CHANGELOG edit (maintainers add changelog entries on landing).
- No refactoring beyond the minimal additive pass-through.

## Evidence

## Evidence

**Real behavior proof (loopback):** A real grammY Bot with an HTTP Bot API
loopback (127.0.0.1) drives a Telegram `callback_query` update through the real
callback router and generic interactive dispatcher into a temporary registered
handler. The handler receives the authoritative ingress values verbatim:
`updateId === 424242`, `messageDate === 1710000000` (see
`interactive-ingress-proof.loopback.integration.test.ts`). No live Telegram
account, no second poller, no webhook, no owner-approval state change.

- **Focused test coverage:** `src/plugins/interactive.test.ts` dispatches a
  Telegram callback with fixed fixture values (`updateId: 424242`,
  `messageDate: 1710000000`) and asserts the handler receives both values
  verbatim in `TelegramInteractiveHandlerContext`.
- **Type/runtime consistency:** `updateId` is typed `number | null`,
  matching the existing `resolveTelegramUpdateId` helper's return type
  under the repository's `strict` tsconfig; `messageDate: number` matches
  grammY's mandatory `Message.date`. The change contains no synthesized or
  fallback values.
- **Clean apply against main:** the patch applies cleanly
  (`git apply --check`) to current `main`; the PR diff is exactly 5 files,
  +29/−0, purely additive.
- **CI:** repository checks run against this PR (status visible on the
  PR). The extension test lane (`pnpm test:extension telegram`) and the
  interactive plugin unit tests cover the touched surface.

