### PR TITLE
fix(matrix): deliver buttons and selects in agent replies

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -717,7 +717,6 @@ extensions/matrix/src/matrix/send/client.ts	1
 extensions/matrix/src/matrix/send/formatting.ts	1
 extensions/matrix/src/matrix/thread-bindings.ts	2
 extensions/matrix/src/onboarding.ts	10
-extensions/matrix/src/outbound.ts	1
 extensions/matrix/src/profile-update.ts	2
 extensions/matrix/src/setup-config.ts	6
 extensions/matrix/src/setup-contract.ts	1

--- a/extensions/matrix/src/matrix/draft-stream.test.ts
+++ b/extensions/matrix/src/matrix/draft-stream.test.ts
@@ -89,6 +89,7 @@ const sendModuleMocks = vi.hoisted(() => {
         };
         msgtype?: string;
         live?: boolean;
+        extraContent?: Record<string, unknown>;
       } = {},
     ) => {
       const convertedText = convertMarkdownTablesMock(newText);
@@ -418,6 +419,31 @@ describe("createMatrixDraftStream", () => {
 
     expect(sendMessageMock).toHaveBeenCalledTimes(2);
     expect(sendMessageMock.mock.calls.at(1)?.[1]).not.toHaveProperty("org.matrix.msc4357.live");
+  });
+
+  it("forwards extra Matrix content when finalizing a live draft", async () => {
+    const stream = createMatrixDraftStream({
+      roomId: "!room:test",
+      client,
+      cfg: {} as import("../types.js").CoreConfig,
+      mode: "partial",
+    });
+    const extraContent = {
+      "com.openclaw.presentation": {
+        version: 1,
+        type: "message.presentation",
+      },
+    };
+
+    stream.update("Hello");
+    await stream.stop();
+    await stream.finalizeLive({ extraContent });
+
+    expect(sendModuleMocks.editMessageMatrix).toHaveBeenCalledTimes(1);
+    expect(sendModuleMocks.editMessageMatrix.mock.calls[0]?.[3]).toMatchObject({
+      extraContent,
+      live: false,
+    });
   });
 
   it("marks live finalize failures for normal final delivery fallback", async () => {

--- a/extensions/matrix/src/matrix/draft-stream.ts
+++ b/extensions/matrix/src/matrix/draft-stream.ts
@@ -3,7 +3,7 @@ import { createFinalizableDraftStreamControlsForState } from "openclaw/plugin-sd
 import type { CoreConfig } from "../types.js";
 import type { MatrixClient } from "./sdk.js";
 import { editMessageMatrix, prepareMatrixSingleText, sendSingleTextMessageMatrix } from "./send.js";
-import { MsgType } from "./send/types.js";
+import { MsgType, type MatrixExtraContentFields } from "./send/types.js";
 
 const DEFAULT_THROTTLE_MS = 1000;
 type MatrixDraftPreviewMode = "partial" | "quiet";
@@ -36,7 +36,7 @@ type MatrixDraftStream = {
   /** Cancel pending draft updates without creating a new preview event. */
   discardPending: () => Promise<void>;
   /** Clear the MSC4357 live marker in place when the draft is kept as final text. */
-  finalizeLive: () => Promise<boolean>;
+  finalizeLive: (opts?: { extraContent?: MatrixExtraContentFields }) => Promise<boolean>;
   /** Reset state for the next text block (after tool calls). */
   reset: () => void;
   /** The event ID of the current draft message, if any. */
@@ -162,7 +162,9 @@ export function createMatrixDraftStream(params: {
 
   log?.(`draft-stream: ready (throttleMs=${DEFAULT_THROTTLE_MS})`);
 
-  const finalizeLive = async (): Promise<boolean> => {
+  const finalizeLive = async (
+    opts: { extraContent?: MatrixExtraContentFields } = {},
+  ): Promise<boolean> => {
     // Send a final edit without the MSC4357 live marker to signal that
     // the stream is complete. Supporting clients will stop the streaming
     // animation and display the final content.
@@ -177,6 +179,7 @@ export function createMatrixDraftStream(params: {
           msgtype: preview.msgtype,
           includeMentions: preview.includeMentions,
           live: false,
+          extraContent: opts.extraContent,
         });
         log?.(`draft-stream: finalized ${currentEventId} (MSC4357 stream ended)`);
         return true;

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
@@ -11,6 +11,7 @@ import {
 } from "openclaw/plugin-sdk/reply-payload";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { CoreConfig, MatrixStreamingMode, ReplyToMode } from "../../types.js";
+import { prepareMatrixReplyPayload, resolveMatrixExtraContent } from "../presentation.js";
 import type { MatrixClient } from "../sdk.js";
 import type { createMatrixDraftController } from "./handler-draft-controller.js";
 import {
@@ -150,7 +151,6 @@ export function createMatrixReplyDispatcher(config: {
         return replacement;
       };
       if (draftStream && info.kind !== "tool" && !payload.isCompactionNotice) {
-        const { hasMedia } = resolveSendableOutboundReplyParts(payload);
         const ttsSupplement = getReplyPayloadTtsSupplement(payload);
         const fallbackPayload =
           ttsSupplement &&
@@ -158,13 +158,15 @@ export function createMatrixReplyDispatcher(config: {
           !payload.text?.trim()
             ? { ...payload, text: ttsSupplement.spokenText }
             : payload;
+        const preparedPayload = prepareMatrixReplyPayload(fallbackPayload);
+        const { hasMedia } = resolveSendableOutboundReplyParts(preparedPayload);
 
         if (draftController.draftDisposition() !== "active") {
           await draftStream.discardPending();
           return await completeDelivery(
             await deliverMatrixReplies({
               cfg,
-              replies: [fallbackPayload],
+              replies: [preparedPayload],
               roomId,
               client,
               runtime,
@@ -180,12 +182,12 @@ export function createMatrixReplyDispatcher(config: {
 
         const payloadReplyMismatch =
           !threadTarget &&
-          (replyToMode !== "off" || payload.replyToTag || payload.replyToCurrent) &&
-          normalizeOptionalString(payload.replyToId) !== draftController.currentReplyToId();
+          (replyToMode !== "off" || preparedPayload.replyToTag || preparedPayload.replyToCurrent) &&
+          normalizeOptionalString(preparedPayload.replyToId) !== draftController.currentReplyToId();
         let mustDeliverFinalNormally = draftStream.mustDeliverFinalNormally();
         const canPotentiallyFinalizeDraft =
-          Boolean(payload.text?.trim()) &&
-          !payload.isError &&
+          Boolean(preparedPayload.text?.trim()) &&
+          !preparedPayload.isError &&
           !payloadReplyMismatch &&
           !mustDeliverFinalNormally;
 
@@ -198,23 +200,27 @@ export function createMatrixReplyDispatcher(config: {
         const draftEventId = draftStream.eventId();
         const draftFinalTextNeedsNormalMentionDelivery =
           Boolean(draftEventId) &&
-          typeof payload.text === "string" &&
-          Boolean(payload.text.trim()) &&
-          !payload.isError &&
+          typeof preparedPayload.text === "string" &&
+          Boolean(preparedPayload.text.trim()) &&
+          !preparedPayload.isError &&
           !payloadReplyMismatch &&
           !mustDeliverFinalNormally &&
-          (await matrixTextWouldActivateMentions(client, payload.text));
+          (await matrixTextWouldActivateMentions(client, preparedPayload.text));
 
         if (
           draftEventId &&
-          payload.text &&
-          !payload.isError &&
+          preparedPayload.text &&
+          !preparedPayload.isError &&
           !hasMedia &&
           !payloadReplyMismatch &&
           !mustDeliverFinalNormally &&
           !draftFinalTextNeedsNormalMentionDelivery
         ) {
-          const finalPreviewText = payload.text;
+          const finalPreviewText = preparedPayload.text;
+          const presentationExtraContent = resolveMatrixExtraContent(preparedPayload);
+          const finalEditExtraContent = quietDraftStreaming
+            ? buildMatrixFinalizedPreviewContent(presentationExtraContent)
+            : presentationExtraContent;
           const { prepareMatrixSingleText } = await loadMatrixSendModule();
           const preparedFinalPreviewContent = prepareMatrixSingleText(finalPreviewText, {
             cfg,
@@ -233,7 +239,7 @@ export function createMatrixReplyDispatcher(config: {
             }
           >({
             kind: "final",
-            payload,
+            payload: preparedPayload,
             adapter: defineFinalizableLivePreviewAdapter({
               draft: {
                 flush: async () => {},
@@ -246,13 +252,11 @@ export function createMatrixReplyDispatcher(config: {
                 finalizeLive: !(
                   quietDraftStreaming || !draftStream.matchesPreparedText(finalPreviewText)
                 ),
-                ...(quietDraftStreaming
-                  ? { extraContent: buildMatrixFinalizedPreviewContent() }
-                  : {}),
+                ...(finalEditExtraContent ? { extraContent: finalEditExtraContent } : {}),
               }),
               editFinal: async (_draftEventId, edit) => {
                 if (edit.finalizeLive) {
-                  if (!(await draftStream.finalizeLive())) {
+                  if (!(await draftStream.finalizeLive({ extraContent: edit.extraContent }))) {
                     throw new Error("Matrix draft live finalize failed");
                   }
                   finalizedDraftContent = draftStream.content() ?? preparedFinalPreviewContent;
@@ -284,7 +288,7 @@ export function createMatrixReplyDispatcher(config: {
                 deliver: async () =>
                   await deliverMatrixReplies({
                     cfg,
-                    replies: [fallbackPayload],
+                    replies: [preparedPayload],
                     roomId,
                     client,
                     runtime,
@@ -312,7 +316,7 @@ export function createMatrixReplyDispatcher(config: {
           return await completeDelivery(settledResult);
         } else if (draftEventId && hasMedia && !payloadReplyMismatch) {
           let textEditOk = !mustDeliverFinalNormally;
-          const payloadText = payload.text ?? ttsSupplement?.spokenText;
+          const payloadText = preparedPayload.text ?? ttsSupplement?.spokenText;
           const preparedPayloadContent =
             typeof payloadText === "string"
               ? (await loadMatrixSendModule()).prepareMatrixSingleText(payloadText, {
@@ -363,15 +367,10 @@ export function createMatrixReplyDispatcher(config: {
           const draftContent = draftStream.content();
           const mediaPayload =
             ttsSupplement && reusesDraftAsFinalText
-              ? buildTtsSupplementMediaPayload(payload)
+              ? buildTtsSupplementMediaPayload(preparedPayload)
               : {
-                  ...payload,
-                  text: reusesDraftAsFinalText
-                    ? undefined
-                    : (payload.text ??
-                      (ttsSupplement?.visibleTextAlreadyDelivered === true
-                        ? undefined
-                        : ttsSupplement?.spokenText)),
+                  ...preparedPayload,
+                  text: reusesDraftAsFinalText ? undefined : preparedPayload.text,
                 };
           const providerDraftContent = finalizedDraftContent ?? preparedPayloadContent;
           const previewDelivery =
@@ -419,14 +418,14 @@ export function createMatrixReplyDispatcher(config: {
         }
         const shouldRedactDraft =
           Boolean(draftEventId) &&
-          (payload.isError ||
+          (preparedPayload.isError ||
             payloadReplyMismatch ||
             mustDeliverFinalNormally ||
             draftFinalTextNeedsNormalMentionDelivery);
         const deliverFallback = async () =>
           await deliverMatrixReplies({
             cfg,
-            replies: [fallbackPayload],
+            replies: [preparedPayload],
             roomId,
             client,
             runtime,

--- a/extensions/matrix/src/matrix/monitor/handler-runtime.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-runtime.ts
@@ -1,6 +1,9 @@
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { MatrixClient } from "../sdk.js";
-import { MATRIX_OPENCLAW_FINALIZED_PREVIEW_KEY } from "../send/types.js";
+import {
+  MATRIX_OPENCLAW_FINALIZED_PREVIEW_KEY,
+  type MatrixExtraContentFields,
+} from "../send/types.js";
 
 export type MatrixDraftStreamHandle = {
   update: (text: string) => void;
@@ -11,7 +14,7 @@ export type MatrixDraftStreamHandle = {
   content: () => string | undefined;
   mustDeliverFinalNormally: () => boolean;
   matchesPreparedText: (text: string) => boolean;
-  finalizeLive: () => Promise<boolean>;
+  finalizeLive: (opts?: { extraContent?: MatrixExtraContentFields }) => Promise<boolean>;
   reset: () => void;
 };
 
@@ -26,8 +29,10 @@ export async function redactMatrixDraftEvent(
   );
 }
 
-export function buildMatrixFinalizedPreviewContent(): Record<string, unknown> {
-  return { [MATRIX_OPENCLAW_FINALIZED_PREVIEW_KEY]: true };
+export function buildMatrixFinalizedPreviewContent(
+  extraContent?: MatrixExtraContentFields,
+): MatrixExtraContentFields {
+  return { ...extraContent, [MATRIX_OPENCLAW_FINALIZED_PREVIEW_KEY]: true };
 }
 
 export const loadMatrixSendModule = createLazyRuntimeModule(() => import("../send.js"));

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import type { MessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
 import { MAX_DATE_TIMESTAMP_MS } from "openclaw/plugin-sdk/number-runtime";
 import {
   testing as sessionBindingTesting,
@@ -3057,6 +3058,7 @@ describe("matrix monitor handler draft streaming", () => {
       audioAsVoice?: boolean;
       spokenText?: string;
       ttsSupplement?: { spokenText: string; visibleTextAlreadyDelivered?: boolean };
+      presentation?: MessagePresentation;
       isCompactionNotice?: boolean;
       isError?: boolean;
       replyToId?: string;
@@ -3285,6 +3287,137 @@ describe("matrix monitor handler draft streaming", () => {
       visibleReplySent: true,
       content: "Single block",
       receipt: { primaryPlatformMessageId: "$draft1" },
+    });
+    await finish();
+  });
+
+  it("finalizes streamed Matrix presentations with structured metadata", async () => {
+    const presentation: MessagePresentation = {
+      title: "Environment",
+      blocks: [
+        {
+          type: "select",
+          placeholder: "Environment",
+          options: [
+            {
+              label: "Production",
+              action: { type: "command", command: "/deploy production" },
+            },
+          ],
+        },
+      ],
+    };
+    const finalText = "Choose\n\nEnvironment\n\nEnvironment:\n- Production: `/deploy production`";
+    const { dispatch } = createStreamingHarness({ streaming: "partial" });
+    const { deliver, opts, finish } = await dispatch();
+
+    opts.onPartialReply?.({ text: finalText });
+    await waitForMatrixState(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+    });
+
+    await deliver({ text: "Choose", presentation }, { kind: "final" });
+
+    const editCall = findMockCall(
+      editMessageMatrixMock,
+      "streamed presentation edit",
+      ([, eventId]) => eventId === "$draft1",
+    );
+    expect(String(editCall[2])).toContain("Production");
+    expect(editCall[3]).toMatchObject({
+      live: false,
+      extraContent: {
+        "com.openclaw.presentation": {
+          version: 1,
+          type: "message.presentation",
+          title: "Environment",
+        },
+      },
+    });
+    expect(deliverMatrixRepliesMock).not.toHaveBeenCalled();
+    await finish();
+  });
+
+  it("does not drop controls-only streamed finals", async () => {
+    const presentation: MessagePresentation = {
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [{ label: "Deploy", action: { type: "command", command: "/deploy" } }],
+        },
+      ],
+    };
+    const { dispatch } = createStreamingHarness({ streaming: "partial" });
+    const { deliver, opts, finish } = await dispatch();
+
+    opts.onPartialReply?.({ text: "Working" });
+    await waitForMatrixState(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+    });
+
+    await deliver({ presentation }, { kind: "final" });
+
+    const editCall = findMockCall(
+      editMessageMatrixMock,
+      "controls-only streamed edit",
+      ([, eventId]) => eventId === "$draft1",
+    );
+    expect(String(editCall[2]).trim()).not.toBe("");
+    expect(editCall[3]).toMatchObject({
+      extraContent: {
+        "com.openclaw.presentation": {
+          version: 1,
+          type: "message.presentation",
+        },
+      },
+    });
+    expect(deliverMatrixRepliesMock).not.toHaveBeenCalled();
+    await finish();
+  });
+
+  it("keeps presentation metadata on the media delivery after reusing a draft", async () => {
+    const presentation: MessagePresentation = {
+      title: "Environment",
+      blocks: [
+        {
+          type: "select",
+          options: [{ label: "Production", value: "/deploy production" }],
+        },
+      ],
+    };
+    const { dispatch } = createStreamingHarness({ streaming: "partial" });
+    const { deliver, opts, finish } = await dispatch();
+
+    opts.onPartialReply?.({ text: "Choose" });
+    await waitForMatrixState(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+    });
+
+    await deliver(
+      { text: "Choose", mediaUrl: "https://example.com/image.png", presentation },
+      { kind: "final" },
+    );
+
+    expect(deliverMatrixRepliesMock).toHaveBeenCalledOnce();
+    const delivery = requireRecord(
+      callArg(deliverMatrixRepliesMock, 0, 0, "media presentation delivery"),
+      "media presentation delivery",
+    );
+    const deliveredPayload = requireRecord(
+      requireArray(delivery.replies, "media presentation replies")[0],
+      "media presentation payload",
+    );
+    expect(deliveredPayload.presentation).toBeUndefined();
+    expect(deliveredPayload.channelData).toMatchObject({
+      matrix: {
+        extraContent: {
+          "com.openclaw.presentation": {
+            version: 1,
+            type: "message.presentation",
+            title: "Environment",
+          },
+        },
+      },
     });
     await finish();
   });

--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -603,6 +603,44 @@ describe("deliverMatrixReplies", () => {
     expect(sendOptions(0).extraContent).toBeUndefined();
   });
 
+  it("keeps supported metadata beside authored fallback data blocks", async () => {
+    await deliverMatrixReplies({
+      cfg,
+      replies: [
+        {
+          text: "Authored table fallback",
+          presentationTextMode: "fallback",
+          presentation: {
+            title: "Status",
+            blocks: [
+              {
+                type: "table",
+                caption: "Session status",
+                headers: ["Item", "Value"],
+                rows: [["Model", "example/model"]],
+              },
+              { type: "context", text: "Updated 1m ago" },
+            ],
+          },
+        },
+      ],
+      roomId: "room:9",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      replyToMode: "off",
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledOnce();
+    expect(sendCall(0)[1]).toBe("Authored table fallback");
+    expect(sendOptions(0).extraContent).toMatchObject({
+      "com.openclaw.presentation": {
+        version: 1,
+        type: "message.presentation",
+        blocks: expect.arrayContaining([{ type: "context", text: "Updated 1m ago" }]),
+      },
+    });
+  });
+
   it("attaches presentation metadata only to the first Matrix media event", async () => {
     const presentation = {
       title: "Environment",

--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -501,4 +501,142 @@ describe("deliverMatrixReplies", () => {
     expect(sendCall(0)[1]).toBe("caption");
     expect(sendOptions(0).mediaUrl).toBe("https://example.com/a.jpg");
   });
+
+  it("renders presentation metadata for direct Matrix replies", async () => {
+    const presentation = {
+      title: "Environment",
+      blocks: [
+        {
+          type: "select" as const,
+          placeholder: "Environment",
+          options: [
+            {
+              label: "Production",
+              action: { type: "command" as const, command: "/deploy production" },
+            },
+          ],
+        },
+      ],
+    };
+
+    await deliverMatrixReplies({
+      cfg,
+      replies: [{ text: "Choose", presentation }],
+      roomId: "room:7",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      replyToMode: "off",
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledOnce();
+    expect(sendCall(0)[1]).toContain("Production");
+    expect(sendCall(0)[1]).toContain("/deploy production");
+    expect(sendCall(0)[1]).not.toBe("Choose");
+    expect(sendOptions(0).extraContent).toEqual({
+      "com.openclaw.presentation": {
+        ...presentation,
+        version: 1,
+        type: "message.presentation",
+      },
+    });
+  });
+
+  it("does not drop controls-only Matrix replies", async () => {
+    const presentation = {
+      blocks: [
+        {
+          type: "buttons" as const,
+          buttons: [{ label: "Deploy", action: { type: "command" as const, command: "/deploy" } }],
+        },
+      ],
+    };
+
+    const result = await deliverMatrixReplies({
+      cfg,
+      replies: [{ presentation }],
+      roomId: "room:8",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      replyToMode: "off",
+    });
+
+    expect(result.visibleReplySent).toBe(true);
+    expect(sendMessageMatrixMock).toHaveBeenCalledOnce();
+    expect(String(sendCall(0)[1]).trim()).not.toBe("");
+    expect(runtimeEnv.error).not.toHaveBeenCalledWith("matrix reply missing text/media");
+    expect(sendOptions(0).extraContent).toMatchObject({
+      "com.openclaw.presentation": {
+        version: 1,
+        type: "message.presentation",
+      },
+    });
+  });
+
+  it("preserves authored fallback when Matrix drops unsupported data blocks", async () => {
+    await deliverMatrixReplies({
+      cfg,
+      replies: [
+        {
+          text: "Authored table fallback",
+          presentationTextMode: "fallback",
+          presentation: {
+            title: "Status",
+            blocks: [
+              {
+                type: "table",
+                caption: "Session status",
+                headers: ["Item", "Value"],
+                rows: [["Model", "example/model"]],
+              },
+            ],
+          },
+        },
+      ],
+      roomId: "room:9",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      replyToMode: "off",
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledOnce();
+    expect(sendCall(0)[1]).toBe("Authored table fallback");
+    expect(sendOptions(0).extraContent).toBeUndefined();
+  });
+
+  it("attaches presentation metadata only to the first Matrix media event", async () => {
+    const presentation = {
+      title: "Environment",
+      blocks: [
+        {
+          type: "select" as const,
+          options: [{ label: "Production", value: "/deploy production" }],
+        },
+      ],
+    };
+
+    await deliverMatrixReplies({
+      cfg,
+      replies: [
+        {
+          text: "Choose",
+          mediaUrls: ["https://example.com/a.jpg", "https://example.com/b.jpg"],
+          presentation,
+        },
+      ],
+      roomId: "room:9",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      replyToMode: "off",
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(2);
+    expect(sendOptions(0).extraContent).toMatchObject({
+      "com.openclaw.presentation": {
+        version: 1,
+        type: "message.presentation",
+        title: "Environment",
+      },
+    });
+    expect(sendOptions(1).extraContent).toBeUndefined();
+  });
 });

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -12,6 +12,7 @@ import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-pay
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { stripReasoningTagsFromText } from "openclaw/plugin-sdk/text-chunking";
 import { getMatrixRuntime } from "../../runtime.js";
+import { prepareMatrixReplyPayload, resolveMatrixExtraContent } from "../presentation.js";
 import type { MatrixClient } from "../sdk.js";
 import { sendMessageMatrix } from "../send.js";
 import type { MatrixSendResult } from "../send/types.js";
@@ -131,14 +132,18 @@ export async function deliverMatrixReplies(params: {
   const acceptedResults: MatrixSendResult[] = [];
   try {
     for (const reply of params.replies) {
-      const visibleText = resolveVisibleMatrixReplyText(reply.text);
-      const { hasMedia, hasText, mediaUrls } = resolveSendableOutboundReplyParts(reply);
-      if (reply.isReasoning === true || (!hasMedia && reply.text && visibleText === undefined)) {
+      const preparedReply = prepareMatrixReplyPayload(reply);
+      const visibleText = resolveVisibleMatrixReplyText(preparedReply.text);
+      const { hasMedia, hasText, mediaUrls } = resolveSendableOutboundReplyParts(preparedReply);
+      if (
+        preparedReply.isReasoning === true ||
+        (!hasMedia && preparedReply.text && visibleText === undefined)
+      ) {
         logVerbose("matrix reply suppressed as reasoning-only");
         continue;
       }
       if (!hasText && !hasMedia) {
-        if (reply?.audioAsVoice) {
+        if (preparedReply.audioAsVoice) {
           logVerbose("matrix reply has audioAsVoice without media/text; skipping");
           continue;
         }
@@ -146,14 +151,17 @@ export async function deliverMatrixReplies(params: {
         continue;
       }
       const explicitReplyToId =
-        reply.replyToTag || reply.replyToCurrent ? reply.replyToId?.trim() : undefined;
+        preparedReply.replyToTag || preparedReply.replyToCurrent
+          ? preparedReply.replyToId?.trim()
+          : undefined;
       const rawText = visibleText ?? "";
+      const extraContent = resolveMatrixExtraContent(preparedReply);
 
       const replyToIdForReply =
         explicitReplyToId ||
         (params.threadId ||
         (params.replyToMode !== "off" && (params.replyToMode === "all" || !hasRepliedRef.value))
-          ? (reply.replyToId ?? params.replyToId)?.trim()
+          ? (preparedReply.replyToId ?? params.replyToId)?.trim()
           : undefined);
       const onDeliveryResult = (result: MatrixSendResult) => {
         // A concrete event consumes the first-reply slot even when a later event fails.
@@ -171,6 +179,7 @@ export async function deliverMatrixReplies(params: {
           replyToId: replyToIdForReply,
           threadId: params.threadId,
           accountId: params.accountId,
+          extraContent,
           onDeliveryResult,
         });
         continue;
@@ -186,8 +195,9 @@ export async function deliverMatrixReplies(params: {
           mediaLocalRoots: params.mediaLocalRoots,
           replyToId: replyToIdForReply,
           threadId: params.threadId,
-          audioAsVoice: reply.audioAsVoice,
+          audioAsVoice: preparedReply.audioAsVoice,
           accountId: params.accountId,
+          extraContent: first ? extraContent : undefined,
           onDeliveryResult,
         });
         first = false;

--- a/extensions/matrix/src/matrix/presentation.ts
+++ b/extensions/matrix/src/matrix/presentation.ts
@@ -1,0 +1,134 @@
+import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-contract";
+import {
+  adaptMessagePresentationForChannel,
+  normalizeMessagePresentation,
+  renderMessagePresentationFallbackText,
+  type MessagePresentation,
+  type MessagePresentationBlock,
+} from "openclaw/plugin-sdk/interactive-runtime";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { MatrixExtraContentFields } from "./send/types.js";
+
+const MATRIX_OPENCLAW_PRESENTATION_KEY = "com.openclaw.presentation" as const;
+const MATRIX_OPENCLAW_PRESENTATION_TYPE = "message.presentation" as const;
+const MATRIX_EMPTY_PRESENTATION_FALLBACK_TEXT = "---";
+
+export const MATRIX_PRESENTATION_CAPABILITIES = {
+  supported: true,
+  buttons: true,
+  selects: true,
+  context: true,
+  divider: true,
+  limits: {
+    text: {
+      markdownDialect: "markdown",
+      supportsEdit: true,
+    },
+  },
+} satisfies NonNullable<ChannelOutboundAdapter["presentationCapabilities"]>;
+
+function resolveMatrixChannelData(payload: ReplyPayload): Record<string, unknown> {
+  const raw = asOptionalRecord(payload.channelData)?.matrix;
+  return asOptionalRecord(raw) ?? {};
+}
+
+function buildMatrixPresentationContent(presentation: MessagePresentation) {
+  return {
+    ...presentation,
+    version: 1,
+    type: MATRIX_OPENCLAW_PRESENTATION_TYPE,
+  };
+}
+
+function resolveMatrixPresentationContent(
+  payload: ReplyPayload,
+): Record<string, unknown> | undefined {
+  const extraContent = asOptionalRecord(resolveMatrixChannelData(payload).extraContent);
+  const presentation = asOptionalRecord(extraContent?.[MATRIX_OPENCLAW_PRESENTATION_KEY]);
+  if (
+    !presentation ||
+    presentation.version !== 1 ||
+    presentation.type !== MATRIX_OPENCLAW_PRESENTATION_TYPE
+  ) {
+    return undefined;
+  }
+  return presentation;
+}
+
+export function renderMatrixPresentationPayload(params: {
+  payload: ReplyPayload;
+  presentation: MessagePresentation;
+}): ReplyPayload {
+  const matrixData = resolveMatrixChannelData(params.payload);
+  const fallbackText = renderMessagePresentationFallbackText({
+    text: params.payload.text,
+    presentation: params.presentation,
+    emptyFallback: MATRIX_EMPTY_PRESENTATION_FALLBACK_TEXT,
+  });
+  return {
+    ...params.payload,
+    text: fallbackText,
+    channelData: {
+      ...params.payload.channelData,
+      matrix: {
+        ...matrixData,
+        extraContent: {
+          [MATRIX_OPENCLAW_PRESENTATION_KEY]: buildMatrixPresentationContent(params.presentation),
+        },
+      },
+    },
+  };
+}
+
+function countMatrixUnsupportedDataBlocks(blocks: readonly MessagePresentationBlock[]): number {
+  return blocks.filter((block) => block.type === "table" || block.type === "chart").length;
+}
+
+export function prepareMatrixReplyPayload(payload: ReplyPayload): ReplyPayload {
+  const presentation = normalizeMessagePresentation(payload.presentation);
+  if (!presentation) {
+    return payload;
+  }
+  const adaptedPresentation = adaptMessagePresentationForChannel({
+    presentation,
+    capabilities: MATRIX_PRESENTATION_CAPABILITIES,
+  });
+  const textIsFallback = payload.presentationTextMode === "fallback";
+  const hasInteractiveBlocks = presentation.blocks.some(
+    (block) => block.type === "buttons" || block.type === "select",
+  );
+  const {
+    presentation: _presentation,
+    presentationTextMode: _presentationTextMode,
+    ...withoutPresentation
+  } = payload;
+  if (
+    textIsFallback &&
+    payload.text?.trim() &&
+    !hasInteractiveBlocks &&
+    countMatrixUnsupportedDataBlocks(presentation.blocks) > 0 &&
+    countMatrixUnsupportedDataBlocks(adaptedPresentation.blocks) === 0
+  ) {
+    return withoutPresentation;
+  }
+  return renderMatrixPresentationPayload({
+    payload: textIsFallback ? { ...withoutPresentation, text: undefined } : withoutPresentation,
+    presentation: adaptedPresentation,
+  });
+}
+
+export function resolveMatrixPayloadText(payload: ReplyPayload): string {
+  const text = payload.text ?? "";
+  if (text.trim() || !resolveMatrixPresentationContent(payload)) {
+    return text;
+  }
+  return MATRIX_EMPTY_PRESENTATION_FALLBACK_TEXT;
+}
+
+export function resolveMatrixExtraContent(
+  payload: ReplyPayload,
+): MatrixExtraContentFields | undefined {
+  const presentation = resolveMatrixPresentationContent(payload);
+  return presentation ? { [MATRIX_OPENCLAW_PRESENTATION_KEY]: presentation } : undefined;
+}

--- a/extensions/matrix/src/matrix/presentation.ts
+++ b/extensions/matrix/src/matrix/presentation.ts
@@ -103,19 +103,24 @@ export function prepareMatrixReplyPayload(payload: ReplyPayload): ReplyPayload {
     presentationTextMode: _presentationTextMode,
     ...withoutPresentation
   } = payload;
-  if (
+  const unsupportedDataBlockCount = countMatrixUnsupportedDataBlocks(presentation.blocks);
+  const preservesAuthoredDataFallback = Boolean(
     textIsFallback &&
     payload.text?.trim() &&
     !hasInteractiveBlocks &&
-    countMatrixUnsupportedDataBlocks(presentation.blocks) > 0 &&
-    countMatrixUnsupportedDataBlocks(adaptedPresentation.blocks) === 0
-  ) {
+    unsupportedDataBlockCount > 0 &&
+    countMatrixUnsupportedDataBlocks(adaptedPresentation.blocks) === 0,
+  );
+  if (preservesAuthoredDataFallback && unsupportedDataBlockCount === presentation.blocks.length) {
     return withoutPresentation;
   }
-  return renderMatrixPresentationPayload({
+  const renderedPayload = renderMatrixPresentationPayload({
     payload: textIsFallback ? { ...withoutPresentation, text: undefined } : withoutPresentation,
     presentation: adaptedPresentation,
   });
+  return preservesAuthoredDataFallback
+    ? { ...renderedPayload, text: payload.text }
+    : renderedPayload;
 }
 
 export function resolveMatrixPayloadText(payload: ReplyPayload): string {

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -7,96 +7,21 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import { attachChannelToResult } from "openclaw/plugin-sdk/channel-send-result";
 import {
-  renderMessagePresentationFallbackText,
-  type MessagePresentation,
-} from "openclaw/plugin-sdk/interactive-runtime";
-import {
   resolveSendableOutboundReplyParts,
   sendPayloadMediaSequence,
 } from "openclaw/plugin-sdk/reply-payload";
-import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
-import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";
+import {
+  MATRIX_PRESENTATION_CAPABILITIES,
+  renderMatrixPresentationPayload,
+  resolveMatrixExtraContent,
+  resolveMatrixPayloadText,
+} from "./matrix/presentation.js";
 import { sendMessageMatrix, sendPollMatrix } from "./matrix/send.js";
-import type { MatrixExtraContentFields } from "./matrix/send/types.js";
-
-const MATRIX_OPENCLAW_PRESENTATION_KEY = "com.openclaw.presentation" as const;
-const MATRIX_OPENCLAW_PRESENTATION_TYPE = "message.presentation" as const;
-const MATRIX_EMPTY_PRESENTATION_FALLBACK_TEXT = "---";
-
-type MatrixChannelData = {
-  extraContent?: MatrixExtraContentFields;
-};
 
 function toMatrixOutboundResult<T extends { roomId: string }>(result: T) {
   const { roomId, ...delivery } = result;
   return { ...delivery, target: { kind: "room" as const, id: roomId } };
-}
-
-function resolveMatrixChannelData(payload: ReplyPayload): MatrixChannelData {
-  const raw = asOptionalRecord(payload.channelData)?.matrix;
-  return (asOptionalRecord(raw) as MatrixChannelData | undefined) ?? {};
-}
-
-function buildMatrixPresentationContent(presentation: MessagePresentation) {
-  return {
-    ...presentation,
-    version: 1,
-    type: MATRIX_OPENCLAW_PRESENTATION_TYPE,
-  };
-}
-
-function resolveMatrixPresentationContent(
-  payload: ReplyPayload,
-): Record<string, unknown> | undefined {
-  const extraContent = asOptionalRecord(resolveMatrixChannelData(payload).extraContent);
-  const presentation = asOptionalRecord(extraContent?.[MATRIX_OPENCLAW_PRESENTATION_KEY]);
-  if (
-    !presentation ||
-    presentation.version !== 1 ||
-    presentation.type !== MATRIX_OPENCLAW_PRESENTATION_TYPE
-  ) {
-    return undefined;
-  }
-  return presentation;
-}
-
-function renderMatrixPresentationPayload(params: {
-  payload: ReplyPayload;
-  presentation: MessagePresentation;
-}): ReplyPayload {
-  const matrixData = resolveMatrixChannelData(params.payload);
-  const fallbackText = renderMessagePresentationFallbackText({
-    text: params.payload.text,
-    presentation: params.presentation,
-    emptyFallback: MATRIX_EMPTY_PRESENTATION_FALLBACK_TEXT,
-  });
-  return {
-    ...params.payload,
-    text: fallbackText,
-    channelData: {
-      ...params.payload.channelData,
-      matrix: {
-        ...matrixData,
-        extraContent: {
-          [MATRIX_OPENCLAW_PRESENTATION_KEY]: buildMatrixPresentationContent(params.presentation),
-        },
-      },
-    },
-  };
-}
-
-function resolveMatrixPayloadText(payload: ReplyPayload): string {
-  const text = payload.text ?? "";
-  if (text.trim() || !resolveMatrixPresentationContent(payload)) {
-    return text;
-  }
-  return MATRIX_EMPTY_PRESENTATION_FALLBACK_TEXT;
-}
-
-function resolveMatrixExtraContent(payload: ReplyPayload): MatrixExtraContentFields | undefined {
-  const presentation = resolveMatrixPresentationContent(payload);
-  return presentation ? { [MATRIX_OPENCLAW_PRESENTATION_KEY]: presentation } : undefined;
 }
 
 function resolveMatrixDeliveryProgress(
@@ -116,19 +41,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
   chunker: chunkTextForOutbound,
   chunkerMode: "markdown",
   textChunkLimit: 4000,
-  presentationCapabilities: {
-    supported: true,
-    buttons: true,
-    selects: true,
-    context: true,
-    divider: true,
-    limits: {
-      text: {
-        markdownDialect: "markdown",
-        supportsEdit: true,
-      },
-    },
-  },
+  presentationCapabilities: MATRIX_PRESENTATION_CAPABILITIES,
   renderPresentation: ({ payload, presentation }) =>
     renderMatrixPresentationPayload({ payload, presentation }),
   sendPayload: async ({

--- a/extensions/qa-lab/src/live-transports/matrix/matrix-scenario-flows.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/matrix-scenario-flows.test.ts
@@ -77,7 +77,7 @@ describe("Matrix QA Lab scenario flows", () => {
 
   it("expands every Matrix module call through the shared flow host", () => {
     const bindings = new Set<string>();
-    expect(scenarios).toHaveLength(83);
+    expect(scenarios).toHaveLength(84);
     for (const scenario of scenarios) {
       expect(scenario.execution.kind, scenario.id).toBe("flow");
       if (scenario.execution.kind !== "flow") {
@@ -97,7 +97,7 @@ describe("Matrix QA Lab scenario flows", () => {
         "result.details ?? (result.artifacts ? JSON.stringify(result.artifacts, null, 2) : undefined)",
       );
     }
-    expect(bindings.size).toBe(83);
+    expect(bindings.size).toBe(84);
   });
 
   it("prepares the shared canary only for canary-dependent scenarios", () => {

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-prompts.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-prompts.ts
@@ -21,6 +21,11 @@ export function buildMatrixPartialStreamingPrompt(sutUserId: string, text: strin
   return `${sutUserId} Partial streaming QA check: reply exactly \`${text}\`.`;
 }
 
+// The mock provider pauses after separate preview deltas so Matrix must create a draft.
+export function buildMatrixFinalOnlyStreamingPrompt(sutUserId: string, text: string) {
+  return `${sutUserId} Final-only marker streaming QA check: reply exactly \`${text}\`.`;
+}
+
 export const MATRIX_QA_TOOL_PROGRESS_TASK_FILENAME = "QA_KICKOFF_TASK.md";
 const MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME =
   "matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt";

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-room.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-room.ts
@@ -1,5 +1,7 @@
 // QA Lab Matrix plugin module implements scenario runtime room behavior.
 import { randomUUID } from "node:crypto";
+import { setTimeout as sleep } from "node:timers/promises";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   MATRIX_QA_BLOCK_ROOM_KEY,
   MATRIX_QA_MEMBERSHIP_ROOM_KEY,
@@ -55,6 +57,130 @@ export {
   runToolProgressPreviewOptOutScenario,
   runToolProgressPreviewScenario,
 } from "./scenario-runtime-tool-progress.js";
+
+const MATRIX_QA_ASK_USER_QUESTION = "Where should this deploy?";
+const MATRIX_QA_ASK_USER_ANSWER = "Production 🚀";
+
+function requireMatrixQaGatewayCall(context: MatrixQaScenarioContext) {
+  if (!context.gatewayCall) {
+    throw new Error("Matrix presentation QA requires Gateway RPC access");
+  }
+  return context.gatewayCall;
+}
+
+function readPendingMatrixQaQuestion(value: unknown) {
+  if (!isRecord(value) || !Array.isArray(value.questions)) {
+    return undefined;
+  }
+  return value.questions.find((entry) => {
+    if (!isRecord(entry) || entry.status !== "pending" || !Array.isArray(entry.questions)) {
+      return false;
+    }
+    return entry.questions.some(
+      (question) => isRecord(question) && question.question === MATRIX_QA_ASK_USER_QUESTION,
+    );
+  });
+}
+
+async function waitForPendingMatrixQaQuestion(context: MatrixQaScenarioContext) {
+  const gatewayCall = requireMatrixQaGatewayCall(context);
+  const deadline = Date.now() + context.timeoutMs;
+  while (Date.now() < deadline) {
+    const pending = readPendingMatrixQaQuestion(await gatewayCall("question.list", {}));
+    if (pending && typeof pending.id === "string") {
+      return pending.id;
+    }
+    await sleep(100);
+  }
+  throw new Error("Matrix presentation QA did not observe a pending ask_user question");
+}
+
+async function runMatrixPresentationReplyScenario(context: MatrixQaScenarioContext) {
+  const gatewayCall = requireMatrixQaGatewayCall(context);
+  const { client, startSince } = await primeMatrixQaDriverScenarioClient(context);
+  const triggerBody = `${context.sutUserId} tool search qa check target=ask_user ask_user_fixture=single. Ask the question.`;
+  const driverEventId = await client.sendTextMessage({
+    body: triggerBody,
+    mentionUserIds: [context.sutUserId],
+    roomId: context.roomId,
+  });
+  const [pendingQuestionId, presentationEvent] = await Promise.all([
+    waitForPendingMatrixQaQuestion(context),
+    client.waitForRoomEvent({
+      observedEvents: context.observedEvents,
+      predicate: (event) =>
+        event.roomId === context.roomId &&
+        event.sender === context.sutUserId &&
+        isMatrixQaMessageLikeKind(event.kind) &&
+        (event.body ?? "").includes(MATRIX_QA_ASK_USER_QUESTION) &&
+        event.presentation?.type === "message.presentation" &&
+        event.presentation.version === 1 &&
+        Boolean(event.presentation.blockTypes?.includes("buttons")) &&
+        Boolean(event.presentation.buttonLabels?.includes("Staging (Recommended)")) &&
+        Boolean(event.presentation.buttonLabels?.includes(MATRIX_QA_ASK_USER_ANSWER)),
+      roomId: context.roomId,
+      since: startSince,
+      timeoutMs: context.timeoutMs,
+    }),
+  ]);
+  if (presentationEvent.event.replacesEventId) {
+    throw new Error("Matrix presentation QA unexpectedly replaced a draft while streaming was off");
+  }
+  const resolution = await gatewayCall(
+    "question.resolve",
+    {
+      id: pendingQuestionId,
+      answers: { answers: { deploy_target: [MATRIX_QA_ASK_USER_ANSWER] } },
+      resolvedBy: "matrix-qa",
+    },
+    { expectFinal: false, timeoutMs: 5_000 },
+  );
+  if (!isRecord(resolution) || resolution.status !== "answered") {
+    throw new Error(
+      `Matrix presentation QA question resolution failed: ${JSON.stringify(resolution)}`,
+    );
+  }
+  const expectedFinal = `ASK-USER-SINGLE-OK | deploy=${MATRIX_QA_ASK_USER_ANSWER}`;
+  const finalReply = await client.waitForRoomEvent({
+    observedEvents: context.observedEvents,
+    predicate: (event) =>
+      event.roomId === context.roomId &&
+      event.sender === context.sutUserId &&
+      isMatrixQaMessageLikeKind(event.kind) &&
+      event.body === expectedFinal,
+    roomId: context.roomId,
+    since: presentationEvent.since,
+    timeoutMs: context.timeoutMs,
+  });
+  advanceMatrixQaActorCursor({
+    actorId: "driver",
+    syncState: context.syncState,
+    nextSince: finalReply.since,
+    startSince,
+  });
+  const reply = buildMatrixReplyArtifact(presentationEvent.event);
+  return {
+    artifacts: {
+      driverEventId,
+      reply,
+      triggerBody,
+    },
+    details: [
+      `driver event: ${driverEventId}`,
+      `presentation event: ${reply.eventId}`,
+      `presentation replacement target: ${reply.replacesEventId ?? "<none>"}`,
+      `presentation blocks: ${reply.presentation?.blockTypes?.join(",") ?? "<none>"}`,
+      `presentation buttons: ${reply.presentation?.buttonLabels?.join(",") ?? "<none>"}`,
+      `final reply event: ${finalReply.event.eventId}`,
+      `final reply body: ${finalReply.event.body ?? "<none>"}`,
+    ].join("\n"),
+  } satisfies MatrixQaScenarioExecution;
+}
+
+export async function runDirectPresentationReplyScenario(context: MatrixQaScenarioContext) {
+  return await runMatrixPresentationReplyScenario(context);
+}
+
 export async function runBlockStreamingScenario(context: MatrixQaScenarioContext) {
   const roomId = resolveMatrixQaScenarioRoomId(context, MATRIX_QA_BLOCK_ROOM_KEY);
   const { client, startSince } = await primeMatrixQaDriverScenarioClient(context);

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-shared.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-shared.ts
@@ -100,6 +100,7 @@ export function resolveMatrixQaNoReplyWindowMs(timeoutMs: number) {
 export {
   buildExactMarkerPrompt,
   buildMatrixBlockStreamingPrompt,
+  buildMatrixFinalOnlyStreamingPrompt,
   buildMatrixPartialStreamingPrompt,
   buildMatrixQaToken,
   buildMatrixQuietStreamingPrompt,
@@ -146,7 +147,9 @@ export function buildMatrixReplyArtifact(
     bodyPreview: truncateMatrixQaPreview(replyBody),
     eventId: event.eventId,
     mentions: event.mentions,
+    presentation: event.presentation,
     relatesTo: event.relatesTo,
+    replacesEventId: event.replacesEventId,
     sender: event.sender,
     ...(token ? { tokenMatched: doesMatrixQaReplyBodyMatchToken(event, token) } : {}),
   };

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-streaming-preview.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-streaming-preview.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import type { MatrixQaObservedEvent } from "../substrate/events.js";
 import {
   advanceMatrixQaActorCursor,
+  buildMatrixFinalOnlyStreamingPrompt,
   buildMatrixPartialStreamingPrompt,
   buildMatrixQuietStreamingPrompt,
   buildMatrixReplyArtifact,
@@ -59,7 +60,7 @@ export async function runStreamingReplacementRetentionScenario(
   });
   try {
     const firstDriverEventId = await client.sendTextMessage({
-      body: buildMatrixReplacementPrompt(context.sutUserId, firstText),
+      body: buildMatrixFinalOnlyStreamingPrompt(context.sutUserId, firstText),
       mentionUserIds: [context.sutUserId],
       roomId: context.roomId,
     });
@@ -101,7 +102,7 @@ export async function runStreamingReplacementRetentionScenario(
     const secondText = `@room ${buildMatrixStreamingPreviewFinalText("MATRIX_QA_SUPERSEDED_DRAFT")}`;
     const secondToken = secondText.split(" ")[1]!;
     const secondDriverEventId = await client.sendTextMessage({
-      body: buildMatrixReplacementPrompt(context.sutUserId, secondText),
+      body: buildMatrixFinalOnlyStreamingPrompt(context.sutUserId, secondText),
       mentionUserIds: [context.sutUserId],
       roomId: context.roomId,
     });
@@ -215,12 +216,6 @@ export async function runStreamingReplacementRetentionScenario(
   } finally {
     faultRule.remove();
   }
-}
-
-function buildMatrixReplacementPrompt(sutUserId: string, finalText: string) {
-  // This fixture emits a short preview separately before the oversized final;
-  // generic partial streaming can finish before Matrix creates any draft.
-  return `${sutUserId} Final-only marker streaming QA check: reply exactly \`${finalText}\`.`;
 }
 
 function buildMatrixStreamingPreviewFinalText(prefix: string) {

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-types.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-types.ts
@@ -5,7 +5,9 @@ export type MatrixQaReplyArtifact = {
   bodyPreview?: string;
   eventId: string;
   mentions?: MatrixQaObservedEvent["mentions"];
+  presentation?: MatrixQaObservedEvent["presentation"];
   relatesTo?: MatrixQaObservedEvent["relatesTo"];
+  replacesEventId?: string;
   sender?: string;
   tokenMatched?: boolean;
 };

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/events.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/events.test.ts
@@ -114,6 +114,53 @@ describe("matrix observed event normalization", () => {
     });
   });
 
+  it("summarizes presentation metadata from replacement content", () => {
+    expect(
+      normalizeMatrixQaObservedEvent("!room:matrix-qa.test", {
+        event_id: "$replace",
+        sender: "@sut:matrix-qa.test",
+        type: "m.room.message",
+        content: {
+          body: "* Where should this deploy?",
+          msgtype: "m.text",
+          "m.new_content": {
+            body: "Where should this deploy?",
+            msgtype: "m.text",
+            "com.openclaw.presentation": {
+              version: 1,
+              type: "message.presentation",
+              title: "Deploy",
+              blocks: [
+                { type: "text", text: "Where should this deploy?" },
+                {
+                  type: "buttons",
+                  buttons: [
+                    { label: "Staging", action: { type: "question" } },
+                    { label: "Production", action: { type: "question" } },
+                  ],
+                },
+              ],
+            },
+          },
+          "m.relates_to": {
+            rel_type: "m.replace",
+            event_id: "$draft",
+          },
+        },
+      }),
+    ).toMatchObject({
+      body: "Where should this deploy?",
+      presentation: {
+        blockTypes: ["text", "buttons"],
+        buttonLabels: ["Staging", "Production"],
+        title: "Deploy",
+        type: "message.presentation",
+        version: 1,
+      },
+      replacesEventId: "$draft",
+    });
+  });
+
   it.each([
     { name: "initial preview", content: { "org.matrix.msc4357.live": {} }, live: true },
     {

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/events.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/events.ts
@@ -1,5 +1,6 @@
 // Qa Lab Matrix module implements events behavior.
 import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 export type MatrixQaRoomEvent = {
   content?: Record<string, unknown>;
   event_id?: string;
@@ -39,6 +40,14 @@ type MatrixQaObservedApproval = {
   version?: number;
 };
 
+type MatrixQaObservedPresentation = {
+  blockTypes?: string[];
+  buttonLabels?: string[];
+  title?: string;
+  type?: string;
+  version?: number;
+};
+
 export type MatrixQaObservedEvent = {
   kind: MatrixQaObservedEventKind;
   roomId: string;
@@ -70,9 +79,11 @@ export type MatrixQaObservedEvent = {
   redactsEventId?: string;
   attachment?: MatrixQaObservedEventAttachment;
   approval?: MatrixQaObservedApproval;
+  presentation?: MatrixQaObservedPresentation;
 };
 
 const MATRIX_QA_APPROVAL_METADATA_KEY = "com.openclaw.approval";
+const MATRIX_QA_PRESENTATION_METADATA_KEY = "com.openclaw.presentation";
 const MATRIX_QA_APPROVAL_COMMAND_PREVIEW_CHARS = 160;
 
 function normalizeMentionUserIds(value: unknown) {
@@ -219,6 +230,33 @@ function normalizeMatrixQaApprovalMetadata(value: unknown): MatrixQaObservedAppr
   };
 }
 
+function normalizeMatrixQaPresentationMetadata(
+  value: unknown,
+): MatrixQaObservedPresentation | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const blocks = Array.isArray(value.blocks) ? value.blocks.filter(isRecord) : [];
+  const blockTypes = blocks
+    .map((block) => (typeof block.type === "string" ? block.type : undefined))
+    .filter((type): type is string => type !== undefined);
+  const buttonLabels = blocks.flatMap((block) =>
+    block.type === "buttons" && Array.isArray(block.buttons)
+      ? block.buttons
+          .filter(isRecord)
+          .map((button) => (typeof button.label === "string" ? button.label : undefined))
+          .filter((label): label is string => label !== undefined)
+      : [],
+  );
+  return {
+    ...(blockTypes.length ? { blockTypes } : {}),
+    ...(buttonLabels.length ? { buttonLabels } : {}),
+    ...(typeof value.title === "string" ? { title: value.title } : {}),
+    ...(typeof value.type === "string" ? { type: value.type } : {}),
+    ...(typeof value.version === "number" ? { version: value.version } : {}),
+  };
+}
+
 export function normalizeMatrixQaObservedEvent(
   roomId: string,
   event: MatrixQaRoomEvent,
@@ -272,6 +310,10 @@ export function normalizeMatrixQaObservedEvent(
   const approval = normalizeMatrixQaApprovalMetadata(
     messageContent[MATRIX_QA_APPROVAL_METADATA_KEY] ?? content[MATRIX_QA_APPROVAL_METADATA_KEY],
   );
+  const presentation = normalizeMatrixQaPresentationMetadata(
+    messageContent[MATRIX_QA_PRESENTATION_METADATA_KEY] ??
+      content[MATRIX_QA_PRESENTATION_METADATA_KEY],
+  );
   const redactsEventId =
     type === "m.room.redaction"
       ? typeof event.redacts === "string"
@@ -317,6 +359,7 @@ export function normalizeMatrixQaObservedEvent(
     ...(replacesEventId ? { replacesEventId } : {}),
     ...(attachment ? { attachment } : {}),
     ...(approval ? { approval } : {}),
+    ...(presentation ? { presentation } : {}),
   };
 }
 

--- a/qa/scenarios/channels/matrix-presentation-agent-reply-direct.yaml
+++ b/qa/scenarios/channels/matrix-presentation-agent-reply-direct.yaml
@@ -1,0 +1,29 @@
+title: Matrix direct agent reply preserves presentation
+scenario:
+  id: matrix-presentation-agent-reply-direct
+  surface: channels
+  coverage:
+    primary:
+      - matrix.message-presentation-metadata
+    secondary:
+      - agent-runtime.tool-ask-user
+  objective: Matrix direct agent reply preserves presentation
+  successCriteria:
+    - Matrix direct agent reply preserves presentation completes successfully.
+  execution:
+    kind: flow
+    channel: matrix
+    providerMode: mock-openai
+    timeoutMs: 75000
+    retryCount: 0
+    config:
+      matrixConfigOverrides:
+        streaming:
+          mode: off
+        toolProfile: coding
+
+flow:
+  module: ./live-transports/matrix/scenarios/scenario-runtime-room.js
+  call: runDirectPresentationReplyScenario
+  args:
+    - expr: "scenarioContext"


### PR DESCRIPTION
Closes #132739

## What Problem This Solves

Fixes an issue where Matrix users receiving agent replies with buttons or selects would get plain text with the controls silently removed. Replies containing only controls were treated as empty and dropped entirely, and streamed finals bypassed the same presentation rendering contract when finalizing their draft event.

## Why This Change Was Made

Fix classification: root-cause fix, not a fallback or downstream guard.

Root cause: the direct monitor delivery and streamed draft-finalization funnels skipped the existing Matrix presentation renderer. Direct delivery decided whether a payload was sendable before controls had produced fallback text, while streamed finals edited the draft with plain text and no presentation metadata. That left the presentation invariant owned only by proactive outbound instead of every Matrix reply exit.

Why this fixes the root cause: Matrix now materializes portable reply presentations through one Matrix-owned renderer shared by proactive outbound, direct monitor replies, and streamed finalization. Materialization happens before text/media sendability decisions, and the resulting fallback text plus `com.openclaw.presentation` metadata follows the existing first-event send/edit seams without changing reply relations, media ownership, draft cleanup, or receipt handling.

Compatibility and contract scope: the existing Matrix `com.openclaw.presentation` wire shape, text fallback behavior, plain text/media defaults, and first-media ownership remain unchanged. There are no core, public Plugin SDK, configuration, protocol-schema, or other-channel changes. Media upload, receipt, redaction, partial-delivery, and draft-cleanup lifecycles are explicitly out of scope.

Related open PR scan: #133268 was inspected as independent context; this PR is self-contained and does not depend on it.

The Matrix production change is +207/-138 lines (net +69). The growth creates the shared Matrix-private presentation owner while deleting the previous 94-line outbound-only implementation.

## User Impact

Matrix agent replies now preserve buttons and selectable options as structured Matrix presentation metadata while always retaining a visible text fallback. Controls-only replies produce a room event instead of disappearing, streamed replies finalize the existing draft with the same metadata, and media replies attach presentation metadata only to their first Matrix event.

## Evidence

- Pre-fix focused regressions failed at the Matrix delivery boundary: text-plus-controls remained plain `Choose`, controls-only returned `visibleReplySent: false`, first-media metadata was absent, and live draft finalization did not forward `extraContent`.
- A follow-up mixed authored-fallback regression also failed before the fix because a table-plus-context payload emitted no Matrix metadata. It now preserves the exact authored body while carrying the adapted context block; all 26 direct reply tests and the 2 streamed presentation sibling tests passed.
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/matrix`: 33 files and 553 tests passed, including direct replies, controls-only replies, first-media ownership, streamed finalization, draft lifecycle, and proactive outbound presentation coverage.
- The affected QA Lab suite passed 4 files and 36 tests, covering scenario catalog loading, Matrix environment setup, replacement-event presentation observation, and stream lifecycle observation.
- A live Matrix QA run against a disposable Tuwunel homeserver passed 2/2 scenarios with the mock OpenAI provider. The streaming-off direct scenario observed `text,text,buttons`, labels `Staging (Recommended)`, `Production 🚀`, and `Other…`, no replacement target, and the resolved final reply `ASK-USER-SINGLE-OK | deploy=Production 🚀`.
- The second live scenario verified real draft replacement and cleanup: one injected replacement failure retained its draft, then a healthy replacement redacted the superseded draft exactly once. This proves the Matrix streaming lifecycle but is not presented as a live streamed-presentation producer; streamed presentation finalization is covered at the Matrix dispatcher and draft-stream owner boundaries because the deterministic `ask_user` fixture is a tool reply rather than a terminal assistant final.
- `pnpm check:changed`: passed formatting, lint, all type-check lanes, import-cycle checks, plugin-boundary checks, and assertion-safety ratchets for the changed surface.
- `pnpm build`: passed after changing the Matrix draft-stream lazy runtime boundary.
- Final patch accounting: Matrix production +207/-138; Matrix product tests +335/-0; QA support +182/-8; QA tests +49/-2; QA scenario +29/-0; shrink-only assertion baseline +0/-1.
