### PR TITLE
fix: preserve conversation order across session catalogs

### DIFF
--- a/docs/plugins/beam.md
+++ b/docs/plugins/beam.md
@@ -82,6 +82,8 @@ Content-Type: application/json
 }
 ```
 
+Send `items` in conversation order, oldest first. Beam preserves that order in storage and displays questions before their replies. Its session-catalog API returns newest-first pages, matching the other coding-session catalogs.
+
 The schema is closed. Beam rejects unknown fields, invalid item types, empty text, more than 200 items, item text over 6,000 characters, non-JSON requests, and bodies over 56 KiB.
 
 A successful upload returns the stable Beam id and a relative Control UI URL:
@@ -146,7 +148,7 @@ Beam can also act as the sender: an opt-in mirror that continuously publishes th
 - `pollSeconds` (default 30, minimum 10): how often the mirror scans local catalogs.
 - `activeWindowMinutes` (default 180): sessions with newer activity than this window count as live and stay mirrored; when a session goes idle past the window the running mirror service retries its final `completed` update until the receiver accepts it or the seven-day retention window ends. Retry state is process-local: a Gateway restart clears pending terminal retries, so the remote row remains live until its normal seven-day retention expires.
 
-The mirror applies the same redaction contract as the beam skill before anything leaves the machine: only user and agent message text is uploaded, while reasoning, tool calls, tool results, and raw payloads are replaced with compact counts. Snapshots are capped to the receiver limits (200 items, 56 KiB), dropping oldest entries first and marking the upload `truncated`. Sessions on paired nodes are not mirrored; the mirror shares only sessions from this Gateway's machine, newest 32 first.
+The mirror applies the same redaction contract as the beam skill before anything leaves the machine: only user and agent message text is uploaded, while reasoning, tool calls, tool results, and raw payloads are replaced with compact counts. It converts newest-first catalog pages into chronological uploads before applying the receiver limits (200 items, 56 KiB), dropping oldest entries first and marking the upload `truncated`. Sessions on paired nodes are not mirrored; the mirror shares only sessions from this Gateway's machine, newest 32 first.
 
 ## Troubleshooting
 

--- a/extensions/acpx/src/pi-session-catalog.test.ts
+++ b/extensions/acpx/src/pi-session-catalog.test.ts
@@ -140,24 +140,24 @@ describe("Pi session catalog", () => {
 
     const transcript = await readLocalPiTranscriptPage({ threadId: "pi-session", limit: 20 });
     expect(transcript.items.map((item) => [item.type, item.text])).toEqual([
-      ["userMessage", "hello"],
-      ["reasoning", "thinking"],
-      ["agentMessage", "hi"],
-      ["toolCall", 'bash\n{"command":"pwd"}'],
       ["toolResult", "bash\n/workspace"],
+      ["toolCall", 'bash\n{"command":"pwd"}'],
+      ["agentMessage", "hi"],
+      ["reasoning", "thinking"],
+      ["userMessage", "hello"],
     ]);
     const itemIds = transcript.items.flatMap((item) => (item.id ? [item.id] : []));
     expect(new Set(itemIds).size).toBe(itemIds.length);
 
     const latest = await readLocalPiTranscriptPage({ threadId: "pi-session", limit: 2 });
-    expect(latest.items.map((item) => item.type)).toEqual(["toolCall", "toolResult"]);
+    expect(latest.items.map((item) => item.type)).toEqual(["toolResult", "toolCall"]);
     expect(latest.nextCursor).toBeTruthy();
     const older = await readLocalPiTranscriptPage({
       threadId: "pi-session",
       limit: 2,
       cursor: latest.nextCursor,
     });
-    expect(older.items.map((item) => item.type)).toEqual(["reasoning", "agentMessage"]);
+    expect(older.items.map((item) => item.type)).toEqual(["agentMessage", "reasoning"]);
     const nonEmitted = Buffer.from(JSON.stringify({ offset: 2, extra: true }), "utf8").toString(
       "base64url",
     );
@@ -384,12 +384,12 @@ describe("Pi session catalog", () => {
 
     const transcript = await readLocalPiTranscriptPage({ threadId: "pi-session", limit: 20 });
     expect(transcript.items.map((item) => [item.type, item.text])).toEqual([
-      ["userMessage", "legacy hello"],
-      ["userMessage", "[image: image/png]"],
-      ["toolCall", "bash\npwd"],
-      ["toolResult", "/workspace"],
-      ["other", "review\nvisible note"],
       ["other", "legacy-review\nlegacy visible note"],
+      ["other", "review\nvisible note"],
+      ["toolResult", "/workspace"],
+      ["toolCall", "bash\npwd"],
+      ["userMessage", "[image: image/png]"],
+      ["userMessage", "legacy hello"],
     ]);
   });
 

--- a/extensions/beam/src/beam.test.ts
+++ b/extensions/beam/src/beam.test.ts
@@ -391,7 +391,14 @@ describe("Beam session catalog", () => {
   it("lists newest sessions and reads paginated transcript items without mutation capabilities", async () => {
     const store = memoryStore();
     await store.put({
-      ...sampleUpload({ truncated: true }),
+      ...sampleUpload({
+        truncated: true,
+        items: [
+          ...sampleUpload().items,
+          { type: "userMessage", text: "Did the upload keep the conversation order?" },
+          { type: "agentMessage", text: "Yes, the question still precedes its answer." },
+        ],
+      }),
       createdAt: 100,
       receivedAt: 200,
     });
@@ -426,10 +433,19 @@ describe("Beam session catalog", () => {
       agentId: "main",
       hostId: "gateway",
       threadId: "0123456789abcdef0123456789abcdef",
-      limit: 1,
+      limit: 2,
     });
     expect(transcript.items).toEqual([
-      expect.objectContaining({ type: "agentMessage", text: "Implemented and tested." }),
+      expect.objectContaining({
+        id: "0123456789abcdef0123456789abcdef:3",
+        type: "agentMessage",
+        text: "Yes, the question still precedes its answer.",
+      }),
+      expect.objectContaining({
+        id: "0123456789abcdef0123456789abcdef:2",
+        type: "userMessage",
+        text: "Did the upload keep the conversation order?",
+      }),
     ]);
     expect(transcript.items[0]).not.toHaveProperty("truncated");
     expect(transcript.nextCursor).toEqual(expect.any(String));
@@ -438,10 +454,11 @@ describe("Beam session catalog", () => {
       agentId: "main",
       hostId: "gateway",
       threadId: "0123456789abcdef0123456789abcdef",
-      limit: 1,
+      limit: 2,
       cursor: transcript.nextCursor,
     });
     expect(older.items).toEqual([
+      expect.objectContaining({ type: "agentMessage", text: "Implemented and tested." }),
       expect.objectContaining({ type: "userMessage", text: "Please fix the upload flow." }),
     ]);
     expect(older.nextCursor).toBeUndefined();
@@ -450,6 +467,7 @@ describe("Beam session catalog", () => {
     if (!current) {
       throw new Error("Beam test store lost the current session");
     }
+    expect(current.items.slice(0, 2)).toEqual(sampleUpload().items);
     await store.put({
       ...current,
       items: [

--- a/extensions/beam/src/mirror.test.ts
+++ b/extensions/beam/src/mirror.test.ts
@@ -90,8 +90,8 @@ function fakeCatalog(params: {
         label: "Local",
         threadId,
         items: params.items ?? [
-          { type: "userMessage", text: "Fix the flow." },
           { type: "agentMessage", text: "Done." },
+          { type: "userMessage", text: "Fix the flow." },
         ],
       };
     },
@@ -214,13 +214,13 @@ describe("parseBeamMirrorConfig", () => {
 });
 
 describe("buildBeamMirrorItems", () => {
-  it("keeps user and agent text, collapses the rest into counts", () => {
+  it("restores chronological text from newest-first catalog items and summarizes raw content", () => {
     const reduced = buildBeamMirrorItems([
-      { type: "userMessage", text: "Fix it." },
-      { type: "toolCall", text: "rm -rf /tmp/x", raw: { command: "secret" } },
-      { type: "toolResult", raw: { output: "secret output" } },
-      { type: "reasoning", text: "private thoughts" },
       { type: "agentMessage", text: "Done." },
+      { type: "reasoning", text: "private thoughts" },
+      { type: "toolResult", raw: { output: "secret output" } },
+      { type: "toolCall", text: "rm -rf /tmp/x", raw: { command: "secret" } },
+      { type: "userMessage", text: "Fix it." },
     ]);
     expect(reduced.items).toEqual([
       { type: "userMessage", text: "Fix it." },
@@ -472,37 +472,51 @@ describe("createBeamMirrorRunner", () => {
     }
   });
 
-  it("uploads active local sessions and skips unchanged ones", async () => {
-    const sent: SentRequest[] = [];
-    const reads: string[] = [];
-    const cancel = vi.fn();
-    const catalog = fakeCatalog({
-      id: "claude",
-      sessions: [{ threadId: "t1", name: "Fix flow", recencyAt: NOW - 60_000 }],
-      onRead: (threadId) => reads.push(threadId),
-    });
-    const runner = createBeamMirrorRunner({
-      runtime: fakeRuntime(mirrorConfig({ token: "scratch-token" })),
-      logger: silentLogger,
-      fetchFn: captureFetch(sent, 200, cancel),
-      now: () => NOW,
-      listCatalogs: () => [catalog],
-    });
-    await runner.tick();
-    await runner.tick();
-    expect(sent).toHaveLength(1);
-    expect(reads).toEqual(["t1", "t1"]);
-    expect(sent[0]?.auth).toBe("Bearer scratch-token");
-    expect(sent[0]?.payload).toMatchObject({
-      version: 1,
-      beamId: beamMirrorId("claude", "gateway:local", "t1"),
-      source: "claude",
-      title: "Fix flow",
-      completed: false,
-    });
-    expect(parseBeamUpload(structuredClone(sent[0]?.payload)).ok).toBe(true);
-    expect(cancel).toHaveBeenCalledOnce();
-  });
+  it.each([2, 50])(
+    "uploads the newest chronological suffix of %i catalog items once",
+    async (count) => {
+      const sent: SentRequest[] = [];
+      const reads: string[] = [];
+      const cancel = vi.fn();
+      const chronological = Array.from({ length: count }, (_, index) => ({
+        type: index % 2 === 0 ? ("userMessage" as const) : ("agentMessage" as const),
+        text: `Message ${index}: ${"text ".repeat(300)}end`,
+      }));
+      const catalog = fakeCatalog({
+        id: "claude",
+        sessions: [{ threadId: "t1", name: "Fix flow", recencyAt: NOW - 60_000 }],
+        items: chronological.toReversed(),
+        onRead: (threadId) => reads.push(threadId),
+      });
+      const runner = createBeamMirrorRunner({
+        runtime: fakeRuntime(mirrorConfig({ token: "scratch-token" })),
+        logger: silentLogger,
+        fetchFn: captureFetch(sent, 200, cancel),
+        now: () => NOW,
+        listCatalogs: () => [catalog],
+      });
+      await runner.tick();
+      await runner.tick();
+      expect(sent).toHaveLength(1);
+      expect(reads).toEqual(["t1", "t1"]);
+      expect(sent[0]?.auth).toBe("Bearer scratch-token");
+      expect(sent[0]?.payload).toMatchObject({
+        version: 1,
+        beamId: beamMirrorId("claude", "gateway:local", "t1"),
+        source: "claude",
+        title: "Fix flow",
+        completed: false,
+      });
+      expect(parseBeamUpload(structuredClone(sent[0]?.payload)).ok).toBe(true);
+      const payload = sent[0]!.payload;
+      expect(payload.items).toEqual(chronological.slice(-payload.items.length));
+      if (count === 50) {
+        expect(payload.truncated).toBe(true);
+        expect(payload.items.length).toBeLessThan(count);
+      }
+      expect(cancel).toHaveBeenCalledOnce();
+    },
+  );
 
   it("does not split a surrogate pair when clipping the session title", async () => {
     const sent: SentRequest[] = [];

--- a/extensions/beam/src/mirror.ts
+++ b/extensions/beam/src/mirror.ts
@@ -163,7 +163,7 @@ function droppedSummary(counts: Map<string, number>): string | undefined {
 }
 
 /**
- * Reduce catalog transcript items to the Beam wire shape. Only user/agent
+ * Reduce newest-first catalog items to chronological Beam uploads. Only user/agent
  * message text crosses the wire; reasoning, tool calls, tool results, and raw
  * payloads collapse into compact counts, matching the beam skill's redaction
  * contract so the mirror never widens what a manual publish would share.
@@ -194,7 +194,7 @@ export function buildBeamMirrorItems(items: readonly SessionCatalogTranscriptIte
         return "other entries";
     }
   };
-  for (const item of items) {
+  for (const item of items.toReversed()) {
     const text = item.text?.trim();
     if ((item.type === "userMessage" || item.type === "agentMessage") && text) {
       flush();

--- a/extensions/beam/src/session-catalog.ts
+++ b/extensions/beam/src/session-catalog.ts
@@ -77,7 +77,8 @@ function transcriptPage(
   const end = Math.min(items.length, Math.max(0, cursor?.end ?? items.length));
   const start = Math.max(0, end - limit);
   return {
-    items: items.slice(start, end),
+    // Uploads are chronological; catalog pages expose newest items first.
+    items: items.slice(start, end).reverse(),
     ...(start > 0 ? { nextCursor: encodeTranscriptCursor({ revision, end: start }) } : {}),
   };
 }

--- a/extensions/beam/src/session-catalog.ts
+++ b/extensions/beam/src/session-catalog.ts
@@ -78,7 +78,7 @@ function transcriptPage(
   const start = Math.max(0, end - limit);
   return {
     // Uploads are chronological; catalog pages expose newest items first.
-    items: items.slice(start, end).reverse(),
+    items: items.slice(start, end).toReversed(),
     ...(start > 0 ? { nextCursor: encodeTranscriptCursor({ revision, end: start }) } : {}),
   };
 }

--- a/extensions/opencode/session-catalog.test.ts
+++ b/extensions/opencode/session-catalog.test.ts
@@ -423,20 +423,20 @@ describe("OpenCode session catalog", () => {
 
     const transcript = await readTestTranscript({ limit: 20 });
     expect(transcript.items.map((item) => [item.type, item.text])).toEqual([
-      ["userMessage", "hello"],
-      ["reasoning", "thinking"],
-      ["agentMessage", "hi"],
-      ["toolCall", 'bash\n{"command":"pwd"}'],
       ["toolResult", "/workspace"],
+      ["toolCall", 'bash\n{"command":"pwd"}'],
+      ["agentMessage", "hi"],
+      ["reasoning", "thinking"],
+      ["userMessage", "hello"],
     ]);
     const itemIds = transcript.items.flatMap((item) => (item.id ? [item.id] : []));
     expect(new Set(itemIds).size).toBe(itemIds.length);
 
     const latest = await readTestTranscript({ limit: 2 });
-    expect(latest.items.map((item) => item.type)).toEqual(["toolCall", "toolResult"]);
+    expect(latest.items.map((item) => item.type)).toEqual(["toolResult", "toolCall"]);
     expect(latest.nextCursor).toBeTruthy();
     const older = await readTestTranscript({ limit: 2, cursor: latest.nextCursor });
-    expect(older.items.map((item) => item.type)).toEqual(["reasoning", "agentMessage"]);
+    expect(older.items.map((item) => item.type)).toEqual(["agentMessage", "reasoning"]);
     const nonEmitted = Buffer.from(JSON.stringify({ offset: 2, extra: true }), "utf8").toString(
       "base64url",
     );

--- a/src/plugin-sdk/session-catalog.test.ts
+++ b/src/plugin-sdk/session-catalog.test.ts
@@ -76,7 +76,7 @@ describe("session catalog SDK", () => {
       id,
       type: "agentMessage",
       text: id,
-      ...(timestamps[index] ? { timestamp: timestamps[index] } : {}),
+      timestamp: timestamps[index],
     }));
     const latest = sessionCatalogPaging.boundTranscriptPage(items, 2, 0);
     expect(latest.items.map((item) => item.id)).toEqual(["1", "a"]);

--- a/src/plugin-sdk/session-catalog.test.ts
+++ b/src/plugin-sdk/session-catalog.test.ts
@@ -7,6 +7,7 @@ import {
   sessionCatalogAdoptedSourceKey,
   type SessionCatalogFamilyOptions,
   type SessionCatalogSession,
+  type SessionCatalogTranscriptItem,
 } from "./session-catalog.js";
 
 const messages = {
@@ -52,6 +53,47 @@ describe("session catalog SDK", () => {
         { threadIdMaxLength: 32, threadIdPattern: /^(?!-)[a-z0-9-]+$/u, messages },
       ),
     ).toThrow("bad thread");
+  });
+
+  it.each([
+    { name: "missing", timestamps: [] },
+    {
+      name: "equal",
+      timestamps: Array.from({ length: 5 }, () => "2026-08-30T12:00:00Z"),
+    },
+    {
+      name: "non-monotonic",
+      timestamps: [
+        "2026-08-30T12:00:04Z",
+        "2026-08-30T12:00:01Z",
+        "2026-08-30T12:00:03Z",
+        "2026-08-30T12:00:00Z",
+        "2026-08-30T12:00:02Z",
+      ],
+    },
+  ])("pages newest-first by source order with $name timestamps", ({ timestamps }) => {
+    const items: SessionCatalogTranscriptItem[] = ["z", "2", "10", "a", "1"].map((id, index) => ({
+      id,
+      type: "agentMessage",
+      text: id,
+      ...(timestamps[index] ? { timestamp: timestamps[index] } : {}),
+    }));
+    const latest = sessionCatalogPaging.boundTranscriptPage(items, 2, 0);
+    expect(latest.items.map((item) => item.id)).toEqual(["1", "a"]);
+    const older = sessionCatalogPaging.boundTranscriptPage(
+      items,
+      2,
+      sessionCatalogPaging.decodeCursor(latest.nextCursor),
+    );
+    expect(older.items.map((item) => item.id)).toEqual(["10", "2"]);
+    const oldest = sessionCatalogPaging.boundTranscriptPage(
+      items,
+      2,
+      sessionCatalogPaging.decodeCursor(older.nextCursor),
+    );
+    expect(oldest.items.map((item) => item.id)).toEqual(["z"]);
+    expect(oldest.nextCursor).toBeUndefined();
+    expect(items.map((item) => item.id)).toEqual(["z", "2", "10", "a", "1"]);
   });
 
   function createFamilyFixture() {

--- a/src/plugin-sdk/session-catalog.ts
+++ b/src/plugin-sdk/session-catalog.ts
@@ -227,7 +227,7 @@ function truncateUtf8(text: string, maxBytes: number): string {
   return `${text.slice(0, end)}…`;
 }
 
-/** Page transcript items from the tail, bounding per-item and per-page byte budgets. */
+/** Page chronological source items newest-first, bounding per-item and per-page byte budgets. */
 function boundSessionCatalogTranscriptPage(
   items: SessionCatalogTranscriptItem[],
   limit: number,
@@ -250,7 +250,7 @@ function boundSessionCatalogTranscriptPage(
     if (page.length > 0 && pageBytes + itemBytes > MAX_TRANSCRIPT_PAGE_BYTES) {
       break;
     }
-    page.unshift(bounded);
+    page.push(bounded);
     pageBytes += itemBytes;
   }
   const consumed = offset + page.length;

--- a/src/plugins/session-catalog-history-import.ts
+++ b/src/plugins/session-catalog-history-import.ts
@@ -101,31 +101,25 @@ function importableSessionCatalogItem(
 async function readBoundedSessionCatalogHistory(params: {
   read: (params: { cursor?: string; limit: number }) => Promise<SessionsCatalogReadResult>;
 }): Promise<SessionCatalogTranscriptItem[]> {
-  const pages: SessionCatalogTranscriptItem[][] = [];
+  const items: SessionCatalogTranscriptItem[] = [];
   let cursor: string | undefined;
-  let itemCount = 0;
   let bytes = 0;
-  while (itemCount < SESSION_CATALOG_HISTORY_IMPORT_MAX_ITEMS) {
+  while (items.length < SESSION_CATALOG_HISTORY_IMPORT_MAX_ITEMS) {
     const page = await params.read({
       limit: Math.min(
         SESSION_CATALOG_HISTORY_IMPORT_PAGE_LIMIT,
-        SESSION_CATALOG_HISTORY_IMPORT_MAX_ITEMS - itemCount,
+        SESSION_CATALOG_HISTORY_IMPORT_MAX_ITEMS - items.length,
       ),
       ...(cursor ? { cursor } : {}),
     });
-    const retained: SessionCatalogTranscriptItem[] = [];
-    // Catalog pages move newest-to-oldest while each page stays chronological.
-    // Walk backward for recent-window bounds, then prepend older retained pages.
-    for (let index = page.items.length - 1; index >= 0; index -= 1) {
-      const item = page.items[index];
-      if (!item) {
-        continue;
-      }
+    // Catalog reads are newest-first. Bound that recent suffix before restoring
+    // source order for persistence; timestamps do not define transcript order.
+    for (const item of page.items) {
       const importableItem = importableSessionCatalogItem(item);
       const itemBytes = Buffer.byteLength(JSON.stringify(importableItem), "utf8");
       const remainingBytes = SESSION_CATALOG_HISTORY_IMPORT_MAX_BYTES - bytes;
-      if (itemCount > 0 && itemBytes > remainingBytes) {
-        return [retained, ...pages.toReversed()].flat();
+      if (items.length > 0 && itemBytes > remainingBytes) {
+        return items.toReversed();
       }
       const retainedItem =
         itemBytes <= remainingBytes
@@ -135,23 +129,21 @@ async function readBoundedSessionCatalogHistory(params: {
         continue;
       }
       const retainedItemBytes = Buffer.byteLength(JSON.stringify(retainedItem), "utf8");
-      retained.unshift(retainedItem);
-      itemCount += 1;
+      items.push(retainedItem);
       bytes += retainedItemBytes;
       if (
-        itemCount === SESSION_CATALOG_HISTORY_IMPORT_MAX_ITEMS ||
+        items.length === SESSION_CATALOG_HISTORY_IMPORT_MAX_ITEMS ||
         bytes === SESSION_CATALOG_HISTORY_IMPORT_MAX_BYTES
       ) {
-        return [retained, ...pages.toReversed()].flat();
+        return items.toReversed();
       }
     }
-    pages.push(retained);
     if (!page.nextCursor || page.nextCursor === cursor) {
       break;
     }
     cursor = page.nextCursor;
   }
-  return pages.toReversed().flat();
+  return items.toReversed();
 }
 
 export async function importSessionCatalogHistory(params: {

--- a/src/plugins/session-catalog.test.ts
+++ b/src/plugins/session-catalog.test.ts
@@ -48,7 +48,7 @@ function catalogReader(items: TranscriptItem[], maxPageSize = Number.POSITIVE_IN
     const pageLimit = Math.min(limit, maxPageSize);
     const end = Math.max(0, items.length - offset);
     const start = Math.max(0, end - pageLimit);
-    const page = items.slice(start, end);
+    const page = items.slice(start, end).toReversed();
     const consumed = offset + page.length;
     return {
       hostId: "gateway",
@@ -135,7 +135,7 @@ describe("importSessionCatalogHistory", () => {
     transcript.lockCalls = 0;
   });
 
-  it("imports backward pages in chronological order with native provenance", async () => {
+  it("imports newest-first pages in source order regardless of timestamps with native provenance", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-25T12:00:00.000Z"));
     try {

--- a/src/plugins/session-catalog.ts
+++ b/src/plugins/session-catalog.ts
@@ -179,6 +179,7 @@ export type SessionCatalogProvider = {
     params: SessionCatalogCreateParams,
   ) => SessionCatalogCreateTarget | undefined;
   list: (params: SessionCatalogListProviderParams) => Promise<SessionCatalogHost[]>;
+  /** Items are newest-first by source order; nextCursor continues to older items. */
   read: (params: SessionCatalogReadProviderParams) => Promise<SessionsCatalogReadResult>;
   continueSession?: (
     params: SessionCatalogContinueProviderParams,


### PR DESCRIPTION
Closes #133377

## What Problem This Solves

Fixes an issue where users opening a manually uploaded Beam conversation saw replies before their questions. The uploaded snapshot and stored messages were chronological, but the Control UI rendered each catalog page backwards.

## Why This Change Was Made

Preserve the existing newest-first session-catalog contract used by Codex, Claude, and the Control UI. Beam converts chronological snapshots at its read boundary; the automatic mirror converts catalog items back to chronological order before dropping older content to satisfy upload limits. The shared Pi/OpenCode pager now follows the same contract, and their history importer restores source order once after collecting the bounded recent history. This removes the conflicting per-page reconstruction without adding ordering flags, timestamp sorting, or storage migrations.

## User Impact

Beam, Pi, and OpenCode conversations display questions before replies, including when older pages load. Mirrored snapshots retain their newest messages when truncated. Pi/OpenCode adoption keeps chronological history and the existing item/byte limits. Manual snapshots already in storage need no re-upload. Previously mirrored snapshots produced in reverse order refresh on the next successful mirror upload; no attempt is made to infer order from their timestamps or message text.

## Evidence

- The live reported session's gateway response contained 13 chronological messages plus its tool summary; the UI displayed the exact reversed sequence. No private transcript or production screenshot is included here.
- Before the production changes, the strengthened tests failed on Beam page order, mirror order/truncation, shared paging, imported history limits, and Pi/OpenCode order.
- 141 focused tests pass: 113 across Beam, mirroring, SDK paging, history import, Pi/OpenCode, and the unchanged Codex catalog, plus 28 Control UI catalog lifecycle tests on clean Testbox. Commands: `node scripts/run-vitest.mjs` with the corresponding eight test files. The affected 20 SDK/Beam tests were rerun after the final lint-only correction.
- Codex autoreview: no accepted/actionable findings in the requested scope and priority.
- Production delta: 6 lines removed overall; tests expanded for multi-message pages, recent-window limits, source-order stability with missing/equal/non-monotonic timestamps, and nonmutation.
- Clean Blacksmith Testbox baseline and final-candidate `pnpm build` passed. Real `POST /api/v1/beam/sessions` → Gateway WebSocket catalog reads → Chromium proved question/reply order, the read-only composer, and all 54 items exactly once across the 50-item page and “Show earlier” page. Synthetic-only state, no provider credentials or mocked RPC. `node scripts/check-changed.mjs --timed --base origin/main` passed in the same clean Testbox (wrapper exit 0). [Exact-head recovery CI](https://github.com/openclaw/openclaw/actions/runs/33324187155) completed successfully on `7a90bc3c7057d1b658ab45d1a74147f42fc98dae`; current PR checks have no pending or failing entries. The original run had a zero-step runner stall that did not clear after cancellation, so the native `scripts/pr ci-dispatch` recovery ran the full gate again. The replacement boundary check passed in 1m26s; no check was bypassed. The first CI run found two lint rules; both are corrected in `7a90bc3c7057`.

The introducing commit is unknown: available local history places Beam's original ordering at a shallow boundary. The repair is based on current source and live behavior, not an attribution inference.

## Visual proof

Before: the four numbered messages appear in reverse source order.

![Before: replies appear above their questions](https://github.com/user-attachments/assets/bbaab577-696c-4208-ab4d-db4705db860c)

After: the same upload displays in source order. The video also loads the older page of the 54-message conversation.

![After: questions precede their replies](https://github.com/user-attachments/assets/1d36600b-9966-4e74-bf0b-56b8cfbccc62)

https://github.com/user-attachments/assets/39d5be3a-d117-47f7-b6b5-09f7154b0bfc

## Review disposition and follow-up

Maintainer landing decision: accept newest-first as the current beta provider-page convention, with chronological order restored only at storage, upload, and history-persistence boundaries. This is the canonical fix for the reported ordering defect; no stable SDK contract, new configuration option, or database schema is changed.

[Compatibility finding and Rank-up moves addressed with live stable-package evidence](https://github.com/openclaw/openclaw/pull/133382#issuecomment-5469971354). Neither current stable nor extended-stable ships the session-catalog SDK or Beam; no chronological legacy-provider branch is added. The existing UI, Codex, and Claude contract remains newest-first on the wire.

Separate follow-up observed during isolated setup: on an unconfigured Gateway, `/chat/main?catalog=beam&...` redirects to model setup because `ui/src/pages/model-setup/first-run.ts:isDefaultChatLanding` ignores catalog query parameters. A supported named-agent catalog URL works and matches the reported path. This first-run deep-link issue is outside the transcript-order repair.
