### PR TITLE
fix(release): detect optional target E2E capability

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1107,6 +1107,10 @@ jobs:
             const packageJson = JSON.parse(require("node:fs").readFileSync("package.json", "utf8"));
             if (typeof packageJson.scripts?.[process.argv[1]] !== "string") process.exit(1);
           ' "$TARGET_REQUIRED_SCRIPT"; then
+            if [[ "$OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS" != "1" ]]; then
+              echo "::error::Selected target does not provide required repo E2E capability: $TARGET_REQUIRED_SCRIPT."
+              exit 1
+            fi
             echo "::notice::Skipping $TARGET_REQUIRED_SCRIPT: selected target does not provide this newer repo E2E capability."
             exit 0
           fi

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1065,6 +1065,7 @@ jobs:
             command: pnpm test:ui:e2e --shard=4/4
           - name: Agent plugin Gateway
             command: pnpm test:e2e:agent-plugin-gateway
+            target_script: test:e2e:agent-plugin-gateway
     env:
       OPENCLAW_BUILD_PRIVATE_QA: "1"
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
@@ -1099,7 +1100,17 @@ jobs:
         env:
           OPENCLAW_E2E_WORKERS: "2"
           OPENCLAW_E2E_USE_PREBUILT_DIST: "1"
-        run: ${{ matrix.command }}
+          TARGET_REQUIRED_SCRIPT: ${{ matrix.target_script || '' }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$TARGET_REQUIRED_SCRIPT" ]] && ! node -e '
+            const packageJson = JSON.parse(require("node:fs").readFileSync("package.json", "utf8"));
+            if (typeof packageJson.scripts?.[process.argv[1]] !== "string") process.exit(1);
+          ' "$TARGET_REQUIRED_SCRIPT"; then
+            echo "::notice::Skipping $TARGET_REQUIRED_SCRIPT: selected target does not provide this newer repo E2E capability."
+            exit 0
+          fi
+          ${{ matrix.command }}
 
   validate_special_e2e:
     needs: validate_selected_ref

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4567,6 +4567,7 @@ server.listen(0, "127.0.0.1", () => {
     const repoE2eRows = repoE2e.strategy.matrix.include as Array<{
       name: string;
       command: string;
+      target_script?: string;
     }>;
     expect(repoE2eRows.map((row) => row.command)).toEqual([
       ...Array.from({ length: 4 }, (_, index) => `pnpm test:e2e:gateway --shard=${index + 1}/4`),
@@ -4574,6 +4575,9 @@ server.listen(0, "127.0.0.1", () => {
       "pnpm test:e2e:agent-plugin-gateway",
     ]);
     expect(new Set(repoE2eRows.map((row) => row.name)).size).toBe(9);
+    expect(repoE2eRows.find((row) => row.name === "Agent plugin Gateway")).toMatchObject({
+      target_script: "test:e2e:agent-plugin-gateway",
+    });
     expect(repoE2e.name).toBe("Repo E2E (${{ matrix.name }})");
     expect(repoE2e.if).toBe("inputs.include_repo_e2e && inputs.live_suite_filter == ''");
     expect(repoE2e["continue-on-error"]).toBe("${{ inputs.advisory }}");
@@ -4588,9 +4592,14 @@ server.listen(0, "127.0.0.1", () => {
     expect(sandboxSetupIndex).toBeGreaterThanOrEqual(0);
     expect(repoE2eIndex).toBeGreaterThan(sandboxSetupIndex);
     expect(repoE2eSteps[repoE2eIndex]).toMatchObject({
-      run: "${{ matrix.command }}",
-      env: { OPENCLAW_E2E_WORKERS: "2", OPENCLAW_E2E_USE_PREBUILT_DIST: "1" },
+      env: {
+        OPENCLAW_E2E_WORKERS: "2",
+        OPENCLAW_E2E_USE_PREBUILT_DIST: "1",
+        TARGET_REQUIRED_SCRIPT: "${{ matrix.target_script || '' }}",
+      },
     });
+    expect(repoE2eSteps[repoE2eIndex]?.run).toContain("selected target does not provide");
+    expect(repoE2eSteps[repoE2eIndex]?.run).toContain("${{ matrix.command }}");
     const targetedGroupStep = releaseChecks.jobs.plan_docker_lane_groups.steps.find(
       (step: WorkflowStep) => step.name === "Build targeted Docker lane groups",
     );

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4598,8 +4598,11 @@ server.listen(0, "127.0.0.1", () => {
         TARGET_REQUIRED_SCRIPT: "${{ matrix.target_script || '' }}",
       },
     });
-    expect(repoE2eSteps[repoE2eIndex]?.run).toContain("selected target does not provide");
-    expect(repoE2eSteps[repoE2eIndex]?.run).toContain("${{ matrix.command }}");
+    const repoE2eRun = repoE2eSteps[repoE2eIndex]?.run;
+    expect(repoE2eRun).toContain("OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS");
+    expect(repoE2eRun).toContain("Selected target does not provide required repo E2E capability");
+    expect(repoE2eRun).toContain("selected target does not provide this newer repo E2E capability");
+    expect(repoE2eRun).toContain("${{ matrix.command }}");
     const targetedGroupStep = releaseChecks.jobs.plan_docker_lane_groups.steps.find(
       (step: WorkflowStep) => step.name === "Build targeted Docker lane groups",
     );


### PR DESCRIPTION
Split from #133510.

The release harness has a current-main Agent Plugin Gateway matrix row, but the frozen `.35` candidate does not expose its package script. Associate only that newer row with the script capability it needs, inspect the candidate `package.json`, and report an explicit successful non-run when the capability is absent. Every candidate-supported matrix row still runs unchanged.

This is target capability detection, not a release-SHA waiver.

Proof: the focused reusable-workflow guard test is included; local execution is currently blocked before test collection by the checkout dependency mismatch `configureFsSafeNative is not a function` from `src/infra/fs-safe-defaults.ts`. `git diff --check` passes.

Production/workflow LOC: +12/-1 (net +11); tests: +11/-2 (net +9). The explicit capability boundary prevents the trusted harness from treating a new test command as part of an older product contract.