### PR TITLE
fix(talk): preserve provider conversation order in browser transcripts

### DIFF
--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -38,6 +38,12 @@ their current ephemeral-token and WebRTC data-channel flow.
 
 Finalized realtime user and assistant utterances are always appended live to the active agent session, so later chat and voice turns share one history. Client-owned transports report their finalized transcripts with stable entry ids; Gateway relay and Gateway-controlled WebRTC sessions append the same events server-side. Provider sessions also receive the bounded realtime profile context used by Discord voice.
 
+OpenAI GA browser Talk keeps provider conversation order even when an assistant
+reply finishes before the user's transcription. Text streams immediately in the
+call view; delayed transcripts appear beside the correct reply. Stopping a call
+drains finalized speech, skips unfinished transcriptions, and records a browser
+console warning when a transcript never completed.
+
 Google Live saves complete utterances during the call, including Gemini 3.1
 transcriptions that omit an explicit transcription-finished flag. Partial text
 stays provisional until the provider's completion boundary.

--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -39,10 +39,11 @@ their current ephemeral-token and WebRTC data-channel flow.
 Finalized realtime user and assistant utterances are always appended live to the active agent session, so later chat and voice turns share one history. Client-owned transports report their finalized transcripts with stable entry ids; Gateway relay and Gateway-controlled WebRTC sessions append the same events server-side. Provider sessions also receive the bounded realtime profile context used by Discord voice.
 
 OpenAI GA browser Talk keeps provider conversation order even when an assistant
-reply finishes before the user's transcription. Text streams immediately in the
-call view; delayed transcripts appear beside the correct reply. Stopping a call
-drains finalized speech, skips unfinished transcriptions, and records a browser
-console warning when a transcript never completed.
+reply finishes before the user's transcription or item announcements arrive out
+of order. Text streams immediately in the call view; late predecessor metadata
+places it beside the correct reply. Stopping a call drains finalized speech,
+skips unfinished transcriptions, and records a browser console warning for
+missing transcriptions or unresolved conversation links.
 
 Google Live saves complete utterances during the call, including Gemini 3.1
 transcriptions that omit an explicit transcription-finished flag. Partial text

--- a/src/talk/voice-transcript.ts
+++ b/src/talk/voice-transcript.ts
@@ -15,6 +15,7 @@ export function normalizeVoiceTranscriptText(text: string): string {
 
 export const VOICE_TRANSCRIPT_QUEUE_POLICY = {
   maxPendingCount: VOICE_TRANSCRIPT_QUEUE_MAX_PENDING,
+  maxEntryChars: VOICE_TRANSCRIPT_MAX_CHARS,
   overflowMessage: VOICE_TRANSCRIPT_QUEUE_OVERFLOW_MESSAGE,
   createQueue: () =>
     new BoundedSerialQueue({

--- a/ui/src/e2e/browser-talk-ordering.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-ordering.e2e.test.ts
@@ -1,0 +1,136 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import {
+  dispatchOpenAiTalkEvent,
+  installOpenAiTalkFixture,
+  videoTalkCatalog,
+} from "./browser-talk-start-stop.fixtures.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI browser Talk transcript ordering",
+  browserLaunchOptions: {
+    args: ["--use-fake-device-for-media-stream", "--use-fake-ui-for-media-stream"],
+  },
+});
+
+suite.define(() => {
+  it("renders and saves overlapping replies beside their delayed user transcripts", async () => {
+    const artifactDir = path.join(process.cwd(), ".artifacts/control-ui-e2e/transcript-ordering");
+    await mkdir(artifactDir, { recursive: true });
+    await suite.withPage(
+      {
+        permissions: ["microphone"],
+        viewport: { width: 1366, height: 900 },
+        recordVideo: { dir: artifactDir, size: { width: 1366, height: 900 } },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "talk.catalog": videoTalkCatalog("openai"),
+            "talk.client.create": {
+              provider: "openai",
+              transport: "webrtc",
+              voiceSessionId: "voice-ordering-e2e",
+              clientSecret: "test-client-secret",
+            },
+          },
+        });
+        await installOpenAiTalkFixture(page);
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await page.getByRole("button", { name: "Start voice input" }).click();
+        await gateway.waitForRequest("talk.client.create");
+        await expect
+          .poll(() =>
+            page.evaluate(() =>
+              Boolean(
+                (
+                  window as Window & {
+                    openclawVideoTalkE2e?: { peer: { remoteDescription: unknown } };
+                  }
+                ).openclawVideoTalkE2e?.peer.remoteDescription,
+              ),
+            ),
+          )
+          .toBe(true);
+        await page.evaluate(() => {
+          (
+            window as Window & {
+              openclawVideoTalkE2e?: { peer: { channel: EventTarget } };
+            }
+          ).openclawVideoTalkE2e?.peer.channel.dispatchEvent(new Event("open"));
+        });
+        const rows = page.locator(".agent-chat__voice-turn-text");
+        const emit = async (event: unknown) => await dispatchOpenAiTalkEvent(page, event);
+        const item = async (id: string, role: "user" | "assistant", previous: string | null) =>
+          await emit({
+            type: "conversation.item.added",
+            previous_item_id: previous,
+            item: {
+              id,
+              type: "message",
+              role,
+              content: role === "user" ? [{ type: "input_audio" }] : [],
+            },
+          });
+        const final = async (id: string, role: "user" | "assistant", transcript: string) =>
+          await emit({
+            type:
+              role === "user"
+                ? "conversation.item.input_audio_transcription.completed"
+                : "response.output_audio_transcript.done",
+            item_id: id,
+            transcript,
+          });
+        await emit({
+          type: "input_audio_buffer.committed",
+          item_id: "question-1",
+          previous_item_id: null,
+        });
+        await item("question-1", "user", null);
+        await item("answer-1", "assistant", "question-1");
+        await item("question-2", "user", "answer-1");
+        await item("answer-2", "assistant", "question-2");
+        await emit({
+          type: "response.output_audio_transcript.delta",
+          item_id: "answer-1",
+          delta: "Glacier.",
+        });
+        await expect.poll(() => rows.allTextContents()).toEqual(["Glacier."]);
+        await page.screenshot({ path: path.join(artifactDir, "streaming.png"), fullPage: true });
+        await final("answer-2", "assistant", "Lantern.");
+        await final("question-2", "user", "Please say lantern.");
+        await final("answer-1", "assistant", "Glacier.");
+        expect(await gateway.getRequests("talk.client.transcript")).toEqual([]);
+        await final("question-1", "user", "Please say glacier.");
+        await expect
+          .poll(() =>
+            gateway
+              .getRequests("talk.client.transcript")
+              .then((requests) => requests.map(({ params }) => params)),
+          )
+          .toEqual([
+            expect.objectContaining({ role: "user", text: "Please say glacier." }),
+            expect.objectContaining({ role: "assistant", text: "Glacier." }),
+            expect.objectContaining({ role: "user", text: "Please say lantern." }),
+            expect.objectContaining({ role: "assistant", text: "Lantern." }),
+          ]);
+        try {
+          await expect
+            .poll(() => rows.allTextContents())
+            .toEqual(["Please say glacier.", "Glacier.", "Please say lantern.", "Lantern."]);
+        } finally {
+          await page.screenshot({
+            path: path.join(artifactDir, "final-order.png"),
+            fullPage: true,
+          });
+        }
+        await page.getByRole("button", { name: "Stop voice input" }).click();
+        await gateway.waitForRequest("talk.client.close");
+        expect(await gateway.getRequests("talk.client.close")).toHaveLength(1);
+      },
+    );
+  });
+});

--- a/ui/src/e2e/browser-talk-ordering.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-ordering.e2e.test.ts
@@ -84,6 +84,18 @@ suite.define(() => {
             item_id: id,
             transcript,
           });
+        await item("answer-2", "assistant", "question-2");
+        await emit({
+          type: "response.output_audio_transcript.delta",
+          item_id: "answer-2",
+          delta: "Lantern.",
+        });
+        await expect.poll(() => rows.allTextContents()).toEqual(["Lantern."]);
+        await page.screenshot({
+          path: path.join(artifactDir, "unresolved-order.png"),
+          fullPage: true,
+        });
+        await final("answer-2", "assistant", "Lantern.");
         await emit({
           type: "input_audio_buffer.committed",
           item_id: "question-1",
@@ -91,16 +103,14 @@ suite.define(() => {
         });
         await item("question-1", "user", null);
         await item("answer-1", "assistant", "question-1");
-        await item("question-2", "user", "answer-1");
-        await item("answer-2", "assistant", "question-2");
         await emit({
           type: "response.output_audio_transcript.delta",
           item_id: "answer-1",
           delta: "Glacier.",
         });
-        await expect.poll(() => rows.allTextContents()).toEqual(["Glacier."]);
+        await expect.poll(() => rows.allTextContents()).toEqual(["Glacier.", "Lantern."]);
         await page.screenshot({ path: path.join(artifactDir, "streaming.png"), fullPage: true });
-        await final("answer-2", "assistant", "Lantern.");
+        await item("question-2", "user", "answer-1");
         await final("question-2", "user", "Please say lantern.");
         await final("answer-1", "assistant", "Glacier.");
         expect(await gateway.getRequests("talk.client.transcript")).toEqual([]);

--- a/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
@@ -9,6 +9,7 @@ import {
   installBlockedMicrophoneFixture,
   installBlockedVideoTalkFixture,
   installTalkBrowserFixtures,
+  installOpenAiTalkFixture,
   videoTalkCatalog,
 } from "./browser-talk-start-stop.fixtures.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -328,94 +329,7 @@ suite.define(() => {
           },
         },
       });
-      await page.addInitScript(() => {
-        const getUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
-        Object.defineProperty(navigator.mediaDevices, "getUserMedia", {
-          configurable: true,
-          value: async (constraints: MediaStreamConstraints) => {
-            const stream = await getUserMedia(constraints);
-            (
-              window as Window & {
-                openclawVideoTalkTracks?: MediaStreamTrack[];
-              }
-            ).openclawVideoTalkTracks = [
-              ...((window as Window & { openclawVideoTalkTracks?: MediaStreamTrack[] })
-                .openclawVideoTalkTracks ?? []),
-              ...stream.getTracks(),
-            ];
-            return stream;
-          },
-        });
-        class FakeDataChannel extends EventTarget {
-          readyState = "open";
-          sent: unknown[] = [];
-
-          send(payload: string) {
-            this.sent.push(JSON.parse(payload));
-          }
-
-          close() {
-            this.readyState = "closed";
-          }
-        }
-
-        class FakePeerConnection extends EventTarget {
-          connectionState = "new";
-          channel = new FakeDataChannel();
-          localDescription: RTCSessionDescriptionInit | null = null;
-          remoteDescription: RTCSessionDescriptionInit | null = null;
-
-          constructor() {
-            super();
-            (
-              window as Window & {
-                openclawVideoTalkE2e?: {
-                  dataChannelCreated: boolean;
-                  peer: FakePeerConnection;
-                };
-              }
-            ).openclawVideoTalkE2e = { dataChannelCreated: false, peer: this };
-          }
-
-          addTrack() {}
-
-          createDataChannel() {
-            const harness = (
-              window as Window & {
-                openclawVideoTalkE2e?: { dataChannelCreated: boolean };
-              }
-            ).openclawVideoTalkE2e;
-            if (harness) {
-              harness.dataChannelCreated = true;
-            }
-            return this.channel;
-          }
-
-          async createOffer() {
-            return { type: "offer" as const, sdp: "offer-sdp" };
-          }
-
-          async setLocalDescription(description: RTCSessionDescriptionInit) {
-            this.localDescription = description;
-          }
-
-          async setRemoteDescription(description: RTCSessionDescriptionInit) {
-            this.remoteDescription = description;
-          }
-
-          close() {
-            this.connectionState = "closed";
-          }
-        }
-
-        Object.defineProperty(window, "RTCPeerConnection", {
-          configurable: true,
-          value: FakePeerConnection,
-        });
-      });
-      await page.route("https://api.openai.com/v1/realtime/calls", async (route) => {
-        await route.fulfill({ status: 200, contentType: "application/sdp", body: "answer-sdp" });
-      });
+      await installOpenAiTalkFixture(page);
 
       await page.setViewportSize({ width: 1366, height: 900 });
       await page.goto(`${suite.server.baseUrl}chat`);
@@ -447,6 +361,21 @@ suite.define(() => {
           }
         ).openclawVideoTalkE2e?.peer.channel;
         channel?.dispatchEvent(new Event("open"));
+      });
+      await dispatchOpenAiTalkEvent(page, {
+        type: "input_audio_buffer.committed",
+        item_id: "unintelligible-input",
+        previous_item_id: null,
+      });
+      await dispatchOpenAiTalkEvent(page, {
+        type: "conversation.item.added",
+        previous_item_id: null,
+        item: {
+          id: "unintelligible-input",
+          type: "message",
+          role: "user",
+          content: [{ type: "input_audio", transcript: null }],
+        },
       });
       await dispatchOpenAiTalkEvent(page, {
         type: "conversation.item.input_audio_transcription.failed",

--- a/ui/src/e2e/browser-talk-start-stop.fixtures.ts
+++ b/ui/src/e2e/browser-talk-start-stop.fixtures.ts
@@ -14,6 +14,97 @@ export async function dispatchOpenAiTalkEvent(page: Page, event: unknown) {
   }, event);
 }
 
+export async function installOpenAiTalkFixture(page: Page) {
+  await page.addInitScript(() => {
+    const getUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
+    Object.defineProperty(navigator.mediaDevices, "getUserMedia", {
+      configurable: true,
+      value: async (constraints: MediaStreamConstraints) => {
+        const stream = await getUserMedia(constraints);
+        (
+          window as Window & {
+            openclawVideoTalkTracks?: MediaStreamTrack[];
+          }
+        ).openclawVideoTalkTracks = [
+          ...((window as Window & { openclawVideoTalkTracks?: MediaStreamTrack[] })
+            .openclawVideoTalkTracks ?? []),
+          ...stream.getTracks(),
+        ];
+        return stream;
+      },
+    });
+    class FakeDataChannel extends EventTarget {
+      readyState = "open";
+      sent: unknown[] = [];
+
+      send(payload: string) {
+        this.sent.push(JSON.parse(payload));
+      }
+
+      close() {
+        this.readyState = "closed";
+      }
+    }
+
+    class FakePeerConnection extends EventTarget {
+      connectionState = "new";
+      channel = new FakeDataChannel();
+      localDescription: RTCSessionDescriptionInit | null = null;
+      remoteDescription: RTCSessionDescriptionInit | null = null;
+
+      constructor() {
+        super();
+        (
+          window as Window & {
+            openclawVideoTalkE2e?: {
+              dataChannelCreated: boolean;
+              peer: FakePeerConnection;
+            };
+          }
+        ).openclawVideoTalkE2e = { dataChannelCreated: false, peer: this };
+      }
+
+      addTrack() {}
+
+      createDataChannel() {
+        const harness = (
+          window as Window & {
+            openclawVideoTalkE2e?: { dataChannelCreated: boolean };
+          }
+        ).openclawVideoTalkE2e;
+        if (harness) {
+          harness.dataChannelCreated = true;
+        }
+        return this.channel;
+      }
+
+      async createOffer() {
+        return { type: "offer" as const, sdp: "offer-sdp" };
+      }
+
+      async setLocalDescription(description: RTCSessionDescriptionInit) {
+        this.localDescription = description;
+      }
+
+      async setRemoteDescription(description: RTCSessionDescriptionInit) {
+        this.remoteDescription = description;
+      }
+
+      close() {
+        this.connectionState = "closed";
+      }
+    }
+
+    Object.defineProperty(window, "RTCPeerConnection", {
+      configurable: true,
+      value: FakePeerConnection,
+    });
+  });
+  await page.route("https://api.openai.com/v1/realtime/calls", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/sdp", body: "answer-sdp" });
+  });
+}
+
 export type WebRtcSdpE2eProof = {
   bodyCancelCount: number;
   bodyCancelResolvedCount: number;

--- a/ui/src/pages/chat/chat-realtime.ts
+++ b/ui/src/pages/chat/chat-realtime.ts
@@ -3,6 +3,7 @@ import { loadSettings, patchSettings, type UiSettings } from "../../app/settings
 import { formatUiError, formatUiExternalText } from "../../lib/format-error.ts";
 import {
   createRealtimeTalkConversationState,
+  orderRealtimeTalkConversation,
   updateRealtimeTalkConversation,
   type RealtimeTalkConversationEntry,
   type RealtimeTalkConversationState,
@@ -226,6 +227,17 @@ export function attachChatRealtimeActions(state: ChatRealtimeState) {
           state.realtimeTalkConversationState = updateRealtimeTalkConversation(
             state.realtimeTalkConversationState,
             entry,
+          );
+          state.realtimeTalkConversation = state.realtimeTalkConversationState.entries;
+          state.requestUpdate();
+        },
+        onTranscriptOrder: (orders) => {
+          if (state.realtimeTalkSession !== session) {
+            return;
+          }
+          state.realtimeTalkConversationState = orderRealtimeTalkConversation(
+            state.realtimeTalkConversationState,
+            orders,
           );
           state.realtimeTalkConversation = state.realtimeTalkConversationState.entries;
           state.requestUpdate();

--- a/ui/src/pages/chat/realtime-talk-conversation.ts
+++ b/ui/src/pages/chat/realtime-talk-conversation.ts
@@ -50,7 +50,7 @@ export function updateRealtimeTalkConversation(
   if (update.final ? text.trim() === "" : text === "") {
     return state;
   }
-  if (update.itemId !== undefined && update.order !== undefined) {
+  if (update.itemId !== undefined) {
     const id = `item-${update.itemId}`;
     const previous = state.entries.find((entry) => entry.id === id);
     const entry = {
@@ -62,12 +62,10 @@ export function updateRealtimeTalkConversation(
     };
     // Provider identities survive delayed ASR and overlapping responses. Text and
     // wall-clock proximity cannot identify which utterance a final replaces.
-    return {
+    return orderRealtimeTalkConversation({
       ...state,
-      entries: [...state.entries.filter((candidate) => candidate.id !== id), entry]
-        .toSorted((left, right) => (left.order ?? 0) - (right.order ?? 0))
-        .slice(-MAX_CONVERSATION_ENTRIES),
-    };
+      entries: [...state.entries.filter((candidate) => candidate.id !== id), entry],
+    });
   }
   const nowMs = update.nowMs ?? Date.now();
   if (update.role === "assistant") {
@@ -105,6 +103,20 @@ export function updateRealtimeTalkConversation(
     update.final,
     nowMs,
   );
+}
+
+export function orderRealtimeTalkConversation(
+  state: RealtimeTalkConversationState,
+  orders: ReadonlyArray<{ itemId: string; order: number }> = [],
+): RealtimeTalkConversationState {
+  const byId = new Map(orders.map(({ itemId, order }) => [`item-${itemId}`, order]));
+  return {
+    ...state,
+    entries: state.entries
+      .map((entry) => (byId.has(entry.id) ? { ...entry, order: byId.get(entry.id) } : entry))
+      .toSorted((left, right) => (left.order ?? Infinity) - (right.order ?? Infinity))
+      .slice(-MAX_CONVERSATION_ENTRIES),
+  };
 }
 
 function upsertRealtimeConversationEntry(

--- a/ui/src/pages/chat/realtime-talk-conversation.ts
+++ b/ui/src/pages/chat/realtime-talk-conversation.ts
@@ -1,5 +1,6 @@
 // Control UI chat module implements realtime talk conversation behavior.
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import type { RealtimeTalkTranscript } from "./realtime-talk-shared.ts";
 
 type RealtimeTalkConversationRole = "user" | "assistant";
 
@@ -8,6 +9,7 @@ export type RealtimeTalkConversationEntry = {
   role: RealtimeTalkConversationRole;
   text: string;
   isStreaming: boolean;
+  order?: number;
 };
 
 export type RealtimeTalkConversationState = {
@@ -19,10 +21,7 @@ export type RealtimeTalkConversationState = {
   assistantEntryId: string | null;
 };
 
-type RealtimeTalkTranscriptUpdate = {
-  role: RealtimeTalkConversationRole;
-  text: string;
-  final: boolean;
+type RealtimeTalkTranscriptUpdate = RealtimeTalkTranscript & {
   nowMs?: number;
 };
 
@@ -50,6 +49,25 @@ export function updateRealtimeTalkConversation(
   const text = update.text;
   if (update.final ? text.trim() === "" : text === "") {
     return state;
+  }
+  if (update.itemId !== undefined && update.order !== undefined) {
+    const id = `item-${update.itemId}`;
+    const previous = state.entries.find((entry) => entry.id === id);
+    const entry = {
+      id,
+      role: update.role,
+      order: update.order,
+      text: boundRealtimeConversationText(update.final ? text : (previous?.text ?? "") + text),
+      isStreaming: !update.final,
+    };
+    // Provider identities survive delayed ASR and overlapping responses. Text and
+    // wall-clock proximity cannot identify which utterance a final replaces.
+    return {
+      ...state,
+      entries: [...state.entries.filter((candidate) => candidate.id !== id), entry]
+        .toSorted((left, right) => (left.order ?? 0) - (right.order ?? 0))
+        .slice(-MAX_CONVERSATION_ENTRIES),
+    };
   }
   const nowMs = update.nowMs ?? Date.now();
   if (update.role === "assistant") {

--- a/ui/src/pages/chat/realtime-talk-ordering.test.ts
+++ b/ui/src/pages/chat/realtime-talk-ordering.test.ts
@@ -5,6 +5,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import {
   createRealtimeTalkConversationState,
+  orderRealtimeTalkConversation,
   updateRealtimeTalkConversation,
 } from "./realtime-talk-conversation.ts";
 import { useRealtimeTalkMicrophoneFixture } from "./realtime-talk-input.test-support.ts";
@@ -86,6 +87,9 @@ function createCall(onTranscript?: (entry: RealtimeTalkTranscript) => void) {
     {
       onStatus,
       onTalkEvent,
+      onTranscriptOrder: (orders) => {
+        conversation = orderRealtimeTalkConversation(conversation, orders);
+      },
       onTranscript: (entry) => {
         conversation = updateRealtimeTalkConversation(conversation, entry);
         onTranscript?.(entry);
@@ -96,6 +100,7 @@ function createCall(onTranscript?: (entry: RealtimeTalkTranscript) => void) {
   onTestFinished(() => session.stop());
   return {
     session,
+    request,
     requests,
     onStatus,
     onTalkEvent,
@@ -138,9 +143,9 @@ describe("browser Talk provider item ordering", () => {
       const settled = starting.catch((error: unknown) => error);
       await waitForFast(() => expect(Peer.instances[0]?.setRemoteDescription).toHaveBeenCalled());
       const peer = Peer.instances[0]!;
-      item(peer, "early-user", "user", null);
       item(peer, "early-answer", "assistant", "early-user");
       final(peer, "early-answer", "assistant", "answer during setup");
+      item(peer, "early-user", "user", null);
       if (outcome === "ready") {
         setup.resolve();
         await starting;
@@ -237,6 +242,129 @@ describe("browser Talk provider item ordering", () => {
       "second answer",
     ]);
     call.session.stop();
+  });
+
+  it.each(["speech", "non-speech"])(
+    "connects an early successor through a late %s predecessor without delaying streaming",
+    async (predecessor) => {
+      const call = await start();
+      item(call.peer, "a2", "assistant", "middle");
+      emit(call.peer, {
+        type: "response.output_audio_transcript.delta",
+        item_id: "a2",
+        delta: "second answer",
+      });
+      expect(call.peer.close).not.toHaveBeenCalled();
+      expect(call.entries()).toEqual([{ role: "assistant", text: "second answer" }]);
+      final(call.peer, "a2", "assistant", "second answer");
+      item(call.peer, "u1", "user", null);
+      item(call.peer, "a1", "assistant", "u1");
+      final(call.peer, "a1", "assistant", "first answer");
+      final(call.peer, "u1", "user", "first question");
+      await waitForFast(() => expect(call.writes()).toHaveLength(2));
+      emit(call.peer, {
+        type: "conversation.item.added",
+        previous_item_id: "a1",
+        item:
+          predecessor === "speech"
+            ? { id: "middle", type: "message", role: "user", content: [{ type: "input_audio" }] }
+            : { id: "middle", type: "function_call_output" },
+      });
+      // Metadata alone must move a previously streamed row into its known order.
+      expect(call.entries().map(({ text }) => text)).toEqual([
+        "first question",
+        "first answer",
+        "second answer",
+      ]);
+      if (predecessor === "speech") {
+        expect(call.writes()).toHaveLength(2);
+        final(call.peer, "middle", "user", "second question");
+      }
+      const expected = [
+        "first question",
+        "first answer",
+        ...(predecessor === "speech" ? ["second question"] : []),
+        "second answer",
+      ];
+      await waitForFast(() =>
+        expect(call.writes().map(({ params }) => params.text)).toEqual(expected),
+      );
+      expect(call.entries().map(({ text }) => text)).toEqual(expected);
+      expect(call.peer.close).not.toHaveBeenCalled();
+    },
+  );
+
+  it("drains a known successor when its predecessor never arrives before stop", async () => {
+    const call = await start();
+    item(call.peer, "a2", "assistant", "a1");
+    final(call.peer, "a2", "assistant", "next answer");
+    item(call.peer, "a1", "assistant", "missing-user");
+    final(call.peer, "a1", "assistant", "known answer");
+    expect(call.peer.close).not.toHaveBeenCalled();
+    expect(call.writes()).toEqual([]);
+    call.session.stop();
+    await waitForFast(() => expect(call.requests.at(-1)?.method).toBe("talk.client.close"));
+    expect(call.writes().map(({ params }) => params.text)).toEqual(["known answer", "next answer"]);
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("unfinished transcript"));
+    item(call.peer, "missing-user", "user", null);
+    final(call.peer, "missing-user", "user", "too late");
+    expect(call.writes()).toHaveLength(2);
+    expect(call.requests.filter(({ method }) => method === "talk.client.close")).toHaveLength(1);
+  });
+
+  it("reports a failed predecessor save while its accepted successor still awaits ASR", async () => {
+    const call = await start();
+    const error = new Error("transcript store unavailable");
+    call.request
+      .mockRejectedValueOnce(error)
+      .mockRejectedValueOnce(error)
+      .mockRejectedValueOnce(error);
+    vi.useFakeTimers();
+    item(call.peer, "u2", "user", "u1");
+    item(call.peer, "u1", "user", null);
+    final(call.peer, "u1", "user", "first question");
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(call.onStatus).toHaveBeenLastCalledWith(
+      "error",
+      "Voice transcript could not be saved: transcript store unavailable",
+    );
+    expect(call.peer.close).not.toHaveBeenCalled();
+    vi.useRealTimers();
+    final(call.peer, "u2", "user", "second question");
+    call.session.stop();
+    await waitForFast(() => expect(call.requests.at(-1)?.method).toBe("talk.client.close"));
+    expect(call.writes().map(({ params }) => params.text)).toEqual(["second question"]);
+    expect(call.onStatus.mock.calls.filter(([status]) => status === "error")).toHaveLength(1);
+  });
+
+  it("keeps a consult flush bound to the accepted successor while its predecessor arrives", async () => {
+    const call = await start();
+    item(call.peer, "a1", "assistant", "u1");
+    final(call.peer, "a1", "assistant", "answer");
+    emit(call.peer, {
+      type: "response.done",
+      response: {
+        status: "completed",
+        output: [
+          {
+            type: "function_call",
+            call_id: "consult-1",
+            name: "openclaw_agent_consult",
+            arguments: JSON.stringify({ question: "check status" }),
+          },
+        ],
+      },
+    });
+    item(call.peer, "u1", "user", null);
+    final(call.peer, "u1", "user", "question");
+    await waitForFast(() =>
+      expect(call.requests.some(({ method }) => method === "talk.client.toolCall")).toBe(true),
+    );
+    expect(
+      call.requests
+        .filter(({ method }) => method !== "talk.client.create")
+        .map(({ method }) => method),
+    ).toEqual(["talk.client.transcript", "talk.client.transcript", "talk.client.toolCall"]);
   });
 
   it.each(["failed", "empty"])(
@@ -338,26 +466,29 @@ describe("browser Talk provider item ordering", () => {
     ]);
   });
 
-  it("bounds unresolved provider items and drains its accepted finals on overflow", async () => {
-    const call = await start();
-    item(call.peer, "u1", "user", null);
-    for (let index = 0; index < 40; index += 1) {
-      item(call.peer, `a${index}`, "assistant", index === 0 ? "u1" : `a${index - 1}`);
-      final(call.peer, `a${index}`, "assistant", `answer-${index}`);
-    }
-    expect(call.writes()).toEqual([]);
-    item(call.peer, "overflow", "user", "a39");
-    expect(call.onStatus).toHaveBeenLastCalledWith(
-      "error",
-      expect.stringContaining("could not keep up"),
-    );
-    await waitForFast(() => expect(call.requests.at(-1)?.method).toBe("talk.client.close"));
-    expect(call.writes().map(({ params }) => params.text)).toEqual(
-      Array.from({ length: 40 }, (_, index) => `answer-${index}`),
-    );
-    final(call.peer, "u1", "user", "too late");
-    expect(call.writes()).toHaveLength(40);
-  });
+  it.each([null, "missing-root"])(
+    "bounds pending items with predecessor %s and drains accepted finals on overflow",
+    async (previous) => {
+      const call = await start();
+      item(call.peer, "u1", "user", previous);
+      for (let index = 0; index < 40; index += 1) {
+        item(call.peer, `a${index}`, "assistant", index === 0 ? "u1" : `a${index - 1}`);
+        final(call.peer, `a${index}`, "assistant", `answer-${index}`);
+      }
+      expect(call.writes()).toEqual([]);
+      item(call.peer, "overflow", "user", "a39");
+      expect(call.onStatus).toHaveBeenLastCalledWith(
+        "error",
+        expect.stringContaining("could not keep up"),
+      );
+      await waitForFast(() => expect(call.requests.at(-1)?.method).toBe("talk.client.close"));
+      expect(call.writes().map(({ params }) => params.text)).toEqual(
+        Array.from({ length: 40 }, (_, index) => `answer-${index}`),
+      );
+      final(call.peer, "u1", "user", "too late");
+      expect(call.writes()).toHaveLength(40);
+    },
+  );
 
   it("persists a keyed final before a consumer synchronously stops the call", async () => {
     const call = createCall((entry) => {

--- a/ui/src/pages/chat/realtime-talk-ordering.test.ts
+++ b/ui/src/pages/chat/realtime-talk-ordering.test.ts
@@ -361,7 +361,9 @@ describe("browser Talk provider item ordering", () => {
 
   it("persists a keyed final before a consumer synchronously stops the call", async () => {
     const call = createCall((entry) => {
-      if (entry.final) call.session.stop();
+      if (entry.final) {
+        call.session.stop();
+      }
     });
     await call.session.start();
     const peer = Peer.instances[0]!;

--- a/ui/src/pages/chat/realtime-talk-ordering.test.ts
+++ b/ui/src/pages/chat/realtime-talk-ordering.test.ts
@@ -1,0 +1,396 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import {
+  createRealtimeTalkConversationState,
+  updateRealtimeTalkConversation,
+} from "./realtime-talk-conversation.ts";
+import { useRealtimeTalkMicrophoneFixture } from "./realtime-talk-input.test-support.ts";
+import type { RealtimeTalkTranscript } from "./realtime-talk-shared.ts";
+import { RealtimeTalkSession } from "./realtime-talk.ts";
+
+class Peer extends EventTarget {
+  static instances: Peer[] = [];
+  static setupBlock: (() => Promise<void>) | undefined;
+  connectionState = "new";
+  channel = Object.assign(new EventTarget(), {
+    readyState: "open",
+    send: vi.fn(),
+    close: vi.fn(),
+  });
+  addTrack = vi.fn();
+  createDataChannel = () => this.channel;
+  createOffer = async () => ({ type: "offer", sdp: "offer-sdp" });
+  setLocalDescription = vi.fn(async () => undefined);
+  setRemoteDescription = vi.fn(async () => await Peer.setupBlock?.());
+  close = vi.fn();
+
+  constructor() {
+    super();
+    Peer.instances.push(this);
+  }
+}
+
+useRealtimeTalkMicrophoneFixture();
+
+function emit(peer: Peer, event: unknown): void {
+  peer.channel.dispatchEvent(new MessageEvent("message", { data: JSON.stringify(event) }));
+}
+
+function item(peer: Peer, id: string, role: "user" | "assistant", previous: string | null): void {
+  emit(peer, {
+    type: "conversation.item.added",
+    previous_item_id: previous,
+    item: {
+      id,
+      type: "message",
+      role,
+      content: role === "user" ? [{ type: "input_audio", transcript: null }] : [],
+    },
+  });
+}
+
+function final(peer: Peer, id: string, role: "user" | "assistant", text: string): void {
+  emit(peer, {
+    type:
+      role === "user"
+        ? "conversation.item.input_audio_transcription.completed"
+        : "response.output_audio_transcript.done",
+    item_id: id,
+    transcript: text,
+  });
+}
+
+function createCall(onTranscript?: (entry: RealtimeTalkTranscript) => void) {
+  let conversation = createRealtimeTalkConversationState();
+  let nextVoiceSession = 0;
+  const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+  const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
+    requests.push({ method, params });
+    return method === "talk.client.create"
+      ? {
+          provider: "openai",
+          transport: "webrtc",
+          voiceSessionId: `voice-${++nextVoiceSession}`,
+          clientSecret: "test-secret",
+        }
+      : { ok: true };
+  });
+  const onStatus = vi.fn();
+  const onTalkEvent = vi.fn();
+  const session = new RealtimeTalkSession(
+    { request } as unknown as GatewayBrowserClient,
+    "agent:main:main",
+    {
+      onStatus,
+      onTalkEvent,
+      onTranscript: (entry) => {
+        conversation = updateRealtimeTalkConversation(conversation, entry);
+        onTranscript?.(entry);
+      },
+    },
+    { transport: "webrtc" },
+  );
+  onTestFinished(() => session.stop());
+  return {
+    session,
+    requests,
+    onStatus,
+    onTalkEvent,
+    entries: () => conversation.entries.map(({ role, text }) => ({ role, text })),
+    writes: () => requests.filter(({ method }) => method === "talk.client.transcript"),
+  };
+}
+
+async function start() {
+  const call = createCall();
+  await call.session.start();
+  return { ...call, peer: Peer.instances.at(-1)! };
+}
+
+describe("browser Talk provider item ordering", () => {
+  beforeEach(() => {
+    Peer.instances = [];
+    Peer.setupBlock = undefined;
+    vi.stubGlobal("RTCPeerConnection", Peer);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("answer-sdp")),
+    );
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it.each(["ready", "stop", "replacement", "failure"])(
+    "owns early provider items during SDP setup through %s",
+    async (outcome) => {
+      const setup = createDeferred();
+      Peer.setupBlock = () => setup.promise;
+      const call = createCall();
+      const starting = call.session.start();
+      const settled = starting.catch((error: unknown) => error);
+      await waitForFast(() => expect(Peer.instances[0]?.setRemoteDescription).toHaveBeenCalled());
+      const peer = Peer.instances[0]!;
+      item(peer, "early-user", "user", null);
+      item(peer, "early-answer", "assistant", "early-user");
+      final(peer, "early-answer", "assistant", "answer during setup");
+      if (outcome === "ready") {
+        setup.resolve();
+        await starting;
+        final(peer, "early-user", "user", "question after setup");
+        await waitForFast(() => expect(call.writes()).toHaveLength(2));
+        expect(call.writes().map(({ params }) => params.text)).toEqual([
+          "question after setup",
+          "answer during setup",
+        ]);
+        call.session.stop();
+      } else {
+        if (outcome === "failure") {
+          setup.reject(new Error("SDP rejected"));
+          expect(await settled).toEqual(new Error("SDP rejected"));
+        } else {
+          if (outcome === "replacement") {
+            Peer.setupBlock = undefined;
+            await call.session.start();
+          } else {
+            call.session.stop();
+          }
+          setup.resolve();
+          await starting;
+        }
+        await waitForFast(() => expect(call.writes()).toHaveLength(1));
+        expect(call.writes()[0]?.params).toMatchObject({
+          voiceSessionId: "voice-1",
+          text: "answer during setup",
+        });
+        final(peer, "early-user", "user", "retired question");
+        expect(call.writes()).toHaveLength(1);
+      }
+      await waitForFast(() =>
+        expect(
+          call.requests.filter(
+            ({ method, params }) =>
+              method === "talk.client.close" && params.voiceSessionId === "voice-1",
+          ),
+        ).toHaveLength(1),
+      );
+    },
+  );
+
+  it("streams immediately but persists a long utterance before its earlier-arriving reply", async () => {
+    const call = await start();
+    emit(call.peer, { type: "input_audio_buffer.speech_started", item_id: "u1" });
+    vi.useFakeTimers();
+    await vi.advanceTimersByTimeAsync(10_000);
+    vi.useRealTimers();
+    item(call.peer, "u1", "user", null);
+    item(call.peer, "a1", "assistant", "u1");
+    emit(call.peer, {
+      type: "response.output_audio_transcript.delta",
+      item_id: "a1",
+      delta: "answer",
+    });
+    expect(call.entries()).toEqual([{ role: "assistant", text: "answer" }]);
+    final(call.peer, "a1", "assistant", "answer");
+    expect(call.writes()).toEqual([]);
+    final(call.peer, "u1", "user", "a long question");
+    await waitForFast(() => expect(call.writes()).toHaveLength(2));
+    expect(call.writes().map(({ params }) => [params.role, params.text])).toEqual([
+      ["user", "a long question"],
+      ["assistant", "answer"],
+    ]);
+    expect(call.entries()).toEqual([
+      { role: "user", text: "a long question" },
+      { role: "assistant", text: "answer" },
+    ]);
+    call.session.stop();
+  });
+
+  it("keeps overlapping turns and identical speech tied to their exact items", async () => {
+    const call = await start();
+    item(call.peer, "u1", "user", null);
+    item(call.peer, "a1", "assistant", "u1");
+    item(call.peer, "u2", "user", "a1");
+    item(call.peer, "a2", "assistant", "u2");
+    final(call.peer, "a2", "assistant", "second answer");
+    final(call.peer, "u2", "user", "yes");
+    final(call.peer, "a1", "assistant", "first answer");
+    final(call.peer, "u1", "user", "yes");
+    await waitForFast(() => expect(call.writes()).toHaveLength(4));
+    expect(call.writes().map(({ params }) => params.text)).toEqual([
+      "yes",
+      "first answer",
+      "yes",
+      "second answer",
+    ]);
+    expect(call.entries().map(({ text }) => text)).toEqual([
+      "yes",
+      "first answer",
+      "yes",
+      "second answer",
+    ]);
+    call.session.stop();
+  });
+
+  it.each(["failed", "empty"])(
+    "settles %s ASR without inventing text or blocking its reply",
+    async (outcome) => {
+      const call = await start();
+      item(call.peer, "u1", "user", null);
+      item(call.peer, "a1", "assistant", "u1");
+      final(call.peer, "a1", "assistant", "heard you");
+      expect(call.writes()).toEqual([]);
+      if (outcome === "failed") {
+        emit(call.peer, {
+          type: "conversation.item.input_audio_transcription.failed",
+          item_id: "u1",
+          error: { message: "speech decoder failed" },
+        });
+        expect(call.onStatus).toHaveBeenLastCalledWith("error", "speech decoder failed");
+        expect(call.onTalkEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: "session.error",
+            itemId: "u1",
+            payload: { message: "speech decoder failed" },
+          }),
+        );
+      } else {
+        final(call.peer, "u1", "user", "");
+      }
+      await waitForFast(() => expect(call.writes()).toHaveLength(1));
+      expect(call.writes()[0]?.params.text).toBe("heard you");
+      expect(call.peer.close).not.toHaveBeenCalled();
+      item(call.peer, "u2", "user", "a1");
+      final(call.peer, "u2", "user", "next question");
+      await waitForFast(() => expect(call.writes()).toHaveLength(2));
+      call.session.stop();
+    },
+  );
+
+  it("deduplicates commit announcements and follows non-speech conversation links", async () => {
+    const call = await start();
+    emit(call.peer, {
+      type: "input_audio_buffer.committed",
+      item_id: "u1",
+      previous_item_id: null,
+    });
+    item(call.peer, "u1", "user", null);
+    emit(call.peer, {
+      type: "conversation.item.added",
+      previous_item_id: "u1",
+      item: { id: "tool", type: "function_call" },
+    });
+    emit(call.peer, {
+      type: "conversation.item.added",
+      previous_item_id: "tool",
+      item: { id: "tool-result", type: "function_call_output" },
+    });
+    emit(call.peer, {
+      type: "conversation.item.added",
+      previous_item_id: "tool-result",
+      item: {
+        id: "control-text",
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text" }],
+      },
+    });
+    item(call.peer, "a1", "assistant", "control-text");
+    final(call.peer, "a1", "assistant", "answer");
+    final(call.peer, "u1", "user", "question");
+    final(call.peer, "u1", "user", "duplicate must not replace question");
+    await waitForFast(() => expect(call.writes()).toHaveLength(2));
+    expect(call.writes().map(({ params }) => [params.entryId, params.text])).toEqual([
+      ["1", "question"],
+      ["2", "answer"],
+    ]);
+    expect(call.entries().map(({ text }) => text)).toEqual(["question", "answer"]);
+  });
+
+  it("releases an assistant item cancelled before it produced any text", async () => {
+    const call = await start();
+    item(call.peer, "u1", "user", null);
+    item(call.peer, "cancelled-answer", "assistant", "u1");
+    final(call.peer, "u1", "user", "first question");
+    emit(call.peer, {
+      type: "response.output_item.done",
+      item: {
+        id: "cancelled-answer",
+        type: "message",
+        role: "assistant",
+        status: "incomplete",
+        content: [],
+      },
+    });
+    item(call.peer, "u2", "user", "cancelled-answer");
+    final(call.peer, "u2", "user", "next question");
+    await waitForFast(() => expect(call.writes()).toHaveLength(2));
+    expect(call.writes().map(({ params }) => params.text)).toEqual([
+      "first question",
+      "next question",
+    ]);
+  });
+
+  it("bounds unresolved provider items and drains its accepted finals on overflow", async () => {
+    const call = await start();
+    item(call.peer, "u1", "user", null);
+    for (let index = 0; index < 40; index += 1) {
+      item(call.peer, `a${index}`, "assistant", index === 0 ? "u1" : `a${index - 1}`);
+      final(call.peer, `a${index}`, "assistant", `answer-${index}`);
+    }
+    expect(call.writes()).toEqual([]);
+    item(call.peer, "overflow", "user", "a39");
+    expect(call.onStatus).toHaveBeenLastCalledWith(
+      "error",
+      expect.stringContaining("could not keep up"),
+    );
+    await waitForFast(() => expect(call.requests.at(-1)?.method).toBe("talk.client.close"));
+    expect(call.writes().map(({ params }) => params.text)).toEqual(
+      Array.from({ length: 40 }, (_, index) => `answer-${index}`),
+    );
+    final(call.peer, "u1", "user", "too late");
+    expect(call.writes()).toHaveLength(40);
+  });
+
+  it("persists a keyed final before a consumer synchronously stops the call", async () => {
+    const call = createCall((entry) => {
+      if (entry.final) call.session.stop();
+    });
+    await call.session.start();
+    const peer = Peer.instances[0]!;
+    item(peer, "u1", "user", null);
+    item(peer, "a1", "assistant", "u1");
+    final(peer, "a1", "assistant", "known before callback");
+    await waitForFast(() => expect(call.requests.at(-1)?.method).toBe("talk.client.close"));
+    expect(call.writes().map(({ params }) => params.text)).toEqual(["known before callback"]);
+    expect(call.requests.filter(({ method }) => method === "talk.client.close")).toHaveLength(1);
+    final(peer, "u1", "user", "late after callback");
+    expect(call.writes()).toHaveLength(1);
+  });
+
+  it("drains known finals before close when an earlier ASR item never finishes", async () => {
+    const call = await start();
+    item(call.peer, "u1", "user", null);
+    item(call.peer, "a1", "assistant", "u1");
+    final(call.peer, "a1", "assistant", "known answer");
+    expect(call.writes()).toEqual([]);
+    call.session.stop();
+    await waitForFast(() => expect(call.requests.at(-1)?.method).toBe("talk.client.close"));
+    expect(
+      call.requests
+        .filter(({ method }) => method !== "talk.client.create")
+        .map(({ method }) => method),
+    ).toEqual(["talk.client.transcript", "talk.client.close"]);
+    expect(call.writes()[0]?.params.text).toBe("known answer");
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("unfinished transcript"));
+    final(call.peer, "u1", "user", "too late");
+    expect(call.writes()).toHaveLength(1);
+  });
+});

--- a/ui/src/pages/chat/realtime-talk-shared.ts
+++ b/ui/src/pages/chat/realtime-talk-shared.ts
@@ -38,6 +38,7 @@ export type RealtimeTalkCallbacks = {
   onVideoCapability?: (capable: boolean) => void;
   onInputLevel?: (level: number) => void;
   onTranscript?: (entry: RealtimeTalkTranscript) => void;
+  onTranscriptOrder?: (items: ReadonlyArray<{ itemId: string; order: number }>) => void;
   onTranscriptItem?: (item: RealtimeTalkTranscriptItem) => void;
   onTalkEvent?: (event: RealtimeTalkEvent) => void;
   onVideoStream?: (stream: MediaStream | null) => void;

--- a/ui/src/pages/chat/realtime-talk-shared.ts
+++ b/ui/src/pages/chat/realtime-talk-shared.ts
@@ -16,11 +16,29 @@ import type { RealtimeTalkInputController } from "./realtime-talk-input.ts";
 export type RealtimeTalkStatus = "idle" | "connecting" | "listening" | "thinking" | "error";
 export type RealtimeTalkEvent = TalkEvent;
 
+export type RealtimeTalkTranscript = {
+  role: "user" | "assistant";
+  text: string;
+  final: boolean;
+  itemId?: string;
+  order?: number;
+};
+
+export type RealtimeTalkTranscriptItem =
+  | {
+      type: "created";
+      itemId: string;
+      previousItemId?: string | null;
+      role: "user" | "assistant" | null;
+    }
+  | { type: "settled"; itemId: string };
+
 export type RealtimeTalkCallbacks = {
   onStatus?: (status: RealtimeTalkStatus, detail?: string) => void;
   onVideoCapability?: (capable: boolean) => void;
   onInputLevel?: (level: number) => void;
-  onTranscript?: (entry: { role: "user" | "assistant"; text: string; final: boolean }) => void;
+  onTranscript?: (entry: RealtimeTalkTranscript) => void;
+  onTranscriptItem?: (item: RealtimeTalkTranscriptItem) => void;
   onTalkEvent?: (event: RealtimeTalkEvent) => void;
   onVideoStream?: (stream: MediaStream | null) => void;
   onVideoError?: (error: unknown) => void;

--- a/ui/src/pages/chat/realtime-talk-transcript-owner.ts
+++ b/ui/src/pages/chat/realtime-talk-transcript-owner.ts
@@ -1,7 +1,145 @@
 import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "@openclaw/gateway-client/browser";
 import type { BoundedSerialQueue } from "../../../../src/shared/bounded-serial-queue.js";
+import { createDeferredCore } from "../../../../src/shared/deferred.js";
+import {
+  normalizeVoiceTranscriptText,
+  VOICE_TRANSCRIPT_QUEUE_POLICY,
+} from "../../../../src/talk/voice-transcript.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { RealtimeTalkTransport } from "./realtime-talk-shared.ts";
+import type {
+  RealtimeTalkTranscript,
+  RealtimeTalkTranscriptItem,
+  RealtimeTalkTransport,
+} from "./realtime-talk-shared.ts";
+
+type ReservedTranscript = {
+  order: number;
+  role: "user" | "assistant";
+  complete?: (text: string | undefined) => void;
+};
+
+// Keep exact identities for the connection: eviction could admit a late duplicate
+// final. This matches the WebRTC response/tool identity budget.
+const MAX_TRANSCRIPT_ITEM_IDENTITIES = 1_024;
+const MAX_TRANSCRIPT_ITEM_ID_CHARS = 1_024;
+
+export class ClientVoiceTranscriptQueue {
+  private sequence = 0;
+  private lastItemId: string | undefined;
+  private readonly items = new Map<string, ReservedTranscript | null>();
+
+  constructor(
+    readonly queue: BoundedSerialQueue,
+    private readonly write: (
+      entryId: string,
+      role: "user" | "assistant",
+      text: string,
+    ) => Promise<void>,
+    private readonly onFailure: (error: unknown) => void,
+  ) {}
+
+  observe(item: RealtimeTalkTranscriptItem): void {
+    if (item.type === "settled") {
+      const reservation = this.requireItem(item.itemId);
+      this.settle(reservation);
+      return;
+    }
+    if (this.items.has(item.itemId)) {
+      return;
+    }
+    if (
+      this.items.size >= MAX_TRANSCRIPT_ITEM_IDENTITIES ||
+      item.itemId.length > MAX_TRANSCRIPT_ITEM_ID_CHARS
+    ) {
+      throw new Error("Realtime transcript item identity limit exceeded");
+    }
+    // This client appends provider items; it never requests historical insertion.
+    // Reject an unknown/rewritten predecessor before committing a false order.
+    if (item.previousItemId != null && item.previousItemId !== this.lastItemId) {
+      throw new Error("Realtime transcript item has an unexpected predecessor");
+    }
+    this.lastItemId = item.itemId;
+    if (item.role === null) {
+      this.items.set(item.itemId, null);
+      return;
+    }
+    const result = createDeferredCore<string | undefined>();
+    const reservation: ReservedTranscript = {
+      order: ++this.sequence,
+      role: item.role,
+      complete: result.resolve,
+    };
+    this.items.set(item.itemId, reservation);
+    // Reserve the existing FIFO position before asynchronous ASR can be overtaken
+    // by assistant finals. Charge the maximum retained text while it is pending.
+    this.enqueue(async () => {
+      const text = await result.promise;
+      if (text) {
+        await this.write(String(reservation.order), reservation.role, text);
+      }
+    }, VOICE_TRANSCRIPT_QUEUE_POLICY.maxEntryChars);
+  }
+
+  publish(entry: RealtimeTalkTranscript): RealtimeTalkTranscript | undefined {
+    if (entry.itemId !== undefined) {
+      const reservation = this.requireItem(entry.itemId);
+      if (reservation.role !== entry.role) {
+        throw new Error("Realtime transcript item changed roles");
+      }
+      if (!reservation.complete) {
+        return undefined;
+      }
+      if (entry.final) {
+        this.settle(reservation, normalizeVoiceTranscriptText(entry.text) || undefined);
+      }
+      return { ...entry, order: reservation.order };
+    }
+    // Google Live and frameless transcripts have no GA item-creation contract.
+    // Their provider completion order continues to own unkeyed admission.
+    if (entry.final) {
+      const text = normalizeVoiceTranscriptText(entry.text);
+      if (text) {
+        const entryId = String(++this.sequence);
+        this.enqueue(() => this.write(entryId, entry.role, text), text.length);
+      }
+    }
+    return entry;
+  }
+
+  close(): string[] {
+    const missing: string[] = [];
+    for (const [itemId, reservation] of this.items) {
+      if (reservation?.complete) {
+        missing.push(itemId);
+        this.settle(reservation);
+      }
+    }
+    this.items.clear();
+    return missing;
+  }
+
+  private settle(reservation: ReservedTranscript, text?: string): void {
+    const complete = reservation.complete;
+    reservation.complete = undefined;
+    complete?.(text);
+  }
+
+  private requireItem(itemId: string): ReservedTranscript {
+    const reservation = this.items.get(itemId);
+    if (!reservation) {
+      throw new Error("Realtime transcript refers to an unknown speech item");
+    }
+    return reservation;
+  }
+
+  private enqueue(run: () => Promise<void>, weight: number): void {
+    const admission = this.queue.enqueue(run, { weight });
+    if (!admission.accepted) {
+      throw new Error(VOICE_TRANSCRIPT_QUEUE_POLICY.overflowMessage);
+    }
+    void admission.completion.catch(this.onFailure);
+  }
+}
 
 export type ClientVoiceSessionOwner = {
   signal: AbortSignal;

--- a/ui/src/pages/chat/realtime-talk-transcript-owner.ts
+++ b/ui/src/pages/chat/realtime-talk-transcript-owner.ts
@@ -13,9 +13,12 @@ import type {
 } from "./realtime-talk-shared.ts";
 
 type ReservedTranscript = {
-  order: number;
-  role: "user" | "assistant";
-  complete?: (text: string | undefined) => void;
+  previousItemId: string | null | undefined;
+  order?: number;
+  role: "user" | "assistant" | null;
+  settled: boolean;
+  written?: boolean;
+  text?: string;
 };
 
 // Keep exact identities for the connection: eviction could admit a late duplicate
@@ -25,8 +28,10 @@ const MAX_TRANSCRIPT_ITEM_ID_CHARS = 1_024;
 
 export class ClientVoiceTranscriptQueue {
   private sequence = 0;
+  private nextWriteOrder = 1;
   private lastItemId: string | undefined;
-  private readonly items = new Map<string, ReservedTranscript | null>();
+  private readonly items = new Map<string, ReservedTranscript>();
+  private changed = createDeferredCore();
 
   constructor(
     readonly queue: BoundedSerialQueue,
@@ -38,46 +43,38 @@ export class ClientVoiceTranscriptQueue {
     private readonly onFailure: (error: unknown) => void,
   ) {}
 
-  observe(item: RealtimeTalkTranscriptItem): void {
+  observe(item: RealtimeTalkTranscriptItem): Array<{ itemId: string; order: number }> {
     if (item.type === "settled") {
-      const reservation = this.requireItem(item.itemId);
-      this.settle(reservation);
-      return;
+      this.settle(this.requireItem(item.itemId));
+      return [];
     }
     if (this.items.has(item.itemId)) {
-      return;
+      return [];
     }
     if (
       this.items.size >= MAX_TRANSCRIPT_ITEM_IDENTITIES ||
-      item.itemId.length > MAX_TRANSCRIPT_ITEM_ID_CHARS
+      item.itemId.length > MAX_TRANSCRIPT_ITEM_ID_CHARS ||
+      (item.previousItemId?.length ?? 0) > MAX_TRANSCRIPT_ITEM_ID_CHARS
     ) {
       throw new Error("Realtime transcript item identity limit exceeded");
     }
-    // This client appends provider items; it never requests historical insertion.
-    // Reject an unknown/rewritten predecessor before committing a false order.
-    if (item.previousItemId != null && item.previousItemId !== this.lastItemId) {
-      throw new Error("Realtime transcript item has an unexpected predecessor");
-    }
-    this.lastItemId = item.itemId;
-    if (item.role === null) {
-      this.items.set(item.itemId, null);
-      return;
-    }
-    const result = createDeferredCore<string | undefined>();
     const reservation: ReservedTranscript = {
-      order: ++this.sequence,
+      previousItemId: item.previousItemId === undefined ? this.lastItemId : item.previousItemId,
       role: item.role,
-      complete: result.resolve,
+      settled: item.role === null,
     };
+    if (item.role !== null) {
+      // Each accepted identity owns a FIFO barrier and the maximum text budget.
+      // Its task drains predecessors too, so consult flushes still cover that identity.
+      this.enqueue(
+        () => this.writeThrough(reservation),
+        VOICE_TRANSCRIPT_QUEUE_POLICY.maxEntryChars,
+        // writeThrough reports at the failed write, even if its target is still pending.
+        () => undefined,
+      );
+    }
     this.items.set(item.itemId, reservation);
-    // Reserve the existing FIFO position before asynchronous ASR can be overtaken
-    // by assistant finals. Charge the maximum retained text while it is pending.
-    this.enqueue(async () => {
-      const text = await result.promise;
-      if (text) {
-        await this.write(String(reservation.order), reservation.role, text);
-      }
-    }, VOICE_TRANSCRIPT_QUEUE_POLICY.maxEntryChars);
+    return this.assignOrders();
   }
 
   publish(entry: RealtimeTalkTranscript): RealtimeTalkTranscript | undefined {
@@ -86,7 +83,7 @@ export class ClientVoiceTranscriptQueue {
       if (reservation.role !== entry.role) {
         throw new Error("Realtime transcript item changed roles");
       }
-      if (!reservation.complete) {
+      if (reservation.settled) {
         return undefined;
       }
       if (entry.final) {
@@ -107,37 +104,117 @@ export class ClientVoiceTranscriptQueue {
   }
 
   close(): string[] {
-    const missing: string[] = [];
+    const missing = new Set<string>();
     for (const [itemId, reservation] of this.items) {
-      if (reservation?.complete) {
-        missing.push(itemId);
+      if (reservation.order === undefined) {
+        missing.add(itemId);
+      }
+      if (!reservation.settled) {
+        missing.add(itemId);
         this.settle(reservation);
       }
+      if (reservation.previousItemId && !this.items.has(reservation.previousItemId)) {
+        missing.add(reservation.previousItemId);
+      }
     }
-    this.items.clear();
-    return missing;
+    // On teardown there can be no more ancestry. Preserve known finals while
+    // reporting the missing links; normal operation never guesses their order.
+    this.assignOrders(true);
+    return [...missing];
+  }
+
+  private assignOrders(closing = false): Array<{ itemId: string; order: number }> {
+    const orders: Array<{ itemId: string; order: number }> = [];
+    while (true) {
+      const pending = [...this.items].filter(([, item]) => item.order === undefined);
+      const next =
+        pending.find(([, item]) =>
+          item.previousItemId == null
+            ? this.lastItemId === undefined
+            : item.previousItemId === this.lastItemId,
+        ) ??
+        (closing
+          ? (pending.find(
+              ([, item]) =>
+                item.previousItemId == null ||
+                !this.items.has(item.previousItemId) ||
+                this.items.get(item.previousItemId)?.order !== undefined,
+            ) ?? pending[0])
+          : undefined);
+      if (!next) {
+        break;
+      }
+      const [itemId, item] = next;
+      item.order = item.role === null ? this.sequence : ++this.sequence;
+      this.lastItemId = itemId;
+      if (item.role !== null) {
+        orders.push({ itemId, order: item.order });
+      }
+    }
+    this.notify();
+    return orders;
+  }
+
+  private async writeThrough(target: ReservedTranscript): Promise<void> {
+    let failure: { error: unknown } | undefined;
+    while (!target.written) {
+      const next = [...this.items.values()].find(
+        (item) => item.role !== null && item.order === this.nextWriteOrder,
+      );
+      if (!next?.settled) {
+        await this.changed.promise;
+        continue;
+      }
+      next.written = true;
+      this.nextWriteOrder += 1;
+      const text = next.text;
+      next.text = undefined;
+      if (text && next.role !== null) {
+        try {
+          await this.write(String(next.order), next.role, text);
+        } catch (error) {
+          // A failed predecessor must not discard this accepted successor.
+          failure ??= { error };
+          this.onFailure(error);
+        }
+      }
+    }
+    if (failure) {
+      throw failure.error;
+    }
   }
 
   private settle(reservation: ReservedTranscript, text?: string): void {
-    const complete = reservation.complete;
-    reservation.complete = undefined;
-    complete?.(text);
+    if (!reservation.settled) {
+      reservation.settled = true;
+      reservation.text = text;
+      this.notify();
+    }
+  }
+
+  private notify(): void {
+    this.changed.resolve();
+    this.changed = createDeferredCore();
   }
 
   private requireItem(itemId: string): ReservedTranscript {
     const reservation = this.items.get(itemId);
-    if (!reservation) {
+    if (!reservation || reservation.role === null) {
       throw new Error("Realtime transcript refers to an unknown speech item");
     }
     return reservation;
   }
 
-  private enqueue(run: () => Promise<void>, weight: number): void {
+  private enqueue(
+    run: () => Promise<void>,
+    weight: number,
+    onFailure: (error: unknown) => void = this.onFailure,
+  ): void {
     const admission = this.queue.enqueue(run, { weight });
     if (!admission.accepted) {
       throw new Error(VOICE_TRANSCRIPT_QUEUE_POLICY.overflowMessage);
     }
-    void admission.completion.catch(this.onFailure);
+    void admission.completion.catch(onFailure);
   }
 }
 

--- a/ui/src/pages/chat/realtime-talk-webrtc-support.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc-support.ts
@@ -1,7 +1,10 @@
 // Control UI chat module owns low-level WebRTC offer and media-message helpers.
 import { normalizeRealtimeVoiceResponseOutcome } from "../../../../src/talk/provider-types.js";
 import { readResponseTextWithLimit } from "../../lib/response-body.ts";
-import type { RealtimeTalkWebRtcSdpSessionResult } from "./realtime-talk-shared.ts";
+import type {
+  RealtimeTalkTranscriptItem,
+  RealtimeTalkWebRtcSdpSessionResult,
+} from "./realtime-talk-shared.ts";
 import type { RealtimeTalkVideoFrame } from "./realtime-talk-video.ts";
 
 const REALTIME_WEBRTC_OFFER_TIMEOUT_MS = 30_000;
@@ -11,6 +14,7 @@ const OPENAI_REALTIME_CALLS_URL = "https://api.openai.com/v1/realtime/calls";
 export type RealtimeServerEvent = {
   type?: string;
   item_id?: string;
+  previous_item_id?: string | null;
   call_id?: string;
   name?: string;
   delta?: string;
@@ -28,6 +32,8 @@ export type RealtimeServerEvent = {
     id?: string;
     type?: string;
     text?: string;
+    role?: string;
+    content?: Array<{ type?: string }>;
   };
   turn?: {
     id?: string;
@@ -35,6 +41,49 @@ export type RealtimeServerEvent = {
     transcript?: string;
   };
 };
+
+export function realtimeTalkTranscriptItem(
+  event: RealtimeServerEvent,
+): RealtimeTalkTranscriptItem | undefined {
+  switch (event.type) {
+    case "input_audio_buffer.committed":
+      return event.item_id
+        ? {
+            type: "created",
+            itemId: event.item_id,
+            previousItemId: event.previous_item_id,
+            role: "user",
+          }
+        : undefined;
+    case "conversation.item.added":
+    case "conversation.item.created": {
+      const item = event.item;
+      if (!item?.id) {
+        return undefined;
+      }
+      const role =
+        item.type !== "message"
+          ? null
+          : item.role === "assistant"
+            ? "assistant"
+            : item.role === "user" && item.content?.some((part) => part.type === "input_audio")
+              ? "user"
+              : null;
+      return { type: "created", itemId: item.id, previousItemId: event.previous_item_id, role };
+    }
+    case "conversation.item.done":
+    case "response.output_item.done":
+      // Interrupted responses may finish an empty assistant item without text.
+      // User item completion does not complete its asynchronous ASR.
+      return event.item?.id && event.item.type === "message" && event.item.role === "assistant"
+        ? { type: "settled", itemId: event.item.id }
+        : undefined;
+    case "conversation.item.input_audio_transcription.failed":
+      return event.item_id ? { type: "settled", itemId: event.item_id } : undefined;
+    default:
+      return undefined;
+  }
+}
 
 export class RealtimeTalkResponseOutcomeOwner {
   private activeResponseId: string | undefined;

--- a/ui/src/pages/chat/realtime-talk-webrtc.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.test.ts
@@ -522,6 +522,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
         role: "user",
         text: "Please try again",
         final: true,
+        itemId: "input-1",
       });
       transport.stop();
     },
@@ -661,11 +662,17 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
       }),
     );
 
-    expect(onTranscript).toHaveBeenCalledWith({ role: "user", text: "hello", final: true });
+    expect(onTranscript).toHaveBeenCalledWith({
+      role: "user",
+      text: "hello",
+      final: true,
+      itemId: "input-1",
+    });
     expect(onTranscript).toHaveBeenCalledWith({
       role: "assistant",
       text: "hi there",
       final: true,
+      itemId: "response-1",
     });
     expect(onTalkEvent.mock.calls.map(([event]) => event.type)).toEqual([
       "transcript.done",
@@ -800,11 +807,13 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
         role: "assistant",
         text: "hi",
         final: false,
+        itemId: "response-1",
       });
       expect(onTranscript).toHaveBeenCalledWith({
         role: "assistant",
         text: "hi there",
         final: true,
+        itemId: "response-1",
       });
       expect(onTalkEvent.mock.calls.map(([event]) => event.type)).toEqual([
         "output.text.delta",

--- a/ui/src/pages/chat/realtime-talk-webrtc.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.test.ts
@@ -529,10 +529,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
   );
 
   it("surfaces speech and response lifecycle status from the OpenAI data channel", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response("answer-sdp")) as unknown as typeof fetch,
-    );
+    stubAnswerSdpFetch();
     const onStatus = vi.fn();
     const onTalkEvent = vi.fn();
     const transport = new WebRtcSdpRealtimeTalkTransport(
@@ -621,10 +618,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
   });
 
   it("emits common Talk transcript events from the OpenAI data channel", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response("answer-sdp")) as unknown as typeof fetch,
-    );
+    stubAnswerSdpFetch();
     const onTranscript = vi.fn();
     const onTalkEvent = vi.fn();
     const transport = new WebRtcSdpRealtimeTalkTransport(
@@ -706,10 +700,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
   });
 
   it("maps frameless Codex transcript events by role and finality", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response("answer-sdp")) as unknown as typeof fetch,
-    );
+    stubAnswerSdpFetch();
     const onTalkEvent = vi.fn();
     const transport = new WebRtcSdpRealtimeTalkTransport(
       {
@@ -770,10 +761,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
   ])(
     "emits assistant transcripts from OpenAI Realtime $label events",
     async ({ deltaType, doneType, doneField }) => {
-      vi.stubGlobal(
-        "fetch",
-        vi.fn(async () => new Response("answer-sdp")) as unknown as typeof fetch,
-      );
+      stubAnswerSdpFetch();
       const onTranscript = vi.fn();
       const onTalkEvent = vi.fn();
       const transport = new WebRtcSdpRealtimeTalkTransport(
@@ -828,10 +816,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
   );
 
   it("aborts an in-flight OpenAI tool consult when the transport stops", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response("answer-sdp")) as unknown as typeof fetch,
-    );
+    stubAnswerSdpFetch();
     const listeners = new Set<(event: { event: string; payload?: unknown }) => void>();
     const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
       if (method === "chat.abort") {
@@ -1060,10 +1045,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
   });
 
   it("does not auto-control ambiguous multilingual speech during an active consult", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response("answer-sdp")) as unknown as typeof fetch,
-    );
+    stubAnswerSdpFetch();
     const request = vi.fn(async (method: string) => {
       if (method === "talk.client.toolCall") {
         return { runId: "run-1" };

--- a/ui/src/pages/chat/realtime-talk-webrtc.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.ts
@@ -21,6 +21,7 @@ import {
 import { captureRealtimeTalkVideoFrame } from "./realtime-talk-video.ts";
 import {
   RealtimeTalkWebRtcOfferExchange,
+  realtimeTalkTranscriptItem,
   RealtimeTalkResponseOutcomeOwner,
   realtimeTalkDataChannelMaxMessageSize,
   realtimeTalkImageEvent,
@@ -292,6 +293,13 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
     } catch {
       return;
     }
+    const transcriptItem = realtimeTalkTranscriptItem(event);
+    if (transcriptItem) {
+      this.ctx.callbacks.onTranscriptItem?.(transcriptItem);
+      if (this.closed) {
+        return;
+      }
+    }
     switch (event.type) {
       case "input_transcript.added":
         this.emitFramelessTranscript("user", event.item?.text, false, event.item?.id);
@@ -318,8 +326,13 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
         return;
       }
       case "conversation.item.input_audio_transcription.completed":
-        if (event.transcript) {
-          this.ctx.callbacks.onTranscript?.({ role: "user", text: event.transcript, final: true });
+        if (typeof event.transcript === "string") {
+          this.ctx.callbacks.onTranscript?.({
+            role: "user",
+            text: event.transcript,
+            final: true,
+            itemId: event.item_id,
+          });
           if (this.closed) {
             return;
           }
@@ -436,13 +449,14 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
 
   private emitAssistantTranscript(event: RealtimeServerEvent, final: boolean): void {
     const text = final ? (event.transcript ?? event.text) : event.delta;
-    if (!text) {
+    if (typeof text !== "string") {
       return;
     }
     this.ctx.callbacks.onTranscript?.({
       role: "assistant",
       text,
       final,
+      itemId: event.item_id,
     });
     if (this.closed) {
       return;

--- a/ui/src/pages/chat/realtime-talk.ts
+++ b/ui/src/pages/chat/realtime-talk.ts
@@ -508,10 +508,15 @@ export class RealtimeTalkSession {
         if (!isCurrent()) {
           return;
         }
+        let orders;
         try {
-          transcripts.observe(item);
+          orders = transcripts.observe(item);
         } catch (error) {
           this.failTranscriptPersistence(owningGeneration, formatUiError(error));
+          return;
+        }
+        if (orders.length > 0) {
+          this.callbacks.onTranscriptOrder?.(orders);
         }
       },
       onTranscript: (entry) => {

--- a/ui/src/pages/chat/realtime-talk.ts
+++ b/ui/src/pages/chat/realtime-talk.ts
@@ -2,10 +2,7 @@
 import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "@openclaw/gateway-client/browser";
 import type { TalkCatalogResult } from "@openclaw/gateway-protocol";
 import { normalizeTalkTransport } from "../../../../src/talk/talk-session-controller.js";
-import {
-  normalizeVoiceTranscriptText,
-  VOICE_TRANSCRIPT_QUEUE_POLICY,
-} from "../../../../src/talk/voice-transcript.js";
+import { VOICE_TRANSCRIPT_QUEUE_POLICY } from "../../../../src/talk/voice-transcript.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { t } from "../../i18n/index.ts";
 import { formatUiError } from "../../lib/format-error.ts";
@@ -19,6 +16,7 @@ import type {
 } from "./realtime-talk-shared.ts";
 import {
   type ClientVoiceSessionOwner,
+  ClientVoiceTranscriptQueue,
   type DetachedVoiceSession,
   reserveClientVoiceSessionOwner,
   retireUncommittedRealtimeTalkTransport,
@@ -116,7 +114,7 @@ export class RealtimeTalkSession {
   private videoOperation = 0;
   private voiceSessionId: string | undefined;
   private transportGeneration = 0;
-  private transcriptSequence = 0;
+  private transcriptItems: ClientVoiceTranscriptQueue | undefined;
   private acceptingTranscripts = false;
   private serverOwnedVoiceSession = false;
   private transcriptQueue = VOICE_TRANSCRIPT_QUEUE_POLICY.createQueue();
@@ -191,6 +189,25 @@ export class RealtimeTalkSession {
         return;
       }
       const nextTransportGeneration = lifecycleGeneration;
+      if (transport !== "gateway-relay") {
+        // SDP setup can already deliver provider items. The logical allocation
+        // owns their queue before its still-provisional transport becomes ready.
+        this.voiceSessionId = voiceSessionId;
+        this.transportGeneration = nextTransportGeneration;
+        this.acceptingTranscripts = true;
+        this.clientVoiceSessionOwner = owner;
+        ownerTransferred = true;
+      }
+      const closeCandidate = () => {
+        if (transport === "gateway-relay") {
+          this.closeUnadoptedVoiceSession(voiceSessionId, transport, owner);
+        } else if (this.clientVoiceSessionOwner === owner) {
+          const detached = this.detachVoiceSession();
+          if (detached) {
+            this.closeLogicalVoiceSession(detached);
+          }
+        }
+      };
       const callbacks =
         transport === "gateway-relay"
           ? this.callbacks
@@ -229,8 +246,7 @@ export class RealtimeTalkSession {
           nextTransport,
           transport,
           owner,
-          closeVoiceSession: () =>
-            this.closeUnadoptedVoiceSession(voiceSessionId, transport, owner),
+          closeVoiceSession: closeCandidate,
         });
         ownerTransferred = true;
         throw error;
@@ -247,22 +263,18 @@ export class RealtimeTalkSession {
           nextTransport,
           transport,
           owner,
-          closeVoiceSession: () =>
-            this.closeUnadoptedVoiceSession(voiceSessionId, transport, owner),
+          closeVoiceSession: closeCandidate,
         });
         ownerTransferred = true;
         return;
       }
-      this.voiceSessionId = voiceSessionId;
-      this.acceptingTranscripts = true;
-      this.serverOwnedVoiceSession = transport === "gateway-relay";
-      this.transportGeneration = nextTransportGeneration;
       this.transport = nextTransport;
-      if (this.serverOwnedVoiceSession) {
+      if (transport === "gateway-relay") {
+        this.voiceSessionId = voiceSessionId;
+        this.transportGeneration = nextTransportGeneration;
+        this.acceptingTranscripts = true;
+        this.serverOwnedVoiceSession = true;
         owner.release();
-        this.clientVoiceSessionOwner = undefined;
-      } else {
-        this.clientVoiceSessionOwner = owner;
       }
       ownerTransferred = true;
       try {
@@ -448,6 +460,32 @@ export class RealtimeTalkSession {
     owningGeneration: number,
     transcriptSignal: AbortSignal,
   ): RealtimeTalkCallbacks {
+    const transcripts = new ClientVoiceTranscriptQueue(
+      this.transcriptQueue,
+      (entryId, role, text) =>
+        this.writeTranscriptWithRetry({
+          voiceSessionId: owningVoiceSessionId,
+          entryId,
+          role,
+          text,
+          signal: transcriptSignal,
+        }),
+      (error) => {
+        if (transcriptSignal.aborted) {
+          return;
+        }
+        const detail = `Voice transcript could not be saved: ${formatUiError(error)}`;
+        console.warn(detail, error);
+        if (this.transportGeneration === owningGeneration) {
+          this.callbacks.onStatus?.("error", detail);
+        }
+      },
+    );
+    this.transcriptItems = transcripts;
+    const isCurrent = () =>
+      this.transportGeneration === owningGeneration &&
+      this.voiceSessionId === owningVoiceSessionId &&
+      this.acceptingTranscripts;
     return {
       ...this.callbacks,
       onTalkEvent: (event) => {
@@ -466,64 +504,41 @@ export class RealtimeTalkSession {
           this.callbacks.onTalkEvent?.(event);
         }
       },
+      onTranscriptItem: (item) => {
+        if (!isCurrent()) {
+          return;
+        }
+        try {
+          transcripts.observe(item);
+        } catch (error) {
+          this.failTranscriptPersistence(owningGeneration, formatUiError(error));
+        }
+      },
       onTranscript: (entry) => {
         // Retired transports cannot append into a restarted call's write queue.
-        if (
-          this.transportGeneration !== owningGeneration ||
-          this.voiceSessionId !== owningVoiceSessionId ||
-          !this.acceptingTranscripts
-        ) {
+        if (!isCurrent()) {
           return;
         }
         // Persist before notifying: a consumer callback that stops or throws must
         // not be able to drop an already-finalized utterance from the write tail.
-        if (entry.final) {
-          const transcriptSeq = this.transcriptSequence + 1;
-          const entryId = String(transcriptSeq);
-          const role = entry.role;
-          const text = normalizeVoiceTranscriptText(entry.text);
-          if (text) {
-            const admission = this.transcriptQueue.enqueue(
-              async () =>
-                await this.writeTranscriptWithRetry({
-                  voiceSessionId: owningVoiceSessionId,
-                  entryId,
-                  role,
-                  text,
-                  signal: transcriptSignal,
-                }),
-              { weight: text.length },
-            );
-            if (!admission.accepted) {
-              if (admission.reason === "overflow") {
-                this.failTranscriptPersistence(owningGeneration);
-              }
-              return;
-            }
-            this.transcriptSequence = transcriptSeq;
-            void admission.completion.catch((error: unknown) => {
-              if (transcriptSignal.aborted) {
-                return;
-              }
-              // The utterance exists only in client memory; after retries and surfacing the error,
-              // keeping the record open cannot recover it, while server entryId dedupe preserves order.
-              // Deferring close would only shift the identical loss to the 6h stale sweep.
-              const detail = `Voice transcript could not be saved: ${formatUiError(error)}`;
-              console.warn(detail, error);
-              // Only surface to the user if this transport is still the active one; a
-              // retired call's late failure must not error a healthy replacement call.
-              if (this.transportGeneration === owningGeneration) {
-                this.callbacks.onStatus?.("error", detail);
-              }
-            });
-          }
+        let published;
+        try {
+          published = transcripts.publish(entry);
+        } catch (error) {
+          this.failTranscriptPersistence(owningGeneration, formatUiError(error));
+          return;
         }
-        this.callbacks.onTranscript?.(entry);
+        if (published) {
+          this.callbacks.onTranscript?.(published);
+        }
       },
     };
   }
 
-  private failTranscriptPersistence(owningGeneration: number): void {
+  private failTranscriptPersistence(
+    owningGeneration: number,
+    detail: string = VOICE_TRANSCRIPT_QUEUE_POLICY.overflowMessage,
+  ): void {
     if (
       this.transportGeneration !== owningGeneration ||
       !this.acceptingTranscripts ||
@@ -535,8 +550,8 @@ export class RealtimeTalkSession {
     // Retire the overflowing transport before accepted-write and close failures
     // settle so the first terminal persistence error keeps precedence.
     this.transportGeneration += 1;
-    console.warn(VOICE_TRANSCRIPT_QUEUE_POLICY.overflowMessage);
-    this.callbacks.onStatus?.("error", VOICE_TRANSCRIPT_QUEUE_POLICY.overflowMessage);
+    console.warn(detail);
+    this.callbacks.onStatus?.("error", detail);
   }
 
   private async writeTranscriptWithRetry(params: {
@@ -580,13 +595,18 @@ export class RealtimeTalkSession {
       transcriptQueue: this.transcriptQueue,
       owner: this.clientVoiceSessionOwner,
     } satisfies DetachedVoiceSession;
+    const missingItems = this.transcriptItems?.close() ?? [];
+    this.transcriptItems = undefined;
     detached.transcriptQueue.seal();
-    this.transcriptSequence = 0;
     this.voiceSessionId = undefined;
     this.acceptingTranscripts = false;
     this.serverOwnedVoiceSession = false;
     this.transcriptQueue = VOICE_TRANSCRIPT_QUEUE_POLICY.createQueue();
     this.clientVoiceSessionOwner = undefined;
+    if (missingItems.length > 0) {
+      const message = `Voice call closed with ${missingItems.length} unfinished transcript item(s); finalized speech was preserved.`;
+      console.warn(message);
+    }
     return detached;
   }
 


### PR DESCRIPTION
Supersedes #132881

## What Problem This Solves

Fixes browser voice transcripts appearing or being saved in the wrong conversation order when OpenAI finishes an assistant answer before asynchronous user transcription. Overlapping assistant items could also merge into one visible reply. A one-second timer cannot establish the order of a longer spoken utterance.

## Why This Change Was Made

Provider item creation reserves capacity and a flush barrier in the existing bounded serial transcript queue. Predecessor links assign conversation order, even when an item arrives before its predecessor. Final text settles the corresponding identity; failed or empty transcription and empty canceled answers settle it without invented text. Exact item identity places late user text beside its answer while assistant deltas still render immediately. A narrow order callback moves already-visible rows when late metadata connects their ancestry. Logical voice allocation owns the queue before awaited SDP setup, so startup failure or cancellation uses the same drain-and-close owner.

The existing queue remains the admission, capacity, flush, and close owner; one bounded identity map owns transcript state. Each admitted task drains through its accepted identity, including predecessors, so a tool consult cannot overtake it. Non-speech items preserve links without creating transcript entries. Missing ancestry remains visible on close, and a failed write reports immediately even when its successor is still pending. Google Live and GPT-Live keep their distinct unkeyed protocol behavior. No new timer, configuration, Gateway schema, storage schema, retention policy, or durable format.

## User Impact

Browser Talk retains the spoken conversation order in the visible transcript and saved history. Failed transcription keeps the error reporting from #133473 and does not block the next utterance. On stop, known finalized speech drains before logical close; missing finals are skipped with a recorded warning.

## Evidence

The original ordering regression failed in five owner scenarios. Four additional cases reproduced lost early items during awaited SDP setup, and an empty canceled assistant item reproduced a blocked later question. All pass with the repaired owner. The combined branch passes 157 tests across nine owner/sibling suites and the UI test typechecks. The combined actual Chromium start-stop/ordering suite passes all 11 cases, including reversed item creation, ASR recovery, Google and relay siblings. Fresh committed-mode Codex autoreview through P2 is scoped-clean.

Direct dependency inspection covered the installed OpenAI Realtime SDK item/predecessor and asynchronous transcription contracts, plus the [official server event reference](https://platform.openai.com/docs/api-reference/realtime-server-events/input_audio_buffer/committed?lang=node). Direct sibling Codex inspection at `63d213884daea50e4f74efc192cdc44f549b67d5` covered `codex-rs/codex-api/src/endpoint/realtime_websocket/protocol_v2.rs:24–79` and transcript DTOs in `codex-rs/protocol/src/protocol.rs:375–382`; the relevant source is unchanged through fetched upstream main `94cbbddafc1776d5e377bca1b05932c697e82238`. Those callbacks lose item identity, so copying their arrival-order aggregation would retain this bug.

Production: +442/-77, net +365. Tests/test support: +799/-113, net +686, including a moved existing browser fixture. Docs: +7. Growth adds bounded identity/predecessor ownership, UI order notifications, and provisional-allocation ownership at the existing queue; it removes completion-order admission instead of adding a second buffer or timer. The unkeyed path remains required by other provider protocols. Exact regression introduction is unknown; the pre-fix owner and live traces prove the current failure.

Before: original UI projection with the repaired queue retained, isolating the merged/misordered visible rows. The original complete bug is separately demonstrated by pre-fix tests and authenticated GA trace.

![Original projection merges and misorders overlapping voice replies](https://github.com/user-attachments/assets/c663f27e-9851-4eb5-87fb-6b9469cfcf3b)

After: exact provider items retain conversation order.

![Voice replies appear beside their corresponding user utterances](https://github.com/user-attachments/assets/1720dead-a227-4c96-8c9c-502bbcb2469f)

Reworks the report and proposed timer-based repair from @vmbbz. Contributor credit: vchat-meme-blip <vmbbz@users.noreply.github.com>.

Authenticated live proof at `2b43d976b08c08145b177dfa8275aba762eae4f0`: a temporary built Gateway, actual Chromium WebRTC, current RealtimeTalkSession and Gateway RPCs, one existing OpenAI OAuth profile and no Platform API key. Two offline synthetic spoken requests asked for “glacier” and “lantern.” The first assistant final arrived before its user ASR final; callback positions still preserved immediate streaming, and both transcript RPCs and closed chat.history were user/glacier → assistant/glacier → user/lantern → assistant/lantern. Both responses drained audio. Durable status was closed, hasUserTranscript=true, with zero unresolved transcript failures. HEAD and an empty working-tree patch fingerprint remained unchanged throughout.

The local full changed gate initially stopped on a new E2E unknown-params type error. That assertion was corrected without a cast or weaker check, and the canonical UI test-type group plus actual browser case passed; downstream checks are covered by hosted CI before landing. The Gateway build and runtime postbuild also completed for the authenticated run.

The first hosted run found two test-only lint violations: a missing conditional brace and repeated SDP fetch fixtures pushing a test file over its size cap. The follow-up reuses the existing fixture and adds braces, removing 16 test lines with no runtime changes. Targeted type-aware lint, all 40 affected owner/WebRTC tests, and fresh independent review pass; that test-only commit preserved the authenticated runtime. The subsequent predecessor repair changes runtime and receives a fresh OAuth proof before landing.

The ClawSweeper predecessor finding and Rank-up move are addressed at `05f1a9a333d2314de0c0a53275b34e86bebd7f13`. Failure-first regressions cover successor final before predecessor creation, speech and non-speech links, reversed startup events, missing ancestry at close/overflow, immediate failed-save visibility, and tool-consult flush ordering. All 157 tests, 11 Chromium cases, UI test typechecks, scoped type-aware lint, and fresh independent P2 review pass. The review flag on `browser-talk-start-stop.fixtures.ts` concerns a moved synthetic browser fixture, not persisted product state; no schema or migration changes occur.

Fresh authenticated proof passed at final `05f1a9a333d2314de0c0a53275b34e86bebd7f13`, with an empty working-tree fingerprint throughout: the isolated built Gateway and actual Chromium WebRTC used one existing OpenAI OAuth profile and no Platform API key. The first assistant final naturally arrived before its user ASR final again. Both visible positions and all four transcript RPCs/durable history preserved user/glacier → assistant/glacier → user/lantern → assistant/lantern. Both audio responses drained; the logical session closed with hasUserTranscript=true and zero unresolved transcript failures. Reversed creation itself is covered by deterministic Chromium and owner tests, not claimed as a naturally observed service trace.
