### PR TITLE
test: preserve Vitest project ownership for CLI filters

### DIFF
--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -1,12 +1,12 @@
 // Session usage tests cover aggregate cost/token usage across configured and
 // discovered agent session logs.
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withEnvAsync } from "../../test-utils/env.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 
 vi.mock("../../config/config.js", () => {
   return {
@@ -225,22 +225,15 @@ function mockStoredSession(
 async function withUsageState(
   run: (writeSessionFile: (fileName: string) => string) => Promise<void>,
 ) {
-  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-usage-test-"));
-  const agentSessionsDir = path.join(stateDir, "agents", "opus", "sessions");
-  const writeSessionFile = (fileName: string) => {
-    const sessionFile = path.join(agentSessionsDir, fileName);
-    fs.writeFileSync(sessionFile, "", "utf-8");
-    return sessionFile;
-  };
-
-  try {
-    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
-      fs.mkdirSync(agentSessionsDir, { recursive: true });
-      await run(writeSessionFile);
+  await withOpenClawTestState({ label: "usage" }, async (state) => {
+    const agentSessionsDir = state.sessionsDir("opus");
+    fs.mkdirSync(agentSessionsDir, { recursive: true });
+    await run((fileName) => {
+      const sessionFile = path.join(agentSessionsDir, fileName);
+      fs.writeFileSync(sessionFile, "", "utf-8");
+      return sessionFile;
     });
-  } finally {
-    fs.rmSync(stateDir, { recursive: true, force: true });
-  }
+  });
 }
 
 describe("sessions.usage", () => {
@@ -941,35 +934,38 @@ describe("sessions.usage", () => {
   });
 
   it("loads bare-key usage details through the persisted fixed-store owner", async () => {
-    const config: OpenClawConfig = {
-      session: { store: "/tmp/shared-sessions.sqlite", scope: "global" },
-      agents: {
-        ownership: "explicit",
-        list: [{ id: "ops" }, { id: "research" }],
-        defaults: { sessionStore: { agentId: "ops" } },
-      },
-    };
-    const entry = { sessionId: "s-ops", updatedAt: 1_000 };
-    vi.mocked(loadGatewaySessionEntryReadOnly).mockReturnValueOnce({
-      cfg: config,
-      agentId: "ops",
-      canonicalKey: "global",
-      entry,
-      legacyKey: undefined,
-      store: { global: entry },
-      storeKeys: ["global"],
-      storePath: "/tmp/shared-sessions.sqlite",
-    });
+    await withOpenClawTestState({ label: "usage-fixed-store-owner" }, async (state) => {
+      const storePath = state.statePath("shared-sessions.sqlite");
+      const config: OpenClawConfig = {
+        session: { store: storePath, scope: "global" },
+        agents: {
+          ownership: "explicit",
+          list: [{ id: "ops" }, { id: "research" }],
+          defaults: { sessionStore: { agentId: "ops" } },
+        },
+      };
+      const entry = { sessionId: "s-ops", updatedAt: 1_000 };
+      vi.mocked(loadGatewaySessionEntryReadOnly).mockReturnValueOnce({
+        cfg: config,
+        agentId: "ops",
+        canonicalKey: "global",
+        entry,
+        legacyKey: undefined,
+        store: { global: entry },
+        storeKeys: ["global"],
+        storePath,
+      });
 
-    const respond = await runSessionsUsageTimeseries({ key: "global" }, config);
+      const respond = await runSessionsUsageTimeseries({ key: "global" }, config);
 
-    expect(mockArg(respond, 0, 0)).toBe(true);
-    expect(vi.mocked(loadGatewaySessionEntryReadOnly)).toHaveBeenCalledWith("global", {
-      agentId: "ops",
+      expect(mockArg(respond, 0, 0)).toBe(true);
+      expect(vi.mocked(loadGatewaySessionEntryReadOnly)).toHaveBeenCalledWith("global", {
+        agentId: "ops",
+      });
+      expect(vi.mocked(loadSessionUsageTimeSeries)).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: "ops" }),
+      );
     });
-    expect(vi.mocked(loadSessionUsageTimeSeries)).toHaveBeenCalledWith(
-      expect.objectContaining({ agentId: "ops" }),
-    );
   });
 
   it("preserves JSONL detail lookup for storeless sessions", async () => {

--- a/test/non-isolated-runner.test.ts
+++ b/test/non-isolated-runner.test.ts
@@ -98,6 +98,9 @@ function fixtureFiles(): Record<string, string> {
     path.join(repoRoot, "src", "infra", "agent-run-registry.ts"),
   );
   const agentEventsPath = JSON.stringify(path.join(repoRoot, "src", "infra", "agent-events.ts"));
+  const activeSessionsPath = JSON.stringify(
+    path.join(repoRoot, "src", "gateway", "active-sessions-shutdown-tracker.ts"),
+  );
   const loggingConsolePath = JSON.stringify(path.join(repoRoot, "src", "logging", "console.ts"));
   const loggingStatePath = JSON.stringify(path.join(repoRoot, "src", "logging", "state.ts"));
   const testEnvPath = JSON.stringify(path.join(repoRoot, "src", "test-utils", "env.ts"));
@@ -210,8 +213,11 @@ function fixtureFiles(): Record<string, string> {
     "05-a-agent-run.test.ts": [
       `import { getAgentRunContext, registerAgentRunContext } from ${agentRunRegistryPath};`,
       `import { emitAgentEvent, onAgentEvent } from ${agentEventsPath};`,
+      `import { listActiveSessionsForShutdown, noteActiveSessionForShutdown } from ${activeSessionsPath};`,
       'import { expect, it } from "vitest";',
       'it("seeds process-global run contexts", () => {',
+      '  noteActiveSessionForShutdown({ cfg: {}, sessionKey: "session-a", sessionId: "session-a", storePath: "/tmp/fixture.sqlite", agentId: "main" });',
+      "  expect(listActiveSessionsForShutdown()).toHaveLength(1);",
       '  registerAgentRunContext("unrelated-run-a", { sessionKey: "session-a" });',
       '  registerAgentRunContext("unrelated-run-b", { sessionKey: "session-b" });',
       '  registerAgentRunContext("reused-run", { sessionKey: "reused-session" });',
@@ -228,8 +234,10 @@ function fixtureFiles(): Record<string, string> {
     "05-b-agent-run.test.ts": [
       `import { clearAgentRunContext, getAgentRunContext, registerAgentRunContext, sweepStaleRunContexts } from ${agentRunRegistryPath};`,
       `import { emitAgentEvent, onAgentEvent } from ${agentEventsPath};`,
+      `import { listActiveSessionsForShutdown } from ${activeSessionsPath};`,
       'import { expect, it } from "vitest";',
       'it("clears agent run registry state", () => {',
+      "  expect(listActiveSessionsForShutdown()).toEqual([]);",
       '  registerAgentRunContext("reused-run", { sessionKey: "reused-session" });',
       "  let sequence;",
       "  const unsubscribe = onAgentEvent((event) => { sequence = event.seq; });",

--- a/test/non-isolated-runner.ts
+++ b/test/non-isolated-runner.ts
@@ -8,6 +8,7 @@ import { TestRunner, type RunnerTask, type RunnerTestFile, vi } from "vitest";
 import { resetAgentEventsForTest } from "../src/infra/agent-events.js";
 import { loggingState } from "../src/logging/state.js";
 import { clearNamedPluginRuntimeStoresForTest } from "../src/plugin-sdk/runtime-store-registry.js";
+import { drainGlobalSingletonLifecycleState } from "../src/shared/global-singleton.js";
 import {
   type CustomElementTracking,
   dropRepoOwnedCustomElements,
@@ -485,6 +486,9 @@ export default class OpenClawNonIsolatedRunner extends TestRunner {
     resetAgentEventsForTest();
     resetOpenClawGlobalDiagnosticState();
     resetOpenClawSessionSuspensionState();
+    // Lifecycle-owned singletons survive module resets; close them before the next file
+    // can observe a previous file's sessions, caches, or registered resources.
+    await drainGlobalSingletonLifecycleState();
     // Named plugin runtimes intentionally survive duplicate module evaluation in production.
     // Clear their shared slots here so one test file cannot lend a partial runtime to the next.
     clearNamedPluginRuntimeStoresForTest();

--- a/test/vitest-cli-ownership.test.ts
+++ b/test/vitest-cli-ownership.test.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import path from "node:path";
+import { assert, expect, it } from "vitest";
+import { createGatewayClientVitestConfig } from "./vitest/vitest.gateway-client.config.ts";
+import { createGatewayCoreVitestConfig } from "./vitest/vitest.gateway-core.config.ts";
+import { createGatewayMethodsIsolatedVitestConfig } from "./vitest/vitest.gateway-methods-isolated.config.ts";
+import { createGatewayMethodsVitestConfig } from "./vitest/vitest.gateway-methods.config.ts";
+import { createGatewayServerIsolatedVitestConfig } from "./vitest/vitest.gateway-server-isolated.config.ts";
+import { createGatewayServerVitestConfig } from "./vitest/vitest.gateway-server.config.ts";
+
+function gatewayProjectFiles(filters: string[]) {
+  const originalArgv = process.argv;
+  process.argv = ["node", "vitest", "run", ...filters];
+  try {
+    return Object.fromEntries<string[]>(
+      [
+        createGatewayCoreVitestConfig,
+        createGatewayClientVitestConfig,
+        createGatewayMethodsVitestConfig,
+        createGatewayMethodsIsolatedVitestConfig,
+        createGatewayServerVitestConfig,
+        createGatewayServerIsolatedVitestConfig,
+      ].map((createConfig) => {
+        const config = createConfig({});
+        const test = config.test!;
+        assert(typeof test.name === "string");
+        const dir = test.dir ?? config.root!;
+        const files = fs
+          .globSync(test.include ?? [], { cwd: dir, exclude: test.exclude })
+          .map((file) => path.relative(config.root!, path.join(dir, file)).replaceAll("\\", "/"))
+          .filter((file) => file.startsWith("src/gateway/"))
+          .filter((file) => selectedByFilters(file, filters))
+          .toSorted();
+        return [test.name, files];
+      }),
+    );
+  } finally {
+    process.argv = originalArgv;
+  }
+}
+
+function selectedByFilters(file: string, filters: string[]): boolean {
+  return (
+    filters.length === 0 ||
+    filters.some((filter) => file === filter || file.startsWith(`${filter}/`))
+  );
+}
+
+it.each(
+  [
+    ["src/gateway"],
+    ["src/gateway/server"],
+    ["src/gateway/server-methods"],
+    ["src/gateway/worker-environments"],
+    ["src/gateway/managed-image-attachments.test.ts"],
+    ["src/gateway/server.sessions.compaction-read-errors.test.ts"],
+    ["src/gateway/server", "src/gateway/worker-environments"],
+  ].map((filters) => ({ filters })),
+)("preserves canonical project ownership for $filters", ({ filters }) => {
+  const canonical = gatewayProjectFiles([]);
+  const expected = Object.fromEntries(
+    Object.entries(canonical).map(([name, files]) => [
+      name,
+      files.filter((file) => selectedByFilters(file, filters)),
+    ]),
+  );
+
+  expect(gatewayProjectFiles(filters)).toEqual(expected);
+  const selected = Object.values(expected).flat();
+  expect(selected.length).toBeGreaterThan(0);
+  expect(new Set(selected).size).toBe(selected.length);
+});

--- a/test/vitest-scoped-config.test.ts
+++ b/test/vitest-scoped-config.test.ts
@@ -249,7 +249,7 @@ describe("createScopedVitestConfig", () => {
       passWithNoTests: true,
     });
 
-    expect(requireTestConfig(config).include).toEqual(["slack/**/*.test.*"]);
+    expect(requireTestConfig(config).include).toEqual(["slack/**/*.test.ts"]);
   });
 
   it("keeps broad package scoped cli directory filters aligned with repo-root include patterns", () => {
@@ -260,7 +260,7 @@ describe("createScopedVitestConfig", () => {
       passWithNoTests: true,
     });
 
-    expect(requireTestConfig(config).include).toEqual(["normalization-core/**/*.test.*"]);
+    expect(requireTestConfig(config).include).toEqual(["**/*.test.ts"]);
   });
 
   it("relativizes scoped include and exclude patterns to the configured dir", () => {

--- a/test/vitest/vitest.pattern-file.ts
+++ b/test/vitest/vitest.pattern-file.ts
@@ -134,20 +134,19 @@ function narrowIncludePatterns(
     return null;
   }
 
-  // Narrowing must intersect the CLI selection with the lane's own scope. When the lane is
-  // rooted deeper than the CLI selection, keep the lane: returning the caller's broader
-  // directory pattern re-admits files the lane never owns — `unit-fast` picks up the stateful
-  // files it excludes, and `contracts-*` picks up every sibling test outside `contracts/`.
-  // Both run `isolate: false`, so those extra files share a worker and pollute unrelated ones.
+  // Vitest applies CLI filters after discovery. Prefix overlap cannot prove glob
+  // containment, so retain the owner's patterns unless selecting an owned literal file.
   const narrowed = new Set<string>();
   for (const candidate of candidatePatterns) {
-    const candidatePrefix = literalPrefixForGlobPattern(candidate);
+    const isLiteral = !/[?*[\]{}]/u.test(candidate);
     for (const laneScope of includePatterns) {
-      if (!patternsCouldOverlap(candidate, laneScope)) {
-        continue;
+      if (isLiteral) {
+        if (path.matchesGlob(candidate, laneScope)) {
+          narrowed.add(candidate);
+        }
+      } else if (patternsCouldOverlap(candidate, laneScope)) {
+        narrowed.add(laneScope);
       }
-      const laneScopePrefix = literalPrefixForGlobPattern(laneScope);
-      narrowed.add(laneScopePrefix.length > candidatePrefix.length ? laneScope : candidate);
     }
   }
   return [...narrowed];


### PR DESCRIPTION
## What Problem This Solves

A directory-filtered Vitest run assigned test files to projects that do not own
them. `src/gateway/managed-image-attachments.test.ts` ran **twice** — 111 tests
under `gateway-core` and 111 again under `gateway-server` — and two assertions
failed only in the copy that ran under the wrong project.

The same file run by name executes once, under `gateway-core`, and passes. The
`gateway-server` project's own config does not include it at all (64 files, 1169
tests, zero occurrences). Only the directory filter mislaid it.

Ownership is lost in `narrowIncludePatterns`:

    narrowed.add(laneScopePrefix.length > candidatePrefix.length ? laneScope : candidate);

For `src/gateway` the normalized CLI candidate is `src/gateway/**/*.test.*`. Its
literal prefix and the server owner's `src/gateway/**/*server*.test.ts` prefix are
both `src/gateway/`, so the equal-length case takes the `: candidate` branch,
substitutes the broad CLI glob, and **drops the `*server*` filename constraint**.
Prefix overlap cannot prove glob containment.

This is not cosmetic. `gateway-server` runs `isolate: false` with
`fileParallelism: false`, so mislaid files join a shared module graph across dozens
of neighbours. An inventory across all 81 root project configs measured the damage:
a directory filter inflated gateway file/project assignments from **954 to 1,914**.
`gateway-server` went from 256 files to 741; `gateway-client` from 17 to 492.

## Why This Change Was Made

Vitest applies CLI filters *after* discovery (`cli-api` filter stage in the
installed Vitest 4.1.11). So the resolver does not need to narrow a glob candidate
at all — it only needs to stop widening an owner. The repair keeps the owner's own
patterns for glob/directory candidates, and admits a literal candidate only when it
actually matches an owning include. Vitest's final filename filter still prevents
extra discovered paths from executing. That is preferable to inventing a second
glob-intersection engine.

The prior code was already trying to solve this: its comment explains that
returning the caller's broader directory pattern "re-admits files the lane never
owns — `unit-fast` picks up the stateful files it excludes". The new form is
strictly more conservative and preserves that protection, because it never
substitutes the caller's pattern for the owner's.

Two shared-state defects surfaced while proving the fix, and both are repaired at
their owner rather than in the consumer test:

- The active-session shutdown tracker survived file boundaries through a
  lifecycle-owned global `Map`. The non-isolated runner reset evaluated modules but
  never drained the registered singleton lifecycle; it now calls the existing
  `drainGlobalSingletonLifecycleState()` at file completion, before resetting
  modules.
- `src/gateway/server-methods/usage.sessions-usage.test.ts` hardcoded
  `/tmp/shared-sessions.sqlite` while requesting agent `ops`, colliding with a
  pre-existing shared database owned by `main`. It now uses the existing
  `withOpenClawTestState` lifecycle for a unique store, retaining the real resolver
  and every assertion.

## User Impact

None at runtime. Production LOC is unchanged (+0/-0); all six changed files are
test or test-infrastructure. Maintainers get correct project ownership, roughly
half the duplicated work on directory-filtered runs, and two fewer order-dependent
failures.

## Evidence

Ownership, measured against unfiltered configs:

| | Canonical | With directory filter (before) | After |
| --- | ---: | ---: | ---: |
| gateway-server | 256 | 741 | 256 |
| gateway-client | 17 | 492 | 17 |
| Total gateway assignments | 954 | 1,914 | 954 |

Post-fix inventory: **zero wrong owners, no lost canonical memberships.**

    node scripts/run-vitest.mjs src/gateway
      before: managed-image-attachments ran under gateway-core AND gateway-server,
              2 failures in the gateway-server copy
      after:  runs under gateway-core only, 111/111

    node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway-server.config.ts
      256 files, 3,909 passing, exit 0, zero managed-image occurrences

    focused: vitest-cli-ownership + vitest-scoped-config + non-isolated-runner
             + usage.sessions-usage                       133 passing, exit 0

The new seven-case ownership regression fails in five cases on pre-fix code and
passes after. The runner boundary regression fails before the drain edit (the
observer inherited the producer's session record) and passes after. A fresh Codex
autoreview reported exit 0, scoped-clean, with no findings.

**Known-unrelated local gate noise, stated rather than hidden.** `check-changed`
exits 1 here on `lint core`, reporting four `eslint(preserve-caught-error)` errors
in `src/commands/models/auth.ts` and `src/plugins/provider-auth-persistence.ts` —
files this PR does not touch. Those call sites pass `{ cause }` as
`AggregateError`'s third argument, which is correct. The installed Oxlint is
**1.78.0** while this repo pins **1.79.0**, and 1.78.0 reads the options bag from
argument two, so it cannot see the cause. The shared `node_modules` is a symlink
into another checkout in active use, so it was deliberately not reinstalled. CI
installs the pinned version; its lint result is the authority here.

**Not claimed:** the cap-assertion failures were *not* a changed media cap. The cap
comes from plain constants. Instrumentation located a native `RegExp.test`
`RangeError: Maximum call stack size exceeded` at
`src/gateway/managed-image-attachments.ts:676`, before the media-kind and byte-limit
checks, on a 22,369,624-character payload; unexpected parser errors are sanitized to
"could not be prepared". A separable managed-media mock leak is **not proven** — the
shutdown-tracker leak above is proven and is a different defect.
