### PR TITLE
feat(process): show timeout causes in list

### DIFF
--- a/src/agents/bash-tools.process.poll-timeout.test.ts
+++ b/src/agents/bash-tools.process.poll-timeout.test.ts
@@ -860,7 +860,7 @@ test.each([
     timedOut: false,
   },
 ] as const)(
-  "process log and poll preserve authoritative $name without log consuming the completion",
+  "process list, log, and poll preserve authoritative $name without consuming the completion",
   async ({ name, exitCode, exitSignal, status, exitReason, timedOut, ...optional }) => {
     const sessionId = `sess-terminal-${name.replaceAll(" ", "-")}`;
     const { processTool, session } = createProcessSessionHarness(sessionId);
@@ -869,6 +869,22 @@ test.each([
     appendOutput(session, "stderr", "terminal output\n");
     markExited(session, exitCode, exitSignal, status, exitReason, optional.noOutputTimedOut);
     recordNotifyOnExitRemoval(session, remove);
+
+    const list = await processTool.execute("toolcall-terminal-list", { action: "list" });
+    const listedSessions = (list.details as { sessions?: Array<{ sessionId?: string }> }).sessions;
+    const listed = listedSessions?.find((candidate) => candidate.sessionId === sessionId);
+    expect(listed).toMatchObject({
+      status,
+      sessionId,
+      exitCode: exitCode ?? undefined,
+      exitReason,
+      timedOut,
+      ...optional,
+    });
+    const listText = list.content[0]?.type === "text" ? list.content[0].text : "";
+    expect(listText).toContain(sessionId);
+    expect(listText.includes(`[${exitReason}]`)).toBe(timedOut);
+    expect(remove).not.toHaveBeenCalled();
 
     const log = await processTool.execute("toolcall-terminal-log", {
       action: "log",

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -350,9 +350,9 @@ export function createProcessTool(
               },
               s.endedAt !== undefined
                 ? {
+                    ...finishedSessionDetails(s.id, s),
+                    status: s.terminalStatus ?? "running",
                     endedAt: s.endedAt,
-                    exitCode: s.exitCode ?? undefined,
-                    exitSignal: s.exitSignal ?? undefined,
                   }
                 : Object.assign(
                     { pid: s.pid ?? undefined },
@@ -362,10 +362,16 @@ export function createProcessTool(
           );
         const lines = sessions.map((s) => {
           const label = s.name ? truncateMiddle(s.name, 80) : truncateMiddle(s.command, 120);
+          const timeoutReason =
+            "exitReason" in s &&
+            (s.exitReason === "overall-timeout" || s.exitReason === "no-output-timeout")
+              ? s.exitReason
+              : undefined;
+          const timeoutMarker = timeoutReason ? ` [${timeoutReason}]` : "";
           const marker = "waitingForInput" in s && s.waitingForInput ? " [input-wait]" : "";
           return `${s.sessionId} ${padProcessStatus(s.status, 9)} ${
             formatDurationCompact(s.runtimeMs) ?? "n/a"
-          }${marker} :: ${label}`;
+          }${timeoutMarker}${marker} :: ${label}`;
         });
         return textResult(lines.join("\n") || "No running or recent sessions.", {
           status: "completed",


### PR DESCRIPTION
## What Problem This Solves

`process list` loses the canonical termination reason for finished background commands. A timed-out command is rendered as a generic failed/signal result, even though the process registry retains the reason and `process poll` already exposes it.

Closes #133314.

## Why This Change Was Made

The process registry is already the owner of `exitReason` and `noOutputTimedOut`, and the existing `finishedSessionDetails` helper is already the canonical projection used by poll. The list path was rebuilding a smaller terminal result instead of reusing that helper.

This change reuses the existing owner-level projection and adds a timeout marker to the model-visible list row. It does not add a new tool action, schema, config option, timeout policy, or persistence path.

There was no human maintainer confirmation before implementation. The implementation follows the bounded I1-Fast issue and the merged P2 precedent in #89104, which established the same canonical timeout fields for foreground and poll results.

## User Impact

Agents can scan multiple background jobs and immediately distinguish:

- overall timeout
- no-output timeout
- ordinary non-zero exit
- successful exit
- manual cancellation

This avoids polling every failed session individually before deciding whether to retry or investigate the command.

## Evidence

### Current behavior / acceptance-red

At exact base `f46f9b5aa39feaec7eda5d9d480972566b6aabf5`, a production `ProcessSession` completed through `addSession` and `markExited(..., "overall-timeout", false)` produced:

```text
process list: proof-overall-timeout failed 52ms :: sleep 2
```

Its list details omitted `exitReason`, `timedOut`, and `noOutputTimedOut`, while `process poll` for the same session returned:

```json
{
  "exitReason": "overall-timeout",
  "timedOut": true,
  "noOutputTimedOut": false
}
```

### Fixed behavior / real readback

At exact head `93d0ba9554814f2fb4b36cef690eaadbad718f00`, the same production registry + process-tool readback returns:

```text
process list: proof-overall-timeout failed 51ms [overall-timeout] :: sleep 2
```

The list details now contain the same `exitReason`, `timedOut`, and `noOutputTimedOut` values as poll. The terminal-state matrix also proves normal non-zero exits and manual cancellation are not labeled as timeouts, and that list does not consume the completion receipt.

### Tests

```text
npx --yes node@24.15.0 scripts/run-vitest.mjs src/agents/bash-tools.process.poll-timeout.test.ts
Test Files  1 passed (1)
Tests       39 passed (39)
```

```text
.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --no-web-search
autoreview scoped-clean: no accepted/actionable findings
overall: patch is correct (0.99)
```

`git diff --check` also passes.

### Existing-solutions preflight

No external tool or new OpenClaw surface is needed. The canonical state and projection helper already exist; the fix makes the list caller reuse them. No viable open issue/PR was found for this exact list projection.

### Scope and LOC

- Production: `+9 / -3` in `src/agents/bash-tools.process.ts`
- Tests: `+17 / -1` in `src/agents/bash-tools.process.poll-timeout.test.ts`
- Total: 2 files

### Compatibility, configuration, protocol, and security

- Configuration/defaults: unchanged
- Tool schema/protocol: unchanged
- Storage/migrations: unchanged
- Permissions/security policy: unchanged
- Execution, timeout, cancellation, and retention behavior: unchanged

### Known limitations

This PR only exposes facts already retained for finished sessions. It does not change how or when commands time out, and it does not redesign process-list pagination or retention.

AI assistance was used for code exploration, implementation, adversarial review, and validation. The final patch was checked against the repository instructions, focused tests, exact-head proof, and a fresh structured autoreview.
