### PR TITLE
fix(e2e): keep delete fixture target-compatible

### DIFF
--- a/scripts/e2e/lib/fixtures/workspace.mjs
+++ b/scripts/e2e/lib/fixtures/workspace.mjs
@@ -31,7 +31,6 @@ function writeAgentsDeleteConfig() {
   writeJson(path.join(stateDir, "openclaw.json"), {
     agents: {
       ownership: "explicit",
-      defaults: { heartbeat: { agentId: "main" } },
       entries: {
         main: { workspace: sharedWorkspace },
         ops: { workspace: sharedWorkspace },

--- a/test/scripts/fixtures-workspace.test.ts
+++ b/test/scripts/fixtures-workspace.test.ts
@@ -42,14 +42,13 @@ function runOpenWebUiWorkspace(workspaceDir: string) {
 }
 
 describe("workspace fixture assertions", () => {
-  it("writes explicit owners for the shared-workspace agents", () => {
+  it("writes only the shared-workspace ownership inputs needed by the delete smoke", () => {
     const root = tempDirs.make("openclaw-fixture-workspace-");
     const { result, stateDir, workspace } = runAgentsDeleteConfig(root);
 
     expect(result.status).toBe(0);
     expect(JSON.parse(readFileSync(path.join(stateDir, "openclaw.json"), "utf8")).agents).toEqual({
       ownership: "explicit",
-      defaults: { heartbeat: { agentId: "main" } },
       entries: { main: { workspace }, ops: { workspace } },
     });
   });


### PR DESCRIPTION
Split from #133510.

The agents-delete shared-workspace smoke asserts explicit ownership and retention semantics. Its fixture also supplied a newer heartbeat config field that the frozen candidate rejects, even though the field is not part of the scenario. Remove that unrelated input and retain only the ownership/entry state the scenario proves.

Proof: focused fixture test is included; local execution is currently blocked before test collection by the checkout dependency mismatch `configureFsSafeNative is not a function` from `src/infra/fs-safe-defaults.ts`. `git diff --check` passes.

Production/tooling LOC: +0/-1 (net -1); tests: +1/-2 (net -1).