### PR TITLE
perf(media): avoid redundant attachment scans and base64 round trips

### DIFF
--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -265,7 +265,7 @@ When `mode: "all"`, outputs are labeled `[Image 1/2]`, `[Audio 2/2]`, etc.
 - Files rejected by an operator-configured `allowedMimes` list get `[Attachment type not allowed: <mime>]` instead, so the prompt never claims support the active configuration disables.
 - Read failures get `[Attachment could not be read]`.
 - URL attachments get `[Attachment skipped: URL file sources are disabled]` when URL file sources are disabled.
-- A file with no extractable text, including an empty local file, gets `[No extractable text]` and does not consume the skip-marker budget.
+- A file with no extractable text, including an empty local text file, gets `[No extractable text]` and does not consume the skip-marker budget.
 - At most five skip markers render per message; further skipped attachments collapse into one reason-neutral `[<n> more attachments skipped]` summary so junk attachments cannot grow the prompt without bound. File and image, audio, or video markers share this five-marker budget.
 - If a PDF falls back to rendered page images, OpenClaw forwards those images to vision-capable reply models and keeps the placeholder `[PDF content rendered to images]` in the file block.
 - Image, audio, and video decisions record one closed disposition for every attachment candidate: handled, handed to native vision, not selected after the attachment limit, disabled, missing a model, denied by chat scope, or failed.

--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -265,7 +265,7 @@ When `mode: "all"`, outputs are labeled `[Image 1/2]`, `[Audio 2/2]`, etc.
 - Files rejected by an operator-configured `allowedMimes` list get `[Attachment type not allowed: <mime>]` instead, so the prompt never claims support the active configuration disables.
 - Read failures get `[Attachment could not be read]`.
 - URL attachments get `[Attachment skipped: URL file sources are disabled]` when URL file sources are disabled.
-- A file with no extractable text gets `[No extractable text]`.
+- A file with no extractable text, including an empty local file, gets `[No extractable text]` and does not consume the skip-marker budget.
 - At most five skip markers render per message; further skipped attachments collapse into one reason-neutral `[<n> more attachments skipped]` summary so junk attachments cannot grow the prompt without bound. File and image, audio, or video markers share this five-marker budget.
 - If a PDF falls back to rendered page images, OpenClaw forwards those images to vision-capable reply models and keeps the placeholder `[PDF content rendered to images]` in the file block.
 - Image, audio, and video decisions record one closed disposition for every attachment candidate: handled, handed to native vision, not selected after the attachment limit, disabled, missing a model, denied by chat scope, or failed.

--- a/packages/media-core/src/attachment-classify.ts
+++ b/packages/media-core/src/attachment-classify.ts
@@ -79,7 +79,7 @@ function resolveUtf16Charset(buffer: Buffer): AttachmentCharset | undefined {
   return zeroOdd >= zeroEven ? "utf-16le" : "utf-16be";
 }
 
-function textRatios(text: string): [printable: number, wordish: number] {
+function textRatios(text: string, includeWordish: boolean): [printable: number, wordish: number] {
   let printable = 0;
   let control = 0;
   let wordish = 0;
@@ -92,7 +92,7 @@ function textRatios(text: string): [printable: number, wordish: number] {
       control += 1;
     } else {
       printable += 1;
-      wordish += Number(WORDISH_CHAR.test(char));
+      wordish += includeWordish ? Number(WORDISH_CHAR.test(char)) : 0;
     }
   }
   const total = printable + control;
@@ -105,9 +105,9 @@ function looksLikeText(buffer: Buffer): boolean {
   }
   const sample = buffer.subarray(0, Math.min(buffer.length, 4096));
   try {
-    return textRatios(new TextDecoder("utf-8", { fatal: true }).decode(sample))[0] > 0.85;
+    return textRatios(new TextDecoder("utf-8", { fatal: true }).decode(sample), false)[0] > 0.85;
   } catch {
-    const [printable, wordish] = textRatios(new TextDecoder("windows-1252").decode(sample));
+    const [printable, wordish] = textRatios(new TextDecoder("windows-1252").decode(sample), true);
     return printable > 0.95 && wordish > 0.3;
   }
 }
@@ -126,7 +126,6 @@ export async function classifyAttachmentBytes(params: {
     filePath: params.name ?? undefined,
   });
   const detectedClass = attachmentClassFromMime(mime);
-  const charset = resolveUtf16Charset(params.buffer);
   const hasUtf16Bom =
     params.buffer.length >= 2 &&
     (params.buffer.readUInt16LE(0) === 0xfeff || params.buffer.readUInt16LE(0) === 0xfffe);
@@ -135,16 +134,16 @@ export async function classifyAttachmentBytes(params: {
     mime?.startsWith("application/vnd.") ||
     (detectedClass !== "binary" && !hasUtf16Bom)
   ) {
+    const charset = detectedClass === "text" ? resolveUtf16Charset(params.buffer) : undefined;
     // Text resolved by extension can still be BOM-less UTF-16; dropping the
     // detected charset here would decode it downstream as UTF-8 mojibake.
-    return detectedClass === "text" && charset
-      ? { mime, class: detectedClass, charset }
-      : { mime, class: detectedClass };
+    return charset ? { mime, class: detectedClass, charset } : { mime, class: detectedClass };
   }
   const signature = params.buffer.length >= 4 ? params.buffer.readUInt32BE(0) : 0;
   if (signature === 0x504b0304 || signature === 0x504b0102 || signature === 0x504b0506) {
     return { mime, class: "archive" };
   }
+  const charset = resolveUtf16Charset(params.buffer);
   if (!charset && !looksLikeText(params.buffer)) {
     return { mime, class: "binary" };
   }

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -2266,12 +2266,11 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Body).toContain("legitimate content");
   });
 
-  it("forces BodyForCommands when only file blocks are added", async () => {
-    const filePath = await createTempMediaFile({
-      fileName: "notes.txt",
-      content: "file content",
-    });
-
+  it.each([
+    { content: "file content", expected: "file content" },
+    { content: "", expected: "[No extractable text]" },
+  ])("finalizes file context with content %j", async ({ content, expected }) => {
+    const filePath = await createTempMediaFile({ fileName: "notes.txt", content });
     const { ctx, result } = await applyWithDisabledMedia({
       body: "<media:document>",
       mediaPath: filePath,
@@ -2280,6 +2279,9 @@ describe("applyMediaUnderstanding", () => {
 
     expect(result.appliedFile).toBe(true);
     expect(ctx.Body).toContain('<file name="notes.txt" mime="text/plain">');
+    expect(ctx.Body).toContain(expected);
+    expect(ctx.agentText).toBe(ctx.Body);
+    expect(ctx.BodyForAgent).toBe(ctx.Body);
     expect(ctx.BodyForCommands).toBe(ctx.Body);
   });
 
@@ -2525,25 +2527,40 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Body).not.toContain("OWNED");
   });
 
-  it("caps cumulative skip markers and collapses overflow into one summary", async () => {
-    const olePayload = Buffer.from("Root Entry WordDocument legacy preview", "utf8");
-    const media: { path: string; contentType: string }[] = [];
-    for (let i = 0; i < 7; i += 1) {
-      const filePath = await createTempMediaFile({
-        fileName: `legacy-${i}.doc`,
-        content: olePayload,
-      });
-      media.push({ path: filePath, contentType: "application/msword" });
-    }
+  it.each([false, true])(
+    "caps skipped markers without counting empty files (empty first: %s)",
+    async (emptyFirst) => {
+      const olePayload = Buffer.from("Root Entry WordDocument legacy preview", "utf8");
+      const media: { path: string; contentType: string }[] = [];
+      if (emptyFirst) {
+        const filePath = await createTempMediaFile({ fileName: "empty.txt", content: "" });
+        media.push({ path: filePath, contentType: "text/plain" });
+      }
+      for (let i = 0; i < 7; i += 1) {
+        const filePath = await createTempMediaFile({
+          fileName: `legacy-${i}.doc`,
+          content: olePayload,
+        });
+        media.push({ path: filePath, contentType: "application/msword" });
+      }
 
-    const ctx: MsgContext = { Body: "<media:file>", media };
-    const result = await applyMediaUnderstanding({ ctx, cfg: createMediaDisabledConfig() });
+      const ctx: MsgContext = { Body: "<media:file>", media };
+      const result = await applyMediaUnderstanding({ ctx, cfg: createMediaDisabledConfig() });
 
-    expect(result.appliedFile).toBe(true);
-    const markerCount = ctx.Body?.split("[Unsupported document format").length ?? 0;
-    expect(markerCount - 1).toBe(5);
-    expect(ctx.Body).toContain("[2 more attachments skipped]");
-  });
+      expect(result.appliedFile).toBe(true);
+      if (emptyFirst) {
+        expect(ctx.Body).toContain(
+          '<file name="empty.txt" mime="text/plain">\n[No extractable text]\n</file>',
+        );
+        expect(ctx.Body).not.toContain("[Attachment could not be read]");
+      }
+      const markerCount = ctx.Body?.split("[Unsupported document format").length ?? 0;
+      expect(markerCount - 1).toBe(5);
+      expect(ctx.Body).toContain('<file name="legacy-4.doc"');
+      expect(ctx.Body).not.toContain('<file name="legacy-5.doc"');
+      expect(ctx.Body).toContain("[2 more attachments skipped]");
+    },
+  );
 
   it("shares one reason-neutral overflow budget across document and media markers", async () => {
     const olePayload = Buffer.from("Root Entry WordDocument legacy preview", "utf8");

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -17,7 +17,7 @@ import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { renderFileContextBlock } from "../media/file-context.js";
-import { extractFileContentFromSource } from "../media/input-files.js";
+import { extractFileContentFromBuffer } from "../media/input-files.js";
 import { classifyMediaReferenceSource } from "../media/media-reference.js";
 import { runMediaCapability } from "./apply-capability.js";
 import { resolveAttachmentKind } from "./attachments.js";
@@ -232,16 +232,13 @@ async function classifyFileAttachment(params: {
         };
     return { outcome, filename, mimeType };
   }
-  let extracted: Awaited<ReturnType<typeof extractFileContentFromSource>>;
+  let extracted: Awaited<ReturnType<typeof extractFileContentFromBuffer>>;
   try {
     const { allowedMimesConfigured: _allowedMimesConfigured, ...baseLimits } = limits;
-    extracted = await extractFileContentFromSource({
-      source: {
-        type: "base64",
-        data: bufferResult.buffer.toString("base64"),
-        mediaType: mimeType,
-        filename: bufferResult.fileName,
-      },
+    extracted = await extractFileContentFromBuffer({
+      // Extractor plugins receive owned mutable bytes, never the attachment cache's buffer.
+      buffer: Buffer.from(bufferResult.buffer),
+      filename: bufferResult.fileName,
       limits: { ...baseLimits, allowedMimes },
       config: cfg,
       classification,

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -387,7 +387,6 @@ export async function extractFileContentFromSource(params: {
   source: InputFileSource;
   limits: InputFileLimits;
   config?: OpenClawConfig;
-  classification?: AttachmentClassification;
 }): Promise<InputFileExtractResult> {
   const { source, limits } = params;
   const filename = source.filename || "file";
@@ -427,6 +426,28 @@ export async function extractFileContentFromSource(params: {
     buffer = result.buffer;
   }
 
+  return await extractFileContentFromBuffer({
+    buffer,
+    filename,
+    mimeType,
+    charset,
+    limits,
+    config: params.config,
+  });
+}
+
+/** Extracts owned bytes after shared size and MIME checks; no source encoding is required. */
+export async function extractFileContentFromBuffer(params: {
+  buffer: Buffer;
+  filename?: string;
+  mimeType?: string;
+  charset?: string;
+  limits: InputFileLimits;
+  config?: OpenClawConfig;
+  classification?: AttachmentClassification;
+}): Promise<InputFileExtractResult> {
+  const { buffer, limits } = params;
+  const filename = params.filename || "file";
   if (buffer.byteLength > limits.maxBytes) {
     throw new Error(`File too large: ${buffer.byteLength} bytes (limit: ${limits.maxBytes} bytes)`);
   }
@@ -434,9 +455,10 @@ export async function extractFileContentFromSource(params: {
   // Direct input_file callers declare their content type; the filename is
   // display metadata and must not override an explicitly allowlisted MIME.
   const classification =
-    params.classification ?? (await classifyAttachmentBytes({ buffer, declaredMime: mimeType }));
-  mimeType = classification.mime;
-  charset = classification.charset ?? charset;
+    params.classification ??
+    (await classifyAttachmentBytes({ buffer, declaredMime: params.mimeType }));
+  const mimeType = classification.mime;
+  const charset = classification.charset ?? params.charset;
 
   if (!mimeType) {
     throw new Error("input_file missing media type");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where attaching an empty local text file reported `[Attachment could not be read]` and consumed a skipped-attachment slot, hiding another attachment's explanation. It also removes avoidable preparation work before local file content reaches the model.

## Why This Change Was Made

Classification now skips charset and character scans when their results are unused, preserving MIME precedence and encoding detection. Local extraction carries its classification into one shared byte-based extractor instead of encoding, validating, and decoding base64; it retains `Buffer.from` so mutable extractor plugins cannot modify the attachment cache.

## User Impact

An empty local text file now produces `[No extractable text]` without consuming the five skipped-marker slots; later unsupported attachments and overflow counts remain accurate. Public empty-base64 requests remain invalid, and existing size, MIME, PDF, and output limits remain in force. No configuration or dependency changes are required.

## Evidence

- Both expanded regression cases failed before the fix while their original controls passed; all 533 tests across 14 suites pass afterward (26.13s).
- Seven copied-source proof modes matched their expected outcomes, including the pre-fix failure; 64 multi-attachment invocations covered ordering and skip-budget effects. PDF/network substitutions establish contract behavior, not live service performance.
- Full changed gate passed (262.30s); managed review found no actionable issues.

Selected-owner medians, with the starting order reversed in a second fresh process:

| Workload | Before → after, before-first | Before → after, candidate-first |
| --- | ---: | ---: |
| Local ASCII extraction, 20 MiB | 86.143 → 1.165 ms | 86.942 → 1.188 ms |
| Local ASCII extraction, 4 KiB | 13.844 → 0.595 µs | 14.956 → 0.607 µs |
| ASCII classification | 58.869 → 29.344 µs | 57.130 → 29.440 µs |
| PNG classification | 13.927 → 12.702 µs | 13.109 → 12.179 µs |

All 24 workloads, 484 paired rounds and 968 variant samples are retained; an independent audit reproduced all wall medians and ratios. Four controls were slower in both orders: DOCX classification (+0.62%/+1.22%), split-codepoint CJK classification (+1.39%/+2.09%), Windows-1252 classification (+0.97%/+2.01%), and public base64 at 64 KiB (+0.74%/+0.26%). Public base64 at 64 bytes was mixed (+1.42%/−0.03%). These are medians, not statistical-significance claims.

Local extraction includes the retained buffer copy, with classification prepared outside the measured call. These measurements do not establish whole-Gateway, file-I/O, provider latency, or RSS/heap improvements; no overall speedup is claimed.

Production: +39/−21 (net +18), establishing the shared owned-byte entry rather than a second extraction pipeline. Tests: +40/−23 (net +17). Documentation: +1/−1.

The committed build passed (166.04s); a subsequent one-word documentation clarification was independently reviewed and rebuilt at final head `8c20b5ac9c5c9fcf28ab3d7479d8f00fcefe8284` (35.45s, with unchanged production build caches reused). Production and test bytes match the measured source.

Fresh isolated Gateway proof at that final head completed three real `openai/gpt-5.6-luna` attachment turns in the original order: UTF-8, unknown MIME, and BOM-less UTF-16. All 43 helper checks passed, including exact run/session correlation, actual media-processing spans under dispatch, complete extracted text in model input, final replies and the separate empty-wire rejection. Two identity RPCs verified the same serving build/process; the wrapper checked source/build/task inputs before and after. Stable decoded content and reply hashes match the preserved pre-change baseline. This is one captured stream invocation per turn, not proof of no lower-level HTTP retry. The historical baseline has separately reviewed upstream MIME/admission/abort drift.

Node CPU profiles were captured for the actual final Gateway PID; they include startup, provider waits and shutdown and are diagnostic evidence, not a controlled whole-turn speedup. The proof client and Gateway launcher/process group are confirmed gone, the port closed and credential FIFO absent. No operator Gateway was changed.

[Exact-head hosted CI passed](https://github.com/openclaw/openclaw/actions/runs/33326242999). The latest ClawSweeper review found no actionable defect; its CI rank-up move is satisfied. The +18 production lines retain one shared byte extraction owner, and the cached-local path has no parallel extraction pipeline.

Telegram-specific E2E was not run: no Telegram transport code changes here. Real Gateway attachment turns exercise the shared cache-to-extractor owner. The empty-local-text and skipped-marker correction is covered by canonical actual-file regressions and the batch proof; `chat.send` rejects an empty wire payload before that owner. This PR does not claim Telegram transport or remote-channel proof.
