### PR TITLE
fix(update): show reliable progress and final outcomes

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -56,6 +56,13 @@ for channel/availability only. Gateway console verbosity (`--verbose`) and
 file log level (`logging.level: "debug"`/`"trace"`) are independent knobs; see
 [Gateway logging](/gateway/logging).
 
+Interactive updates show the current step and elapsed time. When output is
+piped or captured in a log, each step prints its progress without animation.
+Failed steps include the final diagnostics from both output streams; timeouts
+are labeled explicitly. The final total includes plugin updates and requested
+Gateway restart checks. `--json` keeps stdout machine-readable and does not
+print progress steps.
+
 <Note>
 In Nix mode (`OPENCLAW_NIX_MODE=1`), mutating `openclaw update` runs are disabled. Update the Nix source or flake input for this install instead; for nix-openclaw, use the agent-first [Quick Start](https://github.com/openclaw/nix-openclaw#quick-start). `openclaw update status` and `openclaw update --dry-run` remain read-only.
 </Note>

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -34,7 +34,7 @@ import { createCliRuntimeCapture, getMockCallOutput } from "./test-runtime-captu
 const confirm = vi.fn();
 const select = vi.fn();
 const text = vi.fn();
-const spinner = vi.fn(() => ({ start: vi.fn(), stop: vi.fn() }));
+const spinner = vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), clear: vi.fn() }));
 const isCancel = (value: unknown) => value === "cancel";
 
 const readPackageName = vi.fn();
@@ -542,7 +542,7 @@ const {
 const updateCliShared = await import("./update-cli/shared.js");
 const { resolveGitInstallDir } = updateCliShared;
 const { spawnSync } = await import("node:child_process");
-const { readRestartSentinel } = await import("../infra/restart-sentinel.js");
+const { clearRestartSentinel, readRestartSentinel } = await import("../infra/restart-sentinel.js");
 
 function requireValue<T>(value: T | undefined, label: string): T {
   if (value === undefined) {
@@ -3106,11 +3106,13 @@ describe("update-cli", () => {
       return child;
     });
 
-    await expect(updateCommand({ yes: true })).rejects.toThrow(
-      "post-update process exited with code 2",
-    );
+    await updateCommand({ yes: true, json: true });
 
     expect(defaultRuntime.exit).toHaveBeenCalledWith(2);
+    expect(lastWriteJsonCall()).toMatchObject({
+      status: "error",
+      reason: "post-core-update-failed",
+    });
     expect(updateNpmInstalledPlugins).not.toHaveBeenCalled();
   });
 
@@ -4019,6 +4021,43 @@ describe("update-cli", () => {
     expect(packageInstallCommandCall()?.[0]).toContain("openclaw@9999.0.0");
   });
 
+  it.each([true, false])(
+    "uses inspected package runtime requirements when a later lookup disagrees (compatible=%s)",
+    async (compatible) => {
+      mockPackageInstallStatus(createCaseDir("openclaw-runtime-target"));
+      const inspectedEngine = compatible ? ">=22.19.0" : ">=999.0.0";
+      vi.mocked(fetchNpmPackageTargetStatus)
+        .mockResolvedValueOnce(packageTargetStatus({ nodeEngine: inspectedEngine }))
+        .mockResolvedValue(
+          packageTargetStatus({ nodeEngine: compatible ? ">=999.0.0" : ">=22.19.0" }),
+        );
+      nodeVersionSatisfiesEngine.mockImplementation(
+        (_version: string | null, engine: string | null) => engine !== ">=999.0.0",
+      );
+
+      await updateCommand({ yes: true, restart: false });
+
+      if (compatible) {
+        expect(packageInstallCommandCall()?.[0]).toContain("openclaw@9999.0.0");
+      } else {
+        expect(packageInstallCommandCall()).toBeUndefined();
+        expect(getErrorOutput()).toContain("The requested package requires >=999.0.0");
+      }
+      expect(fetchNpmPackageTargetStatus).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("previews the resolved package owner without probing for another manager", async () => {
+    mockPackageInstallStatus(createCaseDir("openclaw-dry-run-owner"));
+    resolveGlobalManager.mockResolvedValueOnce("npm").mockResolvedValue("bun");
+
+    await updateCommand({ dryRun: true, json: true });
+
+    expect(lastWriteJsonCall()).toMatchObject({ mode: "npm" });
+    expect(resolveGlobalManager).toHaveBeenCalledOnce();
+    expect(packageInstallCommandCall()).toBeUndefined();
+  });
+
   it("reports an incompatible package target during dry-run", async () => {
     mockPackageInstallStatus(createCaseDir("openclaw-schema-dry-run"));
     vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue(
@@ -4578,10 +4617,10 @@ describe("update-cli", () => {
     expectPackageInstallSpec("openclaw@9999.0.0");
     const preflightParams = vi
       .mocked(fetchNpmPackageTargetStatus)
-      .mock.calls.find(([params]) => params.target === "latest")?.[0];
+      .mock.calls.find(([params]) => params.target === "9999.0.0")?.[0];
     expect(preflightParams).toEqual(
       expect.objectContaining({
-        target: "latest",
+        target: "9999.0.0",
         spec: "openclaw@9999.0.0",
         cwd: process.cwd(),
       }),
@@ -5713,11 +5752,15 @@ describe("update-cli", () => {
     });
     const serviceCommand = {
       ...servicePlan,
-      environment: Object.fromEntries(
-        Object.entries(servicePlan.environment).filter(
-          (entry): entry is [string, string] => typeof entry[1] === "string",
+      environment: {
+        ...Object.fromEntries(
+          Object.entries(servicePlan.environment).filter(
+            (entry): entry is [string, string] => typeof entry[1] === "string",
+          ),
         ),
-      ),
+        // This sealed service deliberately has no CLI on PATH, including host-wide installs.
+        PATH: wrapperDir,
+      },
     };
     serviceReadCommand.mockResolvedValue(serviceCommand);
     serviceLoaded.mockResolvedValue(true);
@@ -7414,7 +7457,7 @@ describe("update-cli", () => {
     const probeCall = probeGatewayCall() as { includeDetails?: boolean } | undefined;
     expect(probeCall?.includeDetails).toBe(true);
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
-    expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
+    expect(lastWriteJsonCall()).toMatchObject({ status: "error", reason: "restart-unhealthy" });
     expect(getErrorOutput()).toContain(
       "Gateway version mismatch: expected 2026.4.24, running gateway reported 2026.4.23.",
     );
@@ -7556,25 +7599,42 @@ describe("update-cli", () => {
     expect(sentinel?.payload.continuation).toBeUndefined();
   });
 
-  it("marks the control-plane update sentinel failed when restart health verification fails", async () => {
-    const sentinel = await runControlPlaneUpdate({
-      meta: {
-        sessionKey: "agent:main:webchat:dm:user-123",
-        continuationMessage: "This should not report a successful update.",
-      },
-      options: { yes: true, json: true },
-      beforeUpdate: () => {
-        setupNpmUpdatedRootRefresh();
-        prepareRestartScript.mockResolvedValue(null);
-        serviceLoaded.mockResolvedValue(true);
-        mockGatewayProbe("2026.4.23", "old-gateway");
-      },
-    });
-    expect(sentinel?.payload.status).toBe("error");
-    expect(sentinel?.payload.stats?.reason).toBe("restart-unhealthy");
-    expect(sentinel?.payload.continuation).toBeUndefined();
-    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
-  });
+  it.each([false, true])(
+    "preserves control-plane update sentinel consumption on restart health failure (consumed=%s)",
+    async (consumed) => {
+      let sentinelConsumed = false;
+      const sentinel = await runControlPlaneUpdate({
+        meta: {
+          sessionKey: "agent:main:webchat:dm:user-123",
+          continuationMessage: "This should not report a successful update.",
+        },
+        options: { yes: true, json: true },
+        beforeUpdate: async () => {
+          setupNpmUpdatedRootRefresh();
+          prepareRestartScript.mockResolvedValue(null);
+          serviceLoaded.mockResolvedValue(true);
+          mockGatewayProbe("2026.4.23", "old-gateway");
+          if (consumed) {
+            const probeResult = await probeGateway();
+            probeGateway.mockImplementation(async () => {
+              sentinelConsumed = (await clearRestartSentinel()) || sentinelConsumed;
+              return probeResult;
+            });
+          }
+        },
+      });
+      if (consumed) {
+        expect(sentinelConsumed).toBe(true);
+        expect(sentinel).toBeNull();
+      } else {
+        expect(sentinel?.payload.status).toBe("error");
+        expect(sentinel?.payload.stats?.reason).toBe("restart-unhealthy");
+        expect(sentinel?.payload.continuation).toBeUndefined();
+      }
+      expect(lastWriteJsonCall()).toMatchObject({ status: "error", reason: "restart-unhealthy" });
+      expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    },
+  );
 
   it("fails a package update when the restarted gateway reports activated plugin load errors", async () => {
     setupNpmUpdatedRootRefresh();
@@ -7760,51 +7820,43 @@ describe("update-cli", () => {
   });
 
   it("updateCommand continues after doctor sub-step and clears update flag", async () => {
-    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
-    try {
-      await withEnvAsync({ OPENCLAW_UPDATE_IN_PROGRESS: undefined }, async () => {
-        mockRunningManagedGateway([
-          "node",
-          path.join(process.cwd(), "dist", "index.js"),
-          "gateway",
-        ]);
-        mockGitUpdateAfterMutation();
-        prepareRestartScript.mockResolvedValue(null);
-        vi.mocked(runDaemonRestart).mockResolvedValue(true);
-        vi.mocked(doctorCommand).mockResolvedValue(undefined);
-        vi.mocked(defaultRuntime.log).mockClear();
+    await withEnvAsync({ OPENCLAW_UPDATE_IN_PROGRESS: undefined }, async () => {
+      mockRunningManagedGateway(["node", path.join(process.cwd(), "dist", "index.js"), "gateway"]);
+      mockGitUpdateAfterMutation();
+      prepareRestartScript.mockResolvedValue(null);
+      vi.mocked(runDaemonRestart).mockResolvedValue(true);
+      vi.mocked(doctorCommand).mockResolvedValue(undefined);
+      vi.mocked(defaultRuntime.log).mockClear();
 
-        await updateCommand({});
+      await updateCommand({});
 
-        const doctorCall = vi.mocked(doctorCommand).mock.calls[0];
-        expect(doctorCall?.[0]).toBe(defaultRuntime);
-        expect(doctorCall?.[1]?.nonInteractive).toBe(true);
-        expect(process.env.OPENCLAW_UPDATE_IN_PROGRESS).toBeUndefined();
-        const snapshotOrders = createPreUpdateConfigSnapshotMock.mock.invocationCallOrder;
-        expect(createPreUpdateConfigSnapshotMock).toHaveBeenCalledTimes(2);
-        expect(requireValue(snapshotOrders[0], "restart snapshot call order")).toBeLessThan(
-          requireValue(
-            vi.mocked(runDaemonRestart).mock.invocationCallOrder[0],
-            "daemon restart call order",
-          ),
-        );
-        expect(requireValue(snapshotOrders[1], "doctor snapshot call order")).toBeLessThan(
-          requireValue(
-            vi.mocked(doctorCommand).mock.invocationCallOrder[0],
-            "doctor command call order",
-          ),
-        );
+      const doctorCall = vi.mocked(doctorCommand).mock.calls[0];
+      expect(doctorCall?.[0]).toBe(defaultRuntime);
+      expect(doctorCall?.[1]?.nonInteractive).toBe(true);
+      expect(process.env.OPENCLAW_UPDATE_IN_PROGRESS).toBeUndefined();
+      const snapshotOrders = createPreUpdateConfigSnapshotMock.mock.invocationCallOrder;
+      expect(createPreUpdateConfigSnapshotMock).toHaveBeenCalledTimes(2);
+      expect(requireValue(snapshotOrders[0], "restart snapshot call order")).toBeLessThan(
+        requireValue(
+          vi.mocked(runDaemonRestart).mock.invocationCallOrder[0],
+          "daemon restart call order",
+        ),
+      );
+      expect(requireValue(snapshotOrders[1], "doctor snapshot call order")).toBeLessThan(
+        requireValue(
+          vi.mocked(doctorCommand).mock.invocationCallOrder[0],
+          "doctor command call order",
+        ),
+      );
 
-        const logLines = vi.mocked(defaultRuntime.log).mock.calls.map((call) => String(call[0]));
-        expect(
-          logLines.some((line) =>
-            line.includes("Leveled up! New skills unlocked. You're welcome."),
-          ),
-        ).toBe(true);
-      });
-    } finally {
-      randomSpy.mockRestore();
-    }
+      const successIndex = vi
+        .mocked(defaultRuntime.log)
+        .mock.calls.findIndex((call) => String(call[0]).includes("Update Result: OK"));
+      expect(successIndex).toBeGreaterThanOrEqual(0);
+      expect(vi.mocked(defaultRuntime.log).mock.invocationCallOrder[successIndex]).toBeGreaterThan(
+        requireValue(vi.mocked(doctorCommand).mock.invocationCallOrder[0], "doctor call order"),
+      );
+    });
   });
 
   it("marks the whole update command as update-in-progress", async () => {

--- a/src/cli/update-cli/progress.test.ts
+++ b/src/cli/update-cli/progress.test.ts
@@ -1,14 +1,14 @@
 // Update progress tests cover progress event formatting for update operations.
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { UpdateRunResult } from "../../infra/update-runner.js";
+import type { UpdateRunResult, UpdateStepResult } from "../../infra/update-runner.js";
 import { defaultRuntime } from "../../runtime.js";
-import { printResult } from "./progress.js";
+import { createUpdateProgress, printResult } from "./progress.js";
 
 function makeResult(
   stepName: string,
   stderrTail: string,
   mode: UpdateRunResult["mode"] = "npm",
-): UpdateRunResult {
+): UpdateRunResult & { steps: [UpdateStepResult] } {
   return {
     status: "error",
     mode,
@@ -27,12 +27,12 @@ function makeResult(
   };
 }
 
-function renderResult(result: UpdateRunResult): string {
+function renderResult(result: UpdateRunResult, hideSteps = true): string {
   const lines: string[] = [];
   vi.spyOn(defaultRuntime, "log").mockImplementation((...args: unknown[]) => {
     lines.push(args.map(String).join(" "));
   });
-  printResult(result, { hideSteps: true });
+  printResult(result, { hideSteps });
   return lines.join("\n");
 }
 
@@ -118,5 +118,64 @@ describe("update failure hints", () => {
     const output = renderResult(result);
     expect(output).not.toContain("Recovery hints:");
     expect(output).not.toContain("npm config set prefix ~/.local");
+  });
+
+  it("shows the final diagnostics from both build streams", () => {
+    const result = makeResult("build", "Build failed", "git");
+    result.steps[0].stdoutTail = [
+      "old output",
+      ...Array.from({ length: 10 }, (_, i) => `diagnostic ${i}`),
+    ].join("\n");
+
+    const output = renderResult(result, false);
+
+    expect(output).toContain("Building");
+    expect(output).toContain("diagnostic 9");
+    expect(output).toContain("Build failed");
+    expect(output).not.toContain("old output");
+  });
+
+  it("explains a timeout even when the subprocess produced no output", () => {
+    const result = makeResult("build", "", "git");
+    result.steps[0].exitCode = null;
+    result.steps[0].termination = "timeout";
+
+    expect(renderResult(result, false)).toContain("Building — timed out");
+  });
+
+  it("reports redirected progress before completion and preserves stdout failures", () => {
+    const tty = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: false });
+    const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+    const { progress, stop } = createUpdateProgress(true);
+    const step = { name: "build", command: "pnpm build", index: 0, total: 1 };
+    try {
+      progress.onStepStart?.(step);
+      expect(log).toHaveBeenCalledWith("Building...");
+      progress.onStepComplete?.({
+        ...step,
+        durationMs: 1200,
+        exitCode: 1,
+        stdoutTail: "Build type error",
+      });
+      expect(log.mock.calls.flat().join("\n")).toContain("Build type error");
+    } finally {
+      stop();
+      if (tty) {
+        Object.defineProperty(process.stdout, "isTTY", tty);
+      } else {
+        Reflect.deleteProperty(process.stdout, "isTTY");
+      }
+    }
+  });
+
+  it("keeps progress silent when JSON output owns stdout", () => {
+    const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+    const { progress, stop } = createUpdateProgress(false);
+    const step = { name: "build", command: "pnpm build", index: 0, total: 1 };
+    progress.onStepStart?.(step);
+    progress.onStepComplete?.({ ...step, durationMs: 1, exitCode: 0 });
+    stop();
+    expect(log).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/update-cli/progress.ts
+++ b/src/cli/update-cli/progress.ts
@@ -2,19 +2,23 @@
 import { spinner } from "@clack/prompts";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
-import { formatDurationPrecise } from "../../infra/format-time/format-duration.ts";
+import {
+  formatDurationCompact,
+  formatDurationPrecise,
+} from "../../infra/format-time/format-duration.ts";
 import type {
   UpdateRunResult,
   UpdateStepAdvisory,
   UpdateStepInfo,
   UpdateStepProgress,
+  UpdateStepResult,
 } from "../../infra/update-runner.js";
 import { defaultRuntime } from "../../runtime.js";
 import type { UpdateCommandOptions } from "./shared.js";
 
 const STEP_LABELS: Record<string, string> = {
-  "clean check": "Working directory is clean",
-  "upstream check": "Upstream branch exists",
+  "clean check": "Checking for local changes",
+  "upstream check": "Checking the upstream branch",
   "git fetch": "Fetching latest changes",
   "git rebase": "Rebasing onto target commit",
   "git rev-parse @{upstream}": "Resolving upstream commit",
@@ -36,10 +40,21 @@ const STEP_LABELS: Record<string, string> = {
   "global install verify": "Verifying global package",
   "global install swap": "Activating global package",
   "global install": "Installing global package",
+  "global update pack": "Downloading the update",
+  "global update pack verify": "Verifying the downloaded package",
+  checkout: "Checking out candidate",
+  lint: "Checking code quality",
+  "config validate": "Validating configuration",
 };
 
 function getStepLabel(step: Pick<UpdateStepInfo, "name">): string {
-  return STEP_LABELS[step.name] ?? step.name;
+  return (
+    STEP_LABELS[step.name] ??
+    step.name.replace(
+      /^preflight (.+) \(([a-f0-9]+)\)$/,
+      (_match, name: string, sha: string) => `Preflight: ${STEP_LABELS[name] ?? name} (${sha})`,
+    )
+  );
 }
 
 function isAdvisoryStep(step: { advisory?: UpdateStepAdvisory }): boolean {
@@ -136,51 +151,64 @@ export function createUpdateProgress(enabled: boolean): ProgressController {
   }
 
   let currentSpinner: ReturnType<typeof spinner> | null = null;
+  const stop = () => {
+    currentSpinner?.clear();
+    currentSpinner = null;
+  };
 
   const progress: UpdateStepProgress = {
     onStepStart: (step) => {
-      currentSpinner = spinner();
-      currentSpinner.start(theme.accent(getStepLabel(step)));
+      stop();
+      if (process.stdout.isTTY) {
+        currentSpinner = spinner({ indicator: "timer" });
+        currentSpinner.start(theme.accent(getStepLabel(step)));
+      } else {
+        defaultRuntime.log(`${getStepLabel(step)}...`);
+      }
     },
     onStepComplete: (step) => {
-      if (!currentSpinner) {
-        return;
-      }
-
-      const label = getStepLabel(step);
-      const duration = theme.muted(`(${formatDurationPrecise(step.durationMs)})`);
-      const icon = formatStepStatus(step);
-
-      currentSpinner.stop(`${icon} ${label} ${duration}`);
-      currentSpinner = null;
-
-      if (isAdvisoryStep(step) && step.stderrTail) {
-        const lines = step.stderrTail.split("\n").slice(-10);
-        for (const line of lines) {
-          if (line.trim()) {
-            defaultRuntime.log(`    ${theme.warn(line)}`);
-          }
-        }
-      } else if (step.exitCode !== 0 && step.stderrTail) {
-        const lines = step.stderrTail.split("\n").slice(-10);
-        for (const line of lines) {
-          if (line.trim()) {
-            defaultRuntime.log(`    ${theme.error(line)}`);
-          }
-        }
-      }
+      stop();
+      printStep(step);
     },
   };
 
-  return {
-    progress,
-    stop: () => {
-      if (currentSpinner) {
-        currentSpinner.stop();
-        currentSpinner = null;
+  return { progress, stop };
+}
+
+type DisplayStep = Pick<
+  UpdateStepResult,
+  | "name"
+  | "durationMs"
+  | "exitCode"
+  | "advisory"
+  | "stdoutTail"
+  | "stderrTail"
+  | "termination"
+  | "signal"
+>;
+
+function printStep(step: DisplayStep): void {
+  const duration = theme.muted(`(${formatDurationPrecise(step.durationMs)})`);
+  const termination =
+    step.termination === "timeout" || step.termination === "no-output-timeout"
+      ? " — timed out"
+      : step.signal
+        ? ` — interrupted (${step.signal})`
+        : "";
+  defaultRuntime.log(`  ${formatStepStatus(step)} ${getStepLabel(step)}${termination} ${duration}`);
+  if (!isAdvisoryStep(step) && step.exitCode === 0) {
+    return;
+  }
+  // Build tools often report failures on stdout. Keep the final diagnostic from
+  // each stream, so npm's stderr footer cannot hide the actual build error.
+  const color = isAdvisoryStep(step) ? theme.warn : theme.error;
+  for (const output of [step.stdoutTail, step.stderrTail]) {
+    for (const line of (output ?? "").trimEnd().split("\n").slice(-10)) {
+      if (line.trim()) {
+        defaultRuntime.log(`    ${color(line)}`);
       }
-    },
-  };
+    }
+  }
 }
 
 function formatStepStatus(step: {
@@ -233,29 +261,16 @@ export function printResult(result: UpdateRunResult, opts: PrintResultOptions): 
     defaultRuntime.log(`  After: ${theme.muted(after)}`);
   }
 
-  if (!opts.hideSteps && result.steps.length > 0) {
+  // Some preflight failures are synthesized without a progress callback. Keep
+  // their diagnostics visible even when successful streamed steps are hidden.
+  const steps = opts.hideSteps
+    ? result.steps.filter((step) => step.exitCode !== 0 || isAdvisoryStep(step))
+    : result.steps;
+  if (steps.length > 0) {
     defaultRuntime.log("");
     defaultRuntime.log(theme.heading("Steps:"));
-    for (const step of result.steps) {
-      const status = formatStepStatus(step);
-      const duration = theme.muted(`(${formatDurationPrecise(step.durationMs)})`);
-      defaultRuntime.log(`  ${status} ${step.name} ${duration}`);
-
-      if (isAdvisoryStep(step) && step.stderrTail) {
-        const lines = step.stderrTail.split("\n").slice(0, 5);
-        for (const line of lines) {
-          if (line.trim()) {
-            defaultRuntime.log(`      ${theme.warn(line)}`);
-          }
-        }
-      } else if (step.exitCode !== 0 && step.stderrTail) {
-        const lines = step.stderrTail.split("\n").slice(0, 5);
-        for (const line of lines) {
-          if (line.trim()) {
-            defaultRuntime.log(`      ${theme.error(line)}`);
-          }
-        }
-      }
+    for (const step of steps) {
+      printStep(step);
     }
   }
 
@@ -269,5 +284,9 @@ export function printResult(result: UpdateRunResult, opts: PrintResultOptions): 
   }
 
   defaultRuntime.log("");
-  defaultRuntime.log(`Total time: ${theme.muted(formatDurationPrecise(result.durationMs))}`);
+  const totalTime =
+    result.durationMs < 60_000
+      ? formatDurationPrecise(result.durationMs)
+      : (formatDurationCompact(result.durationMs, { spaced: true }) ?? "0ms");
+  defaultRuntime.log(`Total time: ${theme.muted(totalTime)}`);
 }

--- a/src/cli/update-cli/shared.command-runner.test.ts
+++ b/src/cli/update-cli/shared.command-runner.test.ts
@@ -9,6 +9,7 @@ import {
   ensureGitCheckout,
   parseTimeoutMsOrExit,
   resolveUpdateRoot,
+  runUpdateStep,
 } from "./shared.js";
 
 const runCommandWithTimeout = vi.hoisted(() => vi.fn());
@@ -91,6 +92,32 @@ describe("update CLI shared helpers", () => {
       error.mockRestore();
       exit.mockRestore();
     }
+  });
+
+  it("keeps failed command diagnostics in both progress and the final result", async () => {
+    runCommandWithTimeout.mockResolvedValueOnce({
+      ...successfulCommandResult,
+      code: 1,
+      stdout: `${"x".repeat(10_000)}\nBuild type error`,
+      stderr: "Command failed",
+    });
+    const onStepComplete = vi.fn();
+    const result = await runUpdateStep({
+      name: "build",
+      argv: ["pnpm", "build"],
+      timeoutMs: 1200,
+      progress: { onStepComplete },
+    });
+
+    expect(result.stdoutTail).toContain("Build type error");
+    expect(result.stdoutTail?.length).toBeLessThanOrEqual(8001); // includes the truncation marker
+    expect(onStepComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stdoutTail: result.stdoutTail,
+        stderrTail: "Command failed",
+        exitCode: 1,
+      }),
+    );
   });
 
   it("parses complete positive integer timeout values as milliseconds", () => {

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -11,7 +11,6 @@ import { resolveRequiredHomeDir } from "../../infra/home-dir.js";
 import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
 import { readPackageName, readPackageVersion } from "../../infra/package-json.js";
 import { normalizePackageTagInput } from "../../infra/package-tag.js";
-import { trimLogTail } from "../../infra/restart-sentinel.js";
 import { parseSemver } from "../../infra/runtime-guard.js";
 import { fetchNpmTagVersion } from "../../infra/update-check.js";
 import {
@@ -22,6 +21,7 @@ import {
   type CommandRunner,
   type GlobalInstallManager,
 } from "../../infra/update-global.js";
+import { runStep } from "../../infra/update-runner-command.js";
 import type { UpdateStepProgress, UpdateStepResult } from "../../infra/update-runner.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -86,7 +86,6 @@ const OPENCLAW_REPO_URL = "https://github.com/openclaw/openclaw.git";
 // Keep the full commit graph for dev ref switching while deferring historical blobs.
 // A shallow clone would make older or non-default dev targets unreachable.
 const GIT_CLONE_BLOB_FILTER = "--filter=blob:none";
-const MAX_LOG_CHARS = 8000;
 
 export const DEFAULT_PACKAGE_NAME = "openclaw";
 const CORE_PACKAGE_NAMES = new Set([DEFAULT_PACKAGE_NAME]);
@@ -205,48 +204,13 @@ export async function runUpdateStep(params: {
   progress?: UpdateStepProgress;
   env?: NodeJS.ProcessEnv;
 }): Promise<UpdateStepResult> {
-  const command = params.argv.join(" ");
-  params.progress?.onStepStart?.({
-    name: params.name,
-    command,
-    index: 0,
-    total: 0,
-  });
-
-  const started = Date.now();
-  const res = await runCommandWithTimeout(params.argv, {
-    cwd: params.cwd,
-    env: params.env,
-    timeoutMs: params.timeoutMs,
-  });
-  const durationMs = Date.now() - started;
-  const stderrTail = trimLogTail(res.stderr, MAX_LOG_CHARS);
-
-  params.progress?.onStepComplete?.({
-    name: params.name,
-    command,
-    index: 0,
-    total: 0,
-    durationMs,
-    exitCode: res.code,
-    stderrTail,
-    signal: res.signal,
-    killed: res.killed,
-    termination: res.termination,
-  });
-
-  return {
-    name: params.name,
-    command,
+  return await runStep({
+    ...params,
     cwd: params.cwd ?? process.cwd(),
-    durationMs,
-    exitCode: res.code,
-    stdoutTail: trimLogTail(res.stdout, MAX_LOG_CHARS),
-    stderrTail,
-    signal: res.signal,
-    killed: res.killed,
-    termination: res.termination,
-  };
+    runCommand: runCommandWithTimeout,
+    stepIndex: 0,
+    totalSteps: 0,
+  });
 }
 
 type GitCheckoutResult = {

--- a/src/cli/update-cli/update-command-dry-run.ts
+++ b/src/cli/update-cli/update-command-dry-run.ts
@@ -4,7 +4,6 @@ import { canResolveRegistryVersionForPackageTarget } from "../../infra/update-gl
 import type { UpdateRunResult } from "../../infra/update-runner.js";
 import { defaultRuntime } from "../../runtime.js";
 import type { OpenClawDatabaseSchemaPreflight } from "../../state/openclaw-database-preflight.js";
-import { resolveGlobalManager } from "./shared.js";
 import { formatSchemaRefusalLines, hasSchemaRefusal } from "./update-command-git.js";
 import type { ManagedServiceRootRedirect } from "./update-command-service.js";
 
@@ -67,10 +66,11 @@ function printDryRunPreview(preview: UpdateDryRunPreview, jsonMode: boolean): vo
   }
 }
 
-export async function printUpdateDryRun(params: {
+export function printUpdateDryRun(params: {
   root: string;
   installKind: "git" | "package" | "unknown";
   updateInstallKind: "git" | "package" | "unknown";
+  mode: UpdateRunResult["mode"];
   switchToGit: boolean;
   switchToPackage: boolean;
   shouldRestart: boolean;
@@ -87,20 +87,8 @@ export async function printUpdateDryRun(params: {
   managedServiceRootRedirect: ManagedServiceRootRedirect | null;
   explicitTag: string | null;
   packageSchemaPreflight: OpenClawDatabaseSchemaPreflight;
-  timeoutMs: number;
   opts: { tag?: string; json?: boolean };
-}): Promise<void> {
-  let mode: UpdateRunResult["mode"] = "unknown";
-  if (params.updateInstallKind === "git") {
-    mode = "git";
-  } else if (params.updateInstallKind === "package") {
-    mode = await resolveGlobalManager({
-      root: params.root,
-      installKind: params.installKind,
-      timeoutMs: params.timeoutMs,
-    });
-  }
-
+}): void {
   const actions: string[] = [];
   if (params.requestedChannel && params.requestedChannel !== params.storedChannel) {
     actions.push(`Persist update.channel=${params.requestedChannel} in config`);
@@ -108,7 +96,7 @@ export async function printUpdateDryRun(params: {
   if (params.switchToGit) {
     actions.push("Switch install mode from package to git checkout (dev channel)");
   } else if (params.switchToPackage) {
-    actions.push(`Switch install mode from git to package manager (${mode})`);
+    actions.push(`Switch install mode from git to package manager (${params.mode})`);
   } else if (params.updateInstallKind === "git") {
     actions.push(`Run git update flow on channel ${params.channel} (fetch/rebase/build/doctor)`);
   } else if (params.packageAlreadyCurrent) {
@@ -159,7 +147,7 @@ export async function printUpdateDryRun(params: {
       dryRun: true,
       root: params.root,
       installKind: params.installKind,
-      mode,
+      mode: params.mode,
       updateInstallKind: params.updateInstallKind,
       switchToGit: params.switchToGit,
       switchToPackage: params.switchToPackage,

--- a/src/cli/update-cli/update-command-package.ts
+++ b/src/cli/update-cli/update-command-package.ts
@@ -178,6 +178,7 @@ export async function runPackageInstallUpdate(params: {
         ...doctorProgressInfo,
         durationMs: completedDoctorStep.durationMs,
         exitCode: completedDoctorStep.exitCode,
+        stdoutTail: completedDoctorStep.stdoutTail,
         stderrTail: completedDoctorStep.stderrTail,
         signal: completedDoctorStep.signal,
         killed: completedDoctorStep.killed,

--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -29,9 +29,10 @@ const mocks = vi.hoisted(() => ({
     vi.fn<
       typeof import("./update-command-service.js").revalidateManagedGatewayServiceAfterUpdate
     >(),
-  restoreWindowsAutoStart: vi.fn(async () => true),
   updatePlugins: vi.fn(),
-  writeSentinel: vi.fn(async () => undefined),
+  writeSentinel: vi.fn<
+    typeof import("./update-command-post-core.js").writeControlPlaneUpdateRestartSentinelBestEffort
+  >(async () => undefined),
 }));
 
 vi.mock("./progress.js", () => ({ printResult: mocks.printResult }));
@@ -89,7 +90,6 @@ vi.mock("./update-command-service.js", async (importOriginal) => ({
   maybeRestartService: mocks.restartService,
   maybeRestartServiceAfterFailedMutableUpdate: mocks.restart,
   revalidateManagedGatewayServiceAfterUpdate: mocks.revalidateService,
-  restoreWindowsTaskAutoStartOrExit: mocks.restoreWindowsAutoStart,
 }));
 vi.mock("./update-command-post-core.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./update-command-post-core.js")>()),
@@ -97,7 +97,6 @@ vi.mock("./update-command-post-core.js", async (importOriginal) => ({
   writeControlPlaneUpdateRestartSentinelBestEffort: mocks.writeSentinel,
 }));
 
-import { retireStandaloneGitWrapper } from "./update-command-git.js";
 import { finishUpdate } from "./update-command-post-update.js";
 import { resolveUpdatedGatewayRestartPort } from "./update-command-service.js";
 
@@ -173,6 +172,9 @@ async function finishSuccessfulPackageSwitch(params: {
   sealed?: boolean;
   updateMode?: UpdateRunResult["mode"];
   stoppedForUpdate?: boolean;
+  windowsTaskAutoStartRecovery?: NonNullable<
+    FinishUpdateParams["preManagedServiceStop"]
+  >["windowsTaskAutoStartRecovery"];
 }): Promise<void> {
   await finishUpdate({
     result: {
@@ -207,6 +209,7 @@ async function finishSuccessfulPackageSwitch(params: {
     ...(params.restartEnvironment && {
       preManagedServiceStop: {
         stopped: params.stoppedForUpdate ?? true,
+        windowsTaskAutoStartRecovery: params.windowsTaskAutoStartRecovery,
         ...(params.sealed && {
           serviceUpdateVerdict: {
             kind: "owned",
@@ -220,92 +223,6 @@ async function finishSuccessfulPackageSwitch(params: {
     }),
   } as unknown as FinishUpdateParams);
 }
-
-describe("retireStandaloneGitWrapper", () => {
-  it("removes only the installer wrapper for the previous checkout", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-wrapper-retire-"));
-    const oldRoot = path.join(home, "old checkout");
-    const unrelatedWrapper = path.join(home, "earlier", "openclaw");
-    const wrapper = path.join(home, ".local", "bin", "openclaw");
-    const secondWrapper = path.join(home, "legacy", "bin", "openclaw");
-    const oldWrapperContents = `#!/usr/bin/env bash\nset -euo pipefail\nexec /usr/bin/node ${oldRoot.replaceAll(" ", "\\ ")}/dist/entry.js "$@"\n`;
-    await Promise.all([
-      fs.mkdir(path.dirname(unrelatedWrapper), { recursive: true }),
-      fs.mkdir(path.dirname(wrapper), { recursive: true }),
-      fs.mkdir(path.dirname(secondWrapper), { recursive: true }),
-    ]);
-    await fs.writeFile(unrelatedWrapper, "#!/usr/bin/env bash\necho unrelated\n", { mode: 0o755 });
-    await Promise.all([
-      fs.writeFile(wrapper, oldWrapperContents, { mode: 0o755 }),
-      fs.writeFile(secondWrapper, oldWrapperContents, { mode: 0o755 }),
-    ]);
-    try {
-      await expect(
-        retireStandaloneGitWrapper({
-          previousRoot: oldRoot,
-          platform: "linux",
-          searchDirs: [
-            path.dirname(unrelatedWrapper),
-            path.dirname(wrapper),
-            path.dirname(secondWrapper),
-          ],
-        }),
-      ).resolves.toEqual({});
-      await expect(fs.readFile(unrelatedWrapper, "utf8")).resolves.toContain("unrelated");
-      await expect(fs.stat(wrapper)).rejects.toMatchObject({ code: "ENOENT" });
-      await expect(fs.stat(secondWrapper)).rejects.toMatchObject({ code: "ENOENT" });
-
-      await fs.writeFile(
-        wrapper,
-        "#!/usr/bin/env node\nimport '../lib/node_modules/openclaw/openclaw.mjs';\n",
-        { mode: 0o755 },
-      );
-      await expect(
-        retireStandaloneGitWrapper({
-          previousRoot: oldRoot,
-          platform: "linux",
-          searchDirs: [path.dirname(wrapper)],
-        }),
-      ).resolves.toEqual({});
-      await expect(fs.stat(wrapper)).resolves.toBeDefined();
-    } finally {
-      await fs.rm(home, { recursive: true, force: true });
-    }
-  });
-
-  it("removes only the exact PowerShell installer wrapper on Windows", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-wrapper-retire-win-"));
-    const oldRoot = "C:\\Users\\operator\\openclaw";
-    const wrapper = path.join(home, ".local", "bin", "openclaw.cmd");
-    await fs.mkdir(path.dirname(wrapper), { recursive: true });
-    await fs.writeFile(
-      wrapper,
-      `@echo off\r\nnode "${path.win32.join(oldRoot, "dist", "entry.js")}" %*\r\n`,
-    );
-    try {
-      await expect(
-        retireStandaloneGitWrapper({
-          previousRoot: oldRoot,
-          platform: "win32",
-          searchDirs: [path.dirname(wrapper)],
-        }),
-      ).resolves.toEqual({});
-      await expect(fs.stat(wrapper)).rejects.toMatchObject({ code: "ENOENT" });
-
-      await fs.writeFile(wrapper, "@echo off\r\necho unrelated\r\n");
-      await expect(
-        retireStandaloneGitWrapper({
-          previousRoot: oldRoot,
-          platform: "win32",
-          searchDirs: [path.dirname(wrapper)],
-        }),
-      ).resolves.toEqual({});
-      await expect(fs.readFile(wrapper, "utf8")).resolves.toContain("unrelated");
-    } finally {
-      await fs.rm(home, { recursive: true, force: true });
-    }
-  });
-});
 
 describe("successful update finalization ordering", () => {
   beforeEach(() => {
@@ -445,9 +362,6 @@ describe("successful update finalization ordering", () => {
   it("keeps an unhealthy restart blocking before completion refresh", async () => {
     Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
     mocks.restartService.mockResolvedValueOnce(false);
-    mocks.checkCompletionStatus.mockRejectedValueOnce(
-      new Error("completion status should not run after failed restart health"),
-    );
 
     await finishSuccessfulPackageSwitch({
       previousRoot: "/tmp/openclaw-update",
@@ -455,11 +369,76 @@ describe("successful update finalization ordering", () => {
       restartEnvironment: process.env,
     });
 
+    expect(mocks.printResult).toHaveBeenCalledOnce();
+    expect(mocks.printResult).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "error", reason: "restart-unhealthy" }),
+      expect.any(Object),
+    );
     expect(mocks.markSentinelFailure).toHaveBeenCalledWith(
       expect.objectContaining({ reason: "restart-unhealthy" }),
     );
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
     expect(mocks.checkCompletionStatus).not.toHaveBeenCalled();
+  });
+
+  it("reports elapsed time through restart and shell completion refresh", async () => {
+    let now = 1_000;
+    const clock = vi.spyOn(Date, "now").mockImplementation(() => now);
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    mocks.restartService.mockImplementationOnce(async () => {
+      now += 200;
+      return true;
+    });
+    mocks.checkCompletionStatus.mockImplementationOnce(async () => {
+      now += 300;
+      return { shell: "zsh", profileInstalled: true, cacheExists: true, usesSlowPattern: false };
+    });
+    try {
+      await finishSuccessfulPackageSwitch({
+        previousRoot: "/tmp/openclaw-update",
+        packageRoot: "/tmp/openclaw-update",
+        restartEnvironment: process.env,
+      });
+
+      expect(mocks.printResult).toHaveBeenCalledOnce();
+      expect(mocks.printResult.mock.lastCall?.[0]).toMatchObject({ status: "ok", durationMs: 500 });
+      expect(mocks.writeSentinel.mock.lastCall?.[0].result).toEqual(
+        mocks.printResult.mock.lastCall?.[0],
+      );
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  it("reports Windows autostart recovery failure before exiting", async () => {
+    const restore = vi.fn(async () => {
+      throw new Error("task restore failed");
+    });
+
+    await finishSuccessfulPackageSwitch({
+      previousRoot: "/tmp/openclaw-update",
+      packageRoot: "/tmp/openclaw-update",
+      restartEnvironment: process.env,
+      json: true,
+      windowsTaskAutoStartRecovery: {
+        suspended: Promise.resolve(true),
+        restore,
+        complete: () => {},
+        interrupted: () => false,
+      },
+    });
+
+    expect(restore).toHaveBeenCalledOnce();
+    expect(mocks.restartService).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.printResult).toHaveBeenCalledOnce();
+    expect(mocks.printResult).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "error", reason: "windows-task-autostart-restore-failed" }),
+      expect.objectContaining({ json: true }),
+    );
+    expect(mocks.writeSentinel.mock.lastCall?.[0].result).toEqual(
+      mocks.printResult.mock.lastCall?.[0],
+    );
   });
 
   it("retires the wrapper before persisting and printing success", async () => {
@@ -585,13 +564,13 @@ describe("successful update finalization ordering", () => {
         packageRoot: path.join(home, "package"),
       });
 
-      expect(mocks.writeSentinel).toHaveBeenCalledTimes(1);
-      expect(mocks.markSentinelFailure).toHaveBeenCalledWith(
-        expect.objectContaining({ reason: "wrapper-retirement-failed" }),
-      );
+      expect(mocks.writeSentinel).toHaveBeenCalledOnce();
       expect(mocks.printResult).toHaveBeenCalledWith(
         expect.objectContaining({ status: "error", reason: "wrapper-retirement-failed" }),
         expect.any(Object),
+      );
+      expect(mocks.markSentinelFailure).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: "wrapper-retirement-failed" }),
       );
       expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
     } finally {
@@ -820,6 +799,7 @@ describe("successful update finalization ordering", () => {
           packageRoot: "/tmp/openclaw-update",
           restartEnvironment: { ...process.env },
           sealed: true,
+          json: true,
         });
 
         expect(mocks.restartService).not.toHaveBeenCalled();
@@ -828,7 +808,14 @@ describe("successful update finalization ordering", () => {
         expect(defaultRuntime.error).toHaveBeenCalledWith(
           "Stopped gateway service could not be revalidated; inspect it before restarting manually.",
         );
-        expect(mocks.printResult).not.toHaveBeenCalled();
+        expect(mocks.printResult).toHaveBeenCalledOnce();
+        expect(mocks.printResult).toHaveBeenCalledWith(
+          expect.objectContaining({ status: "error", reason: "service-revalidation-failed" }),
+          expect.objectContaining({ json: true }),
+        );
+        expect(mocks.writeSentinel.mock.lastCall?.[0].result).toEqual(
+          mocks.printResult.mock.lastCall?.[0],
+        );
       },
     );
 
@@ -890,13 +877,16 @@ describe("successful update finalization ordering", () => {
         expect(mocks.restartService.mock.invocationCallOrder[0]).toBeLessThan(
           mocks.writeSentinel.mock.invocationCallOrder[1] ?? Number.POSITIVE_INFINITY,
         );
-        expect(mocks.markSentinelFailure).not.toHaveBeenCalled();
       } else {
         expect(mocks.writeSentinel).toHaveBeenCalledOnce();
+        expect(mocks.printResult).toHaveBeenCalledOnce();
+        expect(mocks.printResult).toHaveBeenCalledWith(
+          expect.objectContaining({ status: "error", reason: "restart-unhealthy" }),
+          expect.any(Object),
+        );
         expect(mocks.markSentinelFailure).toHaveBeenCalledWith(
           expect.objectContaining({ reason: "restart-unhealthy" }),
         );
-        expect(mocks.printResult).not.toHaveBeenCalled();
         expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
       }
     });
@@ -945,6 +935,7 @@ async function finishFailedUpdate(
     result,
     opts: { json: options.json },
     showProgress: false,
+    startedAt: Date.now(),
     preManagedServiceStop: { stopped: options.stopped ?? true, serviceEnv: {} },
     controlPlaneUpdateSentinelMeta: undefined,
   } as unknown as FinishUpdateParams);
@@ -961,6 +952,7 @@ async function finishSkippedUpdate(reason: string): Promise<void> {
     },
     opts: {},
     showProgress: false,
+    startedAt: Date.now(),
     controlPlaneUpdateSentinelMeta: undefined,
   } as unknown as FinishUpdateParams);
 }
@@ -995,11 +987,21 @@ describe("failed Git update recovery restart", () => {
     vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined as never);
   });
 
-  it("restarts a managed Gateway after verified rollback recovery", async () => {
-    await finishFailedUpdate(failedResult({ serviceRestartSafe: true }));
+  it.each(["error", "skipped"] as const)(
+    "records the %s outcome before recovery starts the Gateway",
+    async (status) => {
+      mocks.restart.mockImplementationOnce(async () => {
+        expect(mocks.writeSentinel.mock.lastCall?.[0].result).toMatchObject({ status });
+        expect(mocks.printResult).not.toHaveBeenCalled();
+      });
 
-    expect(mocks.restart).toHaveBeenCalledWith(expect.objectContaining({ root: "/repo" }));
-  });
+      await finishFailedUpdate({ ...failedResult({ serviceRestartSafe: true }), status });
+
+      expect(mocks.restart).toHaveBeenCalledWith(expect.objectContaining({ root: "/repo" }));
+      expect(mocks.writeSentinel).toHaveBeenCalledOnce();
+      expect(mocks.printResult).toHaveBeenCalledOnce();
+    },
+  );
 
   it("leaves a managed Gateway stopped after unverified rollback recovery", async () => {
     const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => undefined);
@@ -1069,7 +1071,10 @@ describe("failed Git update recovery restart", () => {
 
     await finishFailedUpdate(result, { json: true });
 
-    expect(mocks.printResult).toHaveBeenCalledWith(result, expect.objectContaining({ json: true }));
+    expect(mocks.printResult).toHaveBeenCalledWith(
+      expect.objectContaining({ ...result, durationMs: expect.any(Number) }),
+      expect.objectContaining({ json: true }),
+    );
     expect(mocks.restart).not.toHaveBeenCalled();
     expect(log).not.toHaveBeenCalled();
   });

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -47,11 +47,11 @@ import {
   isGatewayServiceManagementAllowedForUpdate,
   maybeRestartService,
   maybeRestartServiceAfterFailedMutableUpdate,
+  maybeResumeWindowsTaskAutoStartAfterPackageUpdate,
   revalidateManagedGatewayServiceAfterUpdate,
   resolveGatewayServiceManagementBlockMessageForUpdate,
   resolvePostUpdateServiceStateReadEnv,
   resolveUpdatedGatewayRestartPort,
-  restoreWindowsTaskAutoStartOrExit,
   shouldPrepareUpdatedInstallRestart,
   stripGatewayServiceMarkerEnv,
   tryInstallShellCompletion,
@@ -60,33 +60,6 @@ import {
 import { resolveUnsafeUpdateRecoveryGuidance } from "./update-recovery-guidance.js";
 
 const CLI_NAME = resolveCliName();
-
-const UPDATE_QUIPS = [
-  "Leveled up! New skills unlocked. You're welcome.",
-  "Fresh code, same lobster. Miss me?",
-  "Back and better. Did you even notice I was gone?",
-  "Update complete. I learned some new tricks while I was out.",
-  "Upgraded! Now with 23% more sass.",
-  "I've evolved. Try to keep up.",
-  "New version, who dis? Oh right, still me but shinier.",
-  "Patched, polished, and ready to pinch. Let's go.",
-  "The lobster has molted. Harder shell, sharper claws.",
-  "Update done! Check the changelog or just trust me, it's good.",
-  "Reborn from the boiling waters of npm. Stronger now.",
-  "I went away and came back smarter. You should try it sometime.",
-  "Update complete. The bugs feared me, so they left.",
-  "New version installed. Old version sends its regards.",
-  "Firmware fresh. Brain wrinkles: increased.",
-  "I've seen things you wouldn't believe. Anyway, I'm updated.",
-  "Back online. The changelog is long but our friendship is longer.",
-  "Upgraded! Peter fixed stuff. Blame him if it breaks.",
-  "Molting complete. Please don't look at my soft shell phase.",
-  "Version bump! Same chaos energy, fewer crashes (probably).",
-];
-
-function pickUpdateQuip(): string {
-  return UPDATE_QUIPS[Math.floor(Math.random() * UPDATE_QUIPS.length)] ?? "Update complete.";
-}
 
 export async function finishUpdate(params: {
   result: UpdateRunResult;
@@ -110,19 +83,53 @@ export async function finishUpdate(params: {
   updateStepTimeoutMs: number;
   invocationCwd?: string;
 }): Promise<void> {
-  if (params.result.status !== "ok") {
-    printResult(params.result, { ...params.opts, hideSteps: params.showProgress });
-  }
-
-  if (params.result.status === "error") {
-    if (!(await restoreWindowsTaskAutoStartOrExit(params.preManagedServiceStop))) {
-      return;
-    }
+  // Finalization owns the complete outcome, including recovery, restart, and completion work.
+  const printFinalResult = (result: UpdateRunResult) =>
+    printResult(
+      { ...result, durationMs: Math.max(0, Date.now() - params.startedAt) },
+      { ...params.opts, hideSteps: params.showProgress },
+    );
+  const reportResult = async (result: UpdateRunResult, recoverService = false) => {
+    const finalResult = { ...result, durationMs: Math.max(0, Date.now() - params.startedAt) };
     await writeControlPlaneUpdateRestartSentinelBestEffort({
       meta: params.controlPlaneUpdateSentinelMeta,
-      result: params.result,
+      result: finalResult,
       jsonMode: Boolean(params.opts.json),
     });
+    // The recovering Gateway reads this notification at startup. Persist once
+    // before restarting; rewriting a consumed sentinel could deliver it twice.
+    if (recoverService) {
+      await maybeRestartServiceAfterFailedMutableUpdate({
+        root: result.root,
+        preManagedServiceStop: params.preManagedServiceStop,
+        jsonMode: Boolean(params.opts.json),
+      });
+    }
+    printFinalResult(finalResult);
+  };
+  const restoreWindowsAutoStart = async (result: UpdateRunResult) => {
+    try {
+      await maybeResumeWindowsTaskAutoStartAfterPackageUpdate(params.preManagedServiceStop);
+      return true;
+    } catch (err) {
+      defaultRuntime.error(
+        `Failed to restore Windows Scheduled Task autostart after package update: ${String(err)}`,
+      );
+      await reportResult({
+        ...result,
+        status: "error",
+        reason: "windows-task-autostart-restore-failed",
+      });
+      defaultRuntime.exit(1);
+      return false;
+    }
+  };
+
+  if (params.result.status === "error") {
+    if (!(await restoreWindowsAutoStart(params.result))) {
+      return;
+    }
+    await reportResult(params.result, params.result.recovery?.serviceRestartSafe !== false);
     if (params.result.recovery?.serviceRestartSafe === false) {
       if (!params.opts.json) {
         const managedGatewayStopped = params.preManagedServiceStop?.stopped === true;
@@ -140,31 +147,16 @@ export async function finishUpdate(params: {
           defaultRuntime.log(theme.muted("Keep the gateway stopped until the update succeeds."));
         }
       }
-    } else {
-      await maybeRestartServiceAfterFailedMutableUpdate({
-        root: params.result.root,
-        preManagedServiceStop: params.preManagedServiceStop,
-        jsonMode: Boolean(params.opts.json),
-      });
     }
     defaultRuntime.exit(1);
     return;
   }
 
   if (params.result.status === "skipped") {
-    if (!(await restoreWindowsTaskAutoStartOrExit(params.preManagedServiceStop))) {
+    if (!(await restoreWindowsAutoStart(params.result))) {
       return;
     }
-    await writeControlPlaneUpdateRestartSentinelBestEffort({
-      meta: params.controlPlaneUpdateSentinelMeta,
-      result: params.result,
-      jsonMode: Boolean(params.opts.json),
-    });
-    await maybeRestartServiceAfterFailedMutableUpdate({
-      root: params.result.root,
-      preManagedServiceStop: params.preManagedServiceStop,
-      jsonMode: Boolean(params.opts.json),
-    });
+    await reportResult(params.result, true);
     if (params.result.reason === "dirty") {
       defaultRuntime.error(theme.error("Update blocked: local files are edited in this checkout."));
       defaultRuntime.log(
@@ -245,11 +237,12 @@ export async function finishUpdate(params: {
         }),
     );
     if (freshProcessResult.exitCode !== undefined) {
-      if (!(await restoreWindowsTaskAutoStartOrExit(params.preManagedServiceStop))) {
+      if (!(await restoreWindowsAutoStart(params.result))) {
         return;
       }
+      await reportResult({ ...params.result, status: "error", reason: "post-core-update-failed" });
       defaultRuntime.exit(freshProcessResult.exitCode);
-      throw new Error(`post-update process exited with code ${freshProcessResult.exitCode}`);
+      return;
     }
     pluginsUpdatedInFreshProcess = freshProcessResult.resumed;
     postCorePluginUpdate = freshProcessResult.pluginUpdate;
@@ -345,24 +338,15 @@ export async function finishUpdate(params: {
     : params.result;
 
   if (postCorePluginUpdate?.status === "error") {
-    if (!(await restoreWindowsTaskAutoStartOrExit(params.preManagedServiceStop))) {
+    if (!(await restoreWindowsAutoStart(resultWithPostUpdate))) {
       return;
     }
-    await writeControlPlaneUpdateRestartSentinelBestEffort({
-      meta: params.controlPlaneUpdateSentinelMeta,
-      result: resultWithPostUpdate,
-      jsonMode: Boolean(params.opts.json),
-    });
     // If strict config became valid despite a fresh-doctor process failure, restore the service
     // stopped by this update. Invalid post-migration config intentionally remains stopped.
-    if (postCorePluginUpdate.reason === POST_PLUGIN_DOCTOR_EXECUTION_FAILED_REASON) {
-      await maybeRestartServiceAfterFailedMutableUpdate({
-        root: params.result.root,
-        preManagedServiceStop: params.preManagedServiceStop,
-        jsonMode: Boolean(params.opts.json),
-      });
-    }
-    printResult(resultWithPostUpdate, { ...params.opts, hideSteps: params.showProgress });
+    await reportResult(
+      resultWithPostUpdate,
+      postCorePluginUpdate.reason === POST_PLUGIN_DOCTOR_EXECUTION_FAILED_REASON,
+    );
     defaultRuntime.exit(1);
     return;
   }
@@ -470,6 +454,11 @@ export async function finishUpdate(params: {
             ? formatErrorMessage(err)
             : "Stopped gateway service could not be revalidated; inspect it before restarting manually.";
         defaultRuntime.error(message);
+        await reportResult({
+          ...resultWithPostUpdate,
+          status: "error",
+          reason: "service-revalidation-failed",
+        });
         defaultRuntime.exit(1);
         return;
       }
@@ -486,7 +475,7 @@ export async function finishUpdate(params: {
     jsonMode: Boolean(params.opts.json),
   });
 
-  if (!(await restoreWindowsTaskAutoStartOrExit(params.preManagedServiceStop))) {
+  if (!(await restoreWindowsAutoStart(resultWithPostUpdate))) {
     return;
   }
   const restartOk = await withOwnedManagedUpdateEnv(params.ownedManagedUpdateEnv, async () =>
@@ -510,10 +499,17 @@ export async function finishUpdate(params: {
     }),
   );
   if (!restartOk) {
+    // The Gateway may already have consumed the notification. Mark only an
+    // existing sentinel; recreating it would deliver the update twice.
     await markControlPlaneUpdateRestartSentinelFailureBestEffort({
       meta: params.controlPlaneUpdateSentinelMeta,
       reason: "restart-unhealthy",
       jsonMode: Boolean(params.opts.json),
+    });
+    printFinalResult({
+      ...resultWithPostUpdate,
+      status: "error",
+      reason: "restart-unhealthy",
     });
     defaultRuntime.exit(1);
     return;
@@ -552,25 +548,15 @@ export async function finishUpdate(params: {
         reason: "wrapper-retirement-failed",
         jsonMode: Boolean(params.opts.json),
       });
-      const failedResult: UpdateRunResult = {
+      printFinalResult({
         ...resultWithPostUpdate,
         status: "error",
         reason: "wrapper-retirement-failed",
-      };
-      printResult(failedResult, { ...params.opts, hideSteps: params.showProgress });
+      });
       defaultRuntime.exit(1);
       return;
     }
   }
 
-  await writeControlPlaneUpdateRestartSentinelBestEffort({
-    meta: params.controlPlaneUpdateSentinelMeta,
-    result: resultWithPostUpdate,
-    jsonMode: Boolean(params.opts.json),
-  });
-
-  printResult(resultWithPostUpdate, { ...params.opts, hideSteps: params.showProgress });
-  if (!params.opts.json) {
-    defaultRuntime.log(theme.muted(pickUpdateQuip()));
-  }
+  await reportResult(resultWithPostUpdate);
 }

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -46,8 +46,6 @@ import { getSelfAndAncestorPidsSync } from "../../infra/restart-stale-pids.js";
 import { nodeVersionSatisfiesEngine } from "../../infra/runtime-guard.js";
 import { parseTcpPortFromArgs } from "../../infra/tcp-port.js";
 import type { UpdateChannel } from "../../infra/update-channels.js";
-import { fetchNpmPackageTargetStatus } from "../../infra/update-check-package-target.js";
-import { canResolveRegistryVersionForPackageTarget } from "../../infra/update-global.js";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -446,21 +444,6 @@ export async function maybeResumeWindowsTaskAutoStartAfterPackageUpdate(
   stopState.windowsTaskAutoStartRecovery = undefined;
 }
 
-export async function restoreWindowsTaskAutoStartOrExit(
-  stopState: PreManagedServiceStop | undefined,
-): Promise<boolean> {
-  try {
-    await maybeResumeWindowsTaskAutoStartAfterPackageUpdate(stopState);
-    return true;
-  } catch (err) {
-    defaultRuntime.error(
-      `Failed to restore Windows Scheduled Task autostart after package update: ${String(err)}`,
-    );
-    defaultRuntime.exit(1);
-    return false;
-  }
-}
-
 export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
   updateInstallKind: "git" | "package";
   root: string;
@@ -678,42 +661,23 @@ type PackageRuntimePreflight = {
 };
 
 export async function resolvePackageRuntimePreflight(params: {
-  tag: string;
+  target?: { version: string; nodeEngine: string | null };
   timeoutMs?: number;
   nodeRunner?: string;
   fallbackNodeRunner?: string;
-  spec?: string;
-  command?: string;
-  cwd?: string;
-  env?: NodeJS.ProcessEnv;
 }): Promise<Result<PackageRuntimePreflight, string>> {
   const nodeRunner = normalizeOptionalString(params.nodeRunner);
   const unchanged = (): PackageRuntimePreflight => (nodeRunner ? { nodeRunner } : {});
-  const target = params.tag.trim();
-  if (
-    !target ||
-    !canResolveRegistryVersionForPackageTarget(params.tag) ||
-    (params.spec && !canResolveRegistryVersionForPackageTarget(params.spec))
-  ) {
-    return ok(unchanged());
-  }
-  const status = await fetchNpmPackageTargetStatus({
-    target,
-    spec: params.spec,
-    timeoutMs: params.timeoutMs,
-    command: params.command,
-    cwd: params.cwd,
-    env: params.env,
-  });
-  if (status.error) {
+  const target = params.target;
+  if (!target) {
     return ok(unchanged());
   }
   const runtime = await resolvePackageRuntimeForPreflight({
     nodeRunner,
     timeoutMs: params.timeoutMs,
   });
-  const satisfies = nodeVersionSatisfiesEngine(runtime.version, status.nodeEngine);
-  const targetVersion = status.version ?? target;
+  const satisfies = nodeVersionSatisfiesEngine(runtime.version, target.nodeEngine);
+  const targetVersion = target.version;
   const unchangedRuntime = { ...unchanged(), targetVersion };
   if (satisfies === true) {
     return ok(unchangedRuntime);
@@ -726,7 +690,7 @@ export async function resolvePackageRuntimePreflight(params: {
     });
     const fallbackSatisfies = nodeVersionSatisfiesEngine(
       fallbackRuntime.version,
-      status.nodeEngine,
+      target.nodeEngine,
     );
     if (fallbackSatisfies === true) {
       return ok({
@@ -745,7 +709,7 @@ export async function resolvePackageRuntimePreflight(params: {
   return resultError(
     [
       `${runtimeLabel} is too old for openclaw@${targetVersion}.`,
-      `The requested package requires ${status.nodeEngine}.`,
+      `The requested package requires ${target.nodeEngine}.`,
       runtime.nodeRunner
         ? "Upgrade the Node runtime that owns the managed Gateway service, then rerun `openclaw update`."
         : "Upgrade to Node 22.22.3+, Node 24.15.0+, or Node 25.9.0+, then rerun `openclaw update`.",

--- a/src/cli/update-cli/update-command-wrapper-retirement.test.ts
+++ b/src/cli/update-cli/update-command-wrapper-retirement.test.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { retireStandaloneGitWrapper } from "./update-command-git.js";
+
+describe("retireStandaloneGitWrapper", () => {
+  it("removes only the installer wrapper for the previous checkout", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-wrapper-retire-"));
+    const oldRoot = path.join(home, "old checkout");
+    const unrelatedWrapper = path.join(home, "earlier", "openclaw");
+    const wrapper = path.join(home, ".local", "bin", "openclaw");
+    const secondWrapper = path.join(home, "legacy", "bin", "openclaw");
+    const oldWrapperContents = `#!/usr/bin/env bash\nset -euo pipefail\nexec /usr/bin/node ${oldRoot.replaceAll(" ", "\\ ")}/dist/entry.js "$@"\n`;
+    await Promise.all([
+      fs.mkdir(path.dirname(unrelatedWrapper), { recursive: true }),
+      fs.mkdir(path.dirname(wrapper), { recursive: true }),
+      fs.mkdir(path.dirname(secondWrapper), { recursive: true }),
+    ]);
+    await fs.writeFile(unrelatedWrapper, "#!/usr/bin/env bash\necho unrelated\n", { mode: 0o755 });
+    await Promise.all([
+      fs.writeFile(wrapper, oldWrapperContents, { mode: 0o755 }),
+      fs.writeFile(secondWrapper, oldWrapperContents, { mode: 0o755 }),
+    ]);
+    try {
+      await expect(
+        retireStandaloneGitWrapper({
+          previousRoot: oldRoot,
+          platform: "linux",
+          searchDirs: [
+            path.dirname(unrelatedWrapper),
+            path.dirname(wrapper),
+            path.dirname(secondWrapper),
+          ],
+        }),
+      ).resolves.toEqual({});
+      await expect(fs.readFile(unrelatedWrapper, "utf8")).resolves.toContain("unrelated");
+      await expect(fs.stat(wrapper)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.stat(secondWrapper)).rejects.toMatchObject({ code: "ENOENT" });
+
+      await fs.writeFile(
+        wrapper,
+        "#!/usr/bin/env node\nimport '../lib/node_modules/openclaw/openclaw.mjs';\n",
+        { mode: 0o755 },
+      );
+      await expect(
+        retireStandaloneGitWrapper({
+          previousRoot: oldRoot,
+          platform: "linux",
+          searchDirs: [path.dirname(wrapper)],
+        }),
+      ).resolves.toEqual({});
+      await expect(fs.stat(wrapper)).resolves.toBeDefined();
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("removes only the exact PowerShell installer wrapper on Windows", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-wrapper-retire-win-"));
+    const oldRoot = "C:\\Users\\operator\\openclaw";
+    const wrapper = path.join(home, ".local", "bin", "openclaw.cmd");
+    await fs.mkdir(path.dirname(wrapper), { recursive: true });
+    await fs.writeFile(
+      wrapper,
+      `@echo off\r\nnode "${path.win32.join(oldRoot, "dist", "entry.js")}" %*\r\n`,
+    );
+    try {
+      await expect(
+        retireStandaloneGitWrapper({
+          previousRoot: oldRoot,
+          platform: "win32",
+          searchDirs: [path.dirname(wrapper)],
+        }),
+      ).resolves.toEqual({});
+      await expect(fs.stat(wrapper)).rejects.toMatchObject({ code: "ENOENT" });
+
+      await fs.writeFile(wrapper, "@echo off\r\necho unrelated\r\n");
+      await expect(
+        retireStandaloneGitWrapper({
+          previousRoot: oldRoot,
+          platform: "win32",
+          searchDirs: [path.dirname(wrapper)],
+        }),
+      ).resolves.toEqual({});
+      await expect(fs.readFile(wrapper, "utf8")).resolves.toContain("unrelated");
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -136,6 +136,7 @@ async function updateCommandInternal(
   opts: UpdateCommandOptions,
   recoveryState: UpdateCommandRecoveryState,
 ): Promise<void> {
+  const startedAt = Date.now();
   suppressDeprecations();
   const invocationCwd = tryResolveInvocationCwd();
   const postCoreUpdateResume = process.env[POST_CORE_UPDATE_ENV] === "1";
@@ -208,6 +209,9 @@ async function updateCommandInternal(
     return;
   }
 
+  if (!opts.json) {
+    defaultRuntime.log(theme.muted("Checking for updates..."));
+  }
   const updateStatus = await checkUpdateStatus({
     root,
     timeoutMs: timeoutMs ?? 3500,
@@ -314,6 +318,7 @@ async function updateCommandInternal(
   let installedPackageName = DEFAULT_PACKAGE_NAME;
   let packageAlreadyCurrent = false;
   let packageTargetSchemaVersions: OpenClawSchemaVersions | undefined;
+  let packageRuntimeTarget: { version: string; nodeEngine: string | null } | undefined;
   let managedServiceRootRedirect: ManagedServiceRootRedirect | null = null;
   // Resolved independently of the root redirect so it covers the common case
   // where the package root is the same but the user's PATH-resolved node
@@ -487,6 +492,9 @@ async function updateCommandInternal(
         return;
       }
       packageTargetSchemaVersions = targetMetadata.schemaVersions;
+      // Runtime and schema checks must use the same exact package that will be
+      // installed; rereading a mutable dist-tag can inspect a different release.
+      packageRuntimeTarget = { version: targetVersion, nodeEngine: targetMetadata.nodeEngine };
       // Always install the exact inspected version: a dist-tag can move between
       // this lookup and the install, and an uninspected version would bypass
       // the schema and runtime decisions made here. Missing schema metadata
@@ -509,10 +517,11 @@ async function updateCommandInternal(
   }
 
   if (opts.dryRun) {
-    await printUpdateDryRun({
+    printUpdateDryRun({
       root,
       installKind,
       updateInstallKind,
+      mode: updateInstallKind === "git" ? "git" : (packageInstallTarget?.manager ?? "unknown"),
       switchToGit,
       switchToPackage,
       shouldRestart,
@@ -529,7 +538,6 @@ async function updateCommandInternal(
       managedServiceRootRedirect,
       explicitTag,
       packageSchemaPreflight,
-      timeoutMs: updateStepTimeoutMs,
       opts,
     });
     return;
@@ -576,14 +584,10 @@ async function updateCommandInternal(
       managedServiceNodeRunner !== undefined &&
       (await gatewayServiceCommandUsesRoot({ root })) === true;
     const runtimePreflight = await resolvePackageRuntimePreflight({
-      tag,
-      spec: packageInstallSpec ?? undefined,
+      target: packageRuntimeTarget,
       timeoutMs,
       nodeRunner: managedServiceNodeRunner,
       fallbackNodeRunner: canRefreshManagedServiceNode ? resolveNodeRunner() : undefined,
-      command: packageInstallTarget?.manager === "npm" ? packageInstallTarget.command : undefined,
-      cwd: packageInstallCwd,
-      env: packageInstallEnv,
     });
     if (!runtimePreflight.ok) {
       defaultRuntime.error(runtimePreflight.error);
@@ -613,14 +617,13 @@ async function updateCommandInternal(
   });
   await disableCurrentOpenClawUpdateLaunchdJob().catch(() => undefined);
 
-  const showProgress = !opts.json && process.stdout.isTTY;
+  const showProgress = !opts.json;
   if (!opts.json) {
     defaultRuntime.log(theme.heading("Updating OpenClaw..."));
     defaultRuntime.log("");
   }
 
   const { progress, stop } = createUpdateProgress(showProgress);
-  const startedAt = Date.now();
   const preUpdatePluginInstallRecords = await loadInstalledPluginIndexInstallRecords();
 
   const execution = await executeMutableUpdate({

--- a/src/gateway/test-helpers.config-runtime.ts
+++ b/src/gateway/test-helpers.config-runtime.ts
@@ -13,15 +13,34 @@ import { migratePersistedImplicitMainRoster } from "../config/legacy.roster.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { AgentBinding } from "../config/types.agents.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.js";
+import { validateConfigObjectWithPlugins } from "../config/validation.js";
 import { writeJsonAtomic } from "../infra/json-files.js";
 import { writeConfigMachineState } from "../state/config-machine-state.js";
 import { buildTestConfigSnapshot } from "./test-helpers.config-snapshots.js";
 import { testConfigRoot, testIsNixMode, testState } from "./test-helpers.runtime-state.js";
 
 type GatewayConfigModule = typeof import("../config/config.js");
+type GatewayConfigRuntime = Pick<
+  typeof import("../config/io.js"),
+  "resetConfigRuntimeState" | "getRuntimeConfigSnapshot" | "setRuntimeConfigSnapshot"
+>;
+type GatewayConfigOverrides = Pick<
+  GatewayConfigModule,
+  | "CONFIG_PATH"
+  | "STATE_DIR"
+  | "isNixMode"
+  | "applyConfigOverrides"
+  | "getRuntimeConfig"
+  | "parseConfigJson5"
+  | "validateConfigObject"
+  | "readConfigFileSnapshot"
+  | "readConfigFileSnapshotWithPluginMetadata"
+  | "readConfigFileSnapshotForWrite"
+  | "writeConfigFile"
+>;
 
-/** Wraps the real config module with gateway-test runtime overrides. */
-export function createGatewayConfigModuleMock(actual: GatewayConfigModule): GatewayConfigModule {
+/** Creates gateway-test overrides without importing the facade that re-exports mocked IO. */
+export function createGatewayConfigOverrides(actual: GatewayConfigRuntime): GatewayConfigOverrides {
   const resolveConfigPath = () => path.join(testConfigRoot.value, "openclaw.json");
 
   const composeTestConfig = (baseConfig: Record<string, unknown>) => {
@@ -236,7 +255,7 @@ export function createGatewayConfigModuleMock(actual: GatewayConfigModule): Gate
   const readConfigFileSnapshotWithPluginMetadata =
     async (): Promise<ReadConfigFileSnapshotWithPluginMetadataResult> => {
       const snapshot = await readConfigFileSnapshot();
-      const validation = actual.validateConfigObjectWithPlugins(snapshot.config, {
+      const validation = validateConfigObjectWithPlugins(snapshot.config, {
         env: process.env,
         pluginValidation: "skip",
       });
@@ -278,7 +297,6 @@ export function createGatewayConfigModuleMock(actual: GatewayConfigModule): Gate
   };
 
   return {
-    ...actual,
     get CONFIG_PATH() {
       return resolveConfigPath();
     },

--- a/src/gateway/test-helpers.mocks.ts
+++ b/src/gateway/test-helpers.mocks.ts
@@ -194,16 +194,18 @@ vi.mock("../infra/tailscale.js", async () => {
 
 vi.mock("../config/config.js", async () => {
   const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
-  const { createGatewayConfigModuleMock } = await import("./test-helpers.config-runtime.js");
-  return createGatewayConfigModuleMock(actual);
+  const { createGatewayConfigOverrides } = await import("./test-helpers.config-runtime.js");
+  return Object.defineProperties(
+    { ...actual },
+    Object.getOwnPropertyDescriptors(createGatewayConfigOverrides(actual)),
+  );
 });
 
 vi.mock("../config/io.js", async () => {
   const actual = await vi.importActual<typeof import("../config/io.js")>("../config/io.js");
-  const configActual =
-    await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
-  const { createGatewayConfigModuleMock } = await import("./test-helpers.config-runtime.js");
-  const configMock = createGatewayConfigModuleMock(configActual);
+  // The config facade re-exports IO; waiting for it here can deadlock a fresh module graph.
+  const { createGatewayConfigOverrides } = await import("./test-helpers.config-runtime.js");
+  const configMock = createGatewayConfigOverrides(actual);
   const createConfigIO = vi.fn(() => ({
     ...actual.createConfigIO(),
     getRuntimeConfig: configMock.getRuntimeConfig,

--- a/src/gateway/test-helpers.server-env.test.ts
+++ b/src/gateway/test-helpers.server-env.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { resetConfigRuntimeState } from "../config/config.js";
 import { drainSystemEvents, enqueueSystemEvent } from "../infra/system-events.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
-import { createGatewayConfigModuleMock } from "./test-helpers.config-runtime.js";
+import { createGatewayConfigOverrides } from "./test-helpers.config-runtime.js";
 import { disconnectGatewayClient, startGatewayWithClient } from "./test-helpers.e2e.js";
 import { testState } from "./test-helpers.runtime-state.js";
 import {
@@ -60,9 +60,8 @@ describe("Gateway test environment lifecycle", () => {
   it.each(["session store", "config mock"])(
     "keeps config readable while the %s fixture publishes an update",
     async (fixture) => {
-      const actual =
-        await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
-      const { writeConfigFile } = createGatewayConfigModuleMock(actual);
+      const actual = await vi.importActual<typeof import("../config/io.js")>("../config/io.js");
+      const { writeConfigFile } = createGatewayConfigOverrides(actual);
       await writeConfigFile({ session: { reset: { idleMinutes: 30 } } });
       const configPath = process.env.OPENCLAW_CONFIG_PATH!;
       const readIdleMinutes = () =>

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -51,11 +51,11 @@ describe("resolveNpmChannelTag", () => {
 
   let versionByTag: Record<string, string | null>;
   let runCommand: NpmMetadataCommandRunner;
-  let runCommandMock: ReturnType<typeof vi.fn>;
+  let runCommandMock: ReturnType<typeof vi.fn<NpmMetadataCommandRunner>>;
 
   beforeEach(() => {
     versionByTag = {};
-    runCommandMock = vi.fn(async (argv: string[]) => {
+    runCommandMock = vi.fn<NpmMetadataCommandRunner>(async (argv) => {
       const spec = argv[2] ?? "";
       const tag = spec.slice(spec.lastIndexOf("@") + 1);
       const version = versionByTag[tag] ?? null;
@@ -71,7 +71,7 @@ describe("resolveNpmChannelTag", () => {
         code: version == null ? 1 : 0,
       };
     });
-    runCommand = runCommandMock as unknown as NpmMetadataCommandRunner;
+    runCommand = runCommandMock;
   });
 
   it("delegates package target metadata to npm view with global config scope", async () => {
@@ -396,6 +396,35 @@ describe("resolveNpmChannelTag", () => {
       tag: "latest",
       version: "1.0.3",
     });
+  });
+
+  it("resolves beta and stable within one registry response delay", async () => {
+    vi.useFakeTimers();
+    try {
+      runCommandMock.mockImplementation(async (argv: string[]) => {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 200);
+        });
+        return {
+          stdout: JSON.stringify({
+            version: argv[2] === "openclaw@beta" ? "2026.9.1-beta.1" : "2026.8.30",
+          }),
+          stderr: "",
+          code: 0,
+        };
+      });
+      const completed = vi.fn();
+      const pending = resolveNpmChannelTag({ channel: "beta", timeoutMs: 1000, runCommand });
+      void pending.then(completed);
+
+      await vi.advanceTimersByTimeAsync(200);
+
+      expect(completed).toHaveBeenCalledWith({ tag: "beta", version: "2026.9.1-beta.1" });
+      await pending;
+    } finally {
+      await vi.runAllTimersAsync();
+      vi.useRealTimers();
+    }
   });
 
   it("fetches registry tag versions and reports missing tags", async () => {

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -533,26 +533,23 @@ export async function resolveNpmChannelTag(params: {
       ? { tag: resolved.selector, version: resolved.version }
       : { tag: channelTag, version: null, reason: resolved.reason };
   }
-  const channelStatus = await fetchNpmTagVersion({
-    tag: channelTag,
-    timeoutMs: params.timeoutMs,
-    command: params.command,
-    cwd: params.cwd,
-    env: params.env,
-    runCommand: params.runCommand,
-  });
+  const fetchTag = (tag: string) =>
+    fetchNpmTagVersion({
+      tag,
+      timeoutMs: params.timeoutMs,
+      command: params.command,
+      cwd: params.cwd,
+      env: params.env,
+      runCommand: params.runCommand,
+    });
   if (params.channel !== "beta") {
-    return channelStatus;
+    return await fetchTag(channelTag);
   }
 
-  const latestStatus = await fetchNpmTagVersion({
-    tag: "latest",
-    timeoutMs: params.timeoutMs,
-    command: params.command,
-    cwd: params.cwd,
-    env: params.env,
-    runCommand: params.runCommand,
-  });
+  const [channelStatus, latestStatus] = await Promise.all([
+    fetchTag(channelTag),
+    fetchTag("latest"),
+  ]);
   if (!latestStatus.version) {
     return channelStatus;
   }

--- a/src/infra/update-runner-command.ts
+++ b/src/infra/update-runner-command.ts
@@ -34,12 +34,14 @@ export async function runStep(opts: RunStepOptions): Promise<UpdateStepResult> {
   const started = Date.now();
   const result = await runCommand(argv, { cwd, timeoutMs, env });
   const durationMs = Date.now() - started;
+  const stdoutTail = trimLogTail(result.stdout, MAX_LOG_CHARS);
   const stderrTail = trimLogTail(result.stderr, MAX_LOG_CHARS);
 
   progress?.onStepComplete?.({
     ...stepInfo,
     durationMs,
     exitCode: result.code,
+    stdoutTail,
     stderrTail,
     signal: result.signal,
     killed: result.killed,
@@ -52,7 +54,7 @@ export async function runStep(opts: RunStepOptions): Promise<UpdateStepResult> {
     cwd,
     durationMs,
     exitCode: result.code,
-    stdoutTail: trimLogTail(result.stdout, MAX_LOG_CHARS),
+    stdoutTail,
     stderrTail,
     signal: result.signal,
     killed: result.killed,

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -271,6 +271,9 @@ export async function updateGitCheckout(params: {
   };
 
   const statusCheck = await runStep(step("clean check", gitCleanCheckArgs(gitRoot), gitRoot));
+  if (statusCheck.exitCode !== 0) {
+    return buildError("clean-check-failed");
+  }
   if (statusCheck.stdoutTail?.trim()) {
     return buildError("dirty", "skipped");
   }

--- a/src/infra/update-runner-types.ts
+++ b/src/infra/update-runner-types.ts
@@ -115,15 +115,7 @@ export type UpdateStepInfo = {
   total: number;
 };
 
-type UpdateStepCompletion = UpdateStepInfo & {
-  durationMs: number;
-  exitCode: number | null;
-  stderrTail?: string | null;
-  signal?: NodeJS.Signals | null;
-  killed?: boolean;
-  termination?: "exit" | "timeout" | "no-output-timeout" | "signal";
-  advisory?: UpdateStepAdvisory;
-};
+type UpdateStepCompletion = UpdateStepInfo & Omit<UpdateStepResult, "cwd">;
 
 export type UpdateStepProgress = {
   onStepStart?: (step: UpdateStepInfo) => void;

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -703,20 +703,58 @@ describe("runGatewayUpdate", () => {
     };
   }
 
-  it("skips git update when worktree is dirty", async () => {
-    await setupGitCheckout();
-    const beforeGitMutation = vi.fn<() => Promise<void>>();
-    const { runner, calls } = createRunner({
-      ...buildGitWorktreeProbeResponses({ status: " M README.md" }),
-    });
+  it.each([
+    {
+      name: "dirty",
+      code: 0,
+      stdout: " M README.md",
+      stderr: "",
+      status: "skipped",
+      reason: "dirty",
+    },
+    {
+      name: "unreadable",
+      code: 128,
+      stdout: "",
+      stderr: "fatal: unable to read index",
+      status: "error",
+      reason: "clean-check-failed",
+    },
+    {
+      name: "timed out",
+      code: null,
+      stdout: "",
+      stderr: "git status timed out",
+      status: "error",
+      reason: "clean-check-failed",
+    },
+  ])(
+    "stops git update when the worktree is $name",
+    async ({ code, stdout, stderr, status, reason }) => {
+      await setupGitCheckout();
+      const beforeGitMutation = vi.fn<() => Promise<void>>();
+      const { runner, calls } = createRunner({
+        ...buildGitWorktreeProbeResponses(),
+        [`git -C ${tempDir} status --porcelain -- :!dist/control-ui/`]: { code, stdout, stderr },
+      });
 
-    const result = await runWithRunner(runner, { beforeGitMutation });
+      const result = await runWithRunner(runner, { beforeGitMutation });
 
-    expect(result.status).toBe("skipped");
-    expect(result.reason).toBe("dirty");
-    expect(beforeGitMutation).not.toHaveBeenCalled();
-    expect(calls.filter((call) => call.includes("rebase"))).toEqual([]);
-  });
+      expect(result.status).toBe(status);
+      expect(result.reason).toBe(reason);
+      expect(result.steps).toMatchObject([
+        {
+          name: "clean check",
+          exitCode: code,
+          stdoutTail: stdout || null,
+          stderrTail: stderr || null,
+        },
+      ]);
+      expect(beforeGitMutation).not.toHaveBeenCalled();
+      expect(calls.some((call) => call.includes(" fetch "))).toBe(false);
+      expect(calls.filter((call) => call.includes("rebase"))).toEqual([]);
+    },
+  );
 
   it("uses the supplied update cwd when the process cwd disappeared", async () => {
     await setupGitCheckout();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw update` could reject an already-selected package using another release's Node requirements after a dist-tag moved. Updates also hid build errors written to stdout, left captured logs silent during long steps, underreported total duration, and sometimes exited after restart/recovery failure without a JSON result.

## Why This Change Was Made

Package planning now carries the exact inspected version and Node requirement into runtime preflight, removing a second mutable-tag lookup. Dry-run reuses the resolved package manager, and independent beta/stable metadata reads overlap. CLI package steps share the existing core step runner and bounded diagnostics renderer.

Finalization owns the complete update result, including fresh-process, service-revalidation, Windows autostart, and restart failures. Failure notifications remain persisted once before recovery restarts; late restart failures update only an existing notification, preserving consumption. Elapsed output is finalized afterward. Failed or timed-out Git cleanliness checks now stop before fetch, mutation, or build.

Production LOC: +204/-285 (net -81). Test/support LOC: +532/-212 (net +320), including relocation of two existing wrapper-retirement tests; documentation +7. Removed the duplicate step runner, repeated metadata/manager lookup, duplicated failure reporting, and random completion quips. No configuration, dependency, protocol, or database-schema changes.

## User Impact

Updates show readable step names and an elapsed timer in terminals, plain progress in captured logs, and the final diagnostics from both output streams on failure. Timeouts are identified explicitly. Total time includes initial checks, plugin updates, and requested Gateway restart checks; `--json` keeps stdout machine-readable and reports finalization failures.

## Evidence

- 788 distinct tests passed across 19 selected update CLI, status, runner, plugin-convergence, service, restart, and lifecycle files; one test skipped. New regressions were exercised against pre-fix behavior, including mutable-tag/runtime mismatch, stdout-only failures, missing final JSON outcomes, and failed Git clean checks.
- Final affected CLI/finalization rerun: `node scripts/run-vitest.mjs src/cli/update-cli.test.ts src/cli/update-cli/update-command-post-update.test.ts src/cli/update-cli/update-command-post-core.test.ts` — 322 passed, including a real SQLite sentinel consumed during restart before health failure. This regression failed before the correction.
- Final fixture/split rerun: `node scripts/run-vitest.mjs src/infra/update-check.test.ts src/cli/update-cli/update-command-post-update.test.ts src/cli/update-cli/update-command-wrapper-retirement.test.ts` — 70 passed.
- Full `pnpm build` and the full changed-file gate passed during the initial pass. After the final sentinel correction, `OPENCLAW_RUN_NODE_SKIP_DTS_BUILD=1 pnpm build` passed; `env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs` passed in full on the final updater code. `git diff --check` passed.
- Built CLI `update --dry-run --no-restart`, human and JSON modes, exited 0 with no stderr and byte-identical isolated state afterward. Real terminal progress and a real subprocess stdout-only failure were exercised.
- Removed metadata lookup: three actual npm requests measured 2340/2567/2358 ms. Controlled beta/stable responses (200 ms each) improved from 403 ms serial to 202 ms concurrent; a real concurrent registry lookup completed in 1348 ms. These are component measurements, not an end-to-end upgrade speed claim.
- Fresh independent Codex review is clean through P2 after preserving both pre-recovery notification ordering and consumed-notification handling. The final CI-repair changed-file gate also passed in full. Exact-head [CI33343580913](https://github.com/openclaw/openclaw/actions/runs/33343580913) completed successfully at `c2dbad4e5cca92cc63b65674beaf7d40eefe5877`, with required `openclaw/ci-gate` green.
- Candidate packaged upgrade proof passed on exact head `3b3b2007c1e66c2ccc500e452ac2e45199c8a81d`: `pnpm test:docker:multi-node-update`, configured Blacksmith Testbox `tbx_01m1ags9mehzaw95vckgycpt6m`, [run 33342481567](https://github.com/openclaw/openclaw/actions/runs/33342481567). The updater exited 0, retained the original Node/package root with another Node first on PATH, avoided a split installation, and restarted a real Gateway that passed `/healthz`. The lease is stopped. This lane uses a Linux fixture service manager and refreshes the candidate tarball; registry selection and native macOS/Windows services are covered separately by source/regression proof. The operator's installation and Gateway are untouched.

Follow-ups: avoid full Git-status discovery used only for installation-kind detection; consolidate initial managed-service inspection without weakening later ownership revalidation; profile startup imports under quiet host load. Related open work addresses distinct moved Git release tags (#128345) and container permission guidance (#95887); this PR does not claim to resolve either.

CI follow-up: the first hosted run reported an intermittent hang in the unchanged `src/gateway/server.health.lifecycle.test.ts` import/reset fixture; the stalled case moved between attempts, and the same symptom is recorded in #133530. Source inspection found a circular await: the config facade re-exports mocked IO, while that IO mock awaited the facade. The test-support repair removes the reverse import, takes validation directly from its owner, and preserves live path getters. All 134 tests across the original nine-file shard plus the environment suite pass. The original code also passed locally, so the hang attribution remains an inference fresh hosted CI confirms that the previously failing Gateway shard passes at the new head. The full aggregate gate also passed. No lifecycle assertions or timeouts changed.
