### PR TITLE
fix(ui): avoid voice session expiry while waiting for microphone access

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -4093,7 +4093,7 @@ ui/src/pages/chat/realtime-talk-gateway-relay.ts	1
 ui/src/pages/chat/realtime-talk-google-live.ts	2
 ui/src/pages/chat/realtime-talk-shared.ts	7
 ui/src/pages/chat/realtime-talk-webrtc.ts	3
-ui/src/pages/chat/realtime-talk.ts	7
+ui/src/pages/chat/realtime-talk.ts	2
 ui/src/pages/chat/run-lifecycle.ts	1
 ui/src/pages/chat/scroll.ts	1
 ui/src/pages/chat/session-cache.ts	2

--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -61,6 +61,10 @@ and allow access if prompted. The browser can keep an unanswered permission
 request pending. In Talk, **Stop voice input** cancels startup and releases any
 microphone stream granted after cancellation.
 
+Browser Talk acquires the microphone before creating the provider session, so
+time spent granting permission does not consume a short-lived connection token.
+If session creation fails, Talk releases the microphone before reporting the error.
+
 If the microphone disconnects or its permission is revoked, browser Talk ends
 the call and shows an error. Choose an available **Microphone input**, restore
 permission if needed, and start Talk again. An unexpected GPT-Live connection

--- a/ui/src/e2e/browser-talk-microphone-lifetime.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-microphone-lifetime.e2e.test.ts
@@ -19,7 +19,7 @@ const suite = createControlUiE2eSuite({
 suite.define(() => {
   it("guides a pending microphone request and clears guidance when voice connects", async () => {
     await suite.withPage({ permissions: ["microphone"] }, async ({ page }) => {
-      await installMockGateway(page, {
+      const gateway = await installMockGateway(page, {
         methodResponses: {
           "talk.catalog": videoTalkCatalog("openai"),
           "talk.client.create": {
@@ -55,7 +55,8 @@ suite.define(() => {
           ),
         )
         .toBe(true);
-      await captureMicrophoneLossProof(page, "microphone-access-pending.png");
+      expect(await gateway.getRequests("talk.client.create")).toHaveLength(0);
+      await captureMicrophoneLossProof(page, "prepared-input-pending.png");
       const guidance = page.locator('.agent-chat__talk-status[role="status"]');
       await expect
         .poll(() => guidance.allTextContents())
@@ -74,7 +75,8 @@ suite.define(() => {
         .poll(() => page.locator('.agent-chat__voice-activity[data-status="listening"]').count())
         .toBe(1);
       await expect.poll(() => guidance.count()).toBe(0);
-      await captureMicrophoneLossProof(page, "microphone-access-ready.png");
+      expect(await gateway.getRequests("talk.client.create")).toHaveLength(1);
+      await captureMicrophoneLossProof(page, "prepared-input-ready.png");
       await page.getByRole("button", { name: "Stop voice input" }).click();
     });
   });

--- a/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
@@ -941,16 +941,24 @@ suite.define(() => {
 
       await expect
         .poll(() =>
-          page.evaluate(
-            () =>
-              (
-                window as Window & {
-                  openclawTalkE2eState?: { constraints: unknown[] };
-                }
-              ).openclawTalkE2eState?.constraints.length,
-          ),
+          page.evaluate(() => {
+            const state = (
+              window as Window & {
+                openclawTalkE2eState?: {
+                  constraints: unknown[];
+                  tracksStopped: number;
+                  inputProcessor?: unknown;
+                };
+              }
+            ).openclawTalkE2eState;
+            return {
+              captures: state?.constraints.length,
+              stopped: state?.tracksStopped,
+              relayReady: state?.inputProcessor != null,
+            };
+          }),
         )
-        .toBe(1);
+        .toEqual({ captures: 2, stopped: 1, relayReady: true });
       await gateway.emitGatewayEvent("talk.event", {
         relaySessionId: currentRelaySessionId,
         type: "ready",
@@ -1018,36 +1026,17 @@ suite.define(() => {
 
   it("shows actionable guidance when Talk microphone permission is blocked", async () => {
     await suite.withPage(undefined, async ({ page }) => {
-      const relaySessionId = "relay-blocked-microphone-e2e";
-      const gateway = await installMockGateway(page, {
-        methodResponses: {
-          "talk.client.create": {
-            provider: "openai",
-            transport: "gateway-relay",
-            relaySessionId,
-            audio: {
-              inputEncoding: "pcm16",
-              inputSampleRateHz: 16_000,
-              outputEncoding: "pcm16",
-              outputSampleRateHz: 24_000,
-            },
-          },
-          "talk.session.close": {},
-        },
-      });
+      const gateway = await installMockGateway(page);
       await installBlockedMicrophoneFixture(page);
 
       await page.setViewportSize({ width: 320, height: 720 });
       await page.goto(`${suite.server.baseUrl}chat`);
       await page.getByRole("button", { name: "Tap to talk" }).click();
-      await gateway.waitForRequest("talk.client.create");
-
       await expect
         .poll(() => page.getByRole("alert").locator(".agent-chat__talk-status-text").textContent())
         .toBe("Microphone access is blocked. Allow it in browser site settings to list inputs.");
-      await expect
-        .poll(() => gateway.getRequests("talk.session.close").then((requests) => requests.length))
-        .toBe(1);
+      expect(await gateway.getRequests("talk.client.create")).toHaveLength(0);
+      expect(await gateway.getRequests("talk.session.close")).toHaveLength(0);
       await expect
         .poll(() => page.getByRole("button", { name: "Tap to talk" }).isVisible())
         .toBe(true);

--- a/ui/src/e2e/browser-talk-webkit-error.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-webkit-error.e2e.test.ts
@@ -9,22 +9,7 @@ const suite = createControlUiE2eSuite({ name: "Control UI browser Talk WebKit er
 suite.define(() => {
   it("renders legacy WebKit overconstraints as actionable microphone guidance", async () => {
     await suite.withPage(undefined, async ({ page }) => {
-      const gateway = await installMockGateway(page, {
-        methodResponses: {
-          "talk.client.create": {
-            provider: "openai",
-            transport: "gateway-relay",
-            relaySessionId: "relay-webkit-overconstraint-e2e",
-            audio: {
-              inputEncoding: "pcm16",
-              inputSampleRateHz: 16_000,
-              outputEncoding: "pcm16",
-              outputSampleRateHz: 24_000,
-            },
-          },
-          "talk.session.close": {},
-        },
-      });
+      const gateway = await installMockGateway(page);
       await page.addInitScript(() => {
         Object.defineProperty(navigator, "mediaDevices", {
           configurable: true,
@@ -47,14 +32,11 @@ suite.define(() => {
       await page.locator("[data-settings-microphone]").selectOption("usb");
       await page.goto(`${suite.server.baseUrl}chat`);
       await page.getByRole("button", { name: "Tap to talk" }).click();
-      await gateway.waitForRequest("talk.client.create");
-
       await expect
         .poll(() => page.getByRole("alert").locator(".agent-chat__talk-status-text").textContent())
         .toBe("The selected microphone is unavailable. Choose another input or System default.");
-      await expect
-        .poll(() => gateway.getRequests("talk.session.close").then((requests) => requests.length))
-        .toBe(1);
+      expect(await gateway.getRequests("talk.client.create")).toHaveLength(0);
+      expect(await gateway.getRequests("talk.session.close")).toHaveLength(0);
       await captureComposerProof(page, "webkit-selected-microphone-unavailable-composer.png");
       await page.getByRole("alert").screenshot({
         path: ".artifacts/control-ui-e2e/voice-controls/webkit-selected-microphone-alert.png",

--- a/ui/src/pages/chat/realtime-talk-gateway-relay.test.ts
+++ b/ui/src/pages/chat/realtime-talk-gateway-relay.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { GatewayRelayRealtimeTalkTransport } from "./realtime-talk-gateway-relay.ts";
+import { prepareRealtimeTalkTestInput } from "./realtime-talk-input.test-support.ts";
 import {
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
   REALTIME_VOICE_AGENT_CONTROL_TOOL_NAME,
@@ -121,8 +122,9 @@ function createClient(): RealtimeTalkTransportContext["client"] {
   } as unknown as RealtimeTalkTransportContext["client"];
 }
 
-function createTransport(overrides: Partial<RealtimeTalkTransportContext> = {}) {
+async function createTransport(overrides: Partial<RealtimeTalkTransportContext> = {}) {
   return new GatewayRelayRealtimeTalkTransport(createSession(), {
+    input: await prepareRealtimeTalkTestInput(),
     callbacks: {},
     client: createClient(),
     sessionKey: "main",
@@ -203,34 +205,13 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
     createdSources.length = 0;
   });
 
-  it("preserves audio processing while selecting the exact microphone", async () => {
-    const transport = new GatewayRelayRealtimeTalkTransport(createSession(), {
-      callbacks: {},
-      client: createClient(),
-      sessionKey: "main",
-      inputDeviceId: "usb-mic",
-    });
-
-    await startTransport(transport);
-
-    expect(getUserMedia).toHaveBeenCalledWith({
-      audio: {
-        autoGainControl: true,
-        echoCancellation: true,
-        noiseSuppression: true,
-        deviceId: { exact: "usb-mic" },
-      },
-    });
-    transport.stop();
-  });
-
   it("closes relay resources on microphone loss even when status delivery throws", async () => {
     const track = Object.assign(new EventTarget(), { stop: vi.fn() });
     const addListener = vi.spyOn(track, "addEventListener");
     getUserMedia.mockResolvedValueOnce({ getTracks: () => [track] });
     const client = createClient();
     const onStatus = vi.fn();
-    const transport = createTransport({ client, callbacks: { onStatus } });
+    const transport = await createTransport({ client, callbacks: { onStatus } });
     await startTransport(transport);
     onStatus.mockImplementation(() => {
       throw new Error("status failed");
@@ -253,6 +234,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
 
   it("keeps the microphone processor inaudible locally", async () => {
     const transport = new GatewayRelayRealtimeTalkTransport(createSession(), {
+      input: await prepareRealtimeTalkTestInput(),
       callbacks: {},
       client: createClient(),
       sessionKey: "main",
@@ -273,48 +255,16 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
     expect(sink.disconnect).toHaveBeenCalledOnce();
   });
 
-  it("releases microphone access that resolves after stop", async () => {
-    let resolveMedia: (media: MediaStream) => void = () => undefined;
-    const pendingMedia = new Promise<MediaStream>((resolve) => {
-      resolveMedia = resolve;
-    });
-    getUserMedia.mockReturnValue(pendingMedia);
-    const stopTrack = vi.fn();
-    const onInputLevel = vi.fn();
-    const transport = new GatewayRelayRealtimeTalkTransport(createSession(), {
-      callbacks: { onInputLevel },
-      client: createClient(),
-      sessionKey: "main",
-    });
-
-    const start = transport.start();
-    transport.stop();
-    resolveMedia({
-      getTracks: () => [Object.assign(new EventTarget(), { stop: stopTrack })],
-    } as unknown as MediaStream);
-    await expect(start).resolves.toBe("cancelled");
-
-    expect(stopTrack).toHaveBeenCalledOnce();
-    expect(processors).toHaveLength(0);
-    expect(onInputLevel).not.toHaveBeenCalled();
-  });
-
   it("defers relay effects until the transport is committed", async () => {
-    let resolveMedia: (media: MediaStream) => void = () => undefined;
-    getUserMedia.mockReturnValue(
-      new Promise<MediaStream>((resolve) => {
-        resolveMedia = resolve;
-      }),
-    );
     const client = createClient();
     const onStatus = vi.fn();
     const onTranscript = vi.fn();
-    const transport = createTransport({
+    const transport = await createTransport({
       client,
       callbacks: { onStatus, onTranscript },
     });
 
-    const start = transport.start();
+    await expect(transport.start()).resolves.toBe("ready");
     onStatus.mockClear();
     emitTalkEvent({ relaySessionId: "relay-1", type: "ready" });
     emitTalkEvent({
@@ -336,14 +286,6 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
     expect(onTranscript).not.toHaveBeenCalled();
     expect(requestCallsFor(client, "talk.session.submitToolResult")).toHaveLength(0);
 
-    resolveMedia({
-      getTracks: () => [Object.assign(new EventTarget(), { stop: vi.fn() })],
-    } as unknown as MediaStream);
-    await expect(start).resolves.toBe("ready");
-    expect(onStatus).toHaveBeenCalledExactlyOnceWith("connecting", undefined);
-    onStatus.mockClear();
-    expect(onTranscript).not.toHaveBeenCalled();
-
     transport.activate();
 
     expect(onStatus).toHaveBeenCalledWith("listening");
@@ -359,43 +301,28 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
   });
 
   it("fails a provisional relay whose bounded event buffer overflows", async () => {
-    let resolveMedia: (media: MediaStream) => void = () => undefined;
-    getUserMedia.mockReturnValue(
-      new Promise<MediaStream>((resolve) => {
-        resolveMedia = resolve;
-      }),
-    );
     const onStatus = vi.fn();
     const client = createClient();
-    const transport = createTransport({ callbacks: { onStatus }, client });
+    const transport = await createTransport({ callbacks: { onStatus }, client });
 
-    const start = transport.start();
+    await expect(transport.start()).resolves.toBe("ready");
     onStatus.mockClear();
     for (let index = 0; index < 33; index += 1) {
       emitTalkEvent({ relaySessionId: "relay-1", type: "ready" });
     }
     expect(requestCallsFor(client, "talk.session.close")).toHaveLength(1);
-    resolveMedia({
-      getTracks: () => [Object.assign(new EventTarget(), { stop: vi.fn() })],
-    } as unknown as MediaStream);
 
-    await expect(start).rejects.toThrow(
+    expect(() => transport.activate()).toThrow(
       "Realtime relay emitted too much data before browser setup completed",
     );
     expect(onStatus).not.toHaveBeenCalled();
   });
 
   it("enforces the provisional relay byte bound", async () => {
-    let resolveMedia: (media: MediaStream) => void = () => undefined;
-    getUserMedia.mockReturnValue(
-      new Promise<MediaStream>((resolve) => {
-        resolveMedia = resolve;
-      }),
-    );
     const client = createClient();
-    const transport = createTransport({ client });
+    const transport = await createTransport({ client });
 
-    const start = transport.start();
+    await expect(transport.start()).resolves.toBe("ready");
     emitTalkEvent({
       relaySessionId: "relay-1",
       type: "transcript",
@@ -405,26 +332,17 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
     });
 
     expect(requestCallsFor(client, "talk.session.close")).toHaveLength(1);
-    resolveMedia({
-      getTracks: () => [Object.assign(new EventTarget(), { stop: vi.fn() })],
-    } as unknown as MediaStream);
-    await expect(start).rejects.toThrow(
+    expect(() => transport.activate()).toThrow(
       "Realtime relay emitted too much data before browser setup completed",
     );
   });
 
   it("rejects a relay that closes before browser setup commits", async () => {
-    let resolveMedia: (media: MediaStream) => void = () => undefined;
-    getUserMedia.mockReturnValue(
-      new Promise<MediaStream>((resolve) => {
-        resolveMedia = resolve;
-      }),
-    );
     const client = createClient();
     const onStatus = vi.fn();
-    const transport = createTransport({ callbacks: { onStatus }, client });
+    const transport = await createTransport({ callbacks: { onStatus }, client });
 
-    const start = transport.start();
+    await expect(transport.start()).resolves.toBe("ready");
     onStatus.mockClear();
     emitTalkEvent({
       relaySessionId: "relay-1",
@@ -436,11 +354,8 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       type: "close",
       reason: "error",
     });
-    resolveMedia({
-      getTracks: () => [Object.assign(new EventTarget(), { stop: vi.fn() })],
-    } as unknown as MediaStream);
 
-    await expect(start).rejects.toThrow("provider rejected setup");
+    expect(() => transport.activate()).toThrow("provider rejected setup");
     expect(onStatus).not.toHaveBeenCalled();
     expect(requestCallsFor(client, "talk.session.close")).toHaveLength(0);
   });
@@ -448,7 +363,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
   it("closes the relay when a provisional callback throws during activation", async () => {
     const client = createClient();
     const onStatus = vi.fn();
-    const transport = createTransport({ callbacks: { onStatus }, client });
+    const transport = await createTransport({ callbacks: { onStatus }, client });
 
     const start = transport.start();
     emitTalkEvent({ relaySessionId: "relay-1", type: "ready" });
@@ -464,6 +379,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
   it("forwards common Talk events from Gateway relay frames", async () => {
     const onTalkEvent = vi.fn();
     const transport = new GatewayRelayRealtimeTalkTransport(createSession(), {
+      input: await prepareRealtimeTalkTestInput(),
       callbacks: { onTalkEvent },
       client: createClient(),
       sessionKey: "main",
@@ -493,7 +409,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
 
   it("does not forward Talk events for another relay session", async () => {
     const onTalkEvent = vi.fn();
-    const transport = createTransport({ callbacks: { onTalkEvent } });
+    const transport = await createTransport({ callbacks: { onTalkEvent } });
 
     await startTransport(transport);
     emitTalkEvent({
@@ -518,7 +434,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
 
   it("keeps assistant playback alive while relay input is silence", async () => {
     const client = createClient();
-    const transport = createTransport({ client });
+    const transport = await createTransport({ client });
 
     await startTransport(transport);
     emitTalkEvent({
@@ -538,7 +454,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
 
   it("cancels overflowing playback and ignores late audio until provider clear", async () => {
     const client = createClient();
-    const transport = createTransport({ client });
+    const transport = await createTransport({ client });
 
     await startTransport(transport);
     for (let index = 0; index < 321; index += 1) {
@@ -585,7 +501,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
 
   it("cancels provider output when the first audio chunk exceeds the time budget", async () => {
     const client = createClient();
-    const transport = createTransport({ client });
+    const transport = await createTransport({ client });
 
     await startTransport(transport);
     emitTalkEvent({
@@ -614,7 +530,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
   it("acknowledges provider marks only after the local playback queue drains", async () => {
     vi.useFakeTimers();
     const client = createClient();
-    const transport = createTransport({ client });
+    const transport = await createTransport({ client });
 
     await startTransport(transport);
     emitTalkEvent({
@@ -637,7 +553,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
   it("clears pending provider mark timers when stopped", async () => {
     vi.useFakeTimers();
     const client = createClient();
-    const transport = createTransport({ client });
+    const transport = await createTransport({ client });
 
     await startTransport(transport);
     emitTalkEvent({
@@ -655,7 +571,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
 
   it("reports microphone activity and resets it when stopped", async () => {
     const onInputLevel = vi.fn();
-    const transport = createTransport({ callbacks: { onInputLevel } });
+    const transport = await createTransport({ callbacks: { onInputLevel } });
 
     await startTransport(transport);
     pumpMicrophone(new Float32Array(4096));
@@ -674,7 +590,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
         transport.stop();
       }
     });
-    const transport = createTransport({ client, callbacks: { onInputLevel } });
+    const transport = await createTransport({ client, callbacks: { onInputLevel } });
 
     await expect(transport.start()).resolves.toBe("ready");
     transport.stop();
@@ -713,7 +629,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
         );
       });
     });
-    const transport = createTransport({ callbacks: { onStatus }, client });
+    const transport = await createTransport({ callbacks: { onStatus }, client });
 
     await startTransport(transport);
     const samples = new Float32Array(4096);
@@ -744,7 +660,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
 
   it("preserves accepted microphone frame order", async () => {
     const client = createClient();
-    const transport = createTransport({ client });
+    const transport = await createTransport({ client });
 
     await startTransport(transport);
     for (const timestamp of [10, 20, 30, 40]) {
@@ -772,7 +688,10 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
         rejectOldAppend = reject;
       });
     });
-    const oldTransport = createTransport({ callbacks: { onStatus: oldStatus }, client: oldClient });
+    const oldTransport = await createTransport({
+      callbacks: { onStatus: oldStatus },
+      client: oldClient,
+    });
 
     await oldTransport.start();
     oldStatus.mockClear();
@@ -781,7 +700,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
 
     const replacementStatus = vi.fn();
     const replacementClient = createClient();
-    const replacement = createTransport({
+    const replacement = await createTransport({
       callbacks: { onStatus: replacementStatus },
       client: replacementClient,
     });
@@ -806,7 +725,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       }
       return {};
     });
-    const transport = createTransport({ callbacks: { onStatus }, client });
+    const transport = await createTransport({ callbacks: { onStatus }, client });
 
     await startTransport(transport);
     pumpMicrophone(new Float32Array(4096));
@@ -830,7 +749,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
   it("treats relay close events as local shutdown", async () => {
     const onStatus = vi.fn();
     const client = createClient();
-    const transport = createTransport({ callbacks: { onStatus }, client });
+    const transport = await createTransport({ callbacks: { onStatus }, client });
 
     await startTransport(transport);
     pumpMicrophone(new Float32Array(4096));
@@ -862,7 +781,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       } as unknown as MediaStream);
       const throwingCallback = vi.fn();
       const client = createClient();
-      const transport = createTransport({
+      const transport = await createTransport({
         client,
         callbacks:
           callbackKind === "talk event"
@@ -909,7 +828,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
   it("preserves relay error details across close events", async () => {
     const onStatus = vi.fn();
     const client = createClient();
-    const transport = createTransport({ callbacks: { onStatus }, client });
+    const transport = await createTransport({ callbacks: { onStatus }, client });
 
     await startTransport(transport);
     emitTalkEvent({
@@ -929,7 +848,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
 
   it("cancels relay playback after sustained input speech", async () => {
     const client = createClient();
-    const transport = createTransport({ client });
+    const transport = await createTransport({ client });
     const speech = new Float32Array(4096).fill(0.25);
 
     await startTransport(transport);
@@ -969,7 +888,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       }
       return {};
     });
-    const transport = createTransport({ callbacks: { onStatus }, client });
+    const transport = await createTransport({ callbacks: { onStatus }, client });
 
     await startTransport(transport);
     emitTalkEvent({
@@ -1024,7 +943,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       }
       return {};
     });
-    const transport = createTransport({ callbacks: { onStatus }, client });
+    const transport = await createTransport({ callbacks: { onStatus }, client });
 
     await startTransport(transport);
     emitTalkEvent({
@@ -1073,7 +992,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       }
       return {};
     });
-    const transport = createTransport({ callbacks: { onStatus }, client });
+    const transport = await createTransport({ callbacks: { onStatus }, client });
 
     await startTransport(transport);
     emitTalkEvent({
@@ -1112,7 +1031,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       }
       return {};
     });
-    const transport = createTransport({ client });
+    const transport = await createTransport({ client });
 
     await startTransport(transport);
     emitTalkEvent({
@@ -1149,7 +1068,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       }
       return {};
     });
-    const transport = createTransport({ client });
+    const transport = await createTransport({ client });
 
     await startTransport(transport);
     emitTalkEvent({
@@ -1194,7 +1113,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       }
       return {};
     });
-    const transport = createTransport({ client });
+    const transport = await createTransport({ client });
 
     await startTransport(transport);
     emitTalkEvent({
@@ -1246,7 +1165,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       }
       return {};
     });
-    const transport = createTransport({ client });
+    const transport = await createTransport({ client });
 
     await startTransport(transport);
     emitTalkEvent({
@@ -1281,7 +1200,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       }
       return {};
     });
-    const transport = createTransport({ client });
+    const transport = await createTransport({ client });
     const speech = new Float32Array(4096).fill(0.25);
 
     await startTransport(transport);
@@ -1400,7 +1319,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
         return {};
       });
       const onStatus = vi.fn();
-      const transport = createTransport({ callbacks: { onStatus }, client });
+      const transport = await createTransport({ callbacks: { onStatus }, client });
       const speech = new Float32Array(4096).fill(0.25);
 
       await startTransport(transport);
@@ -1460,7 +1379,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
         return {};
       });
       const onStatus = vi.fn();
-      const transport = createTransport({ callbacks: { onStatus }, client });
+      const transport = await createTransport({ callbacks: { onStatus }, client });
       const speech = new Float32Array(4096).fill(0.25);
 
       await startTransport(transport);
@@ -1515,7 +1434,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       return {};
     });
     const onStatus = vi.fn();
-    const transport = createTransport({ callbacks: { onStatus }, client });
+    const transport = await createTransport({ callbacks: { onStatus }, client });
     const speech = new Float32Array(4096).fill(0.25);
 
     await startTransport(transport);
@@ -1560,7 +1479,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       }
       return {};
     });
-    const transport = createTransport({ client });
+    const transport = await createTransport({ client });
 
     await startTransport(transport);
     emitTalkEvent({
@@ -1624,7 +1543,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       }
       return {};
     });
-    const transport = createTransport({ client });
+    const transport = await createTransport({ client });
 
     await startTransport(transport);
     emitTalkEvent({
@@ -1672,7 +1591,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       expect(options).toBeUndefined();
       return await pendingSteer;
     });
-    const transport = createTransport({ client });
+    const transport = await createTransport({ client });
 
     await startTransport(transport);
     emitTalkEvent({
@@ -1712,7 +1631,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       }
       return {};
     });
-    const transport = createTransport({ client });
+    const transport = await createTransport({ client });
 
     await startTransport(transport);
     emitTalkEvent({
@@ -1759,7 +1678,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       }
       return {};
     });
-    const transport = createTransport({ client });
+    const transport = await createTransport({ client });
 
     await startTransport(transport);
     emitTalkEvent({

--- a/ui/src/pages/chat/realtime-talk-gateway-relay.ts
+++ b/ui/src/pages/chat/realtime-talk-gateway-relay.ts
@@ -11,7 +11,6 @@ import {
   type RealtimeTalkAudioFrame,
 } from "./realtime-talk-audio.ts";
 import type { DelayedToolResult, GatewayRelayEvent } from "./realtime-talk-gateway-relay-types.ts";
-import { RealtimeTalkInputController } from "./realtime-talk-input.ts";
 import {
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
   REALTIME_VOICE_AGENT_CONTROL_TOOL_NAME,
@@ -44,10 +43,7 @@ function estimateRelayEventBytes(event: GatewayRelayEvent): number {
 }
 
 export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport {
-  private readonly input = new RealtimeTalkInputController(
-    (detail) => this.failAudioAppend(detail),
-    (detail) => this.ctx.callbacks.onStatus?.("connecting", detail),
-  );
+  private readonly input = this.ctx.input;
   private inputContext: AudioContext | null = null;
   private outputContext: AudioContext | null = null;
   private inputMeter: RealtimeTalkMediaStreamMeter | null = null;
@@ -79,9 +75,6 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
   ) {}
 
   async start(): Promise<RealtimeTalkTransportStartResult> {
-    if (!navigator.mediaDevices?.getUserMedia) {
-      throw new Error("Realtime Talk requires browser microphone access");
-    }
     if (
       this.session.audio.inputEncoding !== "pcm16" ||
       this.session.audio.outputEncoding !== "pcm16"
@@ -99,19 +92,7 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
       }
       this.handleIncomingRelayEvent(evt.payload as GatewayRelayEvent);
     });
-    let media: MediaStream;
-    try {
-      media = await this.input.open(this.ctx.inputDeviceId);
-    } catch (error) {
-      const startupError = this.currentStartupError();
-      if (startupError) {
-        throw startupError;
-      }
-      if (this.closed) {
-        return "cancelled";
-      }
-      throw error;
-    }
+    const media = this.input.adopt((detail) => this.failAudioAppend(detail));
     const startupError = this.currentStartupError();
     if (startupError) {
       this.input.stop();
@@ -133,6 +114,9 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
   }
 
   activate(): void {
+    if (this.startupError) {
+      throw this.startupError;
+    }
     if (this.closed || this.activated) {
       return;
     }

--- a/ui/src/pages/chat/realtime-talk-google-live-control.test.ts
+++ b/ui/src/pages/chat/realtime-talk-google-live-control.test.ts
@@ -33,7 +33,7 @@ describe("GoogleLiveRealtimeTalkTransport control results", () => {
       }
       throw new Error(`unexpected request: ${method}`);
     });
-    const transport = createTransport({ onStatus, onTalkEvent }, client);
+    const transport = await createTransport({ onStatus, onTalkEvent }, client);
 
     const ws = await startTransport(transport);
     vi.spyOn(ws, "send").mockImplementation(() => {
@@ -86,7 +86,7 @@ describe("GoogleLiveRealtimeTalkTransport control results", () => {
       }
       throw new Error(`unexpected request: ${method}`);
     });
-    const transport = createTransport({}, client);
+    const transport = await createTransport({}, client);
     const ws = await startTransport(transport);
     ws.emitMessage(
       encodeJsonFrame({
@@ -157,7 +157,7 @@ describe("GoogleLiveRealtimeTalkTransport control results", () => {
       }
       throw new Error(`unexpected request: ${method}`);
     });
-    const transport = createTransport({}, client);
+    const transport = await createTransport({}, client);
     const ws = await startTransport(transport);
     ws.emitMessage(
       encodeJsonFrame({
@@ -228,7 +228,7 @@ describe("GoogleLiveRealtimeTalkTransport control results", () => {
       }
       throw new Error(`unexpected request: ${method}`);
     });
-    const transport = createTransport({}, client);
+    const transport = await createTransport({}, client);
     const ws = await startTransport(transport);
     ws.emitMessage(
       encodeJsonFrame({

--- a/ui/src/pages/chat/realtime-talk-google-live-timeout.test.ts
+++ b/ui/src/pages/chat/realtime-talk-google-live-timeout.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GoogleLiveRealtimeTalkTransport } from "./realtime-talk-google-live.ts";
+import { prepareRealtimeTalkTestInput } from "./realtime-talk-input.test-support.ts";
 import type {
   RealtimeTalkCallbacks,
   RealtimeTalkJsonPcmWebSocketSessionResult,
@@ -95,8 +96,9 @@ function createSession(): RealtimeTalkJsonPcmWebSocketSessionResult {
   };
 }
 
-function createTransport(callbacks: RealtimeTalkCallbacks = {}) {
+async function createTransport(callbacks: RealtimeTalkCallbacks = {}) {
   return new GoogleLiveRealtimeTalkTransport(createSession(), {
+    input: await prepareRealtimeTalkTestInput(),
     callbacks,
     client: { request: vi.fn(), addEventListener: vi.fn() } as never,
     sessionKey: "main",
@@ -146,7 +148,7 @@ describe("Google Live setup timeout", () => {
   it("releases browser resources when the WebSocket never opens", async () => {
     const onStatus = vi.fn();
     const onTalkEvent = vi.fn();
-    const transport = createTransport({ onStatus, onTalkEvent });
+    const transport = await createTransport({ onStatus, onTalkEvent });
 
     const { start, socket } = await beginTransport(transport);
     onStatus.mockClear();
@@ -166,7 +168,7 @@ describe("Google Live setup timeout", () => {
 
   it("times out an open socket that never completes Google setup", async () => {
     const onStatus = vi.fn();
-    const transport = createTransport({ onStatus });
+    const transport = await createTransport({ onStatus });
 
     const { start, socket } = await beginTransport(transport);
     onStatus.mockClear();
@@ -185,7 +187,7 @@ describe("Google Live setup timeout", () => {
     const onTalkEvent = vi.fn(() => {
       throw new Error("talk callback must remain provisional");
     });
-    const transport = createTransport({ onStatus, onTalkEvent });
+    const transport = await createTransport({ onStatus, onTalkEvent });
 
     const { start, socket } = await beginTransport(transport);
     onStatus.mockClear();
@@ -210,7 +212,7 @@ describe("Google Live setup timeout", () => {
     ["error", "Realtime connection failed"],
   ] as const)("rejects startup when the WebSocket emits %s", async (event, detail) => {
     const onStatus = vi.fn();
-    const transport = createTransport({ onStatus });
+    const transport = await createTransport({ onStatus });
     const { start, socket } = await beginTransport(transport);
     onStatus.mockClear();
     const rejected = expect(start).rejects.toThrow(detail);
@@ -230,7 +232,7 @@ describe("Google Live setup timeout", () => {
 
   it("rejects when the socket closes after setup but before activation", async () => {
     const onStatus = vi.fn();
-    const transport = createTransport({ onStatus });
+    const transport = await createTransport({ onStatus });
     const { start, socket } = await beginTransport(transport);
     onStatus.mockClear();
     socket.emitOpen();
@@ -249,7 +251,7 @@ describe("Google Live setup timeout", () => {
 
   it("releases resources when a readiness callback throws during activation", async () => {
     const onStatus = vi.fn();
-    const transport = createTransport({ onStatus });
+    const transport = await createTransport({ onStatus });
     const { start, socket } = await beginTransport(transport);
     onStatus.mockClear();
     onStatus.mockImplementation(() => {
@@ -268,7 +270,7 @@ describe("Google Live setup timeout", () => {
   it("reclaims the meter when an input-level callback cancels activation", async () => {
     let stopDuringActivation: () => void = () => undefined;
     const onInputLevel = vi.fn(() => stopDuringActivation());
-    const transport = createTransport({ onInputLevel });
+    const transport = await createTransport({ onInputLevel });
     stopDuringActivation = () => transport.stop({ emitClosed: false });
     const { start, socket } = await beginTransport(transport);
     socket.emitOpen();
@@ -284,7 +286,7 @@ describe("Google Live setup timeout", () => {
 
   it("clears the deadline after Google setup completes", async () => {
     const onStatus = vi.fn();
-    const transport = createTransport({ onStatus });
+    const transport = await createTransport({ onStatus });
 
     const { start, socket } = await beginTransport(transport);
     onStatus.mockClear();
@@ -301,7 +303,7 @@ describe("Google Live setup timeout", () => {
 
   it("clears the deadline when the transport stops", async () => {
     const onStatus = vi.fn();
-    const transport = createTransport({ onStatus });
+    const transport = await createTransport({ onStatus });
 
     const { start } = await beginTransport(transport);
     onStatus.mockClear();

--- a/ui/src/pages/chat/realtime-talk-google-live-transcripts.test.ts
+++ b/ui/src/pages/chat/realtime-talk-google-live-transcripts.test.ts
@@ -9,13 +9,14 @@ import {
   startTransport,
 } from "./realtime-talk-google-live.test-support.ts";
 import { GoogleLiveRealtimeTalkTransport } from "./realtime-talk-google-live.ts";
+import { prepareRealtimeTalkTestInput } from "./realtime-talk-input.test-support.ts";
 
 describe("Google Live browser transcript finality", () => {
   installGoogleLiveTestFixture();
 
   it("finalizes both live 3.1 spoken turns before the session closes", async () => {
     const onTranscript = vi.fn();
-    const transport = createTransport({ onTranscript });
+    const transport = await createTransport({ onTranscript });
     const ws = await startTransport(transport);
     for (const [input, output] of [
       ["Please reply with the single word glacier.", "Glacier."],
@@ -50,7 +51,12 @@ describe("Google Live browser transcript finality", () => {
         ),
         model: "gemini-2.5-flash-native-audio-preview-12-2025",
       },
-      { callbacks: { onTranscript }, client: createClient(), sessionKey: "main" },
+      {
+        input: await prepareRealtimeTalkTestInput(),
+        callbacks: { onTranscript },
+        client: createClient(),
+        sessionKey: "main",
+      },
     );
     const ws = await startTransport(transport);
     for (const transcription of [{ text: "Last " }, { text: "words" }, { finished: true }]) {
@@ -94,7 +100,7 @@ describe("Google Live browser transcript finality", () => {
     async ({ boundary }) => {
       const onTranscript = vi.fn();
       const onTalkEvent = vi.fn();
-      const transport = createTransport({ onTranscript, onTalkEvent });
+      const transport = await createTransport({ onTranscript, onTalkEvent });
       const ws = await startTransport(transport);
       onTalkEvent.mockClear();
       for (const serverContent of [
@@ -128,7 +134,7 @@ describe("Google Live browser transcript finality", () => {
   it("releases the UTF-8 transcript budget on finality and closes on overflow without persisting a partial", async () => {
     const onTranscript = vi.fn();
     const onStatus = vi.fn();
-    const transport = createTransport({ onTranscript, onStatus });
+    const transport = await createTransport({ onTranscript, onStatus });
     const ws = await startTransport(transport);
     const atLimit = "é".repeat(128 * 1024);
     for (const outputTranscription of [

--- a/ui/src/pages/chat/realtime-talk-google-live-video.test.ts
+++ b/ui/src/pages/chat/realtime-talk-google-live-video.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME } from "../../../../src/talk/describe-view-tool.js";
 import { GoogleLiveRealtimeTalkTransport } from "./realtime-talk-google-live.ts";
+import { prepareRealtimeTalkTestInput } from "./realtime-talk-input.test-support.ts";
 import type { RealtimeTalkCallbacks } from "./realtime-talk-shared.ts";
 
 class FakeGoogleLiveWebSocket extends EventTarget {
@@ -58,7 +59,7 @@ class FakeAudioContext {
   async close(): Promise<void> {}
 }
 
-function createTransport(callbacks: RealtimeTalkCallbacks, videoDeviceId?: string) {
+async function createTransport(callbacks: RealtimeTalkCallbacks, videoDeviceId?: string) {
   return new GoogleLiveRealtimeTalkTransport(
     {
       provider: "google",
@@ -76,6 +77,7 @@ function createTransport(callbacks: RealtimeTalkCallbacks, videoDeviceId?: strin
       },
     },
     {
+      input: await prepareRealtimeTalkTestInput(),
       callbacks,
       client: { request: vi.fn(), addEventListener: vi.fn() } as never,
       sessionKey: "main",
@@ -166,7 +168,7 @@ describe("Google Live Video Talk", () => {
       .mockReturnValue("data:image/jpeg;base64,gemini-camera-frame");
     const onStatus = vi.fn();
     const onVideoStream = vi.fn();
-    const transport = createTransport({ onStatus, onVideoStream });
+    const transport = await createTransport({ onStatus, onVideoStream });
 
     const { start, ws } = await beginTransport(transport);
     expect(getUserMedia).toHaveBeenCalledOnce();
@@ -298,7 +300,7 @@ describe("Google Live Video Talk", () => {
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
     vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
     const onVideoStream = vi.fn();
-    const transport = createTransport({ onVideoStream });
+    const transport = await createTransport({ onVideoStream });
 
     await startTransport(transport);
     await transport.setVideoEnabled(true);
@@ -330,7 +332,7 @@ describe("Google Live Video Talk", () => {
     });
     const getUserMedia = vi.fn().mockResolvedValueOnce(audio).mockReturnValueOnce(cameraPending);
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
-    const transport = createTransport({});
+    const transport = await createTransport({});
 
     await startTransport(transport);
     const enabling = transport.setVideoEnabled(true);
@@ -375,7 +377,7 @@ describe("Google Live Video Talk", () => {
         throw new Error("stream callback failed");
       }
     });
-    const transport = createTransport({ onVideoStream });
+    const transport = await createTransport({ onVideoStream });
     const ws = await startTransport(transport);
     await transport.setVideoEnabled(true);
 
@@ -424,7 +426,7 @@ describe("Google Live Video Talk", () => {
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
     vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
     const onVideoStream = vi.fn();
-    const transport = createTransport({ onVideoStream }, "front");
+    const transport = await createTransport({ onVideoStream }, "front");
 
     await startTransport(transport);
     await transport.setVideoEnabled(true);
@@ -474,7 +476,7 @@ describe("Google Live Video Talk", () => {
     });
     const onStatus = vi.fn();
     const onVideoStream = vi.fn();
-    const transport = createTransport({ onStatus, onVideoStream });
+    const transport = await createTransport({ onStatus, onVideoStream });
 
     const { start, ws } = await beginTransport(transport);
     onStatus.mockClear();

--- a/ui/src/pages/chat/realtime-talk-google-live.test-support.ts
+++ b/ui/src/pages/chat/realtime-talk-google-live.test-support.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, expect, vi } from "vitest";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { GoogleLiveRealtimeTalkTransport } from "./realtime-talk-google-live.ts";
+import { prepareRealtimeTalkTestInput } from "./realtime-talk-input.test-support.ts";
 import type {
   RealtimeTalkJsonPcmWebSocketSessionResult,
   RealtimeTalkTransportContext,
@@ -191,7 +192,7 @@ export function createClient(): RealtimeTalkTransportContext["client"] {
   return client;
 }
 
-export function createTransport(
+export async function createTransport(
   callbacks: RealtimeTalkTransportContext["callbacks"] = {},
   client = createClient(),
   inputDeviceId?: string,
@@ -201,10 +202,10 @@ export function createTransport(
       "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained",
     ),
     {
+      input: await prepareRealtimeTalkTestInput(inputDeviceId),
       callbacks,
       client,
       sessionKey: "main",
-      inputDeviceId,
     },
   );
 }

--- a/ui/src/pages/chat/realtime-talk-google-live.test.ts
+++ b/ui/src/pages/chat/realtime-talk-google-live.test.ts
@@ -22,6 +22,7 @@ import {
   wsInstances,
 } from "./realtime-talk-google-live.test-support.ts";
 import { GoogleLiveRealtimeTalkTransport } from "./realtime-talk-google-live.ts";
+import { prepareRealtimeTalkTestInput } from "./realtime-talk-input.test-support.ts";
 import {
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
   REALTIME_VOICE_AGENT_CONTROL_TOOL_NAME,
@@ -36,7 +37,12 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
       createSession(
         "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained?ignored=1",
       ),
-      { callbacks: {}, client: createClient(), sessionKey: "main" },
+      {
+        input: await prepareRealtimeTalkTestInput(),
+        callbacks: {},
+        client: createClient(),
+        sessionKey: "main",
+      },
     );
 
     const { start } = await beginTransport(transport);
@@ -54,6 +60,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
     "wss://generativelanguage.googleapis.com/evil",
   ])("rejects attacker-controlled WebSocket URL %s", async (websocketUrl) => {
     const transport = new GoogleLiveRealtimeTalkTransport(createSession(websocketUrl), {
+      input: await prepareRealtimeTalkTestInput(),
       callbacks: {},
       client: createClient(),
       sessionKey: "main",
@@ -63,25 +70,8 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
     expect(wsInstances).toHaveLength(0);
   });
 
-  it("captures from the selected microphone with an exact constraint", async () => {
-    const transport = createTransport({}, createClient(), "usb-mic");
-
-    const { start } = await beginTransport(transport);
-
-    expect(googleLiveTestFixture.getUserMedia).toHaveBeenCalledWith({
-      audio: {
-        autoGainControl: true,
-        echoCancellation: true,
-        noiseSuppression: true,
-        deviceId: { exact: "usb-mic" },
-      },
-    });
-    transport.stop();
-    await expect(start).resolves.toBe("cancelled");
-  });
-
   it("keeps the microphone processor inaudible locally", async () => {
-    const transport = createTransport();
+    const transport = await createTransport();
 
     await startTransport(transport);
 
@@ -98,31 +88,10 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
     expect(sink.disconnect).toHaveBeenCalledOnce();
   });
 
-  it("releases microphone access that resolves after stop", async () => {
-    let resolveMedia: (media: MediaStream) => void = () => undefined;
-    const pendingMedia = new Promise<MediaStream>((resolve) => {
-      resolveMedia = resolve;
-    });
-    googleLiveTestFixture.getUserMedia.mockReturnValue(pendingMedia);
-    const stopTrack = vi.fn();
-    const onInputLevel = vi.fn();
-    const transport = createTransport({ onInputLevel });
-
-    const start = transport.start();
-    transport.stop();
-    resolveMedia({ getTracks: () => [{ stop: stopTrack }] } as unknown as MediaStream);
-    await expect(start).resolves.toBe("cancelled");
-
-    expect(stopTrack).toHaveBeenCalledOnce();
-    expect(inputProcessors).toHaveLength(0);
-    expect(wsInstances).toHaveLength(0);
-    expect(onInputLevel).not.toHaveBeenCalled();
-  });
-
   it("requests ArrayBuffer frames and decodes binary setup messages", async () => {
     const onStatus = vi.fn();
     const onTalkEvent = vi.fn();
-    const transport = createTransport({ onStatus, onTalkEvent });
+    const transport = await createTransport({ onStatus, onTalkEvent });
 
     const { start, ws } = await beginTransport(transport);
     onStatus.mockClear();
@@ -147,7 +116,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
     const track = Object.assign(new EventTarget(), { stop: vi.fn() });
     googleLiveTestFixture.getUserMedia.mockResolvedValueOnce({ getTracks: () => [track] });
     const onStatus = vi.fn();
-    const transport = createTransport({ onStatus });
+    const transport = await createTransport({ onStatus });
     const ws = await startTransport(transport);
 
     track.dispatchEvent(new Event("ended"));
@@ -163,7 +132,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
   it("releases owned media when the live socket closes", async () => {
     const onStatus = vi.fn();
     const onTranscript = vi.fn();
-    const transport = createTransport({ onStatus, onTranscript });
+    const transport = await createTransport({ onStatus, onTranscript });
 
     const ws = await startTransport(transport);
     pumpMicrophone(new Float32Array(4096));
@@ -191,7 +160,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
   it("preserves socket error precedence and ignores the later close", async () => {
     const onStatus = vi.fn();
     const onTranscript = vi.fn();
-    const transport = createTransport({ onStatus, onTranscript });
+    const transport = await createTransport({ onStatus, onTranscript });
 
     const ws = await startTransport(transport);
     onStatus.mockClear();
@@ -215,7 +184,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
   it.each(["status", "talk event"] as const)(
     "releases socket resources when the terminal %s callback throws",
     async (callbackKind) => {
-      const transport = createTransport(
+      const transport = await createTransport(
         callbackKind === "status"
           ? {
               onStatus: vi.fn((status) => {
@@ -249,7 +218,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
     const onInputLevel = vi.fn(() => {
       throw new Error("meter callback failed");
     });
-    const transport = createTransport({ onInputLevel });
+    const transport = await createTransport({ onInputLevel });
     const { start, ws } = await beginTransport(transport);
     ws.emitOpen();
     ws.emitMessage(encodeJsonFrame({ setupComplete: {} }));
@@ -266,7 +235,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
 
   it("reports microphone activity and resets it when stopped", async () => {
     const onInputLevel = vi.fn();
-    const transport = createTransport({ onInputLevel });
+    const transport = await createTransport({ onInputLevel });
 
     await startTransport(transport);
     pumpMicrophone(new Float32Array(4096));
@@ -279,7 +248,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
 
   it("decodes Blob setup messages", async () => {
     const onStatus = vi.fn();
-    const transport = createTransport({ onStatus });
+    const transport = await createTransport({ onStatus });
 
     const { start, ws } = await beginTransport(transport);
     ws.emitOpen();
@@ -292,7 +261,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
 
   it("stops queued output when Google Live sends interruption", async () => {
     const onTalkEvent = vi.fn();
-    const transport = createTransport({ onTalkEvent });
+    const transport = await createTransport({ onTalkEvent });
     const ws = await startTransport(transport);
 
     ws.emitMessage(
@@ -320,7 +289,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
   it("closes an overflowing playback response and ignores late provider audio", async () => {
     const onStatus = vi.fn();
     const onTalkEvent = vi.fn();
-    const transport = createTransport({ onStatus, onTalkEvent });
+    const transport = await createTransport({ onStatus, onTalkEvent });
     const ws = await startTransport(transport);
 
     ws.emitMessage(
@@ -368,7 +337,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
 
   it("rejects an oversized first frame before decoding provider audio", async () => {
     const onStatus = vi.fn();
-    const transport = createTransport({ onStatus });
+    const transport = await createTransport({ onStatus });
     const ws = await startTransport(transport);
 
     ws.emitMessage(
@@ -401,7 +370,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
   it("emits common Talk events for Google Live transcript and audio frames", async () => {
     const onTranscript = vi.fn();
     const onTalkEvent = vi.fn();
-    const transport = createTransport({ onTalkEvent, onTranscript });
+    const transport = await createTransport({ onTalkEvent, onTranscript });
 
     const ws = await startTransport(transport);
     onTalkEvent.mockClear();
@@ -450,7 +419,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
   it("stops processing the current provider message when a transcript callback closes it", async () => {
     const onTalkEvent = vi.fn();
     const onTranscript = vi.fn(() => transport.stop());
-    const transport = createTransport({ onTalkEvent, onTranscript });
+    const transport = await createTransport({ onTalkEvent, onTranscript });
 
     const ws = await startTransport(transport);
     onTalkEvent.mockClear();
@@ -471,7 +440,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
 
   it("silently disposes a provisional Google Live transport", async () => {
     const onTalkEvent = vi.fn();
-    const transport = createTransport({ onTalkEvent });
+    const transport = await createTransport({ onTalkEvent });
     const { start, ws } = await beginTransport(transport);
 
     transport.stop({ emitClosed: false });
@@ -483,7 +452,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
 
   it("ignores late WebSocket events after stop", async () => {
     const onStatus = vi.fn();
-    const transport = createTransport({ onStatus });
+    const transport = await createTransport({ onStatus });
     const { start, ws } = await beginTransport(transport);
     onStatus.mockClear();
 
@@ -517,7 +486,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
         return { runId };
       }),
     } as unknown as RealtimeTalkTransportContext["client"];
-    const transport = createTransport({ onStatus }, client);
+    const transport = await createTransport({ onStatus }, client);
     const ws = await startTransport(transport);
     onStatus.mockClear();
 
@@ -560,7 +529,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
         return { runId: "run-1" };
       }),
     } as unknown as RealtimeTalkTransportContext["client"];
-    const transport = createTransport({}, client);
+    const transport = await createTransport({}, client);
     const ws = await startTransport(transport);
 
     ws.emitMessage(
@@ -603,7 +572,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
   it("does not retain browser tool arguments while a consult is pending", async () => {
     const client = createClient();
     vi.mocked(client["request"]).mockResolvedValue({ runId: "run-1" });
-    const transport = createTransport({}, client);
+    const transport = await createTransport({}, client);
     const ws = await startTransport(transport);
 
     ws.emitMessage(
@@ -631,7 +600,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
 
   it("answers unsupported browser tools once without retaining them", async () => {
     const onTalkEvent = vi.fn();
-    const transport = createTransport({ onTalkEvent });
+    const transport = await createTransport({ onTalkEvent });
     const ws = await startTransport(transport);
 
     ws.emitMessage(
@@ -681,7 +650,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
 
   it("fails closed when an unsupported browser tool response cannot be sent", async () => {
     const onStatus = vi.fn();
-    const transport = createTransport({ onStatus });
+    const transport = await createTransport({ onStatus });
     const ws = await startTransport(transport);
     vi.spyOn(ws, "send").mockImplementationOnce(() => {
       throw new Error("Google Live socket rejected the unsupported tool result");
@@ -722,7 +691,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
       request,
     } as unknown as RealtimeTalkTransportContext["client"];
     const onStatus = vi.fn();
-    const transport = createTransport({ onStatus }, client);
+    const transport = await createTransport({ onStatus }, client);
     const ws = await startTransport(transport);
 
     ws.emitMessage(
@@ -804,7 +773,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
       addEventListener: vi.fn(() => () => undefined),
       request,
     } as unknown as RealtimeTalkTransportContext["client"];
-    const transport = createTransport({}, client);
+    const transport = await createTransport({}, client);
     const ws = await startTransport(transport);
     const toolCall = {
       id: "call-1",
@@ -859,7 +828,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
       request,
     } as unknown as RealtimeTalkTransportContext["client"];
     const onTalkEvent = vi.fn();
-    const transport = createTransport({ onTalkEvent }, client);
+    const transport = await createTransport({ onTalkEvent }, client);
     const ws = await startTransport(transport);
 
     ws.emitMessage(
@@ -908,7 +877,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
       addEventListener: vi.fn(() => () => undefined),
       request,
     } as unknown as RealtimeTalkTransportContext["client"];
-    const transport = createTransport({ onStatus }, client);
+    const transport = await createTransport({ onStatus }, client);
     const ws = await startTransport(transport);
     const { pendingCalls } = getGoogleLiveToolOwnerState(transport);
     for (let index = 0; index < 1_024; index += 1) {
@@ -947,7 +916,7 @@ describe("GoogleLiveRealtimeTalkTransport", () => {
 
   it("fails closed before evicting seen browser tool-call ids", async () => {
     const onStatus = vi.fn();
-    const transport = createTransport({ onStatus });
+    const transport = await createTransport({ onStatus });
     const ws = await startTransport(transport);
     const internal = getGoogleLiveToolOwnerState(transport);
 

--- a/ui/src/pages/chat/realtime-talk-google-live.ts
+++ b/ui/src/pages/chat/realtime-talk-google-live.ts
@@ -19,7 +19,7 @@ import {
   GoogleLiveToolOwner,
   type GoogleLiveFunctionCall,
 } from "./realtime-talk-google-live-tools.ts";
-import { openRealtimeTalkCamera, RealtimeTalkInputController } from "./realtime-talk-input.ts";
+import { openRealtimeTalkCamera } from "./realtime-talk-input.ts";
 import {
   type RealtimeTalkJsonPcmWebSocketSessionResult,
   createRealtimeTalkEventEmitter,
@@ -81,15 +81,7 @@ function isGemini31LiveModel(model: string | undefined): boolean {
 export class GoogleLiveRealtimeTalkTransport implements RealtimeTalkTransport {
   private ws: WebSocket | null = null;
   private setupTimeout: ReturnType<typeof globalThis.setTimeout> | null = null;
-  private readonly input = new RealtimeTalkInputController(
-    (detail) => {
-      const ws = this.ws;
-      if (ws) {
-        this.failConnection(ws, detail);
-      }
-    },
-    (detail) => this.ctx.callbacks.onStatus?.("connecting", detail),
-  );
+  private readonly input = this.ctx.input;
   private inputContext: AudioContext | null = null;
   private outputContext: AudioContext | null = null;
   private inputMeter: RealtimeTalkMediaStreamMeter | null = null;
@@ -158,7 +150,7 @@ export class GoogleLiveRealtimeTalkTransport implements RealtimeTalkTransport {
   }
 
   async start(): Promise<RealtimeTalkTransportStartResult> {
-    if (!navigator.mediaDevices?.getUserMedia || typeof WebSocket === "undefined") {
+    if (typeof WebSocket === "undefined") {
       throw new Error("Realtime Talk requires browser WebSocket and microphone access");
     }
     if (this.session.protocol !== "google-live-bidi") {
@@ -167,17 +159,12 @@ export class GoogleLiveRealtimeTalkTransport implements RealtimeTalkTransport {
     const wsUrl = buildGoogleLiveUrl(this.session);
     this.closed = false;
     this.cameraPublished = false;
-    try {
-      await this.input.open(this.ctx.inputDeviceId);
-    } catch (error) {
-      if (this.closed) {
-        return "cancelled";
+    this.input.adopt((detail) => {
+      const ws = this.ws;
+      if (ws) {
+        this.failConnection(ws, detail);
       }
-      throw error;
-    }
-    if (this.closed) {
-      return "cancelled";
-    }
+    });
     this.inputContext = new AudioContext({ sampleRate: this.session.audio.inputSampleRateHz });
     this.outputContext = new AudioContext({ sampleRate: this.session.audio.outputSampleRateHz });
     const ws = new WebSocket(wsUrl);

--- a/ui/src/pages/chat/realtime-talk-input.test-support.ts
+++ b/ui/src/pages/chat/realtime-talk-input.test-support.ts
@@ -1,0 +1,25 @@
+import { afterEach, beforeEach, onTestFinished, vi } from "vitest";
+import { RealtimeTalkInputController } from "./realtime-talk-input.ts";
+
+export async function prepareRealtimeTalkTestInput(
+  inputDeviceId?: string,
+): Promise<RealtimeTalkInputController> {
+  const input = new RealtimeTalkInputController(() => undefined);
+  onTestFinished(() => input.stop());
+  await input.open(inputDeviceId);
+  return input;
+}
+
+export function useRealtimeTalkMicrophoneFixture(): void {
+  beforeEach(() => {
+    vi.stubGlobal("navigator", {
+      mediaDevices: {
+        getUserMedia: vi.fn(async () => {
+          const track = Object.assign(new EventTarget(), { stop: vi.fn() });
+          return { getTracks: () => [track], getAudioTracks: () => [track] };
+        }),
+      },
+    });
+  });
+  afterEach(() => vi.unstubAllGlobals());
+}

--- a/ui/src/pages/chat/realtime-talk-input.ts
+++ b/ui/src/pages/chat/realtime-talk-input.ts
@@ -266,12 +266,27 @@ export class RealtimeTalkInputController {
   private media: MediaStream | null = null;
 
   constructor(
-    private readonly onEnded: (detail: string) => void,
+    private onEnded: (detail: string) => void,
     private readonly onConnecting?: (detail?: string) => void,
   ) {}
 
   get stream(): MediaStream | null {
     return this.media;
+  }
+
+  requireStream(): MediaStream {
+    const media = this.media;
+    if (!media) {
+      throw new Error(t("chat.composer.microphoneStopped"));
+    }
+    return media;
+  }
+
+  adopt(onEnded: (detail: string) => void): MediaStream {
+    const media = this.requireStream();
+    // Keep the same stream and listener across the candidate-to-transport handoff.
+    this.onEnded = onEnded;
+    return media;
   }
 
   async open(inputDeviceId: string | undefined): Promise<MediaStream> {

--- a/ui/src/pages/chat/realtime-talk-lifecycle.test.ts
+++ b/ui/src/pages/chat/realtime-talk-lifecycle.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
+import { useRealtimeTalkMicrophoneFixture } from "./realtime-talk-input.test-support.ts";
 import type { RealtimeTalkTransportContext } from "./realtime-talk-shared.ts";
 
 const transportMock = vi.hoisted(() => ({
@@ -61,6 +62,8 @@ function transcriptContext(contexts: RealtimeTalkTransportContext[], index = 0):
   }
   return context as TranscriptContext;
 }
+
+useRealtimeTalkMicrophoneFixture();
 
 describe("RealtimeTalkSession lifecycle", () => {
   beforeEach(() => {

--- a/ui/src/pages/chat/realtime-talk-shared.ts
+++ b/ui/src/pages/chat/realtime-talk-shared.ts
@@ -11,6 +11,7 @@ import type { TalkEvent } from "../../../../src/talk/talk-events.js";
 import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.ts";
 // Control UI chat module implements realtime talk shared behavior.
 import { formatUiError } from "../../lib/format-error.ts";
+import type { RealtimeTalkInputController } from "./realtime-talk-input.ts";
 
 export type RealtimeTalkStatus = "idle" | "connecting" | "listening" | "thinking" | "error";
 export type RealtimeTalkEvent = TalkEvent;
@@ -122,7 +123,7 @@ export type RealtimeTalkTransportContext = {
   voiceSessionId?: string;
   flushTranscriptWrites?: () => Promise<void>;
   callbacks: RealtimeTalkCallbacks;
-  inputDeviceId?: string;
+  input: Pick<RealtimeTalkInputController, "stream" | "adopt" | "stop">;
   videoDeviceId?: string;
   consultThinkingLevel?: string;
   consultFastMode?: boolean;

--- a/ui/src/pages/chat/realtime-talk-startup-input.test.ts
+++ b/ui/src/pages/chat/realtime-talk-startup-input.test.ts
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import type { RealtimeTalkTransportContext } from "./realtime-talk-shared.ts";
+
+const transports = vi.hoisted(
+  () =>
+    [] as Array<{
+      context: RealtimeTalkTransportContext;
+      stop: ReturnType<typeof vi.fn>;
+    }>,
+);
+
+function transportFixture(context: RealtimeTalkTransportContext) {
+  const stop = vi.fn(() => context.input.stop());
+  transports.push({ context, stop });
+  return { start: async () => "ready" as const, stop };
+}
+
+vi.mock("./realtime-talk-webrtc.ts", () => ({
+  WebRtcSdpRealtimeTalkTransport: vi.fn(function (
+    _session: unknown,
+    context: RealtimeTalkTransportContext,
+  ) {
+    return transportFixture(context);
+  }),
+}));
+vi.mock("./realtime-talk-google-live.ts", () => ({
+  GoogleLiveRealtimeTalkTransport: vi.fn(function (
+    _session: unknown,
+    context: RealtimeTalkTransportContext,
+  ) {
+    return transportFixture(context);
+  }),
+}));
+vi.mock("./realtime-talk-gateway-relay.ts", () => ({
+  GatewayRelayRealtimeTalkTransport: vi.fn(function (
+    _session: unknown,
+    context: RealtimeTalkTransportContext,
+  ) {
+    return transportFixture(context);
+  }),
+}));
+
+import { RealtimeTalkSession } from "./realtime-talk.ts";
+
+function microphone() {
+  const track = Object.assign(new EventTarget(), { stop: vi.fn() });
+  const stream = {
+    getTracks: () => [track],
+    getAudioTracks: () => [track],
+  } as unknown as MediaStream;
+  return { track, stream };
+}
+
+const sessions: RealtimeTalkSession[] = [];
+function sessionFor(
+  request: ReturnType<typeof vi.fn>,
+  transport: "webrtc" | "provider-websocket" | "gateway-relay" = "webrtc",
+) {
+  const session = new RealtimeTalkSession(
+    { request } as never,
+    "agent:main:main",
+    {},
+    { transport },
+    { inputDeviceId: "selected-microphone" },
+  );
+  sessions.push(session);
+  return session;
+}
+
+function clientSession(transport: "webrtc" | "provider-websocket" | "gateway-relay" = "webrtc") {
+  return {
+    provider: "fixture",
+    transport,
+    voiceSessionId: "voice-input",
+    relaySessionId: "voice-input",
+    clientSecret: "fixture-secret",
+    expiresAt: Date.now() + 60_000,
+  };
+}
+
+beforeEach(() => {
+  transports.length = 0;
+});
+afterEach(() => {
+  for (const session of sessions.splice(0)) {
+    session.stop();
+  }
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("Realtime Talk microphone preparation", () => {
+  it.each(["webrtc", "provider-websocket", "gateway-relay"] as const)(
+    "allocates %s only after permission is granted, even after the activation lifetime",
+    async (transport) => {
+      vi.useFakeTimers();
+      const permission = createDeferred<MediaStream>();
+      const media = microphone();
+      const getUserMedia = vi.fn(() => permission.promise);
+      vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+      const request = vi.fn(async (method: string) => {
+        if (method === "talk.client.create" && transport === "gateway-relay") {
+          throw new Error("Use relay session creation");
+        }
+        return clientSession(transport);
+      });
+      const session = sessionFor(request, transport);
+      const starting = session.start();
+      void starting.catch(() => undefined);
+      await vi.advanceTimersByTimeAsync(65_000);
+      expect(request).not.toHaveBeenCalled();
+      expect(getUserMedia).toHaveBeenCalledOnce();
+      permission.resolve(media.stream);
+      await starting;
+      expect(request.mock.calls.map(([method]) => method)).toEqual(
+        transport === "gateway-relay"
+          ? ["talk.client.create", "talk.session.create"]
+          : ["talk.client.create"],
+      );
+      expect(getUserMedia).toHaveBeenCalledOnce();
+      expect(getUserMedia).toHaveBeenCalledWith({
+        audio: {
+          autoGainControl: true,
+          echoCancellation: true,
+          noiseSuppression: true,
+          deviceId: { exact: "selected-microphone" },
+        },
+      });
+      expect(transports[0]?.context.input.stream).toBe(media.stream);
+      session.stop();
+      expect(media.track.stop).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("allocates no provider session when microphone permission is denied", async () => {
+    vi.stubGlobal("navigator", {
+      mediaDevices: {
+        getUserMedia: vi.fn(async () => {
+          throw new DOMException("Denied", "NotAllowedError");
+        }),
+      },
+    });
+    const request = vi.fn(async () => clientSession());
+    await expect(sessionFor(request).start()).rejects.toThrow();
+    expect(request).not.toHaveBeenCalled();
+    expect(transports).toHaveLength(0);
+  });
+
+  it("cancels pending permission without allocating and releases a late stream", async () => {
+    const permission = createDeferred<MediaStream>();
+    const media = microphone();
+    const getUserMedia = vi.fn(() => permission.promise);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+    const request = vi.fn(async () => clientSession());
+    const session = sessionFor(request);
+    const starting = session.start();
+    void starting.catch(() => undefined);
+    await waitForFast(() => expect(getUserMedia).toHaveBeenCalledOnce());
+    session.stop();
+    await expect(starting).resolves.toBeUndefined();
+    permission.resolve(media.stream);
+    await waitForFast(() => expect(media.track.stop).toHaveBeenCalledOnce());
+    expect(request).not.toHaveBeenCalled();
+    expect(transports).toHaveLength(0);
+  });
+
+  it("releases prepared microphone ownership when provider creation fails", async () => {
+    const media = microphone();
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia: vi.fn(async () => media.stream) } });
+    const request = vi.fn(async () => {
+      throw new Error("Provider allocation failed");
+    });
+    await expect(sessionFor(request).start()).rejects.toThrow("Provider allocation failed");
+    expect(media.track.stop).toHaveBeenCalledOnce();
+    expect(transports).toHaveLength(0);
+  });
+
+  it.each([false, true])(
+    "rejects microphone loss during allocation without retiring its predecessor (replacement=%s)",
+    async (replacement) => {
+      const previous = microphone();
+      const candidate = microphone();
+      const allocation = createDeferred<ReturnType<typeof clientSession>>();
+      const getUserMedia = vi
+        .fn()
+        .mockResolvedValueOnce(replacement ? previous.stream : candidate.stream)
+        .mockResolvedValueOnce(candidate.stream);
+      vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+      let creates = 0;
+      const request = vi.fn(async (method: string) => {
+        if (method !== "talk.client.create") {
+          return { ok: true };
+        }
+        creates++;
+        return replacement && creates === 1 ? clientSession() : await allocation.promise;
+      });
+      const session = sessionFor(request);
+      if (replacement) {
+        await session.start();
+      }
+      const starting = session.start();
+      void starting.catch(() => undefined);
+      await waitForFast(() => expect(creates).toBe(replacement ? 2 : 1));
+      candidate.track.dispatchEvent(new Event("ended"));
+      allocation.resolve(clientSession());
+      await expect(starting).rejects.toThrow("Microphone");
+      expect(candidate.track.stop).toHaveBeenCalledOnce();
+      expect(transports).toHaveLength(replacement ? 1 : 0);
+      if (replacement) {
+        expect(previous.track.stop).not.toHaveBeenCalled();
+        expect(transports[0]?.stop).not.toHaveBeenCalled();
+      } else {
+        await waitForFast(() =>
+          expect(request.mock.calls.some(([method]) => method === "talk.client.close")).toBe(true),
+        );
+      }
+    },
+  );
+});

--- a/ui/src/pages/chat/realtime-talk-transcript-queue.test.ts
+++ b/ui/src/pages/chat/realtime-talk-transcript-queue.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useRealtimeTalkMicrophoneFixture } from "./realtime-talk-input.test-support.ts";
 import type { RealtimeTalkTransportContext } from "./realtime-talk-shared.ts";
 
 const transportMock = vi.hoisted(() => ({
@@ -25,6 +26,8 @@ vi.mock("./realtime-talk-webrtc.ts", () => ({
 }));
 
 import { RealtimeTalkSession } from "./realtime-talk.ts";
+
+useRealtimeTalkMicrophoneFixture();
 
 describe("RealtimeTalkSession transcript queue", () => {
   beforeEach(() => {

--- a/ui/src/pages/chat/realtime-talk-transport.ts
+++ b/ui/src/pages/chat/realtime-talk-transport.ts
@@ -1,0 +1,40 @@
+import { normalizeTalkTransport } from "../../../../src/talk/talk-session-controller.js";
+import { GatewayRelayRealtimeTalkTransport } from "./realtime-talk-gateway-relay.ts";
+import { GoogleLiveRealtimeTalkTransport } from "./realtime-talk-google-live.ts";
+import type {
+  RealtimeTalkGatewayRelaySessionResult,
+  RealtimeTalkJsonPcmWebSocketSessionResult,
+  RealtimeTalkSessionResult,
+  RealtimeTalkTransport,
+  RealtimeTalkTransportContext,
+  RealtimeTalkWebRtcSdpSessionResult,
+} from "./realtime-talk-shared.ts";
+import { WebRtcSdpRealtimeTalkTransport } from "./realtime-talk-webrtc.ts";
+
+export function createRealtimeTalkTransport(
+  session: RealtimeTalkSessionResult,
+  ctx: RealtimeTalkTransportContext,
+): RealtimeTalkTransport {
+  const transport = resolveRealtimeTalkTransport(session);
+  if (transport === "webrtc") {
+    return new WebRtcSdpRealtimeTalkTransport(session as RealtimeTalkWebRtcSdpSessionResult, ctx);
+  }
+  if (transport === "provider-websocket") {
+    return new GoogleLiveRealtimeTalkTransport(
+      session as RealtimeTalkJsonPcmWebSocketSessionResult,
+      ctx,
+    );
+  }
+  if (transport === "gateway-relay") {
+    return new GatewayRelayRealtimeTalkTransport(
+      session as RealtimeTalkGatewayRelaySessionResult,
+      ctx,
+    );
+  }
+  const unknownTransport = (session as { transport?: string }).transport ?? "unknown";
+  throw new Error(`Unsupported realtime Talk transport: ${unknownTransport}`);
+}
+
+export function resolveRealtimeTalkTransport(session: RealtimeTalkSessionResult): string {
+  return normalizeTalkTransport((session as { transport?: string }).transport) ?? "webrtc";
+}

--- a/ui/src/pages/chat/realtime-talk-transport.ts
+++ b/ui/src/pages/chat/realtime-talk-transport.ts
@@ -17,24 +17,27 @@ export function createRealtimeTalkTransport(
 ): RealtimeTalkTransport {
   const transport = resolveRealtimeTalkTransport(session);
   if (transport === "webrtc") {
+    // SAFETY: The normalized transport selects the Gateway's WebRTC session payload.
     return new WebRtcSdpRealtimeTalkTransport(session as RealtimeTalkWebRtcSdpSessionResult, ctx);
   }
   if (transport === "provider-websocket") {
     return new GoogleLiveRealtimeTalkTransport(
+      // SAFETY: The normalized transport selects the Gateway's provider-WebSocket payload.
       session as RealtimeTalkJsonPcmWebSocketSessionResult,
       ctx,
     );
   }
   if (transport === "gateway-relay") {
     return new GatewayRelayRealtimeTalkTransport(
+      // SAFETY: The normalized transport selects the Gateway's relay session payload.
       session as RealtimeTalkGatewayRelaySessionResult,
       ctx,
     );
   }
-  const unknownTransport = (session as { transport?: string }).transport ?? "unknown";
+  const unknownTransport = session.transport ?? "unknown";
   throw new Error(`Unsupported realtime Talk transport: ${unknownTransport}`);
 }
 
 export function resolveRealtimeTalkTransport(session: RealtimeTalkSessionResult): string {
-  return normalizeTalkTransport((session as { transport?: string }).transport) ?? "webrtc";
+  return normalizeTalkTransport(session.transport) ?? "webrtc";
 }

--- a/ui/src/pages/chat/realtime-talk-webrtc-control.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc-control.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME } from "../../../../src/talk/describe-view-tool.js";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
+import { prepareRealtimeTalkTestInput } from "./realtime-talk-input.test-support.ts";
 import {
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
   REALTIME_VOICE_AGENT_CONTROL_TOOL_NAME,
@@ -51,10 +52,10 @@ class FakePeerConnection extends EventTarget {
   }
 }
 
-function createOpenAiTransport(
+async function createOpenAiTransport(
   client: Record<string, unknown>,
   callbacks: Record<string, unknown> = {},
-): WebRtcSdpRealtimeTalkTransport {
+): Promise<WebRtcSdpRealtimeTalkTransport> {
   return new WebRtcSdpRealtimeTalkTransport(
     {
       provider: "openai",
@@ -62,6 +63,7 @@ function createOpenAiTransport(
       clientSecret: "client-secret-123",
     },
     {
+      input: await prepareRealtimeTalkTestInput(),
       client: client as never,
       sessionKey: "main",
       callbacks: callbacks as never,
@@ -168,7 +170,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
       }
       throw new Error(`unexpected request: ${method}`);
     });
-    const transport = createOpenAiTransport({
+    const transport = await createOpenAiTransport({
       addEventListener: vi.fn(() => () => undefined),
       request,
     });
@@ -204,7 +206,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
       }
       throw new Error(`unexpected request: ${method}`);
     });
-    const transport = createOpenAiTransport({
+    const transport = await createOpenAiTransport({
       addEventListener: vi.fn(() => () => undefined),
       request,
     });
@@ -267,7 +269,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
     { label: "incomplete item", responseStatus: "completed", itemStatus: "incomplete" },
   ])("ignores function calls from a $label", async ({ responseStatus, itemStatus }) => {
     const request = vi.fn();
-    const transport = createOpenAiTransport({ request });
+    const transport = await createOpenAiTransport({ request });
 
     await transport.start();
     dispatchCompletedToolCall(FakePeerConnection.instances[0], {
@@ -289,7 +291,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
       }
       throw new Error(`unexpected request: ${method}`);
     });
-    const transport = createOpenAiTransport({ request });
+    const transport = await createOpenAiTransport({ request });
 
     await transport.start();
     dispatchCompletedToolCall(FakePeerConnection.instances[0], {
@@ -309,7 +311,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
 
   it("requires call, name, and arguments before executing tools", async () => {
     const request = vi.fn();
-    const transport = createOpenAiTransport({ request });
+    const transport = await createOpenAiTransport({ request });
 
     await transport.start();
     const peer = FakePeerConnection.instances[0];
@@ -336,7 +338,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
       throw new Error(`unexpected request: ${method}`);
     });
     const onTalkEvent = vi.fn();
-    const transport = createOpenAiTransport({ request }, { onTalkEvent });
+    const transport = await createOpenAiTransport({ request }, { onTalkEvent });
     const baseArgs = JSON.stringify({ text: "status" });
     const argumentsAtLimit = baseArgs + " ".repeat(256_000 - baseArgs.length);
     const oversizedArguments = JSON.stringify({ text: "é".repeat(128_000) });
@@ -384,7 +386,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
 
   it("ends the session instead of evicting completed call identities", async () => {
     const onStatus = vi.fn();
-    const transport = createOpenAiTransport({}, { onStatus });
+    const transport = await createOpenAiTransport({}, { onStatus });
 
     await transport.start();
     const peer = FakePeerConnection.instances[0];
@@ -432,7 +434,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
       }
       throw new Error(`unexpected request: ${method}`);
     });
-    const transport = createOpenAiTransport({ request }, { onStatus, onTalkEvent });
+    const transport = await createOpenAiTransport({ request }, { onStatus, onTalkEvent });
 
     await transport.start();
     const peer = FakePeerConnection.instances[0];
@@ -458,7 +460,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
 
   it("silently disposes a provisional OpenAI transport", async () => {
     const onTalkEvent = vi.fn();
-    const transport = createOpenAiTransport({}, { onTalkEvent });
+    const transport = await createOpenAiTransport({}, { onTalkEvent });
     await transport.start();
     onTalkEvent.mockClear();
 
@@ -473,7 +475,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
     const onTalkEvent = vi.fn();
     const transportRef: { current?: WebRtcSdpRealtimeTalkTransport } = {};
     const onTranscript = vi.fn(() => transportRef.current?.stop());
-    const transport = createOpenAiTransport({}, { onStatus, onTalkEvent, onTranscript });
+    const transport = await createOpenAiTransport({}, { onStatus, onTalkEvent, onTranscript });
     transportRef.current = transport;
     await transport.start();
     onStatus.mockClear();

--- a/ui/src/pages/chat/realtime-talk-webrtc-video.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc-video.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME } from "../../../../src/talk/describe-view-tool.js";
+import { prepareRealtimeTalkTestInput } from "./realtime-talk-input.test-support.ts";
 import { WebRtcSdpRealtimeTalkTransport } from "./realtime-talk-webrtc.ts";
 
 class FakeDataChannel extends EventTarget {
@@ -104,7 +105,12 @@ describe("OpenAI Realtime media lifecycle", () => {
     const onStatus = vi.fn();
     const transport = new WebRtcSdpRealtimeTalkTransport(
       { provider: "openai", transport: "webrtc", clientSecret: "test-client-secret" },
-      { client: {} as never, sessionKey: "main", callbacks: { onStatus } },
+      {
+        input: await prepareRealtimeTalkTestInput(),
+        client: {} as never,
+        sessionKey: "main",
+        callbacks: { onStatus },
+      },
     );
     try {
       await transport.start();
@@ -117,40 +123,6 @@ describe("OpenAI Realtime media lifecycle", () => {
       expect(document.querySelector("audio")).toBeNull();
     } finally {
       transport.stop();
-    }
-  });
-
-  it("explains pending microphone access and advances to connection setup after acquisition", async () => {
-    const track = Object.assign(new EventTarget(), { stop: vi.fn() });
-    let resolveMedia: (stream: MediaStream) => void = () => undefined;
-    const getUserMedia = vi.fn(
-      () =>
-        new Promise<MediaStream>((resolve) => {
-          resolveMedia = resolve;
-        }),
-    );
-    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
-    const onStatus = vi.fn();
-    const transport = new WebRtcSdpRealtimeTalkTransport(
-      { provider: "openai", transport: "webrtc", clientSecret: "test-client-secret" },
-      { client: {} as never, sessionKey: "main", callbacks: { onStatus } },
-    );
-    const starting = transport.start();
-    try {
-      expect(onStatus).toHaveBeenLastCalledWith(
-        "connecting",
-        "Waiting for microphone access. Bring this tab to the foreground and allow access if prompted.",
-      );
-      expect(fetch).not.toHaveBeenCalled();
-      resolveMedia({
-        getTracks: () => [track],
-        getAudioTracks: () => [track],
-      } as unknown as MediaStream);
-      await expect(starting).resolves.toBe("ready");
-      expect(onStatus).toHaveBeenLastCalledWith("connecting", undefined);
-    } finally {
-      transport.stop();
-      await starting;
     }
   });
 
@@ -206,6 +178,7 @@ describe("OpenAI Realtime media lifecycle", () => {
         clientSecret: "test-client-secret",
       },
       {
+        input: await prepareRealtimeTalkTestInput(),
         client: {} as never,
         sessionKey: "main",
         callbacks: { onStatus, onTalkEvent, onVideoStream },
@@ -324,6 +297,7 @@ describe("OpenAI Realtime media lifecycle", () => {
     const transport = new WebRtcSdpRealtimeTalkTransport(
       { provider: "openai", transport: "webrtc", clientSecret: "test-client-secret" },
       {
+        input: await prepareRealtimeTalkTestInput(),
         client: {} as never,
         sessionKey: "main",
         callbacks: { onVideoStream },
@@ -361,6 +335,7 @@ describe("OpenAI Realtime media lifecycle", () => {
     const transport = new WebRtcSdpRealtimeTalkTransport(
       { provider: "openai", transport: "webrtc", clientSecret: "test-client-secret" },
       {
+        input: await prepareRealtimeTalkTestInput(),
         client: {} as never,
         sessionKey: "main",
         callbacks: { onStatus, onVideoStream },
@@ -401,6 +376,7 @@ describe("OpenAI Realtime media lifecycle", () => {
         clientSecret: "test-client-secret",
       },
       {
+        input: await prepareRealtimeTalkTestInput(),
         client: {} as never,
         sessionKey: "main",
         callbacks: {},
@@ -454,6 +430,7 @@ describe("OpenAI Realtime media lifecycle", () => {
     vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
     const onVideoStream = vi.fn();
     const context = {
+      input: await prepareRealtimeTalkTestInput(),
       client: {} as never,
       sessionKey: "main",
       callbacks: { onVideoStream },
@@ -516,6 +493,7 @@ describe("OpenAI Realtime media lifecycle", () => {
     vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
     const onVideoStream = vi.fn();
     const context = {
+      input: await prepareRealtimeTalkTestInput(),
       client: {} as never,
       sessionKey: "main",
       callbacks: { onVideoStream },

--- a/ui/src/pages/chat/realtime-talk-webrtc.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
+import { prepareRealtimeTalkTestInput } from "./realtime-talk-input.test-support.ts";
 import { REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME } from "./realtime-talk-shared.ts";
 import { WebRtcSdpRealtimeTalkTransport } from "./realtime-talk-webrtc.ts";
 
@@ -103,11 +104,11 @@ function createPendingSdpResponse(signal: AbortSignal | undefined): Response {
   );
 }
 
-function createOpenAiTransport(
+async function createOpenAiTransport(
   client: Record<string, unknown> = {},
   callbacks: Record<string, unknown> = {},
   inputDeviceId?: string,
-): WebRtcSdpRealtimeTalkTransport {
+): Promise<WebRtcSdpRealtimeTalkTransport> {
   return new WebRtcSdpRealtimeTalkTransport(
     {
       provider: "openai",
@@ -116,10 +117,10 @@ function createOpenAiTransport(
       offerResponseMaxBytes: 256 * 1024,
     },
     {
+      input: await prepareRealtimeTalkTestInput(inputDeviceId),
       client: client as never,
       sessionKey: "main",
       callbacks: callbacks as never,
-      inputDeviceId,
     },
   );
 }
@@ -164,7 +165,7 @@ async function startActiveConsult(
   request: ReturnType<typeof vi.fn>,
   options: { responseAlreadyActive?: boolean } = {},
 ): Promise<{ transport: WebRtcSdpRealtimeTalkTransport; peer: FakePeerConnection | undefined }> {
-  const transport = createOpenAiTransport({
+  const transport = await createOpenAiTransport({
     addEventListener: vi.fn(() => () => undefined),
     request,
   });
@@ -208,6 +209,7 @@ function expectSpokenStatusMessage(events: SentRealtimeEvent[], message: string)
 
 describe("WebRtcSdpRealtimeTalkTransport", () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
     vi.useRealTimers();
   });
@@ -251,7 +253,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     }
     vi.stubGlobal("AudioContext", MockAudioContext);
     const onInputLevel = vi.fn();
-    const transport = createOpenAiTransport({}, { onInputLevel });
+    const transport = await createOpenAiTransport({}, { onInputLevel });
 
     await transport.start();
     transport.stop();
@@ -285,7 +287,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
         transport.stop();
       }
     });
-    const transport = createOpenAiTransport({}, { onInputLevel });
+    const transport = await createOpenAiTransport({}, { onInputLevel });
 
     await expect(transport.start()).resolves.toBe("cancelled");
     transport.stop();
@@ -297,56 +299,19 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     expect(close).toHaveBeenCalledOnce();
   });
 
-  it("does not continue WebRTC setup when stopped while microphone access is pending", async () => {
-    const fetchMock = vi.fn(async () => new Response("answer-sdp"));
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-    const stopTrack = vi.fn();
-    const track = Object.assign(new EventTarget(), {
-      stop: stopTrack,
-    }) as unknown as MediaStreamTrack;
-    const stream = {
-      getAudioTracks: () => [track],
-      getTracks: () => [track],
-    } as unknown as MediaStream;
-    let resolveMedia: (stream: MediaStream) => void = () => undefined;
-    Object.defineProperty(globalThis.navigator, "mediaDevices", {
-      configurable: true,
-      value: {
-        getUserMedia: vi.fn(
-          () =>
-            new Promise<MediaStream>((resolve) => {
-              resolveMedia = resolve;
-            }),
-        ),
-      },
-    });
-    const transport = createOpenAiTransport();
-
-    const startPromise = transport.start();
-    const peer = FakePeerConnection.instances[0];
-    transport.stop();
-    resolveMedia(stream);
-
-    await expect(startPromise).resolves.toBe("cancelled");
-    expect(peer?.addTrack).not.toHaveBeenCalled();
-    expect(stopTrack).toHaveBeenCalledTimes(1);
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
   it("suppresses pending setup errors after stop", async () => {
     const fetchMock = vi.fn(async () => new Response("answer-sdp"));
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
     let rejectOffer: (error: Error) => void = () => undefined;
-    const transport = createOpenAiTransport();
+    const transport = await createOpenAiTransport();
 
-    const startPromise = transport.start();
-    const peer = requirePeer();
-    const createOfferSpy = vi.spyOn(peer, "createOffer").mockImplementation(
+    const createOfferSpy = vi.spyOn(FakePeerConnection.prototype, "createOffer").mockImplementation(
       () =>
         new Promise<RTCSessionDescriptionInit>((_, reject) => {
           rejectOffer = reject;
         }),
     );
+    const startPromise = transport.start();
     await waitForFast(() => expect(createOfferSpy).toHaveBeenCalled());
     transport.stop();
     rejectOffer(new Error("closed peer rejected offer creation"));
@@ -370,6 +335,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
         },
       },
       {
+        input: await prepareRealtimeTalkTestInput(),
         client: {} as never,
         sessionKey: "main",
         callbacks: {},
@@ -402,7 +368,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
       return response;
     });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-    const transport = createOpenAiTransport();
+    const transport = await createOpenAiTransport();
 
     const startResult = transport.start().then(
       () => undefined,
@@ -431,7 +397,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
       return response;
     });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-    const transport = createOpenAiTransport();
+    const transport = await createOpenAiTransport();
 
     const startResult = transport.start();
     await waitForFast(() => expect(fetchMock).toHaveBeenCalledTimes(1));
@@ -448,7 +414,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     stubAnswerSdpFetch();
     const onStatus = vi.fn();
     const onTalkEvent = vi.fn();
-    const transport = createOpenAiTransport({}, { onStatus, onTalkEvent });
+    const transport = await createOpenAiTransport({}, { onStatus, onTalkEvent });
     const start = transport.start();
     const peer = requirePeer();
     let finishRemoteDescription: (() => void) | undefined;
@@ -474,7 +440,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
   it("releases an active peer when the terminal status callback throws", async () => {
     stubAnswerSdpFetch();
     const onStatus = vi.fn();
-    const transport = createOpenAiTransport({}, { onStatus });
+    const transport = await createOpenAiTransport({}, { onStatus });
     await expect(transport.start()).resolves.toBe("ready");
     onStatus.mockImplementation(() => {
       throw new Error("consumer failed");
@@ -494,7 +460,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     const onTalkEvent = vi.fn(() => {
       throw new Error("consumer failed");
     });
-    const transport = createOpenAiTransport({}, { onTalkEvent });
+    const transport = await createOpenAiTransport({}, { onTalkEvent });
     await expect(transport.start()).resolves.toBe("ready");
     const peer = requirePeer();
 
@@ -514,7 +480,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
         return new Response("answer-sdp");
       }) as unknown as typeof fetch,
     );
-    const transport = createOpenAiTransport();
+    const transport = await createOpenAiTransport();
 
     await transport.start();
     await vi.runAllTimersAsync();
@@ -536,6 +502,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
         clientSecret: "client-secret-123",
       },
       {
+        input: await prepareRealtimeTalkTestInput(),
         client: {} as never,
         sessionKey: "main",
         callbacks: { onStatus },
@@ -571,6 +538,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
         clientSecret: "client-secret-123",
       },
       {
+        input: await prepareRealtimeTalkTestInput(),
         client: {} as never,
         sessionKey: "main",
         callbacks: { onStatus, onTalkEvent },
@@ -613,7 +581,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     stubAnswerSdpFetch();
     const onStatus = vi.fn();
     const onTalkEvent = vi.fn();
-    const transport = createOpenAiTransport({}, { onStatus, onTalkEvent });
+    const transport = await createOpenAiTransport({}, { onStatus, onTalkEvent });
     await transport.start();
     const peer = FakePeerConnection.instances[0];
     const response = {
@@ -662,6 +630,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
         clientSecret: "client-secret-123",
       },
       {
+        input: await prepareRealtimeTalkTestInput(),
         client: {} as never,
         sessionKey: "main",
         callbacks: { onTranscript, onTalkEvent },
@@ -717,7 +686,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     stubAnswerSdpFetch();
     const onTalkEvent = vi.fn();
     const onTranscript = vi.fn(() => transport.stop());
-    const transport = createOpenAiTransport({}, { onTranscript, onTalkEvent });
+    const transport = await createOpenAiTransport({}, { onTranscript, onTalkEvent });
 
     await transport.start();
     dispatchTranscription(FakePeerConnection.instances[0], "overflow");
@@ -739,6 +708,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
         clientSecret: "client-secret-123",
       },
       {
+        input: await prepareRealtimeTalkTestInput(),
         client: {} as never,
         sessionKey: "main",
         callbacks: { onTalkEvent },
@@ -803,6 +773,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
           clientSecret: "client-secret-123",
         },
         {
+          input: await prepareRealtimeTalkTestInput(),
           client: {} as never,
           sessionKey: "main",
           callbacks: { onTranscript, onTalkEvent },
@@ -867,6 +838,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
         clientSecret: "client-secret-123",
       },
       {
+        input: await prepareRealtimeTalkTestInput(),
         client: {
           addEventListener: vi.fn(
             (listener: (event: { event: string; payload?: unknown }) => void) => {
@@ -1069,6 +1041,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
         clientSecret: "client-secret-123",
       },
       {
+        input: await prepareRealtimeTalkTestInput(),
         client: {
           addEventListener: vi.fn(() => () => undefined),
           request,

--- a/ui/src/pages/chat/realtime-talk-webrtc.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.ts
@@ -4,7 +4,7 @@ import { REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME } from "../../../../src/talk/des
 import { formatUiError } from "../../lib/format-error.ts";
 import { RealtimeTalkMediaStreamMeter } from "./realtime-talk-audio.ts";
 import { RealtimeTalkCameraController } from "./realtime-talk-camera-controller.ts";
-import { openRealtimeTalkCamera, RealtimeTalkInputController } from "./realtime-talk-input.ts";
+import { openRealtimeTalkCamera } from "./realtime-talk-input.ts";
 import {
   type RealtimeTalkWebRtcSdpSessionResult,
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
@@ -44,10 +44,7 @@ const cancelledSetup = Symbol("cancelledSetup");
 export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
   private peer: RTCPeerConnection | null = null;
   private channel: RTCDataChannel | null = null;
-  private readonly input = new RealtimeTalkInputController(
-    (detail) => this.failConnection(detail),
-    (detail) => this.ctx.callbacks.onStatus?.("connecting", detail),
-  );
+  private readonly input = this.ctx.input;
   private audio: HTMLAudioElement | null = null;
   private inputMeter: RealtimeTalkMediaStreamMeter | null = null;
   private closed = false;
@@ -80,7 +77,7 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
   }
 
   async start(): Promise<RealtimeTalkTransportStartResult> {
-    if (!navigator.mediaDevices?.getUserMedia || typeof RTCPeerConnection === "undefined") {
+    if (typeof RTCPeerConnection === "undefined") {
       throw new Error("Realtime Talk requires browser WebRTC and microphone access");
     }
     this.closed = false;
@@ -118,10 +115,7 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
         event.track.addEventListener("unmute", () => play(true), { once: true });
       }
     });
-    const media = await this.awaitSetupStep(peer, this.input.open(this.ctx.inputDeviceId));
-    if (media === cancelledSetup || !this.isCurrentPeer(peer)) {
-      return this.cancelledStart();
-    }
+    const media = this.input.adopt((detail) => this.failConnection(detail));
     if (this.ctx.callbacks.onInputLevel) {
       this.inputMeter = new RealtimeTalkMediaStreamMeter(this.ctx.callbacks.onInputLevel);
       this.inputMeter.start(media);

--- a/ui/src/pages/chat/realtime-talk.test.ts
+++ b/ui/src/pages/chat/realtime-talk.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import * as gatewayRelayTransport from "./realtime-talk-gateway-relay.ts";
 import * as googleLiveTransport from "./realtime-talk-google-live.ts";
+import { useRealtimeTalkMicrophoneFixture } from "./realtime-talk-input.test-support.ts";
 import { createRealtimeTalkEventEmitter } from "./realtime-talk-shared.ts";
 import type {
   RealtimeTalkTransport,
@@ -49,6 +50,8 @@ function transportContext(transport: object | undefined): RealtimeTalkTransportC
   }
   return (transport as { ctx: RealtimeTalkTransportContext }).ctx;
 }
+
+useRealtimeTalkMicrophoneFixture();
 
 describe("RealtimeTalkSession", () => {
   beforeEach(() => {
@@ -565,7 +568,7 @@ describe("RealtimeTalkSession", () => {
       requestTimeoutOptions,
     );
     expect(transportContext(webRtcInstances[0])).toEqual(
-      expect.objectContaining({ inputDeviceId: "usb-mic", videoDeviceId: "desk-camera" }),
+      expect.objectContaining({ videoDeviceId: "desk-camera" }),
     );
   });
 

--- a/ui/src/pages/chat/realtime-talk.ts
+++ b/ui/src/pages/chat/realtime-talk.ts
@@ -9,17 +9,13 @@ import {
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { t } from "../../i18n/index.ts";
 import { formatUiError } from "../../lib/format-error.ts";
-import { GatewayRelayRealtimeTalkTransport } from "./realtime-talk-gateway-relay.ts";
-import { GoogleLiveRealtimeTalkTransport } from "./realtime-talk-google-live.ts";
+import { RealtimeTalkInputController } from "./realtime-talk-input.ts";
 import type {
   RealtimeTalkCallbacks,
   RealtimeTalkGatewayRelaySessionResult,
-  RealtimeTalkJsonPcmWebSocketSessionResult,
   RealtimeTalkSessionResult,
   RealtimeTalkStatus,
   RealtimeTalkTransport,
-  RealtimeTalkTransportContext,
-  RealtimeTalkWebRtcSdpSessionResult,
 } from "./realtime-talk-shared.ts";
 import {
   type ClientVoiceSessionOwner,
@@ -28,7 +24,10 @@ import {
   retireUncommittedRealtimeTalkTransport,
   retryVoiceTranscriptPersistence,
 } from "./realtime-talk-transcript-owner.ts";
-import { WebRtcSdpRealtimeTalkTransport } from "./realtime-talk-webrtc.ts";
+import {
+  createRealtimeTalkTransport,
+  resolveRealtimeTalkTransport,
+} from "./realtime-talk-transport.ts";
 
 export type { RealtimeTalkStatus };
 
@@ -98,34 +97,6 @@ function normalizeLaunchTransport(value: unknown): RealtimeTalkLaunchTransport |
   return undefined;
 }
 
-function createTransport(
-  session: RealtimeTalkSessionResult,
-  ctx: RealtimeTalkTransportContext,
-): RealtimeTalkTransport {
-  const transport = resolveTransport(session);
-  if (transport === "webrtc") {
-    return new WebRtcSdpRealtimeTalkTransport(session as RealtimeTalkWebRtcSdpSessionResult, ctx);
-  }
-  if (transport === "provider-websocket") {
-    return new GoogleLiveRealtimeTalkTransport(
-      session as RealtimeTalkJsonPcmWebSocketSessionResult,
-      ctx,
-    );
-  }
-  if (transport === "gateway-relay") {
-    return new GatewayRelayRealtimeTalkTransport(
-      session as RealtimeTalkGatewayRelaySessionResult,
-      ctx,
-    );
-  }
-  const unknownTransport = (session as { transport?: string }).transport ?? "unknown";
-  throw new Error(`Unsupported realtime Talk transport: ${unknownTransport}`);
-}
-
-function resolveTransport(session: RealtimeTalkSessionResult): string {
-  return normalizeTalkTransport((session as { transport?: string }).transport) ?? "webrtc";
-}
-
 function compactLaunchParams(
   params: RealtimeTalkLaunchOptions & {
     sessionKey: string;
@@ -139,7 +110,7 @@ function compactLaunchParams(
 
 export class RealtimeTalkSession {
   private transport: RealtimeTalkTransport | null = null;
-  private pendingTransport: RealtimeTalkTransport | null = null;
+  private pendingStartup: Pick<RealtimeTalkTransport, "stop"> | null = null;
   private closed = false;
   private lifecycleGeneration = 0;
   private videoEnabled = false;
@@ -163,9 +134,10 @@ export class RealtimeTalkSession {
   async start(): Promise<void> {
     const owner = reserveClientVoiceSessionOwner(this.client, this.sessionKey);
     let ownerTransferred = false;
+    let input: RealtimeTalkInputController | undefined;
     try {
       const lifecycleGeneration = ++this.lifecycleGeneration;
-      this.stopPendingTransport();
+      this.stopPendingStartup();
       this.closed = false;
       this.callbacks.onStatus?.("connecting", t("chat.voice.preparing"));
       const existingTransport = this.transport;
@@ -178,6 +150,25 @@ export class RealtimeTalkSession {
       if (this.closed || lifecycleGeneration !== this.lifecycleGeneration) {
         return;
       }
+      input = new RealtimeTalkInputController(
+        () => undefined,
+        (detail) => this.callbacks.onStatus?.("connecting", detail),
+      );
+      this.pendingStartup = input;
+      try {
+        // Browser permission can wait indefinitely; do not spend a provider's
+        // short activation window until the candidate owns its microphone.
+        await input.open(this.localOptions.inputDeviceId);
+      } catch (error) {
+        if (this.closed || lifecycleGeneration !== this.lifecycleGeneration) {
+          return;
+        }
+        throw error;
+      }
+      if (this.closed || lifecycleGeneration !== this.lifecycleGeneration) {
+        return;
+      }
+      input.requireStream();
       // Declaring voice-transcript arms the server-side spoken-confirmation gate;
       // this client reports every finalized utterance, so the gate is completable.
       const capabilities: Array<"camera-frame" | "voice-transcript"> = ["voice-transcript"];
@@ -185,7 +176,7 @@ export class RealtimeTalkSession {
         capabilities.push("camera-frame");
       }
       const session = await this.createSession({ ...this.options, capabilities });
-      const transport = resolveTransport(session);
+      const transport = resolveRealtimeTalkTransport(session);
       // Managed-room stays unsupported here and carries no voice bookkeeping;
       // reject it before the voice-session requirement produces a misleading error.
       if (transport === "managed-room") {
@@ -232,25 +223,27 @@ export class RealtimeTalkSession {
       let nextTransport: RealtimeTalkTransport | null = null;
       let startResult: Awaited<ReturnType<RealtimeTalkTransport["start"]>>;
       try {
-        nextTransport = createTransport(session, {
+        input.requireStream();
+        nextTransport = createRealtimeTalkTransport(session, {
           client: this.client,
           sessionKey: this.sessionKey,
           voiceSessionId,
           flushTranscriptWrites: async () => await transcriptQueue.flush(),
           callbacks,
-          inputDeviceId: this.localOptions.inputDeviceId,
+          input,
           videoDeviceId: this.localOptions.videoDeviceId,
           consultThinkingLevel: session.consultThinkingLevel,
           consultFastMode: session.consultFastMode,
         });
-        this.pendingTransport = nextTransport;
+        this.pendingStartup = nextTransport;
         this.callbacks.onVideoCapability?.(
           providerVideoCapable && typeof nextTransport.setVideoEnabled === "function",
         );
-        startResult = await nextTransport.start();
+        startResult =
+          this.pendingStartup === nextTransport ? await nextTransport.start() : "cancelled";
       } catch (error) {
-        if (this.pendingTransport === nextTransport) {
-          this.pendingTransport = null;
+        if (this.pendingStartup === nextTransport) {
+          this.pendingStartup = null;
         }
         retireUncommittedRealtimeTalkTransport({
           nextTransport,
@@ -263,8 +256,8 @@ export class RealtimeTalkSession {
         ownerTransferred = true;
         throw error;
       }
-      if (this.pendingTransport === nextTransport) {
-        this.pendingTransport = null;
+      if (this.pendingStartup === nextTransport) {
+        this.pendingStartup = null;
       }
       if (
         startResult === "cancelled" ||
@@ -294,7 +287,7 @@ export class RealtimeTalkSession {
         this.clientVoiceSessionOwner = adoptedOwner;
       }
       try {
-        // Publish the candidate before releasing bounded events buffered during permission.
+        // Publish the candidate before releasing bounded events buffered during startup.
         nextTransport.activate?.();
       } catch (error) {
         const canRestoreExistingTransport =
@@ -329,6 +322,10 @@ export class RealtimeTalkSession {
       ownerTransferred = true;
       existingTransport?.stop({ emitClosed: false });
     } finally {
+      if (input && this.pendingStartup === input) {
+        this.pendingStartup = null;
+        input.stop();
+      }
       if (!ownerTransferred) {
         owner.release();
       }
@@ -417,7 +414,7 @@ export class RealtimeTalkSession {
           }),
           { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS },
         );
-        return resolveTransport(relaySession) === "gateway-relay"
+        return resolveRealtimeTalkTransport(relaySession) === "gateway-relay"
           ? {
               ...relaySession,
               voiceSessionId: (relaySession as RealtimeTalkGatewayRelaySessionResult)
@@ -448,7 +445,7 @@ export class RealtimeTalkSession {
     const transport = this.transport;
     this.transport = null;
     try {
-      this.stopPendingTransport();
+      this.stopPendingStartup();
     } finally {
       try {
         transport?.stop();
@@ -460,10 +457,10 @@ export class RealtimeTalkSession {
     }
   }
 
-  private stopPendingTransport(): void {
-    const pendingTransport = this.pendingTransport;
-    this.pendingTransport = null;
-    pendingTransport?.stop({ emitClosed: false });
+  private stopPendingStartup(): void {
+    const pending = this.pendingStartup;
+    this.pendingStartup = null;
+    pending?.stop({ emitClosed: false });
   }
 
   private closeUnadoptedVoiceSession(


### PR DESCRIPTION
Closes #133359

## What Problem This Solves

Fixes an issue where users starting Browser Talk could lose the connection before it began if granting microphone access took longer than the provider's activation window. OpenAI's pending-offer broker and Google's new-session token both allow 60 seconds; the browser previously allocated that session before requesting microphone access.

## Why This Change Was Made

The browser session now acquires one microphone before allocating a provider session and transfers that same input controller to WebRTC, Google Live, or Gateway relay. One pending-startup owner handles cancellation and replacement. Denial allocates nothing, late grants are released, allocation failures release the microphone, and microphone loss during allocation rejects the candidate. Transport factories move into their own existing-responsibility module; per-transport microphone acquisition and cancellation branches are removed.

This repairs startup ordering rather than increasing provider TTLs or adding refresh/retry paths. Authentication, provider selection, configuration, persistence, and protocol contracts are unchanged. The documented browser permission prompt may wait indefinitely; Codex's WebRTC start contract likewise takes an already-prepared SDP offer (`codex-rs/app-server-protocol/src/protocol/v2/realtime.rs:279` and `codex-rs/codex-api/src/endpoint/realtime_call.rs:129`, directly inspected in openai/codex).

Provenance: the ordering is present in the inspected baseline and its preceding startup-guidance fix; the introducing commit is unknown. #117490 corrected Google's exposed expiry units but did not change microphone acquisition order.

## User Impact

A first-time microphone prompt can remain open without spending the voice connection token's lifetime. Cancelling or denying it does not create a provider session. This applies to all three supported browser transports, with no new setting or operator action.

## Evidence

- Before: a real-clock request to the actual OpenAI localhost offer broker at 60,141 ms returned HTTP 401, `Invalid or expired realtime session token`; it released all reservations and made zero upstream calls. This used synthetic credentials and SDP, not a live authenticated provider call.
- Eight new owner regressions fail on the previous implementation. They cover a 65-second permission wait for all three transports, denial, cancellation with late grant, allocation failure, and microphone loss during initial/replacement allocation.
- After: all 284 voice tests across 19 files pass, including the original WebRTC execution order, transcript/lifecycle, Google, relay, camera, and microphone siblings. Scoped type-aware lint, formatting, and the assertion-safety ratchet pass. The initial hosted run caught undocumented assertions moved into the new factory; redundant casts were removed, the remaining transport assumptions documented, and the former owner baseline reduced. The patch is unchanged after rebasing onto both landed prerequisites (#133353 and #133365).
- Native Chromium Control UI E2E: both microphone-lifetime scenarios plus all 11 start/stop, camera, backpressure, and WebKit-error sibling scenarios pass. The pending-permission scenario explicitly observes zero `talk.client.create` requests while waiting, then exactly one after permission is granted and the UI reaches Listening. This is a synthetic browser/Gateway fixture, not a live provider call. Hosted CI exposed three stale sibling assertions that still expected allocation before microphone permission; they now assert zero allocation/close on denial and two captures with old-input release on stop/restart. No runtime change was needed for that correction.
- Independent Codex review of the final implementation reports no actionable P0–P2 findings. Full clean-install coverage is delegated to hosted CI: the shared local dependency checkout has an unrelated pako type-version mismatch that blocks the broad UI check.

The following inspected synthetic captures show the fixed flow. The RPC assertions above prove allocation order; screenshots alone do not. Visible startup guidance was introduced in #133353, so these are pending/ready flow evidence rather than a new rendering change.

![Microphone permission pending; no provider session allocated](https://github.com/user-attachments/assets/e5b64fbf-f54d-4e1d-9016-126b8f030517)

![Permission granted and voice listening](https://github.com/user-attachments/assets/fa8378a3-0b63-435c-b691-852986b69dc6)

Production: +127/-106, net +21, including the factory relocation. Tests/test support: +466/-384, net +82. Docs: +4. Assertion baseline: +1/-1, reducing the old owner allowance from seven to two. The production increase establishes the canonical prepared-input handoff and single startup-resource owner; it replaces three separate acquisition paths. No generated files, dependencies, or runtime configuration surfaces change.

Remaining limits: live provider recognition accuracy and physical microphone/OS permission behavior are not established by these deterministic tests. Replacement tests preserve the previous browser transport; server-side provider replacement activation is tracked separately in #133387 and is not claimed repaired here. No changes to Google manual-VAD behavior are included.
