### PR TITLE
refactor(plugins): consolidate registry snapshot test fixtures

### DIFF
--- a/src/plugins/plugin-registry-snapshot.test.ts
+++ b/src/plugins/plugin-registry-snapshot.test.ts
@@ -18,6 +18,7 @@ import { loadPluginManifestRegistryForInstalledIndex } from "./manifest-registry
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
+import { createPluginMetadataSnapshotFixture } from "./plugin-metadata.test-support.js";
 import { loadPluginRegistrySnapshotWithMetadata } from "./plugin-registry-snapshot.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 import { writeManagedNpmPlugin } from "./test-helpers/managed-npm-plugin.js";
@@ -40,6 +41,22 @@ function createHermeticEnv(rootDir: string): NodeJS.ProcessEnv {
     OPENCLAW_STATE_DIR: path.join(rootDir, "state"),
     OPENCLAW_VERSION: "2026.4.26",
     VITEST: "true",
+  };
+}
+
+function createCurrentMetadataSnapshot(
+  config: OpenClawConfig,
+  workspaceDir: string,
+): PluginMetadataSnapshot {
+  const snapshot = createPluginMetadataSnapshotFixture();
+  const policyHash = resolveInstalledPluginIndexPolicyHash(config);
+  snapshot.index.policyHash = policyHash;
+  return {
+    ...snapshot,
+    policyHash,
+    configFingerprint: "",
+    workspaceDir,
+    normalizePluginId: (pluginId) => pluginId,
   };
 }
 
@@ -272,49 +289,8 @@ describe("loadPluginRegistrySnapshotWithMetadata", () => {
     const env = createHermeticEnv(makeTempDir());
     const config = {};
     const workspaceDir = path.join(makeTempDir(), "workspace");
-    const policyHash = resolveInstalledPluginIndexPolicyHash(config);
-    const index: InstalledPluginIndex = {
-      version: 1,
-      hostContractVersion: "test",
-      compatRegistryVersion: "test",
-      migrationVersion: 1,
-      policyHash,
-      generatedAtMs: 0,
-      installRecords: {},
-      plugins: [],
-      diagnostics: [],
-    };
-    const snapshot: PluginMetadataSnapshot = {
-      policyHash,
-      configFingerprint: "",
-      workspaceDir,
-      index,
-      registryIndex: index,
-      registryDiagnostics: [],
-      manifestRegistry: { plugins: [], diagnostics: [] },
-      plugins: [],
-      diagnostics: [],
-      byPluginId: new Map(),
-      normalizePluginId: (pluginId: string) => pluginId,
-      owners: {
-        channels: new Map(),
-        channelConfigs: new Map(),
-        providers: new Map(),
-        modelCatalogProviders: new Map(),
-        cliBackends: new Map(),
-        setupProviders: new Map(),
-        commandAliases: new Map(),
-        contracts: new Map(),
-      },
-      metrics: {
-        registrySnapshotMs: 0,
-        manifestRegistryMs: 0,
-        ownerMapsMs: 0,
-        totalMs: 0,
-        indexPluginCount: 0,
-        manifestPluginCount: 0,
-      },
-    };
+    const snapshot = createCurrentMetadataSnapshot(config, workspaceDir);
+    const index = snapshot.index;
     setCurrentPluginMetadataSnapshot(snapshot, { config, env, workspaceDir });
 
     const result = loadPluginRegistrySnapshotWithMetadata({ config, env, workspaceDir });
@@ -360,25 +336,11 @@ describe("loadPluginRegistrySnapshotWithMetadata", () => {
     };
     const config = {};
     const workspaceDir = path.join(makeTempDir(), "workspace");
-    const policyHash = resolveInstalledPluginIndexPolicyHash(config);
-    const index: InstalledPluginIndex = {
-      version: 1,
-      hostContractVersion: "test",
-      compatRegistryVersion: "test",
-      migrationVersion: 1,
-      policyHash,
-      generatedAtMs: 0,
-      installRecords: {},
-      plugins: [],
-      diagnostics: [],
-    };
+    const snapshot = createCurrentMetadataSnapshot(config, workspaceDir);
+    const index = snapshot.index;
     setCurrentPluginMetadataSnapshot(
       {
-        policyHash,
-        configFingerprint: "",
-        workspaceDir,
-        index,
-        registryIndex: index,
+        ...snapshot,
         registrySource: "derived",
         registryDiagnostics: [
           {
@@ -387,29 +349,6 @@ describe("loadPluginRegistrySnapshotWithMetadata", () => {
             message: "missing",
           },
         ],
-        manifestRegistry: { plugins: [], diagnostics: [] },
-        plugins: [],
-        diagnostics: [],
-        byPluginId: new Map(),
-        normalizePluginId: (pluginId: string) => pluginId,
-        owners: {
-          channels: new Map(),
-          channelConfigs: new Map(),
-          providers: new Map(),
-          modelCatalogProviders: new Map(),
-          cliBackends: new Map(),
-          setupProviders: new Map(),
-          commandAliases: new Map(),
-          contracts: new Map(),
-        },
-        metrics: {
-          registrySnapshotMs: 0,
-          manifestRegistryMs: 0,
-          ownerMapsMs: 0,
-          totalMs: 0,
-          indexPluginCount: 0,
-          manifestPluginCount: 0,
-        },
       },
       { config, env, workspaceDir },
     );
@@ -444,52 +383,11 @@ describe("loadPluginRegistrySnapshotWithMetadata", () => {
     };
     const config = {};
     const workspaceDir = path.join(tempRoot, "workspace");
-    const policyHash = resolveInstalledPluginIndexPolicyHash(config);
-    const currentIndex: InstalledPluginIndex = {
-      version: 1,
-      hostContractVersion: "test",
-      compatRegistryVersion: "test",
-      migrationVersion: 1,
-      policyHash,
-      generatedAtMs: 0,
-      installRecords: {},
-      plugins: [],
-      diagnostics: [],
-    };
-    setCurrentPluginMetadataSnapshot(
-      {
-        policyHash,
-        configFingerprint: "",
-        workspaceDir,
-        index: currentIndex,
-        registryIndex: currentIndex,
-        registryDiagnostics: [],
-        manifestRegistry: { plugins: [], diagnostics: [] },
-        plugins: [],
-        diagnostics: [],
-        byPluginId: new Map(),
-        normalizePluginId: (pluginId: string) => pluginId,
-        owners: {
-          channels: new Map(),
-          channelConfigs: new Map(),
-          providers: new Map(),
-          modelCatalogProviders: new Map(),
-          cliBackends: new Map(),
-          setupProviders: new Map(),
-          commandAliases: new Map(),
-          contracts: new Map(),
-        },
-        metrics: {
-          registrySnapshotMs: 0,
-          manifestRegistryMs: 0,
-          ownerMapsMs: 0,
-          totalMs: 0,
-          indexPluginCount: 0,
-          manifestPluginCount: 0,
-        },
-      },
-      { config, env, workspaceDir },
-    );
+    setCurrentPluginMetadataSnapshot(createCurrentMetadataSnapshot(config, workspaceDir), {
+      config,
+      env,
+      workspaceDir,
+    });
 
     const result = loadPluginRegistrySnapshotWithMetadata({
       config,


### PR DESCRIPTION
## What Problem This Solves

Three registry-snapshot tests copy the same empty metadata inventory. Adding a required snapshot field has previously required editing all three copies as well as the canonical test fixture.

## Why This Change Was Made

Reuse `createPluginMetadataSnapshotFixture` through a small file-local adapter that retains the real policy hash, workspace, identity normalizer, and shared `index`/`registryIndex`. Keep the derived-source diagnostic explicit in its test. The canonical helper and all production code are unchanged.

## User Impact

No runtime or public-contract change. All existing assertions, 38 cases, execution order, platform exclusions, and cleanup remain. This removes duplicated setup, not test coverage.

Production LOC: **0**. Tests: **+27 / -129 (102 removed)**. One file changes.

## Evidence

- Baseline and candidate each passed all **38 cases**, with no skips or retries and identical emitted case order. This includes current-snapshot reuse, diagnostic preservation without filesystem reads, explicit derivation inputs, persisted metadata recovery, and path/symlink safety.
- Focused proof used Node 24.19.0 and the ordinary test runner:

```sh
node scripts/run-vitest.mjs src/plugins/plugin-registry-snapshot.test.ts --maxWorkers 2 --reporter verbose
```

- Scoped formatting and `git diff --check` passed.
- The full **20-stage changed-file gate passed**, including core test types, lint, formatting, boundaries, dependency and assertion guards, and all three dead-export scans. No skips or retries.
- Precommit and separate exact-commit Codex reviews each completed with no findings in the requested P0 scope. The normal signed commit preserved the tested source bytes.
- [Exact-head CI33325767786](https://github.com/openclaw/openclaw/actions/runs/33325767786) passed on `f55b644aa34915aa5aff354ff6892b8785e5b82d`: 41 successful jobs, 19 skipped jobs, and a successful required CI gate.
- Normal hosted preparation and merge both passed without rebasing or pushing another head. [Merged as 242a63b1](https://github.com/openclaw/openclaw/commit/242a63b17f1bd8604c8f9e825f0169c086eb37c3). The entire 35,529-entry landed tree equals its actual parent plus the single reviewed test afterimage; independent verification also checked tracked files and index. Native worktree, operation lock, temporary branches, and remote source branch were removed.

The helper adds its normal optional provider facts and cache binding during fixture creation. The adapter preserves the tested lookup inputs; these cases neither read those extra facts nor mutate shared empty arrays. Full-suite paired execution covers the existing shared-worker order. No build or live-provider result is claimed for this test-only change. Mainline drift was reported by the native wrapper as advisory; no strict gate was overridden and no failed proof was waived.
