### PR TITLE
fix(openrouter): reject malformed catalog envelopes

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1917,7 +1917,7 @@ src/agents/model-fallback-attempt.ts	1
 src/agents/model-fallback-runner.ts	2
 src/agents/model-provider-auth.ts	4
 src/agents/model-provider-auth.worker.ts	1
-src/agents/model-scan.ts	4
+src/agents/model-scan.ts	3
 src/agents/model-selection-shared.ts	1
 src/agents/model-tool-support.ts	1
 src/agents/models-config-state.ts	1

--- a/extensions/openrouter/video-generation-provider.test.ts
+++ b/extensions/openrouter/video-generation-provider.test.ts
@@ -376,10 +376,14 @@ describe("openrouter video generation provider", () => {
     expect(rows?.map((row) => row.model)).toEqual(["google/veo-3.1"]);
   });
 
-  it("returns an empty catalog for a malformed OpenRouter video catalog envelope", async () => {
-    fetchWithTimeoutGuardedMock.mockResolvedValueOnce(releasedJson(null));
+  it("does not cache a malformed OpenRouter video catalog envelope", async () => {
+    fetchWithTimeoutGuardedMock.mockResolvedValueOnce(releasedJson({})).mockResolvedValueOnce(
+      releasedJson({
+        data: [{ id: "google/veo-3.1", name: "Veo 3.1" }],
+      }),
+    );
 
-    const rows = await listOpenRouterVideoModelCatalog({
+    const ctx = {
       config: {} as never,
       env: {},
       resolveProviderApiKey: () => ({
@@ -392,9 +396,15 @@ describe("openrouter video generation provider", () => {
         mode: "api_key" as const,
         source: "env" as const,
       }),
-    });
+    };
 
-    expect(rows).toEqual([]);
+    await expect(listOpenRouterVideoModelCatalog(ctx)).rejects.toThrow(
+      /OpenRouter video models request failed.*malformed JSON response/,
+    );
+    await expect(listOpenRouterVideoModelCatalog(ctx)).resolves.toMatchObject([
+      { model: "google/veo-3.1" },
+    ]);
+    expect(fetchWithTimeoutGuardedMock).toHaveBeenCalledTimes(2);
   });
 
   it("lets configured auth replace the OpenRouter catalog default", async () => {

--- a/extensions/openrouter/video-model-catalog.ts
+++ b/extensions/openrouter/video-model-catalog.ts
@@ -7,7 +7,7 @@ import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runt
 import { getCachedLiveCatalogValue } from "openclaw/plugin-sdk/provider-catalog-shared";
 import {
   assertOkOrThrowHttpError,
-  readProviderJsonResponse,
+  readProviderJsonArrayFieldResponse,
   resolveProviderHttpRequestConfig,
   sanitizeConfiguredModelProviderRequest,
 } from "openclaw/plugin-sdk/provider-http";
@@ -91,10 +91,6 @@ function normalizeStringRecord(value: unknown): Record<string, string> | undefin
     }
   }
   return Object.keys(record).length > 0 ? record : undefined;
-}
-
-function isOpenRouterVideoModel(value: unknown): value is OpenRouterVideoModel {
-  return isRecord(value);
 }
 
 function buildOpenRouterVideoModeCapabilities(params: {
@@ -189,13 +185,12 @@ function buildOpenRouterVideoModelCapabilities(
 }
 
 function projectOpenRouterVideoModelsToCatalogEntries(
-  payload: unknown,
+  models: unknown[],
 ): Array<UnifiedModelCatalogEntry<OpenRouterVideoModelCatalogCapabilities>> {
   const entries: Array<UnifiedModelCatalogEntry<OpenRouterVideoModelCatalogCapabilities>> = [];
   const seen = new Set<string>();
-  const models = isRecord(payload) && Array.isArray(payload.data) ? payload.data : [];
   for (const model of models) {
-    if (!isOpenRouterVideoModel(model)) {
+    if (!isRecord(model)) {
       continue;
     }
     const id = normalizeOptionalString(model.id);
@@ -269,7 +264,7 @@ async function fetchOpenRouterVideoModels(params: {
   timeoutMs: number;
   allowPrivateNetwork: boolean;
   dispatcherPolicy: OpenRouterVideoDispatcherPolicy;
-}): Promise<unknown> {
+}): Promise<unknown[]> {
   return await getCachedLiveCatalogValue({
     keyParts: [
       "openrouter",
@@ -290,9 +285,10 @@ async function fetchOpenRouterVideoModels(params: {
       });
       try {
         await assertOkOrThrowHttpError(response, "OpenRouter video models request failed");
-        return await readProviderJsonResponse<unknown>(
+        return await readProviderJsonArrayFieldResponse(
           response,
           "OpenRouter video models request failed",
+          "data",
         );
       } finally {
         await release();

--- a/src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts
+++ b/src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts
@@ -271,6 +271,76 @@ describe("openrouter-model-capabilities", () => {
     });
   });
 
+  it.each([
+    ["missing data", {}],
+    ["non-array data", { data: {} }],
+  ])("preserves cached capabilities when a refresh has %s", async (_label, malformedPayload) => {
+    await withOpenRouterStateDir(async () => {
+      const modelId = "acme/healthy-model";
+      const fetchSpy = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: [
+                {
+                  id: modelId,
+                  name: "Healthy Model",
+                  context_length: 8192,
+                },
+              ],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify(malformedPayload), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      vi.stubGlobal("fetch", fetchSpy);
+
+      const writer = await importOpenRouterModelCapabilities(`malformed-writer-${_label}`);
+      await writer.loadOpenRouterModelCapabilities(modelId);
+      await writer.loadOpenRouterModelCapabilities("acme/new-model");
+
+      expect(writer.getOpenRouterModelCapabilities(modelId)?.name).toBe("Healthy Model");
+      const reader = await importOpenRouterModelCapabilities(`malformed-reader-${_label}`);
+      expect(reader.getOpenRouterModelCapabilities(modelId)?.name).toBe("Healthy Model");
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("treats an explicit empty catalog as an authoritative replacement", async () => {
+    await withOpenRouterStateDir(async () => {
+      const modelId = "acme/removed-model";
+      const fetchSpy = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: [{ id: modelId, name: "Removed Model", context_length: 8192 }],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ data: [] }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      vi.stubGlobal("fetch", fetchSpy);
+
+      const module = await importOpenRouterModelCapabilities("authoritative-empty");
+      await module.loadOpenRouterModelCapabilities(modelId);
+      await module.loadOpenRouterModelCapabilities("acme/new-model");
+
+      expect(module.getOpenRouterModelCapabilities(modelId)).toBeUndefined();
+    });
+  });
+
   it("preserves explicit OpenRouter tool support metadata", async () => {
     await withOpenRouterStateDir(async () => {
       vi.stubGlobal(

--- a/src/agents/embedded-agent-runner/openrouter-model-capabilities.ts
+++ b/src/agents/embedded-agent-runner/openrouter-model-capabilities.ts
@@ -20,19 +20,16 @@
 
 import { parseStrictFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { cancelUnreadResponseBody, readResponseWithLimit } from "../../infra/http-body.js";
+import { cancelUnreadResponseBody } from "../../infra/http-body.js";
 import { resolveProxyFetchFromEnv } from "../../infra/net/proxy-fetch.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { createCorePluginStateSyncKeyedStore } from "../../plugin-state/plugin-state-store.js";
+import { readProviderJsonArrayFieldResponse } from "../provider-http-errors.js";
 
 const log = createSubsystemLogger("openrouter-model-capabilities");
 
 const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
 const FETCH_TIMEOUT_MS = 10_000;
-// Cap the catalog body so an untrusted/oversized OpenRouter response cannot force
-// the runtime to buffer an unbounded payload before parsing. Mirrors the bound
-// applied to the sibling pricing-cache endpoint (16 MiB).
-const OPENROUTER_MODELS_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 const SQLITE_CACHE_OWNER_ID = "core:openrouter-model-capabilities";
 const SQLITE_CACHE_NAMESPACE = "models.v3";
 const SQLITE_CACHE_MAX_ENTRIES = 10_000;
@@ -197,15 +194,19 @@ async function doFetch(): Promise<void> {
       return;
     }
 
-    const bytes = await readResponseWithLimit(response, OPENROUTER_MODELS_RESPONSE_MAX_BYTES, {
-      onOverflow: ({ size }) => new Error(`OpenRouter models response too large: ${size} bytes`),
-    });
-    const data = JSON.parse(bytes.toString("utf8")) as { data?: OpenRouterApiModel[] };
-    const models = data.data ?? [];
+    const models = await readProviderJsonArrayFieldResponse(
+      response,
+      "OpenRouter models response",
+      "data",
+    );
     const map = new Map<string, OpenRouterModelCapabilities>();
 
-    for (const model of models) {
-      if (!model.id) {
+    for (const value of models) {
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        continue;
+      }
+      const model = value as OpenRouterApiModel;
+      if (typeof model.id !== "string" || !model.id) {
         continue;
       }
       map.set(model.id, parseModel(model));

--- a/src/agents/model-scan.test.ts
+++ b/src/agents/model-scan.test.ts
@@ -242,7 +242,7 @@ describe("scanOpenRouterModels", () => {
     );
 
     await expect(scanOpenRouterModels({ fetchImpl, probe: false })).rejects.toThrow(
-      /OpenRouter \/models response too large/,
+      /OpenRouter \/models: JSON response exceeds 16777216 bytes/,
     );
 
     // The reader stopped early instead of draining an unbounded stream, and
@@ -262,9 +262,21 @@ describe("scanOpenRouterModels", () => {
     );
 
     await expect(scanOpenRouterModels({ fetchImpl, probe: false })).rejects.toThrow(
-      /OpenRouter \/models response is malformed JSON/,
+      /OpenRouter \/models: malformed JSON response/,
     );
   });
+
+  it.each([{}, { data: {} }, { data: null }])(
+    "rejects a malformed catalog envelope",
+    async (payload) => {
+      await expect(
+        scanOpenRouterModels({
+          fetchImpl: createFetchFixture(payload),
+          probe: false,
+        }),
+      ).rejects.toThrow(/OpenRouter \/models.*malformed JSON response/);
+    },
+  );
 
   it("requires an API key when probing", async () => {
     const fetchImpl = createFetchFixture({ data: [] });

--- a/src/agents/model-scan.ts
+++ b/src/agents/model-scan.ts
@@ -20,7 +20,7 @@ import {
 import pMap from "p-map";
 import { Type } from "typebox";
 import { formatErrorMessage } from "../infra/errors.js";
-import { cancelUnreadResponseBody, readResponseWithLimit } from "../infra/http-body.js";
+import { cancelUnreadResponseBody } from "../infra/http-body.js";
 /**
  * Scans remote provider model catalogs for configured providers.
  */
@@ -28,6 +28,7 @@ import "../llm/ai-transport-host.js";
 import type { Context, Model, Tool } from "../llm/types.js";
 import { runAbortableTimeout } from "../node-host/with-timeout.js";
 import { inferParamBFromIdOrName } from "../shared/model-param-b.js";
+import { readProviderJsonArrayFieldResponse } from "./provider-http-errors.js";
 
 const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
 const DEFAULT_TIMEOUT_MS = 12_000;
@@ -183,26 +184,6 @@ function isFreeOpenRouterModel(entry: OpenRouterModelMeta): boolean {
   return entry.pricing.prompt === 0 && entry.pricing.completion === 0;
 }
 
-// Reads the OpenRouter /models success body under a byte cap before JSON.parse.
-// The success path was previously buffered with an unbounded res.json(); a faulty
-// or hostile provider could stream an effectively endless document and exhaust
-// memory. readResponseWithLimit caps the read, cancels the stream on overflow,
-// and bounds idle stalls with the call's existing timeout.
-async function readOpenRouterModelsJson(response: Response, timeoutMs: number): Promise<unknown> {
-  const buffer = await readResponseWithLimit(response, OPENROUTER_MODELS_BODY_MAX_BYTES, {
-    chunkTimeoutMs: timeoutMs,
-    onOverflow: ({ size, maxBytes }) =>
-      new Error(`OpenRouter /models response too large: ${size} bytes (limit ${maxBytes} bytes)`),
-    onIdleTimeout: ({ chunkTimeoutMs }) =>
-      new Error(`OpenRouter /models response stalled after ${chunkTimeoutMs}ms`),
-  });
-  try {
-    return JSON.parse(buffer.toString("utf8")) as unknown;
-  } catch (cause) {
-    throw new Error("OpenRouter /models response is malformed JSON", { cause });
-  }
-}
-
 async function fetchOpenRouterModels(
   fetchImpl: typeof fetch,
   timeoutMs: number,
@@ -220,8 +201,17 @@ async function fetchOpenRouterModels(
         if (!res.ok) {
           throw new Error(`OpenRouter /models failed: HTTP ${res.status}`);
         }
-        const payload = (await readOpenRouterModelsJson(res, timeoutMs)) as { data?: unknown };
-        const entries = Array.isArray(payload.data) ? payload.data : [];
+        const entries = await readProviderJsonArrayFieldResponse(
+          res,
+          "OpenRouter /models",
+          "data",
+          {
+            maxBytes: OPENROUTER_MODELS_BODY_MAX_BYTES,
+            chunkTimeoutMs: timeoutMs,
+            onIdleTimeout: ({ chunkTimeoutMs }) =>
+              new Error(`OpenRouter /models response stalled after ${chunkTimeoutMs}ms`),
+          },
+        );
 
         return entries
           .map((entry) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where malformed successful OpenRouter catalog responses could be treated as authoritative empty catalogs. A missing `data` field could erase a healthy derived capability cache, model scans could silently report zero models, and video discovery could cache the false empty result.

## Why This Change Was Made

All three OpenRouter catalog boundaries now use the canonical bounded `readProviderJsonArrayFieldResponse(...)` helper and require the documented top-level `data` array before projecting rows or mutating caches. Explicit `{ "data": [] }` responses remain authoritative empty catalogs, and malformed individual video rows remain skippable.

This changes no SQLite schema, representation, transaction, namespace, retention, TTL, retry, cache-key, configuration, dependency, Plugin SDK, or public API semantics. It only rejects malformed remote envelopes before the existing cache writers.

## User Impact

Operators keep the last healthy OpenRouter capability cache when a refresh response is malformed. Model scans surface the provider contract failure instead of silently reporting no models, and video catalog discovery retries after a malformed response instead of retaining it.

## Evidence

- Pre-fix capability reproduction:
  - healthy cached model: `Healthy Model`
  - refresh with `{}`: in-memory result became `undefined`; fresh import/SQLite result became `undefined`
  - refresh with `{ "data": {} }`: survived only through an incidental iteration error rather than explicit envelope validation
- Post-fix capability proof: both malformed envelopes are rejected before mutation; the healthy model remains available in memory and after a fresh module import. Explicit `{ "data": [] }` still removes the prior derived row.
- Pre-fix scanner proof: `{}`, `{ "data": {} }`, and `{ "data": null }` each resolved to `[]`.
- Post-fix scanner proof: all three reject with a bounded malformed-JSON-response error.
- Pre-fix video proof: `{}` resolved to `[]` and occupied the live catalog cache.
- Post-fix video proof: `{}` rejects; the next request performs a second fetch and returns the valid model.
- Live contract check on August 30, 2026: `GET https://openrouter.ai/api/v1/models` returned a top-level object with a `data` array containing 396 rows.
- Official contracts:
  - https://openrouter.ai/docs/api/api-reference/models/list-all-models-and-their-properties
  - https://openrouter.ai/docs/api/api-reference/video-generation/list-all-video-generation-models
- Focused tests:
  - `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts` (`12 passed`)
  - `node scripts/run-vitest.mjs src/agents/model-scan.test.ts` (`17 passed`)
  - `node scripts/run-vitest.mjs extensions/openrouter/video-generation-provider.test.ts` (`22 passed`)
  - `pnpm test:extension openrouter` (`210 passed`)
- Changed-surface checks:
  - `node scripts/check-changed.mjs --dry-run -- <changed paths>` passed and selected core, core-test, extension, and extension-test lanes.
  - `pnpm check:changed` passed through conflict, ratchet, formatting, contract, boundary, deadcode, core, and core-test typechecks. The extension typecheck then reproduced unrelated current-main Telegram errors because the shared local install has `grammy@1.45.1`/types `4.0.0` while the current lockfile requires `grammy@1.46.0`/types `5.0.0`; this PR changes no Telegram or dependency files.
  - `git diff --check` passed.
- Test audit: regressions assert cache survival/restart behavior, scanner failure, retry behavior, and valid-empty semantics at production boundaries; no test-only production seam was added.
- Autoreview: scoped clean, zero accepted/actionable findings, correctness `0.97`.
- Codex gate: personally inspected `openai/codex@5f49aba876922d6f2f55caa153bbb0ed1b46feba` at `codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; those CLI completion/config sections are unrelated to provider catalog semantics.
- Exact head before publication: `ab88299aa7f623030fda27c5964f98e7f549a72a`
- LOC:
  - production: `+32/-45` (net `-13`)
  - tests: `+99/-7` (net `+92`)
  - assertion-safety ratchet: `+1/-1`
