### PR TITLE
fix(cron): reload scheduler-disabled store and preserve newer runtime on config writes

### DIFF
--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -8,9 +8,9 @@ import {
 } from "../../state/openclaw-state-db.js";
 import { setupCronServiceSuite } from "../service.test-harness.js";
 import * as cronStoreModule from "../store.js";
+import { loadCronStore, saveCronStore } from "../store.js";
 import { cronStoreKey } from "../store/key.js";
 import { updateCronRuntimeRows } from "../store/row-codec.js";
-import { loadCronStore, saveCronStore } from "../store.js";
 import {
   claimCronRunReceiptInDatabase,
   CronRunReceiptConflictError,

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -8,6 +8,8 @@ import {
 } from "../../state/openclaw-state-db.js";
 import { setupCronServiceSuite } from "../service.test-harness.js";
 import * as cronStoreModule from "../store.js";
+import { cronStoreKey } from "../store/key.js";
+import { updateCronRuntimeRows } from "../store/row-codec.js";
 import { loadCronStore, saveCronStore } from "../store.js";
 import {
   claimCronRunReceiptInDatabase,
@@ -42,10 +44,10 @@ async function expectPathMissing(targetPath: string): Promise<void> {
   await expect(fs.stat(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
 }
 
-function createStoreTestState(storePath: string, onEvent = vi.fn()) {
+function createStoreTestState(storePath: string, onEvent = vi.fn(), cronEnabled = true) {
   return createCronServiceState({
     storePath,
-    cronEnabled: true,
+    cronEnabled,
     log: logger,
     nowMs: () => STORE_TEST_NOW,
     enqueueSystemEvent: vi.fn(),
@@ -135,6 +137,63 @@ describe("cron service store seam coverage", () => {
     await expectPathMissing(storePath);
 
     await persist(state);
+  });
+
+  it("reloads shared state for a scheduler-disabled service", async () => {
+    const { storePath } = await makeStorePath();
+    const initial = createReloadCronJob({
+      updatedAtMs: 1_000,
+      state: { nextRunAtMs: 2_000 },
+    });
+    await saveCronStore(storePath, { version: 1, jobs: [initial] });
+    const state = createStoreTestState(storePath, vi.fn(), false);
+    await ensureLoaded(state, { skipRecompute: true });
+
+    const advancedRuntime = {
+      ...initial,
+      updatedAtMs: 8_000,
+      state: { nextRunAtMs: 9_000, lastRunAtMs: 8_000, lastRunStatus: "ok" as const },
+    };
+    // A separate gateway writes the same SQLite partition, so this process
+    // does not receive the in-memory revision notification.
+    runOpenClawStateWriteTransaction(({ db }) => {
+      updateCronRuntimeRows(db, cronStoreKey(storePath), {
+        version: 1,
+        jobs: [advancedRuntime],
+      });
+    });
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    expect(findJobOrThrow(state, initial.id)).toMatchObject(advancedRuntime);
+  });
+
+  it("keeps the scheduler-enabled service cache without a local commit notification", async () => {
+    const { storePath } = await makeStorePath();
+    const initial = createReloadCronJob({
+      updatedAtMs: 1_000,
+      state: { nextRunAtMs: 2_000 },
+    });
+    await saveCronStore(storePath, { version: 1, jobs: [initial] });
+    const state = createStoreTestState(storePath);
+    await ensureLoaded(state, { skipRecompute: true });
+
+    runOpenClawStateWriteTransaction(({ db }) => {
+      updateCronRuntimeRows(db, cronStoreKey(storePath), {
+        version: 1,
+        jobs: [
+          {
+            ...initial,
+            updatedAtMs: 8_000,
+            state: { nextRunAtMs: 9_000, lastRunAtMs: 8_000, lastRunStatus: "ok" },
+          },
+        ],
+      });
+    });
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    expect(findJobOrThrow(state, initial.id)).toMatchObject(initial);
   });
 
   it("quarantines malformed SQLite rows atomically without creating JSON state", async () => {

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -153,7 +153,7 @@ export async function ensureLoaded(
 ) {
   // Keep scheduler-local pacing/catch-up mutations unless another in-process
   // owner actually committed a newer snapshot for this SQLite partition.
-  if (state.store && !opts?.forceReload) {
+  if (state.store && !opts?.forceReload && state.deps.cronEnabled) {
     const loadedRevision = loadedCronStoreRevisions.get(state);
     if (
       loadedRevision === undefined ||

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -10,7 +10,10 @@ import {
   archiveLegacyCronStoreForMigration,
   loadLegacyCronStoreForMigration,
 } from "../commands/doctor/cron/legacy-store-migration.js";
-import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import {
   loadCronJobsStoreWithConfigJobs,
@@ -23,6 +26,8 @@ import {
   saveCronQuarantinedJobs,
   saveCronStore,
 } from "./store.js";
+import { cronStoreKey } from "./store/key.js";
+import { updateCronRuntimeRows } from "./store/row-codec.js";
 import { saveCronJobsStoreWithTransactionHooks } from "./store/transaction-hooks.js";
 import type { CronStoreFile } from "./types.js";
 
@@ -206,6 +211,50 @@ describe("cron store", () => {
       expect((await loadCronStore(storePath)).jobs[0]).toStrictEqual(job);
     },
   );
+
+  it("preserves newer runtime state during an unrelated full config rewrite", async () => {
+    const { storePath } = await makeStorePath();
+    const initial = makeStore("runtime-owner", true);
+    const sibling = makeStore("config-editor", true).jobs[0];
+    if (!sibling) {
+      throw new Error("expected sibling cron job");
+    }
+    initial.jobs.push(sibling);
+    const runtimeOwner = expectDefined(initial.jobs[0], "expected runtime owner cron job");
+    runtimeOwner.state = { nextRunAtMs: 2_000 };
+    runtimeOwner.updatedAtMs = 1_000;
+    sibling.updatedAtMs = 1_000;
+    await saveCronStore(storePath, initial);
+    const staleSnapshot = structuredClone(await loadCronStore(storePath));
+
+    const advancedRuntime = {
+      ...runtimeOwner,
+      updatedAtMs: 8_000,
+      state: { nextRunAtMs: 9_000, lastRunAtMs: 8_000, lastRunStatus: "ok" as const },
+    };
+    runOpenClawStateWriteTransaction(({ db }) => {
+      updateCronRuntimeRows(db, cronStoreKey(storePath), {
+        version: 1,
+        jobs: [advancedRuntime],
+      });
+    });
+
+    const staleSibling = expectDefined(
+      staleSnapshot.jobs.find((job) => job.id === sibling.id),
+      "expected stale sibling cron job",
+    );
+    staleSibling.description = "updated through the management gateway";
+    staleSibling.updatedAtMs = 2_000;
+    await saveCronStore(storePath, staleSnapshot);
+
+    const persistedById = new Map(
+      (await loadCronStore(storePath)).jobs.map((job) => [job.id, job]),
+    );
+    expect(persistedById.get(runtimeOwner.id)).toMatchObject(advancedRuntime);
+    expect(persistedById.get(sibling.id)?.description).toBe(
+      "updated through the management gateway",
+    );
+  });
 
   it("throws when doctor migration reads invalid legacy JSON", async () => {
     const store = await makeStorePath();

--- a/src/cron/store/row-codec.ts
+++ b/src/cron/store/row-codec.ts
@@ -286,16 +286,11 @@ export function replaceCronRows(
   storeKey: string,
   store: CronStoreFile,
 ): CronStoredJob[] {
-  const existingRows = executeSqliteQuerySync(
-    db,
-    getCronStoreKysely(db)
-      .selectFrom("cron_jobs")
-      .select("job_id")
-      .where("store_key", "=", storeKey),
-  ).rows;
+  const existingRows = loadCronRows(db, storeKey);
+  const existingRowsById = new Map(existingRows.map((row) => [row.job_id, row]));
   const normalizedJobs: CronStoredJob[] = [];
   for (const [index, job] of store.jobs.entries()) {
-    normalizedJobs.push(upsertCronJobRow(db, storeKey, job, index));
+    normalizedJobs.push(upsertCronJobRow(db, storeKey, job, index, existingRowsById));
   }
   const nextJobIds = new Set(normalizedJobs.map((job) => job.id));
   for (const row of existingRows) {
@@ -321,10 +316,27 @@ export function upsertCronJobRow(
   storeKey: string,
   job: CronStoredJob,
   sortOrder: number,
+  existingRowsById?: ReadonlyMap<string, CronJobRow>,
 ): CronStoredJob {
-  const normalized = normalizeCronJobForSqlite(job);
+  let normalized = normalizeCronJobForSqlite(job);
   if (!normalized) {
     throw new Error(`Cannot persist invalid cron job ${job.id}`);
+  }
+  const existingRow = existingRowsById?.get(normalized.id);
+  if (
+    existingRow?.job_json === JSON.stringify(stripJobRuntimeFields(normalized)) &&
+    normalizeNumber(existingRow.runtime_updated_at_ms) !== undefined
+  ) {
+    const persisted = rowToCronJob(existingRow, tryParseJsonObject(existingRow.job_json) ?? {});
+    if (persisted && persisted.updatedAtMs > normalized.updatedAtMs) {
+      // Preserve runtime written by another gateway while this full config
+      // rewrite updates an unrelated, configuration-identical row.
+      normalized = {
+        ...normalized,
+        state: structuredClone(persisted.state),
+        updatedAtMs: persisted.updatedAtMs,
+      };
+    }
   }
   const values = bindCronJobRow(storeKey, normalized, sortOrder);
   executeSqliteQuerySync(


### PR DESCRIPTION
## What Problem This Solves

Fixes #131401.

When two gateways share the same SQLite cron store — gateway A exposing cron RPC/agent CRUD with `cron.enabled=false`, gateway B owning scheduling with `cron.enabled=true` — an unrelated CRUD mutation in gateway A could overwrite fresher runtime state (`nextRunAtMs`, `lastRunAtMs`, `runningAtMs`) that gateway B had already persisted. `nextRunAtMs` could move backwards and a completed occurrence could become eligible again.

Two independent gaps caused this:

- `ensureLoaded` only invalidated the service snapshot when the process-local `cronStoreRevisions` map changed. A write from another process never touched that map, so a scheduler-disabled gateway kept its stale snapshot indefinitely.
- `replaceCronRows` calls `upsertCronJobRow` for every job in the in-memory store, and `bindCronJobRow` binds both `state_json` and `runtime_updated_at_ms`, so a full config rewrite replayed stale runtime fields onto rows that had not changed.

## Why This Change Was Made

Two small, targeted fixes:

1. `src/cron/service/store.ts` — the revision-based cache short-circuit in `ensureLoaded` now applies only when the service owns scheduling (`state.deps.cronEnabled`). A scheduler-disabled service always reloads from the shared store before a CRUD operation. The scheduler-enabled single-gateway path is unchanged and keeps its local pacing/catch-up mutations.
2. `src/cron/store/row-codec.ts` — `replaceCronRows` now loads the full existing rows once and hands them to `upsertCronJobRow`. If the persisted row is configuration-identical (`job_json` after stripping runtime fields matches) and carries a newer `updatedAtMs`, the upsert preserves the persisted `state` and `updatedAtMs` instead of replaying the in-memory snapshot. This runs inside the existing SQLite write transaction; no schema change.

## User Impact

Multi-gateway deployments that share one cron store no longer lose scheduler runtime state on unrelated cron edits, and completed occurrences are not re-admitted. Single-gateway behavior is unchanged.

## Evidence

Validation on `a26e69ed2090`, rebased onto `origin/main` at `160c34d86b`.

### Real two-gateway behavior proof (live processes, one shared SQLite state)

Same topology for both runs, on one Linux host (Node v22.23.2), both gateways built from source and started as transient systemd units:

- **Scheduler gateway** — `cron.enabled: true`, `--bind loopback`, runs as root.
- **Management gateway** — `cron.enabled: false`, its own `OPENCLAW_CONFIG_PATH`, the **same `OPENCLAW_STATE_DIR`**, so both processes open the same `state/openclaw.sqlite` and the same cron `store_key`. The gateway-lifecycle state lock is keyed per uid, so the management gateway was started under `unshare -U --map-user=65534 --map-group=65534` (same approach as #131733) to hold concurrent ownership of one state directory; that only changes the lock directories (`state/tmp/openclaw-0` vs `openclaw-65534`, `/tmp/openclaw-state-locks-<uid>`), not the store.
- **After-fix build:** this exact head, `pnpm build:docker` (`OPENCLAW_RUN_NODE_SKIP_DTS_BUILD=1`); `openclaw --version` → `OpenClaw 2026.8.1 (a26e69e)`, `dist/build-info.json.commit = a26e69ed2090552dcb6d8cfdbfa9da48df66875d`; ports 19871 (scheduler) / 19872 (management).
- **Before-fix build:** `origin/main` at `77eb6197884b` (pre-PR, no `existingRowsById` in `dist/`), full `pnpm build`; ports 19873 / 19874, separate state directory.
- **Jobs:** A = `proof-canary` (`--every 20s --command 'echo canary-ran' --no-deliver`, a command payload so no model is involved), B = `proof-edit-target` (`--cron "0 6 * * *" --system-event …`, never due during the run). Both created through the management gateway.
- **Observation points:** `openclaw cron status|list|get|runs --json` against each port, plus direct reads of `cron_jobs` (`state_json`, `runtime_updated_at_ms`, `updated_at`, `job_json.description`) at T0/T1/T2/T3. Epoch values are UTC ms; `--url`/`--token` are stripped from the transcript.

| # | Step | Expected after the fix | Observed on `a26e69ed2090` (after fix) | Observed on `77eb6197884b` (`origin/main`, before fix) |
|---|---|---|---|---|
| a | CRUD through the scheduler-disabled gateway: `cron add` ×2, `cron edit`, `cron rm` ×2 | Persisted to the shared store; the scheduler gateway picks the changes up | ✅ rows present in `cron_jobs` immediately; the scheduler gateway listed the new jobs after 20 s, the edit after 11 s, the removal after 6 s | same (35 s / 11 s / 6 s) — this path is not changed by the PR |
| b | Scheduler runtime advancement for job A (`every 20s`) | `lastRunAtMs`, `nextRunAtMs`, `lastStatus`, `runtime_updated_at_ms` advance, written by the scheduler gateway | ✅ T0→T1: `lastRunAtMs` 18:48:39.983 → 18:48:59.997, `nextRunAtMs` +20 s, `lastStatus=ok`; `cron runs` shows a steady 20 s cadence | same |
| c | Unrelated config write through the disabled gateway (`cron edit <jobB> --description …`) after job A's runtime moved past that gateway's startup snapshot | Job A's next/last-run state is retained; only job B changes | ✅ **RETAINED** — T1 == T2 for job A: `lastRunAtMs=1788115739997`, `nextRunAtMs=1788115759997`, `runtime_updated_at_ms=1788115740038`; job B got the new description and `updated_at` | ❌ **CLOBBERED** — `lastRunAtMs` erased, `nextRunAtMs` rolled back 18:47:25.453 → 18:46:32.073 (the T0 value, already in the past), `runtime_updated_at_ms` rolled back 18:47:05.483 → 18:46:12.073 |
| d | Disabled gateway reloads the shared store before/for its reads | `cron list` on the disabled gateway reports the scheduler-written runtime, not its own stale snapshot | ✅ **FRESH** — :19872 reports `lastRunAtMs=1788115739997`, equal to the store row | ❌ **STALE** — :19874 still reports job A with no `lastRunAtMs` and the T0 `nextRunAtMs` |
| e | After the edit the scheduler keeps its cadence; no completed occurrence is re-admitted | T3 > T2, runs continue every 20 s | ✅ T3 `lastRunAtMs=18:49:40.033`; `cron runs`: 18:48:40 / 18:49:00 / 18:49:20 / 18:49:40, all `ok` | the scheduler's in-memory pacing kept running, but the persisted row was already wrong (see c): any store reload/restart would re-admit the 18:46:32 occurrence |

<details>
<summary>After-fix transcript — <code>a26e69ed2090</code>, scheduler :19871 / management :19872 (redacted; per-run diagnostics blobs trimmed)</summary>

```text
===== after-fix : OpenClaw 2026.8.1 (a26e69e) | state=/tmp/oc-cron-proof/state | scheduler=:19871 (cron.enabled=true) | management=:19872 (cron.enabled=false) =====
[18:48:11] # step 1: scheduler status on both gateways
[18:48:11] $ [gw :19871] openclaw cron status --json
{"enabled":true,"storage":"sqlite","jobs":3,"nextWakeAtMs":1788115927093}
[18:48:13] $ [gw :19872] openclaw cron status --json
{"enabled":false,"storage":"sqlite","jobs":3,"nextWakeAtMs":null}
[18:48:14] # step 2 (a): CRUD through the scheduler-DISABLED gateway :19872 — add job A (every 20s command) and job B (daily system event)
[18:48:14] $ [gw :19872] openclaw cron add --name proof-canary --every 20s --command echo canary-ran --no-deliver
warning: the automations scheduler is disabled in the Gateway; jobs are saved but will not run automatically.
[18:48:16] $ [gw :19872] openclaw cron add --name proof-edit-target --cron 0 6 * * * --system-event proof edit target --session main --description initial description
warning: the automations scheduler is disabled in the Gateway; jobs are saved but will not run automatically.
[18:48:18] # step 3: both gateways list the jobs (T0)
--- :19872 (management) immediately ---
[18:48:18] $ [gw :19872] openclaw cron list --all --json
{"name":"proof-canary","enabled":true,"description":null,"updatedAtMs":1788115696721,"state":{"nextRunAtMs":1788115716721},"status":"idle"}
{"name":"proof-edit-target","enabled":true,"description":"initial description","updatedAtMs":1788115698527,"state":{"nextRunAtMs":1788156000000},"status":"idle"}
[18:48:40] scheduler gateway :19871 listed both jobs added by the management gateway after 20 s
--- :19871 (scheduler) ---
[18:48:40] $ [gw :19871] openclaw cron list --all --json
{"name":"proof-canary","enabled":true,"description":null,"updatedAtMs":1788115720022,"state":{"nextRunAtMs":1788115739983,"lastRunAtMs":1788115719983,"lastRunStatus":"ok","lastStatus":"ok","lastDurationMs":39,"lastDiagnosticSummary":"canary-ran"},"status":"ok"}
{"name":"proof-edit-target","enabled":true,"description":"initial description","updatedAtMs":1788115698527,"state":{"nextRunAtMs":1788156000000},"status":"idle"}
[18:48:42] $ [sqlite] cron_jobs proof-* rows (T0)
proof-canary enabled=1 updated_at=18:48:40.022 runtime_updated_at_ms=18:48:40.022 state={"nextRunAtMs":1788115739983,"lastRunAtMs":1788115719983,"lastRunStatus":"ok","lastStatus":"ok","lastDurationMs":39,"lastDiagnosticSummary":"canary-ran"} desc=""
proof-edit-target enabled=1 updated_at=18:48:18.527 runtime_updated_at_ms=18:48:18.527 state={"nextRunAtMs":1788156000000} desc="initial description"
[18:48:42] # step 4 (b): wait for the scheduler gateway :19871 to run job A at least twice (runtime advancement)
[18:49:00] $ [sqlite] cron_jobs proof-* rows (T1)
proof-canary enabled=1 updated_at=18:49:00.038 runtime_updated_at_ms=18:49:00.038 state={"nextRunAtMs":1788115759997,"lastRunAtMs":1788115739997,"lastRunStatus":"ok","lastStatus":"ok","lastDurationMs":41,"lastDiagnosticSummary":"canary-ran"} desc=""
proof-edit-target enabled=1 updated_at=18:48:18.527 runtime_updated_at_ms=18:48:18.527 state={"nextRunAtMs":1788156000000} desc="initial description"
--- :19871 (scheduler) ---
[18:49:00] $ [gw :19871] openclaw cron list --all --json
{"name":"proof-canary","enabled":true,"description":null,"updatedAtMs":1788115740038,"state":{"nextRunAtMs":1788115759997,"lastRunAtMs":1788115739997,"lastRunStatus":"ok","lastStatus":"ok","lastDurationMs":41,"lastDiagnosticSummary":"canary-ran"},"status":"ok"}
{"name":"proof-edit-target","enabled":true,"description":"initial description","updatedAtMs":1788115698527,"state":{"nextRunAtMs":1788156000000},"status":"idle"}
--- :19872 (management, cron.enabled=false) — must show the runtime the scheduler wrote (d: store reload) ---
[18:49:02] $ [gw :19872] openclaw cron list --all --json
{"name":"proof-canary","enabled":true,"description":null,"updatedAtMs":1788115740038,"state":{"nextRunAtMs":1788115759997,"lastRunAtMs":1788115739997,"lastRunStatus":"ok","lastStatus":"ok","lastDurationMs":41,"lastDiagnosticSummary":"canary-ran"},"status":"ok"}
{"name":"proof-edit-target","enabled":true,"description":"initial description","updatedAtMs":1788115698527,"state":{"nextRunAtMs":1788156000000},"status":"idle"}
MGMT VIEW: FRESH — management gateway reports the scheduler-written lastRunAtMs=1788115739997
[18:49:05] # step 5 (c): UNRELATED config write through the management gateway :19872 — edit job B description
[18:49:05] $ [gw :19872] openclaw cron list --all --json
[18:49:07] $ [gw :19872] openclaw cron edit e46c1769-d3bc-4230-b588-136d930064b4 --description edited via scheduler-disabled gateway
[18:49:09] $ [sqlite] cron_jobs proof-* rows (T2)
proof-canary enabled=1 updated_at=18:49:00.038 runtime_updated_at_ms=18:49:00.038 state={"nextRunAtMs":1788115759997,"lastRunAtMs":1788115739997,"lastRunStatus":"ok","lastStatus":"ok","lastDurationMs":41,"lastDiagnosticSummary":"canary-ran"} desc=""
proof-edit-target enabled=1 updated_at=18:49:09.236 runtime_updated_at_ms=18:49:09.236 state={"nextRunAtMs":1788156000000} desc="edited via scheduler-disabled gateway"
job A (proof-canary) runtime: T1 lastRunAtMs=1788115739997 nextRunAtMs=1788115759997 runtime_updated_at_ms=1788115740038
job A (proof-canary) runtime: T2 lastRunAtMs=1788115739997 nextRunAtMs=1788115759997 runtime_updated_at_ms=1788115740038
RESULT: RETAINED — job A next/last-run state written by the scheduler survived the management-side edit of job B
[18:49:09] # step 6 (d): both gateways read the same post-edit state
--- :19872 (management) ---
[18:49:09] $ [gw :19872] openclaw cron list --all --json
{"name":"proof-canary","enabled":true,"description":null,"updatedAtMs":1788115740038,"state":{"nextRunAtMs":1788115759997,"lastRunAtMs":1788115739997,"lastRunStatus":"ok","lastStatus":"ok","lastDurationMs":41,"lastDiagnosticSummary":"canary-ran"},"status":"ok"}
{"name":"proof-edit-target","enabled":true,"description":"edited via scheduler-disabled gateway","updatedAtMs":1788115749236,"state":{"nextRunAtMs":1788156000000},"status":"idle"}
[18:49:22] scheduler gateway :19871 picked up the management-side edit of job B after 11 s
--- :19871 (scheduler) ---
[18:49:22] $ [gw :19871] openclaw cron list --all --json
{"name":"proof-canary","enabled":true,"description":null,"updatedAtMs":1788115760055,"state":{"nextRunAtMs":1788115780016,"lastRunAtMs":1788115760016,"lastRunStatus":"ok","lastStatus":"ok","lastDurationMs":39,"lastDiagnosticSummary":"canary-ran"},"status":"ok"}
{"name":"proof-edit-target","enabled":true,"description":"edited via scheduler-disabled gateway","updatedAtMs":1788115749236,"state":{"nextRunAtMs":1788156000000},"status":"idle"}
{"name":"proof-edit-target","description":"edited via scheduler-disabled gateway","updatedAtMs":1788115749236,"state":{"nextRunAtMs":1788156000000}}
[18:49:25] # step 7: scheduler keeps advancing job A after the edit (no re-admission of a completed occurrence)
[18:49:50] $ [sqlite] cron_jobs proof-* rows (T3)
proof-canary enabled=1 updated_at=18:49:40.076 runtime_updated_at_ms=18:49:40.076 state={"nextRunAtMs":1788115800033,"lastRunAtMs":1788115780033,"lastRunStatus":"ok","lastStatus":"ok","lastDurationMs":43,"lastDiagnosticSummary":"canary-ran"} desc=""
proof-edit-target enabled=1 updated_at=18:49:09.236 runtime_updated_at_ms=18:49:09.236 state={"nextRunAtMs":1788156000000} desc="edited via scheduler-disabled gateway"
[18:49:50] $ [gw :19872] openclaw cron list --all --json
[18:49:52] $ [gw :19871] openclaw cron runs --id ed298905-9e01-4342-981a-d01fe45ce69a --json
{"ts":1788115780076,"status":"ok","durationMs":43,"output":"canary-ran"}
{"ts":1788115760055,"status":"ok","durationMs":39,"output":"canary-ran"}
{"ts":1788115740038,"status":"ok","durationMs":41,"output":"canary-ran"}
{"ts":1788115720022,"status":"ok","durationMs":39,"output":"canary-ran"}
[18:49:53] # step 8: cleanup through the management gateway; scheduler observes removal
[18:49:53] $ [gw :19872] openclaw cron rm ed298905-9e01-4342-981a-d01fe45ce69a
}
[18:49:55] $ [gw :19872] openclaw cron rm e46c1769-d3bc-4230-b588-136d930064b4
}
[18:50:03] scheduler gateway :19871 dropped the removed jobs after 6 s
--- :19871 (scheduler) proof-* after rm ---
[18:50:03] $ [gw :19871] openclaw cron list --all --json
(none)
===== end after-fix 18:50:05 =====
```

</details>

<details>
<summary>Before-fix transcript — <code>origin/main</code> @ <code>77eb6197884b</code>, scheduler :19873 / management :19874 (same script)</summary>

```text
===== before-fix : OpenClaw 2026.8.1 (77eb619) | state=/tmp/oc-cron-proof/state-before | scheduler=:19873 (cron.enabled=true) | management=:19874 (cron.enabled=false) =====
[18:46:06] # step 1: scheduler status on both gateways
[18:46:06] $ [gw :19873] openclaw cron status --json
{"enabled":true,"storage":"sqlite","jobs":3,"nextWakeAtMs":1788115924578}
[18:46:08] $ [gw :19874] openclaw cron status --json
{"enabled":false,"storage":"sqlite","jobs":3,"nextWakeAtMs":null}
[18:46:10] # step 2 (a): CRUD through the scheduler-DISABLED gateway :19874 — add job A (every 20s command) and job B (daily system event)
[18:46:10] $ [gw :19874] openclaw cron add --name proof-canary --every 20s --command echo canary-ran --no-deliver
warning: the automations scheduler is disabled in the Gateway; jobs are saved but will not run automatically.
[18:46:12] $ [gw :19874] openclaw cron add --name proof-edit-target --cron 0 6 * * * --system-event proof edit target --session main --description initial description
warning: the automations scheduler is disabled in the Gateway; jobs are saved but will not run automatically.
[18:46:13] # step 3: both gateways list the jobs (T0)
--- :19874 (management) immediately ---
[18:46:14] $ [gw :19874] openclaw cron list --all --json
{"name":"proof-canary","enabled":true,"description":null,"updatedAtMs":1788115572073,"state":{"nextRunAtMs":1788115592073},"status":"idle"}
{"name":"proof-edit-target","enabled":true,"description":"initial description","updatedAtMs":1788115573828,"state":{"nextRunAtMs":1788156000000},"status":"idle"}
[18:46:50] scheduler gateway :19873 listed both jobs added by the management gateway after 35 s
--- :19873 (scheduler) ---
[18:46:50] $ [gw :19873] openclaw cron list --all --json
{"name":"proof-canary","enabled":true,"description":null,"updatedAtMs":1788115605491,"state":{"nextRunAtMs":1788115625442,"lastRunAtMs":1788115605442,"lastRunStatus":"ok","lastStatus":"ok","lastDurationMs":49,"lastDiagnosticSummary":"canary-ran"},"status":"ok"}
{"name":"proof-edit-target","enabled":true,"description":"initial description","updatedAtMs":1788115573828,"state":{"nextRunAtMs":1788156000000},"status":"idle"}
[18:46:51] $ [sqlite] cron_jobs proof-* rows (T0)
proof-canary enabled=1 updated_at=18:46:45.491 runtime_updated_at_ms=18:46:45.491 state={"nextRunAtMs":1788115625442,"lastRunAtMs":1788115605442,"lastRunStatus":"ok","lastStatus":"ok","lastDurationMs":49,"lastDiagnosticSummary":"canary-ran"} desc=""
proof-edit-target enabled=1 updated_at=18:46:13.828 runtime_updated_at_ms=18:46:13.828 state={"nextRunAtMs":1788156000000} desc="initial description"
[18:46:51] # step 4 (b): wait for the scheduler gateway :19873 to run job A at least twice (runtime advancement)
[18:47:06] $ [sqlite] cron_jobs proof-* rows (T1)
proof-canary enabled=1 updated_at=18:47:05.483 runtime_updated_at_ms=18:47:05.483 state={"nextRunAtMs":1788115645453,"lastRunAtMs":1788115625453,"lastRunStatus":"ok","lastStatus":"ok","lastDurationMs":30,"lastDiagnosticSummary":"canary-ran"} desc=""
proof-edit-target enabled=1 updated_at=18:46:13.828 runtime_updated_at_ms=18:46:13.828 state={"nextRunAtMs":1788156000000} desc="initial description"
--- :19873 (scheduler) ---
[18:47:06] $ [gw :19873] openclaw cron list --all --json
{"name":"proof-canary","enabled":true,"description":null,"updatedAtMs":1788115625483,"state":{"nextRunAtMs":1788115645453,"lastRunAtMs":1788115625453,"lastRunStatus":"ok","lastStatus":"ok","lastDurationMs":30,"lastDiagnosticSummary":"canary-ran"},"status":"ok"}
{"name":"proof-edit-target","enabled":true,"description":"initial description","updatedAtMs":1788115573828,"state":{"nextRunAtMs":1788156000000},"status":"idle"}
--- :19874 (management, cron.enabled=false) — must show the runtime the scheduler wrote (d: store reload) ---
[18:47:08] $ [gw :19874] openclaw cron list --all --json
{"name":"proof-canary","enabled":true,"description":null,"updatedAtMs":1788115572073,"state":{"nextRunAtMs":1788115592073},"status":"idle"}
{"name":"proof-edit-target","enabled":true,"description":"initial description","updatedAtMs":1788115573828,"state":{"nextRunAtMs":1788156000000},"status":"idle"}
MGMT VIEW: STALE — management gateway reports lastRunAtMs='<none>' while the store has 1788115625453
[18:47:11] # step 5 (c): UNRELATED config write through the management gateway :19874 — edit job B description
[18:47:11] $ [gw :19874] openclaw cron list --all --json
[18:47:13] $ [gw :19874] openclaw cron edit 9d5e55d1-a324-44f0-9360-7f05442e7ea4 --description edited via scheduler-disabled gateway
[18:47:15] $ [sqlite] cron_jobs proof-* rows (T2)
proof-canary enabled=1 updated_at=18:46:12.073 runtime_updated_at_ms=18:46:12.073 state={"nextRunAtMs":1788115592073} desc=""
proof-edit-target enabled=1 updated_at=18:47:15.073 runtime_updated_at_ms=18:47:15.073 state={"nextRunAtMs":1788156000000} desc="edited via scheduler-disabled gateway"
job A (proof-canary) runtime: T1 lastRunAtMs=1788115625453 nextRunAtMs=1788115645453 runtime_updated_at_ms=1788115625483
job A (proof-canary) runtime: T2 lastRunAtMs=0 nextRunAtMs=1788115592073 runtime_updated_at_ms=1788115572073
RESULT: CLOBBERED — job A runtime rolled back by the management-side edit of job B
[18:47:15] # step 6 (d): both gateways read the same post-edit state
--- :19874 (management) ---
[18:47:15] $ [gw :19874] openclaw cron list --all --json
{"name":"proof-canary","enabled":true,"description":null,"updatedAtMs":1788115572073,"state":{"nextRunAtMs":1788115592073},"status":"idle"}
{"name":"proof-edit-target","enabled":true,"description":"edited via scheduler-disabled gateway","updatedAtMs":1788115635073,"state":{"nextRunAtMs":1788156000000},"status":"idle"}
[18:47:27] scheduler gateway :19873 picked up the management-side edit of job B after 11 s
--- :19873 (scheduler) ---
[18:47:27] $ [gw :19873] openclaw cron list --all --json
{"name":"proof-canary","enabled":true,"description":null,"updatedAtMs":1788115645489,"state":{"nextRunAtMs":1788115665463,"lastRunAtMs":1788115645463,"lastRunStatus":"ok","lastStatus":"ok","lastDurationMs":26,"lastDiagnosticSummary":"canary-ran"},"status":"ok"}
{"name":"proof-edit-target","enabled":true,"description":"edited via scheduler-disabled gateway","updatedAtMs":1788115635073,"state":{"nextRunAtMs":1788156000000},"status":"idle"}
{"name":"proof-edit-target","description":"edited via scheduler-disabled gateway","updatedAtMs":1788115635073,"state":{"nextRunAtMs":1788156000000}}
[18:47:31] # step 7: scheduler keeps advancing job A after the edit (no re-admission of a completed occurrence)
[18:47:56] $ [sqlite] cron_jobs proof-* rows (T3)
proof-canary enabled=1 updated_at=18:47:45.565 runtime_updated_at_ms=18:47:45.565 state={"nextRunAtMs":1788115685474,"lastRunAtMs":1788115665474,"lastRunStatus":"ok","lastStatus":"ok","lastDurationMs":91,"lastDiagnosticSummary":"canary-ran"} desc=""
proof-edit-target enabled=1 updated_at=18:47:15.073 runtime_updated_at_ms=18:47:15.073 state={"nextRunAtMs":1788156000000} desc="edited via scheduler-disabled gateway"
[18:47:56] $ [gw :19874] openclaw cron list --all --json
[18:47:57] $ [gw :19873] openclaw cron runs --id f2818c16-2e13-408e-afdf-59aee52ab628 --json
{"ts":1788115665565,"status":"ok","durationMs":91,"output":"canary-ran"}
{"ts":1788115645489,"status":"ok","durationMs":26,"output":"canary-ran"}
{"ts":1788115625483,"status":"ok","durationMs":30,"output":"canary-ran"}
{"ts":1788115605491,"status":"ok","durationMs":49,"output":"canary-ran"}
[18:47:59] # step 8: cleanup through the management gateway; scheduler observes removal
[18:47:59] $ [gw :19874] openclaw cron rm f2818c16-2e13-408e-afdf-59aee52ab628
}
[18:48:01] $ [gw :19874] openclaw cron rm 9d5e55d1-a324-44f0-9360-7f05442e7ea4
}
[18:48:09] scheduler gateway :19873 dropped the removed jobs after 6 s
--- :19873 (scheduler) proof-* after rm ---
[18:48:09] $ [gw :19873] openclaw cron list --all --json
(none)
===== end before-fix 18:48:11 =====
```

</details>

Notes on the transcript: the scheduler-enabled gateway keeps its local snapshot between wakes by design (this PR leaves that path unchanged), which is why its `cron list` catches up with management-side CRUD a few seconds later; the disabled gateway now reloads before every CRUD/read. No production instances were involved: temporary state directories, temporary token, transient units, all removed afterwards.

### Regression tests and static checks

- New regressions:
  - `src/cron/service/store.test.ts` — `reloads shared state for a scheduler-disabled service`, `keeps the scheduler-enabled service cache without a local commit notification`.
  - `src/cron/store.test.ts` — `preserves newer runtime state during an unrelated full config rewrite` (seeds jobs A/B, advances A's runtime out of band, rewrites B's config, asserts A keeps the newer `nextRunAtMs`/`lastRunAtMs`/`updatedAtMs`).
- `pnpm vitest run src/cron/service/store.test.ts src/cron/store.test.ts` — 2 files, 92 passed.
- Changed-file `oxfmt --check`, `oxlint`, `git diff --check` — passed.
- `pnpm check:changed` (typecheck core + core tests, knip dead-export scans, boundary/guard scripts) — passed.

This PR was AI-assisted; the implementation, tests, and validation were reviewed by the submitting author.

