### PR TITLE
docs: link v2026.8.1 release notes to feature guides

### DIFF
--- a/docs/releases/2026.8.1.md
+++ b/docs/releases/2026.8.1.md
@@ -36,13 +36,13 @@ This release changes how sessions and transcripts are stored by moving them into
 Create a [verified backup](/install/updating#before-updating-create-a-verified-backup) before upgrading to protect broader OpenClaw state, and review [downgrading across the session SQLite migration](/install/updating#downgrading-across-the-session-sqlite-migration) before rolling back.
 </Warning>
 
-OpenClaw now gives new Mac, Linux, and Windows installs a clearer path from download to a first useful conversation, while iPhone, iPad, and Android put pairing and permissions where people need them. Guided setup can reuse supported subscriptions, API keys, and local models already available, verifies the chosen model before saving it, and hands off to the web app or terminal when the connection is ready.
+OpenClaw now gives new [Mac, Linux, and Windows installs](/install) a clearer path from download to a first useful conversation, while iPhone, iPad, and Android put pairing and permissions where people need them. Guided setup can reuse supported subscriptions, API keys, and [local models](/gateway/local-models) already available, verifies the chosen model before saving it, and hands off to the web app or terminal when the connection is ready.
 
 <AccordionGroup>
 
 <Accordion title="Installing OpenClaw">
 
-The supported install path now keeps the app or command available after setup. A Mac app opened from Downloads or a disk image can offer to move itself into Applications, where updates and launch at login work properly. On Linux and other Unix systems, the installer makes `openclaw` available in new terminal sessions without asking you to edit shell startup files by hand.
+The [supported install path](/install) now keeps the app or command available after setup. A Mac app opened from Downloads or a disk image can offer to move itself into Applications, where updates and launch at login work properly. On Linux and other Unix systems, the installer makes `openclaw` available in new terminal sessions without asking you to edit shell startup files by hand.
 
 Network installations that would expose OpenClaw without authentication are stopped before anything changes. Reinstalling also protects an existing working setup when preparation is cancelled or fails, and gives OpenClaw time to start before reporting whether it is reachable.
 
@@ -91,9 +91,9 @@ Network installations that would expose OpenClaw without authentication are stop
 
 <Accordion title="Connecting a subscription, API key, or local model">
 
-Guided setup now starts by looking for AI access you may already have. It can reuse verified Codex, ChatGPT, or Claude CLI sign-ins, accept an API key, run a supported provider's own sign-in, or find qualifying Ollama and LM Studio models, then prove that the exact choice can answer before it keeps that model and credential. Access already working on the machine can become part of setup instead of another thing to configure.
+[Guided setup](/start/wizard) now starts by looking for AI access you may already have. It can reuse verified Codex, ChatGPT, or Claude CLI sign-ins, accept an API key, run a supported provider's own sign-in, or find qualifying Ollama and LM Studio models, then prove that the exact choice can answer before it keeps that model and credential. Access already working on the machine can become part of setup instead of another thing to configure.
 
-For OpenAI accounts, setup uses the models the signed-in account can actually access while preserving routes you configured yourself, and administrators can prepare supported local models with live progress. Finding or downloading a local model is only the start, so the supported local-model screens do not show Start chatting until that exact choice passes activation.
+For OpenAI accounts, setup uses the models the signed-in account can actually access while preserving routes you configured yourself, and administrators can prepare supported [local models](/gateway/local-models) with live progress. Finding or downloading a local model is only the start, so the supported local-model screens do not show Start chatting until that exact choice passes activation.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -268,7 +268,7 @@ For OpenAI accounts, setup uses the models the signed-in account can actually ac
 
 <Accordion title="Starting your first conversation">
 
-Successful setup now hands off directly to a first conversation. Graphical Mac, Linux, and Windows sessions can open the web app, while SSH and other headless setups provide an authenticated link with port-forward instructions and keep terminal chat available.
+Successful setup now hands off directly to a [first conversation](/start/wizard). Graphical Mac, Linux, and Windows sessions can open the web app, while SSH and other headless setups provide an authenticated link with port-forward instructions and keep terminal chat available.
 
 From there, the setup conversation can finish supported skill and web-search configuration, then offer an external channel as an optional next step instead of another prerequisite for first use. The classic wizard can still continue without AI because its live model check remains optional.
 
@@ -360,11 +360,11 @@ From there, the setup conversation can finish supported skill and web-search con
 
 <Accordion title="Setting Up OpenClaw on Mac, Windows, and Linux">
 
-On Mac, the main guide points directly to the app, and the local or remote Gateway you choose stays selected even if older startup or cleanup work finishes late. The app waits through the Local Network prompt and legitimate first-run data upgrades, authenticates the exact remote Gateway before moving on, and opens the dashboard only when the connection is ready.
+On [Mac](/platforms/macos), the main guide points directly to the app, and the local or remote Gateway you choose stays selected even if older startup or cleanup work finishes late. The app waits through the Local Network prompt and legitimate first-run data upgrades, authenticates the exact remote Gateway before moving on, and opens the dashboard only when the connection is ready.
 
-On Windows, the guide points to the latest signed x64 and Arm64 Hub installers. The PowerShell installer now recognizes a supported Node runtime correctly and can continue in the same session after Winget installs Node.js. Windows Hub updates independently, so its standalone stable build can be newer than the mirror included with an OpenClaw release.
+On [Windows](/platforms/windows), the guide points to the latest signed x64 and Arm64 Hub installers. The PowerShell installer now recognizes a supported Node runtime correctly and can continue in the same session after Winget installs Node.js. Windows Hub updates independently, so its standalone stable build can be newer than the mirror included with an OpenClaw release.
 
-On Linux, desktop setup can repair or reinstall OpenClaw, connect to a local or remote Gateway directly or through SSH, verify eligible AI access already on the machine, and resume an interrupted activation. Direct certificate-pinned connections remain unavailable inside the desktop app.
+On [Linux](/platforms/linux), desktop setup can repair or reinstall OpenClaw, connect to a local or remote Gateway directly or through SSH, verify eligible AI access already on the machine, and resume an interrupted activation. Direct certificate-pinned connections remain unavailable inside the desktop app.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -448,9 +448,9 @@ On Linux, desktop setup can repair or reinstall OpenClaw, connect to a local or 
 
 Mobile setup now puts QR and setup-code pairing first because that is what most people were trying to find anyway, while discovered Gateways and manual host and credential entry remain available. Secure official pairing shows whether the phone has Full or Limited access, and an unencrypted connection to another machine is automatically kept Limited.
 
-On iPhone and iPad, OpenClaw explains pairing before asking for Local Network access, lets you decide on optional permissions one at a time, and gives eligible administrators a dedicated Settings conversation for Gateway setup and repair without exposing that privileged assistant in ordinary Chat.
+On [iPhone and iPad](/platforms/ios), OpenClaw explains pairing before asking for Local Network access, lets you decide on optional permissions one at a time, and gives eligible administrators a dedicated Settings conversation for Gateway setup and repair without exposing that privileged assistant in ordinary Chat.
 
-On Android, pairing stays usable in landscape, on narrow screens, and with larger system text. Public Gateways can use normal certificate checks while LAN and IP connections keep explicit pinning, and pairing again preserves saved location and notification choices instead of quietly changing consent; revoked permissions remain revoked, and Google Play builds still use foreground location only.
+On [Android](/platforms/android), pairing stays usable in landscape, on narrow screens, and with larger system text. Public Gateways can use normal certificate checks while LAN and IP connections keep explicit pinning, and pairing again preserves saved location and notification choices instead of quietly changing consent; revoked permissions remain revoked, and Google Play builds still use foreground location only.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -496,7 +496,7 @@ On Android, pairing stays usable in landscape, on narrow screens, and with large
 
 <Accordion title="Moving, Importing, or Resetting an Existing Setup">
 
-Imports from Claude, Codex, and Hermes now happen in a temporary staging area, where OpenClaw verifies or repairs the model route before making the new setup active. If the source, import plan, or destination changes along the way, promotion stops rather than replaying a half-finished import against different data.
+[Imports from Claude, Codex, and Hermes](/install/migrating) now happen in a temporary staging area, where OpenClaw verifies or repairs the model route before making the new setup active. If the source, import plan, or destination changes along the way, promotion stops rather than replaying a half-finished import against different data.
 
 Rerunning onboarding keeps the workspace you already use unless you approve a move, and named agents keep the credentials they own through supported creation and configuration-only resets. OpenClaw validates the provider, Gateway, migration, and workspace choices before a reset can move existing data to Trash, but a valid confirmed reset is still destructive.
 
@@ -560,7 +560,7 @@ Rerunning onboarding keeps the workspace you already use unless you approve a mo
 
 <Accordion title="Automating Setup and Recovering from Interruptions">
 
-Non-interactive onboarding now rejects invalid provider, authentication, Gateway, workspace, and conflicting flow choices before it creates an agent or writes configuration. When `--json` is requested, failures return one machine-readable result instead of empty or mixed output, and a concurrent setup for the same profile fails quickly with the current holder when known instead of sitting there looking frozen.
+[Non-interactive onboarding](/start/wizard-cli-automation) now rejects invalid provider, authentication, Gateway, workspace, and conflicting flow choices before it creates an agent or writes configuration. When `--json` is requested, failures return one machine-readable result instead of empty or mixed output, and a concurrent setup for the same profile fails quickly with the current holder when known instead of sitting there looking frozen.
 
 Cancelled or interrupted setup revokes stale work, while failed provider sign-in or local-model preparation can be retried without cancelling a newer attempt. Gateway health failures stay inside setup with the original diagnostic and recovery hints, but `--json` does not waive risk acknowledgement, and deliberately skipping service startup can still finish without a reachable Gateway, so automation must inspect the reported health instead of trusting exit status alone.
 
@@ -638,13 +638,13 @@ Cancelled or interrupted setup revokes stale work, while failed provider sign-in
 
 ## The New Web UI
 
-The rebuilt Control UI puts conversations at the centre of OpenClaw, with files, approvals, settings, and live work close to the conversation so you can set up a Claw, follow what it is doing, and keep working without bouncing between separate tools.
+The rebuilt [Control UI](/web/control-ui) puts conversations at the centre of OpenClaw, with files, approvals, settings, and live work close to the conversation so you can set up a Claw, follow what it is doing, and keep working without bouncing between separate tools.
 
 <AccordionGroup>
 
 <Accordion title="Navigation and sidebar">
 
-The web-based experience in OpenClaw now feels more familiar to anyone who uses apps like ChatGPT, Claude, Gemini, or Perplexity, with conversations in the sidebar and the one you are working in at the centre instead of opening on a separate Overview page. Settings and Inbox keep setup details and alerts out of the way until you need them, conversations can open in real browser tabs or windows, and even little things like the sidebar remembering its width make it feel less like developer tooling.
+The [web-based experience](/web/control-ui) in OpenClaw now feels more familiar to anyone who uses apps like ChatGPT, Claude, Gemini, or Perplexity, with conversations in the sidebar and the one you are working in at the centre instead of opening on a separate Overview page. Settings and Inbox keep setup details and alerts out of the way until you need them, conversations can open in real browser tabs or windows, and even little things like the sidebar remembering its width make it feel less like developer tooling.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -803,7 +803,7 @@ The web-based experience in OpenClaw now feels more familiar to anyone who uses 
 
 <Accordion title="Starting and managing conversations">
 
-Starting a new conversation is now a proper setup screen instead of a blank chat that inherits whatever defaults happen to be active. Before anything begins, you can choose the agent, model, reasoning level, opening message or image, workspace, and the computer that should run it, then use groups, transcript search, status, and batch actions to manage the work later. Supported Codex conversations can also branch from an earlier message without changing the original.
+Starting a [new conversation](/concepts/session) is now a proper setup screen instead of a blank chat that inherits whatever defaults happen to be active. Before anything begins, you can choose the agent, model, reasoning level, opening message or image, workspace, and the computer that should run it, then use groups, transcript search, status, and batch actions to manage the work later. Supported Codex conversations can also branch from an earlier message without changing the original.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1006,7 +1006,7 @@ Starting a new conversation is now a proper setup screen instead of a blank chat
 
 <Accordion title="Chat and history">
 
-Chat now feels much more alive while a Claw is working. Replies render as Markdown while they stream, older messages load without knocking you out of place, and recent conversations can appear before the Gateway finishes refreshing.
+[Chat](/web/webchat) now feels much more alive while a Claw is working. Replies render as Markdown while they stream, older messages load without knocking you out of place, and recent conversations can appear before the Gateway finishes refreshing.
 
 The composer is easier to use during long-running work. You can change the model, reasoning, or speed before sending, edit and reorder queued follow-ups, and use dictation without accidentally sending the result.
 
@@ -1307,9 +1307,9 @@ One of the more useful additions is `/btw`, which opens a separate multi-turn co
 
 <Accordion title="Follow the Work and Approve Actions">
 
-Following a Claw while it works is much easier. Tool calls now pair clearly with their results, command activity is easier to read, file changes show focused diffs, and larger screens can keep running background tasks beside the conversation with elapsed time and recent activity. People with permission to change the conversation can stop work there, while the full Tasks page covers work across conversations.
+Following a Claw while it works is much easier. Tool calls now pair clearly with their results, command activity is easier to read, file changes show focused diffs, and larger screens can keep running background tasks beside the conversation with elapsed time and recent activity. People with permission to change the conversation can stop work there, while the full [Tasks page](/automation/tasks) covers work across conversations.
 
-If you have used approval gates in ChatGPT or Claude Desktop, this should feel familiar. Requests appear inside the conversation that triggered them, other conversations show a quiet indicator when something needs attention, and closing the approval queue leaves the request pending instead of accidentally approving or denying it. A rolling 30-day history is available when you need to look back.
+If you have used [approval gates](/tools/exec-approvals) in ChatGPT or Claude Desktop, this should feel familiar. Requests appear inside the conversation that triggered them, other conversations show a quiet indicator when something needs attention, and closing the approval queue leaves the request pending instead of accidentally approving or denying it. A rolling 30-day history is available when you need to look back.
 
 Once a turn finishes, intermediate commentary and tools fold into a **Worked for** summary you can reopen. Live activity, search results, attachment-only replies, and unresolved errors stay visible instead of being tidied away before they are actually finished.
 
@@ -1447,9 +1447,9 @@ Once a turn finishes, intermediate commentary and tools fold into a **Worked for
 
 OpenClaw can now keep the work beside the conversation instead of making you bounce between tools. On supported administrator connections, you can open and edit eligible existing text or Markdown files from Chat, and if a Claw changes the same file while you are working, the editor stops with a conflict instead of overwriting the newer version. The Changes panel shows branch commits and working-tree edits, while eligible GitHub checkouts add pull-request status, CI summaries, and a link to start a pull request on GitHub.
 
-A docked Browser panel can navigate, click, type, scroll, inspect elements, and mark up a screenshot before attaching that screenshot and page context to the conversation, but it requires advertised browser support and an administrator connection, and whatever appears in the page or capture may be sensitive.
+A [docked Browser panel](/tools/browser) can navigate, click, type, scroll, inspect elements, and mark up a screenshot before attaching that screenshot and page context to the conversation, but it requires advertised browser support and an administrator connection, and whatever appears in the page or capture may be sensitive.
 
-Chat, Details, and Discussion can sit in resizable columns or merge into tabs, while the dashboard, terminal, and desktop can open in focused views when you need more room. The file editor still cannot create or delete files, Changes stays read-only, and Create PR hands off to GitHub rather than submitting inside OpenClaw.
+Chat, Details, and Discussion can sit in resizable columns or merge into tabs, while the dashboard, [terminal](/tools/exec), and desktop can open in focused views when you need more room. The file editor still cannot create or delete files, Changes stays read-only, and Create PR hands off to GitHub rather than submitting inside OpenClaw.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1603,7 +1603,7 @@ Chat, Details, and Discussion can sit in resizable columns or merge into tabs, w
 
 <Accordion title="Settings and connected services">
 
-Settings is now easier to navigate. It has its own full-page workspace, searches both destinations and individual controls, separates common from advanced options, and keeps panel URLs bookmarkable. If a value is incomplete or invalid, the draft stays on screen so you can fix it, and settings the normal form cannot represent safely open in Raw mode instead of being silently lost.
+[Settings](/gateway/configuration) is now easier to navigate. It has its own full-page workspace, searches both destinations and individual controls, separates common from advanced options, and keeps panel URLs bookmarkable. If a value is incomplete or invalid, the draft stays on screen so you can fix it, and settings the normal form cannot represent safely open in Raw mode instead of being silently lost.
 
 Major controls also have clearer homes. Connection details, agent identity and memory, Plugins, MCP servers, devices, channels, and pairing are organized around where you actually manage them, while Model Providers brings together the credential health, available models, quota, balance, budget, and spending data each provider reports. That provider view is read-only, and guided MCP management still lives in Plugins while Settings keeps diagnostics and raw editing.
 
@@ -1776,7 +1776,7 @@ A browser with limited access can request administrator scope, but another admin
 
 <Accordion title="Sharing and Incognito">
 
-On a multi-user Gateway, a conversation now keeps its creator and each identified person's prompts visible, while owners or administrators can choose whether someone else may read, suggest changes, work in a draft, or participate directly. Drafts can be created and published without a race, suggestions keep their author, and lightweight presence and typing cues make it easier to tell who is there without cluttering a solo setup.
+On a [multi-user Gateway](/concepts/multi-user), a conversation now keeps its creator and each identified person's prompts visible, while owners or administrators can choose whether someone else may read, suggest changes, work in a draft, or participate directly. Drafts can be created and published without a race, suggestions keep their author, and lightweight presence and typing cues make it easier to tell who is there without cluttering a solo setup.
 
 People can manage their own display name and avatar, and permitted Online cards can show what someone is working on without exposing IP addresses or conversations the viewer cannot open. These controls make collaboration understandable, but they are not tenant isolation or a security boundary, and revoked access can briefly look available until the UI refreshes or the Gateway rejects the action.
 
@@ -1859,7 +1859,7 @@ Incognito is off by default and deliberately narrower. Its conversation stays in
 
 <Accordion title="Appearance, language, accessibility, and mobile">
 
-The Control UI is easier to navigate without a mouse. Keyboard and focus behavior is more consistent across navigation, dialogs, tabs, Settings, plugins, skills, Usage, Workboards, the terminal, and the browser, with skip links, clearer assistive-technology labels, and focus returning to the right place after menus and dialogs close.
+The [Control UI](/web/control-ui) is easier to navigate without a mouse. Keyboard and focus behavior is more consistent across navigation, dialogs, tabs, Settings, plugins, skills, Usage, Workboards, the terminal, and the browser, with skip links, clearer assistive-technology labels, and focus returning to the right place after menus and dialogs close.
 
 On phones and tablets, text sizing now reaches navigation and sidebar content. Inputs no longer trigger iOS zoom, touch devices avoid desktop-style hover highlights, and Send or Stop responds to the first tap on the documented Android Chrome and installed-PWA layouts while desktop hover behavior stays intact.
 
@@ -2059,7 +2059,7 @@ Appearance now includes seven built-in themes, with offline-safe bundled fonts f
 
 <Accordion title="Control UI Latency and Responsiveness">
 
-The Control UI now reaches Chat faster. In a simulated default-chat test with a mocked Gateway and 50 millisecond HTTP/1.1 latency, JavaScript requests fell from 140 to 45 and startup fell from about 1.6 seconds to 575 milliseconds.
+The [Control UI](/web/control-ui) now reaches Chat faster. In a simulated default-chat test with a mocked Gateway and 50 millisecond HTTP/1.1 latency, JavaScript requests fell from 140 to 45 and startup fell from about 1.6 seconds to 575 milliseconds.
 
 It also stays lighter the longer you leave it open. Hidden panels stop fetching data they do not show, retained state is bounded, and returning to a conversation repeats less rendering.
 
@@ -2362,7 +2362,7 @@ Reconnects reject stale responses and keep the right conversation selected as th
 
 ## Updates and Maintenance
 
-Users could sometimes experience instability after updating OpenClaw. Supported update paths now inspect the installation before replacing it and stop unsafe candidates while leaving the previous CLI runnable. In the Control UI, updates identify the target, ask for confirmation, and keep progress and the final outcome visible.
+Users could sometimes experience instability after updating OpenClaw. [Supported update paths](/install/updating) now inspect the installation before replacing it and stop unsafe candidates while leaving the previous CLI runnable. In the Control UI, updates identify the target, ask for confirmation, and keep progress and the final outcome visible.
 
 Maintenance tools now provide clearer recovery paths. Configuration errors point to the setting that needs attention, Doctor focuses on problems and the next action, new backups are checked against the guarded restore path, destructive cleanup stops when ownership is unclear, and supported restarts give tracked work time to finish before handoff.
 
@@ -2370,9 +2370,9 @@ Maintenance tools now provide clearer recovery paths. Configuration errors point
 
 <Accordion title="Installing OpenClaw Updates">
 
-Gateway updates started in the Control UI now identify the target, require confirmation, show progress through the update and restart, and report the final outcome. On eligible signed Mac apps, that flow updates the app first and then only the app-managed local Gateway; browser and user-managed installs keep their Gateway-only path.
+Gateway updates started in the [Control UI](/install/updating) now identify the target, require confirmation, show progress through the update and restart, and report the final outcome. On eligible signed Mac apps, that flow updates the app first and then only the app-managed local Gateway; browser and user-managed installs keep their Gateway-only path.
 
-Supported CLI updates check Node compatibility, package-manager lifecycle rules, and whether npm, pnpm, or Bun owns the installation before replacement. An unsafe candidate stops while leaving the previous CLI runnable, and an exact `openclaw update --dry-run` previews the path without changing configuration, handoff, cleanup, or restart state.
+[Supported CLI updates](/cli/update) check Node compatibility, package-manager lifecycle rules, and whether npm, pnpm, or Bun owns the installation before replacement. An unsafe candidate stops while leaving the previous CLI runnable, and an exact `openclaw update --dry-run` previews the path without changing configuration, handoff, cleanup, or restart state.
 
 One upgrade path still needs a manual repair. If you are on OpenClaw 2026.7.1 with pnpm 11, run `pnpm add -g openclaw@latest` once. OpenClaw does not upgrade Node for you.
 
@@ -2557,9 +2557,9 @@ One upgrade path still needs a manual repair. If you are on OpenClaw 2026.7.1 wi
 
 <Accordion title="Configuration Errors and Service Repairs">
 
-Bad configuration now stops with a useful answer instead of quietly starting OpenClaw with something else. Packaged builds, CLI checks, service preflight, and Gateway startup show the file, line, full setting path, allowed values when available, and a safe version of what was received; malformed top-level scalar files fail closed instead of loading defaults.
+Bad [configuration](/gateway/configuration) now stops with a useful answer instead of quietly starting OpenClaw with something else. Packaged builds, CLI checks, service preflight, and Gateway startup show the file, line, full setting path, allowed values when available, and a safe version of what was received; malformed top-level scalar files fail closed instead of loading defaults.
 
-If you are upgrading a configuration that still contains retired keys, run `openclaw doctor --fix` before September 18, 2026. Doctor keeps canonical values when old and new keys conflict and removes settings that no longer do anything, although explicitly retired tuning values return to the built-in defaults.
+If you are upgrading a configuration that still contains retired keys, run `openclaw doctor --fix` before September 18, 2026. [Doctor](/cli/doctor) keeps canonical values when old and new keys conflict and removes settings that no longer do anything, although explicitly retired tuning values return to the built-in defaults.
 
 Supported Gateway service repairs preserve the installed state directory, config path, port, managed environment, and eligible file-backed credentials instead of silently retargeting the service. Changing those targets intentionally requires `openclaw gateway install --force`; on Linux, service commands also refuse conflicting user and system units and show which unit owns the Gateway.
 
@@ -2732,7 +2732,7 @@ Supported Gateway service repairs preserve the installed state directory, config
 
 <Accordion title="OpenClaw Restarts and Running Work">
 
-Before a supported snapshot or targeted restart, Gateway suspend and resume can pause new ordinary work, report blockers, and drain the agent runs, deliveries, scheduled jobs, queues, sessions, and background commands OpenClaw already tracks. Failed configuration reloads keep the prior coherent state, and rapid configuration writes retain pending restart intent instead of dropping it.
+Before a supported snapshot or [targeted restart](/gateway/restart-recovery), Gateway suspend and resume can pause new ordinary work, report blockers, and drain the agent runs, deliveries, scheduled jobs, queues, sessions, and background commands OpenClaw already tracks. Failed configuration reloads keep the prior coherent state, and rapid configuration writes retain pending restart intent instead of dropping it.
 
 After restart, health checks, the agent list, and core controls become usable before optional catalog, plugin, and migration work finishes. That work is deferred rather than removed, so the first explicit catalog request can still take longer.
 
@@ -2973,9 +2973,9 @@ The wait covers work OpenClaw tracks. New channel or external ingress, existing 
 
 <Accordion title="Troubleshooting, System Health, and Logs">
 
-Doctor now spends less time reciting healthy inventory and more time showing what broke and what to do next. A recoverable interactive startup failure can offer one confirmed `doctor --fix` attempt, while an unrecoverable configuration stays unchanged with exact instructions to inspect, edit, or move it aside. Bare `openclaw doctor --json` is a read-only advisory check; use `openclaw doctor --lint --all` when you need the advisory checks omitted from the default run.
+[Doctor](/cli/doctor) now spends less time reciting healthy inventory and more time showing what broke and what to do next. A recoverable interactive startup failure can offer one confirmed `doctor --fix` attempt, while an unrecoverable configuration stays unchanged with exact instructions to inspect, edit, or move it aside. Bare `openclaw doctor --json` is a read-only advisory check; use `openclaw doctor --lint --all` when you need the advisory checks omitted from the default run.
 
-Logs now fill their bounded tail window across short reads, preserve Unicode at file boundaries, distinguish line and byte truncation from rollover, and report unavailable storage instead of an empty success. Status keeps its base report when optional health details fail, so missing information remains unknown rather than being shown as healthy.
+[Logs](/cli/logs) now fill their bounded tail window across short reads, preserve Unicode at file boundaries, distinguish line and byte truncation from rollover, and report unavailable storage instead of an empty success. Status keeps its base report when optional health details fail, so missing information remains unknown rather than being shown as healthy.
 
 In the admin Control UI, Ask OpenClaw can turn consequential health state into a diagnostic question and keep the system-care conversation docked as you move around, while the System overlay shows a short history of scheduler pressure, CPU, memory, event-loop delay, and optional disk activity. These controls require admin or operator access and do not appear during onboarding or to read-scoped clients.
 
@@ -3281,7 +3281,7 @@ In the admin Control UI, Ask OpenClaw can turn consequential health state into a
 
 Commands used by scripts now have a more predictable machine interface. The named JSON and JSONL commands keep terminal-reset bytes out of stdout and return a consistent structured error when an invocation fails, so automation no longer has to special-case them.
 
-Shell completion installation and refresh preserve unrelated profile content and permissions while publishing profiles and caches atomically across Bash, Zsh, Fish, and PowerShell. Remote Gateway turns and common read-only commands also skip startup work they do not need, while local probes and human output keep fuller validation; mistyped commands now point to the command tree that rejected them, nearby commands, and the correct help.
+[Shell completion](/cli) installation and refresh preserve unrelated profile content and permissions while publishing profiles and caches atomically across Bash, Zsh, Fish, and PowerShell. Remote Gateway turns and common read-only commands also skip startup work they do not need, while local probes and human output keep fuller validation; mistyped commands now point to the command tree that rejected them, nearby commands, and the correct help.
 
 The predictable machine-output contract covers the named command paths. Human diagnostics can still appear on stderr, successful degraded results remain command-specific, and raw lifecycle-error redaction is not yet universal.
 
@@ -3460,9 +3460,9 @@ The predictable machine-output contract covers the named command paths. Human di
 
 <Accordion title="Backup, restore, reset, and uninstall">
 
-Reset and uninstall now refuse to remove data until the Gateway service is torn down and OpenClaw can establish that no other process owns the state. If teardown or ownership checks fail, the state stays put, and a state-only uninstall leaves configured workspaces alone.
+[Reset and uninstall](/cli/reset) now refuse to remove data until the Gateway service is torn down and OpenClaw can establish that no other process owns the state. If teardown or ownership checks fail, the state stays put, and a state-only uninstall leaves configured workspaces alone.
 
-New full backups preserve configured agent state roots and safe relative links, avoid mistaking active archive work for a stall, and restore default or custom layouts through the same guarded flow. Managed `dev/` checkouts and local source edits still need a separate backup, while older archives containing absolute generated `plugin-skills/` links remain rejected.
+New [full backups](/cli/backup) preserve configured agent state roots and safe relative links, avoid mistaking active archive work for a stall, and restore default or custom layouts through the same guarded flow. Managed `dev/` checkouts and local source edits still need a separate backup, while older archives containing absolute generated `plugin-skills/` links remain rejected.
 
 Known-vulnerable Node and SQLite combinations now stop before state opens, with guidance for whether the embedded Node runtime or shared system SQLite library needs upgrading.
 
@@ -3535,7 +3535,7 @@ Known-vulnerable Node and SQLite combinations now stop before state opens, with 
 
 ## Messaging
 
-Messaging now keeps more of a conversation intact across the places people already talk to their Claw. Telegram gains richer messages and media, Slack keeps live progress and the final answer together, Discord adds opt-in Activities and voice rooms that understand who is present, and the native apps keep media and pending sends inside the conversation where they belong.
+Messaging now keeps more of a conversation intact across the places people already talk to their Claw. [Telegram](/channels/telegram) gains richer messages and media, [Slack](/channels/slack) keeps live progress and the final answer together, [Discord](/channels/discord) adds opt-in Activities and voice rooms that understand who is present, and the native apps keep media and pending sends inside the conversation where they belong.
 
 Across supported channels, OpenClaw now holds accepted messages through managed restarts, reports whether a connection is usable, recovering, or blocked, and preserves an uncertain send instead of blindly sending it again. Recovery starts once OpenClaw has accepted the message, and each service still controls what it can confirm beyond that point.
 
@@ -3543,7 +3543,7 @@ Across supported channels, OpenClaw now holds accepted messages through managed 
 
 <Accordion title="Message Delivery and Recovery">
 
-On supported channels, messages OpenClaw has accepted now stay pending through a managed restart, and channel status shows whether a connection is usable, recovering, or blocked. When a send times out without a confirmed result, OpenClaw keeps that outcome uncertain and can warn on the next contact rather than creating a likely duplicate. Recovery begins after local acceptance.
+On supported channels, [messages OpenClaw has accepted](/concepts/messages) now stay pending through a managed restart, and channel status shows whether a connection is usable, recovering, or blocked. When a send times out without a confirmed result, OpenClaw keeps that outcome uncertain and can warn on the next contact rather than creating a likely duplicate. Recovery begins after local acceptance.
 
 Eligible single-choice questions can use native controls on Telegram, Discord, and Slack, while longer Telegram and Discord turns can show a short status headline with compact tool activity. Multi-select and free-text questions continue through the supported client or text path, and Telegram partial-answer streaming remains a separate opt-in mode.
 
@@ -3862,7 +3862,7 @@ Eligible single-choice questions can use native controls on Telegram, Discord, a
 
 <Accordion title="Telegram">
 
-On rich-enabled Telegram accounts, agents can send native details, tables, checklists, math, maps, file references, locations, venues, and a compatible round video note. Large nested replies paginate within Telegram's limits, and rejected rich structures fall back to the complete plain-text answer instead of dropping the useful part.
+On rich-enabled [Telegram](/channels/telegram) accounts, agents can send native details, tables, checklists, math, maps, file references, locations, venues, and a compatible round video note. Large nested replies paginate within Telegram's limits, and rejected rich structures fall back to the complete plain-text answer instead of dropping the useful part.
 
 Busy conversations hold together better too. Follow-ups stay ordered during active work, accepted updates can resume after a restart, abandoned delivery claims stop freezing the chat, and verified public poll activity returns to the chat or forum topic where it began. Anonymous polls remain display-only, and quoted text reaches the agent as attributed quotation rather than active instructions.
 
@@ -4074,7 +4074,7 @@ Busy conversations hold together better too. Follow-ups stay ordered during acti
 
 <Accordion title="Discord">
 
-Discord now supports opt-in Activities that open configured OpenClaw widgets directly inside Discord. Voice agents can also see who is in the room, use different wake-name rules for one-on-one and group conversations, and optionally join only while a human is present. Activities require explicit channel configuration, a Discord client secret, and a public HTTPS route; occupied-room auto-join is a separate option and does not change the existing always-on default.
+[Discord](/channels/discord) now supports opt-in [Activities](/channels/discord-activities) that open configured OpenClaw widgets directly inside Discord. Voice agents can also see who is in the room, use different wake-name rules for one-on-one and group conversations, and optionally join only while a human is present. Activities require explicit channel configuration, a Discord client secret, and a public HTTPS route; occupied-room auto-join is a separate option and does not change the existing always-on default.
 
 Message retries now reuse their identity to reduce duplicates, interaction replies settle in order, stale reply context is discarded, and repeated resume failures can recover without restarting all of OpenClaw. Forum-thread sends still remain uncertain when retrying them could produce a duplicate.
 
@@ -4244,7 +4244,7 @@ Message retries now reuse their identity to reduce duplicates, interaction repli
 
 <Accordion title="Slack">
 
-Slack progress now stays in one conversation from the first status through the final answer, keeping the running commentary, work steps, and answer inside one streamed message unless an operator chooses the more compact alternative. Charts and tables can render natively too, with readable text preserved when Slack cannot use the native form.
+[Slack](/channels/slack) progress now stays in one conversation from the first status through the final answer, keeping the running commentary, work steps, and answer inside one streamed message unless an operator chooses the more compact alternative. Charts and tables can render natively too, with readable text preserved when Slack cannot use the native form.
 
 One organization-installed app can also serve the Enterprise Grid workspaces Slack grants it, with messages, actions, approvals, and proactive delivery bound to the right workspace. Destinations outside the current conversation require an explicit workspace, requests without verified workspace identity are rejected, and relay mode plus org-wide surfaces remain unsupported.
 
@@ -4401,7 +4401,7 @@ One organization-installed app can also serve the Enterprise Grid workspaces Sla
 
 <Accordion title="WhatsApp">
 
-WhatsApp can now list groups from the linked account without making someone hunt through logs or invite links, and it avoids opening a competing connection while OpenClaw already owns that account. If OpenClaw restarts after accepting an incoming message, the pending work can continue without later events jumping ahead, while multipart replies keep the parts and receipts that actually succeeded instead of replaying the entire response after one part fails.
+[WhatsApp](/channels/whatsapp) can now list groups from the linked account without making someone hunt through logs or invite links, and it avoids opening a competing connection while OpenClaw already owns that account. If OpenClaw restarts after accepting an incoming message, the pending work can continue without later events jumping ahead, while multipart replies keep the parts and receipts that actually succeeded instead of replaying the entire response after one part fails.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -4467,7 +4467,7 @@ WhatsApp can now list groups from the linked account without making someone hunt
 
 <Accordion title="Signal">
 
-Signal replies now keep their native quote block through ordinary, chunked, media, and durable delivery when quoting is enabled. Messages received just before a crash can resume from local storage, and a failed recipient is reported instead of disappearing into a false success. Group sends remain conservative after any member receives the message, so one failed recipient does not cause the whole reply to be repeated to everyone else.
+[Signal](/channels/signal) replies now keep their native quote block through ordinary, chunked, media, and durable delivery when quoting is enabled. Messages received just before a crash can resume from local storage, and a failed recipient is reported instead of disappearing into a false success. Group sends remain conservative after any member receives the message, so one failed recipient does not cause the whole reply to be repeated to everyone else.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -4519,7 +4519,7 @@ Signal replies now keep their native quote block through ordinary, chunked, medi
 
 <Accordion title="iMessage and BlueBubbles">
 
-iMessage is now an official installable plugin that carries existing configuration and state through the move out of core. Eligible approval requests can use native Messages polls, while older bridges, SMS, and failed poll sends keep the existing text, reaction, or command fallback.
+[iMessage](/channels/imessage) is now an official installable plugin that carries existing configuration and state through the move out of core. Eligible approval requests can use native Messages polls, while older bridges, SMS, and failed poll sends keep the existing text, reaction, or command fallback.
 
 Remote Mac setups also keep attachments with the correct existing chat and can use supported remote paths and actions without sharing a filesystem with the machine running OpenClaw, while incoming messages already stored before a crash can replay. New setups still need the plugin and `imsg` on a signed-in Mac, and this remains separate from the iOS and macOS OpenClaw chat apps.
 
@@ -4580,7 +4580,7 @@ Remote Mac setups also keep attachments with the correct existing chat and can u
 
 <Accordion title="Feishu and Lark">
 
-In Feishu, an agent can resend a sticker previously received by that bot account and, when an operator adds labels, find the right sticker by keyword. Accepted Feishu messages and comments can also resume after a restart, streaming cards keep the latest accepted version, and unsupported image formats remain available as file attachments instead of being discarded. Sticker actions and labels are opt-in and do not retroactively organize an existing collection; the sticker and comment work is specifically verified for Feishu rather than every Lark path.
+In [Feishu](/channels/feishu), an agent can resend a sticker previously received by that bot account and, when an operator adds labels, find the right sticker by keyword. Accepted Feishu messages and comments can also resume after a restart, streaming cards keep the latest accepted version, and unsupported image formats remain available as file attachments instead of being discarded. Sticker actions and labels are opt-in and do not retroactively organize an existing collection; the sticker and comment work is specifically verified for Feishu rather than every Lark path.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -4656,7 +4656,7 @@ In Feishu, an agent can resend a sticker previously received by that bot account
 
 <Accordion title="Mattermost">
 
-Mattermost can now read bounded, paginated history from channels the bot can already access once an operator enables the feature. Integrations that rewrite or cancel replies now complete that work before delivery, preventing an early preview from exposing content that the hook removes or changes. Completed sends also keep the real Mattermost post identity across previews, actions, media, and durable paths.
+[Mattermost](/channels/mattermost) can now read bounded, paginated history from channels the bot can already access once an operator enables the feature. Integrations that rewrite or cancel replies now complete that work before delivery, preventing an early preview from exposing content that the hook removes or changes. Completed sends also keep the real Mattermost post identity across previews, actions, media, and durable paths.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -4704,7 +4704,7 @@ Mattermost can now read bounded, paginated history from channels the bot can alr
 
 <Accordion title="Matrix">
 
-Matrix replies can now use native spoilers, underline, tables, and up to 100 discoverable room or personal custom emotes. More importantly, an encrypted room now fails visibly when encryption is unavailable instead of quietly falling back to plaintext text, attachments, filenames, or media metadata. Large tables can still choose their own readable formatting fallback without weakening the room's confidentiality boundary.
+[Matrix](/channels/matrix) replies can now use native spoilers, underline, tables, and up to 100 discoverable room or personal custom emotes. More importantly, an encrypted room now fails visibly when encryption is unavailable instead of quietly falling back to plaintext text, attachments, filenames, or media metadata. Large tables can still choose their own readable formatting fallback without weakening the room's confidentiality boundary.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -4774,7 +4774,7 @@ Matrix replies can now use native spoilers, underline, tables, and up to 100 dis
 
 <Accordion title="Microsoft Teams">
 
-Configured Microsoft Teams approvers can approve or deny eligible exec and plugin requests from a native Adaptive Card in the chat or channel thread where the request began, then see the recorded outcome on that same card. Quoted replies, attachments, streaming results, and duplicate handling also stay bound to the originating conversation. The cards cover configured exec and plugin requests only and require valid authentication, permissions, tenant authorization, and routing.
+Configured [Microsoft Teams](/channels/msteams) approvers can approve or deny eligible exec and plugin requests from a native Adaptive Card in the chat or channel thread where the request began, then see the recorded outcome on that same card. Quoted replies, attachments, streaming results, and duplicate handling also stay bound to the originating conversation. The cards cover configured exec and plugin requests only and require valid authentication, permissions, tenant authorization, and routing.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -4824,7 +4824,7 @@ Configured Microsoft Teams approvers can approve or deny eligible exec and plugi
 
 <Accordion title="Google Chat">
 
-Google Chat webhook events accepted by OpenClaw now remain queued through restarts, keep their order within each space, and recognize Google's retries before they create duplicate work. Recovery begins when the Gateway admits the event; events Google never delivered remain outside that recovery path.
+[Google Chat](/channels/googlechat) webhook events accepted by OpenClaw now remain queued through restarts, keep their order within each space, and recognize Google's retries before they create duplicate work. Recovery begins when the Gateway admits the event; events Google never delivered remain outside that recovery path.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -4861,7 +4861,7 @@ Google Chat webhook events accepted by OpenClaw now remain queued through restar
 
 <Accordion title="LINE">
 
-LINE keeps mixed rich replies and their quick actions together, using the reply path for as many as five messages when the response fits instead of consuming Push API quota unnecessarily. A bot can also post one room-specific introduction when it actually joins an allowed group, while respecting both channel-wide and per-account opt-outs. Webhook events are stored before acknowledgement so work OpenClaw already admitted can continue after a restart.
+[LINE](/channels/line) keeps mixed rich replies and their quick actions together, using the reply path for as many as five messages when the response fits instead of consuming Push API quota unnecessarily. A bot can also post one room-specific introduction when it actually joins an allowed group, while respecting both channel-wide and per-account opt-outs. Webhook events are stored before acknowledgement so work OpenClaw already admitted can continue after a restart.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -4921,7 +4921,7 @@ LINE keeps mixed rich replies and their quick actions together, using the reply 
 
 <Accordion title="SMS, MMS, and RCS with Twilio">
 
-The Twilio-backed channel can now send and receive MMS and show recent provider or carrier states such as sent, delivered, failed, or conflicted without retaining message bodies or phone-number addresses. SMS and RCS messages OpenClaw has already accepted can survive a restart in sender order, while replay protection fails closed instead of accepting work it can no longer protect from duplication.
+The [Twilio-backed channel](/channels/sms) can now send and receive MMS and show recent provider or carrier states such as sent, delivered, failed, or conflicted without retaining message bodies or phone-number addresses. SMS and RCS messages OpenClaw has already accepted can survive a restart in sender order, while replay protection fails closed instead of accepting work it can no longer protect from duplication.
 
 Delivery observations are kept for 30 days and reflect the latest state reported by Twilio or a carrier, which can differ from recipient-visible delivery. If the replay cache fills, new events are rejected rather than accepted without duplicate protection, and Twilio does not retry that response by default.
 
@@ -4957,7 +4957,7 @@ Delivery observations are kept for 30 days and reflect the latest state reported
 
 <Accordion title="ClickClack">
 
-ClickClack can place a team discussion beside an OpenClaw session, giving people somewhere to coordinate around the work without turning the agent's main transcript into a meeting room. Guided and command-line setup, readable discussion names, native command menus, attachments, optional group mention rules, and opt-in progress make that room easier to use while keeping the final answer visible.
+[ClickClack](/channels/clickclack) can place a team discussion beside an OpenClaw session, giving people somewhere to coordinate around the work without turning the agent's main transcript into a meeting room. Guided and command-line setup, readable discussion names, native command menus, attachments, optional group mention rules, and opt-in progress make that room easier to use while keeping the final answer visible.
 
 Opening a discussion still requires an authorized operator and a reachable ClickClack deployment. Generated names remain best effort, and mention-gated or bot-to-bot conversations have to be enabled deliberately.
 
@@ -5006,7 +5006,7 @@ Opening a discussion still requires an authorized operator and a reachable Click
 
 <Accordion title="Reef">
 
-Trusted Claws can talk directly through Reef, OpenClaw's bundled end-to-end encrypted agent channel, using friend-code pairing, direction-specific guard policies, terminal registration and friendship controls, and discovery that keeps an external peer distinct from a local thread. When a peer rejects a message, the sending agent gets bounded feedback and one controlled chance to rephrase before it stops for owner guidance instead of arguing in a loop.
+Trusted Claws can talk directly through [Reef](/channels/reef), OpenClaw's bundled end-to-end encrypted agent channel, using friend-code pairing, direction-specific guard policies, terminal registration and friendship controls, and discovery that keeps an external peer distinct from a local thread. When a peer rejects a message, the sending agent gets bounded feedback and one controlled chance to rephrase before it stops for owner guidance instead of arguing in a loop.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -5049,7 +5049,7 @@ Trusted Claws can talk directly through Reef, OpenClaw's bundled end-to-end encr
 
 <Accordion title="Agent-to-Agent Messaging with A2A">
 
-OpenClaw can now expose selected agents to explicitly trusted external agent systems through the A2A v1.0 protocol. Configured peers can discover those agents, submit and poll authenticated tasks, receive replies as artifacts, and exchange text or structured data, while an unconfigured plugin registers no discovery or task routes at all.
+OpenClaw can now expose selected agents to explicitly trusted external agent systems through the [A2A v1.0 protocol](/channels/a2a). Configured peers can discover those agents, submit and poll authenticated tasks, receive replies as artifacts, and exchange text or structured data, while an unconfigured plugin registers no discovery or task routes at all.
 
 This first version supports one account, keeps tasks in memory, and does not yet provide streaming, push notifications, or cancellation. Authenticated peers currently operate as trusted callers rather than passing through the normal command-policy decision, so this is a deliberate interoperability path for known peers rather than a public agent endpoint.
 
@@ -5070,7 +5070,7 @@ This first version supports one account, keeps tasks in memory, and does not yet
 
 <Accordion title="Buzz">
 
-Buzz is now an official OpenClaw channel for team rooms, with guided setup that can route different rooms to different agents and live directories that give those agents current room and member names without replacing the stable UUIDs used for automation. Replies can use native mentions and threads, and mention-gated rooms can carry a small amount of recent authorized context into the next turn without running the model on every background message.
+[Buzz](/channels/buzz) is now an official OpenClaw channel for team rooms, with guided setup that can route different rooms to different agents and live directories that give those agents current room and member names without replacing the stable UUIDs used for automation. Replies can use native mentions and threads, and mention-gated rooms can carry a small amount of recent authorized context into the next turn without running the model on every background message.
 
 Setup finishes only after Bot-role membership is verified, a room name must resolve uniquely before it can be used safely, native mentions cap at 50, and passive context remains opt-in and tightly bounded.
 
@@ -5107,7 +5107,7 @@ Setup finishes only after Bot-role membership is verified, a room name must reso
 
 <Accordion title="QQ Bot">
 
-QQ Bot has moved to Tencent's integrity-pinned external plugin while keeping the public `qqbot` channel ID and carrying existing credentials, account selection, allowlists, approval restrictions, streaming behavior, and group tool policy when Tencent 2.0 can represent them safely. If an older policy cannot be translated without weakening it, Doctor stops for an explicit repair instead of quietly changing the rules. Inbound envelopes already accepted into the local queue can also resume after a restart.
+[QQ Bot](/channels/qqbot) has moved to Tencent's integrity-pinned external plugin while keeping the public `qqbot` channel ID and carrying existing credentials, account selection, allowlists, approval restrictions, streaming behavior, and group tool policy when Tencent 2.0 can represent them safely. If an older policy cannot be translated without weakening it, Doctor stops for an explicit repair instead of quietly changing the rules. Inbound envelopes already accepted into the local queue can also resume after a restart.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -5158,7 +5158,7 @@ QQ Bot has moved to Tencent's integrity-pinned external plugin while keeping the
 
 <Accordion title="Zalo and Zalo Personal">
 
-Zalo Bot and Zalo Personal now keep accepted messages through restarts using separate recovery paths. Zalo Bot records a webhook before acknowledging it, while Zalo Personal resumes accepted socket messages from its account queue without one delayed conversation holding up unrelated chats. Polling and webhook modes remain mutually exclusive, and targeting, reactions, formatting, delivery errors, and partial receipts remain specific to the path that handled the message.
+[Zalo Bot](/channels/zalo) and [Zalo Personal](/channels/zalouser) now keep accepted messages through restarts using separate recovery paths. Zalo Bot records a webhook before acknowledging it, while Zalo Personal resumes accepted socket messages from its account queue without one delayed conversation holding up unrelated chats. Polling and webhook modes remain mutually exclusive, and targeting, reactions, formatting, delivery errors, and partial receipts remain specific to the path that handled the message.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -5194,7 +5194,7 @@ Zalo Bot and Zalo Personal now keep accepted messages through restarts using sep
 
 <Accordion title="Tlon and Urbit">
 
-Tlon now saves an accepted Urbit message before acknowledging it, so work already admitted to OpenClaw can resume after a restart without immediately abandoning the server cursor. Replies gain native Markdown lists, and oversized SSE events or JSON payloads stop before they can grow in memory without bound.
+[Tlon](/channels/tlon) now saves an accepted Urbit message before acknowledging it, so work already admitted to OpenClaw can resume after a restart without immediately abandoning the server cursor. Replies gain native Markdown lists, and oversized SSE events or JSON payloads stop before they can grow in memory without bound.
 
 There is one hard recovery limit. If Eyre has definitively deleted a channel, OpenClaw can create and subscribe to another one, but the old cursor and its server-side history are gone.
 
@@ -5240,7 +5240,7 @@ There is one hard recovery limit. If Eyre has definitively deleted a channel, Op
 
 <Accordion title="Nextcloud Talk">
 
-Nextcloud Talk can now process different rooms concurrently while preserving message order within each room. Up to 32 deliveries can be active at once, with excess work queued, and sends or reactions to an unresponsive self-hosted or remote server now fail within a bounded time instead of hanging indefinitely.
+[Nextcloud Talk](/channels/nextcloud-talk) can now process different rooms concurrently while preserving message order within each room. Up to 32 deliveries can be active at once, with excess work queued, and sends or reactions to an unresponsive self-hosted or remote server now fail within a bounded time instead of hanging indefinitely.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -5267,7 +5267,7 @@ Nextcloud Talk can now process different rooms concurrently while preserving mes
 
 <Accordion title="Nostr">
 
-A Nostr direct message can move to the next configured relay when one cannot connect, return the real connection error when every relay fails, and expose the successful relay's real event ID instead of a synthetic timestamp. Named accounts, protected keys, profile imports, reply targets, and ordered encrypted chunks also stay attached to the selected account more consistently.
+A [Nostr](/channels/nostr) direct message can move to the next configured relay when one cannot connect, return the real connection error when every relay fails, and expose the successful relay's real event ID instead of a synthetic timestamp. Named accounts, protected keys, profile imports, reply targets, and ordered encrypted chunks also stay attached to the selected account more consistently.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -5297,7 +5297,7 @@ A Nostr direct message can move to the next configured relay when one cannot con
 
 <Accordion title="Synology Chat">
 
-Synology Chat now records inbound webhook work before returning success, allowing accepted messages to resume after a restart. If the local write fails, OpenClaw returns an error so the sender can redeliver, while the upstream retry remains controlled by Synology. Long Unicode replies keep their order, lookups and responses are bounded, and uncertain outbound sends remain unresolved instead of being replayed into a duplicate.
+[Synology Chat](/channels/synology-chat) now records inbound webhook work before returning success, allowing accepted messages to resume after a restart. If the local write fails, OpenClaw returns an error so the sender can redeliver, while the upstream retry remains controlled by Synology. Long Unicode replies keep their order, lookups and responses are bounded, and uncertain outbound sends remain unresolved instead of being replayed into a duplicate.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -5326,7 +5326,7 @@ Synology Chat now records inbound webhook work before returning success, allowin
 
 <Accordion title="Twitch">
 
-Twitch chat already accepted into OpenClaw's local queue can continue after a process crash. Stalled user lookups can be cancelled, stopped accounts stay stopped even when an earlier connection attempt finishes late, and ordinary replies keep normalized attachment links while internal tool traces and XML scaffolding are removed before they reach chat.
+[Twitch](/channels/twitch) chat already accepted into OpenClaw's local queue can continue after a process crash. Stalled user lookups can be cancelled, stopped accounts stay stopped even when an earlier connection attempt finishes late, and ordinary replies keep normalized attachment links while internal tool traces and XML scaffolding are removed before they reach chat.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -5350,7 +5350,7 @@ Twitch chat already accepted into OpenClaw's local queue can continue after a pr
 
 <Accordion title="IRC">
 
-IRC channel messages already admitted to OpenClaw can resume in order after a restart without echoing the bot's own replies back into the room. Direct-message recovery stays tied to the connection that accepted it and stops if that identity changes, while mentions follow IRC nickname rules, Markdown becomes readable plain text, and internal tool traces stay out of the channel.
+[IRC](/channels/irc) channel messages already admitted to OpenClaw can resume in order after a restart without echoing the bot's own replies back into the room. Direct-message recovery stays tied to the connection that accepted it and stops if that identity changes, while mentions follow IRC nickname rules, Markdown becomes readable plain text, and internal tool traces stay out of the channel.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -5372,7 +5372,7 @@ IRC channel messages already admitted to OpenClaw can resume in order after a re
 
 <Accordion title="Android Chat">
 
-Android now writes text, images, and voice notes to its outbox before using the network, keeping them through offline periods and restarts until conversation history confirms delivery. If the outcome remains uncertain, the item stays visible with explicit Retry and Delete controls and is not sent again automatically.
+[Android](/platforms/android) now writes text, images, and voice notes to its outbox before using the network, keeping them through offline periods and restarts until conversation history confirms delivery. If the outcome remains uncertain, the item stays visible with explicit Retry and Delete controls and is not sent again automatically.
 
 Supported audio and video play inline, video uses the native upload flow, and notification replies return to the exact saved conversation or fail. Older 2026.7.x OpenClaw installations use a reduced compatibility path.
 
@@ -5400,7 +5400,7 @@ Supported audio and video play inline, video uses the native upload flow, and no
 
 <Accordion title="iOS and macOS Chat">
 
-The iOS and macOS OpenClaw apps can play supported managed audio and video inside chat, upload video from the native composer, and hand the active attachment to system Now Playing controls. A slow accepted reply stays visibly pending while live state and saved history reconcile, so late history cannot clear a newer turn just because it arrived second.
+The [iOS](/platforms/ios) and [macOS](/platforms/macos) OpenClaw apps can play supported managed audio and video inside chat, upload video from the native composer, and hand the active attachment to system Now Playing controls. A slow accepted reply stays visibly pending while live state and saved history reconcile, so late history cannot clear a newer turn just because it arrived second.
 
 A run that truly produces no output eventually releases the composer without inventing a reply. Native video uploads retain the 20 MB limit, and these chat apps remain separate from the iMessage channel plugin.
 
@@ -5431,7 +5431,7 @@ A run that truly produces no output eventually releases the composer without inv
 
 <Accordion title="Control UI, WebChat, and TUI">
 
-Control UI chat now gives supported managed audio and video their own cards instead of treating every attachment like a download, including a clear preparing or unavailable state when the media is not ready. Across Control UI, WebChat, and TUI, prompts, live work, attachments, and replies stay aligned when several clients share a conversation or reconnect at different times.
+[Control UI chat](/web/webchat) now gives supported managed audio and video their own cards instead of treating every attachment like a download, including a clear preparing or unavailable state when the media is not ready. Across Control UI, WebChat, and TUI, prompts, live work, attachments, and replies stay aligned when several clients share a conversation or reconnect at different times.
 
 These are OpenClaw's own chat clients rather than external messaging services, and the saved conversation remains the final record when a live update and refreshed history disagree.
 
@@ -5477,7 +5477,7 @@ These are OpenClaw's own chat clients rather than external messaging services, a
 
 <Accordion title="Voice calls">
 
-Voice Call can opt into an agent's main transcript when an operator wants phone and desktop conversations to share history, while the default remains one session per phone. Realtime agents can speak their final words and request a hangup, and failed startup, carrier hangup, or media silence now closes the unusable session instead of leaving it active until the maximum duration.
+[Voice Call](/plugins/voice-call) can opt into an agent's main transcript when an operator wants phone and desktop conversations to share history, while the default remains one session per phone. Realtime agents can speak their final words and request a hangup, and failed startup, carrier hangup, or media silence now closes the unusable session instead of leaving it active until the maximum duration.
 
 Choosing the main transcript places raw call turns in primary history. A carrier can still reject a requested hangup, and carrier, provider-media, Discord, Talk, and Meet calls keep their own credentials and lifecycle rather than being treated as one interchangeable voice system.
 
@@ -5521,7 +5521,7 @@ Choosing the main transcript places raw call turns in primary history. A carrier
 
 <Accordion title="Raft">
 
-Raft setup now says clearly when the machine running OpenClaw cannot find the Raft executable instead of presenting a configured channel as healthy. A passing probe means the command-line tool was available at that moment, not that a later connection or message has already succeeded.
+[Raft](/channels/raft) setup now says clearly when the machine running OpenClaw cannot find the Raft executable instead of presenting a configured channel as healthy. A passing probe means the command-line tool was available at that moment, not that a later connection or message has already succeeded.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -5538,7 +5538,7 @@ Raft setup now says clearly when the machine running OpenClaw cannot find the Ra
 
 ## Memory
 
-Memory now lets an eligible personal Claw recall relevant context from that agent's other private conversations, including what mattered immediately before a reset, while visible workflows let you search indexed sources, inspect how memory is working, import supported history, and remove attributable derived memory. Recall stays within the same agent's private conversations and respects explicit isolation and access policy.
+[Memory](/concepts/memory) now lets an eligible personal Claw recall relevant context from that agent's other private conversations, including what mattered immediately before a reset, while visible workflows let you search indexed sources, inspect how memory is working, import supported history, and remove attributable derived memory. Recall stays within the same agent's private conversations and respects explicit isolation and access policy.
 
 Built-in Memory owns the core search and recall path, with a supported Doctor migration from QMD. LanceDB, Memory Wiki, external embedding services, `MEMORY.md`, and `USER.md` still have distinct roles, and forgetting derived memory does not erase the original conversation or copies outside OpenClaw.
 
@@ -5546,7 +5546,7 @@ Built-in Memory owns the core search and recall path, with a supported Doctor mi
 
 <Accordion title="Upgrading to built-in Memory">
 
-Built-in Memory now owns the core search and recall path. If you use QMD, run `openclaw doctor --fix` to remove retired QMD settings, carry forward supported extra paths and any session indexing you explicitly enabled, preserve compatible rows already in the agent database, and rebuild the index from canonical Markdown.
+[Built-in Memory](/concepts/memory-builtin) now owns the core search and recall path. If you use [QMD](/concepts/memory-qmd), run `openclaw doctor --fix` to remove retired QMD settings, carry forward supported extra paths and any session indexing you explicitly enabled, preserve compatible rows already in the agent database, and rebuild the index from canonical Markdown.
 
 The migration carries supported data into a different core, so QMD-only reranking, query expansion, and cross-agent transcript search are retired. Malformed structures, incompatible vector dimensions, and data without a safe owner remain stopped for repair.
 
@@ -5588,9 +5588,9 @@ The migration carries supported data into a different core, so QMD-only rerankin
 
 On eligible personal setups, your Claw can recall relevant context from that same agent's other private conversations by default, including what mattered immediately before you reset the session. Recall remains limited to that agent's private conversations; groups, channels, shared aliases, other agents, deleted history, and policy-blocked sources stay out, and an explicit direct-message isolation setting still wins.
 
-Built-in search now understands filenames, full and partial Unicode paths, and configured extra paths, broadens thin strict matches, and keeps keyword results available when an optional embedding provider cannot start. Search stays within the configured roots and agent boundaries, while required embedding providers fail closed.
+[Built-in search](/concepts/memory-search) now understands filenames, full and partial Unicode paths, and configured extra paths, broadens thin strict matches, and keeps keyword results available when an optional embedding provider cannot start. Search stays within the configured roots and agent boundaries, while required embedding providers fail closed.
 
-Sessions without a configured reset policy now remain open across days, and durable reset or compaction markers explain visible history changes. SQLite-backed chats on web, macOS, iOS, and Android can rewind to a user message, fork the conversation, and switch among preserved branches. Rewinding changes the transcript branch, but it does not undo files, sent messages, or other tool side effects.
+Sessions without a configured reset policy now remain open across days, and durable reset or compaction markers explain visible history changes. SQLite-backed chats on web, macOS, iOS, and Android can rewind to a user message, [fork the conversation](/concepts/session), and switch among preserved branches. Rewinding changes the transcript branch, but it does not undo files, sent messages, or other tool side effects.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -5793,7 +5793,7 @@ Sessions without a configured reset policy now remain open across days, and dura
 
 <Accordion title="Importing memories and conversation history">
 
-Importing is separate from the QMD-to-built-in upgrade. You can bring supported memory from Codex, Claude Code, or Hermes into an agent workspace through the Control UI, first-run setup, or Ask OpenClaw while leaving the source alone and not sweeping in credentials, settings, skills, or arbitrary provider files. If the destination already contains conflicting content, replacement has to be reviewed explicitly.
+Importing is separate from the QMD-to-built-in upgrade. You can [bring supported memory](/install/migrating) from Codex, Claude Code, or Hermes into an agent workspace through the Control UI, first-run setup, or Ask OpenClaw while leaving the source alone and not sweeping in credentials, settings, skills, or arbitrary provider files. If the destination already contains conflicting content, replacement has to be reviewed explicitly.
 
 Old conversations follow their own preview-first path. The CLI shows what it would stage before it writes, the Control UI reports bounded-batch progress, and material owned by that import can be rolled back and applied again. Large histories use bounded or indexed processing, Memory Wiki preserves human notes through supported imports, and older history without complete ownership tracking may need to be rescanned. Staged material still does not become durable memory until dreaming or an explicit promotion chooses it.
 
@@ -5838,11 +5838,11 @@ Old conversations follow their own preview-first path. The CLI shows what it wou
 
 <Accordion title="Reviewing, creating, and forgetting memories">
 
-Settings now has a Memory destination for live status, Dreams, configuration, indexed-source search and browsing, add-on controls, and embedding readiness, so you can see what your Claw has available and open safe workspace memory files. Session and legacy sources remain snippet-only, and add-on changes remain read-only unless the connection has admin authorization.
+Settings now has a [Memory destination](/concepts/memory) for live status, Dreams, configuration, indexed-source search and browsing, add-on controls, and embedding readiness, so you can see what your Claw has available and open safe workspace memory files. Session and legacy sources remain snippet-only, and add-on changes remain read-only unless the connection has admin authorization.
 
 Eligible observations can be consolidated into `MEMORY.md`, durable directives can live in `USER.md`, standing intents can wait for the right event, and project memories stay scoped to the project that produced them. Automatic memory remains bounded and provenance-gated, so content derived from network or restricted sessions keeps an untrusted origin and stays out of automatic context even though an explicit search can still surface it. This provenance protection applies to newly tracked material, while older untracked files retain their existing classification.
 
-`openclaw memory forget` lets you preview a purge by session, hook source, or participant, then remove attributable derived memory and stop the selected session from being pulled back in by backfill, indexing, or dreaming. The purge follows recorded provenance, so the original transcript, older lineage-free notes, other agents' stores, direct or external writes, exports, and backups may remain. Review the preview before applying it.
+[`openclaw memory forget`](/cli/memory) lets you preview a purge by session, hook source, or participant, then remove attributable derived memory and stop the selected session from being pulled back in by backfill, indexing, or dreaming. The purge follows recorded provenance, so the original transcript, older lineage-free notes, other agents' stores, direct or external writes, exports, and backups may remain. Review the preview before applying it.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -5954,7 +5954,7 @@ Eligible observations can be consolidated into `MEMORY.md`, durable directives c
 
 ## Skills
 
-Skills turn the way you work into reusable instructions your Claw can follow again, and this release connects the entire path. You can create and validate a skill, find or install it, call it directly from a conversation, review proposed changes, and have supported edits ready on the next turn of a persistent session. Invalid skills are reported individually, so the rest of the catalog remains available.
+[Skills](/tools/skills) turn the way you work into reusable instructions your Claw can follow again, and this release connects the entire path. You can create and validate a skill, find or install it, call it directly from a conversation, review proposed changes, and have supported edits ready on the next turn of a persistent session. Invalid skills are reported individually, so the rest of the catalog remains available.
 
 Skill Workshop brings proposals, checks, decisions, and applied history into one workflow. Self-learning can turn substantial work and durable corrections into proposed improvements, or maintain skills created through Workshop when automatic learning is enabled, while skills owned by you or someone else stay under their owner's control.
 
@@ -5962,7 +5962,7 @@ Skill Workshop brings proposals, checks, decisions, and applied history into one
 
 <Accordion title="Creating and checking skills">
 
-Creating a skill now follows one guided path from choosing how it should be invoked through adding supporting files, saving it, and validating the result. The checker understands supported invocation metadata and catches problems such as an overlong description before anything is written.
+[Creating a skill](/tools/creating-skills) now follows one guided path from choosing how it should be invoked through adding supporting files, saving it, and validating the result. The checker understands supported invocation metadata and catches problems such as an overlong description before anything is written.
 
 OpenClaw now reports malformed metadata, unreadable files, oversized instructions, and shadowed copies against the skill that caused them, while continuing to load valid skills around it. In a persistent Gateway session, edits to canonical and managed-worktree skills are available on the next turn, and required skill instructions are read in full.
 
@@ -5990,7 +5990,7 @@ OpenClaw now reports malformed metadata, unreadable files, oversized instruction
 
 <Accordion title="Finding, Installing, and Using Skills">
 
-Installed skills, ClawHub discovery, skill settings, and Skill Workshop now share one Plugins hub, giving you one place to find a skill, install it, configure it, and confirm its current status. Skills and plugins keep their separate lifecycles, while reconnecting or switching the active agent, model, or connectors refreshes the lists from the current Gateway.
+[Installed skills](/tools/skills), ClawHub discovery, skill settings, and Skill Workshop now share one Plugins hub, giving you one place to find a skill, install it, configure it, and confirm its current status. Skills and plugins keep their separate lifecycles, while reconnecting or switching the active agent, model, or connectors refreshes the lists from the current Gateway.
 
 When a skill is available to you and the active agent, you can choose it in chat or name up to eight with `$skill-name` across supported chat and agent entry points, including eligible skills hidden from automatic model selection. The chat picker adds references to your draft without sending it, and Code Mode can list and read eligible skills within its existing sandbox and allowlist. Large model-visible catalogs can still be compacted, so `openclaw skills check` remains the complete inventory.
 
@@ -6027,7 +6027,7 @@ When a skill is available to you and the active agent, you can choose it in chat
 
 <Accordion title="Reviewing Changes in Skill Workshop">
 
-Skill Workshop gives you one place to turn an idea or a reusable lesson from substantial past work into a reviewable skill change. You can inspect the proposed instructions and supporting files, see results from plugin-provided scanners, benchmarks, and graders, revise the proposal, and then apply, reject, or quarantine it. Past-work scans produce pending proposals rather than editing live skills, and Android users can search and inspect them before an authenticated administrator makes a change.
+[Skill Workshop](/tools/skill-workshop) gives you one place to turn an idea or a reusable lesson from substantial past work into a reviewable skill change. You can inspect the proposed instructions and supporting files, see results from plugin-provided scanners, benchmarks, and graders, revise the proposal, and then apply, reject, or quarantine it. Past-work scans produce pending proposals rather than editing live skills, and Android users can search and inspect them before an authenticated administrator makes a change.
 
 Every decision stays bound to the exact proposal revision you reviewed, so a later revision returns for review. Critical prompt-injection findings block application, interrupted applies can recover without overwriting a target changed elsewhere, and an explicitly selected remote Gateway remains the authority for the change. Applied revisions are grouped by skill with newest-first history and comparisons that say when the visible diff is incomplete.
 
@@ -6084,7 +6084,7 @@ Every decision stays bound to the exact proposal revision you reviewed, so a lat
 
 OpenClaw can turn substantial work and durable corrections into reusable skills, then improve the Workshop-created skills that actually shaped a run. New and unconfigured installations start in `auto`, while upgrades keep their existing choice. `off` disables automatic repair, `propose` queues changes for review, and `auto` can create or update Workshop-owned skills with targeted patches or a same-turn repair. The conversation already in progress keeps the version it loaded until the next turn.
 
-Skills you wrote and shared skills owned elsewhere remain yours. Automatic learning can suggest improvements to them, but it cannot rewrite or remove them on its own, and explicit `/learn` or past-work scans also produce proposals for review.
+Skills you wrote and shared skills owned elsewhere remain yours. [Automatic learning](/tools/self-learning) can suggest improvements to them, but it cannot rewrite or remove them on its own, and explicit `/learn` or past-work scans also produce proposals for review.
 
 On supported agent runtimes, optional background review runs separately without interrupting or posting into chat. When both the learning mode and scheduled-job settings allow it, a visible weekly job reviews the collection, records usage and outcomes, preserves specialized skills, and creates recoverable backups. Restoring a backup remains an explicit choice.
 
@@ -6134,7 +6134,7 @@ On supported agent runtimes, optional background review runs separately without 
 
 ## Native Apps
 
-This release makes the native apps useful for more of the work around a conversation. iPhone, iPad, and Android bring voice, attachments, model choices, and conversation controls into Chat, macOS adds Quick Chat from the menu bar or a global shortcut, and Wear OS brings transcripts, replies, Talk, and session controls to a paired watch. Apple Watch retains wrist actions through relaunches and retries, while the Linux desktop companion work now covers a tray, an embedded Control UI, and Quick Chat.
+This release makes the [native apps](/platforms) useful for more of the work around a conversation. iPhone, iPad, and Android bring voice, attachments, model choices, and conversation controls into Chat, macOS adds Quick Chat from the menu bar or a global shortcut, and Wear OS brings transcripts, replies, Talk, and session controls to a paired watch. Apple Watch retains wrist actions through relaunches and retries, while the Linux desktop companion work now covers a tray, an embedded Control UI, and Quick Chat.
 
 Progress cards and assistant-created widgets also bring more of the Claw's active work into supported native conversations, with translations, profile accents, waveforms, and file diffs appearing on the specific clients covered below.
 
@@ -6142,7 +6142,7 @@ Progress cards and assistant-created widgets also bring more of the Claw's activ
 
 <Accordion title="iPhone, iPad, and Apple Watch">
 
-On iPhone and iPad, one Chat surface now handles typing, dictation, voice notes, attachments, realtime Talk, and the session, model, reasoning, and tool-activity controls around a conversation. The sidebar makes it easier to switch agents, search and manage recent conversations, see what needs attention, and pin the destinations used most often.
+On [iPhone and iPad](/platforms/ios), one Chat surface now handles typing, dictation, voice notes, attachments, realtime Talk, and the session, model, reasoning, and tool-activity controls around a conversation. The sidebar makes it easier to switch agents, search and manage recent conversations, see what needs attention, and pin the destinations used most often.
 
 Sharing into OpenClaw now previews supported attachments and shows their progress from preparation through completion or failure. Completed shares in this release support text, links, or one to three images, and Send stays unavailable when an unsupported, excess, or unloadable attachment would otherwise be left out.
 
@@ -6220,7 +6220,7 @@ Apple Watch retains messages, approvals, replies, and commands through relaunche
 
 <Accordion title="Android and Wear OS">
 
-Android puts dictation, voice notes, realtime Talk, model and thinking choices, context use, attachments, and the current Talk, Send, or Stop action into one compact composer, with Photos, Videos, and Files behind one plus menu. Text, links, images, supported audio, and common documents received from the system Sharesheet become drafts for review, and unsupported, oversized, or excess items are shown before anything sends.
+[Android](/platforms/android) puts dictation, voice notes, realtime Talk, model and thinking choices, context use, attachments, and the current Talk, Send, or Stop action into one compact composer, with Photos, Videos, and Files behind one plus menu. Text, links, images, supported audio, and common documents received from the system Sharesheet become drafts for review, and unsupported, oversized, or excess items are shown before anything sends.
 
 Search can reach Gateway-backed sessions beyond cached recents while Android is connected, and Threads can expand related parent and child work with descendant status. When the app is offline, search uses the active sessions already in its cache.
 
@@ -6364,7 +6364,7 @@ The Wear OS companion uses its paired Android phone for the connection and store
 
 <Accordion title="macOS app">
 
-macOS Quick Chat opens from the menu bar or a global shortcut over the app already in use, with a picker for the five most recently updated conversations. It streams the reply in place, switches agents, accepts dictation, and selects a model and reasoning level. Screen Recording permission adds window or region capture, while Accessibility permission adds bounded text from the focused app and lets a final answer paste back where the user was working. Captured context clears after the send or when Quick Chat hides.
+[macOS Quick Chat](/platforms/macos) opens from the menu bar or a global shortcut over the app already in use, with a picker for the five most recently updated conversations. It streams the reply in place, switches agents, accepts dictation, and selects a model and reasoning level. Screen Recording permission adds window or region capture, while Accessibility permission adds bounded text from the focused app and lets a final answer paste back where the user was working. Captured context clears after the send or when Quick Chat hides.
 
 Native chat can now rename, fork, pin, archive, mark read or unread, and organize conversations in parent-child trees and groups, with batch actions, inspection, and worktree-backed creation. A worktree request stops when the chosen agent, parent, worktree, or base reference cannot be honored.
 
@@ -6464,7 +6464,7 @@ The Dashboard returns to its remembered frame, Space, and eligible route through
 
 <Accordion title="Linux app">
 
-The Linux desktop companion work now includes first-run setup, tray and service controls, an embedded Control UI, reconnect handling, deep links, autostart, window restoration, update notices, and native alerts for pending requests. Quick Chat switches agents, keeps one Gateway connection open, streams replies in the bar, and shows whether a send was accepted, failed, or is waiting for reconnection.
+The [Linux desktop companion](/platforms/linux) work now includes first-run setup, tray and service controls, an embedded Control UI, reconnect handling, deep links, autostart, window restoration, update notices, and native alerts for pending requests. Quick Chat switches agents, keeps one Gateway connection open, streams replies in the bar, and shows whether a send was accepted, failed, or is waiting for reconnection.
 
 The build and publication path supports .deb and AppImage packages, although their availability as v2026.8.1 downloads has not yet been verified. The summon shortcut works on X11, Wayland keeps the tray entry, and approval decisions remain in the Dashboard or command line.
 
@@ -6499,9 +6499,9 @@ The build and publication path supports .deb and AppImage packages, although the
 
 <Accordion title="Progress and Presentation by Native App">
 
-On iOS, macOS, and Android, rich progress cards can remain above the composer after a run and return through a relaunch or reconnect when the connected Gateway supports saved cards. Those clients also show a working Claw, elapsed time, and long-wait status while a turn runs, then add a duration and token recap when it completes successfully and unambiguously. Older Gateways can still show live fallback cards, but they cannot restore those cards after relaunch, and Android's fallback can sometimes retain a stale completed status.
+On iOS, macOS, and Android, rich [progress cards](/tools/progress-card) can remain above the composer after a run and return through a relaunch or reconnect when the connected Gateway supports saved cards. Those clients also show a working Claw, elapsed time, and long-wait status while a turn runs, then add a duration and token recap when it completes successfully and unambiguously. Older Gateways can still show live fallback cards, but they cannot restore those cards after relaunch, and Android's fallback can sometimes retain a stale completed status.
 
-Assistant-created widgets can render inline on iOS, Android, macOS, and Linux Quick Chat when the client advertises support, and an eligible connected Mac can also present one in its native Canvas panel. Linux Quick Chat remains text-only when it uses a custom Gateway TLS leaf pin. Expandable file-edit diffs cover a narrower set of clients and appear on iPhone, iPad, and Mac.
+[Assistant-created widgets](/web/dashboards) can render inline on iOS, Android, macOS, and Linux Quick Chat when the client advertises support, and an eligible connected Mac can also present one in its native Canvas panel. Linux Quick Chat remains text-only when it uses a custom Gateway TLS leaf pin. Expandable file-edit diffs cover a narrower set of clients and appear on iPhone, iPad, and Mac.
 
 Runtime translations now reach Android's main workflows and named iPhone, iPad, Live Activity, Apple Watch, and Wear status surfaces, with a per-app language picker on Android. Identity-bound iOS, macOS, and Android connections follow the user's profile accent as it changes across devices, and voice surfaces on iOS, watchOS, macOS, and Android share the same phase-based waveform, using synthetic motion where live metering is unavailable.
 
@@ -6591,7 +6591,7 @@ Runtime translations now reach Android's main workflows and named iPhone, iPad, 
 
 ## Models and Providers
 
-Chat and the Models page now open from the catalog OpenClaw already has, so choosing a model no longer waits for a full provider scan. Live discovery runs only when you open a model screen or explicitly refresh it, keeps the last useful list when a lookup fails, and `/model` can change only the current conversation or deliberately update one agent or the shared default.
+Chat and the [Models page](/concepts/models) now open from the catalog OpenClaw already has, so choosing a model no longer waits for a full provider scan. Live discovery runs only when you open a model screen or explicitly refresh it, keeps the last useful list when a lookup fails, and `/model` can change only the current conversation or deliberately update one agent or the shared default.
 
 Once a model is selected, OpenClaw keeps the request inside the intended provider and authorized account order, preserves the real order and outcome of streamed replies and tool calls, carries reasoning and context settings with the model and runtime, and reports plan windows, token use, context pressure, and estimated cost more clearly.
 
@@ -6599,7 +6599,7 @@ Once a model is selected, OpenClaw keeps the request inside the intended provide
 
 <Accordion title="Finding and choosing models">
 
-Chat and the Models page now start from the catalog OpenClaw already has, with supported providers looking for newer chat and text models when you open a picker or request a refresh. If that lookup fails, the built-in entries and last working list remain available.
+Chat and the [Models page](/concepts/models) now start from the catalog OpenClaw already has, with supported providers looking for newer chat and text models when you open a picker or request a refresh. If that lookup fails, the built-in entries and last working list remain available.
 
 A `/model` change can stay with the current conversation or deliberately apply to one agent or the shared default, with persistent changes requiring the right authority. Aliases and fallback keep the provider and account attached to the selected model.
 
@@ -6881,7 +6881,7 @@ The list shows models OpenClaw can identify, while the provider, account, region
 
 <Accordion title="Provider accounts and sign-in">
 
-OpenClaw now keeps model requests inside the provider accounts and credential order you configured. If one account hits an authentication or quota cooldown, the next authorized account for that provider can take over without changing the selected provider or model, and the saved preference resumes when it recovers. Environment keys remain available when no explicit account list is configured.
+OpenClaw now keeps model requests inside the [provider accounts](/concepts/model-failover) and credential order you configured. If one account hits an authentication or quota cooldown, the next authorized account for that provider can take over without changing the selected provider or model, and the saved preference resumes when it recovers. Environment keys remain available when no explicit account list is configured.
 
 OAuth registration stays with the setup conversation where it began, failed credential writes surface as failures, and a successful login applies only to the model route that authenticated. Tenant and custom-endpoint credentials stay on the account and origin they were configured for.
 
@@ -7007,7 +7007,7 @@ OAuth registration stays with the setup conversation where it began, failed cred
 
 <Accordion title="Streaming Replies and Tool Calls">
 
-OpenClaw now distinguishes a complete streamed reply from one that stopped partway through. On supported Responses paths, reasoning, text, tool output, and available usage remain in order; if a stream fails, valid work that already arrived is preserved, and OpenClaw retries or moves to an authorized fallback only when replay is safe. With no safe recovery path, the partial reply remains attached to the error.
+OpenClaw now distinguishes a complete [streamed reply](/concepts/streaming) from one that stopped partway through. On supported Responses paths, reasoning, text, tool output, and available usage remain in order; if a stream fails, valid work that already arrived is preserved, and OpenClaw retries or moves to an authorized fallback only when replay is safe. With no safe recovery path, the partial reply remains attached to the error.
 
 Tool calls wait for a complete name and arguments before they can run, including large streamed arguments and calls whose provider item IDs change along the way. Unmanaged native OpenAI Responses conversations on the official endpoint with storage enabled can continue by sending only new input after the first turn, then recover with full history if that upstream continuation state expires.
 
@@ -7275,11 +7275,11 @@ Tool calls wait for a complete name and arguments before they can run, including
 
 <Accordion title="Reasoning and context limits">
 
-Reasoning settings now stay attached to the selected model and runtime when a conversation is restored or its authentication route is rebuilt. Native Codex supports Ultra for Sol and Terra and Max for Luna; embedded OpenClaw maps Ultra to the provider's highest supported effort and adds guidance for delegated work, which is a different behavior from native Codex Ultra.
+[Reasoning settings](/concepts/context) now stay attached to the selected model and runtime when a conversation is restored or its authentication route is rebuilt. Native Codex supports Ultra for Sol and Terra and Max for Luna; embedded OpenClaw maps Ultra to the provider's highest supported effort and adds guidance for delegated work, which is a different behavior from native Codex Ultra.
 
 Supported GPT and Claude routes expose larger context options. Normal GPT-5.5 and GPT-5.6 runs use a 272,000-token budget with an opt-in 922,000-token input window, and the Control UI can choose 200K or 1M for supported Claude 5 CLI conversations. These options remain limited to the routes, interfaces, and accounts that support them.
 
-Compaction now uses the latest trustworthy context count rather than accumulated cache billing or duplicated history, preserves tool output across supported Responses checkpoints, and falls back to full history when a stored checkpoint is rejected. Context limits are now configured per model, and Doctor can migrate supported provider-level settings tied to explicit model entries.
+[Compaction](/concepts/compaction) now uses the latest trustworthy context count rather than accumulated cache billing or duplicated history, preserves tool output across supported Responses checkpoints, and falls back to full history when a stored checkpoint is rejected. Context limits are now configured per model, and Doctor can migrate supported provider-level settings tied to explicit model entries.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -7419,7 +7419,7 @@ Compaction now uses the latest trustworthy context count rather than accumulated
 
 OpenClaw now separates subscription-plan information from estimated API cost. Chat can show plan windows, reset times, credits, and the account email attached to a snapshot, while completed iOS replies can show supported input, output, cache, cost, and context-pressure details. These figures are snapshots or estimates, not provider invoices, and in mixed API-key and subscription setups the account label identifies the plan snapshot rather than every run.
 
-The Control UI adds a Profile page for lifetime activity recorded by OpenClaw, with Usage and Profile views grouped in the selected time zone, and plugin-initiated model calls now contribute to aggregate totals. OpenClaw cannot reconstruct activity it never recorded.
+The Control UI adds a Profile page for lifetime activity recorded by OpenClaw, with [Usage](/concepts/usage-tracking) and Profile views grouped in the selected time zone, and plugin-initiated model calls now contribute to aggregate totals. OpenClaw cannot reconstruct activity it never recorded.
 
 Supported failed or incomplete turns can retain the provider's token and cost data without being marked successful. Permanent authentication, model, media, and long-window quota failures stop retrying, while transient rate limits and retryable server errors keep their existing retry or authorized same-provider fallback behavior; Codex subscription runs do not silently switch to pay-as-you-go API keys.
 
@@ -7550,7 +7550,7 @@ Supported failed or incomplete turns can retain the provider's token and cost da
 
 ## Automations and Scheduling
 
-Automations now bring scheduled work together under one name across the agent, Control UI, command line, docs, and supported native apps, while existing Cron commands, settings, jobs, and schedule syntax continue to work.
+[Automations](/automation) now bring scheduled work together under one name across the agent, Control UI, command line, docs, and supported native apps, while existing Cron commands, settings, jobs, and schedule syntax continue to work.
 
 History separates whether an automation ran, whether its result was delivered, and whether the whole request completed. Work genuinely missed during a restart or clock change can return without reviving completed or retired jobs, and connected tools keep only the authority captured when the automation was created or reauthorized, checked against current policy and availability each time it runs.
 
@@ -7558,7 +7558,7 @@ History separates whether an automation ran, whether its result was delivered, a
 
 <Accordion title="Creating and managing automations">
 
-Automations is now the user-facing name in the agent tool, Control UI, command line, and docs, while `openclaw automations` offers the same command family as `openclaw cron`. The old command, `/cron` route, `cron.*` settings and RPC names, schedule expressions, identifiers, and stored jobs continue to work.
+[Automations](/automation/cron-jobs) is now the user-facing name in the agent tool, Control UI, command line, and docs, while `openclaw automations` offers the same command family as `openclaw cron`. The old command, `/cron` route, `cron.*` settings and RPC names, schedule expressions, identifiers, and stored jobs continue to work.
 
 The Control UI is the fullest place to search, filter, create, clone, inspect, edit, run, pause, and remove automations, including advanced delivery and failure routing. iOS and Android expose the fields and actions each client supports, Android changes require administrator scope while read-scoped connections remain inspection-only, and script automations remain visible but read-only on clients that cannot replace their payload.
 
@@ -7642,7 +7642,7 @@ The Control UI is the fullest place to search, filter, create, clone, inspect, e
 
 <Accordion title="Schedules and runs">
 
-An owner can turn the current conversation into a `/loop` or eligible reminder that checks a small amount of recent context when it runs and returns one final answer to the same chat. It starts as a fresh run rather than continuing the original transcript, and work created without a conversation stays isolated.
+An owner can turn the current conversation into a [`/loop`](/automation/cron-jobs) or eligible reminder that checks a small amount of recent context when it runs and returns one final answer to the same chat. It starts as a fresh run rather than continuing the original transcript, and work created without a conversation stays isolated.
 
 Recurring schedules, one-time jobs, manual starts, queued work, restart catch-up, on-exit work, commands, and bounded scripts now share one configured capacity limit. Waiting work starts as room becomes available, while successful scripts can retain a small amount of state, notify a destination, wake the main conversation, or ask to be checked again later. Scripts still have time, tool-call, pacing, and state limits, and can be disabled entirely.
 
@@ -7718,7 +7718,7 @@ Force runs and edits no longer pull recurring work away from its natural schedul
 
 <Accordion title="Triggers and connected tools">
 
-An automation can now wait for a condition or monitored event stream and run when something changes. Conditions can be created, filtered, edited, and inspected in the Control UI, are checked before they are saved, and record checks and matches without creating a run for every non-match. Stream schedules are created through the command line or agent and remain read-only in the Control UI, with bounded buffering, batching, and restart backoff. Triggers can still be disabled entirely, and condition intervals must be at least 30 seconds.
+An automation can now wait for a [condition or monitored event stream](/automation/cron-jobs) and run when something changes. Conditions can be created, filtered, edited, and inspected in the Control UI, are checked before they are saved, and record checks and matches without creating a run for every non-match. Stream schedules are created through the command line or agent and remain read-only in the Control UI, with bounded buffering, batching, and restart backoff. Triggers can still be disabled entirely, and condition intervals must be at least 30 seconds.
 
 New or reauthorized Codex jobs can keep the app permissions and eligible connected-tool access they were created with across restarts. That captured authority is a ceiling checked on every run against current accounts, configuration, policy, approvals, and availability. Tools requiring someone present to approve them stay excluded, existing limits do not expand automatically, and some older jobs need a one-time edit or reauthorization before they can retain this access.
 
@@ -7781,9 +7781,9 @@ New or reauthorized Codex jobs can keep the app permissions and eligible connect
 
 <Accordion title="Heartbeats and email watchers">
 
-Heartbeat schedules are now managed as Automations, with failed work and alerts remaining visible and retryable and queued wakes surviving busy periods, handler replacement, and clock changes. Disabling Cron stops scheduled heartbeats while manual and event-driven wakes remain available. Existing installations using `HEARTBEAT.md` must run `openclaw doctor --fix` to migrate valid work because OpenClaw no longer reads that file at runtime.
+[Heartbeat schedules](/automation) are now managed as Automations, with failed work and alerts remaining visible and retryable and queued wakes surviving busy periods, handler replacement, and clock changes. Disabling Cron stops scheduled heartbeats while manual and event-driven wakes remain available. Existing installations using `HEARTBEAT.md` must run `openclaw doctor --fix` to migrate valid work because OpenClaw no longer reads that file at runtime.
 
-Gmail can split an accepted batch into one isolated run per message when its mapping opts in, filter Sent and Draft mail, and keep forwarding through watcher restarts without overlapping renewals or repeated restart loops. Ordinary custom mappings keep their existing behavior, and expired-OAuth renewal health is unchanged.
+[Gmail](/automation/cron-jobs) can split an accepted batch into one isolated run per message when its mapping opts in, filter Sent and Draft mail, and keep forwarding through watcher restarts without overlapping renewals or repeated restart loops. Ordinary custom mappings keep their existing behavior, and expired-OAuth renewal health is unchanged.
 
 The bundled IMAP watcher lets authenticated new mail from an existing mailbox start a restricted reader agent without exposing an HTTP hook. It is disabled by default and inbound-only, requires sender allowlisting and authentication, and cannot send or modify mail. After three temporary admission failures, the message is recorded as skipped.
 
@@ -7871,7 +7871,7 @@ The bundled IMAP watcher lets authenticated new mail from an existing mailbox st
 
 <Accordion title="History, alerts, and delivery">
 
-Automation history now treats running the work, delivering its result, and completing the whole request as separate facts. A job can execute successfully and still say `not-delivered` when default announce delivery fails, while explicitly required delivery can fail `cron run --wait` without rerunning work that already completed. Intentional suppression is not a failure, primary webhooks record accepted or failed outcomes before finalization, and secondary completion webhooks remain detached fan-out.
+[Automation history](/automation/cron-jobs) now treats running the work, delivering its result, and completing the whole request as separate facts. A job can execute successfully and still say `not-delivered` when default announce delivery fails, while explicitly required delivery can fail `cron run --wait` without rerunning work that already completed. Intentional suppression is not a failure, primary webhooks record accepted or failed outcomes before finalization, and secondary completion webhooks remain detached fan-out.
 
 History can show duration, token totals, cache counters, condition checks and fires, delivery traces, cancellation or failure reasons, and direct Inspect links from eligible visible notifications. Inspect links require `gateway.publicOrigin`, historical rows may not have every optional counter, and condition activity belongs to the job's history rather than the global feed.
 
@@ -7985,7 +7985,7 @@ Failure alerts use configurable routes, thresholds, and cooldowns, with route-ba
 
 <Accordion title="Automations After a Restart">
 
-Restart recovery now distinguishes work that was genuinely missed from work that already finished or no longer belongs to the current automation. Queued and deferred runs, rescheduled one-time reminders, and schedule times missed during a restart or clock change can return, while completed slots, deleted or retired jobs, old schedules, and work from a replaced scheduler stay retired.
+[Restart recovery](/gateway/restart-recovery) now distinguishes work that was genuinely missed from work that already finished or no longer belongs to the current automation. Queued and deferred runs, rescheduled one-time reminders, and schedule times missed during a restart or clock change can return, while completed slots, deleted or retired jobs, old schedules, and work from a replaced scheduler stay retired.
 
 Current edits, self-removal, and rescheduling are preserved during startup, concurrent scheduler work no longer overwrites sibling jobs, and damaged older rows remain available for Doctor. Legacy running markers remain interrupted because they cannot establish whether an outside side effect happened, so exactly-once execution in external systems remains outside the scheduler's recovery boundary.
 
@@ -8062,17 +8062,17 @@ Current edits, self-removal, and rescheduling are preserved during startup, conc
 
 ## Browser and Computer Use
 
-OpenClaw can now use signed-in browser sessions through an isolated managed profile or the exact Chrome tabs you choose to share. On macOS, supported cookies can be imported locally or synced to a remote managed browser for an allowlist of sites you choose, while the official Chrome extension keeps live access scoped to shared tabs. Browser actions, downloads, and desktop input also stay attached to their intended tab, page state, and machine, with cancellation and timeouts reaching more of the local and remote work they own.
+OpenClaw can now use [signed-in browser sessions](/tools/browser-login) through an isolated managed profile or the exact Chrome tabs you choose to share. On macOS, supported cookies can be imported locally or synced to a remote managed browser for an allowlist of sites you choose, while the official Chrome extension keeps live access scoped to shared tabs. Browser actions, downloads, and desktop input also stay attached to their intended tab, page state, and machine, with cancellation and timeouts reaching more of the local and remote work they own.
 
-Computer Use can work with supported apps and windows on paired Macs and explicitly enabled Windows machines, and the Desktop panel can open the machine that owns a session. Control still requires the applicable pairing, policy, and operating-system permissions, view-only sessions reject input, and Linux control remains experimental.
+[Computer Use](/nodes/computer-use) can work with supported apps and windows on paired Macs and explicitly enabled Windows machines, and the Desktop panel can open the machine that owns a session. Control still requires the applicable pairing, policy, and operating-system permissions, view-only sessions reject input, and Linux control remains experimental.
 
 <AccordionGroup>
 
 <Accordion title="Browser setup">
 
-On a Mac, you can explicitly copy compatible cookies from Chrome, Brave, Edge, or Chromium into an isolated managed browser after approving Keychain or Touch ID access. If that browser runs on another OpenClaw machine, a separate opt-in sync can send cookies once or continuously for only the sites you allow. Neither path copies local storage or IndexedDB, and device-bound sessions can still ask you to sign in again.
+On a Mac, you can explicitly copy compatible cookies from Chrome, Brave, Edge, or Chromium into an [isolated managed browser](/tools/browser) after approving Keychain or Touch ID access. If that browser runs on another OpenClaw machine, a separate opt-in sync can send cookies once or continuously for only the sites you allow. Neither path copies local storage or IndexedDB, and device-bound sessions can still ask you to sign in again.
 
-For a browser you already have open, the Apps page now points to the official Chrome extension and the command line can prepare its local connection. You decide which tabs to share, each shared tab can have its own copilot, and sending a page, supported document or thread, or selected text to the main conversation is a one-time handoff rather than continuing access to the rest of your browser.
+For a browser you already have open, the Apps page now points to the official [Chrome extension](/tools/chrome-extension) and the command line can prepare its local connection. You decide which tabs to share, each shared tab can have its own copilot, and sending a page, supported document or thread, or selected text to the main conversation is a one-time handoff rather than continuing access to the rest of your browser.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -8127,7 +8127,7 @@ For a browser you already have open, the Apps page now points to the official Ch
 
 Navigation now returns a compact fresh view of the page for the next action, and snapshot references stay aligned with the content that appears in the final bounded snapshot. Multi-action batches pause after moving to a new document or closing a page so the next step can use fresh state, while new tabs can open in the background and the chosen locale, timezone, and device settings remain attached to the controlled page.
 
-Command-line users can run a repeatable JSON plan against one tab, keep ordered results, and choose whether a failure stops the batch or allows the remaining actions to finish. Page reading uses scoped snapshots or explicit evaluation inside the active agent, and cancelled or timed-out downloads stop without claiming a later request's file or publishing unwanted partial output. A download already in its final save can still finish.
+Command-line users can run a [repeatable JSON plan](/cli/browser) against one tab, keep ordered results, and choose whether a failure stops the batch or allows the remaining actions to finish. Page reading uses scoped snapshots or explicit evaluation inside the active agent, and cancelled or timed-out downloads stop without claiming a later request's file or publishing unwanted partial output. A download already in its final save can still finish.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -8195,7 +8195,7 @@ Command-line users can run a repeatable JSON plan against one tab, keep ordered 
 
 <Accordion title="Computer Use">
 
-On a paired Mac, Computer Use can capture the desktop and work with supported apps, windows, and elements through pointer, keyboard, scroll, drag, and wait actions. Settings now shows the selected provider, Accessibility and Screen Recording state, and whether its supporting service is ready. Using those controls still requires pairing, the applicable command and tool policy, required arming, and the macOS permissions OpenClaw reports but cannot grant.
+On a paired Mac, [Computer Use](/nodes/computer-use) can capture the desktop and work with supported apps, windows, and elements through pointer, keyboard, scroll, drag, and wait actions. Settings now shows the selected provider, Accessibility and Screen Recording state, and whether its supporting service is ready. Using those controls still requires pairing, the applicable command and tool policy, required arming, and the macOS permissions OpenClaw reports but cannot grant.
 
 Explicitly enabled Windows machines now use the packaged Computer Use driver without a separately installed service. Linux uses the packaged route too and remains experimental, with complete live click-and-type behavior still unverified in this release. Codex Computer Use remains a separate macOS integration with its own readiness and recovery checks.
 
@@ -8271,7 +8271,7 @@ The Desktop panel can show the main OpenClaw machine, a Labs headless Linux desk
 
 <Accordion title="Remote screens and devices">
 
-OpenClaw now keeps browser and computer work on the explicitly selected eligible paired machine. A disconnected, ambiguous, or ineligible selector returns an actionable error for that device, while unpinned automatic browser routing can still use the main machine when policy permits.
+OpenClaw now keeps browser and computer work on the explicitly selected eligible [paired machine](/gateway/cloud-sessions). A disconnected, ambiguous, or ineligible selector returns an actionable error for that device, while unpinned automatic browser routing can still use the main machine when policy permits.
 
 Browser uploads and downloads can move between the main machine and a remote Browser node without a shared filesystem, and completed downloads return as readable local files. Terminal uploads can place safely quoted remote paths into the active shell without pressing Enter. Transfer size and authorization limits remain in force, malformed screenshots and Canvas data stop before dispatch, and Android accessibility control remains an opt-in local foundation for third-party builds that a Gateway or agent cannot invoke yet.
 
@@ -8324,7 +8324,7 @@ Browser uploads and downloads can move between the main machine and a remote Bro
 
 Tab handles, page references, screenshots, and desktop actions now remain bound to the tab, page, display, request, and provider that created them. Stale or ambiguous state stops with an error, cancellation and timeouts reach more of the local and remote work they own, and relay reconnects restore only tabs that are still shared.
 
-Remote browser connections are validated and remain pinned to their configured endpoint, connection credentials are redacted on the supported paths, and page-controlled text enters model context as untrusted input. Browser and Canvas screenshots remain available to the inspecting agent but are no longer attached automatically to outbound replies. Cleanup stays limited to browsers and tabs OpenClaw owns, and older extension clients may need an upgrade or fresh pairing for the newer relay protections.
+Remote browser connections are validated and remain pinned to their configured endpoint, connection credentials are redacted on the supported paths, and page-controlled text enters model context as untrusted input. [Browser](/tools/browser) and Canvas screenshots remain available to the inspecting agent but are no longer attached automatically to outbound replies. Cleanup stays limited to browsers and tabs OpenClaw owns, and older extension clients may need an upgrade or fresh pairing for the newer relay protections.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -8441,7 +8441,7 @@ Remote browser connections are validated and remain pinned to their configured e
 
 ## Plugins and Integrations
 
-Admins can now browse, search, install, enable, disable, and remove plugins from the Control UI, while the same hub can install curated ClawHub skills and add vetted MCP connectors. Managed installs pause for source review where needed, roll failed changes back to a retryable state, and repair stale or incomplete records without throwing away healthy configuration. Plugin updates also keep work already in flight on the version it started with, then move later work to the replacement only after it loads successfully.
+Admins can now browse, search, install, enable, disable, and remove [plugins](/plugins/manage-plugins) from the Control UI, while the same hub can install curated ClawHub skills and add vetted [MCP connectors](/cli/mcp). Managed installs pause for source review where needed, roll failed changes back to a retryable state, and repair stale or incomplete records without throwing away healthy configuration. Plugin updates also keep work already in flight on the version it started with, then move later work to the replacement only after it loads successfully.
 
 ClawHub installs carry the selected publisher, version, scan state, and source across desktop and mobile, MCP servers recover independently when a connection or catalog changes, and plugin authors get typed Gateway and SDK contracts for building against OpenClaw. Vendor-neutral Agent Plugins can bring skills and supported MCP servers together with scoped storage, giving integrations a clearer path from package to running system.
 
@@ -8449,7 +8449,7 @@ ClawHub installs carry the selected publisher, version, scan state, and source a
 
 <Accordion title="Installing and managing plugins">
 
-Admins can now browse and search installed plugins in the Control UI, see what each one provides, enable or disable it, remove external plugins, install curated ClawHub results, and add vetted MCP connectors. Read-only operators can inspect the same inventory, while advanced sources, updates, and configuration that the web form cannot safely represent remain available through the command line.
+Admins can now browse and search [installed plugins](/plugins/manage-plugins) in the Control UI, see what each one provides, enable or disable it, remove external plugins, install curated ClawHub results, and add vetted MCP connectors. Read-only operators can inspect the same inventory, while advanced sources, updates, and configuration that the web form cannot safely represent remain available through the command line.
 
 The first install from an arbitrary package, repository, archive, local path, or marketplace source stops for explicit review. A plugin that still needs setup can stay disabled, and a failed managed install rolls partial changes back so it can be retried normally. Repair can recover stale or incomplete install generations while preserving healthy configuration, with integrity or version drift still requiring review.
 
@@ -8602,11 +8602,11 @@ Plugin lists and diagnostics now distinguish disabled plugins, discovery or vali
 
 <Accordion title="ClawHub, Claws, and sharing skills">
 
-ClawHub now carries the selected publisher, version, scan result, and exact source through review and installation, including when two skills share a name. Mac, iPhone, iPad, and Android users can browse and install with the same publisher, version, and risk checks, while external skills.sh results keep their pinned source identity and are clearly marked as outside ClawHub scanning.
+[ClawHub](/tools/skills) now carries the selected publisher, version, scan result, and exact source through review and installation, including when two skills share a name. Mac, iPhone, iPad, and Android users can browse and install with the same publisher, version, and risk checks, while external skills.sh results keep their pinned source identity and are clearly marked as outside ClawHub scanning.
 
 Skill updates protect local and concurrent edits unless an operator explicitly forces the overwrite. Direct downloads verify a declared digest and inspect the complete archive within the supported size limit, and older tracked installs without fingerprints need one forced update to establish that baseline.
 
-Experimental Claws can package an agent with managed workspace files, skills, plugins, MCP servers, and scheduled work. You preview the exact plan before applying it, updates and removal act on resources the Claw owns, and shared resources remain in place unless you deliberately choose conflict-aware cleanup. Claws remain behind `OPENCLAW_EXPERIMENTAL_CLAWS=1`, uncertain outside actions can leave visible partial state that needs a fresh plan, and the package does not carry credentials, providers, bindings, arbitrary local paths, executable configuration, sessions, or host state it does not own.
+[Experimental Claws](/cli/claws) can package an agent with managed workspace files, skills, plugins, MCP servers, and scheduled work. You preview the exact plan before applying it, updates and removal act on resources the Claw owns, and shared resources remain in place unless you deliberately choose conflict-aware cleanup. Claws remain behind `OPENCLAW_EXPERIMENTAL_CLAWS=1`, uncertain outside actions can leave visible partial state that needs a fresh plan, and the package does not carry credentials, providers, bindings, arbitrary local paths, executable configuration, sessions, or host state it does not own.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -8708,7 +8708,7 @@ Experimental Claws can package an agent with managed workspace files, skills, pl
 
 <Accordion title="Loading and updating plugins">
 
-Plugin updates now preserve one runtime generation for work already underway. Accepted messages, completions, and workers finish with the plugin version they started with, and later work moves to the replacement only after it has loaded successfully. If a live reload fails, OpenClaw restores the last active commands, providers, hooks, memory, and other registrations.
+[Plugin updates](/plugins/architecture) now preserve one runtime generation for work already underway. Accepted messages, completions, and workers finish with the plugin version they started with, and later work moves to the replacement only after it has loaded successfully. If a live reload fails, OpenClaw restores the last active commands, providers, hooks, memory, and other registrations.
 
 OpenClaw also reuses prepared plugin metadata and runtimes across turns instead of rebuilding the same setup each time, while health shows failed activation, cleanup, or background services directly. A known plugin-owned failure can be quarantined without taking healthy plugins or all of OpenClaw offline, while invalid configuration, failed migrations, ambiguous ownership, and unverifiable state still stop activation.
 
@@ -8847,7 +8847,7 @@ Context-engine plugins remain selected on fresh turns and can advance durable st
 
 <Accordion title="MCP servers and apps">
 
-MCP servers can now recover their connection and catalog after late startup, transport loss, a server restart, or a changed tool list without restarting OpenClaw or taking healthy servers down with them. Tool results retain structured data, screenshots, audio, resources, recovery guidance, and real error state. A call that first discovers an expired stateful session still fails once without replay because it may already have changed something.
+[MCP servers](/cli/mcp) can now recover their connection and catalog after late startup, transport loss, a server restart, or a changed tool list without restarting OpenClaw or taking healthy servers down with them. Tool results retain structured data, screenshots, audio, resources, recovery guidance, and real error state. A call that first discovers an expired stateful session still fails once without replay because it may already have changed something.
 
 Local MCP sign-in can finish in the browser, save and verify the credential, and resume a newly started authorization after a process restart. Shared operator sign-in remains the default, while supported HTTP MCP servers can opt into per-person OAuth that keeps each credential attached to the trusted channel, bot account, and sender. Remote and headless operators keep the manual code path, and this first per-person mode does not add private sign-in delivery, automatic turn resumption, or Control UI account management.
 
@@ -8939,9 +8939,9 @@ MCP Apps remain opt-in and can show supported interactive server interfaces afte
 
 <Accordion title="Building plugins and integrations">
 
-Developers building a Gateway client or embedding OpenClaw now have typed protocol schemas, runtime validation, authentication, reconnect, readiness, timeout, and browser or Node entry-point guidance. The Gateway protocol and reference client are prepared as calendar-versioned npm packages and become installable when the release train publishes them.
+Developers [building a Gateway client](/gateway/protocol) or embedding OpenClaw now have typed protocol schemas, runtime validation, authentication, reconnect, readiness, timeout, and browser or Node entry-point guidance. The Gateway protocol and reference client are prepared as calendar-versioned npm packages and become installable when the release train publishes them.
 
-Plugin authors also get focused contracts for requester-aware hooks, channel setup, CLI backends, bounded provider streams, read-only secret references, and browser meeting adapters. Hook policy remains underneath channel admission, sandboxing, approvals, owner-only tools, and other host policy, and the timeout cleanup for Codex hook relays applies to POSIX hosts rather than Windows.
+[Plugin authors](/plugins/building-plugins) also get focused contracts for requester-aware hooks, channel setup, CLI backends, bounded provider streams, read-only secret references, and browser meeting adapters. Hook policy remains underneath channel admission, sandboxing, approvals, owner-only tools, and other host policy, and the timeout cleanup for Codex hook relays applies to POSIX hosts rather than Windows.
 
 The contract cleanup removes retired July and August SDK paths and replaces the `deactivate` alias with `gateway_stop`, while the beta.5 session-store bridge remains available through October 12, 2026. Clients using the v2026.7.2 beta question, worker, or session-catalog shapes need to move to the renamed and flattened contracts. Custom `agents.defaults.cliBackends` commands, arguments, environment, aliases, and parsers now belong in a backend plugin whose executable is available to the OpenClaw service.
 
@@ -9096,9 +9096,9 @@ The contract cleanup removes retired July and August SDK paths and replaces the 
 
 <Accordion title="Plugin Packages and Host Compatibility">
 
-OpenClaw can now install vendor-neutral Agent Plugins from directories, archives, or Git sources, load their immediate-child skills and valid stdio, HTTP, or SSE MCP servers, and give them scoped bundle and persistent data paths. The OpenClaw extension can add activation hints, while providers, channels, configuration schemas, and runtime entry points stay outside this portable bundle contract. An invalid MCP entry is skipped without blocking valid siblings.
+OpenClaw can now install vendor-neutral [Agent Plugins](/plugins/bundles) from directories, archives, or Git sources, load their immediate-child skills and valid stdio, HTTP, or SSE MCP servers, and give them scoped bundle and persistent data paths. The OpenClaw extension can add activation hints, while providers, channels, configuration schemas, and runtime entry points stay outside this portable bundle contract. An invalid MCP entry is skipped without blocking valid siblings.
 
-Cohere, Meta, BytePlus, ComfyUI, OpenCode, Voyage, Vydra, Volcengine, Mistral, NovitaAI, Teams meetings, and Zoom meetings now ship as separately installed official packages. New setups install the relevant package and restart OpenClaw, and an existing enabled setup relocates when the external artifact is available. OpenCode Go remains bundled because its external placeholder was not usable.
+Cohere, Meta, BytePlus, ComfyUI, OpenCode, Voyage, Vydra, Volcengine, Mistral, NovitaAI, Teams meetings, and Zoom meetings now ship as separately installed [official packages](/plugins/plugin-inventory). New setups install the relevant package and restart OpenClaw, and an existing enabled setup relocates when the external artifact is available. OpenCode Go remains bundled because its external placeholder was not usable.
 
 Plugin loading now handles the specific npm 10 through 12 metadata and lock behavior, direct and peer OpenClaw dependencies, packed host-runtime imports, and concurrent Node ESM cases that had prevented successful installs from activating. Canvas is now focused on the macOS presenter and session-board A2UI path, with its standalone workspace, eval and snapshot surfaces, native push and reset commands, and iOS, Android, and Linux clients removed. Dashboard and A2UI actions remain explicitly granted and sandboxed.
 
@@ -9225,15 +9225,15 @@ Plugin loading now handles the specific npm 10 through 12 metadata and lock beha
 
 ## Security and Privacy
 
-Sensitive work now carries more of its authority with it. Approvals stay attached to the exact request, command, session, and person that received them, removing or pairing a device again retires its old access, and protected credentials can reach supported destinations without entering model-visible text. Sandboxes, network requests, browser actions, and plugin installs also recheck the workspace, destination, document, publisher, version, or artifact they depend on, so stale or mismatched authority stops or asks again instead of being reused.
+Sensitive work now carries more of its authority with it. [Approvals](/tools/exec-approvals) stay attached to the exact request, command, session, and person that received them, removing or pairing a device again retires its old access, and [protected credentials](/gateway/secrets) can reach supported destinations without entering model-visible text. Sandboxes, network requests, browser actions, and plugin installs also recheck the workspace, destination, document, publisher, version, or artifact they depend on, so stale or mismatched authority stops or asks again instead of being reused.
 
 <AccordionGroup>
 
 <Accordion title="Approvals and permissions">
 
-An approval request now has one durable record shared by authorized browser and supported mobile surfaces. The first valid answer settles it, reconnecting cannot revive a completed request, abandoned requests are cancelled, and aborting a run clears the approvals it left pending.
+An [approval request](/tools/exec-approvals) now has one durable record shared by authorized browser and supported mobile surfaces. The first valid answer settles it, reconnecting cannot revive a completed request, abandoned requests are cancelled, and aborting a run clears the approvals it left pending.
 
-Reusable command permission can bind to exact arguments and a working directory, while script-backed commands recheck the bytes that were reviewed before they run. The binding covers the reviewed command and script bytes, while interpreters and changing dependencies can introduce separate behavior; opaque wrappers and commands that can launch something else may ask again. Each session can also choose read-only, guarded, workspace, or full access and override MCP servers, skills, or web search where the client exposes those controls, with full access reserved for administrators. Scheduled and delegated work retains its originating policy, and an uncertain result from another machine is reported as unknown instead of being retried on a guess.
+Reusable command [permission](/gateway/permission-modes) can bind to exact arguments and a working directory, while script-backed commands recheck the bytes that were reviewed before they run. The binding covers the reviewed command and script bytes, while interpreters and changing dependencies can introduce separate behavior; opaque wrappers and commands that can launch something else may ask again. Each session can also choose read-only, guarded, workspace, or full access and override MCP servers, skills, or web search where the client exposes those controls, with full access reserved for administrators. Scheduled and delegated work retains its originating policy, and an uncertain result from another machine is reported as unknown instead of being retried on a guess.
 
 Per-session controls are nonretroactive, so existing sessions without a permission mode keep the previous global posture. Opt-in roles limit collaboration inside one trusted OpenClaw installation rather than creating isolation between hostile tenants.
 
@@ -9487,7 +9487,7 @@ Per-session controls are nonretroactive, so existing sessions without a permissi
 
 <Accordion title="People, devices, and pairing">
 
-Pairing authority now lives on the device record. Removing or pairing a device again retires its old connection and worker access, non-admin device tokens can manage only their own pairing, macOS and Android can review pairing state, and administrators can create a short-lived one-paste command for joining a machine.
+[Pairing](/gateway/pairing) authority now lives on the device record. Removing or pairing a device again retires its old connection and worker access, non-admin device tokens can manage only their own pairing, macOS and Android can review pairing state, and administrators can create a short-lived one-paste command for joining a machine.
 
 Automatic browser enrollment behind a trusted proxy remains off until enabled and stays within configured role and access limits. Verified proxy or Tailscale identity applies only to the current connection instead of rewriting durable pairing. The separate SSH identity check for private-network machines is on by default and follows normal OpenSSH HostName rules, so operators who want manual-only pairing must disable it and leave CIDR auto-approval unset.
 
@@ -9646,7 +9646,7 @@ Participant, session, agent, and requester identity now travels with more of the
 
 <Accordion title="Secrets and private data">
 
-The new team-scoped local Secret Store separates Protected values from Agent-readable environment values. Supported masked requests, Vault or 1Password references, and destination-bound substitution can keep a protected credential out of plaintext configuration and model-visible text while placing it into an approved Gateway-hosted HTTPS request. Agent-readable values are a separate grant for Gateway-hosted commands and can still be printed or transmitted by the command that receives them.
+The new team-scoped local [Secret Store](/gateway/secrets) separates Protected values from Agent-readable environment values. Supported masked requests, Vault or [1Password](/gateway/1password) references, and destination-bound substitution can keep a protected credential out of plaintext configuration and model-visible text while placing it into an approved Gateway-hosted HTTPS request. Agent-readable values are a separate grant for Gateway-hosted commands and can still be printed or transmitted by the command that receives them.
 
 Secret Store values are not encrypted at rest and depend on the filesystem permissions of OpenClaw's state directory. Destination-bound substitution applies only to Gateway-hosted HTTPS commands whose subprocess honors its proxy settings. Raw sockets, containers, remote nodes, provider-native harnesses, plain HTTP, and WebSockets stay outside that path.
 
@@ -9848,11 +9848,11 @@ Common credential and signed-parameter patterns are now redacted across covered 
 
 <Accordion title="Sandbox and file access">
 
-Contributor-controlled code is now prepared inside the designated untrusted-code sandbox, and managed worktrees suppress repository Git hooks unless an administrator deliberately runs the separate setup script. Repositories that relied on implicit hooks will need to move that setup into the explicit path.
+Contributor-controlled code is now prepared inside the designated untrusted-code [sandbox](/gateway/sandboxing), and managed worktrees suppress repository Git hooks unless an administrator deliberately runs the separate setup script. Repositories that relied on implicit hooks will need to move that setup into the explicit path.
 
 Sandbox identity now includes the workspace that owns the run. Newly created guest sessions that require a sandbox receive a separate identity for each authenticated guest and can share a workspace only read-only, while worker sessions on another machine can opt into per-session containers. Direct execution remains the default, and the same per-guest boundary is not established for child sessions they create.
 
-File checks catch more attempts to escape through the named root, denied directories, oversized reads, and POSIX symlink parents. Symlink containment is checked before the filesystem operation rather than atomically beneath the approved root, leaving a remaining window for a path to change between the check and use.
+[File checks](/gateway/security/secure-file-operations) catch more attempts to escape through the named root, denied directories, oversized reads, and POSIX symlink parents. Symlink containment is checked before the filesystem operation rather than atomically beneath the approved root, leaving a remaining window for a path to change between the check and use.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -9949,7 +9949,7 @@ File checks catch more attempts to escape through the named root, denied directo
 
 <Accordion title="Network Access and Untrusted Content">
 
-Network policy now blocks unspecified and local-use NAT64 targets by default, validates guarded redirects and no-auth browser origins, and stops telemetry when its configured proxy is invalid instead of bypassing it. Private automation webhook destinations require an exact-host exception or a broader private-network switch, with the broader setting widening trust across every configured cron webhook.
+[Network policy](/gateway/security/index) now blocks unspecified and local-use NAT64 targets by default, validates guarded redirects and no-auth browser origins, and stops telemetry when its configured proxy is invalid instead of bypassing it. Private automation webhook destinations require an exact-host exception or a broader private-network switch, with the broader setting widening trust across every configured cron webhook.
 
 Text returned by search, fetch, MCP, plugins, Browser, and other network-backed tools is bounded, normalized, and marked as untrusted external content before the model sees it. This makes the source and boundary explicit, while the model can still be influenced by hostile material it reads.
 
@@ -10089,9 +10089,9 @@ Terminal and CSV output neutralize covered control-sequence and formula injectio
 
 <Accordion title="Plugin Permissions and Installation Checks">
 
-Managed external plugin installs now show one capability review bound to the artifact being installed and ask again when an update requests more authority. Skill security verdicts stay attached to the exact publisher and version, ClawHub GitHub installs require a full commit SHA instead of a mutable branch or tag, and managed Homebrew or NodeSource installers stop when a response fails, is empty, redirects, or lacks a shebang.
+Managed external plugin installs now show one [capability review](/plugins/plugin-permission-requests) bound to the artifact being installed and ask again when an update requests more authority. Skill security verdicts stay attached to the exact publisher and version, ClawHub GitHub installs require a full commit SHA instead of a mutable branch or tag, and managed Homebrew or NodeSource installers stop when a response fails, is empty, redirects, or lacks a shebang.
 
-The capability prompt applies to managed external installs. Bundled plugins skip it, already-enabled legacy plugins keep their existing access, and bundled execution retains named compatibility exceptions. The review shows what a plugin is asking to do, while authenticity and code safety continue to depend on artifact integrity, registry identity, and code review. A full commit SHA pins the downloaded archive bytes while source metadata still depends on the resolver, and the installer response check only confirms that the download looks like a script.
+The capability prompt applies to managed external installs. Bundled plugins skip it, already-enabled legacy plugins keep their existing access, and bundled execution retains named compatibility exceptions. The review shows what a plugin is asking to do, while authenticity and code safety continue to depend on [artifact integrity](/gateway/security/dependency-locking), registry identity, and code review. A full commit SHA pins the downloaded archive bytes while source metadata still depends on the resolver, and the installer response check only confirms that the download looks like a script.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -10143,13 +10143,13 @@ The capability prompt applies to managed external installs. Bundled plugins skip
 
 ## Quality-of-Life Improvements
 
-Everyday work in OpenClaw now takes less effort to find, follow, move, and protect. Past conversations are easier to return to, long jobs keep useful progress visible, portable snapshots can be checked before they are needed, and eligible work can run on a cloud worker or paired computer, with cloud sessions later reclaimed to the main machine. Voice, video, meeting capture, agent tools, keyboard access, maintained translations, interface polish, and documentation also pick up changes that make the product easier to use across ordinary work.
+Everyday work in OpenClaw now takes less effort to find, follow, move, and protect. [Past conversations](/concepts/session-search) are easier to return to, long jobs keep useful progress visible, portable snapshots can be checked before they are needed, and eligible work can run on a [cloud worker](/gateway/cloud-workers) or [paired computer](/gateway/cloud-sessions), with cloud sessions later reclaimed to the main machine. Voice, video, meeting capture, agent tools, keyboard access, maintained translations, interface polish, and documentation also pick up changes that make the product easier to use across ordinary work.
 
 <AccordionGroup>
 
 <Accordion title="Past Conversations and Long-Running Work">
 
-Past conversations and long-running work are easier to find and follow. The session catalog groups and opens Codex, Claude Code, OpenCode, and Pi work from the main OpenClaw computer or an eligible paired one, durable progress cards survive reloads and reconnects, and background-task history is available on the web, iOS, and Android. An optional observer can summarize a conversation, answer questions about it, show its timeline, and alert an operator when attention is needed.
+[Past conversations](/concepts/session-search) and long-running work are easier to find and follow. The session catalog groups and opens Codex, Claude Code, OpenCode, and Pi work from the main OpenClaw computer or an eligible paired one, durable [progress cards](/tools/progress-card) survive reloads and reconnects, and background-task history is available on the web, iOS, and Android. An optional observer can summarize a conversation, answer questions about it, show its timeline, and alert an operator when attention is needed.
 
 Resume support depends on the runtime that owns the session. OpenCode and Pi catalogs are view-only, paired-computer actions need an opted-in capable host and an eligible session, and external transcripts remain with their original runtime. The observer can be disabled and requires an available utility model.
 
@@ -10286,7 +10286,7 @@ Resume support depends on the runtime that owns the session. OpenCode and Pi cat
 
 <Accordion title="Stored Data and Backups">
 
-Sessions and transcripts, selected device and authentication records, meeting capture, and runtime journals now use SQLite-backed stores, and portable snapshots can be created, verified, and restored through the same toolset. This gives backup and recovery a checkable path before an incident.
+Sessions and transcripts, selected device and authentication records, meeting capture, and runtime journals now use SQLite-backed stores, and [portable snapshots](/cli/backup) can be created, verified, and restored through the same toolset. This gives backup and recovery a checkable path before an incident.
 
 Some legacy stores require the owning process to be stopped before `openclaw doctor --fix` can migrate them. Pending pairing requests and bootstrap codes are not imported, the macOS tunnel migration cannot be read by older JSON-only builds, and restore refuses to write over an existing target.
 
@@ -10347,7 +10347,7 @@ Some legacy stores require the owning process to be stopped before `openclaw doc
 
 <Accordion title="Remote computers and devices">
 
-Work no longer has to stay on the main machine running OpenClaw. A configured cloud worker can start a session in a selected repository and later return it to the main machine, while an explicitly opted-in paired computer can run a complete turn using a worker bundle verified and supplied by OpenClaw rather than whatever code happens to be installed there.
+Work no longer has to stay on the main machine running OpenClaw. A configured [cloud worker](/gateway/cloud-workers) can start a session in a selected repository and later return it to the main machine, while an explicitly opted-in [paired computer](/gateway/cloud-sessions) can run a complete turn using a worker bundle verified and supplied by OpenClaw rather than whatever code happens to be installed there.
 
 Those are two different paths with different requirements. Cloud workers need a configured profile and the OpenClaw runtime, while paired computers need compatible versions, consent, available capacity, and support for the requested commands. The portable worker bundle does not include the destination machine's native terminal module, so work that depends on a truly interactive terminal still has a real boundary.
 
@@ -10428,11 +10428,11 @@ Those are two different paths with different requirements. Cloud workers need a 
 
 <Accordion title="Voice, meetings, and media">
 
-Talk can use GPT-Live and GA Realtime voice through supported direct-browser and Gateway-relay paths, including eligible ChatGPT or Codex sign-ins. The routes are not interchangeable though, because credentials and transports vary across clients, Android relay remains gated, and Azure configurations are excluded from the ChatGPT OAuth relay path.
+[Talk](/nodes/talk) can use GPT-Live and GA Realtime voice through supported direct-browser and Gateway-relay paths, including eligible ChatGPT or Codex sign-ins. The routes are not interchangeable though, because credentials and transports vary across clients, Android relay remains gated, and Azure configurations are excluded from the ChatGPT OAuth relay path.
 
 Supported OpenAI and Gemini Live calls can add video, remember whether you use the camera, and switch cameras without restarting voice. Those controls only appear on supported browser and provider transports, permission and capture stay on the device, and an unsupported or fallback relay can omit or reject video.
 
-Enabled Google Meet, Microsoft Teams, and Zoom bots can also retain speaker-attributed transcripts and summaries in SQLite. Google Meet's bounded live-caption buffer is a separate path from that durable archive, and meeting retention can still be disabled globally.
+Enabled [Google Meet, Microsoft Teams, and Zoom bots](/plugins/meeting-plugins) can also retain speaker-attributed transcripts and summaries in SQLite. Google Meet's bounded live-caption buffer is a separate path from that durable archive, and meeting retention can still be disabled globally.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -10494,9 +10494,9 @@ Enabled Google Meet, Microsoft Teams, and Zoom bots can also retain speaker-attr
 
 <Accordion title="Code Mode and agent tools">
 
-Code Mode can now treat authorized tools like ordinary asynchronous functions, letting an agent combine trusted results from conversations, files, and sessions in one program or run independent calls together. This is the final interface rather than another layer beside the old one, so the previous `tools` object, `ALL_TOOLS`, exact-ID calls, and raw call envelopes are gone. What a program can compose still stops at the tools it is authorized to use and the structured results those tools declare.
+[Code Mode](/tools/code-mode) can now treat authorized tools like ordinary asynchronous functions, letting an agent combine trusted results from conversations, files, and sessions in one program or run independent calls together. This is the final interface rather than another layer beside the old one, so the previous `tools` object, `ALL_TOOLS`, exact-ID calls, and raw call envelopes are gone. What a program can compose still stops at the tools it is authorized to use and the structured results those tools declare.
 
-Tool Search also does a better job of turning a natural request into a discoverable capability, can search several capability groups in one structured request, and now exposes existing session archive and pin actions. Policy can still hide tools and a request with no valid answer can return nothing, while existing single-query request and response shapes continue to work.
+[Tool Search](/tools) also does a better job of turning a natural request into a discoverable capability, can search several capability groups in one structured request, and now exposes existing session archive and pin actions. Policy can still hide tools and a request with no valid answer can return nothing, while existing single-query request and response shapes continue to work.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -10601,7 +10601,7 @@ Tool Search also does a better job of turning a natural request into a discovera
 
 <Accordion title="Accessibility and language support">
 
-Keyboard users can open plugin details and select Usage sessions again. The 20 maintained non-English Control UI catalogs also include refreshed text for prompts, devices, activity, catalogs, and other expanded surfaces. These catalog updates keep the existing language set aligned with the current interface; they do not add languages or change application logic.
+Keyboard users can open plugin details and select Usage sessions again. The 20 maintained non-English [Control UI](/web/control-ui) catalogs also include refreshed text for prompts, devices, activity, catalogs, and other expanded surfaces. These catalog updates keep the existing language set aligned with the current interface; they do not add languages or change application logic.
 
 Android also has an experimental `mobile_ui` path that lets an authorized agent observe and interact with apps on a supported paired device. It is owner-only, off by default, limited to third-party builds, unavailable through Gateway HTTP and Play builds, and requires both dangerous commands to be armed explicitly.
 
@@ -10638,9 +10638,9 @@ Android also has an experimental `mobile_ui` path that lets an authorized agent 
 
 <Accordion title="Interface polish and compatibility">
 
-Startup and several messaging paths now skip unnecessary work, while smaller fixes across onboarding, Tasks, Worktrees, Activity, dashboards, generated titles, durations, phone numbers, and themes make familiar screens easier to read and use.
+Startup and several messaging paths now skip unnecessary work, while smaller fixes across onboarding, Tasks, Worktrees, Activity, dashboards, generated titles, durations, phone numbers, and themes make [familiar screens](/web/control-ui) easier to read and use.
 
-The optional Control UI lobster now reacts to status changes and adds seasonal or rare variants, visitors, collection rewards, and controls to dismiss one visit or disable visits. These additions are cosmetic, many appearances remain rare or session-seeded, reduced-motion preferences are preserved, and related CLI flourishes stay inside interactive use so automated output is unchanged.
+The optional [Control UI lobster](/web/lobster) now reacts to status changes and adds seasonal or rare variants, visitors, collection rewards, and controls to dismiss one visit or disable visits. These additions are cosmetic, many appearances remain rare or session-seeded, reduced-motion preferences are preserved, and related CLI flourishes stay inside interactive use so automated output is unchanged.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -10731,7 +10731,7 @@ The optional Control UI lobster now reacts to status changes and adds seasonal o
 
 <Accordion title="Documentation">
 
-Setup, migration, recovery, and feature guidance now covers cloud workers, meetings and media, Code Mode, Swarm, portals, sandboxes, local speech, SQLite migrations, backups, and downgrade recovery more clearly. Mobile readers get better top-level links, and the Release and CI pages lose a redundant navigation layer. These are documentation and QA updates; runtime behaviour continues to follow the referenced product and platform contracts.
+Setup, migration, recovery, and feature guidance now covers [cloud workers](/gateway/cloud-workers), [meetings and media](/plugins/meeting-plugins), [Code Mode](/tools/code-mode), Swarm, portals, sandboxes, local speech, [SQLite migrations](/reference/database-schemas), [backups](/install/backups), and downgrade recovery more clearly. Mobile readers get better top-level links, and the Release and CI pages lose a redundant navigation layer. These are documentation and QA updates; runtime behaviour continues to follow the referenced product and platform contracts.
 
 Two cloud-worker details remain out of sync. The Cloud Workers settings guide overstates profile information shown for providers other than Crabbox, and the Daytona guide says `settings.class` can be omitted even though profile validation still requires it, so Daytona profiles should keep the class explicit until the guide and product contract agree.
 
@@ -10790,13 +10790,13 @@ Two cloud-worker details remain out of sync. The Cloud Workers settings guide ov
 
 ## Other Bug Fixes
 
-OpenClaw now preserves completed Codex delegation results through the covered handoffs, keeps accepted user turns from being stored twice, stops cancelled commands before they start, and retains Canvas widget identity and pin state after reload. The rest of this section covers scoped fixes across browser Talk, Copilot and xAI replay, Doctor recovery, plugin upgrades, meeting audio, and the terminal app.
+OpenClaw now preserves completed Codex delegation results through the covered handoffs, keeps accepted user turns from being stored twice, stops cancelled commands before they start, and retains Canvas widget identity and pin state after reload. The rest of this section covers scoped fixes across browser Talk, Copilot and xAI replay, [Doctor](/cli/doctor) recovery, plugin upgrades, meeting audio, and the [terminal app](/web/tui).
 
 <AccordionGroup>
 
 <Accordion title="Agent Work and Handoffs">
 
-In the repaired Codex delegation and `sessions_yield` paths, completed subagent results now survive cleanup and handoff, yielded jobs launch once, and the parent resumes after fan-out finishes.
+In the repaired [Codex delegation](/tools/subagents) and `sessions_yield` paths, completed subagent results now survive cleanup and handoff, yielded jobs launch once, and the parent resumes after fan-out finishes.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -11207,7 +11207,7 @@ In the repaired Codex delegation and `sessions_yield` paths, completed subagent 
 
 <Accordion title="Conversations, history, and stored data">
 
-One accepted user turn now stays one turn across the repaired retry and restart paths instead of being written twice. `/new` and `/reset` also preserve the underlying transcript position while clearing the visible conversation, so resetting what you see does not lose OpenClaw's place in the saved history.
+One accepted user turn now stays one turn across the repaired retry and restart paths instead of being written twice. `/new` and `/reset` also preserve the underlying transcript position while clearing the visible conversation, so resetting what you see does not lose OpenClaw's place in the [saved history](/concepts/session).
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -11533,7 +11533,7 @@ One accepted user turn now stays one turn across the repaired retry and restart 
 
 <Accordion title="Agent tools and code execution">
 
-Code Mode can keep an eligible task moving when it fails before taking action or while discovering tools and skills, and nested tool calls now finish or cancel cleanly instead of hanging. Once a write may have happened, recovery is limited to checking what changed rather than replaying an uncertain action, while cancellation, policy denial, and other final outcomes still stop the task.
+[Code Mode](/tools/code-mode) can keep an eligible task moving when it fails before taking action or while discovering tools and skills, and nested tool calls now finish or cancel cleanly instead of hanging. Once a write may have happened, recovery is limited to checking what changed rather than replaying an uncertain action, while cancellation, policy denial, and other final outcomes still stop the task.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -11782,7 +11782,7 @@ Code Mode can keep an eligible task moving when it fails before taking action or
 
 Cancelling a queued command now keeps it from starting, cancellation during startup reaches the process once it exists, and an explicit replacement retires the command it replaced without killing ordinary work that happens to be running at the same time. Commands already running in the background keep their existing lifetime.
 
-Process output also stays in the order OpenClaw observed it, completion remains attached to the exact process that finished, and polling says when earlier output was omitted. The full history remains available through paged process logs rather than one response that can grow without bound.
+[Process output](/tools/exec) also stays in the order OpenClaw observed it, completion remains attached to the exact process that finished, and polling says when earlier output was omitted. The full history remains available through paged process logs rather than one response that can grow without bound.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -11890,7 +11890,7 @@ Process output also stays in the order OpenClaw observed it, completion remains 
 
 <Accordion title="Automations and task boards">
 
-Workboard now keeps an accepted worker attached to its card, rolls back a failed operation without overwriting someone else's edits, and reconnects launches interrupted by a restart. If OpenClaw does not have a complete view of the running workers, it waits instead of guessing whether one still belongs to the card, and stale launch attempts remain blocked.
+[Workboard](/plugins/workboard) now keeps an accepted worker attached to its card, rolls back a failed operation without overwriting someone else's edits, and reconnects launches interrupted by a restart. If OpenClaw does not have a complete view of the running workers, it waits instead of guessing whether one still belongs to the card, and stale launch attempts remain blocked.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -11958,7 +11958,7 @@ Workboard now keeps an accepted worker attached to its card, rolls back a failed
 
 <Accordion title="Web and dashboard interfaces">
 
-Canvas now keeps generated widgets distinct when their names collide, remembers which widget was pinned after reload, and shows a bounded error when pinning fails instead of making the action disappear. When a stored widget identity is invalid or an occupied name is ambiguous, Canvas still refuses to guess which widget you meant.
+[Canvas](/platforms/mac/canvas) now keeps generated widgets distinct when their names collide, remembers which widget was pinned after reload, and shows a bounded error when pinning fails instead of making the action disappear. When a stored widget identity is invalid or an occupied name is ambiguous, Canvas still refuses to guess which widget you meant.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -12093,7 +12093,7 @@ Canvas now keeps generated widgets distinct when their names collide, remembers 
 
 <Accordion title="Terminal App">
 
-The terminal app now stays on the conversation you most recently selected during rapid switching and preserves the active answer and chosen tool visibility when you return to it. It retries one temporary live-update failure, while a second failure remains visible and full verbosity continues to show stored tool output.
+The [terminal app](/web/tui) now stays on the conversation you most recently selected during rapid switching and preserves the active answer and chosen tool visibility when you return to it. It retries one temporary live-update failure, while a second failure remains visible and full verbosity continues to show stored tool output.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -12193,7 +12193,7 @@ The terminal app now stays on the conversation you most recently selected during
 
 <Accordion title="Voice and Talk">
 
-Browser Realtime Talk now limits stalled microphone uploads, queued playback, replacement work, and abandoned voice sessions instead of letting them grow without bound. A malformed audio frame can be dropped without ending healthy playback, while Google Live ends the current voice session when it cannot safely cancel only the response that overflowed.
+Browser [Realtime Talk](/nodes/talk) now limits stalled microphone uploads, queued playback, replacement work, and abandoned voice sessions instead of letting them grow without bound. A malformed audio frame can be dropped without ending healthy playback, while Google Live ends the current voice session when it cannot safely cancel only the response that overflowed.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -12265,7 +12265,7 @@ Browser Realtime Talk now limits stalled microphone uploads, queued playback, re
 
 <Accordion title="Models and providers">
 
-Specific GitHub Copilot and xAI replay failures now recover without resetting the conversation. Copilot preserves valid same-run reasoning through active tool calls, and affected post-compaction or encrypted-reasoning failures receive one bounded sanitized retry under the matching transport, model family, or xAI decrypt signature.
+Specific [GitHub Copilot](/plugins/reference/github-copilot) and xAI replay failures now recover without resetting the conversation. Copilot preserves valid same-run reasoning through active tool calls, and affected post-compaction or encrypted-reasoning failures receive one bounded sanitized retry under the matching transport, model family, or xAI decrypt signature.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -12361,7 +12361,7 @@ Specific GitHub Copilot and xAI replay failures now recover without resetting th
 
 <Accordion title="Speech and media providers">
 
-Across the affected shared and OpenAI transcription paths, repeated short-lived connections now back off and stop at the configured retry limit, OpenAI turns stay in order, more eligible final words survive microphone close, and a large backlog keeps the newest audio so the session remains responsive.
+Across the affected shared and OpenAI [transcription](/nodes/audio) paths, repeated short-lived connections now back off and stop at the configured retry limit, OpenAI turns stay in order, more eligible final words survive microphone close, and a large backlog keeps the newest audio so the session remains responsive.
 
 Local CLI text-to-speech now caps output memory, handles a broken audio stream safely, and preserves a valid output file when only unused stdout fails. Output metadata from Local CLI and ElevenLabs also reports the audio format that was actually produced.
 
@@ -12529,7 +12529,7 @@ Local CLI text-to-speech now caps output memory, handles a broken audio stream s
 
 <Accordion title="Command line and diagnostics">
 
-Doctor now stops a stale build before repair, safely migrates the covered legacy agent databases without following unrelated state, and gives operators a concrete recovery path when the shared database is corrupt. Corrupt shared state is diagnosed and left unchanged for manual restoration or repair.
+[Doctor](/cli/doctor) now stops a stale build before repair, safely migrates the covered legacy agent databases without following unrelated state, and gives operators a concrete recovery path when the shared database is corrupt. Corrupt shared state is diagnosed and left unchanged for manual restoration or repair.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -12690,7 +12690,7 @@ Doctor now stops a stale build before repair, safely migrates the covered legacy
 
 <Accordion title="Security and permissions">
 
-Doctor's legacy authentication migration now preserves complete credentials, credentials already stored in SQLite, and the selected ChatGPT account across the covered legacy-to-SQLite migrations. Ambiguous ownership, unreadable files, and unverifiable credentials continue to stop the migration.
+Doctor's legacy [authentication migration](/gateway/authentication) now preserves complete credentials, credentials already stored in SQLite, and the selected ChatGPT account across the covered legacy-to-SQLite migrations. Ambiguous ownership, unreadable files, and unverifiable credentials continue to stop the migration.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -12809,7 +12809,7 @@ Doctor's legacy authentication migration now preserves complete credentials, cre
 
 <Accordion title="Plugins and installation">
 
-Plugin upgrades now keep canonical SQLite install and state records when conflicting legacy data is provably stale, archive the old file for recovery, and allow startup to continue. Newer or ambiguous legacy state and archive failures remain blocking so Doctor can retry without discarding either copy.
+[Plugin upgrades](/plugins/manage-plugins) now keep canonical SQLite install and state records when conflicting legacy data is provably stale, archive the old file for recovery, and allow startup to continue. Newer or ambiguous legacy state and archive failures remain blocking so Doctor can retry without discarding either copy.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -12855,7 +12855,7 @@ Plugin upgrades now keep canonical SQLite install and state records when conflic
 
 <Accordion title="Messaging and calls">
 
-Affected Google Meet and Teams sessions now wait for the local audio bridge to stop before teardown completes. Google Meet also rejects malformed node-control requests before dispatch and keeps local audio diagnostics bounded and readable.
+Affected [Google Meet and Teams sessions](/plugins/meeting-plugins) now wait for the local audio bridge to stop before teardown completes. Google Meet also rejects malformed node-control requests before dispatch and keeps local audio diagnostics bounded and readable.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -12977,7 +12977,7 @@ Affected Google Meet and Teams sessions now wait for the local audio bridge to s
 
 <Accordion title="Documentation">
 
-Documentation links now reach their intended external destinations and cross-page headings, while contributor attribution follows renamed accounts correctly. The external-link checker reports future drift on weekly or manual runs without blocking pull requests.
+Documentation links now reach their intended external destinations and cross-page headings, while contributor attribution follows renamed accounts correctly. The [external-link checker](/ci) reports future drift on weekly or manual runs without blocking pull requests.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -13009,7 +13009,7 @@ Documentation links now reach their intended external destinations and cross-pag
 
 ## Maintainer and Internal Changes
 
-Another 5,804 changes in this release primarily affect the people who build and maintain OpenClaw. They cover release and CI work, tests, internal refactors, documentation maintenance, and narrow fixes that sit outside the user-facing product sections above.
+Another 5,804 changes in this release primarily affect the people who build and maintain OpenClaw. They cover [release and CI work](/reference/RELEASING), tests, internal refactors, documentation maintenance, and narrow fixes that sit outside the user-facing product sections above.
 
 <AccordionGroup>
 

--- a/docs/releases/2026.8.1.md
+++ b/docs/releases/2026.8.1.md
@@ -33,7 +33,7 @@ The sections below describe the user-facing result, with the complete PR and com
 
 This release changes how sessions and transcripts are stored by moving them into SQLite. Before downgrading to an older file-backed release, use the current CLI to restore archived legacy transcript artifacts; sessions created after the migration will not appear in older releases.
 
-Create a [verified backup](/install/updating#before-updating-create-a-verified-backup) before upgrading to protect broader OpenClaw state, and review [downgrading across the session SQLite migration](/install/updating#downgrading-across-the-session-sqlite-migration) before rolling back.
+Create a [verified backup](/install/updating#before-updating%3A-create-a-verified-backup) before upgrading to protect broader OpenClaw state, and review [downgrading across the session SQLite migration](/install/updating#downgrading-across-the-session-sqlite-migration) before rolling back.
 </Warning>
 
 OpenClaw now gives new [Mac, Linux, and Windows installs](/install) a clearer path from download to a first useful conversation, while iPhone, iPad, and Android put pairing and permissions where people need them. Guided setup can reuse supported subscriptions, API keys, and [local models](/gateway/local-models) already available, verifies the chosen model before saving it, and hands off to the web app or terminal when the connection is ready.


### PR DESCRIPTION
## What Problem This Solves

The v2026.8.1 release notes announce a very large number of features, but readers often have to leave the page and search the documentation to learn how those features work or how to use them.

## Why This Change Was Made

Adds contextual, root-relative links from all 14 public section summaries and all 117 public subsection summaries to the closest maintained feature guides. This is a link-only editorial pass: the release copy, grouping, 118 accordions, and 16,304 GitHub source links remain unchanged.

The verified-backup link uses the docs renderer's exact encoded heading ID so direct navigation lands on the requested section instead of the top of the Updating page.

## User Impact

Readers can move directly from an announcement point to setup, concepts, platform, channel, tool, security, automation, plugin, and cloud-session documentation without hunting for the right page.

## Evidence

- `pnpm check:docs`
  - docs formatting and Markdown lint passed
  - MDX validation passed
  - 7,204 internal links checked, 0 broken
  - docs config examples passed
- `pnpm docs:list` resolves both `releases/2026.8.1.md` and `gateway/cloud-sessions.md`.
- Mechanical comparison after stripping root-relative Markdown links confirms no non-link release copy changed.
- Local rendered preview at `/releases/2026.8.1/` shows 179 contextual links to 119 exact targets, including three cloud-session links, with no browser console warnings or errors.
- Direct browser navigation to `https://docs.openclaw.ai/install/updating#before-updating%3A-create-a-verified-backup` lands on the target heading (`scrollY=9758`, heading top approximately 120 px below the sticky header).
