### PR TITLE
test: reduce maturity fixture cleanup time

### DIFF
--- a/test/scripts/ci-git-owner.test.ts
+++ b/test/scripts/ci-git-owner.test.ts
@@ -1040,6 +1040,7 @@ posixIt.each(["main-ancestor", "release-tag", "release-branch-head", "floating-m
     const publicationBase = releaseBranch ? release : "main";
     const report = await maturityRun({
       realClock: true,
+      realDrain: false,
       env: {
         ...maturityEnvironment,
         EXPECTED_SHA: floating ? "" : head,


### PR DESCRIPTION
## What Problem This Solves

Four maturity policy tests spent about 74 seconds executing successful trust and output scenarios. Their synthetic Git descendants deliberately ignore TERM, so every successful command also paid the owner's five-second cleanup grace.

## Why This Change Was Made

Opt these four cases into the existing immediate-escalation fixture option while retaining real command clocks. The same real child/grandchild processes, group census, TERM/KILL delivery, joins, extinction checks, unrelated sentinel, trust order, fetch order, exact output bytes and output hash assertions still run. Dedicated real timeout, backoff and cancellation tests retain their existing grace and watchdogs.

Only one test option changes. No production code, sharding, concurrency, assertions, retries, timeouts or test selection changes. Production delta: 0; test delta: +1. No new test is needed because the four existing behavioral cases and their assertions are unchanged.

## User Impact

About 70 seconds less test execution for this four-case group. No product behavior changes.

## Evidence

On one Blacksmith Testbox, a before/after/after/before comparison passed all four cases each time:

| Execution time | First run | Repeat |
| --- | ---: | ---: |
| Before | 74.167 s | 74.301 s |
| After | 3.788 s | 3.772 s |

Mean execution fell from 74.234 s to 3.780 s (94.9%). This is the focused test execution measurement, not a claim about whole-job elapsed time. Local macOS runs also passed; host contention made those timings noisier.

All four command traces, boundary names and ready-attempt sequences matched across variants. A temporary mutation removing `drain(child, job)` only from the rendered fixture made all four unchanged tests fail at the next trust/read boundary with live child and grandchild processes. The supervisor then proved extinction and removed its temporary roots. Restoring exact source returned all four to green in 3.772 s; the production owner remained byte-identical throughout.

Linux proof: Blacksmith Testbox `tbx_01m1a8d4rfy6vmqaw2mfg2jmsf`, [environment run](https://github.com/openclaw/openclaw/actions/runs/33335895656). The environment workflow's status is separate from the successful command result. The first probe invocation stopped at a command-wrapper heredoc syntax error before any test or mutation; the corrected direct argument invocation completed successfully.

All 294 tests in `test/scripts/ci-git-owner.test.ts` and `test/scripts/ci-linux-git.test.ts` passed on Linux, including the unchanged real timeout, backoff and cancellation cases.
All 14 changed-file gates passed, including test-root typechecking and script lint. The normal changed-check router used a separate Blacksmith Testbox and stopped it after success.
Codex autoreview: no accepted findings. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33336760944) completed successfully at `f14d811ede39d756d6ffa27d67852732890e9435`. The completed ClawSweeper review has no actionable findings; its CI requirement is satisfied, and landing will use the native prepare/merge flow.
