### PR TITLE
improve: speed up Git workflow fixture execution

### DIFF
--- a/test/scripts/ci-checkout.test-support.ts
+++ b/test/scripts/ci-checkout.test-support.ts
@@ -61,41 +61,48 @@ export function renderGitTestClock(
   source: string,
   options: { realClock?: boolean; realDrain?: boolean } = {},
 ) {
+  // Command deadlines and TERM grace are independent. Real-clock callers keep
+  // real grace unless they explicitly opt into the fixture's immediate escalation.
+  if (!(options.realDrain ?? options.realClock)) {
+    source = source.replace(
+      "kill_at = deadline - cleanup_seconds / 2",
+      "kill_at = time.monotonic()",
+    );
+  }
   if (options.realClock) {
     return source;
   }
   // Only a ready, deliberately stalled tree advances the fetch clock. Real
   // process startup and teardown retain their independent wall-clock watchdogs.
-  const rendered = source
-    .replace(/fetch_timeout_seconds = [^\n]+/u, "fetch_timeout_seconds = 2")
-    .replace(
-      "def run_git(",
-      `def fetch_clock():
+  return (
+    source
+      .replace(/fetch_timeout_seconds = [^\n]+/u, "fetch_timeout_seconds = 2")
+      .replace(
+        "def run_git(",
+        `def fetch_clock():
     return 2 * sum(name.startswith("fetch-tick-") and name.endswith(".json")
                    for name in os.listdir(os.environ["TMPDIR"]))
 
 
 def run_git(`,
-    )
-    .replace("deadline = time.monotonic() + timeout", "deadline = fetch_clock() + timeout")
-    .replace(
-      "deadline is not None and time.monotonic() >= deadline",
-      "deadline is not None and fetch_clock() >= deadline",
-    )
-    .replace(/\btimeout=(?:30|60|120)(?=[,)])/gu, "timeout=2")
-    .replace(
-      /retry_at = time\.monotonic\(\) \+ [^\n]+/u,
-      'print(f"fixture backoff: {seconds}", flush=True)\n    retry_at = time.monotonic() + 0.05',
-    )
-    .replace(/--((?:checkout-)?git) 120\b/gu, "--$1 2")
-    // Keep pre-fix standalone shell bodies executable for red/green proof.
-    .replaceAll("120s git", "2s git")
-    .replaceAll("sleep $((attempt * 2))", 'echo "fixture backoff: $((attempt * 2))"')
-    .replaceAll("sleep $((attempt * 5))", "sleep 0.05")
-    .replaceAll("sleep 5", "sleep 0.05");
-  return options.realDrain
-    ? rendered
-    : rendered.replace("kill_at = deadline - cleanup_seconds / 2", "kill_at = time.monotonic()");
+      )
+      .replace("deadline = time.monotonic() + timeout", "deadline = fetch_clock() + timeout")
+      .replace(
+        "deadline is not None and time.monotonic() >= deadline",
+        "deadline is not None and fetch_clock() >= deadline",
+      )
+      .replace(/\btimeout=(?:30|60|120)(?=[,)])/gu, "timeout=2")
+      .replace(
+        /retry_at = time\.monotonic\(\) \+ [^\n]+/u,
+        'print(f"fixture backoff: {seconds}", flush=True)\n    retry_at = time.monotonic() + 0.05',
+      )
+      .replace(/--((?:checkout-)?git) 120\b/gu, "--$1 2")
+      // Keep pre-fix standalone shell bodies executable for red/green proof.
+      .replaceAll("120s git", "2s git")
+      .replaceAll("sleep $((attempt * 2))", 'echo "fixture backoff: $((attempt * 2))"')
+      .replaceAll("sleep $((attempt * 5))", "sleep 0.05")
+      .replaceAll("sleep 5", "sleep 0.05")
+  );
 }
 
 export function expectCiCheckoutCleanup(report: Report) {

--- a/test/scripts/ci-git-owner.test-support.ts
+++ b/test/scripts/ci-git-owner.test-support.ts
@@ -174,7 +174,7 @@ export async function runCiGitStep(options: {
   const clock = {
     ...options,
     realDrain:
-      options.realDrain || options.cancelDuringCleanup || options.scenario?.startsWith("cancel-"),
+      options.cancelDuringCleanup || options.scenario?.startsWith("cancel-") || options.realDrain,
   };
   const step: (Step & { run: string }) | undefined = options.action
     ? (
@@ -475,7 +475,7 @@ ${run}`;
       console.log(
         `${typeof options.workflow === "object" ? `${options.workflow.file}/${options.workflow.job}/${options.workflow.step}` : `${options.workflow ?? options.action ?? options.job}/${options.step ?? "Checkout"}`}: ${JSON.stringify(report)}`,
       );
-      expect(result, stderr).toEqual({ code: 0, signal: null });
+      expect(result, `${stderr}\n${report.error ?? ""}`).toEqual({ code: 0, signal: null });
       expect(report.error, stderr).toBeUndefined();
       expectCiCheckoutCleanup(report);
       if (docsAgent) {

--- a/test/scripts/ci-linux-git.test.ts
+++ b/test/scripts/ci-linux-git.test.ts
@@ -714,6 +714,7 @@ posixIt.each([
           }),
       fetchResults: failure ? [failure] : fetches.map(() => 0),
       realClock: true,
+      realDrain: false,
       poisonPython: true,
       env: {
         BASELINE_REF: baseline ? "baseline" : "",
@@ -812,6 +813,7 @@ posixIt.each([
       fetchResults: fetch ? [result] : [],
       cloneResults: fetch ? [] : [result],
       realClock: true,
+      realDrain: false,
       poisonPython: true,
       env: { CRABBOX_REF: "main" },
     });
@@ -933,6 +935,7 @@ posixIt.each([
       fetchResults: [],
       worktreeResults: failure ? ["cleanup-failure"] : lanes.map(() => 0),
       realClock: true,
+      realDrain: false,
       poisonPython: true,
       env: { BASELINE_SHA: base, CANDIDATE_SHA: candidate },
     });

--- a/test/scripts/fixtures/ci-platform-checkout.mjs
+++ b/test/scripts/fixtures/ci-platform-checkout.mjs
@@ -4,7 +4,6 @@ import fs from "node:fs";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
-import { getFileLockProcessStartTime } from "../../../src/shared/pid-alive.ts";
 
 const [mode, root, policyScenario, ...args] = process.argv.slice(2);
 const linux = policyScenario.startsWith("linux:");
@@ -19,6 +18,12 @@ const eventsFile = path.join(root, "events.jsonl");
 const commandsFile = path.join(root, "commands.jsonl");
 const optionsFile = path.join(root, "fixture-options.json");
 const options = fs.existsSync(optionsFile) ? JSON.parse(fs.readFileSync(optionsFile, "utf8")) : {};
+// Resolve identity support before cancellation can enter its cleanup handshake.
+// Ordinary fixture actors do not need the TypeScript module.
+const getFileLockProcessStartTime =
+  options.cancelDuringCleanup && ["supervise", "git"].includes(mode)
+    ? (await import("../../../src/shared/pid-alive.ts")).getFileLockProcessStartTime
+    : undefined;
 const refsFile = path.join(root, "refs.json");
 
 function resolveRef(cwd, ref) {


### PR DESCRIPTION
## What Problem This Solves

The Git workflow fixture starts many short-lived observer and process-tree actors. Every actor loaded a TypeScript PID-identity helper although only cleanup cancellation needed it. Separately, 18 Mantis contract cases repeatedly waited through the same five-second TERM grace while testing trust, installation, and worktree ordering.

## Why This Change Was Made

Resolve the existing PID helper only for the supervisor and Git modes when cleanup cancellation is requested, before either mode starts its lifecycle. Keep both identity checks and their signal ordering unchanged. Ordinary observers, children, and sentinels retain their real process census without loading the unused module.

Separate command-clock selection from the existing fixture drain-clock choice. Real-clock callers continue to get real grace by default; only the three Mantis tables explicitly select immediate escalation. Cancellation scenarios still force real grace. The actors remain TERM-resistant, and the actual owner still signals, inspects, joins, and proves extinction before allowing another operation. Dedicated real-grace and cancellation cases remain unchanged.

Also include the supervisor's existing error text in the result assertion. An earlier baseline failure emitted that detail to console but lost it from the JSON-only failure report. This changes diagnostics, not assertion conditions.

## User Impact

Faster test execution only. No production or workflow changes, dependency additions, sharding, workers, concurrency, test selection, command-timeout, cleanup-deadline, watchdog, fault, or assertion changes. Production/tooling: +0/-0. Tests and test support: +43/-28, including formatting of the existing expression chain.

## Evidence

- Same Linux Node 24.19 worker: the 18 Mantis cases took 87.063 seconds before and 6.367 seconds after; a second candidate run took 6.38 seconds. About 80.7 seconds saved in these cases. No whole-CI duration claim.
- Exact formatted observer source, 12 balanced fresh-process pairs: median 36.400 ms before / 20.559 ms after, 43.5% lower startup including real census. An earlier Linux pair set and two macOS pair sets showed comparable reductions.
- Observer probes preserved actual sentinel registration and identical census events, joined every owned child, and removed the fixture root. Missing-helper probes verified that both identity-owning modes fail before lifecycle startup, while an ordinary observer remains usable.
- All seven observer consumer suites passed: 727 tests. After adding the Mantis clock refinement, 27 before/after option combinations verified that only explicit realClock=true, realDrain=false without forced cancellation changes rendered behavior, and only the escalation line changes.
- Negative behavior proof removed the drain call only from the rendered fixture owner. The existing installer test rejected live child and grandchild processes at the build boundary. The unchanged supervisor then completed cleanup, all owned processes were verified extinct, the root was removed, and the helper was restored byte-for-byte. The production owner was never edited. All 18 restored Mantis cases passed again.
- Final platform-checkout, Git-owner, Linux-Git, and performance-lifecycle sibling suites passed all 430 tests on Linux. All 14 changed-file checks passed. Independent source review and Codex review found no actionable findings. Both temporary workers stopped cleanly. Exact-head hosted [CI run 33326420454](https://github.com/openclaw/openclaw/actions/runs/33326420454) completed successfully for 5d6c7d83f4e951fe5806e1fd2a96aad81b5bbb55. The latest ClawSweeper review found no actionable findings; its ordinary-check requirement is now satisfied.

## Remaining Coverage

Real grace remains the default for real-clock callers, including QA, maturity, base recovery, and ordinary workflow-sanity failure. Platform cancellation, cancellation during drain, and performance-workflow cancellation retain the real cleanup path. No cooperative-child substitution or numeric signal-exit substitute is introduced.
