### PR TITLE
improve: reduce session import, compaction, and UI startup overhead

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -1019,7 +1019,7 @@ export async function loadCompactHooksHarness(): Promise<{
   }));
 
   vi.doMock("../memory-search.js", () => ({
-    resolveMemorySearchConfig: resolveMemorySearchConfigMock,
+    resolveMemorySearchIndexConfig: resolveMemorySearchConfigMock,
   }));
 
   vi.doMock("../runtime-plan/build.js", () => ({

--- a/src/agents/embedded-agent-runner/compaction-hooks.ts
+++ b/src/agents/embedded-agent-runner/compaction-hooks.ts
@@ -8,7 +8,7 @@ import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { getActiveMemorySearchManagerCore } from "../../plugins/memory-runtime.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
-import { resolveMemorySearchConfig } from "../memory-search.js";
+import { resolveMemorySearchIndexConfig } from "../memory-search.js";
 import type { AgentMessage } from "../runtime/index.js";
 import { log } from "./logger.js";
 
@@ -43,7 +43,9 @@ async function runPostCompactionSessionMemorySync(params: PostCompactionSession)
       config: params.config,
       agentId: params.agentId,
     });
-    const resolvedMemory = resolveMemorySearchConfig(params.config, agentId);
+    // The memory backend owns provider resolution; an unavailable backend must
+    // not cold-load embedding plugins just to decide whether to sync.
+    const resolvedMemory = resolveMemorySearchIndexConfig(params.config, agentId);
     if (!resolvedMemory || !resolvedMemory.sources.includes("sessions")) {
       return;
     }

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -176,17 +176,49 @@ function getConfiguredMemoryEmbeddingProvider(
   return getMemoryEmbeddingProvider(providerId, cfg);
 }
 
+/** Resolves indexing eligibility without loading an embedding provider runtime. */
+export function resolveMemorySearchIndexConfig(cfg: OpenClawConfig, agentId: string) {
+  const defaults = cfg.memory?.search;
+  const overrides = resolveAgentConfig(cfg, agentId)?.memory?.search;
+  const enabled = overrides?.enabled ?? defaults?.enabled ?? true;
+  if (!enabled) {
+    return null;
+  }
+  assertSecretOwnerAvailable("capability", runtimeMemorySecretOwnerId(agentId));
+  const rememberAcrossConversations = resolveRememberAcrossConversations(cfg, agentId);
+  const configuredSessionMemory =
+    overrides?.experimental?.sessionMemory ?? defaults?.experimental?.sessionMemory ?? false;
+  const sessionMemory = rememberAcrossConversations || configuredSessionMemory;
+  const configuredSources = overrides?.sources ?? defaults?.sources;
+  const searchSources = normalizeSources(
+    configuredSources,
+    configuredSessionMemory ||
+      (rememberAcrossConversations && configuredSources?.includes("sessions") === true),
+  );
+  const sources = normalizeSources(
+    rememberAcrossConversations ? [...searchSources, "sessions"] : configuredSources,
+    sessionMemory,
+  );
+  return {
+    enabled,
+    rememberAcrossConversations,
+    sources,
+    searchSources,
+    experimental: { sessionMemory },
+    sync: resolveSyncConfig(),
+  };
+}
+
 function mergeConfig(
   cfg: OpenClawConfig,
   defaults: MemorySearchConfig | undefined,
   overrides: MemorySearchConfig | undefined,
   agentId: string,
-): ResolvedMemorySearchConfig {
-  const enabled = overrides?.enabled ?? defaults?.enabled ?? true;
-  const rememberAcrossConversations = resolveRememberAcrossConversations(cfg, agentId);
-  const configuredSessionMemory =
-    overrides?.experimental?.sessionMemory ?? defaults?.experimental?.sessionMemory ?? false;
-  const sessionMemory = rememberAcrossConversations || configuredSessionMemory;
+): ResolvedMemorySearchConfig | null {
+  const indexConfig = resolveMemorySearchIndexConfig(cfg, agentId);
+  if (!indexConfig) {
+    return null;
+  }
   const rawProvider = overrides?.provider ?? defaults?.provider;
   const provider =
     rawProvider?.trim() === "auto"
@@ -239,16 +271,6 @@ function mergeConfig(
   const local = {
     modelPath: overrides?.local?.modelPath ?? defaults?.local?.modelPath,
   };
-  const configuredSources = overrides?.sources ?? defaults?.sources;
-  const searchSources = normalizeSources(
-    configuredSources,
-    configuredSessionMemory ||
-      (rememberAcrossConversations && configuredSources?.includes("sessions") === true),
-  );
-  const sources = normalizeSources(
-    rememberAcrossConversations ? [...searchSources, "sessions"] : configuredSources,
-    sessionMemory,
-  );
   const extraPaths = normalizeConfiguredMemoryExtraPaths([
     ...(defaults?.extraPaths ?? []),
     ...(overrides?.extraPaths ?? []),
@@ -276,7 +298,6 @@ function mergeConfig(
     tokens: DEFAULT_CHUNK_TOKENS,
     overlap: DEFAULT_CHUNK_OVERLAP,
   };
-  const sync = resolveSyncConfig();
   const query = {
     maxResults: overrides?.query?.maxResults ?? defaults?.query?.maxResults ?? DEFAULT_MAX_RESULTS,
     minScore: overrides?.query?.minScore ?? defaults?.query?.minScore ?? DEFAULT_MIN_SCORE,
@@ -302,17 +323,11 @@ function mergeConfig(
 
   const minScore = clampNumber(query.minScore, 0, 1);
   return {
-    enabled,
-    rememberAcrossConversations,
-    sources,
-    searchSources,
+    ...indexConfig,
     extraPaths,
     multimodal,
     provider,
     remote,
-    experimental: {
-      sessionMemory,
-    },
     fallback,
     model,
     inputType,
@@ -322,7 +337,6 @@ function mergeConfig(
     local,
     store,
     chunking,
-    sync,
     query: {
       ...query,
       minScore,
@@ -355,10 +369,9 @@ export function resolveMemorySearchConfig(
   const defaults = cfg.memory?.search;
   const overrides = resolveAgentConfig(cfg, agentId)?.memory?.search;
   const resolved = mergeConfig(cfg, defaults, overrides, agentId);
-  if (!resolved.enabled) {
+  if (!resolved) {
     return null;
   }
-  assertSecretOwnerAvailable("capability", runtimeMemorySecretOwnerId(agentId));
   const isFtsOnly = normalizeProviderId(resolved.provider) === "none";
   const multimodalActive = isMemoryMultimodalEnabled(resolved.multimodal);
   const multimodalProvider = isFtsOnly

--- a/src/config/sessions/session-accessor.sqlite-import-stage.ts
+++ b/src/config/sessions/session-accessor.sqlite-import-stage.ts
@@ -1,5 +1,5 @@
 // Disposable migration spool: never registered, resumed, or read by the runtime.
-import { createHash } from "node:crypto";
+import { hash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -72,7 +72,7 @@ export class SqliteSessionImportStage {
 
   *iterateUnseenEvents(source: number): Generator<TranscriptEvent, void, boolean> {
     for (const row of this.rows(source)) {
-      const eventHash = createHash("sha256").update(row.eventJson).digest();
+      const eventHash = hash("sha256", row.eventJson, "buffer");
       // Hash narrows the lookup; exact bytes decide equality even under a hash collision.
       if (this.findSeen.get(eventHash, row.eventJson) !== undefined) {
         continue;
@@ -87,6 +87,6 @@ export class SqliteSessionImportStage {
   }
 
   addSeen(eventJson: string): void {
-    this.insertSeen.run(createHash("sha256").update(eventJson).digest(), eventJson);
+    this.insertSeen.run(hash("sha256", eventJson, "buffer"), eventJson);
   }
 }

--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -65,8 +65,24 @@ describe("formatAgo", () => {
 });
 
 describe("localized durations", () => {
+  it.each([undefined, null, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, -1])(
+    "preserves invalid duration fallbacks for %s",
+    (durationMs) => {
+      expect(formatDurationCompact(durationMs)).toBeUndefined();
+      expect(formatDurationHuman(durationMs, "unavailable")).toBe("unavailable");
+    },
+  );
+
+  it("keeps zero distinct from a positive duration rounded to zero", () => {
+    expect(formatDurationCompact(0)).toBeUndefined();
+    expect(formatDurationCompact(0.1)).toBe("0ms");
+    expect(formatDurationHuman(0)).toBe("0ms");
+  });
+
   it.each([
+    { durationMs: 999.5, expected: "1s" },
     { durationMs: 59_000, expected: "59s" },
+    { durationMs: 59_500, expected: "1m" },
     { durationMs: 92_000, expected: "1m 32s" },
     { durationMs: 3_660_000, expected: "1h 1m" },
     { durationMs: 49 * 60 * 60 * 1000, expected: "2d 1h" },
@@ -76,6 +92,22 @@ describe("localized durations", () => {
 
   it("switches human durations to days at 24 hours", () => {
     expect(formatDurationHuman(36 * 60 * 60 * 1000)).toBe("2d");
+  });
+
+  it("uses the active locale for both duration formats", async () => {
+    await i18n.setLocale("fr");
+    try {
+      const minute = new Intl.NumberFormat("fr", {
+        style: "unit",
+        unit: "minute",
+        unitDisplay: "narrow",
+        maximumFractionDigits: 0,
+      }).format(1);
+      expect(formatDurationCompact(60_000)).toBe(minute);
+      expect(formatDurationHuman(60_000)).toBe(minute);
+    } finally {
+      await i18n.setLocale("en");
+    }
   });
 });
 

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -2,10 +2,6 @@ import { bucketRelativeTimeMs, type RelativeTimeUnit } from "@openclaw/normaliza
 // Control UI module implements format behavior.
 import { asDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import {
-  formatDurationCompact as formatDurationCompactCore,
-  formatDurationHuman as formatDurationHumanCore,
-} from "../../../src/infra/format-time/format-duration.ts";
 import { i18n, t } from "../i18n/index.ts";
 import { formatUiError } from "./format-error.ts";
 
@@ -99,9 +95,8 @@ export function formatRelativeTimestamp(
 }
 
 export function formatDurationCompact(ms?: number | null): string | undefined {
-  const coreValue = formatDurationCompactCore(ms, { spaced: true });
-  if (!coreValue || ms == null || !Number.isFinite(ms) || ms <= 0) {
-    return coreValue;
+  if (ms == null || !Number.isFinite(ms) || ms <= 0) {
+    return undefined;
   }
   const roundedMs = Math.round(ms);
   if (roundedMs < 1000) {
@@ -139,9 +134,8 @@ export function formatDurationCompact(ms?: number | null): string | undefined {
 }
 
 export function formatDurationHuman(ms?: number | null, fallback = t("common.na")): string {
-  const coreValue = formatDurationHumanCore(ms, fallback);
   if (ms == null || !Number.isFinite(ms) || ms < 0) {
-    return coreValue;
+    return fallback;
   }
   if (ms < 1000) {
     return formatUnit(Math.round(ms), "millisecond");


### PR DESCRIPTION
## What Problem This Solves

Large legacy-session imports spend avoidable CPU time constructing streaming hash objects for JSON strings that are already complete in the migration spool.

## Why This Change Was Made

Use Node's one-shot SHA-256 API for both existing-row preload and incoming-row deduplication. The digest stays a Buffer with identical UTF-8 input, and exact JSON bytes still decide equality. Accepted-only acknowledgement, rejected-identity recency, bounded disk staging, cleanup, and all canonical write/transaction boundaries remain unchanged.

The importer change is a three-line substitution with no production LOC growth. There are no dependency, configuration, schema, index, or persistence-semantic changes. Every supported Node range includes the API; the [Node contract](https://nodejs.org/docs/latest-v24.x/api/crypto.html#cryptohashalgorithm-data-options), [Node 22 source](https://github.com/nodejs/node/blob/v22.16.0/lib/internal/crypto/hash.js), and [Node 24 native implementation](https://github.com/nodejs/node/blob/v24.19.0/src/crypto/crypto_hash.cc) were inspected. Streaming hashes elsewhere remain unchanged because their inputs are streamed.

## User Impact

Median import wall time improved 3.6% for a deep history and 4.3% for many sessions in an isolated Linux Node 24 comparison. Branching and repeated imports were effectively unchanged. Imported data remains identical. The compaction follow-up below removes unnecessary embedding discovery without changing memory eligibility.

## Evidence

- 105 focused tests passed: importer deduplication/rollback/exact handoff and Doctor migration/validation.
- Full-priority Codex autoreview found no actionable defects. Core typechecking and the completed changed guards passed.
- The local aggregate test typecheck encounters unrelated shared-install `tslog` and UI declaration errors; the shared dependency tree was not modified. Clean exact-head CI is required before landing.
- Isolated Blacksmith Testbox proof at head `1d628793d9e92775050a77a99ae41a97ee8c67e9` against base `a39e03cb299f141994ac0f231077b9194acfaa79`, using Node 24.19.0 / SQLite 3.53.3. Only the staging owner differs; all other source and dependencies are identical.
- Five fresh processes per side per shape, with alternating pair order. All 20 paired persisted-data SHA-256 digests match across transcript bytes, identities, window metadata, active positions, projection watermarks, and FTS. Verification is outside the timer. A separate 10k-event trace retains exactly 100,034 SQL calls and the same 34 SQL shapes. Before/after Node CPU profiles completed separately.

| Scenario | Before median | After median | Wall reduction | CPU reduction |
| --- | ---: | ---: | ---: | ---: |
| 100k events, one history | 5958.2 ms | 5744.4 ms | 3.6% | 2.9% |
| 100 sessions × 100 events | 633.7 ms | 606.3 ms | 4.3% | 5.6% |
| 100 branching histories | 988.7 ms | 983.1 ms | 0.6% | 0.8% |
| Repeat import, 10k existing events | 144.1 ms | 142.6 ms | 1.1% | 0.7% |

The branching/replay differences are too small to claim a material gain. Empty, ASCII, Unicode/NUL, lone-surrogate, and 5 MiB input digests also match between APIs.

Packaged stable `2026.7.1-2` to candidate `2026.8.1` at importer head `1d628793d9e92775050a77a99ae41a97ee8c67e9` passed on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/33327664603): 4,800 sessions, 1,227,946 events, 10,000 cron jobs, and five complete state assertions. Automatic migration was checked after update and before standalone Doctor. Repeat Doctor completed in 39 seconds against a 60-second budget. Eight Gateway history samples across two agents (600 messages) were identical after restart; startup took 11 seconds and health/readiness/status checks took one second each. The synthetic plugin fixture required explicit capability consent; this proves automatic data migration, not unattended update-channel switching. Profiles and proof artifacts were collected before stopping the worker.

## Compaction follow-up found during CI

The first CI run failed the unchanged healthy timeout-compaction recovery test at 132.9 seconds. A focused local reproduction failed the same case at 225.1 seconds, with all 29 sibling cases passing. This was a reproducible cold-load defect, not dismissed as runner noise.

Post-compaction sync resolved the complete embedding configuration before discovering whether a memory backend was available. The fixture enables recall through the personal-install defaults but has no memory runtime; the unnecessary OpenAI capability lookup synchronously loaded provider code first. The fix extracts the existing eligibility/source/sync facts into a provider-free resolver shared with full memory configuration. Compaction consumes those facts, and an acquired memory backend owns provider resolution. The built-in manager still performs full provider/multimodal validation before cache reuse or creation; core secret-owner gating remains before any manager acquisition. Custom memory runtimes retain their own provider validation rather than being forced through the built-in adapter's checks.

No test timeout, fixture configuration, assertion, or plugin policy was weakened. The only test-support change points the existing mock at the narrower production resolver. The added 15 production lines establish this shared owner boundary; the importer itself remains net zero. All 242 memory/configuration/recovery/hook tests pass, including the unchanged failing case now completing in 782 ms. Fresh full-priority Codex review is clean. Core typechecking and changed structural guards pass; the local aggregate test typecheck still reports the pre-existing shared-install declarations described above. The full isolated Linux `pnpm build` passed at head `4da5346952f9d59e7f1b47c1d33e79fdc9b6c51e`. The next CI run passed the previously failing compaction shard, but exposed the UI budget issue below. [Final CI](https://github.com/openclaw/openclaw/actions/runs/33330479757) completed successfully for `27e94db402d56a298dadd56c5f5a8d033cd57948`, including both previously failing jobs. The Docker and benchmark evidence above applies to the unchanged importer at the named hash.

[ClawSweeper's final-head review](https://github.com/openclaw/openclaw/pull/133446#issuecomment-5470508691) found no actionable code issues. Its rank-up move—green exact-head CI—is satisfied. The remaining production growth (net +9) establishes the shared provider-free indexing boundary; the unchanged compaction recovery case and final CI verify that it removes the cold load. The review's stored-data heuristic does not describe a data-model change: this diff changes no SQL, schema, tables, indexes, retention, persistent shape, or configuration, and preserves all store/vector values.


## Startup cleanup required by the final integration build

The combined tree with newer main (`5ce50c5cf5ba7454cced0be8079f5c2f7833c46e`) exceeded the unchanged UI startup gzip limit by seven bytes: 346,768 B against 346,761 B. This was not dismissed as a flaky result: main had 77 intervening UI/protocol file changes, while the PR head alone built at 346,677 B. Startup source maps excluded the importer and memory changes.

The UI's localized duration functions called the core formatter and discarded its result on every valid input. Removing those calls preserves their existing invalid-input returns and all localized rounding/Intl output, while removing the only startup import of the core duration helpers, `pretty-ms`, and `parse-ms`. The Linux preview built at 345,419 B, 1,258 B smaller than the preceding head build; all four dependency sources disappeared (402 mapped sources to 398). Build identity differs between the two snapshots, so the exact byte delta includes that small variation. No budget, markup, stylesheet, or translation text changed.

All 58 formatter tests pass before and after, including invalid values, zero versus positive fractions, rounding boundaries, and French output. These tests protect output equivalence; there is no visual change to illustrate. Final full-priority Codex review found no actionable issues across all six files. Production is +50/-41 (net +9), with +33/-1 test/test-support lines. The added core indexing boundary accounts for the remaining production growth; the UI cleanup deletes six production lines. All Testbox workers have been stopped after proof collection.
