### PR TITLE
fix(talk): honor advertised transcription model selections

### DIFF
--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -53,6 +53,8 @@ Voice-originated consult runs require a new, exact spoken confirmation before hi
 
 Transcription-only Talk emits the same Talk event envelope as realtime and STT/TTS sessions, but uses `mode: "transcription"` and `brain: "none"`. All Talk sessions broadcast events on the `talk.event` channel; clients subscribe to it for partial/final transcript updates (`transcript.delta`/`transcript.done`) and other session telemetry.
 
+Transcription providers can advertise their model choices in `talk.catalog.transcription.providers[].models`. Pass `model` to `talk.session.create` to override the configured transcription model for that session. Omitting it keeps the provider configuration, then the matching `agents.defaults.voiceModel`, then the provider's own default.
+
 Browser Video Talk is available for OpenAI Realtime WebRTC and Google Live
 provider-WebSocket sessions. OpenAI gets a single bounded JPEG when
 `describe_view` asks for visual context; it does not receive a continuous

--- a/src/gateway/server-methods/talk-client-create.ts
+++ b/src/gateway/server-methods/talk-client-create.ts
@@ -80,7 +80,7 @@ export const createTalkClient: GatewayRequestHandler = async ({
   }
   try {
     const runtimeConfig = context.getRuntimeConfig();
-    const realtimeConfig = buildTalkRealtimeConfig(runtimeConfig, params.provider);
+    const realtimeConfig = buildTalkRealtimeConfig(runtimeConfig, params.provider, params.model);
     const mode = normalizeOptionalLowercaseString(params.mode) ?? realtimeConfig.mode ?? "realtime";
     if (mode !== "realtime") {
       rejectTalkClientRequest(

--- a/src/gateway/server-methods/talk-session.ts
+++ b/src/gateway/server-methods/talk-session.ts
@@ -244,7 +244,11 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
           );
         }
         const runtimeConfig = context.getRuntimeConfig();
-        const realtimeConfig = buildTalkRealtimeConfig(runtimeConfig, params.provider);
+        const realtimeConfig = buildTalkRealtimeConfig(
+          runtimeConfig,
+          params.provider,
+          params.model,
+        );
         const launchOptions = buildRealtimeVoiceLaunchOptions({
           requested: params,
           defaults: realtimeConfig,
@@ -348,11 +352,16 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
           return;
         }
         const runtimeConfig = context.getRuntimeConfig();
-        const transcriptionConfig = buildTalkTranscriptionConfig(runtimeConfig, params.provider);
+        const transcriptionConfig = buildTalkTranscriptionConfig(
+          runtimeConfig,
+          params.provider,
+          params.model,
+        );
         const resolution = resolveConfiguredRealtimeTranscriptionProvider({
           config: runtimeConfig,
           configuredProviderId: transcriptionConfig.provider,
           providerConfigs: transcriptionConfig.providers,
+          requestedModel: normalizeOptionalString(params.model),
           defaultModel: transcriptionConfig.model,
         });
         const session = createTalkTranscriptionRelaySession({

--- a/src/gateway/server-methods/talk-shared.ts
+++ b/src/gateway/server-methods/talk-shared.ts
@@ -220,6 +220,7 @@ function resolveConfiguredVoiceModelDefaultRef<TConfig extends Record<string, un
   provider: string | undefined;
   providerConfigs: Record<string, TConfig>;
   providers: readonly RealtimeProviderWithConfig<TConfig>[];
+  requestedModel?: string;
 }): { provider: string; model: string } | undefined {
   const configuredProvider = normalizeOptionalString(params.provider);
   const refs = resolveSupportedVoiceModelRefs({
@@ -237,8 +238,11 @@ function resolveConfiguredVoiceModelDefaultRef<TConfig extends Record<string, un
         providerConfigs: params.providerConfigs,
         provider,
       });
-      const rawConfigWithModel =
-        rawConfig.model === undefined ? { ...rawConfig, model: ref.model } : rawConfig;
+      const rawConfigWithModel = {
+        ...rawConfig,
+        model:
+          params.requestedModel ?? (rawConfig.model === undefined ? ref.model : rawConfig.model),
+      };
       const providerConfig =
         provider.resolveConfig?.({
           cfg: params.config,
@@ -253,7 +257,11 @@ function resolveConfiguredVoiceModelDefaultRef<TConfig extends Record<string, un
   return undefined;
 }
 
-export function buildTalkRealtimeConfig(config: OpenClawConfig, requestedProvider?: string) {
+export function buildTalkRealtimeConfig(
+  config: OpenClawConfig,
+  requestedProvider?: string,
+  requestedModel?: string,
+) {
   const voiceCallRealtime = getVoiceCallRealtimeConfig(config);
   const talkRealtime = getRecord(config.talk?.realtime);
   const talkRealtimeProviderConfigs = talkRealtime?.providers as
@@ -278,6 +286,8 @@ export function buildTalkRealtimeConfig(config: OpenClawConfig, requestedProvide
     provider: selectedProvider,
     providerConfigs,
     providers: listRealtimeVoiceProviders(config),
+    requestedModel:
+      normalizeOptionalString(requestedModel) ?? normalizeOptionalString(talkRealtime?.model),
   });
   const provider = selectedProvider ?? voiceModelDefault?.provider;
   const model = normalizeOptionalString(talkRealtime?.model) ?? voiceModelDefault?.model;
@@ -313,7 +323,11 @@ export function buildTalkRealtimeConfig(config: OpenClawConfig, requestedProvide
   };
 }
 
-export function buildTalkTranscriptionConfig(config: OpenClawConfig, requestedProvider?: string) {
+export function buildTalkTranscriptionConfig(
+  config: OpenClawConfig,
+  requestedProvider?: string,
+  requestedModel?: string,
+) {
   const streamingConfig = getVoiceCallStreamingConfig(config);
   const provider = normalizeOptionalString(requestedProvider) ?? streamingConfig.provider;
   const providerConfigs = streamingConfig.providers ?? {};
@@ -323,6 +337,7 @@ export function buildTalkTranscriptionConfig(config: OpenClawConfig, requestedPr
     provider,
     providerConfigs,
     providers: listTalkTranscriptionProviders(config, configuredProviderIds),
+    requestedModel: normalizeOptionalString(requestedModel),
   });
   return {
     provider: provider ?? voiceModelDefault?.provider,
@@ -343,6 +358,7 @@ export function resolveConfiguredRealtimeTranscriptionProvider(params: {
   config: OpenClawConfig;
   configuredProviderId?: string;
   providerConfigs: Record<string, RealtimeTranscriptionProviderConfig>;
+  requestedModel?: string;
   defaultModel?: string;
 }) {
   const normalizedConfigured = normalizeOptionalLowercaseString(params.configuredProviderId);
@@ -362,10 +378,9 @@ export function resolveConfiguredRealtimeTranscriptionProvider(params: {
       provider,
       configuredProviderId: params.configuredProviderId,
     });
-    const rawConfigWithModel =
-      params.defaultModel && rawConfig.model === undefined
-        ? { ...rawConfig, model: params.defaultModel }
-        : rawConfig;
+    const model =
+      params.requestedModel ?? (rawConfig.model === undefined ? params.defaultModel : undefined);
+    const rawConfigWithModel = model ? { ...rawConfig, model } : rawConfig;
     const providerConfig =
       provider.resolveConfig?.({ cfg: params.config, rawConfig: rawConfigWithModel }) ??
       rawConfigWithModel;

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -396,192 +396,197 @@ describe("talk.catalog handler", () => {
     }
   });
 
-  it("returns safe speech, transcription, and realtime catalogs without provider secrets", async () => {
-    mocks.listSpeechProviders.mockReturnValue([
-      {
-        id: "elevenlabs",
-        label: "ElevenLabs",
-        aliases: ["11labs"],
-        models: ["eleven_flash_v2_5"],
-        voices: ["voice-1"],
-        isConfigured: vi.fn(() => true),
-      } as never,
-    ]);
-    mocks.getResolvedSpeechProviderConfig.mockReturnValue({ apiKey: "speech-key" });
-    mocks.listRealtimeTranscriptionProviders.mockReturnValue([
-      {
-        id: "openai",
-        label: "OpenAI Realtime Transcription",
-        aliases: ["openai-realtime"],
-        defaultModel: "gpt-4o-transcribe",
-        resolveConfig: vi.fn(({ rawConfig }) => rawConfig),
-        isConfigured: vi.fn(({ providerConfig }) => providerConfig.apiKey === "stt-key"),
-      } as never,
-      {
-        id: "deepgram",
-        label: "Deepgram Realtime Transcription",
-        aliases: ["deepgram-realtime"],
-        resolveConfig: vi.fn(({ rawConfig }) => rawConfig),
-        isConfigured: vi.fn(({ providerConfig }) => providerConfig.apiKey === "deepgram-key"),
-      } as never,
-    ]);
-    mocks.listRealtimeVoiceProviders.mockReturnValue([
-      {
-        id: "google",
-        label: "Google Live Voice",
-        defaultModel: "gemini-live",
-        resolveConfig: vi.fn(({ rawConfig }) => rawConfig),
-        isConfigured: vi.fn(
-          ({ providerConfig }) =>
-            providerConfig.apiKey === "live-key" &&
-            providerConfig.project === "base" &&
-            providerConfig.model === "talk-model",
-        ),
-        capabilities: {
-          transports: ["provider-websocket", "gateway-relay"],
-          inputAudioFormats: [{ encoding: "pcm16", sampleRateHz: 24000, channels: 1 }],
-          outputAudioFormats: [{ encoding: "pcm16", sampleRateHz: 24000, channels: 1 }],
-          supportsBrowserSession: true,
-          supportsBargeIn: true,
-          supportsToolCalls: true,
-          supportsVideoFrames: true,
-          supportsSessionResumption: true,
-        },
-        createBrowserSession: vi.fn(),
-        createBridge: vi.fn(),
-      } as never,
-      {
-        id: "openai",
-        label: "OpenAI Realtime",
-        resolveConfig: vi.fn(({ rawConfig }) => rawConfig),
-        isConfigured: vi.fn(({ providerConfig }) => providerConfig.apiKey === "openai-key"),
-        createBridge: vi.fn(),
-      } as never,
-    ]);
-    mocks.resolveConfiguredRealtimeVoiceProvider.mockReturnValue({
-      provider: { id: "google" },
-      providerConfig: { apiKey: "live-key", project: "base", model: "talk-model" },
-    } as never);
+  it.each([[undefined], [[]], [["transcribe-default", "transcribe-alternate"]]])(
+    "returns safe catalogs with transcription models %j",
+    async (models) => {
+      mocks.listSpeechProviders.mockReturnValue([
+        {
+          id: "elevenlabs",
+          label: "ElevenLabs",
+          aliases: ["11labs"],
+          models: ["eleven_flash_v2_5"],
+          voices: ["voice-1"],
+          isConfigured: vi.fn(() => true),
+        } as never,
+      ]);
+      mocks.getResolvedSpeechProviderConfig.mockReturnValue({ apiKey: "speech-key" });
+      mocks.listRealtimeTranscriptionProviders.mockReturnValue([
+        {
+          id: "openai",
+          label: "OpenAI Realtime Transcription",
+          aliases: ["openai-realtime"],
+          defaultModel: "gpt-4o-transcribe",
+          models,
+          resolveConfig: vi.fn(({ rawConfig }) => rawConfig),
+          isConfigured: vi.fn(({ providerConfig }) => providerConfig.apiKey === "stt-key"),
+        } as never,
+        {
+          id: "deepgram",
+          label: "Deepgram Realtime Transcription",
+          aliases: ["deepgram-realtime"],
+          resolveConfig: vi.fn(({ rawConfig }) => rawConfig),
+          isConfigured: vi.fn(({ providerConfig }) => providerConfig.apiKey === "deepgram-key"),
+        } as never,
+      ]);
+      mocks.listRealtimeVoiceProviders.mockReturnValue([
+        {
+          id: "google",
+          label: "Google Live Voice",
+          defaultModel: "gemini-live",
+          resolveConfig: vi.fn(({ rawConfig }) => rawConfig),
+          isConfigured: vi.fn(
+            ({ providerConfig }) =>
+              providerConfig.apiKey === "live-key" &&
+              providerConfig.project === "base" &&
+              providerConfig.model === "talk-model",
+          ),
+          capabilities: {
+            transports: ["provider-websocket", "gateway-relay"],
+            inputAudioFormats: [{ encoding: "pcm16", sampleRateHz: 24000, channels: 1 }],
+            outputAudioFormats: [{ encoding: "pcm16", sampleRateHz: 24000, channels: 1 }],
+            supportsBrowserSession: true,
+            supportsBargeIn: true,
+            supportsToolCalls: true,
+            supportsVideoFrames: true,
+            supportsSessionResumption: true,
+          },
+          createBrowserSession: vi.fn(),
+          createBridge: vi.fn(),
+        } as never,
+        {
+          id: "openai",
+          label: "OpenAI Realtime",
+          resolveConfig: vi.fn(({ rawConfig }) => rawConfig),
+          isConfigured: vi.fn(({ providerConfig }) => providerConfig.apiKey === "openai-key"),
+          createBridge: vi.fn(),
+        } as never,
+      ]);
+      mocks.resolveConfiguredRealtimeVoiceProvider.mockReturnValue({
+        provider: { id: "google" },
+        providerConfig: { apiKey: "live-key", project: "base", model: "talk-model" },
+      } as never);
 
-    const respond = vi.fn();
-    await callTalkHandler("talk.catalog", {
-      params: {},
-      client: { connect: { scopes: ["operator.read"] } },
-      respond,
-      context: {
-        getRuntimeConfig: () =>
-          ({
-            talk: {
-              provider: "elevenlabs",
-              providers: { elevenlabs: { apiKey: "speech-key" } },
-              realtime: {
-                provider: "google",
-                providers: {
-                  google: { apiKey: "live-key", project: "base" },
+      const respond = vi.fn();
+      await callTalkHandler("talk.catalog", {
+        params: {},
+        client: { connect: { scopes: ["operator.read"] } },
+        respond,
+        context: {
+          getRuntimeConfig: () =>
+            ({
+              talk: {
+                provider: "elevenlabs",
+                providers: { elevenlabs: { apiKey: "speech-key" } },
+                realtime: {
+                  provider: "google",
+                  providers: {
+                    google: { apiKey: "live-key", project: "base" },
+                  },
+                  model: "talk-model",
                 },
-                model: "talk-model",
               },
-            },
-            plugins: {
-              entries: {
-                "voice-call": {
-                  config: {
-                    streaming: {
-                      provider: "openai-realtime",
-                      providers: { "openai-realtime": { apiKey: "stt-key" } },
+              plugins: {
+                entries: {
+                  "voice-call": {
+                    config: {
+                      streaming: {
+                        provider: "openai-realtime",
+                        providers: { "openai-realtime": { apiKey: "stt-key" } },
+                      },
                     },
                   },
                 },
               },
-            },
-          }) as OpenClawConfig,
-      },
-    });
+            }) as OpenClawConfig,
+        },
+      });
 
-    expect(respond).toHaveBeenCalledWith(
-      true,
-      {
-        modes: ["realtime", "stt-tts", "transcription"],
-        transports: ["webrtc", "provider-websocket", "gateway-relay", "managed-room"],
-        brains: ["agent-consult", "direct-tools", "none"],
-        speech: {
-          activeProvider: "elevenlabs",
-          providers: [
-            {
-              id: "elevenlabs",
-              label: "ElevenLabs",
-              aliases: ["11labs"],
-              configured: true,
-              modes: ["stt-tts"],
-              brains: ["agent-consult"],
-              models: ["eleven_flash_v2_5"],
-              voices: ["voice-1"],
-            },
-          ],
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        {
+          modes: ["realtime", "stt-tts", "transcription"],
+          transports: ["webrtc", "provider-websocket", "gateway-relay", "managed-room"],
+          brains: ["agent-consult", "direct-tools", "none"],
+          speech: {
+            activeProvider: "elevenlabs",
+            providers: [
+              {
+                id: "elevenlabs",
+                label: "ElevenLabs",
+                aliases: ["11labs"],
+                configured: true,
+                modes: ["stt-tts"],
+                brains: ["agent-consult"],
+                models: ["eleven_flash_v2_5"],
+                voices: ["voice-1"],
+              },
+            ],
+          },
+          transcription: {
+            ready: true,
+            activeProvider: "openai",
+            providers: [
+              {
+                id: "openai",
+                label: "OpenAI Realtime Transcription",
+                aliases: ["openai-realtime"],
+                configured: true,
+                modes: ["transcription"],
+                transports: ["gateway-relay"],
+                brains: ["none"],
+                defaultModel: "gpt-4o-transcribe",
+                ...(models?.length ? { models } : {}),
+              },
+              {
+                id: "deepgram",
+                label: "Deepgram Realtime Transcription",
+                aliases: ["deepgram-realtime"],
+                configured: false,
+                modes: ["transcription"],
+                transports: ["gateway-relay"],
+                brains: ["none"],
+              },
+            ],
+          },
+          realtime: {
+            ready: true,
+            activeProvider: "google",
+            providers: [
+              {
+                id: "google",
+                label: "Google Live Voice",
+                configured: true,
+                defaultModel: "gemini-live",
+                modes: ["realtime"],
+                transports: ["provider-websocket", "gateway-relay"],
+                brains: ["agent-consult"],
+                inputAudioFormats: [{ encoding: "pcm16", sampleRateHz: 24000, channels: 1 }],
+                outputAudioFormats: [{ encoding: "pcm16", sampleRateHz: 24000, channels: 1 }],
+                supportsBrowserSession: true,
+                supportsBargeIn: true,
+                supportsToolCalls: true,
+                supportsVideoFrames: true,
+                supportsSessionResumption: true,
+              },
+              {
+                id: "openai",
+                label: "OpenAI Realtime",
+                configured: false,
+                modes: ["realtime"],
+                brains: ["agent-consult"],
+                supportsBrowserSession: false,
+              },
+            ],
+          },
         },
-        transcription: {
-          ready: true,
-          activeProvider: "openai",
-          providers: [
-            {
-              id: "openai",
-              label: "OpenAI Realtime Transcription",
-              aliases: ["openai-realtime"],
-              configured: true,
-              modes: ["transcription"],
-              transports: ["gateway-relay"],
-              brains: ["none"],
-              defaultModel: "gpt-4o-transcribe",
-            },
-            {
-              id: "deepgram",
-              label: "Deepgram Realtime Transcription",
-              aliases: ["deepgram-realtime"],
-              configured: false,
-              modes: ["transcription"],
-              transports: ["gateway-relay"],
-              brains: ["none"],
-            },
-          ],
-        },
-        realtime: {
-          ready: true,
-          activeProvider: "google",
-          providers: [
-            {
-              id: "google",
-              label: "Google Live Voice",
-              configured: true,
-              defaultModel: "gemini-live",
-              modes: ["realtime"],
-              transports: ["provider-websocket", "gateway-relay"],
-              brains: ["agent-consult"],
-              inputAudioFormats: [{ encoding: "pcm16", sampleRateHz: 24000, channels: 1 }],
-              outputAudioFormats: [{ encoding: "pcm16", sampleRateHz: 24000, channels: 1 }],
-              supportsBrowserSession: true,
-              supportsBargeIn: true,
-              supportsToolCalls: true,
-              supportsVideoFrames: true,
-              supportsSessionResumption: true,
-            },
-            {
-              id: "openai",
-              label: "OpenAI Realtime",
-              configured: false,
-              modes: ["realtime"],
-              brains: ["agent-consult"],
-              supportsBrowserSession: false,
-            },
-          ],
-        },
-      },
-      undefined,
-    );
-    const responsePayload = JSON.stringify(mockCallArg(respond, 0, 1));
-    expect(responsePayload).not.toContain("speech-key");
-    expect(responsePayload).not.toContain("stt-key");
-    expect(responsePayload).not.toContain("live-key");
-  });
+        undefined,
+      );
+      const responsePayload = JSON.stringify(mockCallArg(respond, 0, 1));
+      expect(responsePayload).not.toContain("speech-key");
+      expect(responsePayload).not.toContain("stt-key");
+      expect(responsePayload).not.toContain("live-key");
+    },
+  );
 
   it("emits realtime models and voices and mirrors create-time configured inputs", async () => {
     const provider = {
@@ -1745,6 +1750,77 @@ describe("talk.config handler", () => {
 });
 
 describe("talk.session unified handlers", () => {
+  it.each(["transcription", "realtime-relay", "realtime-browser"])(
+    "applies requested models before automatic provider validation for %s",
+    async (surface) => {
+      const provider = {
+        id: "acme",
+        label: "Acme",
+        models: ["voice-default", "voice-current"],
+        resolveConfig: ({ rawConfig }: { rawConfig: Record<string, unknown> }) => {
+          if (!["voice-default", "voice-current"].includes(String(rawConfig.model))) {
+            throw new Error("Unsupported model");
+          }
+          return rawConfig;
+        },
+        isConfigured: () => true,
+        createBrowserSession: vi.fn(async () => ({
+          provider: "acme",
+          transport: "webrtc",
+          clientSecret: "fixture",
+        })),
+      };
+      mocks.listRealtimeTranscriptionProviders.mockReturnValue([provider] as never);
+      mocks.listRealtimeVoiceProviders.mockReturnValue([provider] as never);
+      mocks.resolveConfiguredRealtimeVoiceProvider.mockReturnValue({
+        provider,
+        providerConfig: { model: "voice-current" },
+      } as never);
+      mocks.createTalkTranscriptionRelaySession.mockReturnValue({
+        transcriptionSessionId: "model-transcription",
+      });
+      mocks.createTalkRealtimeRelaySession.mockReturnValue({ relaySessionId: "model-realtime" });
+      const config: OpenClawConfig = {
+        agents: { defaults: { voiceModel: { primary: "acme/voice-default" } } },
+        plugins: {
+          entries: {
+            "voice-call": {
+              config: {
+                streaming: { providers: { acme: { model: "retired-model" } } },
+                realtime: { providers: { acme: { model: "retired-model" } } },
+              },
+            },
+          },
+        },
+      };
+      const respond = vi.fn();
+      await callTalkHandler(
+        surface === "realtime-browser" ? "talk.client.create" : "talk.session.create",
+        {
+          params: {
+            model: " voice-current ",
+            mode: surface === "transcription" ? "transcription" : "realtime",
+          },
+          respond,
+          context: { getRuntimeConfig: () => config, logGateway: { warn: vi.fn() } },
+        },
+      );
+      expectRespondOk(respond);
+      if (surface === "transcription") {
+        expect(mockCallArg(mocks.createTalkTranscriptionRelaySession)).toMatchObject({
+          providerConfig: { model: "voice-current" },
+        });
+      } else {
+        expect(mocks.resolveConfiguredRealtimeVoiceProvider).toHaveBeenCalledWith(
+          expect.objectContaining({
+            configuredProviderId: "acme",
+            providerConfigOverrides: { model: "voice-current" },
+          }),
+        );
+      }
+    },
+  );
+
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.resolveSessionKeyFromResolveParams.mockImplementation(async ({ p }) => {
@@ -2296,96 +2372,105 @@ describe("talk.session unified handlers", () => {
     });
   });
 
-  it("creates transcription gateway-relay sessions through the unified API", async () => {
-    const provider = {
-      id: "openai",
-      label: "OpenAI Realtime Transcription",
-      aliases: ["openai-realtime"],
-      defaultModel: "gpt-4o-transcribe",
-      models: ["gpt-4o-transcribe", "gpt-4o-mini-transcribe"],
-      autoSelectOrder: 1,
-      resolveConfig: vi.fn(({ rawConfig }) => rawConfig),
-      isConfigured: vi.fn(({ providerConfig }) => providerConfig.apiKey === "stt-key"),
-      createSession: vi.fn(),
-    };
-    mocks.listRealtimeTranscriptionProviders.mockReturnValue([provider] as never);
-    mocks.createTalkTranscriptionRelaySession.mockReturnValue({
-      provider: "openai",
-      mode: "transcription",
-      transport: "gateway-relay",
-      transcriptionSessionId: "stt-unified-1",
-      audio: { inputEncoding: "g711_ulaw", inputSampleRateHz: 8000 },
-      expiresAt: 1_797_986_400,
-    });
+  it.each([
+    [undefined, undefined, "gpt-4o-mini-transcribe"],
+    [undefined, "gpt-4o-transcribe", "gpt-4o-transcribe"],
+    ["  ", "gpt-4o-transcribe", "gpt-4o-transcribe"],
+    [" gpt-4o-transcribe ", undefined, "gpt-4o-transcribe"],
+    ["gpt-4o-transcribe", "gpt-4o-mini-transcribe", "gpt-4o-transcribe"],
+  ])(
+    "creates transcription sessions with request %j and configured model %j",
+    async (requestedModel, configuredModel, expectedModel) => {
+      const provider = {
+        id: "openai",
+        label: "OpenAI Realtime Transcription",
+        aliases: ["openai-realtime"],
+        defaultModel: "gpt-4o-transcribe",
+        models: ["gpt-4o-transcribe", "gpt-4o-mini-transcribe"],
+        autoSelectOrder: 1,
+        resolveConfig: vi.fn(({ rawConfig }) => rawConfig),
+        isConfigured: vi.fn(({ providerConfig }) => providerConfig.apiKey === "stt-key"),
+        createSession: vi.fn(),
+      };
+      mocks.listRealtimeTranscriptionProviders.mockReturnValue([provider] as never);
+      mocks.createTalkTranscriptionRelaySession.mockReturnValue({
+        provider: "openai",
+        mode: "transcription",
+        transport: "gateway-relay",
+        transcriptionSessionId: "stt-unified-1",
+        audio: { inputEncoding: "g711_ulaw", inputSampleRateHz: 8000 },
+        expiresAt: 1_797_986_400,
+      });
 
-    const createRespond = vi.fn();
-    await callTalkHandler("talk.session.create", {
-      params: { mode: "transcription", provider: "openai-realtime" },
-      respond: createRespond,
-      context: {
-        getRuntimeConfig: () =>
-          ({
-            agents: {
-              defaults: {
-                voiceModel: { primary: "openai/gpt-4o-mini-transcribe" },
+      const createRespond = vi.fn();
+      await callTalkHandler("talk.session.create", {
+        params: { mode: "transcription", provider: "openai-realtime", model: requestedModel },
+        respond: createRespond,
+        context: {
+          getRuntimeConfig: () =>
+            ({
+              agents: {
+                defaults: {
+                  voiceModel: { primary: "openai/gpt-4o-mini-transcribe" },
+                },
               },
-            },
-            plugins: {
-              entries: {
-                "voice-call": {
-                  config: {
-                    streaming: {
-                      provider: "openai-realtime",
-                      providers: { openai: { apiKey: "stt-key" } },
+              plugins: {
+                entries: {
+                  "voice-call": {
+                    config: {
+                      streaming: {
+                        provider: "openai-realtime",
+                        providers: { openai: { apiKey: "stt-key", model: configuredModel } },
+                      },
                     },
                   },
                 },
               },
-            },
-          }) as OpenClawConfig,
-      },
-    });
+            }) as OpenClawConfig,
+        },
+      });
 
-    expectRespondOk(createRespond, {
-      sessionId: "stt-unified-1",
-      transcriptionSessionId: "stt-unified-1",
-      mode: "transcription",
-      transport: "gateway-relay",
-      brain: "none",
-    });
-    const createInput = mockCallArg(mocks.createTalkTranscriptionRelaySession) as Record<
-      string,
-      unknown
-    >;
-    expectRecordFields(createInput.providerConfig, {
-      apiKey: "stt-key",
-      model: "gpt-4o-mini-transcribe",
-    });
-    const inputRespond = vi.fn();
-    await callTalkHandler("talk.session.appendAudio", {
-      params: { sessionId: "stt-unified-1", audioBase64: "aGVsbG8=" },
-      id: "2",
-      respond: inputRespond,
-      context: {},
-    });
-    expect(mocks.sendTalkTranscriptionRelayAudio).toHaveBeenCalledWith({
-      transcriptionSessionId: "stt-unified-1",
-      connId: "conn-1",
-      audioBase64: "aGVsbG8=",
-    });
+      expectRespondOk(createRespond, {
+        sessionId: "stt-unified-1",
+        transcriptionSessionId: "stt-unified-1",
+        mode: "transcription",
+        transport: "gateway-relay",
+        brain: "none",
+      });
+      const createInput = mockCallArg(mocks.createTalkTranscriptionRelaySession) as Record<
+        string,
+        unknown
+      >;
+      expectRecordFields(createInput.providerConfig, {
+        apiKey: "stt-key",
+        model: expectedModel,
+      });
+      const inputRespond = vi.fn();
+      await callTalkHandler("talk.session.appendAudio", {
+        params: { sessionId: "stt-unified-1", audioBase64: "aGVsbG8=" },
+        id: "2",
+        respond: inputRespond,
+        context: {},
+      });
+      expect(mocks.sendTalkTranscriptionRelayAudio).toHaveBeenCalledWith({
+        transcriptionSessionId: "stt-unified-1",
+        connId: "conn-1",
+        audioBase64: "aGVsbG8=",
+      });
 
-    const closeRespond = vi.fn();
-    await callTalkHandler("talk.session.close", {
-      params: { sessionId: "stt-unified-1" },
-      id: "3",
-      respond: closeRespond,
-      context: {},
-    });
-    expect(mocks.stopTalkTranscriptionRelaySession).toHaveBeenCalledWith({
-      transcriptionSessionId: "stt-unified-1",
-      connId: "conn-1",
-    });
-  });
+      const closeRespond = vi.fn();
+      await callTalkHandler("talk.session.close", {
+        params: { sessionId: "stt-unified-1" },
+        id: "3",
+        respond: closeRespond,
+        context: {},
+      });
+      expect(mocks.stopTalkTranscriptionRelaySession).toHaveBeenCalledWith({
+        transcriptionSessionId: "stt-unified-1",
+        connId: "conn-1",
+      });
+    },
+  );
 
   it("creates transcription sessions with an aliased provider missing from the active registry", async () => {
     const openai = {

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -363,8 +363,10 @@ function buildTalkCatalog(config: OpenClawConfig) {
           modes: ["transcription"],
           transports: ["gateway-relay"],
           brains: ["none"],
-          ...(provider.models?.length ? { models: [...provider.models] } : {}),
         };
+        if (provider.models?.length) {
+          entry.models = [...provider.models];
+        }
         if (provider.defaultModel) {
           entry.defaultModel = provider.defaultModel;
         }

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -363,6 +363,7 @@ function buildTalkCatalog(config: OpenClawConfig) {
           modes: ["transcription"],
           transports: ["gateway-relay"],
           brains: ["none"],
+          ...(provider.models?.length ? { models: [...provider.models] } : {}),
         };
         if (provider.defaultModel) {
           entry.defaultModel = provider.defaultModel;


### PR DESCRIPTION
Supersedes #116699. Related: #106020 (already closed; this PR repairs the remaining transcription behavior).

## What Problem This Solves

Fixes an issue where clients selecting a transcription model through Talk silently received the configured/default model instead. The capability catalog also omitted the model choices declared by transcription plugins. Automatic provider selection could reject a stale configured model before considering a valid request override.

## Why This Change Was Made

The existing Talk resolver now applies the requested model before provider normalization and eligibility checks. The shared preliminary selection step does the same for transcription, realtime relay, and browser realtime sessions. Catalog entries copy nonempty model lists; absent and empty lists remain omitted. No provider API, configuration key, storage schema, or protocol version changes.

This is a trusted-main rewrite of the stale contributor branch, with credit to @lsr911. It addresses the original review's incomplete catalog-to-session flow rather than landing projection alone. Production: +38/-11 (net +27), needed to carry the existing model request across the three entry points and their shared selection owner. Tests: +344/-259 (net +85; most churn is table indentation), docs: +2. A downstream relay-only override was rejected because normalization could already fail before the relay starts.

Provenance: the unified session API accepted `model` while omitting it from transcription resolution in c434d7720b2; the raw-parent patch was inspected. The omission is also present in stable v2026.7.1-2. Catalog omission introduction remains unverified.

## User Impact

Talk clients can discover plugin-declared transcription models and select one for a session. Explicit request models win; blank/omitted requests retain provider configuration, matching voice-model defaults, then provider defaults. Existing realtime provider selection observes the effective model before validation. This does not add a transcription model picker to the web UI.

## Evidence

- Before repair, three catalog/model-precedence regressions failed; the remaining 83 cases passed. A second baseline reproduced premature validation failures in all three session entry points.
- `node scripts/run-vitest.mjs src/gateway/server-methods/talk.test.ts src/gateway/server-methods/talk-client.test.ts src/gateway/server-methods/talk.provider-discovery.test.ts src/gateway/talk-transcription-relay.test.ts`: 118 passed across four suites.
- Fresh independent Codex review: no actionable P0–P2 findings after repairing preliminary selection. Formatting and `git diff --check` pass.
- Full local changed checks passed across the initial run and the scoped lint correction/remainder run. The initial local and CI attempt found the catalog's conditional-spread lint violation; direct assignment fixed it, three catalog cases were rerun, and a fresh independent review of the correction was clean.
- Full production build passed, including plugin SDK verification and the UI bundle. [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33341508676) at `722a7cf1df95987bf0d56b396d7e7f173069252a`.
- An isolated Gateway launched from that build passed the actual public-SDK client/RPC flow. It discovered the synthetic plugin through normal registration, exposed both declared models, selected the default and then an explicit alternate, delivered exact audio bytes, emitted final transcripts, closed both sessions, and rejected post-close audio. The provider fixture is synthetic: this proves routing and lifecycle, not external ASR accuracy, provider availability, or web-UI model selection.
- Probe setup initially failed importing a source client package before RPC execution; using the built public Gateway SDK corrected the probe. The passing run exited zero, stopped its owned Gateway/process groups, and removed temporary state.

## Review Follow-through

ClawSweeper found no correctness defect. Its provider-boundary trace rank-up move is completed below. The existing `model` request now intentionally participates in provider validation instead of silently falling back. The +27 production lines carry that existing field through three entry points and their shared preliminary resolver, plus copy declared catalog models; no parallel resolver, configuration key, schema, or protocol surface was added.

```json
{
  "head": "722a7cf1df95987bf0d56b396d7e7f173069252a",
  "result": "pass",
  "catalog": {"ready": true, "models": ["fixture-default", "fixture-alternate"], "defaultModel": "fixture-default"},
  "sessions": [
    {"request": null, "providerModel": "fixture-default", "audioBytes": 160, "finalTranscript": "fixture transcript; model=fixture-default; bytes=160", "closed": true, "appendAfterCloseRejected": true},
    {"request": "fixture-alternate", "providerModel": "fixture-alternate", "audioBytes": 160, "finalTranscript": "fixture transcript; model=fixture-alternate; bytes=160", "closed": true, "appendAfterCloseRejected": true}
  ],
  "audioSha256AtBothBoundaries": "a99c6db4c58239b4f6e8a4c4c6231de2e616d1d8a30753a893246e32a7651e17"
}
```
