### PR TITLE
chore(parallel): remove duplicate session ID test seam

### DIFF
--- a/extensions/parallel/src/parallel-search-normalize.ts
+++ b/extensions/parallel/src/parallel-search-normalize.ts
@@ -38,7 +38,7 @@ const PARALLEL_MAX_SEARCH_QUERIES = 5;
 const PARALLEL_SESSION_ID_MAX_LENGTH = 1000;
 const PARALLEL_CLIENT_MODEL_MAX_LENGTH = 100;
 
-export const normalizeParallelSessionId: (
+const normalizeParallelSessionId: (
   value: string | undefined,
   maxLength: number,
 ) => string | undefined = normalizeBoundedOptionalString;

--- a/extensions/parallel/src/parallel-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.runtime.ts
@@ -22,7 +22,6 @@ import {
   normalizeParallelObjective,
   normalizeParallelResults,
   normalizeParallelSearchQueries,
-  normalizeParallelSessionId,
   type ParallelSearchResponse,
   resolveParallelSearchCount,
 } from "./parallel-search-normalize.js";
@@ -218,7 +217,6 @@ export const testing = {
   normalizeParallelObjective,
   normalizeParallelResults,
   normalizeParallelSearchQueries,
-  normalizeParallelSessionId,
   resolveParallelApiKey,
   resolveParallelSearchCount,
   resolveParallelSearchEndpoint,

--- a/extensions/parallel/src/parallel-web-search-provider.test.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.test.ts
@@ -300,14 +300,6 @@ describe("parallel web search provider", () => {
       "e",
     ]);
   });
-  it("normalizes session ids, rejecting blanks and values past the given limit", () => {
-    expect(testing.normalizeParallelSessionId("session-abc", 1000)).toBe("session-abc");
-    expect(testing.normalizeParallelSessionId("  ", 1000)).toBeUndefined();
-    expect(testing.normalizeParallelSessionId(undefined, 1000)).toBeUndefined();
-    expect(testing.normalizeParallelSessionId("x".repeat(1001), 1000)).toBeUndefined();
-    expect(testing.normalizeParallelSessionId("x".repeat(101), 100)).toBeUndefined();
-    expect(testing.normalizeParallelSessionId("x".repeat(100), 100)).toBe("x".repeat(100));
-  });
   it("normalizes client_model identifiers", () => {
     expect(testing.normalizeParallelClientModel("claude-opus-4-7")).toBe("claude-opus-4-7");
     expect(testing.normalizeParallelClientModel("  gpt-5.5  ")).toBe("gpt-5.5");


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

A provider-local test repeated the shared bounded-string normalizer contract and kept a production helper exported solely through the Parallel testing facade. The test supplied its own length bounds, so it did not prove the provider's paid or free wiring.

## Why This Change Was Made

Removes the direct normalizer test and test-facade exposure, while keeping the Parallel-named alias private to its runtime owner. Shared trim/blank/UTF-16/length behavior remains covered by normalization-core; Parallel's paid and free execution tests continue to prove caller session forwarding and the free 100-character cap.

## User Impact

No user-visible behavior changes. The Parallel provider exposes less test-only production surface and relies on owner-boundary coverage for the shared normalization contract.

## Evidence

- `node scripts/run-vitest.mjs extensions/parallel/src/parallel-web-search-provider.test.ts packages/normalization-core/src/string-coerce.test.ts` — 2 files, 68 tests passed.
- `node scripts/check-changed.mjs -- extensions/parallel/src/parallel-search-normalize.ts extensions/parallel/src/parallel-web-search-provider.runtime.ts extensions/parallel/src/parallel-web-search-provider.test.ts` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Structured Codex autoreview — clean; no accepted/actionable findings (0.99 confidence).
- Production/test support: +1/-3; tests: +0/-8; net -10 LOC.
