### PR TITLE
chore(test): remove docs spellcheck source mirror

### DIFF
--- a/test/scripts/docs-spellcheck.test.ts
+++ b/test/scripts/docs-spellcheck.test.ts
@@ -2,7 +2,6 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-const SCRIPT_PATH = "scripts/docs-spellcheck.sh";
 const DICTIONARY_PATH = "scripts/codespell-dictionary.txt";
 const IGNORE_PATH = "scripts/codespell-ignore.txt";
 
@@ -11,15 +10,6 @@ function nonEmptyLines(path: string): string[] {
 }
 
 describe("scripts/docs-spellcheck.sh", () => {
-  it("uses the repository dictionary and ignore files", () => {
-    const script = readFileSync(SCRIPT_PATH, "utf8");
-
-    expect(script).toContain("-D");
-    expect(script).toContain("-");
-    expect(script).toContain("-D\n  scripts/codespell-dictionary.txt");
-    expect(script).toContain("-I\n  scripts/codespell-ignore.txt");
-  });
-
   it("keeps codespell config entries non-empty and unique", () => {
     for (const path of [DICTIONARY_PATH, IGNORE_PATH]) {
       const lines = nonEmptyLines(path);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The docs-spellcheck unit test copied four shell-script substrings, including an assertion that only checked for a hyphen. It froze argument formatting without executing the wrapper and duplicated the stronger command boundary.

## Why This Change Was Made

Removes the shell-text mirror and its unused path constant. The retained test still validates dictionary hygiene, while the repository's `docs:spellcheck` command owns whether the wrapper passes the dictionary and ignore files correctly to codespell.

## User Impact

No user-visible behavior changes. Contributors retain dictionary quality checks without a source-format snapshot of the wrapper.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/docs-spellcheck.test.ts` — 1 test passed.
- `node scripts/check-changed.mjs -- test/scripts/docs-spellcheck.test.ts` — passed.
- `pnpm docs:spellcheck` in a disposable codespell environment reached the executable boundary and reported the same five pre-existing corpus findings as current `main`; this test-only diff neither adds nor suppresses them.
- `git diff --check origin/main...HEAD` — passed.
- Structured Codex autoreview — clean; no accepted/actionable findings (0.99 confidence).
- Tests: +0/-10; production: +0/-0; net -10 LOC.
