### PR TITLE
improve(ui): align picker interaction feedback

### DIFF
--- a/ui/src/e2e/chat-picker-interaction-contract.e2e.test.ts
+++ b/ui/src/e2e/chat-picker-interaction-contract.e2e.test.ts
@@ -1,0 +1,148 @@
+import { expect, it } from "vitest";
+import {
+  chatSessionListResponse,
+  controlUiSessionUrl,
+  createChatFlowE2eSuite,
+  installMockGateway,
+} from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+
+suite.define(() => {
+  it("shows the selected permission and disables dropdown motion when requested", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      reducedMotion: "reduce",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const session = {
+      key: "agent:main:session-a",
+      kind: "direct",
+      label: "Session A",
+      permissionMode: "guarded",
+      updatedAt: 2,
+    };
+    await installMockGateway(page, {
+      methodResponses: { "sessions.list": chatSessionListResponse([session]) },
+      sessionKey: session.key,
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, session.key));
+      const pane = page.locator('openclaw-chat-pane[aria-hidden="false"]');
+      const picker = pane.locator(".chat-controls__permission-picker");
+      await pane.locator('[data-chat-permission-select="true"]').click();
+      await pane.locator('[data-chat-permission-option="default"]').waitFor({ state: "visible" });
+
+      const [selectedBackground, unselectedBackground, showDuration, hideDuration] =
+        await Promise.all([
+          pane
+            .locator('[data-chat-permission-option="guarded"]')
+            .evaluate((element) => getComputedStyle(element).backgroundColor),
+          pane
+            .locator('[data-chat-permission-option="workspace"]')
+            .evaluate((element) => getComputedStyle(element).backgroundColor),
+          picker.evaluate((element) =>
+            Number.parseFloat(getComputedStyle(element).getPropertyValue("--show-duration")),
+          ),
+          picker.evaluate((element) =>
+            Number.parseFloat(getComputedStyle(element).getPropertyValue("--hide-duration")),
+          ),
+        ]);
+      expect(selectedBackground).not.toBe(unselectedBackground);
+      expect(showDuration).toBe(0);
+      expect(hideDuration).toBe(0);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("animates inline pickers from their placed edge and honors reduced motion", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      models: Array.from({ length: 12 }, (_, index) => ({
+        id: `model-${index + 1}`,
+        name: `Model ${index + 1}`,
+        provider: "openai",
+      })),
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      const control = page.locator(".chat-composer-model-control");
+
+      for (const picker of [
+        {
+          popup: ".chat-controls__model-picker > wa-popup",
+          trigger: '[data-chat-model-select="true"]',
+        },
+        {
+          popup: ".chat-controls__effort-picker > wa-popup",
+          trigger: '[data-chat-thinking-select="true"]',
+        },
+      ]) {
+        await page.emulateMedia({ reducedMotion: "no-preference" });
+        await page.setViewportSize({ height: 900, width: 1280 });
+        await control.evaluate((element) => {
+          Object.assign((element as HTMLElement).style, {
+            position: "fixed",
+            right: "80px",
+            top: "640px",
+          });
+        });
+        const trigger = control.locator(picker.trigger);
+        const popup = control.locator(picker.popup);
+        await trigger.click();
+        await expect.poll(() => popup.getAttribute("data-current-placement")).toMatch(/^top/u);
+
+        const topMotion = await popup.evaluate((element) => {
+          const surface = element.shadowRoot?.querySelector<HTMLElement>('[part~="popup"]');
+          if (!surface) {
+            return null;
+          }
+          const style = getComputedStyle(surface);
+          return {
+            animationName: style.animationName,
+            height: surface.offsetHeight,
+            originY: Number.parseFloat(style.transformOrigin.split(" ")[1] ?? ""),
+          };
+        });
+        expect(topMotion?.animationName).toBe("chat-composer-picker-in");
+        expect(topMotion?.originY).toBeCloseTo(topMotion?.height ?? -1, 0);
+
+        await page.emulateMedia({ reducedMotion: "reduce" });
+        expect(
+          await popup.evaluate((element) => {
+            const surface = element.shadowRoot?.querySelector<HTMLElement>('[part~="popup"]');
+            return surface ? getComputedStyle(surface).animationName : null;
+          }),
+        ).toBe("none");
+
+        await page.setViewportSize({ height: 320, width: 1280 });
+        await control.evaluate((element) => {
+          (element as HTMLElement).style.top = "24px";
+        });
+        await expect.poll(() => popup.getAttribute("data-current-placement")).toMatch(/^bottom/u);
+        expect(
+          await popup.evaluate((element) => {
+            const surface = element.shadowRoot?.querySelector<HTMLElement>('[part~="popup"]');
+            return surface
+              ? Number.parseFloat(getComputedStyle(surface).transformOrigin.split(" ")[1] ?? "")
+              : null;
+          }),
+        ).toBeCloseTo(0, 0);
+        await trigger.click();
+      }
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+});

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -309,6 +309,7 @@
   --menu-item-radius: var(--radius-sm);
   --menu-item-height: 28px;
   --menu-padding: 4px;
+  --menu-selected: color-mix(in srgb, var(--text) 8%, transparent);
 
   /* Transitions - Crisp and responsive */
   --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
@@ -1110,6 +1111,17 @@ wa-popover::part(body)::-webkit-scrollbar-thumb:hover {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  wa-dropdown,
+  wa-popover,
+  wa-select {
+    --show-duration: 0ms;
+    --hide-duration: 0ms;
+  }
+
+  .chat-controls__inline-select[open] > wa-popup::part(popup) {
+    animation: none !important;
+  }
+
   *,
   *::before,
   *::after {

--- a/ui/src/styles/chat/composer-queue.css
+++ b/ui/src/styles/chat/composer-queue.css
@@ -533,14 +533,9 @@
 
 .chat-queue__overflow wa-dropdown-item {
   width: 100%;
-  font-size: 12px;
-}
-
-.chat-queue__overflow wa-dropdown-item::part(base) {
-  box-sizing: border-box;
-  width: 100%;
   min-height: 32px;
   padding: 5px 8px;
+  font-size: 12px;
 }
 
 .chat-queue__overflow wa-dropdown-item span[slot="icon"] {

--- a/ui/src/styles/chat/composer.css
+++ b/ui/src/styles/chat/composer.css
@@ -11,6 +11,25 @@
   corner-shape: superellipse(1.5);
 }
 
+.chat-controls__inline-select[open] > wa-popup::part(popup) {
+  animation: chat-composer-picker-in var(--wa-transition-fast) ease;
+}
+
+.chat-controls__inline-select[open] > wa-popup[data-current-placement^="top"]::part(popup) {
+  transform-origin: bottom;
+}
+
+.chat-controls__inline-select[open] > wa-popup[data-current-placement^="bottom"]::part(popup) {
+  transform-origin: top;
+}
+
+@keyframes chat-composer-picker-in {
+  from {
+    opacity: 0;
+    scale: 0.9;
+  }
+}
+
 /* Composer popovers share one information architecture: a quiet title, a
    consistent icon/copy/state rail, and a neutral selected surface. Their
    widths still follow the amount of content each owner needs. */
@@ -119,7 +138,7 @@
   --chat-composer-menu-row-gap: 8px;
   --chat-composer-menu-row-radius: calc(10px * var(--openclaw-corner-radius-scale));
   --chat-composer-menu-icon: 16px;
-  --chat-composer-menu-selected: color-mix(in srgb, var(--text) 8%, transparent);
+  --chat-composer-menu-selected: var(--menu-selected);
   /* Breathing room between the draft and the surface it sits in. Small on
      purpose — it exists so the text never touches the frame, not to pad the
      composer out — and owned here so the editor's inset is one decision for
@@ -770,11 +789,6 @@
   color: var(--muted);
 }
 
-.agent-chat__attach-menu-option::part(base) {
-  box-sizing: border-box;
-  width: 100%;
-}
-
 .agent-chat__attach-menu-option svg {
   width: var(--chat-composer-menu-icon);
   height: var(--chat-composer-menu-icon);
@@ -836,15 +850,6 @@
 .agent-chat__capability-menu-state {
   color: var(--text);
   font-size: 12px;
-}
-
-.agent-chat__capability-menu-item::part(base),
-.agent-chat__attach-menu-option::part(base) {
-  box-sizing: border-box;
-  width: 100%;
-  min-height: var(--chat-composer-menu-row-height);
-  padding: var(--chat-composer-menu-row-padding);
-  border-radius: var(--chat-composer-menu-row-radius);
 }
 
 .agent-chat__capability-menu-item svg,
@@ -947,8 +952,8 @@
   display: none;
 }
 
-.agent-chat__capability-menu-subrow::part(base) {
-  padding-left: 28px;
+.agent-chat__capability-menu-subrow {
+  padding-inline-start: 28px;
 }
 
 .agent-chat__capability-menu-link {
@@ -1581,42 +1586,19 @@
 .chat-talk-input-picker::part(menu) {
   width: min(300px, calc(100vw - 24px));
   padding: 8px;
-  /* Same quick family as the chevron's own reveal, anchored at the bottom edge
-     the menu is placed against, so the list reads as continuing out of the
-     control the operator just touched rather than arriving from elsewhere. */
-  transform-origin: bottom right;
-  animation: chat-talk-input-picker-enter 140ms ease-out;
-}
-
-@keyframes chat-talk-input-picker-enter {
-  from {
-    opacity: 0;
-    transform: scale(0.96);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .chat-talk-input-picker::part(menu) {
-    animation: none;
-  }
 }
 
 .chat-talk-input-picker__item {
+  --wa-color-neutral-fill-normal: var(--bg-hover);
+
+  min-height: var(--chat-composer-menu-row-height);
+  padding: var(--chat-composer-menu-row-padding);
+  border-radius: var(--chat-composer-menu-row-radius);
   color: var(--text);
   font-size: 13px;
 }
 
-.chat-talk-input-picker__item::part(base) {
-  min-height: var(--chat-composer-menu-row-height);
-  padding: var(--chat-composer-menu-row-padding);
-  border-radius: var(--chat-composer-menu-row-radius);
-}
-
-.chat-talk-input-picker__item[aria-checked="true"]::part(base) {
+.chat-talk-input-picker__item[aria-checked="true"] {
   background: var(--chat-composer-menu-selected);
 }
 
@@ -2730,13 +2712,6 @@
   outline: none;
 }
 
-.agent-chat__input
-  wa-dropdown[data-chat-pointer-opened-picker]
-  wa-dropdown-item:is(:focus, :focus-visible)::part(base) {
-  outline: none;
-  box-shadow: none;
-}
-
 .chat-controls__inline-select-trigger--disabled {
   cursor: not-allowed;
   opacity: 0.55;
@@ -2814,7 +2789,7 @@
   width: 100%;
   min-height: var(--chat-composer-menu-row-height);
   padding: var(--chat-composer-menu-row-padding);
-  border: 1px solid transparent;
+  border: 0;
   border-radius: var(--chat-composer-menu-row-radius);
   background: transparent;
   color: var(--text);
@@ -2825,7 +2800,6 @@
 
 .chat-controls__inline-select-option:hover,
 .chat-controls__inline-select-option:focus-visible {
-  border-color: color-mix(in srgb, var(--border) 76%, transparent);
   background: var(--bg-hover);
   outline: none;
 }
@@ -2882,6 +2856,8 @@
 }
 
 .chat-controls__permission-option {
+  --wa-color-neutral-fill-normal: var(--bg-hover);
+
   display: flex;
   align-items: center;
   gap: var(--chat-composer-menu-row-gap);
@@ -2935,14 +2911,7 @@
   color: var(--accent);
 }
 
-.chat-controls__permission-option::part(base) {
-  align-items: center;
-  min-height: var(--chat-composer-menu-row-height);
-  padding: var(--chat-composer-menu-row-padding);
-  border-radius: var(--chat-composer-menu-row-radius);
-}
-
-.chat-controls__permission-option--selected::part(base) {
+.chat-controls__permission-option--selected {
   background: var(--chat-composer-menu-selected);
 }
 

--- a/ui/src/styles/chat/side-panel.css
+++ b/ui/src/styles/chat/side-panel.css
@@ -386,20 +386,10 @@
 }
 
 .side-panel-type-menu__item {
+  padding: 9px 8px;
+  background: color-mix(in srgb, var(--text) 3%, transparent);
   font-size: calc(13px * var(--control-ui-text-scale));
   white-space: nowrap;
-}
-
-.side-panel-type-menu__item::part(base) {
-  min-height: var(--menu-item-height);
-  padding: 9px 8px;
-  border-radius: var(--menu-item-radius);
-  background: color-mix(in srgb, var(--text) 3%, transparent);
-}
-
-.side-panel-type-menu__item:hover::part(base),
-.side-panel-type-menu__item:focus-visible::part(base) {
-  background: var(--bg-hover);
 }
 
 .side-panel-type-menu__item + .side-panel-type-menu__item {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3335,7 +3335,7 @@ td.data-table-key-col {
 }
 
 :root[data-theme-mode="light"] .agent-select__trigger {
-  background: white;
+  background: var(--bg-elevated);
 }
 
 .agent-select__trigger:focus-visible {
@@ -3419,9 +3419,17 @@ td.data-table-key-col {
 }
 
 .agent-select__option {
+  --wa-color-neutral-fill-normal: var(--bg-hover);
+
+  padding: 6px 8px;
+  border-radius: var(--menu-item-radius);
   color: var(--text);
   font: inherit;
   font-size: 13px;
+}
+
+.agent-select__option[data-selected] {
+  background: var(--menu-selected);
 }
 
 .agent-select__separator {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -3832,17 +3832,8 @@ openclaw-tooltip.sidebar-hover-tooltip {
   transition: color 120ms ease;
 }
 
-wa-dropdown-item.sidebar-agent-menu__agent-switch::part(base) {
-  justify-content: center;
-  width: 100%;
-  padding: 0;
-  border-radius: var(--menu-item-radius);
-}
-
 wa-dropdown-item.sidebar-agent-menu__agent-switch:hover,
-wa-dropdown-item.sidebar-agent-menu__agent-switch:focus-visible,
-wa-dropdown-item.sidebar-agent-menu__agent-switch:hover::part(base),
-wa-dropdown-item.sidebar-agent-menu__agent-switch:focus-visible::part(base) {
+wa-dropdown-item.sidebar-agent-menu__agent-switch:focus-visible {
   background: transparent !important;
 }
 
@@ -3853,10 +3844,6 @@ wa-dropdown-item.sidebar-agent-menu__agent-switch:focus-visible {
 .sidebar-agent-menu__agent-switch--active {
   background: transparent;
   color: var(--text-strong) !important;
-}
-
-wa-dropdown-item.sidebar-agent-menu__agent-switch--active::part(base) {
-  background: transparent;
 }
 
 .sidebar-agent-menu__agent-tile {

--- a/ui/src/styles/model-setup.css
+++ b/ui/src/styles/model-setup.css
@@ -280,7 +280,7 @@
 }
 
 :root[data-theme-mode="light"] .model-setup-provider-select__trigger {
-  background: white;
+  background: var(--bg-elevated);
 }
 
 .model-setup-provider-select__trigger:focus-visible {
@@ -334,9 +334,17 @@
 }
 
 .model-setup-provider-select__option {
+  --wa-color-neutral-fill-normal: var(--bg-hover);
+
+  padding: 6px 8px;
+  border-radius: var(--menu-item-radius);
   color: var(--text);
   font: inherit;
   font-size: 13px;
+}
+
+.model-setup-provider-select__option[data-selected] {
+  background: var(--menu-selected);
 }
 
 .model-setup-provider-select__option::part(label) {


### PR DESCRIPTION
Closes #133642

Reported and repaired by @vyctorbrzezowski.

## What Problem This Solves

Equivalent picker controls were giving different or missing hover, selected, keyboard-focus, surface, and opening-motion feedback. In particular, Web Awesome dropdown items do not expose a `base` part, so several `::part(base)` rules never affected the visible rows; selected permission and microphone rows could therefore render without their intended wash.

## Why This Change Was Made

This moves dropdown-item geometry and state styling to the public host contract, uses Web Awesome's hover and duration custom properties, and gives model/effort popups the same fast scale/fade family as dropdown menus. The repair follows the existing Web Awesome implementation instead of adding a custom picker abstraction or dependency.

Reduced motion is owned once for the Web Awesome menu family, and inline popup animation is explicitly disabled at the shadow part boundary. Selected rows share one global theme token. Light-theme field triggers keep their existing white pixel through `--bg-elevated`; this is tokenization, not a product color change.

## User Impact

- Selected permission, microphone, agent, and provider choices have a consistent neutral wash.
- Web Awesome menu rows use the Control UI hover surface and intended geometry.
- Model and effort popups animate from the edge they are actually placed against, using the same 75 ms fast token as Web Awesome dropdowns.
- Operators who request reduced motion receive no dropdown/popover/select or inline-popup opening animation.
- Search, selection, keyboard, responsive placement, and shared-sidebar behavior remain unchanged.

Production CSS: +64/-95 (net -31). Tests: +148/-0.

## Evidence

### Permission selected state

Before:

![Permission picker before: selected row had no wash](https://github.com/user-attachments/assets/6f1545ea-2f53-4b8f-ae0b-9b3095f2dae9)

After (final rebased build):

![Permission picker after: selected Workspace row has the shared wash](https://github.com/user-attachments/assets/51e1184b-b979-44c7-9c96-0eeba994a285)

### Agent picker, light theme

Before:

![Agent picker before](https://github.com/user-attachments/assets/55f00696-0254-448d-9411-4335a231eeb6)

After:

![Agent picker after with selected-row wash](https://github.com/user-attachments/assets/d1c1a705-9f1e-4295-b987-77d49f079ef2)

### Model Setup provider picker

Before:

![Model Setup picker before](https://github.com/user-attachments/assets/9e97a6e8-0e76-4051-9e43-b9145284b3a4)

After:

![Model Setup picker after with selected-row wash and retained trigger surface](https://github.com/user-attachments/assets/c7f7d23e-4c6b-4b29-87d0-1d224bebac4b)

### Microphone picker unavailable state

Before:

![Microphone picker before](https://github.com/user-attachments/assets/3d619287-5031-41e8-a097-23a30c9d0c8c)

After:

![Microphone picker after with stable unavailable-state geometry](https://github.com/user-attachments/assets/fe6c71a6-1c53-4aab-a960-0ffe6ca672de)

All attached images were captured from real mocked-Gateway browser flows and inspected before upload.

### Regression and browser proof

- Exact pre-fix parent: `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test ui/src/e2e/chat-picker-interaction-contract.e2e.test.ts` — failed 2/2 as intended: selected and unselected permission backgrounds were both transparent; inline popup `animationName` was `none` instead of `chat-composer-picker-in`.
- Final head: the same command — passed 2/2. It covers selected permission wash, zero Web Awesome show/hide duration under reduced motion, normal inline-popup animation, top/bottom placement origins, and reduced-motion suppression for model and effort pickers.
- `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts` — passed 13/13 before the final main refresh; the focused final-head contract test above re-proved the changed surface after the refresh.
- New Session + Model Setup + Agent Select visual matrix — passed 4/4 focused cases; before/after artifacts retained.
- Final rebased New Session permission visual flow — passed 1/1; screenshot above.
- `node --import ./scripts/tsx.mjs scripts/capture-composer-mic-hover-proof.mts` — passed before and after, with 0 px hover shift.
- `pnpm dlx oxfmt@0.65.0 --check --no-error-on-unmatched-pattern -- <8 changed files>` — passed using the formatter version pinned by current main.
- `pnpm exec oxlint ui/src/e2e/chat-picker-interaction-contract.e2e.test.ts` — passed.
- `node scripts/run-tsgo.mjs -p tsconfig.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/ui.tsbuildinfo` — passed.
- `git diff --check` — passed.
- Autoreview — scoped clean; no actionable P0/P1 findings; overall correctness 0.97.

`pnpm check:changed` was run serially as required. The first run passed every stage through lint and correctly caught that adding coverage to an already-large test file exceeded its line budget; the coverage was moved into its own focused file. After the final main refresh, the rerun reached formatting and stopped because this worktree's pre-existing dependency tree still exposes Oxfmt 0.60 while current main pins 0.65. Worktree policy forbids dependency reconciliation here, so the exact pinned 0.65 formatter, focused lint, UI typecheck, and final browser test were run separately. Exact-head CI uses a clean dependency install and is the authoritative full gate.

## Landing notes

1. Rebased the original change onto current main and its split `ui/src/styles/chat/composer.css` owner; the branch is now a single fresh commit.
2. Added owner-level reduced-motion handling for Web Awesome dropdown/popover/select durations and the inline popup shadow part.
3. Added one global `--menu-selected` token and consumed it from composer, Agent Select, and Model Setup.
4. Replaced hardcoded light-theme `white` with behavior-equivalent `--bg-elevated`; no trigger color change.
5. Removed the Desktop card hunk because that card is not itself an interactive picker.
6. Swept every stale `wa-dropdown-item::part(base)` rule. Unique host behavior moved to hosts; duplicate policy now comes from the existing canonical host rules.
7. Made transform origin follow `data-current-placement` and aligned duration to Web Awesome's fast token.
8. Added focused regression coverage that fails on the exact pre-fix parent and passes on the final head.

Latest ClawSweeper rank-up move: applied. Popup animation is suppressed for reduced-motion users, and the focused real-browser test verifies the computed animation plus Web Awesome duration values. No X-ray adjustment was skipped.

Scope confirmed by the maintainer: the Desktop source-card hover and keyboard-focus behavior described in #133642 is accepted as out of scope for this repair, so the closing reference stands as written.

## Risk and coverage

What else could break:

- `.agent-select__option` is shared with the sidebar agent menu. Existing sidebar host rules still override its padding, hover, and active treatment; the light/dark Agent Select flows pass.
- Model Setup checkbox-adjacent rows retain Web Awesome's intentional leading rail; desktop/mobile provider flows pass and were inspected.
- Removing dead part rules could expose duplicate-policy assumptions. The queue, attach/capability, side-panel, and sidebar owners now use host rules or their existing canonical `session-menu__item` policy; no dropdown-item `base` selectors remain.
- Motion could originate from the wrong edge after a popup flip. The final browser test forces both top and bottom placement and checks the untransformed origin.

What remains uncovered:

- Static screenshots cannot show the 75 ms opening motion; computed-style and placement assertions cover it instead.
- Hover custom-property behavior is visually exercised but not separately asserted for every shared consumer.
- Exact-head CI is still required to close the full changed-files gate with main's clean Oxfmt 0.65 dependency tree.


