### PR TITLE
fix(cron): preserve complete JSON when run output is piped

### DIFF
--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -169,7 +169,7 @@ Add `--wait` when a script should block until that exact queued run records a te
 openclaw automations run <job-id> --wait --wait-timeout 10m --poll-interval 2s
 ```
 
-With `--wait`, the CLI calls `cron.run` first, then polls the durable `cron.runs` row for the returned `runId`; it does not reread mutable job delivery settings. JSON reports payload execution as `status` and whole-run completion as `completionStatus`. The command exits `0` only for `completionStatus: "succeeded"`; `failed`, `unknown`, execution errors/skips, a missing `runId`, and timeout expiry exit non-zero (default `10m`, polled every `2s` by default). `--poll-interval` must be greater than zero.
+With `--wait`, the CLI calls `cron.run` first, then polls the durable `cron.runs` row for the returned `runId`; it does not reread mutable job delivery settings. JSON reports payload execution as `status` and whole-run completion as `completionStatus`. The command exits `0` only for `completionStatus: "succeeded"`; `failed`, `unknown`, execution errors/skips, a missing `runId`, and timeout expiry exit non-zero (default `10m`, polled every `2s` by default). `--poll-interval` must be greater than zero. Completed JSON output, including the run summary, is flushed before the command exits, so it can be piped to a JSON reader.
 
 <Note>
 Use `--due` when you want the manual command to run only if the job is currently due. If `--due --wait` does not enqueue a run, the command returns the normal non-run response instead of polling.

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -2,6 +2,7 @@
 import { Command } from "commander";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CronJob } from "../cron/types.js";
+import { ExitError } from "../runtime.js";
 import { registerCronCli } from "./cron-cli.js";
 
 const CRON_CLI_TEST_TIMEOUT_MS = 15_000;
@@ -64,7 +65,8 @@ vi.mock("./gateway-rpc.js", async () => {
   };
 });
 
-vi.mock("../runtime.js", () => ({
+vi.mock("../runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../runtime.js")>()),
   defaultRuntime: mocks.defaultRuntime,
 }));
 
@@ -240,7 +242,7 @@ async function runNamedCronAdd(name: string, ...args: string[]): Promise<void> {
 }
 
 async function expectCronCommandExit(args: string[]): Promise<void> {
-  await expect(runCronCommand(args)).rejects.toThrow("__exit__:1");
+  await expect(runCronCommand(args)).rejects.toMatchObject({ name: "ExitError", code: 1 });
 }
 
 async function runCronEditAndGetPatch(editArgs: string[]): Promise<CronUpdatePatch> {
@@ -305,7 +307,7 @@ async function expectCronEditWithScheduleLookupExit(
   const program = buildProgram();
   await expect(
     program.parseAsync(["cron", "edit", "job-1", ...editArgs], { from: "user" }),
-  ).rejects.toThrow("__exit__:1");
+  ).rejects.toMatchObject({ name: "ExitError", code: 1 });
 }
 
 async function runCronRunAndCaptureExit(params: {
@@ -354,19 +356,20 @@ async function runCronRunAndCaptureExit(params: {
     },
   );
 
-  const runtime = defaultRuntime as { exit: (code: number) => void };
-  const originalExit = runtime.exit;
-  const exitSpy = vi.fn();
-  runtime.exit = exitSpy;
+  let exitCode: number | undefined;
   try {
     const program = buildProgram();
     await program.parseAsync(params.args ?? ["cron", "run", "job-1"], { from: "user" });
-  } finally {
-    runtime.exit = originalExit;
+  } catch (error) {
+    if (!(error instanceof ExitError)) {
+      throw error;
+    }
+    exitCode = error.code;
   }
+  expect(defaultRuntime.error).not.toHaveBeenCalled();
   const runCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.run");
   return {
-    exitSpy,
+    exitCode,
     runOpts: (runCall?.[1] ?? {}) as { timeout?: string },
     calls: callGatewayFromCli.mock.calls,
   };
@@ -390,14 +393,14 @@ describe("cron cli", () => {
   );
 
   it("uses legacy stored delivery for --wait completion", async () => {
-    const { calls, exitSpy } = await runCronRunAndCaptureExit({
+    const { calls, exitCode } = await runCronRunAndCaptureExit({
       enqueued: true,
       runId: "manual:legacy:123:0",
       runStatus: "ok",
       args: ["cron", "run", "job-1", "--wait", "--wait-timeout", "1s", "--poll-interval", "1ms"],
     });
 
-    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(exitCode).toBe(0);
     expect(calls.some((call) => call[0] === "cron.get")).toBe(false);
   });
 
@@ -472,8 +475,8 @@ describe("cron cli", () => {
       expectedExitCode: 1,
     },
   ])("$name", async ({ ran, enqueued, expectedExitCode }) => {
-    const { exitSpy } = await runCronRunAndCaptureExit({ ran, enqueued });
-    expect(exitSpy).toHaveBeenCalledWith(expectedExitCode);
+    const { exitCode } = await runCronRunAndCaptureExit({ ran, enqueued });
+    expect(exitCode).toBe(expectedExitCode);
   });
 
   it.each([
@@ -483,7 +486,7 @@ describe("cron cli", () => {
   ])(
     "waits for execution $status with completion $completionStatus",
     async ({ status, completionStatus, expectedExitCode }) => {
-      const { calls, exitSpy } = await runCronRunAndCaptureExit({
+      const { calls, exitCode } = await runCronRunAndCaptureExit({
         enqueued: true,
         runId: "manual:job-1:123:0",
         runStatus: status,
@@ -491,7 +494,7 @@ describe("cron cli", () => {
         args: ["cron", "run", "job-1", "--wait", "--wait-timeout", "1s", "--poll-interval", "1ms"],
       });
 
-      expect(exitSpy).toHaveBeenCalledWith(expectedExitCode);
+      expect(exitCode).toBe(expectedExitCode);
       const runsCall = calls.find((call) => call[0] === "cron.runs");
       expect(runsCall?.[2]).toMatchObject({
         id: "job-1",
@@ -526,7 +529,10 @@ describe("cron cli", () => {
     );
 
     const program = buildProgram();
-    await expect(program.parseAsync(args, { from: "user" })).rejects.toThrow("__exit__:1");
+    await expect(program.parseAsync(args, { from: "user" })).rejects.toMatchObject({
+      name: "ExitError",
+      code: 1,
+    });
 
     expectRuntimeErrorContaining(
       "Automation not found: missing. Run `openclaw cron list` to see recent automation ids.",
@@ -590,7 +596,7 @@ describe("cron cli", () => {
   ])(
     "$name",
     async ({ waitTimeout, rpcTimeout, expectedEnqueueTimeout, expectedMaxPollTimeoutMs }) => {
-      const { calls, exitSpy, runOpts } = await runCronRunAndCaptureExit({
+      const { calls, exitCode, runOpts } = await runCronRunAndCaptureExit({
         enqueued: true,
         runId: "manual:job-1:123:0",
         runStatus: "ok",
@@ -611,7 +617,7 @@ describe("cron cli", () => {
       const historyOptions = historyCalls[0]?.[1] as { timeout?: string } | undefined;
       const pollTimeoutMs = Number(historyOptions?.timeout);
 
-      expect(exitSpy).toHaveBeenCalledWith(0);
+      expect(exitCode).toBe(0);
       expect(historyCalls).toHaveLength(1);
       expect(runOpts.timeout).toBe(expectedEnqueueTimeout);
       expect(Number.isSafeInteger(pollTimeoutMs)).toBe(true);
@@ -657,12 +663,12 @@ describe("cron cli", () => {
     vi.setSystemTime(new Date(startedAt.getTime() + clockJumpMs));
     await vi.advanceTimersByTimeAsync(25);
 
-    const { calls, exitSpy, runOpts } = await pendingRun;
+    const { calls, exitCode, runOpts } = await pendingRun;
     const pollTimeouts = calls
       .filter(([method]) => method === "cron.runs")
       .map(([, options]) => Number((options as { timeout?: string }).timeout));
 
-    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(exitCode).toBe(0);
     expect(runOpts.timeout).toBe("600000");
     expect(pollTimeouts).toHaveLength(2);
     expect(pollTimeouts.every(Number.isSafeInteger)).toBe(true);
@@ -723,7 +729,7 @@ describe("cron cli", () => {
       expect(callGatewayFromCli.mock.calls.some((call) => call[0] === "cron.runs")).toBe(true);
     });
 
-    const rejection = expect(run).rejects.toThrow("__exit__:1");
+    const rejection = expect(run).rejects.toMatchObject({ name: "ExitError", code: 1 });
     await vi.advanceTimersByTimeAsync(10);
     await rejection;
     expectRuntimeErrorContaining("timed out waiting for cron run");
@@ -2263,7 +2269,7 @@ describe("cron cli", () => {
         ],
         { from: "user" },
       ),
-    ).rejects.toThrow("__exit__:1");
+    ).rejects.toMatchObject({ name: "ExitError", code: 1 });
     expectRuntimeErrorContaining("Use either --failure-alert-include-skipped");
     expect(callGatewayFromCli).not.toHaveBeenCalled();
   });

--- a/src/cli/cron-cli/cron-pagination.gateway.test.ts
+++ b/src/cli/cron-cli/cron-pagination.gateway.test.ts
@@ -30,7 +30,10 @@ vi.mock("../gateway-rpc.js", async () => {
   };
 });
 
-vi.mock("../../runtime.js", () => ({ defaultRuntime: mocks.runtime }));
+vi.mock("../../runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../runtime.js")>()),
+  defaultRuntime: mocks.runtime,
+}));
 
 const { registerCronCli } = await import("../cron-cli.js");
 

--- a/src/cli/cron-cli/cron-suppression.gateway.test.ts
+++ b/src/cli/cron-cli/cron-suppression.gateway.test.ts
@@ -16,6 +16,7 @@ import type { CronJob } from "../../cron/types.js";
 import { cronHandlers } from "../../gateway/server-methods/cron.js";
 import type { RespondFn } from "../../gateway/server-methods/types.js";
 import { getActiveGatewayRootWorkCount } from "../../process/gateway-work-admission.js";
+import { ExitError } from "../../runtime.js";
 import { resetTaskRegistryForTests } from "../../tasks/task-runtime.test-helpers.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 
@@ -48,12 +49,20 @@ async function runCli(args: string[]) {
   const program = new Command();
   program.exitOverride();
   registerCronCli(program);
-  await program.parseAsync(["cron", ...args], { from: "user" });
+  let exitCode: number | undefined;
+  try {
+    await program.parseAsync(["cron", ...args], { from: "user" });
+  } catch (error) {
+    if (!(error instanceof ExitError)) {
+      throw error;
+    }
+    exitCode = error.code;
+  }
   expect(mocks.runtime.error).not.toHaveBeenCalled();
   return {
     text: mocks.runtime.log.mock.calls.map(([line]) => String(line)).join("\n"),
     json: mocks.runtime.writeJson.mock.calls.at(-1)?.[0],
-    exitCode: mocks.runtime.exit.mock.calls.at(-1)?.[0],
+    exitCode,
   };
 }
 

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -28,17 +28,16 @@ function createCronProgram(): Command {
 
 async function expectCronEditRejection(args: string[], message: string): Promise<void> {
   const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-  const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
 
   try {
-    await createCronProgram().parseAsync(["edit", "job-1", ...args], { from: "user" });
+    await expect(
+      createCronProgram().parseAsync(["edit", "job-1", ...args], { from: "user" }),
+    ).rejects.toMatchObject({ name: "ExitError", code: 1 });
 
     expect(errorSpy).toHaveBeenCalledExactlyOnceWith(expect.stringContaining(message));
-    expect(exitSpy).toHaveBeenCalledExactlyOnceWith(1);
     expect(callGatewayFromCli).not.toHaveBeenCalled();
   } finally {
     errorSpy.mockRestore();
-    exitSpy.mockRestore();
   }
 }
 
@@ -74,7 +73,6 @@ describe("cron edit command", () => {
 
   it("rethrows contradictory options in JSON mode without accessing the Gateway", async () => {
     const originalArgv = process.argv;
-    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
     process.argv = ["node", "openclaw", "cron", "edit", "job-1", "--json"];
     try {
       await expect(
@@ -85,7 +83,6 @@ describe("cron edit command", () => {
       expect(callGatewayFromCli).not.toHaveBeenCalled();
     } finally {
       process.argv = originalArgv;
-      exitSpy.mockRestore();
     }
   });
 
@@ -248,13 +245,14 @@ describe("cron edit command", () => {
 
   it.each(["read", ""])("rejects --tools %j combined with --clear-tools", async (tools) => {
     const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
 
     try {
-      await createCronProgram().parseAsync(
-        ["edit", "job-1", "--pacing-min", "30m", "--tools", tools, "--clear-tools"],
-        { from: "user" },
-      );
+      await expect(
+        createCronProgram().parseAsync(
+          ["edit", "job-1", "--pacing-min", "30m", "--tools", tools, "--clear-tools"],
+          { from: "user" },
+        ),
+      ).rejects.toMatchObject({ name: "ExitError", code: 1 });
 
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining("Use --tools or --clear-tools, not both"),
@@ -262,7 +260,6 @@ describe("cron edit command", () => {
       expect(callGatewayFromCli).not.toHaveBeenCalled();
     } finally {
       errorSpy.mockRestore();
-      exitSpy.mockRestore();
     }
   });
 
@@ -540,14 +537,13 @@ describe("cron edit command", () => {
         return { ok: true };
       });
       const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-      const exitSpy = vi
-        .spyOn(defaultRuntime, "exit")
-        .mockImplementation((() => undefined) as never);
 
       try {
-        await createCronProgram().parseAsync(["edit", "job-1", "--timeout-seconds", "12"], {
-          from: "user",
-        });
+        await expect(
+          createCronProgram().parseAsync(["edit", "job-1", "--timeout-seconds", "12"], {
+            from: "user",
+          }),
+        ).rejects.toMatchObject({ name: "ExitError", code: 1 });
 
         expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(error));
         expect(callGatewayFromCli).toHaveBeenCalledWith("cron.get", expect.anything(), {
@@ -558,20 +554,20 @@ describe("cron edit command", () => {
         );
       } finally {
         errorSpy.mockRestore();
-        exitSpy.mockRestore();
       }
     },
   );
 
   it("rejects generic timeout combined with an explicit systemEvent before cron.update", async () => {
     const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
 
     try {
-      await createCronProgram().parseAsync(
-        ["edit", "job-1", "--system-event", "hello", "--timeout-seconds", "12"],
-        { from: "user" },
-      );
+      await expect(
+        createCronProgram().parseAsync(
+          ["edit", "job-1", "--system-event", "hello", "--timeout-seconds", "12"],
+          { from: "user" },
+        ),
+      ).rejects.toMatchObject({ name: "ExitError", code: 1 });
 
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining("--timeout-seconds is not supported for systemEvent jobs"),
@@ -581,7 +577,6 @@ describe("cron edit command", () => {
       );
     } finally {
       errorSpy.mockRestore();
-      exitSpy.mockRestore();
     }
   });
 
@@ -593,15 +588,14 @@ describe("cron edit command", () => {
     "rejects generic timeout combined with script option %s before cron.update",
     async (flag, value) => {
       const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-      const exitSpy = vi
-        .spyOn(defaultRuntime, "exit")
-        .mockImplementation((() => undefined) as never);
 
       try {
-        await createCronProgram().parseAsync(
-          ["edit", "job-1", "--timeout-seconds", "12", flag, value],
-          { from: "user" },
-        );
+        await expect(
+          createCronProgram().parseAsync(
+            ["edit", "job-1", "--timeout-seconds", "12", flag, value],
+            { from: "user" },
+          ),
+        ).rejects.toMatchObject({ name: "ExitError", code: 1 });
 
         expect(errorSpy).toHaveBeenCalledWith(
           expect.stringContaining("Use --script-timeout-seconds for script jobs"),
@@ -611,7 +605,6 @@ describe("cron edit command", () => {
         );
       } finally {
         errorSpy.mockRestore();
-        exitSpy.mockRestore();
       }
     },
   );
@@ -904,15 +897,14 @@ describe("cron edit command", () => {
     "rejects invalid failure alert cooldown %s",
     async (duration) => {
       const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-      const exitSpy = vi
-        .spyOn(defaultRuntime, "exit")
-        .mockImplementation((() => undefined) as never);
       const program = createCronProgram();
 
       try {
-        await program.parseAsync(["edit", "job-1", "--failure-alert-cooldown", duration], {
-          from: "user",
-        });
+        await expect(
+          program.parseAsync(["edit", "job-1", "--failure-alert-cooldown", duration], {
+            from: "user",
+          }),
+        ).rejects.toMatchObject({ name: "ExitError", code: 1 });
 
         expect(errorSpy).toHaveBeenCalledWith(
           expect.stringContaining("Invalid --failure-alert-cooldown."),
@@ -920,7 +912,6 @@ describe("cron edit command", () => {
         expect(callGatewayFromCli).not.toHaveBeenCalled();
       } finally {
         errorSpy.mockRestore();
-        exitSpy.mockRestore();
       }
     },
   );
@@ -947,12 +938,13 @@ describe("cron edit command", () => {
 
   it("rejects combining --thinking with --clear-thinking", async () => {
     const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
     const program = createCronProgram();
 
-    await program.parseAsync(["edit", "job-1", "--thinking", "high", "--clear-thinking"], {
-      from: "user",
-    });
+    await expect(
+      program.parseAsync(["edit", "job-1", "--thinking", "high", "--clear-thinking"], {
+        from: "user",
+      }),
+    ).rejects.toMatchObject({ name: "ExitError", code: 1 });
 
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining("Use --thinking or --clear-thinking, not both"),
@@ -960,7 +952,6 @@ describe("cron edit command", () => {
     expect(callGatewayFromCli).not.toHaveBeenCalled();
 
     errorSpy.mockRestore();
-    exitSpy.mockRestore();
   });
 
   it("documents the --clear-model flag alongside the sibling --clear-tools", () => {
@@ -1039,10 +1030,11 @@ describe("cron edit command", () => {
     { set: "--account", value: "writer", clear: "--clear-account" },
   ])("rejects $set combined with $clear", async ({ set, value, clear }) => {
     const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
     const program = createCronProgram();
 
-    await program.parseAsync(["edit", "job-1", set, value, clear], { from: "user" });
+    await expect(
+      program.parseAsync(["edit", "job-1", set, value, clear], { from: "user" }),
+    ).rejects.toMatchObject({ name: "ExitError", code: 1 });
 
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining(`Use ${set} or ${clear}, not both`),
@@ -1050,7 +1042,6 @@ describe("cron edit command", () => {
     expect(callGatewayFromCli).not.toHaveBeenCalled();
 
     errorSpy.mockRestore();
-    exitSpy.mockRestore();
   });
 
   it.each(["", "   "])("rejects blank --command-cwd %j", async (value) => {
@@ -1077,13 +1068,14 @@ describe("cron edit command", () => {
 
   it("rejects --webhook combined with a delivery clear flag", async () => {
     const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
     const program = createCronProgram();
 
-    await program.parseAsync(
-      ["edit", "job-1", "--webhook", "https://example.invalid/hook", "--clear-channel"],
-      { from: "user" },
-    );
+    await expect(
+      program.parseAsync(
+        ["edit", "job-1", "--webhook", "https://example.invalid/hook", "--clear-channel"],
+        { from: "user" },
+      ),
+    ).rejects.toMatchObject({ name: "ExitError", code: 1 });
 
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining("--webhook cannot be combined with chat delivery options."),
@@ -1091,7 +1083,6 @@ describe("cron edit command", () => {
     expect(callGatewayFromCli).not.toHaveBeenCalled();
 
     errorSpy.mockRestore();
-    exitSpy.mockRestore();
   });
 
   it.each(["", "not-a-url"])("rejects invalid --webhook %j before gateway RPC", async (value) => {
@@ -1115,13 +1106,14 @@ describe("cron edit command", () => {
     ["--thread-id", "42"],
   ])("rejects explicit chat delivery %s on main systemEvent cron edit", async (flag, value) => {
     const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
     const program = createCronProgram();
 
-    await program.parseAsync(
-      ["edit", "job-1", "--session", "main", "--system-event", "wakeup", flag, value],
-      { from: "user" },
-    );
+    await expect(
+      program.parseAsync(
+        ["edit", "job-1", "--session", "main", "--system-event", "wakeup", flag, value],
+        { from: "user" },
+      ),
+    ).rejects.toMatchObject({ name: "ExitError", code: 1 });
 
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining(
@@ -1131,6 +1123,5 @@ describe("cron edit command", () => {
     expect(callGatewayFromCli).not.toHaveBeenCalled();
 
     errorSpy.mockRestore();
-    exitSpy.mockRestore();
   });
 });

--- a/src/cli/cron-cli/register.cron-options.test.ts
+++ b/src/cli/cron-cli/register.cron-options.test.ts
@@ -74,15 +74,14 @@ describe("shared automation mutation options", () => {
     [["--on-exit", "./watch.sh", "--every", "5m"], "Choose at most one schedule change"],
   ])("rejects invalid exit-triggered schedule options", async (args, message) => {
     const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
     try {
-      await createMutationProgram().parseAsync(["edit", "job-1", ...args], { from: "user" });
+      await expect(
+        createMutationProgram().parseAsync(["edit", "job-1", ...args], { from: "user" }),
+      ).rejects.toMatchObject({ name: "ExitError", code: 1 });
       expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(message));
-      expect(exitSpy).toHaveBeenCalledWith(1);
       expect(callGatewayFromCli).not.toHaveBeenCalled();
     } finally {
       errorSpy.mockRestore();
-      exitSpy.mockRestore();
     }
   });
 
@@ -98,19 +97,18 @@ describe("shared automation mutation options", () => {
     "rejects blank thread id $threadId before automation $operation",
     async ({ args, threadId }) => {
       const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-      const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
       try {
-        await createMutationProgram().parseAsync([...args, "--thread-id", threadId], {
-          from: "user",
-        });
+        await expect(
+          createMutationProgram().parseAsync([...args, "--thread-id", threadId], {
+            from: "user",
+          }),
+        ).rejects.toMatchObject({ name: "ExitError", code: 1 });
         expect(errorSpy).toHaveBeenCalledWith(
           expect.stringContaining("--thread-id must be a positive integer"),
         );
-        expect(exitSpy).toHaveBeenCalledWith(1);
         expect(callGatewayFromCli).not.toHaveBeenCalled();
       } finally {
         errorSpy.mockRestore();
-        exitSpy.mockRestore();
       }
     },
   );
@@ -141,31 +139,30 @@ describe("shared automation mutation options", () => {
     "rejects invalid thread id %j before loading an automation for a combined edit",
     async (threadId) => {
       const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-      const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
       try {
-        await createMutationProgram().parseAsync(
-          [
-            "edit",
-            "job-1",
-            "--pacing-min",
-            "30m",
-            "--channel",
-            "telegram",
-            "--to",
-            "group-123",
-            "--thread-id",
-            threadId,
-          ],
-          { from: "user" },
-        );
+        await expect(
+          createMutationProgram().parseAsync(
+            [
+              "edit",
+              "job-1",
+              "--pacing-min",
+              "30m",
+              "--channel",
+              "telegram",
+              "--to",
+              "group-123",
+              "--thread-id",
+              threadId,
+            ],
+            { from: "user" },
+          ),
+        ).rejects.toMatchObject({ name: "ExitError", code: 1 });
         expect(errorSpy).toHaveBeenCalledWith(
           expect.stringContaining("--thread-id must be a positive integer"),
         );
-        expect(exitSpy).toHaveBeenCalledWith(1);
         expect(callGatewayFromCli).not.toHaveBeenCalled();
       } finally {
         errorSpy.mockRestore();
-        exitSpy.mockRestore();
       }
     },
   );

--- a/src/cli/cron-cli/register.cron-scratch.test.ts
+++ b/src/cli/cron-cli/register.cron-scratch.test.ts
@@ -74,15 +74,14 @@ describe("cron scratch command", () => {
     "rejects non-decimal --expected-revision %j",
     async (revision) => {
       const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-      const exitSpy = vi
-        .spyOn(defaultRuntime, "exit")
-        .mockImplementation((() => undefined) as never);
 
       try {
-        await createCronProgram().parseAsync(
-          ["scratch", "job-1", "--set", "x", "--expected-revision", revision],
-          { from: "user" },
-        );
+        await expect(
+          createCronProgram().parseAsync(
+            ["scratch", "job-1", "--set", "x", "--expected-revision", revision],
+            { from: "user" },
+          ),
+        ).rejects.toMatchObject({ name: "ExitError", code: 1 });
 
         expect(errorSpy).toHaveBeenCalledWith(
           expect.stringContaining("--expected-revision must be a non-negative integer"),
@@ -93,7 +92,6 @@ describe("cron scratch command", () => {
         expect(setCalls).toHaveLength(0);
       } finally {
         errorSpy.mockRestore();
-        exitSpy.mockRestore();
       }
     },
   );

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -11,6 +11,7 @@ import { defaultRuntime } from "../../runtime.js";
 import { sleep } from "../../utils/sleep.js";
 import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
+import { exitCliAfterOutput } from "../one-shot-exit.js";
 import { parseDurationMs } from "../parse-duration.js";
 import { parseTimeoutMs } from "../parse-timeout.js";
 import { findCronJobByIdOrName } from "./list-jobs.js";
@@ -33,11 +34,6 @@ type CronRunCommandResult = {
   enqueued?: boolean;
   runId?: string;
 };
-
-type CronRunLogEntryResult = Pick<
-  CronRunLogEntry,
-  "status" | "completionStatus" | "delivered" | "deliveryStatus"
->;
 
 function parseCronRunWaitDuration(raw: unknown, label: string): number {
   const input =
@@ -65,7 +61,7 @@ async function waitForCronRunCompletion(params: {
   runId: string;
   timeoutMs: number;
   pollIntervalMs: number;
-}): Promise<CronRunLogEntryResult> {
+}): Promise<CronRunLogEntry> {
   // Poll the task ledger rather than cron.run because completion state is written asynchronously.
   const startedAt = performance.now();
   let hasPolled = false;
@@ -86,7 +82,7 @@ async function waitForCronRunCompletion(params: {
       id: params.jobId,
       runId: params.runId,
       limit: 1,
-    })) as { entries?: CronRunLogEntryResult[] };
+    })) as { entries?: CronRunLogEntry[] };
     const entry = page.entries?.[0];
     if (entry?.status === "ok" || entry?.status === "error" || entry?.status === "skipped") {
       return entry;
@@ -282,11 +278,10 @@ export function registerCronSimpleCommands(cron: Command) {
               completionStatus,
               run: completedRun,
             });
-            defaultRuntime.exit(completionStatus === "succeeded" ? 0 : 1);
-            return;
+            exitCliAfterOutput(defaultRuntime, completionStatus === "succeeded" ? 0 : 1);
           }
           printCronJson(res);
-          defaultRuntime.exit(result?.ok && (result?.ran || result?.enqueued) ? 0 : 1);
+          exitCliAfterOutput(defaultRuntime, result?.ok && (result.ran || result.enqueued) ? 0 : 1);
         } catch (err) {
           handleCronCliError(err);
         }

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -21,12 +21,13 @@ import {
   parseOffsetlessIsoDateTimeInTimeZone,
 } from "../../infra/format-time/parse-offsetless-zoned-datetime.js";
 import { formatTimestamp } from "../../logging/timestamps.js";
-import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
+import { defaultRuntime, ExitError, type RuntimeEnv } from "../../runtime.js";
 import { formatLookupMiss } from "../error-format.js";
 import { rethrowExpectedCliError } from "../failure-output.js";
 import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import { callGatewayFromCli } from "../gateway-rpc.js";
 import { isJsonOutputModeActive } from "../json-output-mode.js";
+import { exitCliAfterOutput } from "../one-shot-exit.js";
 import { parseDurationMs as parseSharedDurationMs } from "../parse-duration.js";
 
 function parseCronArgv(value: unknown, flag: string): string[] | undefined {
@@ -228,6 +229,10 @@ function formatCronStatusForDisplay(job: CronJob) {
 }
 
 export function handleCronCliError(err: unknown) {
+  // Completed outcomes must reach CLI cleanup, not become new cron errors.
+  if (err instanceof ExitError) {
+    throw err;
+  }
   rethrowExpectedCliError(err);
   const missingJob = readCronJobNotFoundError(err);
   const message = missingJob ? formatCronLookupMiss(missingJob.jobId) : formatErrorMessage(err);
@@ -235,7 +240,7 @@ export function handleCronCliError(err: unknown) {
     throw missingJob ? new Error(message) : err;
   }
   defaultRuntime.error(danger(message));
-  defaultRuntime.exit(1);
+  exitCliAfterOutput(defaultRuntime, 1);
 }
 
 export const formatCronLookupMiss = (jobId: string) =>

--- a/src/cli/cron-cli/trigger-options.test.ts
+++ b/src/cli/cron-cli/trigger-options.test.ts
@@ -86,9 +86,6 @@ describe("cron trigger CLI options", () => {
     const program = new Command().exitOverride();
     registerCronAddCommand(program);
     const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((code) => {
-      throw new Error(`exit:${code}`);
-    });
 
     try {
       await expect(
@@ -108,7 +105,7 @@ describe("cron trigger CLI options", () => {
           ],
           { from: "user" },
         ),
-      ).rejects.toThrow("exit:1");
+      ).rejects.toMatchObject({ name: "ExitError", code: 1 });
 
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining("--trigger-script must not be blank"),
@@ -116,7 +113,6 @@ describe("cron trigger CLI options", () => {
       expect(callGatewayFromCli).not.toHaveBeenCalled();
     } finally {
       errorSpy.mockRestore();
-      exitSpy.mockRestore();
     }
   });
 
@@ -176,9 +172,6 @@ describe("cron trigger CLI options", () => {
     const program = new Command().exitOverride();
     registerCronAddCommand(program);
     const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((code) => {
-      throw new Error(`exit:${code}`);
-    });
 
     try {
       await expect(
@@ -186,7 +179,7 @@ describe("cron trigger CLI options", () => {
           ["add", "--name", "script job", "--every", "30s", "--script", scriptPath, ...args],
           { from: "user" },
         ),
-      ).rejects.toThrow("exit:1");
+      ).rejects.toMatchObject({ name: "ExitError", code: 1 });
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining(
           "Use --script-timeout-seconds for script jobs, not --timeout-seconds.",
@@ -195,7 +188,6 @@ describe("cron trigger CLI options", () => {
       expect(callGatewayFromCli).not.toHaveBeenCalled();
     } finally {
       errorSpy.mockRestore();
-      exitSpy.mockRestore();
     }
   });
 
@@ -291,9 +283,6 @@ describe("cron trigger CLI options", () => {
     const program = new Command().exitOverride();
     registerCronAddCommand(program);
     const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((code) => {
-      throw new Error(`exit:${code}`);
-    });
 
     try {
       await expect(
@@ -313,7 +302,7 @@ describe("cron trigger CLI options", () => {
           ],
           { from: "user" },
         ),
-      ).rejects.toThrow("exit:1");
+      ).rejects.toMatchObject({ name: "ExitError", code: 1 });
 
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining("Trigger script exceeds 65536 bytes"),
@@ -321,7 +310,6 @@ describe("cron trigger CLI options", () => {
       expect(callGatewayFromCli).not.toHaveBeenCalled();
     } finally {
       errorSpy.mockRestore();
-      exitSpy.mockRestore();
     }
   });
 

--- a/src/cli/cron-output.process.test.ts
+++ b/src/cli/cron-output.process.test.ts
@@ -1,0 +1,134 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { spawnNodeEvalSync } from "../test-utils/node-process.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const summaryBytes = 128 * 1024;
+const sentinel = "\nEND-CRON-SUMMARY\n";
+const summary = "x".repeat(summaryBytes - sentinel.length) + sentinel;
+
+describe("cron process output", () => {
+  it.each([
+    { name: "wait success", args: ["run", "job-1", "--wait"], exitCode: 0, kind: "wait" },
+    {
+      name: "wait failure",
+      args: ["run", "job-1", "--wait", "--json"],
+      exitCode: 1,
+      kind: "wait",
+    },
+    { name: "queued run", args: ["run", "job-1"], exitCode: 0, kind: "admission" },
+    { name: "not-due run", args: ["run", "job-1", "--due"], exitCode: 1, kind: "admission" },
+    { name: "run history", args: ["runs", "--id", "job-1"], exitCode: 0, kind: "history" },
+    { name: "human error", args: ["show", "missing-job"], exitCode: 1, kind: "error" },
+  ])(
+    "drains output and preserves the exit code for $name",
+    ({ args, exitCode, kind }) => {
+      const root = tempDirs.make("openclaw-cron-output-");
+      const sourceUrl = (relative: string) => new URL(relative, import.meta.url).href;
+      const status = exitCode === 0 ? "ok" : "error";
+      const completionStatus = exitCode === 0 ? "succeeded" : "failed";
+      const admission =
+        exitCode === 0 ? { ok: true, enqueued: true, runId: "run-1" } : { ok: true, ran: false };
+      const rpcSource = `
+      const summary = "x".repeat(${summaryBytes} - ${sentinel.length}) + ${JSON.stringify(sentinel)};
+      const row = { ts: 1700000001000, jobId: "job-1", runId: "run-1", action: "finished",
+        status: ${JSON.stringify(status)}, completionStatus: ${JSON.stringify(completionStatus)},
+        summary, runAtMs: 1700000000000, durationMs: 1000 };
+      export async function callGatewayFromCliRuntime(method) {
+        if (method === "cron.run") return ${JSON.stringify(kind === "wait" ? { ok: true, enqueued: true, runId: "run-1" } : admission)};
+        if (method === "cron.runs") return { entries: [row], total: 1, offset: 0, limit: ${kind === "wait" ? 1 : 50}, hasMore: false, nextOffset: null };
+        if (method === "cron.get" && ${kind === "error"}) {
+          throw Object.assign(new Error("cron job not found: missing-job"), {
+            name: "GatewayClientRequestError", gatewayCode: "INVALID_REQUEST",
+          });
+        }
+        if (method === "cron.list" && ${kind === "error"}) return {
+          jobs: [], snapshotRevision: "empty-1", total: 0, offset: 0, limit: 200,
+          hasMore: false, nextOffset: null,
+        };
+        throw new Error("unexpected Gateway RPC: " + method);
+      }
+    `;
+      // Real Commander actions, runtime, and finalizer write to an ordinary OS pipe.
+      // Only Gateway RPC results are synthetic; no live job or operator store is touched.
+      const script = `
+      import { registerHooks } from "node:module";
+      import { Command } from "commander";
+      registerHooks({
+        resolve(specifier, context, nextResolve) {
+          if (specifier.endsWith("/gateway-rpc.runtime.js")) return {
+            shortCircuit: true,
+            url: "data:text/javascript," + encodeURIComponent(${JSON.stringify(rpcSource)}),
+          };
+          return nextResolve(specifier, context);
+        },
+      });
+      const { registerCronCli } = await import(${JSON.stringify(sourceUrl("./cron-cli.ts"))});
+      const { runCliWithExitFinalization } = await import(${JSON.stringify(sourceUrl("./one-shot-exit.ts"))});
+      const { applyResolvedCommandOutputMode } = await import(${JSON.stringify(sourceUrl("./json-output-mode.ts"))});
+      const { isCommandJsonOutputMode } = await import(${JSON.stringify(sourceUrl("./program/json-mode.ts"))});
+      process.argv = [process.execPath, "openclaw", "cron", ...${JSON.stringify(args)}];
+      await runCliWithExitFinalization({
+        run: async () => {
+          const program = new Command().name("openclaw");
+          registerCronCli(program);
+          program.hook("preAction", (_parent, command) => {
+            const jsonMode = isCommandJsonOutputMode(command, process.argv);
+            if (jsonMode !== ${kind !== "error"}) throw new Error("incorrect command output mode");
+            applyResolvedCommandOutputMode(jsonMode);
+          });
+          await program.parseAsync(process.argv);
+        },
+        onError: error => { throw error; },
+      });
+    `;
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        OPENCLAW_STATE_DIR: path.join(root, "state"),
+        OPENCLAW_CONFIG_PATH: path.join(root, "openclaw.json"),
+        TMPDIR: root,
+        TSX_DISABLE_CACHE: "1",
+        NODE_DISABLE_COMPILE_CACHE: "1",
+        NO_COLOR: "1",
+      };
+      delete env.VITEST;
+      delete env.VITEST_POOL_ID;
+      delete env.VITEST_WORKER_ID;
+      const result = spawnNodeEvalSync(script, {
+        imports: ["tsx"],
+        env,
+        maxBuffer: 2 * summaryBytes,
+        timeout: 30_000,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.signal).toBeNull();
+      expect(result.status, result.stderr).toBe(exitCode);
+      if (kind === "error") {
+        expect(result.stdout).toBe("");
+        expect(result.stderr).toContain(
+          "Automation not found: missing-job. Run `openclaw cron list` to see recent automation ids.",
+        );
+        return;
+      }
+      expect(result.stderr).toBe("");
+      const value = JSON.parse(result.stdout);
+      if (kind === "admission") {
+        expect(value).toEqual(admission);
+        return;
+      }
+      expect(kind === "wait" ? value.run : value.entries[0]).toMatchObject({
+        jobId: "job-1",
+        runId: "run-1",
+        status,
+        completionStatus,
+        summary,
+      });
+      if (kind === "wait") {
+        expect(value).toMatchObject({ completed: true, status, completionStatus });
+      }
+    },
+    30_000,
+  );
+});

--- a/test/scripts/bench-cli-startup.test.ts
+++ b/test/scripts/bench-cli-startup.test.ts
@@ -6,16 +6,8 @@ import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import { testing } from "../../scripts/bench-cli-startup.ts";
 import { withEnv } from "../../src/test-utils/env.js";
+import { isProcessAlive } from "../helpers/process-wait.js";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
-
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 describe("bench-cli-startup", () => {
   it("rejects unknown CLI options before running benchmarks", () => {

--- a/test/scripts/run-vitest-profile.test.ts
+++ b/test/scripts/run-vitest-profile.test.ts
@@ -1,6 +1,7 @@
 // Run Vitest Profile tests cover run vitest profile script behavior.
 import { execFile } from "node:child_process";
 import fs from "node:fs";
+import type { HeapProfiler } from "node:inspector";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -143,9 +144,17 @@ export default class extends TestRunner {
         fs.writeFileSync(
           path.join(root, `${name}.test.ts`),
           `import fs from "node:fs";
+import process from "node:process";
 import { isMainThread, threadId } from "node:worker_threads";
 import { expect, inject, it, vi } from "vitest";
+function retain_${name}_heap_workload() {
+  const blocks = [];
+  for (let index = 0; index < 64; index++) blocks.push(new Array(65_536).fill(index));
+  return blocks;
+}
 it("retains the selected execution context", async () => {
+  // Keep a real named allocation alive through the sampler's final GC and stop.
+  process[Symbol.for("openclaw.test.heap-workload.${name}")] = retain_${name}_heap_workload();
   vi.resetModules();
   expect(inject("customSetupCount")).toBe(1);
   expect(isMainThread).toBe(${pool === "forks"});
@@ -216,12 +225,19 @@ it("retains the selected execution context", async () => {
         expect(cpuFiles, result.output).toHaveLength(1);
         expect(heapFiles, result.output).toHaveLength(1);
         const cpu = JSON.parse(fs.readFileSync(path.join(outputDir, cpuFiles[0]!), "utf8"));
-        const heap = JSON.parse(fs.readFileSync(path.join(outputDir, heapFiles[0]!), "utf8"));
+        const heap = JSON.parse(
+          fs.readFileSync(path.join(outputDir, heapFiles[0]!), "utf8"),
+        ) as HeapProfiler.SamplingHeapProfile;
         expect(cpu.nodes.length).toBeGreaterThan(0);
         expect(cpu.samples.length).toBeGreaterThan(0);
         expect(cpu.endTime).toBeGreaterThan(cpu.startTime);
         expect(heap.head.children.length).toBeGreaterThan(0);
-        expect(heap.samples.length).toBeGreaterThan(0);
+        const nodes = [heap.head];
+        for (const node of nodes) nodes.push(...node.children);
+        const workload = nodes.find(
+          (node) => node.callFrame.functionName === `retain_${name}_heap_workload`,
+        );
+        expect(workload?.selfSize).toBeGreaterThan(0);
       }
     },
   );

--- a/test/vitest/vitest.cli-process-paths.mjs
+++ b/test/vitest/vitest.cli-process-paths.mjs
@@ -3,6 +3,7 @@
 export const cliProcessTestFiles = [
   "src/cli/acp-cli-exit.process.test.ts",
   "src/cli/cli-process-child.test-helpers.test.ts",
+  "src/cli/cron-output.process.test.ts",
   "src/cli/gateway-backed-exit.process.test.ts",
   "src/cli/gateway-cli/shutdown-hard-exit.process.test.ts",
   "src/cli/help-exit.process.test.ts",


### PR DESCRIPTION
Related: #133259

## What Problem This Solves

Operators piping `openclaw cron run <id> --wait` to another process could receive truncated, invalid JSON despite the correct success or failure exit code. A valid 128 KiB run summary reproduced a 65,536-byte cutoff for successful and failed waited runs.

## Why This Change Was Made

Cron now uses the existing one-shot output finalizer before terminating, including non-waited outcomes and human-error exits. Its error handler preserves `ExitError` so cleanup and stdout/stderr draining finish without replacing the outcome's diagnostic or exit code. This follows the same output-drain ownership used by Doctor in #133259.

The canonical run-log type replaces a redundant partial type. Scheduling, Gateway responses, summary generation, stores, configuration and shared finalizer deadlines remain unchanged. Production is **+12/−12 (net zero)**; tests/support are **+283/−148 (net +135)** and docs **+1/−1**.

## User Impact

Scripts receive complete waited-run JSON with the original exit status: success remains `0`, failure remains `1`. Queued/not-due outcomes, run history and missing-job diagnostics retain their behavior.

## Evidence

- Maintained OS-pipe regression: original production fails two waited JSON cases while four controls pass; the repair passes all six. Only Gateway RPC results are synthetic; Commander, runtime, finalizer and OS pipes are real.
- Actual source-entry after proof: all six cases pass. Waited outputs contain 133,845/133,885 bytes, the exact 131,072-byte summary and final sentinel, valid JSON, correct 0/1 exits and empty stderr. Proof used Node 26.8.1 source entry, not a packaged binary or live Gateway/job/provider.
- **517 maintained Cron/owner/sibling tests pass**: six process cases, 378 across seven owner/sibling files, and 133 across four corrected validation files. Initial hosted CI exposed 68 obsolete exit-mock expectations; the corrected assertions retain diagnostic and Gateway/no-write checks.
- A later hosted run exposed two tooling-test failures. The heap fixture now retains a named allocation through sampler stop and asserts its positive sampled size; the missing-allocation counterfactual fails, and the full 32-case profiler file passes. The benchmark uses the existing canonical zombie-aware PID helper; its 16 cases and 10 focused PID/wait controls pass. No sampling interval, production cleanup or test deadline was changed.
- One unchanged benchmark diagnostic on Linux Node 24.19.0 passed and observed the child already absent. It did **not** reproduce the historical CI failure, whose PID state/cause remains unknown. The cleanup oracle is corrected against the existing process-liveness contract, not claimed as proof of that historical cause.
- Original 30-check gate and prior 20-check correction gate passed. The final two-test gate is covered by its retained successful prefix and a corrected format/typecheck/lint remainder. An installed Node typing mismatch in redundant heap sample-array assertions was corrected while retaining the named allocation oracle. No full test replay was needed.
- Both the complete final 14-file managed P0–P2 review and the separate review of exact commit `78851fe3` found no actionable findings. Fresh hosted CI for that commit remains pending.

Named follow-up: the benchmark's final cleanup wait result is ignored. The diagnostic did not exercise a live group remaining after that wait, and this PR does not change that production owner.

An earlier coordinator Git metadata scan required a 20-to-60-second allowance after Trace2 showed filesystem traversal latency. Product/check deadlines stayed unchanged. A prior gate's separate temporary-cache cleanup was reconciled without repeating the successful checks. Those original failure receipts remain preserved.
