### PR TITLE
refactor(plugins): simplify registration lifecycle policy

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3442,7 +3442,6 @@ src/plugin-state/plugin-store-validation.ts	1
 src/plugin-state/runtime-health-store.ts	1
 src/plugins/agent-tool-result-middleware.ts	1
 src/plugins/api-facades.ts	1
-src/plugins/api-lifecycle.ts	1
 src/plugins/bundle-config-shared.ts	1
 src/plugins/bundle-lsp.ts	1
 src/plugins/bundle-mcp.ts	2
@@ -3506,7 +3505,7 @@ src/plugins/loader-channel-setup.ts	17
 src/plugins/loader-cli-registry.ts	2
 src/plugins/loader-discovery.ts	1
 src/plugins/loader-load-context.ts	4
-src/plugins/loader-module-runtime.ts	12
+src/plugins/loader-module-runtime.ts	11
 src/plugins/loader-records.ts	1
 src/plugins/loader-runtime-candidate.ts	1
 src/plugins/loader-runtime-load.ts	2

--- a/src/plugins/api-lifecycle.test.ts
+++ b/src/plugins/api-lifecycle.test.ts
@@ -4,6 +4,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { buildPluginApi } from "./api-builder.js";
+import { isLateCallablePluginApiMethod } from "./api-lifecycle.js";
 import { runPluginRegisterSyncInRegistry } from "./loader-module-runtime.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import type { PluginRuntime } from "./runtime/types.js";
@@ -146,5 +147,25 @@ describe("plugin api lifecycle", () => {
 
     expect(result).toBeUndefined();
     expect(registerSessionExtension).not.toHaveBeenCalled();
+  });
+
+  it.each<[string, boolean]>([
+    ["clearRunContext", true],
+    ["emitAgentEvent", true],
+    ["enqueueNextTurnInjection", true],
+    ["getRunContext", true],
+    ["sendSessionAttachment", true],
+    ["scheduleSessionTurn", true],
+    ["setRunContext", true],
+    ["unscheduleSessionTurnsByTag", true],
+    ["registerTool", false],
+    ["registerSessionExtension", false],
+    ["unknown", false],
+    ["", false],
+    ["constructor", false],
+    ["toString", false],
+    ["__proto__", false],
+  ])("classifies late-call eligibility for %j as %s", (methodName, expected) => {
+    expect(isLateCallablePluginApiMethod(methodName)).toBe(expected);
   });
 });

--- a/src/plugins/api-lifecycle.ts
+++ b/src/plugins/api-lifecycle.ts
@@ -1,43 +1,18 @@
 /** Tracks plugin API lifecycle callbacks registered during runtime activation. */
 import type { OpenClawPluginApi } from "./types.js";
 
-type FunctionPropertyNames<T> = Extract<
-  {
-    [K in keyof T]-?: Exclude<T[K], undefined> extends (...args: unknown[]) => unknown ? K : never;
-  }[keyof T],
-  string
->;
-
-/** Names of plugin API methods exposed on the OpenClaw plugin API. */
-type PluginApiMethodName = FunctionPropertyNames<OpenClawPluginApi>;
-
-/** Lifecycle policy for whether a plugin API method can be called after registration. */
-type PluginApiLifecyclePolicy = {
-  phase: "registration" | "runtime";
-  lateCallable: boolean;
-};
-
-const PLUGIN_API_METHOD_POLICIES: Partial<Record<PluginApiMethodName, PluginApiLifecyclePolicy>> = {
-  clearRunContext: { phase: "runtime", lateCallable: true },
-  emitAgentEvent: { phase: "runtime", lateCallable: true },
-  enqueueNextTurnInjection: { phase: "runtime", lateCallable: true },
-  getRunContext: { phase: "runtime", lateCallable: true },
-  sendSessionAttachment: { phase: "runtime", lateCallable: true },
-  scheduleSessionTurn: { phase: "runtime", lateCallable: true },
-  setRunContext: { phase: "runtime", lateCallable: true },
-  unscheduleSessionTurnsByTag: { phase: "runtime", lateCallable: true },
-};
-
-/** Returns lifecycle policy for one plugin API method name. */
-function getPluginApiMethodLifecyclePolicy(
-  methodName: string,
-): PluginApiLifecyclePolicy | undefined {
-  return PLUGIN_API_METHOD_POLICIES[methodName as PluginApiMethodName];
-}
+const LATE_CALLABLE_PLUGIN_API_METHODS: ReadonlySet<string> = new Set<keyof OpenClawPluginApi>([
+  "clearRunContext",
+  "emitAgentEvent",
+  "enqueueNextTurnInjection",
+  "getRunContext",
+  "sendSessionAttachment",
+  "scheduleSessionTurn",
+  "setRunContext",
+  "unscheduleSessionTurnsByTag",
+]);
 
 /** True when a plugin API method remains callable after registration. */
-export function isLateCallablePluginApiMethod(
-  methodName: string,
-): methodName is PluginApiMethodName {
-  return getPluginApiMethodLifecyclePolicy(methodName)?.lateCallable === true;
+export function isLateCallablePluginApiMethod(methodName: string): boolean {
+  return LATE_CALLABLE_PLUGIN_API_METHODS.has(methodName);
 }

--- a/src/plugins/loader-module-runtime.ts
+++ b/src/plugins/loader-module-runtime.ts
@@ -296,9 +296,6 @@ export function resolvePluginModuleExport(moduleExport: unknown): {
     }
   }
   const resolved = candidates[0];
-  if (typeof resolved === "function") {
-    return { register: resolved as OpenClawPluginDefinition["register"] };
-  }
   if (resolved && typeof resolved === "object") {
     const definition = resolved as OpenClawPluginDefinition;
     return { definition, register: definition.register };


### PR DESCRIPTION
## What Problem This Solves

The plugin registration lifecycle carries an unused policy layer even though its only decision is whether a method remains callable after registration. The nearby module-export resolver also repeats a callable fallback that its earlier candidate walk already handles.

## Why This Change Was Made

Use one typed set for the existing eight late-callable methods and remove the unreachable callable fallback. Registration closes at the same boundary; the object-definition fallback and its observable second `register` property read remain intact. The assertion baseline only shrinks to record the two removed assertions.

This is a bounded, maintainer-requested cleanup. It does not add configuration, change plugin API methods, relax registration ownership, or remove an external compatibility path. The reachability argument assumes ordinary JavaScript intrinsics, not arbitrary mutation of built-in collection methods by a plugin.

## User Impact

No intended user-visible change. Plugins retain the same registration-only and runtime-callable behavior with less internal policy machinery to maintain.

Production LOC: **+12 / -40 (28 removed)**. Tests: **+21 / -0**. Assertion baseline: **+1 / -2**. Whole change: **8 lines removed**.

## Evidence

The current candidate is `3a276728a803153a98cfe077b83d267b867539be`, based on `84fde8560d9ac0269c2fc186fd933bb1f11888d1`. The previous candidate's [CI run](https://github.com/openclaw/openclaw/actions/runs/33331084817) failed the Gateway shutdown admission assertion. Canonical #133466 repairs the non-isolated test runner's between-file cleanup ordering; this candidate incorporates that landed repair rather than adding a duplicate fix. The three cleanup production/test afterimages remain identical; the shrink-only assertion baseline also preserves the upstream model-scan row change.

- The composed candidate passed **270 outer cases** across the non-isolated runner, Gateway shutdown, work admission, plugin lifecycle, run-context contract, CLI metadata loading, and loader suites. The existing runner test additionally exercises 34 nested child cases; these are not added to the 270 count. No outer cases were skipped or retried.
- All original 239 lifecycle/loader cases retain their emitted identities and within-file order. The lifecycle table checks all eight permitted names plus registration-only, unknown, empty, and prototype-like names. Existing registration-close and grouped/flat API behavior tests remain.
- All **30 changed checks passed** on the composed source, including core and core-test types, core/scripts lint, assertion/dead-export ratchets, plugin boundaries, and runtime import cycles.
- Earlier baseline/candidate proof passed the original 239 cases; the previous composed candidate also passed 108 Workshop and test-report-owner cases. These older results are retained as history, not relabeled as execution on the new head.
- Earlier direct-Node and `pnpm exec` attempts failed eight isolated Corepack bootstrap cases. The normal package-script `npm_execpath` contract was then verified, and unchanged tests passed through `pnpm test`, without enabling networking, weakening assertions, or changing timeouts. Both those setup failures and the later hosted shutdown failure remain recorded.
- A separate authenticated read-only Codex review of the exact composed commit completed all three input batches with no actionable findings at P0. Context was partitioned across batches; the final batch did not contain the full caller/export traversal context present in the earlier input. This is static review, not a fresh test execution or landing certificate.

Exact composed commands (pinned Node 24.19.0 and repository pnpm 12.1):

```sh
pnpm test test/non-isolated-runner.test.ts src/gateway/worker-environments/computer-transport.shutdown.test.ts src/process/gateway-work-admission.test.ts src/plugins/api-lifecycle.test.ts src/plugins/contracts/run-context-lifecycle.contract.test.ts src/plugins/loader.cli-metadata.test.ts src/plugins/loader.test.ts -- --reporter=verbose
node scripts/check-changed.mjs --base 84fde8560d9ac0269c2fc186fd933bb1f11888d1 -- config/assertion-safety-baseline.txt src/plugins/api-lifecycle.test.ts src/plugins/api-lifecycle.ts src/plugins/loader-module-runtime.ts
```

These are local owner-boundary tests and checks, not a live Gateway, channel, provider, or packaged-plugin run. Exact-head [CI33333932606](https://github.com/openclaw/openclaw/actions/runs/33333932606) completed successfully on `3a276728a803153a98cfe077b83d267b867539be`; the normal exact-head watcher returned GREEN. Normal native hosted preparation and merge remain unexecuted. No earlier failed or older-head run is treated as green evidence.

The watcher retained a raw aggregate FAILURE from six superseded old contexts while the attached current CI run completed successfully. This is the canonical normalized result, not a claim that every historical context passed.

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/133364#issuecomment-5469807781), reviewed at 20:39 UTC on the exact candidate, found no actionable source or security defect. Its outstanding exact-head-check item is now satisfied; there was no separate Rank-up moves list. Normal maintainer preparation and merge handling remain. The fixed current-main observation at `661fedfe55e7b9620ef89747c381e5a6fc88622c` retained all 38 reviewed owner/context files and the trusted launcher closure; unrelated assertion-baseline changes do not alter the two cleanup reductions. This is a static composition check, not new full-main runtime proof.

Final source comparison against `69b819680ba8d38e4717ff91267376164fb57d6a` also preserves the upstream test-runner cleanup from #133368. Its two ordered admission cases were not part of this candidate's recorded 34 nested cases. The plugin owners and other reviewed contexts remain unchanged; this comparison is not a new test execution.
