### PR TITLE
fix(doctor): canonicalize recognized legacy schedule kinds during cron migration

### DIFF
--- a/src/commands/doctor/cron/index.test.ts
+++ b/src/commands/doctor/cron/index.test.ts
@@ -2556,11 +2556,11 @@ describe("maybeRepairLegacyCronStore quarantine recovery", () => {
     });
 
     const persisted = await readPersistedJobs(storePath);
-    expect(persisted.map((job) => job.id).toSorted((a, b) => a.localeCompare(b))).toEqual([
-      "healthy-job",
-      "recreated-variant",
-      "variant-cron",
-    ]);
+    expect(
+      persisted
+        .map((job) => (typeof job.id === "string" ? job.id : ""))
+        .toSorted((a, b) => a.localeCompare(b)),
+    ).toEqual(["healthy-job", "recreated-variant", "variant-cron"]);
     const recovered = persisted.find((job) => job.id === "variant-cron");
     if (!recovered) {
       throw new Error("expected recovered cron job variant-cron");
@@ -2571,7 +2571,7 @@ describe("maybeRepairLegacyCronStore quarantine recovery", () => {
     const quarantine = loadCronQuarantinedJobs(storePath);
     expect(
       quarantine
-        .map((entry) => (entry.job as { id?: string } | undefined)?.id)
+        .map((entry) => (entry.job as { id?: string } | undefined)?.id ?? "")
         .toSorted((a, b) => a.localeCompare(b)),
     ).toEqual(["genuinely-bad", "other-reason", "recreated-variant"]);
     expectNoteContaining("Recovered 1 quarantined automation", "Doctor changes");

--- a/src/commands/doctor/cron/index.test.ts
+++ b/src/commands/doctor/cron/index.test.ts
@@ -2501,4 +2501,127 @@ describe("legacy WhatsApp crontab health check", () => {
     expect(noteMock).not.toHaveBeenCalled();
   });
 });
+
+describe("maybeRepairLegacyCronStore quarantine recovery", () => {
+  it("recovers quarantined invalid-schedule rows whose schedule kinds now canonicalize (#133347)", async () => {
+    const storePath = await makeTempStorePath();
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.dirname(path.dirname(storePath)));
+    await writeCurrentCronStore(storePath, [
+      createCurrentCronJob({ id: "healthy-job", name: "Healthy job" }),
+      createCurrentCronJob({ id: "recreated-variant", name: "Recreated variant" }),
+    ]);
+    saveCronQuarantinedJobs({
+      storePath,
+      nowMs: Date.parse("2026-08-30T18:50:02.000Z"),
+      entries: [
+        {
+          sourceIndex: 0,
+          reason: "invalid-schedule",
+          job: createCurrentCronJob({
+            id: "variant-cron",
+            name: "Variant cron",
+            schedule: { kind: "Cron", expr: "0 9 * * *", tz: "UTC" },
+          }),
+          state: { nextRunAtMs: 123 },
+          updatedAtMs: 456,
+        },
+        {
+          sourceIndex: 1,
+          reason: "invalid-schedule",
+          job: createCurrentCronJob({
+            id: "recreated-variant",
+            schedule: { kind: " every ", everyMs: 60_000 },
+          }),
+        },
+        {
+          sourceIndex: 2,
+          reason: "invalid-schedule",
+          job: createCurrentCronJob({
+            id: "genuinely-bad",
+            schedule: { kind: "daily", at: "09:00" },
+          }),
+        },
+        {
+          sourceIndex: 3,
+          reason: "missing-payload",
+          job: createCurrentCronJob({ id: "other-reason" }),
+        },
+      ],
+    });
+
+    await maybeRepairLegacyCronStore({
+      cfg: createCronConfig(storePath),
+      options: { repair: true },
+      prompter: makePrompter(true),
+    });
+
+    const persisted = await readPersistedJobs(storePath);
+    expect(persisted.map((job) => job.id).toSorted((a, b) => a.localeCompare(b))).toEqual([
+      "healthy-job",
+      "recreated-variant",
+      "variant-cron",
+    ]);
+    const recovered = persisted.find((job) => job.id === "variant-cron");
+    if (!recovered) {
+      throw new Error("expected recovered cron job variant-cron");
+    }
+    expect((recovered.schedule as Record<string, unknown>).kind).toBe("cron");
+    expect(recovered.enabled).toBe(true);
+    expect(recovered.state).toMatchObject({ nextRunAtMs: 123 });
+    const quarantine = loadCronQuarantinedJobs(storePath);
+    expect(
+      quarantine
+        .map((entry) => (entry.job as { id?: string } | undefined)?.id)
+        .toSorted((a, b) => a.localeCompare(b)),
+    ).toEqual(["genuinely-bad", "other-reason", "recreated-variant"]);
+    expectNoteContaining("Recovered 1 quarantined automation", "Doctor changes");
+  });
+
+  it("recovers quarantined rows even when the active store is empty (#133347)", async () => {
+    const storePath = await makeTempStorePath();
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.dirname(path.dirname(storePath)));
+    await writeCurrentCronStore(storePath, []);
+    saveCronQuarantinedJobs({
+      storePath,
+      nowMs: Date.parse("2026-08-30T18:50:02.000Z"),
+      entries: [
+        {
+          sourceIndex: 0,
+          reason: "invalid-schedule",
+          job: createCurrentCronJob({
+            id: "variant-every",
+            schedule: { kind: " Every ", everyMs: 60_000 },
+          }),
+        },
+        {
+          sourceIndex: 1,
+          reason: "invalid-schedule",
+          job: createCurrentCronJob({
+            id: "genuinely-bad",
+            schedule: { kind: "daily", at: "09:00" },
+          }),
+        },
+      ],
+    });
+
+    await maybeRepairLegacyCronStore({
+      cfg: createCronConfig(storePath),
+      options: { repair: true },
+      prompter: makePrompter(true),
+    });
+
+    const persisted = await readPersistedJobs(storePath);
+    expect(persisted.map((job) => job.id)).toEqual(["variant-every"]);
+    const recovered = persisted[0];
+    if (!recovered) {
+      throw new Error("expected recovered cron job variant-every");
+    }
+    expect((recovered.schedule as Record<string, unknown>).kind).toBe("every");
+    const quarantine = loadCronQuarantinedJobs(storePath);
+    expect(quarantine.map((entry) => (entry.job as { id?: string } | undefined)?.id)).toEqual([
+      "genuinely-bad",
+    ]);
+    expectNoteContaining("Recovered 1 quarantined automation", "Doctor changes");
+  });
+});
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/commands/doctor/cron/index.ts
+++ b/src/commands/doctor/cron/index.ts
@@ -384,8 +384,12 @@ export async function maybeRepairLegacyCronStore(params: {
     legacyQuarantine,
     legacyImportCount,
     invalidConfigRows,
+    persistedQuarantine,
     rawJobs,
   } = state;
+  const recoverableQuarantineCount = persistedQuarantine.filter(
+    (entry) => entry.reason === "invalid-schedule" && entry.job,
+  ).length;
   const sqliteStorePath = resolveOpenClawStateSqlitePath();
   try {
     const quarantine = loadCronQuarantinedJobs(storePath);
@@ -415,7 +419,8 @@ export async function maybeRepairLegacyCronStore(params: {
       !legacyStoreDetected &&
       !legacyRunLogDetected &&
       !legacyQuarantine &&
-      invalidConfigRows.length === 0
+      invalidConfigRows.length === 0 &&
+      recoverableQuarantineCount === 0
     ) {
       return;
     }
@@ -432,6 +437,11 @@ export async function maybeRepairLegacyCronStore(params: {
     if (invalidConfigRows.length > 0) {
       previewLines.push(
         `- ${pluralize(invalidConfigRows.length, "malformed cron row")} will be quarantined in SQLite`,
+      );
+    }
+    if (recoverableQuarantineCount > 0) {
+      previewLines.push(
+        `- ${pluralize(recoverableQuarantineCount, "quarantined automation")} will be recovered after its schedule kind normalizes`,
       );
     }
     note(
@@ -605,6 +615,11 @@ export async function maybeRepairLegacyCronStore(params: {
   if (invalidConfigRows.length > 0) {
     previewLines.push(
       `- ${pluralize(invalidConfigRows.length, "malformed cron row")} will be quarantined in SQLite`,
+    );
+  }
+  if (recoverableQuarantineCount > 0) {
+    previewLines.push(
+      `- ${pluralize(recoverableQuarantineCount, "quarantined automation")} will be recovered after its schedule kind normalizes`,
     );
   }
   if (notifyCount > 0) {

--- a/src/commands/doctor/cron/legacy-repair.test.ts
+++ b/src/commands/doctor/cron/legacy-repair.test.ts
@@ -1,14 +1,20 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, expect, it } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { saveCronStore } from "../../../cron/store.js";
-import { loadLegacyCronRepairState } from "./legacy-repair.js";
+import {
+  loadCronQuarantinedJobs,
+  loadCronStore,
+  saveCronQuarantinedJobs,
+  saveCronStore,
+} from "../../../cron/store.js";
+import { loadLegacyCronRepairState, repairLegacyCronStoreWithoutPrompt } from "./legacy-repair.js";
 
 let tempRoot: string | undefined;
 
 afterEach(async () => {
+  vi.unstubAllEnvs();
   if (tempRoot) {
     await fs.rm(tempRoot, { recursive: true, force: true });
     tempRoot = undefined;
@@ -79,3 +85,80 @@ it.each<{
     expect(state?.projectedOwnersByJobId.get("dynamic-default")).toEqual(expectedOwner);
   },
 );
+
+it("repairs recoverable quarantined rows without legacy files on the startup path (#133347)", async () => {
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-quarantine-recovery-"));
+  const storePath = path.join(tempRoot, "cron", "jobs.json");
+  vi.stubEnv("OPENCLAW_STATE_DIR", tempRoot);
+  await saveCronStore(storePath, { version: 1, jobs: [] });
+  saveCronQuarantinedJobs({
+    storePath,
+    nowMs: Date.parse("2026-08-30T18:50:02.000Z"),
+    entries: [
+      {
+        sourceIndex: 0,
+        reason: "invalid-schedule",
+        job: {
+          id: "variant-cron",
+          name: "Variant cron",
+          enabled: true,
+          createdAtMs: 1_700_000_000_000,
+          updatedAtMs: 1_700_000_000_000,
+          schedule: { kind: "Cron", expr: "0 9 * * *", tz: "UTC" },
+          sessionTarget: "main",
+          wakeMode: "now",
+          payload: { kind: "systemEvent", text: "tick" },
+          state: {},
+        },
+        state: { nextRunAtMs: 123 },
+        updatedAtMs: 456,
+      },
+      {
+        sourceIndex: 1,
+        reason: "invalid-schedule",
+        job: {
+          id: "genuinely-bad",
+          name: "Genuinely bad",
+          enabled: true,
+          createdAtMs: 1_700_000_000_000,
+          updatedAtMs: 1_700_000_000_000,
+          schedule: { kind: "daily", at: "09:00" },
+          sessionTarget: "main",
+          wakeMode: "now",
+          payload: { kind: "systemEvent", text: "tick" },
+          state: {},
+        },
+      },
+    ],
+  });
+  const cfg = { cron: { store: storePath } } as OpenClawConfig;
+
+  const result = await repairLegacyCronStoreWithoutPrompt({ cfg });
+
+  expect(result.changes.join("\n")).toContain("Recovered 1 quarantined automation");
+  const persisted = (await loadCronStore(storePath)).jobs as unknown as Array<
+    Record<string, unknown>
+  >;
+  expect(persisted.map((job) => job.id)).toEqual(["variant-cron"]);
+  const recovered = persisted[0];
+  if (!recovered) {
+    throw new Error("expected recovered cron job variant-cron");
+  }
+  expect((recovered.schedule as Record<string, unknown>).kind).toBe("cron");
+  expect(recovered.enabled).toBe(true);
+  expect(recovered.state).toMatchObject({ nextRunAtMs: 123 });
+  const quarantine = loadCronQuarantinedJobs(storePath);
+  expect(quarantine.map((entry) => (entry.job as { id?: string } | undefined)?.id)).toEqual([
+    "genuinely-bad",
+  ]);
+
+  // A second repair run is a no-op: the recovered job is active and the
+  // remaining quarantine row is genuinely malformed.
+  const second = await repairLegacyCronStoreWithoutPrompt({ cfg });
+  expect(second.changes).toEqual([]);
+  expect(
+    ((await loadCronStore(storePath)).jobs as unknown as Array<Record<string, unknown>>).map(
+      (job) => job.id,
+    ),
+  ).toEqual(["variant-cron"]);
+});

--- a/src/commands/doctor/cron/legacy-repair.ts
+++ b/src/commands/doctor/cron/legacy-repair.ts
@@ -1,15 +1,20 @@
 // Doctor cron storage repair mechanics for legacy stores, run logs, payloads, and Codex refs.
-import { normalizeOptionalString } from "../../../../packages/normalization-core/src/string-coerce.js";
+import {
+  normalizeOptionalString,
+  normalizeOptionalStringifiedId,
+} from "../../../../packages/normalization-core/src/string-coerce.js";
 import { tryResolveAmbientOwnerAgentId } from "../../../agents/agent-scope-config.js";
 import { formatCliCommand } from "../../../cli/command-format.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import {
   loadCronJobsStoreWithConfigJobs,
   loadCronJobsStoreWithConfigJobsReadOnly,
+  loadCronQuarantinedJobs,
   resolveCronJobsStorePath,
   saveCronJobsStore,
   saveCronJobsStoreWithMetadata,
   saveCronQuarantinedJobs,
+  deleteCronQuarantinedJobs,
   type CronQuarantinedJob,
   type QuarantinedCronConfigJob,
 } from "../../../cron/store.js";
@@ -51,7 +56,9 @@ import {
 import {
   collectStoredCronCodexRuntimePolicyTargets,
   cronCodexRuntimePolicyTargetKey,
+  hasRecoverableQuarantinedCronScheduleJobs,
   normalizeStoredCronJobs,
+  recoverQuarantinedCronScheduleJobs,
   type CronCodexRuntimePolicyTarget,
 } from "./store-migration.js";
 
@@ -69,6 +76,8 @@ export type LegacyCronRepairState = {
   legacyMigrationAlreadyImported: boolean;
   legacyImportCount: number;
   invalidConfigRows: QuarantinedCronConfigJob[];
+  /** Quarantine rows already persisted in the SQLite state database. */
+  persistedQuarantine: CronQuarantinedJob[];
   projectedOwnersByJobId: ReadonlyMap<string, CronOwnerProjection>;
   rawJobs: Array<Record<string, unknown>>;
 };
@@ -121,12 +130,22 @@ export async function loadLegacyCronRepairState(params: {
   const legacyStoreDetected = await legacyCronStoreFilesExist(storePath);
   const legacyRunLogDetected = await legacyCronRunLogFilesExist(storePath);
   const legacyQuarantine = await loadLegacyCronQuarantineForMigration(storePath);
+  // Quarantined rows whose schedule kind was a recognized case or whitespace
+  // variant are recoverable, so repair must run even without legacy files (#133347).
+  let persistedQuarantine: CronQuarantinedJob[];
+  try {
+    persistedQuarantine = loadCronQuarantinedJobs(storePath);
+  } catch (err) {
+    rethrowSqliteSchemaVersionError(err);
+    persistedQuarantine = [];
+  }
   assertCronStateSchemaSupported(params.env);
   if (
     params.onlyIfLegacyDetected &&
     !legacyStoreDetected &&
     !legacyRunLogDetected &&
-    !legacyQuarantine
+    !legacyQuarantine &&
+    !hasRecoverableQuarantinedCronScheduleJobs(persistedQuarantine)
   ) {
     return null;
   }
@@ -180,6 +199,7 @@ export async function loadLegacyCronRepairState(params: {
     legacyMigrationAlreadyImported,
     legacyImportCount,
     invalidConfigRows,
+    persistedQuarantine,
     projectedOwnersByJobId,
     rawJobs,
   };
@@ -196,6 +216,31 @@ export async function applyLegacyCronStoreRepair(params: {
   const { state } = params;
   const changes: string[] = [];
   const warnings: string[] = [];
+  // Recover quarantined invalid-schedule rows whose schedule kind was a
+  // recognized case or whitespace variant, so enabled automations quarantined
+  // by the 2026.8.1 migration rejoin the active store (#133347).
+  const recoverableQuarantineEntries = [
+    ...state.persistedQuarantine,
+    ...(state.legacyQuarantine?.jobs ?? []),
+  ];
+  const persistedQuarantineEntrySet = new Set<QuarantinedCronConfigJob | CronQuarantinedJob>(
+    state.persistedQuarantine,
+  );
+  const quarantineRecovery =
+    recoverableQuarantineEntries.length > 0
+      ? recoverQuarantinedCronScheduleJobs(
+          recoverableQuarantineEntries,
+          new Set(
+            state.rawJobs
+              .map((job) => normalizeOptionalStringifiedId(job.id))
+              .filter((id): id is string => id !== undefined),
+          ),
+        )
+      : undefined;
+  const recoveredQuarantineJobs = quarantineRecovery?.recoveredJobs ?? [];
+  if (recoveredQuarantineJobs.length > 0) {
+    state.rawJobs.push(...recoveredQuarantineJobs);
+  }
   const runtimePolicyPlan =
     params.migrateCodexModelRefs === true
       ? planCronCodexRefRewriteAgainstPersistedConfig({
@@ -209,12 +254,13 @@ export async function applyLegacyCronStoreRepair(params: {
     (runtimePolicyPlan?.blockedTargets ?? []).map(cronCodexRuntimePolicyTargetKey),
   );
   const normalized =
-    params.normalized ??
-    normalizeStoredCronJobs(state.rawJobs, {
-      migrateCodexModelRefs: params.migrateCodexModelRefs,
-      shouldMigrateCodexRuntimePolicyTarget: (target) =>
-        !blockedRuntimePolicyTargets.has(cronCodexRuntimePolicyTargetKey(target)),
-    });
+    params.normalized && recoveredQuarantineJobs.length === 0
+      ? params.normalized
+      : normalizeStoredCronJobs(state.rawJobs, {
+          migrateCodexModelRefs: params.migrateCodexModelRefs,
+          shouldMigrateCodexRuntimePolicyTarget: (target) =>
+            !blockedRuntimePolicyTargets.has(cronCodexRuntimePolicyTargetKey(target)),
+        });
   warnings.push(
     ...normalized.unsupportedLegacyTriggerScriptJobs.map(
       (job) =>
@@ -236,7 +282,8 @@ export async function applyLegacyCronStoreRepair(params: {
     state.invalidConfigRows.length > 0 ||
     normalized.mutated ||
     notifyMigration.changed ||
-    dreamingMigration.changed;
+    dreamingMigration.changed ||
+    recoveredQuarantineJobs.length > 0;
   const changed =
     state.legacyStoreDetected ||
     state.legacyRunLogDetected ||
@@ -247,7 +294,11 @@ export async function applyLegacyCronStoreRepair(params: {
   }
 
   const quarantineEntries: (QuarantinedCronConfigJob | CronQuarantinedJob)[] = [
-    ...(state.legacyQuarantine?.jobs ?? []),
+    ...(quarantineRecovery?.retainedEntries.filter(
+      (entry) => !persistedQuarantineEntrySet.has(entry),
+    ) ??
+      state.legacyQuarantine?.jobs ??
+      []),
     ...state.invalidConfigRows,
     ...normalized.removedJobs.map((entry) => ({
       sourceIndex: entry.sourceIndex,
@@ -290,6 +341,32 @@ export async function applyLegacyCronStoreRepair(params: {
         ],
       };
     }
+  }
+
+  // Delete recovered quarantine rows only after the active store write commits;
+  // a crash before deletion is safe because the id dedup guard prevents a
+  // duplicate recovery on the next doctor run.
+  const recoveredPersistedQuarantineEntries =
+    quarantineRecovery?.recoveredEntries.filter((entry) =>
+      persistedQuarantineEntrySet.has(entry),
+    ) ?? [];
+  if (recoveredPersistedQuarantineEntries.length > 0) {
+    try {
+      deleteCronQuarantinedJobs({
+        storePath: state.storePath,
+        entries: recoveredPersistedQuarantineEntries,
+      });
+    } catch (err) {
+      rethrowSqliteSchemaVersionError(err);
+      warnings.push(
+        `Failed clearing recovered cron quarantine rows at ${shortenHomePath(state.storePath)}: ${errorMessage(err)}. Rerun ${formatCliCommand("openclaw doctor --fix")} to retry.`,
+      );
+    }
+  }
+  if (recoveredQuarantineJobs.length > 0) {
+    changes.push(
+      `Recovered ${pluralize(recoveredQuarantineJobs.length, "quarantined automation")} whose schedule kind normalized to a canonical form.`,
+    );
   }
 
   if (state.legacyQuarantine) {

--- a/src/commands/doctor/cron/repair-plan.ts
+++ b/src/commands/doctor/cron/repair-plan.ts
@@ -124,6 +124,11 @@ export function formatLegacyIssuePreview(issues: CronLegacyIssueCounts): string[
   if (issues.legacyScheduleCron) {
     lines.push(`- ${pluralize(issues.legacyScheduleCron, "job")} still uses \`schedule.cron\``);
   }
+  if (issues.legacyScheduleKind) {
+    lines.push(
+      `- ${pluralize(issues.legacyScheduleKind, "job")} stores a non-canonical schedule \`kind\` that will be normalized`,
+    );
+  }
   if (issues.legacyPayloadKind) {
     lines.push(`- ${pluralize(issues.legacyPayloadKind, "job")} needs payload kind normalization`);
   }

--- a/src/commands/doctor/cron/store-migration.schedule-kind.test.ts
+++ b/src/commands/doctor/cron/store-migration.schedule-kind.test.ts
@@ -1,0 +1,113 @@
+// Regression tests for legacy schedule-kind canonicalization during doctor
+// migration (#133347): rows whose schedule kind is a recognized case/whitespace
+// variant are normalizable by the public input path and must not be quarantined
+// as invalid-schedule when the legacy JSON inventory migrates into SQLite.
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it } from "vitest";
+import { getInvalidPersistedCronJobReason } from "../../../cron/persisted-shape.js";
+import { normalizeStoredCronJobs } from "./store-migration.js";
+
+function makeLegacyJob(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: "job-legacy",
+    name: "Legacy job",
+    enabled: true,
+    createdAtMs: 1_700_000_000_000,
+    updatedAtMs: 1_700_000_000_000,
+    sessionTarget: "main",
+    wakeMode: "now",
+    payload: {
+      kind: "systemEvent",
+      text: "tick",
+    },
+    state: {},
+    ...overrides,
+  };
+}
+
+describe("normalizeStoredCronJobs schedule kind canonicalization", () => {
+  it("canonicalizes recognized legacy schedule kinds instead of quarantining them (#133347)", () => {
+    const jobs = [
+      makeLegacyJob({
+        id: "legacy-cron-kind",
+        enabled: true,
+        schedule: { kind: "Cron", expr: "0 9 * * *", tz: "UTC" },
+      }),
+      makeLegacyJob({
+        id: "legacy-every-kind",
+        enabled: false,
+        schedule: { kind: " every ", everyMs: 60_000 },
+      }),
+      makeLegacyJob({
+        id: "legacy-stream-kind",
+        enabled: true,
+        schedule: { kind: "Stream", command: ["watch-source"], mode: "Line" },
+      }),
+      makeLegacyJob({
+        id: "legacy-at-kind",
+        enabled: true,
+        schedule: { kind: "At", at: "2026-04-01T10:00:00.000Z" },
+      }),
+    ];
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.mutated).toBe(true);
+    expect(result.issues.invalidSchedule).toBeUndefined();
+    expect(result.issues.legacyScheduleKind).toBe(4);
+    expect(result.removedJobs).toEqual([]);
+    expect(jobs.map((job) => job.id)).toEqual([
+      "legacy-cron-kind",
+      "legacy-every-kind",
+      "legacy-stream-kind",
+      "legacy-at-kind",
+    ]);
+    const scheduleOf = (index: number) => jobs[index]?.schedule as Record<string, unknown>;
+    expect(scheduleOf(0)?.kind).toBe("cron");
+    expect(jobs[0]?.enabled).toBe(true);
+    expect(scheduleOf(1)?.kind).toBe("every");
+    expect(jobs[1]?.enabled).toBe(false);
+    expect(scheduleOf(3)?.kind).toBe("at");
+    expect(scheduleOf(2)?.kind).toBe("stream");
+    expect(scheduleOf(2)?.mode).toBe("line");
+    // Canonicalized rows must survive the strict persisted-shape validation
+    // that gates runtime scheduling, not just the migration pass.
+    for (const job of jobs) {
+      expect(getInvalidPersistedCronJobReason(job)).toBeNull();
+    }
+  });
+
+  it("still quarantines unrecognized legacy schedule kinds (#133347)", () => {
+    const jobs = [
+      makeLegacyJob({
+        id: "legacy-unknown-kind",
+        schedule: { kind: "daily", at: "09:00" },
+      }),
+    ];
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.issues.invalidSchedule).toBe(1);
+    expect(result.removedJobs[0]?.reason).toBe("invalid-schedule");
+    expect(jobs).toEqual([]);
+  });
+
+  it("keeps already-canonical schedule kinds untouched without reporting an issue", () => {
+    const jobs = [
+      makeLegacyJob({
+        id: "canonical-cron",
+        schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+      }),
+    ];
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.issues.legacyScheduleKind).toBeUndefined();
+    expect(result.issues.invalidSchedule).toBeUndefined();
+    expect(result.removedJobs).toEqual([]);
+    const [job] = jobs;
+    expect(
+      (expectDefined(job, "job test invariant").schedule as Record<string, unknown>).kind,
+    ).toBe("cron");
+  });
+});

--- a/src/commands/doctor/cron/store-migration.ts
+++ b/src/commands/doctor/cron/store-migration.ts
@@ -44,6 +44,7 @@ type CronStoreIssueKey =
   | "nonStringId"
   | "legacyScheduleString"
   | "legacyScheduleCron"
+  | "legacyScheduleKind"
   | "legacyPayloadKind"
   | "legacyPayloadCodexModel"
   | "legacyImageInspectionToolName"
@@ -437,6 +438,29 @@ export function normalizeStoredCronJobs(
     if (schedule && typeof schedule === "object" && !Array.isArray(schedule)) {
       const sched = schedule as Record<string, unknown>;
       const kind = normalizeOptionalLowercaseString(sched.kind) ?? "";
+      // The public input path canonicalizes recognized schedule kinds (case and
+      // whitespace variants) before validation, so the migration must apply the
+      // same canonicalization here. Otherwise rows the standard validator
+      // accepts are quarantined as invalid-schedule during migration.
+      const recognizedScheduleKind =
+        kind === "at" ||
+        kind === "every" ||
+        kind === "cron" ||
+        kind === "on-exit" ||
+        kind === "stream";
+      if (recognizedScheduleKind && sched.kind !== kind) {
+        sched.kind = kind;
+        mutated = true;
+        trackIssue("legacyScheduleKind");
+      }
+      if (kind === "stream") {
+        const streamMode = normalizeOptionalLowercaseString(sched.mode);
+        if ((streamMode === "line" || streamMode === "match") && sched.mode !== streamMode) {
+          sched.mode = streamMode;
+          mutated = true;
+          trackIssue("legacyScheduleKind");
+        }
+      }
       if (!kind && ("at" in sched || "atMs" in sched)) {
         sched.kind = "at";
         mutated = true;

--- a/src/commands/doctor/cron/store-migration.ts
+++ b/src/commands/doctor/cron/store-migration.ts
@@ -8,11 +8,14 @@ import {
   normalizeOptionalString,
   normalizeOptionalStringifiedId,
 } from "../../../../packages/normalization-core/src/string-coerce.js";
+import { normalizeCronJobInput } from "../../../cron/normalize.js";
 import { parseAbsoluteTimeMs } from "../../../cron/parse.js";
 import { getInvalidPersistedCronJobReason } from "../../../cron/persisted-shape.js";
+import { normalizeRecognizedCronScheduleKind } from "../../../cron/schedule-kind.js";
 import { coerceFiniteScheduleNumber } from "../../../cron/schedule-number.js";
 import { inferCronJobName } from "../../../cron/service/normalize.js";
 import { normalizeCronStaggerMs, resolveDefaultCronStaggerMs } from "../../../cron/stagger.js";
+import type { CronQuarantinedJob, QuarantinedCronConfigJob } from "../../../cron/store/types.js";
 import {
   isBlockedLegacyCodexModelRef,
   type LegacyCodexModelIdentity,
@@ -437,18 +440,12 @@ export function normalizeStoredCronJobs(
     const schedule = raw.schedule;
     if (schedule && typeof schedule === "object" && !Array.isArray(schedule)) {
       const sched = schedule as Record<string, unknown>;
-      const kind = normalizeOptionalLowercaseString(sched.kind) ?? "";
+      const kind = normalizeRecognizedCronScheduleKind(sched.kind) ?? "";
       // The public input path canonicalizes recognized schedule kinds (case and
       // whitespace variants) before validation, so the migration must apply the
       // same canonicalization here. Otherwise rows the standard validator
-      // accepts are quarantined as invalid-schedule during migration.
-      const recognizedScheduleKind =
-        kind === "at" ||
-        kind === "every" ||
-        kind === "cron" ||
-        kind === "on-exit" ||
-        kind === "stream";
-      if (recognizedScheduleKind && sched.kind !== kind) {
+      // accepts are quarantined as invalid-schedule during migration (#133347).
+      if (kind && sched.kind !== kind) {
         sched.kind = kind;
         mutated = true;
         trackIssue("legacyScheduleKind");
@@ -678,4 +675,87 @@ export function normalizeStoredCronJobs(
     mutated,
     removedJobs,
   };
+}
+
+/** Quarantine entries that may rehydrate after schedule-kind canonicalization (#133347). */
+export function hasRecoverableQuarantinedCronScheduleJobs(
+  entries: ReadonlyArray<QuarantinedCronConfigJob | CronQuarantinedJob>,
+): boolean {
+  return entries.some((entry) => entry.reason === "invalid-schedule" && isRecord(entry.job));
+}
+
+export type QuarantinedCronJobRecovery = {
+  /** Normalized jobs ready to rejoin the active store, preserving id and enabled state. */
+  recoveredJobs: Array<Record<string, unknown>>;
+  /** Quarantine entries whose job recovered; safe to drop once the store write commits. */
+  recoveredEntries: Array<QuarantinedCronConfigJob | CronQuarantinedJob>;
+  /** Quarantine entries that must stay quarantined, including duplicate ids the operator already recreated. */
+  retainedEntries: Array<QuarantinedCronConfigJob | CronQuarantinedJob>;
+};
+
+function restoredCronJobId(job: Record<string, unknown>): string | undefined {
+  return normalizeOptionalStringifiedId(job.id) ?? normalizeOptionalStringifiedId(job.jobId);
+}
+
+/**
+ * Rehydrates quarantined invalid-schedule rows whose definitions now canonicalize
+ * and pass the strict persisted-shape validator (#133347).
+ *
+ * The 2026.8.1 migration quarantined valid legacy rows whose schedule kind was a
+ * recognized case or whitespace variant, so later doctor repairs must revalidate
+ * those rows instead of leaving enabled automations inactive. Only entries whose
+ * job survives the full stored-job normalization are recovered; genuinely
+ * malformed rows and ids already present in the active store stay quarantined.
+ */
+export function recoverQuarantinedCronScheduleJobs(
+  entries: ReadonlyArray<QuarantinedCronConfigJob | CronQuarantinedJob>,
+  activeJobIds: ReadonlySet<string>,
+): QuarantinedCronJobRecovery {
+  const recoveredJobs: Array<Record<string, unknown>> = [];
+  const recoveredEntries: Array<QuarantinedCronConfigJob | CronQuarantinedJob> = [];
+  const retainedEntries: Array<QuarantinedCronConfigJob | CronQuarantinedJob> = [];
+  const recoveredJobIds = new Set<string>();
+  for (const entry of entries) {
+    const job = entry.job;
+    if (entry.reason !== "invalid-schedule" || !isRecord(job)) {
+      retainedEntries.push(entry);
+      continue;
+    }
+    const candidate = structuredClone(job) as Record<string, unknown>;
+    const jobId = restoredCronJobId(candidate);
+    if (jobId && (activeJobIds.has(jobId) || recoveredJobIds.has(jobId))) {
+      // The operator already recreated this automation (or a duplicate entry
+      // recovered first); keep the quarantine record rather than double-adding.
+      retainedEntries.push(entry);
+      continue;
+    }
+    // Restore the runtime state and timestamp preserved at quarantine time so
+    // the recovered row keeps its last/next run bookkeeping.
+    if (isRecord(entry.state)) {
+      candidate.state = structuredClone(entry.state);
+    }
+    if (typeof entry.updatedAtMs === "number" && Number.isFinite(entry.updatedAtMs)) {
+      candidate.updatedAtMs = entry.updatedAtMs;
+    }
+    try {
+      if (normalizeCronJobInput(candidate) === null) {
+        retainedEntries.push(entry);
+        continue;
+      }
+    } catch {
+      retainedEntries.push(entry);
+      continue;
+    }
+    const normalized = normalizeStoredCronJobs([candidate]);
+    if (normalized.jobs.length === 1 && normalized.removedJobs.length === 0) {
+      recoveredJobs.push(candidate);
+      if (jobId) {
+        recoveredJobIds.add(jobId);
+      }
+      recoveredEntries.push(entry);
+    } else {
+      retainedEntries.push(entry);
+    }
+  }
+  return { recoveredJobs, recoveredEntries, retainedEntries };
 }

--- a/src/commands/doctor/cron/store-migration.ts
+++ b/src/commands/doctor/cron/store-migration.ts
@@ -721,7 +721,7 @@ export function recoverQuarantinedCronScheduleJobs(
       retainedEntries.push(entry);
       continue;
     }
-    const candidate = structuredClone(job) as Record<string, unknown>;
+    const candidate = structuredClone(job);
     const jobId = restoredCronJobId(candidate);
     if (jobId && (activeJobIds.has(jobId) || recoveredJobIds.has(jobId))) {
       // The operator already recreated this automation (or a duplicate entry

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -15,6 +15,7 @@ import { normalizeCronCommandArgv, normalizeCronPayload } from "./normalize-payl
 import { snapshotOwnCronRecord } from "./own-record.js";
 import { parseAbsoluteTimeMs } from "./parse.js";
 import { normalizeCronRuntimeAuthority } from "./runtime-authority.js";
+import { normalizeRecognizedCronScheduleKind } from "./schedule-kind.js";
 import { coerceFiniteScheduleNumber } from "./schedule-number.js";
 import {
   normalizeCronScheduledToolCallerOrigin,
@@ -45,15 +46,7 @@ const DEFAULT_OPTIONS: NormalizeOptions = {
 
 function coerceSchedule(schedule: UnknownRecord) {
   const next = snapshotOwnCronRecord(schedule);
-  const rawKind = normalizeLowercaseStringOrEmpty(next.kind);
-  const kind =
-    rawKind === "at" ||
-    rawKind === "every" ||
-    rawKind === "cron" ||
-    rawKind === "on-exit" ||
-    rawKind === "stream"
-      ? rawKind
-      : undefined;
+  const kind = normalizeRecognizedCronScheduleKind(next.kind);
   const exprRaw = normalizeOptionalString(next.expr) ?? "";
   const timezone = normalizeOptionalString(next.tz);
   const commandRaw = normalizeOptionalString(next.command) ?? "";

--- a/src/cron/persisted-shape.ts
+++ b/src/cron/persisted-shape.ts
@@ -6,7 +6,7 @@ import {
 import { asRecord } from "@openclaw/normalization-core/record-coerce";
 import { compileSafeRegex } from "../security/safe-regex.js";
 import { parseAbsoluteTimeMs } from "./parse.js";
-import { CRON_SCHEDULE_KINDS, type CronScheduleKind } from "./schedule-kind.js";
+import { isCanonicalCronScheduleKind } from "./schedule-kind.js";
 import { isSystemOwnedCronPayloadKind, type CronJobState } from "./types.js";
 
 const CRON_STATE_TIMESTAMP_FIELDS = [
@@ -87,7 +87,7 @@ export function getInvalidPersistedCronJobReason(
   }
   const scheduleRecord = schedule as Record<string, unknown>;
   const scheduleKind = scheduleRecord.kind;
-  if (!CRON_SCHEDULE_KINDS.includes(scheduleKind as CronScheduleKind)) {
+  if (!isCanonicalCronScheduleKind(scheduleKind)) {
     return "invalid-schedule";
   }
   if (scheduleKind === "at") {

--- a/src/cron/persisted-shape.ts
+++ b/src/cron/persisted-shape.ts
@@ -6,6 +6,7 @@ import {
 import { asRecord } from "@openclaw/normalization-core/record-coerce";
 import { compileSafeRegex } from "../security/safe-regex.js";
 import { parseAbsoluteTimeMs } from "./parse.js";
+import { CRON_SCHEDULE_KINDS, type CronScheduleKind } from "./schedule-kind.js";
 import { isSystemOwnedCronPayloadKind, type CronJobState } from "./types.js";
 
 const CRON_STATE_TIMESTAMP_FIELDS = [
@@ -86,13 +87,7 @@ export function getInvalidPersistedCronJobReason(
   }
   const scheduleRecord = schedule as Record<string, unknown>;
   const scheduleKind = scheduleRecord.kind;
-  if (
-    scheduleKind !== "at" &&
-    scheduleKind !== "every" &&
-    scheduleKind !== "cron" &&
-    scheduleKind !== "on-exit" &&
-    scheduleKind !== "stream"
-  ) {
+  if (!CRON_SCHEDULE_KINDS.includes(scheduleKind as CronScheduleKind)) {
     return "invalid-schedule";
   }
   if (scheduleKind === "at") {

--- a/src/cron/schedule-kind.ts
+++ b/src/cron/schedule-kind.ts
@@ -2,7 +2,7 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 
 /** Schedule kinds a persisted cron row may carry. */
-export const CRON_SCHEDULE_KINDS = ["at", "every", "cron", "on-exit", "stream"] as const;
+const CRON_SCHEDULE_KINDS = ["at", "every", "cron", "on-exit", "stream"] as const;
 
 export type CronScheduleKind = (typeof CRON_SCHEDULE_KINDS)[number];
 

--- a/src/cron/schedule-kind.ts
+++ b/src/cron/schedule-kind.ts
@@ -6,6 +6,17 @@ export const CRON_SCHEDULE_KINDS = ["at", "every", "cron", "on-exit", "stream"] 
 
 export type CronScheduleKind = (typeof CRON_SCHEDULE_KINDS)[number];
 
+const RECOGNIZED_CRON_SCHEDULE_KIND_BY_NORMALIZED: ReadonlyMap<string, CronScheduleKind> = new Map(
+  CRON_SCHEDULE_KINDS.map((kind) => [kind, kind] as const),
+);
+
+/** Returns true only for the exact canonical schedule kinds. */
+export function isCanonicalCronScheduleKind(value: unknown): boolean {
+  return (
+    typeof value === "string" && RECOGNIZED_CRON_SCHEDULE_KIND_BY_NORMALIZED.get(value) === value
+  );
+}
+
 /**
  * Resolves a recognized schedule kind from case or whitespace variants.
  *
@@ -15,8 +26,5 @@ export type CronScheduleKind = (typeof CRON_SCHEDULE_KINDS)[number];
  * sides agree on which kinds are recognized.
  */
 export function normalizeRecognizedCronScheduleKind(value: unknown): CronScheduleKind | undefined {
-  const kind = normalizeLowercaseStringOrEmpty(value);
-  return CRON_SCHEDULE_KINDS.includes(kind as CronScheduleKind)
-    ? (kind as CronScheduleKind)
-    : undefined;
+  return RECOGNIZED_CRON_SCHEDULE_KIND_BY_NORMALIZED.get(normalizeLowercaseStringOrEmpty(value));
 }

--- a/src/cron/schedule-kind.ts
+++ b/src/cron/schedule-kind.ts
@@ -1,0 +1,22 @@
+/** Canonical cron schedule-kind vocabulary shared by input normalization and validation. */
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+
+/** Schedule kinds a persisted cron row may carry. */
+export const CRON_SCHEDULE_KINDS = ["at", "every", "cron", "on-exit", "stream"] as const;
+
+export type CronScheduleKind = (typeof CRON_SCHEDULE_KINDS)[number];
+
+/**
+ * Resolves a recognized schedule kind from case or whitespace variants.
+ *
+ * The public cron input path and doctor migration both canonicalize these
+ * variants before validation, while the strict persisted-shape validator only
+ * accepts the exact canonical kinds. Keeping the vocabulary here ensures both
+ * sides agree on which kinds are recognized.
+ */
+export function normalizeRecognizedCronScheduleKind(value: unknown): CronScheduleKind | undefined {
+  const kind = normalizeLowercaseStringOrEmpty(value);
+  return CRON_SCHEDULE_KINDS.includes(kind as CronScheduleKind)
+    ? (kind as CronScheduleKind)
+    : undefined;
+}

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -41,7 +41,11 @@ export type {
   LoadedCronStore,
   QuarantinedCronConfigJob,
 } from "./store/types.js";
-export { loadCronQuarantinedJobs, saveCronQuarantinedJobs } from "./store/quarantine.js";
+export {
+  loadCronQuarantinedJobs,
+  saveCronQuarantinedJobs,
+  deleteCronQuarantinedJobs,
+} from "./store/quarantine.js";
 
 const MAX_TRACKED_CRON_STORE_REVISIONS = 64;
 const cronStoreRevisions = new Map<string, number>();

--- a/src/cron/store/quarantine.ts
+++ b/src/cron/store/quarantine.ts
@@ -78,3 +78,20 @@ export function saveCronQuarantinedJobs(params: {
 
   store.registerLegacyMany(records);
 }
+
+/** Deletes recovered quarantine records after their jobs rejoin the active store. */
+export function deleteCronQuarantinedJobs(params: {
+  storePath: string;
+  entries: readonly (QuarantinedCronConfigJob | CronQuarantinedJob)[];
+}): void {
+  if (params.entries.length === 0) {
+    return;
+  }
+  const store = createSqliteAuditRecordStore<CronQuarantinedJob>({
+    scope: cronQuarantineScope(params.storePath),
+    maxEntries: Number.MAX_SAFE_INTEGER,
+  });
+  for (const entry of params.entries) {
+    store.delete(cronQuarantineEntryKey(entry));
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes #133347.

The 2026.8.1 legacy cron store migration quarantined valid legacy rows as `invalid-schedule`, silently removing enabled recurring automations from the active scheduler inventory.

Two defects combined:

1. **Normalization asymmetry (future imports):** the public cron input path (`coerceSchedule` in `src/cron/normalize.ts`) canonicalizes recognized schedule kinds (case/whitespace variants like `Cron`, ` every `, `Stream`) before validation, but the doctor migration (`normalizeStoredCronJobs`) validated raw rows against the strict persisted-shape check (`getInvalidPersistedCronJobReason`) without applying the same canonicalization. Rows that the installed schedule validator accepts were quarantined during the legacy JSON → SQLite migration. The same asymmetry existed for stream schedule `mode` values (`Line`/`Match`).
2. **No recovery (already-affected users):** rows quarantined by that defect live in the persisted SQLite quarantine (`diagnostic_events`), and no repair path ever fed them back through validation. Doctor only displayed them ("Review or repair quarantined rows"), and the gateway startup preflight (`repairLegacyCronStoreWithoutPrompt` with `onlyIfLegacyDetected`) skipped repair entirely once the legacy JSON files were archived. Affected users stayed broken even after upgrading past the migration defect.

## Changes

- `src/cron/schedule-kind.ts` (new): the recognized schedule-kind vocabulary (`at`/`every`/`cron`/`on-exit`/`stream`) shared by input normalization (`coerceSchedule`), the strict persisted-shape validator, and doctor migration — one contract instead of three duplicated lists.
- `src/commands/doctor/cron/store-migration.ts`: canonicalize recognized schedule kinds and stream modes before strict validation during migration (prevents future bad quarantines); add `recoverQuarantinedCronScheduleJobs`, which rehydrates only `invalid-schedule` entries whose job canonicalizes and passes the existing strict validator plus the SQLite persist gate, preserving id, enabled state, runtime state, and `updatedAtMs`. Entries whose id already exists in the active store stay quarantined (the operator already recreated them); genuinely malformed rows are preserved untouched.
- `src/commands/doctor/cron/legacy-repair.ts`: wire recovery into `applyLegacyCronStoreRepair`; load persisted quarantine in the repair state so the gateway startup preflight (`onlyIfLegacyDetected`) also runs when recoverable rows exist. Recovered SQLite quarantine records are deleted only after the active store write commits, so a crash cannot lose a row; a rerun deduplicates by id.
- `src/commands/doctor/cron/index.ts`: preview and prompt for recovery in the interactive doctor flow, including the previously-unreachable empty-active-store case.
- `src/cron/store/quarantine.ts` / `store.ts`: `deleteCronQuarantinedJobs` for recovered records (keyed by the same content hash used on write).

## Evidence

**Pre-fix source repro (main @ `4bc25d7a`):** for each of `Cron` / `" cron "` / `Every` / `Stream` schedule-kind variants, a local repro suite confirmed `normalizeCronJobInput` accepts and canonicalizes the row while `normalizeStoredCronJobs` quarantines the identical definition as `invalid-schedule` (12/12 repro assertions passed) — matching the incident report where preserved definitions re-validate 48/48 under the installed release.

**After-fix end-to-end migrations (this branch, `68b14874` (evidence captured at `cc0f8b43`)):**

```text
✓ src/commands/doctor/cron/index.test.ts > maybeRepairLegacyCronStore quarantine recovery >
    recovers quarantined invalid-schedule rows whose schedule kinds now canonicalize (#133347)  151ms
✓ src/commands/doctor/cron/index.test.ts > maybeRepairLegacyCronStore quarantine recovery >
    recovers quarantined rows even when the active store is empty (#133347)                    163ms
✓ src/commands/doctor/cron/legacy-repair.test.ts >
    repairs recoverable quarantined rows without legacy files on the startup path (#133347)   165ms
```

The first regression seeds a SQLite quarantine with four rows — a recoverable `Cron`-variant (with preserved runtime state `nextRunAtMs: 123`), a variant whose id the operator already recreated, a genuinely unrecognized `daily` kind, and a non-schedule `missing-payload` row — then runs the real doctor repair flow. Traces asserted on the persisted SQLite store: the variant row returns to the active store with canonical `kind: "cron"`, `enabled: true`, and its preserved runtime state; the recreated id is not duplicated; exactly the three unrecoverable rows remain in quarantine; the operator-visible change reads `Recovered 1 quarantined automation whose schedule kind normalized to a canonical form.` The second covers the incident shape (empty active store, all rows quarantined). The third drives the gateway startup preflight path that previously skipped repair entirely, and asserts a second run is a no-op (idempotent).

**Full validation:**

```text
vitest commands shard (doctor/):      38 files, 536 tests passed
vitest cron shard:                   197 files, 2755 tests passed
vitest unit-fast (doctor/cron/):      5 files,  72 tests passed
oxlint / oxfmt on changed files:      clean
tsgo core typecheck:                  clean
check-database-first-legacy-stores:   passed
```

## Notes

- Recovery semantics follow the ClawSweeper review recommendation ("revalidate and restore only recognized invalid-schedule quarantine records"): the strict validator is unchanged, only previously-quarantined rows that now provably pass it are rehydrated, and no quarantine entry is ever rewritten or dropped without recovery. Whether doctor may reactivate validated quarantined automations is flagged for maintainer acceptance in the review; this branch implements the recommended boundary.
- The broader operator-alerting/inventory-count guardrails requested in the issue remain intentionally out of scope (product-policy decisions).

