### PR TITLE
fix(media): quoted file charsets corrupt extracted text

### DIFF
--- a/src/media/input-files.extract.test.ts
+++ b/src/media/input-files.extract.test.ts
@@ -55,6 +55,86 @@ describe("extractFileContentFromSource", () => {
     ).rejects.toThrow(/Unsupported image MIME type: video\//);
   });
 
+  it.each([
+    'text/plain; charset="windows-1252"',
+    'Text/Plain; Charset="WINDOWS-1252"',
+    'text/plain; charset="windows\\-1252"',
+    'text/plain; note="a;charset=utf-8;b"; charset=windows-1252',
+    "text/plain; charset=windows-1252; charset=utf-8",
+    'text/plain; charset="windows-1252"; charset=utf-8',
+    "text/plain; charset=; charset=windows-1252",
+    "text/plain; charset= windows-1252",
+  ])("decodes declared text bytes using %s", async (mediaType) => {
+    const result = await extractFileContentFromSource({
+      source: {
+        type: "base64",
+        data: Buffer.from([0x63, 0x61, 0x66, 0xe9, 0x20, 0x80]).toString("base64"),
+        mediaType,
+      },
+      limits: resolveInputFileLimits(),
+    });
+
+    expect(result.text).toBe("café €");
+  });
+
+  it.each([
+    "text/plain",
+    'text/plain; charset="utf-8"',
+    "text/plain; charset=not-an-encoding; charset=windows-1252",
+    'text/plain; charset=""; charset=windows-1252',
+    "text/plain; charset =windows-1252",
+  ])("keeps UTF-8 decoding for %s", async (mediaType) => {
+    const result = await extractFileContentFromSource({
+      source: { type: "base64", data: Buffer.from("café €").toString("base64"), mediaType },
+      limits: resolveInputFileLimits(),
+    });
+
+    expect(result.text).toBe("café €");
+  });
+
+  it("keeps byte-detected UTF-16 ahead of a declared charset", async () => {
+    const result = await extractFileContentFromSource({
+      source: {
+        type: "base64",
+        data: Buffer.from("\ufeffcafé €", "utf16le").toString("base64"),
+        mediaType: 'text/plain; charset="windows-1252"',
+      },
+      limits: resolveInputFileLimits(),
+    });
+
+    expect(result.text).toBe("café €");
+  });
+
+  it("keeps configured MIME synonyms while parsing charset parameters", async () => {
+    const result = await extractFileContentFromSource({
+      source: {
+        type: "base64",
+        data: Buffer.from("name: café").toString("base64"),
+        mediaType: 'text/yaml; charset="utf-8"',
+      },
+      limits: resolveInputFileLimits({ allowedMimes: ["application/yaml"] }),
+    });
+
+    expect(result.text).toBe("name: café");
+  });
+
+  it.each([
+    ['text/plain; charset="windows-1252', "café €"],
+    ['text/plain; note="a; charset=windows-1252', "caf\uFFFD \uFFFD"],
+    ["plain; charset=windows-1252", "caf\uFFFD \uFFFD"],
+  ])("uses MIME parser recovery without changing admission for %s", async (mediaType, text) => {
+    const result = await extractFileContentFromSource({
+      source: {
+        type: "base64",
+        data: Buffer.from([0x63, 0x61, 0x66, 0xe9, 0x20, 0x80]).toString("base64"),
+        mediaType,
+      },
+      limits: resolveInputFileLimits(),
+    });
+
+    expect(result.text).toBe(text);
+  });
+
   it("keeps the declared MIME when the filename suggests plain text", async () => {
     const payload = JSON.stringify({ report: "q3", revenue: 12345 });
     const limits = resolveInputFileLimits({ allowedMimes: ["application/json"] });

--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -368,6 +368,30 @@ describe("HEIC input image normalization", () => {
 });
 
 describe("guarded input file URL fetches", () => {
+  it.each([
+    'text/plain; charset="windows-1252"',
+    'text/plain; note="a;charset=utf-8;b"; charset=windows-1252',
+  ])("decodes fetched bytes using response metadata %s", async (fetchedContentType) => {
+    const source = {
+      type: "url" as const,
+      url: "https://example.com/notes.txt",
+      mediaType: "text/plain; charset=utf-8",
+    };
+    const release = mockUrlFetchResponse({
+      source,
+      fetchedContentType,
+      fetchedBody: Buffer.from([0x63, 0x61, 0x66, 0xe9, 0x20, 0x80]),
+    });
+
+    await expect(
+      extractFileContentFromSource({
+        source,
+        limits: createFileSourceLimits(["text/plain"], true),
+      }),
+    ).resolves.toEqual({ filename: "file", text: "café €" });
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
   it("cancels ignored HTTP error bodies", async () => {
     let canceled = false;
     const stream = new ReadableStream<Uint8Array>({
@@ -518,6 +542,23 @@ describe("guarded input file URL fetches", () => {
 });
 
 describe("input file MIME sniffing", () => {
+  it.each(['image/apng; charset="utf-8"', "not-a-mime; charset=windows-1252"])(
+    "keeps sniffed URL image admission with %s metadata",
+    async (fetchedContentType) => {
+      const source = { type: "url" as const, url: "https://example.com/image" };
+      const bytes = Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO2N4j8AAAAASUVORK5CYII=",
+        "base64",
+      );
+      const release = mockUrlFetchResponse({ source, fetchedContentType, fetchedBody: bytes });
+
+      await expect(
+        extractImageContentFromSource(source, createImageSourceLimits(["image/png"], true)),
+      ).resolves.toEqual({ type: "image", data: bytes.toString("base64"), mimeType: "image/png" });
+      expect(release).toHaveBeenCalledTimes(1);
+    },
+  );
+
   it("infers printable URL file bytes as text when Content-Type is absent", async () => {
     const body = "headerless printable text";
     mockUrlFetchResponse({
@@ -537,7 +578,7 @@ describe("input file MIME sniffing", () => {
     const body = Buffer.from("headerless printable text");
     mockUrlFetchResponse({
       source: { type: "url", url: "https://example.com/notes" },
-      fetchedContentType: "application/octet-stream",
+      fetchedContentType: 'application/octet-stream; charset="windows-1252"',
       fetchedBody: body,
     });
 

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -1,4 +1,5 @@
 // Input file helpers normalize inline, fetched, and local media inputs.
+import { MIMEType } from "node:util";
 import {
   classifyAttachmentBytes,
   type AttachmentClassification,
@@ -7,10 +8,7 @@ import { canonicalizeBase64, estimateBase64DecodedBytes } from "@openclaw/media-
 import { parseMediaContentLength } from "@openclaw/media-core/content-length";
 import { detectMime, normalizeMimeType } from "@openclaw/media-core/mime";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
-import {
-  normalizeOptionalLowercaseString,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readResponseWithLimit } from "../infra/http-body.js";
@@ -166,12 +164,13 @@ function parseContentType(value: string | undefined): {
   if (!value) {
     return {};
   }
-  const parts = value.split(";").map((part) => part.trim());
-  const mimeType = normalizeMimeType(parts[0]);
-  const charset = parts
-    .map((part) => normalizeOptionalString(part.match(/^charset=(.+)$/i)?.[1]))
-    .find((part) => part && part.length > 0);
-  return { mimeType, charset };
+  const mimeType = normalizeMimeType(value);
+  try {
+    return { mimeType, charset: new MIMEType(value).params.get("charset") ?? undefined };
+  } catch {
+    // Invalid metadata still goes through byte classification and MIME allowlists.
+    return { mimeType };
+  }
 }
 
 /** Converts configured MIME lists into a normalized allowlist, using fallback defaults when empty. */


### PR DESCRIPTION
Closes #133608

## What Problem This Solves

Fixes an issue where users attaching Windows-1252 text would get replacement characters when the charset parameter was quoted. The same bytes decoded correctly with an unquoted charset. A semicolon inside another quoted parameter could also select the wrong encoding.

## Why This Change Was Made

The shared input-file owner now uses the runtime’s built-in `MIMEType` parameter parser instead of its custom semicolon/regex scanner. Existing MIME normalization, byte classification, allowlists, BOM precedence, and unknown-encoding UTF-8 fallback retain their current owners. No dependency, option, or persistence change.

Malformed metadata follows the builtin parser’s parameter recovery; an invalid MIME essence no longer salvages a charset through the old regex. This does not change MIME admission or byte classification.

## User Impact

Quoted and escaped charset labels decode correctly for inline and fetched files. Duplicate parameters and quoted semicolons follow the same parser contract. Production LOC: +9/−10 (net−1); tests: +122/−1.

## Evidence

- The same two full maintained suites went from 10 new failures with 12 new and 34 existing controls passing to 56/56 passing on Node 24.20.0, with independent source/dependency checks before and after. Coverage includes response-header precedence, aliases, BOMs, malformed headers, binary rejection, image sniffing, and existing fetch cleanup/size limits. Fetched-path tests use mocked transport and execute the real extractor; they are not live HTTP end-to-end proof.
- The original real extractor matrix went from 2 failures/6 controls to 8/8 expected results. Its final full audit timed out at the unchanged 30-second limit; a later unchanged audit and collector verified the recorded identities. The original timeout remains recorded, and that later rehash is not claimed as contemporaneous proof.
- Installed Bun 1.4.0 builtin API coverage produced all 16 expected decoded outputs. One raw-label probe expectation incorrectly trimmed leading whitespace; both pinned Node and Bun sources preserve it. The original probe failure is retained with that source-backed interpretation. This is not a full Bun OpenClaw run.
- Independent P0–P2 source/proof review, fresh managed Codex P0 review, and a separate exact-head Codex CLI P0–P2 review found no actionable findings.
- Canonical three-path `check:changed` passed all 29 phases on Node 24.20.0, with no skipped checks. Complete source/install preflight and postflight matched, and all owned processes and task state were cleaned up.

Reviewed commit: `f2ba50a966d130b329cf4b1f9562fe44e9daacde`.
