### PR TITLE
fix(codex): wait for Linux process command readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Codex/Linux: wait for a live app-server process to expose its startup command line within the existing inspection deadline, preserving process identity checks and preventing intermittent startup failures.
 - **Chat attachments:** protect prepared message-tool media from premature cleanup, attach it before publication, and complete interrupted attachment promotion on retries without duplicating the original reply.
 - **Upgrade state metadata:** record the current application version after repairing older databases with an unset version marker, allowing CLI commands to use the running Gateway without attempting another schema repair.
 - **Device workers:** preserve offline-runner classification and reconnect guidance when desktop preparation detects a disconnected device, without treating the disconnect as a model failure.

--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -92,6 +92,9 @@ or discover descendants that independently reparented before inspection.
 
 Linux reads process identities directly from `/proc`, including the boot ID
 and process start ticks, so Alpine/BusyBox installations do not need `procps`.
+During Linux startup, an empty command line waits within the existing inspection
+deadline while the same live process identity remains valid. Registration still
+requires a usable command fingerprint; unreadable or changed identities fail.
 macOS uses its native `ps` with a fixed locale and timezone. Registration checks
 inspect only the observer and the relevant parent and child processes; an
 unrelated unreadable process does not block those checks. Destructive cleanup

--- a/extensions/codex/src/app-server/attempt-startup-retry.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup-retry.test.ts
@@ -225,23 +225,27 @@ describe("Codex app-server startup retry", () => {
       });
       const commandSpy = vi
         .spyOn(processSnapshot, "readCodexAppServerProcessCommand")
-        .mockImplementation(async (pid, deadline) => {
-          if (pid !== firstChild?.pid) {
-            return readCommand(pid, deadline);
+        .mockImplementation(async (observed, deadline) => {
+          if (observed.pid !== firstChild?.pid) {
+            return readCommand(observed, deadline);
           }
           await expect
             .poll(() => fs.readFile(`${fixture.spawnCountPath}.ready`, "utf8").catch(() => ""))
             .toBe("ready");
-          expect(await readCommand(pid, deadline)).toBeDefined();
+          expect(await readCommand(observed, deadline)).toBeDefined();
           firstChild.kill("SIGUSR2");
           // Keep Node's event loop occupied until the OS has exited the real child.
           // Inspection then refuses registration before JS can deliver exit or stderr.
           const exitedBy = Date.now() + 5_000;
           let exited = false;
           while (Date.now() < exitedBy) {
-            const inspected = childProcess.spawnSync("ps", ["-o", "stat=", "-p", String(pid)], {
-              encoding: "utf8",
-            });
+            const inspected = childProcess.spawnSync(
+              "ps",
+              ["-o", "stat=", "-p", String(observed.pid)],
+              {
+                encoding: "utf8",
+              },
+            );
             if (inspected.status === 1 || inspected.stdout.trim().startsWith("Z")) {
               exited = true;
               break;

--- a/extensions/codex/src/app-server/transport-process-registration.procfs.test.ts
+++ b/extensions/codex/src/app-server/transport-process-registration.procfs.test.ts
@@ -8,7 +8,7 @@ import { terminateCodexAppServerOrphan } from "./transport-process-containment.j
 import { prepareCodexAppServerProcessRegistration } from "./transport-process-registration.js";
 import { readCodexAppServerProcessSnapshot } from "./transport-process-snapshot.js";
 
-const procfs = vi.hoisted(() => ({ files: new Map<string, string | Error>() }));
+const procfs = vi.hoisted(() => ({ files: new Map<string, string | Error | (() => string)>() }));
 vi.mock("node:fs/promises", async (importOriginal) => {
   const original = await importOriginal<typeof import("node:fs/promises")>();
   return {
@@ -18,7 +18,8 @@ vi.mock("node:fs/promises", async (importOriginal) => {
       if (typeof file !== "string" || !file.startsWith("/proc/")) {
         return original.readFile(...args);
       }
-      const value = procfs.files.get(file);
+      const stored = procfs.files.get(file);
+      const value = typeof stored === "function" ? stored() : stored;
       return typeof value === "string"
         ? Promise.resolve(value)
         : Promise.reject(value ?? Object.assign(new Error("gone"), { code: "ENOENT" }));
@@ -104,7 +105,7 @@ describe("Codex registration procfs boundary", () => {
     expect(kill).not.toHaveBeenCalled();
   });
 
-  it.for(["readable", "permission", "malformed", "deadline", "missing-observer"])(
+  it.for(["readable", "startup", "permission", "malformed", "deadline", "missing-observer"])(
     "registers a direct child despite an unreadable unrelated process only with usable ownership: %s",
     async (mode, ctx) => {
       addProcess(child.pid, process.pid);
@@ -131,7 +132,13 @@ describe("Codex registration procfs boundary", () => {
         spawned.removeAllListeners();
       });
       const register = await prepareCodexAppServerProcessRegistration();
-      if (mode === "missing-observer") {
+      if (mode === "startup") {
+        let reads = 0;
+        procfs.files.set(`/proc/${child.pid}/cmdline`, () => {
+          expect(store.entries()).toEqual([]);
+          return reads++ === 0 ? "" : command.replaceAll(" ", "\0");
+        });
+      } else if (mode === "missing-observer") {
         procfs.files.delete(`/proc/${process.pid}/stat`);
       } else if (mode !== "readable") {
         procfs.files.set(
@@ -146,7 +153,7 @@ describe("Codex registration procfs boundary", () => {
       const registered = register(spawned);
       spawned.emit("spawn");
 
-      if (mode !== "readable") {
+      if (mode !== "readable" && mode !== "startup") {
         await expect(registered).rejects.toMatchObject({
           reason: mode === "permission" || mode === "deadline" ? mode : "unavailable",
         });

--- a/extensions/codex/src/app-server/transport-process-registration.ts
+++ b/extensions/codex/src/app-server/transport-process-registration.ts
@@ -67,7 +67,7 @@ async function reapRegisteredCodexAppServerOrphans(requestedDeadline?: number): 
     ) {
       let command: string | undefined;
       try {
-        command = await readCodexAppServerProcessCommand(registration.child.pid, deadline);
+        command = await readCodexAppServerProcessCommand(child, deadline);
       } catch (error) {
         // Only a successful inspection may revoke the fingerprint obligation.
         const current = (
@@ -141,7 +141,7 @@ export async function prepareCodexAppServerProcessRegistration(): Promise<
         "Cannot register the Codex child process: its direct-parent identity is unavailable. Retry.",
       );
     }
-    const command = await readCodexAppServerProcessCommand(spawned.pid, Date.now() + 2_000);
+    const command = await readCodexAppServerProcessCommand(spawned, Date.now() + 2_000);
     if (child.exitCode !== null || child.signalCode !== null) {
       throw new Error(
         "Cannot register the Codex child process command: the child exited during inspection. Retry.",

--- a/extensions/codex/src/app-server/transport-process-snapshot.test.ts
+++ b/extensions/codex/src/app-server/transport-process-snapshot.test.ts
@@ -6,6 +6,7 @@ import { isPidAlive } from "openclaw/plugin-sdk/process-runtime";
 import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import {
+  type PosixProcess,
   readCodexAppServerProcessCommand,
   readCodexAppServerProcessSnapshot,
 } from "./transport-process-snapshot.js";
@@ -14,6 +15,14 @@ const procfs = vi.hoisted(() => ({
   readFile: vi.fn<(file: string) => Promise<string>>(),
   readdir: vi.fn<() => Promise<string[]>>(),
 }));
+
+const observedProcess: PosixProcess = {
+  pid: process.pid,
+  ppid: process.ppid,
+  pgid: process.pid,
+  state: "S",
+  startedAt: "00000000-0000-0000-0000-000000000001:12345",
+};
 
 vi.mock("node:fs/promises", async (importOriginal) => {
   const original = await importOriginal<typeof import("node:fs/promises")>();
@@ -34,12 +43,75 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 
 describe("Codex procfs command inspector", () => {
   it.for([
+    "ready",
+    "empty",
+    "gone",
+    "replaced",
+    "zombie",
+    "reparented",
+    "regrouped",
+    "malformed",
+    "permission",
+    "read-error",
+    "replaced after read",
+  ])("binds empty-command startup readiness to the same live process: %s", async (mode, ctx) => {
+    ctx.onTestFinished(() => {
+      procfs.readFile.mockReset();
+      vi.restoreAllMocks();
+    });
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    const bootId = "00000000-0000-0000-0000-000000000001";
+    let commandReads = 0;
+    procfs.readFile.mockImplementation(async (file) => {
+      if (file === "/proc/sys/kernel/random/boot_id") {
+        return bootId;
+      }
+      if (file === `/proc/${process.pid}/cmdline`) {
+        commandReads += 1;
+        if (commandReads > 1 && mode === "read-error") {
+          throw Object.assign(new Error("command read failed"), { code: "EIO" });
+        }
+        return commandReads === 1 || mode === "empty" ? "" : "/opt/codex\0app-server\0";
+      }
+      expect(file).toBe(`/proc/${process.pid}/stat`);
+      if (commandReads && (mode === "gone" || mode === "permission")) {
+        throw Object.assign(new Error("identity unavailable"), {
+          code: mode === "gone" ? "ENOENT" : "EACCES",
+        });
+      }
+      if (commandReads && mode === "malformed") {
+        return "";
+      }
+      const changed = commandReads > 0;
+      const state = changed && mode === "zombie" ? "Z" : "R";
+      const ppid = process.ppid + Number(changed && mode === "reparented");
+      const pgid = process.pid + Number(changed && mode === "regrouped");
+      const replaced =
+        (changed && mode === "replaced") || (commandReads > 1 && mode === "replaced after read");
+      return `${process.pid} (codex) ${state} ${ppid} ${pgid}${" 0".repeat(16)} ${replaced ? 54321 : 12345}\n`;
+    });
+    const observed = (await readCodexAppServerProcessSnapshot(undefined, [process.pid]))[0]!;
+    const inspected = readCodexAppServerProcessCommand(observed, Date.now() + 250);
+    if (mode === "ready") {
+      await expect(inspected).resolves.toBe("/opt/codex app-server");
+    } else {
+      await expect(inspected).rejects.toMatchObject({
+        reason:
+          mode === "empty" ? "deadline" : mode === "permission" ? "permission" : "unavailable",
+      });
+    }
+    if (["ready", "read-error", "replaced after read"].includes(mode)) {
+      expect(commandReads).toBe(2);
+    }
+  });
+
+  it.for([
     {
       input: "/opt/codex\0app-server\0--listen\0stdio://\0",
       expected: "/opt/codex app-server --listen stdio://",
     },
-    { input: "", reason: "unavailable" },
     { input: "\0", reason: "unavailable" },
+    { input: " \0 ", reason: "unavailable" },
     { code: "ENOENT", reason: "unavailable" },
     { code: "ESRCH", reason: "unavailable" },
     { code: "EACCES", reason: "permission" },
@@ -60,7 +132,7 @@ describe("Codex procfs command inspector", () => {
         return fixture.input!;
       });
 
-      const inspected = readCodexAppServerProcessCommand(process.pid, Date.now() + 1_000);
+      const inspected = readCodexAppServerProcessCommand(observedProcess, Date.now() + 1_000);
       if (fixture.reason) {
         await expect(inspected).rejects.toMatchObject({ reason: fixture.reason });
         if (fixture.reason !== "permission") {
@@ -74,7 +146,7 @@ describe("Codex procfs command inspector", () => {
       }
       procfs.readFile.mockClear();
       await expect(
-        readCodexAppServerProcessCommand(process.pid, Date.now() - 1),
+        readCodexAppServerProcessCommand(observedProcess, Date.now() - 1),
       ).rejects.toMatchObject({ reason: "deadline" });
       expect(procfs.readFile).not.toHaveBeenCalled();
     },
@@ -202,7 +274,7 @@ ${mode === "unavailable" ? "process.exit(1);" : "setInterval(() => {}, 1000);"}
             const budgetMs = 1_000;
             const result =
               kind === "command"
-                ? readCodexAppServerProcessCommand(process.pid, startedAt + budgetMs)
+                ? readCodexAppServerProcessCommand(observedProcess, startedAt + budgetMs)
                 : readCodexAppServerProcessSnapshot(startedAt + budgetMs);
             await expect(result).rejects.toMatchObject({
               reason: mode === "hung" ? "deadline" : "unavailable",

--- a/extensions/codex/src/app-server/transport-process-snapshot.ts
+++ b/extensions/codex/src/app-server/transport-process-snapshot.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { readdir, readFile } from "node:fs/promises";
+import { setImmediate } from "node:timers/promises";
 
 export type PosixProcess = {
   pid: number;
@@ -74,27 +75,49 @@ export async function readCodexAppServerProcess(
 }
 
 export async function readCodexAppServerProcessCommand(
-  pid: number,
+  observed: PosixProcess,
   deadline: number,
 ): Promise<string> {
   let output: string;
   if (process.platform === "linux") {
-    const remainingMs = deadline - Date.now();
-    if (remainingMs <= 0) {
-      throw new ProcessInspectionError("deadline");
-    }
-    try {
-      const command = await readFile(`/proc/${pid}/cmdline`, {
-        encoding: "utf8",
-        signal: AbortSignal.timeout(remainingMs),
-      });
+    let pending = false;
+    do {
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        throw new ProcessInspectionError("deadline");
+      }
+      let command: string;
+      try {
+        command = await readFile(`/proc/${observed.pid}/cmdline`, {
+          encoding: "utf8",
+          signal: AbortSignal.timeout(remainingMs),
+        });
+      } catch (error) {
+        throw inspectionFailure(error);
+      }
+      // Linux can expose zero command bytes during exec startup. Wait only for
+      // that state, with the original identity and deadline, including the final read.
+      if (!command || pending) {
+        const current = await readCodexAppServerProcess(observed.pid, deadline);
+        if (
+          !current ||
+          current.startedAt !== observed.startedAt ||
+          current.ppid !== observed.ppid ||
+          current.pgid !== observed.pgid ||
+          current.state.startsWith("Z")
+        ) {
+          throw new ProcessInspectionError("unavailable");
+        }
+      }
       output = command.split("\0").join(" ").trim();
-    } catch (error) {
-      throw inspectionFailure(error);
-    }
+      pending = command.length === 0;
+      if (pending) {
+        await setImmediate();
+      }
+    } while (pending);
   } else {
     output =
-      (await readProcessOutput(["-o", "command=", "-p", String(pid)], deadline))
+      (await readProcessOutput(["-o", "command=", "-p", String(observed.pid)], deadline))
         .split("\n")[0]
         ?.trim() ?? "";
   }

--- a/extensions/codex/src/app-server/transport-startup.test.ts
+++ b/extensions/codex/src/app-server/transport-startup.test.ts
@@ -124,13 +124,13 @@ child.on("exit", (code, signal) => {
         inspected = resolve;
       });
       vi.spyOn(processSnapshot, "readCodexAppServerProcessCommand").mockImplementation(
-        async (pid, deadline) => {
-          if (pid !== wrapper?.pid) {
-            return readCommand(pid, deadline);
+        async (observed, deadline) => {
+          if (observed.pid !== wrapper?.pid) {
+            return readCommand(observed, deadline);
           }
           await expect.poll(() => fs.readFile(readyPath, "utf8").catch(() => "")).not.toBe("");
           nativePid = Number(await fs.readFile(readyPath, "utf8"));
-          const command = await readCommand(pid, deadline);
+          const command = await readCommand(observed, deadline);
           expect(command).toBeDefined();
           if (failure === "commit") {
             for (let index = 0; index < 512; index++) {


### PR DESCRIPTION
## Why

Full release verification intermittently rejected a fresh Codex app-server with `ProcessInspectionError: unavailable` after a disconnect/reconnect. Linux can expose an empty `/proc/<pid>/cmdline` while a live process is still starting. A real launcher probe reproduced zero bytes with unchanged PID, parent, process group, and boot/start identity; the same process exposed its command shortly afterward. The kernel explicitly allows this startup state in [get_mm_cmdline](https://github.com/torvalds/linux/blob/master/fs/proc/base.c).

## Change

Keep command readiness in the existing process inspection owner. Both registration and orphan inspection pass their already-observed process identity. Only zero-byte Linux command reads wait, within the original absolute deadline, with unchanged live identity checked throughout and after command bytes arrive. Permission errors, disappearance, replacement, malformed nonempty data, and expired deadlines still refuse inspection. macOS keeps its existing `ps` path.

Registration still requires a command fingerprint before its durable commit and before Codex initialization. No outer startup retry, larger timeout, alternate launcher, fingerprint bypass, configuration option, or storage change. The former PID-only private reader signature is removed and both callers move together.

## Validation

- Before fix: real Linux persistent app-server probe reproduced the startup race; the focused regression table failed on readiness, deadline, and permission classification.
- Focused owner/sibling suite: 82 tests passed across command inspection, registration, startup refusal cleanup, and startup retry behavior. Final reader assertions: 28 tests passed on Node 24, including actual macOS `ps` deadline cleanup.
- The registration case proves the durable store remains empty while command evidence is unavailable, then commits the fingerprint and cleans up on exit.
- Real Linux after-fix proof: 1,000 actual launcher starts passed; the unchanged original disconnect/reconnect E2E passed in 57.344s. [Testbox run](https://github.com/openclaw/openclaw/actions/runs/33331598067), frozen dependency install and SHA256-verified changed owners/test.
- Managed Codex review through P2: no actionable findings. Local changed-file checks passed through owner tests, boundaries and dead-export scanning, then stopped at unrelated shared-install dependency type errors (for example installed grammy 1.45.1 versus lockfile 1.46.0). No dependency reconciliation or unrelated fixes. Exact-head [CI33331926730](https://github.com/openclaw/openclaw/actions/runs/33331926730) passed on cff22e72197d70b97edd1c936db60737da4a3bba:118 checks passed,17 expected skips; required openclaw/ci-gate99313524855 passed. This PR is not a full release-green claim.

Production delta: +23 net lines in the command reader; the registration caller change is net-neutral. This adds bounded readiness for an observed Linux kernel state to the existing owner, with no compatibility path. Test growth covers identity changes, read errors, permanent empty output, and registration ordering. Docs and changelog describe the behavior.

Upstream contract inspection at 3c062df036070ad5819a9a74160a448b414e9b92: `codex-cli/bin/codex.js:195` (native child spawn with inherited streams) and `codex-rs/app-server/src/message_processor.rs:887` (initialization gate) were inspected directly. The exact dependency's stable source tag was unavailable; this report does not attribute the Linux kernel race to a particular Codex release.

## Maintainer review decisions

Addressing the latest ClawSweeper review and its rank-up move: retain the one-line changelog entry for this maintainer-authored, user-facing fix, as required by the task's changelog policy. The PR body also preserves release-note context. No runtime changes are needed for that policy preference.

Accept the bounded availability tradeoff: a permanently empty command line may consume the existing two-second inspection budget. The observed live Linux startup state requires that wait; identity loss and read errors still refuse immediately, and the regression suite proves the original deadline is not reset. The +23 production lines remain confined to that owner.

The automated stored-data warning does not apply: the process-registration schemas, store namespace, serialized fields, fingerprint format and SQLite structure are unchanged. Only the private command reader's in-memory argument now carries the already-observed process row. No migration or new persistence behavior is introduced.
