### PR TITLE
perf(process): reuse capacity facts within group selection

### DIFF
--- a/src/process/command-queue.capacity-groups.ts
+++ b/src/process/command-queue.capacity-groups.ts
@@ -131,28 +131,36 @@ export function resolveLaneBlockReason(lane: string): CommandLaneBlockReason {
   if (!group) {
     return null;
   }
-  let groupActive = 0;
-  let siblingReserveHeld = 0;
+  return resolveGroupBlockReason(group, lane, readGroupCapacity(group));
+}
+
+type GroupCapacity = { active: number; reserved: number };
+
+function readGroupCapacity(group: LaneGroupState): GroupCapacity {
+  let active = 0;
+  let reserved = 0;
   for (const member of group.members) {
-    const active = getMemberActiveCount(member);
-    groupActive += active;
-    if (member !== lane) {
-      // Unused portion of a sibling's reservation. Held back even while that
-      // sibling is idle — a hard reservation that siblings can borrow is not a
-      // reservation at all.
-      siblingReserveHeld += Math.max(0, (group.reservations.get(member) ?? 0) - active);
-    }
+    const memberActive = getMemberActiveCount(member);
+    active += memberActive;
+    reserved += Math.max(0, (group.reservations.get(member) ?? 0) - memberActive);
   }
-  if (groupActive >= group.budget) {
+  return { active, reserved };
+}
+
+function resolveGroupBlockReason(
+  group: LaneGroupState,
+  lane: string,
+  capacity: GroupCapacity,
+): CommandLaneBlockReason {
+  if (capacity.active >= group.budget) {
     return "group-budget";
   }
-  // Own reservation still unfilled: admit regardless of what siblings hold.
   if (getMemberActiveCount(lane) < (group.reservations.get(lane) ?? 0)) {
     return null;
   }
-  // Otherwise this task would be borrowing unreserved capacity, which must not
-  // eat into what siblings are guaranteed.
-  return groupActive + siblingReserveHeld < group.budget ? null : "sibling-reservation";
+  // The lane's own reservation is filled, so every unused reservation belongs
+  // to a sibling and must remain unavailable for borrowing.
+  return capacity.active + capacity.reserved < group.budget ? null : "sibling-reservation";
 }
 
 export function canAdmitInGroup(lane: string): boolean {
@@ -233,10 +241,17 @@ function resolveNextGroupLane(group: LaneGroupState): string | undefined {
         sequence: number;
       }
     | undefined;
+  let capacity: GroupCapacity | undefined;
   for (const lane of group.members) {
     const state = getQueueState().lanes.get(lane);
     const head = state ? peekLaneQueue(state.queue) : undefined;
-    if (!state || !head || state.draining || resolveLaneBlockReason(lane) !== null) {
+    if (!state || !head || state.draining || state.activeTaskIds.size >= state.maxConcurrent) {
+      continue;
+    }
+    // No callbacks run during selection. Recompute on the next selection after
+    // drainLane commits a slot or re-enters publication/reset through onWait.
+    capacity ??= readGroupCapacity(group);
+    if (resolveGroupBlockReason(group, lane, capacity) !== null) {
       continue;
     }
     if (


### PR DESCRIPTION
## What Problem This Solves

The command queue's capacity-group arbiter repeatedly scans every group member for each eligible lane head within one synchronous selection. The active counts and held reservations cannot change during that selection, so larger groups multiply identical work and the normal cron/hook group also pays for it.

## Why This Change Was Made

Read one transient capacity snapshot when the first eligible head needs it, then use it for the remaining heads in that selection. The existing capacity owner still derives counts from authoritative active-task sets. Every subsequent selection recomputes after a task admission, completion, reset, or callback re-entry; no persistent counter or cache can go stale.

Scalar status/admission queries use the same block-reason calculation. Lane caps, hard sibling reservations, group budgets, priority/sequence/tie ordering, publication transactions and reset generations keep their existing contracts. Production +31/-16, net +15: the small shared capacity value and decision helper replace the repeated scan without adding a second policy owner. No test, config, dependency, protocol or storage surface changes.

## Evidence

- 2,560 finite admission/order fixtures and 17 complete-owner re-entry/reset/publication controls exactly matched baseline. A fresh correctness run after pulling main retained the same digest and all operation-count savings.
- Two fresh Node processes measured all 15 workloads in opposite starting orders, retaining every warmup, sample, negative control and source/process receipt.
- In the actual two-member cron/hook setup, 64 tasks completed the measured queue-owner work at 1.927 to 1.515 microseconds/task and 1.937 to 1.567 microseconds/task (19–21% less elapsed time). Eight-task gains varied from 3–16%; one-member traffic also improved in both orders.
- Eight- and 32-member fixtures show larger savings, but these are generic stress cases: the current built-in group has only two members. Ungrouped main and hooks-off cron are retained controls, not claimed affected paths.
- Scalar two-member snapshot timing was mixed: 0.331 to 0.323 microseconds in one order and 0.317 to 0.325 in the other. No scalar-query speedup is claimed.

These are local queue-owner measurements from publication through task settlement, excluding fixture setup and output hashing. They do not measure provider, network, Gateway end-to-end latency, or retained-memory savings. All 85 existing tests across the five queue/publication/scoped-lane/Gateway suites passed. Full changed-file checks passed, and independent source review plus fresh managed Codex review found no actionable findings. Exact-head hosted CI run 33332574200 passed for 5bb41059a984807d9294aa1cb83b5d38273e6959. The latest ClawSweeper review and its Rank-up moves were read in full: it reports no actionable code findings and asks for exact-head checks plus the latest review check, both now satisfied.
