### PR TITLE
fix: apply formatting-only file edits

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -97,6 +97,12 @@ semantics, use [Tools and custom providers](/gateway/config-tools).
 | Media                   | Analyze, generate, or speak media                                                            | `view_image`, `image_generate`, `music_generate`, `video_generate`, `tts`                                           | [Media overview](/tools/media-overview)                                                                                |
 | Large OpenClaw catalogs | Search, call, and combine many eligible tools without sending every schema to the model      | `exec`, `wait`, `tool_search_code`, `tool_search`, `tool_describe`                                                  | [Code Mode](/tools/code-mode), [Tool Search](/tools/tool-search)                                                       |
 
+The `edit` tool supports targeted formatting changes, including removing trailing
+spaces or replacing Unicode quotes, dashes, and spaces. These changes are applied
+even when the old and new text would compare equal after fuzzy normalization.
+Identical replacement requests and edits that produce unchanged content still
+report no changes.
+
 <Note>
 Code Mode and Tool Search are experimental OpenClaw agent surfaces. Codex
 harness runs use Codex-native code mode, native tool search, deferred dynamic

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -696,8 +696,7 @@ export function splitNoOpEdits(
   const noOpEdits: Edit[] = [];
   const realEdits: Edit[] = [];
   for (const edit of edits) {
-    const fuzzyNoOp = normalizeForFuzzyMatch(edit.oldText) === normalizeForFuzzyMatch(edit.newText);
-    if (edit.oldText === edit.newText || fuzzyNoOp) {
+    if (edit.oldText === edit.newText) {
       applyEditsToNormalizedContent(
         normalizedContent,
         [{ oldText: edit.oldText, newText: "" }],

--- a/src/agents/sessions/tools/edit-formatting.test.ts
+++ b/src/agents/sessions/tools/edit-formatting.test.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { applyPatch } from "diff";
+import { afterEach, beforeEach, expect, it } from "vitest";
+import { computeEditsDiff } from "./edit-diff.js";
+import { createEditTool } from "./edit.js";
+import type { EditToolDetails } from "./tool-contracts.js";
+
+let tmpDir = "";
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-edit-formatting-"));
+});
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+it.each([
+  { name: "trailing spaces", oldText: "alpha  ", newText: "alpha" },
+  { name: "smart quotes", oldText: "say “hello”", newText: 'say "hello"' },
+  { name: "Unicode dash", oldText: "first—last", newText: "first-last" },
+  { name: "non-breaking space", oldText: "first\u00a0last", newText: "first last" },
+  { name: "compatibility characters", oldText: "count: ３", newText: "count: 3" },
+])("applies exact $name replacements in execution and preview", async ({ oldText, newText }) => {
+  const original = `${oldText}\nkeep  \n`;
+  const expected = `${newText}\nkeep  \n`;
+  const filePath = path.join(tmpDir, "example.txt");
+  await fs.writeFile(filePath, original);
+  const edits = [{ oldText, newText }];
+
+  const preview = await computeEditsDiff(filePath, edits, tmpDir);
+  const result = await createEditTool(tmpDir).execute(
+    "formatting",
+    { path: filePath, edits },
+    undefined,
+  );
+
+  expect(result.terminate).not.toBe(true);
+  await expect(fs.readFile(filePath, "utf8")).resolves.toBe(expected);
+  const details = result.details as EditToolDetails;
+  expect(details.changed).toBe(true);
+  if (!details.changed) {
+    throw new Error("Expected a formatting edit to change the file.");
+  }
+  expect(applyPatch(original, details.patch)).toBe(expected);
+  expect(preview).toEqual({ diff: details.diff, firstChangedLine: details.firstChangedLine });
+});
+
+it("preserves a disjoint change beside an actual fuzzy net no-op", async () => {
+  const original = "alpha\nbeta\n";
+  const expected = "alpha\nBETA\n";
+  const filePath = path.join(tmpDir, "example.txt");
+  await fs.writeFile(filePath, original);
+  const edits = [
+    { oldText: "alpha \n", newText: "alpha\n" },
+    { oldText: "beta", newText: "BETA" },
+  ];
+
+  const preview = await computeEditsDiff(filePath, edits, tmpDir);
+  const result = await createEditTool(tmpDir).execute(
+    "mixed",
+    { path: filePath, edits },
+    undefined,
+  );
+
+  expect(result.terminate).not.toBe(true);
+  await expect(fs.readFile(filePath, "utf8")).resolves.toBe(expected);
+  const details = result.details as EditToolDetails;
+  expect(details.changed).toBe(true);
+  if (!details.changed) {
+    throw new Error("Expected the disjoint replacement to change the file.");
+  }
+  expect(applyPatch(original, details.patch)).toBe(expected);
+  expect(preview).toEqual({ diff: details.diff, firstChangedLine: details.firstChangedLine });
+});
+
+it.each([
+  { name: "empty replacement list", edits: [], error: "at least one replacement" },
+  {
+    name: "empty old text",
+    edits: [{ oldText: "", newText: "" }],
+    error: "oldText must not be empty",
+  },
+])("rejects $name without changing the file", async ({ edits, error }) => {
+  const filePath = path.join(tmpDir, "example.txt");
+  await fs.writeFile(filePath, "original\n");
+  await expect(
+    createEditTool(tmpDir).execute("invalid", { path: filePath, edits }, undefined),
+  ).rejects.toThrow(error);
+  await expect(fs.readFile(filePath, "utf8")).resolves.toBe("original\n");
+});

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -723,7 +723,7 @@ describe("edit tool", () => {
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("bazbar\n");
   });
 
-  it("preserves unrelated whitespace beside a fuzzy-equivalent no-op", async () => {
+  it("applies exact formatting beside a disjoint content replacement", async () => {
     const filePath = await createTempFile("foo  \nkeep  \n");
     const tool = createEditTool(tmpDir);
 
@@ -739,7 +739,7 @@ describe("edit tool", () => {
       undefined,
     );
 
-    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("foo  \nchanged  \n");
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("foo\nchanged  \n");
   });
 
   it("rejects duplicate no-op entries", async () => {


### PR DESCRIPTION
Closes #133319

Related: #97044 (no-op file mutations).

## What Problem This Solves

Fixes an issue where exact file edits that only changed formatting were discarded as no-ops. Removing trailing spaces, converting smart quotes or dashes to ASCII, and replacing non-breaking spaces or compatibility characters could leave the file unchanged and return a terminal no-change result. In a batch containing another content change, only that other change applied; the preview also omitted the formatting edit.

## Why This Change Was Made

Fuzzy normalization belongs to finding the source span, not deciding whether the requested replacement changes it. The shared edit/preview owner now retains only explicit identical-request filtering and lets the existing applied-content comparison detect actual net no-ops. Matching, Unicode span mapping, overlap validation, line-ending preservation, filesystem operations and terminal-result policy are unchanged.

Production delta: **+1/−2 (net −1)**. Tests: +93/−2; docs: +6.

## User Impact

Formatting-only replacements now apply and appear in the preview and returned patch, including alongside disjoint content edits. Untouched bytes remain intact. Identical requests and replacements whose actual result is already present still report no changes.

## Evidence

Reviewed head: `35d45829e99265ad283cd22ec0207bb20234914f` (four files; normal commit hooks preserved the tested source bytes).

The actual built-in `createEditTool` ran against temporary local files using its default filesystem operations, with `computeEditsDiff` for preview. On the frozen baseline, four cases failed semantically and two controls passed; after the one-line simplification, all six produced the expected file contents and result/preview behavior. Both runs used Node 24.20.0, verified repository source before evaluation, hashed all 894 imported files before/after, and cleaned their temporary state.

| Scenario | Before | After |
| --- | --- | --- |
| Remove exact trailing spaces | Unchanged file; terminal no-op | Requested spaces removed; sibling whitespace retained |
| Smart quotes to ASCII | Unchanged file; terminal no-op | ASCII quotes written and shown in preview |
| Non-breaking space to ordinary space | Unchanged file; terminal no-op | Ordinary space written and shown in preview |
| Formatting plus disjoint content replacement | Only content replacement applied | Both replacements applied |
| Identical request | Terminal no-op, unchanged | Unchanged |
| Fuzzy request with result already present | Terminal no-op, unchanged | Unchanged |

```json
{"proof":"actual-local-file-edit-and-preview","before":{"semantic_failures":4,"controls_passed":2},"after":{"cases_passed":6,"cases_failed":0},"temporary_state_removed":true,"source_and_dependency_bytes_bound":true,"provider_or_channel_claim":false}
```

Regression command:

```text
node scripts/run-vitest.mjs run src/agents/sessions/tools/edit.test.ts src/agents/sessions/tools/edit-formatting.test.ts src/agents/sessions/tools/edit-diff.test.ts --maxWorkers=1
```

Before: **6 intended failures, 74 passing tests**. After: **80/80 passing**. Coverage includes exact formatting classes, mixed replacements, real no-ops, empty input, missing targets, duplicates/overlap, Unicode span boundaries, UTF-8/BOM and CR/LF/CRLF preservation. Final formatting only wrapped three test expressions; hashes and the mechanical delta were independently verified.

Mandatory isolated autoreview, independent full-priority source/behavior review and a separate read-only Codex review of the exact committed head found no actionable findings. The canonical four-path `check-changed` gate passed without skips, including core/test type checks, lint, boundary guards and unused-export checks; the reviewed file hashes were unchanged. This proves local tool execution and preview; no model, Gateway or channel roundtrip is claimed. The separate no-op terminal-presentation issue #128385 is unchanged.

Hosted validation: [CI run 33316779400](https://github.com/openclaw/openclaw/actions/runs/33316779400) passed on the exact reviewed head above. The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/133320#issuecomment-5469291275) found no actionable correctness or security issues and accepted the canonical owner fix. Its pending-CI item is satisfied; no additional rank-up moves were listed.
