### PR TITLE
fix: retain debug capture headers from Undici requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Docs: https://docs.openclaw.ai
 
 - **Subagent completion:** recognize visible final answers delivered to internal and nested parent sessions, preventing false delivery failures while preserving external channel delivery checks.
 - Codex/Linux: wait for a live app-server process to expose its startup command line within the existing inspection deadline, preserving process identity checks and preventing intermittent startup failures.
+- **Debug proxy captures:** retain headers and content-type metadata from Undici header objects while preserving sensitive-header and registered-secret redaction.
 - **Chat attachments:** protect prepared message-tool media from premature cleanup, attach it before publication, and complete interrupted attachment promotion on retries without duplicating the original reply.
 - **Upgrade state metadata:** record the current application version after repairing older databases with an unset version marker, allowing CLI commands to use the running Gateway without attempting another schema repair.
 - **Device workers:** preserve offline-runner classification and reconnect guidance when desktop preparation detects a disconnected device, without treating the disconnect as a model failure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,6 @@ Docs: https://docs.openclaw.ai
 
 - **Subagent completion:** recognize visible final answers delivered to internal and nested parent sessions, preventing false delivery failures while preserving external channel delivery checks.
 - Codex/Linux: wait for a live app-server process to expose its startup command line within the existing inspection deadline, preserving process identity checks and preventing intermittent startup failures.
-- **Debug proxy captures:** retain headers and content-type metadata from Undici header objects while preserving sensitive-header and registered-secret redaction.
 - **Chat attachments:** protect prepared message-tool media from premature cleanup, attach it before publication, and complete interrupted attachment promotion on retries without duplicating the original reply.
 - **Upgrade state metadata:** record the current application version after repairing older databases with an unset version marker, allowing CLI commands to use the running Gateway without attempting another schema repair.
 - **Device workers:** preserve offline-runner classification and reconnect guidance when desktop preparation detects a disconnected device, without treating the disconnect as a model failure.

--- a/src/infra/fetch-headers.ts
+++ b/src/infra/fetch-headers.ts
@@ -1,11 +1,11 @@
 // Normalizes fetch header inputs while stripping non-header symbols.
-type HeadersLike = {
+export type HeadersLike = {
   entries: () => IterableIterator<[string, string]>;
   get: (name: string) => string | null;
   [Symbol.iterator]: () => IterableIterator<[string, string]>;
 };
 
-function isHeadersLike(value: object): value is HeadersLike {
+export function isHeadersLike(value: object): value is HeadersLike {
   if (typeof Headers !== "undefined" && value instanceof Headers) {
     return true;
   }

--- a/src/proxy-capture/header-redaction.test.ts
+++ b/src/proxy-capture/header-redaction.test.ts
@@ -1,4 +1,5 @@
 /** Canonical debug-proxy capture header redaction. */
+import { Headers as UndiciHeaders } from "undici";
 import { afterEach, describe, expect, it } from "vitest";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
@@ -57,9 +58,12 @@ describe("redactedCaptureHeaders", () => {
     expect(redacted?.via).toBe("1.1 a, 1.1 b");
   });
 
-  it("accepts a Headers instance", () => {
+  it.each([
+    ["global", Headers],
+    ["Undici", UndiciHeaders],
+  ] as const)("accepts a %s Headers instance", (_name, HeadersConstructor) => {
     const redacted = redactedCaptureHeaders(
-      new Headers({ authorization: "Bearer x", accept: "text/plain" }),
+      new HeadersConstructor({ authorization: "Bearer x", accept: "text/plain" }),
     );
     expect(redacted?.authorization).toBe("[REDACTED]");
     expect(redacted?.accept).toBe("text/plain");

--- a/src/proxy-capture/header-redaction.ts
+++ b/src/proxy-capture/header-redaction.ts
@@ -7,6 +7,7 @@
  * the runtime path redacted, so this policy lives in one leaf module that both
  * import rather than being duplicated per writer.
  */
+import { isHeadersLike, type HeadersLike } from "../infra/fetch-headers.js";
 import { redactRegisteredSecretValues } from "../logging/secret-redaction-registry.js";
 
 export const REDACTED_CAPTURE_HEADER_VALUE = "[REDACTED]";
@@ -46,7 +47,7 @@ function isSensitiveCaptureHeaderName(name: string): boolean {
 }
 
 export function redactedCaptureHeaders(
-  headers: Headers | Record<string, string | string[] | undefined> | undefined,
+  headers: HeadersLike | Record<string, string | string[] | undefined> | undefined,
   additionalSensitiveNames?: Iterable<string>,
 ): Record<string, string> | undefined {
   if (!headers) {
@@ -55,8 +56,7 @@ export function redactedCaptureHeaders(
   const additionalSensitive = new Set(
     [...(additionalSensitiveNames ?? [])].map((name) => name.trim().toLowerCase()),
   );
-  const entries =
-    headers instanceof Headers ? Array.from(headers.entries()) : Object.entries(headers);
+  const entries = isHeadersLike(headers) ? Array.from(headers.entries()) : Object.entries(headers);
   const redacted: Record<string, string> = {};
   for (const [name, value] of entries) {
     // Header names are matched exactly and by sensitive fragments because

--- a/src/proxy-capture/runtime.test.ts
+++ b/src/proxy-capture/runtime.test.ts
@@ -1,4 +1,5 @@
 // Proxy capture runtime tests cover session creation and capture lifecycle.
+import { Headers as UndiciHeaders } from "undici";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
@@ -300,39 +301,49 @@ describe("debug proxy runtime", () => {
     expect(events[0]?.dataText).not.toContain(secret);
   });
 
-  it("redacts registered values from HTTP payloads and metadata", async () => {
-    const secret = 'http-"capture\\secret\nline';
-    const contentTypeSecret = "http-content-type-secret";
-    registerSecretValueForRedaction(secret);
-    registerSecretValueForRedaction(contentTypeSecret);
+  it.each([
+    ["record", undefined],
+    ["global Headers", Headers],
+    ["Undici Headers", UndiciHeaders],
+  ] as const)(
+    "redacts registered values from HTTP payloads and metadata with %s",
+    async (_name, HeadersConstructor) => {
+      const secret = 'http-"capture\\secret\nline';
+      const contentTypeSecret = "http-content-type-secret";
+      registerSecretValueForRedaction(secret);
+      registerSecretValueForRedaction(contentTypeSecret);
+      const requestHeaders = { "content-type": `application/json; token=${contentTypeSecret}` };
 
-    captureHttpExchange(
-      {
-        url: "https://api.example.test/v1/messages",
-        method: "POST",
-        requestHeaders: { "content-type": `application/json; token=${contentTypeSecret}` },
-        requestBody: JSON.stringify({ credential: secret }),
-        response: new Response(JSON.stringify({ echoedCredential: secret }), {
-          status: 200,
-          headers: { "content-type": `application/json; token=${contentTypeSecret}` },
-        }),
-        meta: { credential: secret },
-      },
-      settings,
-      deps,
-    );
-    await waitForResponseSettled();
+      captureHttpExchange(
+        {
+          url: "https://api.example.test/v1/messages",
+          method: "POST",
+          requestHeaders: HeadersConstructor
+            ? new HeadersConstructor(requestHeaders)
+            : requestHeaders,
+          requestBody: JSON.stringify({ credential: secret }),
+          response: new Response(JSON.stringify({ echoedCredential: secret }), {
+            status: 200,
+            headers: { "content-type": `application/json; token=${contentTypeSecret}` },
+          }),
+          meta: { credential: secret },
+        },
+        settings,
+        deps,
+      );
+      await waitForResponseSettled();
 
-    const request = events.find((event) => event.kind === "request");
-    const response = events.find((event) => event.kind === "response");
-    expect(request?.dataText).toContain('"credential":"[REDACTED]"');
-    expect(request?.metaJson).toContain('"credential":"[REDACTED]"');
-    expect(request?.contentType).toBe("application/json; token=[REDACTED]");
-    expect(response?.dataText).toContain('"echoedCredential":"[REDACTED]"');
-    expect(response?.metaJson).toContain('"credential":"[REDACTED]"');
-    expect(response?.contentType).toBe("application/json; token=[REDACTED]");
-    expect(JSON.stringify(events)).not.toContain(secret);
-  });
+      const request = events.find((event) => event.kind === "request");
+      const response = events.find((event) => event.kind === "response");
+      expect(request?.dataText).toContain('"credential":"[REDACTED]"');
+      expect(request?.metaJson).toContain('"credential":"[REDACTED]"');
+      expect(request?.contentType).toBe("application/json; token=[REDACTED]");
+      expect(response?.dataText).toContain('"echoedCredential":"[REDACTED]"');
+      expect(response?.metaJson).toContain('"credential":"[REDACTED]"');
+      expect(response?.contentType).toBe("application/json; token=[REDACTED]");
+      expect(JSON.stringify(events)).not.toContain(secret);
+    },
+  );
 
   it("redacts registered values from failed global-fetch capture events", async () => {
     const secret = "capture-failure/secret";
@@ -651,34 +662,45 @@ describe("debug proxy runtime", () => {
     expect(events.some((event) => event.kind === "error")).toBe(false);
   });
 
-  it("records metadata-only for non-cloneable Response-like objects", async () => {
-    initializeDebugProxyCapture("test", settings, deps);
-    // Some seams hand capture a Response-like object that cannot be cloned. It
-    // must still be observable (status/headers) via the shared metadata path,
-    // tagged bodyCapture: "unavailable" (distinct from the "too-large" cap path).
-    const secret = "metadata-only-content-type-secret";
-    registerSecretValueForRedaction(secret);
-    const headers = new Headers({ "content-type": `application/json; token=${secret}` });
-    captureHttpExchange(
-      {
-        url: "https://api.openai.com/v1/uncloneable",
-        method: "GET",
-        response: { status: 503, headers } as unknown as Response,
-      },
-      settings,
-      deps,
-    );
-    await waitForResponseSettled();
-    finalizeDebugProxyCapture(settings, deps);
+  it.each([
+    ["global", Headers],
+    ["Undici", UndiciHeaders],
+  ] as const)(
+    "records metadata-only for non-cloneable Response-like objects with %s Headers",
+    async (_name, HeadersConstructor) => {
+      initializeDebugProxyCapture("test", settings, deps);
+      // Some seams hand capture a Response-like object that cannot be cloned. It
+      // must still be observable (status/headers) via the shared metadata path,
+      // tagged bodyCapture: "unavailable" (distinct from the "too-large" cap path).
+      const secret = "metadata-only-content-type-secret";
+      registerSecretValueForRedaction(secret);
+      const headers = new HeadersConstructor({
+        "content-type": `application/json; token=${secret}`,
+      });
+      captureHttpExchange(
+        {
+          url: "https://api.openai.com/v1/uncloneable",
+          method: "GET",
+          response: { status: 503, headers } as unknown as Response,
+        },
+        settings,
+        deps,
+      );
+      await waitForResponseSettled();
+      finalizeDebugProxyCapture(settings, deps);
 
-    const response = events.find((event) => event.kind === "response");
-    expect(response).toBeDefined();
-    expect(response?.status).toBe(503);
-    expect(response?.contentType).toBe("application/json; token=[REDACTED]");
-    expect(JSON.parse(String(response?.metaJson))).toMatchObject({ bodyCapture: "unavailable" });
-    expect(response).not.toHaveProperty("dataText");
-    expect(events.some((event) => event.kind === "error")).toBe(false);
-  });
+      const response = events.find((event) => event.kind === "response");
+      expect(response).toBeDefined();
+      expect(response?.status).toBe(503);
+      expect(response?.contentType).toBe("application/json; token=[REDACTED]");
+      expect(JSON.parse(String(response?.headersJson))).toStrictEqual({
+        "content-type": "application/json; token=[REDACTED]",
+      });
+      expect(JSON.parse(String(response?.metaJson))).toMatchObject({ bodyCapture: "unavailable" });
+      expect(response).not.toHaveProperty("dataText");
+      expect(events.some((event) => event.kind === "error")).toBe(false);
+    },
+  );
 
   it("records Response-like status metadata when the Headers API is absent", async () => {
     initializeDebugProxyCapture("test", settings, deps);

--- a/src/proxy-capture/runtime.ts
+++ b/src/proxy-capture/runtime.ts
@@ -2,7 +2,11 @@
 import { isUtf8 } from "node:buffer";
 import { randomUUID } from "node:crypto";
 import { URL } from "node:url";
-import { normalizeRequestInitHeadersForFetch } from "../infra/fetch-headers.js";
+import {
+  isHeadersLike,
+  normalizeRequestInitHeadersForFetch,
+  type HeadersLike,
+} from "../infra/fetch-headers.js";
 import { readChunkWithIdleTimeout } from "../infra/http-body.js";
 import {
   hasRegisteredSecretValuesForRedaction,
@@ -475,7 +479,7 @@ export function captureHttpExchange(
   params: {
     url: string;
     method: string;
-    requestHeaders?: Headers | Record<string, string> | undefined;
+    requestHeaders?: HeadersLike | Record<string, string> | undefined;
     requestBody?: BodyInit | Buffer | string | null;
     response: Response;
     transport?: "http" | "sse";
@@ -498,10 +502,11 @@ export function captureHttpExchange(
     typeof params.requestBody === "string" || Buffer.isBuffer(params.requestBody)
       ? params.requestBody
       : null;
-  const rawRequestContentType =
-    params.requestHeaders instanceof Headers
+  const rawRequestContentType = params.requestHeaders
+    ? isHeadersLike(params.requestHeaders)
       ? (params.requestHeaders.get("content-type") ?? undefined)
-      : params.requestHeaders?.["content-type"];
+      : params.requestHeaders["content-type"]
+    : undefined;
   const requestContentType =
     rawRequestContentType === undefined ? undefined : redactCaptureText(rawRequestContentType);
   const rawResponseContentType =


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where debug-proxy captures lost HTTP headers and request content type when a caller supplied genuine Undici `Headers` rather than the global `Headers` constructor.

## Why This Change Was Made

Capture relied on constructor identity and treated distinct Undici headers as plain records. It now reuses the existing fetch-header owner's structural contract: `entries`, `get`, and `Symbol.iterator`. Header enumeration and request content-type lookup share that recognition; sensitive-name and registered-secret redaction remain unchanged.

The existing public `captureHttpExchange` input accepts this minimal structural type without requiring unrelated DOM iterator-disposal methods. No new SDK subpath, dependency, capture setting, storage schema, or transport policy is added.

## User Impact

Operators retain useful headers and content-type metadata in captures from supported distinct header implementations, including metadata-only responses, while sensitive values remain redacted. Existing global headers and plain-record behavior are preserved.

## Evidence

- Before the fix, the grouped baseline reached 39 passing cases and two Undici failures before stopping; it did not complete all six suites. The separately run redactor baseline reached seven passes and one Undici failure.
- Historical pre-rebase proof at `b6b98b3791368da7df2bff53a91d0ddecb141a9b`: 59 runtime/sibling cases, 31 representative SDK cases, full 29-stage changed gate and ordinary 14-stage build. These are not relabeled as composed-head proof.
- At rebased `714078324f8dc8d4f485e8cbd6eb90c531a9e334`, the same 59 runtime/sibling cases and 31 SDK cases passed, followed by all 29 changed checks and the ordinary 14-stage build. The emitted SDK facade, shared header-recognition import and structural declaration were inspected. One normal final rebased-branch Codex review completed scoped-clean at P0, with no findings.
- Hosted CI run `33344389739` completed successfully for `714078324f8dc8d4f485e8cbd6eb90c531a9e334`; this remains historical exact-head evidence.
- `10ce1498ac4d42f6611a0e39aede88f632ce8dfb` removes only the PR's one-line changelog entry to follow the release-owned changelog policy. All five code/test afterimages remain byte-identical to `714`; the normal docs-only review was scoped-clean. No runtime tests or build were rerun for this deletion. Exact-head [CI run 33346899209](https://github.com/openclaw/openclaw/actions/runs/33346899209) passed for `10ce1498ac4d42f6611a0e39aede88f632ce8dfb`.
- Historical precommit/final-branch Codex reviews were scoped-clean at P0. The unchanged secret-redaction registry dependency was omitted by the review helper's sensitive-filename policy and reviewed locally; this remains an explicit isolated-review context gap.

Current composed-head production: +15/−10 (net +5); tests: +86/−60 (net +26); no changelog change relative to the PR base; whole change: net +31. The +5 production lines reuse the canonical shared three-method structural predicate and expose its minimal SDK input type, rather than duplicate constructor-specific recognition; no cleanup credit is claimed.

This is local source, runtime-test, type, and build evidence—not live-provider or package-install proof. The separate embedding-provider batch failure remains unexplained; this repair does not establish its cause or live API equivalence.

Before-merge review follow-up: the exact-head CI item is satisfied above, and the production-growth rationale is explicit. For the [review's dependency-source limitation](https://github.com/openclaw/openclaw/pull/133586#issuecomment-5471612842), local maintainer inspection covered locked Undici 8.10.0's `lib/web/fetch/headers.js`, its iterator implementation and `types/fetch.d.ts`: private header state is accessed through `get`, `entries` and iteration. The inspected files match the retained `714` dependency inventory. This is separate local source evidence; the bot environment did not independently inspect that dependency, and no new runtime or live-provider result is claimed.
