### PR TITLE
improve: speed up legacy session transcript imports

### DIFF
--- a/src/agents/sessions/session-manager-codec.ts
+++ b/src/agents/sessions/session-manager-codec.ts
@@ -391,6 +391,14 @@ export function parseOpaqueLeafEntry(record: unknown):
   };
 }
 
+export function classifySessionFileEntry(rawEntry: FileEntry, sourceVersion: number) {
+  const entry = normalizePersistedLegacyHookMessage(rawEntry) as FileEntry;
+  const recognized =
+    isIndexedSessionEntry(entry) ||
+    (sourceVersion < CURRENT_SESSION_VERSION && isReadableLegacySessionEntry(entry));
+  return { entry, recognized };
+}
+
 export function partitionSessionFileEntries(entries: readonly FileEntry[]): {
   fileEntries: FileEntry[];
   opaqueEntries: Array<{ index: number; record: unknown }>;
@@ -402,20 +410,17 @@ export function partitionSessionFileEntries(entries: readonly FileEntry[]): {
   const header = entries.find((entry) => sessionHeaderSchema.safeParse(entry).success) as
     | SessionHeader
     | undefined;
-  const acceptsLegacyEntries = (header?.version ?? 1) < CURRENT_SESSION_VERSION;
+  const sourceVersion = header?.version ?? 1;
   let hasHeader = false;
   for (const [originalIndex, rawEntry] of entries.entries()) {
-    const entry = normalizePersistedLegacyHookMessage(rawEntry) as FileEntry;
-    if (!hasHeader && sessionHeaderSchema.safeParse(entry).success) {
-      fileEntries.push(entry);
-      fileEntriesByOriginalIndex[originalIndex] = entry;
+    if (!hasHeader && sessionHeaderSchema.safeParse(rawEntry).success) {
+      fileEntries.push(rawEntry);
+      fileEntriesByOriginalIndex[originalIndex] = rawEntry;
       hasHeader = true;
       continue;
     }
-    if (
-      isIndexedSessionEntry(entry) ||
-      (acceptsLegacyEntries && isReadableLegacySessionEntry(entry))
-    ) {
+    const { entry, recognized } = classifySessionFileEntry(rawEntry, sourceVersion);
+    if (recognized) {
       fileEntries.push(entry);
       fileEntriesByOriginalIndex[originalIndex] = entry;
       continue;

--- a/src/commands/doctor-session-sqlite-readers.test.ts
+++ b/src/commands/doctor-session-sqlite-readers.test.ts
@@ -1,0 +1,105 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTranscriptEventReader } from "./doctor-session-sqlite-readers.js";
+
+describe("legacy transcript row classification", () => {
+  let directory: string;
+  let transcriptPath: string;
+  beforeEach(() => {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-reader-classification-"));
+    transcriptPath = path.join(directory, "session.jsonl");
+  });
+  afterEach(() => fs.rmSync(directory, { recursive: true, force: true }));
+
+  it.each([1, 2, 3, 4])("preserves recognized and opaque rows from version %s", (version) => {
+    const unindexedHook = { type: "message", message: { role: "custom", content: "context" } };
+    const opaqueRows = [
+      { type: "session", id: "later-header", version: 1 },
+      { type: "plugin_state", id: "opaque", payload: { keep: "exact" } },
+      { type: "message", id: "malformed", message: { role: "user" } },
+    ];
+    const rows = [
+      { type: "session", version, sessionId: "legacy-header" },
+      { ...unindexedHook, id: "hook", parentId: null },
+      unindexedHook,
+      ...opaqueRows,
+    ];
+    fs.writeFileSync(transcriptPath, rows.map((row) => JSON.stringify(row)).join("\n"));
+    const events: unknown[] = [];
+    const validate = createTranscriptEventReader(
+      transcriptPath,
+      "target-session",
+    )((event) => {
+      events.push(event);
+    });
+    validate();
+
+    expect(events).toHaveLength(rows.length);
+    expect(events[0]).toEqual({
+      type: "session",
+      id: "target-session",
+      version: Math.max(version, 3),
+      timestamp: "",
+      cwd: "",
+    });
+    expect(events[1]).toMatchObject({
+      id: version === 1 ? expect.stringMatching(/^[a-f0-9]{16}-1$/) : "hook",
+      message: { role: "custom", customType: "hook", content: "context" },
+    });
+    if (version < 3) {
+      expect(events[2]).toMatchObject({
+        message: { role: "custom", customType: "hook", content: "context" },
+      });
+    } else {
+      expect(events[2]).toEqual(unindexedHook);
+    }
+    expect(events.slice(3)).toEqual(opaqueRows);
+  });
+
+  it.each([1, 3])("enforces the target limit even during v%s prefix recovery", (version) => {
+    const rows = Array.from({ length: 100_001 }, (_, index) =>
+      JSON.stringify({
+        type: "compaction",
+        id: `c-${index}`,
+        summary: "kept",
+        tokensBefore: 0,
+        firstKeptEntryId: "kept",
+        firstKeptEntryIndex: index,
+      }),
+    );
+    fs.writeFileSync(
+      transcriptPath,
+      `${JSON.stringify({ type: "session", version })}\n${rows.join("\n")}`,
+    );
+    expect(() => createTranscriptEventReader(transcriptPath, "target", true)(() => {})).toThrow(
+      "more than 100000 legacy compaction targets",
+    );
+  });
+
+  it.each([false, true])("handles malformed tails with prefix recovery %s", (allowPrefix) => {
+    const rows = [
+      { type: "session", version: 3, id: "target" },
+      { type: "message", id: "kept", message: { role: "user", content: "x".repeat(70_000) } },
+    ];
+    fs.writeFileSync(
+      transcriptPath,
+      `${rows.map((row) => JSON.stringify(row)).join("\n")}\n{malformed`,
+    );
+    const events: unknown[] = [];
+    const read = () =>
+      createTranscriptEventReader(
+        transcriptPath,
+        "target",
+        allowPrefix,
+      )((event) => events.push(event));
+    if (allowPrefix) {
+      read()();
+      expect(events).toHaveLength(2);
+      expect(events[1]).toEqual(rows[1]);
+    } else {
+      expect(read).toThrow();
+    }
+  });
+});

--- a/src/commands/doctor-session-sqlite-readers.ts
+++ b/src/commands/doctor-session-sqlite-readers.ts
@@ -5,9 +5,9 @@ import type { DatabaseSync } from "node:sqlite";
 import { TextDecoder } from "node:util";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
+  classifySessionFileEntry,
   migrateSessionFileEntryToCurrentVersion,
   normalizeLoadedFileEntry,
-  partitionSessionFileEntries,
   type SessionFileEntryMigrationState,
 } from "../agents/sessions/session-manager-codec.js";
 import type { FileEntry } from "../agents/sessions/session-manager-types.js";
@@ -112,13 +112,6 @@ function readTranscriptEventsForImport(
   // through commit and archive. Fingerprints catch non-cooperating external edits.
   const plan = planTranscriptImport(transcriptPath, allowMalformedPrefix);
   assertTranscriptFileUnchanged(transcriptPath, sourceFingerprint);
-  const classificationHeader = {
-    id: sessionId,
-    type: "session",
-    version: plan.sourceVersion,
-    timestamp: "",
-    cwd: "",
-  } satisfies FileEntry;
   // V1 compactions refer to original row indexes. Stable index-derived IDs let
   // the second pass resolve those links without retaining the transcript.
   const idPrefix = createHash("sha256")
@@ -143,6 +136,9 @@ function readTranscriptEventsForImport(
         allowMalformedPrefix,
       )) {
         let event = loadedEvent;
+        if (plan.sourceVersion >= 2) {
+          recordLegacyCompactionTarget(event, plan.compactionTargetIndexes);
+        }
         let recognizedEvent: FileEntry | undefined;
         if (originalIndex === plan.headerIndex) {
           const canonicalHeader = {
@@ -156,15 +152,15 @@ function readTranscriptEventsForImport(
           event = canonicalHeader;
           recognizedEvent = event;
         } else {
-          // Reuse the runtime partition contract one row at a time. The
-          // synthetic header carries the source version without being emitted.
-          recognizedEvent = partitionSessionFileEntries([classificationHeader, event])
-            .fileEntriesByOriginalIndex[1];
+          const classified = classifySessionFileEntry(event, plan.sourceVersion);
+          // Runtime retains normalized opaque rows; import preserves their loaded bytes.
+          recognizedEvent = classified.recognized ? classified.entry : undefined;
         }
 
         if (recognizedEvent) {
           migrateSessionFileEntryToCurrentVersion(recognizedEvent, originalIndex, migrationState);
           if (
+            plan.sourceVersion < 2 &&
             recognizedEvent.type !== "session" &&
             plan.compactionTargetIndexes.has(originalIndex)
           ) {
@@ -240,26 +236,32 @@ function planTranscriptImport(
     if (plan.headerIndex < 0 && isRecord(event) && event.type === "session") {
       plan.headerIndex = originalIndex;
       plan.sourceVersion = typeof event.version === "number" ? event.version : 1;
-    }
-    if (
-      isRecord(event) &&
-      event.type === "compaction" &&
-      Number.isInteger(event.firstKeptEntryIndex) &&
-      Number(event.firstKeptEntryIndex) >= 0
-    ) {
-      const targetIndex = Number(event.firstKeptEntryIndex);
-      if (
-        !plan.compactionTargetIndexes.has(targetIndex) &&
-        plan.compactionTargetIndexes.size >= MAX_LEGACY_COMPACTION_TARGETS
-      ) {
-        throw new TranscriptImportLimitError(
-          `Transcript has more than ${MAX_LEGACY_COMPACTION_TARGETS} legacy compaction targets`,
-        );
+      // Only v1 needs future row indexes before migration. Newer files validate
+      // the same target limit while streaming, before any canonical write.
+      if (plan.sourceVersion >= 2) {
+        return plan;
       }
-      plan.compactionTargetIndexes.add(targetIndex);
     }
+    recordLegacyCompactionTarget(event, plan.compactionTargetIndexes);
   }
   return plan;
+}
+
+function recordLegacyCompactionTarget(event: FileEntry, targets: Set<number>): void {
+  if (
+    isRecord(event) &&
+    event.type === "compaction" &&
+    Number.isInteger(event.firstKeptEntryIndex) &&
+    Number(event.firstKeptEntryIndex) >= 0
+  ) {
+    const targetIndex = Number(event.firstKeptEntryIndex);
+    if (!targets.has(targetIndex) && targets.size >= MAX_LEGACY_COMPACTION_TARGETS) {
+      throw new TranscriptImportLimitError(
+        `Transcript has more than ${MAX_LEGACY_COMPACTION_TARGETS} legacy compaction targets`,
+      );
+    }
+    targets.add(targetIndex);
+  }
 }
 
 function* iterateTranscriptEvents(


### PR DESCRIPTION
Related: #133446

## What Problem This Solves

Large legacy-session upgrades spend time parsing modern-format JSONL histories twice inside the import reader and repeatedly constructing synthetic two-row files just to classify individual events.

## Why This Change Was Made

The reader now stops planning at the first version-2-or-newer header: only version 1 needs original-row compaction targets before migration. Newer files enforce the same 100,000-distinct-target limit during streaming. Runtime loading and migration share a single-row classifier instead of rebuilding a temporary partition for every event.

Version-1/headerless planning, original-index links, header canonicalization, hook normalization, opaque-row preservation, file fingerprints, accepted-row deduplication, and canonical transaction boundaries remain intact. A malformed newer-file tail may reach the disposable staging spool before failing; all source reads and revalidation still finish before any canonical write. There are no schema, SQL, index, configuration, dependency, concurrency, retention, or durable data-format changes.

## User Impact

Less parsing and allocation during session migration, with the same imported data and failure limits. Version-1 histories retain their required planning pass. In isolated Linux measurements, median complete JSONL-to-SQLite import time fell 7.8% for deep histories, 11.1% across many sessions, and 14.5% for repeat imports. Branching results varied between runs, so no reliable branching speedup is claimed.

## Evidence

- 53 focused tests passed: codec compatibility, SessionManager persistence, version-1 IDs/compaction links, import rollback/deduplication/exact handoff/source revalidation, eight reader boundary cases, and four actual Doctor import/revalidation cases.
- New reader coverage protects versions 1/2/3/4, malformed and duplicate headers, recognized versus opaque custom hooks, unknown plugin payloads, malformed messages, target-limit rejection during prefix recovery, and strict/prefix handling of malformed tails.
- Fresh full-priority Codex autoreview of the complete candidate found no actionable issues. Formatting, scoped lint, and completed changed guards pass. The local aggregate typecheck encounters six pre-existing shared-install `tslog` declaration errors in unchanged `src/logging/logger.ts`; the shared dependency tree was not modified. [Clean exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33332960080) passed, including the complete typechecks.
- Isolated Linux Node 24 paired JSONL-to-SQLite benchmarks completed at `609db0dda18918d610df3b5f80a0032ddda3961a` against `16421ec0b0b3f55d00b1ad1d65dff8774bcb1bdb`. Packaged stable-upgrade proof passed on the same commit; details below.
- Production: +44/-37 (net +7). Tests: +105. The remaining production lines preserve the existing target limit in the streaming pass while eliminating the redundant modern-format planning scan; both consumers reuse the same classifier and target validation remains in one helper.

Local commands: `node scripts/run-vitest.mjs src/commands/doctor-session-sqlite-readers.test.ts src/config/sessions/session-accessor.sqlite-import.test.ts src/agents/sessions/session-manager-codec.test.ts src/agents/sessions/session-migrate-id-dedup.test.ts src/agents/sessions/session-manager.test.ts`; `node scripts/run-vitest.mjs src/commands/doctor-session-sqlite.test.ts --testNamePattern 'repairs legacy transcript|aborts import when|aborts a batch|imports and validates legacy'`; `node scripts/check-changed.mjs -- src/agents/sessions/session-manager-codec.ts src/commands/doctor-session-sqlite-readers.ts src/commands/doctor-session-sqlite-readers.test.ts`.


### Complete file-import measurements

[Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/33332846814), Node 24.19.0 / SQLite 3.53.3. Five fresh processes per side per shape; pair order alternates. Both variants share all other source/dependencies and stable synthetic JSONL fixture paths, including version-1 ID derivation. Fixture generation and verification are outside the import timer.

| Shape | Before median | After median | Wall change | CPU change |
| --- | ---: | ---: | ---: | ---: |
| 100k events, one history | 6377.9 ms | 5877.3 ms | -7.8% | -7.1% |
| 100 sessions × 100 events | 769.2 ms | 683.8 ms | -11.1% | -6.9% |
| 100 branching histories | 1110.2 ms | 1150.7 ms | +3.6% | +4.3% |
| 10k existing events, repeat import | 193.0 ms | 165.0 ms | -14.5% | -20.0% |
| 10k version-1 events | 708.2 ms | 693.4 ms | -2.1% | -3.3% |
| 10k version-2 events | 669.0 ms | 624.0 ms | -6.7% | -5.8% |

The initial branching result was 3.6% slower. An eight-pair follow-up with balanced starting order instead measured 4.4% faster wall time and 4.9% less CPU. These small movements are not consistent enough for a branching performance claim; neither result is hidden. Version-1 movement is also modest and retains the required full planning pass.

All 38 paired data digests match across exact transcript bytes, identities, window metadata, active positions, projection watermarks, and FTS. A separate 10k-event trace retains 100,034 SQL calls across the same 34 shapes. Separate before/after Node CPU profiles completed; timing samples were unprofiled.

[ClawSweeper’s final-head review](https://github.com/openclaw/openclaw/pull/133496#issuecomment-5471034829) found no actionable code issues. Its rank-up request—confirm exact-head CI and inspect the latest review—is satisfied. The stored-data heuristic names the migration-reader path; this diff changes no schema, SQL, indexes, durable shape, or canonical write boundary. Data parity is verified above, and the packaged upgrade proof below passed.

### Packaged upgrade and memory

Packaged Docker upgrade from stable `2026.7.1-2` to the exact candidate `609db0dda18918d610df3b5f80a0032ddda3961a` passed with 4,800 synthetic sessions, 1,227,946 events, and 10,000 cron jobs. Five full-state assertions passed, including automatic migration immediately after update and before standalone Doctor. Eight Gateway history samples across two agents returned 600 messages identically after restart. Repeat Doctor completed in 39 seconds against the unchanged 60-second budget; startup took 11 seconds, and health/readiness/status probes each took 1 second. The scenario uses an explicit candidate tarball, manual Gateway restart, and expected synthetic-plugin capability consent; it does not claim unattended update-channel switching. The Testbox command exited successfully in 13m15s. Proof and CPU profiles were collected and checksum-verified, then the worker was stopped.

Median process peak RSS (KiB), before → after: deep 551,500 → 523,824; wide 405,404 → 405,716; branching 414,112 → 414,436; replay 455,672 → 401,376; v1 400,968 → 404,048; v2 409,064 → 397,180. These are process peaks, not isolated importer allocations; no universal memory-reduction claim is made.
