### PR TITLE
fix(channels): include nested channel diagnostics in logs

### DIFF
--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -45,6 +45,10 @@ it does not guess one agent workspace.
 - `channels resolve <entries...>`: `--channel <name>`, `--account <id>`, `--agent <id>`, `--kind <auto|user|group|channel>` (default `auto`), `--json`
 - `channels logs`: `--channel <name|all>` (default `all`), `--lines <n>` (default `200`), `--json`
 
+`channels logs --channel <name>` matches subsystem or module names rooted at `<name>`
+or `gateway/channels/<name>`, including slash-separated descendants. Similar names
+such as `discord-archive` do not match `discord`.
+
 `channels status --probe` is the live path: on a reachable gateway it runs per-account
 `probeAccount` and optional `auditAccount` checks, so output can include transport
 state plus probe results such as `works`, `probe failed`, `audit ok`, or `audit failed`.

--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -113,7 +113,19 @@ describe("channelsLogsCommand", () => {
       shadow: { module: "external-chat-shadow" },
       match: { module: "external-chat" },
     },
-  ])("excludes a shadow $label while preserving an exact channel match", async (fixture) => {
+    {
+      label: "nested subsystem",
+      channel: "slack",
+      shadow: { subsystem: "slack-archive/send" },
+      match: { subsystem: "slack/send" },
+    },
+    {
+      label: "nested module",
+      channel: "external-chat",
+      shadow: { module: "external-chat-shadow/send" },
+      match: { module: "external-chat/send" },
+    },
+  ])("matches channel boundaries and excludes a shadow $label", async (fixture) => {
     await fs.writeFile(
       logPath,
       [

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -60,8 +60,9 @@ function parseChannelFilter(raw?: string): ChannelLogFilter {
 }
 
 function matchesChannelContext(value: string | undefined, channel: string) {
-  const path = `gateway/channels/${channel}`;
-  return value === channel || value === path || value?.startsWith(`${path}/`) === true;
+  return [channel, `gateway/channels/${channel}`].some(
+    (root) => value === root || value?.startsWith(`${root}/`) === true,
+  );
 }
 
 function matchesChannel(
@@ -73,8 +74,7 @@ function matchesChannel(
     return true;
   }
   return (
-    matchesChannelContext(line.subsystem, channel) ||
-    matchesChannelContext(line.module, channel) ||
+    [line.subsystem, line.module].some((value) => matchesChannelContext(value, channel)) ||
     (line.plugin !== undefined && filter.pluginIds.has(line.plugin))
   );
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**Allow edits from maintainers** remains enabled.

</details>

## What Problem This Solves

Closes #133600.

Fixes an issue where operators using `openclaw channels logs --channel <name>` would miss channel diagnostics when the logger used a nested context such as `discord/gateway`. The records were present in the log file and visible with `--channel all`, but absent from both channel-specific text and JSON output.

## Why This Change Was Made

Use the same exact-root or slash-descendant rule for both recognized context roots: `<channel>` and `gateway/channels/<channel>`. The owning matcher now applies that rule consistently to subsystem and module fields, while preserving exact plugin identity matching and exclusions for lookalike names. Consolidating duplicate field dispatch keeps production code net zero (+4/−4).

## User Impact

Channel-specific logs include nested diagnostics without changing logger namespaces, line/byte limits, rotation, configuration or plugin metadata behavior. The CLI documentation describes the matching boundaries.

## Evidence

- The two added boundary-table cases failed on unchanged production code with `[]` instead of `["match"]`; the two existing boundary controls passed.
- A real SDK logger → persisted log file → parser/tail → Commander fixture went from two missing nested-context cases to all 12 passing text/JSON cases. It also covers all-channel, exact-root, gateway-root/descendant, unrelated-channel and lookalike exclusions. This is an isolated local command flow, not a live Gateway/channel session.
- All 72 focused tests passed: 17 channel-log owner tests, 49 tail/redaction/subsystem tests and six parser tests through their maintained configurations.
- The full canonical three-path gate passed all 29 required phases, including both typechecks, lint and changed-file formatting. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33340019209) passed on `97a0cd22e8de6dd86c0aa9e8b3aeea35fab5b033`: 101 successful jobs and 17 intentional skips.

The first required-gate run stopped at a UI typecheck because the isolated checkout lacked its UI workspace dependency link and resolved the root workspace’s older `pako` package. Restoring the link to the already-installed UI dependencies resolved it; the unchanged full gate then passed. No dependency, declaration shim or check was changed.

Retained proof notes distinguish actual results from harness issues: a baseline label-format mismatch, one parser preflight timeout followed by an approved retry at the same limit, and a late outer-process observation during the real-command AFTER. Source and dependency guards and independent process cleanup passed. The logging tests also emitted existing temporary-file append warnings; the report does not claim warning-free test output.

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/133601#issuecomment-5471770749) has no actionable findings. Its rank-up request to wait for exact-head CI and inspect the latest review is complete.
