### PR TITLE
perf(agents): prepare catalog policies and route lookups once

### DIFF
--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -566,64 +566,94 @@ describe("prepared model catalog builder", () => {
     expect(snapshot.routeVariants).toHaveLength(2);
   });
 
-  it("keeps compat from the catalog route selected by config", async () => {
-    mocks.augmentModelCatalogWithProviderPlugins.mockResolvedValueOnce([
-      {
-        id: "demo",
-        name: "Route B",
-        provider: "custom",
-        api: "openai-completions",
-        baseUrl: "https://route-b.example.test/v1",
-        thinkingLevelMap: { xhigh: "xhigh", max: "max" },
-        compat: { supportsTools: false },
-      },
-    ]);
-    const snapshot = await build({
-      config: {
-        plugins: { enabled: false },
-        models: {
-          providers: {
-            custom: {
-              api: "openai-responses",
-              baseUrl: "https://route-a.example.test/v1",
-              models: [
-                {
-                  id: "demo",
-                  name: "Configured Demo",
-                  contextWindow: 32_000,
-                  maxTokens: 4_096,
-                  reasoning: true,
-                  input: ["text"],
-                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                },
-              ],
+  it.each([false, true])(
+    "keeps the first matching catalog route with borrowed-row retargeting %s",
+    async (retarget) => {
+      mocks.augmentModelCatalogWithProviderPlugins.mockImplementationOnce(async ({ context }) => {
+        const first = context.entries[0];
+        if (retarget && first) {
+          first.id = "demo";
+        }
+        return [
+          {
+            id: "demo",
+            name: "Route B",
+            provider: "custom",
+            api: "openai-completions",
+            baseUrl: "https://route-b.example.test/v1",
+            thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+            compat: { supportsTools: false },
+          },
+        ];
+      });
+      const snapshot = await build({
+        config: {
+          plugins: { enabled: false },
+          models: {
+            providers: {
+              custom: {
+                api: "openai-responses",
+                baseUrl: "https://route-a.example.test/v1",
+                models: [
+                  {
+                    id: "demo",
+                    name: "Configured Demo",
+                    contextWindow: 32_000,
+                    maxTokens: 4_096,
+                    reasoning: true,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  },
+                ],
+              },
             },
           },
         },
-      },
-      entries: [
-        {
-          id: "demo",
-          name: "Route A",
-          provider: "custom",
-          api: "openai-responses",
-          baseUrl: "https://route-a.example.test/v1",
-          thinkingLevelMap: { xhigh: null, max: null },
-          compat: { supportsTools: true },
-        },
-      ],
-      readOnly: false,
-    });
+        entries: [
+          ...(retarget
+            ? [
+                {
+                  id: "spare",
+                  name: "Earlier Route A",
+                  provider: "custom",
+                  api: "openai-responses",
+                  baseUrl: "https://route-a.example.test/v1",
+                  thinkingLevelMap: { xhigh: "high", max: "max" },
+                  compat: { supportsTools: false },
+                } satisfies ModelCatalogEntry,
+              ]
+            : []),
+          {
+            id: "demo",
+            name: "Route A",
+            provider: "custom",
+            api: "openai-responses",
+            baseUrl: "https://route-a.example.test/v1",
+            thinkingLevelMap: { xhigh: null, max: null },
+            compat: { supportsTools: true },
+          },
+        ],
+        readOnly: false,
+      });
 
-    expect(
-      findModelCatalogEntry(snapshot.entries, { provider: "custom", modelId: "demo" }),
-    ).toMatchObject({
-      api: "openai-responses",
-      baseUrl: "https://route-a.example.test/v1",
-      thinkingLevelMap: { xhigh: null, max: null },
-      compat: { supportsTools: true },
-    });
-  });
+      const selectedRoute = {
+        api: "openai-responses",
+        baseUrl: "https://route-a.example.test/v1",
+        thinkingLevelMap: retarget ? { xhigh: "high", max: "max" } : { xhigh: null, max: null },
+        compat: { supportsTools: !retarget },
+      };
+      expect(
+        snapshot.entries.filter((entry) => entry.provider === "custom" && entry.id === "demo"),
+      ).toEqual(
+        Array.from({ length: retarget ? 2 : 1 }, () => expect.objectContaining(selectedRoute)),
+      );
+      expect(
+        snapshot.routeVariants.filter(
+          (entry) => entry.id === "demo" && entry.api === "openai-responses",
+        ),
+      ).toHaveLength(retarget ? 2 : 1);
+    },
+  );
 
   it("keeps configured models absent from registry discovery", async () => {
     const snapshot = await build({

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -26,15 +26,8 @@ import type {
   ModelInputType,
 } from "./model-catalog.types.js";
 import { resolveCatalogOwnedModelCompat } from "./model-compat-catalog.js";
-import {
-  modelKey,
-  normalizeConfiguredProviderCatalogModelId,
-  type ProviderModelIdNormalizationOptions,
-} from "./model-ref-shared.js";
-import {
-  buildConfiguredModelCatalog,
-  hasConfiguredProviderModelRows,
-} from "./model-selection-shared.js";
+import { modelKey, createConfiguredProviderCatalogModelIdNormalizer } from "./model-ref-shared.js";
+import { buildConfiguredModelCatalog } from "./model-selection-shared.js";
 import type { AuthStorageData, ModelRegistry } from "./sessions/index.js";
 
 const log = createSubsystemLogger("model-catalog");
@@ -93,23 +86,28 @@ export function resetModelCatalogBuilderCacheForTest() {
   hasLoggedModelCatalogError = false;
 }
 
-/** Canonicalizes a provider alias against the metadata captured with a prepared catalog. */
-export function canonicalizePreparedModelCatalogProvider(
-  provider: string,
+/** Prepares provider aliases once for one captured catalog metadata generation. */
+export function createPreparedModelCatalogProviderNormalizer(
   metadataSnapshot: Pick<PluginMetadataSnapshot, "manifestRegistry">,
-): string {
-  const normalizedProvider = normalizeProviderId(provider);
-  for (const plugin of metadataSnapshot.manifestRegistry.plugins) {
-    for (const [alias, target] of Object.entries(plugin.modelCatalog?.aliases ?? {})) {
-      if (normalizeProviderId(alias) === normalizedProvider) {
-        const canonicalProvider = normalizeProviderId(target.provider);
-        if (canonicalProvider) {
-          return canonicalProvider;
+): (provider: string) => string {
+  let aliases: Map<string, string> | undefined;
+  return (provider) => {
+    const normalizedProvider = normalizeProviderId(provider);
+    if (!aliases) {
+      aliases = new Map();
+      for (const plugin of metadataSnapshot.manifestRegistry.plugins) {
+        for (const [alias, target] of Object.entries(plugin.modelCatalog?.aliases ?? {})) {
+          const key = normalizeProviderId(alias);
+          const canonicalProvider = normalizeProviderId(target.provider);
+          // Duplicate aliases retain the first nonempty target in manifest order.
+          if (canonicalProvider && !aliases.has(key)) {
+            aliases.set(key, canonicalProvider);
+          }
         }
       }
     }
-  }
-  return normalizedProvider;
+    return aliases.get(normalizedProvider) ?? normalizedProvider;
+  };
 }
 
 function catalogEntryDedupeKey(provider: string, id: string): string {
@@ -274,7 +272,7 @@ function mergeCatalogEntries(
   models: ModelCatalogEntry[],
   entries: ModelCatalogEntry[],
   options?: {
-    catalogRoutes?: readonly ModelCatalogEntry[];
+    catalogRoutes?: ModelCatalogRouteVariantCollector;
     preserveBaseCompat?: boolean;
     preserveBaseName?: boolean;
   },
@@ -294,11 +292,11 @@ function mergeCatalogEntries(
     if (existing) {
       // Logical rows can represent a sibling route; capabilities must come
       // from the exact catalog variant selected by config, not that sibling.
-      const catalogRoute = options?.preserveBaseCompat
-        ? options.catalogRoutes?.find(
-            (candidate) => catalogRouteVariantKey(candidate) === catalogRouteVariantKey(entry),
-          )
+      const routes = options?.catalogRoutes;
+      const routeIndex = options?.preserveBaseCompat
+        ? routes?.indexByKey.get(catalogRouteVariantKey(entry))
         : undefined;
+      const catalogRoute = routeIndex === undefined ? undefined : routes?.entries[routeIndex];
       models[existingIndex] = overlayCatalogMetadata(existing, entry, {
         ...options,
         catalogRoute,
@@ -453,11 +451,10 @@ export async function buildPreparedModelCatalogSnapshot(
   try {
     const workspaceDir = params.workspaceDir;
     const manifestMetadataSnapshot = params.metadataSnapshot;
-    let manifestPlugins: ProviderModelIdNormalizationOptions["manifestPlugins"];
-    const getManifestPlugins = () => {
-      manifestPlugins ??= manifestMetadataSnapshot.plugins;
-      return manifestPlugins;
-    };
+    const manifestPlugins = manifestMetadataSnapshot.plugins;
+    const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer({ manifestPlugins });
+    const normalizeProvider =
+      createPreparedModelCatalogProviderNormalizer(manifestMetadataSnapshot);
     const { buildShouldSuppressBuiltInModelCore } = await loadModelSuppression();
     logStage("catalog-deps-ready");
     const entries = params.modelRegistry.getAll() as DiscoveredModel[];
@@ -480,13 +477,8 @@ export async function buildPreparedModelCatalogSnapshot(
       if (!rawProvider) {
         continue;
       }
-      const provider = canonicalizePreparedModelCatalogProvider(
-        rawProvider,
-        manifestMetadataSnapshot,
-      );
-      const id = normalizeConfiguredProviderCatalogModelId(provider, rawId, {
-        manifestPlugins: getManifestPlugins(),
-      });
+      const provider = normalizeProvider(rawProvider);
+      const id = normalizeModelId(provider, rawId);
       const baseUrl = normalizeOptionalString(entry?.baseUrl);
       if (shouldSuppressBuiltInModel({ provider, id, baseUrl })) {
         continue;
@@ -555,21 +547,19 @@ export async function buildPreparedModelCatalogSnapshot(
     logStage("manifest-models-merged", `entries=${models.length}`);
     const configuredModels = buildConfiguredModelCatalog({
       cfg,
-      manifestPlugins: hasConfiguredProviderModelRows(cfg) ? getManifestPlugins() : undefined,
+      manifestPlugins,
     });
-    let augmentEntries: ModelCatalogEntry[] | undefined;
-    if (configuredModels.length > 0) {
-      const entriesForAugment = [...models];
-      mergeCatalogEntries(entriesForAugment, configuredModels, {
-        catalogRoutes: routeVariants.entries,
-        preserveBaseCompat: true,
-        preserveBaseName: true,
-      });
-      augmentEntries = entriesForAugment;
-    }
     logStage("configured-models-prepared", `entries=${models.length}`);
 
     if (!params.readOnly && params.includeProviderPluginAugmentation !== false) {
+      const augmentEntries = [...models];
+      if (configuredModels.length > 0) {
+        mergeCatalogEntries(augmentEntries, configuredModels, {
+          catalogRoutes: routeVariants,
+          preserveBaseCompat: true,
+          preserveBaseName: true,
+        });
+      }
       const { createProviderApiKeyResolverFromPreparedCredentials } =
         await loadProviderApiKeyResolver();
       const resolveProviderApiKeyForProvider = createProviderApiKeyResolverFromPreparedCredentials(
@@ -592,7 +582,7 @@ export async function buildPreparedModelCatalogSnapshot(
           workspaceDir,
           env,
           resolveProviderApiKey,
-          entries: augmentEntries ?? [...models],
+          entries: augmentEntries,
         },
       });
       if (supplemental.length > 0) {
@@ -600,23 +590,13 @@ export async function buildPreparedModelCatalogSnapshot(
         // discovery omits them; normalize both sets to preserve their routes.
         const accountVisibleModelKeys = new Set(
           [...models, ...configuredModels].map((entry) =>
-            catalogEntryDedupeKey(
-              entry.provider,
-              normalizeConfiguredProviderCatalogModelId(entry.provider, entry.id, {
-                manifestPlugins: getManifestPlugins(),
-              }),
-            ),
+            catalogEntryDedupeKey(entry.provider, normalizeModelId(entry.provider, entry.id)),
           ),
         );
         const normalizedSupplemental: ModelCatalogEntry[] = [];
         for (const entry of supplemental) {
-          const provider = canonicalizePreparedModelCatalogProvider(
-            entry.provider,
-            manifestMetadataSnapshot,
-          );
-          const id = normalizeConfiguredProviderCatalogModelId(provider, entry.id, {
-            manifestPlugins: getManifestPlugins(),
-          });
+          const provider = normalizeProvider(entry.provider);
+          const id = normalizeModelId(provider, entry.id);
           // Account-discovered providers own the visible model set. Synthetic
           // metadata can enrich an available or explicitly configured model,
           // but must never advertise a model the account did not discover.
@@ -646,8 +626,17 @@ export async function buildPreparedModelCatalogSnapshot(
 
     if (configuredModels.length > 0) {
       mergeCatalogRouteVariants(routeVariants, configuredModels, { preserveBaseCompat: true });
+      // Augmentation may mutate borrowed rows. Reindex after the final merge so
+      // route lookup keeps the first current match, including duplicate keys.
+      routeVariants.indexByKey.clear();
+      routeVariants.entries.forEach((entry, index) => {
+        const key = catalogRouteVariantKey(entry);
+        if (!routeVariants.indexByKey.has(key)) {
+          routeVariants.indexByKey.set(key, index);
+        }
+      });
       mergeCatalogEntries(models, configuredModels, {
-        catalogRoutes: routeVariants.entries,
+        catalogRoutes: routeVariants,
         preserveBaseCompat: true,
         preserveBaseName: true,
       });

--- a/src/agents/model-ref-shared.ts
+++ b/src/agents/model-ref-shared.ts
@@ -12,7 +12,7 @@ import {
   collectManifestModelIdNormalizationPolicies,
   normalizeBuiltInProviderModelId,
   normalizeConfiguredProviderCatalogModelRef,
-  normalizeConfiguredProviderCatalogModelId as normalizeConfiguredProviderCatalogModelIdShared,
+  type ManifestModelIdNormalizationRecord,
   normalizeStaticProviderModelIdWithPolicies,
   stripSelfProviderModelPrefix,
 } from "@openclaw/model-catalog-core/provider-model-id-normalization";
@@ -35,22 +35,6 @@ export type ModelManifestNormalizationContext = {
 export type ProviderModelIdNormalizationOptions = {
   allowManifestNormalization?: boolean;
   manifestPlugins?: readonly ManifestModelIdNormalizationRecord[];
-};
-
-type ManifestModelIdNormalizationProvider = {
-  aliases?: Record<string, string>;
-  stripPrefixes?: string[];
-  prefixWhenBare?: string;
-  prefixWhenBareAfterAliasStartsWith?: {
-    modelPrefix: string;
-    prefix: string;
-  }[];
-};
-
-type ManifestModelIdNormalizationRecord = {
-  modelIdNormalization?: {
-    providers?: Record<string, ManifestModelIdNormalizationProvider>;
-  };
 };
 
 /** Normalize a provider ID using the shared catalog rules. */
@@ -124,19 +108,21 @@ export function normalizeConfiguredProviderCatalogModelId(
   model: string,
   options: ProviderModelIdNormalizationOptions = {},
 ): string {
-  if (options.allowManifestNormalization === false) {
-    return normalizeConfiguredProviderCatalogModelIdShared(provider, model, new Map());
-  }
-  if (options.manifestPlugins) {
-    return normalizeConfiguredProviderCatalogModelIdShared(
-      provider,
-      model,
-      collectManifestModelIdNormalizationPolicies(options.manifestPlugins),
-    );
-  }
   return normalizeConfiguredProviderCatalogModelRef(
     normalizeStaticProviderModelId(provider, model, options),
   );
+}
+
+/** Reuses one manifest-policy view across configured model rows in an operation. */
+export function createConfiguredProviderCatalogModelIdNormalizer(
+  options: ProviderModelIdNormalizationOptions = {},
+): (provider: string, model: string) => string {
+  let normalizeStatic: ReturnType<typeof createStaticProviderModelIdNormalizer> | undefined;
+  return (provider, model) =>
+    normalizeConfiguredProviderCatalogModelRef(
+      // Empty operations never prepare policies; default scalar readers retain their current scope.
+      (normalizeStatic ??= createStaticProviderModelIdNormalizer(options))(provider, model),
+    );
 }
 
 type ModelRefNormalizeOptions = ModelManifestNormalizationContext & {

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -25,6 +25,7 @@ import type { ModelCatalogEntry } from "./model-catalog.types.js";
 import { resolveCatalogOwnedModelCompat } from "./model-compat-catalog.js";
 import { splitTrailingAuthProfile } from "./model-ref-profile.js";
 import {
+  createConfiguredProviderCatalogModelIdNormalizer,
   normalizeConfiguredProviderCatalogModelId,
   normalizeStaticProviderModelId,
   type ModelManifestNormalizationContext,
@@ -323,6 +324,10 @@ export function inferUniqueProviderFromConfiguredModels(
   };
   const configuredProviders = params.cfg.models?.providers;
   if (configuredProviders) {
+    const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer({
+      allowManifestNormalization: params.allowManifestNormalization,
+      manifestPlugins: params.manifestPlugins,
+    });
     for (const [providerId, providerConfig] of Object.entries(configuredProviders)) {
       const models = providerConfig?.models;
       if (!Array.isArray(models)) {
@@ -333,10 +338,7 @@ export function inferUniqueProviderFromConfiguredModels(
         if (!modelId) {
           continue;
         }
-        const normalizedModelId = normalizeConfiguredProviderCatalogModelId(providerId, modelId, {
-          allowManifestNormalization: params.allowManifestNormalization,
-          manifestPlugins: params.manifestPlugins,
-        });
+        const normalizedModelId = normalizeModelId(providerId, modelId);
         if (
           modelId === model ||
           normalizeLowercaseStringOrEmpty(modelId) === normalized ||
@@ -1284,7 +1286,7 @@ export function resolveAllowedModelRefFromAliasIndex(
 }
 
 /** True when config contains provider model rows that should seed catalogs. */
-export function hasConfiguredProviderModelRows(cfg: OpenClawConfig): boolean {
+function hasConfiguredProviderModelRows(cfg: OpenClawConfig): boolean {
   const providers = cfg.models?.providers;
   if (!providers || typeof providers !== "object") {
     return false;
@@ -1373,6 +1375,7 @@ export function buildConfiguredModelCatalog(params: {
   }
 
   const manifestPlugins = resolveConfiguredModelManifestPlugins(params);
+  const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer({ manifestPlugins });
   const catalog: ModelCatalogEntry[] = [];
   for (const [providerRaw, provider] of Object.entries(providers)) {
     const providerId = normalizeProviderId(providerRaw);
@@ -1381,9 +1384,7 @@ export function buildConfiguredModelCatalog(params: {
     }
     for (const model of provider.models) {
       const rawId = normalizeOptionalString(model?.id) ?? "";
-      const id = rawId
-        ? normalizeConfiguredProviderCatalogModelId(providerId, rawId, { manifestPlugins })
-        : "";
+      const id = rawId ? normalizeModelId(providerId, rawId) : "";
       if (!id) {
         continue;
       }

--- a/src/agents/models-config.merge.ts
+++ b/src/agents/models-config.merge.ts
@@ -10,7 +10,7 @@ import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import { resolveCatalogOwnedModelCompat } from "./model-compat-catalog.js";
 import {
   modelKey,
-  normalizeConfiguredProviderCatalogModelId,
+  createConfiguredProviderCatalogModelIdNormalizer,
   type ModelManifestNormalizationContext,
 } from "./model-ref-shared.js";
 import type { ProviderConfig } from "./models-config.providers.secrets.js";
@@ -99,6 +99,7 @@ export function mergeProviderModels(
       .filter(([id]) => Boolean(id)),
   );
   const seen = new Set<string>();
+  const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer(options);
 
   const mergedModels = explicitModels.map((explicitModel) => {
     const id = getProviderModelId(explicitModel);
@@ -113,10 +114,7 @@ export function mergeProviderModels(
     const sourceOmittedInput =
       options &&
       options.sourceModelInputOmissions?.has(
-        modelKey(
-          normalizeProviderId(options.providerId),
-          normalizeConfiguredProviderCatalogModelId(options.providerId, id, options),
-        ),
+        modelKey(normalizeProviderId(options.providerId), normalizeModelId(options.providerId, id)),
       ) === true;
     if (options?.preserveConfiguredModelMembership) {
       return sourceOmittedInput && implicitModel.input !== undefined

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -9,7 +9,7 @@ import type { ProviderCatalogOutcome } from "../plugins/provider-catalog.types.j
 import type { PreparedProviderStaticCatalog } from "../plugins/provider-discovery.js";
 import { isRecord } from "../utils.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
-import { modelKey, normalizeConfiguredProviderCatalogModelId } from "./model-ref-shared.js";
+import { modelKey, createConfiguredProviderCatalogModelIdNormalizer } from "./model-ref-shared.js";
 import {
   mergeProviders,
   mergeWithExistingProviderSecrets,
@@ -126,16 +126,12 @@ function buildSourceModelInputOmissions(
   sourceProviders: Record<string, ProviderConfig> | undefined,
   manifestPlugins: PluginMetadataSnapshot["manifestRegistry"]["plugins"] | undefined,
 ): ReadonlySet<string> {
+  const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer({ manifestPlugins });
   return new Set(
     Object.entries(normalizeProviderMapKeys(sourceProviders)).flatMap(([providerId, provider]) =>
       (provider.models ?? [])
         .filter((model) => !Object.hasOwn(model, "input"))
-        .map((model) =>
-          modelKey(
-            providerId,
-            normalizeConfiguredProviderCatalogModelId(providerId, model.id, { manifestPlugins }),
-          ),
-        ),
+        .map((model) => modelKey(providerId, normalizeModelId(providerId, model.id))),
     ),
   );
 }

--- a/src/agents/models-config.providers.normalize.ts
+++ b/src/agents/models-config.providers.normalize.ts
@@ -5,7 +5,7 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store.js";
-import { normalizeConfiguredProviderCatalogModelId } from "./model-ref-shared.js";
+import { createConfiguredProviderCatalogModelIdNormalizer } from "./model-ref-shared.js";
 import {
   normalizeProviderSpecificConfig,
   resolveProviderConfigApiKeyResolver,
@@ -85,16 +85,13 @@ function normalizeProviderModelsForConfig(
     return provider;
   }
 
+  const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer(options);
   let mutated = false;
   const nextModels: ProviderModelConfig[] = [];
   const seenById = new Map<string, number>();
   for (const model of provider.models) {
     const rawId = getProviderModelId(model);
-    const normalizedId = rawId
-      ? normalizeConfiguredProviderCatalogModelId(providerKey, rawId, {
-          manifestPlugins: options.manifestPlugins,
-        })
-      : rawId;
+    const normalizedId = rawId ? normalizeModelId(providerKey, rawId) : rawId;
     const normalizedModel =
       normalizedId && normalizedId !== rawId ? { ...model, id: normalizedId } : model;
     if (normalizedModel !== model) {

--- a/src/flows/model-picker.provider-catalog.ts
+++ b/src/flows/model-picker.provider-catalog.ts
@@ -1,7 +1,7 @@
 // Model picker provider choices projected from the lifecycle-owned catalog.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { resolveDefaultAgentDir } from "../agents/agent-scope.js";
-import { canonicalizePreparedModelCatalogProvider } from "../agents/model-catalog.js";
+import { createPreparedModelCatalogProviderNormalizer } from "../agents/model-catalog.js";
 import type { ModelCatalogSnapshot } from "../agents/model-catalog.types.js";
 import { loadPreparedModelCatalogSnapshot } from "../agents/prepared-model-catalog.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -40,10 +40,8 @@ export async function loadPreferredProviderPickerCatalog(params: {
     env,
     ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
   });
-  const providerFilter = canonicalizePreparedModelCatalogProvider(
-    requestedProvider,
-    metadataSnapshot,
-  );
+  const providerFilter =
+    createPreparedModelCatalogProviderNormalizer(metadataSnapshot)(requestedProvider);
   const snapshot = await loadPreparedModelCatalogSnapshot({
     config: params.cfg,
     agentDir: params.agentDir ?? resolveDefaultAgentDir(params.cfg, params.env),


### PR DESCRIPTION
## What Problem This Solves

Catalog construction repeatedly rebuilds the same manifest normalization rules and scans the same provider aliases for every model. Configured route overlays also search the full physical catalog for each row, and read-only catalog construction prepares an augmentation input that it never consumes.

## What Changes

Four independently measured improvements reuse facts at their existing owner boundaries:

- Prepare configured model-ID normalization once per operation through the existing static normalizer. Remove the duplicate policy type and scalar branches. Calls without an explicit metadata snapshot still consult their current runtime scope.
- Reuse the catalog's numeric route index for donor lookup. After plugin augmentation and the final physical merge, rebuild it with first-current-match precedence. Plugins can mutate borrowed rows; physical duplicates and their route-owned compatibility/thinking fields must survive.
- Build configured augmentation inputs only on the branch that invokes augmentation, retaining the original ordering before credential loading and plugin hooks.
- Prepare provider aliases lazily once per captured metadata snapshot and use that one normalizer in catalog construction and the preferred-provider picker. Preserve manifest ordering, the first nonempty target and one-hop expansion; remove the superseded scalar helper.

Production **+88/−123 = net −35** across seven owners. The existing route test is expanded by **+84/−54 = net +30** to cover both ordinary and borrowed-row-retargeted donors, asserting both resulting duplicate rows. No schema, dependency, config/default, public SDK, protocol, authorization or migration change.

## Measurements and Tradeoffs

Two fresh Node 26.8.1 processes measured the complete pre-change graph against the exact final four-change graph in opposite starting orders. All 103 workload entries and all source bindings passed; individual historical ablations are retained separately and their speedups are not multiplied. The complete configured read-only catalog builder measured:

| Configured models | Before → final, two process medians |
| --- | --- |
| 8 | 222.696/224.199 → 76.327/72.122 µs |
| 32 | 2.617/2.566 → 0.288/0.287 ms |
| 128 | 37.421/37.298 → 1.144/1.292 ms |

All small controls remain in the evidence. Empty read-only construction costs another 0.14–0.17 µs; unknown-alias singleton construction adds 0.76–2.36 µs. With 151 synthetic plugin records, an early-match provider picker adds 2.15–2.21 µs because it prepares the entire alias view. That bounded picker cost is accepted to retain one canonical preparation path. These fixtures exercise real captured metadata generations and complete owners, but provider augmentation and picker catalog loading are substituted at explicit boundaries. No provider/network, whole-turn, startup or memory improvement is claimed.

Final differential coverage includes 7,560 distinct normalization inputs, 516 complete publication/merge scenarios, 192 route scenario entries with 803 comparisons, and the alias-specific scalar/builder/picker matrix (486/462/486 comparisons plus 29 controls). These are layered proof units, not additional canonical tests. Checks preserve exact values, relevant object identity, first-valid/one-hop alias behavior, next-operation freshness and mutation-visible route donors.

## Verification and Contract Boundaries

All **297 canonical tests across 13 files** pass. The complete changed-file gate passes in **244.16 seconds**, including production/test types, lint, import cycles, dead exports and repository guards. Earlier gate failures caught an orphaned helper export and two test typing issues; these were fixed without weakening assertions, and their receipts remain retained. P0–P3 automated Codex review and independent source review are clean.

Manifest aliases are validated plain records from the JSON/JSON5 manifest admission path, not arbitrary executable objects. Metadata generations own their lifetime; no global cache or metadata freshness polling is added. Mutable catalog rows have a different contract: augmentation may retarget them, so an earlier index or a replacement map that discarded physical duplicates would be wrong. The expanded test and differential mutation witness enforce that distinction.

The lead personally inspected the sibling Codex checkout at `6478a751fde8884b2fdc76486fe23175a8e795d4`: `codex-rs/models-manager/src/manager.rs` (refresh/cache/auth/priority ownership), `codex-rs/app-server/src/models.rs`, and `codex-rs/app-server/src/request_processors/catalog_processor.rs:242–298` (hidden filtering and cursor pagination), alongside OpenClaw's native catalog adapter. This refactor does not change native model discovery, readiness or transport capabilities. Native source inspection is not a claim of a live Codex endpoint run.

This is an internal performance refactor with unchanged operator behavior; release-note context is recorded here and the release workflow owns the changelog. A separate unused legacy auth-profile file fixture was recorded as a named test-cleanup follow-up; it is not counted as a performance improvement.

At published head `01e6cb19e721c71d49e1c1e2fbd593330f933650`, all 297 tests pass again after the clean rebase and a fresh P0–P3 review is clean. The build passes in 165.10 seconds. An isolated real OpenAI Gateway passes 52 assertions over 12 catalog RPCs, covering six browse/prepared/refresh modes twice with exact repeated results. Three real model turns, including two actual `web_fetch` calls, pass another 51 assertions over 18 RPCs. In-flight recovery, persisted conversation, history anchors, list/status and restricted-reader behavior remain correct. The task-owned Gateway stopped cleanly and three Node CPU profiles were retained. Live durations are observational, separate from the controlled local measurements. Exact-head hosted CI is now green.

## Landing Review

The completed ClawSweeper review at the exact published head found no introduced correctness or security defect. Its request to check an omitted earlier comment is resolved: all three current comment bodies were read, and the two earlier comments are only an acknowledgement and a review-start placeholder, with no additional findings or rank-up requests. The latest rank-up move is exact-head CI, which has now passed. Lead and independent source reviews are complete; no separate human approval or live native Codex execution is claimed.

The refreshed review comment (updated 11:53:44 UTC) and its earlier review history were also read in full. Its remaining requests are satisfied: [exact-head CI run 33309529273](https://github.com/openclaw/openclaw/actions/runs/33309529273) succeeded without retries, all 248 check-rollup entries completed with no failures, and the prior comments contain no unresolved findings. The delegated maintainer decision is to accept this bounded internal refactor under the requested autonomous performance campaign. Lead and independent source reviews cover the ownership and measured tradeoffs; this does not claim a separate human code review.
