### PR TITLE
fix(docs): align 2026.8.1 navigation expectations

### DIFF
--- a/test/scripts/docs-sync-publish.test.ts
+++ b/test/scripts/docs-sync-publish.test.ts
@@ -175,6 +175,7 @@ describe("docs-sync-publish", () => {
 
     const releaseRoutes = [
       "releases/index",
+      "releases/2026.8.1",
       "releases/2026.7.1",
       "releases/2026.6.11",
       "maturity/scorecard",
@@ -195,6 +196,7 @@ describe("docs-sync-publish", () => {
     ]);
     expect(releaseTab?.groups?.[0]?.pages).toEqual([
       "releases/index",
+      "releases/2026.8.1",
       "releases/2026.7.1",
       "releases/2026.6.11",
     ]);
@@ -222,6 +224,7 @@ describe("docs-sync-publish", () => {
     ]);
     expect(simplifiedChineseReleaseTab?.groups?.[0]?.pages).toEqual([
       "zh-CN/releases/index",
+      "zh-CN/releases/2026.8.1",
       "zh-CN/releases/2026.7.1",
       "zh-CN/releases/2026.6.11",
     ]);


### PR DESCRIPTION
## Summary

- align the release-route inventory with the v2026.8.1 page
- keep the English and zh-CN release-group expectations in sync

## Regression Source

PR #133557 added `docs/releases/2026.8.1.md` and navigation metadata, but left the generated-navigation contract test expecting only the two older release pages. That made current `main` and pull-request merge refs fail `docs-sync-publish.test.ts`.

## Test Audit

This updates an existing publication-contract test. It adds no test-only production seam and directly catches the regression introduced by #133557.

## Evidence

- Pre-fix: `node scripts/run-vitest.mjs test/scripts/docs-sync-publish.test.ts` failed with the missing `releases/2026.8.1` route.
- Post-fix: the same command passes, 1 file and 6 tests.
- `pnpm lint:scripts`: passed.
- Formatting and `git diff --check`: passed.
- Final mandatory autoreview: scoped clean, no actionable findings, correctness 0.99.
- `check-changed` passed every reachable pre-typecheck guard; the aggregate test-root typecheck is not usable in this sparse linked worktree because the shared install and omitted sparse paths do not match the current lockfile. Exact-head CI uses a clean checkout.

LOC: tests +3 / -0; production +0 / -0.
