### PR TITLE
fix(ui): avoid restoring retired voice transports after restart failure

### DIFF
--- a/ui/src/e2e/new-session-page.cloud-startup.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.e2e.test.ts
@@ -277,9 +277,10 @@ suite.define(() => {
 
       const historyCount = (await gateway.getRequests("chat.history")).length;
       await checkDelivery.click();
-      expect(await gateway.waitForRequest("chat.history", { after: historyCount })).toMatchObject({
-        params: { sessionKey, limit: 1000 },
-      });
+      // Background history loads may arrive before this action's request.
+      await expect
+        .poll(async () => (await gateway.getRequests("chat.history")).slice(historyCount))
+        .toContainEqual(expect.objectContaining({ params: { sessionKey, limit: 1000 } }));
       await pollLocatorText(page.getByRole("alert")).toContain("No matching user message");
       await retainedTurn
         .locator(`img[src="data:image/png;base64,${ONE_PIXEL_PNG_B64}"]`)

--- a/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
@@ -552,9 +552,10 @@ suite.define(() => {
       await checkDelivery.waitFor({ state: "visible" });
       const historyCount = (await gateway.getRequests("chat.history")).length;
       await checkDelivery.click();
-      expect(await gateway.waitForRequest("chat.history", { after: historyCount })).toMatchObject({
-        params: { sessionKey, limit: 1000 },
-      });
+      // Background history loads may arrive before this action's request.
+      await expect
+        .poll(async () => (await gateway.getRequests("chat.history")).slice(historyCount))
+        .toContainEqual(expect.objectContaining({ params: { sessionKey, limit: 1000 } }));
       await pollLocatorText(page.getByRole("alert")).toContain("No matching user message");
       await retainedTurn
         .locator(`img[src="data:image/png;base64,${ONE_PIXEL_PNG_B64}"]`)

--- a/ui/src/pages/chat/realtime-talk-lifecycle.test.ts
+++ b/ui/src/pages/chat/realtime-talk-lifecycle.test.ts
@@ -76,6 +76,69 @@ describe("RealtimeTalkSession lifecycle", () => {
     transportMock.stop.mockClear();
   });
 
+  it("retires a restarted call before allocation and drains its accepted transcript after startup fails", async () => {
+    const saved = createDeferred();
+    let creates = 0;
+    let oldStopsAtAllocation = 0;
+    const request = vi.fn(async (method: string, params?: { voiceSessionId?: string }) => {
+      if (method === "talk.client.create") {
+        creates += 1;
+        if (creates === 2) {
+          oldStopsAtAllocation = transportMock.webRtcStops[0]!.mock.calls.length;
+        }
+        return {
+          provider: "openai",
+          transport: "webrtc",
+          voiceSessionId: params?.voiceSessionId ?? `voice-restart-${creates}`,
+          clientSecret: "fixture-secret",
+        };
+      }
+      if (method === "talk.client.transcript") {
+        await saved.promise;
+      }
+      return { ok: true };
+    });
+    const session = new RealtimeTalkSession({ request } as never, "agent:main:main");
+    try {
+      await session.start();
+      const previous = transcriptContext(transportMock.webRtcContexts);
+      previous.callbacks.onTranscript?.({
+        role: "user",
+        text: "accepted before restart",
+        final: true,
+      });
+      transportMock.start.mockRejectedValueOnce(new Error("replacement startup failed"));
+
+      await expect(session.start()).rejects.toThrow("replacement startup failed");
+
+      expect(oldStopsAtAllocation).toBe(1);
+      expect(transportMock.webRtcStops[0]).toHaveBeenCalledOnce();
+      expect(transportMock.webRtcStops[1]).toHaveBeenCalledOnce();
+      await vi.waitFor(() =>
+        expect(
+          request.mock.calls
+            .filter(([method]) => method === "talk.client.close")
+            .map(([, params]) => params?.voiceSessionId),
+        ).toEqual(["voice-restart-2"]),
+      );
+      previous.callbacks.onTranscript?.({ role: "user", text: "stale after restart", final: true });
+      saved.resolve();
+      await vi.waitFor(() =>
+        expect(
+          request.mock.calls
+            .filter(([method]) => method === "talk.client.close")
+            .map(([, params]) => params?.voiceSessionId),
+        ).toEqual(["voice-restart-2", "voice-restart-1"]),
+      );
+      expect(
+        request.mock.calls.filter(([method]) => method === "talk.client.transcript"),
+      ).toHaveLength(1);
+    } finally {
+      saved.resolve();
+      session.stop();
+    }
+  });
+
   it("retries finalized transcript writes in order", async () => {
     vi.useFakeTimers();
     try {
@@ -115,149 +178,84 @@ describe("RealtimeTalkSession lifecycle", () => {
     }
   });
 
-  it("continues entry ids when the same voice session replaces its transport", async () => {
-    const transcriptEntryIds: string[] = [];
-    const request = vi.fn(async (method: string, params?: { entryId?: string }) => {
-      if (method === "talk.client.create") {
-        return {
-          provider: "openai",
-          transport: "webrtc",
-          voiceSessionId: "voice-resume",
-          clientSecret: "secret",
-        };
-      }
-      if (method === "talk.client.transcript") {
-        transcriptEntryIds.push(String(params?.entryId));
-      }
-      return { ok: true };
-    });
-    const client = { request } as never;
-    const session = new RealtimeTalkSession(client, "agent:main:main", {});
-
+  it("starts fresh transcript ownership when restarting the same browser session", async () => {
+    let creates = 0;
+    const entries: Array<{ voiceSessionId?: string; entryId?: string }> = [];
+    const request = vi.fn(
+      async (method: string, params?: { voiceSessionId?: string; entryId?: string }) => {
+        if (method === "talk.client.create") {
+          return {
+            provider: "openai",
+            transport: "webrtc",
+            voiceSessionId: `voice-restart-${++creates}`,
+            clientSecret: "fixture-secret",
+          };
+        }
+        if (method === "talk.client.transcript") {
+          entries.push({ voiceSessionId: params?.voiceSessionId, entryId: params?.entryId });
+        }
+        return { ok: true };
+      },
+    );
+    const session = new RealtimeTalkSession({ request } as never, "agent:main:main");
     await session.start();
-    const firstContext = transcriptContext(transportMock.webRtcContexts);
-    firstContext.callbacks.onTranscript?.({ role: "user", text: "first", final: true });
-    await firstContext.flushTranscriptWrites?.();
-
+    const first = transcriptContext(transportMock.webRtcContexts);
+    first.callbacks.onTranscript?.({ role: "user", text: "first call", final: true });
+    await first.flushTranscriptWrites?.();
     await session.start();
-    const secondContext = transcriptContext(transportMock.webRtcContexts, 1);
-    secondContext.callbacks.onTranscript?.({ role: "assistant", text: "second", final: true });
-    await secondContext.flushTranscriptWrites?.();
-
-    expect(transcriptEntryIds).toEqual(["1", "2"]);
-    expect(transportMock.webRtcStops[0]).toHaveBeenCalledOnce();
-    expect(transportMock.webRtcStops[0]).toHaveBeenCalledWith({ emitClosed: false });
-    expect(transportMock.webRtcStops[1]).not.toHaveBeenCalled();
-    expect(request.mock.calls.filter(([method]) => method === "talk.client.create")).toEqual([
-      [
-        "talk.client.create",
-        { sessionKey: "agent:main:main", capabilities: ["voice-transcript"] },
-        requestTimeoutOptions,
-      ],
-      [
-        "talk.client.create",
-        {
-          sessionKey: "agent:main:main",
-          voiceSessionId: "voice-resume",
-          capabilities: ["voice-transcript"],
-        },
-        requestTimeoutOptions,
-      ],
+    const second = transcriptContext(transportMock.webRtcContexts, 1);
+    second.callbacks.onTranscript?.({ role: "assistant", text: "second call", final: true });
+    await second.flushTranscriptWrites?.();
+    expect(entries).toEqual([
+      { voiceSessionId: "voice-restart-1", entryId: "1" },
+      { voiceSessionId: "voice-restart-2", entryId: "1" },
     ]);
+    for (const [, params] of request.mock.calls.filter(
+      ([method]) => method === "talk.client.create",
+    )) {
+      expect(params).not.toHaveProperty("voiceSessionId");
+    }
+    expect(transportMock.webRtcStops[0]).toHaveBeenCalledOnce();
+    expect(transportMock.webRtcStops[1]).not.toHaveBeenCalled();
     session.stop();
-    expect(transportMock.webRtcStops[1]).toHaveBeenCalledOnce();
-    expect(transportMock.webRtcStops[1]).toHaveBeenCalledWith();
     await vi.waitFor(() =>
       expect(request.mock.calls.filter(([method]) => method === "talk.client.close")).toHaveLength(
-        1,
+        2,
       ),
     );
-    await Promise.resolve();
-
-    const firstReplacement = new RealtimeTalkSession(client, "agent:main:main");
-    const secondReplacement = new RealtimeTalkSession(client, "agent:main:main");
-    await firstReplacement.start();
-    await secondReplacement.start();
-    firstReplacement.stop();
-    secondReplacement.stop();
   });
 
-  it("restores the existing owner when same-session transport startup fails", async () => {
-    const transcriptEntryIds: string[] = [];
-    const request = vi.fn(async (method: string, params?: { entryId?: string }) => {
+  it("closes both calls when a restart cancels during transport startup", async () => {
+    let creates = 0;
+    const request = vi.fn(async (method: string) => {
       if (method === "talk.client.create") {
         return {
           provider: "openai",
           transport: "webrtc",
-          voiceSessionId: "voice-existing",
-          clientSecret: "secret",
+          voiceSessionId: `voice-cancelled-${++creates}`,
+          clientSecret: "fixture-secret",
         };
-      }
-      if (method === "talk.client.transcript") {
-        transcriptEntryIds.push(String(params?.entryId));
-      }
-      return { ok: true };
-    });
-    const client = { request } as never;
-    const session = new RealtimeTalkSession(client, "agent:main:main");
-
-    await session.start();
-    const existingContext = transcriptContext(transportMock.webRtcContexts);
-    transportMock.start.mockRejectedValueOnce(new Error("replacement startup failed"));
-
-    await expect(session.start()).rejects.toThrow("replacement startup failed");
-    expect(request.mock.calls.some(([method]) => method === "talk.client.close")).toBe(false);
-    expect(transportMock.webRtcStops[0]).not.toHaveBeenCalled();
-    expect(transportMock.webRtcStops[1]).toHaveBeenCalledOnce();
-    expect(transportMock.webRtcStops[1]).toHaveBeenCalledWith({ emitClosed: false });
-
-    existingContext.callbacks.onTranscript?.({ role: "user", text: "still active", final: true });
-    await existingContext.flushTranscriptWrites?.();
-    expect(transcriptEntryIds).toEqual(["1"]);
-
-    const concurrent = new RealtimeTalkSession(client, "agent:main:main");
-    await concurrent.start();
-    concurrent.stop();
-    session.stop();
-  });
-
-  it("keeps the active transport when a replacement cancels during startup", async () => {
-    const transcriptEntryIds: string[] = [];
-    const request = vi.fn(async (method: string, params?: { entryId?: string }) => {
-      if (method === "talk.client.create") {
-        return {
-          provider: "openai",
-          transport: "webrtc",
-          voiceSessionId: "voice-cancelled-replacement",
-          clientSecret: "secret",
-        };
-      }
-      if (method === "talk.client.transcript") {
-        transcriptEntryIds.push(String(params?.entryId));
       }
       return { ok: true };
     });
     const session = new RealtimeTalkSession({ request } as never, "agent:main:main");
     await session.start();
-    const activeContext = transcriptContext(transportMock.webRtcContexts);
+    const previous = transcriptContext(transportMock.webRtcContexts);
     transportMock.start.mockResolvedValueOnce("cancelled");
-
     await session.start();
-
-    expect(transportMock.webRtcStops[0]).not.toHaveBeenCalled();
+    expect(transportMock.webRtcStops[0]).toHaveBeenCalledOnce();
     expect(transportMock.webRtcStops[1]).toHaveBeenCalledWith({ emitClosed: false });
-    expect(request.mock.calls.some(([method]) => method === "talk.client.close")).toBe(false);
-    activeContext.callbacks.onTranscript?.({
-      role: "user",
-      text: "active transport survived",
-      final: true,
-    });
-    await activeContext.flushTranscriptWrites?.();
-    expect(transcriptEntryIds).toEqual(["1"]);
+    previous.callbacks.onTranscript?.({ role: "user", text: "stale call", final: true });
+    await vi.waitFor(() =>
+      expect(request.mock.calls.filter(([method]) => method === "talk.client.close")).toHaveLength(
+        2,
+      ),
+    );
+    expect(request.mock.calls.some(([method]) => method === "talk.client.transcript")).toBe(false);
     session.stop();
   });
 
-  it("restores the active relay when replacement activation throws", async () => {
+  it("retires both relays when restart activation throws", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "talk.client.create") {
         return {
@@ -282,8 +280,8 @@ describe("RealtimeTalkSession lifecycle", () => {
 
     await expect(session.start()).rejects.toThrow("activation failed");
 
-    expect(transportMock.relayStops[0]).not.toHaveBeenCalled();
-    expect(transportMock.relayStops[1]).toHaveBeenCalledWith({ emitClosed: false });
+    expect(transportMock.relayStops[0]).toHaveBeenCalledOnce();
+    expect(transportMock.relayStops[1]).toHaveBeenCalledOnce();
     session.stop();
     expect(transportMock.relayStops[0]).toHaveBeenCalledOnce();
   });
@@ -315,7 +313,7 @@ describe("RealtimeTalkSession lifecycle", () => {
     await expect(session.start()).rejects.toThrow("activation stopped");
 
     expect(transportMock.relayStops[0]).toHaveBeenCalledOnce();
-    expect(transportMock.relayStops[0]).toHaveBeenCalledWith({ emitClosed: false });
+    expect(transportMock.relayStops[0]).toHaveBeenCalledWith();
     expect(transportMock.relayStops[1]).toHaveBeenCalledOnce();
     session.stop();
     expect(transportMock.relayStops[0]).toHaveBeenCalledOnce();
@@ -325,12 +323,13 @@ describe("RealtimeTalkSession lifecycle", () => {
   it("ignores transcripts from a superseded pending replacement", async () => {
     const firstReplacementStart = createDeferred<"ready">();
     const transcriptEntryIds: string[] = [];
+    let creates = 0;
     const request = vi.fn(async (method: string, params?: { entryId?: string }) => {
       if (method === "talk.client.create") {
         return {
           provider: "openai",
           transport: "webrtc",
-          voiceSessionId: "voice-overlapping-replacements",
+          voiceSessionId: `voice-overlapping-${++creates}`,
           clientSecret: "secret",
         };
       }
@@ -360,107 +359,72 @@ describe("RealtimeTalkSession lifecycle", () => {
     session.stop();
   });
 
-  it("does not supersede a replacement when owner admission fails", async () => {
+  it("does not supersede an admitted restart when its predecessor is still draining", async () => {
     const replacementCreate = createDeferred<{
       provider: string;
       transport: "webrtc";
       voiceSessionId: string;
       clientSecret: string;
     }>();
-    let createCount = 0;
+    const predecessorClose = createDeferred();
+    let creates = 0;
     const transcriptEntryIds: string[] = [];
-    const request = vi.fn(async (method: string, params?: { entryId?: string }) => {
-      if (method === "talk.client.create") {
-        createCount += 1;
-        if (createCount === 2) {
-          return await replacementCreate.promise;
+    const request = vi.fn(
+      async (method: string, params?: { voiceSessionId?: string; entryId?: string }) => {
+        if (method === "talk.client.create") {
+          if (++creates === 2) {
+            return await replacementCreate.promise;
+          }
+          return {
+            provider: "openai",
+            transport: "webrtc",
+            voiceSessionId: "voice-admission-1",
+            clientSecret: "fixture-secret",
+          };
         }
-        return {
-          provider: "openai",
-          transport: "webrtc",
-          voiceSessionId: "voice-owner-admission",
-          clientSecret: "secret",
-        };
-      }
-      if (method === "talk.client.transcript") {
-        transcriptEntryIds.push(String(params?.entryId));
-      }
-      return { ok: true };
-    });
+        if (method === "talk.client.close" && params?.voiceSessionId === "voice-admission-1") {
+          await predecessorClose.promise;
+        }
+        if (method === "talk.client.transcript") {
+          transcriptEntryIds.push(String(params?.entryId));
+        }
+        return { ok: true };
+      },
+    );
     const session = new RealtimeTalkSession({ request } as never, "agent:main:main");
-    await session.start();
-
-    const replacement = session.start();
-    await vi.waitFor(() => expect(createCount).toBe(2));
-    await expect(session.start()).rejects.toThrow(
-      "Too many active or closing realtime Talk voice sessions",
-    );
-
-    replacementCreate.resolve({
-      provider: "openai",
-      transport: "webrtc",
-      voiceSessionId: "voice-owner-admission",
-      clientSecret: "secret",
-    });
-    await replacement;
-    expect(request.mock.calls.some(([method]) => method === "talk.client.close")).toBe(false);
-    expect(transportMock.webRtcContexts).toHaveLength(2);
-
-    const activeContext = transcriptContext(transportMock.webRtcContexts, 1);
-    activeContext.callbacks.onTranscript?.({ role: "user", text: "still active", final: true });
-    await activeContext.flushTranscriptWrites?.();
-    expect(transcriptEntryIds).toEqual(["1"]);
-    session.stop();
-  });
-
-  it("stops a pending replacement when transcript overflow closes the active call", async () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    const replacementStart = createDeferred<"ready">();
-    const firstTranscript = createDeferred();
-    const request = vi.fn(async (method: string, params?: { entryId?: string }) => {
-      if (method === "talk.client.create") {
-        return {
-          provider: "openai",
-          transport: "webrtc",
-          voiceSessionId: "voice-overflow-replacement",
-          clientSecret: "secret",
-        };
-      }
-      if (method === "talk.client.transcript" && params?.entryId === "1") {
-        await firstTranscript.promise;
-      }
-      return { ok: true };
-    });
-    const onStatus = vi.fn();
-    const session = new RealtimeTalkSession({ request } as never, "agent:main:main", {
-      onStatus,
-    });
-    await session.start();
-    const activeContext = transcriptContext(transportMock.webRtcContexts);
-    transportMock.start.mockImplementationOnce(async () => await replacementStart.promise);
-
-    const replacement = session.start();
-    await vi.waitFor(() => expect(transportMock.webRtcContexts).toHaveLength(2));
-    for (let index = 0; index < 42; index += 1) {
-      activeContext.callbacks.onTranscript?.({
-        role: "user",
-        text: "x".repeat(9_000),
-        final: true,
+    let replacement: Promise<void> | undefined;
+    try {
+      await session.start();
+      replacement = session.start();
+      await vi.waitFor(() => expect(creates).toBe(2));
+      await expect(session.start()).rejects.toThrow(
+        "Too many active or closing realtime Talk voice sessions",
+      );
+      expect(creates).toBe(2);
+      replacementCreate.resolve({
+        provider: "openai",
+        transport: "webrtc",
+        voiceSessionId: "voice-admission-2",
+        clientSecret: "fixture-secret",
       });
+      await replacement;
+      expect(transportMock.webRtcContexts).toHaveLength(2);
+      expect(transportMock.webRtcStops[1]).not.toHaveBeenCalled();
+      const active = transcriptContext(transportMock.webRtcContexts, 1);
+      active.callbacks.onTranscript?.({ role: "user", text: "still active", final: true });
+      await active.flushTranscriptWrites?.();
+      expect(transcriptEntryIds).toEqual(["1"]);
+    } finally {
+      predecessorClose.resolve();
+      replacementCreate.resolve({
+        provider: "openai",
+        transport: "webrtc",
+        voiceSessionId: "voice-admission-2",
+        clientSecret: "fixture-secret",
+      });
+      session.stop();
+      await replacement;
     }
-
-    expect(onStatus).toHaveBeenCalledWith("error", expect.stringContaining("could not keep up"));
-    expect(warn).toHaveBeenCalledOnce();
-    expect(transportMock.webRtcStops[0]).toHaveBeenCalledWith();
-    expect(transportMock.webRtcStops[1]).toHaveBeenCalledWith({ emitClosed: false });
-
-    replacementStart.resolve("ready");
-    await replacement;
-    firstTranscript.resolve();
-    await vi.waitFor(() =>
-      expect(request.mock.calls.some(([method]) => method === "talk.client.close")).toBe(true),
-    );
-    warn.mockRestore();
   });
 
   it("releases newly allocated owners after transport startup failures", async () => {
@@ -530,12 +494,13 @@ describe("RealtimeTalkSession lifecycle", () => {
   it("does not restore a failed replacement after concurrent stop", async () => {
     const replacementStart = createDeferred<"ready">();
     const transcriptEntryIds: string[] = [];
+    let creates = 0;
     const request = vi.fn(async (method: string, params?: { entryId?: string }) => {
       if (method === "talk.client.create") {
         return {
           provider: "openai",
           transport: "webrtc",
-          voiceSessionId: "voice-concurrent-stop",
+          voiceSessionId: `voice-concurrent-stop-${++creates}`,
           clientSecret: "secret",
         };
       }
@@ -550,14 +515,11 @@ describe("RealtimeTalkSession lifecycle", () => {
     const existingContext = transcriptContext(transportMock.webRtcContexts);
     transportMock.start.mockImplementationOnce(async () => await replacementStart.promise);
 
+    existingContext.callbacks.onTranscript?.({ role: "user", text: "before restart", final: true });
+    await existingContext.flushTranscriptWrites?.();
     const replacing = session.start();
     await vi.waitFor(() => expect(transportMock.webRtcContexts).toHaveLength(2));
-    existingContext.callbacks.onTranscript?.({
-      role: "user",
-      text: "while replacement starts",
-      final: true,
-    });
-    await existingContext.flushTranscriptWrites?.();
+    existingContext.callbacks.onTranscript?.({ role: "user", text: "during restart", final: true });
     expect(transcriptEntryIds).toEqual(["1"]);
 
     session.stop();
@@ -572,7 +534,7 @@ describe("RealtimeTalkSession lifecycle", () => {
     expect(transportMock.webRtcStops[1]).toHaveBeenCalledWith({ emitClosed: false });
     await vi.waitFor(() =>
       expect(request.mock.calls.filter(([method]) => method === "talk.client.close")).toHaveLength(
-        1,
+        2,
       ),
     );
 
@@ -680,7 +642,6 @@ describe("RealtimeTalkSession lifecycle", () => {
     const session = new RealtimeTalkSession({ request } as never, "agent:main:main");
     await session.start();
 
-    session.stop();
     await session.start();
 
     const creates = request.mock.calls.filter(([method]) => method === "talk.client.create");
@@ -697,6 +658,7 @@ describe("RealtimeTalkSession lifecycle", () => {
       ],
     ]);
     finishClose?.();
+    session.stop();
     await Promise.resolve();
   });
 
@@ -726,9 +688,15 @@ describe("RealtimeTalkSession lifecycle", () => {
     const third = new RealtimeTalkSession(client, "agent:main:main");
 
     await first.start();
+    await second.start();
+    await expect(first.start()).rejects.toThrow(
+      "Too many active or closing realtime Talk voice sessions",
+    );
+    expect(transportMock.webRtcStops[0]).not.toHaveBeenCalled();
+    expect(transportMock.webRtcStops[1]).not.toHaveBeenCalled();
+    expect(createCount).toBe(2);
     first.stop();
     await vi.waitFor(() => expect(closes).toHaveLength(1));
-    await second.start();
     second.stop();
     await vi.waitFor(() => expect(closes).toHaveLength(2));
 

--- a/ui/src/pages/chat/realtime-talk-startup-input.test.ts
+++ b/ui/src/pages/chat/realtime-talk-startup-input.test.ts
@@ -180,7 +180,7 @@ describe("Realtime Talk microphone preparation", () => {
   });
 
   it.each([false, true])(
-    "rejects microphone loss during allocation without retiring its predecessor (replacement=%s)",
+    "rejects microphone loss during allocation after retiring any previous call (replacement=%s)",
     async (replacement) => {
       const previous = microphone();
       const candidate = microphone();
@@ -206,18 +206,19 @@ describe("Realtime Talk microphone preparation", () => {
       void starting.catch(() => undefined);
       await waitForFast(() => expect(creates).toBe(replacement ? 2 : 1));
       candidate.track.dispatchEvent(new Event("ended"));
-      allocation.resolve(clientSession());
+      allocation.resolve({ ...clientSession(), voiceSessionId: "voice-input-candidate" });
       await expect(starting).rejects.toThrow("Microphone");
       expect(candidate.track.stop).toHaveBeenCalledOnce();
       expect(transports).toHaveLength(replacement ? 1 : 0);
       if (replacement) {
-        expect(previous.track.stop).not.toHaveBeenCalled();
-        expect(transports[0]?.stop).not.toHaveBeenCalled();
-      } else {
-        await waitForFast(() =>
-          expect(request.mock.calls.some(([method]) => method === "talk.client.close")).toBe(true),
-        );
+        expect(previous.track.stop).toHaveBeenCalledOnce();
+        expect(transports[0]?.stop).toHaveBeenCalledOnce();
       }
+      await waitForFast(() =>
+        expect(
+          request.mock.calls.filter(([method]) => method === "talk.client.close"),
+        ).toHaveLength(replacement ? 2 : 1),
+      );
     },
   );
 });

--- a/ui/src/pages/chat/realtime-talk-transcript-owner.ts
+++ b/ui/src/pages/chat/realtime-talk-transcript-owner.ts
@@ -96,13 +96,9 @@ export function retireUncommittedRealtimeTalkTransport(params: {
   nextTransport: RealtimeTalkTransport | null;
   transport: string;
   owner: ClientVoiceSessionOwner;
-  reusesExistingOwner: boolean;
   closeVoiceSession: () => void;
 }): void {
   params.nextTransport?.stop({ emitClosed: false });
-  if (params.reusesExistingOwner) {
-    return;
-  }
   if (params.transport === "gateway-relay" && params.nextTransport) {
     // The relay transport owns server close once constructed; release browser ownership.
     params.owner.release();

--- a/ui/src/pages/chat/realtime-talk.ts
+++ b/ui/src/pages/chat/realtime-talk.ts
@@ -100,7 +100,6 @@ function normalizeLaunchTransport(value: unknown): RealtimeTalkLaunchTransport |
 function compactLaunchParams(
   params: RealtimeTalkLaunchOptions & {
     sessionKey: string;
-    voiceSessionId?: string;
     mode?: string;
     brain?: string;
   },
@@ -117,7 +116,7 @@ export class RealtimeTalkSession {
   private videoOperation = 0;
   private voiceSessionId: string | undefined;
   private transportGeneration = 0;
-  private readonly transcriptSeqByVoiceSessionId = new Map<string, number>();
+  private transcriptSequence = 0;
   private acceptingTranscripts = false;
   private serverOwnedVoiceSession = false;
   private transcriptQueue = VOICE_TRANSCRIPT_QUEUE_POLICY.createQueue();
@@ -136,16 +135,12 @@ export class RealtimeTalkSession {
     let ownerTransferred = false;
     let input: RealtimeTalkInputController | undefined;
     try {
-      const lifecycleGeneration = ++this.lifecycleGeneration;
-      this.stopPendingStartup();
+      // Each start owns a new call. Provider allocation can retire an earlier
+      // transport, so a failed start cannot restore that transport locally.
+      this.retireTransport();
+      const lifecycleGeneration = this.lifecycleGeneration;
       this.closed = false;
       this.callbacks.onStatus?.("connecting", t("chat.voice.preparing"));
-      const existingTransport = this.transport;
-      const existingVoiceSessionId = this.voiceSessionId;
-      const existingOwner = this.clientVoiceSessionOwner;
-      const existingAcceptingTranscripts = this.acceptingTranscripts;
-      const existingServerOwnedVoiceSession = this.serverOwnedVoiceSession;
-      const existingTransportGeneration = this.transportGeneration;
       const providerVideoCapable = await this.resolveVideoCapability();
       if (this.closed || lifecycleGeneration !== this.lifecycleGeneration) {
         return;
@@ -195,21 +190,6 @@ export class RealtimeTalkSession {
         ownerTransferred = true;
         return;
       }
-      if (
-        existingOwner &&
-        (transport === "gateway-relay" || voiceSessionId !== existingVoiceSessionId)
-      ) {
-        this.closeUnadoptedVoiceSession(voiceSessionId, transport, owner);
-        ownerTransferred = true;
-        throw new Error("Realtime Talk replacement changed the active voice session");
-      }
-      const adoptedOwner =
-        existingOwner && voiceSessionId === existingVoiceSessionId ? existingOwner : owner;
-      if (adoptedOwner !== owner) {
-        owner.release();
-      }
-      // Candidate generations must be unique without retiring the committed transport.
-      // Overlapping starts can then fence every superseded candidate independently.
       const nextTransportGeneration = lifecycleGeneration;
       const callbacks =
         transport === "gateway-relay"
@@ -217,7 +197,7 @@ export class RealtimeTalkSession {
           : this.clientOwnedTranscriptCallbacks(
               voiceSessionId,
               nextTransportGeneration,
-              adoptedOwner.signal,
+              owner.signal,
             );
       const transcriptQueue = this.transcriptQueue;
       let nextTransport: RealtimeTalkTransport | null = null;
@@ -248,10 +228,9 @@ export class RealtimeTalkSession {
         retireUncommittedRealtimeTalkTransport({
           nextTransport,
           transport,
-          owner: adoptedOwner,
-          reusesExistingOwner: Boolean(existingOwner && adoptedOwner === existingOwner),
+          owner,
           closeVoiceSession: () =>
-            this.closeUnadoptedVoiceSession(voiceSessionId, transport, adoptedOwner),
+            this.closeUnadoptedVoiceSession(voiceSessionId, transport, owner),
         });
         ownerTransferred = true;
         throw error;
@@ -267,10 +246,9 @@ export class RealtimeTalkSession {
         retireUncommittedRealtimeTalkTransport({
           nextTransport,
           transport,
-          owner: adoptedOwner,
-          reusesExistingOwner: Boolean(existingOwner && adoptedOwner === existingOwner),
+          owner,
           closeVoiceSession: () =>
-            this.closeUnadoptedVoiceSession(voiceSessionId, transport, adoptedOwner),
+            this.closeUnadoptedVoiceSession(voiceSessionId, transport, owner),
         });
         ownerTransferred = true;
         return;
@@ -284,43 +262,18 @@ export class RealtimeTalkSession {
         owner.release();
         this.clientVoiceSessionOwner = undefined;
       } else {
-        this.clientVoiceSessionOwner = adoptedOwner;
-      }
-      try {
-        // Publish the candidate before releasing bounded events buffered during startup.
-        nextTransport.activate?.();
-      } catch (error) {
-        const canRestoreExistingTransport =
-          !this.closed &&
-          lifecycleGeneration === this.lifecycleGeneration &&
-          this.transport === nextTransport;
-        if (canRestoreExistingTransport) {
-          this.voiceSessionId = existingVoiceSessionId;
-          this.acceptingTranscripts = existingAcceptingTranscripts;
-          this.serverOwnedVoiceSession = existingServerOwnedVoiceSession;
-          this.transportGeneration = existingTransportGeneration;
-          this.transport = existingTransport;
-          this.clientVoiceSessionOwner = existingOwner;
-          retireUncommittedRealtimeTalkTransport({
-            nextTransport,
-            transport,
-            owner: adoptedOwner,
-            reusesExistingOwner: Boolean(existingOwner && adoptedOwner === existingOwner),
-            closeVoiceSession: () =>
-              this.closeUnadoptedVoiceSession(voiceSessionId, transport, adoptedOwner),
-          });
-        } else {
-          // Stop or supersession wins activation and owns allocation cleanup.
-          if (this.transport === nextTransport) {
-            nextTransport.stop({ emitClosed: false });
-          }
-          existingTransport?.stop({ emitClosed: false });
-        }
-        ownerTransferred = true;
-        throw error;
+        this.clientVoiceSessionOwner = owner;
       }
       ownerTransferred = true;
-      existingTransport?.stop({ emitClosed: false });
+      try {
+        // Publish before releasing bounded events buffered during startup.
+        nextTransport.activate?.();
+      } catch (error) {
+        if (this.transport === nextTransport) {
+          this.retireTransport();
+        }
+        throw error;
+      }
     } finally {
       if (input && this.pendingStartup === input) {
         this.pendingStartup = null;
@@ -368,7 +321,6 @@ export class RealtimeTalkSession {
         "talk.client.create",
         compactLaunchParams({
           sessionKey: this.sessionKey,
-          voiceSessionId: this.voiceSessionId,
           ...launchOptions,
         }),
         { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS },
@@ -501,7 +453,7 @@ export class RealtimeTalkSession {
       onTalkEvent: (event) => {
         try {
           // A transport's terminal event owns cleanup, even while its error stays
-          // visible. Retired transports cannot close a replacement using the same id.
+          // visible. Retired transports cannot close a newer call.
           if (
             event.type === "session.closed" &&
             this.transportGeneration === owningGeneration &&
@@ -515,8 +467,7 @@ export class RealtimeTalkSession {
         }
       },
       onTranscript: (entry) => {
-        // Transport replacement can reuse the voice session id, so a retired
-        // transport's late finals are fenced by generation, not id alone.
+        // Retired transports cannot append into a restarted call's write queue.
         if (
           this.transportGeneration !== owningGeneration ||
           this.voiceSessionId !== owningVoiceSessionId ||
@@ -527,8 +478,7 @@ export class RealtimeTalkSession {
         // Persist before notifying: a consumer callback that stops or throws must
         // not be able to drop an already-finalized utterance from the write tail.
         if (entry.final) {
-          const transcriptSeq =
-            (this.transcriptSeqByVoiceSessionId.get(owningVoiceSessionId) ?? 0) + 1;
+          const transcriptSeq = this.transcriptSequence + 1;
           const entryId = String(transcriptSeq);
           const role = entry.role;
           const text = normalizeVoiceTranscriptText(entry.text);
@@ -550,7 +500,7 @@ export class RealtimeTalkSession {
               }
               return;
             }
-            this.transcriptSeqByVoiceSessionId.set(owningVoiceSessionId, transcriptSeq);
+            this.transcriptSequence = transcriptSeq;
             void admission.completion.catch((error: unknown) => {
               if (transcriptSignal.aborted) {
                 return;
@@ -631,7 +581,7 @@ export class RealtimeTalkSession {
       owner: this.clientVoiceSessionOwner,
     } satisfies DetachedVoiceSession;
     detached.transcriptQueue.seal();
-    this.transcriptSeqByVoiceSessionId.delete(voiceSessionId);
+    this.transcriptSequence = 0;
     this.voiceSessionId = undefined;
     this.acceptingTranscripts = false;
     this.serverOwnedVoiceSession = false;


### PR DESCRIPTION
Closes #133387

## What Problem This Solves

Fixes an issue where restarting the private browser voice session could restore an old local transport after startup failed, even though the Gateway had already retired the corresponding provider connection. That left client ownership claiming a call which no longer existed upstream.

## Why This Change Was Made

Each admitted Control UI start now uses the existing retirement path before allocating a fresh call. The old microphone/transport stops, accepted transcript writes drain under their original call ID, and failed startup closes only its fresh allocation. Rejected owner admission leaves the existing call or admitted attempt untouched. Removed old-owner reuse, rollback snapshots/restoration, the per-call transcript sequence map, and the cleanup exception for borrowed ownership.

This aligns the private session class with its only production caller: the chat toggle already stops an active session and constructs a fresh one. `ui/package.json` is private with no package exports. The public Gateway/native `voiceSessionId` resume APIs remain unchanged; their docs promise logical call reuse, not physical provider rollback. A new transactional commit/abort protocol would add a capability to preserve an unreachable client-only promise, so it is not introduced.

Provenance: raw parent comparison confirms commit 835f12ef47e added private-client restoration after transport startup failure; subsequent lifecycle changes carried that path forward. No claim is made that all Gateway replacement behavior was introduced by that commit. Direct OSS Codex source inspection at `codex-rs/core/src/realtime_conversation.rs:532` likewise shows its old conversation is stopped before a new one starts; it supplies no promise of transactional media restoration.

## User Impact

Restart failure leaves coherent stopped/error ownership instead of retaining a dead transport. Normal Talk button behavior remains stop-then-start, including the microphone-before-allocation repair from #133384. No new setting, API, protocol version, schema, dependency, or operator action is required.

## Evidence

- A direct-source Gateway owner probe reproduced old-provider closure before browser readiness, rejected old consult admission, and shared logical-session closure after the replacement failed. It used synthetic callbacks and made no external provider call.
- The new browser-owner regression fails before the repair: the old transport has zero stops at replacement allocation. Afterward it stops exactly once before allocation, while its accepted transcript drains and the failed fresh call closes independently.
- All 283 voice tests across 19 files pass. Coverage includes fresh transcript IDs, cancellation, activation failure, stale allocation/close isolation, owner-budget rejection, microphone preparation/loss, transcript overflow, camera, Google, WebRTC and Gateway relay siblings.
- All 13 related native Chromium browser scenarios pass, including pending permission, denied/overconstrained input, microphone loss, stop/restart races, camera paths and relay backpressure. These use synthetic browser/Gateway fixtures; they are not live provider or physical microphone proof.
- Scoped type-aware lint, formatting and diff checks pass. Independent Codex review reports no actionable P0–P2 findings.

Production: +20/-74, net -54. Tests: +205/-234, net -29. Six files; no generated or dependency changes. No rendering/CSS change: the normal visible flow is unchanged, and browser-flow proof is shared with #133384.

CI follow-up: the first hosted run exposed a pre-existing request-selection race in two cloud recovery E2E assertions. They assumed the next `chat.history` request was the delivery check, but a background request for another session could arrive first. Both now require a new request with the exact recovery session and `limit: 1000`; visible recovery, retained attachment, disabled composer and no-replay assertions remain unchanged. No production or harness change was needed. The local rerun was blocked before tests by an unrelated missing `lit-html/directives/style-map.js` in the shared dependency checkout; final hosted CI validates the corrected scenarios.

Remaining limits: the direct public Gateway replacement API retains its documented stop/replace semantics. This PR does not introduce transactional provider replacement, reconnect logic, or a speech-recognition accuracy guarantee. Broad clean-install validation runs in hosted CI because the shared local dependency checkout has an unrelated pako type-version mismatch.
