### PR TITLE
fix(browser): prefer CDP for managed role snapshots

### DIFF
--- a/extensions/browser/src/browser/cdp.internal.test.ts
+++ b/extensions/browser/src/browser/cdp.internal.test.ts
@@ -534,6 +534,16 @@ describe("cdp internal", () => {
       expect(snap.snapshot).toContain('  - button "Inside" [ref=e2]');
       expect(snap.refs.e1?.frameId).toBe("FRAME_1");
       expect(snap.refs.e2?.frameId).toBe("FRAME_1");
+
+      const mainFrameOnly = await snapshotRoleViaCdp({
+        wsUrl: server.wsUrl,
+        options: { interactive: true },
+        recurseIframes: false,
+      });
+
+      expect(mainFrameOnly.snapshot).toContain('- Iframe "Child" [ref=e1]');
+      expect(mainFrameOnly.snapshot).not.toContain('button "Inside"');
+      expect(mainFrameOnly.refs.e2).toBeUndefined();
     });
   });
 

--- a/extensions/browser/src/browser/cdp.internal.test.ts
+++ b/extensions/browser/src/browser/cdp.internal.test.ts
@@ -377,6 +377,48 @@ describe("cdp internal", () => {
   });
 
   describe("snapshotRoleViaCdp", () => {
+    it("keeps zero-based indexes on duplicate role refs", async () => {
+      const server = await startMockWsServer((msg) => {
+        if (msg.method === "Accessibility.getFullAXTree") {
+          return axTreeResult([
+            {
+              nodeId: "1",
+              role: { value: "RootWebArea" },
+              name: { value: "" },
+              childIds: ["2", "3"],
+            },
+            {
+              nodeId: "2",
+              role: { value: "button" },
+              name: { value: "Save" },
+              childIds: [],
+            },
+            {
+              nodeId: "3",
+              role: { value: "button" },
+              name: { value: "Save" },
+              childIds: [],
+            },
+          ]);
+        }
+        if (msg.method === "Runtime.evaluate") {
+          return runtimeValueResult([]);
+        }
+        return undefined;
+      });
+      wss = server.wss;
+
+      const snap = await snapshotRoleViaCdp({
+        wsUrl: server.wsUrl,
+        options: { interactive: true },
+      });
+
+      expect(snap.refs).toMatchObject({
+        e1: { role: "button", name: "Save", nth: 0 },
+        e2: { role: "button", name: "Save", nth: 1 },
+      });
+    });
+
     it("builds role refs, promotes cursor-interactive nodes, and appends link urls", async () => {
       const server = await startMockWsServer((msg) => {
         if (msg.method === "Accessibility.getFullAXTree") {

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -912,6 +912,7 @@ export async function snapshotRoleViaCdp(opts: {
   lookup?: typeof dnsLookupCb;
   options?: CdpRoleSnapshotOptions;
   urls?: boolean;
+  recurseIframes?: boolean;
   timeoutMs?: number;
   maxChars?: number;
   delta?: { mode: RoleSnapshotIdentityMode; previousKeys?: ReadonlySet<string> };
@@ -930,7 +931,7 @@ export async function snapshotRoleViaCdp(opts: {
         send,
         options: opts.options ?? {},
         urls: opts.urls,
-        recurseIframes: true,
+        recurseIframes: opts.recurseIframes ?? true,
         nextRef: { value: 1 },
       });
       const renderedSnapshot =

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -844,10 +844,15 @@ async function buildCdpRoleSnapshot(params: {
     refs[ref] = {
       role,
       ...(node.name ? { name: node.name } : {}),
-      ...(nth > 0 ? { nth } : {}),
+      nth,
       ...(node.backendDOMNodeId ? { backendDOMNodeId: node.backendDOMNodeId } : {}),
       ...(params.frameId ? { frameId: params.frameId } : {}),
     };
+  }
+  for (const node of tree) {
+    if (node.ref && counts.get(`${node.role.toLowerCase()}:${node.name}`) === 1) {
+      delete refs[node.ref]?.nth;
+    }
   }
 
   const iframeFrameIds = await resolveIframeFrameIds(params.send, tree, params.sessionId);

--- a/extensions/browser/src/browser/pw-ai.ts
+++ b/extensions/browser/src/browser/pw-ai.ts
@@ -59,7 +59,7 @@ import {
   snapshotAiViaPlaywright,
   snapshotAriaViaPlaywright,
   snapshotRoleViaPlaywright,
-  storeAriaSnapshotRefsViaPlaywright,
+  storeSnapshotRefsViaPlaywright,
 } from "./pw-tools-core.snapshot.js";
 import {
   emulateMediaViaPlaywright,
@@ -140,7 +140,7 @@ export const pwAi = {
   snapshotAiViaPlaywright,
   snapshotAriaViaPlaywright,
   snapshotRoleViaPlaywright,
-  storeAriaSnapshotRefsViaPlaywright,
+  storeSnapshotRefsViaPlaywright,
   screenshotWithLabelsViaPlaywright,
   storageClearViaPlaywright,
   storageGetViaPlaywright,

--- a/extensions/browser/src/browser/pw-role-snapshot.chromium.test.ts
+++ b/extensions/browser/src/browser/pw-role-snapshot.chromium.test.ts
@@ -1,9 +1,11 @@
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test-support.js";
+import { snapshotRoleViaCdp } from "./cdp.js";
 import { getPlaywrightCore } from "./playwright-core.runtime.js";
 import {
   closePlaywrightBrowserConnection,
+  getMainFrameDocumentIdentityViaPlaywright,
   refLocator,
   restoreRoleRefsForTarget,
 } from "./pw-session.js";
@@ -13,7 +15,7 @@ import {
   snapshotAiViaPlaywright,
   snapshotAriaViaPlaywright,
   snapshotRoleViaPlaywright,
-  storeAriaSnapshotRefsViaPlaywright,
+  storeSnapshotRefsViaPlaywright,
 } from "./pw-tools-core.snapshot.js";
 import { getFreePort } from "./test-port.js";
 
@@ -73,6 +75,74 @@ describe.runIf(process.env.OPENCLAW_BROWSER_SNAPSHOT_E2E === "1")(
         expect(present.snapshot).toContain('button "Present"');
         expect(refFree.refs).toEqual({});
         expect(refFree.snapshot).toContain("https://example.test/docs");
+      } finally {
+        await closePlaywrightBrowserConnection({ cdpUrl });
+        await context.close();
+      }
+    }, 30_000);
+
+    it("publishes actionable main-frame CDP refs into the Playwright cache", async () => {
+      const rootDir = tempDirs.make("openclaw-cdp-role-refs-");
+      const port = await getFreePort();
+      const cdpUrl = `http://127.0.0.1:${port}`;
+      const context = await getPlaywrightCore().chromium.launchPersistentContext(
+        path.join(rootDir, "profile"),
+        {
+          headless: true,
+          executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+          args: [`--remote-debugging-port=${port}`],
+        },
+      );
+      try {
+        const page = context.pages()[0] ?? (await context.newPage());
+        await page.setContent(
+          [
+            "<button onclick=\"document.querySelector('output').textContent='button'\">Native</button>",
+            "<div style=\"cursor:pointer\" onclick=\"document.querySelector('output').textContent='cursor'\">Cursor card</div>",
+            "<output></output>",
+            '<iframe srcdoc="<button>Child frame</button>"></iframe>',
+          ].join(""),
+        );
+        await page.frameLocator("iframe").getByRole("button").waitFor();
+        const session = await context.newCDPSession(page);
+        const { targetInfo } = await session.send("Target.getTargetInfo");
+        await session.detach();
+        const targets = (await fetch(`${cdpUrl}/json/list`).then((res) => res.json())) as Array<{
+          id?: string;
+          webSocketDebuggerUrl?: string;
+        }>;
+        const wsUrl = targets.find(
+          (target) => target.id === targetInfo.targetId,
+        )?.webSocketDebuggerUrl;
+        expect(wsUrl).toBeTypeOf("string");
+        const target = { cdpUrl, targetId: targetInfo.targetId };
+        const snapshot = await snapshotRoleViaCdp({
+          wsUrl: wsUrl!,
+          options: { interactive: true },
+          recurseIframes: false,
+        });
+        const nativeRef = Object.entries(snapshot.refs).find(
+          ([, info]) => info.name === "Native",
+        )?.[0];
+        const cursorRef = Object.entries(snapshot.refs).find(
+          ([, info]) => info.name === "Cursor card",
+        )?.[0];
+
+        expect(nativeRef).toBeDefined();
+        expect(cursorRef).toBeDefined();
+        expect(Object.values(snapshot.refs).some((info) => info.name === "Child frame")).toBe(
+          false,
+        );
+        await storeSnapshotRefsViaPlaywright({
+          ...target,
+          refs: snapshot.refs,
+          expectedDocumentIdentity: await getMainFrameDocumentIdentityViaPlaywright(target),
+        });
+
+        await clickViaPlaywright({ ...target, ref: nativeRef!, timeoutMs: 1_000 });
+        expect(await page.locator("output").textContent()).toBe("button");
+        await clickViaPlaywright({ ...target, ref: cursorRef!, timeoutMs: 1_000 });
+        expect(await page.locator("output").textContent()).toBe("cursor");
       } finally {
         await closePlaywrightBrowserConnection({ cdpUrl });
         await context.close();
@@ -215,7 +285,7 @@ describe.runIf(process.env.OPENCLAW_BROWSER_SNAPSHOT_E2E === "1")(
         expect(await page.locator("output").textContent()).toBe("raw-empty");
         // Real AX names with unavailable DOM ids exercise the existing role fallback.
         // Restore onto the launcher's distinct Page wrapper to cross the target cache.
-        await storeAriaSnapshotRefsViaPlaywright({
+        await storeSnapshotRefsViaPlaywright({
           ...target,
           nodes: aria.nodes.map(({ backendDOMNodeId: _backendId, ...node }) => node),
         });

--- a/extensions/browser/src/browser/pw-role-snapshot.chromium.test.ts
+++ b/extensions/browser/src/browser/pw-role-snapshot.chromium.test.ts
@@ -139,17 +139,15 @@ describe.runIf(process.env.OPENCLAW_BROWSER_SNAPSHOT_E2E === "1")(
         const newCdpSession = context.newCDPSession.bind(context);
         const newCdpSessionSpy = vi
           .spyOn(context, "newCDPSession")
-          .mockImplementation(async (target) => {
-            const markerSession = await newCdpSession(target);
+          .mockImplementation(async (pageOrFrame) => {
+            const markerSession = await newCdpSession(pageOrFrame);
             const send = markerSession.send.bind(markerSession);
             vi.spyOn(markerSession, "send").mockImplementation((async (
               method: string,
               params?: Record<string, unknown>,
             ) => {
-              if (
-                method === "DOM.setAttributeValue" &&
-                nativeRefSet.has(String(params?.value ?? ""))
-              ) {
+              const markerValue = typeof params?.value === "string" ? params.value : "";
+              if (method === "DOM.setAttributeValue" && nativeRefSet.has(markerValue)) {
                 throw new Error("marker write blocked");
               }
               return await (

--- a/extensions/browser/src/browser/pw-role-snapshot.chromium.test.ts
+++ b/extensions/browser/src/browser/pw-role-snapshot.chromium.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test-support.js";
 import { snapshotRoleViaCdp } from "./cdp.js";
 import { getPlaywrightCore } from "./playwright-core.runtime.js";
@@ -97,7 +97,8 @@ describe.runIf(process.env.OPENCLAW_BROWSER_SNAPSHOT_E2E === "1")(
         const page = context.pages()[0] ?? (await context.newPage());
         await page.setContent(
           [
-            "<button onclick=\"document.querySelector('output').textContent='button'\">Native</button>",
+            "<button onclick=\"document.querySelector('output').textContent='first'\">Native</button>",
+            "<button onclick=\"document.querySelector('output').textContent='second'\">Native</button>",
             "<div style=\"cursor:pointer\" onclick=\"document.querySelector('output').textContent='cursor'\">Cursor card</div>",
             "<output></output>",
             '<iframe srcdoc="<button>Child frame</button>"></iframe>',
@@ -121,26 +122,61 @@ describe.runIf(process.env.OPENCLAW_BROWSER_SNAPSHOT_E2E === "1")(
           options: { interactive: true },
           recurseIframes: false,
         });
-        const nativeRef = Object.entries(snapshot.refs).find(
+        const nativeRefs = Object.entries(snapshot.refs).filter(
           ([, info]) => info.name === "Native",
-        )?.[0];
+        );
         const cursorRef = Object.entries(snapshot.refs).find(
           ([, info]) => info.name === "Cursor card",
         )?.[0];
 
-        expect(nativeRef).toBeDefined();
+        expect(nativeRefs).toHaveLength(2);
         expect(cursorRef).toBeDefined();
         expect(Object.values(snapshot.refs).some((info) => info.name === "Child frame")).toBe(
           false,
         );
-        await storeSnapshotRefsViaPlaywright({
-          ...target,
-          refs: snapshot.refs,
-          expectedDocumentIdentity: await getMainFrameDocumentIdentityViaPlaywright(target),
-        });
+        const expectedDocumentIdentity = await getMainFrameDocumentIdentityViaPlaywright(target);
+        const nativeRefSet = new Set(nativeRefs.map(([ref]) => ref));
+        const newCdpSession = context.newCDPSession.bind(context);
+        const newCdpSessionSpy = vi
+          .spyOn(context, "newCDPSession")
+          .mockImplementation(async (target) => {
+            const markerSession = await newCdpSession(target);
+            const send = markerSession.send.bind(markerSession);
+            vi.spyOn(markerSession, "send").mockImplementation((async (
+              method: string,
+              params?: Record<string, unknown>,
+            ) => {
+              if (
+                method === "DOM.setAttributeValue" &&
+                nativeRefSet.has(String(params?.value ?? ""))
+              ) {
+                throw new Error("marker write blocked");
+              }
+              return await (
+                send as (method: string, params?: Record<string, unknown>) => Promise<unknown>
+              )(method, params);
+            }) as typeof markerSession.send);
+            return markerSession;
+          });
+        try {
+          await storeSnapshotRefsViaPlaywright({
+            ...target,
+            page,
+            refs: snapshot.refs,
+            expectedDocumentIdentity,
+          });
+        } finally {
+          newCdpSessionSpy.mockRestore();
+        }
 
-        await clickViaPlaywright({ ...target, ref: nativeRef!, timeoutMs: 1_000 });
-        expect(await page.locator("output").textContent()).toBe("button");
+        for (const [ref] of nativeRefs) {
+          expect(await page.locator(`[${BROWSER_REF_MARKER_ATTRIBUTE}="${ref}"]`).count()).toBe(0);
+        }
+        for (const [index, [ref]] of nativeRefs.entries()) {
+          await clickViaPlaywright({ ...target, ref, timeoutMs: 1_000 });
+          expect(await page.locator("output").textContent()).toBe(["first", "second"][index]);
+        }
+        expect(nativeRefs.map(([, info]) => info.nth)).toEqual([0, 1]);
         await clickViaPlaywright({ ...target, ref: cursorRef!, timeoutMs: 1_000 });
         expect(await page.locator("output").textContent()).toBe("cursor");
       } finally {

--- a/extensions/browser/src/browser/pw-session-actions.ts
+++ b/extensions/browser/src/browser/pw-session-actions.ts
@@ -96,7 +96,7 @@ export function refLocator(page: Page, ref: string) {
       );
     }
     const scope = state?.roleRefsFrame ?? page;
-    if (!isRoleRef && info.domMarker) {
+    if (info.domMarker) {
       return scope.locator(`[${BROWSER_REF_MARKER_ATTRIBUTE}="${normalized}"]`);
     }
     // Playwright omits empty names and names over 900 UTF-16 units from ARIA text.

--- a/extensions/browser/src/browser/pw-session.page-cdp.test.ts
+++ b/extensions/browser/src/browser/pw-session.page-cdp.test.ts
@@ -114,6 +114,34 @@ describe("pw-session page-scoped CDP client", () => {
     expect(sessionDetach).toHaveBeenCalledTimes(1);
   });
 
+  it("marks both generated role refs and raw accessibility refs", async () => {
+    const sessionSend = vi.fn(async (method: string) => {
+      if (method === "DOM.pushNodesByBackendIdsToFrontend") {
+        return { nodeIds: [101, 202] };
+      }
+      return {};
+    });
+    const page = {
+      context: () => ({
+        newCDPSession: vi.fn(async () => ({
+          send: sessionSend,
+          detach: vi.fn(async () => {}),
+        })),
+      }),
+      locator: vi.fn(() => ({ evaluateAll: vi.fn(async () => {}) })),
+    };
+
+    const marked = await markBackendDomRefsOnPage({
+      page: page as never,
+      refs: [
+        { ref: "e1", backendDOMNodeId: 42 },
+        { ref: "ax2", backendDOMNodeId: 84 },
+      ],
+    });
+
+    expect(marked).toEqual(new Set(["e1", "ax2"]));
+  });
+
   it("clears stale markers even when no backend refs are valid", async () => {
     const newCDPSession = vi.fn();
     const evaluateAll = vi.fn(async () => {});

--- a/extensions/browser/src/browser/pw-session.page-cdp.ts
+++ b/extensions/browser/src/browser/pw-session.page-cdp.ts
@@ -81,7 +81,7 @@ export async function markBackendDomRefsOnPage(opts: {
 
   const refs = opts.refs.filter(
     (entry) =>
-      /^ax\d+$/.test(entry.ref) &&
+      /^(?:e|ax)\d+$/.test(entry.ref) &&
       Number.isFinite(entry.backendDOMNodeId) &&
       Math.floor(entry.backendDOMNodeId) > 0,
   );

--- a/extensions/browser/src/browser/pw-session.test.ts
+++ b/extensions/browser/src/browser/pw-session.test.ts
@@ -148,14 +148,14 @@ describe("pw-session refLocator", () => {
     expect(mocks.locator).toHaveBeenCalledWith("aria-ref=e1");
   });
 
-  it("uses backend-marked DOM locators for ax refs", () => {
+  it.each(["e1", "ax12"])("uses backend-marked DOM locators for %s refs", (ref) => {
     const { page, mocks } = fakePage();
     const state = ensurePageState(page);
-    state.roleRefs = { ax12: { role: "button", name: "OK", domMarker: true } };
+    state.roleRefs = { [ref]: { role: "button", name: "OK", domMarker: true } };
 
-    refLocator(page, "ax12");
+    refLocator(page, ref);
 
-    expect(mocks.locator).toHaveBeenCalledWith(`[${BROWSER_REF_MARKER_ATTRIBUTE}="ax12"]`);
+    expect(mocks.locator).toHaveBeenCalledWith(`[${BROWSER_REF_MARKER_ATTRIBUTE}="${ref}"]`);
   });
 
   it("rejects unknown ax refs instead of timing out on aria-ref locators", () => {

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
@@ -7,6 +7,7 @@ const ensurePageState = vi.fn();
 const storeRoleRefsForTarget = vi.fn();
 const withPageScopedCdpClient = vi.fn();
 const markBackendDomRefsOnPage = vi.fn();
+const readMainFrameDocumentIdentityForPage = vi.fn();
 const formatAriaSnapshot = vi.fn();
 const gotoPageWithNavigationGuard = vi.fn();
 const createDownloadCaptureForPage = vi.fn(() => ({
@@ -33,6 +34,7 @@ vi.mock("./pw-download-capture.js", () => ({
 
 vi.mock("./pw-session.page-cdp.js", () => ({
   markBackendDomRefsOnPage,
+  readMainFrameDocumentIdentityForPage,
   withPageScopedCdpClient,
 }));
 
@@ -536,7 +538,7 @@ describe("pw-tools-core aria snapshot storage", () => {
     getPageForTargetId.mockResolvedValue(page);
     markBackendDomRefsOnPage.mockResolvedValue(new Set());
 
-    await mod.storeAriaSnapshotRefsViaPlaywright({
+    await mod.storeSnapshotRefsViaPlaywright({
       cdpUrl: "http://127.0.0.1:9222",
       targetId: "tab-1",
       nodes: [
@@ -557,5 +559,57 @@ describe("pw-tools-core aria snapshot storage", () => {
       },
       mode: "role",
     });
+  });
+
+  it("publishes finalized CDP refs without recomputing duplicate indexes", async () => {
+    const page = { id: "page-1" };
+    const mod = await import("./pw-tools-core.snapshot.js");
+
+    getPageForTargetId.mockResolvedValue(page);
+    markBackendDomRefsOnPage.mockResolvedValue(new Set(["e2"]));
+    readMainFrameDocumentIdentityForPage.mockResolvedValue("cdp:loader-1");
+
+    await mod.storeSnapshotRefsViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "tab-1",
+      expectedDocumentIdentity: "cdp:loader-1",
+      refs: {
+        e1: { role: "button", name: "Save", nth: 0, backendDOMNodeId: 42 },
+        e2: { role: "button", name: "Save", nth: 1, backendDOMNodeId: 84 },
+      },
+    });
+
+    expect(storeRoleRefsForTarget).toHaveBeenCalledWith({
+      page,
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "tab-1",
+      refs: {
+        e1: { role: "button", name: "Save", nth: 0 },
+        e2: { role: "button", name: "Save", nth: 1, domMarker: true },
+      },
+      mode: "role",
+    });
+  });
+
+  it("does not publish CDP refs after the document changes", async () => {
+    const page = { id: "page-1" };
+    const mod = await import("./pw-tools-core.snapshot.js");
+
+    getPageForTargetId.mockResolvedValue(page);
+    markBackendDomRefsOnPage.mockResolvedValue(new Set(["e1"]));
+    readMainFrameDocumentIdentityForPage.mockResolvedValue("cdp:loader-2");
+
+    await expect(
+      mod.storeSnapshotRefsViaPlaywright({
+        cdpUrl: "http://127.0.0.1:9222",
+        targetId: "tab-1",
+        expectedDocumentIdentity: "cdp:loader-1",
+        refs: {
+          e1: { role: "button", name: "Save", backendDOMNodeId: 42 },
+        },
+      }),
+    ).rejects.toThrow("Frame changed while its browser snapshot refs were being published");
+
+    expect(storeRoleRefsForTarget).not.toHaveBeenCalled();
   });
 });

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -41,8 +41,14 @@ import {
   isPolicyDenyNavigationError,
   storeRoleRefsForTarget,
 } from "./pw-session.js";
-import { markBackendDomRefsOnPage, withPageScopedCdpClient } from "./pw-session.page-cdp.js";
+import {
+  markBackendDomRefsOnPage,
+  readMainFrameDocumentIdentityForPage,
+  withPageScopedCdpClient,
+} from "./pw-session.page-cdp.js";
 import { appendSnapshotUrls, type SnapshotUrlEntry } from "./snapshot-urls.js";
+
+type StoredSnapshotRef = RoleRefMap[string] & { backendDOMNodeId?: number };
 
 function resolveBoundedTimeoutMs(
   timeoutMs: number | undefined,
@@ -98,12 +104,8 @@ async function collectSnapshotUrls(page: Page): Promise<SnapshotUrlEntry[]> {
     : [];
 }
 
-function buildStoredAriaRefs(
-  nodes: AriaSnapshotNode[],
-  markedRefs: Set<string>,
-): Record<string, { role: string; name?: string; nth?: number; domMarker?: boolean }> {
-  const refs: Record<string, { role: string; name?: string; nth?: number; domMarker?: boolean }> =
-    {};
+function buildStoredAriaRefs(nodes: AriaSnapshotNode[]): Record<string, StoredSnapshotRef> {
+  const refs: Record<string, StoredSnapshotRef> = {};
   const groups = new Map<string, { count: number; firstRef: string }>();
 
   for (const node of nodes) {
@@ -122,7 +124,9 @@ function buildStoredAriaRefs(
       name,
       // Keep index zero for duplicates; only singleton groups can omit nth.
       nth,
-      ...(markedRefs.has(node.ref) ? { domMarker: true } : {}),
+      ...(typeof node.backendDOMNodeId === "number"
+        ? { backendDOMNodeId: node.backendDOMNodeId }
+        : {}),
     };
   }
 
@@ -136,13 +140,16 @@ function buildStoredAriaRefs(
   return refs;
 }
 
-/** Stores aria snapshot refs so later tool calls can resolve stable element refs. */
-export async function storeAriaSnapshotRefsViaPlaywright(opts: {
+/** Publish raw or finalized snapshot refs into the Playwright action cache. */
+export async function storeSnapshotRefsViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
-  nodes: AriaSnapshotNode[];
   page?: Page;
+  nodes?: AriaSnapshotNode[];
+  refs?: Record<string, StoredSnapshotRef>;
+  expectedDocumentIdentity?: string;
 }): Promise<void> {
+  const sourceRefs = opts.refs ?? buildStoredAriaRefs(opts.nodes ?? []);
   const page =
     opts.page ??
     (await getPageForTargetId({
@@ -152,17 +159,30 @@ export async function storeAriaSnapshotRefsViaPlaywright(opts: {
   ensurePageState(page);
   const markedRefs = await markBackendDomRefsOnPage({
     page,
-    refs: opts.nodes.flatMap((node) =>
-      typeof node.backendDOMNodeId === "number"
-        ? [{ ref: node.ref, backendDOMNodeId: node.backendDOMNodeId }]
+    refs: Object.entries(sourceRefs).flatMap(([ref, info]) =>
+      typeof info.backendDOMNodeId === "number"
+        ? [{ ref, backendDOMNodeId: info.backendDOMNodeId }]
         : [],
     ),
   });
+  if (
+    opts.expectedDocumentIdentity &&
+    (await readMainFrameDocumentIdentityForPage(page)) !== opts.expectedDocumentIdentity
+  ) {
+    throw new Error("Frame changed while its browser snapshot refs were being published; retry.");
+  }
+  const refs: RoleRefMap = Object.fromEntries(
+    Object.entries(sourceRefs).map(([ref, info]) => {
+      const storedInfo = { ...info };
+      delete storedInfo.backendDOMNodeId;
+      return [ref, { ...storedInfo, ...(markedRefs.has(ref) ? { domMarker: true } : {}) }];
+    }),
+  );
   storeRoleRefsForTarget({
     page,
     cdpUrl: opts.cdpUrl,
     targetId: opts.targetId,
-    refs: buildStoredAriaRefs(opts.nodes, markedRefs),
+    refs,
     mode: "role",
   });
 }
@@ -223,7 +243,7 @@ export async function snapshotAriaViaPlaywright(opts: {
   });
   const nodes = Array.isArray(res?.nodes) ? res.nodes : [];
   const formatted = formatAriaSnapshot(nodes, limit);
-  await storeAriaSnapshotRefsViaPlaywright({
+  await storeSnapshotRefsViaPlaywright({
     cdpUrl: opts.cdpUrl,
     targetId: opts.targetId,
     nodes: formatted,

--- a/extensions/browser/src/browser/routes/agent.snapshot.local-managed.test.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.local-managed.test.ts
@@ -36,6 +36,10 @@ const cdpMocks = vi.hoisted(() => ({
   })),
 }));
 
+const pwState = vi.hoisted(() => ({
+  module: null as null | Record<string, ReturnType<typeof vi.fn>>,
+}));
+
 const navigationGuardMocks = vi.hoisted(() => ({
   assertBrowserNavigationAllowed: vi.fn(async () => {}),
   assertBrowserNavigationResultAllowed: vi.fn(async (): Promise<void> => {
@@ -83,7 +87,7 @@ vi.mock("./agent.shared.js", () => ({
   browserNavigationPolicyForProfile: vi.fn(() => ({
     ssrfPolicy: { dangerouslyAllowPrivateNetwork: false },
   })),
-  getPwAiModule: vi.fn(async () => null),
+  getPwAiModule: vi.fn(async () => pwState.module),
   handleRouteError: vi.fn(
     (
       _ctx: unknown,
@@ -120,12 +124,34 @@ function getSnapshotGetHandler(
   return handler;
 }
 
+function createPwModule(overrides: Record<string, ReturnType<typeof vi.fn>> = {}) {
+  return {
+    getMainFrameDocumentIdentityViaPlaywright: vi.fn(async () => "pw:test-document"),
+    getObservedBrowserStateViaPlaywright: vi.fn(async () => ({
+      dialogs: { pending: [], recent: [] },
+    })),
+    snapshotAiViaPlaywright: vi.fn(async () => ({ snapshot: "Playwright" })),
+    snapshotRoleViaPlaywright: vi.fn(async () => ({
+      snapshot: '- button "Playwright" [ref=e1]',
+      refs: { e1: { role: "button", name: "Playwright" } },
+      stats: { lines: 1, chars: 32, refs: 1, interactive: 1 },
+    })),
+    storeSnapshotRefsViaPlaywright: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
 describe("local-managed browser snapshot routes", () => {
   beforeEach(() => {
     routeState.profileCtx.ensureTabAvailable.mockClear();
     cdpMocks.getMainFrameDocumentIdentityViaCdp.mockReset().mockResolvedValue("cdp:test-document");
     cdpMocks.snapshotAria.mockClear();
-    cdpMocks.snapshotRoleViaCdp.mockClear();
+    cdpMocks.snapshotRoleViaCdp.mockReset().mockResolvedValue({
+      snapshot: '- link "private" [ref=e1]',
+      refs: { e1: { role: "link", name: "private" } },
+      stats: { lines: 1, chars: 25, refs: 1, interactive: 1 },
+    });
+    pwState.module = null;
     tabLookup.mockClear();
     navigationGuardMocks.assertBrowserNavigationResultAllowed.mockClear();
     navigationGuardMocks.withBrowserNavigationPolicy.mockClear();
@@ -180,6 +206,166 @@ describe("local-managed browser snapshot routes", () => {
     expect(cdpMocks.snapshotRoleViaCdp).toHaveBeenCalledWith(
       expect.objectContaining({ maxChars: 123 }),
     );
+  });
+
+  it("uses CDP first for unscoped managed role snapshots and publishes its refs", async () => {
+    navigationGuardMocks.assertBrowserNavigationResultAllowed.mockResolvedValue(undefined);
+    const storeSnapshotRefsViaPlaywright = vi.fn(async () => {});
+    const snapshotRoleViaPlaywright = vi.fn(async () => ({
+      snapshot: '- button "Playwright" [ref=e1]',
+      refs: { e1: { role: "button", name: "Playwright" } },
+      stats: { lines: 1, chars: 32, refs: 1, interactive: 1 },
+    }));
+    pwState.module = createPwModule({
+      snapshotRoleViaPlaywright,
+      storeSnapshotRefsViaPlaywright,
+    });
+    const handler = getSnapshotGetHandler();
+    const response = createBrowserRouteResponse();
+
+    await handler?.({ params: {}, query: { format: "ai", interactive: "true" } }, response.res);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toMatchObject({ snapshot: expect.stringContaining("private") });
+    expect(snapshotRoleViaPlaywright).not.toHaveBeenCalled();
+    expect(cdpMocks.snapshotRoleViaCdp).toHaveBeenCalledWith(
+      expect.objectContaining({ recurseIframes: false }),
+    );
+    expect(storeSnapshotRefsViaPlaywright).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18800",
+      targetId: "7",
+      expectedDocumentIdentity: "pw:test-document",
+      refs: { e1: { role: "link", name: "private" } },
+    });
+  });
+
+  it("falls back to Playwright once when the CDP-first snapshot fails early", async () => {
+    navigationGuardMocks.assertBrowserNavigationResultAllowed.mockResolvedValue(undefined);
+    cdpMocks.snapshotRoleViaCdp.mockRejectedValueOnce(new Error("cdp unavailable"));
+    const snapshotRoleViaPlaywright = vi.fn(async () => ({
+      snapshot: '- button "Playwright" [ref=e1]',
+      refs: { e1: { role: "button", name: "Playwright" } },
+      stats: { lines: 1, chars: 32, refs: 1, interactive: 1 },
+    }));
+    pwState.module = createPwModule({
+      snapshotRoleViaPlaywright,
+    });
+    const handler = getSnapshotGetHandler();
+    const response = createBrowserRouteResponse();
+
+    await handler?.({ params: {}, query: { format: "ai", interactive: "true" } }, response.res);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toMatchObject({ snapshot: expect.stringContaining("Playwright") });
+    expect(cdpMocks.snapshotRoleViaCdp).toHaveBeenCalledTimes(1);
+    expect(snapshotRoleViaPlaywright).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["aria refs", { format: "ai", interactive: "true", refs: "aria" }],
+    ["selector scope", { format: "ai", selector: "button" }],
+    ["frame scope", { format: "ai", frame: "iframe" }],
+  ])("keeps %s on Playwright-first role snapshots", async (_name, query) => {
+    navigationGuardMocks.assertBrowserNavigationResultAllowed.mockResolvedValue(undefined);
+    const snapshotRoleViaPlaywright = vi.fn(async () => ({
+      snapshot: '- button "Playwright" [ref=e1]',
+      refs: { e1: { role: "button", name: "Playwright" } },
+      stats: { lines: 1, chars: 32, refs: 1, interactive: 1 },
+    }));
+    pwState.module = createPwModule({
+      snapshotRoleViaPlaywright,
+    });
+    const handler = getSnapshotGetHandler();
+    const response = createBrowserRouteResponse();
+
+    await handler?.({ params: {}, query }, response.res);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toMatchObject({ snapshot: expect.stringContaining("Playwright") });
+    expect(snapshotRoleViaPlaywright).toHaveBeenCalledTimes(1);
+    expect(cdpMocks.snapshotRoleViaCdp).not.toHaveBeenCalled();
+  });
+
+  it("stores raw ARIA refs through Playwright when it is available", async () => {
+    navigationGuardMocks.assertBrowserNavigationResultAllowed.mockResolvedValue(undefined);
+    const storeSnapshotRefsViaPlaywright = vi.fn(async () => {});
+    pwState.module = createPwModule({ storeSnapshotRefsViaPlaywright });
+    const handler = getSnapshotGetHandler();
+    const response = createBrowserRouteResponse();
+
+    await handler?.({ params: {}, query: { format: "aria", limit: "1" } }, response.res);
+
+    expect(response.statusCode).toBe(200);
+    expect(cdpMocks.snapshotAria).toHaveBeenCalledWith({
+      wsUrl: "ws://127.0.0.1/devtools/page/7",
+      lookup: tabLookup,
+      limit: 1,
+      timeoutMs: undefined,
+    });
+    expect(storeSnapshotRefsViaPlaywright).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18800",
+      targetId: "7",
+      nodes: [{ ref: "1", role: "link", name: "private", depth: 0 }],
+    });
+  });
+
+  it.each([
+    ["the default cap", {}, { maxChars: 40_000 }],
+    ["an explicit zero cap", { maxChars: "0" }, {}],
+  ])("forwards %s to Playwright AI snapshots", async (_name, query, expected) => {
+    navigationGuardMocks.assertBrowserNavigationResultAllowed.mockResolvedValue(undefined);
+    const snapshotAiViaPlaywright = vi.fn(async () => ({ snapshot: "Playwright" }));
+    pwState.module = createPwModule({ snapshotAiViaPlaywright });
+    const handler = getSnapshotGetHandler();
+    const response = createBrowserRouteResponse();
+
+    await handler?.({ params: {}, query: { format: "ai", ...query } }, response.res);
+
+    expect(response.statusCode).toBe(200);
+    expect(snapshotAiViaPlaywright).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18800",
+      targetId: "7",
+      ssrfPolicy: { dangerouslyAllowPrivateNetwork: false },
+      timeoutMs: undefined,
+      urls: undefined,
+      delta: undefined,
+      ...expected,
+    });
+  });
+
+  it("surfaces pending dialog state without reading the blocked page", async () => {
+    navigationGuardMocks.assertBrowserNavigationResultAllowed.mockResolvedValue(undefined);
+    const snapshotAiViaPlaywright = vi.fn(async () => ({ snapshot: "Playwright" }));
+    pwState.module = createPwModule({
+      getObservedBrowserStateViaPlaywright: vi.fn(async () => ({
+        dialogs: {
+          pending: [
+            {
+              id: "d1",
+              type: "confirm",
+              message: "Continue?",
+              openedAt: "2026-05-17T12:00:00.000Z",
+            },
+          ],
+          recent: [],
+        },
+      })),
+      snapshotAiViaPlaywright,
+    });
+    const handler = getSnapshotGetHandler();
+    const response = createBrowserRouteResponse();
+
+    await handler?.({ params: {}, query: { format: "ai" } }, response.res);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toMatchObject({
+      blockedByDialog: true,
+      snapshot: "",
+      browserState: {
+        dialogs: { pending: [expect.objectContaining({ id: "d1", message: "Continue?" })] },
+      },
+    });
+    expect(snapshotAiViaPlaywright).not.toHaveBeenCalled();
   });
 
   it("rejects a snapshot when the main-frame loader changes during capture", async () => {

--- a/extensions/browser/src/browser/routes/agent.snapshot.plan.test.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.plan.test.ts
@@ -50,6 +50,17 @@ describe("resolveSnapshotPlan", () => {
     expect(plan.wantsRoleSnapshot).toBe(true);
   });
 
+  it("does not treat refs=role alone as a role snapshot feature", () => {
+    const plan = resolveSnapshotPlan({
+      profile: profile("openclaw"),
+      query: { refs: "role" },
+      hasPlaywright: true,
+    });
+
+    expect(plan.refsMode).toBe("role");
+    expect(plan.wantsRoleSnapshot).toBe(false);
+  });
+
   it("parses timeoutMs from the snapshot query string", () => {
     const plan = resolveSnapshotPlan({
       profile: profile("openclaw"),

--- a/extensions/browser/src/browser/routes/agent.snapshot.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.ts
@@ -859,18 +859,17 @@ export function registerBrowserAgentSnapshotRoutes(
               delta: deltaState.delta,
             };
 
+            const cdpRoleWsUrl =
+              plan.refsMode !== "aria" && !plan.selectorValue && !plan.frameSelectorValue
+                ? tab.wsUrl
+                : null;
             let usedCdpRoleSnapshot = false;
             const cdpRoleSnapshot = async (recurseIframes = true) => {
-              if (
-                !tab.wsUrl ||
-                plan.refsMode === "aria" ||
-                plan.selectorValue ||
-                plan.frameSelectorValue
-              ) {
+              if (!cdpRoleWsUrl) {
                 return null;
               }
               const snapshot = await snapshotRoleViaCdp({
-                wsUrl: tab.wsUrl,
+                wsUrl: cdpRoleWsUrl,
                 ...(tab.wsLookup ? { lookup: tab.wsLookup } : {}),
                 urls: plan.urls,
                 recurseIframes,
@@ -888,15 +887,7 @@ export function registerBrowserAgentSnapshotRoutes(
             };
 
             const pw = pwModule;
-            const cdpFirstPw =
-              pw &&
-              plan.wantsRoleSnapshot &&
-              tab.wsUrl &&
-              plan.refsMode !== "aria" &&
-              !plan.selectorValue &&
-              !plan.frameSelectorValue
-                ? pw
-                : null;
+            const cdpFirstPw = pw && plan.wantsRoleSnapshot && cdpRoleWsUrl ? pw : null;
             const snap = plan.wantsRoleSnapshot
               ? cdpFirstPw
                 ? await cdpRoleSnapshot(false).catch(async () => {

--- a/extensions/browser/src/browser/routes/agent.snapshot.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.ts
@@ -859,17 +859,21 @@ export function registerBrowserAgentSnapshotRoutes(
               delta: deltaState.delta,
             };
 
-            const cdpRoleSnapshot = async () => {
-              if (!tab.wsUrl) {
+            let usedCdpRoleSnapshot = false;
+            const cdpRoleSnapshot = async (recurseIframes = true) => {
+              if (
+                !tab.wsUrl ||
+                plan.refsMode === "aria" ||
+                plan.selectorValue ||
+                plan.frameSelectorValue
+              ) {
                 return null;
               }
-              if (plan.selectorValue || plan.frameSelectorValue) {
-                return null;
-              }
-              return await snapshotRoleViaCdp({
+              const snapshot = await snapshotRoleViaCdp({
                 wsUrl: tab.wsUrl,
                 ...(tab.wsLookup ? { lookup: tab.wsLookup } : {}),
                 urls: plan.urls,
+                recurseIframes,
                 timeoutMs: plan.timeoutMs,
                 maxChars: plan.resolvedMaxChars,
                 options: {
@@ -879,21 +883,29 @@ export function registerBrowserAgentSnapshotRoutes(
                 },
                 delta: deltaState.delta,
               });
+              usedCdpRoleSnapshot = true;
+              return snapshot;
             };
 
-            const pw = await getPwAiModule();
+            const pw = pwModule;
+            const cdpFirstPw =
+              pw &&
+              plan.wantsRoleSnapshot &&
+              tab.wsUrl &&
+              plan.refsMode !== "aria" &&
+              !plan.selectorValue &&
+              !plan.frameSelectorValue
+                ? pw
+                : null;
             const snap = plan.wantsRoleSnapshot
-              ? pw
-                ? await pw
-                    .snapshotRoleViaPlaywright(roleSnapshotArgs)
-                    .catch(async (err: unknown) => {
-                      const fallback = await cdpRoleSnapshot();
-                      if (fallback) {
-                        return fallback;
-                      }
-                      throw err;
-                    })
-                : await cdpRoleSnapshot()
+              ? cdpFirstPw
+                ? await cdpRoleSnapshot(false).catch(async () => {
+                    signal.throwIfAborted();
+                    return await cdpFirstPw.snapshotRoleViaPlaywright(roleSnapshotArgs);
+                  })
+                : pw
+                  ? await pw.snapshotRoleViaPlaywright(roleSnapshotArgs)
+                  : await cdpRoleSnapshot()
               : pw
                 ? await pw.snapshotAiViaPlaywright({
                     cdpUrl: profileCtx.profile.cdpUrl,
@@ -910,6 +922,17 @@ export function registerBrowserAgentSnapshotRoutes(
             if (!snap) {
               await requirePwAi(res, "ai snapshot");
               return;
+            }
+            if (usedCdpRoleSnapshot && pw && "refs" in snap) {
+              await assertDocumentIdentityUnchanged();
+              await pw.storeSnapshotRefsViaPlaywright({
+                cdpUrl: profileCtx.profile.cdpUrl,
+                targetId: tab.targetId,
+                refs: snap.refs,
+                ...(initialDocumentIdentity
+                  ? { expectedDocumentIdentity: initialDocumentIdentity }
+                  : {}),
+              });
             }
             if (plan.labels) {
               if (!pw) {
@@ -1004,7 +1027,7 @@ export function registerBrowserAgentSnapshotRoutes(
             return;
           }
           if (!usePlaywrightAriaSnapshot) {
-            await pwModule?.storeAriaSnapshotRefsViaPlaywright?.({
+            await pwModule?.storeSnapshotRefsViaPlaywright?.({
               cdpUrl: profileCtx.profile.cdpUrl,
               targetId: tab.targetId,
               nodes: resolved.nodes,

--- a/extensions/browser/src/browser/server.agent-contract-core.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-core.test.ts
@@ -4,7 +4,6 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { DEFAULT_AI_SNAPSHOT_MAX_CHARS } from "./constants.js";
 import { ACT_ERROR_CODES } from "./routes/agent.act.errors.js";
 import { isActKind } from "./routes/agent.act.shared.js";
 import {
@@ -488,133 +487,16 @@ describe("browser control server", () => {
     },
     slowTimeoutMs,
   );
-  it("agent contract: snapshot endpoints", async () => {
-    const base = await startServerAndBase();
-    const realFetch = getBrowserTestFetch();
 
-    const snapAria = (await realFetch(`${base}/snapshot?format=aria&limit=1`).then((r) =>
-      r.json(),
-    )) as { ok: boolean; format?: string };
-    expect(snapAria.ok).toBe(true);
-    expect(snapAria.format).toBe("aria");
-    expect(cdpMocks.snapshotAria).toHaveBeenCalledWith({
-      wsUrl: "ws://127.0.0.1/devtools/page/abcd1234",
-      limit: 1,
-    });
-    expect(requirePwMock("storeAriaSnapshotRefsViaPlaywright")).toHaveBeenCalledWith({
-      cdpUrl: state.cdpBaseUrl,
-      targetId: "abcd1234",
-      nodes: [{ ref: "1", role: "link", name: "x", depth: 0 }],
-    });
-
-    const snapAi = (await realFetch(`${base}/snapshot?format=ai`).then((r) => r.json())) as {
-      ok: boolean;
-      format?: string;
-    };
-    expect(snapAi.ok).toBe(true);
-    expect(snapAi.format).toBe("ai");
-    expect(requirePwMock("snapshotAiViaPlaywright")).toHaveBeenCalledWith({
-      cdpUrl: state.cdpBaseUrl,
-      targetId: "abcd1234",
-      maxChars: DEFAULT_AI_SNAPSHOT_MAX_CHARS,
-      ssrfPolicy: {
-        dangerouslyAllowPrivateNetwork: true,
-      },
-    });
-
-    const snapAiZero = (await realFetch(`${base}/snapshot?format=ai&maxChars=0`).then((r) =>
-      r.json(),
-    )) as { ok: boolean; format?: string };
-    expect(snapAiZero.ok).toBe(true);
-    expect(snapAiZero.format).toBe("ai");
-    const [lastCall] = requirePwMock("snapshotAiViaPlaywright").mock.calls.at(-1) ?? [];
-    expect(lastCall).toEqual({
-      cdpUrl: state.cdpBaseUrl,
-      targetId: "abcd1234",
-      ssrfPolicy: {
-        dangerouslyAllowPrivateNetwork: true,
-      },
-    });
-
-    requirePwMock("snapshotRoleViaPlaywright").mockRejectedValueOnce(
-      new Error("playwright stale page"),
-    );
-    const fallback = (await realFetch(`${base}/snapshot?format=ai&interactive=true`).then((r) =>
-      r.json(),
-    )) as { ok: boolean; format?: string; snapshot?: string };
-    expect(fallback.ok).toBe(true);
-    expect(fallback.format).toBe("ai");
-    expect(fallback.snapshot).toContain("Fallback");
-    expect(cdpMocks.snapshotRoleViaCdp).toHaveBeenCalledWith({
-      wsUrl: "ws://127.0.0.1/devtools/page/abcd1234",
-      urls: undefined,
-      maxChars: DEFAULT_AI_SNAPSHOT_MAX_CHARS,
-      timeoutMs: undefined,
-      options: {
-        interactive: true,
-        compact: undefined,
-        maxDepth: undefined,
-      },
-    });
-  });
-
-  it("agent contract: snapshot surfaces pending dialog state without reading the blocked page", async () => {
-    const base = await startServerAndBase();
-    const realFetch = getBrowserTestFetch();
-    requirePwMock("getObservedBrowserStateViaPlaywright").mockResolvedValueOnce({
-      dialogs: {
-        pending: [
-          {
-            id: "d1",
-            type: "confirm",
-            message: "Continue?",
-            openedAt: "2026-05-17T12:00:00.000Z",
-          },
-        ],
-        recent: [],
-      },
-    });
-
-    const snap = (await realFetch(`${base}/snapshot?format=ai`).then((r) => r.json())) as {
-      ok: boolean;
-      blockedByDialog?: boolean;
-      browserState?: { dialogs?: { pending?: Array<{ id?: string; message?: string }> } };
-      snapshot?: string;
-    };
-
-    expect(snap.ok).toBe(true);
-    expect(snap.blockedByDialog).toBe(true);
-    expect(snap.snapshot).toBe("");
-    expect(snap.browserState?.dialogs?.pending?.[0]).toMatchObject({
-      id: "d1",
-      message: "Continue?",
-    });
-    expect(requirePwMock("snapshotAiViaPlaywright")).not.toHaveBeenCalled();
-  });
-
-  it("agent contract: snapshot blocks pending dialog state on disallowed current tab URLs", async () => {
+  it("blocks disallowed snapshot tabs before reading Playwright browser state", async () => {
     setBrowserControlServerSsrFPolicy({ allowPrivateNetwork: false });
     setBrowserControlServerTabUrl("http://127.0.0.1:8080/admin");
-    const base = await startServerAndBase();
-    const realFetch = getBrowserTestFetch();
-    requirePwMock("getObservedBrowserStateViaPlaywright").mockResolvedValueOnce({
-      dialogs: {
-        pending: [
-          {
-            id: "d1",
-            type: "alert",
-            message: "blocked secret",
-            openedAt: "2026-05-17T12:00:00.000Z",
-          },
-        ],
-        recent: [],
-      },
-    });
+    const response = await getBrowserTestFetch()(
+      `${await startServerAndBase()}/snapshot?format=ai`,
+    );
 
-    const res = await realFetch(`${base}/snapshot?format=ai`);
-    expect(res.status).toBe(400);
-    const body = (await res.json()) as { error?: unknown };
-    expect(body.error).toBe(BROWSER_NAVIGATION_BLOCKED_MESSAGE);
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: BROWSER_NAVIGATION_BLOCKED_MESSAGE });
     expect(requirePwMock("getObservedBrowserStateViaPlaywright")).not.toHaveBeenCalled();
     expect(requirePwMock("snapshotAiViaPlaywright")).not.toHaveBeenCalled();
   });

--- a/extensions/browser/src/browser/server.control-server.test-harness.ts
+++ b/extensions/browser/src/browser/server.control-server.test-harness.ts
@@ -242,7 +242,7 @@ const pwMocks = vi.hoisted(() => {
       stats: { lines: 1, chars: 24, refs: 1, interactive: 1 },
     })),
     storageGetViaPlaywright: vi.fn(async () => ({ values: {} })),
-    storeAriaSnapshotRefsViaPlaywright: vi.fn(async () => {}),
+    storeSnapshotRefsViaPlaywright: vi.fn(async () => {}),
     traceStartViaPlaywright: vi.fn(async () => {}),
     traceStopViaPlaywright: vi.fn(async (opts: { path: string }) => opts.path),
     takeScreenshotViaPlaywright: vi.fn(async () => ({


### PR DESCRIPTION
## Summary

- run unscoped managed role snapshots through CDP before Playwright when the request actually asks for role-snapshot features
- publish finalized CDP refs into the Playwright target cache after document revalidation and backend DOM marking
- preserve duplicate `nth` metadata, resolve `domMarker` for both `eN` and `axN`, and disable iframe recursion only on the new fast path

Fixes #133514

## Root cause

The managed snapshot route selected Playwright before CDP. A stalled Playwright role snapshot could therefore consume the request deadline before the existing CDP fallback ran. CDP refs also were not published through the Playwright action cache, so switching the order alone would have returned refs that later actions could not reliably resolve.

The exact-head review also found that the CDP producer omitted `nth` from the first member of a duplicate role/name group. When backend marker publication failed, that first ref fell back to an unqualified `getByRole` locator and strictness-failed.

The route is the ordering owner, CDP snapshot construction is the duplicate-index owner, and Playwright snapshot storage is the ref-publication owner.

## Behavior

CDP-first is limited to requests where all of these are true:

- `plan.wantsRoleSnapshot`
- `refsMode !== "aria"`
- Playwright is available
- the tab has a CDP WebSocket URL
- there is no selector or frame scope

`refs=role` alone is not a trigger. On an early CDP error, the route checks cancellation and falls back to Playwright once. Fallback is not guaranteed after CDP consumes the full request deadline; this change does not partition or extend the budget.

ARIA, selector-scoped, and frame-scoped requests remain Playwright-first. Recursive actionable CDP iframe refs remain out of scope.

Duplicate CDP role/name groups now publish `nth: 0` for the first ref and the later zero-based indexes for siblings. Singleton refs still omit `nth`.

## Validation

- pre-fix original focused reproduction: 6 expected failures across ordering, marker resolution, publication, and iframe recursion
- pre-fix duplicate regression: real Chromium failed because `e1` matched both same-name buttons after its backend marker write was rejected
- focused browser tests: 159 passed
- full Browser plugin suite: 3,495 passed, 26 skipped
- real Chromium snapshot-to-action suite: 3 passed; both duplicate native refs act after marker publication failure, and the cursor-only control remains actionable through its marker
- changed-file guards: formatting, boundaries, dead exports, dependency pins, assertions, and related guards passed; local aggregate extension typecheck reached an unrelated stale shared grammY install mismatch
- exact lint regression from the first review-fix head was reproduced locally and repaired in test code
- autoreview: no actionable findings, confidence 0.99
- test-audit: producer metadata is covered by a normal unit test and marker-failure actionability by the real Chromium boundary without a test-only production seam
- exact-head CI: 57 successful, 43 skipped, 0 failed or pending on `34ad2663ddce62b07aff12066f56b7e4256482c8` ([run 33342515329](https://github.com/openclaw/openclaw/actions/runs/33342515329))

## Scope

- production: +82 / -42, net +40
- tests and test support: +452 / -135, net +317
- removed the oversized snapshot omnibus from the general server contract test and moved its focused route coverage to `agent.snapshot.local-managed.test.ts`
- no config, schema, protocol, dependency, planning-contract, or changelog changes
