### PR TITLE
fix(xai): distinguish missing answer text from malformed JSON

### DIFF
--- a/extensions/xai/code-execution.test.ts
+++ b/extensions/xai/code-execution.test.ts
@@ -277,9 +277,11 @@ describe("xai code_execution tool", () => {
     ).rejects.toThrow("xAI code execution failed: malformed JSON response");
   });
 
-  it("rejects code_execution success JSON without answer text", async () => {
+  it("reports missing code_execution answers without blaming JSON decoding", async () => {
     const mockFetch = vi.fn((_input?: unknown, _init?: unknown) =>
-      Promise.resolve(jsonResponse({ output: [{ type: "code_interpreter_call" }] })),
+      Promise.resolve(
+        jsonResponse({ status: "incomplete", output: [{ type: "code_interpreter_call" }] }),
+      ),
     );
     global.fetch = withFetchPreconnect(mockFetch);
     const tool = createCodeExecutionTool({
@@ -302,6 +304,6 @@ describe("xai code_execution tool", () => {
       tool?.execute?.("code-execution:missing-text", {
         task: "Calculate the mean of [40, 42, 44]",
       }),
-    ).rejects.toThrow("xAI code execution failed: malformed JSON response");
+    ).rejects.toThrow("xAI code execution failed: no answer text returned; try a simpler request");
   });
 });

--- a/extensions/xai/src/responses-tool-shared.test.ts
+++ b/extensions/xai/src/responses-tool-shared.test.ts
@@ -373,9 +373,15 @@ describe("xai responses tool helpers", () => {
     });
   });
 
-  it("rejects successful Responses tool payloads without answer text", () => {
-    expect(() => requireXaiResponseTextAndCitations({}, "xAI tool failed")).toThrow(
-      "xAI tool failed: malformed JSON response",
+  it.each([
+    {},
+    { output: [] },
+    { output_text: "" },
+    { output: [{ type: "code_interpreter_call" }] },
+    { output: [{ type: "message", content: [{ type: "output_text", text: "" }] }] },
+  ])("reports missing answer text without blaming JSON decoding: %j", (data) => {
+    expect(() => requireXaiResponseTextAndCitations(data, "xAI tool failed")).toThrow(
+      "xAI tool failed: no answer text returned; try a simpler request",
     );
   });
 });

--- a/extensions/xai/src/responses-tool-shared.ts
+++ b/extensions/xai/src/responses-tool-shared.ts
@@ -195,7 +195,7 @@ export function requireXaiResponseTextAndCitations(
   const { text, annotationCitations, truncated, retainedRawChars, inlineCitationOffsetsSafe } =
     extractXaiWebSearchContent(data, maxContentChars);
   if (!text) {
-    throw new Error(`${label}: malformed JSON response`);
+    throw new Error(`${label}: no answer text returned; try a simpler request`);
   }
   const explicitCitations = new Set<string>();
   if (Array.isArray(data.citations)) {

--- a/extensions/xai/web-search.test.ts
+++ b/extensions/xai/web-search.test.ts
@@ -670,9 +670,9 @@ describe("xai web search config resolution", () => {
     );
   });
 
-  it("rejects xAI web search success JSON without answer text", async () => {
+  it("reports missing xAI web search answers without blaming JSON decoding", async () => {
     const mockFetch = vi.fn((_input?: unknown, _init?: unknown) =>
-      Promise.resolve(jsonResponse({ output: [] })),
+      Promise.resolve(jsonResponse({ status: "incomplete", output: [] })),
     );
     global.fetch = withFetchPreconnect(mockFetch);
     const tool = requireXaiWebSearchTool({
@@ -680,7 +680,7 @@ describe("xai web search config resolution", () => {
     });
 
     await expect(tool.execute({ query: "OpenClaw" })).rejects.toThrow(
-      "xAI web search failed: malformed JSON response",
+      "xAI web search failed: no answer text returned; try a simpler request",
     );
   });
 

--- a/extensions/xai/x-search.test.ts
+++ b/extensions/xai/x-search.test.ts
@@ -502,9 +502,9 @@ describe("xai x_search tool", () => {
     ).rejects.toThrow("xAI X search failed: malformed JSON response");
   });
 
-  it("rejects x_search success JSON without answer text", async () => {
+  it("reports missing x_search answers without blaming JSON decoding", async () => {
     const mockFetch = vi.fn((_input?: unknown, _init?: unknown) =>
-      Promise.resolve(jsonResponse({ output: [] })),
+      Promise.resolve(jsonResponse({ status: "incomplete", output: [] })),
     );
     global.fetch = withFetchPreconnect(mockFetch);
     const tool = createConfiguredXSearchTool({
@@ -514,9 +514,9 @@ describe("xai x_search tool", () => {
 
     await expect(
       tool?.execute?.("x-search:missing-text", {
-        query: "malformed x_search missing text probe",
+        query: "x_search missing answer probe",
       }),
-    ).rejects.toThrow("xAI X search failed: malformed JSON response");
+    ).rejects.toThrow("xAI X search failed: no answer text returned; try a simpler request");
   });
 
   it("prefers the active runtime config for shared xAI keys", async () => {


### PR DESCRIPTION
Related: #130583

## What Problem This Solves

Fixes an issue where users of xAI web search, X search or code execution would receive `malformed JSON response` when the response was valid JSON but contained no usable answer text. That diagnostic sent investigation toward decoding rather than the missing answer.

## Why This Change Was Made

The shared xAI answer-text requirement now reports `no answer text returned; try a simpler request`. It is the canonical semantic owner used by all three tools; actual JSON decoding errors remain unchanged. No retry, fallback, authentication, request, cache or state behavior changes.

Production LOC: +1/-1 (net 0). Tests: +21/-13 (net +8). The code-execution regression retains its code-interpreter output entry, and genuine malformed JSON stays a separate control.

## User Impact

An xAI tool response without answer text now produces an accurate diagnostic and a suggested next step. This does not manufacture an answer or automatically retry a failed request.

Release-note context: xAI search and code execution now distinguish missing answer text from malformed JSON.

## Evidence

- Maintained shared-owner and three public-caller suites: **103 cases before**, with **8 intended diagnostic failures and 95 passing controls**; **103/103 passed after** under the same setup and assertions.
- Three real public factory flows with strict synthetic HTTP interception: **3 intended failures before; 3/3 passed after**. Nine intercepted requests in each run cover missing answer, subsequent success, genuine invalid JSON, search cache reuse and code-execution output metadata. Unmatched HTTP calls were forbidden; these were not live vendor requests.
- The canonical changed-file gate passed **all 25 selected checks** for the exact five files, including formatting, both typechecks, lint, doctor declaration/closure tests and runtime-cycle checks. Its normal package-manager bootstrap downloaded the pinned pnpm 12.1.0 executable; no project dependency reconciliation was performed.
- Independent managed Codex reviews of both the local diff and exact commit `1c9a191c2c280d1546204c15cbb5c19ef3d8ce30` found no actionable P0–P2 defects. Source/install checks stayed stable, and all recorded test, gate and review processes closed.

**Live vendor limitation:** live xAI validation was infeasible with the available approved routes: `XAI_API_KEY` was absent locally, no approved exact credential locator was known, and the existing hosted dispatch can select only the mixed xAI shard, which also runs paid media and voice tests. It cannot select the single X-search test. No new credential access or broader paid suite was used. Under the repository's concrete-infeasibility policy, this limitation is explicit: neither the missing-answer response nor the corrected tool/factory was verified against the live vendor. The current [official xAI Responses reference](https://docs.x.ai/developers/rest-api-reference/inference/chat#create-new-response) was inspected, but documentation and synthetic proof are not live proof.

Earlier setup/metadata timeouts and two artifact-parser errors were preserved and excluded from product outcomes; the counts above come from completed default/JSON reports. Hosted CI and native landing checks remain to be completed before merge.
