### PR TITLE
fix(channels): preserve long WhatsApp replies with less formatting work

### DIFF
--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -398,6 +398,7 @@ When the linked self number is also present in `allowFrom`, self-chat safeguards
 <AccordionGroup>
   <Accordion title="Text chunking">
     - default chunk limit: `channels.whatsapp.textChunkLimit = 4000`
+    - Markdown is converted before chunks are sent, preserving styles across message boundaries and counting WhatsApp formatting markers toward the limit
     - `channels.whatsapp.streaming.chunkMode = "length" | "newline"`; `newline` prefers paragraph boundaries (blank lines), then falls back to length-safe chunking
 
   </Accordion>

--- a/extensions/googlechat/src/format.ts
+++ b/extensions/googlechat/src/format.ts
@@ -328,7 +328,7 @@ export function formatGoogleChatTextChunks(
   return renderMarkdownIRChunksWithinLimit<string>({
     ir: prepared.ir,
     limit: Math.min(limit, GOOGLE_CHAT_FORMAT_PROFILE.chunk.limit),
-    measureRendered: (rendered: string) => new TextEncoder().encode(rendered).byteLength,
+    measureRendered: (rendered: string) => Buffer.byteLength(rendered, "utf8"),
     renderChunk: (chunk) => renderGoogleChatIR(chunk, prepared.markers),
   }).map((chunk) => chunk.rendered);
 }

--- a/extensions/slack/src/format.ts
+++ b/extensions/slack/src/format.ts
@@ -393,10 +393,11 @@ function protectSlackAssistantTranscriptRoleHeaders(text: string): string {
     return text;
   }
   const tokenProjection = projectSlackMrkdwnVisibleText(text, "token");
-  const fallbackProjection = projectSlackMrkdwnVisibleText(text, "fallback");
+  // Only native date tokens have different modern-client and fallback text.
   if (
     !slackProjectionHasRoleHeader(tokenProjection) &&
-    !slackProjectionHasRoleHeader(fallbackProjection)
+    (!text.includes("<!date^") ||
+      !slackProjectionHasRoleHeader(projectSlackMrkdwnVisibleText(text, "fallback")))
   ) {
     return text;
   }

--- a/extensions/whatsapp/src/channel-outbound.ts
+++ b/extensions/whatsapp/src/channel-outbound.ts
@@ -7,7 +7,6 @@ import {
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-send-result";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { questionGatewayRuntime } from "openclaw/plugin-sdk/question-gateway-runtime";
-import { chunkText } from "openclaw/plugin-sdk/reply-chunking";
 import { createWhatsAppOutboundBase } from "./outbound-base.js";
 import { normalizeWhatsAppPayloadTextPreservingIndentation } from "./outbound-media-contract.js";
 import { resolveWhatsAppOutboundTarget } from "./resolve-outbound-target.js";
@@ -59,7 +58,6 @@ async function registerDeliveredWhatsAppApprovalPayload(
 
 export const whatsappChannelOutbound = {
   ...createWhatsAppOutboundBase({
-    chunker: chunkText,
     sendMessageWhatsApp: async (to, text, options) =>
       await sendMessageWhatsApp(to, text, {
         ...options,

--- a/extensions/whatsapp/src/outbound-base.test.ts
+++ b/extensions/whatsapp/src/outbound-base.test.ts
@@ -30,25 +30,12 @@ function sendMessageOptionsAt(
 }
 
 describe("createWhatsAppOutboundBase", () => {
-  it("exposes the provided chunker", () => {
-    const outbound = createWhatsAppOutboundBase({
-      chunker: (text, limit) => [text.slice(0, limit)],
-      sendMessageWhatsApp: vi.fn(),
-      sendPollWhatsApp: vi.fn(),
-      shouldLogVerbose: () => false,
-      resolveTarget: ({ to }) => ({ ok: true as const, to: to ?? "" }),
-    });
-
-    expect(outbound.chunker?.("alpha beta", 5)).toEqual(["alpha"]);
-  });
-
   it("forwards mediaLocalRoots to sendMessageWhatsApp", async () => {
     const sendMessageWhatsApp = vi.fn(async () => ({
       messageId: "msg-1",
       toJid: "15551234567@s.whatsapp.net",
     }));
     const outbound = createWhatsAppOutboundBase({
-      chunker: (text) => [text],
       sendMessageWhatsApp,
       sendPollWhatsApp: vi.fn(),
       shouldLogVerbose: () => false,
@@ -83,7 +70,6 @@ describe("createWhatsAppOutboundBase", () => {
       toJid: "15551234567@s.whatsapp.net",
     }));
     const outbound = createWhatsAppOutboundBase({
-      chunker: (text) => [text],
       sendMessageWhatsApp,
       sendPollWhatsApp: vi.fn(),
       shouldLogVerbose: () => false,
@@ -118,7 +104,6 @@ describe("createWhatsAppOutboundBase", () => {
       };
     });
     const outbound = createWhatsAppOutboundBase({
-      chunker: (text) => [text],
       sendMessageWhatsApp,
       sendPollWhatsApp: vi.fn(),
       shouldLogVerbose: () => false,
@@ -151,7 +136,6 @@ describe("createWhatsAppOutboundBase", () => {
       toJid: "15551234567@s.whatsapp.net",
     }));
     const outbound = createWhatsAppOutboundBase({
-      chunker: (text) => [text],
       sendMessageWhatsApp,
       sendPollWhatsApp: vi.fn(),
       shouldLogVerbose: () => false,
@@ -196,7 +180,6 @@ describe("createWhatsAppOutboundBase", () => {
       toJid: "15551234567@s.whatsapp.net",
     }));
     const outbound = createWhatsAppOutboundBase({
-      chunker: (text) => [text],
       sendMessageWhatsApp,
       sendPollWhatsApp: vi.fn(),
       shouldLogVerbose: () => false,
@@ -240,7 +223,6 @@ describe("createWhatsAppOutboundBase", () => {
       toJid: "15551234567@s.whatsapp.net",
     }));
     const outbound = createWhatsAppOutboundBase({
-      chunker: (text) => [text],
       sendMessageWhatsApp,
       sendPollWhatsApp: vi.fn(),
       shouldLogVerbose: () => false,
@@ -285,7 +267,6 @@ describe("createWhatsAppOutboundBase", () => {
       toJid: "15551234567@s.whatsapp.net",
     }));
     const outbound = createWhatsAppOutboundBase({
-      chunker: (text) => [text],
       sendMessageWhatsApp,
       sendPollWhatsApp: vi.fn(),
       shouldLogVerbose: () => false,
@@ -330,7 +311,6 @@ describe("createWhatsAppOutboundBase", () => {
       toJid: "5511976136970@s.whatsapp.net",
     }));
     const outbound = createWhatsAppOutboundBase({
-      chunker: (text) => [text],
       sendMessageWhatsApp,
       sendPollWhatsApp: vi.fn(),
       shouldLogVerbose: () => false,
@@ -380,7 +360,6 @@ describe("createWhatsAppOutboundBase", () => {
       toJid: "15551234567@s.whatsapp.net",
     }));
     const outbound = createWhatsAppOutboundBase({
-      chunker: (text) => [text],
       sendMessageWhatsApp,
       sendPollWhatsApp: vi.fn(),
       shouldLogVerbose: () => false,
@@ -427,7 +406,6 @@ describe("createWhatsAppOutboundBase", () => {
       toJid: "5511976136970@s.whatsapp.net",
     }));
     const outbound = createWhatsAppOutboundBase({
-      chunker: (text) => [text],
       sendMessageWhatsApp,
       sendPollWhatsApp: vi.fn(),
       shouldLogVerbose: () => false,
@@ -483,7 +461,6 @@ describe("createWhatsAppOutboundBase", () => {
       toJid: to,
     }));
     const outbound = createWhatsAppOutboundBase({
-      chunker: (text) => [text],
       sendMessageWhatsApp,
       sendPollWhatsApp: vi.fn(),
       shouldLogVerbose: () => false,
@@ -545,7 +522,6 @@ describe("createWhatsAppOutboundBase", () => {
       toJid: "15551234567@s.whatsapp.net",
     }));
     const outbound = createWhatsAppOutboundBase({
-      chunker: (text) => [text],
       sendMessageWhatsApp,
       sendPollWhatsApp: vi.fn(),
       shouldLogVerbose: () => false,
@@ -580,7 +556,6 @@ describe("createWhatsAppOutboundBase", () => {
       toJid: "15551234567@s.whatsapp.net",
     }));
     const outbound = createWhatsAppOutboundBase({
-      chunker: (text) => [text],
       sendMessageWhatsApp,
       sendPollWhatsApp: vi.fn(),
       shouldLogVerbose: () => false,
@@ -621,7 +596,6 @@ describe("createWhatsAppOutboundBase", () => {
       toJid: "15551234567@s.whatsapp.net",
     }));
     const outbound = createWhatsAppOutboundBase({
-      chunker: (text) => [text],
       sendMessageWhatsApp,
       sendPollWhatsApp: vi.fn(),
       shouldLogVerbose: () => false,
@@ -656,7 +630,6 @@ describe("createWhatsAppOutboundBase", () => {
       toJid: "15551234567@s.whatsapp.net",
     }));
     const outbound = createWhatsAppOutboundBase({
-      chunker: (text) => [text],
       sendMessageWhatsApp,
       sendPollWhatsApp: vi.fn(),
       shouldLogVerbose: () => false,
@@ -689,7 +662,6 @@ describe("createWhatsAppOutboundBase", () => {
       toJid: "15551234567@s.whatsapp.net",
     }));
     const outbound = createWhatsAppOutboundBase({
-      chunker: (text) => [text],
       sendMessageWhatsApp,
       sendPollWhatsApp: vi.fn(),
       shouldLogVerbose: () => false,
@@ -718,7 +690,6 @@ describe("createWhatsAppOutboundBase", () => {
       toJid: "1555@s.whatsapp.net",
     }));
     const outbound = createWhatsAppOutboundBase({
-      chunker: (text) => [text],
       sendMessageWhatsApp: vi.fn(),
       sendPollWhatsApp,
       shouldLogVerbose: () => false,

--- a/extensions/whatsapp/src/outbound-base.ts
+++ b/extensions/whatsapp/src/outbound-base.ts
@@ -14,45 +14,13 @@ import {
   normalizeWhatsAppPayloadText,
 } from "./outbound-media-contract.js";
 import { WHATSAPP_LEGACY_OUTBOUND_SEND_DEP_KEYS } from "./outbound-send-deps.js";
-import {
-  lookupInboundMessageMetaForTarget,
-  type WhatsAppQuotedMessageKey,
-} from "./quoted-message.js";
+import { lookupInboundMessageMetaForTarget } from "./quoted-message.js";
 import { toWhatsappJid } from "./text-runtime.js";
 
-type WhatsAppChunker = NonNullable<ChannelOutboundAdapter["chunker"]>;
-type WhatsAppSendTextOptions = {
-  verbose: boolean;
-  cfg: OpenClawConfig;
-  mediaUrl?: string;
-  mediaAccess?: {
-    localRoots?: readonly string[];
-    readFile?: (filePath: string) => Promise<Buffer>;
-  };
-  mediaLocalRoots?: readonly string[];
-  mediaReadFile?: (filePath: string) => Promise<Buffer>;
-  gifPlayback?: boolean;
-  audioAsVoice?: boolean;
-  forceDocument?: boolean;
-  accountId?: string;
-  quotedMessageKey?: WhatsAppQuotedMessageKey;
-  preserveLeadingWhitespace?: boolean;
-  /** Report each accepted internal platform send before the next fallible send. */
-  onDeliveryResult?: (result: { messageId: string; toJid: string }) => Promise<void> | void;
-};
-type WhatsAppSendMessage = (
-  to: string,
-  body: string,
-  options: WhatsAppSendTextOptions,
-) => Promise<{ messageId: string; toJid: string }>;
-type WhatsAppSendPoll = (
-  to: string,
-  poll: Parameters<NonNullable<ChannelOutboundAdapter["sendPoll"]>>[0]["poll"],
-  options: { verbose: boolean; accountId?: string; cfg: OpenClawConfig },
-) => Promise<{ messageId: string; toJid: string }>;
+type WhatsAppSendMessage = typeof import("./send.js").sendMessageWhatsApp;
+type WhatsAppSendPoll = typeof import("./send.js").sendPollWhatsApp;
 
 type CreateWhatsAppOutboundBaseParams = {
-  chunker: WhatsAppChunker;
   sendMessageWhatsApp: WhatsAppSendMessage;
   sendPollWhatsApp: WhatsAppSendPoll;
   shouldLogVerbose: () => boolean;
@@ -72,8 +40,6 @@ function resolveQuoteLookupAccountId(cfg?: OpenClawConfig, accountId?: string | 
 type WhatsAppOutboundBaseCore = Pick<
   ChannelOutboundAdapter,
   | "deliveryMode"
-  | "chunker"
-  | "chunkerMode"
   | "textChunkLimit"
   | "sanitizeText"
   | "deliveryCapabilities"
@@ -85,28 +51,14 @@ type WhatsAppOutboundBaseCore = Pick<
 >;
 
 export function createWhatsAppOutboundBase({
-  chunker,
   sendMessageWhatsApp,
   sendPollWhatsApp,
   shouldLogVerbose,
   resolveTarget,
   normalizeText = normalizeWhatsAppPayloadText,
   skipEmptyText = true,
-}: CreateWhatsAppOutboundBaseParams): Pick<
-  ChannelOutboundAdapter,
-  | "deliveryMode"
-  | "chunker"
-  | "chunkerMode"
-  | "textChunkLimit"
-  | "sanitizeText"
-  | "deliveryCapabilities"
-  | "pollMaxOptions"
-  | "resolveTarget"
-  | "sendPayload"
-  | "sendText"
-  | "sendMedia"
-  | "sendPoll"
-> {
+}: CreateWhatsAppOutboundBaseParams): WhatsAppOutboundBaseCore &
+  Pick<ChannelOutboundAdapter, "sendPayload"> {
   const resolveQuotedMessageKey = (params: {
     accountId: string;
     to: string;
@@ -131,8 +83,6 @@ export function createWhatsAppOutboundBase({
 
   const outbound: WhatsAppOutboundBaseCore = {
     deliveryMode: "gateway",
-    chunker,
-    chunkerMode: "text",
     textChunkLimit: 4000,
     sanitizeText: ({ text }) => normalizeText(text),
     deliveryCapabilities: {
@@ -154,6 +104,10 @@ export function createWhatsAppOutboundBase({
         deps,
         gifPlayback,
         replyToId,
+        replyToIdSource,
+        replyToMode,
+        formatting,
+        onPlatformSendDispatch,
         onDeliveryResult,
       }) => {
         const normalizedText = normalizeText(text);
@@ -176,6 +130,10 @@ export function createWhatsAppOutboundBase({
           cfg,
           accountId: accountId ?? undefined,
           gifPlayback,
+          replyToIdSource,
+          replyToMode,
+          formatting,
+          onPlatformSendDispatch,
           ...(quotedMessageKey ? { quotedMessageKey } : {}),
           ...(onDeliveryResult
             ? {
@@ -200,6 +158,10 @@ export function createWhatsAppOutboundBase({
         gifPlayback,
         forceDocument,
         replyToId,
+        replyToIdSource,
+        replyToMode,
+        formatting,
+        onPlatformSendDispatch,
         onDeliveryResult,
       }) => {
         const lookupAccountId = resolveQuoteLookupAccountId(cfg, accountId);
@@ -224,6 +186,10 @@ export function createWhatsAppOutboundBase({
           accountId: accountId ?? undefined,
           gifPlayback,
           forceDocument,
+          replyToIdSource,
+          replyToMode,
+          formatting,
+          onPlatformSendDispatch,
           ...(quotedMessageKey ? { quotedMessageKey } : {}),
           ...(onDeliveryResult
             ? {

--- a/extensions/whatsapp/src/send.delivery-recovery.test.ts
+++ b/extensions/whatsapp/src/send.delivery-recovery.test.ts
@@ -12,7 +12,7 @@ import { drainPendingDeliveries } from "openclaw/plugin-sdk/delivery-queue-runti
 import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { withStateDirEnv } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { whatsappChannelOutbound } from "./channel-outbound.js";
+import { whatsappChannelOutbound, whatsappMessageAdapter } from "./channel-outbound.js";
 import { createAcceptedWhatsAppSendResult } from "./inbound/send-result.test-helper.js";
 import type { ActiveWebListener } from "./inbound/types.js";
 
@@ -59,10 +59,13 @@ describe("WhatsApp delivery recovery", () => {
         {
           pluginId: "whatsapp",
           source: "test",
-          plugin: createOutboundTestPlugin({
-            id: "whatsapp",
-            outbound: whatsappChannelOutbound,
-          }),
+          plugin: {
+            ...createOutboundTestPlugin({
+              id: "whatsapp",
+              outbound: whatsappChannelOutbound,
+            }),
+            message: whatsappMessageAdapter,
+          },
         },
       ]),
     );
@@ -73,6 +76,137 @@ describe("WhatsApp delivery recovery", () => {
     resetPluginRuntimeStateForTest();
     setActivePluginRegistry(createEmptyPluginRegistry());
   });
+
+  it.each([
+    { mode: "first" as const, explicit: false },
+    { mode: "all" as const, explicit: false },
+    { mode: "first" as const, explicit: true },
+  ])("preserves long styles and $mode quotes (explicit=$explicit)", async ({ mode, explicit }) => {
+    await withStateDirEnv("openclaw-whatsapp-styled-reply-", async () => {
+      const sendMessage = vi.fn<ActiveWebListener["sendMessage"]>();
+      sendMessage.mockImplementation(async () =>
+        createAcceptedWhatsAppSendResult("text", `part-${sendMessage.mock.calls.length}`),
+      );
+      runtimeContextMocks.controllers.set(accountId, {
+        getActiveListener: () => ({ sendMessage, sendComposingTo: vi.fn() }),
+      });
+      const onDeliveryResult = vi.fn();
+      const result = await sendDurableMessageBatch({
+        cfg: { channels: { whatsapp: { textChunkLimit: 160 } } },
+        channel: "whatsapp",
+        to: "+1555",
+        payloads: [
+          { text: `**${"x".repeat(340)}**`, ...(explicit ? { replyToId: "quoted" } : {}) },
+        ],
+        replyToId: "quoted",
+        replyToMode: mode,
+        onDeliveryResult,
+        durability: "required",
+      });
+      expect(result.status).toBe("sent");
+      expect(sendMessage.mock.calls.map(([, text]) => text)).toEqual([
+        `*${"x".repeat(158)}*`,
+        "*xx*",
+        `*${"x".repeat(158)}*`,
+        "*xx*",
+        `*${"x".repeat(20)}*`,
+      ]);
+      expect(sendMessage.mock.calls.map((call) => call[4]?.quotedMessageKey?.id)).toEqual(
+        explicit || mode === "all"
+          ? ["quoted", "quoted", "quoted", "quoted", "quoted"]
+          : ["quoted", undefined, undefined, undefined, undefined],
+      );
+      expect(onDeliveryResult.mock.calls.map(([progress]) => progress.messageId)).toEqual([
+        "part-1",
+        "part-2",
+        "part-3",
+        "part-4",
+        "part-5",
+      ]);
+      expect(
+        onDeliveryResult.mock.calls.map(([progress]) =>
+          progress.receipt?.parts.map((part: { replyToId?: string }) => part.replyToId),
+        ),
+      ).toEqual(
+        explicit || mode === "all"
+          ? [["quoted"], ["quoted"], ["quoted"], ["quoted"], ["quoted"]]
+          : [["quoted"], [undefined], [undefined], [undefined], [undefined]],
+      );
+    });
+  });
+
+  it("keeps payload formatting intact under a narrower delivery limit", async () => {
+    const sendMessage = vi.fn<ActiveWebListener["sendMessage"]>();
+    sendMessage.mockImplementation(async () =>
+      createAcceptedWhatsAppSendResult("text", `payload-${sendMessage.mock.calls.length}`),
+    );
+    runtimeContextMocks.controllers.set(accountId, {
+      getActiveListener: () => ({ sendMessage, sendComposingTo: vi.fn() }),
+    });
+    const onPlatformSendDispatch = vi.fn(async () => {});
+    const onDeliveryResult = vi.fn();
+    const text = `**${"x".repeat(4_200)}**`;
+    await whatsappChannelOutbound.sendPayload!({
+      cfg: { channels: { whatsapp: { textChunkLimit: 160 } } },
+      to: "+1555",
+      text,
+      payload: { text },
+      formatting: { textLimit: 80 },
+      replyToId: "quoted",
+      replyToIdSource: "implicit",
+      replyToMode: "first",
+      onPlatformSendDispatch,
+      onDeliveryResult,
+    });
+    const parts = sendMessage.mock.calls.map(([, part]) => part);
+    expect(parts.length).toBeGreaterThan(1);
+    expect(parts.every((part) => /^\*x+\*$/.test(part) && part.length <= 80)).toBe(true);
+    expect(parts.map((part) => part.slice(1, -1)).join("")).toBe("x".repeat(4_200));
+    expect(sendMessage.mock.calls.map((call) => call[4]?.quotedMessageKey?.id)).toEqual(
+      parts.map((_, index) => (index === 0 ? "quoted" : undefined)),
+    );
+    expect(onPlatformSendDispatch).toHaveBeenCalledTimes(parts.length);
+    expect(onDeliveryResult.mock.calls.map(([result]) => result.messageId)).toEqual(
+      parts.map((_, index) => `payload-${index + 1}`),
+    );
+  });
+
+  it.each(["abort", "transport"] as const)(
+    "retains accepted chunks after a later %s failure",
+    async (failure) => {
+      await withStateDirEnv("openclaw-whatsapp-partial-reply-", async () => {
+        const controller = new AbortController();
+        const sendMessage = vi.fn<ActiveWebListener["sendMessage"]>(async () => {
+          if (sendMessage.mock.calls.length > 1) {
+            throw new Error("transport failed");
+          }
+          return createAcceptedWhatsAppSendResult("text", "accepted-first");
+        });
+        runtimeContextMocks.controllers.set(accountId, {
+          getActiveListener: () => ({ sendMessage, sendComposingTo: vi.fn() }),
+        });
+        const result = await sendDurableMessageBatch({
+          cfg: { channels: { whatsapp: { textChunkLimit: 160 } } },
+          channel: "whatsapp",
+          to: "+1555",
+          payloads: [{ text: `**${"x".repeat(340)}**` }],
+          signal: controller.signal,
+          onDeliveryResult: () => {
+            if (failure === "abort") {
+              controller.abort(new Error("cancelled after first part"));
+            }
+          },
+          durability: "required",
+        });
+        expect(result).toMatchObject({
+          status: "partial_failed",
+          results: [{ messageId: "accepted-first" }],
+          receipt: { platformMessageIds: ["accepted-first"] },
+        });
+        expect(sendMessage).toHaveBeenCalledTimes(failure === "abort" ? 1 : 2);
+      });
+    },
+  );
 
   it("keeps pre-connect recovery replayable, then sends exactly once after connect", async () => {
     await withStateDirEnv("openclaw-whatsapp-delivery-recovery-", async ({ stateDir }) => {

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -1,4 +1,10 @@
 // Whatsapp plugin module implements send behavior.
+import type { ChannelOutboundContext } from "openclaw/plugin-sdk/channel-contract";
+import {
+  createMessageReceiptFromOutboundResults,
+  createReplyToFanout,
+  type MessageReceipt,
+} from "openclaw/plugin-sdk/channel-outbound";
 import { formatCliCommand } from "openclaw/plugin-sdk/cli-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { generateSecureUuid } from "openclaw/plugin-sdk/core";
@@ -151,8 +157,15 @@ export async function sendMessageWhatsApp(
     quotedMessageKey?: WhatsAppQuotedMessageKey;
     preserveLeadingWhitespace?: boolean;
     /** Report each accepted internal platform send before the next fallible send. */
-    onDeliveryResult?: (result: { messageId: string; toJid: string }) => Promise<void> | void;
-  },
+    onDeliveryResult?: (result: {
+      messageId: string;
+      toJid: string;
+      receipt?: MessageReceipt;
+    }) => Promise<void> | void;
+  } & Pick<
+    ChannelOutboundContext,
+    "replyToIdSource" | "replyToMode" | "formatting" | "onPlatformSendDispatch"
+  >,
 ): Promise<{ messageId: string; toJid: string }> {
   return await sendWhatsAppUploadFile(to, body, options);
 }
@@ -198,7 +211,9 @@ async function sendMessageWhatsAppInActivityScope(
     accountId: resolvedAccountId ?? options.accountId,
   });
   const accountIdForFormatting = resolvedAccountId ?? options.accountId;
+  const requestedLimit = options.formatting?.textLimit ?? Infinity;
   const textLimit = Math.min(
+    requestedLimit > 0 ? requestedLimit : Infinity,
     resolveTextChunkLimit(cfg, "whatsapp", accountIdForFormatting, { fallbackLimit: 4_000 }),
     4_096,
   );
@@ -206,7 +221,7 @@ async function sendMessageWhatsAppInActivityScope(
     text,
     textLimit,
     tableMode,
-    resolveChunkMode(cfg, "whatsapp", accountIdForFormatting),
+    options.formatting?.chunkMode ?? resolveChunkMode(cfg, "whatsapp", accountIdForFormatting),
   );
   text = textChunks.shift() ?? text;
   if (!text && !hasMedia) {
@@ -280,46 +295,65 @@ async function sendMessageWhatsAppInActivityScope(
     }
     const hasExplicitAccountId = Boolean(options.accountId?.trim());
     const accountId = hasExplicitAccountId ? resolvedAccountId : undefined;
+    const trailingTextChunks = [visibleTextAfterVoice, ...textChunks].filter(
+      (chunk): chunk is string => Boolean(chunk),
+    );
+    const reportProgress = trailingTextChunks.length > 0 ? options.onDeliveryResult : undefined;
     const sendOptions: ActiveWebSendOptions | undefined =
-      options.gifPlayback ||
-      forceDocumentDelivery ||
-      accountId ||
-      documentFileName ||
-      options.quotedMessageKey
+      options.gifPlayback || forceDocumentDelivery || accountId || documentFileName
         ? {
             ...(options.gifPlayback ? { gifPlayback: true } : {}),
             ...(forceDocumentDelivery ? { asDocument: true } : {}),
             ...(documentFileName ? { fileName: documentFileName } : {}),
-            ...(options.quotedMessageKey ? { quotedMessageKey: options.quotedMessageKey } : {}),
             accountId,
           }
         : undefined;
-    const result = requireWhatsAppAcceptedSendResult(
-      sendOptions
-        ? await active.sendMessage(to, text, mediaBuffer, mediaType, sendOptions)
-        : await active.sendMessage(to, text, mediaBuffer, mediaType),
-    );
-    acceptedResults.push(result);
-    const messageId = result.messageId;
-    const sentRemoteJid = resolveActualSentRemoteJid(result, jid);
-    const trailingTextChunks = [visibleTextAfterVoice, ...textChunks].filter(
-      (chunk): chunk is string => Boolean(chunk),
-    );
+    const quotedSendOptions = options.quotedMessageKey
+      ? { ...sendOptions, quotedMessageKey: options.quotedMessageKey }
+      : sendOptions;
+    const nextReplyToId = createReplyToFanout({
+      replyToId: options.quotedMessageKey?.id,
+      replyToIdSource: options.replyToIdSource,
+      replyToMode: options.replyToMode,
+    });
+    const sendPart = async (part: string, buffer?: Buffer, mime?: string) => {
+      // This owner chunks rendered Markdown; keep each native send behind the
+      // durable dispatch fence and record its actual quote before reporting progress.
+      await options.onPlatformSendDispatch?.();
+      const replyToId = nextReplyToId();
+      const partOptions = replyToId ? quotedSendOptions : sendOptions;
+      const accepted = requireWhatsAppAcceptedSendResult(
+        partOptions
+          ? await active.sendMessage(to, part, buffer, mime, partOptions)
+          : await active.sendMessage(to, part, buffer, mime),
+      );
+      acceptedResults.push(accepted);
+      const result = {
+        messageId: accepted.messageId,
+        toJid: resolveActualSentRemoteJid(accepted, jid),
+      };
+      return {
+        ...result,
+        ...(reportProgress
+          ? {
+              receipt: createMessageReceiptFromOutboundResults({
+                results: [{ channel: "whatsapp", ...result }],
+                kind: buffer ? "media" : "text",
+                replyToId,
+              }),
+            }
+          : {}),
+      };
+    };
+    const result = await sendPart(text, mediaBuffer, mediaType);
+    const { messageId, toJid: sentRemoteJid } = result;
     if (trailingTextChunks.length > 0) {
       // Persist each accepted part before the next fallible send so recovery
       // cannot replay already-delivered media or text chunks.
-      await options.onDeliveryResult?.({ messageId, toJid: sentRemoteJid });
+      await reportProgress?.(result);
       for (const trailingText of trailingTextChunks) {
-        const trailingResult = requireWhatsAppAcceptedSendResult(
-          sendOptions
-            ? await active.sendMessage(to, trailingText, undefined, undefined, sendOptions)
-            : await active.sendMessage(to, trailingText, undefined, undefined),
-        );
-        acceptedResults.push(trailingResult);
-        await options.onDeliveryResult?.({
-          messageId: trailingResult.messageId,
-          toJid: resolveActualSentRemoteJid(trailingResult, jid),
-        });
+        const trailingResult = await sendPart(trailingText);
+        await reportProgress?.(trailingResult);
       }
     }
     const durationMs = Date.now() - startedAt;

--- a/extensions/whatsapp/src/send.voice-delivery.test.ts
+++ b/extensions/whatsapp/src/send.voice-delivery.test.ts
@@ -186,10 +186,22 @@ describe("WhatsApp gateway voice delivery", () => {
     expect(onDeliveryResult).toHaveBeenNthCalledWith(1, {
       messageId: "gateway-scoped-voice",
       toJid: "1555@s.whatsapp.net",
+      receipt: expect.objectContaining({
+        platformMessageIds: ["gateway-scoped-voice"],
+        parts: [
+          expect.objectContaining({ platformMessageId: "gateway-scoped-voice", kind: "media" }),
+        ],
+      }),
     });
     expect(onDeliveryResult).toHaveBeenNthCalledWith(2, {
       messageId: "gateway-scoped-caption",
       toJid: "1555@s.whatsapp.net",
+      receipt: expect.objectContaining({
+        platformMessageIds: ["gateway-scoped-caption"],
+        parts: [
+          expect.objectContaining({ platformMessageId: "gateway-scoped-caption", kind: "text" }),
+        ],
+      }),
     });
     expect(recordChannelActivity).toHaveBeenCalledExactlyOnceWith({
       channel: "whatsapp",

--- a/extensions/whatsapp/src/targets-runtime.ts
+++ b/extensions/whatsapp/src/targets-runtime.ts
@@ -440,10 +440,9 @@ export function markdownToWhatsAppChunks(
   }
   const { ir, escapedMarkers } = prepareWhatsAppMarkdown(text, tableMode);
   const render = (chunk: MarkdownIR) => renderWhatsAppMarkdownIR(chunk, escapedMarkers);
-  const rendered = render(ir);
   let chunks =
     ir.styles.length === 0 && ir.links.length === 0
-      ? chunkMarkdownTextWithMode(rendered, limit, chunkMode)
+      ? chunkMarkdownTextWithMode(render(ir), limit, chunkMode)
       : splitWhatsAppIRForChunkMode(ir, limit, chunkMode).flatMap((source) =>
           renderMarkdownIRChunksWithinLimit({
             ir: source,


### PR DESCRIPTION
## What Problem This Solves

Fixes long WhatsApp replies losing bold and other Markdown formatting when the Gateway splits the raw text before the plugin renders it. The same formatter work also removes unused computation from WhatsApp, Google Chat and Slack outbound processing.

## Why This Change Was Made

WhatsApp's existing sender now owns the complete Markdown input and rendered message limits. Removing its raw adapter chunker fixes both the normal message adapter and payload entrance. Each native send retains its dispatch fence, implicit-first versus explicit/all quote policy, accepted progress and partial-failure identity. Actual per-part quote metadata is recorded in progress receipts. Direct callers still receive the same primary scalar result; media, voice captions, account limits and native caps keep their existing owners. Duplicated send-option types and obsolete chunker scaffolding are removed.

Three independent formatter optimizations stay in their existing owners: avoid a discarded WhatsApp full-message render on styled/link paths; measure Google Chat UTF-8 length without allocating an encoded buffer; and skip Slack's fallback display projection when no native date token can require it. Date fallback role-header protection remains covered.

Production **+91/−93 = −2 lines**; tests **+151/−34 = +117**; docs **+1**. No dependency, config/default, schema, protocol, retry or deadline change. CHANGELOG.md is reserved for release work by current repository policy.

## User Impact

Long WhatsApp replies preserve native styles and quote semantics across rendered chunks. Smaller source preparation costs apply to the selected formatter paths, not provider latency or complete model turns. The existing rendered chunker can leave small remainder chunks; this change preserves its output rather than claiming optimal message counts.

Fresh Node v26.8.1 processes measured 23 fixed workloads in both starting orders, with 11 alternating paired rounds per workload. These are median microseconds per complete formatter operation (before-first / reversed order):

| Workload | Before | Candidate | Time reduction |
| --- | ---: | ---: | ---: |
| WhatsApp short styled text | 12.561 / 12.809 | 10.124 / 10.284 | 19.4% / 19.7% |
| WhatsApp styled paragraphs | 1177.350 / 1168.236 | 1121.176 / 1113.022 | 4.8% / 4.7% |
| Google Chat Unicode chunks | 5771.600 / 5814.150 | 5304.658 / 5400.933 | 8.1% / 7.1% |
| Slack ordinary 4K normalization | 457.741 / 472.401 | 262.148 / 260.454 | 42.7% / 44.9% |
| Slack ordinary 4K chunking | 16868.750 / 17407.812 | 10407.375 / 10362.583 | 38.3% / 40.5% |

All costs remain recorded: WhatsApp short plain text is +0.106–0.180 µs (+2.7–4.7%), 4K plain +0.2–0.3%, links mixed (+0.48%/−0.22%). Slack required date paths cost +0.1–1.4%, depending on workload/order. WhatsApp styled 6K improves only 0.4–1.2%. Two starting orders do not establish statistical significance for small differences. Whole-child RSS includes imports and both variants and is not attributed to either one. Warmup/calibration values were not retained by the original harness.

## Evidence

- **719 tests across 24 canonical suites passed** in 43.66 s, covering all three formatters, shared rendering/sanitization, Slack delivery/readback, Google Chat outbound delivery, WhatsApp direct/voice/adapter/recovery sends, SDK payload planning and reply policy. The seven-case WhatsApp recovery suite was rerun after mechanical type/lint corrections.
- The new real-adapter regression failed before the repair with literal broken Markdown fragments, reproducing the retained built-Gateway native failure. Green coverage checks rendered styles, exact content, per-part quotes/receipts, narrower payload limits, dispatch callbacks and accepted-prefix preservation after cancellation or transport failure. The repaired flow uses the existing formatter’s five balanced parts rather than the three previously broken raw fragments.
- Differential checks passed: 2,496 WhatsApp formatter comparisons; 66,560 Google UTF-8 byte checks plus 928 formatter comparisons; 384 Slack normalization plus 1,536 chunk comparisons. These are overlapping proof layers, not unique user counts. The 12 shared sanitizer composition controls remain included.
- Independent audit recomputed all 506 paired rounds / 1,012 variant samples exactly and verified all 55 measured root inputs and 40 prepared files. Formatter graph SHA256: `62838758adb02a50b329aa9f21623972a6ac0a8ee1ff6af8b49c887cd4e5f45c`. The separate WhatsApp send-owner repair is not in these timing claims.
- Independent source reviews and managed Codex review found no actionable defects. The full changed-file gate passed in 151.63 s after fixing test-only type inference and lint issues; no runtime changes were needed for those retries. The committed build passed in 163.17 s. The final native transport checks passed as detailed below.

Baseline local native Slack passed four fixtures; Google Chat's actual public outbound adapter passed 11 cases / 31 local HTTP sends. WhatsApp's plain and styled cases passed, and its long styled case exposed the repaired bug. These use isolated task state: actual built Gateway/plugins and Crabline native transports for Slack/WhatsApp, deterministic mock OpenAI, and local HTTP boundaries for Google Chat. They are not remote channel authentication or real-model inference. Loopback guards retain and deny the documented background ClawHub discovery attempt; no zero-DNS or successful hosted-catalog claim is made. The same preserved helpers and fixtures now pass against commit `1302ffc312b3ba6bd64c5d3658cdc83371dd95f0`: Google Chat 11 cases / 31 sends and releases (7.88 s), Slack four fixtures plus four signed-webhook checks (33.26 s), and WhatsApp plain → styled → long styled in the original order (40.77 s). The long reply now has five balanced parts reconstructing all 340 characters within the 160-character cap. Both actual Gateway PIDs and all three wrapper process groups are confirmed gone; source/build bindings stayed unchanged. The final helper logic and guard are byte-identical to the preserved failing baseline. These are correctness runs, not end-to-end speed measurements. [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33324476971).

Named follow-ups stay outside this patch: generic aggregate receipts can fill an ambient quote into separately unquoted one-part receipts (already present with the old raw chunks); the generic formatted-send signal field needs an owner audit; rendered-chunk remainder coalescing needs a separate shared-renderer review. The existing WhatsApp test log cleanup race also remains documented. No follow-up or harness fix is counted as an additional performance mechanism.

The latest ClawSweeper review has no actionable findings; its rank-up request to wait for exact-head CI is satisfied. Its stored-data heuristic was checked against the complete adapter diff: this removes internal types/chunking and forwards existing per-call facts, without changing any serialized row, schema or migration contract.
