### PR TITLE
fix(plugins): keep bundled plugins bundled when selected by plugins.load.paths

### DIFF
--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -47,6 +47,10 @@ built entries:
   `plugins.load.paths` or global roots looks for matching JavaScript peers under
   `dist/` first, then beside the TypeScript source entry, trying `.js`, `.mjs`,
   and `.cjs` in that order at each location.
+- A `plugins.load.paths` entry that resolves inside the host's own bundled
+  plugin tree is discovered as that bundled plugin, so it keeps the bundled
+  entry point and bundled provenance whether or not compiled output exists
+  beside the source. Selecting a bundled plugin's own path never reclassifies it.
 - Package installation and managed installed-package discovery require compiled
   output for TypeScript extension and setup entries. Missing compiled output is
   a packaging error, not a reason to fall back to TypeScript.

--- a/src/plugins/discovery-checkout.test.ts
+++ b/src/plugins/discovery-checkout.test.ts
@@ -123,17 +123,86 @@ describe("running checkout discovery", () => {
           candidates: discovery.candidates,
           installRecords: {},
         });
+        // Never keyed on whether the checkout happens to be built: the alias must
+        // resolve exactly what the bundled scan resolves in either state.
         expect(registry.plugins.find((plugin) => plugin.id === "codex")).toMatchObject({
           origin: "bundled",
           rootDir: pluginRoot,
-          source: path.join(
-            pluginRoot,
-            alias.endsWith("directory") && fs.existsSync(path.join(pluginRoot, "dist", "index.js"))
-              ? "dist/index.js"
-              : "index.ts",
-          ),
+          source: path.join(pluginRoot, "index.ts"),
         });
       });
     },
   );
+});
+
+describe("host provenance across bundled build states", () => {
+  // The checkout may or may not be built, so the invariant guard cannot depend on
+  // it: a configured alias of a host-owned plugin must classify identically
+  // whether the entry resolves to the TypeScript source or to compiled output.
+  const aliasShapes = ["direct directory", "symlink directory", "direct file"] as const;
+  const buildStates = [
+    { label: "built", built: true },
+    { label: "unbuilt", built: false },
+  ] as const;
+
+  it.each(
+    buildStates.flatMap(({ label, built }) =>
+      aliasShapes.map((alias) => ({ label, built, alias })),
+    ),
+  )("keeps a $alias alias bundled in a $label bundled tree", ({ built, alias }) => {
+    const stateDir = fs.realpathSync(makeTrackedTempDir("openclaw-host-provenance", tempDirs));
+    const bundledDir = fs.realpathSync(makeTrackedTempDir("openclaw-bundled-tree", tempDirs));
+    const pluginRoot = path.join(bundledDir, "hosted");
+    fs.mkdirSync(pluginRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginRoot, "package.json"),
+      JSON.stringify({ name: "@openclaw/hosted", openclaw: { extensions: ["./index.ts"] } }),
+    );
+    fs.writeFileSync(
+      path.join(pluginRoot, "openclaw.plugin.json"),
+      JSON.stringify({ id: "hosted", configSchema: { type: "object" } }),
+    );
+    fs.writeFileSync(path.join(pluginRoot, "index.ts"), "export default {};\n");
+    if (built) {
+      fs.mkdirSync(path.join(pluginRoot, "dist"), { recursive: true });
+      fs.writeFileSync(path.join(pluginRoot, "dist", "index.js"), "export default {};\n");
+    }
+    let aliasRoot = pluginRoot;
+    if (alias.startsWith("symlink")) {
+      aliasRoot = path.join(stateDir, "linked-hosted");
+      fs.symlinkSync(pluginRoot, aliasRoot, process.platform === "win32" ? "junction" : "dir");
+    }
+    const env = {
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+    };
+    withPluginCache(createPluginCache(), () => {
+      const discovery = discoverOpenClawPlugins({
+        env,
+        extraPaths: [alias.endsWith("directory") ? aliasRoot : path.join(aliasRoot, "index.ts")],
+        installRecords: {},
+      });
+      // One physical plugin must yield one candidate; a second candidate means the
+      // alias resolved a different entry point than the bundled scan did.
+      expect(discovery.candidates.filter((candidate) => candidate.idHint === "hosted")).toEqual([
+        expect.objectContaining({
+          origin: "bundled",
+          rootDir: pluginRoot,
+          source: path.join(pluginRoot, "index.ts"),
+          configSelected: true,
+        }),
+      ]);
+      const registry = loadPluginManifestRegistryCore({
+        env,
+        candidates: discovery.candidates,
+        installRecords: {},
+      });
+      expect(registry.plugins.find((plugin) => plugin.id === "hosted")).toMatchObject({
+        origin: "bundled",
+        rootDir: pluginRoot,
+        source: path.join(pluginRoot, "index.ts"),
+      });
+    });
+  });
 });

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -3045,7 +3045,7 @@ describe("discoverOpenClawPlugins", () => {
   });
 
   it.runIf(process.platform !== "win32")(
-    "rechecks a rejected configured path under bundled policy after deduplicating scoped attempts",
+    "repairs a world-writable bundled plugin selected by config without warning that it was blocked",
     () => {
       const stateDir = makeTempDir();
       const bundledDir = path.join(stateDir, "bundled");
@@ -3060,10 +3060,12 @@ describe("discoverOpenClawPlugins", () => {
         env: buildDiscoveryEnvWithOverrides(stateDir, { OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir }),
         extraPaths: [pluginDir, pluginDir],
       });
+      // A host-owned path gets bundled policy on the first attempt, so the repair
+      // runs once and the operator never sees a "blocked" warning for a plugin that
+      // actually loads. Repeating the same path still yields a single candidate.
       expect(result.candidates).toHaveLength(1);
       expectCandidateFields(result.candidates[0]!, { idHint: "repairable", origin: "bundled" });
-      expect(result.diagnostics).toHaveLength(1);
-      expectDiagnostic({ diagnostics: result.diagnostics, messageIncludes: "world-writable path" });
+      expect(result.diagnostics).toEqual([]);
       expect(fs.statSync(pluginDir).mode & 0o777).toBe(0o755);
     },
   );

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -14,6 +14,7 @@ import { resolveCompatibilityHostVersion } from "../version.js";
 import { detectBundleManifestFormat, loadBundleManifest } from "./bundle-manifest.js";
 import {
   hasUsableBundledPluginTree,
+  resolveBundledPluginsDir,
   resolveSourceCheckoutDependencyDiagnostic,
 } from "./bundled-dir.js";
 import { buildLegacyBundledRootPath } from "./bundled-load-path-aliases.js";
@@ -677,6 +678,17 @@ function resolveBundledSourceCheckoutExtensionsDir(bundledRoot?: string): string
   return legacyRoot;
 }
 
+// Host provenance is a fact about where a plugin lives, not how it was referenced.
+// These are exactly the trees the bundled scan walks, so a configured alias of
+// anything inside them is that same host-owned plugin and must classify identically.
+function isHostBundledPluginRoot(dir: string, env: NodeJS.ProcessEnv): boolean {
+  const bundledRoot = resolveBundledPluginsDir(env);
+  const realDir = pluginCacheRealpathSync(dir) ?? path.resolve(dir);
+  return [bundledRoot, resolveBundledSourceCheckoutExtensionsDir(bundledRoot)].some(
+    (root) => root && isPathInside(pluginCacheRealpathSync(root) ?? path.resolve(root), realDir),
+  );
+}
+
 function readChildDirectoryNames(dir: string | undefined): Set<string> {
   if (!dir || !pluginCacheExistsSync(dir)) {
     return new Set();
@@ -1144,6 +1156,13 @@ function createPluginScanner(env: NodeJS.ProcessEnv, ownershipUid?: number | nul
     if (!stat) {
       return;
     }
+    // Origin gates entry resolution and bundled runtime privileges, so pointing
+    // plugins.load.paths at a host-owned plugin must not reclassify it.
+    const origin =
+      params.origin === "config" &&
+      isHostBundledPluginRoot(stat.isFile() ? path.dirname(resolved) : resolved, env)
+        ? "bundled"
+        : params.origin;
     if (stat.isFile()) {
       if (!isExtensionFile(resolved)) {
         diagnostics.push({
@@ -1157,7 +1176,7 @@ function createPluginScanner(env: NodeJS.ProcessEnv, ownershipUid?: number | nul
         idHint: path.basename(resolved, path.extname(resolved)),
         source: resolved,
         rootDir: path.dirname(resolved),
-        origin: params.origin,
+        origin,
         workspaceDir: params.workspaceDir,
         ...(params.installOwner ? { installOwner: params.installOwner } : {}),
         ...(params.installOwnerAmbiguous ? { installOwnerAmbiguous: true } : {}),
@@ -1169,6 +1188,7 @@ function createPluginScanner(env: NodeJS.ProcessEnv, ownershipUid?: number | nul
       if (
         discoverPluginDirectory({
           ...params,
+          origin,
           dir: resolved,
           rootRealPath: pluginCacheRealpathSync(resolved) ?? undefined,
         })
@@ -1178,7 +1198,7 @@ function createPluginScanner(env: NodeJS.ProcessEnv, ownershipUid?: number | nul
 
       discoverInDirectory({
         dir: resolved,
-        origin: params.origin,
+        origin,
         workspaceDir: params.workspaceDir,
         ...(params.scanFiles !== undefined || params.origin === "config"
           ? { scanFiles: params.scanFiles ?? true }
@@ -1193,10 +1213,16 @@ function createPluginScanner(env: NodeJS.ProcessEnv, ownershipUid?: number | nul
   }
 
   function discoverConfiguredPaths(loadPaths: readonly string[], workspaceDir?: string): void {
+    const firstConfigured = candidates.length;
     for (const loadPath of loadPaths) {
       if (typeof loadPath === "string" && loadPath.trim()) {
         discoverFromPath({ rawPath: loadPath.trim(), origin: "config", workspaceDir });
       }
+    }
+    // Explicit operator selection is its own fact: host-owned aliases keep bundled
+    // origin, so duplicate precedence must not read selection off `origin` alone.
+    for (const candidate of candidates.slice(firstConfigured)) {
+      candidate.configSelected = true;
     }
   }
   function finish(): PluginDiscoveryResult {
@@ -1256,6 +1282,8 @@ function discoveryPolicy(env: NodeJS.ProcessEnv, ownershipUid: number | null | u
   return {
     ownershipUid: currentUid(ownershipUid),
     compatibilityHostVersion: resolveCompatibilityHostVersion(env),
+    // Configured-path classification depends on the host's bundled tree.
+    bundledRoot: resolveBundledPluginsDir(env) ?? "",
     nix: resolveIsNixMode(env),
     sourceOverlaysDisabled: env.OPENCLAW_DISABLE_BUNDLED_SOURCE_OVERLAYS ?? "",
     home: env.OPENCLAW_HOME ?? "",

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -22,6 +22,7 @@ type MockRegistryToolEntry = {
 
 const loadOpenClawPluginsMock = vi.fn();
 const resolveCompatibleRuntimePluginRegistryMock = vi.fn();
+const getLoadedRuntimePluginRegistryMock = vi.fn();
 const applyPluginAutoEnableMock = vi.fn();
 const loadContextMocks = vi.hoisted(() => ({
   actualResolve: undefined as
@@ -39,6 +40,22 @@ vi.mock("./loader.js", () => ({
   resolveRuntimePluginRegistry: (params: unknown) =>
     resolveCompatibleRuntimePluginRegistryMock(params),
 }));
+
+// resolveCompatibleRuntimePluginRegistry now lives in this module, so the
+// ./loader.js seam no longer observes the intra-module call that tool resolution
+// triggers. Count the boundary tools.ts actually crosses, keeping real behavior.
+vi.mock("./active-runtime-registry.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./active-runtime-registry.js")>();
+  return {
+    ...actual,
+    getLoadedRuntimePluginRegistry: (
+      params?: Parameters<typeof actual.getLoadedRuntimePluginRegistry>[0],
+    ) => {
+      getLoadedRuntimePluginRegistryMock(params);
+      return actual.getLoadedRuntimePluginRegistry(params);
+    },
+  };
+});
 
 vi.mock("../config/plugin-auto-enable.js", () => ({
   applyPluginAutoEnable: (params: unknown) => applyPluginAutoEnableMock(params),
@@ -555,6 +572,7 @@ describe("resolvePluginTools optional tools", () => {
 
   beforeEach(() => {
     loadOpenClawPluginsMock.mockReset();
+    getLoadedRuntimePluginRegistryMock.mockReset();
     resolveCompatibleRuntimePluginRegistryMock.mockReset();
     resolveCompatibleRuntimePluginRegistryMock.mockImplementation(() =>
       getActivePluginRegistry?.(),
@@ -3093,7 +3111,7 @@ describe("resolvePluginTools optional tools", () => {
     );
 
     expectResolvedToolNames(tools, ["optional_tool"]);
-    expect(resolveCompatibleRuntimePluginRegistryMock).toHaveBeenCalledOnce();
+    expect(getLoadedRuntimePluginRegistryMock).toHaveBeenCalledOnce();
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
@@ -3133,7 +3151,7 @@ describe("resolvePluginTools optional tools", () => {
 
     expectResolvedToolNames(tools, ["optional_tool"]);
     expect(heavyFactory).not.toHaveBeenCalled();
-    expect(resolveCompatibleRuntimePluginRegistryMock).toHaveBeenCalledOnce();
+    expect(getLoadedRuntimePluginRegistryMock).toHaveBeenCalledOnce();
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
@@ -3193,7 +3211,7 @@ describe("resolvePluginTools optional tools", () => {
 
     expectResolvedToolNames(tools, ["memory_search", "memory_get"]);
     expect(memorySearchFactory).toHaveBeenCalledTimes(1);
-    expect(resolveCompatibleRuntimePluginRegistryMock).toHaveBeenCalledOnce();
+    expect(getLoadedRuntimePluginRegistryMock).toHaveBeenCalledOnce();
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
@@ -3309,7 +3327,7 @@ describe("resolvePluginTools optional tools", () => {
       toolAllowlist: ["*", "tavily"],
       allowGatewaySubagentBinding: true,
     });
-    expect(resolveCompatibleRuntimePluginRegistryMock).toHaveBeenCalledOnce();
+    expect(getLoadedRuntimePluginRegistryMock).toHaveBeenCalledOnce();
     const loaderParams = mockCallParams(loadOpenClawPluginsMock) as {
       onlyPluginIds?: string[];
       toolDiscovery?: unknown;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators who point `plugins.load.paths` at a plugin that already ships with OpenClaw would silently lose that plugin's host privileges — but only when compiled output happened to exist beside the source.

A bundled plugin selected this way was reclassified from `origin: "bundled"` to `origin: "config"`. That origin is not just reporting; it gates real runtime behavior. A demoted plugin is refused host-owned agent event streams (`src/plugins/agent-event-emission.ts:66`), and drops out of bundled channel runtime, bundled capability runtime, and active-runtime-registry trust. The demotion happens in the **built** configuration, which is the one that ships.

The same inconsistency made `openclaw doctor` report a non-pristine startup state for a configured bundled path purely because the checkout was built, since its pristine check compares registry and candidate counts.

## Why This Change Was Made

`origin` was decided by *how* the operator referenced a plugin rather than *where the plugin lives*. Configured paths were labelled `config`, and config/global entry resolution prefers `dist/index.js` while bundled resolution does not — so one physical plugin produced two candidates with different `source` values.

`discovery.finish()` already states the invariant in its own comment ("a configured alias must not downgrade that same physical entry"), but it dedupes on `source`. The guard therefore stopped applying the moment the two entry resolutions diverged. Both candidates then reached the manifest registry's same-`rootDir` branch, which applies the **opposite** policy and ranks `config` above `bundled`. Two dedupe owners with contradictory rules, and which one ran depended on whether `dist/` happened to exist.

The fix classifies at the producer: a configured path whose resolved root lies inside the trees the bundled scan itself walks stays `bundled`, and the operator's selection is recorded separately as `configSelected`. One physical plugin now yields one candidate whose entry point and provenance match the bundled scan in either build state.

Fixing this in the registry instead would have left a bogus `dist/index.js` config candidate in `discovery.candidates` for every other consumer (doctor, status, snapshot) — compensating downstream for a producer failure.

Containment is realpath-based, so the security boundary is unchanged: a directory symlinked *into* the bundled root from outside still classifies as `config`, covered by the existing `does not grant bundled provenance to an outside package symlink` test.

Production delta is +28 lines in `discovery.ts`. That growth buys a named predicate for an ownership/security boundary; I could not get it lower without leaving the entry-point divergence in place.

## User Impact

Operators can list a bundled plugin's own path in `plugins.load.paths` — to pin load order, or alongside other entries — without silently stripping that plugin's host privileges. Behavior no longer depends on whether compiled output exists next to the source, so a built checkout and a fresh one now behave identically.

## Evidence

**Reproduction.** A plain `pnpm build` does *not* leave `extensions/codex/dist/index.js` — `scripts/build-external-plugin-local-dist.mts` stages that output to `dist/extensions/codex` and deletes the plugin-local `dist`. The state is reached through an interrupted build, a standalone plugin package build, or package validation, and it is what the published plugin package ships. Produced here by invoking `buildPluginNpmRuntime` on `extensions/codex` directly:

```
- Expected                + Received
-   "origin": "bundled",  +   "origin": "config",
    "rootDir": ".../extensions/codex",
    "source":  ".../extensions/codex/dist/index.js",
```

**Regression coverage fails pre-fix in both states.** The four existing checkout cases no longer branch on `existsSync`; they assert `index.ts` unconditionally, which is what the bundled scan resolves either way. A new hermetic suite parametrizes build state × alias shape over a temp bundled tree, so the guard no longer depends on what the checkout contains, and asserts the candidate-level invariant (one physical plugin, one candidate, `configSelected: true`) rather than only the registry outcome.

Pre-fix: the 2 original directory cases fail on `origin`; the 2 new **built** directory cases fail on candidate count. The file and unbuilt cases pass pre-fix, as they should — they were never broken.

**Verified in both states:** `src/plugins/discovery-checkout.test.ts` 12/12 with `extensions/codex/dist/index.js` present *and* after removing it.

**Full plugins lane:** 392 files, 6234 passed, 1 skipped, 0 failed.
**Checks:** `check-changed` exit 0 (oxfmt, tsgo, oxlint, import cycles, plugin-boundary, schema/store/pairing guards).
**Autoreview:** Codex, branch scope — `scoped-clean`, no P0 findings, confidence 0.97.

### One judgment call worth a reviewer's eye

`discovery.test.ts`'s `rechecks a rejected configured path under bundled policy` asserted a `blocked plugin candidate: world-writable path` diagnostic. Post-fix that warning is gone: the host-owned path gets bundled policy on the first attempt, so the `chmod` repair runs once and the candidate is accepted. **The warning was always false** — the plugin loaded anyway via the bundled phase, so operators saw "blocked" for something that did load. I retitled the test and asserted the new contract positively (repaired to `0755`, accepted as `bundled`, deduped, no diagnostics) rather than deleting the check. If you read that warning as load-bearing, this is the line to push back on.

### Second commit: unrelated red `main`, fixed here

`src/plugins/tools.optional.test.ts` had 4 failures on clean `origin/main`, unrelated to this change. Per repo policy I fixed it in the landing PR rather than landing onto red.

`d3e058ce78c` (#133518) moved `resolveCompatibleRuntimePluginRegistry` out of `loader-runtime-registry.ts` into `active-runtime-registry.ts` so active-registry reads stop eagerly importing the loader. `tools.ts` calls `getLoadedRuntimePluginRegistry`, which now reaches that function **intra-module**, so the file's `vi.mock("./loader.js")` seam stopped observing it. Behavior was never affected — the implementation moved verbatim, tool names still resolve, no cold load happens — only the observation point went stale. The fix counts the call at the boundary `tools.ts` actually crosses, delegating to the real implementation.

Bisected: 87/87 pass at `d3e058ce78c^`, 4 fail at `d3e058ce78c`.

**Follow-up (not in this PR):** instrumenting the old mock proves the `./loader.js` seam now takes **zero** calls in that file, so every `resolveCompatibleRuntimePluginRegistryMock` setup is inert — including two tests that used `mockReturnValue` to drive registry state and now pass only because `setActivePluginRegistry` supplies it independently. Restoring that coverage needs a real test audit of what each case protects, which is wider than this PR should absorb.
