### PR TITLE
perf(terminal): reuse control scans and simplify sanitization

### DIFF
--- a/packages/terminal-core/src/ansi.ts
+++ b/packages/terminal-core/src/ansi.ts
@@ -163,21 +163,19 @@ export function splitGraphemes(input: string): string[] {
   }
 }
 
+// Construct once without embedding literal controls; DEL and C1 form one range.
+const LOG_CONTROL_CHARS_REGEX = new RegExp(
+  `[${String.fromCharCode(0x00)}-${String.fromCharCode(0x1f)}${String.fromCharCode(0x7f)}-${String.fromCharCode(0x9f)}]`,
+  "g",
+);
+
 /**
  * Sanitize a value for safe interpolation into log messages.
  * Strips ANSI escape sequences, C0/C1 control characters, and DEL to
  * prevent log forging / terminal escape injection (CWE-117).
  */
 export function sanitizeForLog(v: string): string {
-  // Pattern built at runtime so the source file stays free of literal control
-  // characters AND the linter cannot statically detect them (no-control-regex).
-  const c0Start = String.fromCharCode(0x00);
-  const c0End = String.fromCharCode(0x1f);
-  const del = String.fromCharCode(0x7f);
-  const c1Start = String.fromCharCode(0x80);
-  const c1End = String.fromCharCode(0x9f);
-  const controlCharsRegex = new RegExp(`[${c0Start}-${c0End}${del}${c1Start}-${c1End}]`, "g");
-  return stripAnsi(v).replace(controlCharsRegex, "");
+  return stripAnsi(v).replace(LOG_CONTROL_CHARS_REGEX, "");
 }
 
 function textWidth(text: string): number {
@@ -316,10 +314,7 @@ export function truncateToVisibleWidth(input: string, maxWidth: number): string 
         out += segment.value;
         used += controlWidth;
       } else if (controlWidth > 0) {
-        out += widthControls.reduce(
-          (value, control) => value.replaceAll(control, ""),
-          segment.value,
-        );
+        out += segment.value.replaceAll("\t", "");
         budgetSpent = true;
       } else {
         out += segment.value;

--- a/packages/terminal-core/src/safe-text.ts
+++ b/packages/terminal-core/src/safe-text.ts
@@ -3,31 +3,15 @@ import { stripAnsi } from "./ansi.js";
 
 /** Return whether text contains C0 or C1 terminal control characters. */
 export function hasTerminalControl(input: string): boolean {
-  for (const char of input) {
-    const codePoint = char.codePointAt(0);
-    if (
-      codePoint !== undefined &&
-      (codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f))
-    ) {
-      return true;
-    }
-  }
-  return false;
+  return input.search(/\p{Cc}/u) !== -1;
 }
 
 /**
  * Normalize untrusted text for single-line terminal/log rendering.
  */
 export function sanitizeTerminalText(input: string): string {
-  const normalized = stripAnsi(input)
-    .replace(/\r/g, "\\r")
-    .replace(/\n/g, "\\n")
-    .replace(/\t/g, "\\t");
-  let sanitized = "";
-  for (const char of normalized) {
-    if (!hasTerminalControl(char)) {
-      sanitized += char;
-    }
-  }
-  return sanitized;
+  // Strip escapes first so removed bytes cannot become a new ANSI sequence.
+  return stripAnsi(input).replace(/\p{Cc}/gu, (control) =>
+    control === "\r" ? "\\r" : control === "\n" ? "\\n" : control === "\t" ? "\\t" : "",
+  );
 }


### PR DESCRIPTION
## What Problem This Solves

Terminal helpers repeat preparation that can stay at their existing owners: log sanitization reconstructs a fixed regex on every call; single-line rendering scans the same string several times and rebuilds it character by character; the shared control-character predicate iterates Unicode characters in JavaScript; clipped CSI controls repeatedly strip identical TAB characters.

## Why This Change Was Made

Reuse the private log regex, map control characters in one pass after canonical ANSI stripping, use native character search for the existing boolean predicate, and strip all clipped TABs once. The guard and one-pass sanitizer travel together: changing the predicate alone would make the old per-character call pattern slower. No new cache, dependency, configuration, protocol or security policy is introduced.

The same C0/DEL/C1 set is handled. Single-line text still visibly escapes CR/LF/TAB, logging still removes them, and control-byte stripping does not reinterpret newly joined bytes as ANSI. OpenClaw keeps ANSI parsing ownership; grapheme width, embedded TAB budgets, resets and hyperlinks are unchanged.

## Evidence

The complete-owner comparison passed 212,963 scenarios and 1,064,815 comparisons, including every BMP code unit, malformed UTF-16/ANSI, repeated calls and complete table outputs. An independent reviewer inspected the owners, caller boundaries, installed width dependencies, history and all raw receipts. Twelve fresh Node processes ran one variant each, in forward then reverse order, retaining 6,300 samples and all 420 medians. No source or dependency drift was observed. Earlier shared-process attempts and all slower controls remain saved.

Combined short log sanitation improved about 1.89 times. One-kilobyte safe-text calls improved 14–17 times, and complete safe tables improved about 8–17%. Long control-predicate scans improved roughly 6.6–8.9 times; short inputs were neutral. The direct 512-TAB truncation fixture improved about 17–20%; ordinary one-TAB cases were neutral/mixed in its separate variant. These are four distinct owner mechanisms, not four estimates of whole-product speedup.

Costs are explicit: empty safe-text calls cost about 22–25 ns more, empty/early-match predicate calls about 38–43 ns more, and the combined CJK truncation control was about 5–8% slower. Similar CJK variation occurs in unchanged-owner variants; these measurements do not establish its cause. Guard-only regresses the old sanitizer and is not shipped independently. No terminal-write, full-handoff, Gateway, network or retained-memory gain is claimed.

All 196 applicable existing tests passed across five terminal/table/display/resume suites; the Windows-only casing test is skipped on macOS, as it was on baseline. The formatted patch is +13/-34, net -21 production lines, with no test changes. Fresh managed Codex review is scoped-clean (0.96 confidence). A current-main source audit confirms that the original baseline owners equal main and the measured candidates equal the tracked formatted files, with every copied/installed dependency binding intact. Full changed-file checks passed. A real source CLI sessions listing against the task-owned dev Gateway SQLite rendered the expected session, key and runtime columns, with no API key supplied; the process group exited cleanly and source hashes stayed fixed. The first proof driver incorrectly checked stdout only although human output was on stderr; its failed assertion is preserved, and the corrected driver waits for stream closure and checks both streams. Exact-head hosted CI passed: [run 33334704729](https://github.com/openclaw/openclaw/actions/runs/33334704729) at `22e067cde26fb831e1ebf065de74c931e985f2da`. The latest complete ClawSweeper review (20:55 UTC) has no source finding or Rank-up moves; its outstanding exact-head checks are now green. Independent and managed review are complete under the maintainer’s standing landing authorization; no review rule is bypassed.
