### PR TITLE
fix: gateway stop fails with a newer state schema

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -281,7 +281,11 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     policy: { configGuard: "skip", loadPlugins: "never", networkProxy: "bypass" },
   },
   { commandPath: ["gateway", "start"], exact: true, policy: { networkProxy: "bypass" } },
-  { commandPath: ["gateway", "stop"], exact: true, policy: { networkProxy: "bypass" } },
+  {
+    commandPath: ["gateway", "stop"],
+    exact: true,
+    policy: { configGuard: "skip", loadPlugins: "never", networkProxy: "bypass" },
+  },
   { commandPath: ["gateway", "uninstall"], exact: true, policy: { networkProxy: "bypass" } },
   {
     commandPath: ["gateway", "usage-cost"],

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -50,6 +50,7 @@ describe("command-startup-policy", () => {
       ["hooks", "check"],
       ["memory", "search"],
       ["memory", "status"],
+      ["gateway", "stop"],
       ["gateway", "diagnostics", "export"],
       ["gateway", "stability"],
       ["gateway", "usage-cost"],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users trying to stop a managed Gateway would be blocked when the local state database was written by a newer OpenClaw build. This left operators unable to stop the newer service before repairing, downgrading, or replacing the CLI.

## Why This Change Was Made

Gateway stop only asks the local service manager to stop an existing process; it does not need application config, state migrations, or plugins. The command now skips those startup paths while start and restart retain their existing validation.

## User Impact

Operators can run `openclaw gateway stop` from an older CLI even when the active Gateway has upgraded the state database beyond that CLI's supported schema.

## Evidence

- Regression test failed before the production change: `gateway stop: expected false to be true`.
- `pnpm exec vitest run src/cli/command-startup-policy.test.ts src/cli/command-path-policy.test.ts`: 45 passed.
- `pnpm oxfmt --check src/cli/command-catalog.ts src/cli/command-startup-policy.test.ts`: passed.
- `pnpm build`: passed.
