### PR TITLE
refactor(ui): simplify chat rendering and lifecycle state

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -4053,7 +4053,7 @@ ui/src/pages/chat/components/chat-header-session-menu.ts	1
 ui/src/pages/chat/components/chat-message-attachment-availability.ts	1
 ui/src/pages/chat/components/chat-message-bubble.ts	2
 ui/src/pages/chat/components/chat-message-confirmation.ts	2
-ui/src/pages/chat/components/chat-message-markdown.ts	3
+ui/src/pages/chat/components/chat-message-markdown.ts	2
 ui/src/pages/chat/components/chat-message-media.ts	13
 ui/src/pages/chat/components/chat-message-timestamp.ts	4
 ui/src/pages/chat/components/chat-model-picker-options.ts	2
@@ -4068,7 +4068,7 @@ ui/src/pages/chat/components/chat-sidebar-editor-menu.ts	2
 ui/src/pages/chat/components/chat-sidebar-region.runtime.ts	2
 ui/src/pages/chat/components/chat-swarm-progress.ts	2
 ui/src/pages/chat/components/chat-task-suggestions.ts	1
-ui/src/pages/chat/components/chat-thread-interactions.ts	7
+ui/src/pages/chat/components/chat-thread-interactions.ts	6
 ui/src/pages/chat/components/chat-tool-cards.ts	2
 ui/src/pages/chat/components/chat-voice-activity.ts	1
 ui/src/pages/chat/components/session-diff-menus.ts	1

--- a/ui/src/pages/chat/chat-agent-run-grouping.ts
+++ b/ui/src/pages/chat/chat-agent-run-grouping.ts
@@ -79,30 +79,14 @@ function itemIsActive(item: AgentRunFramePart): boolean {
   return itemGroups(item).some((group) => group.isStreaming);
 }
 
-function itemBoundaryId(item: AgentRunFramePart): string | undefined {
-  return item.kind === "stream-run" ? item.boundaryId : undefined;
-}
-
 function groupBoundaryId(group: MessageGroup): string | undefined {
   const firstMessage = group.messages[0]?.message;
   const identity = readSessionMessageIdentity(firstMessage);
-  if (!chatItemStartsUserTurn(group)) {
-    return undefined;
-  }
   const runId = identity?.runId;
   if (runId) {
     return `send:${runId}`;
   }
   return identity?.id ? `entry:${identity.id}` : undefined;
-}
-
-function isExternalBoundary(group: MessageGroup): boolean {
-  return group.role === "user" || assistantGroupIsForwardedBoundary(group);
-}
-
-function itemBoundaryGroup(item: AgentRunFramePart): MessageGroup | undefined {
-  const first = itemGroups(item)[0];
-  return first && chatItemStartsUserTurn(first) ? first : undefined;
 }
 
 function frameKey(runId: string, boundaryId: string, segmentId: string | undefined): string {
@@ -233,36 +217,28 @@ export function coalesceAgentRunFrames(
       segmentId = boundaryId ? undefined : item.key;
       continue;
     }
-    const candidate = item;
-    const boundaryGroup = itemBoundaryGroup(candidate);
-    if (boundaryGroup) {
+    const boundaryGroup = itemGroups(item)[0];
+    if (boundaryGroup && chatItemStartsUserTurn(boundaryGroup)) {
       flush();
       segmentId = undefined;
       const nextBoundaryId = groupBoundaryId(boundaryGroup);
-      if (isExternalBoundary(boundaryGroup) || !nextBoundaryId) {
+      if (
+        boundaryGroup.role === "user" ||
+        assistantGroupIsForwardedBoundary(boundaryGroup) ||
+        !nextBoundaryId
+      ) {
         result.push(item);
         boundaryId = nextBoundaryId;
         continue;
       }
       boundaryId = nextBoundaryId;
     }
-    const candidateBoundaryId = itemBoundaryId(candidate);
+    const candidateBoundaryId = item.kind === "stream-run" ? item.boundaryId : undefined;
     if (candidateBoundaryId && candidateBoundaryId !== boundaryId) {
       flush();
       boundaryId = candidateBoundaryId;
     }
-    const candidateRunId = itemRunId(candidate);
-    if (boundaryId && candidateRunId && itemFailsFrame(candidate)) {
-      if (runId && runId !== candidateRunId) {
-        flush();
-      }
-      runId = candidateRunId;
-      parts.push(candidate);
-      flush(true);
-      boundaryId = undefined;
-      segmentId = item.key;
-      continue;
-    }
+    const candidateRunId = itemRunId(item);
     if (!boundaryId || !candidateRunId) {
       flush();
       result.push(item);
@@ -270,11 +246,17 @@ export function coalesceAgentRunFrames(
       segmentId = item.key;
       continue;
     }
+    const failed = itemFailsFrame(item);
     if (runId && runId !== candidateRunId) {
       flush();
     }
     runId = candidateRunId;
-    parts.push(candidate);
+    parts.push(item);
+    if (failed) {
+      flush(true);
+      boundaryId = undefined;
+      segmentId = item.key;
+    }
   }
   flush();
   return result;

--- a/ui/src/pages/chat/chat-outbox-drain.ts
+++ b/ui/src/pages/chat/chat-outbox-drain.ts
@@ -94,23 +94,15 @@ type StoredChatOutboxDrainLane = {
   rerun: boolean;
 };
 
-type StoredChatOutboxClientState = {
-  lanes: Map<string, StoredChatOutboxDrainLane>;
-};
 export const UNCONFIRMED_CHAT_SEND_ERROR =
   "Reconnected before delivery was confirmed. Check the conversation — retry only if your message didn't arrive.";
 const UNCERTAIN_CLEAR_SUCCESSOR_ERROR =
   "A preceding /clear may have completed. Review the current conversation before retrying.";
 
-const storedChatOutboxClients = new WeakMap<GatewayBrowserClient, StoredChatOutboxClientState>();
-
-function getStoredChatOutboxClientState(client: GatewayBrowserClient): StoredChatOutboxClientState {
-  const state = storedChatOutboxClients.get(client) ?? {
-    lanes: new Map(),
-  };
-  storedChatOutboxClients.set(client, state);
-  return state;
-}
+const storedChatOutboxLanes = new WeakMap<
+  GatewayBrowserClient,
+  Map<string, StoredChatOutboxDrainLane>
+>();
 
 export function scheduleStoredChatOutboxRetry(
   host: ChatHost,
@@ -630,7 +622,8 @@ export async function scheduleStoredChatOutboxDrain(
     return undefined;
   }
   const key = storedChatOutboxScopeKey(scope);
-  const { lanes } = getStoredChatOutboxClientState(client);
+  const lanes = storedChatOutboxLanes.get(client) ?? new Map<string, StoredChatOutboxDrainLane>();
+  storedChatOutboxLanes.set(client, lanes);
   const candidateOwnsScope = visibleSessionMatches(host, scope.sessionKey, scope.agentId);
   if (consumeChatOutboxRetry(host, key, candidateOwnsScope, itemId)) {
     return undefined;

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.ts
@@ -1,7 +1,7 @@
 import type { ApplicationContext } from "../../app/context.ts";
 import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
 import {
-  releaseChatAttachmentPayload,
+  releaseChatAttachmentPayloads,
   releaseDisplacedChatAttachmentPayloads,
 } from "./attachment-payload-store.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
@@ -17,20 +17,6 @@ function handoffKey(paneId: string, state: ChatPageHost, owner: ChatAttachmentGa
     paneId,
     scopeKey: storedChatOutboxScopeKey(resolveStoredChatOutboxScope(state, state.sessionKey)),
   };
-}
-
-function releaseAttachments(
-  attachments: readonly ChatAttachment[],
-  retainedIds = new Set<string>(),
-  releasedIds = new Set<string>(),
-): void {
-  for (const attachment of attachments) {
-    if (retainedIds.has(attachment.id) || releasedIds.has(attachment.id)) {
-      continue;
-    }
-    releasedIds.add(attachment.id);
-    releaseChatAttachmentPayload(attachment.id);
-  }
 }
 
 export function restorePaneStagedAttachments(
@@ -79,10 +65,9 @@ export function discardStateStagedAttachments(state: ChatPageHost | undefined): 
   if (!state) {
     return;
   }
-  const releasedIds = new Set<string>();
-  releaseAttachments(state.chatAttachments, new Set(), releasedIds);
+  releaseChatAttachmentPayloads(state.chatAttachments);
   for (const fallback of Object.values(state.chatComposerFallbackByScope)) {
-    releaseAttachments(fallback.attachments, new Set(), releasedIds);
+    releaseChatAttachmentPayloads(fallback.attachments);
     fallback.attachments = [];
   }
   state.chatAttachments = [];
@@ -103,7 +88,9 @@ export function replacePaneStagedAttachmentGatewayOwner(
   // reconnect or plugin-install rotation must not silently discard them.
   if (state) {
     const dropAnnotations = (attachments: readonly ChatAttachment[]) => {
-      releaseAttachments(attachments.filter((attachment) => attachment.browserAnnotation));
+      releaseChatAttachmentPayloads(
+        attachments.filter((attachment) => attachment.browserAnnotation),
+      );
       return attachments.filter((attachment) => !attachment.browserAnnotation);
     };
     state.chatAttachments = dropAnnotations(state.chatAttachments);

--- a/ui/src/pages/chat/chat-settings-patches.ts
+++ b/ui/src/pages/chat/chat-settings-patches.ts
@@ -24,9 +24,7 @@ type ChatCommandSettingsContext = {
   defaultAgentId?: string;
   agentId?: string;
 };
-type PendingPatchStore = WeakMap<SessionCapability, Map<string, Promise<boolean>>>;
-
-const pendingChatPickerPatches: PendingPatchStore = new WeakMap();
+const pendingChatPickerPatches = new WeakMap<SessionCapability, Map<string, Promise<boolean>>>();
 
 function resolveChatPickerPatchKey(
   host: ChatPickerPatchHost,
@@ -64,40 +62,13 @@ function resolveChatPickerPatchKey(
   return `agent:${normalizeAgentId(resolvedAgentId)}:${settingsKey}`;
 }
 
-function getPendingPatch(
-  store: PendingPatchStore,
-  host: ChatPickerPatchHost,
-  sessionKey: string,
-  agentId?: string,
-): Promise<boolean> | undefined {
-  const patchKey = resolveChatPickerPatchKey(host, sessionKey, agentId);
-  return store.get(host.sessions)?.get(patchKey);
-}
-
-function trackLatestPatch(
-  store: PendingPatchStore,
-  host: ChatPickerPatchHost,
-  sessionKey: string,
-  patchPromise: Promise<boolean>,
-  agentId?: string,
-): void {
-  const pendingBySession = store.get(host.sessions) ?? new Map<string, Promise<boolean>>();
-  store.set(host.sessions, pendingBySession);
-  const patchKey = resolveChatPickerPatchKey(host, sessionKey, agentId);
-  pendingBySession.set(patchKey, patchPromise);
-  void patchPromise.finally(() => {
-    if (pendingBySession.get(patchKey) === patchPromise) {
-      pendingBySession.delete(patchKey);
-    }
-  });
-}
-
 export function getPendingChatPickerPatch(
   host: ChatPickerPatchHost,
   sessionKey: string,
   agentId?: string,
 ): Promise<boolean> | undefined {
-  return getPendingPatch(pendingChatPickerPatches, host, sessionKey, agentId);
+  const patchKey = resolveChatPickerPatchKey(host, sessionKey, agentId);
+  return pendingChatPickerPatches.get(host.sessions)?.get(patchKey);
 }
 
 function trackPendingChatSettingsPatch(
@@ -106,7 +77,16 @@ function trackPendingChatSettingsPatch(
   patchPromise: Promise<boolean>,
   agentId?: string,
 ): void {
-  trackLatestPatch(pendingChatPickerPatches, host, sessionKey, patchPromise, agentId);
+  const pendingBySession =
+    pendingChatPickerPatches.get(host.sessions) ?? new Map<string, Promise<boolean>>();
+  pendingChatPickerPatches.set(host.sessions, pendingBySession);
+  const patchKey = resolveChatPickerPatchKey(host, sessionKey, agentId);
+  pendingBySession.set(patchKey, patchPromise);
+  void patchPromise.finally(() => {
+    if (pendingBySession.get(patchKey) === patchPromise) {
+      pendingBySession.delete(patchKey);
+    }
+  });
 }
 
 export function patchChatSessionSettings(

--- a/ui/src/pages/chat/chat-state-controller.ts
+++ b/ui/src/pages/chat/chat-state-controller.ts
@@ -17,7 +17,6 @@ import type { AfterCommitEffect, RenderLifecycle } from "./render-lifecycle.ts";
 import { cancelChatScroll, scheduleCommittedChatScroll } from "./scroll.ts";
 
 type ChatRenderLifecycleScope = {
-  connectionEpoch: number;
   cancellations: Set<() => void>;
 };
 
@@ -36,7 +35,6 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
   private forceScrollAfterUpdate = false;
   private readonly cleanups: Array<() => void> = [];
   private renderLifecycleConnected = false;
-  private renderLifecycleConnectionEpoch = 0;
   private renderLifecycleScope: ChatRenderLifecycleScope | undefined;
 
   constructor(private readonly host: ReactiveControllerHost) {
@@ -54,7 +52,6 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
   createRenderLifecycle(): RenderLifecycle {
     this.cancelRenderLifecycleScope();
     const scope: ChatRenderLifecycleScope = {
-      connectionEpoch: this.renderLifecycleConnectionEpoch,
       cancellations: new Set(),
     };
     this.renderLifecycleScope = scope;
@@ -119,11 +116,7 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
   }
 
   private isRenderLifecycleScopeActive(scope: ChatRenderLifecycleScope): boolean {
-    return (
-      this.renderLifecycleConnected &&
-      this.renderLifecycleScope === scope &&
-      scope.connectionEpoch === this.renderLifecycleConnectionEpoch
-    );
+    return this.renderLifecycleConnected && this.renderLifecycleScope === scope;
   }
 
   private requestUpdateForScope(scope: ChatRenderLifecycleScope): boolean {
@@ -252,7 +245,6 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
   }
 
   hostConnected() {
-    this.renderLifecycleConnectionEpoch += 1;
     this.renderLifecycleConnected = true;
     // A lifecycle created while detached must never become active on reconnect.
     this.cancelRenderLifecycleScope();

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -2,7 +2,6 @@ import { html, nothing, type TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { styleMap } from "lit/directives/style-map.js";
 import type {
-  ProgressCard,
   SessionPlacementDiskSpace,
   SessionSharingRole,
   SessionSuggestion,
@@ -12,23 +11,16 @@ import type {
   ControlUiSessionBranch,
   ControlUiSessionPullRequest,
 } from "../../../../src/gateway/control-ui-contract.js";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { GatewaySessionRow, ModelCatalogEntry } from "../../api/types.ts";
+import type { GatewaySessionRow } from "../../api/types.ts";
 import type { ExecApprovalDecision, ExecApprovalRequest } from "../../app/exec-approval.ts";
-import type { QuestionPrompt } from "../../app/question-prompt.ts";
-import type { ChatSendShortcut } from "../../app/settings.ts";
 import { renderExecApprovalCard } from "../../components/exec-approval-card.ts";
 import { icons } from "../../components/icons.ts";
 import type { ImageLightboxItem } from "../../components/image-lightbox.ts";
 import { t } from "../../i18n/index.ts";
-import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
-import type { ControlUiFollowUpMode } from "../../lib/chat/follow-up-mode.ts";
 import {
   KEYBOARD_SHORTCUT_COMBOS,
   matchesShortcutCombo,
 } from "../../lib/keyboard-shortcut-catalog.ts";
-import type { ProviderUsageDisplayProps } from "../../lib/provider-quota-summary.ts";
-import type { SessionToolOverrides } from "../../lib/sessions/patch.ts";
 import { getChatHistoryLoadState, retryChatHistoryLoad } from "./chat-history.ts";
 import { getChatPendingInputs, loadChatPendingInputs } from "./chat-pending-inputs.ts";
 import { chatStartupStatusLabel, type ChatRunStartupStatus } from "./chat-run-startup.ts";
@@ -39,16 +31,9 @@ import {
   renderChatTopbarNotices,
 } from "./chat-view-notices.ts";
 import { createChatAttachmentDropHandlers } from "./components/chat-attachments.ts";
-import type {
-  CapabilityMenuProps,
-  ChatComposerDisabledBanner,
-  ChatComposerProps,
-  ChatQueuedEditProps,
-} from "./components/chat-composer-types.ts";
+import type { ChatComposerProps } from "./components/chat-composer-types.ts";
 import { isChatRunWorking, renderChatComposer } from "./components/chat-composer.ts";
 import { isImageLightboxEvent, openInlineChatImage } from "./components/chat-image-lightbox.ts";
-import type { MessageReplyTarget } from "./components/chat-message.ts";
-import type { ChatPermissionPickerProps } from "./components/chat-permission-picker.ts";
 import { renderChatPullRequests } from "./components/chat-pull-requests.ts";
 import { renderChatSessionSuggestions } from "./components/chat-session-suggestions.ts";
 import { renderChatSwarmProgress } from "./components/chat-swarm-progress.ts";
@@ -61,11 +46,6 @@ import {
 } from "./components/chat-thread-interactions.ts";
 import { renderChatThread } from "./components/chat-thread.ts";
 import type { ChatTranscriptController } from "./components/chat-transcript-controller.ts";
-import type { ChatInputHistoryKeyInput, ChatInputHistoryKeyResult } from "./input-history.ts";
-import type { RealtimeTalkCameraDevice } from "./realtime-talk-input.ts";
-import type { RealtimeTalkLevelSignal } from "./realtime-talk-level.ts";
-import type { RealtimeTalkStatus } from "./realtime-talk.ts";
-import type { CompactionStatus, FallbackStatus } from "./tool-stream.ts";
 import type { WorkspaceResultConflict } from "./workspace-conflict.ts";
 import "../../components/resizable-divider.ts";
 export type ChatProps = Omit<
@@ -83,57 +63,16 @@ export type ChatProps = Omit<
   | "onOpenSession"
   | "onSend"
 > &
+  Omit<ChatComposerProps, "anchoredNotices" | "disabled" | "onOpenImage"> &
   ChatTaskSuggestionTrayProps &
   ChatPlacementStartupNoticeProps & {
     transcript: ChatTranscriptController;
     historyState?: ChatState;
     onSessionKeyChange: (next: string) => void;
     thinkingLevel: string | null;
-    sending: boolean;
-    canAbort?: boolean;
     startupStatus?: ChatRunStartupStatus | null;
-    compactionStatus?: CompactionStatus | null;
-    fallbackStatus?: FallbackStatus | null;
-    progressCard?: ProgressCard | null;
-    progressCardHasActiveRun?: boolean;
-    collapseTaskProgress?: boolean;
-    onDismissProgressCard?: (card: ProgressCard) => void;
-    gatewayQuestionPrompts?: readonly QuestionPrompt[];
-    onGatewayQuestionChange?: () => void;
-    onGatewayQuestionSubmit?: (
-      id: string,
-      answers: Record<string, string[]>,
-    ) => void | Promise<void>;
-    onGatewayQuestionSkip?: (id: string) => void | Promise<void>;
-    draft: string;
-    modelCatalog: readonly ModelCatalogEntry[];
-    modelSwitching: boolean;
-    queuedOutboxCount?: number;
-    realtimeTalkActive?: boolean;
-    realtimeTalkStatus?: RealtimeTalkStatus;
-    realtimeTalkDetail?: string | null;
-    realtimeTalkInputLevel?: RealtimeTalkLevelSignal;
-    realtimeTalkVideoStream?: MediaStream | null;
-    realtimeTalkCameraDevices?: RealtimeTalkCameraDevice[];
-    realtimeTalkVideoCapable?: boolean;
-    realtimeTalkVideoPending?: boolean;
-    realtimeTalkCameraError?: boolean;
-    connected: boolean;
-    offline?: boolean;
-    gatewayClient?: GatewayBrowserClient | null;
-    composerHoldToRecord?: boolean;
-    onComposerHoldToRecordChange?: (enabled: boolean) => void;
-    onOpenTalkSettings?: () => void;
-    onOpenDictationSettings?: () => void;
-    suggestionComposer?: boolean;
-    onTypingChange?: (typing: boolean, preview?: string) => void;
-    canSend: boolean;
-    disabledReason: string | null;
-    disabledReasonTone?: "info" | "danger";
-    disabledBanner?: ChatComposerDisabledBanner;
     error: string | null;
     diskSpace?: SessionPlacementDiskSpace;
-    runError?: { summary: string } | null;
     inlineApproval?: ExecApprovalRequest | null;
     approvalBusy?: boolean;
     approvalCanGrant: boolean;
@@ -144,48 +83,14 @@ export type ChatProps = Omit<
     ) => void | Promise<void>;
     workspaceConflict?: WorkspaceResultConflict;
     onDismissWorkspaceConflict?: () => void;
-    toolOverrides?: SessionToolOverrides;
-    capabilityMenu?: CapabilityMenuProps;
     swarmSessions?: readonly GatewaySessionRow[];
-    providerUsage?: ProviderUsageDisplayProps;
     focusMode?: boolean;
     chatMessageMaxWidth?: string | null;
-    sendShortcut?: ChatSendShortcut;
-    followUpMode?: ControlUiFollowUpMode;
-    attachmentLimits?: { maxBytes: number; maxImageBytes: number };
-    attachments?: ChatAttachment[];
-    getAttachments?: () => ChatAttachment[];
-    pendingAttachmentReads?: number;
-    getPendingAttachmentReads?: () => number;
-    readSignal?: AbortSignal;
-    onPendingReadsChange?: (delta: 1 | -1) => void;
-    onAttachmentsChange?: (attachments: ChatAttachment[]) => void;
-    onRemoveAttachment?: (attachment: ChatAttachment) => void;
     showNewMessages?: boolean;
     onScrollToBottom?: (options?: { smooth?: boolean }) => void;
     onRefresh: () => void;
     onToggleFocusMode?: () => void;
-    getDraft?: () => string;
-    onHistoryKeydown?: (input: ChatInputHistoryKeyInput) => ChatInputHistoryKeyResult;
-    onSlashIntent?: () => void | Promise<void>;
-    onSlashCommand?: (command: string) => void;
-    onSend: ChatComposerProps["onSend"];
-    onToggleRealtimeTalk?: () => void;
-    onToggleRealtimeCamera?: () => void;
-    onSwitchRealtimeCamera?: () => void;
     onDismissError?: () => void;
-    onDismissRealtimeTalkError?: () => void;
-    onAbort?: () => void;
-    onQueueRemove: (id: string) => void;
-    onQueueRetry?: (id: string) => void;
-    onQueueSteer?: (id: string) => void;
-    onQueueMove?: (id: string, toIndex: number) => void;
-    queuedEdit?: ChatQueuedEditProps;
-    onGoalAction?: ChatComposerProps["onGoalAction"];
-    onGoalSubmit?: ChatComposerProps["onGoalSubmit"];
-    goalDraftMode?: ChatComposerProps["goalDraftMode"];
-    onGoalDraftModeChange?: ChatComposerProps["onGoalDraftModeChange"];
-    currentSessionId?: string | null;
     onClearHistory?: () => void;
     agentsList: {
       agents: Array<{
@@ -195,15 +100,10 @@ export type ChatProps = Omit<
       }>;
       defaultId?: string;
     } | null;
-    currentAgentId: string;
     onAgentChange: (agentId: string) => void;
     onNavigateToAgent?: () => void;
     onSessionSelect?: (sessionKey: string) => void;
     onRevealWorkspaceFile?: (path: string) => void;
-    composerControls?: TemplateResult | typeof nothing;
-    permissionPicker?: ChatPermissionPickerProps;
-    replyTarget?: MessageReplyTarget | null;
-    onClearReply?: () => void;
     header?: TemplateResult | typeof nothing;
     sessionSuggestions?: readonly SessionSuggestion[];
     sessionSuggestionRole?: SessionSharingRole;

--- a/ui/src/pages/chat/components/chat-composer-types.ts
+++ b/ui/src/pages/chat/components/chat-composer-types.ts
@@ -36,7 +36,7 @@ import type { SlashMenuState } from "./chat-composer-slash-menu.ts";
 import type { ChatPermissionPickerProps } from "./chat-permission-picker.ts";
 
 /** One shape for queued-row edit state and actions. */
-export type ChatQueuedEditProps = {
+type ChatQueuedEditProps = {
   /** Id of the row with an inline draft, or null when no row is being edited. */
   editingId: string | null;
   editingText?: string;

--- a/ui/src/pages/chat/components/chat-message-attachments.ts
+++ b/ui/src/pages/chat/components/chat-message-attachments.ts
@@ -344,6 +344,82 @@ function retryManagedAttachmentAvailability(
   onRequestUpdate?.();
 }
 
+function resolveAttachmentSource(
+  attachment: AttachmentItem["attachment"],
+  options: ImageRenderOptions,
+) {
+  const { resourceBasePath, authToken, onRequestUpdate, resolveArtifactDownload, connectionEpoch } =
+    options;
+  const assistantAvailability = resolveAssistantAttachmentAvailability(
+    attachment.url,
+    options.localMediaPreviewRoots ?? [],
+    resourceBasePath,
+    authToken,
+    onRequestUpdate,
+  );
+  if (assistantAvailability.status !== "available") {
+    return {
+      status: assistantAvailability.status,
+      reason:
+        assistantAvailability.status === "unavailable" ? assistantAvailability.reason : undefined,
+      onRetry:
+        assistantAvailability.status === "unavailable" && assistantAvailability.recoverable
+          ? () =>
+              retryAssistantAttachmentAvailability(
+                attachment.url,
+                resourceBasePath,
+                authToken,
+                onRequestUpdate,
+              )
+          : undefined,
+    };
+  }
+  const managedAvailability = resolveManagedAttachmentAvailability(
+    attachment,
+    resolveArtifactDownload,
+    onRequestUpdate,
+    connectionEpoch,
+  );
+  if (managedAvailability.status !== "available") {
+    return {
+      status: managedAvailability.status,
+      reason: managedAvailability.status === "unavailable" ? managedAvailability.reason : undefined,
+      onRetry:
+        managedAvailability.status === "unavailable" &&
+        attachment.artifactId &&
+        resolveArtifactDownload
+          ? () => retryManagedAttachmentAvailability(attachment, onRequestUpdate, connectionEpoch)
+          : undefined,
+    };
+  }
+  const localSource = isLocalAssistantAttachmentSource(attachment.url);
+  const src = localSource
+    ? buildAssistantAttachmentUrl(
+        attachment.url,
+        resourceBasePath,
+        assistantAvailability.mediaTicket,
+      )
+    : isManagedOutgoingMediaSource(attachment.url)
+      ? applyResourceBasePath(managedAvailability.url, resourceBasePath)
+      : managedAvailability.url;
+  if (!src) {
+    return { status: "checking" as const, reason: undefined, onRetry: undefined };
+  }
+  const playback = assistantAvailability.playback ?? attachment.playback ?? "native";
+  return {
+    status: "available" as const,
+    source: {
+      src,
+      playback,
+      authToken: localSource ? (authToken ?? null) : null,
+      sizeBytes: assistantAvailability.sizeBytes ?? attachment.sizeBytes,
+      durationMs: assistantAvailability.durationMs ?? attachment.durationMs,
+      width: assistantAvailability.width ?? attachment.width,
+      height: assistantAvailability.height ?? attachment.height,
+    },
+  };
+}
+
 export function renderAssistantAttachments(
   attachments: AssistantAttachmentItem[],
   options: ImageRenderOptions,
@@ -354,16 +430,7 @@ export function renderAssistantAttachments(
   if (attachments.length === 0) {
     return nothing;
   }
-  const {
-    connectionEpoch,
-    localMediaPreviewRoots = [],
-    resourceBasePath,
-    authToken,
-    onRequestUpdate,
-    onRequestOpenImage,
-    onOpenImage,
-    resolveArtifactDownload,
-  } = options;
+  const { onRequestOpenImage, onOpenImage, resolveArtifactDownload } = options;
   const renderAttachment = (item: AssistantAttachmentItem) => {
     if (item.type === "attachment_error") {
       const { attachment } = item;
@@ -375,68 +442,21 @@ export function renderAssistantAttachments(
       });
     }
     const { attachment } = item;
-    const localSource = isLocalAssistantAttachmentSource(attachment.url);
-    const assistantAvailability = resolveAssistantAttachmentAvailability(
-      attachment.url,
-      localMediaPreviewRoots,
-      resourceBasePath,
-      authToken,
-      onRequestUpdate,
-    );
-    const managedAvailability =
-      assistantAvailability.status === "available"
-        ? resolveManagedAttachmentAvailability(
-            attachment,
-            resolveArtifactDownload,
-            onRequestUpdate,
-            connectionEpoch,
-          )
-        : null;
-    const availability =
-      assistantAvailability.status !== "available"
-        ? assistantAvailability
-        : managedAvailability?.status === "unavailable"
-          ? managedAvailability
-          : managedAvailability?.status === "checking"
-            ? managedAvailability
-            : assistantAvailability;
-    const attachmentUrl =
-      assistantAvailability.status === "available" && managedAvailability?.status === "available"
-        ? localSource
-          ? buildAssistantAttachmentUrl(
-              attachment.url,
-              resourceBasePath,
-              assistantAvailability.mediaTicket,
-            )
-          : isManagedOutgoingMediaSource(attachment.url)
-            ? applyResourceBasePath(managedAvailability.url, resourceBasePath)
-            : managedAvailability.url
-        : null;
-    const sizeBytes =
-      assistantAvailability.status === "available"
-        ? (assistantAvailability.sizeBytes ?? attachment.sizeBytes)
-        : attachment.sizeBytes;
-    const playback =
-      assistantAvailability.status === "available"
-        ? (assistantAvailability.playback ?? attachment.playback ?? "native")
-        : (attachment.playback ?? "native");
-    const serverDurationMs =
-      assistantAvailability.status === "available"
-        ? (assistantAvailability.durationMs ?? attachment.durationMs)
-        : attachment.durationMs;
-    const mediaWidth =
-      assistantAvailability.status === "available"
-        ? (assistantAvailability.width ?? attachment.width)
-        : attachment.width;
-    const mediaHeight =
-      assistantAvailability.status === "available"
-        ? (assistantAvailability.height ?? attachment.height)
-        : attachment.height;
-    const playbackAuthToken = localSource ? (authToken ?? null) : null;
+    const resolved = resolveAttachmentSource(attachment, options);
+    if (resolved.status !== "available") {
+      return renderAssistantAttachmentStatusCard({
+        label: attachment.label,
+        mimeType: attachment.mimeType,
+        badge: resolved.status === "unavailable" ? t("chat.attachments.unavailable") : "",
+        reason: resolved.status === "unavailable" ? resolved.reason : undefined,
+        onRetry: resolved.onRetry,
+      });
+    }
+    const { src: attachmentUrl, ...media } = resolved.source;
     const safeAttachmentUrl =
       attachment.kind === "audio" || attachment.kind === "video"
-        ? safeMediaAttachmentHref(attachmentUrl ?? "", attachment.kind)
-        : safeAttachmentHref(attachmentUrl ?? "");
+        ? safeMediaAttachmentHref(attachmentUrl, attachment.kind)
+        : safeAttachmentHref(attachmentUrl);
     const openVideoOverlay =
       attachment.kind === "video" && onOpenImage && safeAttachmentUrl
         ? (src: string) => {
@@ -455,24 +475,11 @@ export function renderAssistantAttachments(
           }
         : undefined;
     const hasLiveSidebarSource =
-      localSource ||
+      isLocalAssistantAttachmentSource(attachment.url) ||
       (isManagedOutgoingMediaSource(attachment.url) &&
         Boolean(attachment.artifactId && resolveArtifactDownload));
-    const retryUnavailableAttachment =
-      assistantAvailability.status === "unavailable" && assistantAvailability.recoverable
-        ? () =>
-            retryAssistantAttachmentAvailability(
-              attachment.url,
-              resourceBasePath,
-              authToken,
-              onRequestUpdate,
-            )
-        : managedAvailability?.status === "unavailable" &&
-            Boolean(attachment.artifactId && resolveArtifactDownload)
-          ? () => retryManagedAttachmentAvailability(attachment, onRequestUpdate, connectionEpoch)
-          : undefined;
     const openAttachmentSidebar =
-      onOpenSidebar && attachmentUrl && (hasLiveSidebarSource || safeAttachmentUrl)
+      onOpenSidebar && (hasLiveSidebarSource || safeAttachmentUrl)
         ? () =>
             onOpenSidebar({
               kind: "attachment",
@@ -481,68 +488,21 @@ export function renderAssistantAttachments(
               ...(hasLiveSidebarSource ? {} : { src: safeAttachmentUrl }),
               mimeType: attachment.mimeType,
               sourceIdentity: attachment.url,
-              playback,
-              authToken: playbackAuthToken,
-              sizeBytes,
-              durationMs: serverDurationMs,
-              width: mediaWidth,
-              height: mediaHeight,
+              ...media,
               voiceNote: attachment.isVoiceNote === true,
               ...(hasLiveSidebarSource
                 ? {
                     resolveSource: (sidebarUpdate, runtime) => {
-                      const nextAssistantAvailability = resolveAssistantAttachmentAvailability(
-                        attachment.url,
-                        runtime.localMediaPreviewRoots,
-                        runtime.resourceBasePath,
-                        runtime.authToken,
-                        sidebarUpdate,
-                      );
-                      if (nextAssistantAvailability.status !== "available") {
-                        return null;
-                      }
-                      const nextManagedAvailability = resolveManagedAttachmentAvailability(
-                        attachment,
-                        runtime.resolveArtifactDownload,
-                        sidebarUpdate,
-                        runtime.connectionEpoch,
-                      );
-                      if (nextManagedAvailability.status !== "available") {
-                        return null;
-                      }
-                      return {
-                        src: localSource
-                          ? buildAssistantAttachmentUrl(
-                              attachment.url,
-                              runtime.resourceBasePath,
-                              nextAssistantAvailability.mediaTicket,
-                            )
-                          : applyResourceBasePath(
-                              nextManagedAvailability.url,
-                              runtime.resourceBasePath,
-                            ),
-                        playback:
-                          nextAssistantAvailability.playback ?? attachment.playback ?? "native",
-                        authToken: localSource ? (runtime.authToken ?? null) : null,
-                        sizeBytes: nextAssistantAvailability.sizeBytes ?? attachment.sizeBytes,
-                        durationMs: nextAssistantAvailability.durationMs ?? attachment.durationMs,
-                        width: nextAssistantAvailability.width ?? attachment.width,
-                        height: nextAssistantAvailability.height ?? attachment.height,
-                      };
+                      const next = resolveAttachmentSource(attachment, {
+                        ...runtime,
+                        onRequestUpdate: sidebarUpdate,
+                      });
+                      return next.status === "available" ? next.source : null;
                     },
                   }
                 : {}),
             })
         : undefined;
-    if (!attachmentUrl) {
-      return renderAssistantAttachmentStatusCard({
-        label: attachment.label,
-        mimeType: attachment.mimeType,
-        badge: availability.status === "unavailable" ? t("chat.attachments.unavailable") : "",
-        reason: availability.status === "unavailable" ? availability.reason : undefined,
-        onRetry: retryUnavailableAttachment,
-      });
-    }
     const normalizedMimeType = attachment.mimeType?.split(";", 1)[0]?.trim().toLowerCase() ?? "";
     const inferTypeFromExtension =
       !normalizedMimeType || normalizedMimeType === "application/octet-stream";
@@ -571,7 +531,7 @@ export function renderAssistantAttachments(
           .sourceIdentity=${attachment.url}
           .label=${title}
           .mimeType=${attachment.mimeType ?? "image/svg+xml"}
-          .sizeBytes=${sizeBytes}
+          .sizeBytes=${media.sizeBytes}
           .downloadHref=${safeAttachmentHref(attachmentUrl)}
           .onOpen=${(src: string, release: () => void) =>
             openResolvedImage(onOpenImage, src, title, release, onRequestOpenImage?.())}
@@ -605,10 +565,10 @@ export function renderAssistantAttachments(
         .sourceIdentity=${attachment.url}
         .label=${attachment.label}
         .mimeType=${attachment.mimeType ?? ""}
-        .playback=${playback}
-        .authToken=${playbackAuthToken}
-        .sizeBytes=${sizeBytes}
-        .serverDurationMs=${serverDurationMs}
+        .playback=${media.playback}
+        .authToken=${media.authToken}
+        .sizeBytes=${media.sizeBytes}
+        .serverDurationMs=${media.durationMs}
         .voiceNote=${attachment.isVoiceNote === true}
         .onExpand=${openAttachmentSidebar}
         .onMediaLoaded=${onAssistantAttachmentLoaded}
@@ -620,11 +580,11 @@ export function renderAssistantAttachments(
         .sourceIdentity=${attachment.url}
         .label=${attachment.label}
         .mimeType=${attachment.mimeType ?? ""}
-        .playback=${playback}
-        .authToken=${playbackAuthToken}
-        .sizeBytes=${sizeBytes}
-        .mediaWidth=${mediaWidth}
-        .mediaHeight=${mediaHeight}
+        .playback=${media.playback}
+        .authToken=${media.authToken}
+        .sizeBytes=${media.sizeBytes}
+        .mediaWidth=${media.width}
+        .mediaHeight=${media.height}
         .onExpand=${openVideoOverlay}
         .onFallbackExpand=${openAttachmentSidebar}
         .onMediaLoaded=${onAssistantAttachmentLoaded}
@@ -634,7 +594,7 @@ export function renderAssistantAttachments(
       kind: attachment.kind,
       label: attachment.label,
       mimeType: attachment.mimeType,
-      sizeBytes,
+      sizeBytes: media.sizeBytes,
       downloadHref: safeAttachmentUrl,
       onExpand: openAttachmentSidebar,
       voiceNote: attachment.isVoiceNote === true,

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -38,9 +38,7 @@ import { renderMessageImages, resolveRenderableMessageImages } from "./chat-mess
 import {
   detectJson,
   jsonSummaryLabel,
-  renderAssistantMessageMarkdown,
-  renderMarkdownText,
-  renderUserMessageMarkdown,
+  renderMessageMarkdown,
   resolveMessageDisplayMarkdown,
   type AssistantMessageDisclosure,
 } from "./chat-message-markdown.ts";
@@ -383,7 +381,6 @@ export function renderGroupedMessage(
       ? html`${assistantViewBlocks.map(
           (block) => html`<div class="chat-tool-card__widget-host">
             ${renderToolPreview(block.preview, "chat_message", {
-              onOpenSidebar,
               rawText: block.rawText ?? null,
               canvasPluginSurfaceUrl: opts.canvasPluginSurfaceUrl,
               boardProvider: opts.boardProvider,
@@ -455,29 +452,13 @@ export function renderGroupedMessage(
           <pre class="chat-json-content"><code>${jsonResult.text}</code></pre>
         </details>`
       : bodyMarkdown
-        ? !isStandaloneToolMessage && normalizedRole === "user"
-          ? renderUserMessageMarkdown(
-              bodyMarkdown,
-              messageKey,
-              opts,
-              markdownRenderOptions,
-              duplicateSuffix,
-            )
-          : !isStandaloneToolMessage && normalizedRole === "assistant"
-            ? renderAssistantMessageMarkdown(
-                bodyMarkdown,
-                opts.isStreaming,
-                opts.assistantMessageDisclosure,
-                markdownRenderOptions,
-                duplicateSuffix,
-                opts.isStreaming ? messageKey : undefined,
-              )
-            : renderMarkdownText(
-                bodyMarkdown,
-                opts.isStreaming,
-                markdownRenderOptions,
-                duplicateSuffix,
-              )
+        ? renderMessageMarkdown(
+            bodyMarkdown,
+            messageKey,
+            { ...opts, role: isStandaloneToolMessage ? "tool" : normalizedRole },
+            markdownRenderOptions,
+            duplicateSuffix,
+          )
         : nothing}
     ${hasToolCards
       ? isStandaloneToolMessage && expandsSingleToolCard && singleToolCard

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -122,16 +122,18 @@ function requestMissingFullMessage(
   details: MessageActionDetails | null,
   opts: RenderMessageGroupOptions,
 ) {
-  if (!details?.shouldFetchFullMessage || !details.messageId) {
+  const messageId = details?.fullMessage?.messageId;
+  if (!messageId) {
     return;
   }
-  const expansion = opts.getAssistantMessageExpansion?.(details.messageId);
+  // Projected rows can share a source ID; a preceding row may have started its load.
+  const expansion = opts.getAssistantMessageExpansion?.(messageId);
   // Retry transient failures on later renders, bounded so a dead loader cannot hot-loop.
   if (
     !expansion ||
     (expansion.status === "error" && expansion.revision < FULL_MESSAGE_RETRY_REVISION_LIMIT)
   ) {
-    opts.onToggleAssistantMessageExpanded?.(details.messageId);
+    opts.onToggleAssistantMessageExpanded?.(messageId);
   }
 }
 
@@ -143,19 +145,14 @@ function buildGroupedMessageRenderOptions(
   actionDetails?: MessageActionDetails | null,
 ): GroupedMessageRenderOptions {
   let assistantMessageDisclosure: AssistantMessageDisclosure | undefined;
-  if (
-    actionDetails?.shouldFetchFullMessage &&
-    actionDetails.messageId &&
-    opts.loadFullAssistantMessage &&
-    opts.onToggleAssistantMessageExpanded
-  ) {
-    const messageId = actionDetails.messageId;
-    const expansion = opts.getAssistantMessageExpansion?.(messageId);
+  const fullMessage = actionDetails?.fullMessage;
+  if (fullMessage && opts.loadFullAssistantMessage && opts.onToggleAssistantMessageExpanded) {
+    const { messageId, state: expansion } = fullMessage;
     const retriesExhausted =
       expansion?.status === "error" && expansion.revision >= FULL_MESSAGE_RETRY_REVISION_LIMIT;
     assistantMessageDisclosure = {
       expanded: expansion?.status === "loaded",
-      ...(expansion?.status === "loaded" ? { markdown: actionDetails.markdown } : {}),
+      ...(expansion?.status === "loaded" ? { markdown: actionDetails?.markdown } : {}),
       // Manual re-entry once the bounded automatic retries gave up.
       ...(retriesExhausted
         ? { onRetryFullMessage: () => opts.onToggleAssistantMessageExpanded?.(messageId) }

--- a/ui/src/pages/chat/components/chat-message-markdown.test.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.test.ts
@@ -1,32 +1,29 @@
 /* @vitest-environment jsdom */
-// Contract for the full-message fetch flag: the Gateway marks every display-
+// Contract for full-message eligibility: the Gateway marks every display-
 // capped projection; pending inputs share assistant expansion without gaining
 // transcript mutation actions.
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { persistedMessageEntryId } from "../chat-thread-items.ts";
-import { renderUserMessageMarkdown, resolveMessageActionDetails } from "./chat-message-markdown.ts";
+import { renderMessageMarkdown, resolveMessageActionDetails } from "./chat-message-markdown.ts";
 
 const cappedMeta = { id: "msg-1", truncated: true, reason: "display-cap" };
 
-describe("resolveMessageActionDetails full-message fetch flag", () => {
+describe("resolveMessageActionDetails full-message eligibility", () => {
   it.each([
     { role: "assistant", id: "msg-1", shouldFetch: true },
     { role: "user", id: "msg-1", shouldFetch: false },
     { role: "user", id: "pending:input-1", shouldFetch: true },
-  ])(
-    "role=$role capped by metadata -> shouldFetchFullMessage=$shouldFetch",
-    ({ role, id, shouldFetch }) => {
-      const details = resolveMessageActionDetails({
-        message: { role, content: "Preview\n...(truncated)...", __openclaw: { ...cappedMeta, id } },
-        messageId: "msg-1",
-        canFetchFullMessage: true,
-        onReply: () => {},
-        senderLabel: role,
-      });
-      expect(details?.shouldFetchFullMessage).toBe(shouldFetch);
-    },
-  );
+  ])("role=$role capped by metadata -> eligible=$shouldFetch", ({ role, id, shouldFetch }) => {
+    const details = resolveMessageActionDetails({
+      message: { role, content: "Preview\n...(truncated)...", __openclaw: { ...cappedMeta, id } },
+      messageId: "msg-1",
+      canFetchFullMessage: true,
+      onReply: () => {},
+      senderLabel: role,
+    });
+    expect(details?.fullMessage?.messageId).toBe(shouldFetch ? id : undefined);
+  });
 
   it("expands accepted user text without granting transcript reply or rewind identity", () => {
     const message = {
@@ -64,7 +61,7 @@ describe("resolveMessageActionDetails full-message fetch flag", () => {
       canFetchFullMessage: true,
       senderLabel: "assistant",
     });
-    expect(details?.shouldFetchFullMessage).toBe(false);
+    expect(details?.fullMessage).toBeUndefined();
   });
 
   it("does not fetch an untruncated assistant message", () => {
@@ -74,7 +71,7 @@ describe("resolveMessageActionDetails full-message fetch flag", () => {
       canFetchFullMessage: true,
       senderLabel: "assistant",
     });
-    expect(details?.shouldFetchFullMessage).toBe(false);
+    expect(details?.fullMessage).toBeUndefined();
   });
 
   it("projects an oversized assistant marker to a notice without disabling recovery", () => {
@@ -91,7 +88,7 @@ describe("resolveMessageActionDetails full-message fetch flag", () => {
       senderLabel: "assistant",
     });
 
-    expect(details?.shouldFetchFullMessage).toBe(true);
+    expect(details?.fullMessage?.messageId).toBe("msg-oversized");
     expect(details?.markdown).toBe("This message is too large to display here.");
     expect(details?.replyTarget?.text).toBe("This message is too large to display here.");
 
@@ -108,7 +105,7 @@ describe("resolveMessageActionDetails full-message fetch flag", () => {
       senderLabel: "assistant",
     });
 
-    expect(loaded?.shouldFetchFullMessage).toBe(true);
+    expect(loaded?.fullMessage?.messageId).toBe("msg-oversized");
     expect(loaded?.markdown).toBe("Recovered full assistant content.");
     expect(loaded?.replyTarget?.text).toBe("Recovered full assistant content.");
   });
@@ -134,10 +131,10 @@ describe("user message disclosure", () => {
     const container = document.createElement("div");
 
     render(
-      renderUserMessageMarkdown(
+      renderMessageMarkdown(
         markdown,
         "message",
-        { isStreaming: false, onToggleUserMessageExpanded: vi.fn() },
+        { role: "user", isStreaming: false, onToggleUserMessageExpanded: vi.fn() },
         {},
       ),
       container,

--- a/ui/src/pages/chat/components/chat-message-markdown.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.ts
@@ -80,9 +80,8 @@ export function jsonSummaryLabel(parsed: unknown): string {
 
 export type MessageActionDetails = {
   markdown?: string;
-  messageId?: string;
+  fullMessage?: { messageId: string; state: AssistantMessageExpansionState | undefined };
   replyTarget?: MessageReplyTarget;
-  shouldFetchFullMessage: boolean;
 };
 
 function resolveNormalizedMessageMarkdown(normalizedMessage: NormalizedMessage): string {
@@ -127,12 +126,7 @@ export function resolveMessageActionDetails(params: {
 }): MessageActionDetails | null {
   const { message, messageId: renderMessageId, canFetchFullMessage, onReply, senderLabel } = params;
   const record = message as Record<string, unknown>;
-  const transcriptMeta =
-    record["__openclaw"] &&
-    typeof record["__openclaw"] === "object" &&
-    !Array.isArray(record["__openclaw"])
-      ? (record["__openclaw"] as Record<string, unknown>)
-      : null;
+  const transcriptMeta = asNullableRecord(record["__openclaw"]);
   const messageId =
     typeof transcriptMeta?.id === "string"
       ? transcriptMeta.id
@@ -147,29 +141,27 @@ export function resolveMessageActionDetails(params: {
   // that marker is the whole contract: sniffing the in-band sentinel would fetch
   // for any reply that merely contains the text. Pending user inputs share the
   // same read-only expansion, without becoming transcript reply/rewind targets.
-  const shouldFetchFullMessage = Boolean(
+  const fullMessage =
     (role === "assistant" || pendingInput) &&
     canFetchFullMessage &&
     messageId &&
     !record.openclawMessageToolMirror &&
-    transcriptMeta?.truncated === true,
-  );
-  const expansion =
-    shouldFetchFullMessage && messageId
-      ? params.getAssistantMessageExpansion?.(messageId)
+    transcriptMeta?.truncated === true
+      ? { messageId, state: params.getAssistantMessageExpansion?.(messageId) }
       : undefined;
+  const expansion = fullMessage?.state;
   const expandedMarkdown = expansion?.status === "loaded" ? expansion.markdown : previewMarkdown;
   const visibleMarkdown =
     role === "assistant" ? stripThinkingTags(expandedMarkdown).trim() : expandedMarkdown;
   const markdown = role === "assistant" || pendingInput ? visibleMarkdown : undefined;
   const replyText = onReply && !pendingInput ? truncateUtf16Safe(visibleMarkdown, 500) : "";
-  if (!markdown && !replyText && !shouldFetchFullMessage) {
+  if (!markdown && !replyText && !fullMessage) {
     return null;
   }
   const sourceMessageId = persistedMessageEntryId(message);
   return {
     ...(markdown === undefined ? {} : { markdown }),
-    messageId,
+    fullMessage,
     ...(replyText
       ? {
           replyTarget: {
@@ -180,7 +172,6 @@ export function resolveMessageActionDetails(params: {
           },
         }
       : {}),
-    shouldFetchFullMessage,
   };
 }
 
@@ -258,10 +249,11 @@ function userMessageOverflowRef(expanded: boolean) {
   };
 }
 
-export function renderUserMessageMarkdown(
+export function renderMessageMarkdown(
   markdown: string,
   messageKey: string,
   opts: {
+    role: string;
     isStreaming: boolean;
     isUserMessageExpanded?: (messageId: string) => boolean;
     onToggleUserMessageExpanded?: (messageId: string) => void;
@@ -270,17 +262,40 @@ export function renderUserMessageMarkdown(
   markdownRenderOptions: MarkdownRenderOptions,
   duplicateSuffix?: DuplicateSuffix,
 ) {
-  if (opts.assistantMessageDisclosure?.onRetryFullMessage) {
-    return renderAssistantMessageMarkdown(
-      markdown,
-      opts.isStreaming,
-      opts.assistantMessageDisclosure,
-      markdownRenderOptions,
-      duplicateSuffix,
-    );
+  const disclosure = opts.assistantMessageDisclosure;
+  const isAssistant = opts.role === "assistant";
+  const recoverFullMessage =
+    isAssistant || (opts.role === "user" && disclosure?.onRetryFullMessage);
+  const recovered = recoverFullMessage && disclosure?.expanded;
+  const text = renderMarkdownText(
+    recovered ? (disclosure.markdown ?? markdown) : markdown,
+    opts.isStreaming,
+    recovered ? { ...markdownRenderOptions, mode: "document" } : markdownRenderOptions,
+    duplicateSuffix,
+    isAssistant && opts.isStreaming ? messageKey : undefined,
+  );
+  // Exhausted recovery keeps the preview visible and offers manual re-entry.
+  if (recoverFullMessage && disclosure?.onRetryFullMessage) {
+    return html`
+      ${text}
+      <div class="chat-message-load-error">
+        ${t("chat.messages.fullContentLoadExhausted")}
+        <button
+          type="button"
+          class="chat-message-load-error__retry"
+          @click=${disclosure.onRetryFullMessage}
+        >
+          ${t("common.retry")}
+        </button>
+      </div>
+    `;
   }
-  if (!opts.onToggleUserMessageExpanded || !shouldCollapseUserMessage(markdown)) {
-    return renderMarkdownText(markdown, opts.isStreaming, markdownRenderOptions, duplicateSuffix);
+  if (
+    opts.role !== "user" ||
+    !opts.onToggleUserMessageExpanded ||
+    !shouldCollapseUserMessage(markdown)
+  ) {
+    return text;
   }
 
   const disclosureId = `user-message:${messageKey}`;
@@ -288,7 +303,7 @@ export function renderUserMessageMarkdown(
   return html`
     <div class="chat-message-disclosure ${expanded ? "is-expanded has-overflow" : ""}">
       <div class="chat-message-disclosure__content" ${ref(userMessageOverflowRef(expanded))}>
-        ${renderMarkdownText(markdown, opts.isStreaming, markdownRenderOptions, duplicateSuffix)}
+        ${text}
       </div>
       <button
         class="chat-message-disclosure__toggle"
@@ -311,42 +326,7 @@ export type AssistantMessageDisclosure = {
   onRetryFullMessage?: () => void;
 };
 
-export function renderAssistantMessageMarkdown(
-  previewMarkdown: string,
-  isStreaming: boolean,
-  disclosure: AssistantMessageDisclosure | undefined,
-  markdownRenderOptions: MarkdownRenderOptions,
-  duplicateSuffix?: DuplicateSuffix,
-  streamKey?: string,
-) {
-  const markdown = disclosure?.expanded
-    ? (disclosure.markdown ?? previewMarkdown)
-    : previewMarkdown;
-  const renderOptions = disclosure?.expanded
-    ? { ...markdownRenderOptions, mode: "document" as const }
-    : markdownRenderOptions;
-  const text = renderMarkdownText(markdown, isStreaming, renderOptions, duplicateSuffix, streamKey);
-  if (!disclosure?.onRetryFullMessage) {
-    return text;
-  }
-  // Exhausted automatic retries must not leave a silent truncated preview:
-  // name the failure and offer a manual re-entry into the loader.
-  return html`
-    ${text}
-    <div class="chat-message-load-error">
-      ${t("chat.messages.fullContentLoadExhausted")}
-      <button
-        type="button"
-        class="chat-message-load-error__retry"
-        @click=${disclosure.onRetryFullMessage}
-      >
-        ${t("common.retry")}
-      </button>
-    </div>
-  `;
-}
-
-export function renderMarkdownText(
+function renderMarkdownText(
   markdown: string,
   isStreaming: boolean,
   markdownRenderOptions?: MarkdownRenderOptions,

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -6181,6 +6181,36 @@ describe("grouped chat rendering", () => {
     },
   );
 
+  it("admits one full-message load for repeated source projections in a group", () => {
+    const container = document.createElement("div");
+    const previews = ["First projection", "Updated projection"];
+    let loading = false;
+    const onToggleAssistantMessageExpanded = vi.fn(() => {
+      loading = true;
+    });
+    renderAssistantMessages(
+      container,
+      previews.map((text) =>
+        createAssistantMessage(text, {
+          __openclaw: { id: "shared-source", truncated: true },
+        }),
+      ),
+      {
+        sessionKey: "global",
+        loadFullAssistantMessage: async () => null,
+        getAssistantMessageExpansion: () =>
+          loading ? { status: "loading", revision: 1 } : undefined,
+        onToggleAssistantMessageExpanded,
+      },
+    );
+
+    expect(onToggleAssistantMessageExpanded).toHaveBeenCalledTimes(1);
+    expect(onToggleAssistantMessageExpanded).toHaveBeenCalledWith("shared-source");
+    expect(
+      [...container.querySelectorAll(".chat-text")].map((element) => element.textContent),
+    ).toEqual(previews);
+  });
+
   it.each([
     { state: { status: "error" as const, revision: 2 }, retries: true, label: "bounded error" },
     { state: { status: "error" as const, revision: 6 }, retries: false, label: "exhausted error" },

--- a/ui/src/pages/chat/components/chat-selection-popup.ts
+++ b/ui/src/pages/chat/components/chat-selection-popup.ts
@@ -9,8 +9,7 @@ type ChatSelectionPopupActions = {
   onAskSideChat: (selection: string) => void;
 };
 
-let activeSelectionPopup: HTMLDivElement | null = null;
-let removeDismissListeners: (() => void) | null = null;
+let activeSelectionPopup: { element: HTMLDivElement; listeners: AbortController } | null = null;
 let selectionPopupTimer: number | null = null;
 
 export function removeChatSelectionPopup() {
@@ -20,10 +19,9 @@ export function removeChatSelectionPopup() {
     window.clearTimeout(selectionPopupTimer);
     selectionPopupTimer = null;
   }
-  activeSelectionPopup?.remove();
+  activeSelectionPopup?.element.remove();
+  activeSelectionPopup?.listeners.abort();
   activeSelectionPopup = null;
-  removeDismissListeners?.();
-  removeDismissListeners = null;
 }
 
 function selectionTextWithinChatBubble(
@@ -110,7 +108,8 @@ function showChatSelectionPopup(
     ),
   );
   document.body.appendChild(popup);
-  activeSelectionPopup = popup;
+  const listeners = new AbortController();
+  activeSelectionPopup = { element: popup, listeners };
 
   const popupRect = popup.getBoundingClientRect();
   let left = selectionRect.left + selectionRect.width / 2 - popupRect.width / 2;
@@ -141,16 +140,11 @@ function showChatSelectionPopup(
   // The popup is position:fixed against a since-scrolled selection rect;
   // dismiss instead of chasing the text.
   const handleScroll = () => removeChatSelectionPopup();
-  document.addEventListener("pointerdown", handlePointerDown, true);
-  document.addEventListener("selectionchange", handleSelectionChange);
-  document.addEventListener("keydown", handleKeydown);
-  document.addEventListener("scroll", handleScroll, { capture: true, passive: true });
-  removeDismissListeners = () => {
-    document.removeEventListener("pointerdown", handlePointerDown, true);
-    document.removeEventListener("selectionchange", handleSelectionChange);
-    document.removeEventListener("keydown", handleKeydown);
-    document.removeEventListener("scroll", handleScroll, { capture: true });
-  };
+  const { signal } = listeners;
+  document.addEventListener("pointerdown", handlePointerDown, { capture: true, signal });
+  document.addEventListener("selectionchange", handleSelectionChange, { signal });
+  document.addEventListener("keydown", handleKeydown, { signal });
+  document.addEventListener("scroll", handleScroll, { capture: true, passive: true, signal });
 }
 
 export function handleChatSelectionPointerUp(

--- a/ui/src/pages/chat/components/chat-svg-attachment.ts
+++ b/ui/src/pages/chat/components/chat-svg-attachment.ts
@@ -2,7 +2,7 @@ import { html, nothing, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import { t } from "../../../i18n/index.ts";
 import { OpenClawLightDomContentsElement } from "../../../lit/openclaw-element.ts";
-import { openAttachmentCardFromClick, renderAttachmentCardHeader } from "./chat-attachment-card.ts";
+import { renderCompactAttachmentCard } from "./chat-attachment-card.ts";
 import { observeChatAttachmentViewport } from "./chat-attachment-viewport.ts";
 import { readResponseBytesWithinLimit } from "./chat-response-bytes.ts";
 
@@ -13,7 +13,6 @@ type SvgRenderSource = {
   url: string;
   retainCount: number;
   retired: boolean;
-  revokeOnRetire: boolean;
 };
 
 function isCrossOriginHttpSource(source: string): boolean {
@@ -82,7 +81,7 @@ class ChatSvgAttachment extends OpenClawLightDomContentsElement {
 
   private retireSource(source: SvgRenderSource): void {
     source.retired = true;
-    if (source.revokeOnRetire && source.retainCount === 0) {
+    if (source.retainCount === 0) {
       URL.revokeObjectURL(source.url);
     }
   }
@@ -106,7 +105,7 @@ class ChatSvgAttachment extends OpenClawLightDomContentsElement {
       }
       released = true;
       source.retainCount = Math.max(0, source.retainCount - 1);
-      if (source.revokeOnRetire && source.retired && source.retainCount === 0) {
+      if (source.retired && source.retainCount === 0) {
         URL.revokeObjectURL(source.url);
       }
     };
@@ -166,7 +165,6 @@ class ChatSvgAttachment extends OpenClawLightDomContentsElement {
         url: blobUrl,
         retainCount: 0,
         retired: false,
-        revokeOnRetire: true,
       };
     } catch {
       if (version === this.loadVersion) {
@@ -204,21 +202,14 @@ class ChatSvgAttachment extends OpenClawLightDomContentsElement {
 
   override render() {
     if (this.failed) {
-      return html`<div
-        class="chat-assistant-attachment-card chat-assistant-attachment-card--compact"
-        ?data-openable=${Boolean(this.onExpand)}
-        @click=${(event: MouseEvent) => openAttachmentCardFromClick(event, this.onExpand)}
-      >
-        ${renderAttachmentCardHeader({
-          kind: "document",
-          label: this.label,
-          mimeType: this.mimeType,
-          sizeBytes: this.sizeBytes,
-          downloadHref: this.downloadHref,
-          onExpand: this.onExpand,
-          visualMode: "large-placeholder",
-        })}
-      </div>`;
+      return renderCompactAttachmentCard({
+        kind: "document",
+        label: this.label,
+        mimeType: this.mimeType,
+        sizeBytes: this.sizeBytes,
+        downloadHref: this.downloadHref,
+        onExpand: this.onExpand,
+      });
     }
     const renderSource = this.renderSource;
     if (!renderSource) {

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -316,39 +316,28 @@ export function toggleTranscriptSearch(
   requestUpdate();
 }
 
-let activeReplyContextMenu: HTMLElement | null = null;
-let activeReplyContextMenuPaneId: string | null = null;
-let contextMenuDocumentClickHandler: ((event: MouseEvent) => void) | null = null;
-let contextMenuDocumentContextMenuHandler: ((event: MouseEvent) => void) | null = null;
-let contextMenuKeydownHandler: ((event: KeyboardEvent) => void) | null = null;
+let activeReplyContextMenu: {
+  element: HTMLElement;
+  paneId: string;
+  listeners: AbortController;
+} | null = null;
 
 function removeReplyContextMenu(paneId?: string) {
-  if (paneId && paneId !== activeReplyContextMenuPaneId) {
+  const owner = activeReplyContextMenu;
+  if (paneId && paneId !== owner?.paneId) {
     return;
   }
-  if (activeReplyContextMenu) {
-    dismissConfirmedActionPopovers(activeReplyContextMenu);
-    activeReplyContextMenu.remove();
+  if (owner) {
+    dismissConfirmedActionPopovers(owner.element);
+    owner.element.remove();
   }
   activeReplyContextMenu = null;
-  activeReplyContextMenuPaneId = null;
   const fallbackMenu = document.querySelector<HTMLElement>(".chat-reply-context-menu");
   if (fallbackMenu) {
     dismissConfirmedActionPopovers(fallbackMenu);
     fallbackMenu.remove();
   }
-  if (contextMenuDocumentClickHandler) {
-    document.removeEventListener("click", contextMenuDocumentClickHandler);
-    contextMenuDocumentClickHandler = null;
-  }
-  if (contextMenuDocumentContextMenuHandler) {
-    document.removeEventListener("contextmenu", contextMenuDocumentContextMenuHandler, true);
-    contextMenuDocumentContextMenuHandler = null;
-  }
-  if (contextMenuKeydownHandler) {
-    document.removeEventListener("keydown", contextMenuKeydownHandler);
-    contextMenuKeydownHandler = null;
-  }
+  owner?.listeners.abort();
 }
 
 function stableReplyMessageId(senderLabel: string | undefined, text: string): string {
@@ -587,8 +576,8 @@ export function handleTranscriptContextMenu(event: MouseEvent, props: Transcript
     focusCandidates.push(action.button);
   }
   document.body.appendChild(menu);
-  activeReplyContextMenu = menu;
-  activeReplyContextMenuPaneId = props.paneId;
+  const owner = { element: menu, paneId: props.paneId, listeners: new AbortController() };
+  activeReplyContextMenu = owner;
 
   const menuRect = menu.getBoundingClientRect();
   let left = event.clientX;
@@ -603,15 +592,10 @@ export function handleTranscriptContextMenu(event: MouseEvent, props: Transcript
   menu.style.top = `${Math.max(0, top)}px`;
   focusCandidates.find((button) => !button.disabled)?.focus();
   requestAnimationFrame(() => {
-    if (!menu.isConnected || activeReplyContextMenu !== menu) {
+    if (!menu.isConnected || activeReplyContextMenu !== owner) {
       return;
     }
-    contextMenuDocumentClickHandler = (nextEvent: MouseEvent) => {
-      if (!menu.contains(nextEvent.target as Node | null)) {
-        removeReplyContextMenu();
-      }
-    };
-    contextMenuDocumentContextMenuHandler = (nextEvent: MouseEvent) => {
+    const handleOutsideEvent = (nextEvent: MouseEvent) => {
       if (!menu.contains(nextEvent.target as Node | null)) {
         removeReplyContextMenu();
       }
@@ -624,10 +608,10 @@ export function handleTranscriptContextMenu(event: MouseEvent, props: Transcript
         props.onFocusComposer?.();
       }
     };
-    contextMenuKeydownHandler = handleKeydown;
-    document.addEventListener("click", contextMenuDocumentClickHandler);
+    const { signal } = owner.listeners;
+    document.addEventListener("click", handleOutsideEvent, { signal });
     // Capture closes this owner even when the next menu stops event propagation.
-    document.addEventListener("contextmenu", contextMenuDocumentContextMenuHandler, true);
-    document.addEventListener("keydown", handleKeydown);
+    document.addEventListener("contextmenu", handleOutsideEvent, { capture: true, signal });
+    document.addEventListener("keydown", handleKeydown, { signal });
   });
 }

--- a/ui/src/pages/chat/components/chat-tool-cards.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.test.ts
@@ -1059,7 +1059,6 @@ describe("tool-cards", () => {
         },
         {
           expanded: true,
-          sessionKey: "main",
           onToggleExpanded: vi.fn(),
           onOpenSidebar,
         },

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -33,11 +33,7 @@ import {
   resolveToolCardOutcome,
   type ToolPreview,
 } from "../../../lib/chat/tool-cards.ts";
-import {
-  formatToolDetail,
-  resolveToolDisplay,
-  type EmbedSandboxMode,
-} from "../../../lib/chat/tool-display.ts";
+import { formatToolDetail, resolveToolDisplay } from "../../../lib/chat/tool-display.ts";
 import { getToolCallTitle } from "../tool-titles.ts";
 import { renderDiffBlock, renderDiffStatChips } from "./chat-diff-render.ts";
 import type { SidebarContent } from "./chat-sidebar.ts";
@@ -840,12 +836,8 @@ export function renderToolApprovalReviews(card: ToolCard) {
 
 type ToolCardRenderOptions = {
   runActive?: boolean;
-  sessionKey?: string;
   onOpenSidebar?: (content: SidebarContent) => void;
   onOpenWorkspaceFile?: (target: { path: string; line?: number | null }) => void;
-  canvasPluginSurfaceUrl?: string | null;
-  embedSandboxMode?: EmbedSandboxMode;
-  allowExternalEmbedUrls?: boolean;
 };
 
 export function renderToolCard(
@@ -930,15 +922,7 @@ export function renderToolCard(
 
 export function renderExpandedToolCardContent(
   card: ToolCard,
-  {
-    sessionKey,
-    onOpenSidebar,
-    canvasPluginSurfaceUrl,
-    embedSandboxMode = "scripts",
-    allowExternalEmbedUrls = false,
-    runActive,
-    onOpenWorkspaceFile,
-  }: ToolCardRenderOptions,
+  { onOpenSidebar, runActive, onOpenWorkspaceFile }: ToolCardRenderOptions,
 ) {
   const view = resolveToolCallView({ name: card.name, args: card.args, details: card.details });
   const display = resolveToolDisplay({ name: card.name, args: card.args });
@@ -966,17 +950,6 @@ export function renderExpandedToolCardContent(
     buildSidebarContent(buildToolCardSidebarContent(card), {
       rawText: card.outputText ?? null,
     });
-  const visiblePreview =
-    card.preview?.kind === "canvas"
-      ? renderToolPreview(card.preview, "chat_tool", {
-          onOpenSidebar,
-          rawText: card.outputText,
-          canvasPluginSurfaceUrl,
-          embedSandboxMode,
-          allowExternalEmbedUrls,
-          sessionKey,
-        })
-      : nothing;
   const sidebarAction = canOpenSidebar
     ? html`
         <openclaw-tooltip content=${t("chat.toolCards.openDetails")}>
@@ -1069,7 +1042,7 @@ export function renderExpandedToolCardContent(
         : nothing}
       ${hasOutput
         ? card.preview?.kind === "canvas"
-          ? html`${visiblePreview} ${renderRawOutputToggle(card.outputText!)}`
+          ? renderRawOutputToggle(card.outputText!)
           : renderToolDataBlock({
               ...(isError ? { label: t("chat.toolCards.toolError") } : {}),
               text: card.outputText!,

--- a/ui/src/pages/chat/components/widget-card.ts
+++ b/ui/src/pages/chat/components/widget-card.ts
@@ -25,7 +25,6 @@ import {
 } from "../../../lib/chat/tool-display.ts";
 import { showToast } from "../../../lib/toast.ts";
 import { installWidgetThemeObserver, postWidgetTheme } from "../../../lib/widget-theme.ts";
-import type { SidebarContent } from "./chat-sidebar.ts";
 import { exportWidget } from "./widget-export.ts";
 import "./browser-tab-card.ts";
 
@@ -33,7 +32,6 @@ export { WIDGET_PROMPT_EVENT };
 export type { WidgetPromptEventDetail };
 
 type WidgetCardOptions = {
-  onOpenSidebar?: (content: SidebarContent) => void;
   rawText?: string | null;
   canvasPluginSurfaceUrl?: string | null;
   embedSandboxMode?: EmbedSandboxMode;
@@ -533,7 +531,7 @@ function renderWidgetActions(preview: CanvasToolPreview, hasRawDetails: boolean)
 
 function renderWidgetCard(
   preview: ToolPreview | undefined,
-  surface: "chat_tool" | "chat_message" | "sidebar",
+  surface: "chat_tool" | "chat_message",
   options?: WidgetCardOptions,
 ) {
   if (!preview) {
@@ -548,11 +546,7 @@ function renderWidgetCard(
         ></openclaw-browser-tab-card>`
       : nothing;
   }
-  if (
-    preview.kind !== "canvas" ||
-    surface === "chat_tool" ||
-    (preview.mcpApp && surface !== "chat_message")
-  ) {
+  if (preview.kind !== "canvas" || surface === "chat_tool") {
     return nothing;
   }
   if (preview.surface !== "assistant_message") {


### PR DESCRIPTION
## What Problem This Solves

Continues the maintainer-requested cleanup of Control UI chat after #133508. Composer inputs remained duplicated, transcript and Files views independently resolved the same attachment sources, and menu/listener state was spread across globals. Full-message rendering and tool previews also retained repeated or unreachable paths.

## Why This Change Was Made

The chat view inherits its existing composer contract. One attachment-source projection serves transcript and Files consumers using each owner's current runtime. Popup listeners retire with their menu owner, while render-scope identity replaces a redundant epoch. Full-message render data is prepared once and Markdown dispatch shares one renderer; request admission still rereads state because different projected rows can share a source ID.

Remove the unreachable tool-row canvas preview and unused options, duplicate SVG fallback markup, single-store settings wrappers, a one-field outbox wrapper, and redundant attachment-release bookkeeping. Frame admission uses one append path with unchanged failure ordering. Persistence formats, configuration, protocol, dependencies, media authorization, retry budgets, and asynchronous send boundaries are unchanged.

Production: +256/-568 (**312 lines removed**). Tests: +49/-23 (**26 lines added**). Type-assertion baseline counts shrink to match removed assertions.

## User Impact

No intended behavior or visual change. Composer actions, uncertain-send Retry/Discard, attachment previews, copy/reply actions, tool details, and session lifecycle use fewer independent implementations.

## Evidence

- Seven independent discovery lanes and cross-reviews covered current owners, callers, sibling paths, history and dependency contracts.
- 1,233 focused tests passed: 1,200 normal UI cases plus 33 isolated transcript and attachment-handoff cases. Added coverage ensures repeated source projections admit one full-message load and retain both previews.
- Production UI build and bundle-size budgets passed. After a patch-identical rebase onto current main, the rebuild, 464 focused integration tests, and 8 queue/transcript browser scenarios also passed.
- 49 browser scenarios passed across media files, queue recovery, tool outcomes, message actions, managed images/base paths, and agent-run transcript grouping.
- Fresh Codex autoreview at the repository P0 threshold found no actionable defects.
- Changed-file guards, formatting, dead-export scans, core/UI typechecks, and full core/UI lint passed. The gate exposed two stale assertion-baseline counts, one now-internal type export, and metadata-access style; each was corrected.

Before/after captures show the same synthetic tool-detail surface from the built UI with a mocked Gateway. Both captures were inspected in full and show matching layout. Upload is blocked: after the GitHub upload rate limit reset, the approved CLI publication guard rejected the attachment command as unsafe input. Captures remain local; no alternate route was used to bypass that guard. No production deployment was changed.

## Follow-up noted during source review

The nested Rewind confirmation's checkbox interaction deserves a focused reproduction: its body-portaled click may reach the parent menu's outside-click handler. Existing nested coverage checks Escape. This behavior predates the listener-owner refactor, which preserves the same containment and event rules; no defect or fix is claimed here.
