### PR TITLE
fix(status): preserve prepared context windows

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -274,6 +274,7 @@ function createCommandsStatusRuntimeModuleMock() {
       statusChannel: string;
       provider?: string;
       model: string;
+      thinkingCatalog?: Array<{ provider: string; id: string; contextWindow?: number }>;
       workspaceDir?: string;
       primaryModelLabelOverride?: string;
       includeTranscriptUsage?: boolean;
@@ -314,6 +315,7 @@ function createCommandsStatusRuntimeModuleMock() {
         },
         sessionEntry: params.sessionEntry,
         modelAuth,
+        thinkingCatalog: params.thinkingCatalog,
         includeTranscriptUsage: params.includeTranscriptUsage,
         workspaceDir: params.workspaceDir,
       });
@@ -623,6 +625,15 @@ describe("session_status tool", () => {
     expect(details.statusText).not.toContain("OAuth/token status");
     expect(tool.outputSchema).toBeDefined();
     expect(Value.Check(tool.outputSchema!, result.details)).toBe(true);
+    expect(mockCallArg(buildStatusMessageMock)).toMatchObject({
+      thinkingCatalog: expect.arrayContaining([
+        expect.objectContaining({
+          provider: "openai",
+          id: "gpt-5.4",
+          contextWindow: 400_000,
+        }),
+      ]),
+    });
     // The full contract exceeds the compact hint budget; never promote a truncated shape.
     expect(compactToolOutputHint(tool.outputSchema)).toBeUndefined();
   });

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -250,6 +250,7 @@ async function writeTranscriptUsageLog(params: {
     cacheWrite: number;
     totalTokens: number;
   };
+  model?: string;
 }) {
   const storePath = path.join(
     params.dir,
@@ -271,7 +272,7 @@ async function writeTranscriptUsageLog(params: {
         {
           message: {
             role: "assistant",
-            model: "claude-opus-4-5",
+            model: params.model ?? "claude-opus-4-5",
             usage: params.usage,
           },
         },
@@ -673,6 +674,155 @@ describe("buildStatusReply subagent summary", () => {
       });
 
       expect(normalizeTestText(text)).toContain("Context: 1.0k/200k");
+    });
+  });
+
+  it("uses a prepared context window in ordinary /status text and presentation", async () => {
+    const commandParams = buildCommandTestParams("/status", baseCfg);
+    const reply = await buildStatusReply({
+      cfg: baseCfg,
+      command: commandParams.command,
+      sessionEntry: {
+        sessionId: "sess-status-prepared-context",
+        updatedAt: 0,
+        totalTokens: 45_000,
+        totalTokensFresh: true,
+        totalTokensVersion: 1,
+      },
+      sessionKey: commandParams.sessionKey,
+      parentSessionKey: commandParams.sessionKey,
+      sessionScope: commandParams.sessionScope,
+      storePath: commandParams.storePath,
+      provider: "deepseek",
+      model: "deepseek-v4-flash",
+      contextTokens: 1_000_000,
+      thinkingCatalog: [
+        {
+          provider: "deepseek",
+          id: "deepseek-v4-flash",
+          contextWindow: 1_000_000,
+          contextTokens: 1_000_000,
+        },
+      ],
+      resolvedFastMode: false,
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolveDefaultThinkingLevel: async () => undefined,
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+      modelAuthOverride: "api-key",
+      activeModelAuthOverride: "api-key",
+    });
+    const table = reply?.presentation?.blocks.find((block) => block.type === "table");
+
+    expect(normalizeTestText(reply?.text ?? "")).toContain("Context: 45k/1.0m");
+    expect(table?.type === "table" ? table.rows : []).toContainEqual([
+      "📚 Context",
+      expect.stringContaining("45k/1.0m"),
+    ]);
+  });
+
+  it.each([
+    {
+      name: "binds a bare transcript model to its prepared provider entry",
+      sessionId: "sess-status-recovered-bare-model-context",
+      provider: "deepseek",
+      model: "deepseek-v4-flash",
+      transcriptModel: "small-model",
+      thinkingCatalog: [
+        {
+          provider: "deepseek",
+          id: "deepseek-v4-flash",
+          contextWindow: 1_000_000,
+          contextTokens: 1_000_000,
+        },
+        {
+          provider: "deepseek",
+          id: "small-model",
+          contextWindow: 128_000,
+          contextTokens: 128_000,
+        },
+      ],
+      expectedContext: "Context: 45k/128k",
+      rejectedContext: "Context: 45k/1.0m",
+    },
+    {
+      name: "binds a qualified transcript model to its exact prepared entry",
+      sessionId: "sess-status-recovered-qualified-model-context",
+      provider: "deepseek",
+      model: "deepseek-v4-flash",
+      transcriptModel: "deepseek/deepseek-v4-flash",
+      thinkingCatalog: [
+        {
+          provider: "deepseek",
+          id: "deepseek-v4-flash",
+          contextWindow: 1_000_000,
+          contextTokens: 1_000_000,
+        },
+      ],
+      expectedContext: "Context: 45k/1.0m",
+      rejectedContext: "Context: 45k/200k",
+    },
+    {
+      name: "keeps a cross-route qualified transcript model unbound",
+      sessionId: "sess-status-recovered-cross-route-model-context",
+      provider: "openrouter",
+      model: "google/gemini-2.5-pro",
+      transcriptModel: "google/gemini-2.5-pro",
+      thinkingCatalog: [
+        {
+          provider: "openrouter",
+          id: "google/gemini-2.5-pro",
+          contextWindow: 1_000_000,
+          contextTokens: 1_000_000,
+        },
+      ],
+      expectedContext: "Context: 45k/200k",
+      rejectedContext: "Context: 45k/1.0m",
+    },
+  ])("$name", async (testCase) => {
+    await withTempHome(async (dir) => {
+      await writeTranscriptUsageLog({
+        dir,
+        agentId: "main",
+        sessionId: testCase.sessionId,
+        model: testCase.transcriptModel,
+        usage: {
+          input: 45_000,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 45_000,
+        },
+      });
+
+      const text = await buildStatusText({
+        cfg: baseCfg,
+        sessionEntry: {
+          sessionId: testCase.sessionId,
+          updatedAt: 0,
+          modelSelectionLocked: true,
+        },
+        sessionKey: "agent:main:main",
+        parentSessionKey: "agent:main:main",
+        sessionScope: "per-sender",
+        statusChannel: "mobilechat",
+        provider: testCase.provider,
+        model: testCase.model,
+        contextTokens: 1_000_000,
+        thinkingCatalog: testCase.thinkingCatalog,
+        resolvedFastMode: false,
+        resolvedVerboseLevel: "off",
+        resolvedReasoningLevel: "off",
+        resolveDefaultThinkingLevel: async () => undefined,
+        isGroup: false,
+        defaultGroupActivation: () => "mention",
+        modelAuthOverride: "api-key",
+        activeModelAuthOverride: "api-key",
+      });
+
+      expect(normalizeTestText(text)).toContain(testCase.expectedContext);
+      expect(normalizeTestText(text)).not.toContain(testCase.rejectedContext);
     });
   });
 

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.status.test.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.status.test.ts
@@ -274,6 +274,15 @@ describe("native /status channel model routing", () => {
 
       const statusCall = buildStatusReplyMock.mock.calls[0]?.[0];
       expect(statusCall).toMatchObject({ provider: expectedProvider, model: expectedModel });
+      expect(statusCall.thinkingCatalog).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            provider: "anthropic",
+            id: "claude-fable-5",
+            contextWindow: 1_000_000,
+          }),
+        ]),
+      );
       if (expectedProvider === "anthropic") {
         await expect(statusCall.resolveDefaultThinkingLevel()).resolves.toBe("high");
       }

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -12,6 +12,7 @@ import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agen
 import { resolveExtraParams } from "../agents/embedded-agent-runner/extra-params.js";
 import { resolveFastModeState } from "../agents/fast-mode.js";
 import { resolveModelAuthMode } from "../agents/model-auth.js";
+import { findModelInCatalog } from "../agents/model-catalog-lookup.js";
 import {
   areRuntimeModelRefsEquivalent,
   shouldPreferActiveRuntimeAliasAuthLabel,
@@ -31,6 +32,7 @@ import type {
   ElevatedLevel,
   ReasoningLevel,
   ThinkLevel,
+  ThinkingCatalogEntry,
   VerboseLevel,
 } from "../auto-reply/thinking.js";
 import { resolveChannelModelOverride } from "../channels/model-overrides.js";
@@ -96,6 +98,10 @@ type StatusArgs = {
   agent: AgentConfig;
   agentId?: string;
   configuredDefaultModelLabel?: string;
+  selectedContextWindow?: number;
+  selectedContextTokens?: number;
+  thinkingCatalog?: ThinkingCatalogEntry[];
+  runtimeContextProvider?: string;
   runtimeContextTokens?: number;
   sessionEntry?: SessionEntry;
   sessionKey?: string;
@@ -700,13 +706,12 @@ export function buildStatusMessageParts(args: StatusArgs): StatusMessageParts {
           const provider = logUsage.model.slice(0, slashIndex).trim();
           const model = logUsage.model.slice(slashIndex + 1).trim();
           if (provider && model) {
+            const catalogEntry = findModelInCatalog(args.thinkingCatalog ?? [], provider, model);
             activeProvider = provider;
             activeModel = model;
-            // Preserve model-only lookup for transcript-derived provider/model IDs
-            // like "google/gemini-2.5-pro" that may come from a different upstream
-            // provider (for example OpenRouter).
-            contextLookupProvider = undefined;
-            contextLookupModel = logUsage.model;
+            // Bind exact catalog identities; keep cross-route namespaced ids raw.
+            contextLookupProvider = catalogEntry ? provider : undefined;
+            contextLookupModel = catalogEntry ? model : logUsage.model;
           }
         } else {
           activeModel = logUsage.model;
@@ -738,23 +743,37 @@ export function buildStatusMessageParts(args: StatusArgs): StatusMessageParts {
     cfg: contextConfig,
     provider: selectedLookupProvider,
     model: selectedLookupModel,
+    modelContextWindow: args.selectedContextWindow,
+    modelContextTokens: args.selectedContextTokens,
     allowAsyncLoad: false,
   });
-  const explicitRuntimeContextTokens =
-    typeof args.runtimeContextTokens === "number" && args.runtimeContextTokens > 0
-      ? args.runtimeContextTokens
-      : undefined;
-  const resolvedActiveContextTokens = resolveContextTokensForModel({
+  const activeCatalogEntry = contextLookupProvider
+    ? findModelInCatalog(args.thinkingCatalog ?? [], contextLookupProvider, contextLookupModel)
+    : undefined;
+  const activeModelMatchesPreparedIdentity =
+    normalizeLowercaseStringOrEmpty(contextLookupProvider) ===
+      normalizeLowercaseStringOrEmpty(modelRefs.active.provider) &&
+    normalizeLowercaseStringOrEmpty(contextLookupModel) ===
+      normalizeLowercaseStringOrEmpty(modelRefs.active.model);
+  const activeContextProvider =
+    contextLookupProvider &&
+    normalizeLowercaseStringOrEmpty(contextLookupProvider) ===
+      normalizeLowercaseStringOrEmpty(modelRefs.active.provider)
+      ? (args.runtimeContextProvider ?? contextLookupProvider)
+      : contextLookupProvider;
+  const activeContextTokens = resolveContextTokensForModel({
     cfg: contextConfig,
-    ...(contextLookupProvider ? { provider: contextLookupProvider } : {}),
+    ...(activeContextProvider ? { provider: activeContextProvider } : {}),
+    modelProvider: contextLookupProvider,
     model: contextLookupModel,
+    modelContextWindow: activeCatalogEntry?.contextWindow,
+    modelContextTokens:
+      activeCatalogEntry?.contextTokens ??
+      (activeCatalogEntry || activeModelMatchesPreparedIdentity
+        ? args.runtimeContextTokens
+        : undefined),
     allowAsyncLoad: false,
   });
-  const activeContextTokens =
-    typeof explicitRuntimeContextTokens === "number" &&
-    typeof resolvedActiveContextTokens === "number"
-      ? Math.min(explicitRuntimeContextTokens, resolvedActiveContextTokens)
-      : (explicitRuntimeContextTokens ?? resolvedActiveContextTokens);
   const channelModelNote = resolveChannelModelNote({
     config: args.config,
     entry,

--- a/src/status/status-text.test.ts
+++ b/src/status/status-text.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { formatSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
 import { normalizeSessionDeliveryState } from "../utils/delivery-context.shared.js";
 import { appendSessionCostLine } from "./status-runtime-lines.js";
-import { buildStatusText } from "./status-text.js";
+import { buildStatusReplyParts, buildStatusText } from "./status-text.js";
 
 const mocks = vi.hoisted(() => ({
   loadSessionCostSummariesFromCache: vi.fn(),
@@ -351,6 +351,180 @@ describe("buildStatusText thinking facts", () => {
 
     expect(text).toContain("think high");
     expect(text).not.toMatch(/think\s+off\b/);
+  });
+});
+
+describe("buildStatusText prepared context windows", () => {
+  const catalog = [
+    {
+      provider: "deepseek",
+      id: "deepseek-v4-flash",
+      contextWindow: 1_000_000,
+      contextTokens: 1_000_000,
+    },
+    {
+      provider: "fallback",
+      id: "small-model",
+      contextWindow: 128_000,
+      contextTokens: 128_000,
+    },
+    {
+      provider: "openrouter",
+      id: "deepseek/deepseek-v4-flash",
+      contextWindow: 1_000_000,
+      contextTokens: 1_000_000,
+    },
+  ];
+
+  async function renderPreparedStatus(
+    overrides: Partial<Parameters<typeof buildStatusReplyParts>[0]> = {},
+  ) {
+    return await buildStatusReplyParts({
+      cfg: {},
+      sessionEntry: {
+        sessionId: "prepared-context",
+        updatedAt: 0,
+        totalTokens: 45_000,
+        totalTokensFresh: true,
+        totalTokensVersion: 1,
+      },
+      sessionKey: "agent:main:main",
+      statusChannel: "mobilechat",
+      provider: "deepseek",
+      model: "deepseek-v4-flash",
+      thinkingCatalog: catalog,
+      resolvedHarness: "openclaw",
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolveDefaultThinkingLevel: async () => undefined,
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+      pluginHealthLineOverride: "Plugins: test",
+      taskLineOverride: "",
+      skipDefaultTaskLookup: true,
+      modelAuthOverride: "api-key",
+      activeModelAuthOverride: "api-key",
+      includeTranscriptUsage: false,
+      ...overrides,
+    });
+  }
+
+  it("renders a cold-cache prepared window in plain and rich status", async () => {
+    const parts = await renderPreparedStatus();
+    const table = parts.presentation.blocks.find((block) => block.type === "table");
+
+    expect(parts.text).toContain("Context: 45k/1.0m");
+    expect(parts.text).not.toContain("Context: 45k/200k");
+    expect(table?.type === "table" ? table.rows : []).toContainEqual([
+      "📚 Context",
+      expect.stringContaining("45k/1.0m"),
+    ]);
+  });
+
+  it("keeps the selected prepared window over stale active model state", async () => {
+    const parts = await renderPreparedStatus({
+      sessionEntry: {
+        sessionId: "selected-prepared-context",
+        updatedAt: 0,
+        providerOverride: "deepseek",
+        modelOverride: "deepseek-v4-flash",
+        modelOverrideSource: "user",
+        modelProvider: "fallback",
+        model: "small-model",
+        totalTokens: 45_000,
+        totalTokensFresh: true,
+        totalTokensVersion: 1,
+      },
+    });
+
+    expect(parts.text).toContain("Context: 45k/1.0m");
+    expect(parts.text).not.toContain("Context: 45k/128k");
+  });
+
+  it("uses the active prepared window for an established fallback", async () => {
+    const parts = await renderPreparedStatus({
+      sessionEntry: {
+        sessionId: "active-prepared-context",
+        updatedAt: 0,
+        providerOverride: "deepseek",
+        modelOverride: "deepseek-v4-flash",
+        modelProvider: "fallback",
+        model: "small-model",
+        fallbackNotice: {
+          kind: "active",
+          selectedModel: "deepseek/deepseek-v4-flash",
+          activeModel: "fallback/small-model",
+          reason: "provider unavailable",
+        },
+        totalTokens: 45_000,
+        totalTokensFresh: true,
+        totalTokensVersion: 1,
+      },
+    });
+
+    expect(parts.text).toContain("Context: 45k/128k");
+    expect(parts.text).not.toContain("Context: 45k/1.0m");
+  });
+
+  it("keeps Anthropic authored caps below the prepared Claude CLI window", async () => {
+    const parts = await renderPreparedStatus({
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      resolvedHarness: "claude-cli",
+      thinkingCatalog: [
+        {
+          provider: "anthropic",
+          id: "claude-haiku-4-5",
+          contextWindow: 1_000_000,
+          contextTokens: 1_000_000,
+        },
+      ],
+      cfg: {
+        models: {
+          providers: {
+            anthropic: {
+              baseUrl: "https://api.anthropic.test",
+              models: [
+                {
+                  id: "claude-haiku-4-5",
+                  name: "Claude Haiku 4.5",
+                  reasoning: true,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 1_000_000,
+                  contextTokens: 256_000,
+                  maxTokens: 128_000,
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    expect(parts.text).toContain("Context: 45k/256k");
+    expect(parts.text).not.toContain("Context: 45k/1.0m");
+  });
+
+  it("matches namespaced prepared model IDs without stripping them", async () => {
+    const parts = await renderPreparedStatus({
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-flash",
+      thinkingCatalog: [
+        ...catalog,
+        {
+          provider: "openrouter",
+          id: "deepseek-v4-flash",
+          reasoning: false,
+          input: ["text"],
+          contextWindow: 128_000,
+          contextTokens: 128_000,
+        },
+      ],
+    });
+
+    expect(parts.text).toContain("Context: 45k/1.0m");
+    expect(parts.text).not.toContain("Context: 45k/128k");
   });
 });
 

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -9,12 +9,13 @@ import {
   resolveAgentModelFallbacksOverride,
 } from "../agents/agent-scope.js";
 import { ensureAuthProfileStore } from "../agents/auth-profiles/store.js";
-import { resolveContextTokensForModel, waitForContextWindowCacheLoad } from "../agents/context.js";
+import { waitForContextWindowCacheLoad } from "../agents/context.js";
 import { resolveFastModeState } from "../agents/fast-mode.js";
 import { resolveAgentHarnessAutoSelectionHint } from "../agents/harness/auto-selection.js";
 import { resolveAgentHarnessPolicy } from "../agents/harness/policy.js";
 import { listRegisteredAgentHarnesses } from "../agents/harness/registry.js";
 import { resolveModelAuthLabel } from "../agents/model-auth-label.js";
+import { findModelInCatalog } from "../agents/model-catalog-lookup.js";
 import {
   areRuntimeModelRefsEquivalent,
   shouldPreferActiveRuntimeAliasAuthLabel,
@@ -125,21 +126,6 @@ const loadStatusQueueRuntime = createLazyPromise(() => import("./status-queue.ru
 const loadStatusPluginHealthRuntime = createLazyPromise(
   () => import("./status-plugin-health.runtime.js"),
 );
-
-// Context lookup stays synchronous/non-refreshing so status output does not
-// trigger provider/catalog IO while rendering a command response.
-function resolveStatusRuntimeContextTokens(params: {
-  cfg: OpenClawConfig;
-  provider: string;
-  model: string;
-}): number | undefined {
-  return resolveContextTokensForModel({
-    cfg: params.cfg,
-    provider: params.provider,
-    model: params.model,
-    allowAsyncLoad: false,
-  });
-}
 
 function shouldLoadUsageSummary(params: {
   provider?: string;
@@ -597,17 +583,18 @@ export async function buildStatusReplyParts(
   const explicitThinkingDefault =
     (agentConfig?.thinkingDefault as ThinkLevel | undefined) ??
     (agentDefaults.thinkingDefault as ThinkLevel | undefined);
-  const runtimeContextTokens = resolveStatusRuntimeContextTokens({
-    cfg,
-    provider: activeStatusProvider,
-    model: modelRefs.active.model || model,
-  });
-  const statusRuntimeContextTokens = activeRuntimeIsAuthoritative
-    ? (runtimeContextTokens ??
-      (fallbackState.active && typeof contextTokens === "number" && contextTokens > 0
-        ? contextTokens
-        : undefined))
-    : undefined;
+  const preparedContextTokens =
+    typeof contextTokens === "number" && contextTokens > 0 ? contextTokens : undefined;
+  const selectedCatalogEntry = findModelInCatalog(
+    thinkingCatalog ?? [],
+    selectedLookupProvider,
+    selectedLookupModel,
+  );
+  const initialActiveCatalogEntry = findModelInCatalog(
+    thinkingCatalog ?? [],
+    activeProvider,
+    modelRefs.active.model || model,
+  );
   const requestedThinkLevel =
     resolvedThinkLevel ??
     explicitThinkingDefault ??
@@ -665,7 +652,16 @@ export async function buildStatusReplyParts(
     },
     agentId: statusAgentId,
     configuredDefaultModelLabel,
-    runtimeContextTokens: statusRuntimeContextTokens,
+    selectedContextWindow: selectedCatalogEntry?.contextWindow,
+    selectedContextTokens:
+      selectedCatalogEntry?.contextTokens ??
+      (selectedCatalogEntry && !activeRuntimeIsAuthoritative ? preparedContextTokens : undefined),
+    thinkingCatalog,
+    runtimeContextProvider: activeRuntimeIsAuthoritative ? activeStatusProvider : undefined,
+    runtimeContextTokens:
+      activeRuntimeIsAuthoritative && (initialActiveCatalogEntry || fallbackState.active)
+        ? preparedContextTokens
+        : undefined,
     sessionEntry,
     sessionKey,
     parentSessionKey,


### PR DESCRIPTION
Fixes #133405
Related #127239

This supersedes only the `/status` portion of #127980. The broader context-cache and compaction work remains out of scope. Credit to @Finn763 for the original status-path investigation and proposed direction.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where `/status` and `session_status` could show the generic 200K context limit when their prepared model catalog already contained the selected or active model's larger context window.

## Why This Change Was Made

Status rendering now carries the caller-prepared catalog context into the canonical context resolver for both selected and active models. Selected metadata remains bound to the configured provider; active runtime aliases pass their configured provider separately for authored-cap lookup. Provider-qualified transcript recovery binds only when the recovered provider/model is an exact prepared catalog identity; cross-route namespaced IDs remain raw. This preserves authored caps, active-fallback provenance, and namespaced model IDs without provider hardcoding, request-time discovery, cache lifecycle changes, configuration changes, storage changes, or protocol changes.

## User Impact

Cold-cache status output reports the model's prepared context limit in both plain text and rich status cards. Established fallbacks still report the active model's window, and authored lower caps remain authoritative, including Anthropic caps under the Claude CLI runtime.

This does not claim to change compaction behavior.

## Evidence

Clean-process mock proof used a real ephemeral Gateway child with `qa-channel` and a mock provider:

```text
immediate /status:  Context ?/1.0m
session_status:     Context 64/1.0m (0%)
generic 200K fallback observed: no
```

Focused verification:

```text
171 tests passed across:
- src/status/status-message.test.ts
- src/status/status-text.test.ts
- src/auto-reply/reply/commands-status.test.ts
- src/auto-reply/reply/get-reply-native-slash-fast-path.status.test.ts
- src/agents/openclaw-tools.session-status.test.ts

Claude CLI authored-cap regression:
- before fix: Context: 45k/1.0m
- after fix:  Context: 45k/256k

Qualified transcript recovery:
- before fix, exact catalog identity: Context: 45k/200k
- after fix, exact catalog identity:  Context: 45k/1.0m
- cross-route qualified identity remains unbound: Context: 45k/200k

node scripts/run-tsgo-core-test-shards.mjs --stripe 2/5 --concurrency 2
passed

pnpm check:import-cycles
Import cycle check: 0 runtime value cycles.

git diff --check
passed
```

`pnpm check:changed` passed every changed-file guard through core production typechecking. Its aggregate run later encountered unrelated Control UI imports from the shared dependency install in `ui/src/pages/chat/route-loader-catalog-share.ts`; this branch changes no UI, package, or dependency files. The exact hosted core test-type stripe passes independently.

Autoreview on the final patch: `scoped-clean`, no accepted or actionable findings, correctness `0.99`.

Production LOC: `+59/-43` (net `+15`)  
Tests: `+346/-2`

## Telegram Test Server Proof

Telegram Test Server proof was attempted with the repository `telegram-e2e-userbot` doctor on this exact checkout. It was infeasible on this host because the authenticated Convex CLI/broker access required to lease Test Server credentials is unavailable. The doctor failed before acquiring credentials or starting a Gateway. The existing clean-process mock Gateway proof remains the real-flow evidence for `/status` and `session_status`; it is not represented as Telegram proof.
