### PR TITLE
fix(cli): keep setup and agent help startup lazy

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2443,7 +2443,7 @@ src/cli/update-cli/update-command-config.ts	6
 src/cli/update-cli/update-command-plugins.ts	1
 src/cli/update-cli/update-command-post-update.ts	2
 src/cli/users-cli.ts	1
-src/commands/agent-exec.ts	6
+src/commands/agent-exec.ts	1
 src/commands/agent-via-gateway.ts	7
 src/commands/agents.commands.bind.ts	5
 src/commands/agents.commands.identity.ts	1

--- a/scripts/code-mode-model-matrix.ts
+++ b/scripts/code-mode-model-matrix.ts
@@ -15,7 +15,7 @@ import {
   type QaEvidenceStatus,
   type QaEvidenceSummaryJson,
 } from "../extensions/qa-lab/api.js";
-import type { AgentExecEnvelope } from "../src/commands/agent-exec.ts";
+import type { AgentExecEnvelope } from "../src/commands/agent-exec-result.ts";
 import { requireOptionArgument } from "./lib/arg-utils.mts";
 import { previewForDevToolLog, redactJsonValueForDevToolLog } from "./lib/dev-tooling-safety.ts";
 

--- a/scripts/lib/config-boundary-guard.mts
+++ b/scripts/lib/config-boundary-guard.mts
@@ -40,7 +40,7 @@ const PROCESS_BOUNDARY_DIRECT_CONFIG_LOAD_FILES = new Set([
   // reads the ambient location and resolves from an already published runtime
   // snapshot, so it cannot express a pinned run; the file-scoped loader is the
   // point. Ambient resolution in the same command does use `getRuntimeConfig()`.
-  "src/commands/agent-exec.ts",
+  "src/commands/agent-exec-input.ts",
 ]);
 
 const BROAD_CONFIG_RUNTIME_COMPAT_FILES = new Set([

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
-import { classifyAgentExecResult } from "../../../commands/agent-exec.js";
+import { classifyAgentExecResult } from "../../../commands/agent-exec-result.js";
 import {
   buildEmbeddedRunnerAssistant,
   makeEmbeddedRunnerAttempt,

--- a/src/cli/help-cold-imports.test.ts
+++ b/src/cli/help-cold-imports.test.ts
@@ -148,6 +148,11 @@ vi.mock("../commands/agent-via-gateway.js", () => {
   return { agentCliCommand: vi.fn(async () => {}) };
 });
 
+vi.mock("../commands/agent-exec.js", () => {
+  loaded.mark("agent-exec-command");
+  return { agentExecCommand: vi.fn(async () => {}) };
+});
+
 vi.mock("../commands/agents.commands.add.js", () => {
   loaded.mark("agents-add-command");
   return { agentsAddCommand: vi.fn(async () => {}) };
@@ -311,23 +316,27 @@ describe("subcommand help cold imports", () => {
     expect(loaded.modules).not.toContain("default-runtime");
   });
 
-  it("keeps agents help out of agent action modules", async () => {
-    const { registerAgentsCommands } = await import("./program/register.agent.js");
-    const { registerAgentTurnCommand } = await import("./program/register.agent-turn.js");
-    const program = makeProgram();
+  it.each(["agent", "agent exec", "agents"])(
+    "keeps %s help out of agent action modules",
+    async (command) => {
+      const { registerAgentsCommands } = await import("./program/register.agent.js");
+      const { registerAgentTurnCommand } = await import("./program/register.agent-turn.js");
+      const program = makeProgram();
 
-    registerAgentTurnCommand(program, { agentChannelOptions: "last|telegram|discord" });
-    registerAgentsCommands(program);
-    await expectHelpExit(program, ["agents", "--help"]);
+      registerAgentTurnCommand(program, { agentChannelOptions: "last|telegram|discord" });
+      registerAgentsCommands(program);
+      await expectHelpExit(program, [...command.split(" "), "--help"]);
 
-    expect(loaded.modules).not.toContain("agent-via-gateway-command");
-    expect(loaded.modules).not.toContain("agents-add-command");
-    expect(loaded.modules).not.toContain("agents-bind-command");
-    expect(loaded.modules).not.toContain("agents-delete-command");
-    expect(loaded.modules).not.toContain("agents-identity-command");
-    expect(loaded.modules).not.toContain("agents-list-command");
-    expect(loaded.modules).not.toContain("default-runtime");
-  });
+      expect(loaded.modules).not.toContain("agent-via-gateway-command");
+      expect(loaded.modules).not.toContain("agent-exec-command");
+      expect(loaded.modules).not.toContain("agents-add-command");
+      expect(loaded.modules).not.toContain("agents-bind-command");
+      expect(loaded.modules).not.toContain("agents-delete-command");
+      expect(loaded.modules).not.toContain("agents-identity-command");
+      expect(loaded.modules).not.toContain("agents-list-command");
+      expect(loaded.modules).not.toContain("default-runtime");
+    },
+  );
 
   it("keeps secrets help out of secrets action modules", async () => {
     const { registerSecretsCli } = await import("./secrets-cli.js");

--- a/src/cli/program/register.agent-turn.ts
+++ b/src/cli/program/register.agent-turn.ts
@@ -7,36 +7,9 @@ import { THINKING_LEVELS_HELP } from "../../auto-reply/thinking.shared.js";
 import { inheritOptionFromParent } from "../command-options.js";
 import { measureCliCommandStartup } from "../command-startup-timing.js";
 import { formatHelpExamples } from "../help-format.js";
-import { requestExitAfterOneShotOutput } from "../one-shot-exit.js";
-
-type AgentViaGatewayModule = typeof import("../../commands/agent-via-gateway.js");
-type AgentExecModule = typeof import("../../commands/agent-exec.js");
-type CliUtilsModule = typeof import("../cli-utils.js");
-type GlobalStateModule = typeof import("../../global-state.js");
-type RuntimeModule = typeof import("../../runtime.js");
-
-async function loadAgentCliCommand(): Promise<AgentViaGatewayModule["agentCliCommand"]> {
-  return (await import("../../commands/agent-via-gateway.js")).agentCliCommand;
-}
-
-async function loadAgentExecCommand(): Promise<AgentExecModule["agentExecCommand"]> {
-  return (await import("../../commands/agent-exec.js")).agentExecCommand;
-}
 
 function collectFallback(value: string, previous: string[]): string[] {
   return [...previous, value];
-}
-
-async function loadDefaultRuntime(): Promise<RuntimeModule["defaultRuntime"]> {
-  return (await import("../../runtime.js")).defaultRuntime;
-}
-
-async function loadRunCommandWithRuntime(): Promise<CliUtilsModule["runCommandWithRuntime"]> {
-  return (await import("../cli-utils.js")).runCommandWithRuntime;
-}
-
-async function loadSetVerbose(): Promise<GlobalStateModule["setVerbose"]> {
-  return (await import("../../global-state.js")).setVerbose;
 }
 
 /** Register `openclaw agent` for one Gateway-backed agent turn. */
@@ -110,15 +83,21 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
     .action(async (opts): Promise<void> => {
       const verboseLevel =
         typeof opts.verbose === "string" ? normalizeLowercaseStringOrEmpty(opts.verbose) : "";
-      const [defaultRuntime, runCommandWithRuntime, setVerbose, agentCliCommand] =
-        await measureCliCommandStartup("agent-action-imports", () =>
-          Promise.all([
-            loadDefaultRuntime(),
-            loadRunCommandWithRuntime(),
-            loadSetVerbose(),
-            loadAgentCliCommand(),
-          ]),
-        );
+      const [
+        { defaultRuntime },
+        { runCommandWithRuntime },
+        { setVerbose },
+        { agentCliCommand },
+        { requestExitAfterOneShotOutput },
+      ] = await measureCliCommandStartup("agent-action-imports", () =>
+        Promise.all([
+          import("../../runtime.js"),
+          import("../cli-utils.js"),
+          import("../../global-state.js"),
+          import("../../commands/agent-via-gateway.js"),
+          import("../one-shot-exit.js"),
+        ]),
+      );
       await runCommandWithRuntime(defaultRuntime, async () => {
         setVerbose(verboseLevel === "on");
         await agentCliCommand(opts, defaultRuntime);
@@ -193,10 +172,16 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
         timeout: inheritOptionFromParent<string>(command, "timeout") ?? opts.timeout,
         json: opts.json === true || parentOpts?.json === true,
       };
-      const [defaultRuntime, runCommandWithRuntime, agentExecCommand] = await Promise.all([
-        loadDefaultRuntime(),
-        loadRunCommandWithRuntime(),
-        loadAgentExecCommand(),
+      const [
+        { defaultRuntime },
+        { runCommandWithRuntime },
+        { agentExecCommand },
+        { requestExitAfterOneShotOutput },
+      ] = await Promise.all([
+        import("../../runtime.js"),
+        import("../cli-utils.js"),
+        import("../../commands/agent-exec.js"),
+        import("../one-shot-exit.js"),
       ]);
       await runCommandWithRuntime(defaultRuntime, async () => {
         const result = await agentExecCommand(message, execOpts, defaultRuntime);

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -6,7 +6,6 @@ import { theme } from "../../../packages/terminal-core/src/theme.js";
 import { formatAuthChoiceChoicesForCli } from "../../commands/auth-choice-options.js";
 import type { GatewayDaemonRuntime } from "../../commands/daemon-runtime.js";
 import { CORE_ONBOARD_AUTH_FLAGS } from "../../commands/onboard-core-auth-flags.js";
-import { rejectOnboardingOption } from "../../commands/onboard-options.js";
 import type {
   AuthChoice,
   GatewayAuthChoice,
@@ -45,11 +44,11 @@ const MODERN_ONBOARD_OPTION_KEYS = new Set([
   "json",
 ]);
 
-function validateRecommendationParentOptions(
+async function validateRecommendationParentOptions(
   command: Command,
   runtime: RuntimeEnv,
   json = false,
-): boolean {
+): Promise<boolean> {
   const unsupported = listExplicitOptionFlagsExcept(
     command,
     json ? RECOMMENDATION_READ_PARENT_OPTIONS : NO_RECOMMENDATION_PARENT_OPTIONS,
@@ -57,6 +56,7 @@ function validateRecommendationParentOptions(
   if (unsupported.length === 0) {
     return true;
   }
+  const { rejectOnboardingOption } = await import("../../commands/onboard-options.js");
   return rejectOnboardingOption(
     { json },
     runtime,
@@ -227,12 +227,13 @@ function pickOnboardAuthOptionValues(opts: Record<string, unknown>): Partial<Onb
   };
 }
 
-export function resolveOnboardCommandOptions(
+export async function resolveOnboardCommandOptions(
   opts: Record<string, unknown>,
   command: Command,
   runtime: RuntimeEnv,
-): OnboardOptions | false {
+): Promise<OnboardOptions | false> {
   if (opts.customImageInput === true && opts.customTextInput === true) {
+    const { rejectOnboardingOption } = await import("../../commands/onboard-options.js");
     const message = "Use either --custom-image-input or --custom-text-input, not both.";
     return rejectOnboardingOption({ json: opts.json === true }, runtime, message);
   }
@@ -321,7 +322,7 @@ export function registerOnboardCommand(program: Command): void {
       const { defaultRuntime } = await import("../../runtime.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
         const json = Boolean(opts.json || recommendationsCommand.parent?.opts().json);
-        if (!validateRecommendationParentOptions(command, defaultRuntime, json)) {
+        if (!(await validateRecommendationParentOptions(command, defaultRuntime, json))) {
           return;
         }
         const { onboardRecommendationsCommand } =
@@ -338,8 +339,8 @@ export function registerOnboardCommand(program: Command): void {
       const { defaultRuntime } = await import("../../runtime.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
         if (
-          !validateRecommendationParentOptions(command, defaultRuntime) ||
-          !validateRecommendationParentOptions(recommendations, defaultRuntime)
+          !(await validateRecommendationParentOptions(command, defaultRuntime)) ||
+          !(await validateRecommendationParentOptions(recommendations, defaultRuntime))
         ) {
           return;
         }
@@ -356,8 +357,8 @@ export function registerOnboardCommand(program: Command): void {
       const { defaultRuntime } = await import("../../runtime.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
         if (
-          !validateRecommendationParentOptions(command, defaultRuntime) ||
-          !validateRecommendationParentOptions(recommendations, defaultRuntime)
+          !(await validateRecommendationParentOptions(command, defaultRuntime)) ||
+          !(await validateRecommendationParentOptions(recommendations, defaultRuntime))
         ) {
           return;
         }
@@ -370,6 +371,7 @@ export function registerOnboardCommand(program: Command): void {
   command.action(async (opts, commandRuntime: Command) => {
     const { defaultRuntime } = await import("../../runtime.js");
     await runCommandWithRuntime(defaultRuntime, async () => {
+      const { rejectOnboardingOption } = await import("../../commands/onboard-options.js");
       const rejectOption = (message: string) =>
         rejectOnboardingOption({ json: Boolean(opts.json) }, defaultRuntime, message);
       if (opts.modern) {
@@ -416,7 +418,7 @@ export function registerOnboardCommand(program: Command): void {
         );
         return;
       }
-      const onboardingOptions = resolveOnboardCommandOptions(
+      const onboardingOptions = await resolveOnboardCommandOptions(
         opts as Record<string, unknown>,
         commandRuntime,
         defaultRuntime,

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -3,7 +3,6 @@ import { readStringValue } from "@openclaw/normalization-core/string-coerce";
 import type { Command } from "commander";
 import { formatDocsLink } from "../../../packages/terminal-core/src/links.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
-import { rejectOnboardingOption } from "../../commands/onboard-options.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { hasExplicitOptions, listExplicitOptionFlagsExcept } from "../command-options.js";
@@ -92,6 +91,7 @@ async function runOnboardingEntry(
   if (options.baseline) {
     const unsupportedOptions = listExplicitOptionFlagsExcept(commandRuntime, BASELINE_OPTION_NAMES);
     if (unsupportedOptions.length > 0) {
+      const { rejectOnboardingOption } = await import("../../commands/onboard-options.js");
       const message = `--baseline cannot be combined with: ${unsupportedOptions.join(", ")}.`;
       rejectOnboardingOption({ json: options.json === true }, runtime, message);
       return;
@@ -103,7 +103,7 @@ async function runOnboardingEntry(
     );
     return;
   }
-  const onboardingOptions = resolveOnboardCommandOptions(options, commandRuntime, runtime);
+  const onboardingOptions = await resolveOnboardCommandOptions(options, commandRuntime, runtime);
   if (!onboardingOptions) {
     return;
   }

--- a/src/commands/agent-exec-input.ts
+++ b/src/commands/agent-exec-input.ts
@@ -1,0 +1,231 @@
+import { createReadStream, existsSync } from "node:fs";
+import path from "node:path";
+import { TextDecoder } from "node:util";
+import { readByteStreamWithLimit } from "@openclaw/media-core/read-byte-stream-with-limit";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { mergeDeep } from "../infra/deep-merge.js";
+
+const AGENT_EXEC_MESSAGE_MAX_BYTES = 4 * 1024 * 1024;
+const UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
+
+export type AgentExecCliOptions = {
+  messageFile?: string;
+  cwd?: string;
+  stateDir?: string;
+  config?: string;
+  isolated?: boolean;
+  model?: string;
+  thinking?: string;
+  fallback?: string[];
+  codeMode?: "direct" | "auto" | "code";
+  localModelLean?: boolean;
+  authEnvOnly?: boolean;
+  timeout?: string;
+  json?: boolean;
+};
+
+function decodePrompt(bytes: Buffer, source: string): string {
+  let value: string;
+  try {
+    value = UTF8_DECODER.decode(bytes).replace(/^\uFEFF/, "");
+  } catch {
+    throw new Error(`${source} must be valid UTF-8`);
+  }
+  if (!value.trim()) {
+    throw new Error(`${source} is empty`);
+  }
+  return value;
+}
+
+async function readPromptStream(stream: AsyncIterable<unknown>, source: string): Promise<string> {
+  const bytes = await readByteStreamWithLimit(stream, {
+    maxBytes: AGENT_EXEC_MESSAGE_MAX_BYTES,
+    onOverflow: () => new Error(`${source} exceeds ${String(AGENT_EXEC_MESSAGE_MAX_BYTES)} bytes`),
+  });
+  return decodePrompt(bytes, source);
+}
+
+/** Resolve the one allowed prompt source for `agent exec`. */
+export async function resolveAgentExecPrompt(
+  positionalMessage: string | undefined,
+  messageFile: string | undefined,
+  stdin: AsyncIterable<unknown> = process.stdin,
+): Promise<string> {
+  const file = messageFile?.trim();
+  const hasPositional = positionalMessage !== undefined;
+  if (hasPositional && file) {
+    throw new Error("Use either the prompt argument or --message-file, not both.");
+  }
+  if (messageFile !== undefined && !file) {
+    throw new Error("--message-file must not be empty.");
+  }
+  if (file) {
+    const stream = file === "-" ? stdin : createReadStream(file);
+    try {
+      return await readPromptStream(stream, file === "-" ? "stdin" : `Message file ${file}`);
+    } catch (error) {
+      if (file === "-" || !(error instanceof Error) || !("code" in error)) {
+        throw error;
+      }
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") {
+        throw new Error(`Message file not found: ${file}`, { cause: error });
+      }
+      throw error;
+    }
+  }
+  if (!positionalMessage?.trim()) {
+    throw new Error("Missing prompt. Pass text or use --message-file <path>.");
+  }
+  return positionalMessage;
+}
+
+/**
+ * Facts owned by this invocation rather than by any config, so they win over
+ * both the ambient config and `--config`: exec is always scoped to the folder
+ * it was pointed at, a one-shot turn never bootstraps, and explicit flags
+ * outrank whatever the resolved config says.
+ */
+/**
+ * Drops inherited state and workspace location overrides, which outrank the
+ * facts this invocation owns. `session.store` and `agentDir` can redirect state
+ * outside the invocation root, where its lock or temporary cleanup cannot own
+ * it; a native harness `runtime.acp.cwd` can make the turn edit the wrong repo.
+ * `agents.bindings[].acp.cwd` needs no equivalent because exec runs no channel,
+ * so no binding matches.
+ */
+function stripInheritedAgentLocations(base: OpenClawConfig): OpenClawConfig {
+  const { session, ...root } = base;
+  const { store: _store, ...sessionWithoutStore } = session ?? {};
+  const withoutSessionStore = session ? { ...root, session: sessionWithoutStore } : base;
+  const entries = withoutSessionStore.agents?.entries;
+  if (!entries) {
+    return withoutSessionStore;
+  }
+  return {
+    ...withoutSessionStore,
+    agents: {
+      ...withoutSessionStore.agents,
+      entries: Object.fromEntries(
+        Object.entries(entries).map(([id, entry]) => {
+          const { agentDir: _agentDir, runtime, ...rest } = entry;
+          if (runtime?.type !== "acp" || runtime.acp?.cwd === undefined) {
+            return [id, { ...rest, ...(runtime ? { runtime } : {}) }];
+          }
+          const { cwd: _cwd, ...acp } = runtime.acp;
+          return [id, { ...rest, runtime: { ...runtime, acp } }];
+        }),
+      ),
+    },
+  } as OpenClawConfig;
+}
+
+function buildExecRunOverlay(params: {
+  base: OpenClawConfig;
+  cwd: string;
+  opts: Pick<AgentExecCliOptions, "localModelLean">;
+}): OpenClawConfig {
+  // A per-agent `workspace` outranks `agents.defaults`, so pinning only the
+  // defaults would let an inherited entry silently run the turn against a
+  // different repository. Override every configured entry as well.
+  const entries = Object.keys(params.base.agents?.entries ?? {});
+  return {
+    agents: {
+      defaults: {
+        workspace: params.cwd,
+        skipBootstrap: true,
+        ...(params.opts.localModelLean ? { experimental: { localModelLean: true } } : {}),
+      },
+      ...(entries.length > 0
+        ? { entries: Object.fromEntries(entries.map((id) => [id, { workspace: params.cwd }])) }
+        : {}),
+    },
+    // This process exits after one turn, so live skill invalidation cannot be
+    // observed and would leave Chokidar retaining the otherwise-finished CLI.
+    skills: { load: { watch: false } },
+  } as OpenClawConfig;
+}
+
+/**
+ * Coding one-shot defaults. These merge *under* the resolved config so an
+ * operator who configured a tool profile, shell env, or sandbox keeps it;
+ * notably exec must never downgrade a configured sandbox to `off`.
+ */
+function buildExecConfigDefaults(): OpenClawConfig {
+  return {
+    env: { shellEnv: { enabled: false } },
+    agents: { defaults: { sandbox: { mode: "off" } } },
+    tools: {
+      profile: "coding",
+      fs: { workspaceOnly: true },
+      // No `exec.host`: the default `auto` already resolves to the gateway when
+      // no sandbox is configured, and pinning `gateway` here would route
+      // commands back onto the host for an inherited config that enables one.
+      // `mode: "full"` stays because a headless one-shot has no approval channel.
+      exec: { mode: "full" },
+    },
+  };
+}
+
+/**
+ * Resolves the config exec runs against. Default is the ambient config, so a
+ * one-shot turn behaves like other folder-scoped coding CLIs and can reach
+ * configured providers, credentials, and `agentRuntime` harness choices.
+ *
+ * `--auth-env-only` opts out of that inheritance entirely rather than trying to
+ * launder the resolved config. A config is a credential store by design -- API
+ * keys, secret headers, request auth, an inline `env` block, and login-shell
+ * import all feed provider auth -- so the only closed way to promise
+ * environment-only credentials is to not read it.
+ */
+export async function resolveExecBaseConfig(
+  opts: Pick<AgentExecCliOptions, "authEnvOnly" | "config" | "isolated">,
+): Promise<OpenClawConfig> {
+  // `--isolated` and `--auth-env-only` both mean "read no config", so pairing
+  // either with `--config` is a contradiction. Failing beats silently ignoring
+  // the pinned file, which would run a CI invocation on bare exec defaults.
+  if (opts.config && (opts.isolated || opts.authEnvOnly === true)) {
+    const conflicting = opts.isolated ? "--isolated" : "--auth-env-only";
+    throw new Error(`--config cannot be combined with ${conflicting}.`);
+  }
+  if (opts.isolated || opts.authEnvOnly === true) {
+    // A missing config is normally passed through the persisted-config
+    // migrations, which materialize the legacy main agent. Configless exec
+    // modes must preserve that runtime contract even though they skip all
+    // authored config and its credential surfaces.
+    const { migratePersistedImplicitMainRoster } = await import("../config/legacy.roster.js");
+    const { coerceConfig } = await import("../config/io.read-helpers.js");
+    return coerceConfig(migratePersistedImplicitMainRoster({}).config);
+  }
+  const { createConfigIO, getRuntimeConfig } = await import("../config/io.js");
+  if (!opts.config) {
+    // Ambient means "whatever this process considers effective", so this honors a
+    // runtime snapshot an in-process caller already published and otherwise loads
+    // the ordinary config file exactly as any other command does.
+    return getRuntimeConfig();
+  }
+  // `--config` pins an exact file. The factory loader reads that file directly --
+  // unlike the module-level loader it never resolves from a published runtime
+  // snapshot, so a pinned run cannot be shadowed by one. It throws on a config
+  // that exists but is invalid, so the run cannot silently degrade to exec
+  // defaults, and it finalizes the load (config `env` block, shell-env fallback).
+  const io = createConfigIO({ configPath: path.resolve(opts.config) });
+  if (!existsSync(io.configPath)) {
+    throw new Error(`--config file not found: ${io.configPath}`);
+  }
+  return io.loadConfig();
+}
+
+export function buildExecRunConfig(params: {
+  base: OpenClawConfig;
+  cwd: string;
+  opts?: Pick<AgentExecCliOptions, "localModelLean">;
+}): OpenClawConfig {
+  const opts = params.opts ?? {};
+  const base = stripInheritedAgentLocations(params.base);
+  const withDefaults = mergeDeep(buildExecConfigDefaults(), base) as OpenClawConfig;
+  return mergeDeep(
+    withDefaults,
+    buildExecRunOverlay({ base, cwd: params.cwd, opts }),
+  ) as OpenClawConfig;
+}

--- a/src/commands/agent-exec-input.ts
+++ b/src/commands/agent-exec-input.ts
@@ -67,7 +67,7 @@ export async function resolveAgentExecPrompt(
       if (file === "-" || !(error instanceof Error) || !("code" in error)) {
         throw error;
       }
-      const code = (error as NodeJS.ErrnoException).code;
+      const code = error.code;
       if (code === "ENOENT") {
         throw new Error(`Message file not found: ${file}`, { cause: error });
       }
@@ -117,7 +117,7 @@ function stripInheritedAgentLocations(base: OpenClawConfig): OpenClawConfig {
         }),
       ),
     },
-  } as OpenClawConfig;
+  };
 }
 
 function buildExecRunOverlay(params: {
@@ -143,7 +143,7 @@ function buildExecRunOverlay(params: {
     // This process exits after one turn, so live skill invalidation cannot be
     // observed and would leave Chokidar retaining the otherwise-finished CLI.
     skills: { load: { watch: false } },
-  } as OpenClawConfig;
+  };
 }
 
 /**
@@ -223,9 +223,8 @@ export function buildExecRunConfig(params: {
 }): OpenClawConfig {
   const opts = params.opts ?? {};
   const base = stripInheritedAgentLocations(params.base);
-  const withDefaults = mergeDeep(buildExecConfigDefaults(), base) as OpenClawConfig;
   return mergeDeep(
-    withDefaults,
+    mergeDeep(buildExecConfigDefaults(), base),
     buildExecRunOverlay({ base, cwd: params.cwd, opts }),
-  ) as OpenClawConfig;
+  ) as OpenClawConfig; // SAFETY: Merging three typed configs preserves the OpenClawConfig shape.
 }

--- a/src/commands/agent-exec-result.ts
+++ b/src/commands/agent-exec-result.ts
@@ -1,0 +1,153 @@
+import type { EmbeddedAgentRunMeta } from "../agents/embedded-agent.js";
+
+type AgentExecPayload = {
+  text?: string;
+  mediaUrl?: string | null;
+  mediaUrls?: string[];
+  isError?: boolean;
+  isReasoning?: boolean;
+  isCommentary?: boolean;
+};
+
+type AgentExecRawPayload = AgentExecPayload & Record<string, unknown>;
+
+export type AgentExecRunResult = {
+  payloads?: AgentExecRawPayload[];
+  meta: EmbeddedAgentRunMeta;
+};
+
+type AgentExecStatus = "ok" | "error" | "timeout";
+
+export type AgentExecEnvelope = {
+  ok: boolean;
+  status: AgentExecStatus;
+  final: string;
+  payloads: AgentExecPayload[];
+  usage?: NonNullable<NonNullable<EmbeddedAgentRunMeta["agentMeta"]>["usage"]>;
+  costUsd?: number;
+  codeModeEngaged?: boolean;
+  assistantTurns?: number;
+  bridgeCalls?: NonNullable<NonNullable<EmbeddedAgentRunMeta["agentMeta"]>["bridgeCalls"]>;
+  toolSummary?: NonNullable<EmbeddedAgentRunMeta["toolSummary"]>;
+  model: string | null;
+  provider: string | null;
+  sessionId: string;
+  error?: {
+    message: string;
+    kind: string;
+  };
+};
+
+function projectAgentExecPayload(payload: AgentExecRawPayload): AgentExecPayload {
+  return {
+    ...(typeof payload.text === "string" ? { text: payload.text } : {}),
+    ...(payload.mediaUrl !== undefined ? { mediaUrl: payload.mediaUrl } : {}),
+    ...(Array.isArray(payload.mediaUrls) ? { mediaUrls: [...payload.mediaUrls] } : {}),
+    ...(payload.isError === true ? { isError: true } : {}),
+    ...(payload.isReasoning === true ? { isReasoning: true } : {}),
+    ...(payload.isCommentary === true ? { isCommentary: true } : {}),
+  };
+}
+
+function finalTextFromResult(
+  result: AgentExecRunResult,
+  payloads: AgentExecPayload[],
+  allowMetadataFallback: boolean,
+): string {
+  const payloadText = payloads
+    .filter(
+      (payload) =>
+        payload.isError !== true &&
+        payload.isReasoning !== true &&
+        payload.isCommentary !== true &&
+        typeof payload.text === "string" &&
+        payload.text.trim().length > 0,
+    )
+    .map((payload) => payload.text!.trimEnd())
+    .join("\n");
+  return (
+    payloadText ||
+    (allowMetadataFallback ? result.meta.finalAssistantVisibleText?.trimEnd() : "") ||
+    ""
+  );
+}
+
+function firstErrorPayload(result: AgentExecRunResult): AgentExecPayload | undefined {
+  return result.payloads?.find((payload) => payload.isError === true);
+}
+
+/** Classify an embedded result into the strict `agent exec` process contract. */
+export function classifyAgentExecResult(
+  result: AgentExecRunResult,
+  fallbackExhausted = false,
+  projectedErrorPayload?: string | true,
+): AgentExecEnvelope {
+  const meta = result.meta;
+  const errorPayload = firstErrorPayload(result);
+  const errorPayloadMessage =
+    typeof projectedErrorPayload === "string"
+      ? projectedErrorPayload
+      : typeof errorPayload?.text === "string" && errorPayload.text.trim()
+        ? errorPayload.text
+        : undefined;
+  const hasErrorPayload = projectedErrorPayload !== undefined || errorPayload !== undefined;
+  const payloads = (result.payloads ?? []).map(projectAgentExecPayload);
+  if (typeof projectedErrorPayload === "string") {
+    const projectedErrorIndex = payloads.findIndex(
+      (payload) => payload.isError !== true && payload.text === projectedErrorPayload,
+    );
+    if (projectedErrorIndex >= 0) {
+      payloads[projectedErrorIndex] = {
+        ...payloads[projectedErrorIndex],
+        isError: true,
+      };
+    }
+  }
+  const timeout = meta.stopReason === "timeout" || meta.timeoutPhase !== undefined;
+  const failed =
+    fallbackExhausted ||
+    meta.aborted === true ||
+    meta.error !== undefined ||
+    meta.stopReason === "error" ||
+    hasErrorPayload;
+  const status: AgentExecStatus = timeout ? "timeout" : failed ? "error" : "ok";
+  const errorMessage = timeout
+    ? (meta.error?.message ?? errorPayloadMessage ?? "Agent run timed out")
+    : fallbackExhausted
+      ? (meta.error?.message ?? errorPayloadMessage ?? "All model fallback candidates failed")
+      : (meta.error?.message ?? errorPayloadMessage ?? (failed ? "Agent run failed" : undefined));
+  const errorKind = timeout
+    ? "timeout"
+    : fallbackExhausted
+      ? "fallback_exhausted"
+      : meta.error?.kind
+        ? meta.error.kind
+        : meta.aborted
+          ? "aborted"
+          : hasErrorPayload
+            ? "error_payload"
+            : failed
+              ? "agent_error"
+              : undefined;
+  const agentMeta = meta.agentMeta;
+  return {
+    ok: status === "ok",
+    status,
+    final: finalTextFromResult(result, payloads, !hasErrorPayload),
+    payloads,
+    ...(agentMeta?.usage ? { usage: agentMeta.usage } : {}),
+    ...(agentMeta?.costUsd !== undefined ? { costUsd: agentMeta.costUsd } : {}),
+    ...(agentMeta?.codeModeEngaged !== undefined
+      ? { codeModeEngaged: agentMeta.codeModeEngaged }
+      : {}),
+    ...(agentMeta?.assistantTurns !== undefined
+      ? { assistantTurns: agentMeta.assistantTurns }
+      : {}),
+    ...(agentMeta?.bridgeCalls ? { bridgeCalls: agentMeta.bridgeCalls } : {}),
+    ...(meta.toolSummary ? { toolSummary: meta.toolSummary } : {}),
+    model: agentMeta?.model ?? null,
+    provider: agentMeta?.provider ?? null,
+    sessionId: agentMeta?.sessionId ?? "",
+    ...(errorMessage && errorKind ? { error: { message: errorMessage, kind: errorKind } } : {}),
+  };
+}

--- a/src/commands/agent-exec.configless.test.ts
+++ b/src/commands/agent-exec.configless.test.ts
@@ -1,7 +1,7 @@
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveRunWorkspaceDir } from "../agents/workspace-run.js";
-import { buildExecRunConfig, resolveExecBaseConfig } from "./agent-exec.js";
+import { buildExecRunConfig, resolveExecBaseConfig } from "./agent-exec-input.js";
 
 describe("agent exec configless workspace ownership", () => {
   it.each([

--- a/src/commands/agent-exec.test.ts
+++ b/src/commands/agent-exec.test.ts
@@ -19,12 +19,12 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
-  agentExecCommand,
   buildExecRunConfig,
-  classifyAgentExecResult,
   resolveAgentExecPrompt,
   resolveExecBaseConfig,
-} from "./agent-exec.js";
+} from "./agent-exec-input.js";
+import { classifyAgentExecResult } from "./agent-exec-result.js";
+import { agentExecCommand } from "./agent-exec.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const externalTempDirs: string[] = [];

--- a/src/commands/agent-exec.ts
+++ b/src/commands/agent-exec.ts
@@ -1,17 +1,11 @@
 import { randomUUID } from "node:crypto";
-import { createReadStream, existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { TextDecoder } from "node:util";
-import { readByteStreamWithLimit } from "@openclaw/media-core/read-byte-stream-with-limit";
 import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/number-coercion";
 import { findAgentRunTerminalOutcome } from "../agents/agent-run-terminal-error.js";
-import type { EmbeddedAgentRunMeta } from "../agents/embedded-agent.js";
 import { isExecutionIdentityCollectionEnabled } from "../audit/audit-config.js";
 import { formatCliCommand } from "../cli/command-format.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { mergeDeep } from "../infra/deep-merge.js";
 import type {
   EmbeddedStateLockHandle,
   EmbeddedStateSignalProcess,
@@ -19,64 +13,19 @@ import type {
 import { formatErrorMessage } from "../infra/errors.js";
 import type { GatewayLockIdentity, GatewayLockOptions } from "../infra/gateway-lock.js";
 import { writeRuntimeJson, writeRuntimeStdout, type RuntimeEnv } from "../runtime.js";
+import {
+  buildExecRunConfig,
+  resolveAgentExecPrompt,
+  resolveExecBaseConfig,
+  type AgentExecCliOptions,
+} from "./agent-exec-input.js";
+import {
+  classifyAgentExecResult,
+  type AgentExecEnvelope,
+  type AgentExecRunResult,
+} from "./agent-exec-result.js";
 
-const AGENT_EXEC_MESSAGE_MAX_BYTES = 4 * 1024 * 1024;
 const AGENT_EXEC_DEFAULT_TIMEOUT_SECONDS = 600;
-const UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
-
-export type AgentExecCliOptions = {
-  messageFile?: string;
-  cwd?: string;
-  stateDir?: string;
-  config?: string;
-  isolated?: boolean;
-  model?: string;
-  thinking?: string;
-  fallback?: string[];
-  codeMode?: "direct" | "auto" | "code";
-  localModelLean?: boolean;
-  authEnvOnly?: boolean;
-  timeout?: string;
-  json?: boolean;
-};
-
-type AgentExecPayload = {
-  text?: string;
-  mediaUrl?: string | null;
-  mediaUrls?: string[];
-  isError?: boolean;
-  isReasoning?: boolean;
-  isCommentary?: boolean;
-};
-
-type AgentExecRawPayload = AgentExecPayload & Record<string, unknown>;
-
-type AgentExecRunResult = {
-  payloads?: AgentExecRawPayload[];
-  meta: EmbeddedAgentRunMeta;
-};
-
-type AgentExecStatus = "ok" | "error" | "timeout";
-
-export type AgentExecEnvelope = {
-  ok: boolean;
-  status: AgentExecStatus;
-  final: string;
-  payloads: AgentExecPayload[];
-  usage?: NonNullable<NonNullable<EmbeddedAgentRunMeta["agentMeta"]>["usage"]>;
-  costUsd?: number;
-  codeModeEngaged?: boolean;
-  assistantTurns?: number;
-  bridgeCalls?: NonNullable<NonNullable<EmbeddedAgentRunMeta["agentMeta"]>["bridgeCalls"]>;
-  toolSummary?: NonNullable<EmbeddedAgentRunMeta["toolSummary"]>;
-  model: string | null;
-  provider: string | null;
-  sessionId: string;
-  error?: {
-    message: string;
-    kind: string;
-  };
-};
 
 type AgentExecCommandResult = {
   envelope: AgentExecEnvelope;
@@ -92,176 +41,6 @@ type AgentExecCommandDeps = {
     runtime: RuntimeEnv,
   ) => Promise<AgentExecRunResult | undefined>;
 };
-
-function decodePrompt(bytes: Buffer, source: string): string {
-  let value: string;
-  try {
-    value = UTF8_DECODER.decode(bytes).replace(/^\uFEFF/, "");
-  } catch {
-    throw new Error(`${source} must be valid UTF-8`);
-  }
-  if (!value.trim()) {
-    throw new Error(`${source} is empty`);
-  }
-  return value;
-}
-
-async function readPromptStream(stream: AsyncIterable<unknown>, source: string): Promise<string> {
-  const bytes = await readByteStreamWithLimit(stream, {
-    maxBytes: AGENT_EXEC_MESSAGE_MAX_BYTES,
-    onOverflow: () => new Error(`${source} exceeds ${String(AGENT_EXEC_MESSAGE_MAX_BYTES)} bytes`),
-  });
-  return decodePrompt(bytes, source);
-}
-
-/** Resolve the one allowed prompt source for `agent exec`. */
-export async function resolveAgentExecPrompt(
-  positionalMessage: string | undefined,
-  messageFile: string | undefined,
-  stdin: AsyncIterable<unknown> = process.stdin,
-): Promise<string> {
-  const file = messageFile?.trim();
-  const hasPositional = positionalMessage !== undefined;
-  if (hasPositional && file) {
-    throw new Error("Use either the prompt argument or --message-file, not both.");
-  }
-  if (messageFile !== undefined && !file) {
-    throw new Error("--message-file must not be empty.");
-  }
-  if (file) {
-    const stream = file === "-" ? stdin : createReadStream(file);
-    try {
-      return await readPromptStream(stream, file === "-" ? "stdin" : `Message file ${file}`);
-    } catch (error) {
-      if (file === "-" || !(error instanceof Error) || !("code" in error)) {
-        throw error;
-      }
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code === "ENOENT") {
-        throw new Error(`Message file not found: ${file}`, { cause: error });
-      }
-      throw error;
-    }
-  }
-  if (!positionalMessage?.trim()) {
-    throw new Error("Missing prompt. Pass text or use --message-file <path>.");
-  }
-  return positionalMessage;
-}
-
-function projectAgentExecPayload(payload: AgentExecRawPayload): AgentExecPayload {
-  return {
-    ...(typeof payload.text === "string" ? { text: payload.text } : {}),
-    ...(payload.mediaUrl !== undefined ? { mediaUrl: payload.mediaUrl } : {}),
-    ...(Array.isArray(payload.mediaUrls) ? { mediaUrls: [...payload.mediaUrls] } : {}),
-    ...(payload.isError === true ? { isError: true } : {}),
-    ...(payload.isReasoning === true ? { isReasoning: true } : {}),
-    ...(payload.isCommentary === true ? { isCommentary: true } : {}),
-  };
-}
-
-function finalTextFromResult(
-  result: AgentExecRunResult,
-  payloads: AgentExecPayload[],
-  allowMetadataFallback: boolean,
-): string {
-  const payloadText = payloads
-    .filter(
-      (payload) =>
-        payload.isError !== true &&
-        payload.isReasoning !== true &&
-        payload.isCommentary !== true &&
-        typeof payload.text === "string" &&
-        payload.text.trim().length > 0,
-    )
-    .map((payload) => payload.text!.trimEnd())
-    .join("\n");
-  return (
-    payloadText ||
-    (allowMetadataFallback ? result.meta.finalAssistantVisibleText?.trimEnd() : "") ||
-    ""
-  );
-}
-
-function firstErrorPayload(result: AgentExecRunResult): AgentExecPayload | undefined {
-  return result.payloads?.find((payload) => payload.isError === true);
-}
-
-/** Classify an embedded result into the strict `agent exec` process contract. */
-export function classifyAgentExecResult(
-  result: AgentExecRunResult,
-  fallbackExhausted = false,
-  projectedErrorPayload?: string | true,
-): AgentExecEnvelope {
-  const meta = result.meta;
-  const errorPayload = firstErrorPayload(result);
-  const errorPayloadMessage =
-    typeof projectedErrorPayload === "string"
-      ? projectedErrorPayload
-      : typeof errorPayload?.text === "string" && errorPayload.text.trim()
-        ? errorPayload.text
-        : undefined;
-  const hasErrorPayload = projectedErrorPayload !== undefined || errorPayload !== undefined;
-  const payloads = (result.payloads ?? []).map(projectAgentExecPayload);
-  if (typeof projectedErrorPayload === "string") {
-    const projectedErrorIndex = payloads.findIndex(
-      (payload) => payload.isError !== true && payload.text === projectedErrorPayload,
-    );
-    if (projectedErrorIndex >= 0) {
-      payloads[projectedErrorIndex] = {
-        ...payloads[projectedErrorIndex],
-        isError: true,
-      };
-    }
-  }
-  const timeout = meta.stopReason === "timeout" || meta.timeoutPhase !== undefined;
-  const failed =
-    fallbackExhausted ||
-    meta.aborted === true ||
-    meta.error !== undefined ||
-    meta.stopReason === "error" ||
-    hasErrorPayload;
-  const status: AgentExecStatus = timeout ? "timeout" : failed ? "error" : "ok";
-  const errorMessage = timeout
-    ? (meta.error?.message ?? errorPayloadMessage ?? "Agent run timed out")
-    : fallbackExhausted
-      ? (meta.error?.message ?? errorPayloadMessage ?? "All model fallback candidates failed")
-      : (meta.error?.message ?? errorPayloadMessage ?? (failed ? "Agent run failed" : undefined));
-  const errorKind = timeout
-    ? "timeout"
-    : fallbackExhausted
-      ? "fallback_exhausted"
-      : meta.error?.kind
-        ? meta.error.kind
-        : meta.aborted
-          ? "aborted"
-          : hasErrorPayload
-            ? "error_payload"
-            : failed
-              ? "agent_error"
-              : undefined;
-  const agentMeta = meta.agentMeta;
-  return {
-    ok: status === "ok",
-    status,
-    final: finalTextFromResult(result, payloads, !hasErrorPayload),
-    payloads,
-    ...(agentMeta?.usage ? { usage: agentMeta.usage } : {}),
-    ...(agentMeta?.costUsd !== undefined ? { costUsd: agentMeta.costUsd } : {}),
-    ...(agentMeta?.codeModeEngaged !== undefined
-      ? { codeModeEngaged: agentMeta.codeModeEngaged }
-      : {}),
-    ...(agentMeta?.assistantTurns !== undefined
-      ? { assistantTurns: agentMeta.assistantTurns }
-      : {}),
-    ...(agentMeta?.bridgeCalls ? { bridgeCalls: agentMeta.bridgeCalls } : {}),
-    ...(meta.toolSummary ? { toolSummary: meta.toolSummary } : {}),
-    model: agentMeta?.model ?? null,
-    provider: agentMeta?.provider ?? null,
-    sessionId: agentMeta?.sessionId ?? "",
-    ...(errorMessage && errorKind ? { error: { message: errorMessage, kind: errorKind } } : {}),
-  };
-}
 
 function exitCodeForEnvelope(envelope: AgentExecEnvelope): 0 | 1 | 2 {
   return envelope.status === "ok" ? 0 : envelope.status === "timeout" ? 2 : 1;
@@ -283,156 +62,6 @@ function normalizeCodeMode(
     return true;
   }
   throw new Error("--code-mode must be one of direct, auto, code.");
-}
-
-/**
- * Facts owned by this invocation rather than by any config, so they win over
- * both the ambient config and `--config`: exec is always scoped to the folder
- * it was pointed at, a one-shot turn never bootstraps, and explicit flags
- * outrank whatever the resolved config says.
- */
-/**
- * Drops inherited state and workspace location overrides, which outrank the
- * facts this invocation owns. `session.store` and `agentDir` can redirect state
- * outside the invocation root, where its lock or temporary cleanup cannot own
- * it; a native harness `runtime.acp.cwd` can make the turn edit the wrong repo.
- * `agents.bindings[].acp.cwd` needs no equivalent because exec runs no channel,
- * so no binding matches.
- */
-function stripInheritedAgentLocations(base: OpenClawConfig): OpenClawConfig {
-  const { session, ...root } = base;
-  const { store: _store, ...sessionWithoutStore } = session ?? {};
-  const withoutSessionStore = session ? { ...root, session: sessionWithoutStore } : base;
-  const entries = withoutSessionStore.agents?.entries;
-  if (!entries) {
-    return withoutSessionStore;
-  }
-  return {
-    ...withoutSessionStore,
-    agents: {
-      ...withoutSessionStore.agents,
-      entries: Object.fromEntries(
-        Object.entries(entries).map(([id, entry]) => {
-          const { agentDir: _agentDir, runtime, ...rest } = entry;
-          if (runtime?.type !== "acp" || runtime.acp?.cwd === undefined) {
-            return [id, { ...rest, ...(runtime ? { runtime } : {}) }];
-          }
-          const { cwd: _cwd, ...acp } = runtime.acp;
-          return [id, { ...rest, runtime: { ...runtime, acp } }];
-        }),
-      ),
-    },
-  } as OpenClawConfig;
-}
-
-function buildExecRunOverlay(params: {
-  base: OpenClawConfig;
-  cwd: string;
-  opts: Pick<AgentExecCliOptions, "localModelLean">;
-}): OpenClawConfig {
-  // A per-agent `workspace` outranks `agents.defaults`, so pinning only the
-  // defaults would let an inherited entry silently run the turn against a
-  // different repository. Override every configured entry as well.
-  const entries = Object.keys(params.base.agents?.entries ?? {});
-  return {
-    agents: {
-      defaults: {
-        workspace: params.cwd,
-        skipBootstrap: true,
-        ...(params.opts.localModelLean ? { experimental: { localModelLean: true } } : {}),
-      },
-      ...(entries.length > 0
-        ? { entries: Object.fromEntries(entries.map((id) => [id, { workspace: params.cwd }])) }
-        : {}),
-    },
-    // This process exits after one turn, so live skill invalidation cannot be
-    // observed and would leave Chokidar retaining the otherwise-finished CLI.
-    skills: { load: { watch: false } },
-  } as OpenClawConfig;
-}
-
-/**
- * Coding one-shot defaults. These merge *under* the resolved config so an
- * operator who configured a tool profile, shell env, or sandbox keeps it;
- * notably exec must never downgrade a configured sandbox to `off`.
- */
-function buildExecConfigDefaults(): OpenClawConfig {
-  return {
-    env: { shellEnv: { enabled: false } },
-    agents: { defaults: { sandbox: { mode: "off" } } },
-    tools: {
-      profile: "coding",
-      fs: { workspaceOnly: true },
-      // No `exec.host`: the default `auto` already resolves to the gateway when
-      // no sandbox is configured, and pinning `gateway` here would route
-      // commands back onto the host for an inherited config that enables one.
-      // `mode: "full"` stays because a headless one-shot has no approval channel.
-      exec: { mode: "full" },
-    },
-  };
-}
-
-/**
- * Resolves the config exec runs against. Default is the ambient config, so a
- * one-shot turn behaves like other folder-scoped coding CLIs and can reach
- * configured providers, credentials, and `agentRuntime` harness choices.
- *
- * `--auth-env-only` opts out of that inheritance entirely rather than trying to
- * launder the resolved config. A config is a credential store by design -- API
- * keys, secret headers, request auth, an inline `env` block, and login-shell
- * import all feed provider auth -- so the only closed way to promise
- * environment-only credentials is to not read it.
- */
-export async function resolveExecBaseConfig(
-  opts: Pick<AgentExecCliOptions, "authEnvOnly" | "config" | "isolated">,
-): Promise<OpenClawConfig> {
-  // `--isolated` and `--auth-env-only` both mean "read no config", so pairing
-  // either with `--config` is a contradiction. Failing beats silently ignoring
-  // the pinned file, which would run a CI invocation on bare exec defaults.
-  if (opts.config && (opts.isolated || opts.authEnvOnly === true)) {
-    const conflicting = opts.isolated ? "--isolated" : "--auth-env-only";
-    throw new Error(`--config cannot be combined with ${conflicting}.`);
-  }
-  if (opts.isolated || opts.authEnvOnly === true) {
-    // A missing config is normally passed through the persisted-config
-    // migrations, which materialize the legacy main agent. Configless exec
-    // modes must preserve that runtime contract even though they skip all
-    // authored config and its credential surfaces.
-    const { migratePersistedImplicitMainRoster } = await import("../config/legacy.roster.js");
-    const { coerceConfig } = await import("../config/io.read-helpers.js");
-    return coerceConfig(migratePersistedImplicitMainRoster({}).config);
-  }
-  const { createConfigIO, getRuntimeConfig } = await import("../config/io.js");
-  if (!opts.config) {
-    // Ambient means "whatever this process considers effective", so this honors a
-    // runtime snapshot an in-process caller already published and otherwise loads
-    // the ordinary config file exactly as any other command does.
-    return getRuntimeConfig();
-  }
-  // `--config` pins an exact file. The factory loader reads that file directly --
-  // unlike the module-level loader it never resolves from a published runtime
-  // snapshot, so a pinned run cannot be shadowed by one. It throws on a config
-  // that exists but is invalid, so the run cannot silently degrade to exec
-  // defaults, and it finalizes the load (config `env` block, shell-env fallback).
-  const io = createConfigIO({ configPath: path.resolve(opts.config) });
-  if (!existsSync(io.configPath)) {
-    throw new Error(`--config file not found: ${io.configPath}`);
-  }
-  return io.loadConfig();
-}
-
-export function buildExecRunConfig(params: {
-  base: OpenClawConfig;
-  cwd: string;
-  opts?: Pick<AgentExecCliOptions, "localModelLean">;
-}): OpenClawConfig {
-  const opts = params.opts ?? {};
-  const base = stripInheritedAgentLocations(params.base);
-  const withDefaults = mergeDeep(buildExecConfigDefaults(), base) as OpenClawConfig;
-  return mergeDeep(
-    withDefaults,
-    buildExecRunOverlay({ base, cwd: params.cwd, opts }),
-  ) as OpenClawConfig;
 }
 
 function normalizeTimeoutSeconds(value: string | undefined): string {


### PR DESCRIPTION
Closes #133271

## What Problem This Solves

Resolves a problem where CLI help registration loads action-only runtime code before a command runs. Existing cold-help checks fail for `setup`, `onboard`, and `agents`; the same agent registration path also affects `agent --help` and `agent exec --help`.

## Why This Change Was Made

Move onboarding rejection handling and agent exit finalization behind the existing async action boundary. Await the registration-owned validators without changing their rejection order, and replace five single-export loader wrappers with direct action imports. The canonical JSON rejection and exit-finalization owners stay unchanged.

Removing the broad loader types exposed unclear export ownership in the existing agent-exec command. Split its existing input/config preparation and result projection into owners the command actually consumes, with behavior preserved and test imports migrated without weaker assertions. Remove redundant casts at the new input owner and document its one required typed-merge assertion; the old assertion baseline shrinks without adding an allowance. This makes export ownership explicit instead of hiding unused exports behind whole-module type references. The tooling envelope consumer and the existing pinned-config loader exemption move to the matching owners.

Production: **net -1 line**, discounting the pure moves. Tests: **+9 lines**. No flags, configuration, dependencies, workflow, config policy, or result semantics change.

## User Impact

Help text and command behavior are unchanged. Help registration avoids loading action-only code; onboarding still discovers provider metadata needed to render its provider-specific options. This does not claim that the entire CLI startup is runtime-free.

## Evidence

- Existing cold-help regressions reproduced before the fix; **241 tests across seven suites passed** after the owner split, then both canonical boundary guards and the **52 input/config tests passed again** after assertion cleanup, including JSON rejections, recommendation validation, parent/leaf options, agent exit behavior, config isolation, and terminal-result projection.
- Fresh-process, source-mode proof through the actual setup/onboard fast-help renderer and the agent Commander registrations: all five help outputs are unchanged apart from the expected commit revision in the setup/onboard banner. Agent help no longer loads runtime or exit finalization; setup/onboard no longer load option rejection during registration.
- Fresh autoreview and independent owner/caller/dependency review found no actionable issues. The moved input/config and projection blocks were independently compared against the original source, with no behavior changes or weaker test assertions.

- Full thirteen-path canonical changed gate passed, including core/test/scripts typechecks, lint, all export scans, runtime cycles, and boundary guards.
- Canonical `pnpm build` passed, including CLI bootstrap and SDK-export checks. Fresh source and built-launcher smoke covered `setup`, `onboard`, `agent`, `agent exec`, and `agents` help: all ten commands exited zero with empty stderr. Build metadata identifies `4417a65d98e24cc493cca375defda3c0db319e5d`.
- The temporary smoke comparator initially rejected the expected banner revision change. Raw output was preserved and verified; the remaining commands completed without repeating setup, the gate, or the build.

Exact reviewed head: `4417a65d98e24cc493cca375defda3c0db319e5d`. Provenance: reproduced at source base `6549b0a7c534750d9d6cbef305233b162704b291`; stable-release regression range not established. Required hosted [CI run 33308980556](https://github.com/openclaw/openclaw/actions/runs/33308980556) passed on this exact head, including `openclaw/ci-gate`.
