### PR TITLE
fix: correct MCP URI schema resolution with patched fast-uri

### DIFF
--- a/.github/release/vercel-cli/package-lock.json
+++ b/.github/release/vercel-cli/package-lock.json
@@ -2789,9 +2789,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,7 +116,7 @@ overrides:
   '@aws-sdk/xml-builder': 3.972.40
   '@hono/node-server': 2.1.1
   axios: 1.19.0
-  fast-uri: 4.1.2
+  fast-uri: 4.1.3
   follow-redirects: 1.16.0
   defu: 6.1.7
   fast-xml-parser: 5.11.0
@@ -6727,8 +6727,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@4.1.2:
-    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
+  fast-uri@4.1.3:
+    resolution: {integrity: sha512-7+72G6vLt7jjNas8SmSATx2qeyRIjxeqO3i4IkmDTxlqYZRKANhOe1bnovcp4WZmvsYrp60WyqPyHqgRiX0yXw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -13093,7 +13093,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.2
+      fast-uri: 4.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -13882,7 +13882,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@4.1.2: {}
+  fast-uri@4.1.3: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,7 +32,7 @@ overrides:
   "@aws-sdk/xml-builder": 3.972.40
   "@hono/node-server": 2.1.1
   axios: 1.19.0
-  fast-uri: 4.1.2
+  fast-uri: 4.1.3
   follow-redirects: 1.16.0
   defu: 6.1.7
   fast-xml-parser: 5.11.0

--- a/scripts/materialize-vercel-cli.sh
+++ b/scripts/materialize-vercel-cli.sh
@@ -8,7 +8,7 @@ github_output="${3:-}"
 
 package_json="${source_root}/package.json"
 package_lock="${source_root}/package-lock.json"
-expected_lock_sha256="85e611c2d409f9ce91f2f85bdfbdf02fdaaead2e2e4ba7dfaaac9c7220d6b021"
+expected_lock_sha256="baa314f7f353aa4146efc0c2ab1b31f37a3941ed2f8aacaf50ba0ed248ac8e7f"
 expected_vercel_integrity="sha512-Bj/SN1qln/9guMcIz4gEGn+Ij+amGtkT2kqxwUAFgrLU2Hr0zYk4kX4QfxmZEs6WhheAaMlblVw2VUF2JFP5fA=="
 test -f "${package_json}"
 test -f "${package_lock}"

--- a/src/agents/mcp-tool-metadata.test.ts
+++ b/src/agents/mcp-tool-metadata.test.ts
@@ -9,6 +9,62 @@ function tool(name: string, overrides: Partial<Tool> = {}): Tool {
 
 describe("normalizeMcpToolCatalog", () => {
   it.each([
+    ["IDN hosts", "https://bücher.example/value", "https://xn--bcher-kva.example/value"],
+    ["relative references", "child", "./child"],
+    ["local fragments", "#value", "#value"],
+    ["reserved path escapes", "a%3Ab", "a%3Ab"],
+  ])("validates tool output schemas with %s", (_label, id, ref) => {
+    const normalized = normalizeMcpToolCatalog(
+      [
+        tool("referenced", {
+          outputSchema: {
+            $id: "https://schema.example/root",
+            type: "object",
+            definitions: { value: { $id: id, type: "string" } },
+            properties: { value: { $ref: ref } },
+            required: ["value"],
+          },
+        }),
+      ],
+      createMcpJsonSchemaValidator(),
+    );
+    const validate = normalized.metadata.validatorForCall("referenced")!;
+
+    expect(() => validate({ content: [], structuredContent: { value: "ok" } })).not.toThrow();
+    expect(() => validate({ content: [], structuredContent: { value: 1 } })).toThrow(
+      "Structured content does not match the tool's output schema",
+    );
+  });
+
+  it("keeps nested hostname escapes distinct when resolving tool output schemas", () => {
+    const validate = createMcpJsonSchemaValidator().getValidator({
+      $id: "https://schema.example/root",
+      definitions: {
+        encoded: { $id: "https://127%252e0%252e0%252e1/value", const: "encoded" },
+        plain: { $id: "https://127.0.0.1/value", const: "plain" },
+      },
+      $ref: "https://127%252e0%252e0%252e1/value",
+    });
+
+    expect(validate("encoded").valid).toBe(true);
+    expect(validate("plain").valid).toBe(false);
+  });
+
+  it.each([
+    ["encoded scheme delimiters", "%2f%2fschema.example:/value", "URI scheme is malformed"],
+    ["invalid IPv6", "https://[1:2:3::4::5]/value", "URI host is malformed"],
+    ["malformed percent escapes", "https://schema.example/%ZZ", "malformed percent-encoding"],
+  ])("rejects %s in tool output schema references", (_label, ref, error) => {
+    expect(() =>
+      createMcpJsonSchemaValidator().getValidator({
+        $id: "https://schema.example/root",
+        definitions: { value: { $id: ref, type: "string" } },
+        $ref: ref,
+      }),
+    ).toThrow(error);
+  });
+
+  it.each([
     {
       label: "trim-equivalent names",
       colliding: [tool("duplicate"), tool(" duplicate ")],


### PR DESCRIPTION
Closes #133558 — MCP output schemas misresolve URI identifiers with affected fast-uri pins.

## What Problem This Solves

Resolves a problem where MCP output schemas using IDN references fail to compile and nested hostname escapes collide with a different schema identifier. Malformed URI references also pass through the older resolver. The product and independently locked Vercel release tooling retain fast-uri versions affected by four published upstream high-severity advisories:

- [GHSA-5jgf-p345-68v8: IDN canonicalization](https://github.com/fastify/fast-uri/security/advisories/GHSA-5jgf-p345-68v8)
- [GHSA-fph4-wmhf-6fwf: repeated hostname decoding](https://github.com/fastify/fast-uri/security/advisories/GHSA-fph4-wmhf-6fwf)
- [GHSA-f65p-4m7j-42xc: malformed IPv6](https://github.com/fastify/fast-uri/security/advisories/GHSA-f65p-4m7j-42xc)
- [GHSA-jqff-g426-hqxp: encoded schemes](https://github.com/fastify/fast-uri/security/advisories/GHSA-jqff-g426-hqxp)

This is confirmed schema-resolution behavior and affected-version evidence, **not a claim of demonstrated OpenClaw SSRF exploitability**. The observed consumer is Ajv's URI/schema-reference resolver.

## Why This Change Was Made

Use the maintained upstream patches instead of adding a downstream URI workaround: update the existing product override from **4.1.2 to 4.1.3**, and resolve Vercel's transitive dependency from **3.1.5 to 3.1.6** within its existing Ajv `^3.0.1` range. The product override change was explicitly approved. No new override or cooldown exception is added.

Both locks were regenerated with their owning package managers under a seven-day floor. Registry publication times are **2026-08-23T01:34:36.066Z** and **2026-08-23T01:42:00.349Z**, earlier than the frozen **2026-08-23T21:20:35.163Z** cutoff. Downloaded tarball bytes match fresh registry integrity metadata.

Preserve Vercel **59.3.0**, direct Sandbox **4.0.0**, all nine scoped release-tool overrides, the separately pinned Vercel integrity, lifecycle-script-disabled materialization, and the direct Sandbox executable. Only the complete Vercel lock hash changes to bind the regenerated lock. No changes to the separately owned SDK update are included.

## User Impact

MCP schema identifiers resolve consistently without changing ordinary relative references, local fragments, or reserved path escapes. Malformed references are rejected at the upstream resolver rather than rewritten into another identity. Product and Vercel tooling no longer select versions affected by the four listed advisories.

No new configuration, public API, custom parser, gateway restart, live operator-state change, Vercel deployment, or publication is involved. Release note: fix MCP URI/schema-reference normalization and refresh the corresponding product and release-tool security dependencies.

## Evidence

**Before/after:** the new real MCP/Ajv boundary cases fail against the old product dependency (**5 failures, 6 passes**) for the intended reasons: unresolved IDN, nested-host ID collision, and malformed scheme/IPv6/percent references accepted. With 4.1.3, the focused suite passes **227 tests** across MCP metadata, the real MCP runtime, shared JSON Schema handling, gateway protocol validation, and Vercel release-tool contracts.

```bash
node scripts/run-vitest.mjs src/agents/mcp-tool-metadata.test.ts src/agents/agent-bundle-mcp-runtime.test.ts src/shared/json-schema-defaults.test.ts packages/gateway-protocol/src/index.test.ts packages/gateway-protocol/src/openclaw.schema.test.ts test/scripts/vercel-container-registry-publish.test.ts --reporter=verbose
```

Independent checks against the **actually installed** Ajv 8.20.0 / fast-uri 4.1.3 product pair and Ajv 8.18.0 / fast-uri 3.1.6 release-tool pair pass absolute and scheme-relative IDN references, relative references, local fragments, reserved path escapes, distinct nested hostname escapes, malformed-reference rejection, and the four upstream advisory contracts. The draft-2020-12 TypeBox sibling remains covered by the existing MCP runtime tests.

**Release-tool proof:** a real isolated installation using empty HOME/XDG directories, separate empty npm config files, no credentials, and `npm ci --ignore-scripts` succeeded. The resulting `vercel --version` and direct `sandbox --version` report 59.3.0 and 4.0.0. Tampered-lock and existing-destination checks fail before a stub npm is invoked. Existing mocked registry-command tests pass; **no production Vercel publication or deployment was run**. An initial proof-harness attempt used the same `/dev/null` path for both npm configs; npm rejected duplicate config loading. Retrying with separate empty files fixed the harness without changing product code.

**Graph preservation:** semantic comparison proves every other product and release-tool package/edge unchanged, including all 174 workspace importers, the standalone pnpm toolchain document, Vercel's direct manifest, scoped overrides and Sandbox, and the separate ClawHub lock. The Vercel lock changes only fast-uri's version, URL, and integrity. New lock SHA-256: `baa314f7f353aa4146efc0c2ab1b31f37a3941ed2f8aacaf50ba0ed248ac8e7f`.

**Advisory caveat:** fresh full-graph npm checks report no findings across three separately audited locks, but a focused bulk request also returns `{}` for the old vulnerable versions. npm-green is therefore **not** used as advisory clearance; the four upstream affected ranges and patched releases were checked directly. Existing unrelated dependency-age exceptions are unchanged; the age claim here is about the two changed fast-uri identities.

Production/config/tooling LOC: **+2/-2 (net 0)**. Tests: **+56/-0**. Generated locks: **+8/-8**. No production workaround or new test-only seam.

**Completed local gates:** full `pnpm build` (10m 25s; no ineffective-dynamic-import warning), focused core-test typecheck, focused oxlint, dependency pin guard, formatting and `git diff --check`. The 227-test suite passed on both Node 26.8.1 and Node 24.20.0. Secretless real materialization, tamper rejection, CLI versions, and both installed Ajv URI contracts also passed independently on Node 24.20.0 / npm 11.19.0. The earlier Node 26 install's engine warning came from unchanged `@renovatebot/pep440`; Node 24 parity is now proven.

Fresh Codex autoreview of all five changed files completed **scoped-clean, no accepted/actionable P0 findings**. The broad root-lock `check:changed` plan was inspected; local proof is the full build plus focused owner checks above, not a claim of running the aggregate full suite. Exact-head required CI will be recorded before landing.
