### PR TITLE
fix(test): keep complete multi-project JSON reports

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -272,6 +272,54 @@ If `pnpm test` flakes on a loaded host, rerun once before treating it as a regre
 - `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test`
 - `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-cache pnpm test:changed`
 
+## JSON reports across native processes
+
+For a multi-project or chunked run, explicitly request native JSON with an output
+file, for example:
+
+```bash
+pnpm test test/vitest/vitest.unit-fast-isolated.config.ts test/vitest/vitest.agents-embedded-agent.config.ts --reporter=verbose --reporter=json --outputFile=.artifacts/test-results.json
+```
+
+The project runner and plugin batch runner give each attempt separate native JSON
+and blob files, then publish the requested JSON from Vitest's native report merge.
+They print a companion `<output>.reports-<unique>` directory. Keep that directory:
+it contains original reports, per-attempt coverage files when coverage is enabled,
+and an `index.json` with child exit codes, signals, timeouts and unstarted work.
+Only the accepted retry attempt contributes to the aggregate.
+
+The aggregate preserves the accepted case inventory, but is not a lossless
+replacement for the originals. Native merging does not restore snapshot summaries
+or JSON `coverageMap`, and its `startTime` is the merge time. Passing snapshot tests
+still succeed. Read native originals for those details and the index for process
+outcomes: JSON `success` does not encode every wrapper or unhandled-error failure.
+Separate built-in coverage reports remain per attempt in the companion directory.
+Custom coverage providers/reporters and coverage reporter tuple options require
+separate invocations with unique destinations.
+
+A complete failed-test aggregate is retained with a failing command exit. Missing
+or invalid evidence, cancellation, unstarted required work, or publication failure
+does not publish a complete aggregate; an existing output file is not proof of the
+new run. The diagnostic prints the retained report-set location. Report sets are
+not automatically swept.
+
+Overlapping selections can share native task IDs, so merging them can replace
+independent failure details even when case counts match. Such report sets retain
+their originals and fail publication. Select each configuration once, or run
+overlapping selections separately with distinct output files.
+
+This ownership applies to explicit CLI JSON file requests with named, file-based
+Node projects and native console reporters. Scalar `--outputFile` and
+`--outputFile.json` both work. Config-owned reporter options, other file formats,
+custom reporters and inline/browser project composition require separate native
+invocations with unique output destinations. Do not assume those outputs are
+aggregated. Single-process and console-only runs keep their existing native behavior.
+Native help and other non-test controls stay with the child CLI and do not allocate
+report sets. `run --version` still runs tests, as it does in native Vitest.
+Config-only reporters are not intercepted: multiple children can still overwrite
+the same configured file. Run those configurations separately with distinct paths;
+adding `--reporter=json` alone does not override a reporter tuple's own `outputFile`.
+
 ## Test performance tooling
 
 - `pnpm test:perf:imports`: enables Vitest import-duration + import-breakdown reporting, while still using scoped lane routing for explicit file/directory targets. `pnpm test:perf:imports:changed` scopes the same profiling to files changed since `origin/main`.

--- a/scripts/lib/vitest-batch-runner.mts
+++ b/scripts/lib/vitest-batch-runner.mts
@@ -4,12 +4,14 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { createPnpmRunnerSpawnSpec } from "../pnpm-runner.mts";
 import { installVitestProcessGroupCleanup } from "../vitest-process-group.mts";
 import { spawnOwnedVitestProcess } from "./vitest-process.mts";
+import type { VitestReportOutcome } from "./vitest-report-owner.mts";
 
 export type VitestBatchRunParams = {
   args: string[];
   config: string;
   env?: NodeJS.ProcessEnv;
   targets: string[];
+  onComplete?: (outcome: VitestReportOutcome) => void;
 };
 
 const scriptFile = fileURLToPath(import.meta.url);
@@ -40,6 +42,12 @@ export async function runVitestBatch(params: VitestBatchRunParams): Promise<numb
     });
     completion.finally(teardownChildCleanup).then((result) => {
       const { code, signal } = result;
+      if (params.onComplete) {
+        const outcome = { code: code ?? 1, signal: forwardedSignal ?? signal };
+        params.onComplete(outcome);
+        resolve(outcome.code);
+        return;
+      }
       if (forwardedSignal) {
         process.kill(process.pid, forwardedSignal);
         return;

--- a/scripts/lib/vitest-report-capture.mts
+++ b/scripts/lib/vitest-report-capture.mts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import type { Reporter, TestModule, TestProject, TestSpecification, Vitest } from "vitest/node";
+
+function projectIdentity(project: TestProject) {
+  return {
+    name: project.name,
+    root: project.config.root,
+    config: project.vite.config.configFile,
+    pool: project.config.pool,
+  };
+}
+
+function moduleIdentity(spec: TestSpecification) {
+  return {
+    ...projectIdentity(spec.project),
+    file: spec.moduleId,
+    pool: spec.pool,
+    taskId: spec.taskId,
+  };
+}
+
+// Native Istanbul reporter destinations (istanbul-reports/lib/*/index.js).
+// Tuple options/custom reporters can select their own paths and need a separate contract.
+const coverageFiles: Record<string, string[]> = {
+  text: [],
+  "text-summary": [],
+  "text-lcov": [],
+  teamcity: [],
+  none: [],
+  json: ["coverage-final.json"],
+  "json-summary": ["coverage-summary.json"],
+  lcov: ["lcov.info", "lcov-report/index.html"],
+  lcovonly: ["lcov.info"],
+  html: ["index.html"],
+  "html-spa": ["index.html"],
+  clover: ["clover.xml"],
+  cobertura: ["cobertura-coverage.xml"],
+};
+
+export type VitestReportCapture = {
+  pid: number;
+  command: string[];
+  root: string;
+  projects: ReturnType<typeof projectIdentity>[];
+  modules: ReturnType<typeof moduleIdentity>[];
+  coverageDirectory: string | null;
+  coverageFiles: string[];
+  coverageOnFailure: boolean;
+  processTimedOut: boolean;
+  passWithNoTests: boolean;
+  ignoreUnhandledErrors: boolean;
+  ended?: { reason: string; unhandledErrors: number; failedModules: number };
+};
+
+const sorted = (values: unknown[]) => values.map((value) => JSON.stringify(value)).toSorted();
+
+/** Observe native loading and replay; never replace reporters or reconstruct native tasks. */
+export default class VitestReportCaptureReporter implements Reporter {
+  private output = "";
+  private capture!: VitestReportCapture;
+  private expected: VitestReportCapture[];
+
+  constructor(options: { expected?: VitestReportCapture[] } = {}) {
+    this.expected = options.expected ?? [];
+  }
+
+  onInit(ctx: Vitest) {
+    const output = ctx.config.outputFile;
+    assert(output && typeof output === "object" && typeof output.json === "string");
+    this.output = `${output.json}.capture.json`;
+    for (const reporter of ctx.config.reporters) {
+      if (Array.isArray(reporter) && ["json", "blob"].includes(reporter[0])) {
+        assert(
+          !("outputFile" in reporter[1] && reporter[1].outputFile != null) &&
+            !("filterMeta" in reporter[1] && reporter[1].filterMeta != null),
+          "Multi-invocation JSON cannot preserve config-owned reporter options. Run each config separately with its own native output file.",
+        );
+      }
+    }
+    const projects = ctx.projects.map(projectIdentity);
+    assert(
+      projects.every(
+        (project, index) =>
+          project.name && project.config && !ctx.projects[index]!.isBrowserEnabled(),
+      ),
+      "Multi-invocation JSON requires named file-based Node projects; run inline/browser configurations separately.",
+    );
+    const coverage = ctx.config.coverage;
+    const expectedCoverage = coverage.enabled
+      ? coverage.reporter.flatMap(([name, options]) => {
+          assert(
+            (coverage.provider === "v8" || coverage.provider === "istanbul") &&
+              Object.hasOwn(coverageFiles, name) &&
+              Object.keys(options).length === 0,
+            "Multi-invocation JSON cannot own custom coverage providers/reporters or tuple options. Run each config separately with unique coverage destinations.",
+          );
+          return coverageFiles[name]!;
+        })
+      : [];
+    this.capture = {
+      pid: process.pid,
+      command: [process.execPath, ...process.execArgv, ...process.argv.slice(1)],
+      root: ctx.config.root,
+      projects,
+      modules: [],
+      coverageDirectory: ctx.config.coverage.enabled ? ctx.config.coverage.reportsDirectory : null,
+      coverageFiles: expectedCoverage,
+      coverageOnFailure: coverage.reportOnFailure,
+      processTimedOut: false,
+      passWithNoTests: ctx.config.passWithNoTests,
+      ignoreUnhandledErrors: ctx.config.dangerouslyIgnoreUnhandledErrors,
+    };
+    if (this.expected.length) {
+      const expectedProjects = [
+        ...new Set(this.expected.flatMap((capture) => sorted(capture.projects))),
+      ].toSorted();
+      assert.deepEqual(sorted(projects), expectedProjects, "Native merge project identity changed");
+    }
+    this.writeCapture();
+  }
+
+  onTestRunStart(specs: readonly TestSpecification[]) {
+    if (this.expected.length) {
+      assert.deepEqual(
+        sorted(specs.map(moduleIdentity)),
+        sorted(this.expected.flatMap((capture) => capture.modules)),
+        "Native merge module/project/root/pool attribution changed",
+      );
+    }
+  }
+
+  onTestRunEnd(modules: readonly TestModule[], errors: readonly unknown[], reason: string) {
+    this.capture.modules = modules.map((module) => moduleIdentity(module.toTestSpecification()));
+    this.capture.ended = {
+      reason,
+      unhandledErrors: errors.length,
+      failedModules: modules.filter((module) => !module.ok()).length,
+    };
+    this.writeCapture();
+  }
+
+  onProcessTimeout() {
+    this.capture.processTimedOut = true;
+    this.writeCapture();
+  }
+
+  private writeCapture() {
+    fs.mkdirSync(path.dirname(this.output), { recursive: true });
+    fs.writeFileSync(this.output, JSON.stringify(this.capture));
+  }
+}

--- a/scripts/lib/vitest-report-owner.mts
+++ b/scripts/lib/vitest-report-owner.mts
@@ -1,0 +1,399 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { JsonTestResults } from "vitest/node";
+import type { VitestReportCapture } from "./vitest-report-capture.mts";
+
+export type VitestReportOutcome = {
+  code: number;
+  signal: NodeJS.Signals | null;
+  noOutputTimedOut?: boolean;
+};
+type Invocation = { config: string; args: string[]; includePatterns?: string[] | null };
+type Attempt = { json: string; blob: string; outcome?: VitestReportOutcome; error?: string };
+
+const captureReporter = fileURLToPath(new URL("./vitest-report-capture.mts", import.meta.url));
+const consoleReporters = new Set([
+  "json",
+  "default",
+  "verbose",
+  "dot",
+  "agent",
+  "minimal",
+  "tree",
+  "github-actions",
+  "hanging-process",
+]);
+
+function withoutOutputArgs(args: string[]) {
+  const result: string[] = [];
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]!;
+    if (arg === "--") {
+      return [...result, ...args.slice(index)];
+    }
+    if (/^--(?:output(?:File|-file)(?:\.[^=]+)?|coverage\.reportsDirectory)(?:=|$)/u.test(arg)) {
+      if (!arg.includes("=")) {
+        index++;
+      }
+    } else {
+      result.push(arg);
+    }
+  }
+  return result;
+}
+
+function caseInventory(reports: JsonTestResults[]) {
+  return reports
+    .flatMap((report) =>
+      report.testResults.flatMap((file) =>
+        file.assertionResults.map((test) =>
+          JSON.stringify([file.name, test.fullName, test.status]),
+        ),
+      ),
+    )
+    .toSorted();
+}
+
+function nativeHelpRequested(args: string[], parseCLI: typeof import("vitest/node").parseCLI) {
+  const controls: string[] = [];
+  for (const [index, original] of args.entries()) {
+    if (original === "--") {
+      break;
+    }
+    // CAC treats every prefix except exactly two dashes as a short-option group.
+    const arg = original.replace(/^---+/u, "-");
+    // Project only help onto native watch's boolean/short-alias grammar.
+    // parseCLI(help) prints and skips validation; only the real child may do that.
+    const projected = arg.startsWith("--")
+      ? arg.replace(
+          /^--(no-)?(help|h)(?=[.=]|$)/u,
+          (_, no: string | undefined, name: string) =>
+            `--${no ?? ""}${name === "h" ? "w" : "watch"}`,
+        )
+      : arg.startsWith("-no-")
+        ? arg.replace(/^-no-(help|h)$/u, (_, name: string) =>
+            name === "h" ? "-no-w" : "-no-watch",
+          )
+        : arg.replace(
+            /^-(?!-)([^=]+)/u,
+            (_, flags: string) => `-${flags.replace(/[^h]/gu, "x").replaceAll("h", "w")}`,
+          );
+    if (projected === arg || !/watch|w/u.test(projected)) {
+      continue;
+    }
+    controls.push(projected);
+    const value = args[index + 1];
+    if (value && !value.startsWith("-")) {
+      controls.push(value);
+    }
+  }
+  return Boolean(
+    parseCLI(["vitest", "run", ...controls], { allowUnknownOptions: true }).options.watch,
+  );
+}
+
+/** Own file artifacts only; callers retain admission, retry, environment and process ownership. */
+export async function createVitestReportOwner(invocations: Invocation[], cwd: string) {
+  if (
+    invocations.length < 2 ||
+    invocations.some(({ args }) => args[0] !== "run") ||
+    !invocations.some(({ args }) => args.some((arg) => /^--reporters?(?:=|$)/u.test(arg))) ||
+    !invocations.some(({ args }) =>
+      args.some((arg) => /^--output(?:File|-file)(?:\.|=|$)/u.test(arg)),
+    )
+  ) {
+    return null;
+  }
+  const { parseCLI } = await import("vitest/node");
+  // Both schedulers emit named `run`: unlike `--run --version`, `run --version`
+  // executes tests. Help was classified without output; native errors stay in the child.
+  let parsed: ReturnType<typeof parseCLI>[];
+  try {
+    if (invocations.some(({ args }) => nativeHelpRequested(args, parseCLI))) {
+      return null;
+    }
+    parsed = invocations.map(({ args }) => parseCLI(["vitest", ...args]));
+  } catch {
+    // Repeated help is truthy in CAC but watch rejects repeated scalar values.
+    // That and all native parse errors must be handled by the actual child.
+    return null;
+  }
+  if (
+    parsed.some(
+      ({ options, filter }) =>
+        options.watch ||
+        options.listTags ||
+        options.clearCache ||
+        options.mergeReports ||
+        (options.standalone && !filter.length),
+    )
+  ) {
+    return null;
+  }
+  const runOptions = parsed.map(({ options }) => options);
+  const requests = runOptions.map((option) => {
+    // Native CLI's singular alias is distinct from config-defined reporters.
+    const reporters = (option as typeof option & { reporter?: string[] }).reporter ?? [];
+    const output =
+      typeof option.outputFile === "string" ? option.outputFile : option.outputFile?.json;
+    return reporters.includes("json") && output && !option.watch ? { reporters, output } : null;
+  });
+  if (requests.every((request) => !request)) {
+    return null;
+  }
+  assert(requests.every(Boolean), "Every invocation must share the explicit JSON file request");
+  const request = requests[0]!;
+  assert(
+    requests.every((entry) => entry!.output === request.output),
+    "JSON destinations differ across invocations",
+  );
+  assert(
+    requests.every((entry) => entry!.reporters.every((name) => consoleReporters.has(name))),
+    "Multi-invocation JSON supports native JSON plus console reporters. Run other file/custom reporters separately with unique destinations.",
+  );
+  const { readJsonFile, validateVitestJsonReport } = await import("../test-report-utils.mts");
+  function readNativeReport(file: string) {
+    const invalid = validateVitestJsonReport(file);
+    assert.equal(invalid, null);
+    return readJsonFile(file) as JsonTestResults;
+  }
+
+  const requested = path.resolve(cwd, request.output);
+  fs.mkdirSync(path.dirname(requested), { recursive: true });
+  const directory = fs.mkdtempSync(`${requested}.reports-`);
+  const entries = invocations.map(({ config, args, includePatterns }, invocation) => ({
+    invocation: invocation + 1,
+    config,
+    args,
+    includePatterns,
+    state: "unstarted",
+    acceptedAttempt: null as number | null,
+    attempts: [] as Attempt[],
+  }));
+  const index = {
+    requested,
+    complete: false,
+    entries,
+    error: "",
+    aggregate: "",
+    publication: "",
+    merge: null as VitestReportOutcome | null,
+  };
+  const save = () =>
+    fs.writeFileSync(path.join(directory, "index.json"), JSON.stringify(index, null, 2));
+  save();
+  console.error(`[test] native report set: ${directory}`);
+
+  return {
+    attempt(invocation: number, args: string[]) {
+      const entry = entries[invocation]!;
+      const attemptDirectory = path.join(
+        directory,
+        `${invocation + 1}`,
+        `${entry.attempts.length + 1}`,
+      );
+      fs.mkdirSync(attemptDirectory, { recursive: true });
+      const attempt: Attempt = {
+        json: path.join(attemptDirectory, "report.json"),
+        blob: path.join(attemptDirectory, "blob.json"),
+      };
+      entry.attempts.push(attempt);
+      entry.state = "started";
+      save();
+      const reportArgs = [
+        `--outputFile.json=${attempt.json}`,
+        `--outputFile.blob=${attempt.blob}`,
+        `--coverage.reportsDirectory=${path.join(attemptDirectory, "coverage")}`,
+        "--reporter=blob",
+        `--reporter=${captureReporter}`,
+      ];
+      const original = withoutOutputArgs(args);
+      const separator = original.indexOf("--");
+      original.splice(separator < 0 ? original.length : separator, 0, ...reportArgs);
+      return {
+        args: original,
+        complete(outcome: VitestReportOutcome) {
+          attempt.outcome = outcome;
+          entry.state = "finished";
+          save();
+        },
+        fail(error: unknown) {
+          attempt.error = String(error);
+          entry.state = "error";
+          save();
+        },
+      };
+    },
+    async finish(
+      runMerge: (args: string[]) => Promise<VitestReportOutcome>,
+      incompleteReason?: string,
+    ) {
+      try {
+        if (incompleteReason) {
+          throw new Error(incompleteReason);
+        }
+        const attempts = entries.map((entry) => entry.attempts.at(-1));
+        assert(
+          attempts.every(
+            (attempt) =>
+              attempt?.outcome &&
+              !attempt.error &&
+              !attempt.outcome.signal &&
+              !attempt.outcome.noOutputTimedOut,
+          ),
+          "Report set incomplete: unstarted, interrupted or unsuccessful attempt completion",
+        );
+        const accepted = attempts as Attempt[];
+        entries.forEach((entry) => {
+          entry.acceptedAttempt = entry.attempts.length;
+        });
+        const reports = accepted.map((attempt) => readNativeReport(attempt.json));
+        const captures = accepted.map(
+          (attempt) => readJsonFile(`${attempt.json}.capture.json`) as VitestReportCapture,
+        );
+        assert(
+          captures.every(
+            (capture) =>
+              capture.ended && capture.ended.reason !== "interrupted" && !capture.processTimedOut,
+          ),
+          "Native report completion evidence missing or interrupted",
+        );
+        const taskIds = captures.flatMap((capture) =>
+          capture.modules.map((module) => module.taskId),
+        );
+        assert.equal(
+          new Set(taskIds).size,
+          taskIds.length,
+          "Native merge would replace overlapping task identities; originals retained. Run overlapping selections separately with unique output files.",
+        );
+        captures.forEach((capture, i) => {
+          if (
+            !capture.coverageDirectory ||
+            (reports[i]!.numFailedTests > 0 && !capture.coverageOnFailure)
+          ) {
+            return;
+          }
+          for (const file of capture.coverageFiles) {
+            assert(
+              fs.statSync(path.join(capture.coverageDirectory, file)).isFile(),
+              `Missing native coverage report: ${file}`,
+            );
+          }
+        });
+        const destinations = new Set(
+          captures.map((capture) => path.resolve(capture.root, request.output)),
+        );
+        assert.equal(
+          destinations.size,
+          1,
+          "Relative outputFile resolves to different project roots; use an absolute destination",
+        );
+        const destination = [...destinations][0]!;
+        const projectConfigs = [
+          ...new Map(
+            captures
+              .flatMap((capture) => capture.projects)
+              .map((project) => [JSON.stringify(project), project]),
+          ).values(),
+        ].map((project) => {
+          assert(typeof project.config === "string", "Missing native project configuration");
+          // Native file-project loading otherwise forces the config's directory as root.
+          return { extends: project.config, root: project.root };
+        });
+        const blobs = path.join(directory, "accepted-blobs");
+        fs.mkdirSync(blobs);
+        accepted.forEach((attempt, i) =>
+          fs.copyFileSync(attempt.blob, path.join(blobs, `${i}.json`)),
+        );
+        const staged = path.join(directory, "aggregate.json");
+        const config = path.join(directory, "vitest.merge.config.mjs");
+        fs.writeFileSync(
+          config,
+          `export default ${JSON.stringify({
+            root: cwd,
+            test: {
+              projects: projectConfigs,
+              coverage: { enabled: false },
+              passWithNoTests: captures.every((capture) => capture.passWithNoTests),
+              dangerouslyIgnoreUnhandledErrors: captures.every(
+                (capture) => capture.ignoreUnhandledErrors || capture.ended!.unhandledErrors === 0,
+              ),
+              reporters: [
+                ["json", {}],
+                [captureReporter, { expected: captures }],
+              ],
+            },
+          })};\n`,
+        );
+        const mergeArgs = [
+          "run",
+          "--mergeReports",
+          blobs,
+          "--config",
+          config,
+          "--configLoader=runner",
+          `--outputFile.json=${staged}`,
+        ];
+        if (typeof runOptions[0]?.pool === "string") {
+          mergeArgs.push("--pool", runOptions[0].pool);
+        }
+        index.merge = await runMerge(mergeArgs);
+        const merged = readNativeReport(staged);
+        const replay = readJsonFile(`${staged}.capture.json`) as VitestReportCapture;
+        assert(
+          replay.ended &&
+            !replay.processTimedOut &&
+            !index.merge.signal &&
+            !index.merge.noOutputTimedOut,
+          "Native merge did not complete",
+        );
+        assert.equal(
+          replay.ended.unhandledErrors,
+          captures.reduce((total, capture) => total + capture.ended!.unhandledErrors, 0),
+          "Native merge added or lost unhandled errors",
+        );
+        // Exit 1 also represents a complete failed test run. A replay failure must not be mistaken for it.
+        const expectedFailure = captures.some(
+          (capture) =>
+            capture.ended!.reason === "failed" ||
+            capture.ended!.failedModules ||
+            (!capture.ignoreUnhandledErrors && capture.ended!.unhandledErrors),
+        );
+        assert(
+          index.merge.code === 0 || (index.merge.code === 1 && expectedFailure),
+          "Native merge failed",
+        );
+        assert.deepEqual(
+          caseInventory([merged]),
+          caseInventory(reports),
+          "Native aggregate case inventory differs from accepted reports",
+        );
+        fs.mkdirSync(path.dirname(destination), { recursive: true });
+        const publication = fs.mkdtempSync(`${destination}.publish-`);
+        index.publication = publication;
+        save();
+        const publicationFile = path.join(publication, "report.json");
+        fs.copyFileSync(staged, publicationFile);
+        fs.renameSync(publicationFile, destination);
+        fs.rmdirSync(publication);
+        index.publication = "";
+        index.aggregate = destination;
+        index.complete = true;
+        console.error(
+          `[test] native JSON aggregate: ${destination}; originals: ${directory}. Native merge omits snapshot summaries and JSON coverageMap; startTime is merge time. Use index.json for process outcomes.`,
+        );
+        return index.merge.code;
+      } catch (error) {
+        index.error = String(error);
+        console.error(`[test] report publication failed; retained ${directory}: ${index.error}`);
+        return 1;
+      } finally {
+        save();
+      }
+    },
+  };
+}
+
+export type VitestReportOwner = Awaited<ReturnType<typeof createVitestReportOwner>>;

--- a/scripts/test-extension-batch.mts
+++ b/scripts/test-extension-batch.mts
@@ -22,6 +22,7 @@ import { parsePositiveInt } from "./lib/numeric-options.mjs";
 import { isDirectScriptRun, runVitestBatch } from "./lib/vitest-batch-runner.mts";
 import type { VitestBatchRunParams } from "./lib/vitest-batch-runner.mts";
 import { prepareVitestRuntime } from "./lib/vitest-build-prerequisites.mts";
+import { createVitestReportOwner, type VitestReportOutcome } from "./lib/vitest-report-owner.mts";
 
 const FS_MODULE_CACHE_PATH_ENV_KEY = "OPENCLAW_VITEST_FS_MODULE_CACHE_PATH";
 const PARALLEL_ENV_KEY = "OPENCLAW_EXTENSION_BATCH_PARALLEL";
@@ -193,8 +194,9 @@ function preparePlanGroup(
 
 async function runPlanGroup(
   { group, invocations }: ReturnType<typeof preparePlanGroup>,
-  runGroup: (params: VitestBatchRunParams) => Promise<number>,
+  runGroup: (params: ReturnType<typeof preparePlanGroup>["invocations"][number]) => Promise<number>,
   allowEmptyAfterExclude: boolean,
+  isCancelled: () => boolean,
 ) {
   if (invocations.length === 0) {
     console.error(`[test-extension-batch] ${group.config}: no test files remain after excludes`);
@@ -202,6 +204,9 @@ async function runPlanGroup(
   }
   let finalExitCode = 0;
   for (const [index, invocation] of invocations.entries()) {
+    if (isCancelled()) {
+      break;
+    }
     console.log(
       `[test-extension-batch] ${group.config}: ${group.extensionIds.join(", ")} (${invocation.targets.length} targets${invocations.length > 1 ? `, chunk ${index + 1}/${invocations.length}` : ""})`,
     );
@@ -246,34 +251,131 @@ export async function runExtensionBatchPlan(
   const preparedGroups = orderedGroups.map((group, index) =>
     preparePlanGroup(group, index, env, vitestArgs, exactExcludePaths, useDedicatedCache),
   );
-  // No reader may start while a shared generation is being replaced. Select
-  // from the exact emitted chunks, including existing exact-exclude expansion.
-  const preparationCode = await prepareVitestRuntime(
-    preparedGroups.flatMap(({ invocations }) =>
-      invocations.map(({ config, args, targets }) => ({
-        configs: [config],
-        cli: { args: [...args, ...targets], dir: "extensions", env },
-      })),
-    ),
-    env,
+  const invocations = preparedGroups.flatMap((group) => group.invocations);
+  const reports = await createVitestReportOwner(
+    invocations.map((invocation) => ({
+      config: invocation.config,
+      args: ["run", "--config", invocation.config, ...invocation.args, ...invocation.targets],
+    })),
+    path.resolve(import.meta.dirname, ".."),
   );
-  if (preparationCode !== 0) {
-    return preparationCode;
+  const termination: { signal: NodeJS.Signals | null } = { signal: null };
+  const onSignal = (value: NodeJS.Signals) => {
+    termination.signal ??= value;
+  };
+  if (reports) {
+    process.on("SIGTERM", onSignal);
+    process.on("SIGINT", onSignal);
   }
+  let reportFailure: string | undefined;
   let exitCode = 0;
-  await pMap(
-    preparedGroups,
-    async (group) => {
-      if (exitCode !== 0) {
-        return;
+  const started: Promise<unknown>[] = [];
+  const runInvocation = async (
+    invocation: ReturnType<typeof preparePlanGroup>["invocations"][number],
+  ) => {
+    const attempt = reports?.attempt(invocations.indexOf(invocation), invocation.args);
+    if (!attempt) {
+      return runGroup(invocation);
+    }
+    try {
+      let outcome: VitestReportOutcome | undefined;
+      const code = await runGroup({
+        ...invocation,
+        args: attempt.args,
+        onComplete(value) {
+          outcome = value;
+          termination.signal ??= value.signal;
+        },
+      });
+      attempt.complete(outcome ?? { code, signal: null });
+      return code;
+    } catch (error) {
+      attempt.fail(error);
+      throw error;
+    }
+  };
+  try {
+    // No reader may start while a shared generation is being replaced. Select
+    // from the exact emitted chunks, including existing exact-exclude expansion.
+    const preparationCode = await prepareVitestRuntime(
+      preparedGroups.flatMap((group) =>
+        group.invocations.map(({ config, args, targets }) => ({
+          configs: [config],
+          cli: { args: [...args, ...targets], dir: "extensions", env },
+        })),
+      ),
+      env,
+    );
+    if (preparationCode !== 0) {
+      exitCode = preparationCode;
+      reportFailure = "Runtime preparation failed; invocations unstarted";
+      return exitCode;
+    }
+    try {
+      await pMap(
+        preparedGroups,
+        async (group) => {
+          if (exitCode !== 0 || termination.signal) {
+            return;
+          }
+          const running = runPlanGroup(
+            group,
+            runInvocation,
+            allowEmptyAfterExclude,
+            () => termination.signal !== null,
+          ).then((groupExitCode) => {
+            if (groupExitCode !== 0 && exitCode === 0) {
+              exitCode = groupExitCode;
+            }
+          });
+          started.push(running);
+          await running;
+        },
+        { concurrency: parallelism, stopOnError: true },
+      );
+    } finally {
+      await Promise.allSettled(started);
+    }
+  } catch (error) {
+    reportFailure = String(error);
+    throw error;
+  } finally {
+    if (reports) {
+      try {
+        const reportCode = await reports.finish(
+          async (mergeArgs) => {
+            const args = mergeArgs.slice(1);
+            const configIndex = args.indexOf("--config");
+            const config = args.splice(configIndex, 2)[1]!;
+            let outcome: VitestReportOutcome | undefined;
+            const code = await runVitestBatch({
+              config,
+              args,
+              targets: [],
+              env,
+              onComplete(value) {
+                outcome = value;
+                termination.signal ??= value.signal;
+              },
+            });
+            return outcome ?? { code, signal: null };
+          },
+          termination.signal ? `Cancelled by ${termination.signal}` : reportFailure,
+        );
+        exitCode ||= reportCode;
+      } finally {
+        process.off("SIGTERM", onSignal);
+        process.off("SIGINT", onSignal);
+        if (termination.signal) {
+          process.kill(process.pid, termination.signal);
+          // Give the re-raised signal a turn before a CLI caller exits with the numeric result.
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
+        }
       }
-      const groupExitCode = await runPlanGroup(group, runGroup, allowEmptyAfterExclude);
-      if (groupExitCode !== 0 && exitCode === 0) {
-        exitCode = groupExitCode;
-      }
-    },
-    { concurrency: parallelism, stopOnError: true },
-  );
+    }
+  }
   return exitCode;
 }
 

--- a/scripts/test-projects.mts
+++ b/scripts/test-projects.mts
@@ -14,6 +14,7 @@ import {
   resolveLocalFullSuiteProfile,
   resolveLocalVitestEnv,
 } from "./lib/vitest-local-scheduling.mts";
+import { createVitestReportOwner, type VitestReportOwner } from "./lib/vitest-report-owner.mts";
 import {
   createShardTimingSample,
   readShardTimings,
@@ -49,7 +50,7 @@ import {
   writeVitestIncludeFile,
 } from "./test-projects.test-support.mts";
 
-type VitestRunSpec = BaseVitestRunSpec & { continueOnFailure?: boolean };
+type VitestRunSpec = BaseVitestRunSpec & { continueOnFailure?: boolean; reportIndex?: number };
 type VitestCommandOutcome = {
   code: number;
   noOutputTimedOut: boolean;
@@ -120,7 +121,7 @@ function runPnpmSpecCommand(spec: VitestRunSpec, pnpmArgs: string[]) {
   });
 }
 
-async function runVitestSpec(spec: VitestRunSpec) {
+async function runVitestSpec(spec: VitestRunSpec, reports: VitestReportOwner) {
   if (spec.includeFilePath && spec.includePatterns) {
     writeVitestIncludeFile(spec.includeFilePath, spec.includePatterns, {
       expandGlobs: !spec.watchMode,
@@ -134,7 +135,15 @@ async function runVitestSpec(spec: VitestRunSpec) {
         return preflightResult;
       }
     }
-    return await runPnpmSpecCommand(spec, spec.pnpmArgs);
+    const attempt = reports?.attempt(spec.reportIndex!, spec.pnpmArgs);
+    try {
+      const result = await runPnpmSpecCommand(spec, attempt?.args ?? spec.pnpmArgs);
+      attempt?.complete(result);
+      return result;
+    } catch (error) {
+      attempt?.fail(error);
+      throw error;
+    }
   } finally {
     cleanupVitestRunSpec(spec);
   }
@@ -154,13 +163,13 @@ function applyDefaultParallelVitestWorkerBudget(specs: VitestRunSpec[], env: Nod
   }));
 }
 
-async function runLoggedVitestSpec(spec: VitestRunSpec) {
+async function runLoggedVitestSpec(spec: VitestRunSpec, reports: VitestReportOwner) {
   console.error(`[test] starting ${spec.config}`);
   const startedAt = performance.now();
-  let result = await runVitestSpec(spec);
+  let result = await runVitestSpec(spec, reports);
   if (result.noOutputTimedOut && !spec.watchMode && shouldRetryVitestNoOutputTimeout(spec.env)) {
     console.error(`[test] retrying ${spec.config} after no-output timeout`);
-    result = await runVitestSpec(withRetryNoOutputTimeout(spec));
+    result = await runVitestSpec(withRetryNoOutputTimeout(spec), reports);
   }
   const durationMs = performance.now() - startedAt;
   if (result.noOutputTimedOut && result.signal) {
@@ -174,6 +183,9 @@ async function runLoggedVitestSpec(spec: VitestRunSpec) {
   }
   if (result.signal) {
     console.error(`[test] ${spec.config} exited by signal ${result.signal}`);
+    if (reports) {
+      return { ...result, timing: null };
+    }
     process.kill(process.pid, result.signal);
     return null;
   }
@@ -204,42 +216,65 @@ function printNoChangedTestTargets(args: string[], cwd: string, baseEnv: NodeJS.
   }
 }
 
-async function runVitestSpecsParallel(specs: VitestRunSpec[], concurrency: number) {
+async function runVitestSpecs(
+  specs: VitestRunSpec[],
+  concurrency: number,
+  reports: VitestReportOwner,
+  termination: { signal: NodeJS.Signals | null },
+) {
   let exitCode = 0;
   let stopScheduling = false;
   const failures: FailedVitestShard[] = [];
   const timings: ShardTiming[] = [];
+  const started: Promise<unknown>[] = [];
+  let interrupted = false;
 
-  await pMap(
-    specs,
-    async (spec, index) => {
-      if (stopScheduling) {
-        return;
-      }
-      const result = await runLoggedVitestSpec(spec);
-      if (!result) {
-        // A forwarded termination signal must not admit replacement shards during shutdown.
-        stopScheduling = true;
-        return;
-      }
-      if (result.code !== 0) {
-        exitCode = exitCode || result.code;
-        failures.push({
-          code: result.code,
-          config: spec.config,
-          includePatterns: spec.includePatterns,
-          noOutputTimedOut: result.noOutputTimedOut,
-          order: index,
-          signal: result.signal,
-        });
-      }
-      if (result.timing) {
-        timings.push(result.timing);
-      }
-    },
-    { concurrency, stopOnError: true },
-  );
-  return { exitCode, failures, timings };
+  try {
+    await pMap(
+      specs,
+      (spec, index) => {
+        const running = (async () => {
+          if (stopScheduling || termination.signal) {
+            return;
+          }
+          const result = await runLoggedVitestSpec(spec, reports);
+          if (!result) {
+            // A forwarded termination signal must not admit replacement shards during shutdown.
+            stopScheduling = true;
+            interrupted = true;
+            return;
+          }
+          if (result.signal) {
+            termination.signal ??= result.signal;
+            stopScheduling = true;
+          }
+          if (result.code !== 0) {
+            exitCode = exitCode || result.code;
+            if (concurrency === 1 && spec.continueOnFailure !== true) {
+              stopScheduling = true;
+            }
+            failures.push({
+              code: result.code,
+              config: spec.config,
+              includePatterns: spec.includePatterns,
+              noOutputTimedOut: result.noOutputTimedOut,
+              order: index,
+              signal: result.signal,
+            });
+          }
+          if (result.timing) {
+            timings.push(result.timing);
+          }
+        })();
+        started.push(running);
+        return running;
+      },
+      { concurrency, stopOnError: true },
+    );
+  } finally {
+    await Promise.allSettled(started);
+  }
+  return { exitCode, failures, timings, stopScheduling, interrupted };
 }
 
 async function main() {
@@ -292,7 +327,7 @@ async function main() {
           baseEnv,
           cwd: process.cwd(),
         });
-  const runSpecs = applyDefaultMultiSpecVitestCachePaths(
+  const runSpecs: VitestRunSpec[] = applyDefaultMultiSpecVitestCachePaths(
     applyDefaultVitestNoOutputTimeout(
       applyFullExtensionsHeapBudget(rawRunSpecs, { env: baseEnv }),
       {
@@ -308,106 +343,141 @@ async function main() {
     return;
   }
 
-  const e2eSpecs = runSpecs.filter((spec) => spec.config === "test/vitest/vitest.e2e.config.ts");
-  if (e2eSpecs.length > 0) {
-    const preparedEnv = await prepareE2eVitestRuntime(baseEnv);
-    for (const spec of e2eSpecs) {
-      spec.env = { ...spec.env, ...preparedEnv };
-    }
-  } else {
-    const code = await prepareVitestRuntime(
-      runSpecs.map((spec) => ({ configs: [spec.config], includePatterns: spec.includePatterns })),
-      baseEnv,
-    );
-    if (code !== 0) {
-      printTestSummary("failed", 0, performance.now() - suiteStartedAt);
-      process.exitCode = code;
-      return;
-    }
+  runSpecs.forEach((spec, index) => {
+    spec.reportIndex = index;
+  });
+  const reports = await createVitestReportOwner(
+    runSpecs.map((spec) => ({
+      config: spec.config,
+      includePatterns: spec.includePatterns,
+      args: spec.pnpmArgs.slice(spec.pnpmArgs.indexOf(resolveVitestCliEntry()) + 1),
+    })),
+    process.cwd(),
+  );
+  const termination: { signal: NodeJS.Signals | null } = { signal: null };
+  const onSignal = (signal: NodeJS.Signals) => {
+    termination.signal ??= signal;
+  };
+  if (reports) {
+    process.on("SIGTERM", onSignal);
+    process.on("SIGINT", onSignal);
   }
-
-  const isFullSuiteRun =
-    targetArgs.length === 0 &&
-    changedTargetArgs === null &&
-    !runSpecs.some((spec) => spec.watchMode);
-  const isExplicitParallelMultiConfigRun =
-    Boolean(baseEnv.OPENCLAW_TEST_PROJECTS_PARALLEL) &&
-    runSpecs.length > 1 &&
-    !runSpecs.some((spec) => spec.watchMode);
-  const isParallelShardRun =
-    isFullSuiteRun || isFullExtensionsProjectRun(runSpecs) || isExplicitParallelMultiConfigRun;
-  if (isParallelShardRun) {
-    const concurrency = resolveParallelFullSuiteConcurrency(runSpecs.length, baseEnv);
-    if (!isCiLikeEnv(baseEnv) && runSpecs.length > 1) {
-      console.warn(
-        `[test] warning: broad local run will start ${runSpecs.length} Vitest shards; use \`pnpm test:changed\` for routine checks.`,
-      );
-    }
-    if (concurrency > 1) {
-      const shardTimings = readShardTimings(process.cwd(), baseEnv);
-      const orderedSpecs = orderFullSuiteSpecsForParallelRun(runSpecs, shardTimings).filter(
-        (spec): spec is VitestRunSpec => spec !== undefined,
-      );
-      const parallelSpecs = applyDefaultParallelVitestWorkerBudget(
-        applyParallelVitestCachePaths(orderedSpecs, {
-          cwd: process.cwd(),
-          env: baseEnv,
-        }),
+  let reportFailure: string | undefined;
+  try {
+    const e2eSpecs = runSpecs.filter((spec) => spec.config === "test/vitest/vitest.e2e.config.ts");
+    if (e2eSpecs.length > 0) {
+      const preparedEnv = await prepareE2eVitestRuntime(baseEnv);
+      for (const spec of e2eSpecs) {
+        spec.env = { ...spec.env, ...preparedEnv };
+      }
+    } else {
+      const code = await prepareVitestRuntime(
+        runSpecs.map((spec) => ({ configs: [spec.config], includePatterns: spec.includePatterns })),
         baseEnv,
       );
-      console.error(
-        `[test] running ${parallelSpecs.length} Vitest shards with parallelism ${concurrency}`,
-      );
-      const {
-        exitCode: parallelExitCode,
-        failures,
-        timings,
-      } = await runVitestSpecsParallel(parallelSpecs, concurrency);
-      writeShardTimings(timings, process.cwd(), baseEnv);
-      printTestSummary(
-        parallelExitCode === 0 ? "passed" : "failed",
-        parallelSpecs.length,
-        performance.now() - suiteStartedAt,
-        "Vitest summaries above are per-shard, not aggregate totals.",
-      );
-      for (const line of formatFailedShardDigest(failures)) {
-        console.error(line);
-      }
-      if (parallelExitCode !== 0) {
-        process.exitCode = parallelExitCode;
-      }
-      return;
-    }
-  }
-
-  let exitCode = 0;
-  const timings: ShardTiming[] = [];
-  for (const spec of runSpecs) {
-    const result = await runLoggedVitestSpec(spec);
-    if (!result) {
-      return;
-    }
-    if (result.timing) {
-      timings.push(result.timing);
-    }
-    if (result.code !== 0) {
-      exitCode = exitCode || result.code;
-      if (spec.continueOnFailure !== true) {
-        printTestSummary("failed", timings.length, performance.now() - suiteStartedAt);
-        process.exitCode = result.code;
+      if (code !== 0) {
+        printTestSummary("failed", 0, performance.now() - suiteStartedAt);
+        process.exitCode = code;
         return;
       }
     }
-  }
-  writeShardTimings(timings, process.cwd(), baseEnv);
-  printTestSummary(
-    exitCode === 0 ? "passed" : "failed",
-    timings.length,
-    performance.now() - suiteStartedAt,
-  );
 
-  if (exitCode !== 0) {
-    process.exitCode = exitCode;
+    const isFullSuiteRun =
+      targetArgs.length === 0 &&
+      changedTargetArgs === null &&
+      !runSpecs.some((spec) => spec.watchMode);
+    const isExplicitParallelMultiConfigRun =
+      Boolean(baseEnv.OPENCLAW_TEST_PROJECTS_PARALLEL) &&
+      runSpecs.length > 1 &&
+      !runSpecs.some((spec) => spec.watchMode);
+    const isParallelShardRun =
+      isFullSuiteRun || isFullExtensionsProjectRun(runSpecs) || isExplicitParallelMultiConfigRun;
+    let scheduledSpecs = runSpecs;
+    const concurrency = isParallelShardRun
+      ? resolveParallelFullSuiteConcurrency(runSpecs.length, baseEnv)
+      : 1;
+    if (isParallelShardRun) {
+      if (!isCiLikeEnv(baseEnv) && runSpecs.length > 1) {
+        console.warn(
+          `[test] warning: broad local run will start ${runSpecs.length} Vitest shards; use \`pnpm test:changed\` for routine checks.`,
+        );
+      }
+      if (concurrency > 1) {
+        const shardTimings = readShardTimings(process.cwd(), baseEnv);
+        const orderedSpecs = orderFullSuiteSpecsForParallelRun(runSpecs, shardTimings).filter(
+          (spec): spec is VitestRunSpec => spec !== undefined,
+        );
+        scheduledSpecs = applyDefaultParallelVitestWorkerBudget(
+          applyParallelVitestCachePaths(orderedSpecs, {
+            cwd: process.cwd(),
+            env: baseEnv,
+          }),
+          baseEnv,
+        );
+        console.error(
+          `[test] running ${scheduledSpecs.length} Vitest shards with parallelism ${concurrency}`,
+        );
+      }
+    }
+
+    const result = await runVitestSpecs(scheduledSpecs, concurrency, reports, termination);
+    if (result.interrupted || (concurrency === 1 && termination.signal)) {
+      return;
+    }
+    if (concurrency > 1 || !result.stopScheduling) {
+      writeShardTimings(result.timings, process.cwd(), baseEnv);
+    }
+    printTestSummary(
+      result.exitCode === 0 ? "passed" : "failed",
+      concurrency > 1 ? scheduledSpecs.length : result.timings.length,
+      performance.now() - suiteStartedAt,
+      concurrency > 1 ? "Vitest summaries above are per-shard, not aggregate totals." : undefined,
+    );
+    if (concurrency > 1) {
+      for (const line of formatFailedShardDigest(result.failures)) {
+        console.error(line);
+      }
+    }
+    if (result.exitCode !== 0) {
+      process.exitCode = result.exitCode;
+    }
+  } catch (error) {
+    reportFailure = String(error);
+    throw error;
+  } finally {
+    if (reports) {
+      try {
+        const reportCode = await reports.finish(
+          async (mergeArgs) => {
+            // Per-spec include files have been cleaned up. Replay loads the selected
+            // configs with the caller environment; blobs own the exact executed selection.
+            const outcome = await runPnpmSpecCommand({ ...runSpecs[0]!, env: baseEnv }, [
+              "exec",
+              "node",
+              ...resolveVitestNodeArgs(baseEnv),
+              resolveVitestCliEntry(),
+              ...mergeArgs,
+            ]);
+            termination.signal ??= outcome.signal;
+            return outcome;
+          },
+          termination.signal ? `Cancelled by ${termination.signal}` : reportFailure,
+        );
+        if (reportCode) {
+          process.exitCode ||= reportCode;
+        }
+      } finally {
+        process.off("SIGTERM", onSignal);
+        process.off("SIGINT", onSignal);
+        if (termination.signal) {
+          process.kill(process.pid, termination.signal);
+          // Give the re-raised signal a turn before a CLI caller exits with the numeric result.
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
+        }
+      }
+    }
   }
 }
 

--- a/scripts/test-report-utils.mts
+++ b/scripts/test-report-utils.mts
@@ -32,7 +32,7 @@ export function readJsonFile(filePath: fs.PathOrFileDescriptor) {
   return parsed;
 }
 
-function validateVitestJsonReport(reportPath: fs.PathLike) {
+export function validateVitestJsonReport(reportPath: fs.PathLike) {
   const displayPath = typeof reportPath === "string" ? reportPath : reportPath.toString();
   if (!fs.existsSync(reportPath)) {
     return `missing Vitest JSON report: ${displayPath}`;

--- a/test/scripts/test-extension.test.ts
+++ b/test/scripts/test-extension.test.ts
@@ -197,7 +197,7 @@ describe("scripts/test-extension.mts", () => {
   });
 
   it("includes newly authored Matrix tests in bounded process targets", () => {
-    const root = mkdtempSync(path.join(process.cwd(), "extensions", ".extension-test-plan-"));
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-extension-test-plan-"));
     const relativeRoot = path.relative(process.cwd(), root);
     const testFile = path.join(root, "newly-authored.test.ts");
     writeFileSync(testFile, "export {};\n");

--- a/test/scripts/vitest-report-fixture.ts
+++ b/test/scripts/vitest-report-fixture.ts
@@ -1,6 +1,8 @@
+import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import { spawnOwnedVitestProcess } from "../../scripts/lib/vitest-process.mts";
+import { createPnpmRunnerSpawnSpec } from "../../scripts/pnpm-runner.mts";
 import { waitForFile } from "../helpers/process-wait.js";
 
 const repoRoot = path.resolve(import.meta.dirname, "../..");
@@ -90,6 +92,64 @@ export function createVitestReportFixture(root: string, evidence = path.join(roo
     mode: ReportFixtureMode,
     options: { nativeArgs?: string[]; entry?: "projects" | "batch-cli"; report?: boolean } = {},
   ) => {
+    // Bootstrap and native execution share the fixture's existing timeout budget.
+    const deadline = performance.now() + 45000;
+    if (mode.startsWith("batch") && options.entry !== "batch-cli" && !env.npm_execpath) {
+      // Corepack needs the parent's prepared resources before HOME isolation. Ask
+      // pnpm for its executable; carry that fact, never the parent's writable cache.
+      const bootstrap = path.join(root, "pnpm-bootstrap");
+      write(
+        path.join(bootstrap, "package.json"),
+        JSON.stringify({
+          private: true,
+          scripts: { "pnpm-path": "node -p process.env.npm_execpath" },
+        }),
+      );
+      const spec = createPnpmRunnerSpawnSpec({
+        cwd: repoRoot,
+        env: { ...process.env, COREPACK_ENABLE_NETWORK: "0" },
+        // Preserve pnpm-workspace.yaml's no-reconciliation policy in the owned package.
+        pnpmArgs: [
+          "--dir",
+          bootstrap,
+          "--config.verify-deps-before-run=false",
+          "--silent",
+          "run",
+          "pnpm-path",
+        ],
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const { child, completion } = spawnOwnedVitestProcess(spec);
+      let stdout = "",
+        stderr = "";
+      child.stdout!.on("data", (chunk) => {
+        stdout += chunk;
+      });
+      child.stderr!.on("data", (chunk) => {
+        stderr += chunk;
+      });
+      const timeout = setTimeout(
+        () => child.kill("SIGTERM"),
+        Math.max(0, deadline - performance.now()),
+      );
+      try {
+        const result = await completion;
+        write(
+          path.join(evidence, "bootstrap.json"),
+          JSON.stringify(
+            { command: [spec.command, ...spec.args], ...result, stdout, stderr, joined: true },
+            null,
+            2,
+          ),
+        );
+        assert.equal(result.code, 0, stderr);
+        assert.equal(result.signal, null, stderr);
+        env.npm_execpath = stdout.trim();
+        assert(path.isAbsolute(env.npm_execpath), "pnpm did not expose its executable path");
+      } finally {
+        clearTimeout(timeout);
+      }
+    }
     const output = path.join(evidence, "result.json");
     const ready = path.join(root, "ready");
     const done = path.join(root, "beta.done");
@@ -233,7 +293,10 @@ ${index === 0 ? "test('alpha/two',()=>expect(2).toBe(2));" : "test.skip('beta/sk
     child.stderr!.on("data", (chunk) => {
       stderr += chunk;
     });
-    const timeout = setTimeout(() => child.kill("SIGTERM"), 45000);
+    const timeout = setTimeout(
+      () => child.kill("SIGTERM"),
+      Math.max(0, deadline - performance.now()),
+    );
     try {
       if (["cancel", "batch-cancel"].includes(mode)) {
         await waitForFile(ready, 15000);

--- a/test/scripts/vitest-report-fixture.ts
+++ b/test/scripts/vitest-report-fixture.ts
@@ -1,0 +1,268 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawnOwnedVitestProcess } from "../../scripts/lib/vitest-process.mts";
+import { waitForFile } from "../helpers/process-wait.js";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+const configs = [
+  "test/vitest/vitest.unit-fast-isolated.config.ts",
+  "test/vitest/vitest.agents-embedded-agent.config.ts",
+];
+
+export type ReportFixtureMode =
+  | "overlap"
+  | "serial"
+  | "parallel"
+  | "batch"
+  | "batch-parallel"
+  | "batch-failure"
+  | "batch-fail-fast"
+  | "batch-cancel"
+  | "failure"
+  | "fail-fast"
+  | "unhandled"
+  | "ignored-unhandled"
+  | "empty"
+  | "retry"
+  | "watchdog"
+  | "cancel"
+  | "missing"
+  | "corrupt"
+  | "merge-failure"
+  | "child-write"
+  | "final-write"
+  | "publish-write"
+  | "identity"
+  | "metadata"
+  | "coverage-missing"
+  | "teardown-timeout"
+  | "single"
+  | "tuple"
+  | "dotted"
+  | "chunks";
+
+/** Tiny native configs shared by regression tests and retained operator proofs. */
+export function createVitestReportFixture(root: string, evidence = path.join(root, "reports")) {
+  fs.mkdirSync(root, { recursive: true });
+  fs.mkdirSync(evidence, { recursive: true });
+  fs.symlinkSync(path.join(repoRoot, "node_modules"), path.join(root, "node_modules"), "junction");
+  const write = (file: string, contents: string) => {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, contents);
+  };
+  const env: NodeJS.ProcessEnv = {
+    PATH: process.env.PATH,
+    npm_execpath: process.env.npm_execpath,
+    HOME: path.join(root, "home"),
+    OPENCLAW_HOME: path.join(root, "home"),
+    OPENCLAW_STATE_DIR: path.join(root, "state"),
+    OPENCLAW_CONFIG_PATH: path.join(root, "config/openclaw.json"),
+    OPENCLAW_WORKSPACE_DIR: path.join(root, "workspace"),
+    TMPDIR: path.join(root, "tmp"),
+    TMP: path.join(root, "tmp"),
+    TEMP: path.join(root, "tmp"),
+    XDG_CONFIG_HOME: path.join(root, "xdg/config"),
+    XDG_CACHE_HOME: path.join(root, "xdg/cache"),
+    XDG_DATA_HOME: path.join(root, "xdg/data"),
+    XDG_STATE_HOME: path.join(root, "xdg/state"),
+    XDG_RUNTIME_DIR: path.join(root, "xdg/runtime"),
+    TSX_TSCONFIG_PATH: path.join(repoRoot, "tsconfig.json"),
+    TSX_DISABLE_CACHE: "1",
+    NODE_DISABLE_COMPILE_CACHE: "1",
+    COREPACK_ENABLE_NETWORK: "0",
+    GIT_OPTIONAL_LOCKS: "0",
+    CI: "1",
+    NO_COLOR: "1",
+    FORCE_COLOR: "0",
+    TZ: "UTC",
+    OPENCLAW_TEST_PROJECTS_TIMINGS: "0",
+    OPENCLAW_VITEST_MAX_WORKERS: "1",
+    OPENCLAW_VITEST_FS_MODULE_CACHE_PATH: path.join(root, "cache"),
+    OPENCLAW_VITEST_NO_OUTPUT_RETRY: "0",
+    OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "20000",
+  };
+  for (const [key, value] of Object.entries(env))
+    if (value?.startsWith(root) && key !== "OPENCLAW_CONFIG_PATH")
+      fs.mkdirSync(value, { recursive: true });
+  write(env.OPENCLAW_CONFIG_PATH!, "{}");
+
+  return async (
+    mode: ReportFixtureMode,
+    options: { nativeArgs?: string[]; entry?: "projects" | "batch-cli"; report?: boolean } = {},
+  ) => {
+    const output = path.join(evidence, "result.json");
+    const ready = path.join(root, "ready");
+    const done = path.join(root, "beta.done");
+    const events = path.join(evidence, "executed.jsonl");
+    const isParallel = ["parallel", "batch-parallel", "failure", "overlap"].includes(mode);
+    for (const [index, name] of ["alpha", "beta"].entries()) {
+      const prelude = `import fs from 'node:fs';
+${mode === "teardown-timeout" && index === 0 ? "setInterval(()=>{},1000);" : ""}
+const merging = process.argv.includes('--mergeReports');
+const output = process.argv.find(arg => arg.startsWith('--outputFile.json='))?.slice('--outputFile.json='.length);
+${mode === "coverage-missing" && index === 0 ? `if(!merging)process.once('exit',()=>{const dir=process.argv.find(arg=>arg.startsWith('--coverage.reportsDirectory='))?.split('=').slice(1).join('=');if(dir&&fs.existsSync(dir+'/lcov.info')){fs.copyFileSync(dir+'/lcov.info',dir+'/lcov.info.native-original');fs.unlinkSync(dir+'/lcov.info');}});` : ""}
+${mode === "merge-failure" ? `if(merging)throw new Error('owned native merge failure');` : ""}
+${mode === "final-write" ? `if(merging&&output)fs.mkdirSync(output);` : ""}
+${mode === "child-write" && index === 0 ? `if(!merging&&output)fs.mkdirSync(output);` : ""}
+${mode === "watchdog" && index === 0 ? `if(!merging&&!fs.existsSync(${JSON.stringify(ready)})){fs.writeFileSync(${JSON.stringify(ready)},'started');await new Promise(()=>setInterval(()=>{},1000));}` : ""}
+${["missing", "corrupt"].includes(mode) && index === 0 ? `if(!merging)process.once('exit',()=>{const file=${mode === "missing" ? "output" : "process.argv.find(arg=>arg.startsWith('--outputFile.blob='))?.slice('--outputFile.blob='.length)"};if(file&&fs.existsSync(file)){fs.copyFileSync(file,file+'.native-original');${mode === "missing" ? "fs.unlinkSync(file)" : "fs.writeFileSync(file,'owned corruption')"};}});` : ""}
+`;
+      write(
+        path.join(root, configs[index]!),
+        prelude +
+          `export default {root:${JSON.stringify(root)},cacheDir:${JSON.stringify(path.join(root, "vite-" + name))},test:{name:${mode === "identity" ? `merging?'changed-${name}':'${name}'` : JSON.stringify(name)},include:[${mode === "empty" ? "'absent.test.ts'" : JSON.stringify(name + ".test.ts")}],${mode === "empty" ? "passWithNoTests:true," : ""}${mode === "ignored-unhandled" ? "dangerouslyIgnoreUnhandledErrors:true," : ""}pool:'forks',maxWorkers:1,fileParallelism:false,cache:false,experimental:{fsModuleCache:false},teardownTimeout:1000,${["metadata", "coverage-missing"].includes(mode) ? "coverage:{provider:'v8',include:['covered.ts'],reporter:['json','lcov']}," : ""}${mode === "tuple" ? `reporters:[['json',{outputFile:${JSON.stringify(path.join(evidence, "tuple.json"))}}]],` : ""}}};`,
+      );
+      const failure =
+        (["failure", "batch-failure"].includes(mode) && index === 1) ||
+        (["fail-fast", "batch-fail-fast"].includes(mode) && index === 0);
+      const body = `import fs from 'node:fs';import {test,expect} from 'vitest';
+${["metadata", "coverage-missing"].includes(mode) ? "import {classify} from './covered';" : ""}
+let attempt=0;
+test('${name}/one',${mode === "retry" && index === 0 ? "{retry:1}," : ""}async()=>{
+ fs.appendFileSync(${JSON.stringify(events)},JSON.stringify({name:'${name}/one',pid:process.pid})+'\\n');
+ ${["parallel", "batch-parallel"].includes(mode) && index === 0 ? `const {waitForFile}=await import(${JSON.stringify(path.join(repoRoot, "test/helpers/process-wait.ts"))});await waitForFile(${JSON.stringify(done)},15000);` : ""}
+ ${["cancel", "batch-cancel"].includes(mode) && index === 0 ? `fs.writeFileSync(${JSON.stringify(ready)},String(process.pid));await new Promise(()=>setInterval(()=>{},1000));` : ""}
+ ${["unhandled", "ignored-unhandled"].includes(mode) && index === 1 ? "void Promise.reject(new Error('owned unhandled rejection'));await new Promise(resolve=>setImmediate(resolve));" : ""}
+ ${["metadata", "coverage-missing"].includes(mode) ? `expect(classify(${index})).toMatchInlineSnapshot(${JSON.stringify(index === 0 ? '"zero"' : '"one"')});` : mode === "overlap" ? "expect(0, 'independent failure pid='+process.pid).toBe(1);" : mode === "retry" && index === 0 ? "expect(++attempt).toBe(2);" : `expect(1).toBe(${failure ? 2 : 1});`}
+ ${index === 1 ? `fs.writeFileSync(${JSON.stringify(done)},'done');` : ""}
+});
+${index === 0 ? "test('alpha/two',()=>expect(2).toBe(2));" : "test.skip('beta/skip',()=>{});test.todo('beta/todo');"}`;
+      write(path.join(root, `${name}.test.ts`), body);
+    }
+    write(
+      path.join(root, "covered.ts"),
+      "export function classify(n:number){return n===0?'zero':'one'}",
+    );
+    let targets = mode === "single" ? [configs[0]!] : [...configs];
+    if (mode === "chunks") {
+      const files = [
+        "extensions/telegram/src/owned-one.test.ts",
+        "extensions/telegram/src/owned-two.test.ts",
+      ];
+      for (const [i, file] of files.entries())
+        write(
+          path.join(root, file),
+          `import {test,expect} from 'vitest';test('chunk/${i}',()=>expect(1).toBe(1));`,
+        );
+      write(
+        path.join(root, "test/vitest/vitest.extension-telegram.config.ts"),
+        `import fs from 'node:fs';const file=process.env.OPENCLAW_VITEST_INCLUDE_FILE;export default {root:${JSON.stringify(root)},cacheDir:${JSON.stringify(path.join(root, "vite-chunks"))},test:{name:'chunks',include:file?JSON.parse(fs.readFileSync(file,'utf8')):${JSON.stringify(files)},pool:'forks',maxWorkers:1,cache:false,experimental:{fsModuleCache:false}}};`,
+      );
+      env.OPENCLAW_VITEST_INCLUDE_FILE = path.join(root, "includes.json");
+      write(env.OPENCLAW_VITEST_INCLUDE_FILE, JSON.stringify(files));
+      targets = ["test/vitest/vitest.extension-telegram.config.ts"];
+    }
+    const args = [
+      "--reporter=verbose",
+      "--reporter=json",
+      "--configLoader=runner",
+      mode === "dotted" ? `--outputFile.json=${output}` : `--outputFile=${output}`,
+    ];
+    if (options.report === false) args.splice(0, args.length, "--configLoader=runner");
+    args.push(...(options.nativeArgs ?? []));
+    if (mode === "dotted") args.push("--reporter", "json");
+    if (["metadata", "coverage-missing"].includes(mode)) args.push("--coverage");
+    if (mode === "publish-write") {
+      fs.mkdirSync(output);
+      write(path.join(output, "old"), "old");
+    } else if (["missing", "corrupt", "merge-failure", "final-write", "identity"].includes(mode))
+      write(output, "old report");
+    let command = [path.join(repoRoot, "scripts/run-vitest.mjs"), "run", ...targets, ...args];
+    if (options.entry === "projects" || mode === "overlap") {
+      if (mode === "overlap") targets = [configs[0]!, `./${configs[0]}`];
+      command = [
+        "--import",
+        path.join(repoRoot, "node_modules/tsx/dist/loader.mjs"),
+        path.join(repoRoot, "scripts/test-projects.mts"),
+        ...targets,
+        "--",
+        ...args,
+      ];
+    }
+    if (options.entry === "batch-cli") {
+      command = [
+        "--import",
+        path.join(repoRoot, "node_modules/tsx/dist/loader.mjs"),
+        path.join(repoRoot, "scripts/test-extension-batch.mts"),
+        "alpha,beta",
+        "--",
+        ...args,
+      ];
+    } else if (mode.startsWith("batch")) {
+      const plan = {
+        extensionCount: 2,
+        extensionIds: ["alpha", "beta"],
+        estimatedCost: 2,
+        hasTests: true,
+        testFileCount: 2,
+        planGroups: configs.map((config, i) => ({
+          config: path.join(root, config),
+          estimatedCost: 1,
+          extensionIds: [i ? "beta" : "alpha"],
+          roots: [path.join(root, i ? "beta.test.ts" : "alpha.test.ts")],
+          testFileCount: 1,
+        })),
+      };
+      const entry = path.join(root, "batch.mts");
+      write(
+        entry,
+        `import {runExtensionBatchPlan} from ${JSON.stringify(path.join(repoRoot, "scripts/test-extension-batch.mts"))};process.exitCode=await runExtensionBatchPlan(${JSON.stringify(plan)},{vitestArgs:${JSON.stringify(args)}});`,
+      );
+      command = ["--import", path.join(repoRoot, "node_modules/tsx/dist/loader.mjs"), entry];
+    }
+    const childEnv = {
+      ...env,
+      OPENCLAW_TEST_PROJECTS_PARALLEL: isParallel ? "2" : "1",
+      OPENCLAW_TEST_PROJECTS_SERIAL: isParallel ? "0" : "1",
+      OPENCLAW_EXTENSION_BATCH_PARALLEL: isParallel ? "2" : "1",
+      OPENCLAW_VITEST_NO_OUTPUT_RETRY:
+        mode === "watchdog" ? "1" : env.OPENCLAW_VITEST_NO_OUTPUT_RETRY,
+      OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS:
+        mode === "watchdog" ? "1500" : env.OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS,
+    };
+    const { child, completion } = spawnOwnedVitestProcess({
+      command: process.execPath,
+      args: command,
+      options: { cwd: root, env: childEnv, stdio: ["ignore", "pipe", "pipe"] },
+    });
+    let stdout = "",
+      stderr = "";
+    child.stdout!.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr!.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    const timeout = setTimeout(() => child.kill("SIGTERM"), 45000);
+    try {
+      if (["cancel", "batch-cancel"].includes(mode)) {
+        await waitForFile(ready, 15000);
+        child.kill("SIGTERM");
+      }
+      const result = await completion;
+      write(path.join(evidence, "stdout.log"), stdout);
+      write(path.join(evidence, "stderr.log"), stderr);
+      write(
+        path.join(evidence, "run.json"),
+        JSON.stringify(
+          {
+            command: [process.execPath, ...command],
+            cwd: root,
+            env: childEnv,
+            ...result,
+            pid: child.pid,
+            joined: true,
+          },
+          null,
+          2,
+        ),
+      );
+      const reportSet = stderr.match(/\[test\] native report set: (.+)/u)?.[1];
+      return { ...result, stdout, stderr, output, reportSet };
+    } finally {
+      clearTimeout(timeout);
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
+      await completion;
+    }
+  };
+}

--- a/test/scripts/vitest-report-owner.test.ts
+++ b/test/scripts/vitest-report-owner.test.ts
@@ -82,7 +82,12 @@ describe.skipIf(process.platform === "win32")("native multi-invocation report ow
       const index = json(path.join(result.reportSet!, "index.json"));
       expect(index.complete).toBe(true);
       expect(index.entries[1].attempts[0].outcome.code).toBe(1);
-      if (mode === "unhandled") expect(json(index.entries[1].attempts[0].json).success).toBe(true);
+      if (mode === "unhandled") {
+        const part = index.entries[1].attempts[0].json;
+        expect(json(part).success).toBe(true);
+        expect(json(`${part}.capture.json`).ended.unhandledErrors).toBe(1);
+        expect(result.stderr).toContain("owned unhandled rejection");
+      }
     },
   );
 
@@ -108,12 +113,91 @@ describe.skipIf(process.platform === "win32")("native multi-invocation report ow
       const result = await run(mode);
       expect(result.code !== 0 || result.signal !== null, result.stderr).toBe(true);
       const index = json(path.join(result.reportSet!, "index.json"));
+      const first = index.entries[0].attempts[0];
+      const staged = path.join(result.reportSet!, "aggregate.json");
       if (mode === "cancel" || mode === "batch-cancel") {
         expect(result.signal).toBe("SIGTERM");
-        expect(index.entries[0].attempts[0].outcome.signal).toBe("SIGTERM");
+        expect(first.outcome.signal).toBe("SIGTERM");
+        const events = fs
+          .readFileSync(path.join(path.dirname(result.output), "executed.jsonl"), "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line));
+        expect(events.map((event) => event.name)).toEqual(["alpha/one"]);
+        const capture = json(`${first.json}.capture.json`);
+        expect(fs.readFileSync(path.join(capture.root, "ready"), "utf8")).toBe(
+          String(events[0].pid),
+        );
+        expect(() => process.kill(events[0].pid, 0)).toThrow(
+          expect.objectContaining({ code: "ESRCH" }),
+        );
+      } else if (mode === "fail-fast" || mode === "batch-fail-fast") {
+        const report = json(first.json);
+        expect(inventory(report)).toEqual([
+          ["alpha/one", "failed"],
+          ["alpha/two", "passed"],
+        ]);
+        expect(report.testResults[0].assertionResults[0].failureMessages.join("\n")).toContain(
+          "expected 1 to be 2",
+        );
+        expect(first.outcome.code).toBe(1);
+        expect(json(`${first.json}.capture.json`).ended.reason).toBe("failed");
+      } else if (mode === "tuple") {
+        expect(result.stderr).toContain("cannot preserve config-owned reporter options");
+      } else {
+        const capture = json(`${first.json}.capture.json`);
+        expect(capture.ended.reason).toBe("passed");
+        if (mode === "child-write") {
+          expect(fs.statSync(first.json).isDirectory()).toBe(true);
+          expect(first.outcome.code).toBe(1);
+          expect(result.stderr).toContain("EISDIR");
+        } else {
+          const original = mode === "missing" ? `${first.json}.native-original` : first.json;
+          expect(inventory(json(original))).toEqual(expected.slice(0, 2));
+          expect(first.outcome.code).toBe(0);
+        }
+        if (mode === "missing") {
+          expect(fs.existsSync(first.json)).toBe(false);
+          expect(index.error).toContain("missing Vitest JSON report");
+        } else if (mode === "coverage-missing") {
+          const lcov = path.join(capture.coverageDirectory, "lcov.info");
+          expect(fs.readFileSync(`${lcov}.native-original`, "utf8")).toContain("covered.ts");
+          expect(fs.existsSync(lcov)).toBe(false);
+          expect(index.error).toContain(lcov);
+        } else if (mode === "teardown-timeout") {
+          expect(capture.processTimedOut).toBe(true);
+          expect(index.error).toContain("completion evidence missing or interrupted");
+        } else if (mode !== "child-write") {
+          const second = index.entries[1].attempts[0];
+          expect(inventory(json(second.json))).toEqual(expected.slice(2));
+          expect(second.outcome.code).toBe(0);
+          expect(index.merge.code).toBe(mode === "publish-write" ? 0 : 1);
+          if (mode === "corrupt") {
+            expect(fs.readFileSync(first.blob, "utf8")).toBe("owned corruption");
+            expect(() => json(`${first.blob}.native-original`)).not.toThrow();
+            expect(result.stderr).toContain('"owned corruption" is not valid JSON');
+          } else if (mode === "merge-failure") {
+            expect(result.stderr).toContain("owned native merge failure");
+          } else if (mode === "identity") {
+            expect(result.stderr).toContain("Native merge project identity changed");
+          } else if (mode === "final-write") {
+            expect(fs.statSync(staged).isDirectory()).toBe(true);
+            expect(index.error).toContain("EISDIR");
+          } else if (mode === "publish-write") {
+            expect(inventory(json(staged))).toEqual(expected);
+            expect(fs.readFileSync(path.join(result.output, "old"), "utf8")).toBe("old");
+            expect(fs.readFileSync(path.join(index.publication, "report.json"))).toEqual(
+              fs.readFileSync(staged),
+            );
+            expect(index.error).toMatch(/rename/);
+          }
+        }
       }
       expect(index.complete).toBe(false);
       expect(index.error).not.toBe("");
+      expect(index.aggregate).toBe("");
+      if (!["corrupt", "merge-failure", "identity", "final-write", "publish-write"].includes(mode))
+        expect(index.merge).toBeNull();
       if (["missing", "corrupt", "merge-failure", "final-write", "identity"].includes(mode))
         expect(fs.readFileSync(result.output, "utf8")).toBe("old report");
       if (["fail-fast", "cancel", "batch-fail-fast", "batch-cancel"].includes(mode))

--- a/test/scripts/vitest-report-owner.test.ts
+++ b/test/scripts/vitest-report-owner.test.ts
@@ -1,0 +1,255 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+import { createVitestReportFixture, type ReportFixtureMode } from "./vitest-report-fixture.js";
+
+const json = (file: string) => JSON.parse(fs.readFileSync(file, "utf8"));
+const inventory = (report: {
+  testResults: { assertionResults: { fullName: string; status: string }[] }[];
+}) =>
+  report.testResults
+    .flatMap((file) => file.assertionResults.map((test) => [test.fullName.trim(), test.status]))
+    .sort();
+const expected = [
+  ["alpha/one", "passed"],
+  ["alpha/two", "passed"],
+  ["beta/one", "passed"],
+  ["beta/skip", "skipped"],
+  ["beta/todo", "todo"],
+];
+
+describe.skipIf(process.platform === "win32")("native multi-invocation report ownership", () => {
+  const dirs = useAutoCleanupTempDirTracker(afterEach);
+  const run = (mode: ReportFixtureMode) => createVitestReportFixture(dirs.make("oc-report-"))(mode);
+
+  it.each([
+    "serial",
+    "parallel",
+    "batch",
+    "batch-parallel",
+    "retry",
+    "watchdog",
+    "dotted",
+    "metadata",
+    "ignored-unhandled",
+  ] as const)(
+    "retains the exact case union and native originals: %s",
+    { timeout: 60000 },
+    async (mode) => {
+      const result = await run(mode);
+      expect(result.code, result.stderr).toBe(0);
+      expect(inventory(json(result.output))).toEqual(expected);
+      const index = json(path.join(result.reportSet!, "index.json"));
+      expect(index.complete).toBe(true);
+      const parts = index.entries.map((entry: { attempts: { json: string; blob: string }[] }) =>
+        entry.attempts.at(-1)!,
+      );
+      expect(parts).toHaveLength(2);
+      for (const part of parts) {
+        expect(fs.existsSync(part.blob)).toBe(true);
+        expect(json(`${part.json}.capture.json`).ended).toBeTruthy();
+      }
+      if (mode === "watchdog") {
+        expect(index.entries[0].attempts).toHaveLength(2);
+        expect(index.entries[0].attempts[0].outcome.noOutputTimedOut).toBe(true);
+      }
+      if (mode === "metadata") {
+        expect(parts.map((part: { json: string }) => json(part.json).snapshot.matched)).toEqual([
+          1, 1,
+        ]);
+        expect(json(result.output).snapshot.matched).toBe(0);
+        expect(json(result.output).coverageMap).toBeUndefined();
+        for (const part of parts) {
+          expect(Object.keys(json(part.json).coverageMap)).toHaveLength(1);
+          expect(
+            fs.existsSync(path.join(path.dirname(part.json), "coverage/coverage-final.json")),
+          ).toBe(true);
+        }
+      }
+    },
+  );
+
+  it.each(["failure", "batch-failure", "unhandled"] as const)(
+    "publishes complete evidence without erasing native failure: %s",
+    { timeout: 60000 },
+    async (mode) => {
+      const result = await run(mode);
+      expect(result.code, result.stderr).toBe(1);
+      const cases = expected.map((entry) => [...entry]);
+      if (mode === "failure" || mode === "batch-failure") cases[2]![1] = "failed";
+      expect(inventory(json(result.output))).toEqual(cases);
+      const index = json(path.join(result.reportSet!, "index.json"));
+      expect(index.complete).toBe(true);
+      expect(index.entries[1].attempts[0].outcome.code).toBe(1);
+      if (mode === "unhandled") expect(json(index.entries[1].attempts[0].json).success).toBe(true);
+    },
+  );
+
+  it.each([
+    "missing",
+    "coverage-missing",
+    "teardown-timeout",
+    "corrupt",
+    "merge-failure",
+    "child-write",
+    "final-write",
+    "publish-write",
+    "identity",
+    "tuple",
+    "fail-fast",
+    "cancel",
+    "batch-fail-fast",
+    "batch-cancel",
+  ] as const)(
+    "never publishes incomplete or failed evidence: %s",
+    { timeout: 60000 },
+    async (mode) => {
+      const result = await run(mode);
+      expect(result.code !== 0 || result.signal !== null, result.stderr).toBe(true);
+      const index = json(path.join(result.reportSet!, "index.json"));
+      if (mode === "cancel" || mode === "batch-cancel") {
+        expect(result.signal).toBe("SIGTERM");
+        expect(index.entries[0].attempts[0].outcome.signal).toBe("SIGTERM");
+      }
+      expect(index.complete).toBe(false);
+      expect(index.error).not.toBe("");
+      if (["missing", "corrupt", "merge-failure", "final-write", "identity"].includes(mode))
+        expect(fs.readFileSync(result.output, "utf8")).toBe("old report");
+      if (["fail-fast", "cancel", "batch-fail-fast", "batch-cancel"].includes(mode))
+        expect(index.entries[1].attempts).toHaveLength(0);
+    },
+  );
+
+  it(
+    "retains independent failures when a reachable selection overlaps native task IDs",
+    { timeout: 60000 },
+    async () => {
+      const result = await run("overlap");
+      expect(result.code, result.stderr).toBe(1);
+      const index = json(path.join(result.reportSet!, "index.json"));
+      expect(index.complete).toBe(false);
+      expect(index.error).toContain("overlapping task identities");
+      expect(fs.existsSync(result.output)).toBe(false);
+      const failures = index.entries.map(
+        (entry: { attempts: { json: string }[] }) =>
+          json(entry.attempts[0]!.json).testResults[0].assertionResults[0].failureMessages[0],
+      );
+      expect(failures).toHaveLength(2);
+      expect(new Set(failures).size).toBe(2);
+    },
+  );
+
+  it.each([
+    ["help", ["--help"], "help"],
+    ["short help", ["-h"], "help"],
+    ["native dash prefix", ["---help"], "help"],
+    ["false help", ["--help=false"], "tests"],
+    ["separate false help", ["--help", "false"], "tests"],
+    ["negated help", ["--no-help"], "tests"],
+    ["negated alias", ["--no-h"], "tests"],
+    ["help then negation", ["--help", "--no-help"], "tests"],
+    ["false alias precedence", ["--help=false", "-h"], "tests"],
+    ["long alias precedence", ["--help=false", "--h"], "tests"],
+    ["repeated false", ["--help=false", "--help=false"], "help"],
+    ["short group", ["-vh"], "help"],
+    ["unknown under help", ["--not-an-option", "--help"], "help"],
+    ["missing under help", ["--pool", "--help"], "help"],
+    ["unknown without help", ["--not-an-option", "--help=false"], "error"],
+    ["missing without help", ["--pool", "--no-help"], "error"],
+    ["named run version", ["--version"], "tests"],
+    ["negated version", ["--no-version"], "tests"],
+    ["wrapper consumes separators", ["--", "--help"], "help"],
+    ["list tags", ["--listTags"], "native-error"],
+    ["clear cache", ["--clearCache"], "idle"],
+    ["standalone", ["--standalone"], "native-error"],
+  ] as const)(
+    "leaves native control execution with the project child: %s",
+    { timeout: 60000 },
+    async (_, nativeArgs, kind) => {
+      const result = await createVitestReportFixture(dirs.make("oc-report-control-"))("serial", {
+        entry: "projects",
+        nativeArgs: [...nativeArgs],
+      });
+      expect(result.code, result.stderr).toBe(kind === "error" || kind === "native-error" ? 1 : 0);
+      expect(result.stderr).not.toContain("report publication failed");
+      expect(result.stdout.match(/Usage:/gu) ?? []).toHaveLength(kind === "help" ? 2 : 0);
+      if (kind === "tests") {
+        expect(inventory(json(result.output))).toEqual(expected);
+        expect(json(path.join(result.reportSet!, "index.json")).complete).toBe(true);
+      } else {
+        expect(result.reportSet).toBeUndefined();
+        expect(fs.existsSync(result.output)).toBe(false);
+        if (kind === "error") expect(result.stderr).toMatch(/Unknown option|value is missing/u);
+        if (kind === "native-error")
+          expect(result.stderr).toMatch(/No test tags found|standalone mode requires --watch/u);
+      }
+    },
+  );
+
+  it.each([
+    ["batch", undefined, ["--help"], 2, false],
+    ["batch", undefined, ["--help=false"], 0, true],
+    ["batch", undefined, ["--", "--help"], 0, true],
+    ["batch", "batch-cli", ["--help"], 0, false],
+    ["batch", "batch-cli", ["--", "--help"], 0, false],
+    ["single", "projects", ["--help"], 1, false],
+  ] as const)(
+    "preserves sibling and single-process metadata ownership: %s %s %j",
+    { timeout: 60000 },
+    async (mode, entry, nativeArgs, helpBlocks, tests) => {
+      const result = await createVitestReportFixture(dirs.make("oc-report-control-"))(mode, {
+        entry,
+        nativeArgs: [...nativeArgs],
+      });
+      expect(result.code, result.stderr).toBe(0);
+      expect(result.stdout.match(/Usage:/gu) ?? []).toHaveLength(helpBlocks);
+      expect(result.stderr).not.toContain("report publication failed");
+      if (tests) expect(inventory(json(result.output))).toEqual(expected);
+      else expect(result.reportSet).toBeUndefined();
+      if (entry === "batch-cli")
+        expect(result.stderr.match(/Usage: pnpm test:extensions:batch/gu)).toHaveLength(1);
+    },
+  );
+
+  it("keeps non-report metadata native", { timeout: 60000 }, async () => {
+    const result = await createVitestReportFixture(dirs.make("oc-report-control-"))("serial", {
+      entry: "projects",
+      nativeArgs: ["--help"],
+      report: false,
+    });
+    expect(result.code, result.stderr).toBe(0);
+    expect(result.stdout.match(/Usage:/gu)).toHaveLength(2);
+    expect(result.reportSet).toBeUndefined();
+  });
+
+  it("preserves an explicitly accepted empty selection", { timeout: 60000 }, async () => {
+    const result = await run("empty");
+    expect(result.code, result.stderr).toBe(0);
+    expect(inventory(json(result.output))).toEqual([]);
+    expect(json(path.join(result.reportSet!, "index.json")).complete).toBe(true);
+  });
+
+  it("leaves a single invocation native", { timeout: 60000 }, async () => {
+    const result = await run("single");
+    expect(result.code, result.stderr).toBe(0);
+    expect(result.reportSet).toBeUndefined();
+    expect(inventory(json(result.output))).toEqual(expected.slice(0, 2));
+  });
+
+  it("merges actual planner chunks of the same config once each", { timeout: 60000 }, async () => {
+    const result = await run("chunks");
+    expect(result.code, result.stderr).toBe(0);
+    expect(inventory(json(result.output))).toEqual(
+      Array.from({ length: 2 }, (_, i) => [`chunk/${i}`, "passed"]).sort(),
+    );
+    const index = json(path.join(result.reportSet!, "index.json"));
+    expect(
+      index.entries.map((entry: { includePatterns: string[] }) => entry.includePatterns),
+    ).toEqual([
+      ["extensions/telegram/src/owned-one.test.ts"],
+      ["extensions/telegram/src/owned-two.test.ts"],
+    ]);
+    expect(new Set(index.entries.map((entry: { config: string }) => entry.config)).size).toBe(1);
+  });
+});

--- a/test/vitest-reporters-config.test.ts
+++ b/test/vitest-reporters-config.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import { spawnNodeEvalSync } from "../src/test-utils/node-process.js";
+import { useAutoCleanupTempDirTracker } from "./helpers/temp-dir.js";
 import { DEFAULT_VITEST_TEST_TIMEOUT_MS } from "./vitest/vitest.timeouts.ts";
 
 const reporterConfigs = [
@@ -22,9 +25,22 @@ type ReporterResolution = {
 };
 
 describe("Vitest reporter contracts", () => {
+  const dirs = useAutoCleanupTempDirTracker(afterEach);
   it.each(["false", "true"])(
     "reports completed agent tests and preserves overrides with GITHUB_ACTIONS=%s",
     (githubActions) => {
+      // Vite's bundled loader writes beside the config's nearest node_modules.
+      // Own that lifetime instead of writing into the installed dependency tree.
+      const configRoot = dirs.make("oc-reporter-config-");
+      fs.mkdirSync(path.join(configRoot, "node_modules"));
+      const configFiles = reporterConfigs.map((config, index) => {
+        const file = path.join(configRoot, `${index}.mts`);
+        fs.writeFileSync(
+          file,
+          `export { default } from ${JSON.stringify(path.resolve(config))};\n`,
+        );
+        return file;
+      });
       // Resolve in a fresh process: shared config and std-env capture their environment on import.
       // This starts no test workers and leaves the enclosing Vitest module/cache ownership alone.
       const result = spawnNodeEvalSync(
@@ -34,9 +50,9 @@ describe("Vitest reporter contracts", () => {
           import { sharedVitestConfig } from "./test/vitest/vitest.shared.config.ts";
           import { createTuiPtyVitestConfig } from "./test/vitest/vitest.tui-pty.config.ts";
           const defaults = [];
-          for (const config of ${JSON.stringify(reporterConfigs)}) {
+          for (const [index, config] of ${JSON.stringify(reporterConfigs)}.entries()) {
             const root = config.startsWith("ui/") ? path.resolve("ui") : process.cwd();
-            const options = { root, config: path.resolve(config) };
+            const options = { root, config: ${JSON.stringify(configFiles)}[index] };
             const normal = await resolveConfig(options);
             const cli = parseCLI(["vitest", "--reporter=json"]).options;
             const override = await resolveConfig({ ...cli, ...options });


### PR DESCRIPTION
Closes #133305.

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer branch, so maintainers can push directly to it.

</details>

## What Problem This Solves

Fixes an issue where developers requesting one JSON report for a multi-project test run received only the last native process's results, even though every child and the outer command exited successfully. In the isolated native reproduction, two children executed five cases but the final report contained only three.

## Why This Change Was Made

The project and plugin-batch schedulers now share one artifact owner. It assigns each real invocation/attempt separate native JSON, blob and coverage destinations, retains the originals and actual process outcomes, and publishes an ordinary native Vitest aggregate only after validating complete accepted evidence and exact case/project attribution. Existing planners, runtime preparation, process supervision and retry owners remain in place. Serial and parallel project result handling now share one path.

Native merge is not universally lossless: snapshot summaries and JSON coverage maps stay authoritative in the retained original reports, and aggregate start time is merge time. Overlapping native task IDs can replace independent failure details even when case counts match, so that case retains both originals and fails aggregate publication with separate-invocation guidance. Native metadata/errors remain child-owned, without duplicate help or false report expectations.

A single-process rewrite would change existing process isolation and scheduling. Handwritten JSON/blob merging would duplicate native formats and still miss dependency semantics. Retaining original reports beside the native aggregate preserves the useful evidence without either change.

## User Impact

Explicit CLI JSON file requests across supported named, file-based Node projects now account for all accepted cases. Developers also get a printed companion report-set directory containing original reports, per-attempt outcomes, coverage outputs and unstarted work. Complete failed-test aggregates remain useful and retain a failing command outcome; missing/corrupt evidence, interruption or failed publication cannot look complete.

Single-process, console-only, help and other native non-test behavior stay native. Config-only file reporters, other file formats, custom/tuple reporter options and inline/browser composition remain separate-invocation boundaries, documented with unique-output guidance. No application configuration, dependency, schema, installed state or messaging behavior changes.

## Evidence

**Hosted CI follow-up:** [run 33315115990, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33315115990) failed in `checks-node-compact-small-35`: seven batch-fixture cases attempted a Corepack pnpm download with networking disabled. Commit `cd9cbf9bd3daff4610582ac2f980ab393415ebd2` repairs the fixture prerequisite: resolve the prepared pnpm executable before isolating HOME, then carry only that executable fact. Networking remains disabled, the existing 45-second fixture budget is shared, and no package-manager cache, dependency or production runner changes. [Exact-head CI33318296093, attempt1](https://github.com/openclaw/openclaw/actions/runs/33318296093) passed. Native review validation and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 133309` passed without rewriting the reviewed head. Native merge is next; no merged result is claimed yet.

[Maintainer scope acceptance and direct pinned-Vitest contract inspection](https://github.com/openclaw/openclaw/pull/133309#issuecomment-5469136090) address the published review's scope/dependency items and clarify that the stored files are named test artifacts, not application storage. The earlier local results below remain evidence for their executed environment, not a substitute for repaired-head CI.

Before the fix, the real serial wrapper reproduction exited 0 but retained only beta's three cases instead of alpha plus beta's five. The canonical regression also failed against a read-only pre-fix source export. Native JSON and blob bytes were not fabricated.

The corrected candidate passed **851 selected cases across eleven complete files**, including all **59 native report-owner cases**, **342 planner cases**, the package-manager/shard-runner siblings and the existing process/report owners. The parent independently reran all 59 report cases through a real Corepack-backed parent with no supplied `npm_execpath`, networking denied and writes restricted to owned paths. All source/dependency hashes were unchanged. Earlier independent 342-case planner proof and the 30 report/lifecycle plus 23 control scenarios remain retained; the corrected fixture also passed eight fresh native batch/control scenarios. Repeated executions are not added to the unique-case total.

The CI failure exposed a real false-green fail-fast assertion: the old test accepted bootstrap failure with zero executed cases. The corrected negative rows require the intended native failure, corruption, readiness, timeout, replay or publication evidence, not merely a nonzero exit. The retained before/after counterexample proves failed alpha plus passing alpha sibling and unstarted beta on the repaired fail-fast path.

Independent commands included:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/vitest-report-owner.test.ts --configLoader=runner --reporter=verbose --reporter=json --outputFile='<owned-evidence>/native.json'
```

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/test-projects.test.ts --reporter=verbose --reporter=json --outputFile='<owned-evidence>/native.json'
```

Proof ran on Node 24.15.0 with pinned pnpm 12.1.0 and fixture-owned HOME, state, configuration, workspace, XDG, temporary and cache paths. The corrected native-owner proof uses a Corepack-backed parent; the earlier planner proof used the prepared direct pnpm entry. The planner's Git operations were confined to newly created synthetic test repositories. Source hashes matched before and after.

Coverage includes serial/parallel project and real default batch execution, actual same-config include-file chunks, failure/skip/todo, native test retry, watchdog retry, unhandled errors independent of JSON success, native coverage/snapshot retention, missing/corrupt reports, teardown timeout, child/merge/publication write failures, cancellation, fail-fast/unstarted work, exact project identities, overlapping task IDs, native help/error/negation/alias controls, and single-process parity.

The full classified changed gate, scoped formatting and `git diff --check` passed. A fresh independent **P0-scoped Codex autoreview** reported `scoped-clean` with no findings on the complete original-base candidate, including the fixture follow-up. Application runtime is untouched; script/test-root typechecks and real native CLI/reporter loads cover these development-tool module boundaries. A product build, full product suite, browser lifecycle run and Windows process-group proof were not run.

Earlier diagnostic failures remain accounted for: optional sandbox denial of `ps` was resolved by running the full unchanged process-wrapper file in the ordinary trusted environment; bundled Vite reporter-config proof was repaired at its fixture-owned config/cache producer while keeping the default bundled loader. Initial metadata, overlap, expectation and lint failures were corrected and the complete affected proof rerun. None is presented as an earlier green run. The unrelated unresolved profiler-help investigation is not part of this fix.

**Size and ownership:** production tooling +884/-152 (**net +732**), tests/support **net +686**, docs +48; application runtime 0. This is material tooling growth for native attempt capture, verified cross-process replay and publication across both schedulers. Consolidating the project result path removed 26 lines from the prior candidate; metadata and overlap correctness required additional code. There is no new executor, scheduler framework, handwritten native report format or runtime-state store.

Current-main comparison at `160c34d86b941cb7e79367848e53e3a7ae28d1b4` found the changed files unchanged. Lock/workspace drift upgrades grammY and its types, not the inspected report dependencies or pnpm bootstrap policy. Adjacent planner and CI-test drift adds performance/release workflow-selection coverage; it does not alter native invocation/report ownership. The public reporting contract is documented in `docs/reference/test.md`.

The fixture follow-up adds 147 test/support lines and zero production/tooling lines. Its first bootstrap attempt incorrectly reached dependency reconciliation through a shared test link; that failed run is retained. The final isolated prerequisite package uses the existing no-reconciliation setting, and retained proof verifies that it creates neither node_modules nor a lockfile. No prior failed run is relabeled green.
