### PR TITLE
refactor(ui): avoid redundant presence work in avatar lists

### DIFF
--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -229,8 +229,6 @@ export function renderRecentSession(params: {
       leadingOwner,
       ownerAttribution,
       ownerViewing,
-      session.participants,
-      session.participantCount,
       channelAvatarAuth,
     );
   const trailingDescription = session.isChild

--- a/ui/src/components/session-leading-indicator.ts
+++ b/ui/src/components/session-leading-indicator.ts
@@ -1,8 +1,5 @@
 import { html, nothing, type TemplateResult } from "lit";
-import type {
-  SessionParticipant,
-  SessionParticipantIdentity,
-} from "../../../packages/gateway-protocol/src/schema/session-participant.js";
+import type { SessionParticipantIdentity } from "../../../packages/gateway-protocol/src/schema/session-participant.js";
 import { t } from "../i18n/index.ts";
 import type { SidebarRecentSession } from "./app-sidebar-session-types.ts";
 import {
@@ -53,8 +50,6 @@ export function renderSessionLeadingState(
   ownerActor: SessionCreatedActor | null | undefined,
   attribution: "created" | "owned" | "archived",
   ownerViewing?: boolean,
-  participants?: readonly SessionParticipant[],
-  participantCount?: number,
   avatarAuth?: SessionAvatarAuth,
 ): {
   running: boolean;
@@ -62,6 +57,7 @@ export function renderSessionLeadingState(
   trailingIndicator: TemplateResult | typeof nothing;
   renderedIdentities?: readonly SessionParticipantIdentity[];
 } {
+  const { participants, participantCount } = session;
   const running = sessionHasRunningWork(session);
   const trailingIndicator = session.isChild ? nothing : renderSessionState(session, false);
   // Transient attention always outranks the persistent decorative icon.
@@ -132,17 +128,16 @@ export function renderSessionLeadingState(
       trailingIndicator,
     };
   }
-  const ownerChip =
-    !session.isChild && ownerActor?.id?.trim()
-      ? renderSessionOwnerChip(
-          ownerActor,
-          "row",
-          attribution,
-          ownerViewing,
-          participants,
-          participantCount,
-        )
-      : undefined;
+  const ownerChip = ownerActor?.id?.trim()
+    ? renderSessionOwnerChip(
+        ownerActor,
+        "row",
+        attribution,
+        ownerViewing,
+        participants,
+        participantCount,
+      )
+    : undefined;
   if (session.channelAvatarUrl) {
     ensureChannelAvatarElement();
     return {

--- a/ui/src/components/session-owner-chip.test.ts
+++ b/ui/src/components/session-owner-chip.test.ts
@@ -3,16 +3,7 @@
 import { afterEach, expect, it, vi } from "vitest";
 import type { SessionParticipant } from "../../../packages/gateway-protocol/src/schema/session-participant.js";
 import { setAvatarGatewayOrigin } from "../lib/identity-avatar-context.ts";
-import { listAssignableSessionOwners, type SessionCreatedActor } from "./session-owner-chip.ts";
-
-type OwnerChipElement = HTMLElement & {
-  owner: SessionCreatedActor | null;
-  participants: readonly SessionParticipant[];
-  participantCount: number;
-  attribution: "created" | "owned" | "archived";
-  size: "row" | "header";
-  updateComplete: Promise<boolean>;
-};
+import { listAssignableSessionOwners } from "./session-owner-chip.ts";
 
 afterEach(() => {
   document.body.replaceChildren();
@@ -20,7 +11,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-async function waitForChipUpdate(chip: OwnerChipElement) {
+async function waitForChipUpdate(chip: HTMLElementTagNameMap["openclaw-session-owner-chip"]) {
   await chip.updateComplete;
   // The parent's update does not include the nested avatar's render.
   await Promise.all(
@@ -29,8 +20,7 @@ async function waitForChipUpdate(chip: OwnerChipElement) {
 }
 
 async function mount(params: { participants?: SessionParticipant[]; participantCount?: number }) {
-  // SAFETY: the imported module registers this custom element with these reactive properties.
-  const chip = document.createElement("openclaw-session-owner-chip") as OwnerChipElement;
+  const chip = document.createElement("openclaw-session-owner-chip");
   chip.owner = { type: "human", id: "profile-ada", label: "Ada" };
   chip.attribution = "owned";
   chip.size = "row";

--- a/ui/src/components/session-owner-chip.ts
+++ b/ui/src/components/session-owner-chip.ts
@@ -175,17 +175,7 @@ class SessionOwnerChip extends OpenClawLightDomElement {
     return html`<span class="session-owner-stack" role="group" aria-label=${combinedLabel}>
       <span class="session-owner-stack__back" aria-hidden="true">
         ${this.participantCount === 1 && participant
-          ? html`<openclaw-viewer-avatar
-              .user=${{
-                id: participant.identity.id,
-                name: participant.label,
-                avatarUrl: participant.avatarUrl,
-                watchedSessions: [],
-              }}
-              .markAsViewer=${false}
-              .identity=${participant.identity}
-              variant="session"
-            ></openclaw-viewer-avatar>`
+          ? renderSessionOwnerAvatar({ ...participant, id: participant.identity.id })
           : html`<span class="session-owner-stack__overflow">+${this.participantCount}</span>`}
       </span>
       ${chip}

--- a/ui/src/components/viewer-facepile.test.ts
+++ b/ui/src/components/viewer-facepile.test.ts
@@ -8,15 +8,11 @@ import {
   hasMultiplePresenceIdentities,
   hasSessionPresenceViewers,
   projectOnlinePresenceViewers,
+  projectPresencePayload,
   type PresenceViewer,
 } from "../lib/presence-users.ts";
 import { renderChatAuthorAvatar } from "../pages/chat/components/chat-author-avatar.ts";
 import "./viewer-facepile.ts";
-
-type ViewerAvatarElement = HTMLElement & {
-  user: PresenceViewer | null;
-  updateComplete: Promise<boolean>;
-};
 
 afterEach(() => {
   document.body.replaceChildren();
@@ -31,7 +27,7 @@ it("uses the same user initials and identity hue in the roster and attributed ch
     email: "riley@example.test",
     watchedSessions: [],
   };
-  const viewerAvatar = document.createElement("openclaw-viewer-avatar") as ViewerAvatarElement;
+  const viewerAvatar = document.createElement("openclaw-viewer-avatar");
   viewerAvatar.user = user;
   document.body.append(viewerAvatar);
 
@@ -60,7 +56,7 @@ it("uses the same user initials and identity hue in the roster and attributed ch
 });
 
 it("uses the shared resolver and rejects cross-origin presence avatar metadata", async () => {
-  const avatar = document.createElement("openclaw-viewer-avatar") as ViewerAvatarElement;
+  const avatar = document.createElement("openclaw-viewer-avatar");
   avatar.user = {
     id: "profile-mallory",
     name: "Mallory",
@@ -77,7 +73,7 @@ it("uses the shared resolver and rejects cross-origin presence avatar metadata",
 });
 
 it("renders trusted presence avatar routes directly", async () => {
-  const avatar = document.createElement("openclaw-viewer-avatar") as ViewerAvatarElement;
+  const avatar = document.createElement("openclaw-viewer-avatar");
   avatar.user = {
     id: "profile-ada",
     name: "Ada Lovelace",
@@ -185,7 +181,7 @@ it("shares an authenticated avatar blob between the same user in the roster and 
     watchedSessions: [],
   };
   const avatars = Array.from({ length: 2 }, () => {
-    const avatar = document.createElement("openclaw-viewer-avatar") as ViewerAvatarElement;
+    const avatar = document.createElement("openclaw-viewer-avatar");
     avatar.user = user;
     document.body.append(avatar);
     return avatar;
@@ -210,12 +206,25 @@ it("shares an authenticated avatar blob between the same user in the roster and 
   }
 });
 
-type ViewerFacepileElement = HTMLElementTagNameMap["openclaw-viewer-facepile"];
+it.each(["staticParticipants", "staticUsers"] as const)(
+  "renders an empty %s list without invalidating cached live presence",
+  async (source) => {
+    const payload = { presence: [{ user: { id: "live-viewer" } }] };
+    const projection = projectPresencePayload(payload);
+    const facepile = document.createElement("openclaw-viewer-facepile");
+    facepile[source] = [];
+    document.body.append(facepile);
+    await facepile.updateComplete;
+
+    expect(facepile.querySelector(".viewer-facepile")).toBeNull();
+    expect(projectPresencePayload(payload)).toBe(projection);
+  },
+);
 
 it.each(["first", "second"])(
   "merges device presence into one non-interactive face watching %s",
   async (session) => {
-    const facepile = document.createElement("openclaw-viewer-facepile") as ViewerFacepileElement;
+    const facepile = document.createElement("openclaw-viewer-facepile");
     facepile.sessionKey = `agent:main:${session}`;
     facepile.presencePayload = {
       presence: [
@@ -243,8 +252,7 @@ it.each(["first", "second"])(
 );
 
 it("renders ordered static participant actors without presence filtering", async () => {
-  // SAFETY: the registered custom element exposes the tested reactive properties.
-  const facepile = document.createElement("openclaw-viewer-facepile") as ViewerFacepileElement;
+  const facepile = document.createElement("openclaw-viewer-facepile");
   facepile.maxVisible = 2;
   facepile.staticParticipants = [
     { identity: { type: "profile", id: "profile-ada" }, label: "Ada" },
@@ -265,7 +273,7 @@ it("renders ordered static participant actors without presence filtering", async
 });
 
 it("excludes displayed owners and participants before choosing visible avatars and overflow", async () => {
-  const facepile = document.createElement("openclaw-viewer-facepile") as ViewerFacepileElement;
+  const facepile = document.createElement("openclaw-viewer-facepile");
   facepile.sessionKey = "agent:main:active";
   facepile.excludeIdentities = [
     { type: "profile", id: "owner" },
@@ -352,7 +360,7 @@ it.each([
     ],
   },
 ])("excludes authenticated self from session facepiles when $name", async (fixture) => {
-  const facepile = document.createElement("openclaw-viewer-facepile") as ViewerFacepileElement;
+  const facepile = document.createElement("openclaw-viewer-facepile");
   facepile.selfUser = { id: "self" };
   facepile.selfInstanceId = fixture.selfInstanceId;
   facepile.sessionKey = "agent:main:active";
@@ -395,11 +403,7 @@ it("links faces only when the host opts in, so nested facepiles stay plain", asy
     { identity: { type: "profile", id: "profile-mira" }, label: "Mira" },
   ];
   const mount = async (personActivity?: { basePath: string; navigate: (id: string) => void }) => {
-    const facepile = document.createElement("openclaw-viewer-facepile") as HTMLElement & {
-      staticParticipants: readonly SessionParticipant[];
-      personActivity?: { basePath: string; navigate: (id: string) => void };
-      updateComplete: Promise<boolean>;
-    };
+    const facepile = document.createElement("openclaw-viewer-facepile");
     facepile.staticParticipants = users;
     if (personActivity) {
       facepile.personActivity = personActivity;

--- a/ui/src/components/viewer-facepile.ts
+++ b/ui/src/components/viewer-facepile.ts
@@ -88,13 +88,7 @@ class ViewerFacepile extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) personActivity?: PersonActivityRouting;
 
   override render() {
-    const viewers = projectPresenceViewers(
-      this.presencePayload,
-      this.selfUser,
-      this.selfInstanceId,
-      this.sessionKey,
-      this.excludeIdentities,
-    );
+    // Prepared faces must not evict the cached live projection used by sibling rows.
     const users = this.staticParticipants
       ? this.staticParticipants.map(({ identity, label, avatarUrl }) => ({
           identity,
@@ -103,7 +97,14 @@ class ViewerFacepile extends OpenClawLightDomContentsElement {
           avatarUrl,
           watchedSessions: [],
         }))
-      : (this.staticUsers ?? viewers);
+      : (this.staticUsers ??
+        projectPresenceViewers(
+          this.presencePayload,
+          this.selfUser,
+          this.selfInstanceId,
+          this.sessionKey,
+          this.excludeIdentities,
+        ));
     if (users.length === 0) {
       return nothing;
     }


### PR DESCRIPTION
Related: #133519

## What Problem This Solves

Prepared participant and online-avatar lists unnecessarily recompute live presence whenever they render. Because presence keeps a single cached payload, these unused computations also evict the projection reused by neighboring sidebar rows.

## Why This Change Was Made

Resolve live presence only when the facepile actually needs it. Reuse the existing participant-avatar renderer and read participant data directly from the session, removing duplicate markup and redundant arguments. Tests now use the registered custom-element types rather than mirrored interfaces and casts.

This keeps the deduplication from #133519 at its existing identity and presentation boundaries. Production code is **+22/-38 (net -16)**; tests are **+27/-33 (net -6)**, including two new cache-reuse regressions.

## User Impact

Owner and participant faces still appear once in chat and dashboard headers. Prepared avatar lists stop rebuilding and discarding live-presence state. No configuration, persistence, protocol, or visual-design changes.

## Evidence

- Both new regressions failed before the fix: rendering an empty prepared participant or user list replaced the cached live projection. Both pass after it.
- Focused facepile, owner-chip, sidebar, and presence suites: **357 tests passed**.
- Chromium on Blacksmith Testbox: chat and dashboard deduplication plus presence clearing **2/2 passed**. [Proof run](https://github.com/openclaw/openclaw/actions/runs/33335371666); the leased runner was stopped after collecting artifacts.
- Before/after screenshots use synthetic identities and show unchanged header presentation. “Before” is the already-deduplicated state from #133519; “after” is this refactor.
- Authenticated production verification was unavailable through the browser relay. The browser proof exercises the application with a deterministic Gateway fixture; it is not a production deployment claim.

### Review follow-ups

Two source-derived, pre-existing edge cases were identified during the broader review and remain outside this cache/rendering cleanup. They are not reproduced regressions of this patch:

- **Archive attribution versus participant projection:** an archive row displays `archivedBy`, while the Gateway participant preview excludes the session owner. Investigate a participant archiving another person's session; repair attribution/count ownership together rather than decrementing a truncated preview in the UI.
- **Channel-avatar fallback versus live viewers:** the channel-image component can display an owner-chip fallback before a usable image loads, while the parent row reports no displayed identities for that branch. Investigate loading, missing-auth, 404, decode-error, and successful-image transitions; any repair must track the actual displayed identity through that lifecycle so viewers reappear when the channel image takes over.

![Before refactor: deduplicated chat header](https://github.com/user-attachments/assets/303f890a-2257-45e4-a56a-1e7ac5910eb4)

![After refactor: unchanged deduplicated chat header](https://github.com/user-attachments/assets/5e989cfd-91e5-4dd8-8945-0c1a5efbc668)

![After refactor: deduplicated dashboard header](https://github.com/user-attachments/assets/53de7c59-2b66-4b24-9017-a89cb1e2d108)