### PR TITLE
fix(tts): keep internal reasoning out of spoken summaries

### DIFF
--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -8,7 +8,7 @@ import {
   type ModelRef,
 } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/types.js";
-import type { TextContent } from "../llm/types.js";
+import { sanitizeAssistantVisibleText } from "../shared/text/assistant-visible-text.js";
 import type { ResolvedTtsConfig } from "./tts-types.js";
 export {
   normalizeApplyTextNormalization,
@@ -75,10 +75,6 @@ function resolveSummaryModelRef(
   return { ref: resolved.ref, source: "summaryModel" };
 }
 
-function isTextContentBlock(block: { type: string }): block is TextContent {
-  return block.type === "text";
-}
-
 /** Summarize long text before synthesis using the configured summary model. */
 export async function summarizeText(
   params: {
@@ -139,15 +135,18 @@ export async function summarizeText(
         options: {
           maxTokens: Math.ceil(targetLength / 2),
           temperature: 0.3,
+          // Summary text is spoken; never recover incomplete reasoning as visible prose.
+          strictReasoningTags: true,
           signal: controller.signal,
         },
       });
-      const summary = res.content
-        .filter(isTextContentBlock)
-        .map((block) => block.text.trim())
-        .filter(Boolean)
-        .join(" ")
-        .trim();
+      const summary = sanitizeAssistantVisibleText(
+        res.content
+          .filter((block) => block.type === "text")
+          .map((block) => block.text.trim())
+          .filter(Boolean)
+          .join(" "),
+      );
 
       if (!summary) {
         throw new Error("No summary returned");

--- a/src/tts/tts-summary.test.ts
+++ b/src/tts/tts-summary.test.ts
@@ -1,0 +1,220 @@
+import { randomUUID } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { processCompletionsStream } from "../../packages/ai/src/transports/openai-completions-stream.js";
+import type { AssistantMessage, Model } from "../llm/types.js";
+import { summarizeText } from "./tts-core.js";
+import {
+  clearRuntimeConfigSnapshot,
+  createMockSpeechProvider,
+  createTtsConfig,
+  installSpeechProviders,
+  maybeApplyTtsToPayloadCore,
+  prepareSynthesisMock,
+  resolveTtsConfig,
+  setTtsMachinePrefsPathResolver,
+  synthesizeMock,
+  textToSpeechCore,
+  type OpenClawConfig,
+} from "./tts-runtime.test-support.js";
+
+type Completion =
+  typeof import("../agents/simple-completion-runtime.js").completeWithPreparedSimpleCompletionModel;
+const completion = vi.hoisted(() => ({
+  complete: vi.fn<Completion>(),
+  prepare: vi.fn(),
+}));
+
+vi.mock("../agents/simple-completion-runtime.js", () => ({
+  completeWithPreparedSimpleCompletionModel: completion.complete,
+  prepareSimpleCompletionModel: completion.prepare,
+}));
+
+const model = {
+  id: "test-summary",
+  name: "Test summary",
+  provider: "test-provider",
+  api: "openai-completions",
+  baseUrl: "https://summary.example.test/v1",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 4096,
+  maxTokens: 1024,
+} satisfies Model<"openai-completions">;
+
+function assistant(content: AssistantMessage["content"]): AssistantMessage {
+  return {
+    role: "assistant",
+    content,
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 0,
+  };
+}
+
+const originalText = "The original reply remains visible. ".repeat(60);
+const persistAudio = vi.fn(async () => "/tmp/synthetic-summary.ogg");
+let cfg: OpenClawConfig;
+
+beforeEach(() => {
+  cfg = {
+    ...createTtsConfig(`openclaw-tts-summary-${randomUUID()}`),
+    agents: { defaults: { model: { primary: "test-provider/test-summary" } } },
+    tts: { auto: "always", provider: "mock", summaryModel: "test-provider/test-summary" },
+  };
+  installSpeechProviders([createMockSpeechProvider()]);
+  completion.complete.mockReset();
+  completion.prepare.mockReturnValue({
+    model,
+    auth: { apiKey: "synthetic-test-key", source: "test", mode: "api-key" },
+  });
+  synthesizeMock.mockClear();
+  prepareSynthesisMock.mockClear();
+  persistAudio.mockClear();
+});
+
+afterEach(() => {
+  setTtsMachinePrefsPathResolver();
+  clearRuntimeConfigSnapshot();
+});
+
+function summarize() {
+  return summarizeText({
+    text: originalText,
+    targetLength: 120,
+    cfg,
+    config: resolveTtsConfig(cfg),
+    timeoutMs: 1000,
+  });
+}
+
+function applySummaryToSpeech() {
+  return maybeApplyTtsToPayloadCore(
+    { payload: { text: originalText }, cfg, channel: "telegram", kind: "final" },
+    persistAudio,
+  );
+}
+
+describe("TTS summary visible text", () => {
+  it.each([
+    {
+      name: "reasoning split across text blocks",
+      content: [
+        { type: "thinking", thinking: "Separate private reasoning" },
+        { type: "text", text: "<think>Hidden reasoning" },
+        { type: "text", text: "continues</think>Spoken summary." },
+      ],
+      expected: "Spoken summary.",
+    },
+    {
+      name: "tool scaffolding and model control tokens",
+      content: [
+        {
+          type: "text",
+          text: '<tool_call>{"name":"private_tool"}</tool_call><|im_end|>Spoken summary.',
+        },
+      ],
+      expected: "Spoken summary.",
+    },
+    {
+      name: "ordinary prose and quoted tag examples",
+      content: [
+        { type: "text", text: "The narrator says: use `<think>example</think>` literally." },
+      ],
+      expected: "The narrator says: use `<think>example</think>` literally.",
+    },
+  ] satisfies Array<{ name: string; content: AssistantMessage["content"]; expected: string }>)(
+    "returns only visible summary text: $name",
+    async ({ content, expected }) => {
+      completion.complete.mockResolvedValue(assistant(content));
+      const result = await summarize();
+      expect(result.summary).toBe(expected);
+      expect(result.outputLength).toBe(expected.length);
+      expect(result.inputLength).toBe(originalText.length);
+    },
+  );
+
+  it("rejects summary text that sanitizes to empty", async () => {
+    completion.complete.mockResolvedValue(
+      assistant([{ type: "text", text: "<think>Private only</think>" }]),
+    );
+    await expect(summarize()).rejects.toThrow("No summary returned");
+  });
+
+  it("does not recover unterminated reasoning as summary text at the transport boundary", async () => {
+    completion.complete.mockImplementation(async ({ options }) => {
+      const output = assistant([]);
+      async function* chunks() {
+        yield {
+          id: "summary-chunk",
+          object: "chat.completion.chunk" as const,
+          created: 0,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: { content: "<think>Private reasoning without a close tag" },
+              finish_reason: "stop" as const,
+              logprobs: null,
+            },
+          ],
+        };
+      }
+      await processCompletionsStream(
+        chunks(),
+        output,
+        model,
+        { push() {} },
+        {
+          strictReasoningTags: options?.strictReasoningTags,
+        },
+      );
+      return output;
+    });
+    await expect(summarize()).rejects.toThrow("No summary returned");
+  });
+
+  it("hands the sanitized summary to synthesis while preserving the visible original reply", async () => {
+    completion.complete.mockResolvedValue(
+      assistant([{ type: "text", text: "<think>Private reasoning</think>Spoken summary." }]),
+    );
+    const result = await applySummaryToSpeech();
+    expect(synthesizeMock).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ text: "Spoken summary." }),
+    );
+    expect(result).toMatchObject({
+      text: originalText,
+      spokenText: "Spoken summary.",
+      mediaUrl: "/tmp/synthetic-summary.ogg",
+    });
+  });
+
+  it("keeps the existing original-text fallback when the summary has no visible content", async () => {
+    completion.complete.mockResolvedValue(
+      assistant([{ type: "text", text: "<think>Private only</think>" }]),
+    );
+    const result = await applySummaryToSpeech();
+    expect(synthesizeMock).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ text: `${originalText.slice(0, 1497)}...` }),
+    );
+    expect(result.text).toBe(originalText);
+  });
+
+  it("does not sanitize explicitly requested TTS text as model-generated summary output", async () => {
+    const text = "Say the literal marker <think>example</think> out loud.";
+    const result = await textToSpeechCore({ text, cfg, channel: "telegram" }, persistAudio);
+    expect(result.success).toBe(true);
+    expect(synthesizeMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ text }));
+    expect(completion.complete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #90364.

## What Problem This Solves

Fixes an issue where long auto-TTS replies could speak the summary model's tagged internal reasoning or tool scaffolding along with its answer. An unfinished reasoning block could also be recovered as ordinary text before the speech pipeline saw it.

## Why This Change Was Made

The summary producer requests the existing strict reasoning parser and applies the canonical assistant-visible text sanitizer after assembling text blocks. This keeps reasoning provenance intact until it can be excluded. The redundant local text-block predicate is removed. There is no new sanitizer, provider special case, configuration option, or heuristic for guessing which ordinary prose is reasoning.

Production: +10/-11 (net -1). Tests: +220. The existing original-reply truncation fallback still handles summaries with no visible content. Direct, explicitly requested TTS remains unchanged. Existing auto-TTS documentation already describes summary synthesis and the failure fallback; this restores that contract.

Provenance: raw-parent inspection of ea90866916b shows the raw text assembly was carried forward during the completion transport move, not introduced there. Original introduction remains unverified.

## User Impact

Reasoning tags, separate thinking blocks, and internal tool scaffolding no longer become spoken summary text. Ordinary prose and quoted tag examples remain intact. The original visible reply is preserved.

## Evidence

- Regression-first proof: six intended failures and two preservation passes on unchanged production. The repaired candidate passes 52 tests across `src/tts/tts-summary.test.ts`, `src/tts/tts-core.test.ts`, and `src/tts/tts-runtime-fallbacks.test.ts`.
- Coverage exercises the real completion-stream parser, automatic payload-to-synthesis handoff, empty-summary fallback, and explicit TTS preservation.
- Real Microsoft network synthesis succeeded after an injected synthetic completion passed through the actual summary producer. The provider received only: “This is a public speech integration check. Only this sentence should be spoken.” It returned 34,848 audio bytes (SHA-256 `d2b1cd593f0ec5d8a86adcf391aa993e936a857300760f78dcd43ca526c70004`). The probe used the bundled plugin's public entry and normal synthesis implementation in isolated temporary state; it sent no user messages and used no provider credential.
- Limits: the summary response was synthetic; no live summarization-model request or channel delivery was performed. Audio was checked for successful nonempty output, not transcribed. An earlier uninstrumented probe timed out at an unknown phase; the instrumented provider-boundary probe subsequently passed.
- Type-aware lint, formatting, and fresh independent Codex review pass with no actionable P0–P2 findings. The full changed gate passed, including types, lint, and architecture checks. Exact-head hosted CI remains the final landing gate.

## Review Follow-through

The latest ClawSweeper review found no correctness issue. Its Telegram Test Server rank-up move was checked but could not run: this host has neither an authenticated Convex CLI nor the broker credential pair required by the canonical E2E skill. No credential lease or Telegram message was attempted, and no runtime login/install was used to bypass that prerequisite. This remains a channel-observation gap; the completed proof exercises the repaired summary producer and actual Microsoft synthesis, with limits stated above.
