### PR TITLE
fix: stop cloud work before unrelated provider inspection finishes

### DIFF
--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -390,6 +390,8 @@ openclaw gateway call sessions.reclaim \
 
 Calling `sessions.reclaim` while a turn is active cancels running and pending work and records the active turn’s stopped outcome before workspace reconciliation and teardown. Inputs already waiting, or submitted while reclaim is in progress, do not restart the worker when reclaim completes. Send a new message after reclaim finishes to start new work.
 
+Cancellation does not wait for unrelated provider inspections. Final reconciliation and machine release still wait for earlier placement operations to finish. A later dispatch or move of the same session waits for reclaim, so it cannot replace the worker before Stop finishes.
+
 The result placement is `reclaimed` after an active worker is safely stopped. Reclaim also waits for an in-flight dispatch and retries pending teardown for a failed placement before returning `local`. No other placement states are successful reclaim results.
 
 If provider teardown fails or times out during stop or move, the request reports that failure even if recovery subsequently finishes cleanup. Check the current placement before retrying. A dedicated cloud worker can remain recorded as attached while destruction is uncertain, but its closed authority cannot resume remote workspace processes.

--- a/src/gateway/server-worker-placement-reclaim.preparation.test.ts
+++ b/src/gateway/server-worker-placement-reclaim.preparation.test.ts
@@ -1,0 +1,215 @@
+import { setImmediate } from "node:timers/promises";
+import { expect, it, vi } from "vitest";
+import { beginSessionWorkAdmission } from "../sessions/session-lifecycle-admission.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { createGatewayWorkerPlacementReclaimBarriers } from "./server-worker-placement-reclaim.js";
+
+function fixture(name: string, state: "active" | "failed" | "local" | "reclaimed" = "active") {
+  const request = {
+    sessionId: `session-${name}`,
+    sessionKey: `agent:main:${name}`,
+    agentId: "main",
+  };
+  const entry = { sessionId: request.sessionId, lifecycleRevision: "original", updatedAt: 1 };
+  const target = {
+    storePath: `/fixture/reclaim-preparation-${name}.sqlite`,
+    canonicalKey: request.sessionKey,
+    storeKeys: [request.sessionKey],
+    agentId: request.agentId,
+    store: { [request.sessionKey]: entry },
+  };
+  const placement = {
+    ...request,
+    state,
+    generation: 4,
+    environmentId: "worker",
+    activeOwnerEpoch: 7,
+  };
+  const cancel = vi.fn(async (input: { assertCurrent: () => void }) => input.assertCurrent());
+  const barriers = createGatewayWorkerPlacementReclaimBarriers({
+    placements: { get: () => ({ ...placement }) as never, waitForTurnClaimRelease: async () => {} },
+    loadSessionRuntime: async () => ({
+      managedWorktrees: { findLiveByOwner: () => undefined },
+      resolveGatewaySessionStoreTargetWithStore: () => target,
+      resolveCanonicalSessionEntryFromStoreKeys: () => entry,
+    }),
+    cancelSessionWork: cancel,
+    revokeSessionAuthority: vi.fn(),
+  });
+  const run = vi.fn(async () => ({ ...placement, state: "reclaimed" as const }) as never);
+  const admit = () =>
+    beginSessionWorkAdmission({
+      scope: target.storePath,
+      identities: [request.sessionKey, request.sessionId],
+      assertAllowed: () => {},
+    });
+  return {
+    ...request,
+    entry,
+    placement,
+    cancel,
+    run,
+    admit,
+    prepare: (options: Partial<Parameters<typeof barriers.runReclaimPreparation>[0]> = {}) =>
+      barriers.runReclaimPreparation({ ...request, run, ...options }),
+  };
+}
+
+it("one failed Stop cannot reopen ingress while another Stop still owns its closure", async () => {
+  const f = fixture("overlap");
+  const entered = createDeferredCore();
+  const release = createDeferredCore();
+  let calls = 0;
+  f.cancel.mockImplementation(async ({ assertCurrent }) => {
+    assertCurrent();
+    if (++calls === 1) {
+      entered.resolve();
+      await release.promise;
+    } else {
+      throw new Error("second cancellation failed");
+    }
+  });
+  const first = f.prepare();
+  await entered.promise;
+  try {
+    await expect(f.prepare()).rejects.toThrow("second cancellation failed");
+    await expect(f.admit()).rejects.toThrow();
+    expect(f.run).not.toHaveBeenCalled();
+  } finally {
+    release.resolve();
+    await first;
+  }
+  const fresh = await f.admit();
+  fresh.release();
+});
+
+it.each(["authorization", "incarnation"] as const)(
+  "rejects changed %s after cancellation and reopens admission on failure",
+  async (change) => {
+    const f = fixture(`changed-${change}`);
+    const entered = createDeferredCore();
+    const release = createDeferredCore();
+    let authorized = true;
+    f.cancel.mockImplementation(async ({ assertCurrent }) => {
+      assertCurrent();
+      entered.resolve();
+      await release.promise;
+    });
+    const stop = f.prepare({
+      authorize: () => {
+        if (!authorized) throw new Error("access revoked");
+      },
+    });
+    const rejected = expect(stop).rejects.toThrow(
+      change === "authorization" ? "access revoked" : "Session",
+    );
+    await entered.promise;
+    if (change === "authorization") authorized = false;
+    else f.entry.lifecycleRevision = "replacement-with-same-session-id";
+    release.resolve();
+    await rejected;
+    expect(f.run).not.toHaveBeenCalled();
+    const fresh = await f.admit();
+    fresh.release();
+  },
+);
+
+it("rechecks the exact worker owner after asynchronous cancellation setup", async () => {
+  const f = fixture("changed-worker");
+  const entered = createDeferredCore();
+  const release = createDeferredCore();
+  const signalled = vi.fn();
+  f.cancel.mockImplementation(async ({ assertCurrent }) => {
+    entered.resolve();
+    await release.promise;
+    assertCurrent();
+    signalled();
+  });
+  const stop = f.prepare();
+  const rejected = expect(stop).rejects.toThrow("worker changed before cancellation");
+  await entered.promise;
+  // The store returns immutable snapshots; replacement must not mutate the captured owner.
+  const priorGeneration = f.placement.generation;
+  f.placement.generation = priorGeneration + 1;
+  release.resolve();
+  await rejected;
+  expect(signalled).not.toHaveBeenCalled();
+  expect(f.run).not.toHaveBeenCalled();
+});
+
+it.each(["local", "reclaimed"] as const)(
+  "does not cancel fresh work on an already %s placement",
+  async (state) => {
+    const f = fixture(`idempotent-${state}`, state);
+    const admitted = await f.admit();
+    try {
+      await f.prepare();
+      expect(f.cancel).not.toHaveBeenCalled();
+      expect(admitted.isActive()).toBe(true);
+    } finally {
+      admitted.release();
+    }
+  },
+);
+
+it("auto-suspend eligibility rejects before closing admission or signalling cancellation", async () => {
+  const f = fixture("auto-suspend");
+  await expect(
+    f.prepare({
+      beforeDrain: () => {
+        throw new Error("session is busy");
+      },
+    }),
+  ).rejects.toThrow("session is busy");
+  expect(f.cancel).not.toHaveBeenCalled();
+  expect(f.run).not.toHaveBeenCalled();
+  const fresh = await f.admit();
+  fresh.release();
+});
+
+it("keeps admissions closed while serialized teardown is queued, then revalidates the incarnation", async () => {
+  const f = fixture("queued-teardown");
+  const entered = createDeferredCore();
+  const release = createDeferredCore();
+  const teardown = vi.fn();
+  const stop = f.prepare({
+    run: async (authorize) => {
+      entered.resolve();
+      await release.promise;
+      authorize?.();
+      teardown();
+      return await f.run();
+    },
+  });
+  const rejected = expect(stop).rejects.toThrow("Session");
+  await entered.promise;
+  await expect(f.admit()).rejects.toThrow();
+  f.entry.lifecycleRevision = "new-incarnation";
+  release.resolve();
+  await rejected;
+  expect(teardown).not.toHaveBeenCalled();
+});
+
+it("a pending dispatch retains its producer while preparation fences new ingress", async () => {
+  const f = fixture("pending-dispatch");
+  Object.assign(f.placement, { state: "provisioning" });
+  const entered = createDeferredCore();
+  const release = createDeferredCore();
+  const stop = f.prepare({
+    run: async () => {
+      entered.resolve();
+      await release.promise;
+      return await f.run();
+    },
+  });
+  await entered.promise;
+  try {
+    await setImmediate();
+    expect(f.cancel).not.toHaveBeenCalled();
+    expect(f.run).not.toHaveBeenCalled();
+    await expect(f.admit()).rejects.toThrow();
+  } finally {
+    release.resolve();
+    await stop;
+  }
+});

--- a/src/gateway/server-worker-placement-reclaim.preparation.test.ts
+++ b/src/gateway/server-worker-placement-reclaim.preparation.test.ts
@@ -97,15 +97,20 @@ it.each(["authorization", "incarnation"] as const)(
     });
     const stop = f.prepare({
       authorize: () => {
-        if (!authorized) throw new Error("access revoked");
+        if (!authorized) {
+          throw new Error("access revoked");
+        }
       },
     });
     const rejected = expect(stop).rejects.toThrow(
       change === "authorization" ? "access revoked" : "Session",
     );
     await entered.promise;
-    if (change === "authorization") authorized = false;
-    else f.entry.lifecycleRevision = "replacement-with-same-session-id";
+    if (change === "authorization") {
+      authorized = false;
+    } else {
+      f.entry.lifecycleRevision = "replacement-with-same-session-id";
+    }
     release.resolve();
     await rejected;
     expect(f.run).not.toHaveBeenCalled();

--- a/src/gateway/server-worker-placement-reclaim.test.ts
+++ b/src/gateway/server-worker-placement-reclaim.test.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { setImmediate } from "node:timers/promises";
 import { afterEach, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { clearAgentRunContext } from "../infra/agent-run-registry.js";
@@ -40,10 +41,15 @@ afterEach(async () => {
 
 async function scenario(
   name: string,
-  destroyFailure: boolean,
-  beforeStop = false,
-  staged = false,
-  failedRetry = false,
+  {
+    destroyFailure = false,
+    beforeStop = false,
+    staged = false,
+    failedRetry = false,
+    blockedInspection = false,
+    cancellationNeedsRecovery = false,
+    pendingDispatch = false,
+  } = {},
 ) {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "worker-stop-"));
   roots.push(root);
@@ -95,6 +101,7 @@ async function scenario(
   const harness = createHarness(placements, {
     workspacePath: worktreePath,
     ...(failedRetry ? { failAt: "sync" as const } : {}),
+    runReclaimPreparation: barriers.runReclaimPreparation,
     runReclaimBarrier: barriers.runReclaimBarrier,
     runFailedReclaimBarrier: barriers.runFailedReclaimBarrier,
     ...(destroyFailure
@@ -146,6 +153,16 @@ async function scenario(
     );
   }
   const coordinated = coordinateWorkerPlacementDispatch(harness.service);
+  const provisionEntered = createDeferred();
+  const releaseProvision = createDeferred();
+  if (pendingDispatch) {
+    vi.mocked(harness.environments.create).mockImplementationOnce(async () => {
+      provisionEntered.resolve();
+      await releaseProvision.promise;
+      return harness.ready;
+    });
+  }
+  let dispatching: ReturnType<typeof coordinated.dispatch> | undefined;
   let active;
   if (failedRetry) {
     await expect(coordinated.dispatch(REQUEST)).rejects.toThrow("sync failed");
@@ -153,8 +170,17 @@ async function scenario(
     expect(active.state).toBe("failed");
     expect(harness.environments.get(active.environmentId!)?.state).toBe("destroying");
   } else {
-    active = await coordinated.dispatch(REQUEST);
-    expect(active.state).toBe("active");
+    dispatching = coordinated.dispatch(
+      blockedInspection ? { ...REQUEST, executionMode: "remote-exec" } : REQUEST,
+    );
+    if (pendingDispatch) {
+      await provisionEntered.promise;
+      active = placements.get(REQUEST.sessionId)!;
+      expect(active.state).toBe("provisioning");
+    } else {
+      active = await dispatching;
+      expect(active.state).toBe("active");
+    }
   }
   const admit = (runId: string) =>
     admitWorkerStopChat({
@@ -167,10 +193,45 @@ async function scenario(
       runId,
     });
   const oldRunId = name + "-before-stop-complete";
+  const running = blockedInspection ? await admit(name + "-running").promise : undefined;
+  let cancellationRecovery: Promise<void> | undefined;
+  if (running?.ok) {
+    running.value.activeRunAbort.controller.signal.addEventListener("abort", () => {
+      if (cancellationNeedsRecovery) {
+        // Real worker failure completion joins placement recovery before releasing admission.
+        cancellationRecovery = coordinated.reconcileActive().finally(() => {
+          running.value.cleanupAdmittedRun();
+        });
+      } else {
+        running.value.cleanupAdmittedRun();
+      }
+    });
+  }
+  const inspectionEntered = createDeferred();
+  const releaseInspection = createDeferred();
+  if (blockedInspection) {
+    vi.mocked(harness.environments.reconcileOnce).mockImplementationOnce(async () => {
+      inspectionEntered.resolve();
+      await releaseInspection.promise;
+    });
+  }
+  const sweep = blockedInspection ? coordinated.reconcileActive() : undefined;
+  if (sweep) {
+    await inspectionEntered.promise;
+  }
+  let abortedDuringInspection = false;
+  let destroyedDuringInspection = false;
   let old!: ReturnType<typeof admit>;
   let reclaimResult: { ok: boolean; state?: string; message?: string } | undefined;
   const reserveOld = () => {
     old = admit(oldRunId);
+    if (blockedInspection || pendingDispatch) {
+      void old.promise.then((result) => {
+        if (result.ok) {
+          result.value.cleanupAdmittedRun();
+        }
+      });
+    }
     const reservation = context.dedupe.get(pendingChatSendDedupeKey(oldRunId));
     if (beforeStop) {
       expect((reservation?.payload as { status?: string } | undefined)?.status).toBe("accepted");
@@ -189,12 +250,29 @@ async function scenario(
         return { ok: false, message: error.message };
       },
     );
-    await barrierEntered.promise;
-    if (!beforeStop) {
+    if (blockedInspection) {
+      await setImmediate();
+      abortedDuringInspection =
+        running?.ok === true && running.value.activeRunAbort.controller.signal.aborted;
+      destroyedDuringInspection = vi.mocked(harness.environments.destroy).mock.calls.length > 0;
+      reserveOld();
+      await setImmediate();
+      releaseInspection.resolve();
+    }
+    if (pendingDispatch) {
+      await setImmediate();
+      reserveOld();
+      releaseProvision.resolve();
+      active = await dispatching!;
+    }
+    await Promise.race([barrierEntered.promise, reclaim]);
+    if (!beforeStop && !blockedInspection && !pendingDispatch) {
       reserveOld();
     }
     releaseBarrier.resolve();
     reclaimResult = await reclaim;
+    await sweep;
+    await cancellationRecovery;
   };
   if (beforeStop) {
     // A preceding lifecycle owner holds ingress pending while Stop joins that
@@ -249,14 +327,42 @@ async function scenario(
     preexistingResponses: old.respond.mock.calls,
     explicitNewAdmissionAccepted: freshResult.ok,
     approvalAttachRevocationCount: revocations.length,
+    abortedDuringInspection,
+    destroyedDuringInspection,
     harnessOrder: [...harness.log],
   };
   context.chatRunState.clear();
+  if (running?.ok) {
+    running.value.cleanupAdmittedRun();
+    clearAgentRunContext(name + "-running", running.value.lifecycleGeneration);
+  }
   return report;
 }
 
+it.each([false, true])(
+  "Stop cancels before unrelated inspection releases (recovery=%s)",
+  async (cancellationNeedsRecovery) => {
+    const r = await scenario(`blocked-inspection-${cancellationNeedsRecovery}`, {
+      blockedInspection: true,
+      cancellationNeedsRecovery,
+    });
+    expect(r.abortedDuringInspection).toBe(true);
+    expect(r.destroyedDuringInspection).toBe(false);
+    expect(r.preexistingAdmissionAccepted).toBe(false);
+    expect(r.reclaimResult).toEqual({ ok: true, state: "reclaimed" });
+    expect(r.explicitNewAdmissionAccepted).toBe(true);
+  },
+);
+
+it("Stop fences ingress during provisioning without cancelling its dispatch producer", async () => {
+  const r = await scenario("pending-dispatch", { pendingDispatch: true });
+  expect(r.preexistingAdmissionAccepted).toBe(false);
+  expect(r.reclaimResult).toEqual({ ok: true, state: "reclaimed" });
+  expect(r.explicitNewAdmissionAccepted).toBe(true);
+});
+
 it("successful Stop cancels a preexisting send waiting on its lifecycle fence", async () => {
-  const r = await scenario("successful-stop", false);
+  const r = await scenario("successful-stop");
   expect(r.reclaimResult).toEqual({ ok: true, state: "reclaimed" });
   expect(r.explicitNewAdmissionAccepted).toBe(true);
   expect(
@@ -265,7 +371,7 @@ it("successful Stop cancels a preexisting send waiting on its lifecycle fence", 
   ).toBe(false);
 });
 it("provider stop failure plus successful recovery still cancels preexisting ingress", async () => {
-  const r = await scenario("failed-stop-recovered-cleanup", true);
+  const r = await scenario("failed-stop-recovered-cleanup", { destroyFailure: true });
   expect(r.reclaimResult).toEqual({ ok: false, message: "destroy pending" });
   expect(r.explicitNewAdmissionAccepted).toBe(true);
   expect(
@@ -275,13 +381,17 @@ it("provider stop failure plus successful recovery still cancels preexisting ing
 });
 
 it("a reservation preceding Stop cannot revive a successfully reclaimed worker", async () => {
-  const r = await scenario("pre-stop-reservation", false, true);
+  const r = await scenario("pre-stop-reservation", { beforeStop: true });
   expect(r.reclaimResult).toEqual({ ok: true, state: "reclaimed" });
   expect(r.explicitNewAdmissionAccepted).toBe(true);
   expect(r.preexistingAdmissionAccepted).toBe(false);
 });
 it("accepted staged reclaim recovers provider cleanup but must reject pre-Stop ingress", async () => {
-  const r = await scenario("accepted-staged-stop-recovery", true, true, true);
+  const r = await scenario("accepted-staged-stop-recovery", {
+    destroyFailure: true,
+    beforeStop: true,
+    staged: true,
+  });
   expect(r.reclaimResult).toEqual({ ok: false, message: "destroy pending" });
   expect(r.finalPlacementState).toBe("reclaimed");
   expect(r.pendingWorkspaceResults).toBe(0);
@@ -292,7 +402,11 @@ it("accepted staged reclaim recovers provider cleanup but must reject pre-Stop i
 it.each([false, true])(
   "Stop of an already failed placement cancels pending ingress (before=%s)",
   async (beforeStop) => {
-    const r = await scenario(`failed-retry-${beforeStop}`, true, beforeStop, false, true);
+    const r = await scenario(`failed-retry-${beforeStop}`, {
+      destroyFailure: true,
+      beforeStop,
+      failedRetry: true,
+    });
     expect(r.reclaimResult).toEqual({ ok: true, state: "local" });
     expect(r.environmentState).toBe("destroyed");
     expect(r.providerDestroyAttempts).toBe(2);

--- a/src/gateway/server-worker-placement-reclaim.ts
+++ b/src/gateway/server-worker-placement-reclaim.ts
@@ -3,6 +3,7 @@ import type { ManagedWorktreeService } from "../agents/worktrees/service.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { runExclusiveSessionStoreWrite } from "../config/sessions/store-writer.js";
 import {
+  closeSessionWorkAdmissions,
   interruptSessionWorkAdmissions,
   runExclusiveSessionLifecycleMutation,
   SESSION_WORK_ADMISSION_DRAIN_TIMEOUT_MS,
@@ -49,6 +50,7 @@ export function createGatewayWorkerPlacementReclaimBarriers(
     const cancelAndDrain = async (
       closeWorkAdmissions: (reason: Error) => void,
       assertCurrent: () => void,
+      assertCancellationCurrent = assertCurrent,
     ) => {
       const reason = createAgentRunDirectAbortError();
       assertCurrent();
@@ -57,7 +59,7 @@ export function createGatewayWorkerPlacementReclaimBarriers(
         sessionId,
         sessionKeys: lifecycleIdentities,
         agentId,
-        assertCurrent,
+        assertCurrent: assertCancellationCurrent,
       });
       assertCurrent();
       const released = await interruptSessionWorkAdmissions({
@@ -75,6 +77,90 @@ export function createGatewayWorkerPlacementReclaimBarriers(
       await runExclusiveSessionStoreWrite(target.storePath, async () => {}, { reentrant: true });
     };
     return { sessionRuntime, target, lifecycleIdentities, cancelAndDrain };
+  };
+
+  const runReclaimPreparation: WorkerPlacementReclaimBarriers["runReclaimPreparation"] = async ({
+    sessionId,
+    sessionKey,
+    agentId,
+    authorize,
+    beforeDrain,
+    run,
+  }) => {
+    const { sessionRuntime, target, lifecycleIdentities, cancelAndDrain } =
+      await resolveLifecycleContext({ sessionId, sessionKey, agentId });
+    const entry = sessionRuntime.resolveCanonicalSessionEntryFromStoreKeys(
+      target.store,
+      target.storeKeys,
+    );
+    const revision = entry?.lifecycleRevision ?? null;
+    const assertCurrent = () => {
+      authorize?.();
+      const current = sessionRuntime.resolveGatewaySessionStoreTargetWithStore({
+        cfg: getRuntimeConfig(),
+        key: sessionKey,
+        agentId,
+        clone: false,
+      });
+      const currentEntry = sessionRuntime.resolveCanonicalSessionEntryFromStoreKeys(
+        current.store,
+        current.storeKeys,
+      );
+      if (
+        current.storePath !== target.storePath ||
+        current.canonicalKey !== target.canonicalKey ||
+        current.agentId !== target.agentId ||
+        currentEntry?.sessionId !== sessionId ||
+        (currentEntry.lifecycleRevision ?? null) !== revision
+      ) {
+        throw new WorkerDispatchTargetChangedError(
+          `Session ${sessionKey} changed before cloud worker stop. Retry.`,
+        );
+      }
+    };
+    assertCurrent();
+    beforeDrain?.();
+    const placement = params.placements.get(sessionId);
+    if (!placement || placement.state === "local" || placement.state === "reclaimed") {
+      return await run(assertCurrent);
+    }
+    // This lease blocks ingress without a mutex: cancellation recovery must still be able
+    // to acquire lifecycle and placement fences before Stop reserves its teardown turn.
+    const release = closeSessionWorkAdmissions({
+      scope: target.storePath,
+      identities: lifecycleIdentities,
+      reason: createAgentRunDirectAbortError(),
+    });
+    try {
+      if (
+        placement.state === "active" ||
+        placement.state === "draining" ||
+        placement.state === "failed"
+      ) {
+        await cancelAndDrain(
+          () => {},
+          assertCurrent,
+          () => {
+            assertCurrent();
+            const current = params.placements.get(sessionId);
+            if (
+              current?.generation !== placement.generation ||
+              current.state !== placement.state ||
+              current.environmentId !== placement.environmentId ||
+              current.activeOwnerEpoch !== placement.activeOwnerEpoch
+            ) {
+              throw new WorkerDispatchTargetChangedError(
+                `Session ${sessionKey} cloud worker changed before cancellation. Retry.`,
+              );
+            }
+          },
+        );
+      }
+      assertCurrent();
+      return await run(assertCurrent);
+    } finally {
+      release();
+    }
   };
 
   const runReclaimBarrier: WorkerPlacementReclaimBarriers["runReclaimBarrier"] = async ({
@@ -209,5 +295,5 @@ export function createGatewayWorkerPlacementReclaimBarriers(
       return reclaimedPlacement;
     };
 
-  return { runReclaimBarrier, runFailedReclaimBarrier };
+  return { runReclaimPreparation, runReclaimBarrier, runFailedReclaimBarrier };
 }

--- a/src/gateway/server-worker-placement-reclaim.ts
+++ b/src/gateway/server-worker-placement-reclaim.ts
@@ -13,7 +13,7 @@ import {
   resolveWorkerPlacementSessionTarget,
   WorkerDispatchTargetChangedError,
 } from "./server-worker-placement-session-target.js";
-import type { WorkerPlacementReclaimBarriers } from "./worker-environments/placement-dispatch.js";
+import type { WorkerPlacementReclaimBarriers } from "./worker-environments/placement-reclaim-contract.js";
 import type { WorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
 import type { WorkerPlacementReclaimRequest } from "./worker-environments/service-contract.js";
 

--- a/src/gateway/server.sessions.worker-original-order.test.ts
+++ b/src/gateway/server.sessions.worker-original-order.test.ts
@@ -418,6 +418,7 @@ test("preserves ordered fallback through restart, workspace sync, and safe sessi
     runActivationBarrier: async ({ activate }) => activate(),
     runMoveBarrier: async ({ begin }) => begin(),
     resolveMoveDestination: async () => undefined,
+    runReclaimPreparation: async ({ run, authorize }) => await run(authorize),
     runReclaimBarrier: async ({ begin, reclaim }) => await reclaim(localWorkspace, begin()),
     runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),
     resolveWorkspacePath: async () => localWorkspace,

--- a/src/gateway/worker-environments/placement-dispatch-coordinator.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator.test.ts
@@ -43,7 +43,6 @@ describe("worker placement dispatch coordinator", () => {
       const release = createDeferredCore();
       const events: string[] = [];
       let stops = 0;
-      let coordinated: ReturnType<typeof coordinateWorkerPlacementDispatch>;
       const service = {
         dispatch: vi.fn(async (request: WorkerPlacementDispatchRequest) => {
           events.push(`dispatch:${request.sessionId}`);
@@ -54,7 +53,9 @@ describe("worker placement dispatch coordinator", () => {
         reclaim: async (
           ...[_request, _authorize, _beforeDrain, serialize]: Parameters<DispatchService["reclaim"]>
         ) => {
-          if (++stops > 1) throw new Error("second Stop failed");
+          if (++stops > 1) {
+            throw new Error("second Stop failed");
+          }
           entered.resolve();
           await release.promise;
           await coordinated.reconcileActive();
@@ -67,7 +68,7 @@ describe("worker placement dispatch coordinator", () => {
           events.push("recovery");
         }),
       } as unknown as DispatchService;
-      coordinated = coordinateWorkerPlacementDispatch(service);
+      const coordinated = coordinateWorkerPlacementDispatch(service);
       const stopping = coordinated.reclaim(REQUEST);
       await entered.promise;
       await expect(coordinated.reclaim(REQUEST)).rejects.toThrow("second Stop failed");

--- a/src/gateway/worker-environments/placement-dispatch-coordinator.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator.test.ts
@@ -10,6 +10,15 @@ import type {
 
 type DispatchService = WorkerPlacementDispatchService;
 
+function preparedReclaim(run: () => Promise<unknown>) {
+  return async (
+    _request: unknown,
+    _authorize: unknown,
+    _beforeDrain: unknown,
+    serialize: (operation: () => Promise<unknown>) => Promise<unknown>,
+  ) => await serialize(run);
+}
+
 const REQUEST: WorkerPlacementDispatchRequest = {
   sessionId: "session-1",
   sessionKey: "agent:main:session-1",
@@ -27,6 +36,59 @@ const MOVE_REQUEST: WorkerPlacementMoveRequest = {
 };
 
 describe("worker placement dispatch coordinator", () => {
+  it.each(["dispatch", "move"] as const)(
+    "later %s waits for every same-session Stop while cancellation recovery can run",
+    async (kind) => {
+      const entered = createDeferredCore();
+      const release = createDeferredCore();
+      const events: string[] = [];
+      let stops = 0;
+      let coordinated: ReturnType<typeof coordinateWorkerPlacementDispatch>;
+      const service = {
+        dispatch: vi.fn(async (request: WorkerPlacementDispatchRequest) => {
+          events.push(`dispatch:${request.sessionId}`);
+        }),
+        move: vi.fn(async () => {
+          events.push("move");
+        }),
+        reclaim: async (
+          ...[_request, _authorize, _beforeDrain, serialize]: Parameters<DispatchService["reclaim"]>
+        ) => {
+          if (++stops > 1) throw new Error("second Stop failed");
+          entered.resolve();
+          await release.promise;
+          await coordinated.reconcileActive();
+          return await serialize!(async () => {
+            events.push("stop");
+            return { state: "reclaimed" } as never;
+          });
+        },
+        reconcileActive: vi.fn(async () => {
+          events.push("recovery");
+        }),
+      } as unknown as DispatchService;
+      coordinated = coordinateWorkerPlacementDispatch(service);
+      const stopping = coordinated.reclaim(REQUEST);
+      await entered.promise;
+      await expect(coordinated.reclaim(REQUEST)).rejects.toThrow("second Stop failed");
+      const later =
+        kind === "move" ? coordinated.move(MOVE_REQUEST) : coordinated.dispatch(REQUEST);
+      await coordinated.dispatch({ ...REQUEST, sessionId: "unrelated" });
+      await setImmediatePromise();
+      const beforeRelease = [...events];
+      release.resolve();
+      await Promise.all([stopping, later]);
+      expect(beforeRelease).toEqual(["dispatch:unrelated"]);
+      expect(events).toEqual([
+        "dispatch:unrelated",
+        "recovery",
+        "stop",
+        kind === "move" ? "move" : `dispatch:${REQUEST.sessionId}`,
+      ]);
+      expect(coordinated.isPlacementOperationInFlight(REQUEST.sessionId)).toBe(false);
+    },
+  );
+
   it("forwards in-process transition and authorization hooks outside request equality", async () => {
     const observer = vi.fn();
     const authorize = vi.fn();
@@ -242,7 +304,7 @@ describe("worker placement dispatch coordinator", () => {
     const service = {
       dispatch,
       forceDestroyEnvironment: vi.fn(),
-      reclaim,
+      reclaim: preparedReclaim(reclaim),
       reconcile: vi.fn(),
       reconcileActive: vi.fn(),
     } as unknown as DispatchService;
@@ -663,7 +725,7 @@ describe("worker placement dispatch coordinator", () => {
         dispatch: vi.fn(),
         forceDestroyEnvironment: exclusiveOperation,
         move: exclusiveOperation,
-        reclaim: exclusiveOperation,
+        reclaim: preparedReclaim(exclusiveOperation),
         reconcile: vi.fn(),
         reconcileActive: vi.fn(),
         resumeProvisioning,

--- a/src/gateway/worker-environments/placement-dispatch-coordinator.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator.ts
@@ -122,6 +122,15 @@ export function coordinateWorkerPlacementDispatch(
       operation: ReturnType<WorkerPlacementDispatchService["move"]>;
     }
   >();
+  const reclaimsInFlight = new Map<string, Set<Promise<unknown>>>();
+  const afterSessionReclaims = async <T>(sessionId: string, run: () => Promise<T>): Promise<T> => {
+    // Later caller mutations cannot replace the worker while Stop prepares. Recovery
+    // bypasses this session intent so it can release the very run Stop is draining.
+    while (reclaimsInFlight.has(sessionId)) {
+      await Promise.allSettled(reclaimsInFlight.get(sessionId)!);
+    }
+    return await run();
+  };
   const joinOperation = async <T>(operation: Promise<T>, authorize?: () => void): Promise<T> => {
     // Shared placement work must never inherit another caller's authority across an await.
     authorize?.();
@@ -131,7 +140,9 @@ export function coordinateWorkerPlacementDispatch(
   };
   return {
     isPlacementOperationInFlight: (sessionId) =>
-      dispatchInFlight.has(sessionId) || moveInFlight.has(sessionId),
+      dispatchInFlight.has(sessionId) ||
+      moveInFlight.has(sessionId) ||
+      reclaimsInFlight.has(sessionId),
     dispatch: async (request, onTransition, authorize) => {
       const inFlight = dispatchInFlight.get(request.sessionId);
       if (inFlight) {
@@ -140,8 +151,8 @@ export function coordinateWorkerPlacementDispatch(
         }
         return await joinOperation(inFlight.operation, authorize);
       }
-      const operation = runPlacementOperation(() =>
-        service.dispatch(request, onTransition, authorize),
+      const operation = afterSessionReclaims(request.sessionId, () =>
+        runPlacementOperation(() => service.dispatch(request, onTransition, authorize)),
       );
       dispatchInFlight.set(request.sessionId, { request, operation });
       try {
@@ -164,8 +175,8 @@ export function coordinateWorkerPlacementDispatch(
         }
         return await joinOperation(inFlight.operation, authorize);
       }
-      const operation = runExclusivePlacementOperation(() =>
-        service.move(request, onTransition, authorize),
+      const operation = afterSessionReclaims(request.sessionId, () =>
+        runExclusivePlacementOperation(() => service.move(request, onTransition, authorize)),
       );
       moveInFlight.set(request.sessionId, { request, operation });
       try {
@@ -176,8 +187,24 @@ export function coordinateWorkerPlacementDispatch(
         }
       }
     },
-    reclaim: async (request, authorize, beforeDrain) =>
-      await runExclusivePlacementOperation(() => service.reclaim(request, authorize, beforeDrain)),
+    reclaim: async (request, authorize, beforeDrain) => {
+      // Cancellation may need coordinated recovery. Reserve exclusivity only after it drains.
+      const operation = service.reclaim(
+        request,
+        authorize,
+        beforeDrain,
+        runExclusivePlacementOperation,
+      );
+      const pending = reclaimsInFlight.get(request.sessionId) ?? new Set();
+      pending.add(operation);
+      reclaimsInFlight.set(request.sessionId, pending);
+      try {
+        return await operation;
+      } finally {
+        pending.delete(operation);
+        if (pending.size === 0) reclaimsInFlight.delete(request.sessionId);
+      }
+    },
     reconcile: (mode) => runReconciliation(() => service.reconcile(mode)),
     reconcileActive: (environmentId) =>
       environmentId === undefined

--- a/src/gateway/worker-environments/placement-dispatch-coordinator.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator.ts
@@ -202,7 +202,9 @@ export function coordinateWorkerPlacementDispatch(
         return await operation;
       } finally {
         pending.delete(operation);
-        if (pending.size === 0) reclaimsInFlight.delete(request.sessionId);
+        if (pending.size === 0) {
+          reclaimsInFlight.delete(request.sessionId);
+        }
       }
     },
     reconcile: (mode) => runReconciliation(() => service.reconcile(mode)),

--- a/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
@@ -456,32 +456,35 @@ describe("worker placement dispatch reclaim", () => {
     expect(restarted.log).not.toContain("placement:reclaimed");
   });
 
-  it("serializes concurrent reclaim of an environment-free failed placement back to clean local state", async () => {
-    const harness = createHarness(placementStore);
-    const requested = placementStore.startDispatch(REQUEST);
-    const failed = placementStore.fail({
-      sessionId: REQUEST.sessionId,
-      expectedGeneration: requested.generation,
-      recoveryError: "device worker is offline",
-    });
+  it.each([false, true])(
+    "serializes concurrent failed reclaim back to local (coordinated=%s)",
+    async (coordinated) => {
+      const harness = createHarness(placementStore);
+      const requested = placementStore.startDispatch(REQUEST);
+      const failed = placementStore.fail({
+        sessionId: REQUEST.sessionId,
+        expectedGeneration: requested.generation,
+        recoveryError: "device worker is offline",
+      });
 
-    const results = await Promise.all([
-      harness.service.reclaim(REQUEST),
-      harness.service.reclaim(REQUEST),
-    ]);
-    expect(results[1]).toEqual(results[0]);
-    expect(results[0]).toMatchObject({
-      state: "local",
-      generation: failed.generation + 1,
-      environmentId: null,
-      recoveryError: null,
-      terminalReason: null,
-      terminalAtMs: null,
-    });
+      const service = coordinated
+        ? coordinateWorkerPlacementDispatch(harness.service)
+        : harness.service;
+      const results = await Promise.all([service.reclaim(REQUEST), service.reclaim(REQUEST)]);
+      expect(results[1]).toEqual(results[0]);
+      expect(results[0]).toMatchObject({
+        state: "local",
+        generation: failed.generation + 1,
+        environmentId: null,
+        recoveryError: null,
+        terminalReason: null,
+        terminalAtMs: null,
+      });
 
-    expect(harness.environments.startTunnel).not.toHaveBeenCalled();
-    expect(harness.environments.destroy).not.toHaveBeenCalled();
-  });
+      expect(harness.environments.startTunnel).not.toHaveBeenCalled();
+      expect(harness.environments.destroy).not.toHaveBeenCalled();
+    },
+  );
 
   it("retries pending failed-environment teardown before clearing the placement", async () => {
     const harness = createHarness(placementStore, { failAt: "sync", destroyFails: true });

--- a/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
@@ -689,6 +689,7 @@ describe("worker placement restart recovery", () => {
         runActivationBarrier: async ({ activate }) => activate(),
         runMoveBarrier: async ({ begin }) => begin(),
         resolveMoveDestination: async () => undefined,
+        runReclaimPreparation: async ({ run, authorize }) => await run(authorize),
         runReclaimBarrier: async ({ begin, reclaim }) =>
           await reclaim("/gateway/workspace", begin()),
         runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),

--- a/src/gateway/worker-environments/placement-dispatch-test-harness.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-harness.ts
@@ -30,6 +30,9 @@ import {
 export function createHarness(
   placementStore: PlacementStore,
   options: {
+    runReclaimPreparation?: Parameters<
+      typeof createWorkerPlacementDispatchService
+    >[0]["runReclaimPreparation"];
     runReclaimBarrier?: Parameters<
       typeof createWorkerPlacementDispatchService
     >[0]["runReclaimBarrier"];
@@ -396,6 +399,8 @@ export function createHarness(
   const service = createWorkerPlacementDispatchService({
     placements,
     environments,
+    runReclaimPreparation:
+      options.runReclaimPreparation ?? (async ({ run, authorize }) => await run(authorize)),
     runnerAvailability: createWorkerPlacementRunnerAvailabilityReader({
       environments,
       hasCurrentDeviceRunner: () => options.deviceRunnerAvailable === true,

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -24,6 +24,10 @@ import {
   type WorkerPlacementMoveBarrier,
 } from "./placement-move-service.js";
 import type { WorkerPlacementRunnerAvailabilityReader } from "./placement-projector.js";
+import type {
+  WorkerPlacementReclaimBarriers,
+  WorkerReclaimPlacement,
+} from "./placement-reclaim-contract.js";
 import { placementTurnOwner } from "./placement-record.js";
 import {
   completeMovedWorkspaceTeardown,
@@ -70,42 +74,6 @@ type WorkerLocalDispatchBarrier = (params: {
 }) => Promise<WorkerDispatchPlacement>;
 
 type WorkerDrainingDispatchPlacement = Extract<WorkerDispatchPlacement, { state: "draining" }>;
-type WorkerReclaimStartPlacement = Extract<
-  WorkerDispatchPlacement,
-  { state: "draining" | "reclaimed" }
->;
-type WorkerReclaimPlacement = Extract<WorkerDispatchPlacement, { state: "local" | "reclaimed" }>;
-type WorkerPlacementReclaimBarrier = (
-  params: WorkerPlacementReclaimRequest & {
-    authorize?: WorkerPlacementAuthorization;
-    beforeDrain?: WorkerPlacementAuthorization;
-    begin: () => WorkerReclaimStartPlacement;
-    reclaim: (
-      localPath: string,
-      placement: WorkerReclaimStartPlacement,
-      authorize?: WorkerPlacementAuthorization,
-    ) => Promise<WorkerReclaimPlacement>;
-  },
-) => Promise<WorkerReclaimPlacement>;
-
-type WorkerPlacementFailedReclaimBarrier = (
-  params: WorkerPlacementReclaimRequest & {
-    authorize?: WorkerPlacementAuthorization;
-    reclaim: (authorize?: WorkerPlacementAuthorization) => Promise<WorkerReclaimPlacement>;
-  },
-) => Promise<WorkerReclaimPlacement>;
-
-export type WorkerPlacementReclaimBarriers = {
-  runReclaimPreparation: (
-    params: WorkerPlacementReclaimRequest & {
-      authorize?: WorkerPlacementAuthorization;
-      beforeDrain?: WorkerPlacementAuthorization;
-      run: (authorize?: WorkerPlacementAuthorization) => Promise<WorkerReclaimPlacement>;
-    },
-  ) => Promise<WorkerReclaimPlacement>;
-  runReclaimBarrier: WorkerPlacementReclaimBarrier;
-  runFailedReclaimBarrier: WorkerPlacementFailedReclaimBarrier;
-};
 
 type WorkerPlacementDispatchOptions = WorkerPlacementReclaimBarriers & {
   placements: WorkerDispatchPlacementStore;

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -96,6 +96,13 @@ type WorkerPlacementFailedReclaimBarrier = (
 ) => Promise<WorkerReclaimPlacement>;
 
 export type WorkerPlacementReclaimBarriers = {
+  runReclaimPreparation: (
+    params: WorkerPlacementReclaimRequest & {
+      authorize?: WorkerPlacementAuthorization;
+      beforeDrain?: WorkerPlacementAuthorization;
+      run: (authorize?: WorkerPlacementAuthorization) => Promise<WorkerReclaimPlacement>;
+    },
+  ) => Promise<WorkerReclaimPlacement>;
   runReclaimBarrier: WorkerPlacementReclaimBarrier;
   runFailedReclaimBarrier: WorkerPlacementFailedReclaimBarrier;
 };
@@ -629,18 +636,22 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
       },
     });
 
-  const reclaim = async (
+  const reclaimCurrent = async (
     request: WorkerPlacementReclaimRequest,
     authorize?: WorkerPlacementAuthorization,
     beforeDrain?: WorkerPlacementAuthorization,
+    initial?: WorkerDispatchPlacement,
   ): Promise<WorkerReclaimPlacement> => {
+    authorize?.();
     beforeDrain?.();
     const current = placements.get(request.sessionId);
     if (current?.state === "reclaimed") {
       return current;
     }
     try {
-      const owned = placements.get(request.sessionId);
+      // The preparation/placement wait can span another completed failed cleanup.
+      // Its old generation classifies an idempotent result, never authorizes new teardown.
+      const owned = current?.state === "local" && initial?.state === "failed" ? initial : current;
       if (owned?.state === "failed") {
         return await options.runFailedReclaimBarrier({
           ...request,
@@ -695,6 +706,24 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
       }
       throw error;
     }
+  };
+
+  const reclaim = async (
+    request: WorkerPlacementReclaimRequest,
+    authorize?: WorkerPlacementAuthorization,
+    beforeDrain?: WorkerPlacementAuthorization,
+    serialize: (
+      run: () => Promise<WorkerReclaimPlacement>,
+    ) => Promise<WorkerReclaimPlacement> = async (run) => await run(),
+  ): Promise<WorkerReclaimPlacement> => {
+    const initial = placements.get(request.sessionId);
+    return await options.runReclaimPreparation({
+      ...request,
+      authorize,
+      beforeDrain,
+      run: (reauthorize) =>
+        serialize(() => reclaimCurrent(request, reauthorize, beforeDrain, initial)),
+    });
   };
 
   const abandonment = createWorkerPlacementMoveAbandonment(options);

--- a/src/gateway/worker-environments/placement-move-service.ts
+++ b/src/gateway/worker-environments/placement-move-service.ts
@@ -8,6 +8,7 @@ import type {
   WorkerPlacementMoveIntent,
   WorkerPlacementMoveTarget,
 } from "./placement-move-intent.js";
+import type { WorkerReclaimPlacement } from "./placement-reclaim-contract.js";
 import { isCurrentPlacementTurnClaim, projectWorkerSessionTurnClaim } from "./placement-record.js";
 import type {
   WorkerPlacementDispatchRequest,
@@ -20,7 +21,6 @@ import { isFailedWorkerPlacementEnvironmentGone } from "./session-placement-life
 
 type WorkerDrainingDispatchPlacement = Extract<WorkerDispatchPlacement, { state: "draining" }>;
 type WorkerMovePlacement = Extract<WorkerDispatchPlacement, { state: "local" | "active" }>;
-type WorkerReclaimPlacement = Extract<WorkerDispatchPlacement, { state: "local" | "reclaimed" }>;
 type WorkerPlacementMoveSourceDisposition = "reconcile" | "abandon";
 const RESTART_AUTHORITY_EXPIRED =
   "Cloud worker move request authority expired after Gateway restart; retry move";

--- a/src/gateway/worker-environments/placement-reclaim-contract.ts
+++ b/src/gateway/worker-environments/placement-reclaim-contract.ts
@@ -1,0 +1,42 @@
+import type { WorkerDispatchPlacement } from "./placement-dispatch-failure.js";
+import type {
+  WorkerPlacementAuthorization,
+  WorkerPlacementReclaimRequest,
+} from "./service-contract.js";
+
+export type WorkerReclaimStartPlacement = Extract<
+  WorkerDispatchPlacement,
+  { state: "draining" | "reclaimed" }
+>;
+export type WorkerReclaimPlacement = Extract<
+  WorkerDispatchPlacement,
+  { state: "local" | "reclaimed" }
+>;
+
+export type WorkerPlacementReclaimBarriers = {
+  runReclaimPreparation: (
+    params: WorkerPlacementReclaimRequest & {
+      authorize?: WorkerPlacementAuthorization;
+      beforeDrain?: WorkerPlacementAuthorization;
+      run: (authorize?: WorkerPlacementAuthorization) => Promise<WorkerReclaimPlacement>;
+    },
+  ) => Promise<WorkerReclaimPlacement>;
+  runReclaimBarrier: (
+    params: WorkerPlacementReclaimRequest & {
+      authorize?: WorkerPlacementAuthorization;
+      beforeDrain?: WorkerPlacementAuthorization;
+      begin: () => WorkerReclaimStartPlacement;
+      reclaim: (
+        localPath: string,
+        placement: WorkerReclaimStartPlacement,
+        authorize?: WorkerPlacementAuthorization,
+      ) => Promise<WorkerReclaimPlacement>;
+    },
+  ) => Promise<WorkerReclaimPlacement>;
+  runFailedReclaimBarrier: (
+    params: WorkerPlacementReclaimRequest & {
+      authorize?: WorkerPlacementAuthorization;
+      reclaim: (authorize?: WorkerPlacementAuthorization) => Promise<WorkerReclaimPlacement>;
+    },
+  ) => Promise<WorkerReclaimPlacement>;
+};

--- a/src/gateway/worker-environments/placement-reclaim-contract.ts
+++ b/src/gateway/worker-environments/placement-reclaim-contract.ts
@@ -4,7 +4,7 @@ import type {
   WorkerPlacementReclaimRequest,
 } from "./service-contract.js";
 
-export type WorkerReclaimStartPlacement = Extract<
+type WorkerReclaimStartPlacement = Extract<
   WorkerDispatchPlacement,
   { state: "draining" | "reclaimed" }
 >;

--- a/src/gateway/worker-environments/provider-bootstrap.test.ts
+++ b/src/gateway/worker-environments/provider-bootstrap.test.ts
@@ -241,6 +241,7 @@ describe("worker environment service", () => {
       runActivationBarrier: async ({ activate }) => activate(),
       runMoveBarrier: async ({ begin }) => begin(),
       resolveMoveDestination: async () => undefined,
+      runReclaimPreparation: async ({ run, authorize }) => await run(authorize),
       runReclaimBarrier: async ({ begin, reclaim }) => await reclaim("/gateway/workspace", begin()),
       runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),
       resolveWorkspacePath: async () => "/gateway/workspace",

--- a/src/gateway/worker-environments/provider-provisioning.replay.test.ts
+++ b/src/gateway/worker-environments/provider-provisioning.replay.test.ts
@@ -288,6 +288,7 @@ describe("worker environment service provision replay", () => {
       runActivationBarrier: activationBarrier,
       runMoveBarrier: async ({ begin }) => begin(),
       resolveMoveDestination: async () => undefined,
+      runReclaimPreparation: async ({ run, authorize }) => await run(authorize),
       runReclaimBarrier: async ({ begin, reclaim }) => await reclaim("/gateway/workspace", begin()),
       runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),
       resolveWorkspacePath: async () => "/gateway/workspace",

--- a/src/gateway/worker-environments/provider-provisioning.shutdown-replay.test.ts
+++ b/src/gateway/worker-environments/provider-provisioning.shutdown-replay.test.ts
@@ -137,6 +137,7 @@ describe("worker node provisioning shutdown replay", () => {
         runActivationBarrier: async ({ activate }) => activate(),
         runMoveBarrier: async ({ begin }) => begin(),
         resolveMoveDestination: async () => undefined,
+        runReclaimPreparation: async ({ run, authorize }) => await run(authorize),
         runReclaimBarrier: async ({ begin, reclaim }) =>
           await reclaim("/gateway/workspace", begin()),
         runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),

--- a/src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
@@ -390,6 +390,7 @@ describe("worker turn launcher failure recovery", () => {
       runActivationBarrier: async ({ activate }) => activate(),
       runMoveBarrier: async ({ begin }) => begin(),
       resolveMoveDestination: async () => undefined,
+      runReclaimPreparation: async ({ run, authorize }) => await run(authorize),
       runReclaimBarrier: async ({ begin, reclaim }) => await reclaim(root, begin()),
       runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),
       workspaceOperations,

--- a/src/sessions/session-lifecycle-admission.ts
+++ b/src/sessions/session-lifecycle-admission.ts
@@ -30,8 +30,9 @@ type SessionWorkAdmission = HandoffSessionWorkAdmission & {
 
 type SessionLifecycleMutationOwner = {
   identities: readonly string[];
-  admissionClosedReason?: Error;
 };
+
+type SessionWorkAdmissionClosure = SessionLifecycleMutationOwner & { reason: Error };
 
 type SessionLifecycleAdmissionState = {
   lifecycleQueues: Map<string, StoreWriterQueue>;
@@ -39,6 +40,7 @@ type SessionLifecycleAdmissionState = {
   activeAdmissions: Map<string, Set<SessionWorkAdmission>>;
   activeMutations: Map<string, number>;
   activeMutationRuns?: Set<SessionLifecycleMutationOwner>;
+  admissionClosures: Set<SessionWorkAdmissionClosure>;
   activeMutationKinds: Map<string, Map<SessionLifecycleMutationKind, number>>;
   idleWaiters: Map<string, Set<() => void>>;
   currentAdmissions: AsyncLocalStorage<ReadonlySet<SessionWorkAdmission>>;
@@ -69,6 +71,7 @@ const SESSION_LIFECYCLE_ADMISSION_STATE = resolveGlobalSingleton(
     activeAdmissions: new Map(),
     activeMutations: new Map(),
     activeMutationRuns: new Set(),
+    admissionClosures: new Set(),
     activeMutationKinds: new Map(),
     idleWaiters: new Map(),
     currentAdmissions: new AsyncLocalStorage(),
@@ -82,6 +85,7 @@ const {
   activeMutationKinds: ACTIVE_SESSION_LIFECYCLE_MUTATION_KINDS,
   idleWaiters: SESSION_LIFECYCLE_IDLE_WAITERS,
   currentAdmissions: CURRENT_SESSION_WORK_ADMISSIONS,
+  admissionClosures: SESSION_WORK_ADMISSION_CLOSURES,
 } = SESSION_LIFECYCLE_ADMISSION_STATE;
 // Older runtime chunks can create the shared state without this newer index.
 const ACTIVE_SESSION_LIFECYCLE_MUTATION_RUNS =
@@ -220,6 +224,7 @@ export async function runExclusiveSessionLifecycleMutation<T>(
   const mutationRun: SessionLifecycleMutationOwner = { identities };
   let mutationActivated = false;
   let removeAbortListener = () => {};
+  let releaseWorkAdmissions: (() => void) | undefined;
   const mutation = runWithSessionIdentityLocks(
     identities,
     0,
@@ -249,14 +254,8 @@ export async function runExclusiveSessionLifecycleMutation<T>(
             // The same mutation owner fences ingress through every awaited cleanup step.
             // Removing this owner below reopens admission for an explicit later request.
             closeWorkAdmissions: (reason) => {
-              mutationRun.admissionClosedReason = reason;
-              // Pending owners must retire even if later cancellation or persistence fails.
-              // Acquired runs still follow their canonical abort and terminal ordering.
-              startNormalizedSessionWorkAdmissionInterruption({
-                identities,
-                reason,
-                pendingOnly: true,
-              });
+              releaseWorkAdmissions?.();
+              releaseWorkAdmissions = closeNormalizedSessionWorkAdmissions(identities, reason);
             },
           });
           return await runWithSessionIdentityLocks(identities, 0, params.run);
@@ -293,6 +292,7 @@ export async function runExclusiveSessionLifecycleMutation<T>(
                 }
               }
               ACTIVE_SESSION_LIFECYCLE_MUTATION_RUNS.delete(mutationRun);
+              releaseWorkAdmissions?.();
             });
           }
         }
@@ -540,13 +540,11 @@ export async function beginSessionWorkAdmission(params: {
   };
   let removeAbortListener = () => {};
   try {
-    const closedOwner = [...ACTIVE_SESSION_LIFECYCLE_MUTATION_RUNS].find(
-      (owner) =>
-        owner.admissionClosedReason &&
-        owner.identities.some((identity) => admission.identities.has(identity)),
+    const closedOwner = [...SESSION_WORK_ADMISSION_CLOSURES].find((owner) =>
+      owner.identities.some((identity) => admission.identities.has(identity)),
     );
     if (closedOwner) {
-      admission.interrupt?.(closedOwner.admissionClosedReason);
+      admission.interrupt?.(closedOwner.reason);
     }
     const queuedAbort = new Promise<never>((_, reject) => {
       const onAbort = () => {
@@ -598,6 +596,33 @@ export async function beginSessionWorkAdmission(params: {
   } finally {
     removeAbortListener();
   }
+}
+
+function closeNormalizedSessionWorkAdmissions(identities: readonly string[], reason: Error) {
+  const owner = { identities, reason };
+  SESSION_WORK_ADMISSION_CLOSURES.add(owner);
+  // Retire queued ingress immediately; acquired runs keep their canonical cancellation owner.
+  try {
+    startNormalizedSessionWorkAdmissionInterruption({ identities, reason, pendingOnly: true });
+  } catch (error) {
+    SESSION_WORK_ADMISSION_CLOSURES.delete(owner);
+    throw error;
+  }
+  return () => {
+    SESSION_WORK_ADMISSION_CLOSURES.delete(owner);
+  };
+}
+
+/** Fence ingress while awaiting cleanup that must run outside lifecycle/placement locks. */
+export function closeSessionWorkAdmissions(params: {
+  scope: string;
+  identities: Iterable<string | undefined>;
+  reason: Error;
+}): () => void {
+  return closeNormalizedSessionWorkAdmissions(
+    normalizeSessionIdentities(params.scope, params.identities),
+    params.reason,
+  );
 }
 
 function startNormalizedSessionWorkAdmissionInterruption(params: {


### PR DESCRIPTION
Related: #133241

## What Problem This Solves

Fixes an issue where stopping an active cloud session through `sessions.reclaim` lets its agent keep working while an unrelated worker's provider inspection is slow. The request previously waited for the global placement queue before it could cancel the session. A second overlapping Stop of an already failed worker could also report an error after the first successfully returned it to local execution.

## Why This Change Was Made

The Gateway now closes session ingress and drains canonical cancellation before reserving serialized teardown. A lifecycle-owned admission closure keeps queued messages from reviving the worker without holding the mutexes that cancellation recovery needs. The coordinator retains every in-flight Stop for that session; later dispatches and moves wait outside the global fence, while recovery can finish the cancelled run. Workspace reconciliation, provider destruction, terminal persistence and move/recovery barriers retain their existing owners.

Caller authorization, session identity and lifecycle revision are checked across waits, with the exact worker owner rechecked immediately before cancellation. Failed-to-local completion uses the initial generation only to recognize that exact successful cleanup, never as authority to tear down replacement work. No configuration, protocol, schema, dependency or public tool surface is added. The cloud-worker documentation explains cancellation versus resource-release timing.

## User Impact

An active cloud agent stops without waiting for unrelated provider inspection. Cleanup can still take time, but new work cannot overtake Stop or silently restart the worker. Concurrent Stops recognize an exact completed failed-worker cleanup. The existing two-step Control UI flow (stop the turn, then stop the idle worker) is unchanged.

## Evidence

Exact candidate `0e8b476fc34892a1c7e0a8e196f3dbf2ca8a790f` passed hosted CI [33332652305](https://github.com/openclaw/openclaw/actions/runs/33332652305) and the changed cancellation behavior through real cloud sessions created in the Control UI. The canonical package build and remote bootstrap identities matched this head; the native runtime was Codex 0.151.0.

Three real native CUA click runs, fresh subsequent screenshots, and GUI turn Stop passed. The model screenshots, independent RFB images, and actual Chrome WebVNC all showed the same desktop counter advancing from 0 to 3. In the latest ordinary API Stop run, the exact active native turn emitted `TurnAborted/interrupted` 33 ms after the request and acknowledged execution close after 247 ms. Canonical history recorded that run as killed.

Resource-release proof is separately **failed**, not converted to success: that same RPC later timed out in provider Stop, and the observer WebSocket closed much later. An unrelated allocation was still pending; stopping its task-owned warmup process was a separately recorded manual cleanup intervention. An earlier synthetic held-inspection attempt missed its strict coordination criterion and also failed provider cleanup. Those failed attempts are retained. They do not invalidate the independently observed prompt cancellation, but this PR does not claim that the complete cloud teardown flow is repaired. Broker ingress serialization is tracked in [crabbox#1679](https://github.com/openclaw/crabbox/issues/1679) and [crabbox#1680](https://github.com/openclaw/crabbox/pull/1680); the discovered producer-side provisioning cancellation gap is being repaired separately. The existing blocked-inspection RED/GREEN regression proves the precise queue-order invariant.

- Before repair, the real Gateway cancellation/placement fixture reproduces continued execution during blocked provider inspection. The repaired test observes cancellation before inspection is released and no early provider destruction.
- The expanded regression set passes 126 tests across six files. It covers cancellation that itself needs coordinated recovery, actual pending dispatch, overlapping Stops, later move/dispatch ordering, revoked authorization, same-session-ID reset, worker replacement, pending-ingress fencing and idle suspension.
- Another 233 tests across 18 sibling files pass: move and failure recovery, staged workspace results, terminal persistence failures, startup/shutdown, provisioning replay, device placement and session admission.
- Separate red/green proof covers the failed-to-local overlap. The caller-order tests failed before adding per-session Stop custody, then passed; one failed Stop cannot release another Stop's custody.
- Codex autoreview: scoped clean at P0-only. Independent all-severity source review found no remaining concrete issue; the native proof above independently covers the changed behavior.

Production delta is +235/-56 (net +179); test/test-support delta is +450/-39 (net +411), with two documentation lines added. The growth establishes two necessary ownership boundaries: admission closure without a held lifecycle mutex, and same-session Stop ordering without a held global placement fence. Removing either reproduces a race or deadlock. Existing cancellation and teardown remain canonical; the old mutation-only admission-closure path is replaced by the shared closure owner. The type-only contract extraction is included in this raw count; moves do not add runtime behavior.


## Review dispositions

The latest ClawSweeper finding and its first two rank-up moves ask for compatibility with an older in-process lifecycle singleton. We checked the producing and loading contracts and are not adding that shim: `tsdown.config.ts:776` builds core, SDK and bundled runtimes in one graph; `src/plugins/sdk-alias.ts:1371` captures the host package root for the loader lifecycle; official plugin packaging leaves OpenClaw imports external (`scripts/lib/plugin-npm-runtime-build.mts:101`). The supported package-update flow stops the Gateway before replacement (`docs/install/updating.md:207` and `:377`), while plugin metadata changes require restart (`docs/gateway/configuration.md:587`). Duplicated modules from one build share the current shape. The historical adjacent fallback was accompanied by a same-source duplicate-module test, not proof of mixed-version support. Merely initializing the new Set would also leave an older admission implementation unable to honor the new fence. No supported mixed-version producer or observed affected installation was identified.

The latest review’s two Rank-up moves concern the same old/new chunk premise; the source and history disposition above applies to both. Exact-candidate native cancellation and sibling desktop proof are recorded above; full provider cleanup remains a separately reported failure. Automated persistent-schema classification is not applicable: this change adds process-local cancellation ownership, with no schema or durable-store change. The production increase is justified above by the two separately tested ownership boundaries.

CI found and we corrected mechanical lint/style issues, then an unused type-only export. The export correction changes no runtime behavior. Final exact-head CI passed at 0e8b476fc348 (run 33332652305), including the hosted full validation required by the native workflow. Fresh native cancellation proof is recorded above; a duplicate local full gate is not claimed.
