### PR TITLE
improve(ui): shimmer while GitHub link previews load

### DIFF
--- a/ui/src/components/github-link-hovercard.runtime.ts
+++ b/ui/src/components/github-link-hovercard.runtime.ts
@@ -221,7 +221,18 @@ function renderLoading(card: HTMLDivElement): void {
   const label = t("githubPreview.loading");
   // The card is a dialog, so every render state has to leave it with a name.
   card.setAttribute("aria-label", label);
-  appendTextElement(card, "div", "github-link-hovercard__loading", label);
+  const skeleton = appendTextElement(card, "div", "github-link-hovercard__skeleton", "");
+  skeleton.setAttribute("aria-hidden", "true");
+  for (const [rowClass, parts] of [
+    ["header", ["badge", "repo", "time"]],
+    ["title", ["title"]],
+    ["footer", ["author", "metrics"]],
+  ] as const) {
+    const row = appendTextElement(skeleton, "div", `github-link-hovercard__${rowClass}`, "");
+    for (const part of parts) {
+      appendTextElement(row, "span", `skeleton github-link-hovercard__placeholder--${part}`, "");
+    }
+  }
 }
 
 function renderUnavailable(card: HTMLDivElement): void {

--- a/ui/src/e2e/github-link-hovercard.e2e.test.ts
+++ b/ui/src/e2e/github-link-hovercard.e2e.test.ts
@@ -88,8 +88,9 @@ const pullPreviewResponse = {
 
 // Shared page setup for the two pointer-lifecycle cases below: both only need
 // a single previewable pull-request link, unlike the full walkthrough above.
-async function openPullPreviewPage(): Promise<{
+async function openPullPreviewPage(deferPreview = false): Promise<{
   card: Locator;
+  gateway: Awaited<ReturnType<typeof installMockGateway>>;
   page: Page;
   pullLink: Locator;
 }> {
@@ -102,7 +103,8 @@ async function openPullPreviewPage(): Promise<{
   );
 
   const page = await context.newPage();
-  await installMockGateway(page, {
+  const gateway = await installMockGateway(page, {
+    deferredMethods: deferPreview ? ["controlUi.githubPreview"] : [],
     methodResponses: {
       "controlUi.githubPreview": {
         cases: [{ match: { kind: "pull", number: 99816 }, response: pullPreviewResponse }],
@@ -123,7 +125,7 @@ async function openPullPreviewPage(): Promise<{
   const pullLink = page.locator('a.markdown-github-link[href$="/pull/99816"]');
   const card = page.locator(".github-link-hovercard");
   await pullLink.waitFor({ state: "visible" });
-  return { card, page, pullLink };
+  return { card, gateway, page, pullLink };
 }
 
 describeControlUiE2e("GitHub link hover cards", () => {
@@ -140,6 +142,46 @@ describeControlUiE2e("GitHub link hover cards", () => {
   });
 
   afterEach(closeBrowsers);
+
+  it.each([
+    { theme: "light", reducedMotion: "no-preference", width: 1180, fails: false },
+    { theme: "dark", reducedMotion: "no-preference", width: 1180, fails: false },
+    { theme: "dark", reducedMotion: "reduce", width: 390, fails: true },
+  ] as const)("shimmers while pending ($theme, $reducedMotion, $width)", async (scenario) => {
+    const { card, gateway, page, pullLink } = await openPullPreviewPage(true);
+    await page.emulateMedia({ colorScheme: scenario.theme, reducedMotion: scenario.reducedMotion });
+    await page.setViewportSize({ width: scenario.width, height: 800 });
+    await pullLink.focus();
+    await gateway.waitForRequest("controlUi.githubPreview");
+
+    await expect.poll(() => card.getAttribute("aria-label")).toBe("Loading GitHub details…");
+    const skeleton = card.locator('[aria-hidden="true"]');
+    await skeleton.waitFor({ state: "visible" });
+    expect(await card.locator("a").count()).toBe(0);
+    expect(await card.textContent()).toBe("");
+    const placeholder = skeleton.locator(".skeleton").first();
+    await placeholder.waitFor({ state: "visible" });
+    const animating = () =>
+      placeholder.evaluate((element) =>
+        element
+          .getAnimations({ subtree: true })
+          .some((animation) => animation.playState === "running"),
+      );
+    await expect.poll(animating).toBe(scenario.reducedMotion === "no-preference");
+    const bounds = await card.boundingBox();
+    expect(bounds!.x).toBeGreaterThanOrEqual(0);
+    expect(bounds!.x + bounds!.width).toBeLessThanOrEqual(scenario.width);
+
+    if (scenario.fails) {
+      await gateway.rejectDeferred("controlUi.githubPreview", { message: "Unavailable" });
+      await expectText(card, "GitHub preview unavailable");
+    } else {
+      await gateway.resolveDeferred("controlUi.githubPreview");
+      await expectText(card, pullPreviewResponse.title);
+    }
+    expect(await card.locator(".skeleton").count()).toBe(0);
+    expect(await card.getAttribute("aria-label")).not.toBe("Loading GitHub details…");
+  });
 
   it("previews issue and pull request links while preserving navigation", async () => {
     const context = await newBrowserContext();

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1424,7 +1424,6 @@ openclaw-session-progress-hovercard-provider {
   color: var(--danger);
 }
 
-.github-link-hovercard__loading,
 .github-link-hovercard__unavailable {
   display: flex;
   align-items: center;
@@ -1434,21 +1433,40 @@ openclaw-session-progress-hovercard-provider {
   font-size: var(--control-ui-text-sm);
 }
 
-.github-link-hovercard__loading::before {
-  width: 18px;
-  height: 18px;
-  margin-right: 9px;
-  border: 2px solid color-mix(in srgb, var(--muted) 25%, transparent);
-  border-top-color: var(--muted);
-  border-radius: 50%;
-  content: "";
-  animation: github-hovercard-spin 0.8s linear infinite;
+.github-link-hovercard__skeleton .skeleton {
+  display: block;
+  height: 14px;
+  border-radius: var(--radius-sm);
 }
 
-@keyframes github-hovercard-spin {
-  to {
-    transform: rotate(360deg);
-  }
+.github-link-hovercard__skeleton .github-link-hovercard__placeholder--badge {
+  width: 60px;
+  height: 25px;
+  flex-shrink: 0;
+  border-radius: var(--radius-full);
+}
+
+.github-link-hovercard__placeholder--repo {
+  width: 45%;
+}
+
+.github-link-hovercard__placeholder--time {
+  width: 14%;
+  margin-left: auto;
+}
+
+.github-link-hovercard__skeleton .github-link-hovercard__placeholder--title {
+  width: 90%;
+  height: 20px;
+}
+
+.github-link-hovercard__placeholder--author {
+  width: 35%;
+}
+
+.github-link-hovercard__skeleton .github-link-hovercard__placeholder--metrics {
+  width: 38%;
+  height: 25px;
 }
 
 @media (max-width: 560px) {
@@ -1478,10 +1496,6 @@ openclaw-session-progress-hovercard-provider {
 @media (prefers-reduced-motion: reduce) {
   .github-link-hovercard {
     transition: none;
-  }
-
-  .github-link-hovercard__loading::before {
-    animation: none;
   }
 }
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainers can push to this same-repository branch.

</details>

## What Problem This Solves

The Control UI GitHub link hovercard shows a spinner and “Loading GitHub details…” in an otherwise blank card while fetching a pull request or issue. Replace that plain loader with the requested card-shaped shimmer.

## Why This Change Was Made

The hovercard's loading renderer now uses the existing shared skeleton primitive, arranged like the preview's header, title, and footer. It retains the localized dialog name, hides decorative placeholders from assistive technology, and inherits the shared reduced-motion behavior. The dedicated spinner CSS/keyframes are removed; fetching, caching, completed previews, links, and unavailable-state behavior are unchanged.

No new dependency, setting, or animation implementation is needed. Production delta: +44/-19 (net +25); the growth supplies the placeholder layout after removing the old spinner. Tests: +45/-3.

## User Impact

Hovering or keyboard-focusing a GitHub pull-request or issue link shows a quiet preview-shaped shimmer until details arrive. Reduced-motion users see static placeholders. Successful and failed responses both replace the loading state.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/github-link-hovercard.e2e.test.ts` — 7 passed. New cases cover light/dark, a narrow viewport with reduced motion, accessible labeling, noninteractive placeholders, and successful/failed request completion. The three new cases were run before implementation and failed because the skeleton was absent.
- `node scripts/run-vitest.mjs ui/src/components/github-link-hovercard.test.ts ui/src/styles/shimmer.browser.test.ts` — 20 passed, including preview caching/navigation, lifecycle, shared compositor animation, and reduced motion.
- `pnpm ui:build` — passed, including UI asset budgets.
- `node scripts/check-changed.mjs -- ui/src/components/github-link-hovercard.runtime.ts ui/src/styles/components.css ui/src/e2e/github-link-hovercard.e2e.test.ts` — passed (guards, formatting, i18n, core-test/UI typechecks, code/style lint).
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33321389266) passed for `44c548766542ba7f13631f34e711d36566d59c5c`.
- Autoreview, uncommitted scope, default P0 priority — scoped-clean, no actionable findings.

### Before/after screenshots

Captured and personally inspected before/after screenshots from Chromium running this checkout's Vite UI against an isolated real local Gateway. The operator's Gateway/state was not modified. A synthetic assistant note was added through `chat.inject`; hovering its public GitHub link used the real `controlUi.githubPreview` request (no mocked browser or Gateway traffic).

Before: spinner with loading text, then the real pull-request preview loaded successfully. After: card-shaped skeleton. GitHub's anonymous API quota became exhausted during after verification (HTTP 403, remaining quota 0), exercising the unchanged unavailable state; successful completion is additionally covered by the deterministic browser tests.

| Before — plain loader | After — shimmer skeleton |
| --- | --- |
| <img width="590" alt="Before: GitHub hovercard with spinner and loading text" src="https://github.com/user-attachments/assets/912d11d1-4309-48f8-8c79-2baa7ee4e727" /> | <img width="590" alt="After: GitHub hovercard with card-shaped shimmer placeholders" src="https://github.com/user-attachments/assets/33cd732c-7c24-4e4c-91ef-5a5764842326" /> |

Uploaded through GitHub's standard browser attachment control; no proof assets are committed to the product branch.

