### PR TITLE
feat(beam): name share URLs after their sessions

### DIFF
--- a/docs/plugins/beam.md
+++ b/docs/plugins/beam.md
@@ -92,15 +92,18 @@ A successful upload returns the stable Beam id and a relative Control UI URL:
 {
   "ok": true,
   "beamId": "0123456789abcdef0123456789abcdef",
-  "url": "/beam/0123456789ab"
+  "url": "/beam/fix-the-upload-flow-0123456789ab"
 }
 ```
 
-The returned URL uses a 12-character lowercase hexadecimal prefix and keeps
-that readable path in the browser while the existing read-only Beam catalog
-renders the transcript. A configured Control UI base path prefixes the route,
-for example `/openclaw/beam/0123456789ab`. Longer prefixes through the full
-32-character Beam id also work.
+The returned URL uses the session title slug followed by a 12-character lowercase
+hexadecimal id prefix, matching regular session links. The id remains authoritative:
+bare-id links and links with an older title still resolve, and the browser replaces
+the name with the current title without adding history. Titles that produce no slug
+use the bare id. A configured Control UI base path prefixes the route, for example
+`/openclaw/beam/fix-the-upload-flow-0123456789ab`. Longer prefixes through the full
+32-character Beam id also work. Update the Beam skill before updating the receiver
+so its response validator accepts named links.
 
 Uploading the same `beamId` updates the existing catalog row. A completed upload sets the row status to `completed`; earlier updates display as `live`.
 

--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -198,6 +198,13 @@ export default definePluginEntry({
   one result with no next page; multiple rows or `nextCursor` are explicitly
   ambiguous and never select the first row.
 
+  Pass the title as `displayName` to `buildControlUiCatalogSharePath` from
+  `openclaw/plugin-sdk/session-catalog-runtime` to generate
+  `/<routeSegment>/<title-slug>-<id-prefix>`. It uses the same bounded slug as
+  regular session links. Only the id suffix selects the transcript; the UI
+  refreshes the decorative slug from the catalog row's `name`. Bare-id and
+  stale-title links remain valid, and titles never resolve an ambiguous id.
+
   `routeSegment` must not use the first segment of a built-in Control UI route
   or alias, and it must be unique across active session catalogs. Invalid,
   unsupported, reserved, or multiply owned descriptors fail closed; catalog

--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -198,12 +198,11 @@ export default definePluginEntry({
   one result with no next page; multiple rows or `nextCursor` are explicitly
   ambiguous and never select the first row.
 
-  Pass the title as `displayName` to `buildControlUiCatalogSharePath` from
-  `openclaw/plugin-sdk/session-catalog-runtime` to generate
-  `/<routeSegment>/<title-slug>-<id-prefix>`. It uses the same bounded slug as
-  regular session links. Only the id suffix selects the transcript; the UI
-  refreshes the decorative slug from the catalog row's `name`. Bare-id and
-  stale-title links remain valid, and titles never resolve an ambiguous id.
+  Named share links use `/<routeSegment>/<title-slug>-<id-prefix>` with the same
+  bounded slug as regular session links. Return the title in the catalog row's
+  `name`; the Control UI uses it to refresh the decorative slug. Only the id
+  suffix selects the transcript. Bare-id and stale-title links remain valid,
+  and titles never resolve an ambiguous id.
 
   `routeSegment` must not use the first segment of a built-in Control UI route
   or alias, and it must be unique across active session catalogs. Invalid,

--- a/docs/web/urls.md
+++ b/docs/web/urls.md
@@ -204,7 +204,7 @@ application shell. They do not open a normal application route.
 Beam uploads return a dedicated share path such as:
 
 ```text
-/beam/0123456789ab
+/beam/fix-the-upload-flow-0123456789ab
 ```
 
 This route is an adapter into the existing read-only Beam session catalog, not
@@ -215,69 +215,74 @@ applies; the URL identifies a Beam row but does not authorize access.
 Share links open in chat under the default agent. Sidebar and dashboard navigation
 keep the explicit catalog-query URL so the selected agent and view are preserved.
 
-New URLs use the first 12 lowercase hexadecimal characters of the 32-character
-Beam id. Twelve characters provide 48 bits; against Beam's 500-row retention
+New URLs use the same display-name slug as regular session links, followed by
+the first 12 lowercase hexadecimal characters of the 32-character Beam id.
+The slug is decorative: bare-id links and stale names still resolve by id, and
+the browser replaces the slug with the current title without adding history.
+If the title produces no slug, the URL contains only the id prefix.
+Twelve characters provide 48 bits; against Beam's 500-row retention
 bound, the probability that any pair shares that prefix is about 1 in 2.26
 billion. Resolution still never assumes uniqueness: exactly one retained row
 must match. A missing prefix shows session recovery links, while an
 ambiguous prefix shows the matching rows and asks for a longer id. Any longer
 lowercase hexadecimal prefix through the full 32-character id is accepted.
-Uppercase, non-hexadecimal, shorter, longer, and extra-segment forms are invalid.
+Uppercase, non-hexadecimal, shorter, and longer id suffixes, or extra path segments,
+are invalid.
 
 With `gateway.controlUi.basePath: "/openclaw"`, use
-`/openclaw/beam/0123456789ab`.
+`/openclaw/beam/fix-the-upload-flow-0123456789ab`.
 
 ## Route table
 
 This table lists every Control UI application route. A dash means the route has
 no route-specific URL parameters.
 
-| Page                | Canonical path              | Aliases                   | Parameters or dynamic forms                                    |
-| ------------------- | --------------------------- | ------------------------- | -------------------------------------------------------------- |
-| Chat                | `/chat`                     | -                         | Key-backed session forms above; `?draft=<text>`                |
-| Dashboard           | `/dashboard`                | -                         | Key-backed session forms above; `?draft=<text>`                |
-| Beam transcript     | `/beam/<beam-id>`           | -                         | 12-32 lowercase hexadecimal characters                         |
-| Dashboards          | `/dashboards`               | -                         | -                                                              |
-| Ask OpenClaw        | `/custodian`                | -                         | `?intent=new-agent`, `?onboarding=1`                           |
-| New session         | `/new`                      | -                         | `?agent=<agentId>`, `?catalog=<catalogId>`                     |
-| Activity            | `/activity`                 | -                         | `?view=run&run=<run-id>`, `?view=run&execution=<execution-id>` |
-| Apps                | `/apps`                     | -                         | -                                                              |
-| Portals             | `/portals`                  | -                         | -                                                              |
-| Agents              | `/settings/agents`          | `/agents`                 | `/settings/agents/<agentId>[/<panel>]`                         |
-| Channels            | `/settings/channels`        | `/channels`               | Shared settings parameters below                               |
-| Connection          | `/settings/connection`      | -                         | Shared settings parameters below                               |
-| Legacy General      | `/settings/general`         | `/config`                 | Redirects to Appearance → Language                             |
-| Profile             | `/settings/profile`         | `/profile`                | Shared settings parameters below                               |
-| Communications      | `/settings/communications`  | `/communications`         | Shared settings parameters below                               |
-| Appearance          | `/settings/appearance`      | `/appearance`             | Shared settings parameters below                               |
-| Notifications       | `/settings/notifications`   | -                         | Shared settings parameters below                               |
-| Security            | `/settings/security`        | -                         | Shared settings parameters below                               |
-| Secrets             | `/settings/secrets`         | -                         | Shared settings parameters below                               |
-| Advanced            | `/settings/advanced`        | -                         | Shared settings parameters below                               |
-| Approvals           | `/settings/approvals`       | -                         | Shared settings parameters below                               |
-| Automation settings | `/settings/automation`      | `/automation`             | Shared settings parameters below                               |
-| MCP                 | `/settings/mcp`             | `/mcp`                    | Shared settings parameters below                               |
-| Memory              | `/settings/memory`          | -                         | `/settings/memory/memories\|dreams\|settings`                  |
-| Infrastructure      | `/settings/infrastructure`  | `/infrastructure`         | Shared settings parameters below                               |
-| Labs                | `/settings/labs`            | -                         | Shared settings parameters below                               |
-| About               | `/settings/about`           | -                         | Shared settings parameters below                               |
-| AI and agents       | `/settings/ai-agents`       | `/ai-agents`              | Shared settings parameters below                               |
-| Model setup         | `/settings/model-setup`     | `/model-setup`            | `?firstRun=1`                                                  |
-| Model providers     | `/settings/model-providers` | `/model-providers`        | Shared settings parameters below                               |
-| Import memory       | `/memory-import`            | `/settings/memory-import` | -                                                              |
-| Workboard           | `/workboard`                | -                         | `/workboard/<boardId>`                                         |
-| Worktrees           | `/worktrees`                | `/settings/worktrees`     | -                                                              |
-| Sessions            | `/sessions`                 | `/settings/sessions`      | `?session=<sessionKey>`, `?status=archived\|all`               |
-| Usage               | `/usage`                    | -                         | -                                                              |
-| Debug               | `/debug`                    | -                         | -                                                              |
-| Logs                | `/logs`                     | -                         | -                                                              |
-| Skill Workshop      | `/skills/workshop`          | -                         | -                                                              |
-| Skills              | `/skills`                   | -                         | -                                                              |
-| Plugins             | `/settings/plugins`         | -                         | `/settings/plugins/discover`                                   |
-| Automations         | `/cron`                     | -                         | -                                                              |
-| Tasks               | `/tasks`                    | -                         | -                                                              |
-| Devices             | `/settings/devices`         | `/nodes`                  | Shared settings parameters below                               |
-| Plugin tab host     | `/plugin`                   | -                         | `?plugin=<pluginId>&id=<tabId>`                                |
+| Page                | Canonical path              | Aliases                   | Parameters or dynamic forms                                       |
+| ------------------- | --------------------------- | ------------------------- | ----------------------------------------------------------------- |
+| Chat                | `/chat`                     | -                         | Key-backed session forms above; `?draft=<text>`                   |
+| Dashboard           | `/dashboard`                | -                         | Key-backed session forms above; `?draft=<text>`                   |
+| Beam transcript     | `/beam/<title>-<beam-id>`   | `/beam/<beam-id>`         | Optional title slug and 12-32 lowercase hexadecimal id characters |
+| Dashboards          | `/dashboards`               | -                         | -                                                                 |
+| Ask OpenClaw        | `/custodian`                | -                         | `?intent=new-agent`, `?onboarding=1`                              |
+| New session         | `/new`                      | -                         | `?agent=<agentId>`, `?catalog=<catalogId>`                        |
+| Activity            | `/activity`                 | -                         | `?view=run&run=<run-id>`, `?view=run&execution=<execution-id>`    |
+| Apps                | `/apps`                     | -                         | -                                                                 |
+| Portals             | `/portals`                  | -                         | -                                                                 |
+| Agents              | `/settings/agents`          | `/agents`                 | `/settings/agents/<agentId>[/<panel>]`                            |
+| Channels            | `/settings/channels`        | `/channels`               | Shared settings parameters below                                  |
+| Connection          | `/settings/connection`      | -                         | Shared settings parameters below                                  |
+| Legacy General      | `/settings/general`         | `/config`                 | Redirects to Appearance → Language                                |
+| Profile             | `/settings/profile`         | `/profile`                | Shared settings parameters below                                  |
+| Communications      | `/settings/communications`  | `/communications`         | Shared settings parameters below                                  |
+| Appearance          | `/settings/appearance`      | `/appearance`             | Shared settings parameters below                                  |
+| Notifications       | `/settings/notifications`   | -                         | Shared settings parameters below                                  |
+| Security            | `/settings/security`        | -                         | Shared settings parameters below                                  |
+| Secrets             | `/settings/secrets`         | -                         | Shared settings parameters below                                  |
+| Advanced            | `/settings/advanced`        | -                         | Shared settings parameters below                                  |
+| Approvals           | `/settings/approvals`       | -                         | Shared settings parameters below                                  |
+| Automation settings | `/settings/automation`      | `/automation`             | Shared settings parameters below                                  |
+| MCP                 | `/settings/mcp`             | `/mcp`                    | Shared settings parameters below                                  |
+| Memory              | `/settings/memory`          | -                         | `/settings/memory/memories\|dreams\|settings`                     |
+| Infrastructure      | `/settings/infrastructure`  | `/infrastructure`         | Shared settings parameters below                                  |
+| Labs                | `/settings/labs`            | -                         | Shared settings parameters below                                  |
+| About               | `/settings/about`           | -                         | Shared settings parameters below                                  |
+| AI and agents       | `/settings/ai-agents`       | `/ai-agents`              | Shared settings parameters below                                  |
+| Model setup         | `/settings/model-setup`     | `/model-setup`            | `?firstRun=1`                                                     |
+| Model providers     | `/settings/model-providers` | `/model-providers`        | Shared settings parameters below                                  |
+| Import memory       | `/memory-import`            | `/settings/memory-import` | -                                                                 |
+| Workboard           | `/workboard`                | -                         | `/workboard/<boardId>`                                            |
+| Worktrees           | `/worktrees`                | `/settings/worktrees`     | -                                                                 |
+| Sessions            | `/sessions`                 | `/settings/sessions`      | `?session=<sessionKey>`, `?status=archived\|all`                  |
+| Usage               | `/usage`                    | -                         | -                                                                 |
+| Debug               | `/debug`                    | -                         | -                                                                 |
+| Logs                | `/logs`                     | -                         | -                                                                 |
+| Skill Workshop      | `/skills/workshop`          | -                         | -                                                                 |
+| Skills              | `/skills`                   | -                         | -                                                                 |
+| Plugins             | `/settings/plugins`         | -                         | `/settings/plugins/discover`                                      |
+| Automations         | `/cron`                     | -                         | -                                                                 |
+| Tasks               | `/tasks`                    | -                         | -                                                                 |
+| Devices             | `/settings/devices`         | `/nodes`                  | Shared settings parameters below                                  |
+| Plugin tab host     | `/plugin`                   | -                         | `?plugin=<pluginId>&id=<tabId>`                                   |
 
 Settings routes that use schema-backed deep links accept `?section=<section>`,
 `?advanced=1`, and `#<setting-id>`. These values select content within the page;

--- a/extensions/beam/src/beam.test.ts
+++ b/extensions/beam/src/beam.test.ts
@@ -228,7 +228,7 @@ describe("Beam receiver", () => {
     expect(await first.json()).toEqual({
       ok: true,
       beamId: "0123456789abcdef0123456789abcdef",
-      url: "/beam/0123456789ab",
+      url: "/beam/fix-the-upload-flow-0123456789ab",
     });
     expect(store.values.get("0123456789abcdef0123456789abcdef")).toMatchObject({
       createdAt: 100,
@@ -236,10 +236,14 @@ describe("Beam receiver", () => {
     });
 
     now = 200;
-    await fetch(endpoint, {
+    const updated = await fetch(endpoint, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify(sampleUpload({ completed: true })),
+      body: JSON.stringify(sampleUpload({ completed: true, title: "Renamed upload flow" })),
+    });
+    expect(await updated.json()).toMatchObject({
+      beamId: sampleUpload().beamId,
+      url: "/beam/renamed-upload-flow-0123456789ab",
     });
     expect(store.values.get("0123456789abcdef0123456789abcdef")).toMatchObject({
       createdAt: 100,
@@ -267,7 +271,7 @@ describe("Beam receiver", () => {
     expect(await response.json()).toEqual({
       ok: true,
       beamId: "0123456789abcdef0123456789abcdef",
-      url: "/admin/openclaw/beam/0123456789ab",
+      url: "/admin/openclaw/beam/fix-the-upload-flow-0123456789ab",
     });
   });
 

--- a/extensions/beam/src/http.ts
+++ b/extensions/beam/src/http.ts
@@ -114,6 +114,7 @@ export function createBeamRequestHandler(params: {
         url: buildControlUiCatalogSharePath({
           shareRoute: BEAM_SESSION_SHARE_ROUTE,
           threadId: parsed.value.beamId,
+          displayName: parsed.value.title,
           basePath: params.resolveControlUiBasePath(),
         }),
       });

--- a/packages/session-url-contract/src/grammar.ts
+++ b/packages/session-url-contract/src/grammar.ts
@@ -4,6 +4,20 @@ export const DEFAULT_MAIN_KEY = "main";
 
 const SHORT_SESSION_REF_RE = /^(?:.*-)?([0-9a-f]{8,32})$/iu;
 const FIXED_RESERVED_SESSION_RESTS = new Set(["main", "global", "boot", "sessions"]);
+const SESSION_SLUG_MAX_LENGTH = 48;
+
+export function controlUiSessionSlug(displayName: string | undefined | null): string {
+  const tokens = (displayName ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, "-")
+    .replace(/^-+|-+$/gu, "")
+    .split("-")
+    .filter(Boolean);
+  while (tokens.length > 0 && /^[0-9a-f]+$/u.test(tokens.at(-1) ?? "")) {
+    tokens.pop();
+  }
+  return tokens.join("-").slice(0, SESSION_SLUG_MAX_LENGTH).replace(/-+$/gu, "");
+}
 
 export function normalizeControlUiBasePath(basePath?: string): string {
   const trimmed = basePath?.trim().replace(/^\/+|\/+$/gu, "") ?? "";

--- a/packages/session-url-contract/src/grammar.ts
+++ b/packages/session-url-contract/src/grammar.ts
@@ -7,16 +7,15 @@ const FIXED_RESERVED_SESSION_RESTS = new Set(["main", "global", "boot", "session
 const SESSION_SLUG_MAX_LENGTH = 48;
 
 export function controlUiSessionSlug(displayName: string | undefined | null): string {
-  const tokens = (displayName ?? "")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/gu, "-")
-    .replace(/^-+|-+$/gu, "")
-    .split("-")
-    .filter(Boolean);
-  while (tokens.length > 0 && /^[0-9a-f]+$/u.test(tokens.at(-1) ?? "")) {
-    tokens.pop();
-  }
-  return tokens.join("-").slice(0, SESSION_SLUG_MAX_LENGTH).replace(/-+$/gu, "");
+  // Hex-only trailing tokens would look like the URL's id suffix. Keep through
+  // the last token with a non-hex letter, before truncating the display slug.
+  const slug =
+    (displayName ?? "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/gu, "-")
+      .replace(/^-+|-+$/gu, "")
+      .match(/^.*[g-z][a-z0-9]*/u)?.[0] ?? "";
+  return slug.slice(0, SESSION_SLUG_MAX_LENGTH).replace(/-+$/gu, "");
 }
 
 export function normalizeControlUiBasePath(basePath?: string): string {

--- a/packages/session-url-contract/src/index.test.ts
+++ b/packages/session-url-contract/src/index.test.ts
@@ -83,6 +83,21 @@ describe("buildControlUiCatalogSessionUrl", () => {
 
 describe("buildControlUiCatalogSharePath", () => {
   it.each([
+    ["Fix: upload flow!", "fix-upload-flow-"],
+    ["Deploy face deadbeef", "deploy-"],
+    ["🦞", ""],
+    ["x".repeat(60), `${"x".repeat(48)}-`],
+  ])("uses the session title slug for %s", (displayName, prefix) => {
+    expect(
+      buildControlUiCatalogSharePath({
+        shareRoute: SHARE_ROUTE,
+        threadId: "0123456789abcdef0123456789abcdef",
+        displayName,
+      }),
+    ).toBe(`/beam/${prefix}0123456789ab`);
+  });
+
+  it.each([
     {
       label: "root path",
       basePath: undefined,

--- a/packages/session-url-contract/src/index.ts
+++ b/packages/session-url-contract/src/index.ts
@@ -1,13 +1,14 @@
 import { normalizeAgentId } from "@openclaw/normalization-core/agent-id";
 import { normalizeNullableString } from "@openclaw/normalization-core/string-coerce";
 import {
+  controlUiSessionSlug,
   DEFAULT_MAIN_KEY,
   isReservedSessionRest,
   normalizeControlUiBasePath,
   parseShortSessionRef,
 } from "./grammar.js";
 
-export { normalizeControlUiBasePath };
+export { controlUiSessionSlug, normalizeControlUiBasePath };
 export * from "./focus.js";
 export {
   CONTROL_UI_RESERVED_ROUTE_SEGMENTS,
@@ -43,7 +44,6 @@ type BuildControlUiCatalogSessionUrlParams = {
 export const SESSION_UUID_SUFFIX_RE =
   /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/iu;
 export const SHORT_SESSION_ID_RE = /^[0-9a-f]{8,32}$/iu;
-const SESSION_SLUG_MAX_LENGTH = 48;
 
 function agentSessionKeyParts(sessionKey: string): { agentId: string; rest: string } | null {
   const parts = sessionKey.split(":");
@@ -70,19 +70,6 @@ function encodePathSegment(segment: string): string {
   // pathForWorkboardBoard escapes dots for the same reason.
   const encoded = encodeURIComponent(segment).replaceAll(".", "%2E");
   return encoded.startsWith("~") ? `~${encoded}` : encoded;
-}
-
-export function controlUiSessionSlug(displayName: string | undefined | null): string {
-  const tokens = (displayName ?? "")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/gu, "-")
-    .replace(/^-+|-+$/gu, "")
-    .split("-")
-    .filter(Boolean);
-  while (tokens.length > 0 && /^[0-9a-f]+$/u.test(tokens.at(-1) ?? "")) {
-    tokens.pop();
-  }
-  return tokens.join("-").slice(0, SESSION_SLUG_MAX_LENGTH).replace(/-+$/gu, "");
 }
 
 export function buildControlUiSessionPath(params: BuildControlUiSessionPathParams): string | null {

--- a/packages/session-url-contract/src/parse.test.ts
+++ b/packages/session-url-contract/src/parse.test.ts
@@ -291,6 +291,13 @@ describe("parseControlUiSessionPath", () => {
 describe("matchControlUiCatalogSharePath", () => {
   it.each([
     ["/beam/0123456789ab", undefined, "0123456789ab"],
+    ["/beam/fix-upload-flow-0123456789ab", undefined, "0123456789ab"],
+    ["/beam/old-title-0123456789ab", undefined, "0123456789ab"],
+    [
+      "/openclaw/beam/fix-upload-flow-0123456789abcdef0123456789abcdef",
+      "/openclaw",
+      "0123456789abcdef0123456789abcdef",
+    ],
     [
       "/openclaw/beam/0123456789abcdef0123456789abcdef",
       "/openclaw",

--- a/packages/session-url-contract/src/share-build.ts
+++ b/packages/session-url-contract/src/share-build.ts
@@ -1,5 +1,5 @@
 import { normalizeNullableString } from "@openclaw/normalization-core/string-coerce";
-import { normalizeControlUiBasePath } from "./grammar.js";
+import { controlUiSessionSlug, normalizeControlUiBasePath } from "./grammar.js";
 import { isControlUiReservedRouteSegment, type ControlUiCatalogShareRoute } from "./share.js";
 
 // Keep this subpath out of index.ts: the eager routing barrel would pull share
@@ -21,6 +21,7 @@ export function isControlUiCatalogShareId(
 export function buildControlUiCatalogSharePath(params: {
   shareRoute: ControlUiCatalogShareRoute;
   threadId: string;
+  displayName?: string;
   basePath?: string;
   prefixLength?: number;
 }): string | null {
@@ -42,5 +43,6 @@ export function buildControlUiCatalogSharePath(params: {
       Math.floor(params.prefixLength ?? shareRoute.minPrefixLength),
     ),
   );
-  return `${normalizeControlUiBasePath(params.basePath)}/${shareRoute.routeSegment}/${threadId.slice(0, length)}`;
+  const slug = controlUiSessionSlug(params.displayName);
+  return `${normalizeControlUiBasePath(params.basePath)}/${shareRoute.routeSegment}/${slug ? `${slug}-` : ""}${threadId.slice(0, length)}`;
 }

--- a/packages/session-url-contract/src/share.ts
+++ b/packages/session-url-contract/src/share.ts
@@ -1,6 +1,7 @@
 import { normalizeControlUiBasePath } from "./grammar.js";
 
-const CATALOG_SHARE_PATH_RE = /^([a-z][a-z0-9-]*)\/([a-zA-Z0-9]{12,})$/u;
+const CATALOG_SHARE_PATH_RE =
+  /^([a-z][a-z0-9-]*)\/(?:[a-z0-9]+(?:-[a-z0-9]+)*-)?([a-zA-Z0-9]{12,})$/u;
 
 // This stable contract is shared by URL producers and consumers. The Control UI
 // route-table test keeps it aligned with every built-in path and alias.

--- a/packages/session-url-contract/src/share.ts
+++ b/packages/session-url-contract/src/share.ts
@@ -1,7 +1,6 @@
 import { normalizeControlUiBasePath } from "./grammar.js";
 
-const CATALOG_SHARE_PATH_RE =
-  /^([a-z][a-z0-9-]*)\/(?:[a-z0-9]+(?:-[a-z0-9]+)*-)?([a-zA-Z0-9]{12,})$/u;
+const CATALOG_SHARE_PATH_RE = /^([a-z][a-z0-9-]*)\/(?:[a-z0-9]+-)*([a-zA-Z0-9]{12,})$/u;
 
 // This stable contract is shared by URL producers and consumers. The Control UI
 // route-table test keeps it aligned with every built-in path and alias.

--- a/ui/src/e2e/external-session-catalogs.e2e.test.ts
+++ b/ui/src/e2e/external-session-catalogs.e2e.test.ts
@@ -433,7 +433,7 @@ suite.define(() => {
   );
 
   it("keeps old Beam links working and opens pretty shares under a non-main default agent", async () => {
-    const artifactDir = path.resolve(".artifacts/control-ui-e2e/beam-share-url");
+    const artifactDir = path.resolve(".artifacts/control-ui-e2e/beam-named-share-url");
     await fs.mkdir(artifactDir, { recursive: true });
     const context = await suite.newBrowserContext({
       recordVideo: { dir: artifactDir, size: { width: 1280, height: 720 } },
@@ -441,7 +441,7 @@ suite.define(() => {
     });
     const page = await context.newPage();
     const fullId = "0123456789abcdef0123456789abcdef";
-    const prettyPath = "/openclaw/beam/0123456789ab";
+    const prettyPath = "/openclaw/beam/pretty-beam-route-0123456789ab";
     const queryPath = `/openclaw/chat/research?catalog=beam&host=gateway&thread=${fullId}`;
     const gateway = await installMockGateway(page, {
       basePath: "/openclaw",
@@ -573,6 +573,14 @@ suite.define(() => {
         path: path.join(artifactDir, "beam-pretty-route.png"),
         fullPage: true,
       });
+
+      // Both previously shared IDs and stale names retain their transcript after a rename.
+      for (const reference of ["0123456789ab", "old-title-0123456789ab"]) {
+        await page.goto(new URL(`/openclaw/beam/${reference}`, suite.server.baseUrl).href);
+        await transcript.waitFor();
+        await assertCatalogOwner();
+        await expect.poll(() => new URL(page.url()).pathname).toBe(prettyPath);
+      }
 
       await page.goto(new URL("/openclaw/chat/other", suite.server.baseUrl).href);
       const beamRow = page.locator("a", { hasText: "Pretty Beam route" }).first();

--- a/ui/src/pages/chat/route-loader-catalog-share.test.ts
+++ b/ui/src/pages/chat/route-loader-catalog-share.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
+import { INTERNAL_SESSION_PATH_PARAM } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { loadChatRoute } from "./route-loader.ts";
 
@@ -90,34 +91,52 @@ describe("catalog share route resolution", () => {
     });
   });
 
-  it("resolves a base-path share independently of the default agent id", async () => {
-    const request = vi.fn(async (method: string) => {
-      if (method !== "sessions.catalog.list") {
-        throw new Error(`Unexpected gateway request: ${method}`);
+  it.each(["0123456789ab", "old-title-0123456789ab", "pretty-beam-route-0123456789ab"])(
+    "resolves %s by id and canonicalizes the title under the default agent",
+    async (reference) => {
+      const request = vi.fn(async (method: string) => {
+        if (method !== "sessions.catalog.list") {
+          throw new Error(`Unexpected gateway request: ${method}`);
+        }
+        return beamCatalog([{ threadId: fullId, name: "Pretty Beam route" }]);
+      });
+
+      const loaded = await loadChatRoute(
+        catalogContext(request, "/openclaw"),
+        { pathname: `/openclaw/beam/${reference}`, search: "", hash: "" },
+        "chat",
+        new AbortController().signal,
+      );
+
+      expect(loaded).toMatchObject({
+        kind: "session",
+        sessionKey: `agent:research:catalog:beam:gateway:${fullId}`,
+        agentId: "research",
+        face: "chat",
+      });
+      if (reference === "pretty-beam-route-0123456789ab") {
+        expect(loaded).not.toHaveProperty("canonicalLocation");
+      } else {
+        expect(loaded).toMatchObject({
+          canonicalLocation: {
+            pathname: "/openclaw/beam/pretty-beam-route-0123456789ab",
+            search: "",
+            hash: "",
+          },
+          canonicalLocationSource: {
+            pathname: `/openclaw/beam/${reference}`,
+            search: "",
+            hash: "",
+          },
+        });
       }
-      return beamCatalog([{ threadId: fullId, name: "Pretty Beam route" }]);
-    });
-
-    const loaded = await loadChatRoute(
-      catalogContext(request, "/openclaw"),
-      { pathname: "/openclaw/beam/0123456789ab", search: "", hash: "" },
-      "chat",
-      new AbortController().signal,
-    );
-
-    expect(loaded).toMatchObject({
-      kind: "session",
-      sessionKey: `agent:research:catalog:beam:gateway:${fullId}`,
-      agentId: "research",
-      face: "chat",
-    });
-    expect(loaded).not.toHaveProperty("canonicalLocation");
-    expect(request).toHaveBeenCalledWith("sessions.catalog.list", {
-      agentId: "research",
-      search: "0123456789ab",
-      limitPerHost: 2,
-    });
-  });
+      expect(request).toHaveBeenCalledWith("sessions.catalog.list", {
+        agentId: "research",
+        search: "0123456789ab",
+        limitPerHost: 2,
+      });
+    },
+  );
 
   it("keeps ambiguity, invalid ids, and disabled route owners visible", async () => {
     const ids = ["0123456789ab00000000000000000000", "0123456789abffffffffffffffffffff"];
@@ -137,14 +156,14 @@ describe("catalog share route resolution", () => {
     await expect(
       loadChatRoute(
         context,
-        { pathname: "/beam/0123456789ab", search: "", hash: "" },
+        { pathname: "/beam/candidate-0123456789ab", search: "", hash: "" },
         "chat",
         new AbortController().signal,
       ),
     ).resolves.toMatchObject({
       kind: "ambiguous",
       shortId: "0123456789ab",
-      candidates: [{ href: `/beam/${ids[0]}` }, { href: `/beam/${ids[1]}` }],
+      candidates: [{ href: `/beam/candidate-${ids[0]}` }, { href: `/beam/candidate-${ids[1]}` }],
       truncated: true,
     });
 
@@ -233,5 +252,35 @@ describe("catalog share route resolution", () => {
         new AbortController().signal,
       ),
     ).resolves.toMatchObject({ kind: "route-error" });
+  });
+
+  it("preserves full-id links while canonicalizing an internally bridged stale name", async () => {
+    const request = vi.fn(async () => beamCatalog([{ threadId: fullId, name: "Renamed session" }]));
+    const originalPath = `/openclaw/beam/old-name-${fullId}`;
+    const loaded = await loadChatRoute(
+      catalogContext(request, "/openclaw"),
+      {
+        pathname: "/openclaw/chat",
+        search: `?${new URLSearchParams({ [INTERNAL_SESSION_PATH_PARAM]: originalPath })}`,
+        hash: "",
+      },
+      "chat",
+      new AbortController().signal,
+    );
+    expect(loaded).toMatchObject({
+      kind: "session",
+      sessionKey: `agent:research:catalog:beam:gateway:${fullId}`,
+      canonicalLocation: {
+        pathname: `/openclaw/beam/renamed-session-${fullId}`,
+        search: "",
+        hash: "",
+      },
+      canonicalLocationSource: { pathname: originalPath, search: "", hash: "" },
+    });
+    expect(request).toHaveBeenCalledWith("sessions.catalog.list", {
+      agentId: "research",
+      search: fullId,
+      limitPerHost: 2,
+    });
   });
 });

--- a/ui/src/pages/chat/route-loader-catalog-share.ts
+++ b/ui/src/pages/chat/route-loader-catalog-share.ts
@@ -16,24 +16,19 @@ import { missingSessionRouteData } from "./route-loader-session-reference.ts";
 import type { ChatRouteData } from "./session-route-data.ts";
 
 function targetFromLocation(context: ApplicationContext, location: RouteLocation) {
-  const matchPath = (pathname: string) =>
-    matchControlUiCatalogSharePath({ pathname, basePath: context.basePath });
   const search = new URLSearchParams(location.search);
   const internalPath = search.get(INTERNAL_SESSION_PATH_PARAM);
-  if (!internalPath) {
-    const target = matchPath(location.pathname);
+  const pathname = internalPath || location.pathname;
+  const target = matchControlUiCatalogSharePath({ pathname, basePath: context.basePath });
+  if (!target || !internalPath) {
     return target ? { target, location } : null;
   }
-  const pathname = internalPath;
-  const target = matchPath(pathname);
   search.delete(INTERNAL_SESSION_PATH_PARAM);
   const serializedSearch = search.toString();
-  return target
-    ? {
-        target,
-        location: { ...location, pathname, search: serializedSearch ? `?${serializedSearch}` : "" },
-      }
-    : null;
+  return {
+    target,
+    location: { ...location, pathname, search: serializedSearch ? `?${serializedSearch}` : "" },
+  };
 }
 
 function routeError(message: string): Extract<ChatRouteData, { kind: "route-error" }> {

--- a/ui/src/pages/chat/route-loader-catalog-share.ts
+++ b/ui/src/pages/chat/route-loader-catalog-share.ts
@@ -18,8 +18,22 @@ import type { ChatRouteData } from "./session-route-data.ts";
 function targetFromLocation(context: ApplicationContext, location: RouteLocation) {
   const matchPath = (pathname: string) =>
     matchControlUiCatalogSharePath({ pathname, basePath: context.basePath });
-  const internalPath = new URLSearchParams(location.search).get(INTERNAL_SESSION_PATH_PARAM);
-  return (internalPath ? matchPath(internalPath) : null) ?? matchPath(location.pathname);
+  const search = new URLSearchParams(location.search);
+  const internalPath = search.get(INTERNAL_SESSION_PATH_PARAM);
+  if (!internalPath) {
+    const target = matchPath(location.pathname);
+    return target ? { target, location } : null;
+  }
+  const pathname = internalPath;
+  const target = matchPath(pathname);
+  search.delete(INTERNAL_SESSION_PATH_PARAM);
+  const serializedSearch = search.toString();
+  return target
+    ? {
+        target,
+        location: { ...location, pathname, search: serializedSearch ? `?${serializedSearch}` : "" },
+      }
+    : null;
 }
 
 function routeError(message: string): Extract<ChatRouteData, { kind: "route-error" }> {
@@ -31,10 +45,11 @@ export async function loadCatalogShareRouteFromLocation(
   location: RouteLocation,
   signal: AbortSignal,
 ): Promise<ChatRouteData | null> {
-  const target = targetFromLocation(context, location);
-  if (!target) {
+  const resolved = targetFromLocation(context, location);
+  if (!resolved) {
     return null;
   }
+  const { target, location: sourceLocation } = resolved;
   try {
     const client = await waitForGatewayClient(context.gateway, signal);
     signal.throwIfAborted();
@@ -83,6 +98,7 @@ export async function loadCatalogShareRouteFromLocation(
         const href = buildControlUiCatalogSharePath({
           shareRoute,
           threadId: session.threadId,
+          displayName: session.name,
           basePath: context.basePath,
           prefixLength: shareRoute.fullLength,
         });
@@ -112,13 +128,14 @@ export async function loadCatalogShareRouteFromLocation(
     if (!session) {
       return routeError(t("chat.sessionRoute.catalogShareUnavailable"));
     }
-    if (
-      !buildControlUiCatalogSharePath({
-        shareRoute,
-        threadId: session.threadId,
-        prefixLength: shareRoute.fullLength,
-      })
-    ) {
+    const pathname = buildControlUiCatalogSharePath({
+      shareRoute,
+      threadId: session.threadId,
+      displayName: session.name,
+      basePath: context.basePath,
+      prefixLength: target.shortId.length,
+    });
+    if (!pathname) {
       return routeError(t("chat.sessionRoute.catalogShareUnavailable"));
     }
     return {
@@ -130,6 +147,13 @@ export async function loadCatalogShareRouteFromLocation(
       agentId,
       draft: undefined,
       face: "chat",
+      // Names can change on later uploads; the id resolves the same transcript.
+      ...(pathname !== sourceLocation.pathname
+        ? {
+            canonicalLocation: { ...sourceLocation, pathname },
+            canonicalLocationSource: sourceLocation,
+          }
+        : {}),
     };
   } catch (error) {
     signal.throwIfAborted();


### PR DESCRIPTION
## What Problem This Solves

Beam share links use an opaque ID even when the transcript has a useful title. Regular sessions already have readable title slugs; this applies the same naming rule to Beam: `/beam/fix-ci-947fbac0ac34`.

Related: #125755. The companion client validator is already merged in https://github.com/openclaw/agent-skills/pull/208.

## Why This Change Was Made

Reuse `controlUiSessionSlug` in the shared URL contract and pass the existing Beam title into the share builder. The title is decorative; catalog lookup still uses the immutable ID suffix. The existing route canonicalization mechanism updates bare-ID and stale-title URLs to the current title, preserving prefix length and base paths. Ambiguous prefixes still show a chooser, even when one title matches.

Beam remains a read-only external catalog, independent of native Gateway sessions. There is no new persisted slug, schema, config, auth behavior, or harness title-discovery mechanism. The shared grammar owns title normalization and matching. It keeps the same slug behavior with a linear scan through the last non-hex token; the share builder remains behind its existing entrypoint.

## User Impact

New uploads return named URLs. Existing bare-ID and query URLs keep working, and saved links survive renaming. Default-agent resolution and explicit contextual catalog navigation are unchanged. Update the Beam skill before deploying the receiver; the compatible client has landed. This PR does not deploy the Team server.

## Evidence

- Before the fix, six URL-contract cases and four route-loader cases failed on missing title generation/parsing/canonicalization; they pass with the change.
- 184 focused URL-contract, plugin SDK, Beam receiver/catalog, and UI routing tests passed. Another 54 native routing tests passed with the exact pinned dependencies.
- Chromium E2E passed for named, bare-ID, stale-title, legacy query, reload, non-main default agent, contextual navigation, and read-only behavior.
- The real Beam CLI uploaded a synthetic transcript to the actual receiver on loopback, renamed it, and resolved both URLs through the catalog. Identity and creation time stayed unchanged. The harness used synthetic authorization scope and in-memory storage; it was not a production authentication or storage test.
- The first hosted run caught a private-runtime import recommendation in the public SDK guide. The corrected guide now describes the supported catalog `name` field; the failing assertion reproduced locally and all 19 SDK package-contract tests now pass. Fresh review of the correction is clean.
- The Linux startup guard exposed a two-byte overrun near an already-full recorded baseline. Simplified the shared naming grammar and duplicate path parsing; no budget, allowance, or baseline changes. Existing slug behavior matched in 100,000 deterministic comparisons, including long input checks.
- Full `pnpm build` and `pnpm ui:build` passed, including startup budgets. Codex autoreview found no actionable P0–P2 findings.
- Production delta: +53/-31 (net +22, including the shared helper move); tests +118/-35; docs +71/-57. Production growth supplies named URL generation and uses existing canonical route ownership instead of introducing a second naming store or redirect path.

Before: legacy query link resolves the existing transcript.

![Legacy query link](https://github.com/user-attachments/assets/cb48aff5-0d02-4fb8-a50d-0d0974040010)

After: named link resolves the same read-only transcript.

![Named Beam link](https://github.com/user-attachments/assets/ad87c218-74d2-4e9b-93ef-04940cd81e9e)

Both screenshots were captured from the synthetic browser fixture and inspected before upload.
