### PR TITLE
fix(clawdock): keep credentials out of diagnostic output

### DIFF
--- a/docs/install/clawdock.md
+++ b/docs/install/clawdock.md
@@ -94,9 +94,9 @@ ClawDock reads two separate `.env` files, matching the split described in [Docke
 - The project `.env` next to `docker-compose.yml`: Docker-specific values like image name, ports, and `OPENCLAW_GATEWAY_TOKEN`. `clawdock-token` reads the token from here.
 - `~/.openclaw/.env` (mounted into the container): env-backed secrets OpenClaw itself manages, alongside `openclaw.json` and the shared and per-agent SQLite auth stores.
 
-`clawdock-fix-token` copies the token from the project `.env` into the container's `gateway.remote.token` and `gateway.auth.token` config values and restarts the gateway.
+`clawdock-fix-token` copies the token from the project `.env` into the container's `gateway.remote.token` and `gateway.auth.token` through the validated config setters and restarts the gateway only after both writes succeed. It reports success or failure without printing tokens or token prefixes. `clawdock-token` explicitly prints the full token when you need it.
 
-Use `clawdock-show-config` to inspect `openclaw.json` and both `.env` files quickly; it redacts `.env` values in its printed output.
+Use `clawdock-show-config` to inspect JSON5 config structure and `.env` key names with all values redacted and comments omitted. It uses Node, JSON5, and dotenv from the built OpenClaw Docker image in temporary containers without starting dependencies; no host parser or running gateway is required. If Docker, parsing, or file access fails, it returns a failure with guidance and withholds that file's contents. Ambiguous `.env` values beginning with a literal quote are also withheld to avoid exposing unterminated multiline content. Source files are unchanged.
 
 ## Related
 

--- a/scripts/clawdock/README.md
+++ b/scripts/clawdock/README.md
@@ -160,6 +160,10 @@ The Docker setup uses three config files on the host. The container never stores
 
 **Do NOT** put API keys or bot tokens in `openclaw.json`. Use `~/.openclaw/.env` for all secrets.
 
+`clawdock-show-config` displays JSON5 structure and `.env` key names with all values redacted and comments omitted. It requires Docker and the built OpenClaw image; temporary containers use the image's Node, JSON5, and dotenv without starting dependencies or requiring host parsers. Processing failures withhold the affected file's contents and return a failure with guidance. Ambiguous `.env` values beginning with a literal quote are also withheld to protect unterminated multiline content. Source files are unchanged.
+
+`clawdock-fix-token` checks both config writes and reports success or failure without showing tokens or prefixes. Use `clawdock-token` only when you explicitly want the full token printed.
+
 ### Initial Setup
 
 `./scripts/docker/setup.sh` handles first-time Docker configuration:
@@ -333,9 +337,8 @@ clawdock-fix-token
 This will:
 
 1. Read the token from your `.env` file
-2. Configure it in the OpenClaw config
-3. Restart the gateway
-4. Verify the configuration
+2. Configure both token values through the validated OpenClaw config setters
+3. Restart the gateway only after both writes succeed
 
 ### Permission Denied
 

--- a/scripts/clawdock/clawdock-helpers.sh
+++ b/scripts/clawdock/clawdock-helpers.sh
@@ -54,20 +54,6 @@ _clawdock_trim_quotes() {
   printf "%s" "$value"
 }
 
-_clawdock_mask_value() {
-  local value="$1"
-  local length=${#value}
-  if (( length == 0 )); then
-    printf "%s" "<empty>"
-    return 0
-  fi
-  if (( length == 1 )); then
-    printf "%s" "<redacted:1 char>"
-    return 0
-  fi
-  printf "%s" "<redacted:${length} chars>"
-}
-
 _clawdock_browser_url_for_gateway_url() {
   local url="$1"
   case "$url" in
@@ -222,54 +208,41 @@ clawdock-config() {
 
 clawdock-show-config() {
   _clawdock_ensure_dir >/dev/null 2>&1 || true
-  local config_dir="${HOME}/.openclaw"
+  local config_dir="${HOME}/.openclaw" file rendered result=0
+  local files=("${config_dir}/openclaw.json" "${config_dir}/.env")
+  [[ -z "$CLAWDOCK_DIR" ]] || files+=("${CLAWDOCK_DIR}/.env")
   echo -e "${_CLR_BOLD}Config directory:${_CLR_RESET} ${_CLR_CYAN}${config_dir}${_CLR_RESET}"
   echo ""
 
-  # Show openclaw.json
-  if [[ -f "${config_dir}/openclaw.json" ]]; then
-    echo -e "${_CLR_BOLD}${config_dir}/openclaw.json${_CLR_RESET}"
-    echo -e "${_CLR_DIM}$(cat "${config_dir}/openclaw.json")${_CLR_RESET}"
-  else
-    echo -e "${_CLR_YELLOW}No openclaw.json found${_CLR_RESET}"
-  fi
-  echo ""
-
-  # Show .env (mask secret values)
-  if [[ -f "${config_dir}/.env" ]]; then
-    echo -e "${_CLR_BOLD}${config_dir}/.env${_CLR_RESET}"
-    while IFS= read -r line || [[ -n "$line" ]]; do
-      if [[ "$line" =~ ^[[:space:]]*# ]] || [[ -z "$line" ]]; then
-        echo -e "${_CLR_DIM}${line}${_CLR_RESET}"
-      elif [[ "$line" == *=* ]]; then
-        local key="${line%%=*}"
-        local val="${line#*=}"
-        echo -e "${_CLR_CYAN}${key}${_CLR_RESET}=${_CLR_DIM}$(_clawdock_mask_value "$val")${_CLR_RESET}"
-      else
-        echo -e "${_CLR_DIM}${line}${_CLR_RESET}"
-      fi
-    done < "${config_dir}/.env"
-  else
-    echo -e "${_CLR_YELLOW}No .env found${_CLR_RESET}"
-  fi
-  echo ""
-
-  # Show project .env if available
-  if [[ -n "$CLAWDOCK_DIR" && -f "${CLAWDOCK_DIR}/.env" ]]; then
-    echo -e "${_CLR_BOLD}${CLAWDOCK_DIR}/.env${_CLR_RESET}"
-    while IFS= read -r line || [[ -n "$line" ]]; do
-      if [[ "$line" =~ ^[[:space:]]*# ]] || [[ -z "$line" ]]; then
-        echo -e "${_CLR_DIM}${line}${_CLR_RESET}"
-      elif [[ "$line" == *=* ]]; then
-        local key="${line%%=*}"
-        local val="${line#*=}"
-        echo -e "${_CLR_CYAN}${key}${_CLR_RESET}=${_CLR_DIM}$(_clawdock_mask_value "$val")${_CLR_RESET}"
-      else
-        echo -e "${_CLR_DIM}${line}${_CLR_RESET}"
-      fi
-    done < "${CLAWDOCK_DIR}/.env"
-  fi
-  echo ""
+  for file in "${files[@]}"; do
+    printf '%b%s%b\n' "$_CLR_BOLD" "$file" "$_CLR_RESET"
+    if [[ ! -f "$file" ]]; then
+      echo "Not found"
+      continue
+    fi
+    # Buffer the renderer: neither partial output nor parser errors are safe to show.
+    if rendered=$(_clawdock_compose run --rm --no-deps -T --entrypoint node openclaw-gateway -e '
+      const input = require("node:fs").readFileSync(0, "utf8");
+      if (process.argv[1] === "openclaw.json") {
+        const config = require("json5").parse(input);
+        console.log(JSON.stringify(config, (_key, value) =>
+          value !== null && typeof value === "object" ? value : "<redacted>", 2));
+      } else {
+        const env = require("dotenv").parse(input);
+        // Unterminated quotes can turn secret continuation lines into keys.
+        // Reject ambiguous quote-leading values before displaying any keys.
+        if (Object.values(env).some(value => /^[\x22\x27`]/.test(value))) process.exit(1);
+        console.log(Object.keys(env).map(key => `${key}=<redacted>`).join("\n"));
+      }
+    ' "${file##*/}" 2>/dev/null < "$file"); then
+      printf '%s\n' "$rendered"
+    else
+      echo "Unable to safely display file. Check its syntax and permissions, Docker availability, and the built OpenClaw image."
+      result=1
+    fi
+    echo ""
+  done
+  return "$result"
 }
 
 clawdock-workspace() {
@@ -350,33 +323,27 @@ clawdock-fix-token() {
 
   echo "🔧 Configuring gateway token..."
   local token
-  token=$(clawdock-token)
-  if [[ -z "$token" ]]; then
+  if ! token=$(clawdock-token 2>/dev/null) || [[ -z "$token" ]]; then
     echo "❌ Error: Could not find gateway token"
     echo "   Check: ${CLAWDOCK_DIR}/.env"
     return 1
   fi
 
-  echo "📝 Setting token: ${token:0:20}..."
-
-  _clawdock_compose exec -e "TOKEN=$token" openclaw-gateway \
-    bash -c './openclaw.mjs config set gateway.remote.token "$TOKEN" && ./openclaw.mjs config set gateway.auth.token "$TOKEN"' 2>&1 | _clawdock_filter_warnings
-
-  echo "🔍 Verifying token was saved..."
-  local saved_token
-  saved_token=$(_clawdock_compose exec openclaw-gateway \
-    bash -c "./openclaw.mjs config get gateway.remote.token 2>/dev/null" 2>&1 | _clawdock_filter_warnings | tr -d '\r\n' | head -c 64)
-
-  if [[ "$saved_token" == "$token" ]]; then
-    echo "✅ Token saved correctly!"
-  else
-    echo "⚠️  Token mismatch detected"
-    echo "   Expected: ${token:0:20}..."
-    echo "   Got: ${saved_token:0:20}..."
+  # config set owns validation/persistence; config get intentionally redacts tokens.
+  # Check both writes without forwarding diagnostics that may contain credentials.
+  if ! _clawdock_compose exec -T -e "TOKEN=$token" openclaw-gateway \
+    bash -c './openclaw.mjs config set gateway.remote.token "$TOKEN" && ./openclaw.mjs config set gateway.auth.token "$TOKEN"' >/dev/null 2>&1; then
+    echo "❌ Token configuration failed. Check Docker and config permissions, then retry clawdock-fix-token."
+    return 1
   fi
 
+  echo "✅ Token configured!"
+
   echo "🔄 Restarting gateway..."
-  _clawdock_compose restart openclaw-gateway 2>&1 | _clawdock_filter_warnings
+  if ! _clawdock_compose restart openclaw-gateway >/dev/null 2>&1; then
+    echo "❌ Gateway restart failed. Check Docker, then try clawdock-restart."
+    return 1
+  fi
 
   echo "⏳ Waiting for gateway to start..."
   sleep 5

--- a/test/scripts/clawdock-helpers.test.ts
+++ b/test/scripts/clawdock-helpers.test.ts
@@ -1,6 +1,7 @@
 // Clawdock Helpers tests cover clawdock helpers script behavior.
 import { execFile, spawnSync } from "node:child_process";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -21,8 +22,297 @@ async function writeExecutable(file: string, content: string) {
   await writeFile(file, content, { mode: 0o755 });
 }
 
+async function withDiagnosticFixture(
+  shell: string,
+  run: (fixture: {
+    projectDir: string;
+    configDir: string;
+    binDir: string;
+    containerDir: string;
+    invoke: (command: string, mode?: string) => ReturnType<typeof spawnSync>;
+  }) => Promise<void>,
+) {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "openclaw-clawdock-diagnostics-"));
+  try {
+    const homeDir = path.join(tempDir, "home");
+    const projectDir = path.join(tempDir, "project");
+    const configDir = path.join(homeDir, ".openclaw");
+    const binDir = path.join(tempDir, "bin");
+    const containerDir = path.join(tempDir, "container");
+    for (const dir of [projectDir, configDir, binDir, containerDir]) {
+      await mkdir(dir, { recursive: true });
+    }
+    await writeFile(path.join(projectDir, "docker-compose.yml"), "services: {}\n");
+    await writeFile(
+      path.join(containerDir, "config.json"),
+      JSON.stringify({ gateway: { remote: { token: "synthetic-saved-mismatch" } } }),
+    );
+    await writeExecutable(path.join(binDir, "node"), "#!/bin/sh\nexit 127\n");
+    await mkdir(path.join(containerDir, "node_modules"));
+    for (const dependency of ["dotenv", "json5"]) {
+      await symlink(
+        path.dirname(createRequire(import.meta.url).resolve(`${dependency}/package.json`)),
+        path.join(containerDir, "node_modules", dependency),
+        "dir",
+      );
+    }
+    await writeExecutable(path.join(binDir, "sleep"), "#!/bin/sh\nexit 0\n");
+    await writeExecutable(
+      path.join(binDir, "docker"),
+      `#!/bin/bash
+[[ "$1" == compose && "$2" == -f ]] || exit 90
+shift 3
+if [[ "$1" == run ]]; then
+  [[ "$2" == --rm && "$3" == --no-deps && "$4" == -T && "$5" == --entrypoint && "$6" == node && "$7" == openclaw-gateway ]] || exit 95
+  shift 7
+  cd "$CLAWDOCK_TEST_CONTAINER" || exit 93
+  if [[ "$CLAWDOCK_TEST_MODE" == failed-renderer ]]; then
+    "${process.execPath}" "$@"
+    printf '%s\\n' "$CLAWDOCK_TEST_NOISE"
+    printf '%s\\n' "$CLAWDOCK_TEST_NOISE" >&2
+    exit 1
+  fi
+  exec "${process.execPath}" "$@"
+fi
+if [[ "$1" == restart ]]; then
+  printf '%s\\n' restart >> "$CLAWDOCK_TEST_CONTAINER/events"
+  printf '%s\\n' "$CLAWDOCK_TEST_NOISE"
+  printf '%s\\n' "$CLAWDOCK_TEST_NOISE" >&2
+  [[ "$CLAWDOCK_TEST_MODE" != restart-failure ]]
+  exit $?
+fi
+[[ "$1" == exec ]] || exit 91
+shift
+if [[ "$1" == -T ]]; then shift; fi
+if [[ "$1" == -e ]]; then export "$2"; shift 2; fi
+[[ "$1" == openclaw-gateway ]] || exit 92
+shift
+cd "$CLAWDOCK_TEST_CONTAINER" || exit 93
+if [[ "$1" == node ]]; then shift; exec "${process.execPath}" "$@"; fi
+exec "$@"
+`,
+    );
+    await writeExecutable(
+      path.join(containerDir, "openclaw.mjs"),
+      `#!${process.execPath}
+import fs from 'node:fs';
+const [, action, key, value] = process.argv.slice(2);
+const mode = process.env.CLAWDOCK_TEST_MODE;
+const file = process.env.CLAWDOCK_TEST_CONTAINER + '/config.json';
+const config = JSON.parse(fs.readFileSync(file, 'utf8'));
+fs.appendFileSync('events', JSON.stringify({ action, key, value }) + '\\n');
+console.error(process.env.CLAWDOCK_TEST_NOISE);
+if (action === 'set') {
+  console.error(config.gateway?.remote?.token);
+  console.log(value);
+  if (mode === 'write-failure-' + key) process.exit(1);
+  const owner = key.split('.')[1];
+  config.gateway ??= {};
+  config.gateway[owner] = { token: value };
+  fs.writeFileSync(file, JSON.stringify(config));
+} else if (action === 'get') {
+  console.log('__OPENCLAW_REDACTED__');
+} else process.exit(94);
+`,
+    );
+    await run({
+      projectDir,
+      configDir,
+      binDir,
+      containerDir,
+      invoke: (command, mode = "success") =>
+        spawnSync(shell, ["-f", "-c", `source scripts/clawdock/clawdock-helpers.sh\n${command}`], {
+          cwd: repoRoot,
+          encoding: "utf8",
+          env: {
+            HOME: homeDir,
+            PATH: `${binDir}:/usr/bin:/bin`,
+            CLAWDOCK_DIR: projectDir,
+            CLAWDOCK_TEST_CONTAINER: containerDir,
+            CLAWDOCK_TEST_MODE: mode,
+            CLAWDOCK_TEST_NOISE: "synthetic-backend-credential-do-not-display",
+          },
+        }),
+    });
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+}
+
 describe("scripts/clawdock/clawdock-helpers.sh", () => {
   for (const { available, shell } of shellCases) {
+    describe.runIf(available)(`safe diagnostics in ${shell}`, () => {
+      it.each([
+        { token: "~!", mode: "success" },
+        { token: "synthetic-token-".repeat(6), mode: "success" },
+        { token: "synthetic-$literal-'token", mode: "success" },
+        ...[
+          "write-failure-gateway.remote.token",
+          "write-failure-gateway.auth.token",
+          "restart-failure",
+        ].map((mode) => ({ token: "synthetic-provided-token-0123456789", mode })),
+      ])("repairs without disclosure: $mode ($token)", async ({ token, mode }) => {
+        await withDiagnosticFixture(shell, async ({ projectDir, containerDir, invoke }) => {
+          const envFile = path.join(projectDir, ".env");
+          const envContent = `OPENCLAW_GATEWAY_TOKEN="${token}"\n`;
+          await writeFile(envFile, envContent);
+          const result = invoke("clawdock-fix-token", mode);
+          const output = `${result.stdout}${result.stderr}`;
+          for (const secret of [
+            token,
+            token.slice(0, 20),
+            "synthetic-saved-mis",
+            "synthetic-backend",
+          ]) {
+            expect(output).not.toContain(secret);
+          }
+          expect(result.status).toBe(mode === "success" ? 0 : 1);
+          const events = await readFile(path.join(containerDir, "events"), "utf8");
+          expect(events).toContain(
+            JSON.stringify({ action: "set", key: "gateway.remote.token", value: token }),
+          );
+          if (mode !== "write-failure-gateway.remote.token") {
+            expect(events).toContain(
+              JSON.stringify({ action: "set", key: "gateway.auth.token", value: token }),
+            );
+          }
+          if (mode === "success") {
+            expect(output).toContain("Token configured");
+            expect(output).not.toContain("mismatch");
+            expect(output).toContain("Configuration complete");
+            expect(events).toContain("restart\n");
+            expect(
+              JSON.parse(await readFile(path.join(containerDir, "config.json"), "utf8")),
+            ).toEqual({
+              gateway: { remote: { token }, auth: { token } },
+            });
+          } else {
+            expect(output).not.toContain("Configuration complete");
+            expect(output).toMatch(/failed|mismatch/i);
+            expect(output).toMatch(/check|try/i);
+            if (mode !== "restart-failure") expect(events).not.toContain("restart\n");
+          }
+          const reveal = invoke("clawdock-token");
+          expect(reveal.status).toBe(0);
+          expect(reveal.stdout).toBe(token);
+          expect(reveal.stderr).toBe("");
+          await expect(readFile(envFile, "utf8")).resolves.toBe(envContent);
+        });
+      });
+
+      it("keeps config structure and env keys without values, comments or multiline fragments", async () => {
+        await withDiagnosticFixture(shell, async ({ configDir, projectDir, invoke }) => {
+          const configContent = `{
+  // synthetic-json-comment
+  gateway: {auth: {token: 'synthetic-json-token'}, remote: {password: '~!'},},
+  plugins: [{options: {arbitrary: 'synthetic-plugin-secret'},},],
+  env: {OPAQUE: ['synthetic-array-secret', 782931, true, null,],},
+  empty: {},
+}`;
+          const envContent = [
+            "# synthetic-comment-secret",
+            "API_KEY=synthetic-env-secret",
+            "EMPTY=",
+            'export EXPORTED = "synthetic-export-secret"',
+            'MULTILINE="synthetic-first-line',
+            "synthetic-second-line",
+            "SYNTHETIC_CONTINUATION=synthetic-third-line",
+            'synthetic-last-line"',
+            "SINGLE='synthetic-single-first",
+            "SYNTHETIC_SINGLE_CONTINUATION=synthetic-single-last'",
+            "AFTER=synthetic-after-secret",
+            "synthetic unknown content",
+            "CUSTOM.KEY=synthetic-custom-value",
+          ].join("\n");
+          const files = new Map([
+            [path.join(configDir, "openclaw.json"), configContent],
+            [path.join(configDir, ".env"), envContent],
+            [path.join(projectDir, ".env"), envContent],
+          ]);
+          for (const [file, content] of files) {
+            await writeFile(file, content);
+          }
+          const result = invoke("clawdock-show-config");
+          const output = `${result.stdout}${result.stderr}`;
+          expect(result.status).toBe(0);
+          expect(output).not.toMatch(/synthetic|SYNTHETIC|~!|782931/);
+          expect(output).toContain('"gateway"');
+          expect(output).toContain('"plugins": [');
+          expect(output).toContain('"arbitrary"');
+          for (const key of [
+            "API_KEY",
+            "EMPTY",
+            "EXPORTED",
+            "MULTILINE",
+            "SINGLE",
+            "AFTER",
+            "CUSTOM.KEY",
+          ]) {
+            expect(
+              output.match(new RegExp(`${key.replace(".", "\\.")}=<redacted>`, "g")),
+            ).toHaveLength(2);
+          }
+          expect(output).toContain("redacted");
+          expect(
+            JSON.parse(output.slice(output.indexOf("{"), output.lastIndexOf("}") + 1)),
+          ).toEqual({
+            gateway: { auth: { token: "<redacted>" }, remote: { password: "<redacted>" } },
+            plugins: [{ options: { arbitrary: "<redacted>" } }],
+            env: { OPAQUE: ["<redacted>", "<redacted>", "<redacted>", "<redacted>"] },
+            empty: {},
+          });
+          for (const [file, content] of files) {
+            await expect(readFile(file, "utf8")).resolves.toBe(content);
+          }
+        });
+      });
+
+      it.each([
+        "invalid-json",
+        "missing-json5",
+        "missing-dotenv",
+        "missing-docker",
+        "failed-renderer",
+      ])("fails closed for %s", async (mode) => {
+        await withDiagnosticFixture(shell, async ({ configDir, binDir, containerDir, invoke }) => {
+          const file = path.join(configDir, "openclaw.json");
+          const content =
+            mode === "invalid-json"
+              ? '{"token":"synthetic-parse-secret",'
+              : '{"token":"synthetic-parse-secret"}';
+          await writeFile(file, content);
+          await writeFile(path.join(configDir, ".env"), "API_KEY=synthetic-env-secret\n");
+          if (mode === "missing-json5" || mode === "missing-dotenv") {
+            await rm(path.join(containerDir, "node_modules", mode.slice("missing-".length)));
+          } else if (mode === "missing-docker") {
+            await writeExecutable(path.join(binDir, "docker"), "#!/bin/sh\nexit 127\n");
+          }
+          const result = invoke("clawdock-show-config", mode);
+          expect(result.status).toBe(1);
+          expect(`${result.stdout}${result.stderr}`).not.toContain("synthetic");
+          expect(result.stdout).toMatch(/unable|failed|unavailable/i);
+          expect(result.stdout).toMatch(/check|install/i);
+          await expect(readFile(file, "utf8")).resolves.toBe(content);
+        });
+      });
+
+      it.each(['"', "'", "`"])(
+        "withholds ambiguous unterminated env quoting: %s",
+        async (quote) => {
+          await withDiagnosticFixture(shell, async ({ configDir, invoke }) => {
+            const file = path.join(configDir, ".env");
+            const content = `TOKEN=${quote}synthetic-first-line\nSYNTHETIC_CONTINUATION=synthetic-tail\n`;
+            await writeFile(file, content);
+            const result = invoke("clawdock-show-config");
+            expect(result.status).toBe(1);
+            expect(`${result.stdout}${result.stderr}`).not.toMatch(/synthetic|SYNTHETIC/);
+            expect(result.stdout).toContain("Unable to safely display");
+            await expect(readFile(file, "utf8")).resolves.toBe(content);
+          });
+        },
+      );
+    });
+
     it.runIf(available)(
       `preserves caller state while auto-detecting the checkout in ${shell}`,
       async () => {


### PR DESCRIPTION
Closes #133535

## What Problem This Solves

Fixes an issue where operators running ClawDock token repair or config inspection would expose credential material in routine terminal output. `clawdock-fix-token` printed token prefixes, including a mismatched saved token, while `clawdock-show-config` printed `openclaw.json` verbatim despite advertising redacted values. The `.env` display also passed comments and multiline fragments through unchanged.

## Why This Change Was Made

Keep the disclosure boundary at the helper that owns the diagnostics. Config inspection parses JSON5 and dotenv with dependencies already shipped in the OpenClaw Docker image, preserves structure/key names, and replaces every scalar value with a fixed redaction marker. Failed renderer output is withheld rather than printed partially or passed through raw.

Token repair checks both canonical config setters and the restart result without echoing their potentially sensitive output. The old readback comparison is removed: `config get` deliberately returns redacted secrets, and a second raw-config reader would duplicate include/environment-resolution policy owned by the config implementation. Failures now return nonzero instead of continuing to a misleading completion message.

## User Impact

Routine ClawDock setup/repair/config output no longer reveals credential values or prefixes. The explicitly named `clawdock-token` command still prints the complete token on request. Docker port handling, Compose override ordering, and dashboard behavior are unchanged.

Config inspection requires Docker and the built OpenClaw image, but neither host-side Node/parsers nor a running gateway. Temporary renderer containers do not start dependencies. All values are hidden, including values under arbitrary plugin keys; comments are omitted. Ambiguous quote-leading dotenv values are conservatively withheld, with the limitation documented. Config and env file contents are not modified by inspection.

## Evidence

- Synthetic before/after Bash and Zsh probes reproduced credential disclosure in both automatic commands before the patch, suppressed it afterward, and confirmed exact full-token output remains available only through the explicit reveal command.
- `node scripts/run-vitest.mjs test/scripts/clawdock-helpers.test.ts`: 34 passing tests, including short/long/shell-literal tokens, both setter failures, restart failure, nested JSON5 objects/arrays, multiline dotenv, parser/Docker failures, and explicit reveal. Existing Compose override and dashboard-port tests remain green.
- `node scripts/check-changed.mjs -- scripts/clawdock/clawdock-helpers.sh test/scripts/clawdock-helpers.test.ts docs/install/clawdock.md scripts/clawdock/README.md`: passed.
- `bash -n scripts/clawdock/clawdock-helpers.sh`, `zsh -n scripts/clawdock/clawdock-helpers.sh`, formatting, and `git diff --check`: passed.
- Independent Codex prelanding autoreview on the unchanged frozen patch: scoped-clean at the configured P0 threshold, no findings.
- Real Docker proof on `blacksmith-testbox`, lease `tbx_01m1a78w22pebcs9k4dhswpjef`, [Testbox workflow](https://github.com/openclaw/openclaw/actions/runs/33334968996): official OpenClaw 2026.7.1 image pinned to `ghcr.io/openclaw/openclaw@sha256:2f5ce8848a1a69b3c460622e566cb9395da9fd18d7ef7b038cd8e2c4f195decf`, Docker 28.0.4, Compose 2.38.2. Actual helper functions and installed CLI ran with synthetic temporary state, a nonroot gateway, networking disabled, no published ports, and only the proof-owned bind mount. Thirty assertions passed across the initial and focused runs: before/after disclosure, JSON5/dotenv rendering, exact explicit reveal, both persisted token fields, successful restart/health recovery, real write denial, real Compose parser failure, and missing-token handling. Fixture containers/networks/volumes/state were removed and the lease was independently verified completed.
- Proof correction: an initial invalid-image interpolation fixture failed Compose `config`/`run` but did not fail `exec`/`restart`, so its expected-failure assertion was invalid. A focused rerun verified an actual Compose `exec` parser failure first and passed all six assertions. No product changes resulted. Restart failure after two successful writes is covered by the shell regression suite, not fault-injected in the real Docker run.

Production LOC: +45/-78 (net -33). Tests/test support: +291/-1 (net +290). Documentation: +8/-5. No new dependencies, config options, storage, or protocol changes.

The disclosure is present in stable `v2026.7.1` source. No specific introducing commit or author is claimed. No operator state or real credentials were used in reproduction or regression tests.

Source identity: the final candidate is `42183e31ffee76b9e232793bdfd2e9c96a3259af`, rebased once without changing any of the four reviewed files. Docker proof compared the original helper at `94259f243740d1d37530180e580210a907123661` (SHA-256 `14ad11125fff8645ea438bb38c69588596d95935264ab37109ba1211e7ef8671`) with the candidate helper (SHA-256 `7d718c26fb04a32dbb66e431c67f28a63a4e0ce0bb7e04b6280e4b56280f44f3`).

Final candidate verification repeated all 34 Bash/Zsh tests and the full changed-file gate (`node scripts/check-changed.mjs --timed -- scripts/clawdock/clawdock-helpers.sh test/scripts/clawdock-helpers.test.ts docs/install/clawdock.md scripts/clawdock/README.md`), all passing. The gate emitted a nonblocking temp-directory migration suggestion; the fixture already cleans up in `finally`.

Final CI: [run 33335688305](https://github.com/openclaw/openclaw/actions/runs/33335688305) completed successfully on `42183e31ffee76b9e232793bdfd2e9c96a3259af`; the exact-head watcher exited 0 with `GREEN`. ClawSweeper reported no actionable findings. Its documented Docker-image prerequisite is accepted as part of the approved result; diagnostics intentionally withhold file contents if the image/parser is unavailable.
