### PR TITLE
test(plugins): drive plugin tool registry reuse through the real seam

### DIFF
--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -7,6 +7,7 @@ import type { SecretRef } from "../config/types.secrets.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { loggingState } from "../logging/state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
+import type { PluginLoadOptions } from "./loader-types.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import { appendRuntimePluginToolGrant } from "./tool-grant-allowlist.js";
 
@@ -21,8 +22,6 @@ type MockRegistryToolEntry = {
 };
 
 const loadOpenClawPluginsMock = vi.fn();
-const resolveCompatibleRuntimePluginRegistryMock = vi.fn();
-const getLoadedRuntimePluginRegistryMock = vi.fn();
 const applyPluginAutoEnableMock = vi.fn();
 const loadContextMocks = vi.hoisted(() => ({
   actualResolve: undefined as
@@ -30,30 +29,44 @@ const loadContextMocks = vi.hoisted(() => ({
     | undefined,
   resolve: vi.fn(),
 }));
-
-vi.mock("./loader.js", () => ({
-  loadOpenClawPlugins: (params: unknown) => loadOpenClawPluginsMock(params),
-  loadPluginRegistryHandle: (params: unknown) => loadOpenClawPluginsMock(params),
-  resolveCompatibleRuntimePluginRegistry: (params: unknown) =>
-    resolveCompatibleRuntimePluginRegistryMock(params),
-  resolvePluginRegistryLoadCacheKey: (params: unknown) => JSON.stringify(params),
-  resolveRuntimePluginRegistry: (params: unknown) =>
-    resolveCompatibleRuntimePluginRegistryMock(params),
+const activeRegistryMocks = vi.hoisted(() => ({
+  actualGetLoadedRegistry: undefined as
+    | typeof import("./active-runtime-registry.js").getLoadedRuntimePluginRegistry
+    | undefined,
+  getLoadedRegistry: vi.fn(),
 }));
 
-// resolveCompatibleRuntimePluginRegistry now lives in this module, so the
-// ./loader.js seam no longer observes the intra-module call that tool resolution
-// triggers. Count the boundary tools.ts actually crosses, keeping real behavior.
+// Only the load entry points are intercepted. The registry-resolution bindings
+// stay wired to their real owners so a consumer that crosses them observes
+// production behavior instead of a double that no production path reaches.
+vi.mock("./loader.js", async () => {
+  const [activeRuntimeRegistry, loaderCache] = await Promise.all([
+    import("./active-runtime-registry.js"),
+    import("./loader-cache.js"),
+  ]);
+  const loadPluginRegistryHandle = (params: unknown) => loadOpenClawPluginsMock(params);
+  return {
+    loadOpenClawPlugins: loadPluginRegistryHandle,
+    loadPluginRegistryHandle,
+    resolveCompatibleRuntimePluginRegistry:
+      activeRuntimeRegistry.resolveCompatibleRuntimePluginRegistry,
+    resolvePluginRegistryLoadCacheKey: loaderCache.resolvePluginRegistryLoadCacheKey,
+    resolveRuntimePluginRegistry: (options?: PluginLoadOptions) =>
+      activeRuntimeRegistry.resolveCompatibleRuntimePluginRegistry(options) ??
+      loadPluginRegistryHandle({ ...options, activate: false }),
+  };
+});
+
+// resolvePluginToolRegistry reads the active registry through this module, so
+// this is the seam that decides reuse-vs-rebuild. It delegates to the real
+// implementation; tests drive it by installing an active registry.
 vi.mock("./active-runtime-registry.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./active-runtime-registry.js")>();
+  activeRegistryMocks.actualGetLoadedRegistry = actual.getLoadedRuntimePluginRegistry;
   return {
     ...actual,
-    getLoadedRuntimePluginRegistry: (
-      params?: Parameters<typeof actual.getLoadedRuntimePluginRegistry>[0],
-    ) => {
-      getLoadedRuntimePluginRegistryMock(params);
-      return actual.getLoadedRuntimePluginRegistry(params);
-    },
+    getLoadedRuntimePluginRegistry: (...args: unknown[]) =>
+      activeRegistryMocks.getLoadedRegistry(...args),
   };
 });
 
@@ -524,6 +537,10 @@ function mockCallParams(
   return call[0] as Record<string, unknown>;
 }
 
+function activeRegistryRequiredPluginIds(index = 0): unknown {
+  return mockCallParams(activeRegistryMocks.getLoadedRegistry, index).requiredPluginIds;
+}
+
 function expectLoaderSelectedOnlyPluginIds(expectedPluginIds: readonly string[]) {
   const selectedPluginIds = loadOpenClawPluginsMock.mock.calls.map(
     ([params]) => (params as { onlyPluginIds?: string[] }).onlyPluginIds,
@@ -572,11 +589,13 @@ describe("resolvePluginTools optional tools", () => {
 
   beforeEach(() => {
     loadOpenClawPluginsMock.mockReset();
-    getLoadedRuntimePluginRegistryMock.mockReset();
-    resolveCompatibleRuntimePluginRegistryMock.mockReset();
-    resolveCompatibleRuntimePluginRegistryMock.mockImplementation(() =>
-      getActivePluginRegistry?.(),
-    );
+    activeRegistryMocks.getLoadedRegistry.mockReset();
+    activeRegistryMocks.getLoadedRegistry.mockImplementation((...args: unknown[]) => {
+      if (!activeRegistryMocks.actualGetLoadedRegistry) {
+        throw new Error("active-runtime-registry mock was not initialized");
+      }
+      return activeRegistryMocks.actualGetLoadedRegistry(...(args as [never]));
+    });
     applyPluginAutoEnableMock.mockReset();
     applyPluginAutoEnableMock.mockImplementation(({ config }: { config: unknown }) => ({
       config,
@@ -1157,7 +1176,6 @@ describe("resolvePluginTools optional tools", () => {
       "gateway-bindable",
       "/tmp",
     );
-    resolveCompatibleRuntimePluginRegistryMock.mockReturnValue(partialRegistry);
     loadOpenClawPluginsMock.mockReturnValue(fullRegistry);
 
     const tools = resolvePluginTools(
@@ -1168,6 +1186,7 @@ describe("resolvePluginTools optional tools", () => {
     );
 
     expectResolvedToolNames(tools, ["other_tool", "optional_tool"]);
+    expect(activeRegistryMocks.getLoadedRegistry).toHaveReturnedWith(partialRegistry);
     const loaderParams = mockCallParams(loadOpenClawPluginsMock) as {
       activate?: unknown;
       cache?: unknown;
@@ -1245,7 +1264,6 @@ describe("resolvePluginTools optional tools", () => {
       "gateway-bindable",
       "/tmp",
     );
-    resolveCompatibleRuntimePluginRegistryMock.mockReturnValue(staleRegistry);
     loadOpenClawPluginsMock.mockReturnValue(freshRegistry);
 
     const tools = resolvePluginTools(
@@ -1256,6 +1274,7 @@ describe("resolvePluginTools optional tools", () => {
     );
 
     expectResolvedToolNames(tools, ["other_tool", "optional_tool"]);
+    expect(activeRegistryMocks.getLoadedRegistry).toHaveReturnedWith(staleRegistry);
     expect(getActivePluginRegistry?.()).toBe(staleRegistry);
     expectLoaderSelectedOnlyPluginIds(["multi", "optional-demo"]);
     expect(freshRegistry.diagnostics).toStrictEqual([]);
@@ -2855,7 +2874,6 @@ describe("resolvePluginTools optional tools", () => {
       status: "loaded",
     });
     setActivePluginRegistry?.(replacementRegistry as never, "provider-runtime", "default", "/tmp");
-    resolveCompatibleRuntimePluginRegistryMock.mockReturnValue(undefined);
     loadOpenClawPluginsMock.mockReset();
     loadOpenClawPluginsMock
       .mockReturnValueOnce(gatewayRegistry)
@@ -3086,7 +3104,6 @@ describe("resolvePluginTools optional tools", () => {
 
   it("reuses a compatible active registry instead of loading again", () => {
     const activeRegistry = createOptionalDemoActiveRegistry();
-    resolveCompatibleRuntimePluginRegistryMock.mockReturnValue(activeRegistry);
 
     const tools = resolvePluginTools(
       createResolveToolsParams({
@@ -3095,13 +3112,13 @@ describe("resolvePluginTools optional tools", () => {
     );
 
     expectResolvedToolNames(tools, ["optional_tool"]);
+    expect(activeRegistryMocks.getLoadedRegistry).toHaveReturnedWith(activeRegistry);
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
   it("reuses the gateway-bindable registry when it covers the tool runtime scope", () => {
     const activeRegistry = createOptionalDemoActiveRegistry();
     setActivePluginRegistry(activeRegistry as never, "gateway-startup", "gateway-bindable", "/tmp");
-    resolveCompatibleRuntimePluginRegistryMock.mockReturnValue(activeRegistry);
 
     const tools = resolvePluginTools(
       createResolveToolsParams({
@@ -3111,7 +3128,8 @@ describe("resolvePluginTools optional tools", () => {
     );
 
     expectResolvedToolNames(tools, ["optional_tool"]);
-    expect(getLoadedRuntimePluginRegistryMock).toHaveBeenCalledOnce();
+    expect(activeRegistryMocks.getLoadedRegistry).toHaveBeenCalledOnce();
+    expect(activeRegistryMocks.getLoadedRegistry).toHaveReturnedWith(activeRegistry);
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
@@ -3139,7 +3157,6 @@ describe("resolvePluginTools optional tools", () => {
       diagnostics: [],
     };
     setActivePluginRegistry(activeRegistry as never, "gateway-startup", "gateway-bindable", "/tmp");
-    resolveCompatibleRuntimePluginRegistryMock.mockReturnValue(undefined);
     loadOpenClawPluginsMock.mockReturnValue(activeRegistry);
 
     const tools = resolvePluginTools(
@@ -3151,7 +3168,8 @@ describe("resolvePluginTools optional tools", () => {
 
     expectResolvedToolNames(tools, ["optional_tool"]);
     expect(heavyFactory).not.toHaveBeenCalled();
-    expect(getLoadedRuntimePluginRegistryMock).toHaveBeenCalledOnce();
+    expect(activeRegistryMocks.getLoadedRegistry).toHaveBeenCalledOnce();
+    expect(activeRegistryRequiredPluginIds()).toEqual(["optional-demo"]);
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
@@ -3198,7 +3216,6 @@ describe("resolvePluginTools optional tools", () => {
       diagnostics: [],
     };
     setActivePluginRegistry(activeRegistry as never, "gateway-startup", "gateway-bindable", "/tmp");
-    resolveCompatibleRuntimePluginRegistryMock.mockReturnValue(undefined);
     loadOpenClawPluginsMock.mockReturnValue(activeRegistry);
 
     const tools = resolvePluginTools(
@@ -3211,7 +3228,10 @@ describe("resolvePluginTools optional tools", () => {
 
     expectResolvedToolNames(tools, ["memory_search", "memory_get"]);
     expect(memorySearchFactory).toHaveBeenCalledTimes(1);
-    expect(getLoadedRuntimePluginRegistryMock).toHaveBeenCalledOnce();
+    expect(activeRegistryMocks.getLoadedRegistry).toHaveBeenCalledOnce();
+    // The disabled owner must never enter the runtime scope: asking the active
+    // registry for it would miss and force a pointless cold load.
+    expect(activeRegistryRequiredPluginIds()).toEqual(["memory-core"]);
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
@@ -3268,7 +3288,6 @@ describe("resolvePluginTools optional tools", () => {
       "gateway-bindable",
       "/tmp",
     );
-    resolveCompatibleRuntimePluginRegistryMock.mockReturnValue(undefined);
     loadOpenClawPluginsMock.mockReturnValue(loadedRegistry);
 
     const tools = resolvePluginTools(
@@ -3316,7 +3335,6 @@ describe("resolvePluginTools optional tools", () => {
       ],
     });
     setActivePluginRegistry(activeRegistry as never, "gateway-startup", "gateway-bindable", "/tmp");
-    resolveCompatibleRuntimePluginRegistryMock.mockReturnValue(activeRegistry);
     loadOpenClawPluginsMock.mockReturnValue(createToolRegistry([]));
 
     resolvePluginTools({
@@ -3327,7 +3345,7 @@ describe("resolvePluginTools optional tools", () => {
       toolAllowlist: ["*", "tavily"],
       allowGatewaySubagentBinding: true,
     });
-    expect(getLoadedRuntimePluginRegistryMock).toHaveBeenCalledOnce();
+    expect(activeRegistryMocks.getLoadedRegistry).toHaveBeenCalledOnce();
     const loaderParams = mockCallParams(loadOpenClawPluginsMock) as {
       onlyPluginIds?: string[];
       toolDiscovery?: unknown;


### PR DESCRIPTION
Related: #133584

## What Problem This Solves

Six mock setups in `src/plugins/tools.optional.test.ts` claimed to control which plugin registry tool resolution sees, and controlled nothing. Anyone changing plugin tool registry reuse would read those tests as covering the reuse-vs-rebuild decision, get a green run, and ship a regression the suite never looked at.

#133518 moved `resolveCompatibleRuntimePluginRegistry` out of `loader-runtime-registry.ts` into `active-runtime-registry.ts`, so `getLoadedRuntimePluginRegistry` now reaches it intra-module. The file's `vi.mock("./loader.js")` seam stopped observing it. #133584 repointed the four assertions that failed loudly, but the silent half stayed: a `mockImplementation` probe on `resolveCompatibleRuntimePluginRegistryMock` takes zero calls in this file, so every remaining `mockReturnValue` on it is inert.

Those tests passed only because each one also calls `setActivePluginRegistry`, and the real resolver quietly did the work. Green for a reason none of them asserted.

## Why This Change Was Made

Delete the dead scaffolding and drive the same states through the boundary `tools.ts` actually crosses.

The counting mock added in #133584 becomes the delegate rather than a side-channel counter, so the resolver's return value is observable. That lets the partial-root and stale-root tests assert that the active registry really was consulted and still rebuilt, instead of leaving it implicit. The disabled-owner test pins `requiredPluginIds` to the one owner allowed into the runtime scope, which is the invariant its name promises.

`./loader.js` keeps every binding its consumers import, as an explicit factory must — but the registry-resolution ones now delegate to their real owners (`active-runtime-registry.js`, `loader-cache.js`) instead of to a double no production path reaches. Only the load entry points stay intercepted.

## User Impact

None. Test-only; production is untouched and behavior is unchanged. Maintainers touching plugin tool registry reuse now get a suite that fails when they break it.

## Evidence

Production LOC delta 0. Test delta `56 insertions(+), 38 deletions(-)` in one file.

Each revised test was verified to fail when the invariant it names is broken — mutation applied to production, confirmed red, reverted:

| Mutation | Red |
| --- | --- |
| `resolvePluginToolRegistry` skips the active-registry consult | 22 tests, incl. every `toHaveReturnedWith` |
| scope check reads `registry.plugins` instead of `registry.tools` | the 4 tests whose overrides were removed |
| drop the disabled-entry guards in `resolvePluginToolRuntimePluginIds` **and** `manifest-owner-policy.ts` | disabled-owner test; `requiredPluginIds` becomes `["memory-core", "memory-lancedb"]` |
| re-consult the seam on the reuse branch | 3 of the 4 `toHaveBeenCalledOnce` tests |
| re-consult the seam on the cold-load branch | the 4th |

The disabled-owner case needs both guards dropped: each is independently sufficient, so a single-guard mutation stays green.

Local proof on this head:

- `node scripts/run-vitest.mjs src/plugins/tools.optional.test.ts` — 87/87
- the full `src/plugins` lane at six workers — 392 files, 6228 passed, 1 skipped
- `node scripts/check-changed.mjs` — exit 0
- Structured second-model review of the branch diff — clean, no accepted findings
