### PR TITLE
fix: preserve uploader identity in Beam transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Beam uploader identity:** retain the authenticated snapshot publisher, resolve their current profile for imported user turns, and keep unattributed external transcripts independent of the viewer.
 - **Chat attachments:** protect prepared message-tool media from premature cleanup, attach it before publication, and complete interrupted attachment promotion on retries without duplicating the original reply.
 - **Upgrade state metadata:** record the current application version after repairing older databases with an unset version marker, allowing CLI commands to use the running Gateway without attempting another schema repair.
 - **Device workers:** preserve offline-runner classification and reconnect guidance when desktop preparation detects a disconnected device, without treating the disconnect as a model failure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Beam uploader identity:** retain the authenticated snapshot publisher, resolve their current profile for imported user turns, and keep unattributed external transcripts independent of the viewer.
 - **Chat attachments:** protect prepared message-tool media from premature cleanup, attach it before publication, and complete interrupted attachment promotion on retries without duplicating the original reply.
 - **Upgrade state metadata:** record the current application version after repairing older databases with an unset version marker, allowing CLI commands to use the running Gateway without attempting another schema repair.
 - **Device workers:** preserve offline-runner classification and reconnect guidance when desktop preparation detects a disconnected device, without treating the disconnect as a model failure.

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -5540,6 +5540,7 @@ public struct SessionCatalogTranscriptItem: Codable, Sendable {
     public let text: String?
     public let timestamp: String?
     public let model: String?
+    public let sender: SessionParticipant?
     public let truncated: Bool?
     public let raw: AnyCodable?
 
@@ -5549,6 +5550,7 @@ public struct SessionCatalogTranscriptItem: Codable, Sendable {
         text: String? = nil,
         timestamp: String? = nil,
         model: String? = nil,
+        sender: SessionParticipant? = nil,
         truncated: Bool? = nil,
         raw: AnyCodable? = nil)
     {
@@ -5557,6 +5559,7 @@ public struct SessionCatalogTranscriptItem: Codable, Sendable {
         self.text = text
         self.timestamp = timestamp
         self.model = model
+        self.sender = sender
         self.truncated = truncated
         self.raw = raw
     }

--- a/docs/plugins/beam.md
+++ b/docs/plugins/beam.md
@@ -44,7 +44,7 @@ openclaw gateway restart
 
 The receiver uses normal Gateway HTTP authentication. It is not an anonymous upload endpoint.
 
-- With `gateway.auth.mode: "trusted-proxy"`, send requests through the configured identity-aware proxy. Beam relies on Gateway authentication but does not persist proxy identity headers as uploader attribution.
+- With `gateway.auth.mode: "trusted-proxy"`, send requests through the configured identity-aware proxy. Beam records the verified uploader's OpenClaw profile ID, when available; it does not retain proxy identity headers or credentials.
 - With token or password auth, send `Authorization: Bearer <gateway-token-or-password>`.
 - Do not enable Beam with `gateway.auth.mode: "none"` unless another private ingress fully authenticates every request.
 
@@ -113,7 +113,9 @@ Beam stores sanitized payloads in OpenClaw's shared SQLite-backed plugin state:
 - oldest-entry eviction when the catalog reaches its bound
 - server receipt time controls catalog ordering; clients cannot move themselves ahead with a forged timestamp
 
-The catalog is intentionally shared across the Gateway operator domain. Every client with `operator.read` can view every beamed session, while uploads require `operator.write` or `operator.admin`. Uploader identity is not retained, and any write-authorized operator that knows a Beam id can update that row. OpenClaw operator scopes are not tenant isolation; use a separate Gateway when sessions must be isolated between teams or machines.
+The catalog is intentionally shared across the Gateway operator domain. Every client with `operator.read` can view every beamed session, while uploads require `operator.write` or `operator.admin`. Any write-authorized operator that knows a Beam id can update that row. Uploader attribution does not grant ownership or change access. OpenClaw operator scopes are not tenant isolation; use a separate Gateway when sessions must be isolated between teams or machines.
+
+User turns are attributed to the verified publisher of the current snapshot, using their current profile name and avatar, including merged profiles. Beam's upload format does not identify individual authors within a multi-user transcript. The uploader reference shares the snapshot's seven-day retention and is replaced on each upload. Shared-token uploads, failed profile resolution, and older snapshots without a recorded uploader display **User**; they never inherit the viewer's identity or a previous uploader's identity. Reupload an older snapshot through personal authentication to attribute it.
 
 ## Security boundary
 

--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -162,6 +162,12 @@ export default definePluginEntry({
   `onHost(host)` callback as each host settles; the returned host array remains
   required as the final compatibility snapshot.
 
+  Transcript items may include a `sender` with a qualified `SessionParticipant`
+  identity and optional display label or avatar. Supply only source-known
+  attribution; the viewer and the session adopter are not transcript authors.
+  Core resolves profile identities against current profile data, including merges.
+  User items without attribution display as **User**.
+
   Native source titles are presentation, not unique session labels. When adopting
   a new source, pass its title as `displayName` to the owner-authorized
   [session creator](/plugins/sdk-runtime); the host bounds and stores that snapshot

--- a/extensions/beam/src/beam.test.ts
+++ b/extensions/beam/src/beam.test.ts
@@ -180,7 +180,7 @@ describe("Beam receiver", () => {
       createBeamRequestHandler({
         store,
         resolveClient: () => ({ ...writeClient(), profileId }),
-        resolveControlUiTarget: mainControlUiTarget,
+        resolveControlUiBasePath: rootControlUiBasePath,
       }),
     );
     const upload = (body = sampleUpload()) =>

--- a/extensions/beam/src/beam.test.ts
+++ b/extensions/beam/src/beam.test.ts
@@ -173,6 +173,41 @@ describe("Beam payload validation", () => {
 });
 
 describe("Beam receiver", () => {
+  it("attributes each uploaded snapshot to its verified publisher, never payload claims", async () => {
+    const store = memoryStore();
+    let profileId: string | undefined = "uploader-profile";
+    const endpoint = await serve(
+      createBeamRequestHandler({
+        store,
+        resolveClient: () => ({ ...writeClient(), profileId }),
+        resolveControlUiTarget: mainControlUiTarget,
+      }),
+    );
+    const upload = (body = sampleUpload()) =>
+      fetch(endpoint, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+    const read = () =>
+      createBeamSessionCatalog(store).read({
+        hostId: "gateway",
+        threadId: sampleUpload().beamId,
+      });
+    for (const publisher of ["uploader-profile", "another-profile", undefined]) {
+      profileId = publisher;
+      expect((await upload()).status).toBe(200);
+      expect((await store.get(sampleUpload().beamId))?.uploaderProfileId).toBe(publisher);
+      const transcript = await read();
+      expect(transcript.items.find((item) => item.type === "userMessage")?.sender).toEqual(
+        publisher ? { identity: { type: "profile", id: publisher } } : undefined,
+      );
+      expect(transcript.items.find((item) => item.type === "agentMessage")?.sender).toBeUndefined();
+    }
+    expect((await upload(sampleUpload({ uploaderProfileId: "forged-profile" }))).status).toBe(400);
+    expect((await store.get(sampleUpload().beamId))?.uploaderProfileId).toBeUndefined();
+  });
+
   it("stores authenticated uploads and preserves creation time across updates", async () => {
     const store = memoryStore();
     let now = 100;

--- a/extensions/beam/src/http.ts
+++ b/extensions/beam/src/http.ts
@@ -25,6 +25,7 @@ function firstHeader(req: IncomingMessage, name: string): string | undefined {
 type BeamRequestClient = {
   clientIp: string;
   scopes: readonly string[];
+  profileId?: string;
 };
 
 function currentRequestClient(req: IncomingMessage): BeamRequestClient {
@@ -32,6 +33,7 @@ function currentRequestClient(req: IncomingMessage): BeamRequestClient {
   return {
     clientIp: client?.clientIp ?? req.socket.remoteAddress ?? "unknown",
     scopes: client?.connect?.scopes ?? [],
+    profileId: client?.authenticatedUserProfile?.profileId,
   };
 }
 
@@ -101,6 +103,8 @@ export function createBeamRequestHandler(params: {
       const existing = await params.store.get(parsed.value.beamId);
       await params.store.put({
         ...parsed.value,
+        // An anonymous replacement must not inherit a previous publisher's identity.
+        ...(client.profileId ? { uploaderProfileId: client.profileId } : {}),
         createdAt: existing?.createdAt ?? receivedAt,
         receivedAt,
       });

--- a/extensions/beam/src/session-catalog.ts
+++ b/extensions/beam/src/session-catalog.ts
@@ -32,6 +32,9 @@ function transcriptItems(session: BeamStoredSession): SessionCatalogTranscriptIt
     type: item.type,
     text: item.text,
     timestamp: session.updatedAt,
+    ...(item.type === "userMessage" && session.uploaderProfileId
+      ? { sender: { identity: { type: "profile" as const, id: session.uploaderProfileId } } }
+      : {}),
   }));
 }
 

--- a/extensions/beam/src/types.ts
+++ b/extensions/beam/src/types.ts
@@ -39,6 +39,8 @@ type BeamUpload = {
 };
 
 export type BeamStoredSession = BeamUpload & {
+  /** Verified publisher of this snapshot; never accepted from the upload body. */
+  uploaderProfileId?: string;
   createdAt: number;
   receivedAt: number;
 };

--- a/packages/gateway-protocol/src/schema/sessions-catalog.ts
+++ b/packages/gateway-protocol/src/schema/sessions-catalog.ts
@@ -3,6 +3,7 @@ import { Type } from "typebox";
 import { closedObject } from "./closed-object.js";
 import { PluginJsonValueSchema } from "./plugins.js";
 import { NonEmptyString } from "./primitives.js";
+import { SessionParticipantSchema } from "./session-participant.js";
 import { SessionCreatedActorSchema } from "./sessions-row.js";
 
 const SessionCatalogErrorSchema = closedObject({ code: NonEmptyString, message: NonEmptyString });
@@ -145,6 +146,8 @@ export const SessionCatalogTranscriptItemSchema = closedObject({
   text: Type.Optional(Type.String()),
   timestamp: Type.Optional(Type.String()),
   model: Type.Optional(Type.String()),
+  /** Source-supplied attribution, independent of the viewer and session adopter. */
+  sender: Type.Optional(SessionParticipantSchema),
   truncated: Type.Optional(Type.Boolean()),
   raw: Type.Optional(PluginJsonValueSchema),
 });

--- a/src/gateway/github-user-identity.test.ts
+++ b/src/gateway/github-user-identity.test.ts
@@ -40,6 +40,7 @@ function cloudflareSync(params: {
   assertion?: string;
   userHeader?: string;
   requiredHeaders?: string[];
+  preferCachedIdentity?: boolean;
 }) {
   return createAuthenticatedGitHubIdentitySync({
     authResult: {
@@ -59,6 +60,7 @@ function cloudflareSync(params: {
       "cf-access-jwt-assertion":
         params.assertion ?? accessAssertion("https://team.cloudflareaccess.com"),
     },
+    preferCachedIdentity: params.preferCachedIdentity,
   });
 }
 
@@ -352,6 +354,85 @@ describe("authenticated GitHub identity sync", () => {
       expect(fetchMock).toHaveBeenCalledTimes(4);
     });
   });
+
+  it.each([true, false])(
+    "reuses an exact Access identity before GitHub refresh only when requested: %s",
+    async (preferCachedIdentity) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        const profile = syncGitHubIdentity({
+          identity: { accountId: 58493, login: "ada" },
+          authenticationAlias: { kind: "email", email: "ada@example.com" },
+        });
+        setDisplayName(profile.id, "User Chosen");
+        const fetchMock = vi
+          .spyOn(globalThis, "fetch")
+          .mockResolvedValueOnce(
+            githubResponse({
+              id: 58493,
+              email: "ada@example.com",
+              idp: { type: "github" },
+            }),
+          )
+          .mockResolvedValueOnce(githubResponse({ id: 58493, login: "ada-renamed" }));
+
+        const result = await cloudflareSync({
+          principal: "ADA@Example.COM",
+          preferCachedIdentity,
+        })?.();
+
+        expect(result?.profileId).toBe(profile.id);
+        expect(fetchMock).toHaveBeenCalledTimes(preferCachedIdentity ? 1 : 2);
+        expect(fetchMock.mock.calls[0]?.[0]).toBe(
+          "https://team.cloudflareaccess.com/cdn-cgi/access/get-identity",
+        );
+        expect(getUserProfileListItem(profile.id)).toMatchObject({
+          displayName: "User Chosen",
+          githubIdentity: { login: preferCachedIdentity ? "ada" : "ada-renamed" },
+        });
+      });
+    },
+  );
+
+  it.each([
+    { name: "missing binding", seedCache: false },
+    { name: "different account", accountId: 99999 },
+    { name: "different email", principal: "other@example.com" },
+    { name: "account and email on different profiles", accountId: 99999, otherProfile: true },
+  ])(
+    "requires GitHub verification for a $name even when cached identity is preferred",
+    async ({ seedCache, accountId, principal, otherProfile }) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        if (seedCache !== false) {
+          syncGitHubIdentity({
+            identity: { accountId: 58493, login: "ada" },
+            authenticationAlias: { kind: "email", email: "ada@example.com" },
+          });
+        }
+        if (otherProfile) {
+          syncGitHubIdentity({
+            identity: { accountId: 99999, login: "other" },
+            authenticationAlias: { kind: "email", email: "other@example.com" },
+          });
+        }
+        const authenticatedEmail = principal ?? "ada@example.com";
+        const fetchMock = vi
+          .spyOn(globalThis, "fetch")
+          .mockResolvedValueOnce(
+            githubResponse({
+              id: accountId ?? 58493,
+              email: authenticatedEmail,
+              idp: { type: "github" },
+            }),
+          )
+          .mockResolvedValueOnce(githubResponse({}, 503));
+
+        await expect(
+          cloudflareSync({ principal: authenticatedEmail, preferCachedIdentity: true })?.(),
+        ).rejects.toMatchObject({ statusCode: 502 });
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      });
+    },
+  );
 
   it.each([
     { name: "malformed JWT", assertion: "not-a-jwt" },

--- a/src/gateway/github-user-identity.ts
+++ b/src/gateway/github-user-identity.ts
@@ -210,6 +210,8 @@ export function createAuthenticatedGitHubIdentitySync(params: {
   authResult: GatewayAuthResult;
   authConfig?: GatewayAuthConfig;
   requestHeaders?: IncomingHttpHeaders;
+  /** Reuse an exact verified Access account/email binding before refreshing GitHub metadata. */
+  preferCachedIdentity?: boolean;
 }): AuthenticatedGitHubIdentitySync | undefined {
   const tailscaleLogin = params.authResult.tailscaleIdentity
     ? classifyTailscaleLogin(params.authResult.tailscaleIdentity.login)
@@ -235,6 +237,15 @@ export function createAuthenticatedGitHubIdentitySync(params: {
       access.assertion,
       access.principal,
     );
+    if (params.preferCachedIdentity) {
+      const cached = resolveCachedGitHubIdentity({
+        accountId: accessIdentity.accountId,
+        email: access.principal,
+      });
+      if (cached) {
+        return cached;
+      }
+    }
     let response: Response | undefined;
     let payload: unknown;
     try {

--- a/src/gateway/http-auth-utils.ts
+++ b/src/gateway/http-auth-utils.ts
@@ -154,27 +154,35 @@ async function resolveAuthenticatedHttpUserProfile(params: {
   req: IncomingMessage;
 }): Promise<AuthenticatedHttpUserProfile> {
   const authenticatedUserId = normalizeOptionalString(params.authResult.user);
-  if (!params.cfg.gateway?.roles) {
-    return {};
-  }
+  const rolesConfigured = Boolean(params.cfg.gateway?.roles);
   if (!authenticatedUserId) {
-    if (usesSharedSecretGatewayMethod(params.authResult.method)) {
+    if (!rolesConfigured || usesSharedSecretGatewayMethod(params.authResult.method)) {
       return {};
     }
     throw new Error("operator role policies require a verified durable user profile");
   }
-  const syncGitHubIdentity = createAuthenticatedGitHubIdentitySync({
-    authResult: params.authResult,
-    authConfig: params.cfg.gateway.auth,
-    requestHeaders: params.req.headers,
-  });
-  const profile = syncGitHubIdentity
-    ? await syncGitHubIdentity()
-    : params.authResult.tailscaleIdentity
-      ? ensureProfileForTailscaleIdentity(params.authResult.tailscaleIdentity)
-      : ensureProfileForEmail(authenticatedUserId);
-  const profileId = "profileId" in profile ? profile.profileId : profile.id;
-  return resolveHttpProfile(profileId, profile.updatedAt, params.cfg);
+  try {
+    const syncGitHubIdentity = createAuthenticatedGitHubIdentitySync({
+      authResult: params.authResult,
+      authConfig: params.cfg.gateway?.auth,
+      requestHeaders: params.req.headers,
+      preferCachedIdentity: !rolesConfigured,
+    });
+    const profile = syncGitHubIdentity
+      ? await syncGitHubIdentity()
+      : params.authResult.tailscaleIdentity
+        ? ensureProfileForTailscaleIdentity(params.authResult.tailscaleIdentity)
+        : ensureProfileForEmail(authenticatedUserId);
+    const profileId = "profileId" in profile ? profile.profileId : profile.id;
+    return resolveHttpProfile(profileId, profile.updatedAt, params.cfg);
+  } catch (error) {
+    // Attribution enriches authenticated requests; only configured roles make
+    // durable profile resolution a prerequisite for authorization.
+    if (rolesConfigured) {
+      throw error;
+    }
+    return {};
+  }
 }
 
 function resolveHttpProfile(profileId: string, updatedAt: number, cfg: OpenClawConfig) {
@@ -596,10 +604,7 @@ async function checkGatewayHttpRequestAuthWith(
     browserOriginPolicy,
   });
   if (!authResult.ok) {
-    return {
-      ok: false,
-      authResult,
-    };
+    return { ok: false, authResult };
   }
   let authenticatedProfile;
   try {

--- a/src/gateway/http-utils.authorize-request.test.ts
+++ b/src/gateway/http-utils.authorize-request.test.ts
@@ -1,7 +1,7 @@
 // HTTP authorization utility tests protect gateway request authorization,
 // declared operator scopes, origin handling, and failure response routing.
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./auth.js", () => ({
   authorizeHttpGatewayConnect: vi.fn(),
@@ -40,6 +40,7 @@ const { getRuntimeConfig } = await import("../config/io.js");
 const { sendGatewayAuthFailure } = await import("./http-common.js");
 const profileStore = await import("../state/user-profiles.js");
 const operatorRoles = await import("./operator-role-policy.js");
+const githubIdentity = await import("./github-user-identity.js");
 const { authorizeGatewayHttpRequestOrReply } = await import("./http-utils.js");
 
 function createReq(headers: Record<string, string> = {}): IncomingMessage {
@@ -50,7 +51,24 @@ describe("authorizeGatewayHttpRequestOrReply", () => {
   beforeEach(() => {
     vi.mocked(authorizeHttpGatewayConnect).mockReset();
     vi.mocked(sendGatewayAuthFailure).mockReset();
+    vi.spyOn(profileStore, "ensureProfileForEmail").mockReturnValue({
+      id: "profile-guest",
+      displayName: "Guest",
+      avatarMime: null,
+      mergedInto: null,
+      createdAt: 1,
+      updatedAt: 2,
+    });
+    vi.spyOn(profileStore, "getUserProfileDisplay").mockReturnValue({
+      id: "profile-guest",
+      displayName: "Guest",
+      avatarRevision: "2",
+      hasAvatar: false,
+    });
+    vi.spyOn(githubIdentity, "createAuthenticatedGitHubIdentitySync").mockReturnValue(undefined);
   });
+
+  afterEach(() => vi.restoreAllMocks());
 
   it("marks token-authenticated requests as untrusted for declared HTTP scopes", async () => {
     vi.mocked(authorizeHttpGatewayConnect).mockResolvedValue({
@@ -89,108 +107,100 @@ describe("authorizeGatewayHttpRequestOrReply", () => {
         },
         trustedProxies: ["127.0.0.1"],
       }),
-    ).resolves.toEqual({
+    ).resolves.toMatchObject({
       authMethod: "trusted-proxy",
       user: "operator",
       trustDeclaredOperatorScopes: true,
     });
   });
 
-  it("binds trusted-proxy requests to their canonical profile and effective role", async () => {
-    const role = {
-      sessions: { others: "view" as const },
-      agents: ["guest"],
-      scopes: ["operator.read" as const],
-    };
-    vi.mocked(getRuntimeConfig).mockReturnValue({
-      gateway: {
-        roles: { default: "guest", definitions: { guest: role } },
-      },
-    });
-    const ensureProfile = vi.spyOn(profileStore, "ensureProfileForEmail").mockReturnValue({
-      id: "profile-guest",
-      displayName: "Guest",
-      avatarMime: null,
-      mergedInto: null,
-      createdAt: 1,
-      updatedAt: 2,
-    });
-    const profileDisplay = vi.spyOn(profileStore, "getUserProfileDisplay").mockReturnValue({
-      id: "profile-guest",
-      displayName: "Guest",
-      avatarRevision: "2",
-      hasAvatar: false,
-    });
-    const rolePolicy = vi
-      .spyOn(operatorRoles, "resolveOperatorRolePolicyForProfile")
-      .mockReturnValue(role);
-    vi.mocked(authorizeHttpGatewayConnect).mockResolvedValue({
-      ok: true,
-      method: "trusted-proxy",
-      user: "guest@example.test",
-    });
-
-    try {
-      await expect(
-        authorizeGatewayHttpRequestOrReply({
-          req: createReq(),
-          res: {} as ServerResponse,
-          auth: {
-            mode: "trusted-proxy",
-            allowTailscale: false,
-            trustedProxy: { userHeader: "x-user" },
-          },
-        }),
-      ).resolves.toMatchObject({
-        user: "guest@example.test",
-        authenticatedUserProfile: {
-          profileId: "profile-guest",
-          displayName: "Guest",
-          avatarRevision: "2",
-          hasAvatar: false,
-          updatedAt: 2,
-        },
-        operatorRolePolicy: role,
-      });
-      expect(ensureProfile).toHaveBeenCalledWith("guest@example.test");
-    } finally {
-      ensureProfile.mockRestore();
-      profileDisplay.mockRestore();
-      rolePolicy.mockRestore();
+  it.each([true, false])(
+    "binds trusted-proxy requests to their canonical profile with roles enabled: %s",
+    async (rolesConfigured) => {
+      const role = {
+        sessions: { others: "view" as const },
+        agents: ["guest"],
+        scopes: ["operator.read" as const],
+      };
       vi.mocked(getRuntimeConfig).mockReturnValue({
-        gateway: { controlUi: { allowedOrigins: ["https://control.example.com"] } },
+        gateway: rolesConfigured
+          ? { roles: { default: "guest", definitions: { guest: role } } }
+          : {},
       });
-    }
-  });
+      const ensureProfile = vi.mocked(profileStore.ensureProfileForEmail);
+      const rolePolicy = vi
+        .spyOn(operatorRoles, "resolveOperatorRolePolicyForProfile")
+        .mockReturnValue(rolesConfigured ? role : undefined);
+      vi.mocked(authorizeHttpGatewayConnect).mockResolvedValue({
+        ok: true,
+        method: "trusted-proxy",
+        user: "guest@example.test",
+      });
 
-  it("fails closed when a role-enabled trusted identity cannot resolve its profile", async () => {
-    vi.mocked(getRuntimeConfig).mockReturnValue({
-      gateway: {
-        roles: {
-          default: "guest",
-          definitions: {
-            guest: {
-              sessions: { others: "view" },
-              agents: ["guest"],
-              scopes: ["operator.read"],
+      try {
+        await expect(
+          authorizeGatewayHttpRequestOrReply({
+            req: createReq(),
+            res: {} as ServerResponse,
+            auth: {
+              mode: "trusted-proxy",
+              allowTailscale: false,
+              trustedProxy: { userHeader: "x-user" },
             },
+          }),
+        ).resolves.toEqual({
+          authMethod: "trusted-proxy",
+          user: "guest@example.test",
+          trustDeclaredOperatorScopes: true,
+          authenticatedUserProfile: {
+            profileId: "profile-guest",
+            displayName: "Guest",
+            avatarRevision: "2",
+            hasAvatar: false,
+            updatedAt: 2,
           },
-        },
-      },
-    });
-    const ensureProfile = vi.spyOn(profileStore, "ensureProfileForEmail").mockImplementation(() => {
-      throw new Error("profile store unavailable");
-    });
-    vi.mocked(authorizeHttpGatewayConnect).mockResolvedValue({
-      ok: true,
-      method: "trusted-proxy",
-      user: "guest@example.test",
-    });
-    const response = {} as ServerResponse;
+          ...(rolesConfigured ? { operatorRolePolicy: role } : {}),
+        });
+        expect(ensureProfile).toHaveBeenCalledWith("guest@example.test");
+      } finally {
+        rolePolicy.mockRestore();
+        vi.mocked(getRuntimeConfig).mockReturnValue({
+          gateway: { controlUi: { allowedOrigins: ["https://control.example.com"] } },
+        });
+      }
+    },
+  );
 
-    try {
-      await expect(
-        authorizeGatewayHttpRequestOrReply({
+  it.each([
+    { rolesConfigured: true, failure: "profile store" },
+    { rolesConfigured: false, failure: "profile store" },
+    { rolesConfigured: true, failure: "provider lookup" },
+    { rolesConfigured: false, failure: "provider lookup" },
+  ])(
+    "$failure failure preserves authorization with roles enabled: $rolesConfigured",
+    async ({ rolesConfigured, failure }) => {
+      vi.mocked(getRuntimeConfig).mockReturnValue(
+        rolesConfigured ? { gateway: { roles: { default: "guest", definitions: {} } } } : {},
+      );
+      const error = new Error("identity unavailable");
+      if (failure === "provider lookup") {
+        vi.mocked(githubIdentity.createAuthenticatedGitHubIdentitySync).mockReturnValue(
+          vi.fn().mockRejectedValue(error),
+        );
+      } else {
+        vi.mocked(profileStore.ensureProfileForEmail).mockImplementation(() => {
+          throw error;
+        });
+      }
+      vi.mocked(authorizeHttpGatewayConnect).mockResolvedValue({
+        ok: true,
+        method: "trusted-proxy",
+        user: "guest@example.test",
+      });
+      const response = {} as ServerResponse;
+
+      try {
+        const result = await authorizeGatewayHttpRequestOrReply({
           req: createReq(),
           res: response,
           auth: {
@@ -198,18 +208,67 @@ describe("authorizeGatewayHttpRequestOrReply", () => {
             allowTailscale: false,
             trustedProxy: { userHeader: "x-user" },
           },
-        }),
-      ).resolves.toBeNull();
-      expect(sendGatewayAuthFailure).toHaveBeenCalledWith(response, {
-        ok: false,
-        reason: "user_profile_unavailable",
-      });
-    } finally {
-      ensureProfile.mockRestore();
-      vi.mocked(getRuntimeConfig).mockReturnValue({
-        gateway: { controlUi: { allowedOrigins: ["https://control.example.com"] } },
-      });
-    }
+        });
+        if (rolesConfigured) {
+          expect(result).toBeNull();
+          expect(sendGatewayAuthFailure).toHaveBeenCalledWith(response, {
+            ok: false,
+            reason: "user_profile_unavailable",
+          });
+        } else {
+          expect(result).toEqual({
+            authMethod: "trusted-proxy",
+            user: "guest@example.test",
+            trustDeclaredOperatorScopes: true,
+          });
+          expect(sendGatewayAuthFailure).not.toHaveBeenCalled();
+        }
+      } finally {
+        vi.mocked(getRuntimeConfig).mockReturnValue({
+          gateway: { controlUi: { allowedOrigins: ["https://control.example.com"] } },
+        });
+      }
+    },
+  );
+
+  it("uses the verified GitHub profile before dispatching a request without roles", async () => {
+    const sync = vi.fn().mockResolvedValue({ profileId: "profile-github", updatedAt: 3 });
+    vi.mocked(githubIdentity.createAuthenticatedGitHubIdentitySync).mockReturnValue(sync);
+    vi.mocked(profileStore.getUserProfileDisplay).mockReturnValue({
+      id: "profile-github-canonical",
+      displayName: "GitHub User",
+      avatarRevision: "3",
+      hasAvatar: true,
+    });
+    vi.mocked(authorizeHttpGatewayConnect).mockResolvedValue({
+      ok: true,
+      method: "trusted-proxy",
+      user: "guest@example.test",
+    });
+
+    await expect(
+      authorizeGatewayHttpRequestOrReply({
+        req: createReq(),
+        res: {} as ServerResponse,
+        auth: {
+          mode: "trusted-proxy",
+          allowTailscale: false,
+          trustedProxy: { userHeader: "x-user" },
+        },
+      }),
+    ).resolves.toEqual({
+      authMethod: "trusted-proxy",
+      user: "guest@example.test",
+      trustDeclaredOperatorScopes: true,
+      authenticatedUserProfile: {
+        profileId: "profile-github-canonical",
+        displayName: "GitHub User",
+        avatarRevision: "3",
+        hasAvatar: true,
+        updatedAt: 3,
+      },
+    });
+    expect(profileStore.ensureProfileForEmail).not.toHaveBeenCalled();
   });
 
   it("rejects unbound device tokens when operator roles require durable identity", async () => {

--- a/src/gateway/server-methods/session-catalog-entry-snapshot.test.ts
+++ b/src/gateway/server-methods/session-catalog-entry-snapshot.test.ts
@@ -86,6 +86,60 @@ describe("session catalog entry snapshots", () => {
     hoisted.listSessionEntriesReadOnly.mockReset();
   });
 
+  it("resolves catalog senders against current profiles without attributing unknown turns", async () => {
+    vi.spyOn(userProfiles, "hasMultipleSessionSharingIdentities").mockReturnValue(false);
+    vi.spyOn(userProfiles, "getUserProfileDisplay").mockImplementation((id) => {
+      if (id !== "merged-profile") {
+        throw new Error("unknown profile");
+      }
+      return { id: "current-profile", displayName: "Taylor", avatarRevision: "2", hasAvatar: true };
+    });
+    const items = [
+      { type: "userMessage" as const, text: "Unknown author" },
+      {
+        type: "userMessage" as const,
+        text: "Known author",
+        sender: { identity: { type: "profile" as const, id: "merged-profile" }, label: "Stale" },
+      },
+      {
+        type: "userMessage" as const,
+        text: "Deleted author",
+        sender: { identity: { type: "profile" as const, id: "deleted-profile" } },
+      },
+    ];
+    const catalog = provider("external", "unused");
+    catalog.read = async ({ hostId, threadId }) => ({
+      hostId,
+      threadId,
+      items,
+      nextCursor: "older",
+    });
+    hoisted.activeRegistry.sessionCatalogs = [{ provider: catalog }];
+    const respond = vi.fn();
+    await sessionCatalogHandlers["sessions.catalog.read"]?.({
+      params: { catalogId: "external", hostId: "gateway", threadId: "shared" },
+      respond,
+      context: { getRuntimeConfig: () => ({}) },
+    } as never);
+    expect(respond).toHaveBeenCalledWith(true, {
+      hostId: "gateway",
+      threadId: "shared",
+      nextCursor: "older",
+      items: [
+        items[0],
+        {
+          ...items[1],
+          sender: {
+            identity: { type: "profile", id: "current-profile" },
+            label: "Taylor",
+            avatarUrl: "/api/users/current-profile/avatar?v=2",
+          },
+        },
+        items[2],
+      ],
+    });
+  });
+
   it.each([
     [" BLUE ", "blue"],
     ["default", undefined],

--- a/src/gateway/server-methods/session-catalog.ts
+++ b/src/gateway/server-methods/session-catalog.ts
@@ -26,6 +26,8 @@ import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { recordSessionStateEvent } from "../../sessions/session-state-events.js";
 import { upsertSessionUpstreamLink } from "../../sessions/session-upstream-links.js";
 import { authorizeGatewaySessionCreation } from "../operator-role-policy.js";
+import { projectSessionParticipant } from "../session-identity-projection.js";
+import type { SessionActorProfileIdentity } from "../session-utils-contracts.js";
 import { resolveAgentIdOrRespondError } from "./agent-id-shared.js";
 import { authorizeSessionCatalogThread } from "./session-catalog-authorization.js";
 import {
@@ -535,14 +537,22 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
         return;
       }
       const { catalogId: _catalogId, ...providerRequest } = request;
-      respond(
-        true,
-        await provider.read({
-          ...providerRequest,
-          agentId: authorization.agentId,
-          allowProcessHomeFallback: authorization.allowProcessHomeFallback,
-        }),
-      );
+      const page = await provider.read({
+        ...providerRequest,
+        agentId: authorization.agentId,
+        allowProcessHomeFallback: authorization.allowProcessHomeFallback,
+      });
+      const profiles = new Map<string, SessionActorProfileIdentity | undefined>();
+      respond(true, {
+        ...page,
+        items: page.items.map((item) =>
+          item.sender?.identity.type === "profile"
+            ? Object.assign({}, item, {
+                sender: projectSessionParticipant(item.sender.identity, profiles),
+              })
+            : item,
+        ),
+      });
     } catch (error) {
       const details = catalogError(error);
       respond(

--- a/src/gateway/session-identity-projection.ts
+++ b/src/gateway/session-identity-projection.ts
@@ -23,7 +23,7 @@ import { normalizeControlUiBasePath } from "./control-ui-shared.js";
 import { resolveCurrentUserProfileDisplay } from "./current-user-profile-display.js";
 import type { SessionActorProfileIdentity } from "./session-utils-contracts.js";
 
-function projectParticipant(
+export function projectSessionParticipant(
   identity: SessionParticipantIdentity,
   profiles: Map<string, SessionActorProfileIdentity | undefined>,
   cfg?: OpenClawConfig,
@@ -81,7 +81,7 @@ export function projectSessionActor(
         ? { type: "profile", id }
         : { type: "legacy", actorType: actor.type, source: null, id };
   // Keep original attribution in the display; authority reads the qualified canonical actor.
-  return { type: actor.type, id, ...projectParticipant(identity, profiles, cfg) };
+  return { type: actor.type, id, ...projectSessionParticipant(identity, profiles, cfg) };
 }
 
 /** Projects an identity only when it can own a session durably. */
@@ -147,7 +147,7 @@ export function projectSessionParticipants(
   const identities = userProfileIdentityById ?? new Map();
   const participants = new Map<string, SessionParticipant>();
   for (const { identity } of entry?.participants ?? []) {
-    const participant = projectParticipant(identity, identities, cfg);
+    const participant = projectSessionParticipant(identity, identities, cfg);
     participants.set(JSON.stringify(participant.identity), participant);
   }
   return participants;

--- a/test/plugins/beam-http-identity.test.ts
+++ b/test/plugins/beam-http-identity.test.ts
@@ -1,0 +1,192 @@
+import { once } from "node:events";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import beamPlugin from "../../extensions/beam/index.js";
+import type { OpenClawConfig } from "../../src/config/types.openclaw.js";
+import type { ResolvedGatewayAuth } from "../../src/gateway/auth.js";
+import { createTestGatewayServer } from "../../src/gateway/server-http.test-harness.js";
+import {
+  createGatewayPluginRequestHandler,
+  shouldEnforceGatewayAuthForPluginPath,
+} from "../../src/gateway/server/plugins-http.js";
+import { withTempConfig } from "../../src/gateway/test-temp-config.js";
+import { createSubsystemLogger } from "../../src/logging/subsystem.js";
+import { closePluginStateDatabase } from "../../src/plugin-state/plugin-state-store.js";
+import { createPluginRecord } from "../../src/plugins/loader-records.js";
+import { createPluginRegistry } from "../../src/plugins/registry.js";
+import {
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../../src/plugins/runtime.js";
+import { createPluginRuntime } from "../../src/plugins/runtime/index.js";
+import { listProfiles } from "../../src/state/user-profiles.js";
+import { withOpenClawTestState } from "../../src/test-utils/openclaw-test-state.js";
+
+const routePath = "/api/v1/beam/sessions";
+const log = createSubsystemLogger("test/beam-http-identity");
+const proxyAuth: ResolvedGatewayAuth = {
+  mode: "trusted-proxy",
+  allowTailscale: false,
+  trustedProxy: { userHeader: "x-forwarded-user", allowLoopback: true },
+};
+const tokenAuth: ResolvedGatewayAuth = {
+  mode: "token",
+  allowTailscale: false,
+  token: "synthetic-beam-operator-token",
+};
+
+function registerBeam(config: OpenClawConfig) {
+  const builder = createPluginRegistry({
+    runtime: createPluginRuntime(),
+    logger: log,
+    activateGlobalSideEffects: false,
+  });
+  const record = createPluginRecord({
+    id: "beam",
+    source: fileURLToPath(new URL("../../extensions/beam/index.ts", import.meta.url)),
+    origin: "bundled",
+    enabled: true,
+    configSchema: true,
+  });
+  builder.registry.plugins.push(record);
+  beamPlugin.register(builder.createApi(record, { config }));
+  setActivePluginRegistry(builder.registry);
+  const catalog = builder.registry.sessionCatalogs.find((entry) => entry.provider.id === "beam");
+  if (!catalog) {
+    throw new Error("Beam did not register its session catalog");
+  }
+  return { registry: builder.registry, catalog: catalog.provider };
+}
+
+async function withBeamHttpServer(
+  auth: ResolvedGatewayAuth,
+  run: (origin: string, registration: ReturnType<typeof registerBeam>) => Promise<void>,
+) {
+  const cfg: OpenClawConfig = {
+    agents: { entries: { main: { default: true } } },
+    gateway: { auth, trustedProxies: ["127.0.0.1", "::1"] },
+    plugins: { entries: { beam: { enabled: true } } },
+  };
+  await withTempConfig({
+    cfg,
+    run: async () => {
+      const registration = registerBeam(cfg);
+      const { registry } = registration;
+      const server = createTestGatewayServer({
+        resolvedAuth: auth,
+        overrides: {
+          handlePluginRequest: createGatewayPluginRequestHandler({ registry, log }),
+          shouldEnforcePluginGatewayAuth: (pathContext) =>
+            shouldEnforceGatewayAuthForPluginPath(registry, pathContext),
+        },
+      });
+      const listening = once(server, "listening");
+      server.listen(0, "127.0.0.1");
+      await listening;
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Beam test server did not bind a TCP port");
+      }
+      try {
+        await run(`http://127.0.0.1:${address.port}`, registration);
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+          server.closeAllConnections();
+        });
+        resetPluginRuntimeStateForTest();
+        closePluginStateDatabase();
+      }
+    },
+  });
+}
+
+function snapshot(beamId: string, text: string) {
+  return {
+    version: 1,
+    beamId,
+    source: "fixture",
+    title: "Synthetic uploader identity proof",
+    updatedAt: new Date().toISOString(),
+    completed: true,
+    items: [
+      { type: "userMessage", text },
+      { type: "agentMessage", text: "Synthetic reply" },
+    ],
+  };
+}
+
+async function upload(
+  origin: string,
+  beamId: string,
+  text: string,
+  headers: Record<string, string>,
+) {
+  const response = await fetch(`${origin}${routePath}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(snapshot(beamId, text)),
+    signal: AbortSignal.timeout(10_000),
+  });
+  const body: unknown = await response.json();
+  expect(response.status, JSON.stringify(body)).toBe(200);
+  expect(body).toMatchObject({ ok: true, beamId });
+}
+
+describe("Beam authenticated uploader identity", () => {
+  it("persists real HTTP principals through registry scope and clears them on shared-token replacement", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const firstBeamId = "a".repeat(32);
+      const secondBeamId = "b".repeat(32);
+      const principals = ["alice@example.test", "bob@example.test"];
+      const profileIds: string[] = [];
+
+      await withBeamHttpServer(proxyAuth, async (origin, { catalog }) => {
+        expect(listProfiles()).toEqual([]);
+        for (const [index, principal] of principals.entries()) {
+          const beamId = index === 0 ? firstBeamId : secondBeamId;
+          await upload(origin, beamId, `Question from ${principal}`, {
+            "x-forwarded-user": principal,
+            "x-forwarded-for": "198.51.100.20",
+          });
+          const profile = listProfiles().find((candidate) => candidate.emails.includes(principal));
+          expect(profile).toBeDefined();
+          profileIds.push(profile!.id);
+          const page = await catalog.read({ agentId: "main", hostId: "gateway", threadId: beamId });
+          expect(page.items.find((item) => item.type === "userMessage")?.sender).toEqual({
+            identity: { type: "profile", id: profile!.id },
+          });
+          expect(page.items.find((item) => item.type === "agentMessage")?.sender).toBeUndefined();
+        }
+        expect(new Set(profileIds).size).toBe(2);
+      });
+
+      // Re-register after closing SQLite: the uploader must come from the saved
+      // snapshot, never a retained request or the reader's current identity.
+      await withBeamHttpServer(tokenAuth, async (origin, { catalog }) => {
+        const read = (threadId: string) =>
+          catalog.read({ agentId: "main", hostId: "gateway", threadId });
+        for (const [index, beamId] of [firstBeamId, secondBeamId].entries()) {
+          const page = await read(beamId);
+          expect(page.items.find((item) => item.type === "userMessage")?.sender).toEqual({
+            identity: { type: "profile", id: profileIds[index] },
+          });
+        }
+        await upload(origin, firstBeamId, "Shared-token replacement", {
+          authorization: `Bearer ${tokenAuth.token}`,
+          "x-forwarded-user": principals[0]!,
+          "x-forwarded-for": "198.51.100.20",
+        });
+        const replaced = await read(firstBeamId);
+        expect(replaced.items.find((item) => item.type === "userMessage")).toMatchObject({
+          text: "Shared-token replacement",
+        });
+        expect(replaced.items.every((item) => item.sender === undefined)).toBe(true);
+        expect(
+          (await read(secondBeamId)).items.find((item) => item.type === "userMessage")?.sender,
+        ).toEqual({ identity: { type: "profile", id: profileIds[1] } });
+        expect(listProfiles()).toHaveLength(2);
+      });
+    });
+  });
+});

--- a/ui/src/e2e/external-session-catalogs.e2e.test.ts
+++ b/ui/src/e2e/external-session-catalogs.e2e.test.ts
@@ -23,6 +23,117 @@ const SHARE_ROUTE = {
 } as const;
 
 suite.define(() => {
+  it.each(["Riley", "Morgan"])(
+    "keeps external transcript authors independent of viewer %s",
+    async (viewer) => {
+      await suite.withPage({ viewport: { width: 1440, height: 900 } }, async ({ page }) => {
+        const catalogIds = ["beam", "claude", "codex"];
+        await page.route("**/api/users/uploader-profile/avatar*", (route) =>
+          route.fulfill({
+            contentType: "image/svg+xml",
+            body: '<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40"><rect width="40" height="40" fill="#43786a"/><text x="20" y="28" text-anchor="middle" fill="white" font-size="24">T</text></svg>',
+          }),
+        );
+        await installMockGateway(page, {
+          presenceUsers: [
+            {
+              self: true,
+              id: "viewer-profile",
+              identity: { type: "profile", id: "viewer-profile" },
+              name: viewer,
+              avatarUrl: "/viewer-avatar.png",
+            },
+          ],
+          featureMethods: [
+            "chat.metadata",
+            "chat.startup",
+            "sessions.catalog.list",
+            "sessions.catalog.read",
+          ],
+          methodResponses: {
+            "sessions.catalog.list": {
+              catalogs: catalogIds.map((id) => ({
+                id,
+                label: id,
+                capabilities: { continueSession: false, archive: false },
+                hosts: [
+                  {
+                    hostId: "gateway",
+                    label: "Shared transcripts",
+                    kind: "gateway",
+                    connected: true,
+                    sessions: [
+                      {
+                        threadId: "shared",
+                        name: `${id} shared transcript`,
+                        status: "stored",
+                        canContinue: false,
+                        canArchive: false,
+                      },
+                    ],
+                  },
+                ],
+              })),
+            },
+            "sessions.catalog.read": {
+              hostId: "gateway",
+              threadId: "shared",
+              items: [
+                {
+                  id: "known-question",
+                  type: "userMessage",
+                  text: "The uploader's question.",
+                  sender: {
+                    identity: { type: "profile", id: "uploader-profile" },
+                    label: "Taylor",
+                    avatarUrl: "/api/users/uploader-profile/avatar?v=2",
+                  },
+                },
+                { id: "answer", type: "agentMessage", text: "The imported answer." },
+                { id: "question", type: "userMessage", text: "The imported author's question." },
+              ],
+            },
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}chat`);
+        for (const catalogId of catalogIds) {
+          await page.getByText(`${catalogId} shared transcript`, { exact: true }).click();
+          const pane = page.locator("openclaw-chat-pane.chat-pane-cache__pane--visible");
+          const message = pane
+            .locator(".chat-group.user")
+            .filter({ hasText: "The imported author's question." });
+          await message.waitFor();
+          const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+          if (artifactDir && catalogId === "beam") {
+            await fs.mkdir(artifactDir, { recursive: true });
+            await page.screenshot({ path: path.join(artifactDir, `beam-author-${viewer}.png`) });
+          }
+          expect(await message.locator(".chat-sender-name").textContent()).toBe("User");
+          expect(
+            await message
+              .locator(`[aria-label="${viewer}"], img[alt="${viewer}"], img[src*="viewer-avatar"]`)
+              .count(),
+          ).toBe(0);
+          expect(await message.locator('a[href*="activity"]').count()).toBe(0);
+          const known = pane
+            .locator(".chat-group.user")
+            .filter({ hasText: "The uploader's question." });
+          expect(await known.locator(".chat-sender-name").textContent()).toBe("Taylor");
+          await expect
+            .poll(() =>
+              known
+                .locator('img.chat-avatar[alt="Taylor"]')
+                .evaluateAll((images) =>
+                  images.some((image) => (image as HTMLImageElement).naturalWidth > 0),
+                ),
+            )
+            .toBe(true);
+          expect(await known.locator('a[href*="uploader-profile"]').count()).toBeGreaterThan(0);
+        }
+      });
+    },
+  );
+
   it.each(["sidebar", "cold link"])(
     "preserves catalog pane ownership from %s through retention, split focus, reconnect and adoption",
     async (entrance) => {

--- a/ui/src/pages/chat/chat-pane-session.ts
+++ b/ui/src/pages/chat/chat-pane-session.ts
@@ -6,6 +6,7 @@ import type {
 import type { ControlUiSessionPullRequest } from "../../../../src/gateway/control-ui-contract.js";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { selectApplicationSession } from "../../app/agent-selection.ts";
+import { t } from "../../i18n/index.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { clampText } from "../../lib/format.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
@@ -392,6 +393,18 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
       return text
         ? {
             role: "user",
+            // Missing source attribution must never fall back to the current viewer.
+            senderLabel: item.sender?.label ?? t("sessionsView.user"),
+            ...(item.sender
+              ? {
+                  __openclaw: {
+                    senderIdentity: item.sender.identity,
+                    senderId: item.sender.identity.id,
+                    senderName: item.sender.label,
+                    senderProfileAvatarUrl: item.sender.avatarUrl,
+                  },
+                }
+              : {}),
             content: text,
             ...(timestamp == null ? {} : { timestamp }),
             messageId: item.id,


### PR DESCRIPTION
## What Problem This Solves

Opening a shared Beam transcript showed the current viewer as the author of its imported user messages. Beam discarded the authenticated uploader, and the catalog-to-chat conversion discarded sender metadata before the renderer selected its default viewer identity.

## Why This Change Was Made

Record the authenticated uploader's canonical profile reference when receiving each snapshot, then carry it through the existing session participant contract. Gateway catalog reads resolve current profile names, avatars, and merged identities; the UI preserves that sender and labels missing attribution as **User**. This also fixes viewer attribution for other external catalogs that lack a sender.

HTTP requests now resolve known profiles even when no operator role policies are configured. Cloudflare Access still verifies the current principal and immutable GitHub account before reusing an existing exact account/email binding. Role-enabled and WebSocket refresh behavior stays unchanged. Shared tokens cannot identify a person, body-supplied identity is rejected, and an anonymous replacement clears the previous publisher.

The profile reference shares the snapshot's existing seven-day retention. No SQLite schema, configuration, dependency, or ordering changes. Production delta: +51 lines, generated Swift: +3, tests: +532. The production growth carries the previously missing identity across the existing ingress, storage, catalog, and rendering owners; it introduces no parallel identity store.

## User Impact

Personally authenticated uploads display the publisher's existing profile consistently for every viewer. This identifies the current snapshot publisher; the upload format does not contain per-message authors for multi-author conversations. Existing anonymous snapshots need a personally authenticated reupload because historical authors cannot be recovered safely.

## Evidence

- Captured failing regressions before the fix for lost uploader identity, catalog profile projection, and viewer-based rendering.
- Real loopback HTTP through public Beam registration, Gateway auth, and plugin request scope, with SQLite close/reopen: two synthetic publishers remain distinct; anonymous shared-token replacement and spoofed headers cannot retain or claim another publisher.
- Real Cloudflare Access and GitHub identity lookups using an existing personal login and isolated temporary state: two Access verifications, one GitHub lookup, and the same canonical profile reused. No live Gateway writes or deployment changes. An initial live probe failed; the instrumented rerun passed without production changes.
- Focused receiver, auth, profile merge/deletion, catalog pagination, and browser regressions passed. Browser coverage includes Beam, Claude, and Codex catalogs viewed by two users, known sender avatar/profile links, and existing native identity behavior.
- Core, all 16 core-test projects, UI, plugin, plugin-test, and root-test typechecks passed. Protocol generation, protocol-since guard, and native Swift protocol typecheck passed.
- Changed-file validation passed guards, formatting, i18n, and typechecks, then exposed four lint issues. These were fixed; focused lint, the affected 30-test rerun, and remaining guards passed. The full wrapper was not rerun after those mechanical fixes. Whole-file SwiftLint reports pre-existing generator-style violations; the generated model was validated by regeneration and Swift typecheck.
- Refreshed onto main after #133382 (ordering) and #125755 (readable share URLs). Updated the new receiver test to the current base-path callback. Combined-code verification: real HTTP/SQLite integration, 13 catalog projection tests, and all 11 Beam receiver/catalog tests passed.
- Fresh Codex autoreview after that integration: scoped-clean at the configured P0 threshold. Hosted CI will validate the updated PR head before landing.
- Direct upstream Codex contract inspected: `codex-rs/app-server-protocol/src/protocol/v2/item.rs:236-240`; user messages contain an id, client id, and content, without a human author. No identity is inferred from client ids.

Provenance: confirmed on the pre-fix checkout and current main; original introducing commit is unverified.

Follow-up: limited-scope HTTP session sharing now receives a known profile and therefore uses existing creator/member checks. Default administrators are unaffected. The existing anonymous solo-owner behavior on failed optional identity enrichment deserves separate authorization-owner review; this change does not weaken those checks. Non-GitHub Cloudflare IdPs remain outside the existing GitHub identity resolver.

Synthetic browser proof (Riley is the viewer; Taylor is the known publisher):

Before:

![Before: imported message incorrectly attributed to the viewer Riley](https://github.com/user-attachments/assets/3aa43b69-67cd-4c4e-938e-76b329e45e74)

After:

![After: unknown author is User and known publisher is Taylor, independent of viewer Riley](https://github.com/user-attachments/assets/1e99f8a1-2577-4ec7-936c-bdb1fb7e7b2b)
