### PR TITLE
fix: align session tables with Unicode keys and long model names

### DIFF
--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -27,6 +27,11 @@ openclaw sessions --store ./tmp/sessions.json
 openclaw sessions --json
 ```
 
+Human-readable lists and cleanup previews use terminal-width tables. Long model
+names and flags wrap without being truncated, and Unicode keys stay aligned.
+Long keys show their beginning and end; use `openclaw sessions --json` for complete
+session keys.
+
 Flags:
 
 | Flag                 | Description                                                                   |

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -1,5 +1,7 @@
 // Terminal Core tests cover table behavior.
+import { spawnSync } from "node:child_process";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { note as clackNote } from "@clack/prompts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { sanitizeForLog, stripAnsi, visibleWidth } from "./ansi.js";
@@ -83,6 +85,46 @@ describe("renderTable", () => {
       ["+-------+", "| Name  |", "+-------+", "| alpha |", "| beta  |", "+-------+", ""].join("\n"),
     );
     expect(segment).not.toHaveBeenCalled();
+  });
+
+  it.each([0, 3, 150_000])("renders all %i rows without an argument-count limit", (count) => {
+    const out = renderTable({
+      border: "ascii",
+      columns: [{ key: "Key", header: "Key" }],
+      rows: Array.from({ length: count }, () => ({ Key: "session" })),
+    });
+
+    const lines = out.trimEnd().split("\n");
+    expect(lines).toHaveLength(count + 4);
+    expect(lines.filter((line) => line === "| session |")).toHaveLength(count);
+    expect(lines[1]).toMatch(/^\| Key +\|$/u);
+    expect(lines.at(-1)).toBe(lines[0]);
+  });
+
+  it("renders large tables with the CLI process stack rather than the worker stack", () => {
+    // Worker threads have a larger stack than the CLI process; spreading every
+    // row into Math.max can pass in Vitest but crash a normal sessions --limit all.
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        fileURLToPath(new URL("../../../scripts/tsx.mjs", import.meta.url)),
+        "--input-type=module",
+        "-e",
+        `import { renderTable } from ${JSON.stringify(new URL("./table.ts", import.meta.url).href)};
+const output = renderTable({
+  border: "ascii",
+  columns: [{ key: "Key", header: "Key" }],
+  rows: Array.from({ length: 150_000 }, () => ({ Key: "session" })),
+});
+console.log(JSON.stringify({ rows: output.split("\\n").filter(line => line === "| session |").length }));`,
+      ],
+      { encoding: "utf8", timeout: 30_000 },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({ rows: 150_000 });
   });
 
   it("prefers shrinking flex columns to avoid wrapping non-flex labels", () => {

--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -579,7 +579,7 @@ export function renderTable(opts: RenderTableOptions): string {
 
   const metrics = columns.map((c) => {
     const headerW = visibleWidth(c.header);
-    const cellW = Math.max(0, ...rows.map((r) => visibleWidth(r[c.key] ?? "")));
+    const cellW = rows.reduce((max, row) => Math.max(max, visibleWidth(row[c.key] ?? "")), 0);
     return { headerW, cellW };
   });
 

--- a/src/commands/sessions-cleanup.large-labels.test-support.ts
+++ b/src/commands/sessions-cleanup.large-labels.test-support.ts
@@ -1,0 +1,104 @@
+import { mock } from "node:test";
+
+const count = 150_000;
+const storePath = "/mock/agents/main/agent/openclaw-agent.sqlite";
+const unexpected = () => {
+  throw new Error("unexpected non-preview dependency");
+};
+const beforeStore = Object.fromEntries(
+  Array.from({ length: count }, (_, i) => [
+    `agent:main:label-${i}`,
+    { sessionId: `session-${i}`, updatedAt: 1, model: "gpt-5.6-sol", label: `label-${i}` },
+  ]),
+);
+let serviceCalls = 0;
+
+// Keep the actual command, grid, and label-summary owners. Only fixture the
+// service and unrelated metadata boundaries; no large database is needed.
+mock.module(new URL("../config/config.ts", import.meta.url), {
+  namedExports: { getRuntimeConfig: () => ({}) },
+});
+mock.module(new URL("./session-store-targets.ts", import.meta.url), {
+  namedExports: { resolveSessionStoreTargetsOrExit: () => [{ agentId: "main", storePath }] },
+});
+mock.module(new URL("../config/sessions.ts", import.meta.url), {
+  namedExports: {
+    resolveSessionCleanupAction: () => "keep",
+    isSessionsCleanupPartialResult: unexpected,
+    serializeSessionCleanupResult: unexpected,
+    runSessionsCleanup: async () => {
+      serviceCalls += 1;
+      return {
+        mode: "warn",
+        appliedSummaries: [],
+        previewResults: [
+          {
+            summary: {
+              agentId: "main",
+              storePath,
+              mode: "warn",
+              dryRun: true,
+              beforeCount: count,
+              afterCount: count,
+              missing: 0,
+              dmScopeRetired: 0,
+              modelRunPruned: 0,
+              pruned: 0,
+              capped: 0,
+              diskBudget: null,
+              wouldMutate: false,
+            },
+            beforeStore,
+            missingKeys: new Set(),
+            modelRunPrunedKeys: new Set(),
+            archivedKeys: new Set(),
+            staleKeys: new Set(),
+            cappedKeys: new Set(),
+            dmScopeRetiredKeys: new Set(),
+          },
+        ],
+      };
+    },
+  },
+});
+mock.module(new URL("../gateway/call.ts", import.meta.url), {
+  namedExports: { callGateway: unexpected, isGatewayTransportError: () => false },
+});
+mock.module(new URL("../config/sessions/session-sqlite-target.ts", import.meta.url), {
+  namedExports: { resolveSqliteTargetFromSessionStorePath: () => ({ path: storePath }) },
+});
+mock.module(new URL("./sessions-display-model.ts", import.meta.url), {
+  namedExports: {
+    resolveSessionDisplayModel: (_cfg: unknown, row: { model: string }) => row.model,
+  },
+});
+
+const { sessionsCleanupCommand } = await import("./sessions-cleanup.js");
+let gridPrinted = false;
+let summaryPrinted = false;
+let labelRows = 0;
+let total = "";
+await sessionsCleanupCommand(
+  { dryRun: true, store: storePath },
+  {
+    log: (value: unknown) => {
+      const line = String(value);
+      if (line.includes("Action") && line.includes("Flags")) {
+        gridPrinted = true;
+      }
+      if (line === "Summary by Label:") {
+        summaryPrinted = true;
+      }
+      if (/^label-\d+ +1 kept, 0 pruned$/u.test(line)) {
+        labelRows += 1;
+      }
+      if (line.startsWith("Total:")) {
+        total = line;
+      }
+    },
+    error: unexpected,
+    exit: unexpected,
+  },
+);
+console.log(JSON.stringify({ serviceCalls, gridPrinted, summaryPrinted, labelRows, total }));
+mock.restoreAll();

--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -1,4 +1,6 @@
 // Sessions cleanup tests cover stale session cleanup and runtime output.
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import { GatewayTransportError } from "../gateway/transport-error.js";
@@ -560,6 +562,34 @@ describe("sessionsCleanupCommand", () => {
       (line) => line.includes("stale") && line.includes("prune-stale"),
     );
     expect(stalePruneLines.length).toBeGreaterThan(0);
+  });
+
+  it("finishes a large distinct-label preview with the normal CLI process stack", () => {
+    // A worker's larger stack can hide the argument limit in label-width spreads.
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--experimental-test-module-mocks",
+        "--import",
+        fileURLToPath(new URL("../../scripts/tsx.mjs", import.meta.url)),
+        fileURLToPath(new URL("./sessions-cleanup.large-labels.test-support.ts", import.meta.url)),
+      ],
+      {
+        encoding: "utf8",
+        timeout: 30_000,
+        env: { ...process.env, FORCE_COLOR: "0", NO_COLOR: "1" },
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      serviceCalls: 1,
+      gridPrinted: true,
+      summaryPrinted: true,
+      labelRows: 150_000,
+      total: "Total: 150000 kept, 0 pruned",
+    });
   });
 
   it("renders a dry-run summary grouped by session label", async () => {

--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -2,7 +2,7 @@
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { visibleWidth } from "../../packages/terminal-core/src/ansi.js";
+import { stripAnsi, visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import { GatewayTransportError } from "../gateway/transport-error.js";
 import type { RuntimeEnv } from "../runtime.js";
 
@@ -554,14 +554,17 @@ describe("sessionsCleanupCommand", () => {
     expectLogsToInclude(logs, "Session store: /resolved/openclaw-agent.sqlite");
     expectLogsToInclude(logs, "Planned session actions:");
     expectLogsToInclude(logs, "Would prune unreferenced artifacts: 2");
-    const tableHeaderLines = logs.filter((line) => line.includes("Action") && line.includes("Key"));
-    expect(tableHeaderLines.length).toBeGreaterThan(0);
-    const freshKeepLines = logs.filter((line) => line.includes("fresh") && line.includes("keep"));
-    expect(freshKeepLines.length).toBeGreaterThan(0);
-    const stalePruneLines = logs.filter(
-      (line) => line.includes("stale") && line.includes("prune-stale"),
-    );
-    expect(stalePruneLines.length).toBeGreaterThan(0);
+    const actionKeys = logs
+      .flatMap((entry) => stripAnsi(entry).split("\n"))
+      .map((line) =>
+        line
+          .split(/[|│]/u)
+          .slice(1, 3)
+          .map((cell) => cell.trim()),
+      );
+    expect(actionKeys).toContainEqual(["Action", "Key"]);
+    expect(actionKeys).toContainEqual(["keep", "fresh"]);
+    expect(actionKeys).toContainEqual(["prune-stale", "stale"]);
   });
 
   it("finishes a large distinct-label preview with the normal CLI process stack", () => {

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -130,7 +130,10 @@ function renderLabelSummaries(params: {
   if (summaries.length === 0) {
     return;
   }
-  const labelPad = Math.max(...summaries.map((summary) => visibleWidth(summary.label)));
+  const labelPad = summaries.reduce(
+    (max, summary) => Math.max(max, visibleWidth(summary.label)),
+    0,
+  );
   const totalKept = summaries.reduce((total, summary) => total + summary.kept, 0);
   const totalPruned = summaries.reduce((total, summary) => total + summary.pruned, 0);
   params.runtime.log("");

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -7,7 +7,8 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
-import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
+import { getTerminalTableWidth, renderTable } from "../../packages/terminal-core/src/table.js";
+import { colorize, isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { getRuntimeConfig } from "../config/config.js";
 import {
   resolveSessionCleanupAction,
@@ -30,13 +31,8 @@ import {
   formatSessionFlagsCell,
   formatSessionKeyCell,
   formatSessionModelCell,
-  SESSION_AGE_PAD,
-  SESSION_KEY_PAD,
-  SESSION_MODEL_PAD,
   toSessionDisplayRows,
 } from "./sessions-table.js";
-
-const ACTION_PAD = "archive-dashboard".length;
 
 type SessionCleanupActionRow = ReturnType<typeof toSessionDisplayRows>[number] & {
   action: ReturnType<typeof resolveSessionCleanupAction>;
@@ -53,32 +49,31 @@ function formatCleanupActionCell(
   action: ReturnType<typeof resolveSessionCleanupAction>,
   rich: boolean,
 ): string {
-  const label = action.padEnd(ACTION_PAD);
   if (!rich) {
-    return label;
+    return action;
   }
   if (action === "keep") {
-    return theme.muted(label);
+    return theme.muted(action);
   }
   if (action === "archive-dashboard") {
-    return theme.warn(label);
+    return theme.warn(action);
   }
   if (action === "prune-missing") {
-    return theme.error(label);
+    return theme.error(action);
   }
   if (action === "prune-model-run") {
-    return theme.warn(label);
+    return theme.warn(action);
   }
   if (action === "prune-stale") {
-    return theme.warn(label);
+    return theme.warn(action);
   }
   if (action === "retire-dm-scope") {
-    return theme.warn(label);
+    return theme.warn(action);
   }
   if (action === "cap-overflow") {
-    return theme.accentBright(label);
+    return theme.accentBright(action);
   }
-  return theme.error(label);
+  return theme.error(action);
 }
 
 function buildActionRows(params: {
@@ -195,25 +190,27 @@ function renderStoreDryRunPlan(params: {
   }
   params.runtime.log("");
   params.runtime.log("Planned session actions:");
-  const header = [
-    "Action".padEnd(ACTION_PAD),
-    "Key".padEnd(SESSION_KEY_PAD),
-    "Age".padEnd(SESSION_AGE_PAD),
-    "Model".padEnd(SESSION_MODEL_PAD),
-    "Flags",
-  ].join(" ");
-  params.runtime.log(rich ? theme.heading(header) : header);
-  for (const actionRow of params.actionRows) {
-    const model = resolveSessionDisplayModel(params.cfg, actionRow);
-    const line = [
-      formatCleanupActionCell(actionRow.action, rich),
-      formatSessionKeyCell(actionRow.key, rich),
-      formatSessionAgeCell(actionRow.updatedAt, rich),
-      formatSessionModelCell(model, rich),
-      formatSessionFlagsCell(actionRow, rich),
-    ].join(" ");
-    params.runtime.log(line.trimEnd());
-  }
+  params.runtime.log(
+    renderTable({
+      width: getTerminalTableWidth(),
+      columns: [
+        { key: "action", header: "Action" },
+        { key: "key", header: "Key" },
+        { key: "age", header: "Age" },
+        { key: "model", header: "Model" },
+        { key: "flags", header: "Flags", flex: true },
+      ].map((column) =>
+        Object.assign(column, { header: colorize(rich, theme.heading, column.header) }),
+      ),
+      rows: params.actionRows.map((row) => ({
+        action: formatCleanupActionCell(row.action, rich),
+        key: formatSessionKeyCell(row.key, rich),
+        age: formatSessionAgeCell(row.updatedAt, rich),
+        model: formatSessionModelCell(resolveSessionDisplayModel(params.cfg, row), rich),
+        flags: formatSessionFlagsCell(row, rich),
+      })),
+    }).trimEnd(),
+  );
   renderLabelSummaries({ actionRows: params.actionRows, runtime: params.runtime });
 }
 

--- a/src/commands/sessions-table.test.ts
+++ b/src/commands/sessions-table.test.ts
@@ -1,14 +1,16 @@
-// Sessions table tests cover shared fixed-width cell formatting.
+// Sessions table tests cover shared display-label formatting.
 import { describe, expect, it } from "vitest";
-import { formatSessionKeyCell, SESSION_KEY_PAD } from "./sessions-table.js";
+import { formatSessionKeyCell } from "./sessions-table.js";
 
 describe("formatSessionKeyCell", () => {
-  it("keeps both truncation boundaries UTF-16 safe", () => {
-    const key = `${"a".repeat(15)}😀middle😀${"z".repeat(5)}`;
+  it.each(["😀", "👩‍💻", "e\u0301"])(
+    "keeps complete %s clusters at both summary boundaries",
+    (cluster) => {
+      const key = `${"a".repeat(15)}${cluster}middle${cluster}${"z".repeat(5)}`;
 
-    const rendered = formatSessionKeyCell(key, false);
+      const rendered = formatSessionKeyCell(key, false);
 
-    expect(rendered).toBe(`${"a".repeat(15)}...${"z".repeat(5)}`.padEnd(SESSION_KEY_PAD));
-    expect(rendered).toHaveLength(SESSION_KEY_PAD);
-  });
+      expect(rendered).toBe(`${"a".repeat(15)}${cluster}...${cluster}${"z".repeat(5)}`);
+    },
+  );
 });

--- a/src/commands/sessions-table.ts
+++ b/src/commands/sessions-table.ts
@@ -1,10 +1,9 @@
 /**
  * Shared table formatting helpers for session commands.
  *
- * Cleanup and listing commands use the same row shape and fixed-width cells so
- * terminal output stays aligned across commands.
+ * Cleanup and listing share display labels; terminal-core owns column layout.
  */
-import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { splitGraphemes } from "../../packages/terminal-core/src/ansi.js";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import type { SessionEntry } from "../config/sessions.js";
@@ -58,10 +57,6 @@ export type SessionDisplayRow = {
   contextTokens?: number;
   runtimePolicySessionKey?: string;
 };
-
-export const SESSION_KEY_PAD = 26;
-export const SESSION_AGE_PAD = 9;
-export const SESSION_MODEL_PAD = 14;
 
 /** Converts a persisted session entry into the shared display row shape. */
 export function toSessionDisplayRow(key: string, entry: SessionEntry): SessionDisplayRow {
@@ -119,31 +114,30 @@ export function toSessionDisplayRows(store: Record<string, SessionEntry>): Sessi
 }
 
 function truncateSessionKey(key: string): string {
-  if (key.length <= SESSION_KEY_PAD) {
+  const graphemes = splitGraphemes(key);
+  if (graphemes.length <= 26) {
     return key;
   }
   // Keep both the stable prefix and suffix; the tail often contains direct
   // recipient or runtime identifiers that distinguish otherwise similar keys.
-  const head = Math.max(4, SESSION_KEY_PAD - 10);
-  return `${truncateUtf16Safe(key, head)}...${sliceUtf16Safe(key, -6)}`;
+  return `${graphemes.slice(0, 16).join("")}...${graphemes.slice(-6).join("")}`;
 }
 
 /** Formats a session key cell for table output. */
 export function formatSessionKeyCell(key: string, rich: boolean): string {
-  const label = truncateSessionKey(sanitizeTerminalText(key)).padEnd(SESSION_KEY_PAD);
+  const label = truncateSessionKey(sanitizeTerminalText(key));
   return rich ? theme.accent(label) : label;
 }
 
 /** Formats a relative session age cell for table output. */
 export function formatSessionAgeCell(updatedAt: number | null | undefined, rich: boolean): string {
   const ageLabel = updatedAt ? formatTimeAgo(Date.now() - updatedAt) : "unknown";
-  const padded = ageLabel.padEnd(SESSION_AGE_PAD);
-  return rich ? theme.muted(padded) : padded;
+  return rich ? theme.muted(ageLabel) : ageLabel;
 }
 
 /** Formats a model cell for table output. */
 export function formatSessionModelCell(model: string | null | undefined, rich: boolean): string {
-  const label = sanitizeTerminalText(model ?? "unknown").padEnd(SESSION_MODEL_PAD);
+  const label = sanitizeTerminalText(model ?? "unknown");
   return rich ? theme.info(label) : label;
 }
 

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -1,5 +1,6 @@
 // Sessions command tests cover listing, details, filtering, and transcript display behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stripAnsi, visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import { ExpectedCliError } from "../cli/failure-output.js";
 import {
   assignSessionOwner,
@@ -20,7 +21,23 @@ import {
 
 mockSessionsConfig();
 
+import { sessionsCleanupCommand } from "./sessions-cleanup.js";
 import { sessionsCommand } from "./sessions.js";
+
+function singleSessionTableCells(logs: string[]): string[] {
+  const lines = stripAnsi(logs.join("\n"))
+    .split("\n")
+    .filter((line) => /^[│|]/u.test(line))
+    .map((line) =>
+      line
+        .split(/[│|]/u)
+        .slice(1, -1)
+        .map((cell) => cell.trim()),
+    );
+  const [header = [], ...rows] = lines;
+  expect(rows.length).toBeGreaterThan(0);
+  return header.map((_, index) => rows.map((row) => row[index]).join(""));
+}
 
 describe("sessionsCommand", () => {
   beforeEach(() => {
@@ -55,10 +72,66 @@ describe("sessionsCommand", () => {
 
     expect(logs.join("\n")).toContain("Tokens (ctx %");
 
-    const row = logs.find((line) => line.includes("agent:main:+15555550123")) ?? "";
-    expect(row).toBe(
-      "direct      agent:main:+15555550123    45m ago   test:opus      OpenAI Codex       2.0k/200k (1%)       visibility:shared id:abc123",
+    expect(singleSessionTableCells(logs)).toEqual([
+      "direct",
+      "agent:main:+15555550123",
+      "45m ago",
+      "test:opus",
+      "OpenAI Codex",
+      "2.0k/200k (1%)",
+      "visibility:shared id:abc123",
+    ]);
+  });
+
+  it.each([
+    { name: "listing", run: sessionsCommand, options: {} },
+    { name: "cleanup dry-run", run: sessionsCleanupCommand, options: { dryRun: true } },
+  ])("aligns $name columns for Unicode keys and full model names", async ({ run, options }) => {
+    const entries = [
+      { key: "agent:main:main", model: "gpt-5.6-sol" },
+      { key: "agent:main:東京", model: "gemini-3-flash-preview" },
+      { key: "agent:main:e\u0301", model: "gpt-5.6-sol" },
+      { key: "agent:main:👩‍💻", model: "claude-sonnet-4-6" },
+    ];
+    const store = await writeStore(
+      Object.fromEntries(
+        entries.map(({ key, model }, index) => [
+          key,
+          { sessionId: `row-${index}`, updatedAt: Date.now(), model, systemSent: true },
+        ]),
+      ),
     );
+    const columns = Object.getOwnPropertyDescriptor(process.stdout, "columns");
+    Object.defineProperty(process.stdout, "columns", { configurable: true, value: 240 });
+    try {
+      const { runtime, logs } = makeRuntime();
+      await run({ store, ...options }, runtime);
+      const lines = stripAnsi(logs.join("\n")).split("\n");
+      const header = lines.find((line) => line.includes("Key") && line.includes("Model")) ?? "";
+      expect(header).toContain("Flags");
+      for (const { key, model } of entries) {
+        const row = lines.find((line) => line.includes(key)) ?? "";
+        expect(row).toContain(key);
+        expect(row).toContain(model);
+        expect(row).toContain("system");
+        for (const [title, value] of [
+          ["Key", key],
+          ["Model", model],
+          ["Flags", "system"],
+        ] as const) {
+          expect(visibleWidth(row.slice(0, row.indexOf(value)))).toBe(
+            visibleWidth(header.slice(0, header.indexOf(title))),
+          );
+        }
+      }
+    } finally {
+      cleanupStore(store);
+      if (columns) {
+        Object.defineProperty(process.stdout, "columns", columns);
+      } else {
+        Reflect.deleteProperty(process.stdout, "columns");
+      }
+    }
   });
 
   it("shows recorded totals without a percentage when freshness provenance is missing", async () => {
@@ -113,10 +186,15 @@ describe("sessionsCommand", () => {
 
     expect(logs.join("\n")).toContain("Runtime");
 
-    const row = logs.find((line) => line.includes("agent:main:main")) ?? "";
-    expect(row).toBe(
-      "direct      agent:main:main            1m ago    claude-opus-4-7 Claude CLI         unknown/200k (?%)    visibility:shared id:main-session",
-    );
+    expect(singleSessionTableCells(logs)).toEqual([
+      "direct",
+      "agent:main:main",
+      "1m ago",
+      "claude-opus-4-7",
+      "Claude CLI",
+      "unknown/200k (?%)",
+      "visibility:shared id:main-session",
+    ]);
   });
 
   it("renders configured CLI runtime when the session stores a canonical provider", async () => {
@@ -147,10 +225,15 @@ describe("sessionsCommand", () => {
 
     cleanupStore(store);
 
-    const row = logs.find((line) => line.includes("agent:main:main")) ?? "";
-    expect(row).toBe(
-      "direct      agent:main:main            1m ago    claude-opus-4-7 Claude CLI         unknown/200k (?%)    visibility:shared id:main-session",
-    );
+    expect(singleSessionTableCells(logs)).toEqual([
+      "direct",
+      "agent:main:main",
+      "1m ago",
+      "claude-opus-4-7",
+      "Claude CLI",
+      "unknown/200k (?%)",
+      "visibility:shared id:main-session",
+    ]);
   });
 
   it("renders recorded runtime with current context after a same-model runtime change", async () => {
@@ -338,9 +421,9 @@ describe("sessionsCommand", () => {
 
     const { runtime, logs } = makeRuntime();
     await sessionsCommand({ store }, runtime);
-    const row = logs.find((line) => line.includes(sessionKey)) ?? "";
-    expect(row).toContain(
-      "visibility:suggest owner:profile-owner participants:profile:profile-ada,profile:profile-ben,profile:profile-cam,profile:profile-dee,+1",
+    // Flags may wrap between words or within a long participant identifier.
+    expect(singleSessionTableCells(logs).at(-1)?.replace(/\s/gu, "")).toBe(
+      "visibility:suggestowner:profile-ownerparticipants:profile:profile-ada,profile:profile-ben,profile:profile-cam,profile:profile-dee,+1id:shared-session",
     );
 
     const payload = await runSessionsJson<{

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -3,13 +3,15 @@ import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-
  * Session listing command.
  *
  * It loads one or more agent session stores, enriches rows with model/runtime
- * metadata, and emits JSON or fixed-width terminal tables.
+ * metadata, and emits JSON or terminal tables.
  */
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
+import { getTerminalTableWidth, renderTable } from "../../packages/terminal-core/src/table.js";
+import { colorize, isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { readAcpSessionMetaBatch } from "../acp/runtime/session-meta.js";
 import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import { resolveAuthoredModelContextTokens } from "../agents/context-resolution.js";
@@ -50,9 +52,6 @@ import {
   formatSessionFlagsCell,
   formatSessionKeyCell,
   formatSessionModelCell,
-  SESSION_AGE_PAD,
-  SESSION_KEY_PAD,
-  SESSION_MODEL_PAD,
   type SessionDisplayRow,
   toSessionDisplayRow,
 } from "./sessions-table.js";
@@ -73,10 +72,6 @@ type SessionRow = SessionDisplayRow & {
   acpRuntime: boolean;
 };
 
-const AGENT_PAD = 10;
-const KIND_PAD = 11; // "spawn-child".length — longest kind label
-const RUNTIME_PAD = 18;
-const TOKENS_PAD = 20;
 const DEFAULT_SESSIONS_LIMIT = 100;
 const TOP_N_SELECTION_LIMIT = 200;
 const contextLookupRuntimeLoader = createLazyImportLoader(() => import("../agents/context.js"));
@@ -170,32 +165,30 @@ const formatTokensCell = (
   const ctxLabel = contextTokens ? formatKTokens(contextTokens) : "?";
   if (total === undefined) {
     const label = `unknown/${ctxLabel} (?%)`;
-    return rich ? theme.muted(label.padEnd(TOKENS_PAD)) : label.padEnd(TOKENS_PAD);
+    return rich ? theme.muted(label) : label;
   }
   const pct =
     contextTokens && freshTotal !== undefined
       ? Math.min(999, Math.round((freshTotal / contextTokens) * 100))
       : null;
   const label = `${formatKTokens(total)}/${ctxLabel} (${pct ?? "?"}%)`;
-  const padded = label.padEnd(TOKENS_PAD);
-  return colorByPct(padded, pct, rich);
+  return colorByPct(label, pct, rich);
 };
 
 const formatKindCell = (kind: SessionRow["kind"], rich: boolean) => {
-  const label = kind.padEnd(KIND_PAD);
   if (!rich) {
-    return label;
+    return kind;
   }
   if (kind === "group") {
-    return theme.accentBright(label);
+    return theme.accentBright(kind);
   }
   if (kind === "global") {
-    return theme.warn(label);
+    return theme.warn(kind);
   }
   if (kind === "direct") {
-    return theme.accent(label);
+    return theme.accent(kind);
   }
-  return theme.muted(label);
+  return theme.muted(kind);
 };
 
 function resolveSessionRuntimeLabel(params: {
@@ -214,11 +207,6 @@ function resolveSessionRuntimeLabel(params: {
     fallbackProvider: params.modelProvider,
     classifyCliProvider: params.classifyCliProvider,
   });
-}
-
-function formatRuntimeCell(runtimeLabel: string, rich: boolean): string {
-  const label = runtimeLabel.padEnd(RUNTIME_PAD);
-  return rich ? theme.info(label) : label;
 }
 
 function resolveSessionStoreDisplayPath(target: { agentId: string; storePath: string }): string {
@@ -510,38 +498,36 @@ export async function sessionsCommand(
 
   const rich = isRich();
   const showAgentColumn = aggregateAgents || targets.length > 1;
-  const header = [
-    ...(showAgentColumn ? ["Agent".padEnd(AGENT_PAD)] : []),
-    "Kind".padEnd(KIND_PAD),
-    "Key".padEnd(SESSION_KEY_PAD),
-    "Age".padEnd(SESSION_AGE_PAD),
-    "Model".padEnd(SESSION_MODEL_PAD),
-    "Runtime".padEnd(RUNTIME_PAD),
-    "Tokens (ctx %)".padEnd(TOKENS_PAD),
-    "Flags",
-  ].join(" ");
-
-  runtime.log(rich ? theme.heading(header) : header);
-
-  for (const row of rows) {
-    const model = row.displayModelRef.model;
-    const contextTokens = row.contextTokens ?? configContextTokens;
-    const total = resolveSessionTotalTokens(row);
-    const freshTotal = resolveFreshSessionTotalTokens(row);
-
-    const line = [
-      ...(showAgentColumn
-        ? [rich ? theme.accentBright(row.agentId.padEnd(AGENT_PAD)) : row.agentId.padEnd(AGENT_PAD)]
-        : []),
-      formatKindCell(row.kind, rich),
-      formatSessionKeyCell(row.key, rich),
-      formatSessionAgeCell(row.updatedAt, rich),
-      formatSessionModelCell(model, rich),
-      formatRuntimeCell(row.runtimeLabel, rich),
-      formatTokensCell(total, freshTotal, contextTokens ?? null, rich),
-      formatSessionFlagsCell(row, rich),
-    ].join(" ");
-
-    runtime.log(line.trimEnd());
-  }
+  runtime.log(
+    renderTable({
+      width: getTerminalTableWidth(),
+      columns: [
+        ...(showAgentColumn ? [{ key: "agent", header: "Agent" }] : []),
+        { key: "kind", header: "Kind" },
+        { key: "key", header: "Key" },
+        { key: "age", header: "Age" },
+        { key: "model", header: "Model" },
+        { key: "runtime", header: "Runtime" },
+        { key: "tokens", header: "Tokens (ctx %)" },
+        { key: "flags", header: "Flags", flex: true },
+      ].map((column) =>
+        Object.assign(column, { header: colorize(rich, theme.heading, column.header) }),
+      ),
+      rows: rows.map((row) => ({
+        agent: colorize(rich, theme.accentBright, sanitizeTerminalText(row.agentId)),
+        kind: formatKindCell(row.kind, rich),
+        key: formatSessionKeyCell(row.key, rich),
+        age: formatSessionAgeCell(row.updatedAt, rich),
+        model: formatSessionModelCell(row.displayModelRef.model, rich),
+        runtime: colorize(rich, theme.info, sanitizeTerminalText(row.runtimeLabel)),
+        tokens: formatTokensCell(
+          resolveSessionTotalTokens(row),
+          resolveFreshSessionTotalTokens(row),
+          row.contextTokens ?? configContextTokens,
+          rich,
+        ),
+        flags: formatSessionFlagsCell(row, rich),
+      })),
+    }).trimEnd(),
+  );
 }


### PR DESCRIPTION
Related: #8700

## What Problem This Solves

Fixes an issue where `openclaw sessions` and `openclaw sessions cleanup --dry-run` show misaligned columns with ordinary long model names or Unicode session keys. For example, `gemini-3-flash-preview` shifts the following columns eight terminal cells; CJK, combining accents, and emoji shift them by different amounts.

## Why This Change Was Made

Both commands now supply unpadded display labels to the existing terminal table renderer, which owns column widths, wrapping, and ANSI handling. This removes the duplicated fixed-width header/row layout. Long model names, runtime labels, agent names, and flags remain visible; long session keys still retain their beginning and end, now at complete grapheme boundaries.

The renderer and cleanup label-summary maximum-width calculations also use reductions instead of spreading every row into one function call. A normal Node process otherwise throws `RangeError` with 150,000 valid rows, which would become a new failure for the documented `--limit all` path after this migration. The same preexisting spread in cleanup summaries also failed after the repaired grid when 150,000 sessions had distinct labels; both width owners now complete. No row cap, stack override, retry, or new option is introduced.

Model selection, runtime provenance, JSON serialization, cleanup decisions, session storage, and label grouping/counting are unchanged. The human output adopts the standard bordered table used elsewhere in the CLI. The closed, unmerged #8700 reported the original long-model symptom; this replacement credits @gildo and uses the current shared renderer rather than its older local padding implementation.

## User Impact

Session columns align by terminal display width, including colored output. Narrow terminals wrap full model names and flags instead of truncating or misplacing them. Wider terminals keep rows compact. JSON remains the machine-readable surface and retains complete session keys.

## Evidence

Actual command-owner proof used isolated temporary SQLite stores seeded through the existing session API, then invoked `sessionsCommand` and `sessionsCleanupCommand` directly. It did not use a copied formatter, operator state, a provider, or a packaged CLI binary.

Before the fix, listing Model starts at display column 49 for ASCII keys, 51 for CJK, 48 for a combining accent, and 46 for a ZWJ emoji. An ordinary long Gemini model shifts Flags from column 104 to 112. Cleanup previews reproduce the same defect.

After the fix, eight human command calls cover 80- and 240-column terminals in plain and rich modes for both listing and cleanup, including a long agent name and persisted runtime label. Every physical table line fits the requested width; model names, session IDs, agent names, and runtime labels survive wrapping. Two JSON calls preserve the full keys/models/owners, and all six stored entries remain exactly unchanged after dry-run. An 80-column aggregate table is taller because it preserves every field.

Regression-first checks: both command alignment cases, all three grapheme-summary cases, and the ordinary-process 150,000-row case fail before the owner repair and pass afterward. The large-row test launches the actual renderer in a normal Node child: Vitest's worker stack can hide the original argument-limit failure.

134 unique focused tests pass across the sessions listing, cleanup, label helpers, default-agent selection, model resolution, ACP display, plugin metadata, and terminal table suites. The final affected command file passed 27/27 after its old fixed-padding assertions were changed to verify complete cells across wrapped lines; the total is cumulative across runs, with subsequent changes covered by the summary regression and final row assertions.

Production: +88/-108, net **-20**. Tests: +294/-30, net +264. Docs: +5. No dependency, configuration, schema, protocol, or persistence changes.

Independent review caught the connected cleanup label-summary spread before publication. An actual command probe with mocked service/metadata boundaries printed the full grid, then threw in the summary on the original code. Its ordinary-Node child regression failed before the reduction; afterward, it and the existing grouped/Unicode label controls pass, and the unchanged standalone probe prints all 150,000 label rows and the exact total. An earlier 60-second setup probe was inconclusive and is not counted as defect evidence.

The original required gate exposed a Node typing error in test cleanup and two header-map lint findings; both were corrected and the canonical failed stages plus remaining guards passed. The expanded ten-path gate passed. Review also caught an old assertion that searched an entire grid log; it now checks exact action/key cell pairs, with the targeted case and final format/type/lint checks passing. Fresh full-diff review is clean at P0–P2. The independent reviewer resolved its finding and bound its no-findings verdict to commit `8d96755f2c9611571e89c435898f81162a825936`; a separate peer also verified the exact commit. Hosted CI and the native prepare/merge gates remain required before landing.

Provenance: exact introducing commit is unknown; available history includes a shallow boundary and does not establish introduction. Current-main reproduction and the earlier report in #8700 independently establish the defect.

Named follow-ups, not included or claimed fixed here: streaming `sessions tail` column padding and short-reference ambiguity-label formatting use separate owners and need their own operator-path proof.
