### PR TITLE
feat(lobster): support structured workflow input

### DIFF
--- a/docs/tools/lobster.md
+++ b/docs/tools/lobster.md
@@ -76,10 +76,11 @@ OpenClaw runs Lobster workflows **in-process** using the bundled
 subprocess is spawned; the tool call returns a JSON envelope directly. If the
 pipeline halts for approval or input, the envelope carries a resume token so
 you can continue later. Approval requests may also carry a short approval ID.
-OpenClaw binds each ordinary-mode checkpoint to the exact session that created
-it. A token or approval ID cannot be resumed after `/new`, `/reset`, from
-another session, or again after the continuation starts executing. A response
-rejected by Lobster's pre-execution validation may be corrected and retried.
+OpenClaw binds each structured-input checkpoint to the exact session that
+created it for seven days. Its token cannot be resumed after `/new`, `/reset`,
+from another session, or again after the continuation starts executing. A
+response rejected by Lobster's pre-execution validation may be corrected and
+retried. Approval tokens and IDs retain Lobster's existing resume behavior.
 
 ## Enable
 
@@ -333,8 +334,8 @@ Run a workflow file with args:
 For approval gates, `resume` accepts either `token` or the short `approvalId`
 from `requiresApproval`, and `approve` is required. For structured input,
 provide the `token` from `requiresInput` and a `responseJson` value matching its
-schema. Supply exactly one of `approve` or `responseJson`, and resume from the
-same OpenClaw session that created the checkpoint.
+schema. Supply exactly one of `approve` or `responseJson`. Structured-input
+tokens must be resumed from the same OpenClaw session within seven days.
 
 ### Managed Task Flow mode
 
@@ -383,9 +384,9 @@ pointer to that state, not the full pipeline state.
 - **No secrets** - Lobster doesn't manage OAuth; it calls OpenClaw tools that
   do.
 - **Sandbox-aware** - disabled when the tool context is sandboxed.
-- **Session-bound resume** - ordinary approval and input credentials are stored
-  as redacted SQLite bindings and atomically claimed before Lobster resumes;
-  only pre-execution parse failures release the claim for correction.
+- **Session-bound input resume** - structured-input credentials are stored as
+  seven-day redacted SQLite bindings and atomically claimed before Lobster
+  resumes; only pre-execution parse failures release the claim for correction.
 - **Hardened** - timeouts and output caps enforced by the embedded runner.
 
 ## Troubleshooting

--- a/docs/tools/lobster.md
+++ b/docs/tools/lobster.md
@@ -1,13 +1,14 @@
 ---
-summary: "Typed workflow runtime for OpenClaw with resumable approval gates."
+summary: "Typed workflow runtime for OpenClaw with resumable approval and input gates."
 title: Lobster
 read_when:
   - You want deterministic multi-step workflows with explicit approvals
   - You need to resume a workflow without re-running earlier steps
+  - Your workflow needs a schema-validated operator response
 ---
 
 Lobster runs multi-step tool pipelines as one deterministic tool call, with
-explicit approval checkpoints and resume tokens. It sits one layer above
+explicit approval or structured-input checkpoints and resume tokens. It sits one layer above
 detached background work: for orchestrating flows across many detached tasks,
 see [Task Flow](/automation/taskflow) (`openclaw tasks flow`); for the task
 activity ledger, see [Background Tasks](/automation/tasks).
@@ -22,6 +23,8 @@ runtime:
   result for the whole pipeline.
 - **Approvals built in**: side effects (send, post, delete) halt the workflow
   until explicitly approved.
+- **Structured input built in**: an `ask` step can halt until the operator sends
+  a response matching its JSON Schema.
 - **Resumable**: a halted workflow returns a token; approve and resume without
   re-running earlier steps.
 
@@ -71,8 +74,8 @@ With Lobster, the same job is one call that halts for approval and resumes:
 OpenClaw runs Lobster workflows **in-process** using the bundled
 `@clawdbot/lobster` package as an embedded runner. No external `lobster`
 subprocess is spawned; the tool call returns a JSON envelope directly. If the
-pipeline halts for approval, the envelope carries a resume token (or a short
-approval ID) so you can continue later.
+pipeline halts for approval or input, the envelope carries a resume token so
+you can continue later. Approval requests may also carry a short approval ID.
 
 ## Enable
 
@@ -143,6 +146,19 @@ If the pipeline requests approval, resume with the token:
   "action": "resume",
   "token": "<resumeToken>",
   "approve": true
+}
+```
+
+If an `ask` step returns `status: "needs_input"`, present
+`requiresInput.prompt` and collect a response matching
+`requiresInput.responseSchema`. Resume with the same token and a JSON-encoded
+response:
+
+```json
+{
+  "action": "resume",
+  "token": "<resumeToken>",
+  "responseJson": "{\"decision\":\"approve\"}"
 }
 ```
 
@@ -310,9 +326,10 @@ Run a workflow file with args:
 }
 ```
 
-`resume` accepts either `token` (the full resume token from `requiresApproval`)
-or `approvalId` (the short id from the same object) - use whichever the halted
-run returned. `approve` is required.
+For approval gates, `resume` accepts either `token` or the short `approvalId`
+from `requiresApproval`, and `approve` is required. For structured input,
+provide the `token` from `requiresInput` and a `responseJson` value matching its
+schema. Supply exactly one of `approve` or `responseJson`.
 
 ### Managed Task Flow mode
 
@@ -324,14 +341,18 @@ Lobster envelope to it (`waiting` on approval, `succeeded`/`failed`/`cancelled` 
 completion), and returns `{ ok, envelope, flow, mutation }`. This mode requires
 a bound Task Flow runtime and is intended for plugin/controller code that needs
 durable flow state across gateway restarts, not typical ad hoc agent use.
+Managed Task Flow mode currently persists approval checkpoints only. Run
+structured-input workflows without the managed flow fields.
 
 ## Output envelope
 
-Lobster returns a JSON envelope with one of three statuses:
+Lobster returns a JSON envelope with one of four statuses:
 
 - `ok` - finished successfully
 - `needs_approval` - paused; `requiresApproval` carries a `resumeToken` and a
   short `approvalId`, either of which can resume the run
+- `needs_input` - paused; `requiresInput` carries the prompt, response schema,
+  optional subject/defaults, and a `resumeToken`
 - `cancelled` - explicitly denied or cancelled
 
 The tool surfaces the envelope in both `content` (pretty JSON) and `details`

--- a/docs/tools/lobster.md
+++ b/docs/tools/lobster.md
@@ -76,6 +76,10 @@ OpenClaw runs Lobster workflows **in-process** using the bundled
 subprocess is spawned; the tool call returns a JSON envelope directly. If the
 pipeline halts for approval or input, the envelope carries a resume token so
 you can continue later. Approval requests may also carry a short approval ID.
+OpenClaw binds each ordinary-mode checkpoint to the exact session that created
+it. A token or approval ID cannot be resumed after `/new`, `/reset`, from
+another session, or again after the continuation starts executing. A response
+rejected by Lobster's pre-execution validation may be corrected and retried.
 
 ## Enable
 
@@ -329,7 +333,8 @@ Run a workflow file with args:
 For approval gates, `resume` accepts either `token` or the short `approvalId`
 from `requiresApproval`, and `approve` is required. For structured input,
 provide the `token` from `requiresInput` and a `responseJson` value matching its
-schema. Supply exactly one of `approve` or `responseJson`.
+schema. Supply exactly one of `approve` or `responseJson`, and resume from the
+same OpenClaw session that created the checkpoint.
 
 ### Managed Task Flow mode
 
@@ -378,17 +383,22 @@ pointer to that state, not the full pipeline state.
 - **No secrets** - Lobster doesn't manage OAuth; it calls OpenClaw tools that
   do.
 - **Sandbox-aware** - disabled when the tool context is sandboxed.
+- **Session-bound resume** - ordinary approval and input credentials are stored
+  as redacted SQLite bindings and atomically claimed before Lobster resumes;
+  only pre-execution parse failures release the claim for correction.
 - **Hardened** - timeouts and output caps enforced by the embedded runner.
 
 ## Troubleshooting
 
-| Error                                                         | Cause / fix                                                                      |
-| ------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `lobster runtime timed out`                                   | Pipeline exceeded `timeoutMs`. Increase it or split the pipeline.                |
-| `lobster stdout exceeded maxStdoutBytes` (or `stderr`)        | Captured output exceeded the cap. Raise `maxStdoutBytes` or reduce output.       |
-| `lobster runtime result exceeded maxStdoutBytes`              | The JSON result exceeded the cap. Raise `maxStdoutBytes` or reduce output.       |
-| `run --args-json must be valid JSON`                          | `argsJson` (workflow-file runs) failed to parse. Fix the JSON string.            |
-| `lobster runtime failed` (or another `runtime_error` message) | The embedded runtime returned an error envelope. Check gateway logs for details. |
+| Error                                                           | Cause / fix                                                                      |
+| --------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `lobster runtime timed out`                                     | Pipeline exceeded `timeoutMs`. Increase it or split the pipeline.                |
+| `lobster stdout exceeded maxStdoutBytes` (or `stderr`)          | Captured output exceeded the cap. Raise `maxStdoutBytes` or reduce output.       |
+| `lobster runtime result exceeded maxStdoutBytes`                | The JSON result exceeded the cap. Raise `maxStdoutBytes` or reduce output.       |
+| `run --args-json must be valid JSON`                            | `argsJson` (workflow-file runs) failed to parse. Fix the JSON string.            |
+| `Lobster continuation belongs to another OpenClaw session`      | Resume from the session that created the checkpoint.                             |
+| `Lobster continuation is unavailable, expired, or already used` | The checkpoint was claimed or has no current binding. Run the workflow again.    |
+| `lobster runtime failed` (or another `runtime_error` message)   | The embedded runtime returned an error envelope. Check gateway logs for details. |
 
 ## Learn more
 

--- a/extensions/lobster/README.md
+++ b/extensions/lobster/README.md
@@ -79,8 +79,8 @@ Notes:
 
 - Runs Lobster in process via the published `@clawdbot/lobster/core` runtime.
 - Does not manage OAuth/tokens.
-- Binds resumable checkpoints to the creating OpenClaw session and atomically
-  claims each token or approval ID before continuing the workflow.
+- Binds structured-input checkpoints to the creating OpenClaw session for seven
+  days and atomically claims each token before continuing the workflow.
 - Uses timeouts, stdout caps, and strict JSON envelope parsing.
 
 ## Docs

--- a/extensions/lobster/README.md
+++ b/extensions/lobster/README.md
@@ -79,6 +79,8 @@ Notes:
 
 - Runs Lobster in process via the published `@clawdbot/lobster/core` runtime.
 - Does not manage OAuth/tokens.
+- Binds resumable checkpoints to the creating OpenClaw session and atomically
+  claims each token or approval ID before continuing the workflow.
 - Uses timeouts, stdout caps, and strict JSON envelope parsing.
 
 ## Docs

--- a/extensions/lobster/SKILL.md
+++ b/extensions/lobster/SKILL.md
@@ -1,6 +1,6 @@
 # Lobster
 
-Lobster executes multi-step workflows with approval checkpoints. Use it when:
+Lobster executes multi-step workflows with approval checkpoints and structured input requests. Use it when:
 
 - User wants a repeatable automation (triage, monitor, sync)
 - Actions need human approval before executing (send, post, delete)
@@ -65,6 +65,23 @@ Present the prompt to the user. If they approve:
 }
 ```
 
+### Handle structured input
+
+An `ask` step pauses with `status: "needs_input"`. Present `requiresInput.prompt`
+and use `requiresInput.responseSchema` to collect a valid JSON response. Resume
+with the returned token and `responseJson`, not `approve`:
+
+```json
+{
+  "action": "resume",
+  "token": "<resumeToken>",
+  "responseJson": "{\"decision\":\"approve\"}"
+}
+```
+
+Use ordinary Lobster mode for structured input. Managed Task Flow mode remains
+approval-only.
+
 ## Example workflows
 
 ### Email triage
@@ -87,7 +104,7 @@ Same as above, but halts for approval before returning.
 
 - **Deterministic**: Same input → same output (no LLM variance in pipeline execution)
 - **Approval gates**: `approve` command halts execution, returns token
-- **Resumable**: Use `resume` action with token to continue
+- **Resumable**: Use `resume` with `approve` for approval gates or `responseJson` for input requests
 - **Structured output**: Always returns JSON envelope with `protocolVersion`
 
 ## Don't use Lobster for

--- a/extensions/lobster/SKILL.md
+++ b/extensions/lobster/SKILL.md
@@ -65,9 +65,7 @@ Present the prompt to the user. If they approve:
 }
 ```
 
-Resume from the same OpenClaw session that produced the checkpoint. Tokens and
-approval IDs cannot be moved across sessions or reused after execution starts.
-A response rejected by pre-execution validation may be corrected and retried.
+Approval tokens and IDs retain Lobster's existing resume behavior.
 
 ### Handle structured input
 
@@ -84,7 +82,9 @@ with the returned token and `responseJson`, not `approve`:
 ```
 
 Use ordinary Lobster mode for structured input. Managed Task Flow mode remains
-approval-only.
+approval-only. Resume from the same OpenClaw session within seven days. Input
+tokens cannot be moved across sessions or reused after execution starts; a
+response rejected by pre-execution validation may be corrected and retried.
 
 ## Example workflows
 
@@ -109,7 +109,7 @@ Same as above, but halts for approval before returning.
 - **Deterministic**: Same input → same output (no LLM variance in pipeline execution)
 - **Approval gates**: `approve` command halts execution, returns token
 - **Resumable**: Use `resume` with `approve` for approval gates or `responseJson` for input requests
-- **Session-bound**: Resume credentials are valid only in the creating session and cannot replay execution
+- **Session-bound input**: Structured-input tokens are valid for seven days only in the creating session and cannot replay execution
 - **Structured output**: Always returns JSON envelope with `protocolVersion`
 
 ## Don't use Lobster for

--- a/extensions/lobster/SKILL.md
+++ b/extensions/lobster/SKILL.md
@@ -65,6 +65,10 @@ Present the prompt to the user. If they approve:
 }
 ```
 
+Resume from the same OpenClaw session that produced the checkpoint. Tokens and
+approval IDs cannot be moved across sessions or reused after execution starts.
+A response rejected by pre-execution validation may be corrected and retried.
+
 ### Handle structured input
 
 An `ask` step pauses with `status: "needs_input"`. Present `requiresInput.prompt`
@@ -105,6 +109,7 @@ Same as above, but halts for approval before returning.
 - **Deterministic**: Same input → same output (no LLM variance in pipeline execution)
 - **Approval gates**: `approve` command halts execution, returns token
 - **Resumable**: Use `resume` with `approve` for approval gates or `responseJson` for input requests
+- **Session-bound**: Resume credentials are valid only in the creating session and cannot replay execution
 - **Structured output**: Always returns JSON envelope with `protocolVersion`
 
 ## Don't use Lobster for

--- a/extensions/lobster/index.ts
+++ b/extensions/lobster/index.ts
@@ -7,7 +7,10 @@ import type {
   OpenClawPluginToolContext,
   OpenClawPluginToolFactory,
 } from "./runtime-api.js";
-import type { LobsterContinuationOwner } from "./src/lobster-continuations.js";
+import {
+  LOBSTER_CONTINUATION_TTL_MS,
+  type LobsterContinuationOwner,
+} from "./src/lobster-continuations.js";
 import { createLobsterTool } from "./src/lobster-tool.js";
 
 export default definePluginEntry({
@@ -21,6 +24,7 @@ export default definePluginEntry({
         namespace: "continuations",
         maxEntries: 10_000,
         overflowPolicy: "reject-new",
+        defaultTtlMs: LOBSTER_CONTINUATION_TTL_MS,
       }));
     api.registerTool(
       ((ctx: OpenClawPluginToolContext) => {
@@ -37,6 +41,12 @@ export default definePluginEntry({
                 sessionKey: ctx.sessionKey,
                 sessionId: ctx.sessionId,
                 openStore: openContinuationStore,
+                resolveCurrentSessionId: () =>
+                  api.runtime.agent.session.getSessionEntry({
+                    agentId: ctx.agentId,
+                    sessionKey: ctx.sessionKey!,
+                    readConsistency: "latest",
+                  })?.sessionId,
               }
             : undefined;
         return createLobsterTool(api, { taskFlow, continuationOwner }) as AnyAgentTool;

--- a/extensions/lobster/index.ts
+++ b/extensions/lobster/index.ts
@@ -1,6 +1,13 @@
 // Lobster plugin entrypoint registers its OpenClaw integration.
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
-import type { AnyAgentTool, OpenClawPluginApi, OpenClawPluginToolFactory } from "./runtime-api.js";
+import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import type {
+  AnyAgentTool,
+  OpenClawPluginApi,
+  OpenClawPluginToolContext,
+  OpenClawPluginToolFactory,
+} from "./runtime-api.js";
+import type { LobsterContinuationOwner } from "./src/lobster-continuations.js";
 import { createLobsterTool } from "./src/lobster-tool.js";
 
 export default definePluginEntry({
@@ -8,8 +15,15 @@ export default definePluginEntry({
   name: "Lobster",
   description: "Optional local shell helper tools",
   register(api: OpenClawPluginApi) {
+    let continuationStore: PluginStateSyncKeyedStore<unknown> | undefined;
+    const openContinuationStore = () =>
+      (continuationStore ??= api.runtime.state.openSyncKeyedStore<unknown>({
+        namespace: "continuations",
+        maxEntries: 10_000,
+        overflowPolicy: "reject-new",
+      }));
     api.registerTool(
-      ((ctx) => {
+      ((ctx: OpenClawPluginToolContext) => {
         if (ctx.sandboxed) {
           return null;
         }
@@ -17,7 +31,15 @@ export default definePluginEntry({
           api.runtime?.tasks.managedFlows && ctx.sessionKey
             ? api.runtime.tasks.managedFlows.fromToolContext(ctx)
             : undefined;
-        return createLobsterTool(api, { taskFlow }) as AnyAgentTool;
+        const continuationOwner: LobsterContinuationOwner | undefined =
+          ctx.sessionKey && ctx.sessionId
+            ? {
+                sessionKey: ctx.sessionKey,
+                sessionId: ctx.sessionId,
+                openStore: openContinuationStore,
+              }
+            : undefined;
+        return createLobsterTool(api, { taskFlow, continuationOwner }) as AnyAgentTool;
       }) as OpenClawPluginToolFactory,
       { optional: true },
     );

--- a/extensions/lobster/src/lobster-continuations.test.ts
+++ b/extensions/lobster/src/lobster-continuations.test.ts
@@ -232,6 +232,109 @@ describe("lobster structured-input continuations", () => {
     expect(runner.run).toHaveBeenCalledTimes(2);
   });
 
+  it("binds only one of two concurrent runs that return the same continuation token", async () => {
+    const store = createContinuationStore({ maxEntries: 2 });
+    let startedRuns = 0;
+    let releaseInitialRuns!: () => void;
+    const initialRunsReady = new Promise<void>((resolve) => {
+      releaseInitialRuns = resolve;
+    });
+    const runner = {
+      run: vi.fn(async () => {
+        startedRuns += 1;
+        if (startedRuns <= 2) {
+          if (startedRuns === 2) {
+            releaseInitialRuns();
+          }
+          await initialRunsReady;
+          return {
+            ok: true as const,
+            status: "needs_input" as const,
+            output: [],
+            requiresApproval: null,
+            requiresInput: {
+              type: "input_request" as const,
+              prompt: "Continue?",
+              responseSchema: { type: "boolean" },
+              resumeToken: "input-token-duplicate",
+            },
+          };
+        }
+        return {
+          ok: true as const,
+          status: "ok" as const,
+          output: ["resumed"],
+          requiresApproval: null,
+        };
+      }),
+    };
+    const tool = createLobsterTool(fakeApi(), {
+      runner,
+      continuationOwner: continuationOwner(store),
+    });
+
+    const initialResults = await Promise.allSettled([
+      tool.execute("call-duplicate-run-a", { action: "run", pipeline: "ask a" }),
+      tool.execute("call-duplicate-run-b", { action: "run", pipeline: "ask b" }),
+    ]);
+    expect(initialResults.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    const rejected = initialResults.find((result) => result.status === "rejected");
+    expect(rejected).toMatchObject({
+      status: "rejected",
+      reason: expect.objectContaining({
+        message: "Lobster runtime returned a duplicate continuation credential",
+      }),
+    });
+    expect(store.size()).toBe(1);
+
+    await expect(
+      tool.execute("call-duplicate-resume", {
+        action: "resume",
+        token: "input-token-duplicate",
+        responseJson: "true",
+      }),
+    ).resolves.toBeDefined();
+    await expect(
+      tool.execute("call-duplicate-replay", {
+        action: "resume",
+        token: "input-token-duplicate",
+        responseJson: "true",
+      }),
+    ).rejects.toThrow(/unavailable, expired, or already used/);
+    expect(runner.run).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects an initial run before Lobster executes when the continuation store is full", async () => {
+    const store = createContinuationStore({ maxEntries: 10_000 });
+    for (let index = 0; index < 10_000; index += 1) {
+      store.register(`filler:${index}`, { kind: "filler" });
+    }
+    const runner = {
+      run: vi.fn().mockResolvedValue({
+        ok: true,
+        status: "needs_input",
+        output: [],
+        requiresApproval: null,
+        requiresInput: {
+          type: "input_request",
+          prompt: "Continue?",
+          responseSchema: { type: "boolean" },
+          resumeToken: "input-token-full-store",
+        },
+      }),
+    };
+    const tool = createLobsterTool(fakeApi(), {
+      runner,
+      continuationOwner: continuationOwner(store),
+    });
+
+    await expect(
+      tool.execute("call-input-full-store-run", { action: "run", pipeline: "ask" }),
+    ).rejects.toThrow(/continuation store reached its 10000-row limit/);
+    expect(runner.run).not.toHaveBeenCalled();
+    expect(store.size()).toBe(10_000);
+  });
+
   it("resumes a valid structured-input continuation when the 10,000-row store is full", async () => {
     const store = createContinuationStore({ maxEntries: 10_000 });
     for (let index = 0; index < 9_999; index += 1) {
@@ -334,6 +437,42 @@ describe("lobster structured-input continuations", () => {
         responseJson: "true",
       }),
     ).resolves.toBeDefined();
+    expect(store.size()).toBe(0);
+  });
+
+  it("releases initial reservations for non-input results and errors", async () => {
+    const store = createContinuationStore({ maxEntries: 1 });
+    const runner = {
+      run: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "ok",
+          output: ["done"],
+          requiresApproval: null,
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          error: { type: "runtime_error", message: "runtime failed" },
+        })
+        .mockRejectedValueOnce(new Error("runner failed")),
+    };
+    const tool = createLobsterTool(fakeApi(), {
+      runner,
+      continuationOwner: continuationOwner(store),
+    });
+
+    await expect(
+      tool.execute("call-reservation-success", { action: "run", pipeline: "echo ok" }),
+    ).resolves.toBeDefined();
+    expect(store.size()).toBe(0);
+    await expect(
+      tool.execute("call-reservation-envelope-error", { action: "run", pipeline: "fail" }),
+    ).rejects.toThrow("runtime failed");
+    expect(store.size()).toBe(0);
+    await expect(
+      tool.execute("call-reservation-thrown-error", { action: "run", pipeline: "throw" }),
+    ).rejects.toThrow("runner failed");
     expect(store.size()).toBe(0);
   });
 

--- a/extensions/lobster/src/lobster-continuations.test.ts
+++ b/extensions/lobster/src/lobster-continuations.test.ts
@@ -1,0 +1,451 @@
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawPluginApi } from "../runtime-api.js";
+import {
+  LOBSTER_CONTINUATION_TTL_MS,
+  type LobsterContinuationOwner,
+} from "./lobster-continuations.js";
+import { createEmbeddedLobsterRunner, LobsterRunnerError } from "./lobster-runner.js";
+import { createLobsterTool } from "./lobster-tool.js";
+
+function fakeApi(): OpenClawPluginApi {
+  return createTestPluginApi({
+    id: "lobster",
+    name: "lobster",
+    source: "test",
+    runtime: { version: "test" } as OpenClawPluginApi["runtime"],
+    resolvePath: (path) => path,
+  });
+}
+
+const requireRecord = createRequireRecord("record", "expected-label-record");
+
+function createContinuationStore() {
+  let nowMs = 0;
+  const values = new Map<string, { value: unknown; expiresAt?: number }>();
+  const read = (key: string) => {
+    const record = values.get(key);
+    if (record?.expiresAt !== undefined && record.expiresAt <= nowMs) {
+      values.delete(key);
+      return undefined;
+    }
+    return record?.value;
+  };
+  const write = (key: string, value: unknown, opts?: { ttlMs?: number }) => {
+    values.set(key, {
+      value,
+      ...(opts?.ttlMs !== undefined ? { expiresAt: nowMs + opts.ttlMs } : {}),
+    });
+  };
+  return {
+    register: (key: string, value: unknown, opts?: { ttlMs?: number }) => {
+      write(key, value, opts);
+    },
+    registerIfAbsent: (key: string, value: unknown, opts?: { ttlMs?: number }) => {
+      if (read(key) !== undefined) {
+        return false;
+      }
+      write(key, value, opts);
+      return true;
+    },
+    lookup: read,
+    update: (
+      key: string,
+      updateValue: (current: unknown) => unknown,
+      opts?: { ttlMs?: number },
+    ) => {
+      const next = updateValue(read(key));
+      if (next === undefined) {
+        return false;
+      }
+      write(key, next, opts);
+      return true;
+    },
+    consume: (key: string) => {
+      const value = read(key);
+      values.delete(key);
+      return value;
+    },
+    delete: (key: string) => values.delete(key),
+    deleteIf: (key: string, predicate: (current: unknown) => boolean) => {
+      const current = read(key);
+      return current !== undefined && predicate(current) ? values.delete(key) : false;
+    },
+    entries: () =>
+      [...values.keys()].flatMap((key) => {
+        const value = read(key);
+        const record = values.get(key);
+        return value === undefined || !record
+          ? []
+          : [
+              {
+                key,
+                value,
+                createdAt: 0,
+                ...(record.expiresAt !== undefined ? { expiresAt: record.expiresAt } : {}),
+              },
+            ];
+      }),
+    clear: () => values.clear(),
+    advanceBy: (durationMs: number) => {
+      nowMs += durationMs;
+    },
+  };
+}
+
+function continuationOwner(
+  store = createContinuationStore(),
+  sessionId = "session-a",
+  resolveCurrentSessionId: () => string | undefined = () => sessionId,
+): LobsterContinuationOwner {
+  return {
+    sessionKey: "agent:main:main",
+    sessionId,
+    openStore: () => store,
+    resolveCurrentSessionId,
+  };
+}
+
+describe("lobster structured-input continuations", () => {
+  it("returns structured input requests and parses their resume response", async () => {
+    const runner = {
+      run: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "needs_input",
+          output: [],
+          requiresApproval: null,
+          requiresInput: {
+            type: "input_request",
+            prompt: "Choose a destination",
+            responseSchema: {
+              type: "object",
+              properties: { destination: { type: "string" } },
+              required: ["destination"],
+            },
+            resumeToken: "input-token-1",
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "ok",
+          output: [{ destination: "archive" }],
+          requiresApproval: null,
+        }),
+    };
+    const tool = createLobsterTool(fakeApi(), { runner, continuationOwner: continuationOwner() });
+
+    const first = await tool.execute("call-input-run", {
+      action: "run",
+      pipeline: "ask --prompt 'Choose a destination'",
+    });
+    const firstDetails = requireRecord(first.details, "input request details");
+    expect(firstDetails.status).toBe("needs_input");
+    expect(requireRecord(firstDetails.requiresInput, "input request")).toMatchObject({
+      prompt: "Choose a destination",
+      resumeToken: "input-token-1",
+    });
+
+    const resumed = await tool.execute("call-input-resume", {
+      action: "resume",
+      token: "input-token-1",
+      responseJson: '{"destination":"archive"}',
+    });
+    expect(runner.run).toHaveBeenLastCalledWith(
+      {
+        action: "resume",
+        token: "input-token-1",
+        response: { destination: "archive" },
+        cwd: process.cwd(),
+        timeoutMs: 20_000,
+        maxStdoutBytes: 512_000,
+      },
+      { beforeResumeIo: expect.any(Function) },
+    );
+    expect(requireRecord(resumed.details, "input resume details").output).toEqual([
+      { destination: "archive" },
+    ]);
+    await expect(
+      tool.execute("call-input-replay", {
+        action: "resume",
+        token: "input-token-1",
+        responseJson: '{"destination":"archive"}',
+      }),
+    ).rejects.toThrow(/unavailable, expired, or already used/);
+    expect(runner.run).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows only one concurrent structured-input resume to claim a token", async () => {
+    const runner = {
+      run: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "needs_input",
+          output: [],
+          requiresApproval: null,
+          requiresInput: {
+            type: "input_request",
+            prompt: "Continue?",
+            responseSchema: { type: "boolean" },
+            resumeToken: "input-token-shared-claim",
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "ok",
+          output: ["approved"],
+          requiresApproval: null,
+        }),
+    };
+    const tool = createLobsterTool(fakeApi(), {
+      runner,
+      continuationOwner: continuationOwner(),
+    });
+    await tool.execute("call-input-run", { action: "run", pipeline: "ask" });
+
+    const firstResume = tool.execute("call-input-first-resume", {
+      action: "resume",
+      token: "input-token-shared-claim",
+      responseJson: "true",
+    });
+    await expect(
+      tool.execute("call-input-concurrent-resume", {
+        action: "resume",
+        token: "input-token-shared-claim",
+        responseJson: "true",
+      }),
+    ).rejects.toThrow(/unavailable, expired, or already used/);
+    await expect(firstResume).resolves.toBeDefined();
+    expect(runner.run).toHaveBeenCalledTimes(2);
+  });
+
+  it("expires an abandoned structured-input continuation", async () => {
+    const runner = {
+      run: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "needs_input",
+          output: [],
+          requiresApproval: null,
+          requiresInput: {
+            type: "input_request",
+            prompt: "Continue?",
+            responseSchema: { type: "boolean" },
+            resumeToken: "input-token-expiring",
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "ok",
+          output: ["unexpected"],
+          requiresApproval: null,
+        }),
+    };
+    const store = createContinuationStore();
+    const tool = createLobsterTool(fakeApi(), {
+      runner,
+      continuationOwner: continuationOwner(store),
+    });
+    await tool.execute("call-input-expiring-run", { action: "run", pipeline: "ask" });
+
+    store.advanceBy(LOBSTER_CONTINUATION_TTL_MS);
+    await expect(
+      tool.execute("call-input-expired-resume", {
+        action: "resume",
+        token: "input-token-expiring",
+        responseJson: "true",
+      }),
+    ).rejects.toThrow(/unavailable, expired, or already used/);
+    expect(runner.run).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases a structured-input claim when Lobster rejects the response before execution", async () => {
+    const runner = {
+      run: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "needs_input",
+          output: [],
+          requiresApproval: null,
+          requiresInput: {
+            type: "input_request",
+            prompt: "Choose a destination",
+            responseSchema: { enum: ["archive"] },
+            resumeToken: "input-token-retry",
+          },
+        })
+        .mockRejectedValueOnce(
+          new LobsterRunnerError("response failed schema validation", "parse_error"),
+        )
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "ok",
+          output: ["archive"],
+          requiresApproval: null,
+        }),
+    };
+    const tool = createLobsterTool(fakeApi(), {
+      runner,
+      continuationOwner: continuationOwner(),
+    });
+    await tool.execute("call-input-retry-run", { action: "run", pipeline: "ask" });
+
+    await expect(
+      tool.execute("call-input-invalid-response", {
+        action: "resume",
+        token: "input-token-retry",
+        responseJson: '"inbox"',
+      }),
+    ).rejects.toThrow(/response failed schema validation/);
+    await expect(
+      tool.execute("call-input-valid-response", {
+        action: "resume",
+        token: "input-token-retry",
+        responseJson: '"archive"',
+      }),
+    ).resolves.toBeDefined();
+    expect(runner.run).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects a copied structured-input token before a foreign session reaches the runner", async () => {
+    const runner = {
+      run: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "needs_input",
+          output: [],
+          requiresApproval: null,
+          requiresInput: {
+            type: "input_request",
+            prompt: "Choose a destination",
+            responseSchema: { type: "string" },
+            resumeToken: "input-token-foreign-control",
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "ok",
+          output: ["unexpected"],
+          requiresApproval: null,
+        }),
+    };
+    const store = createContinuationStore();
+    const creatingTool = createLobsterTool(fakeApi(), {
+      runner,
+      continuationOwner: continuationOwner(store, "session-a"),
+    });
+    await creatingTool.execute("call-input-run", {
+      action: "run",
+      pipeline: "ask --prompt 'Choose a destination'",
+    });
+
+    const foreignTool = createLobsterTool(fakeApi(), {
+      runner,
+      continuationOwner: continuationOwner(store, "session-b"),
+    });
+    await expect(
+      foreignTool.execute("call-input-foreign-resume", {
+        action: "resume",
+        token: "input-token-foreign-control",
+        responseJson: '"archive"',
+      }),
+    ).rejects.toThrow(/continuation belongs to another OpenClaw session/);
+    expect(runner.run).toHaveBeenCalledTimes(1);
+  });
+
+  it("revalidates the session after claim and before embedded resume I/O", async () => {
+    const store = createContinuationStore();
+    let currentSessionId = "session-a";
+    const owner = continuationOwner(store, "session-a", () => currentSessionId);
+    const checkpointRunner = {
+      run: vi.fn().mockResolvedValue({
+        ok: true,
+        status: "needs_input",
+        output: [],
+        requiresApproval: null,
+        requiresInput: {
+          type: "input_request",
+          prompt: "Continue?",
+          responseSchema: { type: "boolean" },
+          resumeToken: "input-token-rebound",
+        },
+      }),
+    };
+    await createLobsterTool(fakeApi(), {
+      runner: checkpointRunner,
+      continuationOwner: owner,
+    }).execute("call-input-rebind-run", { action: "run", pipeline: "ask" });
+
+    const runtime = {
+      runToolRequest: vi.fn(),
+      resumeToolRequest: vi.fn().mockResolvedValue({
+        ok: true,
+        status: "ok",
+        output: ["unexpected"],
+        requiresApproval: null,
+      }),
+    };
+    let resolveRuntime!: (value: typeof runtime) => void;
+    const runtimePromise = new Promise<typeof runtime>((resolve) => {
+      resolveRuntime = resolve;
+    });
+    const loadRuntime = vi.fn(() => runtimePromise);
+    const resumeTool = createLobsterTool(fakeApi(), {
+      runner: createEmbeddedLobsterRunner({ loadRuntime }),
+      continuationOwner: owner,
+    });
+    const resumed = resumeTool.execute("call-input-rebind-resume", {
+      action: "resume",
+      token: "input-token-rebound",
+      responseJson: "true",
+    });
+    expect(loadRuntime).toHaveBeenCalledOnce();
+
+    currentSessionId = "session-b";
+    resolveRuntime(runtime);
+    await expect(resumed).rejects.toThrow(/session is no longer active/);
+    expect(runtime.resumeToolRequest).not.toHaveBeenCalled();
+  });
+
+  it("does not return an unbound continuation from one-shot contexts", async () => {
+    const runner = {
+      run: vi.fn().mockResolvedValue({
+        ok: true,
+        status: "needs_input",
+        output: [],
+        requiresApproval: null,
+        requiresInput: {
+          type: "input_request",
+          prompt: "Choose a destination",
+          responseSchema: { type: "string" },
+          resumeToken: "unbound-input-token",
+        },
+      }),
+    };
+    const tool = createLobsterTool(fakeApi(), { runner });
+
+    await expect(
+      tool.execute("call-unbound-input-run", { action: "run", pipeline: "ask" }),
+    ).rejects.toThrow(/requires a bound OpenClaw session/);
+  });
+
+  it("rejects an unbound structured-input resume before the runner", async () => {
+    const runner = { run: vi.fn() };
+    const tool = createLobsterTool(fakeApi(), { runner });
+
+    await expect(
+      tool.execute("call-unbound-input-resume", {
+        action: "resume",
+        token: "input-token-unbound",
+        responseJson: "true",
+      }),
+    ).rejects.toThrow(/unavailable, expired, or already used/);
+    expect(runner.run).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/lobster/src/lobster-continuations.test.ts
+++ b/extensions/lobster/src/lobster-continuations.test.ts
@@ -26,7 +26,7 @@ function fakeApi(): OpenClawPluginApi {
 const requireRecord = createRequireRecord("record", "expected-label-record");
 
 function createContinuationStore(options: { maxEntries?: number } = {}) {
-  let nowMs = 0;
+  let nowMs = Date.now();
   const maxEntries = options.maxEntries ?? Number.POSITIVE_INFINITY;
   const values = new Map<string, { value: unknown; expiresAt?: number }>();
   const read = (key: string) => {
@@ -96,6 +96,7 @@ function createContinuationStore(options: { maxEntries?: number } = {}) {
             ];
       }),
     size: () => values.size,
+    now: () => nowMs,
     clear: () => values.clear(),
     advanceBy: (durationMs: number) => {
       nowMs += durationMs;
@@ -458,6 +459,64 @@ describe("lobster structured-input continuations", () => {
       }),
     ).resolves.toBeDefined();
     expect(runner.run).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not extend the original deadline after an invalid response", async () => {
+    const store = createContinuationStore();
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => store.now());
+    const runner = {
+      run: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "needs_input",
+          output: [],
+          requiresApproval: null,
+          requiresInput: {
+            type: "input_request",
+            prompt: "Choose a destination",
+            responseSchema: { enum: ["archive"] },
+            resumeToken: "input-token-fixed-deadline",
+          },
+        })
+        .mockRejectedValueOnce(
+          new LobsterRunnerError("response failed schema validation", "parse_error"),
+        )
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "ok",
+          output: ["unexpected"],
+          requiresApproval: null,
+        }),
+    };
+    const tool = createLobsterTool(fakeApi(), {
+      runner,
+      continuationOwner: continuationOwner(store),
+    });
+
+    try {
+      await tool.execute("call-input-fixed-deadline-run", { action: "run", pipeline: "ask" });
+      store.advanceBy(LOBSTER_CONTINUATION_TTL_MS - 1);
+      await expect(
+        tool.execute("call-input-fixed-deadline-invalid", {
+          action: "resume",
+          token: "input-token-fixed-deadline",
+          responseJson: '"inbox"',
+        }),
+      ).rejects.toThrow(/response failed schema validation/);
+
+      store.advanceBy(1);
+      await expect(
+        tool.execute("call-input-fixed-deadline-expired", {
+          action: "resume",
+          token: "input-token-fixed-deadline",
+          responseJson: '"archive"',
+        }),
+      ).rejects.toThrow(/unavailable, expired, or already used/);
+      expect(runner.run).toHaveBeenCalledTimes(2);
+    } finally {
+      dateNow.mockRestore();
+    }
   });
 
   it("rejects a copied structured-input token before a foreign session reaches the runner", async () => {

--- a/extensions/lobster/src/lobster-continuations.test.ts
+++ b/extensions/lobster/src/lobster-continuations.test.ts
@@ -3,7 +3,11 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import {
+  assertLobsterContinuationClaimCurrent,
+  claimLobsterContinuation,
   LOBSTER_CONTINUATION_TTL_MS,
+  releaseLobsterContinuation,
+  retireLobsterContinuation,
   type LobsterContinuationOwner,
 } from "./lobster-continuations.js";
 import { createEmbeddedLobsterRunner, LobsterRunnerError } from "./lobster-runner.js";
@@ -21,8 +25,9 @@ function fakeApi(): OpenClawPluginApi {
 
 const requireRecord = createRequireRecord("record", "expected-label-record");
 
-function createContinuationStore() {
+function createContinuationStore(options: { maxEntries?: number } = {}) {
   let nowMs = 0;
+  const maxEntries = options.maxEntries ?? Number.POSITIVE_INFINITY;
   const values = new Map<string, { value: unknown; expiresAt?: number }>();
   const read = (key: string) => {
     const record = values.get(key);
@@ -33,6 +38,9 @@ function createContinuationStore() {
     return record?.value;
   };
   const write = (key: string, value: unknown, opts?: { ttlMs?: number }) => {
+    if (!values.has(key) && values.size >= maxEntries) {
+      throw new Error(`continuation store reached its ${maxEntries}-row limit`);
+    }
     values.set(key, {
       value,
       ...(opts?.ttlMs !== undefined ? { expiresAt: nowMs + opts.ttlMs } : {}),
@@ -87,6 +95,7 @@ function createContinuationStore() {
               },
             ];
       }),
+    size: () => values.size,
     clear: () => values.clear(),
     advanceBy: (durationMs: number) => {
       nowMs += durationMs;
@@ -220,6 +229,145 @@ describe("lobster structured-input continuations", () => {
     ).rejects.toThrow(/unavailable, expired, or already used/);
     await expect(firstResume).resolves.toBeDefined();
     expect(runner.run).toHaveBeenCalledTimes(2);
+  });
+
+  it("resumes a valid structured-input continuation when the 10,000-row store is full", async () => {
+    const store = createContinuationStore({ maxEntries: 10_000 });
+    for (let index = 0; index < 9_999; index += 1) {
+      store.register(`filler:${index}`, { kind: "filler" });
+    }
+    const runner = {
+      run: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "needs_input",
+          output: [],
+          requiresApproval: null,
+          requiresInput: {
+            type: "input_request",
+            prompt: "Continue?",
+            responseSchema: { type: "boolean" },
+            resumeToken: "input-token-at-capacity",
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "ok",
+          output: ["resumed"],
+          requiresApproval: null,
+        }),
+    };
+    const tool = createLobsterTool(fakeApi(), {
+      runner,
+      continuationOwner: continuationOwner(store),
+    });
+    await tool.execute("call-input-capacity-run", { action: "run", pipeline: "ask" });
+    expect(store.size()).toBe(10_000);
+
+    await expect(
+      tool.execute("call-input-capacity-resume", {
+        action: "resume",
+        token: "input-token-at-capacity",
+        responseJson: "true",
+      }),
+    ).resolves.toBeDefined();
+    expect(runner.run).toHaveBeenCalledTimes(2);
+    expect(store.size()).toBe(9_999);
+  });
+
+  it("hands off a full continuation slot when resume needs another input", async () => {
+    const store = createContinuationStore({ maxEntries: 1 });
+    const runner = {
+      run: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "needs_input",
+          output: [],
+          requiresApproval: null,
+          requiresInput: {
+            type: "input_request",
+            prompt: "First input",
+            responseSchema: { type: "boolean" },
+            resumeToken: "input-token-first",
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "needs_input",
+          output: [],
+          requiresApproval: null,
+          requiresInput: {
+            type: "input_request",
+            prompt: "Second input",
+            responseSchema: { type: "boolean" },
+            resumeToken: "input-token-second",
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "ok",
+          output: ["done"],
+          requiresApproval: null,
+        }),
+    };
+    const tool = createLobsterTool(fakeApi(), {
+      runner,
+      continuationOwner: continuationOwner(store),
+    });
+    await tool.execute("call-input-chain-run", { action: "run", pipeline: "ask" });
+
+    await expect(
+      tool.execute("call-input-chain-first-resume", {
+        action: "resume",
+        token: "input-token-first",
+        responseJson: "true",
+      }),
+    ).resolves.toBeDefined();
+    expect(store.size()).toBe(1);
+    await expect(
+      tool.execute("call-input-chain-second-resume", {
+        action: "resume",
+        token: "input-token-second",
+        responseJson: "true",
+      }),
+    ).resolves.toBeDefined();
+    expect(store.size()).toBe(0);
+  });
+
+  it("keeps stale claim handles from releasing or retiring a newer claim", async () => {
+    const store = createContinuationStore();
+    const owner = continuationOwner(store);
+    const tool = createLobsterTool(fakeApi(), {
+      runner: {
+        run: vi.fn().mockResolvedValue({
+          ok: true,
+          status: "needs_input",
+          output: [],
+          requiresApproval: null,
+          requiresInput: {
+            type: "input_request",
+            prompt: "Continue?",
+            responseSchema: { type: "boolean" },
+            resumeToken: "input-token-claim-generation",
+          },
+        }),
+      },
+      continuationOwner: owner,
+    });
+    await tool.execute("call-input-claim-generation-run", { action: "run", pipeline: "ask" });
+    const firstClaim = claimLobsterContinuation(owner, {
+      token: "input-token-claim-generation",
+    });
+    releaseLobsterContinuation(owner, firstClaim);
+    const secondClaim = claimLobsterContinuation(owner, {
+      token: "input-token-claim-generation",
+    });
+
+    releaseLobsterContinuation(owner, firstClaim);
+    retireLobsterContinuation(owner, firstClaim);
+    expect(() => assertLobsterContinuationClaimCurrent(owner, secondClaim)).not.toThrow();
   });
 
   it("expires an abandoned structured-input continuation", async () => {

--- a/extensions/lobster/src/lobster-continuations.ts
+++ b/extensions/lobster/src/lobster-continuations.ts
@@ -74,16 +74,17 @@ function envelopeCredentialKey(
 }
 
 function readContinuationRecord(value: unknown): ContinuationRecord | undefined {
+  const expiresAt = isRecord(value) ? value.expiresAt : undefined;
   if (
     !isRecord(value) ||
     typeof value.sessionKey !== "string" ||
     typeof value.sessionId !== "string" ||
-    !Number.isSafeInteger(value.expiresAt) ||
-    (value.expiresAt as number) <= 0
+    typeof expiresAt !== "number" ||
+    !Number.isSafeInteger(expiresAt) ||
+    expiresAt <= 0
   ) {
     return undefined;
   }
-  const expiresAt = value.expiresAt as number;
   if (value.kind === "binding" && typeof value.credentialKey === "string") {
     return {
       kind: "binding",

--- a/extensions/lobster/src/lobster-continuations.ts
+++ b/extensions/lobster/src/lobster-continuations.ts
@@ -4,15 +4,29 @@ import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { LobsterEnvelope, LobsterRunnerParams } from "./lobster-runner.js";
 
 type ContinuationRecord =
-  | { kind: "binding"; sessionKey: string; sessionId: string; expiresAt: number }
+  | {
+      kind: "reservation";
+      sessionKey: string;
+      sessionId: string;
+      expiresAt: number;
+      leaseId: string;
+    }
+  | {
+      kind: "binding";
+      sessionKey: string;
+      sessionId: string;
+      expiresAt: number;
+      credentialKey: string;
+    }
   | {
       kind: "claim";
       sessionKey: string;
       sessionId: string;
       expiresAt: number;
-      claimId: string;
+      credentialKey: string;
+      leaseId: string;
     };
-type ClaimRecord = Extract<ContinuationRecord, { kind: "claim" }>;
+type LeasedContinuationRecord = Extract<ContinuationRecord, { kind: "reservation" | "claim" }>;
 
 // Each checkpoint gets one fixed deadline so retries cannot keep abandoned
 // continuations alive and permanently exhaust plugin state.
@@ -26,10 +40,20 @@ export type LobsterContinuationOwner = {
 };
 
 export type LobsterContinuationClaim = {
-  credentialKey: string;
-  claimId: string;
+  kind: "claim";
+  slotKey: string;
+  leaseId: string;
   expiresAt: number;
 };
+
+export type LobsterContinuationReservation = {
+  kind: "reservation";
+  slotKey: string;
+  leaseId: string;
+  expiresAt: number;
+};
+
+type LobsterContinuationLease = LobsterContinuationClaim | LobsterContinuationReservation;
 
 function credentialKey(value: string): string {
   const digest = createHash("sha256").update("token\0").update(value.trim()).digest("hex");
@@ -60,21 +84,34 @@ function readContinuationRecord(value: unknown): ContinuationRecord | undefined 
     return undefined;
   }
   const expiresAt = value.expiresAt as number;
-  if (value.kind === "binding") {
+  if (value.kind === "binding" && typeof value.credentialKey === "string") {
     return {
       kind: "binding",
       sessionKey: value.sessionKey,
       sessionId: value.sessionId,
       expiresAt,
+      credentialKey: value.credentialKey,
     };
   }
-  return value.kind === "claim" && typeof value.claimId === "string"
+  if (value.kind === "reservation" && typeof value.leaseId === "string") {
+    return {
+      kind: "reservation",
+      sessionKey: value.sessionKey,
+      sessionId: value.sessionId,
+      expiresAt,
+      leaseId: value.leaseId,
+    };
+  }
+  return value.kind === "claim" &&
+    typeof value.credentialKey === "string" &&
+    typeof value.leaseId === "string"
     ? {
         kind: "claim",
         sessionKey: value.sessionKey,
         sessionId: value.sessionId,
         expiresAt,
-        claimId: value.claimId,
+        credentialKey: value.credentialKey,
+        leaseId: value.leaseId,
       }
     : undefined;
 }
@@ -84,27 +121,27 @@ function readActiveContinuationRecord(value: unknown): ContinuationRecord | unde
   return record && record.expiresAt > Date.now() ? record : undefined;
 }
 
-function isStoredOwnedClaim(
+function isStoredOwnedLease(
   value: unknown,
   owner: LobsterContinuationOwner,
-  claim: LobsterContinuationClaim,
-): value is ClaimRecord {
-  const binding = readContinuationRecord(value);
+  lease: LobsterContinuationLease,
+): value is LeasedContinuationRecord {
+  const record = readContinuationRecord(value);
   return (
-    binding?.kind === "claim" &&
-    binding.sessionKey === owner.sessionKey &&
-    binding.sessionId === owner.sessionId &&
-    binding.claimId === claim.claimId &&
-    binding.expiresAt === claim.expiresAt
+    record?.kind === lease.kind &&
+    record.sessionKey === owner.sessionKey &&
+    record.sessionId === owner.sessionId &&
+    record.leaseId === lease.leaseId &&
+    record.expiresAt === lease.expiresAt
   );
 }
 
-function isActiveOwnedClaim(
+function isActiveOwnedLease(
   value: unknown,
   owner: LobsterContinuationOwner,
-  claim: LobsterContinuationClaim,
-): value is ClaimRecord {
-  return isStoredOwnedClaim(value, owner, claim) && claim.expiresAt > Date.now();
+  lease: LobsterContinuationLease,
+): value is LeasedContinuationRecord {
+  return isStoredOwnedLease(value, owner, lease) && lease.expiresAt > Date.now();
 }
 
 function remainingTtlMs(expiresAt: number): number | undefined {
@@ -129,27 +166,76 @@ function assertCurrentSession(owner: LobsterContinuationOwner): void {
 export function bindLobsterContinuation(
   owner: LobsterContinuationOwner | undefined,
   envelope: Extract<LobsterEnvelope, { ok: true }>,
-): void {
+  lease: LobsterContinuationLease | undefined,
+): boolean {
   const key = envelopeCredentialKey(envelope);
   if (!key) {
-    return;
+    return false;
   }
-  if (!owner) {
+  if (!owner || !lease) {
     throw new Error(
       "Lobster continuation requires a bound OpenClaw session; rerun the workflow from a persistent session",
     );
   }
   assertCurrentSession(owner);
+  const store = owner.openStore();
+  // Plugin tool calls share one Gateway event loop and these store operations
+  // are synchronous, so duplicate detection plus the slot update cannot interleave.
+  const duplicate = store.entries().some((entry) => {
+    if (entry.key === lease.slotKey) {
+      return false;
+    }
+    const record = readActiveContinuationRecord(entry.value);
+    return record?.kind !== "reservation" && record?.credentialKey === key;
+  });
+  if (duplicate) {
+    throw new Error("Lobster runtime returned a duplicate continuation credential");
+  }
   const expiresAt = Date.now() + LOBSTER_CONTINUATION_TTL_MS;
   const binding: ContinuationRecord = {
     kind: "binding",
     sessionKey: owner.sessionKey,
     sessionId: owner.sessionId,
     expiresAt,
+    credentialKey: key,
   };
-  if (!owner.openStore().registerIfAbsent(key, binding, { ttlMs: LOBSTER_CONTINUATION_TTL_MS })) {
-    throw new Error("Lobster runtime returned a duplicate continuation credential");
+  if (
+    !store.update?.(
+      lease.slotKey,
+      (current) => (isActiveOwnedLease(current, owner, lease) ? binding : undefined),
+      { ttlMs: LOBSTER_CONTINUATION_TTL_MS },
+    )
+  ) {
+    throw unavailableError();
   }
+  return true;
+}
+
+export function reserveLobsterContinuation(
+  owner: LobsterContinuationOwner | undefined,
+): LobsterContinuationReservation | undefined {
+  if (!owner) {
+    return undefined;
+  }
+  assertCurrentSession(owner);
+  const leaseId = randomUUID();
+  const slotKey = `slot:${leaseId}`;
+  const expiresAt = Date.now() + LOBSTER_CONTINUATION_TTL_MS;
+  const reservation: ContinuationRecord = {
+    kind: "reservation",
+    sessionKey: owner.sessionKey,
+    sessionId: owner.sessionId,
+    expiresAt,
+    leaseId,
+  };
+  if (
+    !owner
+      .openStore()
+      .registerIfAbsent(slotKey, reservation, { ttlMs: LOBSTER_CONTINUATION_TTL_MS })
+  ) {
+    throw new Error("Lobster continuation slot reservation collided");
+  }
+  return { kind: "reservation", slotKey, leaseId, expiresAt };
 }
 
 export function claimLobsterContinuation(
@@ -165,25 +251,34 @@ export function claimLobsterContinuation(
   if (!key) {
     throw unavailableError();
   }
-  const initial = readActiveContinuationRecord(store.lookup(key));
+  const match = store.entries().find((entry) => {
+    const record = readActiveContinuationRecord(entry.value);
+    return record?.kind !== "reservation" && record?.credentialKey === key;
+  });
+  const initial = match ? readActiveContinuationRecord(match.value) : undefined;
   const ttlMs = initial ? remainingTtlMs(initial.expiresAt) : undefined;
-  if (!initial || ttlMs === undefined) {
+  if (!match || !initial || initial.kind === "reservation" || ttlMs === undefined) {
     throw unavailableError();
   }
-  const claimId = randomUUID();
+  const leaseId = randomUUID();
   let foreignOwner = false;
   const claimed = store.update?.(
-    key,
+    match.key,
     (current) => {
       const latest = readActiveContinuationRecord(current);
-      if (!latest || latest.expiresAt !== initial.expiresAt) {
+      if (
+        !latest ||
+        latest.kind === "reservation" ||
+        latest.credentialKey !== key ||
+        latest.expiresAt !== initial.expiresAt
+      ) {
         return undefined;
       }
       if (latest.sessionKey !== owner.sessionKey || latest.sessionId !== owner.sessionId) {
         foreignOwner = true;
         return undefined;
       }
-      return latest.kind === "binding" ? { ...latest, kind: "claim", claimId } : undefined;
+      return latest.kind === "binding" ? { ...latest, kind: "claim", leaseId } : undefined;
     },
     { ttlMs },
   );
@@ -195,7 +290,12 @@ export function claimLobsterContinuation(
     }
     throw unavailableError();
   }
-  return { credentialKey: key, claimId, expiresAt: initial.expiresAt };
+  return {
+    kind: "claim",
+    slotKey: match.key,
+    leaseId,
+    expiresAt: initial.expiresAt,
+  };
 }
 
 export function assertLobsterContinuationClaimCurrent(
@@ -203,18 +303,18 @@ export function assertLobsterContinuationClaimCurrent(
   claim: LobsterContinuationClaim,
 ): void {
   assertCurrentSession(owner);
-  if (!isActiveOwnedClaim(owner.openStore().lookup(claim.credentialKey), owner, claim)) {
+  if (!isActiveOwnedLease(owner.openStore().lookup(claim.slotKey), owner, claim)) {
     throw unavailableError();
   }
 }
 
 export function retireLobsterContinuation(
   owner: LobsterContinuationOwner,
-  claim: LobsterContinuationClaim,
+  lease: LobsterContinuationLease,
 ): void {
   owner
     .openStore()
-    .deleteIf?.(claim.credentialKey, (current) => isStoredOwnedClaim(current, owner, claim));
+    .deleteIf?.(lease.slotKey, (current) => isStoredOwnedLease(current, owner, lease));
 }
 
 export function releaseLobsterContinuation(
@@ -228,14 +328,15 @@ export function releaseLobsterContinuation(
     return;
   }
   store.update?.(
-    claim.credentialKey,
+    claim.slotKey,
     (current) =>
-      isActiveOwnedClaim(current, owner, claim)
+      isActiveOwnedLease(current, owner, claim) && current.kind === "claim"
         ? {
             kind: "binding",
             sessionKey: current.sessionKey,
             sessionId: current.sessionId,
             expiresAt: current.expiresAt,
+            credentialKey: current.credentialKey,
           }
         : undefined,
     { ttlMs },

--- a/extensions/lobster/src/lobster-continuations.ts
+++ b/extensions/lobster/src/lobster-continuations.ts
@@ -11,10 +11,15 @@ type Binding = {
   credentialKeys: string[];
 };
 
+// Structured-input replies are short-lived conversation continuations. Expiry
+// bounds abandoned bindings so they cannot permanently exhaust plugin state.
+export const LOBSTER_CONTINUATION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
 export type LobsterContinuationOwner = {
   sessionKey: string;
   sessionId: string;
   openStore: () => PluginStateSyncKeyedStore<unknown>;
+  resolveCurrentSessionId: () => string | undefined;
 };
 
 export type LobsterContinuationClaim = {
@@ -22,28 +27,20 @@ export type LobsterContinuationClaim = {
   credentialKeys: string[];
 };
 
-function credentialKey(kind: "token" | "approval", value: string): string {
-  const digest = createHash("sha256").update(kind).update("\0").update(value.trim()).digest("hex");
+function credentialKey(value: string): string {
+  const digest = createHash("sha256").update("token\0").update(value.trim()).digest("hex");
   return `credential:${digest}`;
 }
 
-function credentialKeys(params: Pick<LobsterRunnerParams, "token" | "approvalId">): string[] {
-  return [
-    ...(params.token?.trim() ? [credentialKey("token", params.token)] : []),
-    ...(params.approvalId?.trim() ? [credentialKey("approval", params.approvalId)] : []),
-  ];
+function credentialKeys(params: Pick<LobsterRunnerParams, "token">): string[] {
+  return params.token?.trim() ? [credentialKey(params.token)] : [];
 }
 
 function envelopeCredentialKeys(envelope: Extract<LobsterEnvelope, { ok: true }>): string[] {
   if (envelope.status === "needs_input" && envelope.requiresInput) {
-    return [credentialKey("token", envelope.requiresInput.resumeToken)];
+    return [credentialKey(envelope.requiresInput.resumeToken)];
   }
-  return envelope.status === "needs_approval" && envelope.requiresApproval
-    ? credentialKeys({
-        token: envelope.requiresApproval.resumeToken,
-        approvalId: envelope.requiresApproval.approvalId,
-      })
-    : [];
+  return [];
 }
 
 function readBinding(value: unknown): Binding | undefined {
@@ -86,6 +83,14 @@ function unavailableError(): Error {
   );
 }
 
+function assertCurrentSession(owner: LobsterContinuationOwner): void {
+  if (owner.resolveCurrentSessionId() !== owner.sessionId) {
+    throw new Error(
+      "Lobster continuation session is no longer active; rerun the workflow in the current session",
+    );
+  }
+}
+
 export function bindLobsterContinuation(
   owner: LobsterContinuationOwner | undefined,
   envelope: Extract<LobsterEnvelope, { ok: true }>,
@@ -99,6 +104,7 @@ export function bindLobsterContinuation(
       "Lobster continuation requires a bound OpenClaw session; rerun the workflow from a persistent session",
     );
   }
+  assertCurrentSession(owner);
   const claimKey = `claim:${keys[0]?.slice("credential:".length)}`;
   const binding: Binding = {
     kind: "binding",
@@ -111,7 +117,7 @@ export function bindLobsterContinuation(
   const registered: string[] = [];
   try {
     for (const key of keys) {
-      if (!store.registerIfAbsent(key, binding)) {
+      if (!store.registerIfAbsent(key, binding, { ttlMs: LOBSTER_CONTINUATION_TTL_MS })) {
         throw new Error("Lobster runtime returned a duplicate continuation credential");
       }
       registered.push(key);
@@ -126,11 +132,12 @@ export function bindLobsterContinuation(
 
 export function claimLobsterContinuation(
   owner: LobsterContinuationOwner | undefined,
-  params: Pick<LobsterRunnerParams, "token" | "approvalId">,
+  params: Pick<LobsterRunnerParams, "token">,
 ): LobsterContinuationClaim {
   if (!owner) {
     throw unavailableError();
   }
+  assertCurrentSession(owner);
   const store = owner.openStore();
   let binding: Binding | undefined;
   for (const key of credentialKeys(params)) {
@@ -150,15 +157,29 @@ export function claimLobsterContinuation(
   }
   if (
     !binding ||
-    !store.registerIfAbsent(binding.claimKey, {
-      kind: "claim",
-      sessionKey: owner.sessionKey,
-      sessionId: owner.sessionId,
-    })
+    !store.registerIfAbsent(
+      binding.claimKey,
+      {
+        kind: "claim",
+        sessionKey: owner.sessionKey,
+        sessionId: owner.sessionId,
+      },
+      { ttlMs: LOBSTER_CONTINUATION_TTL_MS },
+    )
   ) {
     throw unavailableError();
   }
   return { claimKey: binding.claimKey, credentialKeys: binding.credentialKeys };
+}
+
+export function assertLobsterContinuationClaimCurrent(
+  owner: LobsterContinuationOwner,
+  claim: LobsterContinuationClaim,
+): void {
+  assertCurrentSession(owner);
+  if (!isOwnedClaim(owner.openStore().lookup(claim.claimKey), owner)) {
+    throw unavailableError();
+  }
 }
 
 export function retireLobsterContinuation(

--- a/extensions/lobster/src/lobster-continuations.ts
+++ b/extensions/lobster/src/lobster-continuations.ts
@@ -4,12 +4,18 @@ import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { LobsterEnvelope, LobsterRunnerParams } from "./lobster-runner.js";
 
 type ContinuationRecord =
-  | { kind: "binding"; sessionKey: string; sessionId: string }
-  | { kind: "claim"; sessionKey: string; sessionId: string; claimId: string };
+  | { kind: "binding"; sessionKey: string; sessionId: string; expiresAt: number }
+  | {
+      kind: "claim";
+      sessionKey: string;
+      sessionId: string;
+      expiresAt: number;
+      claimId: string;
+    };
 type ClaimRecord = Extract<ContinuationRecord, { kind: "claim" }>;
 
-// Expiry after each valid state transition bounds abandoned continuations so
-// they cannot permanently exhaust plugin state.
+// Each checkpoint gets one fixed deadline so retries cannot keep abandoned
+// continuations alive and permanently exhaust plugin state.
 export const LOBSTER_CONTINUATION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 export type LobsterContinuationOwner = {
@@ -22,6 +28,7 @@ export type LobsterContinuationOwner = {
 export type LobsterContinuationClaim = {
   credentialKey: string;
   claimId: string;
+  expiresAt: number;
 };
 
 function credentialKey(value: string): string {
@@ -46,35 +53,63 @@ function readContinuationRecord(value: unknown): ContinuationRecord | undefined 
   if (
     !isRecord(value) ||
     typeof value.sessionKey !== "string" ||
-    typeof value.sessionId !== "string"
+    typeof value.sessionId !== "string" ||
+    !Number.isSafeInteger(value.expiresAt) ||
+    (value.expiresAt as number) <= 0
   ) {
     return undefined;
   }
+  const expiresAt = value.expiresAt as number;
   if (value.kind === "binding") {
-    return { kind: "binding", sessionKey: value.sessionKey, sessionId: value.sessionId };
+    return {
+      kind: "binding",
+      sessionKey: value.sessionKey,
+      sessionId: value.sessionId,
+      expiresAt,
+    };
   }
   return value.kind === "claim" && typeof value.claimId === "string"
     ? {
         kind: "claim",
         sessionKey: value.sessionKey,
         sessionId: value.sessionId,
+        expiresAt,
         claimId: value.claimId,
       }
     : undefined;
 }
 
-function isOwnedClaim(
+function readActiveContinuationRecord(value: unknown): ContinuationRecord | undefined {
+  const record = readContinuationRecord(value);
+  return record && record.expiresAt > Date.now() ? record : undefined;
+}
+
+function isStoredOwnedClaim(
   value: unknown,
   owner: LobsterContinuationOwner,
-  claimId: string,
+  claim: LobsterContinuationClaim,
 ): value is ClaimRecord {
   const binding = readContinuationRecord(value);
   return (
     binding?.kind === "claim" &&
     binding.sessionKey === owner.sessionKey &&
     binding.sessionId === owner.sessionId &&
-    binding.claimId === claimId
+    binding.claimId === claim.claimId &&
+    binding.expiresAt === claim.expiresAt
   );
+}
+
+function isActiveOwnedClaim(
+  value: unknown,
+  owner: LobsterContinuationOwner,
+  claim: LobsterContinuationClaim,
+): value is ClaimRecord {
+  return isStoredOwnedClaim(value, owner, claim) && claim.expiresAt > Date.now();
+}
+
+function remainingTtlMs(expiresAt: number): number | undefined {
+  const remaining = expiresAt - Date.now();
+  return remaining > 0 ? remaining : undefined;
 }
 
 function unavailableError(): Error {
@@ -105,10 +140,12 @@ export function bindLobsterContinuation(
     );
   }
   assertCurrentSession(owner);
+  const expiresAt = Date.now() + LOBSTER_CONTINUATION_TTL_MS;
   const binding: ContinuationRecord = {
     kind: "binding",
     sessionKey: owner.sessionKey,
     sessionId: owner.sessionId,
+    expiresAt,
   };
   if (!owner.openStore().registerIfAbsent(key, binding, { ttlMs: LOBSTER_CONTINUATION_TTL_MS })) {
     throw new Error("Lobster runtime returned a duplicate continuation credential");
@@ -128,13 +165,18 @@ export function claimLobsterContinuation(
   if (!key) {
     throw unavailableError();
   }
+  const initial = readActiveContinuationRecord(store.lookup(key));
+  const ttlMs = initial ? remainingTtlMs(initial.expiresAt) : undefined;
+  if (!initial || ttlMs === undefined) {
+    throw unavailableError();
+  }
   const claimId = randomUUID();
   let foreignOwner = false;
   const claimed = store.update?.(
     key,
     (current) => {
-      const latest = readContinuationRecord(current);
-      if (!latest) {
+      const latest = readActiveContinuationRecord(current);
+      if (!latest || latest.expiresAt !== initial.expiresAt) {
         return undefined;
       }
       if (latest.sessionKey !== owner.sessionKey || latest.sessionId !== owner.sessionId) {
@@ -143,7 +185,7 @@ export function claimLobsterContinuation(
       }
       return latest.kind === "binding" ? { ...latest, kind: "claim", claimId } : undefined;
     },
-    { ttlMs: LOBSTER_CONTINUATION_TTL_MS },
+    { ttlMs },
   );
   if (!claimed) {
     if (foreignOwner) {
@@ -153,7 +195,7 @@ export function claimLobsterContinuation(
     }
     throw unavailableError();
   }
-  return { credentialKey: key, claimId };
+  return { credentialKey: key, claimId, expiresAt: initial.expiresAt };
 }
 
 export function assertLobsterContinuationClaimCurrent(
@@ -161,7 +203,7 @@ export function assertLobsterContinuationClaimCurrent(
   claim: LobsterContinuationClaim,
 ): void {
   assertCurrentSession(owner);
-  if (!isOwnedClaim(owner.openStore().lookup(claim.credentialKey), owner, claim.claimId)) {
+  if (!isActiveOwnedClaim(owner.openStore().lookup(claim.credentialKey), owner, claim)) {
     throw unavailableError();
   }
 }
@@ -172,7 +214,7 @@ export function retireLobsterContinuation(
 ): void {
   owner
     .openStore()
-    .deleteIf?.(claim.credentialKey, (current) => isOwnedClaim(current, owner, claim.claimId));
+    .deleteIf?.(claim.credentialKey, (current) => isStoredOwnedClaim(current, owner, claim));
 }
 
 export function releaseLobsterContinuation(
@@ -180,12 +222,22 @@ export function releaseLobsterContinuation(
   claim: LobsterContinuationClaim,
 ): void {
   const store = owner.openStore();
+  const ttlMs = remainingTtlMs(claim.expiresAt);
+  if (ttlMs === undefined) {
+    retireLobsterContinuation(owner, claim);
+    return;
+  }
   store.update?.(
     claim.credentialKey,
     (current) =>
-      isOwnedClaim(current, owner, claim.claimId)
-        ? { kind: "binding", sessionKey: current.sessionKey, sessionId: current.sessionId }
+      isActiveOwnedClaim(current, owner, claim)
+        ? {
+            kind: "binding",
+            sessionKey: current.sessionKey,
+            sessionId: current.sessionId,
+            expiresAt: current.expiresAt,
+          }
         : undefined,
-    { ttlMs: LOBSTER_CONTINUATION_TTL_MS },
+    { ttlMs },
   );
 }

--- a/extensions/lobster/src/lobster-continuations.ts
+++ b/extensions/lobster/src/lobster-continuations.ts
@@ -1,0 +1,187 @@
+import { createHash } from "node:crypto";
+import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { LobsterEnvelope, LobsterRunnerParams } from "./lobster-runner.js";
+
+type Binding = {
+  kind: "binding";
+  sessionKey: string;
+  sessionId: string;
+  claimKey: string;
+  credentialKeys: string[];
+};
+
+export type LobsterContinuationOwner = {
+  sessionKey: string;
+  sessionId: string;
+  openStore: () => PluginStateSyncKeyedStore<unknown>;
+};
+
+export type LobsterContinuationClaim = {
+  claimKey: string;
+  credentialKeys: string[];
+};
+
+function credentialKey(kind: "token" | "approval", value: string): string {
+  const digest = createHash("sha256").update(kind).update("\0").update(value.trim()).digest("hex");
+  return `credential:${digest}`;
+}
+
+function credentialKeys(params: Pick<LobsterRunnerParams, "token" | "approvalId">): string[] {
+  return [
+    ...(params.token?.trim() ? [credentialKey("token", params.token)] : []),
+    ...(params.approvalId?.trim() ? [credentialKey("approval", params.approvalId)] : []),
+  ];
+}
+
+function envelopeCredentialKeys(envelope: Extract<LobsterEnvelope, { ok: true }>): string[] {
+  if (envelope.status === "needs_input" && envelope.requiresInput) {
+    return [credentialKey("token", envelope.requiresInput.resumeToken)];
+  }
+  return envelope.status === "needs_approval" && envelope.requiresApproval
+    ? credentialKeys({
+        token: envelope.requiresApproval.resumeToken,
+        approvalId: envelope.requiresApproval.approvalId,
+      })
+    : [];
+}
+
+function readBinding(value: unknown): Binding | undefined {
+  const rawKeys = isRecord(value) ? value.credentialKeys : undefined;
+  const keys = Array.isArray(rawKeys)
+    ? rawKeys.filter((key): key is string => typeof key === "string")
+    : [];
+  if (
+    !isRecord(value) ||
+    value.kind !== "binding" ||
+    typeof value.sessionKey !== "string" ||
+    typeof value.sessionId !== "string" ||
+    typeof value.claimKey !== "string" ||
+    !Array.isArray(rawKeys) ||
+    keys.length !== rawKeys.length
+  ) {
+    return undefined;
+  }
+  return {
+    kind: "binding",
+    sessionKey: value.sessionKey,
+    sessionId: value.sessionId,
+    claimKey: value.claimKey,
+    credentialKeys: keys,
+  };
+}
+
+function isOwnedClaim(value: unknown, owner: LobsterContinuationOwner): boolean {
+  return (
+    isRecord(value) &&
+    value.kind === "claim" &&
+    value.sessionKey === owner.sessionKey &&
+    value.sessionId === owner.sessionId
+  );
+}
+
+function unavailableError(): Error {
+  return new Error(
+    "Lobster continuation is unavailable, expired, or already used; rerun the workflow to create a new checkpoint",
+  );
+}
+
+export function bindLobsterContinuation(
+  owner: LobsterContinuationOwner | undefined,
+  envelope: Extract<LobsterEnvelope, { ok: true }>,
+): void {
+  const keys = envelopeCredentialKeys(envelope);
+  if (keys.length === 0) {
+    return;
+  }
+  if (!owner) {
+    throw new Error(
+      "Lobster continuation requires a bound OpenClaw session; rerun the workflow from a persistent session",
+    );
+  }
+  const claimKey = `claim:${keys[0]?.slice("credential:".length)}`;
+  const binding: Binding = {
+    kind: "binding",
+    sessionKey: owner.sessionKey,
+    sessionId: owner.sessionId,
+    claimKey,
+    credentialKeys: keys,
+  };
+  const store = owner.openStore();
+  const registered: string[] = [];
+  try {
+    for (const key of keys) {
+      if (!store.registerIfAbsent(key, binding)) {
+        throw new Error("Lobster runtime returned a duplicate continuation credential");
+      }
+      registered.push(key);
+    }
+  } catch (error) {
+    for (const key of registered) {
+      store.deleteIf?.(key, (current) => readBinding(current)?.claimKey === claimKey);
+    }
+    throw error;
+  }
+}
+
+export function claimLobsterContinuation(
+  owner: LobsterContinuationOwner | undefined,
+  params: Pick<LobsterRunnerParams, "token" | "approvalId">,
+): LobsterContinuationClaim {
+  if (!owner) {
+    throw unavailableError();
+  }
+  const store = owner.openStore();
+  let binding: Binding | undefined;
+  for (const key of credentialKeys(params)) {
+    const current = readBinding(store.lookup(key));
+    if (!current) {
+      throw unavailableError();
+    }
+    if (current.sessionKey !== owner.sessionKey || current.sessionId !== owner.sessionId) {
+      throw new Error(
+        "Lobster continuation belongs to another OpenClaw session; resume it from the session that created it",
+      );
+    }
+    if (binding && binding.claimKey !== current.claimKey) {
+      throw unavailableError();
+    }
+    binding = current;
+  }
+  if (
+    !binding ||
+    !store.registerIfAbsent(binding.claimKey, {
+      kind: "claim",
+      sessionKey: owner.sessionKey,
+      sessionId: owner.sessionId,
+    })
+  ) {
+    throw unavailableError();
+  }
+  return { claimKey: binding.claimKey, credentialKeys: binding.credentialKeys };
+}
+
+export function retireLobsterContinuation(
+  owner: LobsterContinuationOwner,
+  claim: LobsterContinuationClaim,
+): void {
+  const store = owner.openStore();
+  for (const key of claim.credentialKeys) {
+    store.deleteIf?.(key, (current) => {
+      const binding = readBinding(current);
+      return (
+        binding?.claimKey === claim.claimKey &&
+        binding.sessionKey === owner.sessionKey &&
+        binding.sessionId === owner.sessionId
+      );
+    });
+  }
+  store.deleteIf?.(claim.claimKey, (current) => isOwnedClaim(current, owner));
+}
+
+export function releaseLobsterContinuation(
+  owner: LobsterContinuationOwner,
+  claim: LobsterContinuationClaim,
+): void {
+  owner.openStore().deleteIf?.(claim.claimKey, (current) => isOwnedClaim(current, owner));
+}

--- a/extensions/lobster/src/lobster-continuations.ts
+++ b/extensions/lobster/src/lobster-continuations.ts
@@ -1,18 +1,15 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { LobsterEnvelope, LobsterRunnerParams } from "./lobster-runner.js";
 
-type Binding = {
-  kind: "binding";
-  sessionKey: string;
-  sessionId: string;
-  claimKey: string;
-  credentialKeys: string[];
-};
+type ContinuationRecord =
+  | { kind: "binding"; sessionKey: string; sessionId: string }
+  | { kind: "claim"; sessionKey: string; sessionId: string; claimId: string };
+type ClaimRecord = Extract<ContinuationRecord, { kind: "claim" }>;
 
-// Structured-input replies are short-lived conversation continuations. Expiry
-// bounds abandoned bindings so they cannot permanently exhaust plugin state.
+// Expiry after each valid state transition bounds abandoned continuations so
+// they cannot permanently exhaust plugin state.
 export const LOBSTER_CONTINUATION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 export type LobsterContinuationOwner = {
@@ -23,8 +20,8 @@ export type LobsterContinuationOwner = {
 };
 
 export type LobsterContinuationClaim = {
-  claimKey: string;
-  credentialKeys: string[];
+  credentialKey: string;
+  claimId: string;
 };
 
 function credentialKey(value: string): string {
@@ -32,48 +29,51 @@ function credentialKey(value: string): string {
   return `credential:${digest}`;
 }
 
-function credentialKeys(params: Pick<LobsterRunnerParams, "token">): string[] {
-  return params.token?.trim() ? [credentialKey(params.token)] : [];
+function paramsCredentialKey(params: Pick<LobsterRunnerParams, "token">): string | undefined {
+  return params.token?.trim() ? credentialKey(params.token) : undefined;
 }
 
-function envelopeCredentialKeys(envelope: Extract<LobsterEnvelope, { ok: true }>): string[] {
+function envelopeCredentialKey(
+  envelope: Extract<LobsterEnvelope, { ok: true }>,
+): string | undefined {
   if (envelope.status === "needs_input" && envelope.requiresInput) {
-    return [credentialKey(envelope.requiresInput.resumeToken)];
+    return credentialKey(envelope.requiresInput.resumeToken);
   }
-  return [];
+  return undefined;
 }
 
-function readBinding(value: unknown): Binding | undefined {
-  const rawKeys = isRecord(value) ? value.credentialKeys : undefined;
-  const keys = Array.isArray(rawKeys)
-    ? rawKeys.filter((key): key is string => typeof key === "string")
-    : [];
+function readContinuationRecord(value: unknown): ContinuationRecord | undefined {
   if (
     !isRecord(value) ||
-    value.kind !== "binding" ||
     typeof value.sessionKey !== "string" ||
-    typeof value.sessionId !== "string" ||
-    typeof value.claimKey !== "string" ||
-    !Array.isArray(rawKeys) ||
-    keys.length !== rawKeys.length
+    typeof value.sessionId !== "string"
   ) {
     return undefined;
   }
-  return {
-    kind: "binding",
-    sessionKey: value.sessionKey,
-    sessionId: value.sessionId,
-    claimKey: value.claimKey,
-    credentialKeys: keys,
-  };
+  if (value.kind === "binding") {
+    return { kind: "binding", sessionKey: value.sessionKey, sessionId: value.sessionId };
+  }
+  return value.kind === "claim" && typeof value.claimId === "string"
+    ? {
+        kind: "claim",
+        sessionKey: value.sessionKey,
+        sessionId: value.sessionId,
+        claimId: value.claimId,
+      }
+    : undefined;
 }
 
-function isOwnedClaim(value: unknown, owner: LobsterContinuationOwner): boolean {
+function isOwnedClaim(
+  value: unknown,
+  owner: LobsterContinuationOwner,
+  claimId: string,
+): value is ClaimRecord {
+  const binding = readContinuationRecord(value);
   return (
-    isRecord(value) &&
-    value.kind === "claim" &&
-    value.sessionKey === owner.sessionKey &&
-    value.sessionId === owner.sessionId
+    binding?.kind === "claim" &&
+    binding.sessionKey === owner.sessionKey &&
+    binding.sessionId === owner.sessionId &&
+    binding.claimId === claimId
   );
 }
 
@@ -95,8 +95,8 @@ export function bindLobsterContinuation(
   owner: LobsterContinuationOwner | undefined,
   envelope: Extract<LobsterEnvelope, { ok: true }>,
 ): void {
-  const keys = envelopeCredentialKeys(envelope);
-  if (keys.length === 0) {
+  const key = envelopeCredentialKey(envelope);
+  if (!key) {
     return;
   }
   if (!owner) {
@@ -105,28 +105,13 @@ export function bindLobsterContinuation(
     );
   }
   assertCurrentSession(owner);
-  const claimKey = `claim:${keys[0]?.slice("credential:".length)}`;
-  const binding: Binding = {
+  const binding: ContinuationRecord = {
     kind: "binding",
     sessionKey: owner.sessionKey,
     sessionId: owner.sessionId,
-    claimKey,
-    credentialKeys: keys,
   };
-  const store = owner.openStore();
-  const registered: string[] = [];
-  try {
-    for (const key of keys) {
-      if (!store.registerIfAbsent(key, binding, { ttlMs: LOBSTER_CONTINUATION_TTL_MS })) {
-        throw new Error("Lobster runtime returned a duplicate continuation credential");
-      }
-      registered.push(key);
-    }
-  } catch (error) {
-    for (const key of registered) {
-      store.deleteIf?.(key, (current) => readBinding(current)?.claimKey === claimKey);
-    }
-    throw error;
+  if (!owner.openStore().registerIfAbsent(key, binding, { ttlMs: LOBSTER_CONTINUATION_TTL_MS })) {
+    throw new Error("Lobster runtime returned a duplicate continuation credential");
   }
 }
 
@@ -139,37 +124,36 @@ export function claimLobsterContinuation(
   }
   assertCurrentSession(owner);
   const store = owner.openStore();
-  let binding: Binding | undefined;
-  for (const key of credentialKeys(params)) {
-    const current = readBinding(store.lookup(key));
-    if (!current) {
-      throw unavailableError();
-    }
-    if (current.sessionKey !== owner.sessionKey || current.sessionId !== owner.sessionId) {
+  const key = paramsCredentialKey(params);
+  if (!key) {
+    throw unavailableError();
+  }
+  const claimId = randomUUID();
+  let foreignOwner = false;
+  const claimed = store.update?.(
+    key,
+    (current) => {
+      const latest = readContinuationRecord(current);
+      if (!latest) {
+        return undefined;
+      }
+      if (latest.sessionKey !== owner.sessionKey || latest.sessionId !== owner.sessionId) {
+        foreignOwner = true;
+        return undefined;
+      }
+      return latest.kind === "binding" ? { ...latest, kind: "claim", claimId } : undefined;
+    },
+    { ttlMs: LOBSTER_CONTINUATION_TTL_MS },
+  );
+  if (!claimed) {
+    if (foreignOwner) {
       throw new Error(
         "Lobster continuation belongs to another OpenClaw session; resume it from the session that created it",
       );
     }
-    if (binding && binding.claimKey !== current.claimKey) {
-      throw unavailableError();
-    }
-    binding = current;
-  }
-  if (
-    !binding ||
-    !store.registerIfAbsent(
-      binding.claimKey,
-      {
-        kind: "claim",
-        sessionKey: owner.sessionKey,
-        sessionId: owner.sessionId,
-      },
-      { ttlMs: LOBSTER_CONTINUATION_TTL_MS },
-    )
-  ) {
     throw unavailableError();
   }
-  return { claimKey: binding.claimKey, credentialKeys: binding.credentialKeys };
+  return { credentialKey: key, claimId };
 }
 
 export function assertLobsterContinuationClaimCurrent(
@@ -177,7 +161,7 @@ export function assertLobsterContinuationClaimCurrent(
   claim: LobsterContinuationClaim,
 ): void {
   assertCurrentSession(owner);
-  if (!isOwnedClaim(owner.openStore().lookup(claim.claimKey), owner)) {
+  if (!isOwnedClaim(owner.openStore().lookup(claim.credentialKey), owner, claim.claimId)) {
     throw unavailableError();
   }
 }
@@ -186,23 +170,22 @@ export function retireLobsterContinuation(
   owner: LobsterContinuationOwner,
   claim: LobsterContinuationClaim,
 ): void {
-  const store = owner.openStore();
-  for (const key of claim.credentialKeys) {
-    store.deleteIf?.(key, (current) => {
-      const binding = readBinding(current);
-      return (
-        binding?.claimKey === claim.claimKey &&
-        binding.sessionKey === owner.sessionKey &&
-        binding.sessionId === owner.sessionId
-      );
-    });
-  }
-  store.deleteIf?.(claim.claimKey, (current) => isOwnedClaim(current, owner));
+  owner
+    .openStore()
+    .deleteIf?.(claim.credentialKey, (current) => isOwnedClaim(current, owner, claim.claimId));
 }
 
 export function releaseLobsterContinuation(
   owner: LobsterContinuationOwner,
   claim: LobsterContinuationClaim,
 ): void {
-  owner.openStore().deleteIf?.(claim.claimKey, (current) => isOwnedClaim(current, owner));
+  const store = owner.openStore();
+  store.update?.(
+    claim.credentialKey,
+    (current) =>
+      isOwnedClaim(current, owner, claim.claimId)
+        ? { kind: "binding", sessionKey: current.sessionKey, sessionId: current.sessionId }
+        : undefined,
+    { ttlMs: LOBSTER_CONTINUATION_TTL_MS },
+  );
 }

--- a/extensions/lobster/src/lobster-runner.test.ts
+++ b/extensions/lobster/src/lobster-runner.test.ts
@@ -134,6 +134,78 @@ describe("createEmbeddedLobsterRunner", () => {
   );
 
   it.each([
+    [
+      "prompt",
+      { prompt: "x".repeat(4097) },
+      "lobster input request prompt exceeded its model-context limit",
+    ],
+    [
+      "responseSchema",
+      { responseSchema: { type: "string", description: "x".repeat(8193) } },
+      "lobster input request responseSchema exceeded its model-context limit",
+    ],
+    [
+      "defaults",
+      { defaults: "x".repeat(4097) },
+      "lobster input request defaults exceeded its model-context limit",
+    ],
+    [
+      "subject",
+      { subject: "x".repeat(2049) },
+      "lobster input request subject exceeded its model-context limit",
+    ],
+    [
+      "resume token",
+      { resumeToken: "x".repeat(4097) },
+      "lobster input request resumeToken exceeded its model-context limit",
+    ],
+    [
+      "complete envelope",
+      {
+        prompt: "x".repeat(4090),
+        responseSchema: { type: "string", description: "x".repeat(7900) },
+        defaults: "x".repeat(3900),
+        subject: "x".repeat(1900),
+        resumeToken: "x".repeat(300),
+      },
+      "lobster input request exceeded its model-context limit",
+    ],
+  ])(
+    "rejects an oversized structured-input %s with a fixed model budget",
+    async (_field, patch, expectedError) => {
+      const runtime = {
+        runToolRequest: vi.fn().mockResolvedValue({
+          ok: true,
+          status: "needs_input",
+          output: [],
+          requiresApproval: null,
+          requiresInput: {
+            type: "input_request",
+            prompt: "Choose an outcome",
+            responseSchema: { type: "string" },
+            resumeToken: "input-token",
+            ...patch,
+          },
+        }),
+        resumeToolRequest: vi.fn(),
+      };
+      const runner = createEmbeddedLobsterRunner({
+        loadRuntime: vi.fn().mockResolvedValue(runtime),
+      });
+
+      await expect(
+        runner.run({
+          action: "run",
+          pipeline: "ask --prompt 'Choose an outcome'",
+          cwd: process.cwd(),
+          timeoutMs: 2000,
+          maxStdoutBytes: 1_000_000,
+        }),
+      ).rejects.toThrow(expectedError);
+    },
+  );
+
+  it.each([
     "exec --json=true cat data.json",
     "exec --json=true cat config.yaml",
     "exec --json=true cat flow.lobster",

--- a/extensions/lobster/src/lobster-runner.test.ts
+++ b/extensions/lobster/src/lobster-runner.test.ts
@@ -348,7 +348,20 @@ describe("createEmbeddedLobsterRunner", () => {
     ).rejects.toThrow("boom");
   });
 
-  it("fails closed when the embedded runtime requests unsupported input", async () => {
+  it("returns structured input requests and resumes them with a response", async () => {
+    const requiresInput = {
+      type: "input_request" as const,
+      prompt: "Review this draft?",
+      responseSchema: {
+        type: "object",
+        properties: { decision: { type: "string", enum: ["approve", "reject"] } },
+        required: ["decision"],
+        additionalProperties: false,
+      },
+      defaults: { decision: "approve" },
+      subject: { text: "draft body" },
+      resumeToken: "input-resume-token",
+    };
     const runtime = {
       runToolRequest: vi.fn().mockResolvedValue({
         ok: true,
@@ -356,12 +369,16 @@ describe("createEmbeddedLobsterRunner", () => {
         status: "needs_input",
         output: [],
         requiresApproval: null,
-        requiresInput: {
-          prompt: "Need more data",
-          schema: { type: "string" },
-        },
+        requiresInput,
       }),
-      resumeToolRequest: vi.fn(),
+      resumeToolRequest: vi.fn().mockResolvedValue({
+        ok: true,
+        protocolVersion: 1,
+        status: "ok",
+        output: [{ decision: "approve", subject: "draft body" }],
+        requiresApproval: null,
+        requiresInput: null,
+      }),
     };
 
     const runner = createEmbeddedLobsterRunner({
@@ -371,12 +388,41 @@ describe("createEmbeddedLobsterRunner", () => {
     await expect(
       runner.run({
         action: "run",
-        pipeline: "exec --json=true echo hi",
+        pipeline: "ask --prompt 'Review this draft?'",
         cwd: process.cwd(),
         timeoutMs: 2000,
         maxStdoutBytes: 4096,
       }),
-    ).rejects.toThrow("Lobster input requests are not supported by the OpenClaw Lobster tool yet");
+    ).resolves.toEqual({
+      ok: true,
+      status: "needs_input",
+      output: [],
+      requiresApproval: null,
+      requiresInput,
+    });
+
+    await expect(
+      runner.run({
+        action: "resume",
+        token: "input-resume-token",
+        response: { decision: "approve" },
+        cwd: process.cwd(),
+        timeoutMs: 2000,
+        maxStdoutBytes: 4096,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      status: "ok",
+      output: [{ decision: "approve", subject: "draft body" }],
+    });
+    expect(runtime.resumeToolRequest).toHaveBeenCalledOnce();
+    const request = requireRecord(
+      requireFirstCallParam(runtime.resumeToolRequest.mock.calls, "input resume tool request"),
+      "input resume tool request",
+    );
+    expect(request.token).toBe("input-resume-token");
+    expect(request.response).toEqual({ decision: "approve" });
+    expect(request.approved).toBeUndefined();
   });
 
   it("routes resume through the embedded runtime", async () => {
@@ -569,7 +615,7 @@ describe("createEmbeddedLobsterRunner", () => {
     ).rejects.toThrow(/pipeline required/);
   });
 
-  it("requires token and approve for resume", async () => {
+  it("requires a token and exactly one resume decision", async () => {
     const runner = createEmbeddedLobsterRunner({
       loadRuntime: vi.fn().mockResolvedValue({
         runToolRequest: vi.fn(),
@@ -595,7 +641,19 @@ describe("createEmbeddedLobsterRunner", () => {
         timeoutMs: 2000,
         maxStdoutBytes: 4096,
       }),
-    ).rejects.toThrow(/approve required/);
+    ).rejects.toThrow(/exactly one of approve or response required/);
+
+    await expect(
+      runner.run({
+        action: "resume",
+        token: "resume-token",
+        approve: true,
+        response: { decision: "approve" },
+        cwd: process.cwd(),
+        timeoutMs: 2000,
+        maxStdoutBytes: 4096,
+      }),
+    ).rejects.toThrow(/exactly one of approve or response required/);
   });
 
   it("aborts long-running embedded work", async () => {

--- a/extensions/lobster/src/lobster-runner.ts
+++ b/extensions/lobster/src/lobster-runner.ts
@@ -98,6 +98,14 @@ type EmbeddedToolRuntime = {
 };
 
 const workflowExts = new Set([".lobster", ".yaml", ".yml", ".json"]);
+const inputRequestModelLimits = {
+  prompt: 4 * 1024,
+  responseSchema: 8 * 1024,
+  defaults: 4 * 1024,
+  subject: 2 * 1024,
+  resumeToken: 4 * 1024,
+  total: 16 * 1024,
+} as const;
 
 export function resolveLobsterCwd(cwdRaw: unknown): string {
   if (typeof cwdRaw !== "string" || !cwdRaw.trim()) {
@@ -189,7 +197,7 @@ function normalizeInputRequest(
   ) {
     throw new Error("lobster runtime returned an invalid input request");
   }
-  return {
+  const normalized: NonNullable<Extract<LobsterEnvelope, { ok: true }>["requiresInput"]> = {
     type: "input_request",
     prompt: inputRequest.prompt,
     responseSchema: inputRequest.responseSchema,
@@ -197,6 +205,52 @@ function normalizeInputRequest(
     ...(inputRequest.subject !== undefined ? { subject: inputRequest.subject } : {}),
     resumeToken: inputRequest.resumeToken,
   };
+  assertInputRequestModelBudget(normalized);
+  return normalized;
+}
+
+function jsonByteLength(value: unknown): number {
+  let serialized: string | undefined;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    throw new Error("lobster runtime returned a non-JSON input request");
+  }
+  if (serialized === undefined) {
+    throw new Error("lobster runtime returned a non-JSON input request");
+  }
+  return Buffer.byteLength(serialized, "utf8");
+}
+
+function assertInputRequestFieldBudget(
+  field: keyof Omit<typeof inputRequestModelLimits, "total">,
+  value: unknown,
+): void {
+  if (jsonByteLength(value) <= inputRequestModelLimits[field]) {
+    return;
+  }
+  throw new Error(
+    `lobster input request ${field} exceeded its model-context limit; shorten that field in the Lobster ask step and retry`,
+  );
+}
+
+function assertInputRequestModelBudget(
+  inputRequest: NonNullable<Extract<LobsterEnvelope, { ok: true }>["requiresInput"]>,
+): void {
+  assertInputRequestFieldBudget("prompt", inputRequest.prompt);
+  assertInputRequestFieldBudget("responseSchema", inputRequest.responseSchema);
+  if (inputRequest.defaults !== undefined) {
+    assertInputRequestFieldBudget("defaults", inputRequest.defaults);
+  }
+  if (inputRequest.subject !== undefined) {
+    assertInputRequestFieldBudget("subject", inputRequest.subject);
+  }
+  assertInputRequestFieldBudget("resumeToken", inputRequest.resumeToken);
+  if (jsonByteLength(inputRequest) > inputRequestModelLimits.total) {
+    throw new Error(
+      "lobster input request exceeded its model-context limit; shorten the ask prompt, schema, defaults, or subject and retry",
+    );
+  }
 }
 
 export function assertLobsterResumeDecision(

--- a/extensions/lobster/src/lobster-runner.ts
+++ b/extensions/lobster/src/lobster-runner.ts
@@ -77,9 +77,20 @@ type EmbeddedToolEnvelope = {
     resumeToken?: string;
   } | null;
   error?: {
+    type?: string;
     message: string;
   };
 };
+
+export class LobsterRunnerError extends Error {
+  readonly type?: string;
+
+  constructor(message: string, type?: string) {
+    super(message);
+    this.name = "LobsterRunnerError";
+    this.type = type;
+  }
+}
 
 type EmbeddedToolRuntime = {
   runToolRequest: (params: {
@@ -143,7 +154,10 @@ function normalizeEnvelope(
   maxStdoutBytes: number,
 ): Extract<LobsterEnvelope, { ok: true }> {
   if (!envelope.ok) {
-    throw new Error(envelope.error?.message ?? "lobster runtime failed");
+    throw new LobsterRunnerError(
+      envelope.error?.message ?? "lobster runtime failed",
+      envelope.error?.type,
+    );
   }
   const status = envelope.status ?? "ok";
   const inputRequest =

--- a/extensions/lobster/src/lobster-runner.ts
+++ b/extensions/lobster/src/lobster-runner.ts
@@ -45,7 +45,10 @@ export type LobsterRunnerParams = {
 };
 
 export type LobsterRunner = {
-  run: (params: LobsterRunnerParams) => Promise<LobsterEnvelope>;
+  run: (
+    params: LobsterRunnerParams,
+    hooks?: { beforeResumeIo?: () => void },
+  ) => Promise<LobsterEnvelope>;
 };
 
 type EmbeddedToolContext = {
@@ -362,7 +365,7 @@ export function createEmbeddedLobsterRunner(options?: {
   const loadRuntime = options?.loadRuntime ?? loadEmbeddedToolRuntimeFromPackage;
   let runtimePromise: Promise<EmbeddedToolRuntime> | undefined;
   return {
-    async run(params) {
+    async run(params, hooks) {
       runtimePromise ??= loadRuntime();
       const runtime = await runtimePromise;
       return await withTimeout(params.timeoutMs, async (signal) => {
@@ -397,6 +400,9 @@ export function createEmbeddedLobsterRunner(options?: {
             throw new Error("token or approvalId required");
           }
           assertLobsterResumeDecision(params);
+          // The runtime load above may yield while /new or /reset rotates the
+          // session. Recheck immediately before Lobster can consume the token.
+          hooks?.beforeResumeIo?.();
           envelope = await runtime.resumeToolRequest({
             ...(token ? { token } : {}),
             ...(approvalId ? { approvalId } : {}),

--- a/extensions/lobster/src/lobster-runner.ts
+++ b/extensions/lobster/src/lobster-runner.ts
@@ -8,7 +8,7 @@ import { isPathInside } from "openclaw/plugin-sdk/file-access-runtime";
 export type LobsterEnvelope =
   | {
       ok: true;
-      status: "ok" | "needs_approval" | "cancelled";
+      status: "ok" | "needs_approval" | "needs_input" | "cancelled";
       output: unknown[];
       requiresApproval: null | {
         type: "approval_request";
@@ -16,6 +16,14 @@ export type LobsterEnvelope =
         items: unknown[];
         resumeToken?: string;
         approvalId?: string;
+      };
+      requiresInput?: {
+        type: "input_request";
+        prompt: string;
+        responseSchema: unknown;
+        defaults?: unknown;
+        subject?: unknown;
+        resumeToken: string;
       };
     }
   | {
@@ -30,6 +38,7 @@ export type LobsterRunnerParams = {
   token?: string;
   approvalId?: string;
   approve?: boolean;
+  response?: unknown;
   cwd: string;
   timeoutMs: number;
   maxStdoutBytes: number;
@@ -59,6 +68,14 @@ type EmbeddedToolEnvelope = {
     resumeToken?: string;
     approvalId?: string;
   } | null;
+  requiresInput?: {
+    type?: "input_request";
+    prompt: string;
+    responseSchema: unknown;
+    defaults?: unknown;
+    subject?: unknown;
+    resumeToken?: string;
+  } | null;
   error?: {
     message: string;
   };
@@ -75,6 +92,7 @@ type EmbeddedToolRuntime = {
     token?: string;
     approvalId?: string;
     approved?: boolean;
+    response?: unknown;
     ctx?: EmbeddedToolContext;
   }) => Promise<EmbeddedToolEnvelope>;
 };
@@ -119,12 +137,12 @@ function normalizeEnvelope(
   if (!envelope.ok) {
     throw new Error(envelope.error?.message ?? "lobster runtime failed");
   }
-  if (envelope.status === "needs_input") {
-    throw new Error("Lobster input requests are not supported by the OpenClaw Lobster tool yet");
-  }
+  const status = envelope.status ?? "ok";
+  const inputRequest =
+    status === "needs_input" ? normalizeInputRequest(envelope.requiresInput) : undefined;
   const normalized: Extract<LobsterEnvelope, { ok: true }> = {
     ok: true,
-    status: envelope.status ?? "ok",
+    status,
     output: Array.isArray(envelope.output) ? envelope.output : [],
     requiresApproval: envelope.requiresApproval
       ? {
@@ -139,11 +157,56 @@ function normalizeEnvelope(
             : {}),
         }
       : null,
+    ...(inputRequest
+      ? {
+          requiresInput: {
+            type: "input_request",
+            prompt: inputRequest.prompt,
+            responseSchema: inputRequest.responseSchema,
+            ...(inputRequest.defaults !== undefined ? { defaults: inputRequest.defaults } : {}),
+            ...(inputRequest.subject !== undefined ? { subject: inputRequest.subject } : {}),
+            resumeToken: inputRequest.resumeToken,
+          },
+        }
+      : {}),
   };
   if (Buffer.byteLength(JSON.stringify(normalized, null, 2), "utf8") > maxStdoutBytes) {
     throw new Error("lobster runtime result exceeded maxStdoutBytes");
   }
   return normalized;
+}
+
+function normalizeInputRequest(
+  inputRequest: EmbeddedToolEnvelope["requiresInput"],
+): NonNullable<Extract<LobsterEnvelope, { ok: true }>["requiresInput"]> {
+  if (
+    !inputRequest ||
+    inputRequest.type !== "input_request" ||
+    typeof inputRequest.prompt !== "string" ||
+    inputRequest.responseSchema === undefined ||
+    typeof inputRequest.resumeToken !== "string" ||
+    !inputRequest.resumeToken
+  ) {
+    throw new Error("lobster runtime returned an invalid input request");
+  }
+  return {
+    type: "input_request",
+    prompt: inputRequest.prompt,
+    responseSchema: inputRequest.responseSchema,
+    ...(inputRequest.defaults !== undefined ? { defaults: inputRequest.defaults } : {}),
+    ...(inputRequest.subject !== undefined ? { subject: inputRequest.subject } : {}),
+    resumeToken: inputRequest.resumeToken,
+  };
+}
+
+export function assertLobsterResumeDecision(
+  params: Pick<LobsterRunnerParams, "approve" | "response">,
+): void {
+  const hasApprovalDecision = typeof params.approve === "boolean";
+  const hasInputResponse = params.response !== undefined;
+  if (hasApprovalDecision === hasInputResponse) {
+    throw new Error("exactly one of approve or response required");
+  }
 }
 
 function isMissingPathError(error: unknown) {
@@ -265,13 +328,13 @@ export function createEmbeddedLobsterRunner(options?: {
           if (!token && !approvalId) {
             throw new Error("token or approvalId required");
           }
-          if (typeof params.approve !== "boolean") {
-            throw new Error("approve required");
-          }
+          assertLobsterResumeDecision(params);
           envelope = await runtime.resumeToolRequest({
             ...(token ? { token } : {}),
             ...(approvalId ? { approvalId } : {}),
-            approved: params.approve,
+            ...(typeof params.approve === "boolean"
+              ? { approved: params.approve }
+              : { response: params.response }),
             ctx,
           });
         }

--- a/extensions/lobster/src/lobster-taskflow.test.ts
+++ b/extensions/lobster/src/lobster-taskflow.test.ts
@@ -173,6 +173,36 @@ describe("runManagedLobsterFlow", () => {
     });
   });
 
+  it("fails instead of finishing when Lobster requests structured input", async () => {
+    const taskFlow = createFakeTaskFlow();
+    const runner = createRunner({
+      ok: true,
+      status: "needs_input",
+      output: [],
+      requiresApproval: null,
+      requiresInput: {
+        type: "input_request",
+        prompt: "Choose a destination",
+        responseSchema: { type: "string" },
+        resumeToken: "input-token-1",
+      },
+    });
+
+    const result = expectManagedFlowFailure(
+      await runManagedLobsterFlow(createRunFlowParams(taskFlow, runner)),
+    );
+
+    expect(result.error.message).toBe(
+      "managed TaskFlow mode does not support structured input requests",
+    );
+    expect(taskFlow.fail).toHaveBeenCalledWith({
+      flowId: "flow-1",
+      expectedRevision: 1,
+    });
+    expect(taskFlow.finish).not.toHaveBeenCalled();
+    expect(taskFlow.setWaiting).not.toHaveBeenCalled();
+  });
+
   it("fails the flow when the runner throws", async () => {
     const taskFlow = createFakeTaskFlow();
     const runner: LobsterRunner = {

--- a/extensions/lobster/src/lobster-taskflow.ts
+++ b/extensions/lobster/src/lobster-taskflow.ts
@@ -149,6 +149,15 @@ async function executeManagedLobsterFlow(
       const mutation = params.taskFlow.fail(flowMutation);
       return { ok: false, flow, mutation, error: new Error(envelope.error.message) };
     }
+    if (envelope.status === "needs_input") {
+      const mutation = params.taskFlow.fail(flowMutation);
+      return {
+        ok: false,
+        flow,
+        mutation,
+        error: new Error("managed TaskFlow mode does not support structured input requests"),
+      };
+    }
     const mutation =
       envelope.status === "needs_approval"
         ? params.taskFlow.setWaiting({

--- a/extensions/lobster/src/lobster-tool.test.ts
+++ b/extensions/lobster/src/lobster-tool.test.ts
@@ -106,6 +106,86 @@ describe("lobster plugin tool", () => {
     expect(approval.resumeToken).toBe("resume-token-1");
   });
 
+  it("returns structured input requests and parses their resume response", async () => {
+    const runner = {
+      run: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "needs_input",
+          output: [],
+          requiresApproval: null,
+          requiresInput: {
+            type: "input_request",
+            prompt: "Choose a destination",
+            responseSchema: {
+              type: "object",
+              properties: { destination: { type: "string" } },
+              required: ["destination"],
+            },
+            resumeToken: "input-token-1",
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "ok",
+          output: [{ destination: "archive" }],
+          requiresApproval: null,
+        }),
+    };
+    const tool = createLobsterTool(fakeApi(), { runner });
+
+    const first = await tool.execute("call-input-run", {
+      action: "run",
+      pipeline: "ask --prompt 'Choose a destination'",
+    });
+    const firstDetails = requireRecord(first.details, "input request details");
+    expect(firstDetails.status).toBe("needs_input");
+    expect(requireRecord(firstDetails.requiresInput, "input request")).toMatchObject({
+      prompt: "Choose a destination",
+      resumeToken: "input-token-1",
+    });
+
+    const resumed = await tool.execute("call-input-resume", {
+      action: "resume",
+      token: "input-token-1",
+      responseJson: '{"destination":"archive"}',
+    });
+    expect(runner.run).toHaveBeenLastCalledWith({
+      action: "resume",
+      token: "input-token-1",
+      response: { destination: "archive" },
+      cwd: process.cwd(),
+      timeoutMs: 20_000,
+      maxStdoutBytes: 512_000,
+    });
+    expect(requireRecord(resumed.details, "input resume details").output).toEqual([
+      { destination: "archive" },
+    ]);
+  });
+
+  it("rejects invalid or ambiguous structured input responses", async () => {
+    const runner = { run: vi.fn() };
+    const tool = createLobsterTool(fakeApi(), { runner });
+
+    await expect(
+      tool.execute("call-invalid-input-response", {
+        action: "resume",
+        token: "input-token-1",
+        responseJson: "{bad",
+      }),
+    ).rejects.toThrow("responseJson must be valid JSON");
+    await expect(
+      tool.execute("call-ambiguous-input-response", {
+        action: "resume",
+        token: "input-token-1",
+        approve: true,
+        responseJson: '{"destination":"archive"}',
+      }),
+    ).rejects.toThrow(/exactly one of approve or response required/);
+    expect(runner.run).not.toHaveBeenCalled();
+  });
+
   it("keeps ordinary run on the runner for neutral flow defaults and ignores resume credentials", async () => {
     const runner = {
       run: vi.fn().mockResolvedValue({
@@ -550,6 +630,24 @@ describe("lobster plugin tool", () => {
     expect(details.status).toBe("ok");
     const mutation = requireRecord(details.mutation, "managed resume mutation details");
     expect(mutation.applied).toBe(true);
+  });
+
+  it("keeps managed TaskFlow resumes approval-only", async () => {
+    const runner = { run: vi.fn() };
+    const taskFlow = createFakeTaskFlow();
+    const tool = createLobsterTool(fakeApi(), { runner, taskFlow });
+
+    await expect(
+      tool.execute("call-managed-input-resume", {
+        action: "resume",
+        token: "input-token-1",
+        responseJson: '{"destination":"archive"}',
+        flowId: "flow-1",
+        flowExpectedRevision: 1,
+      }),
+    ).rejects.toThrow("managed TaskFlow resume mode only supports approval decisions");
+    expect(taskFlow.resume).not.toHaveBeenCalled();
+    expect(runner.run).not.toHaveBeenCalled();
   });
 
   it("normalizes numeric string flowExpectedRevision before managed resume", async () => {

--- a/extensions/lobster/src/lobster-tool.test.ts
+++ b/extensions/lobster/src/lobster-tool.test.ts
@@ -3,6 +3,8 @@ import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi, OpenClawPluginToolContext } from "../runtime-api.js";
+import type { LobsterContinuationOwner } from "./lobster-continuations.js";
+import { LobsterRunnerError } from "./lobster-runner.js";
 import { createLobsterTool } from "./lobster-tool.js";
 import { createFakeTaskFlow } from "./taskflow-test-helpers.js";
 
@@ -24,6 +26,7 @@ function fakeCtx(overrides: Partial<OpenClawPluginToolContext> = {}): OpenClawPl
     agentDir: "/tmp",
     agentId: "main",
     sessionKey: "main",
+    sessionId: "session-a",
     messageChannel: undefined,
     agentAccountId: undefined,
     sandboxed: false,
@@ -32,6 +35,54 @@ function fakeCtx(overrides: Partial<OpenClawPluginToolContext> = {}): OpenClawPl
 }
 
 const requireRecord = createRequireRecord("record", "expected-label-record");
+
+function createContinuationStore() {
+  const values = new Map<string, unknown>();
+  return {
+    register: (key: string, value: unknown) => {
+      values.set(key, value);
+    },
+    registerIfAbsent: (key: string, value: unknown) => {
+      if (values.has(key)) {
+        return false;
+      }
+      values.set(key, value);
+      return true;
+    },
+    lookup: (key: string) => values.get(key),
+    update: (key: string, updateValue: (current: unknown) => unknown) => {
+      const next = updateValue(values.get(key));
+      if (next === undefined) {
+        return false;
+      }
+      values.set(key, next);
+      return true;
+    },
+    consume: (key: string) => {
+      const value = values.get(key);
+      values.delete(key);
+      return value;
+    },
+    delete: (key: string) => values.delete(key),
+    deleteIf: (key: string, predicate: (current: unknown) => boolean) => {
+      const current = values.get(key);
+      return current !== undefined && predicate(current) ? values.delete(key) : false;
+    },
+    entries: () => [...values].map(([key, value]) => ({ key, value, createdAt: 0 })),
+    clear: () => values.clear(),
+  };
+}
+
+function continuationOwner(
+  store = createContinuationStore(),
+  sessionId = "session-a",
+): LobsterContinuationOwner {
+  return {
+    sessionKey: "agent:main:main",
+    sessionId,
+    openStore: () => store,
+  };
+}
 
 describe("lobster plugin tool", () => {
   it("returns the Lobster envelope in details", async () => {
@@ -44,7 +95,7 @@ describe("lobster plugin tool", () => {
       }),
     };
 
-    const tool = createLobsterTool(fakeApi(), { runner });
+    const tool = createLobsterTool(fakeApi(), { runner, continuationOwner: continuationOwner() });
     const res = await tool.execute("call1", {
       action: "run",
       pipeline: "noop",
@@ -80,7 +131,7 @@ describe("lobster plugin tool", () => {
       }),
     };
 
-    const tool = createLobsterTool(fakeApi(), { runner });
+    const tool = createLobsterTool(fakeApi(), { runner, continuationOwner: continuationOwner() });
     const res = await tool.execute("call-injected-runner", {
       action: "run",
       pipeline: "noop",
@@ -133,7 +184,7 @@ describe("lobster plugin tool", () => {
           requiresApproval: null,
         }),
     };
-    const tool = createLobsterTool(fakeApi(), { runner });
+    const tool = createLobsterTool(fakeApi(), { runner, continuationOwner: continuationOwner() });
 
     const first = await tool.execute("call-input-run", {
       action: "run",
@@ -162,6 +213,177 @@ describe("lobster plugin tool", () => {
     expect(requireRecord(resumed.details, "input resume details").output).toEqual([
       { destination: "archive" },
     ]);
+    await expect(
+      tool.execute("call-input-replay", {
+        action: "resume",
+        token: "input-token-1",
+        responseJson: '{"destination":"archive"}',
+      }),
+    ).rejects.toThrow(/unavailable, expired, or already used/);
+    expect(runner.run).toHaveBeenCalledTimes(2);
+  });
+
+  it("makes approval tokens and ids share one atomic continuation claim", async () => {
+    const runner = {
+      run: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "needs_approval",
+          output: [],
+          requiresApproval: {
+            type: "approval_request",
+            prompt: "Continue?",
+            items: [],
+            resumeToken: "approval-token-shared-claim",
+            approvalId: "approval-id-shared-claim",
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "ok",
+          output: ["approved"],
+          requiresApproval: null,
+        }),
+    };
+    const tool = createLobsterTool(fakeApi(), {
+      runner,
+      continuationOwner: continuationOwner(),
+    });
+    await tool.execute("call-approval-run", { action: "run", pipeline: "approve" });
+
+    const tokenResume = tool.execute("call-approval-token-resume", {
+      action: "resume",
+      token: "approval-token-shared-claim",
+      approve: true,
+    });
+    await expect(
+      tool.execute("call-approval-id-concurrent-resume", {
+        action: "resume",
+        approvalId: "approval-id-shared-claim",
+        approve: true,
+      }),
+    ).rejects.toThrow(/unavailable, expired, or already used/);
+    await expect(tokenResume).resolves.toBeDefined();
+    expect(runner.run).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases a structured-input claim when Lobster rejects the response before execution", async () => {
+    const runner = {
+      run: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "needs_input",
+          output: [],
+          requiresApproval: null,
+          requiresInput: {
+            type: "input_request",
+            prompt: "Choose a destination",
+            responseSchema: { enum: ["archive"] },
+            resumeToken: "input-token-retry",
+          },
+        })
+        .mockRejectedValueOnce(
+          new LobsterRunnerError("response failed schema validation", "parse_error"),
+        )
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "ok",
+          output: ["archive"],
+          requiresApproval: null,
+        }),
+    };
+    const tool = createLobsterTool(fakeApi(), {
+      runner,
+      continuationOwner: continuationOwner(),
+    });
+    await tool.execute("call-input-retry-run", { action: "run", pipeline: "ask" });
+
+    await expect(
+      tool.execute("call-input-invalid-response", {
+        action: "resume",
+        token: "input-token-retry",
+        responseJson: '"inbox"',
+      }),
+    ).rejects.toThrow(/response failed schema validation/);
+    await expect(
+      tool.execute("call-input-valid-response", {
+        action: "resume",
+        token: "input-token-retry",
+        responseJson: '"archive"',
+      }),
+    ).resolves.toBeDefined();
+    expect(runner.run).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects a copied structured-input token before a foreign session reaches the runner", async () => {
+    const runner = {
+      run: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "needs_input",
+          output: [],
+          requiresApproval: null,
+          requiresInput: {
+            type: "input_request",
+            prompt: "Choose a destination",
+            responseSchema: { type: "string" },
+            resumeToken: "input-token-foreign-control",
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "ok",
+          output: ["unexpected"],
+          requiresApproval: null,
+        }),
+    };
+    const store = createContinuationStore();
+    const creatingTool = createLobsterTool(fakeApi(), {
+      runner,
+      continuationOwner: continuationOwner(store, "session-a"),
+    });
+    await creatingTool.execute("call-input-run", {
+      action: "run",
+      pipeline: "ask --prompt 'Choose a destination'",
+    });
+
+    const foreignTool = createLobsterTool(fakeApi(), {
+      runner,
+      continuationOwner: continuationOwner(store, "session-b"),
+    });
+    await expect(
+      foreignTool.execute("call-input-foreign-resume", {
+        action: "resume",
+        token: "input-token-foreign-control",
+        responseJson: '"archive"',
+      }),
+    ).rejects.toThrow(/continuation belongs to another OpenClaw session/);
+    expect(runner.run).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not return an unbound continuation from one-shot contexts", async () => {
+    const runner = {
+      run: vi.fn().mockResolvedValue({
+        ok: true,
+        status: "needs_input",
+        output: [],
+        requiresApproval: null,
+        requiresInput: {
+          type: "input_request",
+          prompt: "Choose a destination",
+          responseSchema: { type: "string" },
+          resumeToken: "unbound-input-token",
+        },
+      }),
+    };
+    const tool = createLobsterTool(fakeApi(), { runner });
+
+    await expect(
+      tool.execute("call-unbound-input-run", { action: "run", pipeline: "ask" }),
+    ).rejects.toThrow(/requires a bound OpenClaw session/);
   });
 
   it("rejects invalid or ambiguous structured input responses", async () => {
@@ -202,7 +424,11 @@ describe("lobster plugin tool", () => {
     };
     const taskFlow = createFakeTaskFlow();
 
-    const tool = createLobsterTool(fakeApi(), { runner, taskFlow });
+    const tool = createLobsterTool(fakeApi(), {
+      runner,
+      taskFlow,
+      continuationOwner: continuationOwner(),
+    });
     const res = await tool.execute("call-default-flow-run", {
       action: "run",
       pipeline: "noop",
@@ -253,16 +479,37 @@ describe("lobster plugin tool", () => {
 
   it("keeps ordinary resume on the runner for neutral flow defaults", async () => {
     const runner = {
-      run: vi.fn().mockResolvedValue({
-        ok: true,
-        status: "ok",
-        output: [{ approved: true }],
-        requiresApproval: null,
-      }),
+      run: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "needs_approval",
+          output: [],
+          requiresApproval: {
+            type: "approval_request",
+            prompt: "Continue?",
+            items: [],
+            resumeToken: "resume-token-1",
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: "ok",
+          output: [{ approved: true }],
+          requiresApproval: null,
+        }),
     };
     const taskFlow = createFakeTaskFlow();
 
-    const tool = createLobsterTool(fakeApi(), { runner, taskFlow });
+    const tool = createLobsterTool(fakeApi(), {
+      runner,
+      taskFlow,
+      continuationOwner: continuationOwner(),
+    });
+    await tool.execute("call-default-flow-run", {
+      action: "run",
+      pipeline: "noop",
+    });
     const res = await tool.execute("call-default-flow-resume", {
       action: "resume",
       token: "resume-token-1",

--- a/extensions/lobster/src/lobster-tool.test.ts
+++ b/extensions/lobster/src/lobster-tool.test.ts
@@ -3,8 +3,6 @@ import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi, OpenClawPluginToolContext } from "../runtime-api.js";
-import type { LobsterContinuationOwner } from "./lobster-continuations.js";
-import { LobsterRunnerError } from "./lobster-runner.js";
 import { createLobsterTool } from "./lobster-tool.js";
 import { createFakeTaskFlow } from "./taskflow-test-helpers.js";
 
@@ -36,54 +34,6 @@ function fakeCtx(overrides: Partial<OpenClawPluginToolContext> = {}): OpenClawPl
 
 const requireRecord = createRequireRecord("record", "expected-label-record");
 
-function createContinuationStore() {
-  const values = new Map<string, unknown>();
-  return {
-    register: (key: string, value: unknown) => {
-      values.set(key, value);
-    },
-    registerIfAbsent: (key: string, value: unknown) => {
-      if (values.has(key)) {
-        return false;
-      }
-      values.set(key, value);
-      return true;
-    },
-    lookup: (key: string) => values.get(key),
-    update: (key: string, updateValue: (current: unknown) => unknown) => {
-      const next = updateValue(values.get(key));
-      if (next === undefined) {
-        return false;
-      }
-      values.set(key, next);
-      return true;
-    },
-    consume: (key: string) => {
-      const value = values.get(key);
-      values.delete(key);
-      return value;
-    },
-    delete: (key: string) => values.delete(key),
-    deleteIf: (key: string, predicate: (current: unknown) => boolean) => {
-      const current = values.get(key);
-      return current !== undefined && predicate(current) ? values.delete(key) : false;
-    },
-    entries: () => [...values].map(([key, value]) => ({ key, value, createdAt: 0 })),
-    clear: () => values.clear(),
-  };
-}
-
-function continuationOwner(
-  store = createContinuationStore(),
-  sessionId = "session-a",
-): LobsterContinuationOwner {
-  return {
-    sessionKey: "agent:main:main",
-    sessionId,
-    openStore: () => store,
-  };
-}
-
 describe("lobster plugin tool", () => {
   it("returns the Lobster envelope in details", async () => {
     const runner = {
@@ -95,7 +45,7 @@ describe("lobster plugin tool", () => {
       }),
     };
 
-    const tool = createLobsterTool(fakeApi(), { runner, continuationOwner: continuationOwner() });
+    const tool = createLobsterTool(fakeApi(), { runner });
     const res = await tool.execute("call1", {
       action: "run",
       pipeline: "noop",
@@ -131,7 +81,7 @@ describe("lobster plugin tool", () => {
       }),
     };
 
-    const tool = createLobsterTool(fakeApi(), { runner, continuationOwner: continuationOwner() });
+    const tool = createLobsterTool(fakeApi(), { runner });
     const res = await tool.execute("call-injected-runner", {
       action: "run",
       pipeline: "noop",
@@ -155,235 +105,6 @@ describe("lobster plugin tool", () => {
     expect(approval.type).toBe("approval_request");
     expect(approval.prompt).toBe("Send these alerts?");
     expect(approval.resumeToken).toBe("resume-token-1");
-  });
-
-  it("returns structured input requests and parses their resume response", async () => {
-    const runner = {
-      run: vi
-        .fn()
-        .mockResolvedValueOnce({
-          ok: true,
-          status: "needs_input",
-          output: [],
-          requiresApproval: null,
-          requiresInput: {
-            type: "input_request",
-            prompt: "Choose a destination",
-            responseSchema: {
-              type: "object",
-              properties: { destination: { type: "string" } },
-              required: ["destination"],
-            },
-            resumeToken: "input-token-1",
-          },
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          status: "ok",
-          output: [{ destination: "archive" }],
-          requiresApproval: null,
-        }),
-    };
-    const tool = createLobsterTool(fakeApi(), { runner, continuationOwner: continuationOwner() });
-
-    const first = await tool.execute("call-input-run", {
-      action: "run",
-      pipeline: "ask --prompt 'Choose a destination'",
-    });
-    const firstDetails = requireRecord(first.details, "input request details");
-    expect(firstDetails.status).toBe("needs_input");
-    expect(requireRecord(firstDetails.requiresInput, "input request")).toMatchObject({
-      prompt: "Choose a destination",
-      resumeToken: "input-token-1",
-    });
-
-    const resumed = await tool.execute("call-input-resume", {
-      action: "resume",
-      token: "input-token-1",
-      responseJson: '{"destination":"archive"}',
-    });
-    expect(runner.run).toHaveBeenLastCalledWith({
-      action: "resume",
-      token: "input-token-1",
-      response: { destination: "archive" },
-      cwd: process.cwd(),
-      timeoutMs: 20_000,
-      maxStdoutBytes: 512_000,
-    });
-    expect(requireRecord(resumed.details, "input resume details").output).toEqual([
-      { destination: "archive" },
-    ]);
-    await expect(
-      tool.execute("call-input-replay", {
-        action: "resume",
-        token: "input-token-1",
-        responseJson: '{"destination":"archive"}',
-      }),
-    ).rejects.toThrow(/unavailable, expired, or already used/);
-    expect(runner.run).toHaveBeenCalledTimes(2);
-  });
-
-  it("makes approval tokens and ids share one atomic continuation claim", async () => {
-    const runner = {
-      run: vi
-        .fn()
-        .mockResolvedValueOnce({
-          ok: true,
-          status: "needs_approval",
-          output: [],
-          requiresApproval: {
-            type: "approval_request",
-            prompt: "Continue?",
-            items: [],
-            resumeToken: "approval-token-shared-claim",
-            approvalId: "approval-id-shared-claim",
-          },
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          status: "ok",
-          output: ["approved"],
-          requiresApproval: null,
-        }),
-    };
-    const tool = createLobsterTool(fakeApi(), {
-      runner,
-      continuationOwner: continuationOwner(),
-    });
-    await tool.execute("call-approval-run", { action: "run", pipeline: "approve" });
-
-    const tokenResume = tool.execute("call-approval-token-resume", {
-      action: "resume",
-      token: "approval-token-shared-claim",
-      approve: true,
-    });
-    await expect(
-      tool.execute("call-approval-id-concurrent-resume", {
-        action: "resume",
-        approvalId: "approval-id-shared-claim",
-        approve: true,
-      }),
-    ).rejects.toThrow(/unavailable, expired, or already used/);
-    await expect(tokenResume).resolves.toBeDefined();
-    expect(runner.run).toHaveBeenCalledTimes(2);
-  });
-
-  it("releases a structured-input claim when Lobster rejects the response before execution", async () => {
-    const runner = {
-      run: vi
-        .fn()
-        .mockResolvedValueOnce({
-          ok: true,
-          status: "needs_input",
-          output: [],
-          requiresApproval: null,
-          requiresInput: {
-            type: "input_request",
-            prompt: "Choose a destination",
-            responseSchema: { enum: ["archive"] },
-            resumeToken: "input-token-retry",
-          },
-        })
-        .mockRejectedValueOnce(
-          new LobsterRunnerError("response failed schema validation", "parse_error"),
-        )
-        .mockResolvedValueOnce({
-          ok: true,
-          status: "ok",
-          output: ["archive"],
-          requiresApproval: null,
-        }),
-    };
-    const tool = createLobsterTool(fakeApi(), {
-      runner,
-      continuationOwner: continuationOwner(),
-    });
-    await tool.execute("call-input-retry-run", { action: "run", pipeline: "ask" });
-
-    await expect(
-      tool.execute("call-input-invalid-response", {
-        action: "resume",
-        token: "input-token-retry",
-        responseJson: '"inbox"',
-      }),
-    ).rejects.toThrow(/response failed schema validation/);
-    await expect(
-      tool.execute("call-input-valid-response", {
-        action: "resume",
-        token: "input-token-retry",
-        responseJson: '"archive"',
-      }),
-    ).resolves.toBeDefined();
-    expect(runner.run).toHaveBeenCalledTimes(3);
-  });
-
-  it("rejects a copied structured-input token before a foreign session reaches the runner", async () => {
-    const runner = {
-      run: vi
-        .fn()
-        .mockResolvedValueOnce({
-          ok: true,
-          status: "needs_input",
-          output: [],
-          requiresApproval: null,
-          requiresInput: {
-            type: "input_request",
-            prompt: "Choose a destination",
-            responseSchema: { type: "string" },
-            resumeToken: "input-token-foreign-control",
-          },
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          status: "ok",
-          output: ["unexpected"],
-          requiresApproval: null,
-        }),
-    };
-    const store = createContinuationStore();
-    const creatingTool = createLobsterTool(fakeApi(), {
-      runner,
-      continuationOwner: continuationOwner(store, "session-a"),
-    });
-    await creatingTool.execute("call-input-run", {
-      action: "run",
-      pipeline: "ask --prompt 'Choose a destination'",
-    });
-
-    const foreignTool = createLobsterTool(fakeApi(), {
-      runner,
-      continuationOwner: continuationOwner(store, "session-b"),
-    });
-    await expect(
-      foreignTool.execute("call-input-foreign-resume", {
-        action: "resume",
-        token: "input-token-foreign-control",
-        responseJson: '"archive"',
-      }),
-    ).rejects.toThrow(/continuation belongs to another OpenClaw session/);
-    expect(runner.run).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not return an unbound continuation from one-shot contexts", async () => {
-    const runner = {
-      run: vi.fn().mockResolvedValue({
-        ok: true,
-        status: "needs_input",
-        output: [],
-        requiresApproval: null,
-        requiresInput: {
-          type: "input_request",
-          prompt: "Choose a destination",
-          responseSchema: { type: "string" },
-          resumeToken: "unbound-input-token",
-        },
-      }),
-    };
-    const tool = createLobsterTool(fakeApi(), { runner });
-
-    await expect(
-      tool.execute("call-unbound-input-run", { action: "run", pipeline: "ask" }),
-    ).rejects.toThrow(/requires a bound OpenClaw session/);
   });
 
   it("rejects invalid or ambiguous structured input responses", async () => {
@@ -427,7 +148,6 @@ describe("lobster plugin tool", () => {
     const tool = createLobsterTool(fakeApi(), {
       runner,
       taskFlow,
-      continuationOwner: continuationOwner(),
     });
     const res = await tool.execute("call-default-flow-run", {
       action: "run",
@@ -504,7 +224,6 @@ describe("lobster plugin tool", () => {
     const tool = createLobsterTool(fakeApi(), {
       runner,
       taskFlow,
-      continuationOwner: continuationOwner(),
     });
     await tool.execute("call-default-flow-run", {
       action: "run",

--- a/extensions/lobster/src/lobster-tool.ts
+++ b/extensions/lobster/src/lobster-tool.ts
@@ -15,6 +15,7 @@ import {
   bindLobsterContinuation,
   claimLobsterContinuation,
   releaseLobsterContinuation,
+  reserveLobsterContinuation,
   retireLobsterContinuation,
   type LobsterContinuationOwner,
 } from "./lobster-continuations.js";
@@ -344,42 +345,54 @@ export function createLobsterTool(api: OpenClawPluginApi, options?: LobsterToolO
         action === "resume" && runnerParams.response !== undefined
           ? claimLobsterContinuation(continuationOwner, runnerParams)
           : undefined;
+      const continuationReservation = continuationClaim
+        ? undefined
+        : reserveLobsterContinuation(continuationOwner);
+      const continuationLease = continuationClaim ?? continuationReservation;
+      let continuationLeaseSettled = false;
       let envelope;
       try {
-        envelope = continuationClaim
-          ? await runner.run(runnerParams, {
-              beforeResumeIo: () => {
-                if (!continuationOwner) {
-                  throw new Error("Lobster continuation owner is unavailable");
-                }
-                assertLobsterContinuationClaimCurrent(continuationOwner, continuationClaim);
-              },
-            })
-          : await runner.run(runnerParams);
-      } catch (error) {
-        if (
-          continuationClaim &&
-          continuationOwner &&
-          error instanceof LobsterRunnerError &&
-          error.type === "parse_error"
-        ) {
-          releaseLobsterContinuation(continuationOwner, continuationClaim);
+        try {
+          envelope = continuationClaim
+            ? await runner.run(runnerParams, {
+                beforeResumeIo: () => {
+                  if (!continuationOwner) {
+                    throw new Error("Lobster continuation owner is unavailable");
+                  }
+                  assertLobsterContinuationClaimCurrent(continuationOwner, continuationClaim);
+                },
+              })
+            : await runner.run(runnerParams);
+        } catch (error) {
+          if (
+            continuationClaim &&
+            continuationOwner &&
+            error instanceof LobsterRunnerError &&
+            error.type === "parse_error"
+          ) {
+            releaseLobsterContinuation(continuationOwner, continuationClaim);
+            continuationLeaseSettled = true;
+          }
+          throw error;
         }
-        throw error;
-      }
-      if (!envelope.ok) {
-        if (envelope.error.type === "parse_error" && continuationClaim && continuationOwner) {
-          releaseLobsterContinuation(continuationOwner, continuationClaim);
+        if (!envelope.ok) {
+          if (envelope.error.type === "parse_error" && continuationClaim && continuationOwner) {
+            releaseLobsterContinuation(continuationOwner, continuationClaim);
+            continuationLeaseSettled = true;
+          }
+          throw new Error(envelope.error.message);
         }
-        throw new Error(envelope.error.message);
+        continuationLeaseSettled = bindLobsterContinuation(
+          continuationOwner,
+          envelope,
+          continuationLease,
+        );
+        return jsonResult(envelope);
+      } finally {
+        if (!continuationLeaseSettled && continuationLease && continuationOwner) {
+          retireLobsterContinuation(continuationOwner, continuationLease);
+        }
       }
-      if (continuationClaim && continuationOwner) {
-        // Lobster consumed this checkpoint before returning; retire it first so
-        // a chained input pause can reuse the same slot in a full store.
-        retireLobsterContinuation(continuationOwner, continuationClaim);
-      }
-      bindLobsterContinuation(continuationOwner, envelope);
-      return jsonResult(envelope);
     },
   };
 }

--- a/extensions/lobster/src/lobster-tool.ts
+++ b/extensions/lobster/src/lobster-tool.ts
@@ -11,8 +11,16 @@ import { jsonResult } from "openclaw/plugin-sdk/tool-results";
 import { Type } from "typebox";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import {
+  bindLobsterContinuation,
+  claimLobsterContinuation,
+  releaseLobsterContinuation,
+  retireLobsterContinuation,
+  type LobsterContinuationOwner,
+} from "./lobster-continuations.js";
+import {
   assertLobsterResumeDecision,
   createEmbeddedLobsterRunner,
+  LobsterRunnerError,
   resolveLobsterCwd,
   type LobsterRunner,
   type LobsterRunnerParams,
@@ -28,6 +36,7 @@ import {
 type LobsterToolOptions = {
   runner?: LobsterRunner;
   taskFlow?: BoundTaskFlow;
+  continuationOwner?: LobsterContinuationOwner;
 };
 
 function readOptionalTrimmedString(value: unknown, fieldName: string): string | undefined {
@@ -328,9 +337,33 @@ export function createLobsterTool(api: OpenClawPluginApi, options?: LobsterToolO
       if (action === "resume") {
         assertLobsterResumeDecision(runnerParams);
       }
-      const envelope = await runner.run(runnerParams);
+      const continuationOwner = options?.continuationOwner;
+      // Claim before awaiting Lobster: copied or concurrent credentials must never reach the runtime.
+      const continuationClaim =
+        action === "resume" ? claimLobsterContinuation(continuationOwner, runnerParams) : undefined;
+      let envelope;
+      try {
+        envelope = await runner.run(runnerParams);
+      } catch (error) {
+        if (
+          continuationClaim &&
+          continuationOwner &&
+          error instanceof LobsterRunnerError &&
+          error.type === "parse_error"
+        ) {
+          releaseLobsterContinuation(continuationOwner, continuationClaim);
+        }
+        throw error;
+      }
       if (!envelope.ok) {
+        if (envelope.error.type === "parse_error" && continuationClaim && continuationOwner) {
+          releaseLobsterContinuation(continuationOwner, continuationClaim);
+        }
         throw new Error(envelope.error.message);
+      }
+      bindLobsterContinuation(continuationOwner, envelope);
+      if (continuationClaim && continuationOwner) {
+        retireLobsterContinuation(continuationOwner, continuationClaim);
       }
       return jsonResult(envelope);
     },

--- a/extensions/lobster/src/lobster-tool.ts
+++ b/extensions/lobster/src/lobster-tool.ts
@@ -11,6 +11,7 @@ import { jsonResult } from "openclaw/plugin-sdk/tool-results";
 import { Type } from "typebox";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import {
+  assertLobsterResumeDecision,
   createEmbeddedLobsterRunner,
   resolveLobsterCwd,
   type LobsterRunner,
@@ -71,6 +72,24 @@ function parseOptionalFlowStateJson(value: unknown): JsonLike | undefined {
     return JSON.parse(trimmed) as JsonLike;
   } catch {
     throw new Error("flowStateJson must be valid JSON");
+  }
+}
+
+function parseOptionalResponseJson(value: unknown): unknown {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new Error("responseJson must be a JSON string");
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error("responseJson must be valid JSON");
+  }
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    throw new Error("responseJson must be valid JSON");
   }
 }
 
@@ -167,6 +186,9 @@ function parseManagedFlowParams(
   if (!credentialParams) {
     throw new Error("token or approvalId required when using managed TaskFlow resume mode");
   }
+  if (runnerParams.response !== undefined) {
+    throw new Error("managed TaskFlow resume mode only supports approval decisions");
+  }
   if (approve === undefined) {
     throw new Error("approve required when using managed TaskFlow resume mode");
   }
@@ -209,7 +231,7 @@ export function createLobsterTool(api: OpenClawPluginApi, options?: LobsterToolO
     name: "lobster",
     label: "Lobster Workflow",
     description:
-      "Run Lobster pipelines as a local-first workflow runtime (typed JSON envelope + resumable approvals).",
+      "Run Lobster pipelines as a local-first workflow runtime with typed JSON envelopes, resumable approvals, and structured input requests.",
     parameters: Type.Object({
       action: Type.Enum(["run", "resume"], { type: "string" }),
       pipeline: Type.Optional(Type.String()),
@@ -217,6 +239,12 @@ export function createLobsterTool(api: OpenClawPluginApi, options?: LobsterToolO
       token: Type.Optional(Type.String()),
       approvalId: Type.Optional(Type.String()),
       approve: Type.Optional(Type.Boolean()),
+      responseJson: Type.Optional(
+        Type.String({
+          description:
+            "JSON response matching requiresInput.responseSchema. Use instead of approve when resuming needs_input.",
+        }),
+      ),
       cwd: Type.Optional(
         Type.String({
           description:
@@ -245,6 +273,8 @@ export function createLobsterTool(api: OpenClawPluginApi, options?: LobsterToolO
       const cwd = resolveLobsterCwd(params.cwd);
       const timeoutMs = readPositiveIntegerParam(params, "timeoutMs") ?? 20_000;
       const maxStdoutBytes = readPositiveIntegerParam(params, "maxStdoutBytes") ?? 512_000;
+      const response =
+        action === "resume" ? parseOptionalResponseJson(params.responseJson) : undefined;
 
       if (api.runtime?.version && api.logger?.debug) {
         api.logger.debug(`lobster plugin runtime=${api.runtime.version}`);
@@ -257,6 +287,7 @@ export function createLobsterTool(api: OpenClawPluginApi, options?: LobsterToolO
         ...(typeof params.token === "string" ? { token: params.token } : {}),
         ...(typeof params.approvalId === "string" ? { approvalId: params.approvalId } : {}),
         ...(typeof params.approve === "boolean" ? { approve: params.approve } : {}),
+        ...(response !== undefined ? { response } : {}),
         cwd,
         timeoutMs,
         maxStdoutBytes,
@@ -294,6 +325,9 @@ export function createLobsterTool(api: OpenClawPluginApi, options?: LobsterToolO
         );
       }
 
+      if (action === "resume") {
+        assertLobsterResumeDecision(runnerParams);
+      }
       const envelope = await runner.run(runnerParams);
       if (!envelope.ok) {
         throw new Error(envelope.error.message);

--- a/extensions/lobster/src/lobster-tool.ts
+++ b/extensions/lobster/src/lobster-tool.ts
@@ -373,10 +373,12 @@ export function createLobsterTool(api: OpenClawPluginApi, options?: LobsterToolO
         }
         throw new Error(envelope.error.message);
       }
-      bindLobsterContinuation(continuationOwner, envelope);
       if (continuationClaim && continuationOwner) {
+        // Lobster consumed this checkpoint before returning; retire it first so
+        // a chained input pause can reuse the same slot in a full store.
         retireLobsterContinuation(continuationOwner, continuationClaim);
       }
+      bindLobsterContinuation(continuationOwner, envelope);
       return jsonResult(envelope);
     },
   };

--- a/extensions/lobster/src/lobster-tool.ts
+++ b/extensions/lobster/src/lobster-tool.ts
@@ -11,6 +11,7 @@ import { jsonResult } from "openclaw/plugin-sdk/tool-results";
 import { Type } from "typebox";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import {
+  assertLobsterContinuationClaimCurrent,
   bindLobsterContinuation,
   claimLobsterContinuation,
   releaseLobsterContinuation,
@@ -340,10 +341,21 @@ export function createLobsterTool(api: OpenClawPluginApi, options?: LobsterToolO
       const continuationOwner = options?.continuationOwner;
       // Claim before awaiting Lobster: copied or concurrent credentials must never reach the runtime.
       const continuationClaim =
-        action === "resume" ? claimLobsterContinuation(continuationOwner, runnerParams) : undefined;
+        action === "resume" && runnerParams.response !== undefined
+          ? claimLobsterContinuation(continuationOwner, runnerParams)
+          : undefined;
       let envelope;
       try {
-        envelope = await runner.run(runnerParams);
+        envelope = continuationClaim
+          ? await runner.run(runnerParams, {
+              beforeResumeIo: () => {
+                if (!continuationOwner) {
+                  throw new Error("Lobster continuation owner is unavailable");
+                }
+                assertLobsterContinuationClaimCurrent(continuationOwner, continuationClaim);
+              },
+            })
+          : await runner.run(runnerParams);
       } catch (error) {
         if (
           continuationClaim &&


### PR DESCRIPTION
## What Problem This Solves

The bundled `@clawdbot/lobster` runtime already supports deterministic workflows that pause with `status: "needs_input"`, a prompt, JSON Schema, resume token, and optional subject/defaults. OpenClaw's Lobster adapter rejected that status, so an ordinary workflow reaching an `ask` step could not collect an operator response or resume its saved checkpoint.

Closes #133339

## Why This Change Was Made

Adapt the existing Lobster structured-input envelope and response-resume API instead of duplicating dependency-owned schema validation or checkpoint execution. OpenClaw supplies host-session admission; compatibility at full continuation capacity is still unresolved as described below.

## Root Cause And Canonical Fix

The adapter normalized approval checkpoints but treated the dependency's structured-input envelope as unsupported. The dependency already owns schema validation and checkpoint execution, so duplicating either in OpenClaw would create a second protocol.

This change keeps one canonical flow:

- preserve the dependency-owned `requiresInput` envelope at the embedded runner boundary
- add bounded `responseJson` input at the model-facing Lobster tool
- delegate validation and execution to `resumeToolRequest({ response })`
- reserve one continuation slot before every embedded run or resume that can return structured input, so a full reject-new namespace fails before dependency side effects or checkpoint creation
- bind only structured-input tokens to the creating OpenClaw `sessionKey` + lifecycle `sessionId`
- atomically replace the reserved or bound row with a generation-tagged binding/claim instead of allocating a second row
- preserve one fixed absolute checkpoint deadline across claim and dependency `parse_error` release
- reread the authoritative latest session and verify the exact claim immediately before dependency resume I/O
- reuse the same claimed slot for chained input and release reservations/claims on every non-input or error path
- retain Lobster's existing sessionless approval-token and approval-ID behavior
- keep managed Task Flow approval-only and fail visibly if it encounters structured input

No parallel validator, raw-token store, config surface, protocol version, migration, or SQLite schema change was added. The earlier approval-binding path was removed after review showed it would break valid sessionless approval checkpoints.

## Existing-Solution And Dependency Preflight

OpenProse and generic user-input surfaces cannot resume a Lobster checkpoint. `@clawdbot/lobster@2026.6.11` is the existing implementation and remains the runtime owner.

The dependency contract is independently inspectable at its exact public release:

- OpenClaw pins [`@clawdbot/lobster` `2026.6.11`](https://github.com/openclaw/openclaw/blob/ddf39cc2197142019088c0c0ea8fb2f2e4f7b3e3/extensions/lobster/package.json#L11), matching [Lobster v2026.6.11](https://github.com/openclaw/lobster/releases/tag/v2026.6.11), commit [`86b8cc20a867`](https://github.com/openclaw/lobster/commit/86b8cc20a867f18c08ae8e3f4fec9ee7d52bf8c9).
- [`token.ts:3`](https://github.com/openclaw/lobster/blob/86b8cc20a867f18c08ae8e3f4fec9ee7d52bf8c9/src/token.ts#L3) serializes token payload JSON to base64url; it has no signature, owner, lifecycle binding, or expiry.
- [`pipeline_resume_state.ts:140`](https://github.com/openclaw/lobster/blob/86b8cc20a867f18c08ae8e3f4fec9ee7d52bf8c9/src/pipeline_resume_state.ts#L140) persists the input checkpoint and returns a token containing protocol/version/kind/`stateKey`.
- [`tool_runtime.ts:151`](https://github.com/openclaw/lobster/blob/86b8cc20a867f18c08ae8e3f4fec9ee7d52bf8c9/src/core/tool_runtime.ts#L151) accepts token or approval ID plus approve/response/cancel and generic runtime context; it has no host-session owner.
- [`tool_runtime.ts:247`](https://github.com/openclaw/lobster/blob/86b8cc20a867f18c08ae8e3f4fec9ee7d52bf8c9/src/core/tool_runtime.ts#L247) loads persisted state, validates an input response as `parse_error` before later stages execute, then resumes the pipeline.
- [`state/store.ts:250`](https://github.com/openclaw/lobster/blob/86b8cc20a867f18c08ae8e3f4fec9ee7d52bf8c9/src/state/store.ts#L250) implements approval ID as a reverse index to the same `stateKey`.

Lobster therefore remains the correct owner of response validation and checkpoint execution. OpenClaw owns only host-session admission for structured-input replies at its trusted tool-context boundary.

## User Impact

Operators can run an ordinary Lobster workflow that pauses for a schema-validated response and resume without replaying earlier deterministic stages.

Structured-input continuations:

- work only in the exact OpenClaw session lifecycle that created them
- cannot reach Lobster after `/new`, `/reset`, foreign-session copy, concurrent claim, or terminal replay
- expire at the original seven-day checkpoint deadline; invalid-response retries cannot renew it
- allow correction when Lobster rejects a response as pre-execution `parse_error`

Preserving existing approval-token and approval-ID behavior is a requirement, not a completed claim: the latest review identifies a full-capacity resume regression. Managed TaskFlow structured-input support remains out of scope.

## Security And Lifecycle Boundary

`extensions/lobster/src/lobster-continuations.ts` owns the OpenClaw binding:

1. Before embedded execution, OpenClaw reserves one random `slot:<uuid>` row containing the exact session owner, lease generation, and expiry. An already-full 10,000-row reject-new namespace therefore fails before Lobster can execute stages or create a checkpoint.
2. A `needs_input` result atomically transforms that same slot into a binding carrying only the SHA-256 credential digest. The raw token and Lobster `stateKey` are not copied into OpenClaw SQLite. Resume finds the digest within the bounded namespace and atomically changes the same row into a generation-tagged claim.
3. `expiresAt` is the checkpoint's fixed absolute seven-day deadline. Claim and dependency `parse_error` release reuse only the remaining TTL, so invalid responses cannot renew retention. The namespace keeps `overflowPolicy: "reject-new"`; expired records free capacity without evicting live continuations.
4. The embedded runner may await runtime loading, so a `beforeResumeIo` hook rereads `getSessionEntry({ readConsistency: "latest" })` and verifies the exact live claim immediately before `resumeToolRequest`.
5. Chained `needs_input` atomically reuses the claimed row. Non-input results and every error path release the reservation or retire the claim; ambiguous failures therefore remain fail-closed through this adapter.
6. The earlier binding-record shape existed only on this unmerged feature branch and is not reachable from a release tag. The repair changes no SQLite schema and needs no shipped-state migration.

Residual boundary: Lobster's dependency-owned raw checkpoint files have no TTL/sweep API. Expiring the OpenClaw binding makes the raw bearer unreachable through this adapter and bounds OpenClaw's 10,000-entry namespace, but it does not delete Lobster's checkpoint file. Solving dependency-file retention requires an upstream Lobster lifecycle API; this PR does not store raw bearer material or reach into dependency-private state.

## Latest ClawSweeper Rank-Up Moves

Historical repair notes follow. The newer September 3 review still identifies an unresolved full-capacity approval-token/approval-ID resume regression and requests Lobster-owner sponsorship; these notes do not claim those items are resolved:

- **Preserve the original deadline:** the absolute `expiresAt` is stored once and carried through claim/release; a parent-red/head-green near-expiry regression and real SQLite proof show invalid input cannot renew it.
- **Provide exact-head runtime proof:** Node 24.19.0 exercised plugin registration, the production tool, pinned Lobster runtime, SQLite reopen, full 10,000-row capacity, invalid-response release, expiry rejection, and direct dependency recovery on the current head.
- **Reserve before dependency execution:** an initial reservation now consumes the future binding slot before Lobster runs; an exactly-full namespace rejects before the runner, while non-input/error paths release it.
- **Keep claim capacity-neutral:** reservation, binding, claim, parse-error release, and chained-input handoff are in-place updates of one slot; exact-limit tests cover 10,000-row resume plus a one-slot chained handoff.
- **Prevent stale-claim ABA:** each claim has a unique generation; release, retire, and pre-I/O checks require the exact owner, generation, and deadline.
- **Preserve sessionless approvals:** continuation binding/claiming applies only when `responseJson` resumes a structured-input checkpoint. Ordinary approval run/resume remains on the existing runner path.
- **Revalidate after claim:** the latest session and exact authoritative claim are checked after awaited runtime loading and immediately before embedded `resumeToolRequest`.

## Evidence

### Current-head Status (2026-09-05)

- Current product head: `5164c56b611f48849498234f07efad294649ece3`. No code or tests were changed or rerun for this description correction.
- The September 3 exact-head review reports that ordinary approval-token and approval-ID resumes reserve a new continuation slot and can fail before the runner when the 10,000-row namespace is full. Both credential forms still need regression coverage and a compatible capacity strategy.
- Lobster-owner sponsorship remains unconfirmed. The later retention suggestion is contributor feedback, not an accepted change to expiry or eviction policy.
- A prior receipt printed `5164c56b611f4b00a4d2ffbc878e7154790c02b1`, which does not match the remote head. Its claim of exact-head linkage is withdrawn; the historical observations below have not been independently rerun against the current full SHA.

### Historical Receipt (Exact-head Linkage Not Reverified)

- The current product identity is listed above; the former receipt's full-SHA attribution is not relied on.
- Original acceptance red: current `main` throws `Lobster input requests are not supported by the OpenClaw Lobster tool yet`
- Security red on parent `487024ddff27`: a foreign `sessionId` could submit a copied valid input token and reach the runner
- Capacity red on parent `375e052c22afb92e0e7abb67578807da4508528a`: valid resume at exactly 10,000 rows, one-slot chained handoff, and stale-claim ABA each fail the new regression tests
- Deadline red on parent `71cf337ab14d479119b70ee1e2ecc9858857056f`: a response rejected one millisecond before expiry renewed the continuation and the post-deadline resume unexpectedly succeeded
- Initial-capacity red on parent `a5d9564d101d8b2b10b8802f5eeb00b0c2a890fa`: with all 10,000 rows occupied, the runner still executed and could create a dependency checkpoint before host binding failed
- Canonical entry: `extensions/lobster/src/lobster-tool.ts` -> `createLobsterTool(...).execute`
- OpenClaw ownership boundary: `extensions/lobster/src/lobster-continuations.ts`
- Dependency boundary: `extensions/lobster/src/lobster-runner.ts` -> published `@clawdbot/lobster/core`

### Real dependency + durable SQLite proof (previous exact head)

The live receipt below was captured on `375e052c22afb92e0e7abb67578807da4508528a` before the capacity-only state-machine repair. The current head preserves the same session/SQLite boundary and adds parent-red/head-green capacity proof below.

An isolated Node 24 harness exercised the real plugin registration path, production tool, published `@clawdbot/lobster@2026.6.11`, real session SQLite, and real plugin-state SQLite.

It created a dependency input checkpoint, began resume, rebound the same `sessionKey` from session A to B while runtime loading was awaited, and proved rejection before dependency resume I/O. A direct dependency resume then succeeded, proving the rejected OpenClaw call had not consumed the checkpoint. It also reopened SQLite, inspected the exact TTL/redacted value, and exercised real short-TTL capacity recovery. Temporary state and proof files were removed.

```json
{
  "realDependencyCheckpoint": true,
  "indexLatestSessionLookup": true,
  "rebindRejectedBeforeResumeIo": true,
  "dependencyCheckpointStillResumable": true,
  "sqliteBindingHasTtl": true,
  "sqliteOmitsRawToken": true,
  "sqliteReopenPreservedBinding": true,
  "expiryCapacityRecovers": true
}
```

### Historical Full-store Preflight Proof

Node 24.15.0 ran behavioral repair head `46e98d3851bcf779feb1a9030a6255af6812b882` through the production `createLobsterTool(...).execute` owner with the keyed-store contract at its exact 10,000-row limit. The earlier maintenance record reported two numeric-assertion changes, 15/15 continuation tests, and an assertion-safety ratchet pass across 4,098 files. Its full-SHA attribution was incorrect; these results are not presented as newly verified current-head evidence.

`a5d9564d101d` acceptance-red failed 1/13: the full store still called the runner once. The repaired head passed 15/15 continuation tests and proved the runner was never called, the store stayed at exactly 10,000 rows, a 9,999-row run could reserve then bind its final slot, a full-store resume and chained input reused one slot, duplicate bindings remained one-time, and success/error paths released reservations.

The installed `@clawdbot/lobster@2026.6.11` source was inspected directly: its runtime finalizes and writes the input checkpoint before returning the token, its checkpoint key is a fresh UUID, and the token is only base64url-encoded checkpoint payload. This confirms the host must reserve before invoking the dependency.

### Capacity + fixed-deadline proof (previous exact head)

An isolated Node 24.19.0 harness ran exact head `ddf39cc2197142019088c0c0ea8fb2f2e4f7b3e3` through the plugin registration factory, production model-facing tool, published `@clawdbot/lobster@2026.6.11` embedded runtime, and real plugin-state SQLite. It filled the reject-new namespace to exactly 10,000 rows, resumed a real dependency input checkpoint without allocating a claim row, reopened SQLite, advanced the host clock to one millisecond before the stored deadline, submitted a real schema-invalid response, and proved both SQLite and the serialized value retained the original deadline. At the deadline, OpenClaw rejected the token while a direct dependency resume still succeeded, proving the adapter had not consumed it. Temporary state and proof files were removed.

```json
{
  "exactHead": "ddf39cc2197142019088c0c0ea8fb2f2e4f7b3e3",
  "node": "v24.19.0",
  "realPluginRegistration": true,
  "pinnedLobsterNeedsInput": true,
  "sqliteRowsAtCapacity": 10000,
  "capacityNeutralResume": true,
  "rawTokenOmittedFromSqlite": true,
  "sqliteReopenPreservedDeadline": true,
  "invalidResponsePreservedDeadline": true,
  "expiredAdapterResumeRejected": true,
  "dependencyCheckpointStillResumable": true
}
```

- Capacity parent red: copying the three capacity regressions onto `375e052c22afb92e0e7abb67578807da4508528a` produced exactly three failures
- Deadline parent red: the new near-expiry regression failed on `71cf337ab14d479119b70ee1e2ecc9858857056f` because the post-deadline resume resolved instead of rejecting
- Head green: continuation state-machine suite passed 15/15; continuation + model-facing tool + embedded runner passed 85/85
- Pinned dependency suite: published Lobster `request_input.test.js` passed 27/27, including chained input suspensions
- Focused Lobster `tsgo`, direct `oxlint`, `oxfmt`, `git diff --check`, and local P0 autoreview: passed

### Focused verification

- Historical reported verification (not rerun on the current head): `npx --yes node@24.15.0 scripts/run-vitest.mjs extensions/lobster/src/lobster-continuations.test.ts --run`: 15 tests passed; `check-assertion-safety-ratchet.mts`, `oxfmt --check`, and `git diff --check` passed
- Behavioral repair head: continuation + model-facing tool + embedded runner, 3 files / 85 tests passed
- Historical reported verification (not rerun on the current head): `node_modules/.bin/tsgo -p extensions/lobster/tsconfig.json --noEmit`: passed
- Previous live-proof head: runner/tool/continuation/TaskFlow suite passed 4 files, 91 tests
- direct `oxlint` with `config/tsconfig/oxlint.extensions.json`: passed for all changed Lobster TypeScript files
- `oxfmt --check`: passed for all changed files
- `node scripts/check-docs-mdx.mjs docs README.md`: 792 files passed
- `git diff --check`: passed

Must-not-fire coverage includes foreign-session copy, concurrent claim, terminal replay, session rotation during awaited runtime load, unbound one-shot contexts, expired continuations, approval-path compatibility, corrected retry after dependency `parse_error`, and near-expiry retry without deadline renewal.

## Scope And Test Audit

- 12 files, `+1749/-55` total
- production TypeScript: `+637/-20` (net `+617`)
- tests: `+1039/-18` (net `+1021`)
- docs/skill: `+73/-17` (net `+56`)
- initial-capacity repair round: production `+183/-69` (net `+114`); tests `+139/-0`
- earlier capacity repair round: production `+84/-99` (net `-15`); tests `+149/-1`
- fixed-deadline repair round: production `+70/-18` (net `+52`); tests `+60/-1`
- config/default/protocol/schema/permission/migration/SQLite-schema impact: none
- production growth justification: this adds a concrete structured-input capability plus host-session ownership, generation safety, and a non-renewable absolute deadline absent from the bearer-only dependency; the latest positive delta persists and enforces that deadline without adding a store, schema, fallback, or parallel validator
- sibling coverage: ordinary approval, structured input, cancel/terminal outcomes, managed TaskFlow projection, dependency loading, model-context bounds, invalid/ambiguous responses, SQLite reopen, TTL expiry, and final-effect session rotation
- test-audit rationale: tests protect the real model-facing tool and dependency I/O boundaries; the runner hook is a production lifecycle seam used by the default embedded runner, not a test-only seam

Not claimed: live channel presentation, managed TaskFlow structured-input persistence, or dependency-owned checkpoint-file cleanup.

