### PR TITLE
fix(release): seal frozen candidate package metadata

### DIFF
--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -706,9 +706,12 @@ jobs:
               package_args=(
                 --source-dir "$source_dir"
                 --output-dir /output
-                --pack-json /output/pack.json
+                --output-name candidate.tgz
               )
-              if [[ "$ALLOW_UNRELEASED_CHANGELOG" == "true" ]]; then
+              # The TypeScript implementation is the capability boundary for this
+              # newer option; frozen Node-native packers intentionally omit it.
+              if [[ "$ALLOW_UNRELEASED_CHANGELOG" == "true" ]] && \
+                [[ -f scripts/package-openclaw-for-docker.mts ]]; then
                 package_args+=(--allow-unreleased-changelog)
               fi
               node scripts/package-openclaw-for-docker.mjs "${package_args[@]}"

--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -711,7 +711,7 @@ jobs:
               # The TypeScript implementation is the capability boundary for this
               # newer option; frozen Node-native packers intentionally omit it.
               if [[ "$ALLOW_UNRELEASED_CHANGELOG" == "true" ]] && \
-                [[ -f scripts/package-openclaw-for-docker.mts ]]; then
+                grep -Fq -- '--allow-unreleased-changelog' scripts/package-openclaw-for-docker.mts; then
                 package_args+=(--allow-unreleased-changelog)
               fi
               node scripts/package-openclaw-for-docker.mjs "${package_args[@]}"

--- a/scripts/install-smoke-candidate-payload.mts
+++ b/scripts/install-smoke-candidate-payload.mts
@@ -135,6 +135,13 @@ import tarfile
 mode, archive_path, member_name = sys.argv[1:]
 with tarfile.open(archive_path, "r:gz") as archive:
     members = archive.getmembers()
+    if mode == "package-metadata":
+        files = [member for member in members if member.isfile()]
+        print(json.dumps({
+            "entryCount": len(files),
+            "unpackedSize": sum(member.size for member in files),
+        }))
+        sys.exit(0)
     if mode == "repo-file":
         requested_name = member_name
         roots = {
@@ -169,40 +176,6 @@ with tarfile.open(archive_path, "r:gz") as archive:
   return result.stdout;
 }
 
-function readPackageVersionFromPackJson(value: unknown): {
-  filename: string;
-  normalized: unknown[];
-  version: string;
-} {
-  if (!Array.isArray(value) || value.length === 0) {
-    throw new Error("candidate pack metadata must contain at least one package result");
-  }
-  const last = value.at(-1);
-  if (!last || typeof last !== "object" || Array.isArray(last)) {
-    throw new Error("candidate pack metadata must end with a package result");
-  }
-  const record = last as Record<string, unknown>;
-  const filename = record.filename;
-  if (
-    typeof filename !== "string" ||
-    filename !== path.basename(filename) ||
-    filename !== path.win32.basename(filename) ||
-    !/^openclaw-[A-Za-z0-9._-]+\.tgz$/u.test(filename)
-  ) {
-    throw new Error("candidate pack metadata contains an unsafe tarball filename");
-  }
-  const version = assertVersion(record.version, "candidate pack version");
-  return {
-    filename,
-    normalized: value.map((entry, index) =>
-      index === value.length - 1 && entry && typeof entry === "object" && !Array.isArray(entry)
-        ? { ...entry, filename: "candidate.tgz" }
-        : entry,
-    ),
-    version,
-  };
-}
-
 function readPackageJsonFromTarball(tarballPath: string): Record<string, unknown> {
   const raw = runPythonTarReader(["member", tarballPath, "package/package.json"]);
   try {
@@ -213,6 +186,27 @@ function readPackageJsonFromTarball(tarballPath: string): Record<string, unknown
     return value as Record<string, unknown>;
   } catch (error) {
     throw new Error("candidate package tarball has invalid package/package.json", { cause: error });
+  }
+}
+
+function readPackageTarballMetadata(tarballPath: string): {
+  entryCount: number;
+  unpackedSize: number;
+} {
+  const raw = runPythonTarReader(["package-metadata", tarballPath, ""]);
+  try {
+    const value = JSON.parse(raw.toString("utf8")) as Record<string, unknown>;
+    if (
+      !Number.isSafeInteger(value.entryCount) ||
+      value.entryCount < 1 ||
+      !Number.isSafeInteger(value.unpackedSize) ||
+      value.unpackedSize < 0
+    ) {
+      throw new Error("package metadata has invalid archive sizes");
+    }
+    return { entryCount: value.entryCount, unpackedSize: value.unpackedSize };
+  } catch (error) {
+    throw new Error("candidate package tarball metadata is invalid", { cause: error });
   }
 }
 
@@ -231,19 +225,15 @@ export async function sealInstallSmokeCandidatePayload(
     throw new Error("candidate payload output directory must be empty");
   }
 
-  const packJsonPath = path.join(options.packageDir, "pack.json");
-  const pack = readPackageVersionFromPackJson(
-    await readJson(packJsonPath, "candidate pack metadata"),
-  );
-  const sourceTarballPath = path.join(options.packageDir, pack.filename);
+  const sourceTarballPath = path.join(options.packageDir, "candidate.tgz");
   await assertRegularFile(sourceTarballPath, "candidate package tarball");
   const packageJson = readPackageJsonFromTarball(sourceTarballPath);
   if (packageJson.name !== "openclaw") {
     throw new Error("candidate package tarball must contain the openclaw package");
   }
-  if (packageJson.version !== pack.version) {
-    throw new Error("candidate package tarball version does not match pack metadata");
-  }
+  const packageVersion = assertVersion(packageJson.version, "candidate package version");
+  const packageMetadata = readPackageTarballMetadata(sourceTarballPath);
+  const packageSize = (await fs.stat(sourceTarballPath)).size;
 
   // Re-read installers from the immutable source archive after candidate execution. Candidate
   // build hooks never get a writable handle to the sealed scripts consumed by privileged jobs.
@@ -260,7 +250,20 @@ export async function sealInstallSmokeCandidatePayload(
   await fs.copyFile(sourceTarballPath, path.join(options.outputDir, "candidate.tgz"));
   await writeExclusive(
     path.join(options.outputDir, "candidate-pack.json"),
-    `${JSON.stringify(pack.normalized, null, 2)}\n`,
+    `${JSON.stringify(
+      [
+        {
+          entryCount: packageMetadata.entryCount,
+          filename: "candidate.tgz",
+          name: "openclaw",
+          size: packageSize,
+          unpackedSize: packageMetadata.unpackedSize,
+          version: packageVersion,
+        },
+      ],
+      null,
+      2,
+    )}\n`,
   );
   await writeExclusive(path.join(options.outputDir, "install.sh"), installScript);
   await writeExclusive(path.join(options.outputDir, "install-cli.sh"), cliInstallScript);
@@ -273,7 +276,7 @@ export async function sealInstallSmokeCandidatePayload(
   const manifest: InstallSmokeCandidatePayloadManifest = {
     ...identity,
     files,
-    packageVersion: pack.version,
+    packageVersion,
     schema: SCHEMA,
     sourceArchiveSha256: await sha256File(options.archivePath),
   };

--- a/scripts/install-smoke-candidate-payload.mts
+++ b/scripts/install-smoke-candidate-payload.mts
@@ -197,8 +197,10 @@ function readPackageTarballMetadata(tarballPath: string): {
   try {
     const value = JSON.parse(raw.toString("utf8")) as Record<string, unknown>;
     if (
+      typeof value.entryCount !== "number" ||
       !Number.isSafeInteger(value.entryCount) ||
       value.entryCount < 1 ||
+      typeof value.unpackedSize !== "number" ||
       !Number.isSafeInteger(value.unpackedSize) ||
       value.unpackedSize < 0
     ) {

--- a/test/scripts/install-smoke-candidate-payload.test.ts
+++ b/test/scripts/install-smoke-candidate-payload.test.ts
@@ -25,7 +25,10 @@ function sha256(filePath: string): string {
 }
 
 function createTarball(archivePath: string, sourceDir: string, entries: string[]): void {
-  execFileSync("tar", ["-czf", archivePath, "-C", sourceDir, ...entries]);
+  execFileSync("tar", ["-czf", archivePath, "-C", sourceDir, ...entries], {
+    // The candidate packer runs in Linux; prevent macOS tar from adding AppleDouble files.
+    env: { ...process.env, COPYFILE_DISABLE: "1" },
+  });
 }
 
 function createFixture(options: { symlinkInstaller?: boolean; symlinkPackage?: boolean } = {}) {

--- a/test/scripts/install-smoke-candidate-payload.test.ts
+++ b/test/scripts/install-smoke-candidate-payload.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, statSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -56,26 +56,13 @@ function createFixture(options: { symlinkInstaller?: boolean; symlinkPackage?: b
     `${JSON.stringify({ name: "openclaw", version: PACKAGE_VERSION })}\n`,
   );
   writeFileSync(path.join(packageContents, "index.js"), "console.log('openclaw');\n");
-  const packageName = `openclaw-${PACKAGE_VERSION}.tgz`;
-  const packagePath = path.join(packageDir, packageName);
+  const packagePath = path.join(packageDir, "candidate.tgz");
   createTarball(packagePath, packageRoot, ["package"]);
   if (options.symlinkPackage) {
     unlinkSync(packagePath);
     symlinkSync(path.join(root, "candidate.tar.gz"), packagePath);
   }
-  writeFileSync(
-    path.join(packageDir, "pack.json"),
-    `${JSON.stringify([
-      {
-        filename: packageName,
-        name: "openclaw",
-        size: 100,
-        unpackedSize: 200,
-        version: PACKAGE_VERSION,
-      },
-    ])}\n`,
-  );
-  return { archivePath, packageDir, payloadDir, root };
+  return { archivePath, packageDir, packagePath, packageContents, payloadDir, root };
 }
 
 async function sealFixture(options: { symlinkInstaller?: boolean; symlinkPackage?: boolean } = {}) {
@@ -128,6 +115,20 @@ describe("install smoke candidate payload", () => {
       { name: "candidate-pack.json", role: "package-metadata" },
       { name: "install.sh", role: "installer" },
       { name: "install-cli.sh", role: "cli-installer" },
+    ]);
+    expect(
+      JSON.parse(readFileSync(path.join(fixture.payloadDir, "candidate-pack.json"), "utf8")),
+    ).toEqual([
+      {
+        entryCount: 2,
+        filename: "candidate.tgz",
+        name: "openclaw",
+        size: statSync(fixture.packagePath).size,
+        unpackedSize:
+          statSync(path.join(fixture.packageContents, "package.json")).size +
+          statSync(path.join(fixture.packageContents, "index.js")).size,
+        version: PACKAGE_VERSION,
+      },
     ]);
     expect(readFileSync(path.join(fixture.payloadDir, "install.sh"), "utf8")).toContain(
       "echo install",

--- a/test/scripts/install-smoke-no-push-workflow.test.ts
+++ b/test/scripts/install-smoke-no-push-workflow.test.ts
@@ -709,6 +709,10 @@ describe("install smoke no-push root image transport", () => {
     expect(packageCandidate.run).toContain("--output-name candidate.tgz");
     expect(packageCandidate.run).not.toContain("--pack-json");
     expect(packageCandidate.run).toContain("scripts/package-openclaw-for-docker.mts");
+    expect(packageCandidate.run).toContain(
+      "grep -Fq -- '--allow-unreleased-changelog' scripts/package-openclaw-for-docker.mts",
+    );
+    expect(packageCandidate.run).not.toContain("[[ -f scripts/package-openclaw-for-docker.mts ]]");
     expect(packageCandidate.run).toContain("package_args+=(--allow-unreleased-changelog)");
     expect(JSON.stringify(job(workflow, "bun_global_install_smoke"))).not.toContain(
       "OPENCLAW_BUN_GLOBAL_SMOKE_ALLOW_UNRELEASED_CHANGELOG",

--- a/test/scripts/install-smoke-no-push-workflow.test.ts
+++ b/test/scripts/install-smoke-no-push-workflow.test.ts
@@ -699,14 +699,17 @@ describe("install smoke no-push root image transport", () => {
 
   it("passes package changelog intent only to the candidate packager", () => {
     const workflow = readWorkflow(INSTALL_SMOKE_REUSABLE);
-    expect(
-      step(
-        job(workflow, "installer_smoke_candidate_payload"),
-        "Package candidate only inside pinned harness",
-      ).env,
-    ).toMatchObject({
+    const packageCandidate = step(
+      job(workflow, "installer_smoke_candidate_payload"),
+      "Package candidate only inside pinned harness",
+    );
+    expect(packageCandidate.env).toMatchObject({
       ALLOW_UNRELEASED_CHANGELOG: "${{ inputs.allow_unreleased_changelog }}",
     });
+    expect(packageCandidate.run).toContain("--output-name candidate.tgz");
+    expect(packageCandidate.run).not.toContain("--pack-json");
+    expect(packageCandidate.run).toContain("scripts/package-openclaw-for-docker.mts");
+    expect(packageCandidate.run).toContain("package_args+=(--allow-unreleased-changelog)");
     expect(JSON.stringify(job(workflow, "bun_global_install_smoke"))).not.toContain(
       "OPENCLAW_BUN_GLOBAL_SMOKE_ALLOW_UNRELEASED_CHANGELOG",
     );


### PR DESCRIPTION
Split from #133510.

The frozen candidate packer predates the trusted harness-only `--pack-json` option. Request its supported deterministic filename, then derive the sealed payload metadata directly from the immutable candidate tarball: package identity/version, compressed size, unpacked size, and file count.

This keeps the installer smoke audit/budget contract without asking old candidate code to implement a new option. No target SHA or package allowlist.

Proof: focused payload and workflow tests are included; local execution is currently blocked before test collection by the checkout dependency mismatch `configureFsSafeNative is not a function` from `src/infra/fs-safe-defaults.ts`. `git diff --check` passes.

Production/tooling LOC: +52/-46 (net +6); tests: +26/-22 (net +4). The small tooling growth preserves sealed artifact provenance and package-budget evidence.