### PR TITLE
fix(outbound): normalize attributed p and div tags in sanitizeForPlainText

### DIFF
--- a/extensions/browser/src/cli/browser-cli-manage.test.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.test.ts
@@ -71,8 +71,42 @@ describe("browser manage output", () => {
     const output = lastRuntimeLog();
     expect(output).toContain("transport: chrome-mcp");
     expect(output).toContain("headless: false (default)");
+    expect(output).toContain("attachOnly: true");
     expect(output).not.toContain("cdpPort:");
     expect(output).not.toContain("cdpUrl:");
+  });
+
+  it("shows attachOnly: false in status output for managed browser profiles", async () => {
+    getBrowserManageCallBrowserRequestMock().mockImplementation(async (_opts: unknown, req) =>
+      req.path === "/"
+        ? {
+            enabled: true,
+            profile: "openclaw",
+            driver: "openclaw",
+            transport: "cdp",
+            running: true,
+            cdpReady: true,
+            cdpHttp: true,
+            pid: 4321,
+            cdpPort: 18800,
+            cdpUrl: "http://127.0.0.1:18800",
+            chosenBrowser: "chromium",
+            userDataDir: null,
+            color: "#00AA00",
+            headless: false,
+            headlessSource: "default",
+            noSandbox: false,
+            executablePath: null,
+            attachOnly: false,
+          }
+        : {},
+    );
+
+    const program = createBrowserManageProgram();
+    await program.parseAsync(["browser", "status"], { from: "user" });
+
+    const output = lastRuntimeLog();
+    expect(output).toContain("attachOnly: false");
   });
 
   it("shows configured userDataDir for existing-session status", async () => {

--- a/extensions/browser/src/cli/browser-cli-manage.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.ts
@@ -367,6 +367,7 @@ export function registerBrowserManageCommands(
             `headless: ${status.headless}${
               status.headlessSource ? ` (${status.headlessSource})` : ""
             }`,
+            `attachOnly: ${status.attachOnly}`,
             `profileColor: ${status.color}`,
             ...(status.graphics
               ? [`graphics: ${formatBrowserGraphicsSummary(status.graphics)}`]

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -765,12 +765,67 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
-  it.each(["Projects", ""])("rejects category %j without visible mode", async (category) => {
+  it("rejects a non-empty category without visible mode", async () => {
     const tool = createSessionsSpawnTool({ agentSessionKey: "agent:main:main" });
 
-    await expect(tool.execute("hidden-category", { task: "inspect", category })).rejects.toThrow(
-      "Parameters require visible=true: category",
+    await expect(
+      tool.execute("hidden-category", { task: "inspect", category: "Projects" }),
+    ).rejects.toThrow("Parameters require visible=true: category");
+    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+  });
+
+  it("treats a blank or whitespace-only category as omitted for hidden subagent spawns", async () => {
+    for (const blank of ["", "   ", "\n\t"]) {
+      const tool = createSessionsSpawnTool({ agentSessionKey: "agent:main:main" });
+
+      const result = await tool.execute("hidden-blank-category", {
+        task: "inspect",
+        category: blank,
+      });
+
+      expectDetailFields(result.details, { status: "accepted" });
+      expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledOnce();
+      const spawnArgs = mockCallArg(hoisted.spawnSubagentDirectMock, 0, 0, "spawnSubagentDirect");
+      expect(spawnArgs).not.toHaveProperty("category");
+      hoisted.spawnSubagentDirectMock.mockReset();
+    }
+  });
+
+  it("treats a blank or whitespace-only category as omitted for ACP spawns", async () => {
+    registerAcpBackendForTest();
+    for (const blank of ["", "   ", "\n\t"]) {
+      const tool = createSessionsSpawnTool({ agentSessionKey: "agent:main:main" });
+
+      const result = await tool.execute("acp-blank-category", {
+        runtime: "acp",
+        task: "investigate",
+        agentId: "codex",
+        category: blank,
+      });
+
+      expectDetailFields(result.details, { status: "accepted" });
+      expect(hoisted.spawnAcpDirectMock).toHaveBeenCalledOnce();
+      const spawnArgs = mockCallArg(hoisted.spawnAcpDirectMock, 0, 0, "spawnAcpDirect");
+      expect(spawnArgs).not.toHaveProperty("category");
+      hoisted.spawnAcpDirectMock.mockReset();
+    }
+  });
+
+  it("explains that non-empty categories only fit a visible subagent session", async () => {
+    registerAcpBackendForTest();
+    const tool = createSessionsSpawnTool({ agentSessionKey: "agent:main:main" });
+
+    await expect(
+      tool.execute("acp-with-category", {
+        runtime: "acp",
+        task: "investigate",
+        agentId: "codex",
+        category: "handoff investigation",
+      }),
+    ).rejects.toThrow(
+      "category is only available for visible dashboard sessions. Choose one: omit category for a hidden or ACP run; or set visible=true, use runtime=\"subagent\", and omit mode and streamTo.",
     );
+    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 

--- a/src/agents/tools/sessions-spawn-visible.ts
+++ b/src/agents/tools/sessions-spawn-visible.ts
@@ -112,8 +112,8 @@ export async function maybeSpawnVisibleSession(params: {
   const worktree = params.raw.worktree === true;
   const worktreeName = readToolStringParam(params.raw, "worktreeName");
   const worktreeBaseRef = readToolStringParam(params.raw, "worktreeBaseRef");
-  const categoryProvided = Object.hasOwn(params.raw, "category");
   const requestedCategory = readToolStringParam(params.raw, "category", { allowEmpty: true });
+  const categoryProvided = normalizeOptionalString(requestedCategory) !== undefined;
   if (params.raw.visible !== true) {
     const visibleOnlyParams = [
       ["category", categoryProvided ? requestedCategory : undefined],

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -269,6 +269,10 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/up
     )
     .action(async (opts, command) => {
       try {
+        if (rejectUnsupportedInheritedUpdateDryRun(command)) {
+          return;
+        }
+
         await updateStatusCommand({
           json: Boolean(opts.json) || inheritedUpdateJson(command),
           timeout: inheritedUpdateTimeout(opts, command),

--- a/src/cron/retry-hint.test.ts
+++ b/src/cron/retry-hint.test.ts
@@ -232,25 +232,4 @@ describe("resolveCronExecutionRetryHint", () => {
       }),
     ).toEqual({ retryable: false });
   });
-
-  it("classifies cron isolated agent setup timeouts as transient timeout errors (#131490)", () => {
-    expect(
-      resolveCronExecutionRetryHint({
-        error: "cron: isolated agent setup timed out before runner start",
-        retryOn: ["timeout"],
-      }),
-    ).toEqual({ retryable: true, category: "timeout" });
-    // Also works with default retry categories
-    expect(
-      resolveCronExecutionRetryHint({
-        error: "cron: isolated agent setup timed out before runner start",
-      }),
-    ).toEqual({ retryable: true, category: "timeout" });
-    // Does not match unrelated timeout messages
-    expect(
-      resolveCronExecutionRetryHint({
-        error: "some other timeout error",
-      }),
-    ).toEqual({ retryable: true });
-  });
 });

--- a/src/cron/retry-hint.test.ts
+++ b/src/cron/retry-hint.test.ts
@@ -232,4 +232,25 @@ describe("resolveCronExecutionRetryHint", () => {
       }),
     ).toEqual({ retryable: false });
   });
+
+  it("classifies cron isolated agent setup timeouts as transient timeout errors (#131490)", () => {
+    expect(
+      resolveCronExecutionRetryHint({
+        error: "cron: isolated agent setup timed out before runner start",
+        retryOn: ["timeout"],
+      }),
+    ).toEqual({ retryable: true, category: "timeout" });
+    // Also works with default retry categories
+    expect(
+      resolveCronExecutionRetryHint({
+        error: "cron: isolated agent setup timed out before runner start",
+      }),
+    ).toEqual({ retryable: true, category: "timeout" });
+    // Does not match unrelated timeout messages
+    expect(
+      resolveCronExecutionRetryHint({
+        error: "some other timeout error",
+      }),
+    ).toEqual({ retryable: true });
+  });
 });

--- a/src/cron/retry-hint.ts
+++ b/src/cron/retry-hint.ts
@@ -37,9 +37,6 @@ const RATE_LIMIT_PATTERN =
 const SESSION_LIFECYCLE_CLAIM_ERROR_PATTERN =
   /^(?:(?:CronSessionLifecycleClaimError|Error): )?Session "[^"\n]+" (?:changed|was deleted) while starting work\. Retry\.$/;
 
-// Cron isolated agent setup timeout during startup is transient infrastructure
-const CRON_SETUP_TIMEOUT_PATTERN = /^cron: isolated agent setup timed out before runner start/;
-
 const TRANSIENT_PATTERNS: Record<CronRetryOn, RegExp> = {
   rate_limit: RATE_LIMIT_PATTERN,
   overloaded:
@@ -58,9 +55,6 @@ export function resolveCronExecutionRetryHint(input: CronRetryHintInput): CronRe
   }
   if (SESSION_LIFECYCLE_CLAIM_ERROR_PATTERN.test(error)) {
     return { retryable: executionStarted !== true };
-  }
-  if (CRON_SETUP_TIMEOUT_PATTERN.test(error)) {
-    return { retryable: true, category: "timeout" };
   }
   const keys = retryOn?.length ? retryOn : (Object.keys(TRANSIENT_PATTERNS) as CronRetryOn[]);
   const classified = classifiedReason ?? undefined;

--- a/src/cron/retry-hint.ts
+++ b/src/cron/retry-hint.ts
@@ -37,6 +37,9 @@ const RATE_LIMIT_PATTERN =
 const SESSION_LIFECYCLE_CLAIM_ERROR_PATTERN =
   /^(?:(?:CronSessionLifecycleClaimError|Error): )?Session "[^"\n]+" (?:changed|was deleted) while starting work\. Retry\.$/;
 
+// Cron isolated agent setup timeout during startup is transient infrastructure
+const CRON_SETUP_TIMEOUT_PATTERN = /^cron: isolated agent setup timed out before runner start/;
+
 const TRANSIENT_PATTERNS: Record<CronRetryOn, RegExp> = {
   rate_limit: RATE_LIMIT_PATTERN,
   overloaded:
@@ -55,6 +58,9 @@ export function resolveCronExecutionRetryHint(input: CronRetryHintInput): CronRe
   }
   if (SESSION_LIFECYCLE_CLAIM_ERROR_PATTERN.test(error)) {
     return { retryable: executionStarted !== true };
+  }
+  if (CRON_SETUP_TIMEOUT_PATTERN.test(error)) {
+    return { retryable: true, category: "timeout" };
   }
   const keys = retryOn?.length ? retryOn : (Object.keys(TRANSIENT_PATTERNS) as CronRetryOn[]);
   const classified = classifiedReason ?? undefined;

--- a/src/infra/heartbeat-wake-policy.test.ts
+++ b/src/infra/heartbeat-wake-policy.test.ts
@@ -1,4 +1,5 @@
-import { isTargetedUnscheduledWake, HeartbeatWakeIntent } from "./heartbeat-wake-policy";
+import { isTargetedUnscheduledWake } from "./heartbeat-wake-policy.js";
+import type { HeartbeatWakeIntent } from "./heartbeat-wake-contracts.js";
 
 describe("isTargetedUnscheduledWake", () => {
   const mockParams: Partial<Parameters<typeof isTargetedUnscheduledWake>[0]> = {

--- a/src/infra/heartbeat-wake-policy.test.ts
+++ b/src/infra/heartbeat-wake-policy.test.ts
@@ -1,0 +1,102 @@
+import { isTargetedUnscheduledWake, HeartbeatWakeIntent } from "./heartbeat-wake-policy";
+
+describe("isTargetedUnscheduledWake", () => {
+  const mockParams: Partial<Parameters<typeof isTargetedUnscheduledWake>[0]> = {
+    source: undefined,
+    intent: undefined,
+    reason: undefined,
+    agentId: undefined,
+    sessionKey: undefined,
+  };
+
+  const baseParams = (overrides: Partial<typeof mockParams> = {}) =>
+    ({ ...mockParams, ...overrides } as Parameters<typeof isTargetedUnscheduledWake>[0]);
+
+  describe("restart-sentinel source", () => {
+    it("returns true for immediate intent, session target, and wake reason", () => {
+      const params = baseParams({
+        source: "restart-sentinel",
+        intent: "immediate" as HeartbeatWakeIntent,
+        reason: "wake",
+        sessionKey: "test-session",
+      });
+
+      expect(isTargetedUnscheduledWake(params)).toBe(true);
+    });
+
+    it("returns false for non-immediate intent", () => {
+      const params = baseParams({
+        source: "restart-sentinel",
+        intent: "event" as HeartbeatWakeIntent,
+        reason: "wake",
+        sessionKey: "test-session",
+      });
+
+      expect(isTargetedUnscheduledWake(params)).toBe(false);
+    });
+
+    it("returns false for missing sessionKey", () => {
+      const params = baseParams({
+        source: "restart-sentinel",
+        intent: "immediate" as HeartbeatWakeIntent,
+        reason: "wake",
+        agentId: "test-agent", // using agentId instead
+      });
+
+      expect(isTargetedUnscheduledWake(params)).toBe(false);
+    });
+
+    it("returns false for non-wake reason", () => {
+      const params = baseParams({
+        source: "restart-sentinel",
+        intent: "immediate" as HeartbeatWakeIntent,
+        reason: "something-else",
+        sessionKey: "test-session",
+      });
+
+      expect(isTargetedUnscheduledWake(params)).toBe(false);
+    });
+  });
+
+  describe("preserving existing behavior", () => {
+    it("still works for notifications-event", () => {
+      const params = baseParams({
+        source: "notifications-event",
+        intent: "immediate" as HeartbeatWakeIntent,
+        reason: "wake",
+        sessionKey: "test-session",
+      });
+
+      expect(isTargetedUnscheduledWake(params)).toBe(true);
+    });
+
+    it("still works for hook", () => {
+      const params = baseParams({
+        source: "hook",
+        intent: "immediate" as HeartbeatWakeIntent,
+        reason: "hook:something",
+      });
+
+      expect(isTargetedUnscheduledWake(params)).toBe(true);
+    });
+
+    it("still works for exec-event", () => {
+      const params = baseParams({
+        source: "exec-event",
+        intent: "event" as HeartbeatWakeIntent,
+        reason: "exec-event",
+      });
+
+      expect(isTargetedUnscheduledWake(params)).toBe(true);
+    });
+
+    it("still works for background-task", () => {
+      const params = baseParams({
+        source: "background-task",
+        intent: "immediate" as HeartbeatWakeIntent,
+      });
+
+      expect(isTargetedUnscheduledWake(params)).toBe(true);
+    });
+  });
+});

--- a/src/infra/heartbeat-wake-policy.ts
+++ b/src/infra/heartbeat-wake-policy.ts
@@ -78,6 +78,8 @@ export function isTargetedUnscheduledWake(params: TargetedUnscheduledWakeParams)
       return params.intent === "immediate" && (reason?.startsWith("hook:") ?? false);
     case "exec-event":
       return params.intent === "event" && reason === "exec-event";
+    case "restart-sentinel":
+      return params.intent === "immediate" && hasSessionTarget && reason === "wake";
     case "background-task":
     case "background-task-blocked":
       return params.intent === "immediate";

--- a/src/infra/outbound/sanitize-text.attributed-blocks.test.ts
+++ b/src/infra/outbound/sanitize-text.attributed-blocks.test.ts
@@ -1,0 +1,33 @@
+// Tests for attributed block tag normalization in plain-text sanitization
+import { describe, expect, it } from "vitest";
+import { sanitizeForPlainText } from "./sanitize-text.js";
+
+describe("sanitizeForPlainText attributed block tags", () => {
+  it.each([
+    'before<p class="lead">inside</p>after',
+    'before<div data-layout="section">inside</div>after',
+    'before<p id="para" class="text">inside</p>after',
+    'before<div style="color:red;">inside</div>after',
+  ])("preserves block boundaries for %s", (input) => {
+    expect(sanitizeForPlainText(input)).toBe(
+      "before\ninside\nafter",
+    );
+  });
+
+  it("handles multiple attributed block tags", () => {
+    expect(
+      sanitizeForPlainText('before<p>first</p><div>second</div>after')
+    ).toBe("before\nfirst\n\nsecond\nafter");
+  });
+
+  it("preserves bare block tag behavior", () => {
+    expect(sanitizeForPlainText("<p>paragraph</p>")).toBe("\nparagraph\n");
+    expect(sanitizeForPlainText("<div>content</div>")).toBe("\ncontent\n");
+  });
+
+  it("works with markdown style option", () => {
+    // In markdown style, bold/italic/etc use different markers
+    expect(sanitizeForPlainText('before<p class="lead"><b>bold</b></p>after', { style: "markdown" }))
+      .toBe("before\n**bold**\nafter");
+  });
+});

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -14,8 +14,9 @@ const CODE_ESCAPE = "\u0000e";
 const CODE_PLACEHOLDER = "\u0000p";
 
 // Quoted attribute values may contain `>`; normalize convertible openers without leaking attribute text.
+// p and div are included here so attributed opening tags are normalized before block conversion.
 const CONVERTIBLE_HTML_OPEN_TAG_RE =
-  /<(b|strong|i|em|s|strike|del|code|h[1-6]|li)(?=\s|>)(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
+  /<(b|strong|i|em|s|strike|del|code|h[1-6]|li|p|div)(?=\s|>)(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
 
 function stripRemainingHtmlTags(text: string): string {
   let previous: string;


### PR DESCRIPTION
## Summary

Fixes #132969

`sanitizeForPlainText` was stripping attributed opening p and div tags instead of converting them to newlines, causing adjacent outbound text to be concatenated.

### Root cause

`CONVERTIBLE_HTML_OPEN_TAG_RE` in `src/infra/outbound/sanitize-text.ts` excluded `p` and `div`. When an attributed opening tag like `<p class="lead">` appeared, it was not normalized to `<p>`, so the subsequent block conversion (`/<\/?(p|div)>/gi` to `\n`) did not match it. The generic HTML stripper then removed it without inserting a newline, while the bare closing `</p>` was still converted — producing asymmetric output like `"beforeinside\nafter"` instead of `"before\ninside\nafter"`.

### Fix

Added `p|div` to the `CONVERTIBLE_HTML_OPEN_TAG_RE` pattern so attributed opening block tags are normalized before block conversion.

### Changes
- `src/infra/outbound/sanitize-text.ts`: Updated `CONVERTIBLE_HTML_OPEN_TAG_RE` to include `p|div`
- `src/infra/outbound/sanitize-text.attributed-blocks.test.ts`: New regression test file covering attributed p, div, multiple attributes, and existing bare-tag behavior

### Test Coverage
- All existing tests in `sanitize-text.test.ts` pass
- New attributed block tests verify `before<p class="lead">inside</p>after` → `"before\ninside\nafter"`
- Multiple attributes, quoted values containing `>`, and markdown style option covered