### PR TITLE
improve: reduce legacy transcript scanning overhead

### DIFF
--- a/src/commands/doctor-session-sqlite-readers.test.ts
+++ b/src/commands/doctor-session-sqlite-readers.test.ts
@@ -2,7 +2,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createTranscriptEventReader } from "./doctor-session-sqlite-readers.js";
+import {
+  countTranscriptEventsForPath,
+  createTranscriptEventReader,
+} from "./doctor-session-sqlite-readers.js";
 
 describe("legacy transcript row classification", () => {
   let directory: string;
@@ -12,6 +15,36 @@ describe("legacy transcript row classification", () => {
     transcriptPath = path.join(directory, "session.jsonl");
   });
   afterEach(() => fs.rmSync(directory, { recursive: true, force: true }));
+
+  it.each([1, 2, 3])("preserves records when UTF-8 splits after byte %s", (splitAfter) => {
+    const header = '\uFEFF{"type":"session","version":3}\r\n \t\r\n';
+    const prefix = '{"type":"plugin_state","payload":"';
+    const padding = "x".repeat(65_536 - Buffer.byteLength(header + prefix) - splitAfter);
+    const firstLine = `${prefix}${padding}🦞"}`;
+    const giant = { type: "plugin_state", payload: "λ".repeat(100_000) };
+    const tail = { type: "plugin_state", payload: "final unterminated row" };
+    fs.writeFileSync(
+      transcriptPath,
+      `${header}${firstLine}\r\n\n${JSON.stringify(giant)}\r\n${JSON.stringify(tail)}`,
+    );
+
+    const events: unknown[] = [];
+    const validate = createTranscriptEventReader(
+      transcriptPath,
+      "target",
+    )((event) => events.push(event));
+    validate();
+
+    expect(events[0]).toEqual({
+      type: "session",
+      version: 3,
+      id: "target",
+      timestamp: "",
+      cwd: "",
+    });
+    expect(events.slice(1)).toEqual([JSON.parse(firstLine), giant, tail]);
+    expect(countTranscriptEventsForPath(transcriptPath)).toEqual({ status: "ok", events: 4 });
+  });
 
   it.each([1, 2, 3, 4])("preserves recognized and opaque rows from version %s", (version) => {
     const unindexedHook = { type: "message", message: { role: "custom", content: "context" } };

--- a/src/commands/doctor-session-sqlite-readers.ts
+++ b/src/commands/doctor-session-sqlite-readers.ts
@@ -540,11 +540,16 @@ function* iterateJsonlLinesSync(filePath: string): Generator<{ lineNumber: numbe
         break;
       }
       const parts = decoder.decode(buffer.subarray(0, bytesRead), { stream: true }).split("\n");
-      for (let index = 0; index < parts.length - 1; index++) {
-        fragments.push(parts[index]!);
-        lineNumber += 1;
-        const text = fragments.join("").trim();
+      // Only the first complete line can span chunks. Keep unterminated giant
+      // records fragmented until a newline arrives instead of repeatedly joining them.
+      if (parts.length > 1 && fragments.length > 0) {
+        fragments.push(parts[0]!);
+        parts[0] = fragments.join("");
         fragments = [];
+      }
+      for (let index = 0; index < parts.length - 1; index++) {
+        lineNumber += 1;
+        const text = parts[index]!.trim();
         if (text) {
           yield { lineNumber, text };
         }


### PR DESCRIPTION
Related: #133546

## What Problem This Solves

Legacy transcript import and Doctor's read-only scans allocate and join a fragment array for every JSONL line, including lines that already fit completely within the decoded read chunk. This adds avoidable work across large histories.

## Why This Change Was Made

Join pending fragments only for the first complete line in a chunk, then consume other complete lines directly. Records spanning several chunks remain fragmented until their newline arrives, avoiding repeated concatenation of giant records. The existing scanner continues to own fatal UTF-8 decoding, whitespace handling, line numbering, EOF flush, and descriptor cleanup.

## User Impact

Less per-line allocation during legacy import, dry-run, and validation. There are no SQL, schema, configuration, dependency, transaction, source-fingerprint, malformed-prefix, or archival changes. Linux Node 24 count-only scans were 10.9% faster for small records and 4.1% faster for large records. Legacy v1/v2 complete-import medians improved 2.8%/3.8%; deep imports were effectively unchanged over ten pairs. Small changes in other shapes are not claimed as meaningful gains.

## Evidence

- 116 focused tests passed, including the complete Doctor session-SQLite suite, reader classification/recovery, and importer rollback/deduplication/source-validation boundaries.
- New table-driven coverage splits a four-byte UTF-8 character at every byte boundary and combines BOM, CRLF, blank lines, a multi-chunk record, and unterminated EOF. Both the import reader and count-only API preserve the records.
- Independent Codex review found no actionable findings at P3; scoped lint and formatting passed. Structural changed-file checks passed through the core graph boundary. Local core types hit six pre-existing errors in unchanged `logger.ts` because the shared `tslog` install lacks `types/BaseLogger.d.ts`; shared dependencies were not modified. Clean exact-head CI is required before landing.
- Production +8/-3 (net +5); tests +34/-1 (net +33). The small chunk-boundary branch replaces per-line buffer assembly; no second reader or new abstraction was added.
- Linux Node 24 paired comparisons passed, including 40 full import pairs and 20 reader/count pairs. The packaged stable-upgrade proof passed. The first Testbox attempt refused an unexpected checkout SHA before measurements; no result from it is counted.

Focused command: `node scripts/run-vitest.mjs src/commands/doctor-session-sqlite-readers.test.ts src/commands/doctor-session-sqlite.test.ts src/config/sessions/session-accessor.sqlite-import.test.ts`.

A separate follow-up remains: removing Doctor's preliminary count scan requires preserving per-alias malformed diagnostics, source changes across batches, and the boundary between recoverable parse failures and blocking normalization failures. This PR leaves that policy unchanged.

### Linux measurements and parity

The [Testbox workflow](https://github.com/openclaw/openclaw/actions/runs/33341084772) hosts the dedicated worker; successful Crabbox command exit/timing records are the proof verdict. Node 24.19.0 / SQLite 3.53.3, candidate `40fe49b0bbbedd6d1d5c166c6f96bdf5bd410a53`. The baseline overrides only `doctor-session-sqlite-readers.ts` with its contents at `cd3543fe715dabbb86d6f090293ef350233d7e0b`; all other code and dependencies are identical. Checkout SHA and source hashes are verified before and after. Fresh processes alternate before/after order, with fixture construction and parity checks outside the timer. All samples remain in the evidence.

Complete file-to-SQLite import medians (five pairs per shape; ten for deep):

| Shape | Before | After | Wall change |
| --- | ---: | ---: | ---: |
| single | 9.0 ms | 9.1 ms | +1.2% |
| deep | 5484.7 ms | 5485.2 ms | +0.0% |
| wide | 643.7 ms | 639.9 ms | -0.6% |
| branch | 981.1 ms | 994.1 ms | +1.3% |
| replay | 156.8 ms | 157.8 ms | +0.6% |
| legacy-v1 | 631.7 ms | 614.3 ms | -2.8% |
| legacy-v2 | 574.8 ms | 552.9 ms | -3.8% |

The first five deep pairs had a 4.6% slower candidate median. A same-worker repeat with reversed starting order had a 1.3% faster median. Combining all ten pairs gives 5484.7 → 5485.2 ms and CPU 5714.2 → 5706.6 ms: no consistent deep-import gain or slowdown is established. Neither run is discarded.

Separate 100k-row scanner medians, five pairs each (`import` here means reader + normalization + digest, without SQLite writes):

| Shape / reader mode | Before | After | Wall change |
| --- | ---: | ---: | ---: |
| small-count | 45.1 ms | 40.1 ms | -10.9% |
| small-import | 878.0 ms | 874.5 ms | -0.4% |
| large-count | 153.2 ms | 146.9 ms | -4.1% |
| large-import | 493.6 ms | 483.7 ms | -2.0% |

Every full-import pair matches exact transcript JSON, identities, window metadata, active positions, watermarks, and FTS. Reader/count pairs match normalized-event digests or counts. The SQL trace is unchanged: 100,034 calls across 34 shapes. Four separate Node CPU profiles (full import and count-only reader, before/after) completed outside the unprofiled timing samples. Raw results and profiles were collected with SHA-256 verification.

### Packaged stable upgrade and landing checks

The existing `published-upgrade-survivor` Docker lane passed from stable `2026.7.1-2` to a candidate tarball whose `dist/build-info.json` identifies exact head `40fe49b0bbbedd6d1d5c166c6f96bdf5bd410a53`. It migrated 4,800 sessions, 1,227,946 transcript events, and 10,000 cron jobs. Full survival assertions passed immediately after the update, before a standalone Doctor could conceal missing automatic migration. Repeat Doctor completed in 40 seconds against a 60-second budget. Eight Gateway history samples across two agents (600 messages) were identical after restart, and the final full-state survival assertion passed.

This lane uses an explicit candidate tarball, manual Gateway restart, and expected consent recovery for synthetic plugin capabilities. It proves automatic migration during that upgrade, not unattended update-channel switching. Docker command exit 0; package build and lane together took 792.7 seconds. Collected proof archive SHA-256: `7fb017e81f1ab8ada701968a936331a5ca52a58908788160fe34615ab28094aa`.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33341121907) passed. The latest ClawSweeper review found no actionable correctness or security findings; its only rank-up move was to wait for exact-head CI, now satisfied.
