### PR TITLE
fix(release): support frozen target entrypoints

### DIFF
--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -706,9 +706,12 @@ jobs:
               package_args=(
                 --source-dir "$source_dir"
                 --output-dir /output
-                --pack-json /output/pack.json
+                --output-name candidate.tgz
               )
-              if [[ "$ALLOW_UNRELEASED_CHANGELOG" == "true" ]]; then
+              # The TypeScript implementation is the capability boundary for this
+              # newer option; frozen Node-native packers intentionally omit it.
+              if [[ "$ALLOW_UNRELEASED_CHANGELOG" == "true" ]] && \
+                [[ -f scripts/package-openclaw-for-docker.mts ]]; then
                 package_args+=(--allow-unreleased-changelog)
               fi
               node scripts/package-openclaw-for-docker.mjs "${package_args[@]}"

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1065,6 +1065,7 @@ jobs:
             command: pnpm test:ui:e2e --shard=4/4
           - name: Agent plugin Gateway
             command: pnpm test:e2e:agent-plugin-gateway
+            target_script: test:e2e:agent-plugin-gateway
     env:
       OPENCLAW_BUILD_PRIVATE_QA: "1"
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
@@ -1099,7 +1100,17 @@ jobs:
         env:
           OPENCLAW_E2E_WORKERS: "2"
           OPENCLAW_E2E_USE_PREBUILT_DIST: "1"
-        run: ${{ matrix.command }}
+          TARGET_REQUIRED_SCRIPT: ${{ matrix.target_script || '' }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$TARGET_REQUIRED_SCRIPT" ]] && ! node -e '
+            const packageJson = JSON.parse(require("node:fs").readFileSync("package.json", "utf8"));
+            if (typeof packageJson.scripts?.[process.argv[1]] !== "string") process.exit(1);
+          ' "$TARGET_REQUIRED_SCRIPT"; then
+            echo "::notice::Skipping $TARGET_REQUIRED_SCRIPT: selected target does not provide this newer repo E2E capability."
+            exit 0
+          fi
+          ${{ matrix.command }}
 
   validate_special_e2e:
     needs: validate_selected_ref

--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -808,7 +808,7 @@ jobs:
           fi
 
           mkdir -p "$SOURCE_PERF_DIR/mock-hello"
-          if ! node -e "const fs=require('node:fs'); const scripts=require('./package.json').scripts||{}; process.exit(scripts['test:gateway:cpu-scenarios'] && scripts['test:extensions:memory'] && scripts.openclaw && fs.existsSync('openclaw.mjs') && fs.existsSync('scripts/profile-extension-memory.mts') ? 0 : 1)"; then
+          if ! node -e "const fs=require('node:fs'); const scripts=require('./package.json').scripts||{}; const extensionProbe=['scripts/profile-extension-memory.mts','scripts/profile-extension-memory.mjs'].some((entry)=>fs.existsSync(entry)); process.exit(scripts['test:gateway:cpu-scenarios'] && scripts['test:extensions:memory'] && scripts.openclaw && fs.existsSync('openclaw.mjs') && extensionProbe ? 0 : 1)"; then
             cat > "$SOURCE_PERF_DIR/index.md" <<EOF
           # OpenClaw Source Performance
 
@@ -820,15 +820,19 @@ jobs:
 
           - Tested ref: ${TESTED_REF}
           - Tested SHA: ${TESTED_SHA}
-          - Required scripts: test:gateway:cpu-scenarios, test:extensions:memory, openclaw, openclaw.mjs, scripts/profile-extension-memory.mts
+          - Required scripts: test:gateway:cpu-scenarios, test:extensions:memory, openclaw, openclaw.mjs, scripts/profile-extension-memory.{mts,mjs}
           EOF
             cat "$SOURCE_PERF_DIR/index.md" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
-          # target_ref may predate the dedicated profile; preserve the historical full build there.
-          if node --import tsx -e "import('./scripts/build-all.mts').then((module) => process.exit(module.BUILD_ALL_PROFILES?.sourcePerformance ? 0 : 1)).catch(() => process.exit(1))"; then
+          # Run the narrower build only when the candidate advertises the profile.
+          if [[ -f scripts/build-all.mts ]] && \
+            node --import tsx scripts/build-all.mts --help | grep -Fxq '  sourcePerformance'; then
             OPENCLAW_BUILD_PRIVATE_QA=1 node --import tsx scripts/build-all.mts sourcePerformance
+          elif [[ -f scripts/build-all.mjs ]] && \
+            node scripts/build-all.mjs --help | grep -Fxq '  sourcePerformance'; then
+            OPENCLAW_BUILD_PRIVATE_QA=1 node scripts/build-all.mjs sourcePerformance
           else
             pnpm build
           fi

--- a/scripts/e2e/lib/fixtures/workspace.mjs
+++ b/scripts/e2e/lib/fixtures/workspace.mjs
@@ -31,7 +31,6 @@ function writeAgentsDeleteConfig() {
   writeJson(path.join(stateDir, "openclaw.json"), {
     agents: {
       ownership: "explicit",
-      defaults: { heartbeat: { agentId: "main" } },
       entries: {
         main: { workspace: sharedWorkspace },
         ops: { workspace: sharedWorkspace },

--- a/scripts/install-smoke-candidate-payload.mts
+++ b/scripts/install-smoke-candidate-payload.mts
@@ -135,6 +135,13 @@ import tarfile
 mode, archive_path, member_name = sys.argv[1:]
 with tarfile.open(archive_path, "r:gz") as archive:
     members = archive.getmembers()
+    if mode == "package-metadata":
+        files = [member for member in members if member.isfile()]
+        print(json.dumps({
+            "entryCount": len(files),
+            "unpackedSize": sum(member.size for member in files),
+        }))
+        sys.exit(0)
     if mode == "repo-file":
         requested_name = member_name
         roots = {
@@ -169,40 +176,6 @@ with tarfile.open(archive_path, "r:gz") as archive:
   return result.stdout;
 }
 
-function readPackageVersionFromPackJson(value: unknown): {
-  filename: string;
-  normalized: unknown[];
-  version: string;
-} {
-  if (!Array.isArray(value) || value.length === 0) {
-    throw new Error("candidate pack metadata must contain at least one package result");
-  }
-  const last = value.at(-1);
-  if (!last || typeof last !== "object" || Array.isArray(last)) {
-    throw new Error("candidate pack metadata must end with a package result");
-  }
-  const record = last as Record<string, unknown>;
-  const filename = record.filename;
-  if (
-    typeof filename !== "string" ||
-    filename !== path.basename(filename) ||
-    filename !== path.win32.basename(filename) ||
-    !/^openclaw-[A-Za-z0-9._-]+\.tgz$/u.test(filename)
-  ) {
-    throw new Error("candidate pack metadata contains an unsafe tarball filename");
-  }
-  const version = assertVersion(record.version, "candidate pack version");
-  return {
-    filename,
-    normalized: value.map((entry, index) =>
-      index === value.length - 1 && entry && typeof entry === "object" && !Array.isArray(entry)
-        ? { ...entry, filename: "candidate.tgz" }
-        : entry,
-    ),
-    version,
-  };
-}
-
 function readPackageJsonFromTarball(tarballPath: string): Record<string, unknown> {
   const raw = runPythonTarReader(["member", tarballPath, "package/package.json"]);
   try {
@@ -213,6 +186,27 @@ function readPackageJsonFromTarball(tarballPath: string): Record<string, unknown
     return value as Record<string, unknown>;
   } catch (error) {
     throw new Error("candidate package tarball has invalid package/package.json", { cause: error });
+  }
+}
+
+function readPackageTarballMetadata(tarballPath: string): {
+  entryCount: number;
+  unpackedSize: number;
+} {
+  const raw = runPythonTarReader(["package-metadata", tarballPath, ""]);
+  try {
+    const value = JSON.parse(raw.toString("utf8")) as Record<string, unknown>;
+    if (
+      !Number.isSafeInteger(value.entryCount) ||
+      value.entryCount < 1 ||
+      !Number.isSafeInteger(value.unpackedSize) ||
+      value.unpackedSize < 0
+    ) {
+      throw new Error("package metadata has invalid archive sizes");
+    }
+    return { entryCount: value.entryCount, unpackedSize: value.unpackedSize };
+  } catch (error) {
+    throw new Error("candidate package tarball metadata is invalid", { cause: error });
   }
 }
 
@@ -231,19 +225,15 @@ export async function sealInstallSmokeCandidatePayload(
     throw new Error("candidate payload output directory must be empty");
   }
 
-  const packJsonPath = path.join(options.packageDir, "pack.json");
-  const pack = readPackageVersionFromPackJson(
-    await readJson(packJsonPath, "candidate pack metadata"),
-  );
-  const sourceTarballPath = path.join(options.packageDir, pack.filename);
+  const sourceTarballPath = path.join(options.packageDir, "candidate.tgz");
   await assertRegularFile(sourceTarballPath, "candidate package tarball");
   const packageJson = readPackageJsonFromTarball(sourceTarballPath);
   if (packageJson.name !== "openclaw") {
     throw new Error("candidate package tarball must contain the openclaw package");
   }
-  if (packageJson.version !== pack.version) {
-    throw new Error("candidate package tarball version does not match pack metadata");
-  }
+  const packageVersion = assertVersion(packageJson.version, "candidate package version");
+  const packageMetadata = readPackageTarballMetadata(sourceTarballPath);
+  const packageSize = (await fs.stat(sourceTarballPath)).size;
 
   // Re-read installers from the immutable source archive after candidate execution. Candidate
   // build hooks never get a writable handle to the sealed scripts consumed by privileged jobs.
@@ -260,7 +250,20 @@ export async function sealInstallSmokeCandidatePayload(
   await fs.copyFile(sourceTarballPath, path.join(options.outputDir, "candidate.tgz"));
   await writeExclusive(
     path.join(options.outputDir, "candidate-pack.json"),
-    `${JSON.stringify(pack.normalized, null, 2)}\n`,
+    `${JSON.stringify(
+      [
+        {
+          entryCount: packageMetadata.entryCount,
+          filename: "candidate.tgz",
+          name: "openclaw",
+          size: packageSize,
+          unpackedSize: packageMetadata.unpackedSize,
+          version: packageVersion,
+        },
+      ],
+      null,
+      2,
+    )}\n`,
   );
   await writeExclusive(path.join(options.outputDir, "install.sh"), installScript);
   await writeExclusive(path.join(options.outputDir, "install-cli.sh"), cliInstallScript);
@@ -273,7 +276,7 @@ export async function sealInstallSmokeCandidatePayload(
   const manifest: InstallSmokeCandidatePayloadManifest = {
     ...identity,
     files,
-    packageVersion: pack.version,
+    packageVersion,
     schema: SCHEMA,
     sourceArchiveSha256: await sha256File(options.archivePath),
   };

--- a/scripts/lib/live-docker-stage.sh
+++ b/scripts/lib/live-docker-stage.sh
@@ -100,6 +100,24 @@ openclaw_live_prepare_cli_backend() {
   fi
 }
 
+openclaw_live_run_staged_script() {
+  local stem="${1:?staged script stem required}"
+  shift
+
+  # Frozen candidates may retain the Node-native .mjs runner while current
+  # sources ship its .mts successor. Run the candidate's available entrypoint.
+  if [ -f "${stem}.mts" ]; then
+    node --import tsx "${stem}.mts" "$@"
+    return
+  fi
+  if [ -f "${stem}.mjs" ]; then
+    node "${stem}.mjs" "$@"
+    return
+  fi
+  echo "staged OpenClaw script entrypoint not found: ${stem}.{mts,mjs}" >&2
+  return 1
+}
+
 openclaw_live_stage_source_tree() {
   local dest_dir="${1:?destination directory required}"
   local stage_mode="${OPENCLAW_LIVE_DOCKER_SOURCE_STAGE_MODE:-copy}"

--- a/scripts/test-live-acp-bind-docker.sh
+++ b/scripts/test-live-acp-bind-docker.sh
@@ -210,7 +210,7 @@ openclaw_live_stage_state_dir "$tmp_dir/.openclaw-state"
 openclaw_live_prepare_staged_config
 cd "$tmp_dir"
 export OPENCLAW_LIVE_ACP_BIND_AGENT_COMMAND="${OPENCLAW_LIVE_ACP_BIND_AGENT_COMMAND:-}"
-node --import tsx scripts/test-live.mts -- ${OPENCLAW_LIVE_ACP_BIND_TEST_FILES:-src/gateway/gateway-acp-bind.live.test.ts}
+openclaw_live_run_staged_script scripts/test-live -- ${OPENCLAW_LIVE_ACP_BIND_TEST_FILES:-src/gateway/gateway-acp-bind.live.test.ts}
 EOF
 
 openclaw_live_acp_bind_append_build_extension acpx

--- a/scripts/test-live-cli-backend-docker.sh
+++ b/scripts/test-live-cli-backend-docker.sh
@@ -294,7 +294,7 @@ openclaw_live_link_runtime_tree "$tmp_dir"
 openclaw_live_stage_state_dir "$tmp_dir/.openclaw-state"
 openclaw_live_prepare_staged_config
 cd "$tmp_dir"
-node --import tsx scripts/test-live.mts -- src/gateway/gateway-cli-backend.live.test.ts
+openclaw_live_run_staged_script scripts/test-live -- src/gateway/gateway-cli-backend.live.test.ts
 EOF
 
 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$ROOT_DIR" "$TRUSTED_HARNESS_DIR/scripts/test-live-build-docker.sh"

--- a/scripts/test-live-codex-harness-docker.sh
+++ b/scripts/test-live-codex-harness-docker.sh
@@ -232,7 +232,7 @@ run_codex_harness_target() {
   export OPENCLAW_LIVE_CODEX_HARNESS_MODEL="$model"
   export OPENCLAW_LIVE_CODEX_HARNESS_THINKING="$thinking"
   echo "==> Codex harness target: model=$model thinking=$thinking"
-  node --import tsx scripts/test-live.mts -- ${OPENCLAW_LIVE_CODEX_TEST_FILES:-src/gateway/gateway-codex-harness.live.test.ts}
+  openclaw_live_run_staged_script scripts/test-live -- ${OPENCLAW_LIVE_CODEX_TEST_FILES:-src/gateway/gateway-codex-harness.live.test.ts}
 }
 if [ -n "${OPENCLAW_LIVE_CODEX_HARNESS_TARGETS:-}" ]; then
   IFS=',' read -r -a harness_targets <<<"$OPENCLAW_LIVE_CODEX_HARNESS_TARGETS"

--- a/scripts/test-live-gateway-models-docker.sh
+++ b/scripts/test-live-gateway-models-docker.sh
@@ -61,11 +61,7 @@ while IFS= read -r docker_package; do
   openclaw_live_run_setup_command 180 "live CLI backend setup" npm install -g "$docker_package"
 done <<<"$docker_packages"
 openclaw_live_stage_gemini_auth
-if [[ -f scripts/test-live.mjs ]]; then
-  node scripts/test-live.mjs -- src/gateway/gateway-models.profiles.live.test.ts
-else
-  node --import tsx scripts/test-live.mts -- src/gateway/gateway-models.profiles.live.test.ts
-fi
+openclaw_live_run_staged_script scripts/test-live -- src/gateway/gateway-models.profiles.live.test.ts
 EOF
 
 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$ROOT_DIR" "$TRUSTED_HARNESS_DIR/scripts/test-live-build-docker.sh"

--- a/scripts/test-live-models-docker.sh
+++ b/scripts/test-live-models-docker.sh
@@ -64,11 +64,7 @@ openclaw_live_link_runtime_tree "$tmp_dir"
 openclaw_live_stage_state_dir "$tmp_dir/.openclaw-state"
 openclaw_live_prepare_staged_config
 cd "$tmp_dir"
-if [[ -f scripts/test-live.mjs ]]; then
-  node scripts/test-live.mjs -- src/agents/models.profiles.live.test.ts
-else
-  node --import tsx scripts/test-live.mts -- src/agents/models.profiles.live.test.ts
-fi
+openclaw_live_run_staged_script scripts/test-live -- src/agents/models.profiles.live.test.ts
 EOF
 
 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$ROOT_DIR" "$TRUSTED_HARNESS_DIR/scripts/test-live-build-docker.sh"

--- a/scripts/test-live-shard.mts
+++ b/scripts/test-live-shard.mts
@@ -712,6 +712,22 @@ export function buildLiveShardSpawnParams(
   } satisfies Pick<PnpmRunnerParams, "detached" | "env" | "stdio">;
 }
 
+export function resolveLiveShardBuildEntrypoint(exists = fs.existsSync): string[] {
+  // Release harnesses run this trusted shard router from a frozen candidate
+  // checkout. Prefer its current TypeScript builder, then its native ancestor.
+  if (exists("scripts/build-all.mts")) {
+    return ["--import", "tsx", "scripts/build-all.mts"];
+  }
+  if (exists("scripts/build-all.mjs")) {
+    return ["scripts/build-all.mjs"];
+  }
+  throw new Error("Live test shard cannot find scripts/build-all.{mts,mjs}");
+}
+
+export function resolveLiveShardBuildProfile(profile: string, usage: string): string {
+  return usage.split("\n").includes(`  ${profile}`) ? profile : "full";
+}
+
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   const rawArgs = process.argv.slice(2);
   const separatorIndex = rawArgs.indexOf("--");
@@ -762,14 +778,32 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
     console.log(
       `[test:live:shard] preparing ${preparation.profile} for ${preparation.requiredArtifact}`,
     );
-    const result = spawnSync(
-      process.execPath,
-      ["--import", "tsx", "scripts/build-all.mts", preparation.profile],
-      {
-        env: { ...process.env, ...preparation.env },
-        stdio: "inherit",
-      },
-    );
+    const buildEntrypoint = resolveLiveShardBuildEntrypoint();
+    const help = spawnSync(process.execPath, [...buildEntrypoint, "--help"], {
+      env: { ...process.env, ...preparation.env },
+      encoding: "utf8",
+    });
+    if (help.error) {
+      console.error(help.error);
+      process.exit(1);
+    }
+    if (help.signal) {
+      process.kill(process.pid, help.signal);
+      process.exit(1);
+    }
+    if ((help.status ?? 1) !== 0) {
+      process.exit(help.status ?? 1);
+    }
+    const buildProfile = resolveLiveShardBuildProfile(preparation.profile, help.stdout);
+    if (buildProfile !== preparation.profile) {
+      console.log(
+        `[test:live:shard] ${preparation.profile} is unavailable; preparing full build instead`,
+      );
+    }
+    const result = spawnSync(process.execPath, [...buildEntrypoint, buildProfile], {
+      env: { ...process.env, ...preparation.env },
+      stdio: "inherit",
+    });
     if (result.error) {
       console.error(result.error);
       process.exit(1);

--- a/scripts/test-live-subagent-announce-docker.sh
+++ b/scripts/test-live-subagent-announce-docker.sh
@@ -85,7 +85,7 @@ cd "$tmp_dir"
 OPENCLAW_LIVE_TEST=1 \
 OPENCLAW_LIVE_SUBAGENT_E2E=1 \
 OPENCLAW_VITEST_MAX_WORKERS="${OPENCLAW_VITEST_MAX_WORKERS:-1}" \
-node --import tsx scripts/test-live.mts -- src/agents/subagents/announce/subagent-announce.live.test.ts -- --reporter=verbose
+openclaw_live_run_staged_script scripts/test-live -- src/agents/subagents/announce/subagent-announce.live.test.ts -- --reporter=verbose
 EOF
 
 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$ROOT_DIR" "$TRUSTED_HARNESS_DIR/scripts/test-live-build-docker.sh"

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4567,6 +4567,7 @@ server.listen(0, "127.0.0.1", () => {
     const repoE2eRows = repoE2e.strategy.matrix.include as Array<{
       name: string;
       command: string;
+      target_script?: string;
     }>;
     expect(repoE2eRows.map((row) => row.command)).toEqual([
       ...Array.from({ length: 4 }, (_, index) => `pnpm test:e2e:gateway --shard=${index + 1}/4`),
@@ -4574,6 +4575,9 @@ server.listen(0, "127.0.0.1", () => {
       "pnpm test:e2e:agent-plugin-gateway",
     ]);
     expect(new Set(repoE2eRows.map((row) => row.name)).size).toBe(9);
+    expect(repoE2eRows.find((row) => row.name === "Agent plugin Gateway")).toMatchObject({
+      target_script: "test:e2e:agent-plugin-gateway",
+    });
     expect(repoE2e.name).toBe("Repo E2E (${{ matrix.name }})");
     expect(repoE2e.if).toBe("inputs.include_repo_e2e && inputs.live_suite_filter == ''");
     expect(repoE2e["continue-on-error"]).toBe("${{ inputs.advisory }}");
@@ -4588,9 +4592,14 @@ server.listen(0, "127.0.0.1", () => {
     expect(sandboxSetupIndex).toBeGreaterThanOrEqual(0);
     expect(repoE2eIndex).toBeGreaterThan(sandboxSetupIndex);
     expect(repoE2eSteps[repoE2eIndex]).toMatchObject({
-      run: "${{ matrix.command }}",
-      env: { OPENCLAW_E2E_WORKERS: "2", OPENCLAW_E2E_USE_PREBUILT_DIST: "1" },
+      env: {
+        OPENCLAW_E2E_WORKERS: "2",
+        OPENCLAW_E2E_USE_PREBUILT_DIST: "1",
+        TARGET_REQUIRED_SCRIPT: "${{ matrix.target_script || '' }}",
+      },
     });
+    expect(repoE2eSteps[repoE2eIndex]?.run).toContain("selected target does not provide");
+    expect(repoE2eSteps[repoE2eIndex]?.run).toContain("${{ matrix.command }}");
     const targetedGroupStep = releaseChecks.jobs.plan_docker_lane_groups.steps.find(
       (step: WorkflowStep) => step.name === "Build targeted Docker lane groups",
     );

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2901,18 +2901,19 @@ docker_e2e_docker_run_cmd run demo
     expect(inner.status, inner.stderr).toBe(0);
   });
 
-  it("selects the live model test runner shipped by the staged candidate", () => {
+  it("routes staged live suites through the candidate entrypoint resolver", () => {
     for (const scriptPath of [
+      "scripts/test-live-acp-bind-docker.sh",
+      "scripts/test-live-cli-backend-docker.sh",
+      "scripts/test-live-codex-harness-docker.sh",
       "scripts/test-live-gateway-models-docker.sh",
       "scripts/test-live-models-docker.sh",
+      "scripts/test-live-subagent-announce-docker.sh",
     ]) {
       const script = readFileSync(scriptPath, "utf8");
-      const legacyRunnerIndex = script.indexOf("node scripts/test-live.mjs --");
-      const currentRunnerIndex = script.indexOf("node --import tsx scripts/test-live.mts --");
 
-      expect(script).toContain("if [[ -f scripts/test-live.mjs ]]; then");
-      expect(legacyRunnerIndex).toBeGreaterThan(-1);
-      expect(currentRunnerIndex).toBeGreaterThan(legacyRunnerIndex);
+      expect(script).toContain("openclaw_live_run_staged_script scripts/test-live --");
+      expect(script).not.toContain("node --import tsx scripts/test-live.mts --");
     }
   });
 

--- a/test/scripts/fixtures-workspace.test.ts
+++ b/test/scripts/fixtures-workspace.test.ts
@@ -42,14 +42,13 @@ function runOpenWebUiWorkspace(workspaceDir: string) {
 }
 
 describe("workspace fixture assertions", () => {
-  it("writes explicit owners for the shared-workspace agents", () => {
+  it("writes only the shared-workspace ownership inputs needed by the delete smoke", () => {
     const root = tempDirs.make("openclaw-fixture-workspace-");
     const { result, stateDir, workspace } = runAgentsDeleteConfig(root);
 
     expect(result.status).toBe(0);
     expect(JSON.parse(readFileSync(path.join(stateDir, "openclaw.json"), "utf8")).agents).toEqual({
       ownership: "explicit",
-      defaults: { heartbeat: { agentId: "main" } },
       entries: { main: { workspace }, ops: { workspace } },
     });
   });

--- a/test/scripts/install-smoke-candidate-payload.test.ts
+++ b/test/scripts/install-smoke-candidate-payload.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, statSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -56,26 +56,13 @@ function createFixture(options: { symlinkInstaller?: boolean; symlinkPackage?: b
     `${JSON.stringify({ name: "openclaw", version: PACKAGE_VERSION })}\n`,
   );
   writeFileSync(path.join(packageContents, "index.js"), "console.log('openclaw');\n");
-  const packageName = `openclaw-${PACKAGE_VERSION}.tgz`;
-  const packagePath = path.join(packageDir, packageName);
+  const packagePath = path.join(packageDir, "candidate.tgz");
   createTarball(packagePath, packageRoot, ["package"]);
   if (options.symlinkPackage) {
     unlinkSync(packagePath);
     symlinkSync(path.join(root, "candidate.tar.gz"), packagePath);
   }
-  writeFileSync(
-    path.join(packageDir, "pack.json"),
-    `${JSON.stringify([
-      {
-        filename: packageName,
-        name: "openclaw",
-        size: 100,
-        unpackedSize: 200,
-        version: PACKAGE_VERSION,
-      },
-    ])}\n`,
-  );
-  return { archivePath, packageDir, payloadDir, root };
+  return { archivePath, packageDir, packagePath, packageContents, payloadDir, root };
 }
 
 async function sealFixture(options: { symlinkInstaller?: boolean; symlinkPackage?: boolean } = {}) {
@@ -128,6 +115,20 @@ describe("install smoke candidate payload", () => {
       { name: "candidate-pack.json", role: "package-metadata" },
       { name: "install.sh", role: "installer" },
       { name: "install-cli.sh", role: "cli-installer" },
+    ]);
+    expect(
+      JSON.parse(readFileSync(path.join(fixture.payloadDir, "candidate-pack.json"), "utf8")),
+    ).toEqual([
+      {
+        entryCount: 2,
+        filename: "candidate.tgz",
+        name: "openclaw",
+        size: statSync(fixture.packagePath).size,
+        unpackedSize:
+          statSync(path.join(fixture.packageContents, "package.json")).size +
+          statSync(path.join(fixture.packageContents, "index.js")).size,
+        version: PACKAGE_VERSION,
+      },
     ]);
     expect(readFileSync(path.join(fixture.payloadDir, "install.sh"), "utf8")).toContain(
       "echo install",

--- a/test/scripts/install-smoke-no-push-workflow.test.ts
+++ b/test/scripts/install-smoke-no-push-workflow.test.ts
@@ -699,14 +699,17 @@ describe("install smoke no-push root image transport", () => {
 
   it("passes package changelog intent only to the candidate packager", () => {
     const workflow = readWorkflow(INSTALL_SMOKE_REUSABLE);
-    expect(
-      step(
-        job(workflow, "installer_smoke_candidate_payload"),
-        "Package candidate only inside pinned harness",
-      ).env,
-    ).toMatchObject({
+    const packageCandidate = step(
+      job(workflow, "installer_smoke_candidate_payload"),
+      "Package candidate only inside pinned harness",
+    );
+    expect(packageCandidate.env).toMatchObject({
       ALLOW_UNRELEASED_CHANGELOG: "${{ inputs.allow_unreleased_changelog }}",
     });
+    expect(packageCandidate.run).toContain("--output-name candidate.tgz");
+    expect(packageCandidate.run).not.toContain("--pack-json");
+    expect(packageCandidate.run).toContain("scripts/package-openclaw-for-docker.mts");
+    expect(packageCandidate.run).toContain("package_args+=(--allow-unreleased-changelog)");
     expect(JSON.stringify(job(workflow, "bun_global_install_smoke"))).not.toContain(
       "OPENCLAW_BUN_GLOBAL_SMOKE_ALLOW_UNRELEASED_CHANGELOG",
     );

--- a/test/scripts/live-docker-stage.test.ts
+++ b/test/scripts/live-docker-stage.test.ts
@@ -108,6 +108,62 @@ describe("live Docker state staging", () => {
     expect(result.stderr).toContain("CLI backend executable was not provisioned:");
   });
 
+  it.each([
+    {
+      entrypoint: "scripts/test-live.mts",
+      expected: "--import tsx scripts/test-live.mts -- target",
+    },
+    { entrypoint: "scripts/test-live.mjs", expected: "scripts/test-live.mjs -- target" },
+  ])("runs the staged $entrypoint live runner", ({ entrypoint, expected }) => {
+    const root = tempDirs.make("openclaw-live-stage-entrypoint-");
+    const binDir = path.join(root, "bin");
+    const callsPath = path.join(root, "calls");
+    mkdirSync(path.join(root, path.dirname(entrypoint)), { recursive: true });
+    mkdirSync(binDir);
+    writeFileSync(path.join(root, entrypoint), "");
+    writeFileSync(
+      path.join(binDir, "node"),
+      '#!/usr/bin/env bash\nset -eu\nprintf "%s\\n" "$*" > "$CALLS_PATH"\n',
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        'set -euo pipefail; cd "$1"; source "$2"; openclaw_live_run_staged_script scripts/test-live -- target',
+        "test",
+        root,
+        stageScriptPath,
+      ],
+      {
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH}`, CALLS_PATH: callsPath },
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readFileSync(callsPath, "utf8").trim()).toBe(expected);
+  });
+
+  it("refuses to replace a missing staged live runner", () => {
+    const root = tempDirs.make("openclaw-live-stage-entrypoint-missing-");
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        'set +e; cd "$1"; source "$2"; openclaw_live_run_staged_script scripts/test-live -- target',
+        "test",
+        root,
+        stageScriptPath,
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("staged OpenClaw script entrypoint not found");
+  });
+
   it("keeps repo-local generated artifacts out of the source copy", () => {
     const script = readFileSync(stageScriptPath, "utf8");
 

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -540,13 +540,19 @@ describe("OpenClaw performance workflow", () => {
 
   it("builds only the QA and startup artifacts required by source probes", () => {
     const run = findStep("Run OpenClaw source performance probes", "source_performance").run ?? "";
-    const build =
+    const typedBuild =
       "OPENCLAW_BUILD_PRIVATE_QA=1 node --import tsx scripts/build-all.mts sourcePerformance";
+    const nativeBuild = "OPENCLAW_BUILD_PRIVATE_QA=1 node scripts/build-all.mjs sourcePerformance";
 
-    expect(run).toContain("module.BUILD_ALL_PROFILES?.sourcePerformance");
-    expect(run).toContain(build);
+    expect(run).toContain("scripts/profile-extension-memory.{mts,mjs}");
+    expect(run).toContain("scripts/build-all.mts --help");
+    expect(run).toContain("scripts/build-all.mjs --help");
+    expect(run).toContain("sourcePerformance");
+    expect(run).toContain(typedBuild);
+    expect(run).toContain(nativeBuild);
     expect(run).toContain("pnpm build");
-    expect(run.indexOf(build)).toBeLessThan(run.indexOf("pnpm test:gateway:cpu-scenarios"));
+    expect(run.indexOf(typedBuild)).toBeLessThan(run.indexOf("pnpm test:gateway:cpu-scenarios"));
+    expect(run.indexOf(nativeBuild)).toBeLessThan(run.indexOf("pnpm test:gateway:cpu-scenarios"));
     expect(run.indexOf("pnpm build")).toBeLessThan(run.indexOf("pnpm test:gateway:cpu-scenarios"));
   });
 

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -15,6 +15,8 @@ import {
   collectAllLiveTestFiles,
   parseLiveShardArgs,
   removeLiveShardReportFile,
+  resolveLiveShardBuildEntrypoint,
+  resolveLiveShardBuildProfile,
   resolveLiveShardPreparation,
   selectLiveShardFiles,
   validateLiveShardReportPayload,
@@ -252,6 +254,24 @@ describe("scripts/test-live-shard", () => {
     expect(
       resolveLiveShardPreparation(selectLiveShardFiles("native-live-src-gateway-core", allFiles)),
     ).toBeNull();
+  });
+
+  it("runs the frozen candidate's available build entrypoint and advertised profile", () => {
+    expect(resolveLiveShardBuildEntrypoint((file) => file.endsWith(".mts"))).toEqual([
+      "--import",
+      "tsx",
+      "scripts/build-all.mts",
+    ]);
+    expect(resolveLiveShardBuildEntrypoint((file) => file.endsWith(".mjs"))).toEqual([
+      "scripts/build-all.mjs",
+    ]);
+    expect(() => resolveLiveShardBuildEntrypoint(() => false)).toThrow(
+      "Live test shard cannot find scripts/build-all.{mts,mjs}",
+    );
+    expect(
+      resolveLiveShardBuildProfile("sourcePerformance", "Profiles:\n  full\n  sourcePerformance\n"),
+    ).toBe("sourcePerformance");
+    expect(resolveLiveShardBuildProfile("sourcePerformance", "Profiles:\n  full\n")).toBe("full");
   });
 
   it.each(["native-live-src-agents", "native-live-extensions-openai"])(


### PR DESCRIPTION
## Summary\n\nMake trusted release harnesses discover capabilities of the checked-out target rather than assuming the current TypeScript surface:\n\n- resolve staged live-test runners and shard builders from  or native ;\n- use a requested build profile only when the selected builder advertises it, otherwise perform its canonical  build;\n- skip the newer Agent plugin Gateway E2E only when the selected target's  lacks that script, with an explicit notice;\n- create candidate-pack metadata from the sealed tarball, including the downstream-required , instead of passing a newer packer-only flag;\n- remove the fixture-only heartbeat default from the agents-delete shared-workspace smoke config.\n\nNo target SHA, version, or error string is allowlisted. Required scenarios still run whenever the target exposes their capability.\n\n## Proof\n\n- 
 RUN  v4.1.10 /private/tmp/openclaw-frozen-target-entrypoints

 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > allows deployments to build an immutable sandbox image tag 21ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > treats Docker registry auth 5xx failures as transient build failures 17ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > detects Docker builder memory exhaustion failures 16ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > detects compiler processes killed by the OOM killer 16ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > retries Corepack connect timeouts without misreading Dockerfile comments as OOM 18ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps shell-script Docker builds behind the helper 1ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > routes standalone Docker smoke runs through the timeout-aware helper 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > runs the sandbox browser sidecar proof from the package-installed image 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > cleans only the sidecar task's containers when the runner exits early 1281ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > gives cleanup-smoke builds enough Node heap while preserving explicit callers 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid cleanup-smoke log byte limits 8ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > normalizes zero-padded cleanup-smoke log byte limits 14ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > prints Docker MCP client logs through the bounded helper 1ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > prints in-container Docker client logs through bounded helpers 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > runs cleanup smoke on the native ARM platform instead of pulling an amd64 tag 17ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > lets Testbox fall back to building when a reused Docker image is missing 1ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > resolves source and compiled candidate test-state entrypoints 56ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > runs current TypeScript and frozen JavaScript Docker harness entrypoints 185ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > routes package-only Docker TypeScript entrypoints through their required runtime 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects malformed Docker E2E resource limits before a suite starts 76ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps Testbox image-build fallback before isolating live MCP code-mode runtime flags 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > wraps centralized Docker builds with the timeout helper 454ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > prints heartbeat progress for long successful centralized Docker builds 18ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > stops the tracked build command without retrying when interrupted 549ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > does not delay fast successful centralized Docker builds until the next heartbeat 450ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > normalizes zero-padded centralized Docker build heartbeat intervals 13ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > normalizes zero-padded centralized Docker build retry counts 13ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid centralized Docker build retry count before invoking docker 14ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid centralized Docker build heartbeat interval before invoking docker 14ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > fails centralized Docker builds fast when timeout is unavailable 143ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps setup-style Docker builds compatible when timeout is unavailable 447ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > 'keeps reused Docker image probes behi…' 193ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > 'explains how to opt out when Docker r…' 34ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > 'does not suggest resource opt-out for…' 30ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > 'rejects invalid Docker run pids limit…' 15ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > 'rejects invalid package-backed Docker…' 19ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > 'diagnoses rejected resource limits th…' 35ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > 'removes functional Docker build packa…' 55ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > 'keeps caller-provided functional Dock…' 44ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > 'cleans generated package mounts after…' 340ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > 'propagates shared E2E command timeout…' 23ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > 'keeps both harness run wrappers avail…' 236ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > 'forwards harness stdin to backgrounde…' 206ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > 'bounds printed Docker E2E logs to the…' 130ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > 'prints heartbeat progress for long su…' 12ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > 'cleans the heartbeat command when the…' 241ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > 'cleans harness containers when heartb…' 369ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > 'normalizes zero-padded Docker E2E sta…' 29ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > derives the browser CDP image from the shared functional image 776ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > fails fast on invalid browser CDP snapshot byte limits 23ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > forwards browser CDP snapshot byte limits into the Docker runner 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > uses Playwright Chromium for the browser CDP snapshot image 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > opens the browser CDP fixture before snapshotting 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > fails Docker commands fast when timeout is unavailable 11ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > uses a Node watchdog for Docker commands when timeout is unavailable 630ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > adds default Docker run resource limits without overriding explicit limits 261ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > runs Docker when resource diagnostic capture is unavailable 18ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > escalates Docker watchdog children that ignore parent SIGTERM 440ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > escalates Docker watchdog children that ignore parent SIGHUP 429ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > uses plain timeout when kill-after is unsupported 171ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > uses gtimeout when timeout is unavailable 380ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps package-backed Docker runs bounded when the package helper is sourced directly 41ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > uses gtimeout for package-backed Docker runs sourced through the package helper 249ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > passes plugin lifecycle sampler timeout overrides into Docker 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid plugin lifecycle Docker phase timeout overrides before package setup 29ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid plugin lifecycle Docker CPU ratio overrides before package setup 27ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > wraps direct Docker E2E npm installs with the shared timeout helper 1ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps upgrade survivor mutable state off the host-mounted artifact tree 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > lets upgrade survivor fixture registries resolve transitive public packages 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > starts the upgrade survivor plugin registry before updates with scenario-owned config 2ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps upgrade survivor wrappers and the embedded payload valid bash 17ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > routes staged live suites through the candidate entrypoint resolver 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > wraps package-backed scenario OpenClaw CLI calls with the shared timeout helper 1ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > preserves actionable, secret-safe typed onboarding failure diagnostics 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > prints channel-add failures through the shared E2E logger 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps real-TTY onboarding drivers aligned with the guided prompt sequence 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps append-only mock E2E state under per-run scratch roots 1ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > kills timed Docker scenario runners after the grace period 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > propagates HTTP probe failures through command substitution 103ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > records an interrupted upgrade survivor phase as failed 935ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps multi-node update Docker artifacts isolated by default 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > reuses the shared bare image for multi-node update targeted runs 564ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > bounds upgrade survivor foreground OpenClaw CLI calls 1ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > scopes candidate device identity doctor markers to the doctor process 564ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > restores the canonical authored config after doctor failure 401ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > restores the canonical authored config after readiness failure 557ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > restores the canonical authored config after service-env failure 418ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > restores the canonical authored config after install failure 654ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > prefers restore failure and retains the authored config snapshot 326ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps upgrade survivor auto-auth success summary set -u safe 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > models systemd restart supervision in update-restart auth fixtures 1ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > stops promptly when the systemctl target is a zombie with spaces and parentheses in comm 220ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps a killable systemctl target active when proc stat is unreadable or malformed 292ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > retains the original post-core warning result separately from exit 0 394ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > retains the original post-core error result separately from exit 0 389ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > retains the original post-core error result separately from exit 78 389ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > leaves post-core capture unavailable for doctor without changing the child outcome 370ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > leaves post-core capture unavailable for worker without changing the child outcome 395ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > leaves post-core capture unavailable for missing-context without changing the child outcome 378ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > leaves post-core capture unavailable for missing without changing the child outcome 69ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > leaves post-core capture unavailable for invalid without changing the child outcome 372ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > leaves post-core capture unavailable for wrong-file without changing the child outcome 375ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > leaves post-core capture unavailable for outside-tmp without changing the child outcome 372ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > leaves post-core capture unavailable for symlink without changing the child outcome 371ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > leaves post-core capture unavailable for hardlink without changing the child outcome 368ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > leaves post-core capture unavailable for oversize without changing the child outcome 369ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > leaves post-core capture unavailable for blocked-output without changing the child outcome 372ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > leaves post-core capture unavailable for sigterm without changing the child outcome 369ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > scopes the passive preload to the original update invocation in scripts/e2e/lib/upgrade-survivor/run.sh 487ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > scopes the passive preload to the original update invocation in scripts/e2e/upgrade-survivor-docker.sh 304ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > exposes the published survivor service through the manager fixture 385ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > requires an update-owned service replacement after consent recovery (unchanged) 484ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > requires an update-owned service replacement after consent recovery (pid-only) 823ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > requires an update-owned service replacement after consent recovery (request-only) 452ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > requires an update-owned service replacement after consent recovery (replaced) 848ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > captures persisted plugin identity without changing application data (sqlite) 390ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > captures persisted plugin identity without changing application data (wal) 395ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > captures persisted plugin identity without changing application data (historical) 359ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > refuses unsafe plugin identity input (index-symlink) 347ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > refuses unsafe plugin identity input (index-hardlink) 346ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > refuses unsafe plugin identity input (index-oversize) 352ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > refuses unsafe plugin identity input (index-cap) 347ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > refuses unsafe plugin identity input (root-symlink) 342ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > refuses unsafe plugin identity input (doctor-symlink) 349ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > refuses unsafe plugin identity input (doctor-hardlink) 352ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > refuses unsafe plugin identity input (doctor-oversize) 352ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > retains a failed service child and only sanitized diagnostics (candidate redactor: false) 483ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > retains a failed service child and only sanitized diagnostics (candidate redactor: true) 487ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > retains supervisor bootstrap stderr without inventing a child exit in scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh 335ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > refuses unsafe private inputs before host publication 381ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > collects before cleanup without masking failure or breaking success in scripts/e2e/lib/upgrade-survivor/run.sh 381ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > collects before cleanup without masking failure or breaking success in scripts/e2e/upgrade-survivor-docker.sh 177ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > publishes only on the host and preserves Docker outcomes (published baseline: false) 2477ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > publishes only on the host and preserves Docker outcomes (published baseline: true) 2055ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > stops supervised gateway restarts after the systemd burst limit 219ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > allows a supervised gateway to drain within the systemd stop timeout 147ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > preserves the ClawHub fixture URL across a supervised gateway restart 105ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > terminates supervised gateway descendants at the systemd stop timeout 316ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > drains the previous gateway process group before restarting 343ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid upgrade survivor Docker start budget before Docker setup 30ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid upgrade survivor Docker status budget before Docker setup 31ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid upgrade survivor Docker probe timeout before Docker setup 33ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid upgrade survivor Docker probe attempt timeout before Docker setup 32ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid upgrade survivor Docker probe body cap before Docker setup 34ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > bounds upgrade survivor failure log diagnostics 1ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > preserves caller-owned file descriptors around harness runs 233ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > cleans Codex npm plugin live package artifacts on every exit path 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > wires the Codex npm plugin live assertion boundary into Docker 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > prints the OpenAI chat-tools gateway log when startup exits early 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > writes the packaged Codex follow-through result independently of stdout logs 35ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid package assertion env before Docker setup for Codex npm plugin live 31ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid package assertion env before Docker setup for Codex npm plugin live agent timeout 34ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid package assertion env before Docker setup for npm onboard channel-agent 29ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid package assertion env before Docker setup for plugins 25ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid package assertion env before Docker setup for release user journey 28ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > forwards package assertion env limits into Docker runners 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > gives Codex on-demand package installs enough time to reach Codex assertions 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > serves the version-matched Codex candidate during package onboarding 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > reuses the candidate registry lifecycle for channel onboarding 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > cleans package-backed onboarding and plugin Docker artifacts on every exit path 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > threads the live plugin tool output cap into the Docker harness 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid live plugin tool Docker timeout values before Docker setup 30ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid live plugin tool Docker output cap values before Docker setup 32ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid live plugin tool Docker output dump cap values before Docker setup 31ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid live plugin tool Docker session scan cap values before Docker setup 32ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps live plugin tool npm pack tarball paths inside the fixture directory 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > cleans every prepared Docker package tarball on every runner exit path 3ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > runs skill install through the package-cleaning Docker harness 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid Docker E2E printed log bytes before setup 8ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid Docker E2E heartbeat termination grace before setup 9ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid Docker E2E log heartbeat env before harness setup 13ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > preserves heredoc stdin through Docker E2E heartbeat logging 132ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > preserves failing heredoc output and status through Docker E2E heartbeat logging 133ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > does not delay fast successful Docker E2E log captures until the next heartbeat 132ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > normalizes zero-padded Docker E2E log heartbeat intervals 8ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > includes procps in the shared Docker E2E image for process watchdogs 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > caches package downloads across prepared Docker E2E image builds 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps private bundled plugins discoverable without persisting a curated registry 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps onboarding Docker E2E resource-guarded 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > cleans resource-sampled Docker E2E temp logs on every exit path 1ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps captured Docker E2E run log replay bounded 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps Open WebUI Docker E2E resource-guarded 1ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid Open WebUI Docker gateway ports before Docker setup 28ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid Open WebUI Docker webui ports before Docker setup 30ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid Open WebUI Docker provider timeouts before Docker setup 35ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid Open WebUI Docker fetch timeouts before Docker setup 35ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > accepts decimal Open WebUI Docker numeric inputs with leading zeroes 36ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid Docker E2E ports before setup 24ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid Docker E2E ports before setup 25ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid Docker E2E ports before setup 24ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid Docker E2E ports before setup 27ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid Docker E2E ports before setup 23ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid Docker E2E ports before setup 23ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid Codex media path Docker timeout before Docker setup 25ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid Codex media path Docker log tail cap before Docker setup 27ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > forwards Codex media path client limits into Docker 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid MCP code-mode client env before setup 26ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid MCP code-mode client env before setup 26ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid MCP code-mode client env before setup 24ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid MCP code-mode client env before setup 26ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > forwards MCP code-mode client fetch limits into Docker 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > forwards MCP code-mode client fetch limits into Docker 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid OpenAI chat tools Docker timeout before auth setup 24ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid OpenAI chat tools Docker body cap before auth setup 25ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > forwards every OpenAI chat tools runtime env knob into Docker 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > forwards every kitchen-sink RPC runtime env knob into Docker 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps the kitchen-sink RPC Docker watchdog above the internal walk budgets 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > bounds kitchen-sink plugin CLI commands inside the Docker sweep 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > routes named Docker E2E container cleanup through the timeout-aware helper 2ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > copies the complete bun harness closure into the package-install lane 2ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > executes each CLI distribution boundary instead of promoting metadata 1ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > routes the gateway network client through the timeout-aware run helper 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > proves gateway suspension across a same-container process restart 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid gateway network client connect timeout before Docker setup 27ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid gateway network client ready timeout before Docker setup 26ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > forwards gateway network client timeout env into the Docker client 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > requires TCP readiness for the gateway network runner 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > copies root lifecycle inputs before cleanup-smoke installs dependencies 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > mounts root helper modules imported by bare Docker E2E scripts 13ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > preserves pnpm lookup paths for scheduled Docker child lanes 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > runs release installer E2E against the npm beta tag 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > times and parallelizes release installer E2E agent turns after gateway startup 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps package acceptance plugin coverage offline-capable 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > allows plugin update smoke to tolerate config metadata migrations 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > fails the multi-node update probe on update or restart regressions 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps a stalled multi-node health request inside the probe deadline 32ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > caps package acceptance legacy compatibility at 2026.4.25 1ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps the doctor switch systemctl shim system scope empty 10ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > reports the installed doctor switch unit through the systemd manager 606ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > distinguishes a missing named doctor switch unit from failed or unsupported inspection 594ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > routes doctor install switch commands through the E2E timeout helper 1ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > uses the account home for upgrade survivor auto-auth state 1ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > bounds doctor install switch command log diagnostics 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > prepares pnpm workspace package fixtures without package dependencies 38ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps bundled plugin install/uninstall sweep chunkable 2ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid bundled plugin Docker list timeout values before Docker setup 26ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid bundled plugin Docker runtime port base values before Docker setup 27ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid bundled plugin Docker runtime log scan values before Docker setup 28ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid bundled plugin Docker runtime command timeout values before Docker setup 32ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > rejects invalid bundled plugin Docker runtime teardown grace values before Docker setup 36ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > passes installer tag env to bash, not curl 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps installer E2E agent turns out of the interactive bootstrap ritual 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps installer E2E tool smokes in isolated sessions 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > bounds installer E2E session transcript tool scans 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > exports SQLite-backed installer E2E sessions before scanning tools 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps OpenAI web search smoke on one gateway agent connection 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > cleans OpenAI web search smoke processes through the E2E helpers 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > runs agents delete shared workspace smoke through one managed gateway 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps OpenAI web search smoke logs isolated per run 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps ClawHub plugin Docker smoke hermetic by default 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > keeps the plugin binding command escape Docker smoke focused 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > routes QR import Docker smoke through the timeout-aware run helper 0ms
 ✓ |tooling-docker| test/scripts/docker-build-helper.test.ts > docker build helper > covers plugin CLI sources in the Docker plugin sweep 1ms

 Test Files  1 passed (1)
      Tests  253 passed (253)
   Start at  13:36:22
   Duration  38.89s (transform 176ms, setup 82ms, import 19ms, tests 38.55s, environment 0ms)


 RUN  v4.1.10 /private/tmp/openclaw-frozen-target-entrypoints

 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > isolates mutations between workflow fixtures 4ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > gates frozen runtime-pair compatibility on the trusted suite outcome 22ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > separates release QA lanes without weakening their resource locks 22ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > preserves module heredocs and cleans child temporary artifacts 68ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > routes PR edited metadata only to interested automation 4ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps ClawSweeper dispatch events aligned with receiver workflows 2ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > runs the PR context and evidence gate only for relevant PR changes 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > isolates auto-response per item and ignores ClawSweeper PR label feedback 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > routes stale bug issues through ClawSweeper instead of Barnacle closure 4ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > makes the hosted release-gate fallback explicit and exact-SHA only 2ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps Testbox pull request validation off leased runner capacity 2ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps every path-filtered hosted gate runnable on landing-relevant events 3ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > pins every external GitHub Action reference to a full commit SHA 14ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > schedules approved Docker refreshes from independently resolved channels 5ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > forbids moving reusable workflow references 0ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps locale refresh matrices alive and publishes each aggregate through a PR 8ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > enables auto-merge for the exact generated pull request head 2555ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > waits for the published pull request head before enabling auto-merge 2931ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > preserves inherited auto-merge while replacing a generated pull request head 3730ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > accepts inherited auto-merge completing immediately after publication 4129ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > waits for the existing pull request head before replacing it 3972ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > refuses to replace an auto-merge-enabled head when publication opts out 3110ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > does not mutate inherited auto-merge when generated publication fails 3861ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > rejects an incompatible inherited auto-merge method without mutating it 3444ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > defers a newer owned snapshot even when the desired diff is disjoint 3097ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > defers stale generator inputs and neutralizes an existing pull request 2148ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > publishes after unrelated source changes when input invalidation is disabled 2625ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > neutralizes an existing pull request when generation has no changes 2193ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > fails stale generated publication when no successor run is guaranteed 4283ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > fails OpenGrep SARIF artifact uploads when reports are missing 2ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > verifies the pinned OpenGrep release binary before installing it 2ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > runs real behavior proof from the trusted workflow revision 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps docs-change detection fail-safe and fixture-aware 0ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > bounds matrix fan-out for runner-registration pressure 2ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > runs changed Docker seed owners in one gated scheduler job 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > splits Windows tests two ways on every runner backend 456ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > installs the Android SDK platform used by Gradle 4ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > binds frozen target context to the declared live release branch 3042ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > pins Swift 6.3 workflow jobs to Xcode 26.6-capable runners 2ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > loads Android CI setup from the workflow revision for frozen targets 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > bounds Android SDK command-line tools downloads 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > covers Android app variants, lint, and benchmark compilation 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > pipelines canonical main CI across two non-canceling slots 0ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps CodeQL critical quality scans off Blacksmith registrations 6ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps security checks hosted and the cache writer on Blacksmith 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > resolves one event-aware logical runner profile without changing physical routing 295ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > honors trusted dispatch runner selection for check shards with context "" 3ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > honors trusted dispatch runner selection for check shards with context "release/2026.9.1" 4ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > encodes GitHub, Blacksmith, and hybrid runner-backend shapes 58ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > gives breaker-routed hosted jobs their hosted timeout budgets 5ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > scans only the pull request commit range for leaked credentials 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps setup cache access explicit and isolates every cache write 384ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > owns one exact immutable semantic dependency cache 41ms
 × |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > preserves pnpm hard links and validates cached importers offline 2472ms
   → Command failed: /opt/homebrew/bin/pnpm --silent run pnpm-path
/Users/dallin/Library/pnpm/store/v11/links/@/pnpm/12.1.0/d7729d4f92dda5a8bf2d5fc406b7c3baae62d5b59b5a90f91b83744fe81a32e0/bin/../node_modules/pnpm/pnpm: line 4: syntax error near unexpected token `)'
/Users/dallin/Library/pnpm/store/v11/links/@/pnpm/12.1.0/d7729d4f92dda5a8bf2d5fc406b7c3baae62d5b59b5a90f91b83744fe81a32e0/bin/../node_modules/pnpm/pnpm: line 4: `pnpm's build under pnpm or Bun, or drop --ignore-scripts).'

 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > persists content-validated public full-build declarations 54ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > persists Node 22 declarations through trusted bounded artifacts 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > fingerprints dependency install inputs without ordinary script churn 1758ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > persists isolated transform and compile caches through immutable protected archives 17ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > warms protected caches without main-run cancellation 4ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > uses bundled Node shards and telemetry-backed runner sizes 4ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps the extension boundary sticky disk on one protected key 3ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps the Gradle sticky disk on O(1) per-task protected keys 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > caches Robolectric SDK artifacts for Android test tasks only 2ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > never keys a Blacksmith sticky disk by unbounded run dimensions 440ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > deletes only exact allowlisted retired sticky disks from protected main 560ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > runs the session accessor ratchet as a visible additional check 7ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > runs the export name collision ratchet as a visible additional check 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > runs the transcript reader ratchet as a visible additional check 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > reports the Plugin SDK API diff as a visible additional check 16ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > uses the current SDK diff and preserves the historical baseline check 1017ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > runs the SQLite transaction ratchet in the session boundary check 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > retains fetch deadlines in other standalone workflows 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > owns Docs Agent Git without changing cadence, deadlines, or action authority 3ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > owns docs mirror Git lifecycle without changing transport or stale-source policy 2ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > bounds .github/workflows/plugin-clawhub-release.yml git fetches 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > pins the Mantis Git owner and preserves distinct terminal ref-validation contracts 3ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps shared Mantis reaction ownership stable 3ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps legacy Mantis scenarios on manual dispatch in .github/workflows/mantis-web-ui-chat-proof.yml 2ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps legacy Mantis scenarios on manual dispatch in .github/workflows/mantis-discord-status-reactions.yml 2ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps legacy Mantis scenarios on manual dispatch in .github/workflows/mantis-discord-thread-attachment.yml 3ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > bounds release ref validation fetches across checkout auth modes 56ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > checks the generated Git owner in the workflow guard lane 128ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > uses the maintained authenticated checkout for security-fast 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps manual candidates separate from trusted cache authority 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > classifies cache write authority from proven candidate identity 2720ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > uses the maintained checkout across workflow sanity jobs 2ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > pins workflow sanity's typed Git policy after Python setup 2ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > prepares Testbox checkouts with one maintained owner and scoped history 18ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > bounds the workflow sanity ShellCheck download 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > pins workflow and pre-commit actionlint to the large-stdin deadlock fix 2ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > runs committed generated baseline drift checks in workflow sanity 2ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > shares checkout ownership across Linux and native platforms with their existing budgets 602ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > checks native and Node state schema versions in the macOS lane 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > retries macOS release builds only when Sparkle metadata is incomplete 1950ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > uses native macOS Swift tests and preserves the first failure 2638ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > bounds the Windows Crabbox hydrate main fetch 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > bounds Mantis Slack runner IP discovery 544ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > fails Windows Testbox setup when Blacksmith phone-home is not accepted 0ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > runs dependency policy guards in PR CI preflight 2ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > runs temp path guardrails in the hosted guard shard 784ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > rejects ambiguous zero-before main pushes and preserves concrete bases 1361ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > uses stable deadcode checks for current and frozen checkouts 1779ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps the preflight manifest import closure dependency-free 175ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > runs mobile protocol coverage for Node and native-only changes 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps type-aware oxlint within hosted fork-runner resources 3ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > runs all baseline ratchets against the exact tested tree 284ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > executes standalone changed-path-facts coverage for 'test-only routing' 400ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > executes standalone changed-path-facts coverage for 'source-only routing' 379ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > executes standalone changed-path-facts coverage for 'legacy combined contract and routing …' 429ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > routes native CI jobs through scope output and manifest ('Git-owner action') 192ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > routes native CI jobs through scope output and manifest ('Docs Agent') 167ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > routes native CI jobs through scope output and manifest ('Performance owner .github/workflows/o…') 175ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > routes native CI jobs through scope output and manifest ('Performance owner test/scripts/opencl…') 175ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > routes native CI jobs through scope output and manifest ('Performance owner test/scripts/opencl…') 175ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > routes native CI jobs through scope output and manifest ('Performance owner test/scripts/opencl…') 179ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > routes native CI jobs through scope output and manifest ('Git-owner fixture') 179ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > routes native CI jobs through scope output and manifest ('Mac app') 192ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > routes native CI jobs through scope output and manifest ('shared native') 310ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > routes native CI jobs through scope output and manifest ('docs') 210ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > routes native CI jobs through scope output and manifest ('unrelated CI workflow') 213ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > routes native CI jobs through scope output and manifest ('ordinary manual') 161ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > routes native CI jobs through scope output and manifest ('historical Mac scope without native N…') 157ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > routes native CI jobs through scope output and manifest ('historical non-Mac scope without nati…') 161ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > forwards changed paths only to canonical PR fallback (pull_request, openclaw/openclaw) 152ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > forwards changed paths only to canonical PR fallback (pull_request, example/openclaw) 160ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > forwards changed paths only to canonical PR fallback (push, openclaw/openclaw) 158ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > forwards changed paths only to canonical PR fallback (workflow_dispatch, openclaw/openclaw) 145ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > uses target-owned CI plans and capabilities for older release checkouts 2241ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > gates current Control UI changes on ordinary and real-Gateway Chromium E2E 338ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > builds artifacts once and smoke-tests the built CLI with Node and Bun 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps automatic source-only Control UI locale drift advisory and manual CI strict 261ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > splits native source verification from generated locale parity 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > measures startup memory before the built artifact-check wave 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates Discord built proof with 'one passing named case' 33ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates Discord built proof with 'a passing frozen case' 32ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates Discord built proof with 'a failed named case' 30ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates Discord built proof with 'a skipped current case' 32ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates Discord built proof with 'a skipped frozen case' 33ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates Discord built proof with 'a missing current case' 32ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates Discord built proof with 'an unavailable historical case' 34ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates Discord built proof with 'a failed suite' 33ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates Discord built proof with 'malformed JSON' 31ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > gates browser native-host proof (frozen=false, present=true) 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > gates browser native-host proof (frozen=false, present=false) 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > gates browser native-host proof (frozen=true, present=true) 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > gates browser native-host proof (frozen=true, present=false) 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates browser native-host proof report: passed 101ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates browser native-host proof report: skipped 101ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates browser native-host proof report: pending 101ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates browser native-host proof report: todo 96ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates browser native-host proof report: absent 95ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates browser native-host proof report: wrong-name 97ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates browser native-host proof report: wrong-file 110ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates browser native-host proof report: failed 98ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates browser native-host proof report: suite-failed 96ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates browser native-host proof report: duplicate 99ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates browser native-host proof report: malformed 96ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > validates browser native-host proof report: missing-report 99ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > runs the scoped SQLite lifecycle proof against the exact built artifact 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > restores dist in PR CI and saves it only from the trusted warmer 2ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps the AI runtime in Testbox build artifact caches 2ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps the full built TUI PTY suite out of the artifact canary gate 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps docs i18n CI on the workflow-owned Go toolchain 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > fails and retries quiet Node test shard stalls quickly 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > clamps Node test workers to the detected core count 0ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > uses candidate-owned script interfaces for frozen target CI 0ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > emits one final CI gate after every selected lane 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > runs Node 22 compatibility only from manual CI dispatches 9ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > accepts only successful required jobs and successful or skipped selected jobs 18ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > resolves topology-aware protocol bases and drives the real guard 5068ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > wires and fetches one explicit protocol base before QA execution 1189ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > pins the QA Git owner before checkouts and preserves all ten terminal fetch contracts 5ms
 ↓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > classifies QA timeouts only from isolated supervisor diagnostics
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps maturity scorecard generated QA evidence handoff strict 9ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > round-trips profile evidence and rejects digest drift 1253ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > suppresses only reported QA result failures when explicitly allowed 29ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > authorizes maturity PR publication only for a canonical direct dispatch 6ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps a reusable maturity call artifact-only even when its caller was dispatched 19ms
 ↓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > copies only regular allowlisted maturity publication files
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps exact release validation identity separate from release context 23ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > checks out the complete Release Decision evidence validator closure 7ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps maturity scorecard release docs opt-in from release checks 10ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps workflow guards in fast CI-routing checks 439ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps push docs validation ClawHub-backed 0ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > skips generated-asset validation only when a frozen candidate lacks the contract 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps network CodeQL off unrelated source-only refactors 0ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > ci workflow guards > keeps the Crabbox gate publisher on protected main with minimal permissions 1ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > pins generated publisher and maturity owners before credentials and selected checkout 8ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > pins simple release admission owners before selected checkout and preserves Git contracts 9ms
 ✓ |tooling| test/scripts/ci-workflow-guards.test.ts > pins every Performance Git owner before checkout and preserves Git deadlines 4ms
 × |tooling| test/scripts/install-smoke-candidate-payload.test.ts > install smoke candidate payload > seals source installers and package bytes into a fully bound payload 275ms
   → expected [ { entryCount: 5, …(5) } ] to deeply equal [ { entryCount: 2, …(5) } ]
 ✓ |tooling| test/scripts/install-smoke-candidate-payload.test.ts > install smoke candidate payload > rejects tampering with candidate.tgz after sealing 191ms
 ✓ |tooling| test/scripts/install-smoke-candidate-payload.test.ts > install smoke candidate payload > rejects tampering with candidate-pack.json after sealing 195ms
 ✓ |tooling| test/scripts/install-smoke-candidate-payload.test.ts > install smoke candidate payload > rejects tampering with install.sh after sealing 184ms
 ✓ |tooling| test/scripts/install-smoke-candidate-payload.test.ts > install smoke candidate payload > rejects tampering with install-cli.sh after sealing 179ms
 ✓ |tooling| test/scripts/install-smoke-candidate-payload.test.ts > install smoke candidate payload > rejects manifest tampering before trusting its file inventory 179ms
 ✓ |tooling| test/scripts/install-smoke-candidate-payload.test.ts > install smoke candidate payload > rejects tuple drift and unexpected artifact files 374ms
 ✓ |tooling| test/scripts/install-smoke-candidate-payload.test.ts > install smoke candidate payload > rejects symlinked candidate inputs before sealing 154ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > uses an optional dispatch identifier to name parent-owned runs 0ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > pins the Kova evaluator with release validation contracts 29ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > keeps live credentials away from custom Kova refs 365ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > keeps arbitrary performance candidates secretless and cacheless 62ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > replaces candidate-owned nested setup actions with the trusted workflow copy 47ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > pins the OCM release archive and checksum 3ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > resolves each target once before benchmark and publication fan out 23ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > passes the requested model through Kova live auth without rewriting Kova source 3ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > sparse-fetches only the public source baseline without publisher credentials 3ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > builds only the QA and startup artifacts required by source probes 3ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > runs only gateway startup cases advertised by the frozen target 3ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > keeps source gateway health waits within one startup budget 3ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > runs trusted CLI performance cases against the frozen candidate entrypoint 5ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > isolates required publication in a fresh artifact-consuming job 3ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > keeps report publication opt-out artifact-only for final release validation 3ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > fails closed when artifact-only mode does not keep the publisher skipped 6ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > mints only a short-lived repo-scoped ClawSweeper app token 9ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > keeps manual non-release publication advisory 19ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > keeps app credentials out of artifact processing and scopes them to Git push 19ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > replays concurrent report commits on the current reports tip 3ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > publishes bounded bundle metadata while retaining full diagnostics as an artifact 14ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > reuses the producing artifact when only publisher jobs rerun 167ms
stdout | test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > advertises a clawgrit URL only after verified success ('direct')
.github/workflows/openclaw-performance.yml/publish/Publish to clawgrit reports: {"code":0,"cancelledDuringCleanup":false,"boundaries":[{"name":"shell-command","alive":[],"sentinelAlive":true},{"name":"shell-command","alive":[],"sentinelAlive":true},{"name":"config:1","alive":[],"sentinelAlive":true},{"name":"remote:1","alive":[],"sentinelAlive":true},{"name":"cat-file:1","alive":[],"sentinelAlive":true},{"name":"push:1","alive":[],"sentinelAlive":true},{"name":"summary","alive":[],"sentinelAlive":true},{"name":"summary","alive":[],"sentinelAlive":true},{"name":"exit","alive":[],"sentinelAlive":true}],"readyAttempts":[1,2,3,4],"cleanupRemaining":[],"ownedProcesses":[{"pid":12129,"role":"sentinel","attempt":0,"instance":"3498aa0b-3202-4054-971c-a716a455a58a-12129"},{"pid":12180,"role":"shell","attempt":0,"instance":"17fea3a6-0cf8-40c6-b88b-cefef0de48a4-12180"},{"pid":12339,"role":"parent","attempt":1,"instance":"d153e919-b307-40b4-811e-82cad997542f-12339"},{"pid":12351,"role":"child","attempt":1,"instance":"daf0fb16-8ab1-43f3-92b7-ea8c7212f85b-12351"},{"pid":12352,"role":"grandchild","attempt":1,"instance":"efebade4-cae1-4eb8-bd81-37debaa4867e-12352"},{"pid":12357,"role":"parent","attempt":2,"instance":"36c3bd79-0047-4996-a8b2-8fe168f38748-12357"},{"pid":12365,"role":"child","attempt":2,"instance":"1b1bfe40-56b8-4cbb-a210-6043ecf530a6-12365"},{"pid":12366,"role":"grandchild","attempt":2,"instance":"f43e9da8-83b1-400b-be16-1178c3ba0673-12366"},{"pid":12371,"role":"parent","attempt":3,"instance":"a3ab0dc8-4f72-4d01-b2f9-c376366cefe3-12371"},{"pid":12380,"role":"child","attempt":3,"instance":"7c022890-a180-439d-85f4-6dc445137499-12380"},{"pid":12381,"role":"grandchild","attempt":3,"instance":"895ccc30-1893-4fe3-9614-ecb824de1ec1-12381"},{"pid":12384,"role":"parent","attempt":4,"instance":"8f8eba9e-bdf5-4c65-9d97-78aec79a35ba-12384"},{"pid":12399,"role":"child","attempt":4,"instance":"03d3e6e5-15f6-40e5-9c57-366411bd946b-12399"},{"pid":12400,"role":"grandchild","attempt":4,"instance":"f5a23985-8a74-4def-87f1-d5a29653dc0d-12400"}],"commands":[{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout r1cbQx/workspace/performance-temp/reports","args":["config","--local","--get","core.hooksPath"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout r1cbQx/workspace/performance-temp/reports","args":["remote","get-url","origin"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout r1cbQx/workspace/performance-temp/reports","args":["cat-file","-e","11b53b14dafb925272ce47d3fc8497fa0dddd43f^{commit}"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout r1cbQx/workspace/performance-temp/reports","args":["push","origin","HEAD:main"],"configuration":[],"envProbe":"{\"token\":false,\"auth\":true,\"hooks\":\"/dev/null\",\"prompt\":\"0\",\"count\":\"2\"}"}],"output":"::add-mask::[redacted]\nTo /private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout r1cbQx/workspace/reports.git\n   20a0ada..11b53b1  HEAD -> main\n"}

 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > advertises a clawgrit URL only after verified success ('direct') 2252ms
stdout | test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > advertises a clawgrit URL only after verified success ('remote duplicate')
.github/workflows/openclaw-performance.yml/publish/Publish to clawgrit reports: {"code":0,"cancelledDuringCleanup":false,"boundaries":[{"name":"shell-command","alive":[],"sentinelAlive":true},{"name":"shell-command","alive":[],"sentinelAlive":true},{"name":"config:1","alive":[],"sentinelAlive":true},{"name":"remote:1","alive":[],"sentinelAlive":true},{"name":"cat-file:1","alive":[],"sentinelAlive":true},{"name":"push:1","alive":[],"sentinelAlive":true},{"name":"backoff","alive":[],"sentinelAlive":true},{"name":"fetch:1","alive":[],"sentinelAlive":true},{"name":"ls-tree:1","alive":[],"sentinelAlive":true},{"name":"summary","alive":[],"sentinelAlive":true},{"name":"summary","alive":[],"sentinelAlive":true},{"name":"exit","alive":[],"sentinelAlive":true}],"readyAttempts":[1,2,3,4,5,6],"cleanupRemaining":[],"ownedProcesses":[{"pid":12473,"role":"sentinel","attempt":0,"instance":"d284fb0c-6018-4896-ba66-c5651e39e31d-12473"},{"pid":12492,"role":"shell","attempt":0,"instance":"017a1c1d-386f-4f56-a2cc-f19ac8618bbc-12492"},{"pid":12502,"role":"parent","attempt":1,"instance":"0f16de36-75b6-418c-917b-3d92a3c55a92-12502"},{"pid":12506,"role":"child","attempt":1,"instance":"6caf29a5-7fa7-44ff-af77-e7bb44b5e08d-12506"},{"pid":12507,"role":"grandchild","attempt":1,"instance":"ded4ec57-0d09-4d59-8582-b16bc07c24f3-12507"},{"pid":12510,"role":"parent","attempt":2,"instance":"ca56b1f1-6785-4a0f-a176-5c5d291d9a68-12510"},{"pid":12520,"role":"child","attempt":2,"instance":"b83b656a-f296-4a43-9115-8036f496f698-12520"},{"pid":12521,"role":"grandchild","attempt":2,"instance":"73c6b89f-3f51-4ea0-be20-5c2125199ece-12521"},{"pid":12524,"role":"parent","attempt":3,"instance":"a4045b4f-9356-4af0-9aaf-f65a2c1de73c-12524"},{"pid":12531,"role":"child","attempt":3,"instance":"7c2c75a8-a361-44ff-9043-86fb80958a53-12531"},{"pid":12532,"role":"grandchild","attempt":3,"instance":"89d0829a-2b54-4f2c-a5ce-b8a2ed167176-12532"},{"pid":12535,"role":"parent","attempt":4,"instance":"2df7eeda-008b-41d6-ac3e-3b6f2560d222-12535"},{"pid":12542,"role":"child","attempt":4,"instance":"f1618c63-f3f5-4689-950c-1d45adb5c95f-12542"},{"pid":12543,"role":"grandchild","attempt":4,"instance":"306cf88d-7e7a-4ced-bad4-ae65ecfcbda9-12543"},{"pid":12563,"role":"parent","attempt":5,"instance":"09c7d7ba-8714-4043-9f65-aa910d74ad26-12563"},{"pid":12569,"role":"child","attempt":5,"instance":"f629aa13-07a9-472a-82bc-fe6816af7fda-12569"},{"pid":12571,"role":"grandchild","attempt":5,"instance":"816470a3-b456-492f-a721-7f1af5a86506-12571"},{"pid":12586,"role":"parent","attempt":6,"instance":"e2c92edf-3a8b-420e-a831-138eea5e9733-12586"},{"pid":12593,"role":"child","attempt":6,"instance":"96763fba-1946-4c48-93be-e9c1c3c9e5e1-12593"},{"pid":12594,"role":"grandchild","attempt":6,"instance":"d708b56f-0004-4b24-8d53-799471e25e78-12594"}],"commands":[{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout Uid0qA/workspace/performance-temp/reports","args":["config","--local","--get","core.hooksPath"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout Uid0qA/workspace/performance-temp/reports","args":["remote","get-url","origin"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout Uid0qA/workspace/performance-temp/reports","args":["cat-file","-e","11b53b14dafb925272ce47d3fc8497fa0dddd43f^{commit}"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout Uid0qA/workspace/performance-temp/reports","args":["push","origin","HEAD:main"],"configuration":[],"envProbe":"{\"token\":false,\"auth\":true,\"hooks\":\"/dev/null\",\"prompt\":\"0\",\"count\":\"2\"}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout Uid0qA/workspace/performance-temp/reports","args":["fetch","--depth=1","origin","main"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout Uid0qA/workspace/performance-temp/reports","args":["ls-tree","--name-only","FETCH_HEAD","--","openclaw-performance/main/123-1/mock-provider/report.json"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"}],"output":"::add-mask::[redacted]\nTo /private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout Uid0qA/workspace/reports.git\n   20a0ada..11b53b1  HEAD -> main\nfixture backoff: 2\nFrom /private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout Uid0qA/workspace/reports\n * branch            main       -> FETCH_HEAD\n"}

 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > advertises a clawgrit URL only after verified success ('remote duplicate') 2539ms
stdout | test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > advertises a clawgrit URL only after verified success ('exhausted')
.github/workflows/openclaw-performance.yml/publish/Publish to clawgrit reports: {"code":1,"cancelledDuringCleanup":false,"boundaries":[{"name":"shell-command","alive":[],"sentinelAlive":true},{"name":"shell-command","alive":[],"sentinelAlive":true},{"name":"config:1","alive":[],"sentinelAlive":true},{"name":"remote:1","alive":[],"sentinelAlive":true},{"name":"cat-file:1","alive":[],"sentinelAlive":true},{"name":"push:1","alive":[],"sentinelAlive":true},{"name":"backoff","alive":[],"sentinelAlive":true},{"name":"fetch:1","alive":[],"sentinelAlive":true},{"name":"push:2","alive":[],"sentinelAlive":true},{"name":"backoff","alive":[],"sentinelAlive":true},{"name":"fetch:2","alive":[],"sentinelAlive":true},{"name":"push:3","alive":[],"sentinelAlive":true},{"name":"backoff","alive":[],"sentinelAlive":true},{"name":"fetch:3","alive":[],"sentinelAlive":true},{"name":"push:4","alive":[],"sentinelAlive":true},{"name":"backoff","alive":[],"sentinelAlive":true},{"name":"fetch:4","alive":[],"sentinelAlive":true},{"name":"push:5","alive":[],"sentinelAlive":true},{"name":"backoff","alive":[],"sentinelAlive":true},{"name":"fetch:5","alive":[],"sentinelAlive":true},{"name":"summary","alive":[],"sentinelAlive":true},{"name":"summary","alive":[],"sentinelAlive":true},{"name":"exit","alive":[],"sentinelAlive":true}],"readyAttempts":[1,2,3,4,5,6,7,8,9,10,11,12,13],"cleanupRemaining":[],"ownedProcesses":[{"pid":12659,"role":"sentinel","attempt":0,"instance":"88968230-ced1-486b-9988-227b654b44ef-12659"},{"pid":12677,"role":"shell","attempt":0,"instance":"e721ab80-c225-4690-931c-9cd32f8ecd8d-12677"},{"pid":12698,"role":"parent","attempt":1,"instance":"e9ff0c7f-66a5-4434-af28-e6e7e99ffcca-12698"},{"pid":12708,"role":"child","attempt":1,"instance":"d8ceb741-e252-446f-b541-a8db77f1468a-12708"},{"pid":12710,"role":"grandchild","attempt":1,"instance":"45560bbc-d9f3-4acf-a1e6-19295f1e2136-12710"},{"pid":12714,"role":"parent","attempt":2,"instance":"7f814343-9fa3-4c69-a5e5-8a3ca6729dda-12714"},{"pid":12722,"role":"child","attempt":2,"instance":"29965ebf-9680-460e-8362-fd5b9278ed79-12722"},{"pid":12723,"role":"grandchild","attempt":2,"instance":"e1ed6554-1f9c-46a9-8cd9-39f1dcb9ceeb-12723"},{"pid":12726,"role":"parent","attempt":3,"instance":"ed9b9ccb-5ffb-4f72-a54e-83cbefb83a04-12726"},{"pid":12733,"role":"child","attempt":3,"instance":"0ecc7c17-c992-4d79-a510-ef1adf389323-12733"},{"pid":12734,"role":"grandchild","attempt":3,"instance":"3be2fa4a-1021-46de-80ca-6640527a377d-12734"},{"pid":12741,"role":"parent","attempt":4,"instance":"dc0df33b-43c1-4a0d-8e46-8cc0481121c0-12741"},{"pid":12753,"role":"child","attempt":4,"instance":"ec2c735e-f2b1-460c-9499-fc3ec2c029a8-12753"},{"pid":12754,"role":"grandchild","attempt":4,"instance":"991de4c6-6226-4eb0-8d6a-9d10e445179c-12754"},{"pid":12762,"role":"parent","attempt":5,"instance":"bb173592-cb67-4157-b9bb-89de2c7cdd67-12762"},{"pid":12766,"role":"child","attempt":5,"instance":"f84d132b-85ae-488c-8b75-ad90d1dab79e-12766"},{"pid":12767,"role":"grandchild","attempt":5,"instance":"b27f617c-bc26-4471-aa42-c518efab5fe3-12767"},{"pid":12769,"role":"parent","attempt":6,"instance":"ac1f85ba-eff0-4301-a3ab-8b7d6e320d27-12769"},{"pid":12777,"role":"child","attempt":6,"instance":"b5030326-9c19-4484-a0b7-6ee2da512b45-12777"},{"pid":12778,"role":"grandchild","attempt":6,"instance":"46144986-ec53-4bde-9aab-1a20c99f4da1-12778"},{"pid":12791,"role":"parent","attempt":7,"instance":"154ae69f-dbd2-44c7-859b-70ee2b82dc8e-12791"},{"pid":12795,"role":"child","attempt":7,"instance":"4ce46f62-aa48-47df-ba04-f4e66a52cdb5-12795"},{"pid":12796,"role":"grandchild","attempt":7,"instance":"ff66154d-d3f6-4be9-9e1e-a20619554858-12796"},{"pid":12798,"role":"parent","attempt":8,"instance":"e3b93d69-44b2-46b9-93d7-881c8f654d93-12798"},{"pid":12805,"role":"child","attempt":8,"instance":"19a7765f-1490-4151-99a9-f01c4e15676f-12805"},{"pid":12806,"role":"grandchild","attempt":8,"instance":"92c5c9ce-1b73-4d3f-a9f6-56f5e3af7322-12806"},{"pid":12815,"role":"parent","attempt":9,"instance":"6c813b8d-f3cf-483e-b641-0ff4f15ab80d-12815"},{"pid":12819,"role":"child","attempt":9,"instance":"6a98cb32-352b-4835-bef4-2c01796b067d-12819"},{"pid":12820,"role":"grandchild","attempt":9,"instance":"b9389f2d-204b-4d4e-98ff-5889cc3a03d4-12820"},{"pid":12822,"role":"parent","attempt":10,"instance":"5ec055d7-7bd0-4c62-9477-dd8f7ecb98b7-12822"},{"pid":12829,"role":"child","attempt":10,"instance":"5e21175b-09c1-4359-80f9-11e61894fec4-12829"},{"pid":12830,"role":"grandchild","attempt":10,"instance":"55402e47-eee3-4257-8939-3ced65640750-12830"},{"pid":12848,"role":"parent","attempt":11,"instance":"77406d43-b22a-4cb3-a548-d91399a46a01-12848"},{"pid":12852,"role":"child","attempt":11,"instance":"97fb3186-d139-48ec-87ca-4e7f802b201f-12852"},{"pid":12853,"role":"grandchild","attempt":11,"instance":"263a1299-7a80-4473-a629-dc4d482e917d-12853"},{"pid":12855,"role":"parent","attempt":12,"instance":"72c61683-6a50-4e49-83bd-4a4e92fb3f66-12855"},{"pid":12863,"role":"child","attempt":12,"instance":"7faeb025-995d-4e83-8e90-cef629b6eae5-12863"},{"pid":12864,"role":"grandchild","attempt":12,"instance":"40b9c4bb-4a99-4761-ac9f-b47d7d0e8041-12864"},{"pid":12872,"role":"parent","attempt":13,"instance":"b77b196f-c3dc-485a-b69e-4d4a1a1f6a37-12872"},{"pid":12876,"role":"child","attempt":13,"instance":"ac1ae836-b02a-4aec-8674-17ed882e11f7-12876"},{"pid":12877,"role":"grandchild","attempt":13,"instance":"26d707cb-94bf-49ba-bf16-de20842b4b84-12877"}],"commands":[{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout h7S930/workspace/performance-temp/reports","args":["config","--local","--get","core.hooksPath"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout h7S930/workspace/performance-temp/reports","args":["remote","get-url","origin"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout h7S930/workspace/performance-temp/reports","args":["cat-file","-e","11b53b14dafb925272ce47d3fc8497fa0dddd43f^{commit}"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout h7S930/workspace/performance-temp/reports","args":["push","origin","HEAD:main"],"configuration":[],"envProbe":"{\"token\":false,\"auth\":true,\"hooks\":\"/dev/null\",\"prompt\":\"0\",\"count\":\"2\"}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout h7S930/workspace/performance-temp/reports","args":["fetch","--depth=1","origin","main"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout h7S930/workspace/performance-temp/reports","args":["push","origin","HEAD:main"],"configuration":[],"envProbe":"{\"token\":false,\"auth\":true,\"hooks\":\"/dev/null\",\"prompt\":\"0\",\"count\":\"2\"}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout h7S930/workspace/performance-temp/reports","args":["fetch","--depth=1","origin","main"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout h7S930/workspace/performance-temp/reports","args":["push","origin","HEAD:main"],"configuration":[],"envProbe":"{\"token\":false,\"auth\":true,\"hooks\":\"/dev/null\",\"prompt\":\"0\",\"count\":\"2\"}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout h7S930/workspace/performance-temp/reports","args":["fetch","--depth=1","origin","main"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout h7S930/workspace/performance-temp/reports","args":["push","origin","HEAD:main"],"configuration":[],"envProbe":"{\"token\":false,\"auth\":true,\"hooks\":\"/dev/null\",\"prompt\":\"0\",\"count\":\"2\"}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout h7S930/workspace/performance-temp/reports","args":["fetch","--depth=1","origin","main"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout h7S930/workspace/performance-temp/reports","args":["push","origin","HEAD:main"],"configuration":[],"envProbe":"{\"token\":false,\"auth\":true,\"hooks\":\"/dev/null\",\"prompt\":\"0\",\"count\":\"2\"}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout h7S930/workspace/performance-temp/reports","args":["fetch","--depth=1","origin","main"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"}],"output":"::add-mask::[redacted]\nfixture backoff: 2\n::warning::Unable to refresh openclaw/clawgrit-reports after publish attempt 1; retrying.\nfixture backoff: 4\n::warning::Unable to refresh openclaw/clawgrit-reports after publish attempt 2; retrying.\nfixture backoff: 6\n::warning::Unable to refresh openclaw/clawgrit-reports after publish attempt 3; retrying.\nfixture backoff: 8\n::warning::Unable to refresh openclaw/clawgrit-reports after publish attempt 4; retrying.\nfixture backoff: 10\n::error::Kova artifacts uploaded, but clawgrit report publish failed after 5 attempts.\n"}

stdout | test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > advertises a clawgrit URL only after verified success ('missing token')
.github/workflows/openclaw-performance.yml/publish/Publish to clawgrit reports: {"code":1,"cancelledDuringCleanup":false,"boundaries":[{"name":"shell-command","alive":[],"sentinelAlive":true},{"name":"shell-command","alive":[],"sentinelAlive":true},{"name":"summary","alive":[],"sentinelAlive":true},{"name":"summary","alive":[],"sentinelAlive":true},{"name":"exit","alive":[],"sentinelAlive":true}],"readyAttempts":[],"cleanupRemaining":[],"ownedProcesses":[{"pid":12939,"role":"sentinel","attempt":0,"instance":"bd56e33e-c6e7-42b8-a33b-138ac203a74c-12939"},{"pid":12958,"role":"shell","attempt":0,"instance":"21fa96fc-9109-4aac-931a-aa7751dbc533-12958"}],"commands":[],"output":"::error::ClawSweeper GitHub App token is unavailable; Kova artifacts were uploaded, but the report cannot be published.\n"}

 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > advertises a clawgrit URL only after verified success ('exhausted') 4652ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > advertises a clawgrit URL only after verified success ('missing token') 591ms
stdout | test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > preserves both reports when concurrent writers update one latest pointer
.github/workflows/openclaw-performance.yml/publish/Publish to clawgrit reports: {"code":0,"cancelledDuringCleanup":false,"boundaries":[{"name":"shell-command","alive":[],"sentinelAlive":true},{"name":"shell-command","alive":[],"sentinelAlive":true},{"name":"config:1","alive":[],"sentinelAlive":true},{"name":"remote:1","alive":[],"sentinelAlive":true},{"name":"cat-file:1","alive":[],"sentinelAlive":true},{"name":"push:1","alive":[],"sentinelAlive":true},{"name":"backoff","alive":[],"sentinelAlive":true},{"name":"fetch:1","alive":[],"sentinelAlive":true},{"name":"ls-tree:1","alive":[],"sentinelAlive":true},{"name":"checkout:1","alive":[],"sentinelAlive":true},{"name":"cherry-pick:1","alive":[],"sentinelAlive":true},{"name":"rev-parse:1","alive":[],"sentinelAlive":true},{"name":"push:2","alive":[],"sentinelAlive":true},{"name":"summary","alive":[],"sentinelAlive":true},{"name":"summary","alive":[],"sentinelAlive":true},{"name":"exit","alive":[],"sentinelAlive":true}],"readyAttempts":[1,2,3,4,5,6,7,8,9,10],"cleanupRemaining":[],"ownedProcesses":[{"pid":13034,"role":"sentinel","attempt":0,"instance":"94471910-9665-492a-acde-54cad8e94654-13034"},{"pid":13051,"role":"shell","attempt":0,"instance":"5fc98886-cc57-4b6d-8b77-7727e2d0d8a5-13051"},{"pid":13067,"role":"parent","attempt":1,"instance":"4505124e-e345-41c8-a7fb-a8101484f598-13067"},{"pid":13071,"role":"child","attempt":1,"instance":"b8c37d03-ba2b-4ef6-ad51-f8c07ae7b847-13071"},{"pid":13072,"role":"grandchild","attempt":1,"instance":"bc3f24bd-1187-416d-b503-d3a31e75824f-13072"},{"pid":13075,"role":"parent","attempt":2,"instance":"2d127e7c-871e-485a-aabd-2ff82ad25ced-13075"},{"pid":13082,"role":"child","attempt":2,"instance":"c79fb053-7cec-438f-bbb7-50cc248e4987-13082"},{"pid":13083,"role":"grandchild","attempt":2,"instance":"0d1bc89f-9a3a-4d71-8bcc-b3fbefab1ea9-13083"},{"pid":13088,"role":"parent","attempt":3,"instance":"9a16e98b-1cde-4708-9adc-20ec6c899d8b-13088"},{"pid":13095,"role":"child","attempt":3,"instance":"9352f8c0-6998-485c-a13c-499014096b72-13095"},{"pid":13096,"role":"grandchild","attempt":3,"instance":"8cdfd008-005b-4f17-b1aa-10286112570b-13096"},{"pid":13099,"role":"parent","attempt":4,"instance":"a461e6cf-b4d5-4e2b-832d-f31d508a59c6-13099"},{"pid":13106,"role":"child","attempt":4,"instance":"8a27bb25-5b55-418b-93e1-b534407d903f-13106"},{"pid":13107,"role":"grandchild","attempt":4,"instance":"c13c908b-3336-4292-8792-02f4facb4974-13107"},{"pid":13117,"role":"parent","attempt":5,"instance":"de9b163e-2e66-462e-87d3-6acb21557692-13117"},{"pid":13122,"role":"child","attempt":5,"instance":"2da144a4-d6e9-4642-b6d8-8839f0b21e6f-13122"},{"pid":13123,"role":"grandchild","attempt":5,"instance":"c33c22cf-229a-4e60-9004-99a047037910-13123"},{"pid":13135,"role":"parent","attempt":6,"instance":"a560f1fd-2f8e-4b7f-84d7-66bb0fc6247b-13135"},{"pid":13147,"role":"child","attempt":6,"instance":"26f98e37-baad-466f-8f0d-6cef50f7e7fb-13147"},{"pid":13150,"role":"grandchild","attempt":6,"instance":"146370ae-ae21-496c-a3a4-50c8db269011-13150"},{"pid":13155,"role":"parent","attempt":7,"instance":"8e91972c-2f0c-4a1b-b43b-a075bde0f25e-13155"},{"pid":13162,"role":"child","attempt":7,"instance":"821a8bee-ba52-4c52-b751-f022ac2df3ff-13162"},{"pid":13163,"role":"grandchild","attempt":7,"instance":"55c783fc-c8f6-417e-bd24-03a2d92556f6-13163"},{"pid":13166,"role":"parent","attempt":8,"instance":"4f8eab74-33f6-473f-a59a-d1c68df78e0a-13166"},{"pid":13173,"role":"child","attempt":8,"instance":"140c60d2-0be4-4fd8-9ff5-32fb18921841-13173"},{"pid":13174,"role":"grandchild","attempt":8,"instance":"dc4529ba-61b0-4618-ac34-987c663d0c8f-13174"},{"pid":13177,"role":"parent","attempt":9,"instance":"08cb2b87-c022-4dd5-84a7-685d811a527c-13177"},{"pid":13184,"role":"child","attempt":9,"instance":"3576962a-8361-4725-8f68-4c455e6e3cdd-13184"},{"pid":13185,"role":"grandchild","attempt":9,"instance":"7ef2d731-6490-47a4-bf4a-58e66dd7b2cc-13185"},{"pid":13188,"role":"parent","attempt":10,"instance":"a9355b65-cb9a-4ae1-9f31-a43bfed8b2d0-13188"},{"pid":13197,"role":"child","attempt":10,"instance":"74b298c3-dc2f-4733-b389-ddabf6585a12-13197"},{"pid":13198,"role":"grandchild","attempt":10,"instance":"9f73ab84-c90f-4cbe-98d7-09f2ea20fc9e-13198"}],"commands":[{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout SXVrDl/workspace/performance-temp/reports","args":["config","--local","--get","core.hooksPath"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout SXVrDl/workspace/performance-temp/reports","args":["remote","get-url","origin"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout SXVrDl/workspace/performance-temp/reports","args":["cat-file","-e","11b53b14dafb925272ce47d3fc8497fa0dddd43f^{commit}"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout SXVrDl/workspace/performance-temp/reports","args":["push","origin","HEAD:main"],"configuration":[],"envProbe":"{\"token\":false,\"auth\":true,\"hooks\":\"/dev/null\",\"prompt\":\"0\",\"count\":\"2\"}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout SXVrDl/workspace/performance-temp/reports","args":["fetch","--depth=1","origin","main"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout SXVrDl/workspace/performance-temp/reports","args":["ls-tree","--name-only","FETCH_HEAD","--","openclaw-performance/main/123-1/mock-provider/report.json"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout SXVrDl/workspace/performance-temp/reports","args":["checkout","--detach","FETCH_HEAD"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout SXVrDl/workspace/performance-temp/reports","args":["cherry-pick","-X","theirs","11b53b14dafb925272ce47d3fc8497fa0dddd43f"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout SXVrDl/workspace/performance-temp/reports","args":["rev-parse","HEAD"],"configuration":["core.hooksPath=/dev/null"],"envProbe":"{\"token\":false,\"auth\":false,\"hooks\":null,\"prompt\":null,\"count\":null}"},{"tool":"git","cwd":"/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout SXVrDl/workspace/performance-temp/reports","args":["push","origin","HEAD:main"],"configuration":[],"envProbe":"{\"token\":false,\"auth\":true,\"hooks\":\"/dev/null\",\"prompt\":\"0\",\"count\":\"2\"}"}],"output":"::add-mask::[redacted]\nTo /private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout SXVrDl/workspace/reports.git\n ! [rejected]        HEAD -> main (fetch first)\nerror: failed to push some refs to '/private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout SXVrDl/workspace/reports.git'\nhint: Updates were rejected because the remote contains work that you do not\nhint: have locally. This is usually caused by another repository pushing to\nhint: the same ref. If you want to integrate the remote changes, use\nhint: 'git pull' before pushing again.\nhint: See the 'Note about fast-forwards' in 'git push --help' for details.\nfixture backoff: 2\nFrom /private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout SXVrDl/workspace/reports\n * branch            main       -> FETCH_HEAD\nHEAD is now at ecc76ec fixture report\nAuto-merging openclaw-performance/main/latest-mock-provider.json\n[detached HEAD 3d21f5f] fixture report\n Date: Sun Aug 30 13:38:28 2026 -0700\n 3 files changed, 3 insertions(+), 1 deletion(-)\n create mode 100644 openclaw-performance/main/123-1/mock-provider/report.json\n create mode 100644 openclaw-performance/main/123-1/mock-provider/source/index.md\nTo /private/tmp/openclaw-frozen-target-entrypoints/.artifacts/ci-checkout/checkout SXVrDl/workspace/reports.git\n   ecc76ec..3d21f5f  HEAD -> main\n"}

 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > preserves both reports when concurrent writers update one latest pointer 3717ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > requires the shared Kova report gate before tolerating partial verdicts 6ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > preserves required PARTIAL failures and clears only advisory PARTIAL failures 320ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > passes one comma-delimited include set to the lane plan and run 15ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > prepares a fail-closed systemd user session for OCM 8ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > validates exact Kova release-plan coverage before execution 3ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > uses Kova's explicit live auth contract without rewriting its state registry 7ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > finalizes Kova artifacts before failing evidence integrity 5ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > runs the trusted lane evidence validator before tolerating gate failures 5ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > selects exactly one full Kova report across producer and publisher paths 19ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > lets OCM discover its native workspace dependency adapter 3ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > fails selected live Kova lanes when live auth is missing 7ms
 ✓ |tooling| test/scripts/openclaw-performance-workflow.test.ts > OpenClaw performance workflow > requires Kova evidence before uploading selected lane artifacts 7ms
 ✓ |tooling| test/scripts/live-docker-stage.test.ts > live Docker state staging > selects 'gemini-api-key' from the supplied Gemini credentials 37ms
 ✓ |tooling| test/scripts/live-docker-stage.test.ts > live Docker state staging > selects 'vertex-ai' from the supplied Gemini credentials 37ms
 ✓ |tooling| test/scripts/live-docker-stage.test.ts > live Docker state staging > selects 'oauth-personal' from the supplied Gemini credentials 4ms
 ✓ |tooling| test/scripts/live-docker-stage.test.ts > live Docker state staging > installs missing CLI executables and refreshes pinned packages 392ms
 ✓ |tooling| test/scripts/live-docker-stage.test.ts > live Docker state staging > fails explicitly when a selected backend has no executable or install package 6ms
 ✓ |tooling| test/scripts/live-docker-stage.test.ts > live Docker state staging > runs the staged 'scripts/test-live.mts' live runner 153ms
 ✓ |tooling| test/scripts/live-docker-stage.test.ts > live Docker state staging > runs the staged 'scripts/test-live.mjs' live runner 171ms
 ✓ |tooling| test/scripts/live-docker-stage.test.ts > live Docker state staging > refuses to replace a missing staged live runner 7ms
 ✓ |tooling| test/scripts/live-docker-stage.test.ts > live Docker state staging > keeps repo-local generated artifacts out of the source copy 0ms
 ✓ |tooling| test/scripts/live-docker-stage.test.ts > live Docker state staging > adds private SDK source exports only to the disposable source stage 2ms
 ✓ |tooling| test/scripts/live-docker-stage.test.ts > live Docker state staging > keeps host-only generated registry state out of the container copy 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > discovers live tests without scanning source roots in-process 25ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > covers every native live test and tracks provider-filtered release fanout 1ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > keeps aggregate shard aliases available outside the release partition 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > routes fixture files across alphabet boundaries and dedicated slow shards 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > rejects unknown shard names 46ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > parses list mode and rejects unknown live shard options 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > prints CLI help before validating shard options 225ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > preserves Vitest passthrough args after the live shard separator 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > adds JSON report evidence without dropping operator output 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > prepares the private QA runtime for live shards that load its built API 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > prepares gateway profile shards with observable source-runtime diagnostics 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > runs the frozen candidate's available build entrypoint and advertised profile 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > prepares executable runtime artifacts before native-live-src-agents exercises live vision 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > prepares executable runtime artifacts before native-live-extensions-openai exercises live vision 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > fails live shard reports with no passing tests 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > requires live shard report evidence for each selected file 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > requires each selected live shard file to have a passing assertion 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > allows explicitly opt-in live shard files to be skipped until their env is enabled 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > allows gateway core opt-in live files to be skipped until their env is enabled 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > allows the OpenAI long-context live file to be skipped until its env is enabled 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > respects explicit opt-in and pass evidence for src/skills/workshop/experience-review.live.test.ts 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > respects explicit opt-in and pass evidence for src/agents/sessions/agent-session.openai-compaction.live.test.ts 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > allows GPT-Live files to be skipped until their shared opt-in is enabled 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > does not count disabled opt-in sentinel assertions as live shard proof 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > removes stale live shard reports before running a shard 1ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > spawns live shard children in a cleanup-friendly process group 0ms
 ✓ |tooling| test/scripts/test-live-shard.test.ts > scripts/test-live-shard > cleans live shard descendants before forwarding parent SIGTERM 285ms
 ✓ |tooling| test/scripts/install-smoke-no-push-workflow.test.ts > install smoke no-push root image transport > keeps schedule/manual orchestration read-only and delegates to the reusable core 1ms
 ✓ |tooling| test/scripts/install-smoke-no-push-workflow.test.ts > install smoke no-push root image transport > makes the reusable core artifact-only and rejects registry transport 112ms
 ✓ |tooling| test/scripts/install-smoke-no-push-workflow.test.ts > install smoke no-push root image transport > builds one local target image and uploads provenance-bound bytes 7ms
 ✓ |tooling| test/scripts/install-smoke-no-push-workflow.test.ts > install smoke no-push root image transport > verifies and loads the immutable artifact in every consumer 6ms
 ✓ |tooling| test/scripts/install-smoke-no-push-workflow.test.ts > install smoke no-push root image transport > binds independent installer producer-consumer pairs to immutable artifact tuples 7ms
 ✓ |tooling| test/scripts/install-smoke-no-push-workflow.test.ts > install smoke no-push root image transport > packages candidate code only in an isolated image and verifies the sealed payload 6ms
 ✓ |tooling| test/scripts/install-smoke-no-push-workflow.test.ts > install smoke no-push root image transport > drains every independent producer and consumer without sibling failure suppression 5ms
 ✓ |tooling| test/scripts/install-smoke-no-push-workflow.test.ts > install smoke no-push root image transport > selects the read-only reusable core from release checks 13ms
 ✓ |tooling| test/scripts/install-smoke-no-push-workflow.test.ts > install smoke no-push root image transport > passes package changelog intent only to the candidate packager 6ms

 Test Files  2 failed | 4 passed (6)
      Tests  2 failed | 280 passed | 2 skipped (284)
   Start at  13:37:02
   Duration  101.87s (transform 179ms, setup 26ms, import 414ms, tests 101.17s, environment 0ms)\n- \n- \n-  reached its conflict-marker lane, but the local  executable is malformed; its runner failed before suite execution. Focused test, actionlint, and diff proof above passed.\n- P0 autoreview: no demonstrated P0 defect.\n\nProduction LOC: +138/-74 (net +64) | Tests: +132/-37 (net +95). The production growth is the shared entrypoint/profile/capability and sealed-tarball metadata boundaries; it replaces target-specific compatibility assumptions.\n\nRelease-harness compatibility only; no release refs, packages, tags, or npm state changed.