### PR TITLE
fix(ci): make Telegram release tests best effort

### DIFF
--- a/.github/workflows/npm-telegram-beta-e2e.yml
+++ b/.github/workflows/npm-telegram-beta-e2e.yml
@@ -583,7 +583,6 @@ jobs:
           OPENCLAW_NPM_TELEGRAM_RTT_CHECKS: ${{ inputs.rtt_scenario }}
           OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
           OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}
-          OPENCLAW_QA_CREDENTIAL_ACQUIRE_TIMEOUT_MS: "600000"
           OPENCLAW_QA_SUITE_PROGRESS: "1"
           OPENCLAW_QA_REDACT_PUBLIC_METADATA: "1"
           INPUT_SCENARIO: ${{ inputs.scenario }}
@@ -781,6 +780,24 @@ jobs:
           fi
 
           pnpm test:docker:npm-telegram-live
+
+      - name: Summarize Telegram attempt
+        if: always()
+        env:
+          ADVISORY: ${{ inputs.advisory }}
+          LANE_OUTCOME: ${{ steps.run_lane.outcome }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Package Telegram attempt"
+            echo
+            echo "- Telegram attempt: ${LANE_OUTCOME}"
+            echo "- Advisory: ${ADVISORY}"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [[ "$ADVISORY" == "true" && "$LANE_OUTCOME" != "success" ]]; then
+            echo "::warning::Package Telegram attempt: ${LANE_OUTCOME}; release testing is best effort."
+          fi
 
       - name: Upload npm Telegram E2E artifacts
         if: always()

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -1412,7 +1412,7 @@ jobs:
       published_upgrade_survivor_baselines: ${{ needs.resolve_target.outputs.run_release_soak == 'true' && 'last-stable-4 2026.4.23 2026.5.2 2026.4.15' || '' }}
       published_upgrade_survivor_scenarios: ${{ needs.resolve_target.outputs.run_release_soak == 'true' && 'reported-issues' || '' }}
       telegram_mode: ${{ (needs.resolve_target.outputs.telegram_waiver != '' || needs.resolve_target.outputs.skip_package_telegram_e2e == 'true') && 'none' || 'mock-openai' }}
-      telegram_advisory: ${{ needs.resolve_target.outputs.release_profile == 'beta' }}
+      telegram_advisory: true
       shared_image_artifact_namespace: release-package
       candidate_artifact_json: ${{ needs.resolve_target.outputs.package_acceptance_package_spec == '' && needs.resolve_target.outputs.candidate_artifact_json || '' }}
       shared_image_policy: no-push-artifact
@@ -2259,12 +2259,16 @@ jobs:
       OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
       OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}
 
-  # The dispatched child owns Telegram evidence/status artifacts; this blocking job
-  # carries its exact conclusion into the parent summary without copying secrets or artifacts.
+  # The child owns Telegram evidence/status artifacts. Preserve its actual outcome
+  # while release policy treats this pool-dependent test attempt as advisory.
   qa_live_telegram_release_checks:
     name: Run QA Lab live Telegram lane
     needs: [resolve_target]
     if: needs.resolve_target.outputs.qa_live_scheduled == 'true' && needs.resolve_target.outputs.qa_live_telegram_enabled == 'true'
+    continue-on-error: true
+    outputs:
+      conclusion: ${{ steps.dispatch.outputs.conclusion || steps.dispatch.outcome }}
+      identity_verified: ${{ steps.dispatch.outputs.identity_verified }}
     runs-on: ubuntu-24.04
     timeout-minutes: 210
     permissions:
@@ -2272,6 +2276,7 @@ jobs:
       contents: read
     steps:
       - name: Dispatch and await trusted Telegram QA
+        id: dispatch
         env:
           GH_TOKEN: ${{ github.token }}
           PARENT_WORKFLOW_REF: ${{ github.ref_name }}
@@ -2360,22 +2365,43 @@ jobs:
           fi
 
           child_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
+          echo "identity_verified=true" >> "$GITHUB_OUTPUT"
           echo "Dispatched trusted Telegram QA: ${child_url}"
+          echo "child_url=${child_url}" >> "$GITHUB_OUTPUT"
           for _ in $(seq 1 1080); do
             run_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}")"
             status="$(jq -r .status <<<"$run_json")"
             if [[ "$status" == "completed" ]]; then
               conclusion="$(jq -r .conclusion <<<"$run_json")"
+              echo "conclusion=${conclusion}" >> "$GITHUB_OUTPUT"
               if [[ "$conclusion" != "success" ]]; then
-                echo "Trusted Telegram QA concluded ${conclusion}: ${child_url}" >&2
+                echo "::warning::Trusted Telegram QA concluded ${conclusion}: ${child_url}" >&2
                 exit 1
               fi
               exit 0
             fi
             sleep 10
           done
-          echo "Timed out awaiting trusted Telegram QA: ${child_url}" >&2
+          echo "::warning::Timed out awaiting trusted Telegram QA: ${child_url}" >&2
           exit 1
+
+      - name: Summarize Telegram attempt
+        if: always()
+        env:
+          CHILD_URL: ${{ steps.dispatch.outputs.child_url }}
+          CONCLUSION: ${{ steps.dispatch.outputs.conclusion || steps.dispatch.outcome }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Telegram release QA (advisory)"
+            echo
+            echo "- Telegram attempt: ${CONCLUSION}"
+            [[ -z "$CHILD_URL" ]] || echo "- Child evidence: ${CHILD_URL}"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [[ "$CONCLUSION" != "success" ]]; then
+            echo "::warning::Telegram attempt: ${CONCLUSION}; release testing is best effort."
+          fi
 
   qa_live_discord_release_checks:
     name: Run QA Lab live Discord lane
@@ -2831,8 +2857,9 @@ jobs:
           RUNTIME_TOOL_COVERAGE_RELEASE_CHECKS_RESULT: ${{ needs.runtime_tool_coverage_release_checks.result }}
           QA_LIVE_RELEASE_CHECKS_RESULT: ${{ needs.qa_live_release_checks.result }}
           QA_LIVE_BUZZ_RELEASE_CHECKS_RESULT: ${{ needs.qa_live_buzz_release_checks.result }}
-          QA_LIVE_TELEGRAM_RELEASE_CHECKS_RESULT: ${{ needs.qa_live_telegram_release_checks.result }}
+          QA_LIVE_TELEGRAM_RELEASE_CHECKS_RESULT: ${{ needs.qa_live_telegram_release_checks.outputs.conclusion || needs.qa_live_telegram_release_checks.result }}
           QA_LIVE_TELEGRAM_SELECTED: ${{ needs.resolve_target.outputs.qa_live_scheduled == 'true' && needs.resolve_target.outputs.qa_live_telegram_enabled == 'true' }}
+          QA_LIVE_TELEGRAM_IDENTITY_VERIFIED: ${{ needs.qa_live_telegram_release_checks.outputs.identity_verified }}
           QA_LIVE_DISCORD_RELEASE_CHECKS_RESULT: ${{ needs.qa_live_discord_release_checks.result }}
           QA_LIVE_WHATSAPP_RELEASE_CHECKS_RESULT: ${{ needs.qa_live_whatsapp_release_checks.result }}
           QA_LIVE_SLACK_RELEASE_CHECKS_RESULT: ${{ needs.qa_live_slack_release_checks.result }}
@@ -2966,13 +2993,19 @@ jobs:
             else
               result="$raw_result"
             fi
-            require_success=false
-            if [[ "$name" == "qa_live_telegram_release_checks" &&
-                  "$QA_LIVE_TELEGRAM_SELECTED" == "true" ]]; then
-              require_success=true
+            if [[ "$name" == "qa_live_telegram_release_checks" ]]; then
+              # Only an identified child execution is advisory; dispatch provenance remains a gate.
+              if [[ "$result" != "skipped" && "$QA_LIVE_TELEGRAM_IDENTITY_VERIFIED" != "true" ]]; then
+                echo "::error::Telegram dispatch identity was not verified"
+                failed=1
+                continue
+              fi
+              if [[ "$result" != "success" && "$QA_LIVE_TELEGRAM_SELECTED" == "true" ]]; then
+                echo "::warning::${name} ended with ${result}; Telegram release testing is best effort and does not block release validation."
+              fi
+              continue
             fi
-            if [[ "$result" != "success" &&
-                  ( "$result" != "skipped" || "$require_success" == "true" ) ]]; then
+            if [[ "$result" != "success" && "$result" != "skipped" ]]; then
               if [[ "$tideclaw_alpha" == "true" ]]; then
                 case "$name" in
                   resolve_target|prepare_release_package|install_smoke_release_checks|package_acceptance_release_checks) ;;

--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1967,8 +1967,6 @@ jobs:
       - name: Validate required QA credential env
         id: validate_credentials
         env:
-          # Release trains share a bounded Telegram pool; wait through overlapping lanes.
-          CREDENTIAL_ACQUIRE_TIMEOUT_MS: "600000"
           JOB_TIMEOUT_MINUTES: "60"
           LEASE_TTL_MS: "7200000"
           OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}
@@ -1990,8 +1988,6 @@ jobs:
           EVIDENCE_ROOT: ${{ steps.create_sut.outputs.evidence_root }}
           OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}
           OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
-          # Keep the CLI lease wait aligned with the validated workflow contract above.
-          OPENCLAW_QA_CREDENTIAL_ACQUIRE_TIMEOUT_MS: "600000"
           OPENCLAW_QA_CREDENTIAL_LEASE_TTL_MS: "7200000"
           OPENCLAW_QA_REDACT_PUBLIC_METADATA: "1"
           OPENCLAW_QA_SUT_FORBIDDEN_SENTINEL: trusted-parent-${{ github.run_id }}-${{ github.run_attempt }}

--- a/docs/reference/full-release-validation.md
+++ b/docs/reference/full-release-validation.md
@@ -229,12 +229,22 @@ Codex `final`, reads randomized workspace inputs, writes their exact artifact,
 and sends explicit completion. This catches the v2026.7.1 regression where an
 ordinary progress send terminated the turn.
 
+Telegram release tests are best effort in every release profile. Selected source
+and package lanes still attempt the real Test Server flow when a Convex credential
+is available. They use the canonical 90-second lease-acquisition retry budget;
+missing broker access, an exhausted pool, or failed tests remain visible as
+failures or skips in the job summaries and evidence, but never block release
+validation. Assertions, credential isolation, lease cleanup, and exact candidate
+identity checks remain unchanged. A successful release decision does not imply
+that Telegram passed; inspect the recorded Telegram outcome separately.
+
 Use `-f skip_package_telegram_e2e=true` only when the release owner explicitly
 defers the Package Acceptance Telegram E2E to a follow-up beta. The input is
 rejected for `stable` and `full`, recorded in validation evidence, and does not disable the focused
 `rerun_group=npm-telegram` workflow.
 
-For the release owner's explicit 2026.8.1 exception, pass
+Best effort is separate from an explicit omission. For the release owner's
+2026.8.1 exception, pass
 `-f telegram_waiver=2026.8.1-owner-approved`. This is accepted only when the
 actual target package is `2026.8.1` and the profile is `stable` or `full`.
 It omits source Telegram QA, Package Acceptance Telegram E2E, and the
@@ -492,7 +502,8 @@ commands print heartbeat lines so a stuck update is visible before the job
 timeout.
 
 QA release-check failures block normal release validation only for selected
-Matrix, Telegram, and QA runtime tool coverage lanes. QA parity, runtime
+Matrix and QA runtime tool coverage lanes. Source and package Telegram outcomes
+are always advisory; failed or skipped attempts are never reported as passed. QA parity, runtime
 parity, and the gated Discord, WhatsApp, and Slack live lanes are advisory and
 publish status artifacts without blocking the release verifier. Tideclaw
 alpha runs may still treat non-package-safety release-check lanes as advisory. With

--- a/scripts/full-release-validation-policy.mjs
+++ b/scripts/full-release-validation-policy.mjs
@@ -1063,6 +1063,8 @@ function isReleaseCheckJobAdvisory({ jobName, releaseProfile, workflowRef }) {
     jobName === "Run QA Lab parity report" ||
     jobName.startsWith("Run QA Lab runtime-pair lane (") ||
     jobName === "Verify QA Lab runtime-pair lanes" ||
+    jobName === "Run QA Lab live Telegram lane" ||
+    jobName.startsWith("Run package acceptance / Telegram package acceptance / ") ||
     jobName === "Run QA Lab live Discord lane" ||
     jobName === "Run QA Lab live WhatsApp lane" ||
     jobName === "Run QA Lab live Slack lane"
@@ -1080,18 +1082,21 @@ function isReleaseCheckJobAdvisory({ jobName, releaseProfile, workflowRef }) {
   }
   return (
     releaseProfile === "beta" &&
-    (jobName.startsWith("Run package acceptance / Telegram package acceptance / ") ||
-      (jobName.startsWith("Run repo/live E2E validation / ") &&
-        (jobName.includes("Docker live") ||
-          jobName.includes("Live media suites") ||
-          jobName.includes("validate_live_provider_suites") ||
-          jobName.includes("validate_release_live_cache") ||
-          jobName.includes("prepare_live_test_image"))))
+    jobName.startsWith("Run repo/live E2E validation / ") &&
+    (jobName.includes("Docker live") ||
+      jobName.includes("Live media suites") ||
+      jobName.includes("validate_live_provider_suites") ||
+      jobName.includes("validate_release_live_cache") ||
+      jobName.includes("prepare_live_test_image"))
   );
 }
 
 function isReleaseChecksChild(key) {
   return ["releaseChecks", "releaseChecksIndependent", "releaseChecksCandidate"].includes(key);
+}
+
+function isAdvisoryChild(key, releaseProfile) {
+  return key === "npmTelegram" || (key === "productPerformance" && releaseProfile === "beta");
 }
 
 function failedJobsForPolicy(child, releaseProfile, workflowRef) {
@@ -1109,7 +1114,7 @@ function failedJobsForPolicy(child, releaseProfile, workflowRef) {
         workflowRef,
       });
     }
-    return !(child.key === "productPerformance" && releaseProfile === "beta");
+    return !isAdvisoryChild(child.key, releaseProfile);
   });
 }
 
@@ -1120,7 +1125,7 @@ export function terminalPolicyPass(child, releaseProfile, workflowRef) {
   if (child.conclusion === "success") {
     return true;
   }
-  if (child.key === "productPerformance" && releaseProfile === "beta") {
+  if (isAdvisoryChild(child.key, releaseProfile)) {
     return true;
   }
   if (isReleaseChecksChild(child.key)) {

--- a/scripts/github/find-reusable-release-validation.sh
+++ b/scripts/github/find-reusable-release-validation.sh
@@ -353,7 +353,7 @@ for ((index = 0; index < run_count; index += 1)); do
         | .reportPublication] == ["artifact-only"])
       and all(.children[];
         .status == "completed"
-        and .conclusion == "success"
+        and .policyPassed == true
         and .workflowSha == $record.root.workflowSha
         and (.sourceParentRunId | tostring) == $run_id
       )

--- a/scripts/lib/release-beta-verifier.ts
+++ b/scripts/lib/release-beta-verifier.ts
@@ -60,6 +60,7 @@ type WorkflowRunSummary = {
   label: string;
   url?: string;
   durationSeconds?: number;
+  advisory?: { status: string; conclusion: string; failedJobs: string[] };
   bootstrapEvidence?: {
     targetSha: string;
     workflowSha: string;
@@ -613,6 +614,7 @@ function verifyWorkflowRun(params: {
   expectedWorkflowName: string;
   expectedHeadBranch?: string;
   allowedHeadBranches?: string[];
+  advisory?: boolean;
   rerunFailed: boolean;
 }): WorkflowRunSummary {
   const raw = runReleaseVerifierCommand("gh", [
@@ -664,7 +666,10 @@ function verifyWorkflowRun(params: {
       `${params.label}: reran ${failedJobs.length} failed job(s); rerun verifier after it finishes.`,
     );
   }
-  if (status !== "completed" || conclusion !== "success" || failedJobs.length > 0) {
+  if (
+    !params.advisory &&
+    (status !== "completed" || conclusion !== "success" || failedJobs.length > 0)
+  ) {
     const failedNames = failedJobs
       .map((job) => normalizeOptionalString(job.name) ?? "<unnamed>")
       .join(", ");
@@ -685,6 +690,15 @@ function verifyWorkflowRun(params: {
     label: params.label,
     url: normalizeOptionalString(run.url),
     durationSeconds,
+    ...(params.advisory
+      ? {
+          advisory: {
+            status: status ?? "unavailable",
+            conclusion: conclusion ?? "unavailable",
+            failedJobs: failedJobs.map((job) => normalizeOptionalString(job.name) ?? "<unnamed>"),
+          },
+        }
+      : {}),
   };
 }
 
@@ -1435,14 +1449,21 @@ export async function verifyBetaRelease(
         repo: args.repo,
         expectedWorkflowName: "NPM Telegram Beta E2E",
         allowedHeadBranches: allowedReleaseWorkflowHeadBranches,
+        advisory: true,
         rerunFailed: false,
       }),
     );
   }
   for (const run of workflowRuns) {
-    lines.push(
-      `${run.label} OK: ${run.id} (${formatDuration(run.durationSeconds)})${run.url ? ` ${run.url}` : ""}`,
-    );
+    if (run.advisory) {
+      lines.push(
+        `${run.label} advisory: ${run.id} (${run.advisory.status}/${run.advisory.conclusion}; failed jobs: ${run.advisory.failedJobs.join(", ") || "none"})${run.url ? ` ${run.url}` : ""}`,
+      );
+    } else {
+      lines.push(
+        `${run.label} OK: ${run.id} (${formatDuration(run.durationSeconds)})${run.url ? ` ${run.url}` : ""}`,
+      );
+    }
   }
 
   if (args.evidenceOut !== undefined) {

--- a/scripts/lib/release-beta-verifier.ts
+++ b/scripts/lib/release-beta-verifier.ts
@@ -667,8 +667,8 @@ function verifyWorkflowRun(params: {
     );
   }
   if (
-    !params.advisory &&
-    (status !== "completed" || conclusion !== "success" || failedJobs.length > 0)
+    status !== "completed" ||
+    (!params.advisory && (conclusion !== "success" || failedJobs.length > 0))
   ) {
     const failedNames = failedJobs
       .map((job) => normalizeOptionalString(job.name) ?? "<unnamed>")

--- a/test/scripts/find-reusable-release-validation.test.ts
+++ b/test/scripts/find-reusable-release-validation.test.ts
@@ -62,6 +62,7 @@ interface ParentTuple {
 
 interface ChildTuple {
   conclusion: string;
+  policyPassed?: boolean;
   dispatchNonce: string;
   displayTitle: string;
   event: string;
@@ -351,6 +352,7 @@ function normalizedEvidence(options: {
       Object.assign(
         {
           conclusion: "success",
+          policyPassed: true,
           dispatchNonce: `full-release-validation-${runId}-${sourceParentAttempt}${suffix}`,
           displayTitle: `${name} full-release-validation-${runId}-${sourceParentAttempt}${suffix}`,
           event: "workflow_dispatch",
@@ -837,6 +839,40 @@ describe("scripts/github/find-reusable-release-validation.sh", () => {
     });
   });
 
+  it.each(["beta", "stable", "full"])(
+    "reuses %s Telegram failures only when the strict verifier accepted their policy",
+    (releaseProfile) => {
+      const { clone, priorSha } = getSharedRepo();
+      const validationInputs = {
+        ...DEFAULT_INPUTS,
+        npmTelegramPackageSpec: "openclaw@2026.7.1",
+      };
+      const record = normalizedEvidence({ targetSha: priorSha, validationInputs, releaseProfile });
+      for (const child of record.children) {
+        if (
+          ["npmTelegram", "releaseChecksIndependent", "releaseChecksCandidate"].includes(child.role)
+        ) {
+          child.conclusion = "failure";
+          record.conclusions.children[child.role] = "failure";
+        }
+      }
+      const { binDir, fixtures, validatorPath } = setUpFixtures([{ record, runId: "111" }]);
+
+      const result = runResolver({
+        binDir,
+        fixtures,
+        inputs: validationInputs,
+        releaseProfile,
+        repoDir: clone,
+        targetSha: priorSha,
+        validatorPath,
+      });
+
+      expect(result.status).toBe(0);
+      expect(parseOutput(result.stdout)).toMatchObject({ evidence_run_id: "111", reuse: "true" });
+    },
+  );
+
   it("rejects noncanonical release refs and workflow SHAs outside trusted main", () => {
     const { clone, priorSha } = getSharedRepo();
     const record = normalizedEvidence({ targetSha: priorSha });
@@ -1062,9 +1098,23 @@ describe("scripts/github/find-reusable-release-validation.sh", () => {
       },
     },
     {
-      label: "failed child",
+      label: "child rejected by canonical policy",
       mutate(record: NormalizedEvidence) {
-        expectDefined(record.children[0], "failed reusable release child").conclusion = "failure";
+        const child = expectDefined(record.children[0], "failed reusable release child");
+        child.conclusion = "failure";
+        child.policyPassed = false;
+      },
+    },
+    {
+      label: "successful child rejected by canonical policy",
+      mutate(record: NormalizedEvidence) {
+        expectDefined(record.children[0], "reusable release child").policyPassed = false;
+      },
+    },
+    {
+      label: "child without canonical policy evidence",
+      mutate(record: NormalizedEvidence) {
+        delete expectDefined(record.children[0], "reusable release child").policyPassed;
       },
     },
     {

--- a/test/scripts/frv.test.ts
+++ b/test/scripts/frv.test.ts
@@ -571,20 +571,23 @@ describe("FRV same-parent recovery", () => {
     expect(scenario.counters.posts.child).toBe(0);
   });
 
-  it("reruns current v2 failed children concurrently, preserves green children, then reruns the parent once", async () => {
+  it("reruns blocking children concurrently, preserves green and advisory children, then reruns the parent once", async () => {
     const first = child("normalCi", "101");
     const second = child("pluginPrerelease", "202");
     const green = child("releaseChecks", "303");
+    const telegram = child("npmTelegram", "505");
+    const selectedPlan = { ...plan([first, second, green, telegram]), releaseProfile: "full" };
     const childRuns = new Map([
       ["101", { attempt: 1, conclusion: "failure" }],
       ["202", { attempt: 1, conclusion: "failure" }],
       ["303", { attempt: 1, conclusion: "success" }],
+      ["505", { attempt: 1, conclusion: "failure" }],
     ]);
     const parent = { attempt: 1, conclusion: "failure" as string | null };
     const events: string[] = [];
     let parentReruns = 0;
     const client = {
-      ...controllerClient([first, second, green], childRuns, parent),
+      ...controllerClient(selectedPlan.children, childRuns, parent),
       rerunFailed: async (runId: string) => {
         events.push(`child:${runId}`);
         childRuns.set(runId, { attempt: 2, conclusion: "success" });
@@ -596,15 +599,30 @@ describe("FRV same-parent recovery", () => {
         parent.attempt = 2;
         parent.conclusion = "success";
       },
-      verify: async () => {
+      verify: async (
+        _runId: string,
+        _plan: Record<string, unknown>,
+        _deadline?: number,
+        attempts?: Record<string, number>,
+      ) => {
+        expect(attempts?.["505"]).toBe(1);
         events.push("verify");
         return "{}";
       },
     };
-    const result = await continueFailed(plan([first, second, green]), "77", client);
+    const result = await continueFailed(selectedPlan, "77", client);
     expect(result).toMatchObject({ action: "reran-parent", finalRunId: "77" });
     expect(events.slice(0, 2).toSorted()).toEqual(["child:101", "child:202"]);
     expect(events).not.toContain("child:303");
+    expect(events).not.toContain("child:505");
+    expect(result.status.children).toContainEqual(
+      expect.objectContaining({
+        key: "npmTelegram",
+        conclusion: "failure",
+        passed: true,
+        effectiveRunAttempt: 1,
+      }),
+    );
     expect(events.indexOf("parent")).toBeGreaterThan(events.indexOf("child:202"));
     expect(events.at(-1)).toBe("verify");
     expect(parentReruns).toBe(1);

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -834,6 +834,66 @@ describe("release decision policy", () => {
     expect(result).toMatchObject({ blockers: [], errors: [], state: "passed" });
   });
 
+  it.each(["beta", "stable", "full"])(
+    "keeps Telegram execution failures advisory for %s releases",
+    (releaseProfile) => {
+      const result = classifyReleaseSnapshot({
+        children: [
+          child("releaseChecks", {
+            conclusion: "failure",
+            jobs: [
+              { conclusion: "failure", name: "Run QA Lab live Telegram lane", status: "completed" },
+              {
+                conclusion: "failure",
+                name: "Run package acceptance / Telegram package acceptance / Run Telegram package E2E",
+                status: "completed",
+              },
+              { conclusion: "success", name: "Verify release checks", status: "completed" },
+            ],
+            status: "completed",
+          }),
+          child("npmTelegram", {
+            conclusion: "failure",
+            jobs: [{ conclusion: "failure", name: "Telegram package E2E", status: "completed" }],
+            runId: "202",
+            status: "completed",
+          }),
+        ],
+        releaseProfile,
+        workflowRef: "main",
+      });
+      expect(result).toMatchObject({ blockers: [], errors: [], state: "passed" });
+    },
+  );
+
+  it("keeps non-Telegram failures and Telegram provenance errors strict", () => {
+    const result = classifyReleaseSnapshot({
+      children: [
+        child("releaseChecks", {
+          conclusion: "failure",
+          jobs: [
+            { conclusion: "failure", name: "Run install smoke", status: "completed" },
+            { conclusion: "success", name: "Verify release checks", status: "completed" },
+          ],
+          status: "completed",
+        }),
+        child("npmTelegram", {
+          conclusion: "failure",
+          errors: [{ kind: "identity_mismatch", message: "wrong workflow SHA", runId: "202" }],
+          runId: "202",
+          status: "completed",
+        }),
+      ],
+      releaseProfile: "stable",
+      workflowRef: "main",
+    });
+    expect(result).toMatchObject({
+      blockers: [expect.objectContaining({ job: "Run install smoke" })],
+      errors: [expect.objectContaining({ kind: "identity_mismatch" })],
+      state: "orchestration_error",
+    });
+  });
+
   it("preserves a blocker and an API error independently", () => {
     const result = classifyReleaseSnapshot({
       children: [

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -364,7 +364,10 @@ describe("release Telegram QA workflow", () => {
       "timeout-minutes": 210,
     });
     expect(caller?.environment).toBeUndefined();
-    expect(caller?.["continue-on-error"]).toBeUndefined();
+    expect(caller?.outputs?.conclusion).toBe(
+      "${{ steps.dispatch.outputs.conclusion || steps.dispatch.outcome }}",
+    );
+    expect(caller?.["continue-on-error"]).toBe(true);
 
     const trusted = job("trusted_identity");
     expect(trusted).toMatchObject({

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1575,6 +1575,7 @@ function runReleaseChecksSummary(params: {
   resolveResult?: "failure" | "success";
   resultOverrides?: Record<string, "cancelled" | "failure" | "skipped" | "success">;
   telegramSelected?: boolean;
+  telegramIdentityVerified?: boolean;
   validatedStatuses?: Array<{ job: string; status: string; variant: string }>;
   workflowRef?: string;
 }) {
@@ -1615,6 +1616,7 @@ function runReleaseChecksSummary(params: {
       QA_LIVE_SLACK_RELEASE_CHECKS_RESULT: "skipped",
       QA_LIVE_TELEGRAM_RELEASE_CHECKS_RESULT: params.currentResult,
       QA_LIVE_TELEGRAM_SELECTED: String(params.telegramSelected ?? true),
+      QA_LIVE_TELEGRAM_IDENTITY_VERIFIED: String(params.telegramIdentityVerified ?? true),
       QA_LIVE_WHATSAPP_RELEASE_CHECKS_RESULT: "skipped",
       RELEASE_CHECK_RUN_ATTEMPT: params.currentAttempt,
       RELEASE_CHECK_RUN_ID: runId,
@@ -5677,7 +5679,7 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
         "${{ (needs.resolve_target.outputs.telegram_waiver != '' || needs.resolve_target.outputs.skip_package_telegram_e2e == 'true') && 'none' || 'mock-openai' }}",
     });
     expect(packageAcceptanceJob.with).toMatchObject({
-      telegram_advisory: "${{ needs.resolve_target.outputs.release_profile == 'beta' }}",
+      telegram_advisory: true,
     });
     expect(workflow).not.toContain("telegram_scenarios:");
     expect(workflow).toContain("ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}");
@@ -6583,7 +6585,7 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
     }
   });
 
-  it("allows beta callers to make only Telegram package acceptance advisory", () => {
+  it("allows release callers to make only Telegram package acceptance advisory", () => {
     const telegramResult = runPackageAcceptanceSummary({
       telegramAdvisory: true,
       telegramEnabled: true,
@@ -6603,6 +6605,33 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
     expect(dockerResult.status).toBe(1);
     expect(dockerResult.stdout).toContain("::error::docker_acceptance ended with failure");
   });
+
+  it.each(["failure", "skipped"] as const)(
+    "reports a package Telegram %s even when no suite report exists",
+    (outcome) => {
+      const report = workflowStep(
+        workflowJob(NPM_TELEGRAM_WORKFLOW, "run_package_telegram_e2e"),
+        "Summarize Telegram attempt",
+      );
+      expect(report.if).toBe("always()");
+      const workdir = tempDirs.make("npm-telegram-attempt-summary-");
+      const summary = resolve(workdir, "summary.md");
+      const result = spawnSync("bash", ["-c", report.run ?? ""], {
+        cwd: workdir,
+        encoding: "utf8",
+        env: {
+          PATH: process.env.PATH,
+          ADVISORY: "true",
+          GITHUB_STEP_SUMMARY: summary,
+          LANE_OUTCOME: outcome,
+        },
+      });
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain(`::warning::Package Telegram attempt: ${outcome}`);
+      expect(readFileSync(summary, "utf8")).toContain(`Telegram attempt: ${outcome}`);
+      expect(readFileSync(summary, "utf8")).not.toContain("passed");
+    },
+  );
 
   it("gives release build steps enough Node heap", () => {
     for (const workflowPath of [LIVE_E2E_WORKFLOW, RELEASE_CHECKS_WORKFLOW]) {
@@ -7052,8 +7081,8 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
 
   it("uses bounded Convex lease waits instead of GitHub concurrency for CI Telegram consumers", () => {
     const telegramJobs = [
-      [NPM_TELEGRAM_WORKFLOW, "run_package_telegram_e2e", "Run package Telegram E2E", "600000"],
-      [RELEASE_TELEGRAM_QA_WORKFLOW, "run_telegram", "Run Telegram live lane", "600000"],
+      [NPM_TELEGRAM_WORKFLOW, "run_package_telegram_e2e", "Run package Telegram E2E", undefined],
+      [RELEASE_TELEGRAM_QA_WORKFLOW, "run_telegram", "Run Telegram live lane", undefined],
       [QA_LIVE_TRANSPORTS_WORKFLOW, "run_live_telegram", "Run Telegram live lane", "1800000"],
     ] as const;
 
@@ -7477,7 +7506,13 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
     expect(telegramDispatch.run).toContain('[[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]');
     expect(telegramDispatch.run).not.toContain("commits/main");
     expect(telegramDispatch.run).not.toContain("dispatch_attempt");
-    expect(telegramCaller["continue-on-error"]).toBeUndefined();
+    expect(telegramCaller["continue-on-error"]).toBe(true);
+    expect(telegramCaller.outputs?.identity_verified).toBe(
+      "${{ steps.dispatch.outputs.identity_verified }}",
+    );
+    expect(telegramDispatch.run?.indexOf('echo "identity_verified=true"')).toBeGreaterThan(
+      telegramDispatch.run?.indexOf('[[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]') ?? -1,
+    );
     expect(telegramCaller["timeout-minutes"]).toBe(210);
 
     const telegramStatus = workflowJob(RELEASE_TELEGRAM_QA_WORKFLOW, "advisory_status");
@@ -7527,6 +7562,8 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
     const verifyStep = workflowStep(summary, "Verify release check results");
     expect(verifyStep.env).toMatchObject({
       QA_LIVE_BUZZ_RELEASE_CHECKS_RESULT: "${{ needs.qa_live_buzz_release_checks.result }}",
+      QA_LIVE_TELEGRAM_RELEASE_CHECKS_RESULT:
+        "${{ needs.qa_live_telegram_release_checks.outputs.conclusion || needs.qa_live_telegram_release_checks.result }}",
       QA_LIVE_RELEASE_CHECKS_RESULT: "${{ needs.qa_live_release_checks.result }}",
       RELEASE_CHECK_RUN_ATTEMPT: "${{ github.run_attempt }}",
       RELEASE_CHECK_RUN_ID: "${{ github.run_id }}",
@@ -7585,10 +7622,12 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
     },
     ...(["cancelled", "failure", "skipped"] as const).map((currentResult) => ({
       emptyStderr: false,
-      expected: [`::error::qa_live_telegram_release_checks ended with ${currentResult}`],
-      name: `rejects a ${currentResult} selected Telegram child`,
+      expected: [
+        `::warning::qa_live_telegram_release_checks ended with ${currentResult}; Telegram release testing is best effort and does not block release validation.`,
+      ],
+      name: `reports a ${currentResult} selected Telegram child without blocking release`,
       params: { currentAttempt: "2", currentResult, telegramSelected: true },
-      status: 1,
+      status: 0,
     })),
     {
       emptyStderr: false,
@@ -7596,6 +7635,31 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
       name: "accepts a skipped unselected Telegram dispatch",
       params: { currentAttempt: "2", currentResult: "skipped", telegramSelected: false },
       status: 0,
+    },
+    {
+      emptyStderr: false,
+      expected: ["::error::Telegram dispatch identity was not verified"],
+      name: "rejects an unverified Telegram child identity despite advisory execution",
+      params: {
+        currentAttempt: "2",
+        currentResult: "failure",
+        telegramIdentityVerified: false,
+      },
+      status: 1,
+    },
+    {
+      emptyStderr: false,
+      expected: [
+        "qa_live_telegram_release_checks ended with failure",
+        "::error::package_acceptance_release_checks ended with failure",
+      ],
+      name: "keeps package failures blocking alongside an advisory Telegram failure",
+      params: {
+        currentAttempt: "2",
+        currentResult: "failure",
+        resultOverrides: { PACKAGE_ACCEPTANCE_RELEASE_CHECKS_RESULT: "failure" },
+      },
+      status: 1,
     },
     {
       emptyStderr: false,
@@ -7611,7 +7675,10 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
     },
     {
       emptyStderr: false,
-      expected: ["qa_live_telegram_release_checks ended with cancelled", "Tideclaw alpha"],
+      expected: [
+        "qa_live_telegram_release_checks ended with cancelled",
+        "Telegram release testing is best effort",
+      ],
       name: "keeps a cancelled Telegram child non-blocking for Tideclaw alpha",
       params: {
         currentAttempt: "2",

--- a/test/scripts/release-beta-verifier.test.ts
+++ b/test/scripts/release-beta-verifier.test.ts
@@ -162,7 +162,6 @@ if (path.basename(process.argv[1]) === "npm" && args[0] === "view" && args[1] ==
     { status: "completed", conclusion: "failure" },
     { status: "completed", conclusion: "cancelled" },
     { status: "completed", conclusion: "skipped" },
-    { status: "in_progress", conclusion: null },
     { status: "completed", conclusion: "success" },
   ])(
     "records optional Telegram as advisory without relabeling $status/$conclusion",
@@ -187,6 +186,14 @@ if (path.basename(process.argv[1]) === "npm" && args[0] === "view" && args[1] ==
       ]);
     },
   );
+
+  it("requires a terminal Telegram attempt before recording advisory evidence", async () => {
+    const fixture = workflowFixture({ status: "in_progress", conclusion: null });
+
+    await expect(verifyBetaRelease(fixture.args, { rootDir: fixture.rootDir })).rejects.toThrow(
+      "NPM Telegram Beta E2E: run 44 is in_progress/<missing>",
+    );
+  });
 
   it("preserves a failed Telegram job even when its advisory workflow concludes success", async () => {
     const fixture = workflowFixture({

--- a/test/scripts/release-beta-verifier.test.ts
+++ b/test/scripts/release-beta-verifier.test.ts
@@ -1,7 +1,8 @@
 // Release Beta Verifier tests cover release beta verifier script behavior.
 /* oxlint-disable typescript/no-base-to-string -- fetch mock normalizes standard RequestInfo inputs for URL assertions. */
 import { createHash } from "node:crypto";
-import { resolve } from "node:path";
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -15,7 +16,11 @@ import {
   runNpmViewWithRetry,
   runReleaseVerifierCommand,
   validateClawHubBootstrapEvidence,
+  verifyBetaRelease,
 } from "../../scripts/lib/release-beta-verifier.ts";
+import { createTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = createTempDirTracker();
 type CommandError = Error & {
   code?: string;
   signal?: NodeJS.Signals;
@@ -92,8 +97,135 @@ function createStoredZip(files: Array<{ name: string; bytes: Buffer }>): Buffer 
 }
 
 afterEach(() => {
+  tempDirs.cleanup();
+  vi.unstubAllEnvs();
   vi.unstubAllGlobals();
   vi.useRealTimers();
+});
+
+describe("verifyBetaRelease workflow outcomes", () => {
+  const version = "2026.5.10-beta.3";
+
+  function workflowFixture(overrides: Record<string, unknown> = {}, telegram = true) {
+    const rootDir = tempDirs.make("release-workflow-outcome-");
+    const binDir = join(rootDir, "bin");
+    mkdirSync(binDir);
+    mkdirSync(join(rootDir, "extensions"));
+    writeFileSync(join(rootDir, "package.json"), JSON.stringify({ version }));
+    const run = {
+      workflowName: telegram ? "NPM Telegram Beta E2E" : "OpenClaw NPM Release",
+      headBranch: "main",
+      event: "workflow_dispatch",
+      status: "completed",
+      conclusion: "success",
+      url: "https://example.invalid/runs/44",
+      createdAt: "2026-07-10T00:00:00Z",
+      updatedAt: "2026-07-10T00:02:00Z",
+      jobs: [],
+      ...overrides,
+    };
+    writeFileSync(join(binDir, "run.json"), JSON.stringify(run));
+    const command = `#!${process.execPath}
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+if (path.basename(process.argv[1]) === "npm" && args[0] === "view" && args[1] === "openclaw@${version}") {
+  console.log(JSON.stringify({version: "${version}", "dist-tags.beta": "${version}", "dist.integrity": "sha512-test", "dist.tarball": "https://example.invalid/openclaw.tgz"}));
+} else if (args[0] === "run" && args[1] === "view" && args[2] === "44") {
+  process.stdout.write(fs.readFileSync(path.join(path.dirname(process.argv[1]), "run.json")));
+} else {
+  throw new Error("Unexpected release verifier command: " + args.join(" "));
+}
+`;
+    for (const name of ["npm", "gh"]) {
+      const file = join(binDir, name);
+      writeFileSync(file, command);
+      chmodSync(file, 0o755);
+    }
+    vi.stubEnv("PATH", `${binDir}:${process.env.PATH}`);
+    const args = parseReleaseVerifyBetaArgs([
+      version,
+      "--skip-postpublish",
+      "--skip-github-release",
+      "--skip-clawhub",
+      "--workflow-ref",
+      "main",
+      telegram ? "--npm-telegram-run" : "--openclaw-npm-run",
+      "44",
+      "--evidence-out",
+      "evidence.json",
+    ]);
+    return { args, rootDir };
+  }
+
+  it.each([
+    { status: "completed", conclusion: "failure" },
+    { status: "completed", conclusion: "cancelled" },
+    { status: "completed", conclusion: "skipped" },
+    { status: "in_progress", conclusion: null },
+    { status: "completed", conclusion: "success" },
+  ])(
+    "records optional Telegram as advisory without relabeling $status/$conclusion",
+    async (run) => {
+      const fixture = workflowFixture(run);
+
+      const lines = await verifyBetaRelease(fixture.args, { rootDir: fixture.rootDir });
+      const evidence = JSON.parse(readFileSync(join(fixture.rootDir, "evidence.json"), "utf8"));
+
+      expect(lines).toContain("openclaw npm OK: 2026.5.10-beta.3 (beta)");
+      expect(lines.some((line) => line.startsWith("NPM Telegram Beta E2E advisory:"))).toBe(true);
+      expect(lines.some((line) => line.startsWith("NPM Telegram Beta E2E OK:"))).toBe(false);
+      expect(evidence.workflowRuns).toEqual([
+        expect.objectContaining({
+          id: "44",
+          advisory: {
+            status: run.status,
+            conclusion: run.conclusion ?? "unavailable",
+            failedJobs: [],
+          },
+        }),
+      ]);
+    },
+  );
+
+  it("preserves a failed Telegram job even when its advisory workflow concludes success", async () => {
+    const fixture = workflowFixture({
+      jobs: [{ name: "Run package Telegram E2E", conclusion: "failure" }],
+    });
+
+    const lines = await verifyBetaRelease(fixture.args, { rootDir: fixture.rootDir });
+    const evidence = JSON.parse(readFileSync(join(fixture.rootDir, "evidence.json"), "utf8"));
+
+    expect(lines.join("\n")).toContain("Run package Telegram E2E");
+    expect(evidence.workflowRuns[0].advisory).toEqual({
+      status: "completed",
+      conclusion: "success",
+      failedJobs: ["Run package Telegram E2E"],
+    });
+  });
+
+  it.each([
+    { override: { workflowName: "Other Workflow" }, error: "workflow is Other Workflow" },
+    { override: { event: "push" }, error: "event is push" },
+    { override: { headBranch: "untrusted" }, error: "branch is untrusted" },
+  ])("keeps Telegram identity validation strict: $error", async ({ override, error }) => {
+    const fixture = workflowFixture({ conclusion: "failure", ...override });
+
+    await expect(verifyBetaRelease(fixture.args, { rootDir: fixture.rootDir })).rejects.toThrow(
+      error,
+    );
+  });
+
+  it.each([
+    { conclusion: "failure" },
+    { jobs: [{ name: "Publish package", conclusion: "failure" }] },
+  ])("keeps non-Telegram workflow failures blocking: %j", async (run) => {
+    const fixture = workflowFixture(run, false);
+
+    await expect(verifyBetaRelease(fixture.args, { rootDir: fixture.rootDir })).rejects.toThrow(
+      "OpenClaw NPM Release: run 44 is",
+    );
+  });
 });
 
 describe("parseReleaseVerifyBetaArgs", () => {

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -1526,9 +1526,15 @@ describe("release CI summary child correlation", () => {
     ).toThrow("manifest parent job was redispatched during recovery");
   });
 
-  it("accepts beta advisory release-check failures through canonical policy", () => {
+  it.each([
+    ["beta", "Run QA Lab parity lane (core)"],
+    ...["beta", "stable", "full"].flatMap((profile) => [
+      [profile, "Run QA Lab live Telegram lane"],
+      [profile, "Run package acceptance / Telegram package acceptance / Run Telegram package E2E"],
+    ]),
+  ])("accepts %s advisory %s failures through canonical policy", (releaseProfile, jobName) => {
     const fixture = trustedMainPackageFixture();
-    fixture.manifest.releaseProfile = "beta";
+    fixture.manifest.releaseProfile = releaseProfile;
     fixture.childRun.conclusion = "failure";
     const originalClient = { ...fixture.client };
     fixture.client.getParentJobs = (requestedRunId: string) =>
@@ -1538,7 +1544,7 @@ describe("release CI summary child correlation", () => {
               completed_at: "2026-07-10T01:10:00Z",
               conclusion: "failure",
               id: 86293408711,
-              name: "Run QA Lab parity lane (core)",
+              name: jobName,
               run_attempt: 1,
               started_at: "2026-07-10T01:00:00Z",
               status: "completed",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where full release verification is blocked by unavailable or unhealthy Telegram Test Server fixtures even after the other release gates pass. The release owner explicitly requested that Telegram testing be best effort whenever the credential pool is available, rather than a release blocker.

## Why This Change Was Made

Use the existing advisory policy for source, packaged, and standalone npm Telegram tests in every release profile. Preserve the actual child/step outcome, evidence links, assertions, credential isolation, and cleanup; failed or skipped Telegram attempts are never relabeled as successful tests. Remove Telegram-only ten-minute acquisition overrides so the canonical 90-second retry budget applies.

The canonical release policy also owns recovery and strict evidence validation. Recovery leaves advisory Telegram failures alone, and evidence reuse consumes the strict verifier's `policyPassed` verdict rather than independently requiring every raw child conclusion to be success. The optional beta verifier reports Telegram status, conclusion, and failed jobs explicitly. Overall workflow/candidate/artifact identity and non-Telegram release gates remain strict. The existing version-specific explicit Telegram omission waiver is unchanged.

## User Impact

Release operators can complete verification when Telegram fixtures are unavailable or the Telegram test fails, with a visible advisory result to investigate separately. This changes release tooling only; no shipped bot behavior, test assertions, credential permissions, configuration options, dependencies, or publication operations change.

## Evidence

- Before the implementation, owner regressions reproduced 30 policy/reporting failures; the existing recovery scenario separately reproduced an unwanted Telegram rerun.
- After the change: 666 tests passed across seven release policy, summary, workflow, reuse, beta-verifier, and recovery suites; two pre-existing platform-dependent tests were skipped.
- Tests execute the workflow summary scripts, preserve failed/skipped outcomes, reject wrong workflow identities, keep non-Telegram failures blocking, and prove recovery does not retry advisory Telegram.
- The final workflow correction passed 249 tests (two existing skips), including rejection of an unverified Telegram child while actual test failures remain advisory.
- Workflow validation (actionlint, zizmor, repository guards), script typecheck/lint, shell syntax, and diff checks passed.
- The local aggregate test-root typecheck is limited by the shared install having grammY 1.45.1/types 4 while this base pins 1.46/types 5; no dependency reconciliation or unrelated Telegram runtime edits were made. The original PR head passed locked-install CI, including all production/test typechecks: [CI run 33321018307](https://github.com/openclaw/openclaw/actions/runs/33321018307).
- Independent managed Codex review is clean after correcting the dispatch-identity boundary.
- The previous full run's actual Telegram fixture failures remain failed evidence; this PR does not claim they passed or repair the fixture. A fresh full run will validate the landed tooling against the same frozen product commit.

Production script delta: +26 lines; workflow delta: +46 lines; documentation: +11 lines. The added lines expose truthful advisory outcomes and share the policy between consumers; obsolete acquisition overrides and duplicated raw-success policy are removed. Test changes are separate.

## Review Follow-through

Addressed ClawSweeper's terminal-state finding and matching rank-up move: the optional beta verifier now requires a completed Telegram attempt, exactly like canonical full verification. Completed failures, cancellations, and skips remain advisory. The new rejection test failed before the two-line correction; all 271 beta-verifier, full-policy, and recovery tests passed afterward, along with script typechecking and lint. This update changes only the reported finding. Final exact-head [CI run 33321864903](https://github.com/openclaw/openclaw/actions/runs/33321864903) passed for d531845f37565882dace628763f7273f845e2876. The updated ClawSweeper review reports no actionable findings.

Release-owner policy decision is confirmed: completed Telegram Test Server failures, cancellations, and skips are advisory for beta, stable, and full release verification. This is the explicitly requested maintainer policy, not a fallback pending approval. Selected attempts still finish and record their real outcomes; identity/provenance and every non-Telegram release gate remain strict. This addresses the updated review's remaining policy-confirmation rank-up move.
