### PR TITLE
fix(test): retire repository test APIs after non-isolated files

### DIFF
--- a/test/non-isolated-runner.test-api-fixtures.ts
+++ b/test/non-isolated-runner.test-api-fixtures.ts
@@ -1,0 +1,205 @@
+import path from "node:path";
+
+export function testApiLifecycleFixtureFiles(repoRoot: string): Record<string, string> {
+  const sourcePath = (name: string) => JSON.stringify(path.join(repoRoot, "src", name));
+  const files: Record<string, string> = {};
+  for (const [prefix, generation] of [
+    ["09-d", "producer"],
+    ["09-e", "observer"],
+  ]) {
+    const observeCleanup =
+      generation === "observer"
+        ? `
+// Check during collection before imports can overwrite the previous generation.
+const remainingKeys = [
+  "openclaw.beforeToolCallBlockedErrorTestApi",
+  "openclaw.backupPlanTestApi",
+  "openclaw.staleAuthOrderTestApi",
+  "openclaw.bashProcessRegistryTestApi",
+  "openclaw.diagnosticRunActivityTestApi",
+].filter((key) => Object.hasOwn(globalThis, Symbol.for(key)));
+expect(remainingKeys, "completed-file test API publications").toEqual([]);
+expect(Object.hasOwn(globalThis, "openclawOpenAIResponsesTransportTestApi")).toBe(false);
+for (const key of [Symbol.for("fixture.foreignTestApi"), Symbol.for("openclaw.google.vertexAdcTestApi"), "openclaw.backupPlanTestApi"]) {
+  expect(Reflect.get(globalThis, key)).toBe("foreign");
+  Reflect.deleteProperty(globalThis, key);
+}
+`
+        : "";
+    files[`${prefix}-test-api-${generation}.test.ts`] = `
+import path from "node:path";
+import { createRequire } from "node:module";
+import { afterAll, describe, expect, it } from "vitest";
+${observeCleanup}
+const { createBeforeToolCallBlockedError } = await import(${sourcePath("agents/agent-tools.before-tool-call.test-support.ts")});
+const { isBeforeToolCallBlockedError } = await import(${sourcePath("agents/agent-tools.before-tool-call.wrapper.ts")});
+const { resolveBackupPlanFromPaths } = await import(${sourcePath("commands/backup.test-support.ts")});
+const { repairStaleConfiguredAuthOrders } = await import(${sourcePath("commands/doctor/shared/stale-auth-order.test-support.ts")});
+const { testing: responses } = await import(${sourcePath("agents/openai-transport-stream.test-support.ts")});
+const registry = await import(${sourcePath("agents/bash-process-registry.ts")});
+const { resetProcessRegistryForTests } = await import(${sourcePath("agents/bash-process-registry.test-support.ts")});
+const { createProcessSessionFixture } = await import(${sourcePath("agents/bash-process-registry.test-helpers.ts")});
+const registryKey = Symbol.for("openclaw.bashProcessRegistryTestApi");
+const capturedRegistryApi = Reflect.get(globalThis, registryKey);
+const replacement = await import(${sourcePath("agents/bash-process-registry.ts?lifetime-replacement")});
+const replacementApi = Reflect.get(globalThis, registryKey);
+expect(replacementApi).not.toBe(capturedRegistryApi);
+const nativeCron = await import(${sourcePath("cron/service/active-run-cancellation.ts")});
+const native = createRequire(import.meta.url)("./native-cron.cjs");
+expect(Reflect.get(globalThis, Symbol.for("openclaw.activeCronTaskRunTestApi"))).toBe(native.api);
+expect(nativeCron.registerActiveCronTaskRun).toBe(native.register);
+const { resetDiagnosticRunActivityForTest, getDiagnosticSessionActivitySnapshot } = await import(${sourcePath("logging/diagnostic-run-activity.ts")});
+const { markDiagnosticRunProgressForTest } = await import(${sourcePath("logging/diagnostic-run-activity.test-support.ts")});
+const { resolveGlobalSingleton } = await import(${sourcePath("shared/global-singleton.ts")});
+const stateDir = path.join(import.meta.dirname, "test-api-state");
+const configPath = path.join(stateDir, "missing-openclaw.json");
+describe("${generation} test API consumers", () => {
+  async function verifyConsumers(message: string): Promise<void> {
+    const blocked = createBeforeToolCallBlockedError(message);
+    expect(blocked.message).toBe(message);
+    expect(isBeforeToolCallBlockedError(blocked)).toBe(true);
+    expect(isBeforeToolCallBlockedError(new Error(message))).toBe(false);
+    expect(responses.isInvalidEncryptedContentError({ code: "invalid_encrypted_content" })).toBe(true);
+    expect(responses.isInvalidEncryptedContentError(new Error("unrelated"))).toBe(false);
+    registry.addSession(createProcessSessionFixture({ id: "captured", backgrounded: true }));
+    replacement.addSession(createProcessSessionFixture({ id: "replacement", backgrounded: true }));
+    try {
+      resetProcessRegistryForTests();
+      expect(registry.listRunningSessions()).toEqual([]);
+      expect(replacement.listRunningSessions().map((session) => session.id)).toEqual(["replacement"]);
+    } finally {
+      resetProcessRegistryForTests();
+      replacementApi.resetProcessRegistryForTests();
+    }
+    const controller = new AbortController();
+    nativeCron.registerActiveCronTaskRun({ runId: "native-fixture", controller });
+    native.api.resetActiveCronTaskRunsForTests();
+    expect(nativeCron.cancelActiveCronTaskRun({ runId: "native-fixture" })).toBe(false);
+    expect(controller.signal.aborted).toBe(false);
+    const plan = await resolveBackupPlanFromPaths({
+      stateDir,
+      configPath,
+      oauthDir: path.join(stateDir, "credentials"),
+      onlyConfig: true,
+    });
+    expect(plan).toMatchObject({
+      included: [],
+      workspaceDirs: [],
+      skipped: [{ kind: "config", sourcePath: configPath, reason: "missing" }],
+    });
+    const cfg = { auth: { order: { "fixture-provider": [] } } };
+    expect(repairStaleConfiguredAuthOrders({ cfg, stores: [] })).toEqual({
+      config: cfg,
+      changes: [],
+    });
+  }
+  it.each(["first test", "second test"])("keeps all three consumers usable in %s", async (phase) => {
+    await verifyConsumers(phase);
+  });
+  afterAll(async () => {
+    await verifyConsumers("afterAll");
+    console.info("test API lifecycle: ${generation} afterAll passed");
+  });
+  const cleanupKey = Symbol("fixture resource teardown");
+  resolveGlobalSingleton(cleanupKey, () => ({}), async () => {
+    try {
+      await verifyConsumers("resource teardown");
+      const key = Symbol.for("openclaw.diagnosticRunActivityTestApi");
+      const priorApi = Reflect.get(globalThis, key);
+      resetDiagnosticRunActivityForTest();
+      expect(Reflect.get(globalThis, key)).not.toBe(priorApi);
+      markDiagnosticRunProgressForTest({ sessionId: "fixture", reason: "teardown" });
+      expect(getDiagnosticSessionActivitySnapshot({ sessionId: "fixture" }).lastProgressReason).toBe("teardown");
+      console.info("test API lifecycle: ${generation} resource teardown passed");
+    } finally {
+      // Release this fixture's own lifecycle registration, including its captured consumers.
+      Reflect.get(globalThis, Symbol.for("openclaw.globalSingletonLifecycleResets")).delete(cleanupKey);
+      Reflect.deleteProperty(globalThis, cleanupKey);
+    }
+  });
+});
+${generation === "producer" ? 'await import("./foreign/extensions/google/vertex-adc.ts");' : ""}
+`;
+  }
+  files["native-cron.cjs"] = `
+const cron = require(${sourcePath("cron/service/active-run-cancellation.ts")});
+module.exports = { register: cron.registerActiveCronTaskRun, api: globalThis[Symbol.for("openclaw.activeCronTaskRunTestApi")] };
+`;
+  files["foreign/extensions/google/vertex-adc.ts"] = `
+for (const key of [Symbol.for("fixture.foreignTestApi"), Symbol.for("openclaw.google.vertexAdcTestApi"), "openclaw.backupPlanTestApi"]) {
+  Reflect.set(globalThis, key, "foreign");
+}
+`;
+  files["09-f-test-api-skipped.test.ts"] = `
+import ${sourcePath("logging/diagnostic-run-activity.ts")};
+import { it } from "vitest";
+it.skip("collects a publisher without running its suite", () => {});
+`;
+  files["09-g-test-api-skipped-observer.test.ts"] = `
+import { expect, it } from "vitest";
+it("retires the skipped file publication", () => {
+  expect(Object.hasOwn(globalThis, Symbol.for("openclaw.diagnosticRunActivityTestApi"))).toBe(false);
+});
+`;
+  files["09-h-test-api-partial-mock.test.ts"] = `
+import { createRequire } from "node:module";
+import { afterAll, expect, it, vi } from "vitest";
+vi.mock(${sourcePath("agents/workspace-legacy-state.ts")}, async () => ({
+  ...await vi.importActual(${sourcePath("agents/workspace-legacy-state.ts")}),
+  prepareLegacyWorkspaceStateReset: vi.fn(),
+}));
+vi.mock(${sourcePath("cron/service/active-run-cancellation.ts")}, async () => ({
+  ...await vi.importActual(${sourcePath("cron/service/active-run-cancellation.ts")}),
+}));
+const nativeCron = await import(${sourcePath("cron/service/active-run-cancellation.ts")});
+await import(${sourcePath("cron/service/active-run-cancellation.ts")});
+const native = createRequire(import.meta.url)("./native-cron.cjs");
+const workspace = await import(${sourcePath("agents/workspace-legacy-state.ts")});
+const { resetLegacyWorkspaceStateCheckForTest } = await import(${sourcePath("agents/workspace-legacy-state.test-support.ts")});
+function verifyPartialMock() {
+  expect(workspace.LEGACY_WORKSPACE_STATE_DIRNAME).toBe(".openclaw");
+  expect(vi.isMockFunction(workspace.prepareLegacyWorkspaceStateReset)).toBe(true);
+  expect(() => resetLegacyWorkspaceStateCheckForTest()).not.toThrow();
+  expect(nativeCron.registerActiveCronTaskRun).toBe(native.register);
+  expect(Reflect.get(globalThis, Symbol.for("openclaw.activeCronTaskRunTestApi"))).toBe(native.api);
+}
+it("uses the real source API behind a partial manual mock", verifyPartialMock);
+afterAll(() => {
+  vi.resetModules();
+  verifyPartialMock();
+});
+`;
+  files["09-i-test-api-partial-mock-observer.test.ts"] = `
+import { createRequire } from "node:module";
+import { expect, it } from "vitest";
+expect(Object.hasOwn(globalThis, Symbol.for("openclaw.workspaceLegacyStateTestApi")), "partial mock source publication retired").toBe(false);
+const { resetLegacyWorkspaceStateCheckForTest } = await import(${sourcePath("agents/workspace-legacy-state.test-support.ts")});
+it("loads a fresh real source after the partial mock retires", () => {
+  expect(() => resetLegacyWorkspaceStateCheckForTest()).not.toThrow();
+  const native = createRequire(import.meta.url)("./native-cron.cjs");
+  expect(Reflect.get(globalThis, Symbol.for("openclaw.activeCronTaskRunTestApi"))).toBe(native.api);
+});
+`;
+  files["09-j-test-api-mock-only.test.ts"] = `
+/* @vitest-environment jsdom */
+import { expect, it, vi } from "vitest";
+vi.mock(${sourcePath("agents/workspace-legacy-state.ts")}, () => ({ LEGACY_WORKSPACE_STATE_DIRNAME: "mock-only" }));
+const workspace = await import(${sourcePath("agents/workspace-legacy-state.ts")});
+it("does not execute the source behind a mock-only import", () => {
+  expect(workspace.LEGACY_WORKSPACE_STATE_DIRNAME).toBe("mock-only");
+  const key = Symbol.for("openclaw.workspaceLegacyStateTestApi");
+  expect(Object.hasOwn(globalThis, key)).toBe(false);
+  Reflect.set(globalThis, key, "foreign");
+});
+`;
+  files["09-k-test-api-mock-only-observer.test.ts"] = `
+/* @vitest-environment jsdom */
+import { expect, it } from "vitest";
+it("preserves a foreign slot when only a prior generation executed its known source", () => {
+  const key = Symbol.for("openclaw.workspaceLegacyStateTestApi");
+  expect(Reflect.get(globalThis, key)).toBe("foreign");
+  Reflect.deleteProperty(globalThis, key);
+});
+`;
+  return files;
+}

--- a/test/non-isolated-runner.test.ts
+++ b/test/non-isolated-runner.test.ts
@@ -8,6 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { expect, it } from "vitest";
+import { testApiLifecycleFixtureFiles } from "./non-isolated-runner.test-api-fixtures.ts";
 
 const execFileAsync = promisify(execFile);
 const repoRoot = path.resolve(import.meta.dirname, "..");
@@ -125,12 +126,21 @@ function fixtureFiles(): Record<string, string> {
     ].join("\n"),
     // Evaluate the real importer graph, then fail collection. The following
     // file must still apply its mock after onAfterRunFiles cleanup.
-    "01-a-crash.test.ts": 'import "./01-mid.js";\nthrow new Error("synthetic collect failure");\n',
+    "01-a-crash.test.ts": [
+      'import "./01-mid.js";',
+      'import { expect } from "vitest";',
+      'expect(Object.hasOwn(globalThis, Symbol.for("openclaw.secretRedactionRegistryTestApi"))).toBe(true);',
+      `await import(${JSON.stringify(path.join(repoRoot, "src/logging/diagnostic-run-activity.ts"))});`,
+      'throw new Error("synthetic collect failure");',
+      "",
+    ].join("\n"),
     "01-b-mock.test.ts": [
       'import { expect, it, vi } from "vitest";',
       'vi.mock("./01-dep.js", () => ({ flavor: () => "mocked" }));',
       'const { describeFlavor } = await import("./01-mid.js");',
       'it("applies mocks after a sibling collection failure", () => {',
+      '  expect(Object.hasOwn(globalThis, Symbol.for("openclaw.secretRedactionRegistryTestApi"))).toBe(false);',
+      '  expect(Object.hasOwn(globalThis, Symbol.for("openclaw.diagnosticRunActivityTestApi"))).toBe(false);',
       '  expect(describeFlavor()).toBe("flavor:mocked");',
       "});",
       "",
@@ -455,6 +465,7 @@ function fixtureFiles(): Record<string, string> {
       "});",
       "",
     ].join("\n"),
+    ...testApiLifecycleFixtureFiles(repoRoot),
     ...documentFocusFixtureFiles(),
   };
 }
@@ -486,6 +497,13 @@ it("cleans every shared runner surface between files", async () => {
         "    isolate: false,",
         "    fileParallelism: false,",
         "    maxWorkers: 1,",
+        // This real source uses only type imports; Node can retain its native generation.
+        `    server: { deps: { external: [new RegExp(${JSON.stringify(
+          `^${path
+            .join(repoRoot, "src/cron/service/active-run-cancellation.ts")
+            .replaceAll("\\", "/")
+            .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`,
+        )})] } },`,
         "    sequence: { sequencer: AlphabeticalSequencer },",
         `    runner: ${JSON.stringify(path.join(root, "runner.ts"))},`,
         "  },",
@@ -506,6 +524,7 @@ it("cleans every shared runner surface between files", async () => {
         path.join(root, "vitest.config.ts"),
         "--configLoader",
         "runner",
+        "--reporter=verbose",
       ],
       { cwd: repoRoot, env: childEnv(), maxBuffer: 16 * 1024 * 1024 },
     ).catch((error: unknown) => error as { stdout?: string; stderr?: string });
@@ -514,7 +533,12 @@ it("cleans every shared runner surface between files", async () => {
     // The collection failure is intentional. Every behavior test after it must
     // pass; any leaked surface turns the summary into a second failure.
     expect(output).toContain("synthetic collect failure");
-    expect(output).toContain("1 failed | 36 passed");
+    expect(output, output).toContain("1 failed | 43 passed | 1 skipped");
+    expect(output, output).toContain("45 passed | 1 skipped");
+    for (const generation of ["producer", "observer"]) {
+      expect(output).toContain(`test API lifecycle: ${generation} afterAll passed`);
+      expect(output).toContain(`test API lifecycle: ${generation} resource teardown passed`);
+    }
     expect(output).not.toContain("first-file");
   } finally {
     await fs.rm(root, { recursive: true, force: true });

--- a/test/non-isolated-runner.ts
+++ b/test/non-isolated-runner.ts
@@ -19,6 +19,7 @@ import {
   dropRepoOwnedCustomElements,
   trackCustomElementRegistry,
 } from "./jsdom-custom-elements.ts";
+import { repositoryTestApiPublications } from "./repository-test-api-publications.ts";
 
 type EvaluatedModuleNode = ViteEvaluatedModuleNode & {
   mockedExports?: unknown;
@@ -27,7 +28,13 @@ type EvaluatedModuleNode = ViteEvaluatedModuleNode & {
 type EvaluatedModules = {
   idToModuleMap: Map<string, EvaluatedModuleNode>;
   invalidateModule: ViteEvaluatedModules["invalidateModule"];
+  [RETIRED_TEST_API_EXECUTIONS]?: WeakSet<ModuleExecution>;
 };
+
+// Vitest's public worker type leaves execution entries untyped; mirror the
+// evaluator's external flag without importing an unexported package subpath.
+type ModuleExecution = { external?: boolean };
+type ModuleExecutionInfo = Map<string, ModuleExecution>;
 
 type SerializableMocker = {
   reset?: () => void;
@@ -36,10 +43,11 @@ type SerializableMocker = {
 
 type TestRunnerInternals = {
   moduleRunner?: { mocker?: SerializableMocker };
-  workerState: { evaluatedModules: unknown };
+  workerState: { evaluatedModules: unknown; moduleExecutionInfo: ModuleExecutionInfo };
 };
 
 const SHARED_TEST_SETUP = Symbol.for("openclaw.sharedTestSetup");
+const RETIRED_TEST_API_EXECUTIONS = Symbol.for("openclaw.retiredTestApiExecutions");
 const EMBEDDED_RUN_STATE = Symbol.for("openclaw.embeddedRunState");
 const REPLY_RUN_REGISTRY = Symbol.for("openclaw.replyRunRegistry");
 const DIAGNOSTIC_EVENTS_STATE = Symbol.for("openclaw.diagnosticEvents.state.v1");
@@ -77,12 +85,29 @@ function getSharedTestHome(): string | undefined {
   return globalState[SHARED_TEST_SETUP]?.tempHome ?? process.env.OPENCLAW_TEST_HOME;
 }
 
-function resetEvaluatedModules(modules: EvaluatedModules) {
+function resetEvaluatedModules(modules: EvaluatedModules, executions: ModuleExecutionInfo) {
   const skipPaths = [/\/vitest\/dist\//, /vitest-virtual-\w+\/dist/u, /@vitest\/dist/u];
+  // Vitest reuses the graph across runner instances. Weak marks prevent a past
+  // execution from owning a later mock-only slot without retaining any records
+  // or changing Vitest's timing/coverage data; each evaluation gets a new record.
+  const retiredExecutions = (modules[RETIRED_TEST_API_EXECUTIONS] ??= new WeakSet());
 
   modules.idToModuleMap.forEach((node, modulePath) => {
     if (skipPaths.some((pattern) => pattern.test(modulePath))) {
       return;
+    }
+    // importActual can execute a source then replace its meta with a mock placeholder.
+    // Vitest's evaluator records each execution independently (including native ones),
+    // using the unprefixed id for automocks. Module resets preserve those records.
+    const key = repositoryTestApiPublications.get(node.file);
+    const executionId = node.id.startsWith("mock:") ? node.id.slice(5) : node.id;
+    const execution = executions.get(executionId);
+    if (key && execution && !execution.external && !retiredExecutions.has(execution)) {
+      retiredExecutions.add(execution);
+      const publication = Object.getOwnPropertyDescriptor(globalThis, key);
+      if (publication?.configurable && "value" in publication) {
+        Reflect.deleteProperty(globalThis, key);
+      }
     }
     // Mock metadata owns factories and cached exports after the registry resets.
     // Retire those nodes while preserving ordinary transformed-code metadata.
@@ -509,6 +534,9 @@ export default class OpenClawNonIsolatedRunner extends TestRunner {
     resetGatewayWorkAdmission();
     vi.resetModules();
     internals.moduleRunner?.mocker?.reset?.();
-    resetEvaluatedModules(internals.workerState.evaluatedModules as EvaluatedModules);
+    resetEvaluatedModules(
+      internals.workerState.evaluatedModules as EvaluatedModules,
+      internals.workerState.moduleExecutionInfo,
+    );
   }
 }

--- a/test/repository-test-api-publications.ts
+++ b/test/repository-test-api-publications.ts
@@ -1,0 +1,175 @@
+import path from "node:path";
+import { normalizeModuleId } from "vite/module-runner";
+
+// Exact source publications, not a naming convention. Keep symbol and string keys
+// distinct; override stores and production singletons have separate lifecycle owners.
+const publications: Record<string, string | symbol> = {
+  "extensions/google/vertex-adc.ts": Symbol.for("openclaw.google.vertexAdcTestApi"),
+  "extensions/memory-lancedb/lancedb-runtime.ts": Symbol.for(
+    "openclaw.memoryLanceDbRuntimeTestApi",
+  ),
+  "packages/ai/src/transports/openai-responses-transport.ts":
+    "openclawOpenAIResponsesTransportTestApi",
+  "src/agents/agent-hooks/compaction-safeguard.ts": Symbol.for(
+    "openclaw.compactionSafeguardTestApi",
+  ),
+  "src/agents/agent-tools.before-tool-call.wrapper.ts": Symbol.for(
+    "openclaw.beforeToolCallBlockedErrorTestApi",
+  ),
+  "src/agents/apply-patch.ts": Symbol.for("openclaw.applyPatchTestApi"),
+  "src/agents/auth-profiles/external-auth.ts": Symbol.for("openclaw.externalAuthTestApi"),
+  "src/agents/auth-profiles/oauth.ts": Symbol.for("openclaw.oauthTestApi"),
+  "src/agents/auth-profiles/runtime-snapshots.ts": Symbol.for(
+    "openclaw.runtimeAuthSnapshotsTestApi",
+  ),
+  "src/agents/auth-profiles/store.ts": Symbol.for("openclaw.authProfileStoreTestApi"),
+  "src/agents/auth-profiles/usage.ts": Symbol.for("openclaw.authProfileUsageTestApi"),
+  "src/agents/bash-process-registry.ts": Symbol.for("openclaw.bashProcessRegistryTestApi"),
+  "src/agents/cli-auth-epoch.ts": Symbol.for("openclaw.cliAuthEpochTestApi"),
+  "src/agents/cli-backends.ts": Symbol.for("openclaw.cliBackendsTestApi"),
+  "src/agents/cli-credentials.ts": Symbol.for("openclaw.cliCredentialsTestApi"),
+  "src/agents/cli-runner/prepare.ts": Symbol.for("openclaw.cliRunnerPrepareTestApi"),
+  "src/agents/command/attempt-execution.helpers.ts": Symbol.for(
+    "openclaw.attemptExecutionHelpersTestApi",
+  ),
+  "src/agents/compaction.ts": Symbol.for("openclaw.compactionTestApi"),
+  "src/agents/embedded-agent-runner/context-engine-maintenance.ts": Symbol.for(
+    "openclaw.contextEngineMaintenanceTestApi",
+  ),
+  "src/agents/embedded-agent-runner/extra-params.ts": Symbol.for("openclaw.extraParamsTestApi"),
+  "src/agents/embedded-agent-runner/run/auth-plan.ts": Symbol.for(
+    "openclaw.embeddedRunAuthPlanTestApi",
+  ),
+  "src/agents/embedded-agent-runner/runs.ts": Symbol.for("openclaw.embeddedRunsTestApi"),
+  "src/agents/embedded-agent-subscribe.handlers.messages.update.ts": Symbol.for(
+    "openclaw.embeddedSubscribeMessagesTestApi",
+  ),
+  "src/agents/embedded-agent-tool-media.ts": Symbol.for("openclaw.embeddedSubscribeToolsTestApi"),
+  "src/agents/mcp-ui-resource.ts": Symbol.for("openclaw.mcpUiResourceTestApi"),
+  "src/agents/media-generation-task-status-shared.ts": Symbol.for(
+    "openclaw.mediaGenerationDuplicateGuardTestApi",
+  ),
+  "src/agents/models-config.plan.ts": Symbol.for("openclaw.modelsConfigPlanTestApi"),
+  "src/agents/models-config.ts": Symbol.for("openclaw.modelsConfigTestApi"),
+  "src/agents/prepared-model-runtime.ts": Symbol.for("openclaw.preparedModelRuntimeTestApi"),
+  "src/agents/session-suspension.ts": Symbol.for("openclaw.sessionSuspensionTestApi"),
+  "src/agents/sessions/tools/bash.ts": Symbol.for("openclaw.bashToolTestApi"),
+  "src/agents/subagents/announce/subagent-announce-delivery.ts": Symbol.for(
+    "openclaw.subagentAnnounceDeliveryTestApi",
+  ),
+  "src/agents/subagents/announce/subagent-announce-output.ts": Symbol.for(
+    "openclaw.subagentAnnounceOutputTestApi",
+  ),
+  "src/agents/subagents/registry/subagent-registry.ts": Symbol.for(
+    "openclaw.subagentRegistryTestApi",
+  ),
+  "src/agents/subagents/spawn/subagent-spawn.ts": Symbol.for("openclaw.subagentSpawnTestApi"),
+  "src/agents/subagents/swarm/swarm-scheduler.ts": Symbol.for("openclaw.swarmSchedulerTestApi"),
+  "src/agents/tool-search.ts": Symbol.for("openclaw.toolSearchTestApi"),
+  "src/agents/tools/agent-step.ts": Symbol.for("openclaw.agentStepTestApi"),
+  "src/agents/tools/ask-user-tool.ts": Symbol.for("openclaw.askUserToolTestApi"),
+  "src/agents/tools/image-generate-tool.ts": Symbol.for("openclaw.imageGenerateToolTestApi"),
+  "src/agents/tools/image-tool.ts": Symbol.for("openclaw.imageToolTestApi"),
+  "src/agents/tools/model-config.helpers.ts": Symbol.for("openclaw.modelConfigHelpersTestApi"),
+  "src/agents/tools/structured-output-tool.ts": Symbol.for("openclaw.structuredOutputToolTestApi"),
+  "src/agents/tools/video-generate-tool.ts": Symbol.for("openclaw.videoGenerateToolTestApi"),
+  "src/agents/tools/web-fetch.ts": Symbol.for("openclaw.webFetchTestApi"),
+  "src/agents/utils/tools-manager.ts": Symbol.for("openclaw.toolsManagerTestApi"),
+  "src/agents/workspace-legacy-state.ts": Symbol.for("openclaw.workspaceLegacyStateTestApi"),
+  "src/agents/worktrees/run-lease.ts": Symbol.for("openclaw.worktreeRunLeaseTestApi"),
+  "src/auto-reply/reply/agent-runner-memory.ts": Symbol.for("openclaw.agentRunnerMemoryTestApi"),
+  "src/auto-reply/reply/agent-runner-session-reset.ts": Symbol.for(
+    "openclaw.agentRunnerSessionResetTestApi",
+  ),
+  "src/auto-reply/reply/commands-login.ts": Symbol.for("openclaw.commandsLoginTestApi"),
+  "src/auto-reply/reply/queue/enqueue.ts": Symbol.for("openclaw.queueEnqueueTestApi"),
+  "src/auto-reply/reply/reply-run-registry.registry.ts": Symbol.for(
+    "openclaw.replyRunRegistryTestApi",
+  ),
+  "src/auto-reply/reply/stage-sandbox-media.ts": Symbol.for("openclaw.stageSandboxMediaTestApi"),
+  "src/auto-reply/usage-bar/template.ts": Symbol.for("openclaw.usageBarTemplateTestApi"),
+  "src/cli/command-secret-gateway.ts": Symbol.for("openclaw.commandSecretGatewayTestApi"),
+  "src/cli/gateway-cli/run.ts": Symbol.for("openclaw.gatewayRunTestApi"),
+  "src/commands/backup-shared.ts": Symbol.for("openclaw.backupPlanTestApi"),
+  "src/commands/doctor-auth-migration-receipts.ts": Symbol.for(
+    "openclaw.authProfileMigrationReceiptsTestApi",
+  ),
+  "src/commands/doctor-heartbeat-main-session-repair.ts": Symbol.for(
+    "openclaw.doctorHeartbeatMainSessionRepairTestApi",
+  ),
+  "src/commands/doctor-sandbox.ts": Symbol.for("openclaw.doctorSandboxTestApi"),
+  "src/commands/doctor-session-snapshots.ts": Symbol.for("openclaw.doctorSessionSnapshotsTestApi"),
+  "src/commands/doctor-whatsapp-responsiveness.ts": Symbol.for(
+    "openclaw.doctorWhatsappResponsivenessTestApi",
+  ),
+  "src/commands/doctor/shared/codex-native-assets.ts": Symbol.for(
+    "openclaw.codexNativeAssetsTestApi",
+  ),
+  "src/commands/doctor/shared/codex-route-session-repair.ts": Symbol.for(
+    "openclaw.codexRouteSessionRepairTestApi",
+  ),
+  "src/commands/doctor/shared/plugin-dependency-cleanup.ts": Symbol.for(
+    "openclaw.pluginDependencyCleanupTestApi",
+  ),
+  "src/commands/doctor/shared/stale-auth-order.ts": Symbol.for("openclaw.staleAuthOrderTestApi"),
+  "src/commands/doctor/shared/stale-oauth-profile-shadows.ts": Symbol.for(
+    "openclaw.staleOAuthProfileShadowsTestApi",
+  ),
+  "src/commands/onboard-non-interactive/local.ts": Symbol.for(
+    "openclaw.onboardNonInteractiveLocalTestApi",
+  ),
+  "src/commands/status.command.ts": Symbol.for("openclaw.statusCommandTestApi"),
+  "src/cron/schedule.ts": Symbol.for("openclaw.cronScheduleTestApi"),
+  "src/cron/service/active-run-cancellation.ts": Symbol.for("openclaw.activeCronTaskRunTestApi"),
+  "src/cron/service/timer.ts": Symbol.for("openclaw.cronTimerTestApi"),
+  "src/cron/session-reaper.ts": Symbol.for("openclaw.cronSessionReaperTestApi"),
+  "src/entry.compile-cache.ts": Symbol.for("openclaw.entryCompileCacheTestApi"),
+  "src/flows/doctor-health-contributions.ts": Symbol.for(
+    "openclaw.doctorHealthContributionsTestApi",
+  ),
+  "src/infra/exec-approvals-store.ts": Symbol.for("openclaw.execApprovalsStoreTestApi"),
+  "src/infra/session-cost-usage-cache-runtime.ts": Symbol.for("openclaw.sessionCostUsageTestApi"),
+  "src/infra/session-delivery-queue-runtime.ts": Symbol.for(
+    "openclaw.sessionDeliveryQueueRuntimeTestApi",
+  ),
+  "src/logging/diagnostic-run-activity.ts": Symbol.for("openclaw.diagnosticRunActivityTestApi"),
+  "src/logging/diagnostic.ts": Symbol.for("openclaw.diagnosticTestApi"),
+  "src/logging/secret-redaction-registry.ts": Symbol.for("openclaw.secretRedactionRegistryTestApi"),
+  "src/media-understanding/runner.ts": Symbol.for("openclaw.mediaUnderstandingRunnerTestApi"),
+  "src/media/playback-transcode.ts": Symbol.for("openclaw.playbackTranscodeTestApi"),
+  "src/media/store.ts": Symbol.for("openclaw.mediaStoreTestApi"),
+  "src/model-catalog/remote-overlay.ts": Symbol.for("openclaw.remoteModelCatalogOverlayTestApi"),
+  "src/node-host/invoke.ts": Symbol.for("openclaw.nodeHostInvokeTestApi"),
+  "src/node-host/plugin-node-host.ts": Symbol.for("openclaw.nodeHostPluginTestApi"),
+  "src/plugin-state/plugin-state-store.sqlite.ts": Symbol.for("openclaw.pluginStateSqliteTestApi"),
+  "src/plugin-state/plugin-state-store.ts": Symbol.for("openclaw.pluginStateStoreTestApi"),
+  "src/plugins/memory-runtime.ts": Symbol.for("openclaw.memoryRuntimeTestApi"),
+  "src/sessions/session-lifecycle-admission.ts": Symbol.for(
+    "openclaw.sessionLifecycleAdmissionTestApi",
+  ),
+  "src/sessions/session-upstream-monitor.ts": Symbol.for("openclaw.sessionUpstreamMonitorTestApi"),
+  "src/sessions/user-turn-transcript.ts": Symbol.for("openclaw.userTurnTranscriptTestApi"),
+  "src/skills/lifecycle/install.ts": Symbol.for("openclaw.skillsInstallTestApi"),
+  "src/skills/lifecycle/upload-store.ts": Symbol.for("openclaw.skillUploadStoreTestApi"),
+  "src/skills/runtime/refresh.ts": Symbol.for("openclaw.skillsRefreshTestApi"),
+  "src/skills/runtime/remote-skills.ts": Symbol.for("openclaw.remoteNodeSkillsTestApi"),
+  "src/system-agent/agent-turn.ts": Symbol.for("openclaw.systemAgentTurnTestApi"),
+  "src/system-agent/assistant-timeout.ts": Symbol.for("openclaw.systemAgentTimeoutTestApi"),
+  "src/talk/client-voice-confirmation.ts": Symbol.for("openclaw.clientVoiceConfirmationTestApi"),
+  "src/talk/client-voice-session.ts": Symbol.for("openclaw.clientVoiceSessionTestApi"),
+  "src/tasks/generated-media-task-activity.ts": Symbol.for(
+    "openclaw.generatedMediaTaskActivityTestApi",
+  ),
+  "src/tasks/task-flow-registry.store.ts": Symbol.for("openclaw.taskFlowRegistryStoreTestApi"),
+  "src/tasks/task-flow-registry.ts": Symbol.for("openclaw.taskFlowRegistryTestApi"),
+  "src/tasks/task-registry.ts": Symbol.for("openclaw.taskRegistryTestApi"),
+};
+
+// Vite's EvaluatedModuleNode.file is a normalized, query-free filesystem path.
+// Store only paths and keys: this table must never retain published API values.
+export const repositoryTestApiPublications: ReadonlyMap<string, string | symbol> = new Map(
+  Object.entries(publications).map(([source, key]) => [
+    normalizeModuleId(path.resolve(import.meta.dirname, "..", source)),
+    key,
+  ]),
+);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where non-isolated repository tests leave completed files' test API publications reachable on `globalThis`, even after their module exports have been reset. Functional tests can pass while obsolete source generations remain retained.

Closes #133630.

## Why This Change Was Made

The runner now retires an exact audited source/property publication only when Vitest recorded a fresh inlined execution for that source. Retirement occurs at the existing module-reset boundary, after file hooks and awaited resource teardown. The 106-entry table contains only normalized source paths and typed property keys (105 symbols, one string); injection stores and runtime singletons retain their existing owners.

Execution records, rather than fetch metadata, distinguish real partial-mock execution from mock-only or native imports: `vi.importActual` can be followed by a manual mock that replaces source metadata with an empty-code placeholder. Graph-owned weak consumption marks prevent earlier execution history from authorizing deletion in a later mock-only file or a new runner instance. Only configurable own data-property slots are removed; captured API objects/functions/classes, native publishers, foreign/lookalike slots, timing/coverage data, and the dependency spy registry remain intact.

This preserves main's gateway-admission cleanup from `50b675ffe17`: reject suspended waiters before async teardown, retire admission after runtime/DOM cleanup, then retire module publications. Alternatives based on symbol names, singleton resets, or fetch metadata do not preserve these ownership boundaries.

## User Impact

Developer/test workflow only. Shared test workers release completed-file API publications while real test-support consumers remain usable through `afterAll` and awaited cleanup. No product behavior, production source, auth/storage/tool-authority semantics, dependency declarations/patches, test budgets, or isolation/shard policy changes.

This establishes publication lifetime correctness. It does not measure reclaimed bytes or prove an OOM cure; independent dependency mock-registry and terminal-settlement repairs remain separate.

## Evidence

Refreshed candidate is based on `5f0aa4f7c56870e01fd8103176eb93ca58700c72`. Local proof used Node 26.8.1, Vitest/runner/spy 4.1.11 and Vite 8.2.2, with the existing frozen lock synchronized (including upstream's `fast-uri` 4.1.3).

```sh
node scripts/run-vitest.mjs test/non-isolated-runner.test.ts test/non-isolated-runner.resolve-mocks.test.ts src/commands/backup.test.ts src/commands/doctor/shared/stale-auth-order.test.ts src/agents/agent-tool-definition-adapter.logging.test.ts src/agents/bash-process-registry.test.ts src/logging/diagnostic-run-activity.test.ts src/agents/openai-transport-stream.replay-and-tools.test.ts src/commands/onboard-helpers.test.ts src/commands/channels.adds-non-default-telegram-account.test.ts
node scripts/check-changed.mjs -- test/non-isolated-runner.ts test/non-isolated-runner.test.ts test/non-isolated-runner.test-api-fixtures.ts test/repository-test-api-publications.ts
git diff --check
```

All passed: 10 files / 249 outer tests across five routed shards; all 14 changed-file checks, including root-test types and script lint. The single ordered child asserts 43 passing files / 45 tests, plus one intentional collection failure and one skip, and successful producer/observer `afterAll` and resource-teardown markers. Coverage includes dynamic and captured consumers, query-qualified replacement, string-key publication, native/foreign preservation, bootstrap, failed/skipped collection, teardown republishing, in-file module reset, partial manual mocks, and later mock-only files across node/jsdom runner batches. The 106 table entries were checked against current publishers with no additional same-invariant publisher found.

The producer/observer regression failed against pre-fix code before the repair. The partial-manual-mock regression separately failed against the intermediate metadata-based candidate before correction. This extends the existing shared child boundary regression without a test-only production seam.

Historical paired proof applies **only** to checkpoint `2a6c333225e5c886bfd630e36037fb7b206408ef`, not the refreshed head: both immutable original-order 75-command-file runs completed 2,795 tests with two skips, 75 cleanup callbacks, and native/logical completion. Retained-property observations fell from 4,289 across 63 distinct keys to zero; the original three keys fell from 205 to zero. The probe inventory of 106 is not a claim of 106 executions. Historical stack: Node 26.7.0, Vitest/runner/spy 4.1.11, Vite 8.2.2, grammY 1.46.0/types 5.0.0. Only bounded count/source summaries are reported; private captures are not attached.

Fresh isolated Codex autoreview of the complete refreshed candidate returned `scoped-clean` with no accepted/actionable findings at the requested P0 reporting threshold. This is not an all-priority review.

Production LOC: +0/-0. Harness/tooling: +206/-3 (net +203), including the 175-line exact ownership table. Tests/fixtures: +231/-2 (net +229). Upstream admission fixtures are excluded from these PR deltas. The table centralizes existing publication ownership; the fixture extraction keeps the existing test readable without suppressions.

Related merged work: #131338 released mock fixture metadata between files; #129456 preserved process-registry cleanup's captured module identity. This repair handles direct global test API publications and preserves both behaviors. Introduction provenance is unknown.

ClawSweeper review follow-through (reviewed head `5d05d2609b6196ba1ac5f0f633f8dec6a090fbe2`, August 31 00:02 UTC): the two P1 findings and their repeated ownership/fixture improvement items are skipped as inapplicable after direct source verification. At `test/non-isolated-runner.test-api-fixtures.ts:14-20`, the absence check converts names with `Symbol.for(key)`. At lines 23 and 129, the foreign backup lookalike is the **string** key `"openclaw.backupPlanTestApi"`, not that symbol. The producer does not overwrite the owned backup symbol with `"foreign"`; both assertions can and do pass. The exact-head ordered child completed in the focused proof above, including its hooks and teardown markers. No fixture correction or value-tracking production seam is warranted by the cited example. The contract retires an audited property namespace after its fresh inlined source execution; it does not claim provenance tracking for arbitrary replacement values written into that same owned slot.

The review's dependency-contract uncertainty is resolved by direct installed-source inspection: Vitest 4.1.11 `dist/module-evaluator.js:10-30` creates fresh execution records, `:70-82` marks native execution `external: true`, and `:192-228` records inlined execution in `finally` with `mock:` removed from its id. `dist/chunks/utils.BX5Fg8C4.js:29-45` resets modules without clearing those records. Vite 8.2.2 `dist/node/module-runner.js:264-280` makes `node.file` query-free, `:318-329` owns normalization/invalidation, and `:355-357` exports the shared normalizer. Vitest's worker loop awaits the file lifecycle (`base.B6Opl8PE.js:66-106`; runner `chunk-artifact.js:3287`), while manual-mock fetch metadata can become an empty-code placeholder (`startVitestModuleRunner.DB-7oCpn.js:683-697`). The requested source/contract checks and ordered regression were completed; the fresh review is under 12 hours old and no source changes followed it. All listed before-merge/Rank-up items are covered by these two resolutions; no re-review request is needed for an unchanged head.

Hosted proof: [exact-head pull_request CI run 33343038625, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33343038625) completed successfully for `5d05d2609b6196ba1ac5f0f633f8dec6a090fbe2`; the required GitHub Actions `openclaw/ci-gate` check is green. No test rerun or source change was needed. The local watcher encountered three GraphQL quota retries and one changing-pagination snapshot retry; these were observation retries, not CI failures. Native review artifacts validate for this head with no accepted findings. The requested lead checkpoint precedes native prepare/merge.
