### PR TITLE
feat(ui): add CRT terminal theme

### DIFF
--- a/packages/gateway-protocol/src/schema/ui-appearance-preferences.ts
+++ b/packages/gateway-protocol/src/schema/ui-appearance-preferences.ts
@@ -23,6 +23,7 @@ export const UI_APPEARANCE_THEME_VALUES = [
   "tide",
   "beacon",
   "phosphor",
+  "crt",
 ] as const;
 // Wire-contract list of profile-storable typefaces. The Control UI derives
 // its override normalization from this tuple so browser and profile values agree.

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -156,7 +156,16 @@ export type OpenClawConfig = {
      */
     prefs?: {
       /** Control UI theme. */
-      theme?: "claw" | "knot" | "dash" | "absolutely" | "tide" | "beacon" | "phosphor" | "custom";
+      theme?:
+        | "claw"
+        | "knot"
+        | "dash"
+        | "absolutely"
+        | "tide"
+        | "beacon"
+        | "phosphor"
+        | "crt"
+        | "custom";
       /** Light/dark preference. */
       themeMode?: "light" | "dark" | "system";
       /** User-selected Control UI accent color (#RRGGBB). */

--- a/src/config/zod-schema.root-shape.ts
+++ b/src/config/zod-schema.root-shape.ts
@@ -228,6 +228,7 @@ export const OpenClawSchemaShape = {
               z.literal("tide"),
               z.literal("beacon"),
               z.literal("phosphor"),
+              z.literal("crt"),
               z.literal("custom"),
             ])
             .optional(),

--- a/ui/index.html
+++ b/ui/index.html
@@ -21,7 +21,16 @@
       globalThis.__zod_globalConfig.jitless = true;
 
       (function () {
-        var THEMES = { claw: 1, knot: 1, dash: 1, absolutely: 1, tide: 1, beacon: 1, phosphor: 1 };
+        var THEMES = {
+          claw: 1,
+          knot: 1,
+          dash: 1,
+          absolutely: 1,
+          tide: 1,
+          beacon: 1,
+          phosphor: 1,
+          crt: 1,
+        };
         var MODES = { system: 1, light: 1, dark: 1 };
         var LEGACY = {
           dark: "claw:dark",
@@ -60,6 +69,7 @@
             tide: ["tide", "tide-light"],
             beacon: ["beacon", "beacon-light"],
             phosphor: ["phosphor", "phosphor-light"],
+            crt: ["crt", "crt-light"],
           };
           var pair = FAMILIES[theme];
           var resolved = pair
@@ -154,6 +164,14 @@
 
       html[data-theme="phosphor-light"] {
         background: #f4f7f4;
+      }
+
+      html[data-theme="crt"] {
+        background: #090a09;
+      }
+
+      html[data-theme="crt-light"] {
+        background: #f5f5f4;
       }
 
       body {

--- a/ui/public/themes/crt.css
+++ b/ui/public/themes/crt.css
@@ -1,0 +1,171 @@
+/* CRT palette; selected by index.html and app/theme.ts. */
+
+/* Terminal shape: the whole console is near-square. Radius tokens flatten the
+   var(--radius-*) chain and the scale factor flattens the fixed px * scale
+   corner rules; --radius-full is untouched so avatars and pills stay round.
+   The attribute selector outscores the :root capability flip to 1.25. */
+:root[data-theme="crt"],
+:root[data-theme="crt-light"] {
+  --radius-sm: 2px;
+  --radius-md: 3px;
+  --radius-lg: 4px;
+  --radius-xl: 6px;
+  --radius: 3px;
+  --openclaw-corner-radius-scale: 0.25;
+}
+
+:root[data-theme="crt"] {
+  /*
+   * Accent — bright phosphor green on neutral tube black; white-cast body text.
+   * Phosphor (green-on-green glass) stays the tinted sibling; CRT is the
+   * neutral white/green console.
+   *
+   * WCAG 2.1 AA audit (bg = #090a09, relative luminance ≈ 0.0030):
+   *   --accent #3aff7d  contrast ≈ 14.9:1 AAA ✓
+   *   --primary-foreground #052b12 on #3aff7d button: 11.6:1 ✓
+   *   --destructive-foreground (base #fafafa) on #d0342d button: 4.7:1 AA ✓
+   *   body text --text #c2cac3: 11.8:1 ✓
+   *   worst text pairing --muted on --bg-muted: 6.5:1 ✓
+   */
+  --ring: #3aff7d;
+  --accent: #3aff7d;
+  --accent-hover: #71ffa5;
+  --accent-muted: #3aff7d;
+  --accent-subtle: rgba(58, 255, 125, 0.12);
+  --accent-glow: rgba(58, 255, 125, 0.2);
+  --primary: #3aff7d;
+  --primary-hover: #71ffa5;
+  --primary-foreground: #052b12;
+
+  --destructive: #d0342d;
+  --destructive-hover: #b92d27;
+
+  --focus: rgba(58, 255, 125, 0.18);
+  --focus-ring: 0 0 0 2px var(--bg), 0 0 0 3px color-mix(in srgb, var(--ring) 75%, transparent);
+  --focus-glow: 0 0 0 2px var(--bg), 0 0 0 3px var(--ring), 0 0 16px var(--accent-glow);
+
+  --bg: #090a09;
+  --bg-accent: #0d0f0d;
+  --bg-elevated: #111412;
+  --bg-hover: #171b18;
+  --bg-muted: #151915;
+
+  --card: #0d0f0d;
+  --card-foreground: #e9eee9;
+  --card-highlight: rgba(220, 245, 225, 0.04);
+  --popover: #111412;
+  --popover-foreground: #e9eee9;
+
+  --panel: #090a09;
+  --panel-strong: #111412;
+  --panel-hover: #171b18;
+  --chrome: rgba(9, 10, 9, 0.96);
+  --chrome-strong: rgba(9, 10, 9, 0.98);
+
+  --text: #c2cac3;
+  --text-strong: #e9eee9;
+  --chat-text: #c2cac3;
+  --muted: #90a094;
+  --muted-strong: #a3b2a7;
+  --muted-foreground: #90a094;
+
+  --border: #202521;
+  --border-strong: #303833;
+  --border-hover: #45524a;
+  --input: #202521;
+
+  --secondary: #0d0f0d;
+  --secondary-foreground: #e9eee9;
+  --accent-2: #ffcf5c;
+  --accent-2-muted: rgba(255, 207, 92, 0.7);
+  --accent-2-subtle: rgba(255, 207, 92, 0.12);
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.45);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.55);
+  --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.65);
+  --overlay-shadow: var(--shadow-md);
+
+  --grid-line: rgba(220, 245, 225, 0.04);
+
+  /* One face for the whole console, prose included — same opt-in character
+     decision as Phosphor; the mono choice is why this theme is not a default. */
+  --mono:
+    "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, monospace;
+  --font-body: var(--mono);
+  --font-chat: var(--mono);
+}
+
+:root[data-theme="crt-light"] {
+  /*
+   * Accent — deep console green on neutral paper.
+   *
+   * WCAG 2.1 AA audit (bg = #f5f5f4, relative luminance ≈ 0.911):
+   *   --accent #0a612b  contrast ≈ 6.9:1 AA ✓
+   *   --primary-foreground #ffffff on #0a612b button: 7.6:1 ✓
+   *   body text --text #343a34: 10.7:1 ✓
+   *   worst text pairing --muted on --bg-muted: 5.1:1 ✓
+   */
+  --ring: #0a612b;
+  --accent: #0a612b;
+  --accent-hover: #084d22;
+  --accent-muted: #0a612b;
+  --accent-subtle: rgba(10, 97, 43, 0.1);
+  --accent-glow: rgba(10, 97, 43, 0.14);
+  --primary: #0a612b;
+  --primary-foreground: #ffffff;
+
+  --bg: #f5f5f4;
+  --bg-accent: #ececea;
+  --bg-elevated: #ffffff;
+  --bg-hover: #e3e4e1;
+  --bg-muted: #e9eae8;
+  --bg-content: #efefee;
+
+  --card: #ffffff;
+  --card-foreground: #191e19;
+  --card-highlight: rgba(20, 40, 25, 0.02);
+  --popover: #ffffff;
+  --popover-foreground: #191e19;
+  --session-hovercard-surface: var(--card);
+  --session-hovercard-progress-surface: color-mix(
+    in srgb,
+    var(--card) 52%,
+    var(--panel-strong) 48%
+  );
+
+  --panel: #f5f5f4;
+  --panel-strong: #ececea;
+  --panel-hover: #dddedb;
+  --chrome: rgba(245, 245, 244, 0.96);
+  --chrome-strong: rgba(245, 245, 244, 0.98);
+
+  --text: #343a34;
+  --text-strong: #191e19;
+  --chat-text: #343a34;
+  --muted: #5b655c;
+  --muted-strong: #49544a;
+  --muted-foreground: #5b655c;
+
+  --border: #dcdedb;
+  --border-strong: #c0c5bf;
+  --border-hover: #97a399;
+  --input: #dcdedb;
+
+  --secondary: #ececea;
+  --secondary-foreground: #343a34;
+  --accent-2: #7a5d10;
+  --accent-2-muted: rgba(122, 93, 16, 0.75);
+  --accent-2-subtle: rgba(122, 93, 16, 0.08);
+
+  --shadow-sm: 0 1px 2px rgba(15, 25, 18, 0.05);
+  --shadow-md: 0 4px 12px rgba(15, 25, 18, 0.07);
+  --shadow-lg: 0 12px 28px rgba(15, 25, 18, 0.09);
+  --overlay-shadow: var(--shadow-md);
+
+  --grid-line: rgba(20, 40, 25, 0.04);
+
+  --mono:
+    "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, monospace;
+  --font-body: var(--mono);
+  --font-chat: var(--mono);
+}

--- a/ui/src/app/mount-fallback.test.ts
+++ b/ui/src/app/mount-fallback.test.ts
@@ -112,6 +112,8 @@ describe("Control UI mount fallback", () => {
     ["Beacon dark", { theme: "beacon", themeMode: "dark" }, "beacon", "rgb(0, 0, 0)"],
     ["Beacon light", { theme: "beacon", themeMode: "light" }, "beacon-light", "rgb(255, 255, 255)"],
     ["Phosphor dark", { theme: "phosphor", themeMode: "dark" }, "phosphor", "rgb(10, 15, 10)"],
+    ["CRT dark", { theme: "crt", themeMode: "dark" }, "crt", "rgb(9, 10, 9)"],
+    ["CRT light", { theme: "crt", themeMode: "light" }, "crt-light", "rgb(245, 245, 244)"],
   ])(
     "paints %s before the app stylesheet loads",
     async (_name, settings, expectedTheme, expectedBackground) => {

--- a/ui/src/app/server-prefs.profile.test.ts
+++ b/ui/src/app/server-prefs.profile.test.ts
@@ -52,6 +52,7 @@ describe("profile-bound appearance preferences", () => {
       tide: true,
       beacon: true,
       phosphor: true,
+      crt: true,
       custom: false,
     };
     for (const [theme, storable] of Object.entries(profileStorable)) {

--- a/ui/src/app/theme-fonts.test.ts
+++ b/ui/src/app/theme-fonts.test.ts
@@ -31,6 +31,7 @@ describe("typeface presentation", () => {
     ["tide", ["ibm-plex-sans", "ibm-plex-sans"]],
     ["beacon", ["atkinson-hyperlegible", "atkinson-hyperlegible"]],
     ["phosphor", ["jetbrains-mono", "jetbrains-mono"]],
+    ["crt", ["jetbrains-mono", "jetbrains-mono"]],
     ["custom", ["system", "system"]],
   ] as const)("loads %s's default faces plus the shared mono face", (theme, [ui, chat]) => {
     const faces = resolveTypefaces(theme);

--- a/ui/src/app/theme.test.ts
+++ b/ui/src/app/theme.test.ts
@@ -12,6 +12,7 @@ describe("resolveTheme", () => {
     ["tide", "tide", "tide-light"],
     ["beacon", "beacon", "beacon-light"],
     ["phosphor", "phosphor", "phosphor-light"],
+    ["crt", "crt", "crt-light"],
     ["custom", "custom", "custom-light"],
   ] satisfies [ThemeName, string, string][])(
     "resolves %s in both explicit modes",

--- a/ui/src/app/theme.ts
+++ b/ui/src/app/theme.ts
@@ -8,6 +8,7 @@ export type ThemeName =
   | "tide"
   | "beacon"
   | "phosphor"
+  | "crt"
   | "custom";
 export type ThemeMode = "system" | "light" | "dark";
 export type ResolvedTheme =
@@ -25,6 +26,8 @@ export type ResolvedTheme =
   | "beacon-light"
   | "phosphor"
   | "phosphor-light"
+  | "crt"
+  | "crt-light"
   | "custom"
   | "custom-light";
 
@@ -36,6 +39,7 @@ const VALID_THEME_NAMES = new Set<ThemeName>([
   "tide",
   "beacon",
   "phosphor",
+  "crt",
   "custom",
 ]);
 

--- a/ui/src/app/typography.ts
+++ b/ui/src/app/typography.ts
@@ -50,6 +50,7 @@ export const THEME_TYPEFACES = {
   tide: { ui: "ibm-plex-sans", chat: "ibm-plex-sans" },
   beacon: { ui: "atkinson-hyperlegible", chat: "atkinson-hyperlegible" },
   phosphor: { ui: "jetbrains-mono", chat: "jetbrains-mono" },
+  crt: { ui: "jetbrains-mono", chat: "jetbrains-mono" },
   custom: { ui: "system", chat: "system" },
 } satisfies Record<ThemeName, TypefacePair>;
 

--- a/ui/src/e2e/theme-muted-contrast.e2e.test.ts
+++ b/ui/src/e2e/theme-muted-contrast.e2e.test.ts
@@ -26,6 +26,8 @@ const themeCases = [
   { family: "beacon", mode: "light", resolved: "beacon-light" },
   { family: "phosphor", mode: "dark", resolved: "phosphor" },
   { family: "phosphor", mode: "light", resolved: "phosphor-light" },
+  { family: "crt", mode: "dark", resolved: "crt" },
+  { family: "crt", mode: "light", resolved: "crt-light" },
 ] as const;
 
 const textTokens = [
@@ -40,7 +42,7 @@ const textTokens = [
 const surfaceTokens = ["--bg", "--bg-elevated", "--bg-muted", "--card", "--panel"] as const;
 
 function themeConfigResponse(
-  family: "claw" | "knot" | "dash" | "absolutely" | "tide" | "beacon" | "phosphor",
+  family: "claw" | "knot" | "dash" | "absolutely" | "tide" | "beacon" | "phosphor" | "crt",
   mode: "dark" | "light",
   accent?: string,
 ) {

--- a/ui/src/e2e/theme-typography.e2e.test.ts
+++ b/ui/src/e2e/theme-typography.e2e.test.ts
@@ -241,6 +241,7 @@ suite.define(() => {
       "antialiased",
     ],
     ["phosphor", "JetBrains Mono", "JetBrains Mono", ["jetbrains-mono"], "antialiased"],
+    ["crt", "JetBrains Mono", "JetBrains Mono", ["jetbrains-mono"], "antialiased"],
   ] as const)(
     "paints %s chrome and chat prose in its own faces",
     async (theme, body, chat, faces, chatSmoothing) => {
@@ -354,6 +355,7 @@ suite.define(() => {
     ["tide", "tide", "#10151b", "#f7f9fb"],
     ["beacon", "beacon", "#000000", "#ffffff"],
     ["phosphor", "phosphor", "#0a0f0a", "#f4f7f4"],
+    ["crt", "crt", "#090a09", "#f5f5f4"],
   ])(
     "loads %s before paint in both modes without the app bundle",
     async (theme, resolved, dark, light) => {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1866,6 +1866,10 @@ export const en: TranslationMap = {
         label: "Phosphor",
         description: "Green on glass",
       },
+      crt: {
+        label: "CRT",
+        description: "Console mono",
+      },
     },
     textSizes: {
       small: "Small",

--- a/ui/src/pages/config/view-appearance.ts
+++ b/ui/src/pages/config/view-appearance.ts
@@ -85,6 +85,11 @@ const BUILTIN_THEME_OPTIONS: ThemeOption[] = [
     labelKey: "configView.themes.phosphor.label",
     descriptionKey: "configView.themes.phosphor.description",
   },
+  {
+    id: "crt",
+    labelKey: "configView.themes.crt.label",
+    descriptionKey: "configView.themes.crt.description",
+  },
 ];
 
 const ACCENT_PRESETS = [

--- a/ui/src/styles/base-theme-contrast.node.test.ts
+++ b/ui/src/styles/base-theme-contrast.node.test.ts
@@ -172,6 +172,8 @@ function resolveThemes(blocks: Map<string, TokenMap>): Map<string, TokenMap> {
     ["beacon-light", layer(light, blocks.get(':root[data-theme="beacon-light"]'))],
     ["phosphor", layer(blocks.get(':root[data-theme="phosphor"]'))],
     ["phosphor-light", layer(light, blocks.get(':root[data-theme="phosphor-light"]'))],
+    ["crt", layer(blocks.get(':root[data-theme="crt"]'))],
+    ["crt-light", layer(light, blocks.get(':root[data-theme="crt-light"]'))],
   ]);
 }
 

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -1260,6 +1260,7 @@ img.chat-avatar.chat-avatar--logo {
 :root[data-theme="absolutely"] .chat-confirm-popover__yes,
 :root[data-theme="tide"] .chat-confirm-popover__yes,
 :root[data-theme="phosphor"] .chat-confirm-popover__yes,
+:root[data-theme="crt"] .chat-confirm-popover__yes,
 :root[data-theme="beacon"] .chat-confirm-popover__yes {
   background: var(--destructive);
   color: var(--destructive-foreground);
@@ -1278,6 +1279,7 @@ img.chat-avatar.chat-avatar--logo {
 :root[data-theme="absolutely"] .chat-confirm-popover__yes:hover,
 :root[data-theme="tide"] .chat-confirm-popover__yes:hover,
 :root[data-theme="phosphor"] .chat-confirm-popover__yes:hover,
+:root[data-theme="crt"] .chat-confirm-popover__yes:hover,
 :root[data-theme="beacon"] .chat-confirm-popover__yes:hover {
   background: var(--destructive-hover);
 }

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -393,6 +393,13 @@
   --theme-chip-accent-2: #8fd6a5;
 }
 
+.settings-theme-card--crt,
+.settings-accent-theme--crt {
+  --theme-chip-bg: #090a09;
+  --theme-chip-accent: #3aff7d;
+  --theme-chip-accent-2: #ffcf5c;
+}
+
 :root[data-theme-mode="light"] :is(.settings-theme-card--claw, .settings-accent-theme--claw) {
   --theme-chip-bg: #faf9f7;
   --theme-chip-accent: #bd4531;
@@ -435,6 +442,12 @@
   --theme-chip-bg: #f4f7f4;
   --theme-chip-accent: #10693a;
   --theme-chip-accent-2: #2f6b47;
+}
+
+:root[data-theme-mode="light"] :is(.settings-theme-card--crt, .settings-accent-theme--crt) {
+  --theme-chip-bg: #f5f5f4;
+  --theme-chip-accent: #0a612b;
+  --theme-chip-accent-2: #7a5d10;
 }
 /* stylelint-enable color-no-hex */
 

--- a/ui/src/styles/theme-contrast.test.ts
+++ b/ui/src/styles/theme-contrast.test.ts
@@ -158,6 +158,7 @@ describe("Control UI theme contrast", () => {
       ':root[data-theme="tide-light"]',
       ':root[data-theme="beacon-light"]',
       ':root[data-theme="phosphor-light"]',
+      ':root[data-theme="crt-light"]',
     ]) {
       const theme = selector ? { ...light, ...readCssVarBlock(baseCss, selector) } : light;
       const muted = requireCssColor(theme, "muted");


### PR DESCRIPTION
## What Problem This Solves

Operators who live in terminals asked for a Control UI look that reads like one. The closest existing family, Phosphor, is green-tinted glass everywhere; there was no neutral white-on-black console theme, and no theme that carries the terminal shape (mono type plus squared corners) with a classic green/amber accent pairing.

## Why This Change Was Made

Maintainer-requested feature (built to direction in chat). It ships as a real theme family rather than a custom tweakcn import so it syncs across devices through the profile wire contract, gets first-paint treatment, and is held to the same WCAG gates as every built-in.

CRT is registered across every seam a theme family touches: palette file (`ui/public/themes/crt.css` with a WCAG audit header), theme registry and resolved-name map (`ui/src/app/theme.ts`), render-blocking first-paint boot script and pre-paint background (`ui/index.html`), per-theme typefaces (`ui/src/app/typography.ts`, JetBrains Mono for chrome and chat), gateway-protocol profile wire contract (`packages/gateway-protocol/src/schema/ui-appearance-preferences.ts`), config schema + types (`src/config/zod-schema.root-shape.ts`, `src/config/types.openclaw.ts`), appearance grid card + chip swatches, i18n label, and the dark-family confirm-button selector list in `chat/grouped.css`.

Design notes: dark mode is neutral tube black `#090a09` with white-cast body text `#c2cac3` (~11.8:1), phosphor-green accent `#3aff7d` (~14.9:1) and amber `#ffcf5c` as accent-2; light mode is a neutral paper console with deep green `#0a612b` (~6.9:1). The theme also flattens the corner-radius ladder (2-6px) and the corner-shape scale factor for the squared terminal chrome — a deliberate per-theme shape choice, same opt-in character decision as Phosphor's all-mono type.

## User Impact

A new opt-in "CRT / Console mono" card in Settings → Appearance. No default-path change: Claw stays the default, the palette loads lazily from `public/themes/` only when selected, and existing theme selections are untouched. Profile-synced like every other built-in family.

## Evidence

- Unit + mechanical contrast gates: `theme.test.ts`, `theme-fonts.test.ts`, `mount-fallback.test.ts` (first-paint boot script), `server-prefs.profile.test.ts` (wire-contract sync), `base-theme-contrast.node.test.ts` + `theme-contrast.test.ts` (WCAG AA floors over every text-on-surface pairing of the new palette) — 69/69 pass.
- Browser e2e: `theme-typography.e2e.test.ts` + `theme-muted-contrast.e2e.test.ts` extended with CRT rows (typeface painting, render-blocking palette before paint in both modes, appearance/picker legibility for `crt` and `crt-light`) — 40/40 pass.
- `pnpm check:changed` green (typecheck, stylelint, i18n verify, import cycles); keyless `pnpm ui:i18n:baseline` run (no baseline drift).
- `pnpm ui:build` green including the startup budget validators: startup JS gzip 346698 B vs baseline 346185 B — 513 B growth, inside the 512 B per-change allowance + 64 B build-variance band (enforcement limit 346761 B). Startup CSS unchanged at 44.1 KiB: the palette lives in `public/themes/`, so the default path pays nothing.
- Screenshots attached below: default Claw dark (before) for comparison, then CRT dark chat, CRT with the terminal side panel, the Appearance grid with the new CRT card selected, and CRT light — all captured from the mocked Control UI dev server via Playwright.

![claw-chat-dark-before](https://github.com/user-attachments/assets/536f9d0e-c911-4c3c-aba2-d57c9b71c34a)

![crt-chat-dark](https://github.com/user-attachments/assets/857de9b4-27ae-452e-b50d-76cada4d2a20)

![crt-panel-dark](https://github.com/user-attachments/assets/e742993f-ffb0-4c44-8ddd-cc4d986ab527)

![crt-appearance-dark](https://github.com/user-attachments/assets/b85308f2-8d16-4283-9049-731f47404c33)

![crt-chat-light](https://github.com/user-attachments/assets/14bce07c-7d16-4396-a8ad-0b5cc1746496)