### PR TITLE
perf(agents): prepare only consumed tool and skill diagnostics

### DIFF
--- a/src/agents/agent-tools.before-tool-call.diagnostics.ts
+++ b/src/agents/agent-tools.before-tool-call.diagnostics.ts
@@ -35,7 +35,7 @@ import {
   resolveSkillTelemetrySource,
   resolveSkillTelemetrySourceValue,
 } from "../skills/loading/source.js";
-import type { SkillSnapshot, SkillTelemetrySource, SkillUsagePath } from "../skills/types.js";
+import type { SkillSnapshot, SkillTelemetrySource } from "../skills/types.js";
 import { isPlainObject, truncateUtf16Safe } from "../utils.js";
 import { buildAdjustedParamsKey } from "./agent-tools.before-tool-call.state.js";
 import type {
@@ -334,51 +334,31 @@ function resolveRelativeToolPath(candidate: string, ctx?: HookContext): string |
   return base ? path.resolve(base, trimmed) : undefined;
 }
 
-function readToolPathCandidates(params: unknown, ctx?: HookContext): string[] {
-  if (!isPlainObject(params)) {
-    return [];
-  }
-  const candidates = typeof params.path === "string" ? [params.path] : [];
-  return candidates
-    .map((candidate) => resolveRelativeToolPath(normalizeFileToolPathParam(candidate), ctx))
-    .filter((candidate): candidate is string => Boolean(candidate));
+function readToolPathCandidate(params: unknown, ctx?: HookContext): string | undefined {
+  return isPlainObject(params) && typeof params.path === "string"
+    ? resolveRelativeToolPath(normalizeFileToolPathParam(params.path), ctx)
+    : undefined;
 }
 
-function skillInstructionPaths(snapshot: SkillSnapshot | undefined): Map<string, SkillUsageMatch> {
-  const matches = new Map<string, SkillUsageMatch>();
-  for (const skill of snapshot?.resolvedSkills ?? []) {
-    const skillName = typeof skill.name === "string" ? skill.name.trim() : "";
-    if (!skillName) {
-      continue;
+function findSkillInstructionMatch(
+  snapshot: SkillSnapshot,
+  candidate: string,
+): SkillUsageMatch | undefined {
+  const skill = snapshot.resolvedSkills?.findLast((entry) => {
+    if (typeof entry.name !== "string" || !entry.name.trim()) {
+      return false;
     }
-    const match = resolvedSkillUsageMatch({ activation: "read", skill });
-    const filePath = typeof skill.filePath === "string" ? skill.filePath.trim() : "";
-    if (filePath) {
-      if (filePath.startsWith("node://")) {
-        matches.set(filePath, match);
-      } else if (path.isAbsolute(filePath)) {
-        matches.set(path.resolve(filePath), match);
-      }
-    }
-    const baseDir = typeof skill.baseDir === "string" ? skill.baseDir.trim() : "";
-    if (baseDir && path.isAbsolute(baseDir)) {
-      matches.set(path.resolve(baseDir, "SKILL.md"), match);
-    }
-  }
-  return matches;
-}
-
-function materializedSkillInstructionPaths(paths: SkillUsagePath[] | undefined) {
-  const matches = new Map<string, SkillUsageMatch>();
-  for (const entry of paths ?? []) {
-    matches.set(path.resolve(entry.readPath), {
-      skillFile: entry.skillFile,
-      skillName: entry.skillName,
-      skillSource: entry.skillSource,
-      activation: "read",
-    });
-  }
-  return matches;
+    const filePath = typeof entry.filePath === "string" ? entry.filePath.trim() : "";
+    const baseDir = typeof entry.baseDir === "string" ? entry.baseDir.trim() : "";
+    return (
+      (filePath &&
+        (filePath.startsWith("node://")
+          ? filePath === candidate
+          : path.isAbsolute(filePath) && path.resolve(filePath) === candidate)) ||
+      (baseDir && path.isAbsolute(baseDir) && path.resolve(baseDir, "SKILL.md") === candidate)
+    );
+  });
+  return skill ? resolvedSkillUsageMatch({ activation: "read", skill }) : undefined;
 }
 
 export function findSkillUsageMatch(params: {
@@ -410,16 +390,24 @@ export function findSkillUsageMatch(params: {
   if (params.toolName !== "read") {
     return undefined;
   }
-  const skillPaths = params.ctx?.skillsSnapshot?.resolvedSkills?.length
-    ? skillInstructionPaths(params.ctx.skillsSnapshot)
-    : materializedSkillInstructionPaths(params.ctx?.skillUsagePaths);
-  for (const candidate of readToolPathCandidates(params.toolParams, params.ctx)) {
-    const match = skillPaths.get(candidate);
-    if (match) {
-      return match;
-    }
+  const candidate = readToolPathCandidate(params.toolParams, params.ctx);
+  if (!candidate) {
+    return undefined;
   }
-  return undefined;
+  if (params.ctx?.skillsSnapshot?.resolvedSkills?.length) {
+    return findSkillInstructionMatch(params.ctx.skillsSnapshot, candidate);
+  }
+  const match = params.ctx?.skillUsagePaths?.findLast(
+    (entry) => path.resolve(entry.readPath) === candidate,
+  );
+  return match
+    ? {
+        skillFile: match.skillFile,
+        skillName: match.skillName,
+        skillSource: match.skillSource,
+        activation: "read",
+      }
+    : undefined;
 }
 
 export function emitSkillUsedDiagnostic(params: {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.results.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.results.ts
@@ -676,7 +676,6 @@ export async function emitToolResultOutput(params: {
     return;
   }
 
-  const outputText = extractToolResultText(sanitizedResult);
   const mediaReply = isToolError ? undefined : extractToolResultMediaArtifact(result);
   const mediaUrls = mediaReply
     ? filterToolResultMediaUrls(
@@ -695,6 +694,7 @@ export async function emitToolResultOutput(params: {
       builtinToolNames: ctx.builtinToolNames,
     }) && ctx.shouldEmitToolOutput();
   if (shouldEmitOutput) {
+    const outputText = extractToolResultText(sanitizedResult);
     if (outputText) {
       ctx.emitToolOutput(rawToolName, meta, outputText, hasStructuredMedia ? undefined : result);
     }


### PR DESCRIPTION
## What Problem This Solves

Quiet tool completions prepare output text that their visibility gate discards. Read-tool skill accounting also builds a complete path-to-skill map and canonicalizes every skill, even when the read matches none of them. Both costs occur before the existing owner has selected what it actually needs.

## Why This Change Was Made

Prepare terminal text inside the existing visible-output branch, after unchanged sanitization, approval and structured-media handling. For skill reads, select the same final lexical match as the overwritten map, then canonicalize that winner freshly. Materialized paths keep their existing precedence and last-match behavior. There is no persistent cache, new configuration, dependency, protocol or storage change; the old eager map-building paths are removed.

## Validation

All 498 existing tests passed across nine subscriber, media, ordering, before-tool-call integration and verbosity/CLI-progress suites. Full pnpm build passed. Fresh managed Codex review and independent complete-owner reviews found no actionable findings. Full changed-file checks passed. Exact-head hosted CI run 33333940817 passed for d4b3a69dbe727c684e32b4a603a117288846ff93. The latest ClawSweeper review was read in full; it has no actionable findings and no additional Rank-up moves.

A real isolated dev Gateway used an environment-delivered OpenAI key with openai/gpt-5.6-luna. A short turn, two actual skill reads with persisted off/full verbosity, and an actual web_fetch all succeeded. Both reads returned the task-owned skill marker, each with one read and zero tool failures; the fetch also reported zero failures. The skill was present in the 30-skill runtime snapshot. Session-setting responses confirmed both verbosity values. The Gateway and client stopped cleanly, and Node CPU profiles were retained.

This is live behavior smoke, not before/after whole-turn latency proof. The Gateway agent RPC exposes item lifecycles and final answers, not physical-channel verbose bubbles; callback/media ordering and trusted skill-usage accounting are covered by the canonical and complete-owner proofs below. The unrelated advertised CLI verbose option is absent from Gateway request construction; that is recorded as a separate follow-up, and this proof used the canonical sessions.patch API.

## Measurements

Two independent changes, **−12 production lines** (+41/−53 by Git): prepare terminal text only inside the existing visible-output branch, and canonicalize only the skill that wins lexical matching. Sanitization, media admission, event order, command activation and fresh matched-path resolution remain at their existing owners. Progress and outcome proposals were rejected and are not included or counted.

The frozen current-source proof passed **811 scenarios / 2,433 complete comparisons** plus **120 uninstrumented comparisons over the exact 40 timing workloads**. Both fresh timing orders passed, retaining all 3,520 samples. The table reports complete copied-owner operations, not Gateway/provider latency.

| Complete operation | Before forward/reverse | Candidate forward/reverse | Speedup forward/reverse |
| --- | ---: | ---: | ---: |
| Quiet terminal, large structured fallback | 1.466 / 1.726 ms | 0.501 / 0.581 ms | 2.928× / 2.969× |
| Wrapped read, 50 skills, miss | 0.734 / 0.770 ms | 0.0549 / 0.0577 ms | 13.362× / 13.329× |
| Wrapped read, 50 skills, last match | 0.756 / 0.736 ms | 0.0302 / 0.0312 ms | 25.055× / 23.626× |
| Combined structured read, no skills | 1.546 / 1.606 ms | 0.571 / 0.575 ms | 2.709× / 2.793× |
| Combined structured read, 50 skills | 2.368 / 2.493 ms | 0.598 / 0.633 ms | 3.959× / 3.938× |
| Combined default exec progress | 0.214 / 0.235 ms | 0.216 / 0.230 ms | 0.992× / 1.019× |
| Plain terminal, full verbosity (isolated terminal change) | 0.1008 / 0.1061 ms | 0.1073 / 0.1086 ms | 0.939× / 0.977× |

Costs are retained, not averaged away: combined plain/full is 0.880×/0.988× and combined plain/off is 0.977×/0.928×. Full structured output is mixed (1.020×/0.960× isolated). The eight-kilobyte built-in exec control is 0.985×/0.986×. All unchanged progress/outcome controls remain in the full table; their differences are not causal speedup claims. Structured fallback is supported, but these fixtures do not measure its production prevalence. Skill paths use warm task-owned filesystem fixtures.

The forward/reverse child processes took 10.975/11.352 s, with user CPU 9.769/10.116 s, system CPU 1.948/1.950 s, and peak RSS 815.14/798.66 MiB. These totals include four copied module graphs plus the harness and do not claim production memory savings. Both process groups are dead; zero network operations were attempted. The separately preserved r6 binding failure happened during a concurrent workspace build, and no r6 timing is claimed.

Final source binding `06a0d9570958c2057e385537752c9f5607df1e6049927c435132dc4743b57ea3`; timing binding `9d102897a003fd652ba460327d7970d65a46dc2428b870fb8d56d799e0f965d9`. Actual owner bodies match the tracked formatted patch at base `02c095ff389dd4f503d72a16c44d33f3fc87ce68`.
