### PR TITLE
perf(agents): reuse prepared prompt context and bootstrap statistics

### DIFF
--- a/src/agents/bootstrap-budget.test.ts
+++ b/src/agents/bootstrap-budget.test.ts
@@ -33,11 +33,13 @@ describe("buildBootstrapBudgetState", () => {
       config: {
         agents: { defaults: { bootstrapMaxChars: 10, bootstrapTotalMaxChars: 12 } },
       },
-      bootstrapFiles,
-      injectedFiles: [
-        { path: "/tmp/AGENTS.md", content: "a".repeat(8) },
-        { path: "/tmp/SOUL.md", content: "b".repeat(4) },
-      ],
+      files: buildBootstrapInjectionStats({
+        bootstrapFiles,
+        injectedFiles: [
+          { path: "/tmp/AGENTS.md", content: "a".repeat(8) },
+          { path: "/tmp/SOUL.md", content: "b".repeat(4) },
+        ],
+      }),
     });
 
     expect(state.bootstrapMaxChars).toBe(10);

--- a/src/agents/bootstrap-budget.ts
+++ b/src/agents/bootstrap-budget.ts
@@ -187,18 +187,14 @@ export function analyzeBootstrapBudget(params: {
 export function buildBootstrapBudgetState(params: {
   config?: OpenClawConfig;
   agentId?: string | null;
-  bootstrapFiles: WorkspaceBootstrapFile[];
-  injectedFiles: EmbeddedContextFile[];
+  files: BootstrapInjectionStat[];
   previousSignature?: string;
   seenSignatures?: string[];
 }) {
   const bootstrapMaxChars = resolveBootstrapMaxChars(params.config, params.agentId);
   const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.config, params.agentId);
   const bootstrapAnalysis = analyzeBootstrapBudget({
-    files: buildBootstrapInjectionStats({
-      bootstrapFiles: params.bootstrapFiles,
-      injectedFiles: params.injectedFiles,
-    }),
+    files: params.files,
     bootstrapMaxChars,
     bootstrapTotalMaxChars,
   });

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -69,6 +69,7 @@ import {
 import type { AuthProfileCredential, AuthProfileStore } from "../auth-profiles/types.js";
 import {
   buildBootstrapBudgetState,
+  buildBootstrapInjectionStats,
   buildBootstrapPromptWarningNotice,
   buildBootstrapTruncationReportMeta,
 } from "../bootstrap-budget.js";
@@ -942,6 +943,10 @@ export async function prepareCliRunContext(
   const bootstrapFilesForInjectionStats = includeBootstrapInSystemContext
     ? bootstrapFiles
     : bootstrapFiles.filter((file) => file.name !== DEFAULT_BOOTSTRAP_FILENAME);
+  const bootstrapInjectionStats = buildBootstrapInjectionStats({
+    bootstrapFiles: bootstrapFilesForInjectionStats,
+    injectedFiles: contextFiles,
+  });
   const {
     bootstrapAnalysis,
     bootstrapMaxChars,
@@ -951,8 +956,7 @@ export async function prepareCliRunContext(
   } = buildBootstrapBudgetState({
     config: params.config,
     agentId: sessionAgentId,
-    bootstrapFiles: bootstrapFilesForInjectionStats,
-    injectedFiles: contextFiles,
+    files: bootstrapInjectionStats,
     seenSignatures: params.bootstrapPromptWarningSignaturesSeen,
     previousSignature: params.bootstrapPromptWarningSignature,
   });
@@ -1774,8 +1778,7 @@ export async function prepareCliRunContext(
       }),
       sandbox: { mode: "off", sandboxed: false },
       systemPrompt,
-      bootstrapFiles: bootstrapFilesForInjectionStats,
-      injectedFiles: contextFiles,
+      injectedWorkspaceFiles: bootstrapInjectionStats,
       skillsPrompt: systemPromptSkillsPrompt,
       tools: promptTools,
       currentTurn: {

--- a/src/agents/embedded-agent-runner/run/attempt-bootstrap-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bootstrap-prepare.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { isEmbeddedMode } from "../../../infra/embedded-mode.js";
-import { buildBootstrapBudgetState } from "../../bootstrap-budget.js";
+import { buildBootstrapBudgetState, buildBootstrapInjectionStats } from "../../bootstrap-budget.js";
 import {
   buildBootstrapContextForFiles,
   hasCompletedBootstrapTurn,
@@ -149,14 +149,20 @@ export async function prepareEmbeddedAttemptBootstrap(params: {
   const contextFiles = bootstrapRouting.includeBootstrapInSystemContext
     ? remappedContextFiles
     : remappedContextFiles.filter((file) => !/(^|[\\/])BOOTSTRAP\.md$/iu.test(file.path.trim()));
-  const bootstrapFilesForInjectionStats = bootstrapRouting.includeBootstrapInSystemContext
-    ? hookAdjustedBootstrapFiles
-    : hookAdjustedBootstrapFiles.filter((file) => file.name !== DEFAULT_BOOTSTRAP_FILENAME);
+  const bootstrapInjectionStats = buildBootstrapInjectionStats({
+    bootstrapFiles: hookAdjustedBootstrapFiles,
+    injectedFiles: contextFiles,
+  });
+  // Stats retain input order. Reports include suppressed BOOTSTRAP rows; budgets do not.
+  const bootstrapBudgetFiles = bootstrapRouting.includeBootstrapInSystemContext
+    ? bootstrapInjectionStats
+    : bootstrapInjectionStats.filter(
+        (_, index) => hookAdjustedBootstrapFiles[index]!.name !== DEFAULT_BOOTSTRAP_FILENAME,
+      );
   const bootstrapBudget = buildBootstrapBudgetState({
     config: attempt.config,
     agentId: params.sessionAgentId,
-    bootstrapFiles: bootstrapFilesForInjectionStats,
-    injectedFiles: contextFiles,
+    files: bootstrapBudgetFiles,
     seenSignatures: attempt.bootstrapPromptWarningSignaturesSeen,
     previousSignature: attempt.bootstrapPromptWarningSignature,
   });
@@ -178,7 +184,7 @@ export async function prepareEmbeddedAttemptBootstrap(params: {
     ...bootstrapBudget,
     bootstrapMode,
     contextFiles,
-    hookAdjustedBootstrapFiles,
+    bootstrapInjectionStats,
     shouldRecordCompletedBootstrapTurn,
     workspaceNotes,
   };

--- a/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
@@ -311,8 +311,7 @@ export async function prepareEmbeddedAttemptSystemPrompt(params: {
       return { mode: runtime.mode, sandboxed: runtime.sandboxed };
     })(),
     systemPrompt: attemptSystemPrompt.systemPrompt,
-    bootstrapFiles: params.bootstrap.hookAdjustedBootstrapFiles,
-    injectedFiles: params.bootstrap.contextFiles,
+    injectedWorkspaceFiles: params.bootstrap.bootstrapInjectionStats,
     skillsPrompt: params.skillsPrompt,
     tools: params.effectiveTools,
   });

--- a/src/agents/system-prompt-report.test.ts
+++ b/src/agents/system-prompt-report.test.ts
@@ -1,6 +1,7 @@
 // System prompt report tests cover prompt accounting, bootstrap injection
 // matching, and hash output used to compare prompt/tool parity.
 import { describe, expect, it } from "vitest";
+import { buildBootstrapInjectionStats } from "./bootstrap-budget.js";
 import { buildSystemPromptReport } from "./system-prompt-report.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
 
@@ -28,8 +29,10 @@ describe("buildSystemPromptReport", () => {
       bootstrapMaxChars: params.bootstrapMaxChars ?? 20_000,
       bootstrapTotalMaxChars: params.bootstrapTotalMaxChars,
       systemPrompt: "system",
-      bootstrapFiles: [params.file],
-      injectedFiles: [{ path: params.injectedPath, content: params.injectedContent }],
+      injectedWorkspaceFiles: buildBootstrapInjectionStats({
+        bootstrapFiles: [params.file],
+        injectedFiles: [{ path: params.injectedPath, content: params.injectedContent }],
+      }),
       skillsPrompt: "",
       tools: [],
     });
@@ -114,11 +117,13 @@ describe("buildSystemPromptReport", () => {
       generatedAt: 0,
       bootstrapMaxChars: 20_000,
       systemPrompt: "system",
-      bootstrapFiles: [file],
-      injectedFiles: [
-        { path: 123 as unknown as string, content: "bad" },
-        { path: "/tmp/workspace/policies/AGENTS.md", content: "trimmed" },
-      ],
+      injectedWorkspaceFiles: buildBootstrapInjectionStats({
+        bootstrapFiles: [file],
+        injectedFiles: [
+          { path: 123 as unknown as string, content: "bad" },
+          { path: "/tmp/workspace/policies/AGENTS.md", content: "trimmed" },
+        ],
+      }),
       skillsPrompt: "",
       tools: [],
     });
@@ -136,8 +141,10 @@ describe("buildSystemPromptReport", () => {
       generatedAt: 0,
       bootstrapMaxChars: 20_000,
       systemPrompt: "custom override",
-      bootstrapFiles: [file],
-      injectedFiles: [{ path: "/tmp/workspace/AGENTS.md", content: "rendered context" }],
+      injectedWorkspaceFiles: buildBootstrapInjectionStats({
+        bootstrapFiles: [file],
+        injectedFiles: [{ path: "/tmp/workspace/AGENTS.md", content: "rendered context" }],
+      }),
       skillsPrompt: "",
       tools: [],
     });
@@ -156,8 +163,10 @@ describe("buildSystemPromptReport", () => {
       generatedAt: 0,
       bootstrapMaxChars: 20_000,
       systemPrompt: "system",
-      bootstrapFiles: [file],
-      injectedFiles: [],
+      injectedWorkspaceFiles: buildBootstrapInjectionStats({
+        bootstrapFiles: [file],
+        injectedFiles: [],
+      }),
       skillsPrompt: "<skill><name>docs</name></skill>",
       tools: [
         {
@@ -175,8 +184,10 @@ describe("buildSystemPromptReport", () => {
       generatedAt: 0,
       bootstrapMaxChars: 20_000,
       systemPrompt: "systen",
-      bootstrapFiles: [file],
-      injectedFiles: [],
+      injectedWorkspaceFiles: buildBootstrapInjectionStats({
+        bootstrapFiles: [file],
+        injectedFiles: [],
+      }),
       skillsPrompt: "<skill><name>docs</name></skill>",
       tools: [],
     });
@@ -201,8 +212,10 @@ describe("buildSystemPromptReport", () => {
       generatedAt: 0,
       bootstrapMaxChars: 20_000,
       systemPrompt: "system",
-      bootstrapFiles: [file],
-      injectedFiles: [],
+      injectedWorkspaceFiles: buildBootstrapInjectionStats({
+        bootstrapFiles: [file],
+        injectedFiles: [],
+      }),
       skillsPrompt: "",
       tools: [
         {

--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -6,10 +6,8 @@
  */
 import { createHash } from "node:crypto";
 import type { SessionSystemPromptReport } from "../config/sessions/types.js";
-import { buildBootstrapInjectionStats } from "./bootstrap-budget.js";
-import type { EmbeddedContextFile } from "./embedded-agent-helpers.js";
+import type { BootstrapInjectionStat } from "./bootstrap-budget.types.js";
 import type { AgentTool } from "./runtime/index.js";
-import type { WorkspaceBootstrapFile } from "./workspace.js";
 
 type ToolReportEntry = SessionSystemPromptReport["tools"]["entries"][number];
 
@@ -116,8 +114,7 @@ export function buildSystemPromptReport(params: {
   bootstrapTruncation?: SessionSystemPromptReport["bootstrapTruncation"];
   sandbox?: SessionSystemPromptReport["sandbox"];
   systemPrompt: string;
-  bootstrapFiles: WorkspaceBootstrapFile[];
-  injectedFiles: EmbeddedContextFile[];
+  injectedWorkspaceFiles: BootstrapInjectionStat[];
   skillsPrompt: string;
   tools: AgentTool[];
   currentTurn?: SessionSystemPromptReport["currentTurn"];
@@ -147,10 +144,7 @@ export function buildSystemPromptReport(params: {
       nonProjectContextChars: Math.max(0, systemPromptChars - projectContextChars),
     },
     ...(params.currentTurn ? { currentTurn: params.currentTurn } : {}),
-    injectedWorkspaceFiles: buildBootstrapInjectionStats({
-      bootstrapFiles: params.bootstrapFiles,
-      injectedFiles: params.injectedFiles,
-    }),
+    injectedWorkspaceFiles: params.injectedWorkspaceFiles,
     skills: {
       promptChars: params.skillsPrompt.length,
       hash: sha256(params.skillsPrompt),

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -92,7 +92,6 @@ const CONTEXT_FILE_ORDER = new Map<string, number>([
   ["memory.md", 70],
 ]);
 
-const DYNAMIC_CONTEXT_FILE_BASENAMES = new Set<string>();
 const DEFAULT_HEARTBEAT_PROMPT_CONTEXT_BLOCK =
   /Default heartbeat prompt:\r?\n`(?:Read HEARTBEAT\.md if it exists|Follow the heartbeat monitor scratch context when provided\.)[^`\r\n]*HEARTBEAT_OK\.`/gu;
 const SYSTEM_PROMPT_STABLE_PREFIX_CACHE_LIMIT = 64;
@@ -174,10 +173,6 @@ function getContextFileBasename(pathValue: string): string {
   return normalizeLowercaseStringOrEmpty(normalizedPath.split("/").pop() ?? normalizedPath);
 }
 
-function isDynamicContextFile(pathValue: string): boolean {
-  return DYNAMIC_CONTEXT_FILE_BASENAMES.has(getContextFileBasename(pathValue));
-}
-
 function isBootstrapContextFile(pathValue: string): boolean {
   return /(^|[\\/])BOOTSTRAP\.md$/iu.test(pathValue.trim());
 }
@@ -189,72 +184,52 @@ function sanitizeContextFileContentForPrompt(content: string): string {
 }
 
 function sortContextFilesForPrompt(contextFiles: EmbeddedContextFile[]): EmbeddedContextFile[] {
-  return contextFiles.toSorted((a, b) => {
-    const aPath = normalizeContextFilePath(a.path);
-    const bPath = normalizeContextFilePath(b.path);
-    const aBase = getContextFileBasename(a.path);
-    const bBase = getContextFileBasename(b.path);
-    const aOrder = CONTEXT_FILE_ORDER.get(aBase) ?? Number.MAX_SAFE_INTEGER;
-    const bOrder = CONTEXT_FILE_ORDER.get(bBase) ?? Number.MAX_SAFE_INTEGER;
-    if (aOrder !== bOrder) {
-      return aOrder - bOrder;
-    }
-    if (aBase !== bBase) {
-      return aBase.localeCompare(bBase);
-    }
-    return aPath.localeCompare(bPath);
-  });
+  return contextFiles
+    .map((file) => {
+      const basename = getContextFileBasename(file.path);
+      return {
+        file,
+        path: normalizeContextFilePath(file.path),
+        basename,
+        order: CONTEXT_FILE_ORDER.get(basename) ?? Number.MAX_SAFE_INTEGER,
+      };
+    })
+    .toSorted((a, b) => {
+      if (a.order !== b.order) {
+        return a.order - b.order;
+      }
+      if (a.basename !== b.basename) {
+        return a.basename.localeCompare(b.basename);
+      }
+      return a.path.localeCompare(b.path);
+    })
+    .map(({ file }) => file);
 }
 
-function prepareContextFilesForPrompt(contextFiles: EmbeddedContextFile[] = []) {
-  const ordered = sortContextFilesForPrompt(
-    contextFiles.filter((file) => typeof file.path === "string" && file.path.trim().length > 0),
-  );
-  return {
-    ordered,
-    stable: ordered.filter((file) => !isDynamicContextFile(file.path)),
-    dynamic: ordered.filter((file) => isDynamicContextFile(file.path)),
-  };
-}
-
-function buildProjectContextSection(params: {
-  files: EmbeddedContextFile[];
-  heading: string;
-  dynamic: boolean;
-}) {
-  if (params.files.length === 0) {
+function buildProjectContextSection(files: EmbeddedContextFile[]) {
+  if (files.length === 0) {
     return [];
   }
-  const lines = [params.heading, ""];
-  if (params.dynamic) {
-    lines.push("Frequently-changing files; below cache boundary when possible:", "");
-  } else {
-    const hasSoulFile = params.files.some(
-      (file) => getContextFileBasename(file.path) === "soul.md",
-    );
-    const hasMemoryFile = params.files.some(
-      (file) => getContextFileBasename(file.path) === "memory.md",
-    );
-    const hasUserFile = params.files.some(
-      (file) => getContextFileBasename(file.path) === "user.md",
-    );
-    lines.push("Loaded project context:");
-    if (hasSoulFile) {
-      lines.push("SOUL.md: persona/tone. Follow it unless higher-priority instructions override.");
-    }
-    if (hasMemoryFile) {
-      lines.push(
-        "MEMORY.md: durable non-profile facts and decisions; use when relevant unless higher-priority instructions override.",
-      );
-    }
-    if (hasUserFile) {
-      lines.push(
-        "USER.md: durable user preferences and profile directives; follow unless higher-priority instructions override.",
-      );
-    }
-    lines.push("");
+  const lines = ["# Project Context", ""];
+  const hasSoulFile = files.some((file) => getContextFileBasename(file.path) === "soul.md");
+  const hasMemoryFile = files.some((file) => getContextFileBasename(file.path) === "memory.md");
+  const hasUserFile = files.some((file) => getContextFileBasename(file.path) === "user.md");
+  lines.push("Loaded project context:");
+  if (hasSoulFile) {
+    lines.push("SOUL.md: persona/tone. Follow it unless higher-priority instructions override.");
   }
-  for (const file of params.files) {
+  if (hasMemoryFile) {
+    lines.push(
+      "MEMORY.md: durable non-profile facts and decisions; use when relevant unless higher-priority instructions override.",
+    );
+  }
+  if (hasUserFile) {
+    lines.push(
+      "USER.md: durable user preferences and profile directives; follow unless higher-priority instructions override.",
+    );
+  }
+  lines.push("");
+  for (const file of files) {
     lines.push(`## ${file.path}`, "", sanitizeContextFileContentForPrompt(file.content), "");
   }
   return lines;
@@ -358,16 +333,12 @@ function buildAgentBootstrapSystemPromptSections(params: {
   bootstrapTruncationNotice?: string;
   contextFiles?: EmbeddedContextFile[];
 }): string[] {
-  const bootstrapFiles =
-    params.bootstrapMode === "full"
-      ? sortContextFilesForPrompt(params.contextFiles ?? []).filter((file) =>
-          isBootstrapContextFile(file.path),
-        )
-      : [];
   const lines = [
     ...buildAgentBootstrapSystemContext({
       bootstrapMode: params.bootstrapMode,
-      hasBootstrapFileInProjectContext: bootstrapFiles.length > 0,
+      hasBootstrapFileInProjectContext:
+        params.bootstrapMode === "full" &&
+        (params.contextFiles?.some((file) => isBootstrapContextFile(file.path)) ?? false),
     }),
   ];
   const bootstrapTruncationNotice = params.bootstrapTruncationNotice?.trim();
@@ -780,25 +751,29 @@ export function appendModelIdentitySystemPrompt(params: {
     return params.systemPrompt;
   }
 
-  let replaced = false;
-  const nextLines = params.systemPrompt
-    .split(/\r?\n/u)
-    .filter((candidate) => {
-      if (!candidate.trimStart().startsWith(MODEL_IDENTITY_PREFIX)) {
-        return true;
+  const source = params.systemPrompt;
+  const parts: string[] = [];
+  let cursor = 0;
+  for (let index = source.indexOf(MODEL_IDENTITY_PREFIX); index !== -1;) {
+    const nextLine = source.indexOf("\n", index);
+    const lineStart = source.lastIndexOf("\n", index) + 1;
+    if (!source.slice(lineStart, index).trimStart()) {
+      // Normalize only original bytes; replacement model text can itself contain CRLFs.
+      const preceding = source.slice(cursor, lineStart).replace(/\r\n/gu, "\n");
+      if (parts.length === 0) {
+        parts.push(preceding, line);
+      } else {
+        // Dropping a duplicate line also drops its preceding normalized LF.
+        parts.push(preceding.slice(0, -1));
       }
-      if (replaced) {
-        return false;
-      }
-      replaced = true;
-      return true;
-    })
-    .map((candidate) =>
-      candidate.trimStart().startsWith(MODEL_IDENTITY_PREFIX) ? line : candidate,
-    );
-
-  if (replaced) {
-    return nextLines.join("\n");
+      cursor = nextLine === -1 ? source.length : nextLine;
+    }
+    // A later occurrence on the same line cannot have a whitespace-only prefix.
+    index = nextLine === -1 ? -1 : source.indexOf(MODEL_IDENTITY_PREFIX, nextLine + 1);
+  }
+  if (parts.length > 0) {
+    parts.push(source.slice(cursor).replace(/\r\n/gu, "\n"));
+    return parts.join("");
   }
 
   const base = params.systemPrompt.trimEnd();
@@ -871,6 +846,15 @@ export function buildAgentSystemPrompt(params: {
   activeProjectKeys?: readonly string[];
   promptContribution?: ProviderSystemPromptContribution;
 }) {
+  const promptMode = params.promptMode ?? "full";
+  const runtimeInfo = params.runtimeInfo;
+  const modelIdentityLine = buildModelIdentityPromptLine(runtimeInfo?.model);
+  if (promptMode === "none") {
+    return ["You are a personal assistant running inside OpenClaw.", modelIdentityLine]
+      .filter(Boolean)
+      .join("\n");
+  }
+
   const acpEnabled = params.acpEnabled === true;
   const promptSurface = params.promptSurface ?? "openclaw_main";
   const sandboxedRuntime = params.sandboxInfo?.enabled === true;
@@ -1047,8 +1031,7 @@ export function buildAgentSystemPrompt(params: {
       ])
       .filter(([, value]) => Boolean(value)),
   ) as Partial<Record<ProviderSystemPromptSectionId, string>>;
-  const promptMode = params.promptMode ?? "full";
-  const isMinimal = promptMode === "minimal" || promptMode === "none";
+  const isMinimal = promptMode === "minimal";
   const includeToolGuidance =
     !isMinimal || availableTools.size > 0 || promptSurface === "cli_backend";
   const ownerDisplay = params.ownerDisplay === "hash" ? "hash" : "raw";
@@ -1069,8 +1052,6 @@ export function buildAgentSystemPrompt(params: {
   const userTimezone = params.userTimezone?.trim();
   const userDate = params.userDate?.trim();
   const skillsPrompt = params.skillsPrompt?.trim();
-  const runtimeInfo = params.runtimeInfo;
-  const modelIdentityLine = buildModelIdentityPromptLine(runtimeInfo?.model);
   const runtimeChannel = normalizeOptionalLowercaseString(runtimeInfo?.channel);
   const runtimeChatType = normalizeChatType(runtimeInfo?.chatType);
   const runtimeCapabilities = runtimeInfo?.capabilities ?? [];
@@ -1170,23 +1151,16 @@ export function buildAgentSystemPrompt(params: {
   });
   const workspaceNotes = normalizeStringEntries(params.workspaceNotes);
 
-  // For "none" mode, return just the basic identity line
-  if (promptMode === "none") {
-    return ["You are a personal assistant running inside OpenClaw.", modelIdentityLine]
-      .filter(Boolean)
-      .join("\n");
-  }
-
-  const contextFiles = prepareContextFilesForPrompt(
+  const contextFiles = sortContextFilesForPrompt(
     filterProjectScopedCuratedContextFiles({
       contextFiles: params.contextFiles,
       activeProjectKeys: params.activeProjectKeys,
-    }),
+    }).filter((file) => typeof file.path === "string" && file.path.trim().length > 0),
   );
   const bootstrapSystemPromptSections = buildAgentBootstrapSystemPromptSections({
     bootstrapMode: params.bootstrapMode,
     bootstrapTruncationNotice: params.bootstrapTruncationNotice,
-    contextFiles: contextFiles.ordered,
+    contextFiles,
   });
   const stablePrefixCacheKey = hashStablePromptInput({
     workspaceDir: params.workspaceDir,
@@ -1228,7 +1202,7 @@ export function buildAgentSystemPrompt(params: {
     memoryCitationsMode: params.memoryCitationsMode,
     memorySection,
     acpEnabled,
-    stableContextFiles: contextFiles.stable,
+    stableContextFiles: contextFiles,
   });
   const stablePrefix = cacheStablePromptPrefix(stablePrefixCacheKey, () => {
     const lines = [
@@ -1452,13 +1426,7 @@ export function buildAgentSystemPrompt(params: {
       lines.push("## Reasoning Format", reasoningHint, "");
     }
 
-    lines.push(
-      ...buildProjectContextSection({
-        files: contextFiles.stable,
-        heading: "# Project Context",
-        dynamic: false,
-      }),
-    );
+    lines.push(...buildProjectContextSection(contextFiles));
 
     if (!isMinimal && silentReplyPromptMode !== "none") {
       lines.push(
@@ -1482,14 +1450,6 @@ export function buildAgentSystemPrompt(params: {
       userDate,
       userTimezone,
       sessionStatusAvailable: availableTools.has("session_status"),
-    }),
-  );
-
-  lines.push(
-    ...buildProjectContextSection({
-      files: contextFiles.dynamic,
-      heading: contextFiles.stable.length > 0 ? "# Dynamic Project Context" : "# Project Context",
-      dynamic: true,
     }),
   );
 

--- a/src/auto-reply/reply/commands-context-report.ts
+++ b/src/auto-reply/reply/commands-context-report.ts
@@ -2,7 +2,10 @@
 import { estimateTokensFromChars } from "@openclaw/normalization-core/cjk-chars";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { resolveSessionAgentIds } from "../../agents/agent-scope.js";
-import { analyzeBootstrapBudget } from "../../agents/bootstrap-budget.js";
+import {
+  analyzeBootstrapBudget,
+  buildBootstrapInjectionStats,
+} from "../../agents/bootstrap-budget.js";
 import { isRealConversationMessage } from "../../agents/compaction-real-conversation.js";
 import {
   resolveBootstrapMaxChars,
@@ -144,6 +147,7 @@ async function resolveContextReport(
   const { systemPrompt, tools, skillsPrompt, bootstrapFiles, injectedFiles, sandboxRuntime } =
     await resolveCommandsSystemPromptBundle(params);
 
+  const injectedWorkspaceFiles = buildBootstrapInjectionStats({ bootstrapFiles, injectedFiles });
   return buildSystemPromptReport({
     source: "estimate",
     generatedAt: Date.now(),
@@ -156,8 +160,7 @@ async function resolveContextReport(
     bootstrapTotalMaxChars,
     sandbox: { mode: sandboxRuntime.mode, sandboxed: sandboxRuntime.sandboxed },
     systemPrompt,
-    bootstrapFiles,
-    injectedFiles,
+    injectedWorkspaceFiles,
     skillsPrompt,
     tools,
   });


### PR DESCRIPTION
Prompt preparation repeatedly normalized and partitioned the same workspace files, split complete prompts to refresh one identity line, and rebuilt bootstrap statistics for the report. Even identity-only prompts prepared tool and channel guidance that they discarded.

This keeps one preparation flow at each owner and removes the unused work. It contains four independently measured mechanisms in the ongoing performance cleanup:

- Prepare context ordering keys once; remove the empty private dynamic-file partition, its alternate renderer, and the redundant bootstrap-only sort.
- Refresh model identity by finding relevant original lines, preserving CRLF normalization, duplicate-line removal, and replacement text exactly.
- Carry the run-owned bootstrap statistics into budget analysis and the prompt report; remove the raw-file array from the prepared embedded result.
- Return the unchanged identity-only prompt before preparing unused sections in `none` mode. Provider/config/attempt transforms and raw-run suppression still run at their existing wrappers.

The embedded and CLI reporting contracts remain deliberately different: embedded reports retain suppressed BOOTSTRAP inventory rows while their warning budget excludes them; CLI reports use the already-filtered inventory. Hook-adjusted records are copied before this preparation and are not exposed to intervening awaited hooks or tool setup. Budget analysis owns separate enriched records. No cross-run cache, new option, fallback, schema, protocol, dependency, or SDK surface is introduced.

Native Codex uses its separate loader and `native_unverified` report, which are unchanged. Direct source inspection included `codex-rs/core/src/agents_md.rs:55`, `:121`, and `:187` at `6478a751fde8884b2fdc76486fe23175a8e795d4`, plus the complete OpenClaw native context/report owner. The native loader's independent byte budget cannot be inferred from OpenClaw's local character inventory.

Production: **+111/−150 = −39 lines** across seven files. Existing tests: **+35/−20 = +15**, solely migrating seven calls to the canonical prepared-statistics API without removing cases or assertions. Release workflow owns the changelog; this is internal performance work with unchanged operator behavior.

Measured on Node 26.8.1, two fresh processes per suite with reversed starting order, six variants, all warmups and samples retained. These are complete-owner/composed preparation timings, not network or whole-turn latency. Final formatted sources, including `toSorted`, are bound in the receipts.

| Operation | Before, forward/reverse | Combined, forward/reverse |
| --- | ---: | ---: |
| Six-file fixture: prompt + identity + report | 44.616 / 45.326 µs | 38.467 / 39.385 µs |
| Complete embedded preparation, six-file fixture | 35.339 / 33.766 µs | 28.862 / 28.740 µs |
| CLI context + budget + identity + report | 31.491 / 30.582 µs | 20.645 / 21.429 µs |
| Same CLI composition, 128 files | 270.682 / 260.280 µs | 158.842 / 165.390 µs |
| Identity-only raw attempt, isolated shortcut | 7.941 / 7.677 µs | 0.828 / 0.887 µs |

The saved benchmark labels containing `default` refer to a six-file injected-context fixture containing TOOLS.md, which remains a valid prepared/hook input but is already retired from automatic loading. They do not measure the current automatic workspace inventory. Original labels, fixtures, and raw samples remain unchanged; a separately named current-loader-shaped validation is recorded below. Tradeoffs remain visible: empty renderer +0.540/+1.190 µs and absent-context embedded wrapper +0.801/+1.676 µs; complete embedded 48K preparation changes −7.1%/+4.7%. The full 36-workload prompt and 23-workload bootstrap tables retain every variant and mixed control. No ablation speedups are multiplied and no per-variant memory claim is made.

Validation: 316 canonical tests across 20 files pass. Final-source differential proof covers 970 composed prompt cases, 36,223 identity cases and 216 configured/attempt cases (191,365 comparisons), plus 744 bootstrap projections and 306 complete embedded preparations (10,700 comparisons). It checks exact strings/JSON, cache keys and boundary placement, frozen inputs, next-operation freshness, collation ties, CRLF insertion, suppression, callback errors, raw/path-only BOOTSTRAP inventory, and both supported agent-config shapes. The earlier lint failure was corrected without suppressing the rule; final lint, core types, the full changed gate (255.366s), and managed P0–P3 review pass. The clean rebase over three upstream fixes leaves all nine changed files and all 54 selected source/dependency bindings byte-identical. Published build, repeated canonical tests and live Gateway proof are recorded below.

Published head `56c911c751c02b411a8cfb9a1ad942adfb0eddd6`: all 316 tests pass again (17.932s), full build passes (154.818s), and the published P0–P3 review is clean. An isolated Gateway completed four real OpenAI turns and two web fetches. There are 84 successful assertions across history recovery, bounded lists, stored prompt accounting/truncation and a fresh workspace-marker turn: the model returned the exact synthetic value present only in AGENTS.md, with no tool calls. The owned Gateway stopped cleanly and two Node CPU profiles are retained.

Two initial report-probe failures were harness assumptions, preserved in the evidence: TOOLS.md was already retired from automatic injection, and existing diagnostic redaction hides the system body. The corrected checks preserve both behaviors, verify stored counts and original-input digests, and use the separate real model marker turn for injection proof. No redaction was disabled. This is live embedded OpenAI proof, not fresh external CLI/native Codex execution or a whole-turn latency comparison.

Additional controls now match the current automatic loader: AGENTS present with optional files absent, five personal files with BOOTSTRAP missing, and six files with onboarding pending. The post-load embedded/CLI compositions passed 108 complete scenarios, 216 exact comparisons, 108 immutability checks and 288 explicit controls. Two fresh reversed-order processes retained all 12 workloads, warmups and samples. Short embedded preparation changed from 25.081/24.898 to 22.026/22.242 µs for the first shape, 33.695/32.464 to 27.203/29.435 µs for the second, and 38.223/39.725 to 32.074/28.247 µs for the third. Corresponding CLI improvements were 22%, 21–24%, and 28–30%. Larger embedded controls remain mixed: AGENTS 8K +0.6/−6.1%, five personal files 40K +1.9/−1.2%, and pending six 48K −6.0/−4.7%. These controls do not time actual filesystem loading or network access and do not replace the earlier synthetic fixtures.

Latest ClawSweeper review `5468696431` (updated 12:48:05 UTC) and the preceding acknowledgement were read in full. No concrete defect was found. Its remaining rank-up move, successful exact-head CI completion, is satisfied: hosted CI `33311383951` succeeded, all 256 rollup checks completed without failure, and no retry was needed. Delegated maintainer decision: accept this internal refactor under the authorized performance campaign. No separate human approval is claimed.
