### PR TITLE
fix(memory): clarify default agent scope in command help

### DIFF
--- a/extensions/memory-core/src/cli.ts
+++ b/extensions/memory-core/src/cli.ts
@@ -198,7 +198,7 @@ export function registerMemoryCli(program: Command, hostOptions?: MemoryCoreRunt
   memory
     .command("status")
     .description("Show memory search index status")
-    .option("--agent <id>", "Agent id (default: default agent)")
+    .option("--agent <id>", "Agent id (default: all configured agents)")
     .option("--json", "Print JSON")
     .option("--deep", "Probe embedding provider availability")
     .option("--index", "Reindex if dirty (implies --deep)")
@@ -211,7 +211,7 @@ export function registerMemoryCli(program: Command, hostOptions?: MemoryCoreRunt
   memory
     .command("index")
     .description("Reindex memory files")
-    .option("--agent <id>", "Agent id (default: default agent)")
+    .option("--agent <id>", "Agent id (default: all configured agents)")
     .option("--force", "Force full reindex", false)
     .option("--verbose", "Verbose logging", false)
     .action(async (opts: MemoryCommandOptions) => {


### PR DESCRIPTION
Closes #133559

## What Problem This Solves

Fixes an issue where users reading `openclaw memory status --help` or `openclaw memory index --help` were told that omitting `--agent` selects only the default agent, even though both commands operate on all configured agents.

## Why This Change Was Made

The shared Memory CLI registrar used the single-agent description for two commands whose existing runtime owners explicitly select all agents. Correct those two descriptions at registration; preserve command selection, option parsing, storage behavior and the seven single-agent sibling descriptions. Production change: +2/−2 lines, net zero.

## User Impact

Status and index help now say `Agent id (default: all configured agents)`. Operators can use `--agent <id>` to narrow those commands without being misled about their default scope.

## Evidence

- Real public registrar and OpenClawCommand/Commander parsing on Node 24.20.0 (before source `0ec1da56`, candidate based on `08349113`, with affected-owner parity verified): before, status/index had two contradictory descriptions; after, all nine help commands returned helpDisplayed/exit 0 with the intended description. The seven default-agent controls remained unchanged.
- Both runs recorded zero command actions, host calls, lazy memory-operation owner loads and state files. The final run had no sticky import denials; source, dependency, Node 24 and identity guards passed before and after. Owned child groups were independently absent, and task runtime state was cleaned. The approved outer wrapper did not record its own numeric PID; the tool session closed with exit 0, and this limitation is retained in the evidence.
- Existing status/index fan-out tests and runtime owners already cover all-agent selection. No redundant test asserting these wording literals was added.
- Independent Codex reviews: managed autoreview scoped clean; separate read-only review found no actionable P0–P2 findings at `077909b4f62dfa754f431f8878d02b395e66d3e4`. Canonical `node scripts/check-changed.mjs --base 083491132ae7aa7949cf6d7e396d096a6aff9afa --head HEAD --timed -- extensions/memory-core/src/cli.ts`: all 24 required checks passed, including the selected 2 test files/5 tests, in 359.990s; no skip flags or separate suite/build. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33336443845) passed on the first attempt for `077909b4f62dfa754f431f8878d02b395e66d3e4`. Native prepare/merge verification remains in progress.

This proof exercises the actual help parser, not full CLI/plugin startup or memory provider/storage operations. The production change does not alter those operations.

Named follow-up: `memory session-backfill --help` repeats the `(default: 92)` annotation for `--limit-days`. That independent wording defect is recorded but intentionally outside this two-description repair.

Final ClawSweeper disposition: the [completed review](https://github.com/openclaw/openclaw/pull/133560#issuecomment-5471395126) found no actionable code or security issue and confirmed the two-description fix. Its ordinary maintainer-handling item is satisfied by the source review, before/after proof, independent reviews and native landing flow; no Rank-up moves were listed.
