### PR TITLE
fix(config): avoid repeated health-state startup warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Config startup warnings:** suppress repeated identical health-state write failures for the same database while preserving retries, distinct errors, and warnings after recovery.
 - **Session memory:** capture the departing conversation before manual, daily, or idle resets close its transcript window, preserving recent messages and their trust provenance in memory artifacts.
 - **Secret egress host binding:** bind each shared-store secret to exact HTTPS destination hosts across CLI, Gateway RPC, and Control UI so unbound sentinel substitution fails closed before plaintext egress.
 - **Release validation:** defer beta candidate Parallels smoke to postpublish `release:beta-smoke` by default, keep stable/full prepublish coverage, and bound nested release workflow monitors with explicit job timeouts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Config startup warnings:** suppress repeated identical health-state write failures for the same database while preserving retries, distinct errors, and warnings after recovery.
 - **Session memory:** capture the departing conversation before manual, daily, or idle resets close its transcript window, preserving recent messages and their trust provenance in memory artifacts.
 - **Secret egress host binding:** bind each shared-store secret to exact HTTPS destination hosts across CLI, Gateway RPC, and Control UI so unbound sentinel substitution fails closed before plaintext egress.
 - **Release validation:** defer beta candidate Parallels smoke to postpublish `release:beta-smoke` by default, keep stable/full prepublish coverage, and bound nested release workflow monitors with explicit job timeouts.

--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -264,6 +264,13 @@ When a Gateway runs from a linked source checkout, its status and schema-refusal
 
 Open the database with a build that supports its schema, or point the older build at a separate `OPENCLAW_STATE_DIR`. Do not edit the database to silence the error.
 
+Config reads also save health fingerprints to this database. If that write fails,
+`Config health-state write failed` reports the first failure for that database
+in the current process. Repeated identical failures are suppressed while writes
+continue to be attempted. A different error, or a failure after a successful
+health-state write, is reported again. Suppressing duplicates does not resolve
+the underlying database error.
+
 ### A database is quarantined after integrity verification failed
 
 The background verifier proved the file is corrupt, and every open now fails fast instead of rescanning. Restore the database from a backup or repair it, then run `openclaw doctor --fix` to clear the quarantine record. Doctor reports an explicit error if the quarantine record itself cannot be cleared; rerun it until it reports clean.

--- a/src/config/io.health-state.test.ts
+++ b/src/config/io.health-state.test.ts
@@ -1,0 +1,133 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import {
+  readConfigHealthStateFromStore,
+  writeConfigHealthStateToStore,
+} from "./io.health-state.js";
+import { createConfigIO } from "./io.js";
+
+const tempDirs = createTempDirTracker();
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  tempDirs.cleanup();
+});
+
+function createHealthDeps(warn = vi.fn()) {
+  const home = tempDirs.make("openclaw-health-warning-");
+  return {
+    env: { HOME: home, OPENCLAW_STATE_DIR: home },
+    homedir: () => home,
+    logger: { warn, error: vi.fn() },
+  };
+}
+
+const healthState = {
+  entries: { "/config.json": { lastObservedSuspiciousSignature: "observed" } },
+};
+
+describe("config health-state warnings", () => {
+  it("deduplicates write failures across fresh sync and async config reads", async () => {
+    const deps = createHealthDeps();
+    const configPath = path.join(deps.env.HOME, "openclaw.json");
+    fs.writeFileSync(configPath, JSON.stringify({ gateway: { mode: "local" } }));
+    openOpenClawStateDatabase(deps).db.exec("PRAGMA query_only = ON");
+
+    for (let i = 0; i < 3; i++) {
+      const options = {
+        ...deps,
+        configPath,
+        env: { ...deps.env, OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" },
+      };
+      expect(createConfigIO(options).loadConfig().gateway?.mode).toBe("local");
+      expect((await createConfigIO(options).readConfigFileSnapshot()).valid).toBe(true);
+    }
+
+    expect(deps.logger.warn).toHaveBeenCalledExactlyOnceWith(
+      expect.stringContaining("readonly database"),
+    );
+  });
+
+  it("reports a newer database schema once across failed reads and writes", () => {
+    const deps = createHealthDeps();
+    const databasePath = resolveOpenClawStateSqlitePath(deps.env);
+    fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+    const db = new DatabaseSync(databasePath);
+    db.exec(`PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION + 1}`);
+    db.close();
+
+    for (let i = 0; i < 3; i++) {
+      expect(readConfigHealthStateFromStore(deps)).toEqual({});
+      writeConfigHealthStateToStore(deps, healthState);
+    }
+    expect(deps.logger.warn).toHaveBeenCalledExactlyOnceWith(
+      expect.stringContaining(`uses newer schema version ${OPENCLAW_STATE_SCHEMA_VERSION + 1}`),
+    );
+  });
+
+  it("reports changed failures and re-arms only after a successful health write", () => {
+    const deps = createHealthDeps();
+    const { db } = openOpenClawStateDatabase(deps);
+    db.exec("PRAGMA query_only = ON");
+    writeConfigHealthStateToStore(deps, healthState);
+    readConfigHealthStateFromStore(deps);
+    writeConfigHealthStateToStore(deps, {});
+    writeConfigHealthStateToStore(deps, healthState);
+    expect(deps.logger.warn).toHaveBeenCalledExactlyOnceWith(
+      expect.stringContaining("readonly database"),
+    );
+
+    db.exec(`
+      PRAGMA query_only = OFF;
+      CREATE TRIGGER reject_health_write BEFORE INSERT ON config_health_entries
+      BEGIN SELECT RAISE(FAIL, 'health write rejected'); END;
+    `);
+    writeConfigHealthStateToStore(deps, healthState);
+    writeConfigHealthStateToStore(deps, healthState);
+    expect(deps.logger.warn).toHaveBeenCalledTimes(2);
+    expect(deps.logger.warn).toHaveBeenLastCalledWith(
+      expect.stringContaining("health write rejected"),
+    );
+
+    db.exec("PRAGMA query_only = ON");
+    writeConfigHealthStateToStore(deps, healthState);
+    expect(deps.logger.warn).toHaveBeenCalledTimes(3);
+    expect(deps.logger.warn).toHaveBeenLastCalledWith(expect.stringContaining("readonly database"));
+
+    db.exec("PRAGMA query_only = OFF; DROP TRIGGER reject_health_write");
+    writeConfigHealthStateToStore(deps, healthState);
+    expect(readConfigHealthStateFromStore(deps)).toEqual(healthState);
+    db.exec("PRAGMA query_only = ON");
+    writeConfigHealthStateToStore(deps, healthState);
+    writeConfigHealthStateToStore(deps, healthState);
+    expect(deps.logger.warn).toHaveBeenCalledTimes(4);
+    expect(deps.logger.warn).toHaveBeenLastCalledWith(expect.stringContaining("readonly database"));
+  });
+
+  it("keeps identical failures independent for different state databases", () => {
+    const warn = vi.fn();
+    const stores = [createHealthDeps(warn), createHealthDeps(warn)] as const;
+    for (const deps of stores) {
+      openOpenClawStateDatabase(deps).db.exec("PRAGMA query_only = ON");
+    }
+    for (let i = 0; i < 2; i++) {
+      for (const deps of stores) {
+        writeConfigHealthStateToStore(deps, healthState);
+      }
+    }
+    expect(warn).toHaveBeenCalledTimes(2);
+    openOpenClawStateDatabase(stores[1]).db.exec("PRAGMA query_only = OFF");
+    writeConfigHealthStateToStore(stores[1], healthState);
+    writeConfigHealthStateToStore(stores[0], healthState);
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/config/io.health-state.ts
+++ b/src/config/io.health-state.ts
@@ -6,7 +6,12 @@ import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { OpenClawStateOwnershipError } from "../state/openclaw-state-ownership.js";
+import { setBoundedConfigIoWarningEntry } from "./io.state.js";
+
+// Fresh config snapshots share a database; retain failures until a write recovers.
+const loggedHealthWriteFailures = new Map<string, string>();
 
 export type ConfigHealthFingerprint = {
   hash: string;
@@ -107,6 +112,8 @@ export function writeConfigHealthStateToStore(
   deps: ConfigHealthStateDeps,
   state: ConfigHealthState,
 ): void {
+  const env = resolveConfigHealthStateEnv(deps);
+  const databasePath = resolveOpenClawStateSqlitePath(env);
   try {
     const entries = Object.entries(state.entries ?? {});
     if (entries.length === 0) {
@@ -140,12 +147,18 @@ export function writeConfigHealthStateToStore(
             ),
         );
       },
-      { env: resolveConfigHealthStateEnv(deps) },
+      { env, path: databasePath },
     );
+    loggedHealthWriteFailures.delete(databasePath);
   } catch (error) {
     if (error instanceof OpenClawStateOwnershipError) {
       throw error;
     }
-    deps.logger.warn(`Config health-state write failed: ${formatErrorMessage(error)}`);
+    const message = formatErrorMessage(error);
+    const repeated = loggedHealthWriteFailures.get(databasePath) === message;
+    setBoundedConfigIoWarningEntry(loggedHealthWriteFailures, databasePath, message);
+    if (!repeated) {
+      deps.logger.warn(`Config health-state write failed: ${message}`);
+    }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators installing or starting the Gateway see the same `Config health-state write failed` warning repeatedly when the state database cannot accept writes. A reproduction with six config reads emitted six identical warnings.

## Why This Change Was Made

Config reads observe health fingerprints, and failed health-state reads leave no saved fingerprint, so later snapshots attempt the write again. The shared health-state writer now retains the last reported error per database using the existing bounded warning-state helper. It still attempts every write and clears the recorded failure only after a successful health-state transaction.

This covers synchronous and asynchronous config reads plus recovery and promotion callers through their existing shared writer. The first failure, changed errors, failures after recovery, and failures in separate databases remain visible. Ownership errors still propagate. Database schema compatibility and persistence semantics are unchanged.

Production LOC: +15/-2 (net +13); regression tests: +133/-0. The additional production state is needed to remember failures across fresh config IO instances and reset reporting after recovery; no new cache abstraction, setting, or schema is introduced.

## User Impact

Persistent failures produce one useful warning instead of repeated startup noise. Operators still receive the underlying error and must resolve it, including using a compatible build for a newer database schema. Troubleshooting documentation describes the reporting behavior; this PR supplies the release-note context for release generation.

## Evidence

- Before the fix, the real SQLite regression emitted six identical warnings from six fresh synchronous/asynchronous config reads; after the fix, it emits one.
- Real SQLite coverage also exercises newer-schema refusal, read-only failures, changed errors, successful-write recovery, empty writes, successful reads during a write failure, and independent databases.
- `node scripts/run-vitest.mjs src/config/io.health-state.test.ts src/config/io.state.test.ts src/config/io.observe-recovery.test.ts src/config/io.write-config.test.ts` — 188 tests passed.
- `node scripts/run-vitest.mjs src/config/io.health-state.test.ts` — all four regressions passed after the final fixture typing adjustment.
- `node scripts/check-changed.mjs -- src/config/io.health-state.ts src/config/io.health-state.test.ts docs/reference/database-schemas.md` — passed, including production/test typechecks, lint, formatting, and storage/import guards.
- `git diff --check` — passed.
- Fresh Codex autoreview found no accepted blocking findings in the requested scope.

The evidence exercises the real config IO and SQLite boundaries in isolated temporary state. The reported user's Gateway service and database were not accessed, and a managed-service installation was not rerun.
