### PR TITLE
feat(ui): add a preference to hide empty session groups

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -267,6 +267,8 @@ The sidebar organizes everything around the agent. The identity row at the top i
 
 Session previews are hidden by default for compact, single-line rows. Enable **Show message preview** in the **Sessions** filter menu to restore routine status text and message previews. The browser remembers your choice. Errors and requests for attention remain visible with previews off.
 
+Enable **Hide empty groups** in the same menu to hide custom groups with no sessions in the current sidebar view. It is off by default, and the browser remembers your choice. Collapsed groups with sessions stay visible. Hidden groups keep their membership and order and remain available in **Move to group**; turn the setting off to use their headers as drag targets again.
+
 **Mark as unread** creates a reminder that remains unread while the current chat stays open, including while a run streams or completes. Leave and reopen the session, or choose **Mark as read**, to clear it.
 
 **Delete** removes the confirmed selection from loaded session lists immediately and leaves any deleted conversation that is open. The Gateway finishes deletion in the background, safely stopping and reclaiming an attached cloud worker first. If deletion fails, the affected session can reappear with an error; other successful deletions and any navigation you made in the meantime are preserved. Browser drafts are retired only after deletion is confirmed, not while the request is pending.

--- a/ui/src/components/app-sidebar-session-menu-renderers.ts
+++ b/ui/src/components/app-sidebar-session-menu-renderers.ts
@@ -269,6 +269,7 @@ export function renderSidebarSessionSortMenu(params: {
   showCron: boolean;
   showPreview: boolean;
   showSystem: boolean;
+  hideEmptyGroups: boolean;
   owners: readonly SessionOwnerOption[];
   ownerFilterId: string | null;
   involvingMe: boolean;
@@ -280,6 +281,7 @@ export function renderSidebarSessionSortMenu(params: {
   onShowCronChange: (show: boolean) => void;
   onShowPreviewChange: (show: boolean) => void;
   onShowSystemChange: (show: boolean) => void;
+  onHideEmptyGroupsChange: (hide: boolean) => void;
   onClose: (restoreFocus: boolean) => void;
 }) {
   const position = params.position;
@@ -322,6 +324,8 @@ export function renderSidebarSessionSortMenu(params: {
             params.onShowCronChange(!params.showCron);
           } else if (value === "show-system") {
             params.onShowSystemChange(!params.showSystem);
+          } else if (value === "hide-empty-groups") {
+            params.onHideEmptyGroupsChange(!params.hideEmptyGroups);
           }
         }}
         @keydown=${(event: KeyboardEvent) =>
@@ -402,6 +406,17 @@ export function renderSidebarSessionSortMenu(params: {
           <span class="session-menu__text">${t("sessionsView.showSystemSessions")}</span>
           <span slot="details" class="session-menu__check" aria-hidden="true"
             >${params.showSystem ? icons.check : nothing}</span
+          >
+        </wa-dropdown-item>
+        <wa-dropdown-item
+          class="sidebar-session-sort-menu__item"
+          type="checkbox"
+          value="hide-empty-groups"
+          .checked=${params.hideEmptyGroups}
+        >
+          <span class="session-menu__text">${t("sessionsView.hideEmptyGroups")}</span>
+          <span slot="details" class="session-menu__check" aria-hidden="true"
+            >${params.hideEmptyGroups ? icons.check : nothing}</span
           >
         </wa-dropdown-item>
       </wa-dropdown>

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -66,6 +66,7 @@ import {
   loadStoredSidebarSessionSortMode,
   loadStoredSidebarSessionStatusFilter,
   loadStoredSidebarSessionsGrouping,
+  loadStoredSidebarSessionsHideEmptyGroups,
   loadStoredSidebarSessionsShowCron,
   loadStoredSidebarSessionsShowPreview,
   loadStoredSidebarSessionsShowSystem,
@@ -167,6 +168,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
   @state() sessionsShowCron = loadStoredSidebarSessionsShowCron();
   @state() sessionsShowPreview = loadStoredSidebarSessionsShowPreview();
   @state() sessionsShowSystem = loadStoredSidebarSessionsShowSystem();
+  @state() sessionsHideEmptyGroups = loadStoredSidebarSessionsHideEmptyGroups();
   @state() sessionsStatusFilter: SidebarSessionStatusFilter =
     loadStoredSidebarSessionStatusFilter();
   @state() hiddenSessionCatalogIds = loadStoredHiddenSessionCatalogIds();
@@ -348,8 +350,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
           ? []
           : this.visibleSessionCatalogs().map((catalog) => catalog.id),
       collapsedSections: this.collapsedSessionSections,
-      hideEmptyOwnerFilteredGroup: (category, rowCount) =>
-        this.sessionOwnerFilterActive && Boolean(category) && rowCount === 0,
+      hideEmptyGroups: this.sessionsHideEmptyGroups || this.sessionOwnerFilterActive,
       visibleSessionLimits: this.sessionData.visibleSessionLimits,
       sortMode: this.effectiveSessionSortMode(),
       statusFilter: this.sessionsStatusFilter,

--- a/ui/src/components/app-sidebar-session-projection.test.ts
+++ b/ui/src/components/app-sidebar-session-projection.test.ts
@@ -44,7 +44,7 @@ function projectionInput(
     grouping: "category",
     knownGroups: [],
     collapsedSections: new Set(),
-    hideEmptyOwnerFilteredGroup: () => false,
+    hideEmptyGroups: false,
     visibleSessionLimits: new Map(),
     sortMode: "created",
     statusFilter: "active",

--- a/ui/src/components/app-sidebar-session-projection.ts
+++ b/ui/src/components/app-sidebar-session-projection.ts
@@ -31,7 +31,7 @@ type SidebarProjectionInput = {
   catalogIds?: readonly string[];
   sectionOrder?: readonly string[];
   collapsedSections: ReadonlySet<string>;
-  hideEmptyOwnerFilteredGroup: (category: string | undefined, rowCount: number) => boolean;
+  hideEmptyGroups: boolean;
   visibleSessionLimits: ReadonlyMap<string, number>;
   sortMode: SidebarSessionSortMode;
   statusFilter: SidebarSessionStatusFilter;
@@ -201,7 +201,7 @@ export class SidebarSessionProjection {
     }).filter(
       (section) =>
         section.id !== "pinned" &&
-        !input.hideEmptyOwnerFilteredGroup(section.category, section.rows.length),
+        !(input.hideEmptyGroups && section.category && section.rows.length === 0),
     );
     const sectionIds = new Set<string>(sections.map((section) => section.id));
     for (const sectionId of this.stickySections.keys()) {

--- a/ui/src/components/app-sidebar-session-types.ts
+++ b/ui/src/components/app-sidebar-session-types.ts
@@ -265,6 +265,7 @@ const SIDEBAR_SESSION_CATALOG_GROUPING_STORAGE_KEY = "openclaw:sidebar:sessions:
 const SIDEBAR_SESSION_SHOW_PREVIEW_STORAGE_KEY = "openclaw:sidebar:sessions:show-preview";
 const SIDEBAR_SESSION_SHOW_CRON_STORAGE_KEY = "openclaw:sidebar:sessions:show-cron";
 const SIDEBAR_SESSION_SHOW_SYSTEM_STORAGE_KEY = "openclaw:sidebar:sessions:show-system";
+const SIDEBAR_SESSION_HIDE_EMPTY_GROUPS_STORAGE_KEY = "openclaw:sidebar:sessions:hide-empty-groups";
 const SIDEBAR_SESSION_STATUS_FILTER_STORAGE_KEY = "openclaw:sidebar:sessions:status-filter";
 const SIDEBAR_SESSION_SORT_MODE_STORAGE_KEY = "openclaw:sidebar:sessions:sort-mode";
 const SIDEBAR_SESSION_COLLAPSED_SECTIONS_STORAGE_KEY =
@@ -297,6 +298,10 @@ export function loadStoredSidebarSessionsShowPreview(): boolean {
 
 export function loadStoredSidebarSessionsShowSystem(): boolean {
   return getSafeLocalStorage()?.getItem(SIDEBAR_SESSION_SHOW_SYSTEM_STORAGE_KEY) === "true";
+}
+
+export function loadStoredSidebarSessionsHideEmptyGroups(): boolean {
+  return getSafeLocalStorage()?.getItem(SIDEBAR_SESSION_HIDE_EMPTY_GROUPS_STORAGE_KEY) === "true";
 }
 
 export function loadStoredSidebarSessionStatusFilter(): SidebarSessionStatusFilter {
@@ -386,6 +391,10 @@ export function storeSidebarSessionsShowPreview(show: boolean) {
 
 export function storeSidebarSessionsShowSystem(show: boolean) {
   getSafeLocalStorage()?.setItem(SIDEBAR_SESSION_SHOW_SYSTEM_STORAGE_KEY, String(show));
+}
+
+export function storeSidebarSessionsHideEmptyGroups(hide: boolean) {
+  getSafeLocalStorage()?.setItem(SIDEBAR_SESSION_HIDE_EMPTY_GROUPS_STORAGE_KEY, String(hide));
 }
 
 export function storeSidebarSessionStatusFilter(value: SidebarSessionStatusFilter) {

--- a/ui/src/components/session-organizer-controller-types.ts
+++ b/ui/src/components/session-organizer-controller-types.ts
@@ -25,6 +25,7 @@ export interface SessionOrganizerControllerHost extends ReactiveControllerHost {
   sessionsShowCron: boolean;
   sessionsShowPreview: boolean;
   sessionsShowSystem: boolean;
+  sessionsHideEmptyGroups: boolean;
   sessionsStatusFilter: SidebarSessionStatusFilter;
   clearSessionSelection(): void;
   findSidebarSessionByKey(sessionKey: string): SidebarRecentSession | undefined;

--- a/ui/src/components/session-organizer-controller.ts
+++ b/ui/src/components/session-organizer-controller.ts
@@ -23,6 +23,7 @@ import {
   storeSidebarSessionStatusFilter,
   storeCollapsedSessionSections,
   storeSidebarSessionsGrouping,
+  storeSidebarSessionsHideEmptyGroups,
   storeSidebarSessionsShowCron,
   storeSidebarSessionsShowPreview,
   storeSidebarSessionsShowSystem,
@@ -773,5 +774,14 @@ export class SessionOrganizerController {
       // Keep the in-memory preference when storage is unavailable.
     }
     void this.host.sessionData.refreshSidebarSessions();
+  }
+
+  setSessionsHideEmptyGroups(hide: boolean) {
+    this.host.sessionsHideEmptyGroups = hide;
+    try {
+      storeSidebarSessionsHideEmptyGroups(hide);
+    } catch {
+      // Keep the in-memory preference when storage is unavailable.
+    }
   }
 }

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -423,6 +423,7 @@ export function renderSidebarSessionSortMenuForController(controller: SidebarMen
     showCron: host.sessionsShowCron,
     showPreview: host.sessionsShowPreview,
     showSystem: host.sessionsShowSystem,
+    hideEmptyGroups: host.sessionsHideEmptyGroups,
     owners: host.sessionOwnershipVisible ? host.sessionOwnerOptions : [],
     ownerFilterId: host.sessionOwnerFilterActive ? host.sessionOwnerFilterId : null,
     involvingMe: host.sessionInvolvingMeFilterActive,
@@ -453,6 +454,10 @@ export function renderSidebarSessionSortMenuForController(controller: SidebarMen
     },
     onShowSystemChange: (show) => {
       host.sessionOrganizer.setSessionsShowSystem(show);
+      controller.closeSessionSortMenu({ restoreFocus: true });
+    },
+    onHideEmptyGroupsChange: (hide) => {
+      host.sessionOrganizer.setSessionsHideEmptyGroups(hide);
       controller.closeSessionSortMenu({ restoreFocus: true });
     },
     onClose: (restoreFocus) => {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1260,6 +1260,7 @@ export const en: TranslationMap = {
     groupByCategory: "Custom groups",
     groupByPerson: "Person",
     showSessionPreview: "Show message preview",
+    hideEmptyGroups: "Hide empty groups",
     showCronSessions: "Show automation sessions",
     showSystemSessions: "Show system sessions",
     groupByChannel: "Channel",

--- a/ui/src/test-helpers/app-sidebar-cases/session-list-sections.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-list-sections.ts
@@ -163,6 +163,59 @@ describe("AppSidebar session section visibility", () => {
     expect(sidebar.querySelector('[data-session-section="ungrouped"]')).not.toBeNull();
   });
 
+  it("persists hiding empty groups without hiding collapsed populated groups", async () => {
+    const harness = createSessionsHarness("main", ["agent:main:main", "agent:main:alpha"]);
+    const alpha = harness.sessions.state.result!.sessions.find(
+      (row) => row.key === "agent:main:alpha",
+    )!;
+    alpha.category = "Alpha";
+    harness.publish({ groups: ["Empty", "Alpha"] });
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const mounted = await mountSidebar(gateway, harness.sessions);
+    let sidebar = mounted.sidebar;
+    sidebar.sessionOrganizer.saveCollapsedSessionSections(new Set(["category:Alpha"]));
+    await sidebar.updateComplete;
+
+    const groupNames = () =>
+      [...sidebar.querySelectorAll("[data-session-section^='category:']")].map((group) =>
+        group.getAttribute("data-session-section"),
+      );
+    const toggleEmptyGroups = async (checked: boolean) => {
+      sidebar.querySelector<HTMLButtonElement>(".sidebar-session-sort")!.click();
+      await sidebar.updateComplete;
+      const menu = sidebar.querySelector(".sidebar-session-sort-menu")!;
+      const toggle = menu.querySelector<HTMLElement & { checked: boolean }>(
+        '[value="hide-empty-groups"]',
+      );
+      expect(toggle?.textContent).toContain("Hide empty groups");
+      expect(toggle?.checked).toBe(checked);
+      menu.dispatchEvent(
+        new CustomEvent("wa-select", {
+          bubbles: true,
+          detail: { item: { value: "hide-empty-groups" } },
+        }),
+      );
+      await sidebar.updateComplete;
+    };
+
+    expect(groupNames()).toEqual(["category:Empty", "category:Alpha"]);
+    await toggleEmptyGroups(false);
+    expect(groupNames()).toEqual(["category:Alpha"]);
+
+    mounted.provider.remove();
+    ({ sidebar } = await mountSidebar(gateway, harness.sessions));
+    expect(groupNames()).toEqual(["category:Alpha"]);
+    expect(sidebar.querySelector('[data-session-key="agent:main:alpha"]')).toBeNull();
+
+    // Membership changes reveal and hide groups without changing the preference.
+    alpha.category = "Empty";
+    harness.publish({ groups: ["Empty", "Alpha"] });
+    await sidebar.updateComplete;
+    expect(groupNames()).toEqual(["category:Empty"]);
+    await toggleEmptyGroups(true);
+    expect(groupNames()).toEqual(["category:Empty", "category:Alpha"]);
+  });
+
   it("renders no chat rows when only the main session exists", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));


### PR DESCRIPTION
Closes #133629

<details>
<summary>Additional instructions</summary>

Maintainers can edit this branch in the main repository.

</details>

## What Problem This Solves

Custom groups with no sessions in the current Control UI sidebar view add clutter. Operators cannot hide those headings without deleting the groups or changing the grouping mode.

## Why This Change Was Made

Add **Hide empty groups** to the existing **Sessions → Filter & sort** menu and persist it with the browser's other sidebar preferences. Reuse the projection that already filters empty groups for owner-filtered views. Test emptiness before collapse and pagination; leave the Gateway's catalog and session membership untouched.

Best-fix verdict: use the existing sidebar projection and preference flow. A server-side catalog filter would mix shared state with a browser-local view preference; deleting groups would lose organization; changing the default would remove existing drag targets.

## User Impact

- Optional, off by default, and remembered across reloads.
- Hides empty custom groups in the current agent/filter view.
- Populated collapsed groups stay visible.
- Group membership and order are retained. Hidden groups remain in **Move to group**; switching the setting off restores their headers and drag targets.
- No Gateway config, schema, protocol, provider, or dependency changes.

## Evidence

AI-assisted implementation, requested and approved in maintainer chat.

Before rebase: 394 focused tests passed; UI build, UI typecheck, focused lint/style checks, i18n verification, and fresh autoreview passed. The integration regression covers the actual menu, persistence across remount, changing group membership, retained collapse state, and restored group ordering. It failed before implementation because the menu option was missing.

An earlier isolated live Gateway recording passed the actual menu toggle, reload persistence, populated collapsed-group retention, and restored ordering. A later replay encountered a newer fixture schema and then isolated Gateway SQLite/page-load stalls; those attempts are not counted as passing. Final rebased verification will be recorded below before landing.

Production LOC: +46/-4 (net +42); tests/test support: +54/-1 (net +53); docs: +2. Production growth supplies the requested persisted preference, menu control, and controller wiring; no new abstraction or second filtering path.

Related work checked: #115348 is historical empty-agent group presentation; #122805 concerns pinned-session membership; #129672 changes hierarchy and empty-group styling. None provides this optional browser-local filter; this PR does not claim to fix their separate behavior.

### Visual proof (earlier live isolated Gateway)

Before — empty groups visible, preference off:

![Before: empty custom groups visible](https://github.com/user-attachments/assets/58d59308-cffd-4d0f-a900-e27ad7635d0c)

After — empty groups hidden, populated Personal group retained:

![After: empty groups hidden](https://github.com/user-attachments/assets/96d60475-1820-4718-acd0-4f25f17ab3fb)

### Rebased head

At `f20d5fed9d101a8e446782b6674e10212d076103`, all 406 focused tests and `pnpm ui:build` passed. Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/33343176696. Fresh immutable-commit autoreview passed with no accepted/actionable findings. The fresh isolated replay loaded the UI but timed out waiting for group readiness, and a follow-up page load also timed out. The earlier inspected full-flow live screenshots above remain the live evidence; the failed fresh replay is not counted as passing. No operator Gateway was modified. Follow-up: investigate isolated Gateway page/group readiness stalls independently of this browser-local preference.

All selected local checks passed on the rebased head: `node scripts/check-changed.mjs --timed` (guards, formatting, dead exports, i18n, core-test and UI typechecks, lint, and styles).
