### PR TITLE
perf(history): reuse prepared display and session facts

### DIFF
--- a/src/chat/transcript-display-position.ts
+++ b/src/chat/transcript-display-position.ts
@@ -25,6 +25,9 @@ export type TranscriptDisplayPosition = z.infer<typeof positionSchema>;
 export function readTranscriptDisplayPosition(
   value: unknown,
 ): TranscriptDisplayPosition | undefined {
+  if (!asOptionalRecord(value)) {
+    return undefined;
+  }
   const parsed = positionSchema.safeParse(value);
   return parsed.success ? parsed.data : undefined;
 }
@@ -34,71 +37,86 @@ export function composeTranscriptDisplay<T>(
   values: T[],
   messageFor: (value: T) => unknown = (value) => value,
 ): T[] {
-  type Row = { value: T; position: TranscriptDisplayPosition };
   const output: T[] = [];
-  let segment: Row[] = [];
+  let start = 0;
+  let positions: TranscriptDisplayPosition[] = [];
+  let activities: number[] = [];
+  let previousStableSeq: number | undefined;
+  let monotonic = true;
   const flush = () => {
-    const rows = segment;
-    segment = [];
-    const stable = rows.filter((row) => !row.position.activity);
-    const monotonic = stable.every((row, index) => {
-      const previous = stable[index - 1];
-      return !previous || previous.position.rawSeq <= row.position.rawSeq;
-    });
-    const activities = rows.flatMap((row) =>
-      row.position.activity ? [{ ...row, activity: row.position.activity }] : [],
-    );
-    if (!monotonic || activities.length === 0) {
-      for (const row of rows) {
-        output.push(row.value);
-      }
+    if (positions.length === 0) {
       return;
     }
-    const ordered = activities.toSorted((left, right) => {
-      const a = left.activity.afterRawSeq;
-      const b = right.activity.afterRawSeq;
+    const current = positions;
+    const activityIndexes = activities;
+    const recompose = monotonic && activityIndexes.length > 0;
+    positions = [];
+    activities = [];
+    previousStableSeq = undefined;
+    monotonic = true;
+    if (!recompose) {
+      return;
+    }
+    // Positions index the collected output tail. Detach only segments that need
+    // recomposition, preserving each value captured by the message selector.
+    const selected = output.splice(start);
+    const ordered = activityIndexes.toSorted((left, right) => {
+      const a = current[left]!.activity!.afterRawSeq;
+      const b = current[right]!.activity!.afterRawSeq;
       if (a === b) {
-        return left.position.rawSeq - right.position.rawSeq;
+        return current[left]!.rawSeq - current[right]!.rawSeq;
       }
       if (a === null) {
         return -1;
       }
       return b === null ? 1 : a - b;
     });
-    const iterator = ordered.values();
-    let next = iterator.next();
+    let next = 0;
     const emitGap = (beforeRawSeq?: number) => {
-      const cohorts = new Map<string, { firstSeq: number; rows: typeof activities }>();
-      while (!next.done) {
-        const row = next.value;
-        const afterRawSeq = row.activity.afterRawSeq;
-        if (beforeRawSeq !== undefined && afterRawSeq !== null && afterRawSeq >= beforeRawSeq) {
+      let cohorts: Map<string, { firstSeq: number; rows: number[] }> | undefined;
+      while (next < ordered.length) {
+        const index = ordered[next]!;
+        const position = current[index]!;
+        const activity = position.activity!;
+        if (
+          beforeRawSeq !== undefined &&
+          activity.afterRawSeq !== null &&
+          activity.afterRawSeq >= beforeRawSeq
+        ) {
           break;
         }
-        let cohort = cohorts.get(row.activity.scopeId);
+        cohorts ??= new Map();
+        let cohort = cohorts.get(activity.scopeId);
         if (!cohort) {
-          cohort = { firstSeq: row.position.rawSeq, rows: [] };
-          cohorts.set(row.activity.scopeId, cohort);
+          cohort = { firstSeq: position.rawSeq, rows: [] };
+          cohorts.set(activity.scopeId, cohort);
         }
-        cohort.firstSeq = Math.min(cohort.firstSeq, row.position.rawSeq);
-        cohort.rows.push(row);
-        next = iterator.next();
+        cohort.firstSeq = Math.min(cohort.firstSeq, position.rawSeq);
+        cohort.rows.push(index);
+        next += 1;
+      }
+      if (!cohorts) {
+        return;
       }
       // Scope cohorts keep a total order; comparing ordinals only for matching
       // scopes inside one comparator would be non-transitive across attempts.
       for (const cohort of [...cohorts.values()].toSorted((a, b) => a.firstSeq - b.firstSeq)) {
         const sorted = cohort.rows.toSorted(
           (a, b) =>
-            a.activity.startOrder - b.activity.startOrder || a.position.rawSeq - b.position.rawSeq,
+            current[a]!.activity!.startOrder - current[b]!.activity!.startOrder ||
+            current[a]!.rawSeq - current[b]!.rawSeq,
         );
-        for (const row of sorted) {
-          output.push(row.value);
+        for (const index of sorted) {
+          output.push(selected[index]!);
         }
       }
     };
-    for (const row of stable) {
-      emitGap(row.position.rawSeq);
-      output.push(row.value);
+    for (let index = 0; index < current.length; index += 1) {
+      const position = current[index]!;
+      if (!position.activity) {
+        emitGap(position.rawSeq);
+        output.push(selected[index]!);
+      }
     }
     emitGap();
   };
@@ -110,12 +128,21 @@ export function composeTranscriptDisplay<T>(
     if (!position) {
       flush();
       output.push(value);
+      start = output.length;
       continue;
     }
-    if (segment.at(-1)?.position.source !== position.source) {
+    if (positions.at(-1)?.source !== position.source) {
       flush();
+      start = output.length;
     }
-    segment.push({ value, position });
+    if (position.activity) {
+      activities.push(positions.length);
+    } else {
+      monotonic &&= previousStableSeq === undefined || previousStableSeq <= position.rawSeq;
+      previousStableSeq = position.rawSeq;
+    }
+    positions.push(position);
+    output.push(value);
   }
   flush();
   return output.every((value, index) => value === values[index]) ? values : output;

--- a/src/config/sessions/session-accessor.entry.ts
+++ b/src/config/sessions/session-accessor.entry.ts
@@ -239,7 +239,7 @@ export function resolveSessionEntryCandidateTarget(
     return {
       agentId: resolvedAgentId,
       candidateKey,
-      entry: structuredClone(resolved.existing),
+      entry: resolved.existing,
       persisted: true,
       sessionKey: resolved.normalizedKey,
     };
@@ -387,11 +387,9 @@ export function listSessionEntriesCore(scope: SessionEntryListScope = {}): Sessi
 }
 
 /**
- * Borrowed keyed view over one resolved store for synchronous read-only hot paths.
- * Unlike loadSessionEntry, `get` is a raw exact persisted-key probe with no alias
- * or canonical-key resolution. The first probe materializes one validated store
- * snapshot; later probes and `entries` reuse its parsed rows. Rows are borrowed,
- * not cloned: callers must not mutate them and must drop the view before any await.
+ * Synchronous read view: `get` queries one exact persisted key without alias resolution;
+ * `entries` reuses a validated store snapshot. List rows and their nested values are
+ * borrowed: callers must not mutate them and must drop the view before any await.
  */
 export function openSessionEntryReadView(
   scope: Omit<SessionEntryListScope, "clone" | "readConsistency"> = {},

--- a/src/config/sessions/session-accessor.sqlite-entry-availability.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-availability.ts
@@ -13,7 +13,6 @@ import {
   readExactSessionEntryRowValidated,
 } from "./session-accessor.sqlite-entry-store.js";
 import {
-  cloneSessionEntry,
   getSessionKysely,
   resolveSqliteReadScope,
   resolveSqliteScope,
@@ -87,7 +86,7 @@ export function loadExactSessionEntryReadOnlyResult(
     found: true,
     value: {
       sessionKey,
-      entry: scope.clone === false ? result.value.entry : cloneSessionEntry(result.value.entry),
+      entry: result.value.entry,
     },
   };
 }

--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -75,6 +75,7 @@ export type ResolvedSessionEntryRow = {
   row: SessionEntryRow;
 };
 
+/** Decodes a fresh owned entry, including its nested JSON, owner and participant values. */
 export function parseReadableSqliteSessionEntryRow(
   database: Pick<OpenClawAgentDatabase, "db">,
   row: Pick<SessionEntryRow, "current_session_id" | "entry_json" | "session_key" | "updated_at"> &

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -115,13 +115,8 @@ export function resolveSessionEntry(
     database: Pick<OpenClawAgentDatabase, "agentId" | "db" | "path">,
   ): ResolvedSqliteSessionEntry => {
     const selected = readSessionEntryRow(database, resolved.sessionKey);
-    const existing = selected?.entry;
     return {
-      existing: existing
-        ? scope.clone === false
-          ? existing
-          : cloneSessionEntry(existing)
-        : undefined,
+      existing: selected?.entry,
       legacyKeys: [],
       normalizedKey: resolved.sessionKey,
     };
@@ -154,9 +149,7 @@ export function loadExactSessionEntry(scope: SessionAccessScope): ExactSessionEn
   const resolved = resolveSqliteScope(scope);
   const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
   const entry = readExactSessionEntryRowValidated(database, sessionKey)?.entry;
-  return entry
-    ? { sessionKey, entry: scope.clone === false ? entry : cloneSessionEntry(entry) }
-    : undefined;
+  return entry ? { sessionKey, entry } : undefined;
 }
 
 /** Lists persisted session keys without materializing their entry JSON. */
@@ -190,7 +183,7 @@ export function loadExactSessionEntryReadOnly(
   return result.found && result.value
     ? {
         sessionKey,
-        entry: scope.clone === false ? result.value : cloneSessionEntry(result.value),
+        entry: result.value,
       }
     : undefined;
 }
@@ -220,14 +213,7 @@ export function listSessionChildEntriesReadOnly(scope: SessionAccessScope): Sess
         return [];
       }
       const entry = parseReadableSqliteSessionEntryRow(database, row);
-      return entry
-        ? [
-            {
-              sessionKey: row.session_key,
-              entry: scope.clone === false ? entry : cloneSessionEntry(entry),
-            },
-          ]
-        : [];
+      return entry ? [{ sessionKey: row.session_key, entry }] : [];
     });
   }, toDatabaseOptions(resolved));
   return result.found ? result.value : [];

--- a/src/config/sessions/session-accessor.types.ts
+++ b/src/config/sessions/session-accessor.types.ts
@@ -111,7 +111,7 @@ export type ResolvedSessionEntryCandidateTarget = {
   agentId: string;
   /** Candidate key that selected the result, or the fallback key. */
   candidateKey: string;
-  /** Session metadata cloned from storage or from the synthesized fallback. */
+  /** Fresh owned session metadata, or a clone of the synthesized fallback. */
   entry: SessionEntry;
   /** False only for synthesized fallback entries that have not been written. */
   persisted: boolean;

--- a/src/gateway/chat-display-projection.core.ts
+++ b/src/gateway/chat-display-projection.core.ts
@@ -43,16 +43,12 @@ type ChatDisplayProjectionOptions = {
   streamErrorFallbackPending?: boolean;
 };
 
-function projectCurrentUserProfileAvatars(
-  messages: Array<Record<string, unknown>>,
-  resolveDisplay: CurrentUserProfileDisplayResolver | undefined,
-): Array<Record<string, unknown>> {
-  if (!resolveDisplay) {
-    return messages;
-  }
+/** Keep profile display reads local to one history page or event projection operation. */
+export function createCurrentUserProfileMessageProjector(
+  resolveDisplay: CurrentUserProfileDisplayResolver,
+) {
   const displayBySenderId = new Map<string, CurrentUserProfileDisplay>();
-  let changed = false;
-  const projected = messages.map((message) => {
+  return (message: Record<string, unknown>): Record<string, unknown> => {
     if (message.role !== "user") {
       return message;
     }
@@ -79,7 +75,6 @@ function projectCurrentUserProfileAvatars(
     ) {
       return message;
     }
-    changed = true;
     return {
       ...message,
       __openclaw: {
@@ -88,6 +83,22 @@ function projectCurrentUserProfileAvatars(
         senderProfileAvatarUrl: display.avatarUrl,
       },
     };
+  };
+}
+
+function projectCurrentUserProfileAvatars(
+  messages: Array<Record<string, unknown>>,
+  resolveDisplay: CurrentUserProfileDisplayResolver | undefined,
+): Array<Record<string, unknown>> {
+  if (!resolveDisplay) {
+    return messages;
+  }
+  const project = createCurrentUserProfileMessageProjector(resolveDisplay);
+  let changed = false;
+  const projected = messages.map((message) => {
+    const row = project(message);
+    changed ||= row !== message;
+    return row;
   });
   return changed ? projected : messages;
 }

--- a/src/gateway/chat-display-projection.history.ts
+++ b/src/gateway/chat-display-projection.history.ts
@@ -233,14 +233,17 @@ function isDisplayHiddenProjectedMessage(message: Record<string, unknown>): bool
   return message.role === "custom" && message.customType === OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE;
 }
 
-function shouldHideProjectedHistoryMessage(message: Record<string, unknown>): boolean {
+function shouldHideProjectedHistoryMessage(
+  message: Record<string, unknown>,
+  roleContent: RoleContentMessage | null,
+  heartbeatUser: boolean,
+): boolean {
   if (isDisplayHiddenProjectedMessage(message)) {
     return true;
   }
   if (isProjectedSessionsSendForwardedMessage(message)) {
     return false;
   }
-  const roleContent = asRoleContentMessage(message);
   if (!roleContent) {
     return false;
   }
@@ -260,10 +263,7 @@ function shouldHideProjectedHistoryMessage(message: Record<string, unknown>): bo
   if (roleContent.role === "assistant" && isEmptyTextOnlyContent(message.content ?? message.text)) {
     return false;
   }
-  if (isHeartbeatUserMessage(roleContent, HEARTBEAT_PROMPT)) {
-    return true;
-  }
-  return isHeartbeatOkResponse(roleContent);
+  return heartbeatUser || isHeartbeatOkResponse(roleContent);
 }
 
 /** Identifies the hidden native input that starts a heartbeat-driven turn. */
@@ -386,13 +386,14 @@ export function filterVisibleProjectedHistoryMessages(
       continue;
     }
     const currentRoleContent = asRoleContentMessage(current);
-    const next = messages[i + 1];
+    const heartbeatUser = Boolean(
+      currentRoleContent && isHeartbeatUserMessage(currentRoleContent, HEARTBEAT_PROMPT),
+    );
+    const next = heartbeatUser ? messages[i + 1] : undefined;
     const nextRoleContent = next ? asRoleContentMessage(next) : null;
     if (
-      currentRoleContent &&
       next &&
       nextRoleContent &&
-      isHeartbeatUserMessage(currentRoleContent, HEARTBEAT_PROMPT) &&
       isHeartbeatOkResponse(nextRoleContent) &&
       !isProjectedSessionsSendForwardedMessage(next)
     ) {
@@ -401,9 +402,9 @@ export function filterVisibleProjectedHistoryMessages(
       i++;
       continue;
     }
-    if (shouldHideProjectedHistoryMessage(current)) {
+    if (shouldHideProjectedHistoryMessage(current, currentRoleContent, heartbeatUser)) {
       changed = true;
-      pendingTurnBoundary ||= isHeartbeatHistoryTurnBoundaryMessage(current);
+      pendingTurnBoundary ||= heartbeatUser && !isSessionsSendInterSessionUserMessage(current);
       continue;
     }
     if (

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -1,6 +1,7 @@
 // Public chat display projection facade.
 export { augmentChatHistoryWithCanvasBlocks } from "./chat-display-projection.canvas.js";
 export {
+  createCurrentUserProfileMessageProjector,
   projectChatDisplayMessage,
   projectChatDisplayMessages,
   projectChatDisplayMessagesWithState,

--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -120,7 +120,11 @@ function extractComparableText(
   };
 }
 
-function prepareComparableMessage(message: unknown, order: number): ComparableHistoryMessage {
+function prepareComparableMessage(
+  message: unknown,
+  order: number,
+  externalIdentityKey: string | undefined,
+): ComparableHistoryMessage {
   if (!message || typeof message !== "object") {
     return { message, order, hasCliImageMentions: false };
   }
@@ -130,7 +134,7 @@ function prepareComparableMessage(message: unknown, order: number): ComparableHi
   return {
     message,
     order,
-    externalIdentityKey: resolveImportedExternalIdentityKey(message),
+    externalIdentityKey,
     hasCliImageMentions: comparableText.hasCliImageMentions,
     ...(comparableText.cliImageTurnKey ? { cliImageTurnKey: comparableText.cliImageTurnKey } : {}),
     role,
@@ -235,18 +239,6 @@ function hasLocalImageMediaFacts(entry: ComparableHistoryMessage): boolean {
   return message ? (readPersistedMediaFacts(message) ?? []).some(isImageMediaFact) : false;
 }
 
-function findLocalImageMediaMatch(
-  candidates: ComparableHistoryMessage[],
-  imported: ComparableHistoryMessage,
-): number {
-  if (!imported.hasCliImageMentions || !imported.cliImageTurnKey) {
-    return -1;
-  }
-  return candidates.findIndex(
-    (candidate) => candidate.cliImageTurnKey === imported.cliImageTurnKey,
-  );
-}
-
 function compareHistoryMessages(a: ComparableHistoryMessage, b: ComparableHistoryMessage): number {
   if (a.timestamp !== undefined && b.timestamp !== undefined && a.timestamp !== b.timestamp) {
     return a.timestamp - b.timestamp;
@@ -262,11 +254,13 @@ export function mergeImportedChatHistoryMessages(params: {
   if (params.importedMessages.length === 0) {
     return params.localMessages;
   }
-  const merged = params.localMessages.map(prepareComparableMessage);
+  const merged = params.localMessages.map((message, order) =>
+    prepareComparableMessage(message, order, resolveImportedExternalIdentityKey(message)),
+  );
   const exactExternalIdentityIndex = new Set<string>();
   const allMessageRoleTextIndex: RoleTextIndex = new Map();
   const identitylessRoleTextIndex: RoleTextIndex = new Map();
-  const localImageMediaCandidates: ComparableHistoryMessage[] = [];
+  const localImageMediaCounts = new Map<string, number>();
   const indexEntry = (entry: ComparableHistoryMessage) => {
     if (entry.externalIdentityKey) {
       exactExternalIdentityIndex.add(entry.externalIdentityKey);
@@ -276,28 +270,30 @@ export function mergeImportedChatHistoryMessages(params: {
     addRoleTextCandidate(allMessageRoleTextIndex, entry);
   };
   for (const entry of merged) {
+    indexEntry(entry);
+    if (!hasLocalImageMediaFacts(entry)) {
+      continue;
+    }
     const localMeta = asOptionalRecord(asOptionalRecord(entry.message)?.["__openclaw"]);
     const localEntryId = normalizeOptionalString(localMeta?.id);
-    if (localEntryId) {
-      entry.cliImageTurnKey = hashCliImageTurnEntryId(localEntryId);
-    }
-    indexEntry(entry);
-    if (hasLocalImageMediaFacts(entry)) {
-      localImageMediaCandidates.push(entry);
+    const turnKey = localEntryId ? hashCliImageTurnEntryId(localEntryId) : entry.cliImageTurnKey;
+    if (turnKey) {
+      localImageMediaCounts.set(turnKey, (localImageMediaCounts.get(turnKey) ?? 0) + 1);
     }
   }
   let nextOrder = merged.length;
   for (const message of params.importedMessages) {
-    const imported = prepareComparableMessage(message, nextOrder);
-    if (
-      imported.externalIdentityKey &&
-      exactExternalIdentityIndex.has(imported.externalIdentityKey)
-    ) {
+    const externalIdentityKey = resolveImportedExternalIdentityKey(message);
+    if (externalIdentityKey && exactExternalIdentityIndex.has(externalIdentityKey)) {
       continue;
     }
-    const localImageMediaIndex = findLocalImageMediaMatch(localImageMediaCandidates, imported);
-    if (localImageMediaIndex !== -1) {
-      localImageMediaCandidates.splice(localImageMediaIndex, 1);
+    const imported = prepareComparableMessage(message, nextOrder, externalIdentityKey);
+    const turnKey = imported.hasCliImageMentions ? imported.cliImageTurnKey : undefined;
+    const matches = turnKey ? localImageMediaCounts.get(turnKey) : undefined;
+    if (turnKey && matches) {
+      // Each local image turn suppresses one import. Counts preserve repeated
+      // keys without retaining or shifting rows that matching never inspects.
+      localImageMediaCounts.set(turnKey, matches - 1);
       continue;
     }
     const duplicate = imported.externalIdentityKey

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -675,37 +675,40 @@ describe("cli session history", () => {
     },
   );
 
-  it("consumes each local media-bearing turn only once", () => {
-    const timestamp = Date.parse("2026-03-26T16:29:54.500Z");
-    const localEntryId = "local-repeated-image";
-    const importedMessages = ["first-image-user", "second-image-user"].map((externalId, index) => ({
-      role: "user",
-      content: `look at this\n\n${formatCliImageTurnContext(hashCliImageTurnEntryId(localEntryId))}\n\n@/Users/demo/workspace/.openclaw-cli-images/cafe0${index + 5}.png`,
-      timestamp: timestamp + index * 60_000,
-      __openclaw: {
-        importedFrom: "claude-cli",
-        cliSessionId: "session-1",
-        externalId,
-      },
-    }));
-
-    const merged = mergeImportedChatHistoryMessages({
-      localMessages: [
-        {
+  it.each([1, 2])(
+    "consumes each local media-bearing turn only once with %i matching local rows",
+    (localCount) => {
+      const timestamp = Date.parse("2026-03-26T16:29:54.500Z");
+      const localEntryId = "local-repeated-image";
+      const importedMessages = ["first-image-user", "second-image-user", "third-image-user"]
+        .slice(0, localCount + 1)
+        .map((externalId, index) => ({
           role: "user",
-          content: "look at this",
-          timestamp,
+          content: `look at this\n\n${formatCliImageTurnContext(hashCliImageTurnEntryId(localEntryId))}\n\n@/Users/demo/workspace/.openclaw-cli-images/cafe0${index + 5}.png`,
+          timestamp: timestamp + index * 60_000,
           __openclaw: {
-            id: localEntryId,
-            media: [{ kind: "image", contentType: "image/png", path: "/media/inbound/cafe05.png" }],
+            importedFrom: "claude-cli",
+            cliSessionId: "session-1",
+            externalId,
           },
+        }));
+      const localMessages = Array.from({ length: localCount }, () => ({
+        role: "user",
+        content: "look at this",
+        timestamp,
+        __openclaw: {
+          id: localEntryId,
+          media: [{ kind: "image", contentType: "image/png", path: "/media/inbound/cafe05.png" }],
         },
-      ],
-      importedMessages,
-    });
+      }));
 
-    expect(merged).toEqual([expect.any(Object), importedMessages[1]]);
-  });
+      const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
+
+      expect(merged).toEqual([...localMessages, importedMessages[localCount]]);
+      expect(merged[0]).toBe(localMessages[0]);
+      expect(merged.at(-1)).toBe(importedMessages[localCount]);
+    },
+  );
 
   it("retains mention-only imports near unrelated local image turns", () => {
     const timestamp = Date.parse("2026-03-26T16:29:54.500Z");

--- a/src/gateway/server-methods/chat-history-delta.ts
+++ b/src/gateway/server-methods/chat-history-delta.ts
@@ -5,6 +5,8 @@ import {
   readTranscriptDisplayDelta,
   type SessionTranscriptDisplayDeltaResult,
 } from "../../config/sessions/session-accessor.sqlite-history-events.js";
+import { createCurrentUserProfileMessageProjector } from "../chat-display-projection.js";
+import { resolveCurrentUserProfileDisplay } from "../current-user-profile-display.js";
 import {
   projectSessionMessagePayload,
   type SessionMessageProjectionState,
@@ -69,6 +71,9 @@ export function readChatHistoryDelta(params: {
     streamErrorFallbackPending: false,
     turnBoundaryPending: false,
   };
+  const projectCurrentUserProfile = createCurrentUserProfileMessageProjector(
+    resolveCurrentUserProfileDisplay,
+  );
   const messages: Record<string, unknown>[] = [];
   for (const row of result.events) {
     const event = readMessageEvent(row.event);
@@ -82,6 +87,7 @@ export function readChatHistoryDelta(params: {
       messageSeq: row.messageSeq,
       transcriptPosition: row.displayPosition,
       projectionState,
+      projectCurrentUserProfile,
       sessionKey: params.sessionKey,
       sessionSnapshot: params.sessionSnapshot,
     });

--- a/src/gateway/server-session-events.test-support.ts
+++ b/src/gateway/server-session-events.test-support.ts
@@ -35,9 +35,10 @@ vi.mock("../config/sessions/session-accessor.js", async (importOriginal) => {
     resolveTranscriptSessionKeyBySessionId: resolveTranscriptSessionKeyBySessionIdMock,
   };
 });
-vi.mock("./chat-display-projection.js", () => ({
-  projectChatDisplayMessage: projectChatDisplayMessageMock,
-}));
+vi.mock("./chat-display-projection.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./chat-display-projection.js")>();
+  return { ...actual, projectChatDisplayMessage: projectChatDisplayMessageMock };
+});
 vi.mock("./session-utils.js", () => ({
   attachOpenClawTranscriptMeta: (message: unknown) => message,
   loadGatewaySessionRow: loadGatewaySessionRowMock,

--- a/src/gateway/server.chat-history-cursor.test.ts
+++ b/src/gateway/server.chat-history-cursor.test.ts
@@ -21,6 +21,8 @@ import { waitForSessionTranscriptIndexReconcile } from "../config/sessions/sessi
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { createNestedToolActivity } from "../sessions/nested-tool-activity.js";
 import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
+import * as userProfiles from "../state/user-profiles.js";
+import { buildControlUiUserAvatarPath } from "./control-ui-contract.js";
 import * as managedOutgoingMedia from "./managed-image-attachments.js";
 import { createDirectChatContext } from "./server-chat.agent-events.test-helpers.js";
 import type { GatewayRequestContext } from "./server-methods/shared-types.js";
@@ -368,6 +370,65 @@ describe("chat.history cursor catch-up", () => {
     expect(
       composed.map((message) => asOptionalRecord(asOptionalRecord(message)?.["__openclaw"])?.id),
     ).toEqual(["cached", "exec", "first", "second", "wait", "later"]);
+  });
+
+  test("reuses sender display reads within each delta and refreshes the next request", async () => {
+    const { context, storePath } = await createCursorSession();
+    const profile = userProfiles.ensureProfileForEmail("cursor-profile@example.test");
+    const cached = await callChat<{ deltaCursor: string }>(context, "chat.history");
+    expect(cached.ok).toBe(true);
+    expect(cached.payload?.deltaCursor).toEqual(expect.any(String));
+    let parentId = "cached";
+    for (let index = 0; index < 3; index += 1) {
+      const eventId = `profile-message-${index}`;
+      await appendTranscriptMessage(currentScope(storePath), {
+        eventId,
+        parentId,
+        message: {
+          role: "user",
+          content: `question ${index}`,
+          __openclaw: { senderIdentity: { type: "profile", id: profile.id } },
+        },
+      });
+      parentId = eventId;
+    }
+    const lookup = vi.spyOn(userProfiles, "getUserProfileDisplay");
+    try {
+      const avatarUrls: string[] = [];
+      for (const byte of [1, 2]) {
+        expect(userProfiles.setAvatar(profile.id, new Uint8Array([byte]), "image/png").ok).toBe(
+          true,
+        );
+        const { avatarRevision } = userProfiles.getUserProfileDisplay(profile.id);
+        const avatarUrl = buildControlUiUserAvatarPath(profile.id, avatarRevision);
+        avatarUrls.push(avatarUrl);
+        lookup.mockClear();
+        const delta = await callChat<{ kind: string; messages: unknown[] }>(
+          context,
+          "chat.history",
+          {
+            cursor: cached.payload?.deltaCursor,
+          },
+        );
+        expect(delta.ok).toBe(true);
+        expect(delta.payload?.kind).toBe("delta");
+        expect(lookup.mock.calls).toEqual([[profile.id]]);
+        expect(delta.payload?.messages).toHaveLength(3);
+        for (const envelope of delta.payload?.messages ?? []) {
+          expect(envelope).toMatchObject({
+            message: {
+              __openclaw: {
+                senderIdentity: { type: "profile", id: profile.id },
+                senderProfileAvatarUrl: avatarUrl,
+              },
+            },
+          });
+        }
+      }
+      expect(avatarUrls[1]).not.toBe(avatarUrls[0]);
+    } finally {
+      lookup.mockRestore();
+    }
   });
 
   test("returns an empty delta at the cached head", async () => {

--- a/src/gateway/session-companion-context.test.ts
+++ b/src/gateway/session-companion-context.test.ts
@@ -6,6 +6,7 @@ import {
   upsertSessionEntryCore,
 } from "../config/sessions/session-accessor.js";
 import * as activeTranscriptEvents from "../config/sessions/session-accessor.sqlite-active-events.js";
+import * as redact from "../logging/redact.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -71,23 +72,29 @@ describe("session companion context", () => {
       .prepare("UPDATE transcript_events SET event_json = '{' WHERE session_id = ? AND seq = 1")
       .run(scope.sessionId);
 
-    const result = await defaultSessionCompanionContextReader.read(scope);
+    const redaction = vi.spyOn(redact, "redactToolPayloadText");
+    try {
+      const result = await defaultSessionCompanionContextReader.read(scope);
 
-    expect(result.kind).toBe("ready");
-    if (result.kind !== "ready") {
-      return;
+      expect(result.kind).toBe("ready");
+      if (result.kind !== "ready") {
+        return;
+      }
+      expect(result.context.messages).toHaveLength(40);
+      expect(result.context.messages.at(0)).toEqual({
+        role: "assistant",
+        text: "message 161",
+        ts: 161,
+      });
+      expect(result.context.messages.at(-1)).toEqual({
+        role: "user",
+        text: "message 200",
+        ts: 200,
+      });
+      expect(redaction).toHaveBeenCalledTimes(40);
+    } finally {
+      redaction.mockRestore();
     }
-    expect(result.context.messages).toHaveLength(40);
-    expect(result.context.messages.at(0)).toEqual({
-      role: "assistant",
-      text: "message 161",
-      ts: 161,
-    });
-    expect(result.context.messages.at(-1)).toEqual({
-      role: "user",
-      text: "message 200",
-      ts: 200,
-    });
   });
 
   it("pages past a tool-heavy tail while retaining the selected session's latest user turn", async () => {

--- a/src/gateway/session-companion-context.ts
+++ b/src/gateway/session-companion-context.ts
@@ -1,12 +1,6 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import {
-  extractStoredAssistantText,
-  stripToolMessages,
-} from "../agents/tools/chat-history-text.js";
-import {
-  isSessionTranscriptProjectionUnavailableError,
-  readSessionTranscriptBoundedMessageTailPage,
-} from "../config/sessions/session-accessor.sqlite-active-events.js";
+import { extractStoredAssistantText } from "../agents/tools/chat-history-text.js";
+import { readSessionTranscriptBoundedMessageTailPage } from "../config/sessions/session-accessor.sqlite-active-events.js";
 import { redactToolPayloadText } from "../logging/redact.js";
 import type {
   SessionCompanionContextMessage,
@@ -73,10 +67,23 @@ function readMessageTimestamp(message: unknown): number {
   return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 }
 
-function sanitizeContextMessages(messages: unknown[]): SessionCompanionContextMessage[] {
-  return stripToolMessages(messages).flatMap((message): SessionCompanionContextMessage[] => {
+function appendContextMessages(
+  events: Array<{ event: unknown }>,
+  messages: SessionCompanionContextMessage[],
+): void {
+  // Keep newest-first context across pages; older discarded rows need no text work.
+  for (
+    let index = events.length - 1;
+    index >= 0 && messages.length < CONTEXT_MAX_MESSAGES;
+    index--
+  ) {
+    const event = events[index]?.event;
+    if (!event || typeof event !== "object") {
+      continue;
+    }
+    const message = (event as { message?: unknown }).message;
     if (!message || typeof message !== "object") {
-      return [];
+      continue;
     }
     const role = (message as { role?: unknown }).role;
     const text =
@@ -85,37 +92,24 @@ function sanitizeContextMessages(messages: unknown[]): SessionCompanionContextMe
         : role === "user"
           ? extractUserText(message)
           : undefined;
-    return text && (role === "assistant" || role === "user")
-      ? [{ role, text, ts: readMessageTimestamp(message) }]
-      : [];
-  });
+    if (text && (role === "assistant" || role === "user")) {
+      messages.push({ role, text, ts: readMessageTimestamp(message) });
+    }
+  }
 }
 
 function selectContextMessages(messages: SessionCompanionContextMessage[]) {
   const selected: SessionCompanionContextMessage[] = [];
   let bytes = 2;
-  for (const message of messages.toReversed()) {
-    if (selected.length >= CONTEXT_MAX_MESSAGES) {
-      break;
-    }
+  for (const message of messages) {
     const messageBytes = Buffer.byteLength(JSON.stringify(message), "utf8") + 1;
     if (bytes + messageBytes > CONTEXT_MAX_BYTES) {
       break;
     }
-    selected.unshift(message);
+    selected.push(message);
     bytes += messageBytes;
   }
-  return selected;
-}
-
-function readPageMessages(events: Array<{ event: unknown }>): unknown[] {
-  return events.flatMap(({ event }) => {
-    if (!event || typeof event !== "object") {
-      return [];
-    }
-    const message = (event as { message?: unknown }).message;
-    return message && typeof message === "object" ? [message] : [];
-  });
+  return selected.toReversed();
 }
 
 async function readSessionCompanionContext(params: {
@@ -151,7 +145,7 @@ async function readSessionCompanionContext(params: {
           totalMessages: number;
         }
       | undefined;
-    let contextMessages: SessionCompanionContextMessage[] = [];
+    const contextMessages: SessionCompanionContextMessage[] = [];
     while (
       contextMessages.length < CONTEXT_MAX_MESSAGES &&
       scannedMessages < CONTEXT_READ_MAX_SCANNED_MESSAGES
@@ -193,10 +187,7 @@ async function readSessionCompanionContext(params: {
       rawBytes += page.serializedBytes;
       scannedMessages += page.scannedMessages;
       offset += page.scannedMessages;
-      contextMessages = [
-        ...sanitizeContextMessages(readPageMessages(pageEvents)),
-        ...contextMessages,
-      ].slice(-CONTEXT_MAX_MESSAGES);
+      appendContextMessages(pageEvents, contextMessages);
       if (pageIsPartial) {
         if (contextMessages.length === 0) {
           return { kind: "unavailable" };
@@ -238,10 +229,7 @@ async function readSessionCompanionContext(params: {
         sessionId,
       },
     };
-  } catch (error) {
-    if (isSessionTranscriptProjectionUnavailableError(error)) {
-      return { kind: "unavailable" };
-    }
+  } catch {
     return { kind: "unavailable" };
   }
 }

--- a/src/gateway/session-transcript-message.ts
+++ b/src/gateway/session-transcript-message.ts
@@ -1,6 +1,7 @@
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type { TranscriptDisplayPosition } from "../chat/transcript-display-position.js";
 import {
+  createCurrentUserProfileMessageProjector,
   projectChatDisplayMessage,
   projectChatDisplayMessagesWithState,
 } from "./chat-display-projection.js";
@@ -57,6 +58,7 @@ export function projectSessionMessagePayload(params: {
   messageSeq?: number;
   transcriptPosition?: TranscriptDisplayPosition;
   projectionState?: SessionMessageProjectionState;
+  projectCurrentUserProfile?: (message: Record<string, unknown>) => Record<string, unknown>;
   runId?: string;
   sessionKey: string;
   sessionSnapshot?: Record<string, unknown>;
@@ -72,12 +74,11 @@ export function projectSessionMessagePayload(params: {
   });
   const projected = params.projectionState
     ? projectChatDisplayMessagesWithState([rawMessage], {
-        resolveCurrentUserProfileDisplay,
         streamErrorFallbackPending: params.projectionState.streamErrorFallbackPending,
         turnBoundaryPending: params.projectionState.turnBoundaryPending,
       })
     : {
-        messages: [projectChatDisplayMessage(rawMessage, { resolveCurrentUserProfileDisplay })],
+        messages: [projectChatDisplayMessage(rawMessage)],
         streamErrorFallbackPending: false,
         turnBoundaryPending: false,
       };
@@ -89,12 +90,15 @@ export function projectSessionMessagePayload(params: {
   if (!message) {
     return { projectionState };
   }
+  const projectCurrentUserProfile =
+    params.projectCurrentUserProfile ??
+    createCurrentUserProfileMessageProjector(resolveCurrentUserProfileDisplay);
   return {
     payload: {
       sessionKey: params.sessionKey,
       ...(senderIsOwner === undefined ? {} : { senderIsOwner }),
       ...(params.agentId ? { agentId: params.agentId } : {}),
-      message,
+      message: projectCurrentUserProfile(message),
       ...(params.messageId ? { messageId: params.messageId } : {}),
       ...(params.messageSeq !== undefined ? { messageSeq: params.messageSeq } : {}),
       ...params.sessionSnapshot,

--- a/src/gateway/session-utils-store-lookup.ts
+++ b/src/gateway/session-utils-store-lookup.ts
@@ -588,6 +588,10 @@ export function resolveGatewaySessionStoreTarget(params: {
   clone?: boolean;
   store?: Record<string, SessionEntry>;
 }): GatewaySessionStoreTarget {
-  const { store: _store, ...target } = resolveGatewaySessionStoreTargetWithStore(params);
+  // Only keys and store metadata escape; omit large prompt snapshots without changing read mode.
+  const { store: _store, ...target } = resolveGatewaySessionStoreTargetWithStore({
+    ...params,
+    projection: "list",
+  });
   return target;
 }

--- a/src/state/user-profile-list.ts
+++ b/src/state/user-profile-list.ts
@@ -1,5 +1,4 @@
 import type { DatabaseSync } from "node:sqlite";
-import { sql } from "kysely";
 import { executeSqliteQuerySync } from "../infra/kysely-sync.js";
 import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
 import { openClawStateDatabaseCache } from "./openclaw-state-db-cache.js";
@@ -13,8 +12,10 @@ import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 import { readUserProfileVersion } from "./user-profile-events.js";
 import { selectUserProfileGitHubIdentities } from "./user-profile-github-identity.js";
 import {
+  selectResolvedUserProfile,
   selectResolvedUserProfileById,
   normalizeUserProfileAvatarMime,
+  userProfileAvatarPresence,
   userProfilesDb,
 } from "./user-profiles-internal.js";
 import {
@@ -42,7 +43,7 @@ export function listProfiles(options: OpenClawStateDatabaseOptions = {}) {
             ...(hasEnsuredUserProfileRoleSchema(database.db) ? (["role"] as const) : []),
             "created_at",
             "updated_at",
-            sql`CASE WHEN avatar IS NULL THEN 0 ELSE 1 END`.as("has_avatar"),
+            userProfileAvatarPresence,
           ])
           .orderBy("created_at", "asc")
           .orderBy("id", "asc"),
@@ -170,15 +171,31 @@ export function readUserProfileAliases(
   return aliases;
 }
 
+const userProfileDisplaySelection = [
+  "id",
+  "display_name",
+  "avatar_mime",
+  "avatar_sha256",
+  "merged_into",
+  "updated_at",
+  userProfileAvatarPresence,
+] as const;
+
+/** Reads merge-aware display data without loading avatar bytes. */
 export function getUserProfileDisplay(
   profileId: string,
   options: OpenClawStateDatabaseOptions = {},
 ): UserProfileDisplay {
-  const profile = withExistingOpenClawStateDatabaseReadOnly(
-    ({ db }) =>
-      tableExists(db, "user_profiles") ? selectResolvedUserProfileById(db, profileId) : undefined,
-    options,
-  );
+  const profile = withExistingOpenClawStateDatabaseReadOnly(({ db }) => {
+    if (!tableExists(db, "user_profiles")) {
+      return undefined;
+    }
+    return selectResolvedUserProfile(
+      db,
+      profileId,
+      userProfilesDb(db).selectFrom("user_profiles").select(userProfileDisplaySelection),
+    );
+  }, options);
   if (!profile) {
     throw new UserProfileNotFoundError(profileId);
   }
@@ -191,6 +208,6 @@ export function getUserProfileDisplay(
     id: profile.id,
     displayName: profile.display_name,
     avatarRevision,
-    hasAvatar: profile.avatar !== null,
+    hasAvatar: profile.has_avatar === 1,
   };
 }

--- a/src/state/user-profiles-internal.ts
+++ b/src/state/user-profiles-internal.ts
@@ -1,5 +1,5 @@
 import type { DatabaseSync } from "node:sqlite";
-import { sql, type SelectQueryBuilder } from "kysely";
+import { expressionBuilder, type SelectQueryBuilder } from "kysely";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import {
   openOpenClawStateDatabase,
@@ -18,9 +18,11 @@ import {
 export type UserProfileRow = UserProfilesDatabase["user_profiles"];
 
 // Selection metadata is immutable and carries no database handle or profile state.
-export const userProfileAvatarPresence = sql<number>`CASE WHEN avatar IS NULL THEN 0 ELSE 1 END`.as(
-  "has_avatar",
-);
+export const userProfileAvatarPresence = expressionBuilder<UserProfilesDatabase, "user_profiles">()(
+  "avatar",
+  "is not",
+  null,
+).as("has_avatar");
 type UserProfileAvatar = {
   bytes: Uint8Array;
   mime: UserProfileAvatarMime;

--- a/src/state/user-profiles-internal.ts
+++ b/src/state/user-profiles-internal.ts
@@ -1,4 +1,5 @@
 import type { DatabaseSync } from "node:sqlite";
+import { sql, type SelectQueryBuilder } from "kysely";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import {
   openOpenClawStateDatabase,
@@ -15,6 +16,11 @@ import {
 } from "./user-profiles-tailscale-avatar.js";
 
 export type UserProfileRow = UserProfilesDatabase["user_profiles"];
+
+// Selection metadata is immutable and carries no database handle or profile state.
+export const userProfileAvatarPresence = sql<number>`CASE WHEN avatar IS NULL THEN 0 ELSE 1 END`.as(
+  "has_avatar",
+);
 type UserProfileAvatar = {
   bytes: Uint8Array;
   mime: UserProfileAvatarMime;
@@ -30,10 +36,19 @@ export function normalizeUserProfileAvatarMime(value: string | null): UserProfil
   return USER_PROFILE_AVATAR_MIME_TYPES.find((candidate) => candidate === value) ?? null;
 }
 
-function selectUserProfileById(db: DatabaseSync, profileId: string): UserProfileRow | undefined {
-  return executeSqliteQueryTakeFirstSync(
-    db,
-    userProfilesDb(db).selectFrom("user_profiles").selectAll().where("id", "=", profileId),
+export function selectResolvedUserProfile<T extends Pick<UserProfileRow, "merged_into">>(
+  db: DatabaseSync,
+  profileId: string,
+  query: SelectQueryBuilder<UserProfilesDatabase, "user_profiles", T>,
+): T | undefined {
+  const profile = executeSqliteQueryTakeFirstSync(db, query.where("id", "=", profileId));
+  if (!profile?.merged_into) {
+    return profile;
+  }
+  // Merge writers repoint aliases and existing tombstones, so durable profile
+  // references need exactly one hop to reach the canonical row.
+  return (
+    executeSqliteQueryTakeFirstSync(db, query.where("id", "=", profile.merged_into)) ?? profile
   );
 }
 
@@ -41,13 +56,11 @@ export function selectResolvedUserProfileById(
   db: DatabaseSync,
   profileId: string,
 ): UserProfileRow | undefined {
-  const profile = selectUserProfileById(db, profileId);
-  if (!profile?.merged_into) {
-    return profile;
-  }
-  // Merge writers repoint aliases and existing tombstones, so durable profile
-  // references need exactly one hop to reach the canonical row.
-  return selectUserProfileById(db, profile.merged_into) ?? profile;
+  return selectResolvedUserProfile(
+    db,
+    profileId,
+    userProfilesDb(db).selectFrom("user_profiles").selectAll(),
+  );
 }
 
 export function requireResolvedUserProfileById(

--- a/src/state/user-profiles.test.ts
+++ b/src/state/user-profiles.test.ts
@@ -236,6 +236,10 @@ describe("user profiles", () => {
 
     expect(tableHasColumn(database, "user_profiles", "role")).toBe(false);
     expect(getUserProfileListItem(profile.id, options)).not.toHaveProperty("role");
+    expect(getUserProfileDisplay(profile.id, options)).toMatchObject({
+      id: profile.id,
+      hasAvatar: false,
+    });
     expect(listProfiles(options)[0]).not.toHaveProperty("role");
     expect(tableHasColumn(database, "user_profiles", "role")).toBe(false);
     expect(getUserProfileRole(profile.id, options)).toBeNull();
@@ -1028,11 +1032,22 @@ describe("user profiles", () => {
     });
   });
 
-  it("stores an allowlisted avatar", () => {
+  it.each([
+    {
+      name: "empty",
+      bytes: [],
+      sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    },
+    {
+      name: "nonempty",
+      bytes: [1, 2, 3],
+      sha256: "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+    },
+  ])("stores an allowlisted avatar with $name content", ({ bytes, sha256 }) => {
     const options = stateOptions();
     const profile = ensureProfileForEmail("ada@example.com", options);
 
-    expect(setAvatar(profile.id, new Uint8Array([1, 2, 3]), "image/png", options)).toEqual({
+    expect(setAvatar(profile.id, new Uint8Array(bytes), "image/png", options)).toEqual({
       ok: true,
       value: expect.objectContaining({
         id: profile.id,
@@ -1042,17 +1057,26 @@ describe("user profiles", () => {
       }),
     });
     expect(getProfileAvatar(profile.id, options)).toEqual({
-      bytes: new Uint8Array([1, 2, 3]),
+      bytes: new Uint8Array(bytes),
       mime: "image/png",
-      sha256: "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+      sha256,
       updatedAt: expect.any(Number),
     });
     expect(listProfiles(options)).toEqual([
       expect.objectContaining({ id: profile.id, hasAvatar: true }),
     ]);
+    expect(getUserProfileDisplay(profile.id, options)).toEqual({
+      id: profile.id,
+      displayName: profile.displayName,
+      hasAvatar: true,
+      avatarRevision: `${sha256}-png`,
+    });
   });
 
-  it("keeps distinct avatar ETags when updates share a millisecond", () => {
+  it.each([
+    { change: "bytes", bytes: [2], mime: "image/png" },
+    { change: "MIME", bytes: [1], mime: "image/webp" },
+  ])("keeps distinct avatar ETags when $change changes within a millisecond", ({ bytes, mime }) => {
     const options = stateOptions();
     const profile = ensureProfileForEmail("ada@example.com", options);
     vi.spyOn(Date, "now").mockReturnValue(100);
@@ -1060,7 +1084,7 @@ describe("user profiles", () => {
     expect(setAvatar(profile.id, new Uint8Array([1]), "image/png", options).ok).toBe(true);
     const first = getProfileAvatar(profile.id, options);
     const firstDisplay = getUserProfileDisplay(profile.id, options);
-    expect(setAvatar(profile.id, new Uint8Array([2]), "image/png", options).ok).toBe(true);
+    expect(setAvatar(profile.id, new Uint8Array(bytes), mime, options).ok).toBe(true);
     const second = getProfileAvatar(profile.id, options);
     const secondDisplay = getUserProfileDisplay(profile.id, options);
 
@@ -1068,24 +1092,6 @@ describe("user profiles", () => {
     expect(firstDisplay.avatarRevision).not.toBe(secondDisplay.avatarRevision);
     expect(formatUserProfileAvatarEtag(first?.sha256 ?? "", first?.mime ?? "image/png")).not.toBe(
       formatUserProfileAvatarEtag(second?.sha256 ?? "", second?.mime ?? "image/png"),
-    );
-  });
-
-  it("keeps distinct avatar ETags when MIME changes with identical bytes", () => {
-    const options = stateOptions();
-    const profile = ensureProfileForEmail("ada@example.com", options);
-    const bytes = new Uint8Array([1, 2, 3]);
-
-    expect(setAvatar(profile.id, bytes, "image/png", options).ok).toBe(true);
-    const png = getProfileAvatar(profile.id, options);
-    const pngDisplay = getUserProfileDisplay(profile.id, options);
-    expect(setAvatar(profile.id, bytes, "image/webp", options).ok).toBe(true);
-    const webp = getProfileAvatar(profile.id, options);
-    const webpDisplay = getUserProfileDisplay(profile.id, options);
-
-    expect(pngDisplay.avatarRevision).not.toBe(webpDisplay.avatarRevision);
-    expect(formatUserProfileAvatarEtag(png?.sha256 ?? "", png?.mime ?? "image/png")).not.toBe(
-      formatUserProfileAvatarEtag(webp?.sha256 ?? "", webp?.mime ?? "image/png"),
     );
   });
 });

--- a/src/state/user-profiles.ts
+++ b/src/state/user-profiles.ts
@@ -26,6 +26,7 @@ import {
   requireResolvedUserProfileById,
   selectResolvedUserProfileById,
   type UserProfileRow,
+  userProfileAvatarPresence,
   userProfilesDb,
 } from "./user-profiles-internal.js";
 import {
@@ -169,10 +170,6 @@ function toUserProfileListItem(
   };
 }
 
-function hasAvatarColumn() {
-  return sql`CASE WHEN avatar IS NULL THEN 0 ELSE 1 END`.as("has_avatar");
-}
-
 function selectUserProfileListItemById(db: DatabaseSync, profileId: string): UserProfileListItem {
   const kysely = userProfilesDb(db);
   const profile = executeSqliteQueryTakeFirstSync(
@@ -187,7 +184,7 @@ function selectUserProfileListItemById(db: DatabaseSync, profileId: string): Use
         ...(hasEnsuredUserProfileRoleSchema(db) ? (["role"] as const) : []),
         "created_at",
         "updated_at",
-        hasAvatarColumn(),
+        userProfileAvatarPresence,
       ])
       .where("id", "=", profileId),
   );
@@ -263,8 +260,6 @@ export function setUserProfileRole(
     { operationLabel: "user-profiles.set-role" },
   );
 }
-
-/** Reads merge-aware display data without exposing avatar content through list/RPC shapes. */
 
 function ensureProfileForEmailWithInitialName(
   email: string,


### PR DESCRIPTION
History preparation repeatedly rediscovered the same visibility, profile, position, import, and session facts. Companion context also normalized and redacted rows that its existing tail limit would discard. This refactor carries prepared facts through the owning operation and removes copies only where the producer already returns fresh objects.

The eight measured changes share the history-read boundary:

- Prepare visibility facts once per row and inspect the next row only for heartbeat handling.
- Select the profile display columns without materializing avatar blobs; retain full profile reads for their existing consumers.
- Resolve a repeated sender once within a delta response. A later request performs a fresh lookup, and scalar/live projection retains its current behavior.
- Capture transcript positions and nested-activity facts once, preserving selector invocation order, mutable-iterator behavior, stable barriers, and output identities.
- Replace repeated CLI image-row searches and splices with per-key remaining capacity.
- Check exact external CLI identity before text preparation, without consuming image capacity for a discarded identity duplicate.
- Remove redundant copies of fresh decoded session entries; retain copies of cached, borrowed, and write-owned objects. Target-only resolution uses the existing list projection without changing database open policy.
- Select the bounded visible companion tail before normalization/redaction, preserving scan limits, partial-message budgeting, chronological output, and abort/generation fences.

No schema, migration, protocol, config/default, public API, dependency, persistent cache, or authorization change. Production is **+238/−189 = +49 lines**; tests are **+146/−68 = +78**. The added production structure owns bounded per-operation facts and explicit projection types. Removed paths include redundant full-row preparation, repeated search/copy work, and duplicate companion error classification. The final companion reversal allocates at most 40 references. Release workflow owns the changelog.

Correctness includes the complete owners, callers, sibling display/live paths, canonical SQLite stores, existing tests, and client transcript contracts. The final integrated proof uses 35 complete owners per variant, all 17 changed production owners, 336 strict source bindings, and 70 copied files. It passes 1,378 display/CLI/UI comparisons, 628 session scenarios with 3,127 comparisons and 152 isolation checks, and 37 actual-SQLite companion scenarios with 156 comparisons, including complete first-ask results and prompts. Subcounts overlap and are not added into a larger claim. Synthetic external CLI artifacts use the real loader/parser; mocked provider acquisition is explicitly separate from live proof.

Canonical verification: all 1,150 tests across 35 files passed on the final base, including upstream first-insert/writer-fence and internal-session cleanup coverage. The profile regression failed before the change at three reads instead of one; the companion regression failed at 128 redactions instead of 40. Both passed after the owner changes. Independent source review and the refreshed managed P0–P3 review are clean. The full changed gate and build pass.

The broader run initially exposed an incomplete wholesale test mock: it omitted the newly canonical projector export and caused a 23-test cascade. The fixture now retains real facade exports and its original scalar override; no product guard or assertion was weakened. Lint also caught an in-place reversal and a profile test file over the line limit. The reversal uses `toReversed()`, and two equivalent ETag tests are parameterized, preserving byte/MIME cases and testing both within one millisecond. All failed attempts remain in local evidence.

After main advanced, the branch was rebased once and the full proof was refreshed. The new first-insert lease owner, write-result copies, synchronous post-commit bookkeeping, idempotency ownership, and transcript-write fences are preserved. The final benchmark compares main `48b0857e` with candidate `37f216f9`; earlier receipts remain attached to their original source bytes.

CI then found a typed raw SQL expression outside the allowed Kysely boundary. The shared avatar-presence selection now uses the typed `avatar IS NOT NULL` expression. Kysely and SQLite source, the existing NULL/empty-BLOB cases and all three consumers confirm identical 0/1 semantics. No guard exception or cast was added. The Kysely guard, all 1,150 canonical tests (68.03 seconds), the full changed gate (271.34 seconds) and a fresh managed P0–P3 review pass. The corrected build passes in 151.19 seconds. All final proof, timings and live checks below use the corrected source. This refines an existing mechanism, not another performance count.

Four quiet fresh processes cover 193 workload shapes in opposite owner/workload orders, with three warmups and five alternating measured samples retained. Complete output equality is checked before timing. Independent reduction and a separate parent recalculation agree on all 772 medians. Representative complete paths are below; values are milliseconds per invocation.

| Path | Original F/R | Candidate F/R |
| --- | ---: | ---: |
| 30-row repeated-profile delta, no avatar | 1.154 / 1.146 | 0.585 / 0.523 |
| Same delta, 512 KiB avatar | 2.156 / 2.129 | 0.607 / 0.611 |
| CLI exact identities, 300 local + 300 imported rows through display/UI | 17.192 / 18.423 | 10.091 / 10.864 |
| CLI image matches, 300 + 300 rows through display/UI | 18.964 / 17.952 | 11.674 / 11.128 |
| Fresh decoded entry, 4 KiB prompt fields, warm handle | 0.064 / 0.064 | 0.057 / 0.060 |
| Target lookup, 128 KiB prompt fields | 0.248 / 0.280 | 0.118 / 0.117 |
| SQLite companion reader, mixed 300-row short-text fixture | 0.978 / 0.963 | 0.715 / 0.730 |
| Complete first-ask preparation, mixed 300-row long-text fixture | 26.367 / 26.631 | 9.334 / 9.440 |

These measure complete local owners with real SQLite, not Gateway RPC, browser paint, cold startup, or provider latency. First-ask timing substitutes only the existing model-selection/run seams. Large avatar/text fixtures are scaling controls. No ablation gains are multiplied and no per-variant memory claim is made. The unweighted matrix has 122 rows faster in both orders, 18 slower, and 53 mixed; that is not a production traffic average or a statistical-significance claim.

Costs remain visible: the no-avatar 30-row fresh-profile history/UI path is +2.3%/+3.4%; the 30-row image merge alone is +2.3%/+1.0%, while its full display/UI composition improves 29–41%; empty companion first-ask is +4.8%/+1.6%. The retained 128 KiB full-store control is +10.8%/+10.8% (32/30 µs). The large default-list-copy control is mixed, −8.1%/+57.5% (−14/+56 µs), and ordinary 30-row UI composition is −0.5%/+9.0%. Required borrowed/cached copies remain. No cost is attributed to GC, JIT, the SQL correction or another cause without evidence.

Every row slower in both orders is retained here; positive percentages mean slower. Both signs for all other rows remain in local raw evidence.

| Workload | Change F / R |
| --- | ---: |
| `profile-null-false-1/full-row-control` | +1.00% / +1.20% |
| `profile-null-false-30/fresh-profile-readonly/sqlite-history-ui` | +2.25% / +3.43% |
| `profile-null-true-1/warm-handle/delta` | +7.85% / +0.85% |
| `profile-32768-false-1/full-row-control` | +1.37% / +3.81% |
| `profile-524288-false-1/fresh-profile-readonly/delta` | +3.32% / +11.10% |
| `profile-524288-false-30/warm-handle/sqlite-history-ui` | +0.81% / +0.07% |
| `profile-524288-true-30/fresh-profile-readonly/sqlite-history-ui` | +1.40% / +0.56% |
| `plain-0/warm-handle/delta` | +2.09% / +1.62% |
| `plain-1/fresh-profile-readonly/delta` | +3.58% / +3.72% |
| `plain-30/fresh-profile-readonly/delta` | +3.93% / +0.91% |
| `CLI-image-forward-1/merge` | +0.33% / +3.57% |
| `CLI-image-forward-30/merge` | +2.28% / +1.02% |
| `full-store-control-131072` | +10.82% / +10.79% |
| `companion-reader-user-30x32` | +0.41% / +0.32% |
| `companion-reader-mixed-30x2000` | +2.40% / +3.47% |
| `companion-reader-sparse-128x2000` | +0.22% / +1.92% |
| `companion-reader-user-0x32` | +1.87% / +6.60% |
| `first-ask-user-0x32` | +4.84% / +1.62% |

The first historical timing attempt failed its output precondition because missing fixture timestamps used the UI wall clock. The failed receipt remains; fixtures now have explicit positive timestamps. No clock mock or weaker equality was used in the final runs.

Live verification at `37f216f95a49a87765e5b5eeb6e8945a26477a04` passed against the actual build: five real OpenAI turns, two web fetches, 107 assertions, and 35 successful proof RPCs. Full and cursor `chat.history`/`chat.startup` responses remained consistent across two canonical avatar writes from another process, and authenticated avatar HTTP reads returned the exact new bytes/ETags. Stored transcript rows stayed byte-identical. Two real companion asks correctly used the selected session and recalled the preceding companion question. The real Claude loader/parser/merge processed a synthetic native-format file; this is not a claim that a native CLI process ran. A fresh connection also recovered history during an actual web tool call, with session/status/anchor checks preserved. The task Gateway stopped cleanly; its process group is confirmed dead and both Node CPU profiles are retained.

The first live companion attempt correctly rejected the task fixture's disjoint tool allowlists before calling the provider. A separate task-only launcher added the two session-read tools already permitted by the companion; read/exec/write remain unavailable. The entire live helper then passed. The original failure and profiles are retained; no product guard or operator configuration changed.

The latest ClawSweeper source review found no introduced defect and asked for exact-head CI completion. Its serialized-state heuristic is addressed by the unchanged storage/schema/write formats, retained write-owned copies, existing upgrade/reader tests, and byte-identical stored transcript checks; this read-only refactor requires no migration. The user-authorized maintainer review is complete. Exact-head CI remains the landing gate.
