### PR TITLE
refactor(ui): simplify outbox custody and draft persistence

### DIFF
--- a/ui/src/e2e/composer-draft-store.e2e.test.ts
+++ b/ui/src/e2e/composer-draft-store.e2e.test.ts
@@ -675,7 +675,6 @@ suite.define(() => {
             expectedRevision: 0,
             revision: 59,
             text: "stale attachment draft",
-            attachments: [],
             storedAttachments: null,
             writeId: "stale-missing-payload",
           });

--- a/ui/src/lib/chat/composer-draft-store.runtime.ts
+++ b/ui/src/lib/chat/composer-draft-store.runtime.ts
@@ -231,14 +231,13 @@ export async function prepareDurableComposerRecovery(
     const values: unknown[] = await requestResult(
       store.index(OWNER_INDEX).getAll(ownerKey({ ...owner, scopeKey: "" })),
     );
+    const records = values.map(parseStoredDraft).filter((record) => record !== null);
     const entries: DurableComposerRecoveryEntry[] = [];
-    let activeCount = values.filter((value) => {
-      const record = parseStoredDraft(value);
-      return record && isActiveDraft(record) && !isLegacyChatDraft(record);
-    }).length;
-    for (const value of values) {
-      const record = parseStoredDraft(value);
-      if (!record || !isLegacyChatDraft(record)) {
+    let activeCount = records.filter(
+      (record) => isActiveDraft(record) && !isLegacyChatDraft(record),
+    ).length;
+    for (const record of records) {
+      if (!isLegacyChatDraft(record)) {
         continue;
       }
       if (
@@ -253,7 +252,9 @@ export async function prepareDurableComposerRecovery(
         ...owner,
         scopeKey: `${CHAT_SCOPE_PREFIX}${originalScope ? storedChatOutboxScopeKey(originalScope) : record.scopeKey}`,
       };
-      const destination = await requestResult(store.get(recordKey(scope)));
+      const destination = identifiable
+        ? await requestResult(store.get(recordKey(scope)))
+        : undefined;
       const retired = parseStoredDraft(destination);
       // Only an exact known target can retire its older draft. Today's config
       // cannot identify an old global bucket or retarget a qualified main key.

--- a/ui/src/lib/chat/outbox-recovery.ts
+++ b/ui/src/lib/chat/outbox-recovery.ts
@@ -5,11 +5,7 @@ import {
   outboxPayloadMatchesOwner,
 } from "./outbox-payload-store.runtime.ts";
 import { normalizeStoredSession } from "./outbox-store-codec.ts";
-import {
-  nextDraftRevision,
-  rememberedDraftAttempt,
-  rememberedDraftRevision,
-} from "./outbox-store-draft-state.ts";
+import { nextDraftRevision, readDraftRevisionState } from "./outbox-store-draft-state.ts";
 import {
   notifyStoredChatOutboxChanges,
   readStoredOutboxStore,
@@ -70,11 +66,8 @@ export function captureChatOutboxRecoveryDestination(
     gatewayOwner: target.gatewayOwner,
     recoveryScope: observeOutboxRecoveryOwner(state),
     session: JSON.stringify(session),
-    revision: Math.max(
-      session?.draftRevision ?? 0,
-      rememberedDraftRevision(storage, target.key, storeSessionKey),
-      rememberedDraftAttempt(storage, target.key, storeSessionKey),
-    ),
+    revision: readDraftRevisionState(storage, target.key, storeSessionKey, session?.draftRevision)
+      .latestAttempt,
   };
 }
 

--- a/ui/src/lib/chat/outbox-store-codec.ts
+++ b/ui/src/lib/chat/outbox-store-codec.ts
@@ -24,6 +24,19 @@ export type StoredComposerSession = {
   updatedAt: number;
 };
 
+export function sameQueuedDeliveryVersion(left: ChatQueueItem, right: ChatQueueItem): boolean {
+  return (
+    left.id === right.id &&
+    left.sendRunId === right.sendRunId &&
+    left.sendAttempts === right.sendAttempts &&
+    left.sendState === right.sendState &&
+    left.agentId === right.agentId &&
+    left.sessionKey === right.sessionKey &&
+    left.orderKey === right.orderKey &&
+    left.attachmentPayload?.key === right.attachmentPayload?.key
+  );
+}
+
 function normalizeOptionalBoolean(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined;
 }

--- a/ui/src/lib/chat/outbox-store-draft-state.ts
+++ b/ui/src/lib/chat/outbox-store-draft-state.ts
@@ -53,18 +53,21 @@ export function rememberDraftAttempt(
   bySession.set(storeSessionKey, Math.max(bySession.get(storeSessionKey) ?? 0, draftRevision));
 }
 
-export function rememberedDraftRevision(
+export function readDraftRevisionState(
   storage: Storage,
   storageKey: string,
   storeSessionKey: string,
-): number {
-  return draftRevisionHighWaterByStorage.get(storage)?.get(storageKey)?.get(storeSessionKey) ?? 0;
-}
-
-export function rememberedDraftAttempt(
-  storage: Storage,
-  storageKey: string,
-  storeSessionKey: string,
-): number {
-  return draftAttemptHighWaterByStorage.get(storage)?.get(storageKey)?.get(storeSessionKey) ?? 0;
+  storedRevision: number | undefined,
+): { committed: number; latestAttempt: number } {
+  const committed = Math.max(
+    storedRevision ?? 0,
+    draftRevisionHighWaterByStorage.get(storage)?.get(storageKey)?.get(storeSessionKey) ?? 0,
+  );
+  return {
+    committed,
+    latestAttempt: Math.max(
+      committed,
+      draftAttemptHighWaterByStorage.get(storage)?.get(storageKey)?.get(storeSessionKey) ?? 0,
+    ),
+  };
 }

--- a/ui/src/lib/chat/outbox-store-retirement.ts
+++ b/ui/src/lib/chat/outbox-store-retirement.ts
@@ -1,9 +1,7 @@
 import { getSafeSessionStorage } from "../../local-storage.ts";
-import { normalizeStoredSession } from "./outbox-store-codec.ts";
 import {
   nextDraftRevision,
-  rememberedDraftAttempt,
-  rememberedDraftRevision,
+  readDraftRevisionState,
   rememberDraftAttempt,
   rememberDraftRevision,
 } from "./outbox-store-draft-state.ts";
@@ -71,11 +69,12 @@ export function retireStoredComposerDrafts(
       const storeSessionKey = storedChatOutboxScopeKey(scope);
       const session = store.sessions[storeSessionKey];
       const storedRevision = session?.draftRevision ?? 0;
-      const currentRevision = Math.max(
+      const currentRevision = readDraftRevisionState(
+        storage,
+        storageTarget.key,
+        storeSessionKey,
         storedRevision,
-        rememberedDraftRevision(storage, storageTarget.key, storeSessionKey),
-        rememberedDraftAttempt(storage, storageTarget.key, storeSessionKey),
-      );
+      ).latestAttempt;
       let minimumRevision = target.retireBeforeRevision;
       if (storedRevision < target.retireBeforeRevision) {
         minimumRevision = nextDraftRevision(Math.max(currentRevision, target.retireBeforeRevision));
@@ -103,7 +102,7 @@ export function retireStoredComposerDrafts(
     writeStoredOutboxStore(storage, storageTarget, store);
     const persisted = readStoredOutboxStore(storage, storageTarget);
     for (const { storeSessionKey, revision } of written) {
-      const session = normalizeStoredSession(persisted.sessions[storeSessionKey]);
+      const session = persisted.sessions[storeSessionKey];
       if (
         session?.draftRevision !== revision ||
         Boolean(session.draft) ||

--- a/ui/src/lib/chat/outbox-store.ts
+++ b/ui/src/lib/chat/outbox-store.ts
@@ -260,7 +260,9 @@ function holdComposerRecovery(
   }
   for (const item of queue ?? []) {
     const owner = item.attachmentPayload?.recoveryScope;
-    groups.set(owner, [...(groups.get(owner) ?? []), item]);
+    const rows = groups.get(owner) ?? [];
+    rows.push(item);
+    groups.set(owner, rows);
   }
   for (const [owner, rows] of groups) {
     store.recovery[`${id}:${JSON.stringify(owner ?? null)}`] = {
@@ -414,7 +416,9 @@ export function readStoredOutboxStore(
           ) {
             return true;
           }
-          identified.set(identifiedKey, [...(identified.get(identifiedKey) ?? []), item]);
+          const rows = identified.get(identifiedKey) ?? [];
+          rows.push(item);
+          identified.set(identifiedKey, rows);
           return false;
         });
         for (const [identifiedKey, queue] of identified) {
@@ -547,13 +551,14 @@ export function writeStoredOutboxStore(
   if (pendingLegacyTransfers.has(store) && retained.length < entries.length) {
     throw new Error("Chat outbox migration exceeds retention; source retained");
   }
-  const payload = JSON.stringify({
+  const retainedStore: StoredComposerState = {
     version: 4,
     gatewayOwner: target.gatewayOwner,
     sessions: Object.fromEntries(retained),
     recovery: store.recovery,
     ...(store.legacyReceipts ? { legacyReceipts: store.legacyReceipts } : {}),
-  });
+  };
+  const payload = JSON.stringify(retainedStore);
   // Verification precedes deleting any legacy source, including quota/no-op writes.
   storage.setItem(target.key, payload);
   if (storage.getItem(target.key) !== payload) {
@@ -569,7 +574,7 @@ export function writeStoredOutboxStore(
     }
   }
   pendingLegacyTransfers.delete(store);
-  retireRemovedOutboxPayloads(storage, target, previous, payload);
+  retireRemovedOutboxPayloads(storage, target, previous, retainedStore);
 }
 
 // Cleanup follows a verified metadata commit, never a credential-filtered view.
@@ -577,7 +582,7 @@ function retireRemovedOutboxPayloads(
   storage: Storage,
   target: ComposerStorageTarget,
   previous: string | null,
-  current: string | null,
+  current: StoredComposerState | null,
 ): void {
   if (!previous) {
     return;
@@ -592,11 +597,10 @@ function retireRemovedOutboxPayloads(
     ) {
       return;
     }
-    const references = (raw: string | null) => {
-      if (raw === null) {
+    const references = (value: unknown) => {
+      if (value === null) {
         return [];
       }
-      const value: unknown = JSON.parse(raw);
       if (
         !isRecord(value) ||
         value.version !== 4 ||
@@ -640,7 +644,7 @@ function retireRemovedOutboxPayloads(
       });
     };
     const remaining = new Set(references(current).map((ref) => ref.key));
-    const removed = references(previous).filter((ref) => !remaining.has(ref.key));
+    const removed = references(JSON.parse(previous)).filter((ref) => !remaining.has(ref.key));
     if (removed.length) {
       void removeOutboxPayloads(removed);
     }

--- a/ui/src/pages/chat/chat-outbox-drain.ts
+++ b/ui/src/pages/chat/chat-outbox-drain.ts
@@ -1,5 +1,6 @@
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
+import { sameQueuedDeliveryVersion } from "../../lib/chat/outbox-store-codec.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { isSessionRunActive } from "../../lib/session-run-state.ts";
 import { visibleSessionMatches } from "../../lib/sessions/index.ts";
@@ -26,7 +27,6 @@ import {
   anyChatOutboxPaneMatches,
   readQueuedMessageById,
   removeQueuedMessageWithoutReleasing,
-  sameQueuedDeliveryVersion,
   syncVisibleChatQueueProjection,
   updateQueuedMessageForSession,
 } from "./chat-queue.ts";

--- a/ui/src/pages/chat/chat-outbox-owner.ts
+++ b/ui/src/pages/chat/chat-outbox-owner.ts
@@ -86,9 +86,12 @@ class ChatOutboxGatewayOwner {
     }
     return projected;
   }
-  snapshot(host: Host, scope: Scope): ChatQueueItem[] {
+  snapshot(
+    host: Host,
+    scope: Scope,
+    durable = this.outbox(host, scope)?.queue ?? [],
+  ): ChatQueueItem[] {
     const key = storedChatOutboxScopeKey(scope);
-    const durable = this.outbox(host, scope)?.queue ?? [];
     const state = this.state(host);
     const local = state.byScope.get(key) ?? [];
     const localById = new Map(local.map((item) => [item.id, item]));
@@ -139,14 +142,14 @@ class ChatOutboxGatewayOwner {
             return;
           }
           if (result.status === "ready") {
-            if (result.item.attachmentPayload?.key !== key) {
+            if (result.update.attachmentPayload?.key !== key) {
               // Copy adoption must not overwrite a retry that replaced the captured row.
               if (
                 !updateStoredChatComposerQueueItem(
                   host,
                   outbox.sessionKey,
                   item,
-                  result.item,
+                  { ...item, ...result.update },
                   outbox.agentId,
                 )
               ) {
@@ -155,12 +158,12 @@ class ChatOutboxGatewayOwner {
             }
             this.keep(host, outbox, {
               ...current,
-              attachments: result.item.attachments,
-              ...(result.item.attachmentPayload?.key !== key
+              attachments: result.update.attachments,
+              ...(result.update.attachmentPayload?.key !== key
                 ? {
-                    attachmentPayload: result.item.attachmentPayload,
-                    sendState: result.item.sendState,
-                    sendError: result.item.sendError,
+                    attachmentPayload: result.update.attachmentPayload,
+                    sendState: result.update.sendState,
+                    sendError: result.update.sendError,
                   }
                 : {}),
             });
@@ -378,7 +381,9 @@ class ChatOutboxGatewayOwner {
     this.prune(host);
   }
   allItems(host: Host): ChatQueueItem[] {
-    const durable = listStoredChatOutboxes(host).flatMap((outbox) => this.snapshot(host, outbox));
+    const durable = listStoredChatOutboxes(host).flatMap((outbox) =>
+      this.snapshot(host, outbox, outbox.queue),
+    );
     const local = [...this.state(host).byScope.values()].flat();
     // The snapshot already merges durable and live state. A stale pane-local
     // copy must not hide its sending overlay during connection retirement.

--- a/ui/src/pages/chat/chat-pending-inputs.test.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.test.ts
@@ -244,7 +244,7 @@ describe("server-owned pending input display", () => {
         if (prepared.status !== "ready") {
           throw new Error(`Could not prepare custody attachment: ${prepared.reason}`);
         }
-        queued = prepared.item;
+        queued = { ...queued, ...prepared.update };
         expect(queued.attachmentPayload).toBeDefined();
       }
       const reference = queued.attachmentPayload;

--- a/ui/src/pages/chat/chat-queue.ts
+++ b/ui/src/pages/chat/chat-queue.ts
@@ -417,19 +417,6 @@ export function removeDeliveredQueuedChatSendForRun(
   return removed;
 }
 
-export function sameQueuedDeliveryVersion(left: ChatQueueItem, right: ChatQueueItem): boolean {
-  return (
-    left.id === right.id &&
-    left.sendRunId === right.sendRunId &&
-    left.sendAttempts === right.sendAttempts &&
-    left.sendState === right.sendState &&
-    left.agentId === right.agentId &&
-    left.sessionKey === right.sessionKey &&
-    left.orderKey === right.orderKey &&
-    left.attachmentPayload?.key === right.attachmentPayload?.key
-  );
-}
-
 export function readDeliveredQueuedChatSendForRun(
   host: ChatQueueScopedSessionHost,
   runId: string | undefined,

--- a/ui/src/pages/chat/chat-send-actions.ts
+++ b/ui/src/pages/chat/chat-send-actions.ts
@@ -41,8 +41,6 @@ import { formatConnectError } from "./connect-error.ts";
 import {
   activeQueuedMessageEdit,
   isQueuedMessageBeingEdited,
-  isQueuedMessageRetryBlocked,
-  isQueuedMessageReorderBlocked,
   QUEUED_MESSAGE_RETRY_CONFLICT_ERROR,
   QUEUED_MESSAGE_REORDER_CONFLICT_ERROR,
   QUEUED_MESSAGE_STEER_CONFLICT_ERROR,
@@ -174,7 +172,7 @@ export function moveQueuedChatMessage(
   if (!item || !isMovableChatQueueItem(item)) {
     return "noop";
   }
-  if (isQueuedMessageReorderBlocked(host, id)) {
+  if (isQueuedMessageBeingEdited(host, id)) {
     setChatError(host, QUEUED_MESSAGE_REORDER_CONFLICT_ERROR);
     return "rejected";
   }
@@ -235,7 +233,7 @@ export async function retryQueuedChatMessage(host: ChatHost, id: string) {
   const retriesFailedDelivery = item?.sendState === "failed" && !item.localCommandName;
   const retriesUnconfirmed =
     item?.sendState === "unconfirmed" && Boolean(item.sendRunId) && !item.localCommandName;
-  if (isQueuedMessageRetryBlocked(host, id)) {
+  if (isQueuedMessageBeingEdited(host, id)) {
     setChatError(host, QUEUED_MESSAGE_RETRY_CONFLICT_ERROR);
     return;
   }

--- a/ui/src/pages/chat/chat-send-queue-state.ts
+++ b/ui/src/pages/chat/chat-send-queue-state.ts
@@ -229,6 +229,7 @@ export async function prepareQueuedChatPayload(
   const connectionIsCurrent = captureChatConnectionOwner(host);
   const ownerIsCurrent = captureOutboxPayloadOwner(host);
   const original = queued;
+  const sessionKey = original.sessionKey ?? queuedSessionKey;
   const payload = await prepareOutboxPayload(host, original);
   const current = readQueuedMessageById(host, id);
   if (
@@ -242,47 +243,32 @@ export async function prepareQueuedChatPayload(
     isQueuedMessageBeingEdited(host, id)
   ) {
     if (payload.status === "ready" && !original.attachmentPayload) {
-      retireOutboxPayload(payload.item);
+      retireOutboxPayload(payload.update);
     }
     return "pending";
   }
   if (payload.status === "failed") {
     const failed = failOutboxPayload(current, payload.reason);
-    updateQueuedMessageForSession(host, original.sessionKey ?? queuedSessionKey, id, () => failed);
-    surfaceChatDeliveryFailure(
-      host,
-      original.sessionKey ?? queuedSessionKey,
-      original.agentId,
-      failed.sendError,
-    );
+    updateQueuedMessageForSession(host, sessionKey, id, () => failed);
+    surfaceChatDeliveryFailure(host, sessionKey, original.agentId, failed.sendError);
     return "failed";
   }
-  const hydrated = payload.item;
+  const hydrated = { ...original, ...payload.update };
   if (
     hydrated.attachmentPayload?.key !== original.attachmentPayload?.key &&
     hydrated.sendState === "unconfirmed"
   ) {
-    updateQueuedMessageForSession(
-      host,
-      original.sessionKey ?? queuedSessionKey,
-      id,
-      () => payload.item,
-    );
+    updateQueuedMessageForSession(host, sessionKey, id, () => hydrated);
     return "pending";
   }
   if (
     (!original.attachmentPayload || original.attachmentStorageError) &&
-    !updateQueuedMessageForSession(
-      host,
-      original.sessionKey ?? queuedSessionKey,
-      id,
-      () => payload.item,
-    )
+    !updateQueuedMessageForSession(host, sessionKey, id, () => hydrated)
   ) {
     if (!original.attachmentPayload) {
-      retireOutboxPayload(payload.item);
+      retireOutboxPayload(payload.update);
     }
     return "pending";
   }
-  return payload.item;
+  return hydrated;
 }

--- a/ui/src/pages/chat/chat-send-submit.ts
+++ b/ui/src/pages/chat/chat-send-submit.ts
@@ -598,7 +598,7 @@ export async function handleSendChat(
           (currentEdit === inlineEdit && currentEdit.revision === submittedInlineEditRevision));
       if (!stillOwnsSubmission) {
         if (payload.status === "ready") {
-          retireOutboxPayload(payload.item);
+          retireOutboxPayload(payload.update);
         }
         return;
       }
@@ -606,7 +606,7 @@ export async function handleSendChat(
         setChatError(host, outboxPayloadError(payload.reason));
         return;
       }
-      queued = payload.item;
+      queued = { ...queued, ...payload.update };
       const hold = chatSendHoldReason(host, submittedSessionKey);
       if (hold || (intent && (isChatBusy(host) || hasDirectSessionRun(host)))) {
         retireOutboxPayload(queued);

--- a/ui/src/pages/chat/chat-send-support.ts
+++ b/ui/src/pages/chat/chat-send-support.ts
@@ -2,6 +2,7 @@ import { asOptionalRecord, isRecord } from "@openclaw/normalization-core/record-
 import type { SessionsListResult } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
+import { sameQueuedDeliveryVersion } from "../../lib/chat/outbox-store-codec.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { resolveSessionDisplayName } from "../../lib/session-display.ts";
 import { visibleSessionMatches } from "../../lib/sessions/index.ts";
@@ -16,7 +17,6 @@ import {
   readDeliveredQueuedChatSendForRun,
   readQueuedMessageById,
   removeDeliveredQueuedChatSendForRun,
-  sameQueuedDeliveryVersion,
   updateQueuedMessageForSession,
 } from "./chat-queue.ts";
 import type { TerminalFailureChatSendAck } from "./chat-send-ack.ts";
@@ -239,7 +239,9 @@ export function retireDeliveredQueuedUserTurn(
       return "stale";
     }
     if (result.status === "ready") {
-      const hydratedAttachments = durableDeliveredAttachments(result.item.attachments);
+      const hydratedAttachments = durableDeliveredAttachments(
+        result.update.attachments ?? stored.attachments,
+      );
       if (hydratedAttachments) {
         return commit({
           ...stored,

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -7209,7 +7209,9 @@ describe("handleSendChat", () => {
         expectDefined(stored.queue[0], "stored input"),
       );
       expect(
-        hydrated.status === "ready" ? hydrated.item.attachments?.map(getChatAttachmentDataUrl) : [],
+        hydrated.status === "ready"
+          ? hydrated.update.attachments?.map(getChatAttachmentDataUrl)
+          : [],
       ).toEqual(dataUrls);
       expect(host.chatMessage).toBe("newer input");
       expect(host.request).not.toHaveBeenCalled();
@@ -7249,7 +7251,7 @@ describe("handleSendChat", () => {
     recovery.mockReturnValue(originalRecovery);
     const hydrated = await prepareOutboxPayload(host, queued);
     expect(
-      hydrated.status === "ready" ? hydrated.item.attachments?.map(getChatAttachmentDataUrl) : [],
+      hydrated.status === "ready" ? hydrated.update.attachments?.map(getChatAttachmentDataUrl) : [],
     ).toEqual(dataUrls);
     expect(host.chatMessage).toBe("newer input");
     expect(host.request).not.toHaveBeenCalled();
@@ -7323,7 +7325,7 @@ describe("handleSendChat", () => {
         ),
       ),
     ).toEqual(dataUrls.map((url) => url.split(",")[1]));
-    expect(hydrated).toMatchObject({ status: "ready", item: { attachmentPayload: reference } });
+    expect(hydrated).toMatchObject({ status: "ready", update: { attachmentPayload: reference } });
     expect(write).toHaveBeenCalledTimes(1);
 
     await retryReconnectableQueuedChatSends(recovered);
@@ -7450,9 +7452,9 @@ describe("handleSendChat", () => {
         pending.push(second);
         releaseRead.resolve();
         const [valid, joined] = await Promise.all([first, second]);
-        expect(valid).toMatchObject({ status: "ready", item: { attachmentPayload: reference } });
+        expect(valid).toMatchObject({ status: "ready", update: { attachmentPayload: reference } });
         expect(
-          valid.status === "ready" ? valid.item.attachments?.map(getChatAttachmentDataUrl) : [],
+          valid.status === "ready" ? valid.update.attachments?.map(getChatAttachmentDataUrl) : [],
         ).toEqual(dataUrls);
         const stored = await readPayload(payloadOwner, reference);
         const retained = expectDefined(
@@ -7471,7 +7473,9 @@ describe("handleSendChat", () => {
         if (!reason) {
           expect(read).toHaveBeenCalledTimes(1);
           expect(
-            joined.status === "ready" ? joined.item.attachments?.map(getChatAttachmentDataUrl) : [],
+            joined.status === "ready"
+              ? joined.update.attachments?.map(getChatAttachmentDataUrl)
+              : [],
           ).toEqual(dataUrls);
         }
       } finally {

--- a/ui/src/pages/chat/chat-state-page.ts
+++ b/ui/src/pages/chat/chat-state-page.ts
@@ -40,7 +40,7 @@ import {
   activeQueuedMessageEdit,
   beginQueuedMessageEdit,
   cancelQueuedMessageEdit,
-  isQueuedMessageRemovalBlocked,
+  isQueuedMessageBeingEdited,
   QUEUED_MESSAGE_EDIT_CONFLICT_ERROR,
   QUEUED_MESSAGE_REMOVAL_CONFLICT_ERROR,
   updateQueuedMessageEdit,
@@ -324,7 +324,7 @@ export function createPageState(
     renderLifecycle.invalidate();
   };
   state.removeQueuedMessage = (id) => {
-    if (isQueuedMessageRemovalBlocked(state, id)) {
+    if (isQueuedMessageBeingEdited(state, id)) {
       setChatError(state, QUEUED_MESSAGE_REMOVAL_CONFLICT_ERROR);
       renderLifecycle.invalidate();
       return;

--- a/ui/src/pages/chat/composer-persistence.test.ts
+++ b/ui/src/pages/chat/composer-persistence.test.ts
@@ -318,7 +318,7 @@ describe("chat composer persistence", () => {
     const editedPane = createState({ chatMessage: "draft from the other pane" });
     expect(persistChatComposerState(editedPane)).toBe(true);
 
-    expect(untouchedPersistence.persistForRouteSwitch()).toBe(true);
+    expect(untouchedPersistence.persistForRouteSwitchResult()).toEqual({ status: "persisted" });
     expect(loadChatComposerSnapshot(editedPane, editedPane.sessionKey)?.draft).toBe(
       "draft from the other pane",
     );
@@ -337,12 +337,11 @@ describe("chat composer persistence", () => {
     olderPersistence.schedule();
     newerPane.chatMessage = "newer draft";
     newerPersistence.schedule();
-    expect(newerPersistence.persistForRouteSwitch()).toBe(true);
+    expect(newerPersistence.persistForRouteSwitchResult()).toEqual({ status: "persisted" });
 
     vi.advanceTimersByTime(200);
 
     expect(loadChatComposerSnapshot(newerPane, newerPane.sessionKey)?.draft).toBe("newer draft");
-    expect(olderPersistence.persistForRouteSwitch()).toBe(false);
     expect(olderPersistence.persistForRouteSwitchResult().status).toBe("conflict");
 
     olderPane.chatMessage = "newest draft after conflict";
@@ -391,7 +390,7 @@ describe("chat composer persistence", () => {
     olderPersistence.schedule();
     clearingPane.chatMessage = "";
     clearingPersistence.schedule();
-    expect(clearingPersistence.persistForRouteSwitch()).toBe(true);
+    expect(clearingPersistence.persistForRouteSwitchResult()).toEqual({ status: "persisted" });
 
     vi.advanceTimersByTime(200);
 
@@ -421,7 +420,7 @@ describe("chat composer persistence", () => {
       sessionKey: "global",
       agentId: "alpha",
     });
-    expect(persistence.persistForRouteSwitch()).toBe(true);
+    expect(persistence.persistForRouteSwitchResult()).toEqual({ status: "persisted" });
     expect(persistence.scopeForRouteSwitch()).toEqual({
       sessionKey: "global",
       agentId: "alpha",
@@ -439,7 +438,7 @@ describe("chat composer persistence", () => {
     state.chatMessage = "draft from route input";
     persistence.schedule();
 
-    expect(persistence.persistForRouteSwitch()).toBe(true);
+    expect(persistence.persistForRouteSwitchResult()).toEqual({ status: "persisted" });
     expect(loadChatComposerSnapshot(state, state.sessionKey)?.draft).toBe("draft from route input");
   });
 
@@ -1387,7 +1386,7 @@ describe("chat composer persistence", () => {
     persistence.start();
     offline.chatMessage = "";
     persistence.schedule();
-    expect(persistence.persistForRouteSwitch()).toBe(true);
+    expect(persistence.persistForRouteSwitchResult()).toEqual({ status: "persisted" });
 
     for (let index = 0; index < 21; index += 1) {
       const sessionKey = `agent:draft-${index}:thread`;

--- a/ui/src/pages/chat/composer-persistence.ts
+++ b/ui/src/pages/chat/composer-persistence.ts
@@ -9,14 +9,14 @@ import {
   INTERRUPTED_SETTINGS_WAIT_ERROR,
   MAX_STORED_QUEUE_ITEMS,
   normalizeStoredQueueItem,
+  sameQueuedDeliveryVersion,
   type StoredComposerSession,
 } from "../../lib/chat/outbox-store-codec.ts";
 import {
   nextDraftRevision,
   rememberDraftAttempt,
   rememberDraftRevision,
-  rememberedDraftAttempt,
-  rememberedDraftRevision,
+  readDraftRevisionState,
 } from "../../lib/chat/outbox-store-draft-state.ts";
 import {
   applyStoredChatOutboxScope,
@@ -111,20 +111,6 @@ type ChatComposerPersistOptions = {
   expectedDraftRevision?: number;
 };
 
-function serializeChatAttachment(attachment: ChatAttachment): ChatAttachment | null {
-  const dataUrl = getChatAttachmentDataUrl(attachment);
-  if (!dataUrl) {
-    return null;
-  }
-  return {
-    id: attachment.id,
-    mimeType: attachment.mimeType,
-    ...(attachment.fileName ? { fileName: attachment.fileName } : {}),
-    ...(typeof attachment.sizeBytes === "number" ? { sizeBytes: attachment.sizeBytes } : {}),
-    dataUrl,
-  };
-}
-
 function serializeQueueItem(item: ChatQueueItem): ChatQueueItem | null {
   if (
     !item.id?.trim() ||
@@ -144,7 +130,11 @@ function serializeQueueItem(item: ChatQueueItem): ChatQueueItem | null {
     if (item.attachmentPayload) {
       return metadata;
     }
-    return serializeChatAttachment(attachment) ?? (item.attachmentStorageError ? metadata : null);
+    const dataUrl = getChatAttachmentDataUrl(attachment);
+    if (dataUrl) {
+      return Object.assign(metadata, { dataUrl });
+    }
+    return item.attachmentStorageError ? metadata : null;
   });
   if (item.attachments?.length && attachments.some((attachment) => attachment === null)) {
     return null;
@@ -173,30 +163,17 @@ function queueItemVersionMatches(
   scope: StoredChatOutboxScope,
 ): boolean {
   const canonicalExpected = serializeQueueItemForScope(expected, scope);
-  return Boolean(
-    canonicalExpected &&
-    stored.id === canonicalExpected.id &&
-    stored.sendRunId === canonicalExpected.sendRunId &&
-    stored.sendAttempts === canonicalExpected.sendAttempts &&
-    stored.sendState === canonicalExpected.sendState &&
-    stored.agentId === canonicalExpected.agentId &&
-    stored.sessionKey === canonicalExpected.sessionKey &&
-    stored.orderKey === canonicalExpected.orderKey &&
-    stored.attachmentPayload?.key === canonicalExpected.attachmentPayload?.key,
-  );
+  return Boolean(canonicalExpected && sameQueuedDeliveryVersion(stored, canonicalExpected));
 }
 
 function queueItemsEqual(
   stored: ChatQueueItem,
-  expected: ChatQueueItem,
+  canonicalExpected: ChatQueueItem,
   scope: StoredChatOutboxScope,
 ): boolean {
   const canonicalStored = serializeQueueItemForScope(stored, scope);
-  const canonicalExpected = serializeQueueItemForScope(expected, scope);
   return Boolean(
-    canonicalStored &&
-    canonicalExpected &&
-    JSON.stringify(canonicalStored) === JSON.stringify(canonicalExpected),
+    canonicalStored && JSON.stringify(canonicalStored) === JSON.stringify(canonicalExpected),
   );
 }
 
@@ -225,10 +202,7 @@ function writeStoredComposerSession(
   };
 }
 
-type ChatComposerDraftRevisionState = {
-  committed: number;
-  latestAttempt: number;
-};
+type ChatComposerDraftRevisionState = ReturnType<typeof readDraftRevisionState>;
 
 function loadChatComposerDraftRevisionState(
   state: ChatComposerScope,
@@ -253,17 +227,7 @@ function loadChatComposerDraftRevisionState(
     }
     const storedDraftRevision = session?.draftRevision;
     rememberDraftRevision(storage, target.key, storeSessionKey, storedDraftRevision);
-    const committed = Math.max(
-      storedDraftRevision ?? 0,
-      rememberedDraftRevision(storage, target.key, storeSessionKey),
-    );
-    return {
-      committed,
-      latestAttempt: Math.max(
-        committed,
-        rememberedDraftAttempt(storage, target.key, storeSessionKey),
-      ),
-    };
+    return readDraftRevisionState(storage, target.key, storeSessionKey, storedDraftRevision);
   } catch {
     return { committed: 0, latestAttempt: 0 };
   }
@@ -382,14 +346,8 @@ function persistCapturedChatComposerStateResult(
     // Draft-only rows are bounded and may evict a clear tombstone. Retain the
     // seen revision while this tab is alive so an older failed write cannot
     // treat an evicted scope as revision zero and resurrect stale input.
-    const committedDraftRevision = Math.max(
-      storedDraftRevision ?? 0,
-      rememberedDraftRevision(storage, target.key, storeSessionKey),
-    );
-    const newestDraftAttempt = Math.max(
-      committedDraftRevision,
-      rememberedDraftAttempt(storage, target.key, storeSessionKey),
-    );
+    const { committed: committedDraftRevision, latestAttempt: newestDraftAttempt } =
+      readDraftRevisionState(storage, target.key, storeSessionKey, storedDraftRevision);
     const draftRevision = options.draftRevision ?? nextDraftRevision(newestDraftAttempt);
     if (!Number.isSafeInteger(draftRevision) || draftRevision <= 0) {
       return "conflict";
@@ -666,7 +624,6 @@ type ChatComposerDraftSnapshot = {
   sessionKey: string;
   chatMessage: string;
   goalMode?: ChatGoalDraftMode;
-  agentId?: string;
   expectedDraftRevision: number;
   draftRevision: number;
   attachments: ChatAttachment[];
@@ -825,10 +782,6 @@ export class ChatComposerPersistence {
     return snapshot.scope;
   }
 
-  persistForRouteSwitch(): boolean {
-    return this.persistForRouteSwitchResult().status === "persisted";
-  }
-
   persistForRouteSwitchResult(): ChatComposerPersistResult {
     const state = this.getState();
     if (!state) {
@@ -892,28 +845,12 @@ export class ChatComposerPersistence {
     return result;
   }
 
-  adoptCurrentRoute() {
-    const state = this.getState();
-    if (!state) {
-      return;
-    }
-    this.pending = null;
-    this.clearTimer();
-    const revisions = this.readDraftRevisions(state);
-    this.committedDraftRevision = revisions.committed;
-    this.latestDraftRevision = revisions.latestAttempt;
-    this.lastPersisted = this.snapshot(state, revisions.committed, revisions.committed);
-    this.durableRestoreProtected = false;
-    this.durablePersistence.resetRestoreScope();
-  }
-
   private persistSnapshot(
     state: DurableChatComposerPersistenceState,
     snapshot: ChatComposerDraftSnapshot,
     enforceExpectedRevision = false,
   ): ChatComposerPersistResult {
     const status = persistCapturedChatComposerStateResult(state, snapshot, {
-      agentId: snapshot.agentId,
       draft: snapshot.chatMessage,
       goalMode: snapshot.goalMode ?? null,
       draftRevision: snapshot.draftRevision,
@@ -980,7 +917,6 @@ export class ChatComposerPersistence {
           revision: draftRevision,
           text: normalizeChatComposerDraft(state.chatMessage),
           ...(goalMode ? { goalMode } : {}),
-          attachments,
           storedAttachments: captureDurableChatAttachments(attachments),
           writeId: `${draftRevision}:${Math.random().toString(36).slice(2)}`,
         }
@@ -991,7 +927,6 @@ export class ChatComposerPersistence {
       sessionKey: state.sessionKey,
       chatMessage: normalizeChatComposerDraft(state.chatMessage),
       ...(goalMode ? { goalMode } : {}),
-      ...(scope.agentId ? { agentId: scope.agentId } : {}),
       expectedDraftRevision,
       draftRevision,
       attachments,
@@ -1105,7 +1040,6 @@ export class ChatComposerPersistence {
     this.durablePersistence.restore(
       {
         scope,
-        committedRevision: this.committedDraftRevision,
         latestRevision: restoreRevision,
         signature: chatAttachmentDraftSignature(
           state.chatMessage,

--- a/ui/src/pages/chat/durable-composer-persistence.ts
+++ b/ui/src/pages/chat/durable-composer-persistence.ts
@@ -20,14 +20,12 @@ export type DurableChatComposerSnapshot = {
   revision: number;
   text: string;
   goalMode?: ChatGoalDraftMode;
-  attachments: ChatAttachment[];
   storedAttachments: DurableComposerDraftAttachment[] | null;
   writeId: string;
 };
 
 type RestoreBaseline = {
   scope: DurableComposerDraftScope;
-  committedRevision: number;
   latestRevision: number;
   signature: string;
 };
@@ -189,17 +187,7 @@ export async function hydrateDurableComposerAttachments(
   }
 }
 
-export async function writeDurableComposerSnapshot(snapshot: {
-  scope: DurableComposerDraftScope;
-  expectedRevision: number;
-  expectedWriteId?: string;
-  expectedWriteIds?: readonly string[];
-  revision: number;
-  text: string;
-  goalMode?: ChatGoalDraftMode;
-  storedAttachments: DurableComposerDraftAttachment[] | null;
-  writeId: string;
-}) {
+export async function writeDurableComposerSnapshot(snapshot: DurableChatComposerSnapshot) {
   const { writeDurableComposerDraft } = await loadDurableComposerStore();
   const payloadUnavailable = snapshot.storedAttachments === null;
   const result = await writeDurableComposerDraft(

--- a/ui/src/pages/chat/outbox-blob-recovery.test.ts
+++ b/ui/src/pages/chat/outbox-blob-recovery.test.ts
@@ -59,7 +59,7 @@ async function prepare(host: ReturnType<typeof hostFor>, id: string, sessionKey 
   if (result.status !== "ready") {
     throw new Error("Expected complete stored payload");
   }
-  const { attachmentStorageError: _, ...stored } = result.item;
+  const { attachmentStorageError: _, ...stored } = { ...item, ...result.update };
   return {
     ...stored,
     attachments: item.attachments?.map(({ id: attachmentId, mimeType, fileName, sizeBytes }) => ({
@@ -90,7 +90,7 @@ async function expectBytes(host: ReturnType<typeof hostFor>, item: ChatQueueItem
   const result = await prepareOutboxPayload(host, item, "handoff");
   expect(result.status).toBe("ready");
   expect(
-    result.status === "ready" ? result.item.attachments?.map(getChatAttachmentDataUrl) : [],
+    result.status === "ready" ? result.update.attachments?.map(getChatAttachmentDataUrl) : [],
   ).toEqual([dataUrl]);
 }
 

--- a/ui/src/pages/chat/outbox-payloads.ts
+++ b/ui/src/pages/chat/outbox-payloads.ts
@@ -15,8 +15,11 @@ import {
 } from "./durable-composer-persistence.ts";
 
 type Host = ChatComposerScope;
+type PayloadUpdate = Pick<ChatQueueItem, "attachments" | "attachmentPayload"> & {
+  attachmentStorageError?: undefined;
+} & ({ sendState: "unconfirmed"; sendError: string } | { sendState?: never; sendError?: never });
 type PayloadResult =
-  | { status: "ready"; item: ChatQueueItem }
+  | { status: "ready"; update: PayloadUpdate }
   | { status: "failed"; reason: OutboxPayloadFailure };
 
 export function outboxPayloadError(reason: OutboxPayloadFailure): string {
@@ -56,14 +59,14 @@ async function preparePayload(
   purpose: "send" | "handoff",
 ): Promise<PayloadResult> {
   if (!item.attachments?.length && !item.attachmentPayload && !item.attachmentStorageError) {
-    return { status: "ready", item };
+    return { status: "ready", update: {} };
   }
   // Incognito keeps the existing tab-only inline outbox and its quota. It must
   // never acquire restart-persistent Blob ownership or hydrate a regular row.
   if (host.selectedChatSessionIncognito) {
     return item.attachmentPayload
       ? { status: "failed", reason: "unavailable" }
-      : { status: "ready", item };
+      : { status: "ready", update: {} };
   }
   const recoveryScope = observeOutboxRecoveryOwner(host);
   if (!recoveryScope) {
@@ -118,6 +121,11 @@ async function preparePayload(
       if (!isCurrent()) {
         return { status: "failed", reason: "unavailable" };
       }
+      const update = {
+        attachments,
+        attachmentPayload: item.attachmentPayload,
+        attachmentStorageError: undefined,
+      };
       if (purpose === "send" && item.attachmentPayload.tabId !== tabId) {
         const copy = await writeOutboxPayload(owner, result.value);
         if (copy.status === "failed") {
@@ -131,17 +139,15 @@ async function preparePayload(
         // owns its copied bytes, but needs explicit review before retrying.
         return {
           status: "ready",
-          item: {
-            ...item,
-            attachments,
+          update: {
+            ...update,
             attachmentPayload: copy.value,
             sendState: "unconfirmed",
             sendError: t("chat.sendErrors.outboxPayloadCopied"),
-            attachmentStorageError: undefined,
           },
         };
       }
-      return { status: "ready", item: { ...item, attachments, attachmentStorageError: undefined } };
+      return { status: "ready", update };
     } catch {
       return { status: "failed", reason: "missing" };
     }
@@ -164,12 +170,13 @@ async function preparePayload(
   }
   return {
     status: "ready",
-    item: { ...item, attachmentPayload: result.value, attachmentStorageError: undefined },
+    update: { attachmentPayload: result.value, attachmentStorageError: undefined },
   };
 }
 
 // Preview and drain share reads/copies so a cloned tab cannot create competing refs.
 // Check admission per caller; only equivalent bundle identities and metadata may join.
+// Share attachment updates, never the first caller's delivery state or captured destination.
 const pendingPayloads = new Map<string, Promise<PayloadResult>>();
 export async function prepareOutboxPayload(
   host: Host,
@@ -200,23 +207,10 @@ export async function prepareOutboxPayload(
   if (!isCurrent()) {
     return { status: "failed", reason: "unavailable" };
   }
-  if (result.status === "failed") {
-    return result;
-  }
-  const copied = result.item.attachmentPayload?.key !== reference.key;
-  return {
-    status: "ready",
-    item: {
-      ...item,
-      attachments: result.item.attachments,
-      attachmentPayload: result.item.attachmentPayload,
-      attachmentStorageError: undefined,
-      ...(copied ? { sendState: result.item.sendState, sendError: result.item.sendError } : {}),
-    },
-  };
+  return result;
 }
 
-export function retireOutboxPayload(item: ChatQueueItem): void {
+export function retireOutboxPayload(item: Pick<ChatQueueItem, "attachmentPayload">): void {
   if (item.attachmentPayload) {
     void removeOutboxPayloads([item.attachmentPayload]);
   }

--- a/ui/src/pages/chat/queued-message-edit.test.ts
+++ b/ui/src/pages/chat/queued-message-edit.test.ts
@@ -35,9 +35,6 @@ import {
   beginQueuedMessageEdit,
   cancelQueuedMessageEdit,
   isQueuedMessageBeingEdited,
-  isQueuedMessageRemovalBlocked,
-  isQueuedMessageReorderBlocked,
-  isQueuedMessageRetryBlocked,
   QUEUED_MESSAGE_REORDER_CONFLICT_ERROR,
   updateQueuedMessageEdit,
 } from "./queued-message-edit.ts";
@@ -390,9 +387,6 @@ describe("queued message edit round-trip", () => {
       beginQueuedMessageEdit(host as never, original.id);
 
       expect(isQueuedMessageBeingEdited(peer as never, original.id)).toBe(true);
-      expect(isQueuedMessageRemovalBlocked(peer as never, original.id)).toBe(true);
-      expect(isQueuedMessageReorderBlocked(peer as never, original.id)).toBe(true);
-      expect(isQueuedMessageRetryBlocked(peer as never, original.id)).toBe(true);
       expect(moveQueuedChatMessage(peer as never, original.id, 0)).toBe("rejected");
       await retryQueuedChatMessage(peer as never, original.id);
       await steerQueuedChatMessage(peer as never, original.id);

--- a/ui/src/pages/chat/queued-message-edit.ts
+++ b/ui/src/pages/chat/queued-message-edit.ts
@@ -2,6 +2,7 @@
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { chatQueueOrderKey, isMovableChatQueueItem } from "../../lib/chat/chat-queue-order.ts";
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
+import { sameQueuedDeliveryVersion } from "../../lib/chat/outbox-store-codec.ts";
 import { storageTargetForGateway } from "../../lib/chat/outbox-store.ts";
 import {
   getChatAttachmentDataUrl,
@@ -56,19 +57,6 @@ function currentQueuedMessageEditOwner(host: QueuedMessageEditHost) {
   };
 }
 
-function queuedMessageEditSourceMatches(edit: QueuedMessageEdit, item: ChatQueueItem): boolean {
-  return (
-    item.id === edit.source.id &&
-    item.sendRunId === edit.source.sendRunId &&
-    item.sendAttempts === edit.source.sendAttempts &&
-    item.sendState === edit.source.sendState &&
-    item.agentId === edit.source.agentId &&
-    item.sessionKey === edit.source.sessionKey &&
-    item.orderKey === edit.source.orderKey &&
-    item.attachmentPayload?.key === edit.source.attachmentPayload?.key
-  );
-}
-
 /** Closed outcomes so the page owns the operator-visible wording. */
 type QueuedMessageEditResult = "started" | "unavailable";
 
@@ -119,21 +107,6 @@ export function isQueuedMessageBeingEdited(host: QueuedMessageEditHost, id: stri
       storedChatOutboxScopeKey(pane.chatQueuedEdit) ===
         storedChatOutboxScopeKey(resolveStoredChatOutboxScope(pane, pane.sessionKey)),
   );
-}
-
-/** Removal is a conflicting shared-outbox action while any pane owns the row draft. */
-export function isQueuedMessageRemovalBlocked(host: QueuedMessageEditHost, id: string): boolean {
-  return isQueuedMessageBeingEdited(host, id);
-}
-
-/** Reordering is also conflicting: submit must not restore a stale position. */
-export function isQueuedMessageReorderBlocked(host: QueuedMessageEditHost, id: string): boolean {
-  return isQueuedMessageBeingEdited(host, id);
-}
-
-/** Retrying must not dispatch the source payload while another pane edits it. */
-export function isQueuedMessageRetryBlocked(host: QueuedMessageEditHost, id: string): boolean {
-  return isQueuedMessageBeingEdited(host, id);
 }
 
 export function beginQueuedMessageEdit(
@@ -226,7 +199,7 @@ export function retireEditedQueuedMessageSource(
       edit.sourceWasDurable ||
       isDurableQueuedMessage(host, edit.id) ||
       !source ||
-      !queuedMessageEditSourceMatches(edit, source)
+      !sameQueuedDeliveryVersion(source, edit.source)
     ) {
       return;
     }

--- a/ui/src/pages/new-session/draft-persistence.ts
+++ b/ui/src/pages/new-session/draft-persistence.ts
@@ -1,4 +1,4 @@
-import type { ChatAttachment, DurableComposerDraftAttachment } from "../../lib/chat/chat-types.ts";
+import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
 import type { DurableComposerDraftScope } from "../../lib/chat/composer-draft-store.runtime.ts";
 import { nextDraftRevision } from "../../lib/chat/outbox-store-draft-state.ts";
 import { storageTargetForGateway } from "../../lib/chat/outbox-store.ts";
@@ -11,23 +11,13 @@ import {
   hydrateDurableComposerAttachments,
   reportDurableComposerStorageError,
   writeDurableComposerSnapshot,
+  type DurableChatComposerSnapshot,
 } from "../chat/durable-composer-persistence.ts";
 
 type NewSessionDraftState = {
   message: string;
   attachments: ChatAttachment[];
   incognito: boolean;
-};
-
-type DraftSnapshot = {
-  scope: DurableComposerDraftScope;
-  expectedRevision: number;
-  expectedWriteId?: string;
-  expectedWriteIds: string[];
-  revision: number;
-  text: string;
-  attachments: DurableComposerDraftAttachment[] | null;
-  writeId: string;
 };
 
 const durableComposerStore = import("../../lib/chat/composer-draft-store.runtime.ts");
@@ -47,7 +37,7 @@ export class NewSessionDraftPersistence {
   private pristineMutationBaseline = 0;
   private restoreGeneration = 0;
   private restoredIdentity = "";
-  private pending: DraftSnapshot | null = null;
+  private pending: DurableChatComposerSnapshot | null = null;
   private timer: ReturnType<typeof globalThis.setTimeout> | null = null;
   private incognitoRetirement: Promise<void> = Promise.resolve();
   private readonly committedByScope = new Map<string, number>();
@@ -262,16 +252,7 @@ export class NewSessionDraftPersistence {
     void this.enqueueWrite(async () => {
       const identity = durableComposerScopeIdentity(snapshot.scope);
       try {
-        const { result, payloadUnavailable } = await writeDurableComposerSnapshot({
-          scope: snapshot.scope,
-          expectedRevision: snapshot.expectedRevision,
-          ...(snapshot.expectedWriteId ? { expectedWriteId: snapshot.expectedWriteId } : {}),
-          expectedWriteIds: snapshot.expectedWriteIds,
-          revision: snapshot.revision,
-          text: snapshot.text,
-          storedAttachments: snapshot.attachments,
-          writeId: snapshot.writeId,
-        });
+        const { result, payloadUnavailable } = await writeDurableComposerSnapshot(snapshot);
         if (payloadUnavailable) {
           reportDurableComposerStorageError(snapshot.scope, this.onStorageError);
         }
@@ -322,7 +303,7 @@ export class NewSessionDraftPersistence {
     };
   }
 
-  private snapshot(): DraftSnapshot | null {
+  private snapshot(): DurableChatComposerSnapshot | null {
     const scope = this.scope();
     if (!scope || this.revision <= 0) {
       return null;
@@ -341,7 +322,7 @@ export class NewSessionDraftPersistence {
       expectedWriteIds,
       revision: this.revision,
       text: state.message,
-      attachments: captureDurableChatAttachments(state.attachments),
+      storedAttachments: captureDurableChatAttachments(state.attachments),
       writeId,
     };
   }


### PR DESCRIPTION
Related: #133052 (durable attachment outbox), #133067 (canonical session recovery).

## What Problem This Solves

Maintainer-requested cleanup of the Control UI outbox after the attachment and recovery repairs. Sending, editing, previewing, recovering, and retiring queued messages had accumulated duplicate delivery-version checks, draft revision calculations, snapshot shapes, and repeated storage projections. That duplication makes the durability boundary harder to maintain without improving the user experience.

## Why This Change Was Made

Keep attachment preparation responsible for attachment updates rather than reconstructed queue rows; each delivery owner retains its own captured destination and delivery state. Consolidate the common delivery-version comparison, revision baseline, and durable write snapshot in their existing owners, remove obsolete wrappers/fields, and carry already-prepared facts instead of rereading or reparsing them.

The narrower admission/removal fences remain distinct. Cleanup still follows verified metadata persistence and examines active plus recovery references across principals; it uses the exact retention-filtered object that was serialized. Draft recovery retains its transaction and identity checks while parsing each record once and skipping destination reads that cannot be used.

Production LOC: **+136 / -275, net -139** across 19 files. Tests: **+19 / -23, net -4** across six files. Total: **net -143** across 25 files. This is not a storage redesign: metadata v4, IndexedDB v2, legacy imports, byte limits, retention, and separate draft/queue lifetimes are unchanged. No configuration, schema, dependency, cache, or index additions.

## User Impact

No intended user-visible behavior change. Complete attachment batches remain durable before admission and fully hydrated before transport. Offline reload, explicit recovery confirmation, duplicate-tab uncertainty, credential isolation, native-lock ownership, and stale-write/edit/connection fences retain their existing behavior. There is no partial-send or volatile-storage fallback.

## Evidence

- **Exact-head CI passed on attempt 1:** [run 33324603156](https://github.com/openclaw/openclaw/actions/runs/33324603156), including the required `openclaw/ci-gate`, for `997c18351662adeccbcf9bceeff2a89b354649e9`.
- [ClawSweeper review](https://github.com/openclaw/openclaw/pull/133409#issuecomment-5470156644) found no correctness/security defects. Its CI-completion and read-latest-review rank-up move is complete. The storage classifier does not correspond to a schema/record change; the preserved migration/upgrade contracts are covered below.
- Fresh isolated **Codex autoreview: scoped-clean at P0**, no findings, after the final source adjustment. Four independent architecture-cleanup reviews preceded implementation.
- Current-main drift checked through `86b6ec0afa2c64d2019ffdb681760b433b2e10b1`: all 25 touched files retain their baseline blobs; adjacent placement-cancellation changes do not consume the changed internal APIs.
- **540 focused tests passed** across nine owner/sibling files, including outbox identity, concurrent hydration admission, persistence, send/submit, pending inputs, row editing, and New Session drafts.
- **35 native Chromium tests passed** across seven files using the real browser storage/Web Locks implementation with a mocked Gateway. Coverage includes the original two-large-PNG steering case, exact bytes/run IDs through offline reload, lost-ACK no-replay, blocked IndexedDB upgrade, duplicate tabs, corrupt/wrong-owner bundles, legacy migration, explicit ambiguous-target recovery, delayed admission versus newer composer input, and reconnect/edit ordering.
- **All 25-path changed gates passed**: formatting, types, lint/styles, i18n, architecture/coercion/dependency guards, and unused exports.
- `pnpm build` passed before the final fresh-object serialization adjustment; the final `pnpm ui:build`, all focused tests, native browser tests, and changed gates passed afterward. Final startup JavaScript gzip: **345,896 bytes**, below the unchanged **346,761-byte** enforcement limit.
- Initial native collection was blocked by a missing installed dependency file. `pnpm install --frozen-lockfile` repaired the install without changing manifests or lockfiles. The separate Vite manifest-finalization error-masking defect is recorded as a follow-up and excluded from this PR.

<details>
<summary>Reproduce focused proof</summary>

Unit/owner proof used `OPENCLAW_VITEST_MAX_WORKERS=3` and a dedicated filesystem-module-cache directory:

```bash
OPENCLAW_VITEST_MAX_WORKERS=3 node scripts/run-vitest.mjs ui/src/lib/chat/outbox-store.test.ts ui/src/pages/chat/outbox-identity.test.ts ui/src/pages/chat/outbox-blob-recovery.test.ts ui/src/pages/chat/composer-persistence.test.ts ui/src/pages/chat/chat-send.test.ts ui/src/pages/chat/chat-send-submit.test.ts ui/src/pages/chat/chat-pending-inputs.test.ts ui/src/pages/chat/queued-message-edit.test.ts ui/src/pages/new-session/draft-persistence.test.ts --run
```

Native browser proof used a separate filesystem-module-cache directory:

```bash
OPENCLAW_VITEST_MAX_WORKERS=3 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-outbox-capacity.e2e.test.ts ui/src/e2e/chat-outbox-payloads.e2e.test.ts ui/src/e2e/chat-outbox-recovery.e2e.test.ts ui/src/e2e/composer-draft-store.e2e.test.ts ui/src/e2e/composer-recovery-fences.e2e.test.ts ui/src/e2e/new-session-page.draft-handoff.e2e.test.ts ui/src/e2e/chat-flow.queue-edit.e2e.test.ts
```

```bash
pnpm ui:build
```

Changed checks ran `node scripts/check-changed.mjs --` with the 25 changed paths; no baseline or budget files were modified.

</details>
