### PR TITLE
fix(msteams): deliver the controls an agent reply offers

### DIFF
--- a/extensions/msteams/src/messenger.presentation.test.ts
+++ b/extensions/msteams/src/messenger.presentation.test.ts
@@ -1,0 +1,196 @@
+// Msteams tests cover delivering a reply's portable presentation.
+import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { StoredConversationReference } from "./conversation-store.js";
+import { renderReplyPayloadsToMessages, sendMSTeamsMessages } from "./messenger.js";
+import { setMSTeamsRuntime } from "./runtime.js";
+import type { MSTeamsApp } from "./sdk.js";
+
+const chunkMarkdownText = (text: string, limit: number) => {
+  if (!text) {
+    return [];
+  }
+  if (limit <= 0 || text.length <= limit) {
+    return [text];
+  }
+  const chunks: string[] = [];
+  for (let index = 0; index < text.length; index += limit) {
+    chunks.push(text.slice(index, index + limit));
+  }
+  return chunks;
+};
+
+const runtimeStub = {
+  config: { loadConfig: () => ({}) },
+  channel: {
+    text: {
+      chunkMarkdownText,
+      chunkMarkdownTextWithMode: chunkMarkdownText,
+      resolveMarkdownTableMode: () => "code",
+      convertMarkdownTables: (text: string) => text,
+    },
+  },
+} as unknown as PluginRuntime;
+
+const conversationRef: StoredConversationReference = {
+  activityId: "activity123",
+  user: { id: "user123", name: "User" },
+  agent: { id: "bot123", name: "Bot" },
+  conversation: { id: "19:abc@thread.tacv2" },
+  channelId: "msteams",
+  serviceUrl: "https://smba.trafficmanager.net/amer/",
+};
+
+const approvalButtons = {
+  type: "buttons" as const,
+  buttons: [
+    { label: "Approve", action: { type: "callback" as const, value: "approve" } },
+    { label: "Deny", action: { type: "callback" as const, value: "deny" } },
+  ],
+};
+
+function render(payload: Parameters<typeof renderReplyPayloadsToMessages>[0][number]) {
+  return renderReplyPayloadsToMessages([payload], { textChunkLimit: 4000, tableMode: "code" });
+}
+
+/** Sends one rendered message and returns the activity handed to the Bot Framework SDK. */
+async function captureActivity(
+  message: Parameters<typeof sendMSTeamsMessages>[0]["messages"][number],
+): Promise<Record<string, unknown>> {
+  let captured: Record<string, unknown> | undefined;
+  const app = {
+    client: { request: vi.fn() },
+    tokenManager: {
+      getBotToken: async () => ({ toString: () => "bot-token" }),
+      getGraphToken: async () => ({ toString: () => "graph-token" }),
+    },
+    send: async (_conversationId: string, activity: unknown) => {
+      captured = activity as Record<string, unknown>;
+      return { id: "captured" };
+    },
+    activitySender: {
+      send: async (activity: unknown) => {
+        captured = activity as Record<string, unknown>;
+        return { id: "captured" };
+      },
+    },
+    reply: async (_conversationId: string, _messageId: string, activity: unknown) => {
+      captured = activity as Record<string, unknown>;
+      return { id: "captured" };
+    },
+    api: {
+      serviceUrl: "https://smba.trafficmanager.net/amer",
+      conversations: {
+        activities: () => ({
+          create: async (activity: unknown) => {
+            captured = activity as Record<string, unknown>;
+            return { id: "captured" };
+          },
+          update: async () => ({ id: "updated" }),
+          delete: async () => {},
+        }),
+      },
+    },
+  } as unknown as MSTeamsApp;
+  await sendMSTeamsMessages({
+    replyStyle: "top-level",
+    app,
+    appId: "app123",
+    conversationRef,
+    messages: [message],
+  });
+  if (!captured) {
+    throw new Error("expected a Teams activity to be sent");
+  }
+  return captured;
+}
+
+describe("msteams reply presentation", () => {
+  beforeEach(() => {
+    setMSTeamsRuntime(runtimeStub);
+  });
+
+  it("delivers the controls a reply offers as a card", () => {
+    const messages = render({
+      text: "Deploy to production?",
+      presentation: {
+        blocks: [{ type: "text", text: "Deploy to production?" }, approvalButtons],
+      },
+    });
+
+    expect(messages).toHaveLength(1);
+    const card = messages[0]?.card as
+      | { actions?: Array<{ title?: string }>; body?: Array<{ text?: string }> }
+      | undefined;
+    expect(card?.actions?.map((action) => action.title)).toEqual(["Approve", "Deny"]);
+    expect(card?.body?.some((block) => block.text === "Deploy to production?")).toBe(true);
+  });
+
+  it("still reaches Teams when the controls are the whole reply", () => {
+    // Without a card this payload has neither text nor media, so nothing was sent.
+    const messages = render({ presentation: { blocks: [approvalButtons] } });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.card).toBeDefined();
+  });
+
+  it("states the controls in prose when the reply also carries media", () => {
+    // A Teams activity carries a card or an attachment, never both.
+    const messages = render({
+      text: "Here it is",
+      mediaUrl: "https://example.com/a.png",
+      presentation: { blocks: [approvalButtons] },
+    });
+
+    expect(messages.some((message) => message.card)).toBe(false);
+    expect(messages[0]?.text).toContain("Approve");
+    expect(messages.some((message) => message.mediaUrl === "https://example.com/a.png")).toBe(true);
+  });
+
+  it("keeps authored prose when the presentation only restates it", () => {
+    // `/status` ships its own plain rendering plus a table Teams cannot render natively.
+    const authored = "Status: ok\n\n| agent | state |\n| --- | --- |\n| main | idle |";
+    const messages = renderReplyPayloadsToMessages(
+      [
+        {
+          text: authored,
+          presentationTextMode: "fallback",
+          presentation: {
+            blocks: [
+              {
+                type: "table",
+                caption: "Agents",
+                headers: ["agent", "state"],
+                rows: [["main", "idle"]],
+              },
+            ],
+          },
+        },
+      ],
+      { textChunkLimit: 4000, tableMode: "off" },
+    );
+
+    expect(messages.some((message) => message.card)).toBe(false);
+    expect(messages[0]?.text).toBe(authored);
+  });
+
+  it("puts the controls on the wire as an adaptive-card attachment", async () => {
+    // Whole send path: render -> buildActivity -> sendMSTeamsMessages.
+    const [message] = render({
+      text: "Deploy to production?",
+      presentation: { blocks: [approvalButtons] },
+    });
+    const activity = await captureActivity(message!);
+
+    const attachments = activity.attachments as Array<{
+      contentType?: string;
+      content?: { actions?: Array<{ title?: string }> };
+    }>;
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]?.contentType).toBe("application/vnd.microsoft.card.adaptive");
+    expect(attachments[0]?.content?.actions?.map((action) => action.title)).toEqual([
+      "Approve",
+      "Deny",
+    ]);
+  });
+});

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -30,6 +30,7 @@ import {
 import { extractFilename, extractMessageId, getMimeType, isLocalPath } from "./media-helpers.js";
 import { parseMentions } from "./mentions.js";
 import { setPendingUploadActivityId } from "./pending-uploads.js";
+import { resolveMSTeamsReplyPresentation } from "./presentation.js";
 import { withRevokedProxyFallback } from "./revoked-context.js";
 import { getMSTeamsRuntime } from "./runtime.js";
 import { sendMSTeamsActivityWithReference } from "./sdk-proactive.js";
@@ -85,6 +86,8 @@ type MSTeamsReplyRenderOptions = {
 export type MSTeamsRenderedMessage = {
   text?: string;
   mediaUrl?: string;
+  /** Adaptive Card carrying a reply's portable presentation. */
+  card?: Record<string, unknown>;
 };
 
 type MSTeamsSendRetryOptions = {
@@ -229,8 +232,14 @@ export function renderReplyPayloadsToMessages(
     });
 
   for (const payload of replies) {
+    const presentation = resolveMSTeamsReplyPresentation(payload);
+    if (presentation?.kind === "card") {
+      // The card is the whole message: its body already carries the reply's text.
+      out.push({ card: presentation.card });
+      continue;
+    }
     const reply = resolveSendableOutboundReplyParts(payload, {
-      text: formatMSTeamsMarkdown(payload.text ?? "", tableMode),
+      text: formatMSTeamsMarkdown(presentation?.text ?? payload.text ?? "", tableMode),
     });
 
     if (!reply.hasContent) {
@@ -286,6 +295,14 @@ async function buildActivity(
   activity.channelData = {
     feedbackLoopEnabled: options?.feedbackLoopEnabled ?? false,
   };
+
+  if (msg.card) {
+    activity.entities = [AI_GENERATED_ENTITY];
+    activity.attachments = [
+      { contentType: "application/vnd.microsoft.card.adaptive", content: msg.card },
+    ];
+    return activity;
+  }
 
   if (msg.text) {
     // Parse mentions from text (format: @[Name](id))
@@ -409,7 +426,7 @@ export async function sendMSTeamsMessages(params: {
   serviceUrlBoundary?: MSTeamsSdkCloudOptions;
 }): Promise<string[]> {
   const messages = params.messages.filter(
-    (m) => (m.text && m.text.trim().length > 0) || m.mediaUrl,
+    (m) => (m.text && m.text.trim().length > 0) || m.mediaUrl || m.card,
   );
   if (messages.length === 0) {
     return [];

--- a/extensions/msteams/src/presentation.ts
+++ b/extensions/msteams/src/presentation.ts
@@ -1,9 +1,14 @@
 // Msteams plugin module implements presentation behavior.
 import {
   adaptMessagePresentationForChannel,
+  normalizeMessagePresentation,
+  renderMessagePresentationFallbackText,
   resolveMessagePresentationButtonAction,
   type MessagePresentation,
+  type MessagePresentationBlock,
 } from "openclaw/plugin-sdk/interactive-runtime";
+import { resolveOutboundMediaUrls } from "openclaw/plugin-sdk/reply-payload";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { ChannelOutboundAdapter } from "../runtime-api.js";
 
@@ -103,5 +108,63 @@ export function buildMSTeamsPresentationCard(params: {
     version: "1.4",
     body,
     ...(actions.length ? { actions } : {}),
+  };
+}
+
+/** How a reply's presentation reaches Teams once the channel has resolved it. */
+export type MSTeamsReplyPresentation =
+  | { kind: "card"; card: Record<string, unknown> }
+  | { kind: "text"; text: string };
+
+const countMSTeamsPresentationDataBlocks = (blocks: readonly MessagePresentationBlock[]): number =>
+  blocks.filter((block) => block.type === "table" || block.type === "chart").length;
+
+/**
+ * Resolve a reply's portable presentation for the monitor's own send path.
+ *
+ * Core runs the presentation renderer inside the outbound send pipeline only, so a
+ * reply the monitor delivers itself reaches Teams with its presentation still
+ * portable — and loses it. Resolving it here puts both Teams delivery paths on the
+ * one card builder, and mirrors `renderPresentationForDelivery`, which owns the same
+ * decision for the outbound path.
+ */
+export function resolveMSTeamsReplyPresentation(
+  payload: ReplyPayload,
+): MSTeamsReplyPresentation | undefined {
+  const presentation = normalizeMessagePresentation(payload.presentation);
+  if (!presentation) {
+    return undefined;
+  }
+  const usesFallbackText = payload.presentationTextMode === "fallback";
+  const adapted = adaptMessagePresentationForChannel({
+    presentation,
+    capabilities: MSTEAMS_PRESENTATION_CAPABILITIES,
+  });
+  // Only a presentation whose structured blocks all degraded to text says nothing its
+  // producer's own fallback prose already says; that prose then stays verbatim.
+  const degradedToTextOnly =
+    !presentation.blocks.some((block) => block.type === "buttons" || block.type === "select") &&
+    countMSTeamsPresentationDataBlocks(presentation.blocks) > 0 &&
+    countMSTeamsPresentationDataBlocks(adapted.blocks) === 0;
+  if (usesFallbackText && payload.text?.trim() && degradedToTextOnly) {
+    return { kind: "text", text: payload.text };
+  }
+  // A Teams activity carries a card or an attachment, never both, so a reply that also
+  // carries media keeps its media and states the controls in prose instead.
+  if (resolveOutboundMediaUrls(payload).length === 0) {
+    return {
+      kind: "card",
+      // The card renders the authored prose itself; passing it again would repeat it.
+      card: buildMSTeamsPresentationCard({
+        presentation,
+        text: usesFallbackText ? undefined : payload.text,
+      }),
+    };
+  }
+  return {
+    kind: "text",
+    text: usesFallbackText
+      ? (payload.text ?? renderMessagePresentationFallbackText({ presentation }))
+      : renderMessagePresentationFallbackText({ text: payload.text, presentation }),
   };
 }


### PR DESCRIPTION
Fixes #133295.

## What Problem This Solves

Every button an agent reply offers is dropped before the message reaches Microsoft Teams, and a reply whose only content is those controls produces no Teams activity at all.

Teams already advertises the capability and already knows how to render it. `outbound.ts:103-123` declares `presentationCapabilities` and wires `renderPresentation` to `buildMSTeamsPresentationCard`, which turns a portable presentation into an Adaptive Card. The only consumer of that card is `sendPayload` (`outbound.ts:139-150`) — the generic outbound pipeline.

The monitor answers inbound turns through its own sender, which never runs that renderer. `renderReplyPayloadsToMessages` (`messenger.ts`) read only text and media:

```ts
const reply = resolveSendableOutboundReplyParts(payload, {
  text: formatMSTeamsMarkdown(payload.text ?? "", tableMode),
});

if (!reply.hasContent) {
  continue;
}
```

`payload.presentation` was never referenced there, `MSTeamsRenderedMessage` was `{ text?, mediaUrl? }` with nowhere to carry a card, and `streamController.preparePayload` is streaming-lifecycle only.

Two user-visible outcomes:

- A reply carrying text plus controls went out as plain text. The controls were not degraded into prose — they were dropped, and nothing reported the loss.
- A controls-only reply produced nothing. `hasContent` is `hasText || hasMedia` (`src/infra/outbound/reply-payload-parts.ts:66`), so the payload was skipped by the `continue` and the dispatcher returned `visibleReplySent: false`.

This is the same split already fixed on LINE (#132478 / PR #132479) and reported for Matrix (#132739). Teams is the third channel with the shape.

## Why This Change Was Made

The presentation is resolved once, by the module that already owns Teams cards, and both delivery paths end up on the same builder:

- `resolveMSTeamsReplyPresentation` (in `presentation.ts`, next to `buildMSTeamsPresentationCard`) answers one question for the monitor's sender: does this reply become a card, or prose? It mirrors `renderPresentationForDelivery`, which owns the same decision for the outbound path, so the two cannot drift.
- `MSTeamsRenderedMessage` gained a `card` field, `renderReplyPayloadsToMessages` emits it, and `buildActivity` attaches it as `application/vnd.microsoft.card.adaptive` — the same attachment shape `sendAdaptiveCardMSTeams` already sends. `sendMSTeamsMessages`' own content filter counts a card as content, so a controls-only reply is no longer filtered out twice.

Three cases the resolver has to get right:

1. **A reply that also carries media** keeps its media and states the controls in prose. A Teams activity carries a card or an attachment, never both — the existing `renderPresentation` returns `null` for media payloads for exactly this reason, and this path now matches it instead of silently dropping the controls.
2. **`presentationTextMode: "fallback"` where every structured block degraded to text** keeps the producer's own prose verbatim and builds no card. That is core's rule, and it is what keeps `/status` — whose presentation is a table Teams cannot render natively — rendering exactly as it does today.
3. **Otherwise** the card is built, and the authored text is passed to the builder only when it is not already the fallback prose for the same blocks, so nothing is said twice.

Production LOC: +82 / −2 (net +80), all of it the resolver plus the card's path through the existing render/build/send chain. There was no seam to absorb it: the rendered-message type had no card, and the activity builder had no adaptive-card branch.

## User Impact

Teams operators get the controls their agent replies already offer on Telegram, Slack and LINE. A reply carrying buttons arrives as an Adaptive Card with those buttons; a controls-only reply produces a message instead of nothing.

Replies without a presentation are untouched, and a reply whose presentation only restates its own authored text — `/status` and anything else in fallback mode whose blocks all degrade — keeps exactly the text it sends today.

## Evidence

`node scripts/run-vitest.mjs extensions/msteams/src/messenger.presentation.test.ts`, against `origin/main`'s rendering (the resolver call removed from the loop):

```
 × delivers the controls a reply offers as a card
   → expected undefined to deeply equal [ 'Approve', 'Deny' ]
 × still reaches Teams when the controls are the whole reply
   → expected [] to have a length of 1 but got +0
 × states the controls in prose when the reply also carries media
   → expected 'Here it is' to contain 'Approve'
 ✓ keeps authored prose when the presentation only restates it
 × puts the controls on the wire as an adaptive-card attachment
   → Target cannot be null or undefined.
 Tests  4 failed | 1 passed (5)
```

The second line is the message-loss case: `[]` — the controls-only reply rendered to no messages at all, so nothing was sent. The fourth test passes on both sides; it is the guard that `/status`-shaped replies do not change.

With the fix, all five pass, and the last one is a send-path proof rather than a rendering assertion: it runs `renderReplyPayloadsToMessages → buildActivity → sendMSTeamsMessages` and captures the activity handed to the Bot Framework SDK:

```
attachments[0].contentType === "application/vnd.microsoft.card.adaptive"
attachments[0].content.actions.map(a => a.title) === ["Approve", "Deny"]
```

```
$ node scripts/run-vitest.mjs extensions/msteams
 Test Files  100 passed (100)
      Tests  1556 passed (1556)

$ node scripts/check-changed.mjs        # exit 0
  conflict markers · max-lines ratchet · assertion SAFETY ratchet · coercion helper guard
  · format changed files · deprecated API usage · plugin boundaries · dead export scan
  · typecheck extensions · typecheck extension tests · lint extension changed files
  · database-first legacy-store guard · runtime import cycles
```

The new tests live in their own file: adding them to `messenger.test.ts` pushed it past the 1000-line `max-lines` limit, and that ratchet is not something to suppress.

**Live-channel proof gap, stated plainly.** I do not have a Microsoft Teams tenant or an Azure Bot registration, and a local Bot Framework service cannot stand in: `channels.msteams.serviceUrl` is schema-restricted to supported Bot Connector hosts (`config-schema.ts:93-99`, `isAllowedMSTeamsServiceUrl`), which is a deliberate boundary I did not want to widen for a test. The strongest proof available without a tenant is the send-path capture above, which exercises every line this PR changes and stops only at the SDK's HTTP call. A tenant-backed screenshot of the rendered card would be stronger, and I would welcome one from anyone who has that environment.
