### PR TITLE
test: guard multi-project Vitest cache ownership

### DIFF
--- a/test/vitest-performance-config.test.ts
+++ b/test/vitest-performance-config.test.ts
@@ -106,6 +106,34 @@ describe("loadVitestExperimentalConfig", () => {
 
 describe("filesystem module cache ownership", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+  const cli = path.join(
+    path.dirname(createRequire(import.meta.url).resolve("vitest/package.json")),
+    "vitest.mjs",
+  );
+  const run = (
+    root: string,
+    checkout: string,
+    args: string[] = [],
+    env: NodeJS.ProcessEnv = {},
+  ) => {
+    const result = spawnSync(
+      process.execPath,
+      [cli, "run", "--config", path.join(checkout, "vitest.config.mjs"), ...args],
+      {
+        cwd: checkout,
+        encoding: "utf8",
+        env: {
+          PATH: process.env.PATH,
+          SystemRoot: process.env.SystemRoot,
+          CI: "1",
+          HOME: root,
+          ...env,
+        },
+        timeout: 15_000,
+      },
+    );
+    expect(result.status, `${result.error ?? ""}\n${result.stdout}\n${result.stderr}`).toBe(0);
+  };
 
   it("preserves another checkout's cache when shared dependencies change", () => {
     const root = tempDirs.make("oc-vitest-cache-ownership-");
@@ -113,10 +141,6 @@ describe("filesystem module cache ownership", () => {
     fs.mkdirSync(path.join(sharedModules, ".pnpm"), { recursive: true });
     const lockfile = path.join(sharedModules, ".pnpm", "lock.yaml");
     fs.writeFileSync(lockfile, "lockfileVersion: 1\n");
-    const cli = path.join(
-      path.dirname(createRequire(import.meta.url).resolve("vitest/package.json")),
-      "vitest.mjs",
-    );
     const prepareCheckout = (name: string) => {
       const checkout = path.join(root, name);
       fs.mkdirSync(checkout);
@@ -147,29 +171,137 @@ describe("filesystem module cache ownership", () => {
       );
       return { checkout, cacheConfig };
     };
-    const run = (checkout: string) => {
-      const result = spawnSync(
-        process.execPath,
-        [cli, "run", "--config", path.join(checkout, "vitest.config.mjs")],
-        {
-          cwd: checkout,
-          encoding: "utf8",
-          env: { PATH: process.env.PATH, SystemRoot: process.env.SystemRoot, CI: "1", HOME: root },
-          timeout: 15_000,
-        },
-      );
-      expect(result.status, `${result.error ?? ""}\n${result.stdout}\n${result.stderr}`).toBe(0);
-    };
     const first = prepareCheckout("first");
     const second = prepareCheckout("second");
-    run(first.checkout);
+    run(root, first.checkout);
     const firstCache =
       first.cacheConfig.experimental?.fsModuleCachePath ??
       path.join(sharedModules, ".experimental-vitest-cache");
     const sentinel = path.join(firstCache, "first-checkout-sentinel");
     fs.writeFileSync(sentinel, "owned by first checkout");
     fs.writeFileSync(lockfile, "lockfileVersion: 2\n");
-    run(second.checkout);
+    run(root, second.checkout);
     expect(fs.readFileSync(sentinel, "utf8")).toBe("owned by first checkout");
+  });
+
+  it("reuses shared project transforms after a lock transition without serving a stale later project", () => {
+    const root = fs.realpathSync(tempDirs.make("oc-vitest-cache-projects-"));
+    fs.mkdirSync(path.join(root, "node_modules"));
+    fs.writeFileSync(
+      path.join(root, "package.json"),
+      JSON.stringify({ name: "cache-projects", type: "module", workspaces: [] }),
+    );
+    const generation = path.join(root, "dependency-generation.txt");
+    const transitionLock = (version: string) => {
+      // bun.lock is only a recognized hash input; no package manager is invoked.
+      fs.writeFileSync(path.join(root, "bun.lock"), JSON.stringify({ version }));
+      fs.writeFileSync(generation, version);
+    };
+    transitionLock("1.0.0");
+    for (const name of ["A", "B"]) {
+      const project = path.join(root, name);
+      fs.mkdirSync(project);
+      fs.writeFileSync(path.join(project, "transforms.txt"), "");
+      fs.writeFileSync(
+        path.join(project, "subject.js"),
+        'export const version = "__DEPENDENCY_VERSION__";\n',
+      );
+      fs.copyFileSync(
+        path.join(project, "subject.js"),
+        path.join(project, "configured-subject.js"),
+      );
+      fs.writeFileSync(
+        path.join(project, "fixture.test.js"),
+        `import { readFileSync } from "node:fs";
+import { version } from "fixture-subject";
+test("executes the current dependency generation", () => {
+  expect(version).toBe(readFileSync(${JSON.stringify(generation)}, "utf8"));
+});
+`,
+      );
+    }
+    const shardOwner = new URL("./vitest/vitest.project-shard-config.ts", import.meta.url).href;
+    const scopedOwner = new URL("./vitest/vitest.scoped-config.ts", import.meta.url).href;
+    const configFile = path.join(root, "vitest.config.mjs");
+    fs.writeFileSync(
+      configFile,
+      `import { appendFileSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { createProjectShardVitestConfig } from ${JSON.stringify(shardOwner)};
+import { createScopedVitestConfig } from ${JSON.stringify(scopedOwner)};
+const root = ${JSON.stringify(root)};
+const aggregate = createProjectShardVitestConfig([]);
+const scoped = createScopedVitestConfig([], { env: {}, argv: [] });
+const subjectFile = "subject.js";
+export default {
+  root,
+  test: {
+    experimental: aggregate.test.experimental,
+    projects: ["A", "B"].map((name) => ({
+      extends: false,
+      root: path.join(root, name),
+      resolve: { alias: { "fixture-subject": path.join(root, name, subjectFile) } },
+      plugins: [{
+        name: "fixture-external-plugin",
+        transform(code, id) {
+          if (id !== path.join(root, name, subjectFile).replaceAll("\\\\", "/")) return;
+          // External plugin generations are outside the config/source graph;
+          // the paired lock change must invalidate their old transform output.
+          const version = readFileSync(${JSON.stringify(generation)}, "utf8");
+          appendFileSync(path.join(root, name, "transforms.txt"), version + "\\n");
+          return { code: code.replace("__DEPENDENCY_VERSION__", version), map: null };
+        },
+      }],
+      test: {
+        name,
+        globals: true,
+        include: ["fixture.test.js"],
+        experimental: scoped.test.experimental,
+      },
+    })),
+  },
+};
+`,
+    );
+    const cacheConfig = loadVitestExperimentalConfig({}, "linux", root);
+    const env = {
+      OPENCLAW_VITEST_FS_MODULE_CACHE: "1",
+      OPENCLAW_VITEST_FS_MODULE_CACHE_PATH: cacheConfig.experimental?.fsModuleCachePath,
+    };
+    const check = (projects: string[], expected: [number, number]) => {
+      run(
+        root,
+        root,
+        projects.flatMap((name) => ["--project", name]),
+        env,
+      );
+      const counts = ["A", "B"].map(
+        (name) =>
+          fs.readFileSync(path.join(root, name, "transforms.txt"), "utf8").split("\n").length - 1,
+      );
+      expect(counts, `subject transforms after selecting ${projects.join("+")}`).toEqual(expected);
+    };
+    check(["A", "B"], [1, 1]);
+    check(["A", "B"], [1, 1]);
+    transitionLock("2.0.0");
+    check(["A"], [2, 1]);
+    check(["A"], [2, 1]);
+    check(["B"], [2, 2]);
+    check(["B"], [2, 2]);
+
+    // Reuse must still respect ordinary source and config invalidation.
+    fs.appendFileSync(path.join(root, "A", "subject.js"), "\n// source edit\n");
+    check(["A", "B"], [3, 2]);
+    fs.writeFileSync(
+      configFile,
+      fs
+        .readFileSync(configFile, "utf8")
+        .replace(
+          'const subjectFile = "subject.js";',
+          'const subjectFile = "configured-subject.js";',
+        ),
+    );
+    check(["A", "B"], [4, 3]);
+    check(["A", "B"], [4, 3]);
   });
 });


### PR DESCRIPTION
Related: [checkout-owned Vitest cache isolation (#132867)](https://github.com/openclaw/openclaw/pull/132867).

<details>
<summary>Additional instructions</summary>

This is a same-repository, maintainer-editable branch.

</details>

## What Problem This Solves

Adds maintainer-requested behavioral regression coverage for the existing shared-leaf Vitest cache workaround. Vitest 4.1.11 can repeatedly discard project transforms when invocation metadata lives elsewhere; merely making a global marker current can instead leave an unselected project's transforms stale.

Current OpenClaw configuration already co-locates root metadata and project transforms. The existing tests protect checkout isolation and configuration shape, but do not prove reuse and later-project freshness across a lockfile transition.

## Why This Change Was Made

Exercise the actual `createProjectShardVitestConfig` and `createScopedVitestConfig` cache settings through real Vitest CLI children in one temporary namespace. Warm two projects, change a fixture-owned lockfile and synthetic external-plugin generation, run A twice, then B twice. Assert actual transform counts and independently check the executed dependency-generation export. Continue with a source edit and a project-alias change to ensure ordinary invalidation still works.

The existing child launcher is shared by both ownership tests. Its 15-second child deadline is unchanged. No dependency, production cache policy, heap, retry, pool, isolation, or worker-budget change; no metadata rewrite or custom cache-key override. This does not implement the separate compiled-worker campaign or repair Vitest's generic separated-root contract.

## User Impact

No operator/runtime behavior changes. Developers gain a guard against accidentally separating cache validity from transforms or allowing stale transforms in a later-selected project.

Production LOC: **+0/-0**. Test LOC: **+151/-19** (net +132), one test file.

## Evidence

- Negative control: temporarily omit only the generated root cache settings, retaining project settings. The new test fails on repeated A with actual cumulative transforms `[3, 1]` versus expected `[2, 1]`. The mutation was removed. This is an intentional negative control, not a claim that current main is broken.
- Positive proof: **131 tests passed** across the performance, project-composition, and scoped-config files. Independently repeated on Node 24.20.0 after the authoring run on Node 26.8.1; final owner-file authoring rerun also passed **10/10**.
- New case: nine joined Vitest children and fourteen executed version assertions. Counts: seed/warm `[1,1]`; lock transition/A repeat `[2,1]`; later B/B repeat `[2,2]`; A source edit `[3,2]`; alias edit/repeat `[4,3]`.
- Formatting and `git diff --check` passed. Source-only scripts lint exited 0. Fresh Codex autoreview returned scoped-clean at its default P0 threshold; parent manual review also completed.

Focused command (the outer cache is proof-owned; the inner test has its own independent temporary cache):

```bash
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH="$PWD/.artifacts/vitest-cache-regression-pr/outer-cache-parent" node scripts/run-vitest.mjs test/vitest-performance-config.test.ts test/vitest-projects-config.test.ts test/vitest-scoped-config.test.ts --reporter=verbose
```

```bash
node_modules/.bin/oxfmt --check test/vitest-performance-config.test.ts
```

```bash
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts
```

Local validation gap: after fast-forwarding this checkout, installed grammy remains 1.45.1 while main pins 1.46.0. Root-test typechecking reports eight existing Telegram type errors (`RichMessageButton` and newer update/message variants), none in the changed file. Dependencies were deliberately left untouched. Exact-head CI with the pinned install must pass typechecking and all required gates before merge. An initial lint invocation using the root tsconfig hit the same declaration-preparation failure; the correct source-only scripts lane subsequently exited 0.
