### PR TITLE
test: reuse publish workflow repository fixtures

### DIFF
--- a/test/scripts/openclaw-performance-workflow.test-support.ts
+++ b/test/scripts/openclaw-performance-workflow.test-support.ts
@@ -12,10 +12,10 @@ import { afterAll } from "vitest";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
 
 const templateDirs = createTempDirTracker();
-let performanceTemplate: string | undefined;
+const performanceTemplates = new Map<"base" | "publish", string>();
 afterAll(() => {
   templateDirs.cleanup();
-  performanceTemplate = undefined;
+  performanceTemplates.clear();
 });
 
 export type PerformanceFixtureOptions = {
@@ -65,9 +65,11 @@ export function preparePerformanceFixture(root: string, options: PerformanceFixt
     run(cwd, "commit", "-m", "fixture report");
   };
   const reuseDefault = !options.baseline && !options.duplicate;
+  const templateKind = options.mode === "publish" ? "publish" : "base";
+  const template = reuseDefault ? performanceTemplates.get(templateKind) : undefined;
   const copyOptions = { recursive: true, mode: fsConstants.COPYFILE_FICLONE };
-  if (reuseDefault && performanceTemplate) {
-    cpSync(performanceTemplate, workspace, copyOptions);
+  if (template) {
+    cpSync(template, workspace, copyOptions);
   } else {
     mkdirSync(temp, { recursive: true });
     mkdirSync(seed);
@@ -87,26 +89,29 @@ export function preparePerformanceFixture(root: string, options: PerformanceFixt
     write(path.join(workspace, "src/config/zod-schema.agent-defaults.ts"), "    mediaModels: z\n");
     run(workspace, "add", "src");
     run(workspace, "commit", "-m", "fixture target");
+    mkdirSync(reports);
+    if (options.mode === "publish") {
+      run(reports, "init", "--initial-branch=main");
+      run(reports, "remote", "add", "origin", "https://github.com/openclaw/clawgrit-reports.git");
+      // Keep FETCH_HEAD's source description valid when the snapshot is copied.
+      run(reports, "fetch", "--depth=1", path.relative(reports, remote), "main");
+      run(reports, "checkout", "-B", "main", "FETCH_HEAD");
+      run(reports, "config", "core.hooksPath", "/dev/null");
+      commitReport(reports, dest);
+      write(path.join(reports, ".git/preexisting.lock"), "not invocation-owned\n");
+    }
     if (reuseDefault) {
       // Snapshot complete repositories before any scenario mutation. Copies own
       // their refs, index and objects; no live process or absolute remote is shared.
-      const template = templateDirs.make("openclaw-performance-template-");
+      const template = templateDirs.make(`openclaw-performance-${templateKind}-template-`);
       cpSync(workspace, template, copyOptions);
-      performanceTemplate = template;
+      performanceTemplates.set(templateKind, template);
     }
   }
   const target = run(workspace, "rev-parse", "HEAD");
-  mkdirSync(reports);
   let reportCommit = "a".repeat(40);
   if (options.mode === "publish") {
-    run(reports, "init", "--initial-branch=main");
-    run(reports, "remote", "add", "origin", "https://github.com/openclaw/clawgrit-reports.git");
-    run(reports, "fetch", "--depth=1", remote, "main");
-    run(reports, "checkout", "-B", "main", "FETCH_HEAD");
-    run(reports, "config", "core.hooksPath", "/dev/null");
-    commitReport(reports, dest);
     reportCommit = run(reports, "rev-parse", "HEAD");
-    write(path.join(reports, ".git/preexisting.lock"), "not invocation-owned\n");
     if (options.race) {
       commitReport(seed, "openclaw-performance/main/200-1/mock-provider");
       run(seed, "push", remote, "HEAD:main");


### PR DESCRIPTION
## What Problem This Solves

Performance-workflow fixtures already reuse a copied base repository, but publish-mode cases still rebuild their reports repository for every case. That repeats repository initialization, remote setup, fetch, checkout, configuration and commit work before exercising the real workflow.

## Why This Change Was Made

Keep two immutable fixture snapshots, one for base cases and one for publish cases, using the existing temporary-directory tracker and copy mechanism. Construct the reports repository before capturing the publish snapshot, then copy complete repositories into each case's workspace. Per-case inputs and race mutations happen only after copying. Specialized baseline and duplicate variants retain fresh construction.

Use a relative local fetch source during setup so FETCH_HEAD's source description remains valid in the copied workspace. Its object ID and the configured public origin URL retain their meanings. Both destination SHA reads, transport routing, inspection closures and all production workflow commands remain per-case.

## User Impact

Test execution only. Seven setup Git launches are removed per warm publish fixture, from nine to two. No product code, dependencies, sharding, concurrency, selection, assertions, command deadlines, real process lifecycle or persistence coverage change. Production/tooling: +0/-0. Test support: +19/-14, net five lines.

## Evidence

- Eight balanced publish-setup pairs on macOS Node 26.5: median 363.265 ms before / 103.734 ms after. Eight balanced pairs on the same Linux Node 24.19 worker: 19.077 ms before / 5.837 ms after. These measure fixture setup, not whole-CI duration.
- Both complete consumer suites passed on Linux: 144 tests, including races, cancellation, failure cleanup, duplicate reconciliation and publish semantics. All 14 changed-file checks passed.
- Cold and warm base/publish probes compare Git trees, indexes, configuration, ref names and history subjects. Files have independent inodes, with no object alternates or retained original workspace paths. Mutating report files, hooks, configuration, refs, seed and bare remote cannot affect either snapshot or a peer fixture.
- FETCH_HEAD retains the report-parent object ID and intentionally changes only its source spelling to a portable relative path. Absent, invalid, trailing-newline, duplicate and race variants retain their behavior. The unsupported publish-plus-duplicate combination remains rejected by Git identically in baseline and candidate.
- Both cached directories and map entries are removed by suite cleanup. Probe children were joined, temporary roots removed, tracked source hashes verified unchanged, and the Linux worker stopped successfully.
- Independent full-priority source review and Codex review found no actionable findings. Exact-head hosted [CI33327453673](https://github.com/openclaw/openclaw/actions/runs/33327453673) completed successfully for c4fc55fd8a4b27baef678faab340409f8f939942. The latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/133438#issuecomment-5470486472) was read in full, including its Rank-up moves: exact-head CI and checking the latest review are both complete; no unresolved code finding or additional move remains.

## Remaining Coverage

All workflow command traces, destination-specific paths, real repositories, persistence, race creation, cancellation and cleanup assertions remain. The cache stores only completed setup state before scenario mutation. No live process, mutable Git state or transport closure is shared between cases.
