### PR TITLE
fix(cli): keep sessions tail columns aligned for Unicode keys

### DIFF
--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -186,8 +186,9 @@ openclaw sessions --all-agents tail --follow
 progress lines. Without `--session-key`, it tails running sessions first, then
 the latest stored session. `--tail <count>` controls how many existing events
 print before follow mode; default `80`, and `0` starts at the current end.
-`--follow` keeps watching the selected SQLite-backed session or an explicit
-legacy trajectory file.
+`--follow` keeps watching the selected SQLite-backed sessions. Session keys use
+fixed-width terminal columns, with long keys truncated at whole grapheme boundaries
+so CJK characters, combining accents, and joined emoji keep progress lines aligned.
 
 The progress view is intentionally conservative: prompt text, tool arguments,
 and tool result bodies are not printed. Tool calls show the tool name with

--- a/src/commands/flows.ts
+++ b/src/commands/flows.ts
@@ -2,7 +2,6 @@
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe, truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
-import { truncateToVisibleWidth, visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { formatCliCommand } from "../cli/command-format.js";
@@ -29,6 +28,7 @@ import {
   isTaskStatusIssue,
 } from "../tasks/task-status.js";
 import { formatTaskStatusCell, TASK_STATUS_CELL_WIDTH } from "./task-status-cell.js";
+import { formatTextCell } from "./text-format.js";
 
 const ID_PAD = 10;
 const MODE_PAD = 14;
@@ -55,12 +55,6 @@ function safeFlowDisplayText(value: string | undefined, maxChars?: number): stri
     return "n/a";
   }
   return typeof maxChars === "number" ? truncate(sanitized, maxChars) : sanitized;
-}
-
-function formatFlowTableCell(value: string | undefined, width: number): string {
-  const text = safeFlowDisplayText(value);
-  const fitted = visibleWidth(text) > width ? `${truncateToVisibleWidth(text, width - 1)}…` : text;
-  return `${fitted}${" ".repeat(width - visibleWidth(fitted))}`;
 }
 
 function shortToken(value: string | undefined, maxChars = ID_PAD): string {
@@ -91,7 +85,7 @@ function formatFlowRows(flows: TaskFlowRecord[], rich: boolean) {
         flow.syncMode.padEnd(MODE_PAD),
         formatTaskStatusCell(flow.status, rich),
         String(flow.revision).padEnd(REV_PAD),
-        formatFlowTableCell(flow.controllerId, CTRL_PAD),
+        formatTextCell(safeFlowDisplayText(flow.controllerId), CTRL_PAD),
         counts.padEnd(14),
         safeFlowDisplayText(flow.goal, 80),
       ].join(" "),

--- a/src/commands/sessions-tail.test.ts
+++ b/src/commands/sessions-tail.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -147,6 +148,85 @@ describe("sessionsTailCommand", () => {
     expect(output).toContain("openai/gpt-5.2 done");
     expect(output).not.toContain("SECRET");
   });
+
+  it.each([
+    ["ASCII", "incident", "incident"],
+    ["CJK", "中文", "中文"],
+    ["combining accent", "e\u0301", "e\u0301"],
+    ["joined emoji", "👩🏽‍💻", "👩🏽‍💻"],
+    ["truncated emoji", `${"a".repeat(17)}👩🏽‍💻-incident`, `${"a".repeat(17)}…`],
+  ])("keeps progress columns aligned with %s session keys", async (_name, suffix, displayed) => {
+    const runtime = makeRuntime();
+    const key = `agent:main:${suffix}`;
+    await writeSessionEntry(key);
+    await appendEvents(
+      [
+        makeEvent({
+          type: "tool.result",
+          ts: "2026-05-18T12:04:21.000Z",
+          data: { name: "proof", success: true },
+        }),
+      ],
+      { key },
+    );
+
+    await sessionsTailCommand({ agent: "main", store: storePath, sessionKey: key }, runtime);
+
+    const line = runtimeOutput(runtime);
+    expect(line.split("\n")).toHaveLength(1);
+    expect(line).toContain(` agent:main:${displayed} `);
+    expect(line).toContain("tool.result");
+    expect(line.endsWith("proof ok")).toBe(true);
+    const previewOffset = line.indexOf("proof ok");
+    expect(visibleWidth(line.slice(0, previewOffset))).toBe(57);
+  });
+
+  it.each([
+    ["CSI inside", "a\u001b[31mb", "custom\u001b[31m", "ab", "custom"],
+    [
+      "OSC inside",
+      "a\u001b]8;;https://example.invalid/\u0007b",
+      "custom\u001b]8;;https://example.invalid/\u0007",
+      "ab",
+      "custom",
+    ],
+    [
+      "CSI beyond cutoff",
+      `${"a".repeat(30)}\u001b[31m`,
+      "custom.progress-long\u001b[31m",
+      `${"a".repeat(18)}…`,
+      "custom.progress…",
+    ],
+    [
+      "OSC beyond cutoff",
+      `${"a".repeat(30)}\u001b]8;;https://example.invalid/\u0007`,
+      "custom.progress-long\u001b]8;;https://example.invalid/\u0007",
+      `${"a".repeat(18)}…`,
+      "custom.progress…",
+    ],
+  ])(
+    "renders %s as plain progress labels",
+    async (_name, suffix, type, displayed, displayedType) => {
+      const runtime = makeRuntime();
+      const key = `agent:main:${suffix}`;
+      await writeSessionEntry(key);
+      await appendEvents(
+        [makeEvent({ type, ts: "2026-05-18T12:04:21.000Z", data: { name: "proof" } })],
+        { key },
+      );
+
+      await sessionsTailCommand({ agent: "main", store: storePath, sessionKey: key }, runtime);
+
+      const line = runtimeOutput(runtime);
+      expect(line.split("\n")).toHaveLength(1);
+      expect(line).not.toContain("\u001b");
+      expect(line).not.toContain("\u0007");
+      expect(line).toContain(` ${displayedType} `);
+      expect(line).toContain(` agent:main:${displayed} `);
+      expect(line.endsWith(" proof")).toBe(true);
+      expect(visibleWidth(line.slice(0, line.lastIndexOf(" proof") + 1))).toBe(57);
+    },
+  );
 
   it("honors the tail count before rendering existing trajectory events", async () => {
     const runtime = makeRuntime();

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -6,6 +6,7 @@ import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/numb
  * and can follow newly appended SQLite trajectory rows.
  */
 import { normalizeOptionalString as toOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { listSessionEntriesReadOnly } from "../config/sessions/session-accessor.js";
@@ -17,7 +18,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import { loadSqliteTrajectoryRuntimeEventRowsSync } from "../trajectory/runtime-store.sqlite.js";
 import type { TrajectoryEvent } from "../trajectory/types.js";
 import { resolveSessionStoreTargetsOrExit } from "./session-store-targets.js";
-import { shortenText } from "./text-format.js";
+import { formatTextCell } from "./text-format.js";
 
 type SessionsTailOptions = {
   store?: string;
@@ -146,10 +147,9 @@ function safePreview(event: TrajectoryEvent): string {
 }
 
 function formatProgressLine(event: TrajectoryEvent): string {
-  const sessionLabel = shortenText(event.sessionKey ?? event.sessionId, SESSION_KEY_PAD).padEnd(
-    SESSION_KEY_PAD,
-  );
-  const typeLabel = shortenText(event.type, EVENT_TYPE_PAD).padEnd(EVENT_TYPE_PAD);
+  const sessionKey = event.sessionKey ?? event.sessionId;
+  const sessionLabel = formatTextCell(sanitizeTerminalText(sessionKey), SESSION_KEY_PAD);
+  const typeLabel = formatTextCell(sanitizeTerminalText(event.type), EVENT_TYPE_PAD);
   const preview = safePreview(event);
   return [formatTimestamp(event.ts), typeLabel, sessionLabel, preview].join(" ").trimEnd();
 }

--- a/src/commands/text-format.ts
+++ b/src/commands/text-format.ts
@@ -1,5 +1,5 @@
 // Tiny text formatting helpers shared by command output.
-// Uses Array.from so truncation respects Unicode code points instead of UTF-16 units.
+import { truncateToVisibleWidth, visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 
 /** Shortens text to maxLen code points, appending an ellipsis when truncated. */
 export const shortenText = (value: string, maxLen: number) => {
@@ -12,3 +12,9 @@ export const shortenText = (value: string, maxLen: number) => {
   }
   return `${chars.slice(0, Math.max(0, maxLen - 1)).join("")}…`;
 };
+
+/** Fits a plain-text terminal cell using visible width and whole graphemes. */
+export function formatTextCell(text: string, width: number): string {
+  const fitted = visibleWidth(text) > width ? `${truncateToVisibleWidth(text, width - 1)}…` : text;
+  return `${fitted}${" ".repeat(width - visibleWidth(fitted))}`;
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators reading `openclaw sessions tail` would see shifted progress columns or a split joined emoji when session keys contain CJK characters, combining accents or emoji.

## Why This Change Was Made

Tail mixed codepoint truncation with UTF-16 padding, neither of which measures terminal cells. Reuse TaskFlow's existing whole-grapheme cell formatter in the shared command text owner and preserve each caller's plain-text normalization boundary. This removes the duplicate formatting path without adding another Unicode algorithm.

Event and session labels are formatted; tool-preview selection and text, stored identities, JSON and routing remain unchanged. TaskFlow normalization and all other `shortenText` callers retain their contracts. Production: +14/-14 (net 0); tests: +80; docs: +1.

## User Impact

Progress previews stay in the same column for ASCII and Unicode keys. Long labels end at whole grapheme boundaries. The sessions documentation now describes this behavior and the existing SQLite follow path.

## Evidence

- The nine new command regressions produced six intended failures and three passing controls on original production. All 45 tests across the tail, Flow and text-format owner files pass after the repair.
- A captured source-entry Commander run exercised the real explicit-key resolver, supported SQLite store APIs, command registration and default runtime. Before, ASCII/CJK/combining/joined-emoji/truncation cases placed previews at columns 57/59/56/52/58. After, all nine cases align at column 57 and retain whole-grapheme, plain labels. Stored rows remained unchanged.
- All 29 required checks in the canonical five-path changed gate passed, including production and test typechecks, scoped lint, formatting and standard guards.
- Independent source/proof review and managed P0–P2 review found no actionable issues.

The command proof used isolated state and the real source CLI path; it did not exercise a packaged binary, live Gateway or provider. The changed behavior is owned by the human-output formatter.
