### PR TITLE
docs: guide routine Gateway updates through their installation owner

### DIFF
--- a/.agents/skills/openclaw-update/SKILL.md
+++ b/.agents/skills/openclaw-update/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: openclaw-update
+description: "Route routine updates of an existing local or remote OpenClaw Gateway to its installation owner, with automatic session recovery. Defer to deployment-specific skills when available."
+---
+
+# Update OpenClaw
+
+Use for general requests to update an existing Claw/Gateway. Select the existing update workflow; do not create another deployer or scheduler. Release validation, publication, new installations, and unrelated hosts are outside this workflow.
+
+## Resolve the owner
+
+Identify the host, runtime user, profile/state root, service, running executable/release, and update owner from operator configuration and live inspection. The current repository or shell CLI may belong to another install. Keep private access details and state out of public artifacts.
+
+Read the owner runbook and choose the matching workflow:
+
+| Installation                               | Update path                                                                                                                                                |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Canonical live main checkout and macOS app | [openclaw-live-updater](../openclaw-live-updater/SKILL.md).                                                                                                |
+| Operator-configured Team server            | [update-team-server](../update-team-server/SKILL.md).                                                                                                      |
+| Other managed deployments                  | Deployment-specific skill/runbook and existing owner, including containers and declarative installations.                                                  |
+| Standard package or single-user source     | [Updating](../../../docs/install/updating.md) and the [update CLI contract](../../../docs/cli/update.md), using the owning CLI on the target host/profile. |
+
+Follow the selected workflow's commands, locks, backup/migration requirements, recovery, and cleanup. Do not apply standard CLI updates inside a separately managed release or running container, mutate files used by a live Gateway, or overwrite dirty checkouts.
+
+“Latest” preserves the configured channel; explicitly requested “latest main” selects the development source flow (`--channel dev` for the standard CLI). Preview the target and report the actual serving SHA: development preflight can select an older buildable commit. Do not auto-accept unapproved downgrades or plugin capability changes.
+
+## Interruption and recovery
+
+An update request includes routine restart and bounded interruption, subject to deployment policy. **Eligible sessions resume automatically. Do not ask again solely because agents, replies, or tasks are active.** Use the owner's graceful drain and recovery-preserving interruption.
+
+Task cancellation, session aborts, and queue clearing can discard work; do not use them to manufacture idleness or manually replay recovered turns. PTYs do not survive. [Restart recovery](../../../docs/gateway/restart-recovery.md) owns recovery behavior and limits.
+
+If the owner lacks controlled interruption, report or repair that gap within scope. Do not invent force flags, bypass persistence/compatibility gates, or repeat the interruption approval question.
+
+## Verify
+
+Use the owner's verification to prove the intended version/commit is serving, RPC/health and configured channels work, and UI/assets load through actual ingress when enabled. Inspect startup/recovery errors without exposing secrets. A build, handoff acknowledgement, or healthy old process is not completion. Report the serving version and remaining issues.

--- a/.agents/skills/openclaw-update/agents/openai.yaml
+++ b/.agents/skills/openclaw-update/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Update OpenClaw"
+  short_description: "Update a Gateway through its installation owner"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -302,6 +302,7 @@
   - changed-files:
       - any-glob-to-any-file:
           - "docs/**"
+          - ".agents/skills/openclaw-update/**"
           - ".agents/skills/update-team-server/**"
 
 "cli":


### PR DESCRIPTION
## What Problem This Solves

Routine requests to update an existing Gateway need a general repository operator entry point. The existing live-checkout, Team-server, and release-validation skills have narrower scopes; selecting one indiscriminately can use the wrong deployment owner or introduce unnecessary interruption approval questions.

## Why This Change Was Made

Add `openclaw-update` as a short routing skill that delegates to the installation's existing owner and canonical update documentation. Keep deployment procedures in their existing skills/runbooks and recovery semantics in the Gateway restart-recovery documentation. Register the skill under the existing `docs` label.

This is maintainer-requested repository operator guidance, not a bundled runtime skill or a new deployer. AI-assisted with Codex.

## User Impact

Agents handling routine updates choose the correct installation workflow and understand that eligible sessions resume automatically. Active work alone does not trigger another interruption approval question; persistence, compatibility, deployment policy, and destructive-operation boundaries remain intact. Completion requires proof that the intended version is serving.

No Gateway runtime, configuration, schema, or update implementation changes.

## Evidence

- Skill schema validation passed with `quick_validate.py`.
- `pnpm dlx oxfmt@0.60.0 --check .agents/skills/openclaw-update/SKILL.md .agents/skills/openclaw-update/agents/openai.yaml .github/labeler.yml` passed.
- Relative links, the existing `.claude/skills` discovery alias, interface metadata, docs-label mapping, and private-host-detail scan passed; `git diff --check` passed.
- Compared with the existing specialized skills and current update/restart-recovery contracts. Command details stay in the canonical CLI docs rather than a second reference document.
- No live deployment was performed for this instruction-only change; existing deployment implementations and recovery behavior are unchanged.

Codex autoreview completed with no accepted/actionable findings at its default P0 threshold. Production LOC: +0/-0; tests: +0/-0; operator guidance and metadata: +41/-0.
