### PR TITLE
fix: release idle desktops and await cleanup before reuse

### DIFF
--- a/src/gateway/desktop/attachment.test.ts
+++ b/src/gateway/desktop/attachment.test.ts
@@ -1,6 +1,8 @@
 import net from "node:net";
 import { PassThrough } from "node:stream";
+import { setImmediate } from "node:timers/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { connectRfbAttachment } from "./attachment.js";
 import { createDesktopSessionRegistry } from "./session-registry.js";
 
@@ -82,18 +84,96 @@ describe("RFB attachments", () => {
     await registry.stopAll();
   });
 
-  it("refreshes the cleanup deadline when an idle stream session is reactivated", async () => {
+  it.each(["acquire", "activate"] as const)("refreshes idle cleanup after %s", async (method) => {
     vi.useFakeTimers();
     const teardown = vi.fn(async () => undefined);
     const registry = createDesktopSessionRegistry({ lingerMs: 25 });
-    await registry.activate({ sourceKey: "node:one", ownerEpoch: 1, teardown });
+    const request = {
+      sourceKey: "node:one",
+      ownerEpoch: 1,
+      teardown,
+      start: async () => ({ attachment: { kind: "tcp", host: "127.0.0.1", port: 5900 } as const }),
+    };
+    await registry[method](request);
     await vi.advanceTimersByTimeAsync(20);
-    await registry.activate({ sourceKey: "node:one", ownerEpoch: 1 });
+    await registry[method](request);
     await vi.advanceTimersByTimeAsync(20);
     expect(teardown).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(5);
     expect(teardown).toHaveBeenCalled();
+    await registry.stopAll();
+  });
+
+  it.each(["stop", "stopAll"] as const)("%s joins teardown already in progress", async (method) => {
+    const registry = createDesktopSessionRegistry();
+    const entered = createDeferredCore();
+    const release = createDeferredCore();
+    await registry.activate({
+      sourceKey: "node:one",
+      ownerEpoch: 1,
+      teardown: async () => {
+        entered.resolve();
+        await release.promise;
+      },
+    });
+    const completed: string[] = [];
+    let reentrantStop: Promise<void> | undefined;
+    registry.attachObserver("node:one", {
+      ownerEpoch: 1,
+      control: false,
+      close: () => {
+        reentrantStop = registry.stop("node:one", 1).then(() => {
+          completed.push("observer");
+        });
+      },
+    });
+    const first = registry.stop("node:one", 1);
+    await entered.promise;
+    const second = (method === "stop" ? registry.stop("node:one", 1) : registry.stopAll()).then(
+      () => {
+        completed.push("second");
+      },
+    );
+    try {
+      await setImmediate();
+      expect(completed).toEqual([]);
+      expect(reentrantStop).toBeDefined();
+      expect(registry.reserveObserver("node:one", 1)).toBeUndefined();
+    } finally {
+      release.resolve();
+      await Promise.all([first, second, reentrantStop]);
+    }
+    expect(completed.toSorted()).toEqual(["observer", "second"]);
+  });
+
+  it.each([1, 2])("waits for stopped resources before acquiring epoch %s", async (ownerEpoch) => {
+    const registry = createDesktopSessionRegistry();
+    const entered = createDeferredCore();
+    const release = createDeferredCore();
+    const attachment = { kind: "tcp", host: "127.0.0.1", port: 5900 } as const;
+    await registry.acquire({
+      sourceKey: "node:one",
+      ownerEpoch: 1,
+      start: async () => ({ attachment }),
+      teardown: async () => {
+        entered.resolve();
+        await release.promise;
+      },
+    });
+    const stopping = registry.stop("node:one", 1);
+    await entered.promise;
+    const start = vi.fn(async () => ({ attachment }));
+    const acquiring = registry.acquire({ sourceKey: "node:one", ownerEpoch, start });
+    try {
+      await setImmediate();
+      expect(start).not.toHaveBeenCalled();
+    } finally {
+      release.resolve();
+      await Promise.all([stopping, acquiring]);
+      await registry.stopAll();
+    }
+    expect(start).toHaveBeenCalledOnce();
   });
 
   it("bounds pending observer reservations before streams are started", async () => {

--- a/src/gateway/desktop/session-registry.ts
+++ b/src/gateway/desktop/session-registry.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { createDeferredCore } from "../../shared/deferred.js";
 import type { ConnectedRfbStream, DesktopRfbAttachment } from "./attachment.js";
 
 const DEFAULT_LINGER_MS = 60_000;
@@ -98,11 +99,11 @@ export function createDesktopSessionRegistry(
     if (entry.stopPromise) {
       return entry.stopPromise;
     }
-    entry.stopPromise = (async () => {
+    // Publish cleanup ownership before observer callbacks can reenter Stop.
+    const stopped = createDeferredCore();
+    entry.stopPromise = stopped.promise;
+    void (async () => {
       entry.stopped = true;
-      if (entries.get(entry.sourceKey) === entry) {
-        entries.delete(entry.sourceKey);
-      }
       clearTimeout(entry.lingerTimer);
       entry.lingerTimer = undefined;
       for (const observer of entry.observers) {
@@ -126,14 +127,31 @@ export function createDesktopSessionRegistry(
       await entry.teardown?.().catch(() => undefined);
       await entry.initialization?.catch(() => undefined);
       await entry.teardown?.().catch(() => undefined);
-    })();
+    })()
+      .finally(() => {
+        // Concurrent Stop and replacement acquisition must join the full teardown.
+        if (entries.get(entry.sourceKey) === entry) {
+          entries.delete(entry.sourceKey);
+        }
+      })
+      .then(stopped.resolve, stopped.reject);
     return entry.stopPromise;
   };
 
   const scheduleLinger = (entry: DesktopSessionEntry): void => {
+    if (!isCurrent(entry) || entry.observers.size > 0 || entry.observerReservations.size > 0) {
+      return;
+    }
     clearTimeout(entry.lingerTimer);
     entry.lingerTimer = setTimeout(() => void stopEntry(entry), lingerMs);
     entry.lingerTimer.unref?.();
+  };
+
+  const waitForReady = async (entry: DesktopSessionEntry): Promise<DesktopSessionStartResult> => {
+    const result = await entry.ready;
+    // Every observation gets an idle attachment window, including same-epoch reuse.
+    scheduleLinger(entry);
+    return result;
   };
 
   async function startSession(
@@ -147,8 +165,8 @@ export function createDesktopSessionRegistry(
       if (request.ownerEpoch < current.ownerEpoch) {
         throw new DesktopSessionStaleOwnerError();
       }
-      if (request.ownerEpoch === current.ownerEpoch) {
-        return await current.ready;
+      if (request.ownerEpoch === current.ownerEpoch && !current.stopped) {
+        return await waitForReady(current);
       }
     }
 
@@ -195,7 +213,7 @@ export function createDesktopSessionRegistry(
       }
       void stopEntry(entry);
     });
-    return await ready;
+    return await waitForReady(entry);
   }
 
   async function acquire(
@@ -210,14 +228,6 @@ export function createDesktopSessionRegistry(
 
   async function activate(request: DesktopSessionActivateRequest): Promise<void> {
     await startSession({ ...request, start: async () => undefined });
-    const entry = entries.get(request.sourceKey);
-    if (
-      entry?.ownerEpoch === request.ownerEpoch &&
-      entry.observers.size === 0 &&
-      entry.observerReservations.size === 0
-    ) {
-      scheduleLinger(entry);
-    }
   }
 
   function attachObserver(sourceKey: string, observer: DesktopSessionObserver) {
@@ -259,13 +269,7 @@ export function createDesktopSessionRegistry(
         if (entry.controller === attached) {
           entry.controller = undefined;
         }
-        if (
-          entry.observers.size === 0 &&
-          entry.observerReservations.size === 0 &&
-          isCurrent(entry)
-        ) {
-          scheduleLinger(entry);
-        }
+        scheduleLinger(entry);
       },
     };
   }
@@ -294,13 +298,7 @@ export function createDesktopSessionRegistry(
         }
         released = true;
         entry.observerReservations.delete(reservationId);
-        if (
-          entry.observers.size === 0 &&
-          entry.observerReservations.size === 0 &&
-          isCurrent(entry)
-        ) {
-          scheduleLinger(entry);
-        }
+        scheduleLinger(entry);
       },
     };
   }

--- a/src/gateway/worker-environments/desktop-tunnel.test.ts
+++ b/src/gateway/worker-environments/desktop-tunnel.test.ts
@@ -1,3 +1,5 @@
+import { access } from "node:fs/promises";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WorkerDesktopEndpoint, WorkerSshEndpoint } from "../../plugins/types.js";
 import type { CommandOptions, SpawnResult } from "../../process/exec.js";
@@ -156,6 +158,32 @@ describe("worker desktop tunnels", () => {
     await manager.stopAll();
   });
 
+  it("expires an unattached acquisition and disposes its SSH identity directory", async ({
+    onTestFinished,
+  }) => {
+    vi.useFakeTimers();
+    const fake = fakeRunner();
+    const manager = createWorkerDesktopTunnels({ runner: fake.runner, lingerMs: 50 });
+    onTestFinished(() => manager.stopAll());
+    const starting = acquire(manager);
+    await waitForStarts(fake.starts, 1);
+    fake.starts[0]!.process.becomeReady();
+    const result = await starting;
+    if (result.attachment.kind !== "unix-socket") {
+      throw new Error("expected an SSH desktop socket");
+    }
+    const identityDirectory = path.dirname(result.attachment.socketPath);
+    await access(identityDirectory);
+    await vi.advanceTimersByTimeAsync(49);
+    await expect(acquire(manager)).resolves.toEqual(result);
+    await vi.advanceTimersByTimeAsync(49);
+    expect(fake.starts[0]!.process.stopCount).toBe(0);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fake.starts[0]!.process.stopCount).toBe(1);
+    await manager.stopAll();
+    await expect(access(identityDirectory)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("fences an older epoch before starting its replacement", async () => {
     const fake = fakeRunner();
     const manager = createWorkerDesktopTunnels({ runner: fake.runner });
@@ -253,6 +281,7 @@ describe("worker desktop tunnels", () => {
     fake.starts[0]?.process.exit();
     await vi.waitFor(() => expect(close).toHaveBeenCalledWith(1012, "desktop tunnel closed"));
     replacement?.release();
+    await manager.stopAll();
   });
 
   it("refuses observer tokens minted against a replaced owner epoch", async () => {
@@ -417,5 +446,6 @@ describe("worker desktop tunnels", () => {
     });
     expect(observer).toBeDefined();
     observer?.release();
+    await manager.stopAll();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a cloud desktop without attaching WebVNC could leave an SSH tunnel and its temporary identity directory running indefinitely. Repeated Stop requests and desktop replacement could also finish or start a successor before the previous desktop finished cleanup.

## Why This Change Was Made

The shared desktop registry owns both idle expiry and teardown completion. Acquisition now refreshes the same idle window as activation. A stopped entry retains its cleanup promise until teardown completes, publishing it before observer callbacks can reenter Stop. Same-epoch reuse cannot return a stopped entry. Existing observer and reservation release paths use the same idle check.

This removes duplicated idle policy rather than adding a new timer, cache, retry, configuration option, or provider-specific path. Production delta: +28/-30 (net -2); tests: +113/-3. Host, managed Linux, node, and SSH desktops retain the same shared lifecycle. Placement reclaim waiting behind provider reconciliation is a separate follow-up; this change does not alter that coordinator. The related workspace SSH cleanup-custody defect is tracked separately in #133455.

## User Impact

Unattached desktop observations expire, repeated Stop requests await complete resource cleanup, and replacements cannot overlap old resources. WebVNC/controller authorization and the existing idle timeout remain unchanged. No visual UI changes or new operator steps.

## Evidence

- Six new regression cases failed on the original implementation: unattached acquire expiry, repeated/reentrant stop, and replacement acquisition while cleanup is pending. All pass with this fix.
- 147 tests across 13 desktop, host/node, SSH tunnel, and desktop RPC files passed, including actual loopback RFB connections and temporary identity-directory cleanup.
- Ten bounded repeats of the two focused files passed: 260/260 tests.
- Formatting and diff whitespace checks passed. Codex autoreview found no P0 issues under the configured P0-only policy; lower severities were reviewed directly, not covered by that automated verdict.
- The full changed gate passed with an isolated frozen-lockfile install: core and all test types, lint, formatting, dead-export scans, and repository guards. The initial shared-install failure was traced to missing local tslog declarations; the published package and isolated install are intact. No shared dependency files were changed.
- The 147-test sibling run passed again in that isolated checkout.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33328297984) and the required `openclaw/ci-gate` passed for `c04bbd4310c74073b69d9a181be1271a5fd04e0b`.
- [ClawSweeper review](https://github.com/openclaw/openclaw/pull/133451#issuecomment-5470539578) found no actionable findings. Its requested next step, exact-head validation, is complete.

The previous authenticated cloud CUA/WebVNC proof belongs to #133241 and is not relabeled as proof of this new head. This PR exercises the resource-lifecycle owner locally; it changes no external provider API contract. Stable release introduction of these defects has not been established.

AI-assisted: yes. The maintainer independently reproduced the defects and reviewed the affected source, callers, sibling lifecycle owners, tests, and history.
