### PR TITLE
test(docker): retain self-upgrade failure diagnostics

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/diagnostics.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/diagnostics.mjs
@@ -33,7 +33,7 @@ const logNames = [
   "gateway-restart.log",
 ];
 // Candidate observations select one declared RPC pair, never an arbitrary private path.
-const rpcLogNames = [
+const rpcLogNames = new Set([
   "channels-status-before",
   "wizard-start",
   "wizard-status",
@@ -59,7 +59,7 @@ const rpcLogNames = [
   "target-wizard-replacement-cancel",
   "target-wizard-purged-status",
   "channels-status",
-];
+]);
 const reasons = [
   "missing or unsafe file",
   "input exceeds cap; omitted whole",
@@ -556,7 +556,7 @@ async function capture(artifactRoot, phase, exitStatus, signal = "", observation
         : readOwned(artifactRoot, name, name);
   }
   const rpcName = readOwned(artifactRoot, "diagnostics/last-rpc", "last RPC")?.trim();
-  if (rpcLogNames.includes(rpcName)) {
+  if (rpcLogNames.has(rpcName)) {
     report.lastRpc = {
       name: rpcName,
       stdout: readOwned(artifactRoot, `${rpcName}.json`, "RPC stdout"),
@@ -695,7 +695,7 @@ export function publishDiagnostics(artifactRoot, destination, redactSensitiveTex
     report.logs[name] = sanitize(snapshot.logs?.[name], name);
   }
   if (snapshot.lastRpc !== undefined) {
-    if (rpcLogNames.includes(snapshot.lastRpc?.name)) {
+    if (rpcLogNames.has(snapshot.lastRpc?.name)) {
       report.lastRpc = {
         name: snapshot.lastRpc.name,
         stdout: sanitize(snapshot.lastRpc.stdout, "RPC stdout"),

--- a/scripts/e2e/lib/upgrade-survivor/diagnostics.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/diagnostics.mjs
@@ -32,6 +32,34 @@ const logNames = [
   "systemctl-shim-gateway.log.bootstrap.log",
   "gateway-restart.log",
 ];
+// Candidate observations select one declared RPC pair, never an arbitrary private path.
+const rpcLogNames = [
+  "channels-status-before",
+  "wizard-start",
+  "wizard-status",
+  "wizard-next",
+  "wizard-duplicate-start",
+  "wizard-cancel",
+  "wizard-cancelled-status",
+  "wizard-replacement-start",
+  "wizard-replacement-cancel",
+  "wizard-replacement-status",
+  "update-rpc",
+  "update-status.candidate",
+  "target-wizard-status-start",
+  "target-wizard-status",
+  "target-wizard-status-retained",
+  "target-wizard-status-cancel",
+  "target-wizard-status-purged",
+  "target-wizard-active-start",
+  "target-wizard-next",
+  "target-wizard-duplicate-start",
+  "target-wizard-cancel",
+  "target-wizard-replacement-start",
+  "target-wizard-replacement-cancel",
+  "target-wizard-purged-status",
+  "channels-status",
+];
 const reasons = [
   "missing or unsafe file",
   "input exceeds cap; omitted whole",
@@ -527,6 +555,20 @@ async function capture(artifactRoot, phase, exitStatus, signal = "", observation
         ? readOwned(process.env.OPENCLAW_STATE_DIR, "logs/gateway-restart.log", name)
         : readOwned(artifactRoot, name, name);
   }
+  const rpcName = readOwned(artifactRoot, "diagnostics/last-rpc", "last RPC")?.trim();
+  if (rpcLogNames.includes(rpcName)) {
+    report.lastRpc = {
+      name: rpcName,
+      stdout: readOwned(artifactRoot, `${rpcName}.json`, "RPC stdout"),
+      stderr: readOwned(
+        artifactRoot,
+        `${rpcName === "update-status.candidate" ? "update-status" : rpcName}.err`,
+        "RPC stderr",
+      ),
+    };
+  } else if (rpcName) {
+    omissions["last RPC"] = reasons[3];
+  }
   const stateRoot = process.env.OPENCLAW_STATE_DIR;
   report.pluginIdentity = await pluginIdentities(stateRoot, artifactRoot);
   report.postCore = {
@@ -617,6 +659,9 @@ export function publishDiagnostics(artifactRoot, destination, redactSensitiveTex
   // arbitrary omission text. Redact every permitted free-text field on the host.
   for (const label of [
     ...logNames,
+    "last RPC",
+    "RPC stdout",
+    "RPC stderr",
     "config",
     "service unit",
     "service environment",
@@ -648,6 +693,17 @@ export function publishDiagnostics(artifactRoot, destination, redactSensitiveTex
   }
   for (const name of logNames) {
     report.logs[name] = sanitize(snapshot.logs?.[name], name);
+  }
+  if (snapshot.lastRpc !== undefined) {
+    if (rpcLogNames.includes(snapshot.lastRpc?.name)) {
+      report.lastRpc = {
+        name: snapshot.lastRpc.name,
+        stdout: sanitize(snapshot.lastRpc.stdout, "RPC stdout"),
+        stderr: sanitize(snapshot.lastRpc.stderr, "RPC stderr"),
+      };
+    } else {
+      omissions["last RPC"] = reasons[3];
+    }
   }
   for (const field of ["ExecStart", "WorkingDirectory", "supervisorWorkingDirectory"]) {
     report.service[field] = sanitize(snapshot.service?.[field], field);

--- a/scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh
+++ b/scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh
@@ -116,9 +116,13 @@ export OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG="$SYSTEMCTL_SHIM_DAEM
 gateway_pid=""
 qa_bus_pid=""
 supervisor_monitor_pid=""
+CURRENT_PHASE=prepare-runtime
+FAILURE_SIGNAL=""
+run_completed=0
 
 mkdir -p \
   "$ARTIFACT_DIR" \
+  "$ARTIFACT_DIR/diagnostics" \
   "$HOME" \
   "$OPENCLAW_STATE_DIR" \
   "$OPENCLAW_TEST_WORKSPACE_DIR" \
@@ -149,7 +153,32 @@ cleanup() {
     wait "$qa_bus_pid" >/dev/null 2>&1 || true
   fi
 }
-trap cleanup EXIT
+on_exit() {
+  local exit_status="$1"
+  # Command substitutions may inherit EXIT; only the scenario owner may capture or stop children.
+  [ "$BASH_SUBSHELL" -eq 0 ] || return "$exit_status"
+  trap - EXIT HUP INT TERM
+  set +e
+  if [ "$exit_status" -eq 0 ] && [ "$run_completed" != 1 ]; then
+    exit_status=1
+  fi
+  if [ "$exit_status" -ne 0 ]; then
+    node scripts/e2e/lib/upgrade-survivor/diagnostics.mjs capture \
+      "$ARTIFACT_DIR" "$CURRENT_PHASE" "$exit_status" "$FAILURE_SIGNAL" ||
+      echo "Self-upgrade diagnostics missing; preserving original failure." >&2
+  fi
+  cleanup
+  exit "$exit_status"
+}
+on_signal() {
+  FAILURE_SIGNAL="$1"
+  trap - HUP INT TERM
+  exit "$2"
+}
+trap 'on_exit $?' EXIT
+trap 'on_signal SIGHUP 129' HUP
+trap 'on_signal SIGINT 130' INT
+trap 'on_signal SIGTERM 143' TERM
 
 package_root() {
   printf '%s/lib/node_modules/openclaw\n' "$npm_config_prefix"
@@ -161,6 +190,7 @@ read_installed_version() {
     "$(package_root)"
 }
 
+CURRENT_PHASE=install-source
 echo "Installing declared source package $SOURCE_SPEC"
 openclaw_e2e_maybe_timeout 600s \
   npm install -g --prefix "$npm_config_prefix" "$SOURCE_SPEC" --no-fund --no-audit \
@@ -176,6 +206,7 @@ if ! openclaw --version | grep -Fq "$SOURCE_VERSION"; then
   exit 1
 fi
 
+CURRENT_PHASE=resolve-target
 target_version="$(
   npm view "openclaw@$TARGET_TAG" version --json --prefer-online --cache "$npm_config_cache" |
     node -e '
@@ -200,6 +231,7 @@ TARGET_VERSION="$target_version" TARGET_TAG="$TARGET_TAG" node -e '
   );
 ' "$TARGET_RESOLUTION_JSON"
 
+CURRENT_PHASE=install-plugin
 qa_plugin_source="/tmp/openclaw-update-run-build/dist/extensions/qa-channel"
 qa_plugin_dir="$qa_plugin_source"
 if [ ! -f "$qa_plugin_source/openclaw.plugin.json" ] || [ ! -f "$qa_plugin_source/index.js" ]; then
@@ -258,6 +290,7 @@ node -e '
     fs.copyFileSync(indexPath, process.env.SOURCE_PLUGIN_INDEX_OUT);
   '
 
+CURRENT_PHASE=configure-gateway
 node scripts/e2e/lib/upgrade-survivor/mock-server.mjs \
   --port "$QA_BUS_PORT" \
   --ready-file "$QA_BUS_READY_FILE" \
@@ -367,6 +400,10 @@ gateway_call() {
   local output="$3"
   local error_output="$4"
   local timeout_ms="${5:-30000}"
+  local rpc_name="${output##*/}"
+  # This named QA observation survives command substitutions; the host accepts only closed RPC labels.
+  printf '%s\n' "${rpc_name%.json}" >"$ARTIFACT_DIR/diagnostics/last-rpc" ||
+    echo "Self-upgrade last RPC diagnostic unavailable." >&2
   openclaw gateway call "$method" \
     --url "ws://127.0.0.1:$PORT" \
     --token "test-token" \
@@ -417,6 +454,7 @@ gateway_call channels.status '{"probe":false,"timeoutMs":2000}' \
   "$ARTIFACT_DIR/channels-status-before.json" \
   "$ARTIFACT_DIR/channels-status-before.err"
 
+CURRENT_PHASE=source-wizard
 echo "Exercising authenticated Gateway wizard RPC lifecycle"
 gateway_call wizard.start '{"mode":"local"}' "$WIZARD_START_JSON" "$WIZARD_START_ERR"
 wizard_session_id="$(
@@ -650,6 +688,7 @@ source_gateway_pid="$gateway_pid"
 ) >"$SUPERVISOR_MONITOR_LOG" 2>&1 &
 supervisor_monitor_pid="$!"
 
+CURRENT_PHASE=update-run
 echo "Invoking authenticated Gateway RPC update.run"
 gateway_call update.run "$update_params" "$UPDATE_RPC_JSON" "$UPDATE_RPC_ERR" 1200000
 update_rpc_completed_at_ms="$(node -e 'process.stdout.write(String(Date.now()))')"
@@ -672,6 +711,7 @@ fi
 
 openclaw_e2e_wait_gateway_ready "$gateway_pid" "$SYSTEMCTL_SHIM_DAEMON_LOG" 180 "$PORT"
 
+CURRENT_PHASE=update-status
 deadline=$((SECONDS + 180))
 update_status_candidate="$ARTIFACT_DIR/update-status.candidate.json"
 while [ "$SECONDS" -lt "$deadline" ]; do
@@ -704,6 +744,7 @@ if [ ! -f "$UPDATE_STATUS_JSON" ]; then
   exit 1
 fi
 
+CURRENT_PHASE=target-wizard
 echo "Exercising current target Gateway wizard RPC lifecycle"
 wait_for_target_wizard_start() {
   local output="$1"
@@ -986,6 +1027,7 @@ TARGET_WIZARD_STATUS_START_JSON="$TARGET_WIZARD_STATUS_START_JSON" \
     );
   '
 
+CURRENT_PHASE=post-restart-probes
 post_restart_observed_at_ms="$(node -e 'process.stdout.write(String(Date.now()))')"
 deadline=$((SECONDS + 60))
 while [ "$SECONDS" -lt "$deadline" ]; do
@@ -1026,6 +1068,7 @@ gateway_call channels.status '{"probe":false,"timeoutMs":2000}' \
   "$CHANNELS_STATUS_JSON" \
   "$CHANNELS_STATUS_ERR"
 
+CURRENT_PHASE=assert-plugin-state
 TARGET_PLUGIN_INDEX_OUT="$TARGET_PLUGIN_INDEX_JSON" node --input-type=module -e '
   import fs from "node:fs";
   import { readPluginInstallIndex } from "./scripts/e2e/lib/plugin-index-sqlite.mjs";
@@ -1120,8 +1163,10 @@ SOURCE_VERSION="$SOURCE_VERSION" \
     fs.writeFileSync(process.env.SUMMARY_JSON, `${JSON.stringify(summary, null, 2)}\n`);
   '
 
+CURRENT_PHASE=assert-summary
 node scripts/e2e/lib/upgrade-survivor/assertions.mjs \
   assert-update-run-self-upgrade \
   "$SUMMARY_JSON"
 
 echo "Gateway update.run package self-upgrade passed source=$SOURCE_VERSION target=$target_version installed=$installed_version note=$RESTART_NOTE."
+run_completed=1

--- a/scripts/e2e/update-run-package-self-upgrade-docker.sh
+++ b/scripts/e2e/update-run-package-self-upgrade-docker.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+source "$ROOT_DIR/scripts/lib/upgrade-survivor-diagnostics.sh"
+HARNESS_ROOT_DIR="$ROOT_DIR"
+LANE_ARTIFACT_SUFFIX=update-run-package-self-upgrade
 
 ALLOW_ENV="OPENCLAW_QA_ALLOW_UPDATE_RUN_SELF"
 SOURCE_VERSION="2026.4.26"
@@ -27,8 +30,21 @@ ARTIFACT_DIR="${OPENCLAW_UPDATE_RUN_SELF_UPGRADE_ARTIFACT_DIR:-$ROOT_DIR/.artifa
 QA_CHANNEL_FIXTURE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-update-run-qa-channel.XXXXXX")"
 HISTORICAL_DIST_ARCHIVE="$QA_CHANNEL_FIXTURE_ROOT/historical-dist.tar"
 
+run_completed=0
+diagnostics_ready=0
 cleanup() {
+  local exit_status="$?"
+  trap - EXIT
+  set +e
+  # A joined successful scenario, not teardown, owns the success result.
+  if [ "$exit_status" -eq 0 ] && [ "$run_completed" != 1 ]; then
+    exit_status=1
+  fi
+  if [ "$exit_status" -ne 0 ] && [ "$diagnostics_ready" = 1 ]; then
+    publish_diagnostics || echo "Self-upgrade diagnostics missing; preserving original failure." >&2
+  fi
   rm -rf "$QA_CHANNEL_FIXTURE_ROOT"
+  exit "$exit_status"
 }
 trap cleanup EXIT
 
@@ -110,6 +126,7 @@ prepare_qa_channel_fixture() {
 
 mkdir -p "$ARTIFACT_DIR"
 chmod -R a+rwX "$ARTIFACT_DIR" || true
+prepare_diagnostics_capture
 prepare_qa_channel_fixture
 
 docker_e2e_build_or_reuse \
@@ -171,3 +188,4 @@ fs.writeFileSync(
 );
 NODE
 exec bash scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh'
+run_completed=1

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -44,6 +44,7 @@ ROOT_DIR="$(cd "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$HARNESS_ROOT_DIR}" && pwd)"
 DOCKER_E2E_HARNESS_ROOT_DIR="$HARNESS_ROOT_DIR"
 source "$HARNESS_ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 source "$HARNESS_ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+source "$HARNESS_ROOT_DIR/scripts/lib/upgrade-survivor-diagnostics.sh"
 source "$HARNESS_ROOT_DIR/scripts/lib/openclaw-e2e-instance.sh"
 source "$HARNESS_ROOT_DIR/scripts/e2e/lib/prepublish-plugin-registry.sh"
 
@@ -126,28 +127,6 @@ resolve_lane_artifact_suffix() {
 LANE_ARTIFACT_SUFFIX="$(resolve_lane_artifact_suffix)"
 LANE_ARTIFACT_SUFFIX="${LANE_ARTIFACT_SUFFIX//[^A-Za-z0-9_.-]/_}"
 ARTIFACT_DIR="${OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_DIR:-$ROOT_DIR/.artifacts/upgrade-survivor/$LANE_ARTIFACT_SUFFIX}"
-prepare_diagnostics_capture() {
-  # A previous attempt must never be published as this container's failure.
-  if [ -L "$ARTIFACT_DIR" ] || [ -L "$ARTIFACT_DIR/diagnostics" ] ||
-    ! rm -f "$ARTIFACT_DIR/diagnostics/raw.json" "$ARTIFACT_DIR/diagnostics/post-core.json"; then
-    echo "Upgrade survivor diagnostics missing: private capture setup failed." >&2
-    return 0
-  fi
-  diagnostics_ready=1
-}
-publish_diagnostics() {
-  # This directory is host-owned and is never mounted into the candidate.
-  local log_root="${OPENCLAW_DOCKER_ALL_LOG_DIR:-$ROOT_DIR/.artifacts/docker-tests}"
-  local diagnostic_dir
-  local private_root
-  private_root="$(cd "$ARTIFACT_DIR" && pwd)" || return
-  mkdir -p "$log_root" || return
-  log_root="$(cd "$log_root" && pwd)" || return
-  diagnostic_dir="$(mktemp -d "$log_root/upgrade-survivor-$LANE_ARTIFACT_SUFFIX.XXXXXX")" || return
-  (cd "$HARNESS_ROOT_DIR" && node --import "$HARNESS_ROOT_DIR/scripts/tsx.mjs" \
-    "$HARNESS_ROOT_DIR/scripts/upgrade-survivor-diagnostics.mjs" \
-    publish "$private_root" "$diagnostic_dir")
-}
 DOCKER_RUN_USER_ARGS=()
 OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DOCKER_ARGS=()
 PROBE_ENV_ARGS=(

--- a/scripts/lib/upgrade-survivor-diagnostics.sh
+++ b/scripts/lib/upgrade-survivor-diagnostics.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Host-only snapshot preparation/publication shared by upgrade harnesses.
+prepare_diagnostics_capture() {
+  # A previous attempt must never be published as this container's failure.
+  if [ -L "$ARTIFACT_DIR" ] || [ -L "$ARTIFACT_DIR/diagnostics" ] ||
+    ! rm -f "$ARTIFACT_DIR/diagnostics/raw.json" "$ARTIFACT_DIR/diagnostics/post-core.json" "$ARTIFACT_DIR/diagnostics/last-rpc"; then
+    echo "Upgrade survivor diagnostics missing: private capture setup failed." >&2
+    return 0
+  fi
+  diagnostics_ready=1
+}
+publish_diagnostics() {
+  # This directory is host-owned and is never mounted into the candidate.
+  local log_root="${OPENCLAW_DOCKER_ALL_LOG_DIR:-$ROOT_DIR/.artifacts/docker-tests}"
+  local diagnostic_dir
+  local private_root
+  private_root="$(cd "$ARTIFACT_DIR" && pwd)" || return
+  mkdir -p "$log_root" || return
+  log_root="$(cd "$log_root" && pwd)" || return
+  diagnostic_dir="$(mktemp -d "$log_root/upgrade-survivor-$LANE_ARTIFACT_SUFFIX.XXXXXX")" || return
+  (cd "$HARNESS_ROOT_DIR" && node --import "$HARNESS_ROOT_DIR/scripts/tsx.mjs" \
+    "$HARNESS_ROOT_DIR/scripts/upgrade-survivor-diagnostics.mjs" \
+    publish "$private_root" "$diagnostic_dir")
+}

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -4610,6 +4610,165 @@ exit ${exitCode}
     },
   );
 
+  it.each([
+    ["direct failure", 42, false],
+    ["substitution failure", 42, false],
+    ["assertion after success", 43, false],
+    ["signal after success", 143, false],
+    ["expected negative", 0, false],
+    ["direct failure", 42, true],
+  ] as const)(
+    "retains self-upgrade RPC evidence through the actual launcher: %s (exit %s, blocked publication: %s)",
+    (scenario, expectedStatus, blockedPublication) => {
+      const workDir = tempDirs.make("openclaw-self-upgrade-diagnostics-");
+      const artifacts = join(workDir, "private");
+      const publicRoot = join(workDir, "public");
+      const fixtureRoot = join(workDir, "historical");
+      const pluginRoot = join(fixtureRoot, "dist/extensions/qa-channel");
+      mkdirSync(join(fixtureRoot, "extensions/qa-channel"), { recursive: true });
+      mkdirSync(pluginRoot, { recursive: true });
+      writeFileSync(
+        join(fixtureRoot, "extensions/qa-channel/package.json"),
+        '{"version":"2026.4.25"}',
+      );
+      for (const file of ["package.json", "openclaw.plugin.json", "index.js", "setup-entry.js"]) {
+        writeFileSync(join(pluginRoot, file), "{}");
+      }
+      if (blockedPublication) {
+        writeFileSync(publicRoot, "not a directory");
+      }
+      const source = readFileSync(
+        "scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh",
+        "utf8",
+      );
+      const setup = source.split('\necho "Installing declared source package')[0];
+      const rpcStart = source.indexOf("gateway_call() {");
+      const rpcEnd = source.indexOf("\n}\n", rpcStart);
+      expect(rpcStart).toBeGreaterThan(0);
+      expect(rpcEnd).toBeGreaterThan(rpcStart);
+      const rpc = source.slice(rpcStart, rpcEnd + 3);
+      const call = 'gateway_call wizard.start \'{}\' "$WIZARD_START_JSON" "$WIZARD_START_ERR"';
+      const invocation =
+        scenario === "expected negative"
+          ? `if ${call}; then exit 99; fi\nprintf continued >"$ARTIFACT_DIR/continued"\nrun_completed=1`
+          : scenario === "substitution failure"
+            ? `result="$( ${call} )"`
+            : `${call}\nCURRENT_PHASE=assert-source-wizard\n${scenario === "signal after success" ? 'kill -TERM "$$"' : "exit 43"}`;
+      writeFileSync(
+        join(workDir, "inner-probe.sh"),
+        `${setup}\n${rpc}\n
+cleanup() { printf "cleanup replacement\\n" >"$WIZARD_START_ERR"; }
+CURRENT_PHASE=source-wizard
+${invocation}
+`,
+      );
+      const rpcStatus = scenario.includes("after success") ? 0 : 42;
+      const binDir = join(workDir, "bin");
+      writeExecutables(binDir, {
+        git: `#!/usr/bin/env bash
+case " $* " in
+  *" archive "*) exec tar -C "$TEST_FIXTURE_ROOT" -cf - . ;;
+  *" rev-parse "*) printf 'be8c24633aaa7ef0425ae1178f096ee8dd6226c0\\n' ;;
+esac
+`,
+        corepack: "#!/bin/sh\nexit 0\n",
+        openclaw: `#!/bin/sh
+printf '{"ok":${rpcStatus === 0},"fixture":"named RPC response"}\\n'
+printf 'controlled RPC stderr token=SELF_UPGRADE_SECRET\\n' >&2
+exit ${rpcStatus}
+`,
+        docker: `#!/usr/bin/env bash
+if [ "$1" = run ]; then
+  printf '%s\\n' "$@" >"$TMPDIR/docker-args"
+  cd "$TEST_REPO_ROOT"
+  exec bash "$TMPDIR/inner-probe.sh"
+fi
+exit 0
+`,
+      });
+      const result = spawnSync(
+        "bash",
+        [join(process.cwd(), "scripts/e2e/update-run-package-self-upgrade-docker.sh")],
+        {
+          encoding: "utf8",
+          cwd: workDir,
+          env: {
+            ...process.env,
+            HOME: workDir,
+            TMPDIR: workDir,
+            PATH: `${binDir}:${process.env.PATH ?? ""}`,
+            TEST_REPO_ROOT: process.cwd(),
+            TEST_FIXTURE_ROOT: fixtureRoot,
+            OPENCLAW_SKIP_DOCKER_BUILD: "1",
+            OPENCLAW_QA_ALLOW_UPDATE_RUN_SELF: "1",
+            OPENCLAW_UPDATE_RUN_SELF_UPGRADE_ARTIFACT_DIR: artifacts,
+            OPENCLAW_UPDATE_RUN_SELF_UPGRADE_RUNTIME_ROOT: join(workDir, "runtime"),
+            OPENCLAW_DOCKER_ALL_LOG_DIR: publicRoot,
+          },
+        },
+      );
+      expect(result.status, result.stdout + result.stderr).toBe(expectedStatus);
+      expect(readFileSync(join(artifacts, "wizard-start.err"), "utf8")).toBe(
+        "cleanup replacement\n",
+      );
+      expect(readFileSync(join(workDir, "docker-args"), "utf8")).not.toContain(publicRoot);
+      if (expectedStatus === 0) {
+        expect(readFileSync(join(artifacts, "continued"), "utf8")).toBe("continued");
+        expect(existsSync(publicRoot)).toBe(false);
+        expect(existsSync(join(artifacts, "diagnostics/raw.json"))).toBe(false);
+      } else if (blockedPublication) {
+        expect(result.stderr).toContain("diagnostics missing");
+      } else {
+        expect(existsSync(publicRoot)).toBe(true);
+        const directories = readdirSync(publicRoot);
+        expect(directories).toHaveLength(1);
+        const uploaded = join(publicRoot, directories[0]!);
+        expect(readdirSync(uploaded)).toEqual(["failure.json"]);
+        const text = readFileSync(join(uploaded, "failure.json"), "utf8");
+        expect(text).not.toContain("SELF_UPGRADE_SECRET");
+        expect(text).not.toContain("cleanup replacement");
+        const report = JSON.parse(text);
+        expect(report).toMatchObject({
+          phase: scenario.includes("after success") ? "assert-source-wizard" : "source-wizard",
+          exitStatus: expectedStatus,
+          signal: scenario === "signal after success" ? "SIGTERM" : null,
+          lastRpc: {
+            name: "wizard-start",
+            stdout: expect.stringContaining("named RPC response"),
+            stderr: expect.stringContaining("controlled RPC stderr"),
+          },
+        });
+      }
+    },
+  );
+
+  it.each(["config-recipe", "../config-recipe", "wizard-not-a-declared-rpc"])(
+    "rejects candidate-selected private RPC evidence: %s",
+    (rpcName) => {
+      const workDir = tempDirs.make("openclaw-rpc-diagnostics-contract-");
+      const artifacts = join(workDir, "private");
+      mkdirSync(join(artifacts, "diagnostics"), { recursive: true });
+      writeFileSync(join(artifacts, "diagnostics/last-rpc"), rpcName);
+      writeFileSync(join(artifacts, "config-recipe.json"), "PRIVATE_RPC_SELECTION_SENTINEL");
+      const captured = runSurvivorDiagnostics("capture", artifacts, ["source-wizard", "42"]);
+      expect(captured.status, captured.stderr).toBe(0);
+      const rawPath = join(artifacts, "diagnostics/raw.json");
+      const raw = readFileSync(rawPath, "utf8");
+      expect(raw).not.toContain("PRIVATE_RPC_SELECTION_SENTINEL");
+      const snapshot = JSON.parse(raw);
+      expect(snapshot.lastRpc).toBeUndefined();
+      // Revalidate at publication too: candidate-authored snapshots cannot broaden the contract.
+      snapshot.lastRpc = { name: rpcName, stdout: "PRIVATE_RPC_SELECTION_SENTINEL", stderr: "" };
+      writeFileSync(rawPath, JSON.stringify(snapshot));
+      const uploaded = join(workDir, "public");
+      const published = runSurvivorDiagnostics("publish", artifacts, [uploaded]);
+      expect(published.status, published.stderr).toBe(0);
+      const text = readFileSync(join(uploaded, "failure.json"), "utf8");
+      expect(text).not.toContain("PRIVATE_RPC_SELECTION_SENTINEL");
+      expect(JSON.parse(text).lastRpc).toBeUndefined();
+    },
+  );
+
   it.each([false, true])(
     "publishes only on the host and preserves Docker outcomes (published baseline: %s)",
     (publishedBaseline) => {


### PR DESCRIPTION
## Why

A full release Docker self-upgrade lane exited during the historical wizard RPC checks, before `update.run`. The uploaded artifact contained the lane runner log but not the RPC response or Gateway evidence retained in the scenario's private directory. An unchanged clean-machine replay passed; the original transient failure remains unlocalized. This PR fixes the diagnostic gap, without claiming to fix that unknown product failure.

## Changes

The self-upgrade scenario captures a bounded snapshot before teardown and records its current phase plus the last declared RPC output pair. A shared host helper publishes only a redacted `failure.json` beneath the existing Docker artifact upload root. The private directory is never uploaded or mounted as a public destination. Both capture and publication reject undeclared RPC labels; existing file identity checks, input caps, and host redaction remain authoritative.

The original exit status and signal survive diagnostic failures. Expected negative RPCs still continue through their existing conditionals, command substitutions cannot tear down the owner, and success requires the scenario to finish. The shared host helper replaces the previous inline upgrade-survivor publisher; there is one publication path.

No product behavior, assertion, timeout, retry, release selection, runtime configuration, or database schema changes. This is internal test tooling, so no release changelog entry.

## Validation

All 262 tests in `test/scripts/docker-build-helper.test.ts` passed on Node24. Independent Codex review through P2 returned scoped-clean, with no actionable findings. Shell syntax, changed-file formatting and boundary checks passed. Local root typechecking is blocked by existing shared dependency drift (installed grammy1.45.1 vs locked1.46.0, plus logger types); no changed file had a reported type error. Clean-install PR CI remains required. The script lint gate passed after a mechanical array-membership to Set correction; all nine focused cases passed again and independent review of that exact delta returned scoped-clean. A fresh Linux Testbox ran the unchanged canonical package self-upgrade entrypoint with all five final tooling file hashes verified: historical2026.4.26 → public latest2026.7.1-2, both authenticated wizard lifecycles, update/restart and post-restart probes passed (245.1s command). Seeded task-private stale diagnostic markers were cleared; the final last-RPC marker was channels-status and no failure snapshot/publication was emitted on success. The lease was stopped. Failure publication is proven by the negative harness cases, not inferred from this passing package flow.

The regression runs the actual outer launcher with fake external Git/build/Docker commands, actual inner lifecycle/RPC functions, and real capture/redaction. Tests-only on the original code failed after the correct RPC/assertion/signal exit at the missing published evidence; the expected negative RPC already passed. After repair, all nine focused cases passed, including command substitution, cleanup ordering, redaction, rejected private paths, and a blocked publisher preserving exit42.

Tooling delta: +145/-23 (net +122), including the shared helper move; test delta: +159; product runtime delta: 0. Added tooling is the missing capture/upload lifecycle, phase markers, and bounded last-RPC projection, rather than a second diagnostics implementation.

The ongoing full verification uses its immutable prior tooling revision and is not evidence for this patch. This PR does not publish a version or rerun unrelated release lanes.

## Review follow-through

Read the complete20:33 ClawSweeper review and preceding comments: prior comments were acknowledgements/status, with no unresolved earlier Rank-up moves. The requested exact-head check is now complete: [CI33333631684](https://github.com/openclaw/openclaw/actions/runs/33333631684) and `openclaw/ci-gate` passed on4d6a00cbe4e94aee543bea27fc289369a4c61f4e. Independent P2 reviews have no actionable findings. The automated stored-data warning is inapplicable: these are named QA evidence artifacts; no OpenClaw runtime store, database schema, migration, or persistence semantics change. The fresh [real Docker proof](https://github.com/openclaw/openclaw/actions/runs/33333551203) passed against all five final tooling hashes and its lease is confirmed completed. Any queued rating refresh does not supersede this completed review or required CI.
