### PR TITLE
fix(gateway): return finalized text in constrained Responses tool streams

### DIFF
--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -91,6 +91,8 @@ Clients that manage their own history can append `response.output` to `input`, t
 
 For `tool_choice: "required"` and function-pinned `tool_choice`, the endpoint narrows the exposed client function-tool set, instructs the runtime to call a client tool before responding, and rejects the turn if it does not include a matching structured client-tool call, matching the `/v1/chat/completions` contract. Non-streaming requests return `502` with an `api_error`; streaming requests emit a `response.failed` event.
 
+Streaming requests hold provisional prose until the matching call is confirmed and use finalized result text when available.
+
 ## Images (`input_image`)
 
 Supports base64 or URL sources:

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -2777,44 +2777,55 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(text).toContain("[DONE]");
   });
 
-  it("emits the tool call when a streaming required tool_choice is satisfied", async () => {
-    const port = enabledPort;
-    agentCommandMock.mockClear();
-    agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
-      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
-      emitAgentEvent({ runId, stream: "assistant", data: { delta: "Calling " } });
-      emitAgentEvent({ runId, stream: "assistant", data: { delta: "the tool." } });
-      return {
-        payloads: [{ text: "Calling the tool." }],
-        meta: {
-          stopReason: "tool_calls",
-          pendingToolCalls: [{ id: "call_1", name: "get_weather", arguments: '{"city":"Taipei"}' }],
-        },
-      };
-    }) as never);
+  it.each([
+    { name: "required", toolChoice: "required" },
+    { name: "pinned", toolChoice: { type: "function", name: "get_weather" } },
+  ] as const)(
+    "uses final result text when a streaming $name tool_choice is satisfied",
+    async ({ toolChoice }) => {
+      const port = enabledPort;
+      agentCommandMock.mockClear();
+      agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
+        const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+        emitAgentEvent({ runId, stream: "assistant", data: { delta: "Working..." } });
+        return {
+          payloads: [{ text: "Done." }],
+          meta: {
+            stopReason: "tool_calls",
+            pendingToolCalls: [
+              { id: "call_1", name: "get_weather", arguments: '{"city":"Taipei"}' },
+            ],
+          },
+        };
+      }) as never);
 
-    const res = await postResponses(port, {
-      stream: true,
-      model: "openclaw",
-      input: "check the weather",
-      tools: WEATHER_TOOL,
-      tool_choice: "required",
-    });
+      const res = await postResponses(port, {
+        stream: true,
+        model: "openclaw",
+        input: "check the weather",
+        tools: WEATHER_TOOL,
+        tool_choice: toolChoice,
+      });
 
-    expect(res.status).toBe(200);
-    const events = parseSseEvents(await res.text());
-    const delta = findSseEvent(events, "response.output_text.delta");
-    expect((parseSseData(delta) as { delta?: string }).delta).toBe("Calling the tool.");
-    const completed = findSseEvent(events, "response.completed");
-    const response = (
-      parseSseData(completed) as {
-        response?: { status?: string; output?: Array<Record<string, unknown>> };
-      }
-    ).response;
-    expect(response?.status).toBe("completed");
-    expect(response?.output?.map((item) => item.type)).toEqual(["message", "function_call"]);
-    expect(response?.output?.[1]?.name).toBe("get_weather");
-  });
+      expect(res.status).toBe(200);
+      const events = parseSseEvents(await res.text());
+      const delta = findSseEvent(events, "response.output_text.delta");
+      expect((parseSseData(delta) as { delta?: string }).delta).toBe("Done.");
+      const completed = findSseEvent(events, "response.completed");
+      const response = (
+        parseSseData(completed) as {
+          response?: { status?: string; output?: Array<Record<string, unknown>> };
+        }
+      ).response;
+      expect(response?.status).toBe("completed");
+      expect(response?.output?.map((item) => item.type)).toEqual(["message", "function_call"]);
+      expect(
+        (((response?.output?.[0]?.content as Array<Record<string, unknown>> | undefined) ?? [])[0]
+          ?.text as string | undefined) ?? "",
+      ).toBe("Done.");
+      expect(response?.output?.[1]?.name).toBe("get_weather");
+    },
+  );
 
   it.each([
     { name: "an initial replacement", previousDelta: undefined, replacementDelta: undefined },

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -1236,8 +1236,11 @@ export async function handleOpenResponsesHttpRequest(
         pendingToolCalls.length > 0
       ) {
         const usage = finalUsage ?? createEmptyUsage();
-        const finalText =
-          accumulatedText || resultPayloadText || bufferedReplaceableAssistantContent;
+        // Held constrained prose can use the final payload; already-emitted
+        // Responses deltas cannot be replaced without contradicting the stream.
+        const finalText = sawAssistantDelta
+          ? accumulatedText || resultPayloadText || bufferedReplaceableAssistantContent
+          : resultPayloadText || accumulatedText || bufferedReplaceableAssistantContent;
 
         if (finalText && !sawAssistantDelta) {
           sawAssistantDelta = true;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenResponses clients using required or function-pinned tools could receive stale provisional assistant text after the run had already produced different finalized text.

## Why This Change Was Made

The terminal Responses projection now prefers finalized result text only before any assistant delta has been emitted. Already-emitted streams retain their text, preserving SSE consistency while matching the finalized behavior used by `/v1/chat/completions`.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] Build/tooling

## Scope

- [x] Core/runtime
- [x] Gateway/protocol
- [ ] Plugin/extension
- [ ] CLI/tooling
- [ ] Docs only
- [ ] CI/build

## Verification

- [x] Targeted tests added/updated
- [x] Manual verification performed
- [ ] Screenshots attached (required for UI changes)
- [ ] Logs/output attached (required for runtime/behavioral changes)

## Evidence

- The regression test emits provisional `Working...` prose but returns finalized `Done.` payload text for both required and function-pinned tool choices.
- Assertions cover the emitted `response.output_text.delta`, completed assistant output, and preserved function call.
- Commit-scoped autoreview (Codex gpt-5.5, high) reported no actionable findings, correctness confidence 0.82.
- Exact-head Windows proof on Node 24.16.0 / SQLite 3.53.0: `node scripts/run-vitest.mjs src/gateway/openresponses-http.test.ts -t "uses final result text when a streaming"` passed both required and pinned Gateway HTTP/SSE cases (2 passed, 87 skipped).

## User Impact

OpenResponses clients using required or pinned tools receive finalized assistant commentary instead of stale provisional text.

## Risks and Rollback

- Risk: low; final payload precedence changes only before any assistant delta has been emitted. Already-emitted streams keep their existing text to avoid contradictory SSE snapshots.
- Rollback: revert the two commits to restore the previous precedence and documentation.

## AI Assistance

AI-assisted by Codex. I reviewed the full streaming branch, sibling `/v1/chat/completions` implementation and tests, protocol consistency, focused regression coverage, and final commit-scoped review.

