### PR TITLE
fix(auth): classify managed SecretRef API keys as static

### DIFF
--- a/src/gateway/server-methods/models-auth-status-api-keys.ts
+++ b/src/gateway/server-methods/models-auth-status-api-keys.ts
@@ -8,7 +8,6 @@ import { resolveProviderEnvAuthEvidence } from "../../agents/model-auth-env.js";
 import {
   isKnownEnvApiKeyMarker,
   isNonSecretApiKeyMarker,
-  NON_ENV_SECRETREF_MARKER,
 } from "../../agents/model-auth-markers.js";
 import { resolveProviderConfigSecretInput } from "../../agents/model-auth-provider-config.js";
 import {
@@ -57,13 +56,6 @@ export function resolveProviderApiKeys(
     }
     const { providerConfig, ref } = resolveProviderConfigSecretInput(cfg, provider);
     if (hasConfiguredSecretInput(providerConfig?.apiKey, cfg.secrets?.defaults)) {
-      // Runtime config redacts non-env SecretRefs to this marker. It still
-      // represents configured static auth, even though this read-only status
-      // check cannot inspect the underlying credential.
-      if (providerConfig?.apiKey === NON_ENV_SECRETREF_MARKER) {
-        apiKeys.set(provider, { source: "config" });
-        continue;
-      }
       const profileReference = resolveProviderEntryApiKeyProfileReference({
         cfg,
         authAliasLookupParams,

--- a/src/gateway/server-methods/models-auth-status-api-keys.ts
+++ b/src/gateway/server-methods/models-auth-status-api-keys.ts
@@ -1,7 +1,4 @@
-import {
-  findNormalizedProviderValue,
-  normalizeProviderId,
-} from "@openclaw/model-catalog-core/provider-id";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { AuthProfileStore } from "../../agents/auth-profiles.js";
 import {
   listProviderEnvAuthLookupKeys,
@@ -11,14 +8,16 @@ import { resolveProviderEnvAuthEvidence } from "../../agents/model-auth-env.js";
 import {
   isKnownEnvApiKeyMarker,
   isNonSecretApiKeyMarker,
+  NON_ENV_SECRETREF_MARKER,
 } from "../../agents/model-auth-markers.js";
+import { resolveProviderConfigSecretInput } from "../../agents/model-auth-provider-config.js";
 import {
   resolveProviderEntryApiKeyProfileReference,
   resolveUsableCustomProviderApiKey,
 } from "../../agents/model-auth.js";
 import type { ProviderAuthAliasLookupParams } from "../../agents/provider-auth-aliases.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { coerceSecretRef, hasConfiguredSecretInput } from "../../config/types.secrets.js";
+import { hasConfiguredSecretInput } from "../../config/types.secrets.js";
 import type { readPreparedCatalog } from "../server-model-catalog-auth.js";
 import type { ModelAuthStatusProvider } from "./models-auth-status.types.js";
 
@@ -56,9 +55,15 @@ export function resolveProviderApiKeys(
     if (!provider) {
       continue;
     }
-    const providerConfig = findNormalizedProviderValue(cfg.models?.providers, provider);
+    const { providerConfig, ref } = resolveProviderConfigSecretInput(cfg, provider);
     if (hasConfiguredSecretInput(providerConfig?.apiKey, cfg.secrets?.defaults)) {
-      const ref = coerceSecretRef(providerConfig?.apiKey, cfg.secrets?.defaults);
+      // Runtime config redacts non-env SecretRefs to this marker. It still
+      // represents configured static auth, even though this read-only status
+      // check cannot inspect the underlying credential.
+      if (providerConfig?.apiKey === NON_ENV_SECRETREF_MARKER) {
+        apiKeys.set(provider, { source: "config" });
+        continue;
+      }
       const profileReference = resolveProviderEntryApiKeyProfileReference({
         cfg,
         authAliasLookupParams,

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -11,6 +11,12 @@ import {
   type AuthProfileStore,
 } from "../../agents/auth-profiles.js";
 import { NON_ENV_SECRETREF_MARKER } from "../../agents/model-auth-markers.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import {
+  resetConfigRuntimeState,
+  setRuntimeConfigSnapshot,
+} from "../../config/runtime-snapshot.js";
+import type { ModelProviderConfig } from "../../config/types.models.js";
 import type { UsageSummary } from "../../infra/provider-usage.types.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../../plugins/installed-plugin-index-policy.js";
 import { resolveProviderAuthLookupMaps } from "../../secrets/provider-env-vars.js";
@@ -328,6 +334,7 @@ function firstDeferredAuthScope() {
 
 afterEach(() => {
   vi.unstubAllEnvs();
+  resetConfigRuntimeState();
 });
 
 function expectLogoutFailurePreservesRun(params: {
@@ -1093,16 +1100,27 @@ describe("models.authStatus", () => {
     }
   });
 
-  it("reports non-env SecretRefs as presence-only config auth", async () => {
-    mocks.getRuntimeConfig.mockReturnValue({
+  it("reports runtime-resolved non-env SecretRefs as presence-only config auth", async () => {
+    const sourceProvider: ModelProviderConfig = {
+      baseUrl: "https://example.test/v1",
+      models: [],
+      apiKey: { source: "file", provider: "mounted-json", id: "model-provider-key" },
+    };
+    const runtimeProvider: ModelProviderConfig = {
+      baseUrl: sourceProvider.baseUrl,
+      models: sourceProvider.models,
+      apiKey: "runtime-secret-value",
+    };
+    const sourceConfig: OpenClawConfig = {
       models: {
         providers: {
-          openai: Object.fromEntries([
-            ["apiKey", { source: "file", provider: "mounted-json", id: "model-provider-key" }],
-          ]),
+          openai: sourceProvider,
         },
       },
-    });
+    };
+    const runtimeConfig: OpenClawConfig = { models: { providers: { openai: runtimeProvider } } };
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+    mocks.getRuntimeConfig.mockReturnValue(runtimeConfig);
     mocks.buildAuthHealthSummary.mockReturnValue({
       now: 0,
       warnAfterMs: 0,
@@ -1193,7 +1211,7 @@ describe("models.authStatus", () => {
     expect(provider).toBeUndefined();
   });
 
-  it("keeps unresolved managed SecretRef markers visible as missing", async () => {
+  it("reports managed SecretRef markers as static config auth", async () => {
     const actualAuthHealth = await vi.importActual<typeof import("../../agents/auth-health.js")>(
       "../../agents/auth-health.js",
     );
@@ -1208,8 +1226,8 @@ describe("models.authStatus", () => {
 
     const provider = await firstAuthStatusProvider();
     expect(provider?.provider).toBe("openai");
-    expect(provider?.apiKey).toBeUndefined();
-    expect(provider?.status).toBe("missing");
+    expect(provider?.apiKey).toEqual({ source: "config" });
+    expect(provider?.status).toBe("static");
   });
 
   it("does not duplicate profile references as config API keys", async () => {

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -1211,7 +1211,7 @@ describe("models.authStatus", () => {
     expect(provider).toBeUndefined();
   });
 
-  it("reports managed SecretRef markers as static config auth", async () => {
+  it("keeps unresolved managed SecretRef markers visible as missing", async () => {
     const actualAuthHealth = await vi.importActual<typeof import("../../agents/auth-health.js")>(
       "../../agents/auth-health.js",
     );
@@ -1226,8 +1226,8 @@ describe("models.authStatus", () => {
 
     const provider = await firstAuthStatusProvider();
     expect(provider?.provider).toBe("openai");
-    expect(provider?.apiKey).toEqual({ source: "config" });
-    expect(provider?.status).toBe("static");
+    expect(provider?.apiKey).toBeUndefined();
+    expect(provider?.status).toBe("missing");
   });
 
   it("does not duplicate profile references as config API keys", async () => {


### PR DESCRIPTION
## What Problem This Solves

Non-env SecretRefs are resolved to opaque runtime values. The auth-status path was inspecting that runtime value, losing the authored SecretRef provenance and reporting the provider as missing. The Control UI turns that state into an “Auth expired” warning.

## Why This Change Was Made

Read the authored SecretRef through the runtime snapshot while retaining the runtime provider config. A configured non-env SecretRef is reported as static config auth; no credential is resolved, exposed, or validated by this status path.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-methods/models-auth-status.test.ts` — 92 passed.
- `pnpm format:check -- src/gateway/server-methods/models-auth-status-api-keys.ts src/gateway/server-methods/models-auth-status.test.ts`
- `git diff --check`
- An isolated, loopback Gateway configured with a test-only `file` SecretRef returned this redacted `models.authStatus` result:
  `{"provider":"openai","status":"static","apiKeySource":"config","containsConfiguredValue":false}`

## Worked on by

- Mateu Hunter (@mateu)
