### PR TITLE
docs: link v2026.8.1 release story

### DIFF
--- a/docs/releases/2026.8.1.md
+++ b/docs/releases/2026.8.1.md
@@ -20,6 +20,8 @@ keywords:
 This page is under active editorial review and does not represent the final v2026.8.1 release notes. Content, grouping, wording, and source lists may change.
 </Warning>
 
+For the story behind this release, read [OpenClaw 2.0, Accidentally](https://openclaw.ai/blog/openclaw-2-accidentally).
+
 This update touches every part of OpenClaw, including installation, messaging, memory, skills, models, automations, the browser and native apps, plugins, security, and many smaller fixes.
 
 The sections below describe the user-facing result, with the complete PR and commit record available inside each subsection when someone wants to dig into it.


### PR DESCRIPTION
Related: openclaw/openclaw.ai#250

## What Problem This Solves

The detailed v2026.8.1 release notes do not link readers to the narrative overview of why the release grew into OpenClaw 2.0.

## Why This Change Was Made

Adds one prominent link near the top of the release notes to **OpenClaw 2.0, Accidentally**. The target will resolve when the related openclaw.ai PR is merged.

## User Impact

Readers can move between the full technical release notes and the shorter release story.

## Evidence

- `git diff --check` passes.
- Confirmed the change is limited to two added Markdown lines in `docs/releases/2026.8.1.md`.
- `node scripts/check-changed.mjs -- docs/releases/2026.8.1.md` classified the change as docs-only; its follow-on check could not run because the checkout is missing the pinned pnpm 12.1.0 binary.
- The destination is the canonical URL requested in openclaw/openclaw.ai#250: https://openclaw.ai/blog/openclaw-2-accidentally

AI-assisted: yes.