### PR TITLE
fix(doctor): preserve disabled shared heartbeat owners

### DIFF
--- a/src/commands/doctor-heartbeat-scratch-migration.test.ts
+++ b/src/commands/doctor-heartbeat-scratch-migration.test.ts
@@ -16,6 +16,7 @@ import {
   collectHeartbeatScratchMigrationFindings,
   maybeMigrateHeartbeatFilesToScratch,
 } from "./doctor-heartbeat-scratch-migration.js";
+import { maybeMigrateHeartbeatTasksToCron } from "./doctor-heartbeat-task-migration.js";
 
 const tempDirs: string[] = [];
 let originalHome: string | undefined;
@@ -180,6 +181,247 @@ describe("HEARTBEAT.md cron scratch migration", () => {
         "shared checklist\n",
       );
     }
+  });
+
+  it("leaves a shared workspace file untouched when only a disabled agent is enrolled", async () => {
+    const fixture = await createFixture();
+    const cfg = {
+      agents: {
+        defaults: { heartbeat: { every: "30m" }, workspace: fixture.workspace },
+        list: [
+          { id: "main", workspace: fixture.workspace },
+          { id: "ollama", workspace: fixture.workspace, heartbeat: { every: "0m" } },
+        ],
+      },
+    } as OpenClawConfig;
+    await fs.writeFile(fixture.heartbeatPath, "shared checklist\n", "utf8");
+
+    await expect(collectHeartbeatScratchMigrationFindings(cfg)).resolves.toEqual([]);
+    const result = await maybeMigrateHeartbeatFilesToScratch({ cfg, shouldRepair: true });
+
+    expect(result).toEqual({ changes: [], warnings: [] });
+    await expect(fs.readFile(fixture.heartbeatPath, "utf8")).resolves.toBe("shared checklist\n");
+  });
+
+  it("copies into enabled scratch while retaining a file shared with a disabled agent", async () => {
+    const fixture = await createFixture();
+    const cfg = {
+      agents: {
+        defaults: { workspace: fixture.workspace },
+        list: [
+          { id: "main", workspace: fixture.workspace, heartbeat: { every: "30m" } },
+          { id: "ollama", workspace: fixture.workspace, heartbeat: { every: "0m" } },
+        ],
+      },
+    } as OpenClawConfig;
+    await fs.writeFile(fixture.heartbeatPath, "shared checklist\n", "utf8");
+
+    await expect(collectHeartbeatScratchMigrationFindings(cfg)).resolves.toEqual([]);
+    const result = await maybeMigrateHeartbeatFilesToScratch({ cfg, shouldRepair: true });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0]).toContain("retained the shared legacy file");
+    await expect(fs.readFile(fixture.heartbeatPath, "utf8")).resolves.toBe("shared checklist\n");
+    const { monitor, storePath } = await loadMonitor(cfg);
+    expect(readCronJobScratchState(storePath, monitor.id).scratch?.content).toBe(
+      "shared checklist\n",
+    );
+
+    const rename = vi.spyOn(fs, "rename");
+    const rerun = await maybeMigrateHeartbeatFilesToScratch({ cfg, shouldRepair: true });
+    expect(rerun).toEqual({ changes: [], warnings: [] });
+    expect(rename).not.toHaveBeenCalled();
+    await expect(fs.readFile(fixture.heartbeatPath, "utf8")).resolves.toBe("shared checklist\n");
+  });
+
+  it("imports a retained task source after its disabled owner is re-enabled", async () => {
+    const fixture = await createFixture();
+    const source =
+      "# Checklist\n\ntasks:\n  - name: inbox\n    interval: 1h\n    prompt: Check inbox\n";
+    const mixed = {
+      agents: {
+        defaults: { workspace: fixture.workspace },
+        list: [
+          { id: "main", workspace: fixture.workspace, heartbeat: { every: "30m" } },
+          { id: "ollama", workspace: fixture.workspace, heartbeat: { every: "0m" } },
+        ],
+      },
+    } as OpenClawConfig;
+    await fs.writeFile(fixture.heartbeatPath, source, "utf8");
+
+    await maybeMigrateHeartbeatFilesToScratch({ cfg: mixed, shouldRepair: true });
+    await maybeMigrateHeartbeatTasksToCron({ cfg: mixed, shouldRepair: true });
+    const enabled = {
+      agents: {
+        defaults: { workspace: fixture.workspace },
+        list: [
+          { id: "main", workspace: fixture.workspace, heartbeat: { every: "30m" } },
+          { id: "ollama", workspace: fixture.workspace, heartbeat: { every: "30m" } },
+        ],
+      },
+    } as OpenClawConfig;
+
+    const result = await maybeMigrateHeartbeatFilesToScratch({
+      cfg: enabled,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toEqual([]);
+    await expect(fs.access(fixture.heartbeatPath)).rejects.toMatchObject({ code: "ENOENT" });
+    const storePath = resolveCronJobsStorePath();
+    const store = await loadCronJobsStore(storePath);
+    const monitor = store.jobs.find(
+      (job) => job.agentId === "ollama" && job.payload.kind === "heartbeat",
+    );
+    expect(monitor).toBeDefined();
+    expect(readCronJobScratchState(storePath, monitor!.id).scratch?.content).toBe(source);
+  });
+
+  it("imports a changed retained source into a re-enabled owner without overwriting its peer", async () => {
+    const fixture = await createFixture();
+    const mixed = {
+      agents: {
+        defaults: { workspace: fixture.workspace },
+        list: [
+          { id: "main", workspace: fixture.workspace, heartbeat: { every: "30m" } },
+          { id: "ollama", workspace: fixture.workspace, heartbeat: { every: "0m" } },
+        ],
+      },
+    } as OpenClawConfig;
+    await fs.writeFile(fixture.heartbeatPath, "original checklist\n", "utf8");
+    await maybeMigrateHeartbeatFilesToScratch({ cfg: mixed, shouldRepair: true });
+    await fs.writeFile(fixture.heartbeatPath, "updated checklist\n", "utf8");
+    const enabled = {
+      agents: {
+        defaults: { workspace: fixture.workspace },
+        list: [
+          { id: "main", workspace: fixture.workspace, heartbeat: { every: "30m" } },
+          { id: "ollama", workspace: fixture.workspace, heartbeat: { every: "30m" } },
+        ],
+      },
+    } as OpenClawConfig;
+
+    const result = await maybeMigrateHeartbeatFilesToScratch({
+      cfg: enabled,
+      shouldRepair: true,
+    });
+
+    expect(result.changes).toHaveLength(1);
+    expect(result.warnings.join("\n")).toContain("already has different cron scratch");
+    await expect(fs.readFile(fixture.heartbeatPath, "utf8")).resolves.toBe("updated checklist\n");
+    const storePath = resolveCronJobsStorePath();
+    const store = await loadCronJobsStore(storePath);
+    const scratchByAgentId = new Map(
+      store.jobs
+        .filter((job) => job.payload.kind === "heartbeat")
+        .map((job) => [job.agentId, readCronJobScratchState(storePath, job.id).scratch?.content]),
+    );
+    expect(scratchByAgentId.get("main")).toBe("original checklist\n");
+    expect(scratchByAgentId.get("ollama")).toBe("updated checklist\n");
+  });
+
+  it("does not import stale bytes while retaining a shared disabled-owner file", async () => {
+    const fixture = await createFixture();
+    const cfg = {
+      agents: {
+        defaults: { workspace: fixture.workspace },
+        list: [
+          { id: "main", workspace: fixture.workspace, heartbeat: { every: "30m" } },
+          { id: "ollama", workspace: fixture.workspace, heartbeat: { every: "0m" } },
+        ],
+      },
+    } as OpenClawConfig;
+    await fs.writeFile(fixture.heartbeatPath, "planned content\n", "utf8");
+    const rename = fs.rename.bind(fs);
+    vi.spyOn(fs, "rename").mockImplementationOnce(async (from, to) => {
+      await fs.writeFile(String(from), "concurrent replacement\n", "utf8");
+      await rename(from, to);
+    });
+
+    const result = await maybeMigrateHeartbeatFilesToScratch({ cfg, shouldRepair: true });
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings.join("\n")).toContain("changed before the migration claim");
+    await expect(fs.readFile(fixture.heartbeatPath, "utf8")).resolves.toBe(
+      "concurrent replacement\n",
+    );
+    const { monitor, storePath } = await loadMonitor(cfg);
+    expect(readCronJobScratchState(storePath, monitor.id)).toEqual({ currentRevision: 0 });
+  });
+
+  it("rolls back retained scratch when the claimed inode changes after acquisition", async () => {
+    const fixture = await createFixture();
+    const cfg = {
+      agents: {
+        defaults: { workspace: fixture.workspace },
+        list: [
+          { id: "main", workspace: fixture.workspace, heartbeat: { every: "30m" } },
+          { id: "ollama", workspace: fixture.workspace, heartbeat: { every: "0m" } },
+        ],
+      },
+    } as OpenClawConfig;
+    await fs.writeFile(fixture.heartbeatPath, "planned content\n", "utf8");
+    const sourceHandle = await fs.open(fixture.heartbeatPath, "r+");
+    const link = fs.link.bind(fs);
+    vi.spyOn(fs, "link").mockImplementationOnce(async (from, to) => {
+      await sourceHandle.truncate(0);
+      await sourceHandle.writeFile("post-claim descriptor edit\n", "utf8");
+      await sourceHandle.sync();
+      await link(from, to);
+    });
+
+    let result;
+    try {
+      result = await maybeMigrateHeartbeatFilesToScratch({ cfg, shouldRepair: true });
+    } finally {
+      await sourceHandle.close();
+    }
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings.join("\n")).toContain("changed after the migration claim was restored");
+    await expect(fs.readFile(fixture.heartbeatPath, "utf8")).resolves.toBe(
+      "post-claim descriptor edit\n",
+    );
+    const { monitor, storePath } = await loadMonitor(cfg);
+    expect(readCronJobScratchState(storePath, monitor.id)).toEqual({ currentRevision: 0 });
+  });
+
+  it("rolls back retained scratch when the claimed inode changes during restoration", async () => {
+    const fixture = await createFixture();
+    const cfg = {
+      agents: {
+        defaults: { workspace: fixture.workspace },
+        list: [
+          { id: "main", workspace: fixture.workspace, heartbeat: { every: "30m" } },
+          { id: "ollama", workspace: fixture.workspace, heartbeat: { every: "0m" } },
+        ],
+      },
+    } as OpenClawConfig;
+    await fs.writeFile(fixture.heartbeatPath, "planned content\n", "utf8");
+    const sourceHandle = await fs.open(fixture.heartbeatPath, "r+");
+    const link = fs.link.bind(fs);
+    vi.spyOn(fs, "link").mockImplementationOnce(async (from, to) => {
+      await link(from, to);
+      await sourceHandle.truncate(0);
+      await sourceHandle.writeFile("restore-window descriptor edit\n", "utf8");
+      await sourceHandle.sync();
+    });
+
+    let result;
+    try {
+      result = await maybeMigrateHeartbeatFilesToScratch({ cfg, shouldRepair: true });
+    } finally {
+      await sourceHandle.close();
+    }
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings.join("\n")).toContain("changed after the migration claim was restored");
+    await expect(fs.readFile(fixture.heartbeatPath, "utf8")).resolves.toBe(
+      "restore-window descriptor edit\n",
+    );
+    const { monitor, storePath } = await loadMonitor(cfg);
+    expect(readCronJobScratchState(storePath, monitor.id)).toEqual({ currentRevision: 0 });
   });
 
   it("respects a configured cron store partition", async () => {

--- a/src/commands/doctor-heartbeat-scratch-migration.test.ts
+++ b/src/commands/doctor-heartbeat-scratch-migration.test.ts
@@ -73,6 +73,18 @@ async function loadMonitor(cfg?: OpenClawConfig) {
   return { monitor, storePath };
 }
 
+function sharedHeartbeatConfig(workspace: string, ollamaEvery = "0m") {
+  return {
+    agents: {
+      defaults: { workspace },
+      list: [
+        { id: "main", workspace, heartbeat: { every: "30m" } },
+        { id: "ollama", workspace, heartbeat: { every: ollamaEvery } },
+      ],
+    },
+  } as OpenClawConfig;
+}
+
 describe("HEARTBEAT.md cron scratch migration", () => {
   it("previews without mutation, then migrates, archives, and reruns idempotently", async () => {
     const fixture = await createFixture();
@@ -205,15 +217,7 @@ describe("HEARTBEAT.md cron scratch migration", () => {
 
   it("copies into enabled scratch while retaining a file shared with a disabled agent", async () => {
     const fixture = await createFixture();
-    const cfg = {
-      agents: {
-        defaults: { workspace: fixture.workspace },
-        list: [
-          { id: "main", workspace: fixture.workspace, heartbeat: { every: "30m" } },
-          { id: "ollama", workspace: fixture.workspace, heartbeat: { every: "0m" } },
-        ],
-      },
-    } as OpenClawConfig;
+    const cfg = sharedHeartbeatConfig(fixture.workspace);
     await fs.writeFile(fixture.heartbeatPath, "shared checklist\n", "utf8");
 
     await expect(collectHeartbeatScratchMigrationFindings(cfg)).resolves.toEqual([]);
@@ -239,28 +243,12 @@ describe("HEARTBEAT.md cron scratch migration", () => {
     const fixture = await createFixture();
     const source =
       "# Checklist\n\ntasks:\n  - name: inbox\n    interval: 1h\n    prompt: Check inbox\n";
-    const mixed = {
-      agents: {
-        defaults: { workspace: fixture.workspace },
-        list: [
-          { id: "main", workspace: fixture.workspace, heartbeat: { every: "30m" } },
-          { id: "ollama", workspace: fixture.workspace, heartbeat: { every: "0m" } },
-        ],
-      },
-    } as OpenClawConfig;
+    const mixed = sharedHeartbeatConfig(fixture.workspace);
     await fs.writeFile(fixture.heartbeatPath, source, "utf8");
 
     await maybeMigrateHeartbeatFilesToScratch({ cfg: mixed, shouldRepair: true });
     await maybeMigrateHeartbeatTasksToCron({ cfg: mixed, shouldRepair: true });
-    const enabled = {
-      agents: {
-        defaults: { workspace: fixture.workspace },
-        list: [
-          { id: "main", workspace: fixture.workspace, heartbeat: { every: "30m" } },
-          { id: "ollama", workspace: fixture.workspace, heartbeat: { every: "30m" } },
-        ],
-      },
-    } as OpenClawConfig;
+    const enabled = sharedHeartbeatConfig(fixture.workspace, "30m");
 
     const result = await maybeMigrateHeartbeatFilesToScratch({
       cfg: enabled,
@@ -280,27 +268,11 @@ describe("HEARTBEAT.md cron scratch migration", () => {
 
   it("imports a changed retained source into a re-enabled owner without overwriting its peer", async () => {
     const fixture = await createFixture();
-    const mixed = {
-      agents: {
-        defaults: { workspace: fixture.workspace },
-        list: [
-          { id: "main", workspace: fixture.workspace, heartbeat: { every: "30m" } },
-          { id: "ollama", workspace: fixture.workspace, heartbeat: { every: "0m" } },
-        ],
-      },
-    } as OpenClawConfig;
+    const mixed = sharedHeartbeatConfig(fixture.workspace);
     await fs.writeFile(fixture.heartbeatPath, "original checklist\n", "utf8");
     await maybeMigrateHeartbeatFilesToScratch({ cfg: mixed, shouldRepair: true });
     await fs.writeFile(fixture.heartbeatPath, "updated checklist\n", "utf8");
-    const enabled = {
-      agents: {
-        defaults: { workspace: fixture.workspace },
-        list: [
-          { id: "main", workspace: fixture.workspace, heartbeat: { every: "30m" } },
-          { id: "ollama", workspace: fixture.workspace, heartbeat: { every: "30m" } },
-        ],
-      },
-    } as OpenClawConfig;
+    const enabled = sharedHeartbeatConfig(fixture.workspace, "30m");
 
     const result = await maybeMigrateHeartbeatFilesToScratch({
       cfg: enabled,
@@ -308,6 +280,8 @@ describe("HEARTBEAT.md cron scratch migration", () => {
     });
 
     expect(result.changes).toHaveLength(1);
+    expect(result.changes[0]).toContain("another heartbeat owner's scratch was left unchanged");
+    expect(result.changes[0]).not.toContain("disabled");
     expect(result.warnings.join("\n")).toContain("already has different cron scratch");
     await expect(fs.readFile(fixture.heartbeatPath, "utf8")).resolves.toBe("updated checklist\n");
     const storePath = resolveCronJobsStorePath();
@@ -323,15 +297,7 @@ describe("HEARTBEAT.md cron scratch migration", () => {
 
   it("does not import stale bytes while retaining a shared disabled-owner file", async () => {
     const fixture = await createFixture();
-    const cfg = {
-      agents: {
-        defaults: { workspace: fixture.workspace },
-        list: [
-          { id: "main", workspace: fixture.workspace, heartbeat: { every: "30m" } },
-          { id: "ollama", workspace: fixture.workspace, heartbeat: { every: "0m" } },
-        ],
-      },
-    } as OpenClawConfig;
+    const cfg = sharedHeartbeatConfig(fixture.workspace);
     await fs.writeFile(fixture.heartbeatPath, "planned content\n", "utf8");
     const rename = fs.rename.bind(fs);
     vi.spyOn(fs, "rename").mockImplementationOnce(async (from, to) => {
@@ -352,15 +318,7 @@ describe("HEARTBEAT.md cron scratch migration", () => {
 
   it("rolls back retained scratch when the claimed inode changes after acquisition", async () => {
     const fixture = await createFixture();
-    const cfg = {
-      agents: {
-        defaults: { workspace: fixture.workspace },
-        list: [
-          { id: "main", workspace: fixture.workspace, heartbeat: { every: "30m" } },
-          { id: "ollama", workspace: fixture.workspace, heartbeat: { every: "0m" } },
-        ],
-      },
-    } as OpenClawConfig;
+    const cfg = sharedHeartbeatConfig(fixture.workspace);
     await fs.writeFile(fixture.heartbeatPath, "planned content\n", "utf8");
     const sourceHandle = await fs.open(fixture.heartbeatPath, "r+");
     const link = fs.link.bind(fs);
@@ -389,15 +347,7 @@ describe("HEARTBEAT.md cron scratch migration", () => {
 
   it("rolls back retained scratch when the claimed inode changes during restoration", async () => {
     const fixture = await createFixture();
-    const cfg = {
-      agents: {
-        defaults: { workspace: fixture.workspace },
-        list: [
-          { id: "main", workspace: fixture.workspace, heartbeat: { every: "30m" } },
-          { id: "ollama", workspace: fixture.workspace, heartbeat: { every: "0m" } },
-        ],
-      },
-    } as OpenClawConfig;
+    const cfg = sharedHeartbeatConfig(fixture.workspace);
     await fs.writeFile(fixture.heartbeatPath, "planned content\n", "utf8");
     const sourceHandle = await fs.open(fixture.heartbeatPath, "r+");
     const link = fs.link.bind(fs);

--- a/src/commands/doctor-heartbeat-scratch-migration.ts
+++ b/src/commands/doctor-heartbeat-scratch-migration.ts
@@ -42,25 +42,21 @@ type HeartbeatSource = {
   sha256: string;
 };
 
-function resolveHeartbeatScratchMigrationAgents(cfg: OpenClawConfig) {
-  return resolveHeartbeatAgents(cfg).filter(
-    (agent) => resolveHeartbeatIntervalMs(cfg, undefined, agent.heartbeat) !== null,
-  );
-}
-
-async function resolveDisabledHeartbeatSourceEntryKeys(cfg: OpenClawConfig) {
-  const entryKeys = new Set<string>();
+async function resolveHeartbeatScratchMigrationOwners(cfg: OpenClawConfig) {
+  const migrationAgents: ReturnType<typeof resolveHeartbeatAgents> = [];
+  const disabledEntryKeys = new Set<string>();
   for (const agent of resolveHeartbeatAgents(cfg)) {
     if (resolveHeartbeatIntervalMs(cfg, undefined, agent.heartbeat) !== null) {
+      migrationAgents.push(agent);
       continue;
     }
     const workspaceDir = resolveAgentWorkspaceDir(cfg, agent.agentId);
     const workspaceRealPath = await fs
       .realpath(workspaceDir)
       .catch(() => path.resolve(workspaceDir));
-    entryKeys.add(path.join(workspaceRealPath, LEGACY_HEARTBEAT_FILENAME));
+    disabledEntryKeys.add(path.join(workspaceRealPath, LEGACY_HEARTBEAT_FILENAME));
   }
-  return entryKeys;
+  return { migrationAgents, disabledEntryKeys };
 }
 
 async function readHeartbeatSource(
@@ -400,8 +396,8 @@ export async function collectHeartbeatScratchMigrationFindings(
   cfg: OpenClawConfig,
 ): Promise<readonly HealthFinding[]> {
   const findings: HealthFinding[] = [];
-  const disabledEntryKeys = await resolveDisabledHeartbeatSourceEntryKeys(cfg);
-  for (const agent of resolveHeartbeatScratchMigrationAgents(cfg)) {
+  const { migrationAgents, disabledEntryKeys } = await resolveHeartbeatScratchMigrationOwners(cfg);
+  for (const agent of migrationAgents) {
     const heartbeatPath = path.join(
       resolveAgentWorkspaceDir(cfg, agent.agentId),
       LEGACY_HEARTBEAT_FILENAME,
@@ -447,8 +443,9 @@ export async function maybeMigrateHeartbeatFilesToScratch(params: {
   const storePath = resolveCronJobsStorePathFromConfig(params.cfg, env);
   const changes: string[] = [];
   const warnings: string[] = [];
-  const migrationAgents = resolveHeartbeatScratchMigrationAgents(params.cfg);
-  const disabledEntryKeys = await resolveDisabledHeartbeatSourceEntryKeys(params.cfg);
+  const { migrationAgents, disabledEntryKeys } = await resolveHeartbeatScratchMigrationOwners(
+    params.cfg,
+  );
   if (!params.shouldRepair) {
     for (const agent of migrationAgents) {
       try {
@@ -527,7 +524,7 @@ export async function maybeMigrateHeartbeatFilesToScratch(params: {
     // concurrent edit in between surfaces as a conflict, never an overwrite.
     let keepSource = retainSource;
     const importAgents: [string, CronJob][] = [];
-    const scratchWritesNeeded = new Set<string>();
+    let scratchWriteNeeded = false;
     const plannedRevisionByJobId = new Map<string, number>();
     for (const [agentId, monitor] of agents) {
       const state = readCronJobScratchState(storePath, monitor.id, { env });
@@ -548,11 +545,11 @@ export async function maybeMigrateHeartbeatFilesToScratch(params: {
       } else {
         importAgents.push([agentId, monitor]);
         if (current?.sourceSha256 !== source.sha256) {
-          scratchWritesNeeded.add(monitor.id);
+          scratchWriteNeeded = true;
         }
       }
     }
-    if (importAgents.length === 0 || (keepSource && scratchWritesNeeded.size === 0)) {
+    if (importAgents.length === 0 || (keepSource && !scratchWriteNeeded)) {
       continue;
     }
 
@@ -594,8 +591,8 @@ export async function maybeMigrateHeartbeatFilesToScratch(params: {
     for (const [agentId, monitor] of importAgents) {
       try {
         const state = readCronJobScratchState(storePath, monitor.id, { env });
-        let wroteScratch = false;
-        if (state.scratch?.sourceSha256 !== source.sha256) {
+        const shouldWriteScratch = state.scratch?.sourceSha256 !== source.sha256;
+        if (shouldWriteScratch) {
           const write = writeCronJobScratch({
             storePath,
             jobId: monitor.id,
@@ -613,16 +610,15 @@ export async function maybeMigrateHeartbeatFilesToScratch(params: {
             previous: state.scratch,
             newRevision: write.currentRevision,
           });
-          wroteScratch = true;
         }
         const verified = readCronJobScratchState(storePath, monitor.id, { env }).scratch;
         if (!verified || verified.sourceSha256 !== source.sha256) {
           throw new Error("scratch verification failed after write");
         }
-        if (!keepSource || wroteScratch) {
+        if (!keepSource || shouldWriteScratch) {
           groupChanges.push(
             keepSource
-              ? `Copied ${shortenHomePath(source.path)} into cron scratch for ${monitor.displayName ?? monitor.name}; retained the shared legacy file because a heartbeat owner is disabled.`
+              ? `Copied ${shortenHomePath(source.path)} into cron scratch for ${monitor.displayName ?? monitor.name}; retained the shared legacy file because ${retainSource ? "a heartbeat owner is disabled" : "another heartbeat owner's scratch was left unchanged"}.`
               : `Migrated ${shortenHomePath(source.path)} into cron scratch for ${monitor.displayName ?? monitor.name}.`,
           );
         }

--- a/src/commands/doctor-heartbeat-scratch-migration.ts
+++ b/src/commands/doctor-heartbeat-scratch-migration.ts
@@ -18,7 +18,7 @@ import { resolveCronJobsStorePathFromConfig } from "../cron/store.js";
 import type { CronJob } from "../cron/types.js";
 import type { HealthFinding } from "../flows/health-checks.js";
 import { formatErrorMessage as errorMessage } from "../infra/errors.js";
-import { resolveHeartbeatAgents } from "../infra/heartbeat-config.js";
+import { resolveHeartbeatAgents, resolveHeartbeatIntervalMs } from "../infra/heartbeat-config.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { readRegularFile } from "../infra/regular-file.js";
 import { escapeRegExp } from "../shared/regexp.js";
@@ -41,6 +41,27 @@ type HeartbeatSource = {
   content: string;
   sha256: string;
 };
+
+function resolveHeartbeatScratchMigrationAgents(cfg: OpenClawConfig) {
+  return resolveHeartbeatAgents(cfg).filter(
+    (agent) => resolveHeartbeatIntervalMs(cfg, undefined, agent.heartbeat) !== null,
+  );
+}
+
+async function resolveDisabledHeartbeatSourceEntryKeys(cfg: OpenClawConfig) {
+  const entryKeys = new Set<string>();
+  for (const agent of resolveHeartbeatAgents(cfg)) {
+    if (resolveHeartbeatIntervalMs(cfg, undefined, agent.heartbeat) !== null) {
+      continue;
+    }
+    const workspaceDir = resolveAgentWorkspaceDir(cfg, agent.agentId);
+    const workspaceRealPath = await fs
+      .realpath(workspaceDir)
+      .catch(() => path.resolve(workspaceDir));
+    entryKeys.add(path.join(workspaceRealPath, LEGACY_HEARTBEAT_FILENAME));
+  }
+  return entryKeys;
+}
 
 async function readHeartbeatSource(
   cfg: OpenClawConfig,
@@ -124,6 +145,7 @@ function archivePathForSource(agentId: string, sha256: string, env: NodeJS.Proce
 type HeartbeatSourceClaim = {
   claimPath: string;
   restore(cause: unknown): Promise<void>;
+  retain(): Promise<void>;
   release(params: { archivePath: string }): Promise<void>;
 };
 
@@ -236,63 +258,78 @@ async function claimHeartbeatSource(source: HeartbeatSource): Promise<HeartbeatS
     await restore(error);
     throw error;
   }
+  // Every final verification failure means "do not trust the import": restore
+  // the claim and tag the error so the caller rolls newly copied scratch back.
+  const changedError = (message: string, cause?: unknown) => {
+    const error = new Error(message, cause !== undefined ? { cause } : undefined);
+    error.name = HEARTBEAT_CLAIM_CHANGED_ERROR;
+    return error;
+  };
+  const failChanged = async (message: string, cause?: unknown): Promise<never> => {
+    const error = changedError(message, cause);
+    await restore(error).catch(() => undefined);
+    throw error;
+  };
+  const readFinalContent = async (filePath: string) => {
+    const workspaceRealPath = await fs.realpath(path.dirname(source.path));
+    const fileRealPath = await fs.realpath(filePath);
+    if (fileRealPath !== workspaceRealPath && !isPathInside(workspaceRealPath, fileRealPath)) {
+      throw new Error("HEARTBEAT.md target escapes the agent workspace");
+    }
+    const finalBytes = await readRegularFile({
+      filePath: fileRealPath,
+      maxBytes: CRON_JOB_SCRATCH_MAX_BYTES,
+    });
+    return utf8Decoder.decode(finalBytes.buffer);
+  };
+  const verifyUnchanged = async () => {
+    // A holder of an already-open descriptor can still mutate the claimed
+    // inode; re-verify the bytes before retiring it. The claim may itself be
+    // a contained symlink, so resolve and containment-check it like the
+    // initial claim did.
+    const finalContent = await readFinalContent(claimPath).catch((error: unknown) =>
+      failChanged("claimed HEARTBEAT.md could not be re-verified before finalization", error),
+    );
+    if (hashCronScratchSource(finalContent) !== source.sha256) {
+      await failChanged("HEARTBEAT.md changed while the migration claim was held");
+    }
+    // An editor atomic-save can recreate the original path while the claim is
+    // held. That recreation is the newest instruction set; treat it like a
+    // changed claim so the import rolls back instead of shadowing it.
+    let recreated: boolean;
+    try {
+      await fs.lstat(source.path);
+      recreated = true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        await failChanged("could not verify the original HEARTBEAT.md path", error);
+      }
+      recreated = false;
+    }
+    if (recreated) {
+      await failChanged("HEARTBEAT.md was recreated while the migration claim was held");
+    }
+  };
+  const verifyRestoredUnchanged = async () => {
+    let finalContent: string;
+    try {
+      finalContent = await readFinalContent(source.path);
+    } catch (error) {
+      throw changedError("restored HEARTBEAT.md could not be re-verified", error);
+    }
+    if (hashCronScratchSource(finalContent) !== source.sha256) {
+      throw changedError("HEARTBEAT.md changed after the migration claim was restored");
+    }
+  };
   return {
     claimPath,
     restore,
+    retain: async () => {
+      await restore(undefined);
+      await verifyRestoredUnchanged();
+    },
     release: async ({ archivePath }) => {
-      // Every verification failure here means "do not trust the import":
-      // restore the claim and tag the error so the caller rolls scratch back.
-      const failChanged = async (message: string, cause?: unknown): Promise<never> => {
-        const error = new Error(message, cause !== undefined ? { cause } : undefined);
-        error.name = HEARTBEAT_CLAIM_CHANGED_ERROR;
-        await restore(error).catch(() => undefined);
-        throw error;
-      };
-      // A holder of an already-open descriptor can still mutate the claimed
-      // inode; re-verify the bytes so release never deletes an unseen edit.
-      // The claim may itself be a contained symlink (renaming a symlink keeps
-      // it a symlink), so resolve and containment-check it like the claim did.
-      let finalContent: string;
-      try {
-        const workspaceRealPath = await fs.realpath(path.dirname(source.path));
-        const claimRealPath = await fs.realpath(claimPath);
-        if (
-          claimRealPath !== workspaceRealPath &&
-          !isPathInside(workspaceRealPath, claimRealPath)
-        ) {
-          throw new Error("claimed HEARTBEAT.md target escapes the agent workspace");
-        }
-        const finalBytes = await readRegularFile({
-          filePath: claimRealPath,
-          maxBytes: CRON_JOB_SCRATCH_MAX_BYTES,
-        });
-        finalContent = utf8Decoder.decode(finalBytes.buffer);
-      } catch (error) {
-        await failChanged("claimed HEARTBEAT.md could not be re-verified before removal", error);
-        throw error;
-      }
-      if (hashCronScratchSource(finalContent) !== source.sha256) {
-        await failChanged("HEARTBEAT.md changed while the migration claim was held");
-      }
-      // An editor atomic-save can recreate the original path while the claim
-      // is held. That recreation is the newest instruction set; treat it like
-      // a changed claim so the import rolls back instead of shadowing it.
-      let recreated: boolean;
-      try {
-        await fs.lstat(source.path);
-        recreated = true;
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-          await failChanged(
-            "could not verify the original HEARTBEAT.md path before removal",
-            error,
-          );
-        }
-        recreated = false;
-      }
-      if (recreated) {
-        await failChanged("HEARTBEAT.md was recreated while the migration claim was held");
-      }
+      await verifyUnchanged();
       // Retire the claim by moving the inode into the archive instead of
       // unlinking it: a writer holding an open descriptor that lands a write
       // after the hash check above still writes into the preserved archive
@@ -363,7 +400,8 @@ export async function collectHeartbeatScratchMigrationFindings(
   cfg: OpenClawConfig,
 ): Promise<readonly HealthFinding[]> {
   const findings: HealthFinding[] = [];
-  for (const agent of resolveHeartbeatAgents(cfg)) {
+  const disabledEntryKeys = await resolveDisabledHeartbeatSourceEntryKeys(cfg);
+  for (const agent of resolveHeartbeatScratchMigrationAgents(cfg)) {
     const heartbeatPath = path.join(
       resolveAgentWorkspaceDir(cfg, agent.agentId),
       LEGACY_HEARTBEAT_FILENAME,
@@ -371,6 +409,9 @@ export async function collectHeartbeatScratchMigrationFindings(
     try {
       const source = await readHeartbeatSource(cfg, agent.agentId);
       if (!source) {
+        continue;
+      }
+      if (disabledEntryKeys.has(source.entryKey)) {
         continue;
       }
       findings.push(
@@ -406,13 +447,18 @@ export async function maybeMigrateHeartbeatFilesToScratch(params: {
   const storePath = resolveCronJobsStorePathFromConfig(params.cfg, env);
   const changes: string[] = [];
   const warnings: string[] = [];
+  const migrationAgents = resolveHeartbeatScratchMigrationAgents(params.cfg);
+  const disabledEntryKeys = await resolveDisabledHeartbeatSourceEntryKeys(params.cfg);
   if (!params.shouldRepair) {
-    for (const agent of resolveHeartbeatAgents(params.cfg)) {
+    for (const agent of migrationAgents) {
       try {
         const source = await readHeartbeatSource(params.cfg, agent.agentId);
         if (source) {
+          const retained = disabledEntryKeys.has(source.entryKey)
+            ? " The shared legacy file will be retained because a heartbeat owner is disabled."
+            : "";
           note(
-            `${shortenHomePath(source.path)} will migrate into scratch for Heartbeat (${agent.agentId}).`,
+            `${shortenHomePath(source.path)} will migrate into scratch for Heartbeat (${agent.agentId}).${retained}`,
             "Heartbeat migration preview",
           );
         }
@@ -441,8 +487,15 @@ export async function maybeMigrateHeartbeatFilesToScratch(params: {
   // Agents can share one workspace file. Group monitors by source path and
   // import into every monitor before the file is archived and removed once, so
   // the first agent's cleanup cannot starve its siblings.
-  const groups = new Map<string, { source: HeartbeatSource; agents: [string, CronJob][] }>();
+  const groups = new Map<
+    string,
+    { source: HeartbeatSource; agents: [string, CronJob][]; retainSource: boolean }
+  >();
+  const migrationAgentIds = new Set(migrationAgents.map((agent) => agent.agentId));
   for (const [agentId, monitor] of monitors) {
+    if (!migrationAgentIds.has(agentId)) {
+      continue;
+    }
     let source: HeartbeatSource | undefined;
     try {
       source = await readHeartbeatSource(params.cfg, agentId, { recoverClaims: true });
@@ -457,58 +510,69 @@ export async function maybeMigrateHeartbeatFilesToScratch(params: {
     // basename), not its resolved file target: two distinct symlinks pointing
     // at one shared file are each claimed and removed, while agents reaching
     // the same workspace through path aliases dedupe onto one entry.
-    const group = groups.get(source.entryKey) ?? { source, agents: [] };
+    const group = groups.get(source.entryKey) ?? {
+      source,
+      agents: [],
+      retainSource: disabledEntryKeys.has(source.entryKey),
+    };
     group.agents.push([agentId, monitor]);
     groups.set(source.entryKey, group);
   }
 
-  for (const { source, agents } of groups.values()) {
+  for (const { source, agents, retainSource } of groups.values()) {
     // Precondition pass first: operator-owned scratch (different content or an
-    // explicit unset tombstone) blocks the whole group before the file is
-    // touched, so nothing is claimed or committed for a source that must stay.
+    // explicit unset tombstone) stays untouched while other owners can still
+    // receive the source. Any skipped owner keeps the shared file in place.
     // The revision seen here is also the CAS token for the later write, so a
     // concurrent edit in between surfaces as a conflict, never an overwrite.
-    let blocked = false;
+    let keepSource = retainSource;
+    const importAgents: [string, CronJob][] = [];
+    const scratchWritesNeeded = new Set<string>();
     const plannedRevisionByJobId = new Map<string, number>();
     for (const [agentId, monitor] of agents) {
       const state = readCronJobScratchState(storePath, monitor.id, { env });
       const current = state.scratch;
       plannedRevisionByJobId.set(monitor.id, state.currentRevision);
       if (state.currentRevision > 0 && !current) {
-        warnings.push(
-          `Agent "${agentId}" scratch was explicitly unset; ${shortenHomePath(source.path)} was left unchanged.`,
-        );
-        blocked = true;
+        warnings.push(`Agent "${agentId}" scratch was explicitly unset; it was left unchanged.`);
+        keepSource = true;
       } else if (
         current &&
         current.content !== source.content &&
         current.sourceSha256 !== source.sha256
       ) {
         warnings.push(
-          `Agent "${agentId}" already has different cron scratch; ${shortenHomePath(source.path)} was left unchanged.`,
+          `Agent "${agentId}" already has different cron scratch; it was left unchanged.`,
         );
-        blocked = true;
+        keepSource = true;
+      } else {
+        importAgents.push([agentId, monitor]);
+        if (current?.sourceSha256 !== source.sha256) {
+          scratchWritesNeeded.add(monitor.id);
+        }
       }
     }
-    if (blocked) {
+    if (importAgents.length === 0 || (keepSource && scratchWritesNeeded.size === 0)) {
       continue;
     }
 
-    // Archive before the claim rename: if doctor dies mid-claim, the content is
-    // already durable under the state backups instead of only at a hidden
-    // .doctor-importing-* path nothing rescans.
-    try {
-      await archiveSource({ agentId: agents[0]![0], source, env });
-    } catch (error) {
-      warnings.push(
-        `${shortenHomePath(source.path)} was not migrated: ${errorMessage(error)}. Rerun doctor to retry safely.`,
-      );
-      continue;
+    if (!keepSource) {
+      // Archive before the claim rename: if doctor dies mid-claim, the content is
+      // already durable under the state backups instead of only at a hidden
+      // .doctor-importing-* path nothing rescans.
+      try {
+        await archiveSource({ agentId: importAgents[0]![0], source, env });
+      } catch (error) {
+        warnings.push(
+          `${shortenHomePath(source.path)} was not migrated: ${errorMessage(error)}. Rerun doctor to retry safely.`,
+        );
+        continue;
+      }
     }
 
     // Claim before committing: once the file is renamed aside and hash-verified,
-    // no concurrent editor can change the bytes that reach scratch, and a claim
-    // failure restores the file with nothing committed.
+    // no concurrent editor can change the bytes that reach scratch. Retained
+    // shared files are restored after the same verified import boundary.
     let claim: HeartbeatSourceClaim;
     try {
       claim = await claimHeartbeatSource(source);
@@ -527,9 +591,10 @@ export async function maybeMigrateHeartbeatFilesToScratch(params: {
       previous: ReturnType<typeof readCronJobScratchState>["scratch"];
       newRevision: number;
     }> = [];
-    for (const [agentId, monitor] of agents) {
+    for (const [agentId, monitor] of importAgents) {
       try {
         const state = readCronJobScratchState(storePath, monitor.id, { env });
+        let wroteScratch = false;
         if (state.scratch?.sourceSha256 !== source.sha256) {
           const write = writeCronJobScratch({
             storePath,
@@ -548,18 +613,19 @@ export async function maybeMigrateHeartbeatFilesToScratch(params: {
             previous: state.scratch,
             newRevision: write.currentRevision,
           });
+          wroteScratch = true;
         }
         const verified = readCronJobScratchState(storePath, monitor.id, { env }).scratch;
-        if (
-          !verified ||
-          verified.content !== source.content ||
-          verified.sourceSha256 !== source.sha256
-        ) {
+        if (!verified || verified.sourceSha256 !== source.sha256) {
           throw new Error("scratch verification failed after write");
         }
-        groupChanges.push(
-          `Migrated ${shortenHomePath(source.path)} into cron scratch for ${monitor.displayName ?? monitor.name}.`,
-        );
+        if (!keepSource || wroteScratch) {
+          groupChanges.push(
+            keepSource
+              ? `Copied ${shortenHomePath(source.path)} into cron scratch for ${monitor.displayName ?? monitor.name}; retained the shared legacy file because a heartbeat owner is disabled.`
+              : `Migrated ${shortenHomePath(source.path)} into cron scratch for ${monitor.displayName ?? monitor.name}.`,
+          );
+        }
       } catch (error) {
         warnings.push(
           `Agent "${agentId}" scratch was not finalized: ${errorMessage(error)}. Rerun doctor to retry safely.`,
@@ -620,11 +686,23 @@ export async function maybeMigrateHeartbeatFilesToScratch(params: {
       }
       continue;
     }
+    if (keepSource) {
+      try {
+        await claim.retain();
+        changes.push(...groupChanges);
+      } catch (error) {
+        rollbackCommitted();
+        warnings.push(
+          `${shortenHomePath(source.path)} was not migrated: ${errorMessage(error)}. Rerun doctor to retry safely.`,
+        );
+      }
+      continue;
+    }
     try {
       // release() re-verifies the claimed bytes; when they changed it restores
       // the newer file itself and reports HeartbeatClaimChangedError.
       await claim.release({
-        archivePath: archivePathForSource(agents[0]![0], source.sha256, env),
+        archivePath: archivePathForSource(importAgents[0]![0], source.sha256, env),
       });
       changes.push(...groupChanges);
     } catch (error) {

--- a/src/commands/doctor-heartbeat-task-migration.test.ts
+++ b/src/commands/doctor-heartbeat-task-migration.test.ts
@@ -148,6 +148,46 @@ async function createExistingInboxJob(fixture: Awaited<ReturnType<typeof createF
 }
 
 describe("heartbeat scratch task cron migration", () => {
+  it("preserves persisted tasks for a disabled owner until it is re-enabled", async () => {
+    const fixture = await createFixture(2_000_000_000_000);
+    fixture.cfg.agents!.defaults!.heartbeat!.every = "0m";
+
+    await expect(collectHeartbeatTaskMigrationFindings(fixture.cfg, fixture.env)).resolves.toEqual(
+      [],
+    );
+    await expect(
+      maybeMigrateHeartbeatTasksToCron({
+        cfg: fixture.cfg,
+        env: fixture.env,
+        shouldRepair: true,
+        nowMs: fixture.nowMs,
+      }),
+    ).resolves.toEqual({ changes: [], warnings: [] });
+    expect(
+      (await loadCronJobsStore(fixture.storePath)).jobs.filter(isHeartbeatTaskCronJob),
+    ).toEqual([]);
+    expect(
+      readCronJobScratchState(fixture.storePath, fixture.monitor.id, { env: fixture.env }).scratch
+        ?.content,
+    ).toContain("tasks:");
+
+    fixture.cfg.agents!.defaults!.heartbeat!.every = "30m";
+    await expect(
+      maybeMigrateHeartbeatTasksToCron({
+        cfg: fixture.cfg,
+        env: fixture.env,
+        shouldRepair: true,
+        nowMs: fixture.nowMs,
+      }),
+    ).resolves.toMatchObject({
+      warnings: [],
+      changes: [expect.stringContaining("2 heartbeat tasks")],
+    });
+    expect(
+      (await loadCronJobsStore(fixture.storePath)).jobs.filter(isHeartbeatTaskCronJob),
+    ).toHaveLength(2);
+  });
+
   it("does not create shared state while detecting heartbeat tasks", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-heartbeat-task-detect-"));
     tempDirs.push(root);

--- a/src/commands/doctor-heartbeat-task-migration.ts
+++ b/src/commands/doctor-heartbeat-task-migration.ts
@@ -28,7 +28,7 @@ import { getCronStoreKysely } from "../cron/store/schema.js";
 import type { CronJob } from "../cron/types.js";
 import type { HealthFinding } from "../flows/health-checks.js";
 import { formatErrorMessage as errorMessage } from "../infra/errors.js";
-import { resolveHeartbeatAgents } from "../infra/heartbeat-config.js";
+import { resolveHeartbeatAgents, resolveHeartbeatIntervalMs } from "../infra/heartbeat-config.js";
 import { resolveHeartbeatSession } from "../infra/heartbeat-runner-session.js";
 import { executeSqliteQuerySync } from "../infra/kysely-sync.js";
 import {
@@ -41,6 +41,12 @@ import { analyzeLegacyHeartbeatTasks, type LegacyHeartbeatTask } from "./heartbe
 const HEARTBEAT_TASK_MIGRATION_CHECK_ID = "core/doctor/heartbeat-task-cron-migration";
 
 type HeartbeatTaskMigrationResult = { changes: string[]; warnings: string[] };
+
+function resolveHeartbeatTaskMigrationAgents(cfg: OpenClawConfig) {
+  return resolveHeartbeatAgents(cfg).filter(
+    (agent) => resolveHeartbeatIntervalMs(cfg, undefined, agent.heartbeat) !== null,
+  );
+}
 
 type ValidatedHeartbeatTask = {
   task: LegacyHeartbeatTask;
@@ -97,7 +103,7 @@ export async function collectHeartbeatTaskMigrationFindings(
 ): Promise<readonly HealthFinding[]> {
   const storePath = resolveCronJobsStorePathFromConfig(cfg, env);
   const findings: HealthFinding[] = [];
-  for (const agent of resolveHeartbeatAgents(cfg)) {
+  for (const agent of resolveHeartbeatTaskMigrationAgents(cfg)) {
     let monitor: ReturnType<typeof readHeartbeatMonitorScratchReadOnly>;
     try {
       monitor = readHeartbeatMonitorScratchReadOnly(storePath, agent.agentId, { env });
@@ -423,7 +429,7 @@ export async function maybeMigrateHeartbeatTasksToCron(params: {
     scratchRevision: number;
     validatedTasks: ValidatedHeartbeatTask[];
   }> = [];
-  for (const agent of resolveHeartbeatAgents(params.cfg)) {
+  for (const agent of resolveHeartbeatTaskMigrationAgents(params.cfg)) {
     let monitor: ReturnType<typeof readHeartbeatMonitorScratch>;
     try {
       monitor = readHeartbeatMonitorScratch(storePath, agent.agentId, { env });

--- a/src/commands/doctor-heartbeat-task-migration.ts
+++ b/src/commands/doctor-heartbeat-task-migration.ts
@@ -197,6 +197,7 @@ type TaskJobPlan = {
 type AgentTaskMigrationPlan = {
   monitorJobId: string;
   scratchRevision: number;
+  sourceSha256?: string;
   strippedContent: string;
   jobs: TaskJobPlan[];
 };
@@ -355,7 +356,7 @@ function commitAgentTaskMigration(params: {
           .set({
             content: params.plan.strippedContent,
             revision: params.plan.scratchRevision + 1,
-            source_sha256: null,
+            source_sha256: params.plan.sourceSha256 ?? null,
             updated_at_ms: params.nowMs,
           })
           .where("store_key", "=", storeKey)
@@ -551,6 +552,9 @@ export async function maybeMigrateHeartbeatTasksToCron(params: {
     const plan: AgentTaskMigrationPlan = {
       monitorJobId: monitor.jobId,
       scratchRevision,
+      ...(monitor.state.scratch?.sourceSha256
+        ? { sourceSha256: monitor.state.scratch.sourceSha256 }
+        : {}),
       strippedContent: document.strippedContent,
       jobs: jobPlans,
     };


### PR DESCRIPTION
Closes #133389

## What Problem This Solves

Doctor used heartbeat enrollment as scratch-import eligibility. An explicitly disabled owner could receive a shared `HEARTBEAT.md` copy, allow Doctor to remove the shared source, or gain enabled task jobs from preexisting scratch.

## Fix

- Classify enabled migration owners and disabled shared-file owners once inside the Doctor scratch migration owner.
- Copy the shared source only into enabled scratch and retain the canonical file while any disabled owner still uses it.
- Preserve source provenance when task conversion strips a migrated task block, so later re-enable remains safe.
- Leave preexisting disabled-owner task scratch untouched until that owner is re-enabled.
- Revalidate retained claims, roll back stale imports, and skip the claim cycle after state converges.
- Report the real retention reason when another enabled owner's scratch differs.

## Evidence

The proof drives the built Doctor command and reads its durable cron state.

- Current main `12f2f9c35510ab2c07a3525c897c0a94e75da256` was red: the built Doctor CLI copied the shared source into both `main` and disabled `ollama` scratch, then removed the source.
- Exact head `e260d51c0f0ad375b51e31ce60680404d24cd7e1` was green in isolated, sanitized remote proof: `main` received revision 1 scratch; disabled `ollama` kept its disabled monitor row and no scratch; the shared source remained byte-identical.
- A second built Doctor invocation left the file and both rows unchanged, with `main` still at revision 1.
- Exact pre-fix head `46597d1ed7eac0ccdafffd7f0cccddbdd507f20a` converted disabled `ollama` task scratch into an enabled task job and advanced scratch from revision 1 to 2.
- Preexisting disabled-owner task scratch also remained at revision 1, created no task job, and converged unchanged on rerun.
- Re-enabling that owner converts the retained task scratch through the normal path.
- Focused scratch, task, and cadence migration tests passed: 37/37.
- The remote changed gate passed formatting, production and test type checks, Oxlint, state/database guards, import-cycle checks, and all other planned lanes.
- Exact-head Autoreview passed with no actionable finding.
- Exact-head CI run `33379875184` is green after one unrelated UI test rerun.
- No TypeScript typecheck or build ran on the maintainer host.

## CI classification

A prior build produced UI gzip output at 346,768 bytes against a 346,761-byte limit, while another job on the same head produced 346,729 bytes. An exact-head remote build also produced 346,764 bytes. This pull request changes no UI file, so that variance was not chased.

## Scope

- Production: +181/-97, net +84.
- Tests: +232/-0.
- The production growth owns retained-source verification, rollback, shared ownership, and re-enable provenance.
- Distillation removed 5 production lines and 50 test lines from the submitted patch before the required disabled-task owner filter was added.

AI-assisted: yes (Codex).
