### PR TITLE
perf: separate static provider catalogs from live discovery

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3404,7 +3404,7 @@ src/plugin-sdk/provider-auth-result.ts	4
 src/plugin-sdk/provider-auth-runtime.ts	1
 src/plugin-sdk/provider-auth.ts	1
 src/plugin-sdk/provider-catalog-live-runtime.ts	2
-src/plugin-sdk/provider-catalog-shared.ts	4
+src/plugin-sdk/provider-catalog-shared.ts	1
 src/plugin-sdk/provider-enable-config.ts	2
 src/plugin-sdk/provider-entry.ts	3
 src/plugin-sdk/provider-onboard.ts	6

--- a/src/plugin-sdk/provider-catalog-shared.ts
+++ b/src/plugin-sdk/provider-catalog-shared.ts
@@ -1,25 +1,15 @@
 // Provider catalog helpers normalize, hash, and expose model catalogs for provider plugins.
 import { createHash } from "node:crypto";
-import { normalizeModelCatalog } from "@openclaw/model-catalog-core/model-catalog-normalize";
-import { buildModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
-import type {
-  ModelCatalogCost,
-  ModelCatalogMediaInputConfig,
-  ModelCatalogModel,
-  ModelCatalogTieredCost,
-} from "@openclaw/model-catalog-core/model-catalog-types";
 import { findNormalizedProviderKey } from "@openclaw/model-catalog-core/provider-id";
 import {
   isFutureDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "../../packages/normalization-core/src/number-coercion.js";
-import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
 import { normalizeConfiguredProviderCatalogModelId } from "../agents/model-ref-shared.js";
 import { resolveProviderRequestCapabilities } from "../agents/provider-attribution.js";
 import type { ModelDefinitionConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
-import type { ProviderPlugin } from "../plugins/types.js";
 import type { ModelProviderConfig } from "./provider-model-shared.js";
 
 export type {
@@ -29,9 +19,14 @@ export type {
 } from "../plugins/types.js";
 
 export {
+  buildManifestModelProviderConfig,
+  buildManifestProviderCatalogFamily,
   buildPairedProviderApiKeyCatalog,
   buildSingleProviderApiKeyCatalog,
   findCatalogTemplate,
+  readManifestProviderDefaultModelRef,
+  type ManifestProviderCatalogEntry,
+  type ManifestProviderCatalogSurface,
 } from "../plugins/provider-catalog.js";
 
 /**
@@ -117,198 +112,6 @@ export async function getCachedLiveCatalogValue<T>(params: {
  */
 export function clearLiveCatalogCacheForTests(): void {
   liveCatalogCache.clear();
-}
-
-function countRawManifestCatalogModels(catalog: unknown): number | undefined {
-  if (!catalog || typeof catalog !== "object") {
-    return undefined;
-  }
-  const models = (catalog as { models?: unknown }).models;
-  return Array.isArray(models) ? models.length : undefined;
-}
-
-/** Reads a provider's normalized manifest default as a fully qualified model ref. */
-export function readManifestProviderDefaultModelRef(
-  manifest: unknown,
-  providerId: string,
-): string | undefined {
-  const catalog = (manifest as { modelCatalog?: { providers?: Record<string, unknown> } })
-    ?.modelCatalog?.providers?.[providerId];
-  const defaultModel = normalizeOptionalString(
-    (catalog as { defaultModel?: unknown })?.defaultModel,
-  );
-  return defaultModel ? buildModelCatalogRef(providerId, defaultModel) : undefined;
-}
-
-function cloneManifestCatalogTieredCost(
-  tier: ModelCatalogTieredCost,
-): NonNullable<ModelDefinitionConfig["cost"]["tieredPricing"]>[number] {
-  return {
-    input: tier.input,
-    output: tier.output,
-    cacheRead: tier.cacheRead,
-    cacheWrite: tier.cacheWrite,
-    range: tier.range.length === 1 ? [tier.range[0]] : [tier.range[0], tier.range[1]],
-  };
-}
-
-function cloneManifestCatalogCost(cost: ModelCatalogCost): ModelDefinitionConfig["cost"] {
-  return {
-    input: cost.input ?? 0,
-    output: cost.output ?? 0,
-    cacheRead: cost.cacheRead ?? 0,
-    cacheWrite: cost.cacheWrite ?? 0,
-    ...(cost.tieredPricing
-      ? { tieredPricing: cost.tieredPricing.map(cloneManifestCatalogTieredCost) }
-      : {}),
-  };
-}
-
-function buildManifestCatalogModelInput(model: ModelCatalogModel): ModelDefinitionConfig["input"] {
-  if (model.input?.includes("document")) {
-    throw new Error(
-      `Manifest modelCatalog row ${model.id} uses unsupported runtime input document`,
-    );
-  }
-  return model.input?.filter((item): item is "text" | "image" => item !== "document") ?? ["text"];
-}
-
-function cloneManifestCatalogMediaInput(
-  mediaInput?: ModelCatalogMediaInputConfig,
-): ModelDefinitionConfig["mediaInput"] | undefined {
-  if (!mediaInput?.image) {
-    return undefined;
-  }
-  return {
-    image: { ...mediaInput.image },
-  };
-}
-
-function buildManifestCatalogModel(
-  providerId: string,
-  model: ModelCatalogModel,
-): ModelDefinitionConfig {
-  if (model.contextWindow === undefined) {
-    throw new Error(`Manifest modelCatalog row ${model.id} is missing contextWindow`);
-  }
-  if (model.maxTokens === undefined) {
-    throw new Error(`Manifest modelCatalog row ${model.id} is missing maxTokens`);
-  }
-  const id = normalizeConfiguredProviderCatalogModelId(providerId, model.id, {
-    allowManifestNormalization: false,
-  });
-  return {
-    id,
-    name: model.name ?? id,
-    ...(model.api ? { api: model.api } : {}),
-    ...(model.baseUrl ? { baseUrl: model.baseUrl } : {}),
-    reasoning: model.reasoning ?? false,
-    input: buildManifestCatalogModelInput(model),
-    cost: cloneManifestCatalogCost(model.cost ?? {}),
-    contextWindow: model.contextWindow,
-    ...(model.contextTokens !== undefined ? { contextTokens: model.contextTokens } : {}),
-    maxTokens: model.maxTokens,
-    ...(model.thinkingLevelMap ? { thinkingLevelMap: { ...model.thinkingLevelMap } } : {}),
-    ...(model.headers ? { headers: { ...model.headers } } : {}),
-    ...(model.compat ? { compat: { ...model.compat } } : {}),
-    ...(model.mediaInput ? { mediaInput: cloneManifestCatalogMediaInput(model.mediaInput) } : {}),
-  };
-}
-
-/**
- * Converts a plugin manifest modelCatalog provider into runtime provider config.
- */
-export function buildManifestModelProviderConfig(params: {
-  /** Provider id that owns the manifest catalog rows. */
-  providerId: string;
-  /** Raw manifest modelCatalog provider block to normalize into runtime config. */
-  catalog: unknown;
-}): ModelProviderConfig {
-  const catalog = normalizeModelCatalog(
-    { providers: { [params.providerId]: params.catalog } },
-    { ownedProviders: new Set([params.providerId]) },
-  )?.providers?.[params.providerId];
-  if (!catalog) {
-    throw new Error(`Missing modelCatalog.providers.${params.providerId}`);
-  }
-  if (!catalog.baseUrl) {
-    throw new Error(`Missing modelCatalog.providers.${params.providerId}.baseUrl`);
-  }
-  const rawModelCount = countRawManifestCatalogModels(params.catalog);
-  if (rawModelCount !== undefined && rawModelCount !== catalog.models.length) {
-    throw new Error(`Invalid modelCatalog.providers.${params.providerId}.models`);
-  }
-  return {
-    baseUrl: catalog.baseUrl,
-    ...(catalog.api ? { api: catalog.api } : {}),
-    ...(catalog.headers ? { headers: { ...catalog.headers } } : {}),
-    models: catalog.models.map((model) => buildManifestCatalogModel(params.providerId, model)),
-  };
-}
-
-export type ManifestProviderCatalogSurface = {
-  id: string;
-  label: string;
-  catalog: unknown;
-};
-
-export type ManifestProviderCatalogEntry = {
-  id: string;
-  label: string;
-  baseUrl: string;
-  models: ModelProviderConfig["models"];
-  buildProvider: () => ModelProviderConfig;
-};
-
-/** Projects an ordered family of manifest catalogs into static provider and model surfaces. */
-export function buildManifestProviderCatalogFamily(params: {
-  surfaces: readonly ManifestProviderCatalogSurface[];
-  docsPath?: string;
-}) {
-  const entries: ManifestProviderCatalogEntry[] = params.surfaces.map((surface) => {
-    const buildProvider = () =>
-      buildManifestModelProviderConfig({
-        providerId: surface.id,
-        catalog: surface.catalog,
-      });
-    const provider = buildProvider();
-    return {
-      id: surface.id,
-      label: surface.label,
-      baseUrl: provider.baseUrl,
-      models: provider.models,
-      buildProvider,
-    };
-  });
-  const staticDiscovery: ProviderPlugin[] = entries.map(({ id, label, buildProvider }) => ({
-    id,
-    label,
-    docsPath: params.docsPath ?? "/providers/models",
-    auth: [],
-    staticCatalog: {
-      order: "simple",
-      run: async () => ({ provider: buildProvider() }),
-    },
-  }));
-
-  return {
-    entries,
-    staticDiscovery,
-    staticCatalog: async () => ({
-      providers: Object.fromEntries(entries.map(({ id, buildProvider }) => [id, buildProvider()])),
-    }),
-    augmentModelCatalog: () =>
-      entries.flatMap(({ id: provider, models }) =>
-        models.map((entry) => ({
-          provider,
-          id: entry.id,
-          name: entry.name,
-          reasoning: entry.reasoning,
-          input: [...entry.input],
-          contextWindow: entry.contextWindow,
-        })),
-      ),
-  };
 }
 
 function normalizeConfiguredCatalogModelInput(

--- a/src/plugin-sdk/provider-entry.test.ts
+++ b/src/plugin-sdk/provider-entry.test.ts
@@ -1,5 +1,5 @@
 // Provider entry tests cover provider plugin entry contracts and catalog integration.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ModelDefinitionConfig } from "../config/types.models.js";
 import { capturePluginRegistration } from "../plugins/captured-registration.js";
 import type { ProviderCatalogContext } from "../plugins/types.js";
@@ -86,6 +86,58 @@ async function captureProviderEntry(params: {
 }
 
 describe("defineSingleProviderPluginEntry", () => {
+  it("keeps static catalog registration independent of live discovery", async () => {
+    const liveCatalog = {
+      provider: { baseUrl: "https://api.demo.test/v1", models: [createModel("live", "Live")] },
+    };
+    const buildLiveCatalog = vi.fn(async () => liveCatalog);
+    const loadLiveCatalog = vi.fn(() => ({
+      buildOpenAICompatibleProviderCatalog: buildLiveCatalog,
+    }));
+    vi.doMock("../agents/provider-attribution.js", () => {
+      throw new Error("Static provider entry loaded transport policy");
+    });
+    vi.doMock("./provider-catalog-live-runtime.js", loadLiveCatalog);
+    vi.resetModules();
+    try {
+      const { defineSingleProviderPluginEntry: defineColdEntry } =
+        await import("./provider-entry.js");
+      const entry = defineColdEntry({
+        id: "demo",
+        name: "Demo Provider",
+        description: "Demo provider plugin",
+        manifest: createProviderManifest(),
+        provider: {
+          label: "Demo",
+          docsPath: "/providers/demo",
+          aliases: ["demo-alias"],
+          catalog: { liveModelDiscovery: true },
+        },
+      });
+      const provider = capturePluginRegistration(entry).providers[0];
+      const context = createCatalogContext();
+      await expect(provider?.staticCatalog?.run(context)).resolves.toMatchObject({
+        provider: { models: [createModel("default", "Default")] },
+      });
+      await expect(provider?.catalog?.run({ ...context, providerIds: [] })).resolves.toBeNull();
+      expect(loadLiveCatalog).not.toHaveBeenCalled();
+
+      const scopedContext = { ...context, providerIds: ["demo-alias"] };
+      await expect(provider?.catalog?.run(scopedContext)).resolves.toBe(liveCatalog);
+      expect(buildLiveCatalog).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          ctx: scopedContext,
+          providerId: "demo",
+          providerAliases: ["demo-alias"],
+        }),
+      );
+    } finally {
+      vi.doUnmock("../agents/provider-attribution.js");
+      vi.doUnmock("./provider-catalog-live-runtime.js");
+      vi.resetModules();
+    }
+  });
+
   it("derives API-key auth and static and live model catalogs from the provider manifest", async () => {
     const manifest = createProviderManifest();
     const entry = defineSingleProviderPluginEntry({

--- a/src/plugin-sdk/provider-entry.ts
+++ b/src/plugin-sdk/provider-entry.ts
@@ -11,6 +11,11 @@ import type {
 } from "../plugins/manifest-types.js";
 import { createProviderApiKeyAuthMethod } from "../plugins/provider-api-key-auth.js";
 import { projectProviderCatalogResultToUnifiedTextRows } from "../plugins/provider-catalog-unified-text.js";
+import {
+  buildManifestModelProviderConfig,
+  buildSingleProviderApiKeyCatalog,
+  readManifestProviderDefaultModelRef,
+} from "../plugins/provider-catalog.js";
 import type {
   ProviderPlugin,
   ProviderCatalogContext,
@@ -25,21 +30,20 @@ import {
   isRecordWithoutThrowing,
   readRecordValue,
 } from "../shared/safe-record.js";
+import { createLazyRuntimeMethod, createLazyRuntimeModule } from "./lazy-runtime.js";
 import { definePluginEntry } from "./plugin-entry.js";
 import type {
   OpenClawPluginApi,
   OpenClawPluginConfigSchema,
   OpenClawPluginDefinition,
 } from "./plugin-entry.js";
-import {
-  buildOpenAICompatibleProviderCatalog,
-  type OpenAICompatibleModelDiscoveryOptions,
-} from "./provider-catalog-live-runtime.js";
-import {
-  buildManifestModelProviderConfig,
-  buildSingleProviderApiKeyCatalog,
-  readManifestProviderDefaultModelRef,
-} from "./provider-catalog-shared.js";
+import type { OpenAICompatibleModelDiscoveryOptions } from "./provider-catalog-live-runtime.js";
+
+// Registration needs static metadata; live discovery loads only when its catalog hook runs.
+const buildOpenAICompatibleProviderCatalog = createLazyRuntimeMethod(
+  createLazyRuntimeModule(() => import("./provider-catalog-live-runtime.js")),
+  (runtime) => runtime.buildOpenAICompatibleProviderCatalog,
+);
 
 type ApiKeyAuthMethodOptions = Parameters<typeof createProviderApiKeyAuthMethod>[0];
 

--- a/src/plugins/provider-catalog.ts
+++ b/src/plugins/provider-catalog.ts
@@ -1,12 +1,21 @@
 // Builds provider catalog entries from plugin manifest metadata.
+import { normalizeModelCatalog } from "@openclaw/model-catalog-core/model-catalog-normalize";
+import { buildModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
+import type {
+  ModelCatalogCost,
+  ModelCatalogMediaInputConfig,
+  ModelCatalogModel,
+  ModelCatalogTieredCost,
+} from "@openclaw/model-catalog-core/model-catalog-types";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { normalizeConfiguredProviderCatalogModelId } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import type { ModelProviderConfig } from "../config/types.js";
+import type { ModelDefinitionConfig, ModelProviderConfig } from "../config/types.models.js";
 import { copyRecordEntries } from "../shared/safe-record.js";
-import type { ProviderCatalogContext, ProviderCatalogResult } from "./types.js";
+import type { ProviderCatalogContext, ProviderCatalogResult, ProviderPlugin } from "./types.js";
 
 function addApiKeyToProvider(
   provider: ModelProviderConfig,
@@ -87,5 +96,198 @@ export async function buildPairedProviderApiKeyCatalog(params: {
         return providerWithApiKey ? [[id, providerWithApiKey]] : [];
       }),
     ),
+  };
+}
+
+function countRawManifestCatalogModels(catalog: unknown): number | undefined {
+  if (!catalog || typeof catalog !== "object") {
+    return undefined;
+  }
+  // SAFETY: Only the unknown models field is read; Array.isArray validates it next.
+  const models = (catalog as { models?: unknown }).models;
+  return Array.isArray(models) ? models.length : undefined;
+}
+
+/** Reads a provider's normalized manifest default as a fully qualified model ref. */
+export function readManifestProviderDefaultModelRef(
+  manifest: unknown,
+  providerId: string,
+): string | undefined {
+  // SAFETY: Optional reads locate metadata without trusting its model value.
+  const catalog = (manifest as { modelCatalog?: { providers?: Record<string, unknown> } })
+    ?.modelCatalog?.providers?.[providerId];
+  const defaultModel = normalizeOptionalString(
+    // SAFETY: The field stays unknown until normalizeOptionalString validates it.
+    (catalog as { defaultModel?: unknown })?.defaultModel,
+  );
+  return defaultModel ? buildModelCatalogRef(providerId, defaultModel) : undefined;
+}
+
+function cloneManifestCatalogTieredCost(
+  tier: ModelCatalogTieredCost,
+): NonNullable<ModelDefinitionConfig["cost"]["tieredPricing"]>[number] {
+  return {
+    input: tier.input,
+    output: tier.output,
+    cacheRead: tier.cacheRead,
+    cacheWrite: tier.cacheWrite,
+    range: tier.range.length === 1 ? [tier.range[0]] : [tier.range[0], tier.range[1]],
+  };
+}
+
+function cloneManifestCatalogCost(cost: ModelCatalogCost): ModelDefinitionConfig["cost"] {
+  return {
+    input: cost.input ?? 0,
+    output: cost.output ?? 0,
+    cacheRead: cost.cacheRead ?? 0,
+    cacheWrite: cost.cacheWrite ?? 0,
+    ...(cost.tieredPricing
+      ? { tieredPricing: cost.tieredPricing.map(cloneManifestCatalogTieredCost) }
+      : {}),
+  };
+}
+
+function buildManifestCatalogModelInput(model: ModelCatalogModel): ModelDefinitionConfig["input"] {
+  if (model.input?.includes("document")) {
+    throw new Error(
+      `Manifest modelCatalog row ${model.id} uses unsupported runtime input document`,
+    );
+  }
+  return model.input?.filter((item): item is "text" | "image" => item !== "document") ?? ["text"];
+}
+
+function cloneManifestCatalogMediaInput(
+  mediaInput?: ModelCatalogMediaInputConfig,
+): ModelDefinitionConfig["mediaInput"] | undefined {
+  if (!mediaInput?.image) {
+    return undefined;
+  }
+  return {
+    image: { ...mediaInput.image },
+  };
+}
+
+function buildManifestCatalogModel(
+  providerId: string,
+  model: ModelCatalogModel,
+): ModelDefinitionConfig {
+  if (model.contextWindow === undefined) {
+    throw new Error(`Manifest modelCatalog row ${model.id} is missing contextWindow`);
+  }
+  if (model.maxTokens === undefined) {
+    throw new Error(`Manifest modelCatalog row ${model.id} is missing maxTokens`);
+  }
+  const id = normalizeConfiguredProviderCatalogModelId(providerId, model.id, new Map());
+  return {
+    id,
+    name: model.name ?? id,
+    ...(model.api ? { api: model.api } : {}),
+    ...(model.baseUrl ? { baseUrl: model.baseUrl } : {}),
+    reasoning: model.reasoning ?? false,
+    input: buildManifestCatalogModelInput(model),
+    cost: cloneManifestCatalogCost(model.cost ?? {}),
+    contextWindow: model.contextWindow,
+    ...(model.contextTokens !== undefined ? { contextTokens: model.contextTokens } : {}),
+    maxTokens: model.maxTokens,
+    ...(model.thinkingLevelMap ? { thinkingLevelMap: { ...model.thinkingLevelMap } } : {}),
+    ...(model.headers ? { headers: { ...model.headers } } : {}),
+    ...(model.compat ? { compat: { ...model.compat } } : {}),
+    ...(model.mediaInput ? { mediaInput: cloneManifestCatalogMediaInput(model.mediaInput) } : {}),
+  };
+}
+
+/**
+ * Converts a plugin manifest modelCatalog provider into runtime provider config.
+ */
+export function buildManifestModelProviderConfig(params: {
+  /** Provider id that owns the manifest catalog rows. */
+  providerId: string;
+  /** Raw manifest modelCatalog provider block to normalize into runtime config. */
+  catalog: unknown;
+}): ModelProviderConfig {
+  const catalog = normalizeModelCatalog(
+    { providers: { [params.providerId]: params.catalog } },
+    { ownedProviders: new Set([params.providerId]) },
+  )?.providers?.[params.providerId];
+  if (!catalog) {
+    throw new Error(`Missing modelCatalog.providers.${params.providerId}`);
+  }
+  if (!catalog.baseUrl) {
+    throw new Error(`Missing modelCatalog.providers.${params.providerId}.baseUrl`);
+  }
+  const rawModelCount = countRawManifestCatalogModels(params.catalog);
+  if (rawModelCount !== undefined && rawModelCount !== catalog.models.length) {
+    throw new Error(`Invalid modelCatalog.providers.${params.providerId}.models`);
+  }
+  return {
+    baseUrl: catalog.baseUrl,
+    ...(catalog.api ? { api: catalog.api } : {}),
+    ...(catalog.headers ? { headers: { ...catalog.headers } } : {}),
+    models: catalog.models.map((model) => buildManifestCatalogModel(params.providerId, model)),
+  };
+}
+
+export type ManifestProviderCatalogSurface = {
+  id: string;
+  label: string;
+  catalog: unknown;
+};
+
+export type ManifestProviderCatalogEntry = {
+  id: string;
+  label: string;
+  baseUrl: string;
+  models: ModelProviderConfig["models"];
+  buildProvider: () => ModelProviderConfig;
+};
+
+/** Projects an ordered family of manifest catalogs into static provider and model surfaces. */
+export function buildManifestProviderCatalogFamily(params: {
+  surfaces: readonly ManifestProviderCatalogSurface[];
+  docsPath?: string;
+}) {
+  const entries: ManifestProviderCatalogEntry[] = params.surfaces.map((surface) => {
+    const buildProvider = () =>
+      buildManifestModelProviderConfig({
+        providerId: surface.id,
+        catalog: surface.catalog,
+      });
+    const provider = buildProvider();
+    return {
+      id: surface.id,
+      label: surface.label,
+      baseUrl: provider.baseUrl,
+      models: provider.models,
+      buildProvider,
+    };
+  });
+  const staticDiscovery: ProviderPlugin[] = entries.map(({ id, label, buildProvider }) => ({
+    id,
+    label,
+    docsPath: params.docsPath ?? "/providers/models",
+    auth: [],
+    staticCatalog: {
+      order: "simple",
+      run: async () => ({ provider: buildProvider() }),
+    },
+  }));
+
+  return {
+    entries,
+    staticDiscovery,
+    staticCatalog: async () => ({
+      providers: Object.fromEntries(entries.map(({ id, buildProvider }) => [id, buildProvider()])),
+    }),
+    augmentModelCatalog: () =>
+      entries.flatMap(({ id: provider, models }) =>
+        models.map((entry) => ({
+          provider,
+          id: entry.id,
+          name: entry.name,
+          reasoning: entry.reasoning,
+          input: [...entry.input],
+          contextWindow: entry.contextWindow,
+        })),
+      ),
   };
 }

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -123,9 +123,9 @@ describe("test-projects args", () => {
       config: "test/vitest/vitest.plugin-sdk.config.ts",
     },
     {
-      title: "routes unit-fast light targets to the cache-friendly unit-fast config",
+      title: "routes plugin-sdk light targets to the plugin-sdk-light config",
       target: "src/plugin-sdk/provider-entry.test.ts",
-      config: "test/vitest/vitest.unit-fast.config.ts",
+      config: "test/vitest/vitest.plugin-sdk-light.config.ts",
     },
     {
       title: "routes fake-timer unit-fast targets to the serial fake-timer config",

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -2429,7 +2429,7 @@ describe("scripts/test-projects changed-target routing", () => {
     {
       title: "keeps public plugin SDK changes focused by default",
       changedPath: "src/plugin-sdk/provider-entry.ts",
-      config: "test/vitest/vitest.unit-fast.config.ts",
+      config: "test/vitest/vitest.plugin-sdk-light.config.ts",
       testPath: "src/plugin-sdk/provider-entry.test.ts",
     },
     {
@@ -2713,7 +2713,7 @@ describe("scripts/test-projects changed-target routing", () => {
 
     expect(plans).toEqual([
       {
-        config: "test/vitest/vitest.unit-fast.config.ts",
+        config: "test/vitest/vitest.plugin-sdk-light.config.ts",
         forwardedArgs: [],
         includePatterns: ["src/plugin-sdk/provider-entry.test.ts"],
         watchMode: false,

--- a/test/vitest-projects-config.test.ts
+++ b/test/vitest-projects-config.test.ts
@@ -162,7 +162,7 @@ describe("projects vitest config", () => {
   });
 
   it.each([
-    ["ordinary", createUnitFastVitestConfig, "src/plugin-sdk/provider-entry.test.ts"],
+    ["ordinary", createUnitFastVitestConfig, "src/plugin-sdk/text-chunking.test.ts"],
     [
       "isolated",
       createUnitFastIsolatedVitestConfig,
@@ -172,7 +172,7 @@ describe("projects vitest config", () => {
   ])("limits %s unit-fast include files to the project's owned tests", (_, createConfig, owned) => {
     const unrelated = "src/gateway/openresponses-http.test.ts";
     const mixedIncludeFile = patternFiles.writePatternFile("mixed-unit-fast-include.json", [
-      "src/plugin-sdk/provider-entry.test.ts",
+      "src/plugin-sdk/text-chunking.test.ts",
       "src/system-agent/assistant.configured.test.ts",
       "src/acp/control-plane/manager.test.ts",
       unrelated,

--- a/test/vitest-unit-fast-config.test.ts
+++ b/test/vitest-unit-fast-config.test.ts
@@ -262,7 +262,7 @@ describe("unit-fast vitest lane", () => {
     expect(testConfig.include).toContain("src/commands/status-overview-values.test.ts");
     expect(testConfig.include).toContain("src/plugins/config-policy.test.ts");
     expect(testConfig.include).toContain("src/sessions/session-lifecycle-events.test.ts");
-    expect(testConfig.include).toContain("src/plugin-sdk/provider-entry.test.ts");
+    expect(testConfig.include).toContain("src/plugin-sdk/text-chunking.test.ts");
     expect(testConfig.include).not.toEqual(expect.arrayContaining(unitFastIsolatedTestFiles));
   });
 
@@ -275,7 +275,7 @@ describe("unit-fast vitest lane", () => {
     );
 
     const testConfig = requireTestConfig(config);
-    expect(testConfig.include).toContain("src/plugin-sdk/provider-entry.test.ts");
+    expect(testConfig.include).toContain("src/plugin-sdk/text-chunking.test.ts");
     expect(testConfig.include).toContain("src/commands/status-overview-values.test.ts");
   });
 
@@ -355,8 +355,8 @@ describe("unit-fast vitest lane", () => {
   });
 
   it("routes unit-fast source files to their unit-fast sibling tests", () => {
-    expect(resolveUnitFastTestIncludePattern("src/plugin-sdk/provider-entry.ts")).toBe(
-      "src/plugin-sdk/provider-entry.test.ts",
+    expect(resolveUnitFastTestIncludePattern("src/plugin-sdk/text-chunking.ts")).toBe(
+      "src/plugin-sdk/text-chunking.test.ts",
     );
     expect(resolveUnitFastTestIncludePattern("src/commands/status-overview-values.ts")).toBe(
       "src/commands/status-overview-values.test.ts",
@@ -485,10 +485,8 @@ describe("unit-fast vitest lane", () => {
     const pluginSdkLight = createPluginSdkLightVitestConfig({});
     const commandsLight = createCommandsLightVitestConfig({});
 
-    expect(unitFastTestFiles).toContain("src/plugin-sdk/provider-entry.test.ts");
-    expect(requireTestConfig(pluginSdkLight).exclude).toContain(
-      "plugin-sdk/provider-entry.test.ts",
-    );
+    expect(unitFastTestFiles).toContain("src/plugin-sdk/text-chunking.test.ts");
+    expect(requireTestConfig(pluginSdkLight).exclude).toContain("plugin-sdk/text-chunking.test.ts");
     expect(requireTestConfig(commandsLight).exclude).toContain("status-overview-values.test.ts");
   });
 });


### PR DESCRIPTION
Related: #130324, #130706

## What Problem This Solves

Provider plugin registration loaded live discovery and transport catalog dependencies even when only static manifest metadata was needed. This change separates that initialization work from the central provider registration path.

## Why This Change Was Made

Manifest catalog builders move into the existing plugin catalog owner. The public SDK continues to export the same functions and types, while provider entry registration imports the lightweight owner directly. Live discovery uses the existing lazy-runtime helpers and loads when its selected catalog hook runs.

The pure catalog normalizer receives an explicit empty policy map, preserving the previous `allowManifestNormalization: false` behavior. The prior provider declaration type is already an alias for the canonical config type. No API migration, configuration, dependency, schema, new SDK subpath, or metadata collection is introduced.

Most production churn is a move. The remaining growth is the lazy import boundary and required assertion-safety comments; the assertion baseline shrinks by three.

| Change | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 222 | 213 | +9 |
| Tests | 65 | 15 | +50 |
| Assertion baseline | 1 | 1 | 0 |

## User Impact

Static provider registration no longer eagerly loads the central live catalog runtime. Live discovery keeps its existing provider/alias scope and output, and existing auth and catalog behavior remain covered by the original tests. No operator action is required.

This does not remove every plugin-specific import path or by itself close the original Gateway CPU investigation. Qianfan onboarding still imports the broader SDK catalog surface; auditing that remaining onboarding boundary is a follow-up, not a fix claimed here.

## Evidence

Verified on `3b80c2f38c5fd32f389176ff190370bb6e43274f` with Node 24.19.0 and pnpm 12.1.0:

- The new cold-import regression failed on unchanged base code at the transport-policy sentinel, then passed after extraction. Static registration and empty discovery scope stay lazy; a matching alias invokes live discovery once.
- All 54 focused tests passed across provider entry, SDK catalog helpers, plugin catalog ownership, live family scope, BytePlus, and Qianfan. All 16 existing provider-entry cases remain. The added test is 30 net lines smaller than the original combined branch's version.
- Changed-file checks passed: core/plugin and test type checks, lint, SDK boundaries/exports, unused exports, and architecture guards. Runtime value cycles: zero.
- Full build passed in 5m 42s, including SDK declarations, 63 package-local plugins, CLI import guards, and UI budgets. No ineffective dynamic import warnings were emitted.
- The real built Qianfan entrypoint imported successfully in the standard isolated RSS harness: 201.8 MiB peak RSS, 46.5 MiB empty-Node baseline, no failure or timeout. This is a candidate measurement, not a before/after memory reduction or authenticated provider test.
- Deslop completed. Managed Codex autoreview returned scoped-clean with no findings at its default P0 priority. Source, lockfile, and tree hashes stayed unchanged through build and profiling.

## CI follow-up

The new cold-import regression correctly routes through SDK-light because it uses module mocks. Updated the existing routing fixtures to retain that ownership and use a pure SDK fixture for ordinary unit-fast checks. Broad/narrow changed-mode and exactly-once ownership assertions remain intact; no tests or assertions were removed and no new cases were added.

Reproduced all eight stale routing failures locally before their edits. Final verification passed 551 tests across all four affected routing suites, the original catalog cohort, and the pure fixture, with zero failures/skips. The expanded changed gate passed; final managed review was scoped-clean at P0. This corrective commit changes only four test files (+12/-14). Full PR totals are net +9 production / +50 test lines.

The original full-build and bounded Qianfan import proof remain associated with 3b80c2f38c5fd32f389176ff190370bb6e43274f; all original source/build hashes and the lockfile remain unchanged. No fresh-build or new authenticated-provider proof is claimed for this fixture-only correction. The separate docs release-list failure has been repaired on main; this corrective commit does not duplicate that change.
