### PR TITLE
fix(plugins): normalize file URLs for native require

### DIFF
--- a/src/plugins/native-module-require.test.ts
+++ b/src/plugins/native-module-require.test.ts
@@ -31,6 +31,26 @@ describe("tryNativeRequireJavaScriptModule", () => {
     expect(result).toEqual({ ok: true, moduleExport: { marker: "native" } });
   });
 
+  it("loads and clears native CommonJS modules addressed by file URLs", () => {
+    const dir = tempDirs.make("openclaw-native-require-");
+    const modulePath = path.join(dir, "plugin.cjs");
+    const moduleUrl = pathToFileURL(modulePath).href;
+    fs.writeFileSync(modulePath, 'module.exports = { marker: "before" };\n', "utf8");
+
+    expect(tryNativeRequireJavaScriptModule(moduleUrl, { allowWindows: true })).toEqual({
+      ok: true,
+      moduleExport: { marker: "before" },
+    });
+
+    fs.writeFileSync(modulePath, 'module.exports = { marker: "after" };\n', "utf8");
+    clearPluginModuleRequireCache(moduleUrl);
+
+    expect(tryNativeRequireJavaScriptModule(moduleUrl, { allowWindows: true })).toEqual({
+      ok: true,
+      moduleExport: { marker: "after" },
+    });
+  });
+
   it("declines modules that need source-transform fallback", () => {
     const dir = tempDirs.make("openclaw-native-require-");
     const modulePath = path.join(dir, "plugin.mjs");

--- a/src/plugins/native-module-require.test.ts
+++ b/src/plugins/native-module-require.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import Module from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { build } from "esbuild";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
@@ -29,26 +30,6 @@ describe("tryNativeRequireJavaScriptModule", () => {
     const result = tryNativeRequireJavaScriptModule(modulePath, { allowWindows: true });
 
     expect(result).toEqual({ ok: true, moduleExport: { marker: "native" } });
-  });
-
-  it("loads and clears native CommonJS modules addressed by file URLs", () => {
-    const dir = tempDirs.make("openclaw-native-require-");
-    const modulePath = path.join(dir, "plugin.cjs");
-    const moduleUrl = pathToFileURL(modulePath).href;
-    fs.writeFileSync(modulePath, 'module.exports = { marker: "before" };\n', "utf8");
-
-    expect(tryNativeRequireJavaScriptModule(moduleUrl, { allowWindows: true })).toEqual({
-      ok: true,
-      moduleExport: { marker: "before" },
-    });
-
-    fs.writeFileSync(modulePath, 'module.exports = { marker: "after" };\n', "utf8");
-    clearPluginModuleRequireCache(moduleUrl);
-
-    expect(tryNativeRequireJavaScriptModule(moduleUrl, { allowWindows: true })).toEqual({
-      ok: true,
-      moduleExport: { marker: "after" },
-    });
   });
 
   it("declines modules that need source-transform fallback", () => {
@@ -217,22 +198,53 @@ describe("tryNativeRequireJavaScriptModule", () => {
     ).toEqual({ ok: false });
   });
 
-  it("clears loaded JavaScript modules from the native require cache", () => {
+  it("loads and evicts path and file-URL modules through plain Node", async () => {
     const dir = tempDirs.make("openclaw-native-require-");
-    const modulePath = path.join(dir, "plugin.cjs");
-    fs.writeFileSync(modulePath, 'module.exports = { marker: "before" };\n', "utf8");
-    expect(tryNativeRequireJavaScriptModule(modulePath, { allowWindows: true })).toEqual({
-      ok: true,
-      moduleExport: { marker: "before" },
+    const ownerPath = path.join(dir, "native-require.mjs");
+    // tsx's CommonJS hook accepts file URLs and masks Node's native contract.
+    await build({
+      entryPoints: [path.resolve("src/plugins/native-module-require.ts")],
+      bundle: true,
+      platform: "node",
+      format: "esm",
+      outfile: ownerPath,
+      logLevel: "silent",
+    });
+    const modulePath = path.join(dir, "space # percent% plugin.cjs");
+    const probePath = path.join(dir, "probe.mjs");
+    fs.writeFileSync(
+      probePath,
+      `import assert from "node:assert/strict";
+import fs from "node:fs";
+import { pathToFileURL } from "node:url";
+import { clearPluginModuleRequireCache as clear, tryNativeRequireJavaScriptModule as load } from ${JSON.stringify(pathToFileURL(ownerPath).href)};
+const modulePath = ${JSON.stringify(modulePath)};
+for (const target of [modulePath, pathToFileURL(modulePath).href]) {
+  fs.writeFileSync(modulePath, 'module.exports = { marker: "before" };\\n');
+  assert.deepEqual(load(target, { allowWindows: true }), { ok: true, moduleExport: { marker: "before" } });
+  fs.writeFileSync(modulePath, 'module.exports = { marker: "after" };\\n');
+  assert.deepEqual(load(target, { allowWindows: true }), { ok: true, moduleExport: { marker: "before" } });
+  clear(target);
+  assert.deepEqual(load(target, { allowWindows: true }), { ok: true, moduleExport: { marker: "after" } });
+  clear(target);
+}
+assert.deepEqual(load(pathToFileURL(modulePath + ".missing.cjs").href, { allowWindows: true }), { ok: false });
+fs.writeFileSync(modulePath, 'require("./missing-dependency.cjs");\\n');
+assert.throws(() => load(pathToFileURL(modulePath).href, { allowWindows: true }), /missing-dependency\\.cjs/);
+console.log("native path + file URL load/cache reload; missing target/dependency controls passed");
+`,
+    );
+    const result = spawnSync(process.execPath, [probePath], {
+      cwd: process.cwd(),
+      env: { ...process.env, NODE_OPTIONS: "" },
+      encoding: "utf8",
+      timeout: 30_000,
     });
 
-    fs.writeFileSync(modulePath, 'module.exports = { marker: "after" };\n', "utf8");
-    clearPluginModuleRequireCache(modulePath);
-
-    expect(tryNativeRequireJavaScriptModule(modulePath, { allowWindows: true })).toEqual({
-      ok: true,
-      moduleExport: { marker: "after" },
-    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout.trim()).toBe(
+      "native path + file URL load/cache reload; missing target/dependency controls passed",
+    );
   });
 
   it("clears local dependencies loaded by a native JavaScript module", () => {

--- a/src/plugins/native-module-require.ts
+++ b/src/plugins/native-module-require.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import Module, { createRequire } from "node:module";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { isPathInside } from "../infra/path-guards.js";
 
 const nodeRequire = createRequire(import.meta.url);
@@ -74,13 +74,17 @@ export function tryNativeRequireJavaScriptModule(
   if (!isJavaScriptModulePath(modulePath)) {
     return { ok: false };
   }
+  const nativeModulePath = toNativeRequirePath(modulePath);
   try {
-    return { ok: true, moduleExport: requireWithOptionalAliases(modulePath, options.aliasMap) };
+    return {
+      ok: true,
+      moduleExport: requireWithOptionalAliases(nativeModulePath, options.aliasMap),
+    };
   } catch (error) {
     const code =
       error && typeof error === "object" ? (error as { code?: unknown }).code : undefined;
     if (
-      isSourceTransformFallbackError(error, modulePath) ||
+      isSourceTransformFallbackError(error, nativeModulePath) ||
       options.fallbackOnNativeError ||
       (options.fallbackOnMissingDependency === true &&
         (code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND"))
@@ -97,7 +101,7 @@ export function clearPluginModuleRequireCache(
   options: { dependencyRoot?: string } = {},
 ): void {
   try {
-    const resolved = nodeRequire.resolve(modulePath);
+    const resolved = nodeRequire.resolve(toNativeRequirePath(modulePath));
     clearRequireCacheSubtree(
       resolved,
       resolveRequireCachePath(options.dependencyRoot ?? path.dirname(resolved)),
@@ -105,6 +109,18 @@ export function clearPluginModuleRequireCache(
     );
   } catch {
     // Best-effort lifecycle cleanup: unresolved paths were not loaded.
+  }
+}
+
+/** Converts file URLs only at CommonJS boundaries, which require native paths. */
+function toNativeRequirePath(modulePath: string): string {
+  if (!/^file:\/\//iu.test(modulePath)) {
+    return modulePath;
+  }
+  try {
+    return fileURLToPath(modulePath);
+  } catch {
+    return modulePath;
   }
 }
 

--- a/src/plugins/native-module-require.ts
+++ b/src/plugins/native-module-require.ts
@@ -60,7 +60,7 @@ function isSourceTransformFallbackError(error: unknown, modulePath: string): boo
 
 /** Attempts native require before falling back to source transform paths. */
 export function tryNativeRequireJavaScriptModule(
-  modulePath: string,
+  moduleSpecifier: string,
   options: {
     allowWindows?: boolean;
     aliasMap?: Record<string, string> | ((specifier: string) => string | undefined);
@@ -71,20 +71,17 @@ export function tryNativeRequireJavaScriptModule(
   if (process.platform === "win32" && options.allowWindows !== true) {
     return { ok: false };
   }
+  const modulePath = toNativeRequirePath(moduleSpecifier);
   if (!isJavaScriptModulePath(modulePath)) {
     return { ok: false };
   }
-  const nativeModulePath = toNativeRequirePath(modulePath);
   try {
-    return {
-      ok: true,
-      moduleExport: requireWithOptionalAliases(nativeModulePath, options.aliasMap),
-    };
+    return { ok: true, moduleExport: requireWithOptionalAliases(modulePath, options.aliasMap) };
   } catch (error) {
     const code =
       error && typeof error === "object" ? (error as { code?: unknown }).code : undefined;
     if (
-      isSourceTransformFallbackError(error, nativeModulePath) ||
+      isSourceTransformFallbackError(error, modulePath) ||
       options.fallbackOnNativeError ||
       (options.fallbackOnMissingDependency === true &&
         (code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND"))
@@ -112,15 +109,12 @@ export function clearPluginModuleRequireCache(
   }
 }
 
-/** Converts file URLs only at CommonJS boundaries, which require native paths. */
-function toNativeRequirePath(modulePath: string): string {
-  if (!/^file:\/\//iu.test(modulePath)) {
-    return modulePath;
-  }
+// Native require and cache keys use paths; ESM/source loaders keep URL specifiers.
+function toNativeRequirePath(specifier: string): string {
   try {
-    return fileURLToPath(modulePath);
+    return /^file:\/\//iu.test(specifier) ? fileURLToPath(specifier) : specifier;
   } catch {
-    return modulePath;
+    return specifier;
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Compiled plugin entrypoints can reach the native CommonJS loader as `file://` URLs. The Windows import-specifier helper deliberately produces that form for ESM loading, but native `require()` and `require.resolve()` need filesystem paths. The unconverted URL can miss native loading and prevent cache eviction during reload.

Fixes #133306.

## Why This Change Was Made

Normalize file URLs at the shared native require/cache boundary, leaving ESM and source-transform loading unchanged. The same normalized path now drives extension detection, native loading, and missing-target classification. Cache cleanup uses that conversion too. Invalid URL conversion keeps the original specifier so the existing native error/fallback behavior remains authoritative.

The maintainer revision reduces the original production increase from 16 to 10 lines (+13/−3), retaining one conversion rule for both boundaries. That small increase implements the distinct CommonJS URL/path contract without duplicating conversion or altering the ESM producer. Existing alias handling and cache-subtree ownership remain intact.

Thanks @sunlit-deng for the fix.

## User Impact

Plugin entrypoints addressed by file URL use the native loader and reload correctly after cache cleanup. The failure is a CommonJS contract issue across platforms; Windows makes it reachable through normal path-to-URL conversion. No configuration, plugin API, dependencies, or install behavior changes.

## Evidence

Incoming head: `f03e006049b7b7fa5fc00bdb11f1efc072c3a21f`. Reviewed head: `5dfba2b5f3e95b82535b4ac140de4769e781be88`. Exact-head hosted owner/build/importer proof is complete; the single UI shard retry passed. The incoming green run is not used to validate the revised test.

The previous URL regression ran under tsx, whose CommonJS hook accepts file URLs and hid the baseline bug. Independent Node 24.20.0 probes using the same trusted owner demonstrated that difference:

| Trusted upstream owner | File-URL load | Path load after rewrite and URL cache-clear |
| --- | --- | --- |
| Plain Node | Declined (`ok: false`) | Stale `before` export |
| Node with tsx hook | Loaded | Updated `after` export |

The replacement extends the existing cache test: bundle the actual owner with the repository's existing esbuild, then launch plain Node with loader-injection options cleared. It checks native paths and percent-encoded file URLs (spaces, `#`, `%`), confirms exports remain cached before eviction, verifies rewritten exports after eviction, and distinguishes a missing target from a missing dependency. There are no native-loader mocks or new production testing seams. Existing tests retain ESM alias, async fallback, evaluation error, dependency eviction, and graph-retirement coverage.

Maintainer-authored equivalent overlays on trusted upstream `c29f34dc5312530761529e7133afa083911e7959`, using its own frozen dependencies, produced:

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/native-module-require.test.ts

Unchanged production + revised test: 1 failed, 13 passed
  Plain Node file-URL load returned { ok: false } instead of the expected export.
Equivalent native-boundary repair: 14 passed
  Native path + file URL load/cache reload; missing target/dependency controls passed.
```

The whole revised owner/test files matched those authored proof bytes before formatting. Original trusted source hashes and a clean checkout were restored afterward. Contributor code executes only in secretless hosted CI. Windows-shaped `fileURLToPath` conversion was checked independently, but this is not a claim of a Windows runtime run.

Fresh independent full-candidate Codex autoreview is scoped-clean at P0, with no accepted/actionable findings. Hosted results are recorded below; the final required rollup is green after one failed UI shard retry.


Published-source proof from [CI 33363294228](https://github.com/openclaw/openclaw/actions/runs/33363294228):

- [Native owner job 99399428061](https://github.com/openclaw/openclaw/actions/runs/33363294228/job/99399428061) ran all 14 cases, including genuine plain-Node path/file-URL loading and cache eviction, missing-target/dependency behavior and retired module graphs.
- [Shared importer job 99399428107](https://github.com/openclaw/openclaw/actions/runs/33363294228/job/99399428107) passed all six Windows/file-URL runtime-import controls.
- [Build job 99399425397](https://github.com/openclaw/openclaw/actions/runs/33363294228/job/99399425397) passed the canonical CI artifact build and bundled shape-guard tests, including cached-loader fallback for package-local and direct-override compiled entries. Separate plugin-module-loader-cache.test.ts was not selected by changed-test targeting.

CI merge eaef15c031dfbc5ae58d3f36db0d305c4d635631 has the reviewed 5df head as parent. Native owner, cached loader, importer and their test blobs match the published candidate exactly.

The first run failed one unrelated UI assertion: [job 99399427795](https://github.com/openclaw/openclaw/actions/runs/33363294228/job/99399427795), workspace-icon transient recovery, expected two global fetches and observed three. Full test/owner/history inspection found no existing main fix. A clean trusted-main diagnostic passed the full 50-case header file and the matching 269-file UI selection with two workers (3,602 passed, 53 skipped); the third fetch did not recur. The failure-only synthetic request ledger was removed and original hashes restored. This is not an exact replay of the entire CI merge or Linux scheduling. One [failed-job retry](https://github.com/openclaw/openclaw/actions/runs/33363294228/job/99405796200) passed the exact recovery assertion and all 3,604 UI cases (53 skipped); no assertions, timeouts, retry policy or production code were changed for this UI failure.

Follow-up: identify the extra global fetch if the intermittent workspace-icon UI assertion recurs. Its request URL is absent from the original CI log and the diagnostic did not reproduce it; no timer or lifecycle root cause is claimed.

Final exact-head CI 33363294228 attempt 2 and Workflow Sanity 33363294225 are green. The final rollup contains 217 successful, 48 skipped and 1 neutral check, with no failed or pending checks.
