### PR TITLE
fix(telegram): inline button presses go unacknowledged during long turns

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -825,7 +825,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     Webhook mode validates request guards, the Telegram secret token, and the JSON body, then commits the update to its durable ingress queue before returning an empty `200`. Successful durable adoption includes `x-openclaw-delivery-accepted: durable`; health, routing, authentication, validation, and storage-error responses omit this header. Reverse proxies and host controllers can require the header to distinguish OpenClaw adoption from a generic empty `200` without inferring acceptance from response timing.
 
-    After the durable write, OpenClaw claims and processes updates through the core channel-ingress drain (per-chat/per-topic lanes, complete at turn adoption, pre-adoption stall timeout). Slow agent turns do not hold Telegram's delivery ACK.
+    After the durable write, OpenClaw claims and processes updates through the core channel-ingress drain (per-chat/per-topic lanes, complete at turn adoption, pre-adoption stall timeout). Slow agent turns do not hold Telegram's delivery ACK. Inline-button presses are acknowledged (`answerCallbackQuery`) at durable admission — before lane blocking — so a press is confirmed to the user within seconds even while a long turn occupies the same chat's lane; the press itself still processes in lane order once the lane drains.
 
   </Accordion>
 

--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -52,7 +52,10 @@ import type { TelegramUpdateKeyContext } from "./bot-updates.js";
 import { apiThrottler, Bot, sequentialize, type ApiClientOptions } from "./bot.runtime.js";
 import type { TelegramBotOptions } from "./bot.types.js";
 import { buildTelegramGroupPeerId } from "./bot/helpers.js";
-import { setTelegramCallbackQueryAnswerPromise } from "./callback-query-answer-state.js";
+import {
+  getTelegramCallbackQueryAdmissionAck,
+  setTelegramCallbackQueryAnswerPromise,
+} from "./callback-query-answer-state.js";
 import { TELEGRAM_CHAT_ACTION_INTERVAL_MS } from "./chat-action-timing.js";
 import {
   asTelegramClientFetch,
@@ -237,10 +240,16 @@ export function createTelegramBotCore(
   // agent turns for the same chat/topic. Telegram has a ~15s server-side timeout
   // for answerCallbackQuery; if an agent turn is already processing, sequentialize
   // delays the answer beyond that window and the user sees a stuck loading spinner.
+  // Updates admitted through the durable ingress spool were already answered at
+  // admission time (before lane blocking); reuse that acknowledgement so neither
+  // this middleware nor the callback router issues a second bare answer against
+  // an already-answered, possibly expired query.
   bot.use(async (ctx, next) => {
     const callback = ctx.callbackQuery;
     if (callback) {
-      const answerPromise = bot.api.answerCallbackQuery(callback.id);
+      const answerPromise =
+        getTelegramCallbackQueryAdmissionAck(bot, callback.id) ??
+        bot.api.answerCallbackQuery(callback.id);
       setTelegramCallbackQueryAnswerPromise(ctx, answerPromise);
       void answerPromise.catch(() => {});
     }

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -88,6 +88,8 @@ const { resolveTelegramFetch } = await import("./fetch.js");
 const { defaultTelegramNativeCommandDeps } = await import("./bot-native-command-deps.runtime.js");
 const messageDispatchDedupe = await import("./message-dispatch-dedupe.js");
 const { createTelegramBotCore: createTelegramBotBase } = await import("./bot-core.js");
+const { recordTelegramCallbackQueryAdmissionAck } =
+  await import("./callback-query-answer-state.js");
 const { getTelegramSequentialConstraints } = await import("./sequential-key.js");
 const {
   createTelegramSpooledReplayDeferredParticipant,
@@ -816,6 +818,92 @@ describe("createTelegramBot", () => {
 
     expect(replySpy).toHaveBeenCalledTimes(1);
     expect(answerCallbackQuerySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses a recorded admission-time acknowledgement instead of answering again", async () => {
+    installPerKeySequentializer();
+    const bot = createTelegramBot({ token: "tok" });
+    const callbackHandler = requireValue(
+      getOnHandler("callback_query") as
+        | ((ctx: Record<string, unknown>) => Promise<void>)
+        | undefined,
+      "callback_query handler",
+    );
+    // The durable ingress spool answered this press at admission time; the
+    // registry entry is what survives from admission to the drain replay.
+    recordTelegramCallbackQueryAdmissionAck(bot, "cbq-admission-ack-1", Promise.resolve(true));
+    const callbackQueryPayload = {
+      id: "cbq-admission-ack-1",
+      data: "cmd:option_a",
+      from: { id: 9, first_name: "Ada", username: "ada_bot" },
+      message: {
+        chat: { id: 1234, type: "private" },
+        date: 1_736_380_800,
+        message_id: 52,
+      },
+    };
+    const callbackCtx = {
+      update: { update_id: 502, callback_query: callbackQueryPayload },
+      callbackQuery: callbackQueryPayload,
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    };
+
+    await runTelegramMiddlewareChain({
+      ctx: callbackCtx,
+      finalHandler: async (ctx) => {
+        await callbackHandler(ctx);
+      },
+    });
+
+    // No second bare answerCallbackQuery for the already-acknowledged press.
+    expect(answerCallbackQuerySpy).not.toHaveBeenCalled();
+    // The press itself still processes through the serialized callback path.
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-answers live when the admission-time acknowledgement failed", async () => {
+    installPerKeySequentializer();
+    const bot = createTelegramBot({ token: "tok" });
+    const callbackHandler = requireValue(
+      getOnHandler("callback_query") as
+        | ((ctx: Record<string, unknown>) => Promise<void>)
+        | undefined,
+      "callback_query handler",
+    );
+    recordTelegramCallbackQueryAdmissionAck(
+      bot,
+      "cbq-admission-ack-2",
+      Promise.reject(new Error("admission answer failed")),
+    );
+    const callbackQueryPayload = {
+      id: "cbq-admission-ack-2",
+      data: "cmd:option_a",
+      from: { id: 9, first_name: "Ada", username: "ada_bot" },
+      message: {
+        chat: { id: 1234, type: "private" },
+        date: 1_736_380_800,
+        message_id: 53,
+      },
+    };
+    const callbackCtx = {
+      update: { update_id: 503, callback_query: callbackQueryPayload },
+      callbackQuery: callbackQueryPayload,
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    };
+
+    await runTelegramMiddlewareChain({
+      ctx: callbackCtx,
+      finalHandler: async (ctx) => {
+        await callbackHandler(ctx);
+      },
+    });
+
+    // The failed admission acknowledgement falls back to a live answer.
+    expect(answerCallbackQuerySpy).toHaveBeenCalledTimes(1);
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-admission-ack-2");
+    expect(replySpy).toHaveBeenCalledTimes(1);
   });
 
   it("acknowledges question callbacks before their handler completes", async () => {

--- a/extensions/telegram/src/callback-query-answer-state.ts
+++ b/extensions/telegram/src/callback-query-answer-state.ts
@@ -1,6 +1,19 @@
+// Telegram plugin module tracks early callback-query acknowledgements:
+// per-context answer promises for the bot pipeline, and the bot-scoped registry
+// of admission-time acknowledgements issued by the durable ingress spool.
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+
 const TELEGRAM_CALLBACK_QUERY_ANSWER_PROMISE = Symbol.for(
   "openclaw.telegram.callbackQueryAnswerPromise",
 );
+
+const TELEGRAM_CALLBACK_QUERY_ADMISSION_ACKS = Symbol.for(
+  "openclaw.telegram.callbackQueryAdmissionAcks",
+);
+
+// One in-flight/settled acknowledgement promise per press is enough; the cap
+// bounds the registry when a chat spams buttons faster than lanes drain.
+const MAX_TRACKED_ADMISSION_ACKS = 512;
 
 export function setTelegramCallbackQueryAnswerPromise(
   ctx: object,
@@ -15,4 +28,101 @@ export function setTelegramCallbackQueryAnswerPromise(
 export function getTelegramCallbackQueryAnswerPromise(ctx: object): Promise<unknown> | undefined {
   const promise = (ctx as Record<PropertyKey, unknown>)[TELEGRAM_CALLBACK_QUERY_ANSWER_PROMISE];
   return promise instanceof Promise ? promise : undefined;
+}
+
+function getTelegramCallbackQueryAdmissionAckStore(
+  bot: object,
+): Map<string, Promise<unknown>> | undefined {
+  const store = (bot as Record<PropertyKey, unknown>)[TELEGRAM_CALLBACK_QUERY_ADMISSION_ACKS];
+  return store instanceof Map ? store : undefined;
+}
+
+/**
+ * Record the admission-time answerCallbackQuery promise for a callback query on
+ * the bot that owns its durable ingress spool, so the drain-time replay can
+ * reuse the acknowledgement instead of issuing a second bare answer.
+ */
+export function recordTelegramCallbackQueryAdmissionAck(
+  bot: object,
+  callbackQueryId: string,
+  answerPromise: Promise<unknown>,
+): void {
+  let store = getTelegramCallbackQueryAdmissionAckStore(bot);
+  if (!store) {
+    store = new Map<string, Promise<unknown>>();
+    Object.defineProperty(bot, TELEGRAM_CALLBACK_QUERY_ADMISSION_ACKS, {
+      configurable: true,
+      value: store,
+    });
+  }
+  if (store.size >= MAX_TRACKED_ADMISSION_ACKS) {
+    const oldest = store.keys().next().value;
+    if (oldest !== undefined) {
+      store.delete(oldest);
+    }
+  }
+  store.set(callbackQueryId, answerPromise);
+}
+
+/**
+ * Look up the admission-time acknowledgement recorded for a callback query.
+ * Returns undefined after a process restart or registry eviction; callers fall
+ * back to answering live, which fails harmlessly once the query expired.
+ */
+export function getTelegramCallbackQueryAdmissionAck(
+  bot: object,
+  callbackQueryId: string,
+): Promise<unknown> | undefined {
+  return getTelegramCallbackQueryAdmissionAckStore(bot)?.get(callbackQueryId);
+}
+
+function resolveTelegramAdmittedCallbackQueryId(update: unknown): string | undefined {
+  const callbackQueryId = (update as { callback_query?: { id?: unknown } } | null | undefined)
+    ?.callback_query?.id;
+  return typeof callbackQueryId === "string" && callbackQueryId.length > 0
+    ? callbackQueryId
+    : undefined;
+}
+
+/**
+ * Answer a callback query at durable-admission time, before per-chat lane
+ * blocking can delay the acknowledgement past Telegram's ~15s
+ * answerCallbackQuery window. The acknowledgement carries no handler result,
+ * so nothing about the outcome needs to be known to send it; outcome feedback
+ * belongs to the chat surface. Fire-and-forget: a failure here must never fail
+ * the spool write (the drain-time middleware still answers live as a fallback).
+ * A webhook redelivery maps to the same spool row, so an already-acknowledged
+ * query is skipped.
+ */
+export function acknowledgeTelegramAdmittedCallbackQuery(
+  bot: object,
+  update: unknown,
+  params: {
+    answer: (callbackQueryId: string) => Promise<unknown>;
+    isNew: boolean;
+    onLog?: (message: string) => void;
+  },
+): void {
+  try {
+    const callbackQueryId = resolveTelegramAdmittedCallbackQueryId(update);
+    if (!callbackQueryId) {
+      return;
+    }
+    if (!params.isNew && getTelegramCallbackQueryAdmissionAck(bot, callbackQueryId)) {
+      return;
+    }
+    const answerPromise = params.answer(callbackQueryId);
+    recordTelegramCallbackQueryAdmissionAck(bot, callbackQueryId, answerPromise);
+    void answerPromise.catch((error: unknown) => {
+      // The drain-time replay re-answers live when this promise rejects, so this
+      // log records the failure without masking it.
+      params.onLog?.(
+        `telegram: admission answerCallbackQuery failed for callback query ${callbackQueryId}: ${formatErrorMessage(error)}`,
+      );
+    });
+  } catch (error) {
+    params.onLog?.(
+      `telegram: admission answerCallbackQuery setup failed: ${formatErrorMessage(error)}`,
+    );
+  }
 }

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -317,11 +317,13 @@ function makeIsolatedBot(params?: {
   handleUpdate?: (update: { update_id?: number }) => Promise<unknown>;
   init?: AsyncVoidFn;
   stop?: AsyncVoidFn;
+  answerCallbackQuery?: (callbackQueryId: string) => Promise<unknown>;
 }) {
   return {
     api: {
       deleteWebhook: vi.fn(params?.deleteWebhook ?? (async () => true)),
       config: { use: vi.fn() },
+      ...(params?.answerCallbackQuery ? { answerCallbackQuery: params.answerCallbackQuery } : {}),
     },
     init: vi.fn(params?.init ?? (async () => undefined)),
     botInfo: {
@@ -845,6 +847,7 @@ function startIsolatedIngressSession(params: {
   spooledUpdateHandlerTimeoutMs?: number;
   spooledUpdateHandlerAbortGraceMs?: number;
   stallThresholdMs?: number;
+  answerCallbackQuery?: (callbackQueryId: string) => Promise<unknown>;
 }) {
   const idleWorker = createIdleIngressWorker();
   const createWorker = params.createWorker ?? idleWorker.createWorker;
@@ -852,6 +855,7 @@ function startIsolatedIngressSession(params: {
     handleUpdate: params.handleUpdate,
     init: params.init,
     stop: params.stop,
+    ...(params.answerCallbackQuery ? { answerCallbackQuery: params.answerCallbackQuery } : {}),
   });
   createTelegramBotMock.mockReturnValueOnce(bot);
   const session = createPollingSession({
@@ -1523,6 +1527,84 @@ describe("TelegramPollingSession", () => {
           expectDefined(worker.ackSpooledUpdate.mock.invocationCallOrder[0], "worker ack order"),
         );
       } finally {
+        abort.abort();
+        await runPromise;
+      }
+    });
+  });
+
+  it("answers a callback query at admission while its chat lane is busy", async () => {
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const answerCallbackQuery = vi.fn(async () => undefined);
+      let releaseBusyTurn: (() => void) | undefined;
+      const busyTurnGate = new Promise<void>((resolve) => {
+        releaseBusyTurn = resolve;
+      });
+      const handleUpdate = vi.fn(async (update: { update_id?: number }) => {
+        if (update.update_id === 50) {
+          await busyTurnGate;
+        }
+      });
+      const worker = createListeningIngressWorker();
+      const { runPromise } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        handleUpdate,
+        createWorker: worker.createWorker,
+        drainIntervalMs: 60_000,
+        getCommittedUpdateId: () => 49,
+        persistUpdateId: vi.fn(async () => undefined),
+        answerCallbackQuery,
+      });
+      const busyTurnUpdate = directUpdate(50, 1234, "busy turn");
+      const callbackPressUpdate = {
+        update_id: 51,
+        callback_query: {
+          id: "callback-51",
+          data: "cmd:option_a",
+          chat_instance: "telegram-private-chat-1234",
+          from: { id: 111, is_bot: false, first_name: "Ada" },
+          message: {
+            chat: { id: 1234, type: "private" as const },
+            date: 1_736_380_800,
+            message_id: 10,
+          },
+        },
+      };
+      try {
+        await waitForTelegramTestState(() => expect(worker.hasListener()).toBe(true));
+        worker.emit({
+          type: "update",
+          requestId: "busy-turn",
+          update: busyTurnUpdate,
+          queued: 1,
+        });
+        await waitForTelegramTestState(() => expect(handleUpdate).toHaveBeenCalledTimes(1));
+
+        worker.emit({
+          type: "update",
+          requestId: "button-press",
+          update: callbackPressUpdate,
+          queued: 1,
+        });
+        await waitForTelegramTestState(() =>
+          expect(worker.ackSpooledUpdate).toHaveBeenCalledWith("button-press", {
+            ok: true,
+            updateId: 51,
+          }),
+        );
+
+        // The press is acknowledged at admission, while the chat lane is still busy.
+        expect(answerCallbackQuery).toHaveBeenCalledTimes(1);
+        expect(answerCallbackQuery).toHaveBeenCalledWith("callback-51");
+        expect(handleUpdate).toHaveBeenCalledTimes(1);
+
+        releaseBusyTurn?.();
+        await waitForTelegramTestState(() => expect(handleUpdate).toHaveBeenCalledTimes(2));
+        expect(handleUpdate).toHaveBeenLastCalledWith(callbackPressUpdate);
+      } finally {
+        releaseBusyTurn?.();
         abort.abort();
         await runPromise;
       }

--- a/extensions/telegram/src/telegram-ingress-drain-factory.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain-factory.test.ts
@@ -32,6 +32,7 @@ type CapturedMonitor = {
     update: unknown,
     lifecycle: TelegramIngressDrainLifecycle,
   ) => Promise<TelegramMessageProcessingResult | void>;
+  onDurableAdmission?: (update: unknown, context: { isNew: boolean }) => void | Promise<void>;
 };
 
 describe("Telegram transport ingress outcome handoff", () => {
@@ -109,4 +110,97 @@ describe("Telegram transport ingress outcome handoff", () => {
       monitor.dispatch({ update_id: 125 }, {} as TelegramIngressDrainLifecycle),
     ).resolves.toEqual({ kind: "skipped" });
   });
+
+  it("answers a callback query once at durable admission and skips webhook redeliveries", () => {
+    const answerCallbackQuery = vi.fn(async () => undefined);
+    const bot = {
+      handleUpdate: vi.fn(async () => undefined),
+      api: { answerCallbackQuery },
+    };
+    createTelegramTransportIngressMonitor({
+      spoolDir: "/tmp/telegram-ingress-proof",
+      bot,
+      cfg: {} as OpenClawConfig,
+      accountId: "default",
+    });
+    const monitor = requireMonitor(mocks.createTelegramIngressMonitor.mock.calls[0]?.[0]);
+    expect(monitor.onDurableAdmission).toBeTypeOf("function");
+
+    const callbackUpdate = {
+      update_id: 201,
+      callback_query: {
+        id: "cbq-admission-1",
+        data: "cmd:option_a",
+        from: { id: 111, is_bot: false, first_name: "Ada" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1_736_380_800,
+          message_id: 10,
+        },
+      },
+    };
+    void monitor.onDurableAdmission?.(callbackUpdate, { isNew: true });
+    expect(answerCallbackQuery).toHaveBeenCalledTimes(1);
+    expect(answerCallbackQuery).toHaveBeenCalledWith("cbq-admission-1");
+
+    // Non-callback updates carry no acknowledgement side channel.
+    void monitor.onDurableAdmission?.(
+      { update_id: 202, message: { chat: { id: 1234 } } },
+      { isNew: true },
+    );
+    expect(answerCallbackQuery).toHaveBeenCalledTimes(1);
+
+    // A webhook redelivery maps to the same spool row and was already answered.
+    void monitor.onDurableAdmission?.(callbackUpdate, { isNew: false });
+    expect(answerCallbackQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs but never fails admission when the admission acknowledgement rejects", () => {
+    const answerCallbackQuery = vi.fn(async () => {
+      throw new Error("query is too old");
+    });
+    const onLog = vi.fn();
+    const bot = {
+      handleUpdate: vi.fn(async () => undefined),
+      api: { answerCallbackQuery },
+    };
+    createTelegramTransportIngressMonitor({
+      spoolDir: "/tmp/telegram-ingress-proof",
+      bot,
+      cfg: {} as OpenClawConfig,
+      accountId: "default",
+      onLog,
+    });
+    const monitor = requireMonitor(mocks.createTelegramIngressMonitor.mock.calls[0]?.[0]);
+
+    expect(
+      () =>
+        void monitor.onDurableAdmission?.(
+          { update_id: 203, callback_query: { id: "cbq-admission-2" } },
+          { isNew: true },
+        ),
+    ).not.toThrow();
+    expect(answerCallbackQuery).toHaveBeenCalledWith("cbq-admission-2");
+  });
+
+  it("leaves admission acknowledgement off when the bot exposes no answer API", () => {
+    const bot = {
+      handleUpdate: vi.fn(async () => undefined),
+    };
+    createTelegramTransportIngressMonitor({
+      spoolDir: "/tmp/telegram-ingress-proof",
+      bot,
+      cfg: {} as OpenClawConfig,
+      accountId: "default",
+    });
+    const monitor = requireMonitor(mocks.createTelegramIngressMonitor.mock.calls[0]?.[0]);
+    expect(monitor.onDurableAdmission).toBeUndefined();
+  });
 });
+
+function requireMonitor(captured: unknown): CapturedMonitor {
+  if (!captured || typeof captured !== "object") {
+    throw new Error("Expected createTelegramIngressMonitor params to be captured.");
+  }
+  return captured as CapturedMonitor;
+}

--- a/extensions/telegram/src/telegram-ingress-drain-factory.ts
+++ b/extensions/telegram/src/telegram-ingress-drain-factory.ts
@@ -5,6 +5,7 @@ import {
   runWithTelegramUpdateProcessingFrame,
   type TelegramMessageProcessingResult,
 } from "./bot-processing-outcome.js";
+import { acknowledgeTelegramAdmittedCallbackQuery } from "./callback-query-answer-state.js";
 import {
   createTelegramIngressMonitor,
   resolveTelegramAdoptionStallTimeoutMs,
@@ -14,6 +15,9 @@ import { openTelegramIngressQueue } from "./telegram-ingress-spool.js";
 
 type TelegramSpooledBot = {
   handleUpdate: (update: never) => Promise<void>;
+  api?: {
+    answerCallbackQuery: (callbackQueryId: string) => Promise<unknown>;
+  };
 };
 
 type CreateTelegramTransportIngressMonitorParams = {
@@ -27,6 +31,12 @@ type CreateTelegramTransportIngressMonitorParams = {
   onLog?: (message: string) => void;
   onError?: (error: unknown) => void;
   abortSignal?: AbortSignal;
+  /**
+   * Optional override for admission-time callback-query acknowledgement (tests).
+   * Default: bot.api.answerCallbackQuery, so both transports answer a press as
+   * soon as its update is durably spooled instead of when its chat lane drains.
+   */
+  answerCallbackQuery?: (callbackQueryId: string) => Promise<unknown>;
   /**
    * Optional override for full dispatch (tests). Default: bot.handleUpdate under
    * the drain lifecycle via bot-message spooled replay path.
@@ -49,6 +59,10 @@ export function createTelegramTransportIngressMonitor(
     configured: params.adoptionStallTimeoutMs,
     env: process.env,
   });
+  const botApi = params.bot.api;
+  const answerSpooledCallbackQuery =
+    params.answerCallbackQuery ??
+    (botApi ? (callbackQueryId: string) => botApi.answerCallbackQuery(callbackQueryId) : undefined);
   return createTelegramIngressMonitor({
     queue,
     cfg: params.cfg,
@@ -59,6 +73,16 @@ export function createTelegramTransportIngressMonitor(
     ...(params.onLog ? { onLog: params.onLog } : {}),
     ...(params.onError ? { onError: params.onError } : {}),
     ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
+    ...(answerSpooledCallbackQuery
+      ? {
+          onDurableAdmission: (update: unknown, context: { isNew: boolean }) =>
+            acknowledgeTelegramAdmittedCallbackQuery(params.bot, update, {
+              answer: answerSpooledCallbackQuery,
+              isNew: context.isNew,
+              ...(params.onLog ? { onLog: params.onLog } : {}),
+            }),
+        }
+      : {}),
     dispatch: async (update, lifecycle) => {
       if (params.dispatchUpdate) {
         return await params.dispatchUpdate(update, lifecycle);

--- a/extensions/telegram/src/telegram-ingress-drain.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.ts
@@ -272,6 +272,8 @@ type CreateTelegramIngressMonitorParams = {
   onLog?: (message: string) => void;
   onError?: (error: unknown) => void;
   abortSignal?: AbortSignal;
+  /** Runs after each durable spool enqueue; the transport factory uses it for admission-time callback-query acknowledgement. */
+  onDurableAdmission?: (update: unknown, context: { isNew: boolean }) => void | Promise<void>;
 };
 
 /**
@@ -450,6 +452,7 @@ export function createTelegramIngressMonitor(params: CreateTelegramIngressMonito
       }
     },
     pollIntervalMs: params.pollIntervalMs ?? TELEGRAM_SPOOLED_DRAIN_POLL_INTERVAL_MS,
+    ...(params.onDurableAdmission ? { onDurableAdmission: params.onDurableAdmission } : {}),
     retention: {
       completedMaxEntries: 1_000,
       failedMaxEntries: 1_000,

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -35,6 +35,7 @@ import {
 const telegramSpooledRetryDeadLetterMinAgeMs = 24 * 60 * 60 * 1000;
 
 const handleUpdateSpy = vi.hoisted(() => vi.fn((..._args: unknown[]): unknown => undefined));
+const answerCallbackQuerySpy = vi.hoisted(() => vi.fn(async () => undefined));
 const setWebhookSpy = vi.hoisted(() => vi.fn());
 const deleteWebhookSpy = vi.hoisted(() => vi.fn(async () => true));
 const initSpy = vi.hoisted(() => vi.fn(async () => undefined));
@@ -243,9 +244,15 @@ function resetTelegramWebhookMocks(): void {
     init: initSpy,
     botInfo: webhookBotInfo,
     handleUpdate: handleUpdateSpy,
-    api: { setWebhook: setWebhookSpy, deleteWebhook: deleteWebhookSpy },
+    api: {
+      setWebhook: setWebhookSpy,
+      deleteWebhook: deleteWebhookSpy,
+      answerCallbackQuery: answerCallbackQuerySpy,
+    },
     stop: stopSpy,
   }));
+  answerCallbackQuerySpy.mockReset();
+  answerCallbackQuerySpy.mockImplementation(async () => undefined);
 }
 
 type MockCallReader = { mock: { calls: unknown[][] } };
@@ -1109,6 +1116,67 @@ describe("startTelegramWebhook", () => {
 
         finishWork?.();
         await waitForWebhookState(() => expect(workFinished).toBe(true));
+      },
+    );
+  });
+
+  it("answers a callback query at admission while its chat lane is busy", async () => {
+    // Hold the callback's chat lane with a long-running turn, mirroring the
+    // regression in openclaw#133294: the press must still be acknowledged
+    // while the lane is blocked, not when it drains minutes later.
+    let releaseBusyTurn: (() => void) | undefined;
+    const busyTurnGate = new Promise<void>((resolve) => {
+      releaseBusyTurn = resolve;
+    });
+    handleUpdateSpy.mockImplementationOnce(async () => {
+      await busyTurnGate;
+    });
+    const busyMessage = {
+      update_id: 11,
+      message: {
+        message_id: 11,
+        date: 1_736_380_800,
+        from: { id: 111, is_bot: false, first_name: "Ada" },
+        chat: { id: 1234, type: "private", first_name: "Ada" },
+        message_thread_id: 42,
+        text: "busy turn",
+      },
+    };
+    const callbackUpdate = {
+      update_id: 12,
+      callback_query: createTelegramPrivateTopicCallback(12),
+    };
+
+    await withStartedWebhook(
+      {
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+      },
+      async ({ port }) => {
+        const busyResponse = await postWebhookJson({
+          url: webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
+          payload: JSON.stringify(busyMessage),
+          secret: TELEGRAM_SECRET,
+        });
+        expect(busyResponse.status).toBe(200);
+        await waitForWebhookState(() => expect(handleUpdateSpy).toHaveBeenCalledTimes(1));
+
+        const pressResponse = await postWebhookJson({
+          url: webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
+          payload: JSON.stringify(callbackUpdate),
+          secret: TELEGRAM_SECRET,
+        });
+        expect(pressResponse.status).toBe(200);
+
+        // The acknowledgement is sent at admission, before the blocked lane drains.
+        await waitForWebhookState(() =>
+          expect(answerCallbackQuerySpy).toHaveBeenCalledWith("callback-12"),
+        );
+        expect(handleUpdateSpy).toHaveBeenCalledTimes(1);
+
+        releaseBusyTurn?.();
+        await waitForWebhookState(() => expect(handleUpdateSpy).toHaveBeenCalledTimes(2));
+        expect(handleUpdateSpy).toHaveBeenLastCalledWith(callbackUpdate);
       },
     );
   });


### PR DESCRIPTION
Fixes #133294

## What Problem This Solves

Fixes an issue where users pressing a Telegram inline button during a long agent turn in the same chat would see no acknowledgement of the press. The callback query was spooled under the same per-chat ingress lane as ordinary messages, so the `answerCallbackQuery` middleware only ran when the lane drained — long after Telegram's ~15s callback-query lifetime. The failure surfaced as `answerCallbackQuery failed: query is too old and response timeout expired` logged at drain time (e.g. 16 minutes after the press), and users, seeing no acknowledgement, pressed again, producing duplicate presses that had to be rejected downstream.

## Why This Change Was Made

Acknowledge a callback query at durable admission: the shared polling/webhook transport monitor sends `answerCallbackQuery` through `onDurableAdmission` — after the spool write commits, before any lane blocking — on both transports via one admission path (`telegram-ingress-drain-factory.ts`). The acknowledgement carries no handler result, so nothing about the outcome needs to be known to send it; outcome feedback already belongs to the chat surface.

Explicit coordination keeps the deferred router from issuing a second bare acknowledgement: the admission-time answer promise is recorded on the bot instance (bot-scoped registry in `callback-query-answer-state.ts`, bounded FIFO), and the bot-core early-answer middleware resolves that record instead of calling the API again. The drain-time callback router then observes the settled admission acknowledgement and skips its redundant re-answer. If the record is missing (process restart before replay) or the admission answer failed, the previous behavior — answer live at replay — is preserved as fallback. Serialized callback processing and lane ordering are unchanged (no new lane, no config surface), which keeps callbacks that mutate session state racing-free with same-chat messages.

Production LOC delta is +147 (core logic ~60 lines; remainder JSDoc and the bounded registry): the fix introduces a new fact — admission-time acknowledgement — that must be recorded at the boundary that owns it (durable admission) and read at the boundary that replays it, and no existing abstraction carries it; the closest owner (`callback-query-answer-state.ts`) was extended rather than adding a parallel module.

Non-goals: no separate callback processing lane (issue fix option 2) — processing order stays serialized; no `telegram.callbackQueryLane` config (option 3).

## User Impact

A button press is confirmed within seconds even while a long turn occupies the same chat's lane: the spinner stops, the press no longer looks lost, and the duplicate-press pattern (17 occurrences / 10 days on the reporting install) disappears. Rejected or stale presses are still reported in the chat, where such feedback belongs. The docs sentence the issue asked for now states that acknowledgements do not ride the per-chat lane (docs/channels/telegram.md).

## Evidence

Regression tests, all verified failing on pre-fix code (6/6 fail with only the production changes reverted; 347 pre-existing tests unaffected) and passing after the fix:

- `extensions/telegram/src/webhook.test.ts` — holds a chat lane with a blocked handler, then admits a callback press over HTTP: the acknowledgement is sent at admission while `handleUpdate` still shows the lane busy; the press dispatches once the lane drains.
- `extensions/telegram/src/polling-session.test.ts` — same boundary scenario through the isolated polling ingress (worker update → spool → ack → worker offset ack), press acknowledged while the lane is blocked.
- `extensions/telegram/src/bot.create-telegram-bot.test.ts` — the drain-time pipeline reuses a recorded admission acknowledgement (zero live `answerCallbackQuery` calls, handler still completes) and re-answers live when the admission acknowledgement failed.
- `extensions/telegram/src/telegram-ingress-drain-factory.test.ts` — admission wiring: answered once, webhook redelivery skipped, admission never fails on answer errors, no answer API → no acknowledgement side channel.

Full local validation:
- `node scripts/run-vitest.mjs extensions/telegram/src/{sequential-key,bot.create-telegram-bot,polling-session,webhook,telegram-ingress-spool,telegram-ingress-drain,telegram-ingress-drain-factory}.test.ts` → 438 passed
- `pnpm tsgo:extensions && pnpm tsgo:extensions:test` → clean
- `pnpm lint:extensions` (telegram) → clean

Live Telegram Test Server proof was not feasible in this environment (no credential lease available locally); the webhook and isolated-polling regression tests drive the real durable spool + drain + HTTP/session admission paths end-to-end, which is the exact failing sequence from the issue (press admitted while lane occupied → acknowledgement before drain).
