### PR TITLE
fix(gateway): reduce control-plane stalls during concurrent turns

### DIFF
--- a/docs/concepts/queue.md
+++ b/docs/concepts/queue.md
@@ -18,6 +18,7 @@ OpenClaw serializes inbound auto-reply runs (all channels) through a tiny in-pro
 - A lane-aware FIFO queue drains each lane with a configurable concurrency cap (default 1 for unconfigured lanes; `main` uses `min(16, max(8, available CPU parallelism))`, and `subagent` defaults to 8).
 - `runEmbeddedAgent` enqueues by **session key** (lane `session:<key>`) to guarantee only one active run per session.
 - Each session run is then queued into a **global lane** (`main` by default) so overall parallelism is capped by `agents.defaults.maxConcurrent`.
+- Embedded attempt preparation starts one stage per event-loop turn so concurrent starts leave room for Gateway requests. Asynchronous stage work can still overlap; this does not lower the run concurrency limit or change session serialization.
 - When verbose logging is enabled, queued runs emit a short notice if they waited more than ~2s before starting.
 - Typing indicators still fire immediately on enqueue (when supported by the channel) so user experience is unchanged while the run waits its turn.
 

--- a/src/agents/embedded-agent-runner/run/attempt-abort.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-abort.test.ts
@@ -212,7 +212,7 @@ describe("createEmbeddedAttemptExternalAbortController", () => {
     }
   });
 
-  it("cleans prepared resources before rejecting a pre-fired signal", async () => {
+  it.each(["stage-start", "prep-cleanup"])("classifies cancellation at %s", async (checkpoint) => {
     const source = new AbortController();
     const reason = new Error("cancelled during setup");
     source.abort(reason);
@@ -226,9 +226,13 @@ describe("createEmbeddedAttemptExternalAbortController", () => {
       state: state.port,
     });
 
-    await expect(controller.throwIfFiredAfterPrepCleanup()).rejects.toBe(reason);
+    if (checkpoint === "stage-start") {
+      expect(() => controller.throwIfFired()).toThrow(reason);
+    } else {
+      await expect(controller.throwIfFiredAfterPrepCleanup()).rejects.toBe(reason);
+    }
 
-    expect(cleanupAfterEarlyAbort).toHaveBeenCalledTimes(1);
+    expect(cleanupAfterEarlyAbort).toHaveBeenCalledTimes(checkpoint === "stage-start" ? 0 : 1);
     expect(state.markAborted).toHaveBeenCalledTimes(1);
     expect(state.markExternalAbort).toHaveBeenCalledTimes(1);
     expect(state.setPromptError).toHaveBeenCalledWith(reason);

--- a/src/agents/embedded-agent-runner/run/attempt-abort.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-abort.test.ts
@@ -212,9 +212,15 @@ describe("createEmbeddedAttemptExternalAbortController", () => {
     }
   });
 
-  it.each(["stage-start", "prep-cleanup"])("classifies cancellation at %s", async (checkpoint) => {
+  it.each([
+    ["stage-start", false],
+    ["prep-cleanup", false],
+    ["stage-start", true],
+    ["prep-cleanup", true],
+  ] as const)("classifies abort at %s (timeout=%s)", async (checkpoint, timeout) => {
     const source = new AbortController();
     const reason = new Error("cancelled during setup");
+    reason.name = timeout ? "TimeoutError" : "AbortError";
     source.abort(reason);
     const cleanupAfterEarlyAbort = vi.fn(async () => {});
     const state = createAbortState();
@@ -236,6 +242,12 @@ describe("createEmbeddedAttemptExternalAbortController", () => {
     expect(state.markAborted).toHaveBeenCalledTimes(1);
     expect(state.markExternalAbort).toHaveBeenCalledTimes(1);
     expect(state.setPromptError).toHaveBeenCalledWith(reason);
+    expect(state.markTimedOut).toHaveBeenCalledTimes(timeout ? 1 : 0);
+    controller.arm();
+    expect(() => controller.throwIfFired()).toThrow(reason);
+    expect(state.markExternalAbort).toHaveBeenCalledTimes(1);
+    expect(state.markTimedOut).toHaveBeenCalledTimes(timeout ? 1 : 0);
+    controller.dispose();
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/attempt-finalize.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-finalize.ts
@@ -474,6 +474,7 @@ export function createEmbeddedAttemptExternalAbortController(input: {
     isPendingOrRetrying: () => boolean;
   }) => void;
   setRunAbort: (abort: RunAbort) => void;
+  throwIfFired: () => void;
   throwIfFiredAfterPrepCleanup: () => Promise<void>;
 } {
   let abortActiveSession: ActiveSessionAbort | undefined;
@@ -520,6 +521,18 @@ export function createEmbeddedAttemptExternalAbortController(input: {
     void abortActiveSession?.(input.runAbortController.signal.reason);
   };
 
+  const readFiredAbortError = () => {
+    const signal = input.abortSignal;
+    if (!signal?.aborted) {
+      return undefined;
+    }
+    const abortError = createAttemptAbortError(signal);
+    input.state.markAborted();
+    input.state.markExternalAbort();
+    input.state.setPromptError(abortError);
+    return abortError;
+  };
+
   return {
     arm: () => {
       const signal = input.abortSignal;
@@ -549,15 +562,17 @@ export function createEmbeddedAttemptExternalAbortController(input: {
     setRunAbort: (abort) => {
       abortRun = abort;
     },
+    throwIfFired: () => {
+      const abortError = readFiredAbortError();
+      if (abortError) {
+        throw abortError;
+      }
+    },
     throwIfFiredAfterPrepCleanup: async () => {
-      const signal = input.abortSignal;
-      if (!signal?.aborted) {
+      const abortError = readFiredAbortError();
+      if (!abortError) {
         return;
       }
-      const abortError = createAttemptAbortError(signal);
-      input.state.markAborted();
-      input.state.markExternalAbort();
-      input.state.setPromptError(abortError);
       await input.cleanupAfterEarlyAbort();
       throw abortError;
     },

--- a/src/agents/embedded-agent-runner/run/attempt-finalize.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-finalize.ts
@@ -482,12 +482,16 @@ export function createEmbeddedAttemptExternalAbortController(input: {
   let isCompactionPendingOrRetrying: (() => boolean) | undefined;
   let isCompactionInFlight: (() => boolean) | undefined;
   let removeListener: (() => void) | undefined;
+  let abortHandled = false;
 
   const onAbort = () => {
     const signal = input.abortSignal;
-    if (!signal) {
+    if (!signal || abortHandled) {
       return;
     }
+    // Preparation checkpoints and the listener share classification and side effects.
+    // Mark before handoff because aborting live work can synchronously re-enter.
+    abortHandled = true;
     input.state.markExternalAbort();
     const reason = getAbortReason(signal);
     const isTimeout = reason ? isSignalTimeoutReason(reason) : false;
@@ -526,11 +530,8 @@ export function createEmbeddedAttemptExternalAbortController(input: {
     if (!signal?.aborted) {
       return undefined;
     }
-    const abortError = createAttemptAbortError(signal);
-    input.state.markAborted();
-    input.state.markExternalAbort();
-    input.state.setPromptError(abortError);
-    return abortError;
+    onAbort();
+    return createAttemptAbortError(signal);
   };
 
   return {

--- a/src/agents/embedded-agent-runner/run/attempt-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-preparation.ts
@@ -1,0 +1,23 @@
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { measureEmbeddedAgentPreparation } from "./preparation-timing.js";
+
+let nextPreparationStart = Promise.resolve();
+
+/** Dispatches attempt stages without letting concurrent starts monopolize the event loop. */
+export function createEmbeddedAttemptPreparation(options: {
+  config?: OpenClawConfig;
+  assertCurrent: () => void;
+}) {
+  return async <T>(stage: string, run: () => Promise<T> | T): Promise<T> => {
+    // Only start turns are serialized. Async work overlaps, and a failed or cancelled
+    // attempt cannot reject the shared tail or inherit another caller's async context.
+    const start = nextPreparationStart.then(() => yieldToEventLoop());
+    nextPreparationStart = start;
+    await start;
+    // Check before acquisition; the caller must receive each result before another
+    // checkpoint can throw so its existing finally blocks own every acquired resource.
+    options.assertCurrent();
+    return measureEmbeddedAgentPreparation(stage, run, { config: options.config });
+  };
+}

--- a/src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts
@@ -1,4 +1,9 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  onInternalDiagnosticEvent,
+  type DiagnosticEventPayload,
+} from "../../../infra/diagnostic-events.js";
+import type { createOpenClawCodingTools } from "../../agent-tools.js";
 import type { ToolSearchCatalogRef } from "../../tool-search.js";
 import {
   cleanupTempPaths,
@@ -58,27 +63,40 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
       mode: "code-mode",
       tools: { codeMode: { enabled: true } },
       cancel: false,
+      timeout: false,
     },
     {
       mode: "tool-search-tools",
       tools: { toolSearch: { enabled: true, mode: "tools" } },
       cancel: false,
+      timeout: false,
     },
     {
       mode: "tool-search-directory",
       tools: { toolSearch: { enabled: true, mode: "directory" } },
       cancel: false,
+      timeout: false,
     },
     {
       mode: "cancelled-code-mode",
       tools: { codeMode: { enabled: true } },
       cancel: true,
+      timeout: false,
+    },
+    {
+      mode: "timed-out-code-mode",
+      tools: { codeMode: { enabled: true } },
+      cancel: true,
+      timeout: true,
     },
   ] as const)(
     "clears the $mode run catalog when preparation fails or is cancelled",
-    async ({ mode, tools, cancel }) => {
+    async ({ mode, tools, cancel, timeout }) => {
       const runId = `run-catalog-diagnostics-${mode}`;
       const diagnosticsError = new Error(`failed ${mode} tool diagnostics`);
+      if (timeout) {
+        diagnosticsError.name = "TimeoutError";
+      }
       const abortController = new AbortController();
       let catalogRef: ToolSearchCatalogRef | undefined;
       const logDiagnostics = vi.fn(() => {
@@ -92,7 +110,16 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
           throw diagnosticsError;
         }
       });
-      hoisted.createOpenClawCodingToolsMock.mockImplementation(() => catalogProbeTools());
+      const cleanup = vi.fn(async (_reason: string) => {});
+      hoisted.createOpenClawCodingToolsMock.mockImplementation((options) => {
+        const toolOptions = options as NonNullable<Parameters<typeof createOpenClawCodingTools>[0]>;
+        toolOptions.registerRunCleanup?.(cleanup);
+        return catalogProbeTools();
+      });
+      const events: DiagnosticEventPayload[] = [];
+      const unsubscribe = onInternalDiagnosticEvent((event) => events.push(event), {
+        include: ["run.completed"],
+      });
 
       const attempt = createContextEngineAttemptRunner({
         contextEngine: createContextEngineBootstrapAndAssemble(),
@@ -112,7 +139,30 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
         },
       });
 
-      await expect(attempt).rejects.toBe(diagnosticsError);
+      try {
+        if (timeout) {
+          await expect(attempt).rejects.toMatchObject({
+            cause: diagnosticsError,
+            terminalOutcome: { status: "timeout" },
+          });
+        } else {
+          await expect(attempt).rejects.toBe(diagnosticsError);
+        }
+      } finally {
+        unsubscribe();
+      }
+      expect(cleanup).toHaveBeenCalledExactlyOnceWith(
+        timeout ? "timeout" : cancel ? "cancel" : "completion",
+      );
+      if (timeout) {
+        expect(events).toContainEqual(
+          expect.objectContaining({
+            type: "run.completed",
+            runId,
+            outcome: "aborted",
+          }),
+        );
+      }
       expect(logDiagnostics).toHaveBeenCalledOnce();
       expect(catalogRef).toBeDefined();
       expect(catalogRef?.current).toBeUndefined();

--- a/src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts
@@ -57,27 +57,40 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
     {
       mode: "code-mode",
       tools: { codeMode: { enabled: true } },
+      cancel: false,
     },
     {
       mode: "tool-search-tools",
       tools: { toolSearch: { enabled: true, mode: "tools" } },
+      cancel: false,
     },
     {
       mode: "tool-search-directory",
       tools: { toolSearch: { enabled: true, mode: "directory" } },
+      cancel: false,
+    },
+    {
+      mode: "cancelled-code-mode",
+      tools: { codeMode: { enabled: true } },
+      cancel: true,
     },
   ] as const)(
-    "clears the $mode run catalog when diagnostics throw during preparation",
-    async ({ mode, tools }) => {
+    "clears the $mode run catalog when preparation fails or is cancelled",
+    async ({ mode, tools, cancel }) => {
       const runId = `run-catalog-diagnostics-${mode}`;
       const diagnosticsError = new Error(`failed ${mode} tool diagnostics`);
+      const abortController = new AbortController();
       let catalogRef: ToolSearchCatalogRef | undefined;
       const logDiagnostics = vi.fn(() => {
         catalogRef = requireAttemptCatalogRef();
         expect(catalogRef.current?.entries).toContainEqual(
           expect.objectContaining({ name: "cataloged_probe_tool" }),
         );
-        throw diagnosticsError;
+        if (cancel) {
+          abortController.abort(diagnosticsError);
+        } else {
+          throw diagnosticsError;
+        }
       });
       hoisted.createOpenClawCodingToolsMock.mockImplementation(() => catalogProbeTools());
 
@@ -87,6 +100,7 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
         tempPaths,
         attemptOverrides: {
           runId,
+          abortSignal: abortController.signal,
           disableTools: false,
           config: { tools },
           runtimePlan: {

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -30,6 +30,7 @@ import {
   createEmbeddedAttemptExternalAbortController,
   type EmbeddedAttemptAbortStatePort,
 } from "./attempt-finalize.js";
+import { createEmbeddedAttemptPreparation } from "./attempt-preparation.js";
 import { prepareEmbeddedAttemptSessionRuntime } from "./attempt-session-runtime-prepare.js";
 import { cleanupEmbeddedAttemptSessionPhase } from "./attempt-session-settle.js";
 import {
@@ -47,10 +48,7 @@ import { prepareEmbeddedAttemptSystemPrompt } from "./attempt-system-prompt-prep
 import { prepareEmbeddedAttemptToolCatalog } from "./attempt-tool-catalog.js";
 import { prepareEmbeddedAttemptToolBase } from "./attempt-tool-prepare.js";
 import { prepareEmbeddedAttemptTranscriptLifecycle } from "./attempt-transcript-lifecycle-prepare.js";
-import {
-  measureEmbeddedAgentPreparation,
-  measureEmbeddedAgentPreparationSync,
-} from "./preparation-timing.js";
+import { measureEmbeddedAgentPreparation } from "./preparation-timing.js";
 import { clearToolActivityRun } from "./tool-activity-heartbeat.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
@@ -152,17 +150,18 @@ export async function runEmbeddedAttempt(
     runId: params.runId,
     state: abortState,
   });
+  const prepare = createEmbeddedAttemptPreparation({
+    config: params.config,
+    assertCurrent: externalAbortController.throwIfFired,
+  });
   try {
-    const preparedSkills = measureEmbeddedAgentPreparationSync(
-      "attempt.skills",
-      () =>
-        prepareEmbeddedAttemptSkills({
-          attempt: params,
-          effectiveWorkspace,
-          sandbox,
-          sessionAgentId,
-        }),
-      { config: params.config },
+    const preparedSkills = await prepare("attempt.skills", () =>
+      prepareEmbeddedAttemptSkills({
+        attempt: params,
+        effectiveWorkspace,
+        sandbox,
+        sessionAgentId,
+      }),
     );
     restoreSkillEnv = preparedSkills.restoreSkillEnv;
     const { codeModeSkills, skillUsagePaths, skillsPrompt, skillsSnapshotForRun } = preparedSkills;
@@ -189,41 +188,38 @@ export async function runEmbeddedAttempt(
     emitDiagnosticRunCompleted = emitCompleted;
     const corePluginToolStages = createEmbeddedRunStageTracker();
     let toolSearchCatalogExecutor: ToolSearchCatalogToolExecutor | undefined;
-    const preparedToolBase = measureEmbeddedAgentPreparationSync(
-      "attempt.tool-base",
-      () =>
-        prepareEmbeddedAttemptToolBase({
-          agentDir,
-          attempt: params,
-          effectiveCwd,
-          effectiveWorkspace,
-          markCoreToolStage: (name) => corePluginToolStages.mark(name),
-          onYield: (message, acknowledgment) => {
-            yieldDetected = true;
-            yieldMessage = message;
-            yieldAcknowledgment = acknowledgment;
-            queueYieldInterruptForSession?.();
-            runAbortController.abort(SESSIONS_YIELD_ABORT_REASON);
-            abortSessionForYield?.();
-          },
-          resolvedWorkspace,
-          runAbortController,
-          runTrace,
-          sandbox,
-          sandboxSessionKey,
-          sessionPermissionPolicy,
-          sessionAgentId,
-          skillUsagePaths,
-          skillsSnapshot: skillsSnapshotForRun,
-          codeModeSkills,
-          toolSearchCatalogExecutor: (toolParams) => {
-            if (!toolSearchCatalogExecutor) {
-              throw new Error("Tool Search catalog executor is unavailable for this run.");
-            }
-            return toolSearchCatalogExecutor(toolParams);
-          },
-        }),
-      { config: params.config },
+    const preparedToolBase = await prepare("attempt.tool-base", () =>
+      prepareEmbeddedAttemptToolBase({
+        agentDir,
+        attempt: params,
+        effectiveCwd,
+        effectiveWorkspace,
+        markCoreToolStage: (name) => corePluginToolStages.mark(name),
+        onYield: (message, acknowledgment) => {
+          yieldDetected = true;
+          yieldMessage = message;
+          yieldAcknowledgment = acknowledgment;
+          queueYieldInterruptForSession?.();
+          runAbortController.abort(SESSIONS_YIELD_ABORT_REASON);
+          abortSessionForYield?.();
+        },
+        resolvedWorkspace,
+        runAbortController,
+        runTrace,
+        sandbox,
+        sandboxSessionKey,
+        sessionPermissionPolicy,
+        sessionAgentId,
+        skillUsagePaths,
+        skillsSnapshot: skillsSnapshotForRun,
+        codeModeSkills,
+        toolSearchCatalogExecutor: (toolParams) => {
+          if (!toolSearchCatalogExecutor) {
+            throw new Error("Tool Search catalog executor is unavailable for this run.");
+          }
+          return toolSearchCatalogExecutor(toolParams);
+        },
+      }),
     );
     toolSearchCatalogRef = preparedToolBase.toolSearchCatalogRef;
     const {
@@ -240,21 +236,18 @@ export async function runEmbeddedAttempt(
     runCleanups = preparedRunCleanups;
     prepStages.mark("core-plugin-tools");
     emitCorePluginToolStageSummary("core-plugin-tools", corePluginToolStages.snapshot());
-    const preparedBootstrap = await measureEmbeddedAgentPreparation(
-      "attempt.bootstrap",
-      () =>
-        prepareEmbeddedAttemptBootstrap({
-          attempt: params,
-          bootstrapWorkspaceDir: params.bootstrapWorkspaceDir,
-          effectiveWorkspace,
-          hasReadTool: toolsEnabled && toolsRaw.some((tool) => tool.name === "read"),
-          isRawModelRun,
-          markStage: (name) => prepStages.mark(name),
-          resolvedWorkspace,
-          sessionAgentId,
-          sessionLabel: params.sessionKey ?? params.sessionId,
-        }),
-      { config: params.config },
+    const preparedBootstrap = await prepare("attempt.bootstrap", () =>
+      prepareEmbeddedAttemptBootstrap({
+        attempt: params,
+        bootstrapWorkspaceDir: params.bootstrapWorkspaceDir,
+        effectiveWorkspace,
+        hasReadTool: toolsEnabled && toolsRaw.some((tool) => tool.name === "read"),
+        isRawModelRun,
+        markStage: (name) => prepStages.mark(name),
+        resolvedWorkspace,
+        sessionAgentId,
+        sessionLabel: params.sessionKey ?? params.sessionId,
+      }),
     );
     // Track sessions_yield tool invocation (callback pattern, like clientToolCallDetected)
     let yieldDetected = false;
@@ -264,20 +257,17 @@ export async function runEmbeddedAttempt(
     let abortSessionForYield: (() => void) | null = null;
     let queueYieldInterruptForSession: (() => void) | null = null;
     let yieldAbortSettled: Promise<void> | null = null;
-    const preparedBundleTools = await measureEmbeddedAgentPreparation(
-      "attempt.bundle-tools",
-      () =>
-        prepareEmbeddedAttemptBundleTools({
-          agentDir,
-          attempt: params,
-          effectiveWorkspace,
-          getCurrentAttemptPluginMetadataSnapshot,
-          getProviderRuntimeHandle,
-          isRawModelRun,
-          preparedToolBase,
-          sessionAgentId,
-        }),
-      { config: params.config },
+    const preparedBundleTools = await prepare("attempt.bundle-tools", () =>
+      prepareEmbeddedAttemptBundleTools({
+        agentDir,
+        attempt: params,
+        effectiveWorkspace,
+        getCurrentAttemptPluginMetadataSnapshot,
+        getProviderRuntimeHandle,
+        isRawModelRun,
+        preparedToolBase,
+        sessionAgentId,
+      }),
     );
     bundleMcpRuntime = preparedBundleTools.bundleMcpRuntime;
     bundleLspRuntime = preparedBundleTools.bundleLspRuntime;
@@ -285,29 +275,26 @@ export async function runEmbeddedAttempt(
     // Catalog preparation registers global run state before tool projection and
     // diagnostics, so arm cleanup before either can fail and leak the catalog.
     toolSearchCatalogApplied = toolSearchCatalogRef !== undefined;
-    const preparedToolCatalog = measureEmbeddedAgentPreparationSync(
-      "attempt.tool-catalog",
-      () =>
-        prepareEmbeddedAttemptToolCatalog({
-          attempt: params,
-          preparedToolBase,
-          bundleTools: { clientTools, uncompactedEffectiveTools },
-          effectiveCwd,
-          effectiveWorkspace,
-          sessionAgentId,
-          sandboxSessionKey,
-          runTrace,
-          abortSignal: runAbortController.signal,
-          executeCodeModeTool: (toolParams) => {
-            if (!toolSearchCatalogExecutor) {
-              throw new Error("Code Mode catalog executor is unavailable for this run.");
-            }
-            return toolSearchCatalogExecutor(toolParams);
-          },
-          getProviderRuntimeHandle,
-          markStage: (name) => prepStages.mark(name),
-        }),
-      { config: params.config },
+    const preparedToolCatalog = await prepare("attempt.tool-catalog", () =>
+      prepareEmbeddedAttemptToolCatalog({
+        attempt: params,
+        preparedToolBase,
+        bundleTools: { clientTools, uncompactedEffectiveTools },
+        effectiveCwd,
+        effectiveWorkspace,
+        sessionAgentId,
+        sandboxSessionKey,
+        runTrace,
+        abortSignal: runAbortController.signal,
+        executeCodeModeTool: (toolParams) => {
+          if (!toolSearchCatalogExecutor) {
+            throw new Error("Code Mode catalog executor is unavailable for this run.");
+          }
+          return toolSearchCatalogExecutor(toolParams);
+        },
+        getProviderRuntimeHandle,
+        markStage: (name) => prepStages.mark(name),
+      }),
     );
     const {
       catalogToolHookContext,
@@ -317,33 +304,29 @@ export async function runEmbeddedAttempt(
       toolSearchRunPlan,
     } = preparedToolCatalog;
     toolSearchCatalogApplied = toolSearch.catalogRegistered;
-    const preparedSystemPrompt = await measureEmbeddedAgentPreparation(
-      "attempt.system-prompt",
-      () =>
-        prepareEmbeddedAttemptSystemPrompt({
-          activeContextEngine,
-          attempt: params,
-          bootstrap: preparedBootstrap,
-          capabilityToolNames: toolSearchRunPlan.capabilityToolNames,
-          effectiveCwd,
-          effectiveTools,
-          effectiveWorkspace,
-          getProviderRuntimeHandle,
-          isRawModelRun,
-          markStage: (name) => prepStages.mark(name),
-          modelToolsEnabled: toolsEnabled,
-          proactiveSubagentOrchestration,
-          sandbox: sandbox ?? undefined,
-          sandboxSessionKey,
-          sessionAgentId,
-          skillsPrompt,
-          codeModeActive: codeModeControlsEnabledForRun,
-          toolSearchCatalogRef,
-          toolSearchDirectoryEnabled:
-            toolSearchControlsEnabledForRun && toolSearch.catalogRegistered,
-          toolSearchRuntimeConfig,
-        }),
-      { config: params.config },
+    const preparedSystemPrompt = await prepare("attempt.system-prompt", () =>
+      prepareEmbeddedAttemptSystemPrompt({
+        activeContextEngine,
+        attempt: params,
+        bootstrap: preparedBootstrap,
+        capabilityToolNames: toolSearchRunPlan.capabilityToolNames,
+        effectiveCwd,
+        effectiveTools,
+        effectiveWorkspace,
+        getProviderRuntimeHandle,
+        isRawModelRun,
+        markStage: (name) => prepStages.mark(name),
+        modelToolsEnabled: toolsEnabled,
+        proactiveSubagentOrchestration,
+        sandbox: sandbox ?? undefined,
+        sandboxSessionKey,
+        sessionAgentId,
+        skillsPrompt,
+        codeModeActive: codeModeControlsEnabledForRun,
+        toolSearchCatalogRef,
+        toolSearchDirectoryEnabled: toolSearchControlsEnabledForRun && toolSearch.catalogRegistered,
+        toolSearchRuntimeConfig,
+      }),
     );
     let sessionManager: ReturnType<typeof guardSessionManager> | undefined;
     const {
@@ -351,14 +334,11 @@ export async function runEmbeddedAttempt(
       ownedTranscriptWriteContext,
       transcriptLifecycle,
       withOwnedTranscriptWrite,
-    } = await measureEmbeddedAgentPreparation(
-      "attempt.transcript-lifecycle",
-      () =>
-        prepareEmbeddedAttemptTranscriptLifecycle({
-          attempt: params,
-          externalAbortController,
-        }),
-      { config: params.config },
+    } = await prepare("attempt.transcript-lifecycle", () =>
+      prepareEmbeddedAttemptTranscriptLifecycle({
+        attempt: params,
+        externalAbortController,
+      }),
     );
 
     let session: AgentSession | undefined;
@@ -368,90 +348,87 @@ export async function runEmbeddedAttempt(
     >["trajectoryRecorder"] = null;
     let buildAbortSettlePromise: () => Promise<void> | null = () => null;
     try {
-      const preparedSessionRuntime = await measureEmbeddedAgentPreparation(
-        "attempt.session-runtime",
-        () =>
-          prepareEmbeddedAttemptSessionRuntime({
-            attempt: params,
-            ...(activeContextEngine ? { activeContextEngine } : {}),
-            agentDir,
-            effectiveCwd,
-            effectiveFsWorkspaceOnly,
-            effectiveWorkspace,
-            initialSystemPrompt: preparedSystemPrompt.systemPromptText,
-            isRawModelRun,
-            nestedToolActivities: preparedToolBase.nestedToolActivities,
-            sessionManager: {
-              replayAllowedToolNames: toolSearchRunPlan.replayAllowedToolNames,
-              resolveActiveContextEnginePluginId,
-              sessionAgentId,
-              transcriptLifecycle,
-              withOwnedTranscriptWrite,
-            },
-            agentSession: {
-              agentCoreThinkingLevel,
-              clientToolPreparation: {
-                catalogToolHookContext,
-                clientTools,
-                codeModeControlsEnabledForRun,
-                deferredDirectoryToolsCallable,
-                effectiveTools,
-                replaySafetyOptions,
-                sandboxEnabled: Boolean(sandbox?.enabled),
-                sandboxSessionKey,
-                sessionAgentId,
-                toolSearchCatalogRef,
-                toolSearchRuntimeConfig,
-                uncompactedEffectiveTools,
-              },
-              getCurrentAttemptPluginMetadataSnapshot,
-              markStage: (stage) => prepStages.mark(stage),
-              runAbortSignal: runAbortController.signal,
-            },
-            contextGuards: { computerContextEpoch },
-            trajectory: {
-              effectiveToolCount: effectiveTools.length,
-              localModelLeanEnabled,
-              ...(preparedSystemPrompt.systemPromptReport
-                ? { systemPromptReport: preparedSystemPrompt.systemPromptReport }
-                : {}),
-            },
-            transport: {
-              abortSignal: runAbortController.signal,
-              codeModeControlsEnabled: codeModeControlsEnabledForRun,
-              getProviderRuntimeHandle,
-              providerThinkingLevel,
-              ...(sandbox !== undefined ? { sandbox } : {}),
+      const preparedSessionRuntime = await prepare("attempt.session-runtime", () =>
+        prepareEmbeddedAttemptSessionRuntime({
+          attempt: params,
+          ...(activeContextEngine ? { activeContextEngine } : {}),
+          agentDir,
+          effectiveCwd,
+          effectiveFsWorkspaceOnly,
+          effectiveWorkspace,
+          initialSystemPrompt: preparedSystemPrompt.systemPromptText,
+          isRawModelRun,
+          nestedToolActivities: preparedToolBase.nestedToolActivities,
+          sessionManager: {
+            replayAllowedToolNames: toolSearchRunPlan.replayAllowedToolNames,
+            resolveActiveContextEnginePluginId,
+            sessionAgentId,
+            transcriptLifecycle,
+            withOwnedTranscriptWrite,
+          },
+          agentSession: {
+            agentCoreThinkingLevel,
+            clientToolPreparation: {
+              catalogToolHookContext,
+              clientTools,
+              codeModeControlsEnabledForRun,
+              deferredDirectoryToolsCallable,
+              effectiveTools,
+              replaySafetyOptions,
+              sandboxEnabled: Boolean(sandbox?.enabled),
               sandboxSessionKey,
+              sessionAgentId,
+              toolSearchCatalogRef,
+              toolSearchRuntimeConfig,
+              uncompactedEffectiveTools,
             },
-            externalAbortController,
-            lifecycle: {
-              onContextGuardsInstalled: (remove) => {
-                removeToolResultContextGuard = remove;
-              },
-              onSessionCreated: (createdSession) => {
-                session = createdSession;
-              },
-              onSessionManagerCreated: (createdSessionManager) => {
-                sessionManager = createdSessionManager;
-              },
-              onSessionSettleTrackerReady: (build) => {
-                buildAbortSettlePromise = build;
-              },
-              onSessionYieldReady: ({ abortActiveSession, activeSession }) => {
-                abortSessionForYield = () => {
-                  yieldAbortSettled = abortActiveSession(SESSIONS_YIELD_ABORT_REASON);
-                };
-                queueYieldInterruptForSession = () => {
-                  queueSessionsYieldInterruptMessage(activeSession);
-                };
-              },
-              onTrajectoryRecorderCreated: (recorder) => {
-                trajectoryRecorder = recorder;
-              },
+            getCurrentAttemptPluginMetadataSnapshot,
+            markStage: (stage) => prepStages.mark(stage),
+            runAbortSignal: runAbortController.signal,
+          },
+          contextGuards: { computerContextEpoch },
+          trajectory: {
+            effectiveToolCount: effectiveTools.length,
+            localModelLeanEnabled,
+            ...(preparedSystemPrompt.systemPromptReport
+              ? { systemPromptReport: preparedSystemPrompt.systemPromptReport }
+              : {}),
+          },
+          transport: {
+            abortSignal: runAbortController.signal,
+            codeModeControlsEnabled: codeModeControlsEnabledForRun,
+            getProviderRuntimeHandle,
+            providerThinkingLevel,
+            ...(sandbox !== undefined ? { sandbox } : {}),
+            sandboxSessionKey,
+          },
+          externalAbortController,
+          lifecycle: {
+            onContextGuardsInstalled: (remove) => {
+              removeToolResultContextGuard = remove;
             },
-          }),
-        { config: params.config },
+            onSessionCreated: (createdSession) => {
+              session = createdSession;
+            },
+            onSessionManagerCreated: (createdSessionManager) => {
+              sessionManager = createdSessionManager;
+            },
+            onSessionSettleTrackerReady: (build) => {
+              buildAbortSettlePromise = build;
+            },
+            onSessionYieldReady: ({ abortActiveSession, activeSession }) => {
+              abortSessionForYield = () => {
+                yieldAbortSettled = abortActiveSession(SESSIONS_YIELD_ABORT_REASON);
+              };
+              queueYieldInterruptForSession = () => {
+                queueSessionsYieldInterruptMessage(activeSession);
+              };
+            },
+            onTrajectoryRecorderCreated: (recorder) => {
+              trajectoryRecorder = recorder;
+            },
+          },
+        }),
       );
       const executionResult = await runEmbeddedAttemptExecutionPhase({
         attempt: params,

--- a/src/agents/embedded-agent-runner/run/preparation-timing.test.ts
+++ b/src/agents/embedded-agent-runner/run/preparation-timing.test.ts
@@ -1,11 +1,12 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
-import {
-  measureEmbeddedAgentPreparation,
-  measureEmbeddedAgentPreparationSync,
-} from "./preparation-timing.js";
+import { createEmbeddedAttemptPreparation } from "./attempt-preparation.js";
+import { measureEmbeddedAgentPreparation } from "./preparation-timing.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -32,7 +33,7 @@ describe("embedded agent preparation timing", () => {
     const { env, path } = await createTimelineEnv();
 
     await measureEmbeddedAgentPreparation("runtime", async () => "async", { env });
-    expect(measureEmbeddedAgentPreparationSync("attempt.tool-base", () => "sync", { env })).toBe(
+    expect(await measureEmbeddedAgentPreparation("attempt.tool-base", () => "sync", { env })).toBe(
       "sync",
     );
 
@@ -55,5 +56,77 @@ describe("embedded agent preparation timing", () => {
       { stage: "attempt.tool-base" },
       { stage: "attempt.tool-base" },
     ]);
+  });
+});
+
+const prepare = createEmbeddedAttemptPreparation({ assertCurrent: () => {} });
+
+describe("embedded attempt preparation dispatch", () => {
+  it("lets control callbacks advance before a burst of preparation stages finishes", async () => {
+    const started: number[] = [];
+    let observedStarts = -1;
+    const controlCallback = createDeferred();
+    await Promise.all(
+      Array.from({ length: 32 }, (_, index) =>
+        prepare("attempt.tool-catalog", () => {
+          started.push(index);
+          if (index === 0) {
+            setImmediate(() => {
+              observedStarts = started.length;
+              controlCallback.resolve();
+            });
+          }
+        }),
+      ),
+    );
+    await controlCallback.promise;
+    expect(started).toEqual(Array.from({ length: 32 }, (_, index) => index));
+    expect(observedStarts).toBe(1);
+  });
+
+  it("preserves caller context and overlaps asynchronous preparation", async () => {
+    const context = new AsyncLocalStorage<string>();
+    const observed: Array<string | undefined> = [];
+    const firstWait = createDeferred();
+    const first = context.run("first", () =>
+      prepare("attempt.bootstrap", async () => {
+        observed.push(context.getStore());
+        await firstWait.promise;
+        observed.push(context.getStore());
+      }),
+    );
+    const second = context.run("second", () =>
+      prepare("attempt.bootstrap", async () => {
+        observed.push(context.getStore());
+        await yieldToEventLoop();
+        firstWait.resolve();
+      }),
+    );
+    await Promise.all([first, second]);
+    expect(observed).toEqual(["first", "second", "first"]);
+  });
+
+  it("rejects stale queued work before acquisition without blocking other attempts", async () => {
+    const controller = new AbortController();
+    const cancelled = createEmbeddedAttemptPreparation({
+      assertCurrent: () => controller.signal.throwIfAborted(),
+    });
+    const acquire = vi.fn();
+    const pending = cancelled("attempt.bundle-tools", acquire);
+    const failure = new Error("cancelled before acquisition");
+    controller.abort(failure);
+    await expect(pending).rejects.toBe(failure);
+    expect(acquire).not.toHaveBeenCalled();
+    await expect(prepare("attempt.tool-catalog", () => "next attempt")).resolves.toBe(
+      "next attempt",
+    );
+    await expect(
+      prepare("attempt.tool-catalog", () => {
+        throw failure;
+      }),
+    ).rejects.toBe(failure);
+    await expect(prepare("attempt.tool-catalog", () => "after failure")).resolves.toBe(
+      "after failure",
+    );
   });
 });

--- a/src/agents/embedded-agent-runner/run/preparation-timing.ts
+++ b/src/agents/embedded-agent-runner/run/preparation-timing.ts
@@ -1,8 +1,5 @@
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import {
-  measureDiagnosticsTimelineSpan,
-  measureDiagnosticsTimelineSpanSync,
-} from "../../../infra/diagnostics-timeline.js";
+import { measureDiagnosticsTimelineSpan } from "../../../infra/diagnostics-timeline.js";
 
 type EmbeddedAgentPreparationTimingOptions = {
   config?: OpenClawConfig;
@@ -25,13 +22,4 @@ export function measureEmbeddedAgentPreparation<T>(
   options: EmbeddedAgentPreparationTimingOptions = {},
 ): Promise<T> {
   return measureDiagnosticsTimelineSpan("agent.prepare", run, timingOptions(stage, options));
-}
-
-/** Measures synchronous pre-provider work under the canonical agent preparation span. */
-export function measureEmbeddedAgentPreparationSync<T>(
-  stage: string,
-  run: () => T,
-  options: EmbeddedAgentPreparationTimingOptions = {},
-): T {
-  return measureDiagnosticsTimelineSpanSync("agent.prepare", run, timingOptions(stage, options));
 }

--- a/src/gateway/plugin-metadata.test-helpers.ts
+++ b/src/gateway/plugin-metadata.test-helpers.ts
@@ -1,3 +1,4 @@
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 
 function ownerEntries(value: ReadonlyMap<string, readonly string[]>) {
@@ -32,7 +33,7 @@ export function assertPluginMetadataSnapshotConsistency(snapshot: PluginMetadata
       throw new Error(`plugin metadata fixture lookup diverged for ${plugin.id}`);
     }
     const providers = new Set(plugin.providers);
-    const cliBackends = new Set(plugin.cliBackends);
+    const cliBackends = new Set([...plugin.cliBackends, ...(plugin.setup?.cliBackends ?? [])]);
     const authRefs = new Set([
       ...(plugin.providerAuthChoices ?? []).map((choice) => choice.choiceId),
       ...(plugin.providerAuthChoices ?? []).flatMap((choice) => choice.deprecatedChoiceIds ?? []),
@@ -55,7 +56,7 @@ export function assertPluginMetadataSnapshotConsistency(snapshot: PluginMetadata
       }
     }
     for (const backend of cliBackends) {
-      appendOwner(expectedCliBackendOwners, backend, plugin.id);
+      appendOwner(expectedCliBackendOwners, normalizeProviderId(backend), plugin.id);
     }
     for (const ref of plugin.syntheticAuthRefs ?? []) {
       if (!providers.has(ref) && !cliBackends.has(ref) && !authRefs.has(ref)) {

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -1,3 +1,4 @@
+import { performance } from "node:perf_hooks";
 import { expectDefined } from "@openclaw/normalization-core";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -71,12 +72,9 @@ import type {
   SessionsListResult,
 } from "./session-utils.types.js";
 
-/**
- * Number of session rows to build per batch before yielding to the event loop.
- * Keeps the main thread responsive during large session list operations while
- * avoiding excessive yielding overhead for small stores.
- */
-const SESSIONS_LIST_YIELD_BATCH_SIZE = 10;
+// Bound synchronous projection work without repeatedly requeueing cheap prepared rows.
+const SESSIONS_LIST_YIELD_INTERVAL_MS = 12;
+const SESSIONS_LIST_ROW_CONTEXT_THRESHOLD = 10;
 
 const SESSIONS_LIST_DEFAULT_LIMIT = 100;
 const SESSIONS_LIST_TRANSCRIPT_FIELD_ROWS = 100;
@@ -486,7 +484,7 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
     Boolean(rowContext) ||
     hasSpawnedByFilter ||
     filteredSessionKeys.size > 0 ||
-    selection.entries.length > SESSIONS_LIST_YIELD_BATCH_SIZE;
+    selection.entries.length > SESSIONS_LIST_ROW_CONTEXT_THRESHOLD;
   const sharedRowContext =
     usePreparedChildReads || selection.entries.length > 0 ? getRowContext() : undefined;
   const storePath = hasIncognito ? params.storePath : (params.durableStorePath ?? params.storePath);
@@ -523,30 +521,28 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
   };
 }
 
-function buildSessionsListResult(params: {
-  cfg: OpenClawConfig;
-  agentId?: string;
-  list: ReturnType<typeof prepareSessionList>;
-  modelCatalog?: SessionListModelCatalog | ModelCatalogEntry[];
-  sessions: GatewaySessionRow[];
-}): SessionsListResult {
-  const { list, sessions } = params;
+function buildSessionsListResult(
+  params: ListSessionsFromStoreParams,
+  list: ReturnType<typeof prepareSessionList>,
+  sessions: GatewaySessionRow[],
+): SessionsListResult {
+  const { cfg, opts, modelCatalog } = params;
   // The defaults projection uses the same agent identity as getSessionDefaults:
   // the requested agent when scoped, otherwise the legacy compatibility agent.
   // Legacy plain-array catalogs (direct list callers) pass through
   // unchanged; per-agent maps resolve by the same identity.
   const preparedDefaultsCatalog =
-    params.modelCatalog instanceof Map
-      ? params.modelCatalog.get(
-          params.agentId
-            ? normalizeAgentId(params.agentId)
+    modelCatalog instanceof Map
+      ? modelCatalog.get(
+          opts.agentId
+            ? normalizeAgentId(opts.agentId)
             : normalizeAgentId(
-                tryResolveLegacyCompatibilityAgentId(params.cfg) ?? LEGACY_IMPLICIT_AGENT_ID,
+                tryResolveLegacyCompatibilityAgentId(cfg) ?? LEGACY_IMPLICIT_AGENT_ID,
               ),
         )
       : undefined;
   const defaultsCatalog =
-    params.modelCatalog instanceof Map ? preparedDefaultsCatalog?.entries : params.modelCatalog;
+    modelCatalog instanceof Map ? preparedDefaultsCatalog?.entries : modelCatalog;
   return {
     ts: list.now,
     path: list.storePath,
@@ -565,8 +561,8 @@ function buildSessionsListResult(params: {
           peopleSessionCount: list.peopleSessionCount,
         }
       : {}),
-    defaults: getSessionDefaults(params.cfg, defaultsCatalog, {
-      ...(params.agentId ? { agentId: params.agentId } : {}),
+    defaults: getSessionDefaults(cfg, defaultsCatalog, {
+      ...(opts.agentId ? { agentId: opts.agentId } : {}),
       allowPluginNormalization: false,
       providerPolicySource: preparedDefaultsCatalog?.pluginRegistry,
     }),
@@ -586,7 +582,7 @@ export function filterAndSortSessionEntries(params: {
   return selectSessionEntries(params).entries;
 }
 
-/** Build rows in batches so session lists do not starve other Gateway work. */
+/** Projects lightweight list rows while sharing the event loop with other requests. */
 export async function listSessionsFromStoreAsync(
   params: ListSessionsFromStoreParams,
 ): Promise<SessionsListResult> {
@@ -596,6 +592,7 @@ export async function listSessionsFromStoreAsync(
   // between rows, the memo never hits, and each row triggers a full
   // loadPluginMetadataSnapshot scan (~100 ms).
   return withPinnedActivePluginRegistryWorkspaceDir(async () => {
+    let workStartedAt = performance.now();
     const { cfg, store, opts } = params;
     const list = prepareSessionList(params);
     const sessions: GatewaySessionRow[] = [];
@@ -663,21 +660,18 @@ export async function listSessionsFromStoreAsync(
         }
       }
       sessions.push(row);
-      // Yield to the event loop between batches so WebSocket heartbeats,
-      // channel I/O, and concurrent RPC calls are not starved.
-      if ((i + 1) % SESSIONS_LIST_YIELD_BATCH_SIZE === 0 && i + 1 < list.entries.length) {
+      if (
+        i + 1 < list.entries.length &&
+        performance.now() - workStartedAt >= SESSIONS_LIST_YIELD_INTERVAL_MS
+      ) {
         await new Promise<void>((resolve) => {
           setImmediate(resolve);
         });
+        // Waiting behind other work is not projection work; start the next budget on resume.
+        workStartedAt = performance.now();
       }
     }
 
-    return buildSessionsListResult({
-      cfg,
-      list,
-      modelCatalog: params.modelCatalog,
-      sessions,
-      agentId: opts.agentId,
-    });
+    return buildSessionsListResult(params, list, sessions);
   });
 }

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -1,6 +1,7 @@
 // Session utility performance tests protect resolver cache scaling for large
 // session lists with repeated provider/model tuples.
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, test, expect, vi } from "vitest";
 import {
@@ -22,6 +23,7 @@ import * as titleReader from "./session-transcript-title-reader.js";
 import { resolveEstimatedSessionCostUsd } from "./session-utils-core.js";
 import { resolveGatewaySessionThinkingProjectionInternal } from "./session-utils-model.js";
 import { buildSessionListRowMetadataContext } from "./session-utils-projection.js";
+import * as rowProjection from "./session-utils-row.js";
 import { listSessionsFromStoreAsync } from "./session-utils.js";
 
 /**
@@ -36,6 +38,59 @@ import { listSessionsFromStoreAsync } from "./session-utils.js";
  * are the actual scaling failure mode we care about.
  */
 describe("session list resolver cache", () => {
+  test.each([
+    { rowWorkMs: 0, shouldYield: false },
+    { rowWorkMs: 20, shouldYield: true },
+  ])(
+    "yields for row work rather than row count ($rowWorkMs ms)",
+    async ({ rowWorkMs, shouldYield }) => {
+      await withStateDirEnv("openclaw-list-work-budget-", async ({ stateDir }) => {
+        resetPluginRuntimeStateForTest();
+        setActivePluginRegistry(createEmptyPluginRegistry());
+        const cfg: OpenClawConfig = {};
+        resetConfigRuntimeState();
+        setRuntimeConfigSnapshot(cfg);
+        const store = Object.fromEntries(
+          Array.from({ length: 32 }, (_, index) => [
+            `agent:main:budget-${index}`,
+            { sessionId: `budget-${index}`, updatedAt: index + 1 },
+          ]),
+        );
+        let workMs = 0;
+        const buildRow = rowProjection.buildGatewaySessionRow;
+        const clock = vi.spyOn(performance, "now").mockImplementation(() => workMs);
+        const rows = vi
+          .spyOn(rowProjection, "buildGatewaySessionRow")
+          .mockImplementation((params) => {
+            const row = buildRow(params);
+            workMs += rowWorkMs;
+            return row;
+          });
+        let controlRan = false;
+        const controlCallback = new Promise<void>((resolve) => {
+          setImmediate(() => {
+            controlRan = true;
+            resolve();
+          });
+        });
+        try {
+          const result = await listSessionsFromStoreAsync({
+            cfg,
+            storePath: path.join(stateDir, "sessions.json"),
+            store,
+            opts: {},
+          });
+          expect(result.sessions.map((row) => row.key)).toEqual(Object.keys(store).toReversed());
+          expect(controlRan).toBe(shouldYield);
+        } finally {
+          rows.mockRestore();
+          clock.mockRestore();
+          await controlCallback;
+        }
+      });
+    },
+  );
+
   test("collapses request-local resolver work to O(unique provider/model tuples)", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/gateway/session-utils.plugin-runtime.test.ts
+++ b/src/gateway/session-utils.plugin-runtime.test.ts
@@ -11,10 +11,7 @@ const normalizeProviderModelIdWithPluginMock = vi.fn();
 const loadPluginManifestRegistryCoreMock = vi.hoisted(() =>
   vi.fn(() => ({ plugins: [], diagnostics: [] })),
 );
-const emptyPluginMetadataSnapshot = vi.hoisted(() => ({
-  configFingerprint: "gateway-session-utils-plugin-runtime-test-empty-plugin-metadata",
-  plugins: [],
-}));
+const getCurrentPluginMetadataSnapshotMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../agents/provider-model-normalization.runtime.js", () => ({
   normalizeProviderModelIdWithRuntime: (params: unknown) =>
@@ -23,7 +20,7 @@ vi.mock("../agents/provider-model-normalization.runtime.js", () => ({
 
 vi.mock("../plugins/current-plugin-metadata-snapshot.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../plugins/current-plugin-metadata-snapshot.js")>()),
-  getCurrentPluginMetadataSnapshot: () => emptyPluginMetadataSnapshot,
+  getCurrentPluginMetadataSnapshot: getCurrentPluginMetadataSnapshotMock,
 }));
 
 vi.mock("../plugins/manifest-registry.js", async (importOriginal) => ({
@@ -36,6 +33,9 @@ let sessionUtils: typeof import("./session-utils.js");
 describe("gateway session list plugin runtime normalization", () => {
   beforeAll(async () => {
     vi.resetModules();
+    const { createPluginMetadataSnapshotFixture } =
+      await import("../plugins/plugin-metadata.test-support.js");
+    getCurrentPluginMetadataSnapshotMock.mockReturnValue(createPluginMetadataSnapshotFixture());
     sessionUtils = await import("./session-utils.js");
   });
 

--- a/src/plugins/bundled-dir.test.ts
+++ b/src/plugins/bundled-dir.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as openClawRoot from "../infra/openclaw-root.js";
 import {
   resolveBundledPluginsDir,
   resolveSourceCheckoutDependencyDiagnostic,
@@ -402,23 +403,61 @@ describe("resolveBundledPluginsDir", () => {
     expect(fs.readdirSync(bundledDir)).toStrictEqual([]);
   });
 
-  it("separates tilde override cache entries by OPENCLAW_HOME", () => {
-    const homeA = makeRepoRoot("openclaw-bundled-dir-home-a-");
-    const homeB = makeRepoRoot("openclaw-bundled-dir-home-b-");
-    seedBundledPluginTree(homeA, "bundled", "memory-core");
-    seedBundledPluginTree(homeB, "bundled", "discord");
-    const envBase = {
-      OPENCLAW_BUNDLED_PLUGINS_DIR: "~/bundled",
-      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
-      VITEST: "true",
-    } satisfies NodeJS.ProcessEnv;
+  it("reuses the prepared bundled root until its cache owner changes", () => {
+    const repoRoot = fs.realpathSync(
+      createOpenClawRoot({
+        prefix: "openclaw-bundled-dir-owner-",
+        hasExtensions: true,
+        hasSrc: true,
+        hasPnpmWorkspace: true,
+      }),
+    );
+    seedBundledPluginTree(repoRoot, "extensions");
+    const owner = createPluginCache();
+    withPluginCache(owner, () =>
+      expectResolvedBundledDirFromRoot({ repoRoot, expectedRelativeDir: "extensions" }),
+    );
 
-    const bundledA = resolveBundledPluginsDir({ ...envBase, OPENCLAW_HOME: homeA });
-    const bundledB = resolveBundledPluginsDir({ ...envBase, OPENCLAW_HOME: homeB });
+    const resolveRoot = vi.spyOn(openClawRoot, "resolveOpenClawPackageRootSync");
+    const sourceDir = path.join(repoRoot, "extensions");
+    expect(withPluginCache(owner, resolveBundledPluginsDir)).toBe(sourceDir);
+    seedBundledPluginTree(repoRoot, path.join("dist", "extensions"));
+    expect(withPluginCache(owner, resolveBundledPluginsDir)).toBe(sourceDir);
+    expect(resolveRoot).not.toHaveBeenCalled();
 
-    expect(fs.realpathSync(bundledA ?? "")).toBe(fs.realpathSync(path.join(homeA, "bundled")));
-    expect(fs.realpathSync(bundledB ?? "")).toBe(fs.realpathSync(path.join(homeB, "bundled")));
+    expect(withPluginCache(createPluginCache(), resolveBundledPluginsDir)).toBe(
+      path.join(repoRoot, "dist", "extensions"),
+    );
+    expect(withPluginCache(owner, resolveBundledPluginsDir)).toBe(sourceDir);
   });
+
+  it.each(["OPENCLAW_HOME", "HOME", "USERPROFILE", "cwd"] as const)(
+    "separates relative override resolution by %s within one cache owner",
+    (homeSource) => {
+      const homeA = makeRepoRoot("openclaw-bundled-dir-home-a-");
+      const homeB = makeRepoRoot("openclaw-bundled-dir-home-b-");
+      seedBundledPluginTree(homeA, "bundled", "memory-core");
+      seedBundledPluginTree(homeB, "bundled", "discord");
+      const envBase = {
+        OPENCLAW_BUNDLED_PLUGINS_DIR: homeSource === "cwd" ? "./bundled" : "~/bundled",
+        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+        VITEST: "true",
+      } satisfies NodeJS.ProcessEnv;
+
+      const cwd = vi.spyOn(process, "cwd");
+      withPluginCache(createPluginCache(), () => {
+        for (const home of [homeA, homeB, homeA]) {
+          if (homeSource === "cwd") {
+            cwd.mockReturnValue(home);
+          }
+          const env = homeSource === "cwd" ? envBase : { ...envBase, [homeSource]: home };
+          expect(fs.realpathSync(resolveBundledPluginsDir(env) ?? "")).toBe(
+            fs.realpathSync(path.join(home, "bundled")),
+          );
+        }
+      });
+    },
+  );
 
   it("ignores an existing override under an argv1-derived fake package root", () => {
     const installedRoot = createOpenClawRoot({

--- a/src/plugins/bundled-dir.ts
+++ b/src/plugins/bundled-dir.ts
@@ -8,6 +8,7 @@ import { uniqueStrings } from "@openclaw/normalization-core/string-normalization
 import { isTruthyEnvValue, isVitestRuntimeEnv } from "../infra/env.js";
 import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
 import { isPathInside } from "../infra/path-guards.js";
+import { tryProcessCwd } from "../infra/safe-cwd.js";
 import { resolveUserPath } from "../utils.js";
 import {
   pluginCacheExistsSync,
@@ -15,6 +16,7 @@ import {
   readPluginCacheDirectory,
   refreshPluginCacheStat,
 } from "./plugin-cache-files.js";
+import { getPluginCache } from "./plugin-cache.js";
 
 const DISABLED_BUNDLED_PLUGINS_DIR = path.join(os.tmpdir(), "openclaw-empty-bundled-plugins");
 const TEST_TRUST_BUNDLED_PLUGINS_DIR_ENV = "OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR";
@@ -164,39 +166,22 @@ export function isPluginInPackageBundledRoots(params: {
 }
 
 function resolveBundledDirFromPackageRoot(packageRoot: string): string | undefined {
-  const sourceExtensionsDir = path.join(packageRoot, "extensions");
   const builtExtensionsDir = path.join(packageRoot, "dist", "extensions");
-  const sourceCheckout = isSourceCheckoutRoot(packageRoot);
-  const hasUsableSourceTree = sourceCheckout && hasUsableBundledPluginTree(sourceExtensionsDir);
   // In pnpm source checkouts, prefer the built bundled plugin runtime when it
   // exists so dist gateway runs avoid loading TS plugin entrypoints through jiti.
   // Keep the source tree as the fallback for fresh checkouts before build.
   const runtimeExtensionsDir = path.join(packageRoot, "dist-runtime", "extensions");
-  const hasUsableRuntimeTree = sourceCheckout
-    ? hasUsableBundledPluginTree(runtimeExtensionsDir)
-    : pluginCacheExistsSync(runtimeExtensionsDir);
-  const hasUsableBuiltTree = sourceCheckout
-    ? hasUsableBundledPluginTree(builtExtensionsDir)
-    : pluginCacheExistsSync(builtExtensionsDir);
-  if (sourceCheckout && hasUsableBuiltTree) {
-    return builtExtensionsDir;
+  if (isSourceCheckoutRoot(packageRoot)) {
+    return [builtExtensionsDir, runtimeExtensionsDir, path.join(packageRoot, "extensions")].find(
+      hasUsableBundledPluginTree,
+    );
   }
-  if (sourceCheckout && hasUsableRuntimeTree) {
-    return runtimeExtensionsDir;
-  }
-  if (hasUsableRuntimeTree && hasUsableBuiltTree) {
-    return runtimeExtensionsDir;
-  }
-  if (hasUsableBuiltTree) {
-    return builtExtensionsDir;
-  }
-  if (hasUsableSourceTree) {
-    return sourceExtensionsDir;
-  }
-  return undefined;
+  return pluginCacheExistsSync(builtExtensionsDir)
+    ? [runtimeExtensionsDir, builtExtensionsDir].find(pluginCacheExistsSync)
+    : undefined;
 }
 
-export function resolveBundledPluginsDir(env: NodeJS.ProcessEnv = process.env): string | undefined {
+function resolveBundledPluginsDirUncached(env: NodeJS.ProcessEnv): string | undefined {
   if (areBundledPluginsDisabled(env)) {
     return resolveDisabledBundledPluginsDir();
   }
@@ -276,4 +261,25 @@ export function resolveBundledPluginsDir(env: NodeJS.ProcessEnv = process.env): 
   }
 
   return undefined;
+}
+
+export function resolveBundledPluginsDir(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const disabled = areBundledPluginsDisabled(env);
+  const override = disabled ? undefined : env.OPENCLAW_BUNDLED_PLUGINS_DIR?.trim();
+  const key = JSON.stringify([
+    import.meta.url,
+    disabled,
+    override ? resolveUserPath(override, env) : undefined,
+    shouldTrustTestBundledPluginsDirOverride(env),
+    process.argv[1],
+    process.execPath,
+    tryProcessCwd(),
+  ]);
+  const metadata = getPluginCache().metadata;
+  // Reuse the selected root, not just its filesystem facts. Management scopes and
+  // Gateway restart acquire a new owner; config activation retains this inventory.
+  if (metadata.bundledPluginsDir?.key !== key) {
+    metadata.bundledPluginsDir = { key, value: resolveBundledPluginsDirUncached(env) };
+  }
+  return metadata.bundledPluginsDir.value;
 }

--- a/src/plugins/plugin-cache-metadata.ts
+++ b/src/plugins/plugin-cache-metadata.ts
@@ -22,6 +22,7 @@ type CurrentPluginMetadataCacheState = {
 
 export type PluginCacheMetadata = {
   metadata: {
+    bundledPluginsDir?: { key: string; value: string | undefined };
     bundledDiscoveryMode?: { value: "compat" | "allowlist" | undefined };
     current: CurrentPluginMetadataCacheState;
     snapshots: Map<string, PluginMetadataSnapshot>;

--- a/src/plugins/plugin-metadata-snapshot.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.test.ts
@@ -758,13 +758,15 @@ describe("plugin metadata snapshot", () => {
     },
   );
 
-  it("prepares provider endpoint and request facts", () => {
+  it("prepares normalized CLI ownership, provider endpoint, and request facts", () => {
     const index = makeIndex();
     const registry = makeManifestRegistry();
     const plugin = registry.plugins[0];
     if (!plugin) {
       throw new Error("expected manifest plugin fixture");
     }
+    plugin.cliBackends = ["DEMO-CLI"];
+    plugin.setup = { cliBackends: ["Demo-CLI", "Other-CLI"] };
     plugin.providerEndpoints = [
       {
         endpointClass: "openai-public",
@@ -790,6 +792,10 @@ describe("plugin metadata snapshot", () => {
 
     const snapshot = loadPluginMetadataSnapshot({ config: {}, env: {}, index });
 
+    expect([...snapshot.owners.cliBackends]).toEqual([
+      ["demo-cli", ["demo"]],
+      ["other-cli", ["demo"]],
+    ]);
     expect(snapshot.owners.providerEndpoints).toContainEqual({
       endpointClass: "openai-public",
       hosts: ["api.example.com"],

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -249,10 +249,10 @@ function buildPluginMetadataOwnerMaps(
       appendOwner(modelCatalogProviders, providerId, plugin.id);
     }
     for (const cliBackendId of plugin.cliBackends ?? []) {
-      appendOwner(cliBackends, cliBackendId, plugin.id);
+      appendOwner(cliBackends, normalizeProviderId(cliBackendId), plugin.id);
     }
     for (const cliBackendId of plugin.setup?.cliBackends ?? []) {
-      appendOwner(cliBackends, cliBackendId, plugin.id);
+      appendOwner(cliBackends, normalizeProviderId(cliBackendId), plugin.id);
     }
     for (const setupProvider of plugin.setup?.providers ?? []) {
       appendOwner(setupProviders, setupProvider.id, plugin.id);

--- a/src/plugins/setup-registry.runtime.test.ts
+++ b/src/plugins/setup-registry.runtime.test.ts
@@ -4,12 +4,12 @@ import { withPluginMetadataSnapshotScope } from "./current-plugin-metadata-snaps
 import { setCurrentPluginMetadataSnapshot } from "./current-plugin-metadata.test-support.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import * as installedPluginIndex from "./installed-plugin-index.js";
-import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import {
   projectPluginMetadataSnapshot,
   type PluginMetadataSnapshot,
 } from "./plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "./plugin-metadata.test-support.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
 
@@ -50,6 +50,7 @@ afterEach(() => {
   loadPluginRegistrySnapshotMock.mockReset();
   loadPluginManifestRegistryForInstalledIndexMock.mockReset();
   loadPluginMetadataSnapshotMock.mockReset();
+  vi.restoreAllMocks();
 });
 
 function createCurrentSnapshot(params: {
@@ -58,67 +59,85 @@ function createCurrentSnapshot(params: {
   workspaceDir?: string;
 }): PluginMetadataSnapshot {
   const policyHash = resolveInstalledPluginIndexPolicyHash({});
-  const index: InstalledPluginIndex = {
-    version: 1,
-    hostContractVersion: "test-host",
-    compatRegistryVersion: "test-compat",
-    migrationVersion: 1,
-    policyHash,
-    generatedAtMs: 0,
-    installRecords: {},
+  const snapshot = createPluginMetadataSnapshotFixture({
     plugins: [
       {
-        pluginId: "openai",
-        manifestPath: `/tmp/openai-${params.manifestHash}/openclaw.plugin.json`,
-        manifestHash: params.manifestHash,
-        source: `/tmp/openai-${params.manifestHash}/index.ts`,
+        id: "openai",
         rootDir: `/tmp/openai-${params.manifestHash}`,
-        origin: "bundled",
-        enabled: true,
+        cliBackends: params.cliBackends,
         enabledByDefault: true,
-        startup: {
-          sidecar: false,
-          memory: false,
-          agentHarnesses: [],
-        },
-        compat: [],
       },
     ],
-    diagnostics: [],
-  };
-  const plugins = [
-    {
-      id: "openai",
-      origin: "bundled",
-      cliBackends: params.cliBackends,
-    },
-  ];
+  });
+  snapshot.index.policyHash = policyHash;
   return {
+    ...snapshot,
     policyHash,
     configFingerprint: params.manifestHash,
     workspaceDir: params.workspaceDir,
-    index,
-    plugins,
-    manifestRegistry: { plugins, diagnostics: [] },
-  } as unknown as PluginMetadataSnapshot;
+  };
 }
 
 describe("setup-registry descriptor lookup", () => {
-  it("resolves backend ownership before evaluating unrelated plugin activation", async () => {
+  it("evaluates activation only for owners of the requested CLI backend", async () => {
     const { resolvePluginSetupCliBackendDescriptor } = await import("./setup-registry.runtime.js");
-    const snapshot = createCurrentSnapshot({ manifestHash: "lookup", cliBackends: ["Other-CLI"] });
+    const snapshot = createPluginMetadataSnapshotFixture({
+      plugins: [
+        { id: "unrelated-provider", providers: ["unrelated"] },
+        { id: "other-cli", cliBackends: ["other-cli"] },
+        { id: "target-owner", cliBackends: ["Target-CLI"] },
+      ],
+    });
+    const activation = vi.spyOn(installedPluginIndex, "isInstalledPluginEnabled");
     withPluginMetadataSnapshotScope(
       snapshot,
       () => {
-        const activation = vi.spyOn(installedPluginIndex, "isInstalledPluginEnabled");
-        try {
-          expect(
-            resolvePluginSetupCliBackendDescriptor({ backend: "model-provider", config: {} }),
-          ).toBeUndefined();
-          expect(activation).not.toHaveBeenCalled();
-        } finally {
-          activation.mockRestore();
-        }
+        expect(resolvePluginSetupCliBackendDescriptor({ backend: "target-cli" })).toEqual({
+          pluginId: "target-owner",
+          backend: { id: "Target-CLI" },
+        });
+        expect(activation.mock.calls.map(([, pluginId]) => pluginId)).toEqual(["target-owner"]);
+        activation.mockClear();
+        expect(resolvePluginSetupCliBackendDescriptor({ backend: "missing-cli" })).toBeUndefined();
+        expect(activation).not.toHaveBeenCalled();
+      },
+      { trustConfigIdentity: true },
+    );
+  });
+
+  it("preserves declaration order across case-equivalent owners and setup contributions", async () => {
+    const { resolvePluginSetupCliBackendDescriptor, resolvePluginSetupCliBackendIds } =
+      await import("./setup-registry.runtime.js");
+    const snapshot = createPluginMetadataSnapshotFixture({
+      plugins: [
+        { id: "first-owner", cliBackends: ["Shared-CLI"] },
+        {
+          id: "second-owner",
+          cliBackends: ["shared-cli"],
+          setup: { cliBackends: ["shared-cli", "SHARED-CLI", "setup-cli"] },
+        },
+        { id: "third-owner", cliBackends: ["Shared-CLI"] },
+      ],
+    });
+    const config = { plugins: { entries: { "first-owner": { enabled: false } } } };
+    withPluginMetadataSnapshotScope(
+      snapshot,
+      () => {
+        expect(resolvePluginSetupCliBackendDescriptor({ backend: "SHARED-CLI", config })).toEqual({
+          pluginId: "second-owner",
+          backend: { id: "shared-cli" },
+        });
+        expect(resolvePluginSetupCliBackendIds({ config })).toEqual([
+          "shared-cli",
+          "shared-cli",
+          "SHARED-CLI",
+          "setup-cli",
+          "Shared-CLI",
+        ]);
+        expect(resolvePluginSetupCliBackendDescriptor({ backend: "SETUP-CLI", config })).toEqual({
+          pluginId: "second-owner",
+          backend: { id: "setup-cli" },
+        });
       },
       { trustConfigIdentity: true },
     );
@@ -164,27 +183,7 @@ describe("setup-registry descriptor lookup", () => {
   });
 
   it("uses enabled metadata cliBackends", async () => {
-    loadPluginMetadataSnapshotMock.mockReturnValue({
-      index: {
-        diagnostics: [],
-        plugins: [
-          {
-            pluginId: "openai",
-            origin: "bundled",
-            enabled: true,
-          },
-          {
-            pluginId: "disabled",
-            origin: "bundled",
-            enabled: false,
-          },
-          {
-            pluginId: "local",
-            origin: "workspace",
-            enabled: true,
-          },
-        ],
-      },
+    const snapshot = createPluginMetadataSnapshotFixture({
       plugins: [
         {
           id: "openai",
@@ -203,6 +202,10 @@ describe("setup-registry descriptor lookup", () => {
         },
       ],
     });
+    for (const record of snapshot.index.plugins) {
+      record.enabled = record.pluginId !== "disabled";
+    }
+    loadPluginMetadataSnapshotMock.mockReturnValue(snapshot);
 
     const { resolvePluginSetupCliBackendDescriptor } = await import("./setup-registry.runtime.js");
 
@@ -301,13 +304,7 @@ describe("setup-registry descriptor lookup", () => {
   });
 
   it("reuses the lifecycle-owned workspace when no runtime workspace is active", async () => {
-    loadPluginMetadataSnapshotMock.mockReturnValue({
-      index: {
-        diagnostics: [],
-        plugins: [],
-      },
-      plugins: [],
-    });
+    loadPluginMetadataSnapshotMock.mockReturnValue(createPluginMetadataSnapshotFixture());
 
     const { resolvePluginSetupCliBackendDescriptor } = await import("./setup-registry.runtime.js");
 

--- a/src/plugins/setup-registry.runtime.ts
+++ b/src/plugins/setup-registry.runtime.ts
@@ -19,50 +19,47 @@ type SetupCliBackendDescriptorLookupParams = {
   env?: NodeJS.ProcessEnv;
 };
 
-function resolveSetupCliBackendDescriptors(
-  params: Partial<SetupCliBackendDescriptorLookupParams> = {},
-): SetupCliBackendDescriptorEntry[] {
+function resolveSetupCliBackendSnapshot(
+  params: Omit<SetupCliBackendDescriptorLookupParams, "backend"> = {},
+) {
   const env = params.env ?? process.env;
   const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState();
-  const snapshot = resolvePluginMetadataSnapshot({
+  return resolvePluginMetadataSnapshot({
     ...(params.config ? { config: params.config } : {}),
     env,
     ...(workspaceDir ? { workspaceDir } : {}),
     allowWorkspaceScopedCurrent: true,
   });
-  const normalizedBackend =
-    params.backend === undefined ? undefined : normalizeProviderId(params.backend);
-  return snapshot.plugins.flatMap((plugin) => {
-    const backendIds = [...plugin.cliBackends, ...(plugin.setup?.cliBackends ?? [])].filter(
-      (id) => normalizedBackend === undefined || normalizeProviderId(id) === normalizedBackend,
-    );
-    // Model-provider probes must not evaluate activation for unrelated plugins;
-    // only manifest owners need current enablement policy.
-    if (
-      backendIds.length === 0 ||
-      !isInstalledPluginEnabled(snapshot.index, plugin.id, params.config)
-    ) {
-      return [];
-    }
-    return backendIds.map(
-      (backendId) =>
-        ({
-          pluginId: plugin.id,
-          backend: { id: backendId },
-        }) satisfies SetupCliBackendDescriptorEntry,
-    );
-  });
 }
 
 export function resolvePluginSetupCliBackendDescriptor(
   params: SetupCliBackendDescriptorLookupParams,
-) {
-  return resolveSetupCliBackendDescriptors(params)[0];
+): SetupCliBackendDescriptorEntry | undefined {
+  const normalized = normalizeProviderId(params.backend);
+  const snapshot = resolveSetupCliBackendSnapshot(params);
+  // The immutable owner map preserves declaration order; only activation uses live policy.
+  const pluginId = snapshot.owners.cliBackends
+    .get(normalized)
+    ?.find((id) => isInstalledPluginEnabled(snapshot.index, id, params.config));
+  const plugin = pluginId ? snapshot.byPluginId.get(pluginId) : undefined;
+  if (!plugin) {
+    return undefined;
+  }
+  const backendId = [...plugin.cliBackends, ...(plugin.setup?.cliBackends ?? [])].find(
+    (id) => normalizeProviderId(id) === normalized,
+  );
+  return backendId ? { pluginId: plugin.id, backend: { id: backendId } } : undefined;
 }
 
 /** Resolve enabled setup CLI backend ids from one metadata snapshot. */
 export function resolvePluginSetupCliBackendIds(
   params: Omit<SetupCliBackendDescriptorLookupParams, "backend"> = {},
 ): string[] {
-  return resolveSetupCliBackendDescriptors(params).map((entry) => entry.backend.id);
+  const snapshot = resolveSetupCliBackendSnapshot(params);
+  return snapshot.plugins.flatMap((plugin) => {
+    const ids = plugin.cliBackends.concat(plugin.setup?.cliBackends ?? []);
+    return ids.length > 0 && isInstalledPluginEnabled(snapshot.index, plugin.id, params.config)
+      ? ids
+      : [];
+  });
 }

--- a/src/secrets/provider-env-vars.dynamic.test.ts
+++ b/src/secrets/provider-env-vars.dynamic.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { sanitizeEnvVars } from "../agents/sandbox/sanitize-env-vars.js";
+import * as installedPluginIndex from "../plugins/installed-plugin-index.js";
 import { resolveLocalProviderAuthEvidence } from "./provider-auth-evidence.js";
 import {
   getProviderEnvVars,
@@ -740,7 +741,7 @@ describe("provider env vars dynamic manifest metadata", () => {
     expect(pluginRegistryMocks.loadPluginMetadataSnapshot).toHaveBeenCalledTimes(1);
   });
 
-  it("resolves alias, env, and evidence lookup maps from one metadata snapshot", () => {
+  it("resolves auth maps with policy work bounded to contributing plugins", () => {
     useInstalledPlugins(
       {
         id: "external-fireworks",
@@ -772,11 +773,30 @@ describe("provider env vars dynamic manifest metadata", () => {
           "legacy-cloud-plan": "legacy-cloud",
         },
       },
+      { id: "channel-only", origin: "bundled", providers: [] },
+      {
+        id: "metadata-only",
+        origin: "bundled",
+        setup: {
+          requiresRuntime: false,
+          providers: [{ id: "metadata-only", envVars: ["METADATA_ONLY_API_KEY"] }],
+        },
+      },
     );
 
-    const lookupMaps = resolveProviderAuthLookupMaps({ config: {} });
+    const policy = vi.spyOn(installedPluginIndex, "isInstalledPluginEnabled");
+    let lookupMaps: ReturnType<typeof resolveProviderAuthLookupMaps>;
+    try {
+      lookupMaps = resolveProviderAuthLookupMaps({ config: {} });
+      expect(policy.mock.calls.length).toBeLessThanOrEqual(2);
+      expect(policy.mock.calls.map(([, pluginId]) => pluginId)).not.toContain("channel-only");
+      expect(policy.mock.calls.map(([, pluginId]) => pluginId)).not.toContain("metadata-only");
+    } finally {
+      policy.mockRestore();
+    }
 
     expect(lookupMaps.aliasMap["fireworks-plan"]).toBe("fireworks");
+    expect(lookupMaps.envCandidateMap["metadata-only"]).toEqual(["METADATA_ONLY_API_KEY"]);
     expect(lookupMaps.envCandidateMap["fireworks-plan"]).toEqual(["FIREWORKS_ALT_API_KEY"]);
     expect(lookupMaps.authEvidenceMap["fireworks-plan"]).toEqual([
       {
@@ -794,23 +814,38 @@ describe("provider env vars dynamic manifest metadata", () => {
     expect(pluginRegistryMocks.loadPluginMetadataSnapshot).toHaveBeenCalledTimes(1);
   });
 
-  it("excludes disabled plugin setup fallback refs from runtime auth lookup maps", () => {
-    useInstalledPlugins({
-      id: "disabled-setup-owner",
-      origin: "global",
-      enabled: false,
-      providers: ["disabled-cloud"],
-      providerAuthAliases: {
-        "disabled-cloud-plan": "disabled-cloud",
+  it("updates runtime auth evidence and fallback refs without dropping disabled credential hints", () => {
+    const plugin = setupPlugin(
+      "disabled-setup-owner",
+      "global",
+      {
+        id: "disabled-cloud",
+        envVars: ["DISABLED_CLOUD_API_KEY"],
+        authEvidence: [{ type: "local-file-with-env", credentialMarker: "cloud-local" }],
       },
-    });
+      {
+        enabled: false,
+        providers: ["disabled-cloud"],
+        providerAuthAliases: {
+          "disabled-cloud-plan": "disabled-cloud",
+        },
+      },
+    );
 
-    const lookupMaps = resolveProviderAuthLookupMaps({
-      config: { plugins: { entries: { "disabled-setup-owner": { enabled: false } } } },
-    });
-
-    expect(lookupMaps.setupProviderFallbackRefs).toEqual([]);
-    expect(pluginRegistryMocks.loadPluginMetadataSnapshot).toHaveBeenCalledTimes(1);
+    pluginRegistryMocks.getCurrentPluginMetadataSnapshot.mockReturnValue(metadataSnapshot(plugin));
+    const config = { plugins: { entries: { "disabled-setup-owner": { enabled: false } } } };
+    for (const enabled of [false, true, false]) {
+      config.plugins.entries["disabled-setup-owner"].enabled = enabled;
+      const lookupMaps = resolveProviderAuthLookupMaps({ config });
+      expect(lookupMaps.setupProviderFallbackRefs).toEqual(
+        enabled ? ["disabled-cloud", "disabled-cloud-plan"] : [],
+      );
+      expect(lookupMaps.authEvidenceMap["disabled-cloud-plan"]).toEqual(
+        enabled ? plugin.setup?.providers?.[0]?.authEvidence : undefined,
+      );
+      expect(lookupMaps.envCandidateMap["disabled-cloud-plan"]).toEqual(["DISABLED_CLOUD_API_KEY"]);
+    }
+    expect(pluginRegistryMocks.loadPluginMetadataSnapshot).not.toHaveBeenCalled();
   });
 
   it("does not reuse a load-path current snapshot for default provider env lookups without parameters", () => {

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -220,24 +220,39 @@ function resolveManifestProviderAuthEnvVarCandidatesFromSnapshot(
   return candidates;
 }
 
-function resolveManifestProviderAuthEvidenceFromSnapshot(
+function resolveManifestRuntimeAuthFacts(
   params: ProviderEnvVarLookupParams | undefined,
   snapshot: PluginMetadataSnapshot,
   aliases: Readonly<Record<string, string>>,
-): Record<string, ProviderAuthEvidence[]> {
+) {
   const evidenceByProvider: Record<string, ProviderAuthEvidence[]> = {};
+  const refs = new Set<string>();
   for (const plugin of snapshot.plugins) {
+    const evidenceProviders = (plugin.setup?.providers ?? []).filter(
+      (provider) => provider.authEvidence?.length,
+    );
+    const fallbackProviders =
+      plugin.setup?.requiresRuntime !== false && (plugin.setup?.providers || plugin.providers)
+        ? listSetupProviderIds(plugin)
+        : [];
+    if (evidenceProviders.length === 0 && fallbackProviders.length === 0) {
+      continue;
+    }
+    // Package contributions are fixed, but their eligibility follows current config.
+    // Evaluate each contributing owner once without narrowing credential-scrubbing hints.
     if (
       snapshot.index.plugins.length > 0 &&
       !isInstalledPluginEnabled(snapshot.index, plugin.id, params?.config)
     ) {
       continue;
     }
-    if (!shouldUsePluginProviderAuthEvidence(plugin, params)) {
-      continue;
+    if (shouldUsePluginProviderAuthEvidence(plugin, params)) {
+      for (const provider of evidenceProviders) {
+        appendUniqueAuthEvidence(evidenceByProvider, provider.id, provider.authEvidence ?? []);
+      }
     }
-    for (const provider of plugin.setup?.providers ?? []) {
-      appendUniqueAuthEvidence(evidenceByProvider, provider.id, provider.authEvidence ?? []);
+    for (const providerId of fallbackProviders) {
+      appendUniqueProviderRef(refs, providerId);
     }
   }
   for (const [alias, target] of Object.entries(aliases).toSorted(([left], [right]) =>
@@ -248,39 +263,15 @@ function resolveManifestProviderAuthEvidenceFromSnapshot(
       appendUniqueAuthEvidence(evidenceByProvider, alias, evidence);
     }
   }
-  return evidenceByProvider;
-}
-
-function resolveManifestSetupProviderFallbackRefsFromSnapshot(
-  params: ProviderEnvVarLookupParams | undefined,
-  snapshot: PluginMetadataSnapshot,
-  aliases: Readonly<Record<string, string>>,
-): string[] {
-  const refs = new Set<string>();
-  for (const plugin of snapshot.plugins) {
-    if (
-      snapshot.index.plugins.length > 0 &&
-      !isInstalledPluginEnabled(snapshot.index, plugin.id, params?.config)
-    ) {
-      continue;
-    }
-    if (plugin.setup?.requiresRuntime === false) {
-      continue;
-    }
-    // Setup fallback refs are only useful for providers that may be reached at runtime.
-    if (plugin.setup?.providers === undefined && plugin.providers === undefined) {
-      continue;
-    }
-    for (const providerId of listSetupProviderIds(plugin)) {
-      appendUniqueProviderRef(refs, providerId);
-    }
-  }
   for (const [alias, target] of Object.entries(aliases)) {
     if (refs.has(target)) {
       appendUniqueProviderRef(refs, alias);
     }
   }
-  return [...refs].toSorted((a, b) => a.localeCompare(b));
+  return {
+    authEvidenceMap: evidenceByProvider,
+    setupProviderFallbackRefs: [...refs].toSorted((a, b) => a.localeCompare(b)),
+  };
 }
 
 /** Resolves provider env-var candidates used by generic auth lookup. */
@@ -310,12 +301,7 @@ export function resolveProviderAuthLookupMaps(
       ...resolveManifestProviderAuthEnvVarCandidatesFromSnapshot(params, snapshot, aliasMap),
       ...CORE_PROVIDER_AUTH_ENV_VAR_CANDIDATES,
     },
-    authEvidenceMap: resolveManifestProviderAuthEvidenceFromSnapshot(params, snapshot, aliasMap),
-    setupProviderFallbackRefs: resolveManifestSetupProviderFallbackRefsFromSnapshot(
-      params,
-      snapshot,
-      aliasMap,
-    ),
+    ...resolveManifestRuntimeAuthFacts(params, snapshot, aliasMap),
   };
 }
 


### PR DESCRIPTION
Related: #133061

## What Problem This Solves

Gateway readiness, session lists, history and Control UI HTTP responses can stall during bursts of concurrent agent turns. This extends the session-update repair in #133061. It reduces measured stalls without claiming to eliminate CPU saturation or every latency tail.

## Why This Change Was Made

Reuse process-stable plugin lookup facts within their existing lifecycle, resolve normalized CLI backend owners before evaluating live activation policy, and collect provider auth metadata in one owner pass. Attempt preparation shares event-loop start turns while preserving asynchronous overlap, caller context and resource cleanup. Session lists yield according to elapsed projection work instead of repeatedly requeueing cheap rows.

Preparation checkpoints and the external abort listener now share once-only timeout classification. A regression reproduced cleanup receiving `cancel` for a timeout before listener setup; it now receives `timeout`, matching the terminal outcome.

No enablement policy is cached. No public configuration, protocol, SQLite schema, persistence semantics or command concurrency settings change. Production diff +355/-367 (net -12), tests/support +412/-126, docs +1. Main's selected-parent session index and nested-tool activity ownership remain intact.

## User Impact

The refactor substantially reduces measured control-plane stalls, but a later identical repeat still exceeded the two-second UI HTTP budget. CPU-pressure readiness diagnostics still report degraded load. A previously observed timeline-disabled UI HTTP tail remains a separate follow-up; it is not dismissed as host noise.

## Evidence

Built current-main baseline `61edeb8a6fe90ade870d11436eb4308469ac436a` and final candidate `a272f175688041b1437ae7d407ee0fc6739158e9`. Same configured workload: 32 turns, 48 seeded sessions, 128 updates across four clients, three history readers with five-request bursts, six subscribers, visible observer, 100 ms cadence and 1000 ms mock stream delay. Fresh isolated HOME/state and random loopback ports; synthetic streaming provider only. No production Gateway stressed or mutated.

| Metric | Current-main baseline | Final candidate |
|---|---:|---:|
| Readiness max | 1781 ms | 308 ms |
| sessions.list max | 2413 ms | 160 ms |
| Control UI HTTP max | 2398 ms | 653 ms |
| History p99 | 2327 ms | 626 ms |
| History max | 2336 ms | 638 ms |
| Fresh handshake max | 743 ms | 411 ms |

Baseline failed; the tabulated final-candidate run passed with zero operation failures. A later fresh-cache repeat completed all32 turns and128 patches but failed the unchanged UI latency budget: UI HTTP2576ms, readiness1748ms, list1934ms, history1893ms, all operation failures zero. The harness incorrectly exited0 because UI is omitted from its control gate. This is a retained observed latency failure for the separate follow-up, not a complete-fix claim or attributed host-noise explanation. The preceding integrated head `7ace3c08c008` passed three32-turn trials (worst readiness597ms/list339ms/UI769ms/history678ms), an8-turn control and three timeline-disabled32-turn controls (UImax922ms). Final candidate raw requests prove32 streaming Responses requests plus1 embedding request; all32 turns and128 patches completed. Older baseline/candidate mock HTTP record totals65/36 varied; their extra requests cannot be classified without retained raw data. Memory indexing is observed in the later browser captures, so total HTTP record count is not a fixed-turn count.

376 integrated tests passed, followed by30 focused timeout/sibling lifecycle tests. The timeout regression failed before its correction. Full local changed-code gates, frozen-source fresh-cache sourcePerformance build, Control UI build and Codex P0 autoreviews passed. An earlier build overlapped native checkout refresh and was explicitly discarded as proof before rebuilding.

The final real-browser-under-load run also passed: real built Control UI, fresh Playwright context, real Gateway WebSocket traffic, visible session-label changes and the selected synthetic reply while load remained active. All32 turns completed; zero page errors/operation failures. Max readiness899ms/list749ms/UI1209ms/history963ms. This adds browser/asset work and is separate from the HTML-only benchmark. Two prior recordings were interrupted by the recorder's own10s reply wait; retained traces show continued control-plane service and19 persisted replies in the inspected failure. The recorder now uses the benchmark's existing120s completion deadline; the2s latency budgets were never raised. Failed captures remain retained locally.

![Final candidate Control UI showing the synthetic reply during load](https://github.com/user-attachments/assets/102a4e09-c177-4345-9c22-c4ffc8193e58)

https://github.com/user-attachments/assets/65381772-7838-4733-a094-73411e4005d9

Captures inspected: synthetic fixture state only. The prior timeline-disabled UI HTTP2164ms observation and final-head UI2576ms repeat remain unresolved; passing repeats do not erase them. UI/history latency were checked directly because the existing benchmark control gate omits those samples; fixing that blind spot and profiling remaining history work is a separate follow-up. No memory-leak or general capacity claim.

AI-assisted implementation. Latest ClawSweeper finding and Rank-up moves addressed by timeout regression and refreshed exact-head proof. Hosted exact-head CI/native landing checks remain pending.
