### PR TITLE
perf(qa): run isolated live transports with bounded concurrency

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -979,7 +979,6 @@ extensions/qa-lab/src/bus-state.ts	2
 extensions/qa-lab/src/character-eval.ts	2
 extensions/qa-lab/src/ci-smoke-plan.ts	1
 extensions/qa-lab/src/cli.runtime.ts	9
-extensions/qa-lab/src/cli.ts	1
 extensions/qa-lab/src/codex-plugin.fixture.ts	2
 extensions/qa-lab/src/confidence-report.ts	2
 extensions/qa-lab/src/crabline-transport.ts	6

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -275,6 +275,8 @@ manual runs execute the catalog-derived selection in one job with up to four
 isolated host workers. Each worker owns its disposable homeserver, Gateway,
 state, and artifacts. Scenario membership stays catalog-owned; `--fail-fast`
 keeps execution serial and stops after the first failure.
+Use `openclaw qa matrix --concurrency <count>` to request fewer workers;
+values above the transport limit stay capped.
 
 ### Discord Mantis scenarios
 

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -216,8 +216,8 @@ Matrix live implementations live under
 
 The adapter provisions a disposable Tuwunel homeserver in Docker (default image
 `ghcr.io/matrix-construct/tuwunel:v1.8.3`, pinned to its multi-architecture OCI
-index digest; server name `matrix-qa.test`, port `28008`), registers temporary
-driver, SUT, and observer users, seeds the required rooms, and records the
+index digest; server name `matrix-qa.test`, Docker-assigned host port), registers
+temporary driver, SUT, and observer users, seeds the required rooms, and records the
 redacted request/response boundary. It then runs the real Matrix plugin inside
 a child QA gateway scoped to that transport (no `qa-channel`) and tears the
 environment down.
@@ -271,8 +271,10 @@ gateway replies.
 
 CI uses the same command surface in
 `.github/workflows/qa-live-transports-convex.yml`. Scheduled, release, and
-manual runs fan the catalog-derived selection across five deterministic shards
-so membership stays scenario-owned while each job remains within its timeout.
+manual runs execute the catalog-derived selection in one job with up to four
+isolated host workers. Each worker owns its disposable homeserver, Gateway,
+state, and artifacts. Scenario membership stays catalog-owned; `--fail-fast`
+keeps execution serial and stops after the first failure.
 
 ### Discord Mantis scenarios
 

--- a/docs/plugins/dependency-resolution.md
+++ b/docs/plugins/dependency-resolution.md
@@ -125,6 +125,17 @@ stages a separate package directory without source `node_modules`, and runs a
 script-free npm install there for runtime dependencies. It then packs or publishes
 the plugin tarball with those dependency files included and removes the staging
 directory. The pnpm-owned source dependency tree stays unchanged.
+
+When a direct runtime dependency has an approved workspace patch for its exact version, npm and
+ClawHub packaging include that dependency from the matching frozen pnpm
+install. Packaging verifies the installed patch identity and packs its bytes
+into the temporary dependency install, then restores the original public
+version specifier in the published manifest. This also applies when bundling
+all runtime dependencies is disabled; unrelated dependencies retain their
+normal install behavior. A stale source install or an explicit
+`bundleRuntimeDependencies: false` opt-out stops packaging rather than
+publishing an unpatched dependency.
+
 Native-heavy packages (Codex, ACPX, Copilot, llama.cpp,
 memory-lancedb, Microsoft Teams, Tlon) opt out with
 `openclaw.release.bundleRuntimeDependencies: false`; they still ship a

--- a/extensions/matrix/src/matrix/client/file-sync-store.sdk.test.ts
+++ b/extensions/matrix/src/matrix/client/file-sync-store.sdk.test.ts
@@ -19,8 +19,12 @@ function verificationSync(nextBatch: string, eventId: string): ISyncResponse {
   return {
     next_batch: nextBatch,
     rooms: {
+      invite: {},
+      leave: {},
+      knock: {},
       join: {
         [roomId]: {
+          summary: { "m.heroes": [] },
           state: { events: [] },
           timeline: {
             prev_batch: "pagination-cursor",
@@ -86,7 +90,9 @@ describe("Matrix SDK sync-cache verification routing", () => {
       await expect(store.getSavedSyncToken()).resolves.toBe(hasCache ? "saved-cursor" : null);
 
       const cachedPrepared = createDeferred<void>();
-      if (!hasCache) cachedPrepared.resolve();
+      if (!hasCache) {
+        cachedPrepared.resolve();
+      }
       const stopped = createDeferred<void>();
       const failed = createDeferred<never>();
       const completed = Promise.race([stopped.promise, failed.promise]);
@@ -97,10 +103,15 @@ describe("Matrix SDK sync-cache verification routing", () => {
         const url = new URL(input instanceof Request ? input.url : String(input));
         expect(url.origin).toBe("https://example.org");
         const endpoint = url.pathname;
-        if (endpoint === "/.well-known/matrix/client") return Response.json({}, { status: 404 });
-        if (endpoint.endsWith("/versions"))
+        if (endpoint === "/.well-known/matrix/client") {
+          return Response.json({}, { status: 404 });
+        }
+        if (endpoint.endsWith("/versions")) {
           return Response.json({ versions: ["v1.11"], unstable_features: {} });
-        if (endpoint.endsWith("/capabilities")) return Response.json({ capabilities: {} });
+        }
+        if (endpoint.endsWith("/capabilities")) {
+          return Response.json({ capabilities: {} });
+        }
         if (endpoint.endsWith("/rtc/transports") || endpoint.endsWith("/room_keys/version")) {
           return Response.json(
             { errcode: "M_NOT_FOUND", error: "Not configured" },
@@ -112,11 +123,15 @@ describe("Matrix SDK sync-cache verification routing", () => {
             global: { override: [], content: [], room: [], sender: [], underride: [] },
           });
         }
-        if (endpoint.endsWith("/filter")) return Response.json({ filter_id: "fixture-filter" });
-        if (endpoint.endsWith("/keys/upload"))
+        if (endpoint.endsWith("/filter")) {
+          return Response.json({ filter_id: "fixture-filter" });
+        }
+        if (endpoint.endsWith("/keys/upload")) {
           return Response.json({ one_time_key_counts: { signed_curve25519: 100 } });
-        if (endpoint.endsWith("/keys/query"))
+        }
+        if (endpoint.endsWith("/keys/query")) {
           return Response.json({ device_keys: {}, failures: {} });
+        }
         if (endpoint.endsWith("/sync")) {
           syncRequests.push(url.searchParams.get("since"));
           await cachedPrepared.promise;
@@ -145,9 +160,15 @@ describe("Matrix SDK sync-cache verification routing", () => {
       client.on(ClientEvent.Event, (event) => events.push(event.getId()));
       client.on(ClientEvent.SyncUnexpectedError, (error) => failed.reject(error));
       client.on(ClientEvent.Sync, (state, _previous, data) => {
-        if (state === SyncState.Prepared && data?.fromCache) cachedPrepared.resolve();
-        if (state === SyncState.Syncing) client.stopClient();
-        if (state === SyncState.Stopped) stopped.resolve();
+        if (state === SyncState.Prepared && data?.fromCache) {
+          cachedPrepared.resolve();
+        }
+        if (state === SyncState.Syncing) {
+          client.stopClient();
+        }
+        if (state === SyncState.Stopped) {
+          stopped.resolve();
+        }
       });
       let started = false;
       try {
@@ -169,7 +190,9 @@ describe("Matrix SDK sync-cache verification routing", () => {
         expect(cryptoInput.mock.calls.map(([event]) => event.getId())).toEqual([liveEventId]);
       } finally {
         client.stopClient();
-        if (started) await stopped.promise;
+        if (started) {
+          await stopped.promise;
+        }
         await store.flush();
       }
     },

--- a/extensions/matrix/src/matrix/client/file-sync-store.sdk.test.ts
+++ b/extensions/matrix/src/matrix/client/file-sync-store.sdk.test.ts
@@ -1,0 +1,177 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { ClientEvent, createClient, type ISyncResponse } from "matrix-js-sdk/lib/matrix.js";
+import { RustCrypto } from "matrix-js-sdk/lib/rust-crypto/rust-crypto.js";
+import { SyncState } from "matrix-js-sdk/lib/sync.js";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installMatrixTestRuntime } from "../../test-runtime.js";
+import { SqliteBackedMatrixSyncStore } from "./file-sync-store.js";
+
+const userId = "@recipient:example.org";
+const roomId = "!verification:example.org";
+const cachedEventId = "$completed-verification";
+const liveEventId = "$fresh-verification";
+
+function verificationSync(nextBatch: string, eventId: string): ISyncResponse {
+  return {
+    next_batch: nextBatch,
+    rooms: {
+      join: {
+        [roomId]: {
+          state: { events: [] },
+          timeline: {
+            prev_batch: "pagination-cursor",
+            events: [
+              {
+                event_id: eventId,
+                sender: "@sender:example.org",
+                origin_server_ts: 1,
+                type: "m.room.message",
+                content: {
+                  msgtype: "m.key.verification.request",
+                  body: "Verification request",
+                  to: userId,
+                  from_device: "SENDER",
+                  methods: ["m.sas.v1"],
+                },
+              },
+            ],
+          },
+          ephemeral: { events: [] },
+          account_data: { events: [] },
+          unread_notifications: {},
+        },
+      },
+    },
+    account_data: { events: [] },
+  };
+}
+
+describe("Matrix SDK sync-cache verification routing", () => {
+  let storageRoot: string;
+
+  beforeEach(() => {
+    resetPluginStateStoreForTests();
+    installMatrixTestRuntime();
+    storageRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-sync-sdk-"));
+    // SDK HTTP deadlines leave timers after completed requests. Advance them only
+    // after the real sync loop stops, without delaying this contract test by 80s.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  });
+
+  afterEach(async () => {
+    await vi.runOnlyPendingTimersAsync();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    resetPluginStateStoreForTests();
+    fs.rmSync(storageRoot, { recursive: true, force: true });
+  });
+
+  it.each([false, true])(
+    "routes only fresh verification events to crypto (saved sync: %s)",
+    async (hasCache) => {
+      if (hasCache) {
+        const seed = new SqliteBackedMatrixSyncStore(storageRoot);
+        await seed.setSyncData(verificationSync("saved-cursor", cachedEventId));
+        seed.markCleanShutdown();
+        await seed.flush();
+        resetPluginStateStoreForTests();
+      }
+      const store = new SqliteBackedMatrixSyncStore(storageRoot);
+      expect(store.hasSavedSyncFromCleanShutdown()).toBe(hasCache);
+      await expect(store.getSavedSyncToken()).resolves.toBe(hasCache ? "saved-cursor" : null);
+
+      const cachedPrepared = createDeferred<void>();
+      if (!hasCache) cachedPrepared.resolve();
+      const stopped = createDeferred<void>();
+      const failed = createDeferred<never>();
+      const completed = Promise.race([stopped.promise, failed.promise]);
+      const events: Array<string | undefined> = [];
+      const syncRequests: Array<string | null> = [];
+      const unexpectedRequests: string[] = [];
+      const fetchFixture: typeof fetch = async (input) => {
+        const url = new URL(input instanceof Request ? input.url : String(input));
+        expect(url.origin).toBe("https://example.org");
+        const endpoint = url.pathname;
+        if (endpoint === "/.well-known/matrix/client") return Response.json({}, { status: 404 });
+        if (endpoint.endsWith("/versions"))
+          return Response.json({ versions: ["v1.11"], unstable_features: {} });
+        if (endpoint.endsWith("/capabilities")) return Response.json({ capabilities: {} });
+        if (endpoint.endsWith("/rtc/transports") || endpoint.endsWith("/room_keys/version")) {
+          return Response.json(
+            { errcode: "M_NOT_FOUND", error: "Not configured" },
+            { status: 404 },
+          );
+        }
+        if (endpoint.endsWith("/pushrules/")) {
+          return Response.json({
+            global: { override: [], content: [], room: [], sender: [], underride: [] },
+          });
+        }
+        if (endpoint.endsWith("/filter")) return Response.json({ filter_id: "fixture-filter" });
+        if (endpoint.endsWith("/keys/upload"))
+          return Response.json({ one_time_key_counts: { signed_curve25519: 100 } });
+        if (endpoint.endsWith("/keys/query"))
+          return Response.json({ device_keys: {}, failures: {} });
+        if (endpoint.endsWith("/sync")) {
+          syncRequests.push(url.searchParams.get("since"));
+          await cachedPrepared.promise;
+          return Response.json(verificationSync("fresh-cursor", liveEventId));
+        }
+        unexpectedRequests.push(endpoint);
+        const error = new Error(`Unexpected fixture request: ${endpoint}`);
+        failed.reject(error);
+        throw error;
+      };
+      // AutoDiscovery uses global fetch independently of the client fetch option.
+      vi.stubGlobal("fetch", fetchFixture);
+      const client = createClient({
+        baseUrl: "https://example.org",
+        userId,
+        deviceId: "RECIPIENT",
+        accessToken: "test-token",
+        fetchFn: fetchFixture,
+        store,
+      });
+      // Keep real client, Rust initialization and sync wiring; observe only the
+      // verification boundary so the test does not invent peer crypto responses.
+      const cryptoInput = vi
+        .spyOn(RustCrypto.prototype, "onLiveEventFromSync")
+        .mockResolvedValue(undefined);
+      client.on(ClientEvent.Event, (event) => events.push(event.getId()));
+      client.on(ClientEvent.SyncUnexpectedError, (error) => failed.reject(error));
+      client.on(ClientEvent.Sync, (state, _previous, data) => {
+        if (state === SyncState.Prepared && data?.fromCache) cachedPrepared.resolve();
+        if (state === SyncState.Syncing) client.stopClient();
+        if (state === SyncState.Stopped) stopped.resolve();
+      });
+      let started = false;
+      try {
+        await client.initRustCrypto({ useIndexedDB: false });
+        await client.startClient();
+        started = true;
+        await completed;
+        expect(unexpectedRequests).toEqual([]);
+        expect(syncRequests).toEqual([hasCache ? "saved-cursor" : null]);
+        expect(events).toEqual(hasCache ? [cachedEventId, liveEventId] : [liveEventId]);
+        expect(
+          client
+            .getRoom(roomId)
+            ?.getLiveTimeline()
+            .getEvents()
+            .map((event) => event.getId()),
+        ).toEqual(events);
+        expect(store.getSyncToken()).toBe("fresh-cursor");
+        expect(cryptoInput.mock.calls.map(([event]) => event.getId())).toEqual([liveEventId]);
+      } finally {
+        client.stopClient();
+        if (started) await stopped.promise;
+        await store.flush();
+      }
+    },
+  );
+});

--- a/extensions/matrix/test-api.ts
+++ b/extensions/matrix/test-api.ts
@@ -1,5 +1,4 @@
 // Matrix API module exposes the plugin public contract.
-export { matrixPlugin } from "./src/channel.js";
 export { MatrixClient } from "./src/matrix/sdk.js";
 export {
   openMatrixIdbSnapshotStoreOptions,

--- a/extensions/qa-lab/src/cli-options.ts
+++ b/extensions/qa-lab/src/cli-options.ts
@@ -1,4 +1,22 @@
 // Qa Lab plugin module implements cli options behavior.
+import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
+
+export function invalidQaCliArgument(message: string): Error & { code: string; exitCode: number } {
+  return Object.assign(new Error(message), {
+    name: "InvalidArgumentError",
+    code: "commander.invalidArgument",
+    exitCode: 1,
+  });
+}
+
+export function parseQaCliPositiveIntegerOption(value: string, flag: string): number {
+  const parsed = parseStrictPositiveInteger(value);
+  if (parsed === undefined) {
+    throw invalidQaCliArgument(`${flag} must be a positive integer.`);
+  }
+  return parsed;
+}
+
 export function collectString(value: string, previous: string[]) {
   const trimmed = value.trim();
   return trimmed ? [...previous, trimmed] : previous;

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -1132,30 +1132,51 @@ describe("qa cli runtime", () => {
     });
   });
 
-  it("runs canonical scenarios through a discovered live adapter factory", async () => {
-    await runQaSuiteCommand({
-      repoRoot: "/tmp/openclaw-repo",
-      outputDir: ".artifacts/qa/telegram-live",
-      channelDriver: "live",
-      channel: "telegram",
-      providerMode: "mock-openai",
-      scenarioIds: ["channel-chat-baseline"],
-    });
-
-    expect(runQaSuite).toHaveBeenCalledWith(
-      expect.objectContaining({
-        adapterFactories: listLiveTransportQaAdapterFactories.mock.results[0]?.value,
+  it.each([
+    { isolatesInstances: undefined, requested: undefined, expected: 1 },
+    { isolatesInstances: undefined, requested: 8, expected: 1 },
+    { isolatesInstances: true, requested: undefined, expected: 4 },
+    { isolatesInstances: true, requested: 1, expected: 1 },
+    { isolatesInstances: true, requested: 2, expected: 2 },
+    { isolatesInstances: true, requested: 8, expected: 4 },
+  ])(
+    "runs discovered live adapters with isolation=$isolatesInstances, concurrency=$requested at $expected workers",
+    async ({ isolatesInstances, requested, expected }) => {
+      vi.stubEnv("OPENCLAW_QA_SUITE_CONCURRENCY", "64");
+      listLiveTransportQaAdapterFactories.mockReturnValue([
+        {
+          id: "telegram",
+          isolatesInstances,
+          matches: ({ channelId, driver }: { channelId: string; driver: string }) =>
+            channelId === "telegram" && driver === "live",
+          create: vi.fn(),
+        },
+      ]);
+      await runQaSuiteCommand({
+        repoRoot: "/tmp/openclaw-repo",
+        outputDir: ".artifacts/qa/telegram-live",
         channelDriver: "live",
-        channelId: "telegram",
-        concurrency: 1,
-        adapterOptions: expect.objectContaining({
-          explicitScenarioSelection: true,
-          repoRoot: path.resolve("/tmp/openclaw-repo"),
-        }),
+        channel: "telegram",
+        concurrency: requested,
+        providerMode: "mock-openai",
         scenarioIds: ["channel-chat-baseline"],
-      }),
-    );
-  });
+      });
+
+      expect(runQaSuite).toHaveBeenCalledWith(
+        expect.objectContaining({
+          adapterFactories: listLiveTransportQaAdapterFactories.mock.results[0]?.value,
+          channelDriver: "live",
+          channelId: "telegram",
+          concurrency: expected,
+          adapterOptions: expect.objectContaining({
+            explicitScenarioSelection: true,
+            repoRoot: path.resolve("/tmp/openclaw-repo"),
+          }),
+          scenarioIds: ["channel-chat-baseline"],
+        }),
+      );
+    },
+  );
 
   it("dispatches one declared-channel scenario through either driver", async () => {
     for (const channelDriver of ["crabline", "live"] as const) {

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -69,6 +69,7 @@ import {
 } from "./qa-credentials-admin.runtime.js";
 import { normalizeQaThinkingLevel, type QaThinkingLevel } from "./qa-gateway-config.js";
 import {
+  defaultQaSuiteConcurrencyForTransport,
   normalizeQaTransportId,
   qaTransportSupportsModuleFlows,
   type QaTransportId,
@@ -1028,6 +1029,12 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
     return undefined;
   }
   const thinkingDefault = parseQaThinkingLevel("--thinking", opts.thinking);
+  // Only isolated live adapters may share the host budget; keep disposable
+  // servers bounded even when a caller requests a larger suite concurrency.
+  const liveConcurrencyLimit =
+    liveAdapterFactory?.isolatesInstances === true
+      ? defaultQaSuiteConcurrencyForTransport(transportId)
+      : undefined;
   const runtimeResult = await runQaSuite({
     repoRoot,
     outputDir: resolveRepoRelativeOutputDir(repoRoot, opts.outputDir),
@@ -1061,7 +1068,16 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
     scenarioIds: liveChannelId ? scenarioIds : hostScenarioIds,
     ...(opts.enabledPluginIds !== undefined ? { enabledPluginIds: opts.enabledPluginIds } : {}),
     ...(liveChannelId
-      ? { concurrency: 1 }
+      ? {
+          concurrency:
+            liveConcurrencyLimit === undefined
+              ? 1
+              : Math.min(
+                  liveConcurrencyLimit,
+                  parseQaPositiveIntegerOption("--concurrency", opts.concurrency) ??
+                    liveConcurrencyLimit,
+                ),
+        }
       : opts.concurrency !== undefined
         ? { concurrency: parseQaPositiveIntegerOption("--concurrency", opts.concurrency) }
         : {}),

--- a/extensions/qa-lab/src/cli.ts
+++ b/extensions/qa-lab/src/cli.ts
@@ -1,8 +1,11 @@
 // Qa Lab plugin module implements cli behavior.
 import type { Command } from "commander";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
-import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
-import { collectString } from "./cli-options.js";
+import {
+  collectString,
+  invalidQaCliArgument,
+  parseQaCliPositiveIntegerOption,
+} from "./cli-options.js";
 import type {
   QaLabSelfCheckCommandOptions,
   QaProfileCommandOptions,
@@ -83,22 +86,6 @@ type QaSuiteCliOptions = QaScenarioRunCliOptions & {
 };
 
 const loadQaLabCliRuntime = createLazyRuntimeModule(() => import("./cli.runtime.js"));
-
-function invalidQaCliArgument(message: string): Error & { code: string; exitCode: number } {
-  const error = new Error(message) as Error & { code: string; exitCode: number };
-  error.name = "InvalidArgumentError";
-  error.code = "commander.invalidArgument";
-  error.exitCode = 1;
-  return error;
-}
-
-function parseQaCliPositiveIntegerOption(value: string, flag: string): number {
-  const parsed = parseStrictPositiveInteger(value);
-  if (parsed === undefined) {
-    throw invalidQaCliArgument(`${flag} must be a positive integer.`);
-  }
-  return parsed;
-}
 
 function parseQaCliTcpPortOption(value: string, flag: string): number {
   const parsed = parseQaCliPositiveIntegerOption(value, flag);

--- a/extensions/qa-lab/src/live-transports/cli.test.ts
+++ b/extensions/qa-lab/src/live-transports/cli.test.ts
@@ -66,4 +66,21 @@ describe("live transport QA contributions", () => {
       expect.objectContaining({ scenarioIds: ["telegram-canary"] }),
     );
   });
+
+  it.each(["discord", "slack", "telegram", "whatsapp"])(
+    "does not expose worker concurrency for the shared-instance %s command",
+    async (commandName) => {
+      const registration = listLiveTransportQaCliRegistrations().find(
+        (candidate) => candidate.commandName === commandName,
+      );
+      const qa = new Command().exitOverride().configureOutput({ writeErr: () => {} });
+      registration?.register(qa);
+
+      await expect(
+        qa.parseAsync(["node", "openclaw", commandName, "--concurrency", "2"]),
+      ).rejects.toThrow("unknown option '--concurrency'");
+      expect(runLiveTransportQaSuiteCommand).not.toHaveBeenCalled();
+      expect(runTelegram).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.test.ts
@@ -350,7 +350,7 @@ describe("matrix scenario environment", () => {
     );
   });
 
-  it("shares the preparation deadline across revision and fresh account readiness", async () => {
+  it("shares the preparation deadline but renews action-time config patch deadlines", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
     const callOrder: string[] = [];
@@ -370,6 +370,9 @@ describe("matrix scenario environment", () => {
           opts?: { deadlineMs?: number; timeoutMs?: number },
         ) => {
           callOrder.push(method);
+          if (opts?.deadlineMs !== undefined && opts.deadlineMs <= Date.now()) {
+            throw new Error("gateway RPC deadline expired");
+          }
           if (method === "config.get") {
             configReadCount += 1;
             if (configReadCount === 1) {
@@ -484,6 +487,17 @@ describe("matrix scenario environment", () => {
       "exec.approval.request",
       { id: "approval-1" },
       { expectFinal: false, timeoutMs: 1_000 },
+    );
+
+    // The setup deadline has expired, but the eight-second action window has not.
+    vi.setSystemTime(61_000);
+    await expect(
+      scenarioContext.patchGatewayConfig({ channels: { matrix: { enabled: true } } }),
+    ).resolves.toBeUndefined();
+    expect(gateway.call).toHaveBeenLastCalledWith(
+      "config.patch",
+      expect.objectContaining({ baseHash: "patched-config-hash" }),
+      { deadlineMs: 69_000, timeoutMs: 60_000 },
     );
   });
 

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.ts
@@ -470,7 +470,8 @@ export function createMatrixQaScenarioEnvironment(params: MatrixQaScenarioEnviro
         opts?: { replacePaths?: string[]; restartDelayMs?: number },
       ) => {
         await patchGatewayConfig({
-          deadlineMs: preparationDeadline,
+          // This callback runs during actions, after the preparation budget may expire.
+          deadlineMs: Date.now() + input.timeoutMs,
           gateway: input.gateway,
           patch,
           replacePaths: opts?.replacePaths,

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-destructive.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-destructive.test.ts
@@ -209,7 +209,7 @@ describe("Matrix sync-state loss driver readiness", () => {
         gatewayStateDir: "/tmp/unused-gateway-state",
         gatewayRuntimeEnv: { OPENCLAW_CONFIG_PATH: "/tmp/unused-gateway-config" },
         restartGatewayAfterStateMutation: async (mutate) => {
-          await mutate();
+          await mutate({ stateDir: "/tmp/unused-gateway-state" });
         },
       });
 

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-destructive.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-destructive.test.ts
@@ -8,6 +8,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { assertMatrixQaCliBackupRestoreFailed } from "./scenario-runtime-e2ee-destructive-recovery.js";
 import { mutateMatrixQaCliStateLoss } from "./scenario-runtime-e2ee-state.js";
+import { createMatrixQaE2eeTestContext } from "./scenario-runtime-e2ee.test-helpers.js";
 import type { MatrixQaScenarioContext } from "./scenario-runtime-shared.js";
 
 const testing = { assertMatrixQaCliBackupRestoreFailed };
@@ -18,6 +19,11 @@ const destructiveScenarioMocks = vi.hoisted(() => ({
   createMatrixQaRecoveryCliRuntime: vi.fn(),
   loginMatrixQaRecoveryDevice: vi.fn(),
   runMatrixQaCliJson: vi.fn(),
+  createMatrixQaDriverScenarioClient: vi.fn(),
+  readMatrixQaGatewayMatrixAccount: vi.fn(),
+  replaceMatrixQaGatewayMatrixAccount: vi.fn(),
+  waitForMatrixSyncStoreWithCursor: vi.fn(),
+  deleteMatrixSyncStoreCursor: vi.fn(),
 }));
 
 const storageMetadataRuntime = vi.hoisted(() => ({
@@ -63,7 +69,25 @@ vi.mock("./scenario-runtime-e2ee-destructive-recovery.js", async (importOriginal
   runMatrixQaCliJson: destructiveScenarioMocks.runMatrixQaCliJson,
 }));
 
-import { runMatrixQaE2eeWrongAccountRecoveryKeyScenario } from "./scenario-runtime-e2ee-destructive.js";
+vi.mock("./scenario-runtime-shared.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./scenario-runtime-shared.js")>()),
+  createMatrixQaDriverScenarioClient: destructiveScenarioMocks.createMatrixQaDriverScenarioClient,
+}));
+
+vi.mock("./scenario-runtime-config.js", () => ({
+  readMatrixQaGatewayMatrixAccount: destructiveScenarioMocks.readMatrixQaGatewayMatrixAccount,
+  replaceMatrixQaGatewayMatrixAccount: destructiveScenarioMocks.replaceMatrixQaGatewayMatrixAccount,
+}));
+
+vi.mock("./scenario-runtime-state-files.js", () => ({
+  waitForMatrixSyncStoreWithCursor: destructiveScenarioMocks.waitForMatrixSyncStoreWithCursor,
+  deleteMatrixSyncStoreCursor: destructiveScenarioMocks.deleteMatrixSyncStoreCursor,
+}));
+
+import {
+  runMatrixQaE2eeSyncStateLossCryptoIntactScenario,
+  runMatrixQaE2eeWrongAccountRecoveryKeyScenario,
+} from "./scenario-runtime-e2ee-destructive.js";
 
 function createDisposableOwner(params: {
   backupVersion: string;
@@ -133,6 +157,77 @@ function createWrongAccountContext(): MatrixQaScenarioContext {
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+describe("Matrix sync-state loss driver readiness", () => {
+  it.each([false, true])(
+    "awaits target room sync before sending (sync fails=%s)",
+    async (fails) => {
+      const order: string[] = [];
+      const account = {
+        accessToken: "replacement-token",
+        deviceId: "REPLACEMENT",
+        password: "replacement-password",
+        userId: "@replacement:matrix-qa.test",
+      };
+      const roomId = "!recovery:matrix-qa.test";
+      const driver = {
+        prime: vi.fn(async () => "driver-cursor"),
+        waitForJoinedMember: vi.fn(async () => {
+          order.push("wait");
+          await Promise.resolve();
+          if (fails) {
+            throw new Error("membership sync failed");
+          }
+          order.push("synced");
+        }),
+        sendTextMessage: vi.fn(async () => {
+          order.push("send");
+          throw new Error("send reached");
+        }),
+        stop: vi.fn(async () => {}),
+      };
+      destructiveScenarioMocks.createMatrixQaClient.mockReturnValue({
+        registerWithToken: vi.fn(async () => account),
+        joinRoom: vi.fn(async () => {}),
+      });
+      destructiveScenarioMocks.createMatrixQaDriverScenarioClient.mockReturnValue({
+        createPrivateRoom: vi.fn(async () => roomId),
+        primeRoom: vi.fn(async () => "raw-cursor"),
+      });
+      destructiveScenarioMocks.createMatrixQaE2eeScenarioClient.mockResolvedValue(driver);
+      destructiveScenarioMocks.readMatrixQaGatewayMatrixAccount.mockResolvedValue({
+        enabled: true,
+      });
+      destructiveScenarioMocks.waitForMatrixSyncStoreWithCursor.mockResolvedValue({
+        cursor: "saved-cursor",
+        pathname: "/tmp/unused-sync-store",
+        source: "sqlite",
+        stateKey: "saved",
+      });
+      const context = createMatrixQaE2eeTestContext({
+        gatewayStateDir: "/tmp/unused-gateway-state",
+        gatewayRuntimeEnv: { OPENCLAW_CONFIG_PATH: "/tmp/unused-gateway-config" },
+        restartGatewayAfterStateMutation: async (mutate) => {
+          await mutate();
+        },
+      });
+
+      await expect(runMatrixQaE2eeSyncStateLossCryptoIntactScenario(context)).rejects.toThrow(
+        fails ? "membership sync failed" : "send reached",
+      );
+      expect(driver.waitForJoinedMember).toHaveBeenCalledWith({
+        roomId,
+        timeoutMs: context.timeoutMs,
+        userId: account.userId,
+      });
+      expect(order).toEqual(fails ? ["wait"] : ["wait", "synced", "send"]);
+      expect(driver.stop).toHaveBeenCalledOnce();
+      expect(destructiveScenarioMocks.replaceMatrixQaGatewayMatrixAccount).toHaveBeenLastCalledWith(
+        expect.objectContaining({ accountId: "sut", accountConfig: { enabled: true } }),
+      );
+    },
+  );
 });
 
 describe("Matrix destructive E2EE storage discovery", () => {

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-destructive.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-destructive.ts
@@ -1089,6 +1089,12 @@ export async function runMatrixQaE2eeSyncStateLossCryptoIntactScenario(
       context,
       "matrix-e2ee-sync-state-loss-crypto-intact",
     );
+    // Cached client readiness does not imply that this newly created room has synced.
+    await driver.waitForJoinedMember({
+      roomId,
+      timeoutMs: context.timeoutMs,
+      userId: account.userId,
+    });
     const token = buildMatrixQaToken("MATRIX_QA_E2EE_SYNC_LOSS");
     const driverStartSince = await driver.prime();
     const rawStartSince = await rawDriver.primeRoom();

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-shared.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-shared.test.ts
@@ -1,8 +1,20 @@
 import { setTimeout as sleep } from "node:timers/promises";
 import type { MatrixVerificationSummary } from "@openclaw/matrix/test-api.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { MatrixQaE2eeScenarioClient } from "../substrate/e2ee-client.js";
-import { waitForMatrixQaVerificationSummary } from "./scenario-runtime-e2ee-shared.js";
+import {
+  createMatrixQaE2eeScenarioClient,
+  type MatrixQaE2eeScenarioClient,
+} from "../substrate/e2ee-client.js";
+import {
+  waitForMatrixQaVerificationSummary,
+  withMatrixQaE2eeDriverAndObserver,
+} from "./scenario-runtime-e2ee-shared.js";
+import { createMatrixQaE2eeTestContext } from "./scenario-runtime-e2ee.test-helpers.js";
+
+vi.mock("../substrate/e2ee-client.js", () => ({
+  createMatrixQaE2eeScenarioClient: vi.fn(),
+  runMatrixQaE2eeBootstrap: vi.fn(),
+}));
 
 vi.mock("node:timers/promises", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:timers/promises")>()),
@@ -38,6 +50,131 @@ function summary(overrides: Partial<MatrixVerificationSummary> = {}): MatrixVeri
     ...overrides,
   };
 }
+
+describe("Matrix E2EE scenario client ownership", () => {
+  const context = createMatrixQaE2eeTestContext();
+  const scenarioId = "matrix-e2ee-qr-verification";
+  const client = (stop: MatrixQaE2eeScenarioClient["stop"]) =>
+    ({ stop }) as MatrixQaE2eeScenarioClient;
+
+  it.each([false, true])(
+    "stops the driver when observer acquisition fails (cleanup fails: %s)",
+    async (cleanupFails) => {
+      const acquisitionFailure = new Error("observer startup failed");
+      const cleanupFailure = new Error("driver persistence failed");
+      const stop = vi.fn(async () => {
+        if (cleanupFails) {
+          throw cleanupFailure;
+        }
+      });
+      vi.mocked(createMatrixQaE2eeScenarioClient)
+        .mockResolvedValueOnce(client(stop))
+        .mockRejectedValueOnce(acquisitionFailure);
+      const run = vi.fn();
+      const failure = await withMatrixQaE2eeDriverAndObserver(context, scenarioId, run).catch(
+        (error: unknown) => error,
+      );
+
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(run).not.toHaveBeenCalled();
+      if (cleanupFails) {
+        expect(failure).toMatchObject({
+          cause: acquisitionFailure,
+          errors: [acquisitionFailure, cleanupFailure],
+        });
+      } else {
+        expect(failure).toBe(acquisitionFailure);
+      }
+    },
+  );
+
+  it.each(["driver", "observer"] as const)(
+    "joins both clients and preserves all errors when %s cleanup fails first",
+    async (firstFailure) => {
+      const scenarioFailure = new Error("verification failed");
+      const driverFailure = new Error("driver shutdown failed");
+      const observerFailure = new Error("observer shutdown failed");
+      const delayedStop = Promise.withResolvers<void>();
+      const stops = {
+        driver: vi.fn(async () => {
+          if (firstFailure !== "driver") {
+            await delayedStop.promise;
+          }
+          throw driverFailure;
+        }),
+        observer: vi.fn(async () => {
+          if (firstFailure !== "observer") {
+            await delayedStop.promise;
+          }
+          throw observerFailure;
+        }),
+      };
+      vi.mocked(createMatrixQaE2eeScenarioClient)
+        .mockResolvedValueOnce(client(stops.driver))
+        .mockResolvedValueOnce(client(stops.observer));
+      const settled = vi.fn();
+      const completion = withMatrixQaE2eeDriverAndObserver(context, scenarioId, async () => {
+        throw scenarioFailure;
+      }).then(settled, settled);
+      try {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(stops.driver).toHaveBeenCalledTimes(1);
+        expect(stops.observer).toHaveBeenCalledTimes(1);
+        expect(settled).not.toHaveBeenCalled();
+      } finally {
+        delayedStop.resolve();
+        await completion;
+      }
+      expect(settled).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          cause: scenarioFailure,
+          errors: [scenarioFailure, driverFailure, observerFailure],
+        }),
+      );
+    },
+  );
+
+  it("returns the scenario result after stopping both clients", async () => {
+    const driver = client(vi.fn(async () => {}));
+    const observer = client(vi.fn(async () => {}));
+    vi.mocked(createMatrixQaE2eeScenarioClient)
+      .mockResolvedValueOnce(driver)
+      .mockResolvedValueOnce(observer);
+    const result = { verified: true };
+    const run = vi.fn(async () => result);
+
+    await expect(withMatrixQaE2eeDriverAndObserver(context, scenarioId, run)).resolves.toBe(result);
+    expect(run).toHaveBeenCalledExactlyOnceWith({ driver, observer });
+    expect(driver.stop).toHaveBeenCalledTimes(1);
+    expect(observer.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves a cleanup-only rejection after joining the other client", async () => {
+    const delayedStop = Promise.withResolvers<void>();
+    const driver = client(vi.fn().mockRejectedValue(undefined));
+    const observer = client(vi.fn(() => delayedStop.promise));
+    vi.mocked(createMatrixQaE2eeScenarioClient)
+      .mockResolvedValueOnce(driver)
+      .mockResolvedValueOnce(observer);
+    const resolved = vi.fn();
+    const rejected = vi.fn();
+    const completion = withMatrixQaE2eeDriverAndObserver(context, scenarioId, async () => ({
+      verified: true,
+    })).then(resolved, rejected);
+    try {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(driver.stop).toHaveBeenCalledTimes(1);
+      expect(observer.stop).toHaveBeenCalledTimes(1);
+      expect(resolved).not.toHaveBeenCalled();
+      expect(rejected).not.toHaveBeenCalled();
+    } finally {
+      delayedStop.resolve();
+      await completion;
+    }
+    expect(resolved).not.toHaveBeenCalled();
+    expect(rejected).toHaveBeenCalledExactlyOnceWith(undefined);
+  });
+});
 
 describe("Matrix verification wait diagnostics", () => {
   it("reports only four latest phase/boolean states at the unchanged polling deadline", async () => {

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-shared.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-shared.test.ts
@@ -1,5 +1,6 @@
 import { setTimeout as sleep } from "node:timers/promises";
 import type { MatrixVerificationSummary } from "@openclaw/matrix/test-api.js";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createMatrixQaE2eeScenarioClient,
@@ -94,7 +95,7 @@ describe("Matrix E2EE scenario client ownership", () => {
       const scenarioFailure = new Error("verification failed");
       const driverFailure = new Error("driver shutdown failed");
       const observerFailure = new Error("observer shutdown failed");
-      const delayedStop = Promise.withResolvers<void>();
+      const delayedStop = createDeferred<void>();
       const stops = {
         driver: vi.fn(async () => {
           if (firstFailure !== "driver") {
@@ -117,7 +118,9 @@ describe("Matrix E2EE scenario client ownership", () => {
         throw scenarioFailure;
       }).then(settled, settled);
       try {
-        await new Promise<void>((resolve) => setImmediate(resolve));
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
         expect(stops.driver).toHaveBeenCalledTimes(1);
         expect(stops.observer).toHaveBeenCalledTimes(1);
         expect(settled).not.toHaveBeenCalled();
@@ -135,8 +138,10 @@ describe("Matrix E2EE scenario client ownership", () => {
   );
 
   it("returns the scenario result after stopping both clients", async () => {
-    const driver = client(vi.fn(async () => {}));
-    const observer = client(vi.fn(async () => {}));
+    const stopDriver = vi.fn(async () => {});
+    const stopObserver = vi.fn(async () => {});
+    const driver = client(stopDriver);
+    const observer = client(stopObserver);
     vi.mocked(createMatrixQaE2eeScenarioClient)
       .mockResolvedValueOnce(driver)
       .mockResolvedValueOnce(observer);
@@ -145,14 +150,16 @@ describe("Matrix E2EE scenario client ownership", () => {
 
     await expect(withMatrixQaE2eeDriverAndObserver(context, scenarioId, run)).resolves.toBe(result);
     expect(run).toHaveBeenCalledExactlyOnceWith({ driver, observer });
-    expect(driver.stop).toHaveBeenCalledTimes(1);
-    expect(observer.stop).toHaveBeenCalledTimes(1);
+    expect(stopDriver).toHaveBeenCalledTimes(1);
+    expect(stopObserver).toHaveBeenCalledTimes(1);
   });
 
   it("preserves a cleanup-only rejection after joining the other client", async () => {
-    const delayedStop = Promise.withResolvers<void>();
-    const driver = client(vi.fn().mockRejectedValue(undefined));
-    const observer = client(vi.fn(() => delayedStop.promise));
+    const delayedStop = createDeferred<void>();
+    const stopDriver = vi.fn().mockRejectedValue(undefined);
+    const stopObserver = vi.fn(() => delayedStop.promise);
+    const driver = client(stopDriver);
+    const observer = client(stopObserver);
     vi.mocked(createMatrixQaE2eeScenarioClient)
       .mockResolvedValueOnce(driver)
       .mockResolvedValueOnce(observer);
@@ -162,9 +169,11 @@ describe("Matrix E2EE scenario client ownership", () => {
       verified: true,
     })).then(resolved, rejected);
     try {
-      await new Promise<void>((resolve) => setImmediate(resolve));
-      expect(driver.stop).toHaveBeenCalledTimes(1);
-      expect(observer.stop).toHaveBeenCalledTimes(1);
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(stopDriver).toHaveBeenCalledTimes(1);
+      expect(stopObserver).toHaveBeenCalledTimes(1);
       expect(resolved).not.toHaveBeenCalled();
       expect(rejected).not.toHaveBeenCalled();
     } finally {

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-shared.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-shared.ts
@@ -2,6 +2,7 @@
 import { randomUUID } from "node:crypto";
 import { setTimeout as sleep } from "node:timers/promises";
 import type { MatrixVerificationSummary } from "@openclaw/matrix/test-api.js";
+import type { Result } from "@openclaw/normalization-core/result";
 import { createMatrixQaClient } from "../substrate/client.js";
 import {
   createMatrixQaE2eeScenarioClient,
@@ -353,12 +354,30 @@ export async function withMatrixQaE2eeDriverAndObserver<T>(
   }) => Promise<T>,
 ) {
   const driver = await createMatrixQaE2eeDriverClient(context, scenarioId);
-  const observer = await createMatrixQaE2eeObserverClient(context, scenarioId);
+  let observer: MatrixQaE2eeScenarioClient | undefined;
+  let outcome: Result<T, unknown>;
   try {
-    return await run({ driver, observer });
-  } finally {
-    await Promise.all([driver.stop(), observer.stop()]);
+    observer = await createMatrixQaE2eeObserverClient(context, scenarioId);
+    outcome = { ok: true, value: await run({ driver, observer }) };
+  } catch (error) {
+    outcome = { ok: false, error };
   }
+  // Join every acquired client before the next scenario can reuse its device and crypto state.
+  const cleanup = await Promise.allSettled(
+    [driver, observer].map(async (client) => client?.stop()),
+  );
+  const failures: unknown[] = outcome.ok ? [] : [outcome.error];
+  failures.push(
+    ...cleanup.flatMap((result) => (result.status === "rejected" ? [result.reason] : [])),
+  );
+  if (outcome.ok && failures.length === 0) {
+    return outcome.value;
+  }
+  throw failures.length === 1
+    ? failures[0]
+    : new AggregateError(failures, "Matrix E2EE scenario and client cleanup failed", {
+        cause: failures[0],
+      });
 }
 
 export async function completeMatrixQaSasVerification(params: {

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-shared.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-shared.ts
@@ -2,7 +2,6 @@
 import { randomUUID } from "node:crypto";
 import { setTimeout as sleep } from "node:timers/promises";
 import type { MatrixVerificationSummary } from "@openclaw/matrix/test-api.js";
-import type { Result } from "@openclaw/normalization-core/result";
 import { createMatrixQaClient } from "../substrate/client.js";
 import {
   createMatrixQaE2eeScenarioClient,
@@ -355,22 +354,21 @@ export async function withMatrixQaE2eeDriverAndObserver<T>(
 ) {
   const driver = await createMatrixQaE2eeDriverClient(context, scenarioId);
   let observer: MatrixQaE2eeScenarioClient | undefined;
-  let outcome: Result<T, unknown>;
-  try {
-    observer = await createMatrixQaE2eeObserverClient(context, scenarioId);
-    outcome = { ok: true, value: await run({ driver, observer }) };
-  } catch (error) {
-    outcome = { ok: false, error };
-  }
+  const [outcome] = await Promise.allSettled([
+    (async () => {
+      observer = await createMatrixQaE2eeObserverClient(context, scenarioId);
+      return await run({ driver, observer });
+    })(),
+  ]);
   // Join every acquired client before the next scenario can reuse its device and crypto state.
   const cleanup = await Promise.allSettled(
     [driver, observer].map(async (client) => client?.stop()),
   );
-  const failures: unknown[] = outcome.ok ? [] : [outcome.error];
+  const failures: unknown[] = outcome.status === "fulfilled" ? [] : [outcome.reason];
   failures.push(
     ...cleanup.flatMap((result) => (result.status === "rejected" ? [result.reason] : [])),
   );
-  if (outcome.ok && failures.length === 0) {
+  if (outcome.status === "fulfilled" && failures.length === 0) {
     return outcome.value;
   }
   throw failures.length === 1

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-shared.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-shared.test.ts
@@ -4,6 +4,7 @@ import {
   buildMatrixNoticeArtifact,
   buildMatrixReplyArtifact,
   resolveMatrixQaNoReplyWindowMs,
+  runNoReplyExpectedScenario,
   truncateMatrixQaPreview,
 } from "./scenario-runtime-shared.js";
 
@@ -24,6 +25,95 @@ describe("matrix scenario runtime shared", () => {
       expect(resolveMatrixQaNoReplyWindowMs(30_000)).toBe(8_000);
     }
   });
+
+  it.each([
+    { observeTrigger: false, reply: false, error: "did not observe the trigger event" },
+    { observeTrigger: true, reply: false, error: undefined },
+    { observeTrigger: true, reply: true, error: "unexpected SUT reply" },
+  ])(
+    "requires observed ingress throughout the no-reply window (trigger=$observeTrigger, reply=$reply)",
+    async ({ observeTrigger, reply, error }) => {
+      vi.useFakeTimers();
+      let polls = 0;
+      const fetchImpl: typeof fetch = async (input, init) => {
+        const url = new URL(String(input));
+        if (init?.method === "PUT") {
+          return Response.json({ event_id: "$trigger" });
+        }
+        if (!url.searchParams.has("since")) {
+          return Response.json({ next_batch: "primed" });
+        }
+        polls += 1;
+        if (polls > 1) {
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, Number(url.searchParams.get("timeout")));
+          });
+        }
+        const event =
+          polls === 1 && observeTrigger
+            ? { event_id: "$trigger", sender: "@observer:matrix-qa.test" }
+            : polls > 1 && reply
+              ? { event_id: "$reply", sender: "@sut:matrix-qa.test" }
+              : undefined;
+        return Response.json({
+          next_batch: `batch-${polls}`,
+          rooms: {
+            join: {
+              "!room:matrix-qa.test": {
+                timeline: {
+                  events: event
+                    ? [{ ...event, type: "m.room.message", content: { body: "marker" } }]
+                    : [],
+                },
+              },
+            },
+          },
+        });
+      };
+      vi.stubGlobal("fetch", fetchImpl);
+      let settled = false;
+      const pending = runNoReplyExpectedScenario({
+        accessToken: "token",
+        actorId: "observer",
+        actorUserId: "@observer:matrix-qa.test",
+        baseUrl: "http://127.0.0.1:28008/",
+        body: "marker",
+        observedEvents: [],
+        roomId: "!room:matrix-qa.test",
+        syncState: {},
+        sutUserId: "@sut:matrix-qa.test",
+        timeoutMs: 8_000,
+        token: "marker",
+      }).then(
+        (value) => ({ value }),
+        (failure: unknown) => ({ error: failure }),
+      );
+      void pending.then(() => {
+        settled = true;
+      });
+      try {
+        await vi.advanceTimersByTimeAsync(7_999);
+        expect(settled).toBe(false);
+        await vi.advanceTimersByTimeAsync(1);
+        const result = await pending;
+        if (error) {
+          expect(result).toMatchObject({
+            error: expect.objectContaining({ message: expect.stringContaining(error) }),
+          });
+        } else {
+          expect(result).toMatchObject({
+            value: { artifacts: { driverEventId: "$trigger", expectedNoReplyWindowMs: 8_000 } },
+          });
+        }
+      } finally {
+        await vi.runAllTimersAsync();
+        await pending;
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+      }
+    },
+  );
+
   it("keeps every shared Matrix preview UTF-16 safe", () => {
     const prefix = "a".repeat(199);
     const event = {

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-shared.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-shared.test.ts
@@ -36,7 +36,7 @@ describe("matrix scenario runtime shared", () => {
       vi.useFakeTimers();
       let polls = 0;
       const fetchImpl: typeof fetch = async (input, init) => {
-        const url = new URL(String(input));
+        const url = new URL(input instanceof Request ? input.url : input);
         if (init?.method === "PUT") {
           return Response.json({ event_id: "$trigger" });
         }

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-shared.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-shared.ts
@@ -647,6 +647,9 @@ export async function runNoReplyExpectedScenario(params: {
       ].join("\n"),
     );
   }
+  if (!observedTriggerEvent) {
+    throw new Error("Matrix no-reply observation did not observe the trigger event");
+  }
   advanceMatrixQaActorCursor({
     actorId: params.actorId,
     syncState: params.syncState,

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-state-files.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-state-files.test.ts
@@ -1,19 +1,177 @@
 // Qa Matrix tests cover persisted runtime state probes.
-import { mkdtemp, rm } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { createClaimableDedupe } from "openclaw/plugin-sdk/persistent-dedupe";
-import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import {
+  createPluginStateSyncKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterEach, describe, expect, it } from "vitest";
-import { waitForMatrixInboundDedupeEntry } from "./scenario-runtime-state-files.js";
+import { createMatrixQaE2eeTestContext } from "./scenario-runtime-e2ee.test-helpers.js";
+import {
+  deleteMatrixSyncStoreCursor,
+  waitForMatrixInboundDedupeEntry,
+  waitForMatrixSyncStoreWithCursor,
+} from "./scenario-runtime-state-files.js";
 
 describe("Matrix QA persisted state probes", () => {
   const tempDirs: string[] = [];
+  const identity = { accountId: "target", userId: "@target:matrix-qa.test" };
+  const context = createMatrixQaE2eeTestContext({
+    sutAccountId: identity.accountId,
+    sutUserId: identity.userId,
+  });
+
+  function openStore(root: string, namespace: string) {
+    return createPluginStateSyncKeyedStoreForTests<unknown>("matrix", {
+      namespace,
+      maxEntries: 20,
+      env: { ...process.env, OPENCLAW_STATE_DIR: root },
+    });
+  }
+
+  async function createStateDir() {
+    const stateDir = await mkdtemp(path.join(os.tmpdir(), "matrix-qa-sync-"));
+    tempDirs.push(stateDir);
+    return stateDir;
+  }
+
+  async function seedSyncStore(params: {
+    root: string;
+    metadata: typeof identity;
+    source: "json" | "sqlite";
+    legacyMetadata?: boolean;
+    cursor: string;
+  }) {
+    await mkdir(params.root, { recursive: true });
+    if (params.legacyMetadata) {
+      await writeFile(path.join(params.root, "storage-meta.json"), JSON.stringify(params.metadata));
+    } else {
+      openStore(params.root, "storage-meta").register("current", params.metadata);
+    }
+    const savedSync = { nextBatch: params.cursor, accountData: [], roomsData: {} };
+    if (params.source === "json") {
+      await writeFile(path.join(params.root, "bot-storage.json"), JSON.stringify({ savedSync }));
+      return;
+    }
+    // These are the persisted sync-cache rows produced by the Matrix store;
+    // real plugin-state writes exercise account-local SQLite discovery.
+    const data = JSON.stringify(savedSync);
+    const store = openStore(params.root, "sync-cache");
+    store.register("current:sync:fixture:0", { kind: "sync-chunk", index: 0, data });
+    store.register("current:meta", {
+      kind: "meta",
+      version: 1,
+      generation: "fixture",
+      chunkCount: 1,
+      syncDigest: createHash("sha256").update(data).digest("hex"),
+    });
+  }
 
   afterEach(async () => {
     resetPluginStateStoreForTests();
     await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })));
   });
+
+  it.each(["accountId", "userId"] as const)(
+    "selects the requested SQLite identity and preserves unrelated state when %s differs",
+    async (field) => {
+      const stateDir = await createStateDir();
+      const other = path.join(stateDir, "matrix", "accounts", "aa-other");
+      const target = path.join(stateDir, "matrix", "accounts", "zz-target");
+      await seedSyncStore({
+        root: other,
+        metadata: { ...identity, [field]: "other" },
+        source: "sqlite",
+        cursor: "other-cursor",
+      });
+      await seedSyncStore({
+        root: target,
+        metadata: identity,
+        source: "sqlite",
+        cursor: "target-cursor",
+      });
+      for (const root of [other, target]) {
+        openStore(root, "idb-snapshot").register("crypto-sentinel", { preserved: root });
+      }
+      resetPluginStateStoreForTests();
+
+      const selected = await waitForMatrixSyncStoreWithCursor({
+        context: createMatrixQaE2eeTestContext(),
+        ...identity,
+        stateDir,
+        timeoutMs: 1_000,
+      });
+      expect(selected).toMatchObject({
+        pathname: path.join(target, "state", "openclaw.sqlite"),
+        cursor: "target-cursor",
+        source: "sqlite",
+      });
+      const unrelatedSyncRows = openStore(other, "sync-cache").entries();
+      await deleteMatrixSyncStoreCursor(selected);
+      expect(openStore(target, "sync-cache").entries()).toEqual([]);
+      expect(openStore(other, "sync-cache").entries()).toEqual(unrelatedSyncRows);
+      for (const root of [other, target]) {
+        expect(openStore(root, "idb-snapshot").lookup("crypto-sentinel")).toEqual({
+          preserved: root,
+        });
+      }
+    },
+  );
+
+  it.each(["json", "sqlite"] as const)(
+    "waits instead of returning another account's %s cursor",
+    async (source) => {
+      const stateDir = await createStateDir();
+      await seedSyncStore({
+        root: path.join(stateDir, "matrix", "accounts", "other"),
+        metadata: { ...identity, accountId: "other" },
+        source,
+        legacyMetadata: source === "json",
+        cursor: "other-cursor",
+      });
+      await expect(
+        waitForMatrixSyncStoreWithCursor({ context, stateDir, timeoutMs: 20 }),
+      ).rejects.toThrow("timed out waiting for Matrix sync store cursor");
+    },
+  );
+
+  it.each(["json", "sqlite"] as const)(
+    "does not let stale JSON metadata override a canonical mismatch for a %s cursor",
+    async (source) => {
+      const stateDir = await createStateDir();
+      const root = path.join(stateDir, "matrix", "accounts", "other");
+      await seedSyncStore({
+        root,
+        metadata: { ...identity, userId: "@other:matrix-qa.test" },
+        source,
+        cursor: "other-cursor",
+      });
+      await writeFile(path.join(root, "storage-meta.json"), JSON.stringify(identity));
+      await expect(
+        waitForMatrixSyncStoreWithCursor({ context, stateDir, timeoutMs: 20 }),
+      ).rejects.toThrow("timed out waiting for Matrix sync store cursor");
+    },
+  );
+
+  it.each(["json", "sqlite"] as const)(
+    "recognizes matching pre-doctor metadata for a %s cursor",
+    async (source) => {
+      const stateDir = await createStateDir();
+      await seedSyncStore({
+        root: path.join(stateDir, "matrix", "accounts", "target"),
+        metadata: identity,
+        source,
+        legacyMetadata: true,
+        cursor: "legacy-cursor",
+      });
+      await expect(
+        waitForMatrixSyncStoreWithCursor({ context, stateDir, timeoutMs: 1_000 }),
+      ).resolves.toMatchObject({ cursor: "legacy-cursor", source });
+    },
+  );
 
   it("observes inbound dedupe entries committed through the core claimable dedupe", async () => {
     const stateDir = await mkdtemp(path.join(os.tmpdir(), "matrix-qa-dedupe-"));

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-state-files.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-state-files.ts
@@ -393,6 +393,7 @@ async function readMatrixStorageMetadata(
       try {
         await fs.access(databasePath);
       } catch (error) {
+        // SAFETY: fs.access rejects with Node errno errors; only ENOENT permits legacy metadata.
         if ((error as NodeJS.ErrnoException).code === "ENOENT") {
           return await readJsonFile(legacyMetadataPath);
         }
@@ -406,9 +407,7 @@ async function readMatrixStorageMetadata(
           WHERE plugin_id = ? AND namespace = ? AND entry_key = ?
             AND (expires_at IS NULL OR expires_at > ?)`,
       )
-      .get(MATRIX_PLUGIN_ID, "storage-meta", "current", Date.now()) as
-      | { valueJson: unknown }
-      | undefined;
+      .get(MATRIX_PLUGIN_ID, "storage-meta", "current", Date.now());
     // Current SQLite identity wins over stale sidecars, including a mismatch.
     // Legacy metadata remains readable only until the Matrix doctor migrates it.
     return row ? parsePluginStateJson(row.valueJson) : await readJsonFile(legacyMetadataPath);

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-state-files.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-state-files.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import { openNodeSqliteDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { MatrixQaScenarioContext } from "./scenario-runtime-shared.js";
@@ -25,6 +26,8 @@ type MatrixSyncStoreCursor = {
   source: "json" | "sqlite";
   stateKey?: string;
 };
+
+type MatrixStateIdentity = { accountId: string; userId: string };
 
 async function readJsonFile(pathname: string): Promise<unknown> {
   return JSON.parse(await fs.readFile(pathname, "utf8")) as unknown;
@@ -109,10 +112,6 @@ function writePersistedMatrixSyncCursor(parsed: unknown, cursor: string): unknow
   throw new Error("Matrix sync store did not contain a persisted sync cursor");
 }
 
-async function readMatrixSyncStoreCursor(pathname: string): Promise<string | null> {
-  return readPersistedMatrixSyncCursor(await readJsonFile(pathname));
-}
-
 function parsePluginStateJson(raw: unknown): unknown {
   if (typeof raw !== "string") {
     return undefined;
@@ -172,22 +171,26 @@ function readMatrixSyncCacheCursorFromRows(
   return cursors;
 }
 
-async function readMatrixSyncCacheCursorsFromSqlite(params: {
-  accountId?: string;
-  context: MatrixQaScenarioContext;
-  stateDir: string;
-  userId?: string;
-}): Promise<MatrixSyncStoreCursor[]> {
+async function readMatrixSyncCacheCursorsFromSqlite(
+  params: MatrixStateIdentity & { stateDir: string },
+): Promise<MatrixSyncStoreCursor[]> {
   const databasePaths = await findFilesByName({
     filename: "openclaw.sqlite",
     rootDir: params.stateDir,
     maxDepth: 10,
   });
-  const cursors: Array<MatrixSyncStoreCursor & { score: number }> = [];
+  const cursors: MatrixSyncStoreCursor[] = [];
   for (const databasePath of databasePaths) {
     try {
       const db = openNodeSqliteDatabase(databasePath, { readOnly: true });
       try {
+        const metadata = await readMatrixStorageMetadata(
+          path.dirname(path.dirname(databasePath)),
+          db,
+        );
+        if (!matchesMatrixStateIdentity(metadata, params)) {
+          continue;
+        }
         const rows = db
           .prepare(
             `SELECT entry_key AS entryKey, value_json AS valueJson
@@ -201,17 +204,7 @@ async function readMatrixSyncCacheCursorsFromSqlite(params: {
           valueJson?: unknown;
         }>;
         for (const cursor of readMatrixSyncCacheCursorFromRows(rows)) {
-          const storageRootDir = path.dirname(path.dirname(databasePath));
-          cursors.push({
-            ...cursor,
-            pathname: databasePath,
-            score: await scoreMatrixStateFile({
-              context: params.context,
-              pathname: path.join(storageRootDir, MATRIX_SYNC_STORE_FILENAME),
-              ...(params.accountId ? { accountId: params.accountId } : {}),
-              ...(params.userId ? { userId: params.userId } : {}),
-            }),
-          });
+          cursors.push({ ...cursor, pathname: databasePath });
         }
       } finally {
         db.close();
@@ -220,9 +213,7 @@ async function readMatrixSyncCacheCursorsFromSqlite(params: {
       continue;
     }
   }
-  return cursors
-    .toSorted((a, b) => b.score - a.score || a.pathname.localeCompare(b.pathname))
-    .map(({ score: _score, ...cursor }) => cursor);
+  return cursors;
 }
 
 function chunkMatrixSyncCacheJson(value: string): string[] {
@@ -390,58 +381,69 @@ export async function deleteMatrixSyncStoreCursor(params: MatrixSyncStoreCursor)
   }
 }
 
-async function scoreMatrixStateFile(params: {
-  accountId?: string;
-  context: MatrixQaScenarioContext;
-  pathname: string;
-  userId?: string;
-}) {
-  let score = params.pathname.includes(`${path.sep}matrix${path.sep}`) ? 4 : 0;
-  const expectedUserId = params.userId ?? params.context.sutUserId;
-  const expectedAccountId = params.accountId ?? params.context.sutAccountId;
+async function readMatrixStorageMetadata(
+  storageRootDir: string,
+  openDatabase?: ReturnType<typeof openNodeSqliteDatabase>,
+): Promise<unknown> {
+  let db = openDatabase;
+  const legacyMetadataPath = path.join(storageRootDir, "storage-meta.json");
   try {
-    const metadata = await readJsonFile(
-      path.join(path.dirname(params.pathname), "storage-meta.json"),
-    );
-    if (isRecord(metadata) && metadata.userId === expectedUserId) {
-      score += 16;
+    if (!db) {
+      const databasePath = path.join(storageRootDir, "state", "openclaw.sqlite");
+      try {
+        await fs.access(databasePath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          return await readJsonFile(legacyMetadataPath);
+        }
+        throw error;
+      }
+      db = openNodeSqliteDatabase(databasePath, { readOnly: true });
     }
-    if (isRecord(metadata) && metadata.accountId === expectedAccountId) {
-      score += 8;
+    const row = db
+      .prepare(
+        `SELECT value_json AS valueJson FROM plugin_state_entries
+          WHERE plugin_id = ? AND namespace = ? AND entry_key = ?
+            AND (expires_at IS NULL OR expires_at > ?)`,
+      )
+      .get(MATRIX_PLUGIN_ID, "storage-meta", "current", Date.now()) as
+      | { valueJson: unknown }
+      | undefined;
+    // Current SQLite identity wins over stale sidecars, including a mismatch.
+    // Legacy metadata remains readable only until the Matrix doctor migrates it.
+    return row ? parsePluginStateJson(row.valueJson) : await readJsonFile(legacyMetadataPath);
+  } finally {
+    if (db && db !== openDatabase) {
+      db.close();
     }
-  } catch {
-    // Missing metadata is allowed; the Matrix client may not have flushed it yet.
   }
-  return score;
 }
 
-async function resolveBestMatrixStateFile(params: {
-  accountId?: string;
-  context: MatrixQaScenarioContext;
-  filename: string;
-  stateDir: string;
-  userId?: string;
-}) {
+function matchesMatrixStateIdentity(metadata: unknown, identity: MatrixStateIdentity): boolean {
+  return (
+    isRecord(metadata) &&
+    metadata.accountId === identity.accountId &&
+    metadata.userId === identity.userId
+  );
+}
+
+async function resolveMatrixSyncStoreFile(params: MatrixStateIdentity & { stateDir: string }) {
   const candidates = await findFilesByName({
-    filename: params.filename,
+    filename: MATRIX_SYNC_STORE_FILENAME,
     rootDir: params.stateDir,
   });
-  if (candidates.length === 0) {
-    return null;
+  for (const pathname of candidates) {
+    try {
+      if (
+        matchesMatrixStateIdentity(await readMatrixStorageMetadata(path.dirname(pathname)), params)
+      ) {
+        return pathname;
+      }
+    } catch {
+      continue;
+    }
   }
-  const scored = await Promise.all(
-    candidates.map(async (pathname) => ({
-      pathname,
-      score: await scoreMatrixStateFile({
-        context: params.context,
-        pathname,
-        ...(params.accountId ? { accountId: params.accountId } : {}),
-        ...(params.userId ? { userId: params.userId } : {}),
-      }),
-    })),
-  );
-  scored.sort((a, b) => b.score - a.score || a.pathname.localeCompare(b.pathname));
-  return scored[0]?.pathname ?? null;
+  return null;
 }
 
 export async function waitForMatrixSyncStoreWithCursor(params: {
@@ -452,30 +454,26 @@ export async function waitForMatrixSyncStoreWithCursor(params: {
   userId?: string;
 }) {
   const startedAt = Date.now();
+  const identity = {
+    accountId: params.accountId ?? params.context.sutAccountId ?? DEFAULT_ACCOUNT_ID,
+    userId: params.userId ?? params.context.sutUserId,
+  };
   let lastPath: string | null = null;
   while (Date.now() - startedAt < params.timeoutMs) {
-    const sqliteCursors = await readMatrixSyncCacheCursorsFromSqlite({
-      context: params.context,
+    const [sqliteCursor] = await readMatrixSyncCacheCursorsFromSqlite({
+      ...identity,
       stateDir: params.stateDir,
-      ...(params.accountId ? { accountId: params.accountId } : {}),
-      ...(params.userId ? { userId: params.userId } : {}),
     });
-    if (sqliteCursors.length > 0) {
-      const cursor = sqliteCursors[0];
-      if (cursor) {
-        return cursor;
-      }
+    if (sqliteCursor) {
+      return sqliteCursor;
     }
-    const pathname = await resolveBestMatrixStateFile({
-      context: params.context,
-      filename: MATRIX_SYNC_STORE_FILENAME,
+    const pathname = await resolveMatrixSyncStoreFile({
+      ...identity,
       stateDir: params.stateDir,
-      ...(params.accountId ? { accountId: params.accountId } : {}),
-      ...(params.userId ? { userId: params.userId } : {}),
     });
     lastPath = pathname;
     if (pathname) {
-      const cursor = await readMatrixSyncStoreCursor(pathname);
+      const cursor = readPersistedMatrixSyncCursor(await readJsonFile(pathname));
       if (cursor) {
         return { cursor, pathname, source: "json" as const };
       }

--- a/extensions/qa-lab/src/live-transports/shared/live-transport-cli.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-transport-cli.ts
@@ -1,26 +1,18 @@
 // Qa Lab plugin module implements live transport cli behavior.
 import type { Command } from "commander";
-import type { QaRunnerCliRegistration } from "openclaw/plugin-sdk/qa-runner-runtime";
+import type {
+  LiveTransportQaCommandOptions as QaRunnerCommandOptions,
+  QaRunnerCliRegistration,
+} from "openclaw/plugin-sdk/qa-runner-runtime";
+import { parseQaCliPositiveIntegerOption } from "../../cli-options.js";
 import { DEFAULT_QA_LIVE_PROVIDER_MODE, formatQaProviderModeHelp } from "../../providers/index.js";
 
-export type LiveTransportQaCommandOptions = {
-  repoRoot?: string;
-  outputDir?: string;
-  providerMode?: string;
-  primaryModel?: string;
-  alternateModel?: string;
-  fastMode?: boolean;
-  allowFailures?: boolean;
-  failFast?: boolean;
-  profile?: string;
-  scenarioIds?: string[];
-  listScenarios?: boolean;
-  sutAccountId?: string;
-  credentialSource?: string;
-  credentialRole?: string;
+export type LiveTransportQaCommandOptions = QaRunnerCommandOptions & {
+  concurrency?: number;
 };
 
 type LiveTransportQaCommanderOptions = {
+  concurrency?: number;
   repoRoot?: string;
   outputDir?: string;
   providerMode?: string;
@@ -74,6 +66,7 @@ function collectStringOption(value: string, previous: string[]) {
 
 function mapCommanderOptions(opts: LiveTransportQaCommanderOptions): LiveTransportQaCommandOptions {
   return {
+    ...(opts.concurrency !== undefined ? { concurrency: opts.concurrency } : {}),
     repoRoot: opts.repoRoot,
     outputDir: opts.outputDir,
     providerMode: opts.providerMode,
@@ -109,6 +102,13 @@ function createSharedLiveTransportQaCliRegistration(
         .option("--scenario <id>", params.scenarioHelp, collectStringOption, [])
         .option("--fast", "Enable provider fast mode where supported");
 
+      if (params.adapterFactory?.isolatesInstances === true) {
+        command.option(
+          "--concurrency <count>",
+          "Scenario worker concurrency (bounded by the transport limit)",
+          (value: string) => parseQaCliPositiveIntegerOption(value, "--concurrency"),
+        );
+      }
       if (params.allowFailuresHelp) {
         command.option("--allow-failures", params.allowFailuresHelp, false);
       }

--- a/extensions/qa-lab/src/live-transports/shared/live-transport-suite.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-transport-suite.runtime.test.ts
@@ -52,7 +52,6 @@ describe("live transport suite runtime", () => {
       failFast: true,
       channelDriver: "live",
       channel: "slack",
-      concurrency: 1,
       scenarioIds: ["slack-canary"],
       sutAccountId: "slack-sut",
       credentialFile: "/secure/slack-qa.json",

--- a/extensions/qa-lab/src/live-transports/shared/live-transport-suite.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-transport-suite.runtime.test.ts
@@ -1,9 +1,11 @@
+import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const runQaSuiteCommand = vi.hoisted(() => vi.fn());
 
 vi.mock("../../cli.runtime.js", () => ({ runQaSuiteCommand }));
 
+import { matrixQaCliRegistration } from "../matrix/cli.js";
 import { runLiveTransportQaSuiteCommand } from "./live-transport-suite.runtime.js";
 
 describe("live transport suite runtime", () => {
@@ -15,6 +17,52 @@ describe("live transport suite runtime", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
+
+  it.each([undefined, 1, 2])(
+    "forwards the dedicated Matrix concurrency %s through parsing and the live suite host",
+    async (concurrency) => {
+      vi.stubEnv("OPENCLAW_QA_MATRIX_DISABLE_FORCE_EXIT", "1");
+      const qa = new Command().exitOverride().configureOutput({ writeErr: () => {} });
+      matrixQaCliRegistration.register(qa);
+
+      await qa.parseAsync([
+        "node",
+        "openclaw",
+        "matrix",
+        "--provider-mode",
+        "mock-openai",
+        "--scenario",
+        "matrix-allowlist-hot-reload",
+        ...(concurrency === undefined ? [] : ["--concurrency", String(concurrency)]),
+      ]);
+
+      expect(runQaSuiteCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channelDriver: "live",
+          channel: "matrix",
+          scenarioIds: ["matrix-allowlist-hot-reload"],
+          ...(concurrency === undefined ? {} : { concurrency }),
+        }),
+      );
+      if (concurrency === undefined) {
+        expect(runQaSuiteCommand.mock.calls[0]?.[0]).not.toHaveProperty("concurrency");
+      }
+    },
+  );
+
+  it.each(["0", "1.5", "2junk"])(
+    "rejects invalid dedicated Matrix concurrency %s before suite dispatch",
+    async (concurrency) => {
+      vi.stubEnv("OPENCLAW_QA_MATRIX_DISABLE_FORCE_EXIT", "1");
+      const qa = new Command().exitOverride().configureOutput({ writeErr: () => {} });
+      matrixQaCliRegistration.register(qa);
+
+      await expect(
+        qa.parseAsync(["node", "openclaw", "matrix", "--concurrency", concurrency]),
+      ).rejects.toThrow("--concurrency must be a positive integer.");
+      expect(runQaSuiteCommand).not.toHaveBeenCalled();
+    },
+  );
 
   it("normalizes one live command into the shared suite host", async () => {
     await runLiveTransportQaSuiteCommand({

--- a/extensions/qa-lab/src/live-transports/shared/live-transport-suite.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-transport-suite.runtime.ts
@@ -1,7 +1,7 @@
-import type { LiveTransportQaCommandOptions } from "openclaw/plugin-sdk/qa-runtime";
 import { runQaSuiteCommand } from "../../cli.runtime.js";
 import type { QaProviderMode } from "../../providers/index.js";
 import { defaultQaModelForMode, normalizeQaProviderMode } from "../../run-config.js";
+import type { LiveTransportQaCommandOptions } from "./live-transport-cli.js";
 
 type LiveTransportScenarioSelection = (params: {
   profile?: string;
@@ -54,6 +54,7 @@ export async function runLiveTransportQaSuiteCommand(params: {
     fastMode: options.fastMode,
     allowFailures: options.allowFailures,
     failFast: options.failFast,
+    ...(options.concurrency !== undefined ? { concurrency: options.concurrency } : {}),
     channelDriver: "live",
     channel: params.channelId,
     scenarioIds: selectedScenarioIds,

--- a/extensions/qa-lab/src/live-transports/shared/live-transport-suite.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-transport-suite.runtime.ts
@@ -56,7 +56,6 @@ export async function runLiveTransportQaSuiteCommand(params: {
     failFast: options.failFast,
     channelDriver: "live",
     channel: params.channelId,
-    concurrency: 1,
     scenarioIds: selectedScenarioIds,
     sutAccountId: options.sutAccountId,
     ...(options.credentialFile ? { credentialFile: options.credentialFile } : {}),

--- a/extensions/qa-lab/src/progress-format.ts
+++ b/extensions/qa-lab/src/progress-format.ts
@@ -1,3 +1,7 @@
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { redactQaGatewayDebugText } from "./gateway-log-redaction.js";
+import type { QaSuiteScenarioResult } from "./suite-types.js";
+
 export function sanitizeQaProgressValue(value: string): string {
   let normalized = "";
   for (const char of value) {
@@ -10,4 +14,20 @@ export function sanitizeQaProgressValue(value: string): string {
   }
   normalized = normalized.replace(/\s+/gu, " ").trim();
   return normalized.length > 0 ? normalized : "<empty>";
+}
+
+export function formatQaScenarioFailureSuffix(result: QaSuiteScenarioResult): string {
+  if (result.status !== "fail") {
+    return "";
+  }
+  const step = result.steps.find((candidate) => candidate.status === "fail");
+  const details = [step?.name, step?.details ?? result.details].filter(Boolean).join(": ");
+  if (!details) {
+    return "";
+  }
+  // Redact before flattening or truncating: either could break a secret pattern
+  // or turn untrusted multiline diagnostics into a CI workflow command.
+  const sanitized = sanitizeQaProgressValue(redactQaGatewayDebugText(details));
+  const bounded = sanitized.length > 512 ? `${sliceUtf16Safe(sanitized, 0, 511)}…` : sanitized;
+  return ` — ${bounded}`;
 }

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -933,43 +933,47 @@ describe("qa suite runtime launcher", () => {
     expect(maxActive()).toBe(2);
   });
 
-  it("runs isolated same-channel adapter instances at suite concurrency", async () => {
-    const repoRoot = await makeTempRepo("qa-suite-pluggable-same-channel-concurrency-");
-    const maxActive = trackMaxActiveFlowRuns();
+  it.each([false, true])(
+    "runs isolated same-channel adapter instances within the suite budget (fail-fast=%s)",
+    async (failFast) => {
+      const repoRoot = await makeTempRepo("qa-suite-pluggable-same-channel-concurrency-");
+      const maxActive = trackMaxActiveFlowRuns();
 
-    const isolatedScenarioId = "matrix-approval-channel-target-both";
-    const sharedScenarioIds = [
-      "matrix-approval-deny-reaction",
-      "matrix-approval-exec-metadata-chunked",
-      "matrix-approval-exec-metadata-single-event",
-      "matrix-approval-plugin-metadata-single-event",
-      "matrix-approval-thread-target",
-    ];
-    const scenarioIds = [isolatedScenarioId, ...sharedScenarioIds];
-    await runQaSuite({
-      repoRoot,
-      outputDir: ".artifacts/qa-e2e/pluggable-same-channel-concurrency",
-      providerMode: "mock-openai",
-      channelDriver: "live",
-      adapterFactories: [
-        {
-          id: "matrix",
-          isolatesInstances: true,
-          matches: ({ channelId, driver }) => driver === "live" && channelId === "matrix",
-          create: vi.fn(),
-        },
-      ],
-      concurrency: 6,
-      scenarioIds,
-    });
+      const isolatedScenarioId = "matrix-approval-channel-target-both";
+      const sharedScenarioIds = [
+        "matrix-approval-deny-reaction",
+        "matrix-approval-exec-metadata-chunked",
+        "matrix-approval-exec-metadata-single-event",
+        "matrix-approval-plugin-metadata-single-event",
+        "matrix-approval-thread-target",
+      ];
+      const scenarioIds = [isolatedScenarioId, ...sharedScenarioIds];
+      await runQaSuite({
+        repoRoot,
+        outputDir: ".artifacts/qa-e2e/pluggable-same-channel-concurrency",
+        providerMode: "mock-openai",
+        channelDriver: "live",
+        adapterFactories: [
+          {
+            id: "matrix",
+            isolatesInstances: true,
+            matches: ({ channelId, driver }) => driver === "live" && channelId === "matrix",
+            create: vi.fn(),
+          },
+        ],
+        concurrency: 6,
+        failFast,
+        scenarioIds,
+      });
 
-    expect(runQaFlowSuite).toHaveBeenCalledTimes(6);
-    expect(runQaFlowSuite.mock.calls.map(([params]) => params?.scenarioIds)).toEqual([
-      ...sharedScenarioIds.map((scenarioId) => [scenarioId]),
-      [isolatedScenarioId],
-    ]);
-    expect(maxActive()).toBe(6);
-  });
+      expect(runQaFlowSuite).toHaveBeenCalledTimes(6);
+      expect(runQaFlowSuite.mock.calls.map(([params]) => params?.scenarioIds)).toEqual([
+        ...sharedScenarioIds.map((scenarioId) => [scenarioId]),
+        [isolatedScenarioId],
+      ]);
+      expect(maxActive()).toBe(failFast ? 1 : 6);
+    },
+  );
 
   it("binds one portable channel scenario without an explicit channel override", async () => {
     const adapterFactories = [

--- a/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
@@ -9,6 +9,7 @@ import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
 import type {
   QaSuiteResolvedRunContext,
   QaSuiteRunner,
+  QaSuiteScenarioResult,
   QaSuiteScenarioRunner,
 } from "./suite-types.js";
 
@@ -125,16 +126,26 @@ describe("isolated QA suite transport cleanup", () => {
   it("records a rejected dispatched worker and leaves the fail-fast tail unstarted", async () => {
     const lab = createCleanupTestLab();
     const context = createCleanupTestContext();
+    context.progressEnabled = true;
     context.selectedScenarios.push(makeQaSuiteTestScenario("never-started"));
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     const runChild = vi
       .fn<QaSuiteRunner>()
       .mockRejectedValueOnce(new Error("isolated worker gateway failed"));
 
-    const result = await runQaFlowSuiteIsolated(
-      { failFast: true, lab, startLab: async () => lab },
-      context,
-      runChild,
-    );
+    let result: Awaited<ReturnType<typeof runQaFlowSuiteIsolated>>;
+    try {
+      result = await runQaFlowSuiteIsolated(
+        { failFast: true, lab, startLab: async () => lab },
+        context,
+        runChild,
+      );
+      expect(stderrWrite.mock.calls.flat().join("")).toContain(
+        "scenario fail (1/2): leased-channel-scenario — isolated scenario worker: isolated worker gateway failed",
+      );
+    } finally {
+      stderrWrite.mockRestore();
+    }
 
     expect(runChild).toHaveBeenCalledOnce();
     expect(result.startedScenarioIds).toEqual(["leased-channel-scenario"]);
@@ -351,52 +362,110 @@ describe("isolated QA suite transport cleanup", () => {
     });
   });
 
-  it("prints one generic completion after a real nested standard run and parent cleanup", async () => {
-    const parentLab = createCleanupTestLab();
-    const childLab = createCleanupTestLab();
-    const startLab = vi
-      .fn<() => Promise<QaLabServerHandle>>()
-      .mockResolvedValueOnce(parentLab)
-      .mockResolvedValueOnce(childLab);
-    const context = createCleanupTestContext();
-    context.channelDriver = undefined;
-    context.progressEnabled = true;
-    const runScenario = vi
-      .fn<QaSuiteScenarioRunner>()
-      .mockResolvedValue({ name: "leased-channel-scenario", status: "pass", steps: [] });
-    const runChild: QaSuiteRunner = async (childParams) => {
-      if (!childParams) {
-        throw new Error("expected nested standard run params");
+  it.each(["pass", "skip", "failed step", "failure details"] as const)(
+    "prints bounded failure progress before artifacts for a nested standard %s result",
+    async (outcome) => {
+      const parentLab = createCleanupTestLab();
+      const childLab = createCleanupTestLab();
+      const startLab = vi
+        .fn<() => Promise<QaLabServerHandle>>()
+        .mockResolvedValueOnce(parentLab)
+        .mockResolvedValueOnce(childLab);
+      const context = createCleanupTestContext();
+      context.channelDriver = undefined;
+      context.progressEnabled = true;
+      const scenario = context.selectedScenarios[0]!;
+      if (scenario.execution.kind === "flow") {
+        scenario.execution.retryCount = 0;
       }
-      return await runQaFlowSuiteStandard(
-        childParams,
-        {
-          ...context,
-          startedAt: new Date("2026-08-04T00:00:01.000Z"),
-          outputDir: childParams.outputDir ?? "/qa-output/scenarios/leased-channel-scenario",
-          concurrency: 1,
-        },
-        runScenario,
-      );
-    };
-    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+      const scenarioStatus = outcome === "pass" || outcome === "skip" ? outcome : "fail";
+      const secret = "synthetic-secret-".repeat(60);
+      const details = `verification refused\napiKey="${secret}"\r::error::fixture\n${"🦞".repeat(400)}`;
+      const scenarioResult = {
+        name: "leased-channel-scenario",
+        status: scenarioStatus,
+        details: outcome === "failed step" ? "unrelated scenario metadata" : details,
+        steps:
+          outcome === "failed step"
+            ? [{ name: "Verify\nrequest", status: "fail" as const, details }]
+            : [],
+      } satisfies QaSuiteScenarioResult;
+      const runScenario = vi.fn<QaSuiteScenarioRunner>().mockResolvedValue(scenarioResult);
+      const runChild: QaSuiteRunner = async (childParams) => {
+        if (!childParams) {
+          throw new Error("expected nested standard run params");
+        }
+        return await runQaFlowSuiteStandard(
+          childParams,
+          {
+            ...context,
+            startedAt: new Date("2026-08-04T00:00:01.000Z"),
+            outputDir: childParams.outputDir ?? "/qa-output/scenarios/leased-channel-scenario",
+            concurrency: 1,
+          },
+          runScenario,
+        );
+      };
+      const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+      const assertScenarioProgress = (expectedCount: number) => {
+        const lines = stderrWrite.mock.calls
+          .flat()
+          .join("")
+          .split("\n")
+          .filter((line) => line.startsWith(`[qa-suite] scenario ${scenarioStatus} (`));
+        expect(lines).toHaveLength(expectedCount);
+        for (const line of lines) {
+          const prefix = `[qa-suite] scenario ${scenarioStatus} (1/1): leased-channel-scenario`;
+          if (scenarioStatus !== "fail") {
+            expect(line).toBe(prefix);
+            continue;
+          }
+          expect(line).toContain(
+            outcome === "failed step"
+              ? "Verify request: verification refused"
+              : "verification refused",
+          );
+          expect(line).toContain("apiKey=<redacted>");
+          expect(line).toContain(": :error::fixture");
+          expect(line).not.toContain("synthetic-secret");
+          expect(line).not.toContain("unrelated scenario metadata");
+          expect(line).not.toMatch(/[\r\n]/u);
+          expect(line.slice(prefix.length)).toMatch(/^ — /u);
+          expect(line.slice(prefix.length + " — ".length).length).toBeLessThanOrEqual(512);
+          expect(line.endsWith("…")).toBe(true);
+          expect(Buffer.from(line).toString("utf8")).toBe(line);
+        }
+      };
+      mocks.writeQaSuiteArtifacts.mockImplementationOnce(async () => {
+        assertScenarioProgress(1);
+        return {
+          evidence: undefined,
+          evidencePath: "/qa-output/qa-evidence.json",
+          report: "",
+          reportPath: "/qa-output/qa-suite-report.md",
+          summaryPath: "/qa-output/qa-suite-summary.json",
+        };
+      });
 
-    try {
-      await runQaFlowSuiteIsolated({ startLab }, context, runChild);
+      try {
+        const result = await runQaFlowSuiteIsolated({ startLab }, context, runChild);
+        assertScenarioProgress(2);
+        expect(result.scenarios).toEqual([scenarioResult]);
 
-      const completionLines = stderrWrite.mock.calls
-        .flat()
-        .join("")
-        .split("\n")
-        .filter((line) => line.startsWith("[qa-suite] run complete"));
-      expect(completionLines).toEqual(["[qa-suite] run complete"]);
-      expect(runScenario).toHaveBeenCalledOnce();
-      expect(childLab.stop).toHaveBeenCalledOnce();
-      expect(parentLab.stop).toHaveBeenCalledOnce();
-    } finally {
-      stderrWrite.mockRestore();
-    }
-  });
+        const completionLines = stderrWrite.mock.calls
+          .flat()
+          .join("")
+          .split("\n")
+          .filter((line) => line.startsWith("[qa-suite] run complete"));
+        expect(completionLines).toEqual(["[qa-suite] run complete"]);
+        expect(runScenario).toHaveBeenCalledOnce();
+        expect(childLab.stop).toHaveBeenCalledOnce();
+        expect(parentLab.stop).toHaveBeenCalledOnce();
+      } finally {
+        stderrWrite.mockRestore();
+      }
+    },
+  );
 
   it.each(["cleanup", "cleanupAfterGatewayStop"] as const)(
     "retries a failed parent %s phase before disposing its owned lab",

--- a/extensions/qa-lab/src/suite-run-isolated.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.ts
@@ -2,7 +2,10 @@ import path from "node:path";
 import { disposeRegisteredAgentHarnesses } from "openclaw/plugin-sdk/agent-harness";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { QaLabLatestReport, QaLabScenarioOutcome } from "./lab-server.types.js";
-import { sanitizeQaProgressValue as sanitizeQaSuiteProgressValue } from "./progress-format.js";
+import {
+  formatQaScenarioFailureSuffix,
+  sanitizeQaProgressValue as sanitizeQaSuiteProgressValue,
+} from "./progress-format.js";
 import { writeQaSuiteArtifacts } from "./suite-artifacts.js";
 import { mapQaSuiteWithConcurrency, resolveQaSuiteWorkerStartStaggerMs } from "./suite-planning.js";
 import { buildQaIsolatedScenarioWorkerParams } from "./suite-support.js";
@@ -216,7 +219,7 @@ export async function runQaFlowSuiteIsolated(
           updateScenarioRun();
           writeQaSuiteProgress(
             progressEnabled,
-            `scenario ${scenarioResult.status} (${index + 1}/${selectedScenarios.length}): ${scenarioIdForLog}`,
+            `scenario ${scenarioResult.status} (${index + 1}/${selectedScenarios.length}): ${scenarioIdForLog}${formatQaScenarioFailureSuffix(scenarioResult)}`,
           );
           completedScenarioResults[index] = scenarioResult;
           writePartialArtifacts();
@@ -247,7 +250,7 @@ export async function runQaFlowSuiteIsolated(
           updateScenarioRun();
           writeQaSuiteProgress(
             progressEnabled,
-            `scenario fail (${index + 1}/${selectedScenarios.length}): ${scenarioIdForLog}`,
+            `scenario fail (${index + 1}/${selectedScenarios.length}): ${scenarioIdForLog}${formatQaScenarioFailureSuffix(scenarioResult)}`,
           );
           completedScenarioResults[index] = scenarioResult;
           writePartialArtifacts();

--- a/extensions/qa-lab/src/suite-run-standard.ts
+++ b/extensions/qa-lab/src/suite-run-standard.ts
@@ -3,7 +3,10 @@ import { disposeRegisteredAgentHarnesses } from "openclaw/plugin-sdk/agent-harne
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createQaGatewayChild } from "./gateway-child.js";
 import type { QaLabLatestReport, QaLabScenarioOutcome } from "./lab-server.types.js";
-import { sanitizeQaProgressValue as sanitizeQaSuiteProgressValue } from "./progress-format.js";
+import {
+  formatQaScenarioFailureSuffix,
+  sanitizeQaProgressValue as sanitizeQaSuiteProgressValue,
+} from "./progress-format.js";
 import { startQaProviderServer } from "./providers/server-runtime.js";
 import {
   measureRuntimeParityCellTiming,
@@ -323,7 +326,7 @@ export async function runQaFlowSuiteStandard(
       scenarios.push(scenarioResult);
       writeQaSuiteProgress(
         progressEnabled,
-        `scenario ${scenarioResult.status} (${index + 1}/${selectedScenarios.length}): ${scenarioIdForLog}`,
+        `scenario ${scenarioResult.status} (${index + 1}/${selectedScenarios.length}): ${scenarioIdForLog}${formatQaScenarioFailureSuffix(scenarioResult)}`,
       );
       liveScenarioOutcomes[index] = {
         id: scenario.id,

--- a/extensions/qa-lab/src/suite-runtime-flow.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.test.ts
@@ -394,7 +394,9 @@ describe("qa suite runtime flow", () => {
       vi.useFakeTimers();
       try {
         const prepareFlow = vi.fn(async () => {
-          await new Promise<void>((resolve) => setTimeout(resolve, preparationMs));
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, preparationMs);
+          });
         });
         const env = createQaSuiteRuntimeFlowTestEnv({ prepareFlow });
         const scenario = makeQaSuiteTestScenario("negative-observation", { config: {} });
@@ -414,7 +416,9 @@ describe("qa suite runtime flow", () => {
             {
               name: "Observe the complete no-reply window",
               run: async () => {
-                await new Promise<void>((resolve) => setTimeout(resolve, 8_000));
+                await new Promise<void>((resolve) => {
+                  setTimeout(resolve, 8_000);
+                });
                 observed();
               },
             },

--- a/extensions/qa-lab/src/suite-runtime-flow.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.test.ts
@@ -388,7 +388,115 @@ describe("qa suite runtime flow", () => {
     );
   });
 
-  it("bounds preparation and actions with one aborting scenario deadline", async () => {
+  it.each([0, 6_000])(
+    "preserves the observation window after %ims of preparation",
+    async (preparationMs) => {
+      vi.useFakeTimers();
+      try {
+        const prepareFlow = vi.fn(async () => {
+          await new Promise<void>((resolve) => setTimeout(resolve, preparationMs));
+        });
+        const env = createQaSuiteRuntimeFlowTestEnv({ prepareFlow });
+        const scenario = makeQaSuiteTestScenario("negative-observation", { config: {} });
+        if (scenario.execution.kind !== "flow") {
+          throw new Error("expected flow scenario");
+        }
+        scenario.execution.timeoutMs = 8_000;
+        createQaScenarioRuntimeApi.mockImplementationOnce(
+          (params: { deps: { runScenario: typeof runQaSuiteScenarioSteps } }) => ({
+            runScenario: params.deps.runScenario,
+          }),
+        );
+        const observed = vi.fn();
+        runScenarioFlow.mockImplementationOnce(async (params) => {
+          const api = params.api as { runScenario: typeof runQaSuiteScenarioSteps };
+          return await api.runScenario("Negative observation", [
+            {
+              name: "Observe the complete no-reply window",
+              run: async () => {
+                await new Promise<void>((resolve) => setTimeout(resolve, 8_000));
+                observed();
+              },
+            },
+          ]);
+        });
+        const pending = runQaSuiteScenarioDefinition({
+          env,
+          scenario,
+          runScenario: runQaSuiteScenarioSteps,
+          splitModelRef: (raw) => parseModelRef(raw, "openai"),
+          formatErrorMessage: (error) => String(error),
+          liveTurnTimeoutMs: () => 60_000,
+          resolveQaLiveTurnTimeoutMs: () => 60_000,
+          constants: qaSuiteRuntimeFlowTestConstants,
+        });
+        await vi.advanceTimersByTimeAsync(preparationMs + 7_999);
+        expect(observed).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        expect((await pending).status).toBe("pass");
+        expect(observed).toHaveBeenCalledOnce();
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each([undefined, 8_000])(
+    "aborts stuck preparation with scenario timeout %s",
+    async (timeoutMs) => {
+      vi.useFakeTimers();
+      try {
+        let preparationSignal: AbortSignal | undefined;
+        const prepareFlow = vi.fn(async (input: { signal?: AbortSignal }) => {
+          preparationSignal = input.signal;
+          await new Promise<void>(() => {});
+        });
+        const env = createQaSuiteRuntimeFlowTestEnv({ prepareFlow });
+        const scenario = makeQaSuiteTestScenario("stuck-preparation", { config: {} });
+        if (scenario.execution.kind !== "flow") {
+          throw new Error("expected flow scenario");
+        }
+        scenario.execution.timeoutMs = timeoutMs;
+        createQaScenarioRuntimeApi.mockImplementationOnce(
+          (params: { deps: { runScenario: typeof runQaSuiteScenarioSteps } }) => ({
+            runScenario: params.deps.runScenario,
+          }),
+        );
+        const action = vi.fn();
+        runScenarioFlow.mockImplementationOnce(async (params) => {
+          const api = params.api as { runScenario: typeof runQaSuiteScenarioSteps };
+          return await api.runScenario("Stuck preparation", [{ name: "Action", run: action }]);
+        });
+        const pending = runQaSuiteScenarioDefinition({
+          env,
+          scenario,
+          runScenario: runQaSuiteScenarioSteps,
+          splitModelRef: (raw) => parseModelRef(raw, "openai"),
+          formatErrorMessage: (error) => String(error),
+          liveTurnTimeoutMs: () => 60_000,
+          resolveQaLiveTurnTimeoutMs: () => 60_000,
+          constants: qaSuiteRuntimeFlowTestConstants,
+        });
+        await vi.advanceTimersByTimeAsync(64_999);
+        expect(preparationSignal?.aborted).toBe(false);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(await pending).toMatchObject({
+          status: "fail",
+          steps: [{ name: "Prepare QA Channel", status: "fail" }],
+        });
+        expect(preparationSignal?.aborted).toBe(true);
+        expect(action).not.toHaveBeenCalled();
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("bounds actions after preparation with an aborting scenario deadline", async () => {
     vi.useFakeTimers();
     try {
       let preparationSignal: AbortSignal | undefined;
@@ -437,13 +545,14 @@ describe("qa suite runtime flow", () => {
         resolveQaLiveTurnTimeoutMs: () => 60_000,
         constants: qaSuiteRuntimeFlowTestConstants,
       });
-      await vi.advanceTimersByTimeAsync(5_029);
+      await vi.advanceTimersByTimeAsync(5_039);
       expect(actionSignal?.aborted).toBe(false);
       await vi.advanceTimersByTimeAsync(1);
       const result = await pending;
 
       expect(result).toMatchObject({ status: "fail", details: expect.stringContaining("30ms") });
-      expect(preparationSignal).toBe(actionSignal);
+      expect(preparationSignal).not.toBe(actionSignal);
+      expect(preparationSignal?.aborted).toBe(false);
       expect(actionSignal?.aborted).toBe(true);
       expect(vi.getTimerCount()).toBe(0);
     } finally {

--- a/extensions/qa-lab/src/suite-runtime-flow.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.ts
@@ -260,22 +260,22 @@ function createQaScenarioDeadline(timeoutMs?: number) {
   const controller = new AbortController();
   let timer: ReturnType<typeof setTimeout> | undefined;
   const deadlineTimeoutMs = resolveQaGatewayTimeoutWithGraceMs(timeoutMs);
-  const deadline =
-    deadlineTimeoutMs === undefined
-      ? undefined
-      : new Promise<never>((_resolve, reject) => {
+  let deadline: Promise<never> | undefined;
+  return {
+    signal: controller.signal,
+    run: async <T>(operation: () => Promise<T>) => {
+      controller.signal.throwIfAborted();
+      if (deadlineTimeoutMs !== undefined) {
+        deadline ??= new Promise<never>((_resolve, reject) => {
           const timeoutError = new Error(`QA scenario flow timed out after ${timeoutMs}ms`);
-          // Scenario-owned polls may consume the full declared timeout. Keep the outer
-          // lifecycle fence later so their terminal result and cleanup stay authoritative.
+          // Start at this owner's first operation. Preparation has a separate
+          // budget and must not consume a scenario's complete observation window.
           timer = setTimeout(() => {
             controller.abort(timeoutError);
             reject(timeoutError);
           }, deadlineTimeoutMs);
         });
-  return {
-    signal: controller.signal,
-    run: async <T>(operation: () => Promise<T>) => {
-      controller.signal.throwIfAborted();
+      }
       // In-flight calls abort cooperatively. The flow runner fences later actions and
       // preserves DSL finally cleanup; the suite owner then tears down runtime resources.
       return deadline ? await Promise.race([operation(), deadline]) : await operation();
@@ -300,43 +300,51 @@ function createQaSuiteScenarioStepRunner(
   const prepareFlow = env.transport.prepareFlow;
   const execution = scenario.execution;
   return async (name, steps) => {
+    const scenarioSteps = steps.map((step) =>
+      Object.assign({}, step, { run: async () => await deadline.run(step.run) }),
+    );
     const preparedSteps =
       prepareFlow && execution.kind === "flow"
         ? [
             {
               name: `Prepare ${env.transport.label}`,
               run: async () => {
-                const prepared = await prepareFlow({
-                  signal: deadline.signal,
-                  config: execution.config ?? {},
-                  gateway: env.gateway,
-                  outputDir: env.outputDir,
-                  primaryModel: env.primaryModel,
-                  scenarioId: scenario.id,
-                  scenarioTitle: scenario.title,
-                  timeoutMs: execution.timeoutMs ?? deps.liveTurnTimeoutMs(env, 60_000),
-                  waitForConfigRestartSettle: async (options) =>
-                    await suiteRuntimeGateway.waitForConfigRestartSettle(
-                      env,
-                      options?.restartDelayMs,
-                      options?.timeoutMs,
-                    ),
-                });
-                deadline.signal.throwIfAborted();
-                if (prepared) {
-                  Object.assign(vars, prepared);
+                const fallbackTimeoutMs = deps.liveTurnTimeoutMs(env, 60_000);
+                const preparationDeadline = createQaScenarioDeadline(
+                  Math.max(execution.timeoutMs ?? 0, fallbackTimeoutMs),
+                );
+                try {
+                  const prepared = await preparationDeadline.run(() =>
+                    prepareFlow({
+                      signal: preparationDeadline.signal,
+                      config: execution.config ?? {},
+                      gateway: env.gateway,
+                      outputDir: env.outputDir,
+                      primaryModel: env.primaryModel,
+                      scenarioId: scenario.id,
+                      scenarioTitle: scenario.title,
+                      timeoutMs: execution.timeoutMs ?? fallbackTimeoutMs,
+                      waitForConfigRestartSettle: async (options) =>
+                        await suiteRuntimeGateway.waitForConfigRestartSettle(
+                          env,
+                          options?.restartDelayMs,
+                          options?.timeoutMs,
+                        ),
+                    }),
+                  );
+                  preparationDeadline.signal.throwIfAborted();
+                  if (prepared) {
+                    Object.assign(vars, prepared);
+                  }
+                } finally {
+                  preparationDeadline.dispose();
                 }
               },
             },
-            ...steps,
+            ...scenarioSteps,
           ]
-        : steps;
-    return await deps.runScenario(
-      name,
-      preparedSteps.map((step) =>
-        Object.assign({}, step, { run: async () => await deadline.run(step.run) }),
-      ),
-    );
+        : scenarioSteps;
+    return await deps.runScenario(name, preparedSteps);
   };
 }
 

--- a/patches/README.md
+++ b/patches/README.md
@@ -2,6 +2,10 @@
 
 Keep existing insertion anchors when extending these patches: pnpm 12 can apply a zero-context, zero-length insertion one line early. After regeneration and installation, verify installed files against the patch's target blob hashes before testing.
 
+`matrix-js-sdk@42.2.0` has an approved temporary patch for saved-sync verification replay. Classic sync propagates its existing cache provenance through ordinary client events, and the crypto listener ignores restored events. This preserves room history, sync cursors, ordinary event listeners, fresh verification events, and to-device processing while preventing cached verification requests from restarting after a clean client shutdown.
+
+Remove the Matrix patch, its registration, and its exact-version guard exception when an upstream release passes `node scripts/run-vitest.mjs extensions/matrix/src/matrix/client/file-sync-store.sdk.test.ts` and the full Matrix QA catalog, including the original DM SAS-to-QR sequence. The regression exercises the real SQLite sync store, SDK cache hydration, and crypto event wiring; it observes crypto input rather than substituting for native verification proof.
+
 `@vitest/runner@4.1.11` has an approved temporary pnpm patch for lost trailing task updates. It accepts the exact batching deadline and clears the consumed timer handle before re-entering the throttle, allowing an early callback to rearm. The 100 ms batching interval and immediate-call cancellation stay unchanged; this is not a maintained fork or a reporting SLA.
 
 Remove the runner patch, its registration, and its exact-version guard exception when upgrading to an upstream fixed version with `test/scripts/vitest-runner-task-updates.test.ts` green. Keep that regression to verify completion delivery without later task events or file-finalization rescue. Generate and register patches through pnpm; never edit installed dependency files manually.

--- a/patches/matrix-js-sdk@42.2.0.patch
+++ b/patches/matrix-js-sdk@42.2.0.patch
@@ -1,0 +1,204 @@
+diff --git a/lib/client.d.ts b/lib/client.d.ts
+index 2cfc6b697f206c53d309c105915c1e7a04603a60..3b441441b89b5eab79af48115381cd7fee0934f0 100644
+--- a/lib/client.d.ts
++++ b/lib/client.d.ts
+@@ -710,6 +710,7 @@ export declare enum ClientEvent {
+      * events received over context, search, or pagination APIs.
+      *
+      * The payload is the matrix event which caused this event to fire.
++     * The optional second argument is true when replaying a saved sync response.
+      * @example
+      * ```
+      * matrixClient.on("event", function(event){
+@@ -802,7 +803,7 @@ type UserEvents = UserEvent.AvatarUrl | UserEvent.DisplayName | UserEvent.Presen
+ export type EmittedEvents = ClientEvent | RoomEvents | RoomStateEvents | CryptoEvents | MatrixEventEvents | RoomMemberEvents | UserEvents | CallEvent | CallEventHandlerEvent.Incoming | GroupCallEventHandlerEvent.Incoming | GroupCallEventHandlerEvent.Outgoing | GroupCallEventHandlerEvent.Ended | GroupCallEventHandlerEvent.Participants | HttpApiEvent.SessionLoggedOut | HttpApiEvent.NoConsent | BeaconEvent;
+ export type ClientEventHandlerMap = {
+     [ClientEvent.Sync]: (state: SyncState, prevState: SyncState | null, data?: ISyncStateData) => void;
+-    [ClientEvent.Event]: (event: MatrixEvent) => void;
++    [ClientEvent.Event]: (event: MatrixEvent, fromCache?: boolean) => void;
+     [ClientEvent.ToDeviceEvent]: (event: MatrixEvent) => void;
+     [ClientEvent.ReceivedToDeviceMessage]: (payload: ReceivedToDeviceMessage) => void;
+     [ClientEvent.AccountData]: (event: MatrixEvent, lastEvent?: MatrixEvent) => void;
+diff --git a/lib/client.js b/lib/client.js
+index eb0462b6d87934c7577299867786eb0f1790315b..14eafe15cc8448b140813f5319f34d648164a64a 100644
+--- a/lib/client.js
++++ b/lib/client.js
+@@ -227,6 +227,7 @@ export let ClientEvent = /*#__PURE__*/function (ClientEvent) {
+    * events received over context, search, or pagination APIs.
+    *
+    * The payload is the matrix event which caused this event to fire.
++   * The optional second argument is true when replaying a saved sync response.
+    * @example
+    * ```
+    * matrixClient.on("event", function(event){
+@@ -1093,8 +1094,11 @@ export class MatrixClient extends TypedEventEmitter {
+     // attach the event listeners needed by RustCrypto
+     this.on(RoomMemberEvent.Membership, rustCrypto.onRoomMembership.bind(rustCrypto));
+     this.on(RoomStateEvent.Events, rustCrypto.onRoomStateEvent.bind(rustCrypto));
+-    this.on(ClientEvent.Event, event => {
+-      void rustCrypto.onLiveEventFromSync(event);
++    this.on(ClientEvent.Event, (event, fromCache) => {
++      // Restored room history must not restart completed verification requests.
++      if (!fromCache) {
++        void rustCrypto.onLiveEventFromSync(event);
++      }
+     });
+ 
+     // re-emit the events emitted by the crypto impl
+diff --git a/lib/sync.js b/lib/sync.js
+index eaf158f49414ef510577b8e9397aff51f0630df6..33c86a52a5fe7268d097c0aacc8391aa2db58c03 100644
+--- a/lib/sync.js
++++ b/lib/sync.js
+@@ -955,7 +955,7 @@ export class SyncApi {
+           user.setPresenceEvent(presenceEvent);
+           client.store.storeUser(user);
+         }
+-        client.emit(ClientEvent.Event, presenceEvent);
++        client.emit(ClientEvent.Event, presenceEvent, syncEventData.fromCache);
+       });
+     }
+ 
+@@ -1065,7 +1065,7 @@ export class SyncApi {
+         room.recalculate();
+       }
+       stateEvents.forEach(function (e) {
+-        client.emit(ClientEvent.Event, e);
++        client.emit(ClientEvent.Event, e, syncEventData.fromCache);
+       });
+     }));
+ 
+@@ -1243,7 +1243,7 @@ export class SyncApi {
+         client.emit(ClientEvent.Room, room);
+       }
+       this.processEventsForNotifs(room, timelineEvents);
+-      const emitEvent = e => client.emit(ClientEvent.Event, e);
++      const emitEvent = e => client.emit(ClientEvent.Event, e, syncEventData.fromCache);
+       // this fires a couple of times for some events. (eg state events are in the timeline and the state)
+       // should this get a sync section as an additional event emission param (e, syncSection))?
+       stateEvents.forEach(emitEvent);
+@@ -1278,16 +1278,16 @@ export class SyncApi {
+       }
+       this.processEventsForNotifs(room, timelineEvents);
+       stateEvents?.forEach(function (e) {
+-        client.emit(ClientEvent.Event, e);
++        client.emit(ClientEvent.Event, e, syncEventData.fromCache);
+       });
+       stateAfterEvents?.forEach(function (e) {
+-        client.emit(ClientEvent.Event, e);
++        client.emit(ClientEvent.Event, e, syncEventData.fromCache);
+       });
+       timelineEvents.forEach(function (e) {
+-        client.emit(ClientEvent.Event, e);
++        client.emit(ClientEvent.Event, e, syncEventData.fromCache);
+       });
+       accountDataEvents.forEach(function (e) {
+-        client.emit(ClientEvent.Event, e);
++        client.emit(ClientEvent.Event, e, syncEventData.fromCache);
+       });
+     }));
+ 
+@@ -1305,7 +1305,7 @@ export class SyncApi {
+         room.recalculate();
+       }
+       stateEvents.forEach(function (e) {
+-        client.emit(ClientEvent.Event, e);
++        client.emit(ClientEvent.Event, e, syncEventData.fromCache);
+       });
+     }));
+ 
+diff --git a/src/client.ts b/src/client.ts
+index e8cadfb3cb11a4ea01807adf275b376fe363e16c..46e1b9e44a6a6cb23de805199b6f69a41946bd13 100644
+--- a/src/client.ts
++++ b/src/client.ts
+@@ -1017,6 +1017,7 @@ export enum ClientEvent {
+      * events received over context, search, or pagination APIs.
+      *
+      * The payload is the matrix event which caused this event to fire.
++     * The optional second argument is true when replaying a saved sync response.
+      * @example
+      * ```
+      * matrixClient.on("event", function(event){
+@@ -1158,7 +1159,7 @@ export type EmittedEvents =
+ 
+ export type ClientEventHandlerMap = {
+     [ClientEvent.Sync]: (state: SyncState, prevState: SyncState | null, data?: ISyncStateData) => void;
+-    [ClientEvent.Event]: (event: MatrixEvent) => void;
++    [ClientEvent.Event]: (event: MatrixEvent, fromCache?: boolean) => void;
+     [ClientEvent.ToDeviceEvent]: (event: MatrixEvent) => void;
+     [ClientEvent.ReceivedToDeviceMessage]: (payload: ReceivedToDeviceMessage) => void;
+     [ClientEvent.AccountData]: (event: MatrixEvent, lastEvent?: MatrixEvent) => void;
+@@ -2049,8 +2050,11 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
+         // attach the event listeners needed by RustCrypto
+         this.on(RoomMemberEvent.Membership, rustCrypto.onRoomMembership.bind(rustCrypto));
+         this.on(RoomStateEvent.Events, rustCrypto.onRoomStateEvent.bind(rustCrypto));
+-        this.on(ClientEvent.Event, (event) => {
+-            void rustCrypto.onLiveEventFromSync(event);
++        this.on(ClientEvent.Event, (event, fromCache) => {
++            // Restored room history must not restart completed verification requests.
++            if (!fromCache) {
++                void rustCrypto.onLiveEventFromSync(event);
++            }
+         });
+ 
+         // re-emit the events emitted by the crypto impl
+diff --git a/src/sync.ts b/src/sync.ts
+index 3e01c4b64494c19c3a13a57a6cc7e33a87f79f56..095d6809515dde949bd1c688beff133427ac011f 100644
+--- a/src/sync.ts
++++ b/src/sync.ts
+@@ -1131,7 +1131,7 @@ export class SyncApi {
+                         user.setPresenceEvent(presenceEvent);
+                         client.store.storeUser(user);
+                     }
+-                    client.emit(ClientEvent.Event, presenceEvent);
++                    client.emit(ClientEvent.Event, presenceEvent, syncEventData.fromCache);
+                 });
+         }
+ 
+@@ -1249,7 +1249,7 @@ export class SyncApi {
+                     room.recalculate();
+                 }
+                 stateEvents.forEach(function (e) {
+-                    client.emit(ClientEvent.Event, e);
++                    client.emit(ClientEvent.Event, e, syncEventData.fromCache);
+                 });
+             }),
+         );
+@@ -1477,7 +1477,7 @@ export class SyncApi {
+ 
+                 this.processEventsForNotifs(room, timelineEvents);
+ 
+-                const emitEvent = (e: MatrixEvent): boolean => client.emit(ClientEvent.Event, e);
++                const emitEvent = (e: MatrixEvent): boolean => client.emit(ClientEvent.Event, e, syncEventData.fromCache);
+                 // this fires a couple of times for some events. (eg state events are in the timeline and the state)
+                 // should this get a sync section as an additional event emission param (e, syncSection))?
+                 stateEvents.forEach(emitEvent);
+@@ -1518,16 +1518,16 @@ export class SyncApi {
+                 this.processEventsForNotifs(room, timelineEvents);
+ 
+                 stateEvents?.forEach(function (e) {
+-                    client.emit(ClientEvent.Event, e);
++                    client.emit(ClientEvent.Event, e, syncEventData.fromCache);
+                 });
+                 stateAfterEvents?.forEach(function (e) {
+-                    client.emit(ClientEvent.Event, e);
++                    client.emit(ClientEvent.Event, e, syncEventData.fromCache);
+                 });
+                 timelineEvents.forEach(function (e) {
+-                    client.emit(ClientEvent.Event, e);
++                    client.emit(ClientEvent.Event, e, syncEventData.fromCache);
+                 });
+                 accountDataEvents.forEach(function (e) {
+-                    client.emit(ClientEvent.Event, e);
++                    client.emit(ClientEvent.Event, e, syncEventData.fromCache);
+                 });
+             }),
+         );
+@@ -1549,7 +1549,7 @@ export class SyncApi {
+                     room.recalculate();
+                 }
+                 stateEvents.forEach(function (e) {
+-                    client.emit(ClientEvent.Event, e);
++                    client.emit(ClientEvent.Event, e, syncEventData.fromCache);
+                 });
+             }),
+         );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,7 @@ packageExtensionsChecksum: sha256-zZ8fyodhMTumshonC7kktCqTPsiHL3UAyS9vltFAlMo=
 
 patchedDependencies:
   '@vitest/runner@4.1.11': 55258cdf55f944f5e9bfbc52251b3696225ca2993e2d9f56b90b88f764193d93
+  matrix-js-sdk@42.2.0: 9e97147d99b86977d6665a676cdf853434ef61eee7cfb176bb66c9c48da599b4
   vitest@4.1.11: c21477c229514823498ab3a08311070cec46b1811e866bc1b3f6ff3f5720da2e
 
 importers:
@@ -1353,7 +1354,7 @@ importers:
         version: 15.0.0
       matrix-js-sdk:
         specifier: 42.2.0
-        version: 42.2.0
+        version: 42.2.0(patch_hash=9e97147d99b86977d6665a676cdf853434ef61eee7cfb176bb66c9c48da599b4)
       music-metadata:
         specifier: 11.15.0
         version: 11.15.0(supports-color@10.2.2)
@@ -14907,7 +14908,7 @@ snapshots:
 
   matrix-events-sdk@0.0.1: {}
 
-  matrix-js-sdk@42.2.0:
+  matrix-js-sdk@42.2.0(patch_hash=9e97147d99b86977d6665a676cdf853434ef61eee7cfb176bb66c9c48da599b4):
     dependencies:
       '@babel/runtime': 8.0.0
       '@matrix-org/matrix-sdk-crypto-wasm': 18.5.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -92,3 +92,4 @@ packageExtensions:
 patchedDependencies:
   "@vitest/runner@4.1.11": patches/@vitest__runner@4.1.11.patch
   "vitest@4.1.11": patches/vitest@4.1.11.patch
+  "matrix-js-sdk@42.2.0": patches/matrix-js-sdk@42.2.0.patch

--- a/scripts/check-package-patches.mts
+++ b/scripts/check-package-patches.mts
@@ -14,6 +14,7 @@ const ALLOWED_PATCHED_DEPENDENCIES = new Map([
   ["vitest@4.1.11", "patches/vitest@4.1.11.patch"],
   ["baileys@7.0.0-rc12", "patches/baileys@7.0.0-rc12.patch"],
   ["baileys@7.0.0-rc13", "patches/baileys@7.0.0-rc13.patch"],
+  ["matrix-js-sdk@42.2.0", "patches/matrix-js-sdk@42.2.0.patch"],
 ]);
 
 const ALLOWED_PATCH_FILES = new Set(["patches/.gitkeep", ...ALLOWED_PATCHED_DEPENDENCIES.values()]);

--- a/scripts/generate-npm-package-lock.mts
+++ b/scripts/generate-npm-package-lock.mts
@@ -2,10 +2,13 @@
 // Generates package-lock.json files that mirror pnpm lock policy for
 // published packages while stripping dev-only dependency state.
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   cpSync,
   existsSync,
   mkdtempSync,
+  lstatSync,
+  realpathSync,
   readFileSync,
   readdirSync,
   rmSync,
@@ -16,6 +19,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { isMainThread, parentPort, Worker, workerData } from "node:worker_threads";
 import pMap from "p-map";
+import semver from "semver";
 import { parse as parseYaml } from "yaml";
 import { isRecord } from "../packages/normalization-core/src/record-coerce.ts";
 import { listChangedPathsFromGit, listStagedChangedPaths } from "./changed-lanes.mts";
@@ -31,7 +35,15 @@ type NpmLockExecInvocation = UnknownRecord & {
   shell?: boolean;
   windowsVerbatimArguments?: boolean;
 };
+export type NpmLocalPackageArtifact = {
+  name: string;
+  version: string;
+  spec: string;
+  integrity: string;
+};
+
 type NpmLockOptions = {
+  localPackageArtifacts?: NpmLocalPackageArtifact[];
   env?: NodeJS.ProcessEnv;
   installStrategy?: "hoisted" | "nested" | "shallow" | "linked" | "" | null;
 };
@@ -504,7 +516,26 @@ function readNpmLockOverrides() {
   return expandScopedOverrideChildren(mergedOverrides);
 }
 
-function packageJsonForNpmLock(packageJson: UnknownRecord, npmLockOverrides: OverrideMap) {
+export function packageRuntimeDependencyField(packageJson: UnknownRecord, name: string) {
+  return recordAt(packageJson, "optionalDependencies")?.[name] !== undefined
+    ? "optionalDependencies"
+    : "dependencies";
+}
+
+function artifactMatchesOwnOverride(artifact: NpmLocalPackageArtifact, spec: unknown) {
+  return (
+    spec === undefined ||
+    spec === `$${artifact.name}` ||
+    spec === "*" ||
+    (typeof spec === "string" && semver.satisfies(artifact.version, spec))
+  );
+}
+
+function packageJsonForNpmLock(
+  packageJson: UnknownRecord,
+  npmLockOverrides: OverrideMap,
+  localPackageArtifacts: NpmLocalPackageArtifact[] = [],
+) {
   const normalized = { ...packageJson };
   delete normalized.bundleDependencies;
   delete normalized.bundledDependencies;
@@ -520,8 +551,97 @@ function packageJsonForNpmLock(packageJson: UnknownRecord, npmLockOverrides: Ove
       ),
     );
   }
-  normalized.overrides = mergeOverrides(packageJson.overrides, npmLockOverrides, {});
+  const packageOverrides = normalizeOverrides(packageJson.overrides);
+  const policyOverrides = { ...npmLockOverrides };
+  const localOverrides: OverrideMap = {};
+  for (const artifact of localPackageArtifacts) {
+    const selector = `${artifact.name}@${artifact.version}`;
+    const current = packageOverrides[selector];
+    if (isRecord(current) && current["."] === `$${artifact.name}`) {
+      const field = packageRuntimeDependencyField(packageJson, artifact.name);
+      if (recordAt(packageJson, field)?.[artifact.name] === artifact.spec) {
+        // Reentry already selected the effective rule. Its synthetic exact key
+        // must not merge children from a previously shadowed exact policy.
+        localOverrides[selector] = current;
+        delete packageOverrides[selector];
+        delete policyOverrides[selector];
+        continue;
+      }
+      const incoming = npmLockOverrides[`${artifact.name}@${artifact.version}`];
+      const ownSpec = isRecord(incoming) ? incoming["."] : incoming;
+      if (!artifactMatchesOwnOverride(artifact, ownSpec)) {
+        throw new Error(`local package artifact conflicts with override for ${artifact.name}`);
+      }
+      // Source-owned references still use the ordinary first-pass policy merge.
+      current["."] = ownSpec ?? artifact.version;
+    }
+  }
+  const overrides = mergeOverrides(packageOverrides, policyOverrides, {}) ?? {};
+  for (const artifact of localPackageArtifacts) {
+    const selector = `${artifact.name}@${artifact.version}`;
+    const current =
+      localOverrides[selector] ??
+      Object.entries(overrides).find(([key]) => {
+        if (key === artifact.name) {
+          return true;
+        }
+        const parsed = parsePnpmPackageKey(key);
+        return (
+          parsed?.name === artifact.name &&
+          (parsed.version === "*" || semver.satisfies(artifact.version, parsed.version))
+        );
+      })?.[1];
+    const ownSpec = isRecord(current) ? current["."] : current;
+    if (!artifactMatchesOwnOverride(artifact, ownSpec)) {
+      throw new Error(`local package artifact conflicts with override for ${artifact.name}`);
+    }
+    // npm matches overrides in order. Only this version references the temporary
+    // direct file spec; keep broad registry pins and child policies for other versions.
+    delete overrides[selector];
+    localOverrides[selector] = { ...(isRecord(current) ? current : {}), ".": `$${artifact.name}` };
+    const field = packageRuntimeDependencyField(normalized, artifact.name);
+    const dependencies = recordAt(normalized, field);
+    if (!dependencies || dependencies[artifact.name] === undefined) {
+      throw new Error(`local package artifact is not a direct dependency: ${artifact.name}`);
+    }
+    normalized[field] = { ...dependencies, [artifact.name]: artifact.spec };
+  }
+  normalized.overrides =
+    Object.keys(localOverrides).length + Object.keys(overrides).length > 0
+      ? { ...localOverrides, ...overrides }
+      : undefined;
   return normalized;
+}
+
+function validateLocalPackageArtifacts(packageDir: string, artifacts: NpmLocalPackageArtifact[]) {
+  const root = realpathSync(packageDir);
+  if (new Set(artifacts.map(({ name }) => name)).size !== artifacts.length) {
+    throw new Error("duplicate local package artifact binding");
+  }
+  for (const artifact of artifacts) {
+    const target = path.resolve(packageDir, artifact.spec.slice("file:".length));
+    if (
+      !artifact.spec.startsWith("file:./") ||
+      !target.endsWith(".tgz") ||
+      !EXACT_VERSION_PATTERN.test(artifact.version) ||
+      !/^(?:@[a-z0-9._-]+\/)?[a-z0-9._-]+$/u.test(artifact.name)
+    ) {
+      throw new Error(`invalid local package artifact: ${artifact.name}`);
+    }
+    const relative = path.relative(root, realpathSync(target));
+    if (
+      !relative ||
+      relative.startsWith("..") ||
+      path.isAbsolute(relative) ||
+      !lstatSync(target).isFile()
+    ) {
+      throw new Error(`local package artifact escapes package root: ${artifact.spec}`);
+    }
+    const integrity = `sha512-${createHash("sha512").update(readFileSync(target)).digest("base64")}`;
+    if (artifact.integrity !== integrity) {
+      throw new Error(`local package artifact integrity mismatch: ${artifact.name}`);
+    }
+  }
 }
 
 function copyLocalFileDependencies(
@@ -934,7 +1054,14 @@ export function generateNpmPackageLock(packageDir: string, options: NpmLockOptio
     const packageJson = parseJsonObject(
       readFileSync(path.join(packageDir, "package.json"), "utf8"),
     );
+    const localPackageArtifacts = options.localPackageArtifacts ?? [];
+    validateLocalPackageArtifacts(packageDir, localPackageArtifacts);
     const npmLockOverrides = readNpmLockOverrides();
+    const normalizedPackageJson = packageJsonForNpmLock(
+      packageJson,
+      npmLockOverrides,
+      localPackageArtifacts,
+    );
     const peerResolutionArgs = shouldUseLegacyPeerDepsForNpmLock(packageJson)
       ? ["--legacy-peer-deps"]
       : [];
@@ -949,9 +1076,9 @@ export function generateNpmPackageLock(packageDir: string, options: NpmLockOptio
     ];
     writeFileSync(
       path.join(tempDir, "package.json"),
-      `${JSON.stringify(packageJsonForNpmLock(packageJson, npmLockOverrides), null, 2)}\n`,
+      `${JSON.stringify(normalizedPackageJson, null, 2)}\n`,
     );
-    copyLocalFileDependencies(packageJson, packageDir, tempDir);
+    copyLocalFileDependencies(normalizedPackageJson, packageDir, tempDir);
     runNpm(npmInstallArgs, tempDir, env);
     normalizeNpmLockOverrides(tempDir, npmLockOverrides, npmInstallArgs, env);
     const generated = normalizeNpmVersionDrift(
@@ -959,7 +1086,7 @@ export function generateNpmPackageLock(packageDir: string, options: NpmLockOptio
         parseJsonObject(readFileSync(path.join(tempDir, "package-lock.json"), "utf8")),
       ),
     );
-    assertNpmLockMatchesPnpmLock(generated);
+    assertNpmLockMatchesPnpmLock(generated, localPackageArtifacts);
     return `${JSON.stringify(generated, null, 2)}\n`;
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
@@ -970,6 +1097,7 @@ function collectPnpmLockViolations(
   npmLock: unknown,
   pnpmLockPackages = readPnpmLockPackages(),
   pnpmLockIntegrities = readPnpmLockPackageIntegrities(),
+  localPackageArtifacts: NpmLocalPackageArtifact[] = [],
 ) {
   const packages = recordAt(npmLock, "packages");
   if (!packages) {
@@ -1003,9 +1131,14 @@ function collectPnpmLockViolations(
       violations.push({ path: lockPath, packageKey });
       continue;
     }
-    const expectedIntegrities = [...(pnpmLockIntegrities.get(packageKey) ?? [])].toSorted(
-      (left, right) => left.localeCompare(right),
+    // Only this direct occurrence may use the independently verified packed bytes.
+    // Registry copies, including nested copies of the same package, retain their lock hashes.
+    const artifact = localPackageArtifacts.find(
+      (entry) => lockPath === `node_modules/${entry.name}`,
     );
+    const expectedIntegrities = [
+      ...(artifact ? [artifact.integrity] : (pnpmLockIntegrities.get(packageKey) ?? [])),
+    ].toSorted((left, right) => left.localeCompare(right));
     if (
       expectedIntegrities.length > 0 &&
       (typeof metadata.integrity !== "string" || !expectedIntegrities.includes(metadata.integrity))
@@ -1021,8 +1154,31 @@ function collectPnpmLockViolations(
   return violations;
 }
 
-function assertNpmLockMatchesPnpmLock(npmLock: unknown) {
-  const violations = collectPnpmLockViolations(npmLock);
+function assertNpmLockMatchesPnpmLock(
+  npmLock: unknown,
+  localPackageArtifacts: NpmLocalPackageArtifact[] = [],
+) {
+  const packages = recordAt(npmLock, "packages");
+  for (const artifact of localPackageArtifacts) {
+    const metadata = recordAt(packages, `node_modules/${artifact.name}`);
+    if (
+      !metadata ||
+      (metadata.name ?? artifact.name) !== artifact.name ||
+      metadata.version !== artifact.version ||
+      metadata.integrity !== artifact.integrity ||
+      metadata.resolved !== artifact.spec.replace(/^file:\.\//u, "file:")
+    ) {
+      throw new Error(
+        `npm lock differs from local package artifact: ${artifact.name}@${artifact.version}`,
+      );
+    }
+  }
+  const violations = collectPnpmLockViolations(
+    npmLock,
+    undefined,
+    undefined,
+    localPackageArtifacts,
+  );
   if (violations.length === 0) {
     return;
   }

--- a/scripts/lib/plugin-npm-package-manifest.mts
+++ b/scripts/lib/plugin-npm-package-manifest.mts
@@ -1,15 +1,21 @@
 // Augments plugin npm package manifests with generated runtime/package metadata.
 import { spawnSync } from "node:child_process";
 import type { SpawnSyncOptions } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import JSON5 from "json5";
+import { parse as parseYaml } from "yaml";
 import {
   generateNpmPackageLock,
   packageJsonForNpmLock,
+  packageRuntimeDependencyField,
   readNpmLockOverrides,
+  parsePnpmPackageKey,
+  type NpmLocalPackageArtifact,
 } from "../generate-npm-package-lock.mts";
 import { resolveNpmRunner } from "../npm-runner.mts";
 import type { NpmRunnerParams } from "../npm-runner.mts";
@@ -18,6 +24,7 @@ import {
   resolvePluginNpmRuntimeBuildPlan,
 } from "./plugin-npm-runtime-build.mts";
 import type { PluginNpmRuntimeBuildPlan, PluginPackageJson } from "./plugin-npm-runtime-build.mts";
+import { pnpmLockfileDocuments } from "./pnpm-lockfile-documents.mjs";
 import { isRecord } from "./record-shared.mjs";
 
 const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA_PATH =
@@ -26,6 +33,7 @@ const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA_PATH =
 type JsonRecord = Record<string, unknown>;
 type PluginPackageParams = Parameters<typeof resolvePluginNpmRuntimeBuildPlan>[0] & {
   bundleDependencies?: unknown;
+  patchedDependencies?: WorkspacePatchedDependency[];
 };
 type GeneratedChannelConfig = {
   description?: string;
@@ -37,7 +45,7 @@ type GeneratedChannelConfigs = Record<string, GeneratedChannelConfig>;
 type PluginPackageContext = Pick<
   PluginNpmRuntimeBuildPlan,
   "packageDir" | "packageJson" | "pluginDir"
->;
+> & { patchedDependencies?: WorkspacePatchedDependency[] };
 type SpawnResult = Pick<ReturnType<typeof spawnSync>, "error" | "status">;
 type PluginSpawnOptions = SpawnSyncOptions;
 type PluginNpmCommandParams = Omit<NpmRunnerParams, "npmArgs">;
@@ -221,13 +229,11 @@ function listPackageRuntimeDependencyNames(packageJson: PluginPackageJson) {
 }
 
 function listConfiguredBundledDependencyNames(packageJson: PluginPackageJson) {
-  if (Array.isArray(packageJson.bundledDependencies)) {
-    return packageJson.bundledDependencies.filter((name) => typeof name === "string");
+  const configured = packageJson.bundleDependencies ?? packageJson.bundledDependencies;
+  if (Array.isArray(configured)) {
+    return configured.filter((name) => typeof name === "string");
   }
-  if (Array.isArray(packageJson.bundleDependencies)) {
-    return packageJson.bundleDependencies.filter((name) => typeof name === "string");
-  }
-  if (packageJson.bundleDependencies === true) {
+  if (configured === true) {
     return listPackageRuntimeDependencyNames(packageJson);
   }
   return [];
@@ -251,7 +257,7 @@ export function resolvePluginNpmCommand(
   });
 }
 
-function spawnNpmSync(args: string[], options: SpawnSyncOptions = {}): SpawnResult {
+function spawnNpmSync(args: string[], options: SpawnSyncOptions = {}) {
   const invocation = resolvePluginNpmCommand(args, { env: options.env ?? process.env });
   return spawnSync(invocation.command, invocation.args, {
     ...options,
@@ -505,15 +511,211 @@ function installMissingOptionalBundledDependencies(params: PluginPackageContext)
   }
 }
 
+type WorkspacePatchedDependency = { name: string; version: string; packageDir: string };
+
+function readYamlRecord(file: string, lockfile = false) {
+  const source = fs.readFileSync(file, "utf8");
+  const value: unknown = parseYaml(lockfile ? pnpmLockfileDocuments(source).dependencies : source);
+  return isRecord(value) ? value : {};
+}
+
+function collectWorkspacePatchedDependencies(
+  repoRoot: string,
+  packageDir: string,
+  packageJson: PluginPackageJson,
+) {
+  const workspacePath = path.join(repoRoot, "pnpm-workspace.yaml");
+  if (!fs.existsSync(workspacePath)) {
+    return [];
+  }
+  const declared = readYamlRecord(workspacePath).patchedDependencies;
+  if (!isRecord(declared)) {
+    return [];
+  }
+  const names = new Set(listPackageRuntimeDependencyNames(packageJson));
+  // check-package-patches owns the allowlist and permits only exact-version selectors.
+  let selected = Object.entries(declared).flatMap(([selector, patchPath]) => {
+    const parsed = parsePnpmPackageKey(selector);
+    return parsed && names.has(parsed.name) ? [{ ...parsed, selector, patchPath }] : [];
+  });
+  if (selected.length === 0) {
+    return [];
+  }
+  const lock = readYamlRecord(path.join(repoRoot, "pnpm-lock.yaml"), true);
+  const importerKey = path.relative(repoRoot, packageDir).replaceAll(path.sep, "/");
+  const importer = isRecord(lock.importers) ? lock.importers[importerKey] : undefined;
+  selected = selected.filter(({ name, version }) => {
+    const field = packageRuntimeDependencyField(packageJson, name);
+    const resolved =
+      isRecord(importer) && isRecord(importer[field]) ? importer[field][name] : undefined;
+    if (
+      !isRecord(resolved) ||
+      typeof resolved.version !== "string" ||
+      resolved.specifier !== packageJson[field]?.[name]
+    ) {
+      throw new Error(
+        `patched runtime dependency is missing from the frozen pnpm importer: ${name}`,
+      );
+    }
+    return resolved.version.split("(")[0] === version;
+  });
+  if (selected.length === 0) {
+    return [];
+  }
+  const modules = readYamlRecord(path.join(repoRoot, "node_modules", ".modules.yaml"));
+  const virtualStoreDir = modules.virtualStoreDir ?? ".pnpm";
+  if (typeof virtualStoreDir !== "string") {
+    throw new Error("frozen pnpm install has an invalid virtualStoreDir");
+  }
+  const installedLock = readYamlRecord(
+    path.resolve(repoRoot, "node_modules", virtualStoreDir, "lock.yaml"),
+    true,
+  );
+  const installedImporter = isRecord(installedLock.importers)
+    ? installedLock.importers[importerKey]
+    : undefined;
+  const require = createRequire(path.join(packageDir, "package.json"));
+  // A root declaration alone does not prove the installed bytes were patched.
+  // Bind the patch hash, importer and actual hoisted package before packing it.
+  return selected.map(({ name, version, selector, patchPath }) => {
+    const patchHash =
+      typeof patchPath === "string"
+        ? createHash("sha256")
+            .update(fs.readFileSync(path.resolve(repoRoot, patchPath)))
+            .digest("hex")
+        : "";
+    const field = packageRuntimeDependencyField(packageJson, name);
+    const resolved =
+      isRecord(importer) && isRecord(importer[field]) ? importer[field][name] : undefined;
+    const installed =
+      isRecord(installedImporter) && isRecord(installedImporter[field])
+        ? installedImporter[field][name]
+        : undefined;
+    if (
+      !patchHash ||
+      !isRecord(lock.patchedDependencies) ||
+      lock.patchedDependencies[selector] !== patchHash ||
+      !isRecord(installedLock.patchedDependencies) ||
+      installedLock.patchedDependencies[selector] !== patchHash ||
+      !isRecord(resolved) ||
+      typeof resolved.version !== "string" ||
+      !resolved.version.startsWith(`${version}(`) ||
+      !resolved.version.includes(`(patch_hash=${patchHash})`) ||
+      !isRecord(installed) ||
+      installed.version !== resolved.version ||
+      installed.specifier !== resolved.specifier
+    ) {
+      throw new Error(
+        `patched runtime dependency requires a matching frozen pnpm install: ${selector}`,
+      );
+    }
+    const candidate = require.resolve
+      .paths(name)
+      ?.map((dir) => path.join(dir, name))
+      .find((dir) => fs.existsSync(path.join(dir, "package.json")));
+    const locations = isRecord(modules.hoistedLocations)
+      ? modules.hoistedLocations[`${name}@${resolved.version}`]
+      : undefined;
+    if (
+      !candidate ||
+      modules.nodeLinker !== "hoisted" ||
+      !Array.isArray(locations) ||
+      !locations.some(
+        (location) =>
+          typeof location === "string" &&
+          fs.realpathSync(path.resolve(repoRoot, location)) === fs.realpathSync(candidate),
+      )
+    ) {
+      throw new Error(`patched runtime dependency is not the frozen pnpm package: ${selector}`);
+    }
+    const installedPackage = readJsonFile(path.join(candidate, "package.json"));
+    if (installedPackage.name !== name || installedPackage.version !== version) {
+      throw new Error(`patched runtime dependency identity mismatch: ${selector}`);
+    }
+    return { name, version, packageDir: fs.realpathSync(candidate) };
+  });
+}
+
+function packPatchedDependencies(packageDir: string, dependencies: WorkspacePatchedDependency[]) {
+  if (dependencies.length === 0) {
+    return { artifacts: [], cleanup: () => {} };
+  }
+  const outputDir = fs.mkdtempSync(path.join(packageDir, ".openclaw-patched-dependencies-"));
+  const cleanup = () => fs.rmSync(outputDir, { recursive: true, force: true });
+  try {
+    const artifacts: NpmLocalPackageArtifact[] = dependencies.map(
+      ({ name, version, packageDir: source }) => {
+        const result = spawnNpmSync(
+          [
+            "pack",
+            source,
+            "--json",
+            "--ignore-scripts",
+            "--workspaces=false",
+            "--pack-destination",
+            outputDir,
+          ],
+          {
+            cwd: packageDir,
+            env: process.env,
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "inherit"],
+          },
+        );
+        if (result.error) {
+          throw result.error;
+        }
+        if (result.status !== 0) {
+          throw new Error(`packing patched runtime dependency failed: ${name}@${version}`);
+        }
+        const output = JSON.parse(String(result.stdout));
+        const entries = Array.isArray(output) ? output : Object.values(output);
+        const packed = entries.length === 1 ? entries[0] : undefined;
+        if (
+          !packed ||
+          packed.name !== name ||
+          packed.version !== version ||
+          typeof packed.filename !== "string" ||
+          path.basename(packed.filename) !== packed.filename
+        ) {
+          throw new Error(`packed runtime dependency identity mismatch: ${name}@${version}`);
+        }
+        const tarball = path.join(outputDir, packed.filename);
+        const integrity = `sha512-${createHash("sha512").update(fs.readFileSync(tarball)).digest("base64")}`;
+        if (packed.integrity !== integrity) {
+          throw new Error(`packed runtime dependency integrity mismatch: ${name}@${version}`);
+        }
+        return {
+          name,
+          version,
+          spec: `file:./${path.relative(packageDir, tarball).replaceAll(path.sep, "/")}`,
+          integrity,
+        };
+      },
+    );
+    return { artifacts, cleanup };
+  } catch (error) {
+    cleanup();
+    throw error;
+  }
+}
+
 function packageOptsOutOfBundledRuntimeDependencies(packageJson: PluginPackageJson | undefined) {
   return packageJson?.openclaw?.release?.bundleRuntimeDependencies === false;
 }
 
-function shouldBundleDependencies(value: unknown, packageJson: PluginPackageJson | undefined) {
+function shouldBundleDependencies(
+  value: unknown,
+  packageJson: PluginPackageJson | undefined,
+  patchedDependencies: WorkspacePatchedDependency[] = [],
+) {
   if (packageOptsOutOfBundledRuntimeDependencies(packageJson)) {
+    if (patchedDependencies.length > 0) {
+      throw new Error("patched runtime dependencies conflict with bundleRuntimeDependencies=false");
+    }
     return false;
   }
-  return value === true || value === "1" || value === "true";
+  return patchedDependencies.length > 0 || value === true || value === "1" || value === "true";
 }
 
 function installPackageLocalBundledDependencies(params: PluginPackageContext) {
@@ -547,7 +749,12 @@ function installPackageLocalBundledDependencies(params: PluginPackageContext) {
   };
   delete installPackageJsonBase.peerDependencies;
   delete installPackageJsonBase.peerDependenciesMeta;
-  const installPackageJson = packageJsonForNpmLock(installPackageJsonBase, readNpmLockOverrides());
+  const patched = packPatchedDependencies(params.packageDir, params.patchedDependencies ?? []);
+  const installPackageJson = packageJsonForNpmLock(
+    installPackageJsonBase,
+    readNpmLockOverrides(),
+    patched.artifacts,
+  );
   const installPackageJsonText = `${JSON.stringify(installPackageJson, null, 2)}\n`;
   if (installPackageJsonText !== packedPackageJsonText) {
     // npm validates peer edges against the package lock during ci even when peers are omitted.
@@ -559,7 +766,7 @@ function installPackageLocalBundledDependencies(params: PluginPackageContext) {
       packageLockPath,
       generatePluginNpmPackageLockWithRetry(
         params.packageDir,
-        { installStrategy: "shallow" },
+        { installStrategy: "shallow", localPackageArtifacts: patched.artifacts },
         { pluginDir: params.pluginDir },
       ),
       "utf8",
@@ -596,9 +803,16 @@ function installPackageLocalBundledDependencies(params: PluginPackageContext) {
       );
     }
     installMissingOptionalBundledDependencies(params);
+    for (const { name, version } of params.patchedDependencies ?? []) {
+      const installed = readInstalledPackageJson(params.packageDir, name)?.packageJson;
+      if (installed?.name !== name || installed.version !== version) {
+        throw new Error(`patched runtime dependency was not installed: ${name}@${version}`);
+      }
+    }
   } finally {
     fs.writeFileSync(packageJsonPath, packedPackageJsonText, "utf8");
     fs.rmSync(packageLockPath, { force: true });
+    patched.cleanup();
   }
 }
 
@@ -652,8 +866,21 @@ export function resolveAugmentedPluginNpmPackageJson(params: PluginPackageParams
         : {}),
     },
   };
-  if (shouldBundleDependencies(params.bundleDependencies, plan.packageJson)) {
-    packageJson.bundledDependencies = listPackageRuntimeDependencyNames(packageJson);
+  if (
+    shouldBundleDependencies(
+      params.bundleDependencies,
+      plan.packageJson,
+      params.patchedDependencies,
+    )
+  ) {
+    packageJson.bundledDependencies = [
+      ...new Set([
+        ...listConfiguredBundledDependencyNames(packageJson),
+        ...(shouldBundleDependencies(params.bundleDependencies, plan.packageJson)
+          ? listPackageRuntimeDependencyNames(packageJson)
+          : (params.patchedDependencies ?? []).map(({ name }) => name)),
+      ]),
+    ].toSorted((left, right) => left.localeCompare(right));
     delete packageJson.bundleDependencies;
     delete packageJson.devDependencies;
   }
@@ -665,7 +892,11 @@ export function resolveAugmentedPluginNpmPackageJson(params: PluginPackageParams
     changed,
     packageJson,
     pluginDir: plan.pluginDir,
-    bundleDependencies: shouldBundleDependencies(params.bundleDependencies, plan.packageJson),
+    bundleDependencies: shouldBundleDependencies(
+      params.bundleDependencies,
+      plan.packageJson,
+      params.patchedDependencies,
+    ),
     reason: changed ? "package-local-runtime" : "unchanged",
   };
 }
@@ -821,12 +1052,16 @@ export function withAugmentedPluginNpmManifestForPackage<T>(
   const packageDir = resolvePackageDir(repoRoot, params.packageDir);
   const packageJsonPath = resolvePackageJsonPath(packageDir);
   const packageJson = fs.existsSync(packageJsonPath) ? readJsonFile(packageJsonPath) : undefined;
+  const patchedDependencies = packageJson
+    ? collectWorkspacePatchedDependencies(repoRoot, packageDir, packageJson)
+    : [];
+  const resolvedParams = { ...params, patchedDependencies };
   if (
     !packageJson ||
-    !shouldBundleDependencies(params.bundleDependencies, packageJson) ||
+    !shouldBundleDependencies(params.bundleDependencies, packageJson, patchedDependencies) ||
     !hasPackageRuntimeDependencies(packageJson)
   ) {
-    return withPluginNpmManifestOverlay(params, callback);
+    return withPluginNpmManifestOverlay(resolvedParams, callback);
   }
 
   // pnpm owns the source install. npm bundling needs a separate tree so its
@@ -839,7 +1074,7 @@ export function withAugmentedPluginNpmManifestForPackage<T>(
       filter: (source) => path.basename(source) !== "node_modules",
     });
     return withPluginNpmManifestOverlay(
-      { ...params, repoRoot, packageDir: stagedPackageDir },
+      { ...resolvedParams, repoRoot, packageDir: stagedPackageDir },
       callback,
     );
   } finally {
@@ -860,6 +1095,7 @@ function withPluginNpmManifestOverlay<T>(
   const bundleDependencies = shouldBundleDependencies(
     params.bundleDependencies,
     packageJsonForBundlePolicy,
+    params.patchedDependencies,
   );
   const resolvedManifest = resolveAugmentedPluginNpmManifest({
     repoRoot,
@@ -868,21 +1104,9 @@ function withPluginNpmManifestOverlay<T>(
   const resolvedPackageJson = resolveAugmentedPluginNpmPackageJson({
     repoRoot,
     packageDir,
-    bundleDependencies,
+    bundleDependencies: params.bundleDependencies,
+    patchedDependencies: params.patchedDependencies,
   });
-
-  if (
-    (!resolvedManifest.changed || !resolvedManifest.manifest) &&
-    (!resolvedPackageJson.changed || !resolvedPackageJson.packageJson)
-  ) {
-    return callback({
-      ...resolvedManifest,
-      packageDir,
-      repoRoot,
-      applied: false,
-      packageJsonApplied: false,
-    });
-  }
 
   const originalManifest =
     resolvedManifest.changed && resolvedManifest.manifest
@@ -910,6 +1134,7 @@ function withPluginNpmManifestOverlay<T>(
         packageDir,
         packageJson: resolvedPackageJson.packageJson,
         pluginDir: resolvedPackageJson.pluginDir ?? path.basename(packageDir),
+        patchedDependencies: params.patchedDependencies,
       });
     }
     return callback({

--- a/scripts/plugin-clawhub-publish.sh
+++ b/scripts/plugin-clawhub-publish.sh
@@ -139,7 +139,7 @@ pack_cmd=(
   "${clawhub_workdir}"
   package
   pack
-  "${package_source}"
+  .
   --pack-destination
   "${pack_dir}"
   --json
@@ -174,6 +174,7 @@ if [[ "${packed_mode}" == "false" ]]; then
 
   pack_json="${pack_dir}/pack.json"
   CLAWHUB_WORKDIR="${clawhub_workdir}" \
+    OPENCLAW_NPM_PACKAGE_LOCK_REPO_ROOT="${invocation_root}" \
     node "${repo_root}/scripts/lib/plugin-npm-package-manifest.mjs" --run "${package_dir}" -- \
     "${pack_cmd[@]}" > "${pack_json}"
   pack_output="$(cat "${pack_json}")"

--- a/src/cli/plugins-authoring-command.test.ts
+++ b/src/cli/plugins-authoring-command.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { Type } from "typebox";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { publicPluginSdkSubpaths } from "../../scripts/lib/plugin-sdk-entries.mjs";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { defineToolPlugin, getToolPluginMetadata } from "../plugin-sdk/tool-plugin.js";
 import { defaultRuntime } from "../runtime.js";
@@ -826,7 +827,9 @@ describe("plugin authoring commands", () => {
     const indexSource = fs.readFileSync(path.join(projectDir, "src/index.ts"), "utf8");
     expect(indexSource).toContain("definePluginEntry");
     expect(indexSource).toContain("api.registerProvider");
-    expect(indexSource).toContain("buildSingleProviderApiKeyCatalog");
+    for (const [, subpath] of indexSource.matchAll(/from "openclaw\/plugin-sdk\/([^"]+)"/g)) {
+      expect(publicPluginSdkSubpaths).toContain(subpath);
+    }
 
     expect(fs.readFileSync(path.join(projectDir, "src/index.test.ts"), "utf8")).toContain(
       "OpenClawPluginApi",

--- a/src/cli/plugins-authoring-command.ts
+++ b/src/cli/plugins-authoring-command.ts
@@ -640,37 +640,12 @@ function writeProviderPluginScaffold(params: { rootDir: string; id: string; name
     `Replace https://api.example.com/v1 with your ${params.name} API base URL.`,
   );
   const indexSource = `import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
-import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
-import { buildSingleProviderApiKeyCatalog } from "openclaw/plugin-sdk/provider-catalog-shared";
-import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth";
 
 const PLUGIN_ID = ${idLiteral};
 const PROVIDER_ID = PLUGIN_ID;
 const DEFAULT_MODEL_ID = ${defaultModelIdLiteral};
 const DEFAULT_MODEL_REF = ${defaultModelRefLiteral};
-
-function buildProvider(): ModelProviderConfig {
-  return {
-    api: "openai-completions",
-    baseUrl: "https://api.example.com/v1",
-    models: [
-      {
-        id: DEFAULT_MODEL_ID,
-        name: "Example Chat",
-        reasoning: false,
-        input: ["text"],
-        cost: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-        },
-        contextWindow: 128000,
-        maxTokens: 8192,
-      },
-    ],
-  };
-}
 
 export default definePluginEntry({
   id: PLUGIN_ID,
@@ -700,13 +675,38 @@ export default definePluginEntry({
       ],
       catalog: {
         order: "simple",
-        run: (ctx) =>
-          buildSingleProviderApiKeyCatalog({
-            ctx,
-            providerId: PROVIDER_ID,
-            buildProvider,
-            allowExplicitBaseUrl: true,
-          }),
+        run: async (ctx) => {
+          const apiKey = ctx.resolveProviderApiKey(PROVIDER_ID).apiKey;
+          if (!apiKey) {
+            return null;
+          }
+          const configuredProvider = Object.entries(ctx.config.models?.providers ?? {}).find(
+            ([providerId]) => providerId.trim().toLowerCase() === PROVIDER_ID.toLowerCase(),
+          )?.[1];
+          return {
+            provider: {
+              api: "openai-completions",
+              models: [
+                {
+                  id: DEFAULT_MODEL_ID,
+                  name: "Example Chat",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: {
+                    input: 0,
+                    output: 0,
+                    cacheRead: 0,
+                    cacheWrite: 0,
+                  },
+                  contextWindow: 128000,
+                  maxTokens: 8192,
+                },
+              ],
+              apiKey,
+              baseUrl: configuredProvider?.baseUrl?.trim() || "https://api.example.com/v1",
+            },
+          };
+        },
       },
     });
   },
@@ -717,7 +717,7 @@ import type { OpenClawPluginApi, ProviderPlugin } from "openclaw/plugin-sdk/plug
 import entry from "./index.js";
 
 describe(${idLiteral}, () => {
-  it("registers the provider", () => {
+  it("registers the provider and resolves its authenticated catalog", async () => {
     const providers: ProviderPlugin[] = [];
     const api = {
       registerProvider(provider: ProviderPlugin) {
@@ -730,6 +730,47 @@ describe(${idLiteral}, () => {
     expect(providers.map((provider) => provider.id)).toEqual([${idLiteral}]);
     expect(providers[0]?.label).toBe(${nameLiteral});
     expect(providers[0]?.envVars).toEqual([${envVarLiteral}]);
+
+    const provider = providers[0];
+    if (!provider?.catalog) {
+      throw new Error("Generated provider did not register its catalog");
+    }
+    expect(provider.auth).toMatchObject([
+      { id: "api-key", kind: "api_key", starterModel: ${defaultModelRefLiteral} },
+    ]);
+    for (const [apiKey, configuredId, baseUrl, expectedBaseUrl] of [
+      [undefined, ${idLiteral}, "https://configured.example/v1", null],
+      ["fixture-api-key", ${jsStringLiteral(`${params.id}-unrelated`)}, "https://unrelated.example/v1", "https://api.example.com/v1"],
+      ["fixture-api-key", ${jsStringLiteral(` ${params.id.toUpperCase()} `)}, " https://configured.example/v1 ", "https://configured.example/v1"],
+      ["fixture-api-key", ${idLiteral}, " ", "https://api.example.com/v1"],
+    ] as const) {
+      const result = await provider.catalog.run({
+        config: { models: { providers: { [configuredId]: { baseUrl, models: [] } } } },
+        env: {},
+        resolveProviderApiKey: () => ({ apiKey }),
+        resolveProviderAuth: () => ({ apiKey, mode: "api_key", source: "env" }),
+      });
+      expect(result).toEqual(
+        expectedBaseUrl === null
+          ? null
+          : {
+              provider: {
+                api: "openai-completions",
+                apiKey,
+                baseUrl: expectedBaseUrl,
+                models: [{
+                  id: ${defaultModelIdLiteral},
+                  name: "Example Chat",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128000,
+                  maxTokens: 8192,
+                }],
+              },
+            },
+      );
+    }
   });
 });
 `;

--- a/test/plugin-clawhub-release.test.ts
+++ b/test/plugin-clawhub-release.test.ts
@@ -1823,9 +1823,7 @@ exit 0
     const invocations = readFileSync(markerPath, "utf8");
     const resolvedRepoDir = realpathSync(repoDir);
     expect(invocations).toContain(`--workdir ${resolvedRepoDir}`);
-    expect(invocations).toContain(
-      `package pack ${join(resolvedRepoDir, "extensions/demo-plugin")}`,
-    );
+    expect(invocations).toContain("package pack .");
     expect(invocations).toContain("package publish ");
     expect(invocations).toContain(".tgz --tags latest");
     expect(invocations).toContain("--dry-run");

--- a/test/plugin-npm-package-manifest.test.ts
+++ b/test/plugin-npm-package-manifest.test.ts
@@ -1,8 +1,11 @@
 // Plugin npm manifest tests validate generated plugin package manifests.
-import { spawnSync, type SpawnSyncOptions } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { execFile, spawnSync, type SpawnSyncOptions } from "node:child_process";
+import { createHash } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
 import { dirname, join, win32 } from "node:path";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   generatePluginNpmPackageLockWithRetry,
@@ -17,6 +20,7 @@ import { writeJsonFile } from "./helpers/temp-repo.js";
 
 const tempDirs: string[] = [];
 const tsxImport = import.meta.resolve("tsx");
+const execFileAsync = promisify(execFile);
 
 afterEach(() => {
   cleanupTempDirs(tempDirs);
@@ -167,6 +171,194 @@ function writeOptionalPlatformDependencyPackage(packageDir: string): string {
   });
   writeFileText(join(dependencyDir, "index.js"), "module.exports = 2;\n");
   return dependencyDir;
+}
+
+function writePatchedRuntimeFixture(bundling = "default") {
+  const optionalDirect = bundling === "optional-direct" || bundling === "skipped-optional";
+  const repoDir = makeTempRepoRoot(tempDirs, "openclaw-plugin-patched-artifact-");
+  const packageDir = writePublishablePluginPackage(repoDir);
+  writeLocalDependencyPackage(packageDir);
+  const packRegistryDependency = (name: string) => {
+    const dependencyDir = join(packageDir, "deps", name);
+    const manifest = JSON.parse(readFileSync(join(dependencyDir, "package.json"), "utf8"));
+    const pack = spawnSync(
+      "npm",
+      ["pack", "--json", "--ignore-scripts", "--pack-destination", repoDir],
+      {
+        cwd: dependencyDir,
+        encoding: "utf8",
+      },
+    );
+    expect(pack.status, pack.stderr).toBe(0);
+    const tarball = readFileSync(join(repoDir, parseNpmPackResult(pack.stdout).filename));
+    return {
+      manifest,
+      tarball,
+      integrity: `sha512-${createHash("sha512").update(tarball).digest("base64")}`,
+    };
+  };
+  const registryVersions = [packRegistryDependency("local-runtime-dep")];
+  if (bundling === "nested-other") {
+    writeJsonFile(join(packageDir, "deps", "local-runtime-dep", "package.json"), {
+      name: "local-runtime-dep",
+      version: "2.0.0",
+      main: "index.js",
+    });
+    writeFileText(
+      join(packageDir, "deps", "local-runtime-dep", "index.js"),
+      "module.exports = 20;\n",
+    );
+    registryVersions.push(packRegistryDependency("local-runtime-dep"));
+  }
+  const sourceManifest = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));
+  sourceManifest.files = ["deps/**"];
+  sourceManifest.dependencies = {
+    "local-runtime-dep": "1.0.0",
+    "unpatched-sibling": "file:./deps/unpatched-sibling",
+  };
+  writeJsonFile(join(packageDir, "deps", "unpatched-sibling", "package.json"), {
+    name: "unpatched-sibling",
+    version: "1.0.0",
+    main: "index.js",
+    ...(bundling.startsWith("nested-")
+      ? {
+          optionalDependencies: {
+            "local-runtime-dep": bundling === "nested-other" ? "2.0.0" : "1.0.0",
+          },
+        }
+      : {}),
+  });
+  writeFileText(
+    join(packageDir, "deps", "unpatched-sibling", "index.js"),
+    bundling.startsWith("nested-")
+      ? 'module.exports = require("local-runtime-dep");\n'
+      : "module.exports = 3;\n",
+  );
+  if (bundling.startsWith("nested-")) {
+    sourceManifest.dependencies["unpatched-sibling"] = "1.0.0";
+    registryVersions.push(packRegistryDependency("unpatched-sibling"));
+  }
+  if (bundling === "range-policy") {
+    delete sourceManifest.dependencies["unpatched-sibling"];
+    sourceManifest.overrides = {
+      "local-runtime-dep@^1.0.0": { ".": "^1.0.0", "unpatched-sibling": "1.0.0" },
+    };
+    registryVersions.push(packRegistryDependency("unpatched-sibling"));
+    writeJsonFile(join(packageDir, "deps", "unpatched-sibling", "package.json"), {
+      name: "unpatched-sibling",
+      version: "1.1.0",
+      main: "index.js",
+    });
+    writeFileText(
+      join(packageDir, "deps", "unpatched-sibling", "index.js"),
+      "module.exports = 4;\n",
+    );
+    registryVersions.push(packRegistryDependency("unpatched-sibling"));
+  }
+  if (optionalDirect) {
+    sourceManifest.dependencies["local-runtime-dep"] = "0.0.0";
+    sourceManifest.optionalDependencies = { "local-runtime-dep": "1.0.0" };
+  }
+  if (bundling === "partial") {
+    sourceManifest.bundledDependencies = ["unpatched-sibling"];
+  } else if (bundling === "explicit-all") {
+    sourceManifest.bundledDependencies = true;
+  }
+  writeJsonFile(join(packageDir, "package.json"), sourceManifest);
+  writeFileText(
+    join(packageDir, "dist", "index.js"),
+    bundling === "range-policy"
+      ? 'import dep from "local-runtime-dep"; export default dep.value; export const sibling = dep.child;\n'
+      : 'export { default } from "local-runtime-dep";\n' +
+          (bundling.startsWith("nested-")
+            ? 'export { default as sibling } from "unpatched-sibling";\n'
+            : ""),
+  );
+  writeFileText(join(packageDir, "dist", "setup-entry.js"), "export {};\n");
+  const installedDir = join(repoDir, "node_modules", "local-runtime-dep");
+  writeJsonFile(join(installedDir, "package.json"), {
+    name: "local-runtime-dep",
+    version: "1.0.0",
+    main: "index.js",
+    ...(bundling === "range-policy"
+      ? { optionalDependencies: { "unpatched-sibling": "^1.0.0" } }
+      : {}),
+    ...(bundling === "skipped-optional"
+      ? { os: [process.platform === "win32" ? "darwin" : "win32"] }
+      : {}),
+    ...(bundling === "dev-engine"
+      ? { devEngines: { packageManager: { name: "pnpm", version: "11.9.0", onFail: "error" } } }
+      : {}),
+  });
+  const installedSource =
+    bundling === "range-policy"
+      ? 'module.exports = {value: 2, child: require("unpatched-sibling")};\n'
+      : "module.exports = 2;\n";
+  writeFileText(join(installedDir, "index.js"), installedSource);
+  const patch = `--- a/index.js\n+++ b/index.js\n@@ -1 +1 @@\n-module.exports = 1;\n+${installedSource}`;
+  const patchHash = createHash("sha256").update(patch).digest("hex");
+  const patchKey = "local-runtime-dep@1.0.0";
+  const patchedVersion = `1.0.0(patch_hash=${patchHash})`;
+  writeFileText(join(repoDir, "patches", "runtime.patch"), patch);
+  writeJsonFile(join(repoDir, "pnpm-workspace.yaml"), {
+    patchedDependencies: { [patchKey]: "patches/runtime.patch" },
+  });
+  const lock = {
+    lockfileVersion: "9.0",
+    patchedDependencies: { [patchKey]: patchHash },
+    importers: {
+      "extensions/diffs": {
+        [optionalDirect ? "optionalDependencies" : "dependencies"]: {
+          "local-runtime-dep": {
+            specifier: "1.0.0",
+            version: patchedVersion,
+          },
+        },
+      },
+    },
+    packages: Object.fromEntries(
+      registryVersions.map(({ manifest, integrity }) => [
+        `${manifest.name}@${manifest.version}`,
+        { resolution: { integrity } },
+      ]),
+    ),
+    snapshots: {
+      [`local-runtime-dep@${patchedVersion}`]: {},
+      ...(bundling.startsWith("nested-")
+        ? {
+            "unpatched-sibling@1.0.0": {
+              optionalDependencies: {
+                "local-runtime-dep": bundling === "nested-other" ? "2.0.0" : "1.0.0",
+              },
+            },
+          }
+        : {}),
+    },
+  };
+  writeJsonFile(join(repoDir, "pnpm-lock.yaml"), lock);
+  writeJsonFile(join(repoDir, "node_modules", ".pnpm", "lock.yaml"), lock);
+  writeJsonFile(join(repoDir, "node_modules", ".modules.yaml"), {
+    nodeLinker: "hoisted",
+    virtualStoreDir: ".pnpm",
+    hoistedLocations: {
+      [`local-runtime-dep@${patchedVersion}`]: ["node_modules/local-runtime-dep"],
+    },
+  });
+  for (const yamlPath of [
+    join(repoDir, "pnpm-workspace.yaml"),
+    join(repoDir, "node_modules", ".modules.yaml"),
+  ]) {
+    writeFileSync(yamlPath, `---\n${readFileSync(yamlPath, "utf8")}`);
+  }
+  return {
+    repoDir,
+    packageDir,
+    sourceManifest,
+    installedDir,
+    installedSource,
+    registryVersions,
+    lock,
+  };
 }
 
 describe("plugin npm package manifest staging", () => {
@@ -708,9 +900,11 @@ process.stdout.write("PACKED_PLUGIN_CHANNEL_STATE_OK\\n");
       expect(files).not.toContain("package-lock.json");
       expect(files).not.toContain("npm-shrinkwrap.json");
       const extract = (file: string) => {
-        const result = spawnSync("tar", ["-xOf", tarball, `package/${file}`], { encoding: "utf8" });
-        expect(result.status, result.stderr).toBe(0);
-        return JSON.parse(result.stdout);
+        const extraction = spawnSync("tar", ["-xOf", tarball, `package/${file}`], {
+          encoding: "utf8",
+        });
+        expect(extraction.status, extraction.stderr).toBe(0);
+        return JSON.parse(extraction.stdout);
       };
       const manifest = extract("package.json");
       expect(manifest.bundledDependencies).toEqual(["local-runtime-dep"]);
@@ -718,6 +912,302 @@ process.stdout.write("PACKED_PLUGIN_CHANNEL_STATE_OK\\n");
       expect(extract("node_modules/local-runtime-dep/package.json").version).toBe("1.0.0");
     },
   );
+
+  it.each([
+    "default",
+    "partial",
+    "all",
+    "clawhub",
+    "optional-direct",
+    "nested-other",
+    "nested-same",
+    "explicit-all",
+    "unchanged",
+    "skipped-optional",
+    "dev-engine",
+    "range-policy",
+  ])("preserves patched dependency packaging contracts (%s)", async (bundling) => {
+    const { repoDir, packageDir, sourceManifest, installedDir, installedSource, registryVersions } =
+      writePatchedRuntimeFixture(bundling);
+    if (bundling === "unchanged") {
+      delete sourceManifest.openclaw.setupEntry;
+      writeJsonFile(join(packageDir, "package.json"), sourceManifest);
+      Object.assign(
+        sourceManifest,
+        resolveAugmentedPluginNpmPackageJson({
+          repoRoot: repoDir,
+          packageDir,
+          bundleDependencies: true,
+        }).packageJson,
+        { bundledDependencies: ["local-runtime-dep"] },
+      );
+      writeJsonFile(join(packageDir, "package.json"), sourceManifest);
+    }
+    const consumerDir = join(repoDir, "consumer");
+    mkdirSync(consumerDir);
+    const originalManifest = readFileSync(join(packageDir, "package.json"), "utf8");
+    const server = createServer((request, response) => {
+      const endpoint = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+      const versions = registryVersions.filter(
+        ({ manifest }) => request.url === `/${manifest.name}`,
+      );
+      const tarball = registryVersions.find(
+        ({ manifest }) => request.url === `/${manifest.name}-${manifest.version}.tgz`,
+      );
+      if (versions.length > 0) {
+        response.setHeader("content-type", "application/json");
+        response.end(
+          JSON.stringify({
+            name: versions[0]?.manifest.name,
+            "dist-tags": { latest: versions.at(-1)?.manifest.version },
+            versions: Object.fromEntries(
+              versions.map(({ manifest, integrity }) => [
+                manifest.version,
+                {
+                  ...manifest,
+                  dist: {
+                    tarball: `${endpoint}/${manifest.name}-${manifest.version}.tgz`,
+                    integrity,
+                  },
+                },
+              ]),
+            ),
+          }),
+        );
+      } else if (tarball) {
+        response.end(tarball.tarball);
+      } else {
+        response.writeHead(404);
+        response.end();
+      }
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const registryEnv = {
+      ...process.env,
+      npm_config_registry: `http://127.0.0.1:${(server.address() as { port: number }).port}`,
+      npm_config_cache: join(repoDir, "npm-cache"),
+    };
+    try {
+      let packResult: NpmPackResult;
+      if (bundling === "clawhub") {
+        const cli = join(repoDir, "clawhub.cjs");
+        const metadata = join(consumerDir, "pack-metadata.json");
+        writeFileText(
+          cli,
+          `#!${process.execPath}
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+const source = args[args.indexOf("pack") + 1];
+const destination = args[args.indexOf("--pack-destination") + 1];
+const stdout = execFileSync("npm", ["pack", source, "--json", "--ignore-scripts", "--pack-destination", destination], { encoding: "utf8" });
+fs.writeFileSync(${JSON.stringify(metadata)}, stdout);
+const output = JSON.parse(stdout);
+const [packed] = Array.isArray(output) ? output : Object.values(output);
+console.log(JSON.stringify({ path: path.join(destination, packed.filename) }));
+`,
+        );
+        chmodSync(cli, 0o700);
+        const env: NodeJS.ProcessEnv = {
+          ...registryEnv,
+          SOURCE_COMMIT: "1".repeat(40),
+          SOURCE_REF: "fixture",
+          OPENCLAW_PLUGIN_NPM_RUNTIME_BUILD: "0",
+          OPENCLAW_CLAWHUB_CLI: cli,
+          OPENCLAW_CLAWHUB_PACK_OUTPUT_DIR: consumerDir,
+        };
+        delete env.OPENCLAW_NPM_PACKAGE_LOCK_REPO_ROOT;
+        await execFileAsync(
+          "bash",
+          [
+            fileURLToPath(new URL("../scripts/plugin-clawhub-publish.sh", import.meta.url)),
+            "--pack",
+            "extensions/diffs",
+          ],
+          { cwd: repoDir, encoding: "utf8", env },
+        );
+        packResult = parseNpmPackResult(readFileSync(metadata, "utf8"));
+      } else {
+        const packing = execFileAsync(
+          process.execPath,
+          [
+            "--import",
+            tsxImport,
+            fileURLToPath(
+              new URL("../scripts/lib/plugin-npm-package-manifest.mts", import.meta.url),
+            ),
+            "--run",
+            packageDir,
+            "--",
+            ...(bundling === "range-policy"
+              ? [
+                  process.execPath,
+                  "--input-type=module",
+                  "-e",
+                  'const m = await import("./dist/index.js"); console.log(JSON.stringify([m.default, m.sibling]));',
+                ]
+              : ["npm", "pack", "--json", "--ignore-scripts", "--pack-destination", consumerDir]),
+          ],
+          {
+            cwd: repoDir,
+            encoding: "utf8",
+            env: {
+              ...registryEnv,
+              OPENCLAW_NPM_PACKAGE_LOCK_REPO_ROOT: repoDir,
+              OPENCLAW_PLUGIN_NPM_BUNDLE_DEPENDENCIES:
+                bundling === "all" || bundling.startsWith("nested-") ? "1" : "0",
+            },
+          },
+        );
+        if (bundling === "skipped-optional") {
+          await expect(packing).rejects.toThrow("patched runtime dependency was not installed");
+          return;
+        }
+        const packed = await packing;
+        if (bundling === "range-policy") {
+          expect(JSON.parse(packed.stdout)).toEqual([2, 3]);
+          return;
+        }
+        packResult = parseNpmPackResult(packed.stdout);
+      }
+      const extracted = spawnSync(
+        "tar",
+        ["-xzf", join(consumerDir, packResult.filename), "-C", consumerDir],
+        { encoding: "utf8" },
+      );
+      expect(extracted.status, extracted.stderr).toBe(0);
+      const consumerPackage = join(consumerDir, "package");
+      const expectedSibling =
+        bundling === "nested-other" ? 20 : bundling === "nested-same" ? 2 : null;
+      if (bundling.startsWith("nested-")) {
+        const bundled = spawnSync(
+          process.execPath,
+          [
+            "--input-type=module",
+            "-e",
+            'const m = await import("./dist/index.js"); console.log(JSON.stringify([m.default, m.sibling]));',
+          ],
+          { cwd: consumerPackage, encoding: "utf8" },
+        );
+        expect(bundled.status, bundled.stderr).toBe(0);
+        expect(JSON.parse(bundled.stdout)).toEqual([2, expectedSibling]);
+      }
+      const npm = resolvePluginNpmCommand([
+        "install",
+        "--ignore-scripts",
+        "--omit=dev",
+        "--omit=peer",
+        "--legacy-peer-deps",
+        "--workspaces=false",
+        "--no-audit",
+        "--no-fund",
+      ]);
+      await execFileAsync(npm.command, npm.args, {
+        cwd: consumerPackage,
+        encoding: "utf8",
+        ...npm,
+        env: { ...registryEnv, ...npm.env },
+      });
+      const loaded = spawnSync(
+        process.execPath,
+        [
+          "--input-type=module",
+          "-e",
+          'const m = await import("./dist/index.js"); console.log(JSON.stringify([m.default, m.sibling]));',
+        ],
+        { cwd: consumerPackage, encoding: "utf8" },
+      );
+      expect(loaded.status, loaded.stderr).toBe(0);
+      expect(JSON.parse(loaded.stdout)).toEqual([2, expectedSibling]);
+      const published = JSON.parse(readFileSync(join(consumerPackage, "package.json"), "utf8"));
+      expect(published.dependencies).toEqual(sourceManifest.dependencies);
+      expect(published.optionalDependencies).toEqual(sourceManifest.optionalDependencies);
+      expect(published.bundledDependencies).toEqual(
+        ["partial", "all", "explicit-all"].includes(bundling) || bundling.startsWith("nested-")
+          ? ["local-runtime-dep", "unpatched-sibling"]
+          : ["local-runtime-dep"],
+      );
+      expect(packResult.files.some(({ path }) => path.endsWith(".tgz"))).toBe(false);
+      expect(readFileSync(join(installedDir, "index.js"), "utf8")).toBe(installedSource);
+      expect(readFileSync(join(packageDir, "package.json"), "utf8")).toBe(originalManifest);
+      expect(existsSync(join(packageDir, "package-lock.json"))).toBe(false);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it.each(["bundle opt-out", "stale install", "stale importer spec", "wrong package identity"])(
+    "rejects a patched artifact when its packaging precondition fails (%s)",
+    (scenario) => {
+      const { repoDir, packageDir, sourceManifest, installedDir, lock } =
+        writePatchedRuntimeFixture();
+      if (scenario === "bundle opt-out") {
+        sourceManifest.openclaw.release.bundleRuntimeDependencies = false;
+        writeJsonFile(join(packageDir, "package.json"), sourceManifest);
+      } else if (scenario === "stale install") {
+        writeJsonFile(join(repoDir, "node_modules", ".pnpm", "lock.yaml"), {
+          ...lock,
+          patchedDependencies: {},
+        });
+      } else if (scenario === "stale importer spec") {
+        lock.importers["extensions/diffs"].dependencies = {
+          "local-runtime-dep": { specifier: "2.0.0", version: "2.0.0" },
+        };
+        writeJsonFile(join(repoDir, "pnpm-lock.yaml"), lock);
+      } else {
+        writeJsonFile(join(installedDir, "package.json"), {
+          name: "local-runtime-dep",
+          version: "2.0.0",
+        });
+      }
+      expect(() =>
+        withAugmentedPluginNpmManifestForPackage({ repoRoot: repoDir, packageDir }, () => {
+          throw new Error("unsafe artifact reached pack callback");
+        }),
+      ).toThrow(
+        scenario === "bundle opt-out"
+          ? "bundleRuntimeDependencies=false"
+          : scenario === "stale install"
+            ? "matching frozen pnpm install"
+            : scenario === "stale importer spec"
+              ? "frozen pnpm importer"
+              : "identity mismatch",
+      );
+      expect(readFileSync(join(installedDir, "index.js"), "utf8")).toBe("module.exports = 2;\n");
+    },
+  );
+
+  it("does not require a patch registered for a different resolved dependency version", () => {
+    const repoDir = makeTempRepoRoot(tempDirs, "openclaw-plugin-unpatched-version-");
+    const packageDir = writePublishablePluginPackage(repoDir);
+    writeFileText(join(packageDir, "dist", "index.js"), "export {};\n");
+    writeFileText(join(packageDir, "dist", "setup-entry.js"), "export {};\n");
+    const packageJson = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));
+    packageJson.dependencies = { "local-runtime-dep": "2.0.0" };
+    writeJsonFile(join(packageDir, "package.json"), packageJson);
+    writeJsonFile(join(repoDir, "pnpm-workspace.yaml"), {
+      patchedDependencies: { "local-runtime-dep@1.0.0": "patches/old.patch" },
+    });
+    writeJsonFile(join(repoDir, "pnpm-lock.yaml"), {
+      importers: {
+        "extensions/diffs": {
+          dependencies: { "local-runtime-dep": { specifier: "2.0.0", version: "2.0.0" } },
+        },
+      },
+    });
+    withAugmentedPluginNpmManifestForPackage({ repoRoot: repoDir, packageDir }, (context) => {
+      expect(context.packageDir).toBe(packageDir);
+      expect(
+        JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8")).bundledDependencies,
+      ).toBeUndefined();
+    });
+    expect(existsSync(join(repoDir, "node_modules"))).toBe(false);
+  });
 
   it("honors plugin package opt-out for bundled runtime dependencies", () => {
     const repoDir = makeTempRepoRoot(tempDirs, "openclaw-plugin-npm-package-bundle-opt-out-");

--- a/test/scripts/check-package-patches.test.ts
+++ b/test/scripts/check-package-patches.test.ts
@@ -58,6 +58,7 @@ describe("check-package-patches", () => {
     ["baileys@7.0.0-rc13", "patches/baileys@7.0.0-rc13.patch"],
     ["@vitest/runner@4.1.11", "patches/@vitest__runner@4.1.11.patch"],
     ["vitest@4.1.11", "patches/vitest@4.1.11.patch"],
+    ["matrix-js-sdk@42.2.0", "patches/matrix-js-sdk@42.2.0.patch"],
   ])("allows approved pnpm patch %s", (specifier, patchPath) => {
     const dir = makeRepo();
     mkdirSync(path.join(dir, "patches"), { recursive: true });
@@ -84,7 +85,11 @@ patchedDependencies:
     expect(collectPackagePatchViolations(dir)).toEqual([]);
   });
 
-  it("rejects new workspace patchedDependencies and patch files", () => {
+  it.each([
+    ["left-pad@1.3.0", "patches/left-pad@1.3.0.patch"],
+    ["matrix-js-sdk@42.2.1", "patches/matrix-js-sdk@42.2.1.patch"],
+    ["matrix-js-sdk@42.2.0", "patches/matrix-js-sdk@42.2.0-other.patch"],
+  ])("rejects unapproved workspace patch %s -> %s", (specifier, patchPath) => {
     const dir = makeRepo();
     mkdirSync(path.join(dir, "patches"), { recursive: true });
     mkdirSync(path.join(dir, "fixtures"), { recursive: true });
@@ -93,11 +98,11 @@ patchedDependencies:
       `packages:
   - .
 patchedDependencies:
-  "left-pad@1.3.0": "patches/left-pad@1.3.0.patch"
+  "${specifier}": "${patchPath}"
 `,
       "utf8",
     );
-    writeFileSync(path.join(dir, "patches", "left-pad@1.3.0.patch"), "diff\n", "utf8");
+    writeFileSync(path.join(dir, patchPath), "diff\n", "utf8");
     writeFileSync(path.join(dir, "fixtures", "fixture.patch"), "diff\n", "utf8");
     git(dir, ["add", "pnpm-workspace.yaml", "patches", "fixtures"]);
 
@@ -105,7 +110,7 @@ patchedDependencies:
       {
         file: "pnpm-workspace.yaml",
         kind: "patchedDependency",
-        detail: "left-pad@1.3.0 -> patches/left-pad@1.3.0.patch",
+        detail: `${specifier} -> ${patchPath}`,
       },
       {
         file: "fixtures/fixture.patch",
@@ -113,7 +118,7 @@ patchedDependencies:
         detail: "new package patch file",
       },
       {
-        file: "patches/left-pad@1.3.0.patch",
+        file: patchPath,
         kind: "patchFile",
         detail: "new package patch file",
       },

--- a/test/scripts/generate-npm-package-lock.test.ts
+++ b/test/scripts/generate-npm-package-lock.test.ts
@@ -1,6 +1,9 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 // Npm Package Lock Generator tests cover transient npm package-lock behavior.
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   applyPackageExtensionPeerMetadata,
   collectOverrideViolations,
@@ -23,6 +26,9 @@ import {
   shouldUseLegacyPeerDepsForNpmLock,
   npmLockPackageDirsForChangedPaths,
 } from "../../scripts/generate-npm-package-lock.mts";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("generate-npm-package-lock", () => {
   function repoRelativePath(value: string): string {
@@ -328,6 +334,264 @@ describe("generate-npm-package-lock", () => {
       },
     ]);
   });
+
+  it.each([false, true, "range"])(
+    "preserves child override policies when a direct dependency is bound to a local artifact (qualified=%s)",
+    (qualified) => {
+      const artifact = {
+        name: "patched",
+        version: "1.0.0",
+        spec: "file:./patched.tgz",
+        integrity: "sha512-local",
+      };
+      const manifest = {
+        dependencies: { patched: "1.0.0" },
+        overrides: qualified
+          ? { "patched@1.0.0": { scopedChild: "3.0.0" }, patched: { child: "2.0.0" } }
+          : { patched: { child: "2.0.0" }, "patched@1.0.0": { scopedChild: "3.0.0" } },
+      };
+      const policy = qualified
+        ? { "patched@1.0.0": { ".": qualified === "range" ? "^1.0.0" : "1.0.0", child: "2.0.0" } }
+        : { patched: "1.0.0" };
+      const normalized = packageJsonForNpmLock(manifest, policy, [artifact]);
+      expect(normalized.overrides).toEqual({
+        "patched@1.0.0": {
+          ".": "$patched",
+          child: "2.0.0",
+          ...(qualified ? { scopedChild: "3.0.0" } : {}),
+        },
+        patched: { ...(qualified ? {} : { ".": "1.0.0" }), child: "2.0.0" },
+      });
+      expect(packageJsonForNpmLock(normalized, policy, [artifact])).toEqual(normalized);
+      expect(manifest.dependencies.patched).toBe("1.0.0");
+    },
+  );
+
+  it("preserves wildcard child policies for prerelease artifacts", () => {
+    const artifact = {
+      name: "patched",
+      version: "1.0.0-beta.1",
+      spec: "file:./patched.tgz",
+      integrity: "sha512-local",
+    };
+    const normalized = packageJsonForNpmLock(
+      {
+        dependencies: { patched: artifact.version },
+        overrides: { "patched@*": { ".": "*", child: "2.0.0" } },
+      },
+      {},
+      [artifact],
+    );
+    expect(normalized.overrides).toMatchObject({
+      "patched@1.0.0-beta.1": { ".": "$patched", child: "2.0.0" },
+    });
+  });
+
+  it.each(["conflicting", "disjoint"])(
+    "keeps shadowed exact children out of artifact normalization reentry (%s)",
+    (scenario) => {
+      const artifact = {
+        name: "patched",
+        version: "1.0.0",
+        spec: "file:./patched.tgz",
+        integrity: "sha512-local",
+      };
+      const manifest = {
+        dependencies: { patched: "1.0.0" },
+        overrides: { "patched@^1.0.0": { ".": "1.0.0", child: "2.0.0" } },
+      };
+      const policy = {
+        "patched@1.0.0": {
+          ".": "1.0.0",
+          [scenario === "conflicting" ? "child" : "shadowedChild"]: "3.0.0",
+        },
+      };
+      const normalized = packageJsonForNpmLock(manifest, policy, [artifact]);
+      expect(normalized.overrides).toMatchObject({
+        "patched@1.0.0": { ".": "$patched", child: "2.0.0" },
+      });
+      expect(packageJsonForNpmLock(normalized, policy, [artifact])).toEqual(normalized);
+    },
+  );
+
+  it("does not treat an ordinary dependency reference as a normalized artifact", () => {
+    expect(() =>
+      packageJsonForNpmLock(
+        {
+          dependencies: { patched: "1.0.0" },
+          overrides: { "patched@1.0.0": { ".": "$patched", child: "2.0.0" } },
+        },
+        { "patched@1.0.0": { ".": "1.0.0", child: "3.0.0" } },
+        [
+          {
+            name: "patched",
+            version: "1.0.0",
+            spec: "file:./patched.tgz",
+            integrity: "sha512-local",
+          },
+        ],
+      ),
+    ).toThrow("overrides.child conflicts");
+  });
+
+  it.each(["^2.0.0", "npm:other@1.0.0"])(
+    "rejects an incompatible artifact own override (%s)",
+    (spec) => {
+      expect(() =>
+        packageJsonForNpmLock(
+          { dependencies: { patched: "1.0.0" } },
+          { "patched@1.0.0": { ".": spec } },
+          [
+            {
+              name: "patched",
+              version: "1.0.0",
+              spec: "file:./patched.tgz",
+              integrity: "sha512-local",
+            },
+          ],
+        ),
+      ).toThrow("local package artifact conflicts with override");
+    },
+  );
+
+  it("keeps registry integrity checks outside the bound direct artifact occurrence", () => {
+    const artifact = {
+      name: "patched",
+      version: "1.0.0",
+      spec: "file:./patched.tgz",
+      integrity: "sha512-local",
+    };
+    expect(
+      collectPnpmLockViolations(
+        {
+          packages: {
+            "node_modules/patched": { version: "1.0.0", integrity: artifact.integrity },
+            "node_modules/parent/node_modules/patched": {
+              version: "1.0.0",
+              integrity: artifact.integrity,
+            },
+            "node_modules/sibling": { version: "1.0.0", integrity: "sha512-tampered" },
+          },
+        },
+        new Set(["patched@1.0.0", "sibling@1.0.0"]),
+        new Map([
+          ["patched@1.0.0", new Set(["sha512-registry"])],
+          ["sibling@1.0.0", new Set(["sha512-sibling"])],
+        ]),
+        [artifact],
+      ),
+    ).toEqual([
+      {
+        path: "node_modules/parent/node_modules/patched",
+        packageKey: "patched@1.0.0",
+        actualIntegrity: "sha512-local",
+        expectedIntegrities: ["sha512-registry"],
+      },
+      {
+        path: "node_modules/sibling",
+        packageKey: "sibling@1.0.0",
+        actualIntegrity: "sha512-tampered",
+        expectedIntegrities: ["sha512-sibling"],
+      },
+    ]);
+  });
+
+  it.each(["valid", "tampered", "wrong-version", "outside-root", "symlink-escape"])(
+    "validates real local dependency tarballs before accepting npm locks (%s)",
+    (scenario) => {
+      const root = tempDirs.make("openclaw-npm-patched-lock-");
+      const source = path.join(root, "source");
+      const packageDir = path.join(root, "plugin");
+      mkdirSync(source);
+      mkdirSync(packageDir);
+      writeFileSync(path.join(root, "pnpm-workspace.yaml"), "{}\n");
+      writeFileSync(
+        path.join(root, "pnpm-lock.yaml"),
+        JSON.stringify({
+          packages: { "fixture-dep@1.0.0": { resolution: { integrity: "sha512-registry" } } },
+        }),
+      );
+      writeFileSync(
+        path.join(source, "package.json"),
+        JSON.stringify({
+          name: "fixture-dep",
+          version: scenario === "wrong-version" ? "2.0.0" : "1.0.0",
+          main: "index.js",
+        }),
+      );
+      writeFileSync(path.join(source, "index.js"), "module.exports = 2;\n");
+      const pack = spawnSync(
+        "npm",
+        ["pack", "--json", "--ignore-scripts", "--pack-destination", packageDir],
+        { cwd: source, encoding: "utf8" },
+      );
+      expect(pack.status, pack.stderr).toBe(0);
+      const packed = JSON.parse(pack.stdout);
+      const [{ filename }] = Array.isArray(packed) ? packed : Object.values(packed);
+      const tarball = path.join(packageDir, filename);
+      const integrity = `sha512-${createHash("sha512").update(readFileSync(tarball)).digest("base64")}`;
+      if (scenario === "tampered") {
+        writeFileSync(tarball, "tampered");
+      }
+      if (scenario === "symlink-escape") {
+        const outside = path.join(root, "outside");
+        mkdirSync(outside);
+        writeFileSync(path.join(outside, filename), readFileSync(tarball));
+        symlinkSync(outside, path.join(packageDir, "linked"), "junction");
+      }
+      const artifact = {
+        name: "fixture-dep",
+        version: "1.0.0",
+        spec:
+          scenario === "outside-root"
+            ? `file:../plugin/${filename}`
+            : scenario === "symlink-escape"
+              ? `file:./linked/${filename}`
+              : `file:./${filename}`,
+        integrity,
+      };
+      writeFileSync(
+        path.join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "fixture-plugin",
+          version: "1.0.0",
+          dependencies: { "fixture-dep": "1.0.0" },
+          ...(scenario === "wrong-version"
+            ? { overrides: { "fixture-dep": { child: "2.0.0" } } }
+            : {}),
+        }),
+      );
+      const script = `import { generateNpmPackageLock } from ${JSON.stringify(new URL("../../scripts/generate-npm-package-lock.mts", import.meta.url).href)}; console.log(generateNpmPackageLock(${JSON.stringify(packageDir)}, { localPackageArtifacts: ${JSON.stringify([artifact])} }));`;
+      const result = spawnSync(
+        process.execPath,
+        ["--import", import.meta.resolve("tsx"), "--input-type=module", "-e", script],
+        {
+          cwd: root,
+          encoding: "utf8",
+          env: { ...process.env, OPENCLAW_NPM_PACKAGE_LOCK_REPO_ROOT: root },
+        },
+      );
+      if (scenario === "valid") {
+        expect(result.status, result.stderr).toBe(0);
+        expect(JSON.parse(result.stdout).packages["node_modules/fixture-dep"]).toMatchObject({
+          version: "1.0.0",
+          integrity,
+        });
+      } else {
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain(
+          scenario === "tampered"
+            ? "local package artifact integrity mismatch"
+            : scenario === "wrong-version"
+              ? "violates workspace overrides: node_modules/fixture-dep locked 2.0.0, expected 1.0.0"
+              : scenario === "symlink-escape"
+                ? "local package artifact escapes package root"
+                : "invalid local package artifact",
+        );
+      }
+      expect(readFileSync(path.join(source, "index.js"), "utf8")).toBe("module.exports = 2;\n");
+    },
+  );
 
   it("normalizes npm patch-version metadata drift", () => {
     expect(

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -214,18 +214,14 @@
   pointer-events: auto;
 }
 
-.chat-group:hover .chat-group-footer--persistent-identity .chat-confirm-wrap,
-.chat-group:hover .chat-group-footer--persistent-identity .chat-group-timestamp,
-.chat-group:hover .chat-group-footer--persistent-identity .msg-meta__summary,
-.chat-group:focus-within .chat-group-footer--persistent-identity .chat-confirm-wrap,
-.chat-group:focus-within .chat-group-footer--persistent-identity .chat-group-timestamp,
-.chat-group:focus-within .chat-group-footer--persistent-identity .msg-meta__summary,
-.chat-group-footer--persistent-identity:has(.msg-meta[open]) .chat-confirm-wrap,
-.chat-group-footer--persistent-identity:has(.msg-meta[open]) .chat-group-timestamp,
-.chat-group-footer--persistent-identity:has(.msg-meta[open]) .msg-meta__summary,
-.chat-group:hover .chat-group-footer--persistent-identity .chat-group-footer-actions,
-.chat-group:focus-within .chat-group-footer--persistent-identity .chat-group-footer-actions,
-.chat-group-footer--persistent-identity:has(.msg-meta[open]) .chat-group-footer-actions {
+.chat-group:hover
+  .chat-group-footer--persistent-identity
+  :is(.chat-confirm-wrap, .chat-group-timestamp, .msg-meta__summary, .chat-group-footer-actions),
+.chat-group:focus-within
+  .chat-group-footer--persistent-identity
+  :is(.chat-confirm-wrap, .chat-group-timestamp, .msg-meta__summary, .chat-group-footer-actions),
+.chat-group-footer--persistent-identity:has(.msg-meta[open])
+  :is(.chat-confirm-wrap, .chat-group-timestamp, .msg-meta__summary, .chat-group-footer-actions) {
   position: static;
   opacity: 1;
   pointer-events: auto;


### PR DESCRIPTION
**Remaining merge gate:** [normal CI](https://github.com/openclaw/openclaw/actions/runs/33357602761) on final head `9e52fe1ce1b528a276259df9735a61ee0a98e70c`. [Provider-scaffold validation](https://github.com/openclaw/openclaw/actions/runs/33357602625) passed. The complete Matrix catalog and all three installed-artifact consumers passed; the separate final worker cleanup probe was unavailable after lease cancellation, as detailed below.

## Problem and changes

Full Matrix release verification serialized its 93-scenario catalog even though the transport factory already isolates homeservers, ports, Gateway state and artifacts. The shared suite scheduler now owns concurrency: isolated factories use the existing four-worker budget, explicit lower limits remain honored, and shared/unknown factories and fail-fast runs stay serial. The dedicated Matrix command no longer overrides that policy. It now exposes `--concurrency` through the shared isolated-adapter parser and forwards it to the canonical suite owner; omitted values and the four-worker cap stay unchanged. Obsolete sharding/fixed-port documentation is removed.

Parallel execution exposed lifecycle defects that this PR repairs at their owners:

- Preparation has its own existing bounded budget, so it cannot consume the scenario's negative-reply observation window. Retained config-patch callbacks receive an action-time deadline. Client cleanup releases partial acquisitions, joins acquired shutdowns and preserves primary and cleanup errors.
- Cached verification events were reentering live crypto processing during SDK recovery. The approved exact-version Matrix SDK 42.2.0 patch carries existing cache provenance through client events and excludes restored events only from live crypto processing. Fresh events, history, cursors and to-device processing retain their paths.
- A recovery driver could report cached readiness before its new encrypted room had synced. It now uses the existing joined-member barrier before priming and sending. Destructive state probes also require exact account/user identity from canonical SQLite metadata; path scoring is removed and stale sidecars cannot override canonical identity.
- The private Matrix test API eagerly loaded an unused channel-plugin export. Removing that export preserves all six consumed runtime functions and reduces measured Linux cold facade loading from 22.790s to 6.442s. This is a component measurement, not an end-to-end speed claim.
- Negative-reply checks require evidence that the trigger was observed. They still wait the complete eight-second window and reject a reply at its edge. Failed standard and isolated scenarios now print a bounded, redacted reason immediately.

CI also exposed a generated provider scaffold using internal SDK imports without published declarations. Its template now uses the documented public SDK and a contextually typed catalog. Credential handling, model output, configured endpoints, `latest`, version floors and public SDK exports are unchanged.

A separate inherited main build failure exceeded the existing compressed CSS limit by 25 bytes. Grouping repeated chat-footer child selectors preserves all hover, focus and open-metadata branches, specificity and touch guards. The actual failing base now builds at 54,746 bytes instead of 54,809, below the unchanged 54,784-byte limit. The change merges cleanly with upstream theme additions; no themes, budget or build guard changed.

## Installed-package boundary

Workspace patching alone did not preserve the SDK fix in installed plugins: runtime compilation externalizes the dependency, and isolated npm installation replaces it with registry bytes. The existing package producer now verifies the approved patch hash, frozen importer, installed identity and location, then uses canonical npm to pack the installed bytes. The existing lock owner binds the exact direct tarball name/version/file spec/integrity; other occurrences retain normal registry integrity checks.

Both npm and ClawHub use that staging owner, including the shared prerelease producer. Bundling preserves patched direct dependencies and explicit bundles, or all runtime dependencies when requested. Public dependency specifiers remain unchanged. Temporary inputs are cleaned up. There is no new public configuration, dependency version, schema, runtime fallback, custom patch engine or publication.

## Verification

- Scheduler, command, adapter and lifecycle coverage: 258 passing tests after four intended regression failures.
- Packaging owners: 103 passing tests and all 94 managed npm locks valid. Regressions cover importer drift, optional dependency omission, direct-only integrity, override ordering, invocation cwd and normalization reentry.
- Real SDK regression: fails against the unpatched dependency and passes with the approved source/runtime/declaration hashes. Original DM SAS → QR sequence passed all eight scenarios; fresh-session, restored-history and cursor behavior remain covered.
- Recovery owner regressions failed before repair and passed afterward. The previously failing encrypted-room recovery case also passed in the original automatic catalog order.
- New negative-observation coverage: intended missing-trigger failure before repair, then 21 helper/sync/request tests passing without a shorter observation window.
- Failure progress: three intended failures before repair, then 61 owner/sibling tests passing, including actual standard/isolated stderr, redaction, Unicode bounds, retries and unchanged pass/skip output.
- Provider scaffold: 25 owner tests pass. A fresh install against published `openclaw@2026.8.1` builds, runs its auth/endpoint/model cases and passes ClawHub 0.23.3 Inspector with zero findings. The [exact-head scaffold workflow](https://github.com/openclaw/openclaw/actions/runs/33357602625) also passed.
- Cold-loader A/B: separate fresh processes and caches on the same Linux 4-CPU worker, Node 24 and frozen dependencies/build. The removed export is present before and absent afterward; all six required functions remain. Source/build/SDK identities and comparison cleanup were checked.
- Dedicated CLI regression: five intended pre-fix failures, then 243 passing parser/runtime/sibling tests. The final typed error-construction cleanup passed 77 tests; the obsolete assertion allowance was removed.
- UI: full isolated failing-base build turns green, 48 compiled-CSS browser comparisons preserve all four footer child classes and an unaffected sibling, and eight existing responsive/contrast tests pass. Stylelint and formatting pass.
- Independent reviews of each changed group are scoped-clean through P2; the final fixture, CLI and CSS reviews found no actionable defects.

Native extension types, changed-path lint, 350 owner tests and the canonical QA build pass. The unfiltered automatic 93-scenario catalog passed **93 PASS / 0 FAIL / 0 SKIP in 596.149s**, with all four original partition lists, exact catalog selection and cap4 verified. All three refreshed npm/default-prerelease/ClawHub consumers passed in 264.030s on `07f4c8298e5aa7aa6d4c5392d6815f4fc6e21721`. Its complete runtime and packaging bytes are identical to final head `9e52fe1`; the sole later change is `ui/src/styles/chat/grouped.css`, verified by the complete Git diff. Normal CI passed on the final head: [run 33357602761, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33357602761/attempts/2). Attempt 1 passed 221 checks and failed only the upstream updater duration race; attempt 2 reran only failed jobs. The separate updater repair #133809 is merged as `f7f38bcc88a329a0b050a1ffa221496803ccf1ff`; the passing retry was not treated as the repair. The prior 91 PASS / 2 FAIL automatic run is retained as failure evidence. Its two action deadlines expired after successful preparation. A separate instrumented 71-case diagnostic used different scheduling and is not counted as original-order proof.

## Scope and limits

Final accounting against the original PR base: QA harness +79 lines, packaging tooling +383, generator runtime net zero, UI styles −4, tests +1,734 plus 41 generated-test lines, test support −1, docs +19, configuration/lock +1. The 204-line dependency patch includes context; its semantic change is SDK source +4 and generated JavaScript/declarations +5. Growth implements explicit concurrency/lifecycle ownership and the missing verified pnpm-to-npm artifact boundary using existing staging, lock and npm owners.

The historical serial catalog took 43m21s, but it is not a controlled comparison against this candidate. The SDK/Rust consumer check uses fixture HTTP; the full Matrix catalog uses real local homeservers and Gateways with a mock model provider. No package or release was published.

Named follow-ups: broad auth/runtime imports in the SDK fixture; concurrent development launchers rebuilding chunks used by another running consumer; the generic suite command's process-exit tail; and duplicate local/SDK live-command registration metadata. A CLI owner-verification failure seen only in the differently scheduled diagnostic passed the final complete catalog; that diagnostic remains retained, not counted as equivalent proof. An earlier lint wrapper's unexplained nonzero exit is retained; an unchanged-source rerun passed, and no speculative runner change was added.

## Final native and artifact proof

The canonical dedicated command ran without scenario filters, concurrency overrides, failure allowances or a warm source-loader cache. All 93 unique evidence entries report live Matrix execution and the validated runtime head. Source (35,588 paths), build (15,076 files) and all five approved SDK files remained unchanged. Minimum available memory was about 9.0 GiB; peak homeservers were four. The state-loss case deleted the exact account-owned SQLite sync store and then received a decrypted matching reply.

The actual npm producer, clean `prepublish-plugin-registry-artifact create` CLI, and real pinned ClawHub 0.23.3 pack path each produced an installed consumer whose SDK resolved inside that artifact. Fresh and cached sync cases passed in all three consumers. Public SDK version remains 42.2.0; only fresh events reach live crypto, while cached history and cursors remain intact.

| Artifact | Bytes | SHA-256 |
| --- | ---: | --- |
| npm, all runtime dependencies bundled | 7,733,947 | `25add4c2677ccc93b4ba7bf4523363647a87e3706f44a272eb8f95c509ca7ba0` |
| Default prerelease producer | 5,517,299 | `697af6a3562594164c20addc3f45f9156974dbd8372b8a118b0d60ac879be97e` |
| ClawHub 0.23.3 | 5,517,299 | `697af6a3562594164c20addc3f45f9156974dbd8372b8a118b0d60ac879be97e` |

The native wrapper is **not** reported as green: every functional phase exited zero, but its final Docker cleanup query failed after the disposable worker was cancelled. The full-catalog checkpoint had already confirmed zero containers; the subsequent artifact script performs no Docker operations. [Worker lifecycle evidence](https://github.com/openclaw/openclaw/actions/runs/33353548411) records the Run Testbox step cancelled at 04:45:08 UTC and a graceful Docker shutdown afterward; the initiator is unknown. The wrapper exit remains 1 and the final cleanup observation remains unknown. Source/build/SDK hashes and the three completed consumer results were retained before shutdown. No completed functional test was rerun or relabeled to hide this infrastructure outcome.

## Latest review disposition

The dedicated-command concurrency finding and rank-up move are repaired with real parser-to-suite coverage. The SQLite warning is a read-only identity lookup over existing rows, with no schema or persisted-format change. The complete catalog and pinned real ClawHub staged-artifact results below resolve the other rank-up move and packaging-proof concern. The earlier differently scheduled CLI diagnostic failure did not recur in the complete original-order catalog. The local and SDK live-command registration implementations still duplicate some parser metadata; consolidating external registration behavior is a separate follow-up.

## UI before and after

Synthetic footer fixture, compiled CSS, identical viewport and hover state. Both captures were inspected for incidental data and are byte-identical; the text is fixture content, not a release verdict.

Before:

![Synthetic chat footer before](https://github.com/user-attachments/assets/4d538971-d05e-456d-8477-3556d83d89e2)

After:

![Synthetic chat footer after](https://github.com/user-attachments/assets/9ff82b56-2961-4e83-8f81-3f3e0472251c)

## Final maintainer acceptance and CI disposition

The maintainer explicitly approved the exact temporary `matrix-js-sdk@42.2.0` patch and its installed-artifact packaging path in this task. Public SDK version stays 42.2.0; the npm, default prerelease, and pinned ClawHub installed consumers above prove those patched bytes. No package publication is part of this PR landing.

The latest exact-head ClawSweeper review has no code findings. Both rank-up requests are addressed: maintainer acceptance is recorded here, and final-head normal CI passed. The serialized-state warning concerns a QA fixture helper that reads the existing account-owned SQLite identity and deletes that disposable test account's sync store; no runtime schema, persisted representation, migration, or user-state semantics change.

The only failing job in normal CI attempt 1 exposed an upstream update-reporting duration race. [Updater repair #133809](https://github.com/openclaw/openclaw/pull/133809) fixes it at the result owner with deterministic regressions; that repair passed its own clean CI and merged before this Matrix PR. Normal CI attempt 2 reran only failed jobs and passed on unchanged `9e52fe1`; all earlier successful checks remain recorded. The final exact-head provider-scaffold workflow also passed.


## Final upstream-contract disposition

The latest reviewer could not fetch upstream source because of its DNS failure. The maintainer-side investigation did inspect retained primary upstream source at immutable Matrix SDK revision `aa1aeed63b5ef0327f0442d63e31efca58df46b0`, along with the installed 42.2.0 SDK and real Rust consumer. All six retained source/download hashes were reverified before landing. [`syncFromCache`](https://github.com/matrix-org/matrix-js-sdk/blob/aa1aeed63b5ef0327f0442d63e31efca58df46b0/src/sync.ts#L819) marks restored responses with `fromCache`, but the later room-event emitter drops that provenance; [`client.ts`](https://github.com/matrix-org/matrix-js-sdk/blob/aa1aeed63b5ef0327f0442d63e31efca58df46b0/src/client.ts#L2052) forwards every emitted event to the live Rust handler. [`onLiveEventFromSync`](https://github.com/matrix-org/matrix-js-sdk/blob/aa1aeed63b5ef0327f0442d63e31efca58df46b0/src/rust-crypto/rust-crypto.ts#L2178) is explicitly for live events and installs a five-minute decryption listener for encrypted events. The patch carries cache provenance to this existing listener boundary while preserving timeline hydration, cursors, live-event processing, and stored formats. Real unpatched-versus-patched regression proof and all three installed consumers above cover that contract.

The exact approved patch remains SHA-256 `9e97147d99b86977d6665a676cdf853434ef61eee7cfb176bb66c9c48da599b4` in the clean current-main merge. Remove its exact-version patch declaration when an upstream SDK version includes equivalent cache-provenance handling and passes the same fresh/cached and installed-artifact regressions. Reverting it requires no state migration because persisted formats do not change, but restores the original cached-event reprocessing behavior; do not silently omit patched bytes from artifacts while retaining the workspace patch.

## Refreshed current-main merge and UI proof

A clean three-way merge of final head `9e52fe1ce1b528a276259df9735a61ee0a98e70c` with current main `f7f38bcc88a329a0b050a1ffa221496803ccf1ff` produces tree `edd9ff336d982887f37bf3bc2262ea751b216c68`. GitHub also reports `MERGEABLE / CLEAN`. Of the 45 PR paths, the changed QA, SDK and package-producer files retain their tested bytes; only the stylesheet and unrelated upstream assertion-baseline reductions differ from the PR head.

The exact merged tree was materialized in an isolated checkout with frozen dependencies, with 3,180 UI/build-owner blobs verified. Current main's newer popover z-index and theme selector changes are preserved; current-main-to-merge UI changes are solely the footer consolidation. Both baseline and merged builds pass all unchanged budgets: largest CSS gzip **54,583 → 54,519 bytes**, leaving **265 bytes** below the existing 54,784-byte limit. All **48** original Chromium state comparisons and **8** selected existing responsive/contrast tests pass. All four refreshed screenshots were inspected and are byte-identical to the earlier public proof, so the existing images remain valid. All owned proof processes joined successfully.

This refresh and the upstream-contract disposition above address both rank-up requests in the latest review without changing the frozen PR head or repeating the already completed Matrix catalog and installed-artifact runs. The native wrapper cleanup caveat above remains explicitly retained.

Final main advancement check: main moved to `d4df20fbf31caa0057e3b0b82617f0f6cdc93969` during proof. A second clean merge produces tree `69b5b60842b7621f8f72964ec25cf0422c37af67`; all UI, QA, Matrix, SDK patch, dependency lock/declaration and package-producer bytes above are unchanged from the freshly proven merge. The intervening changes are unrelated error-helper, audio and WhatsApp test work plus baseline reductions. No repeated full gate was needed for unchanged proof inputs.
