### PR TITLE
chore(cron): remove duplicate Shanghai schedule assertion

### DIFF
--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -471,15 +471,6 @@ describe("cron schedule", () => {
     ).toBeUndefined();
   });
 
-  it("never returns a past timestamp for Asia/Shanghai daily schedule (#30351)", () => {
-    const nowMs = Date.parse("2026-03-01T00:00:00.000Z");
-    const next = computeNextRunAtMs(
-      { kind: "cron", expr: "0 8 * * *", tz: "Asia/Shanghai" },
-      nowMs,
-    );
-    expect(requireTimestamp(next, "next run")).toBeGreaterThan(nowMs);
-  });
-
   it("never returns a previous run that is at-or-after now", () => {
     const nowMs = Date.parse("2026-03-01T00:00:00.000Z");
     const previous = computePreviousRunAtMs(


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The cron schedule suite contained two tests with the same Asia/Shanghai expression, timezone, and timestamp for #30351. The later test only asserted that the result was in the future, a strict subset of the retained exact-timestamp regression.

## Why This Change Was Made

Removes the weaker duplicate while retaining the earlier regression that asserts the exact next local occurrence, future ordering, and correct year through the public `computeNextRunAtMs` boundary.

## User Impact

No user-visible behavior changes. The cron suite keeps the full year-rollback regression with one authoritative proof instead of two overlapping cases.

## Evidence

- `node scripts/run-vitest.mjs src/cron/schedule.test.ts src/cron/service.at-reschedule.test.ts` — 2 files, 74 tests passed.
- `node scripts/check-changed.mjs -- src/cron/schedule.test.ts` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Structured Codex autoreview — clean; no accepted/actionable findings (0.99 confidence).
- Tests: +0/-9; production: +0/-0; net -9 LOC.
