### PR TITLE
fix: Stop waits for pending SSH workspace cleanup

### DIFF
--- a/src/gateway/desktop/host-observe.integration.test.ts
+++ b/src/gateway/desktop/host-observe.integration.test.ts
@@ -1,3 +1,4 @@
+import { on } from "node:events";
 import http from "node:http";
 import net from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -43,29 +44,19 @@ class SocketReader {
 }
 
 class WebSocketReader {
-  private readonly chunks: Buffer[] = [];
-  private readonly waiters: Array<(chunk: Buffer) => void> = [];
+  private readonly messages: AsyncIterator<unknown[]>;
 
   constructor(ws: WebSocket) {
-    ws.on("message", (data: RawData) => {
-      const chunk = Buffer.isBuffer(data) ? data : Buffer.from(data as ArrayBuffer);
-      const waiter = this.waiters.shift();
-      if (waiter) {
-        waiter(chunk);
-      } else {
-        this.chunks.push(chunk);
-      }
-    });
+    this.messages = on(ws, "message", { close: ["close"] });
   }
 
   async next(): Promise<Buffer> {
-    const chunk = this.chunks.shift();
-    return (
-      chunk ??
-      (await new Promise<Buffer>((resolve) => {
-        this.waiters.push(resolve);
-      }))
-    );
+    const message = await this.messages.next();
+    if (message.done) {
+      throw new Error("WebSocket closed before the next RFB frame");
+    }
+    const [data] = message.value as [RawData];
+    return Buffer.isBuffer(data) ? data : Buffer.from(data as ArrayBuffer);
   }
 }
 
@@ -136,7 +127,7 @@ describe("gateway host desktop observe integration", () => {
         }),
     );
 
-    const registry = createDesktopSessionRegistry({ lingerMs: 10 });
+    const registry = createDesktopSessionRegistry();
     const service = createHostDesktopService({
       config: { enabled: true, port: rfbAddress.port },
       registry,

--- a/src/gateway/worker-environments/tunnel.test.ts
+++ b/src/gateway/worker-environments/tunnel.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import { setImmediate } from "node:timers/promises";
 import { describe, expect, it, vi } from "vitest";
 import { createWorkerSshRunner } from "./tunnel-ssh-runner.js";
 import { createWorkerTunnelManager } from "./tunnel.js";
@@ -147,24 +149,184 @@ describe("worker tunnel manager", () => {
     await replacement.stop();
   });
 
-  it("fails initialization that loses ownership before identity preparation completes", async () => {
-    const identity = deferred<Awaited<ReturnType<typeof resolveIdentity>>>();
-    const fake = fakeRunner();
-    const manager = createWorkerTunnelManager({ runner: fake.runner });
-    const starting = manager.start({
-      environmentId: "worker:pending",
-      ownerEpoch: 1,
-      bundleHash: "a".repeat(64),
-      ssh: SSH,
-      resolveIdentity: async () => await identity.promise,
+  it.each(["stop", "stopAll"] as const)(
+    "joins %s while identity preparation drains",
+    async (operation) => {
+      const identity = deferred<Awaited<ReturnType<typeof resolveIdentity>>>();
+      const preparing = deferred<void>();
+      const fake = fakeRunner();
+      const manager = createWorkerTunnelManager({ runner: fake.runner });
+      const starting = manager.start({
+        environmentId: "worker:pending",
+        ownerEpoch: 1,
+        bundleHash: "a".repeat(64),
+        ssh: SSH,
+        resolveIdentity: async () => {
+          preparing.resolve();
+          return await identity.promise;
+        },
+      });
+      const rejected = expect(starting).rejects.toThrow(
+        "Worker tunnel owner is no longer connected",
+      );
+      await preparing.promise;
+      const stops = [
+        operation === "stop" ? manager.stop("worker:pending", 1) : manager.stopAll(),
+        manager.stop("worker:pending", 1),
+        manager.stopAll(),
+      ];
+      const settled = vi.fn();
+      stops.forEach((stopping) => void stopping.then(settled));
+      try {
+        await setImmediate();
+        expect(manager.status("worker:pending")).toBe("stopped");
+        expect(settled).not.toHaveBeenCalled();
+      } finally {
+        identity.resolve(await resolveIdentity());
+        await Promise.all([...stops, rejected]);
+      }
+    },
+  );
+
+  it.each(["stop", "stopAll"] as const)(
+    "joins reentrant %s until workspace commands release their SSH files",
+    async (operation) => {
+      const entered = deferred<void>();
+      const command = deferred<ReturnType<typeof success>>();
+      let reentered: Promise<void> | undefined;
+      let knownHostsPath = "";
+      const fake = fakeRunner(async (argv, options) => {
+        knownHostsPath = argv
+          .find((arg) => arg.startsWith("UserKnownHostsFile="))!
+          .slice("UserKnownHostsFile=".length);
+        options.signal!.addEventListener(
+          "abort",
+          () => {
+            reentered =
+              operation === "stop" ? manager.stop("worker:command", 1) : manager.stopAll();
+          },
+          { once: true },
+        );
+        entered.resolve();
+        return await command.promise;
+      });
+      const manager = createWorkerTunnelManager({ runner: fake.runner });
+      const handle = await startTestTunnel(manager, "worker:command", 1);
+      const running = handle.runWorkspaceCommand(PWD_COMMAND);
+      await entered.promise;
+      const stopping = handle.stop();
+      const settled = vi.fn();
+      void reentered!.then(settled);
+      try {
+        await setImmediate();
+        expect(settled).not.toHaveBeenCalled();
+        await expect(fs.access(knownHostsPath)).resolves.toBeUndefined();
+        await expect(handle.runWorkspaceCommand(PWD_COMMAND)).rejects.toThrow(
+          "no longer connected",
+        );
+      } finally {
+        command.resolve(success());
+        await Promise.all([running, stopping, reentered]);
+      }
+      await expect(fs.access(knownHostsPath)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
+  it.each([
+    { ownerEpoch: 1, stopAgain: false },
+    { ownerEpoch: 1, stopAgain: true },
+    { ownerEpoch: 2, stopAgain: true },
+  ])(
+    "waits for SSH cleanup before replacement epoch $ownerEpoch (stop again: $stopAgain)",
+    async ({ ownerEpoch, stopAgain }) => {
+      const entered = deferred<void>();
+      const command = deferred<ReturnType<typeof success>>();
+      let knownHostsPath = "";
+      const fake = fakeRunner(async (argv) => {
+        knownHostsPath = argv
+          .find((arg) => arg.startsWith("UserKnownHostsFile="))!
+          .slice("UserKnownHostsFile=".length);
+        entered.resolve();
+        return await command.promise;
+      });
+      const manager = createWorkerTunnelManager({ runner: fake.runner });
+      const first = await startTestTunnel(manager, "worker:replacement", 1);
+      const running = first.runWorkspaceCommand(PWD_COMMAND);
+      await entered.promise;
+      const stopping = first.stop();
+      const nextIdentity = vi.fn(async () => {
+        await expect(fs.access(knownHostsPath)).rejects.toMatchObject({ code: "ENOENT" });
+        return await resolveIdentity();
+      });
+      const replacing = manager.start({
+        environmentId: "worker:replacement",
+        ownerEpoch,
+        bundleHash: "a".repeat(64),
+        ssh: SSH,
+        resolveIdentity: nextIdentity,
+      });
+      void replacing.catch(() => undefined);
+      const retainedStop = stopAgain ? manager.stop("worker:replacement", 1) : undefined;
+      const stopped = vi.fn();
+      void retainedStop?.then(stopped);
+      try {
+        await setImmediate();
+        expect(stopped).not.toHaveBeenCalled();
+        expect(nextIdentity).not.toHaveBeenCalled();
+        expect(manager.status("worker:replacement")).toBe(
+          ownerEpoch === 1 && stopAgain ? "stopped" : "connecting",
+        );
+        command.resolve(success());
+        await Promise.all([running, stopping, retainedStop]);
+        if (ownerEpoch === 1 && stopAgain) {
+          await expect(replacing).rejects.toThrow("no longer connected");
+          expect(nextIdentity).not.toHaveBeenCalled();
+        } else {
+          const replacement = await replacing;
+          expect(nextIdentity).toHaveBeenCalledOnce();
+          await expect(replacement.runWorkspaceCommand(PWD_COMMAND)).resolves.toEqual(success());
+        }
+      } finally {
+        command.resolve(success());
+        await Promise.all([running, stopping, retainedStop, replacing.catch(() => undefined)]);
+        await manager.stopAll();
+      }
+    },
+  );
+
+  it("joins a replacement's initialization when prior-owner abort reenters Stop", async () => {
+    const entered = deferred<void>();
+    const command = deferred<ReturnType<typeof success>>();
+    let shutdown: Promise<void> | undefined;
+    const settled = vi.fn();
+    const fake = fakeRunner(async (_argv, options) => {
+      options.signal!.addEventListener(
+        "abort",
+        () => {
+          shutdown = manager.stopAll();
+          void shutdown.then(settled);
+        },
+        { once: true },
+      );
+      entered.resolve();
+      return await command.promise;
     });
-
-    const stopping = manager.stop("worker:pending", 1);
-    identity.resolve(await resolveIdentity());
-
-    await stopping;
-    await expect(starting).rejects.toThrow("Worker tunnel owner is no longer connected");
-    expect(manager.status("worker:pending")).toBe("stopped");
+    const manager = createWorkerTunnelManager({ runner: fake.runner });
+    const first = await startTestTunnel(manager, "worker:reentrant-replacement", 1);
+    const running = first.runWorkspaceCommand(PWD_COMMAND);
+    await entered.promise;
+    const replacing = startTestTunnel(manager, "worker:reentrant-replacement", 2);
+    const rejected = expect(replacing).rejects.toThrow("no longer connected");
+    try {
+      expect(shutdown).toBeDefined();
+      await setImmediate();
+      expect(settled).not.toHaveBeenCalled();
+      expect(manager.status("worker:reentrant-replacement")).toBe("stopped");
+    } finally {
+      command.resolve(success());
+      await Promise.all([running, shutdown, rejected]);
+    }
+    expect(fake.runs).toHaveLength(1);
   });
 });
 

--- a/src/gateway/worker-environments/tunnel.ts
+++ b/src/gateway/worker-environments/tunnel.ts
@@ -1,4 +1,5 @@
 import type { WorkerSshEndpoint } from "../../plugins/types.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import type { DesktopSessionRegistry } from "../desktop/session-registry.js";
 import { createWorkerDesktopTunnels } from "./desktop-tunnel.js";
 import { prepareWorkerSsh, type PreparedWorkerSsh, type WorkerSshIdentityResolver } from "./ssh.js";
@@ -29,7 +30,7 @@ type TunnelEntry = {
   abortController: AbortController;
   status: Exclude<WorkerTunnelStatus, "stopped">;
   prepared?: PreparedWorkerSsh;
-  initialization?: Promise<WorkerTunnelHandle>;
+  initialization: Promise<WorkerTunnelHandle>;
   stopPromise?: Promise<void>;
   workspaceTasks: Set<Promise<unknown>>;
 };
@@ -56,6 +57,7 @@ export function createWorkerTunnelManager(options: WorkerTunnelManagerOptions = 
     ...(options.desktopSessionRegistry ? { registry: options.desktopSessionRegistry } : {}),
   });
   const entries = new Map<string, TunnelEntry>();
+  const owners = new Set<TunnelEntry>();
   const claimedOwnerEpochs = new Map<string, number>();
 
   const isCurrent = (entry: TunnelEntry) =>
@@ -89,15 +91,21 @@ export function createWorkerTunnelManager(options: WorkerTunnelManagerOptions = 
     if (entry.stopPromise) {
       return entry.stopPromise;
     }
-    entry.stopPromise = (async () => {
-      if (entries.get(entry.environmentId) === entry) {
-        entries.delete(entry.environmentId);
-      }
-      entry.abortController.abort(new Error("Worker tunnel owner stopped"));
-      await entry.initialization?.catch(() => undefined);
+    // Abort callbacks can reenter Stop. Publish the shared close before fencing
+    // input, and retain cleanup custody after this owner leaves the live index.
+    const stopped = createDeferredCore();
+    entry.stopPromise = stopped.promise;
+    if (entries.get(entry.environmentId) === entry) {
+      entries.delete(entry.environmentId);
+    }
+    entry.abortController.abort(new Error("Worker tunnel owner stopped"));
+    void (async () => {
+      await entry.initialization.catch(() => undefined);
       await Promise.allSettled(entry.workspaceTasks);
       await entry.prepared?.dispose().catch(() => undefined);
-    })();
+    })()
+      .finally(() => owners.delete(entry))
+      .then(stopped.resolve, stopped.reject);
     return entry.stopPromise;
   };
 
@@ -109,15 +117,12 @@ export function createWorkerTunnelManager(options: WorkerTunnelManagerOptions = 
     }
     claimedOwnerEpochs.set(request.environmentId, request.ownerEpoch);
     const current = entries.get(request.environmentId);
-    if (current) {
-      if (request.ownerEpoch < current.ownerEpoch) {
-        throw new Error("Worker tunnel owner epoch is stale");
-      }
-      if (request.ownerEpoch === current.ownerEpoch) {
-        return await current.initialization!;
-      }
+    if (current?.ownerEpoch === request.ownerEpoch) {
+      return await current.initialization;
     }
 
+    const previous = [...owners].filter((owner) => owner.environmentId === request.environmentId);
+    const initializing = createDeferredCore<WorkerTunnelHandle>();
     const entry: TunnelEntry = {
       environmentId: request.environmentId,
       bundleHash: request.bundleHash,
@@ -126,13 +131,14 @@ export function createWorkerTunnelManager(options: WorkerTunnelManagerOptions = 
       abortController: new AbortController(),
       status: "connecting",
       workspaceTasks: new Set(),
+      initialization: initializing.promise,
     };
-    // Publish the new owner before waiting for prior teardown so stop/drain can fence initialization.
+    // Publish initialization before retiring prior owners: their abort callbacks
+    // may stop this replacement, which must still join the entire cleanup chain.
+    owners.add(entry);
     entries.set(request.environmentId, entry);
-    entry.initialization = (async () => {
-      if (current) {
-        await stopEntry(current);
-      }
+    void (async () => {
+      await Promise.all(previous.map(stopEntry));
       if (!isCurrent(entry)) {
         throw new WorkerTunnelOwnerDisconnectedError();
       }
@@ -149,7 +155,7 @@ export function createWorkerTunnelManager(options: WorkerTunnelManagerOptions = 
       entry.prepared = prepared;
       entry.status = "connected";
       return createHandle(entry);
-    })();
+    })().then(initializing.resolve, initializing.reject);
     try {
       return await entry.initialization;
     } catch (error) {
@@ -159,20 +165,20 @@ export function createWorkerTunnelManager(options: WorkerTunnelManagerOptions = 
   }
 
   async function stop(environmentId: string, ownerEpoch?: number): Promise<void> {
-    const entry = entries.get(environmentId);
-    if (entry && (ownerEpoch === undefined || ownerEpoch === entry.ownerEpoch)) {
-      await stopEntry(entry);
-    }
+    await Promise.all(
+      [...owners]
+        .filter(
+          (entry) =>
+            entry.environmentId === environmentId &&
+            (ownerEpoch === undefined || ownerEpoch === entry.ownerEpoch),
+        )
+        .map(stopEntry),
+    );
     await desktop.stop(environmentId, ownerEpoch);
   }
 
   async function stopAll(): Promise<void> {
-    const current = [...entries.values()];
-    entries.clear();
-    for (const entry of current) {
-      entry.abortController.abort(new Error("Worker tunnel manager stopped"));
-    }
-    await Promise.all([...current.map(stopEntry), desktop.stopAll()]);
+    await Promise.all([...[...owners].map(stopEntry), desktop.stopAll()]);
   }
 
   return {


### PR DESCRIPTION
Closes #133455

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users stopping or replacing a cloud worker could see Stop complete while an earlier SSH workspace operation or identity cleanup was still running. Repeated Stop and gateway shutdown could lose track of an owner whose cleanup had already begun.

## Why This Change Was Made

Keep the active workspace index for immediate input fencing, while retaining each exact owner until initialization, dispatched workspace commands, and SSH file disposal have settled. Publish shared initialization and close promises before abort callbacks can reenter the manager, so repeated/global Stop and same-epoch or newer-epoch replacement all join the canonical cleanup.

## User Impact

Stop waits for the workspace resources it owns to finish cleanup, including when Stop is repeated during an existing cleanup. Replacement workers wait for prior workspace cleanup; retained handles remain disconnected immediately, and an old epoch's Stop does not cancel a newer owner.

No configuration, database, dependency, protocol, or public API changes. The desktop and node tunnel owners retain their existing contracts. A nearby host-observe integration fixture now uses the normal attachment window and reports premature WebSocket closure promptly.

## Evidence

- Before the production repair, the final regression suite produced **8 failures and 6 passes** with no unhandled errors. The failing cases cover pending identity resolution, repeated/global and reentrant Stop, blocked dispatched commands, and replacement startup.
- After the final repair, **82 tests passed across 8 files**: workspace tunnel, desktop tunnel, environment access, workspace sync tunnel, node worker lifecycle, host/node observe integration, and desktop attachment lifecycle.
- Five initial shuffled runs passed **70 workspace tunnel test executions**. After the nearby fixture repair, five shuffled runs (seeds 1–5) passed **95 additional tests** across workspace tunnel and host/node observe integration.
- Regressions exercise real local SSH temporary files and verify they remain present while a dispatched command is blocked, are removed before cleanup completes, and are gone before replacement identity preparation. They also verify retained handles reject and live replacements can execute commands.
- Full final changed-file gate passed, including core and core-test TypeScript checks, lint, format, dead-export scans, and ownership/boundary guards.
- `git diff --check` passed. Independent Codex autoreview completed with no actionable findings at its **P0-only** threshold; a separate source review found no additional issues.
- Production delta: **+37/-31, net +6 lines**. The additional state retains cleanup ownership independently of the active lookup without adding a second cleanup path. Test delta: **+188/-35, net +153 lines**, including a **net reduction of 9 lines** in the host-observe fixture.

The first hosted CI run failed only in `host-observe.integration.test.ts`, which timed out while waiting for a frame after its artificial **10 ms** idle deadline expired. A controlled **30 ms** delay between observation and WebSocket attachment reproduced close code **1013**, with only the probe connection established; removing the unrelated deadline override made that identical ordering pass. The fixture now uses the production default, and Node’s close-aware event iterator replaces its custom frame queue. No production timeout was changed. [Initial failed job](https://github.com/openclaw/openclaw/actions/runs/33330818962/job/99309002422).

Focused command:

```sh
node scripts/run-vitest.mjs src/gateway/worker-environments/tunnel.test.ts src/gateway/worker-environments/desktop-tunnel.test.ts src/gateway/worker-environments/environment-access.test.ts src/gateway/worker-environments/workspace-sync-tunnel.test.ts src/gateway/worker-environments/node-worker-tunnel.lifecycle.test.ts src/gateway/desktop/host-observe.integration.test.ts src/gateway/desktop/node-observe.integration.test.ts src/gateway/desktop/attachment.test.ts
node scripts/check-changed.mjs -- src/gateway/worker-environments/tunnel.ts src/gateway/worker-environments/tunnel.test.ts src/gateway/desktop/host-observe.integration.test.ts
```

This is deterministic lifecycle proof with a controlled SSH runner, not a live cloud-worker run. The failure requires deliberately holding initialization or command completion across concurrent Stop/replacement calls; the regression fixture controls that ordering and observes the actual local file cleanup boundary. No provider API behavior changes.

AI-assisted implementation and review.
