### PR TITLE
fix: remove ignored arguments from agent tools

### DIFF
--- a/docs/plugins/reference/file-transfer.md
+++ b/docs/plugins/reference/file-transfer.md
@@ -20,6 +20,13 @@ CLI commands: `openclaw file-transfer`; contracts: `tools`
 
 <!-- openclaw-plugin-reference:manual-start -->
 
+## Directory archives
+
+`dir_fetch` fetches the whole directory tree, including dotfiles and hidden
+directories. File-transfer policy checks every descendant; a denied entry
+rejects the whole transfer instead of being filtered out. Path identity,
+symlink, archive-size, and extraction limits still apply.
+
 ## Migrate existing permissions
 
 After upgrading, older positive file-transfer permissions remain inactive until

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -188,7 +188,7 @@ Default is `full` for gateway/node hosts; a `sandbox` host defaults to
 
 <ParamField path="ask" type='"off" | "on-miss" | "always"'>
   Configured ask policy for host exec. Controls the baseline approval
-  prompt behavior from `tools.exec.ask` and host approvals defaults.
+  prompt behavior from `tools.exec.mode` and host approvals defaults.
   Default is `off`. The per-call `ask` tool parameter (see
   [Exec tool](/tools/exec#parameters)) can only harden that baseline, and
   channel-origin model calls ignore it when the effective host ask is `off`.
@@ -347,9 +347,9 @@ EOF
 
 </Note>
 
-### Session-only shortcut
+### Session and turn shortcuts
 
-- `/exec security=full ask=off` changes only the current session.
+- `/exec security=full ask=off <task>` requests that policy for the current message only. Include the task in the same message; a standalone directive does not affect the next message. Session permission modes and host policy can still restrict the request.
 - `/elevated full` is a break-glass shortcut that skips exec approvals only
   when both the requested policy and the host approvals document resolve to
   `security: "full"` and `ask: "off"`. A stricter host file, such as `ask:
@@ -610,7 +610,7 @@ id=...)` / `Exec denied (gateway id=...)`).
 - **`ask`** keeps you in the loop while still allowing fast approvals.
 - Per-agent allowlists prevent one agent's approvals from leaking into others.
 - Approvals only apply to host exec requests from **authorized senders**. Unauthorized senders cannot issue `/exec`.
-- `/exec security=full` is a session-level convenience for authorized operators and skips approvals by design. To hard-block host exec, set approvals security to `deny` or deny the `exec` tool via tool policy.
+- `/exec security=full <task>` is a current-turn request by an authorized operator, subject to effective session and host policy. To hard-block exec, deny the `exec` tool via tool policy. See [session overrides](/tools/exec#session-overrides-%2Fexec) for the full-access session exception to host approval floors.
 
 ## Related
 

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -46,10 +46,6 @@ Run in a pseudo-terminal when available. Use for TTY-only CLIs, coding agents, a
 Where to execute. Omit `host` or use `auto` to inherit the configured exec host, including agent and session overrides. When that configured host is also `auto`, it resolves to `sandbox` when a sandbox runtime is active and `gateway` otherwise. A session that requires a sandbox stays sandboxed regardless of the configured host.
 </ParamField>
 
-<ParamField path="security" type="'deny' | 'allowlist' | 'full'">
-Ignored for normal tool calls. `gateway`/`node` security is derived from `tools.exec.mode` and the host approvals file; elevated mode can force full access only when the operator explicitly grants elevated access.
-</ParamField>
-
 <ParamField path="ask" type="'off' | 'on-miss' | 'always'">
 The baseline ask mode is derived from `tools.exec.mode` and host approvals. For channel-origin model calls, per-call `ask` is ignored when the effective host ask is `off`; otherwise it can only harden to a stricter mode.
 </ParamField>
@@ -59,7 +55,7 @@ Node id/name when `host=node`.
 </ParamField>
 
 <ParamField path="elevated" type="boolean" default="false">
-Request elevated mode: escape the sandbox onto the configured host path. `security=full` is forced only when elevated resolves to `full`.
+Request elevated mode: escape the sandbox onto the configured host path when the operator permits it. Elevated `full` skips approvals only when the effective security and ask policy already allow `full` and `off`.
 </ParamField>
 
 Notes:

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -690,6 +690,7 @@ describe("Codex app-server dynamic tool build", () => {
       tools.find((tool) => tool.name === "exec"),
       `${testCase.mode} OpenClaw shell replacement`,
     );
+    expect.soft(gatewayExec.parameters).not.toHaveProperty("properties.security");
     const result = await gatewayExec.execute(`${testCase.mode}-allowlisted`, {
       command: testCase.command,
       ask: "off",
@@ -1437,12 +1438,16 @@ describe("Codex app-server dynamic tool build", () => {
   });
 
   it("exposes OpenClaw sandbox shell tools under distinct names for non-Docker sandbox backends", async () => {
+    const execTool = expectDefined(
+      createOpenClawCodingTools({ workspaceDir: tempDir }).find((tool) => tool.name === "exec"),
+      "assembled exec tool",
+    );
     setOpenClawCodingToolsFactoryForTests(() => [
       createRuntimeDynamicTool("read"),
       createRuntimeDynamicTool("write"),
       createRuntimeDynamicTool("edit"),
       createRuntimeDynamicTool("apply_patch"),
-      createRuntimeDynamicTool("exec"),
+      execTool,
       createRuntimeDynamicTool("process"),
       createRuntimeDynamicTool("message"),
     ]);
@@ -1468,6 +1473,9 @@ describe("Codex app-server dynamic tool build", () => {
     ]);
     expect(tools.find((tool) => tool.name === "sandbox_exec")?.description).toContain(
       "configured sandbox backend",
+    );
+    expect(tools.find((tool) => tool.name === "sandbox_exec")?.parameters).not.toHaveProperty(
+      "properties.security",
     );
     expect(tools.find((tool) => tool.name === "sandbox_process")?.description).toContain(
       "background shell sessions",

--- a/extensions/file-transfer/index.test.ts
+++ b/extensions/file-transfer/index.test.ts
@@ -69,6 +69,12 @@ describe("file-transfer plugin entry", () => {
       "dir_fetch",
       "file_write",
     ]);
+    const directoryTool = registerTool.mock.calls.find(([tool]) => tool.name === "dir_fetch")?.[0];
+    expect(directoryTool?.parameters).toMatchObject({
+      type: "object",
+      required: ["node", "path"],
+    });
+    expect(directoryTool.parameters).not.toHaveProperty("properties.includeDotfiles");
   });
 
   it("fails closed if the lazy policy module cannot load", async () => {

--- a/extensions/file-transfer/src/node-host/dir-fetch.test.ts
+++ b/extensions/file-transfer/src/node-host/dir-fetch.test.ts
@@ -1,4 +1,5 @@
 // File Transfer tests cover dir fetch plugin behavior.
+import { execFileSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -201,6 +202,9 @@ describe("handleDirFetch — happy path", () => {
     await fs.writeFile(path.join(tmpRoot, "b.txt"), "beta\n");
     await fs.mkdir(path.join(tmpRoot, "sub"));
     await fs.writeFile(path.join(tmpRoot, "sub", "c.txt"), "gamma\n");
+    await fs.writeFile(path.join(tmpRoot, ".root-note"), "hidden root\n");
+    await fs.mkdir(path.join(tmpRoot, ".hidden"));
+    await fs.writeFile(path.join(tmpRoot, ".hidden", "note.txt"), "hidden member\n");
 
     const r = await handleDirFetch({ path: tmpRoot });
     if (!r.ok) {
@@ -220,13 +224,19 @@ describe("handleDirFetch — happy path", () => {
     expect(buf[0]).toBe(0x1f);
     expect(buf[1]).toBe(0x8b);
 
-    // file count covers the regular files we created (3); BSD tar may also
+    // file count covers the regular files we created (5); BSD tar may also
     // list directory entries, so be generous.
-    expect(r.fileCount).toBeGreaterThanOrEqual(3);
+    expect(r.fileCount).toBeGreaterThanOrEqual(5);
     expect(r.entries).toContain("a.txt");
     expect(r.entries).toContain("b.txt");
     expect(r.entries).toContain("sub");
     expect(r.entries).toContain("sub/c.txt");
+    const archiveEntries = execFileSync("/usr/bin/tar", ["-tzf", "-"], {
+      input: buf,
+      encoding: "utf8",
+    }).split("\n");
+    expect(archiveEntries).toEqual(expect.arrayContaining(["./.root-note", "./.hidden/note.txt"]));
+    expect(r.entries).toEqual(expect.arrayContaining([".root-note", ".hidden/note.txt"]));
     expect(r.fileCount).toBe(r.entries?.length);
   });
 });

--- a/extensions/file-transfer/src/node-host/dir-fetch.ts
+++ b/extensions/file-transfer/src/node-host/dir-fetch.ts
@@ -23,7 +23,6 @@ const DIR_FETCH_DEFAULT_MAX_BYTES = 8 * 1024 * 1024;
 type DirFetchParams = {
   path?: unknown;
   maxBytes?: unknown;
-  includeDotfiles?: unknown;
   followSymlinks?: unknown;
   preflightOnly?: unknown;
   expectedCanonicalPath?: unknown;
@@ -215,8 +214,7 @@ export async function handleDirFetch(params: DirFetchParams): Promise<DirFetchRe
     };
   }
 
-  // includeDotfiles is reserved; both modes archive everything. Preflight must
-  // still build the capped archive so approval cannot accept an oversized tree.
+  // Preflight must build the capped archive so approval cannot accept an oversized tree.
   const tarBuffer = await createTarArchive(
     canonical,
     canonical,

--- a/extensions/file-transfer/src/tools/descriptors.ts
+++ b/extensions/file-transfer/src/tools/descriptors.ts
@@ -86,11 +86,6 @@ const DirFetchToolSchema = Type.Object({
     description:
       "Max gzipped tarball bytes to fetch. Default 8 MB, hard ceiling 16 MB (single round-trip).",
   }),
-  includeDotfiles: Type.Optional(
-    Type.Boolean({
-      description: "Reserved for v2; currently always includes dotfiles (v1 quirk in BSD tar).",
-    }),
-  ),
   gatewayUrl: Type.Optional(Type.String()),
   gatewayToken: Type.Optional(Type.String()),
   timeoutMs: optionalPositiveIntegerSchema(),
@@ -100,7 +95,7 @@ export const DIR_FETCH_TOOL_DESCRIPTOR: FileTransferToolDescriptor = {
   label: "Directory Fetch",
   name: "dir_fetch",
   description:
-    "Retrieve a directory tree from a paired node as a gzipped tarball, unpack it on the gateway, and return a manifest of saved paths. Use to pull source trees, asset folders, or log directories in a single round-trip. The unpacked files live on the GATEWAY (not your local machine); pass localPath into other tools or use file_fetch on individual entries to ship them elsewhere. Rejects trees larger than 16 MB compressed. Requires operator opt-in: gateway.nodes.allowCommands must include 'dir.fetch', and file-transfer policy must authorize the path through allowReadPaths or a remembered exact approval.",
+    "Retrieve a whole directory tree, including dotfiles, from a paired node as a gzipped tarball. Unpack it on the gateway and return a manifest of saved paths. A denied descendant rejects the whole transfer. The unpacked files live on the gateway; use their localPath for follow-up operations. Rejects trees larger than 16 MB compressed. Requires operator opt-in: gateway.nodes.allowCommands must include 'dir.fetch', and file-transfer policy must authorize the path through allowReadPaths or a remembered exact approval.",
   parameters: DirFetchToolSchema,
 };
 

--- a/extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
+++ b/extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
@@ -84,11 +84,14 @@ async function executeDirFetch(module: typeof import("./dir-fetch-tool.js")) {
 describe("dir.fetch archive extraction", () => {
   it("extracts a bounded tar and returns the plugin-side manifest", async () => {
     const tarBuffer = await createTarBuffer({
-      entries: ["ok.txt", "nested"],
+      entries: ["ok.txt", "nested", ".root-note", ".hidden"],
       setup: async (sourceDir) => {
         await fs.writeFile(path.join(sourceDir, "ok.txt"), "ok");
         await fs.mkdir(path.join(sourceDir, "nested"));
         await fs.writeFile(path.join(sourceDir, "nested", "also-ok.txt"), "also ok");
+        await fs.writeFile(path.join(sourceDir, ".root-note"), "hidden root");
+        await fs.mkdir(path.join(sourceDir, ".hidden"));
+        await fs.writeFile(path.join(sourceDir, ".hidden", "note.txt"), "hidden member");
       },
     });
     const { appendFileTransferAudit, module, saveMediaBuffer } = await importTool(tarBuffer);
@@ -96,15 +99,15 @@ describe("dir.fetch archive extraction", () => {
     const result = await executeDirFetch(module);
 
     expect(result).toMatchObject({
-      content: [{ type: "text", text: expect.stringContaining("Fetched 2 files") }],
+      content: [{ type: "text", text: expect.stringContaining("Fetched 4 files") }],
       details: {
         path: "/tmp/project",
-        fileCount: 2,
+        fileCount: 4,
       },
     });
     const files = (result.details as { files: Array<{ relPath: string; localPath: string }> })
       .files;
-    expect(files).toHaveLength(2);
+    expect(files).toHaveLength(4);
     expect(files).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -121,6 +124,14 @@ describe("dir.fetch archive extraction", () => {
     );
     const localPath = files.find((file) => file.relPath === "ok.txt")?.localPath;
     await expect(fs.readFile(localPath!, "utf8")).resolves.toBe("ok");
+    for (const [relPath, contents] of [
+      [".root-note", "hidden root"],
+      [path.join(".hidden", "note.txt"), "hidden member"],
+    ]) {
+      const hiddenFile = files.find((file) => file.relPath === relPath);
+      expect(hiddenFile).toBeDefined();
+      await expect(fs.readFile(hiddenFile!.localPath, "utf8")).resolves.toBe(contents);
+    }
     expect(saveMediaBuffer).toHaveBeenCalledWith(
       tarBuffer,
       "application/gzip",

--- a/extensions/file-transfer/src/tools/dir-fetch-tool.ts
+++ b/extensions/file-transfer/src/tools/dir-fetch-tool.ts
@@ -10,7 +10,6 @@ import {
   type ArchiveEntryKind,
 } from "openclaw/plugin-sdk/archive";
 import { saveMediaBuffer } from "openclaw/plugin-sdk/media-store";
-import { asBoolean } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { appendFileTransferAudit } from "../shared/audit.js";
 import { IMAGE_MIME_INLINE_SET, mimeFromExtension } from "../shared/mime.js";
 import { humanSize, readClampedInt } from "../shared/params.js";
@@ -135,7 +134,6 @@ export function createDirFetchTool(): AnyAgentTool {
         hardMin: 1,
         hardMax: DIR_FETCH_HARD_MAX_BYTES,
       });
-      const includeDotfiles = asBoolean(params.includeDotfiles) ?? false;
 
       const { nodeId, nodeDisplayName, payload, startedAt } = await invokeNodeToolPayload({
         node,
@@ -144,7 +142,6 @@ export function createDirFetchTool(): AnyAgentTool {
         commandParams: {
           path: dirPath,
           maxBytes,
-          includeDotfiles,
         },
         requestedPath: dirPath,
       });

--- a/src/agents/agent-tools-agent-config.exec.test.ts
+++ b/src/agents/agent-tools-agent-config.exec.test.ts
@@ -166,6 +166,7 @@ describe("Agent-specific exec tool defaults", () => {
     expect.soft(execTool.description).not.toMatch(/background|yieldMs|process/);
     expect.soft(schemaPropertyNames(execTool)).not.toContain("background");
     expect.soft(schemaPropertyNames(execTool)).not.toContain("yieldMs");
+    expect.soft(schemaPropertyNames(execTool)).not.toContain("security");
 
     const result = await execTool.execute("call-runtime-exec-only", {
       command: `${JSON.stringify(process.execPath)} -e "setTimeout(() => {}, 250)"`,
@@ -193,6 +194,7 @@ describe("Agent-specific exec tool defaults", () => {
       ...createTempAgentDirs("test-main-implicit-gateway"),
     });
     const execTool = requireExecTool(tools);
+    expect.soft(schemaPropertyNames(execTool)).not.toContain("security");
 
     const result = await execTool.execute("call-implicit-auto-default", {
       command: "echo done",

--- a/src/agents/agent-tools.schema.test.ts
+++ b/src/agents/agent-tools.schema.test.ts
@@ -56,9 +56,7 @@ describe("direct exec tool schema", () => {
     expect(describeField("timeoutSeconds")).toContain("seconds");
     expect(describeField("pty")).toContain("PTY");
     expect(describeField("elevated")).toContain("if allowed");
-    expect(describeField("security")).toContain("tools.exec.security");
-    expect(describeField("security")).toContain("host approvals");
-    expect(describeField("ask")).toContain("tools.exec.ask");
+    expect(describeField("ask")).toContain("tools.exec.mode");
     expect(describeField("ask")).toContain("channel-origin");
     expect(describeField("ask")).toContain("ask=off");
   });

--- a/src/agents/bash-tools.exec-request-preparation.ts
+++ b/src/agents/bash-tools.exec-request-preparation.ts
@@ -38,7 +38,6 @@ export type ExecToolArgs = Record<string, unknown> & {
   pty?: boolean;
   elevated?: boolean;
   host?: string;
-  security?: string;
   ask?: string;
   node?: string;
 };
@@ -66,14 +65,7 @@ const resolvedExecWorkdirPreparedStates = new WeakMap<
   ExecToolArgs,
   ResolvedExecWorkdirPreparedState
 >();
-const XML_ARG_VALUE_EXEC_PARAM_KEYS = [
-  "command",
-  "workdir",
-  "host",
-  "security",
-  "ask",
-  "node",
-] as const;
+const XML_ARG_VALUE_EXEC_PARAM_KEYS = ["command", "workdir", "host", "ask", "node"] as const;
 
 export function assertSupportedExecParams(args: unknown): void {
   if (isRecord(args) && Object.hasOwn(args, "timeout")) {

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -206,11 +206,18 @@ describe("exec PATH login shell merge", () => {
         command: "echo ok</arg_value>>",
         workdir: `${tempDir}</arg_value>>`,
         host: "gateway</arg_value>>",
-        security: "full</arg_value>>",
         ask: "off</arg_value>>",
         node: "ignored-node</arg_value>>",
         yieldMs: FOREGROUND_TEST_YIELD_MS,
       } as unknown as Parameters<typeof tool.execute>[1];
+      const prepared = await tool.prepareBeforeToolCallParams?.(malformedArgs, {});
+      expect(prepared).toMatchObject({
+        command: "echo ok",
+        workdir: tempDir,
+        host: "gateway",
+        ask: "off",
+        node: "ignored-node",
+      });
       const result = await tool.execute("call-xml-suffix", malformedArgs);
       const value = normalizeText(result.content.find((c) => c.type === "text")?.text);
 

--- a/src/agents/bash-tools.exec.security-floor.test.ts
+++ b/src/agents/bash-tools.exec.security-floor.test.ts
@@ -128,11 +128,12 @@ describe("exec security floor", () => {
       ask: "off",
     });
 
-    const result = await tool.execute("call-1", {
+    const modelArgs = {
       command: "echo hello",
       security: "allowlist",
       ask: "off",
-    });
+    };
+    const result = await tool.execute("call-1", modelArgs);
 
     expect(result.content[0]?.type).toBe("text");
     const text = (result.content[0] as { text?: string }).text ?? "";
@@ -148,13 +149,12 @@ describe("exec security floor", () => {
       safeBins: [],
     });
 
-    await expect(
-      tool.execute("call-2", {
-        command: "echo hello",
-        security: "allowlist",
-        ask: "off",
-      }),
-    ).rejects.toThrow(/exec denied: allowlist miss/i);
+    const modelArgs = {
+      command: "echo hello",
+      security: "allowlist",
+      ask: "off",
+    };
+    await expect(tool.execute("call-2", modelArgs)).rejects.toThrow(/exec denied: allowlist miss/i);
   });
 
   it("ignores model-supplied ask overrides when configured ask is off", async () => {
@@ -210,13 +210,12 @@ describe("exec security floor", () => {
       safeBins: [],
     });
 
-    await expect(
-      tool.execute("call-3", {
-        command: "echo hello",
-        security: "deny",
-        ask: "off",
-      }),
-    ).rejects.toThrow(/exec denied: allowlist miss/i);
+    const modelArgs = {
+      command: "echo hello",
+      security: "deny",
+      ask: "off",
+    };
+    await expect(tool.execute("call-3", modelArgs)).rejects.toThrow(/exec denied: allowlist miss/i);
   });
 
   it("ignores model-supplied full security when configured security is deny", async () => {
@@ -225,13 +224,12 @@ describe("exec security floor", () => {
       ask: "off",
     });
 
-    await expect(
-      tool.execute("call-4", {
-        command: "echo hello",
-        security: "full",
-        ask: "off",
-      }),
-    ).rejects.toThrow(/exec denied/i);
+    const modelArgs = {
+      command: "echo hello",
+      security: "full",
+      ask: "off",
+    };
+    await expect(tool.execute("call-4", modelArgs)).rejects.toThrow(/exec denied/i);
   });
 
   it("does not let host approval defaults deny implicit sandbox execution", async () => {

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -58,15 +58,10 @@ export const execSchema = Type.Object({
   host: optionalStringEnum(EXEC_TOOL_HOST_VALUES, {
     description: "Omit/auto: inherit configured host.",
   }),
-  security: Type.Optional(
-    Type.String({
-      description: "Ignored per call; tools.exec.security and host approvals decide.",
-    }),
-  ),
   ask: Type.Optional(
     Type.String({
       description:
-        "Uses tools.exec.ask and host approvals; channel-origin calls cannot override host ask=off.",
+        "Requests stricter approvals under tools.exec.mode and host policy; channel-origin calls cannot override host ask=off.",
     }),
   ),
   node: Type.Optional(

--- a/src/auto-reply/reply/commands-diagnostics.test.ts
+++ b/src/auto-reply/reply/commands-diagnostics.test.ts
@@ -63,7 +63,6 @@ type ExecDefaults = {
 type ExecParams = {
   ask?: string;
   command?: string;
-  security?: string;
 };
 
 type DiagnosticsSession = {
@@ -319,7 +318,6 @@ describe("diagnostics command", () => {
     expect(execCall.defaults.approvalWarningText).toContain(
       "https://docs.openclaw.ai/gateway/diagnostics",
     );
-    expect(execCall.params.security).toBe("allowlist");
     expect(execCall.params.ask).toBe("always");
     const command = execCall.params.command ?? "";
     expect(command).toContain("gateway");

--- a/src/auto-reply/reply/commands-diagnostics.ts
+++ b/src/auto-reply/reply/commands-diagnostics.ts
@@ -308,7 +308,6 @@ async function requestGatewayDiagnosticsExportApproval(
     const result = await execTool.execute("chat-diagnostics-gateway-export", {
       command,
       env,
-      security: "allowlist",
       ask: "always",
       background: true,
       timeoutSeconds: timeoutSec,

--- a/src/auto-reply/reply/commands-export-trajectory.test-support.ts
+++ b/src/auto-reply/reply/commands-export-trajectory.test-support.ts
@@ -151,7 +151,6 @@ describe("buildExportTrajectoryCommandReply", () => {
     expect(execCall.defaults.sessionStore).toBe("/tmp/openclaw-sessions.json");
     expect(execCall.defaults.currentChannelId).toBe("bot");
     expect(execCall.defaults.accountId).toBe("account-1");
-    expect(execCall.params.security).toBe("allowlist");
     expect(execCall.params.ask).toBe("always");
     expect(execCall.params.background).toBe(true);
     const command = typeof execCall.params.command === "string" ? execCall.params.command : "";

--- a/src/auto-reply/reply/commands-export-trajectory.ts
+++ b/src/auto-reply/reply/commands-export-trajectory.ts
@@ -197,7 +197,6 @@ async function requestTrajectoryExportApproval(
     const result = await execTool.execute("chat-export-trajectory", {
       command: request.command,
       env: request.env,
-      security: "allowlist",
       ask: "always",
       background: true,
       timeoutSeconds: timeoutSec,


### PR DESCRIPTION
Closes #133333.

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer branch, so maintainers can push directly to it.

</details>

## What Problem This Solves

Fixes an issue where agents received tool schemas offering choices that had no effect: `security` on common/completion exec and `includeDotfiles` on directory fetch. These stale arguments cluttered the model-facing contract even though exec policy was already operator-controlled and directory archives already included hidden entries.

## Why This Change Was Made

Remove the unused arguments at their schema owners, together with inert normalization, parsing and forwarding. The shared exec schema also fixes inherited Codex sandbox/direct surfaces without adding another adapter. Already-clean pinned exec aliases keep their defensive stripping.

The real controls are deliberately unchanged: configured exec mode/defaults, approval floors, meaningful `ask`/host/node/elevated inputs, operator `/exec` directives and native node-protocol security remain. Directory fetch still selects the whole tree, including dotfiles, subject to its existing policy, identity, archive and size checks. The tool description now makes clear that a denied descendant can reject the whole transfer. Two internal callers stop sending the unused field but retain their real allowlist/always-ask factory defaults.

## User Impact

Agents see only meaningful arguments on these tools. There is no new execution permission, hidden-file exclusion option, configuration key, dependency, migration or protocol change. Existing execution and transfer behavior stays intact.

The touched docs explain the current exec mode/approval boundary and whole-directory archive behavior. They also correct nearby wording that called turn-only `/exec security` and `ask` overrides session-wide changes. The retained `ask` description says it requests stricter approval, rather than promising hardening across explicit full-session/elevated exceptions.

## Evidence

**Current-head validation:** [CI33318681656, attempt1](https://github.com/openclaw/openclaw/actions/runs/33318681656) passed on `ed2abc8a7d1e546420dd822949ad65268f9605d6`. [Direct sibling Codex inspection and maintainer acceptance](https://github.com/openclaw/openclaw/pull/133336#issuecomment-5469578216) address the completed review's source-contract gap and rank-up request. Native review validation and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 133336` passed on the unchanged reviewed head. Native merge is the next operation.

Before production edits, the assembled-schema regressions failed for the intended reason: two core cases, four Codex collector/direct/inherited cases and one plugin registration case still exposed the removed fields. Real hidden-file archive/extraction checks already passed before cleanup, establishing behavior to preserve rather than inventing a missing exclusion feature.

The final source passed an independent parent run of **582 cases across 37 complete owner/sibling files**, with **two existing Linux-only directory-list race cases skipped on macOS**. Each native JSON result was retained separately so multi-project output could not overwrite earlier evidence. Coverage includes actual assembled common/completion tool schemas, Codex collector/native-policy/schema normalization, configured exec floors and malicious extra inputs, native node prepare/dispatch through the real handler behind mocked transport, the complete file-transfer plugin, diagnostics and trajectory-export callers.

Commands, each with native verbose and JSON stdout reporters in an owned environment:

```bash
node scripts/run-vitest.mjs src/agents/agent-tools-agent-config.exec.test.ts src/agents/agent-tools.schema.test.ts src/agents/bash-tools.schemas.test.ts src/agents/bash-tools.exec.path.test.ts src/agents/bash-tools.exec.security-floor.test.ts src/agents/bash-tools.exec-host-node.integration.test.ts --reporter=verbose --reporter=json
```

```bash
node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tool-build.test.ts extensions/codex/src/app-server/native-execution-policy.test.ts extensions/codex/src/app-server/schema-normalization-runtime-contract.test.ts --reporter=verbose --reporter=json
```

```bash
node scripts/run-vitest.mjs extensions/file-transfer --reporter=verbose --reporter=json
```

```bash
node scripts/run-vitest.mjs src/auto-reply/reply/commands-diagnostics.test.ts src/auto-reply/reply/commands-export-session.test.ts --reporter=verbose --reporter=json
```

The **full classified changed gate**, normal **full build**, docs MDX/manual-block generation checks and `git diff --check` passed. After rebuilding, actual compiled coding-tool assembly and plugin registration confirmed that only the two no-op argument names disappeared; all other inventoried properties, required fields and node commands matched the pre-edit inventory. Both compiled exec variants also contain the final approval-request wording. Source hashes matched before and after proof.

A fresh restricted **P0-scoped Codex autoreview** found no blockers on the complete final candidate. The parent directly inspected the unchanged effective exec policy and archive owners. Sibling Codex source was personally inspected at `63d213884daea50e4f74efc192cdc44f549b67d5`: generic dynamic-tool schemas/arguments in `codex-rs/protocol/src/dynamic_tools.rs` and forwarding in `codex-rs/core/src/tools/handlers/dynamic.rs` are separate from native execution permissions. Installed package metadata is 0.151.0; this is not a claim that the packaged binary was matched to that source or live-tested.

**Limits:** no live provider turn, paired-node transport, configured messaging channel or operator state was used. Node proof exercises the actual handler and harmless subprocesses with synthetic transport/approval inputs. Archive proof uses real macOS tar members and extracted dotfile contents, not Linux/Windows execution. The full product suite was not run. Hosted exact-head CI and native preparation passed; native merge is next.

Earlier test-authoring and check-launcher failures were corrected and retained, not relabeled green. Typechecking identified the two redundant internal payload fields and four intentional hostile-extra-input test objects; the correction preserves their actual policy assertions. Final parent verification ran against the exact reviewed source.

**Size:** production +4/-29 (**net -25**), tests/support +74/-37 (**net +37**), docs +12/-9 (**net +3**). No new source module, compatibility alias, fallback or production test seam.

Current-main comparison at `6931ccfc6491451758502831474fb9046cb803b2` found the changed files and dependency pins unchanged. Adjacent `agent-tools.ts` drift only carries staged media paths into the read-tool constructor; it does not change exec schema/default ownership. Historical configured-authority and directory-placeholder commits are recorded in the linked issue, without attributing those earlier repairs to this change.

Docs: https://docs.openclaw.ai/tools/exec and https://docs.openclaw.ai/plugins/reference/file-transfer.
