### PR TITLE
refactor(plugins): consolidate inert API defaults

### DIFF
--- a/src/plugins/api-builder.ts
+++ b/src/plugins/api-builder.ts
@@ -17,174 +17,87 @@ type BuildPluginApiParams = {
   runtime: PluginRuntime;
   logger: PluginLogger;
   resolvePath: (input: string) => string;
-  handlers?: Partial<
-    Pick<
-      OpenClawPluginApi,
-      | "registerTool"
-      | "registerHook"
-      | "registerHttpRoute"
-      | "registerHostedMediaResolver"
-      | "registerWidgetPresenter"
-      | "registerMcpServerConnectionResolver"
-      | "registerChannel"
-      | "registerGatewayMethod"
-      | "registerSessionCatalog"
-      | "registerCli"
-      | "registerReload"
-      | "registerNodeHostCommand"
-      | "registerNodeInvokePolicy"
-      | "registerSecurityAuditCollector"
-      | "registerService"
-      | "registerGatewayDiscoveryService"
-      | "registerCliBackend"
-      | "registerTextTransforms"
-      | "registerConfigMigration"
-      | "registerMigrationProvider"
-      | "registerAutoEnableProbe"
-      | "registerProvider"
-      | "registerWorkerProvider"
-      | "registerModelCatalogProvider"
-      | "registerEmbeddingProvider"
-      | "registerSpeechProvider"
-      | "registerRealtimeTranscriptionProvider"
-      | "registerRealtimeVoiceProvider"
-      | "registerMediaUnderstandingProvider"
-      | "registerTranscriptSourceProvider"
-      | "registerImageGenerationProvider"
-      | "registerVideoGenerationProvider"
-      | "registerMusicGenerationProvider"
-      | "registerWebFetchProvider"
-      | "registerWebSearchProvider"
-      | "registerInteractiveHandler"
-      | "onConversationBindingResolved"
-      | "registerCommand"
-      | "registerContextEngine"
-      | "registerCompactionProvider"
-      | "registerAgentHarness"
-      | "registerCodexAppServerExtensionFactory"
-      | "registerAgentToolResultMiddleware"
-      | "registerSessionExtension"
-      | "enqueueNextTurnInjection"
-      | "registerTrustedToolPolicy"
-      | "registerToolMetadata"
-      | "registerControlUiDescriptor"
-      | "registerBoardWidgetContentKind"
-      | "registerRuntimeLifecycle"
-      | "registerAgentEventSubscription"
-      | "emitAgentEvent"
-      | "setRunContext"
-      | "getRunContext"
-      | "clearRunContext"
-      | "registerSessionSchedulerJob"
-      | "registerSessionAction"
-      | "sendSessionAttachment"
-      | "scheduleSessionTurn"
-      | "unscheduleSessionTurnsByTag"
-      | "registerDetachedTaskRuntime"
-      | "registerMemoryCapability"
-      | "registerMemoryPromptSupplement"
-      | "registerMemoryPromptPreparation"
-      | "registerMemoryCorpusSupplement"
-      | "on"
-    >
-  >;
+  handlers?: Partial<Pick<OpenClawPluginApi, keyof typeof noops>>;
 };
 
-const noopRegisterTool: OpenClawPluginApi["registerTool"] = () => {};
-const noopRegisterHook: OpenClawPluginApi["registerHook"] = () => {};
-const noopRegisterHttpRoute: OpenClawPluginApi["registerHttpRoute"] = () => {};
-const noopRegisterHostedMediaResolver: OpenClawPluginApi["registerHostedMediaResolver"] = () => {};
-const noopRegisterWidgetPresenter: OpenClawPluginApi["registerWidgetPresenter"] = () => {};
-const noopRegisterMcpServerConnectionResolver: OpenClawPluginApi["registerMcpServerConnectionResolver"] =
-  () => {};
-const noopRegisterChannel: OpenClawPluginApi["registerChannel"] = () => {};
-const noopRegisterGatewayMethod: OpenClawPluginApi["registerGatewayMethod"] = () => {};
-const noopRegisterSessionCatalog: OpenClawPluginApi["registerSessionCatalog"] = () => {};
-const noopRegisterCli: OpenClawPluginApi["registerCli"] = () => {};
-const noopRegisterReload: OpenClawPluginApi["registerReload"] = () => {};
-const noopRegisterNodeHostCommand: OpenClawPluginApi["registerNodeHostCommand"] = () => {};
-const noopRegisterNodeInvokePolicy: OpenClawPluginApi["registerNodeInvokePolicy"] = () => {};
-const noopRegisterSecurityAuditCollector: OpenClawPluginApi["registerSecurityAuditCollector"] =
-  () => {};
-const noopRegisterService: OpenClawPluginApi["registerService"] = () => {};
-const noopRegisterGatewayDiscoveryService: OpenClawPluginApi["registerGatewayDiscoveryService"] =
-  () => {};
-const noopRegisterCliBackend: OpenClawPluginApi["registerCliBackend"] = () => {};
-const noopRegisterTextTransforms: OpenClawPluginApi["registerTextTransforms"] = () => {};
-const noopRegisterConfigMigration: OpenClawPluginApi["registerConfigMigration"] = () => {};
-const noopRegisterMigrationProvider: OpenClawPluginApi["registerMigrationProvider"] = () => {};
-const noopRegisterAutoEnableProbe: OpenClawPluginApi["registerAutoEnableProbe"] = () => {};
-const noopRegisterProvider: OpenClawPluginApi["registerProvider"] = () => {};
-const noopRegisterWorkerProvider: OpenClawPluginApi["registerWorkerProvider"] = () => {};
-const noopRegisterModelCatalogProvider: OpenClawPluginApi["registerModelCatalogProvider"] =
-  () => {};
-const noopRegisterEmbeddingProvider: OpenClawPluginApi["registerEmbeddingProvider"] = () => {};
-const noopRegisterSpeechProvider: OpenClawPluginApi["registerSpeechProvider"] = () => {};
-const noopRegisterRealtimeTranscriptionProvider: OpenClawPluginApi["registerRealtimeTranscriptionProvider"] =
-  () => {};
-const noopRegisterRealtimeVoiceProvider: OpenClawPluginApi["registerRealtimeVoiceProvider"] =
-  () => {};
-const noopRegisterMediaUnderstandingProvider: OpenClawPluginApi["registerMediaUnderstandingProvider"] =
-  () => {};
-const noopRegisterTranscriptsSourceProvider: OpenClawPluginApi["registerTranscriptSourceProvider"] =
-  () => {};
-const noopRegisterImageGenerationProvider: OpenClawPluginApi["registerImageGenerationProvider"] =
-  () => {};
-const noopRegisterVideoGenerationProvider: OpenClawPluginApi["registerVideoGenerationProvider"] =
-  () => {};
-const noopRegisterMusicGenerationProvider: OpenClawPluginApi["registerMusicGenerationProvider"] =
-  () => {};
-const noopRegisterWebFetchProvider: OpenClawPluginApi["registerWebFetchProvider"] = () => {};
-const noopRegisterWebSearchProvider: OpenClawPluginApi["registerWebSearchProvider"] = () => {};
-const noopRegisterInteractiveHandler: OpenClawPluginApi["registerInteractiveHandler"] = () => {};
-const noopOnConversationBindingResolved: OpenClawPluginApi["onConversationBindingResolved"] =
-  () => {};
-const noopRegisterCommand: OpenClawPluginApi["registerCommand"] = () => {};
-const noopRegisterContextEngine: OpenClawPluginApi["registerContextEngine"] = () => {};
-const noopRegisterCompactionProvider: OpenClawPluginApi["registerCompactionProvider"] = () => {};
-const noopRegisterAgentHarness: OpenClawPluginApi["registerAgentHarness"] = () => {};
-const noopRegisterCodexAppServerExtensionFactory: OpenClawPluginApi["registerCodexAppServerExtensionFactory"] =
-  () => {};
-const noopRegisterAgentToolResultMiddleware: OpenClawPluginApi["registerAgentToolResultMiddleware"] =
-  () => {};
-const noopRegisterSessionExtension: OpenClawPluginApi["registerSessionExtension"] = () => {};
-const noopEnqueueNextTurnInjection: OpenClawPluginApi["enqueueNextTurnInjection"] = async (
-  injection,
-) => ({ enqueued: false, id: "", sessionKey: injection.sessionKey });
-const noopRegisterTrustedToolPolicy: OpenClawPluginApi["registerTrustedToolPolicy"] = () => {};
-const noopRegisterToolMetadata: OpenClawPluginApi["registerToolMetadata"] = () => {};
-const noopRegisterControlUiDescriptor: OpenClawPluginApi["registerControlUiDescriptor"] = () => {};
-const noopRegisterBoardWidgetContentKind: OpenClawPluginApi["registerBoardWidgetContentKind"] =
-  () => {};
-const noopRegisterRuntimeLifecycle: OpenClawPluginApi["registerRuntimeLifecycle"] = () => {};
-const noopRegisterAgentEventSubscription: OpenClawPluginApi["registerAgentEventSubscription"] =
-  () => {};
-const noopEmitAgentEvent: OpenClawPluginApi["emitAgentEvent"] = () => ({
-  emitted: false,
-  reason: "not wired",
-});
-const noopSetRunContext: OpenClawPluginApi["setRunContext"] = () => false;
-const noopGetRunContext: OpenClawPluginApi["getRunContext"] = () => undefined;
-const noopClearRunContext: OpenClawPluginApi["clearRunContext"] = () => {};
-const noopRegisterSessionSchedulerJob: OpenClawPluginApi["registerSessionSchedulerJob"] = () =>
-  undefined;
-const noopRegisterSessionAction: OpenClawPluginApi["registerSessionAction"] = () => {};
-const noopSendSessionAttachment: OpenClawPluginApi["sendSessionAttachment"] = async () => ({
-  ok: false,
-  error: "not wired",
-});
-const noopScheduleSessionTurn: OpenClawPluginApi["scheduleSessionTurn"] = async () => undefined;
-const noopUnscheduleSessionTurnsByTag: OpenClawPluginApi["unscheduleSessionTurnsByTag"] =
-  async () => ({ removed: 0, failed: 0 });
-const noopRegisterDetachedTaskRuntime: OpenClawPluginApi["registerDetachedTaskRuntime"] = () => {};
-const noopRegisterMemoryCapability: OpenClawPluginApi["registerMemoryCapability"] = () => {};
-const noopRegisterMemoryPromptSupplement: OpenClawPluginApi["registerMemoryPromptSupplement"] =
-  () => {};
-const noopRegisterMemoryPromptPreparation: OpenClawPluginApi["registerMemoryPromptPreparation"] =
-  () => {};
-const noopRegisterMemoryCorpusSupplement: OpenClawPluginApi["registerMemoryCorpusSupplement"] =
-  () => {};
-const noopOn: OpenClawPluginApi["on"] = () => {};
+const noops = {
+  registerTool: () => {},
+  registerHook: () => {},
+  registerHttpRoute: () => {},
+  registerHostedMediaResolver: () => {},
+  registerWidgetPresenter: () => {},
+  registerMcpServerConnectionResolver: () => {},
+  registerChannel: () => {},
+  registerGatewayMethod: () => {},
+  registerSessionCatalog: () => {},
+  registerCli: () => {},
+  registerReload: () => {},
+  registerNodeHostCommand: () => {},
+  registerNodeInvokePolicy: () => {},
+  registerSecurityAuditCollector: () => {},
+  registerService: () => {},
+  registerGatewayDiscoveryService: () => {},
+  registerCliBackend: () => {},
+  registerTextTransforms: () => {},
+  registerConfigMigration: () => {},
+  registerMigrationProvider: () => {},
+  registerAutoEnableProbe: () => {},
+  registerProvider: () => {},
+  registerWorkerProvider: () => {},
+  registerModelCatalogProvider: () => {},
+  registerEmbeddingProvider: () => {},
+  registerSpeechProvider: () => {},
+  registerRealtimeTranscriptionProvider: () => {},
+  registerRealtimeVoiceProvider: () => {},
+  registerMediaUnderstandingProvider: () => {},
+  registerTranscriptSourceProvider: () => {},
+  registerImageGenerationProvider: () => {},
+  registerVideoGenerationProvider: () => {},
+  registerMusicGenerationProvider: () => {},
+  registerWebFetchProvider: () => {},
+  registerWebSearchProvider: () => {},
+  registerInteractiveHandler: () => {},
+  onConversationBindingResolved: () => {},
+  registerCommand: () => {},
+  registerContextEngine: () => {},
+  registerCompactionProvider: () => {},
+  registerAgentHarness: () => {},
+  registerCodexAppServerExtensionFactory: () => {},
+  registerAgentToolResultMiddleware: () => {},
+  registerSessionExtension: () => {},
+  enqueueNextTurnInjection: async (injection) => ({
+    enqueued: false,
+    id: "",
+    sessionKey: injection.sessionKey,
+  }),
+  registerTrustedToolPolicy: () => {},
+  registerToolMetadata: () => {},
+  registerControlUiDescriptor: () => {},
+  registerBoardWidgetContentKind: () => {},
+  registerRuntimeLifecycle: () => {},
+  registerAgentEventSubscription: () => {},
+  emitAgentEvent: () => ({
+    emitted: false,
+    reason: "not wired",
+  }),
+  setRunContext: () => false,
+  getRunContext: () => undefined,
+  clearRunContext: () => {},
+  registerSessionSchedulerJob: () => undefined,
+  registerSessionAction: () => {},
+  sendSessionAttachment: async () => ({
+    ok: false,
+    error: "not wired",
+  }),
+  scheduleSessionTurn: async () => undefined,
+  unscheduleSessionTurnsByTag: async () => ({ removed: 0, failed: 0 }),
+  registerDetachedTaskRuntime: () => {},
+  registerMemoryCapability: () => {},
+  registerMemoryPromptSupplement: () => {},
+  registerMemoryPromptPreparation: () => {},
+  registerMemoryCorpusSupplement: () => {},
+  on: () => {},
+} satisfies Partial<OpenClawPluginApi>;
 
 export function createUnavailableRuntime(
   registrationMode: "cli-metadata" | "setup-only",
@@ -210,7 +123,8 @@ export function createUnavailableRuntime(
 
 export function buildPluginApi(params: BuildPluginApiParams): OpenClawPluginApi {
   const handlers = params.handlers ?? {};
-  const registerCli = handlers.registerCli ?? noopRegisterCli;
+  // Keep explicit lookups for inherited/nullish handlers; capture CLI once for both entrypoints.
+  const registerCli = handlers.registerCli ?? noops.registerCli;
   const api: OpenClawPluginApiWithoutFacades = {
     id: params.id,
     name: params.name,
@@ -223,104 +137,109 @@ export function buildPluginApi(params: BuildPluginApiParams): OpenClawPluginApi 
     pluginConfig: params.pluginConfig,
     runtime: params.runtime,
     logger: params.logger,
-    registerTool: handlers.registerTool ?? noopRegisterTool,
-    registerHook: handlers.registerHook ?? noopRegisterHook,
-    registerHttpRoute: handlers.registerHttpRoute ?? noopRegisterHttpRoute,
+    registerTool: handlers.registerTool ?? noops.registerTool,
+    registerHook: handlers.registerHook ?? noops.registerHook,
+    registerHttpRoute: handlers.registerHttpRoute ?? noops.registerHttpRoute,
     registerHostedMediaResolver:
-      handlers.registerHostedMediaResolver ?? noopRegisterHostedMediaResolver,
-    registerWidgetPresenter: handlers.registerWidgetPresenter ?? noopRegisterWidgetPresenter,
+      handlers.registerHostedMediaResolver ?? noops.registerHostedMediaResolver,
+    registerWidgetPresenter: handlers.registerWidgetPresenter ?? noops.registerWidgetPresenter,
     registerMcpServerConnectionResolver:
-      handlers.registerMcpServerConnectionResolver ?? noopRegisterMcpServerConnectionResolver,
-    registerChannel: handlers.registerChannel ?? noopRegisterChannel,
-    registerGatewayMethod: handlers.registerGatewayMethod ?? noopRegisterGatewayMethod,
-    registerSessionCatalog: handlers.registerSessionCatalog ?? noopRegisterSessionCatalog,
+      handlers.registerMcpServerConnectionResolver ?? noops.registerMcpServerConnectionResolver,
+    registerChannel: handlers.registerChannel ?? noops.registerChannel,
+    registerGatewayMethod: handlers.registerGatewayMethod ?? noops.registerGatewayMethod,
+    registerSessionCatalog: handlers.registerSessionCatalog ?? noops.registerSessionCatalog,
     registerCli,
     registerNodeCliFeature: (registrar, opts) =>
       registerCli(registrar, {
         ...opts,
         parentPath: ["nodes"],
       }),
-    registerReload: handlers.registerReload ?? noopRegisterReload,
-    registerNodeHostCommand: handlers.registerNodeHostCommand ?? noopRegisterNodeHostCommand,
-    registerNodeInvokePolicy: handlers.registerNodeInvokePolicy ?? noopRegisterNodeInvokePolicy,
+    registerReload: handlers.registerReload ?? noops.registerReload,
+    registerNodeHostCommand: handlers.registerNodeHostCommand ?? noops.registerNodeHostCommand,
+    registerNodeInvokePolicy: handlers.registerNodeInvokePolicy ?? noops.registerNodeInvokePolicy,
     registerSecurityAuditCollector:
-      handlers.registerSecurityAuditCollector ?? noopRegisterSecurityAuditCollector,
-    registerService: handlers.registerService ?? noopRegisterService,
+      handlers.registerSecurityAuditCollector ?? noops.registerSecurityAuditCollector,
+    registerService: handlers.registerService ?? noops.registerService,
     registerGatewayDiscoveryService:
-      handlers.registerGatewayDiscoveryService ?? noopRegisterGatewayDiscoveryService,
-    registerCliBackend: handlers.registerCliBackend ?? noopRegisterCliBackend,
-    registerTextTransforms: handlers.registerTextTransforms ?? noopRegisterTextTransforms,
-    registerConfigMigration: handlers.registerConfigMigration ?? noopRegisterConfigMigration,
-    registerMigrationProvider: handlers.registerMigrationProvider ?? noopRegisterMigrationProvider,
-    registerAutoEnableProbe: handlers.registerAutoEnableProbe ?? noopRegisterAutoEnableProbe,
-    registerProvider: handlers.registerProvider ?? noopRegisterProvider,
-    registerWorkerProvider: handlers.registerWorkerProvider ?? noopRegisterWorkerProvider,
+      handlers.registerGatewayDiscoveryService ?? noops.registerGatewayDiscoveryService,
+    registerCliBackend: handlers.registerCliBackend ?? noops.registerCliBackend,
+    registerTextTransforms: handlers.registerTextTransforms ?? noops.registerTextTransforms,
+    registerConfigMigration: handlers.registerConfigMigration ?? noops.registerConfigMigration,
+    registerMigrationProvider:
+      handlers.registerMigrationProvider ?? noops.registerMigrationProvider,
+    registerAutoEnableProbe: handlers.registerAutoEnableProbe ?? noops.registerAutoEnableProbe,
+    registerProvider: handlers.registerProvider ?? noops.registerProvider,
+    registerWorkerProvider: handlers.registerWorkerProvider ?? noops.registerWorkerProvider,
     registerModelCatalogProvider:
-      handlers.registerModelCatalogProvider ?? noopRegisterModelCatalogProvider,
-    registerEmbeddingProvider: handlers.registerEmbeddingProvider ?? noopRegisterEmbeddingProvider,
-    registerSpeechProvider: handlers.registerSpeechProvider ?? noopRegisterSpeechProvider,
+      handlers.registerModelCatalogProvider ?? noops.registerModelCatalogProvider,
+    registerEmbeddingProvider:
+      handlers.registerEmbeddingProvider ?? noops.registerEmbeddingProvider,
+    registerSpeechProvider: handlers.registerSpeechProvider ?? noops.registerSpeechProvider,
     registerRealtimeTranscriptionProvider:
-      handlers.registerRealtimeTranscriptionProvider ?? noopRegisterRealtimeTranscriptionProvider,
+      handlers.registerRealtimeTranscriptionProvider ?? noops.registerRealtimeTranscriptionProvider,
     registerRealtimeVoiceProvider:
-      handlers.registerRealtimeVoiceProvider ?? noopRegisterRealtimeVoiceProvider,
+      handlers.registerRealtimeVoiceProvider ?? noops.registerRealtimeVoiceProvider,
     registerMediaUnderstandingProvider:
-      handlers.registerMediaUnderstandingProvider ?? noopRegisterMediaUnderstandingProvider,
+      handlers.registerMediaUnderstandingProvider ?? noops.registerMediaUnderstandingProvider,
     registerTranscriptSourceProvider:
-      handlers.registerTranscriptSourceProvider ?? noopRegisterTranscriptsSourceProvider,
+      handlers.registerTranscriptSourceProvider ?? noops.registerTranscriptSourceProvider,
     registerImageGenerationProvider:
-      handlers.registerImageGenerationProvider ?? noopRegisterImageGenerationProvider,
+      handlers.registerImageGenerationProvider ?? noops.registerImageGenerationProvider,
     registerVideoGenerationProvider:
-      handlers.registerVideoGenerationProvider ?? noopRegisterVideoGenerationProvider,
+      handlers.registerVideoGenerationProvider ?? noops.registerVideoGenerationProvider,
     registerMusicGenerationProvider:
-      handlers.registerMusicGenerationProvider ?? noopRegisterMusicGenerationProvider,
-    registerWebFetchProvider: handlers.registerWebFetchProvider ?? noopRegisterWebFetchProvider,
-    registerWebSearchProvider: handlers.registerWebSearchProvider ?? noopRegisterWebSearchProvider,
+      handlers.registerMusicGenerationProvider ?? noops.registerMusicGenerationProvider,
+    registerWebFetchProvider: handlers.registerWebFetchProvider ?? noops.registerWebFetchProvider,
+    registerWebSearchProvider:
+      handlers.registerWebSearchProvider ?? noops.registerWebSearchProvider,
     registerInteractiveHandler:
-      handlers.registerInteractiveHandler ?? noopRegisterInteractiveHandler,
+      handlers.registerInteractiveHandler ?? noops.registerInteractiveHandler,
     onConversationBindingResolved:
-      handlers.onConversationBindingResolved ?? noopOnConversationBindingResolved,
-    registerCommand: handlers.registerCommand ?? noopRegisterCommand,
-    registerContextEngine: handlers.registerContextEngine ?? noopRegisterContextEngine,
+      handlers.onConversationBindingResolved ?? noops.onConversationBindingResolved,
+    registerCommand: handlers.registerCommand ?? noops.registerCommand,
+    registerContextEngine: handlers.registerContextEngine ?? noops.registerContextEngine,
     registerCompactionProvider:
-      handlers.registerCompactionProvider ?? noopRegisterCompactionProvider,
-    registerAgentHarness: handlers.registerAgentHarness ?? noopRegisterAgentHarness,
+      handlers.registerCompactionProvider ?? noops.registerCompactionProvider,
+    registerAgentHarness: handlers.registerAgentHarness ?? noops.registerAgentHarness,
     registerCodexAppServerExtensionFactory:
-      handlers.registerCodexAppServerExtensionFactory ?? noopRegisterCodexAppServerExtensionFactory,
+      handlers.registerCodexAppServerExtensionFactory ??
+      noops.registerCodexAppServerExtensionFactory,
     registerAgentToolResultMiddleware:
-      handlers.registerAgentToolResultMiddleware ?? noopRegisterAgentToolResultMiddleware,
-    registerSessionExtension: handlers.registerSessionExtension ?? noopRegisterSessionExtension,
-    enqueueNextTurnInjection: handlers.enqueueNextTurnInjection ?? noopEnqueueNextTurnInjection,
-    registerTrustedToolPolicy: handlers.registerTrustedToolPolicy ?? noopRegisterTrustedToolPolicy,
-    registerToolMetadata: handlers.registerToolMetadata ?? noopRegisterToolMetadata,
+      handlers.registerAgentToolResultMiddleware ?? noops.registerAgentToolResultMiddleware,
+    registerSessionExtension: handlers.registerSessionExtension ?? noops.registerSessionExtension,
+    enqueueNextTurnInjection: handlers.enqueueNextTurnInjection ?? noops.enqueueNextTurnInjection,
+    registerTrustedToolPolicy:
+      handlers.registerTrustedToolPolicy ?? noops.registerTrustedToolPolicy,
+    registerToolMetadata: handlers.registerToolMetadata ?? noops.registerToolMetadata,
     registerControlUiDescriptor:
-      handlers.registerControlUiDescriptor ?? noopRegisterControlUiDescriptor,
+      handlers.registerControlUiDescriptor ?? noops.registerControlUiDescriptor,
     registerBoardWidgetContentKind:
-      handlers.registerBoardWidgetContentKind ?? noopRegisterBoardWidgetContentKind,
-    registerRuntimeLifecycle: handlers.registerRuntimeLifecycle ?? noopRegisterRuntimeLifecycle,
+      handlers.registerBoardWidgetContentKind ?? noops.registerBoardWidgetContentKind,
+    registerRuntimeLifecycle: handlers.registerRuntimeLifecycle ?? noops.registerRuntimeLifecycle,
     registerAgentEventSubscription:
-      handlers.registerAgentEventSubscription ?? noopRegisterAgentEventSubscription,
-    emitAgentEvent: handlers.emitAgentEvent ?? noopEmitAgentEvent,
-    setRunContext: handlers.setRunContext ?? noopSetRunContext,
-    getRunContext: handlers.getRunContext ?? noopGetRunContext,
-    clearRunContext: handlers.clearRunContext ?? noopClearRunContext,
+      handlers.registerAgentEventSubscription ?? noops.registerAgentEventSubscription,
+    emitAgentEvent: handlers.emitAgentEvent ?? noops.emitAgentEvent,
+    setRunContext: handlers.setRunContext ?? noops.setRunContext,
+    getRunContext: handlers.getRunContext ?? noops.getRunContext,
+    clearRunContext: handlers.clearRunContext ?? noops.clearRunContext,
     registerSessionSchedulerJob:
-      handlers.registerSessionSchedulerJob ?? noopRegisterSessionSchedulerJob,
-    registerSessionAction: handlers.registerSessionAction ?? noopRegisterSessionAction,
-    sendSessionAttachment: handlers.sendSessionAttachment ?? noopSendSessionAttachment,
-    scheduleSessionTurn: handlers.scheduleSessionTurn ?? noopScheduleSessionTurn,
+      handlers.registerSessionSchedulerJob ?? noops.registerSessionSchedulerJob,
+    registerSessionAction: handlers.registerSessionAction ?? noops.registerSessionAction,
+    sendSessionAttachment: handlers.sendSessionAttachment ?? noops.sendSessionAttachment,
+    scheduleSessionTurn: handlers.scheduleSessionTurn ?? noops.scheduleSessionTurn,
     unscheduleSessionTurnsByTag:
-      handlers.unscheduleSessionTurnsByTag ?? noopUnscheduleSessionTurnsByTag,
+      handlers.unscheduleSessionTurnsByTag ?? noops.unscheduleSessionTurnsByTag,
     registerDetachedTaskRuntime:
-      handlers.registerDetachedTaskRuntime ?? noopRegisterDetachedTaskRuntime,
-    registerMemoryCapability: handlers.registerMemoryCapability ?? noopRegisterMemoryCapability,
+      handlers.registerDetachedTaskRuntime ?? noops.registerDetachedTaskRuntime,
+    registerMemoryCapability: handlers.registerMemoryCapability ?? noops.registerMemoryCapability,
     registerMemoryPromptSupplement:
-      handlers.registerMemoryPromptSupplement ?? noopRegisterMemoryPromptSupplement,
+      handlers.registerMemoryPromptSupplement ?? noops.registerMemoryPromptSupplement,
     registerMemoryPromptPreparation:
-      handlers.registerMemoryPromptPreparation ?? noopRegisterMemoryPromptPreparation,
+      handlers.registerMemoryPromptPreparation ?? noops.registerMemoryPromptPreparation,
     registerMemoryCorpusSupplement:
-      handlers.registerMemoryCorpusSupplement ?? noopRegisterMemoryCorpusSupplement,
+      handlers.registerMemoryCorpusSupplement ?? noops.registerMemoryCorpusSupplement,
     resolvePath: params.resolvePath,
-    on: handlers.on ?? noopOn,
+    on: handlers.on ?? noops.on,
   };
   return attachPluginApiFacades(api);
 }

--- a/src/plugins/api-lifecycle.test.ts
+++ b/src/plugins/api-lifecycle.test.ts
@@ -9,8 +9,8 @@ import { createEmptyPluginRegistry } from "./registry-empty.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import type { OpenClawPluginApi } from "./types.js";
 
-function captureRegisteredPluginApi(handlers: Parameters<typeof buildPluginApi>[0]["handlers"]) {
-  const api = buildPluginApi({
+function createPluginApi(handlers: Parameters<typeof buildPluginApi>[0]["handlers"] = {}) {
+  return buildPluginApi({
     id: "late-call-fixture",
     name: "Late Call Fixture",
     source: "test",
@@ -21,6 +21,10 @@ function captureRegisteredPluginApi(handlers: Parameters<typeof buildPluginApi>[
     resolvePath: (input) => input,
     handlers,
   });
+}
+
+function captureRegisteredPluginApi(handlers: Parameters<typeof buildPluginApi>[0]["handlers"]) {
+  const api = createPluginApi(handlers);
   let captured: OpenClawPluginApi | undefined;
   runPluginRegisterSyncInRegistry(
     (pluginApi) => {
@@ -34,6 +38,73 @@ function captureRegisteredPluginApi(handlers: Parameters<typeof buildPluginApi>[
 }
 
 describe("plugin api lifecycle", () => {
+  it("returns inert results for unwired runtime and scheduler handlers", async () => {
+    const api = createPluginApi();
+    const sessionKey = "agent:main:main";
+
+    expect(api.emitAgentEvent({ runId: "run", stream: "lifecycle", data: {} })).toEqual({
+      emitted: false,
+      reason: "not wired",
+    });
+    expect(api.setRunContext({ runId: "run", namespace: "workflow", value: 1 })).toBe(false);
+    expect(api.getRunContext({ runId: "run", namespace: "workflow" })).toBeUndefined();
+    expect(
+      api.registerSessionSchedulerJob({ id: "job", sessionKey, kind: "session-turn" }),
+    ).toBeUndefined();
+    await expect(api.enqueueNextTurnInjection({ sessionKey, text: "queued" })).resolves.toEqual({
+      enqueued: false,
+      id: "",
+      sessionKey,
+    });
+    await expect(
+      api.sendSessionAttachment({ sessionKey, files: [{ path: "/tmp/attachment.txt" }] }),
+    ).resolves.toEqual({ ok: false, error: "not wired" });
+    await expect(
+      api.scheduleSessionTurn({ sessionKey, message: "wake", delayMs: 1_000 }),
+    ).resolves.toBeUndefined();
+    await expect(api.unscheduleSessionTurnsByTag({ sessionKey, tag: "wake" })).resolves.toEqual({
+      removed: 0,
+      failed: 0,
+    });
+  });
+
+  it("keeps inherited handlers, undefined defaults, and one captured CLI lookup", () => {
+    const reads: string[] = [];
+    const registerCli = vi.fn<OpenClawPluginApi["registerCli"]>();
+    const registerHook = vi.fn<OpenClawPluginApi["registerHook"]>();
+    class InheritedHandlers {
+      get registerCli() {
+        reads.push("cli");
+        return registerCli;
+      }
+      get registerTool() {
+        reads.push("tool");
+        return undefined;
+      }
+      get registerHook() {
+        reads.push("hook");
+        return registerHook;
+      }
+    }
+    const api = createPluginApi(new InheritedHandlers());
+    const hook: Parameters<OpenClawPluginApi["registerHook"]>[1] = () => {};
+    const registrar: Parameters<OpenClawPluginApi["registerCli"]>[0] = () => {};
+
+    const toolFactory = vi.fn(() => null);
+    expect(api.registerTool(toolFactory)).toBeUndefined();
+    expect(toolFactory).not.toHaveBeenCalled();
+    expect(api.registerHook).toBe(registerHook);
+    expect(api.registerCli).toBe(registerCli);
+    api.registerHook("message_received", hook);
+    expect(registerHook).toHaveBeenCalledExactlyOnceWith("message_received", hook);
+    api.registerNodeCliFeature(registrar, { commands: ["camera"] });
+    expect(registerCli).toHaveBeenCalledExactlyOnceWith(registrar, {
+      commands: ["camera"],
+      parentPath: ["nodes"],
+    });
+    expect(reads).toEqual(["cli", "tool", "hook"]);
+  });
+
   it("keeps both next-turn injection APIs callable after registration", async () => {
     const enqueueNextTurnInjection = vi.fn(async (injection) => ({
       enqueued: true,


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of the plugin API builder. Its inert defaults and permitted handler overrides repeated the same 66-method inventory, making changes to the registration surface unnecessarily repetitive.

## Why This Change Was Made

Keep one private, typed defaults object and derive the override-key type from it. Remove the separate default-function declarations and handwritten key union. API construction still uses explicit nullish lookups: a generic spread or assignment loop would change inherited-handler handling and observable getter order. The CLI callback is still captured once and shared by both registration entrypoints.

The public API, nested facades, registration lifetimes, unavailable-runtime guard, and individual inert return values are unchanged. Defaults remain stable function objects; object-valued results remain fresh per call. Inferred function debug names change with the source organization; no function-name or source-reflection compatibility claim is made.

## User Impact

No intended user-visible behavior change. Plugins receive the same registration and unwired-operation behavior through the existing API. This adds no configuration, fallback, dependency, storage change, or public API.

## Evidence

The fresh baseline and candidate each passed the same 133 cases, in the same within-suite order, across API lifecycle, captured registration, setup registry and lifecycle, CLI metadata loading, and the Bedrock plugin. The added cases retain meaningful inert-operation outcomes, inherited handlers, undefined defaults, lookup order, and the single captured CLI registration callback. Existing lifecycle cases remain intact.

The complete changed-file gate passed all 29 checks on the candidate. An earlier gate failed with TS2305 on the stale getPluginToolSideEffectOwnerKey import on its original base; that failure is retained. The candidate was then moved onto the already-landed canonical correction in #133155, with its two-file patch unchanged, and the paired tests and full gate were rerun successfully.

The normal full build passed all 14 stages, including SDK declarations, all 148 public SDK export checks, CLI bootstrap/startup metadata, and the Control UI build. Source/index/configuration checks passed afterward; installed dependencies stayed unchanged, and generated outputs were checked against their build owners. Dependency eval and browser-externalization warnings remain recorded; none were suppressed.

The normal isolated pre-commit review completed one P0-scoped pass with no findings. A separate full source, dependency, generated-output, index, configuration, and runtime audit matched the reviewed state afterward. The signed two-file commit is recorded and its complete source and index match the reviewed candidate. The separate exact-commit review also completed one P0-scoped pass with no findings, and its full after-audit matched the signed source. Exact-head [CI run 33309943867](https://github.com/openclaw/openclaw/actions/runs/33309943867) completed successfully for `0a68286c882d37e1a21816a910f98c5dabb76823`. The canonical PR watcher completed with no pending checks and superseded checks accounted for; this does not mean every historical check row passed. No authenticated-provider or real-channel proof is claimed.

The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/133277#issuecomment-5468540862) reported no actionable correctness or security findings and requested normal maintainer handling before merge. Static composition against fetched main `46c1eef6e6d4118dba29cf11285601e8b5e35a5b` preserves both original preimages and yields exactly that parent plus the two reviewed afterimages. All six direct builder importers are unchanged; the only review-context changes are the already-landed CLI fixture cleanup. This is source composition, not execution of the composed tree. The later fetch to `c0cafd728947c55085dcd34742dd05d5adeab994` changed only session-write code and its test; all 29 retained review contexts, nine mapped API callers, and the native launcher closure stayed unchanged. Native review artifact validation completed successfully. Normal mandatory hosted prepare passed on the exact reviewed head without a rebase or push. The normal native merge then landed [4b64c84f](https://github.com/openclaw/openclaw/commit/4b64c84ff03b11f11bf2127c9ebba10789f3aee7).

Postmerge verification compared all 35,506 landed leaf entries and modes against the actual parent plus the two reviewed afterimages. Both preimages and the complete patch bytes match the reviewed change. The clean containing main [0594a100](https://github.com/openclaw/openclaw/commit/0594a100d9710a94cd8c80d72713a3565eefd2ff) includes that merge; source, installed dependencies, generated build outputs and pinned runtimes remained unchanged through the finish. These are source and landing checks, not new live-provider or composed-runtime proof.

Production: +151/-232 (81 fewer lines). Tests: +73/-2 (71 additional lines). Whole change: 10 fewer lines.
