### PR TITLE
perf(gateway): reuse prepared facts across control-plane reads

### DIFF
--- a/scripts/bench-gateway-concurrency.ts
+++ b/scripts/bench-gateway-concurrency.ts
@@ -1377,18 +1377,54 @@ async function runGatewaySample(options: {
   }
 }
 
-function summarizeRuns(runs: readonly BenchmarkRun[]) {
+function summarizeRuns(
+  runs: readonly BenchmarkRun[],
+  options: Pick<CliOptions, "maxControlMs" | "maxHandshakeMs"> = {},
+) {
+  const controlUi = runs.flatMap((run) => run.controlUi);
   const readyz = runs.flatMap((run) => run.readyz);
+  const sessionsList = runs.flatMap((run) => run.sessionsList);
   const history = runs.flatMap((run) => run.history);
   const subscriptions = runs.flatMap((run) => run.messageSubscriptions);
   const subscriptionsDuringLoad = runs.flatMap((run) => run.messageSubscriptionsDuringLoad);
   const sessionUpdates = runs.flatMap((run) => run.sessionUpdates);
+  // Setup subscriptions and warmup probes are not load-phase measurements.
+  const budgetViolations = [
+    {
+      name: "fresh Gateway connection",
+      maxMs: options.maxHandshakeMs,
+      samples: runs.map((run) => run.freshConnection),
+    },
+    ...(
+      [
+        ["readyz", readyz],
+        ["Control UI", controlUi],
+        ["sessions.list", sessionsList],
+        ["chat.history", history],
+        ["sessions.messages.subscribe", subscriptionsDuringLoad],
+        ["sessions.patch", sessionUpdates],
+      ] as const
+    ).map(([name, samples]) => ({
+      name: `Gateway ${name} probe`,
+      maxMs: options.maxControlMs,
+      samples,
+    })),
+  ].flatMap(({ name, maxMs, samples }) => {
+    if (maxMs === undefined) {
+      return [];
+    }
+    const violation = samples.find((sample) => !sample.ok || sample.latencyMs > maxMs);
+    return violation
+      ? [
+          `${name} exceeded ${maxMs}ms: ok=${violation.ok} ` +
+            `latencyMs=${violation.latencyMs.toFixed(1)} error=${violation.error ?? "none"}`,
+        ]
+      : [];
+  });
   return {
-    controlUiFailedSamples: runs.flatMap((run) => run.controlUi).filter((sample) => !sample.ok)
-      .length,
-    controlUiLatencyMs: summarizeNumbers(
-      runs.flatMap((run) => run.controlUi.map((sample) => sample.latencyMs)),
-    ),
+    budgetViolations,
+    controlUiFailedSamples: controlUi.filter((sample) => !sample.ok).length,
+    controlUiLatencyMs: summarizeNumbers(controlUi.map((sample) => sample.latencyMs)),
     cpuCoreRatio: summarizeNumbers(
       readyz.flatMap((sample) => (sample.cpuCoreRatio == null ? [] : [sample.cpuCoreRatio])),
     ),
@@ -1429,12 +1465,8 @@ function summarizeRuns(runs: readonly BenchmarkRun[]) {
     readyzFailedSamples: readyz.filter((sample) => !sample.ok).length,
     sampleCount: readyz.length,
     sessionSeedDurationMs: summarizeNumbers(runs.map((run) => run.sessionSeedDurationMs)),
-    sessionsListLatencyMs: summarizeNumbers(
-      runs.flatMap((run) => run.sessionsList.map((sample) => sample.latencyMs)),
-    ),
-    sessionsListFailedSamples: runs
-      .flatMap((run) => run.sessionsList)
-      .filter((sample) => !sample.ok).length,
+    sessionsListLatencyMs: summarizeNumbers(sessionsList.map((sample) => sample.latencyMs)),
+    sessionsListFailedSamples: sessionsList.filter((sample) => !sample.ok).length,
     sessionUpdateFailedSamples: sessionUpdates.filter((sample) => !sample.ok).length,
     sessionUpdateLatencyMs: summarizeNumbers(sessionUpdates.map((sample) => sample.latencyMs)),
     sessionUpdateSampleCount: sessionUpdates.length,
@@ -1496,7 +1528,7 @@ async function main(): Promise<void> {
     sessionUpdates: options.sessionUpdates,
     streamChunkDelayMs: options.streamChunkDelayMs,
     subscribers: options.subscribers,
-    summary: summarizeRuns(runs),
+    summary: summarizeRuns(runs, options),
     toolEvents: options.toolEvents,
     visibleObserver: options.visibleObserver,
     workspaceFanout: options.workspaceFanout,
@@ -1508,37 +1540,8 @@ async function main(): Promise<void> {
   if (options.json || !options.output) {
     console.log(JSON.stringify(payload, null, 2));
   }
-  if (options.maxHandshakeMs !== undefined) {
-    const violation = runs.find(
-      (run) => !run.freshConnection.ok || run.freshConnection.latencyMs > options.maxHandshakeMs!,
-    );
-    if (violation) {
-      throw new Error(
-        `fresh Gateway connection exceeded ${options.maxHandshakeMs}ms: ` +
-          `ok=${violation.freshConnection.ok} ` +
-          `latencyMs=${violation.freshConnection.latencyMs.toFixed(1)} ` +
-          `error=${violation.freshConnection.error ?? "none"}`,
-      );
-    }
-  }
-  if (options.maxControlMs !== undefined) {
-    const controlSamples: Array<{ name: string; sample: TimedProbe }> = [];
-    for (const run of runs) {
-      controlSamples.push(
-        ...run.readyz.map((sample) => ({ name: "readyz", sample })),
-        ...run.sessionsList.map((sample) => ({ name: "sessions.list", sample })),
-      );
-    }
-    const violation = controlSamples.find(
-      ({ sample }) => !sample.ok || sample.latencyMs > options.maxControlMs!,
-    );
-    if (violation) {
-      throw new Error(
-        `Gateway ${violation.name} probe exceeded ${options.maxControlMs}ms: ` +
-          `ok=${violation.sample.ok} latencyMs=${violation.sample.latencyMs.toFixed(1)} ` +
-          `error=${violation.sample.error ?? "none"}`,
-      );
-    }
+  if (payload.summary.budgetViolations.length > 0) {
+    throw new Error(payload.summary.budgetViolations.join("\n"));
   }
 }
 

--- a/src/agents/agent-project-settings-snapshot.ts
+++ b/src/agents/agent-project-settings-snapshot.ts
@@ -42,10 +42,6 @@ function sanitizeAgentSettingsSnapshot(settings: AgentSettingsSnapshot): AgentSe
   return sanitized;
 }
 
-function sanitizeProjectSettings(settings: AgentSettingsSnapshot): AgentSettingsSnapshot {
-  return sanitizeAgentSettingsSnapshot(settings);
-}
-
 function loadBundleSettingsFile(params: {
   rootDir: string;
   relativePath: string;
@@ -166,7 +162,7 @@ export function buildEmbeddedAgentSettingsSnapshot(params: {
     params.policy === "ignore"
       ? {}
       : params.policy === "sanitize"
-        ? sanitizeProjectSettings(params.projectSettings)
+        ? sanitizeAgentSettingsSnapshot(params.projectSettings)
         : params.projectSettings;
   const withPluginSettings = applyMergePatch(
     params.globalSettings,

--- a/src/agents/agent-project-settings.test.ts
+++ b/src/agents/agent-project-settings.test.ts
@@ -142,45 +142,70 @@ describe("buildEmbeddedAgentSettingsSnapshot", () => {
 });
 
 describe("createPreparedEmbeddedAgentSettingsManager", () => {
-  it("keeps trusted file-backed settings runtime-scoped after preparation", async () => {
-    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-settings-"));
-    try {
-      const cwd = path.join(baseDir, "workspace");
-      const agentDir = path.join(baseDir, "agent");
-      const projectSettingsDir = path.join(cwd, ".openclaw");
-      const agentSettingsPath = path.join(agentDir, "settings.json");
-      await fs.mkdir(projectSettingsDir, { recursive: true });
-      await fs.mkdir(agentDir, { recursive: true });
-      await fs.writeFile(
-        agentSettingsPath,
-        JSON.stringify({ retry: { enabled: true } }, null, 2),
-        "utf8",
-      );
-      await fs.writeFile(
-        path.join(projectSettingsDir, "settings.json"),
-        JSON.stringify({ shellCommandPrefix: "echo trusted &&" }, null, 2),
-        "utf8",
-      );
+  it.each([
+    { policy: "trusted", shellCommandPrefix: "echo trusted &&", reserveTokens: 32_000 },
+    { policy: "sanitize", shellCommandPrefix: "echo global &&", reserveTokens: 32_000 },
+    { policy: "ignore", shellCommandPrefix: "echo global &&", reserveTokens: 22_000 },
+  ] as const)(
+    "keeps $policy file-backed settings runtime-scoped after preparation",
+    async (testCase) => {
+      const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-settings-"));
+      try {
+        const cwd = path.join(baseDir, "workspace");
+        const agentDir = path.join(baseDir, "agent");
+        const projectSettingsDir = path.join(cwd, ".openclaw");
+        const agentSettingsPath = path.join(agentDir, "settings.json");
+        await fs.mkdir(projectSettingsDir, { recursive: true });
+        await fs.mkdir(agentDir, { recursive: true });
+        const globalSettings = {
+          retry: { enabled: true },
+          shellCommandPrefix: "echo global &&",
+          compaction: { reserveTokens: 22_000, keepRecentTokens: 23_000 },
+        };
+        await fs.writeFile(agentSettingsPath, JSON.stringify(globalSettings, null, 2), "utf8");
+        await fs.writeFile(
+          path.join(projectSettingsDir, "settings.json"),
+          JSON.stringify({
+            shellCommandPrefix: "echo trusted &&",
+            compaction: { reserveTokens: 32_000 },
+          }),
+          "utf8",
+        );
 
-      const settingsManager = createPreparedEmbeddedAgentSettingsManager({
-        cwd,
-        agentDir,
-        cfg: {
-          agents: { defaults: { embeddedAgent: { projectSettingsPolicy: "trusted" } } },
-        },
-      });
+        const params = {
+          cwd,
+          agentDir,
+          cfg: {
+            agents: { defaults: { embeddedAgent: { projectSettingsPolicy: testCase.policy } } },
+          },
+        };
+        const settingsManager = createPreparedEmbeddedAgentSettingsManager(params);
 
-      expect(settingsManager.getShellCommandPrefix()).toBe("echo trusted &&");
-      expect(settingsManager.getRetryEnabled()).toBe(false);
+        expect(settingsManager.getShellCommandPrefix()).toBe(testCase.shellCommandPrefix);
+        expect(settingsManager.getCompactionReserveTokens()).toBe(testCase.reserveTokens);
+        expect(settingsManager.getCompactionKeepRecentTokens()).toBe(23_000);
+        expect(settingsManager.getRetryEnabled()).toBe(false);
 
-      await settingsManager.flush();
+        await settingsManager.flush();
 
-      const diskSettings = JSON.parse(await fs.readFile(agentSettingsPath, "utf8")) as {
-        retry?: { enabled?: boolean };
-      };
-      expect(diskSettings.retry?.enabled).toBe(true);
-    } finally {
-      await fs.rm(baseDir, { recursive: true, force: true });
-    }
-  });
+        expect(JSON.parse(await fs.readFile(agentSettingsPath, "utf8"))).toEqual(globalSettings);
+
+        await fs.writeFile(
+          agentSettingsPath,
+          JSON.stringify({
+            ...globalSettings,
+            compaction: { ...globalSettings.compaction, keepRecentTokens: 45_000 },
+          }),
+        );
+        await settingsManager.reload();
+        expect(settingsManager.getCompactionKeepRecentTokens()).toBe(23_000);
+        expect(settingsManager.getRetryEnabled()).toBe(false);
+        const nextSettingsManager = createPreparedEmbeddedAgentSettingsManager(params);
+        expect(nextSettingsManager.getCompactionKeepRecentTokens()).toBe(45_000);
+        await nextSettingsManager.flush();
+      } finally {
+        await fs.rm(baseDir, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/src/agents/agent-project-settings.ts
+++ b/src/agents/agent-project-settings.ts
@@ -9,45 +9,6 @@ import {
 import { applyAgentCompactionSettingsFromConfig } from "./agent-settings.js";
 import { SettingsManager } from "./sessions/index.js";
 
-function createEmbeddedAgentSettingsManager(params: {
-  cwd: string;
-  agentDir: string;
-  cfg?: OpenClawConfig;
-  pluginMetadataSnapshot?: PluginMetadataSnapshot;
-}): SettingsManager {
-  const fileSettingsManager = SettingsManager.create(params.cwd, params.agentDir);
-  const policy = resolveEmbeddedAgentProjectSettingsPolicy(params.cfg);
-  const pluginSettings = loadEnabledBundleAgentSettingsSnapshot({
-    cwd: params.cwd,
-    cfg: params.cfg,
-    pluginMetadataSnapshot: params.pluginMetadataSnapshot,
-  });
-  const hasPluginSettings = Object.keys(pluginSettings).length > 0;
-  if (policy === "trusted" && !hasPluginSettings) {
-    return fileSettingsManager;
-  }
-  const settings = buildEmbeddedAgentSettingsSnapshot({
-    globalSettings: fileSettingsManager.getGlobalSettings(),
-    pluginSettings,
-    projectSettings: fileSettingsManager.getProjectSettings(),
-    policy,
-  });
-  return SettingsManager.inMemory(settings);
-}
-
-function createRuntimeEmbeddedAgentSettingsManager(
-  settingsManager: SettingsManager,
-): SettingsManager {
-  return SettingsManager.inMemory(
-    buildEmbeddedAgentSettingsSnapshot({
-      globalSettings: settingsManager.getGlobalSettings(),
-      pluginSettings: {},
-      projectSettings: settingsManager.getProjectSettings(),
-      policy: "trusted",
-    }),
-  );
-}
-
 /** Creates the runtime SettingsManager with project/plugin settings and compaction overrides. */
 export function createPreparedEmbeddedAgentSettingsManager(params: {
   cwd: string;
@@ -57,8 +18,15 @@ export function createPreparedEmbeddedAgentSettingsManager(params: {
   /** Resolved context window budget so reserve-token floor can be capped for small models. */
   contextTokenBudget?: number;
 }): SettingsManager {
-  const settingsManager = createRuntimeEmbeddedAgentSettingsManager(
-    createEmbeddedAgentSettingsManager(params),
+  const fileSettingsManager = SettingsManager.create(params.cwd, params.agentDir);
+  // Lock-backed reads stay authoritative; runtime writes and reloads use only this snapshot.
+  const settingsManager = SettingsManager.inMemory(
+    buildEmbeddedAgentSettingsSnapshot({
+      globalSettings: fileSettingsManager.getGlobalSettings(),
+      pluginSettings: loadEnabledBundleAgentSettingsSnapshot(params),
+      projectSettings: fileSettingsManager.getProjectSettings(),
+      policy: resolveEmbeddedAgentProjectSettingsPolicy(params.cfg),
+    }),
   );
   applyAgentCompactionSettingsFromConfig({
     settingsManager,

--- a/src/agents/agent-runtime-config.secret-owners.test.ts
+++ b/src/agents/agent-runtime-config.secret-owners.test.ts
@@ -111,6 +111,53 @@ afterEach(async () => {
 });
 
 describe("agent execution respects prepared secret owners", () => {
+  it("reads active config without copying reload-only plugin metadata", async () => {
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      agents: { defaults: { workspace: "/fixture/workspace" } },
+    };
+    const facts = createConfigResolutionFacts([]);
+    setConfigResolutionFacts(config, facts);
+    const manifestRegistry = {
+      plugins: [
+        {
+          id: "refresh-context-fixture",
+          channels: [],
+          providers: [],
+          cliBackends: [],
+          skills: [],
+          hooks: [],
+          origin: "bundled" as const,
+          rootDir: "/fixture/plugin",
+          source: "/fixture/plugin/index.js",
+          manifestPath: "/fixture/plugin/openclaw.plugin.json",
+        },
+      ],
+    };
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config,
+      env: {},
+      includeAuthStoreRefs: false,
+      manifestRegistry,
+    });
+    activateSecretsRuntimeSnapshot(snapshot);
+    const active = getActiveSecretsRuntimeConfigSnapshot();
+    const revision = getRuntimeConfigSnapshotMetadata()?.revision;
+    const clone = vi.spyOn(globalThis, "structuredClone");
+
+    const result = await resolveAgentRuntimeConfig(runtime);
+
+    expect(result.cfg).toBe(active?.config);
+    expect(result.loadedRaw).toBe(result.cfg);
+    expect(result.sourceConfig).toEqual(config);
+    expect(result.sourceConfig).not.toBe(active?.sourceConfig);
+    expect(getConfigResolutionFacts(result.sourceConfig)).toBe(facts);
+    result.sourceConfig.agents!.defaults!.workspace = "/fixture/changed-by-caller";
+    expect(active?.sourceConfig.agents?.defaults?.workspace).toBe("/fixture/workspace");
+    expect(getRuntimeConfigSnapshotMetadata()?.revision).toBe(revision);
+    expect(clone).not.toHaveBeenCalledWith(manifestRegistry);
+  });
+
   it.each(["reply", "agent"] as const)(
     "%s starts with a healthy provider while an unrelated explicit provider ref is cold",
     async (entry) => {

--- a/src/agents/agent-runtime-config.ts
+++ b/src/agents/agent-runtime-config.ts
@@ -5,12 +5,14 @@ import {
   getScopedChannelsCommandSecretTargets,
 } from "../cli/command-secret-targets.js";
 import { getRuntimeConfig, readConfigFileSnapshotForWrite } from "../config/io.js";
+import { cloneConfigWithResolutionFacts } from "../config/resolution-facts.js";
 import { setRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isSecretRef } from "../config/types.secrets.js";
 import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { getActiveSecretsRuntimeConfigSnapshot } from "../secrets/runtime-state.js";
 import { discoverConfigSecretTargetsByIds } from "../secrets/target-registry.js";
 import { listAgentEntries } from "./agent-scope.js";
 import { measureAgentStartup } from "./startup-timing.js";
@@ -36,15 +38,11 @@ export async function resolveAgentRuntimeConfig(
     includeChannelTargets,
     channel: channelSecretScope?.channel,
   });
-  const secretsRuntime = await measureAgentStartup(
-    "secrets-runtime-import",
-    () => import("../secrets/runtime.js"),
-    { config: loadedRaw },
-  );
-  const activeSecretsRuntimeSnapshot = secretsRuntime.getActiveSecretsRuntimeSnapshot();
+  const activeSecretsConfig = getActiveSecretsRuntimeConfigSnapshot();
   let pluginMetadataSnapshot: PluginMetadataSnapshot | undefined;
-  const sourceConfig = activeSecretsRuntimeSnapshot
-    ? activeSecretsRuntimeSnapshot.sourceConfig
+  // Callers own mutable source config, but do not need cloned auth stores or reload metadata.
+  const sourceConfig = activeSecretsConfig
+    ? cloneConfigWithResolutionFacts(activeSecretsConfig.sourceConfig)
     : await measureAgentStartup(
         "config-source",
         async () => {
@@ -87,13 +85,18 @@ export async function resolveAgentRuntimeConfig(
         ).resolvedConfig;
       })()
     : loadedRaw;
-  if (activeSecretsRuntimeSnapshot && cfg !== loadedRaw) {
+  if (activeSecretsConfig && cfg !== loadedRaw) {
     // Gateway activation already published loadedRaw with this source config. Republishing the
     // same object here would advance its lifecycle revision and evict revision-keyed hot caches.
     setRuntimeConfigSnapshot(cfg, sourceConfig);
-  } else if (!activeSecretsRuntimeSnapshot) {
+  } else if (!activeSecretsConfig) {
     // Standalone local agent commands have no Gateway-owned snapshot. Materialize
     // auth-profile refs too; resolving only config refs leaves selected credentials unusable.
+    const secretsRuntime = await measureAgentStartup(
+      "secrets-runtime-import",
+      () => import("../secrets/runtime.js"),
+      { config: cfg },
+    );
     const snapshot = await measureAgentStartup(
       "secrets-snapshot",
       () =>

--- a/src/commands/agent.runtime-config.test.ts
+++ b/src/commands/agent.runtime-config.test.ts
@@ -94,7 +94,12 @@ vi.mock("../config/runtime-snapshot.js", () => ({
   setRuntimeConfigSnapshot: setRuntimeConfigSnapshotMock,
 }));
 
-const getActiveSecretsRuntimeSnapshotMock = vi.hoisted(() => vi.fn<() => object | null>());
+const getActiveSecretsRuntimeConfigSnapshotMock = vi.hoisted(() =>
+  vi.fn<typeof import("../secrets/runtime-state.js").getActiveSecretsRuntimeConfigSnapshot>(),
+);
+vi.mock("../secrets/runtime-state.js", () => ({
+  getActiveSecretsRuntimeConfigSnapshot: getActiveSecretsRuntimeConfigSnapshotMock,
+}));
 const prepareSecretsRuntimeSnapshotMock = vi.hoisted(() =>
   vi.fn(
     async (params: {
@@ -113,7 +118,6 @@ const prepareSecretsRuntimeSnapshotMock = vi.hoisted(() =>
 );
 const activateSecretsRuntimeSnapshotMock = vi.hoisted(() => vi.fn());
 vi.mock("../secrets/runtime.js", () => ({
-  getActiveSecretsRuntimeSnapshot: getActiveSecretsRuntimeSnapshotMock,
   prepareSecretsRuntimeSnapshot: prepareSecretsRuntimeSnapshotMock,
   activateSecretsRuntimeSnapshot: activateSecretsRuntimeSnapshotMock,
 }));
@@ -163,8 +167,10 @@ function mockConfig(home: string, storePath: string): OpenClawConfig {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getActiveSecretsRuntimeSnapshotMock.mockImplementation(() => ({
+  getActiveSecretsRuntimeConfigSnapshotMock.mockImplementation(() => ({
+    config: loadConfigMock(),
     sourceConfig: loadConfigMock(),
+    configRefsPrepared: true,
   }));
   readConfigFileSnapshotForWriteMock.mockResolvedValue({
     snapshot: { valid: false, resolved: {} as OpenClawConfig },
@@ -186,7 +192,7 @@ describe("agentCommand runtime config", () => {
         snapshot: { valid: true, resolved: sourceConfig },
         writeOptions: { basePluginMetadataSnapshot: pluginMetadataSnapshot },
       });
-      getActiveSecretsRuntimeSnapshotMock.mockReturnValue(null);
+      getActiveSecretsRuntimeConfigSnapshotMock.mockReturnValue(null);
 
       await resolveAgentRuntimeConfig(runtime);
 
@@ -258,7 +264,11 @@ describe("agentCommand runtime config", () => {
         snapshot: { valid: true, resolved: sourceConfig },
         writeOptions: {},
       });
-      getActiveSecretsRuntimeSnapshotMock.mockReturnValue({ sourceConfig });
+      getActiveSecretsRuntimeConfigSnapshotMock.mockReturnValue({
+        config: loadedConfig,
+        sourceConfig,
+        configRefsPrepared: true,
+      });
       resolveCommandConfigWithSecretsMock.mockResolvedValueOnce({
         resolvedConfig,
         effectiveConfig: resolvedConfig,
@@ -431,7 +441,8 @@ describe("agentCommand runtime config", () => {
       expect(resolveCommandConfigWithSecretsMock).not.toHaveBeenCalled();
       expect(setRuntimeConfigSnapshotMock).not.toHaveBeenCalled();
       expect(prepared.cfg).toBe(loadedConfig);
-      expect(prepared.sourceConfig).toBe(loadedConfig);
+      expect(prepared.sourceConfig).toEqual(loadedConfig);
+      expect(prepared.sourceConfig).not.toBe(loadedConfig);
     });
   });
 

--- a/src/gateway/assistant-identity.test.ts
+++ b/src/gateway/assistant-identity.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { AVATAR_MAX_DATA_URL_CHARS } from "../shared/avatar-limits.js";
 import { AVATAR_MAX_BYTES } from "../shared/avatar-policy.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
@@ -28,15 +29,49 @@ describe("resolveAssistantIdentity", () => {
     expect(identity.avatar).toBe("W");
   });
 
-  it("uses the first roster entry for presentation on an explicit fleet", () => {
-    const identity = resolveAssistantIdentity({
+  it.each<{
+    name: string;
+    cfg: OpenClawConfig;
+    agentId?: string;
+    expected: string;
+  }>([
+    { name: "implicit main", cfg: {}, expected: "main" },
+    { name: "sole agent", cfg: { agents: { entries: { research: {} } } }, expected: "research" },
+    {
+      name: "first explicit roster entry, not the ambient system owner",
+      cfg: {
+        agents: {
+          ownership: "explicit",
+          entries: { ops: {}, research: {} },
+          defaults: { systemAgent: { agentId: "research" } },
+        },
+      },
+      expected: "ops",
+    },
+    {
+      name: "retained legacy owner",
+      cfg: retainLegacyDefaultAgentId(
+        { agents: { ownership: "explicit", entries: { ops: {}, research: {} } } },
+        "research",
+      ),
+      expected: "research",
+    },
+    {
+      name: "normalized explicit selection",
       cfg: { agents: { ownership: "explicit", entries: { ops: {}, research: {} } } },
+      agentId: "RESEARCH",
+      expected: "research",
+    },
+  ])("uses $name for presentation", ({ cfg, agentId, expected }) => {
+    const identity = resolveAssistantIdentity({
+      cfg,
+      agentId,
       workspaceDir: "",
     });
 
     expect(identity).toEqual({
       ...DEFAULT_ASSISTANT_IDENTITY,
-      agentId: "ops",
+      agentId: expected,
       nameSource: "default",
     });
   });

--- a/src/gateway/assistant-identity.ts
+++ b/src/gateway/assistant-identity.ts
@@ -101,16 +101,20 @@ function normalizeEmojiValue(value: string | undefined): string | undefined {
   return value;
 }
 
+// Presentation may choose the first roster entry even when ambient work needs an explicit owner.
+export function resolveAssistantAgentId(cfg: OpenClawConfig, agentId?: string | null): string {
+  return normalizeAgentId(
+    agentId ?? tryResolveLegacyCompatibilityAgentId(cfg) ?? listAgentEntries(cfg)[0]?.id ?? "main",
+  );
+}
+
 /** Resolve the display name/avatar/emoji for an agent-facing assistant identity. */
 export function resolveAssistantIdentity(params: {
   cfg: OpenClawConfig;
   agentId?: string | null;
   workspaceDir?: string | null;
 }): ResolvedAssistantIdentity {
-  const compatibilityAgentId = tryResolveLegacyCompatibilityAgentId(params.cfg);
-  const presentationAgentId =
-    params.agentId ?? compatibilityAgentId ?? listAgentEntries(params.cfg)[0]?.id ?? "main";
-  const agentId = normalizeAgentId(presentationAgentId);
+  const agentId = resolveAssistantAgentId(params.cfg, params.agentId);
   const workspaceDir = params.workspaceDir ?? resolveAgentWorkspaceDir(params.cfg, agentId);
   const agentIdentity = resolveAgentIdentity(params.cfg, agentId);
   const fileIdentity = workspaceDir ? loadAgentIdentity(workspaceDir) : null;

--- a/src/gateway/control-ui-static.test.ts
+++ b/src/gateway/control-ui-static.test.ts
@@ -20,11 +20,13 @@ function openFile(body: string) {
   const filePath = path.join(tempDirs.make("openclaw-ui-read-"), "asset.txt");
   fs.writeFileSync(filePath, body);
   const fd = fs.openSync(filePath, "r");
+  vi.spyOn(fs, "closeSync");
   return { filePath, fd, size: fs.fstatSync(fd).size };
 }
 
 function expectClosed(fd: number) {
-  expect(() => fs.fstatSync(fd)).toThrow(expect.objectContaining({ code: "EBADF" }));
+  // Observe release itself: after awaiting the read, another worker may reuse the fd number.
+  expect(fs.closeSync).toHaveBeenCalledWith(fd);
 }
 
 describe("pinned Control UI file reads", () => {

--- a/src/gateway/control-ui-static.test.ts
+++ b/src/gateway/control-ui-static.test.ts
@@ -1,0 +1,73 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { readAndCloseControlUiFile } from "./control-ui-static.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => vi.restoreAllMocks());
+
+type ReadChunk = (
+  fd: number,
+  buffer: Buffer,
+  offset: number,
+  length: number,
+  position: number | null,
+  callback: (error: NodeJS.ErrnoException | null, bytesRead: number, buffer: Buffer) => void,
+) => void;
+
+function openFile(body: string) {
+  const filePath = path.join(tempDirs.make("openclaw-ui-read-"), "asset.txt");
+  fs.writeFileSync(filePath, body);
+  const fd = fs.openSync(filePath, "r");
+  return { filePath, fd, size: fs.fstatSync(fd).size };
+}
+
+function expectClosed(fd: number) {
+  expect(() => fs.fstatSync(fd)).toThrow(expect.objectContaining({ code: "EBADF" }));
+}
+
+describe("pinned Control UI file reads", () => {
+  it.each([0, 512 * 1024 + 19])("reads and closes a file of %i bytes", async (size) => {
+    const body = "x".repeat(size);
+    const file = openFile(body);
+    const result = await readAndCloseControlUiFile(file);
+    expect(result.toString()).toBe(body);
+    expectClosed(file.fd);
+  });
+
+  it("fills short reads without adding bytes beyond the pinned size", async () => {
+    const file = openFile("a small static response");
+    const read = fs.read;
+    const shortRead: ReadChunk = (fd, buffer, offset, length, position, callback) =>
+      read(fd, buffer, offset, Math.min(length, 3), position, callback);
+    vi.spyOn(fs, "read").mockImplementation(shortRead as typeof fs.read);
+    expect((await readAndCloseControlUiFile(file)).toString()).toBe("a small static response");
+    expectClosed(file.fd);
+  });
+
+  it("returns only bytes read when the pinned file is truncated", async () => {
+    const file = openFile("original longer content");
+    fs.writeFileSync(file.filePath, "short");
+    expect((await readAndCloseControlUiFile(file)).toString()).toBe("short");
+    expectClosed(file.fd);
+  });
+
+  it("closes the descriptor when a read fails", async () => {
+    const file = openFile("response");
+    const error = Object.assign(new Error("synthetic read failure"), { code: "EIO" });
+    const failRead: ReadChunk = (_fd, buffer, _offset, _length, _position, callback) =>
+      queueMicrotask(() => callback(error, 0, buffer));
+    vi.spyOn(fs, "read").mockImplementation(failRead as typeof fs.read);
+    await expect(readAndCloseControlUiFile(file)).rejects.toBe(error);
+    expectClosed(file.fd);
+  });
+
+  it("retains the readFile allocation limit and closes before rejecting", async () => {
+    const file = openFile("");
+    await expect(readAndCloseControlUiFile({ ...file, size: 2 ** 31 })).rejects.toMatchObject({
+      code: "ERR_FS_FILE_TOO_LARGE",
+    });
+    expectClosed(file.fd);
+  });
+});

--- a/src/gateway/control-ui-static.ts
+++ b/src/gateway/control-ui-static.ts
@@ -370,28 +370,40 @@ export async function sendControlUiHtmlBody(
   res.end(encoding === "identity" ? body : await cachedCompressedControlUiHtml(body, encoding));
 }
 
-function readOpenedFile(fd: number): Promise<Buffer> {
-  return new Promise((resolve, reject) => {
-    fs.readFile(fd, (error, data) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve(data);
-    });
-  });
-}
-
-// Compression can wait in zlib's worker queue, so release the pinned file as
-// soon as its bytes are loaded instead of retaining descriptors per request.
-export async function readAndCloseControlUiFile(fd: number): Promise<Buffer> {
+// Reuse the stat captured by safe open: another queued fstat adds a full
+// event-loop wait under load. Keep Node readFile's allocation and chunk limits;
+// this read ends at the pinned size, even if the file subsequently grows.
+export async function readAndCloseControlUiFile(file: {
+  fd: number;
+  size: number;
+}): Promise<Buffer> {
   try {
-    return await readOpenedFile(fd);
+    if (file.size > 2 ** 31 - 1) {
+      throw Object.assign(new RangeError("Control UI file exceeds the 2 GiB read limit"), {
+        code: "ERR_FS_FILE_TOO_LARGE",
+      });
+    }
+    const buffer = Buffer.allocUnsafe(file.size);
+    let offset = 0;
+    while (offset < buffer.length) {
+      const length = Math.min(512 * 1024, buffer.length - offset);
+      const bytesRead = await new Promise<number>((resolve, reject) => {
+        fs.read(file.fd, buffer, offset, length, null, (error, count) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve(count);
+          }
+        });
+      });
+      if (bytesRead === 0) {
+        break;
+      }
+      offset += bytesRead;
+    }
+    return buffer.subarray(0, offset);
   } finally {
-    fs.closeSync(fd);
+    // Release before compression waits in zlib's worker queue.
+    fs.closeSync(file.fd);
   }
-}
-
-export async function readAndCloseControlUiFileText(fd: number): Promise<string> {
-  return (await readAndCloseControlUiFile(fd)).toString("utf8");
 }

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -1,5 +1,6 @@
 // Control UI HTTP tests cover static asset serving, bootstrap config, avatar and
 // assistant media routes, pairing helpers, and session-generation metadata.
+import { AsyncLocalStorage, createHook } from "node:async_hooks";
 import { createHash, randomUUID } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
@@ -3226,6 +3227,60 @@ describe("handleControlUiHttpRequest", () => {
         expect(handled).toBe(true);
         expect(res.statusCode).toBe(200);
         expect(responseBody(end)).toBe("inside-ok\n");
+      },
+    });
+  });
+
+  it.each(["/", "/settings", "/assets/actual.txt"])(
+    "serves a pinned small file in one asynchronous filesystem operation at %s",
+    async (url) => {
+      await withControlUiRoot({
+        fn: async (tmp) => {
+          await writeAssetFile(tmp, "actual.txt", "inside-ok\n");
+          const requestScope = new AsyncLocalStorage<boolean>();
+          let filesystemOperations = 0;
+          const hook = createHook({
+            init(_id, type) {
+              if (type === "FSREQCALLBACK" && requestScope.getStore()) {
+                filesystemOperations += 1;
+              }
+            },
+          }).enable();
+          try {
+            const { res, end, handled } = await requestScope.run(true, () =>
+              runControlUiRequest({ url, method: "GET", rootPath: tmp }),
+            );
+            expect(handled).toBe(true);
+            expect(res.statusCode).toBe(200);
+            expect(responseBody(end)).toContain(url.startsWith("/assets/") ? "inside-ok" : "<html");
+            // Safe open already captured stat; a second queued metadata read adds
+            // another event-loop wait before these bytes can reach the browser.
+            expect(filesystemOperations).toBe(1);
+          } finally {
+            hook.disable();
+          }
+        },
+      });
+    },
+  );
+
+  it("bounds a static response by the size captured with its pinned descriptor", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { filePath } = await writeAssetFile(tmp, "actual.txt", "original");
+        const fstat = fsSync.fstatSync;
+        vi.spyOn(fsSync, "fstatSync").mockImplementationOnce((fd) => {
+          const stat = fstat(fd);
+          fsSync.appendFileSync(filePath, "-appended-after-open");
+          return stat;
+        });
+        const { res, end } = await runControlUiRequest({
+          url: "/assets/actual.txt",
+          method: "GET",
+          rootPath: tmp,
+        });
+        expect(res.statusCode).toBe(200);
+        expect(responseBody(end)).toBe("original");
       },
     });
   });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -1025,34 +1025,7 @@ export async function handleControlUiHttpRequest(
       safeFile = resolveSafeControlUiFile(retained.rootRealPath, retained.filePath, true);
     }
   }
-  if (safeFile) {
-    if (path.basename(safeFile.path) === "index.html") {
-      if (req.method === "HEAD") {
-        try {
-          const encoding = resolveControlUiHtmlEncoding(req);
-          if (encoding === "not-acceptable") {
-            respondControlUiNotAcceptable(res);
-            return true;
-          }
-          respondHeadForControlUiFile(res, safeFile.path, {
-            encoding: encoding === "identity" ? undefined : encoding,
-          });
-          return true;
-        } finally {
-          fs.closeSync(safeFile.fd);
-        }
-      }
-      const body = (await readAndCloseControlUiFile(safeFile)).toString("utf8");
-      await serveResolvedIndexHtml(
-        req,
-        res,
-        body,
-        basePath,
-        terminalEnabled,
-        opts?.config?.gateway?.controlUi?.environment,
-      );
-      return true;
-    }
+  if (safeFile && path.basename(safeFile.path) !== "index.html") {
     // Filesystem clocks may lead this host; validators cannot postdate message
     // origination or a future date would 304 later replacements (mirrors
     // resolveByteResponse in http-byte-range.ts).
@@ -1095,24 +1068,23 @@ export async function handleControlUiHttpRequest(
     return true;
   }
 
-  // If the requested path looks like a static asset (known extension), return
-  // 404 rather than falling through to the SPA index.html fallback.  We check
-  // against the same extension set used by the static response helper so
-  // that dotted SPA routes (e.g. /user/jane.doe, /v2.0) still get the
-  // client-side router fallback.
-  if (isControlUiStaticAssetExtension(path.extname(fileRel).toLowerCase())) {
-    respondControlUiNotFound(res);
-    return true;
+  if (!safeFile) {
+    // Missing assets stay 404; dotted routes can still use the SPA document.
+    if (isControlUiStaticAssetExtension(path.extname(fileRel).toLowerCase())) {
+      respondControlUiNotFound(res);
+      return true;
+    }
+    if (!route.spaFallback) {
+      return false;
+    }
+    const indexPath = path.resolve(root, "index.html");
+    if (filePath !== indexPath) {
+      safeFile = resolveSafeControlUiFile(rootReal, indexPath, rejectHardlinks);
+    }
   }
 
-  if (!route.spaFallback) {
-    return false;
-  }
-
-  // SPA fallback (client-side router): serve index.html for unknown paths.
-  const indexPath = path.join(root, "index.html");
-  const safeIndex = resolveSafeControlUiFile(rootReal, indexPath, rejectHardlinks);
-  if (safeIndex) {
+  // Direct documents and SPA fallbacks share rewriting, CSP, encoding and fd ownership.
+  if (safeFile) {
     if (req.method === "HEAD") {
       try {
         const encoding = resolveControlUiHtmlEncoding(req);
@@ -1120,15 +1092,15 @@ export async function handleControlUiHttpRequest(
           respondControlUiNotAcceptable(res);
           return true;
         }
-        respondHeadForControlUiFile(res, safeIndex.path, {
+        respondHeadForControlUiFile(res, safeFile.path, {
           encoding: encoding === "identity" ? undefined : encoding,
         });
         return true;
       } finally {
-        fs.closeSync(safeIndex.fd);
+        fs.closeSync(safeFile.fd);
       }
     }
-    const body = (await readAndCloseControlUiFile(safeIndex)).toString("utf8");
+    const body = (await readAndCloseControlUiFile(safeFile)).toString("utf8");
     await serveResolvedIndexHtml(
       req,
       res,

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -76,7 +76,6 @@ import {
   isControlUiPrecompressedAssetExtension,
   isControlUiStaticAssetExtension,
   readAndCloseControlUiFile,
-  readAndCloseControlUiFileText,
   resolveControlUiHtmlEncoding,
   resolveOpenedControlUiRepresentation,
   respondControlUiNotAcceptable,
@@ -1043,7 +1042,7 @@ export async function handleControlUiHttpRequest(
           fs.closeSync(safeFile.fd);
         }
       }
-      const body = await readAndCloseControlUiFileText(safeFile.fd);
+      const body = (await readAndCloseControlUiFile(safeFile)).toString("utf8");
       await serveResolvedIndexHtml(
         req,
         res,
@@ -1087,7 +1086,7 @@ export async function handleControlUiHttpRequest(
         fs.closeSync(representation.bodyFile.fd);
       }
     }
-    const body = await readAndCloseControlUiFile(representation.bodyFile.fd);
+    const body = await readAndCloseControlUiFile(representation.bodyFile);
     await serveControlUiAsset(res, representation.contentPath, body, {
       immutable: immutableAsset,
       encoding: representation.encoding,
@@ -1129,7 +1128,7 @@ export async function handleControlUiHttpRequest(
         fs.closeSync(safeIndex.fd);
       }
     }
-    const body = await readAndCloseControlUiFileText(safeIndex.fd);
+    const body = (await readAndCloseControlUiFile(safeIndex)).toString("utf8");
     await serveResolvedIndexHtml(
       req,
       res,

--- a/src/gateway/server-chat-metadata-lifecycle.integration.test.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.integration.test.ts
@@ -441,9 +441,9 @@ describe("gateway chat metadata lifecycle composition", () => {
         }
         const expectNativeAvailable = async (available: boolean) => {
           const expected = { models: expectedModels(available) };
-          await expect(
-            lifecycle.readStartup({ agentId: "main", readPolicy: "ready" }),
-          ).resolves.toMatchObject({ metadata: expected });
+          const catalogs = await lifecycle.readStartup({ agentId: "main", readPolicy: "ready" });
+          expect(catalogs?.sessionModelCatalog).toBe(catalogs?.defaultModelCatalog);
+          expect(catalogs).not.toHaveProperty("metadata");
           await expect(lifecycle.read({ agentId: "main" })).resolves.toMatchObject(expected);
           await expect(lifecycle.readStartup({ agentId: "main" })).resolves.toMatchObject({
             metadata: expected,
@@ -497,13 +497,21 @@ describe("gateway chat metadata lifecycle composition", () => {
             ? []
             : [expect.objectContaining({ id: "codex-latest", available: false })],
         });
+        const lockedStartup = await lifecycle.readStartup({
+          agentId: "main",
+          sessionEntry: lockedSession,
+        });
+        expect(lockedStartup?.metadata).toEqual(lockedMetadata);
         await expect(
           lifecycle.readStartup({
             agentId: "main",
             sessionEntry: lockedSession,
             readPolicy: "ready",
           }),
-        ).resolves.toMatchObject({ metadata: lockedMetadata });
+        ).resolves.toEqual({
+          sessionModelCatalog: lockedStartup?.sessionModelCatalog,
+          defaultModelCatalog: lockedStartup?.defaultModelCatalog,
+        });
 
         currentConfig = { ...nativeConfig };
         await lifecycle.refresh();

--- a/src/gateway/server-http.control-ui.test.ts
+++ b/src/gateway/server-http.control-ui.test.ts
@@ -1,0 +1,64 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import nodePath from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { withTempDir } from "../test-utils/temp-dir.js";
+import { AUTH_NONE, sendRequest, withGatewayServer } from "./server-http.test-harness.js";
+
+describe("Gateway Control UI identity", () => {
+  it("keeps static requests independent of workspace identity reads while bootstrap resolves identity", async () => {
+    await withTempDir("openclaw-http-identity-", async (controlUiRoot) => {
+      await fs.writeFile(nodePath.join(controlUiRoot, "index.html"), "<html>synthetic UI</html>\n");
+      const workspace = await fs.realpath(controlUiRoot);
+      await fs.writeFile(
+        nodePath.join(controlUiRoot, "IDENTITY.md"),
+        "- Name: Synthetic assistant\n",
+      );
+      await fs.mkdir(nodePath.join(controlUiRoot, "assets"));
+      await fs.writeFile(nodePath.join(controlUiRoot, "assets", "app.js"), "// synthetic asset\n");
+      await withGatewayServer({
+        prefix: "control-ui-static-identity",
+        resolvedAuth: AUTH_NONE,
+        overrides: {
+          controlUiEnabled: true,
+          controlUiBasePath: "",
+          controlUiRoot: { kind: "resolved", path: controlUiRoot },
+          getRuntimeConfig: () => ({
+            agents: {
+              ownership: "explicit",
+              entries: { ops: { workspace }, research: {} },
+              defaults: { systemAgent: { agentId: "research" } },
+            },
+          }),
+        },
+        run: async (server) => {
+          const realpath = vi.spyOn(fsSync, "realpathSync");
+          const identityReads = () =>
+            realpath.mock.calls.filter(
+              ([file]) => nodePath.basename(String(file)) === "IDENTITY.md",
+            );
+          try {
+            for (const path of ["/", "/chat", "/assets/app.js"]) {
+              const response = await sendRequest(server, { path, method: "GET" });
+              expect(response.res.statusCode, path).toBe(200);
+            }
+            expect(identityReads()).toHaveLength(0);
+
+            const bootstrap = await sendRequest(server, {
+              path: "/control-ui-config.json",
+              method: "GET",
+            });
+            expect(JSON.parse(bootstrap.getBody())).toMatchObject({
+              assistantAgentId: "ops",
+              assistantName: "Synthetic assistant",
+              localMediaPreviewRoots: expect.arrayContaining([workspace]),
+            });
+            expect(identityReads().length).toBeGreaterThan(0);
+          } finally {
+            realpath.mockRestore();
+          }
+        },
+      });
+    });
+  });
+});

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -19,7 +19,7 @@ import {
 import { runHttpConnectionRequest } from "../infra/http-request-lifecycle.js";
 import { parseDevicePairingJoinRequestPath } from "../pairing/join-code.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
-import { resolveAssistantIdentity } from "./assistant-identity.js";
+import { resolveAssistantAgentId } from "./assistant-identity.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import {
@@ -351,7 +351,7 @@ export function createGatewayHttpServer(opts: {
         (await getControlUiModule()).handleControlUiHttpRequest(req, res, {
           ...controlUiRouteOptions,
           terminalEnabled: opts.isTerminalEnabled?.() ?? isTerminalConfigEnabled(configSnapshot),
-          agentId: resolveAssistantIdentity({ cfg: configSnapshot }).agentId,
+          agentId: resolveAssistantAgentId(configSnapshot),
           root: controlUiRoot,
         });
       const handleStandaloneControlUiRequest = async () => {
@@ -677,7 +677,7 @@ export function createGatewayHttpServer(opts: {
       addRequestStage(controlUiEnabled, async () =>
         (await getControlUiModule()).handleControlUiAssistantMediaRequest(req, res, {
           ...controlUiRouteOptions,
-          agentId: resolveAssistantIdentity({ cfg: configSnapshot }).agentId,
+          agentId: resolveAssistantAgentId(configSnapshot),
         }),
       );
       addRequestStage(controlUiEnabled, async () =>

--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -478,17 +478,24 @@ async function handleChatHistoryRequest({
   if (Object.hasOwn(historyPage, "activeLeafEntryId")) {
     sessionInfo.activeLeafEntryId = historyPage.activeLeafEntryId ?? null;
   }
-  const defaults = getSessionDefaults(cfg, defaultModelCatalog, {
-    agentId: sessionAgentId,
-    allowPluginNormalization: false,
-    providerPolicySource: "active",
-  });
+  // Cursor responses publish sessionInfo only; the default-model projection is unused.
+  const defaults =
+    cursor === undefined
+      ? getSessionDefaults(cfg, defaultModelCatalog, {
+          agentId: sessionAgentId,
+          allowPluginNormalization: false,
+          providerPolicySource: "active",
+        })
+      : undefined;
   // Unprepared catalog facts are unknown, not an Off default or a smaller profile.
   // Omission lets clients retain richer same-identity metadata; authored defaults still apply.
   for (const [projection, catalog] of [
     [sessionInfo, sessionModelCatalog],
     [defaults, defaultModelCatalog],
   ] as const) {
+    if (!projection) {
+      continue;
+    }
     const provider = projection.modelProvider;
     const model = projection.model;
     const catalogEntry =

--- a/src/gateway/server-methods/chat-metadata-runtime.test-support.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.test-support.ts
@@ -95,6 +95,9 @@ export function createChatMetadataHarness(
       };
     },
   );
+  const readProjection = vi.fn(
+    (projection: { modelCatalog: ModelCatalogEntry[]; models?: unknown[] }) => projection,
+  );
   const context = {
     getRuntimeConfig: () => config,
     loadGatewayModelCatalogSnapshot: async (params?: { readOnly?: boolean }) => {
@@ -135,7 +138,8 @@ export function createChatMetadataHarness(
             buildProjection: async (params) => {
               const projection = await buildProjection(params);
               return {
-                read: () => projection,
+                modelCatalog: projection.modelCatalog,
+                read: () => ({ models: readProjection(projection).models }),
                 isCurrent: () => !invalidProjections.has(projection),
               };
             },
@@ -145,6 +149,7 @@ export function createChatMetadataHarness(
   return {
     buildCommands,
     buildProjection,
+    readProjection,
     getPluginRegistryVersion,
     getAuthStoreRevision,
     getPreparedAuthStore,

--- a/src/gateway/server-methods/chat-metadata-runtime.test.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.test.ts
@@ -144,13 +144,36 @@ describe("gateway chat metadata runtime", () => {
     ]);
     expect(second).toEqual(first);
     expect(first?.defaultModelCatalog).toBe(first?.sessionModelCatalog);
-    expect(first?.metadata.models).toEqual(first?.sessionModelCatalog);
+    expect(first?.metadata?.models).toEqual(first?.sessionModelCatalog);
     expect(harness.buildProjection).toHaveBeenCalledTimes(1);
     expect(harness.getPreparedOwner).not.toHaveBeenCalled();
     expect(harness.getPreparedAuthStore).not.toHaveBeenCalled();
     expect(harness.getAuthStoreRevision).not.toHaveBeenCalled();
     expect(harness.getSkillsVersion).not.toHaveBeenCalled();
     expect(harness.getPluginRegistryVersion).not.toHaveBeenCalled();
+  });
+
+  test("reads settled history catalogs without projecting public model metadata", async () => {
+    const harness = createChatMetadataHarness();
+    await harness.runtime.refresh();
+    harness.readProjection.mockClear();
+
+    for (let read = 0; read < 3; read += 1) {
+      const projection = await harness.runtime.readStartup({
+        agentId: "main",
+        readPolicy: "ready",
+      });
+      expect(projection?.sessionModelCatalog).toEqual([
+        expect.objectContaining({ id: "first", provider: "test" }),
+      ]);
+      expect(projection?.defaultModelCatalog).toBe(projection?.sessionModelCatalog);
+      expect(projection).not.toHaveProperty("metadata");
+    }
+
+    expect(harness.readProjection).not.toHaveBeenCalled();
+    const startup = await harness.runtime.readStartup({ agentId: "main" });
+    expect(startup?.metadata?.models).toEqual(startup?.sessionModelCatalog);
+    expect(harness.readProjection).toHaveBeenCalledOnce();
   });
 
   test("keeps large-roster neutral projections prepared outside the session cache", async () => {
@@ -249,7 +272,11 @@ describe("gateway chat metadata runtime", () => {
       await Promise.all([canonical, optional]);
     }
     const ready = await harness.runtime.readStartup(params);
-    expect(ready).toEqual(await canonical);
+    const startup = await canonical;
+    expect(ready).toEqual({
+      sessionModelCatalog: startup?.sessionModelCatalog,
+      defaultModelCatalog: startup?.defaultModelCatalog,
+    });
     expect(ready?.sessionModelCatalog).toBe(profileCatalog);
     expect(ready?.defaultModelCatalog).toEqual([expect.objectContaining({ id: "first" })]);
     for (const other of [
@@ -296,7 +323,10 @@ describe("gateway chat metadata runtime", () => {
       for (let read = 0; read < 2; read++) {
         await expect(
           harness.runtime.readStartup({ ...params, readPolicy: "ready" }),
-        ).resolves.toEqual(canonical);
+        ).resolves.toEqual({
+          sessionModelCatalog: canonical?.sessionModelCatalog,
+          defaultModelCatalog: canonical?.defaultModelCatalog,
+        });
       }
       expect(harness.buildProjection).toHaveBeenCalledTimes(3);
     },
@@ -379,7 +409,10 @@ describe("gateway chat metadata runtime", () => {
             sessionEntry,
             readPolicy: "ready",
           }),
-        ).resolves.toEqual(newer);
+        ).resolves.toEqual({
+          sessionModelCatalog: newer?.sessionModelCatalog,
+          defaultModelCatalog: newer?.defaultModelCatalog,
+        });
         await expect(
           harness.runtime.readStartup({ agentId: "main", sessionEntry }),
         ).resolves.toEqual(newer);

--- a/src/gateway/server-methods/chat-metadata-runtime.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.ts
@@ -57,15 +57,14 @@ type PreparedAgentMetadata = PreparedAgentFacts & {
   swarmEnabled: boolean;
 };
 
-type PreparedAgentProjection = {
-  metadata: ChatMetadataResult;
+type PreparedAgentProjection<T = ChatMetadataResult> = PreparedProjection<T> & {
   modelCatalog: ModelCatalogEntry[];
 };
 type PreparedProjection<T> = { read: () => T; isCurrent: () => boolean };
 
 type AgentProjectionEntry =
-  | { state: "pending"; promise: Promise<PreparedProjection<PreparedAgentProjection>> }
-  | { state: "ready"; projection: PreparedProjection<PreparedAgentProjection> };
+  | { state: "pending"; promise: Promise<PreparedAgentProjection> }
+  | { state: "ready"; projection: PreparedAgentProjection };
 
 type PreparedMetadataGeneration = {
   epoch: number;
@@ -103,7 +102,7 @@ type ChatMetadataRuntimeDeps = {
     facts: PreparedAgentFacts;
     preferredProfileId?: string;
     lockedProfileId?: string;
-  }) => Promise<PreparedProjection<{ modelCatalog: ModelCatalogEntry[]; models?: unknown[] }>>;
+  }) => Promise<PreparedAgentProjection<{ models?: unknown[] }>>;
 };
 
 const CHAT_METADATA_CACHE_MAX_ENTRIES = 64;
@@ -237,7 +236,7 @@ async function defaultBuildProjection(params: {
   facts: PreparedAgentFacts;
   preferredProfileId?: string;
   lockedProfileId?: string;
-}): Promise<PreparedProjection<{ modelCatalog: ModelCatalogEntry[]; models?: unknown[] }>> {
+}): Promise<PreparedAgentProjection<{ models?: unknown[] }>> {
   const { prepareModelsListResult, createGatewayAgentModelCatalogProjector } =
     await import("./models-list-result.js");
   // Chat metadata must stay on process-published facts. Live discovery belongs to explicit
@@ -273,7 +272,8 @@ async function defaultBuildProjection(params: {
     }),
   ]);
   return {
-    read: () => ({ modelCatalog, models: readModels.read().models }),
+    modelCatalog,
+    read: () => ({ models: readModels.read().models }),
     isCurrent: readModels.isCurrent,
   };
 }
@@ -327,7 +327,7 @@ export function createGatewayChatMetadataRuntime(params: {
     generation: PreparedMetadataGeneration,
     agent: PreparedAgentMetadata,
     sessionEntry?: ChatMetadataSessionEntry,
-  ): Promise<PreparedProjection<PreparedAgentProjection>> => {
+  ): Promise<PreparedAgentProjection> => {
     const profiles = resolveSessionProfiles(sessionEntry);
     const neutral =
       profiles.preferredProfileId === undefined && profiles.lockedProfileId === undefined;
@@ -353,19 +353,13 @@ export function createGatewayChatMetadataRuntime(params: {
         ...profiles,
       })
       .then((prepared) => {
-        const preparedProjection: PreparedProjection<PreparedAgentProjection> = {
-          isCurrent: prepared.isCurrent,
-          read: () => {
-            const { modelCatalog, ...models } = prepared.read();
-            return {
-              modelCatalog,
-              metadata: {
-                ...models,
-                ...(agent.commands !== undefined ? { commands: agent.commands } : {}),
-                swarmEnabled: agent.swarmEnabled,
-              },
-            };
-          },
+        const preparedProjection: PreparedAgentProjection = {
+          ...prepared,
+          read: () => ({
+            ...prepared.read(),
+            ...(agent.commands !== undefined ? { commands: agent.commands } : {}),
+            swarmEnabled: agent.swarmEnabled,
+          }),
         };
         // Only this pending entry may publish its settlement; eviction or invalidation
         // must not let an obsolete completion replace a newer profile projection.
@@ -607,8 +601,7 @@ export function createGatewayChatMetadataRuntime(params: {
           `prepared chat metadata is unavailable for agent "${agentId}"`,
         );
       }
-      const readProjection = await projectAgent(generation, agent, readParams.sessionEntry);
-      return { read: () => readProjection.read().metadata, isCurrent: readProjection.isCurrent };
+      return projectAgent(generation, agent, readParams.sessionEntry);
     });
 
   const readStartup = async (
@@ -618,7 +611,8 @@ export function createGatewayChatMetadataRuntime(params: {
       neutral: PreparedAgentProjection,
       session: PreparedAgentProjection,
     ): ChatStartupProjectionResult => ({
-      metadata: session.metadata,
+      // History consumes stable catalogs only; live readiness stays inside the current-read fence.
+      ...(readParams.readPolicy === "ready" ? {} : { metadata: session.read() }),
       sessionModelCatalog: session.modelCatalog,
       defaultModelCatalog: neutral.modelCatalog,
     });
@@ -636,11 +630,7 @@ export function createGatewayChatMetadataRuntime(params: {
       const readSession = await projectAgent(generation, agent, readParams.sessionEntry);
       return {
         isCurrent: () => readNeutral.isCurrent() && readSession.isCurrent(),
-        read: () => {
-          const neutral = readNeutral.read();
-          const session = readSession === readNeutral ? neutral : readSession.read();
-          return assemble(neutral, session);
-        },
+        read: () => assemble(readNeutral, readSession),
       };
     };
     const profiles = resolveSessionProfiles(readParams.sessionEntry);
@@ -675,9 +665,7 @@ export function createGatewayChatMetadataRuntime(params: {
     ) {
       return undefined;
     }
-    const neutralProjection = neutral.projection.read();
-    const sessionProjection = session === neutral ? neutralProjection : session.projection.read();
-    return assemble(neutralProjection, sessionProjection);
+    return assemble(neutral.projection, session.projection);
   };
 
   const invalidate = () => {

--- a/src/gateway/server-methods/chat-startup-projection-contract.ts
+++ b/src/gateway/server-methods/chat-startup-projection-contract.ts
@@ -4,12 +4,12 @@ import type { ChatMetadataResult, ChatMetadataSessionEntry } from "./chat-metada
 export type ChatStartupProjectionReadParams = {
   agentId: string;
   sessionEntry?: ChatMetadataSessionEntry;
-  // History may use settled facts only; startup retains its current-generation wait.
+  // Ready reads return settled catalogs only; startup also reads current model availability.
   readPolicy?: "current" | "ready";
 };
 
 export type ChatStartupProjectionResult = {
-  metadata: ChatMetadataResult;
+  metadata?: ChatMetadataResult;
   sessionModelCatalog: ModelCatalogEntry[];
   defaultModelCatalog: ModelCatalogEntry[];
 };

--- a/src/gateway/server-methods/sessions-read.test.ts
+++ b/src/gateway/server-methods/sessions-read.test.ts
@@ -518,7 +518,7 @@ test.each([
   { name: "unknown first", keys: [UNKNOWN_SESSION_KEY, "agent:main:preview-valid"] },
   { name: "valid first", keys: ["agent:main:preview-valid", UNKNOWN_SESSION_KEY] },
 ])(
-  "sessions.preview keeps fixed-store cache entries agent-distinct with $name",
+  "sessions.preview keeps fixed-store results agent-distinct with $name lookup order",
   async ({ keys }) => {
     const storePath = await configureFixedSessionStore("preview-order");
     const validSessionKey = "agent:main:preview-valid";

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -61,7 +61,6 @@ import {
   listSessionsFromStoreAsync,
   loadCombinedSessionStoreForGatewayCore,
   resolveCanonicalSessionEntryFromStoreKeys,
-  resolveGatewaySessionStoreTarget,
   resolveGatewaySessionStoreTargetWithStore,
   type SessionsPreviewEntry,
   type SessionsPreviewResult,
@@ -557,7 +556,6 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
     const roleVisibilityFilter = hasOperatorBoundary(client, cfg)
       ? createSessionListEntryFilter({ client, cfg })
       : undefined;
-    const storeCache = new Map<string, Record<string, SessionEntry>>();
     const previews: SessionsPreviewEntry[] = [];
 
     for (const key of keys) {
@@ -570,23 +568,15 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
         return;
       }
       try {
-        const cachedStoreTarget = resolveGatewaySessionStoreTargetWithStore({
+        // Each preview resumes after a yield; read its canonical row from the current store.
+        const target = resolveGatewaySessionStoreTargetWithStore({
           cfg,
           key,
           agentId: requestedAgent.agentId,
+          exactRead: true,
+          readOnly: true,
         });
-        // Fixed stores share a legacy path but resolve to owner-specific SQLite databases. Keep
-        // synthetic misses from poisoning another agent's real store entry in this batch.
-        const storeCacheKey = `${cachedStoreTarget.agentId}\u0000${cachedStoreTarget.storePath}`;
-        const store = storeCache.get(storeCacheKey) ?? cachedStoreTarget.store;
-        storeCache.set(storeCacheKey, store);
-        const target = resolveGatewaySessionStoreTarget({
-          cfg,
-          key,
-          agentId: requestedAgent.agentId,
-          store,
-        });
-        const entry = resolveCanonicalSessionEntryFromStoreKeys(store, target.storeKeys);
+        const entry = resolveCanonicalSessionEntryFromStoreKeys(target.store, target.storeKeys);
         if (!entry?.sessionId || roleVisibilityFilter?.(target.canonicalKey, entry) === false) {
           previews.push({ key, status: "missing", items: [] });
           continue;

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -269,22 +269,6 @@ afterAll(async () => {
   await harness.close();
 });
 
-const sendReq = (
-  ws: { send: (payload: string) => void },
-  id: string,
-  method: string,
-  params: unknown,
-) => {
-  ws.send(
-    JSON.stringify({
-      type: "req",
-      id,
-      method,
-      params,
-    }),
-  );
-};
-
 async function withGatewayChatHarness(
   run: (ctx: { ws: GatewaySocket; createSessionDir: () => Promise<string> }) => Promise<void>,
   options?: { headers?: Record<string, string> },
@@ -8061,18 +8045,16 @@ describe("gateway server chat", () => {
         return undefined;
       });
 
-      const sendResP = onceMessage(ws, (o) => o.type === "res" && o.id === "send-abort-1", 2_000);
-      sendReq(
+      const sendRes = await rpcReq(
         ws,
-        "send-abort-1",
         "chat.send",
         makeChatSendParams({
           idempotencyKey: "idem-abort-1",
           timeoutMs: 30_000,
         }),
+        2_000,
       );
 
-      const sendRes = await sendResP;
       expect(sendRes.ok).toBe(true);
       await waitForFast(() => {
         expect(spy.mock.calls.length).toBeGreaterThan(0);

--- a/src/gateway/server.sessions.preview-resolve.test.ts
+++ b/src/gateway/server.sessions.preview-resolve.test.ts
@@ -142,6 +142,7 @@ test("sessions.preview reads only a bounded tail from a large transcript", async
   );
   const fullRead = vi.spyOn(sessionAccessor, "readSessionTranscriptMessageEvents");
   const tailRead = vi.spyOn(sessionHistoryEvents, "readRecentSessionTranscriptHistoryEvents");
+  const storeRead = vi.spyOn(sessionAccessor, "listSessionEntriesCore");
 
   try {
     const preview = await directSessionReq<{
@@ -156,6 +157,7 @@ test("sessions.preview reads only a bounded tail from a large transcript", async
       })),
     );
     expect(fullRead).not.toHaveBeenCalled();
+    expect(storeRead).not.toHaveBeenCalled();
     expect(tailRead).toHaveBeenCalledOnce();
     expect(tailRead.mock.results[0]).toMatchObject({
       type: "return",
@@ -164,6 +166,7 @@ test("sessions.preview reads only a bounded tail from a large transcript", async
   } finally {
     fullRead.mockRestore();
     tailRead.mockRestore();
+    storeRead.mockRestore();
   }
 });
 

--- a/src/gateway/session-utils-model.acp-owner.test.ts
+++ b/src/gateway/session-utils-model.acp-owner.test.ts
@@ -8,9 +8,16 @@ import {
 import { restoreRegisteredAgentHarnesses } from "../agents/harness/registry.test-support.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
-const readAcpSessionMeta = vi.hoisted(() => vi.fn(() => undefined));
+const { readAcpSessionMeta, readAcpSessionMetaForEntry } = vi.hoisted(() => ({
+  readAcpSessionMeta: vi.fn<typeof import("../acp/runtime/session-meta.js").readAcpSessionMeta>(),
+  readAcpSessionMetaForEntry:
+    vi.fn<typeof import("../acp/runtime/session-meta.js").readAcpSessionMetaForEntry>(),
+}));
 
-vi.mock("../acp/runtime/session-meta.js", () => ({ readAcpSessionMeta }));
+vi.mock("../acp/runtime/session-meta.js", () => ({
+  readAcpSessionMeta,
+  readAcpSessionMetaForEntry,
+}));
 
 import { resolveGatewaySessionThinkingProjectionInternal } from "./session-utils-model.js";
 
@@ -18,7 +25,8 @@ describe("resolveGatewaySessionThinkingProjectionInternal", () => {
   const registeredHarnesses = listRegisteredAgentHarnesses();
   beforeEach(() => {
     clearAgentHarnesses();
-    readAcpSessionMeta.mockClear();
+    readAcpSessionMeta.mockReset();
+    readAcpSessionMetaForEntry.mockReset();
   });
   afterAll(() => restoreRegisteredAgentHarnesses(registeredHarnesses));
 
@@ -102,5 +110,42 @@ describe("resolveGatewaySessionThinkingProjectionInternal", () => {
     });
 
     expect(readAcpSessionMeta).toHaveBeenCalledWith({ sessionKey: "global", agentId: "ops" });
+  });
+
+  it("keeps a prepared row from adopting a replacement session's ACP runtime", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        entries: { ops: {} },
+        defaults: { models: { "openai/gpt-5.6-sol": { agentRuntime: { id: "openclaw" } } } },
+      },
+    };
+    const entry = { sessionId: "original", lifecycleRevision: "original-revision", updatedAt: 1 };
+    const sessionKey = "agent:ops:acp:owned";
+    readAcpSessionMeta.mockReturnValue({
+      backend: "replacement-backend",
+      agent: "ops",
+      runtimeSessionName: "replacement",
+      mode: "persistent",
+      state: "idle",
+      lastActivityAt: 2,
+    });
+
+    const projection = resolveGatewaySessionThinkingProjectionInternal({
+      cfg,
+      agentId: "ops",
+      provider: "openai",
+      model: "gpt-5.6-sol",
+      sessionKey,
+      entry,
+    });
+
+    expect(projection.agentRuntime.id).toBe("openclaw");
+    expect(readAcpSessionMeta).not.toHaveBeenCalled();
+    expect(readAcpSessionMetaForEntry).toHaveBeenCalledWith({
+      cfg,
+      sessionKey,
+      agentId: "ops",
+      entry,
+    });
   });
 });

--- a/src/gateway/session-utils-model.ts
+++ b/src/gateway/session-utils-model.ts
@@ -3,7 +3,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
+import { readAcpSessionMeta, readAcpSessionMetaForEntry } from "../acp/runtime/session-meta.js";
 import {
   resolveCurrentSessionAgentRuntimeMetadata,
   resolveModelAgentRuntimeMetadata,
@@ -237,12 +237,17 @@ type GatewaySessionThinkingProjectionParams = {
 export function resolveGatewaySessionThinkingProjectionInternal(
   params: GatewaySessionThinkingProjectionParams,
 ) {
+  const { cfg, agentId, sessionKey, entry } = params;
   const cachedAcpMeta = params.rowContext?.acpSessionMetaByEntry;
+  // Keep metadata bound to the projected row; rereading its key can adopt a
+  // replacement lifecycle while projecting the original entry.
   const acpMeta =
-    params.entry?.acp ??
-    (params.entry && cachedAcpMeta?.has(params.entry)
-      ? cachedAcpMeta.get(params.entry)
-      : readAcpSessionMeta({ sessionKey: params.sessionKey, agentId: params.agentId }));
+    entry?.acp ??
+    (entry && cachedAcpMeta?.has(entry)
+      ? cachedAcpMeta.get(entry)
+      : entry
+        ? readAcpSessionMetaForEntry({ cfg, sessionKey, agentId, entry })
+        : readAcpSessionMeta({ sessionKey, agentId }));
   const agentRuntime = resolveCurrentSessionAgentRuntimeMetadata({
     cfg: params.cfg,
     agentId: params.agentId,

--- a/src/gateway/session-utils-projection.ts
+++ b/src/gateway/session-utils-projection.ts
@@ -1,12 +1,14 @@
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { normalizeStoredOverrideModel } from "../agents/model-selection.js";
-import { resolveSessionModelRef } from "../agents/session-model-ref.js";
+import {
+  resolveSessionModelIdentityRef,
+  resolveSessionModelRef,
+} from "../agents/session-model-ref.js";
 import { buildSubagentSessionListReadIndex } from "../agents/subagents/registry/subagent-registry-read.js";
 import { resolveSessionStorePathCore, type SessionEntry } from "../config/sessions.js";
 import { resolveConcreteSessionStorePath } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
-import { resolveSessionStoreAgentId } from "./session-store-key.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import { readRecentSessionUsageFromTranscript as readScopedRecentSessionUsageFromTranscript } from "./session-transcript-readers.js";
 import type {
   SessionActorProfileIdentity,
@@ -123,26 +125,40 @@ export function resolveTranscriptUsageFallback(params: {
   key: string;
   entry?: SessionEntry;
   storePath: string;
-  fallbackProvider?: string;
-  fallbackModel?: string;
+  freshTotalTokens?: number;
+  fallbackModelRef?: string;
+  allowPluginNormalization?: boolean;
   maxTranscriptBytes?: number;
   rowContext?: SessionListRowContext;
-  agentId?: string;
+  agentId: string;
 }): {
   estimatedCostUsd?: number;
   totalTokens?: number;
   totalTokensFresh?: boolean;
-  modelProvider?: string;
-  model?: string;
 } | null {
-  const entry = params.entry;
+  const { entry, agentId } = params;
   if (!entry?.sessionId) {
     return null;
   }
-  const parsed = parseAgentSessionKey(params.key);
-  const agentId = parsed?.agentId
-    ? normalizeAgentId(parsed.agentId)
-    : normalizeAgentId(params.agentId ?? resolveSessionStoreAgentId(params.cfg, params.key));
+  const resolvedModel = resolveSessionModelIdentityRef(
+    params.cfg,
+    entry,
+    agentId,
+    params.fallbackModelRef,
+    { allowPluginNormalization: params.allowPluginNormalization },
+  );
+  if (
+    params.freshTotalTokens !== undefined &&
+    resolveEstimatedSessionCostUsd({
+      cfg: params.cfg,
+      provider: resolvedModel.provider,
+      model: resolvedModel.model,
+      entry,
+      rowContext: params.rowContext,
+    }) !== undefined
+  ) {
+    return null;
+  }
   const storePath =
     resolveConcreteSessionStorePath(params.storePath) ??
     resolveSessionStorePathCore(params.cfg.session?.store, { agentId });
@@ -164,12 +180,10 @@ export function resolveTranscriptUsageFallback(params: {
   if (!snapshot) {
     return null;
   }
-  const modelProvider = snapshot.modelProvider ?? params.fallbackProvider;
-  const model = snapshot.model ?? params.fallbackModel;
   const estimatedCostUsd = resolveEstimatedSessionCostUsd({
     cfg: params.cfg,
-    provider: modelProvider,
-    model,
+    provider: snapshot.modelProvider ?? resolvedModel.provider,
+    model: snapshot.model ?? resolvedModel.model,
     explicitCostUsd: snapshot.costUsd,
     entry: {
       inputTokens: snapshot.inputTokens,
@@ -180,8 +194,6 @@ export function resolveTranscriptUsageFallback(params: {
     rowContext: params.rowContext,
   });
   return {
-    modelProvider,
-    model,
     totalTokens: resolvePositiveNumber(snapshot.totalTokens),
     totalTokensFresh: snapshot.totalTokensFresh === true,
     estimatedCostUsd,

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -7,7 +7,6 @@ import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveFastModeState } from "../agents/fast-mode.js";
 import { findModelCatalogEntry, type ModelCatalogEntry } from "../agents/model-catalog.js";
 import { resolveModelContextWindowProfile } from "../agents/model-context-window.js";
-import { resolveSessionModelIdentityRef } from "../agents/session-model-ref.js";
 import {
   countActiveDescendantRuns,
   getSessionDisplaySubagentRunByChildSessionKey,
@@ -238,38 +237,21 @@ export function buildGatewaySessionRow(params: {
     rowContext,
     allowPluginNormalization: !lightweight,
   });
-  const resolvedModel = resolveSessionModelIdentityRef(
-    cfg,
-    entry,
-    sessionAgentId,
-    subagentRun?.model,
-    { allowPluginNormalization: !lightweight },
-  );
   const freshSessionTotalTokens = asNonNegativeFiniteNumber(resolveFreshSessionTotalTokens(entry));
-  const needsTranscriptTotalTokens = freshSessionTotalTokens === undefined;
-  const needsTranscriptEstimatedCostUsd =
-    !skipTranscriptUsage &&
-    resolveEstimatedSessionCostUsd({
-      cfg,
-      provider: resolvedModel.provider,
-      model: resolvedModel.model ?? DEFAULT_MODEL,
-      entry,
-      rowContext,
-    }) === undefined;
-  const transcriptUsage =
-    !skipTranscriptUsage && (needsTranscriptTotalTokens || needsTranscriptEstimatedCostUsd)
-      ? resolveTranscriptUsageFallback({
-          cfg,
-          key,
-          entry,
-          storePath,
-          fallbackProvider: resolvedModel.provider,
-          fallbackModel: resolvedModel.model ?? DEFAULT_MODEL,
-          maxTranscriptBytes: params.transcriptUsageMaxBytes,
-          rowContext: params.rowContext,
-          agentId: sessionAgentId,
-        })
-      : null;
+  const transcriptUsage = !skipTranscriptUsage
+    ? resolveTranscriptUsageFallback({
+        cfg,
+        key,
+        entry,
+        storePath,
+        freshTotalTokens: freshSessionTotalTokens,
+        fallbackModelRef: subagentRun?.model,
+        allowPluginNormalization: !lightweight,
+        maxTranscriptBytes: params.transcriptUsageMaxBytes,
+        rowContext: params.rowContext,
+        agentId: sessionAgentId,
+      })
+    : null;
   const totalTokens =
     freshSessionTotalTokens ?? asNonNegativeFiniteNumber(transcriptUsage?.totalTokens);
   const totalTokensFresh =

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -7,6 +7,7 @@ import { afterAll, beforeEach, describe, expect, onTestFinished, test, vi } from
 import { writeAcpSessionMetaForMigration } from "../acp/runtime/session-meta.js";
 import { resolveExecDefaults } from "../agents/exec-defaults.js";
 import { resolveLegacyInheritedAuthAgentId } from "../agents/legacy-inherited-auth-dir.js";
+import * as sessionModelRefs from "../agents/session-model-ref.js";
 import { SESSION_PERMISSION_BY_EXEC_MODE } from "../agents/session-permission-exec-mode.js";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -1200,12 +1201,14 @@ describe("gateway session utils", () => {
         {
           sessionId: `session-${index}`,
           modelProvider: "openai",
-          model: "gpt-5.5",
+          model: "previous-model",
           updatedAt: Date.now() - index,
         } satisfies SessionEntry,
       ]),
     );
 
+    const historicalModel = vi.spyOn(sessionModelRefs, "resolveSessionModelIdentityRef");
+    onTestFinished(() => historicalModel.mockRestore());
     const result = await listSessionsFromStoreAsync({
       cfg,
       storePath: "",
@@ -1214,6 +1217,10 @@ describe("gateway session utils", () => {
     });
 
     expect(result.sessions).toHaveLength(5);
+    for (const row of result.sessions) {
+      expect(row).toMatchObject({ modelProvider: "openai", model: "gpt-5.5" });
+    }
+    expect(historicalModel).not.toHaveBeenCalled();
     const missingMediumLevelSessionIds = result.sessions
       .filter((session) => !session.thinkingLevels?.some((level) => level.id === "medium"))
       .map((session) => session.sessionId);

--- a/test/scripts/bench-gateway-concurrency.test.ts
+++ b/test/scripts/bench-gateway-concurrency.test.ts
@@ -1,10 +1,39 @@
-// Gateway concurrency benchmark tests cover CLI parsing and bounded percentile summaries.
+// Gateway concurrency benchmark tests cover CLI controls, probe budgets, and summaries.
 import { spawnSync } from "node:child_process";
 import { createServer as createHttpServer } from "node:http";
 import { createServer as createRawServer, type Socket } from "node:net";
 import { performance } from "node:perf_hooks";
 import { describe, expect, it } from "vitest";
 import { testing } from "../../scripts/bench-gateway-concurrency.ts";
+
+type BenchmarkRun = Parameters<typeof testing.summarizeRuns>[0][number];
+
+function createBenchmarkRun(overrides: Partial<BenchmarkRun> = {}): BenchmarkRun {
+  return {
+    controlUi: [],
+    durationMs: 10,
+    freshConnection: { error: null, latencyMs: 25, ok: true },
+    history: [],
+    memory: {
+      after: { atMs: 10, heapTotalMb: 120, heapUsedMb: 80, rssMb: 200 },
+      before: { atMs: 0, heapTotalMb: 100, heapUsedMb: 60, rssMb: 180 },
+      peakRssMb: 210,
+    },
+    messageSubscriptions: [],
+    messageSubscriptionsDuringLoad: [],
+    modelRequestCount: 1,
+    probeWarmup: { durationMs: 2, samples: [] },
+    pluginMetadataScans: { count: 0, durationMs: null, totalDurationMs: 0 },
+    readyz: [],
+    sessionSeedDurationMs: 2,
+    sessionsList: [],
+    sessionUpdates: [],
+    setupDurationMs: 3,
+    turnCount: 8,
+    turnsDurationMs: 5,
+    ...overrides,
+  };
+}
 
 describe("gateway concurrency benchmark script", () => {
   it("parses benchmark controls without booting a gateway", () => {
@@ -112,33 +141,14 @@ describe("gateway concurrency benchmark script", () => {
   });
 
   it("aggregates plugin metadata scans across measured runs", () => {
-    const createRun = (count: number, durations: number[]) => ({
-      controlUi: [],
-      durationMs: 10,
-      freshConnection: { error: null, latencyMs: 25, ok: true },
-      history: [],
-      memory: {
-        after: { atMs: 10, heapTotalMb: 120, heapUsedMb: 80, rssMb: 200 },
-        before: { atMs: 0, heapTotalMb: 100, heapUsedMb: 60, rssMb: 180 },
-        peakRssMb: 210,
-      },
-      messageSubscriptions: [],
-      messageSubscriptionsDuringLoad: [],
-      modelRequestCount: 1,
-      probeWarmup: { durationMs: 2, samples: [] },
-      pluginMetadataScans: {
-        count,
-        durationMs: testing.summarizeNumbers(durations),
-        totalDurationMs: durations.reduce((sum, value) => sum + value, 0),
-      },
-      readyz: [],
-      sessionSeedDurationMs: 2,
-      sessionsList: [],
-      sessionUpdates: [],
-      setupDurationMs: 3,
-      turnCount: 1,
-      turnsDurationMs: 5,
-    });
+    const createRun = (count: number, durations: number[]) =>
+      createBenchmarkRun({
+        pluginMetadataScans: {
+          count,
+          durationMs: testing.summarizeNumbers(durations),
+          totalDurationMs: durations.reduce((sum, value) => sum + value, 0),
+        },
+      });
 
     expect(testing.summarizeRuns([createRun(2, [10, 20]), createRun(1, [30])])).toMatchObject({
       gatewayHeapGrowthMb: { count: 2, max: 20, p50: 20, p95: 20, p99: 20 },
@@ -159,6 +169,80 @@ describe("gateway concurrency benchmark script", () => {
       p99: 100,
     });
     expect(testing.summarizeNumbers([])).toBeNull();
+  });
+
+  it.each([
+    ["readyz", "readyz"],
+    ["controlUi", "Control UI"],
+    ["sessionsList", "sessions.list"],
+    ["history", "chat.history"],
+    ["messageSubscriptionsDuringLoad", "sessions.messages.subscribe"],
+    ["sessionUpdates", "sessions.patch"],
+  ] as const)("enforces the control budget for measured %s probes", (field, name) => {
+    const options = testing.parseOptions(["--max-control-ms", "2000"]);
+    const probe: BenchmarkRun["readyz"][number] = {
+      atMs: 0,
+      cpuCoreRatio: null,
+      degraded: null,
+      degradedSinceMs: null,
+      delayP99Ms: null,
+      error: null,
+      latencyMs: 2_000,
+      ok: true,
+      status: 200,
+      utilization: null,
+    };
+    const run = createBenchmarkRun({ [field]: [probe] });
+    expect(testing.summarizeRuns([run], options).budgetViolations).toEqual([]);
+
+    probe.latencyMs = 2_576;
+    expect(testing.summarizeRuns([run], options).budgetViolations).toEqual([
+      `Gateway ${name} probe exceeded 2000ms: ok=true latencyMs=2576.0 error=none`,
+    ]);
+
+    probe.latencyMs = 10;
+    probe.ok = false;
+    probe.error = "request failed";
+    expect(testing.summarizeRuns([run], options).budgetViolations).toEqual([
+      `Gateway ${name} probe exceeded 2000ms: ok=false latencyMs=10.0 error=request failed`,
+    ]);
+    expect(testing.summarizeRuns([run]).budgetViolations).toEqual([]);
+  });
+
+  it("keeps setup probes outside the control budget and handshakes under their own budget", () => {
+    const slowProbe = { atMs: 0, error: null, latencyMs: 5_000, ok: true };
+    const slowReady = {
+      ...slowProbe,
+      cpuCoreRatio: null,
+      degraded: null,
+      degradedSinceMs: null,
+      delayP99Ms: null,
+      status: 200,
+      utilization: null,
+    };
+    const run = createBenchmarkRun({
+      freshConnection: slowProbe,
+      messageSubscriptions: [slowProbe],
+      probeWarmup: {
+        durationMs: 10_000,
+        samples: [{ controlUi: slowReady, readyz: slowReady, sessionsList: slowProbe }],
+      },
+      sessionSeedDurationMs: 10_000,
+      setupDurationMs: 20_000,
+      turnsDurationMs: 30_000,
+    });
+    const options = testing.parseOptions(["--max-control-ms", "2000"]);
+    expect(testing.summarizeRuns([run], options).budgetViolations).toEqual([]);
+    options.maxHandshakeMs = 2_000;
+    expect(testing.summarizeRuns([run], options).budgetViolations).toEqual([
+      "fresh Gateway connection exceeded 2000ms: ok=true latencyMs=5000.0 error=none",
+    ]);
+    run.freshConnection = { error: null, latencyMs: 2_000, ok: true };
+    expect(testing.summarizeRuns([run], options).budgetViolations).toEqual([]);
+    run.freshConnection = { error: "unauthorized", latencyMs: 10, ok: false };
+    expect(testing.summarizeRuns([run], options).budgetViolations).toEqual([
+      "fresh Gateway connection exceeded 2000ms: ok=false latencyMs=10.0 error=unauthorized",
+    ]);
   });
 
   it.each([
@@ -196,29 +280,7 @@ describe("gateway concurrency benchmark script", () => {
 
   it("gives every gateway sample a fresh pre-warmup timeout budget", async () => {
     const deadlines: number[] = [];
-    const sample = {
-      controlUi: [],
-      durationMs: 10,
-      freshConnection: { error: null, latencyMs: 25, ok: true },
-      history: [],
-      memory: {
-        after: { atMs: 10, heapTotalMb: 120, heapUsedMb: 80, rssMb: 200 },
-        before: { atMs: 0, heapTotalMb: 100, heapUsedMb: 60, rssMb: 180 },
-        peakRssMb: 210,
-      },
-      messageSubscriptions: [],
-      messageSubscriptionsDuringLoad: [],
-      modelRequestCount: 1,
-      pluginMetadataScans: { count: 0, durationMs: null, totalDurationMs: 0 },
-      probeWarmup: { durationMs: 2, samples: [] },
-      readyz: [],
-      sessionSeedDurationMs: 2,
-      sessionsList: [],
-      sessionUpdates: [],
-      setupDurationMs: 3,
-      turnCount: 8,
-      turnsDurationMs: 5,
-    };
+    const sample = createBenchmarkRun();
 
     const runs = await testing.runBenchmarkSamples({
       now: (() => {


### PR DESCRIPTION
## What Problem This Solves

Reduces avoidable work that delays Gateway control requests and the Control UI during concurrent turns. This extends #133429; it does not claim that every observed multi-second tail has a single established cause or is now eliminated.

## Why This Change Was Made

The control plane shares an event loop with agent startup and session projection. The fix carries prepared facts to their consumers and removes duplicate work at the owning boundaries:

- Config resolution copies only the prepared source config, retaining resolution facts and mutation isolation, instead of cloning refresh-only manifests and auth stores. Standalone preparation remains intact.
- Static HTTP requests select the presentation agent without reading workspace identity. Direct HTML and SPA fallback share one serving path; safe-open descriptor and size flow into the asynchronous reader without a second stat. Containment, link checks, allocation/chunk limits, short reads, EOF and closure remain covered. Reads are bounded by the pinned size, not an atomic-content guarantee.
- History consumes settled catalogs without rendering unused live model metadata; current startup/metadata still validate generation and readiness. Cursor responses skip unused defaults. Previews read one current canonical entry after each yield instead of materializing and caching whole stores.
- Lightweight rows skip historical-model resolution. Transcript token/cost policy lives in its existing fallback owner, which consumes the prepared agent/token facts. ACP projection remains bound to the supplied original entry, preventing adoption of a replacement session's runtime.
- Settings preparation creates one final runtime snapshot, removing the intermediate factories and repeated conversion. Locked file reads, merge precedence, trust policies, runtime-only writes and fresh-manager reload behavior are unchanged.

The benchmark now enforces all measured load-control budgets, saves violations in JSON, and exits nonzero after retaining evidence. Setup subscriptions and warmup remain excluded; handshakes retain their separate budget.

## User Impact

Less repeated discovery, copying and projection during concurrent use. No new cache, dependency, configuration, schema, wire protocol, persistent-store, locking or credential-resolution policy. No production Gateway was exercised. Production: **181 added / 243 removed, net -62**; benchmark tooling: net +3; tests: +588 / -131, net +457.

## Evidence

Built and exercised exact head `b1776b9e294b962acec4182138b3441b7c3fa089`, rebased on main `7acb95c3ae6bf28aeec76c86987fef8f4e78a6f6`.

- Full `node scripts/check-changed.mjs` passed: formatting, type checks, changed lint, dead exports, runtime cycles and ownership/storage guards. Runtime and Control UI builds passed.
- Owner suite: 612 tests passed. After the final row refactor, its four relevant suites passed 342 tests; after moving HTTP identity coverage into its own file, both HTTP suites passed 30 tests. These runs overlap and are not summed as unique coverage.
- Fresh Codex P0-scoped review found no actionable P0 finding; this is not an all-priority automated review. Manual review traced the changed owners, callers, siblings and dependency contracts.
- Final three unprofiled runs passed: 96 turns, 384 updates, 3695 history requests, zero operation failures and no budget violations. Final real-browser run also passed, showing session updates and a rendered synthetic reply while load remained active, with no browser errors.
- **The final CPU-profiled run failed the unchanged history budget: max 2904 ms, p99 1485 ms.** The final browser history maximum was 1961 ms. All 273 readiness samples in the three-run test and all 102 in the browser run were degraded; event-loop utilization reached 1. Remaining stalls and saturation are not claimed fixed.

The earlier CI failure in the descriptor test was reproduced and repaired without changing the production close path. An intermediate format gate and a file-length lint failure were also fixed; the final full local gate passed. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33339589271) completed successfully on b1776b9e. A fresh landing Codex P0 review also found no actionable P0 finding. The latest ClawSweeper review had no correctness/security finding; its remaining Rank-up move to finish exact-head CI is satisfied. The remaining profiled history failure above remains an open follow-up, not a claim of complete stall resolution.

Owner regressions were observed failing before repair: static requests performed six workspace identity reads; ready/history reads rendered discarded metadata; preview materialized a whole store; five lightweight rows resolved historical models they never consumed. Selected-model/thinking output and the corresponding security/lifecycle contracts remain asserted. The earlier prepared-config, pinned-read and stale-ACP regressions remain covered.

Final CPU evidence agrees with the owner regressions: discarded public model rendering beneath history/startup fell from 139 samples / 171.2 weighted ms to zero; historical-model resolution beneath ordinary list rows and history/startup also had zero final samples. The remaining eight historical-model samples were all within the intended transcript-usage fallback. Baseline and final runs issued 950 and 1205 history requests respectively. Zero samples alone do not prove zero calls; the regressions independently check invocations. Unequal workloads do not establish an overall speedup percentage.

Within the final shared history/startup handler, synchronous timeline emission accounts for 5.120 seconds of weighted inclusive samples, including 3.363 seconds at native `writeBuffer`. These are sampled intervals, not exact syscall durations. The [timeline owner](https://github.com/openclaw/openclaw/blob/b1776b9e294b962acec4182138b3441b7c3fa089/src/infra/diagnostics-timeline.ts#L195) still appends each enabled event synchronously. There is no common V8/harness clock anchor, so this cost is not causally assigned to the worst history request.

Observed maxima in milliseconds; runs from this refactor pass are retained, including failures. “Pre-refactor” is `8e2b93ee` (latest-main rebase plus the earlier patch); “intermediate” is before the final lightweight-row change. Same workload and limits throughout; browser and CPU instrumentation are identified separately.

| Runtime / measurement | UI HTTP | Readiness | sessions.list | History | Budget |
|---|---:|---:|---:|---:|---|
| Pre-refactor, early / 3 runs | 718 | 567 | 406 | 725 | PASS |
| Pre-refactor, early CPU / 1 run | 838 | 695 | 427 | 837 | PASS |
| Intermediate refactor / 3 runs | 3559 | 2293 | 4469 | 4134 | FAIL |
| Intermediate refactor CPU / 1 run | 2766 | 2350 | 2535 | 2647 | FAIL |
| Pre-refactor, adjacent / 1 run | 1987 | 1399 | 1415 | 1984 | PASS |
| Intermediate refactor, adjacent / 1 run | 1264 | 813 | 426 | 1262 | PASS |
| Final b1776b9e / 3 runs | 1279 | 879 | 746 | 1280 | PASS |
| Final b1776b9e CPU / 1 run | 1047 | 847 | 535 | 2904 | FAIL |
| Pre-refactor, browser / 1 run | 3156 | 2660 | 2660 | 2735 | FAIL |
| Final b1776b9e, browser / 1 run | 1929 | 1271 | 949 | 1961 | PASS |

All listed operation-failure counters were zero; a failed latency gate still counts as a failure. The adjacent old/new runs used exact runtime source and the same workload, but the earlier old-source baseline itself moved from about 10 seconds to 43 seconds per turn batch. Variation remains unexplained; it is not attributed to host noise or declared a product defect. Event-loop saturation remains; no memory leak has been established.

Reproduction (fresh HOME/state/config, mock provider and loopback ports; task proof also directs logging to its owned artifacts):

```sh
node scripts/bench-gateway-concurrency.ts --entry dist/entry.js \
  --runs 3 --warmup 0 --concurrency 32 --session-count 48 \
  --session-updates 128 --session-update-clients 4 \
  --history-clients 3 --history-burst 5 --subscribers 6 --visible-observer \
  --stream-chunk-delay-ms 1000 --cadence-ms 100 --timeout-ms 120000 \
  --max-control-ms 2000 --max-handshake-ms 2000 \
  --output .artifacts/gateway-mixed-32-followup.json --json
```

Two test-fixture repairs are included: descriptor closure is observed at the real native close instead of probing a reusable numeric descriptor after an await; the abort/idempotency smoke uses the shared prepared-runtime RPC fixture with its unchanged 2000 ms response budget. The latter failed twice in full-file order and in isolation, then passed in isolation and in the full file. These test repairs are not offered as production stall causes.

Named follow-up: **batch diagnostics timeline writes without losing trace completeness**. The retained synchronous timeline sink accounts for substantial native I/O in the profile. First correlate emission with an over-budget request using a common clock. A batching design also needs explicit emission visibility, bounded overflow, immediate-exit/graceful-flush contracts and a benchmark artifact boundary after owned shutdown. This PR does not disable the timeline, weaken its evidence, or change those contracts.

## Browser proof

Real built Gateway and Control UI, a synthetic streaming provider, fresh HOME/state/config, loopback only. The before run failed the latency gate while still rendering the reply; the final run passed. Screenshots show the reply while the turn is still busy; the final recording continues through completion. This is a responsiveness check, not a visual redesign or a controlled overall speedup claim. Captures were inspected for secrets and unrelated data.

Before this refactor (`8e2b93ee`):

![Before: synthetic reply under concurrent load](https://github.com/user-attachments/assets/4401c9c3-87ed-4c64-a04c-a4e28a200838)

After (`b1776b9e`):

![After: synthetic reply under concurrent load](https://github.com/user-attachments/assets/b4899de7-f348-4584-9865-4e2363069dcf)

Final browser recording:

https://github.com/user-attachments/assets/fc79f07e-528f-42c8-b49a-7c57d9498869

