### PR TITLE
fix(agents): reject bundle LSP calls after disposal

### DIFF
--- a/src/agents/agent-bundle-lsp-runtime.test.ts
+++ b/src/agents/agent-bundle-lsp-runtime.test.ts
@@ -485,4 +485,29 @@ describe("bundle LSP runtime", () => {
     await runtime.dispose();
     expect(killProcessTreeMock).not.toHaveBeenCalled();
   });
+
+  it("rejects retained tools after the LSP runtime is disposed", async () => {
+    configureSingleLspServer();
+    const child = new MockChildProcess();
+    spawnMock.mockReturnValue(child);
+
+    const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
+    const hoverTool = runtime.tools.find((tool) => tool.name === "lsp_hover_typescript");
+    if (!hoverTool) {
+      throw new Error("expected hover tool");
+    }
+
+    await runtime.dispose();
+
+    await expect(
+      hoverTool.execute("retained-call", {
+        uri: "file:///tmp/workspace/index.ts",
+        line: 0,
+        character: 0,
+      }),
+    ).rejects.toThrow("LSP session disposed");
+    expect(child.receivedMessages).not.toContainEqual(
+      expect.objectContaining({ method: "textDocument/hover" }),
+    );
+  });
 });

--- a/src/agents/agent-bundle-lsp-runtime.test.ts
+++ b/src/agents/agent-bundle-lsp-runtime.test.ts
@@ -486,28 +486,85 @@ describe("bundle LSP runtime", () => {
     expect(killProcessTreeMock).not.toHaveBeenCalled();
   });
 
-  it("rejects retained tools after the LSP runtime is disposed", async () => {
+  it.each([
+    ["lsp_hover_typescript", "textDocument/hover"],
+    ["lsp_definition_typescript", "textDocument/definition"],
+    ["lsp_references_typescript", "textDocument/references"],
+  ])("rejects retained %s requests throughout disposal", async (toolName, method) => {
     configureSingleLspServer();
     const child = new MockChildProcess();
     spawnMock.mockReturnValue(child);
-
     const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
-    const hoverTool = runtime.tools.find((tool) => tool.name === "lsp_hover_typescript");
-    if (!hoverTool) {
+    const tool = runtime.tools.find((candidate) => candidate.name === toolName);
+    if (!tool) {
+      throw new Error(`expected ${toolName} tool`);
+    }
+    const input = { uri: "file:///tmp/workspace/index.ts", line: 0, character: 0 };
+    await tool.execute("before-dispose", input);
+
+    const disposal = runtime.dispose();
+    const during = await tool.execute("during-dispose", input).then(
+      () => "accepted",
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    );
+    await disposal;
+    const after = await tool.execute("after-dispose", input).then(
+      () => "accepted",
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    );
+
+    expect({ during, after }).toEqual({
+      during: "LSP session disposed",
+      after: "LSP session disposed",
+    });
+    expect(child.receivedMessages.filter((message) => message.method === method)).toHaveLength(1);
+    expect(child.receivedMessages.filter((message) => message.method === "shutdown")).toHaveLength(
+      1,
+    );
+    expect(child.receivedMessages.filter((message) => message.method === "exit")).toHaveLength(1);
+    expect(killProcessTreeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects outstanding requests before shutdown and detaches their abort listeners", async () => {
+    configureSingleLspServer();
+    const child = new MockChildProcess("", new Set(["initialize"]));
+    spawnMock.mockReturnValue(child);
+    const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
+    const hover = runtime.tools.find((tool) => tool.name === "lsp_hover_typescript");
+    if (!hover) {
       throw new Error("expected hover tool");
     }
+    const controller = new AbortController();
+    const pending = hover
+      .execute(
+        "pending",
+        {
+          uri: "file:///tmp/workspace/index.ts",
+          line: 0,
+          character: 0,
+        },
+        controller.signal,
+      )
+      .then(
+        () => "accepted",
+        (error: unknown) => (error instanceof Error ? error.message : String(error)),
+      );
 
-    await runtime.dispose();
+    const disposal = runtime.dispose();
+    const shutdown = child.receivedMessages.find((message) => message.method === "shutdown");
+    controller.abort(new Error("caller aborted during shutdown"));
+    const outcome = await pending;
+    child.stdout.write(encodeLspMessage({ jsonrpc: "2.0", id: shutdown?.id, result: null }));
+    await disposal;
 
-    await expect(
-      hoverTool.execute("retained-call", {
-        uri: "file:///tmp/workspace/index.ts",
-        line: 0,
-        character: 0,
-      }),
-    ).rejects.toThrow("LSP session disposed");
-    expect(child.receivedMessages).not.toContainEqual(
-      expect.objectContaining({ method: "textDocument/hover" }),
-    );
+    expect(outcome).toBe("LSP session disposed");
+    expect(child.receivedMessages.map((message) => message.method)).toEqual([
+      "initialize",
+      "initialized",
+      "textDocument/hover",
+      "shutdown",
+      "exit",
+    ]);
+    expect(killProcessTreeMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/agent-bundle-lsp-runtime.ts
+++ b/src/agents/agent-bundle-lsp-runtime.ts
@@ -247,12 +247,19 @@ function lspAbortError(signal?: AbortSignal): Error {
     : createAbortError("LSP request aborted", { cause: signal?.reason });
 }
 
+function lspSessionDisposedError(): Error {
+  return new Error("LSP session disposed");
+}
+
 function sendRequest(
   session: LspSession,
   method: string,
   params?: unknown,
   signal?: AbortSignal,
 ): Promise<unknown> {
+  if (session.disposed && method !== "shutdown") {
+    return Promise.reject(lspSessionDisposedError());
+  }
   if (session.failure) {
     return Promise.reject(session.failure);
   }
@@ -394,7 +401,7 @@ async function disposeSession(session: LspSession) {
       // best-effort
     }
   }
-  session.pendingRequests.rejectAll(new Error("LSP session disposed"));
+  session.pendingRequests.rejectAll(lspSessionDisposedError());
   terminateLspProcessTree(session);
 }
 

--- a/src/agents/agent-bundle-lsp-runtime.ts
+++ b/src/agents/agent-bundle-lsp-runtime.ts
@@ -257,6 +257,7 @@ function sendRequest(
   params?: unknown,
   signal?: AbortSignal,
 ): Promise<unknown> {
+  // Disposal closes tool requests before the child finishes its shutdown handshake.
   if (session.disposed && method !== "shutdown") {
     return Promise.reject(lspSessionDisposedError());
   }
@@ -387,6 +388,8 @@ async function disposeSession(session: LspSession) {
     return;
   }
   session.disposed = true;
+  // Release abort listeners before shutdown forbids cancellation notifications.
+  session.pendingRequests.rejectAll(lspSessionDisposedError());
   activeBundleLspSessions.delete(session);
 
   if (session.initialized) {


### PR DESCRIPTION
## What Problem This Solves

A retained bundle LSP tool could still send requests after its runtime began disposal. The child remains alive during the shutdown handshake, so waiting for process exit lets stale hover, definition, and references calls succeed. An outstanding request also retained its abort listener: aborting it during shutdown sent `$/cancelRequest` after `shutdown`.

## Why This Change Was Made

Close requests at their lifecycle owner. The canonical request function rejects new tool calls as soon as the existing session is disposed, while permitting the internal shutdown handshake. Disposal synchronously rejects outstanding requests before sending shutdown; the pending-request registry releases their abort listeners, so late caller aborts cannot write cancellation notifications. The final rejection remains to clean up a timed-out shutdown request. This preserves the [LSP shutdown contract](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#shutdown): only exit may follow shutdown.

## User Impact

Retained LSP handles and outstanding requests reject promptly when their runtime closes. Normal requests, cancellation before disposal, and the shutdown/exit handshake keep working. All three materialized tools share the same owner; no configuration, protocol, or persistent state changes.

## Evidence

Before editing production, independently authored regressions on trusted main `37db48c3e93cef9330bad6de67fd7d77183e05da` showed all three retained methods succeeding during shutdown and after `dispose()` returned. The expanded tests first perform valid requests and then assert rejection without further child requests. A separate outstanding-request test failed on the initial request-gate-only repair: a caller abort during held shutdown won over disposal and emitted cancellation. After moving pending-request rejection to disposal entry, all 24 tests in `src/agents/agent-bundle-lsp-runtime.test.ts` pass, including normal cancellation, transport failure, final stdout drainage, framing, and global cleanup.

The real-process harness below uses `createBundleLspToolRuntime`, production spawn/framing/cleanup, and a synthetic Node child whose shutdown reply is held. The first probe showed each method reaching the live child twice before the repair and once afterward. The extended probe preserves normal pre-disposal cancellation, then starts another outstanding request and aborts it during shutdown. Before the owner-order repair it records a second cancellation after shutdown; afterward the outstanding request rejects as disposed and the only cancellation precedes shutdown. Retained tool calls still reject, shutdown/exit are recorded, and the child closes. This is a real local LSP-process boundary, not editor or external-provider proof.

Node 24.20.0 extended real-process wall times were 4.07 seconds before the owner-order repair and 5.85 seconds after; the JSON below records process RSS and the measured harness duration. These are proof observations, not a performance claim. The full repaired 24-test command took 25.69 seconds, maximum RSS 1,710,211,072 bytes. The recorded passing source hash precedes only an explanatory lifecycle comment; production behavior and tests are identical to the candidate. Contributor code was not executed locally.

Production +11/-1 (net+10), tests +82/-0. The bounded growth adds one shared lifecycle gate, centralizes the disposal error, releases pending requests before protocol shutdown, and explains both ordering constraints. A per-tool guard or another cancellation guard would duplicate ownership. This addresses the latest ClawSweeper production-growth note. Contributor ancestry and credit are preserved. Thanks @qingminglong.

Changed-scope validation passed formatting, core and core-test typechecks, targeted lint, and required repository guards. The full checker covered the initial guard and poll repair; the added pending-request repair passed fresh core/test typechecks, targeted lint, formatting, the full 24-test owner suite, and the real-child probe. The temporary full-check checkout initially lacked the UI workspace dependency link and resolved an older root pako without declarations; linking the existing pinned UI installation corrected that checkout layout, with no dependency or source change.

Published-head CI is green. The real-child runtime results above are from separately authored equivalents on trusted main; hosted CI also executes the exact published source.

Run from the reviewed, dependency-complete checkout with Node 24:

```sh
node --import ./scripts/tsx.mjs /path/to/probe.mts "$PWD"
```

<details>
<summary>Inspectable synthetic proof harness</summary>

```typescript
// Authored proof draft: run only in a released, dependency-complete trusted checkout.
// Exercises the public runtime factory, production spawn/framing, and tree cleanup.
import assert from "node:assert/strict";
import { createHash } from "node:crypto";
import { readFile } from "node:fs/promises";
import path from "node:path";
import { performance } from "node:perf_hooks";
import { pathToFileURL } from "node:url";
import type { ChildProcess } from "node:child_process";

const repo = process.argv[2];
if (!repo) throw new Error("usage: tools-lsp-real-probe.mts <trusted-checkout>");
const started = performance.now();
const owner = path.join(repo, "src/agents/agent-bundle-lsp-runtime.ts");
const { createBundleLspToolRuntime } = await import(pathToFileURL(owner).href);
const { defaultBundleLspRuntimeDependencies: defaults } = await import(
  pathToFileURL(path.join(repo, "src/agents/agent-bundle-lsp-dependencies.ts")).href
);
const childSource = String.raw`
let buffer = Buffer.alloc(0);
let shutdownId;
function send(id, result) {
  const body = JSON.stringify({ jsonrpc: "2.0", id, result });
  process.stdout.write("Content-Length: " + Buffer.byteLength(body) + "\r\n\r\n" + body);
}
process.on("SIGUSR1", () => {
  if (shutdownId !== undefined) send(shutdownId, null);
});
process.stdin.on("data", (chunk) => {
  buffer = Buffer.concat([buffer, chunk]);
  for (;;) {
    const end = buffer.indexOf("\r\n\r\n");
    if (end < 0) return;
    const size = Number(/Content-Length: (\d+)/i.exec(buffer.subarray(0, end).toString())[1]);
    if (buffer.length < end + 4 + size) return;
    const msg = JSON.parse(buffer.subarray(end + 4, end + 4 + size));
    buffer = buffer.subarray(end + 4 + size);
    process.stderr.write(JSON.stringify({ method: msg.method }) + "\n");
    if (msg.method === "initialize") {
      send(msg.id, { capabilities: { hoverProvider: true, definitionProvider: true, referencesProvider: true } });
    } else if (msg.method === "shutdown") {
      shutdownId = msg.id;
    } else if (msg.method === "exit") {
      process.exit(0);
    } else if (typeof msg.id === "number" && msg.params?.position?.character !== 1) {
      send(msg.id, { contents: "synthetic response", method: msg.method });
    }
  }
});
`;
let child: ChildProcess | undefined;
let runtime: Awaited<ReturnType<typeof createBundleLspToolRuntime>> | undefined;
let disposal: Promise<void> | undefined;
let childClosed: Promise<void> | undefined;
const methods: string[] = [];
let stderrBuffer = "";
let announceShutdown!: () => void;
const shutdownSeen = new Promise<void>((resolve) => { announceShutdown = resolve; });
const observations: Array<Record<string, unknown>> = [];
let closeCode: number | null | undefined;
let closeSignal: NodeJS.Signals | null | undefined;
const deadlines = new Set<ReturnType<typeof setTimeout>>();
function bounded<T>(promise: Promise<T>, label: string): Promise<T> {
  let timer: ReturnType<typeof setTimeout>;
  const deadline = new Promise<never>((_, reject) => {
    timer = setTimeout(() => reject(new Error(`proof deadline: ${label}`)), 3_000);
    deadlines.add(timer);
  });
  return Promise.race([promise, deadline]).finally(() => {
    clearTimeout(timer);
    deadlines.delete(timer);
  });
}
const input = { uri: "file:///synthetic/proof.ts", line: 0, character: 0 };
try {
  assert.notEqual(process.platform, "win32", "this POSIX child-control probe uses SIGUSR1");
  runtime = await bounded(createBundleLspToolRuntime({
    workspaceDir: repo,
    dependencies: {
      ...defaults,
      loadLspConfig: () => ({
        lspServers: { proof: { command: process.execPath, args: ["-e", childSource] } },
        diagnostics: [],
      }),
      spawnServerProcess: (config: unknown) => {
        child = defaults.spawnServerProcess(config);
        childClosed = new Promise<void>((resolve) => {
          child!.once("close", (code, signal) => { closeCode = code; closeSignal = signal; resolve(); });
        });
        child!.stderr!.on("data", (chunk) => {
          stderrBuffer += chunk.toString();
          let end: number;
          while ((end = stderrBuffer.indexOf("\n")) !== -1) {
            const line = stderrBuffer.slice(0, end);
            stderrBuffer = stderrBuffer.slice(end + 1);
            const record = JSON.parse(line);
            methods.push(record.method);
            if (record.method === "shutdown") announceShutdown();
          }
        });
        return child;
      },
    },
  }), "initialize");
  assert.equal(runtime.tools.length, 3);
  for (const tool of runtime.tools) {
    await bounded(tool.execute("before-dispose", input), `valid ${tool.name}`);
  }
  const hover = runtime.tools.find((tool: any) => tool.name === "lsp_hover_proof");
  assert(hover);
  const normalAbort = new AbortController();
  const normalPending = hover.execute("normal-abort", { ...input, character: 1 }, normalAbort.signal).then(
    () => "accepted", (error: unknown) => error instanceof Error ? error.message : String(error),
  );
  normalAbort.abort(new Error("normal caller abort"));
  assert.equal(await normalPending, "normal caller abort");
  const controller = new AbortController();
  const outstanding = hover.execute("outstanding-at-dispose", { ...input, character: 1 }, controller.signal).then(
    () => "accepted", (error: unknown) => error instanceof Error ? error.message : String(error),
  );
  disposal = runtime.dispose();
  await bounded(shutdownSeen, "shutdown reached child");
  assert.equal(child!.exitCode, null);
  assert.equal(child!.signalCode, null);
  controller.abort(new Error("caller aborted during shutdown"));
  const outstandingOutcome = await bounded(outstanding, "outstanding request settlement");
  for (const tool of runtime.tools) {
    const outcome = await bounded(tool.execute("during-dispose", input).then(
      () => "accepted",
      (error: unknown) => error instanceof Error ? error.message : String(error),
    ), `retained ${tool.name}`);
    observations.push({ tool: tool.name, phase: "shutdown-pending", outcome });
  }
  // Release only the synthetic server's held response; runtime still owns exit/termination.
  child!.kill("SIGUSR1");
  await bounded(disposal, "dispose");
  await bounded(childClosed!, "child close");
  const expectedMethods = ["textDocument/hover", "textDocument/definition", "textDocument/references"];
  const requestCounts = Object.fromEntries(expectedMethods.map((method) => [
    method, methods.filter((seen) => seen === method).length,
  ]));
  const passed = observations.every((entry) => entry.outcome === "LSP session disposed") &&
    requestCounts["textDocument/hover"] === 3 && requestCounts["textDocument/definition"] === 1 &&
    requestCounts["textDocument/references"] === 1 && outstandingOutcome === "LSP session disposed" &&
    !methods.slice(methods.indexOf("shutdown") + 1).includes("$/cancelRequest") &&
    methods.filter((method) => method === "$/cancelRequest").length === 1 &&
    methods.filter((method) => method === "shutdown").length === 1;
  console.log(JSON.stringify({
    passed, sourceSha256: createHash("sha256").update(await readFile(owner)).digest("hex"),
    node: process.version, platform: process.platform, observations, requestCounts, methods,
    outstandingOutcome, normalAbortOutcome: "normal caller abort",
    closeCode, closeSignal, wallMs: performance.now() - started, rssBytes: process.memoryUsage().rss,
  }, null, 2));
  if (!passed) process.exitCode = 1;
} finally {
  if (child && child.exitCode === null && child.signalCode === null) {
    child.kill("SIGUSR1");
  }
  await disposal?.catch(() => undefined);
  if (runtime && !disposal) await runtime.dispose();
  if (childClosed) await bounded(childClosed, "final child cleanup");
  for (const timer of deadlines) clearTimeout(timer);
}
```

</details>

<details>
<summary>Before owner-order repair: retained requests blocked, outstanding abort still leaks after shutdown</summary>

```json
{
  "passed": false,
  "sourceSha256": "28e047dd5ee03987546da352ab3b76d45e0db12b0a1bf330b55e8b8943aec8fe",
  "node": "v24.20.0",
  "platform": "darwin",
  "observations": [
    {
      "tool": "lsp_hover_proof",
      "phase": "shutdown-pending",
      "outcome": "LSP session disposed"
    },
    {
      "tool": "lsp_definition_proof",
      "phase": "shutdown-pending",
      "outcome": "LSP session disposed"
    },
    {
      "tool": "lsp_references_proof",
      "phase": "shutdown-pending",
      "outcome": "LSP session disposed"
    }
  ],
  "requestCounts": {
    "textDocument/hover": 3,
    "textDocument/definition": 1,
    "textDocument/references": 1
  },
  "methods": [
    "initialize",
    "initialized",
    "textDocument/hover",
    "textDocument/definition",
    "textDocument/references",
    "textDocument/hover",
    "$/cancelRequest",
    "textDocument/hover",
    "shutdown",
    "$/cancelRequest",
    "exit"
  ],
  "outstandingOutcome": "caller aborted during shutdown",
  "normalAbortOutcome": "normal caller abort",
  "closeCode": null,
  "closeSignal": "SIGTERM",
  "wallMs": 3881.992875,
  "rssBytes": 346505216
}
```

</details>

<details>
<summary>After owner-order repair: normal cancellation preserved, no cancellation after shutdown</summary>

```json
{
  "passed": true,
  "sourceSha256": "1a038c6967b10889c9598d59c31b09b2f73f5e5df82871945c1a9583538830c7",
  "node": "v24.20.0",
  "platform": "darwin",
  "observations": [
    {
      "tool": "lsp_hover_proof",
      "phase": "shutdown-pending",
      "outcome": "LSP session disposed"
    },
    {
      "tool": "lsp_definition_proof",
      "phase": "shutdown-pending",
      "outcome": "LSP session disposed"
    },
    {
      "tool": "lsp_references_proof",
      "phase": "shutdown-pending",
      "outcome": "LSP session disposed"
    }
  ],
  "requestCounts": {
    "textDocument/hover": 3,
    "textDocument/definition": 1,
    "textDocument/references": 1
  },
  "methods": [
    "initialize",
    "initialized",
    "textDocument/hover",
    "textDocument/definition",
    "textDocument/references",
    "textDocument/hover",
    "$/cancelRequest",
    "textDocument/hover",
    "shutdown",
    "exit"
  ],
  "outstandingOutcome": "LSP session disposed",
  "normalAbortOutcome": "normal caller abort",
  "closeCode": null,
  "closeSignal": "SIGTERM",
  "wallMs": 5327.99325,
  "rssBytes": 353878016
}
```

</details>


The exact published commit `5820ed59acc3224fef2a32c6ee6ce418a5af9a3d` passes [CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/33430734888/attempts/2). All 24 LSP owner tests, including the three retained-tool cases and pending-abort ordering regression, passed in the original [LSP test job](https://github.com/openclaw/openclaw/actions/runs/33430734888/job/99615532248).

The first full run failed during an unchanged UI shared-page startup: the fixture did not become visible before its existing deadline, and the rejected setup promise propagated to later cases. The complete UI, test harness, workflow and dependency inputs matched a successful companion run. One failed-jobs-only rerun, with no code, deadline or assertion change, [passed all affected cases in their original order](https://github.com/openclaw/openclaw/actions/runs/33430734888/job/99622683476). The initial render stall remains unexplained; a repeat should capture page, request and Vite diagnostics at shared setup rather than increase timeouts.
