### PR TITLE
perf(browser): reuse snapshot refs and screenshot metadata

### DIFF
--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -823,8 +823,6 @@ async function buildCdpRoleSnapshot(params: {
   }
 
   const counts = new Map<string, number>();
-  const refsByKey = new Map<string, string[]>();
-  const nodesByRef = new Map<string, RoleTreeNode>();
   const refs: Record<string, CdpRoleRef> = {};
   for (const node of tree) {
     const role = node.role.toLowerCase();
@@ -843,13 +841,6 @@ async function buildCdpRoleSnapshot(params: {
     params.nextRef.value += 1;
     node.ref = ref;
     node.nth = nth;
-    const refsForKey = refsByKey.get(key);
-    if (refsForKey) {
-      refsForKey.push(ref);
-    } else {
-      refsByKey.set(key, [ref]);
-    }
-    nodesByRef.set(ref, node);
     refs[ref] = {
       role,
       ...(node.name ? { name: node.name } : {}),
@@ -857,19 +848,6 @@ async function buildCdpRoleSnapshot(params: {
       ...(node.backendDOMNodeId ? { backendDOMNodeId: node.backendDOMNodeId } : {}),
       ...(params.frameId ? { frameId: params.frameId } : {}),
     };
-  }
-  for (const refList of refsByKey.values()) {
-    if (refList.length > 1) {
-      continue;
-    }
-    const ref = refList[0];
-    if (ref) {
-      delete refs[ref]?.nth;
-      const node = nodesByRef.get(ref);
-      if (node) {
-        delete node.nth;
-      }
-    }
   }
 
   const iframeFrameIds = await resolveIframeFrameIds(params.send, tree, params.sessionId);

--- a/extensions/browser/src/browser/chrome-mcp.snapshot.ts
+++ b/extensions/browser/src/browser/chrome-mcp.snapshot.ts
@@ -50,37 +50,6 @@ function shouldCreateRef(role: string, name?: string): boolean {
   return INTERACTIVE_ROLES.has(role) || (CONTENT_ROLES.has(role) && Boolean(name));
 }
 
-type DuplicateTracker = {
-  counts: Map<string, number>;
-  keysByRef: Map<string, string>;
-  duplicates: Set<string>;
-};
-
-function createDuplicateTracker(): DuplicateTracker {
-  return {
-    counts: new Map(),
-    keysByRef: new Map(),
-    duplicates: new Set(),
-  };
-}
-
-function registerRef(
-  tracker: DuplicateTracker,
-  ref: string,
-  role: string,
-  name?: string,
-): number | undefined {
-  const key = `${role}:${name ?? ""}`;
-  const count = tracker.counts.get(key) ?? 0;
-  tracker.counts.set(key, count + 1);
-  tracker.keysByRef.set(ref, key);
-  if (count > 0) {
-    tracker.duplicates.add(key);
-    return count;
-  }
-  return undefined;
-}
-
 /** Build ARIA nodes while preserving whether a traversal ceiling omitted input. */
 export function flattenChromeMcpSnapshotToAriaResult(
   root: ChromeMcpSnapshotNode,
@@ -134,7 +103,7 @@ export function buildAiSnapshotFromChromeMcpSnapshot(params: {
   truncated?: true;
 } {
   const refs: RoleRefMap = {};
-  const tracker = createDuplicateTracker();
+  const counts = new Map<string, number>();
   const lines: string[] = [];
   const maxDepth = Math.min(
     params.options?.maxDepth ?? ROLE_SNAPSHOT_MAX_DEPTH,
@@ -162,7 +131,9 @@ export function buildAiSnapshotFromChromeMcpSnapshot(params: {
       }
       const ref = normalizeSnapshotString(node.id);
       if (ref && shouldCreateRef(role, name)) {
-        const nth = registerRef(tracker, ref, role, name);
+        const key = `${role}:${name ?? ""}`;
+        const nth = counts.get(key);
+        counts.set(key, (nth ?? 0) + 1);
         refs[ref] = nth === undefined ? { role, name } : { role, name, nth };
         line += ` [ref=${ref}]`;
       }
@@ -181,13 +152,6 @@ export function buildAiSnapshotFromChromeMcpSnapshot(params: {
   };
 
   visit(params.root, 0);
-
-  for (const [ref, data] of Object.entries(refs)) {
-    const key = tracker.keysByRef.get(ref);
-    if (key && !tracker.duplicates.has(key)) {
-      delete data.nth;
-    }
-  }
 
   const result = { snapshot: lines.join("\n"), refs };
   return truncated ? { ...result, truncated: true } : result;

--- a/extensions/browser/src/browser/pw-role-snapshot.ts
+++ b/extensions/browser/src/browser/pw-role-snapshot.ts
@@ -68,13 +68,14 @@ export function getRoleSnapshotIdentityKeys<T extends RoleRef>(
 /** Mark ref-bearing lines that were absent from the previous compatible snapshot. */
 function annotateRoleSnapshotDelta<T extends RoleRef>(params: {
   lines: string[];
+  lineRefs: readonly (string | undefined)[];
   refs: Record<string, T>;
   mode: RoleSnapshotIdentityMode;
   previousKeys: ReadonlySet<string>;
 }): boolean {
   const markedKeys = new Set<string>();
   for (const [index, line] of params.lines.entries()) {
-    const ref = findRoleSnapshotLineRef(line);
+    const ref = params.lineRefs[index];
     const value = ref && Object.hasOwn(params.refs, ref) ? params.refs[ref] : undefined;
     if (!ref || !value) {
       continue;
@@ -93,18 +94,20 @@ function annotateRoleSnapshotDelta<T extends RoleRef>(params: {
   return true;
 }
 
-function truncateRoleSnapshot(lines: readonly string[], maxChars: number): string {
+function truncateRoleSnapshot(lines: readonly string[], maxChars: number) {
   const marker =
     maxChars >= ROLE_SNAPSHOT_TRUNCATION_MARKER.length ? ROLE_SNAPSHOT_TRUNCATION_MARKER : "…";
   let prefix = "";
+  let lineCount = 0;
   for (const line of lines) {
     const candidate = prefix ? `${prefix}\n${line}` : line;
     if (candidate.length + 2 + marker.length > maxChars) {
       break;
     }
     prefix = candidate;
+    lineCount += 1;
   }
-  return prefix ? `${prefix}\n\n${marker}` : marker;
+  return { snapshot: prefix ? `${prefix}\n\n${marker}` : marker, lineCount };
 }
 
 /** Apply the final output budget, then keep only refs present on complete output lines. */
@@ -131,22 +134,28 @@ export function finalizeRoleSnapshot<T extends RoleRef>(params: {
   const delta = params.delta;
   const previousKeys = delta?.previousKeys;
   const sourceLines = params.snapshot.split("\n");
-  const annotated =
-    delta && previousKeys !== undefined
-      ? annotateRoleSnapshotDelta({
-          lines: sourceLines,
-          refs: params.refs,
-          mode: delta.mode,
-          previousKeys,
-        })
-      : false;
+  let lineRefs: (string | undefined)[] | undefined;
+  let annotated = false;
+  if (delta && previousKeys !== undefined) {
+    lineRefs = sourceLines.map(findRoleSnapshotLineRef);
+    annotated = annotateRoleSnapshotDelta({
+      lines: sourceLines,
+      lineRefs,
+      refs: params.refs,
+      mode: delta.mode,
+      previousKeys,
+    });
+  }
   const sourceSnapshot = annotated ? sourceLines.join("\n") : params.snapshot;
   const truncated = maxChars !== undefined && sourceSnapshot.length > maxChars;
-  const snapshot = truncated ? truncateRoleSnapshot(sourceLines, maxChars) : sourceSnapshot;
+  const bounded = truncated ? truncateRoleSnapshot(sourceLines, maxChars) : undefined;
+  const snapshot = bounded?.snapshot ?? sourceSnapshot;
   const outputLines = truncated ? snapshot.split("\n") : sourceLines;
   const visibleRefs = new Set<string>();
-  for (const line of outputLines) {
-    const ref = findRoleSnapshotLineRef(line);
+  // Delta suffixes and the truncation marker cannot introduce formatter-owned refs.
+  const visibleLineCount = bounded?.lineCount ?? sourceLines.length;
+  for (let index = 0; index < visibleLineCount; index += 1) {
+    const ref = lineRefs ? lineRefs[index] : findRoleSnapshotLineRef(sourceLines[index]!);
     if (ref) {
       visibleRefs.add(ref);
     }
@@ -238,57 +247,27 @@ function decodeSnapshotName(nameToken: string | undefined): string | undefined {
   return nameToken?.startsWith('"') ? JSON.parse(nameToken) : nameToken;
 }
 
-type RoleNameTracker = {
-  counts: Map<string, number>;
-  refsByKey: Map<string, string[]>;
-  getKey: (role: string, name?: string) => string;
-  getNextIndex: (role: string, name?: string) => number;
-  trackRef: (role: string, name: string | undefined, ref: string) => void;
-  getDuplicateKeys: () => Set<string>;
-};
-
-function createRoleNameTracker(): RoleNameTracker {
-  const counts = new Map<string, number>();
-  const refsByKey = new Map<string, string[]>();
-  return {
-    counts,
-    refsByKey,
-    getKey(role: string, name?: string) {
-      return `${role}:${name ?? ""}`;
-    },
-    getNextIndex(role: string, name?: string) {
-      const key = this.getKey(role, name);
-      const current = counts.get(key) ?? 0;
-      counts.set(key, current + 1);
-      return current;
-    },
-    trackRef(role: string, name: string | undefined, ref: string) {
-      const key = this.getKey(role, name);
-      const list = refsByKey.get(key) ?? [];
-      list.push(ref);
-      refsByKey.set(key, list);
-    },
-    getDuplicateKeys() {
-      const out = new Set<string>();
-      for (const [key, refs] of refsByKey) {
-        if (refs.length > 1) {
-          out.add(key);
-        }
+function createRoleNameTracker() {
+  const groups = new Map<string, { count: number; first: RoleRef }>();
+  return (role: string, name?: string): RoleRef => {
+    const key = `${role}:${name ?? ""}`;
+    const group = groups.get(key);
+    const data: RoleRef = { role, name };
+    if (group) {
+      // The first generated ref gains index zero only when a duplicate appears.
+      if (group.count === 1) {
+        group.first.nth = 0;
       }
-      return out;
-    },
+      data.nth = group.count;
+      group.count += 1;
+    } else {
+      groups.set(key, { count: 1, first: data });
+    }
+    return data;
   };
 }
 
-function removeNthFromNonDuplicates(refs: RoleRefMap, tracker: RoleNameTracker) {
-  const duplicates = tracker.getDuplicateKeys();
-  for (const [ref, data] of Object.entries(refs)) {
-    const key = tracker.getKey(data.role, data.name);
-    if (!duplicates.has(key)) {
-      delete refs[ref]?.nth;
-    }
-  }
-}
+type RoleNameTracker = ReturnType<typeof createRoleNameTracker>;
 
 function compactTree(tree: string) {
   const lines = tree.split("\n");
@@ -374,13 +353,9 @@ function processLine(
   }
 
   const ref = nextRef();
-  const nth = tracker.getNextIndex(role, name);
-  tracker.trackRef(role, name, ref);
-  refs[ref] = {
-    role,
-    name,
-    nth,
-  };
+  const data = tracker(role, name);
+  refs[ref] = data;
+  const nth = data.nth ?? 0;
 
   let enhanced = `${prefix}${roleRaw}`;
   if (name) {
@@ -403,8 +378,8 @@ type InteractiveSnapshotLine = NonNullable<ReturnType<typeof parseSnapshotLine>>
 function buildInteractiveSnapshotLines(params: {
   lines: string[];
   options: RoleSnapshotOptions;
-  resolveRef: (parsed: InteractiveSnapshotLine) => { ref: string; nth?: number } | null;
-  recordRef: (parsed: InteractiveSnapshotLine, ref: string, nth?: number) => void;
+  refs: RoleRefMap;
+  resolveRef: (parsed: InteractiveSnapshotLine) => { ref: string; data: RoleRef } | null;
   formatSuffix: (suffix: string, ref: string) => string;
 }): string[] {
   const out: string[] = [];
@@ -424,15 +399,15 @@ function buildInteractiveSnapshotLines(params: {
     if (!resolved?.ref) {
       continue;
     }
-    params.recordRef(parsed, resolved.ref, resolved.nth);
+    params.refs[resolved.ref] = resolved.data;
 
     let enhanced = `- ${parsed.roleRaw}`;
     if (parsed.name) {
       enhanced += ` ${JSON.stringify(parsed.name)}`;
     }
     enhanced += ` [ref=${resolved.ref}]`;
-    if ((resolved.nth ?? 0) > 0) {
-      enhanced += ` [nth=${resolved.nth}]`;
+    if ((resolved.data.nth ?? 0) > 0) {
+      enhanced += ` [nth=${resolved.data.nth}]`;
     }
     enhanced += params.formatSuffix(parsed.suffix, resolved.ref);
     out.push(enhanced);
@@ -479,23 +454,10 @@ export function buildRoleSnapshotFromAriaSnapshot(
     const result = buildInteractiveSnapshotLines({
       lines,
       options,
-      resolveRef: ({ role, name }) => {
-        const ref = nextRef();
-        const nth = tracker.getNextIndex(role, name);
-        tracker.trackRef(role, name, ref);
-        return { ref, nth };
-      },
-      recordRef: ({ role, name }, ref, nth) => {
-        refs[ref] = {
-          role,
-          name,
-          nth,
-        };
-      },
+      refs,
+      resolveRef: ({ role, name }) => ({ ref: nextRef(), data: tracker(role, name) }),
       formatSuffix: (suffix) => (suffix.includes("[") ? suffix : ""),
     });
-
-    removeNthFromNonDuplicates(refs, tracker);
 
     return {
       snapshot: result.join("\n") || "(no interactive elements)",
@@ -510,8 +472,6 @@ export function buildRoleSnapshotFromAriaSnapshot(
       result.push(processed);
     }
   }
-
-  removeNthFromNonDuplicates(refs, tracker);
 
   const tree = result.join("\n") || "(empty)";
   return {
@@ -541,12 +501,12 @@ export function buildRoleSnapshotFromAiSnapshot(
     const out = buildInteractiveSnapshotLines({
       lines,
       options,
+      refs,
       resolveRef: (parsed) => {
         const ref = parseAiSnapshotRef(parsed.ref);
-        return ref ? { ref } : null;
-      },
-      recordRef: ({ role, name }, ref) => {
-        refs[ref] = { role, ...(name ? { name } : {}) };
+        return ref
+          ? { ref, data: { role: parsed.role, ...(parsed.name ? { name: parsed.name } : {}) } }
+          : null;
       },
       formatSuffix: (suffix, ref) => suffix.replace(` [ref=${ref}]`, ""),
     });

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -104,16 +104,19 @@ function buildStoredAriaRefs(
 ): Record<string, { role: string; name?: string; nth?: number; domMarker?: boolean }> {
   const refs: Record<string, { role: string; name?: string; nth?: number; domMarker?: boolean }> =
     {};
-  const refsByKey = new Map<string, string[]>();
+  const groups = new Map<string, { count: number; firstRef: string }>();
 
   for (const node of nodes) {
     const role = normalizeLowercaseStringOrEmpty(node.role) || "unknown";
     const name = node.name.trim();
     const key = `${role}:${name}`;
-    const refsForKey = refsByKey.get(key) ?? [];
-    const nth = refsForKey.length;
-    refsForKey.push(node.ref);
-    refsByKey.set(key, refsForKey);
+    const group = groups.get(key);
+    const nth = group?.count ?? 0;
+    if (group) {
+      group.count += 1;
+    } else {
+      groups.set(key, { count: 1, firstRef: node.ref });
+    }
     refs[node.ref] = {
       role,
       name,
@@ -123,13 +126,10 @@ function buildStoredAriaRefs(
     };
   }
 
-  for (const refsForKey of refsByKey.values()) {
-    if (refsForKey.length > 1) {
-      continue;
-    }
-    const ref = refsForKey[0];
-    if (ref) {
-      delete refs[ref]?.nth;
+  // Resolve by ref after grouping: later input nodes can overwrite the same ref.
+  for (const { count, firstRef } of groups.values()) {
+    if (count === 1 && firstRef) {
+      delete refs[firstRef]?.nth;
     }
   }
 

--- a/extensions/browser/src/browser/routes/agent.existing-session.test.ts
+++ b/extensions/browser/src/browser/routes/agent.existing-session.test.ts
@@ -73,6 +73,7 @@ vi.mock("../screenshot.js", () => ({
   DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE: 64,
   normalizeBrowserScreenshot: vi.fn(async (buffer: Buffer) => ({
     buffer,
+    sourceDimensions: null,
     contentType: "image/png",
   })),
 }));

--- a/extensions/browser/src/browser/routes/agent.snapshot.local-managed.test.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.local-managed.test.ts
@@ -69,6 +69,7 @@ vi.mock("../screenshot.js", () => ({
   DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE: 64,
   normalizeBrowserScreenshot: vi.fn(async (buffer: Buffer) => ({
     buffer,
+    sourceDimensions: null,
     contentType: "image/png",
   })),
 }));

--- a/extensions/browser/src/browser/routes/agent.snapshot.timeout.test.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.timeout.test.ts
@@ -62,6 +62,7 @@ vi.mock("../screenshot.js", () => ({
   DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE: 64,
   normalizeBrowserScreenshot: vi.fn(async (buffer: Buffer) => ({
     buffer,
+    sourceDimensions: null,
     contentType: "image/png",
   })),
 }));

--- a/extensions/browser/src/browser/routes/agent.snapshot.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.ts
@@ -216,21 +216,14 @@ async function saveNormalizedScreenshotResponse(params: {
   truncated?: boolean;
   annotations?: AnnotationItem[];
 }) {
-  // Measure original dimensions BEFORE normalization so we can rescale
-  // annotation coordinates if the response pipeline shrinks the image
-  // (longest-side or byte-budget cap). Annotation boxes are in the captured
-  // image's pixel space, so they would otherwise drift from the saved media.
-  const originalMeta = params.annotations?.length
-    ? ((await getImageMetadata(params.buffer)) ?? undefined)
-    : undefined;
   const normalized = await normalizeBrowserScreenshot(params.buffer, {
     maxSide: DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE,
     maxBytes: DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES,
   });
   const annotations = await rescaleAnnotationsForNormalization({
     annotations: params.annotations,
-    originalMeta,
-    normalizedBuffer: normalized.buffer,
+    originalBuffer: params.buffer,
+    normalized,
   });
   await saveBrowserMediaResponse({
     res: params.res,
@@ -256,17 +249,18 @@ async function saveNormalizedScreenshotResponse(params: {
  */
 async function rescaleAnnotationsForNormalization(params: {
   annotations?: AnnotationItem[];
-  originalMeta?: { width?: number; height?: number };
-  normalizedBuffer: Buffer;
+  originalBuffer: Buffer;
+  normalized: Awaited<ReturnType<typeof normalizeBrowserScreenshot>>;
 }): Promise<AnnotationItem[] | undefined> {
   if (!params.annotations || params.annotations.length === 0) {
     return params.annotations;
   }
-  const orig = params.originalMeta;
-  if (!orig?.width || !orig?.height) {
+  const orig = params.normalized.sourceDimensions;
+  // The normalizer already owns the source dimensions; identical bytes cannot rescale boxes.
+  if (params.originalBuffer === params.normalized.buffer || !orig?.width || !orig?.height) {
     return params.annotations;
   }
-  const next = await getImageMetadata(params.normalizedBuffer);
+  const next = await getImageMetadata(params.normalized.buffer);
   if (!next?.width || !next?.height) {
     return params.annotations;
   }
@@ -928,17 +922,14 @@ export function registerBrowserAgentSnapshotRoutes(
                 type: "png",
                 timeoutMs: plan.timeoutMs,
               });
-              const originalMeta = labeled.annotations.length
-                ? ((await getImageMetadata(labeled.buffer)) ?? undefined)
-                : undefined;
               const normalized = await normalizeBrowserScreenshot(labeled.buffer, {
                 maxSide: DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE,
                 maxBytes: DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES,
               });
               const scaledAnnotations = await rescaleAnnotationsForNormalization({
                 annotations: labeled.annotations,
-                originalMeta,
-                normalizedBuffer: normalized.buffer,
+                originalBuffer: labeled.buffer,
+                normalized,
               });
               await ensureMediaDir();
               const saved = await saveMediaBuffer(

--- a/extensions/browser/src/browser/screenshot.ts
+++ b/extensions/browser/src/browser/screenshot.ts
@@ -21,7 +21,11 @@ export async function normalizeBrowserScreenshot(
     maxSide?: number;
     maxBytes?: number;
   },
-): Promise<{ buffer: Buffer; contentType?: "image/jpeg" }> {
+): Promise<{
+  buffer: Buffer;
+  contentType?: "image/jpeg";
+  sourceDimensions: { width: number; height: number } | null;
+}> {
   const maxSide = Math.max(1, Math.round(opts?.maxSide ?? DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE));
   const maxBytes = Math.max(1, Math.round(opts?.maxBytes ?? DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES));
 
@@ -31,7 +35,7 @@ export async function normalizeBrowserScreenshot(
   const maxDim = Math.max(width, height);
 
   if (buffer.byteLength <= maxBytes && (maxDim === 0 || (width <= maxSide && height <= maxSide))) {
-    return { buffer };
+    return { buffer, sourceDimensions: meta };
   }
 
   const sideStart = maxDim > 0 ? Math.min(maxSide, maxDim) : maxSide;
@@ -63,7 +67,7 @@ export async function normalizeBrowserScreenshot(
       }
 
       if (out.byteLength <= maxBytes) {
-        return { buffer: out, contentType: "image/jpeg" };
+        return { buffer: out, contentType: "image/jpeg", sourceDimensions: meta };
       }
     }
     if (processorUnavailableError) {

--- a/extensions/browser/src/browser/server.control-server.test-harness.ts
+++ b/extensions/browser/src/browser/server.control-server.test-harness.ts
@@ -570,6 +570,7 @@ vi.mock("./screenshot.js", () => ({
   DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE: 64,
   normalizeBrowserScreenshot: vi.fn(async (buf: Buffer) => ({
     buffer: buf,
+    sourceDimensions: null,
     contentType: "image/png",
   })),
 }));


### PR DESCRIPTION
Browser snapshots currently keep parallel duplicate-ref arrays and maps, then clean them up after construction. Delta finalization parses the same formatter-owned lines twice. Labeled screenshot routes also probe source dimensions already read by normalization, and probe unchanged output again.

This PR removes that repeated preparation at the existing owners. Duplicate-group counts retain each backend’s omitted-versus-zero `nth` contract, including stored ARIA’s final-record lookup for overwritten input refs. Delta requests carry parsed refs and the truncator’s accepted source-line count into visibility filtering; ordinary capped requests still parse only retained lines. Screenshot normalization carries its private source dimensions to both annotation routes, and identical output buffers retain the original annotations without another metadata probe. No public SDK, config, schema, dependency, navigation authority or cache lifecycle changes.

Three distinct mechanisms are proposed, with four snapshot backends sharing one grouping mechanism. The formatted production delta is +88/-191, net -103; four existing test mocks add the new private return field (+4 test/support lines). An iframe-assembly proposal was rejected because a malformed raw-role control changed output; it is excluded.

The snapshot proof passed 1,299 scenarios / 3,897 exact comparisons across complete copied owners. The native image proof passed 34 cases across complete routes and actual Rastermill/Photon processing, including exact bytes, EXIF orientation, budgets, annotation geometry and output identities. Twelve fresh serial timing children retained all 5,508 samples across 90 workloads in both process orders. Source/dependency bindings and process cleanup were checked; all preflight output projections matched.

Representative warm local results: unique ARIA ref construction 1.55–1.77× faster; complete 32-row Playwright delta snapshots 1.36–1.41×; uncapped delta finalization 1.45–1.53×; labeled unchanged screenshot preparation 2.73–3.36×. The heavily capped large delta control and real native resizing (about113 ms) were approximately neutral. These are local owner costs with explicit browser/transport/storage substitutions, not end-to-end browser or provider latency, and ablation gains must not be multiplied.

Negative controls are retained: ordinary unlabelled screenshot POST cost 10.708→12.215µs /10.979→12.029µs (+1.05–1.51µs). Empty-label cases were mixed, including a medium-image +10.14%/+0.52% cost. The canonical source-dimension owner is retained without fixture-specific tuning branches. No retained-memory or whole-turn speedup claim.

The integrated owners exactly match the measured candidates. All260 existing tests across15 files pass; after rebasing onto current main,267 tests across16 files (including the updated pinned-transport suite) pass, as do the full build and full changed-file checks (including production/test types, lint, dead exports and boundary checks). Independent complete-owner review and managed Codex review are clean. No user-visible shape or behavior change requires a docs/changelog update under the current release-only policy.

Live verification passed through29 normal CLI/Gateway calls against a task-owned authenticated development Gateway and signed managed Chrome. It proved duplicate-reference targeting and ordered clicks, unchanged/added-node deltas, ordinary raw and exact element screenshots, both labeled GET/POST normalization paths, scaled annotation geometry, overlay teardown and absence of the private metadata field from public responses. The960×640 element image and both1000×2000 labeled images were visually inspected; raw capture remains756×469 as permitted by its native-surface contract. All owned processes exited, both ports closed, and final source/build bindings matched.

Failed attempts remain recorded. Fresh-profile startup intermittently failed in the unchanged ownership check before the fixture; passive transport/event-loop observations and a local V8 profile do not yet establish its underlying cause. Ownership, SSRF, timeouts and retries were not changed. An early helper assertion incorrectly equated raw native capture size with an emulated CSS viewport; the revised proof follows the documented route contract and separately checks a supported exact element clip. These are after-only behavior checks, not browser startup/whole-turn speed measurements. Chrome-MCP, iframe navigation/reset and raw-CDP snapshot fallback are covered by canonical tests/copied-owner proofs, not claimed as live here.

Rebase note: all six measured production owners remain byte-identical on main7504a3b3 plus this change. The upstream transport fix preserves nested contextless worker/iframe sessions; its complete owner/dependency path was reviewed and added to the canonical test run. The recorded live fixture contains neither workers nor iframes. Build/live receipts retain their original343fe909-plus-candidate provenance; they are not relabeled as a new build.
