### PR TITLE
fix(ui): keep branch and editor tooltips beside their buttons

### DIFF
--- a/ui/src/pages/chat/components/chat-pane-header.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.browser.test.ts
@@ -1,0 +1,95 @@
+import type WaTooltip from "@awesome.me/webawesome/dist/components/tooltip/tooltip.js";
+import { render } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installTitleTooltips } from "../../../components/tooltip-title.ts";
+import { i18n } from "../../../i18n/index.ts";
+import "../../../styles.css";
+import "../../../styles/chat/split-view.css";
+import { mountChatPaneHeader } from "./chat-pane-header.test-support.ts";
+import { renderChatSidebarEditorMenu } from "./chat-sidebar-editor-menu.ts";
+
+describe.skipIf(typeof HTMLElement.prototype.checkVisibility !== "function")(
+  "chat pane branch tooltip positioning",
+  () => {
+    const containers: HTMLElement[] = [];
+    let dispose: () => void;
+    let page: (typeof import("vitest/browser"))["page"];
+
+    beforeEach(async () => {
+      ({ page } = await import("vitest/browser"));
+      await page.viewport(1200, 800);
+      await i18n.setLocale("en");
+      dispose = installTitleTooltips(document);
+    });
+
+    afterEach(() => {
+      dispose();
+      containers.splice(0).forEach((container) => container.remove());
+    });
+
+    it.each(["idle", "busy", "editor"] as const)(
+      "anchors the %s hint to its menu button",
+      async (state) => {
+        const busy = state === "busy";
+        const editor = state === "editor";
+        const onOpenEditor = vi.fn();
+        const reason = "Branch switch is unavailable while the agent is working.";
+        const { container, props } = mountChatPaneHeader(containers, {
+          branchSwitchDisabledReason: busy ? reason : null,
+          branches: [
+            { leafEntryId: "active", headline: "Current work", messageCount: 4, active: true },
+            { leafEntryId: "other", headline: "Earlier idea", messageCount: 2, active: false },
+          ],
+        });
+        if (editor) {
+          render(
+            renderChatSidebarEditorMenu({
+              absolutePath: "/repo/example.ts",
+              open: false,
+              onOpenChange: () => undefined,
+              onOpenEditor,
+            }),
+            container,
+          );
+        }
+        container.style.cssText = "position: fixed; top: 80px; left: 500px; width: 650px";
+        const trigger = container.querySelector<HTMLButtonElement>(
+          editor ? ".sidebar-file-view__action" : ".chat-pane__branches-trigger",
+        )!;
+        await page.elementLocator(trigger).hover();
+        const tooltip = () =>
+          [...document.querySelectorAll("openclaw-tooltip")]
+            .map((element) => element.shadowRoot?.querySelector<WaTooltip>("wa-tooltip"))
+            .find((element) => element?.open);
+        await expect
+          .poll(() => tooltip()?.textContent)
+          .toContain(editor ? "Open in editor" : busy ? reason : "Session branches");
+        await expect
+          .poll(() => {
+            const body = tooltip()?.shadowRoot?.querySelector<HTMLElement>('[part="body"]');
+            if (!body) {
+              return false;
+            }
+            const hint = body.getBoundingClientRect();
+            const button = trigger.getBoundingClientRect();
+            return (
+              hint.width > 0 &&
+              hint.left < button.right &&
+              hint.right > button.left &&
+              Math.min(Math.abs(hint.bottom - button.top), Math.abs(hint.top - button.bottom)) < 24
+            );
+          })
+          .toBe(true);
+
+        if (!busy) {
+          await page.elementLocator(trigger).click();
+          await expect.poll(() => tooltip()).toBeUndefined();
+          await page.getByRole("menuitem", { name: editor ? "VS Code" : /Earlier idea/ }).click();
+          expect(editor ? onOpenEditor : props.onBranchSelect).toHaveBeenCalledWith(
+            editor ? "vscode" : "other",
+          );
+        }
+      },
+    );
+  },
+);

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -488,70 +488,62 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
       ${props.sharingControl ?? nothing}
       ${!props.catalog && props.branches.length > 1
         ? html`
-            <openclaw-tooltip
-              .content=${props.branchSwitchDisabledReason ?? t("chat.sessionHeader.branches")}
+            <wa-dropdown
+              class="chat-pane__branches-menu"
+              placement="bottom-end"
+              @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
+                const leafEntryId = event.detail.item.value;
+                const branch = props.branches.find(
+                  (candidate) => candidate.leafEntryId === leafEntryId,
+                );
+                if (leafEntryId && branch && !branch.active && !props.branchSwitchDisabledReason) {
+                  props.onBranchSelect(leafEntryId);
+                }
+              }}
             >
-              <wa-dropdown
-                class="chat-pane__branches-menu"
-                placement="bottom-end"
-                @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
-                  const leafEntryId = event.detail.item.value;
-                  const branch = props.branches.find(
-                    (candidate) => candidate.leafEntryId === leafEntryId,
-                  );
-                  if (
-                    leafEntryId &&
-                    branch &&
-                    !branch.active &&
-                    !props.branchSwitchDisabledReason
-                  ) {
-                    props.onBranchSelect(leafEntryId);
-                  }
-                }}
+              <button
+                slot="trigger"
+                class="btn btn--ghost btn--icon chat-icon-btn chat-pane__branches-trigger"
+                type="button"
+                ?disabled=${Boolean(props.branchSwitchDisabledReason)}
+                title=${props.branchSwitchDisabledReason ?? t("chat.sessionHeader.branches")}
+                aria-label=${t("chat.sessionHeader.branches")}
               >
-                <button
-                  slot="trigger"
-                  class="btn btn--ghost btn--icon chat-icon-btn chat-pane__branches-trigger"
-                  type="button"
-                  ?disabled=${Boolean(props.branchSwitchDisabledReason)}
-                  aria-label=${t("chat.sessionHeader.branches")}
-                >
-                  ${icons.gitBranch}
-                </button>
-                ${props.branches.map((branch) => {
-                  const relativeTime = branchRelativeTime(branch.updatedAt);
-                  return html`
-                    <wa-dropdown-item
-                      class="chat-pane__branch-item"
-                      value=${branch.leafEntryId}
-                      ?disabled=${branch.active || Boolean(props.branchSwitchDisabledReason)}
-                      data-active=${branch.active ? "true" : "false"}
-                    >
-                      <span class="chat-pane__branch-copy">
-                        <span class="chat-pane__branch-headline"
-                          >${branch.headline || t("chat.sessionHeader.untitledBranch")}</span
-                        >
-                        <span class="chat-pane__branch-meta"
-                          >${t(
-                            branch.messageCount === 1
-                              ? "chat.sessionHeader.oneMessage"
-                              : "chat.sessionHeader.messages",
-                            { count: String(branch.messageCount) },
-                          )}${relativeTime ? ` · ${relativeTime}` : ""}</span
-                        >
-                      </span>
-                      ${branch.active
-                        ? html`<span
-                            class="chat-pane__branch-active"
-                            aria-label=${t("chat.sessionHeader.activeBranch")}
-                            >${icons.check}</span
-                          >`
-                        : nothing}
-                    </wa-dropdown-item>
-                  `;
-                })}
-              </wa-dropdown>
-            </openclaw-tooltip>
+                ${icons.gitBranch}
+              </button>
+              ${props.branches.map((branch) => {
+                const relativeTime = branchRelativeTime(branch.updatedAt);
+                return html`
+                  <wa-dropdown-item
+                    class="chat-pane__branch-item"
+                    value=${branch.leafEntryId}
+                    ?disabled=${branch.active || Boolean(props.branchSwitchDisabledReason)}
+                    data-active=${branch.active ? "true" : "false"}
+                  >
+                    <span class="chat-pane__branch-copy">
+                      <span class="chat-pane__branch-headline"
+                        >${branch.headline || t("chat.sessionHeader.untitledBranch")}</span
+                      >
+                      <span class="chat-pane__branch-meta"
+                        >${t(
+                          branch.messageCount === 1
+                            ? "chat.sessionHeader.oneMessage"
+                            : "chat.sessionHeader.messages",
+                          { count: String(branch.messageCount) },
+                        )}${relativeTime ? ` · ${relativeTime}` : ""}</span
+                      >
+                    </span>
+                    ${branch.active
+                      ? html`<span
+                          class="chat-pane__branch-active"
+                          aria-label=${t("chat.sessionHeader.activeBranch")}
+                          >${icons.check}</span
+                        >`
+                      : nothing}
+                  </wa-dropdown-item>
+                `;
+              })}
+            </wa-dropdown>
           `
         : nothing}
       ${renderGatewayPicker(props)}

--- a/ui/src/pages/chat/components/chat-sidebar-editor-menu.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-editor-menu.ts
@@ -1,6 +1,5 @@
 import { html, nothing } from "lit";
 import { icons } from "../../../components/icons.ts";
-import "../../../components/tooltip.ts";
 import "../../../components/web-awesome.ts";
 import { EDITOR_IDS, EDITOR_LABELS, type EditorId } from "../../../lib/editor-links.ts";
 
@@ -16,37 +15,36 @@ export function renderChatSidebarEditorMenu(params: {
   const label = "Open in editor";
   return html`
     <div class="sidebar-file-view__editor">
-      <openclaw-tooltip .content=${label}>
-        <wa-dropdown
-          class="sidebar-file-view__editor-menu"
-          placement="bottom-end"
-          .open=${params.open}
-          @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
-            const editor = event.detail.item.value;
-            if (editor && EDITOR_IDS.includes(editor as EditorId)) {
-              params.onOpenEditor(editor as EditorId);
-            }
-          }}
-          @wa-show=${() => params.onOpenChange(true)}
-          @wa-hide=${() => params.onOpenChange(false)}
+      <wa-dropdown
+        class="sidebar-file-view__editor-menu"
+        placement="bottom-end"
+        .open=${params.open}
+        @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
+          const editor = event.detail.item.value;
+          if (editor && EDITOR_IDS.includes(editor as EditorId)) {
+            params.onOpenEditor(editor as EditorId);
+          }
+        }}
+        @wa-show=${() => params.onOpenChange(true)}
+        @wa-hide=${() => params.onOpenChange(false)}
+      >
+        <button
+          slot="trigger"
+          class="btn btn--sm sidebar-file-view__action"
+          type="button"
+          title=${label}
+          aria-label=${label}
         >
-          <button
-            slot="trigger"
-            class="btn btn--sm sidebar-file-view__action"
-            type="button"
-            aria-label=${label}
-          >
-            ${icons.externalLink}
-          </button>
-          ${EDITOR_IDS.map(
-            (editor) => html`
-              <wa-dropdown-item class="sidebar-file-view__editor-item" value=${editor}>
-                ${EDITOR_LABELS[editor]}
-              </wa-dropdown-item>
-            `,
-          )}
-        </wa-dropdown>
-      </openclaw-tooltip>
+          ${icons.externalLink}
+        </button>
+        ${EDITOR_IDS.map(
+          (editor) => html`
+            <wa-dropdown-item class="sidebar-file-view__editor-item" value=${editor}>
+              ${EDITOR_LABELS[editor]}
+            </wa-dropdown-item>
+          `,
+        )}
+      </wa-dropdown>
     </div>
   `;
 }

--- a/ui/src/test-helpers/control-ui-e2e.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.test.ts
@@ -1,8 +1,10 @@
 // Control UI tests cover control ui e2e behavior.
-import { describe, expect, it } from "vitest";
+import type { Page } from "playwright";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   resolvePlaywrightChromiumExecutablePath,
   systemChromiumExecutableCandidates,
+  waitForControlUiRoute,
 } from "./control-ui-e2e.ts";
 
 describe("resolvePlaywrightChromiumExecutablePath", () => {
@@ -26,5 +28,56 @@ describe("resolvePlaywrightChromiumExecutablePath", () => {
         () => false,
       ),
     ).toBe("/custom/chromium");
+  });
+});
+
+describe("waitForControlUiRoute", () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it("keeps polling while a new tab has no app element", async () => {
+    // SAFETY: this fixture implements the Page methods used by the route helper.
+    const page = {
+      async waitForFunction(
+        predicate: (target: { routeId: string }) => boolean,
+        target: { routeId: string },
+      ) {
+        expect(predicate(target)).toBe(false);
+        const app = document.createElement("openclaw-app");
+        Object.assign(app, {
+          runtime: {
+            router: {
+              getState: () => ({
+                status: "success",
+                resolvedLocation: { pathname: window.location.pathname },
+                matches: [{ routeId: "chat" }],
+                pendingMatches: [],
+              }),
+            },
+          },
+        });
+        document.body.append(app);
+        expect(predicate(target)).toBe(true);
+        return { dispose: vi.fn() };
+      },
+      evaluate: (read: () => unknown) => read(),
+    } as unknown as Page;
+
+    await waitForControlUiRoute(page, { routeId: "chat" });
+  });
+
+  it("preserves readiness failures when the app is still absent", async () => {
+    const cause = new Error("Route readiness failed");
+    // SAFETY: this fixture implements the Page methods used by the route helper.
+    const page = {
+      waitForFunction: vi.fn().mockRejectedValue(cause),
+      evaluate: (read: () => unknown) => read(),
+    } as unknown as Page;
+
+    await expect(waitForControlUiRoute(page, { routeId: "chat" })).rejects.toMatchObject({
+      cause,
+      message: expect.stringContaining('"router":null'),
+    });
   });
 });

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -123,19 +123,22 @@ export async function waitForControlUiRoute(page: Page, target: ControlUiRouteTa
   try {
     const handle = await page.waitForFunction(
       (expected) => {
-        const app = document.querySelector("openclaw-app") as HTMLElement & {
-          runtime?: {
-            router: {
-              getState: () => {
-                status: string;
-                resolvedLocation: { pathname: string } | null;
-                matches: { routeId: string }[];
-                pendingMatches: unknown[];
+        const app = document.querySelector<
+          HTMLElement & {
+            runtime?: {
+              router: {
+                getState: () => {
+                  status: string;
+                  resolvedLocation: { pathname: string } | null;
+                  matches: { routeId: string }[];
+                  pendingMatches: unknown[];
+                };
               };
             };
-          };
-        };
-        const state = app.runtime?.router.getState();
+          }
+        >("openclaw-app");
+        // Native popup events can arrive before the app element is parsed.
+        const state = app?.runtime?.router.getState();
         const pathname = window.location.pathname;
         // Router paths retain literal characters that browser history percent-encodes.
         // Serialize as a pathname; decoding would alias encoded delimiters and percent data.
@@ -163,17 +166,19 @@ export async function waitForControlUiRoute(page: Page, target: ControlUiRouteTa
     await handle.dispose();
   } catch (error) {
     const state = await page.evaluate(() => {
-      const app = document.querySelector("openclaw-app") as HTMLElement & {
-        runtime?: {
-          router: {
-            getState: () => unknown;
+      const app = document.querySelector<
+        HTMLElement & {
+          runtime?: {
+            router: {
+              getState: () => unknown;
+            };
           };
-        };
-      };
+        }
+      >("openclaw-app");
       return {
         hash: window.location.hash,
         pathname: window.location.pathname,
-        router: app.runtime?.router.getState() ?? null,
+        router: app?.runtime?.router.getState() ?? null,
         search: window.location.search,
       };
     });


### PR DESCRIPTION
Closes #133553

## What Problem This Solves

Fixes an issue where users hovering the conversation branch button see its hint in the window's top-left instead of beside the button, including the disabled explanation while an agent works. The file/diff sidebar editor-menu hint has the same defect.

## Why This Change Was Made

The tooltip wrapped a Web Awesome dropdown whose host uses `display: contents` and therefore has no anchor rectangle. Both controls now use the existing title-tooltip adapter directly on their buttons. The button remains the direct dropdown trigger so menu geometry, selection, and disabled-state handling stay intact; no shared positioning algorithm or dependency changes.

Best-fix verdict: repair the invalid composition at its owners. Moving the tooltip inside `slot="trigger"` would reintroduce the earlier menu-positioning bug; changing shared tooltip geometry would add unnecessary special cases.

Provenance: raw-parent patch comparison verifies commit `87a7084e963` (PR #115352, branch-menu positioning) moved the branch tooltip outside the dropdown. This repair keeps that commit's direct button/menu anchor invariant.

## User Impact

Branch and editor hints appear next to the hovered button. Branch switching remains unavailable while the agent is working, and both menus still dispatch their selected action.

## Evidence

- Added real-Chromium production-renderer regression coverage for idle branch, busy/disabled branch, and editor menu. All three failed on pre-fix geometry and pass after the repair; enabled menu selection and tooltip dismissal are covered too.
- 15 browser tests passed (new regression + title-tooltip accessibility sibling suite).
- 141 focused unit tests passed (header, sidebar, shared tooltip).
- 4 route-helper unit tests and 9 focused E2E tests passed after repairing the CI readiness race below (sidebar interactions and encoded route readiness).
- Complete revised five-file changed gates passed: formatting, UI/core-test typechecks, lint, style lint, i18n, dead exports, and repository guards.
- Fresh automated review returned scoped-clean (P0 default), no accepted/actionable findings.
- Production delta: +83/-93 (net -10, including indentation churn). Tooltip regression tests: +95/-0; CI helper/test repair: +77/-19 (test support +23/-18, tests +54/-1). No added production helper, state, configuration, or dependency.

Commands:

```sh
node scripts/run-vitest.mjs run --config "$PWD/ui/vitest.config.ts" --root ui --project browser src/pages/chat/components/chat-pane-header.browser.test.ts src/components/tooltip-title.browser.test.ts
node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-pane-header.test.ts ui/src/pages/chat/components/chat-sidebar.test.ts ui/src/components/tooltip.test.ts
node scripts/run-vitest.mjs ui/src/test-helpers/control-ui-e2e.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/sidebar-interactions.e2e.test.ts ui/src/e2e/control-ui-route-readiness.e2e.test.ts
node scripts/check-changed.mjs -- ui/src/pages/chat/components/chat-pane-header.ts ui/src/pages/chat/components/chat-sidebar-editor-menu.ts ui/src/pages/chat/components/chat-pane-header.browser.test.ts ui/src/test-helpers/control-ui-e2e.ts ui/src/test-helpers/control-ui-e2e.test.ts
```

### Before / after (Chromium production-component proof)

Before:

![Tooltip detached at the window origin](https://github.com/user-attachments/assets/3c5c7094-1834-42c1-bb0b-4863ee8ca4d4)

After:

![Disabled branch tooltip beside its hovered button](https://github.com/user-attachments/assets/3c38496b-fd7a-4276-86ab-ed61aa5f3efa)

Both captures were inspected. These are browser component screenshots, not an authenticated end-to-end agent conversation.

### Live-flow proof gap

A separate isolated source UI connected to a fresh loopback gateway and completed chat startup. Its empty state had no verified model, so it displayed “No models available” and then Model Setup; no branched conversation or editor trigger was reachable through the normal UI. The preexisting gateway build also showed source/bundle version skew. No existing credentials, operator gateway state, or injected session state were used to bypass setup. The live busy-branch flow is therefore unproven; the deterministic production-renderer geometry failure/pass above is the change-specific proof. Both isolated servers were stopped.

### CI-discovered readiness race

The first exact-head CI run failed only UI E2E shard 8/14: the native new-tab test threw after 2.305s, not the helper's 60s timeout. Playwright permits its browser-context page event before the new document's app element exists; `waitForControlUiRoute` incorrectly dereferenced that absent element both in its polling predicate and in failure diagnostics.

The helper now treats an absent app as not ready and retains the original error cause in diagnostics. Two deterministic regressions fail before/pass after, and the original failing native-tab flow plus encoded-route sibling tests pass. No retries, increased timeout, or weaker route assertion were added. This small test-support repair is included because it blocked this PR's CI.

### Mechanical refresh after an unrelated CI failure

The next CI run passed all UI checks but failed the docs release-navigation expectation. That correction was already merged in [PR #133581](https://github.com/openclaw/openclaw/pull/133581), commit `7504a3b3c45393e793e2a3960585a4e781da94cd`. This branch is rebased onto that existing fix; no duplicate docs edits were added to this PR. All five PR files are byte-identical before and after the refresh. Rebase sanity passed: all 6 docs-sync tests and all 4 readiness-helper tests.

```sh
node scripts/run-vitest.mjs test/scripts/docs-sync-publish.test.ts ui/src/test-helpers/control-ui-e2e.test.ts
```
