### PR TITLE
fix(talk): report browser input transcription failures

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -4092,7 +4092,7 @@ ui/src/pages/chat/performance.ts	1
 ui/src/pages/chat/realtime-talk-gateway-relay.ts	1
 ui/src/pages/chat/realtime-talk-google-live.ts	2
 ui/src/pages/chat/realtime-talk-shared.ts	7
-ui/src/pages/chat/realtime-talk-webrtc.ts	3
+ui/src/pages/chat/realtime-talk-webrtc.ts	2
 ui/src/pages/chat/realtime-talk.ts	2
 ui/src/pages/chat/run-lifecycle.ts	1
 ui/src/pages/chat/scroll.ts	1

--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -65,6 +65,10 @@ Browser Talk acquires the microphone before creating the provider session, so
 time spent granting permission does not consume a short-lived connection token.
 If session creation fails, Talk releases the microphone before reporting the error.
 
+If OpenAI cannot transcribe an utterance, browser Talk shows the provider's error
+without ending the call or inventing a transcript. You can speak again; audio
+responses continue independently of input transcription.
+
 If the microphone disconnects or its permission is revoked, browser Talk ends
 the call and shows an error. Choose an available **Microphone input**, restore
 permission if needed, and start Talk again. An unexpected GPT-Live connection

--- a/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
@@ -3,7 +3,9 @@ import { expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import {
   captureComposerProof,
+  captureMicrophoneLossProof,
   captureVideoTalkProof,
+  dispatchOpenAiTalkEvent,
   installBlockedMicrophoneFixture,
   installBlockedVideoTalkFixture,
   installTalkBrowserFixtures,
@@ -446,6 +448,21 @@ suite.define(() => {
         ).openclawVideoTalkE2e?.peer.channel;
         channel?.dispatchEvent(new Event("open"));
       });
+      await dispatchOpenAiTalkEvent(page, {
+        type: "conversation.item.input_audio_transcription.failed",
+        item_id: "unintelligible-input",
+        error: { message: "The audio could not be transcribed." },
+      });
+      await captureMicrophoneLossProof(page, "input-transcription-error.png");
+      const transcriptionError = page.getByRole("alert").filter({
+        hasText: "The audio could not be transcribed.",
+      });
+      await expect.poll(() => transcriptionError.isVisible()).toBe(true);
+      expect(await page.getByRole("button", { name: "Stop voice input" }).isVisible()).toBe(true);
+      await dispatchOpenAiTalkEvent(page, {
+        type: "input_audio_buffer.speech_started",
+        item_id: "next-input",
+      });
       const turnCameraOn = page.getByRole("button", { name: "Turn camera on" });
       await expect.poll(() => turnCameraOn.isEnabled()).toBe(true);
       await turnCameraOn.click();
@@ -465,33 +482,22 @@ suite.define(() => {
       );
       await captureVideoTalkProof(page, "02-live-camera-preview.png");
 
-      await page.evaluate(() => {
-        const channel = (
-          window as Window & {
-            openclawVideoTalkE2e?: { peer: { channel: EventTarget } };
-          }
-        ).openclawVideoTalkE2e?.peer.channel;
-        channel?.dispatchEvent(
-          new MessageEvent("message", {
-            data: JSON.stringify({
-              type: "response.done",
-              response: {
-                id: "response-camera",
-                status: "completed",
-                output: [
-                  {
-                    type: "function_call",
-                    id: "item-camera",
-                    status: "completed",
-                    call_id: "call-camera",
-                    name: "describe_view",
-                    arguments: "{}",
-                  },
-                ],
-              },
-            }),
-          }),
-        );
+      await dispatchOpenAiTalkEvent(page, {
+        type: "response.done",
+        response: {
+          id: "response-camera",
+          status: "completed",
+          output: [
+            {
+              type: "function_call",
+              id: "item-camera",
+              status: "completed",
+              call_id: "call-camera",
+              name: "describe_view",
+              arguments: "{}",
+            },
+          ],
+        },
       });
       await expect
         .poll(() =>

--- a/ui/src/e2e/browser-talk-start-stop.fixtures.ts
+++ b/ui/src/e2e/browser-talk-start-stop.fixtures.ts
@@ -2,6 +2,18 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 
+export async function dispatchOpenAiTalkEvent(page: Page, event: unknown) {
+  await page.evaluate((payload) => {
+    const channel = (
+      window as Window & { openclawVideoTalkE2e?: { peer: { channel: EventTarget } } }
+    ).openclawVideoTalkE2e?.peer.channel;
+    if (!channel) {
+      throw new Error("Expected the browser Talk data channel");
+    }
+    channel.dispatchEvent(new MessageEvent("message", { data: JSON.stringify(payload) }));
+  }, event);
+}
+
 export type WebRtcSdpE2eProof = {
   bodyCancelCount: number;
   bodyCancelResolvedCount: number;

--- a/ui/src/pages/chat/realtime-talk-webrtc.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.test.ts
@@ -489,40 +489,43 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     transport.stop();
   });
 
-  it("surfaces realtime provider errors from the OpenAI data channel", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response("answer-sdp")) as unknown as typeof fetch,
-    );
-    const onStatus = vi.fn();
-    const transport = new WebRtcSdpRealtimeTalkTransport(
-      {
-        provider: "openai",
-        transport: "webrtc",
-        clientSecret: "client-secret-123",
-      },
-      {
-        input: await prepareRealtimeTalkTestInput(),
-        client: {} as never,
-        sessionKey: "main",
-        callbacks: { onStatus },
-      },
-    );
+  it.each(["error", "conversation.item.input_audio_transcription.failed"])(
+    "surfaces %s without closing the OpenAI data channel",
+    async (type) => {
+      stubAnswerSdpFetch();
+      const onStatus = vi.fn();
+      const onTalkEvent = vi.fn();
+      const onTranscript = vi.fn();
+      const transport = await createOpenAiTransport({}, { onStatus, onTalkEvent, onTranscript });
 
-    await transport.start();
-    const peer = FakePeerConnection.instances[0];
-    peer?.channel.dispatchEvent(
-      new MessageEvent("message", {
-        data: JSON.stringify({
-          type: "error",
-          error: { message: "Realtime model rejected the session" },
+      await transport.start();
+      const peer = requirePeer();
+      const itemId = type === "error" ? undefined : "failed-input";
+      dispatchRealtimeEvent(peer, {
+        type,
+        item_id: itemId,
+        error: { message: "The audio could not be transcribed." },
+      });
+
+      expect(onStatus).toHaveBeenCalledWith("error", "The audio could not be transcribed.");
+      expect(onTalkEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "session.error",
+          itemId,
+          payload: { message: "The audio could not be transcribed." },
         }),
-      }),
-    );
-
-    expect(onStatus).toHaveBeenCalledWith("error", "Realtime model rejected the session");
-    transport.stop();
-  });
+      );
+      expect(onTranscript).not.toHaveBeenCalled();
+      expect(peer.channel.readyState).toBe("open");
+      dispatchTranscription(peer, "Please try again");
+      expect(onTranscript).toHaveBeenCalledWith({
+        role: "user",
+        text: "Please try again",
+        final: true,
+      });
+      transport.stop();
+    },
+  );
 
   it("surfaces speech and response lifecycle status from the OpenAI data channel", async () => {
     vi.stubGlobal(
@@ -902,6 +905,30 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     const sent = sentRealtimeEvents(peer);
     expectSpokenStatusMessage(sent, "OpenClaw is working in read (running).");
     expect(sent).toContainEqual({ type: "response.create" });
+
+    // ASR may fail while a requested response is awaiting response.created.
+    dispatchRealtimeEvent(peer, {
+      type: "conversation.item.input_audio_transcription.failed",
+      item_id: "failed-input",
+      error: { code: "audio_unintelligible" },
+    });
+    dispatchTranscription(peer, "status");
+    await waitForFast(() =>
+      expect(
+        sentRealtimeEvents(peer).filter((event) => event.type === "conversation.item.create"),
+      ).toHaveLength(2),
+    );
+    expect(
+      sentRealtimeEvents(peer).filter((event) => event.type === "response.create"),
+    ).toHaveLength(1);
+    dispatchRealtimeEvent(peer, { type: "response.created", response: { id: "response-2" } });
+    dispatchRealtimeEvent(peer, {
+      type: "response.done",
+      response: { id: "response-2", status: "completed" },
+    });
+    expect(
+      sentRealtimeEvents(peer).filter((event) => event.type === "response.create"),
+    ).toHaveLength(2);
     transport.stop();
   });
 

--- a/ui/src/pages/chat/realtime-talk-webrtc.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.ts
@@ -417,11 +417,16 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
         return;
       }
       case "error":
-        this.responseCreateInFlight = false;
+      case "conversation.item.input_audio_transcription.failed":
+        // ASR runs independently; its failure cannot settle a pending response request.
+        if (event.type === "error") {
+          this.responseCreateInFlight = false;
+        }
         this.ctx.callbacks.onStatus?.("error", this.extractErrorDetail(event.error));
         this.emitTalkEvent({
           type: "session.error",
           final: true,
+          itemId: event.item_id,
           payload: { message: this.extractErrorDetail(event.error) },
         });
 
@@ -480,10 +485,7 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
   }
 
   private extractErrorDetail(error: unknown): string {
-    if (!error || typeof error !== "object") {
-      return "Realtime provider error";
-    }
-    const record = error as Record<string, unknown>;
+    const record = isRecord(error) ? error : {};
     const message = typeof record.message === "string" ? record.message.trim() : "";
     const code = typeof record.code === "string" ? record.code.trim() : "";
     const type = typeof record.type === "string" ? record.type.trim() : "";


### PR DESCRIPTION
Closes #133448

## What Problem This Solves

Fixes an issue where browser Talk silently ignored OpenAI input-transcription failures. Audio and responses could continue while the operator received no explanation for the missing user transcript.

## Why This Change Was Made

The WebRTC transport now sends the item-specific failure through its existing status and Talk event callbacks, retaining the affected item ID. Input transcription runs independently of response generation, so its failure does not release the pending response-create guard. The existing error normalizer now uses the shared record guard instead of a cast.

## User Impact

Browser Talk displays the provider's explanation and remains available for another utterance. It does not invent a transcript or end a recoverable call. No configuration, provider request, Gateway protocol, or stored-data shape changes.

## Evidence

The data-channel regression failed before the repair because no error callback ran. Afterward, 49 tests across the WebRTC transport and owning Talk session passed, including a transcription failure while response creation was pending, a later valid transcript, and resource cleanup.

A real Chromium Control UI run injected the documented provider failure through the data channel. Before the fix no alert appeared; afterward the alert was visible, Talk remained active, the next speech event recovered, and camera/tool/stop behavior still passed. This is deterministic browser proof using synthetic media and a mocked provider/Gateway, not an authenticated provider failure.

OpenAI's [server event contract](https://platform.openai.com/docs/api-reference/realtime-server-events/input_audio_buffer/committed?lang=node) defines transcription failure separately from generic errors. Direct sibling Codex inspection covered `codex-rs/codex-api/src/endpoint/realtime_websocket/protocol_v2.rs:24–79` at `63d213884daea50e4f74efc192cdc44f549b67d5`; that parser also omits this event, so it is not a behavior to copy. OpenClaw's backend sibling already reports it in `extensions/openai/realtime-voice-events.ts`.

Production delta: +7/-5 (net +2); tests/test support +104/-59; docs +4; assertion-count baseline +1/-1. The production growth preserves independent response state and item correlation in the existing error path; no new abstraction or fallback.

Fresh independent Codex autoreview through P2 was scoped-clean. The assertion-count baseline was reduced after removing the cast.

Before (no error reported):

![Browser Talk silently drops the transcription failure](https://github.com/user-attachments/assets/80fde314-f77c-4256-a172-ef46b96248a3)

After (visible error, call remains active):

![Browser Talk reports the transcription failure and keeps the stop control](https://github.com/user-attachments/assets/302ab803-7708-49b7-a1ae-9ad8887d223f)

The relevant Codex files are byte-identical to freshly fetched upstream main `94cbbddafc1776d5e377bca1b05932c697e82238`. Final focused type-aware lint and type checking passed. Local changed checks also passed owner/test/UI types, i18n, dead exports, and architecture guards; the initial lint findings (switch structure and test-file length) were corrected and the exact affected lint/browser checks rerun.

## Maintainer response to review

The authenticated ordinary-GA OAuth two-turn WebRTC run passed with the repaired transport: finalized user and assistant speech reached the Gateway and closed durable history without a Platform API key. That healthy run did not emit an ASR failure. The optional rank-up trace remains unavailable: the documented failure is a server-side transcription error, and this client has no supported operation that deterministically forces that service failure. We did not degrade credentials or send malformed traffic to manufacture it. The adverse event therefore uses the documented envelope through the actual browser handler; it is not presented as a live provider failure.

The net +2 production lines are accepted for independent response ownership and item correlation; extracting another error owner would add more code. The flagged fixture is test support only, not a persistent data model, so there is no storage migration. No duplicate fix job is needed.
