### PR TITLE
test: consolidate model and plugin metadata fixtures

### DIFF
--- a/src/agents/model-selection.plugin-runtime.test.ts
+++ b/src/agents/model-selection.plugin-runtime.test.ts
@@ -2,6 +2,19 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const normalizeProviderModelIdWithPluginMock = vi.fn();
+
+function normalizeLegacyFixtureModel({
+  provider,
+  context,
+}: {
+  provider: string;
+  context: { modelId?: string };
+}) {
+  return provider === "custom-provider" && context.modelId === "custom-legacy-model"
+    ? "custom-modern-model"
+    : undefined;
+}
+
 const emptyPluginMetadataSnapshot = vi.hoisted(() => ({
   configFingerprint: "model-selection-plugin-runtime-test-empty-plugin-metadata",
   plugins: [
@@ -57,15 +70,7 @@ describe("model-selection plugin runtime normalization", () => {
   });
 
   it("delegates provider-owned model id normalization to plugin runtime hooks", async () => {
-    normalizeProviderModelIdWithPluginMock.mockImplementation(({ provider, context }) => {
-      if (
-        provider === "custom-provider" &&
-        (context as { modelId?: string }).modelId === "custom-legacy-model"
-      ) {
-        return "custom-modern-model";
-      }
-      return undefined;
-    });
+    normalizeProviderModelIdWithPluginMock.mockImplementation(normalizeLegacyFixtureModel);
 
     const { parseModelRef } = await import("./model-selection.js");
 
@@ -97,15 +102,7 @@ describe("model-selection plugin runtime normalization", () => {
   });
 
   it("keeps provider plugin normalization when inferring provider for bare defaults", async () => {
-    normalizeProviderModelIdWithPluginMock.mockImplementation(({ provider, context }) => {
-      if (
-        provider === "custom-provider" &&
-        (context as { modelId?: string }).modelId === "custom-legacy-model"
-      ) {
-        return "custom-modern-model";
-      }
-      return undefined;
-    });
+    normalizeProviderModelIdWithPluginMock.mockImplementation(normalizeLegacyFixtureModel);
 
     const { resolveConfiguredModelRef } = await import("./model-selection.js");
 
@@ -130,86 +127,39 @@ describe("model-selection plugin runtime normalization", () => {
     });
   });
 
-  it("keeps model visibility policy construction off plugin runtime hooks by default", async () => {
-    // Visibility policy is a hot/static path. It preserves configured keys
-    // unless callers explicitly opt into runtime plugin normalization.
-    normalizeProviderModelIdWithPluginMock.mockImplementation(({ provider, context }) => {
-      if (
-        provider === "custom-provider" &&
-        (context as { modelId?: string }).modelId === "custom-legacy-model"
-      ) {
-        return "custom-modern-model";
-      }
-      return undefined;
-    });
-
+  it.each([
+    ["keeps model visibility policy construction off plugin runtime hooks by default", undefined],
+    [
+      "propagates explicit plugin runtime normalization opt-in through model visibility policy",
+      true,
+    ],
+  ] as const)("%s", async (_name, allowPluginNormalization) => {
+    normalizeProviderModelIdWithPluginMock.mockImplementation(normalizeLegacyFixtureModel);
     const { createModelVisibilityPolicy } = await import("./model-visibility-policy.js");
-
     const policy = createModelVisibilityPolicy({
       cfg: {
-        agents: {
-          defaults: {
-            models: {
-              "custom-provider/custom-legacy-model": {},
-            },
-          },
-        },
+        agents: { defaults: { models: { "custom-provider/custom-legacy-model": {} } } },
       },
       catalog: [],
       defaultProvider: "custom-provider",
       defaultModel: "custom-legacy-model",
+      ...(allowPluginNormalization ? { allowPluginNormalization } : {}),
     });
 
-    expect(policy.allowedKeys.has("custom-provider/custom-legacy-model")).toBe(true);
-    expect(policy.allowedKeys.has("custom-provider/custom-modern-model")).toBe(false);
-    expect(normalizeProviderModelIdWithPluginMock).not.toHaveBeenCalled();
-  });
-
-  it("propagates explicit plugin runtime normalization opt-in through model visibility policy", async () => {
-    normalizeProviderModelIdWithPluginMock.mockImplementation(({ provider, context }) => {
-      if (
-        provider === "custom-provider" &&
-        (context as { modelId?: string }).modelId === "custom-legacy-model"
-      ) {
-        return "custom-modern-model";
-      }
-      return undefined;
-    });
-
-    const { createModelVisibilityPolicy } = await import("./model-visibility-policy.js");
-
-    const policy = createModelVisibilityPolicy({
-      cfg: {
-        agents: {
-          defaults: {
-            models: {
-              "custom-provider/custom-legacy-model": {},
-            },
-          },
-        },
-      },
-      catalog: [],
-      defaultProvider: "custom-provider",
-      defaultModel: "custom-legacy-model",
-      allowPluginNormalization: true,
-    });
-
-    expect(policy.allowedKeys.has("custom-provider/custom-modern-model")).toBe(true);
-    expect(normalizeProviderModelIdWithPluginMock).toHaveBeenCalled();
+    if (allowPluginNormalization) {
+      expect(policy.allowedKeys.has("custom-provider/custom-modern-model")).toBe(true);
+      expect(normalizeProviderModelIdWithPluginMock).toHaveBeenCalled();
+    } else {
+      expect(policy.allowedKeys.has("custom-provider/custom-legacy-model")).toBe(true);
+      expect(policy.allowedKeys.has("custom-provider/custom-modern-model")).toBe(false);
+      expect(normalizeProviderModelIdWithPluginMock).not.toHaveBeenCalled();
+    }
   });
 
   it("keeps plugin-normalized stored overrides allowed in auto-reply runtime selection", async () => {
     // Stored session overrides are runtime inputs, so provider-owned
     // normalization keeps old persisted ids usable without resetting them.
-    normalizeProviderModelIdWithPluginMock.mockImplementation(({ provider, context }) => {
-      if (
-        provider === "custom-provider" &&
-        (context as { modelId?: string }).modelId === "custom-legacy-model"
-      ) {
-        return "custom-modern-model";
-      }
-      return undefined;
-    });
+    normalizeProviderModelIdWithPluginMock.mockImplementation(normalizeLegacyFixtureModel);
 
     const cfg = {
       agents: {
@@ -268,12 +218,7 @@ describe("model-selection plugin runtime normalization", () => {
   });
 
   it("normalizes raw persisted overrides through plugin runtime hooks", () => {
-    normalizeProviderModelIdWithPluginMock.mockImplementation(({ provider, context }) =>
-      provider === "custom-provider" &&
-      (context as { modelId?: string }).modelId === "custom-legacy-model"
-        ? "custom-modern-model"
-        : undefined,
-    );
+    normalizeProviderModelIdWithPluginMock.mockImplementation(normalizeLegacyFixtureModel);
 
     expect(
       resolveSessionModelRef(

--- a/src/plugins/current-plugin-metadata.test-support.ts
+++ b/src/plugins/current-plugin-metadata.test-support.ts
@@ -1,5 +1,7 @@
 import { adoptCurrentPluginMetadataSnapshotIfAbsent } from "./current-plugin-metadata-snapshot.js";
 import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
+import type { InstalledPluginIndex } from "./installed-plugin-index.js";
+import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
 
 /** Replaces a test fixture through the operation lifecycle's clear and adopt boundaries. */
@@ -11,4 +13,52 @@ export function setCurrentPluginMetadataSnapshot(
   if (snapshot) {
     adoptCurrentPluginMetadataSnapshotIfAbsent(snapshot, options);
   }
+}
+
+export function makePluginMetadataIndex(pluginId = "demo"): InstalledPluginIndex {
+  const rootDir = `/plugins/${pluginId}`;
+  return {
+    version: 1,
+    hostContractVersion: "test",
+    compatRegistryVersion: "test",
+    migrationVersion: 1,
+    policyHash: "test",
+    generatedAtMs: 1,
+    installRecords: {},
+    diagnostics: [],
+    plugins: [
+      {
+        pluginId,
+        manifestPath: `${rootDir}/openclaw.plugin.json`,
+        manifestHash: `${pluginId}-manifest`,
+        rootDir,
+        origin: "global",
+        enabled: true,
+        startup: {
+          sidecar: false,
+          memory: false,
+          agentHarnesses: [],
+        },
+        compat: [],
+      },
+    ],
+  };
+}
+
+export function makePluginMetadataManifestRegistry(pluginId = "demo"): PluginManifestRegistry {
+  const plugin: PluginManifestRecord = {
+    id: pluginId,
+    name: pluginId,
+    channels: [],
+    providers: [pluginId],
+    cliBackends: [],
+    skills: [],
+    hooks: [],
+    commandAliases: [{ name: `${pluginId}-command` }],
+    rootDir: `/plugins/${pluginId}`,
+    source: `/plugins/${pluginId}/index.js`,
+    manifestPath: `/plugins/${pluginId}/openclaw.plugin.json`,
+    origin: "global",
+  };
+  return { plugins: [plugin], diagnostics: [] };
 }

--- a/src/plugins/plugin-metadata-snapshot.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.test.ts
@@ -7,15 +7,14 @@ import {
   withPluginMetadataSnapshotScope,
 } from "./current-plugin-metadata-snapshot.js";
 import { getCurrentPluginMetadataSnapshotState } from "./current-plugin-metadata-state.js";
-import { setCurrentPluginMetadataSnapshot } from "./current-plugin-metadata.test-support.js";
+import {
+  makePluginMetadataIndex as makeIndex,
+  makePluginMetadataManifestRegistry as makeManifestRegistry,
+  setCurrentPluginMetadataSnapshot,
+} from "./current-plugin-metadata.test-support.js";
 import type { PluginDiscoveryResult } from "./discovery.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
-import type { InstalledPluginIndex } from "./installed-plugin-index.js";
-import {
-  loadPluginManifestRegistryCore,
-  type PluginManifestRecord,
-  type PluginManifestRegistry,
-} from "./manifest-registry.js";
+import { loadPluginManifestRegistryCore } from "./manifest-registry.js";
 import {
   createPluginCache,
   getPluginCache,
@@ -57,54 +56,6 @@ vi.mock("./manifest-registry-installed.js", async (importOriginal) => {
       loadPluginManifestRegistryForInstalledIndex(params),
   };
 });
-
-function makeIndex(pluginId = "demo"): InstalledPluginIndex {
-  const rootDir = `/plugins/${pluginId}`;
-  return {
-    version: 1,
-    hostContractVersion: "test",
-    compatRegistryVersion: "test",
-    migrationVersion: 1,
-    policyHash: "test",
-    generatedAtMs: 1,
-    installRecords: {},
-    diagnostics: [],
-    plugins: [
-      {
-        pluginId,
-        manifestPath: `${rootDir}/openclaw.plugin.json`,
-        manifestHash: `${pluginId}-manifest`,
-        rootDir,
-        origin: "global",
-        enabled: true,
-        startup: {
-          sidecar: false,
-          memory: false,
-          agentHarnesses: [],
-        },
-        compat: [],
-      },
-    ],
-  };
-}
-
-function makeManifestRegistry(pluginId = "demo"): PluginManifestRegistry {
-  const plugin: PluginManifestRecord = {
-    id: pluginId,
-    name: pluginId,
-    channels: [],
-    providers: [pluginId],
-    cliBackends: [],
-    skills: [],
-    hooks: [],
-    commandAliases: [{ name: `${pluginId}-command` }],
-    rootDir: `/plugins/${pluginId}`,
-    source: `/plugins/${pluginId}/index.js`,
-    manifestPath: `/plugins/${pluginId}/openclaw.plugin.json`,
-    origin: "global",
-  };
-  return { plugins: [plugin], diagnostics: [] };
-}
 
 describe("plugin metadata snapshot", () => {
   beforeEach(() => {

--- a/src/plugins/providers.runtime.consult-current-snapshot.test.ts
+++ b/src/plugins/providers.runtime.consult-current-snapshot.test.ts
@@ -1,10 +1,13 @@
 // Verifies provider runtime uses current plugin metadata snapshots.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { setCurrentPluginMetadataSnapshot } from "./current-plugin-metadata.test-support.js";
+import {
+  makePluginMetadataIndex as makeIndex,
+  makePluginMetadataManifestRegistry,
+  setCurrentPluginMetadataSnapshot,
+} from "./current-plugin-metadata.test-support.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
-import type { InstalledPluginIndex } from "./installed-plugin-index.js";
-import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
+import type { PluginManifestRegistry } from "./manifest-registry.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import { resetPluginRuntimeStateForTest } from "./runtime.js";
@@ -38,52 +41,13 @@ import { isPluginProvidersLoadInFlight, resolvePluginProvidersCore } from "./pro
 
 const WORKSPACE = "/workspace/a";
 
-function makeIndex(pluginId = "demo"): InstalledPluginIndex {
-  const rootDir = `/plugins/${pluginId}`;
-  return {
-    version: 1,
-    hostContractVersion: "test",
-    compatRegistryVersion: "test",
-    migrationVersion: 1,
-    policyHash: "test",
-    generatedAtMs: 1,
-    installRecords: {},
-    diagnostics: [],
-    plugins: [
-      {
-        pluginId,
-        manifestPath: `${rootDir}/openclaw.plugin.json`,
-        manifestHash: `${pluginId}-manifest`,
-        rootDir,
-        origin: "global",
-        enabled: true,
-        startup: {
-          sidecar: false,
-          memory: false,
-          agentHarnesses: [],
-        },
-        compat: [],
-      },
-    ],
-  };
-}
-
 function makeManifestRegistry(pluginId = "demo"): PluginManifestRegistry {
-  const plugin: PluginManifestRecord = {
-    id: pluginId,
-    name: pluginId,
-    channels: [],
-    providers: [pluginId],
-    cliBackends: [],
-    skills: [],
-    hooks: [],
-    commandAliases: [],
-    rootDir: `/plugins/${pluginId}`,
-    source: `/plugins/${pluginId}/index.js`,
-    manifestPath: `/plugins/${pluginId}/openclaw.plugin.json`,
-    origin: "global",
-  };
-  return { plugins: [plugin], diagnostics: [] };
+  const registry = makePluginMetadataManifestRegistry(pluginId);
+  // Provider fixtures intentionally declare no command aliases.
+  for (const plugin of registry.plugins) {
+    plugin.commandAliases = [];
+  }
+  return registry;
 }
 
 // Build a snapshot from a provided index (no disk) and register it as the


### PR DESCRIPTION
Related: #130706

## What Problem This Solves

Repeated model-normalization and plugin-metadata fixtures make tests harder to maintain and inflate the larger Gateway performance refactor.

## Why This Change Was Made

Share identical index and manifest constructors through the existing test-support module, reuse the legacy-model normalizer, and table the two visibility-policy variants. Keep the original test names, assertions, option omission, and empty command aliases in provider-only fixtures.

This is an independent extraction from #130706. It contains no runtime ownership changes; the Gateway CPU report (#130324) remains unresolved.

## User Impact

No production behavior change. Production LOC: +0/-0. Tests: +53/-193; test support: +50/-0. Total: four files, +103/-193, **90 fewer lines**. No dependency or documentation changes remain.

## Evidence

- The same 105 cases in five complete files pass before and after, with identical names and per-file order. All 161 assertion expressions in the three changed test files are preserved; both metadata suite bodies are unchanged.
- After rebasing onto main, the full cohort including upstream's six docs tests passes: **111 tests across six complete files**. The four-file cleanup patch is byte-identical to the earlier reviewed version.
- The final proportional changed-file gate passes. Fresh managed Codex branch review against the pinned main base returned no findings at its P0 scope.
- Raw/resolved persisted-model tests remain. No timeout, mock boundary, or assertion was weakened. A full product build/live run is not needed for this test-only extraction.

The temporary docs-navigation correction was dropped during rebase because [upstream now derives release expectations from navigation](https://github.com/openclaw/openclaw/commit/cd3543fe715dabbb86d6f090293ef350233d7e0b). The docs test matches main exactly and is outside this PR's final diff. The earlier Matrix crypto native download failure was an installation/network failure; no dependency workaround was added.

The reduction is measured against this PR's pinned main base. It overlaps cleanup already present in #130706 and is not additional savings on top of the earlier cleanup tally.
