### PR TITLE
improve: speed up legacy session transcript imports

### DIFF
--- a/src/agents/sessions/session-manager-codec.ts
+++ b/src/agents/sessions/session-manager-codec.ts
@@ -335,14 +335,13 @@ function isReadableMessage(value: unknown): boolean {
 
 function isReadableLegacySessionEntry(value: unknown): value is FileEntry {
   const message = isRecord(value) && value.type === "message" ? value.message : undefined;
-  const readableLegacyMessage =
-    isRecord(message) && message.role === "hookMessage"
-      ? isReadableContent(message.content)
-      : isReadableMessage(message);
   return (
     isRecord(value) &&
     isSessionEntryType(value.type) &&
-    (value.type !== "message" || readableLegacyMessage)
+    (value.type !== "message" ||
+      (isRecord(message) && message.role === "hookMessage"
+        ? isReadableContent(message.content)
+        : isReadableMessage(message)))
   );
 }
 
@@ -393,9 +392,10 @@ export function parseOpaqueLeafEntry(record: unknown):
 
 export function classifySessionFileEntry(rawEntry: FileEntry, sourceVersion: number) {
   const entry = normalizePersistedLegacyHookMessage(rawEntry) as FileEntry;
+  // Legacy rows can lack modern IDs; avoid constructing a discarded validation error for each one.
   const recognized =
-    isIndexedSessionEntry(entry) ||
-    (sourceVersion < CURRENT_SESSION_VERSION && isReadableLegacySessionEntry(entry));
+    (sourceVersion < CURRENT_SESSION_VERSION && isReadableLegacySessionEntry(entry)) ||
+    isIndexedSessionEntry(entry);
   return { entry, recognized };
 }
 

--- a/src/commands/doctor-session-sqlite-readers.test.ts
+++ b/src/commands/doctor-session-sqlite-readers.test.ts
@@ -48,6 +48,7 @@ describe("legacy transcript row classification", () => {
 
   it.each([1, 2, 3, 4])("preserves recognized and opaque rows from version %s", (version) => {
     const unindexedHook = { type: "message", message: { role: "custom", content: "context" } };
+    const legacyMetadata = { type: "thinking_level_change", thinkingLevel: "low" };
     const opaqueRows = [
       { type: "session", id: "later-header", version: 1 },
       { type: "plugin_state", id: "opaque", payload: { keep: "exact" } },
@@ -57,6 +58,7 @@ describe("legacy transcript row classification", () => {
       { type: "session", version, sessionId: "legacy-header" },
       { ...unindexedHook, id: "hook", parentId: null },
       unindexedHook,
+      legacyMetadata,
       ...opaqueRows,
     ];
     fs.writeFileSync(transcriptPath, rows.map((row) => JSON.stringify(row)).join("\n"));
@@ -88,7 +90,16 @@ describe("legacy transcript row classification", () => {
     } else {
       expect(events[2]).toEqual(unindexedHook);
     }
-    expect(events.slice(3)).toEqual(opaqueRows);
+    expect(events[3]).toEqual(
+      version === 1
+        ? {
+            ...legacyMetadata,
+            id: expect.stringMatching(/^[a-f0-9]{16}-3$/),
+            parentId: expect.stringMatching(/^[a-f0-9]{16}-2$/),
+          }
+        : legacyMetadata,
+    );
+    expect(events.slice(4)).toEqual(opaqueRows);
   });
 
   it.each([1, 3])("enforces the target limit even during v%s prefix recovery", (version) => {


### PR DESCRIPTION
Related: #133611

## What Problem This Solves

Importing older session histories spends CPU rejecting each record against modern requirements before accepting it through the existing legacy reader. Genuine v1 records lack modern IDs, and old hook messages use a retired role, so successful imports repeatedly construct and discard validation errors.

## Why This Change Was Made

Try the existing legacy predicate first for legacy versions, while retaining the modern predicate as the other arm of the same recognition rule. Within legacy validation, validate message content only for message records. All schemas, hook normalization, opaque-row preservation, and migration rules stay unchanged.

## User Impact

Less validation overhead when importing old session histories. Current and future transcript versions keep the existing indexed validation path. No SQLite schema, queries, transactions, configuration, dependencies, or persistence semantics change.

## Evidence

- Extended the existing version 1–4 reader table with unindexed legacy metadata, checking v1 IDs and parent links while retaining malformed-message, opaque-row, and hook coverage.
- Independent Codex review is scoped-clean through P3, confidence 0.99. Scoped lint and formatting passed.
- Production +7/-7 (net zero); tests +12/-1 (net +11).
- All 148 focused tests passed across SessionManager, codec, Doctor, reader, and importer suites. Command: `node scripts/run-vitest.mjs src/agents/sessions/session-manager-codec.test.ts src/agents/sessions/session-manager.test.ts src/commands/doctor-session-sqlite-readers.test.ts src/commands/doctor-session-sqlite.test.ts src/config/sessions/session-accessor.sqlite-import.test.ts`.
- Structural changed-file checks passed through the core graph boundary. Local core types stopped on six pre-existing errors in unchanged `src/logging/logger.ts`; the shared `tslog` install lacks `types/BaseLogger.d.ts`. Shared dependencies were not modified. Exact-head CI passed.
- Linux Node 24.19.0 / SQLite 3.53.3: 50 full-import pairs across nine shapes, identical stored-data digests, unchanged SQL calls (100,034 across 34 shapes), and eight CPU profiles restricted to the import region. The packaged stable-upgrade proof also passed.

The preliminary local classifier screen identified discarded Zod errors as the hotspot. Local full-import wall time was dominated by filesystem stalls, so those samples are retained as exploratory evidence and are not used for speed claims. A separate batch identity-query candidate was not selected because that screen did not establish a gain.

### Linux measurements

Candidate `f3645ed77e5077de973e84330372910f74149476`; baseline overrides only the codec owner with its contents at `5f0aa4f7c56870e01fd8103176eb93ca58700c72`. All other code/dependencies are identical. Fresh processes alternate before/after order. Fixture generation and exact parity checks are outside the timer. These are complete file-to-SQLite imports, not classifier-only measurements. Five pairs per shape, ten for the modern deep control:

| Shape | Before | After | Wall change |
| --- | ---: | ---: | ---: |
| single | 9.0 ms | 9.1 ms | +1.8% |
| deep | 5623.9 ms | 5601.3 ms | -0.4% |
| wide | 672.3 ms | 656.9 ms | -2.3% |
| branch | 1027.5 ms | 1042.5 ms | +1.5% |
| replay | 170.4 ms | 167.0 ms | -2.0% |
| legacy-v1 | 705.3 ms | 631.2 ms | -10.5% |
| legacy-v2 | 592.2 ms | 583.2 ms | -1.5% |
| legacy-metadata-v1 | 488.0 ms | 360.4 ms | -26.1% |
| legacy-hooks-v2 | 561.5 ms | 489.5 ms | -12.8% |

The first five modern deep pairs showed a 4.0% slower candidate median; five additional pairs with reversed starting order showed a 2.3% faster median. All ten combined give 5623.9 → 5601.3 ms, with CPU 5832.6 → 5836.8 ms. No modern deep-history speedup or consistent slowdown is claimed; both runs are retained. Other small control differences are not claimed as meaningful gains. The clear improvements are genuine v1 messages without IDs (10.5%), v1 metadata (26.1%), and v2 hook messages (12.8%).

Median CPU time also fell for the targeted legacy shapes: v1 messages 970.6 → 860.8 ms (11.3%), v1 metadata 738.1 → 574.9 ms (22.1%), and v2 hook messages 803.6 → 700.9 ms (12.8%).

Every full-import pair preserves exact transcript JSON, identities, window metadata, active positions, watermarks, and FTS. Raw results and eight profiles were collected with SHA-256 `9347b6f42ddf2544ecdafb10341ad8894802811d868ed780723c8cebe198195a`. The [Testbox workflow](https://github.com/openclaw/openclaw/actions/runs/33343263242) hosts the dedicated worker; Crabbox command exits/timings provide the proof verdict. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33343312540) is green on the candidate commit.

The latest ClawSweeper review found no source-level correctness or security issue. Its missing-benchmark finding and rank-up move are addressed by the paired wall/CPU measurements and exact preservation-parity results above.

### Packaged stable upgrade

The existing `published-upgrade-survivor` Docker lane passed from latest stable `2026.7.1-2` to a tarball whose build info identifies exact commit `f3645ed77e5077de973e84330372910f74149476`. The volume fixture preserved **4,800 sessions, 1,227,946 transcript events and 10,000 cron jobs**. Automatic migration was asserted immediately after the update and before the later standalone Doctor check. All survival assertions passed, including eight Gateway history samples (600 messages across two agents) that were identical after restart. The repeat Doctor run completed in 38 seconds against its 60-second budget. The lane took 520 seconds; the full build/package/lane command took 795 seconds.

This uses an explicit candidate tarball, a manual Gateway restart and the expected synthetic plugin-capability consent step; it does not prove unattended update-channel switching. The large volume fixture uses v3 transcript headers and proves packaged upgrade integrity. The genuine v1/v2 performance improvements are established separately by the paired full-import benchmarks above.

Proof archive SHA-256: `aa2e370910c7681b3f917f47c89204b23ef52a1a8dab6a9d7a9956ac9eccc1db`. Native review compared latest main `fbfc46e7272` with the benchmark baseline; neither touched file changed there. A shared-ref fetch collision during review preparation was recovered through the native lock-recovery command and a successful retry; no source or shared dependency changes were needed.
