### PR TITLE
fix(voice-call): fence obsolete automatic replies

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1353,7 +1353,7 @@ extensions/voice-call/src/realtime-agent-context.ts	1
 extensions/voice-call/src/response-generator.ts	3
 extensions/voice-call/src/runtime.ts	3
 extensions/voice-call/src/tts-provider-voice.ts	1
-extensions/voice-call/src/webhook.ts	11
+extensions/voice-call/src/webhook.ts	10
 extensions/voice-call/src/webhook/realtime-handler.ts	3
 extensions/volcengine/tts.ts	2
 extensions/voyage/embedding-batch.ts	1

--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -564,6 +564,7 @@ Behavior notes:
 - If a Twilio media stream is already active, Voice Call does not fall back to TwiML `<Say>`. If telephony TTS is unavailable in that state, the playback request fails instead of mixing two playback paths.
 - When telephony TTS falls back to a secondary provider, Voice Call logs a warning with the provider chain (`from`, `to`, `attempts`) for debugging.
 - When Twilio barge-in or stream teardown clears the pending TTS queue, queued playback requests settle instead of hanging callers awaiting playback completion.
+- Resumed caller speech discards older automatic replies that are still being generated. Twilio streaming reacts to speech-start and partial transcripts; carrier webhook calls react when a new speech event arrives. Explicit speech requests remain available, and already accepted agent work can finish without speaking an obsolete reply.
 
 ### TTS examples
 

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -89,6 +89,7 @@ export class CallManager {
   >();
   private maxDurationTimers = new Map<CallId, NodeJS.Timeout>();
   private initialMessageInFlight = new Set<CallId>();
+  private autoResponseOwners = new WeakMap<CallRecord, symbol>();
 
   /**
    * Carrier-side stream session issuer. Wired by the runtime when realtime is
@@ -362,6 +363,7 @@ export class CallManager {
       transcriptWaiters: this.transcriptWaiters,
       maxDurationTimers: this.maxDurationTimers,
       initialMessageInFlight: this.initialMessageInFlight,
+      onCallerSpeech: (call) => this.invalidateAutoResponse(call),
       onCallAnswered: (call) => {
         this.maybeSpeakInitialMessageOnAnswered(call);
       },
@@ -374,6 +376,28 @@ export class CallManager {
    */
   processEvent(event: NormalizedEvent): ProcessEventResult {
     return processManagerEvent(this.getContext(), event);
+  }
+
+  createAutoResponseGuard(call: CallRecord): { isCurrent: () => boolean; release: () => void } {
+    // Call identity fences restored/replaced records; generation identity fences
+    // newer speech without cancelling agent work that was already accepted.
+    const owner = Symbol("automatic response");
+    this.autoResponseOwners.set(call, owner);
+    return {
+      isCurrent: () =>
+        this.activeCalls.get(call.callId) === call &&
+        !TerminalStates.has(call.state) &&
+        this.autoResponseOwners.get(call) === owner,
+      release: () => {
+        if (this.autoResponseOwners.get(call) === owner) {
+          this.autoResponseOwners.delete(call);
+        }
+      },
+    };
+  }
+
+  invalidateAutoResponse(call: CallRecord): void {
+    this.autoResponseOwners.delete(call);
   }
 
   private shouldDeferConversationInitialMessageUntilStreamConnect(): boolean {

--- a/extensions/voice-call/src/manager/context.ts
+++ b/extensions/voice-call/src/manager/context.ts
@@ -46,6 +46,7 @@ export type StreamSessionIssuer = (request: {
 
 type CallManagerHooks = {
   onCallAnswered?: (call: CallRecord) => void;
+  onCallerSpeech?: (call: CallRecord) => void;
   streamSessionIssuer?: StreamSessionIssuer;
 };
 

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -37,6 +37,7 @@ type EventContext = Pick<
   | "maxDurationTimers"
   | "endCallOperations"
   | "onCallAnswered"
+  | "onCallerSpeech"
   | "streamSessionIssuer"
 >;
 
@@ -358,6 +359,9 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
               resolveTranscriptWaiter(ctx, activeCall.callId, event.transcript, event.turnToken);
             });
           }
+        }
+        if (event.transcript.trim()) {
+          effects.push(() => ctx.onCallerSpeech?.(activeCall));
         }
         prepareLiveDurationTimer();
         transitionState(activeCall, "listening");

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -50,15 +50,15 @@ export interface MediaStreamConfig {
   /** Validate whether to accept a media stream for the given call ID. Missing validator rejects. */
   shouldAcceptStream?: (params: { callId: string; streamSid: string; token?: string }) => boolean;
   /** Callback when transcript is received */
-  onTranscript?: (callId: string, transcript: string) => void;
+  onTranscript?: (callId: string, transcript: string, streamSid: string) => void;
   /** Callback for partial transcripts (streaming UI) */
-  onPartialTranscript?: (callId: string, partial: string) => void;
+  onPartialTranscript?: (callId: string, partial: string, streamSid: string) => void;
   /** Callback when stream connects */
   onConnect?: (callId: string, streamSid: string) => void;
   /** Callback when realtime transcription is ready for the stream */
   onTranscriptionReady?: (callId: string, streamSid: string) => void;
   /** Callback when speech starts (barge-in) */
-  onSpeechStart?: (callId: string) => void;
+  onSpeechStart?: (callId: string, streamSid: string) => void;
   /** Callback when stream disconnects */
   onDisconnect?: (callId: string, streamSid: string) => void;
   /** Callback for common Talk events emitted by the telephony STT/TTS adapter. */
@@ -401,7 +401,7 @@ export class MediaStreamHandler {
             payload: { callId: callSid, streamSid, text: partial, role: "user" },
           });
         }
-        this.config.onPartialTranscript?.(callSid, partial);
+        this.config.onPartialTranscript?.(callSid, partial, streamSid);
       },
       onTranscript: (transcript) => {
         const session = this.sessions.get(streamSid);
@@ -420,14 +420,14 @@ export class MediaStreamHandler {
             payload: { callId: callSid, streamSid, text: transcript, role: "user" },
           });
         }
-        this.config.onTranscript?.(callSid, transcript);
+        this.config.onTranscript?.(callSid, transcript, streamSid);
       },
       onSpeechStart: () => {
         const session = this.sessions.get(streamSid);
         if (session) {
           this.ensureActiveTurn(session);
         }
-        this.config.onSpeechStart?.(callSid);
+        this.config.onSpeechStart?.(callSid, streamSid);
       },
       onError: (error) => {
         console.warn("[MediaStream] Transcription session error:", error.message);

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -180,8 +180,9 @@ export class TwilioProvider implements VoiceCallProvider {
     this.activeStreamCalls.add(callSid);
   }
 
-  hasRegisteredStream(callSid: string): boolean {
-    return this.callStreamMap.has(callSid);
+  hasRegisteredStream(callSid: string, streamSid?: string): boolean {
+    const current = this.callStreamMap.get(callSid);
+    return current !== undefined && (streamSid === undefined || current === streamSid);
   }
 
   unregisterCallStream(callSid: string, streamSid?: string): void {

--- a/extensions/voice-call/src/webhook.auto-response.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook.auto-response.lifecycle.test.ts
@@ -1,0 +1,323 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import type { RealtimeTranscriptionSessionCreateRequest } from "openclaw/plugin-sdk/realtime-transcription";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VoiceCallConfigSchema } from "./config.js";
+import { CallManager } from "./manager.js";
+import {
+  createEventManagerHarness,
+  FakeProvider,
+  finalizeTestManagerCalls,
+} from "./manager.test-harness.js";
+import { TwilioProvider } from "./providers/twilio.js";
+import type { NormalizedEvent, WebhookContext } from "./types.js";
+import { VoiceCallWebhookServer } from "./webhook.js";
+import { connectWs, waitForClose } from "./websocket-test-support.js";
+
+type ResponseParams = { onEarlyText?: (text: string) => Promise<boolean> };
+type ResponseResult = { text: string; deliveredEarly: boolean };
+const mocks = vi.hoisted(() => ({
+  generate: vi.fn<(params: ResponseParams) => Promise<ResponseResult>>(),
+  createTranscription: vi.fn<(request: RealtimeTranscriptionSessionCreateRequest) => void>(),
+}));
+vi.mock("./response-generator.js", () => ({ generateVoiceResponse: mocks.generate }));
+vi.mock("./realtime-transcription.runtime.js", () => {
+  const provider = {
+    id: "test-transcription",
+    label: "Test transcription",
+    isConfigured: () => true,
+    createSession: (request: RealtimeTranscriptionSessionCreateRequest) => {
+      mocks.createTranscription(request);
+      return {
+        connect: async () => {},
+        sendAudio: () => {},
+        close: () => {},
+        isConnected: () => true,
+      };
+    },
+  };
+  return {
+    getRealtimeTranscriptionProvider: () => provider,
+    listRealtimeTranscriptionProviders: () => [provider],
+  };
+});
+
+class SpeechProvider extends FakeProvider {
+  private readonly streamOwner = new TwilioProvider({
+    accountSid: "test-account",
+    authToken: "test-auth",
+  });
+  readonly clearTtsQueue = vi.fn();
+  override verifyWebhook(ctx: WebhookContext) {
+    return { ok: true, verifiedRequestKey: ctx.rawBody };
+  }
+  override parseWebhookEvent(ctx: WebhookContext) {
+    return { events: [JSON.parse(ctx.rawBody) as NormalizedEvent], statusCode: 200 };
+  }
+  isValidStreamToken() {
+    return true;
+  }
+  registerCallStream(callId: string, streamId: string) {
+    this.streamOwner.registerCallStream(callId, streamId);
+  }
+  hasRegisteredStream(callId: string, streamId?: string) {
+    return this.streamOwner.hasRegisteredStream(callId, streamId);
+  }
+  unregisterCallStream(callId: string, streamId: string) {
+    this.streamOwner.unregisterCallStream(callId, streamId);
+  }
+}
+
+const state = createEventManagerHarness();
+const managers: CallManager[] = [];
+const servers: VoiceCallWebhookServer[] = [];
+const pendingResponses: ReturnType<typeof createDeferred<ResponseResult>>[] = [];
+
+async function startCall(streaming = false) {
+  const config = VoiceCallConfigSchema.parse({
+    enabled: true,
+    provider: streaming ? "twilio" : "telnyx",
+    fromNumber: "+15550000000",
+    skipSignatureVerification: true,
+    streaming: { enabled: streaming, provider: "test-transcription" },
+  });
+  config.serve.port = 0;
+  const provider = new SpeechProvider(streaming ? "twilio" : "telnyx");
+  const ctx = state.createContext({ config });
+  const manager = new CallManager(config, ctx.storePath);
+  managers.push(manager);
+  await manager.initialize(provider, "https://example.test/voice/webhook");
+  const started = await manager.initiateCall("+15550000001", undefined, { mode: "conversation" });
+  expect(started.success).toBe(true);
+  const server = new VoiceCallWebhookServer(config, manager, provider, {}, undefined, {} as never);
+  servers.push(server);
+  const url = await server.start();
+  let eventId = 0;
+  const speech = async (transcript: string, isFinal = true, id?: string, turnToken?: string) => {
+    const response = await fetch(url, {
+      method: "POST",
+      body: JSON.stringify({
+        id: id ?? `speech-${++eventId}`,
+        type: "call.speech",
+        callId: "request-uuid",
+        providerCallId: "request-uuid",
+        timestamp: Date.now(),
+        transcript,
+        isFinal,
+        ...(turnToken ? { turnToken } : {}),
+      }),
+    });
+    expect(response.status).toBe(200);
+    await response.text();
+  };
+  const openStream = async (streamId: string) => {
+    const ws = await connectWs(
+      `${url.replace("http:", "ws:").replace(config.serve.path, "")}${config.streaming.streamPath}`,
+    );
+    ws.send(
+      JSON.stringify({ event: "start", streamSid: streamId, start: { callSid: "request-uuid" } }),
+    );
+    await vi.waitFor(() =>
+      expect(provider.hasRegisteredStream("request-uuid", streamId)).toBe(true),
+    );
+    const callbacks = mocks.createTranscription.mock.calls.at(-1)?.[0];
+    if (!callbacks) {
+      throw new Error("Expected connected transcription session");
+    }
+    return { ws, callbacks };
+  };
+  return { manager, provider, callId: started.callId, speech, openStream };
+}
+
+async function responseAt(index: number) {
+  await vi.waitFor(() => expect(pendingResponses.length).toBeGreaterThan(index));
+  const response = pendingResponses[index];
+  const early = mocks.generate.mock.calls[index]?.[0].onEarlyText;
+  if (!response || !early) {
+    throw new Error("Expected pending response and early delivery callback");
+  }
+  return {
+    early,
+    finish: async (text: string) => {
+      response.resolve({ text, deliveredEarly: false });
+      // Finish the synchronous provider's promise continuations before asserting absence.
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+    },
+  };
+}
+
+beforeEach(() => {
+  state.setup();
+  mocks.createTranscription.mockClear();
+  mocks.generate.mockReset().mockImplementation(async () => {
+    const response = createDeferred<ResponseResult>();
+    pendingResponses.push(response);
+    return response.promise;
+  });
+});
+afterEach(async () => {
+  for (const response of pendingResponses.splice(0)) {
+    response.resolve({ text: "", deliveredEarly: false });
+  }
+  for (const server of servers.splice(0)) {
+    await server.stop();
+  }
+  for (const manager of managers.splice(0)) {
+    finalizeTestManagerCalls(manager);
+  }
+  state.cleanup();
+});
+
+describe("automatic phone reply ownership", () => {
+  it.each(["native", "partial"] as const)(
+    "drops an old reply after %s stream speech and speaks the next reply",
+    async (signal) => {
+      const call = await startCall(true);
+      const { callbacks } = await call.openStream("stream-1");
+      callbacks.onTranscript?.("first question");
+      const first = await responseAt(0);
+      if (signal === "native") {
+        callbacks.onSpeechStart?.();
+      } else {
+        callbacks.onPartial?.("wait");
+      }
+      expect(await first.early("obsolete early reply")).toBe(false);
+      callbacks.onTranscript?.("replacement question");
+      const second = await responseAt(1);
+      await first.finish("obsolete final reply");
+      await second.finish("current reply");
+      expect(call.provider.playTtsCalls.map((entry) => entry.text)).toEqual(["current reply"]);
+      expect(call.provider.clearTtsQueue).toHaveBeenCalled();
+    },
+  );
+
+  it("invalidates on accepted carrier interim speech without blocking explicit speech", async () => {
+    const call = await startCall();
+    await call.speech("first question");
+    const first = await responseAt(0);
+    await call.speech("wait", false);
+    expect(await first.early("obsolete early reply")).toBe(false);
+    await first.finish("obsolete final reply");
+    expect(await call.manager.speak(call.callId, "explicit announcement")).toEqual({
+      success: true,
+    });
+    expect(call.provider.playTtsCalls.map((entry) => entry.text)).toEqual([
+      "explicit announcement",
+    ]);
+  });
+
+  it("invalidates when newer speech completes an explicit waiting turn", async () => {
+    const call = await startCall();
+    await call.speech("first question");
+    const first = await responseAt(0);
+    const waiting = call.manager.continueCall(call.callId, "explicit prompt");
+    await vi.waitFor(() => expect(call.provider.startListeningCalls).toHaveLength(1));
+    await call.speech("answer to explicit prompt");
+    expect(await waiting).toMatchObject({ success: true, transcript: "answer to explicit prompt" });
+    await first.finish("obsolete final reply");
+    expect(call.provider.playTtsCalls.map((entry) => entry.text)).toEqual(["explicit prompt"]);
+  });
+
+  it("keeps explicit speech available after a speech-start with no final transcript", async () => {
+    const call = await startCall(true);
+    const { callbacks } = await call.openStream("stream-1");
+    callbacks.onSpeechStart?.();
+    callbacks.onError?.(new Error("transcription failed"));
+    expect(await call.manager.speak(call.callId, "Please try again")).toEqual({ success: true });
+    expect(call.provider.playTtsCalls.map((entry) => entry.text)).toEqual(["Please try again"]);
+  });
+
+  it("binds delivery to the exact live call rather than a restored copy of its ID", async () => {
+    const call = await startCall();
+    await call.speech("first question");
+    const first = await responseAt(0);
+    const original = call.manager.getCall(call.callId);
+    await call.manager.initialize(call.provider, "https://example.test/voice/webhook");
+    expect(call.manager.getCall(call.callId)).not.toBe(original);
+    expect(await first.early("obsolete early reply")).toBe(false);
+    await first.finish("obsolete final reply");
+    expect(call.provider.playTtsCalls).toEqual([]);
+  });
+
+  it("does not invalidate on a rejected explicit-turn token", async () => {
+    const call = await startCall(true);
+    await call.speech("first question");
+    const first = await responseAt(0);
+    const waiting = call.manager.continueCall(call.callId, "explicit prompt");
+    await vi.waitFor(() => expect(call.provider.startListeningCalls).toHaveLength(1));
+    const turnToken = call.provider.startListeningCalls.at(0)?.turnToken;
+    if (!turnToken) {
+      throw new Error("Expected explicit turn token");
+    }
+    await call.speech("obsolete input", true, "mismatched-event", "old-token");
+    await first.finish("current reply");
+    expect(call.provider.playTtsCalls.map((entry) => entry.text)).toEqual([
+      "explicit prompt",
+      "current reply",
+    ]);
+    expect(await first.early("late callback after completion")).toBe(false);
+    await call.speech("accepted input", true, "accepted-event", turnToken);
+    expect(await waiting).toMatchObject({ success: true, transcript: "accepted input" });
+  });
+
+  it("does not invalidate on a replayed transcript", async () => {
+    const call = await startCall();
+    await call.speech("first question", true, "same-event");
+    const first = await responseAt(0);
+    await call.speech("first question", true, "same-event");
+    await first.finish("current reply");
+    expect(call.provider.playTtsCalls.map((entry) => entry.text)).toEqual(["current reply"]);
+    expect(mocks.generate).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["native", "partial", "final"] as const)(
+    "ignores late %s speech from a predecessor stream",
+    async (signal) => {
+      const call = await startCall(true);
+      const old = await call.openStream("stream-old");
+      old.callbacks.onTranscript?.("old question");
+      await responseAt(0);
+      const replacement = await call.openStream("stream-new");
+      replacement.callbacks.onTranscript?.("new question");
+      const current = await responseAt(1);
+      call.provider.clearTtsQueue.mockClear();
+      if (signal === "native") {
+        old.callbacks.onSpeechStart?.();
+      } else if (signal === "partial") {
+        old.callbacks.onPartial?.("late old partial");
+      } else {
+        old.callbacks.onTranscript?.("late old transcript");
+      }
+      expect(await current.early("current reply")).toBe(true);
+      await current.finish("");
+      expect(mocks.generate).toHaveBeenCalledTimes(2);
+      expect(call.provider.clearTtsQueue).not.toHaveBeenCalled();
+      expect(call.provider.playTtsCalls.map((entry) => entry.text)).toEqual(["current reply"]);
+    },
+  );
+
+  it("fences a disconnected stream's generation without disrupting its replacement", async () => {
+    const call = await startCall(true);
+    const old = await call.openStream("stream-old");
+    old.callbacks.onTranscript?.("old question");
+    const first = await responseAt(0);
+    const replacement = await call.openStream("stream-new");
+    replacement.callbacks.onTranscript?.("new question");
+    const second = await responseAt(1);
+    const closed = waitForClose(old.ws);
+    old.ws.close();
+    await closed;
+    await first.finish("obsolete reply");
+    await second.finish("replacement reply");
+    expect(call.provider.playTtsCalls.map((entry) => entry.text)).toEqual(["replacement reply"]);
+    const disconnected = waitForClose(replacement.ws);
+    replacement.callbacks.onTranscript?.("last question");
+    const third = await responseAt(2);
+    replacement.ws.close();
+    await disconnected;
+    await vi.waitFor(() => expect(call.provider.hasRegisteredStream("request-uuid")).toBe(false));
+    await third.finish("disconnected reply");
+    expect(call.provider.playTtsCalls.map((entry) => entry.text)).toEqual(["replacement reply"]);
+  });
+});

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -6,6 +6,7 @@ import type { RealtimeTranscriptionProviderPlugin } from "openclaw/plugin-sdk/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VoiceCallConfigSchema, resolveVoiceCallConfig, type VoiceCallConfig } from "./config.js";
 import type { CallManager } from "./manager.js";
+import type { MediaStreamConfig } from "./media-stream.js";
 import type { VoiceCallProvider } from "./providers/base.js";
 import { MockProvider } from "./providers/mock.js";
 import { PlivoProvider } from "./providers/plivo.js";
@@ -128,10 +129,16 @@ const createCall = (startedAt: number): CallRecord => ({
   processedEventIds: [],
 });
 
+const automaticReplyManagerStub = {
+  createAutoResponseGuard: () => ({ isCurrent: () => true, release: () => {} }),
+  invalidateAutoResponse: () => {},
+};
+
 const createManager = (calls: CallRecord[]) => {
   const endCall = vi.fn(async () => ({ success: true }));
   const processEvent = vi.fn<CallManager["processEvent"]>(() => ({ kind: "processed" }));
   const manager = {
+    ...automaticReplyManagerStub,
     getActiveCalls: () => calls,
     endCall,
     processEvent,
@@ -364,6 +371,7 @@ describe("VoiceCallWebhookServer realtime transcription provider selection", () 
   it("records media stream Talk events on the active call metadata", async () => {
     const call = createCall(Date.now());
     const manager = {
+      ...automaticReplyManagerStub,
       getActiveCalls: () => [call],
       getCallByProviderCallId: (providerCallId: string) =>
         providerCallId === "provider-call-1" ? call : undefined,
@@ -372,6 +380,7 @@ describe("VoiceCallWebhookServer realtime transcription provider selection", () 
       speakInitialMessage: vi.fn(async () => {}),
     } as unknown as CallManager;
     const config = createConfig({
+      provider: "twilio",
       streaming: {
         ...createConfig().streaming,
         enabled: true,
@@ -383,7 +392,7 @@ describe("VoiceCallWebhookServer realtime transcription provider selection", () 
       },
     });
 
-    const server = new VoiceCallWebhookServer(config, manager, provider);
+    const server = new VoiceCallWebhookServer(config, manager, createTwilioStreamingProvider());
     try {
       await server.start();
       const mediaHandler = server.getMediaStreamHandler() as unknown as {
@@ -429,6 +438,7 @@ describe("VoiceCallWebhookServer media stream authorization", () => {
       const call = createCall(Date.now());
       const getCallByProviderCallId = vi.fn(() => call);
       const manager = {
+        ...automaticReplyManagerStub,
         getActiveCalls: () => [call],
         getCallByProviderCallId,
         endCall: vi.fn(async () => ({ success: true })),
@@ -2204,6 +2214,7 @@ describe("VoiceCallWebhookServer classic response routing", () => {
     call.sessionKey = "agent:top:voice:15550001111";
     const speak = vi.fn(async () => ({ success: true }));
     const manager = {
+      ...automaticReplyManagerStub,
       getCall: (callId: string) => (callId === call.callId ? call : undefined),
       speak,
     } as unknown as CallManager;
@@ -2250,6 +2261,7 @@ describe("VoiceCallWebhookServer classic response routing", () => {
     call.direction = "inbound";
     const speak = vi.fn(async () => ({ success: true }));
     const manager = {
+      ...automaticReplyManagerStub,
       getCall: (callId: string) => (callId === call.callId ? call : undefined),
       speak,
     } as unknown as CallManager;
@@ -2285,6 +2297,7 @@ describe("VoiceCallWebhookServer classic response routing", () => {
     const call = createCall(Date.now());
     const speak = vi.fn(async () => ({ success: true }));
     const manager = {
+      ...automaticReplyManagerStub,
       getCall: (callId: string) => (callId === call.callId ? call : undefined),
       speak,
     } as unknown as CallManager;
@@ -2429,6 +2442,7 @@ describe("VoiceCallWebhookServer stream disconnect grace", () => {
     );
 
     const manager = {
+      ...automaticReplyManagerStub,
       getActiveCalls: () => [call],
       getCallByProviderCallId,
       endCall,
@@ -2527,15 +2541,12 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
 
   const getMediaCallbacks = (server: VoiceCallWebhookServer) =>
     server.getMediaStreamHandler() as unknown as {
-      config: {
-        onSpeechStart?: (providerCallId: string) => void;
-        onTranscript?: (providerCallId: string, transcript: string) => void;
-        onPartialTranscript?: (providerCallId: string, partial: string) => void;
-      };
+      config: MediaStreamConfig;
     };
 
   it("logs transcript counts without logging transcript content", async () => {
     const manager = {
+      ...automaticReplyManagerStub,
       getActiveCalls: () => [],
       getCallByProviderCallId: vi.fn(() => undefined),
       endCall: vi.fn(async () => ({ success: true })),
@@ -2572,8 +2583,8 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
       const transcript = `${"a".repeat(199)}\uD83D\uDE80tail`;
       const partialText = "user is saying something sensitive";
       const callbacks = getMediaCallbacks(server).config;
-      callbacks.onTranscript?.("CA-utf16", transcript);
-      callbacks.onPartialTranscript?.("CA-partial", partialText);
+      callbacks.onTranscript?.("CA-utf16", transcript, "MZ-log");
+      callbacks.onPartialTranscript?.("CA-partial", partialText, "MZ-log");
 
       expectPrivateLogMetadata({
         messages,
@@ -2611,6 +2622,7 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
       return { kind: "processed" };
     });
     const manager = {
+      ...automaticReplyManagerStub,
       getActiveCalls: () => [call],
       getCallByProviderCallId: (providerCallId: string) =>
         providerCallId === call.providerCallId ? call : undefined,
@@ -2647,10 +2659,10 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
 
     try {
       const media = getMediaCallbacks(server);
-      media.config.onSpeechStart?.("CA-barge");
-      media.config.onTranscript?.("CA-barge", "hello");
-      media.config.onSpeechStart?.("CA-barge");
-      media.config.onTranscript?.("CA-barge", "hello again");
+      media.config.onSpeechStart?.("CA-barge", "MZ-barge");
+      media.config.onTranscript?.("CA-barge", "hello", "MZ-barge");
+      media.config.onSpeechStart?.("CA-barge", "MZ-barge");
+      media.config.onTranscript?.("CA-barge", "hello again", "MZ-barge");
       expect(clearTtsQueue).not.toHaveBeenCalled();
       expect(handleInboundResponse).not.toHaveBeenCalled();
       expect(processEvent).not.toHaveBeenCalled();
@@ -2660,8 +2672,8 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
       }
       call.state = "listening";
 
-      media.config.onSpeechStart?.("CA-barge");
-      media.config.onTranscript?.("CA-barge", "hello after greeting");
+      media.config.onSpeechStart?.("CA-barge", "MZ-barge");
+      media.config.onTranscript?.("CA-barge", "hello after greeting", "MZ-barge");
       expect(clearTtsQueue).toHaveBeenCalledTimes(2);
       expect(handleInboundResponse).toHaveBeenCalledTimes(1);
       expect(processEvent).toHaveBeenCalledTimes(1);
@@ -2697,6 +2709,7 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
         : { kind: "processed" },
     );
     const manager = {
+      ...automaticReplyManagerStub,
       getActiveCalls: () => [call],
       getCallByProviderCallId: (providerCallId: string) =>
         providerCallId === call.providerCallId ? call : undefined,
@@ -2729,8 +2742,8 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
 
     try {
       const media = getMediaCallbacks(server);
-      media.config.onSpeechStart?.("CA-inbound");
-      media.config.onTranscript?.("CA-inbound", "hello");
+      media.config.onSpeechStart?.("CA-inbound", "MZ-inbound");
+      media.config.onTranscript?.("CA-inbound", "hello", "MZ-inbound");
       expect(clearTtsQueue).toHaveBeenCalledTimes(2);
       expect(processEvent).toHaveBeenCalledTimes(1);
       const event = requireFirstMockCall(processEvent.mock.calls, "inbound processed event")[0] as

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -326,6 +326,28 @@ export class VoiceCallWebhookServer {
     return initialMessage.length > 0;
   }
 
+  private getCurrentStream(providerCallId: string, streamSid: string) {
+    // Playback's registration also owns callback admission; an old STT session
+    // must not replace the current stream's reply or call metadata.
+    if (this.provider.name !== "twilio") {
+      return undefined;
+    }
+    const provider = this.provider as TwilioProvider;
+    const call = this.manager.getCallByProviderCallId(providerCallId);
+    return call && provider.hasRegisteredStream(providerCallId, streamSid)
+      ? { call, provider }
+      : undefined;
+  }
+
+  private interruptStreamReply(providerCallId: string, streamSid: string): void {
+    const current = this.getCurrentStream(providerCallId, streamSid);
+    if (!current || this.shouldSuppressBargeInForInitialMessage(current.call)) {
+      return;
+    }
+    this.manager.invalidateAutoResponse(current.call);
+    current.provider.clearTtsQueue(providerCallId);
+  }
+
   /**
    * Initialize media streaming with the selected realtime transcription provider.
    */
@@ -396,13 +418,16 @@ export class VoiceCallWebhookServer {
         }
         return true;
       },
-      onTranscript: (providerCallId, transcript) => {
+      onTranscript: (providerCallId, transcript, streamSid) => {
         this.logger.info(`Transcript received ${providerCallId} chars=${transcript.length}`);
-        const call = this.manager.getCallByProviderCallId(providerCallId);
-        if (!call) {
-          this.logger.warn(`No active call found for provider ID: ${providerCallId}`);
+        const current = this.getCurrentStream(providerCallId, streamSid);
+        if (!current) {
+          this.logger.info(
+            `Ignoring transcript from inactive stream ${streamSid} (${providerCallId})`,
+          );
           return;
         }
+        const { call, provider: streamProvider } = current;
         const suppressBargeIn = this.shouldSuppressBargeInForInitialMessage(call);
         if (suppressBargeIn) {
           this.logger.info(
@@ -411,10 +436,7 @@ export class VoiceCallWebhookServer {
           return;
         }
 
-        // Clear TTS queue on barge-in (user started speaking, interrupt current playback)
-        if (this.provider.name === "twilio") {
-          (this.provider as TwilioProvider).clearTtsQueue(providerCallId);
-        }
+        streamProvider.clearTtsQueue(providerCallId);
 
         // Create a speech event and process it through the manager
         const event: NormalizedEvent = {
@@ -428,35 +450,35 @@ export class VoiceCallWebhookServer {
         };
         this.processEventWithAutoResponse(event);
       },
-      onSpeechStart: (providerCallId) => {
-        if (this.provider.name !== "twilio") {
-          return;
-        }
-        const call = this.manager.getCallByProviderCallId(providerCallId);
-        if (this.shouldSuppressBargeInForInitialMessage(call)) {
-          return;
-        }
-        (this.provider as TwilioProvider).clearTtsQueue(providerCallId);
-      },
-      onPartialTranscript: (callId, partial) => {
+      onSpeechStart: (providerCallId, streamSid) =>
+        this.interruptStreamReply(providerCallId, streamSid),
+      onPartialTranscript: (callId, partial, streamSid) => {
         this.logger.info(`Partial transcript ${callId} chars=${partial.length}`);
+        this.interruptStreamReply(callId, streamSid);
       },
-      onTalkEvent: (providerCallId, _streamSid, event) => {
-        const call = this.manager.getCallByProviderCallId(providerCallId);
-        if (call) {
-          appendRecentTalkEventMetadata(call, event);
+      onTalkEvent: (providerCallId, streamSid, event) => {
+        const current = this.getCurrentStream(providerCallId, streamSid);
+        if (current) {
+          appendRecentTalkEventMetadata(current.call, event);
         }
       },
       onConnect: (callId, streamSid) => {
         this.logger.info(`Media stream connected: ${callId} -> ${streamSid}`);
         this.streamDisconnectGrace.connect(callId, streamSid);
+        const call = this.manager.getCallByProviderCallId(callId);
+        if (call) {
+          this.manager.invalidateAutoResponse(call);
+        }
 
         // Register stream with provider for TTS routing
         if (this.provider.name === "twilio") {
           (this.provider as TwilioProvider).registerCallStream(callId, streamSid);
         }
       },
-      onTranscriptionReady: (callId) => {
+      onTranscriptionReady: (callId, streamSid) => {
+        if (!this.getCurrentStream(callId, streamSid)) {
+          return;
+        }
         this.manager.speakInitialMessage(callId).catch((err: unknown) => {
           this.logger.warn(`Failed to speak initial message: ${String(err)}`);
         });
@@ -464,7 +486,13 @@ export class VoiceCallWebhookServer {
       onDisconnect: (callId, streamSid) => {
         this.logger.info(`Media stream disconnected: ${callId} (${streamSid})`);
         if (this.provider.name === "twilio") {
-          (this.provider as TwilioProvider).unregisterCallStream(callId, streamSid);
+          const twilio = this.provider as TwilioProvider;
+          twilio.unregisterCallStream(callId, streamSid);
+          const call = this.manager.getCallByProviderCallId(callId);
+          // A late disconnect must not revoke the replacement stream's reply.
+          if (call && !twilio.hasRegisteredStream(callId)) {
+            this.manager.invalidateAutoResponse(call);
+          }
         }
 
         this.streamDisconnectGrace.disconnect(callId, streamSid);
@@ -1046,8 +1074,21 @@ export class VoiceCallWebhookServer {
       return;
     }
 
+    const response = this.manager.createAutoResponseGuard(call);
+    const speakResponse = async (text: string): Promise<boolean> => {
+      if (!response.isCurrent()) {
+        this.logger.info(`Discarding superseded automatic reply ${callId}`);
+        return false;
+      }
+      this.logger.info(`AI response queued ${callId} chars=${text.length}`);
+      const result = await this.manager.speak(callId, text, { listenAfterPlayback: true });
+      return result.success;
+    };
     try {
       const { generateVoiceResponse } = await loadResponseGeneratorModule();
+      if (!response.isCurrent()) {
+        return;
+      }
       const numberRouteKey = resolveVoiceCallNumberRouteKeyForCall(call);
       const effectiveConfig = resolveVoiceCallEffectiveConfig(this.config, numberRouteKey).config;
 
@@ -1062,11 +1103,7 @@ export class VoiceCallWebhookServer {
         agentId: resolveCallAgentId(call, effectiveConfig),
         transcript: call.transcript,
         userMessage,
-        onEarlyText: async (text) => {
-          this.logger.info(`Early AI response queued ${callId} chars=${text.length}`);
-          const speakResult = await this.manager.speak(callId, text, { listenAfterPlayback: true });
-          return speakResult.success;
-        },
+        onEarlyText: speakResponse,
       });
 
       if (result.error) {
@@ -1075,11 +1112,12 @@ export class VoiceCallWebhookServer {
       }
 
       if (result.text && !result.deliveredEarly) {
-        this.logger.info(`AI response delivered ${callId} chars=${result.text.length}`);
-        await this.manager.speak(callId, result.text, { listenAfterPlayback: true });
+        await speakResponse(result.text);
       }
     } catch (err) {
       this.logger.error(`Auto-response error: ${String(err)}`);
+    } finally {
+      response.release();
     }
   }
 }


### PR DESCRIPTION
Closes #112360

Supersedes #112361

## What Problem This Solves

Fixes an issue where callers who resumed speaking could still hear an obsolete automatic answer when its generation finished. Late transcription callbacks from a replaced media stream could also cancel or replace the current reply.

## Why This Change Was Made

The audio queue could clear queued speech but did not own replies still being generated; `CallManager` now binds automatic delivery to the exact live call and generation, with accepted speech invalidating it after persistence and replay/turn validation. Early and final text use one delivery path, and stream callbacks reuse Twilio's existing registration to reject predecessor events without another registry or a persistent “caller speaking” lock.

## User Impact

Resumed speech discards obsolete generated replies while explicit speech and already accepted agent work remain available. Existing queue cancellation still owns admitted playback. No provider API, configuration, dependency, or storage format changes.

## Evidence

- Before the repair: 5 of 6 initial owner regressions failed. A carrier-ID variant exposed 2 failures, and overlapping stream IDs exposed 3 late-callback failures before their owner fixes.
- After the repair: 155 tests passed across webhook, manager, event, Twilio, and media-stream suites. After mechanical lint corrections, both affected webhook suites passed again: 71 tests.
- The new 12-case suite uses real HTTP/WebSocket handling, real `CallManager` persistence/lifecycle, and real Twilio stream registration, with injected transcription, generation, and carrier calls. This is **not authenticated carrier/PSTN audio proof**; no external call was placed. Already-issued native carrier playback retains its existing behavior.
- The changed-file gate passed production/test types, plugin/script lint, formatting, export/dependency/storage guards, doctor contract tests, and import-cycle checks. Fresh Codex review found no actionable P0–P2 findings; the only subsequent edit lowered the assertion baseline for a removed cast.
- Production: +108/-40, **net +68**. The missing pre-queue call/generation ownership requires a small in-memory guard; consolidating delivery and stream admission removed duplicate paths. Tests: net +336; docs: +1; tooling baseline: net 0.

Reworks the report and proposed fix from @DonShelly. Contributor credit: Ellis <DonShelly@users.noreply.github.com>.

Authenticated PSTN proof is unavailable because this test environment has no carrier API credential; provisioning one would create persistent access beyond this repair. The change does not alter a carrier API contract. Its changed ownership behavior is exercised through the actual HTTP/WebSocket handlers, manager store and Twilio stream registration above.

Direct Codex source inspection: `codex-rs/core/src/realtime_conversation.rs:2241–2259,2312–2343,2377–2411` at `63d213884daea50e4f74efc192cdc44f549b67d5` confirms the relevant separation between active handoff identity and playback interruption. This classic phone pipeline remains OpenClaw-owned. Exact regression introduction is unknown; the failing pre-fix runtime is recorded above.
