### PR TITLE
perf: reduce repeated prompt and plugin metadata work

### DIFF
--- a/extensions/codex/src/app-server/attempt-context.test.ts
+++ b/extensions/codex/src/app-server/attempt-context.test.ts
@@ -10,6 +10,7 @@ import {
   clearMemoryPluginState,
   registerMemoryCapability,
 } from "openclaw/plugin-sdk/memory-host-core";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildCodexOpenClawPromptContext,
@@ -119,34 +120,36 @@ describe("Codex app-server attempt context", () => {
   });
 
   it("keeps MEMORY.md injected when sandbox effective workspace differs", async () => {
-    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-memory-workspace-"));
-    const sandboxWorkspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-memory-sandbox-"));
-    const memorySummary = "Sandboxed turns need bounded memory fallback.";
-    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memorySummary);
+    await withTempDir("codex-memory-workspace-", async (workspaceDir) => {
+      await withTempDir("codex-memory-sandbox-", async (sandboxWorkspaceDir) => {
+        const memorySummary = "Sandboxed turns need bounded memory fallback.";
+        await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memorySummary);
 
-    const context = await buildCodexWorkspaceBootstrapContext({
-      params: {
-        sessionId: "session-1",
-        sessionKey: "agent:main:session-1",
-        config: {
-          agents: {
-            defaults: {
-              workspace: workspaceDir,
+        const context = await buildCodexWorkspaceBootstrapContext({
+          params: {
+            sessionId: "session-1",
+            sessionKey: "agent:main:session-1",
+            config: {
+              agents: {
+                defaults: {
+                  workspace: workspaceDir,
+                },
+              },
             },
-          },
-        },
-      } as EmbeddedRunAttemptParams,
-      resolvedWorkspace: workspaceDir,
-      effectiveWorkspace: sandboxWorkspaceDir,
-      sessionKey: "agent:main:session-1",
-      sessionAgentId: "main",
-      memoryToolNames: ["memory_search", "memory_get"],
-      ringZeroActive: false,
-    });
+          } as EmbeddedRunAttemptParams,
+          resolvedWorkspace: workspaceDir,
+          effectiveWorkspace: sandboxWorkspaceDir,
+          sessionKey: "agent:main:session-1",
+          sessionAgentId: "main",
+          memoryToolNames: ["memory_search", "memory_get"],
+          ringZeroActive: false,
+        });
 
-    expect(context.memoryReferenceFiles).toEqual([]);
-    expect(context.promptContext).toContain(memorySummary);
-    expect(context.memoryToolRouted).toBe(false);
+        expect(context.memoryReferenceFiles).toEqual([]);
+        expect(context.promptContext).toContain(memorySummary);
+        expect(context.memoryToolRouted).toBe(false);
+      });
+    });
   });
 
   it("passes agent context to Codex memory collaboration guidance", async () => {

--- a/src/agents/embedded-agent-helpers/bootstrap.ts
+++ b/src/agents/embedded-agent-helpers/bootstrap.ts
@@ -113,6 +113,8 @@ type TrimBootstrapResult = {
   originalLength: number;
 };
 
+type PolicyDigestCandidate = { line: string; highPriority: boolean };
+
 type PolicyDigest = {
   text: string;
   omittedLines: number;
@@ -170,42 +172,38 @@ function normalizePolicyDigestLine(line: string): string {
   return `${truncateUtf16Safe(normalized, AGENTS_POLICY_DIGEST_MAX_LINE_CHARS - 1)}…`;
 }
 
-function buildAgentsPolicyDigest(content: string, budget: number): PolicyDigest {
+function buildAgentsPolicyDigest(
+  candidates: readonly PolicyDigestCandidate[],
+  budget: number,
+): PolicyDigest {
   if (budget <= 0) {
     return { text: "", omittedLines: 0 };
   }
 
-  const candidates = content
-    .split(/\r?\n/u)
-    .map((line, index) => ({ index, line: normalizePolicyDigestLine(line) }))
-    .filter(({ line }) => line.length > 0 && isPolicyDigestCandidate(line));
-  const highPriorityPattern =
-    /\b(?:AGENTS\.md|scoped|required|must|never|do not|before subtree|read scoped|security|secret|credential)\b/iu;
-  const selected = new Set<number>();
+  const selected = new Set<PolicyDigestCandidate>();
   let used = 0;
-  const trySelect = (candidate: { index: number; line: string }) => {
+  const trySelect = (candidate: PolicyDigestCandidate) => {
     const separatorChars = selected.size > 0 ? 1 : 0;
     if (used + separatorChars + candidate.line.length > budget) {
       return;
     }
-    selected.add(candidate.index);
+    selected.add(candidate);
     used += separatorChars + candidate.line.length;
   };
 
   for (const candidate of candidates) {
-    if (highPriorityPattern.test(candidate.line)) {
+    if (candidate.highPriority) {
       trySelect(candidate);
     }
   }
   for (const candidate of candidates) {
-    if (!selected.has(candidate.index)) {
+    if (!selected.has(candidate)) {
       trySelect(candidate);
     }
   }
 
   const lines = candidates
-    .filter((candidate) => selected.has(candidate.index))
-    .toSorted((a, b) => a.index - b.index)
+    .filter((candidate) => selected.has(candidate))
     .map((candidate) => candidate.line);
   return {
     text: lines.join("\n"),
@@ -213,21 +211,23 @@ function buildAgentsPolicyDigest(content: string, budget: number): PolicyDigest 
   };
 }
 
-function trimAgentsBootstrapContent(content: string, maxChars: number): TrimBootstrapResult {
-  const trimmed = content.trimEnd();
-  if (trimmed.length <= maxChars) {
-    return {
-      content: trimmed,
-      truncated: false,
-      maxChars,
-      originalLength: trimmed.length,
-    };
-  }
-
+function trimAgentsBootstrapContent(trimmed: string, maxChars: number): TrimBootstrapResult {
   let headChars = Math.floor(maxChars * AGENTS_POLICY_HEAD_RATIO);
   let tailChars = Math.floor(maxChars * AGENTS_POLICY_TAIL_RATIO);
   let digestBudget = Math.floor(maxChars * AGENTS_POLICY_DIGEST_RATIO);
-  let digest = buildAgentsPolicyDigest(trimmed, digestBudget);
+  // Budget refinement reselects these distinct source-ordered lines without reparsing them.
+  const candidates: PolicyDigestCandidate[] = [];
+  if (!(digestBudget <= 0)) {
+    const highPriorityPattern =
+      /\b(?:AGENTS\.md|scoped|required|must|never|do not|before subtree|read scoped|security|secret|credential)\b/iu;
+    for (const sourceLine of trimmed.split(/\r?\n/u)) {
+      const line = normalizePolicyDigestLine(sourceLine);
+      if (line.length > 0 && isPolicyDigestCandidate(line)) {
+        candidates.push({ line, highPriority: highPriorityPattern.test(line) });
+      }
+    }
+  }
+  let digest = buildAgentsPolicyDigest(candidates, digestBudget);
   const render = () =>
     [
       sliceUtf16Safe(trimmed, 0, headChars),
@@ -250,7 +250,7 @@ function trimAgentsBootstrapContent(content: string, maxChars: number): TrimBoot
       headChars = Math.max(1, headChars - overflow);
     } else {
       digestBudget = Math.max(0, digestBudget - overflow);
-      digest = buildAgentsPolicyDigest(trimmed, digestBudget);
+      digest = buildAgentsPolicyDigest(candidates, digestBudget);
     }
     rendered = render();
   }
@@ -278,7 +278,7 @@ function trimBootstrapContent(
     };
   }
   if (isAgentsBootstrapFile(fileName)) {
-    return trimAgentsBootstrapContent(content, maxChars);
+    return trimAgentsBootstrapContent(trimmed, maxChars);
   }
 
   const markerTemplate = (headChars: number, tailChars: number) =>

--- a/src/agents/harness/model-catalog.test.ts
+++ b/src/agents/harness/model-catalog.test.ts
@@ -94,27 +94,42 @@ function registryWithCatalog(loadModelCatalog: () => Promise<readonly never[]>) 
 }
 
 describe("agent harness model catalog", () => {
-  it("does not donate host transport or capabilities to native-owned rows", async () => {
-    const native = {
-      provider: "openai",
-      id: "gpt-5.6-sol",
-      name: "Native model",
-      nativeRuntime: "codex",
-      reasoning: true,
-    };
-    const result = await augmentModelCatalogWithAgentHarness({
-      cfg,
-      agentId: "main",
-      agentDir: "/tmp/main-agent",
-      workspaceDir: "/tmp/workspace",
-      defaultProvider: "openai",
-      defaultModel: "openai/gpt-5.6-sol",
-      snapshot,
-      pluginRegistry: registryWithCatalog(async () => [native] as never),
-    });
-    expect(result.entries[0]).toEqual(native);
-    expect(result.routeVariants[0]).toEqual(native);
-  });
+  it.each([false, true])(
+    "does not donate host transport or capabilities to native-owned rows (host sibling: %s)",
+    async (includeHostRow) => {
+      const native = {
+        provider: "openai",
+        id: "gpt-5.6-sol",
+        name: "Native model",
+        nativeRuntime: "codex",
+        reasoning: true,
+      };
+      const host = { provider: "openai", id: "gpt-5.6-terra", name: "Host model" };
+      const result = await augmentModelCatalogWithAgentHarness({
+        cfg,
+        agentId: "main",
+        agentDir: "/tmp/main-agent",
+        workspaceDir: "/tmp/workspace",
+        defaultProvider: "openai",
+        defaultModel: "openai/gpt-5.6-sol",
+        snapshot,
+        pluginRegistry: registryWithCatalog(
+          async () => (includeHostRow ? [native, host] : [native]) as never,
+        ),
+      });
+      expect(result.entries[0]).toEqual(native);
+      expect(result.routeVariants[0]).toEqual(native);
+      if (includeHostRow) {
+        expect(result.entries[1]).toMatchObject({
+          id: "gpt-5.6-terra",
+          name: "Host model",
+          api: "openai-chatgpt-responses",
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+          reasoning: true,
+        });
+      }
+    },
+  );
   it("merges account-scoped harness models into the prepared generation", async () => {
     const loadModelCatalog = vi.fn(async () => [
       {

--- a/src/agents/harness/model-catalog.ts
+++ b/src/agents/harness/model-catalog.ts
@@ -41,12 +41,11 @@ function normalizeRouteBaseUrl(value: string | undefined): string {
   }
 }
 
-function routeVariantKey(entry: ModelCatalogEntry): string {
-  return [
-    resolveModelCatalogIdentityKey(entry),
-    entry.api ?? "",
-    normalizeRouteBaseUrl(entry.baseUrl),
-  ].join("\0");
+function routeVariantKey(
+  entry: ModelCatalogEntry,
+  identityKey = resolveModelCatalogIdentityKey(entry),
+): string {
+  return [identityKey, entry.api ?? "", normalizeRouteBaseUrl(entry.baseUrl)].join("\0");
 }
 
 function mergeHarnessCompat(
@@ -77,26 +76,31 @@ function enrichHarnessRows(
 ): ModelCatalogEntry[] {
   const routeDonors = new Map<string, ModelCatalogEntry>();
   const identityDonors = new Map<string, ModelCatalogEntry>();
-  // First donor wins: live snapshot entries take precedence over static rows.
-  for (const donor of [...snapshot.entries, ...(snapshot.staticEntries ?? [])]) {
-    const routeKey = routeVariantKey(donor);
-    const identityKey = resolveModelCatalogIdentityKey(donor);
-    if (!routeDonors.has(routeKey)) {
-      routeDonors.set(routeKey, donor);
-    }
-    if (!identityDonors.has(identityKey)) {
-      identityDonors.set(identityKey, donor);
-    }
-  }
+  let donorsPrepared = false;
   return rows.map((entry) => {
     // Native discovery owns these capabilities; host donors cannot invent its transport.
     if (entry.nativeRuntime) {
       return entry;
     }
+    if (!donorsPrepared) {
+      // First donor wins: live snapshot entries take precedence over static rows.
+      for (const donor of [...snapshot.entries, ...(snapshot.staticEntries ?? [])]) {
+        const identityKey = resolveModelCatalogIdentityKey(donor);
+        const routeKey = routeVariantKey(donor, identityKey);
+        if (!routeDonors.has(routeKey)) {
+          routeDonors.set(routeKey, donor);
+        }
+        if (!identityDonors.has(identityKey)) {
+          identityDonors.set(identityKey, donor);
+        }
+      }
+      donorsPrepared = true;
+    }
+    const identityKey = resolveModelCatalogIdentityKey(entry);
     const donor =
-      routeDonors.get(routeVariantKey(entry)) ??
+      routeDonors.get(routeVariantKey(entry, identityKey)) ??
       (entry.api === undefined && entry.baseUrl === undefined
-        ? identityDonors.get(resolveModelCatalogIdentityKey(entry))
+        ? identityDonors.get(identityKey)
         : undefined);
     if (!donor) {
       return entry;

--- a/src/plugins/plugin-cache.ts
+++ b/src/plugins/plugin-cache.ts
@@ -101,6 +101,11 @@ export function resetPluginCache(): void {
 
 export function getPluginCacheRoot(rootDir: string): PluginRootCacheRecord {
   const cache = getPluginCache();
+  // Alias binding can replace the canonical record while older lexical records remain.
+  const cached = cache.roots.get(cache.rootAliases.get(rootDir) ?? rootDir);
+  if (cached) {
+    return cached;
+  }
   const lexical = path.resolve(rootDir);
   const key = cache.rootAliases.get(lexical) ?? lexical;
   let root = cache.roots.get(key);


### PR DESCRIPTION
## What Problem This Solves

Large workspace instructions and repeated model/plugin metadata requests spend CPU preparing information that is already available: policy lines are reparsed during prompt-budget refinement, native-only catalog rows trigger unused host donor indexes, and known plugin roots undergo repeated path resolution.

## Why This Change Was Made

Three existing owners now retain their prepared facts for the correct lifetime:

- Prompt truncation prepares distinct, source-ordered policy candidates once, reuses their priority during budget refinement, and retains output order without sorting again.
- Catalog enrichment populates host donor indexes only at the first host-owned row and reuses each normalized identity. Native rows retain their own capabilities, transport ownership and object identity.
- Plugin metadata returns an existing root record before resolving its path again. Canonical aliases take precedence over older lexical records after rebinding.

No new cross-request cache, public API, configuration, schema, dependency, deadline or protocol surface is added. The native-first catalog test also covers a later host row. A nearby Codex memory test now uses the existing temporary-directory owner to clean both directories on success and failure.

Production: +56/−47 (**+9**): digest 0, catalog +4, root lookup +5. Tests: +64/−46 (**+18**). The small production increase implements lazy preparation and the existing-generation hit path without a wrapper or fallback.

## User Impact

Behavior and prompt bytes stay unchanged. Selected metadata preparation paths use less CPU; this is not a claimed provider, network, native acquisition or whole-turn speedup.

Fresh Node v26.8.1 processes ran each complete owner in both starting orders. Values below are median microseconds per operation (first order / reversed order):

| Complete-owner workload | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Scoped prompt, tight 200-character cap, through final prompt/report | 50.941 / 51.563 | 26.320 / 25.691 | 48.3% / 50.2% |
| Dense prompt, tight cap, through final prompt/report | 605.263 / 595.717 | 319.369 / 323.156 | 47.2% / 45.8% |
| Catalog: one host donor, one native row | 158.551 / 146.922 | 129.537 / 125.062 | 18.3% / 14.9% |
| Catalog: 128 live + 512 static donors, 16 native rows | 6283.125 / 6106.084 | 1105.375 / 1141.750 | 82.4% / 81.3% |
| Same catalog size, 16 host rows | 6096.291 / 6154.667 | 3859.917 / 3983.000 | 36.7% / 35.3% |
| Cached path-exists caller | 1.206 / 1.235 | 0.717 / 0.734 | 40.5% / 40.5% |

All 109 workloads and costs are retained; gains are not added together or weighted into a traffic average. Digest has 6 faster-both, 5 slower-both and 11 mixed cases; donor 67/4/8; root lookup 5/3/0. Those counts describe measurements, not statistical significance.

The ordinary synthetic six-file prompt composition costs +1.021/+0.154 µs (+5.85%/+0.86%). Scoped construction at cap 600 costs +0.542/+0.094 µs (+10.23%/+1.82%). Short AGENTS costs +0.0008/+0.0044 µs; cap-300 construction costs +0.044/+0.045 µs. Unchanged SOUL controls also measure +0.190/+0.343 µs, and unchanged empty-pipeline control is mixed with +1.718 µs in one order. Dense default composition is mixed (+4.10%/−1.97%). The six-file fixture includes retired TOOLS.md as synthetic input and is not an automatic-loader default.

Relative/noncanonical root lookups cost +2.03–2.79% (0.015–0.021 µs); cold root creation costs +0.02%/+4.09% (up to 0.049 µs). Four unchanged catalog early-return controls are slower in both orders by at most 1.88%, under 0.78 µs. Native-only calls still allocate two empty Maps; donor traversal, normalization and population are skipped. Whole-process RSS contains imports and both variants and is not attributed to either variant.

## Evidence

- **419 tests / 22 canonical suites passed**: bootstrap construction/budgets/reports/realtime, catalog preparation/native ownership, plugin caches/lifecycles and Codex context. `pnpm test <selected paths> -- --maxWorkers=1` completed in 60.83 s.
- Full changed-file type/lint/boundary gate passed in 315.61 s: `node scripts/check-changed.mjs --base a22f9d8ef77e8117a6ccd4bd2a3db37886870a7e --timed -- <five changed paths>`.
- Complete-owner differential proofs passed: 13,072 digest comparisons, 6,536 immutability checks and 11,220 controls; 411 catalog fixtures with 1,233 value/byte comparisons, 1,233 alias-graph comparisons and 84 lifecycle checks; 6,144 cache-sequence operations plus real symlink, cwd, alias-identity and lifecycle controls. These are overlapping layers, not a sum of unique user scenarios.
- Independent owner review and managed Codex review found no actionable issues. Parent independently recomputed all 436 medians from the six saved raw result files. Final graph SHA256: `cfb7891c05d51cd7e59133217d4b06c4477d465fc00c0441438d012d320ff011`.
- Baseline built Gateway: four real OpenAI turns, 44 successful RPCs, 596 assertions across default and oversized workspace instructions; actual context-only nonce and successful sessions_list tool lifecycle, bounded prompt reports and request JSON, exact repeated catalog payload digests. All task processes stopped and workspace restored. CPU profiles retained.
- Baseline actual native owner: isolated API-key reference, five native rows with API-key readiness on the second ordinary catalog read, no host transport donation, retained row identity, no persisted native credential file, verified process cleanup. Native reports version 0.151.0. This proves native inventory ownership, not network entitlement or model inference.

Candidate `pnpm build` passed at `5b52d78b1b17d5348c9329c88312f569f86c1380` (154.93 s). The candidate repeats four real OpenAI turns, 44 successful RPCs and 596 assertions; both before/after report/catalog comparisons pass all 28 checks. The candidate native owner again returns five rows on the subsequent read, with the exact baseline native payload digest and all original ownership/auth/cleanup assertions. Across before/candidate: eight real OpenAI turns, 88 RPCs and 1,192 assertions. Prompt hashes and request bytes are retained separately because fresh session identities change the Runtime prompt; only the documented four report identity/time/hash fields are excluded from report comparison. Both actual process groups and protected-input resources are cleaned up. Exact-head CI remains required before merge.

The first cold native read returns the host snapshot without an error; original failures are retained. Source suggests the login response can precede a later account/updated notification that revokes the first observation, but starting revision/notification order was not captured. This remains a named lifecycle investigation, not a fixed bug or cold-start success. No retry or weaker lifetime fence is added to production. Direct contracts checked include `../codex/codex-rs/app-server/src/models.rs`, `request_processors/catalog_processor.rs:243`, `request_processors/account_processor.rs:439`, and native project-document owners.

A separate source-only registration profile exposed expensive Jiti resolution; the unmeasured lazy-import proposal still retains model-preparation imports and is not included or counted here. No CHANGELOG.md edit: current repository policy reserves it for release work.

## ClawSweeper follow-through

The direct Codex source check requested in the latest review and its Rank-up moves is complete. I personally inspected the sibling checkout at `6478a751fde8884b2fdc76486fe23175a8e795d4`: `codex-rs/app-server/src/models.rs:14` and `:28`, `codex-rs/app-server/src/request_processors/catalog_processor.rs:243`, and `codex-rs/app-server-protocol/src/protocol/v2/model.rs:53`, `:92`, and `:147`. The server produces its own model IDs, input modalities and reasoning capabilities, and returns paginated `data`/`nextCursor`; it does not provide a host-provider API or base URL. OpenClaw's unchanged pagination/normalization owner and native catalog mapping preserve that ownership. The changed enrichment owner still returns each native row unchanged before donor work; a later host row still initializes the first-wins donor indexes. The actual before/candidate native runs also preserve the same five-row payload digest and row identity. This closes the reviewer's unavailable-checkout evidence gap; it is not a claim that the remote reviewer performed the check.

The automated “persistent cache schema” classification does not apply to this patch. `src/plugins/plugin-cache.ts:43` owns process-local/operation-local Maps through a singleton and AsyncLocalStorage; `:96` retires the process generation. The patch changes only the lookup in that existing owner. No persistent store, schema, migration, cache generation or invalidation rule changes. All current-generation alias rebinding and scoped-lifecycle controls remain green. No code repair was requested by the review, and the native cold-observation follow-up remains explicitly unresolved above.
