### PR TITLE
fix: keep upgrade survival fixtures idle during service restarts

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/config-recipe.mts
+++ b/scripts/e2e/lib/upgrade-survivor/config-recipe.mts
@@ -132,6 +132,8 @@ function configSetJsonFile(
 
 const representativeConfigSteps: ConfigStep[] = [
   configSetJsonFile("models-openai", "models", "models.providers.openai", "models-openai.json"),
+  // Keep the migration specimen idle while baseline and candidate services run:
+  // a heartbeat refreshes its skills snapshot before inference, even when auth fails.
   configSetJsonFile("agents", "agents", "agents", "agents.json"),
   configSetJsonFile("skills", "skills", "skills", "skills.json"),
   configSetJsonFile("plugins", "plugins", "plugins", "plugins.json"),

--- a/scripts/e2e/lib/upgrade-survivor/config-recipe/agents.json
+++ b/scripts/e2e/lib/upgrade-survivor/config-recipe/agents.json
@@ -3,7 +3,10 @@
     "model": {
       "primary": "openai/gpt-5.5"
     },
-    "contextTokens": 64000
+    "contextTokens": 64000,
+    "heartbeat": {
+      "every": "0m"
+    }
   },
   "list": [
     {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where upgrade-survivor verification can report lost session metadata when the running baseline refreshes the seeded skills cache before migration. The failing update/restart/auth run contained an intervening main-session inference failure; snapshot preparation persists its refresh before provider authentication, so failed inference can still change this specimen. The original log did not capture the wake trigger.

## Why This Change Was Made

Disable periodic heartbeat in the shared authored upgrade fixture using the existing `every: "0m"` contract. The fixture remains idle across baseline startup and service replacement, while explicit cron jobs and agent calls remain enabled. Keep every migration assertion, timeout, plugin check, and update/restart step unchanged. No product configuration surface, persistence logic, or schema changes.

## User Impact

No runtime behavior change. Release verification isolates state preservation from unrelated background cache refreshes. All survivor scenarios share this specimen; the SQLite-volume scenario also checks it after Gateway restart.

## Evidence

The prior failure is [update/restart/auth job 99223457333](https://github.com/openclaw/openclaw/actions/runs/33298680030/job/99223457333). With the fixture change, the complete original-order Docker scenario passed from `openclaw@2026.7.1-2` to candidate `1084faf4371b08bd16573872a68565b558bff780`, using trusted harness `81d7f54399cae9dbf792f82688d6396424884c2d` plus this isolated fixture delta. Blacksmith Testbox `tbx_01m198yarhfpkrv34pm9xcgntx`; 8m12s including package build. Baseline startup18s, update-owned recovery restart52s, health/readiness/status1s each.

Read-only stage observations retained the same prompt hash through baseline service startup, package update, and Doctor migration into SQLite. Session/transcript preservation, plugin artifact audits, supervisor replacement, and authenticated Gateway probes all passed. Existing Doctor coverage also verifies that `0m` remains a disabled monitor during migration. Independent autoreview found no actionable issues. Production delta0; fixture/comment delta+5 lines.

Local changed-file validation passed formatting, erasability, dependency and structural guards, then stopped on the existing shared-checkout `pako` declaration mismatch in `ui/vite.config.ts`. No dependency or type workaround was applied. Exact-head isolated CI remains required before landing.
