### PR TITLE
fix(line): pace block replies with the agent's humanDelay

### DIFF
--- a/extensions/line/src/monitor.lifecycle.test.ts
+++ b/extensions/line/src/monitor.lifecycle.test.ts
@@ -410,7 +410,8 @@ describe("monitorLineProvider lifecycle", () => {
           accountId: "default",
           turn: { record: {} },
         } as unknown as Parameters<typeof onMessage>[0],
-        {} as Parameters<typeof onMessage>[1],
+        // Admission always hands the turn its live config; an empty one is unreachable.
+        { cfg: {} } as Parameters<typeof onMessage>[1],
       );
 
       const prepared = resolvedTurn?.delivery.preparePayload?.({
@@ -430,6 +431,64 @@ describe("monitorLineProvider lifecycle", () => {
       expect(line?.flexMessage).toBeDefined();
     } finally {
       // A leaked registration makes later shared-path signature tests ambiguous.
+      await monitor.stop();
+    }
+  });
+
+  it("paces block replies with the humanDelay the turn's own config carries", async () => {
+    // humanDelay lives on the agent, but only the dispatcher can act on it, so a
+    // turn that never forwards it paces every block reply at zero.
+    const { setLineRuntime } = await import("./runtime.js");
+    type ResolvedTurn = { dispatcherOptions?: { humanDelay?: unknown } };
+    let resolvedTurn: ResolvedTurn | undefined;
+    const runTurn = async (params: {
+      adapter: { resolveTurn: () => ResolvedTurn };
+    }): Promise<{ dispatched: false }> => {
+      resolvedTurn = params.adapter.resolveTurn();
+      return { dispatched: false };
+    };
+    setLineRuntime({
+      channel: { inbound: { run: runTurn } },
+    } as unknown as Parameters<typeof setLineRuntime>[0]);
+    const monitor = await monitorLineProvider({
+      channelAccessToken: "token",
+      channelSecret: "secret", // pragma: allowlist secret
+      config: {} as OpenClawConfig,
+      runtime: {} as RuntimeEnv,
+    });
+    const onMessage = createLineBotMock.mock.calls[0]?.[0]?.onMessage;
+    if (!onMessage) {
+      throw new Error("expected the LINE bot to receive an inbound message handler");
+    }
+
+    try {
+      await onMessage(
+        {
+          ctxPayload: { From: "line:U1", MessageSid: "m1", RawBody: "hi" },
+          replyToken: "reply-token",
+          route: { accountId: "default", agentId: "ops", sessionKey: "line:U1" },
+          isGroup: false,
+          accountId: "default",
+          turn: { record: {} },
+        } as unknown as Parameters<typeof onMessage>[0],
+        {
+          // The per-agent entry wins, so a turn reading only the defaults would
+          // pace at the wrong interval rather than not at all.
+          cfg: {
+            agents: {
+              defaults: { humanDelay: { mode: "natural" } },
+              entries: { ops: { humanDelay: { mode: "custom", minMs: 3_000, maxMs: 4_000 } } },
+            },
+          },
+        } as Parameters<typeof onMessage>[1],
+      );
+
+      expect(resolvedTurn?.dispatcherOptions?.humanDelay).toEqual({
+        mode: "custom",
+        minMs: 3_000,
+        maxMs: 4_000,
+      });
+    } finally {
       await monitor.stop();
     }
   });
@@ -470,7 +529,8 @@ describe("monitorLineProvider lifecycle", () => {
           skillFilter: ["triage"],
           turn: { record: {} },
         } as unknown as Parameters<typeof onMessage>[0],
-        {} as Parameters<typeof onMessage>[1],
+        // Admission always hands the turn its live config; an empty one is unreachable.
+        { cfg: {} } as Parameters<typeof onMessage>[1],
       );
 
       expect(resolvedTurn?.replyOptions?.skillFilter).toEqual(["triage"]);

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -1,5 +1,6 @@
 // Line plugin module implements monitor behavior.
 import type { webhook } from "@line/bot-sdk";
+import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
 import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
 import { hasFinalInboundReplyDispatch } from "openclaw/plugin-sdk/channel-inbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -225,6 +226,11 @@ export async function monitorLineProvider(
               ctxPayload,
               record: ctx.turn.record,
               replyPipeline: {},
+              // Block replies are paced by the agent's own humanDelay; nothing else
+              // reads it, so a turn that never forwards it silently paces at zero.
+              dispatcherOptions: {
+                humanDelay: resolveHumanDelayConfig(turnConfig, route.agentId),
+              },
               ...(replyOptions ? { replyOptions } : {}),
               delivery: {
                 // Core renders presentations inside the outbound send pipeline only,


### PR DESCRIPTION
Fixes #133430

## What Problem This Solves

`agents.defaults.humanDelay` — and its per-agent `agents.entries.*.humanDelay`
override — was accepted on LINE and silently did nothing. Block replies arrived
back-to-back no matter what pause was configured, and nothing in `doctor`,
startup, or the logs said the channel was ignoring it.

Only `createReplyDispatcher` can act on the setting: it reads
`options.humanDelay` and sleeps before every block after the first. `options`
comes from the turn's `dispatcherOptions`, and LINE's turn never set one, so the
value resolved to `undefined` on every turn.

## Why This Change Was Made

This is the same defect Telegram had in #68945, fixed in #69022 by forwarding the
resolved config into that channel's `dispatcherOptions`. This gives LINE the same
wiring — one line at the one seam that owns it — rather than adding a second
pacing mechanism.

It resolves from `turnConfig`, not the monitor's captured config. Admission
already re-read the live config for this event and the delivery path runs on that
same one, so a `humanDelay` edited while the gateway is running takes effect on
the very next turn instead of the next restart.

## User Impact

On LINE, a configured `humanDelay` now paces block replies: each block after the
first waits the configured interval, so a multi-message answer arrives at a human
rhythm instead of all at once. `off` (the default) is unchanged — no delay, no
new behavior for anyone who has not set the option.

## Evidence

### Live: real LINE channel, same three-block answer, both sides of the fix

An agent turn that produces three assistant blocks, with
`blockStreamingDefault: "on"` and `humanDelay: { mode: "custom", minMs: 8000,
maxMs: 8000 }`. Timing runs from webhook delivery until the channel's push-quota
counter reflects all four sends:

```
label=BEFORE-main    quota 166 -> 170  elapsed=2.9s
label=AFTER-fix      quota 171 -> 175  elapsed=19.6s
label=AFTER-fix-run2 quota 175 -> 179  elapsed=18.4s
```

The quota moving by 4 shows LINE delivers each block as its own push, so the
dispatcher path that applies the delay is the one in use. The ~16s difference is
the two paced gaps the setting asks for: the first block and the final reply are
not delayed, so three blocks produce two 8s pauses.

### Regression coverage

`monitor.lifecycle.test.ts` asserts the turn LINE hands to core carries the
resolved `humanDelay`, and uses a per-agent entry that differs from the defaults
so a turn reading the wrong scope fails rather than passing on a lucky match.

Reverting the change fails it with
`expected undefined to deeply equal { mode: 'custom', minMs: 3000, … }`.

The same test file's two existing turn-adapter cases passed an empty delivery
control, a state admission cannot produce — they now pass the live config the
real path always supplies.

### Checks

```
$ node scripts/run-vitest.mjs extensions/line
 Test Files  47 passed (47)
      Tests  696 passed (696)

$ node scripts/check-changed.mjs
(exit 0)
```

### Sibling surfaces

Seven other channels declare `blockStreaming: true` and also never forward the
setting — `clickclack`, `googlechat`, `irc`, `nextcloud-talk`, `reef`, `zalo`,
`zalouser`. I verified the mechanism end to end on LINE only, so they are named
in #133430 as follow-up rather than changed blind here. Worth noting for whoever
picks those up: `humanDelay` is the one `dispatcherOptions` field that is neither
channel-specific nor a callback — every channel resolves it from the same agent
config the same way, so absorbing it into `resolveAssembledReplyPipeline` would
fix all eight at once and delete eleven copies of this line. That is an
owner-boundary call, not one to make inside a channel fix.
