### PR TITLE
test: reuse performance workflow repository fixtures

### DIFF
--- a/scripts/test-extension-batch.mts
+++ b/scripts/test-extension-batch.mts
@@ -3,6 +3,7 @@
 // Runs grouped Vitest plans for one or more bundled plugins.
 import path from "node:path";
 import pMap from "p-map";
+import { waitForever } from "../src/cli/wait.ts";
 import { collectVitestExcludePatterns } from "../test/vitest/vitest.pattern-file.ts";
 import { resolveVitestFsModuleCacheRoot } from "../test/vitest/vitest.performance-config.ts";
 import {
@@ -368,10 +369,9 @@ export async function runExtensionBatchPlan(
         process.off("SIGINT", onSignal);
         if (termination.signal) {
           process.kill(process.pid, termination.signal);
-          // Give the re-raised signal a turn before a CLI caller exits with the numeric result.
-          await new Promise<void>((resolve) => {
-            setImmediate(resolve);
-          });
+          // Keep the loop alive for dependency signal handlers to finish cleanup
+          // and re-raise; a numeric return can win the race with signal delivery.
+          await waitForever();
         }
       }
     }

--- a/scripts/test-projects.mts
+++ b/scripts/test-projects.mts
@@ -4,6 +4,7 @@ import type { SpawnOptions } from "node:child_process";
 import fs from "node:fs";
 import { performance } from "node:perf_hooks";
 import pMap from "p-map";
+import { waitForever } from "../src/cli/wait.ts";
 import { formatMs } from "./lib/check-timing-summary.mts";
 import {
   prepareE2eVitestRuntime,
@@ -471,10 +472,9 @@ async function main() {
         process.off("SIGINT", onSignal);
         if (termination.signal) {
           process.kill(process.pid, termination.signal);
-          // Give the re-raised signal a turn before a CLI caller exits with the numeric result.
-          await new Promise<void>((resolve) => {
-            setImmediate(resolve);
-          });
+          // Keep the loop alive for dependency signal handlers to finish cleanup
+          // and re-raise; a numeric return can win the race with signal delivery.
+          await waitForever();
         }
       }
     }

--- a/test/scripts/openclaw-performance-workflow.test-support.ts
+++ b/test/scripts/openclaw-performance-workflow.test-support.ts
@@ -1,6 +1,22 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  constants as fsConstants,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
+import { afterAll } from "vitest";
+import { createTempDirTracker } from "../helpers/temp-dir.js";
+
+const templateDirs = createTempDirTracker();
+let performanceTemplate: string | undefined;
+afterAll(() => {
+  templateDirs.cleanup();
+  performanceTemplate = undefined;
+});
 
 export type PerformanceFixtureOptions = {
   mode: "target" | "record" | "tested" | "kova" | "baseline" | "prepare" | "publish";
@@ -38,11 +54,6 @@ export function preparePerformanceFixture(root: string, options: PerformanceFixt
     mkdirSync(path.dirname(file), { recursive: true });
     writeFileSync(file, value);
   };
-  mkdirSync(temp, { recursive: true });
-  mkdirSync(seed);
-  run(workspace, "init", "--bare", "--initial-branch=main", remote);
-  run(seed, "init", "--initial-branch=main");
-  write(path.join(seed, "README.md"), "fixture\n");
   const dest = "openclaw-performance/main/123-1/mock-provider";
   const previous = "openclaw-performance/main/100-1/mock-provider";
   const pointer = "openclaw-performance/main/latest-mock-provider.json";
@@ -53,19 +64,37 @@ export function preparePerformanceFixture(root: string, options: PerformanceFixt
     run(cwd, "add", ".");
     run(cwd, "commit", "-m", "fixture report");
   };
-  if (options.baseline !== "absent") {
-    commitReport(seed, options.duplicate ? dest : previous);
-    if (options.baseline === "invalid") write(path.join(seed, pointer), "{invalid");
-    if (options.baseline === "trailing-newline")
-      write(path.join(seed, pointer), JSON.stringify({ path: previous + "\n" }));
+  const reuseDefault = !options.baseline && !options.duplicate;
+  const copyOptions = { recursive: true, mode: fsConstants.COPYFILE_FICLONE };
+  if (reuseDefault && performanceTemplate) {
+    cpSync(performanceTemplate, workspace, copyOptions);
+  } else {
+    mkdirSync(temp, { recursive: true });
+    mkdirSync(seed);
+    run(workspace, "init", "--bare", "--initial-branch=main", remote);
+    run(seed, "init", "--initial-branch=main");
+    write(path.join(seed, "README.md"), "fixture\n");
+    if (options.baseline !== "absent") {
+      commitReport(seed, options.duplicate ? dest : previous);
+      if (options.baseline === "invalid") write(path.join(seed, pointer), "{invalid");
+      if (options.baseline === "trailing-newline")
+        write(path.join(seed, pointer), JSON.stringify({ path: previous + "\n" }));
+    }
+    run(seed, "add", ".");
+    run(seed, "commit", "--allow-empty", "-m", "fixture seed");
+    run(seed, "push", remote, "HEAD:main");
+    run(workspace, "init", "--initial-branch=main");
+    write(path.join(workspace, "src/config/zod-schema.agent-defaults.ts"), "    mediaModels: z\n");
+    run(workspace, "add", "src");
+    run(workspace, "commit", "-m", "fixture target");
+    if (reuseDefault) {
+      // Snapshot complete repositories before any scenario mutation. Copies own
+      // their refs, index and objects; no live process or absolute remote is shared.
+      const template = templateDirs.make("openclaw-performance-template-");
+      cpSync(workspace, template, copyOptions);
+      performanceTemplate = template;
+    }
   }
-  run(seed, "add", ".");
-  run(seed, "commit", "--allow-empty", "-m", "fixture seed");
-  run(seed, "push", remote, "HEAD:main");
-  run(workspace, "init", "--initial-branch=main");
-  write(path.join(workspace, "src/config/zod-schema.agent-defaults.ts"), "    mediaModels: z\n");
-  run(workspace, "add", "src");
-  run(workspace, "commit", "-m", "fixture target");
   const target = run(workspace, "rev-parse", "HEAD");
   mkdirSync(reports);
   let reportCommit = "a".repeat(40);


### PR DESCRIPTION
## What Problem This Solves

Developers running the performance-workflow Git lifecycle tests rebuild identical local repository history for nearly every case. This adds repeated Git process startup before the actual lifecycle checks.

## Why This Change Was Made

Create the default initial history once, then copy the complete workspace into each case's independent directory. Each copy owns its files, refs, index, objects, and local remote. Destination paths are rebuilt per case. Absent, malformed and duplicate baseline fixtures still use their original fresh setup; mode-specific publication, race setup, and all process ownership checks remain unchanged. The existing temporary-directory tracker owns the immutable template and clears it after the suite.

## User Impact

Faster fixture execution, plus an evidence-backed repair for an existing CI cancellation failure. No product behavior, dependency, sharding, workers, concurrency, test selection, assertion weakening, or deadline changes. The test runners now retain their process lifetime until cancellation finishes with the original signal. The 105-case lifecycle suite removes 1,000 repeated bootstrap Git launches while retaining every real process tree, fault and cleanup boundary.

## Evidence

- Six alternating default-fixture measurements: median 312.074 ms before / 44.891 ms after. A second six-pair measurement against the formatted candidate: 281.031 ms / 38.943 ms. Every pair favored the candidate. These are fixture execution measurements, not whole-CI speedups.
- All 105 original lifecycle cases passed before and after: `node scripts/run-vitest.mjs run test/scripts/openclaw-performance-git-lifecycle.test.ts`. The first full runs were 560.794 s / 379.176 s; that larger difference includes warmup/host noise and is not attributed entirely to this patch.
- All 39 sibling workflow tests passed: `node scripts/run-vitest.mjs run test/scripts/openclaw-performance-workflow.test.ts`.
- Supplemental isolated probes compared full tree/index/config/branch/history shapes, independent file identities, cross-copy mutation isolation, all specialized baseline/race variants, destination-local transport paths and registered cleanup.
- Independent source review and Codex autoreview found no accepted findings. Product LOC: +0/-0; runner tooling: +8/-8 (net zero); test support: +47/-18.

- `node scripts/check-changed.mjs -- test/scripts/openclaw-performance-workflow.test-support.ts` passed after a frozen-lockfile install refreshed stale local Telegram types. No dependency manifest or lockfile changed. The composed 26-step changed gate passed on Linux, including core-test, script and test-support typechecks. Removing the unpublished workshop duplicate afterward left all three retained changed files and the shared wait helper byte-identical to that validated source.

## CI Follow-through

The first exact-head run exposed a timestamp tie in the unchanged workshop test `rejects and quarantines proposals without touching active skills`. The fix has since landed independently in #133153 at 4bc25d7a7001c67dadc80835619b200406fe5cb1. This PR drops its unpublished duplicate fixture repair and preserves the canonical main change; no workshop repair is attributed to this PR.

The same CI run also failed the unchanged real `batch-cancel` case: the child recorded SIGTERM, but the outer runner exited normally with code 1. An exact-source Linux Node 24.19 reproduction failed on its sixth case; a lighter diagnostic reproduced it on its second case. The report finalizer's single `setImmediate` could return before Rolldown's `signal-exit` handler received the re-raised signal. That dependency must close its trace subscriber, remove its own handlers, and re-raise the fatal signal. Both project and plugin-batch finalizers now reuse the existing dependency-free `waitForever()` primitive after self-signalling, keeping the event loop referenced until signal termination. No foreign listener is removed, no deadline is enlarged, and no delay or retry is added. All 20 repeated Linux cancellations passed (16 batch, 4 ordinary), including actual outer/child SIGTERM, no surviving worker, no second invocation, and no aggregate publication. Existing cancellation tests remain unchanged. All 59 report-owner integration cases passed through `pnpm test test/scripts/vitest-report-owner.test.ts` on the same Linux worker. The initial direct-Node suite invocation lacked pnpm executable provenance inside its isolated environment; the normal pnpm entrypoint corrected that invocation without any source change. Independent review and Codex autoreview found no accepted findings.

The failed compact shards were diagnosed before a fresh run: the cancellation failure has before/after evidence and the workshop prerequisite is already on main. The composed exact-head run is now green. The latest ClawSweeper rank-up move, complete exact-head CI, is satisfied without a blind rerun or CI waiver.

A second candidate lifecycle run passed all 105 tests in 368.843 seconds. The matching repeated original baseline passed 104/105 but failed an existing supervisor-error path after 50.88 seconds; it is excluded from timing claims. Its valid terminal report proved cleanup, but the JSON-only reporter did not retain the report's error text. Named follow-up: preserve that error in the supervisor assertion diagnostics. No timeout increase or assertion weakening is included here. The stable performance claim remains the paired fixture-setup measurements above.

## Final validation

Exact head `f7f47b2d321ff74727d53e6d89e0bc0bac3f86f4` passed [CI 33323988415](https://github.com/openclaw/openclaw/actions/runs/33323988415), including Linux and macOS. The latest ClawSweeper review has no actionable findings; its request to wait for exact-head green CI is satisfied. Independent maintainer review and Codex autoreview are clean. The retained fixture and signal-finalizer source matches the locally validated bytes.

No workshop test change is included: its prerequisite landed independently in #133153. The observer-startup and supervisor-error diagnostic follow-up is being validated separately and is not part of this head.
