### PR TITLE
fix(node-host): report container hosting startup failures in the native worker

### DIFF
--- a/docs/nodes/troubleshooting.md
+++ b/docs/nodes/troubleshooting.md
@@ -68,6 +68,13 @@ Healthy signals:
 - `nodes describe` includes the capability you're calling.
 - Exec approvals show the expected mode/allowlist.
 
+If startup preparation disables container session hosting that you enabled, check the node host's
+local stderr for `node host worker hosting disabled: ...` and follow the reported
+engine or context recovery guidance. The macOS app forwards worker stderr to its
+logger under subsystem `ai.openclaw`, category `node-host-worker`; see
+[macOS logging](/platforms/mac/logging) for capture options. After fixing the cause,
+restart the node host. Explicitly disabled hosting produces no such diagnostic.
+
 ## Foreground requirements
 
 `camera.*` and `screen.*` are foreground-only on iOS/Android nodes.

--- a/src/logging/redact-patterns.ts
+++ b/src/logging/redact-patterns.ts
@@ -64,8 +64,8 @@ const ENV_ASSIGNMENT_REDACT_PATTERN = String.raw`/\b[A-Z0-9_]*(?:KEY|TOKEN|SECRE
 const ESCAPED_ENV_ASSIGNMENT_REDACT_PATTERN = String.raw`/\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|${PAYMENT_CREDENTIAL_ENV_KEYS})\b\s*[=:]\s*\\+(["'])([^\s"'\\]+)\\+\1/g`;
 // Quoted values may contain the other quote characters; only the matching closing quote ends
 // the value. The unquoted variant accepts one leading quote so unterminated values still mask.
-const STANDALONE_ASSIGNMENT_QUOTED_REDACT_PATTERN = String.raw`(^|[\s,;])(?:${STANDALONE_ASSIGNMENT_SECRET_KEYS})=(["'\x60])((?:(?!\2)[^\r\n])+)\2`;
-const STANDALONE_ASSIGNMENT_REDACT_PATTERN = String.raw`(^|[\s,;])(?:${STANDALONE_ASSIGNMENT_SECRET_KEYS})=(["'\x60]?[^\s&#"'\x60<>]+)`;
+const STANDALONE_ASSIGNMENT_QUOTED_REDACT_PATTERN = String.raw`(^|[\s,;({\[])(?:${STANDALONE_ASSIGNMENT_SECRET_KEYS})=(["'\x60])((?:(?!\2)[^\r\n])+)\2`;
+const STANDALONE_ASSIGNMENT_REDACT_PATTERN = String.raw`(^|[\s,;({\[])(?:${STANDALONE_ASSIGNMENT_SECRET_KEYS})=(["'\x60]?[^\s&#"'\x60<>]+)`;
 const CONFIG_QUOTED_ASSIGNMENT_SECRET_KEYS = String.raw`access[-_]?token|refresh[-_]?token|id[-_]?token|auth[-_]?token|hook[-_]?token|api[-_]?(?:key|secret)|secret[-_]?key|key[-_]?material|authorization|jwt|token|secret|password|passphrase|pass|passwd|${PAYMENT_CREDENTIAL_QUERY_KEYS}`;
 const CONFIG_QUOTED_ASSIGNMENT_REDACT_PATTERN = String.raw`/(^|[\s,{])(?:(?:${CONFIG_QUOTED_ASSIGNMENT_SECRET_KEYS})(?:\s*:\s*|\s+=\s*|=\s*)|[a-z0-9][a-z0-9._-]{0,79}[-_](?:${CONFIG_PREFIXED_PASSWORD_ASSIGNMENT_SECRET_KEYS})\s*[:=]\s*|[a-z0-9_.-]{1,80}\.(?:${CONFIG_ASSIGNMENT_SECRET_KEYS})\s*[:=]\s*)(["'\x60])((?:(?!\2)[^\r\n])+)\2/g`;
 const CONFIG_ASSIGNMENT_REDACT_PATTERN = String.raw`/(^|[\s,{])(?:${CONFIG_ASSIGNMENT_SECRET_KEYS})(?:\s*:\s*|\s+=\s*|=\s+)([^\s#"'\x60<>]+)/g`;

--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -134,6 +134,7 @@ describe("model-visible tool payload redaction", () => {
     'const API_TOKEN = "fixture-only-not-a-real-secret" + suffix; return API_TOKEN;',
     "const API_TOKEN = computeToken(); /* API_TOKEN=fixture-only-not-a-real-secret */",
     'const API_TOKEN = "fixture-only-not-a-real-secret"; @',
+    '(token="fixture-only-not-a-real-secret");',
   ])("retains diagnostic literal masking in input source: %s", (source) => {
     const redacted = redactSourceInputTextWithConfig(source);
     expect(redactToolPayloadTextWithConfig(source)).not.toBe(source);
@@ -152,6 +153,7 @@ describe("model-visible tool payload redaction", () => {
     "const HAS_API_TOKEN = false; return HAS_API_TOKEN;",
     "const HAS_API_TOKEN = true; return HAS_API_TOKEN;",
     "let API_TOKEN = null; return API_TOKEN;",
+    "(token=computeToken());",
   ])("preserves input computations without changing diagnostics: %s", (source) => {
     expect(redactSourceInputTextWithConfig(source)).toBe(source);
     expect(redactToolPayloadTextWithConfig(source)).not.toBe(source);
@@ -197,6 +199,7 @@ describe("model-visible tool payload redaction", () => {
       "token = timeObserverToken",
       "API_TOKEN = computeToken()",
       "API_TOKEN=computeToken()",
+      "(token=computeToken())",
       "API_KEY: str = computeKey()",
       '"api_key": "computeToken()"',
       `registered: ${credentials[0]}`,
@@ -210,6 +213,7 @@ describe("model-visible tool payload redaction", () => {
     expect(output).toContain("token = timeObserverToken");
     expect(output).toContain("API_TOKEN = computeToken()");
     expect(output).toContain("API_TOKEN=computeToken()");
+    expect(output).toContain("(token=computeToken())");
     expect(output).toContain("API_KEY: str = computeKey()");
     expect(output).toContain('"api_key": "computeToken()"');
     for (const credential of credentials) {
@@ -357,10 +361,25 @@ describe("redactSensitiveText", () => {
     expect(output).not.toContain(token);
   });
 
-  it("masks standalone lowercase token assignments in diagnostic output", () => {
-    const input = "matrix access_token=abcdef1234567890ghij next";
-    const output = redactSensitiveText(input, { mode: "tools" });
-    expect(output).toBe("matrix access_token=abcdef…ghij next");
+  it.each([
+    ["matrix access_token=abcdef1234567890ghij next", "matrix access_token=abcdef…ghij next"],
+    [
+      "Docker authentication failed (password=fixture-secret); install and start the engine",
+      "Docker authentication failed (password=*** install and start the engine",
+    ],
+    ["failed [token=fixture-secret]; retry", "failed [token=*** retry"],
+    ["failed {client_secret=fixture-secret}; retry", "failed {client_secret=*** retry"],
+    ['failed (password="it\'s-a-secret"); retry', 'failed (password="***"); retry'],
+    ["failed [token='has\"quotes']; retry", "failed [token='***']; retry"],
+    ["failed {secret=`has'quotes`}; retry", "failed {secret=`***`}; retry"],
+    ['failed (token="unterminated retry', "failed (token=*** retry"],
+  ])("masks standalone diagnostic assignments: %s", (input, expected) => {
+    expect(redactSensitiveText(input)).toBe(expected);
+  });
+
+  it("preserves non-secret key names after opening delimiters", () => {
+    const input = "(token_count=42) [password_hint=visible] {mytoken=visible}";
+    expect(redactSensitiveText(input)).toBe(input);
   });
 
   it("masks JSON fields", () => {

--- a/src/node-host/connection.ts
+++ b/src/node-host/connection.ts
@@ -12,6 +12,7 @@ import {
   NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
   type NodeWorkerCapacitySnapshot,
 } from "../infra/node-runner-inventory.js";
+import { redactSensitiveText } from "../logging/redact.js";
 import type { NodeHostClient } from "./client.js";
 import type { prepareNodeHostRuntime, NodeHostInventory } from "./runtime.js";
 
@@ -345,6 +346,15 @@ export function startNodeHostConnection({
     );
   };
 
+  const onWorkerHostingDisabled = (reason: string) => {
+    workerHostingEnabled = false;
+    writeStderrLine(`node host worker hosting disabled: ${redactSensitiveText(reason)}`);
+    publishRunnerInventory();
+  };
+  // Preparation failures have no supervisor left to report them. Emit once before hello.
+  if (prepared.workerHostingDisabledReason) {
+    onWorkerHostingDisabled(prepared.workerHostingDisabledReason);
+  }
   const disconnect = () => {
     retireGatewayConnection();
     runtime.updateGatewayConnection();
@@ -360,11 +370,7 @@ export function startNodeHostConnection({
       workerCapacity = capacity;
       publishRunnerInventory();
     },
-    onWorkerHostingDisabled: (reason) => {
-      workerHostingEnabled = false;
-      writeStderrLine(`node host worker hosting disabled: ${reason}`);
-      publishRunnerInventory();
-    },
+    onWorkerHostingDisabled,
     onManifestChanged: (manifest) => {
       retireGatewayConnection();
       onManifestChanged(manifest);

--- a/src/node-host/runner.test.ts
+++ b/src/node-host/runner.test.ts
@@ -640,7 +640,7 @@ describe("runNodeHost", () => {
     );
 
     expect(lastCapturedOptions()?.workerRuns).toBeUndefined();
-    expect(stderr).toHaveBeenCalledWith(
+    expect(stderr).toHaveBeenCalledExactlyOnceWith(
       "node host worker hosting disabled: Docker or Podman is unavailable\n",
     );
     stderr.mockRestore();

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -198,11 +198,6 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
     ephemeral: opts.ephemeral,
     installedAppsSharingEnabled: config.installedAppsSharing,
   });
-  if (preparedRuntime.workerHostingDisabledReason) {
-    writeStderrLine(
-      `node host worker hosting disabled: ${preparedRuntime.workerHostingDisabledReason}`,
-    );
-  }
   const { token, password } = opts.gatewayBootstrapToken
     ? {}
     : await resolveNodeHostGatewayCredentials({

--- a/src/node-host/runtime.worker-hosting.test.ts
+++ b/src/node-host/runtime.worker-hosting.test.ts
@@ -119,6 +119,30 @@ describe("node-host worker manifest", () => {
     expect(prepared.workerHostingEnabled).toBe(true);
   });
 
+  it("keeps container hosting opted out without probing an engine or reporting a failure", async () => {
+    const prepared = await prepareNodeHostRuntime({
+      config: {
+        nodeHost: {
+          skills: { enabled: false },
+          workerRuns: { enabled: false, isolation: "container" },
+        },
+      },
+      env: { PATH: "/usr/bin" },
+      enableWorkerRuns: true,
+    });
+    const onWorkerHostingDisabled = vi.fn();
+    const runtime = prepared.start({ client, onWorkerHostingDisabled });
+    try {
+      expect(prepared.workerHostingEnabled).toBe(false);
+      expect(prepared.workerHostingDisabledReason).toBeUndefined();
+      expect(mocks.resolveContainerEngine).not.toHaveBeenCalled();
+      expect(createNodeWorkerSupervisor).not.toHaveBeenCalled();
+      expect(onWorkerHostingDisabled).not.toHaveBeenCalled();
+    } finally {
+      await runtime.close();
+    }
+  });
+
   it("keeps local consent separate from connection metadata", async () => {
     const prepared = await prepareWorkerRuntime();
 

--- a/src/node-host/worker-runtime.test.ts
+++ b/src/node-host/worker-runtime.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events";
 import { setImmediate } from "node:timers/promises";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 
 const fixture = vi.hoisted(() => ({
   prepare: vi.fn(),
@@ -21,11 +21,15 @@ vi.mock("./config.js", () => ({ loadNodeHostConfig: async () => ({}) }));
 vi.mock("./runtime.js", () => ({ prepareNodeHostRuntime: fixture.prepare }));
 import { runNodeHostWorker } from "./worker.js";
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
-it("publishes hosting through the app route and retires it on disconnect", async () => {
+function startWorkerFixture(workerHostingEnabled = true, workerHostingDisabledReason?: string) {
   const events = new EventEmitter();
   const input = Object.assign(events, {
     close: () => {
@@ -34,7 +38,8 @@ it("publishes hosting through the app route and retires it on disconnect", async
   });
   fixture.input = input;
   const messages: Array<Record<string, unknown>> = [];
-  vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+  const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  const stdout = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
     const message = JSON.parse(String(chunk));
     messages.push(message);
     if (message.type === "gateway-request") {
@@ -54,16 +59,44 @@ it("publishes hosting through the app route and retires it on disconnect", async
     return true;
   });
   fixture.start.mockImplementation((callbacks) => {
-    callbacks.onRunnerCapacityChanged?.({ total: 2, available: 2 });
+    if (workerHostingEnabled) {
+      callbacks.onRunnerCapacityChanged?.({ total: 2, available: 2 });
+    }
     return fixture.runtime;
   });
   fixture.prepare.mockResolvedValue({
     manifest: { commands: ["system.run"], caps: ["system"], pathEnv: "/bin" },
-    workerHostingEnabled: true,
+    workerHostingEnabled,
+    workerHostingDisabledReason,
     initialInventory: { skills: [], pluginTools: [] },
     start: fixture.start,
   });
+  const previousExitCode = process.exitCode;
+  const interruptListeners = process.listeners("SIGINT");
+  const terminateListeners = process.listeners("SIGTERM");
   const running = runNodeHostWorker();
+  return {
+    input,
+    messages,
+    stderr,
+    stdout,
+    stop: async () => {
+      try {
+        input.close();
+        await running;
+        expect(fixture.runtime.close).toHaveBeenCalledOnce();
+        expect(fixture.runtime.updateGatewayConnection).toHaveBeenLastCalledWith();
+        expect(process.listeners("SIGINT")).toEqual(interruptListeners);
+        expect(process.listeners("SIGTERM")).toEqual(terminateListeners);
+      } finally {
+        process.exitCode = previousExitCode;
+      }
+    },
+  };
+}
+
+it("publishes hosting through the app route and retires it on disconnect", async () => {
+  const { input, messages, stderr, stop } = startWorkerFixture();
   try {
     await vi.waitFor(() => expect(messages.some((message) => message.type === "ready")).toBe(true));
     expect(fixture.prepare).toHaveBeenCalledWith(
@@ -131,8 +164,87 @@ it("publishes hosting through the app route and retires it on disconnect", async
       }),
     );
     expect(fixture.runtime.invoke).not.toHaveBeenCalled();
+    expect(stderr).not.toHaveBeenCalled();
   } finally {
-    input.close();
-    await running;
+    await stop();
   }
 });
+
+it.each(["prepared failure", "later failure", "configured opt-out"] as const)(
+  "keeps worker hosting diagnostics local across reconnects: %s",
+  async (scenario) => {
+    const secret = "fixture-secret";
+    const action = "install and start the engine";
+    const reason = `Docker authentication failed (password=${secret}); ${action}`;
+    const preparedFailure = scenario === "prepared failure";
+    const laterFailure = scenario === "later failure";
+    const { input, messages, stderr, stdout, stop } = startWorkerFixture(
+      laterFailure,
+      preparedFailure ? reason : undefined,
+    );
+    const expectDiagnostic = () => {
+      expect(stderr).toHaveBeenCalledOnce();
+      const diagnostic = String(stderr.mock.calls[0]?.[0]);
+      expect(diagnostic).toContain(
+        "node host worker hosting disabled: Docker authentication failed",
+      );
+      expect(diagnostic).toContain(action);
+      expect(diagnostic).not.toContain(secret);
+    };
+    try {
+      await vi.waitFor(() =>
+        expect(messages.some((message) => message.type === "ready")).toBe(true),
+      );
+      expect(messages).toHaveLength(1);
+      if (preparedFailure) {
+        expectDiagnostic();
+        expect(stderr.mock.invocationCallOrder[0]).toBeLessThan(
+          stdout.mock.invocationCallOrder[0]!,
+        );
+      } else {
+        expect(stderr).not.toHaveBeenCalled();
+      }
+      const connection = {
+        url: "wss://gateway.example.test/current",
+        protocol: 4,
+        capabilities: [],
+      };
+      const inventories = () =>
+        messages.filter((message) => message.method === "node.runnerInventory.update");
+      input.emit("line", JSON.stringify({ type: "gateway-connection", generation: 1, connection }));
+      await setImmediate();
+      if (laterFailure) {
+        expect(inventories()).toHaveLength(1);
+        expect(inventories()[0]?.params).toMatchObject({ workerHost: { enabled: true } });
+        fixture.start.mock.calls[0]?.[0].onWorkerHostingDisabled(reason);
+        await setImmediate();
+        expectDiagnostic();
+      }
+      const disabledInventory = expect.objectContaining({ workerHost: { enabled: false } });
+      expect(inventories()).toHaveLength(laterFailure ? 2 : 1);
+      expect(inventories().at(-1)?.params).toEqual(disabledInventory);
+      input.emit(
+        "line",
+        JSON.stringify({ type: "gateway-connection", generation: 2, connection: null }),
+      );
+      input.emit("line", JSON.stringify({ type: "gateway-connection", generation: 3, connection }));
+      await setImmediate();
+      expect(inventories()).toHaveLength(laterFailure ? 3 : 2);
+      expect(inventories().at(-1)).toMatchObject({ generation: 3, params: disabledInventory });
+      if (scenario === "configured opt-out") {
+        expect(stderr).not.toHaveBeenCalled();
+      } else {
+        expectDiagnostic();
+      }
+      const output = stdout.mock.calls.map(([chunk]) => String(chunk)).join("");
+      expect(output).not.toContain(secret);
+      expect(output).not.toContain(reason);
+      expect(output).not.toContain(action);
+      expect(output).not.toContain("worker hosting disabled");
+      expect(messages.filter((message) => message.type === "ready")).toHaveLength(1);
+      expect(messages.some((message) => message.type === "manifest")).toBe(false);
+    } finally {
+      await stop();
+    }
+  },
+);


### PR DESCRIPTION
Closes #133654

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can help update this branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators enabling container session hosting through the macOS app's private TypeScript node worker would get a ready node without the local reason hosting was disabled when startup preparation failed. The foreground CLI reported that reason, but the private worker did not. Later hosting-failure diagnostics also bypassed the canonical sensitive-text redactor.

## Why This Change Was Made

The shared node-host connection startup now reports the existing prepared failure through the same handler as later hosting failures, applying canonical redaction before stderr emission. This removes the CLI-only duplicate. The existing quoted/unquoted assignment patterns also recognize opening parentheses, brackets, and braces so credential-like assignments in these diagnostics are masked without a node-specific sanitizer.

The runtime still owns consent, engine preparation, and supervisor lifecycle; the shared connection owner owns local reporting and inventory publication. Duplicating logging in the two callers would leave the same drift hazard. Adding failure details to status/inventory would expand the protocol and expose local engine details unnecessarily, so that broader projection remains out of scope.

## User Impact

An enabled host that cannot prepare container hosting now records one actionable local diagnostic through the native worker's stderr/logger path, matching the foreground CLI. Other node commands remain available. Explicit opt-out stays quiet and does not probe an engine; reconnects do not repeat the startup diagnostic, and inventory remains `workerHost: { enabled: false }` without a reason.

This is the release-note context: native node-host container startup failures are diagnosable locally, with credential-like assignments redacted. [Node troubleshooting](https://docs.openclaw.ai/nodes/troubleshooting) explains the log location and restart/recovery path. No new config, schema, protocol version, storage, or Swift surface is introduced.

## Evidence

The [pre-fix runtime records the preparation cause](https://github.com/openclaw/openclaw/blob/08d09c4d97044ead11aacbe1cc13d5dd7a02c0a3/src/node-host/runtime.ts#L306-L320), but [shared startup only reports later callbacks](https://github.com/openclaw/openclaw/blob/08d09c4d97044ead11aacbe1cc13d5dd7a02c0a3/src/node-host/connection.ts#L348-L372). Preparation clears the supervisor, so no later callback can recover the missing diagnostic before [the private worker emits readiness](https://github.com/openclaw/openclaw/blob/08d09c4d97044ead11aacbe1cc13d5dd7a02c0a3/src/node-host/worker.ts#L58-L76). Fetched main `77279fbbdbe2678843ce4bd398cb20fd40f2f5c6` retained identical affected surfaces.

- **Red → green:** pre-fix worker tests failed on missing prepared stderr and an unredacted synthetic later-failure value. Canonical redactor tests separately demonstrated eight failures before the delimiter-boundary repair.
- **302 tests passed across 10 files:** node-host preparation/runtime/bridge, CLI runner and optional publication, redactor/source policies, token ordering, logger/log-tail, and tool-result redaction. The worker suite passed again, 4/4, after a test-only cleanup correction.
- **Checks:** production and test typechecks, dead-export scans, formatting, touched-file lint, and the remaining changed-scope guards passed; import cycles: 0. The initial aggregate changed check stopped on an unbound-method lint error in the new test cleanup fixture. That callback was made receiver-independent, then touched lint and the remaining guards were rerun successfully; the full aggregate was not redundantly rerun.
- **Build:** `pnpm build` passed, including CLI bootstrap and runtime postbuild validation.
- **Fresh independent Codex autoreview:** scoped-clean at its configured P0-only reporting threshold.

### Controlled real-process proof

The completed build was exercised through the actual `node dist/entry.js node worker` subprocess with piped stdin/stdout/stderr, isolated HOME/state/config, an explicit environment allowlist, disabled unrelated plugins/skills/browser activity, and no MCP servers. Synthetic Docker and Podman executables rejected only read-only startup probes; they never forwarded to a real daemon. Synthetic bridge acknowledgements exercised generations 1 → disconnect 2 → reconnect 3.

| Case | Observed result |
| --- | --- |
| Enabled container hosting, injected engine failure | Exactly one actionable stderr diagnostic before `ready`; both synthetic credential values redacted; only Docker/Podman version probes ran |
| Explicitly disabled container hosting | Zero engine calls, zero stderr diagnostics, successful `ready` |
| Both cases | JSONL-only stdout; disabled inventory at generations 1 and 3 without the reason; no raw synthetic values; exit 0 |

This is **controlled real-process fault injection**, not a naturally occurring container outage, authenticated Gateway session, real container-daemon test, or native Swift-app test. The unchanged Swift stderr-to-logger path was source-inspected; no Swift build/cache or operator instance was touched.

Exact focused test command:

```bash
node scripts/run-vitest.mjs src/node-host/runtime.worker-hosting.test.ts src/node-host/worker-runtime.test.ts src/node-host/worker.test.ts src/node-host/runner.test.ts src/node-host/runner.optional-publication.test.ts src/logging/redact.test.ts src/logging/redact-token-ordering.test.ts src/logging/logger-redaction-behavior.test.ts src/logging/log-tail-redaction.test.ts src/llm/tool-result-redaction.test.ts
```

Local process-driver command (task-local proof artifact, not a shipped command):

```bash
node .artifacts/node-host-landing/prove-worker.mjs
```

Production LOC: **+13/-12 (net +1)**; tests: **+167/-12 (net +155)**; docs: **+7/-0**. The shared-handler consolidation absorbs the repair; the small remaining growth supports redacted reporting and its startup-order explanation, not a parallel runtime path.
