### PR TITLE
fix(browser): preserve contextless worker and iframe sessions

### DIFF
--- a/extensions/browser/src/browser/pw-session-cdp-transport.ts
+++ b/extensions/browser/src/browser/pw-session-cdp-transport.ts
@@ -11,8 +11,8 @@ type CdpSocketLookup = typeof dnsLookupCb;
 // Keep transport-owned replies below that range so Playwright never consumes them.
 const FIRST_INTERNAL_COMMAND_ID = -10_000;
 
-// Playwright exempts only the browser target before requiring browserContextId.
-// Release every other contextless target here or its assertion exits the Gateway.
+// Playwright's browser-root handler requires browserContextId for non-browser targets.
+// Release only those root targets; nested sessions belong to Playwright's frame handler.
 function contextlessTargetSession(message: Record<string, unknown>): string | undefined {
   if (readStringField(message, "method") !== "Target.attachedToTarget") {
     return undefined;
@@ -20,6 +20,7 @@ function contextlessTargetSession(message: Record<string, unknown>): string | un
   const params = asOptionalRecord(message.params);
   const targetInfo = asOptionalRecord(params?.targetInfo);
   if (
+    readStringField(message, "sessionId") ||
     readStringField(targetInfo, "type") === "browser" ||
     readStringField(targetInfo, "browserContextId")
   ) {

--- a/extensions/browser/src/browser/pw-session.pinned-transport.test.ts
+++ b/extensions/browser/src/browser/pw-session.pinned-transport.test.ts
@@ -79,7 +79,7 @@ afterEach(async () => {
 });
 
 describe("pw-session Playwright CDP transport", () => {
-  it("keeps HTTP fallback managed while releasing contextless non-browser targets", async () => {
+  it("keeps HTTP fallback managed while releasing only root contextless non-browser targets", async () => {
     const server = new WebSocketServer({ port: 0, host: "127.0.0.1" });
     await new Promise<void>((resolve) => {
       server.once("listening", () => resolve());
@@ -110,9 +110,20 @@ describe("pw-session Playwright CDP transport", () => {
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce({ url: transportUrl });
     const browser = makeBrowser("A", "https://example.com");
+    let transport: import("playwright-core").ConnectOverCDPTransport | undefined;
     connectOverCdpSpy.mockImplementationOnce((async (transportArg: unknown) => {
       expect(typeof transportArg).not.toBe("string");
-      const transport = transportArg as import("playwright-core").ConnectOverCDPTransport;
+      transport = transportArg as import("playwright-core").ConnectOverCDPTransport;
+      return browser.browser;
+    }) as never);
+
+    try {
+      await expect(listPagesViaPlaywright({ cdpUrl })).resolves.toEqual([
+        expect.objectContaining({ targetId: "A" }),
+      ]);
+      if (!transport) {
+        throw new Error("missing Playwright CDP transport");
+      }
       const delivered: object[] = [];
       // oxlint-disable-next-line unicorn/prefer-add-event-listener -- Playwright's ConnectOverCDPTransport contract uses an onmessage property.
       transport.onmessage = (message) => delivered.push(message);
@@ -126,6 +137,7 @@ describe("pw-session Playwright CDP transport", () => {
         "auction_worklet",
         "other",
         "page",
+        "iframe",
       ];
       for (const [index, type] of contextlessTargetTypes.entries()) {
         socket.send(
@@ -145,18 +157,35 @@ describe("pw-session Playwright CDP transport", () => {
         { type: "other", browserContextId: "default-context" },
         { type: "service_worker", browserContextId: "default-context" },
       ];
-      const forwardedTargets = forwardedTargetInfos.map((targetInfo, index) => ({
+      const forwardedTargets = [
+        ...forwardedTargetInfos.map((targetInfo) => ({
+          targetInfo,
+          sessionId: undefined,
+          waitingForDebugger: true,
+        })),
+        ...["worker", "iframe"].flatMap((type) =>
+          [true, false].map((waitingForDebugger) => ({
+            targetInfo: { type },
+            sessionId: "parent-session",
+            waitingForDebugger,
+          })),
+        ),
+      ].map(({ targetInfo, sessionId, waitingForDebugger }, index) => ({
         method: "Target.attachedToTarget",
+        sessionId,
         params: {
           sessionId: `forwarded-session-${index}`,
           targetInfo: { targetId: `forwarded-target-${index}`, ...targetInfo },
-          waitingForDebugger: true,
+          waitingForDebugger,
         },
       }));
       for (const event of forwardedTargets) {
         socket.send(JSON.stringify(event));
       }
 
+      await vi.waitFor(() => {
+        expect(delivered).toEqual(forwardedTargets);
+      });
       await vi.waitFor(() => {
         expect(commands).toHaveLength(contextlessTargetTypes.length);
       });
@@ -197,18 +226,15 @@ describe("pw-session Playwright CDP transport", () => {
           }),
         ),
       );
-      await vi.waitFor(() => {
-        expect(delivered).toEqual(forwardedTargets);
+      const socketClosed = new Promise<void>((resolve) => {
+        socket.once("close", () => resolve());
       });
       transport.close();
-      return browser.browser;
-    }) as never);
-
-    try {
-      await expect(listPagesViaPlaywright({ cdpUrl })).resolves.toEqual([
-        expect.objectContaining({ targetId: "A" }),
-      ]);
+      await socketClosed;
+      expect(delivered).toEqual(forwardedTargets);
+      expect(commands).toHaveLength(contextlessTargetTypes.length * 2);
     } finally {
+      transport?.close();
       await new Promise<void>((resolve) => {
         server.close(() => resolve());
       });


### PR DESCRIPTION
Closes #133569

Related: https://github.com/openclaw/openclaw/pull/132419 — root contextless-target crash protection.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where browser automation loses nested workers and out-of-process iframes when their CDP attachment event has a parent session but omits `browserContextId`. Playwright never receives those events because the managed transport incorrectly treats them as browser-root targets.

This is a pre-existing main defect, not a regression introduced by the standalone relay feature. The affected modules remain unchanged on main `00b64b81c4073e594c423bcb5e7a5ca1c5a6f6d7`.

## Why This Change Was Made

Only Playwright's browser-root attachment handler requires `browserContextId`. The outer envelope `sessionId` selects the parent session; `params.sessionId` identifies the attached child. Add that missing discriminator to the existing predicate so every parent-routed attachment passes through unchanged, while the root-only protection remains intact.

Root contextless targets still resume, wait for the resume response, and then detach. DNS pinning, endpoint discovery, internal reply suppression, and connection/event cleanup are unchanged. No new configuration, dependencies, compatibility path, public API, or test-only production seam.

## User Impact

Playwright retains ownership of nested worker and iframe sessions even when the optional context field is absent. Existing protection against contextless root targets terminating the Gateway is preserved.

## Evidence

### Before and after

The regression uses the actual managed WebSocket transport through `listPagesViaPlaywright`, with a mock only at the Playwright consumer boundary. Before the production edit, all four nested worker/iframe envelopes (paused and unpaused) were missing; one test failed and the other six passed. After repair, all seven transport tests pass. The test also proves nine root resumes, no detach before a resume response, exactly one detach per resumed root session, unchanged forwarded envelopes, and no leaked internal replies or extra commands after socket closure.

```bash
node scripts/run-vitest.mjs extensions/browser/src/browser/pw-session.pinned-transport.test.ts
```

The final sibling run passed **96/96 tests across six files**, covering pinning, cross-authority redirect rejection, connection retirement/cancellation, scoped cleanup, enumeration, and event-before-close delivery:

```bash
node scripts/run-vitest.mjs extensions/browser/src/browser/pw-session.pinned-transport.test.ts extensions/browser/src/browser/pw-session.connections.test.ts extensions/browser/src/browser/pw-session.enumeration.test.ts extensions/browser/src/browser/pw-session.termination-cdp-ssrf.test.ts extensions/browser/src/browser/cdp.helpers.internal.test.ts extensions/browser/src/browser/cdp.helpers.transport.test.ts
```

The complete changed-scope gate passed, including production/test typechecks, lint, formatting, five doctor-contract tests, export scans, boundary guards, and zero runtime import cycles:

```bash
node scripts/check-changed.mjs -- extensions/browser/src/browser/pw-session-cdp-transport.ts extensions/browser/src/browser/pw-session.pinned-transport.test.ts
```

Fresh Codex autoreview completed `scoped-clean` with no P0 findings. An initial test-fixture conditional-spread lint finding was fixed and the full gate rerun successfully.

### Real dependency and browser proof

Personally inspected installed Playwright **1.62.1**: `lib/coreBundle.js:34732–34738` routes on the outer session ID; `37547–37599` handles nested worker/iframe attachments; `38166–38201` requires the context field only in the root handler.

A disposable, isolated Chrome for Testing **151.0.7922.34** and real Playwright exercised the actual repaired transport. Ordinary traffic passed worker evaluation (`42`), worker-to-page messaging, cross-site OOPIF content/evaluation (`63`), and positive Playwright-owned initialization/resume commands. Chromium naturally included context IDs, so a second **explicitly fault-injected** leg removed only `targetInfo.browserContextId` from nested worker/iframe events. It passed the same assertions without transport-owned resume/detach commands. Every other envelope field and text framing were preserved.

Scratch-fixture framing and startup-budget failures were corrected before the successful run; they were not product failures. The browser, WebSockets, ephemeral ports, and temporary profile were cleaned up. No operator Chrome/Gateway or parked relay work was used. This is dependency/transport proof, not a Gateway or extension-relay end-to-end claim; no UI or visual layout changes are included.

### Scope and size

Production: **+3/-2, net +1**. The one added line is the session-ownership discriminator within the existing predicate. Tests: **+39/-13, net +26**, extending the existing table and making assertion failure/cleanup reliable rather than adding another fixture.

Release-note context: Browser automation now preserves nested worker and iframe CDP sessions that omit a browser context ID while retaining safe release of contextless root targets.
