### PR TITLE
fix: reject unsupported Testbox no-sync runs

### DIFF
--- a/.agents/skills/openclaw-testing/SKILL.md
+++ b/.agents/skills/openclaw-testing/SKILL.md
@@ -161,9 +161,10 @@ sync the current checkout on every run, and stop it before handoff.
   coordinating with another lane. If Testbox queues, fails capacity, or cannot
   allocate, report the blocker or switch to direct AWS Crabbox only when that
   still proves the requested surface.
-- Reuse does not mean stale source: omit `--no-sync` so every run uploads the
-  current checkout. Use `--no-sync` only to rerun an unchanged, already-synced
-  tree intentionally.
+- Blacksmith Testbox owns sync, including reused `--id` runs. Do not pass
+  `--no-sync`; the wrapper rejects it before delegation. Verify the materialized
+  candidate tree before exact-source proof and keep QA evidence outside the
+  synced checkout. Do not bypass security exclusions or silently change providers.
 
 ## Local Development Proof
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1125,10 +1125,9 @@ for later remote commands, sync the current checkout on every run, and stop it
 before handoff.
 
 Crabbox-backed Blacksmith runs warm, claim, sync, run, report, and clean up
-one-shot Testboxes. The built-in sync sanity check fails fast when
-`git status --short` on the synced box shows at least 200 tracked deletions,
-which catches disappearing root files such as `pnpm-lock.yaml`. For intentional
-large-deletion PRs, set `CRABBOX_ALLOW_MASS_DELETIONS=1` for the remote command.
+one-shot Testboxes. Native Blacksmith owns synchronization; Crabbox's direct
+SSH sync controls and mass-deletion sanity checks do not run on this delegated
+path.
 
 Crabbox also terminates a local Blacksmith CLI invocation that stays in the
 sync phase for more than five minutes without post-sync output. Set
@@ -1141,7 +1140,7 @@ Before a first run, check the wrapper from the repo root:
 node scripts/crabbox-wrapper.mjs run --help | sed -n '1,120p'
 ```
 
-The repo wrapper refuses a stale Crabbox binary that does not advertise the selected provider, and Blacksmith-backed runs require Crabbox 0.22.0 or newer so the wrapper gets the current Testbox sync, queue, and cleanup behavior. In Codex worktrees or linked/sparse checkouts, avoid the local `pnpm crabbox:run` script because pnpm may reconcile dependencies before Crabbox starts; invoke the node wrapper directly instead:
+The repo wrapper validates the selected Crabbox binary and provider before running. In Codex worktrees or linked/sparse checkouts, avoid the local `pnpm crabbox:run` script because pnpm may reconcile dependencies before Crabbox starts; invoke the node wrapper directly instead:
 
 ```bash
 node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --timing-json --shell -- "pnpm test <path-or-filter>"
@@ -1215,9 +1214,16 @@ node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --id <tbx_id>
 pnpm crabbox:stop -- <tbx_id>
 ```
 
-Reuse the lease, not stale source. Omit `--no-sync` so each run uploads the
-current checkout; use it only to rerun an unchanged, already-synced tree
-intentionally. Untrusted contributor/fork code must use
+Reuse the lease, not stale source. Blacksmith Testbox owns sync, including
+reused `--id` runs. Do not pass `--no-sync`: the wrapper rejects it before
+lease handling or delegation. A fingerprint cache hit is not a no-sync guarantee.
+
+Sync success is not proof of source identity. Verify the materialized Git tree
+before exact-candidate proof. Keep QA evidence outside the synced checkout and
+download it before another run. Do not bypass security exclusions, accept a
+mismatched tree, or silently switch providers.
+
+Untrusted contributor/fork code must use
 `CRABBOX_ENV_ALLOW=CI`, `--provider aws --no-hydrate`, and a fresh
 temporary remote `HOME` for every command; install dependencies inside that
 sanitized command before testing. Reuse only a newly warmed lease dedicated to

--- a/scripts/crabbox-wrapper.mts
+++ b/scripts/crabbox-wrapper.mts
@@ -3765,9 +3765,7 @@ function injectRemoteTestboxBootstrap(commandArgs: string[], providerName: strin
   if (invocation.start < 0) {
     return commandArgs;
   }
-  const snapshot = hasOption(commandArgs, "--no-sync")
-    ? ""
-    : `if [ -n "$(git status --porcelain=v1)" ]; then git add -A && git -c user.name=OpenClaw -c user.email=ci@openclaw.local -c commit.gpgsign=false commit --no-verify -qm remote-testbox-sync || exit $?; fi; `;
+  const snapshot = `if [ -n "$(git status --porcelain=v1)" ]; then git add -A && git -c user.name=OpenClaw -c user.email=ci@openclaw.local -c commit.gpgsign=false commit --no-verify -qm remote-testbox-sync || exit $?; fi; `;
   return replaceRunCommandWithShell(
     invocation,
     `${snapshot}export CI=true; ${renderRunShellCommand(invocation)}`,
@@ -3924,6 +3922,14 @@ if (provider && !isProviderAdvertised(provider, providers)) {
 }
 
 if (canonicalProvider === "blacksmith-testbox") {
+  // Testbox owns sync; reject before lease or checkout side effects.
+  if (normalizedArgs[0] === "run" && hasOption(normalizedArgs, "--no-sync")) {
+    console.error(
+      "[crabbox] provider=blacksmith-testbox does not support --no-sync. Omit the flag only when source synchronization is intended.",
+    );
+    process.exit(2);
+  }
+
   if (isWindowsRemoteTarget(normalizedArgs)) {
     console.error(
       [

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -1592,6 +1592,51 @@ describe("scripts/crabbox-wrapper", () => {
     expect(result.stderr).not.toContain("failed fast; reusable leases expire");
   });
 
+  it.each([
+    ["--no-sync"],
+    ["-no-sync=true"],
+    ["--no-sync=false"],
+    ["--id", "tbx_unused", "--no-sync"],
+  ])("rejects unsupported Testbox sync flags before delegation: %j", (...flags) => {
+    const invocationLog = makeInvocationLog();
+    const result = runDefaultWrapper(["run", ...flags, "--", "echo ok"], {
+      configJson: { provider: "blacksmith-testbox" },
+      env: {
+        OPENCLAW_FAKE_CRABBOX_INVOCATION_LOG: invocationLog,
+        OPENCLAW_FAKE_CRABBOX_RUN_STATUS: "99",
+      },
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("provider=blacksmith-testbox does not support --no-sync");
+    expect(readInvocations(invocationLog).filter(([command]) => command === "run")).toEqual([]);
+  });
+
+  it.each([
+    { provider: "aws", flags: ["--no-sync"], command: ["echo", "ok"] },
+    { provider: "blacksmith-testbox", flags: [], command: ["echo", "--no-sync"] },
+    { provider: "blacksmith-testbox", flags: ["--label", "--no-sync"], command: ["echo", "ok"] },
+  ])(
+    "preserves sync flags outside Testbox run options: $provider $flags $command",
+    ({ provider, flags, command }) => {
+      const { output } = runSuccessfulDefaultWrapper([
+        "run",
+        "--provider",
+        provider,
+        ...flags,
+        "--",
+        ...command,
+      ]);
+
+      if (flags.length > 0) {
+        expect(output.args).toContain("--no-sync");
+      } else {
+        expect(output.args.at(-1)).toContain("echo --no-sync");
+      }
+    },
+  );
+
   it("requires a current Crabbox binary for Blacksmith Testbox runs", () => {
     const result = runDefaultWrapper(["run", "--provider", "blacksmith-testbox", "--", "echo ok"], {
       env: { OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.21.9" },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers requesting a Testbox run with `--no-sync` could still synchronize and delete remote files. The wrapper treated the flag as meaningful during preparation even though native Testbox execution owns synchronization.

## Why This Change Was Made

Reject the unsupported Testbox option before lease handling, checkout preparation, or delegation, and remove the unreachable snapshot-skip branch. Keep documentation and agent guidance focused on the current contract rather than tool-version history.

This is a command-admission fix, not a repair of native full/checksum synchronization. Provider selection and security exclusions are unchanged.

## User Impact

Unsupported Testbox no-sync requests fail clearly without starting a remote command. Normal Testbox runs, direct-provider no-sync requests, and command arguments that merely contain the flag text keep their existing behavior. Guidance distinguishes successful synchronization from verified source identity and keeps QA evidence outside the synchronized checkout.

## Evidence

- Isolated native-provider reproduction confirmed that a no-sync request still transferred changed input, removed 19 tracked public source paths, and deleted synthetic remote-only QA evidence.
- Four rejection regressions failed on the pre-fix wrapper; direct-provider, option-value, and command-payload controls passed.
- Fresh isolated Testbox validation: all **276 wrapper tests passed** ([lease workflow](https://github.com/openclaw/openclaw/actions/runs/33321568731)); the complete changed gate, script/test typechecks, lint, formatting, and docs listing passed on [the follow-up lease](https://github.com/openclaw/openclaw/actions/runs/33321742102).
- Both proof phases used candidate tree `65047c567f8aef0b8d74415b6f0e47b9cc539f10`, reconstructed outside the native synchronized root. The changed-gate run verified that exact tree before and after execution. The first changed-gate attempt lacked the fixture's `origin/main` ref; corrected the proof setup and reran successfully without product changes. Both leases were stopped. The linked Actions runs own hydration/cleanup; the delegated command output is the test result.
- Fresh Codex autoreview: scoped-clean, no accepted/actionable findings. `git diff --check` passed. No OpenClaw runtime, tests, or builds ran on the controller.

Commands executed inside the isolated Testbox checkout:

```bash
node scripts/run-vitest.mjs test/scripts/crabbox-wrapper.test.ts --reporter=dot
```

```bash
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 CI=1 node scripts/check-changed.mjs -- scripts/crabbox-wrapper.mts test/scripts/crabbox-wrapper.test.ts docs/ci.md .agents/skills/openclaw-testing/SKILL.md
```

```bash
pnpm docs:list
```

Production/tooling LOC: +9/-3 (net +6). Tests: +45/-0. The added production lines enforce the unsupported-option admission boundary; no new configuration, dependencies, exports, or synchronization path.
