### PR TITLE
fix: preserve shell outcomes and dispatch chat bash aliases

### DIFF
--- a/docs/gateway/background-process.md
+++ b/docs/gateway/background-process.md
@@ -38,6 +38,18 @@ Behavior:
 - If automatic completion wake is unavailable, or you need quiet-success confirmation for a command that exits cleanly with no output, poll with `process`.
 - Don't emulate reminders or delayed follow-ups with `sleep` loops or repeated polling — use cron for future work.
 
+### Chat shell shortcuts
+
+With [chat bash enabled](/tools/slash-commands), `/bash <command>` and `! <command>`
+report the recorded exit code or signal. Unknown exit codes stay unknown; failed
+results use a warning indicator even when the recorded code is zero. Foreground
+replies preserve exec warnings and failure guidance. Use `/bash poll <sessionId>`
+or `!poll <sessionId>` to inspect a background job; timeout results include
+retry-safety guidance. `/bash stop` and `!stop` request cancellation of background
+jobs; poll to confirm their final outcome.
+
+Both shortcuts use the same sender authorization and elevated-access gates.
+
 ### Env overrides
 
 | Variable                                 | Effect                                                                                                           |

--- a/extensions/clickclack/src/access.ts
+++ b/extensions/clickclack/src/access.ts
@@ -312,6 +312,9 @@ export async function resolveClickClackInboundAccess(params: {
       ? {
           cfg,
           modeWhenAccessGroupsOff: "configured",
+          // Coarse authorization detection also matches ordinary text; only
+          // actual control commands may bypass the group mention requirement.
+          hasControlCommand: runtime.channel.text.hasControlCommand(params.message.body, cfg),
         }
       : false,
   });

--- a/extensions/clickclack/src/inbound.mention-gating.test.ts
+++ b/extensions/clickclack/src/inbound.mention-gating.test.ts
@@ -1,9 +1,19 @@
-import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
+import {
+  createPluginRuntimeMock,
+  createTestRegistry,
+  withPluginRuntimeRegistryScope,
+} from "openclaw/plugin-sdk/channel-test-helpers";
+import {
+  hasControlCommand,
+  shouldComputeCommandAuthorized,
+} from "openclaw/plugin-sdk/command-detection";
+import { shouldHandleTextCommands } from "openclaw/plugin-sdk/command-surface";
 import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { buildAgentSessionKey, resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { describe, expect, it, vi } from "vitest";
 import { resolveClickClackInboundAccess } from "./access.js";
+import { clickClackPlugin } from "./channel.js";
 import {
   getClickClackDiscussionBindingStore,
   type ClickClackDiscussionBinding,
@@ -71,6 +81,11 @@ function createRuntime(): PluginRuntime {
       },
     },
     channel: {
+      commands: {
+        shouldComputeCommandAuthorized: vi.fn(shouldComputeCommandAuthorized),
+        shouldHandleTextCommands: vi.fn(shouldHandleTextCommands),
+      },
+      text: { hasControlCommand: vi.fn(hasControlCommand) },
       routing: {
         resolveAgentRoute: vi.fn(
           (params: Parameters<PluginRuntime["channel"]["routing"]["resolveAgentRoute"]>[0]) =>
@@ -483,47 +498,153 @@ describe("ClickClack inbound mention gating", () => {
     expect(runtime.channel.inbound.dispatch).not.toHaveBeenCalled();
   });
 
-  it("rejects an unmentioned group message when mention gating is enabled", async () => {
+  it.each([
+    { body: "hello everyone", requested: false },
+    { body: "hello! poll", requested: false },
+    { body: "hello ! poll", requested: true },
+    { body: "hello ! (exit 0)", requested: true },
+    { body: "hello ! 'printf' ok", requested: true },
+    { body: "hello ! 2>/dev/null", requested: true },
+    { body: "hello !poll", requested: true },
+    { body: "hello /status", requested: true },
+    { body: "! poll", requested: true },
+    { body: "!poll", requested: true },
+  ])(
+    "keeps unmentioned $body gated while command metadata requested=$requested",
+    async ({ body, requested }) => {
+      const runtime = createRuntime();
+      setClickClackRuntime(runtime);
+      const params = {
+        account: createAgentAccount({
+          allowFrom: ["usr_owner"],
+          requireMention: true,
+          botHandle: "blackbird",
+        }),
+        config: { commands: { text: true } } satisfies CoreConfig,
+        message: createMessage({ body }),
+      };
+      const access = await resolveClickClackInboundAccess(params);
+      await handleClickClackInbound({ ...params, access });
+
+      expect(access.channelIngress?.commandAccess).toMatchObject({
+        requested,
+        authorized: requested,
+      });
+      expect(runtime.channel.inbound.dispatch).not.toHaveBeenCalled();
+      expect(runtime.agent.runEmbeddedAgent).not.toHaveBeenCalled();
+      expect(runtime.llm.complete).not.toHaveBeenCalled();
+      expect(access.channelIngress?.activationAccess).toMatchObject({
+        shouldSkip: true,
+        shouldBypassMention: false,
+      });
+    },
+  );
+
+  it.each([true, false])(
+    "preserves control bypass on a non-native surface with commands.text=%s",
+    async (text) => {
+      const registry = createTestRegistry([
+        { pluginId: "clickclack", plugin: clickClackPlugin, source: "test" },
+      ]);
+      await withPluginRuntimeRegistryScope(registry, async () => {
+        const runtime = createRuntime();
+        setClickClackRuntime(runtime);
+        const params = {
+          account: createAgentAccount({ allowFrom: ["usr_owner"], requireMention: true }),
+          config: { commands: { text } } satisfies CoreConfig,
+          message: createMessage({ body: "/status" }),
+        };
+        const access = await resolveClickClackInboundAccess(params);
+        await handleClickClackInbound({ ...params, access });
+
+        expect(access.channelIngress?.commandAccess).toMatchObject({
+          requested: true,
+          authorized: true,
+        });
+        expect(access.channelIngress?.activationAccess).toMatchObject({
+          shouldSkip: false,
+          shouldBypassMention: true,
+        });
+        expect(runtime.channel.inbound.dispatch).toHaveBeenCalledTimes(1);
+        expect(
+          vi.mocked(runtime.channel.inbound.dispatch).mock.calls[0]?.[0].ctxPayload
+            .CommandAuthorized,
+        ).toBe(true);
+        expect(runtime.llm.complete).not.toHaveBeenCalled();
+      });
+    },
+  );
+
+  it.each(["hello ! poll", "/status"])(
+    "does not let model mode bypass mentions for %s",
+    async (body) => {
+      const runtime = createRuntime();
+      setClickClackRuntime(runtime);
+      const params = {
+        account: createAgentAccount({
+          replyMode: "model",
+          allowFrom: ["usr_owner"],
+          requireMention: true,
+        }),
+        config: { commands: { text: true } } satisfies CoreConfig,
+        message: createMessage({ body }),
+      };
+      const access = await resolveClickClackInboundAccess(params);
+      await handleClickClackInbound({ ...params, access });
+
+      expect(access.channelIngress?.commandAccess).toMatchObject({
+        requested: true,
+        authorized: true,
+      });
+      expect(access.channelIngress?.activationAccess).toMatchObject({
+        shouldSkip: true,
+        shouldBypassMention: false,
+      });
+      expect(runtime.channel.inbound.dispatch).not.toHaveBeenCalled();
+      expect(runtime.llm.complete).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["hello ! poll", "/status"])("does not admit a denied sender for %s", async (body) => {
     const runtime = createRuntime();
     setClickClackRuntime(runtime);
+    const params = {
+      account: createAgentAccount({ allowFrom: ["usr_other"], requireMention: true }),
+      config: { commands: { text: true } } satisfies CoreConfig,
+      message: createMessage({ body }),
+    };
+    const access = await resolveClickClackInboundAccess(params);
+    await handleClickClackInbound({ ...params, access });
 
-    await handleClickClackInbound({
-      account: createAgentAccount({
-        requireMention: true,
-        botHandle: "blackbird",
-      }),
-      config: {} satisfies CoreConfig,
-      message: createMessage({ body: "hello everyone" }),
-    });
-
+    expect(access.channelIngress?.senderAccess.allowed).toBe(false);
+    expect(access.commandAuthorized).toBe(false);
     expect(runtime.channel.inbound.dispatch).not.toHaveBeenCalled();
-    expect(runtime.agent.runEmbeddedAgent).not.toHaveBeenCalled();
     expect(runtime.llm.complete).not.toHaveBeenCalled();
   });
 
-  it("dispatches a group message when its ClickClack bot handle is mentioned", async () => {
-    const runtime = createRuntime();
-    setClickClackRuntime(runtime);
+  it.each(["@blackbird please help", "@blackbird hello ! poll"])(
+    "dispatches mentioned group text: %s",
+    async (body) => {
+      const runtime = createRuntime();
+      setClickClackRuntime(runtime);
 
-    await handleClickClackInbound({
-      account: createAgentAccount({
-        requireMention: true,
-        botHandle: "blackbird",
-      }),
-      config: {} satisfies CoreConfig,
-      message: createMessage({ body: "@blackbird please help" }),
-    });
+      await handleClickClackInbound({
+        account: createAgentAccount({
+          requireMention: true,
+          botHandle: "blackbird",
+        }),
+        config: {} satisfies CoreConfig,
+        message: createMessage({ body }),
+      });
 
-    const dispatchTurn = vi.mocked(runtime.channel.inbound.dispatch);
-    expect(dispatchTurn).toHaveBeenCalledTimes(1);
-    expect(dispatchTurn.mock.calls[0]?.[0].ctxPayload.WasMentioned).toBe(true);
-  });
+      const dispatchTurn = vi.mocked(runtime.channel.inbound.dispatch);
+      expect(dispatchTurn).toHaveBeenCalledTimes(1);
+      expect(dispatchTurn.mock.calls[0]?.[0].ctxPayload.WasMentioned).toBe(true);
+    },
+  );
 
   it("does not bypass mention gating for a command mentioning another user", async () => {
     const runtime = createRuntime();
-    vi.mocked(runtime.channel.commands.shouldComputeCommandAuthorized).mockReturnValue(true);
-    vi.mocked(runtime.channel.commands.shouldHandleTextCommands).mockReturnValue(true);
-    vi.mocked(runtime.channel.text.hasControlCommand).mockReturnValue(true);
     setClickClackRuntime(runtime);
 
     await handleClickClackInbound({

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.allowlist-warn.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.allowlist-warn.test.ts
@@ -93,6 +93,29 @@ function makeParams(
 }
 
 describe("applyGroupGating allowlist drop warning", () => {
+  it.each(["! exit 0", "!poll", "! poll", "!stop", "! stop", "/bash exit 0"])(
+    "preserves owner command mention gating for %s",
+    async (body) => {
+      const msg = makeUnregisteredGroupMsg("registered@g.us");
+      msg.payload.body = body;
+      msg.platform.selfE164 = "+15550000001";
+      const params = makeParams(msg, vi.fn(), {
+        commands: { bash: true },
+        channels: {
+          whatsapp: {
+            allowFrom: ["+15550000002"],
+            groupAllowFrom: ["+15550000002"],
+            groupPolicy: "allowlist",
+            groups: { "registered@g.us": {} },
+          },
+        },
+      });
+      expect(await applyGroupGating(params)).toMatchObject({
+        shouldProcess: body.startsWith("/bash"),
+      });
+    },
+  );
+
   it.each([
     {
       name: "emits a warn log naming the root groups path for the default account",

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.commands.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.commands.test.ts
@@ -1,0 +1,281 @@
+import * as channelInbound from "openclaw/plugin-sdk/channel-inbound";
+import {
+  createTestRegistry,
+  setActivePluginRegistry,
+  resetPluginRuntimeStateForTest,
+} from "openclaw/plugin-sdk/channel-test-helpers";
+import { resolveCommandAuthorization } from "openclaw/plugin-sdk/command-auth-native";
+import { shouldComputeCommandAuthorized } from "openclaw/plugin-sdk/command-detection";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
+import { createOpenClawTestState, type OpenClawTestState } from "openclaw/plugin-sdk/test-state";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { whatsappPlugin } from "../../channel.js";
+import { checkInboundAccessControl } from "../../inbound/access-control.js";
+import { createTestWebInboundMessage } from "../../inbound/test-message.test-helper.js";
+import { buildMentionConfig } from "../mentions.js";
+import { applyGroupGating } from "./group-gating.js";
+import { processMessage } from "./process-message.js";
+
+describe("WhatsApp command authorization at ordinary DM and mentioned-group dispatch", () => {
+  const owner = "+15550001111";
+  const self = "+15550009999";
+  const member = "+15550002222";
+  const groupId = "synthetic-command-group@g.us";
+  let state: OpenClawTestState;
+  let cfg: OpenClawConfig;
+  const backgroundTasks = new Set<Promise<unknown>>();
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ prefix: "whatsapp-command-boundary-" });
+    cfg = {
+      agents: { defaults: { workspace: state.workspaceDir } },
+      channels: {
+        whatsapp: {
+          dmPolicy: "allowlist",
+          allowFrom: [owner],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [owner, member],
+          groups: { [groupId]: { requireMention: true } },
+        },
+      },
+      commands: { bash: true, ownerAllowFrom: [owner] },
+      tools: { elevated: { enabled: true, allowFrom: { whatsapp: [owner] } } },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "whatsapp", source: "test", plugin: whatsappPlugin }]),
+    );
+  });
+  afterEach(async () => {
+    await Promise.allSettled(backgroundTasks);
+    vi.restoreAllMocks();
+    resetPluginRuntimeStateForTest();
+    await state.cleanup();
+  });
+
+  async function dispatch(body: string, sender = owner, isGroup = false) {
+    const from = isGroup ? groupId : sender;
+    const sessionKey = isGroup
+      ? "agent:main:whatsapp:group:command-fixture"
+      : "agent:main:whatsapp:direct:command-fixture";
+    const sendPairing = vi.fn(async () => {
+      throw new Error("unexpected pairing send");
+    });
+    const access = await checkInboundAccessControl({
+      cfg,
+      accountId: "default",
+      from,
+      selfE164: self,
+      senderE164: sender,
+      group: isGroup,
+      isFromMe: false,
+      remoteJid: isGroup ? groupId : "15550001111@s.whatsapp.net",
+      sock: { sendMessage: sendPairing },
+    });
+    expect(sendPairing).not.toHaveBeenCalled();
+    if (!access.allowed) {
+      return { admitted: false };
+    }
+    const msg = createTestWebInboundMessage({
+      payload: { body },
+      platform: { chatJid: from, recipientJid: self, senderE164: sender, selfE164: self },
+      ...(isGroup
+        ? {
+            group: {
+              mentions: {
+                jids: body.startsWith("@15550009999") ? ["15550009999@s.whatsapp.net"] : [],
+              },
+            },
+          }
+        : {}),
+    });
+    msg.admission = access.admission;
+    const logger = getChildLogger({ module: "whatsapp-command-boundary-test" });
+    const groupHistories = new Map();
+    const groupMemberNames = new Map();
+    if (isGroup) {
+      expect(msg.groupMention).toBeUndefined();
+      const gate = await applyGroupGating({
+        cfg,
+        msg,
+        agentId: "main",
+        sessionKey,
+        groupHistoryKey: groupId,
+        baseMentionConfig: buildMentionConfig(cfg, "main"),
+        groupHistories,
+        groupHistoryLimit: 20,
+        groupMemberNames,
+        logVerbose: vi.fn(),
+        replyLogger: logger,
+      });
+      expect(msg.payload.commandBody ?? msg.payload.body).toBe(body);
+      if (!gate.shouldProcess) {
+        return { gated: true, groupMention: msg.groupMention };
+      }
+      expect(msg.groupMention).toEqual({ wasMentioned: true, requireMention: true });
+    }
+    const buildContext = vi.spyOn(channelInbound, "buildChannelInboundEventContext");
+    const decisions: Array<{ finalized: boolean; authorized: boolean; owner: boolean }> = [];
+    await processMessage({
+      cfg,
+      msg,
+      route: {
+        agentId: "main",
+        accountId: "default",
+        channel: "whatsapp",
+        sessionKey,
+        mainSessionKey: "agent:main:main",
+        lastRoutePolicy: "main",
+        matchedBy: "default",
+      },
+      groupHistoryKey: "command-fixture",
+      groupHistories,
+      groupMemberNames,
+      connectionId: "command-fixture",
+      verbose: false,
+      maxMediaBytes: 1024,
+      backgroundTasks,
+      replyLogger: logger,
+      buildContext: channelInbound.buildChannelInboundEventContext,
+      replyResolver: async () => {
+        throw new Error("unexpected model resolver");
+      },
+      // Stop at dispatch: transport and model execution are outside this producer regression.
+      dispatchReplyFromConfig: async ({ ctx }) => {
+        const auth = resolveCommandAuthorization({
+          ctx,
+          cfg,
+          commandAuthorized: ctx.CommandAuthorized,
+        });
+        decisions.push({
+          finalized: ctx.CommandAuthorized,
+          authorized: auth.isAuthorizedSender,
+          owner: auth.senderIsOwner,
+        });
+        return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
+      },
+    });
+    expect(sendPairing).not.toHaveBeenCalled();
+    expect(buildContext).toHaveBeenCalledOnce();
+    expect(decisions).toHaveLength(1);
+    return {
+      prepared: buildContext.mock.calls[0]?.[0].access?.commands?.authorized,
+      ...decisions[0],
+    };
+  }
+
+  it.each([
+    "! exit 0",
+    "!poll",
+    "! poll",
+    "!stop",
+    "! stop",
+    "/bash exit 0",
+    "/bash poll",
+    "/bash stop",
+    "!",
+    "!: exit 0",
+    "! (exit 0)",
+    "! 'printf' ok",
+    "! ./fixture",
+    "! /bin/true",
+    "! # comment",
+    "! 2>/dev/null",
+  ])("carries real owner authorization to dispatch for %s", async (body) => {
+    expect(await dispatch(body)).toEqual({
+      prepared: true,
+      finalized: true,
+      authorized: true,
+      owner: true,
+    });
+  });
+  it("leaves ordinary text unchecked and default-denied for commands", async () => {
+    expect(shouldComputeCommandAuthorized("ordinary text", cfg)).toBe(false);
+    expect(await dispatch("ordinary text")).toEqual({
+      prepared: undefined,
+      finalized: false,
+      authorized: false,
+      owner: true,
+    });
+  });
+  it.each([true, false])("preserves explicit command allowlist match=%s", async (match) => {
+    cfg.commands!.allowFrom = { whatsapp: match ? [owner] : [] };
+    expect(await dispatch("! poll")).toMatchObject({ authorized: match, owner: true });
+  });
+  it("does not grant command authority to a DM admitted by open policy", async () => {
+    cfg.channels!.whatsapp!.dmPolicy = "open";
+    cfg.channels!.whatsapp!.allowFrom = ["*"];
+    expect(await dispatch("! poll", "+15550002222")).toMatchObject({
+      prepared: true,
+      finalized: true,
+      authorized: false,
+      owner: false,
+    });
+  });
+  it("preserves explicit owner precedence over channel authorization", async () => {
+    cfg.commands!.ownerAllowFrom = ["+15550002222"];
+    expect(await dispatch("! poll")).toMatchObject({
+      prepared: true,
+      finalized: true,
+      authorized: false,
+      owner: false,
+    });
+  });
+  it("keeps text command authorization on the non-native WhatsApp surface", async () => {
+    cfg.commands!.text = false;
+    expect(await dispatch("! poll")).toMatchObject({ authorized: true });
+  });
+  it.each([
+    "! exit 0",
+    "! poll",
+    "! stop",
+    "!exit 0",
+    "!poll",
+    "!stop",
+    "/bash exit 0",
+    "/bash poll",
+    "/bash stop",
+    "!",
+    "! (exit 0)",
+    "! 'printf' ok",
+    "! 2>/dev/null",
+  ])("carries mentioned-group owner authorization for %s", async (command) => {
+    expect(await dispatch(`@15550009999 ${command}`, owner, true)).toEqual({
+      prepared: true,
+      finalized: true,
+      authorized: true,
+      owner: true,
+    });
+  });
+  it.each(["! exit 0", "!poll", "! poll", "!stop", "! stop"])(
+    "keeps unmentioned group input gated for %s",
+    async (body) => {
+      expect(await dispatch(body, owner, true)).toEqual({
+        gated: true,
+        groupMention: { wasMentioned: false, requireMention: true },
+      });
+    },
+  );
+  it("keeps a mentioned admitted group member outside explicit owner authority", async () => {
+    expect(await dispatch("@15550009999 ! poll", member, true)).toEqual({
+      prepared: true,
+      finalized: true,
+      authorized: false,
+      owner: false,
+    });
+  });
+  it("keeps unallowlisted mentioned group senders outside admission", async () => {
+    expect(await dispatch("@15550009999 ! poll", "+15550003333", true)).toEqual({
+      admitted: false,
+    });
+  });
+  it.each([true, false])(
+    "keeps mentioned-group command allowlist match=%s authoritative",
+    async (match) => {
+      cfg.commands!.allowFrom = { whatsapp: match ? [owner] : [] };
+      expect(await dispatch("@15550009999 ! poll", owner, true)).toMatchObject({
+        authorized: match,
+        owner: true,
+      });
+    },
+  );
+});

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -195,27 +195,7 @@ describe("resolveCommandAuthorization", () => {
   });
 
   it("rejects wildcard channel senders when the plugin enforces owner-only commands", () => {
-    setActivePluginRegistry(
-      createTestRegistry([
-        {
-          pluginId: "discord",
-          plugin: {
-            ...createOutboundTestPlugin({
-              id: "discord",
-              outbound: { deliveryMode: "direct" },
-            }),
-            commands: { enforceOwnerForCommands: true },
-            config: {
-              listAccountIds: () => ["default"],
-              resolveAccount: () => ({}),
-              resolveAllowFrom: () => ["*"],
-              formatAllowFrom,
-            },
-          },
-          source: "test",
-        },
-      ]),
-    );
+    registerAllowFromPlugins(createOwnerEnforcingAllowFromPlugin("discord", () => ["*"]));
     const cfg = {
       channels: { discord: { allowFrom: ["*"] } },
     } as OpenClawConfig;
@@ -237,27 +217,7 @@ describe("resolveCommandAuthorization", () => {
   });
 
   it("rejects channel-validated native commands when plugin owner enforcement has no owner allowlist", () => {
-    setActivePluginRegistry(
-      createTestRegistry([
-        {
-          pluginId: "discord",
-          plugin: {
-            ...createOutboundTestPlugin({
-              id: "discord",
-              outbound: { deliveryMode: "direct" },
-            }),
-            commands: { enforceOwnerForCommands: true },
-            config: {
-              listAccountIds: () => ["default"],
-              resolveAccount: () => ({}),
-              resolveAllowFrom: () => ["*"],
-              formatAllowFrom,
-            },
-          },
-          source: "test",
-        },
-      ]),
-    );
+    registerAllowFromPlugins(createOwnerEnforcingAllowFromPlugin("discord", () => ["*"]));
     const cfg = {
       channels: { discord: { allowFrom: ["*"] } },
     } as OpenClawConfig;
@@ -1026,6 +986,38 @@ describe("control command parsing", () => {
     expect(hasInlineCommandTokens("http://example.com/path")).toBe(false);
     expect(hasInlineCommandTokens("stop")).toBe(false);
   });
+
+  it.each([
+    "! exit 0",
+    "!poll",
+    "! poll",
+    "!stop",
+    "! stop",
+    "!",
+    "!: exit 0",
+    "! (exit 0)",
+    "! 'printf' ok",
+    "! ./fixture",
+    "! /bin/true",
+    "! # comment",
+    "! 2>/dev/null",
+    "\n  ! poll",
+    "@bot ! exit 0",
+    "@bot ! poll",
+    "@bot ! stop",
+    "@bot !",
+    "@bot ! (exit 0)",
+    "@bot\t! 'printf' ok",
+    "hello ! poll",
+  ])("requests authorization without granting control-command mention bypass for %s", (body) => {
+    expect(shouldComputeCommandAuthorized(body)).toBe(true);
+    expect(hasControlCommand(body)).toBe(false);
+  });
+
+  it.each([undefined, "", "plain text", "hello! poll", "option A / B", "http://example.com/path"])(
+    "leaves non-command text outside authorization computation: %s",
+    (body) => expect(shouldComputeCommandAuthorized(body)).toBe(false),
+  );
 
   it("detects spaced syntax only for active registered plugin commands", () => {
     expect(shouldComputeCommandAuthorized("/ pair qr")).toBe(false);

--- a/src/auto-reply/command-detection.ts
+++ b/src/auto-reply/command-detection.ts
@@ -89,18 +89,14 @@ export function isSessionBoundaryCommandText(
 }
 
 /**
- * Coarse detection for inline directives/shortcuts (e.g. "hey /status") so channel monitors
- * can decide whether to compute CommandAuthorized for a message.
+ * Coarse detection for inline directives/shortcuts and bash input, including after mentions.
+ * Bang arguments may start with whitespace or shell punctuation, not only letters.
  *
  * This intentionally errs on the side of false positives; CommandAuthorized only gates
  * command/directive execution, not normal chat replies.
  */
 export function hasInlineCommandTokens(text?: string): boolean {
-  const body = text ?? "";
-  if (!body.trim()) {
-    return false;
-  }
-  return /(?:^|\s)[/!][a-z]/i.test(body);
+  return /(?:^|\s)(?:\/[a-z]|!)/i.test(text ?? "");
 }
 
 function hasSpacedPluginCommand(text?: string): boolean {

--- a/src/auto-reply/reply/bash-command.stop.test.ts
+++ b/src/auto-reply/reply/bash-command.stop.test.ts
@@ -1,5 +1,8 @@
-// Tests bash stop command handling and active-process cancellation.
+// Tests chat bash outcome projection and active-process cancellation.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { appendExecTimeoutRetryGuidance } from "../../agents/bash-tools.exec-output.js";
+import { buildExecForegroundResult } from "../../agents/bash-tools.exec-support.js";
+import type { ExecToolDetails } from "../../agents/bash-tools.exec-types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { MsgContext } from "../templating.js";
 
@@ -92,7 +95,7 @@ function backgroundExecResult(sessionId: string) {
   };
 }
 
-describe("handleBashChatCommand stop", () => {
+describe("handleBashChatCommand", () => {
   beforeEach(() => {
     getSessionMock.mockReset();
     getFinishedSessionMock.mockReset();
@@ -101,17 +104,246 @@ describe("handleBashChatCommand stop", () => {
     createExecToolMock.mockReset();
   });
 
-  it("returns immediately after canonical cancellation is admitted", async () => {
-    const session = buildRunningSession();
-    getSessionMock.mockReturnValue(session);
-    getFinishedSessionMock.mockReturnValue(undefined);
+  describe.each(["/bash", "!"])("%s outcomes", (alias) => {
+    it.each<
+      [
+        string,
+        "completed" | "failed",
+        number | null,
+        NodeJS.Signals | number | null,
+        string,
+        string,
+      ]
+    >([
+      ["completed zero", "completed", 0, null, "⚙️", "code 0"],
+      ["completed nonzero", "completed", 1, null, "⚙️", "code 1"],
+      ["shell not executable", "failed", 126, null, "⚠️", "code 126"],
+      ["shell not found", "failed", 127, null, "⚠️", "code 127"],
+      ["failed zero", "failed", 0, null, "⚠️", "code 0"],
+      ["failed unknown", "failed", null, null, "⚠️", "unknown exit code"],
+      ["completed unknown", "completed", null, null, "⚙️", "unknown exit code"],
+      ["signal", "failed", null, "SIGTERM", "⚠️", "signal SIGTERM"],
+      ["numeric signal", "failed", 0, 9, "⚠️", "signal 9"],
+    ])(
+      "preserves %s in foreground and explicit poll",
+      async (_, status, exitCode, exitSignal, prefix, exitLabel) => {
+        const details = {
+          status,
+          exitCode,
+          exitSignal,
+          durationMs: 1,
+          aggregated: "retained output",
+        } satisfies ExecToolDetails;
+        const execute = vi.fn().mockResolvedValue({
+          content: [{ type: "text", text: "producer guidance\nretained output" }],
+          details,
+        });
+        createExecToolMock.mockReturnValue({ execute });
+
+        const foreground = await handleBashChatCommand(buildParams(`${alias} command`));
+        getFinishedSessionMock.mockReturnValue({
+          ...details,
+          id: "finished-job",
+          scopeKey: "chat:bash",
+          terminalStatus: status,
+          tail: "tail",
+        });
+        const polled = await handleBashChatCommand(buildParams(`${alias} poll finished-job`));
+        const next = await handleBashChatCommand(buildParams(`${alias} next`));
+
+        for (const reply of [foreground, polled, next]) {
+          expect.soft(reply.text).toMatch(new RegExp(`^${prefix}`));
+          expect.soft(reply.text).toContain(`\nExit: ${exitLabel}\n`);
+          expect.soft(reply.text).toContain("retained output");
+        }
+        expect(foreground.text).toContain("producer guidance");
+        expect(polled.text).toContain("bash finished (session finished-job)");
+        expect(next.text).toContain("bash: next");
+        expect(execute).toHaveBeenCalledTimes(2);
+      },
+    );
+
+    it("preserves completed producer warnings and retention disclosures", async () => {
+      const result = buildExecForegroundResult({
+        outcome: {
+          status: "completed",
+          exitCode: 0,
+          exitSignal: null,
+          durationMs: 1,
+          aggregated: "retained output",
+          timedOut: false,
+        },
+        warningText: "Warning: continuation options are unavailable; running synchronously.",
+        aggregateOutputDropped: true,
+      });
+      createExecToolMock.mockReturnValue({ execute: vi.fn().mockResolvedValue(result) });
+
+      const reply = await handleBashChatCommand(buildParams(`${alias} command`));
+
+      expect(reply.text).toContain(
+        "[earlier output was discarded at the retention cap and cannot be recovered]",
+      );
+      expect(reply.text).toContain(
+        "Warning: continuation options are unavailable; running synchronously.",
+      );
+      expect(reply.text).toContain("retained output");
+    });
+
+    it("preserves producer failure guidance without reducing it to aggregate output", async () => {
+      const result = buildExecForegroundResult({
+        outcome: {
+          status: "failed",
+          exitCode: null,
+          exitSignal: "SIGKILL",
+          exitReason: "signal",
+          failureKind: "signal",
+          oomScoreWrapperSelected: true,
+          durationMs: 1,
+          aggregated: "partial output",
+          timedOut: false,
+          reason: "partial output\n\nCommand aborted by signal SIGKILL",
+        },
+      });
+      createExecToolMock.mockReturnValue({ execute: vi.fn().mockResolvedValue(result) });
+
+      const reply = await handleBashChatCommand(buildParams(`${alias} command`));
+
+      expect(reply.text).toMatch(/^⚠️/);
+      expect(reply.text).toContain("Exit: signal SIGKILL");
+      expect(reply.text).toContain("Command aborted by signal SIGKILL");
+      expect(reply.text).toContain("SIGKILL alone does not identify");
+      expect(reply.text).toContain("Check cgroup memory events or kernel logs.");
+    });
+
+    it.each(["overall-timeout", "no-output-timeout"] as const)(
+      "keeps %s retry guidance in foreground and explicit polling",
+      async (exitReason) => {
+        const result = buildExecForegroundResult({
+          outcome: {
+            status: "failed",
+            exitCode: null,
+            exitSignal: "SIGTERM",
+            exitReason,
+            failureKind: exitReason,
+            durationMs: 1,
+            aggregated: "partial output",
+            timedOut: true,
+            reason: appendExecTimeoutRetryGuidance(
+              "partial output\n\nCommand timed out.",
+              exitReason,
+            ),
+          },
+        });
+        createExecToolMock.mockReturnValue({ execute: vi.fn().mockResolvedValue(result) });
+        const foreground = await handleBashChatCommand(buildParams(`${alias} command`));
+        getFinishedSessionMock.mockReturnValue({
+          id: "timed-out",
+          scopeKey: "chat:bash",
+          terminalStatus: "failed",
+          exitCode: null,
+          exitSignal: "SIGTERM",
+          exitReason,
+          aggregated: "partial output",
+          tail: "output",
+        });
+
+        const polled = await handleBashChatCommand(buildParams(`${alias} poll timed-out`));
+
+        for (const reply of [foreground, polled]) {
+          expect.soft(reply.text).toMatch(/^⚠️/);
+          expect.soft(reply.text).toContain("Exit: signal SIGTERM");
+          expect.soft(reply.text).toContain("partial output");
+          expect.soft(reply.text).toContain("Verify the resulting state before retrying.");
+          expect.soft(reply.text).toContain("Do not automatically rerun non-idempotent commands.");
+        }
+      },
+    );
+
+    it.each([
+      {
+        status: "approval-pending",
+        approvalId: "approval-1",
+        approvalSlug: "approval",
+        expiresAtMs: 1000,
+        host: "gateway",
+        command: "command",
+      },
+      {
+        status: "approval-unavailable",
+        reason: "no-approval-route",
+        host: "gateway",
+        command: "command",
+      },
+    ] satisfies ExecToolDetails[])(
+      "does not label $status as terminal or block the next command",
+      async (details) => {
+        const execute = vi.fn().mockResolvedValue({
+          content: [{ type: "text", text: "Approval guidance from exec" }],
+          details,
+        });
+        createExecToolMock.mockReturnValue({ execute });
+
+        const first = await handleBashChatCommand(buildParams(`${alias} command`));
+        const next = await handleBashChatCommand(buildParams(`${alias} next`));
+
+        expect(first.text).toBe("Approval guidance from exec");
+        expect(next.text).toBe("Approval guidance from exec");
+        expect(execute).toHaveBeenCalledTimes(2);
+      },
+    );
+
+    it("keeps running responses nonterminal and rejects a concurrent command", async () => {
+      const execute = vi.fn().mockResolvedValue(backgroundExecResult("session-1"));
+      createExecToolMock.mockReturnValue({ execute });
+      const running = await handleBashChatCommand(buildParams(`${alias} command`));
+      getSessionMock.mockReturnValue(buildRunningSession());
+      const concurrent = await handleBashChatCommand(buildParams(`${alias} next`));
+
+      expect(running.text).toContain("Still running; use !poll / !stop");
+      expect(running.text).not.toContain("Exit:");
+      expect(concurrent.text).toContain("A bash job is already running");
+      expect(execute).toHaveBeenCalledTimes(1);
+      getSessionMock.mockReturnValue(undefined);
+      await handleBashChatCommand(buildParams(`${alias} help`));
+    });
+
+    it("accepts another command after a thrown exec error", async () => {
+      const execute = vi.fn().mockRejectedValue(new Error("exec denied"));
+      createExecToolMock.mockReturnValue({ execute });
+
+      const failed = await handleBashChatCommand(buildParams(`${alias} command`));
+      const next = await handleBashChatCommand(buildParams(`${alias} next`));
+
+      expect(failed.text).toContain("⚠️ bash failed: command");
+      expect(failed.text).not.toContain("Exit:");
+      expect(next.text).toContain("⚠️ bash failed: next");
+      expect(execute).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it.each(["/bash", "!"])(
+    "%s returns immediately after canonical cancellation is admitted",
+    async (alias) => {
+      const session = buildRunningSession();
+      getSessionMock.mockReturnValue(session);
+      getFinishedSessionMock.mockReturnValue(undefined);
+
+      const result = await handleBashChatCommand(buildParams(`${alias} stop session-1`));
+
+      expect(result.text).toContain("bash stopping");
+      expect(result.text).toContain("!poll session-1");
+      expect(cancelBackgroundExecSessionMock).toHaveBeenCalledWith("session-1");
+      expect(session.exited).toBe(false);
+    },
+  );
+
+  it("does not cancel a foreground session through chat stop", async () => {
+    getSessionMock.mockReturnValue(buildRunningSession({ backgrounded: false }));
 
     const result = await handleBashChatCommand(buildParams("/bash stop session-1"));
 
-    expect(result.text).toContain("bash stopping");
-    expect(result.text).toContain("!poll session-1");
-    expect(cancelBackgroundExecSessionMock).toHaveBeenCalledWith("session-1");
-    expect(session.exited).toBe(false);
+    expect(result.text).toContain("is not backgrounded");
+    expect(cancelBackgroundExecSessionMock).not.toHaveBeenCalled();
   });
 
   it("includes the full session ID so the user can poll after starting a new job", async () => {

--- a/src/auto-reply/reply/bash-command.ts
+++ b/src/auto-reply/reply/bash-command.ts
@@ -7,6 +7,10 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { cancelBackgroundExecSession } from "../../agents/bash-process-control.js";
 import { getFinishedSession, getSession } from "../../agents/bash-process-registry.js";
+import {
+  appendExecTimeoutRetryGuidance,
+  renderExecExitLabel,
+} from "../../agents/bash-tools.exec-output.js";
 import { createExecTool } from "../../agents/bash-tools.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import { isCommandFlagEnabled } from "../../config/commands.flags.js";
@@ -247,16 +251,16 @@ export async function handleBashChatCommand(params: {
       if (activeJob?.state === "running" && activeJob.sessionId === sessionId) {
         activeJob = null;
       }
-      const exitLabel = finished.exitSignal
-        ? `signal ${String(finished.exitSignal)}`
-        : `code ${String(finished.exitCode ?? 0)}`;
       const prefix = finished.terminalStatus === "completed" ? "⚙️" : "⚠️";
       return {
-        text: [
-          `${prefix} bash finished (session ${formatSessionSnippet(sessionId)}).`,
-          `Exit: ${exitLabel}`,
-          formatOutputBlock(finished.aggregated || finished.tail),
-        ].join("\n"),
+        text: appendExecTimeoutRetryGuidance(
+          [
+            `${prefix} bash finished (session ${formatSessionSnippet(sessionId)}).`,
+            `Exit: ${renderExecExitLabel(finished)}`,
+            formatOutputBlock(finished.aggregated || finished.tail),
+          ].join("\n"),
+          finished.exitReason,
+        ),
       };
     }
     if (activeJob?.state === "running" && activeJob.sessionId === sessionId) {
@@ -307,11 +311,7 @@ export async function handleBashChatCommand(params: {
     };
   }
 
-  const commandText = request.command.trim();
-  if (!commandText) {
-    return buildUsageReply();
-  }
-
+  const commandText = request.command;
   activeJob = {
     state: "starting",
     startedAt: Date.now(),
@@ -339,7 +339,7 @@ export async function handleBashChatCommand(params: {
         defaultLevel: "on",
       },
     });
-    const result = await execTool.execute("chat-bash", {
+    const { content, details } = await execTool.execute("chat-bash", {
       command: commandText,
       background: shouldBackgroundImmediately,
       yieldMs: shouldBackgroundImmediately ? undefined : foregroundMs,
@@ -347,12 +347,12 @@ export async function handleBashChatCommand(params: {
       elevated: true,
     });
 
-    if (result.details?.status === "running") {
-      const sessionId = result.details.sessionId;
+    if (details.status === "running") {
+      const sessionId = details.sessionId;
       activeJob = {
         state: "running",
         sessionId,
-        startedAt: result.details.startedAt,
+        startedAt: details.startedAt,
         command: commandText,
       };
       const snippet = formatSessionSnippet(sessionId);
@@ -362,18 +362,17 @@ export async function handleBashChatCommand(params: {
       };
     }
 
-    // Completed in foreground.
     activeJob = null;
-    const exitCode = result.details?.status === "completed" ? result.details.exitCode : 0;
-    const output =
-      result.details?.status === "completed"
-        ? result.details.aggregated
-        : result.content.map((chunk) => (chunk.type === "text" ? chunk.text : "")).join("\n");
+    // Exec owns warnings and failure guidance; approval replies have no terminal exit.
+    const output = content.map((chunk) => (chunk.type === "text" ? chunk.text : "")).join("\n");
+    if (details.status !== "completed" && details.status !== "failed") {
+      return { text: output };
+    }
     return {
       text: [
-        `⚙️ bash: ${commandText}`,
-        `Exit: ${exitCode}`,
-        formatOutputBlock(output || "(no output)"),
+        `${details.status === "failed" ? "⚠️" : "⚙️"} bash: ${commandText}`,
+        `Exit: ${renderExecExitLabel(details)}`,
+        formatOutputBlock(output),
       ].join("\n"),
     };
   } catch (err) {

--- a/src/auto-reply/reply/context-text.ts
+++ b/src/auto-reply/reply/context-text.ts
@@ -1,13 +1,11 @@
 // Formats finalized message context into prompt-visible text.
-import type { FinalizedRuntimeMsgContext } from "../templating.js";
-
 /** Resolves normalized text for slash/bang command parsing. */
-export function resolveCommandContextText(ctx: FinalizedRuntimeMsgContext): string {
+export function resolveCommandContextText(ctx: { commandText: string }): string {
   return ctx.commandText.trim();
 }
 
 /** Checks whether the inbound context carries an explicit command prefix. */
-export function hasExplicitCommandContextText(ctx: FinalizedRuntimeMsgContext): boolean {
+export function hasExplicitCommandContextText(ctx: { commandText: string }): boolean {
   const text = resolveCommandContextText(ctx);
   return text.startsWith("/") || text.startsWith("!");
 }

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -12,7 +12,10 @@ import {
   setActivePluginRegistry,
 } from "../../plugins/runtime.js";
 import type { SkillCommandSpec } from "../../skills/types.js";
-import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 import type { TemplateContext } from "../templating.js";
 import { markCommandSessionMetadataChanged } from "./command-session-metadata.js";
@@ -28,7 +31,6 @@ const {
   execExecuteMock,
   getChannelPluginMock,
   handleCommandsMock,
-  listChannelPluginsMock,
   listSkillCommandsForWorkspaceMock,
 } = vi.hoisted(() => ({
   buildStatusReplyMock: vi.fn(),
@@ -36,7 +38,6 @@ const {
   execExecuteMock: vi.fn(),
   getChannelPluginMock: vi.fn(),
   handleCommandsMock: vi.fn(),
-  listChannelPluginsMock: vi.fn(),
   listSkillCommandsForWorkspaceMock: vi.fn(),
 }));
 
@@ -68,10 +69,10 @@ vi.mock("../../skills/discovery/chat-commands.runtime.js", () => ({
   listSkillCommandsForWorkspace: (...args: unknown[]) => listSkillCommandsForWorkspaceMock(...args),
 }));
 
-vi.mock("../../channels/plugins/index.js", () => ({
+vi.mock("../../channels/plugins/index.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../channels/plugins/index.js")>()),
   getChannelPlugin: (...args: unknown[]) => getChannelPluginMock(...args),
   getLoadedChannelPlugin: (...args: unknown[]) => getChannelPluginMock(...args),
-  listChannelPlugins: listChannelPluginsMock,
   normalizeChannelId: (value?: string) => value?.trim().toLowerCase() || null,
 }));
 
@@ -275,8 +276,6 @@ describe("handleInlineActions", () => {
   beforeEach(() => {
     handleCommandsMock.mockReset();
     handleCommandsMock.mockResolvedValue({ shouldContinue: true, reply: undefined });
-    listChannelPluginsMock.mockReset();
-    listChannelPluginsMock.mockReturnValue([]);
     listSkillCommandsForWorkspaceMock.mockReset();
     listSkillCommandsForWorkspaceMock.mockReturnValue([]);
     getChannelPluginMock.mockReset();
@@ -298,10 +297,18 @@ describe("handleInlineActions", () => {
 
     beforeEach(async () => {
       registrySnapshot = captureActivePluginRegistrySnapshot();
-      setActivePluginRegistry(createTestRegistry([]));
-      listChannelPluginsMock.mockReturnValue([
-        { id: "discord", capabilities: { nativeCommands: true } },
-      ]);
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "discord",
+            source: "test",
+            plugin: createChannelTestPluginBase({
+              id: "discord",
+              capabilities: { chatTypes: ["direct"], nativeCommands: true },
+            }),
+          },
+        ]),
+      );
       const { handleCommands } = await import("./commands-core.js");
       handleCommandsMock.mockImplementation(handleCommands);
       execExecuteMock.mockReset();

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -3,10 +3,16 @@ import os from "node:os";
 import path from "node:path";
 // Tests inline action skipping when channel config does not define actions.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
 import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
+import {
+  captureActivePluginRegistrySnapshot,
+  restoreActivePluginRegistrySnapshot,
+  setActivePluginRegistry,
+} from "../../plugins/runtime.js";
 import type { SkillCommandSpec } from "../../skills/types.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 import type { TemplateContext } from "../templating.js";
 import { markCommandSessionMetadataChanged } from "./command-session-metadata.js";
@@ -19,14 +25,18 @@ import type { TypingController } from "./typing.js";
 const {
   buildStatusReplyMock,
   createOpenClawToolsMock,
+  execExecuteMock,
   getChannelPluginMock,
   handleCommandsMock,
+  listChannelPluginsMock,
   listSkillCommandsForWorkspaceMock,
 } = vi.hoisted(() => ({
   buildStatusReplyMock: vi.fn(),
   createOpenClawToolsMock: vi.fn(),
+  execExecuteMock: vi.fn(),
   getChannelPluginMock: vi.fn(),
   handleCommandsMock: vi.fn(),
+  listChannelPluginsMock: vi.fn(),
   listSkillCommandsForWorkspaceMock: vi.fn(),
 }));
 
@@ -45,6 +55,15 @@ vi.mock("./commands.runtime.js", () => ({
   buildStatusReply: (...args: unknown[]) => buildStatusReplyMock(...args),
 }));
 
+vi.mock("./commands-handlers.runtime.js", async () => {
+  const { handleBashCommand } = await import("./commands-bash.js");
+  return { loadCommandHandlers: () => [handleBashCommand] };
+});
+
+vi.mock("../../agents/bash-tools.js", () => ({
+  createExecTool: () => ({ execute: execExecuteMock }),
+}));
+
 vi.mock("../../skills/discovery/chat-commands.runtime.js", () => ({
   listSkillCommandsForWorkspace: (...args: unknown[]) => listSkillCommandsForWorkspaceMock(...args),
 }));
@@ -52,7 +71,7 @@ vi.mock("../../skills/discovery/chat-commands.runtime.js", () => ({
 vi.mock("../../channels/plugins/index.js", () => ({
   getChannelPlugin: (...args: unknown[]) => getChannelPluginMock(...args),
   getLoadedChannelPlugin: (...args: unknown[]) => getChannelPluginMock(...args),
-  listChannelPlugins: () => [],
+  listChannelPlugins: listChannelPluginsMock,
   normalizeChannelId: (value?: string) => value?.trim().toLowerCase() || null,
 }));
 
@@ -256,6 +275,8 @@ describe("handleInlineActions", () => {
   beforeEach(() => {
     handleCommandsMock.mockReset();
     handleCommandsMock.mockResolvedValue({ shouldContinue: true, reply: undefined });
+    listChannelPluginsMock.mockReset();
+    listChannelPluginsMock.mockReturnValue([]);
     listSkillCommandsForWorkspaceMock.mockReset();
     listSkillCommandsForWorkspaceMock.mockReturnValue([]);
     getChannelPluginMock.mockReset();
@@ -269,6 +290,139 @@ describe("handleInlineActions", () => {
         : channelId === "discord"
           ? { mentions: { stripPatterns: () => ["<@!?\\d+>"] } }
           : undefined,
+    );
+  });
+
+  describe("chat bash admission", () => {
+    let registrySnapshot: ReturnType<typeof captureActivePluginRegistrySnapshot>;
+
+    beforeEach(async () => {
+      registrySnapshot = captureActivePluginRegistrySnapshot();
+      setActivePluginRegistry(createTestRegistry([]));
+      listChannelPluginsMock.mockReturnValue([
+        { id: "discord", capabilities: { nativeCommands: true } },
+      ]);
+      const { handleCommands } = await import("./commands-core.js");
+      handleCommandsMock.mockImplementation(handleCommands);
+      execExecuteMock.mockReset();
+      execExecuteMock.mockResolvedValue({
+        content: [{ type: "text", text: "producer failure guidance" }],
+        details: { status: "failed", exitCode: 127 },
+      });
+    });
+
+    afterEach(() => restoreActivePluginRegistrySnapshot(registrySnapshot));
+
+    function bashInput(body: string) {
+      return createHandleInlineActionsInput({
+        ctx: buildTestCtx({ Body: body, CommandBody: body, CommandAuthorized: true }),
+        typing: createTypingController(),
+        cleanedBody: body,
+        command: { isAuthorizedSender: true },
+        overrides: {
+          allowTextCommands: true,
+          cfg: { commands: { bash: true } },
+          elevatedEnabled: true,
+          elevatedAllowed: true,
+        },
+      });
+    }
+
+    it.each(["! exit 127", "/bash exit 127"])(
+      "returns the command outcome before a model turn for %s",
+      async (body) => {
+        const result = await handleInlineActions(bashInput(body));
+        expect(result).toMatchObject({
+          kind: "reply",
+          reply: {
+            text: "⚠️ bash: exit 127\nExit: code 127\n```txt\nproducer failure guidance\n```",
+          },
+        });
+        expect(execExecuteMock).toHaveBeenCalledExactlyOnceWith(
+          "chat-bash",
+          expect.objectContaining({ command: "exit 127" }),
+        );
+        if (result.kind !== "reply" || !result.reply || Array.isArray(result.reply)) {
+          throw new Error("expected one command reply");
+        }
+        expect(getReplyPayloadMetadata(result.reply)).toMatchObject({ commandReply: true });
+      },
+    );
+
+    it.each(["!poll", "! poll", "!stop", "! stop", "/bash poll", "/bash stop"])(
+      "dispatches %s without starting a shell",
+      async (body) => {
+        expect(await handleInlineActions(bashInput(body))).toMatchObject({
+          kind: "reply",
+          reply: { text: "⚙️ No active bash job." },
+        });
+        expect(execExecuteMock).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each(["! exit 127", "/bash exit 127"])("preserves gates for %s", async (body) => {
+      const disabled = bashInput(body);
+      disabled.cfg.commands = { bash: false };
+      expect(await handleInlineActions(disabled)).toMatchObject({
+        kind: "reply",
+        reply: { text: expect.stringContaining("bash is disabled") },
+      });
+      for (const gate of ["elevatedEnabled", "elevatedAllowed"] as const) {
+        const denied = bashInput(body);
+        denied[gate] = false;
+        expect(await handleInlineActions(denied)).toMatchObject({
+          kind: "reply",
+          reply: { text: expect.stringContaining("elevated is not available") },
+        });
+      }
+      const unauthorized = bashInput(body);
+      unauthorized.command.isAuthorizedSender = false;
+      unauthorized.ctx.CommandAuthorized = false;
+      expect(await handleInlineActions(unauthorized)).toMatchObject(
+        body.startsWith("!") ? { kind: "continue" } : { kind: "reply", reply: undefined },
+      );
+      const textDisabled = bashInput(body);
+      textDisabled.cfg.commands = { bash: true, text: false };
+      textDisabled.command.surface = "discord";
+      expect(await handleInlineActions(textDisabled)).toMatchObject({ kind: "continue" });
+      const literal = bashInput(body);
+      literal.ctx.CommandInterpretationSuppressed = true;
+      expect(await handleInlineActions(literal)).toMatchObject({ kind: "continue" });
+      expect(execExecuteMock).not.toHaveBeenCalled();
+    });
+
+    it.each(["!poll", "/bash poll"])(
+      "keeps text commands enabled on non-native surfaces with commands.text=false: %s",
+      async (body) => {
+        const input = bashInput(body);
+        input.cfg.commands = { bash: true, text: false };
+        expect(await handleInlineActions(input)).toMatchObject({
+          kind: "reply",
+          reply: { text: "⚙️ No active bash job." },
+        });
+      },
+    );
+
+    it("keeps explicit skill tokens literal in slash command arguments", async () => {
+      const input = bashInput("/bash echo $office_hours");
+      input.skillCommands = officeHoursInlineSkillCommands();
+      expect(await handleInlineActions(input)).toMatchObject({ kind: "reply" });
+      expect(execExecuteMock).toHaveBeenCalledExactlyOnceWith(
+        "chat-bash",
+        expect.objectContaining({ command: "echo $office_hours" }),
+      );
+    });
+
+    it.each(["hello", "explain !poll", "please run /bash exit 127"])(
+      "keeps ordinary text on the fast path: %s",
+      async (body) => {
+        expect(await handleInlineActions(bashInput(body))).toMatchObject({
+          kind: "continue",
+          cleanedBody: body,
+        });
+        expect(handleCommandsMock).not.toHaveBeenCalled();
+        expect(execExecuteMock).not.toHaveBeenCalled();
+      },
     );
   });
 
@@ -912,42 +1066,44 @@ describe("handleInlineActions", () => {
     expect(handleCommandsMock).not.toHaveBeenCalled();
   });
 
-  it("preserves slash commands inside an explicitly referenced skill payload", async () => {
-    const typing = createTypingController();
-    const body = "$office_hours compare /help and /commands with /status";
-    const cleanedBody = stripInlineStatus(body).cleaned;
-    const ctx = buildTestCtx({
-      Body: body,
-      CommandBody: body,
-      Provider: "webchat",
-      Surface: "webchat",
-    });
+  it.each(["$office_hours compare /help and /commands with /status", "! echo $office_hours"])(
+    "preserves commands inside an explicitly referenced skill payload: %s",
+    async (body) => {
+      const typing = createTypingController();
+      const cleanedBody = stripInlineStatus(body).cleaned;
+      const ctx = buildTestCtx({
+        Body: body,
+        CommandBody: body,
+        Provider: "webchat",
+        Surface: "webchat",
+      });
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody,
-        command: {
-          isAuthorizedSender: true,
-          rawBodyNormalized: body,
-          commandBodyNormalized: body,
-        },
-        overrides: {
-          allowTextCommands: true,
-          inlineStatusRequested: true,
-          cfg: { commands: { text: true } },
-          skillCommands: officeHoursInlineSkillCommands(),
-        },
-      }),
-    );
+      const result = await handleInlineActions(
+        createHandleInlineActionsInput({
+          ctx,
+          typing,
+          cleanedBody,
+          command: {
+            isAuthorizedSender: true,
+            rawBodyNormalized: body,
+            commandBodyNormalized: body,
+          },
+          overrides: {
+            allowTextCommands: true,
+            inlineStatusRequested: true,
+            cfg: { commands: { text: true } },
+            skillCommands: officeHoursInlineSkillCommands(),
+          },
+        }),
+      );
 
-    const expected = expandedOfficeHoursRequest(body);
-    expect(result).toMatchObject({ kind: "continue", cleanedBody: expected });
-    expect(ctx.Body).toBe(expected);
-    expect(buildStatusReplyMock).not.toHaveBeenCalled();
-    expect(handleCommandsMock).not.toHaveBeenCalled();
-  });
+      const expected = expandedOfficeHoursRequest(body);
+      expect(result).toMatchObject({ kind: "continue", cleanedBody: expected });
+      expect(ctx.Body).toBe(expected);
+      expect(buildStatusReplyMock).not.toHaveBeenCalled();
+      expect(handleCommandsMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("keeps unauthorized explicit skill references as plain text", async () => {
     const typing = createTypingController();

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -45,6 +45,7 @@ import {
   type CommandSessionMetadataChange,
 } from "./command-session-metadata.js";
 import type { buildStatusReply, handleCommands } from "./commands.runtime.js";
+import { hasExplicitCommandContextText } from "./context-text.js";
 import { isDirectiveOnly } from "./directive-handling.directive-only.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
 import { extractExplicitGroupId } from "./group-id.js";
@@ -673,7 +674,7 @@ export async function handleInlineActions(params: {
     (inlineCommand !== null ||
       directiveAck !== undefined ||
       inlineStatusRequested ||
-      command.commandBodyNormalized.trim().startsWith("/"));
+      hasExplicitCommandContextText({ commandText: command.commandBodyNormalized }));
   if (!shouldRunCommandHandlers) {
     return {
       kind: "continue",

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -2,10 +2,6 @@ import { bucketRelativeTimeMs, type RelativeTimeUnit } from "@openclaw/normaliza
 // Control UI module implements format behavior.
 import { asDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import {
-  formatDurationCompact as formatDurationCompactCore,
-  formatDurationHuman as formatDurationHumanCore,
-} from "../../../src/infra/format-time/format-duration.ts";
 import { i18n, t } from "../i18n/index.ts";
 import { formatUiError } from "./format-error.ts";
 
@@ -99,9 +95,8 @@ export function formatRelativeTimestamp(
 }
 
 export function formatDurationCompact(ms?: number | null): string | undefined {
-  const coreValue = formatDurationCompactCore(ms, { spaced: true });
-  if (!coreValue || ms == null || !Number.isFinite(ms) || ms <= 0) {
-    return coreValue;
+  if (ms == null || !Number.isFinite(ms) || ms <= 0) {
+    return undefined;
   }
   const roundedMs = Math.round(ms);
   if (roundedMs < 1000) {
@@ -139,9 +134,8 @@ export function formatDurationCompact(ms?: number | null): string | undefined {
 }
 
 export function formatDurationHuman(ms?: number | null, fallback = t("common.na")): string {
-  const coreValue = formatDurationHumanCore(ms, fallback);
   if (ms == null || !Number.isFinite(ms) || ms < 0) {
-    return coreValue;
+    return fallback;
   }
   if (ms < 1000) {
     return formatUnit(Math.round(ms), "millisecond");


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/133385 (misleading chat-shell exit results).

## What Problem This Solves

An authorized `/bash` or `!` command could return a failed exec result but display `Exit: 0` above its failure diagnostic. Ordinary exit 1 was already preserved. Real Gateway testing also exposed a connected dispatch gap: ordinary bang-prefixed input continued to the model rather than the documented bash handler.

Following that flow through channel admission exposed two missing facts. WhatsApp did not compute command authorization for spaced or shell-punctuation-leading bang syntax, including after a genuine group mention. ClickClack treated the coarse request for authorization metadata as proof of an actual control command, allowing ordinary unmentioned text containing command-like tokens through its group mention gate.

## Why This Change Was Made

Chat bash now uses the existing exec exit formatter and preserves producer warnings, unknown/signal outcomes and retry guidance. Only completed or failed results get terminal headings; approvals and stop acknowledgements remain nonterminal. Inline admission reuses the existing slash/bang recognizer, dispatcher and executor.

The coarse detector requests metadata for bang input without assuming its arguments begin with a letter. It does not grant authority. ClickClack separately supplies actual control-command recognition to shared ingress. Sender/owner allowlists, bash enablement, elevated access, literal input, explicit-skill precedence, bot policy and reply-mode ownership remain unchanged.

The text-command CI fixture now installs the actual native Discord capability in the registry rather than mocking a contradictory list. Existing fixture helpers remove duplicated setup without removing cases. The branch also contains the identical duration-formatter cleanup already landed in [the session and startup optimization](https://github.com/openclaw/openclaw/pull/133446), merge `ec3077c14e30849980ca50b93928365b421ec3a3`. That upstream change removes discarded English formatting before localized formatting. It is not claimed as another new repair here.

## User Impact

Enabled, authorized shortcuts reach the existing command flow and report the real result. Failed code 127 remains 127, missing codes remain unknown, and signal termination is not rendered as success. Background stop acknowledges cancellation; a later poll reports observed completion. Mention-gated groups still require a real mention except for eligible control commands.

No configuration key, default, dependency, protocol, storage, SDK or permission surface is added. One conservative consequence is explicit: ordinary text with a whitespace-delimited bang token becomes ineligible for automatic restart-safe retry, matching existing treatment of compact bang and slash tokens. No restart-recovery execution proof is claimed.

Branch delta: production **+38/-47 (net -9)**, tests **+932/-120**, docs **+12**. The UI's net -6 is already upstream, leaving net -3 in chat/plugin production. Release-note context: correct chat-shell outcomes and bang dispatch, compute authorization for documented WhatsApp syntax, and preserve ClickClack mention gating. The broader [startup-budget governance issue](https://github.com/openclaw/openclaw/issues/121497) is not closed by the formatter cleanup.

## Evidence

Reviewed source head: `fd18102c790c26b6b70b5e997ecdbb05970e40c7`. Its complete thirteen-file patch reconstructs exactly to the tested working-tree candidate, SHA-256 `4a42b7eb35ffd60d4b12b8ae1dd4195df8335d4505ca29b8ac937f9e084d72bd`; all source hashes match after commit. Fresh structured Codex autoreview was scoped-clean at P0, and a separate independent owner/caller/sibling review found no actionable defects. Exact-head CI is pending; this is not a merge-ready claim.

The original native handler RED/GREEN used real child processes for both aliases and exits 0, 1 and 127. Both 127 cases falsely displayed zero before repair and retained 127 afterward. The ordinary-message Gateway RED run delivered slash controls, then reached the mock provider on the first bang message. Seven dispatch regressions failed before repair and passed afterward; 192 focused cases passed.

Channel-boundary proof:

- WhatsApp exercises real sender admission, group gating, authorization production, context finalization, the core handler and harmless exec. The mentioned-group probe passed 17 scenarios. The original-order 42-file registry composition passed 1,071 cases; later focused suites retain separate native inventories and source epochs.
- ClickClack composes real coarse/control/text predicates, shared ingress and its access/inbound owners. The same ordered 34 cases changed from **8 failed / 26 passed** to **34 passed**. Its complete suite passed **421 cases across 35 files**. Additional WhatsApp, shared-ingress and doctor selections passed **57, 110 and 5** cases respectively. Overlapping runs are not added as unique coverage.
- The canonical check plan contains 37 stages. Twenty-six stages have fresh individual evidence, including the date-sensitive registry guard refreshed for August 31; eleven unchanged stages retain validated passing evidence. The earlier aggregate max-lines failure and subsequent 1,800-second interruption remain failed/incomplete. Fixture consolidation fixed the line-limit failure, and every previously unfinished guard now passes. No uninterrupted aggregate pass is claimed.

The full build passed all fourteen phases, including declarations and Control UI. All **21,059** recorded output files were hash-verified, with no ineffective-dynamic-import warning. Final startup JS was **344,651 B gzip**, below the unchanged **346,761 B** enforcement limit, with eight JS and one CSS startup requests. Earlier same-tree formatter proof retained both complete builds, 117 unchanged tests before/after and 13,419 byte-identical duration results. The standalone non-English fallback catalogs were synthetic; existing tests separately exercise real French. No rendered-browser claim is made.

Rebuilt final-byte delivery used ordinary inbound QA-channel messages, a real Gateway child, harmless actual exec targets and a mock provider, with no native-command override or direct-handler bypass:

```json
{
  "passed": true,
  "deliveredExchanges": 15,
  "foregroundTargets": 7,
  "backgroundTargets": 2,
  "aliases": ["/bash", "!"],
  "exitControls": [0, 1, 127],
  "foregroundTimeout": "observed SIGTERM with retry guidance",
  "backgroundStop": "stopping acknowledgement, then polled SIGTERM",
  "allRepliesBoundToInbound": true,
  "allInboundPollsAcknowledged": true,
  "providerGenerationRequests": 0,
  "allTargetProcessesAbsent": true,
  "bothGatewayOwnersConfirmedStopped": true,
  "gatewayBusAndProviderPortsClosed": true,
  "sourceAndBuildIdentityUnchanged": true,
  "timeoutIntervention": false
}
```

The preceding final-build attempt remains failed: seven foreground checks passed, but the second Gateway never spawned before the unchanged 600-second driver cap. The user-requested fresh-namespace retry above passed in 480.85 seconds with identical product/build bytes and deadlines. Only private harness failure reporting changed to preserve the original error instead of masking it with a cleanup assertion. The preparation delay's root cause remains an explicit follow-up, not a claimed startup repair. Driver pipes joined naturally on the successful run. The public QA API exposes Gateway-owner settlement, not separate Gateway child-pipe-close or exec-diagnostic events; those are not claimed.

Representative actual entry commands are below. The retained invocations also pin Node 24.15.0/pnpm 12.1.0 and add local native-JSON destinations, omitted here to avoid publishing host paths:

```bash
node scripts/run-vitest.mjs extensions/clickclack --reporter=verbose
```

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-whatsapp.config.ts extensions/whatsapp/src/auto-reply/monitor/process-message.commands.test.ts extensions/whatsapp/src/auto-reply/monitor/group-gating.allowlist-warn.test.ts --reporter=verbose
```

```bash
node scripts/run-vitest.mjs src/auto-reply/command-control.test.ts src/channels/mention-gating.test.ts src/channels/message-access/message-access.test.ts src/channels/command-gating.test.ts --reporter=verbose
```

```bash
OPENCLAW_BUILD_PRIVATE_QA=1 node --import ./scripts/tsx.mjs scripts/build-all.mts full
```

The earlier claim that no sibling mention bypass was broadened is withdrawn. Independent review identified ClickClack's separate activation flag and missing control fact; the explicit owner repair and native RED/GREEN address it. Historical reports remain preserved.

ClawSweeper rank-up disposition: exact-head CI remains mandatory. Optional Telegram Test Server proof was unavailable because the local Convex CLI and broker pair were absent; an earlier optional Telegram attempt ended with watchdog exit 143 and no verdict. The real Gateway/mock-channel proof is not authenticated Telegram, WhatsApp or ClickClack delivery, and no all-channel success is claimed. No timeout increase, weakened assertion, budget increase or dependency override was used.

Documentation: [Background exec and chat shell shortcuts](https://docs.openclaw.ai/gateway/background-process).
