### PR TITLE
fix(ui): deduplicate participant and viewer avatars

### DIFF
--- a/docs/concepts/multi-user.md
+++ b/docs/concepts/multi-user.md
@@ -56,7 +56,7 @@ The Control UI keeps ownership and presence visually distinct:
 
 - A solid owner avatar on a session row is permanent for the lifetime of that session and always shows the current owner. It dims slightly while the owner is not connected.
 - When other people or agents have prompted the session, the row avatar becomes a **pair-stack**: the owner stays in front, and either the single other participant peeks out behind, or a **+N** count summarizes several. The chat header shows the owner chip plus a participant facepile of up to four avatars. The owner is excluded from the participant display.
-- Ringed or translucent presence avatars show people who are currently connected or watching; they come from live presence, not ownership, and disappear when those viewers leave.
+- Ringed or translucent presence avatars show people who are currently connected or watching; they come from live presence, not ownership, and disappear when those viewers leave. A person already shown by an owner or participant avatar is not repeated in that surface's live viewers. Participants summarized by a **+N** count can still appear individually as live viewers.
 
 When several people watch the same session, the transcript also shows a live typing indicator above the composer. Someone typing in the Control UI streams their draft text into the indicator bubble as they type; other typists show a three-dot bubble. Drafts are ephemeral presence: they are never persisted, never enter the session transcript or the model's context, and fade a moment after the typist pauses or sends.
 

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -223,7 +223,7 @@ export function renderRecentSession(params: {
         gateway.connection.password.trim()),
     ),
   };
-  const { running, leadingIndicator, trailingIndicator, renderedOwnerIdentity } =
+  const { running, leadingIndicator, trailingIndicator, renderedIdentities } =
     renderSessionLeadingState(
       session,
       leadingOwner,
@@ -371,7 +371,7 @@ export function renderRecentSession(params: {
                 .selfUser=${host.sessionDataContext?.gateway.snapshot.selfUser}
                 .selfInstanceId=${host.sessionData.presenceInstanceId}
                 .sessionKey=${session.key}
-                .excludeIdentity=${renderedOwnerIdentity}
+                .excludeIdentities=${renderedIdentities ?? []}
                 .maxVisible=${3}
                 variant="session"
               ></openclaw-viewer-facepile>

--- a/ui/src/components/session-leading-indicator.ts
+++ b/ui/src/components/session-leading-indicator.ts
@@ -60,7 +60,7 @@ export function renderSessionLeadingState(
   running: boolean;
   leadingIndicator: TemplateResult | typeof nothing;
   trailingIndicator: TemplateResult | typeof nothing;
-  renderedOwnerIdentity?: SessionParticipantIdentity;
+  renderedIdentities?: readonly SessionParticipantIdentity[];
 } {
   const running = sessionHasRunningWork(session);
   const trailingIndicator = session.isChild ? nothing : renderSessionState(session, false);
@@ -171,9 +171,13 @@ export function renderSessionLeadingState(
         circular: true,
       }),
       trailingIndicator,
-      // Single source for facepile dedup: only the identity actually shown in
-      // the lead may be excluded, else attention/archived rows hide a viewer.
-      renderedOwnerIdentity: ownerActor?.identity,
+      // Exclude only visible avatars; a +N stack still needs individual live viewers.
+      renderedIdentities: [
+        ...(ownerActor?.identity ? [ownerActor.identity] : []),
+        ...((participantCount ?? participants?.length) === 1
+          ? (participants ?? []).slice(0, 1).map((participant) => participant.identity)
+          : []),
+      ],
     };
   }
   return {

--- a/ui/src/components/viewer-facepile.test.ts
+++ b/ui/src/components/viewer-facepile.test.ts
@@ -264,13 +264,16 @@ it("renders ordered static participant actors without presence filtering", async
   expect(facepile.querySelector(".viewer-avatar--overflow")?.textContent?.trim()).toBe("+1");
 });
 
-it("excludes the session owner before choosing visible avatars and overflow", async () => {
+it("excludes displayed owners and participants before choosing visible avatars and overflow", async () => {
   const facepile = document.createElement("openclaw-viewer-facepile") as ViewerFacepileElement;
   facepile.sessionKey = "agent:main:active";
-  facepile.excludeIdentity = { type: "profile", id: "owner" };
+  facepile.excludeIdentities = [
+    { type: "profile", id: "owner" },
+    { type: "profile", id: "participant" },
+  ];
   facepile.maxVisible = 2;
   facepile.presencePayload = {
-    presence: ["owner", "alice", "bob", "carol"].map((id) => ({
+    presence: ["owner", "participant", "alice", "bob", "carol"].map((id) => ({
       instanceId: `${id}-instance`,
       user: { id, identity: { type: "profile", id }, name: id },
       watchedSessions: ["agent:main:active"],

--- a/ui/src/components/viewer-facepile.ts
+++ b/ui/src/components/viewer-facepile.ts
@@ -74,7 +74,7 @@ class ViewerFacepile extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) selfUser?: AuthenticatedUser | null;
   @property({ attribute: false }) selfInstanceId?: string;
   @property({ attribute: false }) sessionKey?: string;
-  @property({ attribute: false }) excludeIdentity?: SessionParticipantIdentity;
+  @property({ attribute: false }) excludeIdentities: readonly SessionParticipantIdentity[] = [];
   @property({ attribute: false }) staticParticipants?: readonly SessionParticipant[];
   /** Prepared live presence for the collapsed Online section. */
   @property({ attribute: false }) staticUsers?: readonly PresenceViewer[];
@@ -93,7 +93,7 @@ class ViewerFacepile extends OpenClawLightDomContentsElement {
       this.selfUser,
       this.selfInstanceId,
       this.sessionKey,
-      this.excludeIdentity,
+      this.excludeIdentities,
     );
     const users = this.staticParticipants
       ? this.staticParticipants.map(({ identity, label, avatarUrl }) => ({

--- a/ui/src/e2e/chat-header-owner-presence.capture.e2e.test.ts
+++ b/ui/src/e2e/chat-header-owner-presence.capture.e2e.test.ts
@@ -14,116 +14,156 @@ const outputDir = path.resolve(
   process.env.OPENCLAW_CHAT_HEADER_CAPTURE_OUTPUT_DIR ??
     ".artifacts/control-ui-e2e/chat-header-owner-presence",
 );
-const screenshotPath = path.join(outputDir, "chat-header.png");
-
 suite.define(() => {
-  it("captures the owner chip with another active viewer", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 760, width: 1180 },
-      },
-      async ({ page }) => {
-        const sessionKey = "agent:main:owner-present";
-        await installMockGateway(page, {
-          hasMultipleSessionSharingIdentities: true,
-          presenceUsers: [
-            {
-              self: true,
-              id: "profile-operator",
-              identity: { type: "profile", id: "profile-operator" },
-              name: "Operator",
-            },
-            {
-              id: "profile-ada",
-              identity: { type: "profile", id: "profile-ada" },
-              name: "Ada",
-              watchedSessions: [sessionKey],
-            },
-            {
-              id: "profile-zoe",
-              identity: { type: "profile", id: "profile-zoe" },
-              name: "Zoe",
-              watchedSessions: [sessionKey],
-            },
-          ],
-          sessionKey,
-          methodResponses: {
-            "sessions.list": {
-              count: 1,
-              owners: [
-                {
-                  type: "human",
-                  id: "profile-ada",
-                  identity: { type: "profile", id: "profile-ada" },
-                  label: "Ada",
-                },
-                {
-                  type: "human",
-                  id: "profile-zoe",
-                  identity: { type: "profile", id: "profile-zoe" },
-                  label: "Zoe",
-                },
-              ],
-              defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
-              path: "",
-              sessions: [
-                {
-                  contextTokens: null,
-                  createdActor: {
+  it.each(["chat", "dashboard"] as const)(
+    "deduplicates participants watching the %s",
+    async (face) => {
+      await suite.withPage(
+        {
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport: { height: 760, width: 1180 },
+        },
+        async ({ page }) => {
+          const sessionKey = "agent:main:owner-present";
+          const gateway = await installMockGateway(page, {
+            hasMultipleSessionSharingIdentities: true,
+            presenceUsers: [
+              {
+                self: true,
+                id: "profile-operator",
+                identity: { type: "profile", id: "profile-operator" },
+                name: "Operator",
+              },
+              {
+                id: "profile-ada",
+                identity: { type: "profile", id: "profile-ada" },
+                name: "Ada",
+                watchedSessions: [sessionKey],
+              },
+              {
+                id: "profile-zoe",
+                identity: { type: "profile", id: "profile-zoe" },
+                name: "Zoe",
+                watchedSessions: [sessionKey],
+              },
+              {
+                id: "profile-lin",
+                identity: { type: "profile", id: "profile-lin" },
+                name: "Lin",
+                watchedSessions: [sessionKey],
+              },
+            ],
+            sessionKey,
+            featureMethods: ["board.get"],
+            methodResponses: {
+              "board.get": {
+                sessionKey,
+                revision: 1,
+                tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" }],
+                widgets: [],
+              },
+              "sessions.list": {
+                count: 1,
+                owners: [
+                  {
                     type: "human",
                     id: "profile-ada",
                     identity: { type: "profile", id: "profile-ada" },
                     label: "Ada",
                   },
-                  owner: {
-                    actor: {
+                  {
+                    type: "human",
+                    id: "profile-zoe",
+                    identity: { type: "profile", id: "profile-zoe" },
+                    label: "Zoe",
+                  },
+                ],
+                defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
+                path: "",
+                sessions: [
+                  {
+                    contextTokens: null,
+                    createdActor: {
                       type: "human",
                       id: "profile-ada",
                       identity: { type: "profile", id: "profile-ada" },
                       label: "Ada",
                     },
+                    owner: {
+                      actor: {
+                        type: "human",
+                        id: "profile-ada",
+                        identity: { type: "profile", id: "profile-ada" },
+                        label: "Ada",
+                      },
+                    },
+                    participants: [
+                      { identity: { type: "profile", id: "profile-zoe" }, label: "Zoe" },
+                    ],
+                    participantCount: 1,
+                    displayName: "Owner presence",
+                    hasActiveRun: false,
+                    key: sessionKey,
+                    kind: "direct",
+                    label: "Owner presence",
+                    model: "gpt-5.5",
+                    modelProvider: "openai",
+                    status: "done",
+                    totalTokens: 0,
+                    updatedAt: Date.parse("2026-08-14T12:00:00.000Z"),
                   },
-                  displayName: "Owner presence",
-                  hasActiveRun: false,
-                  key: sessionKey,
-                  kind: "direct",
-                  label: "Owner presence",
-                  model: "gpt-5.5",
-                  modelProvider: "openai",
-                  status: "done",
-                  totalTokens: 0,
-                  updatedAt: Date.parse("2026-08-14T12:00:00.000Z"),
-                },
-              ],
-              ts: Date.parse("2026-08-14T12:00:00.000Z"),
+                ],
+                ts: Date.parse("2026-08-14T12:00:00.000Z"),
+              },
             },
-          },
-        });
+          });
 
-        const response = await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
-        expect(response?.status()).toBe(200);
-        const header = page.locator(".chat-pane__header").first();
-        await header.waitFor({ state: "visible" });
-        await expect.poll(() => header.locator(".session-owner-chip--header").count()).toBe(1);
-        await expect
-          .poll(() => header.locator(".viewer-facepile").getAttribute("data-viewer-count"))
-          .toBe("1");
-        await expect.poll(() => header.locator('[data-viewer-id="profile-ada"]').count()).toBe(0);
-        await expect.poll(() => header.locator('[data-viewer-id="profile-zoe"]').count()).toBe(1);
-        await expect
-          .poll(() => header.locator(".session-owner-chip--header").getAttribute("class"))
-          .not.toContain("session-owner-chip--away");
+          const response = await page.goto(
+            controlUiSessionUrl(suite.server.baseUrl, sessionKey, face),
+          );
+          expect(response?.status()).toBe(200);
+          const header = page.locator(".chat-pane__header").first();
+          await header.waitFor({ state: "visible" });
+          await expect.poll(() => header.locator(".session-owner-chip--header").count()).toBe(1);
+          await expect
+            .poll(() =>
+              header.locator('.chat-pane__participants .viewer-avatar[aria-label="Zoe"]').count(),
+            )
+            .toBe(1);
+          await expect.poll(() => header.locator('[data-viewer-id="profile-lin"]').count()).toBe(1);
 
-        const clip = await header.boundingBox();
-        if (!clip) {
-          throw new Error("Chat header did not expose a screenshot bounding box");
-        }
-        await mkdir(outputDir, { recursive: true });
-        await page.screenshot({ animations: "disabled", clip, path: screenshotPath });
-        process.stdout.write(`Chat header screenshot: ${screenshotPath}\n`);
-      },
-    );
-  });
+          const screenshotPath = path.join(outputDir, `${face}-header.png`);
+          const clip = await header.boundingBox();
+          if (!clip) {
+            throw new Error("Chat header did not expose a screenshot bounding box");
+          }
+          await mkdir(outputDir, { recursive: true });
+          await page.screenshot({ animations: "disabled", clip, path: screenshotPath });
+          process.stdout.write(`Chat header screenshot: ${screenshotPath}\n`);
+
+          await expect
+            .poll(() =>
+              header
+                .locator(".chat-pane__presence .viewer-facepile")
+                .getAttribute("data-viewer-count"),
+            )
+            .toBe("1");
+          await expect.poll(() => header.locator('[data-viewer-id="profile-ada"]').count()).toBe(0);
+          await expect
+            .poll(() => header.locator('.viewer-avatar[aria-label="Zoe"]:visible').count())
+            .toBe(1);
+          await expect
+            .poll(() => header.locator(".session-owner-chip--header").getAttribute("class"))
+            .not.toContain("session-owner-chip--away");
+
+          await gateway.emitGatewayEvent("presence", { presence: [] });
+          await expect.poll(() => header.locator(".chat-pane__presence").count()).toBe(0);
+          await expect
+            .poll(() => header.locator('.viewer-avatar[aria-label="Zoe"]:visible').count())
+            .toBe(1);
+        },
+      );
+    },
+  );
 });

--- a/ui/src/lib/presence-users.test.ts
+++ b/ui/src/lib/presence-users.test.ts
@@ -114,7 +114,13 @@ it.each([
       { user: { id: "same" }, watchedSessions: ["session"] },
     ],
   };
-  const viewers = projectPresenceViewers(payload, undefined, undefined, "session", identity);
+  const viewers = projectPresenceViewers(
+    payload,
+    undefined,
+    undefined,
+    "session",
+    identity ? [identity] : [],
+  );
   expect(viewers.map((user) => user.identity)).toEqual(
     identity?.type === "profile" ? [undefined] : [payload.presence[0]!.user.identity, undefined],
   );

--- a/ui/src/lib/presence-users.ts
+++ b/ui/src/lib/presence-users.ts
@@ -124,7 +124,7 @@ export function projectPresenceViewers(
   selfUser?: AuthenticatedUser | null,
   selfInstanceId?: string,
   sessionKey?: string,
-  excludeIdentity?: SessionParticipantIdentity,
+  excludeIdentities: readonly SessionParticipantIdentity[] = [],
 ): readonly PresenceViewer[] {
   const self =
     selfUser ?? resolveSelfPresenceUser(readPresenceEntries(value) ?? [], selfInstanceId);
@@ -132,7 +132,7 @@ export function projectPresenceViewers(
   return projectPresencePayload(value).users.filter(
     (user) =>
       presenceUserKey(user) !== selfKey &&
-      !presenceMatchesProfile(user, excludeIdentity) &&
+      !excludeIdentities.some((identity) => presenceMatchesProfile(user, identity)) &&
       (sessionKey === undefined || user.watchedSessions.includes(sessionKey)),
   );
 }

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -410,7 +410,10 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
           sharingSnapshot.selfUser,
           sharingSnapshot.client?.instanceId,
           key,
-          renderedOwnerIdentity,
+          [
+            ...(renderedOwnerIdentity ? [renderedOwnerIdentity] : []),
+            ...(showOwnerChip ? (row?.participants ?? []).map(({ identity }) => identity) : []),
+          ],
         );
     const ownerViewing = projectPresencePayload(this.presencePayload).users.some(
       (user) =>

--- a/ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
@@ -342,6 +342,63 @@ describe("AppSidebar session ownership", () => {
     expect(harness.list).toHaveBeenCalledWith(expect.objectContaining({ involvingMe: true }));
   });
 
+  it.each([
+    ["peeking participant", 1, undefined, true, ["profile-carol"]],
+    ["implicit participant count", undefined, undefined, true, ["profile-carol"]],
+    ["participant overflow", 2, undefined, true, ["profile-bob", "profile-carol"]],
+    ["hidden attribution", 1, "sparkles", true, ["profile-ada", "profile-bob", "profile-carol"]],
+    ["unqualified viewer", 1, undefined, false, ["profile-carol", "profile-bob"]],
+  ] as const)(
+    "deduplicates only visible participant identities: %s",
+    async (_name, participantCount, icon, qualified, expectedViewers) => {
+      const gateway = createGatewayHarness({} as GatewayBrowserClient);
+      const harness = createSessionsHarness("main", ["agent:main:main", "agent:main:collab"]);
+      const result = harness.sessions.state.result!;
+      const collab = result.sessions[1]!;
+      setEffectiveOwner(collab, { type: "human", id: "profile-ada", label: "Ada" });
+      collab.participants = [{ identity: { type: "profile", id: "profile-bob" }, label: "Bob" }];
+      if (participantCount === 2) {
+        collab.participants.push({
+          identity: { type: "agent", id: "research" },
+          label: "Research",
+        });
+      }
+      collab.participantCount = participantCount;
+      collab.icon = icon;
+      result.owners = [
+        { type: "human", id: "profile-ada", label: "Ada" },
+        { type: "human", id: "profile-bob", label: "Bob" },
+      ];
+      const { sidebar } = await mountSidebar(gateway.gateway, harness.sessions);
+      harness.publishList({ result, agentId: "main" });
+      gateway.publishEvent("presence", {
+        presence: ["ada", "bob", "carol"].map((name) => {
+          const id = `profile-${name}`;
+          return {
+            instanceId: id,
+            user: {
+              id,
+              ...(qualified || name !== "bob"
+                ? { identity: { type: "profile" as const, id } }
+                : {}),
+            },
+            watchedSessions: [collab.key],
+          };
+        }),
+      });
+      await sidebar.updateComplete;
+      const row = sidebar.querySelector('[data-session-key="agent:main:collab"]')!;
+      await waitForFast(() => {
+        expect(
+          [...row.querySelectorAll("[data-viewer-id]")].map((avatar) =>
+            avatar.getAttribute("data-viewer-id"),
+          ),
+        ).toEqual(expectedViewers);
+      });
+      expect(row.querySelector(".session-owner-stack") !== null).toBe(icon === undefined);
+    },
+  );
+
   it("renders no ownership chrome when the listed sessions have fewer than two owners", async () => {
     const gateway = createGatewayHarness({} as GatewayBrowserClient);
     gateway.publish({
@@ -593,7 +650,7 @@ describe("AppSidebar session ownership", () => {
     const archivedFacepile = sidebar.querySelector(
       '[data-session-key="agent:main:archived"] openclaw-viewer-facepile',
     ) as HTMLElementTagNameMap["openclaw-viewer-facepile"] | null;
-    expect(archivedFacepile?.excludeIdentity).toEqual(archived.archivedBy.identity);
+    expect(archivedFacepile?.excludeIdentities).toEqual([archived.archivedBy.identity]);
 
     setEffectiveOwner(collaborator, { type: "human", id: "profile-ada", label: "Ada" });
     result.owners = [{ type: "human", id: "profile-ada", label: "Ada" }];
@@ -604,6 +661,6 @@ describe("AppSidebar session ownership", () => {
     const soloFacepile = sidebar.querySelector(
       '[data-session-key="agent:main:archived"] openclaw-viewer-facepile',
     ) as HTMLElementTagNameMap["openclaw-viewer-facepile"] | null;
-    expect(soloFacepile?.excludeIdentity).toBeUndefined();
+    expect(soloFacepile?.excludeIdentities).toEqual([]);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where people watching a session appeared twice in its chat or dashboard header: once as a recorded participant and again as a live viewer. Sidebar rows could repeat the same person beside a peeking participant avatar.

## Why This Change Was Made

The shared presence projection excluded only one owner identity. It now accepts the identities already rendered by each surface. The header supplies its owner and participant preview; the sidebar's leading-avatar renderer supplies its owner and single peeking participant. Identity matching still requires the recorded profile namespace, so equal raw IDs or display names never merge unrelated people.

Participants represented only by a +N count remain eligible for individual live-viewer avatars. Hidden attribution also leaves live viewers visible. This reuses the existing projection and removes the scalar exclusion path; no storage, authorization, protocol, or configuration change is needed.

## User Impact

Each displayed person gets one avatar per session header or sidebar row. Permanent participation remains visible after the person stops viewing, and unrelated viewers and overflow counts remain intact. The avatar documentation describes the behavior.

## Evidence

- Before the fix, the same Chromium regression failed in both chat and dashboard: expected one live-viewer avatar, received two.
- After the fix, both browser scenarios pass, including presence clearing without removing the participant avatar. Captures below use only synthetic people.
- Focused presence projection, avatar component, and full sidebar suites pass on [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/33333988634) (`tbx_01m1a61jarz55nv8wgsvrkvvtg`). Sidebar regressions cover the peeking participant, omitted count, +N overflow, hidden attribution, and colliding raw/profile IDs.
- Commands: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-header-owner-presence.capture.e2e.test.ts`; `node scripts/run-vitest.mjs ui/src/lib/presence-users.test.ts ui/src/components/viewer-facepile.test.ts ui/src/components/app-sidebar.test.ts`.
- Codex autoreview: no accepted/actionable findings at the default P0 threshold. Formatting, `git diff --check`, and the full `check:changed` gate pass (core/UI types, changed-file lint, i18n, dead exports and repository guards). Exact-head CI is tracked before landing.
- Production: +18/-11 (net +7); tests/test support: +209/-103; docs: +1/-1. The seven production lines replace scalar exclusion with the actual displayed identity lists at the two rendering boundaries.
- Regression provenance is unknown; current-main behavior was reproduced directly. The production authenticated browser relay was unavailable; browser proof uses the real Control UI with deterministic Gateway responses.

![Before: Zoe appears as participant and live viewer](https://github.com/user-attachments/assets/f263abb9-d3e4-418c-aaee-719ff9cfcce8)

![After: Zoe appears once and Lin remains visible](https://github.com/user-attachments/assets/f6ff5d2c-aa87-4879-b668-9daf56208497)

![Dashboard before deduplication](https://github.com/user-attachments/assets/4f97e8c6-e615-4568-a2d5-371f6b3a6b85)

![Dashboard after deduplication](https://github.com/user-attachments/assets/3e4bb249-ff1f-458b-b7f1-50847709e7fa)
