### PR TITLE
fix(daemon): launchd gateway crash loop leaves no stderr

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1285,7 +1285,7 @@ Model Q&A - defaults, selection, aliases, switching, failover, auth profiles - l
 
     Service/supervisor logs (when the gateway runs via launchd/systemd):
 
-    - macOS launchd stdout: `~/Library/Logs/openclaw/gateway.log` (profiles use `gateway-<profile>.log`; stderr is suppressed).
+    - macOS launchd stdout: `~/Library/Logs/openclaw/gateway.log` (profiles use `gateway-<profile>.log`). stderr: `~/Library/Logs/openclaw/gateway.err.log` (profiles use `gateway-<profile>.err.log`).
     - Linux: `journalctl --user -u openclaw-gateway[-<profile>].service -n 200 --no-pager`.
     - Windows: `schtasks /Query /TN "OpenClaw Gateway (<profile>)" /V /FO LIST`.
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1285,7 +1285,7 @@ Model Q&A - defaults, selection, aliases, switching, failover, auth profiles - l
 
     Service/supervisor logs (when the gateway runs via launchd/systemd):
 
-    - macOS launchd stdout: `~/Library/Logs/openclaw/gateway.log` (profiles use `gateway-<profile>.log`). stderr: `~/Library/Logs/openclaw/gateway.err.log` (profiles use `gateway-<profile>.err.log`; existing LaunchAgents keep `/dev/null` until `openclaw gateway install` or a rewrite-capable `openclaw gateway restart`).
+    - macOS launchd stdout: `~/Library/Logs/openclaw/gateway.log` (profiles use `gateway-<profile>.log`). stderr: `~/Library/Logs/openclaw/gateway.err.log` (profiles use `gateway-<profile>.err.log`; existing LaunchAgents keep `/dev/null` until `openclaw gateway restart` or `openclaw gateway install --force`).
     - Linux: `journalctl --user -u openclaw-gateway[-<profile>].service -n 200 --no-pager`.
     - Windows: `schtasks /Query /TN "OpenClaw Gateway (<profile>)" /V /FO LIST`.
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1285,7 +1285,7 @@ Model Q&A - defaults, selection, aliases, switching, failover, auth profiles - l
 
     Service/supervisor logs (when the gateway runs via launchd/systemd):
 
-    - macOS launchd stdout: `~/Library/Logs/openclaw/gateway.log` (profiles use `gateway-<profile>.log`). stderr: `~/Library/Logs/openclaw/gateway.err.log` (profiles use `gateway-<profile>.err.log`).
+    - macOS launchd stdout: `~/Library/Logs/openclaw/gateway.log` (profiles use `gateway-<profile>.log`). stderr: `~/Library/Logs/openclaw/gateway.err.log` (profiles use `gateway-<profile>.err.log`; existing LaunchAgents keep `/dev/null` until `openclaw gateway install` or a rewrite-capable `openclaw gateway restart`).
     - Linux: `journalctl --user -u openclaw-gateway[-<profile>].service -n 200 --no-pager`.
     - Windows: `schtasks /Query /TN "OpenClaw Gateway (<profile>)" /V /FO LIST`.
 

--- a/docs/platforms/mac/bundled-gateway.md
+++ b/docs/platforms/mac/bundled-gateway.md
@@ -115,7 +115,9 @@ Logging:
 - launchd stdout: `~/Library/Logs/openclaw/gateway.log` (profiles use
   `gateway-<profile>.log`)
 - launchd stderr: `~/Library/Logs/openclaw/gateway.err.log` (profiles use
-  `gateway-<profile>.err.log`)
+  `gateway-<profile>.err.log`). Existing LaunchAgents keep
+  `StandardErrorPath` at `/dev/null` until `openclaw gateway install` or a
+  rewrite-capable `openclaw gateway restart` updates the plist.
 - If the host loops with repeated `EADDRINUSE` or fast restarts, check for
   duplicate `ai.openclaw.gateway` / `ai.openclaw.node` LaunchAgents and the
   launchd-marker workaround in

--- a/docs/platforms/mac/bundled-gateway.md
+++ b/docs/platforms/mac/bundled-gateway.md
@@ -114,7 +114,8 @@ Logging:
 
 - launchd stdout: `~/Library/Logs/openclaw/gateway.log` (profiles use
   `gateway-<profile>.log`)
-- launchd stderr: suppressed
+- launchd stderr: `~/Library/Logs/openclaw/gateway.err.log` (profiles use
+  `gateway-<profile>.err.log`)
 - If the host loops with repeated `EADDRINUSE` or fast restarts, check for
   duplicate `ai.openclaw.gateway` / `ai.openclaw.node` LaunchAgents and the
   launchd-marker workaround in

--- a/docs/platforms/mac/bundled-gateway.md
+++ b/docs/platforms/mac/bundled-gateway.md
@@ -116,8 +116,8 @@ Logging:
   `gateway-<profile>.log`)
 - launchd stderr: `~/Library/Logs/openclaw/gateway.err.log` (profiles use
   `gateway-<profile>.err.log`). Existing LaunchAgents keep
-  `StandardErrorPath` at `/dev/null` until `openclaw gateway install` or a
-  rewrite-capable `openclaw gateway restart` updates the plist.
+  `StandardErrorPath` at `/dev/null` until `openclaw gateway restart` or
+  `openclaw gateway install --force` updates the plist.
 - If the host loops with repeated `EADDRINUSE` or fast restarts, check for
   duplicate `ai.openclaw.gateway` / `ai.openclaw.node` LaunchAgents and the
   launchd-marker workaround in

--- a/docs/platforms/mac/bundled-gateway.md
+++ b/docs/platforms/mac/bundled-gateway.md
@@ -118,6 +118,11 @@ Logging:
   `gateway-<profile>.err.log`). Existing LaunchAgents keep
   `StandardErrorPath` at `/dev/null` until `openclaw gateway restart` or
   `openclaw gateway install --force` updates the plist.
+- Supervisor stderr is raw process output, including shell errors before
+  OpenClaw's logging and redaction start. Inspect and redact it before sharing;
+  malformed custom environment content can expose sensitive fragments. The
+  installer does not tighten read permissions on an existing log file. Check
+  file permissions and ACLs before enabling stderr capture on a shared Mac.
 - If the host loops with repeated `EADDRINUSE` or fast restarts, check for
   duplicate `ai.openclaw.gateway` / `ai.openclaw.node` LaunchAgents and the
   launchd-marker workaround in

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -71,6 +71,18 @@ vi.mock("../../daemon/inspect.js", () => ({
   renderGatewayServiceCleanupHints: renderGatewayServiceCleanupHintsMock,
 }));
 
+const launchdStdioMocks = vi.hoisted(() => ({
+  readPersistedLaunchdStderrPath: vi.fn(() => "/Users/test/Library/Logs/openclaw/gateway.err.log"),
+}));
+
+vi.mock("../../daemon/launchd-stdio.js", () => ({
+  readPersistedLaunchdStderrPath: launchdStdioMocks.readPersistedLaunchdStderrPath,
+  resolveAdvertisedLaunchdStderr: (persistedStderrPath: string | null) =>
+    !persistedStderrPath || persistedStderrPath === "/dev/null"
+      ? { kind: "suppressed" as const }
+      : { kind: "file" as const, path: persistedStderrPath },
+}));
+
 vi.mock("../../daemon/restart-logs.js", () => ({
   resolveGatewayLogPaths: () => ({
     logDir: "/tmp",
@@ -129,6 +141,9 @@ describe("printDaemonStatus", () => {
     isSystemdUnavailableDetailMock.mockReset().mockReturnValue(false);
     renderSystemdUnavailableHintsMock.mockReset().mockReturnValue([]);
     isWSLEnvMock.mockClear();
+    launchdStdioMocks.readPersistedLaunchdStderrPath
+      .mockReset()
+      .mockReturnValue("/Users/test/Library/Logs/openclaw/gateway.err.log");
   });
 
   it("preserves Gateway server metadata while sanitizing JSON output", () => {
@@ -577,6 +592,55 @@ describe("printDaemonStatus", () => {
     expectMockLineContains(runtime.error, "/Users/test/Library/Logs/openclaw/gateway.err.log");
     const errors = runtime.error.mock.calls.map(([line]) => line).join("\n");
     expect(errors.match(/Last gateway error:/g)).toHaveLength(1);
+  });
+
+  it("does not advertise gateway.err.log when the LaunchAgent still discards stderr", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    launchdStdioMocks.readPersistedLaunchdStderrPath.mockReturnValue("/dev/null");
+    try {
+      printDaemonStatus(
+        {
+          service: {
+            label: "LaunchAgent",
+            loadState: { status: "loaded" },
+            loadedText: "loaded",
+            notLoadedText: "not loaded",
+            runtime: { status: "running", pid: 8000 },
+            command: { programArguments: [], environment: { HOME: "/Users/test" } },
+          },
+          gateway: {
+            bindMode: "loopback",
+            bindHost: "127.0.0.1",
+            port: 18789,
+            portSource: "env/config",
+            probeUrl: "ws://127.0.0.1:18789",
+          },
+          port: {
+            port: 18789,
+            status: "free",
+            listeners: [],
+            hints: [],
+          },
+          rpc: {
+            ok: false,
+            kind: "connect",
+            capability: "unknown",
+            error: "gateway closed (1000): ",
+            url: "ws://127.0.0.1:18789",
+          },
+          extraServices: [],
+        },
+        { json: false },
+      );
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+
+    const errors = runtime.error.mock.calls.map(([line]) => line).join("\n");
+    expect(errors).toContain("suppressed (/dev/null)");
+    expect(errors).toContain("openclaw gateway install");
+    expect(errors).not.toContain("gateway.err.log");
   });
 
   it("does not claim an indeterminate port is not listening", () => {

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -75,13 +75,17 @@ const launchdStdioMocks = vi.hoisted(() => ({
   readPersistedLaunchdStderrPath: vi.fn(() => "/Users/test/Library/Logs/openclaw/gateway.err.log"),
 }));
 
-vi.mock("../../daemon/launchd-stdio.js", () => ({
-  readPersistedLaunchdStderrPath: launchdStdioMocks.readPersistedLaunchdStderrPath,
-  resolveAdvertisedLaunchdStderr: (persistedStderrPath: string | null) =>
-    !persistedStderrPath || persistedStderrPath === "/dev/null"
-      ? { kind: "suppressed" as const }
-      : { kind: "file" as const, path: persistedStderrPath },
-}));
+vi.mock("../../daemon/launchd-stdio.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../daemon/launchd-stdio.js")>();
+  return {
+    ...actual,
+    readPersistedLaunchdStderrPath: launchdStdioMocks.readPersistedLaunchdStderrPath,
+    resolveAdvertisedLaunchdStderr: (persistedStderrPath: string | null) =>
+      !persistedStderrPath || persistedStderrPath === "/dev/null"
+        ? { kind: "suppressed" as const }
+        : { kind: "file" as const, path: persistedStderrPath },
+  };
+});
 
 vi.mock("../../daemon/restart-logs.js", () => ({
   resolveGatewayLogPaths: () => ({
@@ -639,7 +643,9 @@ describe("printDaemonStatus", () => {
 
     const errors = runtime.error.mock.calls.map(([line]) => line).join("\n");
     expect(errors).toContain("suppressed (/dev/null)");
-    expect(errors).toContain("openclaw gateway install");
+    expect(errors).toContain("openclaw gateway restart");
+    expect(errors).toContain("openclaw gateway install --force");
+    expect(errors).not.toMatch(/openclaw gateway install(?! --force)/);
     expect(errors).not.toContain("gateway.err.log");
   });
 

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -649,6 +649,69 @@ describe("printDaemonStatus", () => {
     expect(errors).not.toContain("gateway.err.log");
   });
 
+  it("scopes suppressed-stderr rewrite commands to the inspected named profile", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    launchdStdioMocks.readPersistedLaunchdStderrPath.mockReturnValue("/dev/null");
+    try {
+      withEnv(
+        {
+          OPENCLAW_PROFILE: "ambient",
+        },
+        () => {
+          printDaemonStatus(
+            {
+              service: {
+                label: "LaunchAgent",
+                loadState: { status: "loaded" },
+                loadedText: "loaded",
+                notLoadedText: "not loaded",
+                runtime: { status: "running", pid: 8000 },
+                command: {
+                  programArguments: [],
+                  environment: { HOME: "/Users/test", OPENCLAW_PROFILE: "proofstderr22575" },
+                },
+              },
+              gateway: {
+                bindMode: "loopback",
+                bindHost: "127.0.0.1",
+                port: 18789,
+                portSource: "env/config",
+                probeUrl: "ws://127.0.0.1:18789",
+              },
+              port: {
+                port: 18789,
+                status: "free",
+                listeners: [],
+                hints: [],
+              },
+              rpc: {
+                ok: false,
+                kind: "connect",
+                capability: "unknown",
+                error: "gateway closed (1000): ",
+                url: "ws://127.0.0.1:18789",
+              },
+              extraServices: [],
+            },
+            { json: false },
+          );
+        },
+      );
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+
+    const errors = runtime.error.mock.calls.map(([line]) => line).join("\n");
+    const serviceEnv = { OPENCLAW_PROFILE: "proofstderr22575" };
+    expect(errors).toContain(formatCliCommand("openclaw gateway restart", serviceEnv));
+    expect(errors).toContain(formatCliCommand("openclaw gateway install --force", serviceEnv));
+    expect(errors).not.toContain(
+      formatCliCommand("openclaw gateway restart", { OPENCLAW_PROFILE: "ambient" }),
+    );
+    expect(errors).not.toMatch(/\bopenclaw gateway restart\b/);
+  });
+
   it("does not claim an indeterminate port is not listening", () => {
     printDaemonStatus(
       {

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -529,7 +529,7 @@ describe("printDaemonStatus", () => {
     expectMockLineContains(runtime.error, formatCliCommand("openclaw gateway restart"));
   });
 
-  it("prints macOS launchd stdout and suppressed stderr when gateway is not listening", () => {
+  it("prints macOS launchd stdout and stderr log paths when gateway is not listening", () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "darwin" });
     try {
@@ -574,7 +574,7 @@ describe("printDaemonStatus", () => {
 
     expectMockLineContains(runtime.error, "Gateway port 18789 is not listening");
     expectMockLineContains(runtime.error, "/Users/test/Library/Logs/openclaw/gateway.log");
-    expectMockLineContains(runtime.error, "Errors: suppressed");
+    expectMockLineContains(runtime.error, "/Users/test/Library/Logs/openclaw/gateway.err.log");
     const errors = runtime.error.mock.calls.map(([line]) => line).join("\n");
     expect(errors.match(/Last gateway error:/g)).toHaveLength(1);
   });

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -8,6 +8,7 @@ import {
 import { formatGatewayHeapLimitReport } from "../../daemon/gateway-heap.js";
 import { renderGatewayServiceCleanupHints } from "../../daemon/inspect.js";
 import {
+  formatLaunchdStderrRewriteGuidance,
   resolveAdvertisedLaunchdStderr,
   readPersistedLaunchdStderrPath,
 } from "../../daemon/launchd-stdio.js";
@@ -511,7 +512,7 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
         defaultRuntime.error(`${errorText("Errors:")} ${shortenHomePath(advertisedStderr.path)}`);
       } else {
         defaultRuntime.error(
-          `${errorText("Errors:")} suppressed (/dev/null). Rewrite the LaunchAgent with ${formatCliCommand("openclaw gateway install")}.`,
+          `${errorText("Errors:")} suppressed (/dev/null). ${formatLaunchdStderrRewriteGuidance()}`,
         );
       }
     }

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -512,7 +512,7 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
         defaultRuntime.error(`${errorText("Errors:")} ${shortenHomePath(advertisedStderr.path)}`);
       } else {
         defaultRuntime.error(
-          `${errorText("Errors:")} suppressed (/dev/null). ${formatLaunchdStderrRewriteGuidance()}`,
+          `${errorText("Errors:")} suppressed (/dev/null). ${formatLaunchdStderrRewriteGuidance(serviceEnv)}`,
         );
       }
     }

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -500,7 +500,7 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
     } else if (process.platform === "darwin") {
       const logs = resolveGatewaySupervisorLogPaths(serviceEnv, { platform: "darwin" });
       defaultRuntime.error(`${errorText("Logs:")} ${shortenHomePath(logs.stdoutPath)}`);
-      defaultRuntime.error(`${errorText("Errors:")} suppressed`);
+      defaultRuntime.error(`${errorText("Errors:")} ${shortenHomePath(logs.stderrPath)}`);
     }
     defaultRuntime.error(
       `${errorText("Restart log:")} ${shortenHomePath(resolveGatewayRestartLogPath(serviceEnv))}`,

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -8,6 +8,10 @@ import {
 import { formatGatewayHeapLimitReport } from "../../daemon/gateway-heap.js";
 import { renderGatewayServiceCleanupHints } from "../../daemon/inspect.js";
 import {
+  resolveAdvertisedLaunchdStderr,
+  readPersistedLaunchdStderrPath,
+} from "../../daemon/launchd-stdio.js";
+import {
   resolveGatewayRestartLogPath,
   resolveGatewaySupervisorLogPaths,
 } from "../../daemon/restart-logs.js";
@@ -499,8 +503,17 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
       );
     } else if (process.platform === "darwin") {
       const logs = resolveGatewaySupervisorLogPaths(serviceEnv, { platform: "darwin" });
+      const advertisedStderr = resolveAdvertisedLaunchdStderr(
+        readPersistedLaunchdStderrPath(serviceEnv),
+      );
       defaultRuntime.error(`${errorText("Logs:")} ${shortenHomePath(logs.stdoutPath)}`);
-      defaultRuntime.error(`${errorText("Errors:")} ${shortenHomePath(logs.stderrPath)}`);
+      if (advertisedStderr.kind === "file") {
+        defaultRuntime.error(`${errorText("Errors:")} ${shortenHomePath(advertisedStderr.path)}`);
+      } else {
+        defaultRuntime.error(
+          `${errorText("Errors:")} suppressed (/dev/null). Rewrite the LaunchAgent with ${formatCliCommand("openclaw gateway install")}.`,
+        );
+      }
     }
     defaultRuntime.error(
       `${errorText("Restart log:")} ${shortenHomePath(resolveGatewayRestartLogPath(serviceEnv))}`,

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -432,6 +432,10 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
       restartCommand: formatCliCommand("openclaw gateway restart", env),
       env,
       logFile: status.logFile,
+      rewriteCommands: {
+        restartCommand: "openclaw gateway restart",
+        ...(!installBlock ? { forceInstallCommand: "openclaw gateway install --force" } : {}),
+      },
     })) {
       defaultRuntime.error(errorText(hint));
     }

--- a/src/cli/node-cli/daemon.status-hints.test.ts
+++ b/src/cli/node-cli/daemon.status-hints.test.ts
@@ -1,0 +1,104 @@
+// Node status must advertise Node rewrite commands for a legacy /dev/null plist.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveNodeLaunchAgentLabel } from "../../daemon/constants.js";
+import { resolveLaunchAgentPlistPathForLabel } from "../../daemon/launchd-service-files.js";
+import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
+import type { GatewayServiceCommandConfig } from "../../daemon/service-types.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { formatCliCommand } from "../command-format.js";
+import { runNodeDaemonStatus } from "./daemon.js";
+
+const mocks = vi.hoisted(() => {
+  const service = {
+    label: "Node service",
+    loadedText: "loaded",
+    notLoadedText: "not loaded",
+    stage: vi.fn(),
+    install: vi.fn(),
+    uninstall: vi.fn(),
+    stop: vi.fn(),
+    restart: vi.fn(),
+    isLoaded: vi.fn(async () => true),
+    readCommand: vi.fn<() => Promise<GatewayServiceCommandConfig | null>>(async () => null),
+    readRuntime: vi.fn<() => Promise<GatewayServiceRuntime>>(async () => ({ status: "running" })),
+  };
+  return {
+    runtime: {
+      log: vi.fn<(line: string) => void>(),
+      error: vi.fn<(line: string) => void>(),
+      writeJson: vi.fn(),
+      exit: vi.fn(),
+    },
+    service,
+  };
+});
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: mocks.runtime,
+}));
+
+vi.mock("../../daemon/node-service.js", () => ({
+  resolveNodeService: () => mocks.service,
+}));
+
+function stdout(): string {
+  return mocks.runtime.log.mock.calls.map(([line]) => line).join("\n");
+}
+
+describe("runNodeDaemonStatus launchd stderr hints", () => {
+  let homeDir: string;
+
+  beforeEach(() => {
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-node-status-hints-"));
+    mocks.runtime.log.mockClear();
+    mocks.runtime.error.mockClear();
+    mocks.service.isLoaded.mockReset().mockResolvedValue(true);
+    mocks.service.readCommand.mockReset().mockResolvedValue({
+      programArguments: ["node", "node-host"],
+      environment: { HOME: homeDir, OPENCLAW_LOG_PREFIX: "node" },
+    });
+    mocks.service.readRuntime.mockReset().mockResolvedValue({ status: "stopped" });
+  });
+
+  afterEach(() => {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("tells a stopped legacy Node LaunchAgent to rewrite the Node service", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    try {
+      const plistPath = resolveLaunchAgentPlistPathForLabel(
+        { HOME: homeDir },
+        resolveNodeLaunchAgentLabel(),
+      );
+      fs.mkdirSync(path.dirname(plistPath), { recursive: true });
+      fs.writeFileSync(
+        plistPath,
+        `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+  <dict>
+    <key>StandardErrorPath</key>
+    <string>/dev/null</string>
+  </dict>
+</plist>
+`,
+      );
+
+      await withEnvAsync({ HOME: homeDir, OPENCLAW_PROFILE: undefined }, async () => {
+        await runNodeDaemonStatus();
+      });
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+
+    expect(stdout()).toContain("suppressed (/dev/null)");
+    expect(stdout()).toContain(formatCliCommand("openclaw node restart"));
+    expect(stdout()).toContain(formatCliCommand("openclaw node install --force"));
+    expect(stdout()).not.toContain("openclaw gateway restart");
+    expect(stdout()).not.toContain("openclaw gateway install");
+  });
+});

--- a/src/cli/node-cli/daemon.status-hints.test.ts
+++ b/src/cli/node-cli/daemon.status-hints.test.ts
@@ -100,5 +100,15 @@ describe("runNodeDaemonStatus launchd stderr hints", () => {
     expect(stdout()).toContain(formatCliCommand("openclaw node install --force"));
     expect(stdout()).not.toContain("openclaw gateway restart");
     expect(stdout()).not.toContain("openclaw gateway install");
+
+    mocks.runtime.log.mockClear();
+    await withEnvAsync(
+      { HOME: homeDir, OPENCLAW_PROFILE: undefined, OPENCLAW_NIX_MODE: "1" },
+      async () => {
+        await runNodeDaemonStatus();
+      },
+    );
+    expect(stdout()).toContain(formatCliCommand("openclaw node restart"));
+    expect(stdout()).not.toContain("openclaw node install");
   });
 });

--- a/src/cli/node-cli/daemon.status-hints.test.ts
+++ b/src/cli/node-cli/daemon.status-hints.test.ts
@@ -91,24 +91,24 @@ describe("runNodeDaemonStatus launchd stderr hints", () => {
       await withEnvAsync({ HOME: homeDir, OPENCLAW_PROFILE: undefined }, async () => {
         await runNodeDaemonStatus();
       });
+
+      expect(stdout()).toContain("suppressed (/dev/null)");
+      expect(stdout()).toContain(formatCliCommand("openclaw node restart"));
+      expect(stdout()).toContain(formatCliCommand("openclaw node install --force"));
+      expect(stdout()).not.toContain("openclaw gateway restart");
+      expect(stdout()).not.toContain("openclaw gateway install");
+
+      mocks.runtime.log.mockClear();
+      await withEnvAsync(
+        { HOME: homeDir, OPENCLAW_PROFILE: undefined, OPENCLAW_NIX_MODE: "1" },
+        async () => {
+          await runNodeDaemonStatus();
+        },
+      );
+      expect(stdout()).toContain(formatCliCommand("openclaw node restart"));
+      expect(stdout()).not.toContain("openclaw node install");
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform });
     }
-
-    expect(stdout()).toContain("suppressed (/dev/null)");
-    expect(stdout()).toContain(formatCliCommand("openclaw node restart"));
-    expect(stdout()).toContain(formatCliCommand("openclaw node install --force"));
-    expect(stdout()).not.toContain("openclaw gateway restart");
-    expect(stdout()).not.toContain("openclaw gateway install");
-
-    mocks.runtime.log.mockClear();
-    await withEnvAsync(
-      { HOME: homeDir, OPENCLAW_PROFILE: undefined, OPENCLAW_NIX_MODE: "1" },
-      async () => {
-        await runNodeDaemonStatus();
-      },
-    );
-    expect(stdout()).toContain(formatCliCommand("openclaw node restart"));
-    expect(stdout()).not.toContain("openclaw node install");
   });
 });

--- a/src/cli/node-cli/daemon.ts
+++ b/src/cli/node-cli/daemon.ts
@@ -7,6 +7,7 @@ import {
 import { buildNodeInstallPlan } from "../../commands/node-daemon-install-helpers.js";
 import {
   resolveNodeLaunchAgentLabel,
+  resolveNodeServiceIdentityEnvironment,
   resolveNodeSystemdServiceName,
   resolveNodeWindowsTaskName,
 } from "../../daemon/constants.js";
@@ -77,9 +78,16 @@ function renderNodeServiceStartHints(): string[] {
 
 function buildNodeRuntimeHints(env: NodeJS.ProcessEnv = process.env): string[] {
   return buildPlatformRuntimeLogHints({
-    env,
+    env: {
+      ...env,
+      ...resolveNodeServiceIdentityEnvironment(),
+    },
     systemdServiceName: resolveNodeSystemdServiceName(),
     windowsTaskName: resolveNodeWindowsTaskName(),
+    rewriteCommands: {
+      restartCommand: "openclaw node restart",
+      forceInstallCommand: "openclaw node install --force",
+    },
   });
 }
 

--- a/src/cli/node-cli/daemon.ts
+++ b/src/cli/node-cli/daemon.ts
@@ -86,7 +86,9 @@ function buildNodeRuntimeHints(env: NodeJS.ProcessEnv = process.env): string[] {
     windowsTaskName: resolveNodeWindowsTaskName(),
     rewriteCommands: {
       restartCommand: "openclaw node restart",
-      forceInstallCommand: "openclaw node install --force",
+      ...(resolveDaemonInstallBlockMessage("node", env)
+        ? {}
+        : { forceInstallCommand: "openclaw node install --force" }),
     },
   });
 }

--- a/src/commands/status-all/diagnosis.test.ts
+++ b/src/commands/status-all/diagnosis.test.ts
@@ -558,7 +558,7 @@ describe("status-all diagnosis port checks", () => {
     expect(output).not.toContain("Retry: openclaw gateway stability");
   });
 
-  it("does not read or display stale stderr tails on Darwin", async () => {
+  it("reads Darwin supervisor stderr after launchd writes gateway.err.log", async () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "darwin" });
     try {
@@ -575,7 +575,7 @@ describe("status-all diagnosis port checks", () => {
           return ["gateway stdout current"];
         }
         if (filePath.endsWith("gateway.err.log")) {
-          return ["failed to bind gateway socket stale"];
+          return ["failed to bind gateway socket EADDRINUSE"];
         }
         return [];
       });
@@ -584,14 +584,14 @@ describe("status-all diagnosis port checks", () => {
       await appendStatusAllDiagnosis(params);
 
       const output = params.lines.join("\n");
-      expect(gatewayMocks.readFileTailLines).not.toHaveBeenCalledWith(
+      expect(gatewayMocks.readFileTailLines).toHaveBeenCalledWith(
         "/Users/test/Library/Logs/openclaw/gateway.err.log",
         40,
       );
+      expect(output).toContain("# stderr: /Users/test/Library/Logs/openclaw/gateway.err.log");
+      expect(output).toContain("failed to bind gateway socket EADDRINUSE");
       expect(output).toContain("# stdout: /Users/test/Library/Logs/openclaw/gateway.log");
       expect(output).toContain("gateway stdout current");
-      expect(output).not.toContain("# stderr:");
-      expect(output).not.toContain("failed to bind gateway socket stale");
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform });
     }

--- a/src/commands/status-all/diagnosis.test.ts
+++ b/src/commands/status-all/diagnosis.test.ts
@@ -18,6 +18,18 @@ const restartLogMocks = vi.hoisted(() => ({
   resolveGatewayRestartLogPath: vi.fn<() => string>(() => "/tmp/gateway-restart.log"),
 }));
 
+const launchdStdioMocks = vi.hoisted(() => ({
+  readPersistedLaunchdStderrPath: vi.fn(() => "/Users/test/Library/Logs/openclaw/gateway.err.log"),
+}));
+
+vi.mock("../../daemon/launchd-stdio.js", () => ({
+  readPersistedLaunchdStderrPath: launchdStdioMocks.readPersistedLaunchdStderrPath,
+  resolveAdvertisedLaunchdStderr: (persistedStderrPath: string | null) =>
+    !persistedStderrPath || persistedStderrPath === "/dev/null"
+      ? { kind: "suppressed" as const }
+      : { kind: "file" as const, path: persistedStderrPath },
+}));
+
 const gatewayMocks = vi.hoisted(() => ({
   readFileTailLines: vi.fn<(filePath: string, maxLines: number) => Promise<string[]>>(
     async () => [],
@@ -104,6 +116,9 @@ describe("status-all diagnosis port checks", () => {
     restartLogMocks.resolveGatewayRestartLogPath.mockReturnValue("/tmp/gateway-restart.log");
     gatewayMocks.readFileTailLines.mockResolvedValue([]);
     gatewayMocks.summarizeLogTail.mockImplementation((lines: string[]) => lines);
+    launchdStdioMocks.readPersistedLaunchdStderrPath
+      .mockReset()
+      .mockReturnValue("/Users/test/Library/Logs/openclaw/gateway.err.log");
   });
 
   it("keeps first config issue locations and exact pairs before applying the display cap", async () => {

--- a/src/commands/status-all/diagnosis.test.ts
+++ b/src/commands/status-all/diagnosis.test.ts
@@ -22,13 +22,17 @@ const launchdStdioMocks = vi.hoisted(() => ({
   readPersistedLaunchdStderrPath: vi.fn(() => "/Users/test/Library/Logs/openclaw/gateway.err.log"),
 }));
 
-vi.mock("../../daemon/launchd-stdio.js", () => ({
-  readPersistedLaunchdStderrPath: launchdStdioMocks.readPersistedLaunchdStderrPath,
-  resolveAdvertisedLaunchdStderr: (persistedStderrPath: string | null) =>
-    !persistedStderrPath || persistedStderrPath === "/dev/null"
-      ? { kind: "suppressed" as const }
-      : { kind: "file" as const, path: persistedStderrPath },
-}));
+vi.mock("../../daemon/launchd-stdio.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../daemon/launchd-stdio.js")>();
+  return {
+    ...actual,
+    readPersistedLaunchdStderrPath: launchdStdioMocks.readPersistedLaunchdStderrPath,
+    resolveAdvertisedLaunchdStderr: (persistedStderrPath: string | null) =>
+      !persistedStderrPath || persistedStderrPath === "/dev/null"
+        ? { kind: "suppressed" as const }
+        : { kind: "file" as const, path: persistedStderrPath },
+  };
+});
 
 const gatewayMocks = vi.hoisted(() => ({
   readFileTailLines: vi.fn<(filePath: string, maxLines: number) => Promise<string[]>>(

--- a/src/commands/status-all/diagnosis.ts
+++ b/src/commands/status-all/diagnosis.ts
@@ -7,6 +7,7 @@ import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-t
 import type { ProgressReporter } from "../../cli/progress.js";
 import { formatConfigIssueLine } from "../../config/issue-format.js";
 import {
+  formatLaunchdStderrRewriteGuidance,
   resolveAdvertisedLaunchdStderr,
   readPersistedLaunchdStderrPath,
 } from "../../daemon/launchd-stdio.js";
@@ -471,7 +472,7 @@ export async function appendStatusAllDiagnosis(params: {
         }
       } else {
         lines.push(
-          `  ${muted("# stderr: suppressed (/dev/null); rewrite the LaunchAgent with openclaw gateway install")}`,
+          `  ${muted(`# stderr: suppressed (/dev/null); ${formatLaunchdStderrRewriteGuidance()}`)}`,
         );
       }
       lines.push(`  ${muted(`# stdout: ${logPaths.stdoutPath}`)}`);

--- a/src/commands/status-all/diagnosis.ts
+++ b/src/commands/status-all/diagnosis.ts
@@ -445,22 +445,17 @@ export async function appendStatusAllDiagnosis(params: {
   if (logPaths) {
     params.progress.setLabel("Reading logs…");
     const restartLogPath = resolveGatewayRestartLogPath(process.env);
-    const readStderr = process.platform !== "darwin";
     const [stderrTail, stdoutTail, restartTail] = await Promise.all([
-      readStderr ? readFileTailLines(logPaths.stderrPath, 40).catch(() => []) : [],
+      readFileTailLines(logPaths.stderrPath, 40).catch(() => []),
       readFileTailLines(logPaths.stdoutPath, 40).catch(() => []),
       readFileTailLines(restartLogPath, 30).catch(() => []),
     ]);
     if (stderrTail.length > 0 || stdoutTail.length > 0) {
       lines.push("");
       lines.push(muted(`Gateway logs (tail, summarized): ${logPaths.logDir}`));
-      if (readStderr) {
-        lines.push(`  ${muted(`# stderr: ${logPaths.stderrPath}`)}`);
-        for (const line of summarizeLogTail(stderrTail, { maxLines: 22 }).map(
-          redactStatusSecrets,
-        )) {
-          lines.push(`  ${muted(line)}`);
-        }
+      lines.push(`  ${muted(`# stderr: ${logPaths.stderrPath}`)}`);
+      for (const line of summarizeLogTail(stderrTail, { maxLines: 22 }).map(redactStatusSecrets)) {
+        lines.push(`  ${muted(line)}`);
       }
       lines.push(`  ${muted(`# stdout: ${logPaths.stdoutPath}`)}`);
       for (const line of summarizeLogTail(stdoutTail, { maxLines: 22 }).map(redactStatusSecrets)) {

--- a/src/commands/status-all/diagnosis.ts
+++ b/src/commands/status-all/diagnosis.ts
@@ -472,7 +472,7 @@ export async function appendStatusAllDiagnosis(params: {
         }
       } else {
         lines.push(
-          `  ${muted(`# stderr: suppressed (/dev/null); ${formatLaunchdStderrRewriteGuidance()}`)}`,
+          `  ${muted(`# stderr: suppressed (/dev/null); ${formatLaunchdStderrRewriteGuidance(process.env)}`)}`,
         );
       }
       lines.push(`  ${muted(`# stdout: ${logPaths.stdoutPath}`)}`);

--- a/src/commands/status-all/diagnosis.ts
+++ b/src/commands/status-all/diagnosis.ts
@@ -7,6 +7,10 @@ import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-t
 import type { ProgressReporter } from "../../cli/progress.js";
 import { formatConfigIssueLine } from "../../config/issue-format.js";
 import {
+  resolveAdvertisedLaunchdStderr,
+  readPersistedLaunchdStderrPath,
+} from "../../daemon/launchd-stdio.js";
+import {
   resolveGatewayLogPaths,
   resolveGatewayRestartLogPath,
   resolveGatewaySupervisorLogPaths,
@@ -445,17 +449,30 @@ export async function appendStatusAllDiagnosis(params: {
   if (logPaths) {
     params.progress.setLabel("Reading logs…");
     const restartLogPath = resolveGatewayRestartLogPath(process.env);
+    const advertisedStderr =
+      process.platform === "darwin"
+        ? resolveAdvertisedLaunchdStderr(readPersistedLaunchdStderrPath(process.env))
+        : { kind: "file" as const, path: logPaths.stderrPath };
+    const stderrPath = advertisedStderr.kind === "file" ? advertisedStderr.path : null;
     const [stderrTail, stdoutTail, restartTail] = await Promise.all([
-      readFileTailLines(logPaths.stderrPath, 40).catch(() => []),
+      stderrPath ? readFileTailLines(stderrPath, 40).catch(() => []) : Promise.resolve([]),
       readFileTailLines(logPaths.stdoutPath, 40).catch(() => []),
       readFileTailLines(restartLogPath, 30).catch(() => []),
     ]);
-    if (stderrTail.length > 0 || stdoutTail.length > 0) {
+    if (stderrTail.length > 0 || stdoutTail.length > 0 || advertisedStderr.kind === "suppressed") {
       lines.push("");
       lines.push(muted(`Gateway logs (tail, summarized): ${logPaths.logDir}`));
-      lines.push(`  ${muted(`# stderr: ${logPaths.stderrPath}`)}`);
-      for (const line of summarizeLogTail(stderrTail, { maxLines: 22 }).map(redactStatusSecrets)) {
-        lines.push(`  ${muted(line)}`);
+      if (advertisedStderr.kind === "file") {
+        lines.push(`  ${muted(`# stderr: ${advertisedStderr.path}`)}`);
+        for (const line of summarizeLogTail(stderrTail, { maxLines: 22 }).map(
+          redactStatusSecrets,
+        )) {
+          lines.push(`  ${muted(line)}`);
+        }
+      } else {
+        lines.push(
+          `  ${muted("# stderr: suppressed (/dev/null); rewrite the LaunchAgent with openclaw gateway install")}`,
+        );
       }
       lines.push(`  ${muted(`# stdout: ${logPaths.stdoutPath}`)}`);
       for (const line of summarizeLogTail(stdoutTail, { maxLines: 22 }).map(redactStatusSecrets)) {

--- a/src/daemon/diagnostics.test.ts
+++ b/src/daemon/diagnostics.test.ts
@@ -30,19 +30,17 @@ function makeTempStateDir(): string {
 }
 
 describe("readLastGatewayErrorLine", () => {
-  it("ignores stale launchd stderr when stderr is suppressed", async () => {
+  it("prefers the current launchd stderr error over a stale stdout match on darwin", async () => {
     const stateDir = makeTempStateDir();
     const homeDir = makeTempStateDir();
     const env = { HOME: homeDir, OPENCLAW_STATE_DIR: stateDir };
-    const stateLogs = resolveGatewayLogPaths(env);
     const launchdLogs = resolveGatewaySupervisorLogPaths(env, { platform: "darwin" });
-    fs.mkdirSync(stateLogs.logDir, { recursive: true });
     fs.mkdirSync(launchdLogs.logDir, { recursive: true });
-    fs.writeFileSync(stateLogs.stderrPath, "failed to bind gateway socket stale\n", "utf8");
-    fs.writeFileSync(launchdLogs.stdoutPath, "gateway stdout current\n", "utf8");
+    fs.writeFileSync(launchdLogs.stderrPath, "failed to bind gateway socket EADDRINUSE\n", "utf8");
+    fs.writeFileSync(launchdLogs.stdoutPath, "gateway start blocked: stale prior reason\n", "utf8");
 
     await expect(readLastGatewayErrorLine(env, { platform: "darwin" })).resolves.toBe(
-      "gateway stdout current",
+      "failed to bind gateway socket EADDRINUSE",
     );
   });
 

--- a/src/daemon/diagnostics.test.ts
+++ b/src/daemon/diagnostics.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { readGatewayLogTailLines, readLastGatewayErrorLine } from "./diagnostics.js";
+import { resolveLaunchAgentPlistPath } from "./launchd-service-files.js";
 import { resolveGatewayLogPaths, resolveGatewaySupervisorLogPaths } from "./restart-logs.js";
 
 const tempDirs: string[] = [];
@@ -36,6 +37,13 @@ describe("readLastGatewayErrorLine", () => {
     const env = { HOME: homeDir, OPENCLAW_STATE_DIR: stateDir };
     const launchdLogs = resolveGatewaySupervisorLogPaths(env, { platform: "darwin" });
     fs.mkdirSync(launchdLogs.logDir, { recursive: true });
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    fs.mkdirSync(path.dirname(plistPath), { recursive: true });
+    fs.writeFileSync(
+      plistPath,
+      `<plist><dict><key>StandardErrorPath</key><string>${launchdLogs.stderrPath}</string></dict></plist>`,
+      "utf8",
+    );
     fs.writeFileSync(launchdLogs.stderrPath, "failed to bind gateway socket EADDRINUSE\n", "utf8");
     fs.writeFileSync(launchdLogs.stdoutPath, "gateway start blocked: stale prior reason\n", "utf8");
 

--- a/src/daemon/diagnostics.ts
+++ b/src/daemon/diagnostics.ts
@@ -1,5 +1,6 @@
 /** Reads recent gateway service logs for actionable daemon restart diagnostics. */
 import fs, { type FileHandle } from "node:fs/promises";
+import { resolveAdvertisedLaunchdStderr, readPersistedLaunchdStderrPath } from "./launchd-stdio.js";
 import { resolveGatewayLogPaths, resolveGatewaySupervisorLogPaths } from "./restart-logs.js";
 
 // Error patterns worth surfacing from gateway service logs after failed starts.
@@ -94,7 +95,14 @@ export async function readLastGatewayErrorLine(
     platform === "darwin"
       ? resolveGatewaySupervisorLogPaths(env, { platform })
       : resolveGatewayLogPaths(env);
-  const stderrLines = await readGatewayLogTailLines(stderrPath).catch(() => []);
+  const advertisedStderr =
+    platform === "darwin"
+      ? resolveAdvertisedLaunchdStderr(readPersistedLaunchdStderrPath(env))
+      : { kind: "file" as const, path: stderrPath };
+  const stderrLines =
+    advertisedStderr.kind === "file"
+      ? await readGatewayLogTailLines(advertisedStderr.path).catch(() => [])
+      : [];
   const stdoutLines = await readGatewayLogTailLines(stdoutPath).catch(() => []);
   // stderr is the strongest failure signal, so place it last and scan from the
   // end: the most recent stderr error line then wins over any (possibly stale)

--- a/src/daemon/diagnostics.ts
+++ b/src/daemon/diagnostics.ts
@@ -88,18 +88,17 @@ export async function readLastGatewayErrorLine(
   options?: { platform?: NodeJS.Platform; requirePatternMatch?: boolean },
 ): Promise<string | null> {
   const platform = options?.platform ?? process.platform;
-  const readStderr = platform !== "darwin";
-  // launchd supervisor mode combines child stderr into stdout; other platforms
-  // keep stderr as the strongest failure signal.
+  // launchd writes wrapper/process stderr to gateway.err.log; treat it as the
+  // strongest failure signal on every supervisor.
   const { stdoutPath, stderrPath } =
     platform === "darwin"
       ? resolveGatewaySupervisorLogPaths(env, { platform })
       : resolveGatewayLogPaths(env);
-  const stderrLines = readStderr ? await readGatewayLogTailLines(stderrPath).catch(() => []) : [];
+  const stderrLines = await readGatewayLogTailLines(stderrPath).catch(() => []);
   const stdoutLines = await readGatewayLogTailLines(stdoutPath).catch(() => []);
-  // stderr is the strongest failure signal on non-darwin platforms, so place it
-  // last and scan from the end: the most recent stderr error line then wins over
-  // any (possibly stale) stdout match, matching the stderr-first fallback below.
+  // stderr is the strongest failure signal, so place it last and scan from the
+  // end: the most recent stderr error line then wins over any (possibly stale)
+  // stdout match, matching the stderr-first fallback below.
   const lines = [...stdoutLines, ...stderrLines].map((line) => line.trim());
   for (let i = lines.length - 1; i >= 0; i -= 1) {
     const line = lines[i];
@@ -113,7 +112,5 @@ export async function readLastGatewayErrorLine(
   if (options?.requirePatternMatch) {
     return null;
   }
-  return readStderr
-    ? (findLastNonEmptyLine(stderrLines) ?? findLastNonEmptyLine(stdoutLines))
-    : findLastNonEmptyLine(stdoutLines);
+  return findLastNonEmptyLine(stderrLines) ?? findLastNonEmptyLine(stdoutLines);
 }

--- a/src/daemon/launchd-plist.ts
+++ b/src/daemon/launchd-plist.ts
@@ -43,6 +43,25 @@ export function parseLaunchdPlistLabel(contents: string): string | null {
   return rawLabel === undefined ? null : plistUnescape(rawLabel).trim() || null;
 }
 
+function parseLaunchdPlistStringValue(contents: string, key: string): string | null {
+  const match = contents.match(
+    new RegExp(`<key>${key}<\\/key>\\s*<string>([\\s\\S]*?)<\\/string>`, "i"),
+  );
+  const raw = match?.at(1);
+  return raw === undefined ? null : plistUnescape(raw).trim() || null;
+}
+
+/** Reads StandardOutPath / StandardErrorPath from an installed LaunchAgent plist. */
+export function parseLaunchdPlistStdioPaths(contents: string): {
+  stdoutPath: string | null;
+  stderrPath: string | null;
+} {
+  return {
+    stdoutPath: parseLaunchdPlistStringValue(contents, "StandardOutPath"),
+    stderrPath: parseLaunchdPlistStringValue(contents, "StandardErrorPath"),
+  };
+}
+
 type ReadLaunchAgentProgramArgumentsOptions = GatewayServiceReadOptions & {
   expectedEnvironmentWrapperPath?: string;
   expectedEnvironmentFilePath?: string;

--- a/src/daemon/launchd-service-files.ts
+++ b/src/daemon/launchd-service-files.ts
@@ -25,7 +25,6 @@ const LAUNCH_AGENT_PRIVATE_DIR_MODE = 0o700;
 export const LAUNCH_AGENT_ENV_FILE_MODE = 0o600;
 export const LAUNCH_AGENT_ENV_WRAPPER_MODE = 0o700;
 const LAUNCH_AGENT_ENV_DIR_NAME = "service-env";
-const LAUNCH_AGENT_STDERR_PATH = "/dev/null";
 export function resolveLaunchAgentPlistPathForLabel(
   env: Record<string, string | undefined>,
   label: string,
@@ -303,7 +302,9 @@ export async function writeLaunchAgentPlist({
   const label = resolveLaunchAgentLabel(env);
   await assertNoSystemLaunchDaemonOwnership(label);
 
-  const { logDir, stdoutPath } = resolveGatewaySupervisorLogPaths(env, { platform: "darwin" });
+  const { logDir, stdoutPath, stderrPath } = resolveGatewaySupervisorLogPaths(env, {
+    platform: "darwin",
+  });
   await ensureSecureDirectory(logDir);
 
   const plistPath = resolveLaunchAgentPlistPathForLabel(env, label);
@@ -329,7 +330,7 @@ export async function writeLaunchAgentPlist({
     programArguments: prepared.programArguments,
     workingDirectory,
     stdoutPath,
-    stderrPath: LAUNCH_AGENT_STDERR_PATH,
+    stderrPath,
     environment: prepared.inlineEnvironment,
   });
   await publishLaunchAgentPlist({ label, plistPath, contents: plist });
@@ -356,7 +357,9 @@ export async function rewriteLaunchAgentPlistForRestart({
     return false;
   }
 
-  const { logDir, stdoutPath } = resolveGatewaySupervisorLogPaths(env, { platform: "darwin" });
+  const { logDir, stdoutPath, stderrPath } = resolveGatewaySupervisorLogPaths(env, {
+    platform: "darwin",
+  });
   await ensureSecureDirectory(logDir);
 
   const serviceDescription = resolveGatewayServiceDescription({
@@ -382,7 +385,7 @@ export async function rewriteLaunchAgentPlistForRestart({
     programArguments: prepared.programArguments,
     workingDirectory: existing.workingDirectory,
     stdoutPath,
-    stderrPath: LAUNCH_AGENT_STDERR_PATH,
+    stderrPath,
     environment: prepared.inlineEnvironment,
   });
   const previousPlist = await fs.readFile(plistPath, "utf8").catch(() => "");

--- a/src/daemon/launchd-stdio.test.ts
+++ b/src/daemon/launchd-stdio.test.ts
@@ -36,4 +36,18 @@ describe("launchd stdio advertisement", () => {
     expect(guidance).toContain(formatCliCommand("openclaw gateway install --force"));
     expect(guidance).not.toMatch(/openclaw gateway install(?! --force)/);
   });
+
+  it("formats rewrite commands for the diagnosed service owner", () => {
+    const guidance = formatLaunchdStderrRewriteGuidance(
+      {},
+      {
+        restartCommand: "openclaw node restart",
+        forceInstallCommand: "openclaw node install --force",
+      },
+    );
+    expect(guidance).toContain(formatCliCommand("openclaw node restart"));
+    expect(guidance).toContain(formatCliCommand("openclaw node install --force"));
+    expect(guidance).not.toContain("openclaw gateway restart");
+    expect(guidance).not.toContain("openclaw gateway install");
+  });
 });

--- a/src/daemon/launchd-stdio.test.ts
+++ b/src/daemon/launchd-stdio.test.ts
@@ -4,7 +4,6 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { parseLaunchdPlistStdioPaths } from "./launchd-plist.js";
 import {
   formatLaunchdStderrRewriteGuidance,
-  isLaunchdStdioSuppressed,
   resolveAdvertisedLaunchdStderr,
 } from "./launchd-stdio.js";
 
@@ -24,10 +23,9 @@ describe("launchd stdio advertisement", () => {
   });
 
   it("treats /dev/null and a missing plist as suppressed", () => {
-    expect(isLaunchdStdioSuppressed("/dev/null")).toBe(true);
-    expect(isLaunchdStdioSuppressed(null)).toBe(true);
     expect(resolveAdvertisedLaunchdStderr("/dev/null")).toEqual({ kind: "suppressed" });
     expect(resolveAdvertisedLaunchdStderr(null)).toEqual({ kind: "suppressed" });
+    expect(resolveAdvertisedLaunchdStderr("")).toEqual({ kind: "suppressed" });
   });
 
   it("points a loaded legacy LaunchAgent at rewrite-capable commands", () => {

--- a/src/daemon/launchd-stdio.test.ts
+++ b/src/daemon/launchd-stdio.test.ts
@@ -1,0 +1,27 @@
+// Launchd stdio helpers must follow the installed plist, not the rewrite target.
+import { describe, expect, it } from "vitest";
+import { parseLaunchdPlistStdioPaths } from "./launchd-plist.js";
+import { isLaunchdStdioSuppressed, resolveAdvertisedLaunchdStderr } from "./launchd-stdio.js";
+
+describe("launchd stdio advertisement", () => {
+  it("reads StandardErrorPath from the persisted plist", () => {
+    const parsed = parseLaunchdPlistStdioPaths(`
+      <key>StandardOutPath</key>
+      <string>/Users/test/Library/Logs/openclaw/gateway.log</string>
+      <key>StandardErrorPath</key>
+      <string>/Users/test/Library/Logs/openclaw/gateway.err.log</string>
+    `);
+    expect(parsed.stderrPath).toBe("/Users/test/Library/Logs/openclaw/gateway.err.log");
+    expect(resolveAdvertisedLaunchdStderr(parsed.stderrPath)).toEqual({
+      kind: "file",
+      path: "/Users/test/Library/Logs/openclaw/gateway.err.log",
+    });
+  });
+
+  it("treats /dev/null and a missing plist as suppressed", () => {
+    expect(isLaunchdStdioSuppressed("/dev/null")).toBe(true);
+    expect(isLaunchdStdioSuppressed(null)).toBe(true);
+    expect(resolveAdvertisedLaunchdStderr("/dev/null")).toEqual({ kind: "suppressed" });
+    expect(resolveAdvertisedLaunchdStderr(null)).toEqual({ kind: "suppressed" });
+  });
+});

--- a/src/daemon/launchd-stdio.test.ts
+++ b/src/daemon/launchd-stdio.test.ts
@@ -1,7 +1,12 @@
 // Launchd stdio helpers must follow the installed plist, not the rewrite target.
 import { describe, expect, it } from "vitest";
+import { formatCliCommand } from "../cli/command-format.js";
 import { parseLaunchdPlistStdioPaths } from "./launchd-plist.js";
-import { isLaunchdStdioSuppressed, resolveAdvertisedLaunchdStderr } from "./launchd-stdio.js";
+import {
+  formatLaunchdStderrRewriteGuidance,
+  isLaunchdStdioSuppressed,
+  resolveAdvertisedLaunchdStderr,
+} from "./launchd-stdio.js";
 
 describe("launchd stdio advertisement", () => {
   it("reads StandardErrorPath from the persisted plist", () => {
@@ -23,5 +28,12 @@ describe("launchd stdio advertisement", () => {
     expect(isLaunchdStdioSuppressed(null)).toBe(true);
     expect(resolveAdvertisedLaunchdStderr("/dev/null")).toEqual({ kind: "suppressed" });
     expect(resolveAdvertisedLaunchdStderr(null)).toEqual({ kind: "suppressed" });
+  });
+
+  it("points a loaded legacy LaunchAgent at rewrite-capable commands", () => {
+    const guidance = formatLaunchdStderrRewriteGuidance({});
+    expect(guidance).toContain(formatCliCommand("openclaw gateway restart"));
+    expect(guidance).toContain(formatCliCommand("openclaw gateway install --force"));
+    expect(guidance).not.toMatch(/openclaw gateway install(?! --force)/);
   });
 });

--- a/src/daemon/launchd-stdio.ts
+++ b/src/daemon/launchd-stdio.ts
@@ -9,7 +9,7 @@ const LAUNCHD_NULL_STDIO_PATH = "/dev/null";
 
 // Type predicate so advertised-file callers get a real path. A plain boolean
 // leaves `string | null` in the file branch and fails check-prod-types.
-export function isLaunchdStdioSuppressed(
+function isLaunchdStdioSuppressed(
   path: string | null | undefined,
 ): path is null | undefined | "" | typeof LAUNCHD_NULL_STDIO_PATH {
   return !path || path === LAUNCHD_NULL_STDIO_PATH;

--- a/src/daemon/launchd-stdio.ts
+++ b/src/daemon/launchd-stdio.ts
@@ -1,5 +1,6 @@
 /** Reads persisted LaunchAgent stdio paths so status does not invent them. */
 import fs from "node:fs";
+import { formatCliCommand } from "../cli/command-format.js";
 import { parseLaunchdPlistStdioPaths } from "./launchd-plist.js";
 import { resolveLaunchAgentPlistPath } from "./launchd-service-files.js";
 import type { GatewayServiceEnv } from "./service-types.js";
@@ -28,4 +29,9 @@ export function resolveAdvertisedLaunchdStderr(
     return { kind: "suppressed" };
   }
   return { kind: "file", path: persistedStderrPath };
+}
+
+/** Loaded LaunchAgents skip a plain install; restart or install --force rewrites stderr. */
+export function formatLaunchdStderrRewriteGuidance(env: GatewayServiceEnv = process.env): string {
+  return `Rewrite the LaunchAgent with ${formatCliCommand("openclaw gateway restart", env)} or ${formatCliCommand("openclaw gateway install --force", env)}.`;
 }

--- a/src/daemon/launchd-stdio.ts
+++ b/src/daemon/launchd-stdio.ts
@@ -31,7 +31,20 @@ export function resolveAdvertisedLaunchdStderr(
   return { kind: "file", path: persistedStderrPath };
 }
 
+export type LaunchdStderrRewriteCommands = {
+  restartCommand: string;
+  forceInstallCommand: string;
+};
+
+const GATEWAY_LAUNCHD_STDERR_REWRITE_COMMANDS: LaunchdStderrRewriteCommands = {
+  restartCommand: "openclaw gateway restart",
+  forceInstallCommand: "openclaw gateway install --force",
+};
+
 /** Loaded LaunchAgents skip a plain install; restart or install --force rewrites stderr. */
-export function formatLaunchdStderrRewriteGuidance(env: GatewayServiceEnv = process.env): string {
-  return `Rewrite the LaunchAgent with ${formatCliCommand("openclaw gateway restart", env)} or ${formatCliCommand("openclaw gateway install --force", env)}.`;
+export function formatLaunchdStderrRewriteGuidance(
+  env: GatewayServiceEnv = process.env,
+  commands: LaunchdStderrRewriteCommands = GATEWAY_LAUNCHD_STDERR_REWRITE_COMMANDS,
+): string {
+  return `Rewrite the LaunchAgent with ${formatCliCommand(commands.restartCommand, env)} or ${formatCliCommand(commands.forceInstallCommand, env)}.`;
 }

--- a/src/daemon/launchd-stdio.ts
+++ b/src/daemon/launchd-stdio.ts
@@ -7,7 +7,11 @@ import type { GatewayServiceEnv } from "./service-types.js";
 
 const LAUNCHD_NULL_STDIO_PATH = "/dev/null";
 
-export function isLaunchdStdioSuppressed(path: string | null | undefined): boolean {
+// Type predicate so advertised-file callers get a real path. A plain boolean
+// leaves `string | null` in the file branch and fails check-prod-types.
+export function isLaunchdStdioSuppressed(
+  path: string | null | undefined,
+): path is null | undefined | "" | typeof LAUNCHD_NULL_STDIO_PATH {
   return !path || path === LAUNCHD_NULL_STDIO_PATH;
 }
 

--- a/src/daemon/launchd-stdio.ts
+++ b/src/daemon/launchd-stdio.ts
@@ -1,0 +1,31 @@
+/** Reads persisted LaunchAgent stdio paths so status does not invent them. */
+import fs from "node:fs";
+import { parseLaunchdPlistStdioPaths } from "./launchd-plist.js";
+import { resolveLaunchAgentPlistPath } from "./launchd-service-files.js";
+import type { GatewayServiceEnv } from "./service-types.js";
+
+const LAUNCHD_NULL_STDIO_PATH = "/dev/null";
+
+export function isLaunchdStdioSuppressed(path: string | null | undefined): boolean {
+  return !path || path === LAUNCHD_NULL_STDIO_PATH;
+}
+
+/** Returns the installed LaunchAgent stderr path, or null when it is absent or unreadable. */
+export function readPersistedLaunchdStderrPath(env: GatewayServiceEnv): string | null {
+  try {
+    const contents = fs.readFileSync(resolveLaunchAgentPlistPath(env), "utf8");
+    return parseLaunchdPlistStdioPaths(contents).stderrPath;
+  } catch {
+    return null;
+  }
+}
+
+/** Advertises stderr only when the installed plist actually writes that file. */
+export function resolveAdvertisedLaunchdStderr(
+  persistedStderrPath: string | null,
+): { kind: "file"; path: string } | { kind: "suppressed" } {
+  if (isLaunchdStdioSuppressed(persistedStderrPath)) {
+    return { kind: "suppressed" };
+  }
+  return { kind: "file", path: persistedStderrPath };
+}

--- a/src/daemon/launchd-stdio.ts
+++ b/src/daemon/launchd-stdio.ts
@@ -37,7 +37,7 @@ export function resolveAdvertisedLaunchdStderr(
 
 export type LaunchdStderrRewriteCommands = {
   restartCommand: string;
-  forceInstallCommand: string;
+  forceInstallCommand?: string;
 };
 
 const GATEWAY_LAUNCHD_STDERR_REWRITE_COMMANDS: LaunchdStderrRewriteCommands = {
@@ -50,5 +50,8 @@ export function formatLaunchdStderrRewriteGuidance(
   env: GatewayServiceEnv = process.env,
   commands: LaunchdStderrRewriteCommands = GATEWAY_LAUNCHD_STDERR_REWRITE_COMMANDS,
 ): string {
-  return `Rewrite the LaunchAgent with ${formatCliCommand(commands.restartCommand, env)} or ${formatCliCommand(commands.forceInstallCommand, env)}.`;
+  const restartCommand = formatCliCommand(commands.restartCommand, env);
+  return commands.forceInstallCommand
+    ? `Rewrite the LaunchAgent with ${restartCommand} or ${formatCliCommand(commands.forceInstallCommand, env)}.`
+    : `Rewrite the LaunchAgent with ${restartCommand}.`;
 }

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -2532,6 +2532,8 @@ describe("launchd install", () => {
     expect(plist).toContain("<string>/dev/null</string>");
     expect(plist).toContain("<key>StandardOutPath</key>");
     expect(plist).toContain("<string>/Users/test/Library/Logs/openclaw/gateway.log</string>");
+    expect(plist).toContain("<key>StandardErrorPath</key>");
+    expect(plist).toContain("<string>/Users/test/Library/Logs/openclaw/gateway.err.log</string>");
     expect(plist).not.toContain("<key>SuccessfulExit</key>");
     expect(plist).toContain("<key>ExitTimeOut</key>");
     expect(plist).toContain(`<integer>${LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS}</integer>`);
@@ -2564,7 +2566,7 @@ describe("launchd install", () => {
     expect(plist).toContain("<key>StandardOutPath</key>");
     expect(plist).toContain("<string>/Users/test/Library/Logs/openclaw/gateway.log</string>");
     expect(plist).toContain("<key>StandardErrorPath</key>");
-    expect(plist).toContain("<string>/dev/null</string>");
+    expect(plist).toContain("<string>/Users/test/Library/Logs/openclaw/gateway.err.log</string>");
     expect(plist).toContain("<key>KeepAlive</key>");
     expect(plist).toContain("<string>node</string>");
     expect(plist).not.toContain("OPENCLAW_SERVICE_VERSION");

--- a/src/daemon/runtime-hints.test.ts
+++ b/src/daemon/runtime-hints.test.ts
@@ -17,7 +17,7 @@ describe("buildPlatformRuntimeLogHints", () => {
       }),
     ).toEqual([
       "Launchd stdout (if installed): /Users/test/Library/Logs/openclaw/gateway.log",
-      "Launchd stderr (if installed): suppressed",
+      "Launchd stderr (if installed): /Users/test/Library/Logs/openclaw/gateway.err.log",
       "Restart attempts: /tmp/openclaw-state/logs/gateway-restart.log",
     ]);
   });

--- a/src/daemon/runtime-hints.test.ts
+++ b/src/daemon/runtime-hints.test.ts
@@ -1,9 +1,61 @@
 // Daemon runtime hint tests cover platform-specific daemon guidance.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { formatCliCommand } from "../cli/command-format.js";
 import { buildPlatformRuntimeLogHints, buildPlatformServiceStartHints } from "./runtime-hints.js";
 
+const { readPersistedLaunchdStderrPath } = vi.hoisted(() => ({
+  readPersistedLaunchdStderrPath: vi.fn(() => null as string | null),
+}));
+
+vi.mock("./launchd-stdio.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./launchd-stdio.js")>();
+  return {
+    ...actual,
+    readPersistedLaunchdStderrPath,
+  };
+});
+
 describe("buildPlatformRuntimeLogHints", () => {
-  it("renders launchd log hints on darwin", () => {
+  it("does not invent gateway.err.log when the LaunchAgent plist is missing", () => {
+    readPersistedLaunchdStderrPath.mockReturnValue(null);
+    expect(
+      buildPlatformRuntimeLogHints({
+        platform: "darwin",
+        env: {
+          HOME: "/Users/test",
+          OPENCLAW_STATE_DIR: "/tmp/openclaw-state",
+          OPENCLAW_LOG_PREFIX: "gateway",
+        },
+        systemdServiceName: "openclaw-gateway",
+        windowsTaskName: "OpenClaw Gateway",
+      }),
+    ).toEqual([
+      "Launchd stdout (if installed): /Users/test/Library/Logs/openclaw/gateway.log",
+      `Launchd stderr (if installed): suppressed (/dev/null). Rewrite the LaunchAgent with ${formatCliCommand("openclaw gateway install")}.`,
+      "Restart attempts: /tmp/openclaw-state/logs/gateway-restart.log",
+    ]);
+  });
+
+  it("does not invent gateway.err.log when the LaunchAgent still discards stderr", () => {
+    readPersistedLaunchdStderrPath.mockReturnValue("/dev/null");
+    const hints = buildPlatformRuntimeLogHints({
+      platform: "darwin",
+      env: {
+        HOME: "/Users/test",
+        OPENCLAW_STATE_DIR: "/tmp/openclaw-state",
+        OPENCLAW_LOG_PREFIX: "gateway",
+      },
+      systemdServiceName: "openclaw-gateway",
+      windowsTaskName: "OpenClaw Gateway",
+    });
+    expect(hints[1]).toContain("suppressed (/dev/null)");
+    expect(hints[1]).not.toContain("gateway.err.log");
+  });
+
+  it("advertises the persisted LaunchAgent stderr path after rewrite", () => {
+    readPersistedLaunchdStderrPath.mockReturnValue(
+      "/Users/test/Library/Logs/openclaw/gateway.err.log",
+    );
     expect(
       buildPlatformRuntimeLogHints({
         platform: "darwin",

--- a/src/daemon/runtime-hints.test.ts
+++ b/src/daemon/runtime-hints.test.ts
@@ -31,7 +31,7 @@ describe("buildPlatformRuntimeLogHints", () => {
       }),
     ).toEqual([
       "Launchd stdout (if installed): /Users/test/Library/Logs/openclaw/gateway.log",
-      `Launchd stderr (if installed): suppressed (/dev/null). Rewrite the LaunchAgent with ${formatCliCommand("openclaw gateway install")}.`,
+      `Launchd stderr (if installed): suppressed (/dev/null). Rewrite the LaunchAgent with ${formatCliCommand("openclaw gateway restart")} or ${formatCliCommand("openclaw gateway install --force")}.`,
       "Restart attempts: /tmp/openclaw-state/logs/gateway-restart.log",
     ]);
   });

--- a/src/daemon/runtime-hints.test.ts
+++ b/src/daemon/runtime-hints.test.ts
@@ -52,6 +52,28 @@ describe("buildPlatformRuntimeLogHints", () => {
     expect(hints[1]).not.toContain("gateway.err.log");
   });
 
+  it("uses Node rewrite commands for a suppressed Node LaunchAgent", () => {
+    readPersistedLaunchdStderrPath.mockReturnValue("/dev/null");
+    const hints = buildPlatformRuntimeLogHints({
+      platform: "darwin",
+      env: {
+        HOME: "/Users/test",
+        OPENCLAW_STATE_DIR: "/tmp/openclaw-state",
+        OPENCLAW_LOG_PREFIX: "node",
+      },
+      systemdServiceName: "openclaw-node",
+      windowsTaskName: "OpenClaw Node",
+      rewriteCommands: {
+        restartCommand: "openclaw node restart",
+        forceInstallCommand: "openclaw node install --force",
+      },
+    });
+    expect(hints[1]).toContain(formatCliCommand("openclaw node restart"));
+    expect(hints[1]).toContain(formatCliCommand("openclaw node install --force"));
+    expect(hints[1]).not.toContain("openclaw gateway restart");
+    expect(hints[1]).not.toContain("openclaw gateway install");
+  });
+
   it("advertises the persisted LaunchAgent stderr path after rewrite", () => {
     readPersistedLaunchdStderrPath.mockReturnValue(
       "/Users/test/Library/Logs/openclaw/gateway.err.log",

--- a/src/daemon/runtime-hints.ts
+++ b/src/daemon/runtime-hints.ts
@@ -1,7 +1,10 @@
 /** Builds platform-specific log and start hints for daemon status output. */
-import { formatCliCommand } from "../cli/command-format.js";
 import { resolveGatewaySystemdServiceName, resolveGatewayWindowsTaskName } from "./constants.js";
-import { readPersistedLaunchdStderrPath, resolveAdvertisedLaunchdStderr } from "./launchd-stdio.js";
+import {
+  formatLaunchdStderrRewriteGuidance,
+  readPersistedLaunchdStderrPath,
+  resolveAdvertisedLaunchdStderr,
+} from "./launchd-stdio.js";
 import { resolveGatewayRestartLogPath, resolveGatewaySupervisorLogPaths } from "./restart-logs.js";
 
 export function buildPlatformRuntimeLogHints(params: {
@@ -18,7 +21,7 @@ export function buildPlatformRuntimeLogHints(params: {
     const stderrHint =
       advertisedStderr.kind === "file"
         ? `Launchd stderr (if installed): ${advertisedStderr.path}`
-        : `Launchd stderr (if installed): suppressed (/dev/null). Rewrite the LaunchAgent with ${formatCliCommand("openclaw gateway install", env)}.`;
+        : `Launchd stderr (if installed): suppressed (/dev/null). ${formatLaunchdStderrRewriteGuidance(env)}`;
     // Preserve the writer's path bytes; backslashes can be literal POSIX filename characters.
     return [
       `Launchd stdout (if installed): ${logs.stdoutPath}`,

--- a/src/daemon/runtime-hints.ts
+++ b/src/daemon/runtime-hints.ts
@@ -4,6 +4,7 @@ import {
   formatLaunchdStderrRewriteGuidance,
   readPersistedLaunchdStderrPath,
   resolveAdvertisedLaunchdStderr,
+  type LaunchdStderrRewriteCommands,
 } from "./launchd-stdio.js";
 import { resolveGatewayRestartLogPath, resolveGatewaySupervisorLogPaths } from "./restart-logs.js";
 
@@ -12,6 +13,7 @@ export function buildPlatformRuntimeLogHints(params: {
   env?: NodeJS.ProcessEnv;
   systemdServiceName: string;
   windowsTaskName: string;
+  rewriteCommands?: LaunchdStderrRewriteCommands;
 }): string[] {
   const platform = params.platform ?? process.platform;
   const env = { ...process.env, ...params.env };
@@ -21,7 +23,7 @@ export function buildPlatformRuntimeLogHints(params: {
     const stderrHint =
       advertisedStderr.kind === "file"
         ? `Launchd stderr (if installed): ${advertisedStderr.path}`
-        : `Launchd stderr (if installed): suppressed (/dev/null). ${formatLaunchdStderrRewriteGuidance(env)}`;
+        : `Launchd stderr (if installed): suppressed (/dev/null). ${formatLaunchdStderrRewriteGuidance(env, params.rewriteCommands)}`;
     // Preserve the writer's path bytes; backslashes can be literal POSIX filename characters.
     return [
       `Launchd stdout (if installed): ${logs.stdoutPath}`,

--- a/src/daemon/runtime-hints.ts
+++ b/src/daemon/runtime-hints.ts
@@ -15,7 +15,7 @@ export function buildPlatformRuntimeLogHints(params: {
     // Preserve the writer's path bytes; backslashes can be literal POSIX filename characters.
     return [
       `Launchd stdout (if installed): ${logs.stdoutPath}`,
-      "Launchd stderr (if installed): suppressed",
+      `Launchd stderr (if installed): ${logs.stderrPath}`,
       `Restart attempts: ${resolveGatewayRestartLogPath(env)}`,
     ];
   }

--- a/src/daemon/runtime-hints.ts
+++ b/src/daemon/runtime-hints.ts
@@ -1,5 +1,7 @@
 /** Builds platform-specific log and start hints for daemon status output. */
+import { formatCliCommand } from "../cli/command-format.js";
 import { resolveGatewaySystemdServiceName, resolveGatewayWindowsTaskName } from "./constants.js";
+import { readPersistedLaunchdStderrPath, resolveAdvertisedLaunchdStderr } from "./launchd-stdio.js";
 import { resolveGatewayRestartLogPath, resolveGatewaySupervisorLogPaths } from "./restart-logs.js";
 
 export function buildPlatformRuntimeLogHints(params: {
@@ -12,10 +14,15 @@ export function buildPlatformRuntimeLogHints(params: {
   const env = { ...process.env, ...params.env };
   if (platform === "darwin") {
     const logs = resolveGatewaySupervisorLogPaths(env, { platform });
+    const advertisedStderr = resolveAdvertisedLaunchdStderr(readPersistedLaunchdStderrPath(env));
+    const stderrHint =
+      advertisedStderr.kind === "file"
+        ? `Launchd stderr (if installed): ${advertisedStderr.path}`
+        : `Launchd stderr (if installed): suppressed (/dev/null). Rewrite the LaunchAgent with ${formatCliCommand("openclaw gateway install", env)}.`;
     // Preserve the writer's path bytes; backslashes can be literal POSIX filename characters.
     return [
       `Launchd stdout (if installed): ${logs.stdoutPath}`,
-      `Launchd stderr (if installed): ${logs.stderrPath}`,
+      stderrHint,
       `Restart attempts: ${resolveGatewayRestartLogPath(env)}`,
     ];
   }

--- a/src/daemon/runtime-hints.ts
+++ b/src/daemon/runtime-hints.ts
@@ -53,6 +53,7 @@ export function buildGatewayRuntimeRecoveryHints(params: {
   logFile?: string | null;
   platform?: NodeJS.Platform;
   env: NodeJS.ProcessEnv;
+  rewriteCommands?: LaunchdStderrRewriteCommands;
 }): string[] {
   const hints =
     params.kind === "gui-session"
@@ -72,6 +73,7 @@ export function buildGatewayRuntimeRecoveryHints(params: {
         env: params.env,
         systemdServiceName: resolveGatewaySystemdServiceName(params.env.OPENCLAW_PROFILE),
         windowsTaskName: resolveGatewayWindowsTaskName(params.env.OPENCLAW_PROFILE),
+        rewriteCommands: params.rewriteCommands,
       }),
     );
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running the macOS LaunchAgent Gateway encounter a silent crash loop when the generated `service-env` file fails to source, such as after an operator adds an unquoted path with spaces. The shell exits before OpenClaw starts, stdout stays empty, and the installed plist discards stderr through `/dev/null`.

## Why This Change Was Made

Use the existing service/profile-scoped supervisor stderr path when an install or rewrite-capable restart writes the LaunchAgent plist. Status, status-all, diagnostics, and stopped-service hints read the installed destination; they do not invent a log path for an unrevised plist that still suppresses stderr.

Recovery commands use the inspected service environment and identity. Gateway diagnostics name Gateway restart/force-install commands; Node diagnostics name Node commands. A named profile is preserved instead of accidentally targeting the default service. A plain install on an already loaded service does not rewrite its plist.

No separate environment syntax checker is added. The shared producer owns the stderr destination and the shared diagnostic helper owns advertised paths and rewrite guidance.

## User Impact

After a plist rewrite, macOS operators can inspect `~/Library/Logs/openclaw/gateway.err.log` (or `gateway-<profile>.err.log`) to see wrapper/process errors. Old plists keep their existing destination until a rewrite-capable command runs.

**Owner decision still required:** this begins retaining raw shell/process stderr during installation and rewrite-capable restart upgrades. Errors before OpenClaw starts do not pass through application redaction; malformed custom environment content may leave sensitive fragments on disk. Redacting later diagnostic output does not redact those stored bytes. The macOS guide now warns operators to inspect/redact logs before sharing and check permissions and ACLs on shared machines.

Access-protection inspection, not an unrun permission-proof claim:

- The plist retains [`Umask=077`](https://github.com/openclaw/openclaw/blob/4be893f0c01bedf41f33899c434cf551afb201a2/src/daemon/launchd-plist.ts#L18). This does not tighten an already existing file's permissions or remove ACL entries.
- [`ensureSecureDirectory`](https://github.com/openclaw/openclaw/blob/4be893f0c01bedf41f33899c434cf551afb201a2/src/daemon/launchd-service-files.ts#L266) removes group/other write access for the ordinary log directory, not read access. Both plist writers call it. They do not chmod an existing stderr file.
- Generated environment files remain `0600` and wrappers `0700`; those protections are distinct from the raw stderr file. No claim is made that this PR guarantees owner-only access to every pre-existing log.

Upgrade/rollback boundary: no SQLite schema or version changes. The changed durable artifact is the plist's `StandardErrorPath`, and raw logs are an intentional retained artifact. Existing `/dev/null` destinations remain suppressed until rewritten. Rolling back code alone does not remove an already rewritten plist or erase bytes already captured; no cleanup or retention acceptance is claimed. A maintainer must accept this behavior and its access-protection policy before merge.

## Evidence

Current head: `4be893f0c01bedf41f33899c434cf551afb201a2`. The last commit adds only the five-line macOS documentation warning; production and tests are unchanged from `012211cd86004103c8e39cfad6a66abf2789c8fe`.

- Current docs validation: `node scripts/check-docs-mdx.mjs docs/platforms/mac/bundled-gateway.md` passed (1 file); `node --import ./scripts/tsx.mjs scripts/format-docs.mts --check` passed (851 files); `git diff --check` passed. No new runtime execution is attributed to this docs-only commit.
- [Current-head full CI](https://github.com/openclaw/openclaw/actions/runs/34201701009) passed independently at `4be893f0c01bedf41f33899c434cf551afb201a2`, including both Windows shards. Final aggregation: 165 passed, 44 skipped, no failed or pending checks. The [previous production/test head](https://github.com/openclaw/openclaw/actions/runs/34181610032) also passed.
- The prior Linux failure was repaired by keeping the Nix assertion inside the test's mocked Darwin scope and restoring `process.platform` in `finally`. Recorded validation at `012211cd860`: CLI status 52 passed/1 skipped, daemon 196 passed, status-all diagnosis 22 passed, independent P0–P2 review clean.
- Prior live macOS proof, with unchanged production behavior: a throwaway named-profile Gateway installation wrote the scoped stderr path; a broken environment source produced the shell error and exit status in that log; Gateway status advertised the installed file. [Recorded proof](https://github.com/openclaw/openclaw/pull/133380#issuecomment-5472775390). This is not a fresh launchd or ACL test on the latest head.
- `/dev/null`, missing/empty plist paths, named-profile commands, and Node-versus-Gateway recovery are covered through the shared diagnostic owner. No production operator service was restarted or modified for the documentation follow-up.

The remaining retention/security choice is explicitly undisposed; passing tests and the existing `ready for maintainer look` label do not substitute for owner acceptance.
