### PR TITLE
fix(memory): catch up active session after search sync

### DIFF
--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -565,6 +565,45 @@ describe("memory index", () => {
     await pendingSync;
   });
 
+  it("runs one bounded catch-up when the active session changes during reconciliation", async () => {
+    const manager = await getPersistentManager(
+      createCfg({ provider: "none", minScore: 0, onSearch: true, hybrid: { enabled: true } }),
+    );
+    await manager.sync({ reason: "test" });
+
+    let releaseFirstSync = () => {};
+    const firstSync = new Promise<void>((resolve) => {
+      releaseFirstSync = resolve;
+    });
+    const backgroundSync = vi
+      .spyOn(
+        manager as unknown as {
+          syncPublishedIndexInBackground: (params: { reason: string }) => Promise<void>;
+        },
+        "syncPublishedIndexInBackground",
+      )
+      .mockImplementation(async () => {
+        if (backgroundSync.mock.calls.length === 1) {
+          await firstSync;
+          Reflect.set(manager, "dirty", false);
+          Reflect.set(manager, "sessionsDirty", true);
+          return;
+        }
+        Reflect.set(manager, "sessionsDirty", false);
+      });
+
+    Reflect.set(manager, "dirty", false);
+    Reflect.set(manager, "sessionsDirty", true);
+
+    const results = await manager.search("zebra", { maxResults: 5, minScore: 0 });
+    expect(results.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
+    expect(backgroundSync).toHaveBeenCalledTimes(1);
+
+    releaseFirstSync();
+    await vi.waitFor(() => expect(backgroundSync).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(Reflect.get(manager, "sessionsDirty")).toBe(false));
+  });
+
   it("keeps the published index searchable while dirty maintenance builds", async () => {
     providerFixture.forceNoProvider = true;
     const manager = await getPersistentManager(

--- a/extensions/memory-core/src/memory/manager-search-orchestration.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.ts
@@ -206,16 +206,39 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
       if (repairedIndexIdentity.status !== "valid") {
         return [];
       }
-      const backgroundSearchSync = startAsyncSearchSync({
-        enabled:
-          (this.settings.sync.onSearch || sessionStartSync) &&
-          (this.purpose === "default" || this.purpose === "cli"),
+      const backgroundSyncEnabled =
+        (this.settings.sync.onSearch || sessionStartSync) &&
+        (this.purpose === "default" || this.purpose === "cli");
+      const runBackgroundSearchSync = (params: {
+        dirty: boolean;
+        sessionsDirty: boolean;
+        failureLabel: string;
+      }) =>
+        startAsyncSearchSync({
+          enabled: backgroundSyncEnabled,
+          dirty: params.dirty,
+          sessionsDirty: params.sessionsDirty,
+          sync: async (syncParams) => await this.syncPublishedIndexInBackground(syncParams),
+          onError: (err) => {
+            log.warn(`memory sync failed (${params.failureLabel}): ${String(err)}`);
+          },
+        });
+      const initialBackgroundSearchSync = runBackgroundSearchSync({
         dirty: this.dirty,
         sessionsDirty: this.sessionsDirty,
-        sync: async (params) => await this.syncPublishedIndexInBackground(params),
-        onError: (err) => {
-          log.warn(`memory sync failed (search): ${String(err)}`);
-        },
+        failureLabel: "search",
+      });
+      const backgroundSearchSync = initialBackgroundSearchSync?.then(async () => {
+        // The active session transcript can change while maintenance indexes its
+        // previous snapshot. Give that narrow race one bounded follow-up pass so
+        // recall converges without blocking the search or looping forever.
+        if (!this.dirty && this.sessionsDirty) {
+          await runBackgroundSearchSync({
+            dirty: false,
+            sessionsDirty: true,
+            failureLabel: "search-session-catchup",
+          });
+        }
       });
       if (backgroundSearchSync) {
         const trackedSearchSync = backgroundSearchSync.finally(() => {


### PR DESCRIPTION
## What Problem This Solves

When an active session transcript changes during the first background memory refresh started by `memory_search`, that refresh can finish with the session source still dirty. The search remains usable, but the next status read reports the session corpus as stale even though memory files, embeddings, FTS, and index identity are healthy.

This change runs one bounded follow-up session refresh after the initial background refresh completes when only session dirtiness remains. Search stays non-blocking and continuously changing transcripts cannot create an unbounded loop.

## Evidence

- `pnpm vitest run extensions/memory-core/src/memory/manager-search-orchestration.test.ts`: 22 passed
- Added a regression test that changes `sessionsDirty` only after the first asynchronous reconciliation, then verifies exactly one catch-up pass clears it
- Codex autoreview: clean
- Live diagnosis before repair: memory source clean, only sessions dirty, no sync error, complete vector index, FTS ready

## Build Note

The full build reached Control UI packaging but current upstream `main` exceeded its existing startup-JS gzip budget by 84 bytes. This patch does not touch UI code or assets.
