### PR TITLE
fix: package oversized release contribution records without losing notes

### DIFF
--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -236,6 +236,9 @@ This checklist is the public shape of the release flow. Private credentials, sig
 6. Commit only `CHANGELOG.md`. This commit is the **Release SHA**. The complete diff from Code SHA to Release SHA must be exactly `CHANGELOG.md`; any other changed path returns the release to step 2.
 7. Run SHA-pinned Full Release Validation for the Release SHA with evidence reuse enabled. The lightweight parent must record `changelog-only-release-v1`, point at the green Code SHA, and dispatch no product child lanes. This reuses product evidence; it does not reuse package bytes.
 8. Run `OpenClaw NPM Release` with `preflight_only=true` against the Release SHA/tag. Save the successful `preflight_run_id`. This builds and checks the exact package bytes that include the final changelog. Review its **Plugin SDK API diff** summary. If it reports changes, inspect the readable diff (also uploaded as `plugin-sdk-api-release-diff-<run-id>-<run-attempt>`) and record the 8-character acknowledgement digest printed by the report; omit the acknowledgement when it reports no Plugin SDK API changes.
+
+   If the packaged changelog exceeds 500 KiB, packaging keeps every editorial note and replaces only the complete contribution record with a link to the full record in the exact release tag's `CHANGELOG.md`. The full source changelog and contributor credits remain unchanged after postpack restoration. Editorial notes must still satisfy the release-note minimum, and packaging fails if the compact result still exceeds the cap.
+
 9. Run the candidate helper against the untagged Release SHA with the successful Release-SHA validation parent and npm preflight instead of dispatching either again:
 
    ```bash

--- a/scripts/lib/release-notes-compaction.mjs
+++ b/scripts/lib/release-notes-compaction.mjs
@@ -1,0 +1,61 @@
+// Shared plain-JavaScript rendering also runs in package preflight before dependency setup.
+export const OPENCLAW_RELEASE_TAG_PATTERN =
+  /^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(?:-(?:(?:alpha|beta)\.[1-9][0-9]*|[1-9][0-9]*))?$/u;
+
+const CONTRIBUTION_RECORD_HEADING = "### Complete contribution record";
+
+export function validateReleaseNotesRepository(repository) {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(repository)) {
+    throw new Error(`invalid GitHub repository: ${repository}`);
+  }
+}
+
+export function validateReleaseNotesTag(tag) {
+  if (!OPENCLAW_RELEASE_TAG_PATTERN.test(tag)) {
+    throw new Error(`invalid release tag: ${tag}`);
+  }
+}
+
+function tagPinnedContributionRecordUrl(repository, tag) {
+  validateReleaseNotesRepository(repository);
+  validateReleaseNotesTag(tag);
+  return `https://github.com/${repository}/blob/${tag}/CHANGELOG.md#complete-contribution-record`;
+}
+
+function headingIndexOutsideFences(markdown, heading) {
+  let offset = 0;
+  let fence;
+  for (const segment of markdown.split(/(?<=\n)/u)) {
+    const line = segment.replace(/\n$/u, "");
+    const fenceMatch = line.match(/^\s*(?<marker>`{3,}|~{3,})/u);
+    if (fenceMatch?.groups?.marker) {
+      const marker = fenceMatch.groups.marker;
+      if (!fence) {
+        fence = marker;
+      } else if (marker.charAt(0) === fence.charAt(0) && marker.length >= fence.length) {
+        fence = undefined;
+      }
+    } else if (!fence && line === heading) {
+      return offset;
+    }
+    offset += segment.length;
+  }
+  return -1;
+}
+
+export function compactReleaseNotes(section, repository, tag) {
+  const recordIndex = headingIndexOutsideFences(section, CONTRIBUTION_RECORD_HEADING);
+  if (recordIndex < 0) {
+    return null;
+  }
+  const editorialNotes = section.slice(0, recordIndex).trimEnd();
+  const contributionRecordUrl = tagPinnedContributionRecordUrl(repository, tag);
+  const body = [
+    editorialNotes,
+    "",
+    CONTRIBUTION_RECORD_HEADING,
+    "",
+    `The full contribution record is available in the tag-pinned [CHANGELOG.md](${contributionRecordUrl}).`,
+  ].join("\n");
+  return { body, editorialNotes };
+}

--- a/scripts/package-changelog.mjs
+++ b/scripts/package-changelog.mjs
@@ -5,6 +5,7 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { compactReleaseNotes } from "./lib/release-notes-compaction.mjs";
 
 const CHANGELOG_PATH = "CHANGELOG.md";
 const PACKAGE_JSON_PATH = "package.json";
@@ -58,6 +59,16 @@ function extractPreamble(lines, firstHeadingIndex) {
   return lines.slice(0, firstHeadingIndex).join("\n").trimEnd();
 }
 
+function assertMeaningfulReleaseBody(section, version) {
+  const body = section.split(/\r?\n/u).slice(1).join("\n").trim();
+  const bodyBytes = Buffer.byteLength(body, "utf8");
+  if (bodyBytes < MIN_RELEASE_SECTION_BODY_BYTES) {
+    throw new Error(
+      `Packaged changelog section for ${version} is only ${bodyBytes} body bytes, which is below the ${MIN_RELEASE_SECTION_BODY_BYTES} byte safety minimum.`,
+    );
+  }
+}
+
 /**
  * Extracts the current release changelog section for package publishing.
  */
@@ -80,14 +91,20 @@ export function extractCurrentPackageChangelog(content, packageVersion, options 
     .slice(heading.index, nextHeading?.index ?? lines.length)
     .join("\n")
     .trimEnd();
-  const releaseBody = releaseSection.split(/\r?\n/u).slice(1).join("\n").trim();
-  const releaseBodyBytes = Buffer.byteLength(releaseBody, "utf8");
-  if (releaseBodyBytes < MIN_RELEASE_SECTION_BODY_BYTES) {
-    throw new Error(
-      `Packaged changelog section for ${heading.version} is only ${releaseBodyBytes} body bytes, which is below the ${MIN_RELEASE_SECTION_BODY_BYTES} byte safety minimum.`,
+  assertMeaningfulReleaseBody(releaseSection, heading.version);
+  let packaged = `${preamble}\n\n${releaseSection}\n`;
+  if (Buffer.byteLength(packaged, "utf8") > MAX_PACKAGED_CHANGELOG_BYTES) {
+    // Keep every editorial note; only the audited record moves behind its immutable source link.
+    const compacted = compactReleaseNotes(
+      releaseSection,
+      "openclaw/openclaw",
+      `v${packageVersion}`,
     );
+    if (compacted) {
+      assertMeaningfulReleaseBody(compacted.editorialNotes, heading.version);
+      packaged = `${preamble}\n\n${compacted.body}\n`;
+    }
   }
-  const packaged = `${preamble}\n\n${releaseSection}\n`;
   const packagedBytes = Buffer.byteLength(packaged, "utf8");
   if (packagedBytes > MAX_PACKAGED_CHANGELOG_BYTES) {
     throw new Error(

--- a/scripts/render-github-release-notes.mts
+++ b/scripts/render-github-release-notes.mts
@@ -2,6 +2,12 @@
 
 import { readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
+import {
+  compactReleaseNotes,
+  OPENCLAW_RELEASE_TAG_PATTERN,
+  validateReleaseNotesRepository as validateRepository,
+  validateReleaseNotesTag as validateTag,
+} from "./lib/release-notes-compaction.mjs";
 
 type ShippedBaselineExclusion = {
   ref: string;
@@ -27,11 +33,8 @@ type ReleaseNotesTarget = {
   repository: unknown;
 };
 
-const CONTRIBUTION_RECORD_HEADING = "### Complete contribution record";
 const RELEASE_VERIFICATION_HEADING = "### Release verification";
 const SHIPPED_BASELINE_EXCLUSIONS_PREFIX = "Shipped baseline exclusions:";
-const OPENCLAW_RELEASE_TAG_PATTERN =
-  /^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(?:-(?:(?:alpha|beta)\.[1-9][0-9]*|[1-9][0-9]*))?$/u;
 const RELEASE_HEADING_PATTERN =
   /^## (?<version>Unreleased|[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(?:-(?:(?:alpha|beta)\.[1-9][0-9]*|[1-9][0-9]*))?)\r?$/u;
 
@@ -53,18 +56,6 @@ function joinBody(notes: string, tail: string | undefined) {
   const normalizedNotes = notes.trimEnd();
   const normalizedTail = normalizeTail(tail);
   return normalizedTail ? `${normalizedNotes}\n\n${normalizedTail}` : normalizedNotes;
-}
-
-function validateRepository(repository: string) {
-  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(repository)) {
-    fail(`invalid GitHub repository: ${repository}`);
-  }
-}
-
-function validateTag(tag: string) {
-  if (!OPENCLAW_RELEASE_TAG_PATTERN.test(tag)) {
-    fail(`invalid release tag: ${tag}`);
-  }
 }
 
 export function formatContributionRecordProvenance(provenance: ContributionRecordProvenance) {
@@ -274,51 +265,6 @@ export function parseShippedBaselineExclusions(section: string) {
   return baselines;
 }
 
-function tagPinnedContributionRecordUrl(repository: string, tag: string) {
-  validateRepository(repository);
-  validateTag(tag);
-  return `https://github.com/${repository}/blob/${tag}/CHANGELOG.md#complete-contribution-record`;
-}
-
-function headingIndexOutsideFences(markdown: string, heading: string) {
-  let offset = 0;
-  let fence: string | undefined;
-  for (const segment of markdown.split(/(?<=\n)/u)) {
-    const line = segment.replace(/\n$/u, "");
-    const fenceMatch = line.match(/^\s*(?<marker>`{3,}|~{3,})/u);
-    if (fenceMatch?.groups?.marker) {
-      const marker = fenceMatch.groups.marker;
-      if (!fence) {
-        fence = marker;
-      } else if (marker.charAt(0) === fence.charAt(0) && marker.length >= fence.length) {
-        fence = undefined;
-      }
-    } else if (!fence && line === heading) {
-      return offset;
-    }
-    offset += segment.length;
-  }
-  return -1;
-}
-
-function compactReleaseNotes(section: string, repository: string, tag: string) {
-  const recordIndex = headingIndexOutsideFences(section, CONTRIBUTION_RECORD_HEADING);
-  if (recordIndex < 0) {
-    fail(
-      "release notes exceed GitHub's body limit and cannot be compacted without a complete contribution record",
-    );
-  }
-  const editorialNotes = section.slice(0, recordIndex).trimEnd();
-  const contributionRecordUrl = tagPinnedContributionRecordUrl(repository, tag);
-  return [
-    editorialNotes,
-    "",
-    CONTRIBUTION_RECORD_HEADING,
-    "",
-    `The full contribution record is available in the tag-pinned [CHANGELOG.md](${contributionRecordUrl}).`,
-  ].join("\n");
-}
-
 export function dedicatedSectionVersionForTag(tag: unknown) {
   // Correction (vX-N) and alpha tags may carry their own exact changelog
   // heading; beta and stable bodies must come from the stable base section.
@@ -374,7 +320,12 @@ export function renderGithubReleaseNotes({
   }
   const section = releaseNotesSectionForTag(changelog, version, tag);
   const mode = fitsGithubReleaseBody(section) ? "full" : "compact";
-  const baseBody = mode === "full" ? section : compactReleaseNotes(section, repository, tag);
+  const baseBody = mode === "full" ? section : compactReleaseNotes(section, repository, tag)?.body;
+  if (baseBody === undefined) {
+    fail(
+      "release notes exceed GitHub's body limit and cannot be compacted without a complete contribution record",
+    );
+  }
   if (!fitsGithubReleaseBody(baseBody)) {
     const size = githubReleaseBodySize(baseBody);
     fail(

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -513,6 +513,7 @@ describe("package-openclaw-for-docker", () => {
       "scripts/lib/optional-bundled-clusters.mjs",
       "scripts/lib/output-root-guard.mjs",
       "scripts/lib/record-shared.mjs",
+      "scripts/lib/release-notes-compaction.mjs",
       "scripts/lib/root-package-bundled-plugin-excludes.mjs",
       "scripts/lib/windows-cmd-helpers-runtime.mts",
       "scripts/lib/windows-taskkill.mjs",

--- a/test/scripts/ocm-npm-workspace-deps.test.ts
+++ b/test/scripts/ocm-npm-workspace-deps.test.ts
@@ -175,6 +175,11 @@ describe("OCM npm workspace dependency adapter", () => {
         join(scriptsDir, "package-changelog.mjs"),
         readFileSync(packageChangelogPath, "utf8"),
       );
+      mkdirSync(join(scriptsDir, "lib"), { recursive: true });
+      writeFileSync(
+        join(scriptsDir, "lib", "release-notes-compaction.mjs"),
+        readFileSync(new URL("../../scripts/lib/release-notes-compaction.mjs", import.meta.url)),
+      );
       execFileSync(process.execPath, ["scripts/package-changelog.mjs", "prepare"], {
         cwd: root,
         stdio: "pipe",

--- a/test/scripts/package-changelog.test.ts
+++ b/test/scripts/package-changelog.test.ts
@@ -1,5 +1,5 @@
 // Package Changelog tests cover package changelog script behavior.
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -33,6 +33,14 @@ Docs: https://docs.openclaw.ai
 ### Highlights
 - Older highlight.
 `;
+
+const oversizedContributionRecord = `### Complete contribution record
+
+${"- **PR #123** Thanks @contributor.\n".repeat(20_000)}`;
+const oversizedChangelog = cumulativeChangelog.replace(
+  "## 2026.5.27",
+  `${oversizedContributionRecord}\n## 2026.5.27`,
+);
 
 describe("package-changelog", () => {
   it("maps release-channel package versions to package changelog candidate headings", () => {
@@ -163,15 +171,38 @@ Docs: https://docs.openclaw.ai
     ).toThrow("Packaged changelog section for 2026.5.29 is only 7 body bytes");
   });
 
-  it("fails closed when the packaged changelog is unexpectedly large", () => {
-    const source = changelog`
+  it.each(["", oversizedContributionRecord])(
+    "refuses oversized editorial notes even with a contribution record (%#)",
+    (record) => {
+      const source = changelog`
 # Changelog
 ## 2026.5.28
 ${"é".repeat(260_000)}
+${record}
 `;
 
+      expect(() => extractCurrentPackageChangelog(source, "2026.5.28")).toThrow(
+        "exceeds the 512000 byte safety limit",
+      );
+    },
+  );
+
+  it.each(["2026.5.28", "2026.5.28-beta.1", "2026.5.28-alpha.2", "2026.5.28-1"])(
+    "compacts only an oversized contribution record and pins the exact %s tag",
+    (version) => {
+      const editorial = `## ${version}\n\n### Fixes\n\n- Preserve this complete user-facing note and credit. Thanks @contributor.`;
+      const source = `# Changelog\n\n${editorial}\n\n${oversizedContributionRecord}\n`;
+      const packaged = extractCurrentPackageChangelog(source, version);
+      expect(packaged).toBe(
+        `# Changelog\n\n${editorial}\n\n### Complete contribution record\n\nThe full contribution record is available in the tag-pinned [CHANGELOG.md](https://github.com/openclaw/openclaw/blob/v${version}/CHANGELOG.md#complete-contribution-record).\n`,
+      );
+    },
+  );
+
+  it("does not use the generated contribution link to satisfy the release-note minimum", () => {
+    const source = `# Changelog\n\n## 2026.5.28\n\n### Fixes\n\n${oversizedContributionRecord}\n`;
     expect(() => extractCurrentPackageChangelog(source, "2026.5.28")).toThrow(
-      "exceeds the 512000 byte safety limit",
+      "below the 32 byte safety minimum",
     );
   });
 
@@ -190,23 +221,28 @@ Docs: https://docs.openclaw.ai
     );
   });
 
-  it("prepares and restores the packaged changelog without changing the source permanently", async () => {
-    const root = mkdtempSync(path.join(os.tmpdir(), "openclaw-package-changelog-"));
-    try {
-      writeFileSync(path.join(root, "package.json"), '{"version":"2026.5.28-beta.1"}\n', "utf8");
-      writeFileSync(path.join(root, "CHANGELOG.md"), cumulativeChangelog, "utf8");
+  it.each([cumulativeChangelog, oversizedChangelog])(
+    "prepares and restores all source notes and credits (%#)",
+    async (sourceChangelog) => {
+      const root = mkdtempSync(path.join(os.tmpdir(), "openclaw-package-changelog-"));
+      try {
+        writeFileSync(path.join(root, "package.json"), '{"version":"2026.5.28-beta.1"}\n', "utf8");
+        writeFileSync(path.join(root, "CHANGELOG.md"), sourceChangelog, "utf8");
 
-      await expect(preparePackageChangelog(root)).resolves.toBe(true);
-      expect(readFileSync(path.join(root, "CHANGELOG.md"), "utf8")).not.toContain("## Unreleased");
-      expect(readFileSync(path.join(root, "CHANGELOG.md"), "utf8")).not.toContain("## 2026.5.27");
-      expect(readFileSync(path.join(root, "CHANGELOG.md"), "utf8")).toContain("## 2026.5.28");
+        await expect(preparePackageChangelog(root)).resolves.toBe(true);
+        expect(readFileSync(path.join(root, "CHANGELOG.md"), "utf8")).not.toContain(
+          "## Unreleased",
+        );
+        expect(readFileSync(path.join(root, "CHANGELOG.md"), "utf8")).not.toContain("## 2026.5.27");
+        expect(readFileSync(path.join(root, "CHANGELOG.md"), "utf8")).toContain("## 2026.5.28");
 
-      await expect(restorePackageChangelog(root)).resolves.toBe(true);
-      expect(readFileSync(path.join(root, "CHANGELOG.md"), "utf8")).toBe(cumulativeChangelog);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
+        await expect(restorePackageChangelog(root)).resolves.toBe(true);
+        expect(readFileSync(path.join(root, "CHANGELOG.md"), "utf8")).toBe(sourceChangelog);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("recovers an interrupted ephemeral QA package with the default restore path", async () => {
     const root = mkdtempSync(path.join(os.tmpdir(), "openclaw-package-changelog-"));
@@ -226,28 +262,35 @@ Docs: https://docs.openclaw.ai
     }
   });
 
-  it("refuses to restore stale backups over current changelog edits", async () => {
-    const root = mkdtempSync(path.join(os.tmpdir(), "openclaw-package-changelog-"));
-    const backupPath = path.join(
-      root,
-      ".artifacts",
-      "package-changelog",
-      "CHANGELOG.md.prepack-backup",
-    );
-    const editedChangelog = cumulativeChangelog.replace("- Current fix.", "- Current fix edited.");
-    try {
-      writeFileSync(path.join(root, "package.json"), '{"version":"2026.5.28-beta.1"}\n', "utf8");
-      writeFileSync(path.join(root, "CHANGELOG.md"), editedChangelog, "utf8");
-      mkdirSync(path.dirname(backupPath), { recursive: true });
-      writeFileSync(backupPath, cumulativeChangelog, "utf8");
-
-      await expect(restorePackageChangelog(root)).rejects.toThrow(
-        "Refusing to restore packaged changelog backup",
+  it.each([cumulativeChangelog, oversizedChangelog])(
+    "refuses to restore over edits after package preparation (%#)",
+    async (sourceChangelog) => {
+      const root = mkdtempSync(path.join(os.tmpdir(), "openclaw-package-changelog-"));
+      const backupPath = path.join(
+        root,
+        ".artifacts",
+        "package-changelog",
+        "CHANGELOG.md.prepack-backup",
       );
-      expect(readFileSync(path.join(root, "CHANGELOG.md"), "utf8")).toBe(editedChangelog);
-      expect(existsSync(backupPath)).toBe(true);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
+
+      try {
+        writeFileSync(path.join(root, "package.json"), '{"version":"2026.5.28-beta.1"}\n', "utf8");
+        writeFileSync(path.join(root, "CHANGELOG.md"), sourceChangelog, "utf8");
+        await preparePackageChangelog(root);
+        const editedChangelog = readFileSync(path.join(root, "CHANGELOG.md"), "utf8").replace(
+          "- Current fix.",
+          "- Current fix edited.",
+        );
+        writeFileSync(path.join(root, "CHANGELOG.md"), editedChangelog, "utf8");
+
+        await expect(restorePackageChangelog(root)).rejects.toThrow(
+          "Refusing to restore packaged changelog backup",
+        );
+        expect(readFileSync(path.join(root, "CHANGELOG.md"), "utf8")).toBe(editedChangelog);
+        expect(existsSync(backupPath)).toBe(true);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/test/scripts/package-source-preflight.test.ts
+++ b/test/scripts/package-source-preflight.test.ts
@@ -350,6 +350,16 @@ describe("package source preflight", () => {
     ).toThrow("CHANGELOG.md does not contain a release section for 2026.8.1.");
   });
 
+  it("accepts complete oversized contribution records through the package renderer", () => {
+    expect(
+      validatePackageSource({
+        aiManifestContent: aiManifest(),
+        rootManifestContent: rootManifest(),
+        changelogContent: `# Changelog\n\n## 2026.8.1\n\n- A complete release note with its original credit. Thanks @contributor.\n\n### Complete contribution record\n\n${"- **PR #123** Thanks @contributor.\n".repeat(20_000)}`,
+      }),
+    ).toBe("2026.8.1");
+  });
+
   it("rejects source package version drift", () => {
     expect(() =>
       validatePackageSource({


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where release npm preflight and packaging reject a complete changelog whose contribution record makes the current section exceed the 500 KiB package safety cap. The 2026.8.1 candidate rendered 726,562 bytes and failed before building: [npm preflight](https://github.com/openclaw/openclaw/actions/runs/33327277735).

## Why This Change Was Made

Package rendering now uses the existing GitHub release-note compaction owner when the package section is oversized. Both renderers share one plain-JavaScript helper, which also runs before dependency setup. It preserves every editorial note and links the full contribution record at the exact release tag. Ordinary package output, the size cap, the meaningful-note minimum, and edited-backup restoration protection remain intact; the generated link cannot satisfy the editorial minimum.

The alternative of changing only trusted preflight would leave target prepack broken; raising the cap or cutting source notes would weaken the existing contract. The repair belongs to the package projection and its shared renderer. The release guide documents that behavior. No changelog-source, version, dependency, or publication-policy change is included.

Production LOC: +96/-67 (net +29) | Tests/support: +101/-42 (net +59) | Docs: +3/-0. Most helper lines move the established GitHub implementation; net growth adds the package compaction path and independent editorial validation without duplicating rendering policy.

## User Impact

Large releases can package their complete editorial notes while retaining all contributor credit in the source changelog. Postpack restores that full source byte-for-byte. Oversized editorial notes still fail rather than being truncated.

## Evidence

- Before the production change, exact-source preflight failed at 726,562 bytes and the tests-only regression run failed 10 tests. After repair, plain Node preflight succeeds both against the exact source ref and from an isolated copied harness without installed dependencies.
- 75 focused changelog, source-preflight, GitHub-renderer, OCM lifecycle, and docs-map tests pass. Docker package tests pass 52 tests with three existing platform skips; both standalone script-copy fixtures include the shared helper.
- The exact release source renders a 121,488-byte packaged changelog and restores the original source hash through the real postpack owner. GitHub rendering is byte-for-byte unchanged at 121,485 bytes.
- Focused script lint, formatting, script erasability, boundary guards, and diff checks pass. Local `check:changed` stops at unchanged shared dependency type errors in shiki, tslog, and pako; shared dependencies were not modified. Hosted production and test type checks pass on the exact PR head, and CI run 33328486165 attempt 2 is successful. Native prepare accepted the unchanged head.

Provenance: the oversized complete contribution record is the verified trigger; the original introduction of the package cap behavior has not been attributed.

The storage detector does not indicate a runtime schema or persistent-state change: this patch changes the existing temporary package changelog projection only. The existing backup artifact and restoration lifecycle are preserved and tested, including refusal to overwrite edits. ClawSweeper found no actionable issue on the exact head.

The initial CI run has one included-config-file watcher failure outside this patch (callback remained uncalled). The unchanged complete config-reload test file passes 223/223 locally. The single authorized failed-job retry passed in attempt 2 on the unchanged head; the original failure is retained, and no timeout or source change was made. Follow-up: diagnose and synchronize polling watcher readiness in the included-config-file test; the precise intermittent cause remains unproven.
