### PR TITLE
fix(ui): keep notification settings controls and cards consistent

### DIFF
--- a/ui/src/pages/config/notifications-section.test.ts
+++ b/ui/src/pages/config/notifications-section.test.ts
@@ -14,7 +14,7 @@ const userPreferences = {
     backgroundTaskFailed: false,
   },
   detailLevel: "private" as const,
-  quietHours: { enabled: false, startMinute: 1320, endMinute: 420, timeZone: "UTC" },
+  quietHours: { enabled: true, startMinute: 1320, endMinute: 420, timeZone: "UTC" },
   agentIds: [],
 };
 
@@ -88,7 +88,12 @@ describe("Web Push preference saves", () => {
           preferences: {
             durableIdentity: true,
             user: userPreferences,
-            device: { enabled: true, label: "phone" },
+            device: {
+              enabled: true,
+              label: "phone",
+              quietHours: { enabled: true, startMinute: 1320, endMinute: 420, timeZone: "UTC" },
+              agentIds: [],
+            },
             effective: { ...userPreferences, enabled: true, label: "phone" },
           },
         },
@@ -100,7 +105,13 @@ describe("Web Push preference saves", () => {
     const preferenceGroup = expectDefined(preferences, "notification preferences group");
     expect(preferenceGroup.querySelectorAll("wa-switch.settings-toggle")).toHaveLength(7);
     expect(preferenceGroup.querySelectorAll("select.settings-select")).toHaveLength(9);
+    expect(preferenceGroup.querySelectorAll("input.settings-input")).toHaveLength(9);
     expect(preferenceGroup.querySelector('input[type="checkbox"]')).toBeNull();
+    expect(
+      [...preferenceGroup.querySelectorAll('input[type="text"], input[type="time"]')].every(
+        (input) => input.classList.contains("settings-input") && input.hasAttribute("aria-label"),
+      ),
+    ).toBe(true);
     expect(
       [...preferenceGroup.querySelectorAll("select.settings-select")].every((select) =>
         select.hasAttribute("aria-label"),

--- a/ui/src/pages/config/notifications-section.test.ts
+++ b/ui/src/pages/config/notifications-section.test.ts
@@ -96,9 +96,16 @@ describe("Web Push preference saves", () => {
       container,
     );
 
-    const preferences = container.querySelector<HTMLElement>(".settings-page .settings-page");
+    const preferences = container.querySelector<HTMLElement>(".settings-page > .settings-stack");
     const preferenceGroup = expectDefined(preferences, "notification preferences group");
-    expect(preferenceGroup.querySelector("input, select")).not.toBeNull();
+    expect(preferenceGroup.querySelectorAll("wa-switch.settings-toggle")).toHaveLength(7);
+    expect(preferenceGroup.querySelectorAll("select.settings-select")).toHaveLength(9);
+    expect(preferenceGroup.querySelector('input[type="checkbox"]')).toBeNull();
+    expect(
+      [...preferenceGroup.querySelectorAll("select.settings-select")].every((select) =>
+        select.hasAttribute("aria-label"),
+      ),
+    ).toBe(true);
     expect(preferenceGroup.hasAttribute("inert")).toBe(true);
   });
 });

--- a/ui/src/pages/config/notifications-section.ts
+++ b/ui/src/pages/config/notifications-section.ts
@@ -129,9 +129,11 @@ function renderUserNotificationPreferences(
           ? html`
               ${renderSettingsRow({
                 title: t("configView.notifications.quietHoursWindow"),
-                control: html`<span>
+                control: html`
                   <input
+                    class="settings-input"
                     type="time"
+                    aria-label=${t("configView.notifications.quietHoursWindow")}
                     .value=${minutesToTime(preferences.quietHours.startMinute)}
                     @change=${(event: Event) =>
                       patch({
@@ -146,7 +148,9 @@ function renderUserNotificationPreferences(
                   />
                   –
                   <input
+                    class="settings-input"
                     type="time"
+                    aria-label=${t("configView.notifications.quietHoursWindow")}
                     .value=${minutesToTime(preferences.quietHours.endMinute)}
                     @change=${(event: Event) =>
                       patch({
@@ -159,12 +163,14 @@ function renderUserNotificationPreferences(
                         },
                       })}
                   />
-                </span>`,
+                `,
               })}
               ${renderSettingsRow({
                 title: t("configView.notifications.timeZone"),
                 control: html`<input
+                  class="settings-input"
                   type="text"
+                  aria-label=${t("configView.notifications.timeZone")}
                   .value=${preferences.quietHours.timeZone}
                   @change=${(event: Event) =>
                     patch({
@@ -180,7 +186,9 @@ function renderUserNotificationPreferences(
         ${renderSettingsRow({
           title: t("configView.notifications.onlyAgents"),
           control: html`<input
+            class="settings-input"
             type="text"
+            aria-label=${t("configView.notifications.onlyAgents")}
             .value=${preferences.agentIds.join(", ")}
             @change=${(event: Event) =>
               patch({
@@ -216,8 +224,10 @@ function renderDeviceNotificationPreferences(
         ${renderSettingsRow({
           title: t("configView.notifications.notificationLabel"),
           control: html`<input
+            class="settings-input"
             type="text"
             maxlength="80"
+            aria-label=${t("configView.notifications.notificationLabel")}
             .value=${preferences.label}
             @change=${(event: Event) => patch({ label: inputTarget(event).value })}
           />`,
@@ -275,9 +285,11 @@ function renderDeviceNotificationPreferences(
           ? html`
               ${renderSettingsRow({
                 title: t("configView.notifications.quietHoursWindow"),
-                control: html`<span>
+                control: html`
                   <input
+                    class="settings-input"
                     type="time"
+                    aria-label=${t("configView.notifications.quietHoursWindow")}
                     .value=${minutesToTime(deviceQuietHours.startMinute)}
                     @change=${(event: Event) =>
                       patch({
@@ -292,7 +304,9 @@ function renderDeviceNotificationPreferences(
                   />
                   –
                   <input
+                    class="settings-input"
                     type="time"
+                    aria-label=${t("configView.notifications.quietHoursWindow")}
                     .value=${minutesToTime(deviceQuietHours.endMinute)}
                     @change=${(event: Event) =>
                       patch({
@@ -305,12 +319,14 @@ function renderDeviceNotificationPreferences(
                         },
                       })}
                   />
-                </span>`,
+                `,
               })}
               ${renderSettingsRow({
                 title: t("configView.notifications.timeZone"),
                 control: html`<input
+                  class="settings-input"
                   type="text"
+                  aria-label=${t("configView.notifications.timeZone")}
                   .value=${deviceQuietHours.timeZone}
                   @change=${(event: Event) =>
                     patch({
@@ -342,7 +358,9 @@ function renderDeviceNotificationPreferences(
           ? renderSettingsRow({
               title: t("configView.notifications.onlyAgents"),
               control: html`<input
+                class="settings-input"
                 type="text"
+                aria-label=${t("configView.notifications.onlyAgents")}
                 .value=${preferences.agentIds.join(", ")}
                 @change=${(event: Event) =>
                   patch({

--- a/ui/src/pages/config/notifications-section.ts
+++ b/ui/src/pages/config/notifications-section.ts
@@ -12,6 +12,7 @@ import { icons } from "../../components/icons.ts";
 import {
   renderSettingsRow,
   renderSettingsStatus,
+  renderSettingsToggleRow,
   renderSettingsValue,
 } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
@@ -84,25 +85,24 @@ function renderUserNotificationPreferences(
       </div>
       <div class="settings-group">
         ${WEB_PUSH_CATEGORIES.map(([key, label]) =>
-          renderSettingsRow({
+          renderSettingsToggleRow({
             title: label(),
-            control: html`<input
-              type="checkbox"
-              .checked=${preferences.categories[key]}
-              @change=${(event: Event) =>
-                patch({
-                  categories: {
-                    ...preferences.categories,
-                    [key]: inputTarget(event).checked,
-                  },
-                })}
-            />`,
+            checked: preferences.categories[key],
+            onChange: (checked) =>
+              patch({
+                categories: {
+                  ...preferences.categories,
+                  [key]: checked,
+                },
+              }),
           }),
         )}
         ${renderSettingsRow({
           title: t("configView.notifications.lockScreenDetail"),
           description: t("configView.notifications.lockScreenDetailHint"),
           control: html`<select
+            class="settings-select"
+            aria-label=${t("configView.notifications.lockScreenDetail")}
             .value=${preferences.detailLevel}
             @change=${(event: Event) =>
               patch({
@@ -114,19 +114,16 @@ function renderUserNotificationPreferences(
             <option value="detailed">${t("configView.notifications.detailed")}</option>
           </select>`,
         })}
-        ${renderSettingsRow({
+        ${renderSettingsToggleRow({
           title: t("configView.notifications.quietHours"),
-          control: html`<input
-            type="checkbox"
-            .checked=${preferences.quietHours.enabled}
-            @change=${(event: Event) =>
-              patch({
-                quietHours: {
-                  ...preferences.quietHours,
-                  enabled: inputTarget(event).checked,
-                },
-              })}
-          />`,
+          checked: preferences.quietHours.enabled,
+          onChange: (checked) =>
+            patch({
+              quietHours: {
+                ...preferences.quietHours,
+                enabled: checked,
+              },
+            }),
         })}
         ${preferences.quietHours.enabled
           ? html`
@@ -211,13 +208,10 @@ function renderDeviceNotificationPreferences(
         <h2 class="settings-section__heading">${t("configView.notifications.installedApp")}</h2>
       </div>
       <div class="settings-group">
-        ${renderSettingsRow({
+        ${renderSettingsToggleRow({
           title: t("configView.notifications.deliverDevice"),
-          control: html`<input
-            type="checkbox"
-            .checked=${preferences.enabled}
-            @change=${(event: Event) => patch({ enabled: inputTarget(event).checked })}
-          />`,
+          checked: preferences.enabled,
+          onChange: (enabled) => patch({ enabled }),
         })}
         ${renderSettingsRow({
           title: t("configView.notifications.notificationLabel"),
@@ -231,6 +225,8 @@ function renderDeviceNotificationPreferences(
         ${renderSettingsRow({
           title: t("configView.notifications.lockScreenDetail"),
           control: html`<select
+            class="settings-select"
+            aria-label=${t("configView.notifications.lockScreenDetail")}
             .value=${preferences.detailLevel ?? "inherit"}
             @change=${(event: Event) => {
               const value = selectTarget(event).value;
@@ -248,6 +244,8 @@ function renderDeviceNotificationPreferences(
         ${renderSettingsRow({
           title: t("configView.notifications.quietHours"),
           control: html`<select
+            class="settings-select"
+            aria-label=${t("configView.notifications.quietHours")}
             .value=${preferences.quietHours === undefined
               ? "inherit"
               : preferences.quietHours.enabled
@@ -328,6 +326,8 @@ function renderDeviceNotificationPreferences(
         ${renderSettingsRow({
           title: t("configView.notifications.onlyAgents"),
           control: html`<select
+            class="settings-select"
+            aria-label=${t("configView.notifications.onlyAgents")}
             .value=${preferences.agentIds === undefined ? "inherit" : "override"}
             @change=${(event: Event) => {
               const value = selectTarget(event).value;
@@ -358,6 +358,8 @@ function renderDeviceNotificationPreferences(
           renderSettingsRow({
             title: label(),
             control: html`<select
+              class="settings-select"
+              aria-label=${label()}
               .value=${preferences.categories?.[key] === undefined
                 ? "inherit"
                 : preferences.categories[key]
@@ -654,7 +656,7 @@ export function renderNotificationsSection(props: NotificationsSectionProps) {
         </div>
       </section>
       ${registered && push.preferences
-        ? html`<div class="settings-page" ?inert=${push.loading}>
+        ? html`<div class="settings-stack" ?inert=${push.loading}>
             ${push.preferences.durableIdentity
               ? renderUserNotificationPreferences(push.preferences.user, (preferences) =>
                   props.onWebPushSetUserPreferences?.(preferences),


### PR DESCRIPTION
Closes #133513

## What Problem This Solves

Fixes an issue where users with browser push preferences enabled would see browser-default checkboxes, selects, text inputs, and time inputs on Settings → Notifications, while the Account defaults and device cards were narrower and inset relative to Push notifications.

Introduced in #129348.

## Why This Change Was Made

This PR proposes using the existing settings toggle rows, styled select class, and styled input class for every affected notification preference. It also replaces the nested page container with the canonical embedded settings stack so all three sections share one column. The quiet-hours pairs use the existing row control layout to keep both styled time inputs inline. No new component or page-specific style is added.

## User Impact

Notification preferences will match the controls used throughout settings, every select and input will have an accessible name, and Push notifications, Account defaults, and This browser or app will have collinear card borders.

## Evidence

The equivalent local Control UI fixture includes all three sections and supports changing every preference. Relative to the original behavior, this PR renders 7 standard switches instead of browser checkboxes, 9 styled selects, 9 styled text/time inputs, and card widths of 728 / 728 / 728 px instead of 728 / 696 / 696 px.

The refreshed comparison below isolates the input follow-up with both quiet-hours groups and the device agent override expanded. Before, all 9 text/time inputs used the browser's raw 28 px controls with square corners and 2 px borders. In this PR they use the shared 32 px settings control, themed 1 px border, rounded surface, padding, and focus treatment in both themes. The four time inputs remain inline. All 9 inputs accepted and restored representative values before capture.

### Light

| Before | In this PR |
| --- | --- |
| ![Notification inputs before the follow-up in light mode](https://github.com/user-attachments/assets/6b4786b4-687f-4a93-8eff-4a0ad41459d7) | ![Notification inputs in this PR in light mode](https://github.com/user-attachments/assets/a16bfab8-f4c3-46e3-858a-77f524a8003e) |

### Dark

| Before | In this PR |
| --- | --- |
| ![Notification inputs before the follow-up in dark mode](https://github.com/user-attachments/assets/b59e20dc-e5d4-45dd-bad0-8e051a431c84) | ![Notification inputs in this PR in dark mode](https://github.com/user-attachments/assets/74f2d45e-1a79-4c72-b681-f2a37b4c1830) |

Local suites were not run on the maintainer machine; exact-head CI is the validation gate.
