### PR TITLE
refactor(plugins): reuse the void hook binder

### DIFF
--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -7,10 +7,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { writeRestartSentinel } from "../infra/restart-sentinel.js";
-import type {
-  PluginHookGatewayContext,
-  PluginHookGatewayStartEvent,
-} from "../plugins/hook-types.js";
+import type { PluginHookGatewayContext, PluginHookHandlerMap } from "../plugins/hook-types.js";
 import { registerPluginHttpRoute } from "../plugins/http-registry.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
@@ -26,6 +23,8 @@ import {
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import "./server-startup-outcomes.test-support.js";
+
+type PluginHookGatewayStartEvent = Parameters<PluginHookHandlerMap["gateway_start"]>[0];
 
 const hoisted = vi.hoisted(() => {
   const startPluginServices = vi.fn<

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -75,7 +75,6 @@ export type {
   PluginHookMessageReceivedEvent,
   PluginHookMessageSendingEvent,
   PluginHookMessageSendingResult,
-  PluginHookMessageSentEvent,
   PluginHookProviderUpdate,
 } from "./hook-message.types.js";
 export {
@@ -477,7 +476,7 @@ export type PluginHookBeforeAgentFinalizeResult = {
   };
 };
 
-export type PluginHookBeforeCompactionEvent = {
+type PluginHookBeforeCompactionEvent = {
   messageCount: number;
   compactingCount?: number;
   tokenCount?: number;
@@ -485,13 +484,13 @@ export type PluginHookBeforeCompactionEvent = {
   sessionFile?: string;
 };
 
-export type PluginHookBeforeResetEvent = {
+type PluginHookBeforeResetEvent = {
   sessionFile?: string;
   messages?: unknown[];
   reason?: string;
 };
 
-export type PluginHookAfterCompactionEvent = {
+type PluginHookAfterCompactionEvent = {
   messageCount: number;
   tokenCount?: number;
   compactedCount: number;
@@ -783,7 +782,7 @@ export type PluginHookBeforeMessageWriteResult = {
   message?: AgentMessage;
 };
 
-export type PluginHookSessionContext = {
+type PluginHookSessionContext = {
   agentId?: string;
   sessionId: string;
   sessionKey?: string;
@@ -874,7 +873,7 @@ export type PluginHookSubagentDeliveryTargetResult = {
   };
 };
 
-export type PluginHookSubagentSpawnedEvent = PluginHookSubagentSpawnBase & {
+type PluginHookSubagentSpawnedEvent = PluginHookSubagentSpawnBase & {
   runId: string;
   /** Fully resolved provider/model ref applied to the spawned child session. */
   resolvedModel?: string;
@@ -883,7 +882,7 @@ export type PluginHookSubagentSpawnedEvent = PluginHookSubagentSpawnBase & {
 };
 
 /** Portable channel presentation signal for one background child run. */
-export type PluginHookSubagentProgressEvent =
+type PluginHookSubagentProgressEvent =
   | {
       phase: "started";
       runId: string;
@@ -898,7 +897,7 @@ export type PluginHookSubagentProgressEvent =
       requester?: PluginHookSubagentRequester;
     };
 
-export type PluginHookSubagentEndedEvent = {
+type PluginHookSubagentEndedEvent = {
   targetSessionKey: string;
   targetKind: PluginHookSubagentTargetKind;
   reason: string;
@@ -922,7 +921,7 @@ export type PluginHookCronReconciledContext = PluginHookGatewayContext & {
   abortSignal: AbortSignal;
 };
 
-export type PluginHookGatewayStartEvent = {
+type PluginHookGatewayStartEvent = {
   port: number;
 };
 

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -32,7 +32,6 @@ import { cloneHookIsolationValue, HookIsolationError } from "./hook-isolation.js
 import type { GlobalHookRunnerRegistry, HookRunnerRegistry } from "./hook-registry.types.js";
 import { isPluginHookReplyDispatchKind } from "./hook-types.js";
 import type {
-  PluginHookAfterCompactionEvent,
   PluginHookAfterToolCallEvent,
   PluginHookAgentContext,
   PluginHookAgentTrigger,
@@ -56,11 +55,9 @@ import type {
   PluginHookBeforeModelResolveResult,
   PluginHookBeforePromptBuildEvent,
   PluginHookBeforePromptBuildResult,
-  PluginHookBeforeCompactionEvent,
   PluginHookInboundClaimContext,
   PluginHookInboundClaimEvent,
   PluginHookInboundClaimResult,
-  PluginHookBeforeResetEvent,
   PluginHookBeforeToolCallEvent,
   PluginHookBeforeToolCallResult,
   PluginAgentTurnPrepareEvent,
@@ -68,22 +65,14 @@ import type {
   PluginHeartbeatPromptContributionEvent,
   PluginHeartbeatPromptContributionResult,
   PluginHookBeforeAgentRunEvent,
-  PluginHookGatewayContext,
-  PluginHookGatewayStartEvent,
   PluginHookMessageContext,
   PluginHookMessageSendingEvent,
   PluginHookMessageSendingResult,
-  PluginHookMessageSentEvent,
   PluginHookName,
   PluginHookRegistration,
-  PluginHookSessionContext,
-  PluginHookSessionStartEvent,
   PluginHookSubagentContext,
   PluginHookSubagentDeliveryTargetEvent,
   PluginHookSubagentDeliveryTargetResult,
-  PluginHookSubagentEndedEvent,
-  PluginHookSubagentProgressEvent,
-  PluginHookSubagentSpawnedEvent,
   PluginHookToolContext,
   PluginHookToolResultPersistContext,
   PluginHookToolResultPersistEvent,
@@ -1205,26 +1194,6 @@ export function createHookRunner(
     );
   }
 
-  /**
-   * Run before_compaction hook.
-   */
-  async function runBeforeCompaction(
-    event: PluginHookBeforeCompactionEvent,
-    ctx: PluginHookAgentContext,
-  ): Promise<void> {
-    return runVoidHook("before_compaction", event, ctx);
-  }
-
-  /**
-   * Run after_compaction hook.
-   */
-  async function runAfterCompaction(
-    event: PluginHookAfterCompactionEvent,
-    ctx: PluginHookAgentContext,
-  ): Promise<void> {
-    return runVoidHook("after_compaction", event, ctx);
-  }
-
   // =========================================================================
   // Message Hooks
   // =========================================================================
@@ -1768,12 +1737,15 @@ export function createHookRunner(
     runLlmOutput: bindVoidHook("llm_output"),
     runBeforeAgentFinalize,
     runAgentEnd,
-    runBeforeCompaction,
-    runAfterCompaction,
-    runBeforeReset: async (
-      event: PluginHookBeforeResetEvent,
-      ctx: PluginHookAgentContext,
-    ): Promise<void> => runVoidHook("before_reset", event, ctx),
+    /**
+     * Run before_compaction hook.
+     */
+    runBeforeCompaction: bindVoidHook("before_compaction"),
+    /**
+     * Run after_compaction hook.
+     */
+    runAfterCompaction: bindVoidHook("after_compaction"),
+    runBeforeReset: bindVoidHook("before_reset"),
     // Lifecycle gate hooks
     runBeforeAgentRun,
     // Message hooks
@@ -1786,10 +1758,7 @@ export function createHookRunner(
     runReplyDispatch,
     runReplyPayloadSending,
     runMessageSending,
-    runMessageSent: async (
-      event: PluginHookMessageSentEvent,
-      ctx: PluginHookMessageContext,
-    ): Promise<void> => runVoidHook("message_sent", event, ctx),
+    runMessageSent: bindVoidHook("message_sent"),
     // Tool hooks
     runBeforeToolCall,
     runAfterToolCall,
@@ -1797,29 +1766,14 @@ export function createHookRunner(
     // Message write hooks
     runBeforeMessageWrite,
     // Session hooks
-    runSessionStart: async (
-      event: PluginHookSessionStartEvent,
-      ctx: PluginHookSessionContext,
-    ): Promise<void> => runVoidHook("session_start", event, ctx),
+    runSessionStart: bindVoidHook("session_start"),
     runSessionEnd: bindVoidHook("session_end"),
     runSubagentDeliveryTarget,
-    runSubagentSpawned: async (
-      event: PluginHookSubagentSpawnedEvent,
-      ctx: PluginHookSubagentContext,
-    ): Promise<void> => runVoidHook("subagent_spawned", event, ctx),
-    runSubagentProgress: async (
-      event: PluginHookSubagentProgressEvent,
-      ctx: PluginHookSubagentContext,
-    ): Promise<void> => runVoidHook("subagent_progress", event, ctx),
-    runSubagentEnded: async (
-      event: PluginHookSubagentEndedEvent,
-      ctx: PluginHookSubagentContext,
-    ): Promise<void> => runVoidHook("subagent_ended", event, ctx),
+    runSubagentSpawned: bindVoidHook("subagent_spawned"),
+    runSubagentProgress: bindVoidHook("subagent_progress"),
+    runSubagentEnded: bindVoidHook("subagent_ended"),
     // Gateway hooks
-    runGatewayStart: async (
-      event: PluginHookGatewayStartEvent,
-      ctx: PluginHookGatewayContext,
-    ): Promise<void> => runVoidHook("gateway_start", event, ctx),
+    runGatewayStart: bindVoidHook("gateway_start"),
     runGatewayStop: bindVoidHook("gateway_stop"),
     runHeartbeatPromptContribution,
     runCronReconciled: bindVoidHook("cron_reconciled"),

--- a/src/plugins/wired-hooks-gateway.test.ts
+++ b/src/plugins/wired-hooks-gateway.test.ts
@@ -12,9 +12,11 @@ import type {
   PluginHookCronReconciledContext,
   PluginHookCronReconciledEvent,
   PluginHookGatewayContext,
-  PluginHookGatewayStartEvent,
+  PluginHookHandlerMap,
   PluginHookGatewayStopEvent,
 } from "./types.js";
+
+type PluginHookGatewayStartEvent = Parameters<PluginHookHandlerMap["gateway_start"]>[0];
 
 async function expectGatewayHookCall(params: {
   hookName: "gateway_start" | "gateway_stop";

--- a/src/plugins/wired-hooks-message.test.ts
+++ b/src/plugins/wired-hooks-message.test.ts
@@ -9,8 +9,10 @@ import { createHookRunnerWithRegistry } from "./hooks.test-fixtures.js";
 import type {
   PluginHookMessageSendingEvent,
   PluginHookMessageSendingResult,
-  PluginHookMessageSentEvent,
+  PluginHookHandlerMap,
 } from "./types.js";
+
+type PluginHookMessageSentEvent = Parameters<PluginHookHandlerMap["message_sent"]>[0];
 
 async function expectMessageHookCall(params: {
   hookName: "message_sending" | "message_sent";

--- a/src/plugins/wired-hooks-session.test.ts
+++ b/src/plugins/wired-hooks-session.test.ts
@@ -4,12 +4,18 @@
  * Tests the hook runner methods directly since session init is deeply integrated.
  */
 import { describe, expect, it, vi } from "vitest";
-import { createHookRunnerWithRegistry } from "./hooks.test-fixtures.js";
+import {
+  addTestHook,
+  createHookRunnerWithRegistry,
+  TEST_PLUGIN_AGENT_CTX,
+} from "./hooks.test-fixtures.js";
 import type {
-  PluginHookSessionContext,
+  PluginHookHandlerMap,
   PluginHookSessionEndEvent,
   PluginHookSessionStartEvent,
 } from "./types.js";
+
+type PluginHookSessionContext = Parameters<PluginHookHandlerMap["session_start"]>[1];
 
 async function expectSessionHookCall(params: {
   hookName: "session_start" | "session_end";
@@ -52,6 +58,21 @@ describe("session hook runner methods", () => {
     },
   ] as const)("$name", async ({ hookName, event }) => {
     await expectSessionHookCall({ hookName, event, sessionCtx });
+  });
+
+  it("delivers the prior transcript to before_reset hooks registered after runner creation", async () => {
+    const { registry, runner } = createHookRunnerWithRegistry([]);
+    const handler = vi.fn(async () => {});
+    addTestHook({ registry, pluginId: "reset-observer", hookName: "before_reset", handler });
+    const event = {
+      messages: [{ role: "user", content: "Keep this context before reset." }],
+      sessionFile: "/tmp/prior-session.jsonl",
+      reason: "new",
+    };
+
+    await expect(runner.runBeforeReset(event, TEST_PLUGIN_AGENT_CTX)).resolves.toBeUndefined();
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(event, TEST_PLUGIN_AGENT_CTX);
   });
 
   it("hasHooks returns true for registered session hooks", () => {


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested, AI-assisted cleanup of repeated plugin hook dispatch wrappers. Nine ordinary void-hook wrappers duplicated the existing typed binder, making the same dispatch policy harder to maintain consistently. This is a behavior-preserving refactor, not a claimed production incident fix.

## Why This Change Was Made

Reuse the existing `bindVoidHook` for the nine plain wrappers, preserving current-registry lookup, argument forwarding, priority, error handling and the shared compaction timeout/override/unref behavior. Specialized agent-end, tool-call and skill-cloning paths stay separate.

Remove eight now-unused internal type export qualifiers and one redundant re-export, while keeping every event shape and handler-map signature. Four test annotations derive their existing types from the canonical handler parameters. The earlier SDK named-export narrowing and runtime-only `plugin-sdk/types` boundary are already in the base; this change does not introduce that retirement. The public contextual `api.on<K>` declaration path remains reachable in the emitted build.

## User Impact

No intended user-visible behavior, configuration, protocol or storage change. A focused `before_reset` characterization protects event/context forwarding and registration after runner creation. Internal debug function names/stack labels can change; no reflection-identity compatibility claim is made.

Production: +23/-70 (**-47**). Tests: +32/-8 (**+24**). Whole change: **-23 lines**, six files.

## Evidence

Source commit: `cb78b7c1330692e4fb56d12c31ee15c0f28991e4` (signed), parent `efe07d162641c30ab7584b58288d880593707d4c`. Local proof used official Node 24.19 and project-pinned pnpm 12.1.

- Identical baseline/candidate owner, sibling and real projector selection: **85 passed in 11 suites**, same emitted cases and within-suite order.
- Additional complete Gateway post-attach suite: **91 passed**; this is additive proof, not a paired baseline claim.
- Reclassified six-path changed gate: **all 29 checks passed**.
- Normal full build: **all 14 stages passed**, including verification of all **148 public SDK subpaths**.
- Canonical SDK surface check passed: **148 public entrypoints, 4,355 public exports, zero forbidden package-exported subpaths**. No public surface baseline was edited.
- Separate normal precommit and exact-commit Codex reviews were scoped-clean at P0. Each used four automatic complete-context partitions, not four independent invocations or a broader-priority guarantee.
- Full committed/physical/index source mapping and post-proof dependency/generated-output custody were checked. No source changes occurred during normal commit hooks.

The initial changed gate failed at dead exports; it remains a failed run. The narrow type-ownership correction above was followed by the complete 85-case selection, additive Gateway suite, full changed gate, build and SDK check. Historical observer/artifact refusals remain retained, not relabeled successful.

<details>
<summary>Exact local commands</summary>

```sh
node scripts/run-vitest.mjs \
  src/plugins/wired-hooks-session.test.ts \
  src/plugins/wired-hooks-message.test.ts \
  src/plugins/wired-hooks-subagent.test.ts \
  src/plugins/wired-hooks-gateway.test.ts \
  src/plugins/hooks.correlation.test.ts \
  src/plugins/hook-runner-global.test.ts \
  src/plugins/hook-runner-global.compose.test.ts \
  src/plugins/hooks.security.test.ts \
  src/plugins/hooks.phase-hooks.test.ts \
  src/plugins/hooks.compaction-timeout.test.ts \
  extensions/codex/src/app-server/event-projector.verbose-hooks.test.ts \
  --reporter=verbose

node scripts/run-vitest.mjs \
  src/gateway/server-startup-post-attach.test.ts --reporter=verbose

node scripts/check-changed.mjs -- \
  src/gateway/server-startup-post-attach.test.ts \
  src/plugins/hook-types.ts \
  src/plugins/hooks.ts \
  src/plugins/wired-hooks-gateway.test.ts \
  src/plugins/wired-hooks-message.test.ts \
  src/plugins/wired-hooks-session.test.ts

node --import ./scripts/tsx.mjs scripts/build-all.mts
node --max-old-space-size=8192 --import ./scripts/tsx.mjs \
  scripts/plugin-sdk-surface-report.mts --check
```

The focused suites used the normal two-worker harness. Local proof kept its existing finite command budgets and normal assertions; no test skip, timeout expansion, dependency override or guard bypass was used.

</details>

Exact-head CI [33313934916](https://github.com/openclaw/openclaw/actions/runs/33313934916) passed with all185 jobs terminal and the required ci-gate successful. The latest completed ClawSweeper review's current-main composition/Rank-up request is addressed: all six edited preimages still match the base; the77 inspected owner/caller/SDK contexts were reconciled through `aea8ee845ccfc8ff50e5211dffec072bcd0bb0e6`, preserving newer compaction authority and terminal-notification behavior. No source rebase or fresh proof of unrelated main functionality is claimed. Normal hosted preparation and native merge completed successfully without rebase or another source push. Landed as [7cd04f982867](https://github.com/openclaw/openclaw/commit/7cd04f982867d8efc3517d901937c25e69e00a5e). The complete35,521-entry landed tree equals its actual parent plus exactly the six reviewed afterimages; patch bytes, modes and ancestry were verified. The native worktree, temporary branches and operation lock were removed. This is not live-provider, performance or deployment proof.
