### PR TITLE
fix(macos): reuse SFSpeechRecognizer across recognition sessions

### DIFF
--- a/apps/macos/Sources/OpenClaw/SpeechRecognizerCache.swift
+++ b/apps/macos/Sources/OpenClaw/SpeechRecognizerCache.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Speech
+
+/// Reuses one `SFSpeechRecognizer` per locale instead of constructing a new one
+/// for every recognition session.
+///
+/// Each `SFSpeechRecognizer` opens its own XPC connection to the shared
+/// `localspeechrecognition` service and subscribes that service to the
+/// on-device speech assets. The service releases those subscriptions only when
+/// its own max-interval cleanup timer fires, so constructing a recognizer per
+/// session lets connections and asset subscriptions accumulate in a single
+/// long-lived service process.
+///
+/// Deliberately not `Sendable`: `SFSpeechRecognizer` is not `Sendable`, so each
+/// actor keeps its own cache rather than sharing a global instance.
+struct SpeechRecognizerCache {
+    private var recognizer: SFSpeechRecognizer?
+    private var cachedLocaleID: String?
+
+    /// Returns a recognizer for `localeID`, reusing the previous instance while
+    /// the locale is unchanged. A `nil` `localeID` resolves to the current locale.
+    ///
+    /// A failed construction is not cached, so the next call retries.
+    mutating func recognizer(localeID: String?) -> SFSpeechRecognizer? {
+        let resolvedID = localeID ?? Locale.current.identifier
+        if let recognizer = self.recognizer, self.cachedLocaleID == resolvedID {
+            return recognizer
+        }
+        let created = SFSpeechRecognizer(locale: Locale(identifier: resolvedID))
+        self.recognizer = created
+        self.cachedLocaleID = created == nil ? nil : resolvedID
+        return created
+    }
+}

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -51,6 +51,9 @@ actor TalkModeRuntime {
     }
 
     private var recognizer: SFSpeechRecognizer?
+    /// Reused across sessions so each utterance does not open a new
+    /// `localspeechrecognition` connection and asset subscription.
+    private var recognizerCache = SpeechRecognizerCache()
     private var audioEngine: AVAudioEngine?
     private var audioInputObserver: AudioInputDeviceObserver?
     private var activeInputResolution: AudioInputDeviceResolution?
@@ -319,9 +322,7 @@ actor TalkModeRuntime {
                 Locale.autoupdatingCurrent.identifier,
             ],
             supportedLocaleIDs: supportedLocaleIDs)
-        let recognizer = localeID
-            .map { SFSpeechRecognizer(locale: Locale(identifier: $0)) }
-            ?? SFSpeechRecognizer()
+        let recognizer = self.recognizerCache.recognizer(localeID: localeID)
         guard let recognizer, recognizer.isAvailable else {
             self.logger.error("talk recognizer unavailable")
             return false

--- a/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
@@ -27,6 +27,9 @@ actor VoiceWakeRuntime {
     private let logger = Logger(subsystem: "ai.openclaw", category: "voicewake.runtime")
 
     private var recognizer: SFSpeechRecognizer?
+    /// Reused across restarts so each restart does not open a new
+    /// `localspeechrecognition` connection and asset subscription.
+    private var recognizerCache = SpeechRecognizerCache()
     // Lazily created on start to avoid creating an AVAudioEngine at app launch, which can switch Bluetooth
     // headphones into the low-quality headset profile even if Voice Wake is disabled.
     private var audioEngine: AVAudioEngine?
@@ -280,8 +283,7 @@ actor VoiceWakeRuntime {
     }
 
     private func configureSession(localeID: String?) {
-        let locale = localeID.flatMap { Locale(identifier: $0) } ?? Locale(identifier: Locale.current.identifier)
-        self.recognizer = SFSpeechRecognizer(locale: locale)
+        self.recognizer = self.recognizerCache.recognizer(localeID: localeID)
         self.recognizer?.defaultTaskHint = .dictation
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/SpeechRecognizerCacheTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/SpeechRecognizerCacheTests.swift
@@ -1,0 +1,54 @@
+import Speech
+import Testing
+@testable import OpenClaw
+
+struct SpeechRecognizerCacheTests {
+    private static func supportedLocaleIDs(_ count: Int) -> [String] {
+        Array(SFSpeechRecognizer.supportedLocales().map(\.identifier).sorted().prefix(count))
+    }
+
+    @Test func `an unchanged locale reuses the same recognizer`() throws {
+        let localeIDs = Self.supportedLocaleIDs(1)
+        try #require(localeIDs.count == 1)
+        var cache = SpeechRecognizerCache()
+
+        let first = try #require(cache.recognizer(localeID: localeIDs[0]))
+        let second = try #require(cache.recognizer(localeID: localeIDs[0]))
+
+        #expect(first === second)
+    }
+
+    @Test func `a changed locale builds a new recognizer`() throws {
+        let localeIDs = Self.supportedLocaleIDs(2)
+        try #require(localeIDs.count == 2)
+        var cache = SpeechRecognizerCache()
+
+        let first = try #require(cache.recognizer(localeID: localeIDs[0]))
+        let second = try #require(cache.recognizer(localeID: localeIDs[1]))
+
+        #expect(first !== second)
+    }
+
+    @Test func `a nil locale resolves to the current locale and is reused`() throws {
+        var cache = SpeechRecognizerCache()
+
+        // Speech recognition need not support the host's current locale; when it
+        // does not there is no instance to compare and the reuse claim is vacuous.
+        guard let first = cache.recognizer(localeID: nil) else { return }
+        let second = try #require(cache.recognizer(localeID: nil))
+
+        #expect(first === second)
+    }
+
+    @Test func `an unsupported locale is not cached`() throws {
+        let unsupportedID = "zz-ZZ"
+        try #require(!SFSpeechRecognizer.supportedLocales().map(\.identifier).contains(unsupportedID))
+        let localeIDs = Self.supportedLocaleIDs(1)
+        try #require(localeIDs.count == 1)
+        var cache = SpeechRecognizerCache()
+
+        #expect(cache.recognizer(localeID: unsupportedID) == nil)
+        // A failed construction must not poison the cache for a later valid locale.
+        #expect(cache.recognizer(localeID: localeIDs[0]) != nil)
+    }
+}


### PR DESCRIPTION
Related: #133486

## What Problem This Solves

`TalkModeRuntime` constructs a new `SFSpeechRecognizer` for every recognition session, and `VoiceWakeRuntime` does the same on every restart (`configureSession(localeID:)` is called from `start(with:)`).

Each `SFSpeechRecognizer` opens its own XPC connection to the shared system `localspeechrecognition` service and subscribes that service to the on-device speech assets. The service releases those subscriptions only when its own max-interval cleanup timer fires, so per-session construction lets them pile up inside one long-lived service process.

Observed on macOS 26.6.2 (Apple M5 Max), app `2026.7.1`: about an hour of Talk Mode produced **152 XPC connect/invalidate cycles** and **80 asset subscriptions against 2 releases** on a single `localspeechrecognition` process. That process reached **~42 GB RSS**, held **1–1.8 CPU cores**, and was still running acoustic-model inference **~8 hours after** the Talk Mode session ended, with no microphone in use and no client attached.

Full forensic writeup, including the per-pid client attribution table and the timeline, is in #133486.

## Why This Change Was Made

`SFSpeechRecognizer` is designed to be long-lived and reused across many `recognitionTask(with:)` calls — the per-session object is what the app actually controls here, and rebuilding it per utterance is what drives the churn.

This adds `SpeechRecognizerCache`, which holds one recognizer per locale and rebuilds only when the locale changes, then uses it from both runtimes. Notes on the design:

- **Per-actor, not global.** `SFSpeechRecognizer` is not `Sendable`; both runtimes are `actor`s, so each keeps its own cache rather than sharing one instance.
- **Failed construction is not cached**, so an unsupported locale doesn't poison later valid lookups.
- **`discardRecognitionResources()` is unchanged.** It still clears `self.recognizer`; the cache holds the instance across sessions, which is the point.

Behavior at the call sites is otherwise identical — same locale resolution, same `defaultTaskHint`, same availability guard.

## User Impact

Stops unbounded growth of the `localspeechrecognition` service during extended Talk Mode use. The failure is silent from inside the app — nothing surfaces in OpenClaw, and the cost lands in a system process a user has no reason to connect to OpenClaw. On a 128 GB machine it was survivable; on a 16/32 GB Mac, 42 GB of leaked RSS would drive heavy swapping first. The user-visible symptom is a hot, loud Mac with no obvious culprit.

## Evidence

**macOS names the client.** Repeated 152× against the runaway service pid, where pid 20085 is OpenClaw.app:

```
[com.apple.xpc:connection] [0x9cd378000] invalidated because the client process (pid 20085) either cancelled the connection or exited
```

Other apps (Notes, Translate, callservicesd) leave an idle recognizer around too — those sat at 14–37 MB. What is specific here is the volume against one process.

**macOS logged the misuse**, ~6 hours after the session ended:

```
E localspeechrecognition[80257] [com.apple.speech.localspeechrecognition:SpeechFramework]
-[SFEntitledAssetManager _cleanupTimerFired] Cleanup timer fired because the max interval was reached.
You must call `releaseAssetSets` when you no longer need the assets.
```

**What it was doing** — `sample` on the live process, no mic in use, no client attached:

```
2147 Thread_5041732  DispatchQueue: com.apple._EARSpeechRecognizer.recognition (serial)
2147 Thread_5041733  DispatchQueue: ComputeAheadFeatInput (serial)
2147 Thread_5041769: ANEServicesThread
 512 ???  (in libBLAS.dylib)
```

**Killing the pid** reclaimed everything: 82 GB → 42 GB used, 89% → 93% idle, no user-visible breakage (launchd re-spawns on demand).

**Tests.** `SpeechRecognizerCacheTests` covers reuse for an unchanged locale, rebuild on locale change, `nil` locale resolution and reuse, and that a failed construction is not cached. Locales are drawn from `SFSpeechRecognizer.supportedLocales()` rather than hardcoded so the suite doesn't depend on host language support.

## Validation status — please read

**I could not build or run this locally.** Xcode's license was never agreed on the host machine, which disables `swiftc`, `git`, and `otool` there. All four files pass `swiftc -parse` (syntax) using the Command Line Tools toolchain, but that is **not** a typecheck against the SDK and the test suite has **not** been executed.

So: the diagnosis is backed by direct evidence from macOS's own logs and is the part I'd stand behind. The patch is a reasoned fix that follows from it and needs CI or a maintainer to actually validate. Flagging that plainly rather than implying validation I didn't do.

One honest caveat carried over from the issue: subscriptions (80) and connection cycles (152) are not 1:1, and `SFEntitledAssetManager` is Apple-internal — an app cannot call `releaseAssetSets` itself. Reducing recognizer churn is the lever the app controls; I can't prove from outside that it drives the service's accounting all the way to zero.

Happy to iterate on the approach or hand it off if you'd rather fix it differently.
