### PR TITLE
fix(cli): reject partial approval grant limits

### DIFF
--- a/src/cli/exec-approvals-cli.pending-resolve.test.ts
+++ b/src/cli/exec-approvals-cli.pending-resolve.test.ts
@@ -143,6 +143,27 @@ describe("exec approvals pending and resolve CLI", () => {
     defaultRuntime.exit.mockClear();
   });
 
+  it.each(["10junk", "1.5", "0"])(
+    "rejects a malformed grants list limit before the Gateway request (%s)",
+    async (limit) => {
+      await expect(
+        runApprovalsCommand(["approvals", "grants", "list", "--limit", limit, "--json"]),
+      ).rejects.toThrow("--limit must be a positive integer.");
+
+      expect(callGatewayFromCli).not.toHaveBeenCalled();
+    },
+  );
+
+  it("forwards a valid grants list limit as a number", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({ grants: [] });
+
+    await runApprovalsCommand(["approvals", "grants", "list", "--limit", "25", "--json"]);
+
+    const call = callGatewayFromCli.mock.calls[0];
+    expect(call?.[0]).toBe("exec.approval.grants.list");
+    expect(call?.[2]).toEqual({ limit: 25 });
+  });
+
   it("renders pending approvals from all three approval kinds", async () => {
     const now = Date.now();
     callGatewayFromCli.mockImplementation(async (method: string) => {

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import { readByteStreamWithLimit } from "@openclaw/media-core/read-byte-stream-with-limit";
 import { expectDefined } from "@openclaw/normalization-core";
+import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
@@ -1253,15 +1254,14 @@ export function registerExecApprovalsCli(program: Command) {
     .option("--limit <n>", "Maximum rows to return (default 200)")
     .action(async (opts: ExecApprovalsCliOpts & { limit?: string }) => {
       try {
-        const limitRaw = opts.limit === undefined ? undefined : Number.parseInt(opts.limit, 10);
-        const limit =
-          limitRaw !== undefined && Number.isInteger(limitRaw) && limitRaw >= 1
-            ? limitRaw
-            : undefined;
+        const limit = parseStrictPositiveInteger(opts.limit);
+        if (opts.limit !== undefined && limit === undefined) {
+          exitWithError("--limit must be a positive integer.");
+        }
         const result = (await callGatewayFromCli(
           "exec.approval.grants.list",
           opts,
-          limit ? { limit } : {},
+          limit !== undefined ? { limit } : {},
         )) as { grants: StandingGrantCliEntry[] }; // SAFETY: matches ExecApprovalGrantsListResultSchema.
         if (opts.json) {
           defaultRuntime.writeJson(result, 0);


### PR DESCRIPTION
## What Problem This Solves

`openclaw approvals grants list --limit` silently accepted malformed input: `10junk` became `10`, `1.5` became `1`, and `0` was treated as omitted, selecting the Gateway default of 200 rows. That made a mistyped query look valid.

## Why This Change Was Made

Reuse the existing strict positive-integer parser at the CLI registration boundary and report `--limit must be a positive integer.` before the Gateway request. An omitted limit still uses the existing default; valid limits remain numeric request parameters. The Gateway keeps its existing 1–500 bound. This replaces the permissive parsing branch with no net production growth (+6/−6); regression coverage adds 21 lines to the existing Commander suite.

Thanks @qingminglong for the fix and regression coverage.

## User Impact

Malformed limits now exit nonzero with a clear error. Scripts that relied on a truncated value or an implicit default from malformed input must supply a positive integer or omit the flag. Grant authorization, mutation commands, lifetime settings, storage, configuration, and defaults are unchanged.

## Evidence

Reviewed head: `8f273fb3d31e7d8792ff49b2b81685cc1c89624b`.

[CI 33351125520](https://github.com/openclaw/openclaw/actions/runs/33351125520) and [Workflow Sanity 33351125508](https://github.com/openclaw/openclaw/actions/runs/33351125508) passed. The [actual CLI shard log](https://github.com/openclaw/openclaw/actions/runs/33351125520/job/99364694172) records all 17 cases in `exec-approvals-cli.pending-resolve.test.ts` passing, including rejection of `10junk`, `1.5`, and `0` before the mocked Gateway request and numeric forwarding of `25`. The full CLI shard passed 6,075 tests (42 skipped). CI checked merge ref `188d81aca24bfc9c940d0f14f2a150d4f5ecf1ca`; both changed source/test blobs are identical to the reviewed PR head.

Real process proof used the repository source launcher, a fresh synthetic home/config per invocation, and an OS-assigned loopback listener. No production Gateway or real approval operation was used. To keep contributor code isolated, the local run used trusted upstream `c29f34dc5312530761529e7133afa083911e7959` with its own frozen dependencies and a task-authored equivalent repair. The entire repaired CLI owner matched the PR blob `0ef7b657c565756fe60824bae053c5b005f30d8e`; the original source was restored byte-for-byte afterward. Hosted CI supplies execution of the exact PR source/dependency context.

The real command shape was:

```sh
node --import tsx src/entry.ts approvals grants list \
  --limit 10junk --json --url ws://127.0.0.1:<listener-port> \
  --token synthetic-loopback-only --timeout 1000
```

Captured process results:

| Source | Limit | Exit | Loopback connections | Observed result |
| --- | --- | ---: | ---: | --- |
| Trusted upstream before repair | `10junk` | 1 | 1 | Reached transport; listener deliberately rejected upgrade with HTTP 503 |
| Equivalent repaired owner | `10junk` | 1 | 0 | `--limit must be a positive integer.` |
| Equivalent repaired owner | `1.5` | 1 | 0 | `--limit must be a positive integer.` |
| Equivalent repaired owner | `0` | 1 | 0 | `--limit must be a positive integer.` |
| Equivalent repaired owner | `25` | 1 | 1 | Reached transport; deliberate HTTP 503 |
| Equivalent repaired owner | Omitted | 1 | 1 | Reached transport; deliberate HTTP 503 |

Each malformed repaired invocation wrote this JSON to stdout and the same error in the CLI diagnostic on stderr:

```json
{"ok":false,"error":{"type":"cli_error","message":"--limit must be a positive integer."}}
```

The valid/omitted controls prove transport was reachable and validation did not block those inputs; they do not claim a successful grant query. The hosted registration test separately verifies `{ "limit": 25 }` forwarding. This inspectable trace addresses the latest ClawSweeper proof request and its rank-up move. Independent full-candidate Codex autoreview was scoped-clean at P0; no code or tests ran inside the reviewer.

Named follow-up: the separate `approvals resolve --expires-in-days` path still uses `parseInt` and can truncate malformed lifetime input. Its authority-bearing resolution flow needs its own repair and proof; it is unchanged here.
