### PR TITLE
chore(autoreview): sync reviewer-led credential checks

### DIFF
--- a/.agents/skills/autoreview/SKILL.md
+++ b/.agents/skills/autoreview/SKILL.md
@@ -33,7 +33,7 @@ Do not invoke Autoreview automatically before a commit, push, PR, merge, deploy,
 - Tools are useful in review mode. Codex receives the validated bundle in an empty workspace so ignored files and linked-worktree metadata remain unreadable; web search stays available for dependency contracts and upstream docs.
 - Security perspective is always included, but it should not cripple legitimate functionality. Report security findings only when the change creates a concrete, actionable risk or removes an important safety check.
 - Reviewer subprocesses preserve engine authentication and non-credentialed proxy variables needed by headless or restricted-network environments while stripping process-injection, Git override, and credentialed proxy values.
-- Immediately before every provider call, autoreview writes the exact outgoing review pack to an owner-only temporary file and scans it with TruffleHog using `verified,unknown`. It uses the installed binary with `--no-update` to disable self-update checks and attempts. The scan covers prompt and dataset inputs, untracked content, and every diff line, including deleted lines. A finding, scanner error, or missing TruffleHog binary refuses the send and names the implicated repository file when it can be resolved; credentials are never redacted and forwarded. Security-sensitive paths remain omitted. Safe large diffs are sent as one pass while they fit the aggregate prompt limit, then partitioned into complete bounded passes without truncation.
+- Credential checking belongs to the reviewer: the hard rules require inspection of the entire change bundle for accidentally committed credentials and require every suspected real credential to be reported as a P0 security finding without reproducing its value. The helper does not invoke an external credential scanner. Security-sensitive paths remain omitted. Safe large diffs are sent as one pass while they fit the aggregate prompt limit, then partitioned into complete bounded passes without truncation.
 - Regression provenance needs patch proof, not blame alone. `git log -S/-G`, `git blame`, commit subjects, and PR metadata locate candidates. Before saying `introduced by`, inspect raw parents with `git --no-replace-objects cat-file -p <sha>` and verify the implicated behavior changed in `git --no-replace-objects diff --no-ext-diff --no-textconv <raw-parent> <sha> -- <path>`; a genuine root needs raw-header proof that it has no parents.
 - Blame `^sha`, porcelain `boundary`, and shallow/grafted history alone are not introduction proof. `--root` can hide boundary markers; `git show` or `rev-list --parents` can make a shallow boundary look like a root. An available raw parent permits explicit comparison even at a shallow boundary; missing parents or an unverifiable patch require `unknown` with the gap. Use `carried forward` only for verified preexisting behavior and `made visible` only for a verified trigger. Apply the same bar to finding prose, summaries, and owner hints.
 - Keep code author, introducing PR author, merger, committer, automation trigger, and current PR author separate; none of those roles alone proves causation. Cite the verified commit/PR/date. If no PR is traceable, use the verified commit and known author identity; unknown identities stay unknown, and missing PR metadata is not a separate finding.
@@ -191,10 +191,7 @@ history and rerun. The helper does not fetch it automatically.
 
 ## Oversized Bundles
 
-The helper validates the complete patch before partitioning it. For partitioned
-reviews it scans the complete frozen input first, so credentials cannot evade
-detection by crossing a chunk boundary. It also scans each exact outgoing review
-pack before sending it. A safe bundle that fits
+The helper validates the complete patch before partitioning it. A bundle that fits
 the aggregate prompt limit remains one integrated review pass. Larger bundles
 are split at bundle sections and file boundaries where possible; an oversized
 single-file block is split at line boundaries with repeated file/hunk context
@@ -211,7 +208,7 @@ batch, and every evidence byte is retained. All validated reports are merged
 before required-finding and exit-status checks.
 There is no fixed pass-count ceiling: the complete frozen input determines the
 finite pass sequence. The helper prints its size and pass count before running
-passes serially. Each pass retains the same prompt-size limit, secret scan, and
+passes serially. Each pass retains the same prompt-size limit and
 reviewer isolation; a failed pass aborts without publishing a partial verdict.
 
 Preparation prints immediate phase updates and periodic elapsed time to stderr,
@@ -220,7 +217,7 @@ are separate from provider heartbeats and do not count against engine deadlines.
 Bundle construction captures finding membership alongside validated text; normal
 and dry runs reuse that record without reopening untracked files for membership.
 
-Dry runs reuse capture and scanning without whole-tree integrity sweeps. Real
+Dry runs reuse captured inputs and prompt construction without whole-tree integrity sweeps. Real
 reviews retain full fresh tree hashing before bundle construction, before review,
 and before publication, including unrelated tracked files, nonignored untracked files, index
 state, and initialized submodules. Explicit prompt files and datasets also retain
@@ -375,7 +372,7 @@ The helper:
 - supports `codex`, `claude`, `amp`, `pi`, and `kimi`; default is `AUTOREVIEW_ENGINE` or `codex`
 - resolves bare `git`, `gh`, reviewer, and PowerShell shell commands from absolute `PATH` entries only, never from the reviewed checkout; explicit `--*-bin` paths are interpreted from the reviewed repository root when relative and accepted only when both the supplied path and resolved target stay outside the reviewed repository
 - use `--mode commit --commit <ref>` for already-committed work, especially clean `main` after landing
-- validates complete Git patches, scans every outgoing review pack, reviews them in one pass up to the aggregate prompt limit, and automatically uses complete bounded passes above it
+- validates complete Git patches, reviews them in one pass up to the aggregate prompt limit, and automatically uses complete bounded passes above it
 - uses branch mode for committed-only PR work, or explicit local mode with a pinned merge base for a complete PR plus dirty candidate
 - writes reports to stdout and optionally to `--output` or `--json-output` files; preparation progress and provider heartbeats use stderr
 - supports `--dry-run` (validates bundle construction, reviewer CLI resolution, and local isolation startup with version/help probes without contacting a provider; exits nonzero if any check fails), an opt-in per-reviewer wall-clock bound via `--engine-timeout-seconds`, `--prompt`, repo-relative `--prompt-file`, repo-relative `--dataset`, `--no-tools`, `--no-web-search`, repeatable Codex-only safe model/response tuning with `--codex-config key=value`, Codex-only `--codex-speed fast|flex|default`, and commit refs
@@ -419,8 +416,8 @@ The exact source filename `CredentialFile.swift` is allowed for untracked and
 evidence inputs only outside sensitive parent paths, matching its existing
 tracked-source treatment. This is not a general source-extension exemption:
 credential stores, credential directories, `.env`, PEM, and key files retain
-their exclusions. TruffleHog still scans the exact outgoing pack, including
-source content, deleted lines, prompts, and datasets, before every provider call.
+their exclusions. Reviewers inspect the source content, deleted lines, prompts,
+and datasets present in each outgoing pack for accidentally committed credentials.
 
 ## Final Report
 

--- a/.agents/skills/autoreview/scripts/autoreview
+++ b/.agents/skills/autoreview/scripts/autoreview
@@ -1566,10 +1566,6 @@ def validate_git_ref(repo: Path, ref: str, label: str, *, pin: bool = False) -> 
     return result.strip() if pin else ref
 
 
-TRUFFLEHOG_INSTALL_URL = "https://github.com/trufflesecurity/trufflehog#installation"
-TRUFFLEHOG_FINDINGS_EXIT_CODE = 183
-
-
 def git_bytes(
     repo: Path,
     *args: str,
@@ -1597,130 +1593,6 @@ def git_bytes(
             f"{display_escape(detail, 1000, multiline=True)}"
         )
     return result
-
-
-def safe_trufflehog_env(repo: Path) -> dict[str, str]:
-    env = safe_git_env(repo)
-    for key in (
-        "ALL_PROXY",
-        "HTTP_PROXY",
-        "HTTPS_PROXY",
-        "NO_PROXY",
-        "all_proxy",
-        "http_proxy",
-        "https_proxy",
-        "no_proxy",
-    ):
-        value = os.environ.get(key)
-        if not value:
-            continue
-        if key.casefold() != "no_proxy" and not safe_proxy_url(value):
-            raise SystemExit(
-                f"unsafe credentialed or malformed proxy URL in {key}; "
-                "configure a credential-free proxy URL before running autoreview"
-            )
-        env[key] = value
-    return env
-
-
-def review_pack_path_at_line(prompt: str, line_number: int) -> str:
-    current = "review pack"
-    pending_untracked = False
-    diff_header: list[str] = []
-    for index, line in enumerate(prompt.splitlines(), start=1):
-        if line.startswith("# Prompt file: "):
-            current = line.removeprefix("# Prompt file: ").strip() or current
-        elif line.startswith("# Dataset: "):
-            current = line.removeprefix("# Dataset: ").strip() or current
-        elif line == "# Untracked File":
-            pending_untracked = True
-            current = "review pack"
-        elif pending_untracked and line.startswith("path: "):
-            try:
-                path = json.loads(line.removeprefix("path: "))
-            except json.JSONDecodeError:
-                path = None
-            if isinstance(path, str) and path:
-                current = path
-            pending_untracked = False
-        elif line.startswith("diff --git "):
-            diff_header = [line]
-            current = "review pack"
-        elif diff_header and line.startswith(("--- ", "+++ ")):
-            diff_header.append(line)
-            old_path, new_path = diff_section_paths("\n".join(diff_header))
-            current = new_path or old_path or current
-        elif not diff_header and line.startswith(("--- ", "+++ ")):
-            path = diff_marker_path(line[4:])
-            if path:
-                current = path
-        elif diff_header and line.startswith("@@"):
-            old_path, new_path = diff_section_paths("\n".join(diff_header))
-            current = new_path or old_path or current
-            diff_header = []
-        if index == line_number:
-            return current
-    return current
-
-
-def trufflehog_review_pack_paths(prompt: str, output: str) -> list[str]:
-    paths: set[str] = set()
-    for line in output.splitlines():
-        try:
-            finding = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        filesystem = (
-            finding.get("SourceMetadata", {})
-            .get("Data", {})
-            .get("Filesystem", {})
-        )
-        line_number = filesystem.get("line", filesystem.get("Line"))
-        if isinstance(line_number, int) and line_number > 0:
-            paths.add(review_pack_path_at_line(prompt, line_number))
-    return sorted(paths or {"review pack"})
-
-
-def scan_outgoing_review_pack(repo: Path, prompt: str) -> None:
-    trufflehog_bin = find_command("trufflehog", repo)
-    if not trufflehog_bin:
-        raise SystemExit(
-            "refusing to send review pack: TruffleHog is required but was not found. "
-            f"Install it using the official instructions, then rerun autoreview: {TRUFFLEHOG_INSTALL_URL}"
-        )
-    with tempfile.TemporaryDirectory(
-        prefix="autoreview-pack-scan.",
-        dir=safe_temp_root(repo),
-    ) as tempdir:
-        pack_path = Path(tempdir) / "review-pack.txt"
-        pack_path.write_bytes(prompt.encode("utf-8"))
-        pack_path.chmod(0o600)
-        result = run(
-            [
-                trufflehog_bin,
-                "filesystem",
-                str(pack_path),
-                "--json",
-                "--no-color",
-                "--results=verified,unknown",
-                "--fail",
-                "--fail-on-scan-errors",
-                "--no-update",
-            ],
-            Path(tempdir),
-            check=False,
-            env=safe_trufflehog_env(repo),
-        )
-    if result.returncode == TRUFFLEHOG_FINDINGS_EXIT_CODE:
-        paths = trufflehog_review_pack_paths(prompt, result.stdout)
-        raise SystemExit(
-            "refusing to send review pack: TruffleHog found credentials in "
-            + ", ".join(paths)
-        )
-    if result.returncode != 0:
-        raise SystemExit(
-            "refusing to send review pack: TruffleHog could not complete the scan"
-        )
 
 
 def bounded(text: str, limit: int = 180_000) -> str:
@@ -3218,6 +3090,7 @@ def render_review_prompt(
         - Report EVERY distinct actionable defect in this single pass, ordered most severe first. Each review round costs the caller a full fix-test-review cycle; withholding a known defect until a later round wastes one.
         - Before returning, sweep the bundle once more for independent defects in other files or failure modes that you may have stopped scanning for after an earlier find.
         - Include security findings: injection, secret leaks, authz/authn bypass, path traversal, unsafe deserialization, unsafe filesystem or shell use, privacy leaks, and credential handling.
+        - Inspect the entire change bundle for accidentally committed credentials or secrets, including API keys, access tokens, passwords, private keys, and credential-bearing URLs. Report every suspected real credential as a P0 security finding at the smallest file/line location that demonstrates it, without reproducing the credential value. Do not flag obvious placeholders or inert test fixtures unless they are usable credentials or create a concrete risk.
         - Do not reject legitimate functionality merely because it touches shell, filesystem, network, auth, or sensitive data. Report a security finding only when the patch creates a concrete exploitable risk, removes an important safety check, or lacks validation at a trust boundary.
         - Security-sensitive bundle material may be redacted or omitted before review. Continue reviewing the material that is present. A redaction notice is not itself a defect and does not prove either safety or vulnerability in the omitted material.
         - For each finding, use the smallest file/line location that demonstrates the issue.
@@ -3368,17 +3241,9 @@ def prepare_review_prompts(
     datasets: list[ReviewDataset],
     max_prompt_bytes: int,
 ) -> list[str]:
-    prompts = build_review_prompts(
+    return build_review_prompts(
         repo, target, target_ref, bundle, extra_prompt, datasets, max_prompt_bytes,
     )
-    if len(prompts) > 1:
-        # A credential can span a partition boundary. Scan the complete frozen
-        # input before any send, in addition to each exact outgoing pack.
-        scan_outgoing_review_pack(repo, render_review_prompt(
-            current_branch(repo), target, target_ref, ReviewChunk(bundle),
-            extra_prompt, render_datasets(datasets),
-        ))
-    return prompts
 
 
 def write_json_temp(data: dict[str, Any], temp_root: Path) -> Path:
@@ -5951,9 +5816,8 @@ def dry_run_preflight(
     and pass the same repo-relative/existence checks the real run applies
     via capture_evidence_inputs, that the assembled prompt(s) pass
     the same aggregate-size/partition and truncation-refusal checks the
-    real run applies via build_review_prompts/ensure_reviewer_input_complete
-    and the same fail-closed TruffleHog scan of each exact outgoing prompt
-    used by a real run, and that each configured reviewer's CLI binary resolves and
+    real run applies via build_review_prompts/ensure_reviewer_input_complete,
+    and that each configured reviewer's CLI binary resolves and
     its configuration (including, for Kimi, load_kimi_review_config and
     validate_kimi_runtime_auth_sources, and for Claude, the tool
     inventory) is one a real run would actually accept. Returns the
@@ -5990,7 +5854,7 @@ def dry_run_preflight(
     # inputs a real run rejects once combined.
     if bundle_ok and inputs_ok:
         try:
-            with PreparationProgress("bundle/evidence preparation and scan"):
+            with PreparationProgress("bundle/evidence preparation"):
                 input_truncated = captured.truncated or evidence.truncated
                 if reviewers:
                     ensure_reviewer_input_complete(reviewers[0], input_truncated)
@@ -5999,8 +5863,6 @@ def dry_run_preflight(
                     repo, target, target_ref, captured.text, threshold_extra_prompt,
                     evidence.datasets, max_prompt_bytes_for_reviewers(reviewers),
                 )
-                for prompt in prompts:
-                    scan_outgoing_review_pack(repo, prompt)
             with PreparationProgress("evidence verification"):
                 verify_evidence(repo, evidence.files)
             print("prompt: OK", flush=True)
@@ -6036,8 +5898,7 @@ def run_reviewer(
     evidence: list[EvidenceFile] | None = None,
 ) -> dict[str, Any]:
     ensure_reviewer_input_complete(args, input_truncated)
-    with PreparationProgress("outgoing pack scan and evidence verification"):
-        scan_outgoing_review_pack(repo, prompt)
+    with PreparationProgress("evidence verification"):
         verify_evidence(repo, evidence or [])
     raw = run_engine(args, repo, prompt)
     report = extract_json(raw)
@@ -6211,7 +6072,7 @@ def main_impl() -> int:
         evidence = capture_evidence_inputs(args, repo)
     with PreparationProgress("initial source snapshot") as progress:
         review_source_snapshot = source_tree_snapshot(repo, progress)
-    with PreparationProgress("bundle/evidence preparation and scan"):
+    with PreparationProgress("bundle/evidence preparation"):
         captured = build_bundle(repo, target, target_ref, args.commit)
         if target == "commit":
             target_ref = args.commit

--- a/.agents/skills/autoreview/scripts/autoreview_test.py
+++ b/.agents/skills/autoreview/scripts/autoreview_test.py
@@ -158,8 +158,8 @@ class AutoreviewResultScopeTests(unittest.TestCase):
         args = argparse.Namespace(engine="codex", max_priority="P0", require_finding=["Draft finding"])
         for count in (1, 2):
             with self.subTest(count=count), mock.patch.object(
-                AUTOREVIEW, "scan_outgoing_review_pack"
-            ), mock.patch.object(AUTOREVIEW, "run_engine", return_value=json.dumps(DRAFT_REPORT)):
+                AUTOREVIEW, "run_engine", return_value=json.dumps(DRAFT_REPORT)
+            ):
                 reports = AUTOREVIEW.run_review_passes(
                     args, [args], Path.cwd(), ["pack"] * count, {"draft.js"}, False
                 )
@@ -744,114 +744,6 @@ class AutoreviewAmpTests(unittest.TestCase):
                     AUTOREVIEW.run_amp(args, repo, "review")
 
 
-class AutoreviewTruffleHogTests(unittest.TestCase):
-    def test_findings_map_to_prompt_dataset_untracked_and_diff_paths(self) -> None:
-        prompt = "\n".join(
-            (
-                "# Prompt file: review-notes.md",
-                "prompt body",
-                "# Dataset: evidence.json",
-                "dataset body",
-                "# Untracked File",
-                'path: "new/config.ts"',
-                "source-line 1: redacted example",
-                "diff --git a/old.ts b/new.ts",
-                "--- a/old.ts",
-                "+++ b/new.ts",
-                "@@ -1 +1 @@",
-                "+redacted example",
-            )
-        )
-        output = "\n".join(
-            json.dumps(
-                {
-                    "SourceMetadata": {
-                        "Data": {"Filesystem": {"line": line_number}}
-                    }
-                }
-            )
-            for line_number in (2, 4, 7, 12)
-        )
-
-        self.assertEqual(
-            AUTOREVIEW.trufflehog_review_pack_paths(prompt, output),
-            ["evidence.json", "new.ts", "new/config.ts", "review-notes.md"],
-        )
-
-    def test_deleted_diff_finding_maps_to_original_path(self) -> None:
-        prompt = "\n".join(
-            (
-                "# Change Bundle",
-                "diff --git a/config.ts b/config.ts",
-                "deleted file mode 100644",
-                "--- a/config.ts",
-                "+++ /dev/null",
-                "@@ -1 +0,0 @@",
-                "-redacted example",
-            )
-        )
-        output = json.dumps(
-            {
-                "SourceMetadata": {
-                    "Data": {"Filesystem": {"Line": 7}}
-                }
-            }
-        )
-
-        self.assertEqual(
-            AUTOREVIEW.trufflehog_review_pack_paths(prompt, output),
-            ["config.ts"],
-        )
-
-    def test_unusable_scanner_output_falls_back_without_echoing_it(self) -> None:
-        output = "not-json\n" + json.dumps(
-            {
-                "SourceMetadata": {
-                    "Data": {"Filesystem": {"line": "invalid"}}
-                },
-                "Raw": "must-not-be-returned",
-            }
-        )
-
-        self.assertEqual(
-            AUTOREVIEW.trufflehog_review_pack_paths("prompt", output),
-            ["review pack"],
-        )
-
-    def test_scanner_command_requests_verified_and_unknown_results(self) -> None:
-        prompt = "review pack with redacted examples only"
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo = Path(tempdir)
-
-            def run_scanner(
-                command: list[str],
-                cwd: Path,
-                **kwargs: object,
-            ) -> subprocess.CompletedProcess[str]:
-                self.assertEqual(cwd, Path(command[2]).parent)
-                self.assertEqual(Path(command[2]).read_text(encoding="utf-8"), prompt)
-                self.assertEqual(
-                    command[3:],
-                    [
-                        "--json",
-                        "--no-color",
-                        "--results=verified,unknown",
-                        "--fail",
-                        "--fail-on-scan-errors",
-                        "--no-update",
-                    ],
-                )
-                self.assertEqual(kwargs["check"], False)
-                return subprocess.CompletedProcess(command, 0, "", "")
-
-            with mock.patch.object(
-                AUTOREVIEW,
-                "find_command",
-                return_value="/trusted/trufflehog",
-            ), mock.patch.object(AUTOREVIEW, "run", side_effect=run_scanner):
-                AUTOREVIEW.scan_outgoing_review_pack(repo, prompt)
-
-
 class AutoreviewCompatibilityTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -1023,6 +915,8 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
 
     def test_codex_retries_terra_after_sol_access_failure(self) -> None:
         args = argparse.Namespace(
+            engine="codex",
+            max_priority="P0",
             codex_bin="codex",
             codex_config=None,
             codex_speed=None,
@@ -1033,43 +927,31 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
             tools=True,
             web_search=False,
         )
-        models: list[str] = []
+        prompt = "complete retry pack: unicode \u03c0\r\n-deleted line\n unchanged context\n"
+        with tempfile.TemporaryDirectory(prefix="autoreview-codex-fallback.") as tmpdir:
+            events: list[str] = []
 
-        def fake_run(command: list[str], *_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
-            model = command[command.index("--model") + 1]
-            models.append(model)
-            if model == "gpt-5.6-sol":
-                return subprocess.CompletedProcess(
-                    command,
-                    1,
-                    "",
-                    "The model `gpt-5.6-sol` does not exist or you do not have access to it.",
-                )
-            output_path = Path(command[command.index("--output-last-message") + 1])
-            output_path.write_text(json.dumps(FINAL_REPORT))
-            return subprocess.CompletedProcess(command, 0, "", "")
+            def fake_run(command, _cwd, **kwargs):
+                self.assertEqual(kwargs["input_text"], prompt)
+                model = command[command.index("--model") + 1]
+                events.append(model)
+                if model == "gpt-5.6-sol":
+                    return subprocess.CompletedProcess(
+                        command, 1, "",
+                        "The model `gpt-5.6-sol` does not exist or you do not have access to it.",
+                    )
+                output_path = Path(command[command.index("--output-last-message") + 1])
+                output_path.write_text(json.dumps(FINAL_REPORT))
+                return subprocess.CompletedProcess(command, 0, "", "")
 
-        with tempfile.TemporaryDirectory(prefix="autoreview-codex-fallback.") as tmpdir, mock.patch.object(
-            AUTOREVIEW,
-            "resolve_command",
-            return_value="/usr/bin/codex",
-        ), mock.patch.object(
-            AUTOREVIEW,
-            "ensure_codex_isolation_supported",
-            return_value="/usr/bin/codex",
-        ), mock.patch.object(AUTOREVIEW, "codex_auth_config_flags", return_value=[]), mock.patch.object(
-            AUTOREVIEW,
-            "prepare_codex_runtime_auth",
-            return_value=None,
-        ), mock.patch.object(
-            AUTOREVIEW,
-            "run_with_heartbeat",
-            side_effect=fake_run,
-        ):
-            output = AUTOREVIEW.run_codex(args, Path(tmpdir), "review")
-
-        self.assertEqual(json.loads(output), FINAL_REPORT)
-        self.assertEqual(models, ["gpt-5.6-sol", "gpt-5.6-terra"])
+            with mock.patch.object(AUTOREVIEW, "resolve_command", return_value="/usr/bin/codex"), \
+                    mock.patch.object(AUTOREVIEW, "ensure_codex_isolation_supported", return_value="/usr/bin/codex"), \
+                    mock.patch.object(AUTOREVIEW, "codex_auth_config_flags", return_value=[]), \
+                    mock.patch.object(AUTOREVIEW, "prepare_codex_runtime_auth", return_value=None), \
+                    mock.patch.object(AUTOREVIEW, "run_with_heartbeat", side_effect=fake_run):
+                report = AUTOREVIEW.run_reviewer(args, Path(tmpdir), prompt, set(), [])
+                self.assertEqual(report["findings"], [])
+            self.assertEqual(events, ["gpt-5.6-sol", "gpt-5.6-terra"])
 
     def test_codex_runs_outside_repo_with_bundle_only_workspace(self) -> None:
         args = argparse.Namespace(

--- a/.agents/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/.agents/skills/autoreview/tests/test_autoreview_hardening.py
@@ -11,7 +11,6 @@ import re
 import runpy
 import shutil
 import signal
-import stat
 import subprocess
 import sys
 import tempfile
@@ -247,33 +246,6 @@ def installed_java() -> str | None:
     return java if probe.returncode == 0 else None
 
 
-def add_fake_trufflehog(
-    helper: dict[str, object],
-    root: Path,
-    env: dict[str, str],
-) -> None:
-    write_executable(
-        root / "trufflehog",
-        "#!/usr/bin/env python3\nraise SystemExit(0)\n",
-    )
-    env["PATH"] = f"{root}{os.pathsep}{env.get('PATH', '')}"
-
-
-def path_excluding_command(name: str) -> str:
-    """Build a PATH value with every directory that resolves ``name``
-    removed, so a subprocess launched with it cannot find that command
-    even when it is genuinely installed on the host running the tests.
-    """
-    kept = []
-    for part in os.environ.get("PATH", "").split(os.pathsep):
-        if not part:
-            continue
-        if (Path(part) / name).is_file():
-            continue
-        kept.append(part)
-    return os.pathsep.join(kept)
-
-
 class AutoreviewHardeningTests(unittest.TestCase):
     def setUp(self) -> None:
         self.helper = load_helper()
@@ -291,7 +263,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             (repo / "source.md").write_text("after\n")
             (repo / "evidence").mkdir()
             (repo / "evidence/note.md").write_text("frozen evidence\r\n")
-            sends, scans = [], []
+            sends = []
             stdout, stderr = io.StringIO(), io.StringIO()
 
             def engine(_args, _repo, prompt):
@@ -306,16 +278,15 @@ class AutoreviewHardeningTests(unittest.TestCase):
             with mock.patch.dict(self.helper["main_impl"].__globals__, {
                 "repo_root": lambda: repo,
                 "run_engine": engine,
-                "scan_outgoing_review_pack": lambda _repo, prompt: scans.append(prompt),
                 "resolve_engine_binary": lambda *_args: (True, None),
             }), mock.patch.object(sys, "argv", [str(SCRIPT), "--mode", "local", *options]), \
                     contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
-                yield repo, sends, scans, stdout, stderr
+                yield repo, sends, stdout, stderr
 
     def test_preparation_reuses_untracked_capture_and_keeps_three_full_snapshots(self):
         for explicit in (False, True):
             options = ("--dataset", "note.md") if explicit else ()
-            with self.subTest(explicit=explicit), self.preparation_fixture(*options) as (repo, sends, scans, _out, err):
+            with self.subTest(explicit=explicit), self.preparation_fixture(*options) as (repo, sends, _out, err):
                 (repo / "note.md").write_text("untracked evidence\n")
                 read = mock.Mock(wraps=self.helper["file_bundle_snapshot"])
                 fingerprint = mock.Mock(wraps=self.helper["source_file_fingerprint"])
@@ -323,7 +294,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     "file_bundle_snapshot": read, "source_file_fingerprint": fingerprint,
                 }):
                     self.assertEqual(self.helper["main_impl"](), 0)
-                self.assertEqual(scans, sends)
                 # Explicit evidence has its own initial capture and three fresh
                 # checks; finding membership never adds another content read.
                 self.assertEqual(read.call_count, 5 if explicit else 1)
@@ -349,7 +319,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             self.assertFalse(sends)
 
     def test_preparation_progress_precedes_snapshot(self):
-        with self.preparation_fixture() as (_repo, sends, _scans, _out, err):
+        with self.preparation_fixture() as (_repo, sends, _out, err):
             def snapshot(*_args, **_kwargs):
                 self.assertIn("preparation: initial source snapshot", err.getvalue())
                 self.assertFalse(sends)
@@ -360,20 +330,19 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     self.helper["main_impl"]()
 
     def test_dry_run_reuses_capture_without_whole_tree_snapshots(self):
-        with self.preparation_fixture("--dry-run", "--dataset", "evidence/note.md") as (_repo, sends, scans, *_):
+        with self.preparation_fixture("--dry-run", "--dataset", "evidence/note.md") as (_repo, sends, *_):
             snapshot = mock.Mock(side_effect=AssertionError("dry run must not sweep the checkout"))
             with mock.patch.dict(self.helper["main_impl"].__globals__, {"source_tree_snapshot": snapshot}):
                 self.assertEqual(self.helper["main_impl"](), 0)
             snapshot.assert_not_called()
-            self.assertTrue(scans)
             self.assertFalse(sends)
 
     def test_evidence_mutations_refuse_stale_publication_and_later_passes(self):
         for tracked in (False, True):
-            for timing in ("construction", "scan", "review", "between passes"):
+            for timing in ("construction", "review", "between passes"):
                 with self.subTest(tracked=tracked, timing=timing), self.preparation_fixture(
                     "--prompt-file", "evidence/note.md", "--dataset", "evidence/note.md",
-                ) as (repo, sends, _scans, out, _err):
+                ) as (repo, sends, out, _err):
                     evidence = repo / "evidence/note.md"
                     if tracked:
                         git(repo, "add", "-f", "evidence/note.md")
@@ -401,8 +370,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         return result
 
                     patches = {"run_engine": engine, "build_bundle": build}
-                    if timing == "scan":
-                        patches["scan_outgoing_review_pack"] = lambda *_args: mutate()
                     if timing == "between passes":
                         original_prepare = self.helper["prepare_review_prompts"]
                         patches["prepare_review_prompts"] = lambda *args: original_prepare(*args) * 2
@@ -457,7 +424,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
         with self.preparation_fixture(
             "--prompt-file", "evidence/note.md", "--dataset", "evidence/note.md",
             "--dataset", "evidence/note.md",
-        ) as (repo, sends, scans, *_):
+        ) as (repo, sends, *_):
             evidence = (repo / "evidence/note.md").read_bytes().decode()
             original = self.helper["prepare_review_prompts"]
             with mock.patch.dict(self.helper["main_impl"].__globals__, {
@@ -465,7 +432,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
             }):
                 self.assertEqual(self.helper["main_impl"](), 0)
             self.assertEqual(len(sends), 2)
-            self.assertEqual(scans, sends)
             for prompt in sends:
                 self.assertEqual(prompt.count(evidence), 3)
 
@@ -589,148 +555,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 self.assertEqual(captured.paths, {"task.md"})
                 self.assertIn("+task change", captured.text)
                 self.assertFalse(captured.truncated)
-
-    def test_outgoing_pack_scan_disables_installed_scanner_updates(self) -> None:
-        prompt = "harmless review pack\npreserved CRLF\r\nfinal line\r"
-        with tempfile.TemporaryDirectory() as tempdir:
-            root = Path(tempdir)
-            repo = root / "repo"
-            repo.mkdir()
-            write_executable(
-                root / "trufflehog",
-                r'''#!/usr/bin/env python3
-import json
-from pathlib import Path
-import sys
-
-args = sys.argv[1:]
-if "--no-update" not in args:
-    print("updater: cannot move binary: permission denied", file=sys.stderr)
-    raise SystemExit(1)
-assert args[0] == "filesystem"
-assert set(args[2:]) == {
-    "--json", "--no-color", "--results=verified,unknown",
-    "--fail", "--fail-on-scan-errors", "--no-update",
-}
-pack = Path(args[1])
-Path(__file__).with_name("scan.json").write_text(json.dumps({
-    "pack": str(pack),
-    "prompt": pack.read_bytes().decode("utf-8"),
-}))
-''',
-            )
-            with mock.patch.dict(
-                os.environ,
-                {"PATH": f"{root}{os.pathsep}{os.environ.get('PATH', '')}"},
-            ):
-                self.helper["scan_outgoing_review_pack"](repo, prompt)
-
-            record = json.loads((root / "scan.json").read_text(encoding="utf-8"))
-            self.assertEqual(record["prompt"], prompt)
-            self.assertFalse(Path(record["pack"]).parent.exists())
-
-    def test_outgoing_pack_scan_reads_exact_prompt_including_deleted_lines(self) -> None:
-        prompt = (
-            "# Change Bundle\n"
-            "diff --git a/config.ts b/config.ts\n"
-            "deleted file mode 100644\n"
-            "--- a/config.ts\n"
-            "+++ /dev/null\n"
-            "@@ -1 +0,0 @@\n"
-            "-const apiKey = \"removed-but-still-sensitive\";\n"
-        )
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo = init_repo(Path(tempdir))
-
-            def run_scanner(
-                command: list[str],
-                cwd: Path,
-                **_kwargs: object,
-            ) -> subprocess.CompletedProcess[str]:
-                self.assertEqual(command[1], "filesystem")
-                self.assertEqual(Path(command[2]).read_bytes(), prompt.encode("utf-8"))
-                self.assertIn("-const apiKey", prompt)
-                return subprocess.CompletedProcess(command, 0, "", "")
-
-            with mock.patch.dict(
-                self.helper["scan_outgoing_review_pack"].__globals__,
-                {
-                    "find_command": lambda _name, _repo: "/trusted/trufflehog",
-                    "run": run_scanner,
-                },
-            ):
-                self.helper["scan_outgoing_review_pack"](repo, prompt)
-
-    def test_outgoing_pack_scan_refuses_and_names_deleted_file(self) -> None:
-        prompt = (
-            "# Change Bundle\n"
-            "diff --git a/config.ts b/config.ts\n"
-            "deleted file mode 100644\n"
-            "--- a/config.ts\n"
-            "+++ /dev/null\n"
-            "@@ -1 +0,0 @@\n"
-            "-const apiKey = \"removed-but-still-sensitive\";\n"
-        )
-        finding = {
-            "SourceMetadata": {
-                "Data": {
-                    "Filesystem": {
-                        "file": "review-pack.txt",
-                        "line": 7,
-                    }
-                }
-            },
-            "Raw": "must-not-be-printed",
-        }
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo = init_repo(Path(tempdir))
-            with mock.patch.dict(
-                self.helper["scan_outgoing_review_pack"].__globals__,
-                {
-                    "find_command": lambda _name, _repo: "/trusted/trufflehog",
-                    "run": lambda command, _cwd, **_kwargs: subprocess.CompletedProcess(
-                        command,
-                        self.helper["TRUFFLEHOG_FINDINGS_EXIT_CODE"],
-                        json.dumps(finding) + "\n",
-                        "",
-                    ),
-                },
-            ):
-                with self.assertRaisesRegex(SystemExit, "config.ts") as error:
-                    self.helper["scan_outgoing_review_pack"](repo, prompt)
-        self.assertNotIn("must-not-be-printed", str(error.exception))
-
-    def test_outgoing_pack_scan_fails_closed_when_scanner_is_missing(self) -> None:
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo = init_repo(Path(tempdir))
-            with mock.patch.dict(
-                self.helper["scan_outgoing_review_pack"].__globals__,
-                {"find_command": lambda _name, _repo: None},
-            ):
-                with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
-                    self.helper["scan_outgoing_review_pack"](repo, "prompt")
-
-    def test_reviewer_scan_refusal_prevents_provider_call(self) -> None:
-        args = argparse.Namespace(engine="codex", max_priority="P0")
-        provider = mock.Mock()
-        with mock.patch.dict(
-            self.helper["run_reviewer"].__globals__,
-            {
-                "scan_outgoing_review_pack": mock.Mock(
-                    side_effect=SystemExit("refusing to send review pack: config.ts")
-                ),
-                "run_engine": provider,
-            },
-        ):
-            with self.assertRaisesRegex(SystemExit, "config.ts"):
-                self.helper["run_reviewer"](
-                    args,
-                    Path.cwd(),
-                    "prompt",
-                    set(),
-                    [],
-                )
-        provider.assert_not_called()
 
     def test_local_bundle_preserves_boundary_when_sensitive_diff_is_omitted(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -857,7 +681,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             # Expected patches must use the same protected Git policy.
             staged = self.helper["git"](repo, "diff", *self.helper["SAFE_DIFF_FLAGS"], "--cached", incoming)
             unstaged = self.helper["git"](repo, "diff", *self.helper["SAFE_DIFF_FLAGS"])
-            scanned: list[str] = []
             sent: list[str] = []
             report = {
                 "findings": [{
@@ -880,7 +703,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             main = self.helper["main_impl"]
             with mock.patch.dict(main.__globals__, {
                 "repo_root": lambda: repo,
-                "scan_outgoing_review_pack": lambda _repo, prompt: scanned.append(prompt),
                 "run_engine": run_engine,
                 "resolve_engine_binary": lambda _reviewer, _repo: (True, None),
             }):
@@ -892,7 +714,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                         self.assertEqual(main(), 0 if dry_run else 1)
 
             self.assertEqual(len(sent), 1)
-            self.assertEqual(scanned, [sent[0], sent[0]])
             self.assertIn(f"# Staged Diff\nbase: {incoming}", sent[0])
             self.assertIn(staged.rstrip(), sent[0])
             self.assertIn(unstaged.rstrip(), sent[0])
@@ -1023,7 +844,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             for engine in ("codex", "claude", "amp", "pi", "kimi"):
                 for mode, ref, accepted, expected_exit in cases:
                     with self.subTest(engine=engine, mode=mode, ref=bool(ref)):
-                        scans, sends = [], []
+                        sends = []
 
                         def run_engine(_args, _repo, prompt):
                             sends.append(prompt)
@@ -1037,7 +858,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                         output = io.StringIO()
                         with mock.patch.dict(self.helper["main_impl"].__globals__, {
                             "repo_root": lambda: repo, "run_engine": run_engine,
-                            "scan_outgoing_review_pack": lambda _repo, prompt: scans.append(prompt),
                         }), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(output), contextlib.redirect_stderr(io.StringIO()):
                             self.assertEqual(self.helper["main_impl"](), expected_exit)
                         result = json.loads((root / "result.json").read_text())
@@ -1052,7 +872,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                         self.assertNotIn("clean:", text)
                         rejected = result.get("scope_rejected_findings", [])
                         self.assertEqual(len(rejected), 2 - len(accepted))
-                        self.assertEqual(scans, sends)
                         self.assertIn("# Dataset: " + str(Path(e2e)), sends[0])
                         self.assertNotIn("OMIT_STAGED_STORE", sends[0])
                         self.assertNotIn("OMIT_UNTRACKED_ENV", sends[0])
@@ -1109,7 +928,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                         with mock.patch.dict(self.helper["main_impl"].__globals__, {
                             "repo_root": lambda: repo,
                             "build_review_prompts": lambda *_args: ["synthetic pack"] * count,
-                            "scan_outgoing_review_pack": lambda *_args: None,
                             "run_engine": lambda *_args: json.dumps(provider),
                         }), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
                             self.assertEqual(self.helper["main_impl"](), exit_code)
@@ -1127,22 +945,22 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                         if required and expected_status == "incomplete":
                             self.assertEqual(result["missing_required_findings"], required)
 
-    def test_credential_source_exception_still_scans_every_outgoing_input(self) -> None:
+    def test_credential_source_exception_keeps_review_material_and_credential_rule(self) -> None:
         source = "Sources/Configuration/CredentialFile.swift"
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             path = repo / source
             path.parent.mkdir(parents=True)
-            path.write_text("// DELETED_SCAN_MARKER\n", encoding="utf-8")
+            path.write_text("// DELETED_CREDENTIAL_CONTEXT\n", encoding="utf-8")
             git(repo, "add", source)
             git(repo, "commit", "-q", "-m", "base")
-            path.write_text("// STAGED_SCAN_MARKER\n", encoding="utf-8")
+            path.write_text("// STAGED_CREDENTIAL_CONTEXT\n", encoding="utf-8")
             git(repo, "add", source)
             untracked = repo / "Runtime/CredentialFile.swift"
             untracked.parent.mkdir()
-            untracked.write_text("// UNTRACKED_SCAN_MARKER\n", encoding="utf-8")
+            untracked.write_text("// UNTRACKED_CREDENTIAL_CONTEXT\n", encoding="utf-8")
             evidence = self.helper["capture_evidence_inputs"](argparse.Namespace(
-                prompt=["PROMPT_SCAN_MARKER"], prompt_file=[source],
+                prompt=["PROMPT_CREDENTIAL_CONTEXT"], prompt_file=[source],
                 dataset=[str(untracked.relative_to(repo))],
             ), repo)
             extra, datasets = evidence.prompt, evidence.datasets
@@ -1152,38 +970,22 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 "findings": [], "overall_correctness": "patch is correct",
                 "overall_explanation": "Synthetic review.", "overall_confidence": 0.8,
             }))
-            for marker in (None, "DELETED_SCAN_MARKER", "STAGED_SCAN_MARKER", "UNTRACKED_SCAN_MARKER", "PROMPT_SCAN_MARKER"):
-                events = []
-
-                def scanner(command, _repo, **_kwargs):
-                    outgoing = Path(command[2])
-                    self.assertEqual(outgoing.read_bytes(), pack.encode("utf-8"))
-                    if os.name != "nt":
-                        self.assertEqual(stat.S_IMODE(outgoing.stat().st_mode), 0o600)
-                    self.assertIn("--results=verified,unknown", command)
-                    self.assertIn("--no-update", command)
-                    for token in ("-// DELETED_SCAN_MARKER", "+// STAGED_SCAN_MARKER", "UNTRACKED_SCAN_MARKER", "PROMPT_SCAN_MARKER", "# Dataset:", "# Prompt file:"):
-                        self.assertIn(token, pack)
-                    events.append("scan")
-                    if marker:
-                        line = next(i for i, text in enumerate(pack.splitlines(), 1) if marker in text)
-                        detected = {"SourceMetadata": {"Data": {"Filesystem": {"file": str(outgoing), "line": line}}}}
-                        return subprocess.CompletedProcess(command, self.helper["TRUFFLEHOG_FINDINGS_EXIT_CODE"], json.dumps(detected), "")
-                    return subprocess.CompletedProcess(command, 0, "", "")
-
-                provider.reset_mock()
-                with self.subTest(marker=marker), mock.patch.dict(self.helper["run_reviewer"].__globals__, {
-                    "find_command": lambda *_args: "/trusted/trufflehog", "run": scanner, "run_engine": provider,
-                }):
-                    args = argparse.Namespace(engine="codex", max_priority="P2")
-                    if marker:
-                        with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
-                            self.helper["run_reviewer"](args, repo, pack, {source}, [])
-                        provider.assert_not_called()
-                    else:
-                        self.helper["run_reviewer"](args, repo, pack, {source}, [])
-                        provider.assert_called_once_with(args, repo, pack)
-                    self.assertEqual(events, ["scan"])
+            for token in (
+                "-// DELETED_CREDENTIAL_CONTEXT",
+                "+// STAGED_CREDENTIAL_CONTEXT",
+                "UNTRACKED_CREDENTIAL_CONTEXT",
+                "PROMPT_CREDENTIAL_CONTEXT",
+                "# Dataset:",
+                "# Prompt file:",
+                "Report every suspected real credential as a P0 security finding",
+            ):
+                self.assertIn(token, pack)
+            with mock.patch.dict(
+                self.helper["run_reviewer"].__globals__, {"run_engine": provider}
+            ):
+                args = argparse.Namespace(engine="codex", max_priority="P2")
+                self.helper["run_reviewer"](args, repo, pack, {source}, [])
+            provider.assert_called_once_with(args, repo, pack)
 
     def test_tracked_binary_changes_are_blocked_in_all_modes(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -1941,38 +1743,19 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                         self.assertLessEqual(len(prompt.encode("utf-8")), budget)
                         self.assertIn(instructions, prompt)
 
-    def test_partitioned_input_scans_complete_content_before_any_send(self) -> None:
+    def test_partitioned_inputs_keep_credential_review_rule_in_every_pass(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
-            sentinel = "synthetic scanner boundary " + "x" * 160_000 + " end sentinel"
-            for source in ("diff", "dataset"):
-                with self.subTest(source=source):
-                    bundle = "+" + (sentinel if source == "diff" else "safe") + "\n" * 30_000
-                    datasets = (
-                        [self.helper["ReviewDataset"]("evidence.txt", sentinel)]
-                        if source == "dataset" else []
-                    )
-                    prompts = self.helper["build_review_prompts"](
-                        repo, "local", None, bundle, "", datasets, 120_000
-                    )
-                    self.assertGreater(len(prompts), 1)
-                    self.assertFalse(any(sentinel in prompt for prompt in prompts))
-                    scanned = []
-
-                    def scan(_repo, prompt):
-                        scanned.append(prompt)
-                        if sentinel in prompt:
-                            raise SystemExit("complete input scanner rejection")
-
-                    with mock.patch.dict(
-                        self.helper["prepare_review_prompts"].__globals__,
-                        {"scan_outgoing_review_pack": scan},
-                    ), self.assertRaisesRegex(SystemExit, "complete input scanner rejection"):
-                        self.helper["prepare_review_prompts"](
-                            repo, "local", None, bundle, "", datasets, 120_000
-                        )
-                    self.assertEqual(len(scanned), 1)
-                    self.assertIn(sentinel, scanned[0])
+            bundle = "diff --git a/code.py b/code.py\n" + "+review me\n" * 20_000
+            prompts = self.helper["prepare_review_prompts"](
+                repo, "local", None, bundle, "", [], 120_000
+            )
+            self.assertGreater(len(prompts), 1)
+            for prompt in prompts:
+                self.assertIn(
+                    "Report every suspected real credential as a P0 security finding",
+                    prompt,
+                )
 
     def test_review_prompt_preserves_bundle_ending_whitespace(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -2006,15 +1789,10 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             "category": "bug",
             "code_location": {"file_path": "source.txt", "line": 1},
         }
-        for failure in (None, "scan", "engine"):
+        for failure in (None, "engine"):
             with self.subTest(failure=failure), tempfile.TemporaryDirectory() as tempdir:
                 repo = init_repo(Path(tempdir))
                 events = []
-
-                def scan(_repo, prompt):
-                    events.append(("scan", prompt))
-                    if failure == "scan" and prompt == prompts[8]:
-                        raise SystemExit("late scan failure")
 
                 def engine(_args, _repo, prompt):
                     events.append(("engine", prompt))
@@ -2034,7 +1812,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
 
                 with mock.patch.dict(
                     self.helper["run_review_passes"].__globals__,
-                    {"scan_outgoing_review_pack": scan, "run_engine": engine},
+                    {"run_engine": engine},
                 ), contextlib.redirect_stdout(io.StringIO()):
                     if failure:
                         with self.assertRaisesRegex(SystemExit, f"late {failure} failure"):
@@ -2051,11 +1829,9 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                         self.assertEqual(
                             [item["title"] for item in report["findings"]], [finding["title"]]
                         )
-                expected = [
-                    (stage, prompt) for prompt in prompts for stage in ("scan", "engine")
-                ]
+                expected = [("engine", prompt) for prompt in prompts]
                 if failure:
-                    expected = expected[:17 if failure == "scan" else 18]
+                    expected = expected[:9]
                 self.assertEqual(events, expected)
 
     def test_review_patch_does_not_disclose_controls_in_omitted_paths(self) -> None:
@@ -2413,29 +2189,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             ),
             patch,
         )
-
-    @unittest.skipUnless(
-        shutil.which("trufflehog"), "TruffleHog binary not installed"
-    )
-    def test_outgoing_pack_scan_accepts_deleted_swift_status_literals(self) -> None:
-        # Live-scanner companion to the regression above: TruffleHog must not
-        # flag the benign "ok-token" status literal in a deleted-file bundle.
-        source = (FIXTURES / "swift-benign-status-literals.swift").read_text(
-            encoding="utf-8"
-        )
-        prompt = (
-            "# Change Bundle\n"
-            "diff --git a/apps/macos/MenuContentView.swift "
-            "b/apps/macos/MenuContentView.swift\n"
-            "deleted file mode 100644\n"
-            "--- a/apps/macos/MenuContentView.swift\n"
-            "+++ /dev/null\n"
-            f"@@ -1,{len(source.splitlines())} +0,0 @@\n"
-            + "".join(f"-{line}\n" for line in source.splitlines())
-        )
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo = init_repo(Path(tempdir))
-            self.helper["scan_outgoing_review_pack"](repo, prompt)
 
     def test_review_bundle_preserves_typescript_config_paths(self) -> None:
         source = (FIXTURES / "typescript-benign-config-path-references.ts").read_text(
@@ -3421,7 +3174,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             )
             record_path = root / "record.json"
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env.update(
                 {
                     "AUTOREVIEW_FAKE_MUTATE": str(source),
@@ -4705,7 +4457,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
 ''',
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env.update(
                 {
                     "CODEX_HOME": str(source_home),
@@ -4802,7 +4553,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
             invocations = root / "codex-invocations.jsonl"
             record = root / "codex-record.json"
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env.update(
                 {
                     "AUTOREVIEW_FAKE_CODEX_INVOCATIONS": str(invocations),
@@ -4914,10 +4664,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 root / "codex",
                 fake_codex_script(),
             )
-            # Dry run scans the exact prompt too, so use a deterministic
-            # scanner instead of relying on the host installation.
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -4957,7 +4704,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             repo_temp = repo / "tmp"
             repo_temp.mkdir()
             env.update(
@@ -4988,54 +4734,12 @@ os.execv(target, [str(target), *sys.argv[1:]])
             )
 
             self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
-            self.assertIn("prompt: FAILED", result.stdout)
+            self.assertIn("prompt: OK", result.stdout)
             self.assertIn("must be outside the reviewed repository", result.stdout)
             self.assertRegex(
                 result.stdout,
                 r"engine check: codex[^\n]* UNAVAILABLE",
             )
-
-    @unittest.skipIf(os.name == "nt", "the fake executable is POSIX-only")
-    def test_dry_run_flag_exits_nonzero_when_trufflehog_missing(self) -> None:
-        # Dry run applies the same exact-pack scan as a real provider call.
-        with tempfile.TemporaryDirectory() as tempdir:
-            root = Path(tempdir)
-            repo = init_repo(root)
-            source = repo / "source.txt"
-            source.write_text("staged\n", encoding="utf-8")
-            git(repo, "add", "source.txt")
-            codex_bin = write_executable(
-                root / "codex",
-                fake_codex_script(),
-            )
-            env = os.environ.copy()
-            env["PATH"] = path_excluding_command("trufflehog")
-
-            result = subprocess.run(
-                [
-                    sys.executable,
-                    str(SCRIPT),
-                    "--mode",
-                    "local",
-                    "--engine",
-                    "codex",
-                    "--codex-bin",
-                    str(codex_bin),
-                    "--dry-run",
-                ],
-                cwd=repo,
-                env=env,
-                text=True,
-                capture_output=True,
-                check=False,
-            )
-
-            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
-            self.assertIn("prompt: FAILED", result.stdout)
-            self.assertIn("TruffleHog is required but was not found", result.stdout)
-            self.assertIn(self.helper["TRUFFLEHOG_INSTALL_URL"], result.stdout)
-            # The engine itself still resolves; only trufflehog should fail.
-            self.assertRegex(result.stdout, r"engine check: codex[^\n]* OK\b")
 
     def test_dry_run_flag_exits_nonzero_when_codex_no_tools(self) -> None:
         # run_codex() unconditionally refuses --no-tools; --dry-run must
@@ -5149,7 +4853,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 preflight.__globals__,
                 {
                     "build_review_prompts": capturing,
-                    "scan_outgoing_review_pack": lambda _repo, _prompt: None,
                 },
             ):
                 with contextlib.redirect_stdout(stdout):
@@ -5172,7 +4875,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -5214,7 +4916,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_pi_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env["AUTOREVIEW_FAKE_PI_VERSION"] = "0.50.0"
 
             result = subprocess.run(
@@ -5253,7 +4954,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_pi_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -5292,7 +4992,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_kimi_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env["AUTOREVIEW_FAKE_KIMI_VERSION"] = "0.10.0"
 
             result = subprocess.run(
@@ -5331,7 +5030,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_kimi_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             # Isolate KIMI_CODE_HOME to an empty, hermetic directory instead
             # of leaking the host's real ~/.kimi-code (which may or may not
             # exist) into this test; an empty source share has no
@@ -5379,7 +5077,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_kimi_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env["KIMI_CODE_HOME"] = str(repo / ".kimi-code")
 
             result = subprocess.run(
@@ -5434,7 +5131,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
             source_share.mkdir()
             (source_share / "device_id").write_text("not-a-valid-id!!", encoding="utf-8")
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env["KIMI_CODE_HOME"] = str(source_share)
 
             result = subprocess.run(
@@ -5487,7 +5183,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
             source_share.mkdir()
             (source_share / "credentials").write_text("not-a-directory", encoding="utf-8")
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env["KIMI_CODE_HOME"] = str(source_share)
 
             result = subprocess.run(
@@ -5539,7 +5234,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
             )
             (source_share / "credentials").mkdir()
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env["KIMI_CODE_HOME"] = str(source_share)
 
             result = subprocess.run(
@@ -5584,7 +5278,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_claude_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -5635,7 +5328,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_kimi_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             # Prompt limits must not depend on the host's Kimi configuration.
             env["KIMI_CODE_HOME"] = str(root / "kimi-empty-home")
             (root / "kimi-empty-home").mkdir()
@@ -5693,7 +5385,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -5738,7 +5429,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -5779,7 +5469,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [


### PR DESCRIPTION
## Summary
- sync the canonical autoreview change from openclaw/agent-skills#209
- remove the TruffleHog CLI gate from provider calls and dry-run preflight
- require reviewers to report suspected real credentials as P0 findings without reproducing values

## Validation
- skill validator
- Python compilation
- 214 autoreview tests passed (1 platform-dependent skip)

Canonical change: https://github.com/openclaw/agent-skills/pull/209