### PR TITLE
fix: native Codex session usage stays zero after /new

### DIFF
--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -195,6 +195,8 @@ Two different concepts:
 1. **Model context window**: hard cap per model (tokens visible to the model). Comes from the model catalog and can be overridden via config.
 2. **Session store counters**: rolling stats written into the session row (used for `/status` and dashboards). `contextTokens` is a runtime estimate/reporting value - do not treat it as a strict guarantee.
 
+Completed turns update session counters even when no compaction occurred. An ordered context replacement takes precedence over earlier model usage; if its size is unknown, the counters are marked stale instead of borrowing an older request's total. A superseded run cannot overwrite the current writer's counters.
+
 More on limits: [/reference/token-use](/reference/token-use).
 
 ## Compaction: what it is

--- a/src/agents/agent-command.compaction-rotation.test.ts
+++ b/src/agents/agent-command.compaction-rotation.test.ts
@@ -36,9 +36,9 @@ registerAgentCommandCompactionTestHooks();
 
 async function commitAttemptCompaction(
   params: Parameters<typeof state.runAgentAttemptMock>[0],
-  accounting: Pick<CompactionAccountingFact, "count" | "currentContextTokens"> = {
+  accounting: Pick<CompactionAccountingFact, "count" | "currentContextSnapshot"> = {
     count: 1,
-    currentContextTokens: 42,
+    currentContextSnapshot: { tokens: 42 },
   },
 ) {
   const target = params.sessionTarget;
@@ -219,7 +219,7 @@ describe("agentCommand compaction transcript rotation", () => {
 
   it.each([42, 95_000, 0, undefined])(
     "keeps successor context %s from the private ordered fact, not public snapshots",
-    async (currentContextTokens) => {
+    async (tokens) => {
       const storePath = requireStorePath();
       const rotatedSessionFile = formatSqliteSessionFileMarker({
         agentId: "main",
@@ -228,7 +228,10 @@ describe("agentCommand compaction transcript rotation", () => {
       });
       const usage = { input: 100_000, output: 3_000, cacheRead: 20_000, cacheWrite: 1_000 };
       state.runAgentAttemptMock.mockImplementationOnce(async (params) => {
-        const accepted = await commitAttemptCompaction(params, { count: 1, currentContextTokens });
+        const accepted = await commitAttemptCompaction(params, {
+          count: 1,
+          currentContextSnapshot: { tokens },
+        });
         await appendTranscriptMessage(accepted.sessionTarget, {
           message: { role: "assistant", content: "first answer after rotation", timestamp: 1 },
         });
@@ -270,9 +273,9 @@ describe("agentCommand compaction transcript rotation", () => {
         outputTokens: usage.output,
         cacheRead: usage.cacheRead,
         cacheWrite: usage.cacheWrite,
-        totalTokensFresh: currentContextTokens !== undefined,
+        totalTokensFresh: tokens !== undefined,
       });
-      expect(entry.totalTokens).toBe(currentContextTokens);
+      expect(entry.totalTokens).toBe(tokens);
       await expect(
         loadTranscriptEvents({ agentId: "main", sessionId: "rotated-session", storePath }),
       ).resolves.toContainEqual(
@@ -299,7 +302,7 @@ describe("agentCommand compaction transcript rotation", () => {
       params.onCompactionAccounting?.({
         kind: "durable",
         count: 0,
-        currentContextTokens: 95_000,
+        currentContextSnapshot: { tokens: 95_000 },
         target: {
           ...params.sessionTarget,
           lifecycleRevision: entry.lifecycleRevision,
@@ -355,7 +358,7 @@ describe("agentCommand compaction transcript rotation", () => {
           released = true;
         },
       });
-      await commitAttemptCompaction(params, { count: 2, currentContextTokens: 42 });
+      await commitAttemptCompaction(params, { count: 2, currentContextSnapshot: { tokens: 42 } });
       controller.abort(aborted);
       throw aborted;
     });

--- a/src/agents/agent-command.embedded-maintenance.test.ts
+++ b/src/agents/agent-command.embedded-maintenance.test.ts
@@ -204,9 +204,28 @@ describe("agentCommand embedded maintenance", () => {
     expect(findStoredSessionEntry(sessionKey)?.pendingFinalDelivery).toBeUndefined();
   });
 
-  it.each([false, true])(
-    "refreshes count-zero retry context only for its retained writer (replacement=%s)",
-    async (replaceWriter) => {
+  it.each([
+    {
+      retry: "model context",
+      replaceWriter: false,
+      initialTokens: 42,
+      currentContextSnapshot: { tokens: 95_000 },
+    },
+    {
+      retry: "model context",
+      replaceWriter: true,
+      initialTokens: 42,
+      currentContextSnapshot: { tokens: 95_000 },
+    },
+    {
+      retry: "custody only after unknown compaction",
+      replaceWriter: false,
+      initialTokens: undefined,
+      currentContextSnapshot: undefined,
+    },
+  ])(
+    "keeps count-zero retry $retry on its retained writer (replacement=$replaceWriter)",
+    async ({ replaceWriter, initialTokens, currentContextSnapshot }) => {
       const sessionId = "retry-context-owner";
       const sessionKey = `agent:main:explicit:${sessionId}`;
       const storePath = requireStorePath();
@@ -221,7 +240,7 @@ describe("agentCommand embedded maintenance", () => {
         params.onCompactionAccounting?.({
           kind: "durable",
           count: 1,
-          currentContextTokens: 42,
+          currentContextSnapshot: { tokens: initialTokens },
           target: {
             ...target,
             lifecycleRevision: entry.lifecycleRevision,
@@ -256,25 +275,39 @@ describe("agentCommand embedded maintenance", () => {
         params.onCompactionAccounting?.({
           kind: "durable",
           count: 0,
-          currentContextTokens: 95_000,
+          ...(currentContextSnapshot ? { currentContextSnapshot } : {}),
           target: {
             ...target,
             lifecycleRevision: entry.lifecycleRevision,
             activeWriterRunId: entry.activeWriterRunId,
           },
         });
-        return makeResult({ sessionId, text: "retry answer", runner: "embedded" });
+        const result = makeResult({ sessionId, text: "retry answer", runner: "embedded" });
+        if (!currentContextSnapshot) {
+          const usage = { input: 95_000, output: 10 };
+          result.meta.agentMeta = {
+            ...result.meta.agentMeta!,
+            promptTokens: 95_000,
+            usage,
+            lastCallUsage: usage,
+          };
+        }
+        return result;
       });
 
       await agentCommand({ message: "continue", sessionId, sessionKey });
 
       expect(state.runAgentAttemptMock).toHaveBeenCalledTimes(2);
-      expect(findStoredSessionEntry(sessionKey)).toMatchObject({
+      const stored = findStoredSessionEntry(sessionKey);
+      expect(stored).toMatchObject({
         sessionId,
         compactionCount: replaceWriter ? 7 : 1,
-        totalTokens: replaceWriter ? 777 : 95_000,
-        totalTokensFresh: true,
+        totalTokensFresh: replaceWriter || currentContextSnapshot !== undefined,
       });
+      expect(stored?.totalTokens).toBe(replaceWriter ? 777 : currentContextSnapshot?.tokens);
+      if (!currentContextSnapshot) {
+        expect(stored).toMatchObject({ inputTokens: 95_000, outputTokens: 10 });
+      }
       expect(loadSessionEntry({ sessionKey, storePath })?.activeWriterRunId).toBe(
         replaceWriter ? "replacement-writer" : retainedWriter,
       );
@@ -332,7 +365,7 @@ describe("agentCommand embedded maintenance", () => {
         params.onCompactionAccounting?.({
           kind: "durable",
           count: testCase.compactionCount,
-          currentContextTokens: undefined,
+          currentContextSnapshot: { tokens: undefined },
           target: {
             ...target,
             lifecycleRevision: entry.lifecycleRevision,

--- a/src/agents/command/compaction-accounting.ts
+++ b/src/agents/command/compaction-accounting.ts
@@ -35,9 +35,9 @@ export function createCommandCompactionAccounting(params: {
       return accounting;
     },
     beginCandidate() {
-      if (accounting) {
+      if (accounting?.currentContextSnapshot) {
         // Only an ordered fact from this candidate can restore current context.
-        accounting = { ...accounting, currentContextTokens: undefined };
+        accounting = { ...accounting, currentContextSnapshot: { tokens: undefined } };
       }
       let candidateFact: CompactionAccountingFact | undefined;
       return {
@@ -52,7 +52,7 @@ export function createCommandCompactionAccounting(params: {
           }
           candidateFact = fact;
           if (fact?.kind === "durable") {
-            // The first model-only fact binds finalization; later unrelated zeros cannot rebind it.
+            // The first writer fact binds finalization; later unrelated zeros cannot rebind it.
             params.onDurableFact(fact);
           }
         },
@@ -64,7 +64,12 @@ export function createCommandCompactionAccounting(params: {
           const carriedCount = hasSameCompactionWriter(accounting?.target, fact.target)
             ? (accounting?.count ?? 0)
             : 0;
-          accounting = { ...fact, count: carriedCount + fact.count };
+          accounting = {
+            ...fact,
+            count: carriedCount + fact.count,
+            currentContextSnapshot:
+              fact.currentContextSnapshot ?? accounting?.currentContextSnapshot,
+          };
           if (fact.count > 0 && params.persistCounts) {
             await incrementCompactionCount({
               agentId: fact.target.agentId,
@@ -74,7 +79,7 @@ export function createCommandCompactionAccounting(params: {
               storePath: fact.target.storePath,
               expectedSession: fact.target,
               amount: fact.count,
-              tokensAfter: fact.currentContextTokens,
+              tokensAfter: fact.currentContextSnapshot?.tokens,
             });
             params.refreshSessionEntry(fact.target.sessionKey);
           }

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -224,7 +224,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
               compactionAccounting: {
                 kind: "durable",
                 count: 0,
-                currentContextTokens: 42,
+                currentContextSnapshot: { tokens: 42 },
                 target: {
                   agentId: "main",
                   sessionId: owner.sessionId,
@@ -1502,7 +1502,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
         compactionAccounting: {
           kind: "durable",
           count,
-          currentContextTokens: tokens,
+          currentContextSnapshot: { tokens },
           target: {
             agentId: "main",
             sessionId,
@@ -1571,7 +1571,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
           compactionAccounting: {
             kind: "durable",
             count: 0,
-            currentContextTokens: 42,
+            currentContextSnapshot: { tokens: 42 },
             target: {
               agentId: "main",
               sessionId,
@@ -1670,7 +1670,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
           compactionAccounting: {
             kind: "durable",
             count: 1,
-            currentContextTokens: tokens,
+            currentContextSnapshot: { tokens },
             target: {
               agentId: "main",
               sessionId,

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -219,8 +219,9 @@ export async function updateSessionStoreAfterAgentRun(params: {
     }
   }
   if (!preserveUserFacingRunState) {
-    const totalTokens = params.compactionAccounting
-      ? params.compactionAccounting.currentContextTokens
+    const currentContextSnapshot = params.compactionAccounting?.currentContextSnapshot;
+    const totalTokens = currentContextSnapshot
+      ? currentContextSnapshot.tokens
       : hasUsage
         ? deriveSessionTotalTokens({ lastCallUsage, contextTokens, promptTokens })
         : undefined;
@@ -228,7 +229,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
       next.totalTokens = totalTokens;
       next.totalTokensFresh = true;
       next.totalTokensVersion = SESSION_TOTAL_TOKENS_VERSION;
-    } else if (params.compactionAccounting || hasUsage) {
+    } else if (currentContextSnapshot || hasUsage) {
       next.totalTokens = undefined;
       next.totalTokensFresh = false;
       next.totalTokensVersion = undefined;

--- a/src/agents/embedded-agent-runner.cache.live.test.ts
+++ b/src/agents/embedded-agent-runner.cache.live.test.ts
@@ -8,9 +8,10 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { disposeOpenClawAgentDatabaseByPath } from "../state/openclaw-agent-db.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
-import { createTestAdmittedRunContext } from "./admitted-run-context.test-support.js";
+import { prepareSystemAgentRunAdmission } from "./admitted-run-context.js";
 import { runEmbeddedAgent } from "./embedded-agent-runner.js";
 import { compactEmbeddedAgentSessionOnDemand } from "./embedded-agent-runner/compact.runtime.js";
+import type { beginPromptCacheObservation } from "./embedded-agent-runner/prompt-cache-observability.js";
 import { extractEmbeddedAssistantText } from "./embedded-agent-utils.js";
 import {
   buildAssistantHistoryTurn as buildTypedAssistantHistoryTurn,
@@ -51,10 +52,12 @@ type CacheRun = {
   usage: AssistantMessage["usage"];
 };
 type CacheTraceEvent = {
+  runId?: string;
   sessionId?: string;
   stage?: string;
   note?: string;
   options?: {
+    snapshot?: ReturnType<typeof beginPromptCacheObservation>["snapshot"];
     previousCacheRead?: number;
     cacheRead?: number;
     changes?: Array<{ code?: string; detail?: string }>;
@@ -68,7 +71,7 @@ const NOOP_TOOL: Tool = {
   parameters: Type.Object({}, { additionalProperties: false }),
 };
 let liveTestPngBase64 = "";
-let liveRunnerRootDir: string | undefined;
+let liveRunnerPaths: { rootDir: string; agentDir: string; storePath: string } | undefined;
 let liveCacheTraceFile: string | undefined;
 let previousCacheTraceEnv: {
   enabled?: string;
@@ -108,18 +111,18 @@ function makeImageUserTurn(text: string): Message {
 }
 
 function buildRunnerSessionPaths(sessionId: string) {
-  if (!liveRunnerRootDir) {
+  if (!liveRunnerPaths) {
     throw new Error("live runner temp root not initialized");
   }
   return {
-    agentDir: liveRunnerRootDir,
+    agentDir: liveRunnerPaths.agentDir,
     sessionTarget: {
       agentId: "main",
       sessionId,
       sessionKey: `agent:main:live-cache:${sessionId}`,
-      storePath: path.join(liveRunnerRootDir, "openclaw-agent.sqlite"),
+      storePath: liveRunnerPaths.storePath,
     },
-    workspaceDir: path.join(liveRunnerRootDir, `${sessionId}-workspace`),
+    workspaceDir: path.join(liveRunnerPaths.rootDir, `${sessionId}-workspace`),
   };
 }
 
@@ -248,6 +251,7 @@ function normalizeLiveUsage(
 
 function buildEmbeddedRunnerConfig(
   params: LiveResolvedModel & {
+    agentDir: string;
     cacheRetention: "none" | "short" | "long";
     compactionModel?: string;
     modelAlias?: string;
@@ -271,7 +275,7 @@ function buildEmbeddedRunnerConfig(
       },
     },
     agents: {
-      entries: { main: {} },
+      entries: { main: { agentDir: params.agentDir } },
       defaults: {
         models: {
           [modelKey]: {
@@ -331,39 +335,47 @@ async function runEmbeddedCacheProbe(params: {
   const sessionPaths = buildRunnerSessionPaths(params.sessionId);
   const runId = `${params.sessionId}-${params.suffix}-${params.transport ?? "default"}`;
   await fs.mkdir(sessionPaths.workspaceDir, { recursive: true });
-  const result = await withLiveCacheHeartbeat(
-    runEmbeddedAgent({
-      admittedRunContext: createTestAdmittedRunContext(runId),
-      sessionId: params.sessionId,
-      sessionTarget: sessionPaths.sessionTarget,
-      workspaceDir: sessionPaths.workspaceDir,
-      agentDir: sessionPaths.agentDir,
-      config: buildEmbeddedRunnerConfig({
-        apiKey: params.apiKey,
-        cacheRetention: params.cacheRetention,
-        model: params.model,
-        transport: params.transport,
+  const config = buildEmbeddedRunnerConfig({
+    agentDir: sessionPaths.agentDir,
+    apiKey: params.apiKey,
+    cacheRetention: params.cacheRetention,
+    model: params.model,
+    transport: params.transport,
+  });
+  // Full-runner probes own a real admission through settlement, just like production callers.
+  const preparedRunAdmission = prepareSystemAgentRunAdmission(config, runId, "main", "live-cache");
+  try {
+    const result = await withLiveCacheHeartbeat(
+      runEmbeddedAgent({
+        preparedRunAdmission,
+        sessionId: params.sessionId,
+        sessionTarget: sessionPaths.sessionTarget,
+        workspaceDir: sessionPaths.workspaceDir,
+        agentDir: sessionPaths.agentDir,
+        config,
+        prompt: buildEmbeddedCachePrompt(params.suffix, params.promptSections),
+        provider: params.model.provider,
+        model: params.model.id,
+        timeoutMs: params.providerTag === "openai" ? OPENAI_TIMEOUT_MS : ANTHROPIC_TIMEOUT_MS,
+        runId,
+        extraSystemPrompt: params.prefix,
+        disableTools: true,
+        cleanupBundleMcpOnRunEnd: true,
       }),
-      prompt: buildEmbeddedCachePrompt(params.suffix, params.promptSections),
-      provider: params.model.provider,
-      model: params.model.id,
-      timeoutMs: params.providerTag === "openai" ? OPENAI_TIMEOUT_MS : ANTHROPIC_TIMEOUT_MS,
-      runId,
-      extraSystemPrompt: params.prefix,
-      disableTools: true,
-      cleanupBundleMcpOnRunEnd: true,
-    }),
-    `${params.providerTag} embedded cache probe ${params.suffix}${params.transport ? ` (${params.transport})` : ""}`,
-  );
-  const text = extractRunPayloadText(result.payloads);
-  expect(text.toLowerCase()).toContain(params.suffix.toLowerCase());
-  const usage = normalizeLiveUsage(result.meta.agentMeta?.usage);
-  return {
-    suffix: params.suffix,
-    text,
-    usage,
-    hitRate: computeCacheHitRate(usage),
-  };
+      `${params.providerTag} embedded cache probe ${params.suffix}${params.transport ? ` (${params.transport})` : ""}`,
+    );
+    const text = extractRunPayloadText(result.payloads);
+    expect(text.toLowerCase()).toContain(params.suffix.toLowerCase());
+    const usage = normalizeLiveUsage(result.meta.agentMeta?.usage);
+    return {
+      suffix: params.suffix,
+      text,
+      usage,
+      hitRate: computeCacheHitRate(usage),
+    };
+  } finally {
+    preparedRunAdmission.close();
+  }
 }
 
 async function compactLiveCacheSession(params: {
@@ -382,6 +394,7 @@ async function compactLiveCacheSession(params: {
       workspaceDir: sessionPaths.workspaceDir,
       agentDir: sessionPaths.agentDir,
       config: buildEmbeddedRunnerConfig({
+        agentDir: sessionPaths.agentDir,
         apiKey: params.apiKey,
         cacheRetention: params.cacheRetention,
         compactionModel: "live-compaction",
@@ -777,8 +790,18 @@ async function runAnthropicImageCacheProbe(params: {
 
 describeCacheLive("embedded agent runner prompt caching (live)", () => {
   beforeAll(async () => {
-    liveRunnerRootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-live-cache-"));
-    liveCacheTraceFile = path.join(liveRunnerRootDir, "cache-trace.jsonl");
+    // Database disposal must use the registered path even when the temporary root is a symlink.
+    const rootDir = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-live-cache-")),
+    );
+    // Auth/catalog and transcript state share this database and must agree on its agent owner.
+    const agentDir = path.join(rootDir, "agents", "main", "agent");
+    liveRunnerPaths = {
+      rootDir,
+      agentDir,
+      storePath: path.join(agentDir, "openclaw-agent.sqlite"),
+    };
+    liveCacheTraceFile = path.join(rootDir, "cache-trace.jsonl");
     liveTestPngBase64 = (await fs.readFile(LIVE_TEST_PNG_URL)).toString("base64");
     previousCacheTraceEnv = {
       enabled: process.env.OPENCLAW_CACHE_TRACE,
@@ -819,11 +842,11 @@ describeCacheLive("embedded agent runner prompt caching (live)", () => {
     }
     previousCacheTraceEnv = null;
     liveCacheTraceFile = undefined;
-    if (liveRunnerRootDir) {
-      disposeOpenClawAgentDatabaseByPath(path.join(liveRunnerRootDir, "openclaw-agent.sqlite"));
-      await fs.rm(liveRunnerRootDir, { recursive: true, force: true });
+    if (liveRunnerPaths) {
+      disposeOpenClawAgentDatabaseByPath(liveRunnerPaths.storePath);
+      await fs.rm(liveRunnerPaths.rootDir, { recursive: true, force: true });
     }
-    liveRunnerRootDir = undefined;
+    liveRunnerPaths = undefined;
   });
 
   describe("openai", () => {
@@ -1356,7 +1379,31 @@ describeCacheLive("embedded agent runner prompt caching (live)", () => {
         );
 
         expect(followup.usage.cacheRead ?? 0).toBeGreaterThan(1_024);
-        expect(followup.hitRate).toBeGreaterThanOrEqual(0.3);
+        // Only previously written prefixes can hit; compacted history must be written again.
+        // Compare the marked stable prefix and policy, not the whole prompt's cache-hit fraction.
+        const cacheEvents = await readCacheTraceEvents(sessionId);
+        const cacheRunIds = ["compact-prime-a", "compact-prime-b", "compact-hit"].map(
+          (suffix) => `${sessionId}-${suffix}-default`,
+        );
+        const cacheSnapshots = cacheRunIds.map(
+          (runId) =>
+            cacheEvents.find((event) => event.stage === "cache:state" && event.runId === runId)
+              ?.options?.snapshot,
+        );
+        const primedCachePolicy = cacheSnapshots[0];
+        expect(primedCachePolicy).toMatchObject({
+          provider: fixture.model.provider,
+          modelId: fixture.model.id,
+          modelApi: "anthropic-messages",
+          cacheRetention: "short",
+          systemPromptDigest: expect.stringMatching(/\S/),
+          toolDigest: expect.stringMatching(/\S/),
+          toolCount: 0,
+          toolNames: [],
+        });
+        for (const [index, snapshot] of cacheSnapshots.entries()) {
+          expect(snapshot, `cache:state for ${cacheRunIds[index]}`).toEqual(primedCachePolicy);
+        }
         await expectCacheTraceStages(sessionId, ["cache:state", "cache:result"]);
       },
       10 * 60_000,

--- a/src/agents/embedded-agent-runner/run.recovery-cancellation.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.recovery-cancellation.test-support.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { SessionManager } from "../sessions/session-manager.js";
@@ -14,6 +15,7 @@ import {
   mockedRunEmbeddedAttempt,
   createOverflowRunParams,
   resetSharedRunIntegrationHarnessMocks,
+  useOpenAIPlatformAuthFixture,
   type TestRunEmbeddedAgent,
 } from "./run.overflow-compaction.harness.js";
 import {
@@ -141,7 +143,7 @@ describe("recovery cancellation through the public run owner", () => {
         } else {
           expect(onCompactionAccounting).toHaveBeenCalledExactlyOnceWith(
             committed
-              ? { kind: "presentation-only", count: 1, currentContextTokens: 40 }
+              ? { kind: "presentation-only", count: 1, currentContextSnapshot: { tokens: 40 } }
               : undefined,
           );
         }
@@ -401,7 +403,7 @@ describe("recovery cancellation through the public run owner", () => {
     expect(facts).toHaveBeenCalledExactlyOnceWith({
       kind: "durable",
       count: testCase.count,
-      currentContextTokens: testCase.currentContextTokens,
+      currentContextSnapshot: { tokens: testCase.currentContextTokens },
       target: {
         ...runParams.sessionTarget,
         lifecycleRevision: undefined,
@@ -411,6 +413,144 @@ describe("recovery cancellation through the public run owner", () => {
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledOnce();
     expect(mockedCompactDirect).not.toHaveBeenCalled();
   });
+
+  it.each(["current", "replaced"] as const)(
+    "finalizes opaque native usage only for its %s writer",
+    async (writer) => {
+      session = await createSharedRunIntegrationSession();
+      const { runParams } = session;
+      const { sessionId, sessionKey, sessionTarget } = runParams;
+      const { createAgentCommandSessionWorkingCopy } =
+        await import("../command/session-helpers.js");
+      const { createCommandCompactionAccounting } =
+        await import("../command/compaction-accounting.js");
+      const { updateSessionStoreAfterAgentRun } = await import("../command/session-store.js");
+      const { SESSION_TOTAL_TOKENS_VERSION } = await import("../../config/sessions/types.js");
+      const { normalizeUsage } = await import("../usage.js");
+      useOpenAIPlatformAuthFixture();
+      const initialEntry = {
+        sessionId,
+        updatedAt: 1,
+        lifecycleRevision: "native-usage-generation",
+        activeWriterRunId: "previous-writer",
+        totalTokens: 0,
+        totalTokensFresh: true,
+        totalTokensVersion: SESSION_TOTAL_TOKENS_VERSION,
+      };
+      await sessionAccessor.replaceSessionEntry(sessionTarget, initialEntry);
+      const { sessionEntry, sessionStore } = createAgentCommandSessionWorkingCopy({
+        sessionKey,
+        sessionEntry: initialEntry,
+        sessionStore: { [sessionKey]: initialEntry },
+      });
+      if (!sessionEntry || !sessionStore) {
+        throw new Error("The command must retain its pre-claim working copy");
+      }
+      const accounting = createCommandCompactionAccounting({
+        sessionStore,
+        persistCounts: true,
+        onDurableFact: () => {},
+        refreshSessionEntry: () => {},
+      });
+      const candidate = accounting.beginCandidate();
+      const assistant = makeAssistantMessageFixture({
+        model: "gpt-5.6-luna",
+        stopReason: "stop",
+        errorMessage: undefined,
+        content: [{ type: "text", text: "Done." }],
+      });
+      assistant.usage = {
+        ...assistant.usage,
+        input: 3,
+        output: 18,
+        cacheRead: 0,
+        cacheWrite: 13_354,
+        totalTokens: 13_375,
+        contextUsage: { state: "available", promptTokens: 13_357, totalTokens: 13_375 },
+      };
+      mockedBuildEmbeddedRunPayloads.mockReturnValue([{ text: "Done." }]);
+      // Native attempts return usage without the built-in subscription's private events.
+      // Keep admission, writer claim, settlement, and final persistence real.
+      mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+        makeAttemptResult({
+          sessionIdUsed: sessionId,
+          assistantTexts: ["Done."],
+          lastAssistant: assistant,
+          currentAttemptAssistant: assistant,
+          attemptUsage: normalizeUsage(assistant.usage),
+        }),
+      );
+
+      const result = await runEmbeddedAgent({
+        ...runParams,
+        provider: "openai",
+        model: "gpt-5.6-luna",
+        compactionCountOwner: "caller",
+        onCompactionAccounting: candidate.observe,
+      });
+      await candidate.finish(sessionEntry);
+      expect(result.meta.agentMeta?.lastCallUsage?.contextUsage).toEqual({
+        state: "available",
+        promptTokens: 13_357,
+        totalTokens: 13_375,
+      });
+      expect(sessionStore[sessionKey]).toMatchObject({
+        activeWriterRunId: "previous-writer",
+        totalTokens: 0,
+        totalTokensFresh: true,
+      });
+      expect(sessionAccessor.loadSessionEntry(sessionTarget)).toMatchObject({
+        activeWriterRunId: runParams.runId,
+      });
+      if (writer === "replaced") {
+        const { claimAgentSessionWriter } = await import("./run/session-bootstrap.js");
+        await claimAgentSessionWriter({ ...runParams, runId: "replacement-writer" });
+      }
+      const beforeFinalization = sessionAccessor.loadSessionEntry(sessionTarget);
+
+      await updateSessionStoreAfterAgentRun({
+        cfg: {},
+        agentDir: path.dirname(sessionTarget.storePath),
+        sessionId,
+        sessionKey,
+        storePath: sessionTarget.storePath,
+        sessionStore,
+        defaultProvider: "openai",
+        defaultModel: "gpt-5.6-luna",
+        result,
+        compactionAccounting: accounting.fact,
+      });
+
+      const persisted = sessionAccessor.loadSessionEntry({
+        ...sessionTarget,
+        readConsistency: "latest",
+      });
+      if (writer === "replaced") {
+        expect(persisted).toEqual(beforeFinalization);
+        expect(persisted).toMatchObject({ activeWriterRunId: "replacement-writer" });
+      } else {
+        expect(persisted?.totalTokens).toBe(13_357);
+        expect(persisted).toMatchObject({
+          activeWriterRunId: runParams.runId,
+          inputTokens: 3,
+          outputTokens: 18,
+          cacheRead: 0,
+          cacheWrite: 13_354,
+          totalTokensFresh: true,
+          totalTokensVersion: SESSION_TOTAL_TOKENS_VERSION,
+        });
+        expect(persisted?.compactionCount).toBeUndefined();
+        expect(accounting.fact).toMatchObject({
+          kind: "durable",
+          count: 0,
+          target: { ...sessionTarget, activeWriterRunId: runParams.runId },
+        });
+      }
+      expect(accounting.fact?.currentContextSnapshot).toBeUndefined();
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledOnce();
+      expect(mockedCompactDirect).not.toHaveBeenCalled();
+    },
+  );
 
   it("compacts and accounts a fresh persistent run whose first append creates the session row", async () => {
     const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");

--- a/src/agents/embedded-agent-runner/run/internal-params.ts
+++ b/src/agents/embedded-agent-runner/run/internal-params.ts
@@ -18,9 +18,9 @@ export type EmbeddedContextAccountingEvent = Readonly<
   | { kind: "model"; contextTokens: number | undefined }
 >;
 
-/** Each fact carries the latest context (undefined means unknown), never authority to resume. */
+/** Writer custody is independent of telemetry; an absent snapshot is not observed unknown context. */
 export type CompactionAccountingFact = Readonly<
-  { count: number; currentContextTokens?: number } & (
+  { count: number; currentContextSnapshot?: { tokens: number | undefined } } & (
     | { kind: "durable"; target: CompactionAccountingTarget }
     | { kind: "presentation-only" }
   )

--- a/src/agents/embedded-agent-runner/run/run-settlement.ts
+++ b/src/agents/embedded-agent-runner/run/run-settlement.ts
@@ -38,40 +38,43 @@ export async function settleEmbeddedRun(input: {
   const params = runInput.runParams;
   // Publish committed bookkeeping before cleanup can throw or cancellation closes the caller.
   // A returned model/session id is never a substitute for the accepted host target.
-  let fact: CompactionAccountingFact | undefined;
-  if (compaction.state.autoCompactionCount > 0 || compaction.state.currentContextSnapshot) {
-    const committed = compaction.session.committedCompactionSuccessor;
-    const originalCompactionWriter = compaction.session.sessionWriterFence;
-    const target = committed?.sessionTarget ?? compaction.originalTarget;
-    const counts = {
-      count: compaction.state.autoCompactionCount,
-      currentContextTokens: compaction.state.currentContextSnapshot?.tokens,
-    };
-    fact =
-      compaction.durable &&
-      (committed || originalCompactionWriter) &&
-      target.agentId &&
-      target.sessionId &&
-      target.sessionKey &&
-      target.storePath
-        ? {
-            kind: "durable",
-            ...counts,
-            target: {
-              agentId: target.agentId,
-              sessionId: committed?.entry.sessionId ?? target.sessionId,
-              sessionKey: target.sessionKey,
-              storePath: target.storePath,
-              lifecycleRevision: committed
-                ? committed.entry.lifecycleRevision
-                : originalCompactionWriter?.expectedLifecycleRevision,
-              activeWriterRunId: committed
-                ? committed.entry.activeWriterRunId
-                : originalCompactionWriter?.expectedWriterRunId,
-            },
-          }
-        : { kind: "presentation-only", ...counts };
-  }
+  const committed = compaction.session.committedCompactionSuccessor;
+  const originalWriter = compaction.session.sessionWriterFence;
+  const target = committed?.sessionTarget ?? compaction.originalTarget;
+  const counts = {
+    count: compaction.state.autoCompactionCount,
+    currentContextSnapshot:
+      compaction.state.currentContextSnapshot ??
+      (compaction.state.autoCompactionCount > 0 ? { tokens: undefined } : undefined),
+  };
+  // Native runtimes can return usage without ordered context events. Carry their
+  // claimed writer without inventing a context observation that would override it.
+  const fact: CompactionAccountingFact | undefined =
+    compaction.durable &&
+    (committed || originalWriter) &&
+    target.agentId &&
+    target.sessionId &&
+    target.sessionKey &&
+    target.storePath
+      ? {
+          kind: "durable",
+          ...counts,
+          target: {
+            agentId: target.agentId,
+            sessionId: committed?.entry.sessionId ?? target.sessionId,
+            sessionKey: target.sessionKey,
+            storePath: target.storePath,
+            lifecycleRevision: committed
+              ? committed.entry.lifecycleRevision
+              : originalWriter?.expectedLifecycleRevision,
+            activeWriterRunId: committed
+              ? committed.entry.activeWriterRunId
+              : originalWriter?.expectedWriterRunId,
+          },
+        }
+      : counts.count > 0 || counts.currentContextSnapshot
+        ? { kind: "presentation-only", ...counts }
+        : undefined;
   if (params.onCompactionAccounting) {
     params.onCompactionAccounting(fact);
   } else if (fact?.kind === "durable" && fact.count > 0) {
@@ -80,7 +83,7 @@ export async function settleEmbeddedRun(input: {
         ...fact.target,
         expectedSession: fact.target,
         amount: fact.count,
-        tokensAfter: fact.currentContextTokens,
+        tokensAfter: fact.currentContextSnapshot?.tokens,
         // Cancellation preserves bookkeeping, but a reused run id cannot lend a new admission.
         authorize: () =>
           compaction.authority !== undefined &&

--- a/src/auto-reply/reply/agent-runner-compaction-accounting.ts
+++ b/src/auto-reply/reply/agent-runner-compaction-accounting.ts
@@ -5,11 +5,11 @@ import type { AgentTurnCompaction } from "./agent-runner-execution.types.js";
 export function invalidateTurnCompactionContext(compaction: AgentTurnCompaction): void {
   compaction.durable = compaction.durable.map((fact) => ({
     ...fact,
-    currentContextTokens: undefined,
+    currentContextSnapshot: { tokens: undefined },
   }));
 }
 
-/** Fold only observations belonging to the same retained writer; zero counts refresh context. */
+/** Fold same-writer facts; only an ordered snapshot may refresh context. */
 export function recordTurnCompaction(
   compaction: AgentTurnCompaction,
   fact: CompactionAccountingFact,
@@ -36,5 +36,10 @@ export function recordTurnCompaction(
   if (previous) {
     compaction.durable.splice(index, 1);
   }
-  compaction.durable.push({ ...fact, count: (previous?.count ?? 0) + fact.count });
+  // Custody without an observation cannot erase the prior candidate's explicit invalidation.
+  compaction.durable.push({
+    ...fact,
+    count: (previous?.count ?? 0) + fact.count,
+    currentContextSnapshot: fact.currentContextSnapshot ?? previous?.currentContextSnapshot,
+  });
 }

--- a/src/auto-reply/reply/agent-runner-embedded-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-embedded-candidate.ts
@@ -425,7 +425,11 @@ export async function runEmbeddedFallbackCandidate(
     const accounting: CompactionAccountingFact | undefined =
       compactionAccounting ??
       (attemptCompactionCount > 0
-        ? { kind: "presentation-only", count: attemptCompactionCount }
+        ? {
+            kind: "presentation-only",
+            count: attemptCompactionCount,
+            currentContextSnapshot: { tokens: undefined },
+          }
         : undefined);
     params.onCompactionFacts({ accounting, postCompactionModelAttempted });
     revokeMessageActionTurnCapability(messageActionTurnCapability);

--- a/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
@@ -58,7 +58,7 @@ describe("executeAgentTurn: run lifecycle and ownership", () => {
     const fact: CompactionAccountingFact = {
       kind: "durable",
       count: 1,
-      currentContextTokens: 40,
+      currentContextSnapshot: { tokens: 40 },
       target: { ...compactionTarget, sessionId: "accepted-successor" },
     };
     const sessionId = "session";
@@ -538,36 +538,37 @@ describe("executeAgentTurn: run lifecycle and ownership", () => {
   );
 
   it.each([
-    { name: "same-owner model", owner: "same", currentContextTokens: 120 },
-    { name: "same-owner zero", owner: "same", currentContextTokens: 0 },
-    { name: "same-owner unknown", owner: "same", currentContextTokens: undefined },
-    { name: "unrelated writer", owner: "different", currentContextTokens: 999 },
-    { name: "opaque candidate", owner: "opaque", currentContextTokens: undefined },
+    { name: "same-owner model", owner: "same", currentContextSnapshot: { tokens: 120 } },
+    { name: "same-owner zero", owner: "same", currentContextSnapshot: { tokens: 0 } },
+    { name: "same-owner unknown", owner: "same", currentContextSnapshot: { tokens: undefined } },
+    { name: "same-owner custody-only", owner: "same", currentContextSnapshot: undefined },
+    { name: "unrelated writer", owner: "different", currentContextSnapshot: { tokens: 999 } },
+    { name: "opaque candidate", owner: "opaque", currentContextSnapshot: undefined },
   ] as const)(
     "aggregates fallback counts without borrowing $name context",
-    async ({ owner, currentContextTokens }) => {
+    async ({ owner, currentContextSnapshot }) => {
       const first: CompactionAccountingFact = {
         kind: "durable",
         count: 1,
-        currentContextTokens: 80,
+        currentContextSnapshot: { tokens: 80 },
         target: compactionTarget,
       };
       const successor: CompactionAccountingFact = {
         kind: "durable",
         count: 3,
-        currentContextTokens: 40,
+        currentContextSnapshot: { tokens: 40 },
         target: { ...compactionTarget, sessionId: "successor" },
       };
       const otherWriter: CompactionAccountingFact = {
         kind: "durable",
         count: 1,
-        currentContextTokens: 20,
+        currentContextSnapshot: { tokens: 20 },
         target: { ...compactionTarget, sessionId: "successor", activeWriterRunId: "other-writer" },
       };
       const latest: CompactionAccountingFact = {
         kind: "durable",
         count: 1,
-        currentContextTokens: 10,
+        currentContextSnapshot: { tokens: 10 },
         target: { ...compactionTarget, sessionId: "latest-successor" },
       };
       const modelOnly: CompactionAccountingFact | undefined =
@@ -576,14 +577,14 @@ describe("executeAgentTurn: run lifecycle and ownership", () => {
           : {
               kind: "durable",
               count: 0,
-              currentContextTokens,
+              ...(currentContextSnapshot ? { currentContextSnapshot } : {}),
               target: {
                 ...latest.target,
                 activeWriterRunId:
                   owner === "different" ? "unrelated-writer" : compactionTarget.activeWriterRunId,
               },
             };
-      const facts = [first, undefined, successor, otherWriter, latest, modelOnly];
+      const facts = [first, undefined, successor, otherWriter, latest, undefined, modelOnly];
       for (const [index, fact] of facts.entries()) {
         state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
           if (fact) {
@@ -616,7 +617,7 @@ describe("executeAgentTurn: run lifecycle and ownership", () => {
               fallbackAttemptOptions(params, "unknown"),
             );
           }
-          return { result, provider: "anthropic", model: "fallback-5", attempts: [] };
+          return { result, provider: "anthropic", model: "fallback-6", attempts: [] };
         },
       );
 
@@ -627,11 +628,14 @@ describe("executeAgentTurn: run lifecycle and ownership", () => {
       expect(result.outcome.compaction).toEqual({
         count: 8,
         durable: [
-          { ...otherWriter, currentContextTokens: undefined },
+          { ...otherWriter, currentContextSnapshot: { tokens: undefined } },
           {
             ...latest,
             count: 5,
-            currentContextTokens: owner === "same" ? currentContextTokens : undefined,
+            currentContextSnapshot:
+              owner === "same" && currentContextSnapshot
+                ? currentContextSnapshot
+                : { tokens: undefined },
           },
         ],
       });

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -383,7 +383,7 @@ async function commitMemoryCompaction(params: {
   params.run?.onCompactionAccounting?.({
     kind: "durable",
     count: 1,
-    currentContextTokens: 42,
+    currentContextSnapshot: { tokens: 42 },
     target: {
       ...accepted.sessionTarget,
       lifecycleRevision: accepted.entry.lifecycleRevision,
@@ -763,7 +763,7 @@ describe("runMemoryFlushIfNeeded", () => {
         params.onCompactionAccounting?.({
           kind: "durable",
           count: 0,
-          currentContextTokens: 120,
+          currentContextSnapshot: { tokens: 120 },
           target: {
             ...accepted.sessionTarget,
             lifecycleRevision: accepted.entry.lifecycleRevision,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -1699,7 +1699,7 @@ export async function runMemoryFlushIfNeeded(params: {
           storePath: fact.target.storePath,
           expectedSession: fact.target,
           amount: fact.count,
-          tokensAfter: fact.currentContextTokens,
+          tokensAfter: fact.currentContextSnapshot?.tokens,
         });
         if (count === undefined) {
           continue;

--- a/src/auto-reply/reply/agent-runner-result-accounting.persistence.test.ts
+++ b/src/auto-reply/reply/agent-runner-result-accounting.persistence.test.ts
@@ -214,7 +214,7 @@ async function createFixture() {
     const fact: CompactionAccountingFact = {
       kind: "durable",
       count: 1,
-      currentContextTokens: params.currentContextTokens,
+      currentContextSnapshot: { tokens: params.currentContextTokens },
       target: {
         agentId: "main",
         sessionKey,
@@ -404,11 +404,19 @@ describe.each(["ordinary", "followup"] as const)("%s context-pressure accounting
       sessionId: "unverified-successor",
       compactionCount: 2,
       compactionTokensAfter: 40,
+      usage: { input: 120, output: 8 },
+      lastCallUsage: { input: 120, output: 8 },
+      promptTokens: 120,
     });
 
     expect(fixture.read()?.sessionId).toBe("session");
     expect(fixture.read()?.compactionCount).toBeUndefined();
-    expect(fixture.read()?.totalTokens).not.toBe(40);
+    expect(fixture.read()?.totalTokens).toBeUndefined();
+    expect(fixture.read()).toMatchObject({
+      totalTokensFresh: false,
+      inputTokens: 120,
+      outputTokens: 8,
+    });
   });
 
   it.each([

--- a/src/auto-reply/reply/agent-runner-result-accounting.ts
+++ b/src/auto-reply/reply/agent-runner-result-accounting.ts
@@ -64,7 +64,7 @@ export async function accountAgentTurnCompaction(params: {
       storePath: fact.target.storePath,
       expectedSession: fact.target,
       amount: fact.count,
-      tokensAfter: fact.currentContextTokens,
+      tokensAfter: fact.currentContextSnapshot?.tokens,
       authorize,
     });
     if (persistedCount !== undefined) {
@@ -96,7 +96,7 @@ export async function accountAgentTurn(context: AgentTurnAccountingContext) {
   let { activeSessionEntry } = context;
   const latestCompaction = execution.compaction?.durable.at(-1);
   const currentContextSnapshot = execution.compaction
-    ? { tokens: latestCompaction?.currentContextTokens }
+    ? (latestCompaction?.currentContextSnapshot ?? { tokens: undefined })
     : undefined;
   const expectedSession = latestCompaction?.target ?? {
     sessionId: activeSessionEntry?.sessionId ?? followupRun.run.sessionId,

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -1000,7 +1000,7 @@ describe("runReplyAgent auto-compaction token update", () => {
           params.onCompactionAccounting?.({
             kind: "durable",
             count: 1,
-            currentContextTokens: 40,
+            currentContextSnapshot: { tokens: 40 },
             target: {
               agentId: "main",
               sessionId: sessionEntry.sessionId,
@@ -1529,7 +1529,7 @@ describe("runReplyAgent Active Memory inline debug", () => {
       params.onCompactionAccounting?.({
         kind: "durable",
         count: 1,
-        currentContextTokens: 1250,
+        currentContextSnapshot: { tokens: 1250 },
         target: {
           agentId: "main",
           sessionId: sessionEntry.sessionId,

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -183,6 +183,11 @@ const describeDisabled = LIVE && !CODEX_HARNESS_LIVE ? describe : describe.skip;
 const CODEX_HARNESS_TIMEOUT_MS = CODEX_HARNESS_RESTART_STRESS ? 3_600_000 : 900_000;
 const DEFAULT_CODEX_MODEL = "openai/gpt-5.6-luna";
 const GATEWAY_CONNECT_TIMEOUT_MS = 60_000;
+// Request-local tool observation requires a negotiated capability, even for admin clients.
+const CODEX_HARNESS_CLIENT_CAPS = [
+  GATEWAY_CLIENT_CAPS.TOOL_EVENTS,
+  ...(CODEX_HARNESS_MULTI_SESSION_PROBE ? [GATEWAY_CLIENT_CAPS.PLUGIN_APPROVALS] : []),
+];
 const CODEX_HARNESS_REASONING_EFFORTS = [
   "minimal",
   "low",
@@ -2146,10 +2151,7 @@ describeLive("gateway live (Codex harness)", () => {
           timeoutMs: GATEWAY_CONNECT_TIMEOUT_MS,
           requestTimeoutMs: CODEX_HARNESS_REQUEST_TIMEOUT_MS,
           clientDisplayName: "vitest-codex-harness-live",
-          // Approval events require an explicit renderer capability even for admin clients.
-          ...(CODEX_HARNESS_MULTI_SESSION_PROBE
-            ? { caps: [GATEWAY_CLIENT_CAPS.PLUGIN_APPROVALS] }
-            : {}),
+          caps: CODEX_HARNESS_CLIENT_CAPS,
           onEvent: captureGatewayEvent,
         });
         activeApprovalClient = client;
@@ -2465,6 +2467,7 @@ describeLive("gateway live (Codex harness)", () => {
               timeoutMs: GATEWAY_CONNECT_TIMEOUT_MS,
               requestTimeoutMs: CODEX_HARNESS_REQUEST_TIMEOUT_MS,
               clientDisplayName: `vitest-codex-resume-stress-${restart}`,
+              caps: CODEX_HARNESS_CLIENT_CAPS,
               onEvent: captureGatewayEvent,
             });
             activeApprovalClient = client;


### PR DESCRIPTION
Closes #133346 — native Codex turns leave fresh-zero usage after `/new`.

Related: #133260 — recovery compaction cancellation and committed-count accounting.

<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where users running native Codex turns would see zero or stale session usage after `/new`, even though the model returned a successful reply and positive usage. The dropped finalization also left the session's context-window metadata stale, making `/status` and the Sessions UI misleading.

## Why This Change Was Made

The inner run correctly claimed a new session writer, but the private accounting handoff was emitted only after a compaction or an ordered context observation. Native runs can return valid usage without either event. The command therefore finalized against its pre-run working copy, and the existing exact-writer guard correctly rejected that stale identity.

Settlement now carries the already-claimed writer independently of context telemetry. An absent context snapshot permits the existing last-call usage calculation; an explicitly unknown snapshot invalidates freshness, while an observed zero remains a real zero. Both command and reply collectors preserve invalidation across opaque fallbacks. Writer checks, replaced/deleted-owner protection, cancellation accounting, and public/private boundaries remain intact—no latest-row authority adoption, new registry, schema, configuration, protocol, or dependency change.

The requested live verification also exposed stale fixtures: the embedded-cache helper supplied an unbound admission and contradictory agent-directory/database ownership, while the native client omitted the tool-event capability required by its own evidence assertions. Those fixtures now use real admission, consistent temporary ownership, and negotiated tool events before and after restart. The Anthropic post-compaction test checks identical marked-prefix/cache-policy snapshots and real cache reuse instead of assuming that 30% of a rewritten conversation must already be cached. Its prompts, provider/model selection, successful-compaction checks, response checks, and minimum actual cache reads remain unchanged.

## User Impact

Completed native turns update their own token usage and effective context window without requiring a compaction event. Superseded runs still cannot overwrite another writer's session. Unknown post-compaction context stays unknown rather than borrowing stale usage.

## Evidence

The regression test exercises real admission, SQLite writer claim, run settlement, command collection, and final persistence; only the native provider attempt is substituted. Against the original production code, the current-writer case fails after finalization at **0 versus 13,357 tokens**, while the replaced-writer control passes. Both pass with the repair.

On the integrated candidate, **637 focused tests across nine files** passed, followed by the complete changed-code gates, core/core-test typechecks, typed lint, import-cycle/ownership guards, and a full build. Fresh independent Codex review returned scoped-clean at its configured blocking-findings threshold.

Authenticated live proof used isolated per-case homes/state/config/native homes and only the selected CI-hydrated API key:

- **Native Codex API key:** passed the original usage assertion, both four-compaction stress waves, exact event/result/persisted-count parity, real 300,000-byte native commands, hidden-marker recall, and an owned Gateway/app-server restart. The same native thread resumed with a different client. Persisted counts went **0 → 4**, then **5 → 9** in the post-restart wave.
- **OpenAI AgentSession:** two actual automatic compactions across five dense turns, followed by exact durable-marker recall.
- **OpenAI embedded cache:** repeated real runner turns retained cache reuse.
- **Anthropic:** actual manual compaction and a successful follow-up with more than 1,024 cached tokens. The final marked-prefix assertion verification is recorded below.

The final test-only delta passed on tree `b7576b82854be131631433439415bceae72c8cd5` in a fresh Blacksmith Testbox `tbx_01m19wf10jnmc3jve9cq5ypgxf` ([run 33326184977](https://github.com/openclaw/openclaw/actions/runs/33326184977)): complete core-test typechecking, targeted typed lint/formatting, a full build, and both selected Anthropic/OpenAI embedded-cache live cases. Anthropic compacted successfully, replied successfully, reused 2,212 cached tokens, and retained identical marked-prefix/cache-policy snapshots. Production and all other test files are byte-identical to the fully verified native/compaction candidate.

Full native/compaction proof used Blacksmith Testbox `tbx_01m19rq9yz9j99a3bmnzk2s4h3`, hydrated by [run 33323141034](https://github.com/openclaw/openclaw/actions/runs/33323141034). The externally executed command verdicts, not the hydration workflow's cleanup conclusion, are the proof. The initial full command correctly failed the uncalibrated Anthropic whole-request fraction; a diagnostic rerun proved identical marked-prefix/tool/model/cache-policy fingerprints and successful compaction with a 15.2% whole-request hit rate. [Anthropic's cache contract](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) matches previously written cumulative prefixes and promises no first-post-compaction percentage.

### Real Control UI before and after

The same native API-key `/new` flow was run against the original and repaired production code with the real gateway-served Control UI enabled in a temporary diagnostic test copy. Normal dashboard authentication was used; no application-state injection, API mock, or authentication bypass. Existing assertions remained active: the original failed its fresh-zero check after capture, and the repaired case passed. Diagnostic source was restored byte-for-byte afterward. Every capture was inspected and contains only synthetic session data.

| Before | After |
| --- | --- |
| ![Before: successful native turn still shows zero session tokens](https://github.com/user-attachments/assets/075438d8-02f5-41fb-b872-a2aaf407ee5f) | ![After: the same flow shows 13,356 tokens and the native effective context window](https://github.com/user-attachments/assets/b3ecc5d2-1266-4b08-8100-fa7f24270731) |

The repaired UI shows **13,356 / 258,400** tokens. The original also retained the catalog's 272,000-token window because its metadata finalization was rejected; the repair persists the actual native window as well.

https://github.com/user-attachments/assets/16914aaa-7ecd-40bf-9076-7b51ca5296e1

<details>
<summary>Focused and live commands</summary>

```bash
pnpm test src/agents/agent-command.compaction-rotation.test.ts src/agents/agent-command.embedded-maintenance.test.ts src/agents/agent-command.live-model-switch.test.ts src/agents/command/session-store.test.ts src/agents/embedded-agent-runner/run.shared-integration.test.ts src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts src/auto-reply/reply/agent-runner-result-accounting.persistence.test.ts src/auto-reply/reply/agent-runner-memory.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
```

```bash
pnpm build
```

```bash
OPENCLAW_LIVE_OPENAI_COMPACTION=1 OPENCLAW_LIVE_OPENAI_COMPACTION_FULL=0 pnpm test:live src/agents/sessions/agent-session.openai-compaction.live.test.ts
```

```bash
OPENCLAW_LIVE_CACHE_TEST=1 pnpm test:live src/agents/embedded-agent-runner.cache.live.test.ts -t 'preserves cache-safe shaping across compaction followup turns'
```

```bash
OPENCLAW_LIVE_CACHE_TEST=1 pnpm test:live src/agents/embedded-agent-runner.cache.live.test.ts -t 'keeps high OpenAI cache-read rates across repeated embedded-runner turns'
```

```bash
OPENCLAW_LIVE_CODEX_HARNESS=1 OPENCLAW_LIVE_CODEX_HARNESS_AUTH=api-key OPENCLAW_LIVE_CODEX_HARNESS_COMPACTION_STRESS=1 OPENCLAW_LIVE_CODEX_HARNESS_RESUME_STRESS_RESTARTS=1 pnpm test:live src/gateway/gateway-codex-harness.live.test.ts
```

The full `node scripts/check-changed.mjs -- <changed paths>` plan covered all 19 changed paths. The final test-only delta also receives the core-test typecheck and matching targeted typed-lint command. All application execution ran remotely; no operator gateway or state was used.

</details>

### Scope and proof boundaries

Production: **+70/−52 = +18 lines** across eight files. Tests/test support: **+334/−96 = +238 lines**; docs: **+2**. The production growth separates an existing writer-ownership fact from optional telemetry while keeping one canonical handoff; the old telemetry-gated publication path is removed, not retained as a fallback.

Codex `0.151.0` contracts were inspected directly at upstream commit `78c290807ce710180111df227df3b7a4fe845452`: exact optional response usage (`core/src/session/turn.rs:2567`, protocol `v2/thread.rs:1834`), last-request context and compaction recomputation (`context_manager/history.rs:416`, `session/mod.rs:4155`), and native command/event presentation (`tools/handlers/shell_spec.rs:21`, protocol `v2/item.rs:286,901`).

OAuth, Gemini, and full-window stress are not claimed by these runs. The native test used its existing reduced stress profile. No release/version publication or storage migration is part of this change.
