### PR TITLE
fix(matrix): reject malformed durable plan encoding

### DIFF
--- a/extensions/matrix/src/matrix/delivery-plan.test.ts
+++ b/extensions/matrix/src/matrix/delivery-plan.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -6,6 +7,7 @@ import {
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getMatrixRuntime } from "../runtime.js";
 import { installMatrixTestRuntime } from "../test-runtime.js";
 import {
   cleanupMatrixDeliveryPlans,
@@ -169,6 +171,53 @@ describe("Matrix durable delivery plans", () => {
         },
       }),
     ).rejects.toThrow("no longer matches the prepared event batch");
+  });
+
+  it("fails closed when a persisted plan contains invalid UTF-8", async () => {
+    const queueId = "queue-invalid-utf8";
+    const deliveryIdentity = identity(queueId);
+    const plan = await persist({ queueId });
+    const json = JSON.stringify(plan);
+    const marker = "durable hello";
+    const markerOffset = json.indexOf(marker);
+    if (markerOffset < 0) {
+      throw new Error("expected test plan body marker");
+    }
+    const invalidByteOffset = markerOffset + "durable".length;
+    const prefix = new TextEncoder().encode(json.slice(0, invalidByteOffset));
+    const suffix = new TextEncoder().encode(json.slice(invalidByteOffset));
+    const bytes = new Uint8Array(prefix.length + 1 + suffix.length);
+    bytes.set(prefix);
+    bytes[prefix.length] = 0xff;
+    bytes.set(suffix, prefix.length + 1);
+
+    const store = getMatrixRuntime().state.openBlobStore<Record<string, never>>({
+      namespace: "outbound-delivery-plans",
+      maxEntries: 10_000,
+      maxBytesPerEntry: 8 * 1024 * 1024,
+      maxBytesPerNamespace: 256 * 1024 * 1024,
+      overflowPolicy: "reject-new",
+      defaultTtlMs: 24 * 60 * 60 * 1000,
+    });
+    await store.register(`${createHash("sha256").update(queueId).digest("hex")}.0`, bytes, {});
+
+    await expect(reconcileMatrixUnknownSend(reconciliationContext(queueId))).resolves.toMatchObject(
+      {
+        status: "unresolved",
+        retryable: false,
+        error: expect.stringContaining("invalid JSON"),
+      },
+    );
+    expect(client.sendMessage).not.toHaveBeenCalled();
+    await expect(
+      loadMatrixDeliveryPlan({
+        identity: deliveryIdentity,
+        accountId: "default",
+        roomId: "!room:example.org",
+        transactionScopeId: "scope-1",
+        wireEventType: "m.room.message",
+      }),
+    ).resolves.toBeNull();
   });
 
   it("reissues the exact stored event with its transaction id and reports the provider event id", async () => {

--- a/extensions/matrix/src/matrix/delivery-plan.ts
+++ b/extensions/matrix/src/matrix/delivery-plan.ts
@@ -150,7 +150,7 @@ function isPlan(value: unknown): value is MatrixDeliveryPlan {
 function decodePlan(bytes: Uint8Array): MatrixDeliveryPlan {
   let value: unknown;
   try {
-    value = JSON.parse(new TextDecoder().decode(bytes));
+    value = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
   } catch {
     throw new MatrixDeliveryPlanInvariantError("Matrix durable delivery plan is invalid JSON");
   }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Matrix durable delivery recovery could replay a persisted plan whose stored JSON bytes contained malformed UTF-8 as a message with replacement characters.

## Why This Change Was Made

The Matrix durable-plan decoder now uses fatal UTF-8 decoding before JSON parsing. Existing `MatrixDeliveryPlanInvariantError` handling treats malformed plans as terminal and removes them, while valid durable plans keep the existing replay behavior.

## User Impact

Interrupted Matrix sends with corrupted persisted plan bytes fail closed instead of sending altered event content. Normal durable delivery recovery is unchanged.

## Evidence

- Production-module boundary proof imports `loadMatrixDeliveryPlan` from `extensions/matrix/src/matrix/delivery-plan.ts`, persists through the real plugin blob-store boundary, corrupts one stored UTF-8 byte, and runs the same command against the pinned base and this HEAD.
- The pinned base accepted the malformed bytes as `durable� hello`; this HEAD rejects them as `Matrix durable delivery plan is invalid JSON`.
- The valid UTF-8 negative control is accepted on this HEAD.
- Focused Matrix test: `./node_modules/.bin/vitest run --config test/vitest/vitest.extension-matrix.config.ts matrix/src/matrix/delivery-plan.test.ts --reporter=dot` — 1 file passed, 9 tests passed.
- Owning lanes passed: changed-file format check, changed-file extension lint, `tsgo:extensions`, and `tsgo:extensions:test`.
- Extension package-boundary compile passed for all 123 plugins.
- Canonical precedent: `src/infra/clawhub-client.ts:307` already uses `TextDecoder("utf-8", { fatal: true })` for validated response bytes; the existing Matrix invariant-error cleanup path is reused.

```text
$ node --import ./scripts/tsx.mjs proof-live.mts
entrypoint: loadMatrixDeliveryPlan from extensions/matrix/src/matrix/delivery-plan.ts
boundary: real plugin blob-store boundary
base 5bbd9f8e2ebcd9d1f0b72b3a547b80ba4d82713a: valid-control=accepted; corrupt-plan=accepted body=durable� hello
head ffe15b1b3e9298986458498cde6d34b4186d5833: valid-control=accepted; corrupt-plan=rejected error=Matrix durable delivery plan is invalid JSON
negative-control: valid-control=accepted on exact HEAD
```

<details>
<summary>Production proof source</summary>

```typescript
import fs from "node:fs";
import os from "node:os";
import path from "node:path";
import { pathToFileURL } from "node:url";

const repoRoot = process.env.OPENCLAW_PROOF_REPO ?? process.cwd();

const importFromRepo = async (relativePath: string) =>
  await import(pathToFileURL(path.join(repoRoot, relativePath)).href);

const { createPluginBlobStoreForTests, resetPluginBlobStoreForTests } = await importFromRepo(
  "src/plugin-sdk/plugin-state-test-runtime.ts",
);
const { setMatrixRuntime } = await importFromRepo("extensions/matrix/src/runtime.ts");
const {
  createMatrixPlannedEvents,
  loadMatrixDeliveryPlan,
  persistMatrixDeliveryPlan,
  resolveMatrixDurableDeliveryIdentity,
} = await importFromRepo("extensions/matrix/src/matrix/delivery-plan.ts");

const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-proof-"));
const queueId = "proof-invalid-utf8";
const roomId = "!room:example.org";
const transactionScopeId = "proof-scope";
const identity = resolveMatrixDurableDeliveryIdentity({ queueId, partIndex: 0, partCount: 1 });
if (!identity) {
  throw new Error("expected durable Matrix identity");
}

const blobOptions = {
  namespace: "outbound-delivery-plans",
  maxEntries: 10_000,
  maxBytesPerEntry: 8 * 1024 * 1024,
  maxBytesPerNamespace: 256 * 1024 * 1024,
  overflowPolicy: "reject-new" as const,
  defaultTtlMs: 24 * 60 * 60 * 1000,
};

setMatrixRuntime({
  config: {
    current: () => ({}),
    mutateConfigFile: async () => {},
    replaceConfigFile: async () => {},
  },
  state: {
    resolveStateDir: () => stateDir,
    openBlobStore: (options: typeof blobOptions) =>
      createPluginBlobStoreForTests("matrix", options, {
        ...process.env,
        OPENCLAW_STATE_DIR: stateDir,
      }),
  },
} as never);

const events = createMatrixPlannedEvents({
  identity,
  events: [{ receiptKind: "text", content: { msgtype: "m.text", body: "durable hello" } }],
});
const plan = await persistMatrixDeliveryPlan({
  identity,
  accountId: "default",
  roomId,
  transactionScopeId,
  wireEventType: "m.room.message",
  events,
  dispatch: {
    roomId,
    eventType: "m.room.message",
    transactionId: events[0]!.transactionId,
    requestPath: `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${events[0]!.transactionId}`,
  },
});

const valid = await loadMatrixDeliveryPlan({
  identity,
  accountId: "default",
  roomId,
  transactionScopeId,
  wireEventType: "m.room.message",
});
if (!valid) {
  throw new Error("expected valid persisted plan");
}
console.log("valid-control=accepted");

const store = createPluginBlobStoreForTests<Record<string, never>>("matrix", blobOptions, {
  ...process.env,
  OPENCLAW_STATE_DIR: stateDir,
});
const key = (await store.entries())[0]?.key;
if (!key) {
  throw new Error("expected one persisted plan entry");
}
const stored = await store.lookup(key);
if (!stored) {
  throw new Error("expected persisted plan bytes");
}
const json = JSON.stringify(plan);
const marker = "durable hello";
const markerOffset = json.indexOf(marker);
if (markerOffset < 0) {
  throw new Error("expected plan body marker");
}
const invalidByteOffset = markerOffset + "durable".length;
const prefix = new TextEncoder().encode(json.slice(0, invalidByteOffset));
const suffix = new TextEncoder().encode(json.slice(invalidByteOffset));
const invalidBytes = new Uint8Array(prefix.length + 1 + suffix.length);
invalidBytes.set(prefix);
invalidBytes[prefix.length] = 0xff;
invalidBytes.set(suffix, prefix.length + 1);
await store.register(key, invalidBytes, {});

try {
  const loaded = await loadMatrixDeliveryPlan({
    identity,
    accountId: "default",
    roomId,
    transactionScopeId,
    wireEventType: "m.room.message",
  });
  const body = loaded?.events[0]?.content.body;
  console.log(`corrupt-plan=accepted body=${String(body)}`);
} catch (error) {
  const message = error instanceof Error ? error.message : String(error);
  console.log(`corrupt-plan=rejected error=${message}`);
} finally {
  resetPluginBlobStoreForTests();
  fs.rmSync(stateDir, { recursive: true, force: true });
}
```

</details>

AI-assisted: built with Codex
