### PR TITLE
fix: prevent stale fallback models after plugin reloads

### DIFF
--- a/src/agents/model-fallback-candidates.generation.test.ts
+++ b/src/agents/model-fallback-candidates.generation.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withPluginMetadataSnapshotScope } from "../plugins/current-plugin-metadata-snapshot.js";
+import { projectPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
+import { resolveModelCandidateChain } from "./model-fallback-candidates.js";
+
+describe("fallback candidates across provider generations", () => {
+  afterEach(() => resetPluginRuntimeStateForTest());
+
+  it.each(["generation", "request"] as const)(
+    "uses the %s registry with identical metadata and config",
+    (scope) => {
+      const provider = `fallback-${scope}`;
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: `${provider}/primary`, fallbacks: [`${provider}/latest`] },
+          },
+        },
+      };
+      const metadataSnapshot = createPluginMetadataSnapshotFixture({
+        plugins: [{ id: provider, providers: [provider] }],
+      });
+      const createGeneration = (model: string) => {
+        const pluginRegistry = createEmptyPluginRegistry();
+        pluginRegistry.providers.push({
+          pluginId: provider,
+          source: "/tmp/fallback-generation/index.js",
+          provider: {
+            id: provider,
+            label: "Fallback generation",
+            auth: [],
+            normalizeModelId: ({ modelId }) => (modelId === "latest" ? model : undefined),
+          },
+        });
+        return { metadataSnapshot, pluginRegistry };
+      };
+      const a = createGeneration("model-a");
+      const b = createGeneration("model-b");
+      const empty = { metadataSnapshot, pluginRegistry: createEmptyPluginRegistry() };
+      const active = createGeneration("model-active");
+      setActivePluginRegistry(active.pluginRegistry, "fallback-generation-fixture");
+      const resolve = () => resolveModelCandidateChain({ cfg, provider, model: "primary" });
+      const expected = (model: string) => [
+        { provider, model: "primary", routeOrigin: "requested", routeResolution: "raw" },
+        { provider, model, routeOrigin: "configured-fallback", routeResolution: "resolved" },
+      ];
+      for (const [generation, model] of [
+        [a, "model-a"],
+        [b, "model-b"],
+        [empty, "latest"],
+        [a, "model-a"],
+        [a, "model-a"],
+      ] as const) {
+        const candidates =
+          scope === "generation"
+            ? withPluginRuntimeGenerationScope(generation, resolve)
+            : withPluginMetadataSnapshotScope(metadataSnapshot, () =>
+                withPluginRuntimeRegistryScope(generation.pluginRegistry, resolve),
+              );
+        expect(candidates).toEqual(expected(model));
+        for (const candidate of candidates) {
+          candidate.model = "caller-mutation";
+          candidate.routeOrigin = "configured-primary";
+          candidate.routeResolution = "resolved";
+        }
+      }
+      expect(withPluginMetadataSnapshotScope(metadataSnapshot, resolve)).toEqual(
+        expected("model-active"),
+      );
+    },
+  );
+
+  it("keeps narrowed manifest policies separate when the runtime registry is shared", () => {
+    const provider = "fallback-manifest";
+    const metadata = createPluginMetadataSnapshotFixture({
+      plugins: [
+        {
+          id: provider,
+          providers: [provider],
+          modelIdNormalization: {
+            providers: { [provider]: { aliases: { latest: "model-full" } } },
+          },
+        },
+      ],
+    });
+    const narrowed = projectPluginMetadataSnapshot(metadata, []);
+    const pluginRegistry = createEmptyPluginRegistry();
+    const cfg: OpenClawConfig = {};
+    for (const [metadataSnapshot, model] of [
+      [metadata, "model-full"],
+      [narrowed, "latest"],
+      [metadata, "model-full"],
+    ] as const) {
+      expect(
+        withPluginRuntimeGenerationScope({ metadataSnapshot, pluginRegistry }, () =>
+          resolveModelCandidateChain({ cfg, provider, model: "latest", fallbacksOverride: [] }),
+        ),
+      ).toEqual([{ provider, model, routeOrigin: "requested", routeResolution: "raw" }]);
+    }
+  });
+});

--- a/src/agents/model-fallback-candidates.ts
+++ b/src/agents/model-fallback-candidates.ts
@@ -15,6 +15,8 @@ import {
   getActivePluginRegistryWorkspaceDirFromState,
   getPluginRegistryState,
 } from "../plugins/runtime-state.js";
+import { getPluginRegistryForContext } from "../plugins/runtime/gateway-request-scope.js";
+import { getPluginRuntimeGenerationRegistry } from "../plugins/runtime/generation-state.js";
 import { resolveAgentConfig } from "./agent-scope-config.js";
 import {
   allowsPluginModelNormalization,
@@ -42,6 +44,8 @@ import {
 
 const MAX_FALLBACK_CANDIDATE_CACHE_ENTRIES = 256;
 const fallbackCandidateCache = new Map<string, ModelFallbackCandidate[]>();
+const fallbackContextIds = new WeakMap<object, number>();
+let nextFallbackContextId = 0;
 const log = createSubsystemLogger("model-selection");
 
 type ModelCandidateChainParams = ModelManifestNormalizationContext & {
@@ -56,14 +60,7 @@ type ModelCandidateChainParams = ModelManifestNormalizationContext & {
   allowPluginNormalization?: boolean;
 };
 
-function createModelCandidateCollector(): {
-  candidates: ModelFallbackCandidate[];
-  addCandidate: (
-    candidate: ModelCandidate,
-    routeOrigin: ModelFallbackRouteOrigin,
-    routeResolution: ModelFallbackRouteResolution,
-  ) => void;
-} {
+function createModelCandidateCollector() {
   const seen = new Set<string>();
   const candidates: ModelFallbackCandidate[] = [];
 
@@ -162,27 +159,30 @@ export function resolveModelCandidateChain(
   params: ModelCandidateChainParams,
 ): ModelFallbackCandidate[] {
   const cacheKey = resolveFallbackCandidateCacheKey(params);
-  if (cacheKey) {
-    const cached = fallbackCandidateCache.get(cacheKey);
-    if (cached) {
-      return cached.map(cloneModelCandidate);
-    }
+  if (!cacheKey) {
+    return resolveFallbackCandidatesUncached(params);
+  }
+  const cached = fallbackCandidateCache.get(cacheKey);
+  if (cached) {
+    return cached.map((candidate) => Object.assign({}, candidate));
   }
   const candidates = resolveFallbackCandidatesUncached(params);
-  if (cacheKey) {
-    fallbackCandidateCache.set(cacheKey, candidates.map(cloneModelCandidate));
-    pruneMapToMaxSize(fallbackCandidateCache, MAX_FALLBACK_CANDIDATE_CACHE_ENTRIES);
-  }
+  fallbackCandidateCache.set(
+    cacheKey,
+    candidates.map((candidate) => Object.assign({}, candidate)),
+  );
+  pruneMapToMaxSize(fallbackCandidateCache, MAX_FALLBACK_CANDIDATE_CACHE_ENTRIES);
   return candidates;
 }
 
-function cloneModelCandidate(candidate: ModelFallbackCandidate): ModelFallbackCandidate {
-  return {
-    provider: candidate.provider,
-    model: candidate.model,
-    routeOrigin: candidate.routeOrigin,
-    routeResolution: candidate.routeResolution,
-  };
+function getFallbackContextId(value: object): number {
+  const existing = fallbackContextIds.get(value);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const id = nextFallbackContextId++;
+  fallbackContextIds.set(value, id);
+  return id;
 }
 
 function resolveFallbackCandidateCacheKey(params: ModelCandidateChainParams): string | null {
@@ -214,6 +214,7 @@ function resolveFallbackCandidateCacheKey(params: ModelCandidateChainParams): st
     return null;
   }
   const registryState = getPluginRegistryState();
+  const registry = getPluginRuntimeGenerationRegistry() ?? getPluginRegistryForContext();
   const agentConfig =
     params.cfg && params.agentId ? resolveAgentConfig(params.cfg, params.agentId) : undefined;
   return JSON.stringify({
@@ -234,6 +235,10 @@ function resolveFallbackCandidateCacheKey(params: ModelCandidateChainParams): st
       workspaceDir,
     }),
     pluginMetadataFingerprint: pluginMetadata?.configFingerprint ?? null,
+    // Fingerprints omit executable hooks and narrowed metadata views. Weak ids
+    // isolate both without retaining retired registries or growing the cache bound.
+    pluginMetadataIdentity: pluginMetadata ? getFallbackContextId(pluginMetadata) : null,
+    pluginRegistryIdentity: registry ? getFallbackContextId(registry) : null,
     pluginRegistryKey: registryState?.key ?? null,
     pluginRegistryVersion: registryState?.activeVersion ?? null,
     pluginWorkspaceDir: workspaceDir ?? null,


### PR DESCRIPTION
Related: #130706, #130324. CPU/stall recovery for #130324 remains unproven by this repair.

## What Problem This Solves

Resolves a problem where model fallback could select a model normalized by another provider generation after a plugin reload. A narrowed metadata view could also keep applying model aliases from a broader view.

## Why This Change Was Made

Fallback candidate reuse now distinguishes both the selected runtime registry and the exact metadata view. Weak identity tokens keep the existing global 256-entry bound without retaining retired contexts, and callers receive independent copies of cached candidates.

This narrows the former umbrella change to the remaining two-file cache repair. Provider hook and alias ownership landed separately in #141679, and admitted compaction generation selection landed in #139429. Related SDK and model-selection fixture cleanup landed in #139829, #139900, and #140069; the wider extraction remains tracked in #130706.

## User Impact

Fallback uses the provider implementation and manifest rules selected for that run, even when multiple generations coexist. Empty registries and narrowed metadata views remain authoritative, and one caller cannot change another caller's cached model or route provenance.

The production change is +5 lines after removing redundant collector typing and copy-helper plumbing. The regression file adds 107 lines covering three cases. This remains an in-memory cache repair with no configuration, persistent-store, or protocol change.

## Evidence

- Before the fix, warming generation A made both retained-generation and request-scoped B return `model-a` instead of `model-b`. A shared empty registry with full→narrow metadata returned `model-full` instead of `latest`. The unfixed source is identical on the current main base.
- On main `665d4fadbd475a4117dc90696ae2da1037afdb3c`, the cache regression and two normalization sibling files passed **28 tests**. They cover A→B→empty→A→A, active-scope restoration, full→narrow→full metadata, and mutation isolation for model and route fields.
- An isolated synthetic source run through `runWithModelFallback` attempted the expected A/B/empty/A fallback models after each primary failure. This is source-boundary proof, not a package, Gateway, or authenticated-provider result.
- The prior full changed gate and managed **P2 scoped-clean** review carry forward by exact equivalence: both file operations and postimages, all 33 reviewed context files, and 21 additional dependency/tooling/owner files are byte-identical. Current-main targeted lint, formatting, and diff checks passed. Required CI must be assessed on the rewritten PR head.

- [Blacksmith Testbox runtime proof](https://github.com/openclaw/openclaw/actions/runs/34181669478) built exact published head `63be3978bdaf3941ddf3b367c4624ed4e21da739`. Both compiled cache scenarios passed: retained registries A→B→empty→A and metadata full→narrow→full. Across seven contexts, the real fallback runner made all 14 expected primary/fallback attempts; caller-copy isolation and route provenance remained intact. All six production functions came from that natural build. Both process groups settled without escalation, fixtures were removed, source/runtime manifests stayed unchanged, and all 81 exported files were hash-verified.

This is compiled production-boundary proof with synthetic provider callbacks. It does not establish Gateway, external-provider, or CPU/stall recovery. Exact-head CI and native landing remain pending.

Contributor credit remains Peter Steinberger (@steipete).

