### PR TITLE
improve: avoid hashing imported transcript events twice

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-import-stage.ts
+++ b/src/config/sessions/session-accessor.sqlite-import-stage.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { openNodeSqliteDatabase } from "../../infra/node-sqlite.js";
 import { createPrivateSqliteTempDirectorySync } from "../../infra/sqlite-private-directory.js";
+import type { TranscriptEvent } from "./session-accessor.sqlite-contract.js";
 
 type StagedTranscriptRow = { seq: number; eventJson: string; createdAt: number | null };
 
@@ -69,11 +70,20 @@ export class SqliteSessionImportStage {
     this.database.exec("DELETE FROM seen");
   }
 
-  hasSeen(eventJson: string): boolean {
-    // Hash narrows the lookup; exact bytes decide equality even under a hash collision.
-    return (
-      this.findSeen.get(createHash("sha256").update(eventJson).digest(), eventJson) !== undefined
-    );
+  *iterateUnseenEvents(source: number): Generator<TranscriptEvent, void, boolean> {
+    for (const row of this.rows(source)) {
+      const eventHash = createHash("sha256").update(row.eventJson).digest();
+      // Hash narrows the lookup; exact bytes decide equality even under a hash collision.
+      if (this.findSeen.get(eventHash, row.eventJson) !== undefined) {
+        continue;
+      }
+      // SAFETY: staging serialized the caller's TranscriptEvent without transforming its contents.
+      const inserted = yield JSON.parse(row.eventJson) as TranscriptEvent;
+      // Rejected identities stay unseen so later attempts retain their window recency writes.
+      if (inserted) {
+        this.insertSeen.run(eventHash, row.eventJson);
+      }
+    }
   }
 
   addSeen(eventJson: string): void {

--- a/src/config/sessions/session-accessor.sqlite-import.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-import.test.ts
@@ -144,6 +144,7 @@ it("deduplicates existing and incoming bytes and identities, preserves aliases, 
     };
     const first = { ...message, timestamp: 10 };
     const second = { ...message, id: "two", parentId: "one", timestamp: 30 };
+    const rejected = { ...second, timestamp: 99 };
     const opaque = { custom: "no identity", timestamp: 25 };
     const readTranscriptEvents = (append: (event: unknown) => void) => {
       for (const event of [
@@ -153,7 +154,9 @@ it("deduplicates existing and incoming bytes and identities, preserves aliases, 
         opaque,
         opaque,
         second,
-        { ...second, timestamp: 99 },
+        rejected,
+        { ...second, timestamp: 50 },
+        rejected,
       ]) {
         append(event);
       }

--- a/src/config/sessions/session-accessor.sqlite-import.ts
+++ b/src/config/sessions/session-accessor.sqlite-import.ts
@@ -170,18 +170,7 @@ function importSqliteSessionRowsInTransaction(
     transcriptEvents = appendTranscriptEventsInTransaction(
       database,
       transcriptScope,
-      (function* (): Generator<TranscriptEvent, void, boolean> {
-        for (const row of stage.rows(source)) {
-          if (stage.hasSeen(row.eventJson)) {
-            continue;
-          }
-          // SAFETY: staging serialized the caller's TranscriptEvent without transforming its contents.
-          const inserted = yield JSON.parse(row.eventJson) as TranscriptEvent;
-          if (inserted) {
-            stage.addSeen(row.eventJson);
-          }
-        }
-      })(),
+      stage.iterateUnseenEvents(source),
       { allowStoredAlias: true, scheduleProjectionReconcile: false, touchMutation: false },
     );
     // Doctor imports run outside gateway requests and must finish with a complete projection.


### PR DESCRIPTION
## What Problem This Solves

Large transcript imports hash each accepted event twice while maintaining the migration spool's duplicate set. This follows the profiling work in #133127.

## Why This Change Was Made

The staging owner now streams unseen events itself and retains each event's SHA-256 digest across the canonical append acknowledgment. Only accepted rows enter the duplicate set. Exact-byte comparison, per-session reset, rollback, source validation, raw SQLite handoff, and all SQL/write behavior remain unchanged. The existing hashing API is retained.

## User Impact

This removes redundant hashing without changing the schema, durability, transaction boundaries, configuration, or stored transcript contents. Rejected identities still perform their existing session-recency writes on every attempt.

## Evidence

The existing deduplication test now repeats identical rejected bytes around a different timestamp, detecting accidental suppression of the final recency write. Production delta: +16/-17 (net -1); tests +4/-1 (net +3). All 120 focused importer/Doctor tests passed, including batch and deep imports under a 256 MiB heap. Changed-file lint and formatting passed; Codex review found no actionable defect.

Matched benchmark on isolated Linux, Node 24.19.0 / SQLite 3.53.3: three fresh processes per variant and shape, interleaved before/after order. Both variants use this head and dependencies; only the two importer modules are replaced with baseline `1478fcc9611ed18f39eb56f5d90792d931dd5ac9` for the before bundle. Median import wall time:

| Synthetic shape | Before | After | Change |
| --- | ---: | ---: | ---: |
| 100,000-event deep transcript | 6,698 ms | 6,690 ms | Essentially unchanged |
| 100 sessions × 100 events | 743 ms | 706 ms | 5.0% faster |
| Branching transcript | 1,084 ms | 1,013 ms | 6.6% faster |

CPU medians improved 5.0% / 5.2% for wide / branching imports; deep CPU was 1.2% higher. All three wide and branching pairs improved. The SQL trace matched all 32 statement shapes and all 100,034 calls exactly. Both deep Node CPU profiles completed; their single-run timings are not used as benchmark medians. These are importer measurements, not whole-upgrade speed claims. Local measurements affected by unrelated host saturation were excluded.

Full changed-file checks passed through core typechecking; local aggregate test typechecking hit the pre-existing missing `pako` declaration in the shared dependency checkout (`ui/vite.config.ts:9`). [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33320755114). Packaged Docker upgrade from stable `2026.7.1-2` to the candidate at exact commit `d0e05ab6f81ce0c4975f58e66c775abb8f9cc21b` passed ([proof worker](https://github.com/openclaw/openclaw/actions/runs/33320790309)). The lane finished in 544 seconds and verified 4,800 sessions, 1,227,946 transcript events, and 10,000 cron jobs across five complete state assertions. Automatic migration passed immediately after the updater, before standalone Doctor or fixture capability-consent repair. Eight Gateway history samples across two agents (600 messages) matched exactly before/after restart. Repeat Doctor completed in 40 seconds, below its 60-second budget.

This exercises an explicit stable-to-candidate package update, not unattended channel switching. The synthetic plugin fixture required its existing explicit capability-consent step; that occurred after automatic migration had already passed. No operator state or live Gateway was touched.

The latest ClawSweeper review found no correctness or security issue. Its remaining maintainer-handling request is satisfied by the native review/prepare/merge workflow; the generic stored-data warning is covered by the unchanged schema/SQL and packaged upgrade proof above.
