### PR TITLE
fix(codex): explain unavailable selected auth profiles

### DIFF
--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -2664,13 +2664,18 @@ describe("bridgeCodexAppServerStartOptions", () => {
         },
       });
 
-      await expect(
-        applyCodexAppServerAuthProfile({
-          client: { request } as never,
-          agentDir,
-          authProfileId: "anthropic:work",
-        }),
-      ).rejects.toThrow(
+      const rejection = await applyCodexAppServerAuthProfile({
+        client: { request } as never,
+        agentDir,
+        authProfileId: "anthropic:work",
+      }).catch((error: unknown) => error);
+
+      expect(rejection).toBeInstanceOf(Error);
+      expect(rejection).toMatchObject({
+        status: 401,
+        code: "selected_auth_profile_unavailable",
+      });
+      expect((rejection as Error).message).toBe(
         'Codex app-server auth profile "anthropic:work" must use the canonical OpenAI auth provider; run "openclaw doctor --fix" to migrate legacy provider IDs.',
       );
       expect(oauthMocks.refreshOpenAICodexToken).not.toHaveBeenCalled();
@@ -2706,7 +2711,10 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
 
     expect(rejection).toBeInstanceOf(Error);
-    expect((rejection as { status?: unknown }).status).toBe(401);
+    expect(rejection).toMatchObject({
+      status: 401,
+      code: "selected_auth_profile_unavailable",
+    });
     expect(request).not.toHaveBeenCalled();
   });
 

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -800,31 +800,17 @@ export async function applyCodexAppServerAuthProfile(params: {
     await assertNativeCodexAccountMatchesRoute(params.client, params.authRequirement);
     return;
   }
-  let loginParams: CodexLoginAccountParams | undefined;
-  try {
-    loginParams =
-      params.preparedAuth?.kind === "profile"
-        ? params.preparedAuth.snapshot.loginParams
-        : params.preparedAuth?.kind === "api-key"
-          ? { type: "apiKey", apiKey: params.preparedAuth.apiKey }
-          : await resolveCodexAppServerAuthProfileLoginParams({
-              agentDir: params.agentDir,
-              authProfileId: params.authProfileId ?? undefined,
-              authProfileStore: params.authProfileStore,
-              config: params.config,
-            });
-  } catch (error) {
-    if (
-      params.authRequirement === "subscription" &&
-      error instanceof CodexAppServerAuthProfileUnavailableError
-    ) {
-      throw createCodexAppServerAuthError(
-        "Codex subscription auth profile could not produce login credentials. Sign in with `openclaw models auth login --provider openai`, select that profile, then retry.",
-        error,
-      );
-    }
-    throw error;
-  }
+  const loginParams =
+    params.preparedAuth?.kind === "profile"
+      ? params.preparedAuth.snapshot.loginParams
+      : params.preparedAuth?.kind === "api-key"
+        ? { type: "apiKey", apiKey: params.preparedAuth.apiKey }
+        : await resolveCodexAppServerAuthProfileLoginParams({
+            agentDir: params.agentDir,
+            authProfileId: params.authProfileId ?? undefined,
+            authProfileStore: params.authProfileStore,
+            config: params.config,
+          });
   if (params.authRequirement === "subscription" && loginParams?.type !== "chatgptAuthTokens") {
     throw createCodexAppServerAuthError(
       "Codex subscription auth profile could not produce login credentials. Sign in with `openclaw models auth login --provider openai`, select that profile, then retry.",
@@ -888,6 +874,7 @@ function createCodexAppServerAuthError(message: string, cause?: unknown): Error 
 
 class CodexAppServerAuthProfileUnavailableError extends Error {
   readonly status = 401;
+  readonly code = "selected_auth_profile_unavailable";
 }
 
 async function resolveCodexAppServerAuthProfileLoginParams(params: {
@@ -991,12 +978,12 @@ async function resolveCodexAppServerAuthProfileLoginParamsInternal(params: {
   }
   const credential = store.profiles[profileId];
   if (!credential) {
-    throw new Error(
+    throw new CodexAppServerAuthProfileUnavailableError(
       `Codex app-server auth profile "${profileId}" was not found. Select an existing OpenAI profile or sign in again with OpenClaw, then retry.`,
     );
   }
   if (!isCodexAppServerAuthProfileCredential(credential)) {
-    throw new Error(
+    throw new CodexAppServerAuthProfileUnavailableError(
       `Codex app-server auth profile "${profileId}" must use the canonical OpenAI auth provider; run "openclaw doctor --fix" to migrate legacy provider IDs.`,
     );
   }

--- a/src/agents/command/lifecycle.test.ts
+++ b/src/agents/command/lifecycle.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { buildAgentRunTerminalOutcome } from "../agent-run-terminal-outcome.js";
+import { FailoverError } from "../failover-error.js";
+import { renderFailoverCodeUserCopy } from "../failover/user-copy.js";
 import { createAgentCommandLifecycle } from "./lifecycle.js";
 
 const { emitAgentEvent, lifecycleLog } = vi.hoisted(() => ({
@@ -166,6 +168,47 @@ describe("createAgentCommandLifecycle", () => {
       expect(event.data.error).toContain("The provider failed.");
       expect(event.data.error).toContain("Authorization: Bearer");
       expect(JSON.stringify(event)).not.toContain(secret);
+    },
+  );
+
+  it.each(["basic", "post-turn"] as const)(
+    "publishes bounded selected-profile recovery from %s lifecycle errors",
+    (source) => {
+      emitAgentEvent.mockClear();
+      const profileId = "openai:private-profile";
+      const rawCause = `Codex app-server auth profile "${profileId}" was not found`;
+      const lifecycle = createAgentCommandLifecycle({
+        runId: "missing-selected-profile",
+        lifecycleGeneration: () => "test-generation",
+        startedAt: 100,
+        state: {
+          currentTurnUserMessagePersisted: true,
+          lifecycleFinishing: false,
+          lifecycleEnded: false,
+        },
+      });
+      const error = new FailoverError(rawCause, {
+        reason: "auth",
+        code: "selected_auth_profile_unavailable",
+        profileId,
+        cause: new Error(rawCause),
+      });
+
+      if (source === "basic") {
+        lifecycle.emitBasicError(error);
+      } else {
+        lifecycle.emitPostTurnError(error, {
+          metadata: {},
+          outcome: buildAgentRunTerminalOutcome({ status: "error", stopReason: "error" }),
+        });
+      }
+
+      const event = emitAgentEvent.mock.calls[0]?.[0];
+      expect(event.data.error).toBe(
+        renderFailoverCodeUserCopy("selected_auth_profile_unavailable"),
+      );
+      expect(JSON.stringify(event)).not.toContain(profileId);
+      expect(JSON.stringify(event)).not.toContain(rawCause);
     },
   );
 

--- a/src/agents/command/lifecycle.ts
+++ b/src/agents/command/lifecycle.ts
@@ -5,6 +5,8 @@ import { normalizeAgentRunTerminalDeliverySnapshot } from "../agent-run-terminal
 import type { AgentRunTerminalOutcome } from "../agent-run-terminal-outcome.js";
 import { normalizeAgentRunTerminalReceipt } from "../agent-run-terminal-receipt.js";
 import type { EmbeddedAgentRunEntryTerminal } from "../embedded-agent-runner/run-entry.js";
+import { describeFailoverError } from "../failover-error.js";
+import { renderFailoverCodeUserCopy } from "../failover/user-copy.js";
 import {
   AGENT_RUN_SUPERSEDED_STOP_REASON,
   resolveAgentRunAbortLifecycleFields,
@@ -14,6 +16,9 @@ import type { AgentAttemptLifecycleState } from "./attempt-callbacks.js";
 import type { AgentAttemptResult } from "./runtime-loaders.js";
 
 const log = createSubsystemLogger("agents/agent-command");
+
+const formatLifecycleError = (error: unknown): string =>
+  renderFailoverCodeUserCopy(describeFailoverError(error).code) ?? formatErrorMessage(error);
 
 function resolveTerminalLogLevel(
   outcome: AgentRunTerminalOutcome,
@@ -101,7 +106,7 @@ export function createAgentCommandLifecycle(params: {
   };
 
   return {
-    emitBasicError(error: string, extraData?: Record<string, unknown>) {
+    emitBasicError(error: unknown, extraData?: Record<string, unknown>) {
       if (params.state.lifecycleEnded) {
         return;
       }
@@ -114,7 +119,7 @@ export function createAgentCommandLifecycle(params: {
           phase: "error",
           startedAt: params.startedAt,
           endedAt: Date.now(),
-          error: formatErrorMessage(error),
+          error: formatLifecycleError(error),
           ...extraData,
         },
       });
@@ -174,7 +179,7 @@ export function createAgentCommandLifecycle(params: {
           phase: "error",
           startedAt: params.startedAt,
           endedAt: Date.now(),
-          error: formatErrorMessage(error),
+          error: formatLifecycleError(error),
           ...(terminalDelivery ? { terminalDelivery } : {}),
           ...resolveAgentRunErrorLifecycleFields(error, params.abortSignal),
         },

--- a/src/agents/command/run-embedded-attempt.ts
+++ b/src/agents/command/run-embedded-attempt.ts
@@ -670,7 +670,7 @@ export async function runEmbeddedAgentAttempt(params: {
         ? { aborted: true as const, stopReason: "aborted" as const }
         : resolveAgentRunErrorLifecycleFields(err, params.opts.abortSignal);
       lifecycle.emitBasicError(
-        err instanceof Error ? err.message : "Agent run failed",
+        err instanceof Error ? err : new Error("Agent run failed"),
         errorLifecycleFields,
       );
       await fallbackTrajectoryRecorder?.flush();

--- a/src/agents/embedded-agent-runner/run/auth-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.test.ts
@@ -645,6 +645,36 @@ describe("createEmbeddedRunAuthController", () => {
     },
   );
 
+  it("preserves selected-profile identity through auth exhaustion bookkeeping", async () => {
+    const harness = createMutableAuthControllerHarness();
+    mocks.getApiKeyForModelCore.mockRejectedValue(
+      Object.assign(new Error("selected profile missing"), {
+        status: 401,
+        code: "selected_auth_profile_unavailable",
+      }),
+    );
+    const controller = createMutableEmbeddedRunAuthController({
+      harness,
+      setRuntimeApiKey: vi.fn(),
+      profileCandidates: ["first", "second"],
+      fallbackConfigured: true,
+    });
+
+    const error = await controller.initializeAuthProfile().catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(FailoverError);
+    expect(error).toMatchObject({
+      reason: "auth",
+      code: "selected_auth_profile_unavailable",
+      authProfileFailure: { allInCooldown: false },
+    });
+    expect(mocks.getApiKeyForModelCore.mock.calls.map(([params]) => params.profileId)).toEqual([
+      "first",
+      "second",
+    ]);
+    expect(harness.profileIndex).toBe(2);
+  });
+
   it("only enables transient cooldown probing when every automatic profile is transiently cooled", () => {
     const now = Date.now();
     const createStore = (

--- a/src/agents/embedded-agent-runner/run/auth-controller.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.ts
@@ -20,7 +20,11 @@ import {
   isFailoverErrorMessage,
   type FailoverReason,
 } from "../../embedded-agent-helpers.js";
-import { FailoverError, resolveFailoverStatus } from "../../failover-error.js";
+import {
+  describeFailoverError,
+  FailoverError,
+  resolveFailoverStatus,
+} from "../../failover-error.js";
 import { shouldUseTransientCooldownProbeSlot } from "../../failover-policy.js";
 import { renderAuthProfileFailoverCopy } from "../../failover/user-copy.js";
 import {
@@ -498,6 +502,7 @@ export function createEmbeddedRunAuthController(params: {
         model: modelId,
         authMode,
         status: resolveFailoverStatus(reason),
+        code: failoverParams.error ? describeFailoverError(failoverParams.error).code : undefined,
         authProfileFailure: { allInCooldown: failoverParams.allInCooldown },
         cause: failoverParams.error,
       });

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -758,6 +758,22 @@ describe("failover-error", () => {
     expect(err?.provider).toBe("anthropic");
   });
 
+  it("preserves a selected-profile error code in the auth failover lane", () => {
+    const err = coerceToFailoverError(
+      Object.assign(new Error("selected profile missing"), {
+        status: 401,
+        code: "selected_auth_profile_unavailable",
+      }),
+      { provider: "openai", model: "gpt-5.6-sol" },
+    );
+
+    expect(err).toMatchObject({
+      reason: "auth",
+      status: 401,
+      code: "selected_auth_profile_unavailable",
+    });
+  });
+
   it("permission_error with organization denial stays auth_permanent", () => {
     const err = coerceToFailoverError(
       "HTTP 403 permission_error: OAuth authentication is currently not allowed for this organization.",
@@ -794,6 +810,7 @@ describe("failover-error", () => {
       sessionId: "session:browser-abcd",
       lane: "answer",
       status: 429,
+      code: "selected_auth_profile_unavailable",
     });
     expect(err.sessionId).toBe("session:browser-abcd");
     expect(err.lane).toBe("answer");
@@ -806,6 +823,7 @@ describe("failover-error", () => {
     expect(description.lane).toBe("answer");
     expect(description.reason).toBe("rate_limit");
     expect(description.status).toBe(429);
+    expect(description.code).toBe("selected_auth_profile_unavailable");
   });
 
   it("coerceToFailoverError carries sessionId/lane from context (#42713)", () => {

--- a/src/agents/failover/user-copy.test.ts
+++ b/src/agents/failover/user-copy.test.ts
@@ -3,6 +3,7 @@ import {
   renderFormatErrorCopy,
   renderBillingReplyCopy,
   renderCliTimeoutReplyCopy,
+  renderFailoverCodeUserCopy,
   renderMissingApiKeyReplyCopy,
   renderRateLimitOrOverloadedCopy,
   renderRateLimitReplyCopy,
@@ -11,6 +12,18 @@ import {
 describe("failover user copy", () => {
   const tokenLimitCopy =
     "LLM request rejected: configured maxTokens is 384000, above the provider maximum of 65536. Lower maxTokens and try again.";
+
+  it("renders only the allowlisted selected-profile code", () => {
+    expect(renderFailoverCodeUserCopy("selected_auth_profile_unavailable")).toBe(
+      "The selected auth profile is unavailable in this agent's OpenClaw credential store. " +
+        "Import or migrate that credential into the agent, select another configured profile, or run `openclaw configure`, then retry.",
+    );
+    expect(renderFailoverCodeUserCopy("plugin_selected_profile_unavailable")).toBeUndefined();
+    expect(
+      renderFailoverCodeUserCopy({ code: "selected_auth_profile_unavailable" }),
+    ).toBeUndefined();
+  });
+
   it("renders transient copy from the classified reason", () => {
     const raw = "429 Too Many Requests: model overloaded";
     expect(renderRateLimitOrOverloadedCopy({ reason: "rate_limit", raw })).toBe(

--- a/src/agents/failover/user-copy.ts
+++ b/src/agents/failover/user-copy.ts
@@ -38,6 +38,13 @@ export const AUTH_INVALID_TOKEN_USER_TEXT =
   "Authentication failed (provider returned HTTP 401). " +
   "Your provider token may have expired — try the request again in a moment. " +
   "If the failure persists, re-authenticate this provider.";
+const SELECTED_AUTH_PROFILE_UNAVAILABLE_USER_TEXT =
+  "The selected auth profile is unavailable in this agent's OpenClaw credential store. " +
+  "Import or migrate that credential into the agent, select another configured profile, or run `openclaw configure`, then retry.";
+export const renderFailoverCodeUserCopy = (code: unknown): string | undefined =>
+  code === "selected_auth_profile_unavailable"
+    ? SELECTED_AUTH_PROFILE_UNAVAILABLE_USER_TEXT
+    : undefined;
 const MODEL_CAPACITY_ERROR_USER_MESSAGE =
   "⚠️ Selected model is at capacity. Try a different model, or wait and retry.";
 const OVERLOADED_ERROR_USER_MESSAGE =

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -805,6 +805,44 @@ describe("runWithModelFallback", () => {
     ]);
   });
 
+  it("preserves selected-profile identity in exhausted fallback summaries", async () => {
+    const code = "selected_auth_profile_unavailable";
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new FailoverError("primary selected profile missing", {
+          provider: "openai",
+          model: "gpt-5.5",
+          reason: "auth",
+          status: 401,
+          code,
+        }),
+      )
+      .mockRejectedValueOnce(
+        new FailoverError("fallback selected profile missing", {
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+          reason: "auth",
+          status: 401,
+          code,
+        }),
+      );
+
+    const error = requireFallbackSummaryError(
+      await captureRejection(
+        runWithModelFallback({
+          cfg: makeDiagnosticFallbackConfig(["anthropic/claude-opus-4-6"]),
+          provider: "openai",
+          model: "gpt-5.5",
+          run,
+        }),
+      ),
+    );
+
+    expect(error).toMatchObject({ reason: "auth", status: 401, code });
+    expect(error.attempts).toMatchObject([{ code }, { code }]);
+  });
+
   it("does not replay CLI max-turn failures on configured fallback models", async () => {
     const failure = new FailoverError(
       "Claude CLI stopped after reaching the maximum number of turns (limit: 1). Tool actions may already have run; verify their effects before retrying.",

--- a/src/auto-reply/reply/agent-lifecycle-terminal.test.ts
+++ b/src/auto-reply/reply/agent-lifecycle-terminal.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import { FailoverError } from "../../agents/failover-error.js";
+import { renderFailoverCodeUserCopy } from "../../agents/failover/user-copy.js";
+import { createAgentLifecycleTerminalBackstop } from "./agent-lifecycle-terminal.js";
+
+const { emitAgentEvent } = vi.hoisted(() => ({ emitAgentEvent: vi.fn() }));
+
+vi.mock("../../infra/agent-events.js", () => ({ emitAgentEvent }));
+
+describe("createAgentLifecycleTerminalBackstop", () => {
+  it("publishes bounded selected-profile recovery from typed failures", () => {
+    const profileId = "openai:private-profile";
+    const rawCause = `Codex app-server auth profile "${profileId}" was not found`;
+    const terminal = createAgentLifecycleTerminalBackstop({
+      runId: "missing-selected-profile",
+      sessionKey: "agent:main:test",
+      getLifecycleGeneration: () => "test-generation",
+      resolveTerminationFields: () => ({}),
+    });
+
+    terminal.emit(
+      "error",
+      new FailoverError(rawCause, {
+        reason: "auth",
+        code: "selected_auth_profile_unavailable",
+        profileId,
+        cause: new Error(rawCause),
+      }),
+    );
+
+    const event = emitAgentEvent.mock.calls[0]?.[0];
+    expect(event.data.error).toBe(renderFailoverCodeUserCopy("selected_auth_profile_unavailable"));
+    expect(JSON.stringify(event)).not.toContain(profileId);
+    expect(JSON.stringify(event)).not.toContain(rawCause);
+  });
+});

--- a/src/auto-reply/reply/agent-lifecycle-terminal.ts
+++ b/src/auto-reply/reply/agent-lifecycle-terminal.ts
@@ -1,4 +1,6 @@
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
+import { describeFailoverError } from "../../agents/failover-error.js";
+import { renderFailoverCodeUserCopy } from "../../agents/failover/user-copy.js";
 import { AGENT_RUN_RESTART_ABORT_STOP_REASON } from "../../agents/run-termination.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -99,7 +101,9 @@ export function createAgentLifecycleTerminalBackstop(params: {
       data.aborted = true;
       data.stopReason = AGENT_RUN_RESTART_ABORT_STOP_REASON;
     } else if (phase === "error") {
-      data.error = formatErrorMessage(resultOrError);
+      data.error =
+        renderFailoverCodeUserCopy(describeFailoverError(resultOrError).code) ??
+        formatErrorMessage(resultOrError);
       Object.assign(data, terminationFields);
     } else {
       const meta =

--- a/src/auto-reply/reply/agent-runner-error-handler.ts
+++ b/src/auto-reply/reply/agent-runner-error-handler.ts
@@ -16,6 +16,7 @@ import {
   HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
   renderBillingReplyCopy,
   renderControlUiAgentFailureCopy,
+  renderFailoverCodeUserCopy,
   renderRateLimitOrOverloadedCopy,
   renderRateLimitReplyCopy,
 } from "../../agents/failover/user-copy.js";
@@ -481,7 +482,9 @@ export async function handleAgentExecutionError(params: {
         )
       : undefined;
   const externalRunFailureReply =
-    !params.shouldSurfaceToControlUi || externalRunFailureCandidate?.presentation
+    !params.shouldSurfaceToControlUi ||
+    externalRunFailureCandidate?.presentation ||
+    renderFailoverCodeUserCopy(failoverFacts.code)
       ? externalRunFailureCandidate
       : undefined;
   const fallbackText = isBilling

--- a/src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts
@@ -479,6 +479,34 @@ describe("executeAgentTurn: authentication failures", () => {
     }
   });
 
+  it("renders bounded recovery when the selected auth profile is unavailable", async () => {
+    state.isInternalMessageChannelMock.mockReturnValue(true);
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new FailoverError('Codex app-server auth profile "openai:private" was not found', {
+        reason: "auth",
+        provider: "openai",
+        status: 401,
+        code: "selected_auth_profile_unavailable",
+        authProfileFailure: { allInCooldown: false },
+        cause: new Error("arbitrary plugin detail for openai:private"),
+      }),
+    );
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(
+        "The selected auth profile is unavailable in this agent's OpenClaw credential store. Import or migrate that credential into the agent, select another configured profile, or run `openclaw configure`, then retry.",
+      );
+      expect(result.payload.text).not.toContain("openai:private");
+      expect(result.payload.text).not.toContain("arbitrary plugin detail");
+      expect(result.payload.text).not.toContain("/login codex");
+      expect(result.payload.presentation).toBeUndefined();
+    }
+  });
+
   it("does not suggest re-authentication for typed format failures", async () => {
     state.runEmbeddedAgentMock.mockRejectedValueOnce(
       new FailoverError("Format failover exhausted for provider openai", {

--- a/src/auto-reply/reply/agent-runner-failure-reply.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.ts
@@ -23,6 +23,7 @@ import {
   renderAuthProfileFailoverCopy,
   renderBillingReplyCopy,
   renderCliTimeoutReplyCopy,
+  renderFailoverCodeUserCopy,
   renderMissingApiKeyReplyCopy,
   renderRateLimitOrOverloadedCopy,
   renderRateLimitReplyCopy,
@@ -54,6 +55,7 @@ export function resolveReplyFailoverFacts(error: unknown, message: string) {
     : null;
   return {
     reason: classification?.kind === "reason" ? classification.reason : undefined,
+    code: described.code,
     provider: described.provider,
     authMode: described.authMode,
     providerRequestError: resolveProviderRequestFailureCopy({
@@ -223,6 +225,10 @@ export function buildExternalRunFailureReply(
   const failoverFacts =
     options?.failoverFacts ??
     resolveReplyFailoverFacts(error ?? normalizedMessage, normalizedMessage);
+  const failoverCodeCopy = renderFailoverCodeUserCopy(failoverFacts.code);
+  if (failoverCodeCopy) {
+    return { text: failoverCodeCopy, isGenericRunnerFailure: false };
+  }
   const oauthRefreshFailure =
     classifyOAuthRefreshFailureError(error) ?? classifyOAuthRefreshFailure(normalizedMessage);
   const codexLoginRecovery = buildCodexLoginRecovery({

--- a/test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
@@ -1,9 +1,15 @@
 // QA Lab Codex auth product proof exercises doctor, SQLite, Gateway, and app-server together.
+import fs from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createJsonlRequestTailer } from "../../../../scripts/e2e/lib/codex-media-path/jsonl-request-tail.mts";
+import { GatewayClient } from "../../../../src/gateway/client.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../../../src/state/openclaw-agent-db.js";
 import { loadBundledPluginFacade } from "../../../../src/test-utils/bundled-plugin-public-surface.js";
+import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+} from "../../../../src/utils/message-channel.js";
 import { connectGatewayStatusClient, postJson } from "../../../helpers/gateway-e2e-harness.js";
 import {
   createOpenClawTestInstance,
@@ -14,6 +20,11 @@ import { runCodexAuthDoctorMigrationProof } from "./codex-auth-product-proof.tes
 const oauthAccess = "test-oauth-access";
 const ACCOUNT_ID = "qa-codex-account";
 const MODEL = "openai/gpt-5.6-luna";
+const NATIVE_MODEL = "openai/gpt-future";
+const MISSING_PROFILE_ID = "openai:missing";
+const SELECTED_AUTH_PROFILE_UNAVAILABLE_USER_TEXT =
+  "The selected auth profile is unavailable in this agent's OpenClaw credential store. " +
+  "Import or migrate that credential into the agent, select another configured profile, or run `openclaw configure`, then retry.";
 const PRODUCT_OUTPUT = "QA_CODEX_AUTH_PRODUCT_PROOF_OK";
 const REQUEST_TIMEOUT_MS = 60_000;
 
@@ -28,7 +39,29 @@ type AppServerLogEntry = {
 
 type AppServerRequestLog = { read(): AppServerLogEntry[] };
 
-type GatewayHistory = Record<string, unknown> & { messages?: unknown[] };
+type GatewayHistory = Record<string, unknown> & {
+  messages?: unknown[];
+  sessionInfo?: { lastRunError?: unknown };
+};
+
+type GatewayEvent = { event?: string; payload?: unknown };
+
+function expectBoundedMissingProfileRecovery(
+  value: unknown,
+  options?: { allowSessionTruncation?: boolean },
+) {
+  const serialized = JSON.stringify(value);
+  if (options?.allowSessionTruncation) {
+    expect(typeof value).toBe("string");
+    expect(SELECTED_AUTH_PROFILE_UNAVAILABLE_USER_TEXT.startsWith(String(value))).toBe(true);
+  } else {
+    expect(serialized).toContain(SELECTED_AUTH_PROFILE_UNAVAILABLE_USER_TEXT);
+  }
+  expect(serialized).not.toContain(MISSING_PROFILE_ID);
+  expect(serialized).not.toContain("was not found");
+  expect(serialized).not.toContain("Codex app-server auth profile");
+  expect(serialized).not.toContain("/login codex");
+}
 
 afterEach(async () => {
   closeOpenClawAgentDatabasesForTest();
@@ -53,6 +86,18 @@ function waitForRequest(requestLog: AppServerRequestLog, method: string) {
     },
     { interval: 25, timeout: REQUEST_TIMEOUT_MS },
   );
+}
+
+function chatgptAccessToken(accountId: string): string {
+  return [
+    Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url"),
+    Buffer.from(
+      JSON.stringify({
+        "https://api.openai.com/auth": { chatgpt_account_id: accountId },
+      }),
+    ).toString("base64url"),
+    "test-signature",
+  ].join(".");
 }
 
 async function waitForAssistantHistory(testInstance: OpenClawTestInstance, expected: string) {
@@ -103,6 +148,50 @@ async function waitForAssistantHistory(testInstance: OpenClawTestInstance, expec
   } finally {
     client.stop();
   }
+}
+
+async function connectGatewayEventClient(
+  testInstance: OpenClawTestInstance,
+  events: GatewayEvent[],
+) {
+  return await new Promise<GatewayClient>((resolve, reject) => {
+    let settled = false;
+    const finish = (error?: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      if (error) {
+        client.stop();
+        reject(error);
+        return;
+      }
+      resolve(client);
+    };
+    const client = new GatewayClient({
+      url: `ws://127.0.0.1:${testInstance.port}`,
+      origin: `http://127.0.0.1:${testInstance.port}`,
+      token: testInstance.gatewayToken,
+      role: "operator",
+      clientName: GATEWAY_CLIENT_NAMES.WEBCHAT_UI,
+      clientDisplayName: "Codex missing auth profile QA",
+      mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+      scopes: ["operator.admin", "operator.read", "operator.write"],
+      platform: "qa",
+      requestTimeoutMs: REQUEST_TIMEOUT_MS,
+      onEvent: (event) => events.push(event),
+      onHelloOk: () => finish(),
+      onConnectError: (error) => finish(error),
+      onClose: (code, reason) => finish(new Error(`Gateway closed (${code}): ${reason}`)),
+    });
+    const timeout = setTimeout(
+      () => finish(new Error(`Gateway client connection timed out:\n${testInstance.logs()}`)),
+      REQUEST_TIMEOUT_MS,
+    );
+    timeout.unref();
+    client.start();
+  });
 }
 
 describe("Codex auth product proof", () => {
@@ -266,6 +355,218 @@ describe("Codex auth product proof", () => {
               result: accountReadResponse?.result,
             },
           ],
+        })}`,
+      );
+    },
+  );
+
+  it(
+    "returns bounded recovery when the configured profile is absent without calling app-server",
+    { timeout: 180_000 },
+    async () => {
+      const { CODEX_APP_SERVER_VERSION } = await loadBundledPluginFacade<{
+        CODEX_APP_SERVER_VERSION: string;
+      }>({ pluginId: "codex", artifactBasename: "test-api.js" });
+      const appServerFixture = fileURLToPath(
+        new URL("./codex-auth-app-server.fixture.mjs", import.meta.url),
+      );
+      instance = await createOpenClawTestInstance({
+        name: "qa-codex-missing-auth-profile",
+        env: {
+          OPENCLAW_AGENT_HARNESS_FALLBACK: "none",
+          OPENCLAW_QA_CODEX_APP_SERVER_VERSION: CODEX_APP_SERVER_VERSION,
+          OPENCLAW_SKIP_PROVIDERS: undefined,
+        },
+        config: {
+          plugins: {
+            enabled: true,
+            allow: ["codex"],
+            entries: {
+              codex: {
+                enabled: true,
+                config: {
+                  appServer: {
+                    mode: "yolo",
+                    command: process.execPath,
+                    args: [appServerFixture],
+                    requestTimeoutMs: REQUEST_TIMEOUT_MS,
+                    turnCompletionIdleTimeoutMs: REQUEST_TIMEOUT_MS,
+                  },
+                },
+              },
+            },
+          },
+          agents: {
+            defaults: {
+              model: { primary: `${MODEL}@${MISSING_PROFILE_ID}`, fallbacks: [] },
+              models: {
+                [MODEL]: { agentRuntime: { id: "codex" } },
+                [NATIVE_MODEL]: { agentRuntime: { id: "codex" } },
+              },
+              workspace: "~/workspace",
+              skipBootstrap: true,
+              timeoutSeconds: 60,
+              sandbox: { mode: "off" },
+            },
+          },
+        },
+      });
+
+      const requestLog = instance.state.path("codex-auth-app-server.jsonl");
+      instance.env.OPENCLAW_QA_CODEX_AUTH_APP_SERVER_LOG = requestLog;
+      const appServerLog = createJsonlRequestTailer<AppServerLogEntry>(requestLog);
+      await instance.state.writeAuthProfiles({
+        version: 1,
+        profiles: {
+          [MISSING_PROFILE_ID]: {
+            type: "token",
+            provider: "openai",
+            token: chatgptAccessToken(ACCOUNT_ID),
+            accountId: ACCOUNT_ID,
+          },
+        },
+      });
+
+      await instance.startGateway();
+      const sessionKey = "agent:main:qa-codex-missing-auth-profile";
+      const events: GatewayEvent[] = [];
+      const client = await connectGatewayEventClient(instance, events);
+      let runId = "";
+      let terminal: unknown;
+      let failedHistory: GatewayHistory | undefined;
+      try {
+        const setup = await client.request<{ runId?: string; status?: string }>("chat.send", {
+          sessionKey,
+          message: `Reply with ${PRODUCT_OUTPUT}.`,
+          deliver: false,
+          idempotencyKey: "qa-codex-profile-binding-setup",
+        });
+        expect(setup).toMatchObject({ runId: expect.any(String), status: "started" });
+        const setupTerminal = await client.request(
+          "agent.wait",
+          { runId: setup.runId, timeoutMs: REQUEST_TIMEOUT_MS },
+          { timeoutMs: REQUEST_TIMEOUT_MS + 5_000 },
+        );
+        expect(
+          setupTerminal,
+          `${JSON.stringify(setupTerminal)}\n${JSON.stringify(appServerLog.read())}\n${instance.logs()}`,
+        ).toMatchObject({ runId: setup.runId, status: "ok" });
+        await expect(
+          client.request("sessions.patch", { key: sessionKey, model: NATIVE_MODEL }),
+        ).resolves.toMatchObject({ ok: true });
+
+        await instance.state.writeAuthProfiles({ version: 1, profiles: {} });
+        await fs.writeFile(requestLog, "", "utf8");
+        events.length = 0;
+        await client.request("sessions.messages.subscribe", { key: sessionKey });
+        const started = await client.request<{ runId?: string; status?: string }>("chat.send", {
+          sessionKey,
+          message: "Prove missing selected auth profile recovery.",
+          deliver: false,
+          idempotencyKey: "qa-codex-missing-auth-profile",
+        });
+        expect(started).toMatchObject({ runId: expect.any(String), status: "started" });
+        runId = started.runId ?? "";
+        terminal = await client.request(
+          "agent.wait",
+          { runId: started.runId, timeoutMs: REQUEST_TIMEOUT_MS },
+          { timeoutMs: REQUEST_TIMEOUT_MS + 5_000 },
+        );
+        expect(terminal).toMatchObject({ runId, status: "error" });
+        await vi.waitFor(
+          () => {
+            expect(
+              events.find(
+                (event) =>
+                  event.event === "chat" &&
+                  event.payload !== null &&
+                  typeof event.payload === "object" &&
+                  (event.payload as { runId?: unknown }).runId === runId &&
+                  (event.payload as { state?: unknown }).state === "error",
+              ),
+            ).toBeDefined();
+            expect(
+              events.find(
+                (event) =>
+                  event.event === "agent" &&
+                  event.payload !== null &&
+                  typeof event.payload === "object" &&
+                  (event.payload as { runId?: unknown }).runId === runId &&
+                  (event.payload as { stream?: unknown }).stream === "lifecycle" &&
+                  (event.payload as { data?: { phase?: unknown } }).data?.phase === "error",
+              ),
+            ).toBeDefined();
+          },
+          { interval: 20, timeout: 5_000 },
+        );
+
+        await vi.waitFor(
+          async () => {
+            const listed = await client.request<{
+              sessions?: Array<{ key?: unknown; lastRunError?: unknown }>;
+            }>("sessions.list", { limit: 20 });
+            const session = listed.sessions?.find((entry) => entry.key === sessionKey);
+            expect(session).toBeDefined();
+            expectBoundedMissingProfileRecovery(session?.lastRunError, {
+              allowSessionTruncation: true,
+            });
+          },
+          { interval: 50, timeout: REQUEST_TIMEOUT_MS },
+        );
+        failedHistory = await client.request<GatewayHistory>(
+          "chat.history",
+          { agentId: "main", sessionKey, limit: 50 },
+          { timeoutMs: 5_000 },
+        );
+      } finally {
+        client.stop();
+      }
+
+      const failureAppServerLog = createJsonlRequestTailer<AppServerLogEntry>(requestLog);
+      const finalEvent = events.find(
+        (event) =>
+          event.event === "chat" &&
+          event.payload !== null &&
+          typeof event.payload === "object" &&
+          (event.payload as { runId?: unknown }).runId === runId &&
+          (event.payload as { state?: unknown }).state === "error",
+      );
+      const lifecycleEvent = events.find(
+        (event) =>
+          event.event === "agent" &&
+          event.payload !== null &&
+          typeof event.payload === "object" &&
+          (event.payload as { runId?: unknown }).runId === runId &&
+          (event.payload as { stream?: unknown }).stream === "lifecycle" &&
+          (event.payload as { data?: { phase?: unknown } }).data?.phase === "error",
+      );
+      expectBoundedMissingProfileRecovery(finalEvent?.payload);
+      expectBoundedMissingProfileRecovery(lifecycleEvent?.payload);
+      expectBoundedMissingProfileRecovery(terminal);
+      expectBoundedMissingProfileRecovery(failedHistory?.sessionInfo?.lastRunError, {
+        allowSessionTruncation: true,
+      });
+      expect(JSON.stringify(failedHistory)).not.toContain(MISSING_PROFILE_ID);
+      expect(JSON.stringify(failedHistory)).not.toContain("Codex app-server auth profile");
+
+      await waitForRequest(failureAppServerLog, "initialize");
+      const failureMethods = failureAppServerLog
+        .read()
+        .flatMap((entry) => (typeof entry.method === "string" ? [entry.method] : []));
+      expect(failureMethods).toContain("initialize");
+      expect(failureMethods).not.toContain("account/login/start");
+      expect(failureMethods).not.toContain("thread/start");
+      expect(failureMethods).not.toContain("thread/resume");
+      expect(failureMethods).not.toContain("turn/start");
+
+      console.log(
+        `[qa-codex-missing-auth-profile] ${JSON.stringify({
+          assistantOutput: SELECTED_AUTH_PROFILE_UNAVAILABLE_USER_TEXT,
+          historySessionKey: sessionKey,
+          appServerInitialized: true,
+          appServerOperationalRpcCount: failureMethods.filter(
+            (method) => method !== "initialize" && method !== "initialized",
+          ).length,
         })}`,
       );
     },


### PR DESCRIPTION
Fixes #113169

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where agents using the Codex app-server bridge could receive generic expired-login guidance when their selected OpenAI auth profile was missing from that agent's OpenClaw credential store.

The original refresh-miss premise in #113169 was retracted after log review. The remaining reproducible defect is the missing selected-profile path identified in the follow-up and ClawSweeper review: the bridge fails before an operational app-server RPC, but the selected-profile condition was collapsed into generic authentication recovery.

## Why This Change Was Made

The Codex bridge now emits the generic allowlisted code `selected_auth_profile_unavailable` from its existing typed status-401 missing/wrong-profile error. The failover controller preserves that code while retaining `reason: "auth"`, so profile rotation, failure bookkeeping, and model fallback behavior stay unchanged.

A shared static renderer maps only that exact code to bounded credential-import recovery. Final replies, lifecycle producers, terminal projection, persisted `lastRunError`, Control UI, and Gateway chat surfaces use that renderer without exposing the profile ID, raw cause, provider text, or arbitrary plugin copy.

Rejected alternatives:

- Rendering the bridge cause directly would leak profile-specific diagnostics and arbitrary provider/plugin text into user and protocol surfaces.
- Adding a lifecycle or Gateway `errorCode` field would widen the public protocol for a presentation repair.
- Changing the failover reason would alter established auth rotation and fallback semantics.
- Adding Codex-specific IDs or policy to generic core would violate the plugin owner boundary.
- Recommending `/login codex` would be wrong for an absent agent-scoped credential; existing `invalid_grant` and expired-login behavior remains unchanged.

## User Impact

Operators now receive this bounded recovery guidance:

> The selected auth profile is unavailable in this agent's OpenClaw credential store. Import or migrate that credential into the agent, select another configured profile, or run `openclaw configure`, then retry.

The failure remains status 401 and participates in the existing auth rotation/bookkeeping path. Detailed profile diagnostics remain available only in the active structured error/cause.

Reported and clarified by @Jeehut. No co-author attribution is added because the reporter did not author the code.

## Evidence

Before the lifecycle-owner repair, the focused Control UI and Gateway proof exposed the selected profile and raw cause instead of bounded recovery text. After the repair, the final chat reply, public lifecycle event, persisted `lastRunError`, `agent.wait`, and both Gateway chat projections contain only the static recovery text and exclude the profile ID, raw cause, and login button.

The fake Codex app-server correctly receives `initialize`, which is process setup. It receives no `account/login/start`, `thread/start`, `thread/resume`, or `turn/start`; the selected-profile failure occurs before operational app-server RPC. A live OpenAI call would not exercise this boundary, so the fake app-server Gateway flow is the correct end-to-end proof.

Validation on exact head `dc3117ff7f907dad877156a9e269254ec85b8445`, tree `b8a4301d2ef7e581e74312c0e739d40696530d2d`:

- Focused bridge/failover/lifecycle/final-reply corpus: 426 passed on the behavior candidate; 32 affected focused tests passed again after the final private-export cleanup.
- Gateway chat suites: 229 passed on the behavior candidate; the final cleanup changes only static-copy export visibility and test expectations.
- QA Lab fake-app-server Gateway proof: 2 passed.
- `pnpm lint`: passed.
- `pnpm format:check`: passed.
- Core, core-test, extension, and extension-test TypeScript graphs: passed.
- `check:changed` applicable gates passed; the root-test graph is unavailable in this sparse worktree because tracked Android, QA broker, and `ui/config` inputs are absent.
- Mandatory autoreview: no accepted/actionable findings on the full behavior candidate or final cleanup; final-delta correctness 0.99.
- Existing `invalid_grant` copy remains covered and unchanged.

LOC: production `+51/-34` (net `+17`); tests `+524/-9` (net `+515`). No protocol, config, persistence, public API, or dependency change.

Codex app-server account/login behavior was checked directly against `openai/codex` at `5f49aba876922d6f2f55caa153bbb0ed1b46feba`:

- `codex-rs/app-server-protocol/src/protocol/v2/account.rs:60-85`
- `codex-rs/app-server-protocol/src/protocol/common.rs:1196-1201`
- `codex-rs/app-server/src/request_processors/account_processor.rs:327-338`
- `codex-rs/app-server/src/request_processors/account_processor.rs:369-378`

No documentation or changelog change: the existing OpenAI provider documentation already covers credential import/migration, and this PR corrects runtime guidance to match it.
