### PR TITLE
fix(qa): mark extended-stable suite artifacts complete

### DIFF
--- a/extensions/qa-lab/src/suite-summary.ts
+++ b/extensions/qa-lab/src/suite-summary.ts
@@ -45,6 +45,7 @@ export type QaSuiteSummaryJson = {
   };
   evidence?: QaEvidenceSummaryJson;
   run: {
+    status: "running" | "completed";
     startedAt: string;
     finishedAt: string;
     providerMode: QaProviderMode;

--- a/extensions/qa-lab/src/suite.summary-json.test.ts
+++ b/extensions/qa-lab/src/suite.summary-json.test.ts
@@ -23,6 +23,7 @@ describe("buildQaSuiteSummaryJson", () => {
 
   it("records provider/model/mode so parity gates can verify labels", () => {
     const json = buildQaSuiteSummaryJson(baseParams);
+    expect(json.run.status).toBe("completed");
     expect(json.run.startedAt).toBe("2026-04-11T00:00:00.000Z");
     expect(json.run.finishedAt).toBe("2026-04-11T00:05:00.000Z");
     expect(json.run.providerMode).toBe("mock-openai");
@@ -39,6 +40,12 @@ describe("buildQaSuiteSummaryJson", () => {
     expect(json.run.channelCapabilityMatrixPath).toBeNull();
     expect(json.run.channelDriverSmokePath).toBeNull();
     expect(json.run.scenarioIds).toBeNull();
+  });
+
+  it("distinguishes an in-progress artifact from terminal suite output", () => {
+    const json = buildQaSuiteSummaryJson({ ...baseParams, status: "running" });
+
+    expect(json.run.status).toBe("running");
   });
 
   it("records Crabline channel-driver metadata when selected", () => {

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -562,6 +562,7 @@ function mergeQaRuntimeEnvPatches(
 }
 
 export type QaSuiteSummaryJsonParams = {
+  status?: QaSuiteSummaryJson["run"]["status"];
   scenarios: QaSuiteScenarioResult[];
   startedAt: Date;
   finishedAt: Date;
@@ -622,6 +623,7 @@ export function buildQaSuiteSummaryJson(params: QaSuiteSummaryJsonParams): QaSui
     ...(params.metrics ? { metrics: params.metrics } : {}),
     ...(params.evidence ? { evidence: params.evidence } : {}),
     run: {
+      status: params.status ?? "completed",
       startedAt: params.startedAt.toISOString(),
       finishedAt: params.finishedAt.toISOString(),
       providerMode: params.providerMode,
@@ -877,6 +879,7 @@ async function runQaRuntimeParitySuite(params: {
 }
 
 async function writeQaSuiteArtifacts(params: {
+  status?: QaSuiteSummaryJson["run"]["status"];
   outputDir: string;
   startedAt: Date;
   finishedAt: Date;
@@ -1267,6 +1270,7 @@ export async function runQaFlowSuite(params?: QaSuiteRunParams): Promise<QaSuite
         .then(async () => {
           const partialFinishedAt = new Date();
           const { report, reportPath } = await writeQaSuiteArtifacts({
+            status: "running",
             outputDir,
             startedAt,
             finishedAt: partialFinishedAt,


### PR DESCRIPTION
Supersedes #133511.

## What Problem This Solves

Resolves a release-validation failure where the .35 QA runtime-pair candidate run completed successfully but its aggregate summary lacked the terminal completion marker expected by the trusted release validator.

## Why This Change Was Made

Backports the established QA artifact lifecycle marker at the producer: completed suite summaries serialize `run.status: "completed"`; concurrent progress snapshots serialize `"running"`. The trusted validator remains strict and unchanged.

## User Impact

Release operators receive a terminal, self-describing candidate QA artifact. No runtime, package, tag, npm, or publication behavior changes.

## Evidence

- Archived .35 aggregate artifact replay: `release-qa-runtime-pair-lane-core-782a8f79688d1f102dc4c0e13d7b15fa8b06c869-33331806870-1`, path `runtime-pair-core/qa-suite-summary.json`: 19/19 passed; canonical pair and manifest; adding the producer completion marker is accepted by the unchanged trusted validator (`{ total: 19, passed: 19, failed: 0, skipped: 0 }`).
- `node scripts/run-vitest.mjs extensions/qa-lab/src/suite.summary-json.test.ts` — 13 passed.
- `node scripts/run-oxlint.mjs --tsconfig extensions/qa-lab/tsconfig.json extensions/qa-lab/src/suite-summary.ts extensions/qa-lab/src/suite.ts extensions/qa-lab/src/suite.summary-json.test.ts` — passed.
- `node scripts/check-changed.mjs -- ...` — delegated run in progress: https://github.com/openclaw/openclaw/actions/runs/33334774811
- `git diff --check` — passed.

Production LOC: +5/-0 (net +5) | Tests: +7/-0

Provenance: backports the completion marker from #125924 (88edcd165480), the producer-side half of the terminal-evidence contract later enforced by #126407.
