### PR TITLE
refactor: share compatible embedding batch polling

### DIFF
--- a/extensions/openai/embedding-batch.test.ts
+++ b/extensions/openai/embedding-batch.test.ts
@@ -201,13 +201,28 @@ describe("OpenAI embedding batch output", () => {
       name: "pending status",
       pollIntervalMs: 2_000,
       expectedWaits: [500],
-      retryFirstStatus: false,
+      statusSequence: [],
+      expectedStatusTimes: [],
+      advanceClock: true,
+      timeoutCause: undefined,
     },
     {
       name: "retry backoff",
       pollIntervalMs: 500,
       expectedWaits: [500, 500],
-      retryFirstStatus: true,
+      statusSequence: ["retry"],
+      expectedStatusTimes: [500],
+      advanceClock: false,
+      timeoutCause: 503,
+    },
+    {
+      name: "combined pending and retry backoff",
+      pollIntervalMs: 100,
+      expectedWaits: [100, 200, 400, 300],
+      statusSequence: ["pending", "retry", "pending"],
+      expectedStatusTimes: [100, 300, 700],
+      advanceClock: false,
+      timeoutCause: undefined,
     },
   ])("clamps $name waits to the remaining batch timeout", async (scenario) => {
     vi.useFakeTimers();
@@ -220,6 +235,7 @@ describe("OpenAI embedding batch output", () => {
         scenario.expectedWaits.includes(Number(timeout)),
       );
     let statusCalls = 0;
+    const statusTimes: number[] = [];
     const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = fetchInputUrl(input);
       if (url.endsWith("/files") && init?.method === "POST") {
@@ -230,7 +246,12 @@ describe("OpenAI embedding batch output", () => {
       }
       if (url.endsWith("/batches/batch-0")) {
         statusCalls += 1;
-        if (scenario.retryFirstStatus && statusCalls === 1) {
+        statusTimes.push(Date.now());
+        const nextStatus = scenario.statusSequence[statusCalls - 1];
+        if (nextStatus === "pending") {
+          return jsonResponse({ id: "batch-0", status: "in_progress" });
+        }
+        if (nextStatus === "retry") {
           return jsonResponse({ error: { message: "retry status" } }, 503);
         }
         return jsonResponse({ id: "batch-0", status: "completed", output_file_id: "output-0" });
@@ -267,14 +288,14 @@ describe("OpenAI embedding batch output", () => {
       pollIntervalMs: scenario.pollIntervalMs,
       timeoutMs: 1_000,
       debug: (message) => {
-        if (!scenario.retryFirstStatus && message.includes("batch-0 in_progress")) {
+        if (scenario.advanceClock && message.includes("batch-0 in_progress")) {
           vi.setSystemTime(500);
         }
       },
     });
     const rejection = expect(result).rejects.toMatchObject({
       message: "openai batch batch-0 timed out after 1000ms",
-      ...(scenario.retryFirstStatus ? { cause: { status: 503 } } : {}),
+      ...(scenario.timeoutCause ? { cause: { status: scenario.timeoutCause } } : {}),
     });
 
     for (const [index, waitMs] of scenario.expectedWaits.entries()) {
@@ -286,64 +307,84 @@ describe("OpenAI embedding batch output", () => {
       await vi.advanceTimersByTimeAsync(waitMs);
     }
     await rejection;
-    expect(statusCalls).toBe(scenario.retryFirstStatus ? 1 : 0);
+    if (scenario.timeoutCause === undefined) {
+      await expect(result).rejects.not.toHaveProperty("cause");
+    }
+    expect(statusCalls).toBe(scenario.expectedStatusTimes.length);
+    expect(statusTimes).toEqual(scenario.expectedStatusTimes);
   });
 
-  it("reads a completed error file before downloading successful output", async () => {
-    let outputFetched = false;
-    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = fetchInputUrl(input);
-      if (url.endsWith("/files") && init?.method === "POST") {
-        return jsonResponse({ id: "input-0" });
-      }
-      if (url.endsWith("/batches") && init?.method === "POST") {
-        return jsonResponse({
-          id: "batch-0",
-          status: "completed",
-          output_file_id: "output-0",
-          error_file_id: "error-0",
-        });
-      }
-      if (url.endsWith("/files/error-0/content")) {
-        return new Response(
-          JSON.stringify({
-            custom_id: "0",
-            response: { status_code: 500, message: "provider rejected request" },
-            error: null,
-          }),
-        );
-      }
-      if (url.endsWith("/files/output-0/content")) {
-        outputFetched = true;
-      }
-      return new Response("unexpected request", { status: 500 });
-    });
+  it.each(["create", "status", "failed"] as const)(
+    "reads a batch error file from %s before downloading successful output",
+    async (completionStage) => {
+      vi.useFakeTimers();
+      let outputFetched = false;
+      const terminal = {
+        id: "batch-0",
+        status: completionStage === "failed" ? "failed" : "completed",
+        output_file_id: "output-0",
+        error_file_id: "error-0",
+      };
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = fetchInputUrl(input);
+        if (url.endsWith("/files") && init?.method === "POST") {
+          return jsonResponse({ id: "input-0" });
+        }
+        if (url.endsWith("/batches") && init?.method === "POST") {
+          return jsonResponse(
+            completionStage === "create" ? terminal : { id: "batch-0", status: "in_progress" },
+          );
+        }
+        if (url.endsWith("/batches/batch-0")) {
+          return jsonResponse(terminal);
+        }
+        if (url.endsWith("/files/error-0/content")) {
+          return new Response(
+            JSON.stringify({
+              custom_id: "0",
+              response: { status_code: 500, message: "provider rejected request" },
+              error: null,
+            }),
+          );
+        }
+        if (url.endsWith("/files/output-0/content")) {
+          outputFetched = true;
+        }
+        return new Response("unexpected request", { status: 500 });
+      });
 
-    await expect(
-      runOpenAiEmbeddingBatches({
-        openAi: {
-          baseUrl: "https://openai-compatible.example/v1",
-          headers: { Authorization: "Bearer test" },
-          model: "text-embedding-3-small",
-          fetchImpl,
-        },
-        agentId: "main",
-        requests: [
-          {
-            custom_id: "0",
-            method: "POST",
-            url: "/v1/embeddings",
-            body: { model: "text-embedding-3-small", input: "payload" },
+      const rejection = expect(
+        runOpenAiEmbeddingBatches({
+          openAi: {
+            baseUrl: "https://openai-compatible.example/v1",
+            headers: { Authorization: "Bearer test" },
+            model: "text-embedding-3-small",
+            fetchImpl,
           },
-        ],
-        wait: true,
-        concurrency: 1,
-        pollIntervalMs: 1,
-        timeoutMs: 1_000,
-      }),
-    ).rejects.toThrow("openai batch batch-0 completed: provider rejected request");
-    expect(outputFetched).toBe(false);
-  });
+          agentId: "main",
+          requests: [
+            {
+              custom_id: "0",
+              method: "POST",
+              url: "/v1/embeddings",
+              body: { model: "text-embedding-3-small", input: "payload" },
+            },
+          ],
+          wait: true,
+          concurrency: 1,
+          pollIntervalMs: 1,
+          timeoutMs: 1_000,
+        }),
+      ).rejects.toThrow(`openai batch batch-0 ${terminal.status}: provider rejected request`);
+      await vi.advanceTimersByTimeAsync(1);
+      await rejection;
+      expect(outputFetched).toBe(false);
+      expect(fetchImpl).toHaveBeenCalledTimes(completionStage === "create" ? 3 : 4);
+      expect(
+        fetchImpl.mock.calls.filter(([input]) => fetchInputUrl(input).endsWith("/batches/batch-0")),
+      ).toHaveLength(completionStage === "create" ? 0 : 1);
+    },
+  );
 
   it("splits provider uploads by serialized JSONL byte cap", async () => {
     const requests: Parameters<typeof runOpenAiEmbeddingBatches>[0]["requests"] = Array.from(

--- a/extensions/openai/embedding-batch.ts
+++ b/extensions/openai/embedding-batch.ts
@@ -11,16 +11,14 @@ import {
   postJsonWithRetry,
   readEmbeddingBatchJsonl,
   resolveEmbeddingEndpointUrl,
-  resolveBatchCompletionFromStatus,
   resolveCompletedBatchResult,
   runEmbeddingBatchGroups,
   throwIfBatchCompletionError,
-  throwIfBatchTerminalFailure,
   type EmbeddingBatchExecutionParams,
   type EmbeddingBatchStatus,
-  type BatchCompletionResult,
   type ProviderBatchOutputLine,
   uploadBatchJsonlFile,
+  waitForEmbeddingBatch,
   withRemoteHttpResponse,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
@@ -207,23 +205,6 @@ async function readOpenAiBatchError(params: {
   }
 }
 
-function createOpenAiBatchPollBackoff(params: { pollIntervalMs: number; timeoutMs: number }): {
-  nextDelayMs: () => number;
-} {
-  const maxDelayMs = Math.max(
-    params.pollIntervalMs,
-    Math.min(params.timeoutMs, OPENAI_BATCH_MAX_POLL_BACKOFF_MS),
-  );
-  let delayMs = params.pollIntervalMs;
-  return {
-    nextDelayMs: () => {
-      const current = delayMs;
-      delayMs = Math.min(maxDelayMs, current * 2);
-      return current;
-    },
-  };
-}
-
 function formatOpenAiBatchProgress(status: OpenAiBatchStatus): string {
   const counts = status.request_counts;
   if (!counts || typeof counts.total !== "number") {
@@ -247,105 +228,6 @@ function isRetryableOpenAiBatchPollError(error: unknown): boolean {
         (status >= 500 && status <= 599))) ||
     /\b(ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN)\b|fetch failed|network error/i.test(message)
   );
-}
-
-async function waitForOpenAiBatch(params: {
-  openAi: OpenAiEmbeddingClient;
-  batchId: string;
-  wait: boolean;
-  pollIntervalMs: number;
-  timeoutMs: number;
-  debug?: (message: string, data?: Record<string, unknown>) => void;
-  initial?: OpenAiBatchStatus;
-}): Promise<BatchCompletionResult> {
-  const deadline = createProviderOperationDeadline({
-    label: `openai batch ${params.batchId}`,
-    timeoutMs: params.timeoutMs,
-  });
-  const pollBackoff = createOpenAiBatchPollBackoff(params);
-  let current: OpenAiBatchStatus | undefined = params.initial;
-  while (true) {
-    let status: OpenAiBatchStatus;
-    let statusSignal: AbortSignal | undefined;
-    try {
-      if (current) {
-        status = current;
-      } else {
-        statusSignal = AbortSignal.timeout(
-          resolveProviderOperationTimeoutMs({
-            deadline,
-            defaultTimeoutMs: params.timeoutMs,
-          }),
-        );
-        status = await fetchOpenAiBatchStatus({
-          openAi: params.openAi,
-          batchId: params.batchId,
-          signal: statusSignal,
-        });
-      }
-    } catch (error) {
-      if (statusSignal?.aborted) {
-        throw new Error(`openai batch ${params.batchId} timed out after ${params.timeoutMs}ms`, {
-          cause: error,
-        });
-      }
-      if (!params.wait || !isRetryableOpenAiBatchPollError(error)) {
-        throw error;
-      }
-      const delayMs = pollBackoff.nextDelayMs();
-      params.debug?.(
-        `openai batch ${params.batchId} status check failed: ${formatOpenAiBatchDiagnostic(error)}; waiting up to ${delayMs}ms`,
-      );
-      try {
-        await waitProviderOperationPollInterval({ deadline, pollIntervalMs: delayMs });
-        resolveProviderOperationTimeoutMs({ deadline, defaultTimeoutMs: params.timeoutMs });
-      } catch {
-        throw new Error(`openai batch ${params.batchId} timed out after ${params.timeoutMs}ms`, {
-          cause: error,
-        });
-      }
-      current = undefined;
-      continue;
-    }
-    const state = status.status ?? "unknown";
-    await throwIfBatchCompletionError({
-      provider: "openai",
-      status: { ...status, id: params.batchId },
-      readError: async (errorFileId) =>
-        await readOpenAiBatchError({
-          openAi: params.openAi,
-          errorFileId,
-        }),
-    });
-    if (state === "completed") {
-      return resolveBatchCompletionFromStatus({
-        provider: "openai",
-        batchId: params.batchId,
-        status,
-      });
-    }
-    await throwIfBatchTerminalFailure({
-      provider: "openai",
-      status: { ...status, id: params.batchId },
-      readError: async (errorFileId) =>
-        await readOpenAiBatchError({
-          openAi: params.openAi,
-          errorFileId,
-        }),
-    });
-    if (!params.wait) {
-      throw new Error(`openai batch ${params.batchId} still ${state}; wait disabled`);
-    }
-    const delayMs = pollBackoff.nextDelayMs();
-    params.debug?.(
-      `openai batch ${params.batchId} ${state}${formatOpenAiBatchProgress(
-        status,
-      )}; waiting up to ${delayMs}ms`,
-    );
-    await waitProviderOperationPollInterval({ deadline, pollIntervalMs: delayMs });
-    resolveProviderOperationTimeoutMs({ deadline, defaultTimeoutMs: params.timeoutMs });
-    current = undefined;
-  }
 }
 
 export async function runOpenAiEmbeddingBatches(
@@ -401,16 +283,36 @@ export async function runOpenAiEmbeddingBatches(
         provider: "openai",
         status: batchInfo,
         wait: params.wait,
-        waitForBatch: async () =>
-          await waitForOpenAiBatch({
-            openAi: params.openAi,
+        waitForBatch: async () => {
+          const openAi = params.openAi;
+          const wait = params.wait;
+          const debug = params.debug;
+          const deadline = createProviderOperationDeadline({
+            label: `openai batch ${batchId}`,
+            timeoutMs,
+          });
+          return await waitForEmbeddingBatch({
+            provider: "openai",
             batchId,
-            wait: params.wait,
+            wait,
             pollIntervalMs,
             timeoutMs,
-            debug: params.debug,
+            debug,
             initial: batchInfo,
-          }),
+            fetchStatus: (signal) => fetchOpenAiBatchStatus({ openAi, batchId, signal }),
+            resolveTimeoutMs: () =>
+              resolveProviderOperationTimeoutMs({ deadline, defaultTimeoutMs: timeoutMs }),
+            waitForPoll: (delayMs) =>
+              waitProviderOperationPollInterval({ deadline, pollIntervalMs: delayMs }),
+            readError: async (errorFileId) => await readOpenAiBatchError({ openAi, errorFileId }),
+            backoff: {
+              maxDelayMs: OPENAI_BATCH_MAX_POLL_BACKOFF_MS,
+              shouldRetry: isRetryableOpenAiBatchPollError,
+              formatError: formatOpenAiBatchDiagnostic,
+              formatProgress: formatOpenAiBatchProgress,
+            },
+          });
+        },
       });
 
       const errors: string[] = [];

--- a/extensions/voyage/embedding-batch.test.ts
+++ b/extensions/voyage/embedding-batch.test.ts
@@ -326,7 +326,9 @@ describe("voyage batch bounded reads", () => {
 
   it("normalizes and bounds a non-OK status diagnostic through the public runner", async () => {
     const streamed = streamingResponse({ chunkCount: 20, chunkSize: 1024 * 1024, status: 500 });
-    stubBatchFetch((stage) => (stage === "status" ? streamed.response : undefined));
+    const fetchMock = stubBatchFetch((stage) =>
+      stage === "status" ? streamed.response : undefined,
+    );
 
     await expect(runBatch()).rejects.toMatchObject({
       name: "ProviderHttpError",
@@ -335,6 +337,9 @@ describe("voyage batch bounded reads", () => {
     });
     expect(streamed.getReadCount()).toBeLessThan(20);
     expect(streamed.wasCanceled()).toBe(true);
+    expect(
+      fetchMock.mock.calls.filter(([input]) => fetchInputUrl(input).endsWith("/batches/batch-0")),
+    ).toHaveLength(1);
   });
 
   it("uses the shared output reader and stops after the expected result", async () => {

--- a/extensions/voyage/embedding-batch.ts
+++ b/extensions/voyage/embedding-batch.ts
@@ -10,16 +10,14 @@ import {
   postJsonWithRetry,
   readEmbeddingBatchJsonl,
   resolveEmbeddingEndpointUrl,
-  resolveBatchCompletionFromStatus,
   resolveCompletedBatchResult,
   runEmbeddingBatchGroups,
   throwIfBatchCompletionError,
-  throwIfBatchTerminalFailure,
   type EmbeddingBatchExecutionParams,
   type EmbeddingBatchStatus,
-  type BatchCompletionResult,
   type ProviderBatchOutputLine,
   uploadBatchJsonlFile,
+  waitForEmbeddingBatch,
   withRemoteHttpResponse,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
@@ -155,89 +153,6 @@ async function readVoyageBatchError(params: {
   }
 }
 
-async function waitForVoyageBatch(params: {
-  client: VoyageEmbeddingClient;
-  batchId: string;
-  wait: boolean;
-  pollIntervalMs: number;
-  timeoutMs: number;
-  debug?: (message: string, data?: Record<string, unknown>) => void;
-  initial?: VoyageBatchStatus;
-}): Promise<BatchCompletionResult> {
-  const deadline = createProviderOperationDeadline({
-    label: `voyage batch ${params.batchId}`,
-    timeoutMs: params.timeoutMs,
-  });
-  let current: VoyageBatchStatus | undefined = params.initial;
-  while (true) {
-    let status: VoyageBatchStatus;
-    if (current) {
-      status = current;
-    } else {
-      const signal = AbortSignal.timeout(
-        resolveProviderOperationTimeoutMs({
-          deadline,
-          defaultTimeoutMs: params.timeoutMs,
-        }),
-      );
-      try {
-        status = await fetchVoyageBatchStatus({
-          client: params.client,
-          batchId: params.batchId,
-          signal,
-        });
-      } catch (error) {
-        if (signal.aborted) {
-          throw new Error(`voyage batch ${params.batchId} timed out after ${params.timeoutMs}ms`, {
-            cause: error,
-          });
-        }
-        throw error;
-      }
-    }
-    const state = status.status ?? "unknown";
-    await throwIfBatchCompletionError({
-      provider: "voyage",
-      status: { ...status, id: params.batchId },
-      readError: async (errorFileId) =>
-        await readVoyageBatchError({
-          client: params.client,
-          errorFileId,
-        }),
-    });
-    if (state === "completed") {
-      return resolveBatchCompletionFromStatus({
-        provider: "voyage",
-        batchId: params.batchId,
-        status,
-      });
-    }
-    await throwIfBatchTerminalFailure({
-      provider: "voyage",
-      status: { ...status, id: params.batchId },
-      readError: async (errorFileId) =>
-        await readVoyageBatchError({
-          client: params.client,
-          errorFileId,
-        }),
-    });
-    if (!params.wait) {
-      throw new Error(`voyage batch ${params.batchId} still ${state}; wait disabled`);
-    }
-    const waitMs = Math.min(
-      params.pollIntervalMs,
-      resolveProviderOperationTimeoutMs({
-        deadline,
-        defaultTimeoutMs: params.timeoutMs,
-      }),
-    );
-    params.debug?.(`voyage batch ${params.batchId} ${state}; waiting ${waitMs}ms`);
-    await waitProviderOperationPollInterval({ deadline, pollIntervalMs: waitMs });
-    resolveProviderOperationTimeoutMs({ deadline, defaultTimeoutMs: params.timeoutMs });
-    current = undefined;
-  }
-}
-
 export async function runVoyageEmbeddingBatches(
   params: {
     client: VoyageEmbeddingClient;
@@ -280,16 +195,30 @@ export async function runVoyageEmbeddingBatches(
         provider: "voyage",
         status: batchInfo,
         wait: params.wait,
-        waitForBatch: async () =>
-          await waitForVoyageBatch({
-            client: params.client,
+        waitForBatch: async () => {
+          const client = params.client;
+          const wait = params.wait;
+          const debug = params.debug;
+          const deadline = createProviderOperationDeadline({
+            label: `voyage batch ${batchId}`,
+            timeoutMs,
+          });
+          return await waitForEmbeddingBatch({
+            provider: "voyage",
             batchId,
-            wait: params.wait,
+            wait,
             pollIntervalMs,
             timeoutMs,
-            debug: params.debug,
+            debug,
             initial: batchInfo,
-          }),
+            fetchStatus: (signal) => fetchVoyageBatchStatus({ client, batchId, signal }),
+            resolveTimeoutMs: () =>
+              resolveProviderOperationTimeoutMs({ deadline, defaultTimeoutMs: timeoutMs }),
+            waitForPoll: (delayMs) =>
+              waitProviderOperationPollInterval({ deadline, pollIntervalMs: delayMs }),
+            readError: async (errorFileId) => await readVoyageBatchError({ client, errorFileId }),
+          });
+        },
       });
 
       const errors: string[] = [];

--- a/packages/memory-host-sdk/src/engine-embeddings.ts
+++ b/packages/memory-host-sdk/src/engine-embeddings.ts
@@ -39,6 +39,7 @@ export {
   resolveCompletedBatchResult,
   throwIfBatchCompletionError,
   throwIfBatchTerminalFailure,
+  waitForEmbeddingBatch,
   type BatchCompletionResult,
 } from "./host/batch-status.js";
 export { uploadBatchJsonlFile } from "./host/batch-upload.js";

--- a/packages/memory-host-sdk/src/host/batch-status.ts
+++ b/packages/memory-host-sdk/src/host/batch-status.ts
@@ -82,3 +82,105 @@ export async function resolveCompletedBatchResult(params: {
   }
   return completed;
 }
+
+/**
+ * Share compatible status transitions while callers retain the canonical
+ * deadline and transport owners; only a supplied backoff policy retries reads.
+ */
+export async function waitForEmbeddingBatch<TStatus extends EmbeddingBatchStatus>(params: {
+  provider: string;
+  batchId: string;
+  wait: boolean;
+  pollIntervalMs: number;
+  timeoutMs: number;
+  debug?: (message: string, data?: Record<string, unknown>) => void;
+  initial?: TStatus;
+  fetchStatus: (signal: AbortSignal) => Promise<TStatus>;
+  resolveTimeoutMs: () => number;
+  waitForPoll: (delayMs: number) => Promise<void>;
+  readError: (errorFileId: string) => Promise<string | undefined>;
+  backoff?: {
+    maxDelayMs: number;
+    shouldRetry: (error: unknown) => boolean;
+    formatError: (error: unknown) => string;
+    formatProgress: (status: TStatus) => string;
+  };
+}): Promise<BatchCompletionResult> {
+  const label = `${params.provider} batch ${params.batchId}`;
+  const backoff = params.backoff;
+  const maxDelayMs = backoff
+    ? Math.max(params.pollIntervalMs, Math.min(params.timeoutMs, backoff.maxDelayMs))
+    : params.pollIntervalMs;
+  let nextPollDelayMs = params.pollIntervalMs;
+  const nextDelayMs = () => {
+    const delay = nextPollDelayMs;
+    nextPollDelayMs = Math.min(maxDelayMs, delay * 2);
+    return delay;
+  };
+  let current: TStatus | undefined = params.initial;
+  while (true) {
+    let status: TStatus;
+    let statusSignal: AbortSignal | undefined;
+    try {
+      if (current) {
+        status = current;
+      } else {
+        statusSignal = AbortSignal.timeout(params.resolveTimeoutMs());
+        status = await params.fetchStatus(statusSignal);
+      }
+    } catch (error) {
+      if (statusSignal?.aborted) {
+        throw new Error(`${label} timed out after ${params.timeoutMs}ms`, { cause: error });
+      }
+      if (!params.wait || !backoff?.shouldRetry(error)) {
+        throw error;
+      }
+      const delayMs = nextDelayMs();
+      params.debug?.(
+        `${label} status check failed: ${backoff.formatError(error)}; waiting up to ${delayMs}ms`,
+      );
+      try {
+        await params.waitForPoll(delayMs);
+        params.resolveTimeoutMs();
+      } catch {
+        throw new Error(`${label} timed out after ${params.timeoutMs}ms`, { cause: error });
+      }
+      current = undefined;
+      continue;
+    }
+    const state = status.status ?? "unknown";
+    await throwIfBatchCompletionError({
+      provider: params.provider,
+      status: { ...status, id: params.batchId },
+      readError: params.readError,
+    });
+    if (state === "completed") {
+      return resolveBatchCompletionFromStatus({
+        provider: params.provider,
+        batchId: params.batchId,
+        status,
+      });
+    }
+    await throwIfBatchTerminalFailure({
+      provider: params.provider,
+      status: { ...status, id: params.batchId },
+      readError: params.readError,
+    });
+    if (!params.wait) {
+      throw new Error(`${label} still ${state}; wait disabled`);
+    }
+    // Fixed polling resolves remaining time before logging; backoff logs its
+    // requested delay and lets the shared wait clamp it afterward.
+    const waitMs = backoff
+      ? nextDelayMs()
+      : Math.min(params.pollIntervalMs, params.resolveTimeoutMs());
+    params.debug?.(
+      backoff
+        ? `${label} ${state}${backoff.formatProgress(status)}; waiting up to ${waitMs}ms`
+        : `${label} ${state}; waiting ${waitMs}ms`,
+    );
+    await params.waitForPoll(waitMs);
+    params.resolveTimeoutMs();
+    current = undefined;
+  }
+}

--- a/src/plugin-sdk/memory-core-host-engine-embeddings.ts
+++ b/src/plugin-sdk/memory-core-host-engine-embeddings.ts
@@ -51,6 +51,7 @@ export {
   sanitizeEmbeddingCacheHeaders,
   throwIfBatchCompletionError,
   throwIfBatchTerminalFailure,
+  waitForEmbeddingBatch,
   uploadBatchJsonlFile,
   withRemoteHttpResponse,
 } from "../../packages/memory-host-sdk/src/engine-embeddings.js";


### PR DESCRIPTION
## What Problem This Solves

OpenAI and Voyage maintained parallel batch-polling loops for initial status, completion/error-file handling, terminal failures and polling deadlines. Keeping their shared transitions aligned required changing both implementations.

## Why This Change Was Made

One shared status loop now owns those transitions. Callers retain their deadline and HTTP owners; OpenAI supplies its existing bounded retry/backoff policy, while Voyage keeps fixed polling and immediate status-error propagation. Upload/create payloads, completion windows, byte/record bounds and output accounting remain unchanged. The change removes 69 production code lines (65 physical lines) and adds 46 test code lines.

## User Impact

No intended behavior change. Batch completion, error precedence, timeout causes, progress text and provider-specific retry behavior retain their contracts. The helper is exposed through the existing memory-host SDK seam. The existing release version synchronization pairs updated Voyage packages with a supporting host; no versions or storage formats change here.

## Evidence

- 62 baseline and 65 candidate focused cases passed, including combined pending/retry backoff, completion-error precedence, and Voyage's single failed status request.
- Strict real OpenAI batch comparison passed on Blacksmith Testbox for baseline ffc2292f3aae705edb429575681b53f8e8ae98ac and candidate 7496876e256d587af0fe5d5afbc173560066cbbd. Each batch completed two successful requests, returned both expected finite 1536-dimensional vectors, preserved input/output-file and custom-id accounting, and made zero ordinary embedding calls. Input/output files were deleted after terminal confirmation; the owned Testbox was stopped. [Testbox lifecycle run](https://github.com/openclaw/openclaw/actions/runs/34022620253).
- The earlier reported provider input-file failure did not recur. Two initial attempts in this verification failed in the external observer (fetch-dispatcher mismatch, then output-clone lifetime); both were reproduced with credential-free loopback, corrected in the proof driver only, and preserved as failed receipts. No production retry, timeout, poller or assertion was weakened.
- All 36 selected repository checks passed, including four type lanes, SDK/unused-export checks, lint and runtime guards. Normal pnpm build passed all 16 phases in 6m 25s.
- Fresh full-candidate P2 review is clean. Final source tree cd3d855be3c94cb485a7cbe7a3397defdc35e149 matches the live-tested candidate and remains clean.
- Voyage has focused transport/deadline coverage; no authenticated Voyage batch run is claimed. There are no schema, store, cache-key, vector-format or migration changes.
