### PR TITLE
fix(browser): keep handed-off created tabs in relay tabs syncs

### DIFF
--- a/extensions/browser/chrome-extension/background.creation-lifecycle.test.ts
+++ b/extensions/browser/chrome-extension/background.creation-lifecycle.test.ts
@@ -263,3 +263,55 @@ describe("physical tab creation authority", () => {
     },
   );
 });
+
+describe("tabs sync snapshot coherence", () => {
+  it("republishes a handed-off creation over a stale accessible-tabs snapshot", async () => {
+    const harness = await loadBackground({
+      storedConfig: config("selected"),
+      initialTabs: [{ id: 100, url: "https://example.com/unrelated", groupId: 7 }],
+    });
+    const socket = harness.relaySockets[0];
+    assert(socket);
+    await harness.authenticate(socket);
+    const frames = () =>
+      socket.send.mock.calls.map(([raw]) => JSON.parse(raw) as Record<string, unknown>);
+
+    // Chrome resolves tabs.query snapshots in the browser process and may
+    // deliver a creation's tab/group events only after the createTab command
+    // already replied; park one sync's pre-creation snapshot across the handoff.
+    const staleSnapshot = createDeferred<void>();
+    releases.push(() => staleSnapshot.resolve());
+    const liveQuery = harness.tabsQuery.getMockImplementation()!;
+    let snapshotHeld = false;
+    harness.tabsQuery.mockImplementationOnce(async () => {
+      const snapshot = await liveQuery();
+      snapshotHeld = true;
+      await staleSnapshot.promise;
+      return snapshot;
+    });
+    harness.updateTab(100, { title: "poke" });
+    await vi.waitFor(() => expect(snapshotHeld).toBe(true));
+
+    socket.receive({ type: "createTab", url: "about:blank", background: true, seq: 1 });
+    await vi.waitFor(() =>
+      expect(frames().find((frame) => frame.seq === 1)).toMatchObject({
+        type: "result",
+        result: { tabId: 101 },
+      }),
+    );
+    const handoffFrameCount = frames().length;
+    staleSnapshot.resolve();
+
+    // The relay bridge deletes tabs missing from a sync and revokes their CDP
+    // sessions; a list computed before the creation must not publish past its
+    // handoff, or the client that just received the target loses it mid-action.
+    const tabsFramesAfterHandoff = () =>
+      frames()
+        .slice(handoffFrameCount)
+        .filter((frame) => frame.type === "tabs");
+    await vi.waitFor(() => expect(tabsFramesAfterHandoff().length).toBeGreaterThan(0));
+    for (const frame of tabsFramesAfterHandoff()) {
+      expect((frame.tabs as Array<{ tabId: number }>).map((tab) => tab.tabId)).toContain(101);
+    }
+  });
+});

--- a/extensions/browser/chrome-extension/modules/tab-access.js
+++ b/extensions/browser/chrome-extension/modules/tab-access.js
@@ -322,6 +322,10 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab, getGr
       created.assertCurrent();
       handoff({ tabId: tab.id, targetId: attached.targetId });
       created.handedOff = true;
+      // Handoff flips canPublishTab with no epoch change. Retire in-flight
+      // accessible-list snapshots, or a query that predates this creation can
+      // publish a tabs sync omitting the tab and the bridge revokes its sessions.
+      discoveryRevision += 1;
     } catch (error) {
       // Rollback belongs to the creator, before any id is handed to the relay.
       // Never use ordinary close as a privileged bypass or close a user-revoked tab.


### PR DESCRIPTION
# What Problem This Solves

`extensions/browser/chrome-extension/bootstrap.chromium.test.ts` keeps flaking on CI (latest: PR #133593, run 33339161828, shard checks-ui-e2e 14/14): the selected-mode `assertRelayTabCreation` phase fails with `page.goto: Target page, context or browser has been closed` while navigating the freshly created tab to `/browser-owner-proof`, even though the tab itself was created, grouped, and — per the gateway diagnostic — actually completed the navigation with HTTP 200.

This is not a test-only race. The extension's `syncTabsToRelay` publishes the accessible-tab list the relay bridge treats as authoritative: any tab missing from a `tabs` sync is deleted from the bridge inventory and its CDP sessions are retired (`Target.detachedFromTarget` to every client). The list is computed by `listAccessibleTabs`, whose only coherence guard is `discoveryRevision` — and the tab-creation flow deliberately bumps no revision when the created tab is grouped (the `created.grouping` consume path in `observeTabUpdate`) or handed off (`created.handedOff = true` flips `canPublishTab`). Chrome resolves `tabs.query` snapshots in the browser process and can deliver the creation's tab/group events only after the `createTab` command has already replied, so a sync whose query snapshot predates the creation can pass the revision-stability check, get sent after the handoff reply (same-socket FIFO puts it after the bridge adopted the tab), and revoke the just-created target while the client's first `page.goto` is still waiting for `load`. In all-tabs mode the ungrouped snapshot still includes the tab, which is why only the selected-mode iteration flakes.

# Why This Change Was Made

Fix at the producer that owns list coherence: `createTab` in `modules/tab-access.js` now bumps `discoveryRevision` when the creation is handed off. Any in-flight `listAccessibleTabs` computation whose snapshot predates the creation fails its stability check and recomputes from a fresh `tabs.query`, which necessarily postdates grouping (grouping precedes handoff in the creation flow). A sync sent before the handoff still omits the tab by design (`canPublishTab`), but same-socket FIFO delivers it before the bridge ever adopts the tab, so it cannot revoke anything. The bump touches only `discoveryRevision` — no epoch (`revision`/`tabRevisions`) changes, so no attachment or creation authority is retired.

The bridge's delete-on-omission behavior is intentionally unchanged: it is the real revocation mechanism, and the published list is the recorded fact it should trust.

# User Impact

Extension-relay clients (Playwright over the relay, chrome-devtools-mcp) no longer lose a freshly created tab mid-navigation when a stale accessible-tabs sync lands in selected access mode. The recurring `bootstrap.chromium.test.ts` CI flake — already carrying five prior flake fixes (#131841, #132485, #132504, #132662, #132878) — is fixed at its remaining root cause.

# Evidence

- CI failure analysis (run 33339161828): the mode=all creation passed end-to-end; ~100 ms later the mode=selected `/tabs/open` returned 500 with the `page.goto` closure error while the gateway diagnostic shows the tab's real navigation finishing 200 (`http.request`/`http.finish` at ms 12740) and the created tab present, grouped, and at the proof URL in the test's own evidence JSON.
- New deterministic regression test `background.creation-lifecycle.test.ts › tabs sync snapshot coherence › republishes a handed-off creation over a stale accessible-tabs snapshot`: parks one sync's pre-creation `tabs.query` snapshot across a full `createTab` handoff, then asserts every post-handoff `tabs` frame includes the created tab. Fails pre-fix (`expected [ 100 ] to include 101` — the stale sync publishing without the handed-off tab) and passes post-fix.
- `node scripts/run-vitest.mjs extensions/browser/chrome-extension/` — 18 files, 515 tests passed; full `check:changed` gate green; Codex autoreview scoped-clean.
- Live proof: `pnpm build`, then 13 bounded iterations of `OPENCLAW_BROWSER_EXTENSION_E2E=1 node scripts/run-vitest.mjs extensions/browser/chrome-extension/bootstrap.chromium.test.ts` (macOS, Playwright chromium-headless-shell v1234), including 3 under deliberate 12-process CPU load — 12/13 green. Full disclosure: one iteration failed while the host was saturated by the concurrent typecheck gate and Codex review (247 s shard vs the usual ~45 s), and its failure output was discarded by the loop's `tail -3` pipe, so I could not classify it; 7 subsequent iterations with full logs (idle and loaded) all passed.
- Production LOC delta: +4 in `modules/tab-access.js` (1 statement + 3-line invariant comment); +52 test lines.
