### PR TITLE
fix(gateway): retry node wakes after clock rollback

### DIFF
--- a/src/gateway/node-wake-state-store.ts
+++ b/src/gateway/node-wake-state-store.ts
@@ -10,9 +10,10 @@ type StoredNodeWakeAttempt = {
 export type NodeWakeOwnerState = {
   nodeId: string;
   stateKey: string;
-  lastWakeAtMs: number;
+  // Process-local monotonic times; wall-clock changes must not alter throttling.
+  lastWakeAtMs?: number;
   inFlightWake?: Promise<StoredNodeWakeAttempt>;
-  lastNudgeAtMs: number;
+  lastNudgeAtMs?: number;
   lifecycle?: {
     controller: AbortController;
     users: number;

--- a/src/gateway/node-wake-state.test-support.ts
+++ b/src/gateway/node-wake-state.test-support.ts
@@ -6,9 +6,9 @@ export function getNodeWakeStateSnapshot(
   pairingGeneration?: string,
 ):
   | {
-      lastWakeAtMs: number;
+      lastWakeAtMs: number | undefined;
       wakeInFlight: boolean;
-      lastNudgeAtMs: number;
+      lastNudgeAtMs: number | undefined;
       lifecycleUsers: number;
     }
   | undefined {

--- a/src/gateway/node-wake-state.test.ts
+++ b/src/gateway/node-wake-state.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   captureNodeWakeLifecycle,
   clearNodeWakeState,
@@ -23,6 +23,10 @@ const sentWake: NodeWakeAttempt = {
 
 beforeEach(() => {
   resetNodeWakeStateForTest();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("node wake lifecycle ownership", () => {
@@ -123,6 +127,33 @@ describe("node wake coordination", () => {
     });
   });
 
+  it("allows a wake retry after the system clock moves backward", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:10.000Z"));
+    const attempt = vi.fn(async (markAttempted: () => void) => {
+      markAttempted();
+      return sentWake;
+    });
+
+    await runNodeWakeAttempt({
+      nodeId: "node-clock-rollback",
+      force: false,
+      throttleMs: 60_000,
+      attempt,
+    });
+    vi.setSystemTime(new Date("2026-01-01T00:00:05.000Z"));
+
+    await expect(
+      runNodeWakeAttempt({
+        nodeId: "node-clock-rollback",
+        force: false,
+        throttleMs: 60_000,
+        attempt,
+      }),
+    ).resolves.toEqual(sentWake);
+    expect(attempt).toHaveBeenCalledTimes(2);
+  });
+
   it("tracks reconnect-nudge throttle independently from wake throttle", async () => {
     const sent = await runNodeWakeNudgeAttempt({
       nodeId: "node-1",
@@ -141,5 +172,40 @@ describe("node wake coordination", () => {
     expect(throttled.reason).toBe("throttled");
     expect(getNodeWakeStateSnapshot("node-1")?.lastWakeAtMs).toBe(0);
     expect(getNodeWakeStateSnapshot("node-1")?.lastNudgeAtMs).toBeGreaterThan(0);
+  });
+
+  it("allows a reconnect nudge after the system clock moves backward", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:10.000Z"));
+    const attempt = vi.fn(async () => ({
+      sent: true,
+      throttled: false,
+      reason: "sent" as const,
+      durationMs: 1,
+    }));
+    const throttled = () => ({
+      sent: false,
+      throttled: true,
+      reason: "throttled" as const,
+      durationMs: 0,
+    });
+
+    await runNodeWakeNudgeAttempt({
+      nodeId: "node-clock-rollback",
+      throttleMs: 60_000,
+      throttled,
+      attempt,
+    });
+    vi.setSystemTime(new Date("2026-01-01T00:00:05.000Z"));
+
+    await expect(
+      runNodeWakeNudgeAttempt({
+        nodeId: "node-clock-rollback",
+        throttleMs: 60_000,
+        throttled,
+        attempt,
+      }),
+    ).resolves.toMatchObject({ reason: "sent" });
+    expect(attempt).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/gateway/node-wake-state.test.ts
+++ b/src/gateway/node-wake-state.test.ts
@@ -26,7 +26,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  vi.useRealTimers();
+  vi.restoreAllMocks();
 });
 
 describe("node wake lifecycle ownership", () => {
@@ -70,12 +70,48 @@ describe("node wake lifecycle ownership", () => {
     clearNodeWakeState("node-active");
 
     expect(lifecycle.aborted).toBe(false);
-    expect(getNodeWakeStateSnapshot("node-active")?.lastWakeAtMs).toBe(0);
+    expect(getNodeWakeStateSnapshot("node-active")?.lastWakeAtMs).toBeUndefined();
     releaseNodeWakeLifecycle("node-active", lifecycle);
   });
 });
 
 describe("node wake coordination", () => {
+  it.each([-3_600_000, 3_600_000])(
+    "keeps wake and nudge throttle intervals across a %i ms wall-clock change",
+    async (clockChange) => {
+      let elapsed = 0;
+      vi.spyOn(performance, "now").mockImplementation(() => elapsed);
+      const wallClock = vi.spyOn(Date, "now").mockReturnValue(10_000_000);
+      const wake = () =>
+        runNodeWakeAttempt({
+          nodeId: "clock-node",
+          force: false,
+          throttleMs: 1_000,
+          attempt: async (markAttempted) => {
+            markAttempted();
+            return sentWake;
+          },
+        });
+      const nudge = () =>
+        runNodeWakeNudgeAttempt({
+          nodeId: "clock-node",
+          throttleMs: 1_000,
+          throttled: () => ({ sent: false, throttled: true, reason: "throttled", durationMs: 0 }),
+          attempt: async () => ({ sent: true, throttled: false, reason: "sent", durationMs: 0 }),
+        });
+
+      expect((await wake()).path).toBe("sent");
+      expect((await nudge()).reason).toBe("sent");
+      wallClock.mockReturnValue(10_000_000 + clockChange);
+      elapsed = 999;
+      expect((await wake()).path).toBe("throttled");
+      expect((await nudge()).reason).toBe("throttled");
+      elapsed = 1_000;
+      expect((await wake()).path).toBe("sent");
+      expect((await nudge()).reason).toBe("sent");
+    },
+  );
+
   it("deduplicates concurrent wake attempts for one generation", async () => {
     let finish: ((attempt: NodeWakeAttempt) => void) | undefined;
     const attempt = vi.fn(
@@ -127,33 +163,6 @@ describe("node wake coordination", () => {
     });
   });
 
-  it("allows a wake retry after the system clock moves backward", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:10.000Z"));
-    const attempt = vi.fn(async (markAttempted: () => void) => {
-      markAttempted();
-      return sentWake;
-    });
-
-    await runNodeWakeAttempt({
-      nodeId: "node-clock-rollback",
-      force: false,
-      throttleMs: 60_000,
-      attempt,
-    });
-    vi.setSystemTime(new Date("2026-01-01T00:00:05.000Z"));
-
-    await expect(
-      runNodeWakeAttempt({
-        nodeId: "node-clock-rollback",
-        force: false,
-        throttleMs: 60_000,
-        attempt,
-      }),
-    ).resolves.toEqual(sentWake);
-    expect(attempt).toHaveBeenCalledTimes(2);
-  });
-
   it("tracks reconnect-nudge throttle independently from wake throttle", async () => {
     const sent = await runNodeWakeNudgeAttempt({
       nodeId: "node-1",
@@ -170,42 +179,7 @@ describe("node wake coordination", () => {
 
     expect(sent.reason).toBe("sent");
     expect(throttled.reason).toBe("throttled");
-    expect(getNodeWakeStateSnapshot("node-1")?.lastWakeAtMs).toBe(0);
+    expect(getNodeWakeStateSnapshot("node-1")?.lastWakeAtMs).toBeUndefined();
     expect(getNodeWakeStateSnapshot("node-1")?.lastNudgeAtMs).toBeGreaterThan(0);
-  });
-
-  it("allows a reconnect nudge after the system clock moves backward", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:10.000Z"));
-    const attempt = vi.fn(async () => ({
-      sent: true,
-      throttled: false,
-      reason: "sent" as const,
-      durationMs: 1,
-    }));
-    const throttled = () => ({
-      sent: false,
-      throttled: true,
-      reason: "throttled" as const,
-      durationMs: 0,
-    });
-
-    await runNodeWakeNudgeAttempt({
-      nodeId: "node-clock-rollback",
-      throttleMs: 60_000,
-      throttled,
-      attempt,
-    });
-    vi.setSystemTime(new Date("2026-01-01T00:00:05.000Z"));
-
-    await expect(
-      runNodeWakeNudgeAttempt({
-        nodeId: "node-clock-rollback",
-        throttleMs: 60_000,
-        throttled,
-        attempt,
-      }),
-    ).resolves.toMatchObject({ reason: "sent" });
-    expect(attempt).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/gateway/node-wake-state.ts
+++ b/src/gateway/node-wake-state.ts
@@ -124,10 +124,12 @@ export async function runNodeWakeAttempt(params: {
   if (owner.inFlightWake) {
     return await owner.inFlightWake;
   }
+  const now = Date.now();
   if (
     !params.force &&
     owner.lastWakeAtMs > 0 &&
-    Date.now() - owner.lastWakeAtMs < params.throttleMs
+    now >= owner.lastWakeAtMs &&
+    now - owner.lastWakeAtMs < params.throttleMs
   ) {
     return { available: true, throttled: true, path: "throttled", durationMs: 0 };
   }
@@ -155,7 +157,12 @@ export async function runNodeWakeNudgeAttempt(params: {
   attempt: () => Promise<NodeWakeNudgeAttempt>;
 }): Promise<NodeWakeNudgeAttempt> {
   const owner = getOrCreateNodeWakeOwner(params.nodeId, params.pairingGeneration);
-  if (owner.lastNudgeAtMs > 0 && Date.now() - owner.lastNudgeAtMs < params.throttleMs) {
+  const now = Date.now();
+  if (
+    owner.lastNudgeAtMs > 0 &&
+    now >= owner.lastNudgeAtMs &&
+    now - owner.lastNudgeAtMs < params.throttleMs
+  ) {
     return params.throttled();
   }
   const result = await params.attempt();

--- a/src/gateway/node-wake-state.ts
+++ b/src/gateway/node-wake-state.ts
@@ -47,8 +47,6 @@ function getOrCreateNodeWakeOwner(nodeId: string, pairingGeneration?: string): N
   const created: NodeWakeOwnerState = {
     nodeId: normalizedNodeId,
     stateKey,
-    lastWakeAtMs: 0,
-    lastNudgeAtMs: 0,
   };
   nodeWakeStateByOwner.set(stateKey, created);
   return created;
@@ -58,8 +56,8 @@ function deleteIdleNodeWakeOwner(owner: NodeWakeOwnerState): void {
   if (
     owner.lifecycle?.users ||
     owner.inFlightWake ||
-    owner.lastWakeAtMs > 0 ||
-    owner.lastNudgeAtMs > 0
+    owner.lastWakeAtMs !== undefined ||
+    owner.lastNudgeAtMs !== undefined
   ) {
     return;
   }
@@ -124,18 +122,16 @@ export async function runNodeWakeAttempt(params: {
   if (owner.inFlightWake) {
     return await owner.inFlightWake;
   }
-  const now = Date.now();
   if (
     !params.force &&
-    owner.lastWakeAtMs > 0 &&
-    now >= owner.lastWakeAtMs &&
-    now - owner.lastWakeAtMs < params.throttleMs
+    owner.lastWakeAtMs !== undefined &&
+    performance.now() - owner.lastWakeAtMs < params.throttleMs
   ) {
     return { available: true, throttled: true, path: "throttled", durationMs: 0 };
   }
 
   const attempt = params.attempt(() => {
-    owner.lastWakeAtMs = Date.now();
+    owner.lastWakeAtMs = performance.now();
   });
   owner.inFlightWake = attempt;
   try {
@@ -157,17 +153,15 @@ export async function runNodeWakeNudgeAttempt(params: {
   attempt: () => Promise<NodeWakeNudgeAttempt>;
 }): Promise<NodeWakeNudgeAttempt> {
   const owner = getOrCreateNodeWakeOwner(params.nodeId, params.pairingGeneration);
-  const now = Date.now();
   if (
-    owner.lastNudgeAtMs > 0 &&
-    now >= owner.lastNudgeAtMs &&
-    now - owner.lastNudgeAtMs < params.throttleMs
+    owner.lastNudgeAtMs !== undefined &&
+    performance.now() - owner.lastNudgeAtMs < params.throttleMs
   ) {
     return params.throttled();
   }
   const result = await params.attempt();
   if (result.reason === "sent") {
-    owner.lastNudgeAtMs = Date.now();
+    owner.lastNudgeAtMs = performance.now();
   }
   deleteIdleNodeWakeOwner(owner);
   return result;
@@ -179,9 +173,9 @@ export function clearNodeWakeState(nodeId: string): void {
     if (owner.nodeId !== normalizedNodeId) {
       continue;
     }
-    owner.lastWakeAtMs = 0;
+    owner.lastWakeAtMs = undefined;
     owner.inFlightWake = undefined;
-    owner.lastNudgeAtMs = 0;
+    owner.lastNudgeAtMs = undefined;
     deleteIdleNodeWakeOwner(owner);
   }
 }

--- a/src/gateway/server-methods/nodes.invoke-wake.test.ts
+++ b/src/gateway/server-methods/nodes.invoke-wake.test.ts
@@ -1384,6 +1384,33 @@ describe("node.invoke APNs wake path", () => {
     expect(mocks.sendApnsBackgroundWake).not.toHaveBeenCalled();
   });
 
+  it("retries a direct wake after the system clock moves backward", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:10.000Z"));
+    const nodeId = "ios-node-clock-rollback";
+    mockDirectWakeConfig(nodeId);
+    mocks.sendApnsBackgroundWake.mockResolvedValue({
+      ok: true,
+      status: 200,
+      tokenSuffix: "1234abcd",
+      topic: "ai.openclaw.ios",
+      environment: "sandbox",
+      transport: "direct",
+    });
+
+    await expect(maybeWakeNodeWithApns(nodeId)).resolves.toMatchObject({
+      path: "sent",
+      throttled: false,
+    });
+    vi.setSystemTime(new Date("2026-01-01T00:00:05.000Z"));
+
+    await expect(maybeWakeNodeWithApns(nodeId)).resolves.toMatchObject({
+      path: "sent",
+      throttled: false,
+    });
+    expect(mocks.sendApnsBackgroundWake).toHaveBeenCalledTimes(2);
+  });
+
   it("does not share an in-flight wake with a replacement pairing generation", async () => {
     const nodeId = "ios-node-replacement-in-flight";
     const generationOne = { nodeId, key: "generation-1" };

--- a/src/gateway/server-methods/nodes.invoke-wake.test.ts
+++ b/src/gateway/server-methods/nodes.invoke-wake.test.ts
@@ -1384,33 +1384,6 @@ describe("node.invoke APNs wake path", () => {
     expect(mocks.sendApnsBackgroundWake).not.toHaveBeenCalled();
   });
 
-  it("retries a direct wake after the system clock moves backward", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:10.000Z"));
-    const nodeId = "ios-node-clock-rollback";
-    mockDirectWakeConfig(nodeId);
-    mocks.sendApnsBackgroundWake.mockResolvedValue({
-      ok: true,
-      status: 200,
-      tokenSuffix: "1234abcd",
-      topic: "ai.openclaw.ios",
-      environment: "sandbox",
-      transport: "direct",
-    });
-
-    await expect(maybeWakeNodeWithApns(nodeId)).resolves.toMatchObject({
-      path: "sent",
-      throttled: false,
-    });
-    vi.setSystemTime(new Date("2026-01-01T00:00:05.000Z"));
-
-    await expect(maybeWakeNodeWithApns(nodeId)).resolves.toMatchObject({
-      path: "sent",
-      throttled: false,
-    });
-    expect(mocks.sendApnsBackgroundWake).toHaveBeenCalledTimes(2);
-  });
-
   it("does not share an in-flight wake with a replacement pairing generation", async () => {
     const nodeId = "ios-node-replacement-in-flight";
     const generationOne = { nodeId, key: "generation-1" };
@@ -2056,6 +2029,35 @@ describe("node.invoke APNs wake path", () => {
     await expect(reconnectPromise).resolves.toBe(false);
     expect(nodeRegistry.get).toHaveBeenCalledWith("ios-node-never-reconnects");
   });
+
+  it.each([-3_600_000, 3_600_000])(
+    "keeps the reconnect wait interval across a %i ms wall-clock change",
+    async (clockChange) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(10_000_000);
+      const nodeRegistry = {
+        get: vi.fn(() => undefined),
+        getForPairingGeneration: vi.fn(() => undefined),
+      };
+      let settled = false;
+      const reconnect = waitForNodeReconnect({
+        nodeId: "clock-node",
+        context: { nodeRegistry },
+        timeoutMs: 300,
+        pollMs: 50,
+      }).then((result) => {
+        settled = true;
+        return result;
+      });
+
+      vi.setSystemTime(10_000_000 + clockChange);
+      await vi.advanceTimersByTimeAsync(299);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(settled).toBe(true);
+      await expect(reconnect).resolves.toBe(false);
+    },
+  );
 
   it("broadcasts canonical Talk capture events for successful PTT node commands", async () => {
     const respond = vi.fn();

--- a/src/gateway/server-methods/nodes.wake.ts
+++ b/src/gateway/server-methods/nodes.wake.ts
@@ -100,11 +100,11 @@ export async function maybeWakeNodeWithApns(
       force: opts?.force === true,
       throttleMs: nodeInvokePolicy.wakeThrottleMs,
       attempt: async (markAttempted) => {
-        const startedAtMs = Date.now();
+        const startedAtMs = performance.now();
         let attempted = false;
         const withDuration = (attempt: Omit<NodeWakeAttempt, "durationMs">): NodeWakeAttempt => ({
           ...attempt,
-          durationMs: Math.max(0, Date.now() - startedAtMs),
+          durationMs: Math.round(performance.now() - startedAtMs),
         });
         const markWakeAttempted = () => {
           attempted = true;
@@ -220,12 +220,12 @@ export async function maybeSendNodeWakeNudge(
     generation?: NodePairingGeneration;
   },
 ): Promise<NodeWakeNudgeAttempt> {
-  const startedAtMs = Date.now();
+  const startedAtMs = performance.now();
   const withDuration = (
     attempt: Omit<NodeWakeNudgeAttempt, "durationMs">,
   ): NodeWakeNudgeAttempt => ({
     ...attempt,
-    durationMs: Math.max(0, Date.now() - startedAtMs),
+    durationMs: Math.round(performance.now() - startedAtMs),
   });
   const lifecycleProvided = opts?.lifecycle !== undefined;
   const pairingGeneration = opts?.generation?.key;
@@ -356,9 +356,9 @@ export async function waitForNodeReconnect(params: {
 }): Promise<boolean> {
   const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, NODE_WAKE_RECONNECT_WAIT_MS, 1);
   const pollMs = resolveTimerTimeoutMs(params.pollMs, NODE_WAKE_RECONNECT_POLL_MS, 50);
-  const deadline = Date.now() + timeoutMs;
+  const deadline = performance.now() + timeoutMs;
 
-  while (Date.now() < deadline) {
+  while (performance.now() < deadline) {
     if (
       params.lifecycle &&
       !isNodeWakeLifecycleCurrent(params.nodeId, params.lifecycle, params.pairingGeneration)
@@ -371,7 +371,7 @@ export async function waitForNodeReconnect(params: {
     if (resolveDispatchableNodeSession(session)) {
       return true;
     }
-    await delayMs(Math.min(pollMs, Math.max(0, deadline - Date.now())));
+    await delayMs(Math.min(pollMs, Math.max(0, deadline - performance.now())));
   }
   if (
     params.lifecycle &&


### PR DESCRIPTION
## What Problem This Solves

Host clock corrections can suppress node wakes for too long or bypass their throttle. Reconnect waits use the same wall-clock arithmetic and can finish early or run beyond their intended interval.

## Why This Change Was Made

The Gateway's process-local wake owner now measures wake and nudge intervals with `performance.now()`. The reconnect helper and wake/nudge duration measurements use that same elapsed-time clock. An absent prior attempt is represented explicitly, so a valid monotonic timestamp of zero still retains the throttle and lifecycle owner.

The repair removes the zero-as-absence timestamp convention and keeps the existing pairing generation, cancellation, in-flight deduplication, forced retry, and cleanup owners. Signed relay requests still use wall-clock timestamps. There is no configuration, storage, migration, or protocol change.

Production +22/-20 (net +2), including the owner comment and optional timestamp representation; tests/test support +74/-5 (net +69). The small increase represents the explicit distinction between no attempt and a real attempt at time zero.

## User Impact

Node wake throttles and reconnect intervals remain stable across backward and forward wall-clock changes. Wake duration diagnostics report elapsed milliseconds. Thanks @qingminglong for the original report and fix.

## Evidence

Independently authored proof used trusted main `2f6d085fc3b6a7f9fbf27b4e614f7542689b680e` and Node 24.20.0 with an isolated temporary state directory.

- Four regressions failed on unchanged production: wake throttling after a backward/forward one-hour correction, and reconnect waits after the same corrections. After repair, all 85 owner and Gateway sibling tests pass, including forced retry, no-registration cleanup, pairing replacement, and in-flight cancellation.
- The real wake/nudge helpers used the SQLite registration owner, device signer, and fetch client against a synthetic loopback relay. Before repair, the rollback never resumed sending after elapsed expiry, while the forward jump sent prematurely. After repair, both cases throttle during the interval and send after expiry. All eight resulting requests had verified signatures and wall-clock signing timestamps.
- The relay probe controls elapsed time and wall time independently and checks the duration projection. It proves the production relay client boundary; it does not claim delivery through Apple's service to a physical device.
- Independent full-candidate review completed clean. All applicable changed-file checks passed. The exact published-head CI remains required before landing.

```sh
node scripts/run-vitest.mjs run src/gateway/node-wake-state.test.ts src/gateway/server-methods/nodes.invoke-wake.test.ts src/gateway/server-methods/nodes.wake-leak.test.ts --maxWorkers 2
```

Node's documented [`performance.now()` contract](https://nodejs.org/api/perf_hooks.html#performancenow) is process-relative elapsed time. The relay signing owner continues to use its existing epoch timestamp contract.

## Review follow-through

The original rollback-only predicate would allow an immediate retry during the intended throttle. The final repair retains the actual interval in both directions and covers the sibling reconnect wait. The broader `node.invoke` absolute deadline adapter and aggregate log timers still use wall-clock semantics; auditing those shared absolute-deadline callers is a separate follow-up because their owner contract spans other operations.
