### PR TITLE
fix(media): preserve Matroska extensions after byte detection

### DIFF
--- a/packages/media-core/src/mime.test.ts
+++ b/packages/media-core/src/mime.test.ts
@@ -51,6 +51,14 @@ describe("mime detection", () => {
     },
   );
 
+  it("normalizes byte-detected Matroska to the filename MIME spelling", async () => {
+    const buffer = Buffer.from("1a45dfa38b4282886d6174726f736b61", "hex");
+    const detected = await detectMime({ buffer, filePath: "clip.bin" });
+
+    expect(detected).toBe("video/x-matroska");
+    expect(extensionForMime(detected)).toBe(".mkv");
+  });
+
   it.each([
     { format: "avif", expected: "image/avif" },
     { format: "jpg", expected: "image/jpeg" },

--- a/packages/media-core/src/mime.ts
+++ b/packages/media-core/src/mime.ts
@@ -162,8 +162,9 @@ const MIME_SYNONYMS: Record<string, string> = {
   "text/yaml": "application/yaml",
   "application/x-yaml": "application/yaml",
   "application/xml": "text/xml",
-  // Preserve the shipped AVI filename/header spelling for byte-detected containers.
+  // Preserve shipped filename/header spellings for byte-detected container aliases.
   "video/vnd.avi": "video/x-msvideo",
+  "video/matroska": "video/x-matroska",
 };
 
 /** Normalizes MIME strings by dropping parameters, lowercasing, and folding registered synonyms. */


### PR DESCRIPTION
## What Problem This Solves

Briefly describe the problem and fix:

- Problem: byte detection reports Matroska containers as `video/matroska`, while OpenClaw's filename and extension tables use `video/x-matroska`. Extensionless or mislabeled MKV input therefore loses the canonical `.mkv` mapping after sniffing.
- Why this fix: normalize the detector spelling at the existing MIME synonym boundary, matching the established AVI alias handling without adding a new format path or configuration surface.
- What changed: added the Matroska synonym and a regression test using a minimal EBML/Matroska header.
- What did not change: no playback policy, allowlist, config, protocol, or dependency changes.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] Build/tooling

## Scope

- [x] Core/runtime
- [ ] Gateway/protocol
- [ ] Plugin/extension
- [ ] CLI/tooling
- [ ] Docs only
- [ ] CI/build

## Verification

- [x] Targeted tests added/updated
- [x] Manual verification performed
- [ ] Screenshots attached (required for UI changes)
- [ ] Logs/output attached (required for runtime/behavioral changes)

## Evidence

- Before the production change, `node scripts/run-vitest.mjs packages/media-core/src/mime.test.ts` failed only the new regression: expected `video/x-matroska`, received `video/matroska` (189 passed, 1 failed).
- On current `origin/main`, the same focused suite passes: 190/190.
- The pinned `file-type@22.0.2` detector returns `{ ext: "mkv", mime: "video/matroska" }` for the regression header.
- Commit-scoped autoreview (Codex gpt-5.5, high) reported no actionable findings, correctness confidence 0.82.
- Exact-head real media-store save/read proof (`9fb8cb5b791c081f71de623d54f24347aa7f2720`, Node 24.16.0): a byte-sniffed Matroska buffer was persisted as `video/x-matroska` with `.mkv`, then fetched byte-for-byte (`storedBytes=16`, `fetchedBytes=16`, `bytesMatch=true`).

## User Impact

Byte-detected Matroska attachments retain the same canonical MIME and `.mkv` extension behavior as filename-detected MKV files.

## Risks and Rollback

- Risk: very low; the change only folds an equivalent Matroska spelling into an existing canonical value.
- Rollback: revert this commit to restore pass-through handling of `video/matroska`.

## AI Assistance

AI-assisted by Codex. I reviewed the implementation, dependency behavior, focused red/green test, and final commit-scoped review.

