### PR TITLE
fix(release): allow guarded stable Docker recovery

### DIFF
--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -84,7 +84,7 @@ on:
         default: true
         type: boolean
       publish_docker_only:
-        description: Publish Docker only after independently verifying an already-published beta or extended-stable npm package
+        description: Publish Docker only after independently verifying an already-published beta, stable, or extended-stable npm package
         required: true
         default: false
         type: boolean
@@ -239,10 +239,15 @@ jobs:
               echo "publish_docker_only requires publish_openclaw_npm=false." >&2
               exit 1
             fi
-            if [[ "${RELEASE_NPM_DIST_TAG}" != "beta" && "${RELEASE_NPM_DIST_TAG}" != "extended-stable" ]]; then
-              echo "publish_docker_only supports already-published beta or extended-stable releases only." >&2
+            if [[ "${RELEASE_NPM_DIST_TAG}" != "beta" && "${RELEASE_NPM_DIST_TAG}" != "extended-stable" && "${RELEASE_NPM_DIST_TAG}" != "latest" ]]; then
+              echo "publish_docker_only supports already-published beta, stable, or extended-stable releases only." >&2
               exit 1
             fi
+          fi
+          # Before checkout, admit latest only for the regular stable train (patches 1-32).
+          if [[ "${PUBLISH_DOCKER_ONLY}" == "true" && "${RELEASE_NPM_DIST_TAG}" == "latest" && ! "${RELEASE_TAG}" =~ ^v[0-9]{4}\.([1-9]|1[0-2])\.([1-9]|[12][0-9]|3[0-2])(-[1-9][0-9]*)?$ ]]; then
+            echo "Docker-only latest recovery requires a regular stable release tag." >&2
+            exit 1
           fi
           if [[ "${RELEASE_NPM_DIST_TAG}" == "extended-stable" && "${PUBLISH_OPENCLAW_NPM}" == "true" ]]; then
             echo "Extended-stable core npm publication stays on the canonical extended-stable release flow; use publish_docker_only=true only after its registry readback." >&2

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -611,11 +611,11 @@ gh workflow run openclaw-release-publish.yml \
 
 Include `plugin_sdk_api_acknowledgement` only when the npm preflight's Plugin SDK API report contains changes.
 
-If a beta package is already published but its container images are missing,
-do not rerun npm or plugin publication. Reuse the immutable beta tag plus its
+If a beta or regular stable package is already published but its container images are missing,
+do not rerun npm or plugin publication. Reuse the immutable release tag plus its
 successful npm preflight and Full Release Validation evidence through the
 Docker-only recovery path. The workflow rechecks the exact npm version, the
-`beta` selector, and the published tarball digest before building containers:
+selected npm dist-tag, and the published tarball digest before building containers:
 
 ```bash
 gh workflow run openclaw-release-publish.yml \
@@ -628,6 +628,13 @@ gh workflow run openclaw-release-publish.yml \
   -f publish_openclaw_npm=false \
   -f publish_docker_only=true
 ```
+
+For regular stable recovery, use the same command with `tag=vYYYY.M.PATCH` and
+`npm_dist_tag=latest`. Only regular stable tags (patches 1–32, including correction
+suffixes) are accepted for `latest`; extended-stable recovery retains its own
+selector. Recovery builds the canonical versioned images without republishing
+npm packages or plugins, dispatching native releases, or finalizing the GitHub
+release. Existing approval and provenance checks still apply.
 
 Stable publish to the default beta dist-tag:
 
@@ -745,7 +752,7 @@ readback confirms that every exact package and `extended-stable` tag converged.
 - `windows_node_installer_digests`: candidate-approved compact JSON map of the current Windows installer names to their pinned `sha256:` digests; required for stable OpenClaw publish
 - `npm_telegram_run_id`: optional successful `NPM Telegram Beta E2E` run id to include in final release evidence
 - `npm_dist_tag`: npm target tag for the OpenClaw package, one of `alpha`, `beta`, `latest`, or `extended-stable`
-- `publish_docker_only`: beta or extended-stable recovery/closeout path. It requires `publish_openclaw_npm=false`, complete preflight and Full Release Validation evidence, then verifies the exact npm package, selected dist-tag, and tarball digest before invoking Docker publication.
+- `publish_docker_only`: beta, regular stable (`latest`), or extended-stable recovery/closeout path. It requires `publish_openclaw_npm=false`, complete preflight and Full Release Validation evidence, then verifies the exact npm package, selected dist-tag, and tarball digest before invoking Docker publication.
 - `plugin_publish_scope`: defaults to `all-publishable`; use `selected` only for focused plugin-only repair work with `publish_openclaw_npm=false`
 - `plugins`: comma-separated `@openclaw/*` package names when `plugin_publish_scope=selected`
 - `publish_openclaw_npm`: defaults to `true`; set `false` only when using the workflow as a plugin-only repair orchestrator

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1741,10 +1741,12 @@ describe("package acceptance workflow", () => {
     );
   });
 
-  it("allows Docker-only recovery for beta and extended-stable releases", () => {
+  it("allows Docker-only recovery for beta, stable, and extended-stable releases", () => {
     for (const release of [
       { distTag: "beta", tag: "v2026.8.1-beta.2" },
       { distTag: "extended-stable", tag: "v2026.7.33" },
+      { distTag: "latest", tag: "v2026.8.1" },
+      { distTag: "latest", tag: "v2026.12.32-1" },
     ]) {
       const result = runReleasePublishInputValidation({
         PUBLISH_DOCKER_ONLY: "true",
@@ -1755,16 +1757,41 @@ describe("package acceptance workflow", () => {
       expect(result.status, result.stderr).toBe(0);
     }
 
-    const latest = runReleasePublishInputValidation({
-      PUBLISH_DOCKER_ONLY: "true",
-      PUBLISH_OPENCLAW_NPM: "false",
-      RELEASE_NPM_DIST_TAG: "latest",
-      RELEASE_TAG: "v2026.8.1",
-    });
-    expect(latest.status).toBe(1);
-    expect(latest.stderr).toContain(
-      "publish_docker_only supports already-published beta or extended-stable releases only",
-    );
+    for (const tag of [
+      "v2026.8.1-alpha.1",
+      "v2026.8.1-beta.1",
+      "v2026.7.33",
+      "v2026.7.33-1",
+      "v2026.13.1",
+      "v2026.08.1",
+      "v2026.8.01",
+      "v2026.8.1-0",
+    ]) {
+      const result = runReleasePublishInputValidation({
+        PUBLISH_DOCKER_ONLY: "true",
+        PUBLISH_OPENCLAW_NPM: "false",
+        RELEASE_NPM_DIST_TAG: "latest",
+        RELEASE_TAG: tag,
+      });
+      expect(result.status, tag).toBe(1);
+    }
+    const rejectedInputs: Record<string, string>[] = [
+      { PUBLISH_OPENCLAW_NPM: "true" },
+      { PREFLIGHT_RUN_ID: "" },
+      { FULL_RELEASE_VALIDATION_RUN_ID: "", FULL_RELEASE_VALIDATION_RUN_ATTEMPT: "" },
+      { RELEASE_NPM_DIST_TAG: "alpha", RELEASE_TAG: "v2026.8.1-alpha.1" },
+    ];
+    for (const overrides of rejectedInputs) {
+      expect(
+        runReleasePublishInputValidation({
+          PUBLISH_DOCKER_ONLY: "true",
+          PUBLISH_OPENCLAW_NPM: "false",
+          RELEASE_NPM_DIST_TAG: "latest",
+          RELEASE_TAG: "v2026.8.1",
+          ...overrides,
+        }).status,
+      ).toBe(1);
+    }
 
     const workflow = readWorkflow(RELEASE_PUBLISH_WORKFLOW);
     const input = workflow.on?.workflow_dispatch?.inputs?.publish_docker_only as
@@ -1775,7 +1802,7 @@ describe("package acceptance workflow", () => {
       verifyJob,
       "Verify exact npm and selector readback matches preflight bytes",
     );
-    expect(input?.description).toContain("beta or extended-stable");
+    expect(input?.description).toContain("beta, stable, or extended-stable");
     expect(verifyStep.env?.RELEASE_NPM_DIST_TAG).toBe("${{ inputs.npm_dist_tag }}");
     expect(verifyStep.run).toContain('npm view "openclaw@${RELEASE_NPM_DIST_TAG}" version');
     expect(verifyStep.run).not.toContain("npm view openclaw@extended-stable version");


### PR DESCRIPTION
When a stable npm release is already published but container publication is incomplete, the existing Docker-only recovery path rejects `npm_dist_tag=latest`. That leaves regular stable releases without the guarded recovery path already available to beta and extended-stable releases.

Allow `latest` only for regular stable tags: valid month, patches 1–32, and optional positive correction suffix. Keep the existing requirement to disable npm publication, immutable preflight and Full Release Validation evidence, exact npm version and selector readback, tarball digest comparison, protected tooling identity, and Docker approval/provenance checks. Recovery does not dispatch native releases or finalize the GitHub Release. No product code, new workflow input, or preflight compatibility change.

Validation: the executable workflow regression failed before the repair and passes afterward. The other 232 owning workflow tests passed; the sole initial post-fix failure was the input description assertion, corrected and rerun successfully. Both canonical FRV validator test files pass (118 tests), including older trusted producer acceptance and unrelated producer rejection. Formatting and diff checks pass; structured review reports no actionable findings in its default scope. Publication itself is not exercised by tests because it changes public registries.

The changed gate passed structural, format, pin and patch checks. Local root test types stop on existing shared-dependency errors in grammY, tslog and pako; the new test table typing was corrected and its error no longer occurs. Exact hosted type checks are required before landing; the scoped lint wrapper also stops on the unchanged tslog declaration build. Shared dependencies were not modified.

Workflow production delta is +5 lines; tests +27, docs +7. The added admission check is required because input validation executes before checkout and must reject prerelease or extended-stable tags on the new `latest` path.
