### PR TITLE
fix(outbound): preserve block boundaries for attributed p and div tags during sanitization

### DIFF
--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -61,6 +61,20 @@ describe("sanitizeForPlainText", () => {
     expect(sanitizeForPlainText("<p>paragraph</p>")).toBe("\nparagraph\n");
   });
 
+  it("converts attributed <p> and <div> to newlines without leaking attributes", () => {
+    expect(
+      sanitizeForPlainText(
+        '<p class="lead" id="p1">paragraph one</p><p data-x="p2">paragraph two</p>',
+      ),
+    ).toBe("\nparagraph one\n\nparagraph two\n");
+    expect(sanitizeForPlainText('<div class="container" id="main">block text</div>')).toBe(
+      "\nblock text\n",
+    );
+    expect(sanitizeForPlainText('<p title="p>">text with bracket in attr</p>')).toBe(
+      "\ntext with bracket in attr\n",
+    );
+  });
+
   it("converts headings to bold text with newlines", () => {
     expect(sanitizeForPlainText("<h1>Title</h1>")).toBe("\n*Title*\n");
     expect(sanitizeForPlainText("<h3>Section</h3>")).toBe("\n*Section*\n");

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -15,7 +15,7 @@ const CODE_PLACEHOLDER = "\u0000p";
 
 // Quoted attribute values may contain `>`; normalize convertible openers without leaking attribute text.
 const CONVERTIBLE_HTML_OPEN_TAG_RE =
-  /<(b|strong|i|em|s|strike|del|code|h[1-6]|li)(?=\s|>)(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
+  /<(b|strong|i|em|s|strike|del|code|h[1-6]|li|p|div)(?=\s|>)(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
 // br, p, and div own line structure, so they stay outside the inert-tree removal pass.
 const EMPTY_HTML_ELEMENT_RE =
   /<((?!(?:br|p|div)(?=[\s>]))[a-z][a-z0-9_.:-]*)(?=[\s>])(?:[^"'<>]|"[^"]*"|'[^']*')*>(?:[^\S\r\n\u2028\u2029]|<(?!\/?(?:br|p|div)(?=[\s/>]))\/?[a-z][a-z0-9_.:-]*(?=[\s/>])(?:[^"'<>]|"[^"]*"|'[^']*')*>)*<\/\1\s*>/gi;


### PR DESCRIPTION
Fixes #132969

## What Problem This Solves

In `src/infra/outbound/sanitize-text.ts`, `CONVERTIBLE_HTML_OPEN_TAG_RE` normalizes convertible HTML openers with attributes (e.g. `<strong title="...">` → `<strong>`) before tag conversion, but its tag-name pattern omitted `p` and `div`.

When outbound text contains attributed block tags (e.g. `<p class="intro">`, `<div id="main">`), the opening tag was never normalized to `<p>` or `<div>`. As a result, it bypassed the block element replacement rule (`<\/?(p|div)>` → `\n`) and fell through to generic tag stripping, completely discarding the opening block newline boundary while keeping the closing newline.

This change includes `p` and `div` in `CONVERTIBLE_HTML_OPEN_TAG_RE`, ensuring attributed block openers are properly converted to bare tags and produce expected newline block boundaries.

## Evidence

- **Unit tests:**
  - `pnpm test src/infra/outbound/sanitize-text.test.ts` (all 76 tests pass)
  - `pnpm test src/infra/outbound/deliver-payload.presentation.test.ts src/infra/outbound/markdown-details.test.ts` (all tests pass)
- **Verification cases:**
  - `<p class="lead" id="p1">paragraph one</p><p data-x="p2">paragraph two</p>` → `\nparagraph one\n\nparagraph two\n`
  - `<div class="container" id="main">block text</div>` → `\nblock text\n`
  - `<p title="p>">text with bracket in attr</p>` → `\ntext with bracket in attr\n`

## Production LOC Delta

- `src/infra/outbound/sanitize-text.ts`: 1 modified line (net 0 LOC growth)
- `src/infra/outbound/sanitize-text.test.ts`: +14 test LOC

Co-authored-by: Antigravity <antigravity@users.noreply.github.com>