### PR TITLE
test: assert release navigation shape instead of pinned versions

### DIFF
--- a/test/scripts/docs-sync-publish.test.ts
+++ b/test/scripts/docs-sync-publish.test.ts
@@ -174,7 +174,6 @@ describe("docs-sync-publish", () => {
     ]);
 
     const releaseTab = english!.tabs.find((tab) => tab.tab === "Release & CI");
-    const releaseRoutes = collectPages(releaseTab);
     const releaseNotes = collectPages(releaseTab?.groups?.[0]);
     expect(releaseTab?.groups?.map((group) => group.group)).toEqual([
       "Release notes",
@@ -182,8 +181,28 @@ describe("docs-sync-publish", () => {
       "Release process",
       "Testing and CI",
     ]);
+    // Every release adds a releases/<version> page, so read the published versions from the
+    // navigation rather than pinning them here; only the index-first ordering and the version
+    // route shape are invariant. Pinning the list makes this assertion fail on release PRs whose
+    // change classification never selects this lane, so the break first lands on main.
     expect(releaseNotes[0]).toBe("releases/index");
-    expect(new Set(collectPages(releaseTab))).toHaveLength(releaseRoutes.length);
+    expect(releaseNotes.length).toBeGreaterThan(1);
+    for (const page of releaseNotes.slice(1)) {
+      expect(page).toMatch(/^releases\/\d{4}\.\d{1,2}\.\d+$/);
+    }
+    const releaseRoutes = [
+      ...releaseNotes,
+      "maturity/scorecard",
+      "maturity/taxonomy",
+      "reference/RELEASING",
+      "reference/full-release-validation",
+      "reference/release-performance-sweep",
+      "reference/test",
+      "ci",
+      "help/scripts",
+    ];
+    expect(collectPages(releaseTab)).toEqual(releaseRoutes);
+    expect(new Set(releaseRoutes)).toHaveLength(releaseRoutes.length);
 
     const englishWithoutClawHub = {
       ...english,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where cutting a release turned `main` red for everyone. The
`docs-sync-publish` navigation test pinned the exact release-notes page list, so
every release that added a `docs/releases/<version>.md` page plus its
`docs/docs.json` nav entry broke the assertion. Because that assertion lives in
the `tooling` lane and a release PR's change classification never selects it, the
release PR itself went green and the failure first surfaced on `main`, where
every subsequent PR inherited it. This already happened once end-to-end:
#133557 (v2026.8.1 release notes) turned `main` red and #133581 fixed it by
bumping the literal, leaving the landmine armed for the next release.

## Why This Change Was Made

#133565 removed the pinned literals, but by making `releaseRoutes` tautological
(`collectPages(releaseTab)` compared against itself), which also dropped the
English route-composition assertion entirely — the eight fixed non-release routes
and their order stopped being checked, and only `releaseNotes[0]` survived from
the release-notes group. This restores the invariants while keeping the list
release-proof: the published versions are read from the English navigation, and
the test asserts that `releases/index` is first, that every entry after it matches
`/^releases\/\d{4}\.\d{1,2}\.\d+$/`, that the full tab equals those pages followed
by the fixed non-release routes, that there are no duplicates, and that the zh-CN
release group mirrors the English list exactly with the `zh-CN/` prefix. The
locale-mirroring assertions are unchanged and now compare against a list that
means something.

## User Impact

No user-visible or runtime change. Maintainers stop having to repair `main` after
every release, and the navigation invariants that actually matter are enforced
again instead of being silently dropped.

## Evidence

Test-only change: production `+0/-0`, tests `+21/-2`.

```
node scripts/run-vitest.mjs test/scripts/docs-sync-publish.test.ts
# Test Files  1 passed (1) | Tests  6 passed (6)
```

Three negative controls, each reverted afterwards:

1. Added a synthetic `releases/2026.9.1` nav entry and page — still 6 passing, so
   the next release no longer breaks this lane.
2. Temporarily filtered one release page out of the zh-CN prefix path in
   `scripts/docs-sync-publish.mjs` — fails with
   `expected [ …(579) ] to deeply equal [ …(580) ]`, so the mirror assertion still
   has teeth. Note zh-Hans is the one locale with `navMode: "overlay"`
   (`docs/.i18n/zh-Hans-navigation.json`), so this guards a real composition step.
3. Renamed a release entry to `releases/next` — fails on the version-shape regex,
   so the derived list cannot absorb a malformed route.

`node scripts/check-changed.mjs` is green (format, test-root typecheck, lint,
guards). Fresh `$autoreview` on the diff: `scoped-clean`, no accepted findings.
