### PR TITLE
test(auto-reply): prepare memory flush model capabilities

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -799,6 +799,12 @@ describe("runMemoryFlushIfNeeded", () => {
     });
 
     const result = await runDefaultMemoryFlush(sessionEntry, {
+      followupRun: createTestFollowupRun({
+        thinkingCatalog: [
+          { provider: "anthropic", id: "claude", input: ["text"] },
+          { provider: "anthropic", id: "fallback", input: ["text"] },
+        ],
+      }),
       sessionStore,
       sessionKey,
       storePath,
@@ -951,10 +957,15 @@ describe("runMemoryFlushIfNeeded", () => {
         };
       },
     );
-    const followupRun = createTestFollowupRun();
-    followupRun.run.provider = "openai";
-    followupRun.run.model = "gpt-5.6-sol";
-    followupRun.run.thinkLevel = "ultra";
+    const followupRun = createTestFollowupRun({
+      provider: "openai",
+      model: "gpt-5.6-sol",
+      thinkLevel: "ultra",
+      thinkingCatalog: [
+        { provider: "openai", id: "gpt-5.6-sol", input: ["text"] },
+        { provider: "demo", id: "basic", input: ["text"] },
+      ],
+    });
 
     await runMemoryFlushIfNeeded({
       cfg: {
@@ -1005,7 +1016,9 @@ describe("runMemoryFlushIfNeeded", () => {
       model: "qwen3.5:4b",
     });
     followupRun.run.thinkLevel = "high";
-    followupRun.run.thinkingCatalog = [{ provider: "ollama", id: "qwen3.5:4b", reasoning: true }];
+    followupRun.run.thinkingCatalog = [
+      { provider: "ollama", id: "qwen3.5:4b", reasoning: true, input: ["text"] },
+    ];
 
     await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
@@ -1458,7 +1471,14 @@ describe("runMemoryFlushIfNeeded", () => {
           },
         },
       },
-      followupRun: createTestFollowupRun({ provider: "anthropic", model: "claude" }),
+      followupRun: createTestFollowupRun({
+        provider: "anthropic",
+        model: "claude",
+        thinkingCatalog: [
+          { provider: "anthropic", id: "claude", input: ["text"] },
+          { provider: "ollama", id: "qwen3:8b", input: ["text"] },
+        ],
+      }),
       sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude",
       modelContextTokens: 100_000,

--- a/src/auto-reply/reply/agent-runner.test-fixtures.ts
+++ b/src/auto-reply/reply/agent-runner.test-fixtures.ts
@@ -43,7 +43,13 @@ export function createTestFollowupRun(overrides: Partial<FollowupRun["run"]> = {
       skillsSnapshot: { prompt: "", skills: [] },
       provider: "anthropic",
       model: "claude",
-      thinkingCatalog: [{ provider: "anthropic", id: "claude", input: ["text"] }],
+      thinkingCatalog: [
+        {
+          provider: overrides.provider ?? "anthropic",
+          id: overrides.model ?? "claude",
+          input: ["text"],
+        },
+      ],
       thinkLevel: "low",
       verboseLevel: "off",
       elevatedLevel: "off",


### PR DESCRIPTION
## Why

Full release verification timed out in the memory-flush Ultra fallback test while 835 other tests in that shard passed. Its follow-up fixture selected OpenAI and a fallback model but retained the shared fixture's unrelated Anthropic catalog row. Input-capability preparation consequently started real model/harness discovery during a test whose embedded runner was already mocked.

## What changed

The shared fixture now builds its default input row for the selected provider/model, while explicit catalog overrides remain authoritative. The memory tests supply input rows for their additional fallback and configured maintenance candidates, and retain the runtime-discovered Ollama reasoning metadata. This fixes the fixture at its producer and covers the related model-selection cases.

Thinking policy, Ultra-to-high fallback, immutable-turn checks, model routing, mocks, assertions and timeouts are unchanged. Product/runtime code is unchanged; no changelog entry is needed for internal test fixtures.

## Proof

The hosted test stalled for 123.071s and failed its 120s Vitest timeout. The unchanged local focused run stalled on the same test until the canonical no-output watchdog terminated it; that was a wrapper exit 143, not a local Vitest timeout. Adding the initial explicit model facts made the three focused cases pass: Ultra 340ms, Ollama 326ms and compaction fallback 925ms. An original-order whole-file run then exposed the same missing facts in the next selected-model override, motivating the shared fixture correction.

All 103 existing memory tests passed in original order after the final producer correction. Independent Codex review through P2 returned scoped-clean with no actionable findings. Final formatting and targeted lint passed. All changed-file gates through dead-code checks passed; the local core test type check stopped on six pre-existing logger type errors outside these files. Clean Linux proof passed all 138 tests across the four whole shared-fixture caller files with no skips in 29.80s of Vitest time (93.408s including source sync and frozen install). The worker verified the exact two committed file hashes. Clean-install [CI 33334931811](https://github.com/openclaw/openclaw/actions/runs/33334931811) passed on exact head b05fffa40bc8855e5f00509771cdfd453fb01057, including the required openclaw/ci-gate. The latest ClawSweeper comment is the intake acknowledgement, with no published findings or rank-up moves to address. One combined local run stalled before any test result under heavy host load; it is not counted as an assertion failure or proof of the fix.

Test/support delta: +33/-7; product runtime delta: 0. The ongoing full release also exposed a separate internal subagent completion-accounting defect; this PR does not claim to repair that issue or make that run green.
