### PR TITLE
fix(ui): hide redundant error details

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -576,7 +576,7 @@ They are generated separately from the agent's work, so a title is not a complet
 status or a report of tool access. Existing titles and manual names are left
 unchanged; click a title to rename it.
 
-Chat error banners, including cloud runner failures, keep a compact preview. Open **Error details** to read and select the complete diagnostic received by the UI, then use **Copy error** to copy it. The disclosure works with Enter or Space; the expanded text wraps long lines and can be scrolled with the keyboard. Expanding or copying an error does not retry the failed operation.
+Chat error banners, including cloud runner failures, show complete one-line errors directly. When a diagnostic contains additional lines, open **Error details** to read and select the complete diagnostic received by the UI, then use **Copy error** to copy it. The disclosure works with Enter or Space; the expanded text wraps long lines and can be scrolled with the keyboard. Expanding or copying an error does not retry the failed operation.
 
 <AccordionGroup>
   <Accordion title="Send and history semantics">

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -576,7 +576,7 @@ They are generated separately from the agent's work, so a title is not a complet
 status or a report of tool access. Existing titles and manual names are left
 unchanged; click a title to rename it.
 
-Chat error banners, including cloud runner failures, show complete one-line errors directly. When a diagnostic contains additional lines, open **Error details** to read and select the complete diagnostic received by the UI, then use **Copy error** to copy it. The disclosure works with Enter or Space; the expanded text wraps long lines and can be scrolled with the keyboard. Expanding or copying an error does not retry the failed operation.
+Chat error banners, including cloud runner failures, show short messages in full. Use **Copy error** to copy the complete diagnostic received by the UI. **Error details** appears only when the complete diagnostic adds information beyond the preview, such as additional lines or text shortened for the preview; repeated lines and whitespace-only differences do not add details. Open it to read and select the complete diagnostic. The disclosure works with Enter or Space; the expanded text wraps long lines and can be scrolled with the keyboard. Expanding or copying an error does not retry the failed operation. Retry and other recovery actions remain separate from the disclosure.
 
 <AccordionGroup>
   <Accordion title="Send and history semantics">

--- a/src/plugin-state/plugin-state-store.errors.test.ts
+++ b/src/plugin-state/plugin-state-store.errors.test.ts
@@ -1,0 +1,104 @@
+import { DatabaseSync } from "node:sqlite";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearOpenClawDatabaseQuarantine,
+  recordOpenClawDatabaseQuarantine,
+} from "../state/openclaw-quarantine-store.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
+import {
+  clearOpenClawStateDatabaseOpenFailure,
+  openOpenClawStateDatabase,
+  recordOpenClawStateDatabaseOpenFailure,
+} from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import {
+  closePluginStateDatabase,
+  createPluginStateKeyedStore,
+  resetPluginStateStoreForTests,
+} from "./plugin-state-store.js";
+
+let testState: OpenClawTestState | undefined;
+beforeAll(async () => {
+  testState = await createOpenClawTestState({ label: "plugin-state-open-errors" });
+});
+beforeEach(() => testState?.applyEnv());
+afterEach(() => resetPluginStateStoreForTests());
+afterAll(async () => testState?.cleanup());
+
+describe("plugin state open errors", () => {
+  it("fails closed for process-local and persisted database quarantine", async () => {
+    const store = createPluginStateKeyedStore("discord", {
+      namespace: "quarantine",
+      maxEntries: 10,
+    });
+    await store.register("k", { ok: true });
+    const databasePath = resolveOpenClawStateSqlitePath(testState?.env);
+    closePluginStateDatabase();
+
+    recordOpenClawStateDatabaseOpenFailure(databasePath, new Error("latched failure"));
+    await expect(store.lookup("k")).rejects.toMatchObject({
+      code: "PLUGIN_STATE_OPEN_FAILED",
+      path: databasePath,
+      message: "Failed to open the plugin state database.",
+    });
+    clearOpenClawStateDatabaseOpenFailure(databasePath);
+
+    expect(
+      recordOpenClawDatabaseQuarantine({
+        env: testState?.env,
+        kind: "state",
+        path: databasePath,
+        reason: "persisted failure",
+      }),
+    ).toBe(true);
+    try {
+      for (const operation of [() => store.lookup("k"), () => store.register("k", { ok: true })]) {
+        await expect(operation()).rejects.toMatchObject({
+          code: "PLUGIN_STATE_OPEN_FAILED",
+          path: databasePath,
+          message:
+            "Failed to open the plugin state database.\nDatabase integrity verification failed. Restore or repair the state database, then run openclaw doctor --fix.",
+        });
+      }
+    } finally {
+      clearOpenClawStateDatabaseOpenFailure(databasePath);
+      expect(clearOpenClawDatabaseQuarantine(databasePath, { env: testState?.env })).toBe(true);
+    }
+  });
+
+  it("fails closed for a newer shared-state schema", async () => {
+    const store = createPluginStateKeyedStore("discord", {
+      namespace: "newer-schema",
+      maxEntries: 10,
+    });
+    await store.register("k", { ok: true });
+    const databasePath = resolveOpenClawStateSqlitePath(testState?.env);
+    openOpenClawStateDatabase().db.exec(
+      `PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION + 1};`,
+    );
+    closePluginStateDatabase();
+
+    try {
+      for (const operation of [() => store.lookup("k"), () => store.register("k", { ok: true })]) {
+        await expect(operation()).rejects.toMatchObject({
+          code: "PLUGIN_STATE_OPEN_FAILED",
+          path: databasePath,
+          message:
+            "Failed to open the plugin state database.\nThe state database uses a newer schema. Run an OpenClaw build that supports it.",
+        });
+      }
+    } finally {
+      clearOpenClawStateDatabaseOpenFailure(databasePath);
+      const database = new DatabaseSync(databasePath);
+      try {
+        database.exec(`PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION};`);
+      } finally {
+        database.close();
+      }
+    }
+  });
+});

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -8,7 +8,9 @@ import {
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { isTerminalSqliteIntegrityError } from "../infra/sqlite-integrity.js";
 import { normalizeSqliteNumber } from "../infra/sqlite-number.js";
+import { isSqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
@@ -113,10 +115,22 @@ function wrapPluginStateError(
   if (error instanceof PluginStateStoreError) {
     return error;
   }
+  let publicMessage = message;
+  // Only owner-classified failures get public hints. Cause messages can contain
+  // database paths, SQL, or stored values and must stay out of this message.
+  if (fallbackCode === "PLUGIN_STATE_OPEN_FAILED") {
+    if (isSqliteSchemaVersionError(error)) {
+      publicMessage +=
+        "\nThe state database uses a newer schema. Run an OpenClaw build that supports it.";
+    } else if (error instanceof Error && isTerminalSqliteIntegrityError(error)) {
+      publicMessage +=
+        "\nDatabase integrity verification failed. Restore or repair the state database, then run openclaw doctor --fix.";
+    }
+  }
   return createPluginStateError({
     code: fallbackCode,
     operation,
-    message,
+    message: publicMessage,
     path: pathname,
     cause: error,
   });

--- a/src/plugin-state/plugin-state-store.test.ts
+++ b/src/plugin-state/plugin-state-store.test.ts
@@ -1,19 +1,11 @@
 // Plugin state store tests cover per-plugin persisted state reads and writes.
 import { chmodSync, existsSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
-import { DatabaseSync } from "node:sqlite";
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  clearOpenClawDatabaseQuarantine,
-  recordOpenClawDatabaseQuarantine,
-} from "../state/openclaw-quarantine-store.js";
-import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
-import {
-  clearOpenClawStateDatabaseOpenFailure,
   isOpenClawStateDatabaseOpen,
   openOpenClawStateDatabase,
-  recordOpenClawStateDatabaseOpenFailure,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import {
@@ -927,68 +919,6 @@ describe("plugin state keyed store", () => {
         expect(existsSync(databasePath)).toBe(false);
       },
     );
-  });
-
-  it("fails closed for process-local and persisted database quarantine", async () => {
-    await withPluginStateTestState(async () => {
-      const store = createPluginStateKeyedStore("discord", {
-        namespace: "quarantine",
-        maxEntries: 10,
-      });
-      await store.register("k", { ok: true });
-      const databasePath = resolveOpenClawStateSqlitePath(testState?.env);
-      closePluginStateDatabase();
-
-      recordOpenClawStateDatabaseOpenFailure(databasePath, new Error("latched failure"));
-      await expect(store.lookup("k")).rejects.toMatchObject({
-        code: "PLUGIN_STATE_OPEN_FAILED",
-        path: databasePath,
-      });
-      clearOpenClawStateDatabaseOpenFailure(databasePath);
-
-      expect(
-        recordOpenClawDatabaseQuarantine({
-          env: testState?.env,
-          kind: "state",
-          path: databasePath,
-          reason: "persisted failure",
-        }),
-      ).toBe(true);
-      await expect(store.lookup("k")).rejects.toMatchObject({
-        code: "PLUGIN_STATE_OPEN_FAILED",
-        path: databasePath,
-      });
-      expect(clearOpenClawDatabaseQuarantine(databasePath, { env: testState?.env })).toBe(true);
-    });
-  });
-
-  it("fails closed for a newer shared-state schema", async () => {
-    await withPluginStateTestState(async () => {
-      const store = createPluginStateKeyedStore("discord", {
-        namespace: "newer-schema",
-        maxEntries: 10,
-      });
-      await store.register("k", { ok: true });
-      const databasePath = resolveOpenClawStateSqlitePath(testState?.env);
-      openOpenClawStateDatabase().db.exec(
-        `PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION + 1};`,
-      );
-      closePluginStateDatabase();
-
-      try {
-        await expect(store.lookup("k")).rejects.toMatchObject({
-          code: "PLUGIN_STATE_OPEN_FAILED",
-          path: databasePath,
-        });
-      } finally {
-        const database = new DatabaseSync(databasePath);
-        try {
-          database.exec(`PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION};`);
-        } finally {
-          database.close();
-        }
-      }
-    });
   });
 
   it.runIf(process.platform !== "win32")(

--- a/ui/src/e2e/chat-flow.queue-edit.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.queue-edit.e2e.test.ts
@@ -284,7 +284,6 @@ suite.define(() => {
 
       await page
         .getByRole("alert")
-        .locator("summary")
         .getByText("Could not store this message for reconnect.", { exact: false })
         .waitFor({ timeout: 10_000 });
       await row.waitFor();

--- a/ui/src/e2e/chat-flow.streaming.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.streaming.e2e.test.ts
@@ -438,7 +438,9 @@ suite.define(() => {
           await page.screenshot({ path: path.join(artifactDir, `terminal-partial-${label}.png`) });
         }
         const alert = page.locator(".chat-error");
-        await alert.locator("summary").getByText(errorText).waitFor({ timeout: 10_000 });
+        await alert.getByText("Error details", { exact: true }).click();
+        await alert.getByText(errorText, { exact: true }).waitFor({ timeout: 10_000 });
+        await alert.getByText("Error details", { exact: true }).click();
         expect(await alert.getByRole("button", { name: "Dismiss error" }).count()).toBe(0);
         expect(await alert.getByRole("button", { name: "Retry", exact: true }).count()).toBe(0);
         expect(await page.locator(".chat-thread-inner").getByText(errorText).count()).toBe(0);

--- a/ui/src/e2e/chat-header-session-outcomes.e2e.test.ts
+++ b/ui/src/e2e/chat-header-session-outcomes.e2e.test.ts
@@ -215,11 +215,7 @@ suite.define(() => {
           ),
         )
         .toBe(sessionA);
-      await visiblePane
-        .getByRole("alert")
-        .locator("summary")
-        .getByText(message, { exact: true })
-        .waitFor();
+      await visiblePane.getByRole("alert").getByText(message, { exact: true }).waitFor();
 
       await page.getByRole("button", { name: "Runs on Cloud" }).click();
       await page.getByText("Stop cloud worker…", { exact: true }).waitFor();

--- a/ui/src/e2e/chat-outbox-capacity.e2e.test.ts
+++ b/ui/src/e2e/chat-outbox-capacity.e2e.test.ts
@@ -212,7 +212,7 @@ suite.define(() => {
                 utf16Bytes: 2 * (key.length + sessionStorage.getItem(key)!.length),
               })),
             );
-            const error = await pane.locator(".chat-error__summary strong").allTextContents();
+            const error = await pane.getByRole("alert").allInnerTexts();
             const evidence = {
               gateway: "mock; no provider or operator Gateway contacted",
               browser: suite.browser.version(),

--- a/ui/src/e2e/chat-outbox-payloads.e2e.test.ts
+++ b/ui/src/e2e/chat-outbox-payloads.e2e.test.ts
@@ -374,7 +374,7 @@ suite.define(() => {
       await stage(page, "Mock Gateway: retain on blocked storage");
       await paneFor(page).getByRole("button", { name: "Send message", exact: true }).click();
       await paneFor(page)
-        .locator(".chat-error__summary strong")
+        .getByRole("alert")
         .filter({ hasText: "Browser attachment storage is unavailable" })
         .waitFor();
       expect(await composerFor(page).inputValue()).toBe("Mock Gateway: retain on blocked storage");

--- a/ui/src/e2e/chat-reply-preview-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-reply-preview-recovery.e2e.test.ts
@@ -76,7 +76,6 @@ suite.define(() => {
           await page
             .locator(".chat-pane-cache__pane--active")
             .getByRole("alert")
-            .locator("summary")
             .getByText("The original message is unavailable.", { exact: true })
             .waitFor();
           await expectRequestCountStable(gateway, "chat.message.get", 1);

--- a/ui/src/pages/chat/chat-view-notices.ts
+++ b/ui/src/pages/chat/chat-view-notices.ts
@@ -66,6 +66,16 @@ function renderDiskSpaceNotice(diskSpace: SessionPlacementDiskSpace | undefined)
 }
 
 function renderErrorNotice(error: string, action: TemplateResult | typeof nothing = nothing) {
+  const lines = error.split(/\r?\n/u);
+  const summaryIndex = lines.findIndex((line) => line.trim());
+  const summary = lines[summaryIndex]?.trim() ?? "";
+  const normalizedDetails = lines
+    .slice(summaryIndex + 1)
+    .join(" ")
+    .trim()
+    .replace(/\s+/gu, " ");
+  const hasDetails =
+    normalizedDetails !== "" && normalizedDetails !== summary.replace(/\s+/gu, " ");
   return html`
     <div
       class="chat-composer-neighbor-card chat-composer-neighbor-card--danger chat-error"
@@ -74,16 +84,20 @@ function renderErrorNotice(error: string, action: TemplateResult | typeof nothin
       <span class="chat-composer-neighbor-card__icon" aria-hidden="true"
         >${icons.alertTriangle}</span
       >
-      <details class="chat-error__content">
-        <summary class="chat-error__summary">
-          <strong>${error}</strong>
-          <span>${t("chat.errorDetails")}</span>
-          <span class="chat-error__chevron" aria-hidden="true">${icons.chevronDown}</span>
-        </summary>
-        <pre class="chat-error__diagnostic" tabindex="0" aria-label=${t("chat.errorDetails")}>
+      ${hasDetails
+        ? html`<details class="chat-error__content">
+            <summary class="chat-error__summary">
+              <strong>${summary}</strong>
+              <span>${t("chat.errorDetails")}</span>
+              <span class="chat-error__chevron" aria-hidden="true">${icons.chevronDown}</span>
+            </summary>
+            <pre class="chat-error__diagnostic" tabindex="0" aria-label=${t("chat.errorDetails")}>
 ${error}</pre>
-        ${renderCopyButton(error, t("chat.copyError"))}
-      </details>
+            ${renderCopyButton(error, t("chat.copyError"))}
+          </details>`
+        : html`<span class="chat-error__content"
+            ><strong>${summary}</strong>${renderCopyButton(error, t("chat.copyError"))}</span
+          >`}
       ${action}
     </div>
   `;

--- a/ui/src/pages/chat/chat-view-notices.ts
+++ b/ui/src/pages/chat/chat-view-notices.ts
@@ -5,6 +5,7 @@ import { renderCopyButton } from "../../components/copy-button.ts";
 import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
 import { formatBytes } from "../../lib/agents/display.ts";
+import { clampText } from "../../lib/format.ts";
 import { chatMessagesContainQueuedSend } from "./chat-send-support.ts";
 import { renderWorkspaceConflictNotice } from "./components/chat-workspace-conflict.ts";
 import type { WorkspaceResultConflict } from "./workspace-conflict.ts";
@@ -66,16 +67,14 @@ function renderDiskSpaceNotice(diskSpace: SessionPlacementDiskSpace | undefined)
 }
 
 function renderErrorNotice(error: string, action: TemplateResult | typeof nothing = nothing) {
-  const lines = error.split(/\r?\n/u);
-  const summaryIndex = lines.findIndex((line) => line.trim());
-  const summary = lines[summaryIndex]?.trim() ?? "";
-  const normalizedDetails = lines
-    .slice(summaryIndex + 1)
-    .join(" ")
+  const lines = error
     .trim()
-    .replace(/\s+/gu, " ");
-  const hasDetails =
-    normalizedDetails !== "" && normalizedDetails !== summary.replace(/\s+/gu, " ");
+    .split(/\r?\n/u)
+    .map((line) => line.replace(/\s+/gu, " ").trim());
+  const [firstLine = ""] = lines;
+  const summary = clampText(firstLine);
+  const hasDetails = lines.some((line) => line !== "" && line !== summary);
+  // Plain summaries wrap fully; only expandable previews may clip at narrow widths.
   return html`
     <div
       class="chat-composer-neighbor-card chat-composer-neighbor-card--danger chat-error"

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -954,6 +954,28 @@ describe("inline approval card", () => {
 });
 
 describe("chat run error", () => {
+  it.each(["run", "request"])("omits redundant %s error details", (source) => {
+    const container = renderChatView(
+      source === "run"
+        ? { runError: { summary: "Gateway unavailable" } }
+        : { error: "Gateway unavailable" },
+    );
+    const alert = requireElement(container, ".chat-error", "chat run error");
+
+    expect(alert.querySelector("details")).toBeNull();
+    expect(alert.textContent).toContain("Gateway unavailable");
+    expect(alert.querySelector<HTMLButtonElement>('[aria-label="Copy error"]')).not.toBeNull();
+  });
+
+  it("ignores whitespace-only differences when deciding whether details add information", () => {
+    const container = renderChatView({
+      runError: { summary: "Gateway unavailable\n  Gateway   unavailable  " },
+    });
+
+    expect(container.querySelector(".chat-error details")).toBeNull();
+    expect(container.querySelector(".chat-error strong")?.textContent).toBe("Gateway unavailable");
+  });
+
   it("keeps Check delivery reachable when exact history deduplicates the retained bubble", () => {
     vi.mocked(chatThread.buildCachedChatItems).mockRestore();
     vi.mocked(chatMessage.renderMessageGroup).mockRestore();
@@ -1057,6 +1079,9 @@ describe("chat run error", () => {
       expect(alert.getAttribute("role")).toBe("alert");
       const details = requireElement(alert, "details", "error disclosure");
       expect(details.hasAttribute("open")).toBe(false);
+      expect(requireElement(details, "summary strong", "error summary").textContent).toBe(
+        "Error: gateway disconnected",
+      );
       expect(requireElement(details, "pre", "full diagnostic").textContent).toBe(diagnostic);
       expect(alert.querySelector("img")).toBeNull();
       expect(alert.querySelector<HTMLButtonElement>('[aria-label="Copy error"]')).not.toBeNull();

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -954,27 +954,34 @@ describe("inline approval card", () => {
 });
 
 describe("chat run error", () => {
-  it.each(["run", "request"])("omits redundant %s error details", (source) => {
-    const container = renderChatView(
-      source === "run"
-        ? { runError: { summary: "Gateway unavailable" } }
-        : { error: "Gateway unavailable" },
-    );
-    const alert = requireElement(container, ".chat-error", "chat run error");
-
-    expect(alert.querySelector("details")).toBeNull();
-    expect(alert.textContent).toContain("Gateway unavailable");
-    expect(alert.querySelector<HTMLButtonElement>('[aria-label="Copy error"]')).not.toBeNull();
-  });
-
-  it("ignores whitespace-only differences when deciding whether details add information", () => {
-    const container = renderChatView({
-      runError: { summary: "Gateway unavailable\n  Gateway   unavailable  " },
-    });
-
-    expect(container.querySelector(".chat-error details")).toBeNull();
-    expect(container.querySelector(".chat-error strong")?.textContent).toBe("Gateway unavailable");
-  });
+  it.each(["run", "request"])(
+    "does not offer redundant details for a short %s error",
+    async (source) => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      vi.stubGlobal("navigator", { clipboard: { writeText } });
+      const message = "Failed to open the plugin state database.";
+      for (const diagnostic of [
+        message,
+        ` \n ${message.replaceAll(" ", "  \t")} \n `,
+        `${message}\n${message}`,
+        `${message}\n  ${message.replaceAll(" ", "  \t")} \n `,
+      ]) {
+        const container = renderChatView(
+          source === "run" ? { runError: { summary: diagnostic } } : { error: diagnostic },
+        );
+        const alert = requireElement(container, ".chat-error", "chat error");
+        expect(alert.getAttribute("role")).toBe("alert");
+        expect(alert.querySelector("strong")?.textContent?.replace(/\s+/gu, " ").trim()).toBe(
+          message,
+        );
+        expect(alert.querySelector("details")).toBeNull();
+        expect(alert.textContent).not.toContain("Error details");
+        alert.querySelector<HTMLButtonElement>('[aria-label="Copy error"]')?.click();
+        await Promise.resolve();
+        expect(writeText).toHaveBeenLastCalledWith(diagnostic);
+      }
+    },
+  );
 
   it("keeps Check delivery reachable when exact history deduplicates the retained bubble", () => {
     vi.mocked(chatThread.buildCachedChatItems).mockRestore();
@@ -1066,33 +1073,40 @@ describe("chat run error", () => {
     },
   );
 
-  it.each(["run", "request"])(
-    "exposes the complete %s error as selectable text and a copy action",
-    (source) => {
-      const diagnostic =
-        "Error: gateway disconnected\n<img src=x onerror=alert(1)>\nFinal diagnostic line";
-      const container = renderChatView(
-        source === "run" ? { runError: { summary: diagnostic } } : { error: diagnostic },
-      );
+  it.each([
+    ["run", "Error: gateway disconnected\n<img src=x onerror=alert(1)>\nFinal diagnostic line"],
+    ["request", "Error: gateway disconnected\n<img src=x onerror=alert(1)>\nFinal diagnostic line"],
+    ["run", `Request failed: ${"Long diagnostic text. ".repeat(20)}Final diagnostic line`],
+    ["request", `Request failed: ${"Long diagnostic text. ".repeat(20)}Final diagnostic line`],
+  ])("exposes the complete %s error as selectable text and a copy action", (source, diagnostic) => {
+    const container = renderChatView(
+      source === "run" ? { runError: { summary: diagnostic } } : { error: diagnostic },
+    );
 
-      const alert = requireElement(container, ".chat-error", "chat run error");
-      expect(alert.getAttribute("role")).toBe("alert");
-      const details = requireElement(alert, "details", "error disclosure");
-      expect(details.hasAttribute("open")).toBe(false);
-      expect(requireElement(details, "summary strong", "error summary").textContent).toBe(
-        "Error: gateway disconnected",
-      );
-      expect(requireElement(details, "pre", "full diagnostic").textContent).toBe(diagnostic);
-      expect(alert.querySelector("img")).toBeNull();
-      expect(alert.querySelector<HTMLButtonElement>('[aria-label="Copy error"]')).not.toBeNull();
-      expect(alert.querySelector<HTMLButtonElement>('[aria-label="Dismiss error"]') !== null).toBe(
-        source === "request",
-      );
-      expect(
-        alert.closest(source === "run" ? ".agent-chat__composer-overlay" : ".chat-topbar-notices"),
-      ).not.toBeNull();
-    },
-  );
+    const alert = requireElement(container, ".chat-error", "chat run error");
+    expect(alert.getAttribute("role")).toBe("alert");
+    const details = requireElement(alert, "details", "error disclosure");
+    expect(details.hasAttribute("open")).toBe(false);
+    const preview = requireElement(details, "strong", "error preview").textContent ?? "";
+    expect(preview).not.toContain("Final diagnostic line");
+    expect(preview.length).toBeLessThanOrEqual(120);
+    if (diagnostic.includes("\n")) {
+      expect(preview).toBe("Error: gateway disconnected");
+    } else {
+      expect(preview).toMatch(/^Request failed: .+…$/u);
+    }
+    const fullDiagnostic = requireElement(details, "pre", "full diagnostic");
+    expect(fullDiagnostic.textContent).toBe(diagnostic);
+    expect(fullDiagnostic.getAttribute("tabindex")).toBe("0");
+    expect(alert.querySelector("img")).toBeNull();
+    expect(alert.querySelector<HTMLButtonElement>('[aria-label="Copy error"]')).not.toBeNull();
+    expect(alert.querySelector<HTMLButtonElement>('[aria-label="Dismiss error"]') !== null).toBe(
+      source === "request",
+    );
+    expect(
+      alert.closest(source === "run" ? ".agent-chat__composer-overlay" : ".chat-topbar-notices"),
+    ).not.toBeNull();
+  });
 
   it("keeps dismiss on the error state owned by its callback", () => {
     const onDismissError = vi.fn();
@@ -1101,6 +1115,7 @@ describe("chat run error", () => {
     container.querySelector<HTMLButtonElement>('[aria-label="Dismiss error"]')?.click();
 
     expect(onDismissError).toHaveBeenCalledOnce();
+    expect(container.querySelector(".chat-error details")).toBeNull();
     expect(container.querySelector(".chat-error")?.closest(".chat-topbar-notices")).not.toBeNull();
   });
 

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -82,6 +82,7 @@ openclaw-chat-page {
   flex: 1;
   min-width: 0;
   overflow-wrap: anywhere;
+  user-select: text;
 }
 
 .chat-error:has(details[open]) {


### PR DESCRIPTION
Closes #133367

## What Problem This Solves

Fixes an issue where users opening **Error details** on a short Control UI chat error would see the visible headline repeated with no additional information. Plugin-state database failures also discarded recognized failure context from the public message, leaving operators with only a generic database-open error.

## Why This Change Was Made

The shared error-card owner now shows short messages once and offers the native disclosure only when the complete diagnostic adds information beyond a bounded first-line preview. It retains the contributor’s simple-error **Copy error** action and whitespace/repeated-line handling, while preserving expandable long single-line diagnostics, exact raw copying, text selection, and separate retry/dismiss actions across request, run, and startup errors.

The existing plugin-state error wrapper adds fixed recovery sentences only for its existing newer-schema and terminal-integrity classifications, covering both read-only and writable open paths. It does not expose raw causes, paths, SQL, or stored values. Unrecognized failures remain generic. No database schema, storage semantics, configuration, protocol, or dependency changes are included.

This keeps one canonical renderer and one existing error owner. Caller-specific filtering would duplicate the policy; flattening arbitrary nested causes would expose data that does not belong in public messages.

Thanks @vyctorbrzezowski for the initial fix and regression coverage; this PR preserves that contribution and completes its review follow-ups.

## User Impact

Short errors remain fully visible, selectable, and copyable without a redundant disclosure. Meaningful multiline details and long diagnostics still expand through the keyboard or pointer, retain their complete contents, and wrap on mobile. Recognized database schema/integrity failures now explain the failure class and recovery direction instead of hiding that context.

## Evidence

Candidate: `ce3c8d19429a54f811f141f041ee021a3c5096f4`.

**Regression proof:** the original draft’s IndexedDB-upgrade browser test reproduced the reported selector timeout. The same renderer passed after the assertion was changed to target the visible alert instead of disclosure-specific markup. Both related browser assertions now work independently of the card variant. Additional failing-before cases cover long single-line diagnostics and the safe database hints.

The combined candidate passed:

- **319 UI tests:** `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts ui/src/pages/chat/chat-view.test.ts ui/src/lib/format-error.test.ts`
- **42 database tests:** `node scripts/run-vitest.mjs src/plugin-state/plugin-state-store.test.ts src/plugin-state/plugin-state-store.errors.test.ts`
- **13 browser E2E tests:** `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-outbox-payloads.e2e.test.ts ui/src/e2e/chat-outbox-capacity.e2e.test.ts`
- **Complete changed-file gate:** `node scripts/check-changed.mjs -- docs/web/control-ui.md src/plugin-state/plugin-state-store.sqlite.ts src/plugin-state/plugin-state-store.test.ts src/plugin-state/plugin-state-store.errors.test.ts ui/src/pages/chat/chat-view-notices.ts ui/src/pages/chat/chat-view.test.ts ui/src/styles/chat/layout.css ui/src/e2e/chat-outbox-payloads.e2e.test.ts ui/src/e2e/chat-outbox-capacity.e2e.test.ts`
- Formatting, `git diff --check`, and native review guard.
- Fresh independent review: no actionable P0 findings at the configured review threshold.

The first aggregate gate caught a test typing issue; it was corrected and the complete gate rerun successfully. No baseline, budget, assertion, or validation gate was weakened.

**Visual proof:** attached captures were inspected and contain only synthetic data. A real browser running the Control UI against the mocked Gateway verified short-error disclosure absence and exact copying, text selection, multiline keyboard expansion/copying, long single-line preservation, and desktop/mobile rendering. The repository E2E lane also exercises the production UI bundle and native IndexedDB. The private live session was not accessed because the authenticated local Chrome relay was unavailable; these tests do not identify the original live database failure.

**ClawSweeper follow-through:** the template-dependent IndexedDB assertion is repaired, its capacity-evidence sibling is aligned, and both requested focused unit/browser lanes passed. Both Rank-up moves are addressed.

**Size:** production +38/-10 (net +28), tests +173/-103 (net +70), docs +1/-1. Growth supplies conditional bounded presentation, fixed safe diagnostics, and selectable text; no new production module or parallel path. Test counts include relocating two existing database boundary cases without increasing the file-size allowance.

Control UI behavior documentation: https://docs.openclaw.ai/web/control-ui#chat-behavior

## Final-head CI and follow-through

[CI run 33326424865](https://github.com/openclaw/openclaw/actions/runs/33326424865) passed on `ce3c8d19429a54f811f141f041ee021a3c5096f4`, including the required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33326424865/job/99299092865). The final-head ClawSweeper review found no actionable defect.

The first CI run exposed four additional disclosure-specific browser assertions. Their test-only correction passed all **25 additional browser tests**, bringing targeted browser proof to **38 tests across six modules**. Production files are unchanged from the approved build and visual proof. The additional commands were:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-header-session-outcomes.e2e.test.ts ui/src/e2e/chat-flow.queue-edit.e2e.test.ts ui/src/e2e/chat-reply-preview-recovery.e2e.test.ts ui/src/e2e/chat-flow.streaming.e2e.test.ts
```

```bash
node scripts/check-changed.mjs -- ui/src/e2e/chat-header-session-outcomes.e2e.test.ts ui/src/e2e/chat-flow.queue-edit.e2e.test.ts ui/src/e2e/chat-reply-preview-recovery.e2e.test.ts ui/src/e2e/chat-flow.streaming.e2e.test.ts
```

`pnpm build` also passed, including the production UI size checks. The stored-data detector note is a filename-based false positive: the SQLite-module change only adds imports and fixed public error text, not a schema, migration, storage, or recovery-operation change.

## Before and after

| Before | After |
| --- | --- |
| ![Before: redundant details](https://github.com/user-attachments/assets/8d4932c2-ce28-41d7-b717-a98f2010a73a) | ![After: short error with Copy](https://github.com/user-attachments/assets/9cc280e4-d24e-428c-ac22-cfea9a46137e) |

### Useful diagnostics remain available

![After: useful database details](https://github.com/user-attachments/assets/75835875-9e8a-4926-8ee3-1fcc60e0cf60)

### Mobile

![After: mobile details](https://github.com/user-attachments/assets/71f58d08-1e55-40c3-90b0-3641502ddf3b)
