### PR TITLE
fix(cli): skip the startup config guard for plugin authoring commands

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -608,6 +608,12 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     },
     route: { id: "plugins-list" },
   },
+  // Authoring commands operate on a target package, not operator config, and a
+  // scaffolded plugin build can run through an older CLI; the startup guard
+  // would abort them on a host config they never read.
+  { commandPath: ["plugins", "build"], exact: true, policy: { configGuard: "skip" } },
+  { commandPath: ["plugins", "validate"], exact: true, policy: { configGuard: "skip" } },
+  { commandPath: ["plugins", "init"], exact: true, policy: { configGuard: "skip" } },
   {
     commandPath: ["onboard"],
     exact: true,

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -455,6 +455,17 @@ describe("command-path-policy", () => {
         loadPlugins: "never",
       });
     }
+    // Authoring commands operate on a target package, not operator config, so
+    // a host config the running CLI predates must not abort them.
+    for (const commandPath of [
+      ["plugins", "build"],
+      ["plugins", "validate"],
+      ["plugins", "init"],
+    ]) {
+      expectResolvedPolicy(commandPath, {
+        configGuard: "skip",
+      });
+    }
     expectResolvedPolicy(["cron", "list"], {
       configGuard: "skip",
       loadPlugins: "never",

--- a/src/cli/plugins-authoring.process.test.ts
+++ b/src/cli/plugins-authoring.process.test.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { runCliProcessChild } from "./cli-process-child.test-helpers.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const pluginId = "authoring-proof";
+const invalidConfig = '{"gateway":{"port":"invalid"}}\n';
+
+async function createAuthoringFixture(root: string) {
+  const project = path.join(root, "project");
+  await fs.mkdir(project, { recursive: true });
+  await fs.writeFile(
+    path.join(project, "package.json"),
+    JSON.stringify({
+      name: "openclaw-plugin-authoring-proof",
+      version: "1.0.0",
+      type: "module",
+      openclaw: { extensions: ["./index.ts"] },
+    }),
+  );
+  await fs.writeFile(
+    path.join(project, "index.ts"),
+    `import { defineToolPlugin } from "openclaw/plugin-sdk/tool-plugin";
+export default defineToolPlugin({
+  id: "authoring-proof", name: "Authoring Proof", description: "Authoring fixture.",
+  tools: (tool) => [tool({
+    name: "echo", description: "Echo input.",
+    parameters: { type: "object", properties: {} },
+    execute: async () => ({ ok: true }),
+  })],
+});
+`,
+  );
+  await fs.writeFile(
+    path.join(project, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: pluginId,
+      name: "Authoring Proof",
+      description: "Authoring fixture.",
+      version: "1.0.0",
+      configSchema: { type: "object", additionalProperties: false, properties: {} },
+      activation: { onStartup: true },
+      contracts: { tools: ["echo"] },
+    }),
+  );
+  return project;
+}
+
+async function runPlugins(root: string, args: string[]) {
+  const configPath = path.join(root, "openclaw.json");
+  await fs.writeFile(configPath, invalidConfig);
+  return runCliProcessChild({
+    nodeArgs: ["--import", "tsx", path.resolve("src", "entry.ts"), "plugins", ...args],
+    env: {
+      ...process.env,
+      HOME: root,
+      USERPROFILE: root,
+      NODE_DISABLE_COMPILE_CACHE: "1",
+      NODE_ENV: undefined,
+      NODE_OPTIONS: undefined,
+      NO_COLOR: "1",
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_HIDE_BANNER: "1",
+      OPENCLAW_HOME: root,
+      OPENCLAW_NO_RESPAWN: "1",
+      OPENCLAW_STATE_DIR: path.join(root, "state"),
+      VITEST: undefined,
+      VITEST_POOL_ID: undefined,
+      VITEST_WORKER_ID: undefined,
+    },
+  });
+}
+
+describe("plugin authoring with invalid host config", () => {
+  it.each(["init", "build", "validate"] as const)(
+    "runs plugins %s against its target package",
+    async (command) => {
+      const root = tempDirs.make("openclaw-plugin-authoring-process-");
+      const project =
+        command === "init" ? path.join(root, "project") : await createAuthoringFixture(root);
+      if (command === "build") {
+        await fs.unlink(path.join(project, "openclaw.plugin.json"));
+      }
+      const args =
+        command === "init"
+          ? [command, pluginId, "--directory", project]
+          : [command, "--root", project, ...(command === "validate" ? ["--json"] : [])];
+
+      const result = await runPlugins(root, args);
+
+      expect(result.code, result.stderr).toBe(0);
+      expect(await fs.readFile(path.join(root, "openclaw.json"), "utf8")).toBe(invalidConfig);
+      const manifest = JSON.parse(
+        await fs.readFile(path.join(project, "openclaw.plugin.json"), "utf8"),
+      );
+      expect(manifest).toMatchObject({ id: pluginId, contracts: { tools: ["echo"] } });
+      if (command === "validate") {
+        expect(JSON.parse(result.stdout)).toEqual({ valid: true, pluginId, errors: [] });
+      }
+    },
+  );
+
+  it("still rejects invalid host config for plugin enable", async () => {
+    const root = tempDirs.make("openclaw-plugin-enable-process-");
+    const result = await runPlugins(root, ["enable", pluginId]);
+    expect(result.code, result.stderr).toBe(1);
+    expect(result.stderr).toContain("OpenClaw config is invalid");
+    expect(await fs.readFile(path.join(root, "openclaw.json"), "utf8")).toBe(invalidConfig);
+  });
+});

--- a/test/vitest/vitest.cli-process-paths.mjs
+++ b/test/vitest/vitest.cli-process-paths.mjs
@@ -7,6 +7,7 @@ export const cliProcessTestFiles = [
   "src/cli/gateway-cli/shutdown-hard-exit.process.test.ts",
   "src/cli/help-exit.process.test.ts",
   "src/cli/hooks-cli.process.test.ts",
+  "src/cli/plugins-authoring.process.test.ts",
   "src/cli/mcp-cli.import-boundary.test.ts",
   "src/cli/gateway-cli/run-loop.direct-stop-active-work.process.test.ts",
 ];


### PR DESCRIPTION
## What Problem This Solves

Fixes #133303. Package-local `openclaw plugins init`, `build`, and `validate` can abort on invalid host configuration before they reach the target package.

## Why This Change Was Made

These three authoring commands now declare `configGuard: "skip"` on their exact leaves in the existing command catalog. Their handlers read or write a target plugin package and do not require operator config readiness. Plugin install, enable, disable, update, registry, and doctor keep their existing guards.

The repair stays at the startup policy owner. Allowing invalid config inside the guard would still perform unrelated state preflight, and skipping all plugin commands would change operator operations.

## User Impact

Plugin authors can scaffold, build metadata, and validate a target package even when the CLI cannot validate the host config. Operator commands still reject invalid config.

Thanks @ruel225 for the report and original repair.

## Evidence

- Real source-CLI regression against unchanged main: all three authoring commands fail on synthetic invalid `gateway.port`; the `plugins enable` rejection control passes. Temporary authored test bytes were removed and production hashes stayed unchanged.
- Added four actual CLI process cases assert generated package metadata, validation JSON, unchanged config bytes, and operator-command rejection. They are registered in the existing serial CLI process lane used by CI.
- Fresh complete-candidate Codex review completed with no actionable P0 findings. Trusted formatting and diff checks passed.
- Production LOC +6/-0: three exact catalog declarations plus their rationale. Tests +123/-0; test-support registration +1/-0. No new config key, runtime branch, timeout, or CI runner setting.
- Exact candidate [CLI process CI](https://github.com/openclaw/openclaw/actions/runs/33350111797/job/99361884619) passed all4 new cases and the complete9-file/85-test process suite. The exact-head aggregate CI run33350111797 completed successfully.

A valid-config unchanged-main fixture control also reached the existing100-second child guard during startup. An enabled startup timeline locates it inside legacy-state migration, before the authoring handler. Its internal cause remains unknown; no larger timeout or migration-internals repair is claimed. Candidate hosted CI has now passed all three authoring cases and the operator control; the aggregate CI gate also passed.

The latest ClawSweeper review at02:20UTC requested actual after-fix output. The linked hosted job now supplies all four named process results, satisfying its proof request and rank-up move. No post-review behavior change was made.
