### PR TITLE
perf(test): prepare source Gateway runtimes before live shards

### DIFF
--- a/scripts/test-live-shard.mts
+++ b/scripts/test-live-shard.mts
@@ -224,6 +224,10 @@ function isExtensionInRange(file: string, start: string, end: string) {
   return first !== undefined && first >= start && first <= end;
 }
 
+function isSourceGatewayLiveTest(file: string) {
+  return file.startsWith("src/gateway/") || file.startsWith("src/system-agent/");
+}
+
 function isGatewayBackendLiveTest(file: string) {
   return (
     file === "src/gateway/gateway-acp-bind.live.test.ts" ||
@@ -291,13 +295,11 @@ export function selectLiveShardFiles(shard: string, files = collectAllLiveTestFi
     case "native-live-src-agents-zai-coding":
       return files.filter((file) => file === "src/agents/zai.live.test.ts");
     case "native-live-src-gateway":
-      return files.filter(
-        (file) => file.startsWith("src/gateway/") || file.startsWith("src/system-agent/"),
-      );
+      return files.filter(isSourceGatewayLiveTest);
     case "native-live-src-gateway-core":
       return files.filter(
         (file) =>
-          (file.startsWith("src/gateway/") || file.startsWith("src/system-agent/")) &&
+          isSourceGatewayLiveTest(file) &&
           !isGatewayBackendLiveTest(file) &&
           !isGatewayProfilesLiveTest(file),
       );
@@ -402,10 +404,10 @@ export function buildLiveShardPnpmArgs(files: string[], passthroughArgs: string[
  */
 export function resolveLiveShardPreparation(files: string[]): LiveShardPreparation | null {
   const gatewayProfiles = files.some(isGatewayProfilesLiveTest);
-  // Vision requests load provider and agent runtime plugins. Compile them before
-  // Vitest starts so cold source transforms do not consume the request deadline.
+  // Source gateways and vision requests load provider and agent runtime plugins.
+  // Compile them before Vitest so cold transforms do not consume live deadlines.
   if (
-    gatewayProfiles ||
+    files.some(isSourceGatewayLiveTest) ||
     files.includes("src/agents/tools/image-tool.providers.live.test.ts") ||
     files.includes("extensions/openai/openai.live.test.ts")
   ) {

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -249,8 +249,27 @@ describe("scripts/test-live-shard", () => {
         OPENCLAW_PLUGIN_LIFECYCLE_TRACE: "1",
       },
     });
+  });
+
+  it.each(["native-live-src-gateway-core", "native-live-src-gateway-backends"])(
+    "prepares the source gateway runtime before %s starts Vitest",
+    (shard) => {
+      expect(resolveLiveShardPreparation(selectLiveShardFiles(shard, allFiles))).toEqual({
+        env: {},
+        profile: "sourcePerformance",
+        requiredArtifact: "dist/.runtime-postbuildstamp",
+      });
+    },
+  );
+
+  it("prepares system-agent gateway tests without building unrelated source shards", () => {
+    expect(resolveLiveShardPreparation(["src/system-agent/rescue-channel.live.test.ts"])).toEqual({
+      env: {},
+      profile: "sourcePerformance",
+      requiredArtifact: "dist/.runtime-postbuildstamp",
+    });
     expect(
-      resolveLiveShardPreparation(selectLiveShardFiles("native-live-src-gateway-core", allFiles)),
+      resolveLiveShardPreparation(selectLiveShardFiles("native-live-src-infra", allFiles)),
     ).toBeNull();
   });
 
@@ -650,8 +669,11 @@ describe("scripts/test-live-shard", () => {
         runner.kill("SIGTERM");
 
         await expect(waitForClose(runner)).resolves.toEqual({ code: null, signal: "SIGTERM" });
-        await waitFor(() => existsSync(signaledPath), 5_000);
-        expect(readFileSync(signaledPath, "utf8")).toBe("SIGTERM");
+        // Creation precedes the synchronous write; wait for the signal receipt itself.
+        await waitFor(
+          () => existsSync(signaledPath) && readFileSync(signaledPath, "utf8") === "SIGTERM",
+          5_000,
+        );
         await waitFor(() => !isProcessAlive(childPid), 5_000);
         await waitFor(() => !isProcessAlive(descendantPid), 5_000);
       } finally {


### PR DESCRIPTION
Source Gateway core and backend live shards started Vitest without the runtime preparation already used by Gateway profile tests. Cold plugin transforms consumed most of the live test time: a controlled Linux run spent 183 seconds starting the Gateway and about 5 seconds on the model turn.

Reuse the canonical source-Gateway classification for both shard selection and `sourcePerformance` preparation. This keeps core, backend, aggregate and system-agent Gateway tests on the existing build owner, while preserving selected files, profile diagnostics, provider settings, retries, deadlines, and strict result validation. No new configuration, runner jobs, or runtime fallback. Internal test-runner delta is +2 lines; product runtime code is unchanged.

Also fix a nearby observed test race: the SIGTERM receipt file could exist before its contents were written. The cleanup test now waits for the exact receipt with the same deadline and still checks both child processes exit.

Validation:
- New preparation regression checks failed on the old owner (3 failures); all 29 focused tests now pass. Canonical scripts lint and formatting pass.
- [Controlled Linux pair](https://github.com/openclaw/openclaw/actions/runs/33340142927): cold 229.126s versus 28.935s preparation + 55.425s tests = 84.361s, 63.18% lower total time. Both arms passed the same 8 tests with the same 21 opt-in skips, using separate empty transform caches on the same observed 4-CPU host. One pair does not remove OS-cache or provider variability.
- [Automatic preparation proof](https://github.com/openclaw/openclaw/actions/runs/33340802594): the changed owner itself prepares the runtime and runs the unchanged five-file core command; 8 passed, 21 original gated skips, no retry, 89.013s total. The tested owner bytes match this PR; candidate product source was pinned and unchanged.
- Independent Codex review through P2: no actionable findings.

This addresses measured startup cost; the earlier uninstrumented CI timeouts do not establish which phase stalled. The full release run remains separately blocked by a Moonshot Docker image probe under investigation; no release gate is weakened here. A mistakenly broad local lint invocation also exposed missing declarations in the shared host tslog installation; the canonical scripts lint route passes, and that dependency repair is tracked separately.
