### PR TITLE
refactor(settings): restore one storage load path

### DIFF
--- a/src/agents/sessions/settings-manager.ts
+++ b/src/agents/sessions/settings-manager.ts
@@ -98,14 +98,10 @@ export class SettingsManager {
   private static loadScope(storage: SettingsStorage, scope: SettingsScope): SettingsScopeState {
     let content: string | undefined;
     try {
-      if (storage.readSettingsScope) {
-        content = storage.readSettingsScope(scope);
-      } else {
-        storage.withLock(scope, (current) => {
-          content = current;
-          return undefined;
-        });
-      }
+      storage.withLock(scope, (current) => {
+        content = current;
+        return undefined;
+      });
       const settings = content
         ? SettingsManager.migrateSettings(JSON.parse(content) as Record<string, unknown>)
         : {};

--- a/src/agents/sessions/settings-storage.test.ts
+++ b/src/agents/sessions/settings-storage.test.ts
@@ -1,80 +1,11 @@
-import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { waitForChildClose, waitForFile } from "../../../test/helpers/process-wait.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { SettingsManager } from "./settings-manager.js";
+import { FileSettingsStorage } from "./settings-storage.js";
 
-const writerScript = String.raw`
-  import { existsSync, readFileSync, writeFileSync } from "node:fs";
-  import { join } from "node:path";
-
-  const [moduleUrl, settingsDir, markerDir, field] = process.argv.slice(1);
-  const { FileSettingsStorage } = await import(moduleUrl);
-  const settingsPath = join(settingsDir, "settings.json");
-  const otherEntered = join(markerDir, "theme.entered");
-  const contenderSawLock = join(markerDir, "contender-saw-lock");
-
-  if (field === "theme" && existsSync(settingsPath + ".lock")) {
-    writeFileSync(contenderSawLock, "ready");
-  }
-
-  const storage = new FileSettingsStorage(settingsDir, settingsDir);
-  storage.withLock("global", (current) => {
-    writeFileSync(join(markerDir, field + ".entered"), "ready");
-    if (field === "defaultModel") {
-      const deadline = Date.now() + 5_000;
-      const pause = new Int32Array(new SharedArrayBuffer(4));
-      while (!existsSync(otherEntered) && !existsSync(contenderSawLock)) {
-        if (Date.now() >= deadline) {
-          throw new Error("contending writer did not reach the settings boundary");
-        }
-        Atomics.wait(pause, 0, 0, 10);
-      }
-    }
-    const settings = current ? JSON.parse(current) : {};
-    settings[field] = field === "theme" ? "dark" : "provider/model";
-    return JSON.stringify(settings, null, 2);
-  });
-`;
-
-const children = new Map<ChildProcess, Promise<unknown>>();
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-
-afterEach(async () => {
-  for (const child of children.keys()) {
-    child.kill("SIGKILL");
-  }
-  await Promise.allSettled(children.values());
-  children.clear();
-});
-
-function spawnWriter(settingsDir: string, markerDir: string, field: string) {
-  const moduleUrl = pathToFileURL(resolve("src/agents/sessions/settings-storage.ts")).href;
-  const child = spawn(
-    process.execPath,
-    [
-      "--import",
-      "tsx",
-      "--input-type=module",
-      "--eval",
-      writerScript,
-      moduleUrl,
-      settingsDir,
-      markerDir,
-      field,
-    ],
-    { stdio: ["ignore", "pipe", "pipe"] },
-  );
-  const done = waitForChildClose(child, 10_000);
-  children.set(child, done);
-  let output = "";
-  child.stdout?.setEncoding("utf8").on("data", (chunk) => (output += chunk));
-  child.stderr?.setEncoding("utf8").on("data", (chunk) => (output += chunk));
-  return { child, done, output: () => output };
-}
 
 describe("FileSettingsStorage", () => {
   it("loads missing settings without creating their directories", () => {
@@ -87,25 +18,32 @@ describe("FileSettingsStorage", () => {
     expect(existsSync(join(root, ".openclaw"))).toBe(false);
   });
 
-  it("preserves concurrent first writes from separate processes", async () => {
-    const root = tempDirs.make("openclaw-settings-first-write-");
+  it("locks before reading when the settings directory exists", () => {
+    const root = tempDirs.make("openclaw-settings-lock-");
     const settingsDir = join(root, "agent");
-    const markerDir = join(root, "markers");
-    mkdirSync(markerDir);
+    const settingsPath = join(settingsDir, "settings.json");
+    mkdirSync(settingsDir);
+    const storage = new FileSettingsStorage(settingsDir, settingsDir);
+    let lockedDuringRead = false;
 
-    const first = spawnWriter(settingsDir, markerDir, "defaultModel");
-    await waitForFile(join(markerDir, "defaultModel.entered"), 5_000);
-    const contender = spawnWriter(settingsDir, markerDir, "theme");
-
-    for (const writer of [first, contender]) {
-      const result = await writer.done;
-      children.delete(writer.child);
-      expect(result, writer.output()).toEqual({ code: 0, signal: null });
-    }
-
-    expect(JSON.parse(readFileSync(join(settingsDir, "settings.json"), "utf8"))).toEqual({
-      defaultModel: "provider/model",
-      theme: "dark",
+    storage.withLock("global", (current) => {
+      lockedDuringRead = existsSync(`${settingsPath}.lock`);
+      expect(current).toBeUndefined();
+      return undefined;
     });
-  }, 15_000);
+
+    expect(lockedDuringRead).toBe(true);
+    expect(existsSync(settingsPath)).toBe(false);
+  });
+
+  it("creates a missing directory when the callback writes", () => {
+    const root = tempDirs.make("openclaw-settings-write-");
+    const settingsDir = join(root, "agent");
+    const settingsPath = join(settingsDir, "settings.json");
+    const storage = new FileSettingsStorage(settingsDir, settingsDir);
+
+    storage.withLock("global", () => JSON.stringify({ theme: "dark" }));
+
+    expect(JSON.parse(readFileSync(settingsPath, "utf8"))).toEqual({ theme: "dark" });
+  });
 });

--- a/src/agents/sessions/settings-storage.ts
+++ b/src/agents/sessions/settings-storage.ts
@@ -118,8 +118,6 @@ export type SettingsScope = "global" | "project";
 export const SETTINGS_SCOPES: SettingsScope[] = ["global", "project"];
 
 export interface SettingsStorage {
-  // Optional so shipped custom backends can keep serving reads through withLock.
-  readSettingsScope?(scope: SettingsScope): string | undefined;
   withLock(scope: SettingsScope, fn: (current: string | undefined) => string | undefined): void;
 }
 
@@ -138,36 +136,29 @@ export class FileSettingsStorage implements SettingsStorage {
     };
   }
 
-  readSettingsScope(scope: SettingsScope): string | undefined {
-    const path = this.paths[scope];
-    if (!existsSync(path)) {
-      return undefined;
-    }
-    const release = acquireFileLockSyncWithRetry(path);
-    try {
-      return readFileSync(path, "utf-8");
-    } finally {
-      release();
-    }
-  }
-
   withLock(scope: SettingsScope, fn: (current: string | undefined) => string | undefined): void {
     const path = this.paths[scope];
     const dir = dirname(path);
 
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true });
-    }
-    // Lock before reading, or concurrent first writers can merge from the same empty state.
-    const release = acquireFileLockSyncWithRetry(path);
+    let release: (() => void) | undefined;
     try {
+      const directoryExists = existsSync(dir);
+      if (directoryExists) {
+        release = acquireFileLockSyncWithRetry(path);
+      }
+      // Missing-directory reads stay side-effect free. Concurrent external first creators
+      // remain unsupported because they can derive writes before a lock path exists.
       const current = existsSync(path) ? readFileSync(path, "utf-8") : undefined;
       const next = fn(current);
       if (next !== undefined) {
+        if (!directoryExists) {
+          mkdirSync(dir, { recursive: true });
+          release = acquireFileLockSyncWithRetry(path);
+        }
         writeFileSync(path, next, "utf-8");
       }
     } finally {
-      release();
+      release?.();
     }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

PR #124471 added an unshipped optional settings-read path and a large synthetic two-process test for a topology OpenClaw does not use.

This internal refactor removes that complexity. It makes no Gateway, local-agent, worker, ClawHub, or public Plugin SDK behavior-fix claim.

## Change

- Remove `readSettingsScope` from `SettingsStorage` and `FileSettingsStorage`.
- Load and persist settings through the existing `withLock` callback.
- Keep reads side-effect free while the settings directory is absent.
- Lock before reading when the directory already exists.
- Create the directory and lock only when an absent-directory callback produces a write.

Two unsupported external processes can still race while creating the first settings directory. OpenClaw product paths do not use that topology.

## Evidence

Focused storage and manager contract tests pass:

```text
node scripts/run-vitest.mjs src/agents/sessions/settings-storage.test.ts src/agents/sessions/settings-manager.test.ts
Test Files  2 passed (2)
Tests       8 passed (8)
```

These owner tests are not product-path proof. They verify:

- Missing global and project settings directories remain absent after load.
- An existing settings directory is locked before its absent file is read.
- A callback that writes creates the missing directory and settings file.

Production delta: `+16/-29`, net `-13`. Test delta: `+26/-88`, net `-62`.
