### PR TITLE
fix: identify cloud worker bootstrap failures

### DIFF
--- a/extensions/crabbox/src/crabbox-worker-command-error.ts
+++ b/extensions/crabbox/src/crabbox-worker-command-error.ts
@@ -1,5 +1,4 @@
 import { redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
-import { WorkerProviderError } from "openclaw/plugin-sdk/plugin-entry";
 import type { SpawnResult } from "openclaw/plugin-sdk/process-runtime";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
@@ -29,11 +28,4 @@ export function crabboxCommandError(action: string, result: SpawnResult): Error 
   return new Error(
     `Crabbox ${action} failed with exit code ${exitCode}${crabboxCommandDetail(result)}`,
   );
-}
-
-export function permanentCrabboxCommandError(
-  action: string,
-  result: SpawnResult,
-): WorkerProviderError {
-  return new WorkerProviderError(crabboxCommandError(action, result).message);
 }

--- a/extensions/crabbox/src/crabbox-worker-node-enrollment.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-node-enrollment.test.ts
@@ -57,7 +57,9 @@ if (args[0] === "--version") {
   fs.appendFileSync(path.join(state, "enabled"), args[2] + "\\n");
 } else {
   process.title = "openclaw-connect";
-  fs.writeFileSync(path.join(state, "launch.json"), JSON.stringify({ build: ${JSON.stringify(build)}, args, cli: process.argv[1], token: process.env.CRABBOX_WORKER_BOOTSTRAP_TOKEN, setupCode: process.env.CRABBOX_WORKER_SETUP_CODE, environment: { DISPLAY: process.env.DISPLAY, DBUS_SESSION_BUS_ADDRESS: process.env.DBUS_SESSION_BUS_ADDRESS, XDG_RUNTIME_DIR: process.env.XDG_RUNTIME_DIR }, enabledPlugins: fs.readFileSync(path.join(state, "enabled"), "utf8").trim().split("\\n") }));
+  fs.writeFileSync(path.join(state, "launch.json.tmp"), JSON.stringify({ build: ${JSON.stringify(build)}, args, cli: process.argv[1], token: process.env.CRABBOX_WORKER_BOOTSTRAP_TOKEN, setupCode: process.env.CRABBOX_WORKER_SETUP_CODE, environment: { DISPLAY: process.env.DISPLAY, DBUS_SESSION_BUS_ADDRESS: process.env.DBUS_SESSION_BUS_ADDRESS, XDG_RUNTIME_DIR: process.env.XDG_RUNTIME_DIR }, enabledPlugins: fs.readFileSync(path.join(state, "enabled"), "utf8").trim().split("\\n") }));
+  // Existence signals readiness only after the child publishes complete JSON.
+  fs.renameSync(path.join(state, "launch.json.tmp"), path.join(state, "launch.json"));
   setInterval(() => {}, 60000);
 }
 `,
@@ -88,7 +90,10 @@ function testHome() {
   return { home, stateDir, stop };
 }
 
-async function serveArtifact(archive: Buffer, options: { tls?: boolean; redirect?: boolean } = {}) {
+async function serveArtifact(
+  archive: Buffer,
+  options: { tls?: boolean; redirect?: boolean; truncate?: boolean } = {},
+) {
   let tls: { cert: Buffer; key: Buffer } | undefined;
   if (options.tls) {
     const directory = tempDirs.make("crabbox-bootstrap-tls-");
@@ -124,6 +129,10 @@ async function serveArtifact(archive: Buffer, options: { tls?: boolean; redirect
       return;
     }
     response.writeHead(200, { "content-length": archive.length });
+    if (options.truncate) {
+      response.write(archive.subarray(0, 1), () => response.destroy());
+      return;
+    }
     response.end(archive);
   };
   const server = tls ? https.createServer(tls, handle) : http.createServer(handle);
@@ -315,28 +324,33 @@ describe.skipIf(process.platform === "win32")("source node bootstrap", () => {
     30_000,
   );
 
-  it.each(["digest", "length", "redirect"] as const)(
+  it.each([
+    ["digest", "integrity verification"],
+    ["length", "length does not match"],
+    ["redirect", "HTTP 302"],
+    ["truncated", "bootstrap download failed (ECONNRESET): aborted"],
+  ] as const)(
     "rejects a bad archive %s before installing or starting a node",
-    async (failure) => {
+    async (failure, diagnosis) => {
       const { home, stateDir } = testHome();
       const archive = await packageFixture("first");
-      const { nodeBootstrap } = await serveArtifact(archive, { redirect: failure === "redirect" });
+      const { nodeBootstrap, authorizations } = await serveArtifact(archive, {
+        redirect: failure === "redirect",
+        truncate: failure === "truncated",
+      });
       const result = await enroll(home, {
         ...nodeBootstrap,
         ...(failure === "digest" ? { sha256: "f".repeat(64) } : {}),
         ...(failure === "length" ? { bytes: archive.length + 1 } : {}),
       });
       expect(result.code).toBe(1);
-      expect(result.output).toContain(
-        failure === "digest"
-          ? "integrity verification"
-          : failure === "length"
-            ? "length does not match"
-            : "HTTP 302",
-      );
+      expect(result.output).toContain(diagnosis);
       expect(result.output).not.toContain(nodeBootstrap.token);
+      expect(result.output).not.toContain(setupCode);
+      expect(authorizations).toEqual([`Bearer ${nodeBootstrap.token}`]);
       expect(fs.existsSync(path.join(stateDir, "node.pid"))).toBe(false);
       expect(fs.readdirSync(stateDir)).toEqual([]);
+      expect(fs.readdirSync(path.join(home, ".openclaw-worker", "node-runtimes"))).toEqual([]);
     },
   );
 

--- a/extensions/crabbox/src/crabbox-worker-node-enrollment.ts
+++ b/extensions/crabbox/src/crabbox-worker-node-enrollment.ts
@@ -47,6 +47,7 @@ const setupCode = process.env.${CLOUD_SETUP_CODE_ENV};
 delete process.env.${CLOUD_BOOTSTRAP_TOKEN_ENV};
 delete process.env.${CLOUD_SETUP_CODE_ENV};
 process.umask(0o077);
+let phase = "preparation";
 (async () => {
   const stateDir = path.join(os.homedir(), ".openclaw", "cloud-workers", leaseId);
   const runtimeRoot = path.join(os.homedir(), ".openclaw-worker", "node-runtimes");
@@ -85,6 +86,7 @@ process.umask(0o077);
     fs.unlinkSync(pidFile);
   }
   const verifyRuntime = (root) => {
+    phase = "runtime verification";
     if (!fs.lstatSync(root).isDirectory() || fs.realpathSync(root) !== root) throw new Error("Cloud worker bootstrap runtime path is unsafe");
     const packageRoot = path.join(root, "node_modules", "openclaw");
     const manifest = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"));
@@ -100,6 +102,7 @@ process.umask(0o077);
   } else {
     const stage = fs.mkdtempSync(path.join(stateDir, "node-bootstrap-"));
     try {
+      phase = "download";
       if (!token) throw new Error("Cloud worker bootstrap download authority is unavailable");
       const url = new URL(bootstrap.url);
       if (!["http:", "https:"].includes(url.protocol) || url.username || url.password || url.search || url.hash || (bootstrap.tlsFingerprint && url.protocol !== "https:")) throw new Error("Cloud worker bootstrap artifact transport is invalid");
@@ -137,6 +140,7 @@ process.umask(0o077);
         }
       } finally { response.destroy(); await output.close(); }
       if (bytes !== bootstrap.bytes || hash.digest("hex") !== bootstrap.sha256) throw new Error("Cloud worker bootstrap archive failed integrity verification");
+      phase = "installation";
       const installDir = path.join(stage, "runtime");
       fs.mkdirSync(installDir, { mode: 0o700 });
       // npm 12 requires a project policy even when ignore-scripts is false.
@@ -157,6 +161,7 @@ process.umask(0o077);
       fs.renameSync(installDir, runtimeDir);
     } finally { fs.rmSync(stage, { recursive: true, force: true }); }
   }
+  phase = "activation";
   try {
     if (!fs.lstatSync(runtimeLink).isSymbolicLink()) throw new Error("Cloud worker runtime pointer is occupied");
     fs.unlinkSync(runtimeLink);
@@ -171,6 +176,7 @@ process.umask(0o077);
     fs.writeFileSync(setupFile, setupCode + "\\n", { mode: 0o600 });
   }
   const args = mode === "connect" ? ["connect", "--target-file", setupFile] : ["node", "run"];
+  phase = "node launch";
   const log = fs.openSync(path.join(stateDir, "node.log"), "a", 0o600);
   let child;
   try {
@@ -180,7 +186,7 @@ process.umask(0o077);
     catch (error) { process.kill(-child.pid, "SIGTERM"); throw error; }
     child.unref();
   } finally { fs.closeSync(log); }
-})().catch((error) => { console.error(error.message); process.exitCode = 1; });
+})().catch((error) => { console.error("Cloud worker node bootstrap " + phase + " failed" + (error.code ? " (" + error.code + ")" : "") + ": " + error.message); process.exitCode = 1; });
 CRABBOX_NODE_ENROLLMENT_SCRIPT`;
   return {
     command,

--- a/extensions/crabbox/src/crabbox-worker-provider.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.ts
@@ -10,10 +10,7 @@ import { createPluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-stat
 import { runCommandWithTimeout } from "openclaw/plugin-sdk/process-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
-import {
-  crabboxCommandError,
-  permanentCrabboxCommandError,
-} from "./crabbox-worker-command-error.js";
+import { crabboxCommandError } from "./crabbox-worker-command-error.js";
 import {
   type CrabboxCommandRunner,
   isUnrecognizedLease,
@@ -329,7 +326,7 @@ async function runProvisionSetupAndWaitReady(
         }),
     );
     if (result.termination !== "exit" || result.code !== 0) {
-      throw permanentCrabboxCommandError(params.phase, result);
+      throw new WorkerProviderError(crabboxCommandError(params.phase, result).message);
     }
   } catch (error) {
     return await failProvisionAfterCleanup({ ...params, id: params.inspect.id }, error);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators creating a cloud session would receive only `aborted` when the node runtime download was interrupted. The message lost the failing bootstrap phase and the native transport error code, making a network interruption hard to distinguish from package installation or node startup failures.

## Why This Change Was Made

The generated enrollment script now reports the phase and optional error code where those facts are known. The existing provider formatter still bounds and redacts that message. The provider's one-use permanent-error wrapper is removed; error classification and cleanup are unchanged.

No retry, timeout, allocation, credential, schema, configuration, or protocol changes. This diagnoses the failed operation; it does not claim to repair an underlying network failure. An observed test-fixture race was also repaired at the producer by publishing its readiness JSON atomically.

## User Impact

An interrupted response now reports `Cloud worker node bootstrap download failed (ECONNRESET): aborted`. Installation, verification, activation, and node launch failures likewise identify their phase. This is the release-note context; the root changelog is release-generated.

## Evidence

- Real generated-script reproduction: a loopback HTTP server sends status 200 and one body byte, then disconnects. The new assertion fails before the patch and passes afterward. Exactly one request is made; temporary state is removed; no runtime or PID is published; download and enrollment credentials are absent from output.
- Both complete owner test files pass: 254 passed, 1 skipped. Coverage includes successful cold/warm artifact use, TLS pinning before bearer transmission, rejected redirects/digest/length/truncation, error classification, and cleanup failure preservation.
- The first run exposed two unchanged fixture failures caused by observing an incompletely written readiness file. Atomic publication fixed both; no timeout or assertion was weakened.
- Local scoped lint was blocked before linting by an incomplete shared dependency installation: tslog's declared BaseLogger/interfaces type files are missing. Shared dependencies were not modified. Hosted CI remains required before landing.

Fresh isolated Codex review: scoped-clean at P0, confidence 0.99. The real HTTP regression also passes on both Node 24 and Node 26.

Production LOC: +9/-14, net **−5**. Tests: net **+14**. Four files; no generated or dependency changes.

Provenance: the lossy catch is present in the current artifact-bootstrap implementation. Related outer-phase and packaging fixes do not preserve the native code discarded here; exact introducing ancestry has not been established, so no author attribution is inferred.

AWS changed-path proof: the exact candidate generated script passed the same real interrupted-HTTP reproduction on Node 24.18.1, provider aws, task lease cbx_c5cd202c5338, run run_fa541cd46568. One request, expected ECONNRESET diagnosis, temporary-state cleanup, no published runtime/PID, and no credential output. This is live Linux failure-path proof, not a successful model-backed cloud turn; that separate broader test remains in progress.

ClawSweeper review follow-through: exact-head CI [33344633552](https://github.com/openclaw/openclaw/actions/runs/33344633552) passed, and maintainer code review found no actionable defect. Its generic unknown-data-model-change flag does not correspond to a persistence change: the production diff adds only a process-local phase variable and error formatting and inlines an equivalent error constructor. No stored table, file format, migration, retention, or replay semantics change.
