### PR TITLE
fix(ui): preserve offline drafts and resume canceled queue edits

### DIFF
--- a/ui/src/app/app-host.gateway-lineage.test.ts
+++ b/ui/src/app/app-host.gateway-lineage.test.ts
@@ -1,6 +1,5 @@
-/* @vitest-environment jsdom */
-
 import { render } from "lit";
+/* @vitest-environment jsdom */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   GatewayBrowserClient,
@@ -8,6 +7,7 @@ import type {
   GatewayHelloOk,
 } from "../api/gateway.ts";
 import type { AgentsListResult } from "../api/types.ts";
+import { captureChatOutboxAdmission } from "../lib/chat/outbox-store.ts";
 import { createSessionCapability } from "../lib/sessions/index.ts";
 import { sessionsResult } from "../lib/sessions/session-capability.test-support.ts";
 import {
@@ -194,7 +194,7 @@ describe("Control UI Gateway target lineage", () => {
       const composer = document.createElement("div");
       try {
         expect(
-          admitQueuedMessageForSession(state, sessionKey, {
+          admitQueuedMessageForSession(state, captureChatOutboxAdmission(state, sessionKey), {
             id: "owner-row",
             text: "Original queued message",
             createdAt: 1000,

--- a/ui/src/app/app-shell-gateway.ts
+++ b/ui/src/app/app-shell-gateway.ts
@@ -29,20 +29,10 @@ export type StoredOutboxScopeHost = {
   hello?: { snapshot?: unknown } | null;
 };
 
-export type OutboxStoreRuntime = {
-  summarizeStoredChatOutboxes: (state: StoredOutboxScopeHost) => {
-    countsByScope: ReadonlyMap<string, number>;
-    attentionCountsByScope: ReadonlyMap<string, number>;
-    draftScopes: ReadonlySet<string>;
-    total: number;
-  };
-  resolveStoredChatOutboxScope: (
-    state: StoredOutboxScopeHost,
-    sessionKey: string,
-  ) => { sessionKey: string; agentId?: string };
-  storedChatOutboxScopeKey: (scope: { sessionKey: string; agentId?: string }) => string;
-  subscribeStoredChatOutboxChanges: (listener: () => void) => () => void;
-};
+export type OutboxStoreRuntime = Pick<
+  typeof import("../lib/chat/outbox-store-projection.ts"),
+  "summarizeStoredChatOutboxes" | "subscribeStoredChatOutboxChanges"
+>;
 
 export interface ShellGatewayHost {
   readonly context: ApplicationContext<RouteId> | undefined;

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -209,24 +209,7 @@ export function renderApplicationShell(host: ShellViewHost) {
   const canHoldUpdate =
     canUpdate && canCallGatewayMethod(gatewaySnapshot, "update.hold", "operator.admin");
   const outboxScopeHost = host.storedOutboxScopeHost(context);
-  const outboxStoreRuntime = host.outboxStoreRuntime;
-  const storedOutboxes = outboxStoreRuntime?.summarizeStoredChatOutboxes(outboxScopeHost) ?? null;
-  const outboxAttentionCountForSession = outboxStoreRuntime
-    ? (sessionKey: string) => {
-        const scope = outboxStoreRuntime.resolveStoredChatOutboxScope(outboxScopeHost, sessionKey);
-        const scopeKey = outboxStoreRuntime.storedChatOutboxScopeKey(scope);
-        return storedOutboxes?.attentionCountsByScope.get(scopeKey) ?? 0;
-      }
-    : () => 0;
-  const hasSessionDraft = outboxStoreRuntime
-    ? (sessionKey: string) => {
-        const scope = outboxStoreRuntime.resolveStoredChatOutboxScope(outboxScopeHost, sessionKey);
-        return (
-          storedOutboxes?.draftScopes.has(outboxStoreRuntime.storedChatOutboxScopeKey(scope)) ===
-          true
-        );
-      }
-    : EMPTY_SESSION_HAS_DRAFT;
+  const storedOutboxes = host.outboxStoreRuntime?.summarizeStoredChatOutboxes(outboxScopeHost);
   const navigationSnapshot = context.navigation.snapshot;
   const overlaySnapshot = context.overlays.snapshot;
   // The install keeps running after `update.run` answers, so the reconciliation
@@ -349,8 +332,8 @@ export function renderApplicationShell(host: ShellViewHost) {
       restartPending: gatewaySnapshot.restartPending === true,
       queuedOutboxCount: storedOutboxes?.total ?? 0,
       lastError: gatewaySnapshot.lastError,
-      outboxAttentionCountForSession,
-      hasSessionDraft,
+      outboxAttentionCountForSession: storedOutboxes?.attentionCountForSession ?? (() => 0),
+      hasSessionDraft: storedOutboxes?.hasSessionDraft ?? EMPTY_SESSION_HAS_DRAFT,
       terminalAvailable,
       catalogOpenTarget: normalizeCatalogOpenTarget(uiSettings.catalogOpenTarget),
       canPairDevice: gatewayConnected && (operatorAccess.canAdmin || operatorAccess.canPair),

--- a/ui/src/app/bootstrap-location.ts
+++ b/ui/src/app/bootstrap-location.ts
@@ -10,7 +10,6 @@ import {
   resolveUiConfiguredMainKey,
   resolveUiDefaultAgentId,
 } from "../lib/sessions/session-key.ts";
-import { isDefaultChatLanding } from "../pages/model-setup/first-run.ts";
 import type { ApplicationGateway } from "./context.ts";
 import { waitForGatewayClient } from "./gateway-readiness.ts";
 
@@ -18,6 +17,16 @@ type ReleasedSessionQuery = {
   face: BoardFace;
   sessionKey: string;
 };
+
+// Saved selection only fills an implicit landing. Agent paths remain explicit,
+// even when first-run setup is eligible to run on that same path.
+function isPersistedSessionLanding(location: RouteLocation, basePath: string): boolean {
+  return (
+    !new URLSearchParams(location.search + "&" + location.hash.slice(1)).has("session") &&
+    (routeIdFromPath(location.pathname, basePath) === null ||
+      /^\/chat\/?$/u.test(location.pathname.slice(basePath.length)))
+  );
+}
 
 function resolvePersistedAgentId(
   selectedAgentId: string | null | undefined,
@@ -110,7 +119,7 @@ export function normalizeInitialApplicationLocation(
   fallbackAgentId: string,
   mainKey?: string | null,
 ) {
-  if (!isDefaultChatLanding(location, basePath, routeIdFromPath) || !sessionKey.trim()) {
+  if (!isPersistedSessionLanding(location, basePath) || !sessionKey.trim()) {
     return location;
   }
   const agentId = parseAgentSessionKey(sessionKey)?.agentId ?? fallbackAgentId.trim();
@@ -134,7 +143,7 @@ export async function resolveInitialApplicationLocation(params: {
   if (releasedLocation) {
     return releasedLocation;
   }
-  if (!isDefaultChatLanding(params.location, params.basePath, routeIdFromPath)) {
+  if (!isPersistedSessionLanding(params.location, params.basePath)) {
     return params.location;
   }
   // Explicit routes must start immediately; only the implicit session landing

--- a/ui/src/app/bootstrap.agent-selection.test.ts
+++ b/ui/src/app/bootstrap.agent-selection.test.ts
@@ -1,10 +1,60 @@
 import { gatewayOriginScope } from "@openclaw/gateway-client/browser";
+import { buildControlUiSessionPath } from "@openclaw/session-url-contract";
+import type { RouteLocation } from "@openclaw/uirouter";
 import { expect, it, vi } from "vitest";
 import type { RouteId } from "../app-routes.ts";
+import { startModelSetupFirstRunRedirectAfterLocation } from "../pages/model-setup/first-run.ts";
 import { resolveInitialApplicationLocation } from "./bootstrap-location.ts";
 import { bootstrapApplication } from "./bootstrap.ts";
 import type { ApplicationContext } from "./context.ts";
 import { loadGatewaySessionSelection, loadSettings, saveSettings } from "./settings.ts";
+
+it.each([
+  { agentId: "main", savedAgentId: "work", basePath: "", suffix: "" },
+  { agentId: "work", savedAgentId: "main", basePath: "", suffix: "" },
+  { agentId: "main", savedAgentId: "work", basePath: "/openclaw", suffix: "/" },
+  { agentId: "work", savedAgentId: "main", basePath: "/openclaw", suffix: "/" },
+])(
+  "keeps cold explicit $agentId over saved $savedAgentId at $basePath (suffix '$suffix')",
+  async ({ agentId, savedAgentId, basePath, suffix }) => {
+    const pathname = buildControlUiSessionPath({
+      namespace: "chat",
+      sessionKey: `agent:${agentId}:main`,
+      exactKey: true,
+      basePath,
+    });
+    expect(pathname).toBe(`${basePath}/chat/${agentId}`);
+    const requested = { pathname: `${pathname}${suffix}`, search: "?draft=keep", hash: "#pane" };
+    let currentLocation: RouteLocation = requested;
+    const replace = vi.fn((location: RouteLocation) => {
+      currentLocation = location;
+    });
+    const gateway = {
+      snapshot: { phase: "connecting", client: null, hello: null },
+      subscribe: vi.fn(() => () => undefined),
+    } as unknown as ApplicationContext<RouteId>["gateway"];
+    const initialLocationReady = resolveInitialApplicationLocation({
+      location: requested,
+      basePath,
+      sessionKey: `agent:${savedAgentId}:main`,
+      selectedAgentId: savedAgentId,
+      gateway,
+      agentsList: () => null,
+      signal: new AbortController().signal,
+    });
+
+    await startModelSetupFirstRunRedirectAfterLocation({
+      context: { gateway } as ApplicationContext<RouteId>,
+      enabled: false,
+      history: { location: () => currentLocation, replace },
+      initialLocationReady,
+    });
+
+    expect(currentLocation).toEqual(requested);
+    expect(replace).not.toHaveBeenCalled();
+    expect(gateway.subscribe).not.toHaveBeenCalled();
+  },
+);
 
 it("routes a canonical global session through its persisted agent owner", async () => {
   const subscribe = vi.fn(() => () => undefined);

--- a/ui/src/e2e/attachment-file-styles.e2e.test.ts
+++ b/ui/src/e2e/attachment-file-styles.e2e.test.ts
@@ -1,0 +1,139 @@
+import { expect, it } from "vitest";
+import { createPlaybackMediaFixture } from "../../../test/fixtures/media-playback.js";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Attachment file styles" });
+
+suite.define(() => {
+  it("preserves large, preview, and unavailable file visuals in both themes", async () => {
+    await suite.withPage({ locale: "en-US", serviceWorkers: "block" }, async ({ page }) => {
+      await page.route("**/style-proof.mp3", (route) =>
+        route.fulfill({ contentType: "audio/mpeg", body: createPlaybackMediaFixture("mp3") }),
+      );
+      await installMockGateway(page, {
+        historyMessages: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "attachment",
+                attachment: {
+                  kind: "document",
+                  label: "report.pdf",
+                  mimeType: "application/pdf",
+                  url: new URL("report.pdf", suite.server.baseUrl).href,
+                },
+              },
+              {
+                type: "attachment",
+                attachment: {
+                  kind: "audio",
+                  label: "style-proof.mp3",
+                  mimeType: "audio/mpeg",
+                  url: new URL("style-proof.mp3", suite.server.baseUrl).href,
+                },
+              },
+              {
+                type: "attachment_error",
+                attachment: {
+                  code: "file-not-found",
+                  kind: "document",
+                  label: "missing.pdf",
+                },
+              },
+            ],
+            timestamp: 1,
+          },
+        ],
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const compact = page.locator('.chat-attachment-file-icon[data-mode="preview-with-favicon"]');
+      await compact.waitFor({ state: "visible" });
+      const documentCard = page.locator(".chat-assistant-attachment-card--compact", {
+        hasText: "report.pdf",
+      });
+      const unavailable = page.locator(".chat-assistant-attachment-card--definitive", {
+        hasText: "missing.pdf",
+      });
+      await unavailable.waitFor({ state: "visible" });
+
+      for (const theme of ["dark", "light"]) {
+        await page.evaluate((mode) => {
+          document.documentElement.dataset.themeMode = mode;
+        }, theme);
+        const large = documentCard.locator(".chat-attachment-file-icon");
+        const largeStyle = await large.evaluate((icon) => {
+          const style = getComputedStyle(icon);
+          const overlay = icon.querySelector(".chat-attachment-file-icon__overlay")!;
+          const glyph = getComputedStyle(overlay);
+          return {
+            width: style.width,
+            height: style.height,
+            background: style.backgroundImage,
+            glyphWidth: glyph.width,
+            glyphHeight: glyph.height,
+            mask: glyph.maskImage,
+            webkitMask: glyph.webkitMaskImage,
+          };
+        });
+        expect(largeStyle).toMatchObject({
+          width: "44px",
+          height: "44px",
+          glyphWidth: "14px",
+          glyphHeight: "14px",
+        });
+        expect(largeStyle.background).toContain(`large/shell-${theme}.svg`);
+        expect(largeStyle.mask).toContain("overlays/pdf.svg");
+        expect(largeStyle.webkitMask).toBe(largeStyle.mask);
+        const previewStyle = await compact.evaluate((icon) => {
+          const style = getComputedStyle(icon);
+          return { width: style.width, height: style.height, background: style.backgroundImage };
+        });
+        expect(previewStyle).toMatchObject({ width: "20px", height: "20px" });
+        expect(previewStyle.background).toContain(`compact/${theme}/mp3.svg`);
+        expect(
+          await documentCard.evaluate((card) => {
+            const style = getComputedStyle(card);
+            return [style.display, style.padding];
+          }),
+        ).toEqual(["block", "0px"]);
+        const failedStyle = await unavailable.evaluate((card) => {
+          const icon = card.querySelector(".chat-attachment-file-icon")!;
+          const metadata = card.querySelector(".chat-assistant-attachment-card__status-meta")!;
+          const title = card.querySelector(".chat-assistant-attachment-card__title")!;
+          return {
+            color: getComputedStyle(card).color,
+            danger: getComputedStyle(card).getPropertyValue("--danger").trim(),
+            iconColor: getComputedStyle(icon).color,
+            statusColor: getComputedStyle(metadata).color,
+            opacity: getComputedStyle(icon).opacity,
+            decoration: getComputedStyle(title).textDecorationLine,
+            thickness: getComputedStyle(title).textDecorationThickness,
+            display: getComputedStyle(card).display,
+            padding: getComputedStyle(card).padding,
+          };
+        });
+        expect(failedStyle).toMatchObject({
+          iconColor: failedStyle.color,
+          statusColor: failedStyle.color,
+          opacity: "0.42",
+          decoration: "line-through",
+          thickness: "1px",
+          display: "block",
+          padding: "0px",
+        });
+        expect(failedStyle.color).toBe(
+          await page.evaluate((color) => {
+            const sample = document.createElement("span");
+            sample.style.color = color;
+            document.body.append(sample);
+            const resolved = getComputedStyle(sample).color;
+            sample.remove();
+            return resolved;
+          }, failedStyle.danger),
+        );
+      }
+    });
+  });
+});

--- a/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
@@ -2,11 +2,11 @@ import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
+import { storedChatOutboxScopeKey } from "../lib/chat/outbox-store.ts";
 import {
-  resolveStoredChatOutboxScope,
-  storedChatOutboxScopeKey,
-} from "../lib/chat/outbox-store.ts";
-import type { UiSessionDefaultsHost } from "../lib/sessions/session-key.ts";
+  resolveUiConversationIdentity,
+  type UiSessionDefaultsHost,
+} from "../lib/sessions/session-key.ts";
 import {
   controlUiSessionUrl,
   installMockGateway,
@@ -81,7 +81,7 @@ async function waitForCommittedAttachmentDraft(
         hello: state.hello,
       };
     });
-  const storedScope = resolveStoredChatOutboxScope(defaults, sessionKey);
+  const storedScope = resolveUiConversationIdentity(defaults, sessionKey);
   await waitForCommittedComposerDraft(
     page,
     `chat:v3:${storedChatOutboxScopeKey(storedScope)}`,

--- a/ui/src/e2e/chat-outbox-agent-scope.e2e.test.ts
+++ b/ui/src/e2e/chat-outbox-agent-scope.e2e.test.ts
@@ -24,6 +24,7 @@ suite.define(() => {
       viewport: { height: 900, width: 1280 },
     });
     const page = await context.newPage();
+    const activePane = page.locator(".chat-pane-cache__pane--active");
     const agentsList = {
       agents: [
         { id: "main", name: "Main" },
@@ -33,11 +34,11 @@ suite.define(() => {
       mainKey: "main",
       scope: "global",
     };
-    const historyResponse = (active: boolean) => ({
+    const historyResponse = (agentId: "main" | "work", active: boolean) => ({
       messages: [],
-      sessionId: active ? "main-global-session" : "work-global-session",
+      sessionId: `${agentId}-global-session`,
       sessionInfo: {
-        activeRunIds: active ? ["main-active-run"] : [],
+        activeRunIds: active ? [`${agentId}-active-run`] : [],
         hasActiveRun: active,
         key: "global",
         status: active ? "running" : "done",
@@ -63,19 +64,25 @@ suite.define(() => {
         "agents.list": agentsList,
         "chat.history": {
           cases: [
-            { match: { agentId: "work", sessionKey: "global" }, response: historyResponse(true) },
-            { match: { agentId: "main", sessionKey: "global" }, response: historyResponse(true) },
+            {
+              match: { agentId: "work", sessionKey: "global" },
+              response: historyResponse("work", true),
+            },
+            {
+              match: { agentId: "main", sessionKey: "global" },
+              response: historyResponse("main", true),
+            },
           ],
         },
         "chat.startup": {
           cases: [
             {
               match: { agentId: "work" },
-              response: { ...historyResponse(false), agentsList },
+              response: { ...historyResponse("work", false), agentsList },
             },
             {
               match: { agentId: "main" },
-              response: { ...historyResponse(true), agentsList },
+              response: { ...historyResponse("main", true), agentsList },
             },
           ],
         },
@@ -144,8 +151,14 @@ suite.define(() => {
       await gateway.deferNext("chat.send");
       await gateway.setMethodResponse("chat.history", {
         cases: [
-          { match: { agentId: "work", sessionKey: "global" }, response: historyResponse(false) },
-          { match: { agentId: "main", sessionKey: "global" }, response: historyResponse(true) },
+          {
+            match: { agentId: "work", sessionKey: "global" },
+            response: historyResponse("work", false),
+          },
+          {
+            match: { agentId: "main", sessionKey: "global" },
+            response: historyResponse("main", true),
+          },
         ],
       });
       await gateway.emitGatewayEvent("sessions.changed", {
@@ -162,6 +175,17 @@ suite.define(() => {
       expect(params).toMatchObject({ agentId: "work", message: prompt, sessionKey: "global" });
       const runId = requireString(params.idempotencyKey, "inactive-agent outbox run id");
       await expectRequestCountStable(gateway, "chat.send", 1);
+      const recoveryRequests = (await gateway.getRequests("chat.history"))
+        .map((entry) => requireRecord(entry.params))
+        .filter((historyParams) => Array.isArray(historyParams.inputRunIds));
+      expect(recoveryRequests.length).toBeGreaterThan(0);
+      for (const historyParams of recoveryRequests) {
+        expect(historyParams).toMatchObject({
+          agentId: "work",
+          sessionKey: "global",
+          inputRunIds: [runId],
+        });
+      }
       const workPath = controlUiSessionPath("agent:work:main");
       await page.evaluate((pathname) => {
         const app = document.querySelector("openclaw-app") as HTMLElement & {
@@ -202,7 +226,7 @@ suite.define(() => {
         sessionKey: "global",
         status: "running",
       });
-      await page.locator(".chat-group.user").getByText(prompt).waitFor({ timeout: 10_000 });
+      await activePane.locator(".chat-group.user").getByText(prompt).waitFor({ timeout: 10_000 });
       await gateway.resolveDeferred("chat.send", { runId, status: "started" });
       if (artifactDir) {
         await page.screenshot({
@@ -223,11 +247,24 @@ suite.define(() => {
         state: "final",
       });
       await queue.waitFor({ state: "detached", timeout: 10_000 });
-      await page
+      // Retained panes also receive this conversation's events; assert its rendered owner.
+      const reply = activePane
         .locator(".chat-group.assistant")
-        .getByText("Work outbox delivered.", { exact: true })
-        .waitFor({ timeout: 10_000 });
+        .getByText("Work outbox delivered.", { exact: true });
+      await reply.waitFor({ timeout: 10_000 });
       await expectRequestCountStable(gateway, "chat.send", 1);
+      expect(await activePane.count()).toBe(1);
+      expect(await reply.count()).toBe(1);
+      const messages = await activePane.evaluate(
+        (pane) => (pane as HTMLElement & { state: { chatMessages: unknown[] } }).state.chatMessages,
+      );
+      expect(messages.map(requireRecord).filter((message) => message.role === "assistant")).toEqual(
+        [
+          expect.objectContaining({
+            content: [{ text: "Work outbox delivered.", type: "text" }],
+          }),
+        ],
+      );
       if (artifactDir) {
         await page.screenshot({
           path: `${artifactDir}/inactive-agent-delivered.png`,

--- a/ui/src/e2e/child-session-load-errors.e2e.test.ts
+++ b/ui/src/e2e/child-session-load-errors.e2e.test.ts
@@ -1,10 +1,10 @@
 import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   captureUiProof,
   controlUiSessionUrl,
   createSessionManagementE2eSuite,
   installMockGateway,
-  sessionRow,
   sessionsListResponse,
 } from "./session-management.test-support.ts";
 

--- a/ui/src/e2e/composer-draft-store.e2e.test.ts
+++ b/ui/src/e2e/composer-draft-store.e2e.test.ts
@@ -74,11 +74,15 @@ suite.define(() => {
       const composerHandle = await page.evaluateHandle<
         typeof import("../pages/chat/composer-persistence.ts")
       >('import("/src/pages/chat/composer-persistence.ts")');
+      const sessionKeyHandle = await page.evaluateHandle<
+        typeof import("../lib/sessions/session-key.ts")
+      >('import("/src/lib/sessions/session-key.ts")');
       const result = await page.evaluate(
-        async ({ draftStore, composer }) => {
+        async ({ draftStore, sessionKeys, composer }) => {
           const client = { recoveryScope: "credential-a", recoveryScopeReady: true };
           const state = {
             settings: { gatewayUrl: "owner-fence-gateway" },
+            hello: null,
             sessionKey: "agent:main:owner-fence",
             chatMessage: "",
             chatAttachments: [],
@@ -91,7 +95,7 @@ suite.define(() => {
             gatewayOwner: state.settings.gatewayUrl,
             recoveryScope: client.recoveryScope,
             scopeKey: `chat:v3:${composer.storedChatOutboxScopeKey(
-              composer.resolveStoredChatOutboxScope(state, state.sessionKey),
+              sessionKeys.resolveUiConversationIdentity(state, state.sessionKey),
             )}`,
           };
           const persistence = new composer.ChatComposerPersistence(() => state);
@@ -128,7 +132,7 @@ suite.define(() => {
           );
           return draftStore.readDurableComposerDraft(scope);
         },
-        { draftStore: storeHandle, composer: composerHandle },
+        { draftStore: storeHandle, sessionKeys: sessionKeyHandle, composer: composerHandle },
       );
 
       expect(result).toMatchObject({
@@ -435,11 +439,14 @@ suite.define(() => {
       const composerHandle = await page.evaluateHandle<
         typeof import("../pages/chat/composer-persistence.ts")
       >('import("/src/pages/chat/composer-persistence.ts")');
+      const sessionKeyHandle = await page.evaluateHandle<
+        typeof import("../lib/sessions/session-key.ts")
+      >('import("/src/lib/sessions/session-key.ts")');
       const durableHandle = await page.evaluateHandle<
         typeof import("../pages/chat/durable-composer-persistence.ts")
       >('import("/src/pages/chat/durable-composer-persistence.ts")');
       const result = await page.evaluate(
-        async ({ draftStore, composer, durable }) => {
+        async ({ draftStore, sessionKeys, composer, durable }) => {
           const waitFor = async (predicate: () => Promise<boolean>) => {
             for (let attempt = 0; attempt < 100; attempt += 1) {
               if (await predicate()) {
@@ -453,6 +460,7 @@ suite.define(() => {
           };
           const state = {
             settings: { gatewayUrl: "incognito-chat-gateway" },
+            hello: null,
             sessionKey: "agent:main:incognito-chat",
             chatMessage: "",
             chatAttachments: [] as import("../lib/chat/chat-types.ts").ChatAttachment[],
@@ -464,7 +472,7 @@ suite.define(() => {
             connected: true,
             selectedChatSessionIncognito: false,
           };
-          const storedScope = composer.resolveStoredChatOutboxScope(state, state.sessionKey);
+          const storedScope = sessionKeys.resolveUiConversationIdentity(state, state.sessionKey);
           const scope = {
             gatewayOwner: state.settings.gatewayUrl,
             recoveryScope: state.client.recoveryScope,
@@ -513,7 +521,12 @@ suite.define(() => {
             attachments: restartedState.chatAttachments.length,
           };
         },
-        { draftStore: storeHandle, composer: composerHandle, durable: durableHandle },
+        {
+          draftStore: storeHandle,
+          sessionKeys: sessionKeyHandle,
+          composer: composerHandle,
+          durable: durableHandle,
+        },
       );
 
       expect(result).toEqual({ message: "", attachments: 0 });

--- a/ui/src/e2e/composer-recovery-fences.e2e.test.ts
+++ b/ui/src/e2e/composer-recovery-fences.e2e.test.ts
@@ -1,6 +1,13 @@
 import { expect, it } from "vitest";
+import type { ChatQueueItem } from "../lib/chat/chat-types.ts";
+import {
+  waitForControlUiGatewayReady,
+  waitForControlUiGatewayReconnecting,
+} from "../test-helpers/control-ui-e2e-readiness.ts";
 import { installMockGateway, startControlUiE2eServer } from "../test-helpers/control-ui-e2e.ts";
+import { expectRequestCountStable, requireRecord } from "./chat-flow.test-support.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import { waitForCommittedComposerDraft } from "./settle.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI composer recovery fences",
@@ -10,6 +17,157 @@ const suite = createControlUiE2eSuite({
 });
 
 suite.define(() => {
+  it("commits an independent offline split-pane draft after submit, remove and reorder", async () => {
+    await suite.withPage(
+      { locale: "en-US", serviceWorkers: "block", viewport: { width: 1440, height: 1000 } },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          sessionKey: "agent:main:main",
+          historyMessages: [{ role: "assistant", content: "Split draft owner ready." }],
+        });
+        await page.goto(`${suite.server.baseUrl}chat/main`);
+        await waitForControlUiGatewayReady(page);
+        await page.getByText("Split draft owner ready.", { exact: true }).waitFor();
+        await page.locator(".agent-chat__composer-combobox textarea").fill("split seed");
+        await page.getByRole("button", { name: "Send message", exact: true }).click();
+        const seed = await gateway.waitForRequest("chat.send");
+        await gateway.emitChatFinal({
+          runId: String(requireRecord(seed.params).idempotencyKey),
+          text: "Split seed completed.",
+        });
+        await page
+          .locator(".chat-bubble")
+          .getByText("Split seed completed.", { exact: true })
+          .waitFor();
+        await page.getByRole("button", { name: "Open split view", exact: true }).click();
+        const panes = page.locator("openclaw-chat-pane.chat-split-view__pane");
+        await expect.poll(() => panes.count()).toBe(2);
+        const left = panes.nth(0);
+        const right = panes.nth(1);
+        const composer = left.locator(".agent-chat__composer-combobox textarea");
+        const attachmentBytes = Buffer.from("independent queued attachment bytes");
+        await gateway.setOnline(false);
+        await waitForControlUiGatewayReconnecting(page);
+        const messages = ["split tail", "split attachment", "split remove"];
+        for (const [index, message] of messages.entries()) {
+          await composer.fill(message);
+          if (index === 1) {
+            await left.locator(".agent-chat__file-input").setInputFiles({
+              name: "split.txt",
+              mimeType: "text/plain",
+              buffer: attachmentBytes,
+            });
+            await expect.poll(() => left.locator(".chat-attachment-thumb").count()).toBe(1);
+          }
+          await left.getByRole("button", { name: "Send message", exact: true }).click();
+          await expect.poll(() => composer.inputValue()).toBe("");
+          await expect.poll(() => right.locator(".chat-queue__item").count()).toBe(index + 1);
+        }
+        await right
+          .locator(".chat-queue__item", { hasText: "split remove" })
+          .locator(".chat-queue__remove")
+          .click();
+        await expect.poll(() => left.locator(".chat-queue__item").count()).toBe(2);
+        await right
+          .locator(".chat-queue__item", { hasText: "split attachment" })
+          .locator(".chat-queue__grip")
+          .focus();
+        await page.keyboard.press("ArrowUp");
+        for (const pane of [left, right]) {
+          await expect
+            .poll(() => pane.locator(".chat-queue__item .chat-queue__text").allTextContents())
+            .toEqual(["split attachment", "split tail"]);
+        }
+        const draft = "independent split composer draft";
+        await composer.fill(draft);
+        await waitForCommittedComposerDraft(
+          page,
+          "chat:v3:agent:main:main\u0000agent:main",
+          draft,
+          0,
+        );
+        expect(await composer.inputValue()).toBe(draft);
+        await expectRequestCountStable(gateway, "chat.send", 1);
+        const original = await page.evaluate(() =>
+          Object.keys(sessionStorage)
+            .filter((key) => key.startsWith("openclaw.control.chatComposer.v4:"))
+            .flatMap((key) => {
+              const store = JSON.parse(sessionStorage.getItem(key)!) as {
+                sessions: Record<string, { queue?: ChatQueueItem[] }>;
+              };
+              return Object.values(store.sessions).flatMap((session) => session.queue ?? []);
+            }),
+        );
+        expect(original).toHaveLength(2);
+        for (const item of original) {
+          expect(item.sendRunId).toEqual(expect.any(String));
+        }
+        const attachment = original.find((item) => item.text === "split attachment")!;
+        const tail = original.find((item) => item.text === "split tail")!;
+        expect(attachment.attachmentPayload).toBeDefined();
+        const edited = left.locator(`[data-chat-queue-item="${attachment.id}"]`);
+        await edited.dblclick();
+        await edited.locator(".chat-queue__edit-input").fill("discard this replacement");
+        await gateway.setOnline(true);
+        await waitForControlUiGatewayReady(page);
+        await expectRequestCountStable(gateway, "chat.send", 1);
+        await right
+          .locator(".chat-queue__item", { hasText: "split attachment" })
+          .locator(".chat-queue__remove")
+          .click();
+        await right.getByText(/Finish or cancel that edit before removing it/).waitFor();
+        expect(await left.locator(".chat-queue__item").count()).toBe(2);
+        expect(await edited.locator(".chat-queue__edit-input").inputValue()).toBe(
+          "discard this replacement",
+        );
+        await edited.locator(".chat-queue__edit-cancel").click();
+        await expect.poll(() => left.locator(".chat-queue__edit-input").count()).toBe(0);
+        // Cancel releases the local hold; no peer mutation or retry should be needed to drain.
+        await expect.poll(async () => (await gateway.getRequests("chat.send")).length).toBe(2);
+        const first = (await gateway.getRequests("chat.send"))[1]!;
+        expect(first.params).toMatchObject({
+          message: attachment.text,
+          sessionKey: "agent:main:main",
+          idempotencyKey: attachment.sendRunId,
+          attachments: [
+            {
+              fileName: "split.txt",
+              mimeType: "text/plain",
+              content: attachmentBytes.toString("base64"),
+            },
+          ],
+        });
+        await expectRequestCountStable(gateway, "chat.send", 2);
+        await gateway.emitChatFinal({
+          runId: String(requireRecord(first.params).idempotencyKey),
+          text: "Original attachment completed.",
+        });
+        await expect.poll(async () => (await gateway.getRequests("chat.send")).length).toBe(3);
+        const second = (await gateway.getRequests("chat.send"))[2]!;
+        expect(second.params).toMatchObject({
+          message: tail.text,
+          sessionKey: "agent:main:main",
+          idempotencyKey: tail.sendRunId,
+        });
+        await gateway.emitChatFinal({
+          runId: String(requireRecord(second.params).idempotencyKey),
+          text: "Original tail completed.",
+        });
+        for (const pane of [left, right]) {
+          await expect.poll(() => pane.locator(".chat-queue__item").count()).toBe(0);
+        }
+        await expectRequestCountStable(gateway, "chat.send", 3);
+        expect(await composer.inputValue()).toBe(draft);
+        await waitForCommittedComposerDraft(
+          page,
+          "chat:v3:agent:main:main\u0000agent:main",
+          draft,
+          0,
+        );
+      },
+    );
+  });
+
   it.each(["incognito", "toggle-incognito", "replacement", "reconnect"])(
     "fences recovery confirmation after %s at the rendered owner boundary",
     async (change) => {

--- a/ui/src/e2e/mobile-chat-session-menu.e2e.test.ts
+++ b/ui/src/e2e/mobile-chat-session-menu.e2e.test.ts
@@ -1,10 +1,10 @@
 import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   captureUiProof,
   controlUiSessionUrl,
   createSessionManagementE2eSuite,
   installMockGateway,
-  sessionRow,
   sessionsListResponse,
 } from "./session-management.test-support.ts";
 

--- a/ui/src/e2e/mobile-sidebar-session-menu.e2e.test.ts
+++ b/ui/src/e2e/mobile-sidebar-session-menu.e2e.test.ts
@@ -1,10 +1,10 @@
 import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   captureUiProof,
   controlUiSessionUrl,
   createSessionManagementE2eSuite,
   installMockGateway,
-  sessionRow,
   sessionsListResponse,
 } from "./session-management.test-support.ts";
 

--- a/ui/src/e2e/session-color.e2e.test.ts
+++ b/ui/src/e2e/session-color.e2e.test.ts
@@ -1,12 +1,12 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   controlUiSessionUrl,
   createSessionManagementE2eSuite,
   installMockGateway,
   openSessionMenuSubmenu,
-  sessionRow,
   sessionsListResponse,
   waitForPatch,
 } from "./session-management.test-support.ts";

--- a/ui/src/e2e/session-link-not-found.e2e.test.ts
+++ b/ui/src/e2e/session-link-not-found.e2e.test.ts
@@ -1,11 +1,8 @@
 import { expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
-import {
-  captureUiProof,
-  sessionRow,
-  sessionsListResponse,
-} from "./session-management.test-support.ts";
+import { captureUiProof, sessionsListResponse } from "./session-management.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "missing session link",

--- a/ui/src/e2e/session-management.account-label.e2e.test.ts
+++ b/ui/src/e2e/session-management.account-label.e2e.test.ts
@@ -1,10 +1,10 @@
 import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   captureUiProof,
   controlUiSessionUrl,
   createSessionManagementE2eSuite,
   installMockGateway,
-  sessionRow,
   sessionsListResponse,
   trimmedTextContents,
 } from "./session-management.test-support.ts";

--- a/ui/src/e2e/session-management.archive.e2e.test.ts
+++ b/ui/src/e2e/session-management.archive.e2e.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import { expectRequestCountStable } from "./chat-flow.test-support.ts";
 import {
   activateSelfRemovingControl,
@@ -10,7 +11,6 @@ import {
   createSessionManagementE2eSuite,
   installMockGateway,
   requireRecord,
-  sessionRow,
   sessionsListResponse,
   uiProofArtifactDir,
   waitForConfirmModal,

--- a/ui/src/e2e/session-management.archived-actions.e2e.test.ts
+++ b/ui/src/e2e/session-management.archived-actions.e2e.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { expect, it } from "vitest";
 import { CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT } from "../../../src/gateway/control-ui-contract.js";
 import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../lib/session-pull-requests.ts";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   activateSelfRemovingControl,
   captureUiProof,
@@ -10,7 +11,6 @@ import {
   createSessionManagementE2eSuite,
   installMockGateway,
   requireRecord,
-  sessionRow,
   sessionsListResponse,
   uiProofArtifactDir,
   waitForPatch,

--- a/ui/src/e2e/session-management.copy-session-id.e2e.test.ts
+++ b/ui/src/e2e/session-management.copy-session-id.e2e.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   activateSelfRemovingControl,
   captureUiProof,
@@ -6,7 +7,6 @@ import {
   controlUiSessionUrl,
   installMockGateway,
   openSessionMenuSubmenu,
-  sessionRow,
   sessionsListResponse,
 } from "./session-management.test-support.ts";
 

--- a/ui/src/e2e/session-management.created-sort.e2e.test.ts
+++ b/ui/src/e2e/session-management.created-sort.e2e.test.ts
@@ -1,12 +1,12 @@
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   captureUiProof,
   captureUiProofEnabled,
   createSessionManagementE2eSuite,
   controlUiSessionUrl,
   installMockGateway,
-  sessionRow,
   sessionsListResponse,
   uiProofArtifactDir,
 } from "./session-management.test-support.ts";

--- a/ui/src/e2e/session-management.delete.e2e.test.ts
+++ b/ui/src/e2e/session-management.delete.e2e.test.ts
@@ -2,13 +2,13 @@ import path from "node:path";
 import { expect, it } from "vitest";
 import type { ApplicationContext } from "../app/context.ts";
 import { defaultControlUiFeatureMethods } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import { expectRequestCountStable } from "./chat-flow.test-support.ts";
 import {
   captureUiProof,
   captureUiProofEnabled,
   createSessionManagementE2eSuite,
   installMockGateway,
-  sessionRow,
   sessionsListResponse,
   uiProofArtifactDir,
   waitForConfirmModal,

--- a/ui/src/e2e/session-management.draft-indicator.e2e.test.ts
+++ b/ui/src/e2e/session-management.draft-indicator.e2e.test.ts
@@ -1,13 +1,13 @@
 import { expect, it } from "vitest";
 import type { ChatPaneElement } from "../pages/chat/route-draft-focus-handoff.ts";
 import { waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   captureUiProof,
   controlUiSessionPath,
   controlUiSessionUrl,
   createSessionManagementE2eSuite,
   installMockGateway,
-  sessionRow,
   sessionsListResponse,
 } from "./session-management.test-support.ts";
 import { waitForSettledFormControls } from "./settle.test-support.ts";

--- a/ui/src/e2e/session-management.filtered-errors.e2e.test.ts
+++ b/ui/src/e2e/session-management.filtered-errors.e2e.test.ts
@@ -1,9 +1,9 @@
 import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   captureUiProof,
   createSessionManagementE2eSuite,
   installMockGateway,
-  sessionRow,
   sessionsListResponse,
 } from "./session-management.test-support.ts";
 

--- a/ui/src/e2e/session-management.group-identity.e2e.test.ts
+++ b/ui/src/e2e/session-management.group-identity.e2e.test.ts
@@ -1,6 +1,7 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   activateSelfRemovingControl,
   captureUiProofEnabled,
@@ -9,7 +10,6 @@ import {
   installMockGateway,
   openSessionMenuSubmenu,
   requireRecord,
-  sessionRow,
   sessionsListResponse,
 } from "./session-management.test-support.ts";
 

--- a/ui/src/e2e/session-management.group-return.e2e.test.ts
+++ b/ui/src/e2e/session-management.group-return.e2e.test.ts
@@ -1,12 +1,12 @@
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   captureUiProof,
   createSessionManagementE2eSuite,
   installMockGateway,
   openSessionMenuSubmenu,
   requireRecord,
-  sessionRow,
   sessionsListResponse,
   waitForPatch,
 } from "./session-management.test-support.ts";

--- a/ui/src/e2e/session-management.groups.e2e.test.ts
+++ b/ui/src/e2e/session-management.groups.e2e.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { expect, it } from "vitest";
 import { defaultControlUiFeatureMethods } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   actionOpacity,
   activateSelfRemovingControl,
@@ -13,7 +14,6 @@ import {
   installMockGateway,
   openSessionMenuSubmenu,
   requireRecord,
-  sessionRow,
   sessionsListResponse,
   submitInputDialog,
   uiProofArtifactDir,

--- a/ui/src/e2e/session-management.new-group.e2e.test.ts
+++ b/ui/src/e2e/session-management.new-group.e2e.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   activateSelfRemovingControl,
   captureUiProof,
@@ -7,7 +8,6 @@ import {
   installMockGateway,
   openSessionMenuSubmenu,
   requireRecord,
-  sessionRow,
   sessionsListResponse,
   submitInputDialog,
   waitForPatch,

--- a/ui/src/e2e/session-management.operator-scopes.e2e.test.ts
+++ b/ui/src/e2e/session-management.operator-scopes.e2e.test.ts
@@ -1,8 +1,8 @@
 import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   createSessionManagementE2eSuite,
   installMockGateway,
-  sessionRow,
   sessionsListResponse,
 } from "./session-management.test-support.ts";
 

--- a/ui/src/e2e/session-management.optimistic-pin.e2e.test.ts
+++ b/ui/src/e2e/session-management.optimistic-pin.e2e.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   activateSelfRemovingControl,
   captureUiProof,
@@ -7,7 +8,6 @@ import {
   createSessionManagementE2eSuite,
   controlUiSessionUrl,
   installMockGateway,
-  sessionRow,
   sessionsListResponse,
   trimmedTextContents,
   uiProofArtifactDir,

--- a/ui/src/e2e/session-management.queue.e2e.test.ts
+++ b/ui/src/e2e/session-management.queue.e2e.test.ts
@@ -1,12 +1,12 @@
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   captureUiProof,
   captureUiProofEnabled,
   controlUiSessionUrl,
   createSessionManagementE2eSuite,
   installMockGateway,
-  sessionRow,
   sessionsListResponse,
   uiProofArtifactDir,
 } from "./session-management.test-support.ts";

--- a/ui/src/e2e/session-management.rename-identity.e2e.test.ts
+++ b/ui/src/e2e/session-management.rename-identity.e2e.test.ts
@@ -1,13 +1,13 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   captureUiProofEnabled,
   controlUiSessionUrl,
   createSessionManagementE2eSuite,
   installMockGateway,
   requireRecord,
-  sessionRow,
   sessionsListResponse,
   waitForPatch,
 } from "./session-management.test-support.ts";

--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -4,6 +4,7 @@ import {
   waitForControlUiGatewayReady,
   waitForControlUiGatewayReconnecting,
 } from "../test-helpers/control-ui-e2e-readiness.ts";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import { expectRequestCountStable } from "./chat-flow.test-support.ts";
 import {
   actionOpacity,
@@ -15,7 +16,6 @@ import {
   createSessionManagementE2eSuite,
   installMockGateway,
   requireRecord,
-  sessionRow,
   sessionsListResponse,
   trimmedTextContents,
   uiProofArtifactDir,

--- a/ui/src/e2e/session-management.test-support.ts
+++ b/ui/src/e2e/session-management.test-support.ts
@@ -12,7 +12,6 @@ import {
   type MockGatewayControls,
   type MockGatewayRequest,
 } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiSessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 export { controlUiSessionPath, controlUiSessionUrl, installMockGateway, waitForConfirmModal };
@@ -33,33 +32,6 @@ export function createSessionManagementE2eSuite(source = false) {
     unavailableMessage: (executablePath) =>
       `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
   });
-}
-
-export function sessionRow(
-  key: string,
-  label: string,
-  updatedAt: number,
-  options: {
-    archived?: boolean;
-    archivedAt?: number;
-    sessionId?: string;
-    category?: string;
-    pinned?: boolean;
-    pinnedAt?: number;
-    hasActiveRun?: boolean;
-    unread?: boolean;
-    markedUnreadAt?: number;
-    status?: string;
-    spawnedBy?: string;
-    startedAt?: number;
-    endedAt?: number;
-    childSessions?: string[];
-    execNode?: string;
-    forkSource?: { sessionKey: string; sessionId: string; entryId?: string };
-    worktree?: { id?: string; branch?: string; repoRoot?: string };
-  } = {},
-) {
-  return createControlUiSessionRow(key, label, updatedAt, options);
 }
 
 export function sessionsListResponse(

--- a/ui/src/e2e/session-management.trailing-state.e2e.test.ts
+++ b/ui/src/e2e/session-management.trailing-state.e2e.test.ts
@@ -1,6 +1,7 @@
 import { expect, it } from "vitest";
 import { CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT } from "../../../src/gateway/control-ui-contract.js";
 import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../lib/session-pull-requests.ts";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   actionOpacity,
   captureUiProof,
@@ -8,7 +9,6 @@ import {
   createSessionManagementE2eSuite,
   installMockGateway,
   requireRecord,
-  sessionRow,
   sessionsListResponse,
 } from "./session-management.test-support.ts";
 

--- a/ui/src/e2e/session-management.unread.e2e.test.ts
+++ b/ui/src/e2e/session-management.unread.e2e.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { GATEWAY_SERVER_CAPS } from "@openclaw/gateway-protocol";
 import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import { expectRequestCountStable } from "./chat-flow.test-support.ts";
 import {
   captureUiProof,
@@ -10,7 +11,6 @@ import {
   createSessionManagementE2eSuite,
   installMockGateway,
   requireRecord,
-  sessionRow,
   sessionsListResponse,
   uiProofArtifactDir,
   waitForPatch,

--- a/ui/src/e2e/session-manager-history.e2e.test.ts
+++ b/ui/src/e2e/session-manager-history.e2e.test.ts
@@ -2,13 +2,13 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 import {
   activateSelfRemovingControl,
   controlUiSessionPath,
   installMockGateway,
   requireRecord,
-  sessionRow,
   sessionsListResponse,
   waitForPatch,
 } from "./session-management.test-support.ts";

--- a/ui/src/e2e/sidebar-per-tab-visibility.capture.e2e.test.ts
+++ b/ui/src/e2e/sidebar-per-tab-visibility.capture.e2e.test.ts
@@ -1,11 +1,11 @@
 import { expect, it } from "vitest";
 import { SIDEBAR_SESSION_NAV_COLLAPSE_QUERY } from "../app-session-route-paths.ts";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   captureUiProof,
   controlUiSessionUrl,
   createSessionManagementE2eSuite,
   installMockGateway,
-  sessionRow,
   sessionsListResponse,
 } from "./session-management.test-support.ts";
 

--- a/ui/src/e2e/sidebar-roster-completeness.capture.e2e.test.ts
+++ b/ui/src/e2e/sidebar-roster-completeness.capture.e2e.test.ts
@@ -1,10 +1,10 @@
 import { expect, it } from "vitest";
 import { SIDEBAR_SESSION_ROSTER_LIMIT } from "../../../src/shared/session-list-limits.ts";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   captureUiProof,
   createSessionManagementE2eSuite,
   installMockGateway,
-  sessionRow,
   sessionsListResponse,
 } from "./session-management.test-support.ts";
 

--- a/ui/src/e2e/sidebar-session-stability.e2e.test.ts
+++ b/ui/src/e2e/sidebar-session-stability.e2e.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   captureUiProof,
   captureUiProofEnabled,
@@ -7,7 +8,6 @@ import {
   controlUiSessionUrl,
   createSessionManagementE2eSuite,
   installMockGateway,
-  sessionRow,
   sessionsListResponse,
   uiProofArtifactDir,
 } from "./session-management.test-support.ts";

--- a/ui/src/e2e/sidebar-transient-surfaces.e2e.test.ts
+++ b/ui/src/e2e/sidebar-transient-surfaces.e2e.test.ts
@@ -3,10 +3,10 @@ import path from "node:path";
 import type { Locator } from "playwright";
 import { expect, it } from "vitest";
 import { waitForControlUiSettingsTakeover } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   controlUiSessionUrl,
   installMockGateway,
-  sessionRow,
   sessionsListResponse,
 } from "./session-management.test-support.ts";
 import { createSidebarCustomizationSuite } from "./sidebar-customization.test-support.ts";

--- a/ui/src/lib/chat/outbox-recovery.ts
+++ b/ui/src/lib/chat/outbox-recovery.ts
@@ -1,5 +1,5 @@
 import { getSafeSessionStorage } from "../../local-storage.ts";
-import { hasUiSessionDefaults } from "../sessions/session-key.ts";
+import { resolveUiConversationIdentity, hasUiSessionDefaults } from "../sessions/session-key.ts";
 import {
   observeOutboxRecoveryOwner,
   outboxPayloadMatchesOwner,
@@ -10,7 +10,6 @@ import {
   notifyStoredChatOutboxChanges,
   readStoredOutboxStore,
   resolvePendingComposerSessions,
-  resolveStoredChatOutboxScope,
   storedChatOutboxScopeKey,
   storageTargetForGateway,
   writeStoredOutboxStore,
@@ -58,7 +57,7 @@ export function captureChatOutboxRecoveryDestination(
   const store = readStoredOutboxStore(storage, target);
   resolvePendingComposerSessions(store, state);
   const storeSessionKey = storedChatOutboxScopeKey(
-    resolveStoredChatOutboxScope(state, scope.sessionKey, scope.agentId),
+    resolveUiConversationIdentity(state, scope.sessionKey, scope.agentId),
   );
   const session = store.sessions[storeSessionKey] ?? null;
   return {
@@ -95,7 +94,7 @@ export function restoreChatOutboxRecovery(
     ) {
       return "conflict";
     }
-    const scope = resolveStoredChatOutboxScope(
+    const scope = resolveUiConversationIdentity(
       state,
       destination.scope.sessionKey,
       destination.scope.agentId,

--- a/ui/src/lib/chat/outbox-store-draft-state.ts
+++ b/ui/src/lib/chat/outbox-store-draft-state.ts
@@ -1,6 +1,6 @@
 let lastIssuedDraftRevision = 0;
-const draftRevisionHighWaterByStorage = new WeakMap<Storage, Map<string, Map<string, number>>>();
-const draftAttemptHighWaterByStorage = new WeakMap<Storage, Map<string, Map<string, number>>>();
+type DraftHighWater = { committed: number; attempted: number };
+const draftHighWaterByStorage = new WeakMap<Storage, Map<string, Map<string, DraftHighWater>>>();
 
 export function observeDraftRevision(draftRevision: number | undefined): void {
   lastIssuedDraftRevision = Math.max(lastIssuedDraftRevision, draftRevision ?? 0);
@@ -21,17 +21,8 @@ export function rememberDraftRevision(
   if (draftRevision === undefined) {
     return;
   }
-  let byStorageKey = draftRevisionHighWaterByStorage.get(storage);
-  if (!byStorageKey) {
-    byStorageKey = new Map();
-    draftRevisionHighWaterByStorage.set(storage, byStorageKey);
-  }
-  let bySession = byStorageKey.get(storageKey);
-  if (!bySession) {
-    bySession = new Map();
-    byStorageKey.set(storageKey, bySession);
-  }
-  bySession.set(storeSessionKey, Math.max(bySession.get(storeSessionKey) ?? 0, draftRevision));
+  const highWater = draftHighWater(storage, storageKey, storeSessionKey);
+  highWater.committed = Math.max(highWater.committed, draftRevision);
 }
 
 export function rememberDraftAttempt(
@@ -40,17 +31,27 @@ export function rememberDraftAttempt(
   storeSessionKey: string,
   draftRevision: number,
 ) {
-  let byStorageKey = draftAttemptHighWaterByStorage.get(storage);
+  const highWater = draftHighWater(storage, storageKey, storeSessionKey);
+  highWater.attempted = Math.max(highWater.attempted, draftRevision);
+}
+
+function draftHighWater(storage: Storage, storageKey: string, storeSessionKey: string) {
+  let byStorageKey = draftHighWaterByStorage.get(storage);
   if (!byStorageKey) {
     byStorageKey = new Map();
-    draftAttemptHighWaterByStorage.set(storage, byStorageKey);
+    draftHighWaterByStorage.set(storage, byStorageKey);
   }
   let bySession = byStorageKey.get(storageKey);
   if (!bySession) {
     bySession = new Map();
     byStorageKey.set(storageKey, bySession);
   }
-  bySession.set(storeSessionKey, Math.max(bySession.get(storeSessionKey) ?? 0, draftRevision));
+  let highWater = bySession.get(storeSessionKey);
+  if (!highWater) {
+    highWater = { committed: 0, attempted: 0 };
+    bySession.set(storeSessionKey, highWater);
+  }
+  return highWater;
 }
 
 export function readDraftRevisionState(
@@ -59,15 +60,10 @@ export function readDraftRevisionState(
   storeSessionKey: string,
   storedRevision: number | undefined,
 ): { committed: number; latestAttempt: number } {
-  const committed = Math.max(
-    storedRevision ?? 0,
-    draftRevisionHighWaterByStorage.get(storage)?.get(storageKey)?.get(storeSessionKey) ?? 0,
-  );
+  const highWater = draftHighWaterByStorage.get(storage)?.get(storageKey)?.get(storeSessionKey);
+  const committed = Math.max(storedRevision ?? 0, highWater?.committed ?? 0);
   return {
     committed,
-    latestAttempt: Math.max(
-      committed,
-      draftAttemptHighWaterByStorage.get(storage)?.get(storageKey)?.get(storeSessionKey) ?? 0,
-    ),
+    latestAttempt: Math.max(committed, highWater?.attempted ?? 0),
   };
 }

--- a/ui/src/lib/chat/outbox-store-projection.ts
+++ b/ui/src/lib/chat/outbox-store-projection.ts
@@ -1,4 +1,5 @@
 import { getSafeSessionStorage } from "../../local-storage.ts";
+import { resolveUiConversationIdentity } from "../sessions/session-key.ts";
 import { compareChatQueueOrder } from "./chat-queue-order.ts";
 import type { ChatQueueItem } from "./chat-types.ts";
 import { outboxPayloadMatchesOwner } from "./outbox-payload-store.runtime.ts";
@@ -7,7 +8,6 @@ import {
   readProjectedOutboxStore,
   parseStoredChatOutboxScope,
   resolvePendingComposerSessions,
-  resolveStoredChatOutboxScope,
   storedChatOutboxScopeKey,
   storageTargetForGateway,
   subscribeStoredChatOutboxChanges,
@@ -16,7 +16,7 @@ import {
   type StoredChatOutboxScope,
 } from "./outbox-store.ts";
 
-export { resolveStoredChatOutboxScope, storedChatOutboxScopeKey, subscribeStoredChatOutboxChanges };
+export { subscribeStoredChatOutboxChanges };
 
 export type StoredChatOutbox = StoredChatOutboxScope & { queue: ChatQueueItem[] };
 
@@ -100,15 +100,21 @@ export function summarizeStoredChatOutboxes(state: ChatComposerScope) {
       idsByScope.set(scopeKey, ids);
     }
   }
-  const countsByScope = new Map<string, number>();
   const attentionCountsByScope = new Map<string, number>();
   let total = 0;
   for (const [scopeKey, ids] of idsByScope) {
-    countsByScope.set(scopeKey, ids.all.size);
     total += ids.all.size;
     if (ids.attention.size) {
       attentionCountsByScope.set(scopeKey, ids.attention.size);
     }
   }
-  return { countsByScope, attentionCountsByScope, draftScopes, total };
+  // Resolve sidebar queries with this render's state; stored destinations stay captured.
+  const sessionScopeKey = (sessionKey: string) =>
+    storedChatOutboxScopeKey(resolveUiConversationIdentity(state, sessionKey));
+  return {
+    total,
+    attentionCountForSession: (sessionKey: string) =>
+      attentionCountsByScope.get(sessionScopeKey(sessionKey)) ?? 0,
+    hasSessionDraft: (sessionKey: string) => draftScopes.has(sessionScopeKey(sessionKey)),
+  };
 }

--- a/ui/src/lib/chat/outbox-store.test.ts
+++ b/ui/src/lib/chat/outbox-store.test.ts
@@ -7,7 +7,6 @@ import { retireStoredComposerDrafts } from "./outbox-store-retirement.ts";
 import {
   readProjectedOutboxStore,
   readStoredOutboxStore,
-  resolveStoredChatOutboxScope,
   storedChatOutboxScopeKey,
   storageTargetForGateway,
   subscribeStoredChatOutboxChanges,
@@ -149,12 +148,6 @@ describe("stored outbox summaries", () => {
         }),
       );
       expect(summarizeStoredChatOutboxes({ settings: { gatewayUrl } }).total).toBe(1);
-      expect(
-        resolveStoredChatOutboxScope(
-          { settings: { gatewayUrl }, agentsList: null, hello: null },
-          "workspace",
-        ),
-      ).toEqual({ sessionKey: "workspace" });
     }
 
     sessionStorage.clear();
@@ -164,12 +157,6 @@ describe("stored outbox summaries", () => {
     unsubscribe();
 
     for (const gatewayUrl of gatewayUrls) {
-      expect(
-        resolveStoredChatOutboxScope(
-          { settings: { gatewayUrl }, agentsList: null, hello: null },
-          "workspace",
-        ),
-      ).toEqual({ sessionKey: "workspace" });
       expect(summarizeStoredChatOutboxes({ settings: { gatewayUrl } }).total).toBe(0);
     }
     expect(listener).toHaveBeenCalledOnce();
@@ -290,7 +277,76 @@ describe("stored outbox summaries", () => {
     unsubscribe();
   });
 
-  it("lists only non-empty drafts under the same scope used by sidebar sessions", () => {
+  it.each([
+    {
+      name: "named sessions before defaults",
+      state: { hello: null },
+      storedKey: "thread-draft\u0000agent:main",
+      present: ["thread-draft"],
+      absent: ["agent:main:thread-draft"],
+    },
+    {
+      name: "unresolved main before defaults",
+      state: { hello: null },
+      storedKey: "main\u0000agent:@unresolved",
+      present: ["main"],
+      absent: ["agent:main:main"],
+    },
+    {
+      name: "configured default-main aliases",
+      state: {
+        assistantAgentId: "previous",
+        agentsList: { defaultId: "work", mainKey: "workspace" },
+      },
+      storedKey: "agent:work:workspace\u0000agent:work",
+      present: ["main", "workspace", "agent:work:main", "agent:work:workspace"],
+      absent: ["agent:previous:main"],
+    },
+    {
+      name: "qualified cross-agent main aliases",
+      state: { agentsList: { defaultId: "main", mainKey: "workspace" } },
+      storedKey: "agent:work:workspace\u0000agent:work",
+      present: ["agent:work:main", "agent:work:workspace"],
+      absent: ["main", "workspace", "agent:main:workspace"],
+    },
+    {
+      name: "raw global and qualified selected-agent aliases",
+      state: {
+        assistantAgentId: "work",
+        agentsList: { defaultId: "main", mainKey: "workspace", scope: "global" },
+      },
+      storedKey: "global\u0000agent:work",
+      present: ["global", "agent:work:main", "agent:work:workspace"],
+      absent: ["main", "workspace", "agent:main:main", "agent:work:global"],
+    },
+    {
+      name: "global default-main aliases with another agent selected",
+      state: {
+        assistantAgentId: "work",
+        agentsList: { defaultId: "main", mainKey: "workspace", scope: "global" },
+      },
+      storedKey: "global\u0000agent:main",
+      present: ["main", "workspace", "agent:main:main"],
+      absent: ["global", "agent:work:main"],
+    },
+    {
+      name: "qualified global-named session",
+      state: {
+        assistantAgentId: "work",
+        agentsList: { defaultId: "main", mainKey: "workspace", scope: "global" },
+      },
+      storedKey: "agent:work:global\u0000agent:work",
+      present: ["agent:work:global"],
+      absent: ["global", "main", "agent:work:main"],
+    },
+    {
+      name: "opaque qualified session casing",
+      state: { agentsList: { defaultId: "main", mainKey: "main" } },
+      storedKey: "agent:work:matrix:channel:!Room:Server\u0000agent:work",
+      present: ["agent:work:matrix:channel:!Room:Server", "Agent:Work:MATRIX:CHANNEL:!Room:Server"],
+      absent: ["agent:work:matrix:channel:!room:server"],
+    },
+  ])("queries draft and attention snapshots for $name", ({ state, storedKey, present, absent }) => {
     const gatewayUrl = "ws://gateway.test/control";
     sessionStorage.setItem(
       `openclaw.control.chatComposer.v4:${encodeURIComponent(gatewayUrl)}`,
@@ -299,9 +355,12 @@ describe("stored outbox summaries", () => {
         recovery: {},
         gatewayOwner: gatewayUrl,
         sessions: {
-          "thread-draft\u0000agent:main": {
+          [storedKey]: {
             draft: "finish this message",
             draftRevision: 3,
+            queue: [
+              { id: "failed", text: "retry this message", createdAt: 3, sendState: "failed" },
+            ],
             updatedAt: 3,
           },
           "thread-empty\u0000agent:main": { draftRevision: 2, updatedAt: 2 },
@@ -312,11 +371,20 @@ describe("stored outbox summaries", () => {
         },
       }),
     );
-    const state = { settings: { gatewayUrl } };
+    const summary = summarizeStoredChatOutboxes({ ...state, settings: { gatewayUrl } });
+    const read = vi.spyOn(sessionStorage, "getItem");
+    sessionStorage.clear();
 
-    expect([...summarizeStoredChatOutboxes(state).draftScopes]).toEqual([
-      storedChatOutboxScopeKey(resolveStoredChatOutboxScope(state, "thread-draft")),
-    ]);
+    expect(summary.total).toBe(2);
+    for (const sessionKey of present) {
+      expect(summary.hasSessionDraft(sessionKey), sessionKey).toBe(true);
+      expect(summary.attentionCountForSession(sessionKey), sessionKey).toBe(1);
+    }
+    for (const sessionKey of [...absent, "thread-empty", "thread-queue", "absent"]) {
+      expect(summary.hasSessionDraft(sessionKey), sessionKey).toBe(false);
+      expect(summary.attentionCountForSession(sessionKey), sessionKey).toBe(0);
+    }
+    expect(read).not.toHaveBeenCalled();
   });
 
   it("bridges matching storage events until the last subscriber leaves", () => {
@@ -432,8 +500,6 @@ describe("stored outbox summaries", () => {
 
     const summary = summarizeStoredChatOutboxes({ settings: { gatewayUrl } });
     expect(summary.total).toBe(2);
-    expect(summary.countsByScope.get(storedChatOutboxScopeKey({ sessionKey: "thread-a" }))).toBe(1);
-    expect(summary.countsByScope.get(storedChatOutboxScopeKey({ sessionKey: "thread-b" }))).toBe(1);
   });
 
   it("counts only durable operator-review states for session-row attention", () => {
@@ -474,6 +540,13 @@ describe("stored outbox summaries", () => {
                 createdAt: 13,
                 sendState: "unconfirmed",
               },
+              {
+                id: "other-owner",
+                text: "another credential's attachment",
+                createdAt: 14,
+                sendState: "failed",
+                attachmentPayload: { key: "bundle", recoveryScope: "other-owner", tabId: "tab" },
+              },
             ],
             updatedAt: 13,
           },
@@ -493,14 +566,10 @@ describe("stored outbox summaries", () => {
     );
 
     const summary = summarizeStoredChatOutboxes({ settings: { gatewayUrl } });
-    const threadA = storedChatOutboxScopeKey({ sessionKey: "thread-a" });
-    const threadB = storedChatOutboxScopeKey({ sessionKey: "thread-b" });
-
     expect(summary.total).toBe(8);
-    expect(summary.countsByScope.get(threadA)).toBe(7);
-    expect(summary.countsByScope.get(threadB)).toBe(1);
-    expect(summary.attentionCountsByScope.get(threadA)).toBe(3);
-    expect(summary.attentionCountsByScope.get(threadB)).toBe(1);
+    expect(summary.attentionCountForSession("thread-a")).toBe(3);
+    expect(summary.attentionCountForSession("thread-b")).toBe(1);
+    expect(summary.attentionCountForSession("absent")).toBe(0);
   });
 
   it("derives badges and replay from the same migrated durable queue", () => {
@@ -536,7 +605,6 @@ describe("stored outbox summaries", () => {
     const outboxes = listStoredChatOutboxes(state);
 
     expect(summary.total).toBe(1);
-    expect(summary.countsByScope.get(storedChatOutboxScopeKey(outboxes[0]!))).toBe(1);
     expect(outboxes[0]?.queue).toEqual([
       {
         id: "shared",

--- a/ui/src/lib/chat/outbox-store.ts
+++ b/ui/src/lib/chat/outbox-store.ts
@@ -174,7 +174,7 @@ export function resolvePendingComposerSessions(
     if (!source) {
       continue;
     }
-    const resolved = resolveStoredChatOutboxScope(state, source.sessionKey, source.agentId);
+    const resolved = resolveUiConversationIdentity(state, source.sessionKey, source.agentId);
     const nextKey = storedChatOutboxScopeKey(resolved);
     const { awaitingDefaults: _, ...session } = pending;
     const destination = store.sessions[nextKey];
@@ -211,21 +211,13 @@ export function resolvePendingComposerSessions(
   return migrated;
 }
 
-export function resolveStoredChatOutboxScope(
-  state: ChatComposerScope,
-  sessionKey: string,
-  agentIdOverride?: string,
-): StoredChatOutboxScope {
-  return resolveUiConversationIdentity(state, sessionKey, agentIdOverride);
-}
-
 export function captureChatOutboxAdmission(
   state: ChatComposerScope,
   sessionKey: string,
   agentId?: string,
 ) {
   return {
-    scope: resolveStoredChatOutboxScope(state, sessionKey, agentId),
+    scope: resolveUiConversationIdentity(state, sessionKey, agentId),
     awaitingDefaults: !hasUiSessionDefaults(state),
   };
 }

--- a/ui/src/pages/chat/chat-composer-memory-fallback.ts
+++ b/ui/src/pages/chat/chat-composer-memory-fallback.ts
@@ -1,12 +1,14 @@
 import type { ChatAttachment, ChatGoalDraftMode } from "../../lib/chat/chat-types.ts";
 import { parseStoredChatOutboxScope } from "../../lib/chat/outbox-store.ts";
-import { hasUiSessionDefaults } from "../../lib/sessions/session-key.ts";
+import {
+  resolveUiConversationIdentity,
+  hasUiSessionDefaults,
+} from "../../lib/sessions/session-key.ts";
 import { releaseDisplacedChatAttachmentPayloads } from "./attachment-payload-store.ts";
 import type { ChatComposerMemoryFallback, ChatPageHost } from "./chat-state-host.ts";
 import {
   loadChatComposerCommittedDraftRevision,
   loadChatComposerDraftRevision,
-  resolveStoredChatOutboxScope,
   storedChatOutboxScopeKey,
   type ChatComposerDraftRetry,
   type StoredChatOutboxScope,
@@ -23,7 +25,7 @@ function resolveChatComposerMemoryFallback(
   sessionKey: string,
   scopeOverride?: StoredChatOutboxScope,
 ): { fallback?: ChatComposerMemoryFallback; scopeKey: string } {
-  const scope = scopeOverride ?? resolveStoredChatOutboxScope(state, sessionKey);
+  const scope = scopeOverride ?? resolveUiConversationIdentity(state, sessionKey);
   const scopeKey = storedChatOutboxScopeKey(scope);
   const fallbackSourceKeys = new Set([scopeKey]);
   for (const key of Object.keys(state.chatComposerFallbackByScope)) {
@@ -32,7 +34,7 @@ function resolveChatComposerMemoryFallback(
       source &&
       state.chatComposerFallbackByScope[key]?.awaitingDefaults &&
       storedChatOutboxScopeKey(
-        resolveStoredChatOutboxScope(state, source.sessionKey, source.agentId),
+        resolveUiConversationIdentity(state, source.sessionKey, source.agentId),
       ) === scopeKey
     ) {
       fallbackSourceKeys.add(key);

--- a/ui/src/pages/chat/chat-history-cursor.test.ts
+++ b/ui/src/pages/chat/chat-history-cursor.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
+import { captureChatOutboxAdmission } from "../../lib/chat/outbox-store.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { loadChatHistory } from "./chat-history.ts";
 import { makeChatHost } from "./chat-host.test-support.ts";
@@ -155,7 +156,13 @@ describe("chat history cursor revalidation", () => {
         sessionKey,
         sender: { id: "bob-profile", name: "Bob Proof" },
       };
-      expect(admitStoredChatComposerQueueItem(state, sessionKey, queued)).toBe(true);
+      expect(
+        admitStoredChatComposerQueueItem(
+          state,
+          captureChatOutboxAdmission(state, sessionKey, queued.agentId),
+          queued,
+        ),
+      ).toBe(true);
       state.chatQueue = [queued];
       const renderedBobMessages = () =>
         buildChatItems({

--- a/ui/src/pages/chat/chat-outbox-drain.ts
+++ b/ui/src/pages/chat/chat-outbox-drain.ts
@@ -31,7 +31,7 @@ import {
   removeDeliveredQueuedChatSendForRun,
   removeQueuedMessageWithoutReleasing,
   syncVisibleChatQueueProjection,
-  updateQueuedMessageForSession,
+  updateQueuedMessage,
 } from "./chat-queue.ts";
 import type { ChatHost } from "./chat-send-contract.ts";
 import {
@@ -189,7 +189,7 @@ async function readCurrentStoredChatHistory(
     if (item.sendState === targetState && item.sendError === error) {
       return "blocked";
     }
-    const parked = updateQueuedMessageForSession(host, outbox.sessionKey, item.id, (entry) => ({
+    const parked = updateQueuedMessage(host, item.id, (entry) => ({
       ...entry,
       sendError: error,
       sendState: targetState,
@@ -331,7 +331,7 @@ async function reconcileStoredChatOutboxHead(
     if (retryUnconfirmed) {
       return "send";
     }
-    const parked = updateQueuedMessageForSession(host, outbox.sessionKey, item.id, (entry) => ({
+    const parked = updateQueuedMessage(host, item.id, (entry) => ({
       ...entry,
       sendError: UNCONFIRMED_CHAT_SEND_ERROR,
       sendState: "unconfirmed",
@@ -404,7 +404,7 @@ async function drainStoredChatOutbox(
     const visible = visibleSessionMatches(host, outbox.sessionKey, outbox.agentId);
     if (item.localCommandName) {
       const setCommandState = (sendState: ChatQueueItem["sendState"], sendError?: string) =>
-        updateQueuedMessageForSession(host, outbox.sessionKey, item.id, (entry) => ({
+        updateQueuedMessage(host, item.id, (entry) => ({
           ...entry,
           sendError,
           sendState,
@@ -440,7 +440,7 @@ async function drainStoredChatOutbox(
           return "blocked";
         }
         if (confirmation === "cancelled") {
-          if (!removeQueuedMessageWithoutReleasing(host, item.id, outbox.sessionKey)) {
+          if (!removeQueuedMessageWithoutReleasing(host, item.id)) {
             return "blocked";
           }
           continue;
@@ -541,24 +541,18 @@ async function drainStoredChatOutbox(
           const successor = currentIndex >= 0 ? currentOutbox?.queue[currentIndex + 1] : undefined;
           if (
             successor &&
-            !updateQueuedMessageForSession(
-              host,
-              outbox.sessionKey,
-              successor.id,
-              (entry) => ({
-                ...entry,
-                sendError: UNCERTAIN_CLEAR_SUCCESSOR_ERROR,
-                sendState: "unconfirmed",
-              }),
-              outbox.agentId,
-            )
+            !updateQueuedMessage(host, successor.id, (entry) => ({
+              ...entry,
+              sendError: UNCERTAIN_CLEAR_SUCCESSOR_ERROR,
+              sendState: "unconfirmed",
+            }))
           ) {
             dependencies.setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
             // Keep the claimed clear row as the reload-safe barrier.
             return "blocked";
           }
         }
-        if (!removeQueuedMessageWithoutReleasing(host, item.id, outbox.sessionKey)) {
+        if (!removeQueuedMessageWithoutReleasing(host, item.id)) {
           surfaceChatDeliveryFailure(
             host,
             outbox.sessionKey,

--- a/ui/src/pages/chat/chat-outbox-owner.ts
+++ b/ui/src/pages/chat/chat-outbox-owner.ts
@@ -4,13 +4,16 @@ import {
   outboxPayloadMatchesOwner,
   observeOutboxRecoveryOwner,
 } from "../../lib/chat/outbox-payload-store.runtime.ts";
-import { subscribeStoredChatOutboxChanges } from "../../lib/chat/outbox-store.ts";
+import {
+  applyStoredChatOutboxScope,
+  subscribeStoredChatOutboxChanges,
+} from "../../lib/chat/outbox-store.ts";
+import { resolveUiConversationIdentity } from "../../lib/sessions/session-key.ts";
 import { getSafeSessionStorage } from "../../local-storage.ts";
 import { getChatAttachmentDataUrl } from "./attachment-payload-store.ts";
 import {
   listStoredChatOutboxes,
   updateStoredChatComposerQueueItem,
-  resolveStoredChatOutboxScope,
   storedChatOutboxScopeKey,
   type ChatComposerScope as Composer,
   type StoredChatOutboxScope as Scope,
@@ -22,7 +25,7 @@ import {
 } from "./outbox-payloads.ts";
 type Host = Composer & { chatQueue: ChatQueueItem[]; sessionKey: string; requestUpdate?(): void };
 type HostProjection = {
-  byScope: Map<string, ChatQueueItem[]>;
+  byScope: Map<string, { scope: Scope; queue: ChatQueueItem[] }>;
   durableSeen: Set<string>;
   retryable: Set<string>;
 };
@@ -51,14 +54,14 @@ class ChatOutboxGatewayOwner {
     if (existing) {
       return existing;
     }
-    const scope = resolveStoredChatOutboxScope(host, host.sessionKey);
+    const scope = resolveUiConversationIdentity(host, host.sessionKey);
     const durableSeen = new Set(this.outbox(host, scope)?.queue.map((item) => item.id));
     const created: HostProjection = { byScope: new Map(), durableSeen, retryable: new Set() };
     if (host.chatQueue.length) {
-      created.byScope.set(
-        storedChatOutboxScopeKey(scope),
-        host.chatQueue.filter((item) => outboxPayloadMatchesOwner(host, item)),
-      );
+      created.byScope.set(storedChatOutboxScopeKey(scope), {
+        scope,
+        queue: host.chatQueue.filter((item) => outboxPayloadMatchesOwner(host, item)),
+      });
     }
     this.hosts.set(host, created);
     return created;
@@ -70,6 +73,17 @@ class ChatOutboxGatewayOwner {
   }
   durable(host: Composer, id: string) {
     return listStoredChatOutboxes(host).find(({ queue }) => queue.some((item) => item.id === id));
+  }
+  locate(host: Host, id: string) {
+    const outbox = this.durable(host, id);
+    const captured = outbox ?? this.local(this.state(host), id)?.scope;
+    if (!captured) {
+      return undefined;
+    }
+    const { sessionKey, agentId } = captured;
+    const scope = { sessionKey, agentId };
+    const item = this.snapshot(host, scope, outbox?.queue ?? []).find((row) => row.id === id);
+    return item ? { item, scope, durable: outbox?.queue.find((row) => row.id === id) } : undefined;
   }
   private project(item: ChatQueueItem, local: ChatQueueItem): ChatQueueItem {
     const projected: ChatQueueItem = { ...item };
@@ -93,7 +107,7 @@ class ChatOutboxGatewayOwner {
   ): ChatQueueItem[] {
     const key = storedChatOutboxScopeKey(scope);
     const state = this.state(host);
-    const local = state.byScope.get(key) ?? [];
+    const local = state.byScope.get(key)?.queue ?? [];
     const localById = new Map(local.map((item) => [item.id, item]));
     const visible = durable.map((item) => {
       state.durableSeen.add(item.id);
@@ -118,7 +132,7 @@ class ChatOutboxGatewayOwner {
       return;
     }
     observeOutboxRecoveryOwner(host);
-    host.chatQueue = this.snapshot(host, resolveStoredChatOutboxScope(host, host.sessionKey));
+    host.chatQueue = this.snapshot(host, resolveUiConversationIdentity(host, host.sessionKey));
     for (const item of host.chatQueue) {
       const key = item.attachmentPayload?.key;
       if (
@@ -257,22 +271,22 @@ class ChatOutboxGatewayOwner {
       listStoredChatOutboxes(host).flatMap((outbox) => outbox.queue.map((item) => item.id)),
     );
     durableIds.forEach((id) => state.durableSeen.add(id));
-    for (const [key, queue] of state.byScope) {
-      state.byScope.set(
-        key,
-        queue.filter((item) => durableIds.has(item.id) || isActiveLocal(state, item)),
+    for (const local of state.byScope.values()) {
+      local.queue = local.queue.filter(
+        (item) => durableIds.has(item.id) || isActiveLocal(state, item),
       );
     }
   }
   replace(
     host: Host,
-    scope: Scope,
+    { sessionKey, agentId }: Scope,
     queue: ChatQueueItem[],
     options: { requestUpdate?: boolean } = {},
   ): void {
+    const scope = { sessionKey, agentId };
     const state = this.state(host);
     const key = storedChatOutboxScopeKey(scope);
-    const previous = state.byScope.get(key) ?? [];
+    const previous = state.byScope.get(key)?.queue ?? [];
     const previousById = new Map(previous.map((item) => [item.id, item]));
     const retainedIds = new Set(queue.map((item) => item.id));
     for (const item of previous) {
@@ -281,29 +295,30 @@ class ChatOutboxGatewayOwner {
       }
     }
     this.outbox(host, scope)?.queue.forEach((item) => state.durableSeen.add(item.id));
-    state.byScope.set(
-      key,
-      queue.map((item) => this.project(item, previousById.get(item.id) ?? item)),
-    );
+    state.byScope.set(key, {
+      scope,
+      queue: queue.map((item) => this.project(item, previousById.get(item.id) ?? item)),
+    });
     this.syncHost(host, options);
   }
-  keep(host: Host, scope: Scope, item: ChatQueueItem, retryable = false): void {
+  keep(host: Host, { sessionKey, agentId }: Scope, item: ChatQueueItem, retryable = false): void {
+    const scope = { sessionKey, agentId };
     const state = this.state(host);
     const key = storedChatOutboxScopeKey(scope);
-    const queue = (state.byScope.get(key) ?? []).filter((entry) => entry.id !== item.id);
-    queue.push({ ...item, ...scope });
+    const queue = (state.byScope.get(key)?.queue ?? []).filter((entry) => entry.id !== item.id);
+    queue.push(applyStoredChatOutboxScope(item, scope));
     queue.sort(compareChatQueueOrder);
-    state.byScope.set(key, queue);
+    state.byScope.set(key, { scope, queue });
     if (retryable) {
       state.retryable.add(item.id);
     }
     this.syncHost(host);
   }
   private local(state: HostProjection, id: string) {
-    for (const [key, queue] of state.byScope) {
+    for (const { scope, queue } of state.byScope.values()) {
       const index = queue.findIndex((item) => item.id === id);
       if (index >= 0) {
-        return { key, queue, index };
+        return { scope, queue, index };
       }
     }
     return undefined;
@@ -337,7 +352,6 @@ class ChatOutboxGatewayOwner {
       match.queue[match.index] = this.project(stored, current);
     } else {
       match.queue.splice(match.index, 1);
-      state.byScope.set(match.key, match.queue);
     }
     this.syncHost(host);
     return current;
@@ -384,7 +398,7 @@ class ChatOutboxGatewayOwner {
     const durable = listStoredChatOutboxes(host).flatMap((outbox) =>
       this.snapshot(host, outbox, outbox.queue),
     );
-    const local = [...this.state(host).byScope.values()].flat();
+    const local = [...this.state(host).byScope.values()].flatMap(({ queue }) => queue);
     // The snapshot already merges durable and live state. A stale pane-local
     // copy must not hide its sending overlay during connection retirement.
     const items = new Map([...local, ...durable].map((item) => [item.id, item]));
@@ -394,7 +408,7 @@ class ChatOutboxGatewayOwner {
   private prune(host: Host): void {
     const state = this.hosts.get(host);
     if (state && !this.panes.has(host)) {
-      const active = [...state.byScope.values()].some((queue) =>
+      const active = [...state.byScope.values()].some(({ queue }) =>
         queue.some((item) => isActiveLocal(state, item)),
       );
       if (!active && !this.live.size) {

--- a/ui/src/pages/chat/chat-outbox-recovery.ts
+++ b/ui/src/pages/chat/chat-outbox-recovery.ts
@@ -9,11 +9,11 @@ import {
   type ChatOutboxRecoveryEntry,
 } from "../../lib/chat/outbox-recovery.ts";
 import {
-  resolveStoredChatOutboxScope,
   storageTargetForGateway,
   storedChatOutboxScopeKey,
   subscribeStoredChatOutboxChanges,
 } from "../../lib/chat/outbox-store.ts";
+import { resolveUiConversationIdentity } from "../../lib/sessions/session-key.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 
 const draftStore = import("../../lib/chat/composer-draft-store.runtime.ts");
@@ -116,7 +116,7 @@ class ChatOutboxRecovery extends LitElement {
         this.error = t("chat.outboxRecoveryConflict");
         return;
       }
-      const scope = resolveStoredChatOutboxScope(host, host.sessionKey);
+      const scope = resolveUiConversationIdentity(host, host.sessionKey);
       const destination = captureChatOutboxRecoveryDestination(host, scope);
       const durableScope = { ...owner, scopeKey: `chat:v3:${storedChatOutboxScopeKey(scope)}` };
       const store = await draftStore;

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
@@ -1,11 +1,11 @@
-/* @vitest-environment jsdom */
-
 import { describe, expect, it } from "vitest";
+/* @vitest-environment jsdom */
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { createChatAttachmentHandoff } from "../../app/chat-attachment-handoff.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
+import { resolveUiConversationIdentity } from "../../lib/sessions/session-key.ts";
 import {
   getChatAttachmentDataUrl,
   registerChatAttachmentPayload,
@@ -20,7 +20,7 @@ import {
 } from "./chat-pane-attachment-handoff.ts";
 import { createTestChatPane } from "./chat-pane.test-support.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
-import { resolveStoredChatOutboxScope, storedChatOutboxScopeKey } from "./composer-persistence.ts";
+import { storedChatOutboxScopeKey } from "./composer-persistence.ts";
 import type { ChatSplitLayout } from "./split-layout-types.ts";
 
 function storedAttachment(id: string, mimeType = "image/png"): ChatAttachment {
@@ -107,7 +107,7 @@ describe("staged chat attachment pane handoff", () => {
       activePaneId: "p2",
     } satisfies ChatSplitLayout;
     const scopeKey = storedChatOutboxScopeKey(
-      resolveStoredChatOutboxScope(current, current.sessionKey),
+      resolveUiConversationIdentity(current, current.sessionKey),
     );
 
     closeStagedPane(pane.context, root, layout, pane.paneId);
@@ -145,7 +145,7 @@ describe("staged chat attachment pane handoff", () => {
     const reopened = storedAttachment("reopened");
     current.chatAttachments = [reopened];
     const scopeKey = storedChatOutboxScopeKey(
-      resolveStoredChatOutboxScope(current, current.sessionKey),
+      resolveUiConversationIdentity(current, current.sessionKey),
     );
 
     pane.disconnectedCallback();
@@ -249,7 +249,9 @@ describe("staged chat attachment pane handoff", () => {
     handoff.prepare({
       owner,
       paneId: "p1",
-      scopeKey: storedChatOutboxScopeKey(resolveStoredChatOutboxScope(remount, remount.sessionKey)),
+      scopeKey: storedChatOutboxScopeKey(
+        resolveUiConversationIdentity(remount, remount.sessionKey),
+      ),
       attachments: [],
       fallbacks: {
         collision: {

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.ts
@@ -1,11 +1,12 @@
 import type { ApplicationContext } from "../../app/context.ts";
 import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
+import { resolveUiConversationIdentity } from "../../lib/sessions/session-key.ts";
 import {
   releaseChatAttachmentPayloads,
   releaseDisplacedChatAttachmentPayloads,
 } from "./attachment-payload-store.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
-import { resolveStoredChatOutboxScope, storedChatOutboxScopeKey } from "./composer-persistence.ts";
+import { storedChatOutboxScopeKey } from "./composer-persistence.ts";
 import type { ChatSplitLayout } from "./split-layout-types.ts";
 import { panesOf, visiblePanesOf } from "./split-layout.ts";
 
@@ -15,7 +16,7 @@ function handoffKey(paneId: string, state: ChatPageHost, owner: ChatAttachmentGa
   return {
     owner,
     paneId,
-    scopeKey: storedChatOutboxScopeKey(resolveStoredChatOutboxScope(state, state.sessionKey)),
+    scopeKey: storedChatOutboxScopeKey(resolveUiConversationIdentity(state, state.sessionKey)),
   };
 }
 

--- a/ui/src/pages/chat/chat-pane-browser-annotation-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-browser-annotation-lifecycle.test.ts
@@ -1,11 +1,11 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
 /* @vitest-environment jsdom */
 /* @vitest-environment-options {"url":"http://chat-pane-browser-annotation-lifecycle.test/"} */
-
-import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import type { BrowserAnnotationDraft } from "../../components/browser/browser-annotation.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
+import { resolveUiConversationIdentity } from "../../lib/sessions/session-key.ts";
 import {
   cloneChatAttachmentsForIndependentOwner,
   getChatAttachmentDataUrl,
@@ -17,7 +17,7 @@ import {
   createTestChatPane,
   type TestChatPane,
 } from "./chat-pane.test-support.ts";
-import { resolveStoredChatOutboxScope, storedChatOutboxScopeKey } from "./composer-persistence.ts";
+import { storedChatOutboxScopeKey } from "./composer-persistence.ts";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -114,7 +114,7 @@ describe("staged attachment composer adoption", () => {
       },
     };
     const scopeKey = storedChatOutboxScopeKey(
-      resolveStoredChatOutboxScope(state, state.sessionKey),
+      resolveUiConversationIdentity(state, state.sessionKey),
     );
 
     pane.disconnectedCallback();
@@ -155,7 +155,7 @@ describe("staged attachment composer adoption", () => {
     const ordinary = storedAttachment("late-dispose-ordinary", false);
     state.chatAttachments.push(ordinary);
     const scopeKey = storedChatOutboxScopeKey(
-      resolveStoredChatOutboxScope(state, state.sessionKey),
+      resolveUiConversationIdentity(state, state.sessionKey),
     );
     pane.context.chatAttachmentHandoff.dispose();
 

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -1,13 +1,11 @@
-import "./chat-outbox-recovery.ts";
 import { html, nothing } from "lit";
+import "./chat-outbox-recovery.ts";
 import type { SessionObserverDigest } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { isDesktopPanelAvailable } from "../../app/panel-availability.ts";
 import { latestBrowserTabCards } from "../../lib/chat/browser-tab-preview.ts";
-import {
-  resolveStoredChatOutboxScope,
-  storedChatOutboxScopeKey,
-} from "../../lib/chat/outbox-store.ts";
+import { storedChatOutboxScopeKey } from "../../lib/chat/outbox-store.ts";
+import { resolveUiConversationIdentity } from "../../lib/sessions/session-key.ts";
 import { ChatPaneBrowserAnnotationRender } from "./chat-pane-browser-annotation-render.ts";
 import {
   availableSidebarSlots,
@@ -86,7 +84,7 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       .identity=${JSON.stringify([
         state.settings.gatewayUrl,
         state.connected && state.client?.recoveryScopeReady ? state.client.recoveryScope : null,
-        storedChatOutboxScopeKey(resolveStoredChatOutboxScope(state, state.sessionKey)),
+        storedChatOutboxScopeKey(resolveUiConversationIdentity(state, state.sessionKey)),
       ])}
       @outbox-restored=${() => {
         this.chatState.restoreComposer();

--- a/ui/src/pages/chat/chat-pending-inputs.test.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.test.ts
@@ -5,7 +5,10 @@ import type { ChatPendingInputsPage } from "../../../../packages/gateway-protoco
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import * as outboxPayloadStore from "../../lib/chat/outbox-payload-store.runtime.ts";
-import { storageTargetForGateway } from "../../lib/chat/outbox-store.ts";
+import {
+  captureChatOutboxAdmission,
+  storageTargetForGateway,
+} from "../../lib/chat/outbox-store.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { getChatHistoryLoadState, loadChatHistory } from "./chat-history.ts";
 import { makeChatHost } from "./chat-host.test-support.ts";
@@ -48,7 +51,12 @@ async function retainDeliveredUserTurn(
   host: Parameters<typeof retireDeliveredQueuedUserTurn>[0],
   item: ChatQueueItem,
 ): Promise<void> {
-  expect(admitQueuedMessageForSession(host, item.sessionKey ?? host.sessionKey, item)).toBe(true);
+  const admission = captureChatOutboxAdmission(
+    host,
+    item.sessionKey ?? host.sessionKey,
+    item.agentId,
+  );
+  expect(admitQueuedMessageForSession(host, admission, item)).toBe(true);
   const outbox = expectDefined(
     listStoredChatOutboxes(host).find((entry) =>
       entry.queue.some((queued) => queued.id === item.id),
@@ -502,7 +510,13 @@ describe("server-owned pending input display", () => {
         expect(stored.value).toHaveLength(1);
         expect(Buffer.from(await stored.value[0]!.blob.arrayBuffer())).toEqual(imageBytes);
       }
-      expect(admitQueuedMessageForSession(host, sessionKey, queued)).toBe(true);
+      expect(
+        admitQueuedMessageForSession(
+          host,
+          captureChatOutboxAdmission(host, sessionKey, queued.agentId),
+          queued,
+        ),
+      ).toBe(true);
       expect(
         loadChatComposerSnapshot(host, sessionKey)?.queue[0]?.attachments?.[0]?.dataUrl,
       ).toBeUndefined();

--- a/ui/src/pages/chat/chat-queue-reorder.test.ts
+++ b/ui/src/pages/chat/chat-queue-reorder.test.ts
@@ -1,6 +1,8 @@
 /* @vitest-environment jsdom */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadSettings } from "../../app/settings.ts";
 import type { ChatQueueItem } from "../../lib/chat/chat-types.ts";
+import { captureChatOutboxAdmission } from "../../lib/chat/outbox-store.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { makeChatHost } from "./chat-host.test-support.ts";
 import { admitQueuedMessageForSession, subscribeChatOutboxProjection } from "./chat-queue.ts";
@@ -22,18 +24,31 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-function queueHost(items: readonly Partial<ChatQueueItem>[]) {
-  const host = makeChatHost({ sessionKey: SESSION_KEY, connected: false });
+function queueHost(items: readonly Partial<ChatQueueItem>[], sessionKey = SESSION_KEY) {
+  const host = makeChatHost({
+    sessionKey,
+    connected: false,
+    agentsList: {
+      defaultId: "main",
+      mainKey: "main",
+      scope: "per-sender",
+      agents: [{ id: "main" }],
+    },
+  });
   const unsubscribe = subscribeChatOutboxProjection(host as never);
   items.forEach((item, index) => {
-    const admitted = admitQueuedMessageForSession(host as never, SESSION_KEY, {
-      id: `queued-${index + 1}`,
-      text: `message ${index + 1}`,
-      createdAt: 1_000 + index,
-      sendState: "waiting-reconnect",
-      sessionKey: SESSION_KEY,
-      ...item,
-    });
+    const admitted = admitQueuedMessageForSession(
+      host as never,
+      captureChatOutboxAdmission(host, sessionKey, item.agentId),
+      {
+        id: `queued-${index + 1}`,
+        text: `message ${index + 1}`,
+        createdAt: 1_000 + index,
+        sendState: "waiting-reconnect",
+        sessionKey,
+        ...item,
+      },
+    );
     expect(admitted).toBe(true);
   });
   return { host, unsubscribe };
@@ -45,6 +60,36 @@ function storedOrder(host: unknown): string[] {
 }
 
 describe("queued message reorder", () => {
+  it("reorders the captured inactive outbox after current main defaults change", () => {
+    const { host: fixture, unsubscribe } = queueHost([{}, {}], "agent:main:main");
+    const host = Object.assign(fixture, {
+      settings: {
+        ...loadSettings(),
+        ...fixture.settings,
+        gatewayUrl: fixture.settings.gatewayUrl ?? "",
+      },
+    });
+    try {
+      host.sessionKey = "agent:main:other";
+      host.agentsList = {
+        defaultId: "main",
+        mainKey: "workspace",
+        scope: "per-sender",
+        agents: [{ id: "main" }],
+      };
+      expect(moveQueuedChatMessage(host, "queued-2", 0)).toBe("moved");
+      expect(listStoredChatOutboxes(host)).toMatchObject([
+        {
+          sessionKey: "agent:main:main",
+          agentId: "main",
+          queue: [{ id: "queued-2" }, { id: "queued-1" }],
+        },
+      ]);
+    } finally {
+      unsubscribe();
+    }
+  });
+
   it("moves a row to the head of both the visible queue and the stored outbox", () => {
     const { host, unsubscribe } = queueHost([{}, {}, {}]);
 

--- a/ui/src/pages/chat/chat-queue.ts
+++ b/ui/src/pages/chat/chat-queue.ts
@@ -1,9 +1,10 @@
 // Control UI page module owns Chat queue storage and queue item cleanup.
 import { compareChatQueueOrder, isMovableChatQueueItem } from "../../lib/chat/chat-queue-order.ts";
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
-import { captureChatOutboxAdmission } from "../../lib/chat/outbox-store.ts";
+import type { captureChatOutboxAdmission } from "../../lib/chat/outbox-store.ts";
 import type { SenderIdentity } from "../../lib/chat/sender-label.ts";
 import { scopedAgentIdForSession, type SessionScopeHost } from "../../lib/sessions/index.ts";
+import { resolveUiConversationIdentity } from "../../lib/sessions/session-key.ts";
 import { generateUUID } from "../../lib/uuid.ts";
 import { releaseChatAttachmentPayloads } from "./attachment-payload-store.ts";
 import { chatOutboxOwner } from "./chat-outbox-owner.ts";
@@ -11,7 +12,6 @@ import {
   admitStoredChatComposerQueueItem,
   listStoredChatOutboxes,
   removeStoredChatComposerQueueItem,
-  resolveStoredChatOutboxScope,
   storedChatOutboxScopeKey,
   updateStoredChatComposerQueueItem,
   updateStoredChatComposerQueueItems,
@@ -77,7 +77,7 @@ export function keepVolatileQueuedMessage(
   agentId?: string,
   options: { retryable?: boolean } = {},
 ): void {
-  const scope = resolveStoredChatOutboxScope(host, sessionKey, agentId ?? item.agentId);
+  const scope = resolveUiConversationIdentity(host, sessionKey, agentId ?? item.agentId);
   chatOutboxOwner(host).keep(host, scope, item, options.retryable);
 }
 
@@ -145,7 +145,7 @@ export function readChatQueueForScope(
   sessionKey: string,
   agentId?: string,
 ): ChatQueueItem[] {
-  const scope = resolveStoredChatOutboxScope(host, sessionKey, agentId);
+  const scope = resolveUiConversationIdentity(host, sessionKey, agentId);
   return chatOutboxOwner(host).snapshot(host, scope);
 }
 
@@ -156,7 +156,7 @@ function writeChatQueueForScope(
   agentId?: string,
   options: { requestUpdate?: boolean } = {},
 ) {
-  const scope = resolveStoredChatOutboxScope(host, sessionKey, agentId);
+  const scope = resolveUiConversationIdentity(host, sessionKey, agentId);
   chatOutboxOwner(host).replace(host, scope, queue, options);
 }
 
@@ -164,19 +164,7 @@ export function readQueuedMessageById(
   host: ChatQueueScopedSessionHost,
   id: string,
 ): ChatQueueItem | null {
-  return (
-    chatOutboxOwner(host)
-      .allItems(host)
-      .find((item) => item.id === id) ?? null
-  );
-}
-
-export function updateQueuedMessage(
-  host: ChatQueueScopedSessionHost,
-  id: string,
-  update: (item: ChatQueueItem) => ChatQueueItem,
-): ChatQueueItem | null {
-  return updateQueuedMessageForSession(host, host.sessionKey, id, update);
+  return chatOutboxOwner(host).locate(host, id)?.item ?? null;
 }
 
 export function updateVolatileQueuedMessage(
@@ -188,34 +176,23 @@ export function updateVolatileQueuedMessage(
   return chatOutboxOwner(host).change(host, id, update, options.retryable);
 }
 
-export function updateQueuedMessageForSession(
+export function updateQueuedMessage(
   host: ChatQueueScopedSessionHost,
-  sessionKey: string,
   id: string,
   update: (item: ChatQueueItem) => ChatQueueItem,
-  agentId?: string,
 ): ChatQueueItem | null {
   const owner = chatOutboxOwner(host);
-  const stored = owner.durable(host, id);
-  const scope: StoredChatOutboxScope =
-    stored ?? resolveStoredChatOutboxScope(host, sessionKey, agentId);
-  const storedItem = stored?.queue.find((item) => item.id === id);
-  const current = owner.allItems(host).find((item) => item.id === id) ?? storedItem;
-  if (!current) {
+  const located = owner.locate(host, id);
+  if (!located) {
     return null;
   }
+  const { item: current, scope, durable } = located;
   const nextItem = update(current);
-  if (!stored) {
+  if (!durable) {
     return owner.change(host, id, () => nextItem);
   }
   if (
-    !updateStoredChatComposerQueueItem(
-      host,
-      stored.sessionKey,
-      current,
-      nextItem,
-      stored.agentId ?? current.agentId ?? nextItem.agentId,
-    )
+    !updateStoredChatComposerQueueItem(host, scope.sessionKey, current, nextItem, scope.agentId)
   ) {
     if (!isProcessLiveQueueProjection(nextItem)) {
       owner.projectLive(host, scope, id);
@@ -247,7 +224,8 @@ export function updateQueuedMessageForSession(
  */
 type QueuedMessageMoveRow = {
   id: string;
-  stored: StoredChatOutbox | undefined;
+  scope: StoredChatOutboxScope;
+  durable: ChatQueueItem | undefined;
   current: ChatQueueItem;
   next: ChatQueueItem;
 };
@@ -259,16 +237,20 @@ export function updateQueuedMessagesForSession(
   const owner = chatOutboxOwner(host);
   const rows: QueuedMessageMoveRow[] = [];
   for (const { id, update } of updates) {
-    const stored = owner.durable(host, id);
-    const storedItem = stored?.queue.find((item) => item.id === id);
-    const current = owner.allItems(host).find((item) => item.id === id) ?? storedItem;
-    if (!current) {
+    const located = owner.locate(host, id);
+    if (!located) {
       return false;
     }
-    rows.push({ id, stored, current, next: update(current) });
+    rows.push({
+      id,
+      scope: located.scope,
+      durable: located.durable,
+      current: located.item,
+      next: update(located.item),
+    });
   }
-  const durableRows = rows.filter((row) => row.stored);
-  const outbox = durableRows[0]?.stored;
+  const durableRows = rows.filter((row) => row.durable);
+  const outbox = durableRows[0]?.scope;
   if (outbox) {
     const applied = updateStoredChatComposerQueueItems(
       host,
@@ -287,7 +269,7 @@ export function updateQueuedMessagesForSession(
     }
   }
   for (const row of rows) {
-    if (!row.stored) {
+    if (!row.durable) {
       owner.change(host, row.id, () => row.next);
     }
   }
@@ -301,14 +283,13 @@ export function updateQueuedMessagesForSession(
  */
 export function admitQueuedMessageForSession(
   host: ChatQueueScopedSessionHost,
-  sessionKey: string,
+  captured: ReturnType<typeof captureChatOutboxAdmission>,
   item: ChatQueueItem,
   replaces?: StoredChatQueueReplacement,
-  captured = captureChatOutboxAdmission(host, sessionKey, item.agentId),
 ): boolean {
   const owner = chatOutboxOwner(host);
   owner.keep(host, captured.scope, item);
-  if (!admitStoredChatComposerQueueItem(host, sessionKey, item, item.agentId, replaces, captured)) {
+  if (!admitStoredChatComposerQueueItem(host, captured, item, replaces)) {
     return false;
   }
   if (item.sendState !== "waiting-model") {
@@ -320,39 +301,32 @@ export function admitQueuedMessageForSession(
 export function removeQueuedMessageWithoutReleasing(
   host: ChatQueueScopedSessionHost,
   id: string,
-  sessionKey = host.sessionKey,
-  agentId?: string,
 ): ChatQueueItem | null {
   const owner = chatOutboxOwner(host);
-  const stored = owner.durable(host, id);
-  const scope: StoredChatOutboxScope =
-    stored ?? resolveStoredChatOutboxScope(host, sessionKey, agentId);
-  const storedItem = stored?.queue.find((entry) => entry.id === id) ?? null;
-  const item = owner.allItems(host).find((entry) => entry.id === id) ?? storedItem;
-  if (item && !owner.mayRemove(host, scope, id)) {
+  const located = owner.locate(host, id);
+  if (located && !owner.mayRemove(host, located.scope, id)) {
     owner.syncHost(host);
     return null;
   }
   if (
-    item &&
-    stored &&
+    located?.durable &&
     !removeStoredChatComposerQueueItem(
       host,
-      stored.sessionKey,
+      located.scope.sessionKey,
       id,
-      item,
-      stored.agentId ?? item.agentId,
+      located.item,
+      located.scope.agentId,
     )
   ) {
     owner.syncHost(host);
     return null;
   }
-  if (item) {
-    owner.projectLive(host, scope, id);
+  if (located) {
+    owner.projectLive(host, located.scope, id);
     owner.change(host, id);
   }
   owner.publish(undefined, true);
-  return item;
+  return located?.item ?? null;
 }
 
 export function removeVisibleOrScopedQueuedMessageWithoutReleasing(
@@ -362,7 +336,7 @@ export function removeVisibleOrScopedQueuedMessageWithoutReleasing(
 ): ChatQueueItem | null {
   return (
     removeQueuedMessageWithoutReleasing(host, id) ??
-    (sessionKey ? removeQueuedMessageWithoutReleasing(host, id, sessionKey) : null)
+    (sessionKey ? removeQueuedMessageWithoutReleasing(host, id) : null)
   );
 }
 
@@ -395,12 +369,7 @@ export function removeDeliveredQueuedChatSendForRun(
   if (!match) {
     return null;
   }
-  const removed = removeQueuedMessageWithoutReleasing(
-    host,
-    match.item.id,
-    match.outbox.sessionKey,
-    match.outbox.agentId,
-  );
+  const removed = removeQueuedMessageWithoutReleasing(host, match.item.id);
   if (!removed) {
     return null;
   }
@@ -455,15 +424,9 @@ export function markQueuedChatSendsWaitingForReconnect(host: ChatQueueScopedSess
       }));
       continue;
     }
-    updateQueuedMessageForSession(
-      host,
-      item.sessionKey ?? host.sessionKey,
-      item.id,
-      (current) => ({
-        ...current,
-        sendState: "waiting-reconnect",
-      }),
-      item.agentId,
-    );
+    updateQueuedMessage(host, item.id, (current) => ({
+      ...current,
+      sendState: "waiting-reconnect",
+    }));
   }
 }

--- a/ui/src/pages/chat/chat-reset-delivery.ts
+++ b/ui/src/pages/chat/chat-reset-delivery.ts
@@ -38,17 +38,14 @@ export function createResetSlashCommandSender(
     if (item) {
       publishPendingSendMessage(host, item);
     }
-    if (
-      !item ||
-      !admitQueuedMessageForSession(host, host.sessionKey, item, undefined, pending?.admission)
-    ) {
+    if (!pending || !admitQueuedMessageForSession(host, pending.admission, pending.item)) {
       if (item) {
         cancelChatDelivery(host, item, { previousDraft: options.previousDraft });
       }
       setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
       return;
     }
-    await deliverChatQueueItem(host, item, {
+    await deliverChatQueueItem(host, pending.item, {
       previousDraft: options.previousDraft,
       restoreDraft: options.restoreDraft,
       routingSessionKey: host.sessionKey,

--- a/ui/src/pages/chat/chat-send-actions.ts
+++ b/ui/src/pages/chat/chat-send-actions.ts
@@ -7,6 +7,7 @@ import {
   reorderChatQueueItems,
 } from "../../lib/chat/chat-queue-order.ts";
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
+import { hasUiSessionDefaults } from "../../lib/sessions/session-key.ts";
 import { generateUUID } from "../../lib/uuid.ts";
 import { loadChatBranches, loadChatHistory, type ChatState } from "./chat-history.ts";
 import {
@@ -18,7 +19,6 @@ import { chatOutboxOwner } from "./chat-outbox-owner.ts";
 import {
   admitQueuedMessageForSession,
   isVolatileQueuedMessage,
-  readChatQueueForScope,
   readQueuedMessageById,
   updateQueuedMessage,
   updateQueuedMessagesForSession,
@@ -165,16 +165,16 @@ export function moveQueuedChatMessage(
   id: string,
   toIndex: number,
 ): ChatQueueMoveResult {
-  const item = readQueuedMessageById(host, id);
-  if (!item || !isMovableChatQueueItem(item)) {
+  const owner = chatOutboxOwner(host);
+  const located = owner.locate(host, id);
+  if (!located || !isMovableChatQueueItem(located.item)) {
     return "noop";
   }
   if (isQueuedMessageBeingEdited(host, id)) {
     setChatError(host, QUEUED_MESSAGE_REORDER_CONFLICT_ERROR);
     return "rejected";
   }
-  const sessionKey = item.sessionKey ?? host.sessionKey;
-  const scope = readChatQueueForScope(host, sessionKey, item.agentId);
+  const scope = owner.snapshot(host, located.scope);
   // This pane already excludes its own edited row from rendered move indices,
   // but cannot see edits owned by peers. Rebuild that exact offered index space
   // so a peer-edit barrier is distinguishable from an ordinary no-op.
@@ -243,10 +243,15 @@ export async function retryQueuedChatMessage(host: ChatHost, id: string) {
   ) {
     return;
   }
-  let outbox = chatOutboxOwner(host).durable(host, item.id);
-  if (!outbox) {
+  const owner = chatOutboxOwner(host);
+  const located = owner.locate(host, item.id);
+  if (!located) {
+    return;
+  }
+  if (!located.durable) {
     const wasVolatile = isVolatileQueuedMessage(host, item.id);
-    if (!admitQueuedMessageForSession(host, item.sessionKey ?? host.sessionKey, item)) {
+    const admission = { scope: located.scope, awaitingDefaults: !hasUiSessionDefaults(host) };
+    if (!admitQueuedMessageForSession(host, admission, item)) {
       if (
         wasVolatile &&
         !item.localCommandName &&
@@ -278,11 +283,12 @@ export async function retryQueuedChatMessage(host: ChatHost, id: string) {
     setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
     return;
   }
-  outbox = chatOutboxOwner(host).durable(host, retry.id);
-  if (!outbox) {
+  const retried = owner.locate(host, retry.id);
+  if (!retried?.durable) {
     setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
     return;
   }
+  const outbox = retried.scope;
   const explicitAdmission = retry.queueMode || retriesFailedDelivery || retriesUnconfirmed;
   const drain = scheduleStoredChatOutboxDrain(
     host,

--- a/ui/src/pages/chat/chat-send-delivery.ts
+++ b/ui/src/pages/chat/chat-send-delivery.ts
@@ -23,7 +23,7 @@ import {
   excludeComposerAttachments,
   readQueuedMessageById,
   removeQueuedMessageWithoutReleasing,
-  updateQueuedMessageForSession,
+  updateQueuedMessage,
 } from "./chat-queue.ts";
 import { createResetSlashCommandSender } from "./chat-reset-delivery.ts";
 import { isTerminalFailureChatSendAck } from "./chat-send-ack.ts";
@@ -80,7 +80,7 @@ async function settleDeliverySettings(
   consumed: Set<Promise<boolean>>,
 ): Promise<ChatQueueItem | QueuedChatSendResult> {
   const route = options?.routingSessionKey ?? queueSessionKey;
-  const setState = deliveryStateWriter(host, storageMode, queueSessionKey, item.id);
+  const setState = deliveryStateWriter(host, storageMode, item.id);
   const routeVisible = (agentId = item.agentId) => visibleSessionMatches(host, route, agentId);
   let current = readQueuedMessageById(host, item.id);
   let pendingSettings =
@@ -119,14 +119,12 @@ function publishSettledDeliverySettings(
   host: ChatHost,
   item: ChatQueueItem,
   storageMode: QueuedChatStorageMode,
-  queueSessionKey: string,
 ): ChatQueueItem | QueuedChatSendResult {
   // Keep one non-drainable durable barrier across the complete picker tail.
   // Publishing earlier can let reconnect race a newer or cancelled selection.
   const current = deliveryStateWriter(
     host,
     storageMode,
-    queueSessionKey,
     item.id,
   )(reconnectSafeQueuedSendState(host));
   if (!current) {
@@ -193,7 +191,7 @@ async function sendQueuedChatMessage(
     return prepared;
   }
   if (consumedSettings.size) {
-    prepared = publishSettledDeliverySettings(host, prepared, storageMode, queueSessionKey);
+    prepared = publishSettledDeliverySettings(host, prepared, storageMode);
     if (typeof prepared === "string") {
       return prepared;
     }
@@ -208,7 +206,7 @@ async function sendQueuedChatMessage(
   if (!prepared.sendRunId || !prepared.sendState) {
     const sessionKey = prepared.sessionKey ?? queuedSessionKey;
     prepared =
-      updateQueuedSendItem(host, storageMode, sessionKey, prepared.id, (item) => ({
+      updateQueuedSendItem(host, storageMode, prepared.id, (item) => ({
         ...item,
         sendAttempts: item.sendAttempts ?? 0,
         sendRunId: item.sendRunId ?? generateUUID(),
@@ -231,11 +229,11 @@ async function sendQueuedChatMessage(
   const message = prepared.intent ? prepared.text : prepared.text.trim();
   const attachments = (queued.attachmentPayload ? queued.attachments : prepared.attachments) ?? [];
   if (!message && attachments.length === 0) {
-    removeQueuedMessageWithoutReleasing(host, id, prepared.sessionKey ?? host.sessionKey);
+    removeQueuedMessageWithoutReleasing(host, id);
     return "sent";
   }
   const sessionKey = prepared.sessionKey ?? host.sessionKey;
-  const setState = deliveryStateWriter(host, storageMode, sessionKey, id);
+  const setState = deliveryStateWriter(host, storageMode, id);
   if (options?.target) {
     const access = readChatResetTargetAccess(host, options.target);
     if (!access.allowed) {
@@ -261,7 +259,7 @@ async function sendQueuedChatMessage(
   const runId = prepared.sendRunId ?? generateUUID();
   const startedAt = Date.now();
   const requestStartedAtMs = controlUiNowMs();
-  const sendingItem = updateQueuedSendItem(host, storageMode, sessionKey, id, (item) => ({
+  const sendingItem = updateQueuedSendItem(host, storageMode, id, (item) => ({
     ...item,
     sendAttempts: (item.sendAttempts ?? 0) + 1,
     sendError: undefined,
@@ -369,7 +367,7 @@ async function sendQueuedChatMessage(
     const retireOnAck = ack.status === "ok" || storageMode === "memory";
     let retirementFailed = false;
     if (retireOnAck) {
-      removeQueuedMessageWithoutReleasing(host, id, sessionKey);
+      removeQueuedMessageWithoutReleasing(host, id);
       retirementFailed = storageMode === "durable" && readQueuedMessageById(host, id) !== null;
     }
     if (isVisible()) {
@@ -478,7 +476,7 @@ async function sendQueuedChatMessage(
         if (restore) {
           cancelChatDelivery(host, prepared, options ?? {});
         } else {
-          updateQueuedSendItem(host, storageMode, sessionKey, id, (item) => ({
+          updateQueuedSendItem(host, storageMode, id, (item) => ({
             ...item,
             ...rollbackAttempt,
             sendError: safelyRejected ? error : UNCONFIRMED_CHAT_SEND_ERROR,
@@ -496,7 +494,7 @@ async function sendQueuedChatMessage(
         });
         return restore ? "failed" : "pending";
       }
-      const waiting = updateQueuedMessageForSession(host, sessionKey, id, (item) => ({
+      const waiting = updateQueuedMessage(host, id, (item) => ({
         ...item,
         ...rollbackAttempt,
         sendError: error,
@@ -507,7 +505,7 @@ async function sendQueuedChatMessage(
         if (restore) {
           cancelChatDelivery(host, prepared, options ?? {});
         } else {
-          updateQueuedMessageForSession(host, sessionKey, id, (item) => ({
+          updateQueuedMessage(host, id, (item) => ({
             ...item,
             sendError: OFFLINE_QUEUE_STORAGE_ERROR,
             sendState: "failed",
@@ -618,7 +616,7 @@ export async function deliverChatQueueItem(
         );
       }
       if (typeof admitted !== "string") {
-        admitted = publishSettledDeliverySettings(host, admitted, storageMode, sessionKey);
+        admitted = publishSettledDeliverySettings(host, admitted, storageMode);
       }
       if (typeof admitted === "string") {
         drainResult = admitted;

--- a/ui/src/pages/chat/chat-send-queue-state.ts
+++ b/ui/src/pages/chat/chat-send-queue-state.ts
@@ -12,7 +12,7 @@ import type {
 import { chatOutboxOwner } from "./chat-outbox-owner.ts";
 import {
   readQueuedMessageById,
-  updateQueuedMessageForSession,
+  updateQueuedMessage,
   updateVolatileQueuedMessage,
 } from "./chat-queue.ts";
 import type { ChatHost } from "./chat-send-contract.ts";
@@ -125,23 +125,21 @@ export function captureChatConnectionOwner(
 export function updateQueuedSendItem(
   host: ChatHost,
   storageMode: QueuedChatStorageMode,
-  sessionKey: string,
   id: string,
   update: (item: ChatQueueItem) => ChatQueueItem,
 ): ChatQueueItem | null {
   return storageMode === "memory"
     ? updateVolatileQueuedMessage(host, id, update, { retryable: true })
-    : updateQueuedMessageForSession(host, sessionKey, id, update);
+    : updateQueuedMessage(host, id, update);
 }
 
 export function deliveryStateWriter(
   host: ChatHost,
   storageMode: QueuedChatStorageMode,
-  sessionKey: string,
   id: string,
 ) {
   return (sendState: ChatQueueItem["sendState"], sendError?: string) =>
-    updateQueuedSendItem(host, storageMode, sessionKey, id, (item) => ({
+    updateQueuedSendItem(host, storageMode, id, (item) => ({
       ...item,
       sendError,
       sendState,
@@ -156,7 +154,7 @@ export function finishChatDeliveryAdmission(
   options?: QueuedChatSendOptions,
 ): ChatQueueItem | QueuedChatSendResult {
   const route = options?.routingSessionKey ?? queueSessionKey;
-  const setState = deliveryStateWriter(host, storageMode, queueSessionKey, item.id);
+  const setState = deliveryStateWriter(host, storageMode, item.id);
   const routeVisible = (agentId = item.agentId) => visibleSessionMatches(host, route, agentId);
   const current = readQueuedMessageById(host, item.id);
   if (!current) {
@@ -249,7 +247,7 @@ export async function prepareQueuedChatPayload(
   }
   if (payload.status === "failed") {
     const failed = failOutboxPayload(current, payload.reason);
-    updateQueuedMessageForSession(host, sessionKey, id, () => failed);
+    updateQueuedMessage(host, id, () => failed);
     surfaceChatDeliveryFailure(host, sessionKey, original.agentId, failed.sendError);
     return "failed";
   }
@@ -258,12 +256,12 @@ export async function prepareQueuedChatPayload(
     hydrated.attachmentPayload?.key !== original.attachmentPayload?.key &&
     hydrated.sendState === "unconfirmed"
   ) {
-    updateQueuedMessageForSession(host, sessionKey, id, () => hydrated);
+    updateQueuedMessage(host, id, () => hydrated);
     return "pending";
   }
   if (
     (!original.attachmentPayload || original.attachmentStorageError) &&
-    !updateQueuedMessageForSession(host, sessionKey, id, () => hydrated)
+    !updateQueuedMessage(host, id, () => hydrated)
   ) {
     if (!original.attachmentPayload) {
       retireOutboxPayload(payload.update);

--- a/ui/src/pages/chat/chat-send-submit.test.ts
+++ b/ui/src/pages/chat/chat-send-submit.test.ts
@@ -2,7 +2,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayRequestError } from "../../api/gateway.ts";
 import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
-import { readStoredOutboxStore, storageTargetForGateway } from "../../lib/chat/outbox-store.ts";
+import {
+  captureChatOutboxAdmission,
+  readStoredOutboxStore,
+  storageTargetForGateway,
+} from "../../lib/chat/outbox-store.ts";
 import { createSessionCapability } from "../../lib/sessions/index.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import {
@@ -233,7 +237,9 @@ describe("structured Goal admission", () => {
     };
     // The same browser persistence owner used on reconnect restores this immutable row.
     const { admitQueuedMessageForSession } = await import("./chat-queue.ts");
-    expect(admitQueuedMessageForSession(host, host.sessionKey, queued)).toBe(true);
+    expect(
+      admitQueuedMessageForSession(host, captureChatOutboxAdmission(host, host.sessionKey), queued),
+    ).toBe(true);
     host.currentSessionId = "incarnation-b";
     host.chatDisplayedLeafEntryId = "leaf-b";
     await retryQueuedChatMessage(host, queued.id);

--- a/ui/src/pages/chat/chat-send-submit.ts
+++ b/ui/src/pages/chat/chat-send-submit.ts
@@ -7,7 +7,9 @@ import { parseSlashCommand } from "../../lib/chat/commands.ts";
 import { extractCompanionCommandQuestion } from "../../lib/chat/companion-question.ts";
 import { resolveCurrentUserIdentity } from "../../lib/chat/current-user-identity.ts";
 import type { ControlUiFollowUpMode } from "../../lib/chat/follow-up-mode.ts";
+import { captureChatOutboxAdmission } from "../../lib/chat/outbox-store.ts";
 import { scopedAgentIdForSession, visibleSessionMatches } from "../../lib/sessions/index.ts";
+import { resolveUiConversationIdentity } from "../../lib/sessions/session-key.ts";
 import {
   getChatAttachmentDataUrl,
   releaseChatAttachmentPayloads,
@@ -57,7 +59,6 @@ import {
 import { recordChatSendTiming } from "./chat-send-timing.ts";
 import { getPendingChatPickerPatch } from "./chat-session.ts";
 import { withChatSubmitGuard } from "./chat-submit-guard.ts";
-import { resolveStoredChatOutboxScope } from "./composer-persistence.ts";
 import {
   recordNonTranscriptInputHistory,
   resetChatInputHistoryNavigation,
@@ -365,7 +366,7 @@ export async function handleSendChat(
         if (messageOverride == null) {
           recordNonTranscriptInputHistory(host, userMessage);
         }
-        const recoveryScope = resolveStoredChatOutboxScope(host, submittedSessionKey);
+        const recoveryScope = resolveUiConversationIdentity(host, submittedSessionKey);
         await sendDetachedCommandMessage(host, message, {
           attachments: deliveredAttachments.length ? deliveredAttachments : undefined,
           recovery: captureChatCommandComposerRecovery(
@@ -394,6 +395,7 @@ export async function handleSendChat(
         }
         const submitKey = chatSubmitKey(host, "local", message, attachmentsToSend);
         await withChatSubmitGuard(host, submitKey, async () => {
+          const admission = captureChatOutboxAdmission(host, host.sessionKey);
           if (messageOverride == null) {
             recordNonTranscriptInputHistory(host, userMessage);
             host.chatMessage = "";
@@ -414,7 +416,7 @@ export async function handleSendChat(
             return;
           }
           queued.sendState = reconnectSafeQueuedSendState(host);
-          if (!admitQueuedMessageForSession(host, host.sessionKey, queued)) {
+          if (!admitQueuedMessageForSession(host, admission, queued)) {
             removeQueuedMessageWithoutReleasing(host, queued.id);
             if (messageOverride == null) {
               host.chatMessage = previousDraft;
@@ -434,7 +436,7 @@ export async function handleSendChat(
         }
         let prevDraft = messageOverride == null ? previousDraft : undefined;
         let recoveryComposer: { draft: string; attachments: ChatAttachment[] } | undefined;
-        const recoveryScope = resolveStoredChatOutboxScope(host, submittedSessionKey);
+        const recoveryScope = resolveUiConversationIdentity(host, submittedSessionKey);
         if (messageOverride == null) {
           recordNonTranscriptInputHistory(host, userMessage);
           if (waitsForPicker) {
@@ -634,7 +636,7 @@ export async function handleSendChat(
     publishPendingSendMessage(host, queued);
     const admittedDurably = admitQueuedMessageForSession(
       host,
-      submittedSessionKey,
+      submission.admission,
       queued,
       resumedEdit
         ? {
@@ -642,7 +644,6 @@ export async function handleSendChat(
             expected: resumedEdit.source,
           }
         : undefined,
-      submission.admission,
     );
     if (resumedEdit) {
       retireEditedQueuedMessageSource(host, admittedDurably, queued.attachments, resumedEdit);

--- a/ui/src/pages/chat/chat-send-support.ts
+++ b/ui/src/pages/chat/chat-send-support.ts
@@ -17,7 +17,7 @@ import {
   readDeliveredQueuedChatSendForRun,
   readQueuedMessageById,
   removeDeliveredQueuedChatSendForRun,
-  updateQueuedMessageForSession,
+  updateQueuedMessage,
 } from "./chat-queue.ts";
 import type { TerminalFailureChatSendAck } from "./chat-send-ack.ts";
 import type { ChatHost } from "./chat-send-contract.ts";
@@ -257,12 +257,8 @@ export function retireDeliveredQueuedUserTurn(
     const reason = result.status === "failed" ? result.reason : "missing";
     // Delivery proof must never become a fresh-send retry because local bytes
     // were unavailable. Keep the same run identity and its no-replay barrier.
-    updateQueuedMessageForSession(
-      host,
-      scope.sessionKey,
-      stored.id,
-      (item) => failOutboxPayload({ ...item, sendState: "unconfirmed" }, reason),
-      scope.agentId,
+    updateQueuedMessage(host, stored.id, (item) =>
+      failOutboxPayload({ ...item, sendState: "unconfirmed" }, reason),
     );
     return "retained";
   });

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -1,6 +1,5 @@
-/* @vitest-environment jsdom */
-
 import { reduceSessionProjection } from "@openclaw/gateway-client/browser";
+/* @vitest-environment jsdom */
 import { expectDefined } from "@openclaw/normalization-core";
 import { render } from "lit";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
@@ -22,6 +21,7 @@ import {
 import { extractText } from "../../lib/chat/message-extract.ts";
 import * as outboxPayloadStore from "../../lib/chat/outbox-payload-store.runtime.ts";
 import {
+  captureChatOutboxAdmission,
   readStoredOutboxStore,
   storageTargetForGateway,
   subscribeStoredChatOutboxChanges,
@@ -31,6 +31,7 @@ import {
   createGatewayHarness,
   sessionsResult as sessionListFixture,
 } from "../../lib/sessions/session-capability.test-support.ts";
+import { resolveUiConversationIdentity } from "../../lib/sessions/session-key.ts";
 import { createResolvedModelPatch } from "../../test-helpers/chat-model.ts";
 import {
   createTestGatewayClient,
@@ -73,7 +74,6 @@ import {
   listStoredChatOutboxes,
   loadChatComposerSnapshot,
   removeStoredChatComposerQueueItem,
-  resolveStoredChatOutboxScope,
   storedChatOutboxScopeKey,
   updateStoredChatComposerQueueItem,
 } from "./composer-persistence.ts";
@@ -110,7 +110,7 @@ function writeChatQueueForScope(
   queue: ChatQueueItem[],
   agentId?: string,
 ): void {
-  const scope = resolveStoredChatOutboxScope(host, sessionKey, agentId);
+  const scope = resolveUiConversationIdentity(host, sessionKey, agentId);
   chatOutboxOwner(host).replace(host, scope, queue);
 }
 
@@ -371,14 +371,12 @@ function eventPayloads(host: TestChatHost, event: string): Array<Record<string, 
 
 function admitHostQueueItems(host: TestChatHost): void {
   for (const item of host.chatQueue) {
-    expect(
-      admitStoredChatComposerQueueItem(
-        host,
-        item.sessionKey ?? host.sessionKey,
-        item,
-        item.agentId,
-      ),
-    ).toBe(true);
+    const admission = captureChatOutboxAdmission(
+      host,
+      item.sessionKey ?? host.sessionKey,
+      item.agentId,
+    );
+    expect(admitStoredChatComposerQueueItem(host, admission, item)).toBe(true);
   }
 }
 
@@ -3709,7 +3707,8 @@ describe("handleSendChat", () => {
       requestHandlers: {},
       chatQueue: [original],
     });
-    expect(admitQueuedMessageForSession(host, original.sessionKey, original)).toBe(true);
+    const originalAdmission = captureChatOutboxAdmission(host, original.sessionKey);
+    expect(admitQueuedMessageForSession(host, originalAdmission, original)).toBe(true);
     const getItem = vi.spyOn(storage, "getItem").mockImplementation(() => {
       throw new DOMException("storage unavailable", "SecurityError");
     });
@@ -3738,7 +3737,8 @@ describe("handleSendChat", () => {
       requestHandlers: {},
       chatQueue: [original],
     });
-    expect(admitQueuedMessageForSession(host, original.sessionKey, original)).toBe(true);
+    const originalAdmission = captureChatOutboxAdmission(host, original.sessionKey);
+    expect(admitQueuedMessageForSession(host, originalAdmission, original)).toBe(true);
     const getItem = vi.spyOn(storage, "getItem").mockImplementation(() => {
       throw new DOMException("storage unavailable", "SecurityError");
     });
@@ -3776,7 +3776,8 @@ describe("handleSendChat", () => {
       chatMessage: "new foreground send",
       chatQueue: [retryItem],
     });
-    expect(admitQueuedMessageForSession(host, retryItem.sessionKey, retryItem)).toBe(true);
+    const retryAdmission = captureChatOutboxAdmission(host, retryItem.sessionKey);
+    expect(admitQueuedMessageForSession(host, retryAdmission, retryItem)).toBe(true);
 
     const foreground = handleSendChat(host);
     await waitForFast(() => expect(host.request).toHaveBeenCalledTimes(1));
@@ -3837,7 +3838,8 @@ describe("handleSendChat", () => {
       sessionKey: "agent:other",
     };
     writeChatQueueForScope(host, replayItem.sessionKey, [replayItem]);
-    expect(admitQueuedMessageForSession(host, replayItem.sessionKey, replayItem)).toBe(true);
+    const replayAdmission = captureChatOutboxAdmission(host, replayItem.sessionKey);
+    expect(admitQueuedMessageForSession(host, replayAdmission, replayItem)).toBe(true);
 
     const replay = retryReconnectableQueuedChatSends(host);
     expect(await raceWithMacrotask(replay)).toBe("pending");
@@ -4135,7 +4137,7 @@ describe("handleSendChat", () => {
       chatStream: "Waiting for approval...",
       sessionKey: "agent:main:first",
     });
-    const scopeKey = storedChatOutboxScopeKey(resolveStoredChatOutboxScope(host, host.sessionKey));
+    const scopeKey = storedChatOutboxScopeKey(resolveUiConversationIdentity(host, host.sessionKey));
     host.chatComposerFallbackByScope = {
       [scopeKey]: {
         message: host.chatMessage,
@@ -4313,7 +4315,7 @@ describe("handleSendChat", () => {
       connectionEpoch: 1,
       sessionKey: "agent:main:first",
     });
-    const scopeKey = storedChatOutboxScopeKey(resolveStoredChatOutboxScope(host, host.sessionKey));
+    const scopeKey = storedChatOutboxScopeKey(resolveUiConversationIdentity(host, host.sessionKey));
     host.chatComposerFallbackByScope = {
       [scopeKey]: {
         message: host.chatMessage,
@@ -4645,7 +4647,8 @@ describe("handleSendChat", () => {
       chatRunId: "active-run",
       settings: { chatFollowUpMode: "steer" },
     });
-    expect(admitQueuedMessageForSession(host, host.sessionKey, older)).toBe(true);
+    const olderAdmission = captureChatOutboxAdmission(host, host.sessionKey);
+    expect(admitQueuedMessageForSession(host, olderAdmission, older)).toBe(true);
 
     await handleSendChat(host);
 
@@ -5028,8 +5031,10 @@ describe("handleSendChat", () => {
     });
     writeChatQueueForScope(host, slowItem.sessionKey, [slowItem]);
     writeChatQueueForScope(host, readyItem.sessionKey, [readyItem]);
-    expect(admitQueuedMessageForSession(host, slowItem.sessionKey, slowItem)).toBe(true);
-    expect(admitQueuedMessageForSession(host, readyItem.sessionKey, readyItem)).toBe(true);
+    const slowAdmission = captureChatOutboxAdmission(host, slowItem.sessionKey);
+    expect(admitQueuedMessageForSession(host, slowAdmission, slowItem)).toBe(true);
+    const readyAdmission = captureChatOutboxAdmission(host, readyItem.sessionKey);
+    expect(admitQueuedMessageForSession(host, readyAdmission, readyItem)).toBe(true);
 
     const resume = retryReconnectableQueuedChatSends(host);
 
@@ -5085,7 +5090,8 @@ describe("handleSendChat", () => {
       sessionKey: inactiveSessionKey,
     };
     writeChatQueueForScope(host, inactiveSessionKey, [inactiveItem]);
-    expect(admitQueuedMessageForSession(host, inactiveSessionKey, inactiveItem)).toBe(true);
+    const inactiveAdmission = captureChatOutboxAdmission(host, inactiveSessionKey);
+    expect(admitQueuedMessageForSession(host, inactiveAdmission, inactiveItem)).toBe(true);
     const resume = retryReconnectableQueuedChatSends(host);
 
     await waitForFast(() => expect(sentSessions).toContain(inactiveSessionKey));
@@ -5145,8 +5151,10 @@ describe("handleSendChat", () => {
     };
     host.chatQueue = [mainItem];
     writeChatQueueForScope(host, "global", [workItem], "work");
-    expect(admitQueuedMessageForSession(host, "global", mainItem)).toBe(true);
-    expect(admitQueuedMessageForSession(host, "global", workItem)).toBe(true);
+    const mainAdmission = captureChatOutboxAdmission(host, "global", mainItem.agentId);
+    expect(admitQueuedMessageForSession(host, mainAdmission, mainItem)).toBe(true);
+    const workAdmission = captureChatOutboxAdmission(host, "global", workItem.agentId);
+    expect(admitQueuedMessageForSession(host, workAdmission, workItem)).toBe(true);
     await host.sessions.refresh({ agentId: "main", force: true });
     expect(host.request).toHaveBeenCalledWith(
       "sessions.list",
@@ -5246,7 +5254,8 @@ describe("handleSendChat", () => {
     const item = createQueuedLocalCommand("shared-local-command", "/think high");
     const firstHost = makeChatHost({ client, chatQueue: [item] });
     const secondHost = makeChatHost({ client, chatQueue: [{ ...item }] });
-    expect(admitQueuedMessageForSession(firstHost, firstHost.sessionKey, item)).toBe(true);
+    const admission = captureChatOutboxAdmission(firstHost, firstHost.sessionKey);
+    expect(admitQueuedMessageForSession(firstHost, admission, item)).toBe(true);
 
     await Promise.all([
       retryReconnectableQueuedChatSends(firstHost),
@@ -5311,7 +5320,8 @@ describe("handleSendChat", () => {
       const stopEditing = subscribeChatOutboxProjection(editing);
       const stopPeer = subscribeChatOutboxProjection(peer);
       try {
-        expect(admitQueuedMessageForSession(editing, editing.sessionKey, item)).toBe(true);
+        const admission = captureChatOutboxAdmission(editing, editing.sessionKey);
+        expect(admitQueuedMessageForSession(editing, admission, item)).toBe(true);
         expect(beginQueuedMessageEdit(editing, item.id)).toBe("started");
         if (credentials === "replaced") {
           vi.spyOn(client, "recoveryScope", "get").mockReturnValue("replacement-recovery-scope");
@@ -5350,7 +5360,8 @@ describe("handleSendChat", () => {
     const peer = makeChatHost({ client, chatQueue: [] });
     const stopHost = subscribeChatOutboxProjection(host);
     let stopPeer = () => {};
-    expect(admitQueuedMessageForSession(host, host.sessionKey, item)).toBe(true);
+    const admission = captureChatOutboxAdmission(host, host.sessionKey);
+    expect(admitQueuedMessageForSession(host, admission, item)).toBe(true);
 
     try {
       const draining = retryReconnectableQueuedChatSends(host);
@@ -5372,7 +5383,8 @@ describe("handleSendChat", () => {
         sessionKey: peer.sessionKey,
       };
       peer.chatQueue = [...peer.chatQueue, peerItem];
-      expect(admitQueuedMessageForSession(peer, peer.sessionKey, peerItem)).toBe(true);
+      const peerAdmission = captureChatOutboxAdmission(peer, peer.sessionKey);
+      expect(admitQueuedMessageForSession(peer, peerAdmission, peerItem)).toBe(true);
       expect(host.chatQueue[0]?.sendState).toBe("executing-command");
       expect(peer.chatQueue[0]?.sendState).toBe("executing-command");
       removeQueuedMessage(peer, peerItem.id);
@@ -5661,7 +5673,8 @@ describe("handleSendChat", () => {
       refreshCurrentSessionTools,
       sessionKey: item.sessionKey,
     });
-    expect(admitQueuedMessageForSession(host, item.sessionKey, item)).toBe(true);
+    const admission = captureChatOutboxAdmission(host, item.sessionKey);
+    expect(admitQueuedMessageForSession(host, admission, item)).toBe(true);
 
     const draining = retryReconnectableQueuedChatSends(host);
     await waitForFast(() => expect(executeSlashCommandMock).toHaveBeenCalledTimes(1));
@@ -5707,7 +5720,8 @@ describe("handleSendChat", () => {
       sessionKey: item.sessionKey,
       refreshCurrentSessionTools: refreshTools,
     });
-    expect(admitQueuedMessageForSession(host, item.sessionKey, item)).toBe(true);
+    const admission = captureChatOutboxAdmission(host, item.sessionKey);
+    expect(admitQueuedMessageForSession(host, admission, item)).toBe(true);
 
     const draining = retryReconnectableQueuedChatSends(host);
     await waitForFast(() => expect(executeSlashCommandMock).toHaveBeenCalledTimes(1));
@@ -5749,7 +5763,8 @@ describe("handleSendChat", () => {
         sessionKey: item.sessionKey,
         refreshCurrentSessionTools: refreshTools,
       });
-      expect(admitQueuedMessageForSession(host, item.sessionKey, item)).toBe(true);
+      const admission = captureChatOutboxAdmission(host, item.sessionKey);
+      expect(admitQueuedMessageForSession(host, admission, item)).toBe(true);
 
       const draining = retryReconnectableQueuedChatSends(host);
       await waitForFast(() => expect(executeSlashCommandMock).toHaveBeenCalledTimes(1));
@@ -5784,7 +5799,8 @@ describe("handleSendChat", () => {
       chatQueue: [item],
       sessionKey: item.sessionKey,
     });
-    expect(admitQueuedMessageForSession(host, item.sessionKey, item)).toBe(true);
+    const admission = captureChatOutboxAdmission(host, item.sessionKey);
+    expect(admitQueuedMessageForSession(host, admission, item)).toBe(true);
 
     const draining = retryReconnectableQueuedChatSends(host);
     await waitForFast(() => expect(executeSlashCommandMock).toHaveBeenCalledTimes(1));
@@ -5818,13 +5834,14 @@ describe("handleSendChat", () => {
       sessionKey: "agent:main",
     };
     const host = makeChatHost({ chatQueue: [item] });
-    expect(admitQueuedMessageForSession(host, host.sessionKey, item)).toBe(true);
+    const admission = captureChatOutboxAdmission(host, host.sessionKey);
+    expect(admitQueuedMessageForSession(host, admission, item)).toBe(true);
 
     expect(
       removeDeliveredQueuedChatSendForRun(
         host,
         item.sendRunId,
-        resolveStoredChatOutboxScope(host, item.sessionKey),
+        resolveUiConversationIdentity(host, item.sessionKey),
       ),
     ).toMatchObject({ id: item.id });
 
@@ -5844,13 +5861,14 @@ describe("handleSendChat", () => {
     };
     const sender = makeChatHost({ chatQueue: [item], sessionKey: item.sessionKey });
     const replacement = makeChatHost({ chatQueue: [], sessionKey: "agent:main:replacement" });
-    expect(admitQueuedMessageForSession(sender, item.sessionKey, item)).toBe(true);
+    const admission = captureChatOutboxAdmission(sender, item.sessionKey);
+    expect(admitQueuedMessageForSession(sender, admission, item)).toBe(true);
 
     expect(
       removeDeliveredQueuedChatSendForRun(
         replacement,
         item.sendRunId,
-        resolveStoredChatOutboxScope(replacement, item.sessionKey),
+        resolveUiConversationIdentity(replacement, item.sessionKey),
       ),
     ).toMatchObject({ id: item.id });
 
@@ -5885,8 +5903,10 @@ describe("handleSendChat", () => {
       pendingSessionMessageReloadSessionKey: null,
       requestUpdate: vi.fn(),
     });
-    expect(admitQueuedMessageForSession(host, selected.sessionKey, selected)).toBe(true);
-    expect(admitQueuedMessageForSession(host, foreign.sessionKey, foreign)).toBe(true);
+    const selectedAdmission = captureChatOutboxAdmission(host, selected.sessionKey);
+    expect(admitQueuedMessageForSession(host, selectedAdmission, selected)).toBe(true);
+    const foreignAdmission = captureChatOutboxAdmission(host, foreign.sessionKey);
+    expect(admitQueuedMessageForSession(host, foreignAdmission, foreign)).toBe(true);
 
     expect(
       handlePageGatewayEvent(asChatPageHost(host), {
@@ -5943,8 +5963,18 @@ describe("handleSendChat", () => {
       pendingSessionMessageReloadSessionKey: null,
       requestUpdate: vi.fn(),
     });
-    expect(admitQueuedMessageForSession(host, selected.sessionKey, selected)).toBe(true);
-    expect(admitQueuedMessageForSession(host, defaultAgent.sessionKey, defaultAgent)).toBe(true);
+    const selectedAdmission = captureChatOutboxAdmission(
+      host,
+      selected.sessionKey,
+      selected.agentId,
+    );
+    expect(admitQueuedMessageForSession(host, selectedAdmission, selected)).toBe(true);
+    const defaultAgentAdmission = captureChatOutboxAdmission(
+      host,
+      defaultAgent.sessionKey,
+      defaultAgent.agentId,
+    );
+    expect(admitQueuedMessageForSession(host, defaultAgentAdmission, defaultAgent)).toBe(true);
 
     expect(
       handlePageGatewayEvent(asChatPageHost(host), {
@@ -6003,7 +6033,8 @@ describe("handleSendChat", () => {
       });
     }
     cacheEmptyChatSnapshot(inactive, item.sessionKey);
-    expect(admitQueuedMessageForSession(visible, item.sessionKey, item)).toBe(true);
+    const admission = captureChatOutboxAdmission(visible, item.sessionKey);
+    expect(admitQueuedMessageForSession(visible, admission, item)).toBe(true);
     const event = {
       event: "chat",
       payload: {
@@ -6302,7 +6333,8 @@ describe("handleSendChat", () => {
       },
       chatQueue: [item],
     });
-    expect(admitQueuedMessageForSession(host, item.sessionKey, item)).toBe(true);
+    const admission = captureChatOutboxAdmission(host, item.sessionKey);
+    expect(admitQueuedMessageForSession(host, admission, item)).toBe(true);
 
     await retryReconnectableQueuedChatSends(host);
 
@@ -6325,7 +6357,8 @@ describe("handleSendChat", () => {
       },
       chatQueue: [item],
     });
-    expect(admitQueuedMessageForSession(host, host.sessionKey, item)).toBe(true);
+    const admission = captureChatOutboxAdmission(host, host.sessionKey);
+    expect(admitQueuedMessageForSession(host, admission, item)).toBe(true);
     let failedClaims = 0;
     vi.spyOn(storage, "setItem").mockImplementation((key, value) => {
       if (value.includes(item.id) && value.includes('"unconfirmed"') && failedClaims === 0) {
@@ -6374,8 +6407,10 @@ describe("handleSendChat", () => {
       },
       chatQueue: [item, following],
     });
-    expect(admitQueuedMessageForSession(host, host.sessionKey, item)).toBe(true);
-    expect(admitQueuedMessageForSession(host, host.sessionKey, following)).toBe(true);
+    const admission = captureChatOutboxAdmission(host, host.sessionKey);
+    expect(admitQueuedMessageForSession(host, admission, item)).toBe(true);
+    const followingAdmission = captureChatOutboxAdmission(host, host.sessionKey);
+    expect(admitQueuedMessageForSession(host, followingAdmission, following)).toBe(true);
 
     await retryReconnectableQueuedChatSends(host);
 
@@ -6426,8 +6461,10 @@ describe("handleSendChat", () => {
       chatMessages: [{ role: "user", content: "possibly cleared" }],
       chatQueue: [clear, successor],
     });
-    expect(admitQueuedMessageForSession(host, host.sessionKey, clear)).toBe(true);
-    expect(admitQueuedMessageForSession(host, host.sessionKey, successor)).toBe(true);
+    const clearAdmission = captureChatOutboxAdmission(host, host.sessionKey);
+    expect(admitQueuedMessageForSession(host, clearAdmission, clear)).toBe(true);
+    const successorAdmission = captureChatOutboxAdmission(host, host.sessionKey);
+    expect(admitQueuedMessageForSession(host, successorAdmission, successor)).toBe(true);
 
     await retryReconnectableQueuedChatSends(host);
 
@@ -6507,8 +6544,10 @@ describe("handleSendChat", () => {
       },
       chatQueue: [clear, successor],
     });
-    expect(admitQueuedMessageForSession(host, host.sessionKey, clear)).toBe(true);
-    expect(admitQueuedMessageForSession(host, host.sessionKey, successor)).toBe(true);
+    const clearAdmission = captureChatOutboxAdmission(host, host.sessionKey);
+    expect(admitQueuedMessageForSession(host, clearAdmission, clear)).toBe(true);
+    const successorAdmission = captureChatOutboxAdmission(host, host.sessionKey);
+    expect(admitQueuedMessageForSession(host, successorAdmission, successor)).toBe(true);
     vi.spyOn(storage, "setItem").mockImplementation((key, value) => {
       const successorIndex = value.indexOf(`"id":"${successor.id}"`);
       const successorRecord =
@@ -6574,7 +6613,8 @@ describe("handleSendChat", () => {
     };
     const host = makeChatHost({ sessionKey: "agent:main:new-route" });
     writeChatQueueForScope(host, queuedSessionKey, [item]);
-    expect(admitQueuedMessageForSession(host, queuedSessionKey, item)).toBe(true);
+    const admission = captureChatOutboxAdmission(host, queuedSessionKey);
+    expect(admitQueuedMessageForSession(host, admission, item)).toBe(true);
 
     expect(
       removeVisibleOrScopedQueuedMessageWithoutReleasing(host, item.id, queuedSessionKey),
@@ -6601,7 +6641,8 @@ describe("handleSendChat", () => {
     };
     source.chatQueue = [item];
     try {
-      expect(admitQueuedMessageForSession(source, source.sessionKey, item)).toBe(true);
+      const admission = captureChatOutboxAdmission(source, source.sessionKey);
+      expect(admitQueuedMessageForSession(source, admission, item)).toBe(true);
       expect(otherGateway.chatQueue).toStrictEqual([]);
     } finally {
       stopOther();
@@ -6620,7 +6661,8 @@ describe("handleSendChat", () => {
     };
     const stopPeer = subscribeChatOutboxProjection(peer);
     try {
-      expect(admitStoredChatComposerQueueItem(source, source.sessionKey, item)).toBe(true);
+      const admission = captureChatOutboxAdmission(source, source.sessionKey);
+      expect(admitStoredChatComposerQueueItem(source, admission, item)).toBe(true);
       expect(peer.chatQueue).toEqual([expect.objectContaining({ id: item.id })]);
 
       expect(removeStoredChatComposerQueueItem(source, source.sessionKey, item.id, item)).toBe(
@@ -6646,7 +6688,8 @@ describe("handleSendChat", () => {
     const stopSource = subscribeChatOutboxProjection(source);
     const stopCachedPane = subscribeChatOutboxProjection(cachedPane);
     try {
-      expect(admitQueuedMessageForSession(source, sessionKey, item)).toBe(true);
+      const admission = captureChatOutboxAdmission(source, sessionKey);
+      expect(admitQueuedMessageForSession(source, admission, item)).toBe(true);
 
       removeQueuedMessage(source, item.id);
 
@@ -6679,7 +6722,8 @@ describe("handleSendChat", () => {
     const stopSource = subscribeChatOutboxProjection(source);
     const stopPeer = subscribeChatOutboxProjection(peer);
     try {
-      expect(admitQueuedMessageForSession(source, item.sessionKey, item)).toBe(true);
+      const admission = captureChatOutboxAdmission(source, item.sessionKey);
+      expect(admitQueuedMessageForSession(source, admission, item)).toBe(true);
 
       removeQueuedMessage(source, item.id);
 
@@ -6897,7 +6941,8 @@ describe("handleSendChat", () => {
       chatQueue: [item],
     });
     const stalePeer = makeChatHost({ client, chatQueue: [{ ...item }] });
-    expect(admitQueuedMessageForSession(host, host.sessionKey, item)).toBe(true);
+    const admission = captureChatOutboxAdmission(host, host.sessionKey);
+    expect(admitQueuedMessageForSession(host, admission, item)).toBe(true);
 
     const send = retryReconnectableQueuedChatSends(host);
     await waitForFast(() =>
@@ -6935,7 +6980,7 @@ describe("handleSendChat", () => {
         removeDeliveredQueuedChatSendForRun(
           host,
           runId,
-          resolveStoredChatOutboxScope(host, item.sessionKey),
+          resolveUiConversationIdentity(host, item.sessionKey),
         ),
       ).toMatchObject({ id: item.id });
       expect(latePeer.chatQueue).toStrictEqual([]);
@@ -7622,7 +7667,8 @@ describe("handleSendChat", () => {
       const stopSource = subscribeChatOutboxProjection(source);
       let stopRecovered = () => {};
       try {
-        expect(admitQueuedMessageForSession(source, source.sessionKey, item)).toBe(true);
+        const admission = captureChatOutboxAdmission(source, source.sessionKey, item.agentId);
+        expect(admitQueuedMessageForSession(source, admission, item)).toBe(true);
         vi.spyOn(outboxPayloadStore, "writeOutboxPayload").mockResolvedValueOnce({
           status: "failed",
           reason,
@@ -10102,7 +10148,8 @@ describe("handleSendChat", () => {
       chatQueue: [original],
       sessionKey: original.sessionKey,
     });
-    expect(admitQueuedMessageForSession(host, host.sessionKey, original)).toBe(true);
+    const originalAdmission = captureChatOutboxAdmission(host, host.sessionKey, original.agentId);
+    expect(admitQueuedMessageForSession(host, originalAdmission, original)).toBe(true);
 
     const sending = steerQueuedChatMessage(host, original.id);
     await waitForFast(() =>
@@ -10163,7 +10210,8 @@ describe("handleSendChat", () => {
       chatQueue: [original],
       sessionKey: original.sessionKey,
     });
-    expect(admitQueuedMessageForSession(host, host.sessionKey, original)).toBe(true);
+    const originalAdmission = captureChatOutboxAdmission(host, host.sessionKey, original.agentId);
+    expect(admitQueuedMessageForSession(host, originalAdmission, original)).toBe(true);
 
     await retryQueuedChatMessage(host, original.id);
 

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -15,6 +15,7 @@ import {
   type SessionChangedResult,
 } from "../../lib/sessions/reconcile.ts";
 import {
+  resolveUiConversationIdentity,
   areUiSessionKeysEquivalent,
   isUiGlobalSessionKey,
   normalizeAgentId,
@@ -47,7 +48,6 @@ import {
   refreshSessionWorkspace,
   retireSessionWorkspaceCheckout,
 } from "./components/chat-session-workspace.ts";
-import { resolveStoredChatOutboxScope } from "./composer-persistence.ts";
 import {
   getChatSessionProjection,
   readChatSessionProjectionScope,
@@ -635,7 +635,7 @@ export function handlePageGatewayEvent(
     }
     // A cold Blob read may finish after another connection or retry takes over.
     // Apply the terminal only after its complete user turn owns independent bytes.
-    const scope = resolveStoredChatOutboxScope(
+    const scope = resolveUiConversationIdentity(
       state,
       terminalPayload.sessionKey,
       isUiGlobalSessionKey(terminalPayload.sessionKey)

--- a/ui/src/pages/chat/chat-state-page.ts
+++ b/ui/src/pages/chat/chat-state-page.ts
@@ -376,7 +376,10 @@ export function createPageState(
       );
   };
   state.cancelQueuedChatMessageEdit = () => {
-    cancelQueuedMessageEdit(state);
+    if (cancelQueuedMessageEdit(state)) {
+      // Reconnect may have parked the drain on this local hold; Cancel does not write storage.
+      void resumeStoredChatOutboxes(state);
+    }
     renderLifecycle.invalidate();
   };
   state.updateSidebarLayout = (layout) => {

--- a/ui/src/pages/chat/components/chat-attachment-file-icon.ts
+++ b/ui/src/pages/chat/components/chat-attachment-file-icon.ts
@@ -2,9 +2,8 @@ import { html } from "lit";
 import { styleMap } from "lit/directives/style-map.js";
 import { inferControlUiPublicAssetPath } from "../../../app/public-assets.ts";
 import { getMediaFileExtension } from "../../../lib/media-file-extension.ts";
-
 // The icon owns its CSS so composer and transcript call sites cannot render it unstyled.
-let attachmentIconStyles: Promise<unknown> | undefined;
+import "../../../styles/chat/attachments.css";
 
 type AttachmentFileIconFamily =
   | "unknown"
@@ -271,8 +270,6 @@ export function renderAttachmentFileIcon(options: {
   mode: AttachmentFileVisualMode;
   unavailable?: boolean;
 }) {
-  attachmentIconStyles ??= import("../../../styles/chat/attachments.css");
-  void attachmentIconStyles;
   const resolved = resolveAttachmentFileIcon(options.filename, options.mimeType);
   const compactLight = resolved.compact
     ? fileIconAssetPath(`compact/light/${resolved.compact}`)
@@ -296,9 +293,8 @@ export function renderAttachmentFileIcon(options: {
       "--chat-file-icon-compact-dark": `url("${compactDark}")`,
     })}
   >
-    <span class="chat-attachment-file-icon__large">
-      <span class="chat-attachment-file-icon__overlay"></span>
-    </span>
-    <span class="chat-attachment-file-icon__compact"></span>
+    ${options.mode === "large-placeholder"
+      ? html`<span class="chat-attachment-file-icon__overlay"></span>`
+      : null}
   </span>`;
 }

--- a/ui/src/pages/chat/composer-persistence.test.ts
+++ b/ui/src/pages/chat/composer-persistence.test.ts
@@ -2,7 +2,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatGoalDraftMode, ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { readChatOutboxRecovery } from "../../lib/chat/outbox-recovery.ts";
-import { subscribeStoredChatOutboxChanges } from "../../lib/chat/outbox-store.ts";
+import {
+  captureChatOutboxAdmission,
+  subscribeStoredChatOutboxChanges,
+} from "../../lib/chat/outbox-store.ts";
+import { resolveUiConversationIdentity } from "../../lib/sessions/session-key.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import {
   admitStoredChatComposerQueueItem,
@@ -12,7 +16,6 @@ import {
   loadChatComposerSnapshot,
   persistChatComposerState,
   removeStoredChatComposerQueueItem,
-  resolveStoredChatOutboxScope,
   restoreChatComposerState,
   updateStoredChatComposerQueueItem,
 } from "./composer-persistence.ts";
@@ -88,7 +91,8 @@ describe("chat composer persistence", () => {
     expect(loadChatComposerSnapshot(state, "agent:lily:other")).toBeNull();
 
     const queued = reconnectItem("other-message", 1);
-    expect(admitStoredChatComposerQueueItem(state, state.sessionKey, queued)).toBe(true);
+    const queuedAdmission = captureChatOutboxAdmission(state, state.sessionKey, queued.agentId);
+    expect(admitStoredChatComposerQueueItem(state, queuedAdmission, queued)).toBe(true);
     expect(removeStoredChatComposerQueueItem(state, state.sessionKey, queued.id)).toBe(true);
     expect(loadChatComposerSnapshot(state, state.sessionKey)?.goalMode).toEqual(goalMode);
   });
@@ -253,7 +257,12 @@ describe("chat composer persistence", () => {
       expect(listener).toHaveBeenCalledTimes(1);
       expect(persistChatComposerState({ ...state, chatMessage: "" })).toBe(true);
       expect(listener).toHaveBeenCalledTimes(2);
-      expect(admitStoredChatComposerQueueItem(state, state.sessionKey, original)).toBe(true);
+      const originalAdmission = captureChatOutboxAdmission(
+        state,
+        state.sessionKey,
+        original.agentId,
+      );
+      expect(admitStoredChatComposerQueueItem(state, originalAdmission, original)).toBe(true);
       expect(listener).toHaveBeenCalledTimes(3);
       expect(
         updateStoredChatComposerQueueItem(
@@ -447,7 +456,11 @@ describe("chat composer persistence", () => {
     for (let index = 0; index < 20; index += 1) {
       const sessionKey = `agent:worker-${index}:thread`;
       expect(
-        admitStoredChatComposerQueueItem(state, sessionKey, reconnectItem(`scope-${index}`, index)),
+        admitStoredChatComposerQueueItem(
+          state,
+          captureChatOutboxAdmission(state, sessionKey),
+          reconnectItem(`scope-${index}`, index),
+        ),
       ).toBe(true);
     }
 
@@ -462,7 +475,12 @@ describe("chat composer persistence", () => {
   it("preserves a newer outbox attempt when a stale pane saves its draft", () => {
     const admitted = reconnectItem("shared", 1);
     const stalePane = createState({ chatQueue: [admitted] });
-    expect(admitStoredChatComposerQueueItem(stalePane, stalePane.sessionKey, admitted)).toBe(true);
+    const admittedAdmission = captureChatOutboxAdmission(
+      stalePane,
+      stalePane.sessionKey,
+      admitted.agentId,
+    );
+    expect(admitStoredChatComposerQueueItem(stalePane, admittedAdmission, admitted)).toBe(true);
     const attempted = { ...admitted, sendAttempts: 1 };
     expect(
       updateStoredChatComposerQueueItem(stalePane, stalePane.sessionKey, admitted, attempted),
@@ -487,8 +505,20 @@ describe("chat composer persistence", () => {
     const first = reconnectItem("first-pane", 1);
     const second = reconnectItem("second-pane", 2);
 
-    expect(admitStoredChatComposerQueueItem(createState(), "agent:lily:main", first)).toBe(true);
-    expect(admitStoredChatComposerQueueItem(createState(), "agent:lily:main", second)).toBe(true);
+    expect(
+      admitStoredChatComposerQueueItem(
+        createState(),
+        captureChatOutboxAdmission(createState(), "agent:lily:main", first.agentId),
+        first,
+      ),
+    ).toBe(true);
+    expect(
+      admitStoredChatComposerQueueItem(
+        createState(),
+        captureChatOutboxAdmission(createState(), "agent:lily:main", second.agentId),
+        second,
+      ),
+    ).toBe(true);
 
     expect(
       loadChatComposerSnapshot(createState(), "agent:lily:main")?.queue.map((item) => item.id),
@@ -497,13 +527,23 @@ describe("chat composer persistence", () => {
 
   it("rejects conflicting admission of an existing item id", () => {
     const item = reconnectItem("same-id", 1);
-    expect(admitStoredChatComposerQueueItem(createState(), "agent:lily:main", item)).toBe(true);
+    expect(
+      admitStoredChatComposerQueueItem(
+        createState(),
+        captureChatOutboxAdmission(createState(), "agent:lily:main", item.agentId),
+        item,
+      ),
+    ).toBe(true);
 
     expect(
-      admitStoredChatComposerQueueItem(createState(), "agent:lily:main", {
-        ...item,
-        text: "different payload",
-      }),
+      admitStoredChatComposerQueueItem(
+        createState(),
+        captureChatOutboxAdmission(createState(), "agent:lily:main", item.agentId),
+        {
+          ...item,
+          text: "different payload",
+        },
+      ),
     ).toBe(false);
   });
 
@@ -529,7 +569,12 @@ describe("chat composer persistence", () => {
         change === "send-attempt"
           ? { ...original, sendAttempts: 1 }
           : { ...original, attachmentPayload: { ...reference, key: "replacement-payload" } };
-      expect(admitStoredChatComposerQueueItem(state, state.sessionKey, original)).toBe(true);
+      const originalAdmission = captureChatOutboxAdmission(
+        state,
+        state.sessionKey,
+        original.agentId,
+      );
+      expect(admitStoredChatComposerQueueItem(state, originalAdmission, original)).toBe(true);
       expect(updateStoredChatComposerQueueItem(state, state.sessionKey, original, successor)).toBe(
         true,
       );
@@ -559,8 +604,10 @@ describe("chat composer persistence", () => {
     const offlineGlobal = createState({ agentsList: null, hello: null, sessionKey: "global" });
     const mainItem = reconnectItem("unresolved-main", 1);
     const globalItem = reconnectItem("unresolved-global", 2);
-    expect(admitStoredChatComposerQueueItem(offlineMain, "main", mainItem)).toBe(true);
-    expect(admitStoredChatComposerQueueItem(offlineGlobal, "global", globalItem)).toBe(true);
+    const mainAdmission = captureChatOutboxAdmission(offlineMain, "main", mainItem.agentId);
+    expect(admitStoredChatComposerQueueItem(offlineMain, mainAdmission, mainItem)).toBe(true);
+    const globalAdmission = captureChatOutboxAdmission(offlineGlobal, "global", globalItem.agentId);
+    expect(admitStoredChatComposerQueueItem(offlineGlobal, globalAdmission, globalItem)).toBe(true);
     expect(listStoredChatOutboxes(offlineMain)).toEqual([
       {
         sessionKey: "main",
@@ -644,7 +691,8 @@ describe("chat composer persistence", () => {
     });
     const item = reconnectItem("offline-workspace", 1);
     expect(persistChatComposerState(offline)).toBe(true);
-    expect(admitStoredChatComposerQueueItem(offline, offline.sessionKey, item)).toBe(true);
+    const admission = captureChatOutboxAdmission(offline, offline.sessionKey, item.agentId);
+    expect(admitStoredChatComposerQueueItem(offline, admission, item)).toBe(true);
 
     const reconnected = createState({
       agentsList: { defaultId: "work", mainKey: "workspace", scope: "global" },
@@ -691,7 +739,8 @@ describe("chat composer persistence", () => {
       sessionKey: "matrix:group:RoomCase",
     });
     const item = reconnectItem("opaque-room", 1);
-    expect(admitStoredChatComposerQueueItem(state, state.sessionKey, item)).toBe(true);
+    const admission = captureChatOutboxAdmission(state, state.sessionKey, item.agentId);
+    expect(admitStoredChatComposerQueueItem(state, admission, item)).toBe(true);
 
     expect(loadChatComposerSnapshot(state, state.sessionKey)?.queue).toEqual([
       { ...item, sessionKey: state.sessionKey },
@@ -769,7 +818,8 @@ describe("chat composer persistence", () => {
       sessionKey: "agent:main:workspace",
     });
     const item = reconnectItem("explicit-main-workspace", 1);
-    expect(admitStoredChatComposerQueueItem(offline, offline.sessionKey, item)).toBe(true);
+    const admission = captureChatOutboxAdmission(offline, offline.sessionKey, item.agentId);
+    expect(admitStoredChatComposerQueueItem(offline, admission, item)).toBe(true);
 
     const selectedWork = createState({
       agentsList: { defaultId: "work", mainKey: "workspace", scope: "global" },
@@ -792,7 +842,12 @@ describe("chat composer persistence", () => {
     });
     const queued = reconnectItem("custom-main-queue", 1);
     expect(persistChatComposerState(resolved)).toBe(true);
-    expect(admitStoredChatComposerQueueItem(resolved, resolved.sessionKey, queued)).toBe(true);
+    const queuedAdmission = captureChatOutboxAdmission(
+      resolved,
+      resolved.sessionKey,
+      queued.agentId,
+    );
+    expect(admitStoredChatComposerQueueItem(resolved, queuedAdmission, queued)).toBe(true);
 
     const offline = createState({
       agentsList: null,
@@ -814,7 +869,7 @@ describe("chat composer persistence", () => {
       expect(
         admitStoredChatComposerQueueItem(
           createState({ sessionKey }),
-          sessionKey,
+          captureChatOutboxAdmission(createState({ sessionKey }), sessionKey),
           reconnectItem(`custom-clear-capacity-${index}`, index + 2),
         ),
       ).toBe(true);
@@ -849,7 +904,12 @@ describe("chat composer persistence", () => {
     });
     const queued = reconnectItem("qualified-custom-main", 1);
     expect(persistChatComposerState(connected)).toBe(true);
-    expect(admitStoredChatComposerQueueItem(connected, connected.sessionKey, queued)).toBe(true);
+    const queuedAdmission = captureChatOutboxAdmission(
+      connected,
+      connected.sessionKey,
+      queued.agentId,
+    );
+    expect(admitStoredChatComposerQueueItem(connected, queuedAdmission, queued)).toBe(true);
 
     const gatewayUrl = connected.settings?.gatewayUrl;
     const storageKey = storageKeyForGateway(gatewayUrl);
@@ -866,7 +926,7 @@ describe("chat composer persistence", () => {
       sessionKey: "agent:work:workspace",
     });
     expect(loadChatComposerDraftRevision(offline, offline.sessionKey)).toBeGreaterThan(0);
-    expect(resolveStoredChatOutboxScope(offline, offline.sessionKey)).toEqual({
+    expect(resolveUiConversationIdentity(offline, offline.sessionKey)).toEqual({
       agentId: "work",
       sessionKey: "agent:work:workspace",
     });
@@ -876,7 +936,7 @@ describe("chat composer persistence", () => {
     });
 
     const unrelatedRoute = "agent:work:project";
-    expect(resolveStoredChatOutboxScope(offline, unrelatedRoute)).toEqual({
+    expect(resolveUiConversationIdentity(offline, unrelatedRoute)).toEqual({
       agentId: "work",
       sessionKey: unrelatedRoute,
     });
@@ -900,11 +960,19 @@ describe("chat composer persistence", () => {
   it("migrates unresolved global input only to the selected agent", () => {
     const alpha = createState({ assistantAgentId: "alpha", sessionKey: "global" });
     const alphaItem = reconnectItem("alpha-existing", 1);
-    expect(admitStoredChatComposerQueueItem(alpha, "global", alphaItem)).toBe(true);
+    const alphaAdmission = captureChatOutboxAdmission(alpha, "global", alphaItem.agentId);
+    expect(admitStoredChatComposerQueueItem(alpha, alphaAdmission, alphaItem)).toBe(true);
 
     const unresolved = createState({ agentsList: null, hello: null, sessionKey: "global" });
     const unresolvedItem = reconnectItem("selected-work", 2);
-    expect(admitStoredChatComposerQueueItem(unresolved, "global", unresolvedItem)).toBe(true);
+    const unresolvedAdmission = captureChatOutboxAdmission(
+      unresolved,
+      "global",
+      unresolvedItem.agentId,
+    );
+    expect(admitStoredChatComposerQueueItem(unresolved, unresolvedAdmission, unresolvedItem)).toBe(
+      true,
+    );
 
     const selectedWork = createState({
       assistantAgentId: "work",
@@ -1022,14 +1090,22 @@ describe("chat composer persistence", () => {
     expect(
       admitStoredChatComposerQueueItem(
         createState({ assistantAgentId: "work", sessionKey: "global" }),
-        "global",
+        captureChatOutboxAdmission(
+          createState({ assistantAgentId: "work", sessionKey: "global" }),
+          "global",
+          workItem.agentId,
+        ),
         workItem,
       ),
     ).toBe(true);
     expect(
       admitStoredChatComposerQueueItem(
         createState({ assistantAgentId: "other", sessionKey: "global" }),
-        "global",
+        captureChatOutboxAdmission(
+          createState({ assistantAgentId: "other", sessionKey: "global" }),
+          "global",
+          otherItem.agentId,
+        ),
         otherItem,
       ),
     ).toBe(true);
@@ -1064,7 +1140,8 @@ describe("chat composer persistence", () => {
     });
     const item = reconnectItem("unresolved-with-quota", 1);
     expect(persistChatComposerState(unresolved)).toBe(true);
-    expect(admitStoredChatComposerQueueItem(unresolved, "main", item)).toBe(true);
+    const admission = captureChatOutboxAdmission(unresolved, "main", item.agentId);
+    expect(admitStoredChatComposerQueueItem(unresolved, admission, item)).toBe(true);
     vi.spyOn(storage, "setItem").mockImplementation(() => {
       throw new DOMException("quota exceeded", "QuotaExceededError");
     });
@@ -1087,8 +1164,14 @@ describe("chat composer persistence", () => {
     });
     const bare = reconnectItem("bare-configured", 1);
     const qualified = reconnectItem("qualified-configured", 2);
-    expect(admitStoredChatComposerQueueItem(state, "workspace", bare)).toBe(true);
-    expect(admitStoredChatComposerQueueItem(state, "agent:work:workspace", qualified)).toBe(true);
+    const bareAdmission = captureChatOutboxAdmission(state, "workspace", bare.agentId);
+    expect(admitStoredChatComposerQueueItem(state, bareAdmission, bare)).toBe(true);
+    const qualifiedAdmission = captureChatOutboxAdmission(
+      state,
+      "agent:work:workspace",
+      qualified.agentId,
+    );
+    expect(admitStoredChatComposerQueueItem(state, qualifiedAdmission, qualified)).toBe(true);
 
     expect(loadChatComposerSnapshot(state, "global")?.queue.map((item) => item.id)).toEqual([
       "bare-configured",
@@ -1139,8 +1222,10 @@ describe("chat composer persistence", () => {
     const state = createState();
     const older = reconnectItem("inactive-a", 1);
     const newer = reconnectItem("inactive-b", 2);
-    expect(admitStoredChatComposerQueueItem(state, "agent:alpha:thread:1", older)).toBe(true);
-    expect(admitStoredChatComposerQueueItem(state, "agent:beta:thread:2", newer)).toBe(true);
+    const olderAdmission = captureChatOutboxAdmission(state, "agent:alpha:thread:1", older.agentId);
+    expect(admitStoredChatComposerQueueItem(state, olderAdmission, older)).toBe(true);
+    const newerAdmission = captureChatOutboxAdmission(state, "agent:beta:thread:2", newer.agentId);
+    expect(admitStoredChatComposerQueueItem(state, newerAdmission, newer)).toBe(true);
 
     expect(listStoredChatOutboxes(state)).toEqual([
       {
@@ -1183,9 +1268,22 @@ describe("chat composer persistence", () => {
       ...reconnectItem("executing-command", 3),
       sendState: "executing-command",
     };
-    expect(admitStoredChatComposerQueueItem(state, state.sessionKey, sending)).toBe(true);
-    expect(admitStoredChatComposerQueueItem(state, state.sessionKey, waitingModel)).toBe(true);
-    expect(admitStoredChatComposerQueueItem(state, state.sessionKey, executingCommand)).toBe(true);
+    const sendingAdmission = captureChatOutboxAdmission(state, state.sessionKey, sending.agentId);
+    expect(admitStoredChatComposerQueueItem(state, sendingAdmission, sending)).toBe(true);
+    const waitingModelAdmission = captureChatOutboxAdmission(
+      state,
+      state.sessionKey,
+      waitingModel.agentId,
+    );
+    expect(admitStoredChatComposerQueueItem(state, waitingModelAdmission, waitingModel)).toBe(true);
+    const executingCommandAdmission = captureChatOutboxAdmission(
+      state,
+      state.sessionKey,
+      executingCommand.agentId,
+    );
+    expect(
+      admitStoredChatComposerQueueItem(state, executingCommandAdmission, executingCommand),
+    ).toBe(true);
 
     expect(loadChatComposerSnapshot(state, state.sessionKey)?.queue).toEqual([
       { ...sending, sendState: "waiting-reconnect", sessionKey: state.sessionKey, agentId: "lily" },
@@ -1208,7 +1306,11 @@ describe("chat composer persistence", () => {
   it("scopes composer state and outboxes by gateway", () => {
     const state = createState({ chatMessage: "gateway-local draft" });
     persistChatComposerState(state);
-    admitStoredChatComposerQueueItem(state, state.sessionKey, reconnectItem("gateway-local", 1));
+    admitStoredChatComposerQueueItem(
+      state,
+      captureChatOutboxAdmission(state, state.sessionKey),
+      reconnectItem("gateway-local", 1),
+    );
     const otherGateway = createState({
       settings: { gatewayUrl: "ws://other-gateway.test/control" },
     });
@@ -1237,9 +1339,15 @@ describe("chat composer persistence", () => {
     const firstItem = reconnectItem("first-long-gateway", 1);
     const secondItem = reconnectItem("second-long-gateway", 2);
     expect(persistChatComposerState(first)).toBe(true);
-    expect(admitStoredChatComposerQueueItem(first, first.sessionKey, firstItem)).toBe(true);
+    const firstAdmission = captureChatOutboxAdmission(first, first.sessionKey, firstItem.agentId);
+    expect(admitStoredChatComposerQueueItem(first, firstAdmission, firstItem)).toBe(true);
     expect(persistChatComposerState(second)).toBe(true);
-    expect(admitStoredChatComposerQueueItem(second, second.sessionKey, secondItem)).toBe(true);
+    const secondAdmission = captureChatOutboxAdmission(
+      second,
+      second.sessionKey,
+      secondItem.agentId,
+    );
+    expect(admitStoredChatComposerQueueItem(second, secondAdmission, secondItem)).toBe(true);
 
     expect(loadChatComposerSnapshot(first, first.sessionKey)).toEqual({
       draft: "first gateway draft",
@@ -1320,7 +1428,7 @@ describe("chat composer persistence", () => {
       expect(
         admitStoredChatComposerQueueItem(
           createState({ sessionKey }),
-          sessionKey,
+          captureChatOutboxAdmission(createState({ sessionKey }), sessionKey),
           reconnectItem(`queued-${index}`, index),
         ),
       ).toBe(true);
@@ -1336,7 +1444,10 @@ describe("chat composer persistence", () => {
     expect(
       admitStoredChatComposerQueueItem(
         createState({ sessionKey: twentiethSessionKey }),
-        twentiethSessionKey,
+        captureChatOutboxAdmission(
+          createState({ sessionKey: twentiethSessionKey }),
+          twentiethSessionKey,
+        ),
         reconnectItem("queued-19", 19),
       ),
     ).toBe(true);
@@ -1358,7 +1469,10 @@ describe("chat composer persistence", () => {
     expect(
       admitStoredChatComposerQueueItem(
         createState({ sessionKey: overflowSessionKey }),
-        overflowSessionKey,
+        captureChatOutboxAdmission(
+          createState({ sessionKey: overflowSessionKey }),
+          overflowSessionKey,
+        ),
         reconnectItem("queued-20", 20),
       ),
     ).toBe(false);
@@ -1376,7 +1490,12 @@ describe("chat composer persistence", () => {
     });
     const queued = reconnectItem("resolved-work-queue", 1);
     expect(persistChatComposerState(resolved)).toBe(true);
-    expect(admitStoredChatComposerQueueItem(resolved, resolved.sessionKey, queued)).toBe(true);
+    const queuedAdmission = captureChatOutboxAdmission(
+      resolved,
+      resolved.sessionKey,
+      queued.agentId,
+    );
+    expect(admitStoredChatComposerQueueItem(resolved, queuedAdmission, queued)).toBe(true);
 
     const offline = createState({ sessionKey: "main", chatMessage: "stale resolved draft" });
     expect(persistChatComposerState(offline)).toBe(true);
@@ -1402,7 +1521,7 @@ describe("chat composer persistence", () => {
       expect(
         admitStoredChatComposerQueueItem(
           createState({ sessionKey }),
-          sessionKey,
+          captureChatOutboxAdmission(createState({ sessionKey }), sessionKey),
           reconnectItem(`clear-fence-capacity-${index}`, index + 2),
         ),
       ).toBe(true);
@@ -1443,7 +1562,7 @@ describe("chat composer persistence", () => {
       expect(
         admitStoredChatComposerQueueItem(
           createState({ sessionKey }),
-          sessionKey,
+          captureChatOutboxAdmission(createState({ sessionKey }), sessionKey),
           reconnectItem(`capacity-${index}`, index),
         ),
       ).toBe(true);
@@ -1469,7 +1588,7 @@ describe("chat composer persistence", () => {
       expect(
         admitStoredChatComposerQueueItem(
           createState({ sessionKey }),
-          sessionKey,
+          captureChatOutboxAdmission(createState({ sessionKey }), sessionKey),
           reconnectItem(`queue-only-${index}`, index),
         ),
       ).toBe(true);
@@ -1487,7 +1606,12 @@ describe("chat composer persistence", () => {
       ),
     ).toBe(true);
     const sameScope = reconnectItem("same-scope-queue", 21);
-    expect(admitStoredChatComposerQueueItem(state, state.sessionKey, sameScope)).toBe(true);
+    const sameScopeAdmission = captureChatOutboxAdmission(
+      state,
+      state.sessionKey,
+      sameScope.agentId,
+    );
+    expect(admitStoredChatComposerQueueItem(state, sameScopeAdmission, sameScope)).toBe(true);
     expect(loadChatComposerSnapshot(state, state.sessionKey)).toEqual({
       draft: "",
       queue: [{ ...sameScope, sessionKey: state.sessionKey, agentId: "lily" }],
@@ -1511,9 +1635,13 @@ describe("chat composer persistence", () => {
     const outboxes = Array.from({ length: 20 }, (_, index) => {
       const sessionKey = `agent:lily:failed-fence:${index}`;
       const item = reconnectItem(`failed-fence-${index}`, index);
-      expect(admitStoredChatComposerQueueItem(createState({ sessionKey }), sessionKey, item)).toBe(
-        true,
-      );
+      expect(
+        admitStoredChatComposerQueueItem(
+          createState({ sessionKey }),
+          captureChatOutboxAdmission(createState({ sessionKey }), sessionKey, item.agentId),
+          item,
+        ),
+      ).toBe(true);
       return { item, sessionKey };
     });
     expect(loadChatComposerSnapshot(baseline, baseline.sessionKey)).toBeNull();
@@ -1590,9 +1718,13 @@ describe("chat composer persistence", () => {
     const outboxes = Array.from({ length: 20 }, (_, index) => {
       const sessionKey = `agent:lily:stale-fence:${index}`;
       const item = reconnectItem(`stale-fence-${index}`, index);
-      expect(admitStoredChatComposerQueueItem(createState({ sessionKey }), sessionKey, item)).toBe(
-        true,
-      );
+      expect(
+        admitStoredChatComposerQueueItem(
+          createState({ sessionKey }),
+          captureChatOutboxAdmission(createState({ sessionKey }), sessionKey, item.agentId),
+          item,
+        ),
+      ).toBe(true);
       return { item, sessionKey };
     });
     expect(loadChatComposerSnapshot(baseline, baseline.sessionKey)).toBeNull();
@@ -1645,9 +1777,13 @@ describe("chat composer persistence", () => {
     const outboxes = Array.from({ length: 20 }, (_, index) => {
       const sessionKey = `agent:lily:failed-revert:${index}`;
       const item = reconnectItem(`failed-revert-${index}`, index);
-      expect(admitStoredChatComposerQueueItem(createState({ sessionKey }), sessionKey, item)).toBe(
-        true,
-      );
+      expect(
+        admitStoredChatComposerQueueItem(
+          createState({ sessionKey }),
+          captureChatOutboxAdmission(createState({ sessionKey }), sessionKey, item.agentId),
+          item,
+        ),
+      ).toBe(true);
       return { item, sessionKey };
     });
     expect(loadChatComposerSnapshot(state, state.sessionKey)).toBeNull();
@@ -1689,7 +1825,8 @@ describe("chat composer persistence", () => {
     vi.stubGlobal("sessionStorage", storage);
     const state = createState();
     const item = reconnectItem("readable-after-quota", 1);
-    expect(admitStoredChatComposerQueueItem(state, state.sessionKey, item)).toBe(true);
+    const admission = captureChatOutboxAdmission(state, state.sessionKey, item.agentId);
+    expect(admitStoredChatComposerQueueItem(state, admission, item)).toBe(true);
     vi.spyOn(storage, "setItem").mockImplementation(() => {
       throw new DOMException("quota exceeded", "QuotaExceededError");
     });

--- a/ui/src/pages/chat/composer-persistence.ts
+++ b/ui/src/pages/chat/composer-persistence.ts
@@ -24,7 +24,6 @@ import {
   notifyStoredChatOutboxChanges,
   readStoredOutboxStore as readStore,
   resolvePendingComposerSessions,
-  resolveStoredChatOutboxScope,
   storedChatOutboxScopeKey,
   storageTargetForGateway,
   writeStoredOutboxStore as writeStore,
@@ -32,7 +31,10 @@ import {
   type StoredChatOutboxScope,
   type StoredComposerState,
 } from "../../lib/chat/outbox-store.ts";
-import { hasUiSessionDefaults } from "../../lib/sessions/session-key.ts";
+import {
+  resolveUiConversationIdentity,
+  hasUiSessionDefaults,
+} from "../../lib/sessions/session-key.ts";
 // Control UI chat module implements composer persistence behavior.
 import { getSafeSessionStorage } from "../../local-storage.ts";
 import {
@@ -53,10 +55,7 @@ export const CHAT_COMPOSER_DRAFT_STORAGE_ERROR =
   "Could not store the previous draft in browser storage. It remains available in this tab.";
 
 export { INTERRUPTED_SETTINGS_WAIT_ERROR } from "../../lib/chat/outbox-store-codec.ts";
-export {
-  resolveStoredChatOutboxScope,
-  storedChatOutboxScopeKey,
-} from "../../lib/chat/outbox-store.ts";
+export { storedChatOutboxScopeKey } from "../../lib/chat/outbox-store.ts";
 export { listStoredChatOutboxes } from "../../lib/chat/outbox-store-projection.ts";
 export type { ChatComposerScope, StoredChatOutboxScope } from "../../lib/chat/outbox-store.ts";
 export type { StoredChatOutbox } from "../../lib/chat/outbox-store-projection.ts";
@@ -204,44 +203,15 @@ function writeStoredComposerSession(
 
 type ChatComposerDraftRevisionState = ReturnType<typeof readDraftRevisionState>;
 
-function loadChatComposerDraftRevisionState(
-  state: ChatComposerScope,
-  scope: StoredChatOutboxScope,
-): ChatComposerDraftRevisionState {
-  const storage = getSafeSessionStorage();
-  if (!storage) {
-    return { committed: 0, latestAttempt: 0 };
-  }
-  try {
-    const target = storageTargetForGateway(state.settings?.gatewayUrl);
-    const store = readStore(storage, target);
-    const migrated = resolvePendingComposerSessions(store, state);
-    const storeSessionKey = storedChatOutboxScopeKey(scope);
-    const session = store.sessions[storeSessionKey] ?? null;
-    if (migrated) {
-      try {
-        writeStore(storage, target, store);
-      } catch {
-        // The readable draft is still the concurrency baseline for this pane.
-      }
-    }
-    const storedDraftRevision = session?.draftRevision;
-    rememberDraftRevision(storage, target.key, storeSessionKey, storedDraftRevision);
-    return readDraftRevisionState(storage, target.key, storeSessionKey, storedDraftRevision);
-  } catch {
-    return { committed: 0, latestAttempt: 0 };
-  }
-}
-
 export function loadChatComposerDraftRevision(
   state: ChatComposerScope,
   sessionKey: string,
   agentIdOverride?: string,
 ): number {
-  return loadChatComposerDraftRevisionState(
+  return loadCapturedChatComposerState(
     state,
-    resolveStoredChatOutboxScope(state, sessionKey, agentIdOverride),
-  ).latestAttempt;
+    resolveUiConversationIdentity(state, sessionKey, agentIdOverride),
+  ).revisions.latestAttempt;
 }
 
 export function loadChatComposerCommittedDraftRevision(
@@ -249,36 +219,34 @@ export function loadChatComposerCommittedDraftRevision(
   sessionKey: string,
   agentIdOverride?: string,
 ): number {
-  return loadChatComposerDraftRevisionState(
+  return loadCapturedChatComposerState(
     state,
-    resolveStoredChatOutboxScope(state, sessionKey, agentIdOverride),
-  ).committed;
+    resolveUiConversationIdentity(state, sessionKey, agentIdOverride),
+  ).revisions.committed;
 }
 
 export function loadChatComposerSnapshot(
-  state: Pick<
-    ChatComposerPersistenceState,
-    "settings" | "assistantAgentId" | "agentsList" | "hello" | "client" | "connected"
-  >,
+  state: ChatComposerScope,
   sessionKey: string,
   agentIdOverride?: string,
 ): { draft: string; goalMode?: ChatGoalDraftMode; queue: ChatQueueItem[] } | null {
-  return loadCapturedChatComposerSnapshot(
+  return loadCapturedChatComposerState(
     state,
-    resolveStoredChatOutboxScope(state, sessionKey, agentIdOverride),
-  );
+    resolveUiConversationIdentity(state, sessionKey, agentIdOverride),
+  ).snapshot;
 }
 
-function loadCapturedChatComposerSnapshot(
-  state: Pick<
-    ChatComposerPersistenceState,
-    "settings" | "assistantAgentId" | "agentsList" | "hello" | "client" | "connected"
-  >,
+function loadCapturedChatComposerState(
+  state: ChatComposerScope,
   captured: StoredChatOutboxScope,
-): { draft: string; goalMode?: ChatGoalDraftMode; queue: ChatQueueItem[] } | null {
+): {
+  snapshot: { draft: string; goalMode?: ChatGoalDraftMode; queue: ChatQueueItem[] } | null;
+  revisions: ChatComposerDraftRevisionState;
+} {
+  const empty = { snapshot: null, revisions: { committed: 0, latestAttempt: 0 } };
   const storage = getSafeSessionStorage();
   if (!storage) {
-    return null;
+    return empty;
   }
   try {
     const target = storageTargetForGateway(state.settings?.gatewayUrl);
@@ -291,21 +259,27 @@ function loadCapturedChatComposerSnapshot(
         // Migration persistence is best-effort; readable drafts and outboxes remain usable.
       }
     }
-    const session = store.sessions[storedChatOutboxScopeKey(captured)];
+    const scopeKey = storedChatOutboxScopeKey(captured);
+    const session = store.sessions[scopeKey];
+    rememberDraftRevision(storage, target.key, scopeKey, session?.draftRevision);
+    const revisions = readDraftRevisionState(storage, target.key, scopeKey, session?.draftRevision);
     const draft = normalizeChatComposerDraft(session?.draft ?? "");
     if (!session || (!draft && !session.goalMode && !session.queue?.length)) {
-      return null;
+      return { snapshot: null, revisions };
     }
     return {
-      draft,
-      ...(session.goalMode ? { goalMode: session.goalMode } : {}),
-      queue: (session.queue ?? [])
-        .filter((item) => outboxPayloadMatchesOwner(state, item))
-        .map((item) => serializeQueueItemForScope(item, captured))
-        .filter((item): item is ChatQueueItem => item !== null),
+      revisions,
+      snapshot: {
+        draft,
+        ...(session.goalMode ? { goalMode: session.goalMode } : {}),
+        queue: (session.queue ?? [])
+          .filter((item) => outboxPayloadMatchesOwner(state, item))
+          .map((item) => serializeQueueItemForScope(item, captured))
+          .filter((item): item is ChatQueueItem => item !== null),
+      },
     };
   } catch {
-    return null;
+    return empty;
   }
 }
 
@@ -415,14 +389,12 @@ export function persistChatComposerState(
 
 export function admitStoredChatComposerQueueItem(
   state: ChatComposerScope,
-  sessionKey: string,
+  captured: ReturnType<typeof captureChatOutboxAdmission>,
   item: ChatQueueItem,
-  agentId?: string,
   replaces?: StoredChatQueueReplacement,
-  captured = captureChatOutboxAdmission(state, sessionKey, agentId ?? item.agentId),
 ): boolean {
   const storage = getSafeSessionStorage();
-  if (!storage || !sessionKey.trim()) {
+  if (!storage || !captured.scope.sessionKey.trim()) {
     return false;
   }
   try {
@@ -634,6 +606,7 @@ export class ChatComposerPersistence {
   private timer: ReturnType<typeof globalThis.setTimeout> | null = null;
   private ready = false;
   private pending: ChatComposerDraftSnapshot | null = null;
+  private publishing = false;
   private lastPersisted: ChatComposerDraftSnapshot | null = null;
   private committedDraftRevision = 0;
   private latestDraftRevision = 0;
@@ -669,10 +642,12 @@ export class ChatComposerPersistence {
     }
     this.ready = true;
     this.pending = null;
-    const revisions = this.readDraftRevisions(state);
+    const { revisions, snapshot: stored } = loadCapturedChatComposerState(
+      state,
+      resolveUiConversationIdentity(state, state.sessionKey),
+    );
     this.committedDraftRevision = revisions.committed;
     this.latestDraftRevision = revisions.latestAttempt;
-    const stored = loadChatComposerSnapshot(state, state.sessionKey);
     this.durableRestoreProtected =
       (state.chatAttachments?.length ?? 0) > 0 ||
       (stored?.draft ?? "") !== state.chatMessage ||
@@ -711,20 +686,12 @@ export class ChatComposerPersistence {
     if (!this.ready || !state) {
       return;
     }
-    const current = this.snapshot(state);
-    if (this.isUnchanged(current)) {
+    if (this.isUnchanged(state)) {
       if (!this.pending) {
         this.clearTimer();
         return;
       }
-      if (
-        chatAttachmentDraftSignature(
-          this.pending.chatMessage,
-          this.pending.attachments,
-          this.pending.goalMode,
-        ) ===
-        chatAttachmentDraftSignature(current.chatMessage, current.attachments, current.goalMode)
-      ) {
+      if (this.matchesCurrentContent(this.pending, state)) {
         this.clearTimer();
         this.timer = globalThis.setTimeout(
           () => this.persistNow(),
@@ -746,13 +713,12 @@ export class ChatComposerPersistence {
 
   persistNow() {
     const state = this.getState();
-    if (!this.ready || !state) {
+    if (!this.ready || !state || this.publishing) {
       return;
     }
     let snapshot = this.pending;
     if (!snapshot) {
-      const current = this.snapshot(state);
-      if (this.isUnchanged(current)) {
+      if (this.isUnchanged(state)) {
         return;
       }
       snapshot = this.snapshot(
@@ -763,7 +729,7 @@ export class ChatComposerPersistence {
       this.latestDraftRevision = snapshot.draftRevision;
     }
     this.clearTimer();
-    this.pending = this.persistSnapshot(state, snapshot).status === "persisted" ? null : snapshot;
+    this.persistSnapshot(state, snapshot);
   }
 
   persistChangedState() {
@@ -776,10 +742,10 @@ export class ChatComposerPersistence {
     if (!state) {
       return null;
     }
-    const current = this.snapshot(state);
-    const snapshot =
-      this.pending ?? (this.isUnchanged(current) ? (this.lastPersisted ?? current) : current);
-    return snapshot.scope;
+    return (
+      (this.pending ?? (this.isUnchanged(state) ? this.lastPersisted : null))?.scope ??
+      resolveUiConversationIdentity(state, state.sessionKey)
+    );
   }
 
   persistForRouteSwitchResult(): ChatComposerPersistResult {
@@ -789,17 +755,15 @@ export class ChatComposerPersistence {
     }
     let snapshot = this.pending;
     let enforceExpectedRevision = false;
-    const current = this.snapshot(state);
-    if (!snapshot && this.ready && this.isUnchanged(current)) {
-      const baseline = this.lastPersisted ?? current;
+    if (!snapshot && this.ready && this.isUnchanged(state)) {
+      const baseline = this.lastPersisted!;
       if (!baseline.chatMessage && !baseline.goalMode && baseline.attachments.length === 0) {
         this.pending = null;
         this.clearTimer();
         return { status: "persisted" };
       }
-      const revisions = this.readDraftRevisions(state, baseline.scope);
+      const { revisions, snapshot: stored } = loadCapturedChatComposerState(state, baseline.scope);
       const storedRevision = revisions.committed;
-      const stored = loadCapturedChatComposerSnapshot(state, baseline.scope);
       if (
         baseline.attachments.length === 0 &&
         storedRevision === baseline.draftRevision &&
@@ -828,7 +792,12 @@ export class ChatComposerPersistence {
       };
       this.latestDraftRevision = snapshot.draftRevision;
       enforceExpectedRevision = true;
-    } else if (!snapshot && !this.ready && !current.chatMessage && !current.goalMode) {
+    } else if (
+      !snapshot &&
+      !this.ready &&
+      !normalizeChatComposerDraft(state.chatMessage) &&
+      !state.chatGoalDraftMode
+    ) {
       this.pending = null;
       this.clearTimer();
       return { status: "persisted" };
@@ -840,9 +809,7 @@ export class ChatComposerPersistence {
     );
     this.latestDraftRevision = Math.max(this.latestDraftRevision, snapshot.draftRevision);
     this.clearTimer();
-    const result = this.persistSnapshot(state, snapshot, enforceExpectedRevision);
-    this.pending = result.status === "persisted" ? null : snapshot;
-    return result;
+    return this.persistSnapshot(state, snapshot, enforceExpectedRevision);
   }
 
   private persistSnapshot(
@@ -850,16 +817,28 @@ export class ChatComposerPersistence {
     snapshot: ChatComposerDraftSnapshot,
     enforceExpectedRevision = false,
   ): ChatComposerPersistResult {
-    const status = persistCapturedChatComposerStateResult(state, snapshot, {
-      draft: snapshot.chatMessage,
-      goalMode: snapshot.goalMode ?? null,
-      draftRevision: snapshot.draftRevision,
-      ...(enforceExpectedRevision ? { expectedDraftRevision: snapshot.expectedDraftRevision } : {}),
-    });
+    // Presence notifications synchronously reenter the controller. Publish this
+    // exact snapshot first; subscribers must not mint a second write for it.
+    this.pending = snapshot;
+    this.publishing = true;
+    let status: ChatComposerPersistStatus;
+    try {
+      status = persistCapturedChatComposerStateResult(state, snapshot, {
+        draft: snapshot.chatMessage,
+        goalMode: snapshot.goalMode ?? null,
+        draftRevision: snapshot.draftRevision,
+        ...(enforceExpectedRevision
+          ? { expectedDraftRevision: snapshot.expectedDraftRevision }
+          : {}),
+      });
+    } finally {
+      this.publishing = false;
+    }
     if (snapshot.durable) {
       this.durablePersistence.persist(snapshot.durable);
     }
-    if (status === "persisted") {
+    if (status === "persisted" && this.pending === snapshot) {
+      this.pending = null;
       this.committedDraftRevision = snapshot.draftRevision;
       this.latestDraftRevision = Math.max(this.latestDraftRevision, snapshot.draftRevision);
       this.lastPersisted = snapshot;
@@ -883,13 +862,28 @@ export class ChatComposerPersistence {
     this.timer = null;
   }
 
-  private isUnchanged(snapshot: ChatComposerDraftSnapshot): boolean {
+  private isUnchanged(state: ChatComposerPersistenceState): boolean {
     const last = this.lastPersisted;
     return Boolean(
-      last &&
-      last.sessionKey === snapshot.sessionKey &&
-      chatAttachmentDraftSignature(last.chatMessage, last.attachments, last.goalMode) ===
-        chatAttachmentDraftSignature(snapshot.chatMessage, snapshot.attachments, snapshot.goalMode),
+      last && last.sessionKey === state.sessionKey && this.matchesCurrentContent(last, state),
+    );
+  }
+
+  private matchesCurrentContent(
+    snapshot: ChatComposerDraftSnapshot,
+    state: ChatComposerPersistenceState,
+  ): boolean {
+    return (
+      chatAttachmentDraftSignature(
+        snapshot.chatMessage,
+        snapshot.attachments,
+        snapshot.goalMode,
+      ) ===
+      chatAttachmentDraftSignature(
+        normalizeChatComposerDraft(state.chatMessage),
+        state.chatAttachments ?? [],
+        state.chatGoalDraftMode,
+      )
     );
   }
 
@@ -898,7 +892,7 @@ export class ChatComposerPersistence {
     draftRevision: number = this.latestDraftRevision,
     expectedDraftRevision: number = this.committedDraftRevision,
   ): ChatComposerDraftSnapshot {
-    const scope = resolveStoredChatOutboxScope(state, state.sessionKey);
+    const scope = resolveUiConversationIdentity(state, state.sessionKey);
     const durableScope = this.resolveDurableScope(state, scope);
     const goalMode = state.chatGoalDraftMode ? { ...state.chatGoalDraftMode } : undefined;
     const attachments = (state.chatAttachments ?? []).map((attachment) =>
@@ -936,7 +930,7 @@ export class ChatComposerPersistence {
 
   private resolveDurableScope(
     state: DurableChatComposerPersistenceState,
-    scope: StoredChatOutboxScope = resolveStoredChatOutboxScope(state, state.sessionKey),
+    scope: StoredChatOutboxScope = resolveUiConversationIdentity(state, state.sessionKey),
   ) {
     if (state.selectedChatSessionIncognito) {
       return null;
@@ -955,7 +949,7 @@ export class ChatComposerPersistence {
 
   private resolveConnectedDurableScope(
     state: DurableChatComposerPersistenceState,
-    scope: StoredChatOutboxScope = resolveStoredChatOutboxScope(state, state.sessionKey),
+    scope: StoredChatOutboxScope = resolveUiConversationIdentity(state, state.sessionKey),
   ) {
     const recoveryScope = state.client?.recoveryScope?.trim();
     if (!state.connected || !state.client?.recoveryScopeReady || !recoveryScope) {
@@ -970,7 +964,7 @@ export class ChatComposerPersistence {
 
   private synchronizeDurablePersistence() {
     const state = this.getState();
-    if (!this.ready || !state) {
+    if (!this.ready || !state || this.publishing) {
       return;
     }
     const connectedScope = this.resolveConnectedDurableScope(state);
@@ -988,7 +982,7 @@ export class ChatComposerPersistence {
       return;
     }
     this.durableRetiredScopeKey = "";
-    const scope = connectedScope;
+    const scope = this.resolveDurableScope(state);
     if (!scope) {
       return;
     }
@@ -1073,7 +1067,7 @@ export class ChatComposerPersistence {
         this.latestDraftRevision = adoptedRevision;
         this.lastPersisted = this.snapshot(state, adoptedRevision, adoptedRevision);
         persistChatComposerStateResult(state, state.sessionKey, {
-          agentId: resolveStoredChatOutboxScope(state, state.sessionKey).agentId,
+          agentId: resolveUiConversationIdentity(state, state.sessionKey).agentId,
           draft: state.chatMessage,
           goalMode: state.chatGoalDraftMode,
           draftRevision: adoptedRevision,
@@ -1103,9 +1097,9 @@ export class ChatComposerPersistence {
 
   private readDraftRevisions(
     state: DurableChatComposerPersistenceState,
-    scope = resolveStoredChatOutboxScope(state, state.sessionKey),
+    scope = resolveUiConversationIdentity(state, state.sessionKey),
   ): ChatComposerDraftRevisionState {
-    return loadChatComposerDraftRevisionState(state, scope);
+    return loadCapturedChatComposerState(state, scope).revisions;
   }
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/pages/chat/durable-composer-persistence.ts
+++ b/ui/src/pages/chat/durable-composer-persistence.ts
@@ -40,7 +40,6 @@ type RestoredDraft = {
 const reportedStorageOwners = new Set<string>();
 
 const durableComposerStore = import("../../lib/chat/composer-draft-store.runtime.ts");
-const loadDurableComposerStore = () => durableComposerStore;
 
 function durableComposerOwnerKey(scope: DurableComposerDraftScope): string {
   return JSON.stringify([scope.gatewayOwner, scope.recoveryScope]);
@@ -188,7 +187,7 @@ export async function hydrateDurableComposerAttachments(
 }
 
 export async function writeDurableComposerSnapshot(snapshot: DurableChatComposerSnapshot) {
-  const { writeDurableComposerDraft } = await loadDurableComposerStore();
+  const { writeDurableComposerDraft } = await durableComposerStore;
   const payloadUnavailable = snapshot.storedAttachments === null;
   const result = await writeDurableComposerDraft(
     snapshot.scope,
@@ -281,7 +280,7 @@ export class DurableChatComposerPersistence {
   retire(scope: DurableComposerDraftScope, minimumRevision: number) {
     this.resetRestoreScope();
     const run = async () => {
-      const { retireDurableComposerDraft } = await loadDurableComposerStore();
+      const { retireDurableComposerDraft } = await durableComposerStore;
       const result = await retireDurableComposerDraft(scope, minimumRevision);
       if (result.status === "storage-failed") {
         reportDurableComposerStorageError(scope, this.onStorageError);
@@ -312,8 +311,7 @@ export class DurableChatComposerPersistence {
     apply: (draft: RestoredDraft) => void,
     onCurrentWins: (storedRevision: number) => void,
   ) {
-    const { readDurableComposerDraft, prepareDurableComposerRecovery } =
-      await loadDurableComposerStore();
+    const { readDurableComposerDraft, prepareDurableComposerRecovery } = await durableComposerStore;
     if (baseline.scope.scopeKey.startsWith("chat:v3:")) {
       const recovery = await prepareDurableComposerRecovery(baseline.scope);
       if (recovery.status === "storage-failed") {

--- a/ui/src/pages/chat/outbox-identity.test.ts
+++ b/ui/src/pages/chat/outbox-identity.test.ts
@@ -6,16 +6,18 @@ import {
   restoreChatOutboxRecovery,
 } from "../../lib/chat/outbox-recovery.ts";
 import {
+  captureChatOutboxAdmission,
   storageTargetForGateway,
   subscribeStoredChatOutboxChanges,
 } from "../../lib/chat/outbox-store.ts";
+import { resolveUiConversationIdentity } from "../../lib/sessions/session-key.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
+import { readQueuedMessageById, removeQueuedMessage, updateQueuedMessage } from "./chat-queue.ts";
 import {
   admitStoredChatComposerQueueItem,
   listStoredChatOutboxes,
   loadChatComposerSnapshot,
   persistChatComposerState,
-  resolveStoredChatOutboxScope,
   updateStoredChatComposerQueueItem,
   removeStoredChatComposerQueueItem,
 } from "./composer-persistence.ts";
@@ -53,7 +55,7 @@ describe("outbox destination identity", () => {
       const host = { ...state, sessionKey: input };
       expect(persistChatComposerState(host)).toBe(true);
       expect(
-        admitStoredChatComposerQueueItem(host, input, {
+        admitStoredChatComposerQueueItem(host, captureChatOutboxAdmission(host, input), {
           id: "queued",
           text: "follow up",
           createdAt: 1,
@@ -83,11 +85,11 @@ describe("outbox destination identity", () => {
 
   it("maps main aliases to global only under configured global scope", () => {
     const host = { ...state, agentsList: { ...state.agentsList, scope: "global" } };
-    expect(resolveStoredChatOutboxScope(host, "main")).toEqual({
+    expect(resolveUiConversationIdentity(host, "main")).toEqual({
       sessionKey: "global",
       agentId: "default",
     });
-    expect(resolveStoredChatOutboxScope(host, "agent:other:workspace")).toEqual({
+    expect(resolveUiConversationIdentity(host, "agent:other:workspace")).toEqual({
       sessionKey: "global",
       agentId: "other",
     });
@@ -368,6 +370,20 @@ describe("partially preserved legacy identity", () => {
 });
 
 describe("captured outbox scope review regressions", () => {
+  it("keeps only row data when a durable row becomes a local model wait", () => {
+    const host = { ...state, hello: null };
+    const admission = captureChatOutboxAdmission(host, host.sessionKey);
+    const item = { id: "model-wait", text: "keep target", createdAt: 1 };
+    expect(admitStoredChatComposerQueueItem(host, admission, item)).toBe(true);
+    const stored = listStoredChatOutboxes(host)[0]!.queue[0]!;
+
+    updateQueuedMessage(host, item.id, (current) => ({ ...current, sendState: "waiting-model" }));
+
+    expect(readQueuedMessageById(host, item.id)).toEqual({ ...stored, sendState: "waiting-model" });
+    expect(removeQueuedMessage(host, item.id)).toBe("removed");
+    expect(host.chatQueue).toEqual([]);
+    expect(readQueuedMessageById(host, item.id)).toBeNull();
+  });
   it("verifies the admitted queue target when a notification changes defaults", () => {
     const host = { ...state, agentsList: { ...state.agentsList } };
     const unsubscribe = subscribeStoredChatOutboxChanges(() => {
@@ -375,7 +391,11 @@ describe("captured outbox scope review regressions", () => {
     });
     try {
       const item = { id: "captured-admission", text: "keep target", createdAt: 1 };
-      const admitted = admitStoredChatComposerQueueItem(host, "main", item);
+      const admitted = admitStoredChatComposerQueueItem(
+        host,
+        captureChatOutboxAdmission(host, "main"),
+        item,
+      );
       expect(listStoredChatOutboxes(host)).toEqual([
         {
           sessionKey: state.sessionKey,
@@ -395,11 +415,15 @@ describe("captured outbox scope review regressions", () => {
       agentsList: { defaultId: "main", mainKey: "main", scope: "per-sender" },
     };
     expect(
-      admitStoredChatComposerQueueItem(initial, initial.sessionKey, {
-        id: "captured",
-        text: "keep target",
-        createdAt: 1,
-      }),
+      admitStoredChatComposerQueueItem(
+        initial,
+        captureChatOutboxAdmission(initial, initial.sessionKey),
+        {
+          id: "captured",
+          text: "keep target",
+          createdAt: 1,
+        },
+      ),
     ).toBe(true);
     const changed = { ...initial, agentsList: { ...initial.agentsList, mainKey: "workspace" } };
     const original = listStoredChatOutboxes(changed)[0]!;

--- a/ui/src/pages/chat/queued-message-edit.test.ts
+++ b/ui/src/pages/chat/queued-message-edit.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { AgentsListResult } from "../../api/types.ts";
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
+import { captureChatOutboxAdmission } from "../../lib/chat/outbox-store.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import {
   getChatAttachmentDataUrl,
@@ -78,14 +79,18 @@ function queueHost(
   const unsubscribe = trackOutboxProjection(host as never);
   items.forEach((item, index) => {
     expect(
-      admitQueuedMessageForSession(host as never, SESSION_KEY, {
-        id: `queued-${index + 1}`,
-        text: `message ${index + 1}`,
-        createdAt: 1_000 + index,
-        sendState: "waiting-reconnect",
-        sessionKey: SESSION_KEY,
-        ...item,
-      }),
+      admitQueuedMessageForSession(
+        host as never,
+        captureChatOutboxAdmission(host, SESSION_KEY, item.agentId),
+        {
+          id: `queued-${index + 1}`,
+          text: `message ${index + 1}`,
+          createdAt: 1_000 + index,
+          sendState: "waiting-reconnect",
+          sessionKey: SESSION_KEY,
+          ...item,
+        },
+      ),
     ).toBe(true);
   });
   return { host, unsubscribe };
@@ -145,7 +150,7 @@ async function submitQueuedEdit(host: ReturnType<typeof makeChatHost>): Promise<
 describe("queued message edit round-trip", () => {
   it("keeps the row-local draft and attachments separate from the composer", () => {
     const attachment = { id: "att-1", mimeType: "image/png", dataUrl: "data:image/png;base64,iVB" };
-    const { host, unsubscribe } = queueHost([{}, { attachments: [attachment] }, {}]);
+    const { host } = queueHost([{}, { attachments: [attachment] }, {}]);
     host.chatMessage = "separate composer draft";
 
     expect(beginQueuedMessageEdit(host as never, "queued-2")).toBe("started");
@@ -158,11 +163,10 @@ describe("queued message edit round-trip", () => {
     expect(storedOrder(host)).toEqual(["message 1", "message 2", "message 3"]);
     expect(isQueuedMessageBeingEdited(host as never, "queued-2")).toBe(true);
     expect(isQueuedMessageBeingEdited(host as never, "queued-1")).toBe(false);
-    unsubscribe();
   });
 
   it("leaves the queue untouched when the edit is cancelled", () => {
-    const { host, unsubscribe } = queueHost([{}, {}, {}]);
+    const { host } = queueHost([{}, {}, {}]);
     host.chatMessage = "separate composer draft";
     beginQueuedMessageEdit(host as never, "queued-2");
     updateQueuedMessageEdit(host as never, "half-typed replacement");
@@ -173,13 +177,12 @@ describe("queued message edit round-trip", () => {
     expect(host.chatMessage).toBe("separate composer draft");
     expect(host.chatAttachments).toEqual([]);
     expect(isQueuedMessageBeingEdited(host as never, "queued-2")).toBe(false);
-    unsubscribe();
   });
 
   it("leaves composer attachments untouched when an edit is cancelled", () => {
     const original = stageQueuedImage("att-original");
     const added = stageQueuedImage("att-added");
-    const { host, unsubscribe } = queueHost([{ attachments: [original] }]);
+    const { host } = queueHost([{ attachments: [original] }]);
     host.chatAttachments = [added];
     beginQueuedMessageEdit(host as never, "queued-1");
 
@@ -189,11 +192,10 @@ describe("queued message edit round-trip", () => {
     expect(getChatAttachmentDataUrl(original)).not.toBeNull();
     expect(getChatAttachmentDataUrl(added)).not.toBeNull();
     expect(host.chatAttachments).toEqual([added]);
-    unsubscribe();
   });
 
   it("replaces the row in the same slot when the edited message is sent", async () => {
-    const { host, unsubscribe } = queueHost([{}, {}, {}]);
+    const { host } = queueHost([{}, {}, {}]);
     beginQueuedMessageEdit(host as never, "queued-2");
     updateQueuedMessageEdit(host as never, "message 2, corrected");
 
@@ -201,14 +203,13 @@ describe("queued message edit round-trip", () => {
 
     expect(storedOrder(host)).toEqual(["message 1", "message 2, corrected", "message 3"]);
     expect(isQueuedMessageBeingEdited(host as never, "queued-2")).toBe(false);
-    unsubscribe();
   });
 
   it.each(["/stop", "/compact", "stop"])(
     "keeps the source row and rejects a command-like inline edit: %s",
     async (command) => {
       const sendRequest = vi.fn(() => ({ status: "started" as const }));
-      const { host, unsubscribe } = queueHost([{}], {
+      const { host } = queueHost([{}], {
         chatRunId: "run-active",
         connected: true,
         requestHandlers: { "chat.send": sendRequest },
@@ -222,12 +223,11 @@ describe("queued message edit round-trip", () => {
       expect(host.chatQueuedEdit?.draftText).toBe(command);
       expect(sendRequest).not.toHaveBeenCalled();
       expect(host.chatError).toContain("Queued-row edits cannot run commands or stop aliases");
-      unsubscribe();
     },
   );
 
   it("keeps a composer send separate from an open row edit", async () => {
-    const { host, unsubscribe } = queueHost([{}, {}]);
+    const { host } = queueHost([{}, {}]);
     beginQueuedMessageEdit(host as never, "queued-1");
     updateQueuedMessageEdit(host as never, "message 1, corrected");
     host.chatMessage = "separate composer send";
@@ -236,7 +236,6 @@ describe("queued message edit round-trip", () => {
 
     expect(storedOrder(host)).toEqual(["message 1", "message 2", "separate composer send"]);
     expect(host.chatQueuedEdit?.draftText).toBe("message 1, corrected");
-    unsubscribe();
   });
 
   it.each(
@@ -246,7 +245,7 @@ describe("queued message edit round-trip", () => {
   )(
     "retains a stale edit after peer $mutation (route round trip: $roundTrip)",
     async ({ roundTrip, mutation }) => {
-      const { host, unsubscribe } = queueHost([{}, {}]);
+      const { host } = queueHost([{}, {}]);
       beginQueuedMessageEdit(host as never, "queued-1");
       updateQueuedMessageEdit(host as never, "message 1, corrected");
       const captured = host.chatQueuedEdit?.source;
@@ -276,7 +275,6 @@ describe("queued message edit round-trip", () => {
       expect(host.chatError).toBe(OFFLINE_QUEUE_STORAGE_ERROR);
       expect(cancelQueuedMessageEdit(host as never)).toBe(true);
       expect(storedOrder(host)).toEqual(expectedOrder);
-      unsubscribe();
     },
   );
 
@@ -284,7 +282,7 @@ describe("queued message edit round-trip", () => {
     const history = createDeferred<{ messages: unknown[] }>();
     const historyRequest = vi.fn(() => history.promise);
     const sendRequest = vi.fn(() => ({ status: "started" as const }));
-    const { host, unsubscribe } = queueHost([{}], {
+    const { host } = queueHost([{}], {
       chatLoading: true,
       connected: true,
       requestHandlers: {
@@ -303,14 +301,13 @@ describe("queued message edit round-trip", () => {
 
     expect(storedOrder(host)).toEqual(["message 1"]);
     expect(sendRequest).not.toHaveBeenCalled();
-    unsubscribe();
   });
 
   it("aborts a replacement when its draft changes during history loading", async () => {
     const history = createDeferred<{ messages: unknown[] }>();
     const historyRequest = vi.fn(() => history.promise);
     const sendRequest = vi.fn(() => ({ status: "started" as const }));
-    const { host, unsubscribe } = queueHost([{}], {
+    const { host } = queueHost([{}], {
       chatLoading: true,
       connected: true,
       requestHandlers: {
@@ -330,16 +327,11 @@ describe("queued message edit round-trip", () => {
     expect(storedOrder(host)).toEqual(["message 1"]);
     expect(host.chatQueuedEdit?.draftText).toBe("message 1, changed while loading");
     expect(sendRequest).not.toHaveBeenCalled();
-    unsubscribe();
   });
 
   it("preserves attachments and reply context on the replacement", async () => {
     const kept = stageQueuedImage("att-kept");
-    const { host, unsubscribe } = queueHost([
-      {},
-      { attachments: [kept], replyToId: "reply-source" },
-      {},
-    ]);
+    const { host } = queueHost([{}, { attachments: [kept], replyToId: "reply-source" }, {}]);
     beginQueuedMessageEdit(host as never, "queued-2");
     updateQueuedMessageEdit(host as never, "message 2, corrected");
     await submitQueuedEdit(host);
@@ -349,11 +341,10 @@ describe("queued message edit round-trip", () => {
     expect(replacement?.attachments?.map((attachment) => attachment.id)).toEqual(["att-kept"]);
     expect(replacement?.replyToId).toBe("reply-source");
     expect(getChatAttachmentDataUrl(kept)).not.toBeNull();
-    unsubscribe();
   });
 
   it("keeps the original queued when the replacement's stored write is rejected", async () => {
-    const { host, unsubscribe } = queueHost([{}, {}, {}]);
+    const { host } = queueHost([{}, {}, {}]);
     beginQueuedMessageEdit(host as never, "queued-2");
     updateQueuedMessageEdit(host as never, "message 2, corrected");
     rejectStoredGrowth();
@@ -367,7 +358,6 @@ describe("queued message edit round-trip", () => {
     expect(isQueuedMessageBeingEdited(host as never, "queued-2")).toBe(true);
     expect(host.chatQueuedEdit?.draftText).toBe("message 2, corrected");
     expect(host.chatError).toBe(OFFLINE_QUEUE_STORAGE_ERROR);
-    unsubscribe();
   });
 
   it("fences peer remove, reorder, retry, and steer actions while a row edit is open", async () => {
@@ -455,7 +445,7 @@ describe("queued message edit round-trip", () => {
   it("does not collapse same-payload row and composer sends", async () => {
     const ack = createDeferred<{ status: "started" }>();
     const sendRequest = vi.fn(() => ack.promise);
-    const { host, unsubscribe } = queueHost([{}], {
+    const { host } = queueHost([{}], {
       connected: true,
       requestHandlers: { "chat.send": sendRequest },
     });
@@ -471,21 +461,24 @@ describe("queued message edit round-trip", () => {
 
     ack.resolve({ status: "started" });
     await Promise.all([rowSend, composerSend]);
-    unsubscribe();
   });
 
   it("cannot retire a row in the outbox a global agent switch left behind", async () => {
     const host = makeChatHost({ assistantAgentId: "lily", connected: false, sessionKey: "global" });
     const unsubscribe = trackOutboxProjection(host as never);
     expect(
-      admitQueuedMessageForSession(host as never, "global", {
-        id: "queued-1",
-        text: "message 1",
-        agentId: "lily",
-        createdAt: 1_000,
-        sendState: "waiting-reconnect",
-        sessionKey: "global",
-      }),
+      admitQueuedMessageForSession(
+        host as never,
+        captureChatOutboxAdmission(host, "global", "lily"),
+        {
+          id: "queued-1",
+          text: "message 1",
+          agentId: "lily",
+          createdAt: 1_000,
+          sendState: "waiting-reconnect",
+          sessionKey: "global",
+        },
+      ),
     ).toBe(true);
     expect(beginQueuedMessageEdit(host as never, "queued-1")).toBe("started");
 
@@ -504,19 +497,8 @@ describe("queued message edit round-trip", () => {
     unsubscribe();
   });
 
-  it("starts a row edit while the composer holds a separate message", () => {
-    const { host, unsubscribe } = queueHost([{}, {}]);
-    host.chatMessage = "typing something else";
-
-    expect(beginQueuedMessageEdit(host as never, "queued-1")).toBe("started");
-
-    expect(storedOrder(host)).toEqual(["message 1", "message 2"]);
-    expect(host.chatMessage).toBe("typing something else");
-    unsubscribe();
-  });
-
   it("edits one row at a time and rejects a submit naming another row", async () => {
-    const { host, unsubscribe } = queueHost([{}, {}]);
+    const { host } = queueHost([{}, {}]);
     beginQueuedMessageEdit(host as never, "queued-1");
 
     expect(beginQueuedMessageEdit(host as never, "queued-2")).toBe("unavailable");
@@ -525,17 +507,15 @@ describe("queued message edit round-trip", () => {
     });
     expect(storedOrder(host)).toEqual(["message 1", "message 2"]);
     expect(host.chatQueuedEdit?.id).toBe("queued-1");
-    unsubscribe();
   });
 
   it.each([
     { label: "a local command", overrides: { localCommandName: "compact" } },
     { label: "a delivery-uncertain row", overrides: { sendState: "unconfirmed" as const } },
   ])("refuses to edit $label", ({ overrides }) => {
-    const { host, unsubscribe } = queueHost([overrides]);
+    const { host } = queueHost([overrides]);
 
     expect(beginQueuedMessageEdit(host as never, "queued-1")).toBe("unavailable");
-    unsubscribe();
   });
 
   it.each([false, true])(
@@ -605,7 +585,7 @@ describe("queued message edit round-trip", () => {
   );
 
   it("leaves the edit behind when the pane routes to another session", () => {
-    const { host, unsubscribe } = queueHost([{}, {}]);
+    const { host } = queueHost([{}, {}]);
     beginQueuedMessageEdit(host as never, "queued-1");
 
     host.sessionKey = "agent:other";
@@ -614,6 +594,5 @@ describe("queued message edit round-trip", () => {
     // and the stale edit must not lock the composer in the new session either.
     expect(isQueuedMessageBeingEdited(host as never, "queued-1")).toBe(false);
     expect(cancelQueuedMessageEdit(host as never)).toBe(false);
-    unsubscribe();
   });
 });

--- a/ui/src/pages/chat/queued-message-edit.ts
+++ b/ui/src/pages/chat/queued-message-edit.ts
@@ -4,6 +4,7 @@ import { chatQueueOrderKey, isMovableChatQueueItem } from "../../lib/chat/chat-q
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { sameQueuedDeliveryVersion } from "../../lib/chat/outbox-store-codec.ts";
 import { storageTargetForGateway } from "../../lib/chat/outbox-store.ts";
+import { resolveUiConversationIdentity } from "../../lib/sessions/session-key.ts";
 import {
   getChatAttachmentDataUrl,
   releaseChatAttachmentPayloads,
@@ -15,7 +16,7 @@ import {
   removeVisibleOrScopedQueuedMessageWithoutReleasing,
   type ChatQueueScopedSessionHost,
 } from "./chat-queue.ts";
-import { resolveStoredChatOutboxScope, storedChatOutboxScopeKey } from "./composer-persistence.ts";
+import { storedChatOutboxScopeKey } from "./composer-persistence.ts";
 
 /**
  * The edited row stays in the queue, holding its own place, so the operator can
@@ -51,7 +52,7 @@ function currentQueuedMessageEditOwner(host: QueuedMessageEditHost) {
     return null;
   }
   return {
-    ...resolveStoredChatOutboxScope(host, host.sessionKey),
+    ...resolveUiConversationIdentity(host, host.sessionKey),
     gatewayOwner: storageTargetForGateway(host.settings?.gatewayUrl).gatewayOwner,
     recoveryScope: host.client?.recoveryScope?.trim() || undefined,
   };
@@ -105,7 +106,7 @@ export function isQueuedMessageBeingEdited(host: QueuedMessageEditHost, id: stri
       pane.chatQueuedEdit?.id === id &&
       pane.chatQueuedEdit.gatewayOwner === gatewayOwner &&
       storedChatOutboxScopeKey(pane.chatQueuedEdit) ===
-        storedChatOutboxScopeKey(resolveStoredChatOutboxScope(pane, pane.sessionKey)),
+        storedChatOutboxScopeKey(resolveUiConversationIdentity(pane, pane.sessionKey)),
   );
 }
 

--- a/ui/src/pages/new-session/draft-persistence.ts
+++ b/ui/src/pages/new-session/draft-persistence.ts
@@ -20,8 +20,9 @@ type NewSessionDraftState = {
   incognito: boolean;
 };
 
+type DraftLineage = { revision: number; writeId?: string; localWriteIds: Set<string> };
+
 const durableComposerStore = import("../../lib/chat/composer-draft-store.runtime.ts");
-const loadDurableComposerStore = () => durableComposerStore;
 const NEW_SESSION_DRAFT_PERSIST_DELAY_MS = 200;
 
 export class NewSessionDraftPersistence {
@@ -40,9 +41,7 @@ export class NewSessionDraftPersistence {
   private pending: DurableChatComposerSnapshot | null = null;
   private timer: ReturnType<typeof globalThis.setTimeout> | null = null;
   private incognitoRetirement: Promise<void> = Promise.resolve();
-  private readonly committedByScope = new Map<string, number>();
-  private readonly committedWriteIdByScope = new Map<string, string>();
-  private readonly localWriteIdsByScope = new Map<string, Set<string>>();
+  private readonly lineageByScope = new Map<string, DraftLineage>();
 
   constructor(
     private readonly read: () => NewSessionDraftState,
@@ -148,94 +147,86 @@ export class NewSessionDraftPersistence {
     this.timer = globalThis.setTimeout(() => this.persistNow(), NEW_SESSION_DRAFT_PERSIST_DELAY_MS);
   }
 
-  retireActive(): Promise<void> {
+  async retireActive(): Promise<void> {
     this.mutationGeneration += 1;
     this.discardPending();
     const requestedRevision = nextDraftRevision(this.revision);
     this.revision = requestedRevision;
     const scope = this.scope();
     if (!scope) {
-      return Promise.resolve();
+      return;
     }
-    return this.enqueueWrite(async () => {
-      const { retireDurableComposerDraft } = await loadDurableComposerStore();
-      const identity = durableComposerScopeIdentity(scope);
-      const minimumRevision = Math.max(requestedRevision, this.committedByScope.get(identity) ?? 0);
-      const result = await retireDurableComposerDraft(scope, minimumRevision);
-      if (result.status === "storage-failed") {
-        reportDurableComposerStorageError(scope, this.onStorageError);
-      } else if (result.status === "persisted") {
-        this.localWriteIdsByScope.delete(identity);
-        this.adoptCommittedRevision(scope, result.revision ?? minimumRevision, result.writeId);
-      }
-    });
+    const { retireDurableComposerDraft } = await durableComposerStore;
+    const lineage = this.lineage(scope);
+    const minimumRevision = Math.max(requestedRevision, lineage.revision);
+    const result = await retireDurableComposerDraft(scope, minimumRevision);
+    if (result.status === "storage-failed") {
+      reportDurableComposerStorageError(scope, this.onStorageError);
+    } else if (result.status === "persisted") {
+      lineage.localWriteIds.clear();
+      this.adoptCommittedRevision(scope, result.revision ?? minimumRevision, result.writeId);
+    }
   }
 
-  clearSubmittedDraft(): Promise<void> {
+  async clearSubmittedDraft(): Promise<void> {
     this.persistNow();
     this.mutationGeneration += 1;
     const scope = this.scope();
     if (!scope) {
-      return Promise.resolve();
+      return;
     }
     const submitted = this.read();
     const submittedAttachments = captureDurableChatAttachments(submitted.attachments);
-    return this.enqueueWrite(async () => {
-      const { readDurableComposerDraft } = await loadDurableComposerStore();
-      const identity = durableComposerScopeIdentity(scope);
-      let expectedRevision = this.committedByScope.get(identity) ?? 0;
-      let expectedWriteId = this.committedWriteIdByScope.get(identity);
-      // A closing source page can finish an identical write between read and CAS.
-      // Re-read boundedly; differing newer content always wins immediately.
-      for (let attempt = 0; attempt < 3; attempt += 1) {
-        const current = await readDurableComposerDraft(scope);
-        if (current.status === "storage-failed") {
-          reportDurableComposerStorageError(scope, this.onStorageError);
-          return;
-        }
-        const currentRevision =
-          (current.status === "found" ? current.draft.revision : current.revision) ?? 0;
-        const currentWriteId = current.status === "found" ? current.draft.writeId : current.writeId;
-        if (currentRevision !== expectedRevision || currentWriteId !== expectedWriteId) {
-          if (
-            current.status !== "found" ||
-            !(await durableComposerDraftMatches(
-              current.draft,
-              submitted.message,
-              submittedAttachments,
-            ))
-          ) {
-            return;
-          }
-          expectedRevision = currentRevision;
-          expectedWriteId = currentWriteId;
-          this.adoptCommittedRevision(scope, currentRevision, currentWriteId);
-        }
-        const revision = nextDraftRevision(Math.max(this.revision, expectedRevision));
-        const writeId = `clear:${revision}`;
-        const { result } = await writeDurableComposerSnapshot({
-          scope,
-          expectedRevision,
-          ...(expectedWriteId ? { expectedWriteId } : {}),
-          revision,
-          text: "",
-          storedAttachments: [],
-          writeId,
-        });
-        if (result.status === "persisted") {
-          this.adoptCommittedRevision(
-            scope,
-            result.revision ?? revision,
-            result.writeId ?? writeId,
-          );
-          return;
-        }
-        if (result.status === "storage-failed") {
-          reportDurableComposerStorageError(scope, this.onStorageError);
-          return;
-        }
+    const { readDurableComposerDraft } = await durableComposerStore;
+    const lineage = this.lineage(scope);
+    let expectedRevision = lineage.revision;
+    let expectedWriteId = lineage.writeId;
+    // A closing source page can finish an identical write between read and CAS.
+    // Re-read boundedly; differing newer content always wins immediately.
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const current = await readDurableComposerDraft(scope);
+      if (current.status === "storage-failed") {
+        reportDurableComposerStorageError(scope, this.onStorageError);
+        return;
       }
-    });
+      const currentRevision =
+        (current.status === "found" ? current.draft.revision : current.revision) ?? 0;
+      const currentWriteId = current.status === "found" ? current.draft.writeId : current.writeId;
+      if (currentRevision !== expectedRevision || currentWriteId !== expectedWriteId) {
+        if (
+          current.status !== "found" ||
+          !(await durableComposerDraftMatches(
+            current.draft,
+            submitted.message,
+            submittedAttachments,
+          ))
+        ) {
+          return;
+        }
+        expectedRevision = currentRevision;
+        expectedWriteId = currentWriteId;
+        this.adoptCommittedRevision(scope, currentRevision, currentWriteId);
+      }
+      const revision = nextDraftRevision(Math.max(this.revision, expectedRevision));
+      const writeId = `clear:${revision}`;
+      const { result } = await writeDurableComposerSnapshot({
+        scope,
+        expectedRevision,
+        ...(expectedWriteId ? { expectedWriteId } : {}),
+        revision,
+        text: "",
+        storedAttachments: [],
+        writeId,
+      });
+      if (result.status === "persisted") {
+        this.adoptCommittedRevision(scope, result.revision ?? revision, result.writeId ?? writeId);
+        return;
+      }
+      if (result.status === "storage-failed") {
+        reportDurableComposerStorageError(scope, this.onStorageError);
+        return;
+      }
+    }
   }
 
   persistNow() {
@@ -249,8 +240,9 @@ export class NewSessionDraftPersistence {
       return;
     }
     this.pending = null;
-    void this.enqueueWrite(async () => {
-      const identity = durableComposerScopeIdentity(snapshot.scope);
+    // Start each captured write before teardown; native transactions and CAS
+    // order writes without delaying attachments behind a promise chain.
+    void (async () => {
       try {
         const { result, payloadUnavailable } = await writeDurableComposerSnapshot(snapshot);
         if (payloadUnavailable) {
@@ -278,13 +270,9 @@ export class NewSessionDraftPersistence {
         this.restoredIdentity = "";
         this.activateRoute(this.routeKey);
       } finally {
-        const localWriteIds = this.localWriteIdsByScope.get(identity);
-        localWriteIds?.delete(snapshot.writeId);
-        if (localWriteIds?.size === 0) {
-          this.localWriteIdsByScope.delete(identity);
-        }
+        this.forgetLocalWrite(snapshot);
       }
-    });
+    })();
   }
 
   disconnect() {
@@ -309,16 +297,14 @@ export class NewSessionDraftPersistence {
       return null;
     }
     const state = this.read();
-    const identity = durableComposerScopeIdentity(scope);
-    const expectedWriteIds = [...(this.localWriteIdsByScope.get(identity) ?? [])];
+    const lineage = this.lineage(scope);
+    const expectedWriteIds = [...lineage.localWriteIds];
     const writeId = `${this.revision}:${Math.random().toString(36).slice(2)}`;
-    this.rememberLocalWriteId(identity, writeId);
+    lineage.localWriteIds.add(writeId);
     return {
       scope,
-      expectedRevision: this.committedByScope.get(identity) ?? 0,
-      ...(this.committedWriteIdByScope.get(identity)
-        ? { expectedWriteId: this.committedWriteIdByScope.get(identity) }
-        : {}),
+      expectedRevision: lineage.revision,
+      ...(lineage.writeId ? { expectedWriteId: lineage.writeId } : {}),
       expectedWriteIds,
       revision: this.revision,
       text: state.message,
@@ -333,7 +319,7 @@ export class NewSessionDraftPersistence {
     mutationGeneration: number,
     signature: string,
   ) {
-    const { readDurableComposerDraft } = await loadDurableComposerStore();
+    const { readDurableComposerDraft } = await durableComposerStore;
     const result = await readDurableComposerDraft(scope);
     if (result.status === "storage-failed") {
       reportDurableComposerStorageError(scope, this.onStorageError);
@@ -341,16 +327,10 @@ export class NewSessionDraftPersistence {
     }
     const storedRevision = result.status === "found" ? result.draft.revision : result.revision;
     const storedWriteId = result.status === "found" ? result.draft.writeId : result.writeId;
-    const identity = durableComposerScopeIdentity(scope);
-    if (storedRevision !== undefined) {
-      this.committedByScope.set(identity, storedRevision);
-      if (storedWriteId) {
-        this.committedWriteIdByScope.set(identity, storedWriteId);
-      }
-    } else {
-      this.committedByScope.delete(identity);
-      this.committedWriteIdByScope.delete(identity);
-    }
+    const lineage = this.lineage(scope);
+    // An absent authoritative row clears committed facts, never in-flight IDs.
+    lineage.revision = storedRevision ?? 0;
+    lineage.writeId = storedWriteId;
     const current = this.read();
     const currentScope = this.scope();
     if (
@@ -408,12 +388,6 @@ export class NewSessionDraftPersistence {
     this.apply(result.status === "found" ? result.draft.text : "", attachments);
   }
 
-  private enqueueWrite(run: () => Promise<void>): Promise<void> {
-    // Flush timers before teardown, then start each IndexedDB transaction independently.
-    // Store ordering and revision CAS serialize writes without promise-chain delays.
-    return run();
-  }
-
   private clearTimer() {
     if (this.timer === null) {
       return;
@@ -429,18 +403,29 @@ export class NewSessionDraftPersistence {
     if (!snapshot) {
       return;
     }
+    this.forgetLocalWrite(snapshot);
+  }
+
+  private forgetLocalWrite(snapshot: DurableChatComposerSnapshot) {
     const identity = durableComposerScopeIdentity(snapshot.scope);
-    const localWriteIds = this.localWriteIdsByScope.get(identity);
-    localWriteIds?.delete(snapshot.writeId);
-    if (localWriteIds?.size === 0) {
-      this.localWriteIdsByScope.delete(identity);
+    const lineage = this.lineageByScope.get(identity);
+    if (!lineage) {
+      return;
+    }
+    lineage.localWriteIds.delete(snapshot.writeId);
+    if (!lineage.revision && !lineage.writeId && !lineage.localWriteIds.size) {
+      this.lineageByScope.delete(identity);
     }
   }
 
-  private rememberLocalWriteId(identity: string, writeId: string) {
-    const writeIds = this.localWriteIdsByScope.get(identity) ?? new Set<string>();
-    writeIds.add(writeId);
-    this.localWriteIdsByScope.set(identity, writeIds);
+  private lineage(scope: DurableComposerDraftScope): DraftLineage {
+    const identity = durableComposerScopeIdentity(scope);
+    let lineage = this.lineageByScope.get(identity);
+    if (!lineage) {
+      lineage = { revision: 0, localWriteIds: new Set() };
+      this.lineageByScope.set(identity, lineage);
+    }
+    return lineage;
   }
 
   private adoptCommittedRevision(
@@ -449,9 +434,10 @@ export class NewSessionDraftPersistence {
     writeId?: string,
   ) {
     const identity = durableComposerScopeIdentity(scope);
-    this.committedByScope.set(identity, revision);
+    const lineage = this.lineage(scope);
+    lineage.revision = revision;
     if (writeId) {
-      this.committedWriteIdByScope.set(identity, writeId);
+      lineage.writeId = writeId;
     }
     const currentScope = this.scope();
     if (

--- a/ui/src/pages/new-session/rejected-initial-turn.ts
+++ b/ui/src/pages/new-session/rejected-initial-turn.ts
@@ -29,6 +29,12 @@ export function retainRejectedInitialTurn(options: {
     sessionKey: options.sessionKey,
     agentId: normalizeAgentId(options.agentId),
   };
+  // The rejected turn already has a server-created destination; never resolve
+  // it against the defaults of a later selected route.
+  const admission = {
+    scope: { sessionKey: rejectedItem.sessionKey, agentId: rejectedItem.agentId },
+    awaitingDefaults: false,
+  };
   const persisted = admitStoredChatComposerQueueItem(
     {
       settings: loadSettings(),
@@ -36,7 +42,7 @@ export function retainRejectedInitialTurn(options: {
       agentsList: options.context.agents.state.agentsList,
       hello: gateway.hello,
     },
-    options.sessionKey,
+    admission,
     rejectedItem,
   );
   if (persisted) {

--- a/ui/src/styles/chat/attachments.css
+++ b/ui/src/styles/chat/attachments.css
@@ -2,120 +2,34 @@
   position: relative;
   display: inline-block;
   flex: none;
-  color: var(--file-icon-glyph);
-}
-
-.chat-attachment-file-icon[data-mode="large-placeholder"] {
   width: 44px;
   height: 44px;
+  color: var(--file-icon-glyph);
+  background: var(--chat-file-icon-shell-dark) center / contain no-repeat;
 }
 
 .chat-attachment-file-icon[data-mode="preview-with-favicon"] {
   width: 20px;
   height: 20px;
-}
-
-.chat-attachment-file-icon__large,
-.chat-attachment-file-icon__compact {
-  position: absolute;
-  inset: 0;
-  display: none;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: contain;
-}
-
-.chat-attachment-file-icon[data-mode="large-placeholder"] .chat-attachment-file-icon__large {
-  display: block;
-  background-image: var(--chat-file-icon-shell-dark);
-}
-
-.chat-attachment-file-icon[data-mode="preview-with-favicon"] .chat-attachment-file-icon__compact {
-  display: block;
   background-image: var(--chat-file-icon-compact-dark);
 }
 
-:root[data-theme-mode="light"]
-  .chat-attachment-file-icon[data-mode="large-placeholder"]
-  .chat-attachment-file-icon__large {
+:root[data-theme-mode="light"] .chat-attachment-file-icon {
   background-image: var(--chat-file-icon-shell-light);
 }
 
-:root[data-theme-mode="light"]
-  .chat-attachment-file-icon[data-mode="preview-with-favicon"]
-  .chat-attachment-file-icon__compact {
+:root[data-theme-mode="light"] .chat-attachment-file-icon[data-mode="preview-with-favicon"] {
   background-image: var(--chat-file-icon-compact-light);
 }
 
 .chat-attachment-file-icon__overlay {
   position: absolute;
-  top: 15px;
-  left: 15px;
-  width: 14px;
-  height: 14px;
-  background-color: var(--chat-file-icon-accent, currentColor);
+  inset: 15px;
+  background-color: var(--chat-file-icon-accent);
   -webkit-mask: var(--chat-file-icon-overlay) center / 14px 14px no-repeat;
   mask: var(--chat-file-icon-overlay) center / 14px 14px no-repeat;
 }
 
-.chat-attachment-file-icon--unavailable
-  :is(.chat-attachment-file-icon__large, .chat-attachment-file-icon__compact) {
+.chat-attachment-file-icon--unavailable {
   opacity: 0.42;
-}
-
-.chat-assistant-attachment-card__title--unavailable {
-  color: var(--muted);
-  text-decoration: line-through;
-  text-decoration-color: color-mix(in srgb, currentColor 35%, transparent);
-  text-decoration-thickness: 1px;
-}
-
-.chat-assistant-attachment-card--recoverable {
-  color: var(--warn);
-}
-
-.chat-assistant-attachment-card--definitive {
-  color: var(--danger);
-}
-
-.chat-assistant-attachment-card--recoverable .chat-assistant-attachment-card__status-meta,
-.chat-assistant-attachment-card--definitive .chat-assistant-attachment-card__status-meta,
-.chat-assistant-attachment-card--recoverable .chat-attachment-file-icon,
-.chat-assistant-attachment-card--definitive .chat-attachment-file-icon {
-  color: currentColor;
-}
-
-.chat-assistant-attachment-card--checking {
-  --skeleton-base: color-mix(in srgb, var(--muted) 15%, transparent);
-  --skeleton-highlight: color-mix(in srgb, var(--text) 30%, transparent);
-}
-
-.chat-assistant-attachment-card--checking .chat-assistant-attachment-card__status-meta {
-  inline-size: clamp(112px, 14vw, 144px);
-  max-inline-size: 100%;
-}
-
-.chat-assistant-attachment-card__action-skeleton {
-  position: absolute;
-  inset-block-start: 0;
-  inset-inline-end: 0;
-  inline-size: 64px;
-  block-size: 30px;
-  flex: none;
-  border-radius: 999px;
-}
-
-.chat-assistant-attachment-card__actions--loading {
-  position: relative;
-  padding-inline-start: 38px;
-  block-size: 30px;
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.chat-assistant-attachment-card__actions--loading::before {
-  content: attr(data-label);
-  visibility: hidden;
-  padding: 0 12px;
-  border: 1px solid transparent;
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1462,12 +1462,6 @@ openclaw-chat-video-player {
   padding: 0;
 }
 
-.chat-assistant-attachment-card--compact,
-.chat-assistant-attachment-card--blocked {
-  display: block;
-  padding: 0;
-}
-
 .chat-assistant-attachment-card--blocked {
   color: var(--text);
 }
@@ -1647,9 +1641,60 @@ openclaw-chat-video-player {
   width: auto;
   padding: 0 12px;
   border: 1px solid var(--chat-attachment-border, var(--border-strong));
-  color: var(--text);
   font-size: 12px;
   font-weight: 600;
+}
+
+.chat-assistant-attachment-card__title--unavailable {
+  color: var(--muted);
+  text-decoration: line-through color-mix(in srgb, currentColor 35%, transparent) 1px;
+}
+
+.chat-assistant-attachment-card--recoverable {
+  color: var(--warn);
+}
+
+.chat-assistant-attachment-card--definitive {
+  color: var(--danger);
+}
+
+:is(.chat-assistant-attachment-card--recoverable, .chat-assistant-attachment-card--definitive)
+  :is(.chat-assistant-attachment-card__status-meta, .chat-attachment-file-icon) {
+  color: inherit;
+}
+
+.chat-assistant-attachment-card--checking {
+  --skeleton-base: color-mix(in srgb, var(--muted) 15%, transparent);
+  --skeleton-highlight: color-mix(in srgb, var(--text) 30%, transparent);
+}
+
+.chat-assistant-attachment-card__status-meta.skeleton {
+  inline-size: clamp(112px, 14vw, 144px);
+  max-inline-size: 100%;
+}
+
+.chat-assistant-attachment-card__action-skeleton {
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline-end: 0;
+  inline-size: 64px;
+  block-size: 30px;
+  border-radius: 999px;
+}
+
+.chat-assistant-attachment-card__actions--loading {
+  position: relative;
+  padding-inline-start: 38px;
+  block-size: 30px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.chat-assistant-attachment-card__actions--loading::before {
+  content: attr(data-label);
+  visibility: hidden;
+  padding: 0 12px;
+  border: 1px solid transparent;
 }
 
 @media (hover: hover) and (pointer: fine) {

--- a/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
@@ -328,91 +328,52 @@ describe("mock gateway stateful sessions", () => {
     });
   });
 
-  it("does not publish a rejected catalog adoption to sessions.list", async ({ gatewayPage }) => {
-    const { window, execute } = gatewayPage;
-    const sessionKey = "agent:main:rejected-adoption";
-    const script = createControlUiMockGatewayInitScript({
-      methodResponses: {
-        "sessions.catalog.continue": {
-          __mockError: { code: "INVALID_REQUEST", message: "catalog adoption rejected" },
-        },
-      },
-    });
-    execute(script);
-
-    const socket = new window.WebSocket("ws://mock-gateway");
-    const frames: ResponseFrame[] = [];
-    socket.addEventListener("message", (event: MessageEvent) => {
-      frames.push(JSON.parse(String(event.data)) as ResponseFrame);
-    });
-    await flushMockTimers();
-
-    socket.send(
-      JSON.stringify({
-        type: "req",
-        id: "rejected-adoption",
-        method: "sessions.catalog.continue",
-        params: { catalogId: "codex", hostId: "gateway:local", threadId: "thread-1" },
-      }),
-    );
-    await flushMockTimers();
-    socket.send(
-      JSON.stringify({
-        type: "req",
-        id: "list-after-rejected-adoption",
-        method: "sessions.list",
-        params: { agentId: "main", search: "rejected-adoption" },
-      }),
-    );
-    await flushMockTimers();
-
-    const listed = frames.find((frame) => frame.id === "list-after-rejected-adoption")?.payload;
-    expect(listed).toMatchObject({ count: 1, sessions: [{ key: "agent:main:main" }] });
-    expect(JSON.stringify(listed)).not.toContain(sessionKey);
-  });
-
-  it("does not publish a rejected session creation to sessions.list", async ({ gatewayPage }) => {
-    const { window, execute } = gatewayPage;
-    const sessionKey = "agent:main:rejected-session";
-    const script = createControlUiMockGatewayInitScript({
-      methodResponses: {
-        "sessions.create": {
-          __mockError: { code: "INVALID_REQUEST", message: "session creation rejected" },
-        },
-      },
-    });
-    execute(script);
-
-    const socket = new window.WebSocket("ws://mock-gateway");
-    const frames: ResponseFrame[] = [];
-    socket.addEventListener("message", (event: MessageEvent) => {
-      frames.push(JSON.parse(String(event.data)) as ResponseFrame);
-    });
-    await flushMockTimers();
-
-    socket.send(
-      JSON.stringify({
-        type: "req",
-        id: "rejected-create",
-        method: "sessions.create",
-        params: { agentId: "main", key: sessionKey },
-      }),
-    );
-    await flushMockTimers();
-    socket.send(
-      JSON.stringify({
-        type: "req",
-        id: "list-after-rejection",
-        method: "sessions.list",
-        params: { agentId: "main", search: "rejected-session" },
-      }),
-    );
-    await flushMockTimers();
-
-    const listed = frames.find((frame) => frame.id === "list-after-rejection")?.payload;
-    expect(listed).toMatchObject({ count: 1, sessions: [{ key: "agent:main:main" }] });
-    expect(JSON.stringify(listed)).not.toContain(sessionKey);
-  });
+  it.for(["sessions.catalog.continue", "sessions.create"])(
+    "does not publish rejected %s materialization to sessions.list",
+    async (method, { gatewayPage }) => {
+      const { window, execute } = gatewayPage;
+      const sessionKey = "agent:main:rejected-session";
+      execute(
+        createControlUiMockGatewayInitScript({
+          methodResponses: {
+            [method]: {
+              __mockError: { code: "INVALID_REQUEST", message: "materialization rejected" },
+            },
+          },
+        }),
+      );
+      const socket = new window.WebSocket("ws://mock-gateway");
+      const frames: ResponseFrame[] = [];
+      socket.addEventListener("message", (event: MessageEvent) => {
+        frames.push(JSON.parse(String(event.data)) as ResponseFrame);
+      });
+      await flushMockTimers();
+      socket.send(
+        JSON.stringify({
+          type: "req",
+          id: "rejected",
+          method,
+          params:
+            method === "sessions.create"
+              ? { agentId: "main", key: sessionKey }
+              : { catalogId: "codex", hostId: "gateway:local", threadId: "thread-1" },
+        }),
+      );
+      await flushMockTimers();
+      socket.send(
+        JSON.stringify({
+          type: "req",
+          id: "list-after-rejection",
+          method: "sessions.list",
+          params: { agentId: "main", search: "rejected-session" },
+        }),
+      );
+      await flushMockTimers();
+      const listed = frames.find((frame) => frame.id === "list-after-rejection")?.payload;
+      expect(listed).toMatchObject({ count: 1, sessions: [{ key: "agent:main:main" }] });
+      expect(JSON.stringify(listed)).not.toContain(sessionKey);
+    },
+  );
 
   it("cycles subscription-scoped session events and stops after unsubscribe", async ({
     gatewayPage,

--- a/ui/src/test-helpers/control-ui-session-fixtures.ts
+++ b/ui/src/test-helpers/control-ui-session-fixtures.ts
@@ -12,16 +12,16 @@ export type ControlUiSessionFixture = {
 };
 
 // Also serialized into the page realm; keep these builders free of module captures.
-export function createControlUiSessionRow<T extends Partial<ControlUiSessionFixture>>(
+export function createControlUiSessionRow(
   key: string,
   label: string,
   updatedAt: number,
-  options: T,
+  options?: Partial<ControlUiSessionFixture>,
 ) {
-  const archivedAt = options.archivedAt ?? (options.archived ? updatedAt : undefined);
+  const archivedAt = options?.archivedAt ?? (options?.archived ? updatedAt : undefined);
   const pinnedAt =
     archivedAt === undefined
-      ? (options.pinnedAt ?? (options.pinned ? updatedAt : undefined))
+      ? (options?.pinnedAt ?? (options?.pinned ? updatedAt : undefined))
       : undefined;
   return {
     displayName: label,
@@ -35,8 +35,8 @@ export function createControlUiSessionRow<T extends Partial<ControlUiSessionFixt
     totalTokens: 0,
     updatedAt,
     ...options,
-    contextTokens: options.contextTokens ?? null,
-    kind: options.kind ?? "direct",
+    contextTokens: options?.contextTokens ?? null,
+    kind: options?.kind ?? "direct",
     pinned: pinnedAt !== undefined,
     pinnedAt,
     archived: archivedAt !== undefined,


### PR DESCRIPTION
Closes #133555 — offline split-pane drafts can remain only in tab storage after queue activity.
Closes #133603 — Cancel can close a queued edit after reconnect without waking delivery.

Related: #133067 — the earlier main-session recovery-target repair; #133409 — the already-landed custody simplification. Their changes are not duplicated here.

<details>
<summary>Additional instructions</summary>

Maintainer-owned branch in `openclaw/openclaw`; maintainers can update it.

</details>

## What Problem This Solves

Fixes an issue where users composing an independent draft while manipulating an offline split-pane queue could see newer text in the UI and tab storage while the native durable draft remained older. It also fixes Cancel closing a queued-message editor after reconnect without waking delivery: the original messages stayed parked until another event occurred.

This maintainer-requested follow-up removes repeated queue discovery, overlapping admission arguments, duplicate draft bookkeeping and thin adapters. Real-browser verification also exposed two nearby ownership mistakes: saved selection could override an explicit `/chat/main` URL, and first use of attachment icons during a complete Gateway outage could leave a rejected stylesheet import cached.

## Why This Change Was Made

The existing owners now carry their facts forward. One located queue row includes its captured destination; callers supply the admission captured before asynchronous work; committed and attempted draft revisions remain separate facts inside one record; New Session lineage retains in-flight writes without parallel maps. Composer persistence reserves its pending snapshot before synchronous publication can reenter it, and offline reconciliation uses the already-authenticated retained owner.

Cancel wakes the existing drain only after successfully releasing its local edit hold. It does not mutate storage, invent a retry or bypass history, uncertainty, credential or peer-edit checks. Explicit startup routes and attachment styles remain with their actual owners, while the sidebar asks the projection for domain answers rather than interpreting storage keys and raw maps.

**Storage boundary:** the consolidated maps are in-memory bookkeeping, not a serialized-format migration. Metadata v4, IndexedDB v2, storage keys and limits, retention, migration receipts/source retention, tombstones, revision/CAS and winner semantics, uncertainty, and Blob custody remain unchanged. No new dependency, configuration option, schema, compatibility layer, timeout increase or performance-budget change.

## User Impact

Independent drafts remain durably committed through offline queue activity. Cancel resumes original queued messages in order, preserving their original run IDs and attachment bytes, without submitting or overwriting the main composer draft. Explicit agent URLs win over saved selection, and attachment icons work on first offline use.

The cleanup removes **114 production lines**: **+509/−623**. Tests/support are **+1,079/−422, net +657**, across **80 files** overall. Upstream #133409's 139 removed production lines are excluded. The structural reduction includes one queue-location policy, consolidated revision/lineage containers, explicit admission capture, and removal of forwarding layers, obsolete scope reexports, promise-return wrappers and raw-map sidebar coupling.

## Evidence

[Resolved-head proof and final Cancel/Save recordings](https://github.com/openclaw/openclaw/pull/133628#issuecomment-5472678618) document the rebuilt production candidate. The later CI correction is test-only; production bytes are unchanged.

The native draft regression failed before repair at transaction-complete IndexedDB equality. The extended same-tab Cancel regression also failed before the action fix: the editor closed, but only the seed send existed. The identical test then passed with the existing drain wake, preserving original run IDs, attachment bytes, FIFO, the peer edit hold and the independent visible/durable draft.

The first current-main integration passed **1,492 cases in 43 files**, full changed checks, both compiler contracts and both cycle checks. The subsequent small refresh passed **602 focused cases in 12 files**, both compilers and scoped lint. Fresh complete builds and independent scoped Codex reviews passed; the final build measured **345,427/347,353 B startup JavaScript gzip** and **54,771/54,784 B largest CSS gzip**, with unchanged limits and no ineffective-dynamic-import warnings. Frozen source hashes were matched to the resulting commit and served assets. These overlapping validation cohorts are not summed as unique tests.

**Real isolated flow:** Gateway → OpenClaw runtime → OpenAI (`gpt-5.6-luna`), with synthetic content and no fabricated Gateway replies. The final rebuilt Cancel and Save runs each completed three logical sends, exact 91-byte attachment delivery, correct original/replacement run identities and FIFO, and independent native/visible draft retention. Both had zero browser errors or observer failures and complete owned-resource cleanup. Earlier source-equivalent flows also passed whole-Gateway restart/first-offline attachment, both main/work destination directions, attachment reload, legacy confirmation/explicit uncertainty Retry, newer New Session handoff and Incognito. Every offered capture was inspected; published downloads matched the inspected originals.

**CI correction:** the first exact-head run and the requested retry exposed a page-wide locator matching both the active pane and a retained hidden pane. Local diagnostics showed one visible reply, one canonical reply per pane and one send—not duplicate delivery. The test now scopes strict assertions to the active owner, adds canonical/DOM uniqueness and recovery-history ownership checks, and keeps fixture agent identity independent of activity. The original 26-file selection plus fitting siblings pass **306 cases in 30 files**, with no skips/todos; the exact final case, compilers, lint and independent review also pass. Local replay order differs from CI cache order, but the defect reproduces in isolation. Fresh [exact-head CI and complete browser audit](https://github.com/openclaw/openclaw/pull/133628#issuecomment-5472678618) passed: 334 files / 1,365 tests across 13 disjoint mocked shards, with zero failed/skipped/retried cases; separate real-Gateway 4 files / 9 cases and browser-extension 1 file / 1 case also passed. The supplemental UI suite has one opt-in memory Chromium skip, not counted as executed proof.

**Explicit gaps:** raw `global` live verification failed at the seed turn, before queue activity, because a backend ACP metadata lookup dropped the explicit agent owner. Custom-main variants were blocked by the existing loaded-config policy forcing `main` despite the documented custom key. These are separately recorded follow-ups, not hidden by special fixtures or counted as live passes. The distinct recorded-idle wake-up work in #131948 is not incorporated.

**Provenance:** exact introducing commits and last-known-good releases are not established. The pre-fix Cancel action's complete owning module matched the verified current-main snapshot `5835fbeac7d6be65612fb666f47f10b6bc4ca30c`. No introduction claim is inferred from blame alone.

**Validation limitation:** the broader CI-file replay regenerated ten older quota/lobster fixture PNGs at fixed paths before backup; their prior bytes were not preserved. Eight other fixture outputs were restored. All 79 task-specific outbox captures remained byte-identical, and none of the overwritten fixture outputs is offered as PR proof. Run-scoped fixture capture output is recorded as a separate follow-up.

### Before and after

Before: Cancel closed the editor, but both messages remained parked.

![Before: closed edit and parked queue](https://github.com/user-attachments/assets/4033b7bb-a30b-43e7-a663-70ebdd47a175)

After: both original messages delivered, with the independent draft retained.

![After: original delivery and retained draft](https://github.com/user-attachments/assets/f2c17853-c375-4175-afe8-a1da710791ce)

Final uncut Cancel flow:

https://github.com/user-attachments/assets/bb9d86e7-4881-4aeb-8002-4f8354d05b0d

Final uncut Save control:

https://github.com/user-attachments/assets/d271e5b4-6504-4276-b699-9221549163ff
