### PR TITLE
fix(ui): preserve the original error when a Control UI build fails

### DIFF
--- a/ui/src/app/vite-build.node.test.ts
+++ b/ui/src/app/vite-build.node.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment node
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { brotliDecompressSync, gunzipSync } from "node:zlib";
+import { build, type InlineConfig } from "vite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ControlUiAssetManifest } from "../../../src/gateway/control-ui-asset-manifest.ts";
+import controlUiViteConfig from "../../vite.config.ts";
+
+describe("Control UI Vite build", () => {
+  let root: string;
+  let outDir: string;
+  let config: InlineConfig;
+
+  beforeEach(async () => {
+    root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "control-ui-vite-build-")));
+    outDir = path.join(root, "dist");
+    config = {
+      ...controlUiViteConfig({ outDir }),
+      configFile: false,
+      root,
+      publicDir: false,
+      logLevel: "silent",
+    };
+    await fs.writeFile(
+      path.join(root, "index.html"),
+      '<button>Load</button><script type="module" src="./main.js"></script>',
+    );
+    await fs.writeFile(
+      path.join(root, "main.js"),
+      `document.querySelector("button").addEventListener("click", async () => {
+        const { message } = await import("./lazy.js");
+        document.body.dataset.message = message;
+      });`,
+    );
+    await fs.writeFile(
+      path.join(root, "lazy.js"),
+      'import "./lazy.css"; export const message = "Lazy content loaded";',
+    );
+    await fs.writeFile(path.join(root, "lazy.css"), "body { color: green; }");
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("preserves an unresolved import diagnostic with a fresh output directory", async () => {
+    await fs.writeFile(path.join(root, "main.js"), 'import "./missing-module.js";');
+
+    const result = build(config);
+
+    await expect(result).rejects.toThrow(/Could not resolve.*missing-module\.js/u);
+    await expect(result).rejects.not.toThrow(/ENOENT|asset-manifest/u);
+    await expect(fs.stat(outDir)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("inventories final emitted bytes and compressed variants, excluding source maps", async () => {
+    await build(config);
+
+    const manifest: ControlUiAssetManifest = JSON.parse(
+      await fs.readFile(path.join(outDir, "asset-manifest.json"), "utf8"),
+    );
+    const emitted = (await fs.readdir(path.join(outDir, "assets"))).toSorted();
+    expect(emitted.some((name) => name.endsWith(".map"))).toBe(true);
+    expect(manifest.assets.map((entry) => entry.path).toSorted()).toEqual(
+      emitted.filter((name) => !name.endsWith(".map")).map((name) => `assets/${name}`),
+    );
+    for (const entry of manifest.assets) {
+      const source = await fs.readFile(path.join(outDir, entry.path));
+      expect(entry.size).toBe(source.byteLength);
+      expect(entry.sha256).toBe(createHash("sha256").update(source).digest("hex"));
+    }
+
+    const scripts = emitted.filter((name) => name.endsWith(".js"));
+    expect(scripts.length).toBeGreaterThan(1);
+    expect(emitted.some((name) => name.endsWith(".css"))).toBe(true);
+    for (const name of emitted.filter((fileName) => /\.(js|css)$/u.test(fileName))) {
+      const source = await fs.readFile(path.join(outDir, "assets", name));
+      const brotli = await fs.readFile(path.join(outDir, "assets", `${name}.br`));
+      const gzip = await fs.readFile(path.join(outDir, "assets", `${name}.gz`));
+      expect(brotliDecompressSync(brotli)).toEqual(source);
+      expect(gunzipSync(gzip)).toEqual(source);
+    }
+    const serviceWorker = await fs.readFile(path.join(outDir, "sw.js"), "utf8");
+    const embeddedBuildId = /const EMBEDDED_CACHE_VERSION = "([^"]+)"/u.exec(serviceWorker)?.[1];
+    const buildInfo = JSON.parse(config.define?.["globalThis.OPENCLAW_CONTROL_UI_BUILD_INFO"]);
+    expect(embeddedBuildId).toBe(buildInfo.buildId);
+  });
+
+  it("fails when a completed build emits outside the required assets directory", async () => {
+    config.build = { ...config.build, assetsDir: "bundles" };
+
+    await expect(build(config)).rejects.toThrow(/ENOENT.*assets/u);
+    expect(await fs.readFile(path.join(outDir, "index.html"), "utf8")).toContain("bundles/");
+    expect((await fs.readdir(path.join(outDir, "bundles"))).length).toBeGreaterThan(0);
+    await expect(fs.stat(path.join(outDir, "asset-manifest.json"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("preserves an output write failure without finalizing the build", async () => {
+    await fs.mkdir(outDir);
+    await fs.writeFile(path.join(outDir, "blocked"), "output obstruction");
+    config.build = { ...config.build, emptyOutDir: false, assetsDir: "blocked" };
+
+    const result = build(config);
+
+    await expect(result).rejects.toThrow(/blocked/u);
+    await expect(result).rejects.not.toThrow(/scandir|asset-manifest/u);
+    expect(await fs.readFile(path.join(outDir, "blocked"), "utf8")).toBe("output obstruction");
+    for (const file of ["asset-manifest.json", "sw.js"]) {
+      await expect(fs.stat(path.join(outDir, file))).rejects.toMatchObject({ code: "ENOENT" });
+    }
+  });
+});

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -397,7 +397,7 @@ function controlUiServiceWorkerBuildIdPlugin(buildId: string, buildOutDir: strin
   return {
     name: "control-ui-service-worker-build-id",
     apply: "build",
-    closeBundle() {
+    writeBundle() {
       const swPath = path.join(buildOutDir, "sw.js");
       const publicSwPath = path.join(here, "public/sw.js");
       const source = fs.readFileSync(publicSwPath, "utf8");
@@ -465,7 +465,9 @@ function controlUiAssetManifestPlugin(buildOutDir: string): Plugin {
   return {
     name: "control-ui-asset-manifest",
     apply: "build",
-    closeBundle() {
+    // Rolldown runs writeBundle hooks sequentially; this plugin follows precompression.
+    // closeBundle can run again without an error after a failed build, masking its diagnostic.
+    writeBundle() {
       const assets = collectControlUiAssetManifestEntries(buildOutDir);
       const manifest = {
         version: CONTROL_UI_ASSET_MANIFEST_VERSION,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This PR uses a branch in the canonical repository so maintainers can update it.

</details>

## What Problem This Solves

Resolves a problem where Control UI builds and native UI E2E global setup report a secondary `ENOENT` while scanning a fresh output directory instead of the original build failure. An unresolved import prevented assets from being emitted, but manifest finalization still tried to scan `<outDir>/assets`, hiding the diagnostic needed to fix the import or installation.

## Why This Change Was Made

Move asset-manifest and service-worker finalization from `closeBundle` to `writeBundle`, the lifecycle boundary that runs only after output has been written. Installed Vite 8.2.2 closes in `finally`; a real probe with its nested Rolldown 1.2.5 observed `closeBundle(error)` followed by another `closeBundle()` without an error, so an optional-error guard alone still reproduced the masking. Rolldown runs hooks sequentially, keeping manifest collection after final emitted bytes and the existing Brotli/gzip precompression.

The strict asset scan is unchanged: a nominally successful build without the required assets directory still fails. No missing-directory catch, empty-assets workaround, lifecycle flags, new dependencies, storage changes, or guard-budget adjustments are introduced.

## User Impact

Developers get the original unresolved-import or output-write error, and failed builds do not emit success-only finalization artifacts. Successful builds retain the same manifest, compressed asset, and service-worker contracts. This is build-tooling behavior; there is no rendered UI or visual change.

Production/tooling LOC: **+4/-2 (net +2 comment lines; executable LOC neutral)**. Tests: **+117/-0**.

## Evidence

- Before the fix, the new real programmatic Vite regression failed: expected `Could not resolve ... missing-module.js`, received `ENOENT ... scandir <temporary-root>/dist/assets`. The error-argument-only alternative also failed because of the second close callback.
- After the fix, **32 tests passed** across the new build-boundary regressions, existing Vite config tests, and Gateway manifest contract tests:
  ```bash
  node scripts/run-vitest.mjs ui/src/app/vite-build.node.test.ts ui/src/app/vite-config.node.test.ts src/gateway/control-ui-asset-manifest.test.ts
  ```
- The four build-boundary cases use actual Vite builds with temporary HTML/JS/CSS fixtures: unresolved import, successful lazy-import output with manifest/sidecar integrity, missing assets after otherwise successful emission, and a filesystem obstruction during output writing. No plugin hooks are mocked or invoked manually.
- Complete changed-scope checks passed, including core test types, UI types, targeted lint/stylelint, i18n verification, and selected guards:
  ```bash
  node scripts/check-changed.mjs -- ui/vite.config.ts ui/src/app/vite-build.node.test.ts
  ```
- The production UI build passed with performance budgets unchanged:
  ```bash
  pnpm ui:build
  ```
  Independently parsed the generated manifest with the Gateway parser and verified all **1,191 entries** against disk hashes/sizes; all **794 Brotli/gzip sidecars** decoded to the final emitted bytes. Source maps remain excluded from the manifest.
- Formatting and `git diff --check` passed. Isolated Codex autoreview found no accepted/actionable findings at its default P0 scope. The initial changed gate found a shadowed variable in the new test; the naming-only correction passed the complete rerun.
- Dependency contracts were inspected directly: Vite's rethrow/finally path (`dist/node/chunks/node.js:33825-33835`), Rolldown's close-hook adapter, post-write hook contract, and sequential hook semantics. The real lifecycle probe independently confirmed both close callbacks.
- ClawSweeper's [review and rank-up request](https://github.com/openclaw/openclaw/pull/133494#issuecomment-5471023148) found no actionable code defect and requested independent dependency-contract confirmation. The landing reviewer personally inspected the installed **Vite 8.2.2** and its **nested Rolldown 1.2.5** (not the root Rolldown): `vite/dist/node/chunks/node.js:33818-33835` rethrows and then closes in `finally`; nested `rolldown/dist/shared/bindingify-input-options-COG1sboO.mjs:1710-1722` adapts write/close hooks; `define-config-DwTNhgWB.d.mts:3105-3111` documents post-write timing and `:3224-3231` states sequential hook semantics. This confirms the contract against the actual installed dependency; exact-head CI completion remains required before landing.
