### PR TITLE
fix(ui): wait for restored draft before clearing

### DIFF
--- a/ui/src/e2e/session-management.draft-indicator.e2e.test.ts
+++ b/ui/src/e2e/session-management.draft-indicator.e2e.test.ts
@@ -1,0 +1,97 @@
+import { expect, it } from "vitest";
+import type { ChatPaneElement } from "../pages/chat/route-draft-focus-handoff.ts";
+import { waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
+import {
+  captureUiProof,
+  controlUiSessionPath,
+  controlUiSessionUrl,
+  createSessionManagementE2eSuite,
+  installMockGateway,
+  sessionRow,
+  sessionsListResponse,
+} from "./session-management.test-support.ts";
+import { waitForSettledFormControls } from "./settle.test-support.ts";
+
+const suite = createSessionManagementE2eSuite();
+
+suite.define(() => {
+  it("keeps the browser-local draft pencil visible on active Home beside activity", async () => {
+    const mainKey = "agent:main:main";
+    const secondKey = "agent:main:draft-second";
+    const context = await suite.browser.newContext({
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse([
+          sessionRow(mainKey, "Main", 2, {
+            hasActiveRun: true,
+            startedAt: 1,
+            status: "running",
+          }),
+          sessionRow(secondKey, "Draft second", 1),
+        ]),
+      },
+      sessionKey: mainKey,
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, mainKey));
+      const homeRow = page.locator(".nav-item--home");
+      const secondRow = page.locator(`[data-session-key="${secondKey}"]`);
+      const composer = page.locator(
+        'openclaw-chat-pane[aria-hidden="false"] .agent-chat__composer-combobox > textarea',
+      );
+      await homeRow.waitFor({ state: "visible", timeout: 10_000 });
+      await secondRow.waitFor({ state: "visible" });
+      await composer.waitFor({ state: "visible" });
+      await captureUiProof(page, "draft-indicator-before.png");
+
+      await composer.fill("Keep this unsent");
+      const activity = homeRow.getByRole("img", { name: "Active run" });
+      const draft = homeRow.getByRole("img", { name: "Unsent draft" });
+      await activity.waitFor();
+      await draft.waitFor();
+      const activityBox = await activity.boundingBox();
+      const draftBox = await draft.boundingBox();
+      if (!activityBox || !draftBox) {
+        throw new Error("expected activity and draft icon bounds");
+      }
+      expect(draftBox.x).toBeGreaterThanOrEqual(activityBox.x + activityBox.width);
+      await captureUiProof(page, "draft-indicator-active.png");
+
+      await secondRow.getByRole("link").click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(secondKey));
+      await draft.waitFor();
+
+      await homeRow.click();
+      await waitForControlUiRoute(page, {
+        pathname: controlUiSessionPath(mainKey),
+        routeId: "chat",
+      });
+      await draft.waitFor();
+      const presentedPanes = page.locator('openclaw-chat-pane[aria-hidden="false"]');
+      await expect
+        .poll(() =>
+          presentedPanes.evaluateAll((panes) =>
+            panes.map((pane) => (pane as ChatPaneElement).sessionKey),
+          ),
+        )
+        .toEqual([mainKey]);
+
+      await waitForSettledFormControls(page, [{ locator: composer, value: "Keep this unsent" }]);
+      await composer.fill("");
+      await waitForSettledFormControls(page, [{ locator: composer, value: "" }]);
+      await expect.poll(() => draft.count()).toBe(0);
+      await secondRow.getByRole("link").click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(secondKey));
+      await expect.poll(() => draft.count()).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -1,11 +1,9 @@
 import path from "node:path";
 import { expect, it } from "vitest";
-import type { ChatPaneElement } from "../pages/chat/route-draft-focus-handoff.ts";
 import {
   waitForControlUiGatewayReady,
   waitForControlUiGatewayReconnecting,
 } from "../test-helpers/control-ui-e2e-readiness.ts";
-import { waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
 import { expectRequestCountStable } from "./chat-flow.test-support.ts";
 import {
   actionOpacity,
@@ -27,83 +25,6 @@ import {
 const suite = createSessionManagementE2eSuite();
 
 suite.define(() => {
-  it("keeps the browser-local draft pencil visible on active Home beside activity", async () => {
-    const mainKey = "agent:main:main";
-    const secondKey = "agent:main:draft-second";
-    const context = await suite.browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    await installMockGateway(page, {
-      methodResponses: {
-        "sessions.list": sessionsListResponse([
-          sessionRow(mainKey, "Main", 2, {
-            hasActiveRun: true,
-            startedAt: 1,
-            status: "running",
-          }),
-          sessionRow(secondKey, "Draft second", 1),
-        ]),
-      },
-      sessionKey: mainKey,
-    });
-
-    try {
-      await page.goto(controlUiSessionUrl(suite.server.baseUrl, mainKey));
-      const homeRow = page.locator(".nav-item--home");
-      const secondRow = page.locator(`[data-session-key="${secondKey}"]`);
-      const composer = page.locator(
-        'openclaw-chat-pane[aria-hidden="false"] .agent-chat__composer-combobox > textarea',
-      );
-      await homeRow.waitFor({ state: "visible", timeout: 10_000 });
-      await secondRow.waitFor({ state: "visible" });
-      await composer.waitFor({ state: "visible" });
-      await captureUiProof(page, "draft-indicator-before.png");
-
-      await composer.fill("Keep this unsent");
-      const activity = homeRow.getByRole("img", { name: "Active run" });
-      const draft = homeRow.getByRole("img", { name: "Unsent draft" });
-      await activity.waitFor();
-      await draft.waitFor();
-      const activityBox = await activity.boundingBox();
-      const draftBox = await draft.boundingBox();
-      if (!activityBox || !draftBox) {
-        throw new Error("expected activity and draft icon bounds");
-      }
-      expect(draftBox.x).toBeGreaterThanOrEqual(activityBox.x + activityBox.width);
-      await captureUiProof(page, "draft-indicator-active.png");
-
-      await secondRow.getByRole("link").click();
-      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(secondKey));
-      await draft.waitFor();
-
-      await homeRow.click();
-      await waitForControlUiRoute(page, {
-        pathname: controlUiSessionPath(mainKey),
-        routeId: "chat",
-      });
-      await draft.waitFor();
-      const presentedPanes = page.locator('openclaw-chat-pane[aria-hidden="false"]');
-      await expect
-        .poll(() =>
-          presentedPanes.evaluateAll((panes) =>
-            panes.map((pane) => (pane as ChatPaneElement).sessionKey),
-          ),
-        )
-        .toEqual([mainKey]);
-
-      await composer.fill("");
-      await secondRow.getByRole("link").click();
-      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(secondKey));
-      await expect.poll(() => draft.count()).toBe(0);
-    } finally {
-      await context.close();
-    }
-  });
-
   it("expands and manages child sessions inline before opening a child chat", async () => {
     const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
     const parentKey = "agent:main:release-plan";


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure where the Control UI session-management E2E could leave a restored draft badge visible after clearing the composer on a slow CI runner.

## Why This Change Was Made

The test now waits for the retained composer value to finish restoring, then waits for the cleared form state and draft-badge removal before navigating. The focused scenario lives in its own draft-indicator E2E file so the existing sidebar suite remains below the enforced line cap. This is a test-only synchronization repair; production behavior is unchanged.

## User Impact

No product behavior changes. Main and Full Release Validation can reliably verify the existing restored-draft clearing behavior.

## Evidence

- Before: Full Release Validation on `af8dad8e9e32d50088064702ee1614ea8d7687d9` failed in `session-management.sidebar.e2e.test.ts` because the draft badge count remained `1` after an empty fill raced retained-composer restoration:
  - https://github.com/openclaw/openclaw/actions/runs/33333802824
  - https://github.com/openclaw/openclaw/actions/runs/33333825663/job/99317224894
- The first PR head exposed the existing sidebar file's 1000-line lint ceiling after the four-line repair:
  - https://github.com/openclaw/openclaw/actions/runs/33338186414/job/99328911178
- Focused repaired test before the ownership split: 10 consecutive runs passed.
- Pre-split exact failing CI shard `11/13`: 26 files and 110 tests passed.
- Final draft-indicator + sidebar focused E2E pair: 2 files and 11 tests passed.
- Final exact `check-lint-core-4` stripe: passed.
- Max-lines ratchet and file-level oxlint: passed.
- Changed-scope guards passed. The initial core-test typecheck resolved stale root `pako@1.0.11` because the sparse GWT lacked its normal `ui/node_modules` link; rerunning the failed typecheck with the current UI workspace dependency (`pako@3.0.1`, bundled declarations) passed.
- `git diff --check`: passed.
- Autoreview (`gpt-5.6-sol`, high): scoped clean, no actionable findings.
- Production LOC: `+0/-0`; tests: `+97/-79` (net `+18`).
