### PR TITLE
fix(release): resolve frozen candidate entrypoints

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -808,7 +808,7 @@ jobs:
           fi
 
           mkdir -p "$SOURCE_PERF_DIR/mock-hello"
-          if ! node -e "const fs=require('node:fs'); const scripts=require('./package.json').scripts||{}; process.exit(scripts['test:gateway:cpu-scenarios'] && scripts['test:extensions:memory'] && scripts.openclaw && fs.existsSync('openclaw.mjs') && fs.existsSync('scripts/profile-extension-memory.mts') ? 0 : 1)"; then
+          if ! node -e "const fs=require('node:fs'); const scripts=require('./package.json').scripts||{}; const extensionProbe=['scripts/profile-extension-memory.mts','scripts/profile-extension-memory.mjs'].some((entry)=>fs.existsSync(entry)); process.exit(scripts['test:gateway:cpu-scenarios'] && scripts['test:extensions:memory'] && scripts.openclaw && fs.existsSync('openclaw.mjs') && extensionProbe ? 0 : 1)"; then
             cat > "$SOURCE_PERF_DIR/index.md" <<EOF
           # OpenClaw Source Performance
 
@@ -820,15 +820,19 @@ jobs:
 
           - Tested ref: ${TESTED_REF}
           - Tested SHA: ${TESTED_SHA}
-          - Required scripts: test:gateway:cpu-scenarios, test:extensions:memory, openclaw, openclaw.mjs, scripts/profile-extension-memory.mts
+          - Required scripts: test:gateway:cpu-scenarios, test:extensions:memory, openclaw, openclaw.mjs, scripts/profile-extension-memory.{mts,mjs}
           EOF
             cat "$SOURCE_PERF_DIR/index.md" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
-          # target_ref may predate the dedicated profile; preserve the historical full build there.
-          if node --import tsx -e "import('./scripts/build-all.mts').then((module) => process.exit(module.BUILD_ALL_PROFILES?.sourcePerformance ? 0 : 1)).catch(() => process.exit(1))"; then
+          # Run the narrower build only when the candidate advertises the profile.
+          if [[ -f scripts/build-all.mts ]] && \
+            node --import tsx scripts/build-all.mts --help | grep -Fxq '  sourcePerformance'; then
             OPENCLAW_BUILD_PRIVATE_QA=1 node --import tsx scripts/build-all.mts sourcePerformance
+          elif [[ -f scripts/build-all.mjs ]] && \
+            node scripts/build-all.mjs --help | grep -Fxq '  sourcePerformance'; then
+            OPENCLAW_BUILD_PRIVATE_QA=1 node scripts/build-all.mjs sourcePerformance
           else
             pnpm build
           fi

--- a/scripts/lib/live-docker-stage.sh
+++ b/scripts/lib/live-docker-stage.sh
@@ -100,6 +100,24 @@ openclaw_live_prepare_cli_backend() {
   fi
 }
 
+openclaw_live_run_staged_script() {
+  local stem="${1:?staged script stem required}"
+  shift
+
+  # Frozen candidates may retain the Node-native .mjs runner while current
+  # sources ship its .mts successor. Run the candidate's available entrypoint.
+  if [ -f "${stem}.mts" ]; then
+    node --import tsx "${stem}.mts" "$@"
+    return
+  fi
+  if [ -f "${stem}.mjs" ]; then
+    node "${stem}.mjs" "$@"
+    return
+  fi
+  echo "staged OpenClaw script entrypoint not found: ${stem}.{mts,mjs}" >&2
+  return 1
+}
+
 openclaw_live_stage_source_tree() {
   local dest_dir="${1:?destination directory required}"
   local stage_mode="${OPENCLAW_LIVE_DOCKER_SOURCE_STAGE_MODE:-copy}"

--- a/scripts/test-live-acp-bind-docker.sh
+++ b/scripts/test-live-acp-bind-docker.sh
@@ -210,7 +210,7 @@ openclaw_live_stage_state_dir "$tmp_dir/.openclaw-state"
 openclaw_live_prepare_staged_config
 cd "$tmp_dir"
 export OPENCLAW_LIVE_ACP_BIND_AGENT_COMMAND="${OPENCLAW_LIVE_ACP_BIND_AGENT_COMMAND:-}"
-node --import tsx scripts/test-live.mts -- ${OPENCLAW_LIVE_ACP_BIND_TEST_FILES:-src/gateway/gateway-acp-bind.live.test.ts}
+openclaw_live_run_staged_script scripts/test-live -- ${OPENCLAW_LIVE_ACP_BIND_TEST_FILES:-src/gateway/gateway-acp-bind.live.test.ts}
 EOF
 
 openclaw_live_acp_bind_append_build_extension acpx

--- a/scripts/test-live-cli-backend-docker.sh
+++ b/scripts/test-live-cli-backend-docker.sh
@@ -294,7 +294,7 @@ openclaw_live_link_runtime_tree "$tmp_dir"
 openclaw_live_stage_state_dir "$tmp_dir/.openclaw-state"
 openclaw_live_prepare_staged_config
 cd "$tmp_dir"
-node --import tsx scripts/test-live.mts -- src/gateway/gateway-cli-backend.live.test.ts
+openclaw_live_run_staged_script scripts/test-live -- src/gateway/gateway-cli-backend.live.test.ts
 EOF
 
 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$ROOT_DIR" "$TRUSTED_HARNESS_DIR/scripts/test-live-build-docker.sh"

--- a/scripts/test-live-codex-harness-docker.sh
+++ b/scripts/test-live-codex-harness-docker.sh
@@ -232,7 +232,7 @@ run_codex_harness_target() {
   export OPENCLAW_LIVE_CODEX_HARNESS_MODEL="$model"
   export OPENCLAW_LIVE_CODEX_HARNESS_THINKING="$thinking"
   echo "==> Codex harness target: model=$model thinking=$thinking"
-  node --import tsx scripts/test-live.mts -- ${OPENCLAW_LIVE_CODEX_TEST_FILES:-src/gateway/gateway-codex-harness.live.test.ts}
+  openclaw_live_run_staged_script scripts/test-live -- ${OPENCLAW_LIVE_CODEX_TEST_FILES:-src/gateway/gateway-codex-harness.live.test.ts}
 }
 if [ -n "${OPENCLAW_LIVE_CODEX_HARNESS_TARGETS:-}" ]; then
   IFS=',' read -r -a harness_targets <<<"$OPENCLAW_LIVE_CODEX_HARNESS_TARGETS"

--- a/scripts/test-live-gateway-models-docker.sh
+++ b/scripts/test-live-gateway-models-docker.sh
@@ -61,11 +61,7 @@ while IFS= read -r docker_package; do
   openclaw_live_run_setup_command 180 "live CLI backend setup" npm install -g "$docker_package"
 done <<<"$docker_packages"
 openclaw_live_stage_gemini_auth
-if [[ -f scripts/test-live.mjs ]]; then
-  node scripts/test-live.mjs -- src/gateway/gateway-models.profiles.live.test.ts
-else
-  node --import tsx scripts/test-live.mts -- src/gateway/gateway-models.profiles.live.test.ts
-fi
+openclaw_live_run_staged_script scripts/test-live -- src/gateway/gateway-models.profiles.live.test.ts
 EOF
 
 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$ROOT_DIR" "$TRUSTED_HARNESS_DIR/scripts/test-live-build-docker.sh"

--- a/scripts/test-live-models-docker.sh
+++ b/scripts/test-live-models-docker.sh
@@ -64,11 +64,7 @@ openclaw_live_link_runtime_tree "$tmp_dir"
 openclaw_live_stage_state_dir "$tmp_dir/.openclaw-state"
 openclaw_live_prepare_staged_config
 cd "$tmp_dir"
-if [[ -f scripts/test-live.mjs ]]; then
-  node scripts/test-live.mjs -- src/agents/models.profiles.live.test.ts
-else
-  node --import tsx scripts/test-live.mts -- src/agents/models.profiles.live.test.ts
-fi
+openclaw_live_run_staged_script scripts/test-live -- src/agents/models.profiles.live.test.ts
 EOF
 
 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$ROOT_DIR" "$TRUSTED_HARNESS_DIR/scripts/test-live-build-docker.sh"

--- a/scripts/test-live-shard.mts
+++ b/scripts/test-live-shard.mts
@@ -712,6 +712,22 @@ export function buildLiveShardSpawnParams(
   } satisfies Pick<PnpmRunnerParams, "detached" | "env" | "stdio">;
 }
 
+export function resolveLiveShardBuildEntrypoint(exists = fs.existsSync): string[] {
+  // Release harnesses run this trusted shard router from a frozen candidate
+  // checkout. Prefer its current TypeScript builder, then its native ancestor.
+  if (exists("scripts/build-all.mts")) {
+    return ["--import", "tsx", "scripts/build-all.mts"];
+  }
+  if (exists("scripts/build-all.mjs")) {
+    return ["scripts/build-all.mjs"];
+  }
+  throw new Error("Live test shard cannot find scripts/build-all.{mts,mjs}");
+}
+
+export function resolveLiveShardBuildProfile(profile: string, usage: string): string {
+  return usage.split("\n").includes(`  ${profile}`) ? profile : "full";
+}
+
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   const rawArgs = process.argv.slice(2);
   const separatorIndex = rawArgs.indexOf("--");
@@ -762,14 +778,32 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
     console.log(
       `[test:live:shard] preparing ${preparation.profile} for ${preparation.requiredArtifact}`,
     );
-    const result = spawnSync(
-      process.execPath,
-      ["--import", "tsx", "scripts/build-all.mts", preparation.profile],
-      {
-        env: { ...process.env, ...preparation.env },
-        stdio: "inherit",
-      },
-    );
+    const buildEntrypoint = resolveLiveShardBuildEntrypoint();
+    const help = spawnSync(process.execPath, [...buildEntrypoint, "--help"], {
+      env: { ...process.env, ...preparation.env },
+      encoding: "utf8",
+    });
+    if (help.error) {
+      console.error(help.error);
+      process.exit(1);
+    }
+    if (help.signal) {
+      process.kill(process.pid, help.signal);
+      process.exit(1);
+    }
+    if ((help.status ?? 1) !== 0) {
+      process.exit(help.status ?? 1);
+    }
+    const buildProfile = resolveLiveShardBuildProfile(preparation.profile, help.stdout);
+    if (buildProfile !== preparation.profile) {
+      console.log(
+        `[test:live:shard] ${preparation.profile} is unavailable; preparing full build instead`,
+      );
+    }
+    const result = spawnSync(process.execPath, [...buildEntrypoint, buildProfile], {
+      env: { ...process.env, ...preparation.env },
+      stdio: "inherit",
+    });
     if (result.error) {
       console.error(result.error);
       process.exit(1);

--- a/scripts/test-live-shard.mts
+++ b/scripts/test-live-shard.mts
@@ -724,8 +724,8 @@ export function resolveLiveShardBuildEntrypoint(exists = fs.existsSync): string[
   throw new Error("Live test shard cannot find scripts/build-all.{mts,mjs}");
 }
 
-export function resolveLiveShardBuildProfile(profile: string, usage: string): string {
-  return usage.split("\n").includes(`  ${profile}`) ? profile : "full";
+export function resolveLiveShardBuildProfile(profile: string, helpOutput: string): string {
+  return helpOutput.split("\n").includes(`  ${profile}`) ? profile : "full";
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/test-live-subagent-announce-docker.sh
+++ b/scripts/test-live-subagent-announce-docker.sh
@@ -85,7 +85,7 @@ cd "$tmp_dir"
 OPENCLAW_LIVE_TEST=1 \
 OPENCLAW_LIVE_SUBAGENT_E2E=1 \
 OPENCLAW_VITEST_MAX_WORKERS="${OPENCLAW_VITEST_MAX_WORKERS:-1}" \
-node --import tsx scripts/test-live.mts -- src/agents/subagents/announce/subagent-announce.live.test.ts -- --reporter=verbose
+openclaw_live_run_staged_script scripts/test-live -- src/agents/subagents/announce/subagent-announce.live.test.ts -- --reporter=verbose
 EOF
 
 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$ROOT_DIR" "$TRUSTED_HARNESS_DIR/scripts/test-live-build-docker.sh"

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2901,18 +2901,19 @@ docker_e2e_docker_run_cmd run demo
     expect(inner.status, inner.stderr).toBe(0);
   });
 
-  it("selects the live model test runner shipped by the staged candidate", () => {
+  it("routes staged live suites through the candidate entrypoint resolver", () => {
     for (const scriptPath of [
+      "scripts/test-live-acp-bind-docker.sh",
+      "scripts/test-live-cli-backend-docker.sh",
+      "scripts/test-live-codex-harness-docker.sh",
       "scripts/test-live-gateway-models-docker.sh",
       "scripts/test-live-models-docker.sh",
+      "scripts/test-live-subagent-announce-docker.sh",
     ]) {
       const script = readFileSync(scriptPath, "utf8");
-      const legacyRunnerIndex = script.indexOf("node scripts/test-live.mjs --");
-      const currentRunnerIndex = script.indexOf("node --import tsx scripts/test-live.mts --");
 
-      expect(script).toContain("if [[ -f scripts/test-live.mjs ]]; then");
-      expect(legacyRunnerIndex).toBeGreaterThan(-1);
-      expect(currentRunnerIndex).toBeGreaterThan(legacyRunnerIndex);
+      expect(script).toContain("openclaw_live_run_staged_script scripts/test-live --");
+      expect(script).not.toContain("node --import tsx scripts/test-live.mts --");
     }
   });
 

--- a/test/scripts/live-docker-stage.test.ts
+++ b/test/scripts/live-docker-stage.test.ts
@@ -108,6 +108,62 @@ describe("live Docker state staging", () => {
     expect(result.stderr).toContain("CLI backend executable was not provisioned:");
   });
 
+  it.each([
+    {
+      entrypoint: "scripts/test-live.mts",
+      expected: "--import tsx scripts/test-live.mts -- target",
+    },
+    { entrypoint: "scripts/test-live.mjs", expected: "scripts/test-live.mjs -- target" },
+  ])("runs the staged $entrypoint live runner", ({ entrypoint, expected }) => {
+    const root = tempDirs.make("openclaw-live-stage-entrypoint-");
+    const binDir = path.join(root, "bin");
+    const callsPath = path.join(root, "calls");
+    mkdirSync(path.join(root, path.dirname(entrypoint)), { recursive: true });
+    mkdirSync(binDir);
+    writeFileSync(path.join(root, entrypoint), "");
+    writeFileSync(
+      path.join(binDir, "node"),
+      '#!/usr/bin/env bash\nset -eu\nprintf "%s\\n" "$*" > "$CALLS_PATH"\n',
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        'set -euo pipefail; cd "$1"; source "$2"; openclaw_live_run_staged_script scripts/test-live -- target',
+        "test",
+        root,
+        stageScriptPath,
+      ],
+      {
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH}`, CALLS_PATH: callsPath },
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readFileSync(callsPath, "utf8").trim()).toBe(expected);
+  });
+
+  it("refuses to replace a missing staged live runner", () => {
+    const root = tempDirs.make("openclaw-live-stage-entrypoint-missing-");
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        'set +e; cd "$1"; source "$2"; openclaw_live_run_staged_script scripts/test-live -- target',
+        "test",
+        root,
+        stageScriptPath,
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("staged OpenClaw script entrypoint not found");
+  });
+
   it("keeps repo-local generated artifacts out of the source copy", () => {
     const script = readFileSync(stageScriptPath, "utf8");
 

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -540,13 +540,19 @@ describe("OpenClaw performance workflow", () => {
 
   it("builds only the QA and startup artifacts required by source probes", () => {
     const run = findStep("Run OpenClaw source performance probes", "source_performance").run ?? "";
-    const build =
+    const typedBuild =
       "OPENCLAW_BUILD_PRIVATE_QA=1 node --import tsx scripts/build-all.mts sourcePerformance";
+    const nativeBuild = "OPENCLAW_BUILD_PRIVATE_QA=1 node scripts/build-all.mjs sourcePerformance";
 
-    expect(run).toContain("module.BUILD_ALL_PROFILES?.sourcePerformance");
-    expect(run).toContain(build);
+    expect(run).toContain("scripts/profile-extension-memory.{mts,mjs}");
+    expect(run).toContain("scripts/build-all.mts --help");
+    expect(run).toContain("scripts/build-all.mjs --help");
+    expect(run).toContain("sourcePerformance");
+    expect(run).toContain(typedBuild);
+    expect(run).toContain(nativeBuild);
     expect(run).toContain("pnpm build");
-    expect(run.indexOf(build)).toBeLessThan(run.indexOf("pnpm test:gateway:cpu-scenarios"));
+    expect(run.indexOf(typedBuild)).toBeLessThan(run.indexOf("pnpm test:gateway:cpu-scenarios"));
+    expect(run.indexOf(nativeBuild)).toBeLessThan(run.indexOf("pnpm test:gateway:cpu-scenarios"));
     expect(run.indexOf("pnpm build")).toBeLessThan(run.indexOf("pnpm test:gateway:cpu-scenarios"));
   });
 

--- a/test/scripts/test-live-cli-backend-docker.test.ts
+++ b/test/scripts/test-live-cli-backend-docker.test.ts
@@ -15,11 +15,11 @@ function readForwardedDockerEnvVars(): string[] {
 }
 
 describe("scripts/test-live-cli-backend-docker.sh", () => {
-  it("runs the staged live test without invoking pnpm inside Docker", () => {
+  it("runs the staged live test through the staged entrypoint resolver", () => {
     const script = fs.readFileSync(SCRIPT_PATH, "utf8");
 
     expect(script).toContain(
-      "node --import tsx scripts/test-live.mts -- src/gateway/gateway-cli-backend.live.test.ts",
+      "openclaw_live_run_staged_script scripts/test-live -- src/gateway/gateway-cli-backend.live.test.ts",
     );
     expect(script).not.toContain("pnpm test:live src/gateway/gateway-cli-backend.live.test.ts");
   });

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -15,6 +15,8 @@ import {
   collectAllLiveTestFiles,
   parseLiveShardArgs,
   removeLiveShardReportFile,
+  resolveLiveShardBuildEntrypoint,
+  resolveLiveShardBuildProfile,
   resolveLiveShardPreparation,
   selectLiveShardFiles,
   validateLiveShardReportPayload,
@@ -252,6 +254,24 @@ describe("scripts/test-live-shard", () => {
     expect(
       resolveLiveShardPreparation(selectLiveShardFiles("native-live-src-gateway-core", allFiles)),
     ).toBeNull();
+  });
+
+  it("runs the frozen candidate's available build entrypoint and advertised profile", () => {
+    expect(resolveLiveShardBuildEntrypoint((file) => file.endsWith(".mts"))).toEqual([
+      "--import",
+      "tsx",
+      "scripts/build-all.mts",
+    ]);
+    expect(resolveLiveShardBuildEntrypoint((file) => file.endsWith(".mjs"))).toEqual([
+      "scripts/build-all.mjs",
+    ]);
+    expect(() => resolveLiveShardBuildEntrypoint(() => false)).toThrow(
+      "Live test shard cannot find scripts/build-all.{mts,mjs}",
+    );
+    expect(
+      resolveLiveShardBuildProfile("sourcePerformance", "Profiles:\n  full\n  sourcePerformance\n"),
+    ).toBe("sourcePerformance");
+    expect(resolveLiveShardBuildProfile("sourcePerformance", "Profiles:\n  full\n")).toBe("full");
   });
 
   it.each(["native-live-src-agents", "native-live-extensions-openai"])(

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -257,12 +257,12 @@ describe("scripts/test-live-shard", () => {
   });
 
   it("runs the frozen candidate's available build entrypoint and advertised profile", () => {
-    expect(resolveLiveShardBuildEntrypoint((file) => file.endsWith(".mts"))).toEqual([
+    expect(resolveLiveShardBuildEntrypoint((file) => file === "scripts/build-all.mts")).toEqual([
       "--import",
       "tsx",
       "scripts/build-all.mts",
     ]);
-    expect(resolveLiveShardBuildEntrypoint((file) => file.endsWith(".mjs"))).toEqual([
+    expect(resolveLiveShardBuildEntrypoint((file) => file === "scripts/build-all.mjs")).toEqual([
       "scripts/build-all.mjs",
     ]);
     expect(() => resolveLiveShardBuildEntrypoint(() => false)).toThrow(


### PR DESCRIPTION
Split from #133510.

The trusted release harness runs frozen candidates that may retain Node-native `.mjs` entrypoints and omit newer narrow build profiles. Resolve the entrypoint from the staged candidate, and select a narrow profile only when that candidate advertises it; otherwise preserve the full build.

Includes the native live-shard and Docker live-wrapper callers plus the source-performance harness. No target SHA or release-specific waiver.

Frozen-candidate proof (SHA `782a8f79688d1f102dc4c0e13d7b15fa8b06c869`):

- `openclaw_live_run_staged_script .../scripts/test-live --help` selected and ran `scripts/test-live.mjs`.
- Its real `scripts/build-all.mjs --help` advertises `full`, `ciArtifacts`, `gatewayWatch`, `qaRuntime`, and `cliStartup`—not `sourcePerformance`.
- The trusted `test-live-shard.mts native-live-src-gateway-profiles` route logged `sourcePerformance is unavailable; preparing full build instead`, completed the candidate full build, then invoked `node scripts/test-live.mjs`. The deliberately non-matching test filter caused the expected zero-passing-test exit only after that behavior was proven.

Focused owner tests pass: `node scripts/run-vitest.mjs test/scripts/test-live-shard.test.ts` (27/27). `git diff --check` passes.

Production/tooling LOC: +75/-26 (net +49); tests: +94/-11 (net +83). The shared staged-entrypoint boundary is new behavior required for older candidates; no product/runtime code changes.
