### PR TITLE
improve(ui): remove media device refresh buttons

### DIFF
--- a/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
@@ -1050,7 +1050,9 @@ suite.define(() => {
 
       await page.setViewportSize({ width: 320, height: 720 });
       await page.goto(`${suite.server.baseUrl}settings/appearance`);
-      await page.getByRole("button", { name: "Refresh: Microphone input" }).click();
+      const microphonePicker = page.getByRole("combobox", { name: "Microphone input" });
+      await microphonePicker.press("ArrowDown");
+      await microphonePicker.press("Escape");
 
       const permissionAlert = page.getByRole("alert");
       await expect.poll(() => permissionAlert.isVisible()).toBe(true);

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -512,7 +512,7 @@ export class ConfigPage extends OpenClawLightDomElement {
     this.syncUpdateCountdownPolling();
     this.scrollToPendingRouteTarget();
     // Device labels stay hidden until the user grants media permission; each
-    // refresh button next to a picker requests its permission explicitly.
+    // picker requests its permission explicitly when opened.
     if (this.pageId === "appearance" && !this.microphoneLoaded) {
       this.microphoneLoaded = true;
       void this.refreshMicrophones(false);

--- a/ui/src/pages/config/view-appearance-preferences.ts
+++ b/ui/src/pages/config/view-appearance-preferences.ts
@@ -6,7 +6,6 @@ import {
   normalizeChatSendShortcut,
   UI_APPEARANCE_DEFAULTS,
 } from "../../app/settings.ts";
-import { icons } from "../../components/icons.ts";
 import { getLobsterdexEntries } from "../../components/lobster-dex.ts";
 import { previewLobsterChirp } from "../../components/lobster-pet-audio.ts";
 import {
@@ -94,7 +93,6 @@ function renderSettingsMediaDeviceField(options: {
       ? [{ label: options.fallbackLabel(state.devices.length + 1), value: selectedDeviceId }]
       : []),
   ];
-  const refreshLabel = `${t("common.refresh")}: ${options.title}`;
   let accessRequested = false;
   const requestAccess = () => {
     if (accessRequested || !state.permissionRequired) {
@@ -143,15 +141,6 @@ function renderSettingsMediaDeviceField(options: {
           `,
         )}
       </select>
-      <button
-        type="button"
-        class="btn btn--sm btn--icon"
-        aria-label=${refreshLabel}
-        ?disabled=${state.loading}
-        @click=${() => options.onRefresh?.()}
-      >
-        ${state.loading ? icons.loader : icons.refresh}
-      </button>
     `,
   });
 }

--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -2208,6 +2208,9 @@ describe("config view", () => {
       "System default",
       "Desk Camera",
     ]);
+    for (const select of [microphoneSelect, cameraSelect]) {
+      expect(select.closest(".settings-row")?.querySelector("button")).toBeNull();
+    }
     expect(container.textContent).toContain("Hold microphone button to start dictation");
 
     microphoneSelect.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, button: 0 }));


### PR DESCRIPTION
## What Problem This Solves

The Microphone input and Camera rows in Settings → Appearance show an extra circular-arrow button beside each dropdown. These are device-list refresh buttons, despite looking like reset controls. This maintainer-requested cleanup removes both.

Related: #131960 (remove reset-to-default icons from settings rows); these remaining media controls are refresh buttons.

## Why This Change Was Made

Delete the buttons from the shared media-device row and remove the unused icon import/label. Keep the existing dropdown-triggered permission request, passive discovery on page entry, and hardware-change subscription. Update the nearby permission comment and exercise the dropdown instead of the removed button in the existing narrow-screen E2E.

## User Impact

Both rows contain just their device dropdown. System default, saved devices, permission prompts, and automatic device-list updates remain available. No config, persistence, protocol, or provider changes.

## Evidence

- Regression-first: the existing browser test, extended to reject buttons in either media row, fails against the original implementation and passes after deletion.
- `cd ui && node ../scripts/run-vitest.mjs run --config vitest.config.ts src/pages/config/view.browser.test.ts src/pages/config/config-page.test.ts src/pages/chat/realtime-talk-input.test.ts` — 123 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/browser-talk-start-stop.e2e.test.ts -t 'keeps blocked microphone guidance readable'` — passed; dropdown keyboard activation still shows permission guidance within a 320px viewport.
- Real Vite Control UI connected to a separate loopback Gateway using temporary state/config and disabled plugins; inspected desktop and mobile screenshots. Both buttons absent and both System default selections work. The preview used an installed Gateway with the current source UI, not a mocked Gateway.
- `pnpm ui:build` and `pnpm build` — passed.
- Fresh autoreview: scoped-clean, no accepted/actionable P0 findings.
- `node scripts/check-changed.mjs -- ui/src/pages/config/view-appearance-preferences.ts ui/src/pages/config/config-page.ts ui/src/pages/config/view.browser.test.ts ui/src/e2e/browser-talk-start-stop.e2e.test.ts` — passed (format, guards, dead exports, i18n, core-test/UI types, changed-file lint/styles).
- Production: +1/-12 (net -11); tests: +6/-1 (net +5).
- AI-assisted implementation.

### Before

![Before: media dropdowns with refresh controls](https://github.com/user-attachments/assets/429a043a-c9b9-4ff2-8053-3fad78390cf1)

### After

![After: media dropdowns without refresh controls](https://github.com/user-attachments/assets/9220b445-42c7-454e-8e60-3bd649fda929)

### Mobile

![Mobile: both media dropdowns fit without refresh controls](https://github.com/user-attachments/assets/5e8b30c0-6d35-48a3-9bd5-148f7d2aa3dc)
