### PR TITLE
fix(telegram): acknowledge durably queued callbacks promptly

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -582,6 +582,8 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     Callback action values not claimed by a registered plugin interactive handler are passed to the agent as text: `callback_data: <value>`.
 
+    With durable ingress, OpenClaw sends the callback acknowledgement after storing the update, without waiting for earlier handlers in that chat's lane. Telegram clears its loading indicator when the acknowledgement succeeds; the button's action still follows normal authorization and ordered processing.
+
   </Accordion>
 
   <Accordion title="Telegram message actions for agents and automation">
@@ -819,7 +821,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     The listener reserves `/healthz` for health checks, so `webhookPath` must use a different route. If an existing setup uses `/healthz`, choose another route, update the path in `webhookUrl` and the reverse proxy mapping, then restart OpenClaw.
 
-    In long-polling mode, OpenClaw persists its restart watermark only after an update dispatches successfully; a failed handler leaves that update retryable in the same process instead of marking it completed.
+    In the default isolated long-polling mode, OpenClaw persists its restart watermark after an update is committed to the durable ingress queue. A failed handler remains retryable from that queue. Classic polling (`polling.isolated: false`) advances its watermark after dispatch succeeds.
 
     The local listener binds to `127.0.0.1:8787` by default. For public ingress, put a reverse proxy in front of the local port, or set `webhookHost: "0.0.0.0"` intentionally.
 

--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -52,7 +52,10 @@ import type { TelegramUpdateKeyContext } from "./bot-updates.js";
 import { apiThrottler, Bot, sequentialize, type ApiClientOptions } from "./bot.runtime.js";
 import type { TelegramBotOptions } from "./bot.types.js";
 import { buildTelegramGroupPeerId } from "./bot/helpers.js";
-import { setTelegramCallbackQueryAnswerPromise } from "./callback-query-answer-state.js";
+import {
+  setTelegramCallbackQueryAnswerPromise,
+  takeTelegramCallbackQueryAdmissionAnswer,
+} from "./callback-query-answer-state.js";
 import { TELEGRAM_CHAT_ACTION_INTERVAL_MS } from "./chat-action-timing.js";
 import {
   asTelegramClientFetch,
@@ -233,14 +236,15 @@ export function createTelegramBotCore(
     }
   });
 
-  // Answer callback queries immediately before sequentialize queues them behind
-  // agent turns for the same chat/topic. Telegram has a ~15s server-side timeout
-  // for answerCallbackQuery; if an agent turn is already processing, sequentialize
-  // delays the answer beyond that window and the user sees a stuck loading spinner.
+  // Durable transports start the answer after spool commit; classic polling and
+  // restart replay start it here. Both paths must beat same-lane sequentialization
+  // or Telegram expires answerCallbackQuery while an agent turn is still running.
   bot.use(async (ctx, next) => {
     const callback = ctx.callbackQuery;
     if (callback) {
-      const answerPromise = bot.api.answerCallbackQuery(callback.id);
+      const answerPromise =
+        takeTelegramCallbackQueryAdmissionAnswer(bot, callback.id) ??
+        bot.api.answerCallbackQuery(callback.id);
       setTelegramCallbackQueryAnswerPromise(ctx, answerPromise);
       void answerPromise.catch(() => {});
     }

--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -54,6 +54,7 @@ import type { TelegramBotOptions } from "./bot.types.js";
 import { buildTelegramGroupPeerId } from "./bot/helpers.js";
 import {
   setTelegramCallbackQueryAnswerPromise,
+  startTelegramCallbackQueryAnswer,
   takeTelegramCallbackQueryAdmissionAnswer,
 } from "./callback-query-answer-state.js";
 import { TELEGRAM_CHAT_ACTION_INTERVAL_MS } from "./chat-action-timing.js";
@@ -237,14 +238,14 @@ export function createTelegramBotCore(
   });
 
   // Durable transports start the answer after spool commit; classic polling and
-  // restart replay start it here. Both paths must beat same-lane sequentialization
-  // or Telegram expires answerCallbackQuery while an agent turn is still running.
+  // restart replay start it here. Both paths precede same-lane sequentialization
+  // so callback acknowledgements cannot wait for earlier handlers.
   bot.use(async (ctx, next) => {
     const callback = ctx.callbackQuery;
     if (callback) {
       const answerPromise =
         takeTelegramCallbackQueryAdmissionAnswer(bot, callback.id) ??
-        bot.api.answerCallbackQuery(callback.id);
+        startTelegramCallbackQueryAnswer(bot, callback.id, false);
       setTelegramCallbackQueryAnswerPromise(ctx, answerPromise);
       void answerPromise.catch(() => {});
     }

--- a/extensions/telegram/src/bot-handlers.callback-router.ts
+++ b/extensions/telegram/src/bot-handlers.callback-router.ts
@@ -46,7 +46,10 @@ import {
   withResolvedTelegramForumFlag,
 } from "./bot/helpers.js";
 import type { TelegramContext, TelegramGetChat } from "./bot/types.js";
-import { getTelegramCallbackQueryAnswerPromise } from "./callback-query-answer-state.js";
+import {
+  getTelegramCallbackQueryAnswerPromise,
+  startTelegramCallbackQueryAnswer,
+} from "./callback-query-answer-state.js";
 import { buildCommandsPaginationKeyboard, buildTelegramModelsMenuButtons } from "./command-ui.js";
 import { resolveTelegramInlineButtonsScope } from "./inline-buttons.js";
 import {
@@ -101,14 +104,11 @@ export function createTelegramCallbackRouter({
       return;
     }
     let callbackAnswered = false;
-    const answerCallbackQuery = async (text?: string) => {
+    const answerCallbackQuery = async () => {
       await withTelegramApiErrorLogging({
         operation: "answerCallbackQuery",
         runtime,
-        fn: () =>
-          text
-            ? bot.api.answerCallbackQuery(callback.id, { text })
-            : bot.api.answerCallbackQuery(callback.id),
+        fn: () => startTelegramCallbackQueryAnswer(bot, callback.id, false),
       }).catch(() => {});
       callbackAnswered = true;
     };

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -34,6 +34,10 @@ import {
 } from "./bot.test-helpers.js";
 import type { TelegramBotOptions } from "./bot.types.js";
 import type { TelegramGetChat } from "./bot/types.js";
+import {
+  recordTelegramCallbackQueryAdmissionAnswer,
+  takeTelegramCallbackQueryAdmissionAnswer,
+} from "./callback-query-answer-state.js";
 import { buildTelegramOpaqueCallbackData } from "./native-command-callback-data.js";
 import type { TelegramPollRegistryEntry } from "./poll-registry.js";
 import type { TelegramRuntime } from "./runtime.types.js";
@@ -816,6 +820,41 @@ describe("createTelegramBot", () => {
 
     expect(replySpy).toHaveBeenCalledTimes(1);
     expect(answerCallbackQuerySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses the callback answer started at durable admission", async () => {
+    const bot = createTelegramBot({ token: "tok" });
+    const callbackId = "cbq-durable-admission-1";
+    recordTelegramCallbackQueryAdmissionAnswer(bot, callbackId, Promise.resolve(true));
+    answerCallbackQuerySpy.mockClear();
+
+    await runTelegramMiddlewareChain({
+      ctx: makeGenericCallbackContext({ id: callbackId, updateId: 403 }),
+      finalHandler: async () => {},
+    });
+
+    expect(answerCallbackQuerySpy).not.toHaveBeenCalled();
+    expect(takeTelegramCallbackQueryAdmissionAnswer(bot, callbackId)).toBeUndefined();
+  });
+
+  it("re-answers a durable callback after bot restart loses admission state", async () => {
+    const callbackId = "cbq-restart-replay-1";
+    const stoppedBot = createTelegramBot({ token: "tok" });
+    recordTelegramCallbackQueryAdmissionAnswer(stoppedBot, callbackId, Promise.resolve(true));
+    middlewareUseSpy.mockClear();
+    createTelegramBot({ token: "tok" });
+    answerCallbackQuerySpy.mockClear();
+    const ctx = makeGenericCallbackContext({ id: callbackId, updateId: 404 });
+
+    await withTelegramSpooledReplayUpdate(
+      requireRecord(ctx.update, "callback update"),
+      async () => {
+        await runTelegramMiddlewareChain({ ctx, finalHandler: async () => {} });
+      },
+    );
+
+    expect(answerCallbackQuerySpy).toHaveBeenCalledOnce();
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith(callbackId);
   });
 
   it("acknowledges question callbacks before their handler completes", async () => {

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -35,7 +35,7 @@ import {
 import type { TelegramBotOptions } from "./bot.types.js";
 import type { TelegramGetChat } from "./bot/types.js";
 import {
-  recordTelegramCallbackQueryAdmissionAnswer,
+  startTelegramCallbackQueryAnswer,
   takeTelegramCallbackQueryAdmissionAnswer,
 } from "./callback-query-answer-state.js";
 import { buildTelegramOpaqueCallbackData } from "./native-command-callback-data.js";
@@ -825,25 +825,25 @@ describe("createTelegramBot", () => {
   it("reuses the callback answer started at durable admission", async () => {
     const bot = createTelegramBot({ token: "tok" });
     const callbackId = "cbq-durable-admission-1";
-    recordTelegramCallbackQueryAdmissionAnswer(bot, callbackId, Promise.resolve(true));
-    answerCallbackQuerySpy.mockClear();
+    await startTelegramCallbackQueryAnswer(bot, callbackId, true);
 
     await runTelegramMiddlewareChain({
       ctx: makeGenericCallbackContext({ id: callbackId, updateId: 403 }),
       finalHandler: async () => {},
     });
 
-    expect(answerCallbackQuerySpy).not.toHaveBeenCalled();
+    expect(answerCallbackQuerySpy).toHaveBeenCalledOnce();
     expect(takeTelegramCallbackQueryAdmissionAnswer(bot, callbackId)).toBeUndefined();
   });
 
   it("re-answers a durable callback after bot restart loses admission state", async () => {
     const callbackId = "cbq-restart-replay-1";
     const stoppedBot = createTelegramBot({ token: "tok" });
-    recordTelegramCallbackQueryAdmissionAnswer(stoppedBot, callbackId, Promise.resolve(true));
+    await startTelegramCallbackQueryAnswer(stoppedBot, callbackId, true);
     middlewareUseSpy.mockClear();
-    createTelegramBot({ token: "tok" });
-    answerCallbackQuerySpy.mockClear();
+    const restartedBot = createTelegramBot({ token: "tok" });
+    const pendingAnswer = createDeferred<true>();
+    answerCallbackQuerySpy.mockImplementationOnce(() => pendingAnswer.promise);
     const ctx = makeGenericCallbackContext({ id: callbackId, updateId: 404 });
 
     await withTelegramSpooledReplayUpdate(
@@ -853,8 +853,16 @@ describe("createTelegramBot", () => {
       },
     );
 
-    expect(answerCallbackQuerySpy).toHaveBeenCalledOnce();
-    expect(answerCallbackQuerySpy).toHaveBeenCalledWith(callbackId);
+    try {
+      const duplicate = startTelegramCallbackQueryAnswer(restartedBot, callbackId, false);
+      expect(duplicate).toBe(pendingAnswer.promise);
+      expect(answerCallbackQuerySpy).toHaveBeenCalledTimes(2);
+      expect(answerCallbackQuerySpy).toHaveBeenCalledWith(callbackId);
+    } finally {
+      pendingAnswer.resolve(true);
+      await pendingAnswer.promise;
+    }
+    expect(takeTelegramCallbackQueryAdmissionAnswer(restartedBot, callbackId)).toBeUndefined();
   });
 
   it("acknowledges question callbacks before their handler completes", async () => {

--- a/extensions/telegram/src/callback-query-answer-state.ts
+++ b/extensions/telegram/src/callback-query-answer-state.ts
@@ -1,6 +1,44 @@
 const TELEGRAM_CALLBACK_QUERY_ANSWER_PROMISE = Symbol.for(
   "openclaw.telegram.callbackQueryAnswerPromise",
 );
+// Durable admission precedes bot middleware. Keep only new-row answers until
+// that same bot consumes them; the WeakMap releases all state with the bot.
+const telegramCallbackQueryAdmissionAnswers = new WeakMap<object, Map<string, Promise<unknown>>>();
+
+export function recordTelegramCallbackQueryAdmissionAnswer(
+  bot: object,
+  callbackQueryId: string,
+  promise: Promise<unknown>,
+): void {
+  const existingAnswers = telegramCallbackQueryAdmissionAnswers.get(bot);
+  const answers = existingAnswers ?? new Map<string, Promise<unknown>>();
+  if (!existingAnswers) {
+    telegramCallbackQueryAdmissionAnswers.set(bot, answers);
+  }
+  answers.set(callbackQueryId, promise);
+  void promise.catch(() => {
+    if (answers.get(callbackQueryId) === promise) {
+      answers.delete(callbackQueryId);
+    }
+  });
+}
+
+export function getTelegramCallbackQueryAdmissionAnswer(
+  bot: object,
+  callbackQueryId: string,
+): Promise<unknown> | undefined {
+  return telegramCallbackQueryAdmissionAnswers.get(bot)?.get(callbackQueryId);
+}
+
+export function takeTelegramCallbackQueryAdmissionAnswer(
+  bot: object,
+  callbackQueryId: string,
+): Promise<unknown> | undefined {
+  const answers = telegramCallbackQueryAdmissionAnswers.get(bot);
+  const promise = answers?.get(callbackQueryId);
+  answers?.delete(callbackQueryId);
+  return promise;
+}
 
 export function setTelegramCallbackQueryAnswerPromise(
   ctx: object,

--- a/extensions/telegram/src/callback-query-answer-state.ts
+++ b/extensions/telegram/src/callback-query-answer-state.ts
@@ -1,43 +1,60 @@
 const TELEGRAM_CALLBACK_QUERY_ANSWER_PROMISE = Symbol.for(
   "openclaw.telegram.callbackQueryAnswerPromise",
 );
-// Durable admission precedes bot middleware. Keep only new-row answers until
-// that same bot consumes them; the WeakMap releases all state with the bot.
-const telegramCallbackQueryAdmissionAnswers = new WeakMap<object, Map<string, Promise<unknown>>>();
+type CallbackQueryAnswer = {
+  promise: Promise<unknown>;
+  pending: boolean;
+  retainUntilDispatch: boolean;
+};
+// Consuming an answer must not stop coalescing in-flight requests. Only new rows
+// retain settled answers: duplicate admissions may be tombstones that never dispatch.
+const telegramCallbackQueryAnswers = new WeakMap<object, Map<string, CallbackQueryAnswer>>();
 
-export function recordTelegramCallbackQueryAdmissionAnswer(
-  bot: object,
+export function startTelegramCallbackQueryAnswer(
+  bot: { api: { answerCallbackQuery: (id: string) => Promise<unknown> } },
   callbackQueryId: string,
-  promise: Promise<unknown>,
-): void {
-  const existingAnswers = telegramCallbackQueryAdmissionAnswers.get(bot);
-  const answers = existingAnswers ?? new Map<string, Promise<unknown>>();
-  if (!existingAnswers) {
-    telegramCallbackQueryAdmissionAnswers.set(bot, answers);
+  retainUntilDispatch: boolean,
+): Promise<unknown> {
+  let answers = telegramCallbackQueryAnswers.get(bot);
+  if (!answers) {
+    answers = new Map();
+    telegramCallbackQueryAnswers.set(bot, answers);
   }
-  answers.set(callbackQueryId, promise);
-  void promise.catch(() => {
-    if (answers.get(callbackQueryId) === promise) {
-      answers.delete(callbackQueryId);
-    }
-  });
-}
-
-export function getTelegramCallbackQueryAdmissionAnswer(
-  bot: object,
-  callbackQueryId: string,
-): Promise<unknown> | undefined {
-  return telegramCallbackQueryAdmissionAnswers.get(bot)?.get(callbackQueryId);
+  const existing = answers.get(callbackQueryId);
+  if (existing) {
+    return existing.promise;
+  }
+  const answer = {
+    promise: bot.api.answerCallbackQuery(callbackQueryId),
+    pending: true,
+    retainUntilDispatch,
+  };
+  answers.set(callbackQueryId, answer);
+  void answer.promise.then(
+    () => {
+      answer.pending = false;
+      if (!answer.retainUntilDispatch) {
+        answers.delete(callbackQueryId);
+      }
+    },
+    () => answers.delete(callbackQueryId),
+  );
+  return answer.promise;
 }
 
 export function takeTelegramCallbackQueryAdmissionAnswer(
   bot: object,
   callbackQueryId: string,
 ): Promise<unknown> | undefined {
-  const answers = telegramCallbackQueryAdmissionAnswers.get(bot);
-  const promise = answers?.get(callbackQueryId);
-  answers?.delete(callbackQueryId);
-  return promise;
+  const answers = telegramCallbackQueryAnswers.get(bot);
+  const answer = answers?.get(callbackQueryId);
+  if (answer) {
+    answer.retainUntilDispatch = false;
+    if (!answer.pending) {
+      answers?.delete(callbackQueryId);
+    }
+  }
+  return answer?.promise;
 }
 
 export function setTelegramCallbackQueryAnswerPromise(

--- a/extensions/telegram/src/telegram-ingress-callback.integration.test.ts
+++ b/extensions/telegram/src/telegram-ingress-callback.integration.test.ts
@@ -1,0 +1,286 @@
+// Real grammY command handling and SQLite ingress, with a loopback Telegram API.
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import { createServer, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import type { Message } from "grammy/types";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
+import { expect, it, vi } from "vitest";
+import { defaultTelegramBotDeps } from "./bot-deps.js";
+import { telegramBotInfoForTest } from "./bot.create-telegram-bot.test-support.js";
+import { createTelegramBot } from "./bot.js";
+import { runTelegramChannelInboundEventWithHarness } from "./bot.test-helpers.js";
+import * as callbackQueryAnswerState from "./callback-query-answer-state.js";
+import { setTelegramRuntime } from "./runtime.js";
+import {
+  clearTelegramRuntimeForTest,
+  resetTelegramAccountThrottlersForTest,
+} from "./runtime.test-support.js";
+import type { TelegramRuntime } from "./runtime.types.js";
+import { createTelegramTransportIngressMonitor } from "./telegram-ingress-drain-factory.js";
+import { openTelegramIngressQueue } from "./telegram-ingress-spool.js";
+
+const downstream = vi.hoisted(() =>
+  vi.fn(async (_ctx: MsgContext) => ({
+    queuedFinal: false,
+    counts: { block: 0, final: 0, tool: 0 },
+  })),
+);
+
+vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>();
+  return {
+    ...actual,
+    runChannelInboundEvent: async (params: Parameters<typeof actual.runChannelInboundEvent>[0]) =>
+      await runTelegramChannelInboundEventWithHarness(
+        actual,
+        params,
+        async (dispatchParams) => await downstream(dispatchParams.ctx),
+      ),
+  };
+});
+
+it.each(["none", "middleware", "handler"] as const)(
+  "answers a callback during a native menu request with %s ACK recovery",
+  async (recovery) => {
+    downstream.mockClear();
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "telegram-native-admission-"));
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    resetPluginStateStoreForTests({ closeDatabase: false });
+    resetTelegramAccountThrottlersForTest();
+    setTelegramRuntime({
+      state: {
+        openChannelIngressQueue: (
+          options?: Omit<Parameters<typeof createChannelIngressQueueForTests>[0], "channelId">,
+        ) => createChannelIngressQueueForTests({ ...options, channelId: "telegram" }),
+        openKeyedStore: ((options) =>
+          createPluginStateKeyedStoreForTests(
+            "telegram",
+            options,
+          )) as TelegramRuntime["state"]["openKeyedStore"],
+      },
+      channel: {},
+    } as TelegramRuntime);
+
+    const requests: Array<{ method: string; payload: Record<string, unknown> }> = [];
+    const runtimeErrors: unknown[] = [];
+    let menu: Message.TextMessage | undefined;
+    let heldMenuResponse: ServerResponse | undefined;
+    const heldAnswerResponses: ServerResponse[] = [];
+    let releaseAnswers = recovery === "none";
+    const sendResult = (response: ServerResponse, result: unknown) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ ok: true, result }));
+    };
+    const server = createServer((request, response) => {
+      void (async () => {
+        const chunks: Buffer[] = [];
+        for await (const chunk of request) {
+          chunks.push(Buffer.from(chunk));
+        }
+        const payload = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<
+          string,
+          unknown
+        >;
+        const method = request.url?.split("/").at(-1) ?? "";
+        requests.push({ method, payload });
+        if (method === "answerCallbackQuery" && !releaseAnswers) {
+          const answerCount = requests.filter((entry) => entry.method === method).length;
+          if (recovery === "middleware" && answerCount === 1) {
+            response.writeHead(503, { "content-type": "application/json" });
+            response.end(
+              JSON.stringify({ ok: false, error_code: 503, description: "ACK unavailable" }),
+            );
+          } else {
+            heldAnswerResponses.push(response);
+          }
+          return;
+        }
+        if (method === "sendMessage" && payload.reply_markup) {
+          menu = {
+            message_id: 80,
+            date: 1_736_380_800,
+            chat: { id: 111, type: "private", first_name: "Ada" },
+            from: telegramBotInfoForTest,
+            text: String(payload.text),
+            reply_markup: payload.reply_markup as Message.TextMessage["reply_markup"],
+          };
+          heldMenuResponse = response;
+          return;
+        }
+        sendResult(response, true);
+      })().catch((error: unknown) =>
+        response.destroy(error instanceof Error ? error : new Error(String(error))),
+      );
+    });
+    const telegramTransport = { fetch, sourceFetch: fetch, close: async () => {} };
+    let monitor: ReturnType<typeof createTelegramTransportIngressMonitor> | undefined;
+    const readHandlerAnswer = vi.spyOn(
+      callbackQueryAnswerState,
+      "getTelegramCallbackQueryAnswerPromise",
+    );
+    try {
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const apiRoot = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+      const cfg: OpenClawConfig = {
+        commands: { native: true, nativeSkills: false },
+        channels: { telegram: { apiRoot, dmPolicy: "open", allowFrom: ["*"] } },
+        session: { store: path.join(stateDir, "sessions.json") },
+      };
+      const bot = createTelegramBot({
+        token: "123456:loopback-token",
+        botInfo: telegramBotInfoForTest,
+        config: cfg,
+        telegramTransport,
+        telegramDeps: {
+          ...defaultTelegramBotDeps,
+          getRuntimeConfig: () => cfg,
+          listSkillCommandsForAgents: () => [],
+          readChannelAllowFromStore: async () => [],
+        },
+        runtime: {
+          log: () => {},
+          error: (error) => runtimeErrors.push(error),
+          exit: () => {
+            throw new Error("unexpected runtime exit");
+          },
+        },
+      });
+      const answerRequests = vi.spyOn(bot.api, "answerCallbackQuery");
+      const spoolDir = path.join(stateDir, "telegram", "ingress-spool-default");
+      monitor = createTelegramTransportIngressMonitor({
+        spoolDir,
+        bot,
+        cfg,
+        accountId: "default",
+        botInfo: telegramBotInfoForTest,
+        pollIntervalMs: 10,
+        onError: (error) => runtimeErrors.push(error),
+      });
+      const queue = openTelegramIngressQueue(spoolDir);
+      const actor = { id: 111, is_bot: false, first_name: "Ada" };
+      monitor.start();
+      await monitor.admit({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          date: 1_736_380_800,
+          chat: { id: 111, type: "private", first_name: "Ada" },
+          from: actor,
+          text: "/usage",
+          entities: [{ type: "bot_command", offset: 0, length: 6 }],
+        },
+      });
+      await vi.waitFor(
+        () => expect(menu, `native menu not sent: ${runtimeErrors.join("; ")}`).toBeDefined(),
+        { timeout: 5_000, interval: 10 },
+      );
+      expect(await queue.listClaims()).toHaveLength(1);
+      expect(downstream).not.toHaveBeenCalled();
+      const button = menu?.reply_markup?.inline_keyboard
+        .flat()
+        .find((entry) => "callback_data" in entry && entry.callback_data === "tgcmd:/usage off");
+      expect(button).toBeDefined();
+      const callbackUpdate = {
+        update_id: 2,
+        callback_query: {
+          id: "native-menu-callback",
+          chat_instance: "native-menu-chat",
+          from: actor,
+          message: menu,
+          data: button && "callback_data" in button ? button.callback_data : undefined,
+        },
+      };
+      await monitor.admit(callbackUpdate);
+      await vi.waitFor(
+        () =>
+          expect(requests.filter(({ method }) => method === "answerCallbackQuery")).toHaveLength(1),
+        { timeout: 1_000, interval: 10 },
+      );
+      expect(await queue.listClaims()).toHaveLength(1);
+      expect(await queue.listPending({ limit: "all" })).toHaveLength(1);
+      expect(downstream).not.toHaveBeenCalled();
+      if (recovery !== "none") {
+        if (recovery === "middleware") {
+          const firstAnswer = answerRequests.mock.results[0]?.value;
+          expect(firstAnswer).toBeDefined();
+          await expect(firstAnswer).rejects.toThrow("ACK unavailable");
+        }
+        expect(heldMenuResponse).toBeDefined();
+        sendResult(heldMenuResponse!, menu);
+        heldMenuResponse = undefined;
+        if (recovery === "handler") {
+          // Let the real router consume the pending admission answer before rejecting it.
+          await vi.waitFor(() => expect(readHandlerAnswer).toHaveBeenCalled(), { interval: 10 });
+          const firstResponse = heldAnswerResponses.shift();
+          expect(firstResponse).toBeDefined();
+          firstResponse!.writeHead(503, { "content-type": "application/json" });
+          firstResponse!.end(
+            JSON.stringify({ ok: false, error_code: 503, description: "ACK unavailable" }),
+          );
+        }
+        await vi.waitFor(() => expect(answerRequests).toHaveBeenCalledTimes(2), { interval: 10 });
+        await monitor.admit(callbackUpdate);
+        await monitor.admit(callbackUpdate);
+        releaseAnswers = true;
+        for (const response of heldAnswerResponses) {
+          sendResult(response, true);
+        }
+        await Promise.allSettled(answerRequests.mock.results.map((result) => result.value));
+        const callbackRequests = requests.filter(({ method }) => method === "answerCallbackQuery");
+        console.log(
+          "CALLBACK_RECOVERY_HTTP_PROOF",
+          JSON.stringify({ recovery, requests: callbackRequests.length }),
+        );
+        expect(callbackRequests).toHaveLength(2);
+        expect(
+          callbackQueryAnswerState.takeTelegramCallbackQueryAdmissionAnswer(
+            bot,
+            "native-menu-callback",
+          ),
+        ).toBeUndefined();
+      }
+    } finally {
+      releaseAnswers = true;
+      for (const response of heldAnswerResponses) {
+        if (!response.writableEnded) {
+          sendResult(response, true);
+        }
+      }
+      if (heldMenuResponse && !heldMenuResponse.writableEnded) {
+        sendResult(heldMenuResponse, menu);
+      }
+      await monitor?.waitForIdle();
+      await monitor?.stop();
+      readHandlerAnswer.mockRestore();
+      await telegramTransport.close();
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+      clearTelegramRuntimeForTest();
+      resetTelegramAccountThrottlersForTest();
+      closeOpenClawStateDatabaseForTest();
+      resetPluginStateStoreForTests({ closeDatabase: false });
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+    expect(runtimeErrors).toEqual([]);
+    expect(downstream).toHaveBeenCalledOnce();
+  },
+);

--- a/extensions/telegram/src/telegram-ingress-drain-factory.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain-factory.test.ts
@@ -28,6 +28,7 @@ const { createTelegramTransportIngressMonitor } =
   await import("./telegram-ingress-drain-factory.js");
 
 type CapturedMonitor = {
+  onDurableAdmission: (update: unknown, context: { isNew: boolean }) => void | Promise<void>;
   dispatch: (
     update: unknown,
     lifecycle: TelegramIngressDrainLifecycle,
@@ -37,6 +38,28 @@ type CapturedMonitor = {
 describe("Telegram transport ingress outcome handoff", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("reuses an in-flight callback answer for duplicate durable admission", async () => {
+    const answerCallbackQuery = vi.fn(() => new Promise<true>(() => {}));
+    const bot = {
+      handleUpdate: vi.fn(async () => {}),
+      api: { answerCallbackQuery },
+    };
+    createTelegramTransportIngressMonitor({
+      spoolDir: "/tmp/telegram-ingress-proof",
+      bot,
+      cfg: {} as OpenClawConfig,
+      accountId: "default",
+    });
+    const monitor = mocks.createTelegramIngressMonitor.mock.calls[0]?.[0] as CapturedMonitor;
+    const update = { update_id: 122, callback_query: { id: "callback-122" } };
+
+    await monitor.onDurableAdmission(update, { isNew: true });
+    await monitor.onDurableAdmission(update, { isNew: false });
+
+    expect(answerCallbackQuery).toHaveBeenCalledOnce();
+    expect(answerCallbackQuery).toHaveBeenCalledWith("callback-122");
   });
 
   it.each([
@@ -52,6 +75,7 @@ describe("Telegram transport ingress outcome handoff", () => {
             recordTelegramMessageProcessingResult(outcome);
           });
         }),
+        api: { answerCallbackQuery: vi.fn(async () => true) },
       };
       createTelegramTransportIngressMonitor({
         spoolDir: "/tmp/telegram-ingress-proof",
@@ -74,6 +98,7 @@ describe("Telegram transport ingress outcome handoff", () => {
       handleUpdate: vi.fn(async () => {
         await runWithTelegramUpdateProcessingFrame(async () => {});
       }),
+      api: { answerCallbackQuery: vi.fn(async () => true) },
     };
     createTelegramTransportIngressMonitor({
       spoolDir: "/tmp/telegram-ingress-proof",
@@ -96,6 +121,7 @@ describe("Telegram transport ingress outcome handoff", () => {
           ensureTelegramMessageProcessingResult({ kind: "completed" });
         });
       }),
+      api: { answerCallbackQuery: vi.fn(async () => true) },
     };
     createTelegramTransportIngressMonitor({
       spoolDir: "/tmp/telegram-ingress-proof",

--- a/extensions/telegram/src/telegram-ingress-drain-factory.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain-factory.test.ts
@@ -1,5 +1,9 @@
-/** Verifies the grammY-to-durable-ingress terminal outcome handoff. */
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+/** Verifies callback admission and the grammY terminal outcome handoff. */
+import { once } from "node:events";
+import { createServer, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { Api } from "grammy";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ensureTelegramMessageProcessingResult,
@@ -7,6 +11,7 @@ import {
   runWithTelegramUpdateProcessingFrame,
   type TelegramMessageProcessingResult,
 } from "./bot-processing-outcome.js";
+import { takeTelegramCallbackQueryAdmissionAnswer } from "./callback-query-answer-state.js";
 import type { TelegramIngressDrainLifecycle } from "./telegram-ingress-drain.js";
 
 const mocks = vi.hoisted(() => ({
@@ -40,27 +45,136 @@ describe("Telegram transport ingress outcome handoff", () => {
     vi.clearAllMocks();
   });
 
-  it("reuses an in-flight callback answer for duplicate durable admission", async () => {
-    const answerCallbackQuery = vi.fn(() => new Promise<true>(() => {}));
-    const bot = {
-      handleUpdate: vi.fn(async () => {}),
-      api: { answerCallbackQuery },
-    };
-    createTelegramTransportIngressMonitor({
-      spoolDir: "/tmp/telegram-ingress-proof",
-      bot,
-      cfg: {} as OpenClawConfig,
-      accountId: "default",
-    });
-    const monitor = mocks.createTelegramIngressMonitor.mock.calls[0]?.[0] as CapturedMonitor;
-    const update = { update_id: 122, callback_query: { id: "callback-122" } };
-
-    await monitor.onDurableAdmission(update, { isNew: true });
-    await monitor.onDurableAdmission(update, { isNew: false });
-
-    expect(answerCallbackQuery).toHaveBeenCalledOnce();
-    expect(answerCallbackQuery).toHaveBeenCalledWith("callback-122");
-  });
+  it.each([
+    {
+      name: "after a rejected new-row answer",
+      rejectNewAnswer: true,
+      startNewPending: false,
+      consumePending: false,
+      expectedRequests: 2,
+    },
+    {
+      name: "for an existing durable row",
+      rejectNewAnswer: false,
+      startNewPending: false,
+      consumePending: false,
+      expectedRequests: 1,
+    },
+    {
+      name: "while middleware consumes a pending answer",
+      rejectNewAnswer: false,
+      startNewPending: true,
+      consumePending: true,
+      expectedRequests: 1,
+    },
+    {
+      name: "before middleware consumes a new-row answer",
+      rejectNewAnswer: false,
+      startNewPending: true,
+      consumePending: false,
+      expectedRequests: 1,
+    },
+  ])(
+    "coalesces duplicate callback answers $name",
+    async ({ rejectNewAnswer, startNewPending, consumePending, expectedRequests }) => {
+      const callbackId = "callback-redelivered";
+      const requestIds: string[] = [];
+      const pendingResponses: ServerResponse[] = [];
+      const answerRequests: Promise<true>[] = [];
+      const pendingAnswer = createDeferred<void>();
+      let releaseAnswers = false;
+      const sendAnswer = (response: ServerResponse) => {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ ok: true, result: true }));
+      };
+      const server = createServer((request, response) => {
+        let body = "";
+        request.setEncoding("utf8");
+        request.on("data", (chunk: string) => {
+          body += chunk;
+        });
+        request.on("end", () => {
+          const payload = JSON.parse(body) as { callback_query_id: string };
+          requestIds.push(payload.callback_query_id);
+          if (rejectNewAnswer && requestIds.length === 1) {
+            response.writeHead(503, { "content-type": "application/json" });
+            response.end(
+              JSON.stringify({ ok: false, error_code: 503, description: "ACK unavailable" }),
+            );
+            return;
+          }
+          pendingResponses.push(response);
+          pendingAnswer.resolve();
+          if (releaseAnswers) {
+            sendAnswer(response);
+          }
+        });
+      });
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address() as AddressInfo;
+      const api = new Api("1000000:test-token", { apiRoot: `http://127.0.0.1:${address.port}` });
+      const bot = {
+        handleUpdate: vi.fn(async () => {}),
+        api: {
+          answerCallbackQuery: (id: string) => {
+            const answer = api.answerCallbackQuery(id);
+            answerRequests.push(answer);
+            return answer;
+          },
+        },
+      };
+      createTelegramTransportIngressMonitor({
+        spoolDir: "/tmp/telegram-ingress-proof",
+        bot,
+        cfg: {},
+        accountId: "default",
+      });
+      const monitor = mocks.createTelegramIngressMonitor.mock.calls[0]?.[0] as CapturedMonitor;
+      const update = { update_id: 125, callback_query: { id: callbackId } };
+      try {
+        if (rejectNewAnswer) {
+          await monitor.onDurableAdmission(update, { isNew: true });
+          const initialAnswers = await Promise.allSettled(answerRequests);
+          expect(initialAnswers).toMatchObject([{ status: "rejected" }]);
+        }
+        if (startNewPending) {
+          await monitor.onDurableAdmission(update, { isNew: true });
+          await pendingAnswer.promise;
+          if (consumePending) {
+            expect(takeTelegramCallbackQueryAdmissionAnswer(bot, callbackId)).toBeDefined();
+          }
+        }
+        await monitor.onDurableAdmission(update, { isNew: false });
+        await pendingAnswer.promise;
+        await monitor.onDurableAdmission(update, { isNew: false });
+        releaseAnswers = true;
+        for (const response of pendingResponses) {
+          sendAnswer(response);
+        }
+        await Promise.allSettled(answerRequests);
+        expect(requestIds).toEqual(Array.from({ length: expectedRequests }, () => callbackId));
+        expect(bot.handleUpdate).not.toHaveBeenCalled();
+        if (startNewPending && !consumePending) {
+          expect(takeTelegramCallbackQueryAdmissionAnswer(bot, callbackId)).toBeDefined();
+        }
+        // Tombstones never dispatch; their settled answers must not remain per bot.
+        expect(takeTelegramCallbackQueryAdmissionAnswer(bot, callbackId)).toBeUndefined();
+      } finally {
+        releaseAnswers = true;
+        for (const response of pendingResponses) {
+          if (!response.writableEnded) {
+            sendAnswer(response);
+          }
+        }
+        await Promise.allSettled(answerRequests);
+        server.closeAllConnections();
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    },
+  );
 
   it.each([
     { kind: "completed" as const },
@@ -80,7 +194,7 @@ describe("Telegram transport ingress outcome handoff", () => {
       createTelegramTransportIngressMonitor({
         spoolDir: "/tmp/telegram-ingress-proof",
         bot,
-        cfg: {} as OpenClawConfig,
+        cfg: {},
         accountId: "default",
       });
       const monitor = mocks.createTelegramIngressMonitor.mock.calls[0]?.[0] as CapturedMonitor;
@@ -103,7 +217,7 @@ describe("Telegram transport ingress outcome handoff", () => {
     createTelegramTransportIngressMonitor({
       spoolDir: "/tmp/telegram-ingress-proof",
       bot,
-      cfg: {} as OpenClawConfig,
+      cfg: {},
       accountId: "default",
     });
     const monitor = mocks.createTelegramIngressMonitor.mock.calls[0]?.[0] as CapturedMonitor;
@@ -126,7 +240,7 @@ describe("Telegram transport ingress outcome handoff", () => {
     createTelegramTransportIngressMonitor({
       spoolDir: "/tmp/telegram-ingress-proof",
       bot,
-      cfg: {} as OpenClawConfig,
+      cfg: {},
       accountId: "default",
     });
     const monitor = mocks.createTelegramIngressMonitor.mock.calls[0]?.[0] as CapturedMonitor;

--- a/extensions/telegram/src/telegram-ingress-drain-factory.ts
+++ b/extensions/telegram/src/telegram-ingress-drain-factory.ts
@@ -1,10 +1,15 @@
 // Telegram plugin module builds transport-shared durable ingress monitors.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { TelegramBotInfo } from "./bot-info.js";
 import {
   runWithTelegramUpdateProcessingFrame,
   type TelegramMessageProcessingResult,
 } from "./bot-processing-outcome.js";
+import {
+  getTelegramCallbackQueryAdmissionAnswer,
+  recordTelegramCallbackQueryAdmissionAnswer,
+} from "./callback-query-answer-state.js";
 import {
   createTelegramIngressMonitor,
   resolveTelegramAdoptionStallTimeoutMs,
@@ -14,6 +19,9 @@ import { openTelegramIngressQueue } from "./telegram-ingress-spool.js";
 
 type TelegramSpooledBot = {
   handleUpdate: (update: never) => Promise<void>;
+  api: {
+    answerCallbackQuery: (callbackQueryId: string) => Promise<unknown>;
+  };
 };
 
 type CreateTelegramTransportIngressMonitorParams = {
@@ -59,6 +67,29 @@ export function createTelegramTransportIngressMonitor(
     ...(params.onLog ? { onLog: params.onLog } : {}),
     ...(params.onError ? { onError: params.onError } : {}),
     ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
+    // Core runs this after append commit and before claim, so callback acknowledgement
+    // cannot erase Telegram's redelivery path or wait behind the handler lane.
+    onDurableAdmission: (update, context) => {
+      if (!isRecord(update)) {
+        return;
+      }
+      const callbackQuery = update.callback_query;
+      if (!isRecord(callbackQuery)) {
+        return;
+      }
+      const callbackQueryId = callbackQuery.id;
+      if (typeof callbackQueryId !== "string" || callbackQueryId.trim().length === 0) {
+        return;
+      }
+      if (!context.isNew && getTelegramCallbackQueryAdmissionAnswer(params.bot, callbackQueryId)) {
+        return;
+      }
+      const answerPromise = params.bot.api.answerCallbackQuery(callbackQueryId);
+      if (context.isNew) {
+        recordTelegramCallbackQueryAdmissionAnswer(params.bot, callbackQueryId, answerPromise);
+      }
+      void answerPromise.catch(() => {});
+    },
     dispatch: async (update, lifecycle) => {
       if (params.dispatchUpdate) {
         return await params.dispatchUpdate(update, lifecycle);

--- a/extensions/telegram/src/telegram-ingress-drain-factory.ts
+++ b/extensions/telegram/src/telegram-ingress-drain-factory.ts
@@ -6,10 +6,7 @@ import {
   runWithTelegramUpdateProcessingFrame,
   type TelegramMessageProcessingResult,
 } from "./bot-processing-outcome.js";
-import {
-  getTelegramCallbackQueryAdmissionAnswer,
-  recordTelegramCallbackQueryAdmissionAnswer,
-} from "./callback-query-answer-state.js";
+import { startTelegramCallbackQueryAnswer } from "./callback-query-answer-state.js";
 import {
   createTelegramIngressMonitor,
   resolveTelegramAdoptionStallTimeoutMs,
@@ -81,14 +78,7 @@ export function createTelegramTransportIngressMonitor(
       if (typeof callbackQueryId !== "string" || callbackQueryId.trim().length === 0) {
         return;
       }
-      if (!context.isNew && getTelegramCallbackQueryAdmissionAnswer(params.bot, callbackQueryId)) {
-        return;
-      }
-      const answerPromise = params.bot.api.answerCallbackQuery(callbackQueryId);
-      if (context.isNew) {
-        recordTelegramCallbackQueryAdmissionAnswer(params.bot, callbackQueryId, answerPromise);
-      }
-      void answerPromise.catch(() => {});
+      void startTelegramCallbackQueryAnswer(params.bot, callbackQueryId, context.isNew);
     },
     dispatch: async (update, lifecycle) => {
       if (params.dispatchUpdate) {

--- a/extensions/telegram/src/telegram-ingress-drain.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.ts
@@ -269,6 +269,7 @@ type CreateTelegramIngressMonitorParams = {
   adoptionStallTimeoutMs?: number;
   pollIntervalMs?: number;
   dispatch: TelegramIngressDrainDispatch;
+  onDurableAdmission?: (update: unknown, context: { isNew: boolean }) => void | Promise<void>;
   onLog?: (message: string) => void;
   onError?: (error: unknown) => void;
   abortSignal?: AbortSignal;
@@ -480,6 +481,7 @@ export function createTelegramIngressMonitor(params: CreateTelegramIngressMonito
     ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
     admissionMode: "while-running",
     createStoppedError: () => new Error("Telegram ingress monitor is stopped."),
+    ...(params.onDurableAdmission ? { onDurableAdmission: params.onDurableAdmission } : {}),
     ...(params.onError ? { onError: params.onError } : {}),
   });
 }

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -35,6 +35,7 @@ import {
 const telegramSpooledRetryDeadLetterMinAgeMs = 24 * 60 * 60 * 1000;
 
 const handleUpdateSpy = vi.hoisted(() => vi.fn((..._args: unknown[]): unknown => undefined));
+const answerCallbackQuerySpy = vi.hoisted(() => vi.fn(async () => true));
 const setWebhookSpy = vi.hoisted(() => vi.fn());
 const deleteWebhookSpy = vi.hoisted(() => vi.fn(async () => true));
 const initSpy = vi.hoisted(() => vi.fn(async () => undefined));
@@ -51,7 +52,11 @@ const createTelegramBotSpy = vi.hoisted(() =>
     init: initSpy,
     botInfo: webhookBotInfo,
     handleUpdate: handleUpdateSpy,
-    api: { setWebhook: setWebhookSpy, deleteWebhook: deleteWebhookSpy },
+    api: {
+      setWebhook: setWebhookSpy,
+      deleteWebhook: deleteWebhookSpy,
+      answerCallbackQuery: answerCallbackQuerySpy,
+    },
     stop: stopSpy,
   })),
 );
@@ -228,6 +233,8 @@ function createTelegramPrivateTopicCallback(updateId: number) {
 function resetTelegramWebhookMocks(): void {
   handleUpdateSpy.mockReset();
   handleUpdateSpy.mockImplementation((..._args: unknown[]): unknown => undefined);
+  answerCallbackQuerySpy.mockReset();
+  answerCallbackQuerySpy.mockImplementation(async () => true);
 
   setWebhookSpy.mockReset();
   deleteWebhookSpy.mockReset();
@@ -243,7 +250,11 @@ function resetTelegramWebhookMocks(): void {
     init: initSpy,
     botInfo: webhookBotInfo,
     handleUpdate: handleUpdateSpy,
-    api: { setWebhook: setWebhookSpy, deleteWebhook: deleteWebhookSpy },
+    api: {
+      setWebhook: setWebhookSpy,
+      deleteWebhook: deleteWebhookSpy,
+      answerCallbackQuery: answerCallbackQuerySpy,
+    },
     stop: stopSpy,
   }));
 }
@@ -1109,6 +1120,68 @@ describe("startTelegramWebhook", () => {
 
         finishWork?.();
         await waitForWebhookState(() => expect(workFinished).toBe(true));
+      },
+    );
+  });
+
+  it("answers a durably admitted callback before its same-chat lane drains", async () => {
+    const blockingUpdate = {
+      update_id: 5,
+      message: {
+        message_id: 5,
+        date: 1_736_380_800,
+        from: { id: 111, is_bot: false, first_name: "Ada" },
+        chat: { id: 1234, type: "private" },
+        text: "slow",
+      },
+    };
+    const callbackUpdate = {
+      update_id: 6,
+      callback_query: createTelegramPrivateTopicCallback(6),
+    };
+    const seenUpdateIds: number[] = [];
+    let releaseBlockingUpdate: (() => void) | undefined;
+    const blockingUpdateCompleted = new Promise<void>((resolve) => {
+      releaseBlockingUpdate = resolve;
+    });
+    handleUpdateSpy.mockImplementation(async (update: unknown) => {
+      const updateId = (update as { update_id: number }).update_id;
+      seenUpdateIds.push(updateId);
+      if (updateId === blockingUpdate.update_id) {
+        await blockingUpdateCompleted;
+      }
+    });
+
+    await withStartedWebhook(
+      {
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+      },
+      async ({ port }) => {
+        const url = webhookUrl(port, TELEGRAM_WEBHOOK_PATH);
+        try {
+          const blockingResponse = await postWebhookJson({
+            url,
+            payload: JSON.stringify(blockingUpdate),
+            secret: TELEGRAM_SECRET,
+          });
+          expect(blockingResponse.status).toBe(200);
+          await waitForWebhookState(() => expect(seenUpdateIds).toEqual([5]));
+
+          const callbackResponse = await postWebhookJson({
+            url,
+            payload: JSON.stringify(callbackUpdate),
+            secret: TELEGRAM_SECRET,
+          });
+          expect(callbackResponse.status).toBe(200);
+          expect(callbackResponse.headers.get("x-openclaw-delivery-accepted")).toBe("durable");
+          expect(answerCallbackQuerySpy).toHaveBeenCalledWith("callback-6");
+          expect(seenUpdateIds).toEqual([5]);
+        } finally {
+          releaseBlockingUpdate?.();
+        }
+
+        await waitForWebhookState(() => expect(seenUpdateIds).toEqual([5, 6]));
       },
     );
   });
@@ -2397,6 +2470,7 @@ describe("startTelegramWebhook", () => {
 
   it("returns non-200 when the webhook update cannot be spooled durably", async () => {
     handleUpdateSpy.mockClear();
+    answerCallbackQuerySpy.mockClear();
     await withStartedWebhook(
       {
         secret: TELEGRAM_SECRET,
@@ -2405,12 +2479,15 @@ describe("startTelegramWebhook", () => {
       async ({ port }) => {
         const response = await postWebhookJson({
           url: webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
-          payload: JSON.stringify({ message: { text: "missing update id" } }),
+          payload: JSON.stringify({
+            callback_query: createTelegramPrivateTopicCallback(33),
+          }),
           secret: TELEGRAM_SECRET,
         });
 
         expect(response.status).toBe(500);
         expect(response.headers.get("x-openclaw-delivery-accepted")).toBeNull();
+        expect(answerCallbackQuerySpy).not.toHaveBeenCalled();
         expect(handleUpdateSpy).not.toHaveBeenCalled();
       },
     );


### PR DESCRIPTION
## What Problem This Solves

A durably queued Telegram button press can wait behind an earlier handler before reaching callback-answer middleware. The reproduced case is a native `/usage` menu awaiting its `sendMessage` response: the callback has committed to SQLite but its acknowledgement has not started.

Start the Bot API acknowledgement immediately after durable commit and carry its promise into normal middleware. Callback authorization and business ordering remain with their existing owners. Classic polling and restart replay still start acknowledgement in middleware when no admission answer exists.

The maintainer improvement gives admission, middleware, and callback-router recovery one request owner. In-flight answers coalesce even after middleware consumes them. Successful answers for new durable rows remain available until dispatch; duplicate/tombstone and recovery answers release their state on settlement, and failures are evicted. This removes the split lookup/record API and untracked retry paths without changing queue storage, retention, configuration, or authorization. The unused private callback-answer text parameter is also removed; all callers used the plain acknowledgement.

Closes #133294. Thanks @zhangguiping-xydt for the original repair.

## Evidence

Final tested tree: `bc4c15044ef3a586a343daf8dec6794aa95f1d42`, published as signed commit `cc7a5634d530009840060d91a3b2024ed0cb1d91`.

The native-handler reproduction uses real grammY, loopback Bot API HTTP, and the real SQLite ingress queue. With the exact pre-PR owners from `aea8ee845ccfc8ff50e5211dffec072bcd0bb0e6`, one native update remained claimed and the callback remained pending with **0 ACK requests**. Submitted head `5502b3eab245e4079eba75f7cab79f1a77e1201d` produced **1 ACK before release**, then exactly one downstream callback dispatch. The submitted head's original three suites passed all 254 tests. [Original red/control run](https://crabbox.openclaw.ai/portal/runs/run_7c22b79bf989).

The submitted patch failed three additional HTTP lifecycle cases: rejection followed by duplicate admission made 3 requests instead of 2; an existing durable row made 2 instead of 1; consuming a pending answer allowed 3 instead of 1. The new-row control passed. Independent review then exposed the same ownership gap in middleware and router recovery. Both real-router regressions reproduced **3 requests instead of 2** before repair and now produce **2**, including a duplicate arrival while the retry remains pending. Restart coverage also checks shared pending requests and eviction after settlement. [Recovery red](https://crabbox.openclaw.ai/portal/runs/run_1b71b50b8f7a), [final focused green](https://crabbox.openclaw.ai/portal/runs/run_80d88abf4257).

The final three directly affected suites passed **160 tests**. An earlier candidate passed seven focused suites /377 tests covering webhook, polling, durable coalescing, draining, bot creation and native callbacks; that is sibling evidence, not a claim that every prior suite reran on the final bytes. The final ten-file formatter, both production/extension-test typechecks, and every changed-file structural/lint gate passed. Typed lint reported zero warnings and errors over all nine TypeScript files. Test cleanup uses the existing SDK `createDeferred`, removes the unresolved-promise fixture, and satisfies the native lint rules without disabling retries or weakening assertions.

Independent managed Codex review of the whole PR plus working-tree improvements completed both passes with **no actionable P0–P2 findings**, and final source verification passed. Its preceding finding was reproduced and fixed through the common request owner.

The final candidate passed a fresh full `pnpm build` and the public `node openclaw.mjs --version` invocation from a neutral home. The built Gateway then passed the native-handler and adopted-model scenarios. All ten source hashes matched the tested manifest afterward. [Final build and Gateway run](https://crabbox.openclaw.ai/portal/runs/run_cbd8f6bb3d19).

The actual HTTP/event receipt, with only synthetic fixture output shown:

```text
native menu held: ACK requests=1; queue=1 claimed + 1 pending; provider requests=0
2 duplicate deliveries while ACK pending: ACK requests=1
native reply accepted: ⚙️ Usage footer: off.
already-adopted model request held: callback ACK requests=1
provider HTTP requests=1 (POST /v1/responses)
model reply accepted: CALLBACK_PROVIDER_CONTROL_OK
7 webhook deliveries: HTTP 200, durable acceptance
5 final ingress rows: completed; retry counts=[0,0,0,0,0]
cleanup: owned children stopped, scratch removed, proxy closed
```


The Gateway harness uses the public launcher, real Telegram plugin/webhook/SQLite, local Crabline Bot API simulator, and the repository's mock OpenAI server. It separately holds a real native menu response and an already-adopted model response; ordinary model work is not assumed to occupy durable ingress. Crabline 0.1.17 lacks `editMessageReplyMarkup`, so the task-scoped proxy validates an existing sent message, changes its reply markup, and returns the edited Message per the [Bot API contract](https://core.telegram.org/bots/api#editmessagereplymarkup). No production simulator code or dependency was added.

Telegram Test Server proof is unavailable on the verified proof host because it has neither an authenticated Convex CLI nor the required broker pair. No real Telegram client spinner trace is claimed. The local Gateway/HTTP run is the channel-visible evidence.

All changed production owners and relevant core ingress owners matched the PR base on inspected local main snapshot `ef44eab5ed8320cd5a5f34d790cedceffaefc36f`. Dependency inspection covered pinned grammY 1.46.0, runner 2.0.3 and transformer-throttler 1.2.1. The final source manifest is SHA-256 `35f306a379283d4a854f185129101c7d9afe5e57072841b3a009cf9d3561bcfa`.

Whole-PR delta: production **+95/-12 (net +83)**, tests **+558/-8**, docs **+3/-1**. The original admission capability accounts for net +75 production lines; the maintainer repair adds net +8 while removing duplicate ownership paths. Its pending and retain-until-dispatch facts distinguish transport completion from middleware consumption without adding persistent state. Release-note context: Telegram acknowledges durably queued callback buttons promptly and coalesces duplicate or recovered acknowledgements while preserving ordered actions.
