### PR TITLE
fix(package): keep postinstall inventory readable

### DIFF
--- a/src/infra/package-dist-inventory.test.ts
+++ b/src/infra/package-dist-inventory.test.ts
@@ -23,9 +23,12 @@ describe("package dist inventory", () => {
       await expect(writePackageDistInventory(packageRoot)).resolves.toEqual([
         "dist/current-BR6xv1a1.js",
       ]);
-      expect(
-        (await fs.stat(path.join(packageRoot, "dist", "postinstall-inventory.json"))).mode & 0o777,
-      ).toBe(0o644);
+      if (process.platform !== "win32") {
+        expect(
+          (await fs.stat(path.join(packageRoot, "dist", "postinstall-inventory.json"))).mode &
+            0o777,
+        ).toBe(0o644);
+      }
       await expect(readPackageDistInventoryIfPresent(packageRoot)).resolves.toStrictEqual([
         "dist/current-BR6xv1a1.js",
       ]);

--- a/src/infra/package-dist-inventory.test.ts
+++ b/src/infra/package-dist-inventory.test.ts
@@ -23,6 +23,9 @@ describe("package dist inventory", () => {
       await expect(writePackageDistInventory(packageRoot)).resolves.toEqual([
         "dist/current-BR6xv1a1.js",
       ]);
+      expect(
+        (await fs.stat(path.join(packageRoot, "dist", "postinstall-inventory.json"))).mode & 0o777,
+      ).toBe(0o644);
       await expect(readPackageDistInventoryIfPresent(packageRoot)).resolves.toStrictEqual([
         "dist/current-BR6xv1a1.js",
       ]);

--- a/src/infra/package-dist-inventory.ts
+++ b/src/infra/package-dist-inventory.ts
@@ -487,7 +487,7 @@ export async function writePackageDistInventory(packageRoot: string): Promise<st
   await assertNoLegacyPluginDependencyStagingDebris(packageRoot);
   const inventory = sortUniqueStrings(await collectPackageDistInventory(packageRoot));
   const inventoryPath = path.join(packageRoot, PACKAGE_DIST_INVENTORY_RELATIVE_PATH);
-  await writeJson(inventoryPath, inventory, { trailingNewline: true });
+  await writeJson(inventoryPath, inventory, { trailingNewline: true, mode: 0o644 });
   return inventory;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where non-root users could receive a package tarball whose postinstall inventory is owner-only, causing package validation to reject the release artifact and preventing installed-package maintenance from reading its inventory.

## Why This Change Was Made

The existing package-inventory producer uses the pinned fs-safe atomic writer, whose secure default file mode is `0600`. The inventory is package metadata rather than private state, so the producer now explicitly writes it as `0644`; all candidate pack flows use that producer.

## User Impact

The packaged inventory remains readable after normal global installation, and candidate package validation no longer rejects its tarball for an owner-only `dist/postinstall-inventory.json` entry.

## Evidence

- Reproduced against the frozen `782a8f7` candidate: the unmodified producer wrote mode `0600`; the fix writes `0644`.
- Focused regression: `node scripts/run-vitest.mjs run src/infra/package-dist-inventory.test.ts` (14 passed). The added assertion fails on the pre-fix producer.
- Focused lint: `node scripts/run-oxlint.mjs --tsconfig tsconfig.json src/infra/package-dist-inventory.ts src/infra/package-dist-inventory.test.ts`.
- Verified the pinned `@openclaw/fs-safe@0.3.0` public types accept `WriteJsonOptions.mode`; its atomic writer applies the final mode after rename.