### PR TITLE
improve: reduce transcript import watermark overhead

### DIFF
--- a/src/config/sessions/session-transcript-index.ts
+++ b/src/config/sessions/session-transcript-index.ts
@@ -163,30 +163,28 @@ function writeWatermark(
   sessionId: string,
   watermark: SessionTranscriptProjectionState,
   now: number,
+  updateExisting = false,
 ): SessionTranscriptProjectionState {
+  const kysely = getIndexKysely(db);
+  const values = {
+    active_event_count: watermark.activeEventCount,
+    active_message_count: watermark.activeMessageCount,
+    indexed_seq: watermark.indexedSeq,
+    leaf_event_id: watermark.leafEventId,
+    needs_rebuild: watermark.needsRebuild ? 1 : 0,
+    updated_at: now,
+  };
   executeSqliteQuerySync(
     db,
-    getIndexKysely(db)
-      .insertInto("session_transcript_index_state")
-      .values({
-        session_id: sessionId,
-        active_event_count: watermark.activeEventCount,
-        active_message_count: watermark.activeMessageCount,
-        indexed_seq: watermark.indexedSeq,
-        leaf_event_id: watermark.leafEventId,
-        needs_rebuild: watermark.needsRebuild ? 1 : 0,
-        updated_at: now,
-      })
-      .onConflict((conflict) =>
-        conflict.column("session_id").doUpdateSet({
-          active_event_count: watermark.activeEventCount,
-          active_message_count: watermark.activeMessageCount,
-          indexed_seq: watermark.indexedSeq,
-          leaf_event_id: watermark.leafEventId,
-          needs_rebuild: watermark.needsRebuild ? 1 : 0,
-          updated_at: now,
-        }),
-      ),
+    updateExisting
+      ? kysely
+          .updateTable("session_transcript_index_state")
+          .set(values)
+          .where("session_id", "=", sessionId)
+      : kysely
+          .insertInto("session_transcript_index_state")
+          .values({ session_id: sessionId, ...values })
+          .onConflict((conflict) => conflict.column("session_id").doUpdateSet(values)),
   );
   return watermark;
 }
@@ -266,13 +264,7 @@ export function createTranscriptIndexAppenderInTransaction(
         // transcripts): stay unindexed until reconcile rebuilds the session.
         return true;
       }
-      watermark = applyForwardIndex(db, sessionId, params, {
-        activeEventCount: 0,
-        activeMessageCount: 0,
-        indexedSeq: -1,
-        leafEventId: null,
-        needsRebuild: false,
-      });
+      watermark = applyForwardIndex(db, sessionId, params, watermark);
       return false;
     }
     if (watermark.needsRebuild) {
@@ -328,7 +320,7 @@ function applyForwardIndex(
   db: DatabaseSync,
   sessionId: string,
   params: TranscriptIndexAppend,
-  watermark: SessionTranscriptProjectionState,
+  watermark: SessionTranscriptProjectionState | undefined,
 ): SessionTranscriptProjectionState {
   const entry = extractTranscriptIndexEntry(params.event, params.createdAt);
   if (entry) {
@@ -338,10 +330,10 @@ function applyForwardIndex(
   const projectsMessage = projectsActiveEvent && hasTranscriptMessage(params.event);
   if (projectsActiveEvent) {
     insertActiveEventRow(db, {
-      activePosition: watermark.activeEventCount,
+      activePosition: watermark?.activeEventCount ?? 0,
       contextEligible: transcriptEventContextEligibility(params.event),
       eventSeq: params.seq,
-      messagePosition: projectsMessage ? watermark.activeMessageCount : null,
+      messagePosition: projectsMessage ? (watermark?.activeMessageCount ?? 0) : null,
       sessionId,
     });
   }
@@ -353,13 +345,16 @@ function applyForwardIndex(
     db,
     sessionId,
     {
-      activeEventCount: watermark.activeEventCount + (projectsActiveEvent ? 1 : 0),
-      activeMessageCount: watermark.activeMessageCount + (projectsMessage ? 1 : 0),
+      activeEventCount: (watermark?.activeEventCount ?? 0) + (projectsActiveEvent ? 1 : 0),
+      activeMessageCount: (watermark?.activeMessageCount ?? 0) + (projectsMessage ? 1 : 0),
       indexedSeq: params.seq,
-      leafEventId: advancesLeaf ? params.eventId : watermark.leafEventId,
+      leafEventId: advancesLeaf ? params.eventId : (watermark?.leafEventId ?? null),
       needsRebuild: false,
     },
     params.createdAt,
+    // The synchronous appender owns this row until its batch ends; initialization
+    // still upserts, while subsequent events avoid repeated conflict resolution.
+    watermark !== undefined,
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Large session imports repeatedly construct and execute projection-watermark UPSERTs even after the synchronous append owner knows that row exists. This change reduces import elapsed time by 4.1–7.4% in matched synthetic workloads.

## Why This Change Was Made

Use UPDATE for a proven-existing watermark, while retaining UPSERT for initialization, dirty marking and rebuilds. The private writer maps its six fields once; the appender passes its actual optional prior state instead of fabricating an initial watermark. Every write remains in its original order and transaction.

No schema, index, cache, public API, configuration, dependency, durability, concurrency, recovery or visibility change. This is a bounded query optimization under the database-schema review checkpoint, not a store redesign. The worker's claim-fenced publication path is unchanged. Production +29/-34 (net−5); tests unchanged.

## User Impact

Lower CPU and elapsed time during large imports, without changing stored history, identity ownership, search results or migration behavior.

## Evidence

Matched Node 24.19.0/SQLite3.53.3 runs: three fresh processes per side and shape, interleaved before/after, on one isolated worker. Baseline `86b6ec0afa2c64d2019ffdb681760b433b2e10b1`; runtime-tested candidate `851fe4c1d87828b178d19eebe6381c80740be8ad`. The final rebased importer owner and its append/staging/SQL/schema dependencies are byte-identical to that tested candidate.

| Synthetic shape | Before median | After median | Wall reduction | CPU reduction |
| --- | ---: | ---: | ---: | ---: |
| One 100,000-event transcript | 6085.0ms | 5782.8ms | 5.0% | 6.1% |
| 100 sessions × 100 events | 649.5ms | 601.8ms | 7.4% | 6.4% |
| 100 branching  sessions × 100 events | 965.6ms | 925.9ms | 4.1% | 4.5% |

All nine pairs matched persisted-data SHA-256 digests across transcript bytes, identities, windows, active positions, watermark counts/cursor/dirty state and FTS. A separate 10k-event SQL trace retained all 100,034 calls: 10,001 watermark UPSERTs became one initial UPSERT plus 10,000 UPDATEs. Those were the only changed SQL shapes. Before/after Node CPU profiles completed separately from timing samples. Local timings were excluded because the host was saturated.

Blacksmith Testbox `tbx_01m19t750tgr25hnnwbcb442hc`, [worker run](https://github.com/openclaw/openclaw/actions/runs/33324341526), was stopped after artifact collection. Packaged stable `2026.7.1-2`→candidate `2026.8.1` passed with 4,800 sessions, 1,227,946 events and 10,000 cron jobs across five complete state assertions. Automatic migration was checked immediately after the updater, before standalone Doctor; repeat Doctor took 38s under its 60s budget. Eight Gateway history samples across two agents/600 messages matched after restart. The synthetic plugin fixture required its existing capability consent; this proves automatic migration, not unattended update-channel switching.

37 focused owner/sibling tests passed: importer rollback/deduplication/exact handoff, active projections, replacement ownership, context eligibility and projection rebuilds, including 100k-message bounded reads and interrupted/concurrent publication. Core types, guards, formatting, lint and Codex review passed. Existing behavior tests plus paired SQL/data proof cover the optimization without adding an implementation-shaped test.

The initial CI run exposed the unrelated native-runner batch-cancel race. It reproduced locally; upstream #133356 landed the same root-cause repair using the existing CLI wait helper while this PR was being validated. This PR was rebased onto that repair and retains only the importer change. Local broad tooling validation also reproduced three unchanged-baseline failures: two parser cases because the shared Vitest installation lacks the checked-in patch, and a cache-clear timeout. Shared pako/shiki/tslog declarations also block aggregate local type gates. Shared dependencies were not modified and no assertions/timeouts were weakened; clean CI on the final head is required before landing.

Final validation: [CI33326072465](https://github.com/openclaw/openclaw/actions/runs/33326072465) completed successfully on `6b2ad28c575137866985e20b358c3e059732b941`. Fresh Codex review is clean. The latest ClawSweeper review was read in full: its pending CI, packaged-upgrade and dependency-contract confirmations are satisfied. Installed Kysely source was inspected directly in addition to the passing types and real SQL proof. Maintainer assessment: proceed with this bounded optimization under the existing synchronous appender ownership contract; it changes no material persistence semantics or store operating model.
