### PR TITLE
improve(ui): capitalize permission mode names

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -6051,7 +6051,7 @@ export const en: TranslationMap = {
       updateFailed: "Failed to update permissions: {error}",
       modes: {
         "read-only": {
-          label: "Read only",
+          label: "Read Only",
           description: "Read within the session root; writes and commands are blocked.",
         },
         guarded: {
@@ -6063,7 +6063,7 @@ export const en: TranslationMap = {
           description: "An AI reviewer checks requests beyond the session root.",
         },
         full: {
-          label: "Full access",
+          label: "Full Access",
           description: "No reviewer; files and commands are unrestricted.",
         },
       },

--- a/ui/src/pages/chat/chat-pane-session-controls.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.test.ts
@@ -130,10 +130,10 @@ describe("chat pane composer controls", () => {
 
   it.each([
     [undefined, "Default"],
-    ["read-only", "Default (Read only)"],
+    ["read-only", "Default (Read Only)"],
     ["guarded", "Default (Guarded)"],
     ["workspace", "Default (Workspace)"],
-    ["full", "Default (Full access)"],
+    ["full", "Default (Full Access)"],
   ] as const)(
     "labels inherited permissions for %s without selecting a mode",
     (defaultMode, label) => {
@@ -238,7 +238,7 @@ describe("chat pane composer controls", () => {
     expect(defaultOption?.textContent).toContain("Default (Guarded)");
     expect(
       container.querySelector('[data-chat-permission-select="true"]')?.textContent?.trim(),
-    ).toBe("Full access");
+    ).toBe("Full Access");
     expect(full?.hasAttribute("disabled")).toBe(true);
     expect(full?.getAttribute("aria-checked")).toBe("true");
     expect(full?.querySelector(".chat-controls__permission-shortcut")).toBeNull();


### PR DESCRIPTION
## What Problem This Solves

The Control UI permission picker presents the named modes as “Full access” and “Read only.” The maintainer-requested naming refinement is **Full Access** and **Read Only**, without changing general UI sentence case.

## Why This Change Was Made

Update the two canonical English mode labels. The shared picker already uses them for Chat and New Session, selected chips, menu options, accessible names, and inherited labels such as **Default (Full Access)**. No formatter or runtime policy change is needed.

Descriptions, generic prose, device-pairing labels, protocol values (`full`, `read-only`), and Default's configuration-inheritance semantics remain unchanged. Foreign translations remain owned by the post-merge locale refresh workflow.

## User Impact

Permission-mode names use consistent title case in the picker and composer. Selecting Default still clears the session override rather than granting the displayed mode.

## Evidence

- Owner: `ui/src/i18n/locales/en.ts`; shared formatter: `ui/src/pages/chat/components/chat-permission-picker.ts:53`.
- Callers: `ui/src/pages/chat/chat-pane-session-controls.ts` and `ui/src/pages/new-session/new-session-page.ts:583`.
- Personally inspected Codex upstream `codex-rs/utils/approval-presets/src/lib.rs:32` and `:52`: its named presets use Read Only and Full Access.
- Existing rendering tests cover inherited labels, accessible names, and the explicit full-access selection. Their expectations are updated; no duplicate tests or test-only production seams.
- Production LOC: +2/-2; tests: +3/-3. No added runtime logic, config, storage, or protocol changes.

### Local validation

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-session-controls.test.ts`: 25/25 pass. Before the label edits, the updated expectations failed in exactly three cases (the two inherited labels and explicit Full Access selection); the other 22 passed.
- `pnpm ui:i18n:baseline`: passed; no generated files changed.
- `pnpm ui:build`: passed, including finalized sidecar and startup-size checks.
- Real Chromium against the candidate Vite UI and a fresh loopback-only Gateway on a separate port: inspected the before/after menu and composer, selected Full Access then Read Only, and opened New Session's shared menu. No models or channels were used. The Gateway used the installed build in isolated temporary state; the UI was the candidate source, hence the expected server-update banner.
- Local screenshots inspected: `full-access-before.png`, `full-access-after.png`, `full-access-selected.png`, `full-access-new-session.png`. Attachment upload is blocked: installed gh has no `--attach`, and the configured CLI's binary-input protection rejects the user-attachments PNG upload (`string rewrite protection blocked unsafe input`). The guard was not bypassed. The documented Crabbox publishing fallback is also unavailable (`artifact_upload_unavailable`: artifact broker not configured). Screenshots remain available in the task's local proof files.
- Autoreview: trivial-copy exception (two label literals and three corresponding existing assertions; no logic change).

- `node scripts/check-changed.mjs -- ui/src/i18n/locales/en.ts ui/src/pages/chat/chat-pane-session-controls.test.ts`: initial process exited 137 during its broad Knip scan; all earlier guards and changed formatting passed. The independent rerun passed all three Knip scans with zero findings.
- Remaining UI checks passed independently: `pnpm lint:ui:i18n`, `pnpm tsgo:ui`, changed-file oxlint, and changed-file stylelint.
- `node scripts/report-test-temp-creations.mjs --base origin/main --head HEAD` and `pnpm lint:tmp:tsgo-core-boundary`: passed.
- `pnpm tsgo:core:test`: passed after the build-artifact lock cleared. All remaining constituents of the interrupted changed-check plan have now passed independently.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/33344220049 (in progress). Final check outcomes will be recorded before landing.
