### PR TITLE
fix(docker): restore container CLI access with custom host ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       OPENCLAW_CONFIG_PATH: /home/node/.openclaw/openclaw.json
       OPENCLAW_CONFIG_DIR: /home/node/.openclaw
       OPENCLAW_WORKSPACE_DIR: /home/node/.openclaw/workspace
+      # .env controls host publishing; in-container clients use the fixed listener.
+      OPENCLAW_GATEWAY_PORT: "18789"
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN:-}
       OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: ${OPENCLAW_ALLOW_INSECURE_PRIVATE_WS:-}
       # Empty means auto: Bonjour disables itself in detected containers.
@@ -112,6 +114,8 @@ services:
       OPENCLAW_CONFIG_PATH: /home/node/.openclaw/openclaw.json
       OPENCLAW_CONFIG_DIR: /home/node/.openclaw
       OPENCLAW_WORKSPACE_DIR: /home/node/.openclaw/workspace
+      # Shared gateway network namespace: use its listener, not the .env host port.
+      OPENCLAW_GATEWAY_PORT: "18789"
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN:-}
       OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: ${OPENCLAW_ALLOW_INSECURE_PRIVATE_WS:-}
       BROWSER: echo

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -83,6 +83,8 @@ Hosting multiple users? See [Multi-tenant hosting](/gateway/multi-tenant-hosting
     docker compose run --rm openclaw-cli dashboard --no-open
     ```
 
+    With a custom `OPENCLAW_GATEWAY_PORT`, replace port `18789` in the printed URL with your host port before opening it in the browser; keep the rest of the URL intact. Dashboard commands inside either container use the internal listener port. [ClawDock](/install/clawdock) remaps the browser URL automatically.
+
   </Step>
 
   <Step title="Configure channels (optional)">
@@ -194,6 +196,7 @@ Optional variables accepted by `scripts/docker/setup.sh` (and, for the gateway c
 | Variable                                        | Purpose                                                                                                           |
 | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `OPENCLAW_IMAGE`                                | Use a remote image instead of building locally                                                                    |
+| `OPENCLAW_GATEWAY_PORT`                         | Host-published gateway port (default `18789`); both containers keep port `18789` internally                       |
 | `OPENCLAW_IMAGE_APT_PACKAGES`                   | Install extra apt packages during build (space-separated). Legacy alias: `OPENCLAW_DOCKER_APT_PACKAGES`           |
 | `OPENCLAW_IMAGE_PIP_PACKAGES`                   | Install extra Python packages during build (space-separated)                                                      |
 | `OPENCLAW_EXTENSIONS`                           | Compile/package supported selected plugins and install their runtime dependencies (comma- or space-separated ids) |
@@ -216,6 +219,8 @@ Optional variables accepted by `scripts/docker/setup.sh` (and, for the gateway c
 | `OTEL_SERVICE_NAME`                             | Service name used for OpenTelemetry resources                                                                     |
 | `OTEL_SEMCONV_STABILITY_OPT_IN`                 | Opt in to latest experimental GenAI semantic attributes                                                           |
 | `OPENCLAW_OTEL_PRELOADED`                       | Skip starting a second OpenTelemetry SDK when one is preloaded                                                    |
+
+After changing `.env` or Compose environment settings, run `docker compose up -d openclaw-gateway` to recreate the gateway with the new values. `docker compose restart` does not apply environment changes.
 
 The official image ships no Homebrew. During onboarding, OpenClaw hides brew-only skill dependency installers in a Linux container without `brew`; provide those dependencies through a custom image or install manually. Use `OPENCLAW_IMAGE_APT_PACKAGES` for Debian-packaged dependencies and `OPENCLAW_IMAGE_PIP_PACKAGES` for Python dependencies (runs `python3 -m pip install --break-system-packages` at build time, so pin versions and use only indexes you trust).
 

--- a/scripts/e2e/compose-setup.sh
+++ b/scripts/e2e/compose-setup.sh
@@ -220,13 +220,25 @@ export OPENCLAW_CONFIG_DIR="$PROJECT_DIR/config"
 export OPENCLAW_WORKSPACE_DIR="$PROJECT_DIR/config/workspace"
 export OPENCLAW_AUTH_PROFILE_SECRET_DIR="$PROJECT_DIR/auth-profile"
 export OPENCLAW_GATEWAY_TOKEN="$TOKEN"
-export OPENCLAW_GATEWAY_PORT=0
 export OPENCLAW_BRIDGE_PORT=0
 export OPENCLAW_MSTEAMS_PORT=0
 export OPENCLAW_DISABLE_BONJOUR=1
 export OPENCLAW_CURRENT_PACKAGE_TGZ="$PACKAGE_TGZ"
 
 docker_e2e_build_or_reuse "$IMAGE_NAME" compose-setup "$ROOT_DIR/scripts/e2e/Dockerfile" "$ROOT_DIR" functional
+
+# Allocate after image preparation to minimize the release-to-bind race with Compose.
+# Persist the host port like setup.sh so env_file exercises both internal-port overrides.
+OPENCLAW_GATEWAY_PORT="$(node <<'NODE'
+const server = require("node:net").createServer();
+server.listen(0, "0.0.0.0", () => {
+  console.log(server.address().port);
+  server.close();
+});
+NODE
+)"
+export OPENCLAW_GATEWAY_PORT
+printf 'OPENCLAW_GATEWAY_PORT=%s\n' "$OPENCLAW_GATEWAY_PORT" >"$PROJECT_DIR/.env"
 
 assert_dockerfile_healthcheck
 "${COMPOSE[@]}" config --format json >"$PROJECT_DIR/compose-config.json"

--- a/src/docker-setup.e2e.test.ts
+++ b/src/docker-setup.e2e.test.ts
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { parse } from "yaml";
 import {
   cleanupDockerSetupSandboxRoot,
   collectMatchingLines,
@@ -952,20 +953,31 @@ describe("scripts/docker/setup.sh", () => {
     expect(compose.match(/TZ: \$\{OPENCLAW_TZ:-UTC\}/g)).toHaveLength(2);
   });
 
-  it("pins container-side state, workspace, and config dirs on both services so host .env paths cannot leak (#77436)", async () => {
-    const compose = await readFile(join(repoRoot, "docker-compose.yml"), "utf8");
-    // Both gateway and CLI services must override env_file values with the
-    // canonical container paths so host-style paths written to `.env` cannot
-    // reach runtime code inside Linux Docker.
-    expect(compose.match(/OPENCLAW_HOME: \/home\/node$/gm)).toHaveLength(2);
-    expect(compose.match(/OPENCLAW_STATE_DIR: \/home\/node\/\.openclaw$/gm)).toHaveLength(2);
-    expect(
-      compose.match(/OPENCLAW_CONFIG_PATH: \/home\/node\/\.openclaw\/openclaw\.json$/gm),
-    ).toHaveLength(2);
-    expect(compose.match(/OPENCLAW_CONFIG_DIR: \/home\/node\/\.openclaw$/gm)).toHaveLength(2);
-    expect(
-      compose.match(/OPENCLAW_WORKSPACE_DIR: \/home\/node\/\.openclaw\/workspace$/gm),
-    ).toHaveLength(2);
+  it("isolates container paths and listener port from host .env values on both services", async () => {
+    const { services } = parse(await readFile(join(repoRoot, "docker-compose.yml"), "utf8")) as {
+      services: Record<
+        "openclaw-gateway" | "openclaw-cli",
+        {
+          environment: Record<string, string>;
+          command: string[];
+          ports: string[];
+        }
+      >;
+    };
+    const gateway = services["openclaw-gateway"];
+    const listenerPort = gateway.command[gateway.command.indexOf("--port") + 1];
+    expect(listenerPort).toBe("18789");
+    expect(gateway.ports).toContain(`\${OPENCLAW_GATEWAY_PORT:-18789}:${listenerPort}`);
+    for (const name of ["openclaw-gateway", "openclaw-cli"] as const) {
+      expect(services[name].environment, name).toMatchObject({
+        OPENCLAW_HOME: "/home/node",
+        OPENCLAW_STATE_DIR: "/home/node/.openclaw",
+        OPENCLAW_CONFIG_PATH: "/home/node/.openclaw/openclaw.json",
+        OPENCLAW_CONFIG_DIR: "/home/node/.openclaw",
+        OPENCLAW_WORKSPACE_DIR: "/home/node/.openclaw/workspace",
+        OPENCLAW_GATEWAY_PORT: listenerPort,
+      });
+    }
   });
 
   it("Dockerfile ARG OPENCLAW_IMAGE_APT_PACKAGES must not have a default value", async () => {


### PR DESCRIPTION
Closes #133503

Related: [Model Setup readiness repair (#133434)](https://github.com/openclaw/openclaw/pull/133434), where this independent Docker issue was observed during verification. That PR is unchanged.

<details>
<summary>Additional instructions</summary>

This branch is in `openclaw/openclaw` and remains editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where users running Docker Compose with a custom host gateway port would see `Gateway is not running.` from the container-local dashboard command, and failed authenticated health commands, despite a ready Gateway. Both the gateway container and CLI sidecar are affected.

## Why This Change Was Made

Compose already publishes a configurable host port to the fixed internal listener at `18789`, but its `.env` import leaks the host port into both container environments. Pin the existing environment variable to the internal listener in both services, matching their network namespace and the established container-path overrides; keep host publishing, CLI resolution, authentication, and readiness behavior unchanged.

The existing environment-isolation regression now checks the parsed Compose structure rather than counting text matches. The packaged Compose lane now writes a dynamically allocated nonzero host port into its private `.env`, so its existing gateway/sidecar health checks exercise this failure instead of bypassing it with port `0` and no env file.

Production LOC: **+4/-0**, comprising two environment bindings and two comments. Tests: **+26/-14**; E2E support: **+13/-1**; docs: **+5/-0**. Both bindings are necessary at their respective service boundaries; no new config option, dependency, migration, fallback, or runtime code path is introduced.

## User Impact

Container-local dashboard and authenticated health commands work with custom host ports. The host port remains unchanged. Docker docs clarify that browser URLs use the published host port and that Compose containers must be recreated, rather than merely restarted, to apply environment changes.

## Evidence

### Real before/after reproduction

Ran canonical `bash scripts/docker/setup.sh --offline` in a unique disposable Compose project using isolated config, workspace, and auth-profile directories. The frozen runtime image was built from `35ab0416d54068ae9c7ec86a264d45af80466a87`; the affected Compose and CLI port code is identical in the fix base `d434b3dbe0b23af6854084d4fa94cbb9257aaf8a`.

| Observation | Before | After |
| --- | --- | --- |
| Host publishing | `53743:18789` | `53743:18789` |
| Published `/readyz` | ready | ready |
| Gateway and CLI container environment port | `53743` | `18789` |
| Dashboard JSON in both services | exit 1, `Gateway is not running.` | exit 0, `ok: true`, handoff present |
| Authenticated health JSON in both services | exit 1 | exit 0, `ok: true` |

The passing run used no invocation-level port override. Credentials and handoff URLs were not printed. The operator's state and host port `18789` were never used, and the task-owned containers and reproduction state were removed.

### Regression and sibling proof

- `node scripts/run-vitest.mjs src/docker-setup.e2e.test.ts`: **40 passed, 1 failed before the Compose pin; 41 passed afterward**.
- `node scripts/run-vitest.mjs src/docker-setup.e2e.test.ts src/dockerfile.test.ts src/docker-healthcheck.test.ts test/scripts/clawdock-helpers.test.ts test/scripts/docker-e2e-source-roots.test.ts`: **95 tests passed across five files**.
- `bash scripts/e2e/compose-setup.sh`: **passed against a freshly packed candidate**, including both services' correct-token acceptance, wrong-token rejection, `/healthz` and `/readyz`, forced Docker unhealthy state, and recovery. The lane built the candidate runtime/package and its task-owned image. Package SHA-256: `ff7369346b5e9fd906e880472803dd0df68385a3136276a3bd9c8f77a535e6c6`.
- Real `docker compose config --format json`: default, numeric custom, IPv4-bound custom, and IPv6-bound custom host mappings are preserved while both internal environment ports remain `18789`. Default-port verification was config-only; it did not bind that host port.
- Formatting, docs MDX, shell syntax, max-lines/env-budget and assertion-safety ratchets, `git diff --check`, and focused lint passed. The first lint attempt detected changing package-build artifacts; its serial rerun passed without code changes.
- Fresh Codex autoreview: scoped-clean at P0, with no accepted/actionable findings.

The local all-lanes changed gate was not run: Compose is conservatively classified as an unknown/all-lanes surface. Exact-head hosted CI is required before landing.

### Provenance and contract

Raw-parent inspection verifies that [the `.env` import change](https://github.com/openclaw/openclaw/commit/b258c3fc6578f2c8c9b8e5904c0bbc66942ef7ca) introduced this leakage, and stable tag `v2026.5.3` contains it. This fix follows the earlier [host/container port separation (#5110)](https://github.com/openclaw/openclaw/pull/5110) and container-path isolation repairs.

Docker documents that explicit [service environment settings override `env_file`](https://docs.docker.com/reference/compose-file/services/#env_file), and [restart does not apply changed environment settings](https://docs.docker.com/reference/cli/docker/compose/restart/).

### Review follow-through and hosted CI

[Exact-head CI run 33333563167](https://github.com/openclaw/openclaw/actions/runs/33333563167) completed successfully for `22665f3cc7cdc9b16ed1902580c434a8e6842554`; the native CI watcher reported `GREEN` with zero pending checks.

The [ClawSweeper review](https://github.com/openclaw/openclaw/pull/133504#issuecomment-5471099313) found no correctness or security defect and accepted the real Docker proof. Its two pre-merge items are satisfied: exact-head CI is green, and the existing structural regression plus real Docker proof preserve custom host publication while both service environments use `18789`. The corrected environment semantics and container-recreation requirement are documented. No rank-up request remains unaddressed. The 20:40 UTC review refresh also found no actionable defect. Its rank-up move to confirm the exact-head merge gate is satisfied by the successful CI run and native hosted-gate verification.
