### PR TITLE
fix(google): avoid duplicate turn completion after voice interruption

### DIFF
--- a/ui/src/pages/chat/realtime-talk-google-live-transcripts.test.ts
+++ b/ui/src/pages/chat/realtime-talk-google-live-transcripts.test.ts
@@ -65,37 +65,65 @@ describe("Google Live browser transcript finality", () => {
     transport.stop();
   });
 
-  it("finalizes interrupted output on its original Talk turn without merging the next response", async () => {
-    const onTranscript = vi.fn();
-    const onTalkEvent = vi.fn();
-    const transport = createTransport({ onTranscript, onTalkEvent });
-    const ws = await startTransport(transport);
-    onTalkEvent.mockClear();
-    for (const serverContent of [
-      { outputTranscription: { text: "Interrupted " } },
-      { outputTranscription: { text: "response" } },
-      { interrupted: true },
-      { outputTranscription: { text: "Next response", finished: true } },
-      { turnComplete: true },
-    ]) {
-      ws.emitMessage(encodeJsonFrame({ serverContent }));
-      await flushMicrotasks();
-    }
-    expect(
-      onTranscript.mock.calls.filter(([entry]) => entry.final).map(([entry]) => entry.text),
-    ).toEqual(["Interrupted response", "Next response"]);
-    expect(onTalkEvent.mock.calls.map(([event]) => [event.type, event.turnId])).toEqual([
-      ["output.text.delta", "turn-1"],
-      ["output.text.delta", "turn-1"],
-      ["output.text.done", "turn-1"],
-      ["turn.cancelled", "turn-1"],
-      ["output.text.delta", "turn-2"],
-      ["output.text.done", "turn-2"],
-      ["turn.ended", "turn-2"],
-    ]);
-    transport.stop();
-    expect(onTranscript.mock.calls.filter(([entry]) => entry.final)).toHaveLength(2);
-  });
+  it.each([
+    {
+      name: "before the next input transcript",
+      boundary: [
+        { interrupted: true },
+        { turnComplete: true },
+        { inputTranscription: { text: "New question" } },
+      ],
+    },
+    {
+      name: "after an independently ordered input transcript",
+      boundary: [
+        { interrupted: true },
+        { inputTranscription: { text: "New question" } },
+        { turnComplete: true },
+      ],
+    },
+    {
+      name: "in the interruption frame",
+      boundary: [
+        { interrupted: true, turnComplete: true },
+        { inputTranscription: { text: "New question" } },
+      ],
+    },
+  ])(
+    "does not end another Talk turn when interrupted completion arrives $name",
+    async ({ boundary }) => {
+      const onTranscript = vi.fn();
+      const onTalkEvent = vi.fn();
+      const transport = createTransport({ onTranscript, onTalkEvent });
+      const ws = await startTransport(transport);
+      onTalkEvent.mockClear();
+      for (const serverContent of [
+        { outputTranscription: { text: "Interrupted " } },
+        { outputTranscription: { text: "response" } },
+        ...boundary,
+        { outputTranscription: { text: "Next response", finished: true } },
+        { turnComplete: true },
+      ]) {
+        ws.emitMessage(encodeJsonFrame({ serverContent }));
+        await flushMicrotasks();
+      }
+      expect(
+        onTranscript.mock.calls.filter(([entry]) => entry.final).map(([entry]) => entry.text),
+      ).toEqual(["Interrupted response", "New question", "Next response"]);
+      expect(onTalkEvent.mock.calls.map(([event]) => [event.type, event.turnId])).toEqual([
+        ["output.text.delta", "turn-1"],
+        ["output.text.delta", "turn-1"],
+        ["output.text.done", "turn-1"],
+        ["turn.cancelled", "turn-1"],
+        ["transcript.done", "turn-2"],
+        ["output.text.delta", "turn-2"],
+        ["output.text.done", "turn-2"],
+        ["turn.ended", "turn-2"],
+      ]);
+      transport.stop();
+      expect(onTranscript.mock.calls.filter(([entry]) => entry.final)).toHaveLength(3);
+    },
+  );
 
   it("releases the UTF-8 transcript budget on finality and closes on overflow without persisting a partial", async () => {
     const onTranscript = vi.fn();

--- a/ui/src/pages/chat/realtime-talk-google-live.ts
+++ b/ui/src/pages/chat/realtime-talk-google-live.ts
@@ -92,6 +92,7 @@ export class GoogleLiveRealtimeTalkTransport implements RealtimeTalkTransport {
   private inputMeter: RealtimeTalkMediaStreamMeter | null = null;
   private readonly inputPump = new RealtimeTalkPcmInputPump();
   private closed = false;
+  private interruptedTurn = false;
   private readonly camera: RealtimeTalkCameraController;
   private readonly lifecycle = new GoogleLiveConnectionLifecycle();
   private cameraPublished = false;
@@ -270,6 +271,7 @@ export class GoogleLiveRealtimeTalkTransport implements RealtimeTalkTransport {
 
   private releaseResources(): void {
     this.clearSetupTimeout();
+    this.interruptedTurn = false;
     this.pendingTranscripts.user = { text: "", byteCount: 0 };
     this.pendingTranscripts.assistant = { text: "", byteCount: 0 };
     const inputMeter = this.inputMeter;
@@ -377,6 +379,7 @@ export class GoogleLiveRealtimeTalkTransport implements RealtimeTalkTransport {
     }
     const content = message.serverContent;
     if (content?.interrupted) {
+      this.interruptedTurn = true;
       this.stopOutput();
     }
     if (content?.inputTranscription && !this.appendTranscript("user", content.inputTranscription)) {
@@ -421,8 +424,13 @@ export class GoogleLiveRealtimeTalkTransport implements RealtimeTalkTransport {
         final: true,
         payload: { reason: "provider-interrupted" },
       });
-    } else if (content?.turnComplete) {
+    } else if (content?.turnComplete && !this.interruptedTurn) {
       this.emitTalkEvent({ type: "turn.ended", final: true });
+    }
+    // Google completes interrupted turns separately; input transcription can
+    // arrive in between and must not have its new Talk turn closed by that frame.
+    if (content?.turnComplete) {
+      this.interruptedTurn = false;
     }
     if (this.closed) {
       return;


### PR DESCRIPTION
Closes #133351

## What Problem This Solves

Fixes an issue where Google Live Browser Talk would create an extra ended turn, or prematurely end the next input turn, when Google completed an already-interrupted response.

## Why This Change Was Made

Google sends an interruption followed by completion of that same model turn. Input transcription is independently ordered and may arrive between those messages. The Google browser producer now retains the interruption fact until the matching completion and consumes that completion without emitting a second terminal event. Immediate cancellation, audio clearing, and transcript finalization are unchanged.

This belongs in the Google producer: a generic no-active-turn guard would still incorrectly end an intervening input turn. Gateway relay uses a different event producer and does not emit this duplicate pair. No auth, configuration, protocol, persistence, or provider deadline changes. Provenance: introducing commit unknown; the previous interruption test omitted the separate completion frame.

## User Impact

Interrupted Google browser calls preserve Talk turn correlation. The evidence does not show lost saved transcripts or an audible defect, and this change makes no claim to improve speech recognition accuracy. No rendered UI changes.

## Evidence

Two regression cases failed before the fix: completion before the next input, and completion after an independently ordered input. The same-frame control already passed. After the fix, all 59 Google browser tests passed across transcript finality, transport, control, video, and setup timeout coverage.

```sh
node scripts/run-vitest.mjs ui/src/pages/chat/realtime-talk-google-live-transcripts.test.ts --reporter=verbose
# Before: 2 failed, 4 passed; extra terminal event and wrong subsequent turn IDs.

node scripts/run-vitest.mjs ui/src/pages/chat/realtime-talk-google-live-transcripts.test.ts ui/src/pages/chat/realtime-talk-google-live.test.ts ui/src/pages/chat/realtime-talk-google-live-control.test.ts ui/src/pages/chat/realtime-talk-google-live-timeout.test.ts ui/src/pages/chat/realtime-talk-google-live-video.test.ts
# After: 59 passed.
```

A live Google v1beta call using `gemini-3.1-flash-live-preview` and SDK 2.18.0 reproduced the separate-frame sequence with synthetic speech. The provider emitted interruption at 4047 ms, completion at 4142 ms, the next input transcript at 5726 ms, then “Crystal” and a normal completion. Zero errors; clean close. Input-before-completion is supported by the specification and tested deterministically, but was not observed in that call. The live probe establishes the provider sequence; the actual browser producer and shared emitter are exercised by the regression tests.

Contract checked directly: https://ai.google.dev/api/live#bidigeneratecontentservercontent and installed SDK types. Fresh pinned Codex review found no actionable P0-P2 findings. Scoped formatting and whitespace checks passed.

Production: +9/-1 (net +8), recording a provider-owned fact not previously retained. Tests: +59/-31, replacing the incomplete test with three ordering cases. The shared emitter, relay, and OpenAI paths are unchanged.

### Provider contract confirmation

Maintainer verification addresses the review's unavailable-network limitation and rank-up request. Google’s current [Live API reference](https://ai.google.dev/api/live#bidigeneratecontentservercontent), checked on August 30, states the interrupted generation sequence as `interrupted > turn_complete`; the installed `@google/genai` 2.18.0 declarations repeat: “in interrupted turn, it will go through interrupted > turn_complete.” The same reference says input transcription has no guaranteed ordering, which is why the marker remains through intervening input. The retained live trace independently confirms one interruption and its separate completion, 95 ms apart.

Maintainer decision: retain the producer-local marker. Its eight net production lines record the required cross-frame fact; a shared-emitter guard would not protect an intervening input turn. Exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/33321485000
