### PR TITLE
fix(release): preserve frozen plugin prerelease context

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -1092,6 +1092,7 @@ jobs:
           CHILD_WORKFLOW_KIND: plugin-prerelease
           PHASE: independent
           TARGET_REF: ${{ inputs.ref }}
+          TARGET_CONTEXT_REF: ${{ inputs.target_context_ref }}
           TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
           CHILD_WORKFLOW_REF: ${{ github.ref_name }}
           PARENT_WORKFLOW_SHA: ${{ github.sha }}
@@ -1117,6 +1118,7 @@ jobs:
           CHILD_WORKFLOW_KIND: plugin-prerelease
           PHASE: candidate
           TARGET_REF: ${{ inputs.ref }}
+          TARGET_CONTEXT_REF: ${{ inputs.target_context_ref }}
           TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
           CHILD_WORKFLOW_REF: ${{ github.ref_name }}
           PARENT_WORKFLOW_SHA: ${{ github.sha }}

--- a/test/scripts/openclaw-npm-extended-stable-full-validation-workflow.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-full-validation-workflow.test.ts
@@ -6,7 +6,7 @@ import { parse } from "yaml";
 const fullValidationPath = ".github/workflows/full-release-validation.yml";
 const releaseChecksPath = ".github/workflows/openclaw-release-checks.yml";
 
-type Step = { name?: string; run?: string };
+type Step = { env?: Record<string, string>; name?: string; run?: string };
 type Job = { steps?: Step[] };
 type Workflow = { jobs?: Record<string, Job> };
 
@@ -15,12 +15,20 @@ function workflow(path: string): Workflow {
 }
 
 function stepRun(path: string, jobName: string, stepName: string): string {
-  const job = workflow(path).jobs?.[jobName];
-  const step = job?.steps?.find((candidate) => candidate.name === stepName);
-  if (!step?.run) {
-    throw new Error(`Missing workflow step: ${jobName} / ${stepName}`);
+  const step = workflowStep(path, jobName, stepName);
+  if (!step.run) {
+    throw new Error(`Missing workflow step run: ${jobName} / ${stepName}`);
   }
   return step.run;
+}
+
+function workflowStep(path: string, jobName: string, stepName: string): Step {
+  const job = workflow(path).jobs?.[jobName];
+  const step = job?.steps?.find((candidate) => candidate.name === stepName);
+  if (!step) {
+    throw new Error(`Missing workflow step: ${jobName} / ${stepName}`);
+  }
+  return step;
 }
 
 function runReleaseChecksTrustedRefGuard(workflowRef: string): ReturnType<typeof spawnSync> {
@@ -40,6 +48,21 @@ function runReleaseChecksTrustedRefGuard(workflowRef: string): ReturnType<typeof
 }
 
 describe("extended-stable Full Release Validation workflow", () => {
+  it("passes frozen target context to both plugin prerelease phases", () => {
+    const phases = [
+      {
+        job: "plugin_prerelease_independent",
+        step: "Dispatch plugin prerelease independent phase",
+      },
+      { job: "plugin_prerelease_candidate", step: "Dispatch plugin prerelease candidate phase" },
+    ];
+    for (const phase of phases) {
+      const dispatch = workflowStep(fullValidationPath, phase.job, phase.step);
+      expect(dispatch.env?.TARGET_CONTEXT_REF).toBe("${{ inputs.target_context_ref }}");
+      expect(dispatch.run).toContain('args+=(-f target_context_ref="$TARGET_CONTEXT_REF")');
+    }
+  });
+
   it("lets the exact extended-stable branch reach every child at the target SHA", () => {
     const fullValidation = readFileSync(fullValidationPath, "utf8");
     const childDispatches = [


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where extended-stable Full Release Validation dispatched plugin prerelease phases without the frozen target context, causing the child workflow to lose release-branch provenance.

## Why This Change Was Made

Both independent and candidate plugin prerelease callers now carry the existing target-context input into the shared dispatcher. The immutable SHA remains the execution target; the context ref is provenance only.

## User Impact

Release operators can validate frozen extended-stable targets through plugin prerelease without a main-only policy or inventory being selected accidentally.

## Evidence

- Added a contract covering both plugin prerelease phases; it fails on the prior workflow because `TARGET_CONTEXT_REF` is absent.
- `node scripts/run-vitest.mjs test/scripts/openclaw-npm-extended-stable-full-validation-workflow.test.ts`
- `actionlint .github/workflows/full-release-validation.yml`
- `autoreview --mode branch --base origin/main` — clean, no actionable findings.

The broader changed-file TypeScript lane remains red on pre-existing current-main dependency/API drift outside this diff; the edited workflow test has no TypeScript diagnostic.