### PR TITLE
improve: update initialized transcript windows directly

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-import.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-import.test.ts
@@ -165,6 +165,9 @@ it("deduplicates existing and incoming bytes and identities, preserves aliases, 
     const stages = observeStages();
     await importSqliteSessionRows({ ...params, readTranscriptEvents: (append) => append(first) });
     const db = openOpenClawAgentDatabase({ agentId: "main", env: state.env }).db;
+    db.prepare("UPDATE session_windows SET created_at = 7 WHERE session_id = ?").run(
+      params.entry.sessionId,
+    );
     const generation = db.prepare("SELECT generation FROM transcript_rewrite_watermarks").get();
     expect(await importSqliteSessionRows({ ...params, readTranscriptEvents })).toMatchObject({
       transcriptEvents: 2,
@@ -188,7 +191,10 @@ it("deduplicates existing and incoming bytes and identities, preserves aliases, 
     expect(
       db.prepare("SELECT event_id FROM transcript_event_identities ORDER BY seq").all(),
     ).toEqual([{ event_id: "one" }, { event_id: "two" }]);
-    expect(db.prepare("SELECT updated_at FROM session_windows").get()).toEqual({ updated_at: 99 });
+    expect(db.prepare("SELECT created_at, updated_at FROM session_windows").get()).toEqual({
+      created_at: 7,
+      updated_at: 99,
+    });
     expect(db.prepare("SELECT generation FROM transcript_rewrite_watermarks").get()).toEqual(
       generation,
     );

--- a/src/config/sessions/session-accessor.sqlite-transcript-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-state.ts
@@ -181,15 +181,6 @@ export function ensureTranscriptSessionRoot(
     );
     publishSessionEntryCacheInvalidation(database);
   }
-  upsertTranscriptSessionWindowInTransaction(database, scope, updatedAt);
-}
-
-export function upsertTranscriptSessionWindowInTransaction(
-  database: OpenClawAgentDatabase,
-  scope: ResolvedTranscriptScope,
-  updatedAt: number,
-): void {
-  const db = getSessionKysely(database.db);
   executeSqliteQuerySync(
     database.db,
     db

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -32,7 +32,6 @@ import {
   readNextTranscriptSeq,
   rotateTranscriptGenerationInTransaction,
   touchTranscriptMutationInTransaction,
-  upsertTranscriptSessionWindowInTransaction,
 } from "./session-accessor.sqlite-transcript-state.js";
 import {
   createTranscriptIndexAppenderInTransaction,
@@ -83,9 +82,15 @@ function appendTranscriptEvent(
   const db = getSessionKysely(database.db);
   const createdAt = readEventTimestamp(persistedEvent) ?? Date.now();
   if (cursor.initialized) {
-    // Even rejected identities update window recency. Only root/generation setup
-    // is shared by the synchronous batch; per-attempt writes stay in order.
-    upsertTranscriptSessionWindowInTransaction(database, scope, createdAt);
+    // The first attempt established this window and the batch cannot delete it.
+    // Even rejected identities update recency; keep each attempt's write in order.
+    executeSqliteQuerySync(
+      database.db,
+      db
+        .updateTable("session_windows")
+        .set({ updated_at: createdAt })
+        .where("session_id", "=", scope.sessionId),
+    );
   } else {
     ensureTranscriptSessionRoot(database, scope, createdAt, {
       allowStoredAlias: options.allowStoredAlias === true,


### PR DESCRIPTION
## What Problem This Solves

Transcript imports repeatedly execute a full session-window INSERT/ON CONFLICT after the batch has already established that row. Each subsequent attempt only needs to update recency. This follows #133350.

## Why This Change Was Made

The canonical append owner now directly updates the existing window after its batch cursor is initialized. The first attempt still performs the unchanged root/window UPSERT and generation setup. Every later attempt still writes recency before identity rejection, in the same order and transaction. The now-single-use upsert helper is folded back into root setup.

## User Impact

This avoids redundant insert/conflict work without changing schema, indexes, transaction boundaries, durability, concurrency, or stored-data semantics. It covers migration and the existing prepared-array batch callers; single-event appends, exact SQLite handoff, replacement, identity checks, and rollback remain unchanged.

## Evidence

67 focused tests passed across importer, generic append/media, active projections, parent forks, message cuts, recovery, and context eligibility. The existing importer dedupe case now also checks that original creation time survives repeated recency updates; rejected events still produce the final timestamp 99 after 99/50/99 attempts. Existing empty-store batch coverage verifies first-window creation. Changed-file lint and formatting passed. Codex review and independent owner/caller review found no actionable defect.

Production delta: +9/-13 (net -4); tests +7/-1 (net +6). No new dependency, configuration, cache, or query-binding abstraction.

Matched isolated Linux benchmark on Node 24.19.0 / SQLite 3.53.3, with three fresh processes per variant and shape and interleaved before/after order. Both bundles share the same checkout and dependencies; the before bundle substitutes only the two changed production modules from baseline `7515f08a53180ffd277d5f72b81524a937bbf9b0`.

| Synthetic shape | Before median | After median | Improvement |
| --- | ---: | ---: | ---: |
| 100,000-event deep transcript | 6,380 ms | 5,930 ms | 7.1% |
| 100 sessions × 100 events | 701 ms | 658 ms | 6.1% |
| Branching transcripts | 1,057 ms | 997 ms | 5.7% |

CPU medians improved 6.5%, 5.3%, and 4.7%, respectively. Every matched pair produced identical digests over deterministic transcript-event, identity, window-metadata, active-projection, and FTS fields. The trace kept 100,034 total calls and changed only the expected window shapes: 10,001 upserts became 1 initial upsert plus 10,000 direct updates. All other statement call counts matched. Before/after Node CPU profiles completed separately from median measurements. These are importer timings, not whole-upgrade gains; local timings affected by host saturation were excluded.

Packaged Docker upgrade from stable `2026.7.1-2` to the exact candidate `218501ec4204ff461ced041a3e648170c1d2338b` passed. The lane completed in 527 seconds and verified 4,800 sessions, 1,227,946 events, and 10,000 cron jobs across five complete state assertions. Automatic migration passed before standalone Doctor or the fixture's explicit capability-consent repair. Eight Gateway history samples across two agents (600 messages) matched before/after restart. Repeat Doctor took 39 seconds within its 60-second budget. Candidate build metadata verifies the commit. [Proof worker](https://github.com/openclaw/openclaw/actions/runs/33322283232) was stopped after successful commands and local artifact collection.

This covers an explicit stable-to-candidate package update and automatic data migration, not unattended channel switching. No operator state or live Gateway was touched. [Exact-head CI passed on attempt 2](https://github.com/openclaw/openclaw/actions/runs/33322321417).

CI follow-up: `src/skills/workshop/service.test.ts:1011` assumes reject/quarantine receive distinct millisecond timestamps. Its store intentionally orders timestamp ties by proposal ID (`store.ts:420`), so equal timestamps can swap two correctly persisted statuses. The first CI attempt hit this unrelated ordering assertion; the unchanged head passed a bounded failed-job retry. The importer patch does not change this store. Named follow-up: make Workshop status/scoping tests independent of timestamp ties, including the similar assertion at line 774.

ClawSweeper found no actionable defect. Its sole Rank-up move—complete exact-head checks—is satisfied by the CI result above.
