### PR TITLE
fix(gateway): distinguish socat forwards that name OpenClaw

### DIFF
--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -1,5 +1,7 @@
+import { spawn } from "node:child_process";
 // Process coverage for one-shot Gateway CLI output followed by clean exit.
 import { createHash } from "node:crypto";
+import { once } from "node:events";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -556,6 +558,76 @@ describe("gateway-backed CLI process exit", () => {
           .map((value) => Number.parseInt(value, 10)),
       );
       expect(entryPids.size).toBe(1);
+    },
+  );
+
+  it.runIf(process.platform === "linux")(
+    "reports a socat-owned port through the gateway status entry process",
+    async () => {
+      const root = tempDirs.make("openclaw-gateway-status-socat-");
+      const stateDir = path.join(root, "state");
+      const configPath = path.join(stateDir, "openclaw.json");
+      const listenerPath = path.join(root, "socat-listener.mjs");
+      const port = await getFreePort();
+      await fs.mkdir(stateDir, { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ gateway: { mode: "local", bind: "loopback", auth: { mode: "none" } } }),
+      );
+      await fs.writeFile(
+        listenerPath,
+        [
+          'import fs from "node:fs";',
+          'import net from "node:net";',
+          'fs.writeFileSync("/proc/self/comm", "socat");',
+          'net.createServer().listen(Number(process.argv[2]), "127.0.0.1", () => {',
+          '  process.stdout.write("ready\\n");',
+          "});",
+          "",
+        ].join("\n"),
+      );
+      const listener = spawn(process.execPath, [listenerPath, String(port), "openclaw"], {
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let listenerStderr = "";
+      listener.stderr.setEncoding("utf8");
+      listener.stderr.on("data", (chunk: string) => {
+        listenerStderr += chunk;
+      });
+
+      try {
+        const ready = await Promise.race([
+          once(listener.stdout, "data").then(([chunk]) => String(chunk)),
+          once(listener, "exit").then(([code, signal]) => {
+            throw new Error(
+              `socat fixture exited before listening: code=${code} signal=${signal}\n${listenerStderr}`,
+            );
+          }),
+        ]);
+        expect(ready).toContain("ready");
+
+        const result = await runIsolatedGatewayCli({
+          args: ["gateway", "status", "--port", String(port), "--no-probe", "--json"],
+          root,
+          stateDir,
+          configPath,
+        });
+
+        expect(result, result.stderr).toMatchObject({ code: 0, signal: null, stderr: "" });
+        expect(JSON.parse(result.stdout)).toMatchObject({
+          port: {
+            port,
+            status: "busy",
+            listeners: [expect.objectContaining({ command: "socat" })],
+            hints: ["Another process is listening on this port."],
+          },
+        });
+      } finally {
+        if (listener.exitCode === null && listener.signalCode === null) {
+          listener.kill("SIGTERM");
+          await once(listener, "exit");
+        }
+      }
     },
   );
 

--- a/src/infra/ports-format.test.ts
+++ b/src/infra/ports-format.test.ts
@@ -43,9 +43,35 @@ describe("ports-format", () => {
     [{ commandLine: "/opt/fast-ssh/server --listen 127.0.0.1:18789" }, "non_gateway"],
     [{ commandLine: "ssh -N -L 9999:remote:22 host" }, "ssh"],
     [{ commandLine: "node /Users/me/Projects/openclaw/dist/entry.js gateway" }, "gateway"],
+    [{ command: "socat" }, "non_gateway"],
+    [
+      {
+        commandLine: "socat TCP-LISTEN:18789,bind=100.64.0.1,fork TCP:127.0.0.1:18789",
+      },
+      "non_gateway",
+    ],
+    [
+      {
+        commandLine: "/opt/homebrew/bin/socat TCP-LISTEN:18789,reuseaddr,fork TCP:127.0.0.1:18789",
+      },
+      "non_gateway",
+    ],
     [{ commandLine: "python -m http.server 18789" }, "unknown"],
   ] as const)("classifies port listener %j", (listener, expected) => {
     expect(classifyPortListener(listener, 18789)).toBe(expected);
+  });
+
+  it("does not treat a socat port forward as the gateway", () => {
+    const hints = buildPortHints(
+      [
+        {
+          commandLine: "socat TCP-LISTEN:18789,bind=100.64.0.1,fork TCP:127.0.0.1:18789",
+        },
+      ],
+      18789,
+    );
+    expect(hints).not.toContain(gatewayAlreadyRunningHint);
+    expect(hints).toContain("Another process is listening on this port.");
   });
 
   it("does not emit the SSH tunnel hint for an ssh-named non-tunnel process", () => {

--- a/src/infra/ports-format.test.ts
+++ b/src/infra/ports-format.test.ts
@@ -46,29 +46,11 @@ describe("ports-format", () => {
     [{ command: "node", commandLine: "node /tmp/socat/openclaw/dist/index.js gateway" }, "gateway"],
     [{ command: "socat" }, "non_gateway"],
     [{ command: "socat1" }, "non_gateway"],
-    [
-      {
-        commandLine: "socat TCP-LISTEN:18789,bind=100.64.0.1,fork TCP:127.0.0.1:18789",
-      },
-      "non_gateway",
-    ],
-    [
-      {
-        commandLine: "/opt/homebrew/bin/socat TCP-LISTEN:18789,reuseaddr,fork TCP:127.0.0.1:18789",
-      },
-      "non_gateway",
-    ],
-    [
-      {
-        commandLine:
-          '"C:\\Program Files\\socat\\socat.exe" TCP-LISTEN:18789,fork TCP:127.0.0.1:18789',
-      },
-      "non_gateway",
-    ],
+    [{ command: "socat.exe" }, "non_gateway"],
     [
       {
         command: "socat",
-        commandLine: "socat TCP-LISTEN:18789,fork EXEC:openclaw",
+        commandLine: "socat -lpopenclaw TCP-LISTEN:18789,fork TCP:127.0.0.1:18789",
       },
       "non_gateway",
     ],
@@ -79,51 +61,9 @@ describe("ports-format", () => {
       },
       "gateway",
     ],
-    [{ commandLine: "openclaw gateway --profile socat" }, "gateway"],
     [{ commandLine: "python -m http.server 18789" }, "unknown"],
   ] as const)("classifies port listener %j", (listener, expected) => {
     expect(classifyPortListener(listener, 18789)).toBe(expected);
-  });
-
-  it("does not treat a socat port forward as the gateway", () => {
-    const hints = buildPortHints(
-      [
-        {
-          commandLine: "socat TCP-LISTEN:18789,bind=100.64.0.1,fork TCP:127.0.0.1:18789",
-        },
-      ],
-      18789,
-    );
-    expect(hints).not.toContain(gatewayAlreadyRunningHint);
-    expect(hints).toContain("Another process is listening on this port.");
-  });
-
-  it("keeps an OpenClaw listener whose path contains socat as the gateway", () => {
-    const listener = {
-      command: "node",
-      commandLine: "node /tmp/socat/openclaw/dist/index.js gateway",
-    };
-    expect(classifyPortListener(listener, 18789)).toBe("gateway");
-    expect(buildPortHints([listener], 18789)).toContain(gatewayAlreadyRunningHint);
-  });
-
-  it("does not treat a socat command line that mentions openclaw as the gateway", () => {
-    const listener = {
-      commandLine: "socat TCP-LISTEN:18789,bind=100.64.0.1,fork TCP:127.0.0.1:18789 openclaw",
-    };
-    expect(classifyPortListener(listener, 18789)).toBe("non_gateway");
-    const hints = buildPortHints([listener], 18789);
-    expect(hints).not.toContain(gatewayAlreadyRunningHint);
-    expect(hints).toContain("Another process is listening on this port.");
-  });
-
-  it("keeps a Gateway launched with --profile socat as the gateway", () => {
-    const listener = {
-      command: "node",
-      commandLine: "node /Users/me/Projects/openclaw/dist/index.js gateway --profile socat",
-    };
-    expect(classifyPortListener(listener, 18789)).toBe("gateway");
-    expect(buildPortHints([listener], 18789)).toContain(gatewayAlreadyRunningHint);
   });
 
   it("does not emit the SSH tunnel hint for an ssh-named non-tunnel process", () => {

--- a/src/infra/ports-format.test.ts
+++ b/src/infra/ports-format.test.ts
@@ -43,6 +43,7 @@ describe("ports-format", () => {
     [{ commandLine: "/opt/fast-ssh/server --listen 127.0.0.1:18789" }, "non_gateway"],
     [{ commandLine: "ssh -N -L 9999:remote:22 host" }, "ssh"],
     [{ commandLine: "node /Users/me/Projects/openclaw/dist/entry.js gateway" }, "gateway"],
+    [{ command: "node", commandLine: "node /tmp/socat/openclaw/dist/index.js gateway" }, "gateway"],
     [{ command: "socat" }, "non_gateway"],
     [
       {
@@ -79,6 +80,15 @@ describe("ports-format", () => {
     );
     expect(hints).not.toContain(gatewayAlreadyRunningHint);
     expect(hints).toContain("Another process is listening on this port.");
+  });
+
+  it("keeps an OpenClaw listener whose path contains socat as the gateway", () => {
+    const listener = {
+      command: "node",
+      commandLine: "node /tmp/socat/openclaw/dist/index.js gateway",
+    };
+    expect(classifyPortListener(listener, 18789)).toBe("gateway");
+    expect(buildPortHints([listener], 18789)).toContain(gatewayAlreadyRunningHint);
   });
 
   it("does not treat a socat command line that mentions openclaw as the gateway", () => {

--- a/src/infra/ports-format.test.ts
+++ b/src/infra/ports-format.test.ts
@@ -45,6 +45,7 @@ describe("ports-format", () => {
     [{ commandLine: "node /Users/me/Projects/openclaw/dist/entry.js gateway" }, "gateway"],
     [{ command: "node", commandLine: "node /tmp/socat/openclaw/dist/index.js gateway" }, "gateway"],
     [{ command: "socat" }, "non_gateway"],
+    [{ command: "socat1" }, "non_gateway"],
     [
       {
         commandLine: "socat TCP-LISTEN:18789,bind=100.64.0.1,fork TCP:127.0.0.1:18789",
@@ -59,11 +60,26 @@ describe("ports-format", () => {
     ],
     [
       {
+        commandLine:
+          '"C:\\Program Files\\socat\\socat.exe" TCP-LISTEN:18789,fork TCP:127.0.0.1:18789',
+      },
+      "non_gateway",
+    ],
+    [
+      {
         command: "socat",
         commandLine: "socat TCP-LISTEN:18789,fork EXEC:openclaw",
       },
       "non_gateway",
     ],
+    [
+      {
+        command: "node",
+        commandLine: "node /Users/me/Projects/openclaw/dist/index.js gateway --profile socat",
+      },
+      "gateway",
+    ],
+    [{ commandLine: "openclaw gateway --profile socat" }, "gateway"],
     [{ commandLine: "python -m http.server 18789" }, "unknown"],
   ] as const)("classifies port listener %j", (listener, expected) => {
     expect(classifyPortListener(listener, 18789)).toBe(expected);
@@ -99,6 +115,15 @@ describe("ports-format", () => {
     const hints = buildPortHints([listener], 18789);
     expect(hints).not.toContain(gatewayAlreadyRunningHint);
     expect(hints).toContain("Another process is listening on this port.");
+  });
+
+  it("keeps a Gateway launched with --profile socat as the gateway", () => {
+    const listener = {
+      command: "node",
+      commandLine: "node /Users/me/Projects/openclaw/dist/index.js gateway --profile socat",
+    };
+    expect(classifyPortListener(listener, 18789)).toBe("gateway");
+    expect(buildPortHints([listener], 18789)).toContain(gatewayAlreadyRunningHint);
   });
 
   it("does not emit the SSH tunnel hint for an ssh-named non-tunnel process", () => {

--- a/src/infra/ports-format.test.ts
+++ b/src/infra/ports-format.test.ts
@@ -56,6 +56,13 @@ describe("ports-format", () => {
       },
       "non_gateway",
     ],
+    [
+      {
+        command: "socat",
+        commandLine: "socat TCP-LISTEN:18789,fork EXEC:openclaw",
+      },
+      "non_gateway",
+    ],
     [{ commandLine: "python -m http.server 18789" }, "unknown"],
   ] as const)("classifies port listener %j", (listener, expected) => {
     expect(classifyPortListener(listener, 18789)).toBe(expected);
@@ -70,6 +77,16 @@ describe("ports-format", () => {
       ],
       18789,
     );
+    expect(hints).not.toContain(gatewayAlreadyRunningHint);
+    expect(hints).toContain("Another process is listening on this port.");
+  });
+
+  it("does not treat a socat command line that mentions openclaw as the gateway", () => {
+    const listener = {
+      commandLine: "socat TCP-LISTEN:18789,bind=100.64.0.1,fork TCP:127.0.0.1:18789 openclaw",
+    };
+    expect(classifyPortListener(listener, 18789)).toBe("non_gateway");
+    const hints = buildPortHints([listener], 18789);
     expect(hints).not.toContain(gatewayAlreadyRunningHint);
     expect(hints).toContain("Another process is listening on this port.");
   });

--- a/src/infra/ports-format.ts
+++ b/src/infra/ports-format.ts
@@ -39,6 +39,16 @@ export function classifyPortListener(listener: PortListener, _port: number): Por
   if (/(?:^|[/\\\s])[^/\\\s]*ssh[^/\\\s]*(?:\.exe)?(?:[/\\\s"']|$)/.test(commandLine)) {
     return "non_gateway";
   }
+  // Tailscale / Funnel users often front the gateway with socat on the same
+  // port (different bind address). That is not the gateway and must not look
+  // like an occupied OpenClaw listener.
+  if (
+    command === "socat" ||
+    /(?:^|[/\\])socat(?:\.exe)?$/.test(command) ||
+    /(?:^|[/\\\s"'=])socat(?:\.exe)?(?:[/\\\s"']|$)/.test(commandLine)
+  ) {
+    return "non_gateway";
+  }
   return "unknown";
 }
 

--- a/src/infra/ports-format.ts
+++ b/src/infra/ports-format.ts
@@ -5,48 +5,16 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { parseTcpListenerEndpoint } from "./ports-netstat.js";
 import type { PortListener, PortListenerKind, PortUsage } from "./ports-types.js";
 
-function readFirstCommandLineToken(commandLine: string): string {
-  const trimmed = commandLine.trim();
-  if (!trimmed) {
-    return "";
-  }
-  if (trimmed.startsWith('"')) {
-    const end = trimmed.indexOf('"', 1);
-    return end === -1 ? trimmed.slice(1) : trimmed.slice(1, end);
-  }
-  if (trimmed.startsWith("'")) {
-    const end = trimmed.indexOf("'", 1);
-    return end === -1 ? trimmed.slice(1) : trimmed.slice(1, end);
-  }
-  return trimmed.split(/\s/, 1)[0] ?? "";
-}
-
-function isSocatExecutableIdentity(value: string): boolean {
-  // argv[0] / lsof command only. `socat` is a valid profile name, so a later
-  // `--profile socat` token must not hide a real Gateway listener.
-  // macOS lsof may suffix a digit when two socat processes share a name.
-  return /(?:^|[/\\])socat(?:\d+)?(?:\.exe)?$/.test(value);
-}
-
-function isSocatPortListener(command: string, commandLine: string): boolean {
-  return (
-    isSocatExecutableIdentity(command) ||
-    isSocatExecutableIdentity(readFirstCommandLineToken(commandLine))
-  );
-}
-
 /** Classifies a listener as OpenClaw Gateway, SSH tunnel, known non-gateway, or unknown. */
 export function classifyPortListener(listener: PortListener, _port: number): PortListenerKind {
   const command = normalizeLowercaseStringOrEmpty(listener.command ?? "");
   const commandLine = normalizeLowercaseStringOrEmpty(listener.commandLine ?? "");
-  const raw = normalizeLowercaseStringOrEmpty(
-    `${listener.commandLine ?? ""} ${listener.command ?? ""}`,
-  );
-  // Executable identity first. Unix inspection records the full `ps` command
-  // line, so a socat forward can mention OpenClaw without being the gateway.
-  if (isSocatPortListener(command, commandLine)) {
+  // The inspected command identifies the listener owner. Check it before argv,
+  // where a socat forward may name OpenClaw. Observed macOS output also uses `socat1`.
+  if (command === "socat" || command === "socat1" || command === "socat.exe") {
     return "non_gateway";
   }
+  const raw = `${commandLine} ${command}`;
   if (raw.includes("openclaw")) {
     return "gateway";
   }

--- a/src/infra/ports-format.ts
+++ b/src/infra/ports-format.ts
@@ -5,16 +5,33 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { parseTcpListenerEndpoint } from "./ports-netstat.js";
 import type { PortListener, PortListenerKind, PortUsage } from "./ports-types.js";
 
-function isSocatPortListener(command: string, commandLine: string): boolean {
-  // Executable identity only. A Gateway launched from a path that merely
-  // contains `/socat/` must still classify as the Gateway; matching any
-  // command-line token hid those listeners from status and restart.
-  const hasSocatCommand = command === "socat" || /(?:^|[/\\])socat(?:\.exe)?$/.test(command);
-  if (hasSocatCommand) {
-    return true;
+function readFirstCommandLineToken(commandLine: string): string {
+  const trimmed = commandLine.trim();
+  if (!trimmed) {
+    return "";
   }
-  return /(?:^|[\s"'])(?:(?:"[^"]*[/\\])|(?:'[^']*[/\\])|(?:\S*[/\\]))?socat(?:\.exe)?(?:[\s"']|$)/.test(
-    commandLine,
+  if (trimmed.startsWith('"')) {
+    const end = trimmed.indexOf('"', 1);
+    return end === -1 ? trimmed.slice(1) : trimmed.slice(1, end);
+  }
+  if (trimmed.startsWith("'")) {
+    const end = trimmed.indexOf("'", 1);
+    return end === -1 ? trimmed.slice(1) : trimmed.slice(1, end);
+  }
+  return trimmed.split(/\s/, 1)[0] ?? "";
+}
+
+function isSocatExecutableIdentity(value: string): boolean {
+  // argv[0] / lsof command only. `socat` is a valid profile name, so a later
+  // `--profile socat` token must not hide a real Gateway listener.
+  // macOS lsof may suffix a digit when two socat processes share a name.
+  return /(?:^|[/\\])socat(?:\d+)?(?:\.exe)?$/.test(value);
+}
+
+function isSocatPortListener(command: string, commandLine: string): boolean {
+  return (
+    isSocatExecutableIdentity(command) ||
+    isSocatExecutableIdentity(readFirstCommandLineToken(commandLine))
   );
 }
 

--- a/src/infra/ports-format.ts
+++ b/src/infra/ports-format.ts
@@ -6,10 +6,15 @@ import { parseTcpListenerEndpoint } from "./ports-netstat.js";
 import type { PortListener, PortListenerKind, PortUsage } from "./ports-types.js";
 
 function isSocatPortListener(command: string, commandLine: string): boolean {
-  return (
-    command === "socat" ||
-    /(?:^|[/\\])socat(?:\.exe)?$/.test(command) ||
-    /(?:^|[/\\\s"'=])socat(?:\.exe)?(?:[/\\\s"']|$)/.test(commandLine)
+  // Executable identity only. A Gateway launched from a path that merely
+  // contains `/socat/` must still classify as the Gateway; matching any
+  // command-line token hid those listeners from status and restart.
+  const hasSocatCommand = command === "socat" || /(?:^|[/\\])socat(?:\.exe)?$/.test(command);
+  if (hasSocatCommand) {
+    return true;
+  }
+  return /(?:^|[\s"'])(?:(?:"[^"]*[/\\])|(?:'[^']*[/\\])|(?:\S*[/\\]))?socat(?:\.exe)?(?:[\s"']|$)/.test(
+    commandLine,
   );
 }
 

--- a/src/infra/ports-format.ts
+++ b/src/infra/ports-format.ts
@@ -5,16 +5,29 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { parseTcpListenerEndpoint } from "./ports-netstat.js";
 import type { PortListener, PortListenerKind, PortUsage } from "./ports-types.js";
 
+function isSocatPortListener(command: string, commandLine: string): boolean {
+  return (
+    command === "socat" ||
+    /(?:^|[/\\])socat(?:\.exe)?$/.test(command) ||
+    /(?:^|[/\\\s"'=])socat(?:\.exe)?(?:[/\\\s"']|$)/.test(commandLine)
+  );
+}
+
 /** Classifies a listener as OpenClaw Gateway, SSH tunnel, known non-gateway, or unknown. */
 export function classifyPortListener(listener: PortListener, _port: number): PortListenerKind {
+  const command = normalizeLowercaseStringOrEmpty(listener.command ?? "");
+  const commandLine = normalizeLowercaseStringOrEmpty(listener.commandLine ?? "");
   const raw = normalizeLowercaseStringOrEmpty(
     `${listener.commandLine ?? ""} ${listener.command ?? ""}`,
   );
+  // Executable identity first. Unix inspection records the full `ps` command
+  // line, so a socat forward can mention OpenClaw without being the gateway.
+  if (isSocatPortListener(command, commandLine)) {
+    return "non_gateway";
+  }
   if (raw.includes("openclaw")) {
     return "gateway";
   }
-  const command = normalizeLowercaseStringOrEmpty(listener.command ?? "");
-  const commandLine = normalizeLowercaseStringOrEmpty(listener.commandLine ?? "");
   const hasSshCommand = /(?:^|[/\\])ssh(?:\.exe)?$/.test(command);
   const hasSshExecutable =
     hasSshCommand ||
@@ -37,16 +50,6 @@ export function classifyPortListener(listener: PortListener, _port: number): Por
     return "non_gateway";
   }
   if (/(?:^|[/\\\s])[^/\\\s]*ssh[^/\\\s]*(?:\.exe)?(?:[/\\\s"']|$)/.test(commandLine)) {
-    return "non_gateway";
-  }
-  // Tailscale / Funnel users often front the gateway with socat on the same
-  // port (different bind address). That is not the gateway and must not look
-  // like an occupied OpenClaw listener.
-  if (
-    command === "socat" ||
-    /(?:^|[/\\])socat(?:\.exe)?$/.test(command) ||
-    /(?:^|[/\\\s"'=])socat(?:\.exe)?(?:[/\\\s"']|$)/.test(commandLine)
-  ) {
     return "non_gateway";
   }
   return "unknown";

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -223,6 +223,49 @@ describe("ports helpers", () => {
 });
 
 describeUnix("inspectPortUsage", () => {
+  it("distinguishes a socat forward from a Gateway profile named socat", async () => {
+    const gatewayServer = net.createServer();
+    const gatewayAddress = await listenServer(gatewayServer, 0, "127.0.0.1");
+    if (!gatewayAddress) {
+      return;
+    }
+    const socatServer = net.createServer();
+    const socatAddress = await listenServer(socatServer, gatewayAddress.port, "127.0.0.2");
+    if (!socatAddress) {
+      await closeServer(gatewayServer);
+      return;
+    }
+    const port = gatewayAddress.port;
+
+    mockUnixCommands({
+      lsof: commandOutput(
+        `p111\ncopenclaw-gatewa\nnTCP 127.0.0.1:${port} (LISTEN)\n` +
+          `p222\ncsocat\nnTCP 127.0.0.2:${port} (LISTEN)\n`,
+      ),
+      commandLine: (pid) =>
+        pid === "111"
+          ? "openclaw-gateway --profile socat"
+          : `socat -lpopenclaw TCP-LISTEN:${port},bind=127.0.0.2,fork TCP:127.0.0.1:${port}`,
+    });
+
+    try {
+      const result = await inspectPortUsage(port, {
+        probeHosts: ["127.0.0.2", "127.0.0.1"],
+      });
+
+      expect(result.status).toBe("busy");
+      expect(result.listeners).toHaveLength(2);
+      expect(result.hints).toEqual([
+        expect.stringContaining("Gateway already running locally"),
+        "Another process is listening on this port.",
+        expect.stringContaining("Multiple listeners detected"),
+      ]);
+    } finally {
+      await closeServer(socatServer);
+      await closeServer(gatewayServer);
+    }
+  });
+
   it("keeps only listener rows that can block a scoped bind", async () => {
     const server = net.createServer();
     const address = await listenServer(server, 0, "127.0.0.1");


### PR DESCRIPTION
## What Problem This Solves

`openclaw gateway status` classified any listener whose process arguments contained `openclaw` as another Gateway.

A valid `socat` TCP forward can name OpenClaw in its arguments. For example, `-lpopenclaw` sets the forwarding process's logging name. When an OpenClaw Gateway and that forward listened on different addresses with the same numeric port, status kept the port busy but failed to identify `socat` as another process.

## Root Cause

Listener classification checked the full process arguments for `openclaw` before it checked the operating system's listener-owner command field.

The argument text is not executable identity. It can contain profile names, paths, logging labels, and forwarding targets.

## Fix

Check the inspected listener-owner command first. Treat `socat`, observed macOS `socat1`, and Windows `socat.exe` as non-Gateway owners before checking process arguments for OpenClaw.

This keeps an OpenClaw process launched with `--profile socat` classified as the Gateway. It also keeps the selected port busy while the forward is listening.

The repair removes the added command-line tokenizer and moves the regression to the `inspectPortUsage` owner boundary.

## User Impact

Gateway status now lists the real Gateway and the `socat` forward as different owners. Operators see the existing Gateway hint plus `Another process is listening on this port.`

## Evidence

Exact head: `bb27e573661c2685050f9f2448ea39fd6c6da06c`

- Current main `ae22204e7a20391ede4fb1ffb88d74709ff4af6f`, fresh secretless Linux container: a real profile named `socat` ran the Gateway on loopback. Real `socat -lpopenclaw` listened on the container address and forwarded to the same loopback port. Status reported the port busy and listed both listeners, but omitted the other-process hint.
- Exact head, same topology: status reported the port busy, listed both listeners, retained the Gateway hint, and added `Another process is listening on this port.`
- Anti-cheat: after stopping only `socat`, the profile-named Gateway remained busy and did not emit the other-process hint.
- Regression test: the new `inspectPortUsage` case failed against current-main production code for the missing other-process hint and passed on this head.
- Focused tests: the formatter, port-inspection, and real CLI process suites passed 126 tests with one platform skip.
- Process proof: the regression runs `gateway status --port ... --no-probe --json` through the shipped CLI entry process against a real Linux TCP listener whose operating-system command is `socat` and whose arguments name OpenClaw.
- Formatting: the four changed files passed `pnpm format:check`.
- Lint: the four changed files passed Oxlint with zero warnings and zero errors.
- Build: the production-identical predecessor `2904ce655c99eecc37386da92caa61d3802bdfd3` passed `pnpm build` in a fresh secretless container. Exact-head Blacksmith CI supplies the final build gate.

Production LOC: +8/-5, net +3. Tests: +133/-0. The production growth is the owner-command branch that prevents argument text from overriding listener identity.
