### PR TITLE
fix: keep run output token counts cumulative and recoverable

### DIFF
--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -380,6 +380,23 @@ field; OpenClaw does not infer it from assistant prose. The helper
 intentionally leaves prompt errors, in-flight turns, and intentional silent
 replies such as `NO_REPLY` unclassified.
 
+### Live output-token usage
+
+Call `params.hostCapabilities.reportOutputTokens?.(outputTokens)` once per
+completed model response. Pass that response's output tokens, not a
+thread-lifetime or cumulative attempt total. Deduplicate native response
+notifications before calling it.
+
+The host binds this callback to the admitted run, adds the response to its
+lifecycle-scoped total, and publishes the cumulative `usage` event globally and
+through `params.onAgentEvent`. Do not emit a second usage event. Retries share
+the same run total; run cleanup releases it. A closed or superseded capability
+rejects reporting. Invalid or nonpositive counts do not emit an event.
+
+The capability is optional for compatibility with older hosts; when absent,
+live output-token reporting is unavailable. Keep last-response context
+snapshots and persisted billing usage separate from this live counter.
+
 ### Agent-end side effects
 
 Native harnesses must call `runAgentEndSideEffects(...)` from

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -121,6 +121,12 @@ In chat:
 
 Other surfaces:
 
+- **Control UI:** the working indicator and completed-run recap show cumulative
+  **output tokens** for that run, including its model calls across tool use and
+  retries. Counts update when the runtime reports completed-response usage, not
+  on every streamed text fragment. Reloading an active run restores its latest
+  count. This counter excludes input tokens and is separate from the composer
+  context-window meter and persisted billing summaries.
 - **TUI/Web TUI:** `/status` and `/usage` are supported.
 - **CLI:** `openclaw status --usage` and `openclaw channels list` show
   normalized provider quota windows (`X% left`, not per-response costs).

--- a/extensions/codex/src/app-server/event-projector-usage.ts
+++ b/extensions/codex/src/app-server/event-projector-usage.ts
@@ -12,7 +12,7 @@ function readTokenCount(record: JsonObject, key: string): number | undefined {
 function readCodexThreadTokenUsage(params: JsonObject): ReturnType<typeof normalizeUsage> {
   const tokenUsage = isJsonObject(params.tokenUsage) ? params.tokenUsage : undefined;
   const last = tokenUsage && isJsonObject(tokenUsage.last) ? tokenUsage.last : undefined;
-  return last ? normalizeCodexThreadTokenUsage(last) : undefined;
+  return last ? normalizeCodexResponseTokenUsage(last) : undefined;
 }
 
 export function readCodexThreadContextSnapshot(params: JsonObject): {
@@ -21,7 +21,6 @@ export function readCodexThreadContextSnapshot(params: JsonObject): {
   cacheWriteInputTokens?: number;
   inputTokens?: number;
   modelContextWindow?: number;
-  outputTokens?: number;
   promptTokens?: number;
   reasoningOutputTokens?: number;
 } {
@@ -35,7 +34,6 @@ export function readCodexThreadContextSnapshot(params: JsonObject): {
   const inputTokens = last ? readTokenCount(last, "inputTokens") : undefined;
   const cachedInputTokens = last ? readTokenCount(last, "cachedInputTokens") : undefined;
   const cacheWriteInputTokens = last ? readTokenCount(last, "cacheWriteInputTokens") : undefined;
-  const outputTokens = last ? readTokenCount(last, "outputTokens") : undefined;
   const reasoningOutputTokens = last ? readTokenCount(last, "reasoningOutputTokens") : undefined;
   return {
     ...(activeContextTokens !== undefined ? { activeContextTokens } : {}),
@@ -43,7 +41,6 @@ export function readCodexThreadContextSnapshot(params: JsonObject): {
     ...(cacheWriteInputTokens !== undefined ? { cacheWriteInputTokens } : {}),
     ...(inputTokens !== undefined ? { inputTokens } : {}),
     ...(modelContextWindow && modelContextWindow > 0 ? { modelContextWindow } : {}),
-    ...(outputTokens !== undefined ? { outputTokens } : {}),
     ...(inputTokens !== undefined ? { promptTokens: inputTokens } : {}),
     ...(reasoningOutputTokens !== undefined ? { reasoningOutputTokens } : {}),
   };
@@ -62,19 +59,9 @@ export function projectCodexThreadUsageUpdate(
   }
 }
 
-export function normalizeCodexThreadTokenUsage(
-  record: JsonObject,
-): ReturnType<typeof normalizeUsage> {
-  return normalizeCodexTokenUsageBreakdown(record);
-}
-
 export function normalizeCodexResponseTokenUsage(
   record: JsonObject,
 ): ReturnType<typeof normalizeUsage> {
-  return normalizeCodexTokenUsageBreakdown(record);
-}
-
-function normalizeCodexTokenUsageBreakdown(record: JsonObject): ReturnType<typeof normalizeUsage> {
   // v2 TokenUsageBreakdown. inputTokens includes cached input; OpenClaw usage
   // tracks uncached input, cache reads, and cache writes separately.
   const totalTokens = readTokenCount(record, "totalTokens");
@@ -130,14 +117,19 @@ export class CodexResponseCompletionProjection {
     this.usage = undefined;
   }
 
-  record(params: JsonObject): void {
+  record(params: JsonObject, reportOutputTokens?: (outputTokens: number) => void): void {
     const responseId = readString(params, "responseId");
-    if (responseId) {
-      this.responseIds.add(responseId);
+    if (!responseId || this.responseIds.has(responseId)) {
+      return;
     }
+    this.responseIds.add(responseId);
     const usage = isJsonObject(params.usage) ? params.usage : undefined;
     // Every provider completion replaces the prior response snapshot. A final
     // response with missing or malformed usage must leave freshness unknown.
     this.usage = usage ? normalizeCodexResponseTokenUsage(usage) : undefined;
+    const outputTokens = this.usage?.output;
+    if (outputTokens !== undefined) {
+      reportOutputTokens?.(outputTokens);
+    }
   }
 }

--- a/extensions/codex/src/app-server/event-projector.test-harness.ts
+++ b/extensions/codex/src/app-server/event-projector.test-harness.ts
@@ -23,6 +23,7 @@ import {
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CodexAppServerEventProjector } from "./event-projector.js";
+import { createCodexTestHostCapabilities } from "./host-capability.test-support.js";
 import { createCodexTestModel, createCodexTestToolTerminalObserver } from "./test-support.js";
 
 export { readAttemptTerminal } from "./attempt-terminal.test-helper.js";
@@ -105,6 +106,7 @@ export async function createParams(): Promise<EmbeddedRunAttemptParams> {
     model: createCodexTestModel(),
     thinkLevel: "medium",
     observeToolTerminal: createCodexTestToolTerminalObserver(),
+    hostCapabilities: createCodexTestHostCapabilities(),
   } as EmbeddedRunAttemptParams;
 }
 

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -32,7 +32,7 @@ import { CodexToolProgressProjection } from "./event-projector-tool-progress.js"
 import { CodexToolTranscriptProjection } from "./event-projector-tool-transcript.js";
 import {
   CodexResponseCompletionProjection,
-  normalizeCodexThreadTokenUsage,
+  normalizeCodexResponseTokenUsage,
   projectCodexThreadUsageUpdate,
 } from "./event-projector-usage.js";
 import {
@@ -85,7 +85,7 @@ export class CodexAppServerEventProjector {
   private promptErrorSource: AttemptFailureSource | null = null;
   private synthesizedMissingToolResultError: string | null = null;
   private aborted = false;
-  private tokenUsage: ReturnType<typeof normalizeCodexThreadTokenUsage>;
+  private tokenUsage: ReturnType<typeof normalizeCodexResponseTokenUsage>;
   private contextTokens: number | undefined;
   private contextTokensSource: "runtime" | "runtime-configured" | "resolved" | undefined;
   private readonly responseCompletions = new CodexResponseCompletionProjection();
@@ -346,7 +346,7 @@ export class CodexAppServerEventProjector {
         await this.handleTurnCompleted(params);
         break;
       case "rawResponse/completed":
-        this.responseCompletions.record(params);
+        this.responseCompletions.record(params, this.params.hostCapabilities.reportOutputTokens);
         break;
       case "rawResponseItem/completed":
         await this.handleRawResponseItemCompleted(params);

--- a/extensions/codex/src/app-server/event-projector.usage.test.ts
+++ b/extensions/codex/src/app-server/event-projector.usage.test.ts
@@ -1,4 +1,9 @@
-import { normalizeUsage } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  emitAgentEvent,
+  normalizeUsage,
+  onAgentEvent,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { createAdmittedHostCapabilityTestFixture } from "openclaw/plugin-sdk/plugin-test-runtime";
 import {
   describe,
   registerCodexEventProjectorTestLifecycle,
@@ -33,9 +38,9 @@ describe("CodexAppServerEventProjector usage projection", () => {
 
   it("emits native context-window and prompt-token snapshots", async () => {
     const params = await createParams();
-    const onAgentEvent = vi.fn();
+    const callback = vi.fn();
     const projector = await createProjector(
-      { ...params, onAgentEvent },
+      { ...params, onAgentEvent: callback },
       { initialContextTokens: 1_050_000 },
     );
 
@@ -55,7 +60,7 @@ describe("CodexAppServerEventProjector usage projection", () => {
       }),
     );
 
-    expect(onAgentEvent).toHaveBeenCalledWith({
+    expect(callback).toHaveBeenCalledWith({
       stream: "usage",
       data: {
         activeContextTokens: 300_010,
@@ -63,7 +68,6 @@ describe("CodexAppServerEventProjector usage projection", () => {
         cacheWriteInputTokens: 5_000,
         inputTokens: 300_000,
         modelContextWindow: 875_900,
-        outputTokens: 10,
         promptTokens: 300_000,
         reasoningOutputTokens: 4,
       },
@@ -72,6 +76,95 @@ describe("CodexAppServerEventProjector usage projection", () => {
       contextTokens: 875_900,
       contextTokensSource: "runtime",
     });
+  });
+
+  it("publishes each completed response once before tools settle and carries totals across native turns", async () => {
+    const params = await createParams();
+    const callback = vi.fn();
+    const hosts: Array<Awaited<ReturnType<typeof createAdmittedHostCapabilityTestFixture>>> = [];
+    const createBoundProjector = async (attempt: typeof params) => {
+      const host = await createAdmittedHostCapabilityTestFixture(attempt);
+      hosts.push(host);
+      const projector = await createProjector({
+        ...attempt,
+        hostCapabilities: host.hostCapabilities,
+      });
+      return { host, projector };
+    };
+    const observed: number[] = [];
+    const unsubscribe = onAgentEvent((event) => {
+      if (event.stream === "lifecycle") {
+        params.lifecycleGeneration = event.lifecycleGeneration;
+      }
+      if (event.stream === "usage" && typeof event.data.outputTokens === "number") {
+        observed.push(event.data.outputTokens);
+      }
+    });
+    emitAgentEvent({
+      runId: params.runId,
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1 },
+    });
+    params.onAgentEvent = callback;
+    const { host: runHost, projector } = await createBoundProjector(params);
+    const response = (responseId: string, outputTokens: number) =>
+      forCurrentTurn("rawResponse/completed", {
+        responseId,
+        usage: {
+          inputTokens: 5,
+          cachedInputTokens: 2,
+          outputTokens,
+          totalTokens: 5 + outputTokens,
+          reasoningOutputTokens: 0,
+        },
+      });
+
+    try {
+      await projector.handleNotification(response("response-1", 100));
+      expect(observed).toEqual([100]);
+      await projector.handleNotification(response("response-2", 20));
+      await projector.handleNotification(response("response-1", 100));
+      await projector.handleNotification(
+        forCurrentTurn("error", { error: { message: "retry" }, willRetry: true }),
+      );
+      await projector.handleNotification(response("response-3", 50));
+      await projector.handleNotification(response("response-1", 100));
+      await projector.handleNotification(
+        forCurrentTurn("thread/tokenUsage/updated", {
+          tokenUsage: { last: { inputTokens: 5, outputTokens: 50, totalTokens: 55 } },
+        }),
+      );
+      expect(observed).toEqual([100, 120, 170]);
+      expect(projector.buildResult(buildEmptyToolTelemetry()).attemptUsage?.output).toBe(50);
+
+      const nextAttempt = await createProjector({
+        ...params,
+        hostCapabilities: runHost.hostCapabilities,
+      });
+      await nextAttempt.handleNotification(response("response-4", 10));
+      expect(observed).toEqual([100, 120, 170, 180]);
+      const { projector: otherRun } = await createBoundProjector({
+        ...params,
+        runId: "another-run",
+      });
+      await otherRun.handleNotification(response("another-response", 7));
+
+      expect(observed).toEqual([100, 120, 170, 180, 7]);
+      expect(
+        callback.mock.calls
+          .map(([event]) => event)
+          .filter(
+            (event) => event.stream === "usage" && typeof event.data.outputTokens === "number",
+          )
+          .map((event) => event.data.outputTokens),
+      ).toEqual(observed);
+    } finally {
+      unsubscribe();
+      for (const host of hosts) {
+        host.closeHost();
+        host.closeAdmission();
+      }
+    }
   });
 
   it("marks native telemetry constrained by an authored context cap", async () => {

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -3,8 +3,7 @@ import { createInlineCodeState } from "../../packages/markdown-core/src/code-spa
  * Subscribes to embedded-agent sessions and streams formatted replies/events.
  */
 import { formatToolAggregate } from "../auto-reply/tool-meta.js";
-import { emitAgentEventIfCurrent } from "../infra/agent-events.js";
-import { recordAgentRunOutputTokens } from "../infra/agent-run-usage.js";
+import { emitAgentRunOutputTokens } from "../infra/agent-events.js";
 import type { AssistantMessage } from "../llm/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { parseInlineDirectives } from "../utils/directive-tags.js";
@@ -200,17 +199,10 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     if (!lifecycleGeneration) {
       return;
     }
-    const data = recordAgentRunOutputTokens({
+    const data = emitAgentRunOutputTokens({
       runId: params.runId,
       lifecycleGeneration,
       outputTokens,
-      emit: (usage) =>
-        emitAgentEventIfCurrent({
-          runId: params.runId,
-          lifecycleGeneration,
-          stream: "usage",
-          data: usage,
-        }),
     });
     if (!data || !params.onAgentEvent) {
       return;

--- a/src/agents/harness/host-capability-types.ts
+++ b/src/agents/harness/host-capability-types.ts
@@ -33,6 +33,8 @@ export type AgentHarnessHostCapabilities = Readonly<{
   version: 1;
   /** Fails closed unless this exact admitted run capability remains active. */
   assertActive: () => void;
+  /** Reports one completed model call's output tokens to this admitted run's live total. */
+  reportOutputTokens?: (outputTokens: number) => void;
   /** Closure-bound event sink backed by the host-owned trajectory recorder. */
   trajectory?: Readonly<{
     recordEvent: (type: string, data?: Record<string, unknown>) => void;

--- a/src/agents/harness/host-capability.test.ts
+++ b/src/agents/harness/host-capability.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import type { GatewayRequestContext } from "../../gateway/server-methods/types.js";
+import { onAgentEvent } from "../../infra/agent-events.js";
 import {
   resetAgentRunRegistryForTest,
   rotateAgentRunRegistryLifecycleGeneration,
@@ -140,6 +141,55 @@ describe("agent harness host capability", () => {
     mockRunBefore.mockClear();
     mockCallGatewayTool.mockReset();
   });
+
+  it.each(["host closure", "authority release", "gateway restart"])(
+    "binds output usage to its original run and rejects reporting after %s",
+    async (revocation) => {
+      const onUsage = vi.fn();
+      const forgedCallback = vi.fn();
+      const { attempt } = await admittedAttempt("run-usage", {
+        onAgentEvent: onUsage,
+      });
+      let host = createAgentHarnessHostCapabilities({ attempt, pluginId: "codex" });
+      const events: Array<{ runId: string; sessionKey?: string; outputTokens: unknown }> = [];
+      const stop = onAgentEvent((event) => {
+        if (event.stream === "usage") {
+          events.push({
+            runId: event.runId,
+            sessionKey: event.sessionKey,
+            outputTokens: event.data.outputTokens,
+          });
+        }
+      });
+      try {
+        host.capabilities.reportOutputTokens?.(12);
+        host.close();
+        host = createAgentHarnessHostCapabilities({ attempt, pluginId: "codex" });
+        attempt.runId = "forged-run";
+        attempt.lifecycleGeneration = "forged-generation";
+        attempt.sessionKey = "forged-session";
+        attempt.onAgentEvent = forgedCallback;
+        host.capabilities.reportOutputTokens?.(8);
+        if (revocation === "host closure") {
+          host.close();
+        } else if (revocation === "authority release") {
+          closeAdmittedRunDelegatedAuthority(attempt.admittedRunContext);
+        } else {
+          rotateAgentRunRegistryLifecycleGeneration();
+        }
+        expect(() => host.capabilities.reportOutputTokens?.(100)).toThrow("no longer active");
+        expect(events).toEqual([
+          { runId: "run-usage", sessionKey: "agent:main:session-1", outputTokens: 12 },
+          { runId: "run-usage", sessionKey: "agent:main:session-1", outputTokens: 20 },
+        ]);
+        expect(onUsage.mock.calls.map(([event]) => event.data.outputTokens)).toEqual([12, 20]);
+        expect(forgedCallback).not.toHaveBeenCalled();
+      } finally {
+        stop();
+        host.close();
+      }
+    },
+  );
 
   it("binds Full node invocation to the exact live admission, session and placement", async () => {
     const previousRegistry = getActivePluginRegistry();

--- a/src/agents/harness/host-capability.ts
+++ b/src/agents/harness/host-capability.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { emitAgentRunOutputTokens } from "../../infra/agent-events.js";
 import { getActiveDiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
 import { prepareSystemRunMutableFileApproval } from "../../infra/system-run-approval-binding.js";
 import { buildAgentHookContextChannelFields } from "../../plugins/hook-agent-context.js";
@@ -19,7 +20,9 @@ import {
   runBeforeToolCallHook,
 } from "../agent-tools.before-tool-call.js";
 import { createOpenClawCodingTools } from "../agent-tools.js";
+import { log } from "../embedded-agent-runner/logger.js";
 import type { EmbeddedRunAttemptParams } from "../embedded-agent-runner/run/types.js";
+import { runBestEffortCallback } from "../embedded-agent-subscribe.callback.js";
 import { createCronScheduledToolProjection } from "../exec-tool-target-pinning.js";
 import { prepareGitHubToolEnvironment } from "../github-tool-identity.js";
 import {
@@ -171,6 +174,7 @@ export function createAgentHarnessHostCapabilities(params: {
   runWithScope: <T>(run: () => Promise<T>) => Promise<T>;
 } {
   const attempt = params.attempt;
+  const { sessionKey, onAgentEvent } = attempt;
   // Capture the selected harness declaration before plugin code can mutate it.
   // Full must not cover other commands merely because the same plugin owns them.
   const requiredNodeCommands = new Set(params.requiredNodeCommands);
@@ -179,6 +183,8 @@ export function createAgentHarnessHostCapabilities(params: {
   if (!delegatedAuthority) {
     throw new Error("agent harness host capability requires active admitted run authority");
   }
+  const { lifecycleGeneration } = delegatedAuthority;
+  const { runId } = delegatedAuthority.operationalRunInstance;
   let active = true;
   // Lexical closure must also fence work already past its entry guard. The
   // result guards below cover exact authority loss that does not use close().
@@ -339,6 +345,22 @@ export function createAgentHarnessHostCapabilities(params: {
     kind: "agent-harness-host-capability" as const,
     version: 1 as const,
     assertActive,
+    reportOutputTokens: (outputTokens) => {
+      assertActive();
+      const data = emitAgentRunOutputTokens({
+        runId,
+        lifecycleGeneration,
+        sessionKey,
+        outputTokens,
+      });
+      if (data && onAgentEvent) {
+        runBestEffortCallback({
+          label: "usage agent event",
+          log,
+          callback: () => onAgentEvent({ stream: "usage", data }),
+        });
+      }
+    },
     ...(trajectoryRecorder
       ? {
           trajectory: Object.freeze({

--- a/src/gateway/server-chat-progress-snapshot.ts
+++ b/src/gateway/server-chat-progress-snapshot.ts
@@ -46,6 +46,7 @@ export function updateChatRunProgressSnapshot(
     ["start", "input_delta", "update", "review", "result"].includes(phase) &&
     (phase !== "review" || (mode === "full" && Boolean(reviewId)));
   const isPreamble = event.stream === "item" && data.kind === "preamble";
+  const isUsage = event.stream === "usage";
   const isNotice = event.stream === "notice" && phase === "warning";
   const guardianTargetItemId =
     typeof data.targetItemId === "string" ? data.targetItemId.trim() : "";
@@ -65,12 +66,13 @@ export function updateChatRunProgressSnapshot(
         candidate.data.phase === "strict_review_required" &&
         candidate.data.reviewId === data.reviewId,
     );
-  if (mode === "summary" && !isTool && !isPreamble) {
+  if (mode === "summary" && !isTool && !isPreamble && !isUsage) {
     return snapshot;
   }
   if (
     !isTool &&
     !isPreamble &&
+    !isUsage &&
     !isStartupStatus &&
     !isStandaloneGuardian &&
     !isNotice &&
@@ -91,6 +93,9 @@ export function updateChatRunProgressSnapshot(
     candidate.data?.kind === "preamble" &&
     (candidate.data.itemId ?? "") === preambleItemId;
   const previousPreamble = preambleItemId ? next.events.find(matchesPreamble) : undefined;
+  const previousUsage = isUsage
+    ? next.events.find((candidate) => candidate.stream === "usage")
+    : undefined;
 
   const removeWhere = (predicate: (candidate: AgentEventPayload) => boolean) => {
     next.events = next.events.filter((candidate) => !predicate(candidate));
@@ -104,7 +109,10 @@ export function updateChatRunProgressSnapshot(
     return next;
   }
 
-  if (isStartupStatus || isTool || isPreamble) {
+  if (isUsage) {
+    // Context-only updates must retain the run total already reported by completed responses.
+    removeWhere((candidate) => candidate.stream === "usage");
+  } else if (isStartupStatus || isTool || isPreamble) {
     // Remove superseded startup and item state together; recount retained mutable payloads once.
     removeWhere((candidate) => {
       if (candidate.stream === "run_status") {
@@ -168,7 +176,7 @@ export function updateChatRunProgressSnapshot(
           itemId: preambleItemId || undefined,
           progressText: data.progressText,
         }
-      : { ...data };
+      : { ...previousUsage?.data, ...data };
   for (const key of Object.keys(storedData)) {
     if (storedData[key] === undefined) {
       delete storedData[key];
@@ -215,7 +223,8 @@ export function updateChatRunProgressSnapshot(
     next.events.length > CHAT_RUN_PROGRESS_MAX_EVENTS ||
     next.byteLength > CHAT_RUN_PROGRESS_MAX_BYTES
   ) {
-    const oldest = next.events[0];
+    // The single usage snapshot is current run state, not evictable activity history.
+    const oldest = next.events.find((candidate) => candidate.stream !== "usage");
     if (!oldest) {
       break;
     }

--- a/src/gateway/server-chat-state.test.ts
+++ b/src/gateway/server-chat-state.test.ts
@@ -52,6 +52,36 @@ describe("createChatRunState", () => {
     expect(state.registry.shift("run-b")?.clientRunId).toBe("client-b-2");
   });
 
+  it.each(["full", "summary"] as const)(
+    "retains the latest usage through %s reconnect eviction",
+    (mode) => {
+      const state = createChatRunState();
+      const event = (seq: number, stream: string, data: Record<string, unknown>) =>
+        state.recordProgressEvent("run-1", { runId: "run-1", seq, stream, ts: seq, data }, mode);
+      event(1, "usage", { outputTokens: 100 });
+      event(2, "usage", { outputTokens: 170 });
+      event(1, "usage", { outputTokens: 100 });
+      event(3, "usage", { activeContextTokens: 900 });
+      for (let seq = 4; seq < 65; seq += 1) {
+        event(seq, "tool", { phase: "start", toolCallId: `tool-${seq}`, name: "read" });
+      }
+      const snapshot = state.runs.get("run-1")?.progressSnapshot;
+      expect(snapshot?.events.filter((candidate) => candidate.stream === "usage")).toEqual([
+        {
+          runId: "run-1",
+          seq: 3,
+          stream: "usage",
+          ts: 3,
+          data: { outputTokens: 170, activeContextTokens: 900 },
+        },
+      ]);
+      expect(snapshot?.events).toHaveLength(50);
+      expect(snapshot?.byteLength).toBeLessThanOrEqual(128 * 1024);
+      state.clearRun("run-1");
+      expect(state.runs.has("run-1")).toBe(false);
+    },
+  );
+
   it.each(["naming_worktree", "creating_worktree", "running_setup", "preparing_context"])(
     "retains only the latest startup status (%s) until observable run activity begins",
     (phase) => {

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -352,6 +352,23 @@ describe("agent event handler", () => {
     );
   });
 
+  it("replays cumulative usage with the same client identity as live delivery", () => {
+    const { chatRunState, handler, broadcast } = createHarness();
+    registerChatRun(chatRunState, "provider-run", "session-1", "client-run");
+    emitAgentEvents(handler, "provider-run", [
+      ["usage", { outputTokens: 100 }],
+      ["usage", { outputTokens: 170 }],
+    ]);
+    const usage = agentBroadcastCalls(broadcast).at(-1)?.[1];
+    expect(usage).toMatchObject({
+      runId: "client-run",
+      sessionKey: "session-1",
+      stream: "usage",
+      data: { outputTokens: 170 },
+    });
+    expect(chatRunState.runs.get("client-run")?.progressSnapshot?.events).toEqual([usage]);
+  });
+
   it("records, replaces, dismisses, and clears normalized plan snapshots", () => {
     const { chatRunState, handler } = createHarness();
     registerChatRun(chatRunState, "provider-run", "session-1", "client-run");

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1480,18 +1480,7 @@ export function createAgentEventHandler({
         ...(explanation ? { explanation } : {}),
       };
     }
-    if (
-      recordsInFlightProgress &&
-      !isAborted &&
-      ((isToolEvent && !suppressHeartbeatToolEvents) ||
-        isItemEvent ||
-        evt.stream === "run_status" ||
-        evt.stream === "notice" ||
-        typeof evt.data?.reviewId === "string" ||
-        evt.data?.phase === "started" ||
-        evt.data?.phase === "completed" ||
-        evt.data?.phase === "warning")
-    ) {
+    if (recordsInFlightProgress && !isAborted && !suppressHeartbeatToolEvents) {
       // Persist the client-facing identity after run/session remapping. Route
       // changes discard transient UI rows, so history replay must use the same
       // payload identity as live delivery or tool results cannot reconcile.

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -7,6 +7,7 @@ import {
   emitAgentEvent,
   emitAgentEventForOwner,
   emitAgentEventIfCurrent,
+  emitAgentRunOutputTokens,
   getAgentEventLifecycleGeneration,
   onAgentAuditEvent,
   onAgentEvent,
@@ -28,7 +29,6 @@ import {
   sweepStaleRunContexts,
 } from "./agent-run-registry.js";
 import { emitAgentRunStatusEvent } from "./agent-run-status-events.js";
-import { recordAgentRunOutputTokens } from "./agent-run-usage.js";
 
 type AgentEventsModule = {
   events: typeof import("./agent-events.js");
@@ -133,30 +133,29 @@ describe("agent-events sequencing", () => {
         seen.push(event.data.outputTokens as number);
       }
     });
-    const emitUsage = (outputTokens: number) => {
-      recordAgentRunOutputTokens({
+    const emitUsage = (outputTokens: number, generation = lifecycleGeneration) =>
+      emitAgentRunOutputTokens({
         runId: "usage-run",
-        lifecycleGeneration,
+        lifecycleGeneration: generation,
         outputTokens,
-        emit: (data) =>
-          emitAgentEventIfCurrent({
-            runId: "usage-run",
-            lifecycleGeneration,
-            stream: "usage",
-            data,
-          }),
       });
-    };
 
-    emitUsage(12);
+    expect(emitUsage(12)).toEqual({ outputTokens: 12 });
     registerAgentRunContext("usage-run", { sessionKey: "main", lifecycleGeneration });
     emitUsage(8);
     clearAgentRunContext("usage-run", lifecycleGeneration);
     registerAgentRunContext("usage-run", { sessionKey: "main", lifecycleGeneration });
     emitUsage(3);
+    const nextGeneration = rotateAgentEventLifecycleGeneration();
+    claimAgentRunContext("usage-run", {
+      sessionKey: "main",
+      lifecycleGeneration: nextGeneration,
+    });
+    expect(emitUsage(100)).toBeUndefined();
+    emitUsage(4, nextGeneration);
     stop();
 
-    expect(seen).toEqual([12, 20, 3]);
+    expect(seen).toEqual([12, 20, 3, 4]);
   });
 
   test("clears sequence state when guarded cleanup finds no run context", () => {

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -12,6 +12,7 @@ import {
   resetAgentRunRegistryForTest,
   rotateAgentRunRegistryLifecycleGeneration,
 } from "./agent-run-registry.js";
+import { recordAgentRunOutputTokens } from "./agent-run-usage.js";
 
 /** Approval event phase for request/resolution transitions. */
 type AgentApprovalEventPhase = "requested" | "resolved";
@@ -376,6 +377,26 @@ export function emitAgentEventIfCurrent(event: Omit<AgentEventPayload, "seq" | "
   }
   notifyListeners(iterateAgentEventListeners(getAgentEventState(), enriched), enriched);
   return true;
+}
+
+/** Adds one completed model call, returning its accepted run total for local callbacks. */
+export function emitAgentRunOutputTokens(params: {
+  runId: string;
+  lifecycleGeneration: string;
+  outputTokens: number;
+  sessionKey?: string;
+}): { outputTokens: number } | undefined {
+  return recordAgentRunOutputTokens({
+    ...params,
+    emit: (data) =>
+      emitAgentEventIfCurrent({
+        runId: params.runId,
+        lifecycleGeneration: params.lifecycleGeneration,
+        sessionKey: params.sessionKey,
+        stream: "usage",
+        data,
+      }),
+  });
 }
 
 /** Emits an agent event after assigning per-run sequence, timestamp, and context metadata. */

--- a/ui/src/e2e/chat-flow.stream-reconciliation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.stream-reconciliation.e2e.test.ts
@@ -92,7 +92,7 @@ suite.define(() => {
             .poll(async () =>
               (await page.locator(".chat-working-indicator__tokens").textContent())?.trim(),
             )
-            .toBe("2.4k tokens");
+            .toBe("2,400 output tokens");
           await expect.poll(() => page.locator(".chat-bubble.streaming").count()).toBe(0);
           expect(
             (await page.locator(".chat-group.assistant .chat-text").allTextContents()).map(

--- a/ui/src/e2e/chat-flow.streaming.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.streaming.e2e.test.ts
@@ -600,7 +600,7 @@ suite.define(() => {
         .poll(async () =>
           (await page.locator(".chat-working-indicator__tokens").textContent())?.trim(),
         )
-        .toBe("2.4k tokens");
+        .toBe("2,400 output tokens");
 
       const response = "The streamed response is now visible.";
       await gateway.emitGatewayEvent("chat", {
@@ -621,7 +621,7 @@ suite.define(() => {
         (row, visibleResponse) => ({
           connected: row.isConnected,
           hasResponse: row.textContent?.includes(visibleResponse) ?? false,
-          hasTokens: row.textContent?.includes("2.4k tokens") ?? false,
+          hasTokens: row.textContent?.includes("2,400 output tokens") ?? false,
           key: row.getAttribute("data-virtual-row-key"),
         }),
         response,

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5784,8 +5784,8 @@ export const en: TranslationMap = {
     },
     turnRecap: {
       doneIn: "Done in {duration}",
-      tokens: "{count} tokens",
-      tokensOne: "1 token",
+      tokens: "{count} output tokens",
+      tokensOne: "1 output token",
     },
     commands: {
       arguments: "Command arguments",

--- a/ui/src/pages/chat/chat-history.inflight.test.ts
+++ b/ui/src/pages/chat/chat-history.inflight.test.ts
@@ -185,7 +185,7 @@ describe("chat history in-flight assistant recovery", () => {
     },
   );
 
-  it("restores active tool state and authoritative preamble time from the in-flight run snapshot", async () => {
+  it("restores tools, preamble time, and output usage from the in-flight run snapshot", async () => {
     const history = activeHistory("run-live");
     (history.inFlightRun as { events?: unknown[] }).events = [
       {
@@ -213,11 +213,20 @@ describe("chat history in-flight assistant recovery", () => {
           args: { path: "README.md" },
         },
       },
+      {
+        runId: "run-live",
+        seq: 3,
+        stream: "usage",
+        ts: 1_100,
+        sessionKey: "main",
+        data: { outputTokens: 695, context: { totalTokens: 1_500, contextWindow: 8_000 } },
+      },
     ];
     const state = createState(history);
 
     await loadHistoryWithBrowserTimers(state);
 
+    expect(state.chatRunUsageById?.get("run-live")?.outputTokens).toBe(695);
     expect(state.chatToolMessages[0]).toMatchObject({
       runId: "run-live",
       toolCallId: "call-restored",

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -69,7 +69,7 @@ import { activeQueuedMessageEdit } from "./queued-message-edit.ts";
 import { hasAbortableSessionRun } from "./run-lifecycle.ts";
 import { scheduleChatScroll } from "./scroll.ts";
 import { maybeResetToolStream } from "./stream-reconciliation.ts";
-import { resolveActiveRunOutputTokens, resolveChatProjectionRunId } from "./tool-stream.ts";
+import { resolveChatProjectionRunId } from "./tool-stream.ts";
 import { configureToolTitleFetcher } from "./tool-titles.ts";
 import { workspaceResultConflictFromPlacement } from "./workspace-conflict.ts";
 
@@ -250,11 +250,6 @@ export class ChatPane extends ChatPaneLayoutRender {
       presenceEntries: readPresenceEntries(this.presencePayload),
       presenceInstanceId: gatewaySnapshot.client?.instanceId,
     });
-    const runOutputTokens = resolveActiveRunOutputTokens({
-      localRunId: state.chatRunId,
-      activeRunIds: selectedSession?.activeRunIds,
-      usageByRun: state.chatRunUsageById,
-    });
     const projectionRunId = resolveChatProjectionRunId({
       localRunId: state.chatRunId,
       activeRunIds: selectedSession?.activeRunIds,
@@ -359,7 +354,7 @@ export class ChatPane extends ChatPaneLayoutRender {
       stream: catalogKey ? null : state.chatStream,
       streamStartedAt: catalogKey ? null : state.chatStreamStartedAt,
       runId: catalogKey ? null : projectionRunId,
-      runOutputTokens: catalogKey ? null : runOutputTokens,
+      runUsageById: catalogKey ? undefined : state.chatRunUsageById,
       assistantAvatarUrl: resolveChatAvatarUrl(state),
       sendShortcut: state.settings.chatSendShortcut,
       followUpMode: state.chatFollowUpMode,

--- a/ui/src/pages/chat/chat-progress.test.ts
+++ b/ui/src/pages/chat/chat-progress.test.ts
@@ -1,9 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resetWorkingProgress, resolveTurnRecap, resolveWorkingProgress } from "./chat-progress.ts";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
+import {
+  resetWorkingProgress,
+  resolveTurnRecap,
+  resolveWorkingProgress,
+  type TurnRecapWatch,
+} from "./chat-progress.ts";
 
 const SESSION = "agent:main:main";
-const PREVIOUS_ENDED_AT = 900_000;
-const RUN_ENDED_AT = 1_000_000;
 
 describe("resolveWorkingProgress", () => {
   beforeEach(() => resetWorkingProgress());
@@ -32,195 +36,144 @@ describe("resolveWorkingProgress", () => {
   });
 });
 
-const doneRow = (endedAt: number, runtimeMs = 51_000, outputTokens?: number) => ({
-  status: "done",
-  endedAt,
-  runtimeMs,
-  ...(outputTokens === undefined ? {} : { outputTokens }),
-});
-
 describe("resolveTurnRecap", () => {
-  beforeEach(() => resetWorkingProgress());
-  afterEach(() => resetWorkingProgress());
+  let host: { turnRecapWatch: TurnRecapWatch | null };
+  const runId = "watched-run";
+  const doneRow = { lastRunId: runId, status: "done" as const, runtimeMs: 14_000 };
+  const usage = (outputTokens: number, owner = runId) =>
+    new Map([[owner, { outputTokens, seq: 1 }]]);
+  const resolve = (params: Omit<Parameters<typeof resolveTurnRecap>[1], "sessionKey"> = {}) =>
+    resolveTurnRecap(host, { sessionKey: SESSION, ...params });
+  const watch = () => resolve({ indicator: { runId } });
 
-  it("resolves once a fresh terminal stamp lands, then sticks", () => {
-    // Indicator up: previous run's terminal stamp becomes the baseline.
-    expect(resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT))).toBeNull();
-    // Indicator settles but only the stale row is visible so far.
-    expect(resolveTurnRecap(SESSION, false, doneRow(PREVIOUS_ENDED_AT))).toBeNull();
-    // Fresh terminal patch: recap resolves and keeps resolving.
-    const row = doneRow(RUN_ENDED_AT, 51_000, 485);
-    expect(resolveTurnRecap(SESSION, false, row)).toEqual({
-      runtimeMs: 51_000,
-      outputTokens: 485,
-    });
-    expect(resolveTurnRecap(SESSION, false, row)).toEqual({
-      runtimeMs: 51_000,
-      outputTokens: 485,
-    });
+  beforeEach(() => {
+    host = { turnRecapWatch: null };
   });
 
-  it("does not show the previous turn's token count when the usage persist lags", () => {
-    // Terminal stamp and usage persist are separate writes: the fresh-endedAt
-    // row still carries the previous turn's outputTokens (10).
-    resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT, 51_000, 10));
-    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT, 14_000, 10))).toEqual({
+  it("matches the watched run instead of inferring identity from session-row values", () => {
+    expect(watch()).toBeNull();
+    expect(
+      resolve({ row: { ...doneRow, lastRunId: "previous-run" }, usageByRun: usage(690) }),
+    ).toBeNull();
+    expect(resolve({ row: doneRow, usageByRun: usage(690) })).toEqual({
+      runId,
       runtimeMs: 14_000,
-      outputTokens: null,
+      outputTokens: 690,
     });
   });
 
-  it("falls back to the watched run's live usage counter for a lagging row", () => {
-    resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT, 51_000, 10), 120);
-    // Counter grows while the run streams; the watch keeps the max.
-    resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT, 51_000, 10), 695);
-    // Usage map entry died at lifecycle end: settle renders pass null.
-    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT, 14_000, 10), null)).toEqual({
+  it("reconciles usage arriving after the first completed recap", () => {
+    watch();
+    expect(resolve({ row: doneRow, usageByRun: usage(690) })).toEqual({
+      runId,
+      runtimeMs: 14_000,
+      outputTokens: 690,
+    });
+    expect(resolve({ row: doneRow, usageByRun: usage(695) })).toEqual({
+      runId,
       runtimeMs: 14_000,
       outputTokens: 695,
     });
-  });
-
-  it("prefers the row's tokens once the usage persist has landed", () => {
-    resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT, 51_000, 10), 690);
-    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT, 14_000, 695))).toEqual({
+    expect(resolve({ row: doneRow, usageByRun: usage(680) })).toEqual({
+      runId,
       runtimeMs: 14_000,
-      outputTokens: 695,
+      outputTokens: 680,
     });
   });
 
-  it("rejects the previous turn's row even seconds after this run started", () => {
-    resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT));
-    // Rapid back-to-back turns: the old done row stays stale forever, and so
-    // does any regressed (out-of-order) stamp.
-    expect(resolveTurnRecap(SESSION, false, doneRow(PREVIOUS_ENDED_AT))).toBeNull();
-    expect(resolveTurnRecap(SESSION, false, doneRow(PREVIOUS_ENDED_AT - 5_000))).toBeNull();
+  it("retains a matching terminal that arrives before the indicator disappears", () => {
+    expect(resolve({ indicator: { runId }, row: doneRow, usageByRun: usage(695) })).toBeNull();
+    expect(resolve()).toEqual({ runId, runtimeMs: 14_000, outputTokens: 695 });
   });
 
-  it("expires an unresolved watch instead of matching a later run", () => {
-    vi.useFakeTimers({ now: 1_000_000 });
-    try {
-      // A queued send showed the claw but the run never started.
-      resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT));
-      expect(resolveTurnRecap(SESSION, false, doneRow(PREVIOUS_ENDED_AT))).toBeNull();
-      vi.advanceTimersByTime(31_000);
-      expect(resolveTurnRecap(SESSION, false, doneRow(PREVIOUS_ENDED_AT))).toBeNull();
-      // A cron/background completion minutes later cannot claim the turn.
-      expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT))).toBeNull();
-    } finally {
-      vi.useRealTimers();
-    }
+  it("keeps a resolved recap against unwatched terminal rows and usage", () => {
+    watch();
+    const recap = resolve({ row: doneRow, usageByRun: usage(695) });
+    expect(
+      resolve({
+        row: { ...doneRow, lastRunId: "foreign-run", runtimeMs: 1_000 },
+        usageByRun: usage(900, "foreign-run"),
+      }),
+    ).toEqual(recap);
   });
 
-  it("consumes the watch on a fresh done row without runtime data", () => {
-    resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT));
-    expect(resolveTurnRecap(SESSION, false, { status: "done", endedAt: RUN_ENDED_AT })).toBeNull();
-    // The watch concluded; a later completion cannot attach.
-    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT + 1_000))).toBeNull();
-  });
-
-  it("treats a cleared baseline (run start patch seen) as stale-free", () => {
-    // Start patch cleared endedAt before the watch began.
-    expect(resolveTurnRecap(SESSION, true, { status: "running" })).toBeNull();
-    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT, 2_000))).toEqual({
-      runtimeMs: 2_000,
+  it("waits for runtime data without borrowing another run's count", () => {
+    watch();
+    expect(
+      resolve({ row: { lastRunId: runId, status: "done" }, usageByRun: usage(900, "foreign-run") }),
+    ).toBeNull();
+    expect(resolve({ row: doneRow, usageByRun: usage(900, "foreign-run") })).toEqual({
+      runId,
+      runtimeMs: 14_000,
       outputTokens: null,
     });
   });
 
-  it("never resolves without having watched a working indicator", () => {
-    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT))).toBeNull();
-  });
-
-  it("consumes a watch whose baseline row was never observed", () => {
-    // Session row unavailable for the entire watch (capped list, still loading).
-    expect(resolveTurnRecap(SESSION, true, undefined)).toBeNull();
-    // The row appears only after settle, carrying the PREVIOUS run's stamp:
-    // with no baseline it must not pass as this turn's terminal.
-    expect(resolveTurnRecap(SESSION, false, doneRow(PREVIOUS_ENDED_AT))).toBeNull();
-    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT))).toBeNull();
-  });
-
-  it("adopts the first row observed mid-watch as the baseline", () => {
-    expect(resolveTurnRecap(SESSION, true, undefined)).toBeNull();
-    // Row loads while the claw is still up, showing the previous stamp.
-    expect(resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT))).toBeNull();
-    // Normal settle: only a fresh stamp resolves.
-    expect(resolveTurnRecap(SESSION, false, doneRow(PREVIOUS_ENDED_AT))).toBeNull();
-    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT, 6_000))).toEqual({
-      runtimeMs: 6_000,
-      outputTokens: null,
-    });
-  });
-
-  it("forfeits the turn when a terminal stamp changes mid-watch", () => {
-    // Watch starts after the run-start patch cleared endedAt.
-    expect(resolveTurnRecap(SESSION, true, { status: "running" })).toBeNull();
-    // A terminal lands while the claw is still up: attribution is ambiguous
-    // (early own-terminal, delayed prior run, other device) — consume quietly.
-    expect(resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT))).toBeNull();
-    expect(resolveTurnRecap(SESSION, false, doneRow(PREVIOUS_ENDED_AT))).toBeNull();
-    // Later stamps (e.g. a cron run) must not attach to the forfeited turn.
-    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT, 4_000))).toBeNull();
-  });
-
-  it("forfeits a failed turn whose terminal raced the indicator", () => {
-    resolveTurnRecap(SESSION, true, { status: "running" });
-    // The watched run fails while its claw is still visible.
-    resolveTurnRecap(SESSION, true, { status: "failed", endedAt: RUN_ENDED_AT });
+  it("reports equal counts on consecutive runs and preserves a known zero", () => {
+    watch();
+    expect(resolve({ row: doneRow, usageByRun: usage(0) })?.outputTokens).toBe(0);
+    const nextRunId = "next-run";
+    expect(resolve({ indicator: { runId: nextRunId }, row: doneRow })).toBeNull();
+    expect(resolve({ row: doneRow })).toBeNull();
     expect(
-      resolveTurnRecap(SESSION, false, { status: "failed", endedAt: RUN_ENDED_AT }),
-    ).toBeNull();
-    // A background run's later success cannot masquerade as this turn.
-    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT + 60_000))).toBeNull();
+      resolve({ row: { ...doneRow, lastRunId: nextRunId }, usageByRun: usage(0, nextRunId) }),
+    ).toEqual({ runId: nextRunId, runtimeMs: 14_000, outputTokens: 0 });
   });
 
-  it("freezes the first resolved recap against later unwatched terminals", () => {
-    resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT));
-    const settled = resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT, 51_000, 485));
-    expect(settled).toEqual({ runtimeMs: 51_000, outputTokens: 485 });
-    // A background/cron run finishing later must not rewrite the recap.
-    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT + 90_000, 7_000, 42))).toEqual(
-      settled,
-    );
+  it.each(["failed", "timeout", "killed"] as const)(
+    "stays quiet for a watched %s run",
+    (status) => {
+      watch();
+      expect(resolve({ row: { ...doneRow, status }, usageByRun: usage(695) })).toBeNull();
+      expect(
+        resolve({
+          row: { ...doneRow, lastRunId: "foreign-run" },
+          usageByRun: usage(900, "foreign-run"),
+        }),
+      ).toBeNull();
+    },
+  );
+
+  it("never invents a watch from history or an unidentified queued indicator", () => {
+    expect(resolve({ row: doneRow, usageByRun: usage(695) })).toBeNull();
+    expect(resolve({ indicator: {}, row: doneRow })).toBeNull();
+    expect(resolve({ row: doneRow, usageByRun: usage(695) })).toBeNull();
   });
 
-  it("hides the recap as soon as the next run's indicator appears", () => {
-    resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT));
-    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT, 51_000, 485))).toEqual({
-      runtimeMs: 51_000,
-      outputTokens: 485,
-    });
-    // Next turn: indicator visible again — recap gone before its terminal row changes.
-    expect(resolveTurnRecap(SESSION, true, doneRow(RUN_ENDED_AT))).toBeNull();
-    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT))).toBeNull();
-    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT + 1_000, 2_000, 12))).toEqual({
-      runtimeMs: 2_000,
-      outputTokens: 12,
-    });
+  it("clears the previous recap when a new queued turn has no run identity yet", () => {
+    watch();
+    expect(resolve({ row: doneRow, usageByRun: usage(695) })).not.toBeNull();
+    expect(resolve({ indicator: {}, row: doneRow })).toBeNull();
+    expect(resolve({ row: doneRow, usageByRun: usage(695) })).toBeNull();
   });
 
-  it("stays quiet for failed runs but ignores stale failed rows", () => {
-    resolveTurnRecap(SESSION, true, {
-      status: "failed",
-      endedAt: PREVIOUS_ENDED_AT,
-    });
-    // Stale failed row from before this run must not consume the watch.
-    expect(
-      resolveTurnRecap(SESSION, false, { status: "failed", endedAt: PREVIOUS_ENDED_AT }),
-    ).toBeNull();
-    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT, 3_000))).toEqual({
-      runtimeMs: 3_000,
-      outputTokens: null,
-    });
-  });
+  it.each(["agent", "gateway"])(
+    "invalidates a settled global recap when its %s changes",
+    (owner) => {
+      const params = {
+        sessionKey: "global",
+        agentId: "first",
+        gatewayClient: createTestGatewayClient(() => null),
+        usageByRun: usage(695),
+      };
+      resolveTurnRecap(host, { ...params, indicator: { runId } });
+      expect(resolveTurnRecap(host, { ...params, row: doneRow })).not.toBeNull();
+      const replacement =
+        owner === "agent"
+          ? { ...params, agentId: "second" }
+          : { ...params, gatewayClient: createTestGatewayClient(() => null) };
+      expect(resolveTurnRecap(host, { ...replacement, row: doneRow })).toBeNull();
+      expect(resolveTurnRecap(host, { ...params, row: doneRow })).toBeNull();
+    },
+  );
 
-  it("consumes the watch on a fresh failed row", () => {
-    resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT));
-    expect(
-      resolveTurnRecap(SESSION, false, { status: "failed", endedAt: RUN_ENDED_AT }),
-    ).toBeNull();
-    // A later done stamp belongs to some other run; the watch is gone.
-    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT + 1_000))).toBeNull();
+  it("isolates watches by pane and resets them on session changes", () => {
+    const other = { turnRecapWatch: null };
+    watch();
+    const params = { sessionKey: SESSION, row: doneRow, usageByRun: usage(695) };
+    expect(resolveTurnRecap(other, params)).toBeNull();
+    expect(resolveTurnRecap(host, params)).not.toBeNull();
+    expect(resolveTurnRecap(host, { ...params, sessionKey: "other-session" })).toBeNull();
+    expect(resolveTurnRecap(host, params)).toBeNull();
   });
 });

--- a/ui/src/pages/chat/chat-progress.ts
+++ b/ui/src/pages/chat/chat-progress.ts
@@ -1,7 +1,10 @@
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewaySessionRow } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
 import type { ChatGuardianNotice, ChatItem, ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { formatCompactTokenCount } from "../../lib/format.ts";
+import type { RunOutputUsage } from "./tool-stream.ts";
 
 type WorkingProgress = {
   key: string;
@@ -248,159 +251,69 @@ export function clearWorkingProgress(sessionKey: string): void {
 
 export function resetWorkingProgress(): void {
   workingProgressBySession.clear();
-  turnRecapWatchBySession.clear();
   anonymousWorkingProgressId = 0;
 }
 
 export type TurnRecap = { runtimeMs: number; outputTokens: number | null };
 
-/** `baselineEndedAt` is the session row's endedAt when the working indicator
- * appeared — i.e. the PREVIOUS run's terminal stamp (or null once the run
- * start patch cleared it). Only a row whose endedAt moved past the baseline
- * belongs to the run this pane just watched; timestamps never correlate
- * reliably because consecutive turns can be seconds apart. `settled` freezes
- * the first resolved recap so later terminal rows from runs this pane never
- * watched (background/cron/other devices) cannot rewrite the displayed row. */
-type TurnRecapWatch = {
-  watching: boolean;
-  /** False while no session row was observed during the watch: with no
-   * baseline, a later row's stamp cannot be told apart from the previous
-   * run's, so such a watch is consumed unresolved at settle. */
-  baselineKnown: boolean;
-  baselineEndedAt: number | null;
-  /** The previous run's persisted token count. The terminal stamp and the
-   * usage persist are separate gateway writes, so a fresh-endedAt row can
-   * still carry the PREVIOUS turn's outputTokens; an unchanged value at
-   * resolve is treated as that lag, not this turn's count. */
-  baselineOutputTokens: number | null;
-  /** Highest live usage-stream counter observed for the watched run. Fills
-   * in when the row's outputTokens hasn't been rewritten yet (see above);
-   * attributed by chatRunId upstream, so it cannot be another run's. */
-  liveOutputTokens: number | null;
-  /** A terminal stamp changed while the claw was still up: some run's
-   * terminal (this one's early, or an interleaved older patch) already
-   * passed, so settle cannot attribute later stamps and must consume the
-   * watch. Without a run identity on session rows, every anomalous
-   * interleaving fails quiet instead of risking a wrong recap. */
-  absorbedTerminal: boolean;
-  /** First idle render after the indicator cleared; the watch expires a
-   * short window later so a canceled queued send (indicator shown, run
-   * never started) cannot hand its watch to a much-later background/cron
-   * completion. */
-  settleStartedAt: number | null;
-  settled: TurnRecap | null;
+// The pane owns one watched run. Session-wide usage is a different fact and
+// may still describe the previous response when the terminal row arrives.
+export type TurnRecapWatch = {
+  sessionKey: string;
+  agentId: string | null;
+  gatewayClient: GatewayBrowserClient | null;
+  runId: string;
+  recap: TurnRecap | null;
 };
 
-/** The watched run's terminal patch lands within moments of the indicator
- * clearing; anything arriving after this window is another run's. Accepted
- * residual: session rows carry no run identity, so an unrelated same-session
- * completion INSIDE this window (e.g. after a canceled queued send) can be
- * shown as the watched turn's recap. Closing that needs a terminal-row run
- * id from the gateway; until then the row is cosmetic and self-corrects on
- * the next turn. */
-const TURN_RECAP_SETTLE_WINDOW_MS = 30_000;
-
-const turnRecapWatchBySession = new Map<string, TurnRecapWatch>();
-
-type TurnRecapSessionRow = {
-  status?: string;
-  endedAt?: number;
-  runtimeMs?: number;
-  outputTokens?: number;
-};
-
-function rowOutputTokens(row: TurnRecapSessionRow | undefined): number | null {
-  return typeof row?.outputTokens === "number" ? row.outputTokens : null;
-}
-
-/** Post-turn recap for the bottom-of-thread status row. While the working
- * indicator is visible the session is "watched" (and any older recap hides);
- * once it settles, the first session row carrying a fresh terminal stamp
- * resolves the recap, which then sticks until the next run. Failed runs stay
- * quiet — the error surfaces own those. */
 export function resolveTurnRecap(
-  sessionKey: string,
-  indicatorVisible: boolean,
-  row: TurnRecapSessionRow | undefined,
-  liveOutputTokens: number | null = null,
-): TurnRecap | null {
-  const watch = turnRecapWatchBySession.get(sessionKey);
-  const rowEndedAt = typeof row?.endedAt === "number" ? row.endedAt : null;
-  if (watch && liveOutputTokens !== null && liveOutputTokens > (watch.liveOutputTokens ?? -1)) {
-    // Monotonic max: the usage map entry is dropped at lifecycle end, so the
-    // last counter seen while watching/settling is the run's final total.
-    watch.liveOutputTokens = liveOutputTokens;
+  host: { turnRecapWatch: TurnRecapWatch | null },
+  params: {
+    sessionKey: string;
+    agentId?: string | null;
+    gatewayClient?: GatewayBrowserClient | null;
+    indicator?: { runId?: string };
+    row?: Pick<GatewaySessionRow, "lastRunId" | "status" | "runtimeMs">;
+    usageByRun?: ReadonlyMap<string, RunOutputUsage>;
+  },
+): (TurnRecap & { runId: string }) | null {
+  const { sessionKey, agentId = null, gatewayClient = null, indicator, row, usageByRun } = params;
+  let watch = host.turnRecapWatch;
+  if (
+    watch?.sessionKey !== sessionKey ||
+    watch.agentId !== agentId ||
+    watch.gatewayClient !== gatewayClient
+  ) {
+    watch = null;
   }
-  if (indicatorVisible) {
-    if (!watch || !watch.watching) {
-      turnRecapWatchBySession.set(sessionKey, {
-        watching: true,
-        baselineKnown: row !== undefined,
-        baselineEndedAt: rowEndedAt,
-        baselineOutputTokens: rowOutputTokens(row),
-        liveOutputTokens,
-        absorbedTerminal: false,
-        settleStartedAt: null,
-        settled: null,
-      });
-    } else if (!watch.baselineKnown) {
-      if (row !== undefined) {
-        watch.baselineKnown = true;
-        watch.baselineEndedAt = rowEndedAt;
-        watch.baselineOutputTokens = rowOutputTokens(row);
-      }
-    } else if (rowEndedAt !== null && rowEndedAt !== watch.baselineEndedAt) {
-      watch.baselineEndedAt = rowEndedAt;
-      watch.absorbedTerminal = true;
+  if (indicator) {
+    const runId = indicator.runId;
+    if (!runId) {
+      host.turnRecapWatch = null;
+      return null;
     }
-    return null;
+    if (watch?.runId !== runId) {
+      watch = { sessionKey, agentId, gatewayClient, runId, recap: null };
+    }
   }
+  host.turnRecapWatch = watch;
   if (!watch) {
     return null;
   }
-  watch.watching = false;
-  if (watch.settled) {
-    return watch.settled;
+  const outputTokens =
+    usageByRun?.get(watch.runId)?.outputTokens ?? watch.recap?.outputTokens ?? null;
+  if (row?.lastRunId === watch.runId) {
+    const runtimeMs = row.runtimeMs;
+    if (row.status === "done" && typeof runtimeMs === "number" && Number.isFinite(runtimeMs)) {
+      watch.recap = { runtimeMs, outputTokens };
+    } else if (row.status && row.status !== "done") {
+      watch.recap = null;
+    }
   }
-  if (watch.absorbedTerminal || !watch.baselineKnown) {
-    // See TurnRecapWatch: attribution is ambiguous, so this turn quietly
-    // gets no recap rather than freezing another run's numbers.
-    turnRecapWatchBySession.delete(sessionKey);
-    return null;
+  // Usage can arrive after terminal presentation. Keep accepting facts for
+  // this exact run without borrowing another run's session-row counters.
+  if (watch.recap && watch.recap.outputTokens !== outputTokens) {
+    watch.recap = { ...watch.recap, outputTokens };
   }
-  if (watch.settleStartedAt === null) {
-    watch.settleStartedAt = Date.now();
-  } else if (Date.now() - watch.settleStartedAt > TURN_RECAP_SETTLE_WINDOW_MS) {
-    turnRecapWatchBySession.delete(sessionKey);
-    return null;
-  }
-  const isStale =
-    rowEndedAt === null || (watch.baselineEndedAt !== null && rowEndedAt <= watch.baselineEndedAt);
-  if (isStale) {
-    // No terminal patch for the watched run yet; keep waiting (bounded by
-    // the settle window above). Stamps never regress, so <= is stale.
-    return null;
-  }
-  // A fresh terminal always concludes the watch: recap on a clean "done",
-  // quiet consume otherwise — waiting past it would let unrelated later
-  // completions attach to this turn.
-  turnRecapWatchBySession.delete(sessionKey);
-  const runtimeMs = row?.runtimeMs;
-  if (row?.status !== "done" || typeof runtimeMs !== "number" || !Number.isFinite(runtimeMs)) {
-    return null;
-  }
-  // The terminal stamp and the usage persist are separate gateway writes, so
-  // this fresh-endedAt row can still carry the previous turn's outputTokens.
-  // An unchanged-from-baseline value is that lag: fall back to the watched
-  // run's live counter (or show none) rather than the stale number.
-  const rowTokens = rowOutputTokens(row);
-  const settled: TurnRecap = {
-    runtimeMs,
-    outputTokens:
-      rowTokens !== null && rowTokens !== watch.baselineOutputTokens
-        ? rowTokens
-        : watch.liveOutputTokens,
-  };
-  turnRecapWatchBySession.set(sessionKey, { ...watch, settled });
-  return settled;
+  return indicator || !watch.recap ? null : { ...watch.recap, runId: watch.runId };
 }

--- a/ui/src/pages/chat/chat-send-contract.ts
+++ b/ui/src/pages/chat/chat-send-contract.ts
@@ -51,7 +51,6 @@ export type ChatHost = ChatInputHistoryState &
     chatDisplayedLeafEntryId?: string | null;
     chatRunId: string | null;
     chatRunStartup?: ChatRunStartupState | null;
-    chatRunUsageById?: Map<string, number>;
     chatSending: boolean;
     chatSendingScopeKey?: string | null;
     chatRunError?: ChatRunError | null;

--- a/ui/src/pages/chat/chat-state-contract.ts
+++ b/ui/src/pages/chat/chat-state-contract.ts
@@ -10,6 +10,7 @@ import type { ChatRunStartupState } from "./chat-run-startup.ts";
 import type { ChatRunError, LocalTerminalReconcile } from "./run-lifecycle.ts";
 import type { ChatMessageCache } from "./session-message-cache.ts";
 import type { StreamCausalBoundaryState } from "./stream-causal-boundary.ts";
+import type { RunOutputUsage } from "./tool-stream.ts";
 
 type ChatAgentsListSnapshot = Partial<Omit<AgentsListResult, "agents">> & {
   agents?: AgentsListResult["agents"];
@@ -46,7 +47,7 @@ export type ChatState = StreamCausalBoundaryState & {
   /** True when the active run was recovered from the embedded-run registry and
    * Stop must use the session-owned abort path (sessions.abort), not chat.abort. */
   chatRunSessionAbortable?: boolean;
-  chatRunUsageById?: Map<string, number>;
+  chatRunUsageById?: Map<string, RunOutputUsage>;
   /** Producer-cumulative text; visible tails derive from the segment baseline. */
   chatStream: string | null;
   chatStreamStartedAt: number | null;

--- a/ui/src/pages/chat/chat-state-page.ts
+++ b/ui/src/pages/chat/chat-state-page.ts
@@ -61,7 +61,7 @@ import {
   normalizeSidebarLayout,
   openSlot,
 } from "./sidebar-layout.ts";
-import { resetToolStream } from "./tool-stream.ts";
+import { resetToolStream, type RunOutputUsage } from "./tool-stream.ts";
 
 type ChatPageElement = {
   getBoundingClientRect?: () => DOMRect;
@@ -190,7 +190,7 @@ export function createPageState(
     chatEffectiveQueueMode: undefined,
     chatAttachments: [],
     chatRunId: null,
-    chatRunUsageById: new Map<string, number>(),
+    chatRunUsageById: new Map<string, RunOutputUsage>(),
     chatStream: null,
     chatStreamStartedAt: null,
     chatRunStartup: null,

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -152,6 +152,7 @@ const buildChatItemsMock = vi.fn(
           kind: "group",
           key: "group:assistant:test",
           role: "assistant",
+          runId: (props.messages.at(-1) as { runId?: string } | undefined)?.runId,
           messages: props.messages.map((message, index) => ({
             key: `message:${index}`,
             message,
@@ -2955,7 +2956,9 @@ describe("chat loading skeleton", () => {
   it("routes live and completed status into the existing assistant turn", () => {
     renderChatView({
       canAbort: true,
-      messages: [{ role: "assistant", content: "Finished answer", timestamp: 1 }],
+      messages: [
+        { role: "assistant", content: "Finished answer", timestamp: 1, runId: "run-composed" },
+      ],
       stream: null,
     });
 
@@ -2968,11 +2971,14 @@ describe("chat loading skeleton", () => {
 
     renderMessageGroupMock.mockClear();
     vi.spyOn(chatProgress, "resolveTurnRecap").mockReturnValue({
+      runId: "run-composed",
       runtimeMs: 5_000,
       outputTokens: 42,
     });
     const container = renderChatView({
-      messages: [{ role: "assistant", content: "Finished answer", timestamp: 1 }],
+      messages: [
+        { role: "assistant", content: "Finished answer", timestamp: 1, runId: "run-composed" },
+      ],
     });
 
     expect(renderMessageGroupMock).toHaveBeenCalledTimes(1);
@@ -3012,6 +3018,7 @@ describe("chat loading skeleton", () => {
       },
     ]);
     vi.spyOn(chatProgress, "resolveTurnRecap").mockReturnValue({
+      runId: "run-composed",
       runtimeMs: 5_000,
       outputTokens: 42,
     });
@@ -3087,7 +3094,12 @@ describe("chat loading skeleton", () => {
     // Run usage arrives on its own patches, so the transcript items, the
     // shared render context, and this row's own identity all stay put while
     // the counter ticks.
-    const readingIndicator = { kind: "reading-indicator", key: "reading:test", startedAt: 1 };
+    const readingIndicator = {
+      kind: "reading-indicator",
+      key: "reading:test",
+      startedAt: 1,
+      runId: "usage-run",
+    };
     const reply = {
       kind: "group",
       key: "group:assistant:reply",
@@ -3102,7 +3114,11 @@ describe("chat loading skeleton", () => {
       isStreaming: false,
     };
     const renderWithUsage = (container: HTMLElement, runOutputTokens: number) => {
-      renderChatInto(container, { canAbort: true, runOutputTokens, stream: null });
+      renderChatInto(container, {
+        canAbort: true,
+        runUsageById: new Map([["usage-run", { outputTokens: runOutputTokens, seq: 1 }]]),
+        stream: null,
+      });
     };
 
     const streamGroupSpy = vi.fn(renderStreamGroupMock);
@@ -3191,9 +3207,19 @@ describe("chat loading skeleton", () => {
     const container = document.createElement("div");
     const streamPartsSpy = vi.spyOn(chatMessage, "renderStreamGroupParts");
 
-    renderChatInto(container, { canAbort: true, runId, runOutputTokens: 5_500, stream: null });
+    renderChatInto(container, {
+      canAbort: true,
+      runId,
+      runUsageById: new Map([[runId, { outputTokens: 5_500, seq: 1 }]]),
+      stream: null,
+    });
     streamPartsSpy.mockClear();
-    renderChatInto(container, { canAbort: true, runId, runOutputTokens: 7_200, stream: null });
+    renderChatInto(container, {
+      canAbort: true,
+      runId,
+      runUsageById: new Map([[runId, { outputTokens: 7_200, seq: 2 }]]),
+      stream: null,
+    });
 
     expect(streamPartsSpy.mock.calls.at(-1)?.[1].runOutputTokens).toBe(7_200);
   });
@@ -3263,6 +3289,7 @@ describe("chat loading skeleton", () => {
       },
     ] as ReturnType<typeof chatThread.buildCachedChatItems>);
     vi.spyOn(chatProgress, "resolveTurnRecap").mockReturnValue({
+      runId: "run-composed",
       runtimeMs: 5_000,
       outputTokens: 42,
     });
@@ -3276,16 +3303,18 @@ describe("chat loading skeleton", () => {
     expect(frameCall?.[0].messages).toHaveLength(1);
     expect(frameCall?.[1].frameContent).toBeDefined();
     expect(frameCall?.[1].turnRecap).toEqual({
+      runId,
       runtimeMs: 5_000,
       outputTokens: 42,
     });
     expect(container.querySelector(".chat-turn-recap")).toBeNull();
   });
 
-  it("releases the embedded recap when a later reply becomes the settled turn", () => {
+  it("does not move a watched recap onto a later unrelated run", () => {
     const firstReply = {
       kind: "group",
       key: "group:assistant:first",
+      runId: "run-composed",
       role: "assistant",
       messages: [
         {
@@ -3299,6 +3328,7 @@ describe("chat loading skeleton", () => {
     const secondReply = {
       ...firstReply,
       key: "group:assistant:second",
+      runId: "foreign-run",
       messages: [
         {
           key: "message:assistant:second",
@@ -3308,6 +3338,7 @@ describe("chat loading skeleton", () => {
       timestamp: 2,
     };
     vi.spyOn(chatProgress, "resolveTurnRecap").mockReturnValue({
+      runId: "run-composed",
       runtimeMs: 5_000,
       outputTokens: 42,
     });
@@ -3335,7 +3366,8 @@ describe("chat loading skeleton", () => {
     expect(
       renderMessageGroupMock.mock.calls.find(([group]) => group.key === secondReply.key)?.[1]
         .turnRecap,
-    ).toBeDefined();
+    ).toBeUndefined();
+    expect(container.querySelector(".chat-turn-recap")).toBeNull();
   });
 
   it("shows prompt-bar progress beside context usage while the current session send is awaiting acknowledgement", () => {

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1812,7 +1812,7 @@ describe("grouped chat rendering", () => {
     render(renderTurnRecapRow({ runtimeMs: 30_000, outputTokens: 2_400 }), withTokens);
     expect(
       withTokens.querySelector(".chat-turn-recap")?.textContent?.replace(/\s+/g, " ").trim(),
-    ).toBe("Done in 30 seconds · 2.4k tokens");
+    ).toBe("Done in 30 seconds · 2,400 output tokens");
   });
 
   it("shows live output usage beside elapsed time", () => {
@@ -1827,9 +1827,9 @@ describe("grouped chat rendering", () => {
 
     expect(container.querySelector(".chat-working-indicator__elapsed")).not.toBeNull();
     expect(container.querySelector(".chat-working-indicator__tokens")?.textContent?.trim()).toBe(
-      "5.5k tokens",
+      "5,500 output tokens",
     );
-    // Streaming tokens replace the whimsical phrase: one liveness signal at a time.
+    // Known usage replaces the pre-usage working phrase.
     expect(container.querySelector("openclaw-working-phrase")).toBeNull();
   });
 
@@ -1845,11 +1845,13 @@ describe("grouped chat rendering", () => {
       container,
     );
 
-    expect(container.querySelector(".chat-working-indicator__status")?.textContent?.trim()).toBe(
+    expect(container.querySelector(".chat-working-indicator__status")?.textContent).toContain(
       "Waiting for approval…",
     );
     expect(container.querySelector(".chat-working-indicator__elapsed")).toBeNull();
-    expect(container.querySelector(".chat-working-indicator__tokens")).toBeNull();
+    expect(container.querySelector(".chat-working-indicator__tokens")?.textContent).toBe(
+      "5,500 output tokens",
+    );
   });
 
   it("keeps streamed assistant content in the guttered group without an avatar", () => {

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -3,6 +3,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing, type TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
 import type { ChatPendingInputsPage } from "../../../../../packages/gateway-protocol/src/schema/logs-chat.js";
+import type { GatewayBrowserClient } from "../../../api/gateway.ts";
 import type {
   AgentsListResult,
   GatewaySessionRow,
@@ -29,10 +30,12 @@ import {
 import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
 import { fnv1aUtf16 } from "../../../lib/fnv1a.ts";
 import type { UiSessionDefaultsHost } from "../../../lib/sessions/session-key.ts";
+import type { TurnRecapWatch } from "../chat-progress.ts";
 import { resetChatThreadState } from "../chat-thread.ts";
 import type { LinkFaviconFetcher } from "../link-favicon-loader.ts";
 import type { RealtimeTalkConversationEntry } from "../realtime-talk-conversation.ts";
 import type { ChatRunUiStatus } from "../run-lifecycle.ts";
+import type { RunOutputUsage } from "../tool-stream.ts";
 import type { BackgroundTasksProps } from "./chat-background-tasks.types.ts";
 import type { ChatHistoryBoundaryProps } from "./chat-history-boundary.ts";
 import type { ArtifactDownloadResolver } from "./chat-message-media.ts";
@@ -46,6 +49,7 @@ import { handleChatSelectionPointerUp, removeChatSelectionPopup } from "./chat-s
 import type { SidebarContent, SidebarFullMessageLoader } from "./chat-sidebar.ts";
 
 export type ChatThreadState = {
+  turnRecapWatch: TurnRecapWatch | null;
   searchOpen: boolean;
   searchQuery: string;
   searchFocusPending: boolean;
@@ -71,6 +75,7 @@ export type ChatThreadProps = ChatSendStatusActions & {
   /** Routing for peer sender names in a shared session. */
   personActivity?: PersonActivityRouting;
   sessionKey: string;
+  gatewayClient?: GatewayBrowserClient | null;
   selectedSession: GatewaySessionRow | undefined;
   boardProvider?: BoardProvider;
   announceTranscript?: boolean;
@@ -86,7 +91,7 @@ export type ChatThreadProps = ChatSendStatusActions & {
   streamStartedAt: number | null;
   /** Browser-local active run identity, retained across transient disconnects. */
   runId?: string | null;
-  runOutputTokens?: number | null;
+  runUsageById?: ReadonlyMap<string, RunOutputUsage>;
   runStatus?: ChatRunUiStatus | null;
   queue: ChatQueueItem[];
   pendingInputs?: ChatPendingInputsPage["items"];
@@ -167,6 +172,7 @@ type TranscriptInteractionProps = Pick<
 
 function createTranscriptState(): ChatThreadState {
   return {
+    turnRecapWatch: null,
     searchOpen: false,
     searchQuery: "",
     searchFocusPending: false,

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -135,6 +135,10 @@ export function projectChatTranscript(
     searchOpen: state.searchOpen,
     searchQuery: state.searchQuery,
   });
+  const workingIndicator = chatItems.find((item) => item.kind === "reading-indicator");
+  const runOutputTokens = workingIndicator?.runId
+    ? (props.runUsageById?.get(workingIndicator.runId)?.outputTokens ?? null)
+    : null;
   if (props.showToolCalls && !searchFiltering) {
     scheduleToolTitlesForTranscript(collectToolTitleCandidates(chatItems));
   }
@@ -266,7 +270,7 @@ export function projectChatTranscript(
     assistant: assistantIdentity,
     startupLabel: props.startupLabel,
     waitingApproval: props.waitingApproval,
-    runOutputTokens: props.runOutputTokens,
+    runOutputTokens,
     questionPrompts,
   } satisfies StreamGroupOptions;
   // Latest ownership crosses rows: the former owner must rerender when a
@@ -339,7 +343,7 @@ export function projectChatTranscript(
   };
   // Only the working indicator shows live usage, so rows without one keep
   // memoizing across usage patches.
-  const workingUsageKey = `usage:${props.runOutputTokens ?? ""}`;
+  const workingUsageKey = `usage:${runOutputTokens ?? ""}`;
   const liveStatusSignature = (item: ChatRenderItem): string => {
     if (item.kind === "agent-run-frame") {
       const hasWorkingIndicator = item.parts.some(
@@ -430,18 +434,14 @@ export function projectChatTranscript(
     { searchActive: searchFiltering },
   );
   const collapsedItems = coalesceAgentRunFrames(semanticItems, { searchActive: searchFiltering });
-  // Watch/settle on actual indicator visibility (not runWorking): queued
-  // sends show the claw before the run starts, and the recap must never
-  // stack under a visible working row.
-  const workingIndicatorVisible = chatItems.some((item) => item.kind === "reading-indicator");
-  // runOutputTokens is the live usage-stream counter for the pane's own run;
-  // its map entry dies at lifecycle end, so the watch captures the max seen.
-  const turnRecap = resolveTurnRecap(
-    props.sessionKey,
-    workingIndicatorVisible,
-    activeSession,
-    props.runOutputTokens ?? null,
-  );
+  const resolvedRecap = resolveTurnRecap(state, {
+    sessionKey: props.sessionKey,
+    agentId: props.currentAgentId,
+    gatewayClient: props.gatewayClient,
+    indicator: workingIndicator,
+    row: activeSession,
+    usageByRun: props.runUsageById,
+  });
   const transcriptItems = collapsedItems.filter((item, index) => {
     const previous = collapsedItems[index - 1];
     const activeStatusParts =
@@ -482,6 +482,11 @@ export function projectChatTranscript(
           assistantGroupCanOwnActiveRunStatus(lastTranscriptItem)
         ? lastTranscriptItem
         : null;
+  // An unwatched background run must not inherit the visible turn's recap.
+  const turnRecap =
+    resolvedRecap && (!tailStatusOwner?.runId || tailStatusOwner.runId === resolvedRecap.runId)
+      ? resolvedRecap
+      : null;
   latestAssistantItemKey =
     !props.runActive &&
     !props.runWorking &&
@@ -523,7 +528,7 @@ export function projectChatTranscript(
   }
   transcript.syncMessageRows(messageRowKeysById);
   let turnRecapOwnerKey: string | null = null;
-  if (turnRecap !== null && tailStatusOwner) {
+  if (turnRecap !== null && tailStatusOwner?.runId === turnRecap.runId) {
     turnRecapByGroupKey.set(tailStatusOwner.key, turnRecap);
     turnRecapOwnerKey = tailStatusOwner.key;
   }

--- a/ui/src/pages/chat/components/chat-transcript-render.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-render.test.ts
@@ -3,7 +3,10 @@
 import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewaySessionRow, SessionsListResult } from "../../../api/types.ts";
+import { createTestGatewayClient } from "../../../test-helpers/gateway-client.ts";
 import { createTestTranscript } from "../chat-view.test-helpers.ts";
+import { agentEvent, createHost } from "../tool-stream.test-helpers.ts";
+import { handleAgentEvent } from "../tool-stream.ts";
 import { renderTranscriptSearch, toggleTranscriptSearch } from "./chat-thread-interactions.ts";
 import { renderChatThread } from "./chat-thread.ts";
 import {
@@ -38,6 +41,113 @@ function touchPointerUp(element: Element): void {
 describe("chat transcript rendering", () => {
   beforeEach(installTranscriptDomMocks);
   afterEach(resetTranscriptTestDom);
+
+  it("keeps exact-run usage visible through final event batching and later corrections", async () => {
+    const runId = "watched-run";
+    const sessionKey = "global";
+    const host = createHost({ sessionKey, chatRunId: runId });
+    const props = threadProps("pane-run-usage", sessionKey, [
+      {
+        role: "user",
+        content: "Check the workspace",
+        timestamp: 1_000,
+        __openclaw: { idempotencyKey: `${runId}:user` },
+      },
+      { role: "assistant", content: "Workspace checked", timestamp: 2_000, runId },
+    ]);
+    props.gatewayClient = createTestGatewayClient(() => null);
+    props.currentAgentId = "first";
+    props.runId = runId;
+    props.runWorking = true;
+    props.selectedSession = {
+      key: sessionKey,
+      kind: "direct",
+      updatedAt: 1,
+      status: "done",
+      lastRunId: "previous-run",
+      endedAt: 1,
+      runtimeMs: 1,
+      outputTokens: 10,
+    };
+    const transcript = createTestTranscript();
+    const container = document.body.appendChild(document.createElement("div"));
+    const rerender = () => {
+      props.runUsageById = host.chatRunUsageById;
+      render(renderChatThread(props, transcript), container);
+      transcript.hostUpdated();
+    };
+    handleAgentEvent(
+      host,
+      agentEvent("sibling-run", 1, "usage", { outputTokens: 900 }, sessionKey),
+    );
+    rerender();
+    transcript.hostConnected();
+    await flushDeferredRowPrune();
+    expect(container.querySelector(".chat-working-indicator__tokens")).toBeNull();
+
+    handleAgentEvent(host, agentEvent(runId, 1, "usage", { outputTokens: 6_900 }, sessionKey));
+    rerender();
+    expect(requireElement(container, ".chat-working-indicator__tokens").textContent).toBe(
+      "6,900 output tokens",
+    );
+    // Final usage and lifecycle can share one browser render; neither may discard the count.
+    handleAgentEvent(host, agentEvent(runId, 2, "usage", { outputTokens: 6_950 }, sessionKey));
+    handleAgentEvent(host, agentEvent(runId, 3, "lifecycle", { phase: "end" }, sessionKey));
+    props.runId = null;
+    props.runWorking = false;
+    props.selectedSession = {
+      ...props.selectedSession,
+      lastRunId: runId,
+      endedAt: 16_000,
+      runtimeMs: 14_000,
+    };
+    rerender();
+    expect(requireElement(container, ".chat-turn-recap").textContent).toContain(
+      "6,950 output tokens",
+    );
+    handleAgentEvent(host, agentEvent(runId, 4, "usage", { outputTokens: 6_951 }, sessionKey));
+    rerender();
+    expect(requireElement(container, ".chat-turn-recap").textContent).toContain(
+      "6,951 output tokens",
+    );
+    handleAgentEvent(
+      host,
+      agentEvent("sibling-run", 2, "usage", { outputTokens: 1_000 }, sessionKey),
+    );
+    rerender();
+    expect(requireElement(container, ".chat-turn-recap").textContent).toContain(
+      "6,951 output tokens",
+    );
+    for (const replaceOwner of [
+      () => {
+        props.currentAgentId = "second";
+      },
+      () => {
+        props.gatewayClient = createTestGatewayClient(() => null);
+      },
+    ]) {
+      replaceOwner();
+      rerender();
+      expect(container.querySelector(".chat-turn-recap")).toBeNull();
+      props.currentAgentId = "first";
+      props.runId = runId;
+      props.runWorking = true;
+      rerender();
+      props.runId = null;
+      props.runWorking = false;
+      rerender();
+      expect(requireElement(container, ".chat-turn-recap").textContent).toContain(
+        "6,951 output tokens",
+      );
+    }
+    props.messages = [
+      ...props.messages,
+      { role: "assistant", content: "Background reply", timestamp: 20_000, runId: "sibling-run" },
+    ];
+    rerender();
+    expect(container.querySelector(".chat-turn-recap")).toBeNull();
+    transcript.hostDisconnected();
+  });
 
   it.each([true, false])(
     "keeps browser cards visible with capture limited to the active pane (%s)",

--- a/ui/src/pages/chat/components/chat-working-indicator.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator.ts
@@ -4,7 +4,6 @@ import "../../../components/working-phrase.ts";
 import { icons } from "../../../components/icons.ts";
 import { i18n, t } from "../../../i18n/index.ts";
 import type { ChatItem } from "../../../lib/chat/chat-types.ts";
-import { formatCompactTokenCount } from "../../../lib/format.ts";
 import type { TurnRecap } from "../chat-progress.ts";
 import { selectWorkingClawSurprise } from "./chat-working-indicator-surprise.ts";
 
@@ -39,11 +38,12 @@ function formatTurnRecapDuration(ms: number): string {
   return new Intl.ListFormat(locale, { style: "long", type: "unit" }).format(parts);
 }
 
-// 0 is a valid count (command-only turns); only null/undefined means "unknown".
+// Keep counts exact so small response updates remain visible above 1,000 tokens.
+// 0 is valid; only null/undefined means "unknown".
 function outputTokensLabel(outputTokens: number): string {
   return outputTokens === 1
     ? t("chat.turnRecap.tokensOne")
-    : t("chat.turnRecap.tokens", { count: formatCompactTokenCount(outputTokens) });
+    : t("chat.turnRecap.tokens", { count: outputTokens.toLocaleString(i18n.getLocale()) });
 }
 
 function renderLiveOutputTokens(outputTokens: number | null | undefined) {
@@ -67,8 +67,8 @@ export function renderChatWorkingIndicator(
 ) {
   const waitingApproval = options.waitingApproval === true;
   const continuation = options.presentation === "continuation";
-  // Streaming tokens are the real liveness signal; the whimsical phrase only
-  // covers the stretch before any usage data exists.
+  // Providers report exact usage at response boundaries, not per text delta.
+  // Keep the latest count visible while the run continues through tools.
   const hasTokens = options.outputTokens !== null && options.outputTokens !== undefined;
   // The animated claw stays decorative; the text status exposes progress without
   // announcing every elapsed-time tick to screen readers.
@@ -92,7 +92,9 @@ export function renderChatWorkingIndicator(
           `}
       <span class="chat-working-indicator__status">
         ${waitingApproval
-          ? html`<span>${t("chat.waitingForApproval")}</span>`
+          ? html`<span>${t("chat.waitingForApproval")}</span>${renderLiveOutputTokens(
+                options.outputTokens,
+              )}`
           : options.startupLabel
             ? html`
                 <span>${options.startupLabel}</span>
@@ -124,8 +126,8 @@ export function renderChatWorkingIndicator(
 }
 
 /** Post-turn recap row: once the run settles, the parked claw reports how
- * long the turn took (and its output tokens when the terminal patch carried
- * them). Sticky until the next run replaces it. */
+ * long the turn took and its latest known output usage. Sticky until the
+ * next run replaces it. */
 export function renderTurnRecapRow(
   recap: TurnRecap,
   options: { presentation?: "standalone" | "continuation" } = {},

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -34,6 +34,7 @@ import { rolloverChatStream } from "./stream-causal-boundary.ts";
 import { buildToolStreamIdentity } from "./tool-stream-identity.ts";
 
 const TOOL_STREAM_LIMIT = 50;
+const RUN_USAGE_LIMIT = 50;
 const TOOL_STREAM_THROTTLE_MS = 80;
 const TOOL_OUTPUT_CHAR_LIMIT = 120_000;
 
@@ -78,6 +79,8 @@ export type ToolStreamEntry = {
   message: Record<string, unknown>;
 };
 
+export type RunOutputUsage = { outputTokens: number; seq: number };
+
 export type ToolStreamHost = {
   sessionKey: string;
   assistantAgentId?: string | null;
@@ -85,7 +88,7 @@ export type ToolStreamHost = {
   hello?: { snapshot?: unknown } | null;
   chatRunId: string | null;
   chatMessages?: unknown[];
-  chatRunUsageById?: Map<string, number>;
+  chatRunUsageById?: Map<string, RunOutputUsage>;
   chatStream: string | null;
   chatStreamStartedAt: number | null;
   chatRunStartup?: ChatRunStartupState | null;
@@ -450,24 +453,6 @@ export type WaitingApprovalStatus = {
   runId: string;
 };
 
-export function resolveActiveRunOutputTokens(params: {
-  localRunId?: string | null;
-  activeRunIds?: readonly string[];
-  usageByRun?: ReadonlyMap<string, number>;
-}): number | null {
-  const localUsage = params.localRunId ? params.usageByRun?.get(params.localRunId) : undefined;
-  if (localUsage !== undefined) {
-    return localUsage;
-  }
-  for (const runId of params.activeRunIds ?? []) {
-    const usage = params.usageByRun?.get(runId);
-    if (usage !== undefined) {
-      return usage;
-    }
-  }
-  return null;
-}
-
 export function resolveChatProjectionRunId(params: {
   localRunId?: string | null;
   activeRunIds?: readonly string[];
@@ -738,10 +723,18 @@ function handleUsageEvent(host: ToolStreamHost, payload: AgentEventPayload): boo
     return true;
   }
   const current = host.chatRunUsageById?.get(payload.runId);
-  if (current !== undefined && outputTokens <= current) {
+  if (current && payload.seq <= current.seq) {
     return true;
   }
-  host.chatRunUsageById = new Map(host.chatRunUsageById).set(payload.runId, outputTokens);
+  // Keep the sequence with its count across stream resets and terminal events:
+  // recovery snapshots must not overwrite newer live usage or erase the recap.
+  const usageByRun = new Map(host.chatRunUsageById);
+  usageByRun.delete(payload.runId);
+  usageByRun.set(payload.runId, { outputTokens, seq: payload.seq });
+  for (const staleRunId of [...usageByRun.keys()].slice(0, -RUN_USAGE_LIMIT)) {
+    usageByRun.delete(staleRunId);
+  }
+  host.chatRunUsageById = usageByRun;
   return true;
 }
 
@@ -1081,15 +1074,6 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   }
 
   if (payload.stream === "lifecycle") {
-    const phase = payload.data?.phase;
-    if (
-      (phase === "start" || phase === "end" || phase === "error") &&
-      host.chatRunUsageById?.has(payload.runId)
-    ) {
-      const usageByRun = new Map(host.chatRunUsageById);
-      usageByRun.delete(payload.runId);
-      host.chatRunUsageById = usageByRun;
-    }
     if (handleLifecycleApprovalEvent(host, payload)) {
       return true;
     }

--- a/ui/src/pages/chat/tool-stream.usage.node.test.ts
+++ b/ui/src/pages/chat/tool-stream.usage.node.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { createHost } from "./tool-stream.test-helpers.ts";
-import { handleAgentEvent, resolveActiveRunOutputTokens } from "./tool-stream.ts";
+import { handleAgentEvent, resetToolStream } from "./tool-stream.ts";
 
 type AgentEvent = NonNullable<Parameters<typeof handleAgentEvent>[1]>;
 
@@ -23,18 +23,52 @@ function agentEvent(
 }
 
 describe("app-tool-stream run usage", () => {
-  it("tracks monotonic output usage for a session-owned engine run", () => {
+  it("bounds retained usage while keeping the most recently updated run", () => {
+    const host = createHost();
+    for (let index = 0; index < 60; index++) {
+      handleAgentEvent(
+        host,
+        agentEvent(`run-${index}`, 1, "usage", { outputTokens: index }, "main"),
+      );
+      handleAgentEvent(
+        host,
+        agentEvent("still-active", index + 1, "usage", { outputTokens: index }, "main"),
+      );
+    }
+    expect(host.chatRunUsageById?.size).toBe(50);
+    expect(host.chatRunUsageById?.has("run-0")).toBe(false);
+    expect(host.chatRunUsageById?.get("still-active")?.outputTokens).toBe(59);
+  });
+
+  it("keeps the last usage through completion even without an intervening render", () => {
+    const host = createHost({ chatRunId: "client-run" });
+    handleAgentEvent(host, agentEvent("client-run", 1, "usage", { outputTokens: 695 }, "main"));
+    handleAgentEvent(host, agentEvent("client-run", 2, "lifecycle", { phase: "end" }, "main"));
+    expect(host.chatRunUsageById?.get("client-run")?.outputTokens).toBe(695);
+  });
+
+  it("accepts a newer corrected count but ignores older recovery usage", () => {
+    const host = createHost({ chatRunId: "client-run" });
+    handleAgentEvent(host, agentEvent("client-run", 8, "usage", { outputTokens: 120 }, "main"));
+    handleAgentEvent(host, agentEvent("client-run", 9, "usage", { outputTokens: 115 }, "main"));
+    resetToolStream(host);
+    handleAgentEvent(host, agentEvent("client-run", 7, "lifecycle", { phase: "start" }, "main"));
+    handleAgentEvent(host, agentEvent("client-run", 7, "usage", { outputTokens: 150 }, "main"));
+    expect(host.chatRunUsageById?.get("client-run")?.outputTokens).toBe(115);
+  });
+
+  it("tracks sequence-ordered output usage for a session-owned engine run", () => {
     const host = createHost({ chatRunId: "client-run" });
 
     handleAgentEvent(host, agentEvent("engine-run", 1, "usage", { outputTokens: 12 }, "main"));
     handleAgentEvent(host, agentEvent("engine-run", 2, "usage", { outputTokens: 8 }, "main"));
 
-    expect(host.chatRunUsageById?.get("engine-run")).toBe(12);
+    expect(host.chatRunUsageById?.get("engine-run")?.outputTokens).toBe(8);
 
     handleAgentEvent(host, agentEvent("engine-run", 3, "lifecycle", { phase: "start" }, "main"));
     handleAgentEvent(host, agentEvent("engine-run", 4, "usage", { outputTokens: 3 }, "main"));
 
-    expect(host.chatRunUsageById?.get("engine-run")).toBe(3);
+    expect(host.chatRunUsageById?.get("engine-run")?.outputTokens).toBe(3);
   });
 
   it("keeps session-scoped usage separate for concurrent active runs", () => {
@@ -44,8 +78,8 @@ describe("app-tool-stream run usage", () => {
     handleAgentEvent(host, agentEvent("run-b", 1, "usage", { outputTokens: 10 }, "main"));
 
     expect(Array.from(host.chatRunUsageById?.entries() ?? [])).toEqual([
-      ["run-a", 100],
-      ["run-b", 10],
+      ["run-a", { outputTokens: 100, seq: 1 }],
+      ["run-b", { outputTokens: 10, seq: 1 }],
     ]);
   });
 
@@ -190,30 +224,8 @@ describe("app-tool-stream run usage", () => {
     handleAgentEvent(host, agentEvent("engine-run", 1, "usage", { outputTokens: 20 }));
     handleAgentEvent(host, agentEvent("client-run", 2, "usage", { outputTokens: 7 }));
 
-    expect(Array.from(host.chatRunUsageById?.entries() ?? [])).toEqual([["client-run", 7]]);
-  });
-});
-
-describe("active run output usage selection", () => {
-  it("prefers local client-run usage and falls back to a server active run", () => {
-    const usageByRun = new Map([
-      ["client-run", 12],
-      ["engine-run", 30],
+    expect(Array.from(host.chatRunUsageById?.entries() ?? [])).toEqual([
+      ["client-run", { outputTokens: 7, seq: 2 }],
     ]);
-
-    expect(
-      resolveActiveRunOutputTokens({
-        localRunId: "client-run",
-        activeRunIds: ["engine-run"],
-        usageByRun,
-      }),
-    ).toBe(12);
-    expect(
-      resolveActiveRunOutputTokens({
-        localRunId: "missing-client-run",
-        activeRunIds: ["missing-engine-run", "engine-run"],
-        usageByRun,
-      }),
-    ).toBe(30);
   });
 });


### PR DESCRIPTION
Closes #133562

<details>
<summary>Additional instructions</summary>

This upstream repository branch is directly editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where users watching a multi-call run in the Control UI would see an output-token count stall at one call's maximum, disappear on reload, or freeze before the final usage arrived. Small increases above 1,000 tokens were also hidden by compact-number rounding.

## Why This Change Was Made

Completed responses now report output-token deltas through the admitted run's host capability into the existing lifecycle-owned cumulative counter, shared with Pi. Gateway recovery retains that same run fact, and the UI reconciles by run ID and event sequence instead of maxima, timestamps, or session-wide billing values.

The Codex plugin reports each unique raw response completion before pending tools drain; thread-context updates remain context facts and no longer overwrite the run tally. The pane owns one exact-run recap and accepts late usage for it. This removes the global recap map, 30-second settlement heuristic, sibling-count fallback, and terminal usage deletion. No config, schema, dependency, protocol-version, or persisted-billing change.

## User Impact

- Exact, localized **output tokens** accumulate across model calls and stay visible through tool execution and approval waits.
- Reloading an active conversation restores the latest tally; a stale replay cannot overwrite newer live data.
- The final recap accepts later authoritative counts without borrowing another run's usage.
- Usage remains response-boundary data, not a per-streamed-token estimate. The context meter and session billing semantics are unchanged.
- Harness plugins can optionally report completed-call output through a closure-bound host capability. Existing version-1 hosts and plugin source compatibility are preserved.

## Evidence

### Real provider + browser before/after

Used an isolated Gateway, the normal `/chat/main` route, real `openai/gpt-5.6-luna`, and three sequential native shell calls. The operator's Gateway/state was not modified. Both owned proof gateways were stopped afterward.

| Observation | Before | After |
| --- | --- | --- |
| Native response outputs | 136 + 85 + 82 + 8 = 311 | 114 + 83 + 81 + 8 = 286 |
| Emitted output counts | 136, 85, 82, 8 | 114, 197, 278, 286 |
| Reload with no new usage event | 136 vanished | 114 retained |
| Final visible recap | absent on this flow | 286 output tokens |
| First count versus pending tool | delayed until completion | about 14 seconds before tool result |

Recorded and visually inspected before/after screenshots and videos (143.72s and 69.56s); checked native usage and Gateway events independently. Hash guards confirmed the running artifacts did not change during either proof (5,945 before files; 6,214 after files). **Publication limitation:** the host's content-protection wrapper rejected both the binary attachment endpoint and its supported `gh --attach` route. No protection was bypassed; recordings remain local and are not linked as publicly accessible evidence.

### Regression and build proof

Observed pre-fix failures for cumulative usage, late recap correction, lifecycle batching, stale replay, sibling isolation, and history recovery. Added/extended existing suites; no test-only production seam. The exact-number DOM regression failed at `6.9k` before the formatter change and now sees 6,900 → 6,950 → 6,951.

1,051 focused tests passed across the affected scopes: UI 632, Gateway 182, infra 48, Pi 109, harness host 42, Codex usage 16, Codex assistant 22. Covered host closure/release/restart, sparse attempts, same-admission handoff, duplicate response IDs, projector transitions, full/summary replay, bounded snapshot eviction, and actual transcript rendering. Commands used the repository `node scripts/run-vitest.mjs` runner with the affected test files; cache-off was used for the final host/Codex runs after the local filesystem module cache stalled before assertions.

```sh
OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs src/agents/harness/host-capability.test.ts extensions/codex/src/app-server/event-projector.usage.test.ts
OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs ui/src/pages/chat/chat-progress.test.ts ui/src/pages/chat/chat-view.test.ts ui/src/pages/chat/chat-history.inflight.test.ts ui/src/pages/chat/components/chat-message.test.ts ui/src/pages/chat/components/chat-transcript-render.test.ts ui/src/pages/chat/tool-stream.usage.node.test.ts
OPENCLAW_BUILD_ALL_NO_PNPM=1 node --import ./scripts/tsx.mjs scripts/build-all.mts ciArtifacts
OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.streaming.e2e.test.ts ui/src/e2e/chat-flow.stream-reconciliation.e2e.test.ts
node scripts/check-changed.mjs
pnpm plugin-sdk:surface:check
git diff --check
```

Candidate runtime/plugins/SDK declarations/export gate/UI build passed. Fresh uncommitted autoreview returned no findings. The full changed-file plan passed guards, formatting, core/UI/plugin/test typechecks, and core/UI lint; final plugin lint found two shadowed test names and the projector line limit. Those were corrected by renaming test locals and keeping response reporting inside its existing usage projection. Post-rebase UI 632 + Codex usage 16 tests and UI typecheck passed; fresh full-candidate autoreview was scoped-clean at the repository-required P0 threshold. Final plugin lint passed after the cleanup. The first CI run (https://github.com/openclaw/openclaw/actions/runs/33341038719) exposed three stale browser expectations across shards 7/14 and 11/14: expected `2.4k tokens`, observed the intended `2,400 output tokens`. Updated only those exact assertions, preserving their render-boundary and row-stability checks. Both complete browser files now pass locally (14 E2E tests). Production is unchanged by this follow-up; new head `1928c1f644f74c593e4df11544de052c7b699ab5` passed [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33341533043), including the required `openclaw/ci-gate` (native watcher exited 0; no pending checks).

### Contracts, scope, and review

Directly inspected the pinned Codex `rust-v0.151.0` implementation: [raw completion before usage recording](https://github.com/openai/codex/blob/rust-v0.151.0/codex-rs/core/src/session/turn.rs#L2567-L2602), [tool drain before TokenCount](https://github.com/openai/codex/blob/rust-v0.151.0/codex-rs/core/src/session/turn.rs#L2777-L2787), [app-server projection](https://github.com/openai/codex/blob/rust-v0.151.0/codex-rs/app-server/src/bespoke_event_handling.rs#L1115-L1126), and protocol thread/response usage types. No SDK export-budget growth.

Best-fix verdict: fixes the producer and owning lifecycle, not a UI polling workaround. A UI-only sum/max would mishandle replay and native turn transitions; thread totals would contaminate a run with previous turns. Pi, Codex, host lifecycle, Gateway fanout/recovery, and pane ownership were checked together.

Production **+184/-252 (net -68)**; tests/test support **+541/-232**; docs **+23/-0**. Added host responsibility is shared and closure-bound; larger UI heuristics and duplicate normalizers were removed.

Provenance: raw parent diffs verify the maximum/lifecycle-deletion behavior in `c670fb0e273` (PR #112333, July 22) and one-shot recap settlement in `cec17abe55a3` (PR #112060, July 21). Both introducing PRs were authored and merged by steipete; these roles are distinct from the current repair. The original snapshot-omission introduction remains unknown; current baseline reproduction is established.

Separate follow-up: #89474 tracks persisted Codex tool-loop billing undercount. This PR repairs the live run output counter, not that storage/accounting design, and does not close it.

