### PR TITLE
fix(ui): explain pending voice microphone access

### DIFF
--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -54,6 +54,13 @@ browser at up to one frame per second, while `describe_view` reports the
 camera-stream state. In both cases, camera frames bypass the Gateway, and
 stopping Talk releases the camera and microphone tracks.
 
+Browser Talk shows startup progress while preparing the session, waiting for
+microphone access, and connecting. Talk and dictation show microphone guidance
+while the browser's capture request is pending: bring the tab to the foreground
+and allow access if prompted. The browser can keep an unanswered permission
+request pending. In Talk, **Stop voice input** cancels startup and releases any
+microphone stream granted after cancellation.
+
 If the microphone disconnects or its permission is revoked, browser Talk ends
 the call and shows an error. Choose an available **Microphone input**, restore
 permission if needed, and start Talk again. An unexpected GPT-Live connection

--- a/ui/src/e2e/browser-talk-microphone-lifetime.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-microphone-lifetime.e2e.test.ts
@@ -17,6 +17,68 @@ const suite = createControlUiE2eSuite({
 });
 
 suite.define(() => {
+  it("guides a pending microphone request and clears guidance when voice connects", async () => {
+    await suite.withPage({ permissions: ["microphone"] }, async ({ page }) => {
+      await installMockGateway(page, {
+        methodResponses: {
+          "talk.catalog": videoTalkCatalog("openai"),
+          "talk.client.create": {
+            provider: "openai",
+            voiceSessionId: "voice-microphone-access-e2e",
+            transport: "webrtc",
+            clientSecret: "test-client-secret",
+          },
+        },
+      });
+      await installMicrophoneLossWebRtcFixture(page);
+      await page.addInitScript(() => {
+        const getUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
+        let release = () => {};
+        const permission = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        const proof = { requested: false, release: () => release() };
+        Object.defineProperty(window, "openclawMicrophoneAccessE2e", { value: proof });
+        navigator.mediaDevices.getUserMedia = (constraints) => {
+          proof.requested = true;
+          return permission.then(() => getUserMedia(constraints));
+        };
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.getByRole("button", { name: "Start voice input" }).click();
+      await expect
+        .poll(() =>
+          page.evaluate(
+            () =>
+              (window as Window & { openclawMicrophoneAccessE2e?: { requested: boolean } })
+                .openclawMicrophoneAccessE2e?.requested,
+          ),
+        )
+        .toBe(true);
+      await captureMicrophoneLossProof(page, "microphone-access-pending.png");
+      const guidance = page.locator('.agent-chat__talk-status[role="status"]');
+      await expect
+        .poll(() => guidance.allTextContents())
+        .toEqual([
+          expect.stringContaining(
+            "Waiting for microphone access. Bring this tab to the foreground and allow access if prompted.",
+          ),
+        ]);
+      await expect.poll(() => guidance.isVisible()).toBe(true);
+      await page.evaluate(() =>
+        (
+          window as Window & { openclawMicrophoneAccessE2e?: { release: () => void } }
+        ).openclawMicrophoneAccessE2e?.release(),
+      );
+      await expect
+        .poll(() => page.locator('.agent-chat__voice-activity[data-status="listening"]').count())
+        .toBe(1);
+      await expect.poll(() => guidance.count()).toBe(0);
+      await captureMicrophoneLossProof(page, "microphone-access-ready.png");
+      await page.getByRole("button", { name: "Stop voice input" }).click();
+    });
+  });
+
   it("surfaces microphone loss and closes native browser call resources", async () => {
     await suite.withPage({ permissions: ["microphone"] }, async ({ page }) => {
       const gateway = await installMockGateway(page, {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -6291,6 +6291,8 @@ export const en: TranslationMap = {
       cameraPreview: "Camera preview",
       dismissVoiceInputError: "Dismiss voice input error",
       microphoneAccessFailed: "Unable to access microphone inputs.",
+      microphoneAccessPending:
+        "Waiting for microphone access. Bring this tab to the foreground and allow access if prompted.",
       microphoneBusy: "Microphone inputs are busy or unavailable to the browser.",
       microphoneStopped: "Microphone input stopped. Choose an available input and start again.",
       microphoneFallback: "Microphone {number}",
@@ -6318,7 +6320,6 @@ export const en: TranslationMap = {
         "Hold until dictation starts, then release and keep speaking. Tap Stop to insert the transcript.",
       dictationAudioUnsupported: "The Gateway returned an unsupported dictation audio format.",
       dictationBrowserAudioUnsupported: "This browser cannot capture dictation audio at 8 kHz.",
-      dictationConnecting: "Starting dictation…",
       dictationDisconnected: "Dictation stopped because the Gateway disconnected.",
       dictationFailed: "Dictation failed.",
       dictationInterruptedRecovery:
@@ -6367,6 +6368,7 @@ export const en: TranslationMap = {
     },
     voice: {
       asking: "Asking OpenClaw...",
+      preparing: "Preparing voice session...",
       connecting: "Connecting voice input...",
       listening: "Listening...",
     },

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -127,6 +127,49 @@ afterEach(async () => {
 });
 
 describe("renderChatComposer controls", () => {
+  it("shows actionable connecting guidance in a visible status region", () => {
+    const detail =
+      "Waiting for microphone access. Bring this tab to the foreground and allow access if prompted.";
+    const { container } = renderComposer({
+      realtimeTalkActive: true,
+      realtimeTalkStatus: "connecting",
+      realtimeTalkDetail: detail,
+      onToggleRealtimeTalk: vi.fn(),
+    });
+    const pending = container.querySelector('.agent-chat__talk-status[role="status"]');
+    expect(pending?.textContent).toContain(detail);
+    expect(pending?.closest(".sr-only")).toBeNull();
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(button(container, t("chat.composer.stopVoiceInput")).disabled).toBe(false);
+  });
+
+  it("shows the same microphone guidance while dictation waits for access", async () => {
+    vi.useFakeTimers();
+    openMicrophoneMock.mockReturnValue(new Promise(() => {}));
+    const container = document.createElement("div");
+    document.body.append(container);
+    const composerProps = props({
+      gatewayClient: {
+        request: vi.fn(async () => ({ transcription: { ready: true } })),
+      } as unknown as GatewayBrowserClient,
+      onToggleRealtimeTalk: vi.fn(),
+    });
+    const draw = () => render(renderChatComposer(composerProps), container);
+    composerProps.onRequestUpdate = draw;
+    draw();
+    await vi.advanceTimersByTimeAsync(0);
+    button(container, t("chat.composer.startVoiceInput")).dispatchEvent(
+      dictationPointer("pointerdown", 15),
+    );
+    await vi.advanceTimersByTimeAsync(800);
+    expect(
+      container.querySelector('.agent-chat__talk-status[role="status"]')?.textContent,
+    ).toContain(
+      "Waiting for microphone access. Bring this tab to the foreground and allow access if prompted.",
+    );
+    expect(container.querySelector(".agent-chat__dictation-phase")).toBeNull();
+  });
+
   it("labels the message input independently of its placeholder", () => {
     const { container } = renderComposer();
     const textarea = container.querySelector<HTMLTextAreaElement>("textarea");

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -3570,7 +3570,7 @@ describe("chat voice controls", () => {
     ["connecting", "Connecting voice input..."],
     ["listening", "Listening..."],
     ["thinking", "Asking OpenClaw..."],
-  ] as const)("renders %s voice activity without visible status copy", (status, label) => {
+  ] as const)("renders %s voice activity with the appropriate status region", (status, label) => {
     const inputLevel = new RealtimeTalkLevelSignal();
     inputLevel.set(0.64);
     const container = renderChatView({
@@ -3587,11 +3587,17 @@ describe("chat voice controls", () => {
     expect(visualizer?.getAttribute("data-source")).toBe("microphone");
     expect(visualizer?.getAttribute("aria-hidden")).toBe("true");
     expect(visualizer?.querySelectorAll(".agent-chat__voice-activity-bar")).toHaveLength(7);
-    const statusRegion = container.querySelector('[role="status"].agent-chat__voice-status');
+    const statusRegion = container.querySelector(
+      status === "connecting"
+        ? '[role="status"].agent-chat__talk-status'
+        : '[role="status"].agent-chat__voice-status',
+    );
     expect(statusRegion?.getAttribute("aria-live")).toBe("polite");
     expect(statusRegion?.getAttribute("aria-atomic")).toBe("true");
     expect(statusRegion?.textContent?.trim()).toBe(label);
-    expect(container.querySelector(".agent-chat__talk-status")).toBeNull();
+    if (status !== "connecting") {
+      expect(container.querySelector(".agent-chat__talk-status")).toBeNull();
+    }
   });
 
   it("keeps the stop control without a live meter when a running session errors", () => {

--- a/ui/src/pages/chat/components/chat-composer-controls.ts
+++ b/ui/src/pages/chat/components/chat-composer-controls.ts
@@ -14,7 +14,11 @@ import {
 } from "../realtime-talk-input.ts";
 import type { RealtimeTalkLevelSignal } from "../realtime-talk-level.ts";
 import type { RealtimeTalkStatus } from "../realtime-talk.ts";
-import { renderMicrophoneActivity, voiceStatusLabel } from "./chat-voice-activity.ts";
+import {
+  renderChatVoiceStatus,
+  renderMicrophoneActivity,
+  voiceStatusLabel,
+} from "./chat-voice-activity.ts";
 
 export type ChatRunControlsProps = {
   canAbort: boolean;
@@ -369,13 +373,13 @@ export function renderComposerDictationSendAction(
     return nothing;
   }
   return html`
-    <span class="sr-only" role="status" aria-live="polite" aria-atomic="true"
-      >${dictation.finalizing
-        ? t("chat.composer.dictationFinalizing")
-        : dictation.connecting
-          ? t("chat.composer.dictationConnecting")
-          : t("chat.composer.dictationListening")}</span
-    >
+    ${dictation.connecting
+      ? nothing
+      : html`<span class="sr-only" role="status" aria-live="polite" aria-atomic="true"
+          >${dictation.finalizing
+            ? t("chat.composer.dictationFinalizing")
+            : t("chat.composer.dictationListening")}</span
+        >`}
     <openclaw-tooltip .content=${t("chat.runControls.send")}>
       <button
         class="chat-send-btn chat-send-btn--send chat-send-btn--dictation-commit"
@@ -401,7 +405,13 @@ export function renderComposerDictationStatus(dictation?: ComposerDictationContr
   if (!dictation?.active) {
     return nothing;
   }
-  const listening = !dictation.connecting && !dictation.finalizing;
+  if (dictation.connecting) {
+    return renderChatVoiceStatus({
+      status: "connecting",
+      detail: t("chat.composer.microphoneAccessPending"),
+    });
+  }
+  const listening = !dictation.finalizing;
   return html`
     <div class="agent-chat__composer-status-stack">
       <div
@@ -412,11 +422,9 @@ export function renderComposerDictationStatus(dictation?: ComposerDictationContr
             ? " agent-chat__dictation-phase--listening"
             : ""}"
         >
-          ${dictation.connecting
-            ? t("chat.composer.dictationConnecting")
-            : dictation.finalizing
-              ? t("chat.composer.dictationFinalizing")
-              : t("chat.composer.dictationListening")}
+          ${dictation.finalizing
+            ? t("chat.composer.dictationFinalizing")
+            : t("chat.composer.dictationListening")}
         </span>
       </div>
     </div>
@@ -606,7 +614,7 @@ export function renderChatPrimaryActions(props: ChatRunControlsProps) {
             </openclaw-tooltip>
             ${props.microphonePicker}
           </span>
-          ${voiceErrored
+          ${voiceErrored || props.voiceStatus === "connecting"
             ? nothing
             : html`
                 <span

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -50,7 +50,7 @@ import {
   restorePointerOpenedChatComposerTrigger,
 } from "./chat-picker-overlay.ts";
 import type { createGatewayQuestionPanelProps } from "./chat-question-card.ts";
-import { renderChatVoiceError } from "./chat-voice-activity.ts";
+import { renderChatVoiceStatus } from "./chat-voice-activity.ts";
 
 type ChatComposerViewContext = {
   props: ChatComposerProps;
@@ -183,8 +183,8 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
     state.capabilityMenuView = "root";
   }
   const disabledReasonId = paneDomId(props.paneId, "disabled-reason");
-  const voiceError = showComposerInput
-    ? renderChatVoiceError({
+  const composerAlerts = showComposerInput
+    ? renderChatVoiceStatus({
         status: props.realtimeTalkCameraError ? "error" : props.realtimeTalkStatus,
         detail: props.realtimeTalkDetail,
         onDismissError: props.realtimeTalkCameraError
@@ -192,12 +192,6 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
           : props.onDismissRealtimeTalkError,
       })
     : nothing;
-  const composerAlerts =
-    voiceError !== nothing
-      ? html`<div class="agent-chat__composer-errors agent-chat__composer-errors--standalone">
-          ${voiceError}
-        </div>`
-      : nothing;
   const offlineText = props.offline
     ? props.queuedOutboxCount
       ? t("chat.composer.offlineQueuedHint", { count: String(props.queuedOutboxCount) })

--- a/ui/src/pages/chat/components/chat-voice-activity.ts
+++ b/ui/src/pages/chat/components/chat-voice-activity.ts
@@ -141,32 +141,48 @@ export function renderMicrophoneActivity(props: MicrophoneActivityProps): Templa
   `;
 }
 
-type ChatVoiceErrorProps = {
+type ChatVoiceStatusProps = {
   status?: RealtimeTalkStatus;
   detail?: string | null;
   onDismissError?: () => void;
 };
 
-export function renderChatVoiceError(props: ChatVoiceErrorProps): TemplateResult | typeof nothing {
+export function renderChatVoiceStatus(
+  props: ChatVoiceStatusProps,
+): TemplateResult | typeof nothing {
+  if (props.status === "connecting") {
+    return html`<div
+      class="callout agent-chat__talk-status"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      ${voiceStatusLabel(props.status, props.detail)}
+    </div>`;
+  }
   if (props.status !== "error" || !props.detail) {
     return nothing;
   }
   return html`
-    <div class="agent-chat__composer-error agent-chat__talk-status" role="alert">
-      <span class="agent-chat__composer-error-icon" aria-hidden="true">${icons.alertTriangle}</span>
-      <span class="agent-chat__talk-status-text">${props.detail}</span>
-      ${props.onDismissError
-        ? html`
-            <button
-              class="callout__dismiss"
-              type="button"
-              @click=${props.onDismissError}
-              aria-label=${t("chat.composer.dismissVoiceInputError")}
-            >
-              ${icons.x}
-            </button>
-          `
-        : nothing}
+    <div class="agent-chat__composer-errors agent-chat__composer-errors--standalone">
+      <div class="agent-chat__composer-error agent-chat__talk-status" role="alert">
+        <span class="agent-chat__composer-error-icon" aria-hidden="true"
+          >${icons.alertTriangle}</span
+        >
+        <span class="agent-chat__talk-status-text">${props.detail}</span>
+        ${props.onDismissError
+          ? html`
+              <button
+                class="callout__dismiss"
+                type="button"
+                @click=${props.onDismissError}
+                aria-label=${t("chat.composer.dismissVoiceInputError")}
+              >
+                ${icons.x}
+              </button>
+            `
+          : nothing}
+      </div>
     </div>
   `;
 }

--- a/ui/src/pages/chat/realtime-talk-gateway-relay.test.ts
+++ b/ui/src/pages/chat/realtime-talk-gateway-relay.test.ts
@@ -229,11 +229,12 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
     const addListener = vi.spyOn(track, "addEventListener");
     getUserMedia.mockResolvedValueOnce({ getTracks: () => [track] });
     const client = createClient();
-    const onStatus = vi.fn(() => {
-      throw new Error("status failed");
-    });
+    const onStatus = vi.fn();
     const transport = createTransport({ client, callbacks: { onStatus } });
     await startTransport(transport);
+    onStatus.mockImplementation(() => {
+      throw new Error("status failed");
+    });
 
     const ended = addListener.mock.calls[0]?.[1];
     expect(() => {
@@ -314,6 +315,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
     });
 
     const start = transport.start();
+    onStatus.mockClear();
     emitTalkEvent({ relaySessionId: "relay-1", type: "ready" });
     emitTalkEvent({
       relaySessionId: "relay-1",
@@ -338,7 +340,8 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       getTracks: () => [Object.assign(new EventTarget(), { stop: vi.fn() })],
     } as unknown as MediaStream);
     await expect(start).resolves.toBe("ready");
-    expect(onStatus).not.toHaveBeenCalled();
+    expect(onStatus).toHaveBeenCalledExactlyOnceWith("connecting", undefined);
+    onStatus.mockClear();
     expect(onTranscript).not.toHaveBeenCalled();
 
     transport.activate();
@@ -367,6 +370,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
     const transport = createTransport({ callbacks: { onStatus }, client });
 
     const start = transport.start();
+    onStatus.mockClear();
     for (let index = 0; index < 33; index += 1) {
       emitTalkEvent({ relaySessionId: "relay-1", type: "ready" });
     }
@@ -421,6 +425,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
     const transport = createTransport({ callbacks: { onStatus }, client });
 
     const start = transport.start();
+    onStatus.mockClear();
     emitTalkEvent({
       relaySessionId: "relay-1",
       type: "error",
@@ -442,14 +447,15 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
 
   it("closes the relay when a provisional callback throws during activation", async () => {
     const client = createClient();
-    const onStatus = vi.fn(() => {
-      throw new Error("consumer failed");
-    });
+    const onStatus = vi.fn();
     const transport = createTransport({ callbacks: { onStatus }, client });
 
     const start = transport.start();
     emitTalkEvent({ relaySessionId: "relay-1", type: "ready" });
     await expect(start).resolves.toBe("ready");
+    onStatus.mockImplementation(() => {
+      throw new Error("consumer failed");
+    });
 
     expect(() => transport.activate()).toThrow("consumer failed");
     expect(requestCallsFor(client, "talk.session.close")).toHaveLength(1);
@@ -769,6 +775,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
     const oldTransport = createTransport({ callbacks: { onStatus: oldStatus }, client: oldClient });
 
     await oldTransport.start();
+    oldStatus.mockClear();
     pumpMicrophone(new Float32Array(4096));
     oldTransport.stop();
 
@@ -779,6 +786,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       client: replacementClient,
     });
     await replacement.start();
+    replacementStatus.mockClear();
     pumpMicrophone(new Float32Array(4096));
     rejectOldAppend(new Error("late stale append failure"));
     await Promise.resolve();
@@ -852,9 +860,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       getUserMedia.mockResolvedValue({
         getTracks: () => [Object.assign(new EventTarget(), { stop: stopTrack })],
       } as unknown as MediaStream);
-      const throwingCallback = vi.fn(() => {
-        throw new Error("consumer failed");
-      });
+      const throwingCallback = vi.fn();
       const client = createClient();
       const transport = createTransport({
         client,
@@ -865,6 +871,9 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       });
 
       await startTransport(transport);
+      throwingCallback.mockImplementation(() => {
+        throw new Error("consumer failed");
+      });
       expect(() =>
         emitTalkEvent({
           relaySessionId: "relay-1",

--- a/ui/src/pages/chat/realtime-talk-gateway-relay.ts
+++ b/ui/src/pages/chat/realtime-talk-gateway-relay.ts
@@ -44,8 +44,9 @@ function estimateRelayEventBytes(event: GatewayRelayEvent): number {
 }
 
 export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport {
-  private readonly input = new RealtimeTalkInputController((detail) =>
-    this.failAudioAppend(detail),
+  private readonly input = new RealtimeTalkInputController(
+    (detail) => this.failAudioAppend(detail),
+    (detail) => this.ctx.callbacks.onStatus?.("connecting", detail),
   );
   private inputContext: AudioContext | null = null;
   private outputContext: AudioContext | null = null;

--- a/ui/src/pages/chat/realtime-talk-google-live-timeout.test.ts
+++ b/ui/src/pages/chat/realtime-talk-google-live-timeout.test.ts
@@ -149,6 +149,7 @@ describe("Google Live setup timeout", () => {
     const transport = createTransport({ onStatus, onTalkEvent });
 
     const { start, socket } = await beginTransport(transport);
+    onStatus.mockClear();
     socket.readyState = 0;
     const rejected = expect(start).rejects.toThrow("Realtime connection timed out after 30000ms");
     await vi.advanceTimersByTimeAsync(SETUP_TIMEOUT_MS);
@@ -168,6 +169,7 @@ describe("Google Live setup timeout", () => {
     const transport = createTransport({ onStatus });
 
     const { start, socket } = await beginTransport(transport);
+    onStatus.mockClear();
     socket.emitOpen();
     const rejected = expect(start).rejects.toThrow("Realtime connection timed out after 30000ms");
     await vi.advanceTimersByTimeAsync(SETUP_TIMEOUT_MS);
@@ -179,15 +181,17 @@ describe("Google Live setup timeout", () => {
   });
 
   it("does not publish provisional terminal callbacks when setup times out", async () => {
-    const onStatus = vi.fn(() => {
-      throw new Error("status callback must remain provisional");
-    });
+    const onStatus = vi.fn();
     const onTalkEvent = vi.fn(() => {
       throw new Error("talk callback must remain provisional");
     });
     const transport = createTransport({ onStatus, onTalkEvent });
 
     const { start, socket } = await beginTransport(transport);
+    onStatus.mockClear();
+    onStatus.mockImplementation(() => {
+      throw new Error("status callback must remain provisional");
+    });
     socket.readyState = 0;
     const rejected = expect(start).rejects.toThrow("Realtime connection timed out after 30000ms");
     await vi.advanceTimersByTimeAsync(SETUP_TIMEOUT_MS);
@@ -208,6 +212,7 @@ describe("Google Live setup timeout", () => {
     const onStatus = vi.fn();
     const transport = createTransport({ onStatus });
     const { start, socket } = await beginTransport(transport);
+    onStatus.mockClear();
     const rejected = expect(start).rejects.toThrow(detail);
 
     if (event === "close") {
@@ -227,6 +232,7 @@ describe("Google Live setup timeout", () => {
     const onStatus = vi.fn();
     const transport = createTransport({ onStatus });
     const { start, socket } = await beginTransport(transport);
+    onStatus.mockClear();
     socket.emitOpen();
     socket.emitMessage({ setupComplete: {} });
     await Promise.resolve();
@@ -242,11 +248,13 @@ describe("Google Live setup timeout", () => {
   });
 
   it("releases resources when a readiness callback throws during activation", async () => {
-    const onStatus = vi.fn(() => {
-      throw new Error("consumer failed");
-    });
+    const onStatus = vi.fn();
     const transport = createTransport({ onStatus });
     const { start, socket } = await beginTransport(transport);
+    onStatus.mockClear();
+    onStatus.mockImplementation(() => {
+      throw new Error("consumer failed");
+    });
     socket.emitOpen();
     socket.emitMessage({ setupComplete: {} });
     await expect(start).resolves.toBe("ready");
@@ -279,6 +287,7 @@ describe("Google Live setup timeout", () => {
     const transport = createTransport({ onStatus });
 
     const { start, socket } = await beginTransport(transport);
+    onStatus.mockClear();
     socket.emitOpen();
     socket.emitMessage({ setupComplete: {} });
     await expect(start).resolves.toBe("ready");
@@ -295,6 +304,7 @@ describe("Google Live setup timeout", () => {
     const transport = createTransport({ onStatus });
 
     const { start } = await beginTransport(transport);
+    onStatus.mockClear();
     transport.stop();
     await expect(start).resolves.toBe("cancelled");
     await vi.advanceTimersByTimeAsync(SETUP_TIMEOUT_MS);

--- a/ui/src/pages/chat/realtime-talk-google-live-video.test.ts
+++ b/ui/src/pages/chat/realtime-talk-google-live-video.test.ts
@@ -477,6 +477,7 @@ describe("Google Live Video Talk", () => {
     const transport = createTransport({ onStatus, onVideoStream });
 
     const { start, ws } = await beginTransport(transport);
+    onStatus.mockClear();
     await transport.setVideoEnabled(true);
     ws.emitOpen();
     const rejected = expect(start).rejects.toThrow("Realtime connection timed out after 30000ms");

--- a/ui/src/pages/chat/realtime-talk-google-live.test.ts
+++ b/ui/src/pages/chat/realtime-talk-google-live.test.ts
@@ -125,6 +125,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
     const transport = createTransport({ onStatus, onTalkEvent });
 
     const { start, ws } = await beginTransport(transport);
+    onStatus.mockClear();
     ws.emitOpen();
     ws.emitMessage(encodeJsonFrame({ setupComplete: {} }));
     await expect(start).resolves.toBe("ready");
@@ -484,6 +485,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
     const onStatus = vi.fn();
     const transport = createTransport({ onStatus });
     const { start, ws } = await beginTransport(transport);
+    onStatus.mockClear();
 
     transport.stop();
     await expect(start).resolves.toBe("cancelled");

--- a/ui/src/pages/chat/realtime-talk-google-live.ts
+++ b/ui/src/pages/chat/realtime-talk-google-live.ts
@@ -81,12 +81,15 @@ function isGemini31LiveModel(model: string | undefined): boolean {
 export class GoogleLiveRealtimeTalkTransport implements RealtimeTalkTransport {
   private ws: WebSocket | null = null;
   private setupTimeout: ReturnType<typeof globalThis.setTimeout> | null = null;
-  private readonly input = new RealtimeTalkInputController((detail) => {
-    const ws = this.ws;
-    if (ws) {
-      this.failConnection(ws, detail);
-    }
-  });
+  private readonly input = new RealtimeTalkInputController(
+    (detail) => {
+      const ws = this.ws;
+      if (ws) {
+        this.failConnection(ws, detail);
+      }
+    },
+    (detail) => this.ctx.callbacks.onStatus?.("connecting", detail),
+  );
   private inputContext: AudioContext | null = null;
   private outputContext: AudioContext | null = null;
   private inputMeter: RealtimeTalkMediaStreamMeter | null = null;

--- a/ui/src/pages/chat/realtime-talk-input.test.ts
+++ b/ui/src/pages/chat/realtime-talk-input.test.ts
@@ -41,8 +41,11 @@ function microphoneEndedListener(
 
 const ownedInputs = new Set<RealtimeTalkInputController>();
 
-function createMicrophoneInput(onEnded: (detail: string) => void = () => undefined) {
-  const input = new RealtimeTalkInputController(onEnded);
+function createMicrophoneInput(
+  onEnded: (detail: string) => void = () => undefined,
+  onConnecting?: (detail?: string) => void,
+) {
+  const input = new RealtimeTalkInputController(onEnded, onConnecting);
   ownedInputs.add(input);
   return input;
 }
@@ -58,6 +61,24 @@ afterEach(() => {
 });
 
 describe("realtime Talk microphone lifetime", () => {
+  it.each(["requesting", "acquired"])(
+    "releases ownership if the %s status callback throws",
+    async (phase) => {
+      const { track, stream } = microphoneFixture();
+      const getUserMedia = vi.fn(async () => stream);
+      vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+      const input = createMicrophoneInput(undefined, (detail) => {
+        if ((phase === "requesting") === Boolean(detail)) {
+          throw new Error("status consumer failed");
+        }
+      });
+      await expect(input.open(undefined)).rejects.toThrow("status consumer failed");
+      expect(input.stream).toBeNull();
+      expect(getUserMedia).toHaveBeenCalledTimes(phase === "requesting" ? 0 : 1);
+      expect(track.stop).toHaveBeenCalledTimes(phase === "requesting" ? 0 : 1);
+    },
+  );
+
   it("releases input before a throwing microphone-loss callback", async () => {
     const { track, addEventListener, stream } = microphoneFixture();
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia: vi.fn(async () => stream) } });
@@ -123,8 +144,11 @@ describe("realtime Talk microphone lifetime", () => {
       },
     });
     const onEnded = vi.fn();
-    const input = createMicrophoneInput(onEnded);
+    const onConnecting = vi.fn();
+    const input = createMicrophoneInput(onEnded, onConnecting);
     const opening = input.open(undefined);
+    expect(onConnecting).toHaveBeenCalledWith(expect.stringContaining("Waiting for microphone"));
+    onConnecting.mockClear();
     input.stop();
     await expect(opening).rejects.toMatchObject({ name: "AbortError" });
 
@@ -133,6 +157,7 @@ describe("realtime Talk microphone lifetime", () => {
     expect(input.stream).toBeNull();
     expect(addEventListener).not.toHaveBeenCalled();
     expect(onEnded).not.toHaveBeenCalled();
+    expect(onConnecting).not.toHaveBeenCalled();
   });
 });
 

--- a/ui/src/pages/chat/realtime-talk-input.ts
+++ b/ui/src/pages/chat/realtime-talk-input.ts
@@ -265,7 +265,10 @@ export class RealtimeTalkInputController {
   private controller: AbortController | null = null;
   private media: MediaStream | null = null;
 
-  constructor(private readonly onEnded: (detail: string) => void) {}
+  constructor(
+    private readonly onEnded: (detail: string) => void,
+    private readonly onConnecting?: (detail?: string) => void,
+  ) {}
 
   get stream(): MediaStream | null {
     return this.media;
@@ -276,6 +279,7 @@ export class RealtimeTalkInputController {
     const controller = new AbortController();
     this.controller = controller;
     try {
+      this.onConnecting?.(t("chat.composer.microphoneAccessPending"));
       const media = await openRealtimeTalkInput(inputDeviceId, { signal: controller.signal });
       if (controller.signal.aborted) {
         media.getTracks().forEach((track) => track.stop());
@@ -293,6 +297,9 @@ export class RealtimeTalkInputController {
       for (const track of media.getTracks()) {
         track.addEventListener("ended", onEnded, { signal: controller.signal });
       }
+      // Only the current, successful acquisition advances the visible startup phase.
+      // Cancellation must not overwrite idle or a replacement's microphone prompt.
+      this.onConnecting?.();
       return media;
     } catch (error) {
       if (this.controller === controller) {

--- a/ui/src/pages/chat/realtime-talk-lifecycle.test.ts
+++ b/ui/src/pages/chat/realtime-talk-lifecycle.test.ts
@@ -520,7 +520,7 @@ describe("RealtimeTalkSession lifecycle", () => {
 
     await expect(session.start()).rejects.toThrow("Realtime connection closed");
 
-    expect(onStatus).toHaveBeenCalledWith("connecting");
+    expect(onStatus).toHaveBeenCalledWith("connecting", "Preparing voice session...");
     expect(transportMock.webRtcStops[0]).toHaveBeenCalledWith({ emitClosed: false });
   });
 

--- a/ui/src/pages/chat/realtime-talk-webrtc-video.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc-video.test.ts
@@ -120,6 +120,40 @@ describe("OpenAI Realtime media lifecycle", () => {
     }
   });
 
+  it("explains pending microphone access and advances to connection setup after acquisition", async () => {
+    const track = Object.assign(new EventTarget(), { stop: vi.fn() });
+    let resolveMedia: (stream: MediaStream) => void = () => undefined;
+    const getUserMedia = vi.fn(
+      () =>
+        new Promise<MediaStream>((resolve) => {
+          resolveMedia = resolve;
+        }),
+    );
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+    const onStatus = vi.fn();
+    const transport = new WebRtcSdpRealtimeTalkTransport(
+      { provider: "openai", transport: "webrtc", clientSecret: "test-client-secret" },
+      { client: {} as never, sessionKey: "main", callbacks: { onStatus } },
+    );
+    const starting = transport.start();
+    try {
+      expect(onStatus).toHaveBeenLastCalledWith(
+        "connecting",
+        "Waiting for microphone access. Bring this tab to the foreground and allow access if prompted.",
+      );
+      expect(fetch).not.toHaveBeenCalled();
+      resolveMedia({
+        getTracks: () => [track],
+        getAudioTracks: () => [track],
+      } as unknown as MediaStream);
+      await expect(starting).resolves.toBe("ready");
+      expect(onStatus).toHaveBeenLastCalledWith("connecting", undefined);
+    } finally {
+      transport.stop();
+      await starting;
+    }
+  });
+
   it("starts audio-only, toggles local camera, and reports camera-off tool calls", async () => {
     const audioStop = vi.fn();
     const videoStop = vi.fn();

--- a/ui/src/pages/chat/realtime-talk-webrtc.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.test.ts
@@ -50,6 +50,14 @@ class FakePeerConnection extends EventTarget {
   }
 }
 
+function requirePeer(): FakePeerConnection {
+  const peer = FakePeerConnection.instances[0];
+  if (!peer) {
+    throw new Error("expected WebRTC peer");
+  }
+  return peer;
+}
+
 function requireTalkEvent(
   onTalkEvent: ReturnType<typeof vi.fn>,
   index: number,
@@ -332,10 +340,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     const transport = createOpenAiTransport();
 
     const startPromise = transport.start();
-    const peer = FakePeerConnection.instances[0];
-    if (!peer) {
-      throw new Error("expected WebRTC peer");
-    }
+    const peer = requirePeer();
     const createOfferSpy = vi.spyOn(peer, "createOffer").mockImplementation(
       () =>
         new Promise<RTCSessionDescriptionInit>((_, reject) => {
@@ -445,10 +450,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     const onTalkEvent = vi.fn();
     const transport = createOpenAiTransport({}, { onStatus, onTalkEvent });
     const start = transport.start();
-    const peer = FakePeerConnection.instances[0];
-    if (!peer) {
-      throw new Error("expected WebRTC peer");
-    }
+    const peer = requirePeer();
     let finishRemoteDescription: (() => void) | undefined;
     const remoteDescription = vi.spyOn(peer, "setRemoteDescription").mockImplementation(
       async () =>
@@ -477,10 +479,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     onStatus.mockImplementation(() => {
       throw new Error("consumer failed");
     });
-    const peer = FakePeerConnection.instances[0];
-    if (!peer) {
-      throw new Error("expected WebRTC peer");
-    }
+    const peer = requirePeer();
 
     peer.connectionState = "failed";
     peer.dispatchEvent(new Event("connectionstatechange"));
@@ -497,10 +496,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     });
     const transport = createOpenAiTransport({}, { onTalkEvent });
     await expect(transport.start()).resolves.toBe("ready");
-    const peer = FakePeerConnection.instances[0];
-    if (!peer) {
-      throw new Error("expected WebRTC peer");
-    }
+    const peer = requirePeer();
 
     expect(() => transport.stop()).toThrow("consumer failed");
 

--- a/ui/src/pages/chat/realtime-talk-webrtc.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.test.ts
@@ -457,6 +457,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
         }),
     );
     await waitForFast(() => expect(remoteDescription).toHaveBeenCalled());
+    onStatus.mockClear();
 
     peer.connectionState = "failed";
     peer.dispatchEvent(new Event("connectionstatechange"));
@@ -470,11 +471,12 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
 
   it("releases an active peer when the terminal status callback throws", async () => {
     stubAnswerSdpFetch();
-    const onStatus = vi.fn(() => {
-      throw new Error("consumer failed");
-    });
+    const onStatus = vi.fn();
     const transport = createOpenAiTransport({}, { onStatus });
     await expect(transport.start()).resolves.toBe("ready");
+    onStatus.mockImplementation(() => {
+      throw new Error("consumer failed");
+    });
     const peer = FakePeerConnection.instances[0];
     if (!peer) {
       throw new Error("expected WebRTC peer");

--- a/ui/src/pages/chat/realtime-talk-webrtc.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.ts
@@ -44,7 +44,10 @@ const cancelledSetup = Symbol("cancelledSetup");
 export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
   private peer: RTCPeerConnection | null = null;
   private channel: RTCDataChannel | null = null;
-  private readonly input = new RealtimeTalkInputController((detail) => this.failConnection(detail));
+  private readonly input = new RealtimeTalkInputController(
+    (detail) => this.failConnection(detail),
+    (detail) => this.ctx.callbacks.onStatus?.("connecting", detail),
+  );
   private audio: HTMLAudioElement | null = null;
   private inputMeter: RealtimeTalkMediaStreamMeter | null = null;
   private closed = false;

--- a/ui/src/pages/chat/realtime-talk.test.ts
+++ b/ui/src/pages/chat/realtime-talk.test.ts
@@ -136,7 +136,7 @@ describe("RealtimeTalkSession", () => {
     expect(googleStart).toHaveBeenCalledTimes(1);
     expect(webRtcInstances).toHaveLength(0);
     expect(relayInstances).toHaveLength(0);
-    expect(onStatus).toHaveBeenCalledWith("connecting");
+    expect(onStatus).toHaveBeenCalledWith("connecting", "Preparing voice session...");
   });
 
   it("defaults legacy session results without an explicit transport to WebRTC", async () => {

--- a/ui/src/pages/chat/realtime-talk.ts
+++ b/ui/src/pages/chat/realtime-talk.ts
@@ -7,6 +7,7 @@ import {
   VOICE_TRANSCRIPT_QUEUE_POLICY,
 } from "../../../../src/talk/voice-transcript.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { t } from "../../i18n/index.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { GatewayRelayRealtimeTalkTransport } from "./realtime-talk-gateway-relay.ts";
 import { GoogleLiveRealtimeTalkTransport } from "./realtime-talk-google-live.ts";
@@ -166,7 +167,7 @@ export class RealtimeTalkSession {
       const lifecycleGeneration = ++this.lifecycleGeneration;
       this.stopPendingTransport();
       this.closed = false;
-      this.callbacks.onStatus?.("connecting");
+      this.callbacks.onStatus?.("connecting", t("chat.voice.preparing"));
       const existingTransport = this.transport;
       const existingVoiceSessionId = this.voiceSessionId;
       const existingOwner = this.clientVoiceSessionOwner;


### PR DESCRIPTION
Closes #133348

## What Problem This Solves

Fixes an issue where users starting Browser Talk would see an animated stop control without visible guidance when microphone access remained pending. The same missing permission guidance affected dictation in chat and the new-session composer.

## Why This Change Was Made

The shared microphone owner now reports when capture is being requested and when acquisition succeeds. The composer displays that existing connecting state as a neutral status callout, separating session preparation, microphone access, and provider connection. Cancellation cannot publish a late status or retain a late-granted stream. The existing error renderer remains the single owner for errors; duplicate connecting announcements and unused dictation copy are removed.

No new configuration, timeout, permission bypass, dependency, or persistence contract. The browser is allowed to leave a permission request unresolved; adding an arbitrary timeout would not fix that condition. Provenance: introducing commit unknown; #127673 handled rejected requests, not pending requests.

## User Impact

Users can see what startup is waiting for and receive foreground/permission guidance while the microphone request is pending. Stop remains available. Guidance disappears when the connection is ready, while existing microphone-loss errors and cleanup remain intact.

## Evidence

Two focused pre-fix regressions failed for missing microphone-phase status and missing visible composer guidance. The native Chromium scenario also failed on the baseline. The repaired run passes the pending-access flow, real Chromium capture acquisition, transition to Listening, and existing microphone-ended cleanup. Gateway/provider signaling is synthetic in that deterministic browser test; this is not a claim about physical microphone permission prompts or live provider recognition accuracy.

Focused tests cover the shared microphone lifetime, OpenAI WebRTC, Google Live, Gateway relay, session ownership, chat rendering, and new-session dictation. Before/after pictures below use inspected synthetic data only. Browser contract: https://w3c.github.io/mediacapture-main/#dom-mediadevices-getusermedia

Production UI: +88/-53 (net +35). Tests/test support: +233/-43. Docs: +7. The production growth supplies previously absent lifecycle progress and visible guidance through existing status/rendering owners; no new state machine or fallback path.

Release-note context: Browser Talk and dictation explain pending microphone access and show startup progress.

Before:

![Pending microphone access before the fix](https://github.com/user-attachments/assets/a06373b5-3c7d-4b42-8959-559c06b0f697)

After:

![Visible microphone-access guidance after the fix](https://github.com/user-attachments/assets/2857617c-7845-488c-8bf0-90e777d52b14)

<details>
<summary>Focused validation commands and outcomes</summary>

```sh
node scripts/run-vitest.mjs ui/src/pages/chat/realtime-talk-input.test.ts ui/src/pages/chat/realtime-talk-webrtc-video.test.ts ui/src/pages/chat/chat-composer.test.ts
# 71 passed

node scripts/run-vitest.mjs ui/src/pages/chat/realtime-talk-input.test.ts ui/src/pages/chat/realtime-talk-webrtc.test.ts ui/src/pages/chat/realtime-talk-webrtc-control.test.ts ui/src/pages/chat/realtime-talk-webrtc-video.test.ts ui/src/pages/chat/realtime-talk-google-live.test.ts ui/src/pages/chat/realtime-talk-google-live-timeout.test.ts ui/src/pages/chat/realtime-talk-google-live-video.test.ts ui/src/pages/chat/realtime-talk-gateway-relay.test.ts ui/src/pages/chat/realtime-talk.test.ts ui/src/pages/chat/realtime-talk-lifecycle.test.ts ui/src/pages/chat/chat-realtime.test.ts ui/src/pages/chat/chat-composer.test.ts ui/src/pages/chat/chat-view.test.ts ui/src/pages/new-session/composer-dictation-control.test.ts
# 591 passed; one relay assertion still counted intentional startup progress.
# Corrected that assertion to clear completed startup calls before injecting the stale failure.

node scripts/run-vitest.mjs ui/src/pages/chat/realtime-talk-gateway-relay.test.ts ui/src/pages/chat/chat-composer.test.ts ui/src/pages/chat/chat-view.test.ts ui/src/pages/new-session/composer-dictation-control.test.ts
# Final rerun: 401 passed, including duplicate dictation-announcement cleanup.

node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/browser-talk-microphone-lifetime.e2e.test.ts
# 2 passed

node --import ./scripts/tsx.mjs scripts/control-ui-i18n-verify.ts baseline
node --import ./scripts/tsx.mjs scripts/control-ui-i18n-verify.ts verify
# Passed; no generated locale changes.
```

Fresh Codex autoreview against the pinned baseline found no actionable P0-P2 findings.

</details>

Known separate follow-ups: #133351 tracks Google interruption turn correlation. Long microphone waits can also expire an already-created short-lived offer; this PR makes the wait visible but does not change allocation order or extend provider deadlines.

CI correction: initial run 33320952669 found the existing WebRTC test file at 1002 counted lines. Shared the repeated peer lookup guard without changing assertions; the focused 27-test rerun and exact core lint command passed:

```sh
node scripts/run-vitest.mjs ui/src/pages/chat/realtime-talk-webrtc.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ui/src/pages/chat/realtime-talk-webrtc.test.ts
```

The full candidate received another clean pinned Codex review before the correction was pushed. Local broad changed-check verification is limited by the shared checkout dependency tree resolving pako 1.0.11 instead of the locked UI 3.0.1; the artifact-preparing lint invocation also encountered stale Telegram dependency types. No dependencies or gates were changed. The correctly scoped core lint passed, and the first clean hosted run passed its UI/type and browser lanes. Exact-head hosted CI remains required for landing. Long microphone allocation delay is tracked in #133359.
