### PR TITLE
perf(state): streamline SQLite schema comparison

### DIFF
--- a/src/infra/sqlite-schema-contract.ts
+++ b/src/infra/sqlite-schema-contract.ts
@@ -193,7 +193,11 @@ export function collectSqliteSchemaIssues(
       ) {
         continue;
       }
-      if (!actualTable.triggers.some((actualTrigger) => isEqual(actualTrigger, expectedTrigger))) {
+      if (
+        !actualTable.triggers.some((actualTrigger) =>
+          isEqualTrigger(actualTrigger, expectedTrigger),
+        )
+      ) {
         add("missing-or-drifted-trigger", expectedTrigger.name);
       }
     }
@@ -208,7 +212,9 @@ export function collectSqliteSchemaIssues(
       }
       for (const canonicalTrigger of triggerGroup.triggers) {
         if (
-          !actualTable.triggers.some((actualTrigger) => isEqual(actualTrigger, canonicalTrigger))
+          !actualTable.triggers.some((actualTrigger) =>
+            isEqualTrigger(actualTrigger, canonicalTrigger),
+          )
         ) {
           add("missing-or-drifted-trigger", canonicalTrigger.name);
         }
@@ -217,10 +223,10 @@ export function collectSqliteSchemaIssues(
     for (const actualTrigger of actualTable.triggers) {
       if (
         !expectedTable.triggers.some((expectedTrigger) =>
-          isEqual(actualTrigger, expectedTrigger),
+          isEqualTrigger(actualTrigger, expectedTrigger),
         ) &&
         !optionalCanonicalTriggers.some((canonicalTrigger) =>
-          isEqual(actualTrigger, canonicalTrigger),
+          isEqualTrigger(actualTrigger, canonicalTrigger),
         )
       ) {
         add("unexpected-trigger", actualTrigger.name);
@@ -495,7 +501,7 @@ function compareTableDefinitions(
       add("column-definition-drift", objectName);
     }
   }
-  if (!isEqual(actual.constraints, expected.constraints)) {
+  if (JSON.stringify(actual.constraints) !== JSON.stringify(expected.constraints)) {
     add("table-constraint-drift", tableName);
   }
   return issues;
@@ -582,8 +588,8 @@ function sqliteIndexTermKind(cid: number): SqliteIndexTermContract["kind"] {
   return cid === -2 ? "expression" : cid === -1 ? "rowid" : "column";
 }
 
-function isEqual(left: unknown, right: unknown): boolean {
-  return JSON.stringify(left) === JSON.stringify(right);
+function isEqualTrigger(left: SqliteSchemaRow, right: SqliteSchemaRow): boolean {
+  return left.name === right.name && left.sql === right.sql;
 }
 
 function compareJson(left: unknown, right: unknown): number {

--- a/src/infra/sqlite-schema-sql.ts
+++ b/src/infra/sqlite-schema-sql.ts
@@ -58,12 +58,10 @@ export function normalizeSchemaSql(sql: string | null): string | null {
     return null;
   }
   const normalized = normalizeSqlWhitespace(sql).replace(/;\s*$/u, "").trim();
-  return normalized
-    .replace(/^(CREATE TABLE) IF NOT EXISTS /iu, "$1 ")
-    .replace(/^(CREATE VIRTUAL TABLE) IF NOT EXISTS /iu, "$1 ")
-    .replace(/^(CREATE UNIQUE INDEX) IF NOT EXISTS /iu, "$1 ")
-    .replace(/^(CREATE INDEX) IF NOT EXISTS /iu, "$1 ")
-    .replace(/^(CREATE TRIGGER) IF NOT EXISTS /iu, "$1 ");
+  return normalized.replace(
+    /^(CREATE (?:TABLE|VIRTUAL TABLE|UNIQUE INDEX|INDEX|TRIGGER)) IF NOT EXISTS /iu,
+    "$1 ",
+  );
 }
 
 export function splitSqlList(sql: string): string[] {
@@ -134,35 +132,37 @@ export function findSqlClosingParenthesis(sql: string, open: number): number {
 export function normalizeSqlWhitespace(sql: string): string {
   let normalized = "";
   let pendingSpace = false;
-  let index = 0;
-  while (index < sql.length) {
-    const quoted = skipSqlQuoted(sql, index, sql[index] ?? "");
+  // Ordinary spans have no quote, comment opener or whitespace to interpret.
+  const segments = /[^\s'"`[/-]+|\s+|./gsu;
+  let segment: RegExpExecArray | null;
+  while ((segment = segments.exec(sql))) {
+    const index = segment.index;
+    const char = segment[0][0] ?? "";
+    const quoted = skipSqlQuoted(sql, index, char);
     if (quoted !== index) {
       if (pendingSpace && normalized.length > 0) {
         normalized += " ";
       }
       normalized += sql.slice(index, quoted);
       pendingSpace = false;
-      index = quoted;
+      segments.lastIndex = quoted;
       continue;
     }
     const comment = skipSqlComment(sql, index);
     if (comment !== index) {
       pendingSpace = true;
-      index = comment;
+      segments.lastIndex = comment;
       continue;
     }
-    const char = sql[index] ?? "";
     if (/\s/u.test(char)) {
       pendingSpace = true;
     } else {
       if (pendingSpace && normalized.length > 0) {
         normalized += " ";
       }
-      normalized += char;
+      normalized += segment[0];
       pendingSpace = false;
     }
-    index += 1;
   }
   return normalized.trim();
 }


### PR DESCRIPTION
Schema inspection repeatedly scanned ordinary SQL one character at a time, ran five mutually exclusive CREATE-prefix replacements, and serialized already-projected trigger rows for equality. This keeps the existing schema contract and quote/comment handling while skipping ordinary text spans, combining the prefix match, and comparing the owned trigger fields directly. The remaining constraints-only serialization is unchanged and inlined at its sole caller.

There are three measured improvements, with no schema, migration, database-write, cache, configuration, or public API change. Production is +27/−21 lines (net +6); tests are unchanged. The small increase keeps quote/comment boundaries and the trigger projection explicit. Existing canonical tests cover these contracts, so this does not add implementation-mirroring tests.

Validation: all 108 existing schema-contract, index, state-maintenance and preflight tests passed before and after; the full build and `pnpm check:changed` passed. Independent source review and managed review found no actionable defects. A fresh graph of the complete owners and actual state/agent SQL assets passed 68,741 differential scenarios and 274,964 comparisons, including 26 native in-memory SQLite cases, Unicode and comment handling, drift, optional trigger groups, and error behavior.

Ten fresh processes in forward and reverse order produced 3,630 raw samples across 33 fixed workloads. Complete checks of the actual state schema took 7.2–7.7% less elapsed time, and the agent schema 6.7–12.7% less. A 16-trigger case took 39–44% less. Costs are retained: a synthetic 50-table case took 4.0–5.5% more, and a quoted-schema control was 5.8% slower forward and neutral reverse. These are warm owner measurements from one pair of orders, not confidence intervals or whole-Gateway, model, or memory claims.

The fully rebuilt Gateway also reached readiness on startup and restart over the task-owned database, passed six real health requests, and executed both changed owners according to V8 coverage. Both processes exited cleanly with their ports and process groups closed. A prior mixed source/built probe failed plugin loading and had a cleanup-inspection error; that failed evidence is retained, and a separate audit verified cleanup before the successful rebuilt runs. No product fix or performance gain is attributed to that fixture failure.

Pre-merge review follow-through: exact-head CI run 33343012903 passed. The latest ClawSweeper review has no findings or before-merge actions. Its automated stored-table warning does not apply to this diff: no schema SQL asset, DDL, schema version, migration, or persisted data shape changes. The real Gateway proof opened the existing task database on both startup and restart.
