### PR TITLE
docs: remove v2026.8.1 draft warning

### DIFF
--- a/docs/releases/2026.8.1.md
+++ b/docs/releases/2026.8.1.md
@@ -14,12 +14,6 @@ keywords:
 
 # v2026.8.1 (AKA OpenClaw 2.0)
 
-<Warning>
-**Draft release notes**
-
-This page is under active editorial review and does not represent the final v2026.8.1 release notes. Content, grouping, wording, and source lists may change.
-</Warning>
-
 For the story behind this release, read [OpenClaw 2.0, Accidentally](https://openclaw.ai/blog/openclaw-2-accidentally).
 
 This update touches every part of OpenClaw, including installation, messaging, memory, skills, models, automations, the browser and native apps, plugins, security, and many smaller fixes.


### PR DESCRIPTION
Related: openclaw/openclaw.ai#250

Follows #133620. Coordinate merge with openclaw/openclaw.ai#250.

## What Problem This Solves

The published v2026.8.1 release notes still tell readers that they are a draft, even though the release story is ready to publish.

## Why This Change Was Made

Removes only the obsolete top-level editorial draft warning. The storage and downgrade warning remains unchanged.

## User Impact

Readers see the release notes as finalized and can follow the existing link to the OpenClaw 2.0 release story once the companion website PR merges.

## Evidence

- `git diff --check` passes.
- The diff contains only six removed Markdown lines.
- Confirmed the storage and downgrade warning remains present.
- The prior docs-only wrapper run classified this release-note surface as docs-only; its follow-on local check was blocked by the checkout missing the pinned pnpm 12.1.0 binary.

AI-assisted: yes.