### PR TITLE
fix(commands): ignore missing SecretRef passEnv values

### DIFF
--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -991,6 +991,11 @@ describe("buildGatewayInstallPlan", () => {
             },
           },
         },
+        channels: {
+          discord: {
+            token: { source: "exec", provider: "onepassword", id: "value" },
+          },
+        },
       },
     });
 

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -1002,6 +1002,39 @@ describe("buildGatewayInstallPlan", () => {
     expect(passEnvWarnings).toHaveLength(0);
   });
 
+  it("keeps the blocked warning when a Windows-only passEnv name is populated on a non-Windows host", async () => {
+    mockNodeGatewayPlanFixture({
+      serviceEnvironment: { OPENCLAW_PORT: "3000" },
+    });
+
+    const warn = vi.fn();
+    const plan = await buildGatewayInstallPlan({
+      env: isolatedPlanEnv({ WINDIR: "C:/Windows" }),
+      port: 3000,
+      runtime: "node",
+      platform: "linux",
+      warn,
+      config: {
+        secrets: {
+          providers: {
+            onepassword: {
+              source: "exec",
+              command: "/usr/bin/op",
+              args: ["read", "op://Private/Discord/password"],
+              passEnv: ["WINDIR"],
+            },
+          },
+        },
+      },
+    });
+
+    expect(plan.environment.WINDIR).toBeUndefined();
+    const passEnvWarnings = warn.mock.calls.filter((call) =>
+      String(call[0]).includes("blocked by host-env security policy"),
+    );
+    expect(passEnvWarnings).toHaveLength(1);
+  });
+
   it("includes passEnv values for plugin-managed exec SecretRef providers", async () => {
     mockNodeGatewayPlanFixture({
       serviceEnvironment: {

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -1025,6 +1025,11 @@ describe("buildGatewayInstallPlan", () => {
             },
           },
         },
+        channels: {
+          discord: {
+            token: { source: "exec", provider: "onepassword", id: "value" },
+          },
+        },
       },
     });
 

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -970,81 +970,6 @@ describe("buildGatewayInstallPlan", () => {
     expect(plan.environment.OP_CONNECT_TOKEN).toBe("op-connect-token");
     expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBeUndefined();
   });
-  it("skips Windows-only passEnv entries on non-Windows hosts without warnings", async () => {
-    mockNodeGatewayPlanFixture({ serviceEnvironment: { OPENCLAW_PORT: "3000" } });
-    const warn = vi.fn();
-
-    const plan = await buildGatewayInstallPlan({
-      env: isolatedPlanEnv(),
-      port: 3000,
-      runtime: "node",
-      platform: "linux",
-      warn,
-      config: {
-        secrets: {
-          providers: {
-            onepassword: {
-              source: "exec",
-              command: "/usr/bin/op",
-              args: ["read", "op://Private/Discord/password"],
-              passEnv: ["WINDIR", "SYSTEMROOT"],
-            },
-          },
-        },
-        channels: {
-          discord: {
-            token: { source: "exec", provider: "onepassword", id: "value" },
-          },
-        },
-      },
-    });
-
-    expect(plan.environment.WINDIR).toBeUndefined();
-    expect(plan.environment.SYSTEMROOT).toBeUndefined();
-    const passEnvWarnings = warn.mock.calls.filter((call) =>
-      String(call[0]).includes("blocked by host-env security policy"),
-    );
-    expect(passEnvWarnings).toHaveLength(0);
-  });
-
-  it("keeps the blocked warning when a Windows-only passEnv name is populated on a non-Windows host", async () => {
-    mockNodeGatewayPlanFixture({
-      serviceEnvironment: { OPENCLAW_PORT: "3000" },
-    });
-
-    const warn = vi.fn();
-    const plan = await buildGatewayInstallPlan({
-      env: isolatedPlanEnv({ WINDIR: "C:/Windows" }),
-      port: 3000,
-      runtime: "node",
-      platform: "linux",
-      warn,
-      config: {
-        secrets: {
-          providers: {
-            onepassword: {
-              source: "exec",
-              command: "/usr/bin/op",
-              args: ["read", "op://Private/Discord/password"],
-              passEnv: ["WINDIR"],
-            },
-          },
-        },
-        channels: {
-          discord: {
-            token: { source: "exec", provider: "onepassword", id: "value" },
-          },
-        },
-      },
-    });
-
-    expect(plan.environment.WINDIR).toBeUndefined();
-    const passEnvWarnings = warn.mock.calls.filter((call) =>
-      String(call[0]).includes("blocked by host-env security policy"),
-    );
-    expect(passEnvWarnings).toHaveLength(1);
-  });
-
   it("includes passEnv values for plugin-managed exec SecretRef providers", async () => {
     mockNodeGatewayPlanFixture({
       serviceEnvironment: {
@@ -1226,16 +1151,13 @@ describe("buildGatewayInstallPlan", () => {
     expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBeUndefined();
   });
 
-  it("allows safe inherited passEnv names while blocking dangerous exec SecretRef env", async () => {
-    mockNodeGatewayPlanFixture({
-      serviceEnvironment: {
-        OPENCLAW_PORT: "3000",
-      },
-    });
-
-    const warn = vi.fn();
-    const plan = await buildGatewayInstallPlan({
-      env: isolatedPlanEnv({
+  it.each(["linux", "win32"] as const)(
+    "ignores missing passEnv values while blocking populated dangerous values on %s",
+    async (platform) => {
+      mockNodeGatewayPlanFixture({ serviceEnvironment: { OPENCLAW_PORT: "3000" } });
+      const env = isolatedPlanEnv({
+        SYSTEMROOT: " ",
+        SAFE_PASS_ENV: " safe-value ",
         BASH_ENV: "/tmp/openclaw-test-bashenv",
         XDG_CONFIG_HOME: "/tmp/openclaw-test-xdg-home",
         XDG_CONFIG_DIRS: "/etc/xdg:/opt/xdg",
@@ -1243,64 +1165,84 @@ describe("buildGatewayInstallPlan", () => {
         AWS_ACCESS_KEY_ID: "aws-access-key",
         DOCKER_HOST: "tcp://docker.example.test:2376",
         NODE_TLS_REJECT_UNAUTHORIZED: "0",
-      }),
-      port: 3000,
-      runtime: "node",
-      warn,
-      config: {
-        secrets: {
-          providers: {
-            onepassword: {
-              source: "exec",
-              command: "/usr/bin/op",
-              args: ["read", "op://Private/Discord/password"],
-              passEnv: [
-                "HOME",
-                "BASH_ENV",
-                "XDG_CONFIG_HOME",
-                "XDG_CONFIG_DIRS",
-                "GH_TOKEN",
-                "AWS_ACCESS_KEY_ID",
-                "DOCKER_HOST",
-                "NODE_TLS_REJECT_UNAUTHORIZED",
-              ],
+      });
+      Object.setPrototypeOf(env, { WINDIR: "C:/Inherited" });
+      const warn = vi.fn();
+      const plan = await buildGatewayInstallPlan({
+        env,
+        port: 3000,
+        runtime: "node",
+        platform,
+        warn,
+        config: {
+          secrets: {
+            providers: {
+              onepassword: {
+                source: "exec",
+                command: "/usr/bin/op",
+                args: ["read", "op://Private/Discord/password"],
+                passEnv: [
+                  "HOME",
+                  "NODE_OPTIONS",
+                  "SYSTEMROOT",
+                  "WINDIR",
+                  "SAFE_PASS_ENV",
+                  "BASH_ENV",
+                  "XDG_CONFIG_HOME",
+                  "XDG_CONFIG_DIRS",
+                  "GH_TOKEN",
+                  "AWS_ACCESS_KEY_ID",
+                  "DOCKER_HOST",
+                  "NODE_TLS_REJECT_UNAUTHORIZED",
+                ],
+              },
+            },
+          },
+          channels: {
+            discord: {
+              token: { source: "exec", provider: "onepassword", id: "value" },
             },
           },
         },
-        channels: {
-          discord: {
-            token: { source: "exec", provider: "onepassword", id: "value" },
-          },
-        },
-      },
-    });
+      });
 
-    expect(plan.environment.HOME).toBe(isolatedHome);
-    expect(plan.environment.BASH_ENV).toBeUndefined();
-    expect(plan.environment.XDG_CONFIG_HOME).toBeUndefined();
-    expect(plan.environment.XDG_CONFIG_DIRS).toBeUndefined();
-    expect(plan.environment.GH_TOKEN).toBeUndefined();
-    expect(plan.environment.AWS_ACCESS_KEY_ID).toBeUndefined();
-    expect(plan.environment.DOCKER_HOST).toBeUndefined();
-    expect(plan.environment.NODE_TLS_REJECT_UNAUTHORIZED).toBeUndefined();
-    expect(warn).not.toHaveBeenCalledWith(
-      'Exec SecretRef passEnv ref "HOME" blocked by host-env security policy',
-      "Config SecretRef",
-    );
-    const warningOutput = warn.mock.calls.map(([message]) => message).join("\n");
-    for (const blockedName of [
-      "XDG_CONFIG_HOME",
-      "XDG_CONFIG_DIRS",
-      "BASH_ENV",
-      "GH_TOKEN",
-      "AWS_ACCESS_KEY_ID",
-      "DOCKER_HOST",
-      "NODE_TLS_REJECT_UNAUTHORIZED",
-    ]) {
-      expect(warningOutput).toContain(blockedName);
-    }
-    expect(warn.mock.calls.every(([, title]) => title === "Config SecretRef")).toBe(true);
-  });
+      expect(plan.environment.HOME).toBe(isolatedHome);
+      expect(plan.environment.SAFE_PASS_ENV).toBe("safe-value");
+      for (const blockedName of [
+        "NODE_OPTIONS",
+        "SYSTEMROOT",
+        "WINDIR",
+        "BASH_ENV",
+        "XDG_CONFIG_HOME",
+        "XDG_CONFIG_DIRS",
+        "GH_TOKEN",
+        "AWS_ACCESS_KEY_ID",
+        "DOCKER_HOST",
+        "NODE_TLS_REJECT_UNAUTHORIZED",
+      ]) {
+        expect(plan.environment[blockedName]).toBeUndefined();
+      }
+      const warningOutput = warn.mock.calls.map(([message]) => message).join("\n");
+      for (const silentName of ["HOME", "NODE_OPTIONS", "SYSTEMROOT", "WINDIR"]) {
+        expect(warn).not.toHaveBeenCalledWith(
+          `Exec SecretRef passEnv ref "${silentName}" blocked by host-env security policy`,
+          "Config SecretRef",
+        );
+      }
+      for (const blockedName of [
+        "XDG_CONFIG_HOME",
+        "XDG_CONFIG_DIRS",
+        "BASH_ENV",
+        "GH_TOKEN",
+        "AWS_ACCESS_KEY_ID",
+        "DOCKER_HOST",
+        "NODE_TLS_REJECT_UNAUTHORIZED",
+      ]) {
+        expect(warningOutput).toContain(blockedName);
+      }
+      expect(warn.mock.calls.every(([, title]) => title === "Config SecretRef")).toBe(true);
+    },
+  );
 
   it("blocks dangerous passEnv values for auth-profile exec SecretRef providers", async () => {
     mockNodeGatewayPlanFixture({

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -975,7 +975,7 @@ describe("buildGatewayInstallPlan", () => {
     const warn = vi.fn();
 
     const plan = await buildGatewayInstallPlan({
-      env: {},
+      env: isolatedPlanEnv(),
       port: 3000,
       runtime: "node",
       platform: "linux",

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -970,6 +970,37 @@ describe("buildGatewayInstallPlan", () => {
     expect(plan.environment.OP_CONNECT_TOKEN).toBe("op-connect-token");
     expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBeUndefined();
   });
+  it("skips Windows-only passEnv entries on non-Windows hosts without warnings", async () => {
+    mockNodeGatewayPlanFixture({ serviceEnvironment: { OPENCLAW_PORT: "3000" } });
+    const warn = vi.fn();
+
+    const plan = await buildGatewayInstallPlan({
+      env: {},
+      port: 3000,
+      runtime: "node",
+      platform: "linux",
+      warn,
+      config: {
+        secrets: {
+          providers: {
+            onepassword: {
+              source: "exec",
+              command: "/usr/bin/op",
+              args: ["read", "op://Private/Discord/password"],
+              passEnv: ["WINDIR", "SYSTEMROOT"],
+            },
+          },
+        },
+      },
+    });
+
+    expect(plan.environment.WINDIR).toBeUndefined();
+    expect(plan.environment.SYSTEMROOT).toBeUndefined();
+    const passEnvWarnings = warn.mock.calls.filter((call) =>
+      String(call[0]).includes("blocked by host-env security policy"),
+    );
+    expect(passEnvWarnings).toHaveLength(0);
+  });
 
   it("includes passEnv values for plugin-managed exec SecretRef providers", async () => {
     mockNodeGatewayPlanFixture({

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -71,6 +71,10 @@ const NON_PERSISTED_CONFIG_SECRET_ENV_TARGET_IDS = new Set([
   "gateway.auth.token",
 ]);
 const EXEC_SECRET_REF_PASS_ENV_ALLOWED_OVERRIDE_ONLY_KEYS = new Set(["HOME"]);
+// These Windows service environment names only exist on Windows; on other
+// hosts they are absent and evaluating them for passEnv yields nothing but
+// false-positive security warnings.
+const WINDOWS_ONLY_PASS_ENV_KEYS = new Set(["SYSTEMROOT", "WINDIR"]);
 
 function configContainsSecretRef(config: OpenClawConfig | undefined): boolean {
   if (!config) {
@@ -408,6 +412,14 @@ function collectExecSecretRefPassEnvServiceEnvVars(params: {
       continue;
     }
     for (const rawKey of execProvider.passEnv ?? []) {
+      // Windows-only service environment names are inert on non-Windows hosts;
+      // evaluating them here would only produce false-positive security warnings.
+      if (
+        process.platform !== "win32" &&
+        WINDOWS_ONLY_PASS_ENV_KEYS.has(rawKey.trim().toUpperCase())
+      ) {
+        continue;
+      }
       const key = normalizeEnvVarKey(rawKey, { portable: true });
       if (!key) {
         params.warn?.(

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -341,6 +341,7 @@ function collectExecSecretRefPassEnvServiceEnvVars(params: {
   configContainsSecretRef: boolean;
   authStore?: AuthProfileStore;
   durableEnvironment: Record<string, string | undefined>;
+  platform: NodeJS.Platform;
   warn?: DaemonInstallWarnFn;
 }): Record<string, string> {
   if (!params.config) {
@@ -411,21 +412,23 @@ function collectExecSecretRefPassEnvServiceEnvVars(params: {
     if (!execProvider) {
       continue;
     }
+    console.log("RIG_DEBUG execProvider:", JSON.stringify(execProvider));
     for (const rawKey of execProvider.passEnv ?? []) {
-      // Windows-only service environment names are inert on non-Windows hosts;
-      // evaluating them here would only produce false-positive security warnings.
-      if (
-        process.platform !== "win32" &&
-        WINDOWS_ONLY_PASS_ENV_KEYS.has(rawKey.trim().toUpperCase())
-      ) {
-        continue;
-      }
       const key = normalizeEnvVarKey(rawKey, { portable: true });
       if (!key) {
         params.warn?.(
           `Exec SecretRef passEnv id "${rawKey}" is not portable and was not added to the service environment`,
           warningTitle,
         );
+        continue;
+      }
+      // Windows-only service environment names are inert on non-Windows hosts
+      // when absent; a populated value still goes through the security policy.
+      if (
+        params.platform !== "win32" &&
+        WINDOWS_ONLY_PASS_ENV_KEYS.has(key.toUpperCase()) &&
+        !params.env[key]?.trim()
+      ) {
         continue;
       }
       if (isBlockedExecSecretRefPassEnvKey(key)) {
@@ -721,6 +724,7 @@ async function buildGatewayInstallEnvironment(params: {
     configContainsSecretRef: containsConfigSecretRef,
     authStore,
     durableEnvironment,
+    platform: params.platform,
     warn: params.warn,
   });
   const authProfileEnvironment = collectAuthProfileServiceEnvVars({

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -412,7 +412,6 @@ function collectExecSecretRefPassEnvServiceEnvVars(params: {
     if (!execProvider) {
       continue;
     }
-    console.log("RIG_DEBUG execProvider:", JSON.stringify(execProvider));
     for (const rawKey of execProvider.passEnv ?? []) {
       const key = normalizeEnvVarKey(rawKey, { portable: true });
       if (!key) {

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -71,10 +71,6 @@ const NON_PERSISTED_CONFIG_SECRET_ENV_TARGET_IDS = new Set([
   "gateway.auth.token",
 ]);
 const EXEC_SECRET_REF_PASS_ENV_ALLOWED_OVERRIDE_ONLY_KEYS = new Set(["HOME"]);
-// These Windows service environment names only exist on Windows; on other
-// hosts they are absent and evaluating them for passEnv yields nothing but
-// false-positive security warnings.
-const WINDOWS_ONLY_PASS_ENV_KEYS = new Set(["SYSTEMROOT", "WINDIR"]);
 
 function configContainsSecretRef(config: OpenClawConfig | undefined): boolean {
   if (!config) {
@@ -341,7 +337,6 @@ function collectExecSecretRefPassEnvServiceEnvVars(params: {
   configContainsSecretRef: boolean;
   authStore?: AuthProfileStore;
   durableEnvironment: Record<string, string | undefined>;
-  platform: NodeJS.Platform;
   warn?: DaemonInstallWarnFn;
 }): Record<string, string> {
   if (!params.config) {
@@ -421,13 +416,8 @@ function collectExecSecretRefPassEnvServiceEnvVars(params: {
         );
         continue;
       }
-      // Windows-only service environment names are inert on non-Windows hosts
-      // when absent; a populated value still goes through the security policy.
-      if (
-        params.platform !== "win32" &&
-        WINDOWS_ONLY_PASS_ENV_KEYS.has(key.toUpperCase()) &&
-        !params.env[key]?.trim()
-      ) {
+      const value = Object.hasOwn(params.env, key) ? params.env[key]?.trim() : undefined;
+      if (!value) {
         continue;
       }
       if (isBlockedExecSecretRefPassEnvKey(key)) {
@@ -438,10 +428,6 @@ function collectExecSecretRefPassEnvServiceEnvVars(params: {
         continue;
       }
       if (Object.hasOwn(params.durableEnvironment, key)) {
-        continue;
-      }
-      const value = params.env[key]?.trim();
-      if (!value) {
         continue;
       }
       entries[key] = value;
@@ -723,7 +709,6 @@ async function buildGatewayInstallEnvironment(params: {
     configContainsSecretRef: containsConfigSecretRef,
     authStore,
     durableEnvironment,
-    platform: params.platform,
     warn: params.warn,
   });
   const authProfileEnvironment = collectAuthProfileServiceEnvVars({


### PR DESCRIPTION
Fixes #133561

## What Problem This Solves

Exec-backed SecretRef integrations may declare `passEnv` names that are absent on the current host. The shared service-environment collector warned for blocked names before establishing that the process owned a nonempty value, so absent, whitespace-only, and inherited names produced false host-env security warnings. The bundled 1Password integration exposed this on macOS and Linux through `SYSTEMROOT` and `WINDIR`.

## Why This Change Was Made

The owner is `collectExecSecretRefPassEnvServiceEnvVars`. It now reads and trims only an own environment property first, skips missing values, then preserves the existing blocked-key warning/exclusion and durable-environment precedence.

This replaces the platform-specific patch with one generic flow. It does not add platform policy, config, manifests, protocol, storage, dependencies, or fallbacks. The `HOME` exception remains ahead of the blocklist.

## User Impact

Doctor, install, and service-repair planning no longer emits false warnings for unavailable `passEnv` names. Populated dangerous values remain blocked and visible. Populated allowed values and `HOME` behavior are unchanged.

## Evidence

### Real Gateway service-plan proof

Sanitized direct AWS Linux run from a fresh fork checkout, public network, no instance role, no Tailscale, no hydration, and only `CI` forwarded. The probe used the actual bundled 1Password manifest and the unmocked `buildGatewayInstallPlan` service-plan path.

Crabbox run: `run_f9fadb8e71d5`

```json
{"revision":"base","sha":"214deebc66988f99a9a2ad70e0e7c46a721bf067","absentWarnings":{"SYSTEMROOT":true,"WINDIR":true},"whitespaceInheritedWarnings":{"SYSTEMROOT":true,"WINDIR":true},"populatedBlockedWarned":true,"populatedBlockedInputExcluded":true,"allowedValue":"safe-value","homeRetained":true}
{"revision":"head","sha":"5cadc3af9780601338a0208c848dfb5df5ac30b5","absentWarnings":{"SYSTEMROOT":false,"WINDIR":false},"whitespaceInheritedWarnings":{"SYSTEMROOT":false,"WINDIR":false},"populatedBlockedWarned":true,"populatedBlockedInputExcluded":true,"allowedValue":"safe-value","homeRetained":true}
```

The base trace proves the real warning defect for absent `SYSTEMROOT`/`WINDIR`. The exact head is silent for absent, whitespace-only, and inherited names. A populated blocked `NODE_OPTIONS` still warns, and the supplied preload sentinel is excluded from the generated service environment. A populated allowed value survives, and `HOME` remains retained.

### Regression and validation

- Base-red regression: the focused owner test failed on the contributor head because absent `NODE_OPTIONS` emitted one warning instead of zero.
- Focused daemon-install suite: 75/75 passed.
- Coverage runs on both `linux` and `win32` platform inputs for absent, whitespace-only, inherited, populated blocked, populated allowed, and `HOME` cases.
- Existing dangerous-value and `HOME` behavior remains covered.
- Targeted oxfmt and oxlint passed.
- `pnpm check:changed` passed through production typechecking; its final local core-test graph encountered the checkout's shared missing `pako` declaration. Exact-head CI core test-type jobs are green.
- Exact autoreview command completed cleanly with score 0.99.
- Test audit: the regression exercises the real planner boundary, fails on the pre-fix behavior, and consolidates the duplicated platform-specific cases without a test-only seam.

### Scope and LOC

- Production: +4/-4, net 0.
- Tests: +80/-64, net +16.
- Only `src/commands/daemon-install-helpers.ts` and `src/commands/daemon-install-helpers.test.ts` changed.

### Current and shipped behavior

Current `main` and latest stable `2026.7.1-2` both contain the generic warning-before-value ordering. The reported bundled 1Password trigger was observed on beta `2026.9.1-beta.1`.

### Contract checks

The relevant OpenAI Codex CLI source was inspected directly at `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`. Those sections cover command/TUI completion plumbing and do not impose a protocol or runtime dependency on this OpenClaw service-environment repair.
