### PR TITLE
fix(gateway): report timed-out HTTP agent runs as failures

### DIFF
--- a/docs/gateway/openai-http-api.md
+++ b/docs/gateway/openai-http-api.md
@@ -219,6 +219,8 @@ Set `stream: true` to receive Server-Sent Events:
 - Each event line is `data: <json>`
 - Stream ends with `data: [DONE]`
 
+Failed agent runs, including whole-agent timeouts, return an error instead of a successful completion. A streaming failure emits an `error` object followed by `[DONE]`; partial content may already have reached the client. Timeout settings follow the [agent loop](/concepts/agent-loop#timeouts).
+
 ## Open WebUI quick setup
 
 - Base URL: `http://127.0.0.1:18789/v1`

--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -225,6 +225,8 @@ Set `stream: true` to receive Server-Sent Events:
 
 Event types currently emitted: `response.created`, `response.in_progress`, `response.output_item.added`, `response.content_part.added`, `response.output_text.delta`, `response.output_text.done`, `response.content_part.done`, `response.output_item.done`, `response.completed`, `response.failed` (on error).
 
+Failed agent runs, including whole-agent timeouts, return a failed response. Streaming failures emit `response.failed` followed by `[DONE]`; partial content may already have reached the client. Timeout settings follow the [agent loop](/concepts/agent-loop#timeouts).
+
 ## Usage
 
 `usage` is populated when the underlying provider reports token counts. OpenClaw normalizes common OpenAI-style aliases before those counters reach downstream status/session surfaces, including `input_tokens` / `output_tokens` and `prompt_tokens` / `completion_tokens`.

--- a/src/gateway/openai-compat-errors.ts
+++ b/src/gateway/openai-compat-errors.ts
@@ -1,4 +1,3 @@
-import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { describeFailoverError, resolveFailoverStatus } from "../agents/failover-error.js";
 // OpenAI-compatible error helpers.
 // Converts OpenClaw failover/sampling errors to OpenAI-style HTTP responses.
@@ -31,12 +30,6 @@ const ERROR_TYPE_BY_REASON = {
   unclassified: undefined,
   unknown: undefined,
 } satisfies Record<FailoverReason, string | undefined>;
-
-/** Resolved agent failures must not become successful OpenAI HTTP responses. */
-export function isFailedOpenAiAgentRun(result: unknown): boolean {
-  const metadata = asOptionalRecord(asOptionalRecord(result)?.meta);
-  return Boolean(metadata?.error) || metadata?.stopReason === "error";
-}
 
 function statusForReason(reason: FailoverReason, status: number | undefined): number {
   if (reason === "server_error") {

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -20,6 +20,7 @@ import { subscribeEmbeddedAgentSession } from "../agents/embedded-agent-subscrib
 import { FailoverError } from "../agents/failover-error.js";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
+import { recordAgentRunTerminalOutcome } from "../channels/turn/agent-run-terminal-outcome.js";
 import { resetConfigRuntimeState } from "../config/config.js";
 import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
 import {
@@ -2049,10 +2050,15 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
   it("rejects resolved terminal agent failures without exposing provider details", async () => {
     const privateDetail = "raw provider detail should stay private";
     agentCommandMock.mockClear();
-    agentCommandMock.mockResolvedValueOnce({
-      payloads: [{ text: "Command may have changed state", isError: true }],
-      meta: { error: { kind: "incomplete_turn", message: privateDetail } },
-    } as never);
+    agentCommandMock.mockResolvedValueOnce(
+      recordAgentRunTerminalOutcome(
+        {
+          payloads: [{ text: "Command may have changed state", isError: true }],
+          meta: { error: { kind: "incomplete_turn", message: privateDetail } },
+        },
+        "failed",
+      ) as never,
+    );
 
     const res = await postChatCompletions(enabledPort, {
       model: "openclaw",
@@ -2066,18 +2072,30 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     expect(body).not.toContain(privateDetail);
   });
 
-  it("rejects resolved error stop reasons", async () => {
+  it.each([
+    { name: "error stop", meta: { stopReason: "error" }, outcome: "failed", status: 500 },
+    {
+      name: "run-budget timeout without error metadata",
+      meta: { aborted: false, timeoutPhase: "provider", providerStarted: true },
+      outcome: "failed",
+      status: 500,
+    },
+    { name: "completed run with an error payload", meta: {}, outcome: "completed", status: 200 },
+  ] as const)("uses the recorded outcome for $name", async ({ meta, outcome, status }) => {
     agentCommandMock.mockClear();
-    agentCommandMock.mockResolvedValueOnce({
-      payloads: [{ text: "Command may have changed state", isError: true }],
-      meta: { stopReason: "error" },
-    } as never);
+    agentCommandMock.mockResolvedValueOnce(
+      recordAgentRunTerminalOutcome(
+        { payloads: [{ text: "Command may have changed state", isError: true }], meta },
+        outcome,
+      ) as never,
+    );
 
     const res = await postChatCompletions(enabledPort, {
       model: "openclaw",
       messages: [{ role: "user", content: "hi" }],
     });
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(status);
+    await res.text();
   });
 
   it.each(
@@ -2090,6 +2108,11 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       {
         label: "an error stop reason",
         meta: { stopReason: "error" },
+        expectedPhase: "end" as const,
+      },
+      {
+        label: "a run-budget timeout without error metadata",
+        meta: { aborted: false, timeoutPhase: "provider" as const, providerStarted: true },
         expectedPhase: "end" as const,
       },
     ].flatMap((failure) =>
@@ -2123,6 +2146,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         if (!runId) {
           throw new Error("expected a streaming chat-completion run ID");
         }
+        emitAgentEvent({ runId, stream: "assistant", data: { delta: "partial answer" } });
         const result = {
           payloads: [{ text: "Command may have changed state", isError: true }],
           meta: { durationMs: 0, ...meta },
@@ -2140,7 +2164,11 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
           });
           const terminal = {
             metadata: {},
-            outcome: buildAgentRunTerminalOutcome({ status: "error", stopReason: "error" }),
+            outcome: buildAgentRunTerminalOutcome({
+              status: meta.timeoutPhase ? "timeout" : "error",
+              stopReason: meta.timeoutPhase ? undefined : "error",
+              timeoutPhase: meta.timeoutPhase,
+            }),
           };
           if (lifecycle.resolveResultError(result, false)) {
             lifecycle.emitResultError(result, false, terminal);
@@ -2148,7 +2176,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
             lifecycle.emitEnd(terminal);
           }
         }
-        return result;
+        return recordAgentRunTerminalOutcome(result, "failed");
       }) as never);
 
       try {
@@ -2158,16 +2186,22 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
           stream: true,
         });
         const finishReasons: Array<string | null> = [];
+        const content: string[] = [];
         await expect(async () => {
           for await (const chunk of stream) {
             finishReasons.push(...chunk.choices.map((choice) => choice.finish_reason));
+            content.push(...chunk.choices.map((choice) => choice.delta.content ?? ""));
           }
         }).rejects.toMatchObject({
           error: { message: "internal error", type: "api_error" },
         });
         expect(finishReasons).not.toContain("stop");
+        expect(content.join("")).toBe("partial answer");
         expect(terminals).toEqual([
-          { phase: producerTerminal ? expectedPhase : "error", status: "error" },
+          {
+            phase: producerTerminal ? expectedPhase : "error",
+            status: producerTerminal && meta.timeoutPhase ? "timeout" : "error",
+          },
         ]);
       } finally {
         unsubscribe();

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -16,6 +16,7 @@ import type { AgentStreamParams, ClientToolDefinition } from "../agents/command/
 import type { ImageContent } from "../agents/command/types.js";
 import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import { toOpenAiChatCompletionsUsage, type OpenAiChatCompletionsUsage } from "../agents/usage.js";
+import { readAgentRunTerminalOutcome } from "../channels/turn/agent-run-terminal-outcome.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { agentCommandFromGatewayIngress } from "../commands/agent.js";
 import { getRuntimeConfig } from "../config/io.js";
@@ -74,11 +75,7 @@ import {
 } from "./http-utils.js";
 import { normalizeInputHostnameAllowlist } from "./input-allowlist.js";
 import { resolveAgentRunUsage } from "./openai-agent-run-usage.js";
-import {
-  isFailedOpenAiAgentRun,
-  resolveOpenAiCompatError,
-  validateOpenAiSamplingParams,
-} from "./openai-compat-errors.js";
+import { resolveOpenAiCompatError, validateOpenAiSamplingParams } from "./openai-compat-errors.js";
 import {
   isToolChoiceConstraintSatisfied,
   resolveUnsatisfiedToolChoiceMessage,
@@ -1080,7 +1077,7 @@ export async function handleOpenAiHttpRequest(
       }
 
       const meta = (result as { meta?: { error?: unknown; stopReason?: unknown } } | null)?.meta;
-      if (isFailedOpenAiAgentRun(result)) {
+      if (readAgentRunTerminalOutcome(result) === "failed") {
         throw new Error("agent run failed");
       }
       const usage = resolveChatCompletionUsage(result);
@@ -1358,7 +1355,7 @@ export async function handleOpenAiHttpRequest(
         return;
       }
 
-      if (isFailedOpenAiAgentRun(result)) {
+      if (readAgentRunTerminalOutcome(result) === "failed") {
         terminalLifecyclePhase = "error";
         finishStreamWithError({ message: "internal error", type: "api_error" });
         return;

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -15,6 +15,7 @@ import { createAgentCommandLifecycle } from "../agents/command/lifecycle.js";
 import { FailoverError } from "../agents/failover-error.js";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
+import { recordAgentRunTerminalOutcome } from "../channels/turn/agent-run-terminal-outcome.js";
 import { resetConfigRuntimeState } from "../config/config.js";
 import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
 import {
@@ -1923,10 +1924,15 @@ describe("OpenResponses HTTP API (e2e)", () => {
   it("rejects resolved terminal agent failures without exposing provider details", async () => {
     const privateDetail = "raw provider detail should stay private";
     agentCommandMock.mockClear();
-    agentCommandMock.mockResolvedValueOnce({
-      payloads: [{ text: "Command may have changed state", isError: true }],
-      meta: { error: { kind: "incomplete_turn", message: privateDetail } },
-    } as never);
+    agentCommandMock.mockResolvedValueOnce(
+      recordAgentRunTerminalOutcome(
+        {
+          payloads: [{ text: "Command may have changed state", isError: true }],
+          meta: { error: { kind: "incomplete_turn", message: privateDetail } },
+        },
+        "failed",
+      ) as never,
+    );
 
     const res = await postResponses(enabledPort, { model: "openclaw", input: "hi" });
     const body = await res.text();
@@ -1939,15 +1945,27 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(body).not.toContain(privateDetail);
   });
 
-  it("rejects resolved error stop reasons", async () => {
+  it.each([
+    { name: "error stop", meta: { stopReason: "error" }, outcome: "failed", status: 500 },
+    {
+      name: "run-budget timeout without error metadata",
+      meta: { aborted: false, timeoutPhase: "provider", providerStarted: true },
+      outcome: "failed",
+      status: 500,
+    },
+    { name: "completed run with an error payload", meta: {}, outcome: "completed", status: 200 },
+  ] as const)("uses the recorded outcome for $name", async ({ meta, outcome, status }) => {
     agentCommandMock.mockClear();
-    agentCommandMock.mockResolvedValueOnce({
-      payloads: [{ text: "Command may have changed state", isError: true }],
-      meta: { stopReason: "error" },
-    } as never);
+    agentCommandMock.mockResolvedValueOnce(
+      recordAgentRunTerminalOutcome(
+        { payloads: [{ text: "Command may have changed state", isError: true }], meta },
+        outcome,
+      ) as never,
+    );
 
     const res = await postResponses(enabledPort, { model: "openclaw", input: "hi" });
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(status);
+    await res.text();
   });
 
   it.each(
@@ -1960,6 +1978,11 @@ describe("OpenResponses HTTP API (e2e)", () => {
       {
         label: "an error stop reason",
         meta: { stopReason: "error" },
+        expectedPhase: "end" as const,
+      },
+      {
+        label: "a run-budget timeout without error metadata",
+        meta: { aborted: false, timeoutPhase: "provider" as const, providerStarted: true },
         expectedPhase: "end" as const,
       },
     ].flatMap((failure) =>
@@ -1993,6 +2016,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
         if (!runId) {
           throw new Error("expected a streaming response run ID");
         }
+        emitAgentEvent({ runId, stream: "assistant", data: { delta: "partial answer" } });
         const result = {
           payloads: [{ text: "Command may have changed state", isError: true }],
           meta: {
@@ -2019,7 +2043,11 @@ describe("OpenResponses HTTP API (e2e)", () => {
           });
           const terminal = {
             metadata: {},
-            outcome: buildAgentRunTerminalOutcome({ status: "error", stopReason: "error" }),
+            outcome: buildAgentRunTerminalOutcome({
+              status: meta.timeoutPhase ? "timeout" : "error",
+              stopReason: meta.timeoutPhase ? undefined : "error",
+              timeoutPhase: meta.timeoutPhase,
+            }),
           };
           if (lifecycle.resolveResultError(result, false)) {
             lifecycle.emitResultError(result, false, terminal);
@@ -2027,7 +2055,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
             lifecycle.emitEnd(terminal);
           }
         }
-        return result;
+        return recordAgentRunTerminalOutcome(result, "failed");
       }) as never);
 
       try {
@@ -2039,6 +2067,8 @@ describe("OpenResponses HTTP API (e2e)", () => {
         });
         const stream = client.responses.stream({ model: "openclaw", input: "hi" });
         const terminalEvents: string[] = [];
+        const content: string[] = [];
+        stream.on("response.output_text.delta", (event) => content.push(event.delta));
         stream.on("response.completed", () => terminalEvents.push("response.completed"));
         stream.on("response.failed", () => terminalEvents.push("response.failed"));
 
@@ -2051,8 +2081,12 @@ describe("OpenResponses HTTP API (e2e)", () => {
           total_tokens: 18,
         });
         expect(terminalEvents).toEqual(["response.failed"]);
+        expect(content.join("")).toBe("partial answer");
         expect(terminals).toEqual([
-          { phase: producerTerminal ? expectedPhase : "error", status: "error" },
+          {
+            phase: producerTerminal ? expectedPhase : "error",
+            status: producerTerminal && meta.timeoutPhase ? "timeout" : "error",
+          },
         ]);
       } finally {
         unsubscribe();

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -14,6 +14,7 @@ import { isClientToolNameConflictError } from "../agents/agent-tool-definition-a
 import type { ImageContent } from "../agents/command/types.js";
 import type { ClientToolDefinition } from "../agents/embedded-agent-runner/run/params.js";
 import { toOpenAiResponsesUsage } from "../agents/usage.js";
+import { readAgentRunTerminalOutcome } from "../channels/turn/agent-run-terminal-outcome.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { agentCommandFromGatewayIngress } from "../commands/agent.js";
@@ -82,7 +83,7 @@ import {
   type Usage,
 } from "./open-responses.schema.js";
 import { resolveAgentRunUsage } from "./openai-agent-run-usage.js";
-import { isFailedOpenAiAgentRun, resolveOpenAiCompatError } from "./openai-compat-errors.js";
+import { resolveOpenAiCompatError } from "./openai-compat-errors.js";
 import {
   isToolChoiceConstraintSatisfied,
   resolveUnsatisfiedToolChoiceMessage,
@@ -753,7 +754,7 @@ export async function handleOpenResponsesHttpRequest(
       }
 
       const meta = (result as { meta?: { error?: unknown; stopReason?: unknown } } | null)?.meta;
-      if (isFailedOpenAiAgentRun(result)) {
+      if (readAgentRunTerminalOutcome(result) === "failed") {
         throw new Error("agent run failed");
       }
       const assistantText = resolveResponsePayloadText(result);
@@ -1182,7 +1183,7 @@ export async function handleOpenResponsesHttpRequest(
         return;
       }
 
-      if (isFailedOpenAiAgentRun(result)) {
+      if (readAgentRunTerminalOutcome(result) === "failed") {
         terminalLifecyclePhase = "error";
         rememberResponseSession();
         finalizeFailedResponse(


### PR DESCRIPTION
Closes #133274

## What Problem This Solves

Fixes an issue where callers of the OpenAI-compatible Chat Completions and Responses endpoints receive successful completion when the whole-agent run budget expires. Streaming callers can receive partial text followed by success without seeing the timeout.

## Why This Change Was Made

Both command return paths already record the final run outcome after delivery and cleanup. All four HTTP projections now read that fact instead of inferring failure from optional `meta.error` or `stopReason: "error"` fields. This deletes the duplicate classifier; timeout and cancellation precedence, retry policy, existing error envelopes, and disconnect handling remain unchanged.

Both SSE endpoints already wait for the returned command result before finalizing, so no additional timing state is needed. Adding timeout-string matching or another HTTP-specific classifier would duplicate the existing owner policy.

Production LOC: **+8/-17 (net −9)**. Tests: **+94/-26 (net +68)**. Docs: **+4/-0**.

## User Impact

Expired agent runs report an error through JSON or a failed streaming terminal instead of presenting an incomplete answer as successful. Already-delivered partial content remains delivered; successful and genuinely recovered runs keep their normal completion behavior. No public configuration, protocol, auth, or persistence changes.

## Evidence

Candidate head: `9a6d534b62362a76f5bcc05424181645e8545341`.

Actual baseline proof used the canonical compiled Gateway CLI, maintained isolated instance helper, real agent command/runtime, a deterministic localhost Responses provider, and official OpenAI SDK 7.5.0. With an existing 3-second agent budget and 30-second provider deadline:

| Surface | Before | After |
| --- | --- | --- |
| Chat JSON | HTTP 200, timeout prose, `finish_reason: "stop"` | HTTP 500 / SDK error |
| Chat SSE after partial output | Partial answer then `stop`, no SDK error | Partial answer retained, then one SDK error and `[DONE]`; no success finish |
| Responses JSON | HTTP 200, `status: "completed"` | HTTP 500 / SDK error |
| Responses SSE after partial output | Partial answer then `response.completed` | Partial answer retained, then one `response.failed` and `[DONE]` |

Normal success passed. A genuine recovery control made exactly two provider requests and logged the agent's retry before returning one successful completion. Ordinary provider-request timeouts already reported errors correctly. Each stream closed once with one terminal and one `[DONE]`.

Six new regression cases failed on unchanged production for the expected JSON/SSE success misclassification; 14 existing controls passed. After the repair, **all 156 Chat and Responses tests pass**, including private-error redaction, partial output, completed error-marked payloads, stream finalization, client disconnects and client-tool siblings. The fresh structured autoreview is clean for its explicitly limited P0 scope. A separate all-priority Codex review and independent source/runtime verification found no actionable issues on the exact candidate.

The canonical candidate build passed in 225.62 seconds. All six actual compiled after-proof requests passed: the four repaired paths above, normal Responses success, and genuine OpenAI-provider recovery requiring exactly two provider requests plus the runtime retry log. Three isolated Gateway instances were cleaned up; all 28 guarded runtime/helper source hashes and all three build stamps matched the candidate.

```json
{"head":"9a6d534b62362a76f5bcc05424181645e8545341","actual_gateway_cli_sdk":{"passed":6,"failed":0,"budget_failures_reported":4,"success_controls":2,"recovered_provider_attempts":2,"one_terminal_and_done_per_stream":true,"cleanup":true}}
```

The canonical seven-path changed gate passed in 426.51 seconds with unchanged source hashes and a clean checkout. [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33309474836) passed; its actual checkout merge contains the reviewed candidate and implementation base. Native CI/Testbox prepare and merge gates passed. Landed as [a8c8c82708361d2f859f820562ae1b00cf162e93](https://github.com/openclaw/openclaw/commit/a8c8c82708361d2f859f820562ae1b00cf162e93); remote main and all seven reviewed/landed file blobs were verified, and native cleanup completed. No external provider/model request, external Codex runtime, or released-binary reproduction is claimed; the recorded terminal fact is source-traced, not a runtime spy in the compiled proof.

The baseline is `0320297d7a1573c08cfaab781f93bd57dc4a694b`; all 29 implicated source/test/docs/provider paths were verified identical on implementation base `4306140e0b8824fc8e41f19bdf1ef119e37247d9`. Direct dependency inspection covered the installed SDK error/final-response behavior and upstream Codex retry-versus-terminal status contracts. No upstream Codex defect or protocol change is asserted.

## Maintainer Review Disposition

The August 30 ClawSweeper review on the exact candidate found no actionable correctness or security issue and judged the canonical outcome reader the best fix. Its remaining SDK-source limitation is resolved by direct inspection of the installed SDK 7.5.0 SSE parser (`src/core/streaming.ts:45–123`) and Responses accumulator/final-result handling (`src/lib/responses/ResponseStream.ts:205–218,289–301`), plus the six actual compiled Gateway/SDK cases above. The implementation preserves ordered partial output and the existing error/failed-response contracts.

The generated stored-data-model warning is not applicable: `src/gateway/openai-compat-errors.ts` only loses the optional-metadata classifier and its import. No embedding, persisted data, schema, or migration code changes. The existing command fact is an in-process symbol property and is unchanged. There is no separate Rank-up moves list in that review; its normal CI/merge next step is tracked by the pending gates above. No rereview is requested for this unchanged head.
