### PR TITLE
fix(agents): preserve find result paths

### DIFF
--- a/src/agents/sessions/tools/find.fd.test.ts
+++ b/src/agents/sessions/tools/find.fd.test.ts
@@ -65,6 +65,43 @@ it("rejects partial fd output when fd exits with an error", async () => {
   await expect(result).rejects.toThrow("fd failed while reading subtree");
 });
 
+it.each([false, true])("preserves fd paths with trailing search separator=%s", async (trailing) => {
+  const searchRoot = path.resolve(path.sep, "find-fixture");
+  const paths = [
+    path.join(searchRoot, "alpha.txt"),
+    path.join(searchRoot, "report.txt "),
+    path.join(searchRoot, "🦞.txt"),
+    `${path.join(searchRoot, "folder space ")}${path.sep}`,
+    path.join(searchRoot, "literal\\"),
+  ];
+  const child = createChild();
+  vi.mocked(spawnCommand).mockReturnValue(child as never);
+  vi.mocked(ensureTool).mockResolvedValue("fd");
+  const tool = createFindToolDefinition(searchRoot);
+  const pending = tool.execute(
+    "paths",
+    { pattern: "*", path: trailing ? `${searchRoot}${path.sep}` : searchRoot },
+    undefined,
+    undefined,
+    {} as never,
+  );
+  await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
+  child.stdout.end(`${paths.join("\n")}\n`);
+  child.stderr.end();
+  child.emit("close", 0, null);
+  const result = await pending;
+  expect(textContent(result)).toBe(
+    [
+      "alpha.txt",
+      "report.txt ",
+      "🦞.txt",
+      "folder space /",
+      process.platform === "win32" ? "literal/" : "literal\\",
+    ].join("\n"),
+  );
+  expect(result.details).toBeUndefined();
+});
+
 it("keeps multibyte stderr intact when pipe chunks split a character", async () => {
   const child = createChild();
   vi.mocked(spawnCommand).mockReturnValue(child as never);

--- a/src/agents/sessions/tools/find.test.ts
+++ b/src/agents/sessions/tools/find.test.ts
@@ -1,5 +1,6 @@
 // find tool tests cover custom search operation wiring and result-limit
 // normalization for session file discovery.
+import path from "node:path";
 import { Value } from "typebox/value";
 import { describe, expect, it, vi } from "vitest";
 import { createFindToolDefinition, type FindOperations } from "./find.js";
@@ -23,6 +24,72 @@ function execute(tool: ReturnType<typeof createFindToolDefinition>, limit: numbe
 }
 
 describe("find tool", () => {
+  const workspace = path.resolve(path.sep, "find-fixture");
+  it.each([
+    {
+      name: "absolute result",
+      search: workspace,
+      found: path.join(workspace, "alpha.txt"),
+      expected: "alpha.txt",
+    },
+    {
+      name: "trailing search separator",
+      search: `${workspace}${path.sep}`,
+      found: path.join(workspace, "alpha.txt"),
+      expected: "alpha.txt",
+    },
+    {
+      name: "root search",
+      search: path.parse(workspace).root,
+      found: path.join(path.parse(workspace).root, "alpha.txt"),
+      expected: "alpha.txt",
+    },
+    { name: "relative result", search: workspace, found: "alpha.txt", expected: "alpha.txt" },
+    { name: "self-directory absolute", search: workspace, found: workspace, expected: "." },
+    {
+      name: "self-directory with separator",
+      search: workspace,
+      found: `${workspace}${path.sep}`,
+      expected: "./",
+    },
+    { name: "self-directory relative", search: workspace, found: ".", expected: "." },
+    {
+      name: "prefix sibling",
+      search: workspace,
+      found: path.join(`${workspace}-other`, "alpha.txt"),
+      expected: "../find-fixture-other/alpha.txt",
+    },
+    {
+      name: "filename whitespace",
+      search: workspace,
+      found: path.join(workspace, "report.txt "),
+      expected: "report.txt ",
+    },
+    {
+      name: "absolute directory marker",
+      search: `${workspace}${path.sep}`,
+      found: `${path.join(workspace, "folder")}${path.sep}`,
+      expected: "folder/",
+    },
+    {
+      name: "relative directory marker",
+      search: workspace,
+      found: `folder${path.sep}`,
+      expected: "folder/",
+    },
+  ])("preserves $name from custom operations", async ({ search, found, expected }) => {
+    const tool = createFindToolDefinition(workspace, { operations: operations([found]) });
+    const result = await tool.execute(
+      "paths",
+      { pattern: "*", path: search },
+      undefined,
+      undefined,
+      {} as never,
+    );
+    expect(textContent(result)).toBe(expected);
+    expect(result.details).toBeUndefined();
+  });
+
   it("rejects fractional limits", async () => {
     const tool = createFindToolDefinition("/workspace", { operations: operations([]) });
 

--- a/src/agents/sessions/tools/find.ts
+++ b/src/agents/sessions/tools/find.ts
@@ -116,15 +116,29 @@ function formatFindResult(
 }
 
 function buildFindResult(params: {
-  relativized: string[];
+  paths: string[];
+  searchPath: string;
   effectiveLimit: number;
   limitNotice: string;
 }): {
   content: Array<{ type: "text"; text: string }>;
   details: FindToolDetails | undefined;
 } {
-  const resultLimitReached = params.relativized.length > params.effectiveLimit;
-  const rawOutput = params.relativized.slice(0, params.effectiveLimit).join("\n");
+  const resultLimitReached = params.paths.length > params.effectiveLimit;
+  const rawOutput = params.paths
+    .slice(0, params.effectiveLimit)
+    .map((foundPath) => {
+      // Backends may return search-relative paths; only absolute paths need relativizing.
+      // Preserve directory markers and filename whitespace when formatting either backend.
+      const normalized = normalizeNativePathSeparators(foundPath);
+      const relativePath = path.isAbsolute(foundPath)
+        ? normalizeNativePathSeparators(path.relative(params.searchPath, foundPath) || ".")
+        : normalized;
+      return normalized.endsWith("/") && !relativePath.endsWith("/")
+        ? `${relativePath}/`
+        : relativePath;
+    })
+    .join("\n");
   const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
   let resultOutput = truncation.content;
   const details: FindToolDetails = {};
@@ -230,17 +244,11 @@ export function createFindToolDefinition(
                 return;
               }
 
-              // Relativize paths against the search root for stable output.
-              const relativized = results.slice(0, observationLimit).map((p) => {
-                if (p.startsWith(searchPath)) {
-                  return normalizeNativePathSeparators(p.slice(searchPath.length + 1));
-                }
-                return normalizeNativePathSeparators(path.relative(searchPath, p));
-              });
               settle(() =>
                 resolve(
                   buildFindResult({
-                    relativized,
+                    paths: results,
+                    searchPath,
                     effectiveLimit,
                     limitNotice: `${effectiveLimit} results limit reached`,
                   }),
@@ -351,29 +359,11 @@ export function createFindToolDefinition(
                 return;
               }
 
-              const relativized: string[] = [];
-              for (const rawLine of lines) {
-                const line = rawLine.replace(/\r$/, "").trim();
-                if (!line) {
-                  continue;
-                }
-                const hadTrailingSlash = line.endsWith("/") || line.endsWith("\\");
-                let relativePath;
-                if (line.startsWith(searchPath)) {
-                  relativePath = line.slice(searchPath.length + 1);
-                } else {
-                  relativePath = path.relative(searchPath, line);
-                }
-                if (hadTrailingSlash && !relativePath.endsWith("/")) {
-                  relativePath += "/";
-                }
-                relativized.push(normalizeNativePathSeparators(relativePath));
-              }
-
               settle(() =>
                 resolve(
                   buildFindResult({
-                    relativized,
+                    paths: lines,
+                    searchPath,
                     effectiveLimit,
                     limitNotice: `${effectiveLimit} results limit reached. Use limit=${effectiveLimit * 2} for more, or refine pattern`,
                   }),


### PR DESCRIPTION
Closes #133301

## What Problem This Solves

Fixes an issue where agents using `find` received unusable paths when the search directory ended in a separator, filenames contained trailing whitespace or a literal POSIX backslash, or custom backends returned relative paths. Results could lose their first character, point into the wrong directory, or falsely appear to be directories.

## Why This Change Was Made

Format both backends in the existing result owner. Relativize absolute paths with the native path library, retain search-relative results, preserve directory markers and filename bytes, and represent the search directory itself as `.` or `./`. This removes both manual prefix-slicing paths without changing traversal, ignore rules, limits, stream handling, or public operation shapes. Production is net **−10 lines**; tests add 104 lines.

## User Impact

Agents can pass the returned filenames directly to `read`, including when the search directory has a trailing separator or filenames contain meaningful whitespace, Unicode, or a literal POSIX backslash. Custom backends retain the documented relative-or-absolute path contract. No configuration, migration, dependency, or operator action is required.

## Evidence

- Captured native and custom-backend failures before the repair, including a separate literal-backslash regression.
- Final focused suites: 40 passed, with one existing Windows-only case skipped on macOS.
- Actual native `fd` 10.5.0 on Darwin: all three final scenarios passed; the `read` tool successfully consumed all seven returned file paths. This proof uses temporary fixtures only, with downloads disabled.
- Committed tests use the existing hermetic process/custom-backend seams; no external `fd` installation is required in CI.
- The full maintained `check:changed` gate passed for all three changed paths, including all core test type shards and architecture checks.
- Independent P0–P2 source and behavior review passed; fresh automated review was scoped-clean at P0.
- [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33314428885) at `a9769e3ceab19b2f0663a75000db843bcc03d71b`, including the required merge gate.
- [ClawSweeper reviewed the exact head](https://github.com/openclaw/openclaw/pull/133302#issuecomment-5469032289): no findings and no before-merge actions.
- Native Windows execution was not performed locally; Windows separator cases are covered hermetically. The existing newline-delimited filename transport is unchanged; this repair does not claim support for filenames containing newlines.
