### PR TITLE
feat: make agent assignment consistent across model adapters

### DIFF
--- a/extensions/codex/src/app-server/attempt-context.test.ts
+++ b/extensions/codex/src/app-server/attempt-context.test.ts
@@ -238,6 +238,9 @@ describe("Codex app-server attempt context", () => {
         path.join(executionDir, "AGENTS.md"),
       );
       expect(context.turnScopedDeveloperInstructions).toContain("Canonical agent soul");
+      expect(context.turnScopedDeveloperInstructions).toContain(
+        "OpenClaw Agent Assignment remains authoritative for agent ID, name, specialist scope, and handoff boundary.",
+      );
       expect(context.turnScopedDeveloperInstructions).not.toContain("Canonical agent instructions");
       expect(context.memoryToolRouted).toBe(true);
       expect(context.promptContext).toBeUndefined();

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -796,7 +796,7 @@ function renderCodexWorkspaceCollaborationDeveloperInstructions(
     files,
     header: "## OpenClaw Agent Soul",
     preamble:
-      "OpenClaw loaded these workspace instruction files from the active agent workspace. They are the canonical definitions of who you are, how you think and work, and the human you work alongside. Internalize and follow them accordingly.",
+      "OpenClaw loaded these workspace instruction files from the active agent workspace. They may define personality, working style, and human context. OpenClaw Agent Assignment remains authoritative for agent ID, name, specialist scope, and handoff boundary.",
     wrapperTag: "AGENT_SOUL",
   });
 }

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -2247,6 +2247,46 @@ describe("Codex app-server turn input image sanitizing", () => {
     );
   });
 
+  it("projects config assignment per turn without persisting it in thread instructions", () => {
+    const params = createAttemptParams({ provider: "openai" });
+    params.agentId = "worker";
+    params.config = {
+      agents: {
+        entries: {
+          worker: {
+            identity: { name: "Configured Worker" },
+            description: "Owns configured specialist work.",
+          },
+        },
+      },
+    };
+    const appServer = createAppServerOptions() as never;
+    const threadRequest = buildThreadStartParams(params, {
+      appServer,
+      cwd: "/repo",
+      dynamicTools: [],
+    });
+    const turnRequest = buildTurnStartParams(params, {
+      threadId: "thread-1",
+      cwd: "/repo",
+      appServer,
+      turnScopedDeveloperInstructions:
+        "IDENTITY.md says Name: Stale File Worker and owns conflicting workspace work.",
+    });
+    const turnInstructions = turnRequest.collaborationMode?.settings.developer_instructions ?? "";
+
+    expect(threadRequest.developerInstructions).not.toContain("## Agent Assignment");
+    expect(turnInstructions).toContain("## Agent Assignment");
+    expect(turnInstructions).toContain("Name: Configured Worker");
+    expect(turnInstructions).toContain(
+      "OpenClaw config is authoritative for agent ID, name, specialist scope, and handoff boundary.",
+    );
+    expect(turnInstructions).toContain("Name: Stale File Worker");
+    expect(turnInstructions.indexOf("Name: Configured Worker")).toBeLessThan(
+      turnInstructions.indexOf("Name: Stale File Worker"),
+    );
+  });
+
   it("places memory collaboration instructions before skills", () => {
     const request = buildTurnStartParams(createAttemptParams({ provider: "openai" }), {
       threadId: "thread-1",

--- a/extensions/codex/src/app-server/thread-prompt.test.ts
+++ b/extensions/codex/src/app-server/thread-prompt.test.ts
@@ -57,6 +57,26 @@ function buildInstructions(overrides: Partial<EmbeddedRunAttemptParams> = {}): s
   });
 }
 
+describe("buildDeveloperInstructions agent assignment", () => {
+  it("keeps assignment out of thread-lifetime instructions", () => {
+    expect(
+      buildInstructions({
+        agentId: "worker",
+        config: {
+          agents: {
+            entries: {
+              worker: {
+                identity: { name: "Worker" },
+                description: "Owns bounded specialist work.",
+              },
+            },
+          },
+        },
+      }),
+    ).not.toContain("## Agent Assignment");
+  });
+});
+
 describe("buildDeveloperInstructions delegation guidance", () => {
   it("shares the visible-session delegation policy with a canonical main session", () => {
     const instructions = buildInstructions();

--- a/extensions/codex/src/app-server/turn-params.ts
+++ b/extensions/codex/src/app-server/turn-params.ts
@@ -1,4 +1,7 @@
-import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  buildAgentAssignmentPrompt,
+  type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   asOptionalRecord,
   normalizeOptionalString,
@@ -181,6 +184,7 @@ function buildTurnScopedCollaborationInstructions(
   } = {},
 ): string | null {
   const contextInstructions = joinPresentSections(
+    buildAgentAssignmentPrompt({ config: params.config, agentId: params.agentId }),
     options.turnScopedDeveloperInstructions,
     options.memoryCollaborationInstructions,
     options.skillsCollaborationInstructions,

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -329,7 +329,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: strict session-agent resolution aliases preserve shipped Plugin SDK behavior.
       // +1: manifest-owned plugin capability secret availability guard.
       // +1: canonical diagnostic flag checker through its focused subpath.
-      4353,
+      // +1: shared selected-agent assignment renderer for native harness parity.
+      4354,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -435,7 +436,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: strict session-agent resolution aliases preserve shipped Plugin SDK behavior.
       // +1: manifest-owned plugin capability secret availability guard.
       // +1: canonical diagnostic flag checker through its focused subpath.
-      2591,
+      // +1: shared selected-agent assignment renderer for native harness parity.
+      2592,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/agent-assignment-prompt.test.ts
+++ b/src/agents/agent-assignment-prompt.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { buildAgentAssignmentPrompt } from "./agent-assignment-prompt.js";
+
+describe("buildAgentAssignmentPrompt", () => {
+  it("omits the block when no agent was selected", () => {
+    expect(buildAgentAssignmentPrompt({ config: {}, agentId: undefined })).toBeUndefined();
+  });
+
+  it("keeps the selected technical identity when optional metadata is absent", () => {
+    expect(buildAgentAssignmentPrompt({ config: {}, agentId: "worker" })).toBe(
+      [
+        "## Agent Assignment",
+        "OpenClaw config is authoritative for agent ID, name, specialist scope, and handoff boundary.",
+        "Agent ID: worker",
+      ].join("\n"),
+    );
+  });
+
+  it("sanitizes and bounds human-authored assignment metadata", () => {
+    const config = {
+      agents: {
+        entries: {
+          worker: {
+            identity: { name: "\nBuild\u200b Agent\r" },
+            description: `  Owns\nimplementation.  ${"x".repeat(1_100)}😀`,
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const prompt = buildAgentAssignmentPrompt({ config, agentId: "worker" });
+
+    expect(prompt).toContain(
+      "OpenClaw config is authoritative for agent ID, name, specialist scope, and handoff boundary.",
+    );
+    expect(prompt).toContain("Name: Build Agent");
+    expect(prompt).toContain("Specialist scope and handoff boundary: Owns implementation.");
+    expect(prompt).not.toContain("\nimplementation");
+    expect(prompt).not.toContain("\u200b");
+    expect(prompt).not.toContain("😀");
+    expect(prompt?.split("Specialist scope and handoff boundary: ")[1]).toHaveLength(1_024);
+  });
+});

--- a/src/agents/agent-assignment-prompt.ts
+++ b/src/agents/agent-assignment-prompt.ts
@@ -1,0 +1,53 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { resolveAgentConfig } from "./agent-scope-config.js";
+import { resolveAgentIdentity } from "./identity.js";
+import { sanitizeForPromptLiteral } from "./sanitize-for-prompt.js";
+
+const MAX_AGENT_ASSIGNMENT_ID_CHARS = 128;
+const MAX_AGENT_ASSIGNMENT_NAME_CHARS = 128;
+const MAX_AGENT_ASSIGNMENT_DESCRIPTION_CHARS = 1_024;
+
+function normalizeAssignmentText(value: string, maxChars: number): string | undefined {
+  const normalized = sanitizeForPromptLiteral(value.replace(/\s+/gu, " ")).trim();
+  const bounded = truncateUtf16Safe(normalized, maxChars).trimEnd();
+  return bounded || undefined;
+}
+
+/** Builds the selected agent's bounded factual self-assignment for model context. */
+export function buildAgentAssignmentPrompt(params: {
+  config?: OpenClawConfig;
+  agentId?: string;
+}): string | undefined {
+  if (!params.agentId?.trim()) {
+    return undefined;
+  }
+  const agentId = normalizeAssignmentText(
+    normalizeAgentId(params.agentId),
+    MAX_AGENT_ASSIGNMENT_ID_CHARS,
+  );
+  if (!agentId) {
+    return undefined;
+  }
+  const resolved = params.config ? resolveAgentConfig(params.config, agentId) : undefined;
+  const agentName = params.config
+    ? normalizeAssignmentText(
+        resolveAgentIdentity(params.config, agentId)?.name ?? "",
+        MAX_AGENT_ASSIGNMENT_NAME_CHARS,
+      )
+    : undefined;
+  const description = normalizeAssignmentText(
+    resolved?.description ?? "",
+    MAX_AGENT_ASSIGNMENT_DESCRIPTION_CHARS,
+  );
+  return [
+    "## Agent Assignment",
+    "OpenClaw config is authoritative for agent ID, name, specialist scope, and handoff boundary.",
+    `Agent ID: ${agentId}`,
+    agentName && agentName !== agentId ? `Name: ${agentName}` : undefined,
+    description ? `Specialist scope and handoff boundary: ${description}` : undefined,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n");
+}

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -55,6 +55,7 @@ export class AgentSelectionRequiredError extends Error {
 /** Per-agent config after applying agent defaults and normalizing scalar fields. */
 export type ResolvedAgentConfig = {
   name?: string;
+  description?: string;
   workspace?: string;
   agentDir?: string;
   model?: AgentEntry["model"];
@@ -339,6 +340,7 @@ export function resolveAgentConfig(
   const agentDefaults = cfg.agents?.defaults;
   return {
     name: readStringValue(entry.name),
+    description: readStringValue(entry.description),
     workspace: readStringValue(entry.workspace),
     agentDir: readStringValue(entry.agentDir),
     model:

--- a/src/agents/cli-runner/helpers.system-prompt.test.ts
+++ b/src/agents/cli-runner/helpers.system-prompt.test.ts
@@ -176,6 +176,34 @@ describe("buildCliAgentSystemPrompt", () => {
     expect(prompt).toContain("sessionId=session-123");
   });
 
+  it("includes the configured specialist assignment", () => {
+    const prompt = buildCliAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      config: {
+        agents: {
+          entries: {
+            editor: {
+              identity: { name: "Editor" },
+              description: "Owns editorial quality and hands source disputes back to research.",
+            },
+          },
+        },
+      },
+      tools: [],
+      modelDisplay: "test/model",
+      agentId: "editor",
+    });
+
+    expect(prompt).toContain(
+      [
+        "## Agent Assignment",
+        "Agent ID: editor",
+        "Name: Editor",
+        "Specialist scope and handoff boundary: Owns editorial quality and hands source disputes back to research.",
+      ].join("\n"),
+    );
+  });
+
   it("includes Telegram channel context for CLI final replies without core rich guidance", () => {
     const prompt = buildCliAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/embedded-agent-runner/system-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/system-prompt.test.ts
@@ -33,6 +33,45 @@ describe("buildEmbeddedSystemPrompt", () => {
     clearMemoryPluginState();
   });
 
+  it("includes the configured specialist assignment", () => {
+    const prompt = buildEmbeddedSystemPrompt({
+      config: {
+        agents: {
+          entries: {
+            writer: {
+              identity: { name: "Writer" },
+              description: "Drafts approved work and hands final review to the editor.",
+            },
+          },
+        },
+      },
+      agentId: "writer",
+      workspaceDir: "/tmp/openclaw",
+      reasoningTagHint: false,
+      runtimeInfo: {
+        agentId: "writer",
+        host: "local",
+        os: "darwin",
+        arch: "arm64",
+        node: process.version,
+        model: "gpt-5.4",
+        provider: "openai",
+      },
+      tools: [],
+      userTimezone: "UTC",
+      userDate: "2026-01-05",
+    });
+
+    expect(prompt).toContain(
+      [
+        "## Agent Assignment",
+        "Agent ID: writer",
+        "Name: Writer",
+        "Specialist scope and handoff boundary: Drafts approved work and hands final review to the editor.",
+      ].join("\n"),
+    );
+  });
+
   it("forwards provider prompt contributions into the embedded prompt", () => {
     const prompt = buildEmbeddedSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt-config.test.ts
+++ b/src/agents/system-prompt-config.test.ts
@@ -20,7 +20,118 @@ function buildPrompt(config: OpenClawConfig, agentId = "main", sessionKey?: stri
   });
 }
 
+const assignmentCases = [
+  {
+    agentId: "main",
+    agentName: "Coordinator",
+    description: "Coordinates work and hands specialist execution to the matching agent.",
+  },
+  {
+    agentId: "research",
+    agentName: "Researcher",
+    description: "Investigates evidence and hands implementation to the owning specialist.",
+  },
+  {
+    agentId: "editor",
+    agentName: "Editor",
+    description: "Owns editorial quality and hands source disputes back to research.",
+  },
+  {
+    agentId: "writer",
+    agentName: "Writer",
+    description: "Drafts approved work and hands final review to the editor.",
+  },
+  {
+    agentId: "code-ops",
+    agentName: "Code Operations",
+    description: "Owns implementation and hands product decisions to the coordinator.",
+  },
+] as const;
+
 describe("buildConfiguredAgentSystemPrompt", () => {
+  it.each(assignmentCases)(
+    "projects the $agentId agent's factual assignment",
+    ({ agentId, agentName, description }) => {
+      const prompt = buildPrompt(
+        {
+          agents: {
+            entries: {
+              [agentId]: { identity: { name: agentName }, description },
+            },
+          },
+        },
+        agentId,
+      );
+
+      expect(prompt).toContain(
+        [
+          "## Agent Assignment",
+          "OpenClaw config is authoritative for agent ID, name, specialist scope, and handoff boundary.",
+          `Agent ID: ${agentId}`,
+          `Name: ${agentName}`,
+          `Specialist scope and handoff boundary: ${description}`,
+        ].join("\n"),
+      );
+    },
+  );
+
+  it("keeps the selected assignment in prompt mode none", () => {
+    const prompt = buildConfiguredAgentSystemPrompt({
+      config: {
+        agents: {
+          entries: {
+            worker: {
+              identity: { name: "Worker" },
+              description: "Handles bounded specialist work.",
+            },
+          },
+        },
+      },
+      agentId: "worker",
+      workspaceDir: "/tmp/openclaw",
+      promptMode: "none",
+    });
+
+    expect(prompt).toContain(
+      "## Agent Assignment\nOpenClaw config is authoritative for agent ID, name, specialist scope, and handoff boundary.\nAgent ID: worker\nName: Worker",
+    );
+    expect(prompt).toContain(
+      "Specialist scope and handoff boundary: Handles bounded specialist work.",
+    );
+  });
+
+  it("keeps config assignment authoritative over conflicting workspace identity", () => {
+    const prompt = buildConfiguredAgentSystemPrompt({
+      config: {
+        agents: {
+          entries: {
+            worker: {
+              identity: { name: "Configured Worker" },
+              description: "Owns configured specialist work.",
+            },
+          },
+        },
+      },
+      agentId: "worker",
+      workspaceDir: "/tmp/openclaw",
+      contextFiles: [
+        {
+          path: "/tmp/openclaw/IDENTITY.md",
+          content: "Name: Stale File Worker\nScope: Owns conflicting workspace work.",
+        },
+      ],
+    });
+
+    expect(prompt).toContain(
+      "OpenClaw config is authoritative for agent ID, name, specialist scope, and handoff boundary.",
+    );
+    expect(prompt).toContain("Name: Configured Worker");
+    expect(prompt).toContain("Name: Stale File Worker");
+    expect(prompt.indexOf("Name: Configured Worker")).toBeLessThan(
+      prompt.indexOf("Name: Stale File Worker"),
+    );
+  });
+
   it.each([
     {
       name: "prefers delegation in the canonical main session",

--- a/src/agents/system-prompt-config.ts
+++ b/src/agents/system-prompt-config.ts
@@ -7,6 +7,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { buildTtsSystemPromptHint } from "../tts/tts-settings.js";
+import { buildAgentAssignmentPrompt } from "./agent-assignment-prompt.js";
 import { resolveMainSessionDelegationMode } from "./delegation-guidance.js";
 import { resolveOwnerDisplaySetting } from "./owner-display.js";
 import { buildAgentSystemPrompt } from "./system-prompt.js";
@@ -83,5 +84,6 @@ export function buildConfiguredAgentSystemPrompt(params: ConfiguredAgentSystemPr
   return buildAgentSystemPrompt({
     ...renderParams,
     ...configParams,
+    agentAssignmentPrompt: buildAgentAssignmentPrompt({ config, agentId }),
   });
 }

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -269,6 +269,18 @@ describe("buildAgentSystemPrompt", () => {
     }
   });
 
+  it("preserves the prompt-mode-none output when no agent assignment exists", () => {
+    expect(
+      buildAgentSystemPrompt({
+        workspaceDir: "/tmp/openclaw",
+        promptMode: "none",
+        runtimeInfo: { model: "openai/gpt-test" },
+      }),
+    ).toBe(
+      "You are a personal assistant running inside OpenClaw.\nCurrent model identity: openai/gpt-test. Model question: answer this current-run value.",
+    );
+  });
+
   it("preserves required visible-source message-tool guidance in minimal prompts", () => {
     const requiredMessageGuidance = "Current source visible reply MUST use `message(action=send)`";
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -782,6 +782,7 @@ export function appendModelIdentitySystemPrompt(params: {
 
 export function buildAgentSystemPrompt(params: {
   workspaceDir: string;
+  agentAssignmentPrompt?: string;
   defaultThinkLevel?: ThinkLevel;
   reasoningLevel?: ReasoningLevel;
   extraSystemPrompt?: string;
@@ -850,9 +851,12 @@ export function buildAgentSystemPrompt(params: {
   const runtimeInfo = params.runtimeInfo;
   const modelIdentityLine = buildModelIdentityPromptLine(runtimeInfo?.model);
   if (promptMode === "none") {
-    return ["You are a personal assistant running inside OpenClaw.", modelIdentityLine]
-      .filter(Boolean)
-      .join("\n");
+    const promptSections = [
+      "You are a personal assistant running inside OpenClaw.",
+      params.agentAssignmentPrompt,
+      modelIdentityLine,
+    ].filter(Boolean);
+    return promptSections.join(params.agentAssignmentPrompt ? "\n\n" : "\n");
   }
 
   const acpEnabled = params.acpEnabled === true;
@@ -1164,6 +1168,7 @@ export function buildAgentSystemPrompt(params: {
   });
   const stablePrefixCacheKey = hashStablePromptInput({
     workspaceDir: params.workspaceDir,
+    agentAssignmentPrompt: params.agentAssignmentPrompt,
     promptMode,
     promptSurface,
     toolLines,
@@ -1208,6 +1213,8 @@ export function buildAgentSystemPrompt(params: {
     const lines = [
       "You are a personal assistant running inside OpenClaw.",
       "",
+      params.agentAssignmentPrompt,
+      params.agentAssignmentPrompt ? "" : undefined,
       ...(includeToolGuidance
         ? [
             "## Tooling",

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -280,6 +280,7 @@ export {
   buildDelegationGuidanceSection,
   resolveMainSessionDelegationMode,
 } from "../agents/delegation-guidance.js";
+export { buildAgentAssignmentPrompt } from "../agents/agent-assignment-prompt.js";
 export { buildHarnessVisibleReplyGuidance } from "../auto-reply/source-reply-delivery-mode.js";
 export { normalizeQuestionTimeoutSeconds } from "../agents/tools/ask-user-tool-normalization.js";
 export { buildCredentialSafetyPrompt } from "../agents/transcript-credential-safety.js";


### PR DESCRIPTION
Closes #133435

## What Problem This Solves

Resolves a problem where an agent selected through OpenClaw could receive different or incomplete model-visible identity depending on whether the run used the generic embedded/CLI path or the native Codex adapter. Existing `agentId`, `identity.name`, and `description` configuration did not form one consistent specialist assignment across those paths.

## Why This Change Was Made

OpenClaw now assembles one bounded, sanitized factual agent-assignment block from the selected agent config and projects it through both the generic system prompt and native Codex's per-turn collaboration instructions. Config remains authoritative for ID, name, specialist scope, and handoff boundary; workspace files may still define personality, working style, and human context.

This does not change config storage, agent CRUD, workspace mirroring, personality files, authenticated-human identity, or any downstream deployment.

## User Impact

Agents can consistently know which OpenClaw agent they are and the configured scope they should own or hand off, regardless of whether they run through the generic embedded/CLI adapter or native Codex. Native Codex receives the assignment per turn, so a reused thread does not retain the wrong selected-agent assignment.

## Evidence

- Focused core prompt tests pass, including sanitization, bounds, metadata absence, prompt-mode compatibility, and config precedence.
- Native Codex focused suite passes: 3 files, 212 tests, including per-turn projection and exclusion from thread-lifetime instructions.
- CLI-runner and embedded-runner fixtures prove the same configured assignment reaches both generic adapters.
- `pnpm check:changed` passes on current `origin/main`, including formatting, core/extension/script typechecks, SDK surface accounting, plugin boundaries, lint, dead-code scans, and import-cycle guards.
- `pnpm build` passes.
- Repository autoreview reports scoped-clean with no accepted/actionable findings.

The complete Codex extension lane also exposed an unrelated existing sandbox HTTP redirect assertion (`POST` receiving `308`) in an unchanged file. Four other timing failures from that run passed targeted reruns; the assignment-focused Codex suite is green.
