### PR TITLE
fix(ui): hide URL tooltips while rich cards are open

### DIFF
--- a/ui/src/components/tooltip-title.ts
+++ b/ui/src/components/tooltip-title.ts
@@ -55,7 +55,12 @@ export function installTitleTooltips(ownerDocument: Document) {
     }
   };
 
-  const content = () => active?.anchor.getAttribute("data-tooltip") ?? active?.title ?? "";
+  // Portaled cards open after title discovery, including lazy-loaded providers.
+  // Keep native titles suppressed while the expanded dialog owns the preview.
+  const content = () =>
+    active?.anchor.matches('[aria-haspopup="dialog"][aria-expanded="true"]')
+      ? ""
+      : (active?.anchor.getAttribute("data-tooltip") ?? active?.title ?? "");
   const update = (records: MutationRecord[]) => {
     if (!active) {
       return;
@@ -164,7 +169,7 @@ export function installTitleTooltips(ownerDocument: Document) {
     anchor.addEventListener("focusout", handleFocusOut);
     observer.observe(anchor, {
       attributes: true,
-      attributeFilter: ["title", "data-tooltip", "aria-hidden"],
+      attributeFilter: ["title", "data-tooltip", "aria-hidden", "aria-haspopup", "aria-expanded"],
       characterData: true,
       subtree: true,
     });

--- a/ui/src/components/tooltip.test.ts
+++ b/ui/src/components/tooltip.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPortaledHovercard, PortaledHovercardController } from "./portaled-hovercard.ts";
 import { installTitleTooltips } from "./tooltip-title.ts";
 
 type TooltipElement = HTMLElement & {
@@ -671,6 +672,52 @@ describe("title tooltips", () => {
     expect(webAwesomeTooltip(delegated!)?.open).toBe(false);
     expect(webAwesomeTooltip(explicit.tooltip)?.open).toBe(true);
   });
+
+  it.each(["pointer", "focus"] as const)(
+    "yields a %s title tooltip to a rich card without restoring the native title",
+    async (input) => {
+      const trigger = document.createElement("a");
+      trigger.href = "https://example.com/item";
+      trigger.title = trigger.href;
+      trigger.textContent = "Item";
+      document.body.append(trigger);
+      const activate = () =>
+        input === "pointer" ? dispatchMousePointer(trigger, "pointerover") : focusTrigger(trigger);
+      activate();
+      const tooltip = document.querySelector<TooltipElement>("openclaw-tooltip")!;
+      await tooltip.updateComplete;
+      vi.advanceTimersByTime(150);
+      expectOpenCount(1);
+
+      const hovercard = new PortaledHovercardController(() => hovercard.reset());
+      hovercard.markTrigger(trigger);
+      await Promise.resolve();
+      await tooltip.updateComplete;
+      expectOpenCount(1);
+
+      hovercard.mount(trigger, createPortaledHovercard("item-preview", "preview"), "vertical");
+      await Promise.resolve();
+      await tooltip.updateComplete;
+      expectOpenCount(0);
+      expect(trigger.title).toBe("");
+      activate();
+      await tooltip.updateComplete;
+      vi.advanceTimersByTime(150);
+      expectOpenCount(0);
+
+      hovercard.reset();
+      await Promise.resolve();
+      await tooltip.updateComplete;
+      expectOpenCount(0);
+      dispatchMousePointer(trigger, "pointerleave");
+      trigger.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+      expect(trigger.title).toBe(trigger.href);
+      activate();
+      await tooltip.updateComplete;
+      vi.advanceTimersByTime(150);
+      expectOpenCount(1);
+    },
+  );
 
   it("tracks dynamic titles and restores the latest title and accessible name", async () => {
     const trigger = document.createElement("button");

--- a/ui/src/e2e/github-link-hovercard.e2e.test.ts
+++ b/ui/src/e2e/github-link-hovercard.e2e.test.ts
@@ -251,6 +251,10 @@ describeControlUiE2e("GitHub link hover cards", () => {
     await expectText(card, "+101");
     await expectText(card, "−12");
     await expectText(card, "3 files");
+    await page.clock.runFor(300);
+    await captureArtifact(page, "github-hovercard-title-tooltip");
+    await expect.poll(() => page.locator("openclaw-tooltip[open]").count()).toBe(0);
+    expect(await pullLink.getAttribute("title")).toBe("");
     await expect.poll(() => card.locator("img").count()).toBe(1);
     expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(1);
     const pullBox = await card.boundingBox();
@@ -265,6 +269,7 @@ describeControlUiE2e("GitHub link hover cards", () => {
     await expectText(card, "Keep hover previews compact");
     await expectText(card, "octocat");
     await expectText(card, "4 comments");
+    await expect.poll(() => page.locator("openclaw-tooltip[open]").count()).toBe(0);
     await expect.poll(() => card.locator("img").count()).toBe(1);
     expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(2);
 
@@ -278,6 +283,12 @@ describeControlUiE2e("GitHub link hover cards", () => {
     await page.getByRole("link", { exact: true, name: "repository" }).hover();
     await page.clock.runFor(300);
     await expect.poll(() => card.count()).toBe(0);
+
+    const fileLink = page.getByRole("link", { name: "SKILL.md" });
+    await fileLink.hover();
+    await expect
+      .poll(() => page.locator("openclaw-tooltip[open]").textContent())
+      .toContain("https://github.com/blader/humanizer/blob/main/SKILL.md");
 
     const missingLink = page.getByRole("link", { name: "missing item" });
     await missingLink.hover();
@@ -297,6 +308,7 @@ describeControlUiE2e("GitHub link hover cards", () => {
 
     await pullLink.focus();
     await expectText(card, "Merged");
+    await expect.poll(() => page.locator("openclaw-tooltip[open]").count()).toBe(0);
     await page.keyboard.press("Escape");
     await expect.poll(() => card.count()).toBe(0);
     await expect


### PR DESCRIPTION
Closes #133397

<details>
<summary>Additional instructions</summary>

Same-repository branch; maintainers can push edits.

</details>

## What Problem This Solves

Fixes an issue where users hovering or keyboard-focusing a compact GitHub link see both the plain URL tooltip and the rich preview card in Control UI chat.

## Why This Change Was Made

The shared title-tooltip owner now observes the existing expanded-dialog lifecycle and suppresses its content while a rich card owns the preview. Native titles stay suppressed, so hiding the shared tooltip does not resurrect a browser tooltip. No GitHub-specific branch, new state, configuration, or dependency is added.

Removing Markdown titles was rejected because non-preview links still need the full URL. Skipping title adaptation entirely would restore native browser tooltips. The shared adapter is the narrowest common owner for GitHub, session, and person cards.

Production LOC: +7/-2 (net +5). Tests: +59/-0. Growth is limited to reusing the existing dialog state in the content expression and mutation filter; no parallel policy/state helper was added. No paths removed.

## User Impact

Rich-card links show one preview instead of overlapping popups. Ordinary links retain their URL tooltip. Mouse navigation, keyboard focus, Escape, and links within the card remain usable.

## Evidence

AI-assisted. Reported by @steipete with a screenshot; source and behavior verified locally.

- Both new mouse/focus regressions fail before the production change (`expected length 0 but got 1`) and pass afterward.
- The existing GitHub E2E, extended with a no-duplicate-tooltip assertion, also fails before the fix and passes afterward.
- 54 focused unit tests pass: `node scripts/run-vitest.mjs ui/src/components/tooltip.test.ts ui/src/components/github-link-hovercard.test.ts`.
- All four GitHub browser flows pass: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/github-link-hovercard.e2e.test.ts`.
- 12 Chromium accessible-name tests pass (from `ui/`): `node ../scripts/run-vitest.mjs run --config vitest.config.ts --project chromium src/components/tooltip-title.browser.test.ts`.
- Changed-file formatting, typechecks, lint, and guards pass: `node scripts/check-changed.mjs -- ui/src/components/tooltip-title.ts ui/src/components/tooltip.test.ts ui/src/e2e/github-link-hovercard.e2e.test.ts`.
- Before/after screenshots were captured and inspected in Chromium against the built Control UI with deterministic mock Gateway data. The before capture shows the URL bubble above the rich card; the after capture shows the rich card alone. This is browser/UI proof, not live authenticated GitHub API proof; no API behavior changes.
- Artifact publication gap: this host's GitHub CLI lacks `--attach`; its upload request was rejected by string-rewrite protection. The documented Crabbox broker fallback returned `artifact_upload_unavailable` because its upload backend is unconfigured. Captures remain local under `.artifacts/rich-link-tooltip/{before,after}/github-hovercard-title-tooltip.png` and can be attached when an upload route is available.
- Fresh pre-commit autoreview (Codex Sol, high): clean, no accepted/actionable findings.

Root-cause map: app-root installs `installTitleTooltips`; Markdown supplies the URL title; `tooltip-title.ts` adapts it into `Tooltip`; `PortaledHovercardController` records dialog expansion for GitHub, session-progress, and person cards. The adapter previously ignored that lifecycle. Web Awesome 3.11.0 source confirms closing its tooltip releases the popup; the adapter retains native-title and accessible-name ownership.

Provenance: the shared adaptation was introduced by #131335 (author and merger @steipete, 2026-08-28), commit 590c7d65bd0a23eabc2a65ab2fdb6b3d7434c837. Current main retains the same missing lifecycle observation.
