### PR TITLE
fix(mattermost): record a button click before answering it

### DIFF
--- a/extensions/mattermost/src/mattermost/interactions.test.ts
+++ b/extensions/mattermost/src/mattermost/interactions.test.ts
@@ -14,6 +14,7 @@ import {
   setInteractionCallbackUrl,
   setInteractionSecret,
 } from "./interactions.js";
+import type { MattermostIngressInteraction } from "./monitor-ingress.js";
 
 type ButtonAction = {
   id: string;
@@ -860,7 +861,7 @@ describe("createMattermostInteractionHandler", () => {
 
   it("blocks button dispatch when the sender is not allowed for the action", async () => {
     const { context, token } = createActionContext();
-    const dispatchButtonClick = vi.fn();
+    const admitInteraction = vi.fn();
     const handleInteraction = vi.fn();
     const handler = createMattermostInteractionHandler({
       client: createMattermostClientMock(async (_path: string, init?: { method?: string }) =>
@@ -875,7 +876,7 @@ describe("createMattermostInteractionHandler", () => {
         },
       }),
       handleInteraction,
-      dispatchButtonClick,
+      admitInteraction,
     });
 
     const res = await runHandler(handler, {
@@ -885,51 +886,94 @@ describe("createMattermostInteractionHandler", () => {
     expect(res.statusCode).toBe(200);
     expect(res.body).toContain("blocked");
     expect(handleInteraction).not.toHaveBeenCalled();
-    expect(dispatchButtonClick).not.toHaveBeenCalled();
+    expect(admitInteraction).not.toHaveBeenCalled();
   });
 
-  it("forwards fetched post threading metadata to session and button callbacks", async () => {
-    const enqueueSystemEvent = vi.fn();
-    setInteractionRuntime(enqueueSystemEvent);
+  it("records the whole click, with its thread root, before answering Mattermost", async () => {
+    setInteractionRuntime();
     const { context, token } = createActionContext();
-    const resolveSessionKey = vi.fn().mockResolvedValue("session:thread:root-9");
-    const dispatchButtonClick = vi.fn();
+    const answeredAfterAdmission: string[] = [];
+    const admitInteraction = vi.fn(async () => {
+      answeredAfterAdmission.push("admitted");
+    });
     const fetchedPost = createActionPost({ rootId: "root-9" });
     const handler = createMattermostInteractionHandler({
-      client: createMattermostClientMock(async (_path: string, init?: { method?: string }) =>
-        init?.method === "PUT" ? { id: "post-1" } : fetchedPost,
-      ),
+      client: createMattermostClientMock(async (_path: string, init?: { method?: string }) => {
+        if (init?.method === "PUT") {
+          answeredAfterAdmission.push("post-updated");
+          return { id: "post-1" };
+        }
+        return fetchedPost;
+      }),
       botUserId: "bot",
       accountId: "acct",
-      resolveSessionKey,
-      dispatchButtonClick,
+      admitInteraction,
     });
 
     const res = await runHandler(handler, {
       body: createInteractionBody({ context, token, userName: "alice" }),
     });
+
     expect(res.statusCode).toBe(200);
-    expect(resolveSessionKey).toHaveBeenCalledWith({
-      channelId: "chan-1",
-      userId: "user-1",
-      post: fetchedPost,
-    });
-    expect(enqueueSystemEvent).toHaveBeenCalledWith(
-      'Mattermost button click: action="approve" by alice in channel chan-1',
-      {
-        sessionKey: "session:thread:root-9",
-        contextKey: "mattermost:interaction:post-1:approve",
-      },
-    );
-    expect(dispatchButtonClick).toHaveBeenCalledWith({
+    expect(admitInteraction).toHaveBeenCalledWith({
+      eventId: expect.any(String),
       channelId: "chan-1",
       userId: "user-1",
       userName: "alice",
       actionId: "approve",
       actionName: "Approve",
       postId: "post-1",
-      post: fetchedPost,
+      rootId: "root-9",
     });
+    // Nothing may claim the click was taken until it is recoverable.
+    expect(answeredAfterAdmission).toEqual(["admitted", "post-updated"]);
+  });
+
+  it("gives every click its own record so a repeated press is not swallowed", async () => {
+    setInteractionRuntime();
+    const { context, token } = createActionContext();
+    const admitInteraction = vi.fn(async (_interaction: MattermostIngressInteraction) => {});
+    const handler = createMattermostInteractionHandler({
+      client: createMattermostClientMock(async (_path: string, init?: { method?: string }) =>
+        init?.method === "PUT" ? { id: "post-1" } : createActionPost(),
+      ),
+      botUserId: "bot",
+      accountId: "acct",
+      admitInteraction,
+    });
+    const body = createInteractionBody({ context, token, userName: "alice" });
+
+    await runHandler(handler, { body });
+    await runHandler(handler, { body });
+
+    const [first, second] = admitInteraction.mock.calls.map(([interaction]) => interaction.eventId);
+    expect(first).toBeTruthy();
+    expect(second).not.toBe(first);
+  });
+
+  it("refuses the click when it cannot be recorded instead of reporting success", async () => {
+    setInteractionRuntime();
+    const { context, token } = createActionContext();
+    const requestLog: Array<{ path: string; method?: string }> = [];
+    const handler = createMattermostInteractionHandler({
+      client: createMattermostClientMock(async (path: string, init?: { method?: string }) => {
+        requestLog.push({ path, method: init?.method });
+        return createActionPost();
+      }),
+      botUserId: "bot",
+      accountId: "acct",
+      admitInteraction: async () => {
+        throw new Error("ingress storage unavailable");
+      },
+    });
+
+    const res = await runHandler(handler, {
+      body: createInteractionBody({ context, token, userName: "alice" }),
+    });
+
+    expect(res.statusCode).toBe(500);
+    // The buttons must stay clickable: nothing accepted this press.
+    expect(requestLog.some((entry) => entry.method === "PUT")).toBe(false);
   });
 
   it("lets a custom interaction handler short-circuit generic completion updates", async () => {
@@ -938,7 +982,7 @@ describe("createMattermostInteractionHandler", () => {
     const handleInteraction = vi.fn().mockResolvedValue({
       ephemeral_text: "Only the original requester can use this picker.",
     });
-    const dispatchButtonClick = vi.fn();
+    const admitInteraction = vi.fn();
     const originalPost = createActionPost({
       actionId: "mdlprov",
       actionName: "Browse providers",
@@ -951,7 +995,7 @@ describe("createMattermostInteractionHandler", () => {
       botUserId: "bot",
       accountId: "acct",
       handleInteraction,
-      dispatchButtonClick,
+      admitInteraction,
     });
     const body = createInteractionBody({
       context,
@@ -978,6 +1022,6 @@ describe("createMattermostInteractionHandler", () => {
       context,
       post: originalPost,
     });
-    expect(dispatchButtonClick).not.toHaveBeenCalled();
+    expect(admitInteraction).not.toHaveBeenCalled();
   });
 });

--- a/extensions/mattermost/src/mattermost/interactions.ts
+++ b/extensions/mattermost/src/mattermost/interactions.ts
@@ -1,5 +1,5 @@
 // Mattermost plugin module implements interactions behavior.
-import { createHmac } from "node:crypto";
+import { createHmac, randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { resolveGatewayPort } from "openclaw/plugin-sdk/gateway-config-runtime";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
@@ -7,8 +7,8 @@ import {
   normalizeOptionalString,
   normalizeStringifiedOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { getMattermostRuntime } from "../runtime.js";
 import { updateMattermostPost, type MattermostClient, type MattermostPost } from "./client.js";
+import type { MattermostIngressInteraction } from "./monitor-ingress.js";
 import {
   isTrustedProxyAddress,
   readRequestBodyWithLimit,
@@ -368,11 +368,6 @@ export function createMattermostInteractionHandler(params: {
   allowedSourceIps?: string[];
   trustedProxies?: string[];
   allowRealIpFallback?: boolean;
-  resolveSessionKey?: (params: {
-    channelId: string;
-    userId: string;
-    post: MattermostPost;
-  }) => Promise<string>;
   handleInteraction?: (opts: {
     payload: MattermostInteractionPayload;
     userName: string;
@@ -386,19 +381,11 @@ export function createMattermostInteractionHandler(params: {
     payload: MattermostInteractionPayload;
     post: MattermostPost;
   }) => Promise<MattermostInteractionAuthorizationResult>;
-  dispatchButtonClick?: (opts: {
-    channelId: string;
-    userId: string;
-    userName: string;
-    actionId: string;
-    actionName: string;
-    postId: string;
-    post: MattermostPost;
-  }) => Promise<void>;
+  /** Records the click durably; a rejection must reach the caller before any success reply. */
+  admitInteraction?: (interaction: MattermostIngressInteraction) => Promise<void>;
   log?: (message: string) => void;
 }): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
   const { client, accountId, log } = params;
-  const core = getMattermostRuntime();
 
   function parseInteractionPayload(raw: string): MattermostInteractionPayload {
     try {
@@ -609,29 +596,30 @@ export function createMattermostInteractionHandler(params: {
       }
     }
 
-    // Dispatch as system event so the agent can handle it.
-    // Wrapped in try/catch — the post update below must still run even if
-    // system event dispatch fails (e.g. missing sessionKey or channel lookup).
-    try {
-      const eventLabel =
-        `Mattermost button click: action="${actionId}" ` +
-        `by ${payload.user_name ?? payload.user_id} ` +
-        `in channel ${payload.channel_id}`;
-
-      const sessionKey = params.resolveSessionKey
-        ? await params.resolveSessionKey({
-            channelId: payload.channel_id,
-            userId: payload.user_id,
-            post: originalPost,
-          })
-        : `agent:main:mattermost:${accountId}:${payload.channel_id}`;
-
-      core.system.enqueueSystemEvent(eventLabel, {
-        sessionKey,
-        contextKey: `mattermost:interaction:${payload.post_id}:${actionId}`,
-      });
-    } catch (err) {
-      log?.(`mattermost interaction: system event dispatch failed: ${String(err)}`);
+    // Record the click before anything tells the user it was taken. Mattermost
+    // treats the response as final and never redelivers, so an accepted click that
+    // is only in this process is lost to a restart, a crash, or a throwing handler.
+    if (params.admitInteraction) {
+      try {
+        await params.admitInteraction({
+          // No callback field is unique per press, and a post can be clicked again
+          // when the completion update below fails, so admission mints the id.
+          eventId: randomUUID(),
+          channelId: payload.channel_id,
+          userId: payload.user_id,
+          userName,
+          actionId,
+          actionName: clickedButtonName,
+          postId: payload.post_id,
+          ...(originalPost.root_id?.trim() ? { rootId: originalPost.root_id.trim() } : {}),
+        });
+      } catch (err) {
+        log?.(`mattermost interaction: durable admission failed: ${String(err)}`);
+        res.statusCode = 500;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ error: "Interaction could not be accepted" }));
+        return;
+      }
     }
 
     // Update the post via API to replace buttons with a completion indicator.
@@ -654,22 +642,5 @@ export function createMattermostInteractionHandler(params: {
     res.statusCode = 200;
     res.setHeader("Content-Type", "application/json");
     res.end("{}");
-
-    // Dispatch a synthetic inbound message so the agent responds to the button click.
-    if (params.dispatchButtonClick) {
-      try {
-        await params.dispatchButtonClick({
-          channelId: payload.channel_id,
-          userId: payload.user_id,
-          userName,
-          actionId,
-          actionName: clickedButtonName,
-          postId: payload.post_id,
-          post: originalPost,
-        });
-      } catch (err) {
-        log?.(`mattermost interaction: dispatchButtonClick failed: ${String(err)}`);
-      }
-    }
   };
 }

--- a/extensions/mattermost/src/mattermost/monitor-context.ts
+++ b/extensions/mattermost/src/mattermost/monitor-context.ts
@@ -42,8 +42,11 @@ export function buildMattermostModelPickerSelectMessageSid(params: {
 export function buildMattermostButtonInteractionMessageSid(params: {
   postId: string;
   actionId: string;
+  eventId: string;
 }): string {
-  return `interaction:${params.postId}:${params.actionId}`;
+  // One press is one inbound event. Keying on post and action alone lets shared
+  // inbound dedupe fold a second, legitimate press of the same button into the first.
+  return `interaction:${params.postId}:${params.actionId}:${params.eventId}`;
 }
 
 export function resolveMattermostReplyRootId(params: {

--- a/extensions/mattermost/src/mattermost/monitor-ingress.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-ingress.test.ts
@@ -15,6 +15,21 @@ type MattermostIngressQueue = NonNullable<
 >;
 type MattermostIngressPayload = Parameters<MattermostIngressQueue["enqueue"]>[1];
 type MattermostIngressDispatch = Parameters<typeof createMattermostIngressMonitor>[0]["dispatch"];
+type MattermostIngressInteractionDispatch = Parameters<
+  typeof createMattermostIngressMonitor
+>[0]["dispatchInteraction"];
+
+function buttonClick(params?: { eventId?: string; channelId?: string; postId?: string }) {
+  return {
+    eventId: params?.eventId ?? "click-1",
+    channelId: params?.channelId ?? "channel-1",
+    userId: "user-1",
+    userName: "alice",
+    actionId: "approve",
+    actionName: "Approve",
+    postId: params?.postId ?? "post-1",
+  };
+}
 
 function postedEvent(params?: {
   postId?: string;
@@ -43,11 +58,15 @@ function startMonitor(
     error: vi.fn(),
     log: vi.fn(),
   },
+  dispatchInteraction: MattermostIngressInteractionDispatch = async (_interaction, lifecycle) => {
+    await lifecycle.onAdopted();
+  },
 ) {
   return createMattermostIngressMonitor({
     accountId,
     queue,
     dispatch,
+    dispatchInteraction,
     runtime,
     pollIntervalMs: 60_000,
     adoptionStallTimeoutMs: 5_000,
@@ -156,6 +175,77 @@ describe("Mattermost durable ingress", () => {
         expect(recoveredDispatch).toHaveBeenCalledTimes(1);
       } finally {
         await recovered.stop();
+      }
+    });
+  });
+
+  it("answers a recorded button click after the process that took it is gone", async () => {
+    await withQueue(async (queue) => {
+      const droppedClick = vi.fn(async (_interaction, lifecycle) => {
+        lifecycle.onDeferred();
+        return { kind: "deferred" } as const;
+      });
+      const accepted = startMonitor(queue, vi.fn(), "default", undefined, droppedClick);
+      await accepted.receiveInteraction(buttonClick({ eventId: "click-restart" }));
+      await accepted.waitForIdle();
+      // The click is durable, so losing this process cannot lose the press.
+      expect(await queue.listClaims()).toHaveLength(1);
+      await accepted.stop();
+
+      const replayed = vi.fn(async (_interaction, lifecycle) => {
+        await lifecycle.onAdopted();
+      });
+      const recovered = startMonitor(queue, vi.fn(), "default", undefined, replayed);
+      try {
+        await recovered.waitForIdle();
+        expect(replayed).toHaveBeenCalledTimes(1);
+        expect(replayed.mock.calls[0]?.[0]).toMatchObject({
+          eventId: "click-restart",
+          actionId: "approve",
+          postId: "post-1",
+        });
+      } finally {
+        await recovered.stop();
+      }
+    });
+  });
+
+  it("keeps a click in its channel's lane so it stays ordered behind that channel's posts", async () => {
+    await withQueue(async (queue) => {
+      const monitor = startMonitor(queue, vi.fn(), "default", undefined, async (_i, lifecycle) => {
+        lifecycle.onDeferred();
+        return { kind: "deferred" } as const;
+      });
+      try {
+        await monitor.receiveInteraction(
+          buttonClick({ eventId: "click-lane", channelId: "channel-raw" }),
+        );
+        await monitor.waitForIdle();
+        expect(await queue.listClaims()).toEqual([
+          expect.objectContaining({
+            id: "click-lane",
+            laneKey: "channel:channel-raw",
+            payload: expect.objectContaining({
+              interaction: expect.objectContaining({ actionId: "approve" }),
+            }),
+          }),
+        ]);
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+
+  it("surfaces a failed click append so the callback is never answered with success", async () => {
+    await withQueue(async (queue) => {
+      vi.spyOn(queue, "enqueue").mockRejectedValue(new Error("ingress storage unavailable"));
+      const monitor = startMonitor(queue, vi.fn());
+      try {
+        await expect(monitor.receiveInteraction(buttonClick())).rejects.toThrow(
+          "ingress storage unavailable",
+        );
+      } finally {
+        await monitor.stop();
       }
     });
   });

--- a/extensions/mattermost/src/mattermost/monitor-ingress.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-ingress.test.ts
@@ -550,6 +550,31 @@ describe("Mattermost durable ingress", () => {
     });
   });
 
+  it("dead-letters a stored row of an unrecognized shape without retry", async () => {
+    // A reader must treat a row it cannot name as permanently bad, not as work to
+    // retry. That is what keeps one unreadable row from holding up the lane's
+    // posts behind it, and it is the property a downgrade relies on when it meets
+    // a row a newer process wrote.
+    await withQueue(async (queue) => {
+      await queue.enqueue(
+        "row-unknown-shape",
+        { version: 1, receivedAt: 1 } as MattermostIngressPayload,
+        { receivedAt: 1, laneKey: "channel:channel-1" },
+      );
+      const dispatch = vi.fn();
+      const monitor = startMonitor(queue, dispatch);
+      try {
+        await monitor.waitForIdle();
+        expect(
+          (await queue.enqueue("row-unknown-shape", {} as MattermostIngressPayload)).kind,
+        ).toBe("failed");
+        expect(dispatch).not.toHaveBeenCalled();
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+
   it("dead-letters a persisted authorless post without using broadcast recipient identity", async () => {
     await withQueue(async (queue) => {
       await queue.enqueue(

--- a/extensions/mattermost/src/mattermost/monitor-ingress.ts
+++ b/extensions/mattermost/src/mattermost/monitor-ingress.ts
@@ -27,11 +27,28 @@ export type MattermostIngressLifecycle = {
   onAbandoned: () => void | Promise<void>;
 };
 
-type MattermostIngressPayload = {
-  version: 1;
-  receivedAt: number;
-  rawEvent: string;
+/** One durable unit of Mattermost inbound work: a socket event or a button click. */
+type MattermostIngressEvent =
+  | { kind: "posted"; rawEvent: string }
+  | { kind: "interaction"; interaction: MattermostIngressInteraction };
+
+/** The whole click, so replay needs no second lookup of a post the click already rewrote. */
+export type MattermostIngressInteraction = {
+  eventId: string;
+  channelId: string;
+  userId: string;
+  userName: string;
+  actionId: string;
+  actionName: string;
+  postId: string;
+  rootId?: string;
 };
+
+type MattermostIngressBody =
+  | { receivedAt: number; rawEvent: string }
+  | { receivedAt: number; interaction: MattermostIngressInteraction };
+
+type MattermostIngressPayload = { version: 1 } & MattermostIngressBody;
 
 export type MattermostIngressPost = MattermostPost & { user_id: string };
 
@@ -40,6 +57,11 @@ type MattermostIngressDispatchResult = ChannelIngressMonitorDeliveryResult;
 type MattermostIngressDispatch = (
   post: MattermostIngressPost,
   payload: MattermostEventPayload,
+  lifecycle: MattermostIngressLifecycle,
+) => Promise<MattermostIngressDispatchResult | void> | MattermostIngressDispatchResult | void;
+
+type MattermostIngressInteractionDispatch = (
+  interaction: MattermostIngressInteraction,
   lifecycle: MattermostIngressLifecycle,
 ) => Promise<MattermostIngressDispatchResult | void> | MattermostIngressDispatchResult | void;
 
@@ -87,7 +109,7 @@ function requiredString(value: unknown, field: string): string {
   );
 }
 
-function inspectMattermostIngressEvent(rawEvent: string): {
+function inspectMattermostPostedEvent(rawEvent: string): {
   eventId: string;
   laneKey: string;
 } | null {
@@ -111,6 +133,36 @@ function inspectMattermostIngressEvent(rawEvent: string): {
         ? data.channel_id.trim()
         : requiredString(broadcast?.channel_id, "channel_id");
   return { eventId, laneKey: `channel:${channelId}` };
+}
+
+function inspectMattermostIngressEvent(event: MattermostIngressEvent): {
+  eventId: string;
+  laneKey: string;
+} | null {
+  if (event.kind === "posted") {
+    return inspectMattermostPostedEvent(event.rawEvent);
+  }
+  const { eventId, channelId } = event.interaction;
+  // A click carries no field Mattermost guarantees unique per press, so admission
+  // mints the id. Sharing the posted lane keeps a click ordered behind the messages
+  // already queued for its channel.
+  return {
+    eventId: requiredString(eventId, "interaction.eventId"),
+    laneKey: `channel:${requiredString(channelId, "interaction.channelId")}`,
+  };
+}
+
+function parseClaimedInteraction(
+  interaction: MattermostIngressInteraction | undefined,
+  eventId: string,
+): MattermostIngressInteraction {
+  if (!interaction || interaction.eventId !== eventId || !interaction.channelId?.trim()) {
+    throw new MattermostIngressPermanentError(
+      "invalid-event",
+      `Mattermost ingress row ${eventId} has invalid interaction identity.`,
+    );
+  }
+  return interaction;
 }
 
 function parseClaimedEvent(
@@ -156,6 +208,7 @@ function resolveMattermostIngressNonRetryableFailure(error: unknown) {
 
 type MattermostIngressMonitor = {
   receive: (rawEvent: string) => Promise<void>;
+  receiveInteraction: (interaction: MattermostIngressInteraction) => Promise<void>;
   stop: () => Promise<void>;
   waitForIdle: () => Promise<void>;
 };
@@ -164,14 +217,15 @@ export function createMattermostIngressMonitor(options: {
   accountId: string;
   queue?: ChannelIngressQueue<MattermostIngressPayload>;
   dispatch: MattermostIngressDispatch;
+  dispatchInteraction: MattermostIngressInteractionDispatch;
   runtime: Pick<RuntimeEnv, "error" | "log">;
   pollIntervalMs?: number;
   adoptionStallTimeoutMs?: number;
   abortSignal?: AbortSignal;
 }): MattermostIngressMonitor {
   const monitor = createChannelIngressMonitor<
-    string,
-    Omit<MattermostIngressPayload, "version">,
+    MattermostIngressEvent,
+    MattermostIngressBody,
     MattermostIngressPayload
   >({
     queue:
@@ -180,15 +234,27 @@ export function createMattermostIngressMonitor(options: {
         getMattermostRuntime().state.openChannelIngressQueue<MattermostIngressPayload>({
           accountId: options.accountId,
         })),
-    inspect: (rawEvent) => inspectMattermostIngressEvent(rawEvent),
+    inspect: (event) => inspectMattermostIngressEvent(event),
     payload: {
+      // Posted rows keep their exact stored shape, so an upgrade never orphans the
+      // events a previous process already queued.
       version: MATTERMOST_INGRESS_PAYLOAD_VERSION,
-      serialize: (rawEvent, { receivedAt }) => ({ receivedAt, rawEvent }),
-      deserialize: (body) => body.rawEvent,
+      serialize: (event, { receivedAt }) =>
+        event.kind === "posted"
+          ? { receivedAt, rawEvent: event.rawEvent }
+          : { receivedAt, interaction: event.interaction },
+      deserialize: (body) =>
+        "rawEvent" in body
+          ? { kind: "posted", rawEvent: body.rawEvent }
+          : { kind: "interaction", interaction: body.interaction },
       encode: ({ body }) => ({ version: MATTERMOST_INGRESS_PAYLOAD_VERSION, ...body }),
+
       decode: (payload) => ({
         version: payload.version,
-        body: { receivedAt: payload.receivedAt, rawEvent: payload.rawEvent },
+        body:
+          "rawEvent" in payload
+            ? { receivedAt: payload.receivedAt, rawEvent: payload.rawEvent }
+            : { receivedAt: payload.receivedAt, interaction: payload.interaction },
       }),
       createClaimError: (kind, claim) =>
         new MattermostIngressPermanentError(
@@ -198,11 +264,18 @@ export function createMattermostIngressMonitor(options: {
             : `Mattermost ingress row ${claim.id} has invalid post identity.`,
         ),
     },
-    deliver: async (rawEvent, lifecycle, claim) => {
-      const { post, payload } = parseClaimedEvent(rawEvent, claim.id);
+    deliver: async (event, lifecycle, claim) => {
+      if (event.kind === "interaction") {
+        const interaction = parseClaimedInteraction(event.interaction, claim.id);
+        return await options.dispatchInteraction(interaction, lifecycle);
+      }
+      const { post, payload } = parseClaimedEvent(event.rawEvent, claim.id);
       return await options.dispatch(post, payload, lifecycle);
     },
     pollIntervalMs: options.pollIntervalMs ?? MATTERMOST_INGRESS_POLL_INTERVAL_MS,
+    // The interaction route outlives the socket during shutdown, so a click already
+    // being answered must still be recorded for the next process to replay.
+    admissionMode: "durable-after-stop",
     // Preserve Mattermost's existing one-drain-at-a-time delivery cycle.
     waitForDeliveryIdleBeforeRepump: true,
     retention: "standard",
@@ -221,9 +294,15 @@ export function createMattermostIngressMonitor(options: {
   monitor.start();
 
   return {
+    // A click has already been validated and is about to be answered; a failed
+    // append must reach the caller so the HTTP response reports the refusal
+    // instead of telling Mattermost the click was taken.
+    receiveInteraction: async (interaction) => {
+      await monitor.admit({ kind: "interaction", interaction });
+    },
     receive: async (rawEvent) => {
       try {
-        await monitor.admit(rawEvent);
+        await monitor.admit({ kind: "posted", rawEvent });
       } catch (error) {
         // Permanent shape errors cannot recover through a reconnect; record the drop and keep
         // reading. Storage failures still escape so the WebSocket exposes the outage.

--- a/extensions/mattermost/src/mattermost/monitor-ingress.ts
+++ b/extensions/mattermost/src/mattermost/monitor-ingress.ts
@@ -243,10 +243,22 @@ export function createMattermostIngressMonitor(options: {
         event.kind === "posted"
           ? { receivedAt, rawEvent: event.rawEvent }
           : { receivedAt, interaction: event.interaction },
-      deserialize: (body) =>
-        "rawEvent" in body
-          ? { kind: "posted", rawEvent: body.rawEvent }
-          : { kind: "interaction", interaction: body.interaction },
+      // Stored bytes become a typed event here, so a row naming neither shape is
+      // rejected now. Letting it through would surface later as a plain TypeError,
+      // which the drain reads as retryable — one unreadable row would then hold up
+      // every post queued behind it in the same lane.
+      deserialize: (body) => {
+        if ("rawEvent" in body) {
+          return { kind: "posted", rawEvent: body.rawEvent };
+        }
+        if (!("interaction" in body) || !isRecord(body.interaction)) {
+          throw new MattermostIngressPermanentError(
+            "invalid-event",
+            "Mattermost ingress row names neither a posted event nor an interaction.",
+          );
+        }
+        return { kind: "interaction", interaction: body.interaction };
+      },
       encode: ({ body }) => ({ version: MATTERMOST_INGRESS_PAYLOAD_VERSION, ...body }),
 
       decode: (payload) => ({

--- a/extensions/mattermost/src/mattermost/monitor-interactions.dispatch.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-interactions.dispatch.test.ts
@@ -103,12 +103,45 @@ describe("createMattermostInteractionDispatch", () => {
 
     const outcome = await createMattermostInteractionDispatch(monitor)(recordedClick, lifecycle);
 
+    // Route preparation may run first — it is a read. What must not happen is any
+    // agent-visible effect.
     expect(mocks.dispatch).not.toHaveBeenCalled();
     expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
-    expect(mocks.buildEventPlan).not.toHaveBeenCalled();
     // A refused click reached no turn, so it must settle instead of waiting for an
     // adoption that will never come.
     expect(outcome).toBe("dropped");
+  });
+
+  it("refuses a click whose sender loses access while its route is prepared", async () => {
+    // Authorization has to be the last thing before the enqueue and dispatch. Route
+    // preparation awaits a channel lookup, so a pairing or allowlist change can land
+    // inside that await; a check taken before it would already be stale.
+    const monitor = createMonitor();
+    mocks.buildEventPlan.mockImplementation(async () => {
+      mocks.authorize.mockResolvedValue({ ok: false, roomLabel: "#ops" });
+      return {
+        channelId: "channel-1",
+        channelDisplay: "Ops",
+        kind: "channel",
+        roomLabel: "#ops",
+        route: { agentId: "main", dmScope: "per-peer", sessionKey: "agent:main:mm" },
+        thread: { sessionKey: "agent:main:mm", effectiveReplyToId: undefined },
+        to: "channel:channel-1",
+        finalizeContext: (context: Record<string, unknown>) => context,
+        createReplyPlan: () => ({
+          replyOptions: {},
+          replyPipeline: {},
+          tableMode: "off",
+          textLimit: 4000,
+        }),
+      };
+    });
+
+    const outcome = await createMattermostInteractionDispatch(monitor)(recordedClick, lifecycle);
+
+    expect(outcome).toBe("dropped");
+    expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(mocks.dispatch).not.toHaveBeenCalled();
   });
 
   it("settles a click whose channel can no longer be routed", async () => {

--- a/extensions/mattermost/src/mattermost/monitor-interactions.dispatch.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-interactions.dispatch.test.ts
@@ -1,0 +1,153 @@
+// Mattermost tests cover replaying a recorded button click.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  authorize: vi.fn(),
+  buildEventPlan: vi.fn(),
+  deliverReply: vi.fn(),
+  dispatch: vi.fn(),
+  enqueueSystemEvent: vi.fn(),
+}));
+
+vi.mock("./monitor-auth.js", () => ({
+  authorizeMattermostCommandInvocation: mocks.authorize,
+}));
+
+vi.mock("./monitor-event-plan.js", () => ({
+  buildMattermostEventPlan: mocks.buildEventPlan,
+}));
+
+vi.mock("./reply-delivery.js", () => ({
+  deliverMattermostReplyPayload: mocks.deliverReply,
+}));
+
+import type {
+  MattermostIngressInteraction,
+  MattermostIngressLifecycle,
+} from "./monitor-ingress.js";
+import { createMattermostInteractionDispatch } from "./monitor-interactions.js";
+import type { MattermostMonitorContext } from "./monitor-types.js";
+
+const recordedClick: MattermostIngressInteraction = {
+  eventId: "click-1",
+  channelId: "channel-1",
+  userId: "user-1",
+  userName: "alice",
+  actionId: "approve",
+  actionName: "Approve",
+  postId: "post-1",
+};
+
+const lifecycle = {
+  abortSignal: new AbortController().signal,
+  onAdopted: vi.fn(),
+  onDeferred: vi.fn(),
+  onAdoptionFinalizing: vi.fn(),
+  onAbandoned: vi.fn(),
+} as unknown as MattermostIngressLifecycle;
+
+function createMonitor(): MattermostMonitorContext {
+  return {
+    account: { accountId: "default", config: {} },
+    cfg: {},
+    core: {
+      channel: {
+        commands: { shouldHandleTextCommands: vi.fn(() => true) },
+        inbound: { dispatch: mocks.dispatch },
+        text: { convertMarkdownTables: vi.fn((text: string) => text) },
+      },
+      system: { enqueueSystemEvent: mocks.enqueueSystemEvent },
+    },
+    pairing: { readAllowFromStore: vi.fn(async () => []) },
+    resources: { resolveChannelInfo: vi.fn(async () => ({ id: "channel-1", type: "O" })) },
+    runtime: { error: vi.fn(), log: vi.fn() },
+  } as unknown as MattermostMonitorContext;
+}
+
+describe("createMattermostInteractionDispatch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authorize.mockResolvedValue({
+      ok: true,
+      commandAuthorized: true,
+      channelInfo: { id: "channel-1", team_id: "team-1", type: "O" },
+      kind: "channel",
+      chatType: "channel",
+      channelName: "ops",
+      channelDisplay: "Ops",
+      roomLabel: "#ops",
+    });
+    mocks.buildEventPlan.mockResolvedValue({
+      channelId: "channel-1",
+      channelDisplay: "Ops",
+      kind: "channel",
+      roomLabel: "#ops",
+      route: { agentId: "main", dmScope: "per-peer", sessionKey: "agent:main:mm" },
+      thread: { sessionKey: "agent:main:mm", effectiveReplyToId: undefined },
+      to: "channel:channel-1",
+      finalizeContext: (context: Record<string, unknown>) => context,
+      createReplyPlan: () => ({
+        replyOptions: {},
+        replyPipeline: {},
+        tableMode: "off",
+        textLimit: 4000,
+      }),
+    });
+    mocks.dispatch.mockResolvedValue(undefined);
+  });
+
+  it("refuses a recorded click whose sender lost access after it was taken", async () => {
+    // The click was authorized when it was recorded; the allowlist has since narrowed.
+    mocks.authorize.mockResolvedValue({ ok: false, roomLabel: "#ops" });
+    const monitor = createMonitor();
+
+    const outcome = await createMattermostInteractionDispatch(monitor)(recordedClick, lifecycle);
+
+    expect(mocks.dispatch).not.toHaveBeenCalled();
+    expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(mocks.buildEventPlan).not.toHaveBeenCalled();
+    // A refused click reached no turn, so it must settle instead of waiting for an
+    // adoption that will never come.
+    expect(outcome).toBe("dropped");
+  });
+
+  it("settles a click whose channel can no longer be routed", async () => {
+    mocks.buildEventPlan.mockResolvedValue(undefined);
+    const monitor = createMonitor();
+
+    const outcome = await createMattermostInteractionDispatch(monitor)(recordedClick, lifecycle);
+
+    expect(mocks.dispatch).not.toHaveBeenCalled();
+    expect(outcome).toBe("dropped");
+  });
+
+  it("answers a recorded click whose sender still has access", async () => {
+    const monitor = createMonitor();
+
+    const outcome = await createMattermostInteractionDispatch(monitor)(recordedClick, lifecycle);
+
+    expect(outcome).toBe("dispatched");
+    expect(mocks.dispatch).toHaveBeenCalledOnce();
+    const dispatched = mocks.dispatch.mock.calls[0]?.[0] as {
+      ctxPayload?: Record<string, unknown>;
+    };
+    expect(dispatched.ctxPayload?.MessageSid).toBe("interaction:post-1:approve:click-1");
+    expect(dispatched.ctxPayload?.CommandAuthorized).toBe(false);
+  });
+
+  it("gives a second press of the same button its own inbound identity", async () => {
+    const monitor = createMonitor();
+    const dispatch = createMattermostInteractionDispatch(monitor);
+
+    await dispatch(recordedClick, lifecycle);
+    await dispatch({ ...recordedClick, eventId: "click-2" }, lifecycle);
+
+    const sids = mocks.dispatch.mock.calls.map(
+      ([params]) => (params as { ctxPayload?: Record<string, unknown> }).ctxPayload?.MessageSid,
+    );
+    expect(sids).toEqual([
+      "interaction:post-1:approve:click-1",
+      "interaction:post-1:approve:click-2",
+    ]);
+  });
+});

--- a/extensions/mattermost/src/mattermost/monitor-interactions.ts
+++ b/extensions/mattermost/src/mattermost/monitor-interactions.ts
@@ -1,5 +1,6 @@
 // Mattermost plugin module registers interactive callback transport handling.
 import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
+import { bindIngressLifecycleToReplyOptions } from "openclaw/plugin-sdk/channel-outbound";
 import { createMattermostInteractionHandler } from "./interactions.js";
 import { authorizeMattermostCommandInvocation } from "./monitor-auth.js";
 import {
@@ -7,6 +8,10 @@ import {
   resolveMattermostInteractionReplyRootId,
 } from "./monitor-context.js";
 import { buildMattermostEventPlan } from "./monitor-event-plan.js";
+import type {
+  MattermostIngressInteraction,
+  MattermostIngressLifecycle,
+} from "./monitor-ingress.js";
 import type { MattermostModelPickerInteractionHandler } from "./monitor-model-picker.js";
 import type { MattermostMonitorContext } from "./monitor-types.js";
 import { deliverMattermostReplyPayload } from "./reply-delivery.js";
@@ -14,15 +19,43 @@ import type { ReplyPayload } from "./runtime-api.js";
 import { registerPluginHttpRoute } from "./runtime-api.js";
 import { sendMessageMattermost } from "./send.js";
 
+/**
+ * Resolve whether this sender may act on this channel right now.
+ *
+ * The transport asks before recording a click and the drain asks again before the
+ * agent sees it: a recorded click carries no authority of its own, so a press taken
+ * before an allowlist narrowed must not still act after it.
+ */
+async function resolveMattermostInteractionAccess(
+  monitor: MattermostMonitorContext,
+  params: { senderId: string; senderName: string; channelId: string },
+) {
+  const { account, cfg, core, pairing, resources } = monitor;
+  return await authorizeMattermostCommandInvocation({
+    account,
+    cfg,
+    senderId: params.senderId,
+    senderName: params.senderName,
+    channelId: params.channelId,
+    channelInfo: await resources.resolveChannelInfo(params.channelId),
+    readStoreAllowFrom: pairing.readAllowFromStore,
+    allowTextCommands: core.channel.commands.shouldHandleTextCommands({
+      cfg,
+      surface: "mattermost",
+    }),
+    hasControlCommand: false,
+  });
+}
+
 export function registerMattermostInteractions(params: {
   monitor: MattermostMonitorContext;
   interactionPath: string;
   allowedSourceIps: string[];
   handleModelPickerInteraction: MattermostModelPickerInteractionHandler;
+  admitInteraction: (interaction: MattermostIngressInteraction) => Promise<void>;
 }): () => void {
   const { monitor } = params;
-  const { account, botUserId, cfg, client, core, pairing, resources, runtime } = monitor;
-  const { resolveChannelInfo } = resources;
+  const { account, botUserId, cfg, client, runtime } = monitor;
   return registerPluginHttpRoute({
     path: params.interactionPath,
     fallbackPath: "/mattermost/interactions/default",
@@ -36,21 +69,10 @@ export function registerMattermostInteractions(params: {
       allowRealIpFallback: cfg.gateway?.allowRealIpFallback === true,
       handleInteraction: params.handleModelPickerInteraction,
       authorizeButtonClick: async ({ payload, post }) => {
-        const channelInfo = await resolveChannelInfo(payload.channel_id);
-        const allowTextCommands = core.channel.commands.shouldHandleTextCommands({
-          cfg,
-          surface: "mattermost",
-        });
-        const decision = await authorizeMattermostCommandInvocation({
-          account,
-          cfg,
+        const decision = await resolveMattermostInteractionAccess(monitor, {
           senderId: payload.user_id,
           senderName: payload.user_name ?? "",
           channelId: payload.channel_id,
-          channelInfo,
-          readStoreAllowFrom: pairing.readAllowFromStore,
-          allowTextCommands,
-          hasControlCommand: false,
         });
         if (decision.ok) {
           return { ok: true };
@@ -66,97 +88,7 @@ export function registerMattermostInteractions(params: {
           },
         };
       },
-      resolveSessionKey: async ({ channelId, userId, post }) => {
-        const eventPlan = await buildMattermostEventPlan(monitor, {
-          channelId,
-          senderId: userId,
-          postId: post.id,
-          threadRootId: post.root_id,
-          dropLabel: "interaction session event",
-        });
-        if (!eventPlan) {
-          throw new Error("Mattermost channel type could not be resolved");
-        }
-        return eventPlan.thread.sessionKey;
-      },
-      dispatchButtonClick: async (button) => {
-        const sourcePostId = button.post.id || button.postId;
-        const interactionMessageSid = buildMattermostButtonInteractionMessageSid({
-          postId: button.postId,
-          actionId: button.actionId,
-        });
-        const eventPlan = await buildMattermostEventPlan(monitor, {
-          channelId: button.channelId,
-          senderId: button.userId,
-          postId: sourcePostId,
-          threadRootId: button.post.root_id,
-          dropLabel: "interaction dispatch",
-        });
-        if (!eventPlan) {
-          return;
-        }
-        const { channelDisplay, channelId, kind, route, thread, to } = eventPlan;
-        const bodyText = `[Button click: user @${button.userName} selected "${button.actionName}"]`;
-        const ctxPayload = eventPlan.finalizeContext({
-          Body: bodyText,
-          BodyForAgent: bodyText,
-          RawBody: bodyText,
-          CommandBody: bodyText,
-          ConversationLabel: `mattermost:${button.userName}`,
-          GroupSubject: kind !== "direct" ? channelDisplay || button.channelId : undefined,
-          SenderName: button.userName,
-          MessageSid: interactionMessageSid,
-          WasMentioned: true,
-          CommandAuthorized: false,
-        });
-        const { replyOptions, replyPipeline, tableMode, textLimit } = eventPlan.createReplyPlan();
-        await core.channel.inbound.dispatch({
-          cfg,
-          channel: "mattermost",
-          accountId: account.accountId,
-          route: {
-            agentId: route.agentId,
-            dmScope: route.dmScope,
-            sessionKey: thread.sessionKey,
-          },
-          ctxPayload,
-          delivery: {
-            observeMessageSent: true,
-            deliver: async (payload: ReplyPayload) => {
-              const result = await deliverMattermostReplyPayload({
-                core,
-                cfg,
-                payload,
-                channelId,
-                accountId: account.accountId,
-                agentId: route.agentId,
-                replyToId: resolveMattermostInteractionReplyRootId({
-                  kind,
-                  threadRootId: thread.effectiveReplyToId,
-                  replyToId: payload.replyToId,
-                  interactionMessageSid,
-                  sourcePostId,
-                }),
-                textLimit,
-                tableMode,
-                sendMessage: sendMessageMattermost,
-              });
-              if (result.visibleReplySent) {
-                runtime.log?.(`delivered button-click reply to ${to}`);
-              }
-              return result;
-            },
-            onError: (err, info) => {
-              runtime.error?.(`mattermost button-click ${info.kind} reply failed: ${String(err)}`);
-            },
-          },
-          replyPipeline,
-          dispatcherOptions: {
-            humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
-          },
-          replyOptions,
-        });
-      },
+      admitInteraction: params.admitInteraction,
       log: (message) => runtime.log?.(message),
     }),
     pluginId: "mattermost",
@@ -165,4 +97,123 @@ export function registerMattermostInteractions(params: {
     log: (message: string) => runtime.log?.(message),
     throwOnFailure: true,
   });
+}
+
+/** Whether a recorded click was handed to a turn, or settled without reaching one. */
+export type MattermostInteractionDispatchOutcome = "dispatched" | "dropped";
+
+/**
+ * Answer a recorded button click.
+ *
+ * The transport records the click and returns; this runs from the durable drain,
+ * so a restart, a crash, or a throwing turn replays it instead of losing it.
+ */
+export function createMattermostInteractionDispatch(
+  monitor: MattermostMonitorContext,
+): (
+  interaction: MattermostIngressInteraction,
+  turnAdoptionLifecycle: MattermostIngressLifecycle,
+) => Promise<MattermostInteractionDispatchOutcome> {
+  const { account, cfg, core, runtime } = monitor;
+  return async (interaction, turnAdoptionLifecycle) => {
+    // A stored click is evidence that a press happened, never a standing grant.
+    const access = await resolveMattermostInteractionAccess(monitor, {
+      senderId: interaction.userId,
+      senderName: interaction.userName,
+      channelId: interaction.channelId,
+    });
+    if (!access.ok) {
+      runtime.log?.(
+        `mattermost: dropping recorded button click for ${interaction.userName} (${access.roomLabel})`,
+      );
+      return "dropped";
+    }
+    const interactionMessageSid = buildMattermostButtonInteractionMessageSid({
+      postId: interaction.postId,
+      actionId: interaction.actionId,
+      eventId: interaction.eventId,
+    });
+    const eventPlan = await buildMattermostEventPlan(monitor, {
+      channelId: interaction.channelId,
+      senderId: interaction.userId,
+      postId: interaction.postId,
+      threadRootId: interaction.rootId,
+      dropLabel: "interaction dispatch",
+    });
+    if (!eventPlan) {
+      return "dropped";
+    }
+    const { channelDisplay, channelId, kind, route, thread, to } = eventPlan;
+    core.system.enqueueSystemEvent(
+      `Mattermost button click: action="${interaction.actionId}" ` +
+        `by ${interaction.userName} in channel ${interaction.channelId}`,
+      { sessionKey: thread.sessionKey, contextKey: `mattermost:${interactionMessageSid}` },
+    );
+    const bodyText = `[Button click: user @${interaction.userName} selected "${interaction.actionName}"]`;
+    const ctxPayload = eventPlan.finalizeContext({
+      Body: bodyText,
+      BodyForAgent: bodyText,
+      RawBody: bodyText,
+      CommandBody: bodyText,
+      ConversationLabel: `mattermost:${interaction.userName}`,
+      GroupSubject: kind !== "direct" ? channelDisplay || interaction.channelId : undefined,
+      SenderName: interaction.userName,
+      MessageSid: interactionMessageSid,
+      WasMentioned: true,
+      CommandAuthorized: false,
+    });
+    const { replyOptions, replyPipeline, tableMode, textLimit } = eventPlan.createReplyPlan();
+    await core.channel.inbound.dispatch({
+      cfg,
+      channel: "mattermost",
+      accountId: account.accountId,
+      route: {
+        agentId: route.agentId,
+        dmScope: route.dmScope,
+        sessionKey: thread.sessionKey,
+      },
+      ctxPayload,
+      delivery: {
+        observeMessageSent: true,
+        deliver: async (payload: ReplyPayload) => {
+          const result = await deliverMattermostReplyPayload({
+            core,
+            cfg,
+            payload,
+            channelId,
+            accountId: account.accountId,
+            agentId: route.agentId,
+            replyToId: resolveMattermostInteractionReplyRootId({
+              kind,
+              threadRootId: thread.effectiveReplyToId,
+              replyToId: payload.replyToId,
+              interactionMessageSid,
+              sourcePostId: interaction.postId,
+            }),
+            textLimit,
+            tableMode,
+            sendMessage: sendMessageMattermost,
+          });
+          if (result.visibleReplySent) {
+            runtime.log?.(`delivered button-click reply to ${to}`);
+          }
+          return result;
+        },
+        onError: (err, info) => {
+          runtime.error?.(`mattermost button-click ${info.kind} reply failed: ${String(err)}`);
+        },
+      },
+      replyPipeline,
+      dispatcherOptions: {
+        humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+      },
+      // The claim belongs to the drain until the turn adopts it, so an interrupted
+      // click is replayed rather than completed by having merely been started.
+      replyOptions: {
+        ...replyOptions,
+        ...bindIngressLifecycleToReplyOptions(turnAdoptionLifecycle),
+      },
+    });
+    return "dispatched";
+  };
 }

--- a/extensions/mattermost/src/mattermost/monitor-interactions.ts
+++ b/extensions/mattermost/src/mattermost/monitor-interactions.ts
@@ -116,7 +116,22 @@ export function createMattermostInteractionDispatch(
 ) => Promise<MattermostInteractionDispatchOutcome> {
   const { account, cfg, core, runtime } = monitor;
   return async (interaction, turnAdoptionLifecycle) => {
+    // Route preparation only reads transport metadata and produces nothing the
+    // agent can see, so it runs first. That leaves no await between the
+    // authorization below and the effects it guards.
+    const eventPlan = await buildMattermostEventPlan(monitor, {
+      channelId: interaction.channelId,
+      senderId: interaction.userId,
+      postId: interaction.postId,
+      threadRootId: interaction.rootId,
+      dropLabel: "interaction dispatch",
+    });
+    if (!eventPlan) {
+      return "dropped";
+    }
     // A stored click is evidence that a press happened, never a standing grant.
+    // Resolved here rather than before the route so a pairing or allowlist change
+    // during preparation cannot reach the enqueue and dispatch below.
     const access = await resolveMattermostInteractionAccess(monitor, {
       senderId: interaction.userId,
       senderName: interaction.userName,
@@ -133,16 +148,6 @@ export function createMattermostInteractionDispatch(
       actionId: interaction.actionId,
       eventId: interaction.eventId,
     });
-    const eventPlan = await buildMattermostEventPlan(monitor, {
-      channelId: interaction.channelId,
-      senderId: interaction.userId,
-      postId: interaction.postId,
-      threadRootId: interaction.rootId,
-      dropLabel: "interaction dispatch",
-    });
-    if (!eventPlan) {
-      return "dropped";
-    }
     const { channelDisplay, channelId, kind, route, thread, to } = eventPlan;
     core.system.enqueueSystemEvent(
       `Mattermost button click: action="${interaction.actionId}" ` +

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -185,10 +185,20 @@ describe("resolveMattermostInteractionReplyRootId", () => {
   const interactionMessageSid = buildMattermostButtonInteractionMessageSid({
     postId: "source-post-123",
     actionId: "approve",
+    eventId: "click-1",
   });
 
-  it("keeps the established synthetic event identity", () => {
-    expect(interactionMessageSid).toBe("interaction:source-post-123:approve");
+  it("gives each press of one button its own synthetic event identity", () => {
+    // Shared inbound dedupe keys on this value, so two legitimate presses of the same
+    // button must not collapse into one turn.
+    expect(interactionMessageSid).toBe("interaction:source-post-123:approve:click-1");
+    expect(
+      buildMattermostButtonInteractionMessageSid({
+        postId: "source-post-123",
+        actionId: "approve",
+        eventId: "click-2",
+      }),
+    ).not.toBe(interactionMessageSid);
   });
 
   it("maps reply-to-current from the synthetic interaction id to the provider post", () => {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -25,7 +25,10 @@ import {
   type MattermostIngressLifecycle,
   type MattermostIngressPost,
 } from "./monitor-ingress.js";
-import { registerMattermostInteractions } from "./monitor-interactions.js";
+import {
+  createMattermostInteractionDispatch,
+  registerMattermostInteractions,
+} from "./monitor-interactions.js";
 import { createMattermostModelPickerInteractionHandler } from "./monitor-model-picker.js";
 import { createMattermostPostHandler } from "./monitor-posts.js";
 import { createMattermostReactionHandler } from "./monitor-reactions.js";
@@ -214,29 +217,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     logVerboseMessage,
     statusSink: opts.statusSink,
   };
-  const unregisterInteractions = registerMattermostInteractions({
-    monitor,
-    interactionPath,
-    allowedSourceIps:
-      allowedInteractionSourceIps.length > 0 ? allowedInteractionSourceIps : ["127.0.0.1", "::1"],
-    handleModelPickerInteraction: createMattermostModelPickerInteractionHandler(monitor),
-  });
-  try {
-    await registerMattermostMonitorSlashCommands({
-      client,
-      cfg,
-      runtime,
-      account,
-      baseUrl,
-      botUserId,
-    });
-  } catch (error) {
-    // The callback route must exist before remote slash setup, but not outlive failed startup.
-    unregisterInteractions();
-    throw error;
-  }
-  const slashEnabled = getSlashCommandState(account.accountId) != null;
   const handlePost = createMattermostPostHandler(monitor);
+  const dispatchInteraction = createMattermostInteractionDispatch(monitor);
   const handleReactionEvent = createMattermostReactionHandler(monitor);
 
   const debouncer = core.channel.debounce.createInboundDebouncer<{
@@ -321,7 +303,39 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       await debouncer.enqueue({ post, payload, turnAdoptionLifecycle });
       return { kind: "deferred" };
     },
+    dispatchInteraction: async (interaction, turnAdoptionLifecycle) => {
+      // Same contract as a post: the turn's adoption settles the claim, so a click
+      // that never reached adoption is still there for the next process. A refused or
+      // unroutable click reached no turn and is finished, so it settles here instead
+      // of waiting for an adoption that will never come.
+      const outcome = await dispatchInteraction(interaction, turnAdoptionLifecycle);
+      return outcome === "dispatched" ? { kind: "deferred" } : { kind: "completed" };
+    },
   });
+  const unregisterInteractions = registerMattermostInteractions({
+    monitor,
+    interactionPath,
+    allowedSourceIps:
+      allowedInteractionSourceIps.length > 0 ? allowedInteractionSourceIps : ["127.0.0.1", "::1"],
+    handleModelPickerInteraction: createMattermostModelPickerInteractionHandler(monitor),
+    admitInteraction: ingress.receiveInteraction,
+  });
+  try {
+    await registerMattermostMonitorSlashCommands({
+      client,
+      cfg,
+      runtime,
+      account,
+      baseUrl,
+      botUserId,
+    });
+  } catch (error) {
+    // The callback route must exist before remote slash setup, but not outlive failed startup.
+    unregisterInteractions();
+    await ingress.stop();
+    throw error;
+  }
+  const slashEnabled = getSlashCommandState(account.accountId) != null;
   let sequence = 1;
   const connectOnce = createMattermostConnectOnce({
     wsUrl: `${baseUrl.replace(/^http/i, "ws")}/api/v4/websocket`,


### PR DESCRIPTION
Fixes #132840.

## What Problem This Solves

A Mattermost interactive button click is answered with HTTP 200 and then handled entirely from process memory. Mattermost treats that response as final and never redelivers, so a gateway restart, a crash, or a throwing handler after the 200 loses the click with no record anywhere — while the post is rewritten to `✓ **Approve** selected by @user`, telling the user it was taken.

On `main`, `createMattermostInteractionHandler` validates the click, then:

- puts it in the in-memory system-event queue (`interactions.ts:629`), which is documented as non-persistent, capped, and cleared on restart,
- answers `200 {}` (`interactions.ts:654`),
- and only then calls `dispatchButtonClick` (`interactions.ts:661`) inside a swallowed `try/catch`, so a throwing turn is lost behind an already-sent success.

The Mattermost durable ingress (`monitor-ingress.ts`) admitted only `posted` WebSocket events, so a click had no durable row at any point. Interactive buttons are default-on whenever Mattermost is enabled.

## Why This Change Was Made

The click now follows the same admit-then-answer contract the channel already uses for messages, owned by the same durable ingress:

- **`monitor-ingress.ts`** admits a second kind of inbound work. Its raw event became `{ kind: "posted", rawEvent }` | `{ kind: "interaction", interaction }`, and the stored payload became a discriminated body. Posted rows keep their exact stored shape and version, so an upgrade never orphans events a previous process already queued. A click shares its channel's lane, so it stays ordered behind that channel's messages.
- **`interactions.ts`** records the click before anything reports success, and answers `500` if it cannot — leaving the buttons clickable rather than claiming a press that no longer exists. The completion update and the 200 now happen only after the click is recoverable. The transport no longer dispatches, resolves session keys, or enqueues system events; that code left the handler (net −29 lines there).
- **`monitor-interactions.ts`** owns `createMattermostInteractionDispatch`, the drain-side answer to a recorded click. It carries the drain's lifecycle through the canonical `bindIngressLifecycleToReplyOptions`, so the claim settles on turn adoption exactly like a post, and the system-event enqueue that used to be swallowed now shares that one owner.
- **`monitor.ts`** builds the ingress before registering the callback route so the route can admit into it, and stops it on the failed-startup path that previously only unregistered the route.

Because a click has no field Mattermost guarantees unique per press, admission mints the id — the same choice the Slack repair made for interactive payloads. Keying on `post + action` would silently swallow a second, legitimate press after a failed completion update. That id also enters the synthetic inbound `MessageSid`, so shared inbound dedupe cannot fold a second press back into the first one layer below the queue. The record carries the whole click (channel, user, action, post, thread root), so replay needs no second lookup of a post the click itself already rewrote.

**A recorded click carries no authority of its own.** `resolveMattermostInteractionAccess` is now the one owner of that decision: the transport asks it before recording a press, and the drain asks it again immediately before the agent sees one. A click accepted while a sender was allowed, and replayed after the allowlist narrowed, is dropped with a recorded reason instead of acting on stale policy — the same closure-bound rule the Gateway applies to delegated run authority. The extraction also removes the duplicate the inline callback held.

A refused click is also *finished*, not parked. The dispatch reports whether it reached a turn, so a click that was refused or whose channel can no longer be routed settles its claim instead of waiting for an adoption that will never come. Live testing caught this: an earlier revision left the refused row `claimed` forever.

`admissionMode: "durable-after-stop"` covers shutdown: the interaction route outlives the socket, so a click already being answered is still recorded for the next process.

Production LOC: +312 / −200 (net +112), of which the transport handler is net negative and roughly 85 of the additions are the dispatch block moved out of the HTTP callback. The genuinely new surface is the second durable event kind in the ingress owner — the queue had exactly one kind, so nothing existing could absorb it — plus the authorization owner the replay path needs. That last piece is a security invariant that cannot be expressed more cheaply: without it a durable click is a bearer token.

## User Impact

An accepted button click survives the process that accepted it. If the gateway restarts or crashes before the click's turn is adopted, the next process replays it instead of dropping it; a throwing dispatch now spends the drain's retry budget instead of disappearing behind a success response. If the click cannot be recorded at all, Mattermost is told so and the buttons stay live.

Behavior for a healthy click is unchanged: same completion update, same reply, same session and threading.

## Evidence

Live Mattermost server (`mattermost/mattermost-team-edition` + Postgres in Docker), a bot account, an isolated Gateway (`OPENCLAW_STATE_DIR`, own port, own auth token), and a local mock model provider. Buttons were posted through the real `message send` path; clicks were made with `POST /api/v4/posts/{post}/actions/{action}`, so Mattermost itself called the gateway's interaction callback. Identical scenario on both builds, each on a fresh state directory.

**Before, on `origin/main`.** Click accepted, post rewritten — and no durable record exists:

```
$ curl -X POST .../posts/$POST/actions/beforeok
{"status":"OK","trigger_id":"fn5356wo438rpmfspag4996dde"}

post attachment: ['✓ **Approve** selected by @ocadmin']

sqlite> select event_id, status, attempts from channel_ingress_events;
   ('1raawa5967gd9bttmyxpf56r5a', 'completed', 0)     # the posted message
   ('t44nb5j7wiyeifdw475uadu4kh', 'completed', 0)     # the posted message
                                                      # <- nothing for the click
```

After `kill -9` and a restart, the click leaves no trace at all and is never answered:

```
$ grep -ciE "beforeok|interaction:" gateway-after-restart.log
0
```

**After, on this branch** (re-run against commit `d350402d2a0`, whose `extensions/mattermost` tree is byte-identical to the current head — the later rebase only moved the base, `git diff d350402d2a0 <head> -- extensions/mattermost` is empty). The same click, clicked while another turn held the channel's lane so the press had not yet been adopted:

```
$ curl -X POST .../posts/$POST/actions/headok
{"status":"OK","trigger_id":"nazwk68ybjyudppbsxmy6wzcsw"}

post attachment: ['✓ **Approve** selected by @ocadmin']

sqlite> select event_id, status, claim_owner is not null, attempts from channel_ingress_events;
   ('kaiceozdqpdw8pip9ruecepygw', 'completed', 0, 0)              # the button post
   ('6ahc1zuc1ff9pbyq7kwsi37gby', 'completed', 0, 0)              # the lane-holding message
   ('f1acfdde-ddb9-46f9-bc2a-8cc4301295fc', 'claimed', 1, 0)      # the click, held by the drain
```

`kill -9`, then restart: the row survives, the drain re-dispatches the click with no second press, and the replayed inbound identity carries the recorded event id:

```
sqlite> ('f1acfdde-ddb9-46f9-bc2a-8cc4301295fc', 'pending', 6)

messageId=interaction:kaiceozdqpdw8pip9ruecepygw:headok:f1acfdde-ddb9-46f9-bc2a-8cc4301295fc
```

The still-authorized sender is not dropped by the replay-time access check (`grep -c "dropping recorded button click"` = 0), and a healthy click on the same head answers end to end:

```
--- bot 'Head happy: approve?...' | ['✓ **Approve** selected by @ocadmin']
--- bot  <agent reply to the click>
```

**Revocation, on the same head.** The click is taken while its sender is on the allowlist, held at `claimed` behind another turn, then the gateway is killed, the sender is removed from `groupAllowFrom`, and the gateway restarts:

```
sqlite> ('b35e635c-7295-43c5-b43e-755ead216630', 'claimed')     # before revocation

$ grep -c "dropping recorded button click" gateway-after-restart.log
1
   mattermost: dropping recorded button click for ocadmin (#oc-test)

$ grep -c "messageId=interaction:" gateway-after-restart.log
0                                                                # never reached the agent

sqlite> ('b35e635c-7295-43c5-b43e-755ead216630', 'completed', 1) # settled, not parked
```

The same scenario with the sender left on the allowlist replays normally on that head — `dropping` count `0`, and the click reaches the agent carrying its recorded id:

```
messageId=interaction:yppdyof7b7d1igw5pxcqsrxjye:keepok:f61e8dbb-a1d0-4a72-b8cb-9c37c26045d0
```

**Control, same branch, plain message instead of a click.** A posted message queued behind the same held turn, killed and restarted the same way, ends in the same state (`pending`, retrying, same adoption contention against main-session restart recovery). The click now behaves exactly like a message rather than getting semantics of its own; the post-restart retry friction after a hard kill is shared with the existing message path, not introduced here.

Regression tests (`node scripts/run-vitest.mjs extensions/mattermost`):

- `answers a recorded button click after the process that took it is gone` — admits a click whose dispatch never adopts, stops that monitor, starts a fresh one over the same SQLite queue, and asserts the click is dispatched exactly once with its action and post intact.
- `keeps a click in its channel's lane so it stays ordered behind that channel's posts`.
- `surfaces a failed click append so the callback is never answered with success`.
- `records the whole click, with its thread root, before answering Mattermost` — asserts the ordering (`["admitted", "post-updated"]`), so nothing can claim the click was taken before it is recoverable.
- `gives every click its own record so a repeated press is not swallowed`.
- `refuses the click when it cannot be recorded instead of reporting success` — 500, and no completion `PUT`.
- `refuses a recorded click whose sender lost access after it was taken` — no dispatch, no system event, no event plan built. Against a dispatch without the recheck it fails with `expected "vi.fn()" to not be called at all, but actually been called 1 times`.
- `gives a second press of the same button its own inbound identity` — two presses dispatch as `interaction:post-1:approve:click-1` and `…:click-2`.
- `settles a click whose channel can no longer be routed` — reports `dropped` so the claim does not wait on a turn that never starts.

The two tests that asserted the old inline dispatch were removed rather than updated: that behavior is gone.

```
$ node scripts/run-vitest.mjs extensions/mattermost
 Test Files  54 passed (54)
      Tests  841 passed (841)

$ node scripts/check-changed.mjs        # exit 0
  conflict markers · max-lines ratchet · assertion SAFETY ratchet · coercion helper guard
  · format changed files · deprecated API usage · plugin boundaries · dead export scan
  · typecheck extensions · typecheck extension tests · lint extension changed files
  · database-first legacy-store guard · runtime import cycles

$ pnpm build                            # no [INEFFECTIVE_DYNAMIC_IMPORT]
```

**Review round: the two P1 findings.**

*Authorization could go stale during route preparation.* The drain authorized the sender and then awaited event-plan construction — a channel lookup that reaches the Mattermost API on a cache miss — before the system-event enqueue and the inbound dispatch. A revocation landing inside that await still reached the agent. Route preparation only reads transport metadata and produces nothing the agent can see, so it now runs first and authorization is the last step before those effects: no await separates the check from what it guards.

Red/green, original order restored and the test left unchanged:

```
× refuses a click whose sender loses access while its route is prepared
  AssertionError: expected 'dispatched' to be 'dropped'
```

Restored: 5 passed. One existing assertion moved from `buildEventPlan` not being called to no agent-visible effect having happened, because the first was pinning the call order this change deliberately reverses.

*Stored-shape compatibility was measured rather than redesigned.* Instead of reasoning about the prior reader, it was run: `origin/main`'s `monitor-ingress.ts` and its test file were checked out and handed a row in the new interaction shape.

```
readback.kind         = failed    # dead-lettered, not retried
dispatch calls        = 0         # never mistaken for a posted event
later post dispatched = true      # the lane keeps draining behind it
```

The path it takes: the prior `deserialize` returns `body.rawEvent` (undefined) → `parseRawObject` throws `MattermostIngressPermanentError` (`monitor-ingress.ts:50-65`) → `resolveMattermostIngressNonRetryableFailure` classifies that as non-retryable (same file, 147-155) → the row is dropped and its lane keeps draining. A downgrade therefore loses that one click — which is what main does with every click today, since main holds clicks in memory only. No queue poisoning and no regression against current behaviour, so the stored shape is left as it is.

*Proving that surfaced a real defect in this branch.* A stored row naming neither shape produced `{ kind: "interaction", interaction: undefined }`, and `inspectMattermostIngressEvent` destructured it — a plain `TypeError`, which the drain reads as retryable. One such row would retry forever and hold up every post queued behind it in the same lane. The existing malformed-payload test missed this because a broken `rawEvent` takes the posted branch and throws the permanent error correctly. The row is now rejected at `deserialize`, the boundary where stored bytes become a typed event, so it dead-letters like every other unreadable row:

```
# guard removed
 × dead-letters a stored row of an unrecognized shape without retry
   AssertionError: expected 'pending' to be 'failed'
# restored
 Tests  20 passed (20)
```

**Re-run after those fixes**, on Windows / Node 24:

```
extension-mattermost project      846 passed | 1 failed (847)
```

The single failure is `model-picker.test.ts` failing its temp-directory cleanup with `EPERM ... syscall: 'rm'`; it touches none of these paths and reproduces without this branch on the same machine. Both tsgo lanes (`tsconfig.extensions.json`, `test/tsconfig/tsconfig.extensions.test.json`) report no errors, `oxlint` no findings, `oxfmt --check` clean on the four touched files, and both ratchets (`check:assertion-safety`, `check:max-lines-ratchet`) pass against `origin/main`.

## Follow-up found while building the rig

`extensions/mattermost/src/normalize.ts:24` drops every presentation button that uses the modern `action` field and renders only the deprecated `value` form, so `ask_user` prompts reach Mattermost as plain text with no buttons. Out of scope here — this PR is about clicks that do reach the server — but it is a real gap worth its own issue, and it is why the evidence above uses `value` buttons.

