### PR TITLE
perf(logging): reuse prepared diagnostic facts

### DIFF
--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -303,6 +303,15 @@ export function markDiagnosticOwnedToolActivity(
   }
 }
 
+function hasDiagnosticActivityOwner(activity: SessionActivity): boolean {
+  for (const registration of activeDiagnosticOwners.values()) {
+    if (registration.activity === activity) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function recordModelStarted(
   event: ModelStartedActivityEvent,
   provenance?: CoreModelRequestLifecycleProvenance,
@@ -322,13 +331,7 @@ function recordModelStarted(
   if (!activity) {
     return;
   }
-  if (
-    !provenance &&
-    !coreRequestForTest &&
-    [...activeDiagnosticOwners.values()].some(({ activity: ownerActivity }) =>
-      Object.is(ownerActivity, activity),
-    )
-  ) {
+  if (!provenance && !coreRequestForTest && hasDiagnosticActivityOwner(activity)) {
     return;
   }
   if (shouldIgnoreRecoveredOwnerStartEvent(activity, event)) {
@@ -372,12 +375,7 @@ function recordModelEnded(
   if (!activity) {
     return;
   }
-  if (
-    !provenance &&
-    [...activeDiagnosticOwners.values()].some(({ activity: ownerActivity }) =>
-      Object.is(ownerActivity, activity),
-    )
-  ) {
+  if (!provenance && hasDiagnosticActivityOwner(activity)) {
     activity.activeModelCalls.delete(modelCallKey(event));
     return;
   }
@@ -430,12 +428,10 @@ function recordRunCompleted(
   }
   activity.activeTools.clear();
   activity.activeModelCalls.clear();
-  const hasCoreOwner = [...activeDiagnosticOwners.values()].some(
-    ({ activity: ownerActivity, owner }) =>
-      ownerActivity === activity && owner.runId === event.runId,
-  );
-  if (hasCoreOwner) {
-    return;
+  for (const registration of activeDiagnosticOwners.values()) {
+    if (registration.activity === activity && registration.owner.runId === event.runId) {
+      return;
+    }
   }
   activityByRunId.delete(event.runId);
   if (activity.repeatedRequestOwnerRunId === event.runId) {

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -156,7 +156,11 @@ export function getDiagnosticSessionState(ref: SessionRef): SessionState {
   pruneDiagnosticSessionStates();
   const key = resolveSessionKey(ref);
   const direct = diagnosticSessionStates.get(key);
-  const sessionIdEntry = ref.sessionId ? findStateEntryBySessionId(ref.sessionId) : undefined;
+  // This owner merges id aliases before assigning them; an exact direct hit is already canonical.
+  const sessionIdEntry =
+    ref.sessionId && direct?.sessionId !== ref.sessionId
+      ? findStateEntryBySessionId(ref.sessionId)
+      : undefined;
   const existing = direct ?? sessionIdEntry?.[1];
   if (existing) {
     if (direct && sessionIdEntry && sessionIdEntry[1] !== direct) {

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -177,7 +177,8 @@ async function recoverStuckSession(
     });
 }
 
-function formatDiagnosticWorkLabel(
+function pushLimitedDiagnosticLabel(
+  labels: string[],
   state: {
     sessionId?: string;
     sessionKey?: string;
@@ -187,22 +188,22 @@ function formatDiagnosticWorkLabel(
     lastActivity: number;
   },
   now: number,
-): string {
+): void {
   const label = state.sessionKey ?? state.sessionId ?? "unknown";
   const ageSeconds = Math.round(Math.max(0, now - state.lastActivity) / 1000);
   const activity = getDiagnosticSessionActivitySnapshot(
     { sessionId: state.sessionId, sessionKey: state.sessionKey },
     now,
   );
+  // Activity lookup reconciles aliases even when the bounded label list is full.
+  if (labels.length >= 5) {
+    return;
+  }
   const workKind = activity.activeWorkKind ? `/${activity.activeWorkKind}` : "";
   const lastProgress = activity.lastProgressReason ? ` last=${activity.lastProgressReason}` : "";
-  return `${label}(${state.state}${workKind},q=${state.queueDepth},age=${ageSeconds}s${lastProgress})`;
-}
-
-function pushLimitedDiagnosticLabel(labels: string[], label: string, limit = 5): void {
-  if (labels.length < limit) {
-    labels.push(label);
-  }
+  labels.push(
+    `${label}(${state.state}${workKind},q=${state.queueDepth},age=${ageSeconds}s${lastProgress})`,
+  );
 }
 
 function resolveDiagnosticQueuedBacklog(state: {
@@ -227,14 +228,14 @@ function getDiagnosticWorkSnapshot(now = Date.now()): DiagnosticWorkSnapshot {
   for (const state of diagnosticSessionStates.values()) {
     if (state.state === "processing") {
       activeCount += 1;
-      pushLimitedDiagnosticLabel(activeLabels, formatDiagnosticWorkLabel(state, now));
+      pushLimitedDiagnosticLabel(activeLabels, state, now);
     } else if (state.state === "waiting") {
       waitingCount += 1;
-      pushLimitedDiagnosticLabel(waitingLabels, formatDiagnosticWorkLabel(state, now));
+      pushLimitedDiagnosticLabel(waitingLabels, state, now);
     }
     const queuedBacklog = resolveDiagnosticQueuedBacklog(state);
     if (queuedBacklog > 0) {
-      pushLimitedDiagnosticLabel(queuedLabels, formatDiagnosticWorkLabel(state, now));
+      pushLimitedDiagnosticLabel(queuedLabels, state, now);
     }
     queuedCount += queuedBacklog;
   }


### PR DESCRIPTION
Diagnostic bookkeeping repeated work even when its owner already had the needed facts: an exact session key/id match still scanned all states, bounded labels formatted strings that were discarded, and model/run handlers copied every owner registration before looking for a match.

This keeps preparation at the existing owners. Exact canonical identity hits reuse the direct lookup; changed-id and alias paths retain the existing merge flow. Label construction moves behind the five-label cap, while every activity lookup still runs in the original order because it reconciles aliases. Owner checks iterate the authoritative Map directly, and run completion still requires the exact run id as well as activity identity. There is no new cache, index, configuration, public API, protocol, storage, or authorization policy. The old formatting helper and temporary owner arrays are removed.

These are three measured mechanisms. Production is +33/−32 lines (net +1); tests are unchanged. The final production ASTs match the measured proposals after formatting. The one-line increase retains an explicit canonical-identity invariant and ordinary loops compatible with the repository's TypeScript target.

All 130 existing diagnostic, activity, core model-request, loop-admission, and command-poll tests passed on baseline and candidate. Full `pnpm check:changed` passed, including production/test typechecks, lint, Knip, database guards and zero runtime import cycles. Independent source review and managed review found no actionable defects. The first baseline invocation named a nonexistent test path; that failed invocation is retained separately from the corrected successful run.

The saved complete-owner differential corpus passed 1,208 scenarios and 4,832 comparisons, plus 180,000 producer-invariant checks. A reviewer-requested supplement adds 24 shared-owner/alias scenarios and 96 comparisons, covering different run ids sharing one activity, exact-owner closure and later completion. Existing shared-activity completion behavior is preserved; this does not claim to repair broader completion cleanup.

Ten fresh forward/reverse timing processes cover 73 fixed workloads, 6,570 raw samples and 730 independently recomputed medians. At 64/512 states, a last exact identity lookup drops from roughly 0.34/2.67 µs to 0.015 µs by avoiding the scan. ID-only lookup retains its existing scan. Larger bounded-label snapshots take roughly 9–17% less elapsed time; owner event processing improves at 64/512 registrations. All empty, small, ID-only and completion-miss costs remain in the evidence rather than being omitted.

Measurements cover the complete local state, snapshot and event owners with declared unrelated configuration/logger/runtime boundaries, not whole-Gateway, live-provider, heartbeat, recovery or memory performance. Current-main source checks find the same relevant owners and dependencies; the only broad manifest drift is the already-reviewed fast-uri lockfile update, which is outside this compiled graph. Existing documentation and operator-visible behavior remain unchanged.
