### PR TITLE
fix(scripts): preserve protected GitHub CLI routing

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -120,6 +120,17 @@ pull-request head:
 node scripts/watch-pr-ci.mjs <pr-number> <full-head-sha>
 ```
 
+Maintainer GitHub helpers use the external `gh` on the caller's unchanged
+`PATH`, so that route owns credentials, filtering, and any native delegation.
+“Plain” means normalized terminal output: helpers do not discover native
+installations, extract default-route tokens, or retry a refusal through another
+binary. `OPENCLAW_GH_BIN` is an explicit operator-owned override for supporting
+callers; choose it only when its authentication and protections are appropriate.
+PATH-based read helpers, including this watcher, ignore that override.
+Authoritative REST reads request revalidation with `Cache-Control: max-age=0`
+and supply concrete repository paths. Writer identity comes from the authenticated
+GraphQL viewer, not a relay's REST caller profile.
+
 The default `rollup` mode waits for the attached CI workflow to succeed and
 for the remaining rollup checks to finish without failures. Supersession stays
 within workflow identity; `Auto response` is excluded from the wait.

--- a/scripts/frv.mjs
+++ b/scripts/frv.mjs
@@ -163,18 +163,27 @@ async function execGhRead(args, options = {}) {
   throw lastError;
 }
 
+function readFreshGhApi(repository, path, args = []) {
+  // Rerun decisions require current attempts and jobs, not a relay's earlier snapshot.
+  return execGhRead([
+    "api",
+    `repos/${repository}/${path}`,
+    "-H",
+    "Cache-Control: max-age=0",
+    ...args,
+  ]);
+}
+
 async function ghJson(repository, path) {
-  return JSON.parse(await execGhRead(["api", `repos/${repository}/${path}`]));
+  return JSON.parse(await readFreshGhApi(repository, path));
 }
 
 async function ghAttemptJobs(repository, runId, runAttempt) {
-  const output = await execGhRead([
-    "api",
-    "--paginate",
-    `repos/${repository}/actions/runs/${runId}/attempts/${runAttempt}/jobs?per_page=100`,
-    "--jq",
-    ".jobs[] | @json",
-  ]);
+  const output = await readFreshGhApi(
+    repository,
+    `actions/runs/${runId}/attempts/${runAttempt}/jobs?per_page=100`,
+    ["--paginate", "--jq", ".jobs[] | @json"],
+  );
   return output
     ? output
         .split("\n")
@@ -404,12 +413,7 @@ export function createClient(repository, dependencies = {}) {
   const apiJson = dependencies.apiJson ?? ((path) => ghJson(repository, path));
   const apiText =
     dependencies.apiText ??
-    ((path, jq) =>
-      execGhRead(
-        jq
-          ? ["api", "--paginate", `repos/${repository}/${path}`, "--jq", jq]
-          : ["api", `repos/${repository}/${path}`],
-      ));
+    ((path, jq) => readFreshGhApi(repository, path, jq ? ["--paginate", "--jq", jq] : []));
   const mutate = dependencies.mutate ?? ((args) => execGh(args));
   const rerun = (runId, action) =>
     mutate(["api", "-X", "POST", `repos/${repository}/actions/runs/${runId}/${action}`]);

--- a/scripts/lib/plain-gh.mjs
+++ b/scripts/lib/plain-gh.mjs
@@ -1,6 +1,5 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
-import path from "node:path";
 
 /** @typedef {import("node:child_process").ExecFileSyncOptions} ExecFileSyncOptions */
 /** @typedef {import("node:child_process").ExecFileSyncOptionsWithBufferEncoding} ExecFileSyncOptionsWithBufferEncoding */
@@ -14,14 +13,6 @@ import path from "node:path";
  */
 
 const PLAIN_GH_MAX_BUFFER_BYTES = 32 * 1024 * 1024;
-export const PLAIN_GH_SYSTEM_CANDIDATES = [
-  // Prefer package-manager opt paths: bin/gh may intentionally be an Octopool shim.
-  "/opt/homebrew/opt/gh/bin/gh",
-  "/usr/local/opt/gh/bin/gh",
-  "/home/linuxbrew/.linuxbrew/opt/gh/bin/gh",
-  "/opt/homebrew/bin/gh",
-  "/usr/local/bin/gh",
-];
 
 /**
  * @param {string} filePath
@@ -37,17 +28,9 @@ function isExecutable(filePath) {
 }
 
 /**
- * @param {NodeJS.ProcessEnv} env
- * @returns {string[]}
- */
-function pathEntries(env) {
-  return (env.PATH ?? "").split(path.delimiter).filter(Boolean);
-}
-
-/**
- * Credential-injecting PATH wrappers may be the only authenticated gh entry
- * point even though writes need the unwrapped CLI. Forward its token only to
- * the selected plain CLI process; never persist it in process.env.
+ * Explicit binary overrides may need credentials from a separate PATH entry
+ * point. Forward its token only to that child; the default PATH route owns its
+ * credentials and must not have them extracted or reinjected.
  *
  * @param {NodeJS.ProcessEnv} env
  * @returns {NodeJS.ProcessEnv}
@@ -55,6 +38,7 @@ function pathEntries(env) {
 export function plainGhAuthenticatedEnv(env) {
   const next = plainGhEnv(env);
   if (
+    !next.OPENCLAW_GH_BIN ||
     next.GH_TOKEN ||
     next.GITHUB_TOKEN ||
     next.GH_ENTERPRISE_TOKEN ||
@@ -108,13 +92,9 @@ export function plainGhEnv(env = process.env) {
 
 /**
  * @param {NodeJS.ProcessEnv} [env]
- * @param {readonly string[]} [systemCandidates]
  * @returns {string}
  */
-export function resolvePlainGhBin(
-  env = process.env,
-  systemCandidates = PLAIN_GH_SYSTEM_CANDIDATES,
-) {
+export function resolvePlainGhBin(env = process.env) {
   if (env.OPENCLAW_GH_BIN) {
     if (isExecutable(env.OPENCLAW_GH_BIN)) {
       return env.OPENCLAW_GH_BIN;
@@ -122,31 +102,8 @@ export function resolvePlainGhBin(
     throw new Error(`OPENCLAW_GH_BIN is not executable: ${env.OPENCLAW_GH_BIN}`);
   }
 
-  for (const candidate of systemCandidates) {
-    if (isExecutable(candidate)) {
-      return candidate;
-    }
-  }
-
-  const homeBin = env.HOME ? path.join(env.HOME, "bin") : "";
-  for (const entry of pathEntries(env)) {
-    if (homeBin && entry === homeBin) {
-      continue;
-    }
-    const candidate = path.join(entry, process.platform === "win32" ? "gh.exe" : "gh");
-    if (isExecutable(candidate)) {
-      return candidate;
-    }
-  }
-
-  for (const entry of pathEntries(env)) {
-    const candidate = path.join(entry, process.platform === "win32" ? "gh.exe" : "gh");
-    if (isExecutable(candidate)) {
-      return candidate;
-    }
-  }
-
-  throw new Error("missing required command: gh");
+  // child_process resolves PATH in the child cwd, including relative and empty entries.
+  return "gh";
 }
 
 /**
@@ -211,7 +168,7 @@ export function execPlainGh(args, options = {}) {
  */
 export function execGhRead(args, options = {}, params = {}) {
   const env = plainGhEnv(options.env ?? process.env);
-  // Reads stay on the cache-aware PATH shim; the explicit binary is reserved for writes.
+  // Cache-aware reads stay on PATH even when another caller selects an explicit binary.
   delete env.OPENCLAW_GH_BIN;
   const execFileSyncImpl = params.execFileSyncImpl ?? execFileSync;
   return execFileSyncImpl("gh", args, {

--- a/scripts/lib/plain-gh.sh
+++ b/scripts/lib/plain-gh.sh
@@ -23,58 +23,13 @@ resolve_plain_gh_bin() {
     return 1
   fi
 
-  local candidate
-  while IFS= read -r candidate; do
-    if [ -x "$candidate" ]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done < <(plain_gh_system_candidates)
-
-  if candidate=$(PATH="$(plain_gh_search_path)" type -P gh 2>/dev/null); then
-    printf '%s\n' "$candidate"
-    return 0
-  fi
-
+  # PATH owns routing and guarded delegation; plain only normalizes output.
   type -P gh 2>/dev/null
 }
 
-plain_gh_system_candidates() {
-  # bin/gh may intentionally be an Octopool shim; prefer package-manager opt paths.
-  printf '%s\n' \
-    /opt/homebrew/opt/gh/bin/gh \
-    /usr/local/opt/gh/bin/gh \
-    /home/linuxbrew/.linuxbrew/opt/gh/bin/gh \
-    /opt/homebrew/bin/gh \
-    /usr/local/bin/gh
-}
-
-plain_gh_search_path() {
-  local path_value="${PATH:-}"
-  local home_bin="${HOME:-}/bin"
-  local item
-  local output=""
-  local first=true
-  local path_parts=()
-
-  IFS=':' read -r -a path_parts <<<"$path_value"
-  for item in "${path_parts[@]}"; do
-    if [ -n "${HOME:-}" ] && [ "$item" = "$home_bin" ]; then
-      continue
-    fi
-    if [ "$first" = "true" ]; then
-      output="$item"
-      first=false
-    else
-      output="${output}:$item"
-    fi
-  done
-
-  printf '%s\n' "$output"
-}
-
 plain_gh_auth_token() {
-  if [ -n "${GH_TOKEN:-}" ] ||
+  if [ -z "${OPENCLAW_GH_BIN:-}" ] ||
+    [ -n "${GH_TOKEN:-}" ] ||
     [ -n "${GITHUB_TOKEN:-}" ] ||
     [ -n "${GH_ENTERPRISE_TOKEN:-}" ] ||
     [ -n "${GITHUB_ENTERPRISE_TOKEN:-}" ]; then

--- a/scripts/pr
+++ b/scripts/pr
@@ -233,10 +233,8 @@ require_cmds() {
       missing+=("$cmd")
     fi
   done
-  if ! OPENCLAW_GH_BIN="$(resolve_plain_gh_bin)"; then
-    missing+=("real-gh")
-  else
-    export OPENCLAW_GH_BIN
+  if ! resolve_plain_gh_bin >/dev/null; then
+    missing+=("gh")
   fi
 
   if [ "${#missing[@]}" -gt 0 ]; then

--- a/scripts/pr-lib/crabbox-merge-bypass.sh
+++ b/scripts/pr-lib/crabbox-merge-bypass.sh
@@ -35,12 +35,16 @@ verify_crabbox_admin_merge_bypass() {
     return 1
   fi
 
+  local repo_nwo
+  repo_nwo=$(gh_plain repo view --json nameWithOwner --jq .nameWithOwner) || return 1
+  # Mutable authorization evidence must be revalidated even when PATH uses a cache.
+  local api_read=(api -H 'Cache-Control: max-age=0')
   local proof_dir=".local/merge-crabbox-bypass"
   rm -rf "$proof_dir"
   mkdir -p "$proof_dir"
   read_required_checks_for_crabbox_bypass "$pr" "$proof_dir/required-checks.json" || return 1
-  gh_plain api user >"$proof_dir/actor.json" || return 1
-  gh_plain api "repos/{owner}/{repo}/pulls/$pr" >"$proof_dir/pull-request.json" || return 1
+  gh_plain api graphql -f 'query=query { viewer { login } }' --jq .data.viewer >"$proof_dir/actor.json" || return 1
+  gh_plain "${api_read[@]}" "repos/$repo_nwo/pulls/$pr" >"$proof_dir/pull-request.json" || return 1
   local actor
   actor=$(jq -r '.login // empty' "$proof_dir/actor.json")
   if [ -z "$actor" ]; then
@@ -48,8 +52,8 @@ verify_crabbox_admin_merge_bypass() {
     return 1
   fi
 
-  if ! gh_plain api --paginate --slurp \
-    "repos/{owner}/{repo}/commits/$head_sha/check-runs?filter=latest&per_page=100" \
+  if ! gh_plain "${api_read[@]}" --paginate --slurp \
+    "repos/$repo_nwo/commits/$head_sha/check-runs?filter=latest&per_page=100" \
     >"$proof_dir/check-run-pages.json"; then
     echo "Crabbox merge bypass failed: unable to read exact-head check runs." >&2
     return 1
@@ -71,7 +75,7 @@ verify_crabbox_admin_merge_bypass() {
     echo "Crabbox merge bypass failed: trusted gate has no exact Actions run URL." >&2
     return 1
   fi
-  gh_plain api "repos/{owner}/{repo}/actions/runs/$crabbox_publisher_run_id" \
+  gh_plain "${api_read[@]}" "repos/$repo_nwo/actions/runs/$crabbox_publisher_run_id" \
     >"$proof_dir/publisher-run.json" || return 1
 
   local ci_details_url
@@ -91,10 +95,10 @@ verify_crabbox_admin_merge_bypass() {
     return 1
   fi
 
-  gh_plain api "repos/{owner}/{repo}/actions/runs/$ci_run_id" \
+  gh_plain "${api_read[@]}" "repos/$repo_nwo/actions/runs/$ci_run_id" \
     >"$proof_dir/workflow-run.json" || return 1
-  if ! gh_plain api --paginate --slurp \
-    "repos/{owner}/{repo}/actions/runs/$ci_run_id/jobs?filter=latest&per_page=100" \
+  if ! gh_plain "${api_read[@]}" --paginate --slurp \
+    "repos/$repo_nwo/actions/runs/$ci_run_id/jobs?filter=latest&per_page=100" \
     >"$proof_dir/job-pages.json"; then
     echo "Crabbox merge bypass failed: unable to read normal CI jobs." >&2
     return 1
@@ -103,19 +107,19 @@ verify_crabbox_admin_merge_bypass() {
 
   local encoded_actor
   encoded_actor=$(jq -rn --arg value "$actor" '$value | @uri')
-  gh_plain api "orgs/openclaw/memberships/$encoded_actor" \
+  gh_plain "${api_read[@]}" "orgs/openclaw/memberships/$encoded_actor" \
     >"$proof_dir/membership.json" || return 1
-  gh_plain api "repos/{owner}/{repo}/git/ref/heads/main" >"$proof_dir/main-ref.json" || return 1
+  gh_plain "${api_read[@]}" "repos/$repo_nwo/git/ref/heads/main" >"$proof_dir/main-ref.json" || return 1
   local workflow_sha
   local main_sha
   workflow_sha=$(jq -er '.head_sha | select(type == "string" and test("^[0-9a-f]{40}$"))' \
     "$proof_dir/publisher-run.json") || return 1
   main_sha=$(jq -er '.object.sha | select(type == "string" and test("^[0-9a-f]{40}$"))' \
     "$proof_dir/main-ref.json") || return 1
-  gh_plain api "repos/{owner}/{repo}/compare/$workflow_sha...$main_sha" \
+  gh_plain "${api_read[@]}" "repos/$repo_nwo/compare/$workflow_sha...$main_sha" \
     >"$proof_dir/main-comparison.json" || return 1
   # Keep this as the final remote authority read before the verifier returns.
-  gh_plain api "repos/{owner}/{repo}/git/ref/heads/main" \
+  gh_plain "${api_read[@]}" "repos/$repo_nwo/git/ref/heads/main" \
     >"$proof_dir/final-main-ref.json" || return 1
   if ! node "$script_parent_dir/pr-lib/crabbox-merge-bypass.mjs" \
     --actor "$proof_dir/actor.json" \

--- a/scripts/pr-lib/gates.sh
+++ b/scripts/pr-lib/gates.sh
@@ -209,8 +209,8 @@ require_remote_testbox_gate_stamp() {
 
 require_active_org_admin_for_crabbox_gate() {
   local actor membership
-  actor=$(gh api user --jq .login)
-  membership=$(gh api "orgs/openclaw/memberships/$actor")
+  actor=$(gh_plain api graphql -f 'query=query { viewer { login } }' --jq .data.viewer.login) || return
+  membership=$(gh_plain api "orgs/openclaw/memberships/$actor" -H 'Cache-Control: max-age=0') || return
   if [ "$(printf '%s\n' "$membership" | jq -r .state)" != "active" ] ||
     [ "$(printf '%s\n' "$membership" | jq -r .role)" != "admin" ]; then
     echo "OPENCLAW_PR_GATES_REMOTE=crabbox-aws requires an active openclaw organization admin." >&2

--- a/scripts/pr-lib/merge-outcome.sh
+++ b/scripts/pr-lib/merge-outcome.sh
@@ -216,7 +216,7 @@ merge_outcome_resume() {
     marker="<!-- openclaw-merge:$(printf '%s\n' "$MERGE_OUTCOME_RECORD" | jq -r .attempt) -->"
     # Absence never permits a second POST: the first response may have been lost.
     if comments=$(gh_plain api --hostname "$MERGE_REPO_HOST" --paginate --slurp \
-      "repos/$MERGE_REPO_NAME/issues/$pr/comments?per_page=100") &&
+      "repos/$MERGE_REPO_NAME/issues/$pr/comments?per_page=100" -H 'Cache-Control: max-age=0') &&
       comment_url=$(printf '%s\n' "$comments" | jq -er --arg marker "$marker" \
         '[.[][] | select(.body | contains($marker))] | select(length == 1) | .[0].html_url | select(type == "string" and length > 0)'); then
       echo "Completion comment observed: $comment_url"

--- a/scripts/pr-lib/merge.sh
+++ b/scripts/pr-lib/merge.sh
@@ -37,7 +37,7 @@ record_crabbox_landing_parent_audit() {
     echo "merge completed; post-merge audit failed: unable to prepare the landing parent artifact." >&2
     return 1
   fi
-  if ! gh_plain api "repos/{owner}/{repo}/commits/$landed_sha" >"$commit_file"; then
+  if ! gh_plain api "repos/$MERGE_REPO_NAME/commits/$landed_sha" >"$commit_file"; then
     rm -f "$audit_tmp"
     echo "Crabbox landing parent audit failed after merge: unable to read landed commit $landed_sha." >&2
     return 1
@@ -557,7 +557,7 @@ merge_run() {
     fi
   fi
   if [ -n "$recovery_oid" ]; then
-    recovery_actor=$(gh_plain api --hostname "$MERGE_REPO_HOST" user --jq '.login | select(type == "string" and length > 0)') || return 1
+    recovery_actor=$(gh_plain api --hostname "$MERGE_REPO_HOST" graphql -f 'query=query { viewer { login } }' --jq '.data.viewer.login | select(type == "string" and length > 0)') || return 1
     [ -n "$recovery_actor" ] || { merge_outcome_stop "cannot identify the operator recovery actor"; return 1; }
   fi
   merge_outcome_stable "$pr" || return 1
@@ -648,8 +648,8 @@ merge_run() {
   # Only this uninterrupted completion path owns cleanup. The exact-head lease
   # protects advanced/different-head recreations, but cannot detect same-SHA recreation.
   local head_json head_ref head_repo cleanup_complete=true
-  if head_json=$(gh_plain pr view "$pr" --repo "$MERGE_REPO_URL" --json headRefName,headRepository,headRepositoryOwner) &&
-    head_ref=$(printf '%s\n' "$head_json" | jq -er '.headRefName | select(type == "string" and length > 0)') &&
+  if head_json=$(gh_plain pr view "$pr" --repo "$MERGE_REPO_URL" --json headRefOid,headRefName,headRepository,headRepositoryOwner) &&
+    head_ref=$(printf '%s\n' "$head_json" | jq -er --arg head "$PREP_HEAD_SHA" 'select(.headRefOid == $head) | .headRefName | select(type == "string" and length > 0)') &&
     head_repo=$(printf '%s\n' "$head_json" | jq -er '.headRepositoryOwner.login + "/" + .headRepository.name | select(test("^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"))') &&
     git check-ref-format "refs/heads/$head_ref"; then
     local cleanup_error ref_status=0

--- a/scripts/pr-lib/review.sh
+++ b/scripts/pr-lib/review.sh
@@ -31,7 +31,8 @@ review_claim() {
     local user_log
     user_log=".local/review-claim-user-attempt-$attempt.log"
 
-    if reviewer=$(gh_plain api user --jq .login 2>"$user_log"); then
+    # A relay's REST /user may identify its caller, not the local mutation writer.
+    if reviewer=$(gh_plain api graphql -f 'query=query { viewer { login } }' --jq .data.viewer.login 2>"$user_log"); then
       printf "%s\n" "$reviewer" >"$user_log"
       break
     fi

--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -354,9 +354,12 @@ pr_meta_json() {
 
   actual_file_count=$(printf '%s\n' "$files" | jq -r 'length')
   if [ "$actual_file_count" -ne "$expected_file_count" ]; then
+    local repo_nwo
+    repo_nwo=$(gh_plain repo view --json nameWithOwner --jq .nameWithOwner) || return 1
+    # Pin the base repository and revalidate every page before the final head check.
     if ! files=$(
       set -o pipefail
-      gh_plain api --paginate "repos/{owner}/{repo}/pulls/$pr/files?per_page=100" |
+      gh_plain api --paginate "repos/$repo_nwo/pulls/$pr/files?per_page=100" -H 'Cache-Control: max-age=0' |
         jq -cs '
           add
           | map({

--- a/test/scripts/frv.test.ts
+++ b/test/scripts/frv.test.ts
@@ -1,3 +1,8 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import {
   continueFailed,
@@ -1019,3 +1024,90 @@ describe("FRV strict verifier", () => {
     ).rejects.toThrow("verification failed");
   });
 });
+
+describe("FRV protected gh evidence reads", () => {
+  it.each([
+    ["getRun", ["101"], "actions/runs/101", { run_attempt: 2 }],
+    ["getRunAttempt", ["101", 2], "actions/runs/101/attempts/2", { run_attempt: 2 }],
+    [
+      "getAttemptJobs",
+      ["101", 2],
+      "actions/runs/101/attempts/2/jobs?per_page=100",
+      [{ id: 1 }, { id: 2 }],
+    ],
+    [
+      "getParentJobs",
+      ["77"],
+      "actions/runs/77/jobs?filter=all&per_page=100",
+      [{ id: 1 }, { id: 2 }],
+    ],
+    ["getJobLog", [1], "actions/jobs/1/logs", "job evidence"],
+  ])("revalidates %s through the default protected route", (method, args, endpoint, expected) => {
+    const result = runProtectedFrv(
+      String(method),
+      args as Array<string | number>,
+      String(endpoint),
+    );
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual(expected);
+    expect(result.calls).toHaveLength(1);
+  });
+
+  it("preserves protected refusal status without retry or alternate execution", () => {
+    const result = runProtectedFrv("getRun", ["101"], "actions/runs/101", true);
+    expect(result.status).toBe(19);
+    expect(result.stderr).toContain("protected refusal");
+    expect(result.calls).toHaveLength(1);
+  });
+});
+
+function runProtectedFrv(
+  method: string,
+  args: Array<string | number>,
+  endpoint: string,
+  denied = false,
+) {
+  const root = mkdtempSync(join(tmpdir(), "frv-protected-"));
+  const gh = join(root, "gh");
+  writeFileSync(
+    gh,
+    `#!${process.execPath}
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync("calls.jsonl", JSON.stringify(args) + "\\n");
+const fail = (message, code) => { console.error(message); process.exit(code); };
+if (${denied}) fail("protected refusal", 19);
+if (args[0] !== "api" || !args.includes(${JSON.stringify(`repos/${REPOSITORY}/${endpoint}`)})) fail("unexpected request", 17);
+if (!args.some((arg, i) => ["-H", "--header"].includes(arg) && args[i+1] === "Cache-Control: max-age=0")) fail("missing live header", 18);
+if (${endpoint.includes("/jobs?")}) {
+  if (!args.includes("--paginate") || !args.includes(".jobs[] | @json")) fail("missing pagination", 17);
+  console.log('{"id":1}\\n{"id":2}');
+} else console.log(${endpoint.endsWith("/logs") ? JSON.stringify("job evidence") : JSON.stringify('{"run_attempt":2}')});
+`,
+  );
+  chmodSync(gh, 0o755);
+  try {
+    const moduleUrl = pathToFileURL(join(process.cwd(), "scripts/frv.mjs")).href;
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        `
+      import {createClient} from ${JSON.stringify(moduleUrl)};
+      try {
+        console.log(JSON.stringify(await createClient(${JSON.stringify(REPOSITORY)})[${JSON.stringify(method)}](...${JSON.stringify(args)})));
+      } catch (error) { console.error(error.message); process.exitCode = error.code; }
+    `,
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: { HOME: root, PATH: `${root}${delimiter}${process.env.PATH ?? ""}` },
+      },
+    );
+    return { ...result, calls: readFileSync(join(root, "calls.jsonl"), "utf8").trim().split("\n") };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}

--- a/test/scripts/plain-gh.test.ts
+++ b/test/scripts/plain-gh.test.ts
@@ -1,6 +1,14 @@
-// Plain GitHub CLI helper tests cover wrapper-safe gh execution for maintainer scripts.
-import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+// Exercise real subprocess boundaries with disposable PATH routes and synthetic credentials.
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -8,167 +16,344 @@ import {
   execGhJson,
   execGhRead,
   execPlainGh,
-  plainGhEnv,
-  PLAIN_GH_SYSTEM_CANDIDATES,
+  plainGhAuthenticatedEnv,
   resolvePlainGhBin,
 } from "../../scripts/lib/plain-gh.mjs";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const shellHelper = path.resolve("scripts/lib/plain-gh.sh");
+const tokenNames = [
+  "GH_TOKEN",
+  "GITHUB_TOKEN",
+  "GH_ENTERPRISE_TOKEN",
+  "GITHUB_ENTERPRISE_TOKEN",
+] as const;
+const engines = ["shell", "Node"] as const;
 
-function makeFakeGh(): string {
-  const dir = tempDirs.make("plain-gh-");
-  const binDir = path.join(dir, "bin");
-  mkdirSync(binDir);
-  const ghPath = path.join(binDir, "gh");
-  writeFileSync(
-    ghPath,
-    `#!/usr/bin/env bash
-printf 'argv=%s\\n' "$*"
-printf 'NO_COLOR=%s\\n' "\${NO_COLOR-}"
-printf 'GH_FORCE_TTY=%s\\n' "\${GH_FORCE_TTY-}"
-printf 'FORCE_COLOR=%s\\n' "\${FORCE_COLOR-}"
-printf 'CLICOLOR=%s\\n' "\${CLICOLOR-}"
-printf 'CLICOLOR_FORCE=%s\\n' "\${CLICOLOR_FORCE-}"
-printf 'COLORTERM_SET=%s\\n' "\${COLORTERM+x}"
-printf 'OPENCLAW_GH_BIN_SET=%s\\n' "\${OPENCLAW_GH_BIN+x}"
-printf 'GH_TOKEN_SET=%s\\n' "\${GH_TOKEN:+1}"
-`,
-  );
-  chmodSync(ghPath, 0o755);
-  return ghPath;
+function makeFixture() {
+  const root = tempDirs.make("plain-gh-");
+  const home = path.join(root, "home");
+  const protectedBin = path.join(home, "bin");
+  const secondBin = path.join(root, "second");
+  const toolsBin = path.join(root, "tools");
+  for (const dir of [protectedBin, secondBin, toolsBin]) {
+    mkdirSync(dir, { recursive: true });
+  }
+  symlinkSync("/usr/bin/env", path.join(toolsBin, "env"));
+  const calls = path.join(root, "calls.jsonl");
+  writeFileSync(calls, "");
+  for (const [dir, route] of [
+    [protectedBin, "protected"],
+    [secondBin, "second"],
+  ] as const) {
+    const gh = path.join(dir, "gh");
+    writeFileSync(
+      gh,
+      `#!${process.execPath}
+const fs = require("node:fs");
+const env = process.env;
+const argv = process.argv.slice(2);
+const route = ${JSON.stringify(route)};
+fs.appendFileSync(env.FAKE_GH_CALLS, JSON.stringify({ route, argv, override: env.OPENCLAW_GH_BIN ?? null }) + "\\n");
+if (argv[0] === "auth" && argv[1] === "token") {
+  process.stdout.write("fixture-token\\n");
+} else if (env.FAKE_GH_REJECT && route === "protected") {
+  process.stdout.write("protected refusal\\n");
+  process.stderr.write("policy denied\\n");
+  process.exitCode = 23;
+} else if (env.FAKE_GH_BYTES) {
+  process.stdout.write(Buffer.alloc(Number(env.FAKE_GH_BYTES), 0xff));
+} else {
+  const colors = Object.fromEntries(["NO_COLOR", "FORCE_COLOR", "CLICOLOR", "CLICOLOR_FORCE", "COLORTERM", "GH_FORCE_TTY"].map(key => [key, env[key] ?? null]));
+  const tokens = Object.fromEntries(${JSON.stringify(tokenNames)}.filter(key => env[key]).map(key => [key, env[key]]));
+  const result = JSON.stringify({ route, argv, colors, tokens, override: env.OPENCLAW_GH_BIN ?? null, cwd: process.cwd() });
+  const colored = env.NO_COLOR !== "1" || env.FORCE_COLOR !== "0" || env.CLICOLOR !== "0" || env.CLICOLOR_FORCE !== "0" || env.COLORTERM || env.GH_FORCE_TTY;
+  process.stdout.write(colored ? "\\x1b[31m" + result + "\\x1b[0m" : result);
 }
-
-function makeLargeFakeGh(): string {
-  const dir = tempDirs.make("plain-gh-large-");
-  const ghPath = path.join(dir, "gh");
-  writeFileSync(
-    ghPath,
-    `#!/usr/bin/env node
-const bytes = Number(process.env.PLAIN_GH_FAKE_BYTES ?? "0");
-process.stdout.write("x".repeat(bytes));
 `,
-  );
-  chmodSync(ghPath, 0o755);
-  return ghPath;
-}
-
-function makeCredentialForwardingGh() {
-  const dir = tempDirs.make("plain-gh-auth-forward-");
-  const binDir = path.join(dir, "bin");
-  const calls = path.join(dir, "calls.log");
-  const realGh = path.join(dir, "real-gh");
-  mkdirSync(binDir);
-  writeFileSync(
-    path.join(binDir, "gh"),
-    `#!/bin/sh
-printf 'path:%s\\n' "$*" >> "$PLAIN_GH_FAKE_CALLS"
-if [ "$1 $2" = "auth token" ]; then
-  printf 'forwarded-test-token\\n'
-  exit 0
-fi
-exit 9
-`,
-  );
-  writeFileSync(
-    realGh,
-    `#!/bin/sh
-printf 'plain:%s\\n' "$*" >> "$PLAIN_GH_FAKE_CALLS"
-case "$PLAIN_GH_EXPECTED_TOKEN_ENV" in
-  GH_TOKEN) token="\${GH_TOKEN-}"; other_token="\${GH_ENTERPRISE_TOKEN-}" ;;
-  GH_ENTERPRISE_TOKEN) token="\${GH_ENTERPRISE_TOKEN-}"; other_token="\${GH_TOKEN-}" ;;
-  *) echo 'unexpected token environment' >&2; exit 7 ;;
-esac
-if [ "$token" != "forwarded-test-token" ] || [ -n "$other_token" ]; then
-  echo 'missing forwarded credentials' >&2
-  exit 8
-fi
-printf 'authenticated plain gh\\n'
-`,
-  );
-  chmodSync(path.join(binDir, "gh"), 0o755);
-  chmodSync(realGh, 0o755);
-  return { binDir, calls, realGh };
-}
-
-describe("plain gh helpers", () => {
-  it("prefers OPENCLAW_GH_BIN over PATH shims", () => {
-    const ghPath = makeFakeGh();
-
-    expect(
-      resolvePlainGhBin({
-        HOME: path.dirname(path.dirname(ghPath)),
-        OPENCLAW_GH_BIN: ghPath,
-        PATH: "",
-      }),
-    ).toBe(ghPath);
-  });
-
-  it("prefers package-manager gh paths over bin shims", () => {
-    const realGh = makeFakeGh();
-    const shimGh = makeFakeGh();
-
-    expect(resolvePlainGhBin({ PATH: shimGh }, [realGh, shimGh])).toBe(realGh);
-    expect(PLAIN_GH_SYSTEM_CANDIDATES.indexOf("/opt/homebrew/opt/gh/bin/gh")).toBeLessThan(
-      PLAIN_GH_SYSTEM_CANDIDATES.indexOf("/opt/homebrew/bin/gh"),
     );
-  });
+    chmodSync(gh, 0o755);
+  }
+  const env: NodeJS.ProcessEnv = {
+    HOME: home,
+    PATH: [protectedBin, secondBin, toolsBin].join(path.delimiter),
+    FAKE_GH_CALLS: calls,
+    CLICOLOR: "1",
+    CLICOLOR_FORCE: "1",
+    COLORTERM: "truecolor",
+    FORCE_COLOR: "3",
+    GH_FORCE_TTY: "120",
+  };
+  return {
+    root,
+    home,
+    protectedBin,
+    secondBin,
+    toolsBin,
+    env,
+    override: path.join(secondBin, "gh"),
+    calls: () =>
+      readFileSync(calls, "utf8")
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line)),
+  };
+}
 
-  it("normalizes color environment for JSON-safe gh output", () => {
-    expect(
-      plainGhEnv({
-        CLICOLOR: "1",
-        CLICOLOR_FORCE: "1",
-        COLORTERM: "truecolor",
-        FORCE_COLOR: "3",
+function runGh(engine: (typeof engines)[number], env: NodeJS.ProcessEnv, cwd?: string) {
+  const options = { cwd, encoding: "utf8" as const, env, stdio: "pipe" as const };
+  if (engine === "Node") {
+    return execPlainGh(["--version"], options);
+  }
+  return execFileSync(
+    "/bin/bash",
+    ["-c", 'source "$1"; shift; gh_plain "$@"', "plain-gh", shellHelper, "--version"],
+    options,
+  );
+}
+
+describe.each(engines)("%s plain gh execution", (engine) => {
+  it.each([undefined, ""])(
+    "keeps HOME/bin first on PATH with override %j and does not extract credentials",
+    (override) => {
+      const fixture = makeFixture();
+      fixture.env.OPENCLAW_GH_BIN = override;
+      const before = { ...fixture.env };
+      const result = JSON.parse(runGh(engine, fixture.env));
+      expect(result).toMatchObject({
+        route: "protected",
+        argv: ["--version"],
+        colors: {
+          NO_COLOR: "1",
+          FORCE_COLOR: "0",
+          CLICOLOR: "0",
+          CLICOLOR_FORCE: "0",
+          COLORTERM: null,
+          GH_FORCE_TTY: null,
+        },
+      });
+      expect(result.tokens).toEqual({});
+      expect(fixture.calls()).toEqual([
+        { route: "protected", argv: ["--version"], override: override ?? null },
+      ]);
+      expect(fixture.env).toEqual(before);
+    },
+  );
+
+  it("preserves a protected refusal and both output streams without fallback", () => {
+    const fixture = makeFixture();
+    fixture.env.FAKE_GH_REJECT = "1";
+    expect(() => runGh(engine, fixture.env)).toThrow(
+      expect.objectContaining({
+        status: 23,
+        stdout: "protected refusal\n",
+        stderr: "policy denied\n",
       }),
-    ).toMatchObject({
-      NO_COLOR: "1",
-      FORCE_COLOR: "0",
-      CLICOLOR: "0",
-      CLICOLOR_FORCE: "0",
-    });
-    expect(plainGhEnv({ COLORTERM: "truecolor" })).not.toHaveProperty("COLORTERM");
-    expect(plainGhEnv({ GH_FORCE_TTY: "120" })).not.toHaveProperty("GH_FORCE_TTY");
+    );
+    expect(fixture.calls()).toEqual([{ route: "protected", argv: ["--version"], override: null }]);
   });
 
-  it("routes explicit GET reads through the PATH shim", () => {
-    const ghPath = makeFakeGh();
-    const output = execGhApiRead("repos/openclaw/openclaw/pulls/1", {
+  it.each(["missing PATH command", "nonexecutable override"])(
+    "refuses %s without native discovery",
+    (failure) => {
+      const fixture = makeFixture();
+      if (failure === "missing PATH command") {
+        fixture.env.PATH = fixture.toolsBin;
+      } else {
+        fixture.env.OPENCLAW_GH_BIN = path.join(fixture.root, "not-executable");
+        writeFileSync(fixture.env.OPENCLAW_GH_BIN, "not executable");
+        // Existing ambient credentials isolate executable validation from split-auth probing.
+        fixture.env.GH_TOKEN = "fixture-ambient";
+      }
+      expect(() => runGh(engine, fixture.env)).toThrow();
+      expect(fixture.calls()).toEqual([]);
+    },
+  );
+
+  it.each(tokenNames)("preserves ambient %s without probing in either route", (tokenName) => {
+    const fixture = makeFixture();
+    fixture.env[tokenName] = "fixture-ambient";
+    for (const explicit of [false, true]) {
+      fixture.env.OPENCLAW_GH_BIN = explicit ? fixture.override : undefined;
+      const before = { ...fixture.env };
+      const result = JSON.parse(runGh(engine, fixture.env));
+      expect(result).toMatchObject({
+        route: explicit ? "second" : "protected",
+        override: explicit ? fixture.override : null,
+      });
+      expect(result.tokens).toEqual({ [tokenName]: "fixture-ambient" });
+      expect(fixture.env).toEqual(before);
+    }
+    expect(fixture.calls()).toEqual([
+      { route: "protected", argv: ["--version"], override: null },
+      { route: "second", argv: ["--version"], override: fixture.override },
+    ]);
+  });
+
+  it.each([
+    { host: undefined, tokenName: "GH_TOKEN", args: ["auth", "token"] },
+    {
+      host: "github.com",
+      tokenName: "GH_TOKEN",
+      args: ["auth", "token", "--hostname", "github.com"],
+    },
+    {
+      host: "github.example.com",
+      tokenName: "GH_ENTERPRISE_TOKEN",
+      args: ["auth", "token", "--hostname", "github.example.com"],
+    },
+  ])(
+    "forwards explicit override credentials for host $host only to the child",
+    ({ host, tokenName, args }) => {
+      const fixture = makeFixture();
+      Object.assign(fixture.env, { GH_HOST: host, OPENCLAW_GH_BIN: fixture.override });
+      const before = { ...fixture.env };
+      const output =
+        engine === "Node"
+          ? execFileSync(
+              process.execPath,
+              [
+                "--input-type=module",
+                "-e",
+                `import { execPlainGh } from ${JSON.stringify(path.resolve("scripts/lib/plain-gh.mjs"))};
+const before = JSON.stringify(process.env);
+process.stdout.write(execPlainGh(["--version"], { encoding: "utf8" }));
+if (JSON.stringify(process.env) !== before) throw new Error("parent environment changed");`,
+              ],
+              { encoding: "utf8", env: fixture.env, stdio: "pipe" },
+            )
+          : execFileSync(
+              "/bin/bash",
+              [
+                "-c",
+                'source "$1"; gh_plain --version && test -z "${GH_TOKEN-}${GH_ENTERPRISE_TOKEN-}"',
+                "plain-gh",
+                shellHelper,
+              ],
+              { encoding: "utf8", env: fixture.env, stdio: "pipe" },
+            );
+      const result = JSON.parse(output);
+      expect(result).toMatchObject({
+        route: "second",
+        override: fixture.override,
+      });
+      expect(result.tokens).toEqual({ [tokenName]: "fixture-token" });
+      expect(fixture.calls()).toEqual([
+        { route: "protected", argv: args, override: engine === "shell" ? "" : null },
+        { route: "second", argv: ["--version"], override: fixture.override },
+      ]);
+      expect(fixture.env).toEqual(before);
+    },
+  );
+});
+
+describe("plain gh subprocess contracts", () => {
+  it("ignores a shell function shadowing the external PATH executable", () => {
+    const fixture = makeFixture();
+    const output = execFileSync(
+      "/bin/bash",
+      [
+        "-c",
+        'source "$1"; gh() { echo function-shadow >&2; return 71; }; resolved=$(resolve_plain_gh_bin); "$resolved" --version',
+        "plain-gh",
+        shellHelper,
+      ],
+      { encoding: "utf8", env: fixture.env, stdio: "pipe" },
+    );
+    expect(output).toContain('"route":"protected"');
+    expect(fixture.calls()).toHaveLength(1);
+  });
+
+  it.each(["bin", ""])("uses the Node child cwd for relative PATH entry %j", (entry) => {
+    const fixture = makeFixture();
+    const cwd = entry ? fixture.home : fixture.protectedBin;
+    fixture.env.PATH = [entry, fixture.secondBin, fixture.toolsBin].join(path.delimiter);
+    expect(JSON.parse(runGh("Node", fixture.env, cwd))).toMatchObject({ route: "protected", cwd });
+    expect(fixture.calls()).toHaveLength(1);
+  });
+
+  it("keeps direct resolver/environment consumers on PATH without an auth probe", () => {
+    const fixture = makeFixture();
+    const output = execFileSync(resolvePlainGhBin(fixture.env), ["--version"], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        OPENCLAW_GH_BIN: "/identity-sensitive/plain-gh",
-        PATH: `${path.dirname(ghPath)}${path.delimiter}${process.env.PATH ?? ""}`,
-      },
+      env: plainGhAuthenticatedEnv(fixture.env),
+      stdio: "pipe",
     });
-
-    expect(output).toContain("argv=api repos/openclaw/openclaw/pulls/1 --method GET");
-    expect(output).toContain("OPENCLAW_GH_BIN_SET=");
+    expect(JSON.parse(output).route).toBe("protected");
+    expect(fixture.calls()).toEqual([{ route: "protected", argv: ["--version"], override: null }]);
   });
 
-  it("shares bounded PATH-shim reads and JSON parsing", () => {
-    const calls: unknown[][] = [];
-    const execFileSyncImpl = (...args: unknown[]) => {
-      calls.push(args);
-      return '{"ok":true}';
-    };
+  it("keeps explicit reads override-independent and parses normalized JSON", () => {
+    const fixture = makeFixture();
+    fixture.env.OPENCLAW_GH_BIN = "/invalid-explicit-override";
+    const options = { encoding: "utf8" as const, env: fixture.env };
+    expect(JSON.parse(execGhApiRead("repos/example/repo", options))).toMatchObject({
+      route: "protected",
+      argv: ["api", "repos/example/repo", "--method", "GET"],
+      override: null,
+    });
+    expect(execGhJson(["--version"], options)).toMatchObject({
+      route: "protected",
+      override: null,
+    });
+    expect(fixture.calls()).toHaveLength(2);
+    expect(fixture.env.OPENCLAW_GH_BIN).toBe("/invalid-explicit-override");
+  });
 
+  it.each([execPlainGh, execGhRead])(
+    "preserves binary output, streaming, and caller buffer limits (%#)",
+    (execute) => {
+      const fixture = makeFixture();
+      // Explicit selection also keeps this payload proof harmless on the pre-fix resolver.
+      fixture.env.OPENCLAW_GH_BIN = fixture.override;
+      fixture.env.GH_TOKEN = "fixture-ambient";
+      fixture.env.FAKE_GH_BYTES = String(2 * 1024 * 1024);
+      const options = {
+        env: fixture.env,
+        stdio: "pipe" as const,
+        timeout: 10_000,
+        killSignal: "SIGKILL" as const,
+      };
+      const output = execute(["--version"], options);
+      expect(output).toEqual(Buffer.alloc(2 * 1024 * 1024, 0xff));
+      expect(() => execute(["--version"], { ...options, maxBuffer: 1024 })).toThrow(
+        expect.objectContaining({ code: "ENOBUFS" }),
+      );
+      const destination = path.join(fixture.root, "artifact.bin");
+      const fd = openSync(destination, "w");
+      try {
+        execute(["--version"], { ...options, stdio: ["ignore", fd, "pipe"] });
+      } finally {
+        closeSync(fd);
+      }
+      expect(readFileSync(destination)).toEqual(output);
+    },
+  );
+
+  it("preserves bounded read options and invocation errors", () => {
+    const calls: unknown[][] = [];
     expect(
       execGhJson(
-        ["api", "repos/openclaw/openclaw"],
+        ["api", "repos/example/repo"],
         {
           killSignal: "SIGKILL",
           stdio: ["ignore", "pipe", "inherit"],
           timeout: 60_000,
         },
-        { execFileSyncImpl },
+        {
+          execFileSyncImpl: (...args: unknown[]) => {
+            calls.push(args);
+            return '{"ok":true}';
+          },
+        },
       ),
     ).toEqual({ ok: true });
     expect(calls).toEqual([
       [
         "gh",
-        ["api", "repos/openclaw/openclaw"],
+        ["api", "repos/example/repo"],
         expect.objectContaining({
           encoding: "utf8",
           killSignal: "SIGKILL",
@@ -178,18 +363,10 @@ describe("plain gh helpers", () => {
         }),
       ],
     ]);
-    expect(
-      execGhRead(
-        ["api", "rate_limit"],
-        { encoding: "utf8" },
-        { execFileSyncImpl: () => " result " },
-      ),
-    ).toBe(" result ");
-
     const failure = new Error("gh read failed");
     expect(() =>
       execGhRead(
-        ["api", "rate_limit"],
+        ["--version"],
         {},
         {
           execFileSyncImpl: () => {
@@ -198,120 +375,5 @@ describe("plain gh helpers", () => {
         },
       ),
     ).toThrow(failure);
-  });
-
-  it("runs the shell helper with color disabled", () => {
-    const ghPath = makeFakeGh();
-    const outputPath = path.join(path.dirname(path.dirname(ghPath)), "output.txt");
-    const script = [
-      "set -euo pipefail",
-      "source scripts/lib/plain-gh.sh",
-      `OPENCLAW_GH_BIN=${JSON.stringify(ghPath)}`,
-      "export OPENCLAW_GH_BIN",
-      `gh_plain api rate_limit > ${JSON.stringify(outputPath)}`,
-    ].join("\n");
-
-    const result = spawnSync("bash", ["-lc", script], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        CLICOLOR: "1",
-        CLICOLOR_FORCE: "1",
-        COLORTERM: "truecolor",
-        FORCE_COLOR: "3",
-        GH_TOKEN: "existing-test-token",
-      },
-    });
-
-    expect(result.status).toBe(0);
-    expect(readFileSync(outputPath, "utf8")).toContain("argv=api rate_limit");
-    expect(readFileSync(outputPath, "utf8")).toContain("NO_COLOR=1");
-    expect(readFileSync(outputPath, "utf8")).toContain("GH_FORCE_TTY=");
-    expect(readFileSync(outputPath, "utf8")).toContain("FORCE_COLOR=0");
-    expect(readFileSync(outputPath, "utf8")).toContain("CLICOLOR=0");
-    expect(readFileSync(outputPath, "utf8")).toContain("CLICOLOR_FORCE=0");
-    expect(readFileSync(outputPath, "utf8")).toContain("COLORTERM_SET=");
-  });
-
-  it.each([
-    {
-      host: undefined,
-      name: "github.com",
-      tokenArgs: "auth token",
-      tokenEnv: "GH_TOKEN",
-    },
-    {
-      host: "github.example.com",
-      name: "an Enterprise host",
-      tokenArgs: "auth token --hostname github.example.com",
-      tokenEnv: "GH_ENTERPRISE_TOKEN",
-    },
-  ])("forwards $name credentials from a PATH wrapper to the plain CLI", (testCase) => {
-    const fixture = makeCredentialForwardingGh();
-    const env: NodeJS.ProcessEnv = {
-      ...process.env,
-      OPENCLAW_GH_BIN: fixture.realGh,
-      PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH ?? ""}`,
-      PLAIN_GH_EXPECTED_TOKEN_ENV: testCase.tokenEnv,
-      PLAIN_GH_FAKE_CALLS: fixture.calls,
-    };
-    if (testCase.host) {
-      env.GH_HOST = testCase.host;
-    } else {
-      delete env.GH_HOST;
-    }
-    for (const name of [
-      "GH_TOKEN",
-      "GITHUB_TOKEN",
-      "GH_ENTERPRISE_TOKEN",
-      "GITHUB_ENTERPRISE_TOKEN",
-    ]) {
-      delete env[name];
-    }
-
-    expect(execPlainGh(["api", "user"], { encoding: "utf8", env })).toBe(
-      "authenticated plain gh\n",
-    );
-    const shell = spawnSync("bash", ["-c", "source scripts/lib/plain-gh.sh; gh_plain api user"], {
-      cwd: process.cwd(),
-      encoding: "utf8",
-      env,
-    });
-
-    expect(shell.status, shell.stderr).toBe(0);
-    expect(shell.stdout).toBe("authenticated plain gh\n");
-    expect(readFileSync(fixture.calls, "utf8").trim().split("\n")).toEqual([
-      `path:${testCase.tokenArgs}`,
-      "plain:api user",
-      `path:${testCase.tokenArgs}`,
-      "plain:api user",
-    ]);
-  });
-
-  it("captures large gh payloads by default", () => {
-    const ghPath = makeLargeFakeGh();
-    const bytes = 2 * 1024 * 1024;
-
-    const output = execPlainGh(["api", "large"], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        GH_TOKEN: "large-payload-test-token",
-        OPENCLAW_GH_BIN: ghPath,
-        PLAIN_GH_FAKE_BYTES: String(bytes),
-      },
-    });
-
-    expect(output).toHaveLength(bytes);
-  });
-
-  it("keeps the shell resolver on external gh binaries", () => {
-    const helper = readFileSync("scripts/lib/plain-gh.sh", "utf8");
-
-    expect(helper).toContain("type -P gh");
-    expect(helper).not.toContain("command -v gh");
-    expect(helper.indexOf("/opt/homebrew/opt/gh/bin/gh")).toBeLessThan(
-      helper.indexOf("/opt/homebrew/bin/gh"),
-    );
   });
 });

--- a/test/scripts/pr-crabbox-merge-bypass.test.ts
+++ b/test/scripts/pr-crabbox-merge-bypass.test.ts
@@ -119,7 +119,7 @@ function input() {
       path: ".github/workflows/pr-crabbox-gate-publisher.yml",
       status: "completed",
     },
-    requiredChecks: [{ bucket: "fail", name: "openclaw/ci-gate", state: "SKIPPED" }],
+    requiredChecks: [{ bucket: "skipping", name: "openclaw/ci-gate", state: "SKIPPED" }],
     workflowRun: {
       conclusion: "failure",
       event: "pull_request",
@@ -322,7 +322,7 @@ describe("Crabbox admin merge bypass verifier", () => {
 
 function runProtectedShell(
   command: string,
-  { role = "admin", state = "active", denied = "", override = false } = {},
+  { role = "admin", state = "active", denied = "", override = false, revoke = false } = {},
 ) {
   const root = mkdtempSync(join(tmpdir(), "pr-crabbox-protected-"));
   const bin = join(root, "bin");
@@ -340,21 +340,34 @@ const cp = require("node:child_process");
 const args = process.argv.slice(2);
 fs.appendFileSync("calls.jsonl", JSON.stringify(args) + "\\n");
 const value = JSON.parse(fs.readFileSync("input.json", "utf8"));
+const save = () => fs.writeFileSync("input.json", JSON.stringify(value));
 const fail = (message, code = 19) => { console.error(message); process.exit(code); };
 const out = (data) => console.log(typeof data === "string" ? data : JSON.stringify(data));
+const repo = {id:123,nameWithOwner:"openclaw/openclaw",url:"https://github.com/openclaw/openclaw"};
+const pr = {id:"fixture-pr",number:131091,url:repo.url+"/pull/131091",state:"OPEN",isDraft:false,
+  headRefOid:value.headSha,headRefName:"topic",baseRefName:"main",baseRefOid:"${baseSha}",
+  isCrossRepository:false,mergeable:"MERGEABLE",mergeStateStatus:"BLOCKED",mergeCommit:null,
+  autoMergeRequest:null,isInMergeQueue:false,isMergeQueueEnabled:false};
 if (args.some(arg => /\\{(?:owner|repo)\\}/u.test(arg))) fail("unresolved repository placeholder");
 const endpoint = args.find(arg => /^(?:repos\\/|orgs\\/|user$|graphql$)/u.test(arg));
 if (endpoint && endpoint === process.env.FAKE_DENIED) fail("protected refusal");
-if (args[0] === "repo" && args[1] === "view") out("openclaw/openclaw");
+if (args[0] === "repo" && args[1] === "view") out(args.includes("--jq") ? repo.nameWithOwner : repo);
 else if (args[0] === "pr" && args[1] === "checks" && args.includes("--required")) {
-  out(value.requiredChecks); process.exit(1);
-} else if (endpoint === "user") out(args.includes("--jq") ? "relay-reader" : {login:"relay-reader"});
+  // gh v2.98.0 checks.go exports JSON before applying its human-output exit codes.
+  out(value.requiredChecks);
+} else if (args[0] === "pr" && args[1] === "view") out(args.includes("--jq") ? pr.headRefOid : pr);
+else if (args[0] === "pr" && args[1] === "merge") out("synthetic merge request accepted");
+else if (args[0] === "workflow" && args[1] === "run") { value.dispatched = true; save(); }
+else if (endpoint === "graphql" && args.some(arg => arg.includes("repository(owner:"))) {
+  out({data:{repository:{...repo,ref:{target:{oid:"${mainSha}"}},pullRequest:pr}}});
+} else if (endpoint === "user") out(args[args.indexOf("--jq")+1] === ".login" ? "relay-reader" : {login:"relay-reader"});
 else if (endpoint === "graphql" && args.includes("query=query { viewer { login } }")) {
   const json = JSON.stringify({data:{viewer:value.actor}});
   out(cp.execFileSync("jq", ["-r", args[args.indexOf("--jq") + 1]], {input:json,encoding:"utf8"}).trim());
 } else {
   if (!endpoint) fail("unexpected command");
-  const mutable = !/\\/compare\\/|\\/commits\\/[a-f0-9]{40}$/u.test(endpoint);
+  const mutable = endpoint.startsWith("orgs/") ||
+    (!process.env.FAKE_DISPATCH && !/\\/compare\\/|\\/commits\\/[a-f0-9]{40}$/u.test(endpoint));
   if (mutable && !args.some((arg,i) => ["-H", "--header"].includes(arg) && args[i+1] === "Cache-Control: max-age=0")) fail("missing live header", 18);
   if (endpoint.includes("/check-runs?") || endpoint.includes("/jobs?")) {
     if (!args.includes("--paginate") || !args.includes("--slurp")) fail("missing pagination");
@@ -362,10 +375,15 @@ else if (endpoint === "graphql" && args.includes("query=query { viewer { login }
   const prefix = "repos/openclaw/openclaw/";
   if (endpoint === prefix + "pulls/131091") out(value.pullRequest);
   else if (endpoint === prefix + "commits/" + value.headSha + "/check-runs?filter=latest&per_page=100") out(value.checkRuns.check_runs.map(check => ({check_runs:[check]})));
-  else if (endpoint === prefix + "actions/runs/8001") out(value.publisherRun);
+  else if (endpoint === prefix + "actions/workflows/pr-crabbox-gate-publisher.yml/runs") out({workflow_runs:value.dispatched ? [{...value.publisherRun,html_url:repo.url+"/actions/runs/8001",display_title:"PR Crabbox gate #131091 / "+value.headSha}] : []});
+  else if (endpoint === prefix + "actions/runs/8001") out({...value.publisherRun,html_url:repo.url+"/actions/runs/8001"});
   else if (endpoint === prefix + "actions/runs/7001") out(value.workflowRun);
   else if (endpoint === prefix + "actions/runs/7001/jobs?filter=latest&per_page=100") out(value.jobs.jobs.map(job => ({jobs:[job]})));
-  else if (endpoint === "orgs/openclaw/memberships/maintainer") out(value.membership);
+  else if (endpoint === "orgs/openclaw/memberships/maintainer") {
+    value.membershipReads = (value.membershipReads || 0) + 1;
+    if (process.env.FAKE_REVOKE && value.membershipReads === 2) value.membership.role = "member";
+    save(); out(value.membership);
+  }
   else if (endpoint === "orgs/openclaw/memberships/relay-reader") out({role:"admin",state:"active",user:{login:"relay-reader"}});
   else if (endpoint === prefix + "git/ref/heads/main") out(value.mainRef);
   else if (endpoint === prefix + "compare/${workflowSha}...${mainSha}") out(value.mainComparison);
@@ -378,6 +396,23 @@ else if (endpoint === "graphql" && args.includes("query=query { viewer { login }
   writeFileSync(selected, protectedGh);
   chmodSync(gh, 0o755);
   chmodSync(selected, 0o755);
+  // Keep all network-capable executables task-local, including explicit gh selection.
+  // Node only substitutes the unrelated CI wait; both authorization verifiers run unchanged.
+  for (const [name, body] of Object.entries({
+    node: `case "$1" in */watch-pr-ci.mjs) exit 0;; esac\nexec '${process.execPath}' "$@"`,
+    git: `case "$1" in
+      fetch|cat-file|merge-base) exit 0;;
+      merge-tree) echo candidate-tree;;
+      rev-parse) echo main-tree;;
+      -c) exit 0;;
+      *) echo "unexpected fixture git: $*" >&2; exit 19;;
+    esac`,
+    aws: "exit 19",
+    crabbox: "exit 19",
+  })) {
+    writeFileSync(join(bin, name), `#!/bin/sh\n${body}\n`);
+    chmodSync(join(bin, name), 0o755);
+  }
   try {
     const result = spawnSync(
       "bash",
@@ -402,6 +437,8 @@ else if (endpoint === "graphql" && args.includes("query=query { viewer { login }
           GH_TOKEN: "synthetic-token",
           OPENCLAW_GH_BIN: override ? selected : "",
           FAKE_DENIED: denied,
+          FAKE_DISPATCH: command.includes("finalize_remote_crabbox_aws_gate") ? "1" : "",
+          FAKE_REVOKE: revoke ? "1" : "",
           GATES_MODE: "remote_crabbox_aws",
           REMOTE_GATES_PROVIDER: "aws",
           FULL_GATES_HEAD_SHA: headSha,
@@ -422,6 +459,7 @@ else if (endpoint === "graphql" && args.includes("query=query { viewer { login }
       ...result,
       proof: readArtifact("merge-crabbox-bypass.json"),
       audit: readArtifact("merge-crabbox-parent-audit.json"),
+      intent: readArtifact("intent.json"),
       calls: readFileSync(join(root, "calls.jsonl"), "utf8")
         .trim()
         .split("\n")
@@ -480,4 +518,115 @@ describe("Crabbox protected gh request producers", () => {
     });
     expect(result.calls).toHaveLength(1);
   });
+});
+
+// Replace local preparation and Git persistence only. merge_run, merge_verify,
+// live identity/membership reads, bypass validation and the merge request remain real.
+const mergeAuthorizationCommand = `
+enter_worktree() { PR_MAIN_SHA=${mainSha}; }
+refresh_main_snapshot() { PR_MAIN_SHA=${mainSha}; }
+verify_prep_branch_matches_prepared_head() { :; }
+validate_review_artifact_data() { :; }
+require_ready_review_recommendation() { :; }
+mark_pr_operation_side_effects_started() { :; }
+is_canonical_pr_number() { [[ "$1" =~ ^[1-9][0-9]*$ ]]; }
+merge_outcome_load_local() { MERGE_OUTCOME_OID=""; MERGE_OUTCOME_RECORD=""; }
+merge_outcome_write() { MERGE_OUTCOME_RECORD="$1"; printf '%s\\n' "$1" > .local/intent.json; }
+for artifact in review.md review.json pr-meta.env pr-meta.json prep.md; do
+  echo fixture > ".local/$artifact"
+done
+printf '%s\\n' PREP_HEAD_SHA=${headSha} PREP_REPLACED_HOSTED_ANCESTRY=false PREP_AUTHOR_ACCESS=maintainer > .local/prep.env
+echo GATES_MODE=remote_crabbox_aws > .local/gates.env
+merge_run 131091
+`;
+
+describe("Crabbox authorization before final effects", () => {
+  it.each(["member", "admin"])("gates remote dispatch on the authenticated %s", (role) => {
+    const result = runProtectedShell(`finalize_remote_crabbox_aws_gate 131091 ${headSha}`, {
+      role,
+    });
+    expect(result.status, result.stdout + result.stderr).toBe(role === "admin" ? 0 : 1);
+    const viewer = result.calls.findIndex((args) => args.includes("graphql"));
+    const membership = result.calls.findIndex((args) =>
+      args.includes("orgs/openclaw/memberships/maintainer"),
+    );
+    const dispatches = result.calls.filter((args) => args[0] === "workflow" && args[1] === "run");
+    expect(viewer).toBeGreaterThanOrEqual(0);
+    expect(membership).toBeGreaterThan(viewer);
+    expect(result.calls.some((args) => args.includes("user"))).toBe(false);
+    expect(result.calls.filter((args) => args[0] === "pr" && args[1] === "merge")).toEqual([]);
+    expect(dispatches).toHaveLength(role === "admin" ? 1 : 0);
+    if (role === "admin") {
+      expect(result.calls.indexOf(dispatches[0]!)).toBeGreaterThan(membership);
+      expect(dispatches[0]).toEqual([
+        "workflow",
+        "run",
+        "pr-crabbox-gate-publisher.yml",
+        "--ref",
+        "main",
+        "-f",
+        "pr_number=131091",
+        "-f",
+        `head_sha=${headSha}`,
+        "-f",
+        `base_sha=${baseSha}`,
+      ]);
+    } else {
+      expect(result.stderr).toContain("requires an active openclaw organization admin");
+    }
+  });
+
+  it.each([
+    { role: "member", revoke: false, reads: 1, merges: 0 },
+    { role: "admin", revoke: false, reads: 2, merges: 1 },
+    { role: "admin", revoke: true, reads: 2, merges: 0 },
+  ])(
+    "gates admin merge on $role membership (revoked=$revoke)",
+    ({ role, revoke, reads, merges }) => {
+      const result = runProtectedShell(mergeAuthorizationCommand, { role, revoke });
+      const output = result.stdout + result.stderr;
+      expect(result.status, output).toBe(1);
+      const viewers = result.calls.filter((args) =>
+        args.includes("query=query { viewer { login } }"),
+      );
+      const memberships = result.calls.filter((args) =>
+        args.includes("orgs/openclaw/memberships/maintainer"),
+      );
+      const requests = result.calls.filter((args) => args[0] === "pr" && args[1] === "merge");
+      expect(viewers).toHaveLength(reads);
+      expect(memberships).toHaveLength(reads);
+      expect(requests).toHaveLength(merges);
+      expect(result.calls.some((args) => args.includes("user") || args[0] === "workflow")).toBe(
+        false,
+      );
+      if (merges) {
+        expect(requests[0]).toEqual([
+          "pr",
+          "merge",
+          "131091",
+          "--repo",
+          "https://github.com/openclaw/openclaw",
+          "--squash",
+          "--admin",
+          "--match-head-commit",
+          headSha,
+        ]);
+        expect(result.calls.indexOf(requests[0]!)).toBeGreaterThan(
+          result.calls.indexOf(memberships[1]!),
+        );
+        expect(result.intent).toMatchObject({ route: "admin", head: headSha, accepted: true });
+        // The fake accepts the request without claiming a real merge receipt.
+        expect(output).toContain("prior dispatch unresolved");
+      } else {
+        expect(output).toContain("maintainer is not an active openclaw organization admin");
+        expect(result.intent).toBeUndefined();
+      }
+      if (revoke) {
+        expect(output).toContain("merge-verify passed for PR #131091");
+        expect(
+          result.calls.filter((args) => args.some((arg) => arg.includes("repository(owner:"))),
+        ).toHaveLength(2);
+      }
+    },
+  );
 });

--- a/test/scripts/pr-crabbox-merge-bypass.test.ts
+++ b/test/scripts/pr-crabbox-merge-bypass.test.ts
@@ -1,3 +1,15 @@
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { formatCrabboxGateCheckSummary } from "../../scripts/pr-lib/crabbox-gate-contract.mjs";
 import { validateCrabboxMergeBypass } from "../../scripts/pr-lib/crabbox-merge-bypass.mjs";
@@ -305,5 +317,167 @@ describe("Crabbox admin merge bypass verifier", () => {
     value.workflowRun.conclusion = "cancelled";
     value.jobs.jobs[1]!.conclusion = "cancelled";
     expect(() => validateCrabboxMergeBypass(value)).toThrow(/normal CI workflow identity/u);
+  });
+});
+
+function runProtectedShell(
+  command: string,
+  { role = "admin", state = "active", denied = "", override = false } = {},
+) {
+  const root = mkdtempSync(join(tmpdir(), "pr-crabbox-protected-"));
+  const bin = join(root, "bin");
+  mkdirSync(bin);
+  mkdirSync(join(root, ".local"));
+  writeFileSync(join(root, "calls.jsonl"), "");
+  const evidence = input();
+  evidence.membership.role = role;
+  evidence.membership.state = state;
+  writeFileSync(join(root, "input.json"), JSON.stringify(evidence));
+  const gh = join(bin, "gh");
+  const protectedGh = `#!${process.execPath}
+const fs = require("node:fs");
+const cp = require("node:child_process");
+const args = process.argv.slice(2);
+fs.appendFileSync("calls.jsonl", JSON.stringify(args) + "\\n");
+const value = JSON.parse(fs.readFileSync("input.json", "utf8"));
+const fail = (message, code = 19) => { console.error(message); process.exit(code); };
+const out = (data) => console.log(typeof data === "string" ? data : JSON.stringify(data));
+if (args.some(arg => /\\{(?:owner|repo)\\}/u.test(arg))) fail("unresolved repository placeholder");
+const endpoint = args.find(arg => /^(?:repos\\/|orgs\\/|user$|graphql$)/u.test(arg));
+if (endpoint && endpoint === process.env.FAKE_DENIED) fail("protected refusal");
+if (args[0] === "repo" && args[1] === "view") out("openclaw/openclaw");
+else if (args[0] === "pr" && args[1] === "checks" && args.includes("--required")) {
+  out(value.requiredChecks); process.exit(1);
+} else if (endpoint === "user") out(args.includes("--jq") ? "relay-reader" : {login:"relay-reader"});
+else if (endpoint === "graphql" && args.includes("query=query { viewer { login } }")) {
+  const json = JSON.stringify({data:{viewer:value.actor}});
+  out(cp.execFileSync("jq", ["-r", args[args.indexOf("--jq") + 1]], {input:json,encoding:"utf8"}).trim());
+} else {
+  if (!endpoint) fail("unexpected command");
+  const mutable = !/\\/compare\\/|\\/commits\\/[a-f0-9]{40}$/u.test(endpoint);
+  if (mutable && !args.some((arg,i) => ["-H", "--header"].includes(arg) && args[i+1] === "Cache-Control: max-age=0")) fail("missing live header", 18);
+  if (endpoint.includes("/check-runs?") || endpoint.includes("/jobs?")) {
+    if (!args.includes("--paginate") || !args.includes("--slurp")) fail("missing pagination");
+  }
+  const prefix = "repos/openclaw/openclaw/";
+  if (endpoint === prefix + "pulls/131091") out(value.pullRequest);
+  else if (endpoint === prefix + "commits/" + value.headSha + "/check-runs?filter=latest&per_page=100") out(value.checkRuns.check_runs.map(check => ({check_runs:[check]})));
+  else if (endpoint === prefix + "actions/runs/8001") out(value.publisherRun);
+  else if (endpoint === prefix + "actions/runs/7001") out(value.workflowRun);
+  else if (endpoint === prefix + "actions/runs/7001/jobs?filter=latest&per_page=100") out(value.jobs.jobs.map(job => ({jobs:[job]})));
+  else if (endpoint === "orgs/openclaw/memberships/maintainer") out(value.membership);
+  else if (endpoint === "orgs/openclaw/memberships/relay-reader") out({role:"admin",state:"active",user:{login:"relay-reader"}});
+  else if (endpoint === prefix + "git/ref/heads/main") out(value.mainRef);
+  else if (endpoint === prefix + "compare/${workflowSha}...${mainSha}") out(value.mainComparison);
+  else if (endpoint === "repos/prepared/base/commits/${headSha}") out({parents:[{sha:"${mainSha}"}]});
+  else fail("unexpected endpoint: " + endpoint);
+}
+`;
+  writeFileSync(gh, override ? "#!/bin/sh\nexit 19\n" : protectedGh);
+  const selected = join(root, "selected-gh");
+  writeFileSync(selected, protectedGh);
+  chmodSync(gh, 0o755);
+  chmodSync(selected, 0o755);
+  try {
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        [
+          "set -euo pipefail",
+          `script_parent_dir='${process.cwd()}/scripts'`,
+          'source "$script_parent_dir/lib/plain-gh.sh"',
+          'source "$script_parent_dir/pr-lib/common.sh"',
+          'source "$script_parent_dir/pr-lib/gates.sh"',
+          'source "$script_parent_dir/pr-lib/merge.sh"',
+          command,
+        ].join("\n"),
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          HOME: root,
+          PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`,
+          GH_TOKEN: "synthetic-token",
+          OPENCLAW_GH_BIN: override ? selected : "",
+          FAKE_DENIED: denied,
+          GATES_MODE: "remote_crabbox_aws",
+          REMOTE_GATES_PROVIDER: "aws",
+          FULL_GATES_HEAD_SHA: headSha,
+          LAST_VERIFIED_HEAD_SHA: headSha,
+          REMOTE_GATES_RUN_ID: runId,
+          REMOTE_GATES_LEASE_ID: leaseId,
+          MERGE_REPO_NAME: "prepared/base",
+        },
+      },
+    );
+    const readArtifact = (name: string) => {
+      const file = join(root, ".local", name);
+      return existsSync(file) && readFileSync(file, "utf8").trim()
+        ? JSON.parse(readFileSync(file, "utf8"))
+        : undefined;
+    };
+    return {
+      ...result,
+      proof: readArtifact("merge-crabbox-bypass.json"),
+      audit: readArtifact("merge-crabbox-parent-audit.json"),
+      calls: readFileSync(join(root, "calls.jsonl"), "utf8")
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as string[]),
+    };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe("Crabbox protected gh request producers", () => {
+  it("verifies fresh paginated proof using the authenticated writer and actual repository", () => {
+    const result = runProtectedShell(`verify_crabbox_admin_merge_bypass 131091 ${headSha}`);
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    expect(result.proof).toMatchObject({ actor: "maintainer", mainSha, workflowSha, ciRunId });
+    expect(result.calls.at(-1)).toContain("repos/openclaw/openclaw/git/ref/heads/main");
+    expect(result.calls.filter((args) => args.includes("--paginate"))).toHaveLength(2);
+  });
+
+  it.each([false, true])(
+    "checks the selected writer's live admin membership (override=%s)",
+    (override) => {
+      const result = runProtectedShell("require_active_org_admin_for_crabbox_gate", { override });
+      expect(result.status, result.stdout + result.stderr).toBe(0);
+      expect(result.stdout.trim()).toBe("maintainer");
+    },
+  );
+
+  it.each([
+    { role: "member", state: "active" },
+    { role: "admin", state: "pending" },
+  ])("rejects writer membership $state/$role despite the relay's admin identity", (membership) => {
+    const result = runProtectedShell("require_active_org_admin_for_crabbox_gate", membership);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("requires an active openclaw organization admin");
+  });
+
+  it("keeps protected refusal terminal without alternate identity or dispatch", () => {
+    const result = runProtectedShell("require_active_org_admin_for_crabbox_gate", {
+      denied: "graphql",
+    });
+    expect(result.status).toBe(19);
+    expect(result.stderr).toContain("protected refusal");
+    expect(result.calls).toHaveLength(1);
+  });
+
+  it("audits the immutable landed commit in the prepared repository", () => {
+    const result = runProtectedShell(`record_crabbox_landing_parent_audit ${headSha} ${mainSha}`);
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    expect(result.audit).toEqual({
+      status: "match",
+      landedSha: headSha,
+      expectedParentSha: mainSha,
+      actualParentSha: mainSha,
+    });
+    expect(result.calls).toHaveLength(1);
   });
 });

--- a/test/scripts/pr-merge-outcome.test.ts
+++ b/test/scripts/pr-merge-outcome.test.ts
@@ -168,11 +168,15 @@ const out=(value)=>console.log(typeof value==="string"?value:JSON.stringify(valu
 const fail=(text)=>{save();console.error(text);process.exit(1)};
 if(route==="sleep") {s.settlementSleeps.push(Number(args[0]));save();process.exit(0);}
 s.calls.push([route,...args]);save();
+if(args.some(arg=>arg.includes("{owner}")||arg.includes("{repo}"))) fail("protected unresolved repository placeholder");
 const main=()=>git(["--git-dir="+process.env.FIXTURE_REMOTE,"rev-parse","refs/heads/main"]);
 if(args[0]==="repo") out(args.includes("--jq")?s.repo.nameWithOwner:s.repo);
-else if(args[0]==="api"&&args.includes("user")) out(s.operator);
+else if(args[0]==="api"&&args.includes("user")) out("relay-reader");
+else if(args.includes("graphql")&&args.includes("query=query { viewer { login } }")) out(s.operator);
 else if(args[0]==="pr"&&args[1]==="checks") {out([{name:"CI",bucket:s.gates,state:s.gates==="pass"?"SUCCESS":"FAILURE"}]);}
 else if(args[0]==="pr"&&args[1]==="view") {
+  const fields=args[args.indexOf("--json")+1].split(",");
+  if(fields.includes("headRefName")&&!fields.includes("headRefOid")) fail("missing live cleanup metadata");
   const pr={...s.pr,changedFiles:0,files:[],headRefName:"topic",headRepository:{name:"repo"},headRepositoryOwner:{login:"fixture"}};
   if(route==="path"&&s.stale) {pr.state="OPEN";pr.mergeCommit=null;}
   if(args.includes("--jq")) {const q=args[args.indexOf("--jq")+1];out(q===".state"?pr.state:q===".mergeCommit.oid"?pr.mergeCommit?.oid??"null":pr.url);}
@@ -246,7 +250,10 @@ else if(args[0]==="pr"&&args[1]==="view") {
     save();
     if(s.comment!=="success") fail("comment response lost");
     out(url);
-  } else out([s.comments]);
+  } else {
+    if(!args.includes("Cache-Control: max-age=0")) fail("missing live comment header");
+    out([s.comments]);
+  }
 } else if(args.some(x=>x.includes("/commits/"))) {
   if(s.audit) fail("audit unavailable");
   out({parents:[{sha:git(["rev-parse",s.pr.mergeCommit.oid+"^1"])}]});
@@ -260,6 +267,7 @@ save();
     `#!/usr/bin/env bash
 set -euo pipefail
 script_parent_dir="$FIXTURE_SCRIPTS"
+source "$script_parent_dir/lib/plain-gh.sh"
 source "$script_parent_dir/pr-lib/worktree.sh"
 source "$script_parent_dir/pr-lib/operation-lock.sh"
 source "$script_parent_dir/pr-lib/common.sh"
@@ -1336,6 +1344,27 @@ describePosix("native merge outcome with real Git and supervised lock recovery",
     expect(f.state().mutations).toBe(1);
     f.git(["merge-base", "--is-ancestor", f.head, f.record().landed]);
   });
+  it("audits a confirmed admin landing using the prepared repository", () => {
+    const f = fixture();
+    f.save({ ...f.state(), admin: true, gates: "fail", comment: "rejected" });
+    const result = f.run();
+    expect(result.status, result.output).toBe(1);
+    expect(f.record().phase, result.output).toBe("commenting");
+    expect(f.state().calls).toContainEqual([
+      "direct",
+      "api",
+      `repos/fixture/repo/commits/${f.record().landed}`,
+    ]);
+    expect(
+      JSON.parse(readFileSync(join(f.worktree, ".local/merge-crabbox-parent-audit.json"), "utf8")),
+    ).toMatchObject({
+      status: "match",
+      expectedParentSha: f.base,
+      actualParentSha: f.base,
+    });
+    f.recover();
+  });
+
   it("retains confirmed admin merge before failed post-merge audit", () => {
     const f = fixture();
     f.save({ ...f.state(), admin: true, audit: true, gates: "fail" });

--- a/test/scripts/pr-metadata.test.ts
+++ b/test/scripts/pr-metadata.test.ts
@@ -15,6 +15,15 @@ function createFakeGh(): string {
     `#!/usr/bin/env bash
 set -euo pipefail
 
+if [[ "$*" == *'{owner}'* || "$*" == *'{repo}'* ]]; then
+  echo "protected gh: unresolved repository placeholder" >&2
+  exit 19
+fi
+if [ "$1 $2" = "repo view" ]; then
+  printf 'base-owner/base-repo\\n'
+  exit 0
+fi
+
 if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
   pr_view_count=0
   if [ -f "$FAKE_PR_VIEW_COUNT_FILE" ]; then
@@ -51,6 +60,7 @@ if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
         number: 42,
         url: "https://example.test/pr/42",
         headRefOid: $headRefOid,
+        headRepository: {nameWithOwner: "fork-owner/fork-repo"},
         changedFiles: $changedFiles,
         files: [
           range(0; $fileCount)
@@ -72,7 +82,8 @@ if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
 fi
 
 if [ "$1" = "api" ] && [ "$2" = "--paginate" ]; then
-  [ "$3" = 'repos/{owner}/{repo}/pulls/42/files?per_page=100' ] || { echo "unexpected endpoint: $3" >&2; exit 4; }
+  [[ "$*" == *'repos/base-owner/base-repo/pulls/42/files?per_page=100'* ]] || { echo "unexpected repository" >&2; exit 4; }
+  [[ "$*" == *'Cache-Control: max-age=0'* ]] || { echo "authoritative files require revalidation" >&2; exit 18; }
   if [ "\${FAKE_REST_FILE_COUNT:-101}" = "2" ]; then
     jq -nc '[range(0; 2) | {filename: ("src/file-" + (tostring) + ".ts"), status: (if . == 1 then "removed" else "modified" end), additions: 1, deletions: 0}]'
     exit 0
@@ -132,7 +143,7 @@ function readPrMetadata(
         FAKE_PR_VIEW_FAILURE_TARGET: options.prViewFailureTarget ?? "all",
         FAKE_REJECT_REVIEW_REQUESTS: options.rejectReviewRequests ? "1" : "0",
         FAKE_REST_FILE_COUNT: options.restFileCount ?? "101",
-        OPENCLAW_GH_BIN: join(fakeGhDir, "gh"),
+        OPENCLAW_GH_BIN: "",
         PATH: `${fakeGhDir}:${process.env.PATH}`,
       },
       encoding: "utf8",
@@ -194,7 +205,7 @@ describe("PR metadata", () => {
     ]);
   });
 
-  it("paginates all changed files and preserves the GraphQL file shape", () => {
+  it("paginates fresh base-repository files through protected gh and preserves the GraphQL shape", () => {
     const result = readPrMetadata(createFakeGh());
 
     expect(result.status).toBe(0);

--- a/test/scripts/pr-wrappers.test.ts
+++ b/test/scripts/pr-wrappers.test.ts
@@ -210,9 +210,7 @@ describe("scripts/pr wrappers", () => {
     expect(script).toContain("export NO_COLOR=1");
     expect(script).toContain("unset COLORTERM");
     expect(script).toContain('source "$script_parent_dir/lib/plain-gh.sh"');
-    expect(script).toContain("OPENCLAW_GH_BIN=");
     expect(script).toContain("for cmd in git gh jq rg pnpm node");
-    expect(script).toContain('missing+=("real-gh")');
     expect(script).not.toContain("gh() {");
     expect(script).toContain("scripts/watch-pr-ci.mjs");
     expect(script).toContain("scripts/watch-pr-ci.mts");
@@ -236,6 +234,28 @@ describe("scripts/pr wrappers", () => {
     expect(script).toContain("only support PRs targeting main");
   });
 
+  itPosix("preserves the caller's gh route environment through startup", () => {
+    const fixture = makeMismatchedWrapperRepo();
+    try {
+      cpSync("scripts/lib/plain-gh.sh", join(fixture.canonical, "scripts/lib/plain-gh.sh"));
+      writeFileSync(
+        join(fixture.canonical, "scripts/pr-lib/worktree.sh"),
+        `list_pr_worktrees() { /bin/sh -c 'printf "%s\\n" "\${OPENCLAW_GH_BIN-absent}"'; }\n`,
+      );
+      for (const override of [undefined, "", join(fixture.bin, "gh")]) {
+        const result = spawnSync(join(fixture.canonical, "scripts/pr"), ["ls"], {
+          cwd: fixture.canonical,
+          encoding: "utf8",
+          env: { ...fixture.env, OPENCLAW_GH_BIN: override },
+        });
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stdout).toBe(`${override ?? "absent"}\n`);
+      }
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   it("routes cached reads and writer-sensitive operations through their owning gh seams", () => {
     const script = readScript("scripts/pr");
     const common = readScript("scripts/pr-lib/common.sh");
@@ -247,8 +267,6 @@ describe("scripts/pr wrappers", () => {
     expect(script).toContain('base_json=$(read_pr_view_json "$pr" "baseRefName")');
     expect(common).toContain('gh pr view "$pr" --json "$fields"');
     expect(worktree).toContain('metadata=$(read_pr_view_json "$pr"');
-    expect(worktree).toContain('gh_plain api --paginate "repos/{owner}/{repo}/pulls/$pr/files');
-    expect(review).toContain("reviewer=$(gh_plain api user --jq .login");
     expect(review).toContain('gh_plain pr edit "$pr" --add-assignee "$reviewer"');
     expect(push).toContain('gh_plain api graphql --input - <<< "$payload"');
     expect(merge).toContain('gh_plain pr merge "$pr"');
@@ -680,66 +698,66 @@ exit 1
     expect(result.stderr).toBe("");
   });
 
-  it("resolves review writer identity and assignment through the real GitHub CLI", () => {
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-pr-review-writer-"));
-    const bin = join(dir, "bin");
-    const pathCalls = join(dir, "path-calls.log");
-    const realCalls = join(dir, "real-calls.log");
-    const realGh = join(dir, "real-gh");
-    mkdirSync(bin);
-    writeFileSync(
-      join(bin, "gh"),
-      `#!/bin/sh
-printf '%s\n' "$*" >> "$OPENCLAW_TEST_PATH_CALLS"
-exit 9
-`,
-    );
-    writeFileSync(
-      realGh,
-      `#!/bin/sh
-printf '%s\n' "$*" >> "$OPENCLAW_TEST_REAL_CALLS"
+  it.each(["default", "override"])(
+    "resolves review writer identity through the selected protected gh (%s)",
+    (route) => {
+      const dir = mkdtempSync(join(tmpdir(), "openclaw-pr-review-writer-"));
+      const bin = join(dir, "bin");
+      const calls = join(dir, "calls.log");
+      mkdirSync(bin);
+      const protectedGh = `#!/bin/sh
+printf '%s\\n' "$*" >> "$OPENCLAW_TEST_CALLS"
 case "$1 $2" in
-  "api user") printf 'maintainer\n' ;;
-  "pr edit") exit 0 ;;
-  *) exit 2 ;;
+  "api user") printf 'relay-reader\\n' ;;
+  "api graphql") printf 'writer-maintainer\\n' ;;
+  "pr edit") [ "$5" = writer-maintainer ] ;;
+  *) exit 19 ;;
 esac
-`,
-    );
-    chmodSync(join(bin, "gh"), 0o755);
-    chmodSync(realGh, 0o755);
-
-    const result = spawnSync(
-      "bash",
-      [
-        "-c",
-        [
-          "source scripts/lib/plain-gh.sh",
-          "source scripts/pr-lib/review.sh",
-          'enter_worktree() { cd "$OPENCLAW_TEST_ROOT"; mkdir -p .local; }',
-          "mark_pr_operation_side_effects_started() { :; }",
-          "print_relevant_log_excerpt() { :; }",
-          "review_claim 42",
-        ].join("\n"),
-      ],
-      {
-        cwd: process.cwd(),
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          OPENCLAW_GH_BIN: realGh,
-          OPENCLAW_TEST_PATH_CALLS: pathCalls,
-          OPENCLAW_TEST_REAL_CALLS: realCalls,
-          OPENCLAW_TEST_ROOT: dir,
-          PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`,
-        },
-      },
-    );
-    const realInvocations = readFileSync(realCalls, "utf8");
-    rmSync(dir, { recursive: true, force: true });
-
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-    expect(realInvocations).toContain("api user --jq .login");
-    expect(realInvocations).toContain("pr edit 42 --add-assignee maintainer");
-    expect(existsSync(pathCalls)).toBe(false);
-  });
+`;
+      const pathGh = join(bin, "gh");
+      const overrideGh = join(dir, "selected-gh");
+      writeFileSync(pathGh, route === "default" ? protectedGh : "#!/bin/sh\nexit 19\n");
+      writeFileSync(overrideGh, protectedGh);
+      chmodSync(pathGh, 0o755);
+      chmodSync(overrideGh, 0o755);
+      try {
+        const result = spawnSync(
+          "bash",
+          [
+            "-c",
+            [
+              "source scripts/lib/plain-gh.sh",
+              "source scripts/pr-lib/common.sh",
+              "source scripts/pr-lib/review.sh",
+              'enter_worktree() { cd "$OPENCLAW_TEST_ROOT"; mkdir -p .local; }',
+              "review_claim 42",
+            ].join("\n"),
+          ],
+          {
+            cwd: process.cwd(),
+            encoding: "utf8",
+            env: {
+              HOME: dir,
+              GH_TOKEN: "synthetic-writer-token",
+              OPENCLAW_GH_BIN: route === "override" ? overrideGh : "",
+              OPENCLAW_TEST_CALLS: calls,
+              OPENCLAW_TEST_ROOT: dir,
+              PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`,
+            },
+          },
+        );
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+        expect(result.stdout).toContain("@writer-maintainer assigned to PR #42");
+        expect(readFileSync(calls, "utf8").trim().split("\n")).toEqual([
+          expect.stringContaining("api graphql -f query=query { viewer { login } }"),
+          "pr edit 42 --add-assignee writer-maintainer",
+        ]);
+        expect(readFileSync(join(dir, ".local/review-claim-user-attempt-1.log"), "utf8")).toBe(
+          "writer-maintainer\n",
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
 });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can help update the branch.

</details>

## What Problem This Solves

Fixes an issue where maintainers running PR and release-validation tooling could silently skip their configured protected GitHub CLI route when a package-managed native `gh` was installed. The shared helpers preferred native installation paths over PATH, and `scripts/pr` exported that selection to children.

The behavior is present in the [reported main snapshot](https://github.com/openclaw/openclaw/commit/357078cf7087534443dac92eb86e8aa32abb7b08). This is a standalone maintainer-requested repair, separate from unrelated test-fixture work.

## Why This Change Was Made

“Plain” should mean normalized terminal output, not an unwrapped transport. Default shell and Node execution now preserves PATH; explicit binary overrides retain validation and child-scoped split-auth forwarding. Automatic native discovery, HOME/bin exclusion, and the manufactured startup override are removed.

The caller boundary also has to preserve meaning: PR metadata and merge evidence use concrete base/prepared repository paths, mutable authoritative REST reads request `Cache-Control: max-age=0`, and writer authorization uses the authenticated GraphQL viewer rather than a relay caller profile. FRV run/attempt/job evidence uses the same explicit freshness contract. Cleanup reads and checks the prepared head before choosing a branch for the existing leased deletion.

## User Impact

New invocations honor the selected CLI’s credentials, filters, guarded delegation, and refusals. Existing token variables and explicit override/Enterprise handling remain supported. The CI watcher already uses the PATH-only read helper and keeps that behavior.

This does **not** weaken protected filters, change host authentication/PATH/configuration, alter owner/review rules, or add a native fallback after a refusal. Merge variants unsupported by a configured protected route remain refused; this change does not add support for custom-body, admin, auto, or other restricted modes. Contributor credit and existing merge authorization/locking/recovery rules remain intact.

Production LOC: +60/-138 (net -78). Tests: +852/-317 (net +535). Documentation: +11. No dependency, package, schema, protocol, or release-version change.

## Evidence

- Before production edits, the route-boundary tests failed 20 cases and passed 12; the repaired helper suite passes all 32. A separate startup regression demonstrated that an absent override was replaced by the native installation path before this change.
- Synthetic protected executables reject unresolved repository placeholders, distinguish relay identity from writer identity, require live evidence headers, and preserve refusal status. Coverage includes default/explicit routes, all four existing token variables, Enterprise hosts, shell function shadowing, relative/empty Node PATH entries and child cwd, binary output/streaming, pagination, and prepared-repository merge evidence.
- Live read-only proof passed through the installed protected route: shell and both Node helpers read repository metadata; synthetic unsafe input remained refused; the real PR metadata producer returned a complete head-bound file list; and the selected-writer/active-admin queries succeeded. No live merge, assignment, dispatch, or other GitHub mutation was used for repair proof.
- Changed-file formatting, shell syntax, root test typechecking, script lint, repository guards, and `git diff --check` passed.
- Independent frozen-diff Codex autoreview was scoped-clean at its P0 threshold. Pre-commit and exact-head hosted evidence are verified again during landing.

Focused commands used:

```bash
node scripts/run-vitest.mjs test/scripts/plain-gh.test.ts
```

```bash
node scripts/run-vitest.mjs test/scripts/plain-gh.test.ts test/scripts/pr-metadata.test.ts test/scripts/pr-wrappers.test.ts test/scripts/pr-crabbox-merge-bypass.test.ts test/scripts/frv.test.ts
```

```bash
node scripts/run-vitest.mjs test/scripts/pr-crabbox-merge-bypass.test.ts test/scripts/pr-merge-outcome.test.ts -t 'Crabbox|operator recovery preserves prior evidence|audits a confirmed admin|reconciles a merged receipt without waiting'
```

```bash
node scripts/run-vitest.mjs test/scripts/pr-merge-outcome.test.ts -t 'operator recovery preserves prior evidence and consumes one exact attempt'
```

```bash
node scripts/run-vitest.mjs test/scripts/secret-scanning-maintainer.test.ts
```

```bash
git diff --name-only -z | xargs -0 node scripts/check-changed.mjs --
```

The five-file owner run initially passed 138/139 tests and caught a refusal exit-status normalization mistake; the fix was verified by the complete Crabbox suite in the next run. That next run passed 34 cases but hit the existing merge fixture’s timeout before operator recovery; its isolated unchanged-limit rerun passed. An earlier wider sibling run similarly hit one watcher timeout, whose focused neighboring cases passed on rerun. No timeout was raised, assertion weakened, or watcher fixture changed. These results are not a claim that an entire broad suite passed in one run.


The [ClawSweeper final-effect proof request](https://github.com/openclaw/openclaw/pull/133624#issuecomment-5472055860) is addressed by extending the existing protected-CLI fixture. `finalize_remote_crabbox_aws_gate` runs through the real dispatch code to the fake workflow client; `merge_run` retains the real `merge_verify`, GraphQL viewer/membership reads, complete bypass verifier, final revalidation, and actual merge-request caller. Only synthetic CLI/API/Git/preparation/persistence dependencies are substituted. Both PATH and explicit CLI selection resolve to task-local fakes with synthetic token state.

| Scenario | Viewer reads | Writer membership reads | Workflow dispatches | Admin merge requests |
| --- | ---: | ---: | ---: | ---: |
| Active non-admin dispatch | 1 | 1 | 0 | 0 |
| Active admin dispatch | 1 | 1 | 1 | 0 |
| Active non-admin merge | 1 | 1 | 0 | 0 |
| Active admin merge | 2 | 2 | 0 | 1 |
| Admin membership revoked at final reread | 2 | 2 | 0 | 0 |

Each denial asserts that authoritative reads occurred before checking zero effects. The fake REST `/user` is a different admin relay identity. Denied merge cases leave no intent; the admin positive control reaches exactly one pinned synthetic `--admin --squash` request, then intentionally reports an unresolved OPEN receipt. These are local synthetic effects, not live GitHub dispatches or merges. Native `gh pr checks --required --json` is modeled with exit 0 and a `skipping`/`SKIPPED` row: cli/cli v2.98.0 exports JSON before its non-JSON failure/pending exit handling.

Temporary-source negative controls established regression value: restoring the relay identity shortcut allowed the non-admin scenario to reach both intended effects; omitting final admin revalidation allowed revoked membership to reach the merge request. Production files were not changed for these controls.

Additional verification:

```bash
node scripts/run-vitest.mjs test/scripts/pr-crabbox-merge-bypass.test.ts test/scripts/pr-prepare-gates.test.ts test/scripts/pr-merge-outcome.test.ts -t 'Crabbox|operator recovery preserves prior evidence|audits a confirmed admin|reconciles a merged receipt without waiting'
```

Passed 44 cases across three files. The existing real-Git sibling cases passed without changing their timeout.

```bash
node scripts/run-vitest.mjs test/scripts/pr-crabbox-merge-bypass.test.ts test/scripts/plain-gh.test.ts
```

Passed all 69 cases. The added harness uses synthetic local Git/preparation state to test the authorization boundary independently of the existing slow repository setup; real authorization and effect owners remain active.

```bash
node scripts/check-changed.mjs -- test/scripts/pr-crabbox-merge-bypass.test.ts
```

The actual changed-file gate passed, including formatting, root test typecheck, script lint, and repository guards. Shell syntax and `git diff --check` passed. Fresh isolated Codex autoreview of the new uncommitted diff was scoped-clean at P0 with no findings; its helper enforced the empty-workspace and outgoing-pack secret-scan boundaries.

Other review dispositions: guarded PATH refusals are intentional and documented above. There are no persistent-store/schema/version changes; the bot's persistence heuristic is inapplicable. Current-main comparison against native baseline `0b392310b92` found the pre-fix behavior still present. The omitted acknowledgement comment is not a new code defect. The initial exact-head [CI run 33342704877](https://github.com/openclaw/openclaw/actions/runs/33342704877) completed successfully; test-only head `5650afff12f48f212b9604f495446ae01b2bdbb6` passed [exact-head CI run 33344782712](https://github.com/openclaw/openclaw/actions/runs/33344782712) and [Workflow Sanity 33344782739](https://github.com/openclaw/openclaw/actions/runs/33344782739). Native review initialization, main/PR checkout, guard, artifact validation, and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 133624` passed. Prepared head remained unchanged. After exact-head parent approval, native ordinary pinned squash completed as [923454e6ddb1](https://github.com/openclaw/openclaw/commit/923454e6ddb1b054956d9f733215b749a92f625e). GitHub confirms MERGED; [native completion receipt](https://github.com/openclaw/openclaw/pull/133624#issuecomment-5472415677). No duplicate re-review request is needed for this finding-only proof addition under the fresh-review policy.
