### PR TITLE
fix: write tool skips overwrites after lossy UTF-8 decoding

### DIFF
--- a/src/agents/sessions/tools/write.test.ts
+++ b/src/agents/sessions/tools/write.test.ts
@@ -125,18 +125,24 @@ describe("write tool", () => {
     await expect(fs.stat(filePath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("rejects a delegated write that leaves stale same-size content", async () => {
-    const filePath = await createTempPath("stale.txt");
-    await fs.writeFile(filePath, "stale\n", "utf-8");
-    const tool = createWriteTool(tmpDir, {
-      operations: createRecoverableOperations(async () => {}),
-    });
+  it.each([
+    { name: "text", original: Buffer.from("stale\n"), content: "fresh\n" },
+    { name: "invalid UTF-8", original: Buffer.from([0xf0, 0x90, 0x80]), content: "\uFFFD" },
+  ])(
+    "rejects a delegated write that leaves stale same-size bytes: $name",
+    async ({ original, content }) => {
+      const filePath = await createTempPath("stale.txt");
+      await fs.writeFile(filePath, original);
+      const tool = createWriteTool(tmpDir, {
+        operations: createRecoverableOperations(async () => {}),
+      });
 
-    await expect(
-      tool.execute("call-1", { path: filePath, content: "fresh\n" }, undefined),
-    ).rejects.toThrow("Write verification failed");
-    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("stale\n");
-  });
+      await expect(tool.execute("call-1", { path: filePath, content }, undefined)).rejects.toThrow(
+        "Write verification failed",
+      );
+      await expect(fs.readFile(filePath)).resolves.toEqual(original);
+    },
+  );
 
   it("rejects a delegated write that leaves a non-file target", async () => {
     const filePath = await createTempPath("directory");
@@ -150,19 +156,38 @@ describe("write tool", () => {
     ).rejects.toThrow("Write verification failed");
   });
 
-  it("verifies delegated writes by their persisted UTF-8 bytes", async () => {
-    const filePath = await createTempPath("surrogate.txt");
-    const content = "unpaired \ud800 surrogate\n";
-    const tool = createWriteTool(tmpDir, {
-      operations: createRecoverableOperations((absolutePath, requestedContent) =>
+  it.each(["buffer", "text"] as const)(
+    "verifies delegated UTF-8 bytes with %s readback",
+    async (readback) => {
+      const filePath = await createTempPath("surrogate.txt");
+      const content = "unpaired \ud800 surrogate\n";
+      const operations = createRecoverableOperations((absolutePath, requestedContent) =>
         fs.writeFile(absolutePath, requestedContent, "utf-8"),
-      ),
-    });
+      );
+      if (readback === "text") {
+        operations.readFile = (absolutePath) => fs.readFile(absolutePath, "utf8");
+      }
+      const tool = createWriteTool(tmpDir, { operations });
+
+      await expect(
+        tool.execute("call-1", { path: filePath, content }, undefined),
+      ).resolves.toMatchObject({ details: { changed: true, created: true } });
+      await expect(fs.readFile(filePath)).resolves.toEqual(Buffer.from(content, "utf8"));
+      await expect(
+        tool.execute("call-2", { path: filePath, content }, undefined),
+      ).resolves.toMatchObject({ details: { changed: false }, terminate: true });
+    },
+  );
+
+  it("overwrites invalid UTF-8 bytes that decode to the requested text", async () => {
+    const filePath = await createTempPath("invalid.txt");
+    await fs.writeFile(filePath, Buffer.from([0xf0, 0x90, 0x80]));
+    const tool = createWriteTool(tmpDir);
 
     await expect(
-      tool.execute("call-1", { path: filePath, content }, undefined),
-    ).resolves.toMatchObject({ details: { changed: true, created: true } });
-    await expect(fs.readFile(filePath)).resolves.toEqual(Buffer.from(content, "utf8"));
+      tool.execute("call-1", { path: filePath, content: "\uFFFD" }, undefined),
+    ).resolves.toMatchObject({ details: { changed: true, created: false } });
+    await expect(fs.readFile(filePath)).resolves.toEqual(Buffer.from("\uFFFD", "utf8"));
   });
 
   it("writes file URL paths through the shared session path resolver", async () => {
@@ -190,23 +215,22 @@ describe("write tool", () => {
     await expect(fs.readFile(asciiPath, "utf-8")).resolves.toBe("ascii\n");
   });
 
-  it("returns terminal no-op when writing identical content to existing file", async () => {
-    const filePath = await createTempPath("identical.txt");
-    await fs.writeFile(filePath, "hello\n", "utf-8");
-    const tool = createWriteTool(tmpDir);
+  it.each(["hello\n", "café 🦀\r\n日本語 e\u0301\r\n", "\uFFFD\r\n"])(
+    "returns terminal no-op for identical UTF-8 content: %j",
+    async (content) => {
+      const filePath = await createTempPath("identical.txt");
+      await fs.writeFile(filePath, content, "utf-8");
+      const tool = createWriteTool(tmpDir);
 
-    const result = await tool.execute(
-      "call-1",
-      { path: "identical.txt", content: "hello\n" },
-      undefined,
-    );
+      const result = await tool.execute("call-1", { path: "identical.txt", content }, undefined);
 
-    const tc0 = expectDefined(result.content[0], "result.content[0] test invariant");
-    expect("text" in tc0 ? tc0.text : "").toContain("No changes made");
-    expect((result as { terminate?: boolean }).terminate).toBe(true);
-    expect(result.details).toEqual({ changed: false });
-    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("hello\n");
-  });
+      const tc0 = expectDefined(result.content[0], "result.content[0] test invariant");
+      expect("text" in tc0 ? tc0.text : "").toContain("No changes made");
+      expect((result as { terminate?: boolean }).terminate).toBe(true);
+      expect(result.details).toEqual({ changed: false });
+      await expect(fs.readFile(filePath)).resolves.toEqual(Buffer.from(content, "utf8"));
+    },
+  );
 
   it("reports a created file with its authoritative diff", async () => {
     await createTempPath("created.txt");

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -328,9 +328,6 @@ async function readOriginalWriteState(
   content: string,
   ops: WriteOperations,
 ): Promise<WriteToolPrecheck> {
-  if (!ops.statFile) {
-    return { state: "unknown" };
-  }
   let stat: PersistedFileStat | null;
   try {
     stat = await ops.statFile(absolutePath);
@@ -354,14 +351,16 @@ async function readOriginalWriteState(
 
   try {
     const originalContent = await ops.readFile(absolutePath);
-    const originalText = Buffer.isBuffer(originalContent)
-      ? originalContent.toString("utf8")
-      : originalContent;
+    const originalBytes = Buffer.isBuffer(originalContent)
+      ? originalContent
+      : Buffer.from(originalContent, "utf8");
+    const originalText = originalBytes.toString("utf8");
     if (Buffer.byteLength(originalText, "utf8") > WRITE_PRECHECK_READ_LIMIT_BYTES) {
       return { state: "unknown", beforeStat: stat, readAttempted: true };
     }
     return {
-      state: originalText === content ? "same" : "different",
+      // No-op receipts need the same encoded bytes as post-write verification.
+      state: originalBytes.equals(Buffer.from(content, "utf8")) ? "same" : "different",
       beforeStat: stat,
       beforeText: originalText,
       readAttempted: true,


### PR DESCRIPTION
Closes #133281

## What Problem This Solves

Fixes an issue where an agent asking the `write` tool to overwrite a file could receive “already has identical content” while different original bytes remained on disk. A three-byte truncated UTF-8 sequence and a literal replacement character expose the problem because they decode to the same text and have the same byte length. Repeating a write containing an unpaired surrogate could also incorrectly report a change when its UTF-8 bytes were already present.

## Why This Change Was Made

The write precheck now compares persisted UTF-8 bytes, matching the existing post-write verification contract. Decoded text remains available for bounded display diffs. The obsolete optional-stat branch is removed from that same owner; the operation is required and its invocation is already caught.

Read/diff budgets, per-file ordering, abort recovery, edit matching, filesystem adapters, and path policies are unchanged. No config, schema, dependency, or public option changes. Production: +6/−7, net −1; tests: +63/−39, net +24.

## User Impact

Complete rewrites persist the requested bytes instead of silently returning a false no-op. Already-identical UTF-8 content returns an accurate no-op, including the encoding behavior already supported by the write verifier.

## Evidence

- Real host `write` tool, Node 24.20.0: before the fix, original bytes `F0 90 80` remained after requesting `EF BF BD`, with `changed:false` and `terminate:true`. After the fix, the requested bytes are persisted and the result reports an overwrite.
- The same five temporary-document fixtures pass after the repair, covering Unicode/CRLF creation and repeat, literal U+FFFD identity, the invalid-byte overwrite, already-encoded surrogate content, and same-size Unicode replacement. Both real-tool runs had empty stderr and isolated task state; no credentials or operator files were used.
- Four regression cases fail on the original owner and pass after the repair; all 26 write tests pass, including Buffer and string delegated readbacks and rejection of a writer that leaves stale invalid bytes.
- All 101 owner/sibling tests pass, including edit line-ending behavior, host-write rollback and filesystem result contracts. Fresh exact-commit review across P0–P3 and independent source/behavior review found no actionable findings.
- The complete canonical changed-file gate passed on the exact reviewed bytes, including core/test types, lint, formatting, ratchets, boundaries and import cycles. The repository wrapper fell back to local execution before any remote checks started; no checks were skipped.

Reviewed commit: `6e58241481b2b9cffc447dba9c6aac2d2aadbc74`. Both touched owners remain unchanged on current main compared with the before-proof baseline.

The original precheck condition is also present in stable `v2026.7.1`; exact introduction provenance is not established.
