### PR TITLE
improve: speed up legacy imports and transcript replacement

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2687,7 +2687,7 @@ src/config/sessions/session-accessor.sqlite-reset-window.ts	3
 src/config/sessions/session-accessor.sqlite-title-probes.ts	2
 src/config/sessions/session-accessor.sqlite-transcript-message-append.ts	1
 src/config/sessions/session-accessor.sqlite-transcript-mirror.ts	1
-src/config/sessions/session-accessor.sqlite-transcript-store.ts	7
+src/config/sessions/session-accessor.sqlite-transcript-store.ts	2
 src/config/sessions/session-accessor.sqlite-transcript-write.ts	5
 src/config/sessions/session-accessor.sqlite-visible-cursor.ts	1
 src/config/sessions/session-accessor.transcript-range.ts	3

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -1,9 +1,11 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { AgentMessage } from "../../agents/runtime/index.js";
 import { getCodeModeSourceAppend } from "../../agents/transcript-code-mode-source.js";
 import { redactTranscriptMessage } from "../../agents/transcript-redact.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
+  prepareSqliteQuerySync,
 } from "../../infra/kysely-sync.js";
 import { redactSecrets } from "../../logging/redact.js";
 import { canonicalizePersistedUserMessageMedia } from "../../media/media-facts.js";
@@ -60,7 +62,24 @@ type TranscriptAppendCursor = {
   initialized?: boolean;
   nextSeq?: number;
   appendToIndex?: ReturnType<typeof createTranscriptIndexAppenderInTransaction>;
+  updateWindow?: (createdAt: number) => unknown;
+  insertEvent?: ReturnType<typeof createTranscriptEventInserter>;
 };
+
+function createTranscriptEventInserter(database: OpenClawAgentDatabase, sessionId: string) {
+  return prepareSqliteQuerySync<{ seq: number; eventJson: string; createdAt: number }>(
+    database.db,
+    (parameter) =>
+      getSessionKysely(database.db)
+        .insertInto("transcript_events")
+        .values({
+          session_id: sessionId,
+          seq: parameter((row) => row.seq),
+          event_json: parameter((row) => row.eventJson),
+          created_at: parameter((row) => row.createdAt),
+        }),
+  );
+}
 
 export function appendTranscriptEventInTransaction(
   database: OpenClawAgentDatabase,
@@ -84,13 +103,13 @@ function appendTranscriptEvent(
   if (cursor.initialized) {
     // The first attempt established this window and the batch cannot delete it.
     // Even rejected identities update recency; keep each attempt's write in order.
-    executeSqliteQuerySync(
-      database.db,
+    cursor.updateWindow ??= prepareSqliteQuerySync<number>(database.db, (parameter) =>
       db
         .updateTable("session_windows")
-        .set({ updated_at: createdAt })
+        .set({ updated_at: parameter((timestamp) => timestamp) })
         .where("session_id", "=", scope.sessionId),
     );
+    cursor.updateWindow(createdAt);
   } else {
     ensureTranscriptSessionRoot(database, scope, createdAt, {
       allowStoredAlias: options.allowStoredAlias === true,
@@ -109,15 +128,8 @@ function appendTranscriptEvent(
     return false;
   }
   const seq = cursor.nextSeq ?? readNextTranscriptSeq(database, scope.sessionId);
-  executeSqliteQuerySync(
-    database.db,
-    db.insertInto("transcript_events").values({
-      session_id: scope.sessionId,
-      seq,
-      event_json: JSON.stringify(persistedEvent),
-      created_at: createdAt,
-    }),
-  );
+  cursor.insertEvent ??= createTranscriptEventInserter(database, scope.sessionId);
+  cursor.insertEvent({ seq, eventJson: JSON.stringify(persistedEvent), createdAt });
   cursor.nextSeq = seq + 1;
   if (options.touchMutation !== false) {
     touchTranscriptMutationInTransaction(database, scope.sessionId);
@@ -246,7 +258,11 @@ function appendTranscriptEventRowInTransaction(
   scope: ResolvedTranscriptScope,
   event: TranscriptEvent,
   seq: number,
-  state: { seenEventIds: Set<string>; seenMessageIdempotencyKeys: Set<string> },
+  state: {
+    seenEventIds: Set<string>;
+    seenMessageIdempotencyKeys: Set<string>;
+    insertEvent: ReturnType<typeof createTranscriptEventInserter>;
+  },
   createdAtOverride?: number,
 ): boolean {
   const persistedEvent = canonicalizeTranscriptEventMedia(event);
@@ -256,15 +272,7 @@ function appendTranscriptEventRowInTransaction(
   if (identity && state.seenEventIds.has(identity.eventId)) {
     return false;
   }
-  executeSqliteQuerySync(
-    database.db,
-    db.insertInto("transcript_events").values({
-      session_id: scope.sessionId,
-      seq,
-      event_json: JSON.stringify(persistedEvent),
-      created_at: createdAt,
-    }),
-  );
+  state.insertEvent({ seq, eventJson: JSON.stringify(persistedEvent), createdAt });
   const appendToIndex = createTranscriptIndexAppenderInTransaction(database.db, scope.sessionId);
   appendToIndex({
     seq,
@@ -425,8 +433,11 @@ export function replaceSqliteTranscriptEventsInTransaction(
     markSessionTranscriptIndexDirtyInTransaction(database.db, resolved.sessionId);
   }
   let seq = 0;
-  const seenEventIds = new Set<string>();
-  const seenMessageIdempotencyKeys = new Set<string>();
+  const state = {
+    seenEventIds: new Set<string>(),
+    seenMessageIdempotencyKeys: new Set<string>(),
+    insertEvent: createTranscriptEventInserter(database, resolved.sessionId),
+  };
   for (const [eventIndex, event] of events.entries()) {
     if (
       appendTranscriptEventRowInTransaction(
@@ -434,10 +445,7 @@ export function replaceSqliteTranscriptEventsInTransaction(
         resolved,
         event,
         seq,
-        {
-          seenEventIds,
-          seenMessageIdempotencyKeys,
-        },
+        state,
         options.createdAtByIndex?.[eventIndex],
       )
     ) {
@@ -672,52 +680,45 @@ function readTranscriptEventIdentity(event: unknown):
       messageIdempotencyKey: string | null;
     }
   | undefined {
-  if (!event || typeof event !== "object" || Array.isArray(event)) {
+  if (!isRecord(event)) {
     return undefined;
   }
-  const record = event as Record<string, unknown>;
-  const eventId = typeof record.id === "string" && record.id.trim() ? record.id.trim() : undefined;
+  const eventId = typeof event.id === "string" && event.id.trim() ? event.id.trim() : undefined;
   return eventId
     ? {
         eventId,
-        eventType: typeof record.type === "string" ? record.type : null,
-        parentId: typeof record.parentId === "string" ? record.parentId : null,
-        messageIdempotencyKey: readMessageIdempotencyKey(record.message),
+        eventType: typeof event.type === "string" ? event.type : null,
+        parentId: typeof event.parentId === "string" ? event.parentId : null,
+        messageIdempotencyKey: readMessageIdempotencyKey(event.message),
       }
     : undefined;
 }
 
 function canonicalizeTranscriptEventMedia(event: TranscriptEvent): TranscriptEvent {
-  if (!event || typeof event !== "object" || Array.isArray(event)) {
+  if (!isRecord(event)) {
     return event;
   }
-  const record = event as Record<string, unknown>;
-  const message = record.message;
-  if (
-    record.type !== "message" ||
-    !message ||
-    typeof message !== "object" ||
-    Array.isArray(message)
-  ) {
+  const message = event.message;
+  if (event.type !== "message" || !isRecord(message)) {
     return event;
   }
   const canonical = canonicalizePersistedUserMessageMedia(message);
-  return canonical.changed ? { ...record, message: canonical.message } : event;
+  return canonical.changed ? { ...event, message: canonical.message } : event;
 }
 
 export function readMessageIdempotencyKey(message: unknown): string | null {
-  if (!message || typeof message !== "object" || Array.isArray(message)) {
+  if (!isRecord(message)) {
     return null;
   }
-  const value = (message as { idempotencyKey?: unknown }).idempotencyKey;
+  const value = message.idempotencyKey;
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
 function readEventTimestamp(event: unknown): number | undefined {
-  if (!event || typeof event !== "object" || Array.isArray(event)) {
+  if (!isRecord(event)) {
     return undefined;
   }
-  const value = (event as { timestamp?: unknown }).timestamp;
+  const value = event.timestamp;
   if (typeof value === "number" && Number.isFinite(value)) {
     return value;
   }
@@ -742,10 +743,5 @@ export function redactTranscriptMessageForStorage<TMessage>(
 }
 
 function isTranscriptAgentMessage(value: unknown): value is AgentMessage {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    !Array.isArray(value) &&
-    typeof (value as { role?: unknown }).role === "string"
-  );
+  return isRecord(value) && typeof value.role === "string";
 }

--- a/src/infra/kysely-sync.test.ts
+++ b/src/infra/kysely-sync.test.ts
@@ -12,6 +12,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
   iterateSqliteQuerySync,
+  prepareSqliteQuerySync,
 } from "./kysely-sync.js";
 
 type SyncHelperTestDatabase = {
@@ -60,6 +61,54 @@ describe("kysely sync helpers", () => {
       { id: 1, name: "Ada" },
       { id: 2, name: "Grace" },
     ]);
+  });
+
+  it("binds changing values without confusing repeated bindings and literal parameters", () => {
+    database = new DatabaseSync(":memory:");
+    const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
+    const select = prepareSqliteQuerySync<{
+      name: string | null;
+      bytes: Uint8Array;
+      count: bigint;
+    }>(database, (parameter) => {
+      const name = parameter((input) => input.name);
+      return db.selectNoFrom([
+        name.as("name"),
+        name.as("repeated"),
+        sql.val("literal").as("literal"),
+        parameter((input) => input.bytes).as("bytes"),
+        parameter((input) => input.count).as("count"),
+      ]);
+    });
+    for (const name of ["literal", "'); DROP TABLE items; --", null, "λ🦞"]) {
+      const bytes = new Uint8Array([1, 2, 255]);
+      expect(select({ name, bytes, count: 42n }).rows).toEqual([
+        { name, repeated: name, literal: "literal", bytes, count: 42 },
+      ]);
+    }
+  });
+
+  it("keeps prepared query bindings independent during synchronous callback re-entry", () => {
+    database = new DatabaseSync(":memory:");
+    enableNodeSqliteKyselyStatementCache(database);
+    const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
+    const select = prepareSqliteQuerySync<number, { nested: number; input: number }>(
+      database,
+      (parameter) => {
+        const value = parameter((input) => input);
+        return db.selectNoFrom([
+          db.fn<number>("nested_value", [value]).as("nested"),
+          value.as("input"),
+        ]);
+      },
+    );
+    database.function("nested_value", (value) => {
+      const input = Number(value);
+      return input === 0 ? 0 : select(input - 1).rows[0]!.nested + 1;
+    });
+    for (const input of [2, 3, 4]) {
+      expect(select(input).rows).toEqual([{ nested: input, input }]);
+    }
   });
 
   it("returns identical results while repeated statements move from cold to warm", () => {

--- a/src/infra/kysely-sync.ts
+++ b/src/infra/kysely-sync.ts
@@ -1,7 +1,7 @@
 // Adapts node:sqlite sync database calls for Kysely-style query execution.
 import type { DatabaseSync, SQLInputValue, StatementSync } from "node:sqlite";
-import type { Compilable, CompiledQuery, Kysely, QueryResult } from "kysely";
-import { InsertQueryNode, Kysely as KyselyInstance, SqliteDialect } from "kysely";
+import type { Compilable, CompiledQuery, Kysely, QueryResult, RawBuilder } from "kysely";
+import { InsertQueryNode, Kysely as KyselyInstance, sql as kyselySql, SqliteDialect } from "kysely";
 import {
   clearNodeSqliteKyselyCacheForDatabase,
   kyselyByDatabase,
@@ -267,6 +267,31 @@ export function executeSqliteQuerySync<Row>(
   query: Compilable<Row>,
 ): QueryResult<Row> {
   return executeCompiledSqliteQuerySync<Row>(db, query.compile());
+}
+
+/** Compile a fixed query once; bind fresh values through the normal sync executor on each call. */
+export function prepareSqliteQuerySync<Params, Row = unknown>(
+  db: DatabaseSync,
+  build: (
+    parameter: <Value extends SQLInputValue>(read: (params: Params) => Value) => RawBuilder<Value>,
+  ) => Compilable<Row>,
+): (params: Params) => QueryResult<Row> {
+  const bindings = new Map<unknown, (params: Params) => SQLInputValue>();
+  const compiled = build((read) => {
+    const marker = Symbol("sqlite-query-parameter");
+    bindings.set(marker, read);
+    // Kysely preserves bound values in compiler order. Unique markers avoid
+    // positional assumptions and collisions with literal query parameters.
+    /* kysely-allow-raw: a bound value expression, with no raw SQL or identifiers. */
+    return kyselySql<ReturnType<typeof read>>`${marker}`;
+  }).compile();
+  const readers = compiled.parameters.map((value) => bindings.get(value) ?? (() => value));
+  return (params) =>
+    executeCompiledSqliteQuerySync(db, {
+      ...compiled,
+      // Keep bindings invocation-local: SQLite callbacks can re-enter this runner.
+      parameters: readers.map((read) => read(params)),
+    });
 }
 
 /** Compile and lazily iterate a Kysely query synchronously against node:sqlite. */


### PR DESCRIPTION
Related: #133496

## What Problem This Solves

Legacy session imports and transcript replacements repeatedly rebuild the same Kysely insert query. Batch imports also rebuild the same window-recency update for every event. This spends CPU on query construction after SQLite statement caching has already removed most prepare work.

## Why This Change Was Made

Compile these fixed query shapes once per synchronous batch and bind fresh values for each execution. A small typed preparation helper uses Kysely's bound-value expressions and compiler ordering, then delegates to the existing synchronous executor. It does not introduce another native statement cache or bypass cache admission, authorizer invalidation, re-entry handling, error reporting, or cleanup. Transcript append and replacement share one insert builder.

The SQL, write order, timestamps, JSON normalization, duplicate handling, idempotency ownership, projections, and transaction boundaries are unchanged. There are no schema, index, configuration, dependency, retention, concurrency, or durable-format changes.

## User Impact

Less query-building work during legacy imports and transcript replacement. Isolated Linux median complete file-to-SQLite import time fell 6.8% for deep histories, 4.7% across many sessions, 6.8% for v1 files, and 18.1% for v2 files. Branching, replay, and tiny-import changes were modest; no material gain is claimed for those controls. The packaged stable upgrade and final-head CI both passed after a metadata-only assertion-baseline correction.

## Evidence

- 99 focused tests passed across synchronous Kysely execution, legacy import rollback/deduplication/source validation, active-branch projections, accessor conformance, and context eligibility/replacement. One existing 100k-message concurrent-rebuild test was excluded from the local run; the large importer/package proof runs on isolated Linux.
- New coverage exercises changing null/blob/bigint/Unicode/injection-like values, repeated bindings mixed with literal parameters, and synchronous callback re-entry without corrupting outer bindings.
- Full-priority independent Codex autoreview found no actionable findings. Formatting and completed structural guards pass. The local aggregate gate stops at six pre-existing `tslog` declaration errors in unchanged `src/logging/logger.ts`; the shared install lacks `types/BaseLogger.d.ts` and was not modified. Clean exact-head CI subsequently passed, including type checks.
- Three exploratory local before/after 10k imports had identical full persisted-data digests and lower CPU in every pair. Isolated Linux timing, CPU profiles, SQL traces, and a packaged stable upgrade gate landing.
- Production +77/-56 (net +21); tests +49. The added preparation seam preserves typed Kysely construction without hard-coded SQL or positional binding assumptions. The duplicate append/replacement insert builder is removed, and all execution safeguards remain owned by the existing executor. Nearby normalization now uses the existing canonical non-array record guard instead of repeated checks and casts.

Focused command: `node scripts/run-vitest.mjs src/infra/kysely-sync.test.ts src/config/sessions/session-accessor.sqlite-import.test.ts src/config/sessions/session-accessor.sqlite-active-events.test.ts src/config/sessions/session-accessor.conformance.test.ts src/config/sessions/session-transcript-context-eligibility.test.ts --testNamePattern '^(?!.*100k-message)'`.

Separate follow-up opportunities: Doctor's preliminary transcript-count scan still reparses rows before staging, and the JSONL reader still assembles temporary fragment arrays for complete lines. These are outside this query-construction change.

### Isolated Linux measurements

[Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/33335666090), Node 24.19.0 / SQLite 3.53.3, exact candidate `1c410b2575f7b05f96e884558bdd0614685e4c2b`. Only the two production owners are overridden for the baseline from `e60b4ec5260f91c4969654aa9dee5c4d5396f089`; all other source and dependencies are identical. Five fresh processes per side per shape, alternating pair order. Fixture creation and digest verification are outside the timer; stable fixture paths preserve v1 ID derivation.

| Shape | Before median | After median | Wall change | CPU change |
| --- | ---: | ---: | ---: | ---: |
| One event | 8.4 ms | 8.1 ms | -2.8% | -2.0% |
| 100k events, one history | 6080.5 ms | 5665.7 ms | -6.8% | -5.8% |
| 100 sessions × 100 events | 707.3 ms | 674.0 ms | -4.7% | -1.7% |
| 100 branching histories | 996.9 ms | 967.8 ms | -2.9% | -2.9% |
| 10k existing events, repeat import | 156.2 ms | 154.4 ms | -1.1% | -0.4% |
| 10k version-1 events | 662.1 ms | 617.4 ms | -6.8% | -6.3% |
| 10k version-2 events | 731.9 ms | 599.6 ms | -18.1% | -25.7% |

All 35 paired digests match across exact transcript bytes, identities, window metadata, active positions, projection watermarks, and FTS. The separate 10k-event trace retains 100,034 SQL calls across the same 34 shapes. Before/after Node CPU profiles completed separately from the unprofiled timing samples. All samples, including outliers, remain in the evidence; small movements in controls should not be treated as reliable speedups.

### Packaged upgrade and final-head scope

The packaged Docker upgrade from stable `2026.7.1-2` passed with 4,800 synthetic sessions, 1,227,946 events, and 10,000 cron jobs. Five full-state assertions passed, including automatic migration immediately after update and before standalone Doctor. Eight Gateway history samples across two agents returned 600 messages identically after restart. Repeat Doctor completed in 37 seconds against the unchanged 60-second budget; startup took 11 seconds, and health/readiness/status probes each took 1 second. The scenario uses an explicit candidate tarball, manual Gateway restart, and expected synthetic-plugin capability consent; it does not claim unattended update-channel switching. The command exited successfully in 13m14s; proof and CPU profiles were collected and checksum-verified, then the worker was stopped.

The package and benchmarks ran at `1c410b2575f7b05f96e884558bdd0614685e4c2b`. Final head `f29c696bfbd0fe91ea475768bc73fcf0b223b31a` differs only in `config/assertion-safety-baseline.txt` (7 → 2), recording the five removed casts. All production and test file hashes are identical. The baseline file is absent from the package inventory, so that correction does not change the tested runtime. The first CI run correctly caught the stale allowance; its exact ratchet passes after the correction, and independent review of that one-line change is clean. [Final-head CI](https://github.com/openclaw/openclaw/actions/runs/33336577483) completed successfully at `f29c696bfbd0fe91ea475768bc73fcf0b223b31a`.

### Dependency contract and review disposition

[ClawSweeper’s final-head review](https://github.com/openclaw/openclaw/pull/133546#issuecomment-5471346934), refreshed at 2026-08-30 21:41 UTC and personally read before landing, found no concrete code defect, but could not inspect the pinned dependency in its environment. I directly inspected installed Kysely 0.29.5 and independently fetched the versioned upstream compiler: [compileQuery](https://github.com/kysely-org/kysely/blob/v0.29.5/src/query-compiler/default-query-compiler.ts#L137) copies the ordered parameter array; [visitValue](https://github.com/kysely-org/kysely/blob/v0.29.5/src/query-compiler/default-query-compiler.ts#L520) forwards bound values unchanged; [addParameter](https://github.com/kysely-org/kysely/blob/v0.29.5/src/query-compiler/default-query-compiler.ts#L1891) appends the original value. A separate final-head executable probe confirmed marker identity, repeated marker ordering, and literal preservation in the installed version. The new SQLite tests also execute these bindings and nested callbacks, and all 35 complete import pairs match stored data. This resolves the dependency-inspection gap. I read the latest completed comment and its rank-up list; its exact-head CI request is now satisfied by the successful final run. The dependency contract is verified and accepted on that evidence; all requested rank-up work is addressed, with no skips.

Median process peak RSS (KiB), before → after: single 353,788 → 353,916; deep 512,860 → 512,636; wide 399,612 → 405,784; branch 406,024 → 405,228; replay 395,208 → 400,816; legacy-v1 406,332 → 402,048; legacy-v2 527,984 → 396,640. These are process peaks, not isolated importer allocations; no universal memory reduction is claimed.
