### PR TITLE
fix(cron): keep valid legacy jobs active during migration

### DIFF
--- a/src/commands/doctor/cron/index.test.ts
+++ b/src/commands/doctor/cron/index.test.ts
@@ -2290,6 +2290,50 @@ describe("maybeRepairLegacyCronStore", () => {
     expect(delivery.to).toBe("telegram:123");
   });
 
+  it("keeps valid legacy schedule-kind variants active after SQLite migration", async () => {
+    const storePath = await makeTempStorePath();
+    await writeCronStore(storePath, [
+      createLegacyCronJob({
+        id: "legacy-cron-kind",
+        jobId: undefined,
+        enabled: true,
+        schedule: { kind: " CRON ", cron: "0 7 * * *", tz: "UTC" },
+      }),
+      createLegacyCronJob({
+        id: "legacy-every-kind",
+        jobId: undefined,
+        enabled: true,
+        schedule: { kind: "Every", everyMs: 60_000 },
+      }),
+      createLegacyCronJob({
+        id: "legacy-stream-kind",
+        jobId: undefined,
+        enabled: true,
+        schedule: { kind: " Stream ", command: ["node", "events.mjs"], mode: "line" },
+      }),
+    ]);
+
+    await maybeRepairLegacyCronStore({
+      cfg: createCronConfig(storePath),
+      options: {},
+      prompter: makePrompter(true),
+    });
+
+    const jobs = await readPersistedJobs(storePath);
+    expect(
+      jobs.map((job) => ({
+        id: job.id,
+        enabled: job.enabled,
+        kind: requireRecord(job.schedule, "cron schedule").kind,
+      })),
+    ).toEqual([
+      { id: "legacy-cron-kind", enabled: true, kind: "cron" },
+      { id: "legacy-every-kind", enabled: true, kind: "every" },
+      { id: "legacy-stream-kind", enabled: true, kind: "stream" },
+    ]);
+    expect(loadCronQuarantinedJobs(storePath)).toEqual([]);
+  });
+
   it("quarantines invalid legacy rows before saving the repaired store", async () => {
     const storePath = await makeTempStorePath();
     await writeCronStore(storePath, [

--- a/src/commands/doctor/cron/store-migration.schedule-kind.test.ts
+++ b/src/commands/doctor/cron/store-migration.schedule-kind.test.ts
@@ -1,0 +1,85 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it } from "vitest";
+import { normalizeStoredCronJobs } from "./store-migration.js";
+
+const scheduleKindCases = [
+  {
+    id: "job-at-kind",
+    canonicalKind: "at",
+    schedule: { kind: " At ", at: "2026-08-31T10:00:00.000Z" },
+  },
+  {
+    id: "job-every-kind",
+    canonicalKind: "every",
+    schedule: { kind: "Every", everyMs: 120_000 },
+  },
+  {
+    id: "job-cron-kind",
+    canonicalKind: "cron",
+    schedule: { kind: " CRON ", cron: "17 * * * *", tz: "UTC" },
+  },
+  {
+    id: "job-on-exit-kind",
+    canonicalKind: "on-exit",
+    schedule: { kind: " On-Exit ", command: "cleanup" },
+  },
+  {
+    id: "job-stream-kind",
+    canonicalKind: "stream",
+    schedule: { kind: " Stream ", command: ["node", "events.mjs"], mode: "line" },
+  },
+];
+
+describe("legacy cron schedule kind migration", () => {
+  it.each(scheduleKindCases)(
+    "keeps valid legacy $canonicalKind schedules active when kind needs normalization",
+    ({ id, canonicalKind, schedule }) => {
+      const jobs: Array<Record<string, unknown>> = [
+        {
+          id,
+          name: "Legacy job",
+          enabled: true,
+          createdAtMs: 1_700_000_000_000,
+          updatedAtMs: 1_700_000_000_000,
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          schedule,
+          payload: { kind: "systemEvent", text: "tick" },
+          state: {},
+        },
+      ];
+
+      const result = normalizeStoredCronJobs(jobs);
+      const job = expectDefined(jobs[0], "job test invariant");
+
+      expect(result.removedJobs).toEqual([]);
+      expect(result.issues.invalidSchedule).toBeUndefined();
+      expect(job).toMatchObject({ id, enabled: true });
+      expect((job.schedule as Record<string, unknown>).kind).toBe(canonicalKind);
+    },
+  );
+
+  it("quarantines unknown kinds without rewriting the diagnostic row", () => {
+    const jobs: Array<Record<string, unknown>> = [
+      {
+        id: "job-unknown-kind",
+        name: "Unknown legacy job",
+        enabled: true,
+        createdAtMs: 1_700_000_000_000,
+        updatedAtMs: 1_700_000_000_000,
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        schedule: { kind: " DAILY ", at: "09:00" },
+        payload: { kind: "systemEvent", text: "tick" },
+        state: {},
+      },
+    ];
+
+    const result = normalizeStoredCronJobs(jobs);
+    const removed = expectDefined(result.removedJobs[0], "removed job test invariant");
+
+    expect(jobs).toEqual([]);
+    expect(removed.reason).toBe("invalid-schedule");
+    expect((removed.job.schedule as Record<string, unknown>).kind).toBe(" DAILY ");
+  });
+});

--- a/src/commands/doctor/cron/store-migration.ts
+++ b/src/commands/doctor/cron/store-migration.ts
@@ -437,7 +437,18 @@ export function normalizeStoredCronJobs(
     if (schedule && typeof schedule === "object" && !Array.isArray(schedule)) {
       const sched = schedule as Record<string, unknown>;
       const kind = normalizeOptionalLowercaseString(sched.kind) ?? "";
-      if (!kind && ("at" in sched || "atMs" in sched)) {
+      const canonicalKind =
+        kind === "at" ||
+        kind === "every" ||
+        kind === "cron" ||
+        kind === "on-exit" ||
+        kind === "stream"
+          ? kind
+          : undefined;
+      if (canonicalKind && sched.kind !== canonicalKind) {
+        sched.kind = canonicalKind;
+        mutated = true;
+      } else if (!kind && ("at" in sched || "atMs" in sched)) {
         sched.kind = "at";
         mutated = true;
       }


### PR DESCRIPTION
Related: #133347

## What Problem This Solves

Fixes an issue where users upgrading a legacy automation store could have valid scheduled jobs disappear from the active inventory when `schedule.kind` contained capitalization or surrounding whitespace. Doctor classified those rows as `invalid-schedule` and quarantined them, so enabled automations silently stopped even though the Gateway and scheduler remained healthy.

## Why This Change Was Made

Doctor now writes a recognized normalized legacy `schedule.kind` back to the migration-owned row before strict persisted-shape validation. This keeps valid `at`, `every`, `cron`, `on-exit`, and `stream` schedules canonical while preserving strict rejection of genuinely unknown kinds and retaining their original quarantine diagnostics.

The change stays at the persistent-state migration owner. It does not change the SQLite schema, runtime validator, scheduler behavior, public configuration, or automation protocol.

This change does not automatically reactivate rows already stored in quarantine. Re-enabling previously inactive automations can restart user workflows and changes persisted recovery semantics, so that needs an explicit maintainer product decision rather than being coupled to the prevention fix.

## User Impact

Future legacy-store migrations keep valid schedule-kind variants active, preserving their IDs and enabled state instead of moving them to quarantine. Existing canonical rows are unchanged, and unsupported schedule kinds are still quarantined without rewriting the preserved diagnostic row.

Installations already affected by the earlier migration still require deliberate recovery of their quarantined rows; this PR does not silently restart them.

## Evidence

- **Regression proof on pre-fix code:** the new owner-boundary table test failed for all five supported schedule kinds because every row was removed with `invalid-schedule`; the Doctor integration test expected three active cron/every/stream rows but observed an empty inventory.
- **Owner-boundary regression:** `node scripts/run-vitest.mjs src/commands/doctor/cron/store-migration.schedule-kind.test.ts` — 6 tests passed. The table covers `at`, `every`, `cron`, `on-exit`, and `stream`, and a separate case proves unknown kinds remain quarantined without rewriting their diagnostic value.
- **JSON-to-SQLite Doctor regression:** `node scripts/run-vitest.mjs src/commands/doctor/cron/index.test.ts` — 67 tests passed. The migration preserves active cron/every/stream rows and writes no quarantine entries for them.
- **Strict persisted-shape siblings:** `node scripts/run-vitest.mjs src/cron/persisted-shape.onexit.test.ts src/cron/persisted-shape.stream.test.ts` — 6 tests passed, including rejection of a genuinely unknown schedule kind.
- **Changed-scope checks:** `node scripts/check-changed.mjs -- <changed paths>` — formatting, core typechecks, lint, state-schema, database-first, import-cycle, and architecture guards passed.
- **Real isolated Doctor → Gateway proof:** three enabled legacy rows with `schedule.kind` values `" CRON "`, `"Every"`, and `" Stream "` were written to an isolated state directory. `openclaw doctor --fix --non-interactive` migrated them, a session-owned Gateway started on a non-default loopback port, and `openclaw automations list --all --json` returned:

  ```json
  [
    { "id": "legacy-cron-kind", "enabled": true, "kind": "cron" },
    { "id": "legacy-every-kind", "enabled": true, "kind": "every" },
    { "id": "legacy-stream-kind", "enabled": true, "kind": "stream" }
  ]
  ```

  Task execution was disabled only for the proof while preserving stored enabled flags and the real Gateway inventory path. The temporary state and session-owned Gateway were cleaned up afterward.
