### PR TITLE
fix(ci): keep full release evidence out of argv

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -1857,104 +1857,11 @@ jobs:
           set -euo pipefail
           manifest_dir="${RUNNER_TEMP}/full-release-validation"
           mkdir -p "$manifest_dir"
-          TARGET_SHA="$(jq -r '.targetSha' "$RELEASE_EXECUTION_PLAN_PATH")"
-          NORMAL_CI_RUN_ID="$(jq -r '.children[] | select(.key == "normalCi") | .runId' "$RELEASE_EXECUTION_PLAN_PATH")"
-          PLUGIN_PRERELEASE_INDEPENDENT_RUN_ID="$(jq -r '.children[] | select(.key == "pluginPrereleaseIndependent") | .runId' "$RELEASE_EXECUTION_PLAN_PATH")"
-          PLUGIN_PRERELEASE_CANDIDATE_RUN_ID="$(jq -r '.children[] | select(.key == "pluginPrereleaseCandidate") | .runId' "$RELEASE_EXECUTION_PLAN_PATH")"
-          RELEASE_CHECKS_INDEPENDENT_RUN_ID="$(jq -r '.children[] | select(.key == "releaseChecksIndependent") | .runId' "$RELEASE_EXECUTION_PLAN_PATH")"
-          RELEASE_CHECKS_CANDIDATE_RUN_ID="$(jq -r '.children[] | select(.key == "releaseChecksCandidate") | .runId' "$RELEASE_EXECUTION_PLAN_PATH")"
-          NPM_TELEGRAM_RUN_ID="$(jq -r '.children[] | select(.key == "npmTelegram") | .runId' "$RELEASE_EXECUTION_PLAN_PATH")"
-          PERFORMANCE_RUN_ID="$(jq -r '.children[] | select(.key == "productPerformance") | .runId' "$RELEASE_EXECUTION_PLAN_PATH")"
-          EXECUTION_PLAN_SHA256="$(jq -r '.sha256' "$RELEASE_EXECUTION_PLAN_PATH")"
-          SOURCE_PARENT_RUN_ATTEMPT="$(jq -r '.parentRunAttempt' "$RELEASE_EXECUTION_PLAN_PATH")"
-          CANDIDATE_BINDING="$(jq -c '.candidate' "$RELEASE_EXECUTION_PLAN_PATH")"
-          EVIDENCE_REUSE="$(jq -r '.evidenceReuse.requested' "$RELEASE_EXECUTION_PLAN_PATH")"
-          EVIDENCE_RUN_ID="$(jq -r '.evidenceReuse.selectedRunId // ""' "$RELEASE_EXECUTION_PLAN_PATH")"
-          EVIDENCE_ROOT_RUN_ID="$(jq -r '.evidenceReuse.rootRunId // ""' "$RELEASE_EXECUTION_PLAN_PATH")"
-          EVIDENCE_SHA="$(jq -r '.evidenceReuse.evidenceSha // ""' "$RELEASE_EXECUTION_PLAN_PATH")"
-          EVIDENCE_POLICY="$(jq -r '.evidenceReuse.policy // ""' "$RELEASE_EXECUTION_PLAN_PATH")"
-          EVIDENCE_CHANGED_PATHS="$(jq -c '.evidenceReuse.changedPaths // []' "$RELEASE_EXECUTION_PLAN_PATH")"
-          EVIDENCE_MANIFEST="$(jq -c '.evidenceReuse.sourceManifest // empty' "$RELEASE_EXECUTION_PLAN_PATH")"
-          PERFORMANCE_CONCLUSION="$(jq -r '.children.productPerformance.conclusion // ""' "$DIAGNOSTIC_DRAIN_PATH")"
-          CHILD_EVIDENCE="$(
-            jq -c '
-              .children
-              | with_entries(
-                  .value = {
-                    runId: .value.runId,
-                    plannedRunAttempt: .value.plannedRunAttempt,
-                    effectiveRunAttempt: .value.runAttempt,
-                    observedRunAttempts: .value.observedRunAttempts,
-                    compositeJobsSha256: .value.compositeJobsSha256,
-                    dispatchActor: .value.dispatchActor,
-                    triggeringActor: .value.triggeringActor,
-                    repository: .value.repository,
-                    jobs: (
-                      .value.timing.jobs
-                      | map({
-                          name,
-                          status,
-                          conclusion,
-                          acceptedRunAttempt,
-                          startedAt,
-                          completedAt,
-                          url
-                        })
-                    )
-                  }
-                )
-            ' "$DIAGNOSTIC_DRAIN_PATH"
-          )"
-          if [[ "$EVIDENCE_REUSE" == "true" ]]; then
-            # Inherit the evidence manifest (profile, soak, child runs) so future
-            # reuse lookups and evidence consumers keep resolving the chain root.
-            jq -c \
-              --arg runId "$GITHUB_RUN_ID" \
-              --arg runAttempt "$GITHUB_RUN_ATTEMPT" \
-              --arg workflowRef "$GITHUB_REF_NAME" \
-              --arg workflowSha "$GITHUB_SHA" \
-              --arg workflowFullRef "$GITHUB_REF" \
-              --arg workflowRefType "$GITHUB_REF_TYPE" \
-              --arg targetRef "$TARGET_REF" \
-              --arg targetSha "$TARGET_SHA" \
-              --arg evidenceRunId "$EVIDENCE_RUN_ID" \
-              --arg evidenceRootRunId "$EVIDENCE_ROOT_RUN_ID" \
-              --arg evidenceSha "$EVIDENCE_SHA" \
-              --arg evidencePolicy "$EVIDENCE_POLICY" \
-              --arg executionPlanSha256 "$EXECUTION_PLAN_SHA256" \
-              --arg sourceParentRunAttempt "$SOURCE_PARENT_RUN_ATTEMPT" \
-              --argjson candidateBinding "$CANDIDATE_BINDING" \
-              --argjson evidenceChangedPaths "$EVIDENCE_CHANGED_PATHS" \
-              --argjson childEvidence "$CHILD_EVIDENCE" \
-              '. + {
-                version: 4,
-                runId: $runId,
-                runAttempt: $runAttempt,
-                workflowRef: $workflowRef,
-                workflowSha: $workflowSha,
-                workflowFullRef: $workflowFullRef,
-                workflowRefType: $workflowRefType,
-                targetRef: $targetRef,
-                targetSha: $targetSha,
-                evidenceReuse: {
-                  policy: $evidencePolicy,
-                  runId: $evidenceRootRunId,
-                  selectedRunId: $evidenceRunId,
-                  evidenceSha: $evidenceSha,
-                  changedPaths: $evidenceChangedPaths
-                },
-                controls: ((.controls // {}) + {
-                  performanceReportPublication: "artifact-only"
-                }),
-                candidateBinding: $candidateBinding,
-                childEvidence: $childEvidence,
-                executionPlanSha256: $executionPlanSha256,
-                sourceParentRunAttempt: ($sourceParentRunAttempt | tonumber)
-              }' <<< "$EVIDENCE_MANIFEST" > "${manifest_dir}/full-release-validation-manifest.json"
-            exit 0
-          fi
+          # Full-matrix evidence exceeds Linux's per-argument limit. Keep the
+          # sealed plan and complete job inventory in files through serialization.
           jq -cn \
-            --arg workflowName "Full Release Validation" \
+            --slurpfile plan "$RELEASE_EXECUTION_PLAN_PATH" \
+            --slurpfile drain "$DIAGNOSTIC_DRAIN_PATH" \
             --arg runId "$GITHUB_RUN_ID" \
             --arg runAttempt "$GITHUB_RUN_ATTEMPT" \
             --arg workflowRef "$GITHUB_REF_NAME" \
@@ -1962,21 +1869,9 @@ jobs:
             --arg workflowFullRef "$GITHUB_REF" \
             --arg workflowRefType "$GITHUB_REF_TYPE" \
             --arg targetRef "$TARGET_REF" \
-            --arg targetSha "$TARGET_SHA" \
             --arg releaseProfile "$RELEASE_PROFILE" \
             --arg rerunGroup "$RERUN_GROUP" \
             --arg runReleaseSoak "$RUN_RELEASE_SOAK" \
-            --arg normalCiRunId "$NORMAL_CI_RUN_ID" \
-            --arg pluginPrereleaseIndependentRunId "$PLUGIN_PRERELEASE_INDEPENDENT_RUN_ID" \
-            --arg pluginPrereleaseCandidateRunId "$PLUGIN_PRERELEASE_CANDIDATE_RUN_ID" \
-            --arg releaseChecksIndependentRunId "$RELEASE_CHECKS_INDEPENDENT_RUN_ID" \
-            --arg releaseChecksCandidateRunId "$RELEASE_CHECKS_CANDIDATE_RUN_ID" \
-            --arg npmTelegramRunId "$NPM_TELEGRAM_RUN_ID" \
-            --arg performanceRunId "$PERFORMANCE_RUN_ID" \
-            --arg performanceConclusion "$PERFORMANCE_CONCLUSION" \
-            --arg executionPlanSha256 "$EXECUTION_PLAN_SHA256" \
-            --arg sourceParentRunAttempt "$SOURCE_PARENT_RUN_ATTEMPT" \
-            --argjson candidateBinding "$CANDIDATE_BINDING" \
             --arg provider "$PROVIDER" \
             --arg mode "$MODE" \
             --arg targetContextRef "$TARGET_CONTEXT_REF" \
@@ -1993,60 +1888,93 @@ jobs:
             --arg targetVersion "$TARGET_VERSION" \
             --arg allowUnreleasedChangelog "$ALLOW_UNRELEASED_CHANGELOG" \
             --arg pluginPrereleaseNodeExcludePatternsJson "$PLUGIN_PRERELEASE_NODE_EXCLUDE_PATTERNS_JSON" \
-            --argjson childEvidence "$CHILD_EVIDENCE" \
-            '{
-              version: 4,
-              workflowName: $workflowName,
-              runId: $runId,
-              runAttempt: $runAttempt,
-              workflowRef: $workflowRef,
-              workflowSha: $workflowSha,
-              workflowFullRef: $workflowFullRef,
-              workflowRefType: $workflowRefType,
-              targetRef: $targetRef,
-              targetSha: $targetSha,
-              releaseProfile: $releaseProfile,
-              rerunGroup: $rerunGroup,
-              runReleaseSoak: $runReleaseSoak,
-              executionPlanSha256: $executionPlanSha256,
-              sourceParentRunAttempt: ($sourceParentRunAttempt | tonumber),
-              candidateBinding: $candidateBinding,
-              childEvidence: $childEvidence,
-              validationInputs: ({
-                provider: $provider,
-                mode: $mode,
-                targetContextRef: $targetContextRef,
-                liveSuiteFilter: $liveSuiteFilter,
-                crossOsSuiteFilter: $crossOsSuiteFilter,
-                releasePackageSpec: $releasePackageSpec,
-                packageAcceptancePackageSpec: $packageAcceptancePackageSpec,
-                codexPluginSpec: $codexPluginSpec,
-                npmTelegramPackageSpec: $npmTelegramPackageSpec,
-                npmTelegramProviderMode: $npmTelegramProviderMode,
-                npmTelegramScenario: $npmTelegramScenario,
-                skipPackageTelegramE2e: $skipPackageTelegramE2e,
-                allowUnreleasedChangelog: $allowUnreleasedChangelog,
-                pluginPrereleaseNodeExcludePatternsJson: $pluginPrereleaseNodeExcludePatternsJson
-              } + (if $telegramWaiver == "" then {} else {telegramWaiver: $telegramWaiver, targetVersion: $targetVersion} end)),
-              controls: {
-                stableSoakRequired: ($releaseProfile == "stable" or $releaseProfile == "full"),
-                performanceBlocking: ($releaseProfile != "beta"),
-                performanceReportPublication: "artifact-only"
-              },
-              childRuns: {
-                normalCi: $normalCiRunId,
-                pluginPrereleaseIndependent: $pluginPrereleaseIndependentRunId,
-                pluginPrereleaseCandidate: $pluginPrereleaseCandidateRunId,
-                releaseChecksIndependent: $releaseChecksIndependentRunId,
-                releaseChecksCandidate: $releaseChecksCandidateRunId,
-                npmTelegram: $npmTelegramRunId,
-                productPerformance: {
-                  runId: $performanceRunId,
-                  conclusion: $performanceConclusion,
-                  blocking: ($releaseProfile != "beta")
+            '$plan[0] as $plan
+            | $drain[0] as $drain
+            | ($drain.children | with_entries(.value = {
+                runId: .value.runId,
+                plannedRunAttempt: .value.plannedRunAttempt,
+                effectiveRunAttempt: .value.runAttempt,
+                observedRunAttempts: .value.observedRunAttempts,
+                compositeJobsSha256: .value.compositeJobsSha256,
+                dispatchActor: .value.dispatchActor,
+                triggeringActor: .value.triggeringActor,
+                repository: .value.repository,
+                jobs: (.value.timing.jobs | map({
+                  name, status, conclusion, acceptedRunAttempt, startedAt, completedAt, url
+                }))
+              })) as $childEvidence
+            | {
+                version: 4,
+                runId: $runId,
+                runAttempt: $runAttempt,
+                workflowRef: $workflowRef,
+                workflowSha: $workflowSha,
+                workflowFullRef: $workflowFullRef,
+                workflowRefType: $workflowRefType,
+                targetRef: $targetRef,
+                targetSha: $plan.targetSha,
+                candidateBinding: $plan.candidate,
+                childEvidence: $childEvidence,
+                executionPlanSha256: $plan.sha256,
+                sourceParentRunAttempt: ($plan.parentRunAttempt | tonumber)
+              } as $current
+            | if $plan.evidenceReuse.requested then
+                # Preserve the root manifest coverage and inputs when reusing evidence.
+                $plan.evidenceReuse.sourceManifest + $current + {
+                  evidenceReuse: {
+                    policy: $plan.evidenceReuse.policy,
+                    runId: $plan.evidenceReuse.rootRunId,
+                    selectedRunId: $plan.evidenceReuse.selectedRunId,
+                    evidenceSha: $plan.evidenceReuse.evidenceSha,
+                    changedPaths: ($plan.evidenceReuse.changedPaths // [])
+                  },
+                  controls: (($plan.evidenceReuse.sourceManifest.controls // {}) + {
+                    performanceReportPublication: "artifact-only"
+                  })
                 }
-              }
-            }' > "${manifest_dir}/full-release-validation-manifest.json"
+              else
+                ($plan.children | map({key: .key, value: .runId}) | from_entries) as $runs
+                | $current + {
+                  workflowName: "Full Release Validation",
+                  releaseProfile: $releaseProfile,
+                  rerunGroup: $rerunGroup,
+                  runReleaseSoak: $runReleaseSoak,
+                  validationInputs: ({
+                    provider: $provider,
+                    mode: $mode,
+                    targetContextRef: $targetContextRef,
+                    liveSuiteFilter: $liveSuiteFilter,
+                    crossOsSuiteFilter: $crossOsSuiteFilter,
+                    releasePackageSpec: $releasePackageSpec,
+                    packageAcceptancePackageSpec: $packageAcceptancePackageSpec,
+                    codexPluginSpec: $codexPluginSpec,
+                    npmTelegramPackageSpec: $npmTelegramPackageSpec,
+                    npmTelegramProviderMode: $npmTelegramProviderMode,
+                    npmTelegramScenario: $npmTelegramScenario,
+                    skipPackageTelegramE2e: $skipPackageTelegramE2e,
+                    allowUnreleasedChangelog: $allowUnreleasedChangelog,
+                    pluginPrereleaseNodeExcludePatternsJson: $pluginPrereleaseNodeExcludePatternsJson
+                  } + (if $telegramWaiver == "" then {} else {telegramWaiver: $telegramWaiver, targetVersion: $targetVersion} end)),
+                  controls: {
+                    stableSoakRequired: ($releaseProfile == "stable" or $releaseProfile == "full"),
+                    performanceBlocking: ($releaseProfile != "beta"),
+                    performanceReportPublication: "artifact-only"
+                  },
+                  childRuns: {
+                    normalCi: ($runs.normalCi // ""),
+                    pluginPrereleaseIndependent: ($runs.pluginPrereleaseIndependent // ""),
+                    pluginPrereleaseCandidate: ($runs.pluginPrereleaseCandidate // ""),
+                    releaseChecksIndependent: ($runs.releaseChecksIndependent // ""),
+                    releaseChecksCandidate: ($runs.releaseChecksCandidate // ""),
+                    npmTelegram: ($runs.npmTelegram // ""),
+                    productPerformance: {
+                      runId: ($runs.productPerformance // ""),
+                      conclusion: ($drain.children.productPerformance.conclusion // ""),
+                      blocking: ($releaseProfile != "beta")
+                    }
+                  }
+                }
+              end' > "${manifest_dir}/full-release-validation-manifest.json"
 
       - name: Validate release validation manifest
         env:

--- a/test/scripts/full-release-artifact-contract.test.ts
+++ b/test/scripts/full-release-artifact-contract.test.ts
@@ -1,6 +1,7 @@
+import { spawnSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { tryReadReleaseDecision } from "../../scripts/full-release-validation-at-sha.mts";
 import {
@@ -10,10 +11,11 @@ import {
   serializeReleaseArtifact,
 } from "../../scripts/full-release-validation-policy.mjs";
 import { tryReadReleaseDecisionArtifact } from "../../scripts/release-ci-summary.mjs";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const SHA = "a".repeat(40);
 
-function fullMatrixDecision() {
+function fullMatrixChildren() {
   // Observed full-profile fanout from parent 33230733150, including both phases.
   const counts = {
     normalCi: 186,
@@ -23,7 +25,7 @@ function fullMatrixDecision() {
     releaseChecksCandidate: 121,
     productPerformance: 7,
   };
-  const children = Object.entries(counts).map(([key, count], childIndex) => {
+  return Object.entries(counts).map(([key, count], childIndex) => {
     const runId = String(1000 + childIndex);
     const composite = composeReleaseAttemptJobs(
       [
@@ -65,6 +67,9 @@ function fullMatrixDecision() {
       updatedAt: "2026-08-29T03:26:00Z",
     };
   });
+}
+
+function fullMatrixDecision(children = fullMatrixChildren()) {
   return buildReleaseStateArtifact({
     children,
     decision: { activeRunIds: [], blockers: [], errors: [], state: "passed" },
@@ -83,6 +88,138 @@ function fullMatrixDecision() {
 }
 
 describe("full release artifact contract", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  it.each([false, true])(
+    "writes all matrix evidence with reuse=%s without argv size limits",
+    (reuse) => {
+      const workflow = parse(readFileSync(".github/workflows/full-release-validation.yml", "utf8"));
+      const writer = workflow.jobs.summary.steps.find(
+        (entry: { name: string }) => entry.name === "Write release validation manifest",
+      );
+      const children = fullMatrixChildren();
+      const drain = fullMatrixDecision(children);
+      const expectedChildren = Object.fromEntries(
+        children.map((child) => [
+          child.key,
+          {
+            runId: child.runId,
+            plannedRunAttempt: child.plannedRunAttempt,
+            effectiveRunAttempt: child.runAttempt,
+            observedRunAttempts: child.observedRunAttempts,
+            compositeJobsSha256: child.compositeJobsSha256,
+            dispatchActor: child.dispatchActor,
+            triggeringActor: child.triggeringActor,
+            repository: child.repository,
+            jobs: child.jobs.map(
+              ({ name, status, conclusion, acceptedRunAttempt, startedAt, completedAt, url }) => ({
+                name,
+                status,
+                conclusion,
+                acceptedRunAttempt,
+                startedAt,
+                completedAt,
+                url,
+              }),
+            ),
+          },
+        ]),
+      );
+      expect(Buffer.byteLength(JSON.stringify(expectedChildren))).toBeGreaterThan(128 * 1024);
+      const sourceManifest = {
+        releaseProfile: "stable",
+        runReleaseSoak: "true",
+        childRuns: { normalCi: "1000" },
+        validationInputs: { provider: "openai" },
+        controls: { stableSoakRequired: true },
+        childEvidence: expectedChildren,
+      };
+      const plan = {
+        targetSha: SHA,
+        sha256: "b".repeat(64),
+        parentRunAttempt: 1,
+        candidate: { package: { sourceSha: SHA } },
+        children: children.map((child) => ({
+          key: child.key,
+          runId: child.runId,
+        })),
+        evidenceReuse: {
+          requested: reuse,
+          selectedRunId: "99",
+          rootRunId: "98",
+          evidenceSha: "c".repeat(40),
+          policy: "changelog-only-release-v1",
+          changedPaths: ["CHANGELOG.md"],
+          sourceManifest,
+        },
+      };
+      const dir = tempDirs.make("full-release-manifest-");
+      const planPath = join(dir, "plan.json");
+      const drainPath = join(dir, "drain.json");
+      writeFileSync(planPath, JSON.stringify(plan));
+      writeFileSync(drainPath, serializeReleaseArtifact(drain));
+      const result = spawnSync("bash", ["-c", writer.run], {
+        encoding: "utf8",
+        env: {
+          ...Object.fromEntries(Object.keys(writer.env).map((key) => [key, ""])),
+          PATH: process.env.PATH,
+          RUNNER_TEMP: dir,
+          GITHUB_RUN_ID: "124",
+          GITHUB_RUN_ATTEMPT: "2",
+          GITHUB_REF_NAME: "release-ci/test",
+          GITHUB_SHA: "d".repeat(40),
+          GITHUB_REF: "refs/heads/release-ci/test",
+          GITHUB_REF_TYPE: "branch",
+          TARGET_REF: SHA,
+          RELEASE_PROFILE: "full",
+          RERUN_GROUP: "all",
+          RUN_RELEASE_SOAK: "true",
+          RELEASE_EXECUTION_PLAN_PATH: planPath,
+          DIAGNOSTIC_DRAIN_PATH: drainPath,
+        },
+      });
+      expect(result.status, result.stderr).toBe(0);
+      const bytes = readFileSync(
+        join(dir, "full-release-validation/full-release-validation-manifest.json"),
+        "utf8",
+      );
+      expect(Buffer.byteLength(bytes)).toBeLessThan(MAX_RELEASE_ARTIFACT_BYTES);
+      const manifest = JSON.parse(bytes);
+      expect(manifest.childEvidence).toEqual(expectedChildren);
+      expect(manifest).toMatchObject({
+        version: 4,
+        runId: "124",
+        runAttempt: "2",
+        targetSha: SHA,
+        candidateBinding: plan.candidate,
+        executionPlanSha256: plan.sha256,
+        sourceParentRunAttempt: 1,
+      });
+      if (reuse) {
+        expect(manifest).toMatchObject({
+          releaseProfile: "stable",
+          runReleaseSoak: "true",
+          childRuns: sourceManifest.childRuns,
+          validationInputs: sourceManifest.validationInputs,
+          evidenceReuse: {
+            policy: plan.evidenceReuse.policy,
+            runId: "98",
+            selectedRunId: "99",
+            evidenceSha: plan.evidenceReuse.evidenceSha,
+            changedPaths: ["CHANGELOG.md"],
+          },
+        });
+      } else {
+        expect(manifest).toMatchObject({
+          releaseProfile: "full",
+          rerunGroup: "all",
+          childRuns: sourceManifest.childRuns,
+        });
+        expect(manifest).not.toHaveProperty("evidenceReuse");
+      }
+    },
+  );
+
   it("compacts the full matrix without dropping job evidence and bounds UTF-8 bytes", () => {
     const payload = fullMatrixDecision();
     const compact = serializeReleaseArtifact(payload);

--- a/test/scripts/full-release-validation-continuation-workflow.test.ts
+++ b/test/scripts/full-release-validation-continuation-workflow.test.ts
@@ -75,11 +75,7 @@ describe("full release same-parent recovery workflow", () => {
     }
   });
 
-  it("records effective attempts and composite jobs in the final manifest", () => {
-    const write = String(step("summary", "Write release validation manifest").run);
-    expect(write).toContain("CHILD_EVIDENCE=");
-    expect(write).toContain("acceptedRunAttempt");
-    expect(write).toContain("compositeJobsSha256");
+  it("validates final manifest attempts against the diagnostic drain", () => {
     expect(step("summary", "Validate release validation manifest").env).toMatchObject({
       DIAGNOSTIC_DRAIN_PATH:
         "${{ runner.temp }}/full-release-diagnostics/full-release-diagnostic-manifest.json",

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3579,9 +3579,6 @@ describe("package acceptance workflow", () => {
     expect(planUpload.if).toBe("always()");
     expect(planUpload.with?.name).toBe("full-release-execution-plan-${{ github.run_id }}");
     expect(manifestStep.env).not.toHaveProperty("EVIDENCE_MANIFEST");
-    expect(manifestStep.run).toContain(
-      'EVIDENCE_MANIFEST="$(jq -c \'.evidenceReuse.sourceManifest // empty\' "$RELEASE_EXECUTION_PLAN_PATH")"',
-    );
     expect(manifestStep.run).not.toContain("needs.evidence_reuse.outputs");
     expect(decisionUpload.with?.name).toBe(
       "full-release-decision-${{ github.run_id }}-${{ github.run_attempt }}",
@@ -3624,13 +3621,6 @@ describe("package acceptance workflow", () => {
     expect(manifest.env).not.toHaveProperty("TARGET_SHA");
     expect(manifest.env).not.toHaveProperty("NORMAL_CI_RUN_ID");
     expect(manifest.env).not.toHaveProperty("EVIDENCE_REUSE");
-    expectTextToIncludeAll(manifest.run, [
-      'TARGET_SHA="$(jq -r \'.targetSha\' "$RELEASE_EXECUTION_PLAN_PATH")"',
-      'NORMAL_CI_RUN_ID="$(jq -r \'.children[] | select(.key == "normalCi") | .runId\' "$RELEASE_EXECUTION_PLAN_PATH")"',
-      'EVIDENCE_RUN_ID="$(jq -r \'.evidenceReuse.selectedRunId // ""\' "$RELEASE_EXECUTION_PLAN_PATH")"',
-      'EVIDENCE_MANIFEST="$(jq -c \'.evidenceReuse.sourceManifest // empty\' "$RELEASE_EXECUTION_PLAN_PATH")"',
-      'PERFORMANCE_CONCLUSION="$(jq -r \'.children.productPerformance.conclusion // ""\' "$DIAGNOSTIC_DRAIN_PATH")"',
-    ]);
     expect(manifest.run).not.toContain("needs.evidence_reuse.outputs");
     expect(evidenceDispatch.run).toContain(
       'EVIDENCE_REUSE="$(jq -r \'.evidenceReuse.requested\' "$RELEASE_EXECUTION_PLAN_PATH")"',
@@ -7794,10 +7784,6 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
     expect(manifestStep.env?.DIAGNOSTIC_DRAIN_PATH).toContain(
       "full-release-diagnostic-manifest.json",
     );
-    expect(manifestStep.run).toContain(
-      `PERFORMANCE_RUN_ID="$(jq -r '.children[] | select(.key == "productPerformance") | .runId' "$RELEASE_EXECUTION_PLAN_PATH")"`,
-    );
-    expect(manifestStep.run).toContain('--arg performanceRunId "$PERFORMANCE_RUN_ID"');
   });
 
   it("wires evidence attempts into the acceptance gate", () => {

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -775,6 +775,7 @@ describe("scripts/test-projects changed-target routing", () => {
         "test/scripts/ci-workflow-guards.test.ts",
         "test/scripts/frv-proof-broker.test.ts",
         "test/scripts/frv.test.ts",
+        "test/scripts/full-release-artifact-contract.test.ts",
         "test/scripts/full-release-validation-continuation-workflow.test.ts",
         "test/scripts/openclaw-performance-workflow.test.ts",
         "test/scripts/release-plan-producer.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation can finish every required test and still fail while writing its final manifest. In [run 33322711134](https://github.com/openclaw/openclaw/actions/runs/33322711134), Release Decision and Diagnostic Drain passed, but the final writer exited 126 with `jq: Argument list too long`. The collected child evidence was 133,128 bytes, exceeding Linux's 131,072-byte per-argument limit.

## Why This Change Was Made

The manifest writer passed the complete job inventory to jq through one `--argjson` argument in both fresh and reused-evidence branches. It now reads the existing sealed plan and diagnostic files with `--slurpfile`, projects child evidence inside jq, and shares the current-run fields between the two branches. This removes the large shell intermediates and 72 net workflow lines.

The manifest schema, complete job/attempt/hash evidence, reuse inheritance, candidate identity, subsequent strict validation, and 1 MiB artifact limit are unchanged. Telegram remains best effort under the previously landed release-owner policy; this change does not alter any gate or test assertion. No product runtime, configuration, dependency, publication, or changelog change is involved.

## Evidence

- The existing full-matrix fixture now executes the actual Bash/jq writer for fresh and reused evidence. It checks a child projection larger than 128 KiB, complete job/attempt/hash preservation, candidate binding, reused root fields, and a final manifest below 1 MiB.
- One Linux Testbox invocation reproduced both old-writer failures (`Argument list too long`, shell exit 126; seven tests passed and two failed), then passed all nine tests with the fixed writer. The task-owned lease was stopped after proof. [Native proof run](https://github.com/openclaw/openclaw/actions/runs/33326090894).
- A private replay of the failed run's digest-verified plan and diagnostic artifacts produced identical parsed manifest contents before and after the change for both branches. Those reconstructed files are test proof only, not authoritative release evidence.
- All 266 focused workflow tests passed. Workflow checks, including actionlint and zizmor, passed. Final independent managed Codex review found no actionable P0–P2 findings after the test-typing cleanup. The final artifact/continuation rerun passed all 14 tests; script lint also passed.
- The changed gate passed its guards and formatting checks. Local aggregate test-root typechecking is limited by the shared dependency install: existing grammY and logger dependency types do not match this checkout. The new test typing errors were fixed; the final typecheck reports only those unrelated paths. No shared dependency reconciliation or unrelated runtime edits were made. The final locked-install CI run passed all aggregate typechecks.

Production/tooling delta: 72 fewer workflow lines; no production TypeScript change. Test changes add executable artifact-boundary coverage and remove obsolete source-string assertions. The original failed full run is preserved as failed evidence; a fresh full validation is required after the repair lands because that parent owns its candidate artifacts.

## CI Follow-through

The first exact-head CI run caught a companion routing expectation: the new regression's direct workflow reference is correctly discovered by the changed-test router, but its strict expected target list still had 18 entries instead of 19. The correction adds the artifact-contract test to that list without changing routing behavior. The focused routing case reproduced the failure locally and passed after the one-line update; the other tests were intentionally filtered out of that focused rerun. The manifest writer and Linux before/after proof are unchanged. ClawSweeper identified no actionable findings. Its remaining exact-head CI step is now complete: [CI 33327518022](https://github.com/openclaw/openclaw/actions/runs/33327518022) passed on f108e1c11901df3c2fa379a9242bcf0820333a26. The one-line routing correction also passed focused verification and independent managed review; it does not change production behavior.

Latest review follow-through: the 18:37 UTC ClawSweeper review contains no actionable code or security findings. Its check-visibility concern is resolved by a fresh required-check read on `f108e1c11901df3c2fa379a9242bcf0820333a26`: `openclaw/ci-gate` is successful in CI run [33327518022](https://github.com/openclaw/openclaw/actions/runs/33327518022). Maintainer authorization to land this release-verification repair is already explicit. A fresh all-group validation will provide authoritative release evidence after landing; the earlier failed parent is not being relabeled or reused as a success.
