### PR TITLE
fix(telegram): keep normal commentary in temporary progress drafts

### DIFF
--- a/docs/concepts/progress-drafts.md
+++ b/docs/concepts/progress-drafts.md
@@ -268,6 +268,21 @@ With the commentary lane enabled, preambles render only as those interleaved
 💬 lines; the status headline below stays out of the way so the lane keeps its
 documented shape.
 
+### Telegram commentary delivery
+
+Telegram uses the same shared setting, but it also preserves the existing
+durable CLI-commentary path when the draft lane is off:
+
+| `streaming.progress.commentary` | Session verbose level | Where completed CLI commentary appears                                  |
+| ------------------------------- | --------------------- | ----------------------------------------------------------------------- |
+| `false` (default)               | `off`                 | Durable Telegram message; the draft can still show its status headline. |
+| `true`                          | `off`                 | Temporary interleaved commentary line in the progress draft.            |
+| `true`                          | `on` or `full`        | Durable Telegram message owned by verbose progress.                     |
+
+Set the draft lane in configuration and use `/verbose on`, `/verbose full`, or
+`/verbose off` in a chat to change that session's verbose level. To set the
+default for new sessions, configure `agents.defaults.verboseDefault`.
+
 ### Status headline
 
 On Discord and Telegram in progress mode, the model's typed pre-tool preamble

--- a/extensions/telegram/src/bot-message-dispatch-reply.ts
+++ b/extensions/telegram/src/bot-message-dispatch-reply.ts
@@ -372,8 +372,10 @@ export async function deliverReply(
     const isDurableProgressCommentary =
       turn.streamMode === "progress" &&
       info.kind === "block" &&
-      effectivePayload.isCommentary === true;
-    // CLI finals exclude separately classified commentary, so it must outlive the progress draft.
+      effectivePayload.isCommentary === true &&
+      turn.verboseProgressActive();
+    // Only verbose progress owns a durable commentary block. Otherwise it stays
+    // in the disposable draft and must not survive its collapse as a new bubble.
     const suppressProgressAnswerBlock =
       turn.streamMode === "progress" &&
       info.kind === "block" &&

--- a/extensions/telegram/src/bot-message-dispatch-reply.ts
+++ b/extensions/telegram/src/bot-message-dispatch-reply.ts
@@ -373,9 +373,9 @@ export async function deliverReply(
       turn.streamMode === "progress" &&
       info.kind === "block" &&
       effectivePayload.isCommentary === true &&
-      turn.verboseProgressActive();
-    // Only verbose progress owns a durable commentary block. Otherwise it stays
-    // in the disposable draft and must not survive its collapse as a new bubble.
+      (!turn.commentaryProgressEnabled || turn.verboseProgressActive());
+    // When draft commentary is disabled, no draft can own the block.
+    // Otherwise only verbose progress owns durable commentary.
     const suppressProgressAnswerBlock =
       turn.streamMode === "progress" &&
       info.kind === "block" &&

--- a/extensions/telegram/src/bot-message-dispatch-turn.ts
+++ b/extensions/telegram/src/bot-message-dispatch-turn.ts
@@ -270,10 +270,9 @@ export async function runTelegramDispatchTurn(turn: Turn) {
             commentaryProgressEnabled:
               turn.streamMode === "progress" ? turn.commentaryProgressEnabled : undefined,
             progressPreambleEnabled: turn.progressPreambleEnabled,
-            commentaryPayloadsEnabled:
-              turn.streamMode === "progress" ? turn.commentaryProgressEnabled : undefined,
-            // Regular commentary belongs only in the disposable progress draft.
-            // A durable verbose lane explicitly takes ownership, preventing duplicate bubbles.
+            commentaryPayloadsEnabled: turn.progressPreambleEnabled,
+            // The draft can own commentary only when its opt-in is enabled.
+            // Otherwise CLI commentary must remain durable instead of being dropped.
             shouldDeliverCommentaryPayloads:
               turn.streamMode === "progress" && turn.commentaryProgressEnabled
                 ? () => turn.verboseProgressActive()

--- a/extensions/telegram/src/bot-message-dispatch-turn.ts
+++ b/extensions/telegram/src/bot-message-dispatch-turn.ts
@@ -270,9 +270,10 @@ export async function runTelegramDispatchTurn(turn: Turn) {
             commentaryProgressEnabled:
               turn.streamMode === "progress" ? turn.commentaryProgressEnabled : undefined,
             progressPreambleEnabled: turn.progressPreambleEnabled,
-            commentaryPayloadsEnabled: turn.progressPreambleEnabled,
-            // Read the current getter after core freezes visibility so draft
-            // and durable commentary cannot both own the same preamble.
+            commentaryPayloadsEnabled:
+              turn.streamMode === "progress" ? turn.commentaryProgressEnabled : undefined,
+            // Regular commentary belongs only in the disposable progress draft.
+            // A durable verbose lane explicitly takes ownership, preventing duplicate bubbles.
             shouldDeliverCommentaryPayloads:
               turn.streamMode === "progress" && turn.commentaryProgressEnabled
                 ? () => turn.verboseProgressActive()

--- a/extensions/telegram/src/bot-message-dispatch.progress-lifecycle.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-lifecycle.test.ts
@@ -163,6 +163,36 @@ describeTelegramDispatch("dispatchTelegramMessage progress-lifecycle", () => {
     expect(allDeliveredReplyTexts()).toEqual(["TEST DONE"]);
   });
 
+  it("keeps CLI pre-tool commentary durable when draft commentary is disabled", async () => {
+    const markers = "Durable markers: saffron-penguin-194, velvet-cedar, quartz-harbor";
+    setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        expect(replyOptions?.commentaryPayloadsEnabled).toBe(true);
+        expect(replyOptions?.shouldDeliverCommentaryPayloads).toBeUndefined();
+        await replyOptions?.onItemEvent?.({
+          kind: "preamble",
+          itemId: "commentary-1",
+          progressText: markers,
+          suppressDurableProgress: true,
+        });
+        await replyOptions?.onBlockReplyQueued?.({ text: markers, isCommentary: true });
+        await dispatcherOptions.deliver({ text: markers, isCommentary: true }, { kind: "block" });
+        await replyOptions?.onToolStart?.({ name: "Bash", phase: "start" });
+        await dispatcherOptions.deliver({ text: "TEST DONE" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress" } },
+    });
+
+    expect(allDeliveredReplyTexts()).toEqual([markers, "TEST DONE"]);
+  });
+
   it("persists CLI pre-tool commentary when verbose progress owns the durable lane", async () => {
     const markers = "Verbose markers: lantern-otter-582, compass-velvet, cloud-atelier";
     setupDraftStreams({ answerMessageId: 2001 });

--- a/extensions/telegram/src/bot-message-dispatch.progress-lifecycle.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-lifecycle.test.ts
@@ -132,13 +132,13 @@ describeTelegramDispatch("dispatchTelegramMessage progress-lifecycle", () => {
     expectWindowRetiredAfterFinal(answerDraftStream, deliverReplies);
   });
 
-  it("keeps CLI pre-tool commentary after the progress window retires", async () => {
+  it("keeps ordinary CLI pre-tool commentary in the temporary progress window", async () => {
     const markers = "Test markers: caribou-lampion-473, fromage-quantique, satellite-en-tricot";
-    setupDraftStreams({ answerMessageId: 2001 });
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
         expect(replyOptions?.commentaryPayloadsEnabled).toBe(true);
-        expect(replyOptions?.shouldDeliverCommentaryPayloads).toBeUndefined();
+        expect(replyOptions?.shouldDeliverCommentaryPayloads?.()).toBe(false);
         await replyOptions?.onItemEvent?.({
           kind: "preamble",
           itemId: "commentary-1",
@@ -152,13 +152,41 @@ describeTelegramDispatch("dispatchTelegramMessage progress-lifecycle", () => {
         return { queuedFinal: true };
       },
     );
-
     await dispatchWithContext({
       context: createContext(),
       streamMode: "progress",
-      telegramCfg: { streaming: { mode: "progress" } },
+      telegramCfg: { streaming: { mode: "progress", progress: { commentary: true } } },
     });
+    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining(markers) }),
+    );
+    expect(allDeliveredReplyTexts()).toEqual(["TEST DONE"]);
+  });
 
+  it("persists CLI pre-tool commentary when verbose progress owns the durable lane", async () => {
+    const markers = "Verbose markers: lantern-otter-582, compass-velvet, cloud-atelier";
+    setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        replyOptions?.onVerboseProgressVisibility?.(() => true);
+        expect(replyOptions?.shouldDeliverCommentaryPayloads?.()).toBe(true);
+        await replyOptions?.onItemEvent?.({
+          kind: "preamble",
+          itemId: "commentary-1",
+          progressText: markers,
+          suppressDurableProgress: true,
+        });
+        await replyOptions?.onBlockReplyQueued?.({ text: markers, isCommentary: true });
+        await dispatcherOptions.deliver({ text: markers, isCommentary: true }, { kind: "block" });
+        await dispatcherOptions.deliver({ text: "TEST DONE" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { commentary: true } } },
+    });
     expect(allDeliveredReplyTexts()).toEqual([markers, "TEST DONE"]);
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.progress.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.progress.test-utils.ts
@@ -181,6 +181,40 @@ describe("dispatchReplyFromConfig", () => {
     },
   );
 
+  it("keeps commentary durable when a channel registers no draft owner", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "group",
+      From: "telegram:group:-100123",
+      SessionKey: "agent:main:telegram:group:-100123",
+    });
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: automaticGroupReplyConfig,
+      dispatcher,
+      replyResolver: async (_ctx, opts) => {
+        expect(opts?.commentaryPayloadsEnabled).toBe(true);
+        expect(opts?.shouldDeliverCommentaryPayloads).toBeUndefined();
+        await opts?.onBlockReply?.({
+          text: "Inspecting the dispatch path.",
+          isCommentary: true,
+        });
+        return { text: "Done." } satisfies ReplyPayload;
+      },
+      replyOptions: { commentaryPayloadsEnabled: true },
+    });
+
+    expect(dispatcher.sendBlockReply).toHaveBeenCalledExactlyOnceWith({
+      text: "Inspecting the dispatch path.",
+      isCommentary: true,
+    });
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledExactlyOnceWith({ text: "Done." });
+  });
+
   it("forwards channel-owned group progress callbacks while source delivery is suppressed", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {


### PR DESCRIPTION
Related: #128259

## What Problem This Solves

Fixes an issue where Telegram users with progress commentary enabled see normal pre-tool commentary remain as a durable chat bubble after the final answer, even when verbose progress is off.

## Why This Change Was Made

The Telegram dispatch and final-reply paths now use the same frozen verbose ownership decision. Ordinary commentary stays only in the disposable progress draft; verbose progress deliberately owns a durable copy.

## User Impact

Normal Telegram progress can show temporary commentary while work is running, then leave only the final answer. Users who enable verbose progress continue to receive durable commentary and tool detail.

## Evidence

- Regression proof: applying only the new lifecycle expectation to clean current main fails because the delivered messages contain both commentary and the final answer.
- Focused repair: bot-message-dispatch.progress-lifecycle.test.ts passes 12 tests, including normal temporary commentary and the verbose durable exception.
- Sibling protection: bot-message-dispatch.progress-updates.test.ts passes 34 tests.
- Formatting, diff check, and changed-file checks passed.
- Build limitation: the clean package-profile build fails in runtime postbuild because this linked worktree must borrow node_modules from stale dev_syu; its workspace @openclaw/ai exports do not match current main. The failing Anthropic and iMessage module imports are unrelated to this Telegram-only diff.
- Real Telegram proof was not run: this executor lacks the required crabbox client, so a burner-account session could not be started. Obtain that proof before landing.
