### PR TITLE
fix(voice): discover configured provider candidates

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3448,7 +3448,7 @@ src/plugins/bundle-mcp.ts	2
 src/plugins/bundled-channel-config-metadata.ts	4
 src/plugins/bundled-plugin-scan.ts	1
 src/plugins/candidate-install-owner.ts	2
-src/plugins/capability-provider-runtime.ts	16
+src/plugins/capability-provider-runtime.ts	15
 src/plugins/captured-registration.ts	2
 src/plugins/channel-presence-policy.ts	2
 src/plugins/channel-validation.ts	1

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -893,6 +893,10 @@ catalog, API-key auth, and dynamic model resolution.
         Consumers can pass candidate provider IDs as the optional second argument
         to `listRealtimeVoiceProviders(cfg, providerIds)`. Omit the argument for
         ordinary catalog discovery; per-call candidates do not change that catalog.
+        Automatic realtime voice and Voice Call transcription selection uses declared alias config as
+        defaults, with earlier aliases preferred and canonical values taking precedence.
+        An explicitly selected alias still overrides canonical config without inheriting
+        settings from other aliases.
 
         ```typescript
         api.registerRealtimeVoiceProvider({

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -837,6 +837,11 @@ catalog, API-key auth, and dynamic model resolution.
         from the same SDK entrypoint.
       </Tab>
       <Tab title="Realtime transcription">
+        Consumers can pass candidate provider IDs as the optional second argument
+        to `listRealtimeTranscriptionProviders(cfg, providerIds)`. This discovers
+        providers named in plugin-local config without broadening the active
+        registry or bypassing plugin enablement and allow/deny policy.
+
         Prefer `createRealtimeTranscriptionWebSocketSession(...)` - the shared
         helper handles proxy capture, reconnect backoff, close flushing, ready
         handshakes, audio queueing, and close-event diagnostics. Your plugin
@@ -885,6 +890,10 @@ catalog, API-key auth, and dynamic model resolution.
         compatible transcription APIs.
       </Tab>
       <Tab title="Realtime voice">
+        Consumers can pass candidate provider IDs as the optional second argument
+        to `listRealtimeVoiceProviders(cfg, providerIds)`. Omit the argument for
+        ordinary catalog discovery; per-call candidates do not change that catalog.
+
         ```typescript
         api.registerRealtimeVoiceProvider({
           id: "acme-ai",

--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -273,7 +273,7 @@ audio mode per call.
 Current runtime behavior:
 
 - `realtime.enabled` is supported for Twilio and Telnyx.
-- `realtime.provider` is optional. If unset, Voice Call uses the first registered realtime voice provider.
+- `realtime.provider` is optional. If unset, Voice Call selects the first configured realtime voice provider in provider priority order. Providers named in `realtime.providers` are discovered even when another provider is already active; plugin disablement and allow/deny rules still apply.
 - Bundled realtime voice providers: Google Gemini Live (`google`) and OpenAI (`openai`), registered by their provider plugins.
 - Provider-owned raw config lives under `realtime.providers.<providerId>`.
 - Voice Call exposes the built-in `openclaw_end_call` realtime tool on every call. It takes no arguments or call ID; the active voice bridge binds it to the current call.
@@ -455,7 +455,7 @@ authenticated `realtime.enabled` path instead.
 
 Current runtime behavior:
 
-- `streaming.provider` is optional. If unset, Voice Call uses the first registered realtime transcription provider.
+- `streaming.provider` is optional. If unset, Voice Call selects the first configured realtime transcription provider in provider priority order. Providers named in `streaming.providers` are discovered even when another provider is already active; plugin disablement and allow/deny rules still apply.
 - Bundled realtime transcription providers: Deepgram (`deepgram`), ElevenLabs (`elevenlabs`), Mistral (`mistral`), OpenAI (`openai`), and xAI (`xai`), registered by their provider plugins.
 - Provider-owned raw config lives under `streaming.providers.<providerId>`.
 - After Twilio sends an accepted stream `start` message, Voice Call registers the stream immediately, queues inbound media through the transcription provider while the provider connects, and starts the initial greeting only after realtime transcription is ready.

--- a/extensions/voice-call/src/webhook.provider-discovery.test.ts
+++ b/extensions/voice-call/src/webhook.provider-discovery.test.ts
@@ -18,9 +18,13 @@ afterEach(resetPluginRuntimeStateForTest);
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("VoiceCallWebhookServer transcription provider discovery", () => {
-  it.each([undefined, "configured-stt"])(
-    "initializes streaming from configured candidates with explicit selection %s",
-    async (configuredProviderId) => {
+  it.each(
+    ["configured-stt", "configured-stt-alias"].flatMap((configKey) =>
+      [undefined, configKey].map((configuredProviderId) => ({ configKey, configuredProviderId })),
+    ),
+  )(
+    "initializes streaming from $configKey config with explicit selection $configuredProviderId",
+    async ({ configuredProviderId, configKey }) => {
       const root = tempDirs.make("voice-call-provider-discovery-");
       const workspace = path.join(root, "workspace");
       fs.mkdirSync(workspace, { recursive: true });
@@ -31,7 +35,7 @@ describe("VoiceCallWebhookServer transcription provider discovery", () => {
           path.join(pluginDir, "index.cjs"),
           `module.exports = { id: "${id}", register(api) {
             api.registerRealtimeTranscriptionProvider({
-              id: "${id}", label: "${id}",
+              id: "${id}", aliases: ["${id}-alias"], label: "${id}",
               isConfigured: ({ providerConfig }) => providerConfig.ready === true,
               createSession: () => { throw new Error("startup must not start transcription"); },
             });
@@ -86,7 +90,7 @@ describe("VoiceCallWebhookServer transcription provider discovery", () => {
           config.streaming.provider = configuredProviderId;
           config.streaming.providers = {
             "active-stt": { ready: false },
-            "configured-stt": { ready: true },
+            [configKey]: { ready: true },
           };
           const server = new VoiceCallWebhookServer(
             config,

--- a/extensions/voice-call/src/webhook.provider-discovery.test.ts
+++ b/extensions/voice-call/src/webhook.provider-discovery.test.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  createEmptyPluginRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/channel-test-helpers";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { getRealtimeTranscriptionProvider } from "openclaw/plugin-sdk/realtime-transcription";
+import { useAutoCleanupTempDirTracker, withEnvAsync } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it } from "vitest";
+import { CallManager } from "./manager.js";
+import { MockProvider } from "./providers/mock.js";
+import { createVoiceCallBaseConfig } from "./test-fixtures.js";
+import { VoiceCallWebhookServer } from "./webhook.js";
+
+afterEach(resetPluginRuntimeStateForTest);
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("VoiceCallWebhookServer transcription provider discovery", () => {
+  it.each([undefined, "configured-stt"])(
+    "initializes streaming from configured candidates with explicit selection %s",
+    async (configuredProviderId) => {
+      const root = tempDirs.make("voice-call-provider-discovery-");
+      const workspace = path.join(root, "workspace");
+      fs.mkdirSync(workspace, { recursive: true });
+      for (const id of ["active-stt", "configured-stt"]) {
+        const pluginDir = path.join(root, "extensions", id);
+        fs.mkdirSync(pluginDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(pluginDir, "index.cjs"),
+          `module.exports = { id: "${id}", register(api) {
+            api.registerRealtimeTranscriptionProvider({
+              id: "${id}", label: "${id}",
+              isConfigured: ({ providerConfig }) => providerConfig.ready === true,
+              createSession: () => { throw new Error("startup must not start transcription"); },
+            });
+          } };`,
+        );
+        fs.writeFileSync(
+          path.join(pluginDir, "openclaw.plugin.json"),
+          JSON.stringify({
+            id,
+            configSchema: { type: "object", additionalProperties: false, properties: {} },
+            contracts: { realtimeTranscriptionProviders: [id] },
+          }),
+        );
+        fs.writeFileSync(
+          path.join(pluginDir, "package.json"),
+          JSON.stringify({ openclaw: { extensions: ["./index.cjs"] } }),
+        );
+      }
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { workspace } },
+        plugins: {
+          allow: ["active-stt", "configured-stt"],
+          entries: {
+            "active-stt": { enabled: true },
+            "configured-stt": { enabled: true },
+          },
+        },
+      };
+      await withEnvAsync(
+        {
+          OPENCLAW_STATE_DIR: path.join(root, "state"),
+          OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(root, "extensions"),
+          OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+        },
+        async () => {
+          const activeProvider = getRealtimeTranscriptionProvider("active-stt", cfg);
+          if (!activeProvider) {
+            throw new Error("expected the real loader to discover the active fixture provider");
+          }
+          const registry = createEmptyPluginRegistry();
+          registry.realtimeTranscriptionProviders.push({
+            pluginId: "active-stt",
+            pluginName: "active-stt",
+            source: path.join(root, "extensions", "active-stt", "index.cjs"),
+            provider: activeProvider,
+          });
+          setActivePluginRegistry(registry, undefined, "default", workspace);
+          const config = createVoiceCallBaseConfig();
+          config.serve.port = 0;
+          config.streaming.enabled = true;
+          config.streaming.provider = configuredProviderId;
+          config.streaming.providers = {
+            "active-stt": { ready: false },
+            "configured-stt": { ready: true },
+          };
+          const server = new VoiceCallWebhookServer(
+            config,
+            new CallManager(config, path.join(root, "calls")),
+            new MockProvider(),
+            cfg,
+          );
+          try {
+            await server.start();
+            expect(server.getMediaStreamHandler()).not.toBeNull();
+          } finally {
+            await server.stop();
+          }
+        },
+      );
+    },
+  );
+});

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -356,7 +356,7 @@ describe("VoiceCallWebhookServer realtime transcription provider selection", () 
     try {
       await server.start();
       expect(mocks.getRealtimeTranscriptionProvider).not.toHaveBeenCalled();
-      expect(mocks.listRealtimeTranscriptionProviders).toHaveBeenCalledWith(null);
+      expect(mocks.listRealtimeTranscriptionProviders).toHaveBeenCalledWith(null, ["openai"]);
       const mediaStreamHandler = server.getMediaStreamHandler();
       if (!mediaStreamHandler) {
         throw new Error("expected media stream handler");

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -364,7 +364,8 @@ export class VoiceCallWebhookServer {
       cfgForResolve: pluginConfig ?? ({} as OpenClawConfig),
       getConfiguredProvider: (providerId) =>
         getRealtimeTranscriptionProvider(providerId, pluginConfig),
-      listProviders: () => listRealtimeTranscriptionProviders(pluginConfig),
+      listProviders: () =>
+        listRealtimeTranscriptionProviders(pluginConfig, Object.keys(streaming.providers)),
       resolveProviderConfig: ({ provider, cfg, rawConfig }) =>
         provider.resolveConfig?.({ cfg, rawConfig }) ?? rawConfig,
       isProviderConfigured: ({ provider, cfg, providerConfig }) =>

--- a/src/gateway/server-methods/talk.provider-discovery.test.ts
+++ b/src/gateway/server-methods/talk.provider-discovery.test.ts
@@ -1,0 +1,58 @@
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  loadOpenClawPlugins,
+  resetPluginLoaderTestStateForTest,
+} from "../../plugins/loader.test-fixtures.js";
+import { createVoiceProviderFixture } from "../../talk/provider-discovery.test-fixtures.js";
+import { listRealtimeVoiceProviders } from "../../talk/provider-registry.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { callGatewayHandler } from "./skills.test-helpers.js";
+import { talkHandlers } from "./talk.js";
+
+afterEach(resetPluginLoaderTestStateForTest);
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+describe("Talk catalog provider discovery", () => {
+  it("includes configured realtime candidates missing from the active registry", async () => {
+    const { cfg, env } = createVoiceProviderFixture();
+    cfg.plugins = {
+      ...cfg.plugins,
+      entries: {
+        ...cfg.plugins?.entries,
+        "voice-call": {
+          config: { realtime: { providers: { "configured-voice": { ready: true } } } },
+        },
+      },
+    };
+    await withEnvAsync(env, async () => {
+      const registry = loadOpenClawPlugins({ config: cfg, onlyPluginIds: ["active-voice"] });
+      const result = await callGatewayHandler(
+        talkHandlers,
+        "talk.catalog",
+        {},
+        {
+          context: { getRuntimeConfig: () => cfg },
+        },
+      );
+
+      expect(result).toMatchObject({
+        ok: true,
+        error: undefined,
+        response: {
+          realtime: {
+            ready: true,
+            activeProvider: "configured-voice",
+            providers: [
+              { id: "active-voice", configured: false },
+              { id: "configured-voice", configured: true },
+            ],
+          },
+        },
+      });
+      expect(listRealtimeVoiceProviders(cfg)).toEqual(
+        registry.realtimeVoiceProviders.map((entry) => entry.provider),
+      );
+    });
+  });
+});

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -695,98 +695,109 @@ describe("talk.catalog handler", () => {
     expect(catalog.realtime).toEqual(expect.objectContaining({ ready: true }));
   });
 
-  it("reports the runtime-selected automatic providers instead of registry row order", async () => {
-    const transcriptionSlow = {
-      id: "transcription-slow",
-      label: "Transcription Slow",
-      autoSelectOrder: 20,
-      isConfigured: vi.fn(({ providerConfig }) => providerConfig.enabled === true),
-    };
-    const transcriptionFast = {
-      id: "transcription-fast",
-      label: "Transcription Fast",
-      models: ["transcribe-model"],
-      autoSelectOrder: 10,
-      isConfigured: vi.fn(
-        ({ providerConfig }) =>
-          providerConfig.enabled === true && providerConfig.model === "transcribe-model",
-      ),
-    };
-    const realtimeSlow = {
-      id: "realtime-slow",
-      label: "Realtime Slow",
-      autoSelectOrder: 20,
-      isConfigured: vi.fn(({ providerConfig }) => providerConfig.enabled === true),
-      createBridge: vi.fn(),
-    };
-    const realtimeFast = {
-      id: "realtime-fast",
-      label: "Realtime Fast",
-      autoSelectOrder: 10,
-      isConfigured: vi.fn(({ providerConfig }) => providerConfig.enabled === true),
-      createBridge: vi.fn(),
-    };
-    mocks.listRealtimeTranscriptionProviders.mockReturnValue([
-      transcriptionSlow,
-      transcriptionFast,
-    ] as never);
-    mocks.listRealtimeVoiceProviders.mockReturnValue([realtimeSlow, realtimeFast] as never);
-    mocks.resolveConfiguredRealtimeVoiceProvider.mockReturnValue({
-      provider: realtimeFast,
-      providerConfig: { enabled: true },
-    } as never);
+  it.each(["realtime-fast", "realtime-fast-alias"])(
+    "reports the runtime-selected automatic providers and configured rows for %s",
+    async (configKey) => {
+      const transcriptionSlow = {
+        id: "transcription-slow",
+        label: "Transcription Slow",
+        autoSelectOrder: 20,
+        isConfigured: vi.fn(({ providerConfig }) => providerConfig.enabled === true),
+      };
+      const transcriptionFast = {
+        id: "transcription-fast",
+        label: "Transcription Fast",
+        models: ["transcribe-model"],
+        autoSelectOrder: 10,
+        isConfigured: vi.fn(
+          ({ providerConfig }) =>
+            providerConfig.enabled === true && providerConfig.model === "transcribe-model",
+        ),
+      };
+      const realtimeSlow = {
+        id: "realtime-slow",
+        label: "Realtime Slow",
+        autoSelectOrder: 20,
+        isConfigured: vi.fn(({ providerConfig }) => providerConfig.enabled === true),
+        createBridge: vi.fn(),
+      };
+      const realtimeFast = {
+        id: "realtime-fast",
+        aliases: ["realtime-fast-alias"],
+        label: "Realtime Fast",
+        autoSelectOrder: 10,
+        isConfigured: vi.fn(({ providerConfig }) => providerConfig.enabled === true),
+        createBridge: vi.fn(),
+      };
+      mocks.listRealtimeTranscriptionProviders.mockReturnValue([
+        transcriptionSlow,
+        transcriptionFast,
+      ] as never);
+      mocks.listRealtimeVoiceProviders.mockReturnValue([realtimeSlow, realtimeFast] as never);
+      mocks.resolveConfiguredRealtimeVoiceProvider.mockReturnValue({
+        provider: realtimeFast,
+        providerConfig: { enabled: true },
+      } as never);
 
-    const respond = vi.fn();
-    await callTalkHandler("talk.catalog", {
-      params: {},
-      client: { connect: { scopes: ["operator.read"] } },
-      respond,
-      context: {
-        getRuntimeConfig: () =>
-          ({
-            agents: {
-              defaults: {
-                voiceModel: { primary: "transcription-fast/transcribe-model" },
-              },
-            },
-            talk: {
-              realtime: {
-                providers: {
-                  "realtime-slow": { enabled: true },
-                  "realtime-fast": { enabled: true },
+      const respond = vi.fn();
+      await callTalkHandler("talk.catalog", {
+        params: {},
+        client: { connect: { scopes: ["operator.read"] } },
+        respond,
+        context: {
+          getRuntimeConfig: () =>
+            ({
+              agents: {
+                defaults: {
+                  voiceModel: { primary: "transcription-fast/transcribe-model" },
                 },
               },
-            },
-            plugins: {
-              entries: {
-                "voice-call": {
-                  config: {
-                    streaming: {
-                      providers: {
-                        "transcription-slow": { enabled: true },
-                        "transcription-fast": { enabled: true },
+              talk: {
+                realtime: {
+                  providers: {
+                    "realtime-slow": { enabled: true },
+                    [configKey]: { enabled: true },
+                  },
+                },
+              },
+              plugins: {
+                entries: {
+                  "voice-call": {
+                    config: {
+                      streaming: {
+                        providers: {
+                          "transcription-slow": { enabled: true },
+                          "transcription-fast": { enabled: true },
+                        },
                       },
                     },
                   },
                 },
               },
-            },
-          }) as OpenClawConfig,
-      },
-    });
+            }) as OpenClawConfig,
+        },
+      });
 
-    expect(mockCallArg(respond, 0, 1)).toMatchObject({
-      transcription: {
-        ready: true,
-        activeProvider: "transcription-fast",
-        providers: [
-          { id: "transcription-slow", configured: true },
-          { id: "transcription-fast", configured: true },
-        ],
-      },
-      realtime: { ready: true, activeProvider: "realtime-fast" },
-    });
-  });
+      expect(mockCallArg(respond, 0, 1)).toMatchObject({
+        transcription: {
+          ready: true,
+          activeProvider: "transcription-fast",
+          providers: [
+            { id: "transcription-slow", configured: true },
+            { id: "transcription-fast", configured: true },
+          ],
+        },
+        realtime: {
+          ready: true,
+          activeProvider: "realtime-fast",
+          providers: [
+            { id: "realtime-slow", configured: true },
+            { id: "realtime-fast", configured: true },
+          ],
+        },
+      });
+    },
+  );
 
   it("includes a provider-map transcription provider missing from the active registry", async () => {
     const openai = {

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -260,6 +260,7 @@ function buildTalkCatalog(config: OpenClawConfig) {
   );
   const activeTranscriptionProvider = transcriptionSelection.activeProvider;
   const realtimeConfig = buildTalkRealtimeConfig(config);
+  const realtimeProviderIds = Object.keys(realtimeConfig.providers);
   const realtimeSurface =
     realtimeConfig.transport === "gateway-relay" ? "gateway-relay" : "browser-session";
   // Mirror talk.client.create's resolution inputs (agent scope + top-level model
@@ -375,11 +376,12 @@ function buildTalkCatalog(config: OpenClawConfig) {
     realtime: {
       ready: realtimeSelection.ready,
       ...(activeRealtimeProvider ? { activeProvider: activeRealtimeProvider } : {}),
-      providers: listRealtimeVoiceProviders(config).map((provider) => {
+      providers: listRealtimeVoiceProviders(config, realtimeProviderIds).map((provider) => {
         const available = isSecretOwnerAvailable("capability", "talk:realtime");
         const rawConfig = resolveProviderRawConfig({
           providerConfigs: realtimeConfig.providers ?? {},
           providerId: provider.id,
+          providerAliases: provider.aliases,
           configuredProviderId:
             provider.id === activeRealtimeProvider ? realtimeConfig.provider : undefined,
         });
@@ -443,7 +445,9 @@ function buildTalkCatalog(config: OpenClawConfig) {
           entry.transports = [...capabilities.transports];
         }
         if (capabilities?.inputAudioFormats) {
-          entry.inputAudioFormats = capabilities.inputAudioFormats.map((format) => ({ ...format }));
+          entry.inputAudioFormats = capabilities.inputAudioFormats.map((format) => ({
+            ...format,
+          }));
         }
         if (capabilities?.outputAudioFormats) {
           entry.outputAudioFormats = capabilities.outputAudioFormats.map((format) => ({

--- a/src/media-generation/provider-registry.ts
+++ b/src/media-generation/provider-registry.ts
@@ -21,17 +21,20 @@ export function createMediaProviderRegistry<TKey extends MediaProviderRegistryKe
   key: TKey,
   options: { directLookup?: boolean } = {},
 ) {
-  const buildProviderMaps = (cfg?: OpenClawConfig) =>
+  const buildProviderMaps = (cfg?: OpenClawConfig, additionalProviderIds?: readonly string[]) =>
     buildCapabilityProviderMaps(
       // The capability runtime's private provider type uses this same registry mapping.
       capabilityProviderRuntime.resolvePluginCapabilityProviders({
         key,
         cfg,
+        additionalProviderIds,
       }) as MediaProvider<TKey>[],
     );
 
   return {
-    listProviders: (cfg?: OpenClawConfig) => [...buildProviderMaps(cfg).canonical.values()],
+    listProviders: (cfg?: OpenClawConfig, additionalProviderIds?: readonly string[]) => [
+      ...buildProviderMaps(cfg, additionalProviderIds).canonical.values(),
+    ],
     getProvider: (providerId: string | undefined, cfg?: OpenClawConfig) => {
       const normalized = normalizeCapabilityProviderId(providerId);
       if (!normalized) {

--- a/src/plugin-sdk/provider-selection-runtime.test.ts
+++ b/src/plugin-sdk/provider-selection-runtime.test.ts
@@ -113,19 +113,38 @@ describe("plugin-sdk provider-selection-runtime", () => {
     expect(resolveProviderConfig).not.toHaveBeenCalled();
   });
 
-  it("merges canonical and selected provider config", () => {
-    expect(
-      resolveProviderRawConfig({
-        providerId: "canonical",
-        configuredProviderId: "alias",
-        providerConfigs: {
-          canonical: { apiKey: "default", model: "base" },
-          alias: { model: "alias-model" },
-        },
-      }),
-    ).toEqual({
-      apiKey: "default",
-      model: "alias-model",
-    });
-  });
+  it.each([
+    {
+      configuredProviderId: undefined,
+      expected: { apiKey: "default", model: "base", voice: "first", language: "en" },
+    },
+    {
+      configuredProviderId: "alias",
+      expected: { apiKey: "default", model: "alias-model", voice: "first" },
+    },
+    {
+      configuredProviderId: "canonical",
+      expected: { apiKey: "default", model: "base" },
+    },
+    {
+      configuredProviderId: "other-alias",
+      expected: { apiKey: "default", model: "other-model", voice: "second", language: "en" },
+    },
+  ])(
+    "merges provider config with explicit selection $configuredProviderId",
+    ({ configuredProviderId, expected }) => {
+      expect(
+        resolveProviderRawConfig({
+          providerId: "canonical",
+          providerAliases: ["alias", "other-alias"],
+          configuredProviderId,
+          providerConfigs: {
+            canonical: { apiKey: "default", model: "base" },
+            "other-alias": { model: "other-model", voice: "second", language: "en" },
+            alias: { model: "alias-model", voice: "first" },
+          },
+        }),
+      ).toEqual(expected);
+    },
+  );
 });

--- a/src/plugin-sdk/provider-selection-runtime.test.ts
+++ b/src/plugin-sdk/provider-selection-runtime.test.ts
@@ -19,6 +19,18 @@ describe("plugin-sdk provider-selection-runtime", () => {
     { id: "second", autoSelectOrder: 2, configured: true },
   ];
 
+  it("preserves JSON config keys without invoking prototype setters", () => {
+    const rawConfig = JSON.parse('{"__proto__":{"marker":"config-value"},"constructor":"literal"}');
+    const resolved = resolveProviderRawConfig({
+      providerId: "canonical",
+      providerConfigs: { canonical: rawConfig },
+    });
+
+    expect(Object.getPrototypeOf(resolved)).toBe(Object.prototype);
+    expect(Object.hasOwn(resolved, "__proto__")).toBe(true);
+    expect(resolved).toEqual(rawConfig);
+  });
+
   it("selects an explicit provider when it exists", () => {
     const selection = selectConfiguredOrAutoProvider({
       configuredProviderId: " second ",

--- a/src/plugin-sdk/provider-selection-runtime.ts
+++ b/src/plugin-sdk/provider-selection-runtime.ts
@@ -93,12 +93,10 @@ export function resolveProviderRawConfig(params: {
   const providerIds = params.configuredProviderId
     ? [params.providerId, params.configuredProviderId]
     : [...(params.providerAliases ?? []).toReversed(), params.providerId];
-  return providerIds.reduce<Record<string, unknown>>(
-    (config, providerId) => ({
-      ...config,
-      ...readProviderConfig(params.providerConfigs, providerId),
-    }),
-    {},
+  return Object.fromEntries(
+    providerIds.flatMap((providerId) =>
+      Object.entries(readProviderConfig(params.providerConfigs, providerId) ?? {}),
+    ),
   );
 }
 

--- a/src/plugin-sdk/provider-selection-runtime.ts
+++ b/src/plugin-sdk/provider-selection-runtime.ts
@@ -5,6 +5,8 @@ import { normalizeOptionalString } from "../../packages/normalization-core/src/s
 export type AutoSelectableProvider = {
   /** Provider id used for explicit config lookup and selected result metadata. */
   id: string;
+  /** Declared aliases, in preference order, used for automatic config defaults. */
+  aliases?: readonly string[];
   /** Lower values win when no explicit provider is configured. */
   autoSelectOrder?: number;
 };
@@ -75,25 +77,29 @@ export function selectConfiguredOrAutoProvider<TProvider extends AutoSelectableP
   };
 }
 
-/** Merge canonical provider config with selected-provider override config. */
+/** Merge automatic alias defaults, canonical config, and explicit selected overrides. */
 export function resolveProviderRawConfig(params: {
-  /** Canonical provider id whose default config should be read first. */
+  /** Canonical provider id whose config overrides automatic alias defaults. */
   providerId: string;
+  /** Declared aliases used only for automatic selection; earlier aliases take precedence. */
+  providerAliases?: readonly string[];
   /** Optional selected/alias provider id whose config overrides canonical values. */
   configuredProviderId?: string;
   /** Provider config map keyed by canonical and configured provider ids. */
   providerConfigs?: Record<string, Record<string, unknown> | undefined>;
 }): Record<string, unknown> {
-  const canonicalProviderConfig = readProviderConfig(params.providerConfigs, params.providerId);
-  const selectedProviderConfig = readProviderConfig(
-    params.providerConfigs,
-    params.configuredProviderId,
+  // Canonical values beat automatic alias defaults. Explicit selection retains
+  // its canonical-plus-selected merge without inheriting unrelated alias config.
+  const providerIds = params.configuredProviderId
+    ? [params.providerId, params.configuredProviderId]
+    : [...(params.providerAliases ?? []).toReversed(), params.providerId];
+  return providerIds.reduce<Record<string, unknown>>(
+    (config, providerId) => ({
+      ...config,
+      ...readProviderConfig(params.providerConfigs, providerId),
+    }),
+    {},
   );
-
-  return {
-    ...canonicalProviderConfig,
-    ...selectedProviderConfig,
-  };
 }
 
 /** Resolve a configured or auto-selected provider that passes capability config checks. */
@@ -104,7 +110,7 @@ export function resolveConfiguredCapabilityProvider<
 >(params: {
   /** Optional explicit provider id from config or user input. */
   configuredProviderId?: string;
-  /** Provider config map used to merge canonical and selected provider settings. */
+  /** Provider config map used to merge alias defaults, canonical settings, and explicit overrides. */
   providerConfigs?: Record<string, Record<string, unknown> | undefined>;
   /** Current full config used only for configured-state checks. */
   cfg: TFullConfig | undefined;
@@ -121,7 +127,7 @@ export function resolveConfiguredCapabilityProvider<
     provider: TProvider;
     /** Full config passed through for capability-specific config resolution. */
     cfg: TFullConfig;
-    /** Merged raw provider config for canonical and selected provider ids. */
+    /** Raw provider config after alias defaults and canonical/explicit precedence. */
     rawConfig: Record<string, unknown>;
   }) => TConfig;
   isProviderConfigured: (params: {
@@ -168,6 +174,7 @@ export function resolveConfiguredCapabilityProvider<
     }
     const resolution = resolveProviderCandidate({
       ...params,
+      configuredProviderId,
       provider,
     });
     if (resolution.ok) {
@@ -247,6 +254,7 @@ function resolveProviderCandidate<
 }): ResolvedConfiguredProvider<TProvider, TConfig> {
   const rawProviderConfig = resolveProviderRawConfig({
     providerId: params.provider.id,
+    providerAliases: params.provider.aliases,
     configuredProviderId: params.configuredProviderId,
     providerConfigs: params.providerConfigs,
   });

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -886,6 +886,10 @@ describe("resolvePluginCapabilityProviders", () => {
       id: "xai",
       provider: { defaultModel: "shadowed-model" },
     });
+    addCapabilityProvider(loaded, "imageGenerationProviders", {
+      id: "unconfigured-image",
+      provider: { isConfigured: () => false },
+    });
     mocks.loadPluginManifestRegistryCore.mockReturnValue({
       plugins: [
         {
@@ -898,6 +902,11 @@ describe("resolvePluginCapabilityProviders", () => {
           origin: "bundled",
           contracts: { imageGenerationProviders: ["xai"] },
         },
+        {
+          id: "unconfigured-image",
+          origin: "bundled",
+          contracts: { imageGenerationProviders: ["unconfigured-image"] },
+        },
       ] as never,
       diagnostics: [],
     });
@@ -905,16 +914,34 @@ describe("resolvePluginCapabilityProviders", () => {
       params === undefined ? active : loaded,
     );
 
+    const cfg: OpenClawConfig = { plugins: { allow: ["fal", "xai", "unconfigured-image"] } };
     const providers = resolvePluginCapabilityProviders({
       key: "imageGenerationProviders",
-      cfg: { plugins: { allow: ["fal", "xai"] } } as OpenClawConfig,
+      cfg,
     });
 
-    expectResolvedCapabilityProviderIds(providers, ["xai", "fal"]);
+    expectResolvedCapabilityProviderIds(providers, ["xai", "fal", "unconfigured-image"]);
     expect(providers[0]).toBe(active.imageGenerationProviders[0]?.provider);
     expect(providers[1]).toBe(loaded.imageGenerationProviders[0]?.provider);
     expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith();
-    expectActiveRegistryLookup(["fal", "xai"]);
+    expectActiveRegistryLookup(["fal", "unconfigured-image", "xai"]);
+
+    const requestedProviders = resolvePluginCapabilityProviders({
+      key: "imageGenerationProviders",
+      cfg,
+      additionalProviderIds: [" FAL ", "fal"],
+    });
+    expectResolvedCapabilityProviderIds(requestedProviders, ["xai", "fal", "unconfigured-image"]);
+    expect(requestedProviders[0]).toBe(active.imageGenerationProviders[0]?.provider);
+    expect(requestedProviders[1]).toBe(loaded.imageGenerationProviders[0]?.provider);
+    expectResolvedCapabilityProviderIds(
+      resolvePluginCapabilityProviders({
+        key: "imageGenerationProviders",
+        cfg,
+        additionalProviderIds: [],
+      }),
+      ["xai", "fal", "unconfigured-image"],
+    );
   });
 
   it.each([

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -312,10 +312,6 @@ function collectRequestedCapabilityProviderIds(params: {
   }
 }
 
-function nonEmptyRequestedProviders(requested: Set<string> | undefined): Set<string> | undefined {
-  return requested && requested.size > 0 ? requested : undefined;
-}
-
 function shouldScopeCapabilityLoadToRequestedProviders(
   key: CapabilityProviderRegistryKey,
 ): boolean {
@@ -347,17 +343,6 @@ function filterLoadedProvidersForRequestedConfig<K extends CapabilityProviderReg
   requested: Set<string>;
   entries: PluginRegistry[K];
 }): PluginRegistry[K] {
-  if (
-    params.key !== "speechProviders" &&
-    params.key !== "realtimeTranscriptionProviders" &&
-    params.key !== "realtimeVoiceProviders" &&
-    params.key !== "mediaUnderstandingProviders"
-  ) {
-    return [];
-  }
-  if (params.requested.size === 0) {
-    return [];
-  }
   return params.entries.filter((entry) => {
     const provider = entry.provider as { id?: unknown; aliases?: unknown };
     if (typeof provider.id === "string" && params.requested.has(provider.id.toLowerCase())) {
@@ -383,6 +368,7 @@ function resolveRequestedCapabilityPluginIds(params: {
   }
   const runtimePluginIds = new Set<string>();
   const bundledCompatPluginIds = new Set<string>();
+  let hasUnresolvedProvider = false;
   for (const providerId of params.requested) {
     const resolution = resolveCapabilityPluginIds({
       key: params.key,
@@ -390,6 +376,7 @@ function resolveRequestedCapabilityPluginIds(params: {
       providerId,
       pluginMetadataSnapshot: params.pluginMetadataSnapshot,
     });
+    hasUnresolvedProvider ||= resolution.runtimePluginIds.length === 0;
     for (const pluginId of resolution.runtimePluginIds) {
       runtimePluginIds.add(pluginId);
     }
@@ -397,12 +384,17 @@ function resolveRequestedCapabilityPluginIds(params: {
       bundledCompatPluginIds.add(pluginId);
     }
   }
-  return runtimePluginIds.size > 0
-    ? {
+  if (runtimePluginIds.size === 0) {
+    return undefined;
+  }
+  // Manifests can omit runtime aliases. Partial matches must still search all
+  // eligible owners before the caller filters providers to the requested ids.
+  return hasUnresolvedProvider
+    ? resolveCapabilityPluginIds(params)
+    : {
         runtimePluginIds: sortUniqueStrings(runtimePluginIds),
         bundledCompatPluginIds: sortUniqueStrings(bundledCompatPluginIds),
-      }
-    : undefined;
+      };
 }
 
 function filterPolicyAllowedCapabilityProviders<K extends CapabilityProviderRegistryKey>(params: {
@@ -539,6 +531,7 @@ export function resolvePluginCapabilityProvider<K extends CapabilityProviderRegi
 export function resolvePluginCapabilityProviders<K extends CapabilityProviderRegistryKey>(params: {
   key: K;
   cfg?: OpenClawConfig;
+  additionalProviderIds?: readonly string[];
 }): CapabilityProviderFor<K>[] {
   if (shouldSkipCapabilityResolution(params)) {
     return [];
@@ -552,34 +545,25 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
     cfg: params.cfg,
     key: params.key,
   });
-  const missingRequestedProviders =
-    activeProviders.length > 0
-      ? nonEmptyRequestedProviders(
-          collectRequestedCapabilityProviderIds({
-            key: params.key,
-            cfg: params.cfg,
-            includeVoiceModel: true,
-          }),
-        )
-      : undefined;
-  if (activeProviders.length > 0) {
-    if (!missingRequestedProviders && !shouldMergeManifestProvidersWhenActive(params.key)) {
-      return activeProviders.map((entry) => entry.provider) as CapabilityProviderFor<K>[];
-    }
-    if (missingRequestedProviders) {
-      removeActiveProviderIds(missingRequestedProviders, activeProviders);
-      if (missingRequestedProviders.size === 0) {
-        return activeProviders.map((entry) => entry.provider) as CapabilityProviderFor<K>[];
-      }
+  const requested =
+    collectRequestedCapabilityProviderIds({
+      key: params.key,
+      cfg: params.cfg,
+      includeVoiceModel: activeProviders.length > 0,
+    }) ?? new Set<string>();
+  const mergeManifestProviders = shouldMergeManifestProvidersWhenActive(params.key);
+  // Broaden an existing scope; cold and generation catalogs already include all
+  // eligible owners. A caller's default config map must never narrow those catalogs.
+  if (requested.size > 0 || (activeProviders.length > 0 && !mergeManifestProviders)) {
+    for (const providerId of params.additionalProviderIds ?? []) {
+      addStringValue(requested, providerId);
     }
   }
-  const requestedProviders =
-    missingRequestedProviders ??
-    (activeProviders.length === 0
-      ? nonEmptyRequestedProviders(
-          collectRequestedCapabilityProviderIds({ key: params.key, cfg: params.cfg }),
-        )
-      : undefined);
+  removeActiveProviderIds(requested, activeProviders);
+  const requestedProviders = requested.size > 0 ? requested : undefined;
+  if (activeProviders.length > 0 && !requestedProviders && !mergeManifestProviders) {
+    return activeProviders.map((entry) => entry.provider) as CapabilityProviderFor<K>[];
+  }
   const requestedProviderLoadScope =
     requestedProviders && shouldScopeCapabilityLoadToRequestedProviders(params.key)
       ? requestedProviders
@@ -618,22 +602,16 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
     loadOptions,
     requested: requestedProviderFilter,
   });
-  const requestedLoadedProviders = requestedProviderFilter
+  const loadedProviderFilter =
+    activeProviders.length > 0 ? requestedProviders : requestedProviderFilter;
+  const requestedLoadedProviders = loadedProviderFilter
     ? filterLoadedProvidersForRequestedConfig({
         key: params.key,
-        requested: requestedProviderFilter,
+        requested: loadedProviderFilter,
         entries: loadedProviders,
       })
     : loadedProviders;
-  const mergeLoadedProviders =
-    activeProviders.length > 0 && missingRequestedProviders
-      ? filterLoadedProvidersForRequestedConfig({
-          key: params.key,
-          requested: missingRequestedProviders,
-          entries: requestedLoadedProviders,
-        })
-      : requestedLoadedProviders;
-  return mergeCapabilityProviderEntries(activeProviders, mergeLoadedProviders).map(
+  return mergeCapabilityProviderEntries(activeProviders, requestedLoadedProviders).map(
     (entry) => entry.provider as CapabilityProviderFor<K>,
   );
 }

--- a/src/talk/provider-discovery.test-fixtures.ts
+++ b/src/talk/provider-discovery.test-fixtures.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  EMPTY_PLUGIN_SCHEMA,
+  makePluginLoaderTempDir,
+  mkdirSafe,
+  writePlugin,
+} from "../plugins/loader.test-fixtures.js";
+
+export function createVoiceProviderFixture(policy: OpenClawConfig["plugins"] = {}) {
+  const root = fs.realpathSync(makePluginLoaderTempDir());
+  const workspace = path.join(root, "workspace");
+  mkdirSafe(workspace);
+  for (const [id, order] of [
+    ["active-voice", 20],
+    ["configured-voice", 10],
+  ] as const) {
+    const plugin = writePlugin({
+      id,
+      dir: path.join(root, "extensions", id),
+      filename: "index.cjs",
+      body: `module.exports = { id: "${id}", register(api) {
+        api.registerRealtimeVoiceProvider({
+          id: "${id}", aliases: ["${id}-alias"], label: "${id}", autoSelectOrder: ${order},
+          resolveConfig: ({ rawConfig }) => ({ ...rawConfig, resolved: true }),
+          isConfigured: ({ providerConfig }) => providerConfig.ready === true ||
+            process.env.VOICE_DISCOVERY_TEST_CONFIGURED_PROVIDER === "${id}",
+          createBridge: () => { throw new Error("provider discovery must not start media"); },
+        });
+      } };`,
+    });
+    fs.writeFileSync(
+      path.join(plugin.dir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id,
+        configSchema: EMPTY_PLUGIN_SCHEMA,
+        contracts: { realtimeVoiceProviders: [id] },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(plugin.dir, "package.json"),
+      JSON.stringify({ openclaw: { extensions: ["./index.cjs"] } }),
+    );
+  }
+  const cfg: OpenClawConfig = {
+    agents: { defaults: { workspace } },
+    plugins: {
+      allow: ["active-voice", "configured-voice"],
+      ...policy,
+      entries: {
+        "active-voice": { enabled: true },
+        "configured-voice": { enabled: true },
+        ...policy?.entries,
+      },
+    },
+  };
+  return {
+    cfg,
+    env: {
+      OPENCLAW_STATE_DIR: path.join(root, "state"),
+      OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(root, "extensions"),
+      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+    },
+  };
+}

--- a/src/talk/provider-registry.ts
+++ b/src/talk/provider-registry.ts
@@ -20,27 +20,19 @@ export function normalizeRealtimeVoiceProviderId(
   return normalizeCapabilityProviderId(providerId);
 }
 
-// Realtime voice providers are regular plugin capability providers; Talk keeps this small
-// wrapper so gateway and SDK callers do not need to know the manifest capability key.
-function resolveRealtimeVoiceProviderEntries(cfg?: OpenClawConfig): RealtimeVoiceProviderPlugin[] {
-  return resolvePluginCapabilityProviders({
+/**
+ * Lists canonical realtime voice providers, discovering additional candidates through manifest policy.
+ */
+export function listRealtimeVoiceProviders(
+  cfg?: OpenClawConfig,
+  additionalProviderIds?: readonly string[],
+): RealtimeVoiceProviderPlugin[] {
+  const providers = resolvePluginCapabilityProviders({
     key: "realtimeVoiceProviders",
     cfg,
+    additionalProviderIds,
   });
-}
-
-function buildProviderMaps(cfg?: OpenClawConfig): {
-  canonical: Map<string, RealtimeVoiceProviderPlugin>;
-  aliases: Map<string, RealtimeVoiceProviderPlugin>;
-} {
-  return buildCapabilityProviderMaps(resolveRealtimeVoiceProviderEntries(cfg));
-}
-
-/**
- * Lists canonical realtime voice provider plugins in registry order.
- */
-export function listRealtimeVoiceProviders(cfg?: OpenClawConfig): RealtimeVoiceProviderPlugin[] {
-  return [...buildProviderMaps(cfg).canonical.values()];
+  return [...buildCapabilityProviderMaps(providers).canonical.values()];
 }
 
 /**

--- a/src/talk/provider-resolver.discovery.test.ts
+++ b/src/talk/provider-resolver.discovery.test.ts
@@ -1,17 +1,12 @@
-import fs from "node:fs";
-import path from "node:path";
 import { afterAll, afterEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   cleanupPluginLoaderFixturesForTest,
-  EMPTY_PLUGIN_SCHEMA,
   loadOpenClawPlugins,
-  makePluginLoaderTempDir,
-  mkdirSafe,
   resetPluginLoaderTestStateForTest,
-  writePlugin,
 } from "../plugins/loader.test-fixtures.js";
 import { withEnv } from "../test-utils/env.js";
+import { createVoiceProviderFixture } from "./provider-discovery.test-fixtures.js";
 import { listRealtimeVoiceProviders } from "./provider-registry.js";
 import { resolveConfiguredRealtimeVoiceProvider } from "./provider-resolver.js";
 
@@ -19,70 +14,24 @@ function withVoiceProviders(
   run: (cfg: OpenClawConfig) => void,
   policy: OpenClawConfig["plugins"] = {},
 ) {
-  const root = fs.realpathSync(makePluginLoaderTempDir());
-  const workspace = path.join(root, "workspace");
-  mkdirSafe(workspace);
-  for (const [id, order] of [
-    ["active-voice", 20],
-    ["configured-voice", 10],
-  ] as const) {
-    const plugin = writePlugin({
-      id,
-      dir: path.join(root, "extensions", id),
-      filename: "index.cjs",
-      body: `module.exports = { id: "${id}", register(api) {
-        api.registerRealtimeVoiceProvider({
-          id: "${id}", aliases: ["${id}-alias"], label: "${id}", autoSelectOrder: ${order},
-          resolveConfig: ({ rawConfig }) => ({ ...rawConfig, resolved: true }),
-          isConfigured: ({ providerConfig }) => providerConfig.ready === true ||
-            process.env.VOICE_DISCOVERY_TEST_CONFIGURED_PROVIDER === "${id}",
-          createBridge: () => { throw new Error("provider discovery must not start media"); },
-        });
-      } };`,
-    });
-    fs.writeFileSync(
-      path.join(plugin.dir, "openclaw.plugin.json"),
-      JSON.stringify({
-        id,
-        configSchema: EMPTY_PLUGIN_SCHEMA,
-        contracts: { realtimeVoiceProviders: [id] },
-      }),
-    );
-    fs.writeFileSync(
-      path.join(plugin.dir, "package.json"),
-      JSON.stringify({ openclaw: { extensions: ["./index.cjs"] } }),
-    );
-  }
-  const cfg: OpenClawConfig = {
-    agents: { defaults: { workspace } },
-    plugins: {
-      allow: ["active-voice", "configured-voice"],
-      ...policy,
-      entries: {
-        "active-voice": { enabled: true },
-        "configured-voice": { enabled: true },
-        ...policy?.entries,
-      },
-    },
-  };
-  return withEnv(
-    {
-      OPENCLAW_STATE_DIR: path.join(root, "state"),
-      OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(root, "extensions"),
-      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
-      OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
-    },
-    () => run(cfg),
-  );
+  const { cfg, env } = createVoiceProviderFixture(policy);
+  return withEnv(env, () => run(cfg));
 }
 
 afterEach(resetPluginLoaderTestStateForTest);
 afterAll(cleanupPluginLoaderFixturesForTest);
 
 describe("realtime voice provider discovery", () => {
-  it.each([false, true])(
-    "discovers configured candidates when the active provider is configured=%s",
-    (activeReady) => {
+  it.each(
+    [false, true].flatMap((activeReady) =>
+      ["configured-voice", "configured-voice-alias"].map((configKey) => ({
+        activeReady,
+        configKey,
+      })),
+    ),
+  )(
+    "discovers $configKey config when the active provider is configured=$activeReady",
+    ({ activeReady, configKey }) => {
       withVoiceProviders((cfg) => {
         const registry = loadOpenClawPlugins({ config: cfg, onlyPluginIds: ["active-voice"] });
         expect(registry.realtimeVoiceProviders.map((entry) => entry.provider.id)).toEqual([
@@ -93,7 +42,7 @@ describe("realtime voice provider discovery", () => {
           cfg,
           providerConfigs: {
             "active-voice": { ready: activeReady },
-            "configured-voice": { ready: true },
+            [configKey]: { ready: true },
           },
         });
 
@@ -107,14 +56,21 @@ describe("realtime voice provider discovery", () => {
     },
   );
 
-  it.each([undefined, "configured-voice"])(
-    "selects a configured provider from a cold registry with explicit selection %s",
-    (configuredProviderId) => {
+  it.each(
+    ["configured-voice", "configured-voice-alias"].flatMap((configKey) =>
+      [undefined, " ", configKey].map((configuredProviderId) => ({
+        configKey,
+        configuredProviderId,
+      })),
+    ),
+  )(
+    "selects cold $configKey config with explicit selection $configuredProviderId",
+    ({ configuredProviderId, configKey }) => {
       withVoiceProviders((cfg) => {
         const result = resolveConfiguredRealtimeVoiceProvider({
           cfg,
           configuredProviderId,
-          providerConfigs: { "configured-voice": { ready: true } },
+          providerConfigs: { [configKey]: { ready: true } },
         });
         expect(result.provider.id).toBe("configured-voice");
       });

--- a/src/talk/provider-resolver.discovery.test.ts
+++ b/src/talk/provider-resolver.discovery.test.ts
@@ -1,0 +1,209 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  EMPTY_PLUGIN_SCHEMA,
+  loadOpenClawPlugins,
+  makePluginLoaderTempDir,
+  mkdirSafe,
+  resetPluginLoaderTestStateForTest,
+  writePlugin,
+} from "../plugins/loader.test-fixtures.js";
+import { withEnv } from "../test-utils/env.js";
+import { listRealtimeVoiceProviders } from "./provider-registry.js";
+import { resolveConfiguredRealtimeVoiceProvider } from "./provider-resolver.js";
+
+function withVoiceProviders(
+  run: (cfg: OpenClawConfig) => void,
+  policy: OpenClawConfig["plugins"] = {},
+) {
+  const root = fs.realpathSync(makePluginLoaderTempDir());
+  const workspace = path.join(root, "workspace");
+  mkdirSafe(workspace);
+  for (const [id, order] of [
+    ["active-voice", 20],
+    ["configured-voice", 10],
+  ] as const) {
+    const plugin = writePlugin({
+      id,
+      dir: path.join(root, "extensions", id),
+      filename: "index.cjs",
+      body: `module.exports = { id: "${id}", register(api) {
+        api.registerRealtimeVoiceProvider({
+          id: "${id}", aliases: ["${id}-alias"], label: "${id}", autoSelectOrder: ${order},
+          resolveConfig: ({ rawConfig }) => ({ ...rawConfig, resolved: true }),
+          isConfigured: ({ providerConfig }) => providerConfig.ready === true ||
+            process.env.VOICE_DISCOVERY_TEST_CONFIGURED_PROVIDER === "${id}",
+          createBridge: () => { throw new Error("provider discovery must not start media"); },
+        });
+      } };`,
+    });
+    fs.writeFileSync(
+      path.join(plugin.dir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id,
+        configSchema: EMPTY_PLUGIN_SCHEMA,
+        contracts: { realtimeVoiceProviders: [id] },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(plugin.dir, "package.json"),
+      JSON.stringify({ openclaw: { extensions: ["./index.cjs"] } }),
+    );
+  }
+  const cfg: OpenClawConfig = {
+    agents: { defaults: { workspace } },
+    plugins: {
+      allow: ["active-voice", "configured-voice"],
+      ...policy,
+      entries: {
+        "active-voice": { enabled: true },
+        "configured-voice": { enabled: true },
+        ...policy?.entries,
+      },
+    },
+  };
+  return withEnv(
+    {
+      OPENCLAW_STATE_DIR: path.join(root, "state"),
+      OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(root, "extensions"),
+      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+    },
+    () => run(cfg),
+  );
+}
+
+afterEach(resetPluginLoaderTestStateForTest);
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+describe("realtime voice provider discovery", () => {
+  it.each([false, true])(
+    "discovers configured candidates when the active provider is configured=%s",
+    (activeReady) => {
+      withVoiceProviders((cfg) => {
+        const registry = loadOpenClawPlugins({ config: cfg, onlyPluginIds: ["active-voice"] });
+        expect(registry.realtimeVoiceProviders.map((entry) => entry.provider.id)).toEqual([
+          "active-voice",
+        ]);
+
+        const result = resolveConfiguredRealtimeVoiceProvider({
+          cfg,
+          providerConfigs: {
+            "active-voice": { ready: activeReady },
+            "configured-voice": { ready: true },
+          },
+        });
+
+        expect(result.provider.id).toBe("configured-voice");
+        expect(result.providerConfig).toEqual({ ready: true, resolved: true });
+        // Per-call discovery must not broaden catalogs or replace active objects.
+        expect(listRealtimeVoiceProviders(cfg)).toEqual(
+          registry.realtimeVoiceProviders.map((entry) => entry.provider),
+        );
+      });
+    },
+  );
+
+  it.each([undefined, "configured-voice"])(
+    "selects a configured provider from a cold registry with explicit selection %s",
+    (configuredProviderId) => {
+      withVoiceProviders((cfg) => {
+        const result = resolveConfiguredRealtimeVoiceProvider({
+          cfg,
+          configuredProviderId,
+          providerConfigs: { "configured-voice": { ready: true } },
+        });
+        expect(result.provider.id).toBe("configured-voice");
+      });
+    },
+  );
+
+  it("keeps environment-configured providers eligible with an unconfigured default map", () => {
+    withEnv({ VOICE_DISCOVERY_TEST_CONFIGURED_PROVIDER: "active-voice" }, () => {
+      withVoiceProviders((cfg) => {
+        const result = resolveConfiguredRealtimeVoiceProvider({
+          cfg,
+          providerConfigs: { "configured-voice": { ready: false } },
+        });
+        expect(result.provider.id).toBe("active-voice");
+      });
+    });
+  });
+
+  it("extends a cold config-derived discovery scope with per-call candidates", () => {
+    withVoiceProviders((cfg) => {
+      cfg.talk = { realtime: { provider: "active-voice" } };
+      const result = resolveConfiguredRealtimeVoiceProvider({
+        cfg,
+        providerConfigs: { "configured-voice": { ready: true } },
+      });
+      expect(result.provider.id).toBe("configured-voice");
+    });
+  });
+
+  it.each([
+    ["active-voice", "configured-voice-alias"],
+    ["configured-voice-alias", "active-voice"],
+  ])("discovers mixed canonical and runtime-alias candidates %s + %s", (scopeId, candidateId) => {
+    withEnv({ VOICE_DISCOVERY_TEST_CONFIGURED_PROVIDER: "configured-voice" }, () => {
+      withVoiceProviders((cfg) => {
+        cfg.talk = { realtime: { provider: scopeId } };
+        const result = resolveConfiguredRealtimeVoiceProvider({
+          cfg,
+          providerConfigs: { [candidateId]: {} },
+        });
+        expect(result.provider.id).toBe("configured-voice");
+      });
+    });
+  });
+
+  it.each([
+    { label: "disabled", policy: { entries: { "configured-voice": { enabled: false } } } },
+    { label: "denied", policy: { deny: ["configured-voice"] } },
+    { label: "not allowed", policy: { allow: ["active-voice"] } },
+  ])("does not auto-select a $label configured owner", ({ policy }) => {
+    withVoiceProviders((cfg) => {
+      loadOpenClawPlugins({ config: cfg, onlyPluginIds: ["active-voice"] });
+      const result = resolveConfiguredRealtimeVoiceProvider({
+        cfg,
+        providerConfigs: {
+          "active-voice": { ready: true },
+          "configured-voice": { ready: true },
+        },
+      });
+      expect(result.provider.id).toBe("active-voice");
+    }, policy);
+  });
+
+  it("does not discover configured owners when plugins are globally disabled", () => {
+    withVoiceProviders(
+      (cfg) => {
+        expect(() =>
+          resolveConfiguredRealtimeVoiceProvider({
+            cfg,
+            providerConfigs: { "configured-voice": { ready: true } },
+          }),
+        ).toThrow("No realtime voice provider registered");
+      },
+      { enabled: false },
+    );
+  });
+
+  it("keeps a caller-supplied provider list authoritative", () => {
+    withVoiceProviders((cfg) => {
+      const registry = loadOpenClawPlugins({ config: cfg, onlyPluginIds: ["active-voice"] });
+      const result = resolveConfiguredRealtimeVoiceProvider({
+        cfg,
+        providers: registry.realtimeVoiceProviders.map((entry) => entry.provider),
+        providerConfigs: {
+          "active-voice": { ready: true },
+          "configured-voice": { ready: true },
+        },
+      });
+      expect(result.provider.id).toBe("active-voice");
+    });
+  });
+});

--- a/src/talk/provider-resolver.ts
+++ b/src/talk/provider-resolver.ts
@@ -100,7 +100,6 @@ export function resolveConfiguredRealtimeVoiceProvider(
   params: ResolveConfiguredRealtimeVoiceProviderParams,
 ): ResolvedRealtimeVoiceProvider {
   const cfgForResolve = params.cfgForResolve ?? params.cfg ?? ({} as OpenClawConfig);
-  const providers = params.providers ?? listRealtimeVoiceProviders(params.cfg);
   const resolution = resolveConfiguredCapabilityProvider({
     configuredProviderId: params.configuredProviderId,
     providerConfigs: params.providerConfigs,
@@ -109,7 +108,9 @@ export function resolveConfiguredRealtimeVoiceProvider(
     getConfiguredProvider: (providerId) =>
       params.providers?.find((entry) => entry.id === providerId) ??
       getRealtimeVoiceProvider(providerId, params.cfg),
-    listProviders: () => providers,
+    listProviders: () =>
+      params.providers ??
+      listRealtimeVoiceProviders(params.cfg, Object.keys(params.providerConfigs ?? {})),
     isProviderAvailable: params.isProviderAvailable
       ? ({ provider }) => params.isProviderAvailable?.(provider) === true
       : undefined,


### PR DESCRIPTION
Supersedes #126662.

## What Problem This Solves

Voice Call could ignore a configured realtime voice or transcription provider when an unrelated provider was already active. Automatic transcription startup could leave the media stream handler absent even though the webhook started successfully. Alias-backed settings could then be dropped after discovery, and the Talk catalog could omit the runtime-selected provider or incorrectly label it unconfigured.

## Why This Change Was Made

The existing capability loader accepts supplemental candidate provider IDs from callers. Realtime selection, Voice Call transcription startup, and Talk catalog enumeration pass their provider-map keys through that same discovery owner. Manifest ownership, plugin enablement and allow/deny policy still control loading; active object identity, provider priority, and caller-supplied provider lists remain authoritative. Core does not parse Voice Call configuration or duplicate alias metadata.

Cold and generation catalogs remain broad. Supplemental candidates extend an existing scope without excluding environment-configured providers. Partial canonical/runtime-alias manifest matches search eligible owners before filtering requested providers. Redundant Talk registry wrappers and duplicate collection/filtering paths are removed.

The shared raw-config resolver uses the selected provider's declared aliases as automatic defaults, with earlier aliases preferred and canonical fields taking precedence. Explicit selection retains canonical-plus-selected-key precedence without inheriting other aliases. The existing normalized selection ID is carried into candidate resolution, so whitespace-only input consistently means automatic selection. Talk catalog rows use the same alias settings and candidates as runtime selection. The separate whole-record lookup used by Talk transcription keeps its existing contract.

## Evidence

Failure-first reproductions cover the original active-registry discovery failure, actual public-SDK loader and loopback webhook startup, cold/generation catalog narrowing, mixed canonical/runtime aliases, map-backed alias configuration loss, catalog row readiness/enumeration, and whitespace-only automatic selection. Focused runs cover 187 distinct tests across the real-loader, SDK selector, webhook and Talk handler paths after accounting for overlapping runs. Coverage includes priority, active/cold/explicit/automatic selection, disable/deny/allow/global disable, ordinary catalog isolation and authoritative supplied lists.

The full build passed at the preceding commit eb2823863c2a855e8fd488b4c337057f96ea267f, including all 148 public SDK exports and unchanged UI budgets. The built Voice Call import profile passed (1/1), followed by all 168 then-current targeted tests. The follow-up changes existing raw-field merging and catalog arguments; it introduces no production import, lazy-loading, or build-tool changes. Completed local checks, independent review, and final exact-head hosted CI are recorded below. Cancelled intermediate checks are not counted as passes.

Production: +79/-94, net -15 across seven files. Tests/support: +571/-101, net +470 across eight files, including a moved shared fixture and reindented existing catalog setup. Docs: +15/-2. Assertion-baseline bookkeeping: +1/-1. No new operator config, environment variable, manifest metadata, SDK subpath, dependency, Gateway protocol, schema, or persisted format. Existing provider list methods gain optional candidate IDs; existing selector inputs gain optional alias metadata. Omitting these preserves the existing API contract.

The startup proof uses the real plugin loader, CallManager and localhost webhook, with synthetic providers that reject starting external media sessions. The catalog proof invokes the real Talk RPC handler and loader. These prove the changed discovery/configuration/startup boundaries; no authenticated telephone call is claimed, and no carrier or provider API contract changes.

## Review Follow-through

ClawSweeper's alias-configuration finding and Rank-up move are addressed at the canonical raw-config owner, with map-backed realtime and transcription regressions. Follow-up independent review also found the connected catalog enumeration and normalized-selection defects; both have failing-before reproductions and owner-level repairs. The additive SDK contract is accepted in the maintainer decision linked below; no shipped API is removed or narrowed.

https://github.com/openclaw/openclaw/pull/133507#issuecomment-5471102566

Reworks @itkdm's report and proposed repair. Contributor credit: bujidao <152999386+itkdm@users.noreply.github.com>.

Final head: `3a599424993b67840b1d6b97425975daaca129a4`. The whole-repair Codex review and final two-file lint cleanup review are both scoped-clean through P2. CI on the prior head caught an accumulating-spread lint rule; the merge now uses ordered entries with the same precedence and safe own-JSON-key semantics. All 29 focused selector/real-loader tests passed, including the added JSON-key regression, and canonical type-aware lint passed. Completed local guards through plugin boundaries passed; the interrupted broad local run is not claimed as complete. Exact-head hosted CI completed successfully and supplied the final full validation before landing.

Landed as `723a2fba82a3b7146e87105e1e102e68931134ca` after [exact-head CI33336977365](https://github.com/openclaw/openclaw/actions/runs/33336977365) completed successfully. The latest exact-head ClawSweeper review has no actionable finding; its Rank-up moves were rechecked and satisfied. Native prepare/merge verified the CI gate without bypass. Contributor co-author credit is present in the landed commit.
