### PR TITLE
test: isolate shared /tmp session-store paths in runner and health suites

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildPreparedCliRunContext } from "../../agents/cli-runner.test-helpers.js";
 import { executeDeps } from "../../agents/cli-runner/execute-deps.js";
@@ -24,6 +25,7 @@ import {
   expectMockCallArgFields,
   initialFallbackAttemptOptions,
   createMinimalRunAgentTurnParams,
+  makeTestSessionStorePath,
 } from "./agent-runner-execution.test-support.js";
 import type { FallbackRunnerParams } from "./agent-runner-execution.test-support.js";
 
@@ -522,9 +524,10 @@ describe("executeAgentTurn: CLI session routing", () => {
       MediaTypes: ["image/png"],
     } as never;
     followupRun.userTurnTranscriptRecorder = createTestUserTurnRecorder(preparedUserTurnMessage);
+    const storePath = makeTestSessionStorePath();
     const sessionEntry: SessionEntry = {
       sessionId: "session",
-      sessionFile: "/tmp/session.jsonl",
+      sessionFile: path.join(path.dirname(storePath), "session.jsonl"),
       updatedAt: 1,
     };
     const activeSessionStore = { main: sessionEntry };
@@ -534,7 +537,7 @@ describe("executeAgentTurn: CLI session routing", () => {
       commandBody: "runtime prompt",
       transcriptCommandBody: "display prompt",
       activeSessionStore,
-      storePath: "/tmp/sessions.json",
+      storePath,
       getActiveSessionEntry: () => activeSessionStore.main,
     });
 
@@ -546,12 +549,12 @@ describe("executeAgentTurn: CLI session routing", () => {
       sessionId: "session",
       suppressNextUserMessagePersistence: false,
       persistAssistantTranscript: true,
-      storePath: "/tmp/sessions.json",
+      storePath,
       sessionTarget: {
         agentId: "main",
         sessionId: "session",
         sessionKey: "main",
-        storePath: "/tmp/sessions.json",
+        storePath,
       },
     });
     const call = requireMockCall(state.runCliAgentMock, 0, "CLI runtime");

--- a/src/auto-reply/reply/agent-runner-execution-context-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-context-failures.test.ts
@@ -14,6 +14,7 @@ import {
   requireRecord,
   expectRecordFields,
   createMinimalRunAgentTurnParams,
+  makeTestSessionStorePath,
 } from "./agent-runner-execution.test-support.js";
 import type { FallbackRunnerParams } from "./agent-runner-execution.test-support.js";
 
@@ -49,7 +50,7 @@ describe("executeAgentTurn: context failures", () => {
       sessionKey: "agent:main:main",
       getActiveSessionEntry: () => activeSessionEntry,
       activeSessionStore,
-      storePath: "/tmp/sessions.json",
+      storePath: makeTestSessionStorePath(),
     });
 
     expect(result.kind).toBe("final");
@@ -95,7 +96,7 @@ describe("executeAgentTurn: context failures", () => {
       sessionKey: "agent:main:main",
       getActiveSessionEntry: () => activeSessionEntry,
       activeSessionStore,
-      storePath: "/tmp/sessions.json",
+      storePath: makeTestSessionStorePath(),
     });
 
     expect(result.kind).toBe("final");

--- a/src/auto-reply/reply/agent-runner-execution.test-support.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test-support.ts
@@ -603,6 +603,18 @@ export function expectBlockReplyCall(
   expectMockCallArgFields(onBlockReply, index, "block reply payload", fields);
 }
 
+/**
+ * Session-store paths reach production resolution, which derives a real agent
+ * SQLite file from the store's directory. A shared /tmp path would therefore
+ * open the machine-wide agent database and make unrelated suites depend on it.
+ */
+export function makeTestSessionStorePath(): string {
+  return path.join(
+    useAutoCleanupTempDirTracker(onTestFinished).make("openclaw-agent-execution-store-"),
+    "sessions.json",
+  );
+}
+
 export function createMinimalRunAgentTurnParams(overrides?: {
   followupRun?: FollowupRun;
   opts?: GetReplyOptions;

--- a/src/gateway/health/collector.deadline.test.ts
+++ b/src/gateway/health/collector.deadline.test.ts
@@ -1,4 +1,6 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
@@ -49,13 +51,22 @@ async function collectDeadlineSnapshot(params: {
   });
 }
 
+const tempDirs = createTempDirTracker();
+
+afterAll(() => {
+  tempDirs.cleanup();
+});
+
 describe("gateway health collection deadline", () => {
   beforeAll(async () => {
     vi.doMock("../../config/config.js", () => ({
       getRuntimeConfig: () => testConfig,
     }));
+    // Store paths reach real SQLite target resolution, which inspects the agent
+    // database beside them; a shared /tmp path would read machine-wide state.
+    const storePath = path.join(tempDirs.make("openclaw-health-deadline-"), "sessions.json");
     vi.doMock("../../config/sessions/paths.js", () => ({
-      resolveSessionStorePathCore: () => "/tmp/sessions.json",
+      resolveSessionStorePathCore: () => storePath,
     }));
     vi.doMock("../../config/sessions/session-accessor.js", () => ({
       listSessionEntriesReadOnly: () => [],

--- a/src/gateway/health/collector.legacy-owner.test.ts
+++ b/src/gateway/health/collector.legacy-owner.test.ts
@@ -1,4 +1,6 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import { retainLegacyDefaultAgentId } from "../../config/legacy.default-agent-owner.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -39,13 +41,22 @@ function createHealthPlugin(): ChannelPlugin {
   };
 }
 
+const tempDirs = createTempDirTracker();
+
+afterAll(() => {
+  tempDirs.cleanup();
+});
+
 describe("collectGatewayHealthSnapshot legacy owner projection", () => {
   beforeAll(async () => {
     vi.doMock("../../config/config.js", () => ({
       getRuntimeConfig: () => testConfig,
     }));
+    // Store paths reach real SQLite target resolution, which inspects the agent
+    // database beside them; a shared /tmp path would read machine-wide state.
+    const storePath = path.join(tempDirs.make("openclaw-health-legacy-owner-"), "sessions.json");
     vi.doMock("../../config/sessions/paths.js", () => ({
-      resolveSessionStorePathCore: () => "/tmp/sessions.json",
+      resolveSessionStorePathCore: () => storePath,
     }));
     vi.doMock("../../config/sessions/session-accessor.js", () => ({
       listSessionEntriesReadOnly: () => [],


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where OpenClaw's own test suite writes a shared, machine-wide
SQLite database at `/tmp/openclaw-agent.sqlite`, outside any per-test temporary
directory.

The agent-runner execution fixtures hand `storePath: "/tmp/sessions.json"` to the
real `executeAgentTurn`. Production resolution derives the agent database from the
store's directory (`resolveSqliteTargetFromSessionStorePath` -> dirname `/tmp`), so
those turns create and migrate `/tmp/openclaw-agent.sqlite` through
`openOpenClawAgentDatabase`.

That file is harmless while it matches the current schema version. It stops being
harmless the next time `OPENCLAW_AGENT_SCHEMA_VERSION`
(`src/state/openclaw-agent-db-contract.ts`) is bumped: a stale copy left on a
developer or runner machine then fails every unrelated suite that reaches the real
session accessor, with a migration error from
`src/state/openclaw-agent-db-schema-helpers.ts`. That is exactly the failure
#132960 had to repair across 14 suites, and a remaining producer brings it back.

## Why This Change Was Made

Route the leaking store paths through the existing `test/helpers/temp-dir` tracker,
matching the pattern established in #132960, rather than deleting the shared path
(a cleanup hook would race other suites on the same machine).

The auto-reply harness already owns tracked `agentDir`, `sessionFile`, and
`workspaceDir` for these fixtures, so it gains one `makeTestSessionStorePath()`
helper beside them and the five leaking literals call it.

The same investigation found `src/gateway/health/collector.deadline.test.ts` and
`collector.legacy-owner.test.ts` mocking `resolveSessionStorePathCore` to the same
shared `/tmp/sessions.json`. Those suites never create the database — they mock the
accessor — but real target resolution still opens `/tmp/openclaw-agent.sqlite`
read-only to read its owner, so the `store.path` they assert on depends on whether
a machine-wide database happens to exist and who owns it. Same invariant, fixed in
the same change.

## User Impact

No user-visible or runtime behavior change: test-only, production LOC unchanged.
Developers and CI runners no longer accumulate a shared `/tmp/openclaw-agent.sqlite`
from these suites, so the next agent-schema bump cannot resurrect the cross-suite
failure mode that #132960 cleaned up.

## Evidence

Producer located by instrumenting `openNodeSqliteDatabase` with a stack-trace probe
(file-append, because vitest swallows `process.stderr.write` from production
modules) and running lane groups with the shared file removed:

```
@@@PRODUCER@@@ /tmp/openclaw-agent.sqlite
    at openNodeSqliteDatabase (src/infra/node-sqlite.ts)
    at openOpenClawAgentDatabase (src/state/openclaw-agent-db.ts:326)
    at resolveSessionEntry (src/config/sessions/session-accessor.sqlite-entry.ts:135)
    at loadSessionEntry (src/config/sessions/session-accessor.sqlite-entry.ts:140)
    at createAgentPatchedSessionModelRunGuard (src/agents/session-model-auto-revert.ts:146)
    at executeAgentTurnInternalWithRetryState (src/auto-reply/reply/agent-runner-execution.ts:301)
    ...
    at src/auto-reply/reply/agent-runner-execution.test-support.ts:335
    at src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts:532
```

Regression proof, shared file deleted before each run:

- Before: full `src/auto-reply` lane created `/tmp/openclaw-agent.sqlite` at schema 19.
- After: full `src/auto-reply` lane (6160 tests) leaves it absent.
- `src/auto-reply/reply/agent-runner-execution-{cli-sessions,context-failures}.test.ts`: 22/22 pass, file stays absent.
- `src/gateway/health`: passes, file stays absent.
- `node scripts/check-changed.mjs`: clean.
- Codex autoreview (`--mode branch --base origin/main`): `scoped-clean`, no accepted findings.

Note for reviewers: this host runs several OpenClaw checkouts concurrently, and any
of them recreates the same machine-wide path. File-existence timing is therefore not
attribution here; the stack-trace probe above is.

Follow-up recorded, not in this PR: `test/scripts/docs-sync-publish.test.ts` pins the
release-notes page list, so each release breaks it on `main` from a lane that
release PRs do not select (#133557 -> #133581). It should read the versions from the
navigation instead.
