### PR TITLE
docs: clarify provider normalization ownership

### DIFF
--- a/docs/plugins/architecture-internals.md
+++ b/docs/plugins/architecture-internals.md
@@ -273,7 +273,7 @@ listed here.
 | _(built-in model lookup)_         | OpenClaw tries the normal registry/catalog path first                                                          | _(not a plugin hook)_                                                                                                                         |
 | `normalizeModelId`                | Normalize legacy or preview model-id aliases before lookup                                                     | Provider owns alias cleanup before canonical model resolution                                                                                 |
 | `normalizeTransport`              | Normalize provider-family `api` / `baseUrl` before generic model assembly                                      | Provider owns transport cleanup for custom provider ids in the same transport family                                                          |
-| `normalizeConfig`                 | Normalize `models.providers.<id>` before runtime/provider resolution                                           | Provider needs config cleanup that should live with the plugin; bundled Google-family helpers also backstop supported Google config entries   |
+| `normalizeConfig`                 | Normalize `models.providers.<id>` before runtime/provider resolution                                           | Provider needs config cleanup that should live with the owning plugin                                                                         |
 | `applyNativeStreamingUsageCompat` | Apply native streaming-usage compat rewrites to config providers                                               | Provider needs endpoint-driven native streaming usage metadata fixes                                                                          |
 | `resolveConfigApiKey`             | Resolve env-marker auth for config providers before runtime auth loading                                       | Providers expose their own env-marker API-key resolution hooks                                                                                |
 | `resolveSyntheticAuth`            | Surface local/self-hosted or config-backed auth without persisting plaintext                                   | Provider can operate with a synthetic/local credential marker                                                                                 |
@@ -312,13 +312,25 @@ listed here.
 | `validateReplayTurns`             | Final replay-turn validation or reshaping before the embedded runner                                           | Provider transport needs stricter turn validation after generic sanitation                                                                    |
 | `onModelSelected`                 | Run provider-owned post-selection side effects                                                                 | Provider needs telemetry or provider-owned state when a model becomes active                                                                  |
 
-`normalizeModelId`, `normalizeTransport`, and `normalizeConfig` first check the
-matched provider plugin, then fall through other hook-capable provider plugins
-until one actually changes the model id or transport/config. That keeps
-alias/compat provider shims working without requiring the caller to know which
-bundled plugin owns the rewrite. If no provider hook rewrites a supported
-Google-family config entry, the bundled Google config normalizer still applies
-that compatibility cleanup.
+Normalization dispatch is hook-specific:
+
+- `normalizeModelId` uses the matched provider hook's non-empty result. If none
+  is returned, OpenClaw applies manifest-declared model-ID normalization; it does
+  not try other providers' normalization hooks.
+- `normalizeTransport` tries the matched provider first. Only if that does not
+  change `api` or `baseUrl` and the provider has no `models.providers.<id>` entry
+  does it try other transport hooks, stopping at the first change.
+- `normalizeConfig` uses the owning bundled provider's lightweight policy surface
+  first. If that surface has no `normalizeConfig` hook, OpenClaw may call the
+  matched runtime owner, provided runtime loading is allowed and, when a config
+  is supplied, that owner has explicit plugin activation. It never scans other
+  providers' hooks or falls through after the owning hook returns no change.
+  Config assembly passes `allowRuntimePluginLoad: false`, so it uses bundled
+  policy without loading provider runtime.
+
+Google-family config cleanup is implemented by the Google plugin's own
+`normalizeConfig` hook, shared with its lightweight policy surface. It is not a
+separate core compatibility backstop.
 
 If the provider needs a fully custom wire protocol or custom request executor,
 that is a different class of extension. These hooks are for provider behavior


### PR DESCRIPTION
## What Problem This Solves

Resolves contradictory provider-plugin documentation: the internals page said `normalizeModelId`, `normalizeTransport`, and `normalizeConfig` all fell through other providers' hooks until something changed, then described a generic Google config compatibility backstop. That does not match current dispatch or the SDK guide and can mislead plugin authors about which provider owns normalization.

## Why This Change Was Made

Document the three existing dispatch rules separately: matched-hook then manifest model-ID normalization; transport fallback only when the provider has no configured model-provider entry; and bundled-policy or gated matched-runtime-owner config normalization. Explain that config assembly disables runtime plugin loading and that Google config cleanup belongs to Google's own shared policy implementation. Remove the same stale backstop claim from the hook table.

This is a documentation-only follow-up. It does not rewrite provider loaders or duplicate the [MCP import repair (#133028)](https://github.com/openclaw/openclaw/pull/133028) or [tool-metadata work (#132932)](https://github.com/openclaw/openclaw/pull/132932).

## User Impact

Plugin authors get an accurate explanation of ownership and fallback eligibility. Runtime behavior, configuration, and the Plugin SDK do not change. The SDK provider guide already describes config ownership correctly and remains untouched.

## Evidence

Source-audited against freshly fetched `main` at `86b6ec0afa2c64d2019ffdb681760b433b2e10b1`; the relevant docs, owner, caller, and test files match the working branch's baseline.

- Dispatch: `src/plugins/provider-runtime.ts:380–464`, including the configured-provider and explicit-runtime-activation gates.
- Callees: `src/plugins/provider-hook-runtime.ts`, `src/plugins/manifest-model-id-normalization.ts`, and `src/plugins/provider-public-artifacts.ts`.
- Callers: `src/agents/provider-model-normalization.runtime.ts`, `src/agents/embedded-agent-runner/model.provider-hooks.ts`, and `src/agents/models-config.providers.policy.ts` (passes `allowRuntimePluginLoad: false`).
- Google ownership: `extensions/google/provider-policy-api.ts`, `extensions/google/provider-registration.ts`, and `extensions/google/provider-policy.ts` share the same config normalizer.
- Cross-doc consistency: `docs/plugins/sdk-provider-plugins.md` runtime fallback notes.

Validation passed:

```bash
pnpm docs:list
```

```bash
node_modules/.bin/oxfmt --check docs/plugins/architecture-internals.md
```

```bash
node scripts/check-docs-mdx.mjs docs/plugins/architecture-internals.md
```

```bash
pnpm docs:check-links
```

```bash
git diff --check
```

```bash
node scripts/run-vitest.mjs src/plugins/provider-runtime.test.ts extensions/google/provider-policy-api.test.ts -t 'normaliz|config hooks|bundled.*config|matched provider|configured core transport'
```

The link audit checked 7,024 links with zero broken. The focused test run passed 14 selected cases across two shards (64 unrelated cases filtered out). Its first cold run timed out in `beforeAll` before any tests executed; an identical retry passed without source, timeout, or configuration changes. Cold test-import cost is recorded as a separate follow-up, not folded into this docs patch.

Proof limits: the supplied-config explicit external-owner activation branch is source-verified, not independently exercised by these selected tests. No new tests or live-provider run were added because runtime behavior is unchanged.

Production LOC: +0/-0. Tests/test support: +0/-0. Documentation: +20/-8 in one English source page. No generated or localized docs change.
