### PR TITLE
perf(plugins): avoid eager loader imports for active registry reads

### DIFF
--- a/src/plugins/active-runtime-registry.import.test.ts
+++ b/src/plugins/active-runtime-registry.import.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import {
+  clearActivePluginRegistry,
+  getActivePluginRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "./runtime.js";
+
+afterEach(async () => {
+  vi.doUnmock("./loader-runtime-load.js");
+  await clearActivePluginRegistry();
+  resetPluginRuntimeStateForTest();
+  vi.resetModules();
+});
+
+it("reads loaded registries without evaluating the plugin loader on hits or misses", async () => {
+  await clearActivePluginRegistry();
+  vi.resetModules();
+  vi.doMock("./loader-runtime-load.js", () => {
+    throw new Error("loaded-registry lookup must not evaluate loader-runtime-load");
+  });
+
+  const { getLoadedRuntimePluginRegistry } = await import("./active-runtime-registry.js");
+  expect(getLoadedRuntimePluginRegistry()).toBeUndefined();
+
+  const { resolvePluginLoadCacheContext } = await import("./loader-load-context.js");
+  const loadOptions = { config: {}, installRecords: {} };
+  const registry = createEmptyPluginRegistry();
+  setActivePluginRegistry(registry, resolvePluginLoadCacheContext(loadOptions).cacheKey);
+
+  expect(getLoadedRuntimePluginRegistry()).toBe(registry);
+  expect(getLoadedRuntimePluginRegistry({ loadOptions })).toBe(registry);
+  expect(
+    getLoadedRuntimePluginRegistry({
+      loadOptions: { ...loadOptions, workspaceDir: "/different-workspace" },
+    }),
+  ).toBeUndefined();
+  expect(getActivePluginRegistry()).toBe(registry);
+});

--- a/src/plugins/active-runtime-registry.ts
+++ b/src/plugins/active-runtime-registry.ts
@@ -1,12 +1,34 @@
 // Stores active runtime plugin registry state and activation metadata.
 import { normalizeSortedUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
-import { resolveCompatibleRuntimePluginRegistry, type PluginLoadOptions } from "./loader.js";
+import { resolvePluginLoadCacheContext } from "./loader-load-context.js";
+import type { PluginLoadOptions } from "./loader-types.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginRecord, PluginRegistry } from "./registry-types.js";
-import { getActivePluginRegistry, getActivePluginRegistryWorkspaceDir } from "./runtime.js";
+import {
+  getActivePluginRegistry,
+  getActivePluginRegistryKey,
+  getActivePluginRegistryWorkspaceDir,
+} from "./runtime.js";
 
 export function getActiveRuntimePluginRegistry(): PluginRegistry | null {
   return getActivePluginRegistry();
+}
+
+/** Return the exact active registry without triggering a fresh load on cache miss. */
+export function resolveCompatibleRuntimePluginRegistry(
+  options?: PluginLoadOptions,
+): PluginRegistry | undefined {
+  const activeRegistry = getActivePluginRegistry() ?? undefined;
+  if (!activeRegistry || options === undefined) {
+    return activeRegistry;
+  }
+  const activeCacheKey = getActivePluginRegistryKey();
+  if (!activeCacheKey) {
+    return undefined;
+  }
+  return resolvePluginLoadCacheContext(options).cacheKey === activeCacheKey
+    ? activeRegistry
+    : undefined;
 }
 
 function isRuntimePluginRecordLoaded(plugin: PluginRecord): boolean {

--- a/src/plugins/loader-runtime-registry.ts
+++ b/src/plugins/loader-runtime-registry.ts
@@ -1,28 +1,13 @@
+import { resolveCompatibleRuntimePluginRegistry } from "./active-runtime-registry.js";
 import { isPluginRegistryLoadInFlight } from "./loader-cache.js";
-import { resolvePluginLoadCacheContext } from "./loader-load-context.js";
 import { loadOpenClawPlugins } from "./loader-runtime-load.js";
 import type { PluginLoadOptions } from "./loader-types.js";
-import type { PluginRegistry } from "./registry.js";
-import { getActivePluginRegistry, getActivePluginRegistryKey } from "./runtime.js";
-
-function getExactActivePluginRegistry(options?: PluginLoadOptions): PluginRegistry | undefined {
-  const activeRegistry = getActivePluginRegistry() ?? undefined;
-  if (!activeRegistry || options === undefined) {
-    return activeRegistry;
-  }
-  const activeCacheKey = getActivePluginRegistryKey();
-  if (!activeCacheKey) {
-    return undefined;
-  }
-  return resolvePluginLoadCacheContext(options).cacheKey === activeCacheKey
-    ? activeRegistry
-    : undefined;
-}
+import type { PluginRegistry } from "./registry-types.js";
 
 export function resolveRuntimePluginRegistry(
   options?: PluginLoadOptions,
 ): PluginRegistry | undefined {
-  const activeRegistry = getExactActivePluginRegistry(options);
+  const activeRegistry = resolveCompatibleRuntimePluginRegistry(options);
   if (activeRegistry) {
     return activeRegistry;
   }
@@ -40,11 +25,4 @@ export function getRuntimePluginRegistryForLoadOptions(
   options?: PluginLoadOptions,
 ): PluginRegistry | undefined {
   return resolveRuntimePluginRegistry(options);
-}
-
-/** Return the exact active registry without triggering a fresh load on cache miss. */
-export function resolveCompatibleRuntimePluginRegistry(
-  options?: PluginLoadOptions,
-): PluginRegistry | undefined {
-  return getExactActivePluginRegistry(options);
 }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1,6 +1,7 @@
 /** Stable public facade for plugin loading and runtime-registry resolution. */
 import { loadOpenClawPlugins } from "./loader-runtime-load.js";
 import type { PluginLoadOptions } from "./loader-types.js";
+export { resolveCompatibleRuntimePluginRegistry } from "./active-runtime-registry.js";
 export {
   clearPluginRegistryLoadCache,
   isPluginRegistryLoadInFlight,
@@ -9,7 +10,6 @@ export {
 export { loadOpenClawPluginCliRegistry } from "./loader-cli-registry.js";
 export {
   getRuntimePluginRegistryForLoadOptions,
-  resolveCompatibleRuntimePluginRegistry,
   resolveRuntimePluginRegistry,
 } from "./loader-runtime-registry.js";
 

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -102,7 +102,7 @@ let runProviderDynamicModel: typeof import("./provider-runtime.js").runProviderD
 let validateProviderReplayTurnsWithPlugin: typeof import("./provider-runtime.js").validateProviderReplayTurnsWithPlugin;
 let wrapProviderSimpleCompletionStreamFn: typeof import("./provider-runtime.js").wrapProviderSimpleCompletionStreamFn;
 let wrapProviderStreamFn: typeof import("./provider-runtime.js").wrapProviderStreamFn;
-let createEmptyPluginRegistry: typeof import("./registry.js").createEmptyPluginRegistry;
+let createEmptyPluginRegistry: typeof import("./registry-empty.js").createEmptyPluginRegistry;
 let resetPluginRuntimeStateForTest: typeof import("./runtime.js").resetPluginRuntimeStateForTest;
 let setActivePluginRegistry: typeof import("./runtime.js").setActivePluginRegistry;
 
@@ -355,7 +355,7 @@ describe("provider-runtime", () => {
       await import("./provider-hook-runtime.js"));
     await import("../agents/ai-transport-runtime-host.js");
     ({ getAiTransportHost } = await import("@openclaw/ai"));
-    ({ createEmptyPluginRegistry } = await import("./registry.js"));
+    ({ createEmptyPluginRegistry } = await import("./registry-empty.js"));
     ({ resetPluginRuntimeStateForTest, setActivePluginRegistry } = await import("./runtime.js"));
   });
 


### PR DESCRIPTION
Related: [#132932 — tool-metadata import extraction](https://github.com/openclaw/openclaw/pull/132932), [#133028 — MCP import-boundary repair](https://github.com/openclaw/openclaw/pull/133028). Both were already included in the reported failing revision; this repairs a separate import edge.

## What Problem This Solves

Resolves a problem where developers running focused provider-runtime tests paid the cold import cost of the full plugin loader, config validation, and doctor migration modules even when the operation only read already-registered state. This was isolated while investigating a reported `beforeAll` timeout at 180 seconds; an identical retry had passed without a source or timeout change.

The timed failure itself did not recur during this investigation. The reproducible defect is the eager activation-loader dependency of the read-only registry boundary, not a demonstrated universal 180-second timeout.

## Why This Change Was Made

The canonical exact active-registry lookup now belongs to the active-registry reader. The loading resolver reuses it, and the loader facade keeps its existing export. This removes the dependency from the read-only reader back into the activation loader, along with the obsolete private-lookup/public-forwarder pair. Simply importing `loader-runtime-registry.ts` instead of the barrel would retain its eager loader import.

The provider test now obtains its empty registry from the existing `registry-empty.ts` leaf. The real transport-host setup, module reset, mock boundaries, and every ownership/normalization assertion remain intact. Exact cache keys, workspace matching, scoped containment, empty scopes, disabled/deferred owners, and the loading resolver's miss/in-flight behavior are unchanged. No provider-wide synchronous-loader rewrite, runtime fallback, new cache, configuration option, timeout increase, dependency change, or docs expansion.

## User Impact

Lower incidental import work for loaded-registry readers and focused provider test setup. No intended change to operator configuration, provider ownership, plugin activation decisions, or public SDK behavior. This is a bounded maintainer-requested performance repair, not a new feature.

Production LOC: **+28/-28, net 0**, across three files, mostly moving the existing lookup body. Tests: **+42/-2, net +40**. No existing behavior assertions were removed.

## Evidence

**Deterministic regression:** the new import-boundary test exercises real registry hits, misses, matching/mismatching load options, and unchanged active identity while a narrow sentinel rejects evaluation of `loader-runtime-load.ts`. Before the production change it failed at `loader.ts:2` with `loaded-registry lookup must not evaluate loader-runtime-load`; after the change it passes. It does not mock the reader or broadly replace the runtime. Cleanup is safe for the default non-isolated runner.

**Full owner and sibling proof:** 284 passing tests across 12 files, including all 69 provider-runtime cases and all 9 Google policy cases. This includes active-registry, loading-registry, provider, capability, migration, web-provider, status/facade, runtime-registry, and middleware coverage. A separate focused loader test passed the real loading resolver's same-snapshot in-flight short circuit.

```bash
node scripts/run-vitest.mjs src/plugins/active-runtime-registry.import.test.ts src/plugins/provider-runtime.test.ts src/plugins/active-runtime-registry.test.ts src/plugins/loader.runtime-registry.test.ts extensions/google/provider-policy-api.test.ts src/plugins/providers.test.ts src/plugins/capability-provider-runtime.test.ts src/plugins/migration-provider-runtime.test.ts src/plugins/web-provider-runtime-shared.test.ts src/plugins/status.compatibility.integration.test.ts src/plugins/runtime/runtime-registry-loader.test.ts src/plugins/agent-tool-result-middleware.test.ts
```

```bash
node scripts/run-vitest.mjs src/plugins/loader.test.ts -t 'resolveRuntimePluginRegistry'
```

**Cold-cache experiment:** the following unchanged command was run before and after with separate, initially absent task-owned `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH` roots; the after run was then repeated against its warmed cache. No shared caches were deleted, and no behavior/worker/pool/timeout settings were forced.

```bash
node scripts/run-vitest.mjs src/plugins/provider-runtime.test.ts extensions/google/provider-policy-api.test.ts -t 'normaliz|config hooks|bundled.*config|matched provider|configured core transport'
```

| Run | Whole-command wall | Provider suite | Provider transform | Google suite | Peak RSS |
| --- | ---: | ---: | ---: | ---: | ---: |
| Before, fresh cache | 47.07s | 28.55s | 21.54s | 7.91s | 805.7 MiB |
| After, fresh cache | 10.36s | 4.48s | 2.66s | 2.58s | 715.6 MiB |
| After, identical warm retry | 4.65s | 1.50s | 0.526s | 1.16s | 500.1 MiB |
| Later independent after, another fresh cache | 129.72s | 53.68s | 35.52s | 41.77s | 576.0 MiB |

Every row passed the same 9 selected core and 5 Google cases. The independent lead also reran the new import regression separately and it passed. The later rerun and the unchanged Google suite's variation demonstrate substantial shared-host noise: **these samples do not establish a stable speedup percentage or explain the original timeout's amplification**. The deterministic import regression and unchanged owner behavior are the acceptance evidence.

**Gates:** existing formatter, full `node scripts/check-changed.mjs` plan for the five changed files, core/test typechecks, lint, dead-export checks, and `pnpm build` passed. Runtime value cycles: 0; ineffective-dynamic-import warnings: 0. Build completed in 8m 15.9s. Independent Codex autoreview reported the selected uncommitted diff scoped-clean at its configured blocking priority; the lead inspected the owner, callers, siblings, and complete patch.

No UI, channel-delivery, external API, persistence, schema, or protocol behavior changed, so browser/channel/live-provider proof is not the applicable surface. The actual developer flow is the real repository test wrapper above. Exact-head CI is required before landing.
