### PR TITLE
perf(test): shorten escaped-output timeout grace

### DIFF
--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -1145,6 +1145,8 @@ child.once('message', () => { ${normalExit ? "process.exit(0);" : ""} });
                 args,
                 stdio: ["ignore", "pipe", "pipe"],
                 timeoutMs: mode === "timeout" ? 100 : undefined,
+                // This row verifies the full pipe-drain budget, not the default TERM grace.
+                timeoutKillGraceMs: 100,
                 requireProcessTreeExit: normalExit,
                 signal: abortController.signal,
                 onReady: (owned) => {


### PR DESCRIPTION
## What Problem This Solves

The escaped-output timeout regression spends about ten seconds checking that a managed command fails closed when a detached descendant keeps its output pipes open. Roughly half that time is the default termination grace, before the separate pipe-drain deadline starts.

## Why This Change Was Made

Use the existing `timeoutKillGraceMs: 100` option for this fixture. It retains a real graceful interval and the full five-second pipe-drain budget. The normal-exit and normal-drainage rows have no timeout, and the sibling-failure row keeps its separate cancellation path. Dedicated graceful, forced, nested and forwarded-signal tests retain their existing timings and assertions.

No production code, sharding, concurrency, test selection, watchdog, timeout deadline or assertion changes. Production LOC delta: 0; tests: +2/-0. This is an internal test change, so no changelog entry is needed.

## User Impact

Faster test execution with the same escaped-pipe cleanup coverage. This does not change application behavior or claim an equivalent reduction in total CI wall time.

## Evidence

Balanced Linux baseline/candidate/candidate/baseline runs used the same Blacksmith Testbox and command:

```sh
node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts -t 'joins escaped output' --reporter=json --outputFile=<report.json>
```

| Measurement | Baseline mean | Candidate mean | Saved |
| --- | ---: | ---: | ---: |
| Timeout case | 10.111 s | 5.210 s | 4.901 s |
| Existing concurrent four-case group | 10.111 s | 6.053 s | 4.058 s (40.1%) |

Two local macOS runs per version corroborated the result. All 73 local owner and sibling cases passed (one platform-specific skip), including default-grace and real pipe-drain tests. Independent Codex review found no accepted/actionable findings.

The Linux negative control removed the production owner's pipe-closure condition only in the disposable proof environment. The unchanged timeout test rejected the incorrect timeout outcome at its existing cleanup-failure assertion; the original owner was then restored. The retained failure was verified at the exact cleanup assertion before the restored full-suite run.

Linux full owner/sibling coverage: all 74 cases passed. All 14 changed checks passed; source fences were intact and escaped-output fixture processes were absent. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33343087527) completed successfully at `121b95e5a5567154ff9f09af0f44c1a8624e7e59`. The completed ClawSweeper review found no actionable issues; its normal maintainer-review requirement is covered by the reviewed, explicitly authorized landing. Environment: Blacksmith Testbox `tbx_01m1agx5b0mafrmc26b7er3re3`, [proof environment run](https://github.com/openclaw/openclaw/actions/runs/33342566556).
