### PR TITLE
perf: reduce repeated diagnostic lifecycle scans

### DIFF
--- a/src/infra/diagnostic-trace-propagation.test.ts
+++ b/src/infra/diagnostic-trace-propagation.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, expect, it, vi } from "vitest";
+import {
+  formatPropagatedDiagnosticTraceparent,
+  registerDiagnosticTracePropagationBridge,
+  resetDiagnosticTracePropagationForTest,
+} from "./diagnostic-trace-propagation.js";
+
+afterEach(resetDiagnosticTracePropagationForTest);
+
+it("shares exporter ordering and cleanup across module instances", async () => {
+  const trace = {
+    traceId: "1234567890abcdef1234567890abcdef",
+    spanId: "1234567890abcdef",
+  };
+  const older = { resolveTraceContext: () => ({ ...trace, traceFlags: "00" }) };
+  const current = { resolveTraceContext: () => undefined };
+  const stopOlder = registerDiagnosticTracePropagationBridge(older);
+  vi.resetModules();
+  const duplicate = await import("./diagnostic-trace-propagation.js");
+  const stopCurrent = duplicate.registerDiagnosticTracePropagationBridge(current);
+  const stopDuplicate = registerDiagnosticTracePropagationBridge(older);
+
+  expect(formatPropagatedDiagnosticTraceparent(trace)).toBeUndefined();
+  stopCurrent();
+  expect(duplicate.formatPropagatedDiagnosticTraceparent(trace)).toBe(
+    `00-${trace.traceId}-${trace.spanId}-00`,
+  );
+
+  const stopLatest = duplicate.registerDiagnosticTracePropagationBridge(current);
+  stopOlder();
+  stopDuplicate();
+  expect(formatPropagatedDiagnosticTraceparent(trace)).toBeUndefined();
+  stopLatest();
+  expect(formatPropagatedDiagnosticTraceparent(trace)).toBe(
+    `00-${trace.traceId}-${trace.spanId}-01`,
+  );
+
+  registerDiagnosticTracePropagationBridge(current);
+  duplicate.resetDiagnosticTracePropagationForTest();
+  expect(formatPropagatedDiagnosticTraceparent(trace)).toBe(
+    `00-${trace.traceId}-${trace.spanId}-01`,
+  );
+});

--- a/src/infra/diagnostic-trace-propagation.ts
+++ b/src/infra/diagnostic-trace-propagation.ts
@@ -69,7 +69,11 @@ function getDiagnosticTracePropagationState(): DiagnosticTracePropagationState {
 function activeDiagnosticTracePropagationBridge():
   | RegisteredDiagnosticTracePropagationBridge
   | undefined {
-  return Array.from(getDiagnosticTracePropagationState().bridges).at(-1);
+  let active: RegisteredDiagnosticTracePropagationBridge | undefined;
+  for (const bridge of getDiagnosticTracePropagationState().bridges) {
+    active = bridge;
+  }
+  return active;
 }
 
 export function registerDiagnosticTracePropagationBridge(

--- a/src/logging/diagnostic-embedded-run-index.ts
+++ b/src/logging/diagnostic-embedded-run-index.ts
@@ -12,18 +12,24 @@ export function createDiagnosticEmbeddedRunIndex<
       return undefined;
     }
     activity.activeEmbeddedRuns.delete(workKey);
-    const runIdStillActive = Array.from(activity.activeEmbeddedRuns.values()).some(
-      (candidate) => candidate.runId === embeddedRun.runId,
-    );
-    if (!runIdStillActive && runIdIndex.get(embeddedRun.runId) === activity) {
+    for (const candidate of activity.activeEmbeddedRuns.values()) {
+      if (candidate.runId === embeddedRun.runId) {
+        return embeddedRun;
+      }
+    }
+    if (runIdIndex.get(embeddedRun.runId) === activity) {
       runIdIndex.delete(embeddedRun.runId);
     }
     return embeddedRun;
   };
   const clear = (activity: TActivity): void => {
-    for (const workKey of Array.from(activity.activeEmbeddedRuns.keys())) {
-      remove(activity, workKey);
+    // Every local owner is leaving; only retain indexes now owned by another activity.
+    for (const { runId } of activity.activeEmbeddedRuns.values()) {
+      if (runIdIndex.get(runId) === activity) {
+        runIdIndex.delete(runId);
+      }
     }
+    activity.activeEmbeddedRuns.clear();
   };
   return { clear, remove };
 }

--- a/src/logging/diagnostic-embedded-run-index.ts
+++ b/src/logging/diagnostic-embedded-run-index.ts
@@ -12,12 +12,10 @@ export function createDiagnosticEmbeddedRunIndex<
       return undefined;
     }
     activity.activeEmbeddedRuns.delete(workKey);
-    for (const candidate of activity.activeEmbeddedRuns.values()) {
-      if (candidate.runId === embeddedRun.runId) {
-        return embeddedRun;
-      }
-    }
-    if (runIdIndex.get(embeddedRun.runId) === activity) {
+    const runIdStillActive = Array.from(activity.activeEmbeddedRuns.values()).some(
+      (candidate) => candidate.runId === embeddedRun.runId,
+    );
+    if (!runIdStillActive && runIdIndex.get(embeddedRun.runId) === activity) {
       runIdIndex.delete(embeddedRun.runId);
     }
     return embeddedRun;

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -188,7 +188,7 @@ export function getDiagnosticSessionState(ref: SessionRef): SessionState {
     queueDepth: 0,
   };
   diagnosticSessionStates.set(key, created);
-  pruneDiagnosticSessionStates(Date.now(), true);
+  pruneDiagnosticSessionStates();
   return created;
 }
 

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -40,7 +40,6 @@ import {
   diagnosticSessionStates,
   getDiagnosticSessionState,
   peekDiagnosticSessionState,
-  pruneDiagnosticSessionStates,
   resetDiagnosticSessionStateForTest,
 } from "./diagnostic-session-state.js";
 import {
@@ -214,17 +213,12 @@ describe("diagnostic session state pruning", () => {
   it("caps tracked session states to a bounded max", () => {
     const now = Date.now();
     for (let i = 0; i < 2001; i += 1) {
-      diagnosticSessionStates.set(`session-${i}`, {
-        sessionId: `session-${i}`,
-        lastActivity: now + i,
-        generation: 0,
-        state: "idle",
-        queueDepth: 1,
-      });
+      vi.setSystemTime(now + i);
+      getDiagnosticSessionState({ sessionKey: `session-${i}` }).queueDepth = 1;
     }
-    pruneDiagnosticSessionStates(now + 2002, true);
 
     expect(diagnosticSessionStates.size).toBe(2000);
+    expect(diagnosticSessionStates.has("session-0")).toBe(false);
   });
 
   it("reuses keyed session state when later looked up by sessionId", () => {

--- a/test/non-isolated-runner.test.ts
+++ b/test/non-isolated-runner.test.ts
@@ -98,6 +98,9 @@ function fixtureFiles(): Record<string, string> {
     path.join(repoRoot, "src", "infra", "agent-run-registry.ts"),
   );
   const agentEventsPath = JSON.stringify(path.join(repoRoot, "src", "infra", "agent-events.ts"));
+  const workAdmissionPath = JSON.stringify(
+    path.join(repoRoot, "src", "process", "gateway-work-admission.ts"),
+  );
   const activeSessionsPath = JSON.stringify(
     path.join(repoRoot, "src", "gateway", "active-sessions-shutdown-tracker.ts"),
   );
@@ -211,11 +214,15 @@ function fixtureFiles(): Record<string, string> {
       "",
     ].join("\n"),
     "05-a-agent-run.test.ts": [
+      `import { getActiveGatewayRootWorkCount, markGatewayRestartDraining, tryBeginGatewayRootWorkAdmission } from ${workAdmissionPath};`,
       `import { getAgentRunContext, registerAgentRunContext } from ${agentRunRegistryPath};`,
       `import { emitAgentEvent, onAgentEvent } from ${agentEventsPath};`,
       `import { listActiveSessionsForShutdown, noteActiveSessionForShutdown } from ${activeSessionsPath};`,
       'import { expect, it } from "vitest";',
       'it("seeds process-global run contexts", () => {',
+      "  expect(tryBeginGatewayRootWorkAdmission()).not.toBeNull();",
+      "  expect(getActiveGatewayRootWorkCount()).toBe(1);",
+      "  markGatewayRestartDraining();",
       '  noteActiveSessionForShutdown({ cfg: {}, sessionKey: "session-a", sessionId: "session-a", storePath: "/tmp/fixture.sqlite", agentId: "main" });',
       "  expect(listActiveSessionsForShutdown()).toHaveLength(1);",
       '  registerAgentRunContext("unrelated-run-a", { sessionKey: "session-a" });',
@@ -232,11 +239,16 @@ function fixtureFiles(): Record<string, string> {
       "",
     ].join("\n"),
     "05-b-agent-run.test.ts": [
+      `import { getActiveGatewayRootWorkCount, tryBeginGatewayRootWorkAdmission } from ${workAdmissionPath};`,
       `import { clearAgentRunContext, getAgentRunContext, registerAgentRunContext, sweepStaleRunContexts } from ${agentRunRegistryPath};`,
       `import { emitAgentEvent, onAgentEvent } from ${agentEventsPath};`,
       `import { listActiveSessionsForShutdown } from ${activeSessionsPath};`,
       'import { expect, it } from "vitest";',
       'it("clears agent run registry state", () => {',
+      "  expect(getActiveGatewayRootWorkCount()).toBe(0);",
+      "  const admission = tryBeginGatewayRootWorkAdmission();",
+      "  expect(admission).not.toBeNull();",
+      "  admission?.release();",
       "  expect(listActiveSessionsForShutdown()).toEqual([]);",
       '  registerAgentRunContext("reused-run", { sessionKey: "reused-session" });',
       "  let sequence;",

--- a/test/non-isolated-runner.ts
+++ b/test/non-isolated-runner.ts
@@ -8,6 +8,7 @@ import { TestRunner, type RunnerTask, type RunnerTestFile, vi } from "vitest";
 import { resetAgentEventsForTest } from "../src/infra/agent-events.js";
 import { loggingState } from "../src/logging/state.js";
 import { clearNamedPluginRuntimeStoresForTest } from "../src/plugin-sdk/runtime-store-registry.js";
+import { resetGatewayWorkAdmission } from "../src/process/gateway-work-admission.js";
 import { drainGlobalSingletonLifecycleState } from "../src/shared/global-singleton.js";
 import {
   type CustomElementTracking,
@@ -489,6 +490,9 @@ export default class OpenClawNonIsolatedRunner extends TestRunner {
     // Lifecycle-owned singletons survive module resets; close them before the next file
     // can observe a previous file's sessions, caches, or registered resources.
     await drainGlobalSingletonLifecycleState();
+    // Finish file-owned teardown before retiring its admission leases and
+    // reopening the shared worker for the next file.
+    resetGatewayWorkAdmission();
     // Named plugin runtimes intentionally survive duplicate module evaluation in production.
     // Clear their shared slots here so one test file cannot lend a partial runtime to the next.
     clearNamedPluginRuntimeStoresForTest();


### PR DESCRIPTION
## What Problem This Solves

Busy Gateways spend unnecessary synchronous work maintaining diagnostic session and exporter state. Bulk embedded-run cleanup repeatedly scans the shrinking collection, new sessions force a full prune even below the cap, and trace preparation allocates an array just to select the current exporter.

## Why This Change Was Made

Clear a session's embedded-run indexes in one pass while preserving indexes rehomed to another activity. Let session creation use the existing prune interval and synchronous size guard. Walk the authoritative shared bridge Set directly, preserving duplicate registration, exporter ordering, cleanup, and cross-module visibility without introducing a cache.

These are three separate measured mechanisms. An attempted optimization of individual run removal was dropped after broader controls failed to establish a reliable benefit; that path remains unchanged.

## User Impact

Lower diagnostic housekeeping cost without changing run recovery, exporter selection, queue accounting, or the 2,000-session bound. Expired idle diagnostic entries may remain until the existing interval or forced heartbeat rather than being swept on every new session. No configuration, persistent storage, protocol, or authorization surface changes.

Production LOC: +12/-4 (net +8). Tests and test support: +62/-9 (net +53), including the CI isolation repair below. The small production growth replaces repeated bulk teardown with a direct ownership-preserving pass and removes per-event array allocation.

## Evidence

- 159 focused tests passed across diagnostic events, session pruning/aliases, embedded run activity/recovery, trace propagation, and plugin service replacement. The cap test now reaches the real session-creation owner; the new bridge test covers registration order, duplicate registration, inactive cleanup, restoration, reset, and duplicate module instances.
- Full changed-file checks passed, including core/test type checks, lint, guards, dead exports, and import cycles. A subsequent single-file reversal passed the focused tests and lint again.
- Fresh managed Codex autoreview passed after removing the proposed bridge cache and supplying the complete pruning owner for review. Independent source review checked callers, siblings, lifecycle ownership, and measurement limitations.
- Source-bound Node 26.8.1 owner fixtures in fresh processes and both orders: a 2,048-owner clear was 3.056–3.067 ms before and 0.050–0.051 ms after; creating 2,000 keyed sessions was 8.076–8.182 ms before and 0.289–0.292 ms after; 10,000 trace selections with one exporter were 0.107–0.111 ms before and 0.051–0.053 ms after. Empty/single and larger controls are retained. These are isolated costs, not whole-agent latency or RSS claims. The byte-identical unique/late-match individual-removal control still differs by roughly 0.8 microseconds across bundle contexts; that unresolved JIT/context-sensitive result is retained, not claimed as an algorithm gain or regression.
- Separate operation instrumentation: bulk-clear visits fell from 2,096,128 to 2,048, and keyed creation's prune visits from 2,001,000 to zero below the cap. Randomized ownership equivalence covered 500 scenarios and 10,000 individual removals, including rehomed indexes.
- Full build passed. The built, isolated dev Gateway completed three real OpenAI turns (one short turn and two web-fetch turns), with five successful HTTP responses and clean shutdown. Agent durations were 1.704 / 5.695 / 3.883 seconds; these are smoke observations, not comparative speed claims. Two Node CPU profiles are retained for discovery. The subsequent changes are test-only, so the measured and live-tested production bytes remain identical.

Local proof: `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/logging/diagnostic.test.ts src/logging/diagnostic-run-activity.test.ts src/infra/diagnostic-events.test.ts src/infra/diagnostic-trace-propagation.test.ts src/plugins/services.replacement.test.ts`; `node scripts/check-changed.mjs -- <the five changed files>`; `pnpm build`. Raw source hashes, samples, rejected variants, operation counts, and review receipts are retained in the local campaign artifacts.

## CI repair and review follow-through

The first exact-head CI run reproduced the existing main failure in the first desktop-shutdown case: an active root count of one where zero was required ([PR run](https://github.com/openclaw/openclaw/actions/runs/33329877159/job/99306524919), [main run](https://github.com/openclaw/openclaw/actions/runs/33328805132/job/99303738752)). The shared non-isolated runner drained lifecycle owners but left the process-global admission singleton alive between files.

The existing alphabetical, single-worker producer/observer fixture now leaves a real admission lease and restart fence in the producer. Before the repair its observer fails with exactly 1 versus 0. File-boundary cleanup now calls the existing admission reset only after resource teardown. The same fixture passes, as do all six original desktop-shutdown cases and 24 admission-owner tests. No desktop assertion, production shutdown path, retry, or timeout changed. The precise predecessor responsible in hosted CI is not claimed to be identified. This test-only cleanup is not counted as a fourth performance mechanism.

The latest ClawSweeper review found no source defect; its rank-up move requests completed exact-head CI and retained final Gateway proof. Gateway proof is complete and recorded above; the refreshed [exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33330615984) passed, including the original failing shard. Fresh managed Codex review found no actionable issues in the combined source and test changes.
