### PR TITLE
fix(ui): preserve explicit theme while reconnecting

### DIFF
--- a/ui/src/app/app-host.server-prefs.test.ts
+++ b/ui/src/app/app-host.server-prefs.test.ts
@@ -48,7 +48,10 @@ describe("OpenClaw shell locale preferences", () => {
     const runtimeConfig = { state } as unknown as ApplicationContext["runtimeConfig"];
     const refreshTheme = vi.fn();
     const context = {
-      gateway: { connection: { gatewayUrl: "ws://locale.test" } },
+      gateway: {
+        connection: { gatewayUrl: "ws://locale.test" },
+        snapshot: { phase: "connected" },
+      },
       navigation: { update: vi.fn() },
       theme: { refresh: refreshTheme },
       runtimeConfig,
@@ -84,7 +87,10 @@ describe("OpenClaw shell locale preferences", () => {
     const runtimeConfig = { state } as unknown as ApplicationContext["runtimeConfig"];
     const refreshTheme = vi.fn();
     const context = {
-      gateway: { connection: { gatewayUrl: "ws://locale.test" } },
+      gateway: {
+        connection: { gatewayUrl: "ws://locale.test" },
+        snapshot: { phase: "connected" },
+      },
       navigation: { update: vi.fn() },
       theme: { refresh: refreshTheme },
       runtimeConfig,
@@ -116,7 +122,10 @@ describe("OpenClaw shell locale preferences", () => {
     const runtimeConfig = { state } as unknown as ApplicationContext["runtimeConfig"];
     const recordServerSelection = vi.fn();
     const context = {
-      gateway: { connection: { gatewayUrl: "ws://theme.test" } },
+      gateway: {
+        connection: { gatewayUrl: "ws://theme.test" },
+        snapshot: { phase: "connected" },
+      },
       navigation: { update: vi.fn() },
       theme: { recordServerSelection, refresh: vi.fn(), serverSelection: null },
       runtimeConfig,

--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -618,7 +618,10 @@ describe("OpenClaw shell server preferences", () => {
       },
     } as unknown as ApplicationContext["runtimeConfig"];
     const context = {
-      gateway: { connection: { gatewayUrl: "ws://sidebar.test" } },
+      gateway: {
+        connection: { gatewayUrl: "ws://sidebar.test" },
+        snapshot: { phase: "connected" },
+      },
       navigation: { update: updateNavigation },
       theme: { refresh: refreshTheme },
       // reconcileServerUiPrefs only accepts the current context's capability.

--- a/ui/src/app/app-shell-gateway.ts
+++ b/ui/src/app/app-shell-gateway.ts
@@ -100,7 +100,13 @@ export class ShellGatewayOwner {
   reconcileServerUiPrefs(runtimeConfig: ApplicationContext["runtimeConfig"]): void {
     const snapshot = runtimeConfig.state.configSnapshot;
     const context = this.host.context;
-    if (!snapshot?.config || !context || context.runtimeConfig !== runtimeConfig) {
+    if (
+      !snapshot?.config ||
+      !context ||
+      context.runtimeConfig !== runtimeConfig ||
+      // selfUser is cleared on close; retained config must not reclassify that as an identity swap.
+      context.gateway.snapshot.phase !== "connected"
+    ) {
       return;
     }
     const scope = context.gateway.connection.gatewayUrl;

--- a/ui/src/e2e/settings-prefs-reconnect.e2e.test.ts
+++ b/ui/src/e2e/settings-prefs-reconnect.e2e.test.ts
@@ -44,8 +44,9 @@ function patchPrefs(request: MockGatewayRequest): Record<string, unknown> {
   return requireRecord(ui.prefs, "config.patch ui.prefs");
 }
 
-async function createContext(): Promise<BrowserContext> {
+async function createContext(colorScheme?: "dark" | "light"): Promise<BrowserContext> {
   return suite.browser.newContext({
+    ...(colorScheme ? { colorScheme } : {}),
     locale: "en-US",
     serviceWorkers: "block",
     viewport: { height: 900, width: 1440 },
@@ -135,6 +136,54 @@ function themeModeOption(page: Page, mode: "system" | "light" | "dark") {
 }
 
 suite.define(() => {
+  it("preserves a profile's explicit light theme while reconnecting", async () => {
+    const context = await createContext("dark");
+    const page = await context.newPage();
+    const initial = configResponse({}, "prefs-profile-light-1");
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "config.get": initial,
+        "users.prefs.get": {
+          entries: { "ui.theme": "claw", "ui.themeMode": "light" },
+          status: "ok",
+        },
+      },
+      presenceUsers: [{ id: "profile-theme-light", self: true }],
+    });
+
+    try {
+      const response = await page.goto(`${suite.server.baseUrl}chat`);
+      expect(response?.status()).toBe(200);
+      await gateway.waitForRequest("config.get");
+      await gateway.waitForRequest("users.prefs.get");
+      await gateway.waitForRequest("chat.startup");
+      await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe("light");
+      await expect
+        .poll(() => page.locator("html").getAttribute("data-theme-resolved"))
+        .toBe("light");
+      await expect
+        .poll(() => readSettingsMirror(page))
+        .toMatchObject({ theme: "claw", themeMode: "light" });
+
+      await gateway.setOnline(false);
+      await page.locator(".sidebar-footer-bar__status").filter({ hasText: "Offline" }).waitFor();
+      await page
+        .locator(".agent-chat__composer-status-band")
+        .filter({ hasText: "Offline" })
+        .waitFor();
+
+      await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe("light");
+      await expect
+        .poll(() => page.locator("html").getAttribute("data-theme-resolved"))
+        .toBe("light");
+      await expect
+        .poll(() => readSettingsMirror(page))
+        .toMatchObject({ theme: "claw", themeMode: "light" });
+    } finally {
+      await context.close();
+    }
+  });
+
   it("replays an offline theme edit after a same-client reconnect", async () => {
     const context = await createContext();
     const page = await context.newPage();


### PR DESCRIPTION
Fixes #133416

## What Problem This Solves

Fixes an issue where users with an explicit Control UI theme would see the interface switch to their system theme when the Gateway connection dropped. A light profile on a dark-system browser changed to dark during the visible reconnecting state and its local settings mirror was overwritten.

## Why This Change Was Made

In this PR, server preference reconciliation runs only while the Gateway has an authoritative connected snapshot. A disconnected snapshot clears `selfUser`, but that unknown identity is transient and must not be classified as an authenticated-profile scope change.

This keeps the preference reconciler as the canonical owner: connected transitions between profiles or to a genuinely anonymous session still reconcile normally, while disconnect freezes the last known profile scope and values. The connection coordinator continues publishing disconnected state for reconnect scheduling, pending writes, drafts, and other lifecycle consumers; no duplicate theme-specific fallback or dead path is added.

## User Impact

Explicit theme, theme mode, locale, sidebar, and appearance preferences will remain stable during an outage. Once the Gateway reconnects with an authoritative identity, the existing reconciliation path resumes and applies the correct scope.

## Evidence

### Recorded browser reproduction

The fixture uses an explicit `light` profile preference with a dark system scheme, then makes the mock Gateway unavailable and waits for both visible offline indicators without fixed delays.

Before — the interface flips to dark and the local mirror changes from `light` to `system`:

![Offline Control UI before the repair](https://github.com/user-attachments/assets/c81d2516-54dd-4f16-9dd6-e9cfd78f263f)

https://github.com/user-attachments/assets/34eb3d13-48b2-4270-bb77-7a9d8bc8e049

After — the same offline state preserves the light document theme and persisted mirror:

![Offline Control UI after the repair](https://github.com/user-attachments/assets/1b29ca51-9cea-4889-8f50-7c739e0d2dd3)

https://github.com/user-attachments/assets/a71a00b7-d9d7-441d-9abf-0c1bf554bd76

### Regression proof

- The focused browser regression fails against the pre-fix owner with `expected 'dark' to be 'light'`.
- The same test passes on `7a8445974e52061f19d73d7d09c5c322b3ef14ba` while also observing the offline footer, offline composer banner, document theme attributes, and local settings mirror.
- Existing connected reconciliation fixtures now declare their connected phase explicitly, preserving authenticated profile switches, anonymous connected scope, locale, sidebar, and appearance coverage.
- Formatting and whitespace validation pass. Full CI is green on the exact head.
- ClawSweeper rank-up move applied: the PR is ready and the required exact-head UI and browser-E2E checks are green.

### Scope

- Production: +7 / -1 lines. The net growth is the owner-level phase guard plus its lifecycle invariant comment; no new branch outside the canonical reconciliation flow was introduced.
- Tests: +66 / -5 lines, including the end-to-end regression and explicit connected-state fixtures.
- No configuration, protocol, persistence schema, dependency, or documentation surface changes.
