### PR TITLE
fix(package): publish readable dist inventory

### DIFF
--- a/scripts/lib/package-dist-inventory.ts
+++ b/scripts/lib/package-dist-inventory.ts
@@ -130,7 +130,7 @@ async function writePackageDistInventoryFile(
     entries.filter((relativePath) => relativePath !== PACKAGE_INSTALL_GUARD_RELATIVE_PATH),
   );
   const inventoryPath = path.join(packageRoot, PACKAGE_DIST_INVENTORY_RELATIVE_PATH);
-  await writeJson(inventoryPath, inventory, { trailingNewline: true });
+  await writeJson(inventoryPath, inventory, { mode: 0o644, trailingNewline: true });
   return inventory;
 }
 

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -550,6 +550,11 @@ describe("bundled plugin postinstall", () => {
     await fs.writeFile(currentFile, "export {};\n");
     await fs.writeFile(currentManifest, "{}\n");
     await writePackageDistInventory(packageRoot);
+    if (process.platform !== "win32") {
+      expect(
+        (await fs.stat(path.join(packageRoot, "dist", "postinstall-inventory.json"))).mode & 0o777,
+      ).toBe(0o644);
+    }
     await fs.writeFile(stalePackage, "{}\n");
     await fs.writeFile(staleManifest, "{}\n");
 


### PR DESCRIPTION
## Summary

Forward-ports the explicit public mode for `dist/postinstall-inventory.json` to the current package-inventory writer. This is the same producer-boundary contract fixed for the extended-stable candidate in #133500: package consumers must be able to read the packaged inventory, while unrelated JSON writes retain fs-safe's private default.

## Proof

- `node scripts/run-vitest.mjs test/scripts/postinstall-bundled-plugins.test.ts` — 29 passed.
- `git diff --check` — passed.
- Focused oxlint was attempted but its prerequisite `prepare-extension-package-boundary-artifacts` fails on unrelated current-main plugin-SDK declaration diagnostics before lint starts; no diagnostic references this change.

## Scope

Production: +1/-1. Test: +5/-0. The POSIX mode assertion is skipped on Windows, where POSIX permission bits are not portable.
