### PR TITLE
test(zalo): pin the setup wizard locale so prompt assertions are shell-independent

### DIFF
--- a/extensions/zalo/src/setup-surface.test.ts
+++ b/extensions/zalo/src/setup-surface.test.ts
@@ -7,16 +7,20 @@ import {
   runSetupWizardConfigure,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { WizardPrompter } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import { listZaloAccountIds, resolveDefaultZaloAccountId, resolveZaloAccount } from "./accounts.js";
-
-// The wizard resolves prompt copy from the shell locale on every prompt. The
-// asserted prompt text is the English copy, so pin the locale instead of
-// failing on non-English developer shells (wizardT re-reads the env per call).
-process.env.OPENCLAW_LOCALE = "en";
 import { zaloDmPolicy } from "./setup-core.js";
 import { zaloSetupAdapter, zaloSetupWizard } from "./setup-surface.js";
+
+// The wizard resolves prompt copy from the shell locale on every prompt, and
+// the asserted prompt text is the English copy. Stub the locale before each
+// test (wizardT re-reads the env per call) instead of assigning the raw env:
+// this worker is non-isolated, so a direct assignment would leak English into
+// later files and mask their locale-sensitive coverage.
+beforeEach(() => {
+  vi.stubEnv("OPENCLAW_LOCALE", "en");
+});
 
 const zaloSetupPlugin = {
   id: "zalo",

--- a/extensions/zalo/src/setup-surface.test.ts
+++ b/extensions/zalo/src/setup-surface.test.ts
@@ -10,6 +10,11 @@ import type { WizardPrompter } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import { listZaloAccountIds, resolveDefaultZaloAccountId, resolveZaloAccount } from "./accounts.js";
+
+// The wizard resolves prompt copy from the shell locale on every prompt. The
+// asserted prompt text is the English copy, so pin the locale instead of
+// failing on non-English developer shells (wizardT re-reads the env per call).
+process.env.OPENCLAW_LOCALE = "en";
 import { zaloDmPolicy } from "./setup-core.js";
 import { zaloSetupAdapter, zaloSetupWizard } from "./setup-surface.js";
 


### PR DESCRIPTION
## What Problem This Solves

The Zalo setup-surface suite fails on any non-English developer shell. `wizardT` resolves prompt copy from `OPENCLAW_LOCALE` / `LC_ALL` / `LC_MESSAGES` / `LANG` **on every prompt** (`src/wizard/i18n/index.ts`), and the test asserts the English copy verbatim:

```
Error: Unexpected prompt: 输入 Zalo bot token
❯ extensions/zalo/src/setup-surface.test.ts:47
```

On a `zh_CN.UTF-8` shell the wizard prompts `输入 Zalo bot token`, the English assertion never matches, and the suite reports a false failure with no product defect behind it.

## Why This Change Was Made

The suite's assertions are written against the English copy, so the suite depends on the English locale. Pinning the locale in the test file states that dependency explicitly instead of leaving it to the contributor's shell environment. No production code changes.

## User Impact

None for the product. Contributors running tests on non-English shells get a stable suite instead of a false failure.

## Evidence

On the same checkout, before the fix (shell `zh_CN.UTF-8`):

```
FAIL extensions/zalo/src/setup-surface.test.ts > zalo setup wizard > configures a polling token flow
Error: Unexpected prompt: 输入 Zalo bot token
Tests  1 failed | 5 passed (6)
```

After the fix, same shell, no env override:

```
Tests  6 passed (6)
```

Full `extensions/zalo` suite with the pin in place: 176 passed (0 failed). Production LOC delta: none (tests only, +5).


## ClawSweeper follow-up

Addressed the P2 finding ("Scope and restore the locale override"): the file-level raw `process.env.OPENCLAW_LOCALE = "en"` assignment is replaced with a per-test `vi.stubEnv("OPENCLAW_LOCALE", "en")` in `beforeEach`. The non-isolated runner restores env through `vi.unstubAllEnvs()` after every file (`test/non-isolated-runner.ts`), which cannot see a raw `process.env` assignment — so the pin would have leaked English into later files of the same worker and masked their locale-sensitive coverage. The stub path is the one the runner's own cross-file env pair (`test/non-isolated-runner.test.ts`, "seeds gateway helper env" / "restores gateway helper env") already owns.

Re-verified on the fixed head: full `extensions/zalo` suite green under a `zh_CN.UTF-8` shell (`Tests 6 passed (6)`), no raw locale pin left behind. Production LOC delta: none (tests only).
