### PR TITLE
refactor(agents): simplify compaction accounting

### DIFF
--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -1216,10 +1216,7 @@ export function runAgentAttempt(params: {
   const embeddedPersistencePrompt = params.opts.gitCoauthorAttribution
     ? (continuationTranscriptBody ?? effectivePrompt)
     : continuationTranscriptBody;
-  const embeddedRunBase: Omit<
-    RunEmbeddedAgentInternalParams,
-    "compactionCountOwner" | "onCompactionAccounting"
-  > = {
+  const embeddedRunParams: RunEmbeddedAgentInternalParams = {
     preparedRunAdmission: params.preparedRunAdmission,
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
@@ -1336,6 +1333,7 @@ export function runAgentAttempt(params: {
     contextEngineLogicalTurnLease: params.contextEngineLogicalTurnLease,
     onContextEngineTurnCandidate: params.onContextEngineTurnCandidate,
     onUserMessagePersisted: params.onUserMessagePersisted,
+    onCompactionAccounting: params.onCompactionAccounting,
     onSuccessfulAuthProfile: params.onSuccessfulAuthProfile
       ? (successfulProfileId) =>
           params.onSuccessfulAuthProfile?.({
@@ -1357,13 +1355,6 @@ export function runAgentAttempt(params: {
     bootstrapPromptWarningSignaturesSeen,
     bootstrapPromptWarningSignature,
   };
-  const embeddedRunParams: RunEmbeddedAgentInternalParams = params.onCompactionAccounting
-    ? {
-        ...embeddedRunBase,
-        compactionCountOwner: "caller",
-        onCompactionAccounting: params.onCompactionAccounting,
-      }
-    : embeddedRunBase;
   setChannelSourceTurnId(embeddedRunParams, readChannelSourceTurnId(params.runContext));
   setChannelSourceTurnSameThreadRequired(
     embeddedRunParams,

--- a/src/agents/command/compaction-accounting.ts
+++ b/src/agents/command/compaction-accounting.ts
@@ -1,26 +1,9 @@
+import { hasSameCompactionWriter } from "../../auto-reply/reply/agent-runner-compaction-accounting.js";
 import { incrementCompactionCount } from "../../auto-reply/reply/session-updates.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
-import type {
-  CompactionAccountingFact,
-  CompactionAccountingTarget,
-} from "../embedded-agent-runner/run/internal-params.js";
+import type { CompactionAccountingFact } from "../embedded-agent-runner/run/internal-params.js";
 
 type DurableCompactionFact = Extract<CompactionAccountingFact, { kind: "durable" }>;
-
-function hasSameCompactionWriter(
-  previous: CompactionAccountingTarget | undefined,
-  current: CompactionAccountingTarget,
-): boolean {
-  // Physical session IDs may rotate while the binding and retained writer stay fixed.
-  return (
-    previous !== undefined &&
-    previous.agentId === current.agentId &&
-    previous.sessionKey === current.sessionKey &&
-    previous.storePath === current.storePath &&
-    previous.lifecycleRevision === current.lifecycleRevision &&
-    previous.activeWriterRunId === current.activeWriterRunId
-  );
-}
 
 /** Keeps command context observations and completed counts on their original writer. */
 export function createCommandCompactionAccounting(params: {

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1706,122 +1706,95 @@ describe("updateSessionStoreAfterAgentRun", () => {
     },
   );
 
-  it("keeps ordinary CLI context independent of historical compaction metadata", async () => {
-    await withTempSessionStore(async ({ storePath }) => {
-      const cfg = {} as OpenClawConfig;
-      const sessionKey = "agent:main:explicit:test-zero-compaction-with-usage";
-      const sessionId = "test-zero-compaction-with-usage-session";
-      const sessionStore: Record<string, SessionEntry> = {
-        [sessionKey]: {
-          sessionId,
-          updatedAt: 1,
-          totalTokens: 1_794_391,
-          totalTokensFresh: true,
-          inputTokens: 20,
-          outputTokens: 10_855,
-          cacheRead: 1_761_324,
-          cacheWrite: 33_047,
-        },
-      };
-      await seedSessionStore(storePath, sessionStore);
-
-      await updateSessionStoreAfterAgentRun({
-        cfg,
-        sessionId,
-        sessionKey,
-        storePath,
-        sessionStore,
-        defaultProvider: "claude-cli",
-        defaultModel: "claude-opus-4-7",
-        result: {
-          meta: {
-            durationMs: 500,
-            agentMeta: {
-              sessionId,
-              provider: "claude-cli",
-              model: "claude-opus-4-7",
-              usage: {
-                input: 20,
-                output: 10_855,
-                cacheRead: 1_761_324,
-                cacheWrite: 33_047,
-              },
-              lastCallUsage: {
-                input: 20,
-                output: 10_855,
-                cacheRead: 1_761_324,
-                cacheWrite: 33_047,
-              },
-              compactionCount: 1,
-              compactionTokensAfter: 0,
-            },
+  it.each([
+    {
+      runtime: "CLI",
+      sessionKey: "agent:main:explicit:test-zero-compaction-with-usage",
+      sessionId: "test-zero-compaction-with-usage-session",
+      provider: "claude-cli",
+      model: "claude-opus-4-7",
+      initial: {
+        totalTokens: 1_794_391,
+        inputTokens: 20,
+        outputTokens: 10_855,
+        cacheRead: 1_761_324,
+        cacheWrite: 33_047,
+      },
+      usage: { input: 20, output: 10_855, cacheRead: 1_761_324, cacheWrite: 33_047 },
+      lastCallUsage: { input: 20, output: 10_855, cacheRead: 1_761_324, cacheWrite: 33_047 },
+      compactionTokensAfter: 0,
+      expected: {
+        totalTokens: 1_794_391,
+        inputTokens: 20,
+        outputTokens: 10_855,
+        cacheRead: 1_761_324,
+        cacheWrite: 33_047,
+      },
+    },
+    {
+      runtime: "model",
+      sessionKey: "agent:main:explicit:test-positive-compaction-with-usage",
+      sessionId: "test-positive-compaction-with-usage-session",
+      provider: "openai",
+      model: "gpt-5.5",
+      initial: { totalTokens: 180_000 },
+      usage: { input: 100_000, output: 3_000, cacheRead: 20_000 },
+      lastCallUsage: { input: 91_000, output: 1_000, cacheRead: 4_000 },
+      compactionTokensAfter: 80_000,
+      expected: {
+        totalTokens: 95_000,
+        inputTokens: 100_000,
+        outputTokens: 3_000,
+        cacheRead: 20_000,
+      },
+    },
+  ])(
+    "keeps ordinary $runtime context independent of historical compaction metadata",
+    async (testCase) => {
+      await withTempSessionStore(async ({ storePath }) => {
+        const cfg = {} as OpenClawConfig;
+        const { sessionKey, sessionId, provider, model } = testCase;
+        const sessionStore: Record<string, SessionEntry> = {
+          [sessionKey]: {
+            sessionId,
+            updatedAt: 1,
+            ...testCase.initial,
+            totalTokensFresh: true,
           },
-        } as EmbeddedAgentRunResult,
-      });
+        };
+        await seedSessionStore(storePath, sessionStore);
 
-      expect(sessionStore[sessionKey]?.totalTokens).toBe(1_794_391);
-      expect(sessionStore[sessionKey]?.totalTokensFresh).toBe(true);
-      expect(sessionStore[sessionKey]?.inputTokens).toBe(20);
-      expect(sessionStore[sessionKey]?.outputTokens).toBe(10_855);
-      expect(sessionStore[sessionKey]?.cacheRead).toBe(1_761_324);
-      expect(sessionStore[sessionKey]?.cacheWrite).toBe(33_047);
-    });
-  });
-
-  it("keeps ordinary model context independent of historical compaction metadata", async () => {
-    await withTempSessionStore(async ({ storePath }) => {
-      const cfg = {} as OpenClawConfig;
-      const sessionKey = "agent:main:explicit:test-positive-compaction-with-usage";
-      const sessionId = "test-positive-compaction-with-usage-session";
-      const sessionStore: Record<string, SessionEntry> = {
-        [sessionKey]: {
+        await updateSessionStoreAfterAgentRun({
+          cfg,
           sessionId,
-          updatedAt: 1,
-          totalTokens: 180_000,
-          totalTokensFresh: true,
-        },
-      };
-      await seedSessionStore(storePath, sessionStore);
-
-      await updateSessionStoreAfterAgentRun({
-        cfg,
-        sessionId,
-        sessionKey,
-        storePath,
-        sessionStore,
-        defaultProvider: "openai",
-        defaultModel: "gpt-5.5",
-        result: {
-          meta: {
-            durationMs: 500,
-            agentMeta: {
-              sessionId,
-              provider: "openai",
-              model: "gpt-5.5",
-              usage: {
-                input: 100_000,
-                output: 3_000,
-                cacheRead: 20_000,
+          sessionKey,
+          storePath,
+          sessionStore,
+          defaultProvider: provider,
+          defaultModel: model,
+          result: {
+            meta: {
+              durationMs: 500,
+              agentMeta: {
+                sessionId,
+                provider,
+                model,
+                usage: testCase.usage,
+                lastCallUsage: testCase.lastCallUsage,
+                compactionCount: 1,
+                compactionTokensAfter: testCase.compactionTokensAfter,
               },
-              lastCallUsage: {
-                input: 91_000,
-                output: 1_000,
-                cacheRead: 4_000,
-              },
-              compactionCount: 1,
-              compactionTokensAfter: 80_000,
             },
-          },
-        } as EmbeddedAgentRunResult,
-      });
+          } as EmbeddedAgentRunResult,
+        });
 
-      expect(sessionStore[sessionKey]?.totalTokens).toBe(95_000);
-      expect(sessionStore[sessionKey]?.totalTokensFresh).toBe(true);
-      expect(sessionStore[sessionKey]?.inputTokens).toBe(100_000);
-      expect(sessionStore[sessionKey]?.outputTokens).toBe(3_000);
-      expect(sessionStore[sessionKey]?.cacheRead).toBe(20_000);
-    });
-  });
+        expect(sessionStore[sessionKey]).toMatchObject({
+          ...testCase.expected,
+          totalTokensFresh: true,
+        });
+      });
+    },
+  );
 
   it.each([0, 80_000, Number.POSITIVE_INFINITY])(
     "does not revive historical compaction snapshot %s without a private fact",

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -13,7 +13,7 @@ import { projectSessionSnapshotChanges } from "../../config/sessions/session-sna
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
 import type { InternalSessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { createLazyPromise } from "../../shared/lazy-promise.js";
 import {
   clearAllCliSessions,
   clearCliSession,
@@ -30,16 +30,8 @@ import { deriveSessionTotalTokens, hasNonzeroUsage } from "../usage.js";
 
 type RunResult = Awaited<ReturnType<(typeof import("../embedded-agent.js"))["runEmbeddedAgent"]>>;
 
-const usageFormatModuleLoader = createLazyImportLoader(() => import("../../utils/usage-format.js"));
-const contextModuleLoader = createLazyImportLoader(() => import("../context.js"));
-
-async function getUsageFormatModule() {
-  return await usageFormatModuleLoader.load();
-}
-
-async function getContextModule() {
-  return await contextModuleLoader.load();
-}
+const getUsageFormatModule = createLazyPromise(() => import("../../utils/usage-format.js"));
+const getContextModule = createLazyPromise(() => import("../context.js"));
 
 export function normalizeSessionTokenCount(value: number | undefined): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
@@ -220,25 +212,19 @@ export async function updateSessionStoreAfterAgentRun(params: {
   }
   if (!preserveUserFacingRunState) {
     const currentContextSnapshot = params.compactionAccounting?.currentContextSnapshot;
-    const totalTokens = currentContextSnapshot
-      ? currentContextSnapshot.tokens
-      : hasUsage
-        ? deriveSessionTotalTokens({ lastCallUsage, contextTokens, promptTokens })
-        : undefined;
-    if (totalTokens !== undefined) {
+    if (currentContextSnapshot || hasUsage) {
+      const totalTokens = currentContextSnapshot
+        ? currentContextSnapshot.tokens
+        : deriveSessionTotalTokens({ lastCallUsage, contextTokens, promptTokens });
       next.totalTokens = totalTokens;
-      next.totalTokensFresh = true;
-      next.totalTokensVersion = SESSION_TOTAL_TOKENS_VERSION;
-    } else if (currentContextSnapshot || hasUsage) {
-      next.totalTokens = undefined;
-      next.totalTokensFresh = false;
-      next.totalTokensVersion = undefined;
+      next.totalTokensFresh = totalTokens !== undefined;
+      next.totalTokensVersion =
+        totalTokens !== undefined ? SESSION_TOTAL_TOKENS_VERSION : undefined;
     } else if (
       typeof entry.totalTokens === "number" &&
       Number.isFinite(entry.totalTokens) &&
       entry.totalTokens > 0
     ) {
-      next.totalTokens = entry.totalTokens;
       next.totalTokensFresh = false;
       next.totalTokensVersion = undefined;
     }

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -1080,9 +1080,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
 export async function warmRunOverflowCompactionHarness(
   runEmbeddedAgent: TestRunEmbeddedAgent,
   state: Pick<OpenClawTestState, "workspaceDir">,
-  params?: Partial<
-    Omit<Parameters<typeof runEmbeddedAgent>[0], "compactionCountOwner" | "onCompactionAccounting">
-  >,
+  params?: Partial<Parameters<typeof runEmbeddedAgent>[0]>,
 ): Promise<void> {
   resetRunOverflowCompactionHarnessMocks();
   mockedGlobalHookRunner.hasHooks.mockReturnValue(false);

--- a/src/agents/embedded-agent-runner/run.recovery-cancellation.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.recovery-cancellation.test-support.ts
@@ -123,7 +123,6 @@ describe("recovery cancellation through the public run owner", () => {
           owner === "caller"
             ? runEmbeddedAgent({
                 ...runParams,
-                compactionCountOwner: "caller",
                 onCompactionAccounting,
               })
             : runEmbeddedAgent(runParams);
@@ -395,7 +394,6 @@ describe("recovery cancellation through the public run owner", () => {
 
     const result = await runEmbeddedAgent({
       ...runParams,
-      compactionCountOwner: "caller",
       onCompactionAccounting: facts,
     });
 
@@ -485,7 +483,6 @@ describe("recovery cancellation through the public run owner", () => {
         ...runParams,
         provider: "openai",
         model: "gpt-5.6-luna",
-        compactionCountOwner: "caller",
         onCompactionAccounting: candidate.observe,
       });
       await candidate.finish(sessionEntry);

--- a/src/agents/embedded-agent-runner/run.session-prompt-state.test.ts
+++ b/src/agents/embedded-agent-runner/run.session-prompt-state.test.ts
@@ -73,11 +73,7 @@ function createRecorder(
   };
 }
 
-function createState(
-  overrides: Partial<
-    Omit<PreparedEmbeddedRunInput["runParams"], "compactionCountOwner" | "onCompactionAccounting">
-  > = {},
-) {
+function createState(overrides: Partial<PreparedEmbeddedRunInput["runParams"]> = {}) {
   return createEmbeddedRunSessionPromptState({
     runParams: { ...BASE_RUN_PARAMS, ...overrides },
     sessionAgentId: "main",

--- a/src/agents/embedded-agent-runner/run/internal-params.ts
+++ b/src/agents/embedded-agent-runner/run/internal-params.ts
@@ -26,37 +26,32 @@ export type CompactionAccountingFact = Readonly<
   )
 >;
 
-type CompactionAccountingParams =
-  | { compactionCountOwner?: "subscription"; onCompactionAccounting?: never }
-  | {
-      compactionCountOwner: "caller";
-      onCompactionAccounting: (fact: CompactionAccountingFact | undefined) => void;
-    };
-
-export type RunEmbeddedAgentInternalParams = RunEmbeddedAgentParams &
-  CompactionAccountingParams & {
-    /** Attempt-local context observer, installed by the host loop before dispatch. */
-    onContextAccountingEvent?: (event: EmbeddedContextAccountingEvent) => void;
-    onSuccessfulAuthBinding?: (binding: AgentExecutionAuthBinding) => void;
-    /** Maintenance needs the winning profile, not native runtime artifact capture. */
-    onSuccessfulAuthProfile?: (profileId: string | undefined) => void;
-    authProfileStateMode?: "read-write" | "read-only";
-    /** Prepare only the requested candidate with this runtime; fallbacks keep their own policy. */
-    agentHarnessRuntimePreparationHint?: string;
-    /** Keep staged setup config and credentials outside configured Gateway ownership. */
-    preparedModelRuntimeMode?: "isolated-read-only";
-    /** Ring-zero tool override, supplied only by the OpenClaw orchestrator. */
-    systemAgentTool?: SystemAgentToolOptions;
-    /** Gateway-private lifecycle generation selected before command admission. */
-    pluginGeneration?: PreparedModelRuntimePluginGeneration;
-    /** Host-only transfer of attempt terminal resources to the logical turn. */
-    onDeferredLifecycleOwner?: (owner: DeferredEmbeddedRunLifecycleOwner) => void;
-    /** Aborts the logical turn when its retained embedded handle is cancelled. */
-    onDeferredLifecycleAbort?: (reason?: "user_abort" | "restart" | "superseded") => void;
-  };
+export type RunEmbeddedAgentInternalParams = RunEmbeddedAgentParams & {
+  onCompactionAccounting?: (fact: CompactionAccountingFact | undefined) => void;
+  /** Attempt-local context observer, installed by the host loop before dispatch. */
+  onContextAccountingEvent?: (event: EmbeddedContextAccountingEvent) => void;
+  onSuccessfulAuthBinding?: (binding: AgentExecutionAuthBinding) => void;
+  /** Maintenance needs the winning profile, not native runtime artifact capture. */
+  onSuccessfulAuthProfile?: (profileId: string | undefined) => void;
+  authProfileStateMode?: "read-write" | "read-only";
+  /** Prepare only the requested candidate with this runtime; fallbacks keep their own policy. */
+  agentHarnessRuntimePreparationHint?: string;
+  /** Keep staged setup config and credentials outside configured Gateway ownership. */
+  preparedModelRuntimeMode?: "isolated-read-only";
+  /** Ring-zero tool override, supplied only by the OpenClaw orchestrator. */
+  systemAgentTool?: SystemAgentToolOptions;
+  /** Gateway-private lifecycle generation selected before command admission. */
+  pluginGeneration?: PreparedModelRuntimePluginGeneration;
+  /** Host-only transfer of attempt terminal resources to the logical turn. */
+  onDeferredLifecycleOwner?: (owner: DeferredEmbeddedRunLifecycleOwner) => void;
+  /** Aborts the logical turn when its retained embedded handle is cancelled. */
+  onDeferredLifecycleAbort?: (reason?: "user_abort" | "restart" | "superseded") => void;
+};
 
 export type EmbeddedRunAttemptInternalParams = EmbeddedRunAttemptParams &
-  Pick<RunEmbeddedAgentInternalParams, "compactionCountOwner" | "onContextAccountingEvent">;
+  Pick<RunEmbeddedAgentInternalParams, "onContextAccountingEvent"> & {
+    compactionCountOwner?: "subscription" | "caller";
+  };
 
 export type RunEmbeddedAgentParamsWithSessionFile = RunEmbeddedAgentInternalParams & {
   sessionFile: string;

--- a/src/agents/embedded-agent-subscribe.types.ts
+++ b/src/agents/embedded-agent-subscribe.types.ts
@@ -13,7 +13,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HookRunner } from "../plugins/hooks.js";
 import type { BlockReplyPayload } from "./embedded-agent-payloads.js";
 import type { EmbeddedRunReplayState } from "./embedded-agent-runner/replay-state.js";
-import type { RunEmbeddedAgentInternalParams } from "./embedded-agent-runner/run/internal-params.js";
+import type { EmbeddedRunAttemptInternalParams } from "./embedded-agent-runner/run/internal-params.js";
 import type { EmbeddedRunAttemptParams } from "./embedded-agent-runner/run/types.js";
 import type { BlockReplyFlushContext } from "./embedded-agent-runner/types.js";
 import type {
@@ -109,8 +109,8 @@ export type SubscribeEmbeddedAgentSessionParams = {
    */
   suppressLiveStreamOutput?: boolean;
   config?: OpenClawConfig;
-  compactionCountOwner?: RunEmbeddedAgentInternalParams["compactionCountOwner"];
-  onContextAccountingEvent?: RunEmbeddedAgentInternalParams["onContextAccountingEvent"];
+  compactionCountOwner?: EmbeddedRunAttemptInternalParams["compactionCountOwner"];
+  onContextAccountingEvent?: EmbeddedRunAttemptInternalParams["onContextAccountingEvent"];
   sessionPersistence?: EmbeddedRunAttemptParams["sessionPersistence"];
   sessionKey?: string;
   /** Current transport channel resolved for this run. */

--- a/src/auto-reply/reply/agent-runner-compaction-accounting.ts
+++ b/src/auto-reply/reply/agent-runner-compaction-accounting.ts
@@ -1,5 +1,23 @@
-import type { CompactionAccountingFact } from "../../agents/embedded-agent-runner/run/internal-params.js";
+import type {
+  CompactionAccountingFact,
+  CompactionAccountingTarget,
+} from "../../agents/embedded-agent-runner/run/internal-params.js";
 import type { AgentTurnCompaction } from "./agent-runner-execution.types.js";
+
+export function hasSameCompactionWriter(
+  previous: CompactionAccountingTarget | undefined,
+  current: CompactionAccountingTarget,
+): boolean {
+  // Physical session IDs may rotate while the binding and retained writer stay fixed.
+  return (
+    previous !== undefined &&
+    previous.agentId === current.agentId &&
+    previous.sessionKey === current.sessionKey &&
+    previous.storePath === current.storePath &&
+    previous.lifecycleRevision === current.lifecycleRevision &&
+    previous.activeWriterRunId === current.activeWriterRunId
+  );
+}
 
 /** A later opaque candidate may lose freshness, but must never fabricate it. */
 export function invalidateTurnCompactionContext(compaction: AgentTurnCompaction): void {
@@ -21,13 +39,8 @@ export function recordTurnCompaction(
   if (fact.kind !== "durable") {
     return;
   }
-  const index = compaction.durable.findIndex(
-    ({ target }) =>
-      target.agentId === fact.target.agentId &&
-      target.sessionKey === fact.target.sessionKey &&
-      target.storePath === fact.target.storePath &&
-      target.lifecycleRevision === fact.target.lifecycleRevision &&
-      target.activeWriterRunId === fact.target.activeWriterRunId,
+  const index = compaction.durable.findIndex(({ target }) =>
+    hasSameCompactionWriter(target, fact.target),
   );
   const previous = compaction.durable[index];
   if (!previous && fact.count === 0) {

--- a/src/auto-reply/reply/agent-runner-embedded-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-embedded-candidate.ts
@@ -235,7 +235,6 @@ export async function runEmbeddedFallbackCandidate(
         abortSignal: params.runAbortSignal,
         replyOperation: turn.replyOperation,
         deferTerminalLifecycle: true,
-        compactionCountOwner: "caller",
         onCompactionAccounting: (fact) => {
           compactionAccounting = fact;
         },

--- a/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
@@ -388,19 +388,10 @@ describe("executeAgentTurn: run lifecycle and ownership", () => {
     const { replyOperation, freezeAbortMock } = createMockReplyOperation();
     const abortController = new AbortController();
     let operationResult: ReplyOperation["result"] = null;
-    let releaseFallback: () => void = () => undefined;
-    let markCandidateSettled: () => void = () => undefined;
-    const candidateSettled = new Promise<void>((resolve) => {
-      markCandidateSettled = resolve;
-    });
-    const fallbackRelease = new Promise<void>((resolve) => {
-      releaseFallback = resolve;
-    });
-    let releaseToolTask: () => void = () => undefined;
-    const pendingToolTask = new Promise<void>((resolve) => {
-      releaseToolTask = resolve;
-    });
-    const pendingToolTasks = new Set([pendingToolTask]);
+    const candidateSettled = createDeferred();
+    const fallbackRelease = createDeferred();
+    const pendingToolTask = createDeferred();
+    const pendingToolTasks = new Set([pendingToolTask.promise]);
     Object.defineProperty(replyOperation, "abortSignal", {
       configurable: true,
       get: () => abortController.signal,
@@ -420,8 +411,8 @@ describe("executeAgentTurn: run lifecycle and ownership", () => {
     });
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
       const result = await params.run("anthropic", "claude", initialFallbackAttemptOptions(params));
-      markCandidateSettled();
-      await fallbackRelease;
+      candidateSettled.resolve();
+      await fallbackRelease.promise;
       return {
         result,
         provider: "anthropic",
@@ -436,19 +427,19 @@ describe("executeAgentTurn: run lifecycle and ownership", () => {
       replyOperation,
       pendingToolTasks,
     });
-    await candidateSettled;
+    await candidateSettled.promise;
     expect(replyOperation.abortByUser()).toBe(true);
     let settled = false;
     void pending.then(() => {
       settled = true;
     });
-    releaseFallback();
+    fallbackRelease.resolve();
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
     });
     expect(settled).toBe(false);
     expect(freezeAbortMock).not.toHaveBeenCalled();
-    releaseToolTask();
+    pendingToolTask.resolve();
 
     await expect(pending).resolves.toEqual({
       kind: "final",

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -318,15 +318,6 @@ function followupUsesCliRuntime(params: FollowupRuntimeParams, runtimeId: string
   );
 }
 
-function resolveFollowupContextConfigProvider(params: FollowupRuntimeParams): string {
-  const provider = params.followupRun.run.provider;
-  return resolveContextConfigProviderForRuntime({
-    provider,
-    runtimeId: resolveFollowupAgentRuntimeId(params),
-    config: params.cfg,
-  });
-}
-
 function resolveFollowupAgentRuntimeId(params: FollowupRuntimeParams): string {
   if (params.agentHarnessId) {
     return params.agentHarnessId;
@@ -1301,12 +1292,10 @@ export async function runMemoryFlushIfNeeded(params: {
     recordMemoryFlushFailure(error, params, activeSessionEntry);
   const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
     cfg: params.cfg,
-    provider: resolveFollowupContextConfigProvider({
-      cfg: params.cfg,
-      followupRun: params.followupRun,
-      sessionEntry: entry,
-      sessionKey: params.sessionKey,
-      runtimePolicySessionKey: params.runtimePolicySessionKey,
+    provider: resolveContextConfigProviderForRuntime({
+      provider: params.followupRun.run.provider,
+      runtimeId,
+      config: params.cfg,
     }),
     modelId: params.followupRun.run.model ?? params.defaultModel,
   });
@@ -1663,7 +1652,6 @@ export async function runMemoryFlushIfNeeded(params: {
             bootstrapPromptWarningSignature:
               bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],
             abortSignal: deferredLifecycle.signal,
-            compactionCountOwner: "caller",
             onCompactionAccounting: (fact) => {
               if (fact) {
                 recordTurnCompaction(compaction, fact);


### PR DESCRIPTION
Related: #133441 — native session usage remained zero after `/new`; #133260 — recovery compaction cancellation and committed-count ownership.

<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch. This is an explicitly maintainer-requested cleanup of the accounting repairs above.

</details>

## What Problem This Solves

Compaction accounting retained a redundant outer ownership selector, a two-stage parameter adapter, duplicated writer identity checks, and forwarding helpers that made the repaired flow harder to audit. This follow-up reduces that maintenance burden without changing the session behavior established by the preceding fixes.

## Why This Change Was Made

The full runner already chooses callback handoff versus default count persistence from `onCompactionAccounting`; its outer `compactionCountOwner` tag no longer controls execution. Remove that tag and coupled union, build one command parameter object, and keep the real count-owner selector on the lower attempt/subscription contract. Private-field rejection and harness stripping remain unchanged.

The command and reply collectors now reuse the same logical-writer predicate without merging their different policies. Session finalization handles a context observation in one branch and uses the existing lazy-promise helper directly. Memory-flush preparation carries its already-resolved runtime instead of resolving it again. Two historical-context tests share one table-driven body, and the cancellation test reuses the existing deferred-promise helper without changing its execution order.

## User Impact

No intended user-visible change. Current writers still persist their usage; superseded writers cannot overwrite another run. Absent context, explicitly unknown context, and measured zero remain distinct. Command/reply accumulation, default settlement, standalone subscriptions, cancellation closeout, and billing-versus-context semantics are preserved.

## Evidence

Verified candidate tree `fe0d00fed8d29fa0c04375c76bd66609bae28864`, based on `cbb8926a43dbfb96ea9fadf5faa8b197f53b78dd`, in an independent exact-source checkout on Blacksmith Testbox `tbx_01m1a53cpr5y7bz7sc8trdx85p` ([proof environment run 33333220718](https://github.com/openclaw/openclaw/actions/runs/33333220718)). The external command completed successfully; the workflow link identifies the hydration environment, not a substitute test verdict.

**902 tests across 16 files passed, with zero failures or skips** (174.79s). The full changed-code gate passed (725.63s), including core/core-test typechecks, typed lint, formatting, dead-export scans, schema/ownership guards, and **zero runtime import cycles**. A full build passed (224.24s), with no ineffective dynamic-import warnings. A final report inspection confirmed both current/replaced native-writer regressions passed. The complete candidate tree was verified before execution and after every phase; each owned process group closed, and the Testbox was stopped after inspection. Runtime execution used fresh process-lifetime homes/state/config and did not load the Testbox's hydrated provider credentials.

The four cleanup-review perspectives and lead diff review were followed by fresh isolated Codex autoreview, which returned **scoped-clean at the configured P0 gate**, with no accepted/actionable findings. Local formatter and `git diff --check` passed. No application tests, probes, or builds ran on the controller.

<details>
<summary>Exact focused validation commands</summary>

```bash
pnpm test src/agents/agent-command.compaction-rotation.test.ts src/agents/agent-command.embedded-maintenance.test.ts src/agents/agent-command.live-model-switch.test.ts src/agents/command/attempt-execution.test.ts src/agents/command/session-store.test.ts src/agents/embedded-agent-runner/run.shared-integration.test.ts src/agents/embedded-agent-runner/run.session-prompt-state.test.ts src/agents/embedded-agent-runner/run.overflow-compaction.test.ts src/shared/lazy-promise.test.ts src/agents/embedded-agent-subscribe.handlers.compaction.test.ts src/agents/harness/selection.test.ts src/plugins/runtime/runtime-embedded-agent.runtime.test.ts src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts src/auto-reply/reply/agent-runner-result-accounting.persistence.test.ts src/auto-reply/reply/agent-runner-memory.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts --reporter=default --reporter=json --outputFile=.artifacts/compaction-cleanup-625078-focused.json
```

```bash
node scripts/check-changed.mjs -- src/agents/command/attempt-execution.ts src/agents/command/compaction-accounting.ts src/agents/command/session-store.test.ts src/agents/command/session-store.ts src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts src/agents/embedded-agent-runner/run.recovery-cancellation.test-support.ts src/agents/embedded-agent-runner/run.session-prompt-state.test.ts src/agents/embedded-agent-runner/run/internal-params.ts src/agents/embedded-agent-subscribe.types.ts src/auto-reply/reply/agent-runner-compaction-accounting.ts src/auto-reply/reply/agent-runner-embedded-candidate.ts src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts src/auto-reply/reply/agent-runner-memory.ts
```

```bash
pnpm build
```

</details>

Production: **+66/−111 = −45 lines** across eight files. Tests/test support: **+94/−139 = −45 lines** across five files. **Net reduction: 90 lines**, with no new file, manager, compatibility path, configuration, schema, protocol, dependency, or public SDK surface.

The actual admission → SQLite writer claim → settlement → command collector → finalizer regression remains, including both current and replaced native writers. Historical CLI/model cases retain their names and exact inputs. Standalone subscription ownership and plugin/harness private-field boundary tests are included in the focused proof. No benchmark or new provider/UI behavior claim is made by this refactor.

Pinned Codex `0.151.0` source was inspected directly at [`78c290807ce710180111df227df3b7a4fe845452`](https://github.com/openai/codex/commit/78c290807ce710180111df227df3b7a4fe845452): [optional completion usage and distinct total/last usage](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L1834-L1879), [last-request context accounting](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/core/src/context_manager/history.rs#L429-L447), and [post-compaction recomputation](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/core/src/session/mod.rs#L4155-L4193). Those native contracts and the corresponding OpenClaw fences are unchanged.
