### PR TITLE
perf(sqlite): narrow schema metadata and reuse index fingerprints

### DIFF
--- a/src/infra/sqlite-schema-contract.ts
+++ b/src/infra/sqlite-schema-contract.ts
@@ -138,8 +138,14 @@ export function collectSqliteSchemaIssues(
         !allowedMissingTables.has(tableName),
       ),
     );
+    const actualIndexFingerprints = new Set(
+      actualTable.indexes.map((index) => JSON.stringify(index)),
+    );
+    const expectedIndexFingerprints = new Set(
+      expectedTable.indexes.map((index) => JSON.stringify(index)),
+    );
     for (const expectedIndex of expectedTable.indexes) {
-      if (!actualTable.indexes.some((actualIndex) => isEqual(actualIndex, expectedIndex))) {
+      if (!actualIndexFingerprints.has(JSON.stringify(expectedIndex))) {
         const objectName = expectedIndex.name ?? tableName;
         const namedIndexPresent = expectedIndex.name
           ? actualTable.indexes.some((actualIndex) => actualIndex.name === expectedIndex.name)
@@ -159,10 +165,7 @@ export function collectSqliteSchemaIssues(
       }
     }
     for (const actualIndex of actualTable.indexes) {
-      if (
-        actualIndex.unique === 1 &&
-        !expectedTable.indexes.some((expectedIndex) => isEqual(actualIndex, expectedIndex))
-      ) {
+      if (actualIndex.unique === 1 && !expectedIndexFingerprints.has(JSON.stringify(actualIndex))) {
         const objectName = actualIndex.name ?? tableName;
         add(
           "unexpected-unique-index",
@@ -404,9 +407,9 @@ function collectSqliteTableContract(
   }
 
   const quotedTable = quoteSqliteIdentifier(tableName);
-  const tableList = (database.prepare("PRAGMA table_list").all() as SqliteTableListRow[]).find(
-    (entry) => entry.name === tableName,
-  );
+  const tableList = (
+    database.prepare(`PRAGMA table_list(${quotedTable})`).all() as SqliteTableListRow[]
+  ).find((entry) => entry.name === tableName);
   if (!tableList) {
     throw new Error(`Could not inspect SQLite table options for ${tableName}.`);
   }


### PR DESCRIPTION
Schema validation repeatedly asked SQLite for every table's metadata while inspecting one table, then repeatedly serialized the same index contracts inside nested comparisons. This adds avoidable work to shared-state and agent-database validation.

Two measured changes stay inside the existing schema owner:

- Request the current table through SQLite's documented `table_list(table-name)` argument, retaining the exact-name selection and schema ordering. This reduces returned JavaScript rows, not the number of queries or all internal SQLite scanning.
- Prepare operation-local sets of the existing JSON index fingerprints. Keep diagnostic order, missing-index exceptions, and rejection of unexpected unique indexes unchanged. Do not cache the sets across calls: canonical fingerprint records are exposed by an existing helper, and current database shape must remain fresh.

No schema version, DDL, migration, transaction, repair policy, persistent cache, option, dependency, or public API changes. Production **+11/−8 = +3 lines**, justified by replacing repeated comparisons with bounded per-operation preparation. Existing tests are unchanged; no new mirror tests or benchmark framework is added. Release workflow owns the changelog.

The [SQLite table-list contract](https://sqlite.org/pragma.html#pragma_table_list), installed synchronous Node SQLite types, and SQLite's implementation were inspected directly. Filtering still visits schema entries internally; this PR makes no constant-time lookup claim. Real SQLite controls preserve quoted/mixed-case names, strict/without-rowid tables, attached/temp shadows, virtual tables, expression/partial indexes, allowed missing objects, external DDL, and retained read snapshots.

Final formatted-source timing uses four complete uninstrumented owner variants on Node 26.8.1: original, table-only, fingerprint-only, and both. Two fresh processes reverse the starting order; all 20 workloads, three warmups and nine samples per variant are retained. The canonical expected-schema cache is warm. This measures full schema comparison, not Gateway startup, provider latency, or memory.

| Complete comparison | Original F/R | Combined F/R |
| --- | ---: | ---: |
| Canonical state schema | 21.476 / 21.743 ms | 13.668 / 13.792 ms |
| Canonical agent schema | 5.211 / 5.348 ms | 3.737 / 3.704 ms |
| One table, 8 indexes | 147.775 / 144.229 µs | 114.738 / 115.096 µs |
| One table, 32 indexes | 793.475 / 800.296 µs | 409.837 / 427.608 µs |

Both mechanisms are checked separately. State table metadata rows returned fall 13,804→116 and agent rows 2,650→50, with the same 116/50 query counts. Owner JSON serializations fall 2,352→1,539 and 946→664; a 32-index table falls 1,340→252. Fingerprint-only default-schema timings are mixed, while richer index sets improve substantially. Beyond table-only, the final combination changes agent comparison +0.4%/−1.1% and state −1.0%/−1.3%; gains are not multiplied.

Costs remain visible: the empty control adds about 7–8 ns; a one-index table changes +0.7%/−9.4%; a table with 16 extra nonunique indexes changes +3.3%/−5.3%. The earlier fingerprint-only agent +11.8% sample remains in the original evidence; final integration does not erase it.

Validation: 415 canonical tests pass with 5 existing skips across 11 files, before and after. Three final differential runs each pass 1,279 comparisons with actual SQLite, including complete canonical schemas and exact issue ordering. All eight owner/dependency/SQL-asset bindings and 12 copied source hashes are checked. The full changed gate passes in 245.446s; independent complete-owner review and managed P0–P3 review are clean. Published build passes (164.881s), and a second managed P0–P3 review of the published head is clean. Exact-head CI and the latest ClawSweeper review remain landing gates.


Live verification at published head `90bb7708c2360e0febb95d5697d8f1aa56dc442a`: an isolated Gateway completed three real OpenAI turns and two web fetches; all 51 history/recovery assertions and 18 successful proof RPCs passed. Canonical read-only maintenance/preflight then validated the real populated state database and registered agent database with no incompatible or indeterminate result. The owned Gateway stopped cleanly and its Node CPU profiles are retained. These are behavior and profiling observations, not before/after whole-turn latency claims.

Two harness failures are retained: removing the synthetic workspace after recent initialization correctly triggered the existing disappearance guard before a provider call; the exact fixture files were restored. A separate preflight invocation omitted the helper's required options object and failed before database reads; the invocation was corrected. Neither failure required a product change or weaker guard.


Latest ClawSweeper review `5468896933` (updated 13:26:34 UTC) and the acknowledgement were read in full. No defect was found. Its remaining exact-head check is satisfied: CI `33312938312` succeeded, all 253 rollup checks completed without failure, and no retry was needed. The automated serialized-state flag does not correspond to a persisted-format change here: this diff writes no data, changes no schema or fingerprint shape, and uses the pre-existing JSON equality representation only in memory. No migration is required. Delegated maintainer decision: accept this bounded internal refactor under the authorized performance campaign; no separate human approval is claimed.
