### PR TITLE
perf: speed up chat history preparation

### DIFF
--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -162,6 +162,10 @@ export function stripHeartbeatToken(
   if (!trimmed) {
     return { shouldSkip: true, text: "", didStrip: false };
   }
+  // Markup cleanup inserts spaces or removes edge wrappers; it cannot create this token.
+  if (!trimmed.includes(HEARTBEAT_TOKEN)) {
+    return { shouldSkip: false, text: trimmed, didStrip: false };
+  }
 
   const mode: StripHeartbeatMode = opts.mode ?? "message";
   const maxAckCharsRaw = opts.maxAckChars;
@@ -187,10 +191,6 @@ export function stripHeartbeatToken(
       .replace(/[*`~_]+$/, "");
 
   const trimmedNormalized = stripMarkup(trimmed);
-  const hasToken = trimmed.includes(HEARTBEAT_TOKEN) || trimmedNormalized.includes(HEARTBEAT_TOKEN);
-  if (!hasToken) {
-    return { shouldSkip: false, text: trimmed, didStrip: false };
-  }
 
   const strippedOriginal = stripTokenAtEdges(trimmed);
   const strippedNormalized = stripTokenAtEdges(trimmedNormalized);

--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -38,23 +38,14 @@ function isInboundContextHeaderLine(line: string): boolean {
   return t.length > INBOUND_CONTEXT_MARKER.length && t.endsWith(INBOUND_CONTEXT_MARKER);
 }
 
-// Pre-compiled fast-path regex — avoids line-by-line parse when no blocks present.
-// Active-memory's bare Context: sentinel is valid only as a complete line.
-const SENTINEL_SUBSTRING_ALTERNATIVES = [INBOUND_CONTEXT_MARKER, ...MESSAGE_TOOL_DELIVERY_HINTS]
-  .map((sentinel) => sentinel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
-  .join("|");
-const ACTIVE_MEMORY_HEADER_ESCAPED = ACTIVE_MEMORY_CONTEXT_HEADER.replace(
-  /[.*+?^${}()|[\]\\]/g,
-  "\\$&",
-);
-const SENTINEL_FAST_RE = new RegExp(
-  `${SENTINEL_SUBSTRING_ALTERNATIVES}|^[ \t]*${ACTIVE_MEMORY_HEADER_ESCAPED}[ \t]*$`,
-  "m",
-);
-
 /** Fast check for whether text contains any inbound metadata sentinel. */
 export function hasInboundMetadataSentinel(text: string): boolean {
-  return Boolean(text && SENTINEL_FAST_RE.test(text));
+  return (
+    text.includes(INBOUND_CONTEXT_MARKER) ||
+    MESSAGE_TOOL_DELIVERY_HINTS.some((hint) => text.includes(hint)) ||
+    // Active-memory's bare Context: sentinel is valid only as a complete line.
+    (text.includes(ACTIVE_MEMORY_CONTEXT_HEADER) && /^[ \t]*Context:[ \t]*$/m.test(text))
+  );
 }
 
 function isMessageToolDeliveryHintLine(line: string): boolean {
@@ -212,7 +203,7 @@ export function stripInboundMetadata(text: string): string {
   }
 
   const withoutTimestamp = text.replace(LEADING_TIMESTAMP_PREFIX_RE, "");
-  if (!SENTINEL_FAST_RE.test(withoutTimestamp)) {
+  if (!hasInboundMetadataSentinel(withoutTimestamp)) {
     return withoutTimestamp;
   }
 
@@ -282,7 +273,7 @@ export function stripInboundMetadata(text: string): string {
 
 /** Strips only leading inbound metadata blocks while preserving later user text. */
 export function stripLeadingInboundMetadata(text: string): string {
-  if (!text || !SENTINEL_FAST_RE.test(text)) {
+  if (!hasInboundMetadataSentinel(text)) {
     return text;
   }
 


### PR DESCRIPTION
## What Problem This Solves

Opening or scrolling back through long Control UI chats still spends avoidable Gateway time scanning ordinary messages for inbound metadata and heartbeat acknowledgement markup.

Follow-up to #133565, which increased history windows and optimized the initial projection path.

## Why This Change Was Made

The metadata owner now checks literal provenance markers and delivery hints directly, using its whole-line regex only when `Context:` is present. Both metadata-stripping entry points share that detector. The heartbeat owner skips markup cleanup when the literal acknowledgement token is absent; the cleanup only inserts spaces or removes edge wrappers, so it cannot create that token.

This removes repeated scans at their shared owners, benefiting Gateway history, TUI formatting, and model replay. Production LOC: +12/-21 (net -9); tests: +0/-0. No new cache, configuration, storage, protocol, page-size, or rendering changes. The full-text and capped sanitization passes remain because TTS matching and deduplication need uncapped text.

## User Impact

Chats open and older history loads with less Gateway processing. Existing metadata stripping, heartbeat suppression, displayed messages, initial 400-message windows, and older 1,000-message windows retain their behavior.

Release-note context: Chat history skips metadata-pattern and heartbeat-markup scans for ordinary messages, reducing Gateway work when opening chats and loading older history.

## Evidence

Paired Node inspector measurements against baseline `6af76da58f4c469398eea9f03101c8d8fd349996` on the same macOS arm64 machine, Node 26.8.1, real isolated SQLite transcripts with 3,000 messages and 2,048 Markdown characters per message. Five warmup rounds and 30 measured rounds per scenario, with scenario order rotated. These medians measure history read/projection; they exclude setup, serialization, network, and browser painting.

| Rich-history scenario | Before | After | Reduction |
|---|---:|---:|---:|
| Initial 400 | 22.056 ms | 16.770 ms | 24.0% |
| Initial 1,000 | 55.197 ms | 41.764 ms | 24.3% |
| Older 1,000, offset 1,000 | 14.479 ms | 11.248 ms | 22.3% |

An independent earlier pair measured 15–17% less time for rich initial pages. Metadata-heavy pages improved about 9–10%; short-message differences were small and noisy on the busy host. The expanded rich CPU profile fell from 4,420.8 to 3,395.7 ms; metadata stripping and heartbeat markup cleanup accounted for 502.8 and 179.4 ms of sampled self time before this patch and disappear from the top frames afterward. No browser-paint improvement is claimed.

467 existing focused/integration tests passed: 358 local heartbeat, metadata, presentation, Gateway projection, TUI, and CLI replay tests, plus 109 clean Linux tests for provider-boundary cache stability and a real ephemeral Gateway's REST/SSE history flow. [Blacksmith Testbox run 33342433086](https://github.com/openclaw/openclaw/actions/runs/33342433086) completed with wrapper exit 0 and its lease was stopped; the backing Actions lifecycle may show cancellation after successful external cleanup.

600,000 deterministic old/new helper comparisons over 50,000 adversarial strings matched. All 15 page snapshots (8,100 messages) were deeply equal after normalizing only the source identifier derived from each fresh database's path and rewrite generation. Existing behavior tests plus paired profiling and differential checks were used instead of adding timing assertions or implementation-coupled tests. Temporary measurement harnesses are not part of the product diff.

Targeted formatting, lint, and strict typechecking of both edited modules passed. The broad local changed gate stopped at six pre-existing `tslog` declaration errors in `src/logging/logger.ts`; local integration setup also lacked `shiki/wasm`, so integration proof ran in the clean Linux Testbox. Named local follow-up: repair the shared dependency installation. Required Codex autoreview passed with no findings; exact-head [CI run 33343149590](https://github.com/openclaw/openclaw/actions/runs/33343149590) passed for `5a0f80701bf8bf8cb71f669392200106c0da982c`. This satisfies ClawSweeper’s remaining CI request.
