### PR TITLE
fix: reuse plugin metadata during prepared Gateway runs

### DIFF
--- a/src/plugins/bundled-dir.ts
+++ b/src/plugins/bundled-dir.ts
@@ -49,7 +49,7 @@ function isSourceCheckoutRoot(packageRoot: string): boolean {
   );
 }
 
-function shouldTrustTestBundledPluginsDirOverride(env: NodeJS.ProcessEnv): boolean {
+export function shouldTrustTestBundledPluginsDirOverride(env: NodeJS.ProcessEnv): boolean {
   const isVitestProcess = isVitestRuntimeEnv(env) || isVitestRuntimeEnv(process.env);
   return (
     isVitestProcess &&

--- a/src/plugins/current-plugin-metadata-snapshot.test.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeConfiguredProviderCatalogModelId,
 } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { describe, expect, it, vi } from "vitest";
+import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import {
   getCurrentPluginMetadataSnapshot,
   installTemporaryCurrentPluginMetadataSnapshot,
@@ -601,6 +602,48 @@ describe("current plugin metadata snapshot", () => {
         expect(rootProbes).not.toHaveBeenCalled();
       } finally {
         rootProbes.mockRestore();
+      }
+    },
+  );
+
+  it.each(["supplied", "ambient"] as const)(
+    "rejects configless default-discovery reuse when %s bundled-directory trust changes",
+    (trustSource) => {
+      const overrideRoot = fs.realpathSync(
+        fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-metadata-bundled-trust-")),
+      );
+      const originalTrust = process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR;
+      const env: NodeJS.ProcessEnv = {
+        VITEST: "true",
+        OPENCLAW_BUNDLED_PLUGINS_DIR: overrideRoot,
+      };
+      delete process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR;
+
+      try {
+        const snapshot = createSnapshot();
+        const originalRoot = resolveBundledPluginsDir(env);
+        expect(originalRoot).toBeDefined();
+        expect(originalRoot).not.toBe(overrideRoot);
+        setCurrentPluginMetadataSnapshot(snapshot, { env });
+        const request = { env, requireDefaultDiscoveryContext: true };
+        expect(getCurrentPluginMetadataSnapshot(request)).toBe(snapshot);
+
+        withPluginRuntimeGenerationScope({ metadataSnapshot: snapshot }, () => {
+          const trustEnv = trustSource === "supplied" ? env : process.env;
+          trustEnv.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR = "1";
+          expect(resolveBundledPluginsDir(env)).toBe(overrideRoot);
+          expect(getCurrentPluginMetadataSnapshot(request)).toBe(snapshot);
+        });
+
+        expect(getCurrentPluginMetadataSnapshot(request)).toBeUndefined();
+      } finally {
+        clearCurrentPluginMetadataSnapshot();
+        if (originalTrust === undefined) {
+          delete process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR;
+        } else {
+          process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR = originalTrust;
+        }
+        fs.rmSync(overrideRoot, { recursive: true, force: true });
       }
     },
   );

--- a/src/plugins/current-plugin-metadata-snapshot.test.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.test.ts
@@ -17,6 +17,7 @@ import {
 import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
 import { setCurrentPluginMetadataSnapshot } from "./current-plugin-metadata.test-support.js";
 import { getGlobalHookRunnerRegistry } from "./hook-runner-global-state.js";
+import { withPluginInstallRoots } from "./install-root-context.js";
 import * as installedPluginIndexPolicy from "./installed-plugin-index-policy.js";
 import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store-write.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
@@ -208,6 +209,7 @@ describe("current plugin metadata snapshot", () => {
         expect(
           getCurrentPluginMetadataSnapshot({
             config: { plugins: { allow: ["derived-run-policy"] } },
+            env: { OPENCLAW_BUNDLED_PLUGINS_DIR: "/plugins/redirected-run" },
             workspaceDir: agentWorkspaceDir,
           }),
         ).toBe(metadataSnapshot);
@@ -458,17 +460,45 @@ describe("current plugin metadata snapshot", () => {
     );
   });
 
-  it("trusts the config identity paired with an immutable runtime generation", () => {
+  it("enters an immutable runtime generation without probing discovery roots", () => {
     const sourceConfig = { plugins: { allow: ["source"] } };
     const runtimeConfig = { plugins: { allow: ["runtime"] } };
     const workspaceDir = "/workspace";
     const snapshot = createSnapshot({ config: sourceConfig, workspaceDir });
 
-    withPluginRuntimeGenerationScope({ metadataSnapshot: snapshot }, () => {
-      expect(getCurrentPluginMetadataSnapshot({ config: runtimeConfig, workspaceDir })).toBe(
-        snapshot,
-      );
-    });
+    const rootProbes = vi.spyOn(fs, "existsSync");
+    try {
+      withPluginRuntimeGenerationScope({ metadataSnapshot: snapshot }, () => {
+        expect(getCurrentPluginMetadataSnapshot({ config: runtimeConfig, workspaceDir })).toBe(
+          snapshot,
+        );
+      });
+      expect(rootProbes).not.toHaveBeenCalled();
+    } finally {
+      rootProbes.mockRestore();
+    }
+  });
+
+  it("keeps prepared metadata usable when the launch directory is removed", () => {
+    const config = {};
+    const snapshot = createSnapshot({ config });
+    setCurrentPluginMetadataSnapshot(snapshot, { config });
+    const launchCwd = process.cwd();
+    const cwd = vi.spyOn(process, "cwd");
+    try {
+      cwd.mockImplementation(() => {
+        throw new Error("ENOENT: uv_cwd");
+      });
+      expect(getCurrentPluginMetadataSnapshot({ config })).toBeUndefined();
+      withPluginRuntimeGenerationScope({ metadataSnapshot: snapshot }, () => {
+        expect(getCurrentPluginMetadataSnapshot({ config })).toBe(snapshot);
+      });
+
+      cwd.mockReturnValue(launchCwd);
+      expect(getCurrentPluginMetadataSnapshot({ config })).toBe(snapshot);
+    } finally {
+      cwd.mockRestore();
+    }
   });
 
   it("rejects a workspace-scoped snapshot when the caller does not provide workspace scope", () => {
@@ -530,18 +560,50 @@ describe("current plugin metadata snapshot", () => {
     }
   });
 
-  it("accepts configless default-discovery reuse for snapshots created without load paths", () => {
-    const config = { plugins: { allow: ["demo"] } };
-    const snapshot = createSnapshot({ config });
-    setCurrentPluginMetadataSnapshot(snapshot, { config });
+  it.each([
+    {
+      name: "development root",
+      env: { HOME: "/home/metadata" },
+      changedEnv: { HOME: "/home/metadata", OPENCLAW_DEV_SOURCE_ROOT: process.cwd() },
+    },
+    {
+      name: "Termux prefix",
+      env: { PREFIX: "/data/data/com.termux/files/usr", ANDROID_DATA: "/data" },
+      changedEnv: { PREFIX: "/other/com.termux/files/usr", ANDROID_DATA: "/data" },
+    },
+    {
+      name: "Termux detection",
+      env: { PREFIX: "/data/data/com.termux/files/usr", ANDROID_DATA: "/data" },
+      changedEnv: { PREFIX: "/data/data/com.termux/files/usr" },
+    },
+  ])(
+    "reuses configless metadata without probing discovery roots and checks $name",
+    ({ env, changedEnv }) => {
+      const config = { plugins: { allow: ["demo"] } };
+      const snapshot = createSnapshot({ config });
+      setCurrentPluginMetadataSnapshot(snapshot, { config, env });
 
-    expect(
-      getCurrentPluginMetadataSnapshot({
-        allowWorkspaceScopedSnapshot: true,
-        requireDefaultDiscoveryContext: true,
-      }),
-    ).toBe(snapshot);
-  });
+      const rootProbes = vi.spyOn(fs, "existsSync");
+      try {
+        expect(
+          getCurrentPluginMetadataSnapshot({
+            env,
+            allowWorkspaceScopedSnapshot: true,
+            requireDefaultDiscoveryContext: true,
+          }),
+        ).toBe(snapshot);
+        expect(
+          getCurrentPluginMetadataSnapshot({
+            env: changedEnv,
+            requireDefaultDiscoveryContext: true,
+          }),
+        ).toBeUndefined();
+        expect(rootProbes).not.toHaveBeenCalled();
+      } finally {
+        rootProbes.mockRestore();
+      }
+    },
+  );
 
   it("rejects configless default-discovery reuse for scoped snapshots", () => {
     const config = { plugins: { allow: ["demo"] } };
@@ -589,38 +651,50 @@ describe("current plugin metadata snapshot", () => {
     expect(getCurrentPluginMetadataSnapshot({ config, pluginIdScope })).toBe(scoped);
   });
 
-  it("reuses exact cached config when env-resolved plugin load paths change before reload", () => {
-    const config = { plugins: { load: { paths: ["~/plugins"] } } };
+  it.each([
+    { config: { plugins: { load: { paths: ["~/plugins"] } } }, key: "HOME" },
+    { config: {}, key: "HOME" },
+    { config: {}, key: "OPENCLAW_BUNDLED_PLUGINS_DIR" },
+  ])("rejects ordinary metadata when $key changes for $config", ({ config, key }) => {
     const snapshot = createSnapshot({ config });
     const snapshotEnv = {
       HOME: "/home/snapshot",
       OPENCLAW_HOME: undefined,
-    } as NodeJS.ProcessEnv;
-    const requestedEnv = {
-      HOME: "/home/requested",
-      OPENCLAW_HOME: undefined,
-    } as NodeJS.ProcessEnv;
+      [key]: "/plugins/snapshot",
+    };
+    const requestedEnv = { ...snapshotEnv, [key]: "/plugins/requested" };
     setCurrentPluginMetadataSnapshot(snapshot, { config, env: snapshotEnv });
 
     expect(getCurrentPluginMetadataSnapshot({ config, env: snapshotEnv })).toBe(snapshot);
-    expect(getCurrentPluginMetadataSnapshot({ config, env: requestedEnv })).toBe(snapshot);
+    expect(getCurrentPluginMetadataSnapshot({ config, env: requestedEnv })).toBeUndefined();
+    withPluginMetadataSnapshotScope(
+      snapshot,
+      () => {
+        expect(getCurrentPluginMetadataSnapshot({ config, env: snapshotEnv })).toBe(snapshot);
+        expect(getCurrentPluginMetadataSnapshot({ config, env: requestedEnv })).toBeUndefined();
+      },
+      { config, env: snapshotEnv },
+    );
   });
 
-  it("reuses exact cached config when env-resolved plugin roots change before reload", () => {
+  it("keeps ordinary metadata within its captured pinned install roots", () => {
     const config = {};
     const snapshot = createSnapshot({ config });
-    const snapshotEnv = {
-      HOME: "/home/snapshot",
-      OPENCLAW_HOME: undefined,
-    } as NodeJS.ProcessEnv;
-    const requestedEnv = {
-      HOME: "/home/requested",
-      OPENCLAW_HOME: undefined,
-    } as NodeJS.ProcessEnv;
-    setCurrentPluginMetadataSnapshot(snapshot, { config, env: snapshotEnv });
-
-    expect(getCurrentPluginMetadataSnapshot({ config, env: snapshotEnv })).toBe(snapshot);
-    expect(getCurrentPluginMetadataSnapshot({ config, env: requestedEnv })).toBe(snapshot);
+    const roots = {
+      extensionsDir: "/plugins/extensions",
+      gitDir: "/plugins/git",
+      npmDir: "/plugins/npm",
+      stateDir: "/plugins/state",
+    };
+    withPluginInstallRoots(roots, () => {
+      setCurrentPluginMetadataSnapshot(snapshot, { config });
+      expect(getCurrentPluginMetadataSnapshot({ config })).toBe(snapshot);
+      withPluginInstallRoots({ ...roots, npmDir: "/plugins/replacement/npm" }, () => {
+        expect(getCurrentPluginMetadataSnapshot({ config })).toBeUndefined();
+      });
+      expect(getCurrentPluginMetadataSnapshot({ config })).toBe(snapshot);
+    });
+    expect(getCurrentPluginMetadataSnapshot({ config })).toBeUndefined();
   });
 
   it("reuses exact cached config after in-place policy changes before reload", () => {
@@ -647,7 +721,7 @@ describe("current plugin metadata snapshot", () => {
     expect(getCurrentPluginMetadataSnapshot({ config })).toBe(snapshot);
   });
 
-  it("reuses exact cached config after in-place env root changes before reload", () => {
+  it("rejects exact cached config after in-place env root changes", () => {
     const config = {};
     const snapshot = createSnapshot({ config });
     const env = {
@@ -660,7 +734,7 @@ describe("current plugin metadata snapshot", () => {
 
     env.HOME = "/home/requested";
 
-    expect(getCurrentPluginMetadataSnapshot({ config, env })).toBe(snapshot);
+    expect(getCurrentPluginMetadataSnapshot({ config, env })).toBeUndefined();
   });
 
   it("keeps source-policy compatibility when storing an auto-enabled runtime config", () => {
@@ -724,7 +798,9 @@ describe("current plugin metadata snapshot", () => {
 
   it("restores the previous current snapshot after a temporary lease", () => {
     const firstConfig = { plugins: { allow: ["first"] } };
-    const secondConfig = { plugins: { allow: ["second"] } };
+    const secondConfig = {
+      plugins: { allow: ["second"], load: { paths: ["/plugins/temporary"] } },
+    };
     const first = createSnapshot({ config: firstConfig });
     const second = createSnapshot({ config: secondConfig });
     setCurrentPluginMetadataSnapshot(first, { config: firstConfig });
@@ -733,13 +809,17 @@ describe("current plugin metadata snapshot", () => {
       config: secondConfig,
     });
     expect(getCurrentPluginMetadataSnapshot({ config: secondConfig })).toBe(second);
+    expect(
+      getCurrentPluginMetadataSnapshot({ requireDefaultDiscoveryContext: true }),
+    ).toBeUndefined();
     expect(lease.release()).toBe(true);
 
     expect(getCurrentPluginMetadataSnapshot({ config: firstConfig })).toBe(first);
+    expect(getCurrentPluginMetadataSnapshot({ requireDefaultDiscoveryContext: true })).toBe(first);
     expect(getCurrentPluginMetadataSnapshot({ config: secondConfig })).toBeUndefined();
   });
 
-  it("restores exact config identity across a temporary metadata snapshot", () => {
+  it("restores exact config identity and environment across a temporary metadata snapshot", () => {
     const config = { plugins: { load: { paths: ["~/plugins"] } } };
     const snapshot = createSnapshot({ config });
     const originalEnv = {
@@ -755,7 +835,8 @@ describe("current plugin metadata snapshot", () => {
     const lease = installTemporaryCurrentPluginMetadataSnapshot(createSnapshot());
     expect(lease.release()).toBe(true);
 
-    expect(getCurrentPluginMetadataSnapshot({ config, env: changedEnv })).toBe(snapshot);
+    expect(getCurrentPluginMetadataSnapshot({ config, env: originalEnv })).toBe(snapshot);
+    expect(getCurrentPluginMetadataSnapshot({ config, env: changedEnv })).toBeUndefined();
   });
 
   it("restores exact config identity after in-place changes", () => {

--- a/src/plugins/current-plugin-metadata-snapshot.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.ts
@@ -21,6 +21,7 @@ import {
   resolvePluginControlPlaneFingerprint,
   type ResolvePluginControlPlaneContextParams,
 } from "./plugin-control-plane-context.js";
+import { resolvePluginMetadataEnvFingerprint } from "./plugin-metadata-env.js";
 import { registerPluginMetadataSnapshotReaders } from "./plugin-metadata-snapshot.runtime.js";
 import type {
   PluginMetadataSnapshot,
@@ -68,6 +69,8 @@ type CurrentPluginMetadataSnapshotParams = {
 type PluginMetadataSnapshotCandidate = {
   snapshot: PluginMetadataSnapshot | undefined;
   configFingerprint: string | undefined;
+  envFingerprint?: string;
+  defaultDiscoveryCompatible?: boolean;
   compatiblePolicyHashes?: readonly string[];
   compatibleConfigFingerprints?: readonly string[];
   hasConfigIdentity?: (config: OpenClawConfig) => boolean;
@@ -106,7 +109,7 @@ function resolvePluginMetadataControlPlaneFingerprint(
 }
 
 function publishCurrentPluginMetadataSnapshot(
-  snapshot: PluginMetadataSnapshot | undefined,
+  snapshot: PluginMetadataSnapshot,
   options: CurrentPluginMetadataSnapshotOptions,
   owner: "gateway" | "operation" = "operation",
 ): CurrentPluginMetadataSnapshotRevision {
@@ -114,59 +117,37 @@ function publishCurrentPluginMetadataSnapshot(
     throw new Error("Gateway plugin metadata can only be replaced after shutdown");
   }
   currentPluginMetadataConfigIdentityCache.clear();
-  const compatiblePolicyHashes = snapshot
-    ? options.compatibleConfigs?.map((config) =>
-        resolveInstalledPluginIndexPolicyHash(config, options.env),
-      )
-    : undefined;
-  const compatibleConfigFingerprints = snapshot
-    ? options.compatibleConfigs?.map((config, index) =>
-        resolvePluginMetadataControlPlaneFingerprint(config, {
-          env: options.env,
-          index: snapshot.index,
-          policyHash: compatiblePolicyHashes?.[index],
-          workspaceDir: options.workspaceDir ?? snapshot.workspaceDir,
-        }),
-      )
-    : undefined;
-  const configFingerprint = snapshot
-    ? resolvePluginMetadataControlPlaneFingerprint(options.config, {
-        env: options.env,
-        index: snapshot.index,
-        policyHash: snapshot.policyHash,
-        workspaceDir: options.workspaceDir ?? snapshot.workspaceDir,
-      })
-    : undefined;
-  const defaultDiscoveryConfigFingerprint = snapshot
-    ? resolvePluginMetadataControlPlaneFingerprint(
-        {},
-        {
-          env: options.env,
-          index: snapshot.index,
-          policyHash: snapshot.policyHash,
-          workspaceDir: options.workspaceDir ?? snapshot.workspaceDir,
-        },
-      )
-    : undefined;
+  const fingerprint = (config: OpenClawConfig | undefined, policyHash: string | undefined) =>
+    resolvePluginMetadataControlPlaneFingerprint(config, {
+      env: options.env,
+      index: snapshot.index,
+      policyHash,
+      workspaceDir: options.workspaceDir ?? snapshot.workspaceDir,
+    });
+  const compatiblePolicyHashes = options.compatibleConfigs?.map((config) =>
+    resolveInstalledPluginIndexPolicyHash(config, options.env),
+  );
+  const compatibleConfigFingerprints = options.compatibleConfigs?.map((config, index) =>
+    fingerprint(config, compatiblePolicyHashes?.[index]),
+  );
+  const configFingerprint = fingerprint(options.config, snapshot.policyHash);
+  const defaultDiscoveryConfigFingerprint = fingerprint({}, snapshot.policyHash);
   const defaultDiscoveryCompatible =
-    snapshot &&
-    defaultDiscoveryConfigFingerprint &&
-    (configFingerprint === defaultDiscoveryConfigFingerprint ||
-      snapshot.configFingerprint === defaultDiscoveryConfigFingerprint ||
-      Boolean(compatibleConfigFingerprints?.includes(defaultDiscoveryConfigFingerprint)));
+    configFingerprint === defaultDiscoveryConfigFingerprint ||
+    snapshot.configFingerprint === defaultDiscoveryConfigFingerprint ||
+    Boolean(compatibleConfigFingerprints?.includes(defaultDiscoveryConfigFingerprint));
   const revision = setCurrentPluginMetadataSnapshotState(
     snapshot,
     configFingerprint,
     compatiblePolicyHashes,
     compatibleConfigFingerprints,
     owner === "gateway" || defaultDiscoveryCompatible
-      ? snapshot?.owners.modelIdNormalizationPolicies
+      ? snapshot.owners.modelIdNormalizationPolicies
       : undefined,
     owner,
+    resolvePluginMetadataEnvFingerprint(options.env),
+    defaultDiscoveryCompatible,
   );
-  if (!snapshot) {
-    return revision;
-  }
   if (options.config) {
     const policyHash = resolveInstalledPluginIndexPolicyHash(options.config, options.env);
     if (
@@ -243,6 +224,8 @@ function restoreCapturedCurrentPluginMetadataSnapshotState(
     state.compatibleConfigFingerprints,
     state.modelIdNormalizationPolicies,
     state.owner,
+    state.envFingerprint,
+    state.defaultDiscoveryCompatible,
   );
 }
 
@@ -350,6 +333,7 @@ export function withPluginMetadataSnapshotScope<T>(
       {
         snapshot,
         configFingerprint,
+        envFingerprint: resolvePluginMetadataEnvFingerprint(options.env),
         compatiblePolicyHashes,
         compatibleConfigFingerprints,
         hasConfigIdentity: (config) => configIdentities.has(config),
@@ -376,6 +360,9 @@ function resolveCompatiblePluginMetadataSnapshot(
     return snapshot;
   }
   const env = params.env ?? process.env;
+  if (candidate.envFingerprint !== resolvePluginMetadataEnvFingerprint(env)) {
+    return undefined;
+  }
   const requestedPluginIds = normalizePluginIdScope(
     params.pluginIds ?? params.pluginIdScope?.resolve({ index: snapshot.index }),
   );
@@ -437,23 +424,12 @@ function resolveCompatiblePluginMetadataSnapshot(
       return undefined;
     }
   }
-  if (params.requireDefaultDiscoveryContext === true && options.scopedOwnerContext !== true) {
-    const defaultDiscoveryConfigFingerprint = resolvePluginMetadataControlPlaneFingerprint(
-      {},
-      {
-        env: params.env,
-        index: snapshot.index,
-        policyHash: snapshot.policyHash,
-        workspaceDir: requestedWorkspaceDir,
-      },
-    );
-    const fingerprintMatches =
-      candidate.configFingerprint === defaultDiscoveryConfigFingerprint ||
-      snapshot.configFingerprint === defaultDiscoveryConfigFingerprint ||
-      Boolean(candidate.compatibleConfigFingerprints?.includes(defaultDiscoveryConfigFingerprint));
-    if (!fingerprintMatches) {
-      return undefined;
-    }
+  if (
+    params.requireDefaultDiscoveryContext === true &&
+    options.scopedOwnerContext !== true &&
+    candidate.defaultDiscoveryCompatible !== true
+  ) {
+    return undefined;
   }
   return snapshot;
 }
@@ -502,6 +478,8 @@ export function getCurrentPluginMetadataSnapshot(
     snapshot,
     owner,
     configFingerprint,
+    envFingerprint,
+    defaultDiscoveryCompatible,
     compatiblePolicyHashes,
     compatibleConfigFingerprints,
   } = getCurrentPluginMetadataSnapshotState();
@@ -509,6 +487,8 @@ export function getCurrentPluginMetadataSnapshot(
     {
       snapshot: snapshot as PluginMetadataSnapshot | undefined,
       configFingerprint,
+      envFingerprint,
+      defaultDiscoveryCompatible,
       compatiblePolicyHashes,
       compatibleConfigFingerprints,
       hasConfigIdentity: (config) => currentPluginMetadataConfigIdentityCache.has(config),

--- a/src/plugins/current-plugin-metadata-state.ts
+++ b/src/plugins/current-plugin-metadata-state.ts
@@ -33,11 +33,15 @@ export function setCurrentPluginMetadataSnapshotState(
   compatibleConfigFingerprints?: readonly string[],
   modelIdNormalizationPolicies?: PluginMetadataSnapshot["owners"]["modelIdNormalizationPolicies"],
   owner: "gateway" | "operation" = "operation",
+  envFingerprint?: string,
+  defaultDiscoveryCompatible = false,
 ): CurrentPluginMetadataSnapshotRevision {
   const state = getProcessPluginCache().metadata.current;
   state.snapshot = snapshot;
   state.owner = owner;
   state.configFingerprint = snapshot ? configFingerprint : undefined;
+  state.envFingerprint = snapshot ? envFingerprint : undefined;
+  state.defaultDiscoveryCompatible = Boolean(snapshot && defaultDiscoveryCompatible);
   state.compatiblePolicyHashes = snapshot ? compatiblePolicyHashes : undefined;
   state.compatibleConfigFingerprints = snapshot ? compatibleConfigFingerprints : undefined;
   state.modelIdNormalizationPolicies = snapshot ? modelIdNormalizationPolicies : undefined;
@@ -46,24 +50,10 @@ export function setCurrentPluginMetadataSnapshotState(
   return state.revision;
 }
 
-/** Clears the process-current plugin metadata snapshot. */
-function clearCurrentPluginMetadataSnapshotState(): CurrentPluginMetadataSnapshotRevision {
-  const state = getProcessPluginCache().metadata.current;
-  state.snapshot = undefined;
-  state.owner = "operation";
-  state.configFingerprint = undefined;
-  state.compatiblePolicyHashes = undefined;
-  state.compatibleConfigFingerprints = undefined;
-  state.modelIdNormalizationPolicies = undefined;
-  setCurrentManifestModelIdNormalizationPolicies(undefined);
-  state.revision = Symbol("plugin-metadata-snapshot");
-  return state.revision;
-}
-
 /** Clears the snapshot, its identity cache, and process-wide model normalization. */
 export function clearCurrentPluginMetadataSnapshot(): void {
   currentPluginMetadataConfigIdentityCache.clear();
-  clearCurrentPluginMetadataSnapshotState();
+  setCurrentPluginMetadataSnapshotState(undefined, undefined);
 }
 
 /** Install-ledger writes cannot retire metadata owned by a running Gateway. */
@@ -98,6 +88,8 @@ export function getCurrentPluginMetadataSnapshotState() {
     snapshot: state.snapshot,
     owner: state.owner,
     configFingerprint: state.configFingerprint,
+    envFingerprint: state.envFingerprint,
+    defaultDiscoveryCompatible: state.defaultDiscoveryCompatible,
     compatiblePolicyHashes: state.compatiblePolicyHashes,
     compatibleConfigFingerprints: state.compatibleConfigFingerprints,
     modelIdNormalizationPolicies: state.modelIdNormalizationPolicies,

--- a/src/plugins/plugin-cache-metadata.ts
+++ b/src/plugins/plugin-cache-metadata.ts
@@ -12,6 +12,8 @@ type CurrentPluginMetadataCacheState = {
   snapshot: unknown;
   owner: "gateway" | "operation";
   configFingerprint: string | undefined;
+  envFingerprint: string | undefined;
+  defaultDiscoveryCompatible: boolean;
   compatiblePolicyHashes: readonly string[] | undefined;
   compatibleConfigFingerprints: readonly string[] | undefined;
   modelIdNormalizationPolicies:
@@ -53,6 +55,8 @@ export function createPluginCacheMetadata(): PluginCacheMetadata {
         snapshot: undefined,
         owner: "operation",
         configFingerprint: undefined,
+        envFingerprint: undefined,
+        defaultDiscoveryCompatible: false,
         compatiblePolicyHashes: undefined,
         compatibleConfigFingerprints: undefined,
         modelIdNormalizationPolicies: undefined,

--- a/src/plugins/plugin-metadata-env.ts
+++ b/src/plugins/plugin-metadata-env.ts
@@ -1,4 +1,5 @@
 import { tryProcessCwd } from "../infra/safe-cwd.js";
+import { shouldTrustTestBundledPluginsDirOverride } from "./bundled-dir.js";
 import {
   hasActivePluginInstallRoots,
   resolveActivePluginInstallRoots,
@@ -33,6 +34,7 @@ export function resolvePluginMetadataEnvFingerprint(env: NodeJS.ProcessEnv = pro
       }),
     ),
     installRoots: hasActivePluginInstallRoots() ? resolveActivePluginInstallRoots() : undefined,
+    trustBundledPluginsDirOverride: shouldTrustTestBundledPluginsDirOverride(env),
     cwd: tryProcessCwd(),
   });
 }

--- a/src/plugins/plugin-metadata-env.ts
+++ b/src/plugins/plugin-metadata-env.ts
@@ -1,0 +1,38 @@
+import { tryProcessCwd } from "../infra/safe-cwd.js";
+import {
+  hasActivePluginInstallRoots,
+  resolveActivePluginInstallRoots,
+} from "./install-root-context.js";
+import { hashJson } from "./installed-plugin-index-hash.js";
+
+const PLUGIN_METADATA_ENV_KEYS = [
+  "ANDROID_DATA",
+  "APPDATA",
+  "HOME",
+  "OPENCLAW_BUNDLED_PLUGINS_DIR",
+  "OPENCLAW_COMPATIBILITY_HOST_VERSION",
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_DEV_SOURCE_ROOT",
+  "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+  "OPENCLAW_DISABLE_BUNDLED_SOURCE_OVERLAYS",
+  "OPENCLAW_HOME",
+  "OPENCLAW_NIX_MODE",
+  "OPENCLAW_STATE_DIR",
+  "PREFIX",
+  "USERPROFILE",
+  "XDG_CONFIG_HOME",
+] as const;
+
+/** Compares discovery namespaces without resolving or probing filesystem roots. */
+export function resolvePluginMetadataEnvFingerprint(env: NodeJS.ProcessEnv = process.env): string {
+  return hashJson({
+    env: Object.fromEntries(
+      PLUGIN_METADATA_ENV_KEYS.flatMap((key) => {
+        const value = env[key];
+        return value === undefined ? [] : [[key, value]];
+      }),
+    ),
+    installRoots: hasActivePluginInstallRoots() ? resolveActivePluginInstallRoots() : undefined,
+    cwd: tryProcessCwd(),
+  });
+}

--- a/src/plugins/plugin-metadata-snapshot.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.test.ts
@@ -1,8 +1,13 @@
 // Verifies lifecycle snapshot loading, ownership facts, and immutable boundaries.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeTempDir } from "../../test/helpers/temp-dir.js";
 import { resolveDefaultModelForAgent } from "../agents/model-selection-config.js";
 import { buildConfiguredModelCatalog } from "../agents/model-selection-shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { writeConfigMachineState } from "../state/config-machine-state.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { clearBundledDiscoveryModeMemo } from "./bundled-discovery-state.js";
+import { removeBundledDiscoveryStateRoot } from "./bundled-discovery.test-support.js";
 import {
   adoptCurrentPluginMetadataSnapshotIfAbsent,
   getCurrentPluginMetadataSnapshot,
@@ -123,6 +128,51 @@ describe("plugin metadata snapshot", () => {
       env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1", OPENCLAW_STATE_DIR: "/unselected-state" },
     });
     expect(registry).toBe(snapshot.manifestRegistry);
+  });
+
+  it("refreshes snapshots for the selected environment's discovery policy", async () => {
+    const roots: string[] = [];
+    const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+    try {
+      setTestEnvValue("OPENCLAW_STATE_DIR", makeTempDir(roots, "openclaw-metadata-process-"));
+      const env = {
+        ...process.env,
+        OPENCLAW_STATE_DIR: makeTempDir(roots, "openclaw-metadata-selected-"),
+      };
+      const config = {};
+      writeConfigMachineState("plugins.bundledDiscovery", "compat", { env });
+      clearBundledDiscoveryModeMemo();
+      const index = makeIndex();
+      index.policyHash = resolveInstalledPluginIndexPolicyHash(config, env);
+      loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+        source: "persisted",
+        snapshot: index,
+        diagnostics: [],
+      });
+
+      const first = loadPluginMetadataSnapshot({ config, env });
+      expect(first.index.plugins.map((plugin) => plugin.enabled)).toEqual([true]);
+      expect(loadPluginMetadataSnapshot({ config, env })).toBe(first);
+
+      // Doctor updates machine policy and the persisted inventory without changing env paths.
+      writeConfigMachineState("plugins.bundledDiscovery", "allowlist", { env });
+      clearBundledDiscoveryModeMemo();
+      index.policyHash = resolveInstalledPluginIndexPolicyHash(config, env);
+      index.plugins = index.plugins.map((plugin) => ({ ...plugin, enabled: false }));
+
+      const refreshed = loadPluginMetadataSnapshot({ config, env });
+      expect(refreshed.index.plugins.map((plugin) => plugin.enabled)).toEqual([false]);
+      expect(refreshed.policyHash).toBe(index.policyHash);
+      expect(loadPluginMetadataSnapshot({ config, env })).toBe(refreshed);
+
+      writeConfigMachineState("plugins.bundledDiscovery", "compat");
+      clearBundledDiscoveryModeMemo();
+      expect(loadPluginMetadataSnapshot({ config, env })).toBe(refreshed);
+      expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
+    } finally {
+      envSnapshot.restore();
+      await Promise.all(roots.map(removeBundledDiscoveryStateRoot));
+    }
   });
 
   it("publishes the complete prepared cache and keeps fresh operations outside boot scopes", () => {

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -9,7 +9,6 @@ import {
   getCurrentPluginMetadataSnapshot,
   isCurrentPluginMetadataSnapshotRuntimeGeneration,
 } from "./current-plugin-metadata-snapshot.js";
-import { resolveActivePluginInstallRoots } from "./install-root-context.js";
 import { hashJson } from "./installed-plugin-index-hash.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
@@ -30,6 +29,7 @@ import {
   withPluginCache,
 } from "./plugin-cache.js";
 import { resolvePluginControlPlaneFingerprint } from "./plugin-control-plane-context.js";
+import { resolvePluginMetadataEnvFingerprint } from "./plugin-metadata-env.js";
 import { buildPluginMetadataProviderFacts } from "./plugin-metadata-provider-facts.js";
 import {
   adoptCurrentPluginMetadataSnapshotIfAbsentRuntime,
@@ -45,41 +45,13 @@ import { createPluginRegistryIdNormalizer } from "./plugin-registry-id-normalize
 import { loadPluginRegistrySnapshotWithMetadata } from "./plugin-registry-snapshot.js";
 import { normalizePluginIdScope, serializePluginIdScope } from "./plugin-scope.js";
 
-const PLUGIN_METADATA_ENV_KEYS = [
-  "APPDATA",
-  "HOME",
-  "OPENCLAW_BUNDLED_PLUGINS_DIR",
-  "OPENCLAW_COMPATIBILITY_HOST_VERSION",
-  "OPENCLAW_CONFIG_PATH",
-  "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
-  "OPENCLAW_DISABLE_BUNDLED_SOURCE_OVERLAYS",
-  "OPENCLAW_HOME",
-  "OPENCLAW_NIX_MODE",
-  "OPENCLAW_STATE_DIR",
-  "USERPROFILE",
-  "XDG_CONFIG_HOME",
-] as const;
 const MAX_PLUGIN_METADATA_PROJECTIONS = 64;
 export type {
   PluginMetadataSnapshot,
   PluginMetadataSnapshotOwnerMaps,
 } from "./plugin-metadata-snapshot.types.js";
 
-function pickPluginMetadataEnv(env: NodeJS.ProcessEnv): Record<string, string> {
-  return Object.fromEntries(
-    PLUGIN_METADATA_ENV_KEYS.flatMap((key) => {
-      const value = env[key];
-      return value === undefined ? [] : [[key, value]];
-    }),
-  );
-}
-
-export function resolvePluginMetadataEnvFingerprint(env: NodeJS.ProcessEnv): string {
-  return hashJson({
-    env: pickPluginMetadataEnv(env),
-    installRoots: resolveActivePluginInstallRoots(env),
-  });
-}
+export { resolvePluginMetadataEnvFingerprint } from "./plugin-metadata-env.js";
 
 function throwReadonlyPluginMetadataMutation(): never {
   throw new TypeError("Plugin metadata snapshots are immutable");
@@ -355,7 +327,7 @@ export function resolvePluginMetadataSnapshotCacheKey(
 ): string {
   return hashJson({
     env: resolvePluginMetadataEnvFingerprint(params.env ?? process.env),
-    policy: resolveInstalledPluginIndexPolicyHash(params.config),
+    policy: resolveInstalledPluginIndexPolicyHash(params.config, params.env),
     loadPaths: params.config?.plugins?.load?.paths,
     workspaceDir: params.workspaceDir,
     stateDir: params.stateDir,


### PR DESCRIPTION
Related: #130324. Split from #130706; the broader CPU/stall investigation remains separate.

## What Problem This Solves

Ordinary plugin metadata readers repeated discovery-root checks and could reuse snapshots across incompatible discovery environments. The snapshot owner now captures the environment and default-discovery compatibility once. Immutable prepared Gateway generations retain their existing no-rediscovery behavior.

The latest review also found a missing discovery fact: the effective test-only bundled-directory trust decision already changes root selection, but was absent from the metadata fingerprint. This update reuses that existing pure predicate in the fingerprint. Supplied and ambient selector changes now invalidate ordinary configless reuse; a retained generation still uses its captured snapshot.

## Why This Change Was Made

Reuse belongs to the snapshot owner. Clearing and restoring metadata use the canonical state setter, removed launch directories use the existing safe-CWD helper, and policy hashing receives the selected environment. Main's prepared normalization-policy maps, publication eligibility, and exact lease restoration remain intact. There is no duplicate trust policy, root IO in the fingerprint, additional cache, new setting or environment variable, dependency, schema, persistent-store design, protocol, or compatibility path.

## Evidence

Current source: `c583c96644ed7d798a7537f59128ac8cf143661a`, integrated on main `e27a72435258a05d09ff5e98b2c2ac2fe18d49f4`.

- The original metadata reproduction failed 11 owner cases on unchanged e27, then passed the same 72 cases after repair.
- The review follow-up reproduced both supplied and ambient trust failures on unchanged f036: **2 failed / 41 passed**. The identical file passed **43/43** after repair. The original ordered 20-file cohort passed **337/337**.
- The full eight-path changed gate passed, including type/lint, export, runtime-cycle and storage/authentication guards. The independent static/type cycle check passed. Managed Codex P0 review returned no findings; this is not an all-priority review claim. Source remained unchanged through validation and matches the committed tree.
- A fresh ordinary full build on c583 passed in **261.00 seconds**, including the maintained declaration-cache path. The sealed output inventory has **15,048 entries across 17 roots**. All 35,861 tracked source entries remained unchanged.
- The freshly built Gateway passed **ten final-response and persisted-history checks** in the original main/worker order. Calibrated Inspector observers recorded **12 retained scope entries, zero scoped fingerprints and zero scoped discovery-root resolutions**. The same window still recorded eight fingerprints and twelve root resolutions outside that scope; this is not a process-wide zero-discovery claim.
- The runtime driver exited 0 in 29.82 seconds. An independent post-join audit, followed by the landing owner's direct checks, found all five observed processes absent, all three ports refusing connections, and both temporary roots removed. All sealed source/build inputs remained unchanged. Both existing fixture refresh controls were disabled, and no owned Git fetch or transport was observed; observation is sampled, not complete network monitoring.
- Exact-head [CI run 33447944490](https://github.com/openclaw/openclaw/actions/runs/33447944490) and required `openclaw/ci-gate` succeeded for c583. The latest ClawSweeper review's pending build/runtime/CI items and Rank-up move are now addressed.

Evidence identities: build receipt SHA-256 `53161c6d771911193c6bfc75bf2bfb6317341b4897e7acede04f8e20cdc25d71`; runtime receipt `c26285162e8e37e5e250ef23be9e05c9fbf19d336b0bc780f3fcb45ef2d85dad`; raw ten-turn summary `484282433600055c35cc4501bacccd4df7049025c14a179612450cac127a5d89`.

Historical f036 evidence is preserved, not relabeled: its ordinary build and corrected ten-turn synthetic Gateway run passed, with zero root/fingerprint recomputation inside the retained scope. An earlier f036 run also passed behavior but unexpectedly fetched public Git metadata because one background refresh remained enabled. The corrected run disabled both existing fixture refresh settings and observed no owned Git transport. That is bounded process observation, not a whole-host egress claim. The older ec935 cold SDK declaration timeout remains unexplained.

No authenticated provider/channel, production soak, all-worker CPU measurement, or whole-incident performance claim is made. Telegram is explicitly waived, not passed.

## Review Follow-through and Size

The deleted-CWD finding and the latest bundled-directory trust finding are repaired with their canonical helpers and failing-before coverage. The review's exact-head CI prerequisite passed. Its generic stored-data warning does not identify a persistent change: these facts are process-local.

Production: **+96 / -108 = -12 lines** in six files. Tests: **+217 / -43 = +174 lines** in two existing files. The trust follow-up adds two production lines to the existing fingerprint and 43 test lines. Changelogs are written at release time; none is included here.
