### PR TITLE
fix(release): accept protected-tag npm preflight candidates

### DIFF
--- a/scripts/release-candidate-checklist.mts
+++ b/scripts/release-candidate-checklist.mts
@@ -28,6 +28,7 @@ import {
 } from "./lib/arg-utils.mts";
 import { readBoundedResponseText } from "./lib/bounded-response.mjs";
 import { validatePluginSdkApiReleaseEvidence } from "./plugin-sdk-api-release-evidence.mjs";
+import { validateReleaseToolingIdentity } from "./release-tooling-identity.mjs";
 import {
   dedicatedSectionVersionForTag,
   extractChangelogReleaseSections,
@@ -849,26 +850,73 @@ export function validateTrustedToolingPin({
   return pinnedToolingSha;
 }
 
-export function validateNpmPreflightRunSource({
-  workflowRun,
-  workflowRef,
-  isTrustedWorkflowAncestor = gitIsAncestor,
-}: {
-  workflowRun: { headSha: string };
-  workflowRef: string;
-  isTrustedWorkflowAncestor?: (ancestor: string, target: string) => boolean;
-}) {
+export async function validateNpmPreflightRunSource(
+  {
+    repository,
+    runId,
+    workflowRun,
+    workflowRef,
+    isTrustedWorkflowAncestor = gitIsAncestor,
+  }: {
+    repository: string;
+    runId: string;
+    workflowRun: Omit<RunInfo, "jobs" | "url">;
+    workflowRef: string;
+    isTrustedWorkflowAncestor?: (ancestor: string, target: string) => boolean;
+  },
+  apiOptions: GithubApiOptions = {},
+) {
+  const [workflowPath, fullRef] = String(workflowRun.workflowPath).split("@", 2);
+  if (
+    String(workflowRun.databaseId) !== runId ||
+    !Number.isSafeInteger(workflowRun.runAttempt) ||
+    workflowRun.runAttempt < 1 ||
+    workflowRun.repository !== repository ||
+    workflowRun.workflowName !== "OpenClaw NPM Release" ||
+    workflowPath !== ".github/workflows/openclaw-npm-release.yml" ||
+    workflowRun.event !== "workflow_dispatch" ||
+    workflowRun.status !== "completed" ||
+    workflowRun.conclusion !== "success" ||
+    !/^[a-f0-9]{40}$/u.test(workflowRun.headSha)
+  ) {
+    throw new Error(`npm preflight run ${runId} has invalid workflow identity`);
+  }
+  const ref = workflowRun.headBranch ?? "";
+  const protectedTag = workflowRef === "main" && ref.startsWith("release-publish/");
+  const expectedFullRef = `refs/${protectedTag ? "tags" : "heads"}/${ref}`;
+  if ((!protectedTag && ref !== workflowRef) || (fullRef && fullRef !== expectedFullRef)) {
+    throw new Error(`npm preflight run ${runId} workflow ref mismatch`);
+  }
   const trustedRef = `refs/remotes/origin/${workflowRef}`;
   if (!isTrustedWorkflowAncestor(workflowRun.headSha, trustedRef)) {
     throw new Error(
       `npm preflight workflow SHA ${workflowRun.headSha} is not reachable from trusted ${workflowRef}`,
     );
   }
-  return {
-    status: "passed",
-    headSha: workflowRun.headSha,
-    workflowRef,
-  };
+  if (protectedTag) {
+    const [tagRef, branches] = await Promise.all([
+      githubApi(`repos/${repository}/git/ref/tags/${ref}`, apiOptions),
+      githubApi(`repos/${repository}/git/matching-refs/heads/${ref}`, apiOptions),
+    ]);
+    // Actions reports a short headBranch for tags too. A same-name branch cannot
+    // establish tag provenance, even when its commit happens to match.
+    if (
+      !Array.isArray(branches) ||
+      branches.some(
+        (branch) =>
+          !isRecord(branch) || typeof branch.ref !== "string" || branch.ref === `refs/heads/${ref}`,
+      )
+    ) {
+      throw new Error(`npm preflight run ${runId} has ambiguous protected tag provenance`);
+    }
+    validateReleaseToolingIdentity({
+      workflowRef: ref,
+      workflowFullRef: expectedFullRef,
+      workflowSha: workflowRun.headSha,
+      tagRef,
+    });
+  }
+  return { status: "passed", headSha: workflowRun.headSha, workflowRef: ref };
 }
 
 function candidateContributionRecordPullRequests(
@@ -1338,7 +1386,12 @@ function summarizeFailedRun(info: RunInfo) {
 async function waitForSuccessfulRun(
   repo: string,
   runId: string,
-  expected: { allowShaPinnedWorkflowRef?: boolean; workflowName: string; workflowRef: string },
+  expected: {
+    allowShaPinnedWorkflowRef?: boolean;
+    workflowName: string;
+    workflowRef: string;
+    validateSource?: (info: RunInfo) => ReturnType<typeof validateNpmPreflightRunSource>;
+  },
 ) {
   let lastState = "";
   for (;;) {
@@ -1367,6 +1420,9 @@ async function waitForSuccessfulRun(
           `run ${runId} workflow mismatch: expected ${expected.workflowName}, got ${info.workflowName}`,
         );
       }
+      if (expected.validateSource) {
+        return { run: info, source: await expected.validateSource(info) };
+      }
       const acceptsPinnedWorkflow =
         expected.allowShaPinnedWorkflowRef && isShaPinnedReleaseValidationBranch(info.headBranch);
       if (info.headBranch !== expected.workflowRef && !acceptsPinnedWorkflow) {
@@ -1374,7 +1430,7 @@ async function waitForSuccessfulRun(
           `run ${runId} branch mismatch: expected ${expected.workflowRef}, got ${info.headBranch}`,
         );
       }
-      return info;
+      return { run: info, source: undefined };
     }
     await wait(30_000);
   }
@@ -1453,8 +1509,11 @@ export function buildPublishCommand(
     fullReleaseRunAttempt?: number;
     npmTelegramRunId?: string;
   },
+  npmPreflightSource?: Awaited<ReturnType<typeof validateNpmPreflightRunSource>>,
 ) {
-  const workflowRef = options.tag.includes("-alpha.") ? options.workflowRef : "main";
+  const workflowRef =
+    npmPreflightSource?.workflowRef ??
+    (options.tag.includes("-alpha.") ? options.workflowRef : "main");
   if (options.tag.includes("-alpha.") && !TIDECLAW_ALPHA_WORKFLOW_REF_PATTERN.test(workflowRef)) {
     throw new Error(
       "alpha release publish requires a matching tideclaw/alpha/YYYY-MM-DD-HHMMZ workflow ref",
@@ -1769,7 +1828,7 @@ async function runTelegramIfNeeded(
     harness_ref: options.workflowRef,
     provider_mode: options.telegramProviderMode,
   });
-  const runLocal = await waitForSuccessfulRun(options.repo, runId, {
+  const { run: runLocal } = await waitForSuccessfulRun(options.repo, runId, {
     workflowName: "NPM Telegram Beta E2E",
     workflowRef: options.workflowRef,
   });
@@ -1905,19 +1964,26 @@ async function main() {
     npmPreflightRunId: options.npmPreflightRunId,
   });
 
-  const fullRun = await waitForSuccessfulRun(options.repo, options.fullReleaseRunId, {
+  const { run: fullRun } = await waitForSuccessfulRun(options.repo, options.fullReleaseRunId, {
     workflowName: "Full Release Validation",
     workflowRef: options.workflowRef,
     allowShaPinnedWorkflowRef: true,
   });
-  const npmRun = await waitForSuccessfulRun(options.repo, options.npmPreflightRunId, {
-    workflowName: "OpenClaw NPM Release",
-    workflowRef: options.workflowRef,
-  });
-  const npmPreflightSource = validateNpmPreflightRunSource({
-    workflowRun: { headSha: npmRun.headSha },
-    workflowRef: options.workflowRef,
-  });
+  const { run: npmRun, source: npmPreflightSource } = await waitForSuccessfulRun(
+    options.repo,
+    options.npmPreflightRunId,
+    {
+      workflowName: "OpenClaw NPM Release",
+      workflowRef: options.workflowRef,
+      validateSource: (workflowRun) =>
+        validateNpmPreflightRunSource({
+          repository: options.repo,
+          runId: options.npmPreflightRunId,
+          workflowRun,
+          workflowRef: options.workflowRef,
+        }),
+    },
+  );
 
   const npmDir = join(options.outputDir, "npm-preflight");
   const pluginSdkApiDir = join(options.outputDir, "plugin-sdk-api-evidence");
@@ -2060,11 +2126,14 @@ async function main() {
     "scripts/plugin-clawhub-release-plan.ts",
     options,
   );
-  const publishCommand = buildPublishCommand({
-    ...options,
-    fullReleaseRunAttempt: fullRun.runAttempt,
-    npmTelegramRunId: npmTelegram.runId,
-  });
+  const publishCommand = buildPublishCommand(
+    {
+      ...options,
+      fullReleaseRunAttempt: fullRun.runAttempt,
+      npmTelegramRunId: npmTelegram.runId,
+    },
+    npmPreflightSource,
+  );
   const evidence = {
     version: 1,
     tag: options.tag,

--- a/test/scripts/release-candidate-checklist.test.ts
+++ b/test/scripts/release-candidate-checklist.test.ts
@@ -921,32 +921,169 @@ describe("release candidate checklist", () => {
     ).toThrow("missing dependency tarball metadata");
   });
 
-  it("trusts the npm workflow SHA while binding the candidate through its manifest", () => {
-    const workflowSha = "a".repeat(40);
-    const isTrustedWorkflowAncestor = vi.fn(() => true);
-
-    expect(
-      validateNpmPreflightRunSource({
-        workflowRun: { headSha: workflowSha },
-        workflowRef: "main",
-        isTrustedWorkflowAncestor,
-      }),
-    ).toEqual({
-      status: "passed",
-      headSha: workflowSha,
+  describe("npm preflight source", () => {
+    const repo = "openclaw/openclaw";
+    const headSha = "a".repeat(40);
+    const protectedRef = `release-publish/${headSha.slice(0, 12)}-123`;
+    const workflowRun = {
+      databaseId: 456,
+      runAttempt: 2,
+      repository: repo,
+      workflowName: "OpenClaw NPM Release",
+      workflowPath: ".github/workflows/openclaw-npm-release.yml",
+      event: "workflow_dispatch",
+      status: "completed",
+      conclusion: "success",
+      headBranch: "main",
+      headSha,
+    };
+    const source = {
+      repository: repo,
+      runId: "456",
       workflowRef: "main",
-    });
-    expect(isTrustedWorkflowAncestor).toHaveBeenCalledWith(workflowSha, "refs/remotes/origin/main");
-  });
-
-  it("rejects npm preflight workflow code outside the trusted ref", () => {
-    expect(() =>
-      validateNpmPreflightRunSource({
-        workflowRun: { headSha: "a".repeat(40) },
-        workflowRef: "main",
-        isTrustedWorkflowAncestor: () => false,
+      workflowRun,
+      isTrustedWorkflowAncestor: () => true,
+    };
+    const tagRef = {
+      ref: `refs/tags/${protectedRef}`,
+      object: { type: "commit", sha: headSha },
+    };
+    const api = (tag: unknown = tagRef, branches: unknown = []) => ({
+      token: "",
+      fetchImpl: vi.fn(async (url: string) => {
+        if (url.includes(`/repos/${repo}/git/ref/tags/`)) return jsonResponse(tag);
+        if (url.includes(`/repos/${repo}/git/matching-refs/heads/`)) return jsonResponse(branches);
+        throw new Error(`unexpected request: ${url}`);
       }),
-    ).toThrow("is not reachable from trusted main");
+    });
+
+    it.each(["main", "tideclaw/alpha/2026-07-10-1200Z"])(
+      "retains the exact %s npm workflow source",
+      async (workflowRef) => {
+        const isTrustedWorkflowAncestor = vi.fn(() => true);
+        expect(
+          await validateNpmPreflightRunSource({
+            ...source,
+            workflowRef,
+            workflowRun: { ...workflowRun, headBranch: workflowRef },
+            isTrustedWorkflowAncestor,
+          }),
+        ).toEqual({ status: "passed", headSha, workflowRef });
+        expect(isTrustedWorkflowAncestor).toHaveBeenCalledWith(
+          headSha,
+          `refs/remotes/origin/${workflowRef}`,
+        );
+      },
+    );
+
+    it("accepts and records a protected npm preflight tag from trusted main", async () => {
+      const validated = await validateNpmPreflightRunSource(
+        { ...source, workflowRun: { ...workflowRun, headBranch: protectedRef } },
+        api(),
+      );
+      expect(validated).toEqual({ status: "passed", headSha, workflowRef: protectedRef });
+      expect(buildPublishCommand(parseArgs(["--tag", "v2026.7.1-beta.3"]), validated)).toContain(
+        `'--ref' '${protectedRef}'`,
+      );
+    });
+
+    it.each([
+      ["moved", { ...tagRef, object: { type: "commit", sha: "b".repeat(40) } }],
+      ["annotated", { ...tagRef, object: { type: "tag", sha: headSha } }],
+      ["missing", null],
+    ])("rejects a %s protected npm preflight tag", async (_label, tag) => {
+      await expect(
+        Promise.resolve().then(() =>
+          validateNpmPreflightRunSource(
+            {
+              ...source,
+              workflowRun: { ...workflowRun, headBranch: protectedRef },
+            },
+            api(tag),
+          ),
+        ),
+      ).rejects.toThrow("protected release tooling tag");
+    });
+
+    it("rejects a same-name branch instead of inferring tag provenance", async () => {
+      await expect(
+        Promise.resolve().then(() =>
+          validateNpmPreflightRunSource(
+            {
+              ...source,
+              workflowRun: { ...workflowRun, headBranch: protectedRef },
+            },
+            api(tagRef, [{ ref: `refs/heads/${protectedRef}` }]),
+          ),
+        ),
+      ).rejects.toThrow("ambiguous");
+    });
+
+    it.each([{}, [{}], [{ ref: 42 }]])(
+      "rejects malformed branch lookup data %j",
+      async (branches) => {
+        await expect(
+          validateNpmPreflightRunSource(
+            {
+              ...source,
+              workflowRun: { ...workflowRun, headBranch: protectedRef },
+            },
+            api(tagRef, branches),
+          ),
+        ).rejects.toThrow("ambiguous");
+      },
+    );
+
+    it.each([404, 503])("rejects unreadable tag provenance with HTTP %s", async (status) => {
+      await expect(
+        validateNpmPreflightRunSource(
+          {
+            ...source,
+            workflowRun: { ...workflowRun, headBranch: protectedRef },
+          },
+          { token: "", fetchImpl: async () => jsonResponse({}, { status }) },
+        ),
+      ).rejects.toThrow(`failed with ${status}`);
+    });
+
+    it.each([
+      { databaseId: 457 },
+      { runAttempt: 0 },
+      { repository: "other/openclaw" },
+      { workflowName: "Other workflow" },
+      { workflowPath: ".github/workflows/ci.yml" },
+      { event: "push" },
+      { status: "in_progress" },
+      { conclusion: "failure" },
+      { headSha: "not-a-sha" },
+      { headBranch: "release/2026.7.1" },
+      { headBranch: `release-publish/${"b".repeat(12)}-123` },
+      { headBranch: `release-publish/${"a".repeat(12)}-0` },
+      { workflowPath: ".github/workflows/openclaw-npm-release.yml@refs/heads/other" },
+    ])("rejects mismatched npm preflight identity %j", async (override) => {
+      await expect(
+        Promise.resolve().then(() =>
+          validateNpmPreflightRunSource(
+            {
+              ...source,
+              workflowRun: { ...workflowRun, ...override },
+            },
+            api(),
+          ),
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("rejects npm preflight workflow code outside the trusted ref", async () => {
+      await expect(
+        Promise.resolve().then(() =>
+          validateNpmPreflightRunSource({
+            ...source,
+            isTrustedWorkflowAncestor: () => false,
+          }),
+        ),
+      ).rejects.toThrow("is not reachable from trusted main");
+    });
   });
 
   it("requires run ids when dispatch is disabled", () => {

--- a/test/scripts/release-candidate-checklist.test.ts
+++ b/test/scripts/release-candidate-checklist.test.ts
@@ -1051,7 +1051,7 @@ describe("release candidate checklist", () => {
       { runAttempt: 0 },
       { repository: "other/openclaw" },
       { workflowName: "Other workflow" },
-      { workflowPath: ".github/workflows/ci.yml" },
+      { workflowPath: ".github/workflows/unrelated.yml" },
       { event: "push" },
       { status: "in_progress" },
       { conclusion: "failure" },

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -887,6 +887,7 @@ describe("scripts/test-projects changed-target routing", () => {
         "test/scripts/ci-workflow-guards.test.ts",
         "test/scripts/openclaw-npm-resume-run.test.ts",
         "test/scripts/package-source-preflight.test.ts",
+        "test/scripts/release-candidate-checklist.test.ts",
         "test/scripts/release-plan-producer.test.ts",
       ],
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release maintainers could not consume a successful npm preflight from the protected tooling tag supported by the publisher. The candidate checklist rejected that run as outside `main`; its generated publish command also switched the workflow ref back to `main`, which could select newer tooling incompatible with the frozen preflight.

## Why This Change Was Made

The npm source validator now owns run identity and ref acceptance. It retains trusted-main ancestry, reuses the canonical lightweight-tag/SHA validator, and rejects same-name branches or unreadable reference evidence. The waiter carries the validated source receipt into the generated publish command. Normal `main` and matching alpha runs retain their existing behavior; release code, manifests, SDK evidence, and publisher gates are unchanged.

## User Impact

Maintainers can finish a release with its frozen publisher tooling after `main` advances. There is no application runtime or configuration change.

## Evidence

- Before the repair, protected-tag source identity was recorded as `main`, invalid run/tag cases were accepted by the source validator, and the publish command selected `main` instead of the validated protected tag. These assertions failed before their corresponding fixes.
- 160 focused tests pass across candidate checklist, canonical tooling identity, and full-validation evidence suites. Coverage includes main/alpha preservation, moved or annotated tags, branch ambiguity, malformed/unreadable reference responses, and wrong workflow/run/attempt identities.
- Full changed-file gate passes (script and test-root types, formatting, lint, and release/tooling guards). Final independent review is scoped-clean at P0 (0.96).
- Read-only live source validation passes for historical protected-tag preflight [31396215503 attempt 1](https://github.com/openclaw/openclaw/actions/runs/31396215503), including live tag binding and same-name branch absence; the generated publisher ref remains that exact tag. This historical probe is not current release acceptance. Exact-head hosted CI remains pending. No package, tag, or release was published by this change.

Tooling LOC: +101/-32 (net +69); tests: +160/-23. The added tooling establishes the protected-tag admission boundary and carries its receipt through publication command generation, using the existing shared tag validator rather than duplicating it.
