### PR TITLE
fix(line): stay quiet while another channel holds the chat

### DIFF
--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -43,8 +43,10 @@ https://gateway-host/line/webhook
 ```
 
 The Gateway answers LINE's signed webhook verification request: a `POST` with an
-empty `events` list. For signed inbound events, it writes each event to the durable
-ingress queue before returning `200`; agent processing continues asynchronously.
+empty `events` list. Signed events in LINE's `standby` mode are acknowledged without
+queueing or replying, because another channel holds chat control. Other signed
+inbound events enter the durable ingress queue before `200`; agent processing
+continues asynchronously.
 Failed delivery is retried from the queue, including after a Gateway restart, and
 poison events become failed queue records after bounded retries. If durable
 persistence fails, the request returns
@@ -66,7 +68,8 @@ Security notes:
 
 The [Setup](#setup) webhook contract acknowledges an event only after it is durably
 queued. The durable `200` carries `x-openclaw-delivery-accepted: durable`; signed
-verification pings (empty event lists) and error responses omit the marker, so
+verification pings (empty event lists), standby-only batches, and error responses
+omit the marker, so
 reverse proxies can require it to distinguish durable acceptance from a generic
 `200`. From there, delivery runs through the core channel-ingress drain with
 LINE-specific settings:

--- a/extensions/line/src/bot.ts
+++ b/extensions/line/src/bot.ts
@@ -1,5 +1,4 @@
 // Line plugin module implements bot behavior.
-import type { webhook } from "@line/bot-sdk";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { DEFAULT_GROUP_HISTORY_LIMIT, type HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import {
@@ -41,7 +40,7 @@ interface LineBotOptions {
 }
 
 interface LineBot {
-  handleWebhook: (body: webhook.CallbackRequest) => Promise<void>;
+  handleWebhook: ReturnType<typeof createLineWebhookSpool>["accept"];
   account: ResolvedLineAccount;
   stop: () => Promise<void>;
 }

--- a/extensions/line/src/monitor.lifecycle.test.ts
+++ b/extensions/line/src/monitor.lifecycle.test.ts
@@ -2,15 +2,18 @@
 import crypto from "node:crypto";
 import { createServer, IncomingMessage, type ServerResponse } from "node:http";
 import { Socket } from "node:net";
+import type { webhook } from "@line/bot-sdk";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { createMockIncomingRequest } from "openclaw/plugin-sdk/test-env";
 import { WEBHOOK_IN_FLIGHT_DEFAULTS } from "openclaw/plugin-sdk/webhook-request-guards";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createLineWebhookSpool } from "./webhook-spool.js";
+import { createEvent, withQueue } from "./webhook-spool.test-support.js";
 
 type LineNodeWebhookHandler = (req: IncomingMessage, res: ServerResponse) => Promise<void>;
-type LineHandleWebhook = (...args: unknown[]) => Promise<void>;
+type LineHandleWebhook = ReturnType<typeof import("./bot.js").createLineBot>["handleWebhook"];
 type LineBotOptions = Parameters<typeof import("./bot.js").createLineBot>[0];
 
 const {
@@ -22,7 +25,7 @@ const {
 } = vi.hoisted(() => ({
   createLineBotMock: vi.fn((_options: LineBotOptions) => ({
     account: { accountId: "default" },
-    handleWebhook: vi.fn<LineHandleWebhook>(),
+    handleWebhook: vi.fn<LineHandleWebhook>().mockResolvedValue("durable"),
     stop: vi.fn(),
   })),
   createLineNodeWebhookHandlerMock: vi.fn<() => LineNodeWebhookHandler>(() =>
@@ -170,7 +173,7 @@ describe("monitorLineProvider lifecycle", () => {
     createLineBotMock.mockReset();
     createLineBotMock.mockImplementation(() => ({
       account: { accountId: "default" },
-      handleWebhook: vi.fn<LineHandleWebhook>(),
+      handleWebhook: vi.fn<LineHandleWebhook>().mockResolvedValue("durable"),
       stop: vi.fn(async () => undefined),
     }));
     // Clear call history only; the implementation was wired to the actual
@@ -655,8 +658,8 @@ describe("monitorLineProvider lifecycle", () => {
       let releaseAdmission: (() => void) | undefined;
       bot.handleWebhook.mockImplementationOnce(
         () =>
-          new Promise<void>((resolve) => {
-            releaseAdmission = resolve;
+          new Promise<Awaited<ReturnType<LineHandleWebhook>>>((resolve) => {
+            releaseAdmission = () => resolve("durable");
           }),
       );
       const signature = crypto.createHmac("SHA256", "secret").update(payload).digest("base64");
@@ -711,6 +714,69 @@ describe("monitorLineProvider lifecycle", () => {
       expect(message).toContain("retryAfterMs");
       expect(message).not.toContain("[object Object]");
       expect(message).not.toContain(bearerToken);
+
+      // Keep the HTTP receipt tied to the real queue, including deliberate non-admission.
+      await withQueue(async (queue) => {
+        const delivered: webhook.Event[] = [];
+        const spool = createLineWebhookSpool({
+          accountId: "default",
+          runtime,
+          queue,
+          deliver: async (event, _destination, control) => {
+            delivered.push(event);
+            await control.turnAdoptionLifecycle.onAdopted();
+          },
+        });
+        bot.handleWebhook.mockImplementation(spool.accept);
+        const active = createEvent({ webhookEventId: "receipt-active" });
+        const standby = createEvent({ webhookEventId: "receipt-standby", mode: "standby" });
+        const common = {
+          mode: "standby" as const,
+          timestamp: Date.now(),
+          deliveryContext: { isRedelivery: false },
+        };
+        const postback: webhook.Event = {
+          ...common,
+          type: "postback",
+          webhookEventId: "receipt-postback",
+          source: { type: "user", userId: "user-standby" },
+          postback: { data: "continue" },
+        };
+        const join = {
+          ...common,
+          type: "join",
+          webhookEventId: "receipt-join",
+          source: { type: "group", groupId: "group-standby" },
+        };
+        try {
+          for (const [events, expectedIds, marker] of [
+            [[standby, postback, join], [], null],
+            [[standby, active], ["message:message-receipt-active"], "durable"],
+            [[active], ["message:message-receipt-active"], "durable"],
+          ] as const) {
+            const body = JSON.stringify({ destination: "fixture-bot", events });
+            const admittedResponse = await fetch(webhookUrl, {
+              method: "POST",
+              headers: {
+                "content-type": "application/json",
+                "x-line-signature": crypto
+                  .createHmac("SHA256", "secret")
+                  .update(body)
+                  .digest("base64"),
+              },
+              body,
+            });
+            expect(admittedResponse.status).toBe(200);
+            expect((await queue.listPending()).map((entry) => entry.id)).toEqual(expectedIds);
+            expect(admittedResponse.headers.get("x-openclaw-delivery-accepted")).toBe(marker);
+            expect(await admittedResponse.json()).toEqual({ status: "ok" });
+          }
+          spool.start();
+          await vi.waitFor(() => expect(delivered).toEqual([active]));
+        } finally {
+          await spool.stop();
+        }
+      });
     } finally {
       try {
         if (server.listening) {
@@ -808,8 +874,8 @@ describe("monitorLineProvider lifecycle", () => {
     };
     bot.handleWebhook.mockImplementation(
       () =>
-        new Promise<void>((resolve) => {
-          releaseWebhook = resolve;
+        new Promise<Awaited<ReturnType<LineHandleWebhook>>>((resolve) => {
+          releaseWebhook = () => resolve("durable");
         }),
     );
 

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -1,5 +1,4 @@
 // Line plugin module implements monitor behavior.
-import type { webhook } from "@line/bot-sdk";
 import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
 import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
 import { hasFinalInboundReplyDispatch } from "openclaw/plugin-sdk/channel-inbound";
@@ -62,7 +61,7 @@ interface MonitorLineProviderOptions {
 
 interface LineProviderMonitor {
   account: ResolvedLineAccount;
-  handleWebhook: (body: webhook.CallbackRequest) => Promise<void>;
+  handleWebhook: ReturnType<typeof createLineBot>["handleWebhook"];
   stop: () => Promise<void>;
 }
 
@@ -418,9 +417,10 @@ export async function monitorLineProvider(
 
           if (body.events && body.events.length > 0) {
             logVerbose(`line: received ${body.events.length} webhook events`);
-            await match.target.bot.handleWebhook(body);
-            // Only a committed event is adopted; signed LINE verification pings must stay unmarked.
-            res.setHeader("x-openclaw-delivery-accepted", "durable");
+            // Only the admission owner can distinguish queued events from ignored standby deliveries.
+            if ((await match.target.bot.handleWebhook(body)) === "durable") {
+              res.setHeader("x-openclaw-delivery-accepted", "durable");
+            }
           }
           res.statusCode = 200;
           res.setHeader("Content-Type", "application/json");

--- a/extensions/line/src/webhook-node.test.ts
+++ b/extensions/line/src/webhook-node.test.ts
@@ -105,7 +105,7 @@ function createMiddlewareRequest(
 }
 
 function createPostWebhookTestHarness(rawBody: string, secret = "secret") {
-  const bot = { handleWebhook: vi.fn(async () => {}) };
+  const bot = { handleWebhook: vi.fn(async () => "durable" as const) };
   const runtime = createRuntimeMock();
   const handler = createLineNodeWebhookHandler({
     channelSecret: secret,
@@ -198,6 +198,7 @@ async function invokeNodePostContract(params: {
       // oxlint-disable-next-line typescript/only-throw-error -- Webhook boundaries must report non-Error throws from downstream dispatchers.
       throw params.failWith;
     }
+    return "durable" as const;
   });
   const runtime = createRuntimeMock();
   const handler = createLineNodeWebhookHandler({
@@ -380,7 +381,7 @@ describe("LINE webhook shared POST contract", () => {
 
 describe("createLineNodeWebhookHandler", () => {
   it("returns 200 for GET", async () => {
-    const bot = { handleWebhook: vi.fn(async () => {}) };
+    const bot = { handleWebhook: vi.fn(async () => "durable" as const) };
     const runtime = createRuntimeMock();
     const handler = createLineNodeWebhookHandler({
       channelSecret: "secret",
@@ -397,7 +398,7 @@ describe("createLineNodeWebhookHandler", () => {
   });
 
   it("returns 204 for HEAD", async () => {
-    const bot = { handleWebhook: vi.fn(async () => {}) };
+    const bot = { handleWebhook: vi.fn(async () => "durable" as const) };
     const runtime = createRuntimeMock();
     const handler = createLineNodeWebhookHandler({
       channelSecret: "secret",
@@ -425,7 +426,7 @@ describe("createLineNodeWebhookHandler", () => {
   });
 
   it("rejects unsigned POST requests before reading the body", async () => {
-    const bot = { handleWebhook: vi.fn(async () => {}) };
+    const bot = { handleWebhook: vi.fn(async () => "durable" as const) };
     const runtime = createRuntimeMock();
     const readBody = vi.fn(async () => JSON.stringify({ events: [{ type: "message" }] }));
     const handler = createLineNodeWebhookHandler({
@@ -458,7 +459,7 @@ describe("createLineNodeWebhookHandler", () => {
 
   it("uses strict pre-auth limits for signed POST requests", async () => {
     const rawBody = JSON.stringify({ events: [{ type: "message" }] });
-    const bot = { handleWebhook: vi.fn(async () => {}) };
+    const bot = { handleWebhook: vi.fn(async () => "durable" as const) };
     const runtime = createRuntimeMock();
     const readBody = vi.fn(async (_req: IncomingMessage, maxBytes: number, timeoutMs?: number) => {
       expect(maxBytes).toBe(64 * 1024);
@@ -514,8 +515,8 @@ describe("createLineNodeWebhookHandler", () => {
     const bot = {
       handleWebhook: vi.fn(
         async () =>
-          await new Promise<void>((resolve) => {
-            releaseAuthenticated = resolve;
+          await new Promise<"durable">((resolve) => {
+            releaseAuthenticated = () => resolve("durable");
           }),
       ),
     };

--- a/extensions/line/src/webhook-node.ts
+++ b/extensions/line/src/webhook-node.ts
@@ -1,6 +1,5 @@
 // Line plugin module implements webhook node behavior.
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { webhook } from "@line/bot-sdk";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { danger, logVerbose, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import {
@@ -8,6 +7,7 @@ import {
   readRequestBodyWithLimit,
   requestBodyErrorToText,
 } from "openclaw/plugin-sdk/webhook-request-guards";
+import type { createLineBot } from "./bot.js";
 import { parseLineWebhookBody, validateLineSignature } from "./webhook-utils.js";
 
 const LINE_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
@@ -29,7 +29,7 @@ type ReadBodyFn = (req: IncomingMessage, maxBytes: number, timeoutMs?: number) =
 
 export function createLineNodeWebhookHandler(params: {
   channelSecret: string;
-  bot: { handleWebhook: (body: webhook.CallbackRequest) => Promise<void> };
+  bot: Pick<ReturnType<typeof createLineBot>, "handleWebhook">;
   runtime: RuntimeEnv;
   readBody?: ReadBodyFn;
   maxBodyBytes?: number;

--- a/extensions/line/src/webhook-spool.test-support.ts
+++ b/extensions/line/src/webhook-spool.test-support.ts
@@ -31,7 +31,9 @@ export function createEvent(params: {
   messageId?: string;
   userId?: string;
   text?: string;
+  mode?: webhook.EventMode;
 }): webhook.Event {
+  const mode = params.mode ?? "active";
   const event: webhook.MessageEvent = {
     type: "message",
     message: {
@@ -40,10 +42,11 @@ export function createEvent(params: {
       text: params.text ?? "hello",
       quoteToken: "test-quote-token-placeholder",
     },
-    replyToken: "test-reply-token",
+    // LINE omits the reply token from the copy it sends to a standby channel.
+    ...(mode === "standby" ? {} : { replyToken: "test-reply-token" }),
     timestamp: Date.now(),
     source: { type: "user", userId: params.userId ?? "user-1" },
-    mode: "active",
+    mode,
     webhookEventId: params.webhookEventId,
     deliveryContext: { isRedelivery: false },
   };

--- a/extensions/line/src/webhook-spool.test-support.ts
+++ b/extensions/line/src/webhook-spool.test-support.ts
@@ -33,7 +33,6 @@ export function createEvent(params: {
   text?: string;
   mode?: webhook.EventMode;
 }): webhook.Event {
-  const mode = params.mode ?? "active";
   const event: webhook.MessageEvent = {
     type: "message",
     message: {
@@ -42,11 +41,10 @@ export function createEvent(params: {
       text: params.text ?? "hello",
       quoteToken: "test-quote-token-placeholder",
     },
-    // LINE omits the reply token from the copy it sends to a standby channel.
-    ...(mode === "standby" ? {} : { replyToken: "test-reply-token" }),
+    ...(params.mode === "standby" ? {} : { replyToken: "test-reply-token" }),
     timestamp: Date.now(),
     source: { type: "user", userId: params.userId ?? "user-1" },
-    mode,
+    mode: params.mode ?? "active",
     webhookEventId: params.webhookEventId,
     deliveryContext: { isRedelivery: false },
   };

--- a/extensions/line/src/webhook-spool.test.ts
+++ b/extensions/line/src/webhook-spool.test.ts
@@ -95,39 +95,6 @@ describe("LINE webhook spool", () => {
     });
   });
 
-  it("never admits an event delivered while another channel holds chat control", async () => {
-    await withQueue(async (queue) => {
-      const deliver = vi.fn(async (_event, _destination, control) => {
-        await control.turnAdoptionLifecycle.onAdopted();
-      });
-      const spool = createLineWebhookSpool({
-        accountId: "default",
-        runtime: runtime(),
-        queue,
-        deliver,
-      });
-      const standby = createEvent({
-        webhookEventId: "event-standby",
-        userId: "user-standby",
-        mode: "standby",
-      });
-      const active = createEvent({ webhookEventId: "event-active", userId: "user-active" });
-
-      await spool.accept({ destination: "destination-1", events: [standby, active] });
-
-      const pending = await queue.listPending();
-      expect(pending.map((entry) => entry.id)).toEqual(["message:message-event-active"]);
-
-      spool.start();
-      try {
-        await waitForVerdict(queue, "message:message-event-active", "completed");
-        expect(deliver.mock.calls.map((call) => call[0])).toEqual([active]);
-      } finally {
-        await spool.stop();
-      }
-    });
-  });
-
   it("caps active deliveries across repeated drain pumps", async () => {
     await withQueue(async (queue) => {
       let releaseDeliveries = () => {};

--- a/extensions/line/src/webhook-spool.test.ts
+++ b/extensions/line/src/webhook-spool.test.ts
@@ -95,6 +95,39 @@ describe("LINE webhook spool", () => {
     });
   });
 
+  it("never admits an event delivered while another channel holds chat control", async () => {
+    await withQueue(async (queue) => {
+      const deliver = vi.fn(async (_event, _destination, control) => {
+        await control.turnAdoptionLifecycle.onAdopted();
+      });
+      const spool = createLineWebhookSpool({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver,
+      });
+      const standby = createEvent({
+        webhookEventId: "event-standby",
+        userId: "user-standby",
+        mode: "standby",
+      });
+      const active = createEvent({ webhookEventId: "event-active", userId: "user-active" });
+
+      await spool.accept({ destination: "destination-1", events: [standby, active] });
+
+      const pending = await queue.listPending();
+      expect(pending.map((entry) => entry.id)).toEqual(["message:message-event-active"]);
+
+      spool.start();
+      try {
+        await waitForVerdict(queue, "message:message-event-active", "completed");
+        expect(deliver.mock.calls.map((call) => call[0])).toEqual([active]);
+      } finally {
+        await spool.stop();
+      }
+    });
+  });
+
   it("caps active deliveries across repeated drain pumps", async () => {
     await withQueue(async (queue) => {
       let releaseDeliveries = () => {};

--- a/extensions/line/src/webhook-spool.ts
+++ b/extensions/line/src/webhook-spool.ts
@@ -8,7 +8,7 @@ import {
   type ChannelIngressQueue,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { danger, type RuntimeEnv, warn } from "openclaw/plugin-sdk/runtime-env";
+import { danger, logVerbose, type RuntimeEnv, warn } from "openclaw/plugin-sdk/runtime-env";
 import { runDetachedWebhookWork } from "openclaw/plugin-sdk/webhook-request-guards";
 import { getLineRuntime } from "./runtime.js";
 import {
@@ -250,11 +250,21 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
   return {
     accept: async (body) => {
       const events = body.events ?? [];
-      if (events.length === 0) {
+      // LINE copies every event to each channel on an Official Account and marks the
+      // copies for channels without chat control as standby: they carry no reply token
+      // and must not send, so admitting one would answer over the channel that does.
+      const admissible = events.filter((event) => event.mode !== "standby");
+      const ignored = events.length - admissible.length;
+      if (ignored > 0) {
+        logVerbose(
+          `line: ignoring ${ignored} standby webhook events; another channel holds chat control`,
+        );
+      }
+      if (admissible.length === 0) {
         return;
       }
       await monitor.admitBatch(
-        events.map((event) => ({ event, destination: body.destination ?? "" })),
+        admissible.map((event) => ({ event, destination: body.destination ?? "" })),
         { receivedAt: Date.now() },
       );
     },

--- a/extensions/line/src/webhook-spool.ts
+++ b/extensions/line/src/webhook-spool.ts
@@ -8,7 +8,7 @@ import {
   type ChannelIngressQueue,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { danger, logVerbose, type RuntimeEnv, warn } from "openclaw/plugin-sdk/runtime-env";
+import { danger, type RuntimeEnv, warn } from "openclaw/plugin-sdk/runtime-env";
 import { runDetachedWebhookWork } from "openclaw/plugin-sdk/webhook-request-guards";
 import { getLineRuntime } from "./runtime.js";
 import {
@@ -61,7 +61,7 @@ export class LineWebhookTerminalDeliveryError extends Error {
 }
 
 type LineWebhookSpool = {
-  accept: (body: webhook.CallbackRequest) => Promise<void>;
+  accept: (body: webhook.CallbackRequest) => Promise<"durable" | "ignored">;
   start: () => void;
   stop: () => Promise<void>;
 };
@@ -249,24 +249,16 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
 
   return {
     accept: async (body) => {
-      const events = body.events ?? [];
-      // LINE copies every event to each channel on an Official Account and marks the
-      // copies for channels without chat control as standby: they carry no reply token
-      // and must not send, so admitting one would answer over the channel that does.
-      const admissible = events.filter((event) => event.mode !== "standby");
-      const ignored = events.length - admissible.length;
-      if (ignored > 0) {
-        logVerbose(
-          `line: ignoring ${ignored} standby webhook events; another channel holds chat control`,
-        );
+      // Standby deliveries belong to the channel holding LINE chat control.
+      const events = (body.events ?? []).filter((event) => event.mode !== "standby");
+      if (events.length === 0) {
+        return "ignored";
       }
-      if (admissible.length === 0) {
-        return;
-      }
-      await monitor.admitBatch(
-        admissible.map((event) => ({ event, destination: body.destination ?? "" })),
+      const admissions = await monitor.admitBatch(
+        events.map((event) => ({ event, destination: body.destination ?? "" })),
         { receivedAt: Date.now() },
       );
+      return admissions.some((admission) => admission.kind === "durable") ? "durable" : "ignored";
     },
     start: () => {
       if (!stopTask) {


### PR DESCRIPTION
## What Problem This Solves

LINE sends standby webhook copies to channels that do not hold chat control. OpenClaw admitted those copies and could answer over the controlling channel, using push quota when no reply token was present.

Closes #133576.

## Why This Change Was Made

Filter standby events at the plugin's admission owner before they enter the queue or start a turn. Propagate the existing canonical admission result to the HTTP route so an ignored batch is never marked `x-openclaw-delivery-accepted: durable`. Active duplicates still receive their durable acknowledgment.

The contributor's admission fix is preserved. The improved repair replaces the separate skip log with an explicit ignored admission result and replaces duplicate spool-only coverage with signed HTTP plus real queue coverage. It leaves historical queued rows and the existing queue schema unchanged. Original contributor history is preserved.

## User Impact

Standby deliveries return HTTP 200 without new queue rows, turns, or a false durable marker. Active deliveries retain normal admission and drain behavior. Production +14/-13 (net +1), tests/support +84/-16; the small source growth carries the admission owner's fact through the existing bot/HTTP boundary. Documentation +6/-3.

## Evidence

Independent maintainer proof executed trusted main plus equivalent authored changes, without executing fork scripts or configuration locally. Baseline regressions failed; repaired coverage passed 79 LINE owner/sibling tests plus the core heartbeat cadence test, followed by 18 final target tests. Production/test typechecks, lint, relevant static guards, and the complete build passed. Fresh complete-candidate Codex reviews found no actionable P0 findings. Published head `22cd4834aad83f66328a0986573b7c0101649493` passed [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33428521100). Hosted LINE suites passed 721 tests, including the changed regression.

Signed loopback HTTP and a real SQLite ingress queue cover standby message/postback/join batches, mixed active batches, duplicate suppression, durable receipts, and actual active draining. Existing unsigned requests, verification pings, held admissions, redacted failures, shutdown, and restart-recovery controls pass.

The contributor separately reported an authenticated LINE A/B replay: a captured event replayed as standby consumed one push on the old build and none on the repaired build; active replay still completed. That is attributed contributor evidence. The maintainer independently proves the new admission/HTTP behavior with synthetic signed requests; no new credentialed LINE delivery or historical-row migration is claimed.

Installed LINE SDK11.2.0 and official documentation were inspected for standby mode and reply-token behavior. The defect is present in the current owner; exact original introduction is unknown. Latest ClawSweeper dependency/proof requests are addressed by these source and behavior checks.

Thanks @edenfunf.
