### PR TITLE
refactor(agents): reuse Workshop text result envelopes

### DIFF
--- a/src/agents/tools/skill-workshop-tool-collection.ts
+++ b/src/agents/tools/skill-workshop-tool-collection.ts
@@ -19,6 +19,7 @@ import { listSkillCollectionReviewOutcomes } from "../../skills/workshop/collect
 import { readSkillProposalTargetTreeSha256 } from "../../skills/workshop/proposal-bundle.js";
 import { stringEnum } from "../schema/typebox.js";
 import { readToolStringParam, ToolInputError } from "./common.js";
+import { textResult } from "./tool-results.js";
 
 const SKILL_COLLECTION_HISTORY_REASON_MAX_CHARS = 300;
 const SKILL_COLLECTION_HISTORY_NAME_LIMIT = 10;
@@ -122,15 +123,10 @@ export async function executeSkillCollectionReconcile(params: {
       params.context.reconciling = false;
     }
   }
-  return {
-    content: [
-      {
-        type: "text" as const,
-        text: `Reconciled the skill collection: kept ${result.kept.length}, wrote ${result.written.length}, dropped ${result.dropped.length}. Backup ${result.backupId}.`,
-      },
-    ],
-    details: result,
-  };
+  return textResult(
+    `Reconciled the skill collection: kept ${result.kept.length}, wrote ${result.written.length}, dropped ${result.dropped.length}. Backup ${result.backupId}.`,
+    result,
+  );
 }
 
 export async function executeSkillCollectionRestore(params: {
@@ -138,15 +134,10 @@ export async function executeSkillCollectionRestore(params: {
   env?: NodeJS.ProcessEnv;
 }) {
   const result = await restoreLatestSkillCollectionBackup(params);
-  return {
-    content: [
-      {
-        type: "text" as const,
-        text: `Restored skill collection backup ${result.backupId}: restored ${result.restored.length}, removed ${result.removed.length}.`,
-      },
-    ],
-    details: result,
-  };
+  return textResult(
+    `Restored skill collection backup ${result.backupId}: restored ${result.restored.length}, removed ${result.removed.length}.`,
+    result,
+  );
 }
 
 export function executeSkillCollectionHistory(
@@ -189,15 +180,10 @@ export function executeSkillCollectionHistory(
   if (truncated) {
     text = `${truncateUtf16Safe(text, textLimit)}${SKILL_COLLECTION_HISTORY_TRUNCATION_MARKER}`;
   }
-  return {
-    content: [
-      {
-        type: "text" as const,
-        text: outcomes.length === 0 ? "No recorded collection reviews." : text,
-      },
-    ],
-    details: { reviews, truncated },
-  };
+  return textResult(outcomes.length === 0 ? "No recorded collection reviews." : text, {
+    reviews,
+    truncated,
+  });
 }
 
 function readCollectionPlanParam(params: Record<string, unknown>): SkillCollectionPlanEntry[] {

--- a/src/agents/tools/skill-workshop-tool-helpers.ts
+++ b/src/agents/tools/skill-workshop-tool-helpers.ts
@@ -17,6 +17,7 @@ import type {
   SkillWorkshopProposalReviewCompletion,
 } from "../../skills/workshop/types.js";
 import { readPositiveIntegerParam, readToolStringParam, ToolInputError } from "./common.js";
+import { textResult } from "./tool-results.js";
 
 export function assertAutonomousSkillSize(
   name: string,
@@ -97,10 +98,7 @@ export async function completeProposalReview(completion: SkillWorkshopProposalRe
 }
 
 function completionResult() {
-  return {
-    content: [{ type: "text" as const, text: "Completed Skill Workshop review." }],
-    details: { completed: true },
-  };
+  return textResult("Completed Skill Workshop review.", { completed: true });
 }
 
 export function proposalMutationText(action: string, record: SkillProposalRecord): string {
@@ -111,20 +109,17 @@ export function actionResult(
   record: SkillProposalRecord,
   options: { contentText: string; targetSkillFile?: string },
 ) {
-  return {
-    content: [{ type: "text" as const, text: options.contentText }],
-    details: {
-      id: record.id,
-      status: record.status,
-      kind: record.kind,
-      skillName: record.target.skillName,
-      skillKey: record.target.skillKey,
-      targetSkillFile: options.targetSkillFile ?? record.target.skillFile,
-      scanState: record.scan.state,
-      proposedVersion: record.proposedVersion,
-      draftHash: record.draftHash,
-    },
-  };
+  return textResult(options.contentText, {
+    id: record.id,
+    status: record.status,
+    kind: record.kind,
+    skillName: record.target.skillName,
+    skillKey: record.target.skillKey,
+    targetSkillFile: options.targetSkillFile ?? record.target.skillFile,
+    scanState: record.scan.state,
+    proposedVersion: record.proposedVersion,
+    draftHash: record.draftHash,
+  });
 }
 
 export function proposalResult(

--- a/src/agents/tools/skill-workshop-tool.collection-restore.test.ts
+++ b/src/agents/tools/skill-workshop-tool.collection-restore.test.ts
@@ -43,10 +43,11 @@ describe("skill_workshop collection restore", () => {
       collectionReconcile: { approvedSkillNames: new Set(["duplicate"]) },
     });
     await reviewTool.execute("read", { action: "read", skill_name: "duplicate" });
-    await reviewTool.execute("reconcile", {
+    const reconciled = await reviewTool.execute("reconcile", {
       action: "reconcile",
       collection: [{ action: "drop", name: "duplicate", reason: "redundant" }],
     });
+    const backupId = (reconciled.details as { backupId: string }).backupId;
     const aliasParent = await tempDirs.make("openclaw-skill-collection-restore-alias-");
     const workspaceAlias = path.join(aliasParent, "workspace-alias");
     await fs.symlink(
@@ -59,7 +60,16 @@ describe("skill_workshop collection restore", () => {
       workspaceDir: workspaceAlias,
       env: testState.env,
     });
-    await foregroundTool.execute("restore", { action: "restore_collection" });
+    const restored = await foregroundTool.execute("restore", { action: "restore_collection" });
+    expect(restored).toMatchObject({
+      content: [
+        {
+          type: "text",
+          text: `Restored skill collection backup ${backupId}: restored 1, removed 0.`,
+        },
+      ],
+      details: { backupId, restored: ["duplicate"], removed: [] },
+    });
 
     await expect(
       fs.readFile(path.join(workspaceAlias, "skills", "duplicate", "SKILL.md"), "utf8"),

--- a/src/agents/tools/skill-workshop-tool.ts
+++ b/src/agents/tools/skill-workshop-tool.ts
@@ -83,6 +83,7 @@ import {
   SKILL_PROPOSAL_STATUSES,
   SKILL_WORKSHOP_ACTIONS,
 } from "./skill-workshop-tool-schema.js";
+import { textResult } from "./tool-results.js";
 
 const SKILL_WORKSHOP_MUTATION_ACTIONS = new Set(["create", "patch", "update", "revise"]);
 function requireProposalContent(content: string | undefined): string {
@@ -279,10 +280,11 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
               readMaxChars,
             )
           : skill.content;
-        return {
-          content: [{ type: "text", text }],
-          details: { skillKey: skill.skillKey, sizeBytes, contentIncluded: !truncated },
-        };
+        return textResult(text, {
+          skillKey: skill.skillKey,
+          sizeBytes,
+          contentIncluded: !truncated,
+        });
       }
 
       if (action === "prepare_patch") {
@@ -335,12 +337,7 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
           query,
           limit,
         });
-        return {
-          content: [{ type: "text", text: formatProposalList(proposals) }],
-          details: {
-            proposals,
-          },
-        };
+        return textResult(formatProposalList(proposals), { proposals });
       }
 
       if (action === "inspect") {
@@ -392,20 +389,12 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
           expectedRevisionHash: readToolStringParam(params, "expected_revision_hash"),
           correlationId: readToolStringParam(params, "correlation_id"),
         });
-        return {
-          content: [
-            {
-              type: "text",
-              text: formatProposalEvaluation(evaluated.evaluation, evaluated.record.id),
-            },
-          ],
-          details: {
-            id: evaluated.record.id,
-            proposedVersion: evaluated.evaluation.proposedVersion,
-            revisionHash: evaluated.evaluation.revisionHash,
-            evaluation: evaluated.evaluation,
-          },
-        };
+        return textResult(formatProposalEvaluation(evaluated.evaluation, evaluated.record.id), {
+          id: evaluated.record.id,
+          proposedVersion: evaluated.evaluation.proposedVersion,
+          revisionHash: evaluated.evaluation.revisionHash,
+          evaluation: evaluated.evaluation,
+        });
       }
 
       if (action === "apply") {


### PR DESCRIPTION
## What Problem This Solves

Skill Workshop repeats the same single-text tool-result envelope in eight action paths, despite having a shared `textResult` helper for that contract.

## Why This Change Was Made

Use the existing helper for read, list, evaluate, mutation results, review completion, collection reconciliation, restore, and history. Keep the distinct structured proposal projection unchanged. This centralizes only envelope construction, not Workshop policy, persistence, authorization, or lifecycle decisions.

## User Impact

Model-facing text, typed details, truncation, revision checks, collection ownership, and side effects are unchanged. An existing workspace-alias restore case now also checks the returned text and receipt-linked details, while retaining its filesystem assertion.

Production LOC: **+39 / -69 (30 removed)**. Tests: **+12 / -2 (10 added)**. Whole change: **20 lines removed**, across four files.

## Evidence

- The characterized baseline and candidate each passed all **60 cases in 11 files**, using the same normal runner arguments. Case multiplicity and within-suite order are preserved; no retries or skipped cases.
- Coverage includes isolated review ownership, revision-bound mutations, proposal evaluation/projection, bounded history, workspace-alias restoration, and the shared result-helper contract.
- Formatting preserved the tested bytes, and the normal **29-stage changed-file gate passed**, including core and core-test types, lint, all three dead-export scans, boundaries, schema/store guards, and import-cycle checks.
- Precommit and separate exact-commit Codex reviews both completed with no P0 findings. Normal commit hooks preserved all four tested afterimages and the 32 reviewed source contexts. Reviewed commit: `6738095a1747438d1a86439fc05974ebb3f05a85`.
- [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33328468671) completed successfully: 167 successful jobs and 18 skipped, including the required `openclaw/ci-gate`. No CI retry or cancellation was needed.
- The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/133453#issuecomment-5470558991) has no actionable source findings. Its remaining normal-CI step is satisfied by the run above; the maintainer landing decision and native checks remain separate.

The review's stored-data heuristic does not correspond to a storage change: collection reconciliation, restoration and history still call the same owners with the same inputs and results. Only the returned text/details envelopes change construction. No schema, migration, embedding metadata, or persistence behavior changes, so migration proof is not applicable.

This is a behavior-neutral result-envelope refactor, not a change to the backing store or tool protocol. No performance, live-provider, or new built-CLI result is claimed.

Landed as [d434b3dbe0b2](https://github.com/openclaw/openclaw/commit/d434b3dbe0b23af6854084d4fa94cbb9257aaf8a). Normal hosted preparation and merge both completed successfully without a rebase or push. Independent and maintainer checks confirmed that all 35,555 landed tree entries equal the actual main parent plus exactly the four reviewed afterimages; main ancestry and the actual 30-production/20-total line reduction are verified.
