### PR TITLE
fix(sessions): keep failed deletions in cleanup accounting

### DIFF
--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -272,8 +272,10 @@ resources may remain, cleanup prints a warning on stderr without changing the
 JSON result. Dry runs do not load harness plugins.
 
 Applied artifact cleanup counts only successful file removals. If a file cannot
-be deleted, it contributes no freed bytes and remains part of disk usage;
-cleanup continues with other eligible files. If usage stays above the target,
+be deleted, it contributes no freed bytes and remains part of disk usage.
+Unreferenced artifact cleanup and legacy disk-budget enforcement continue with
+other eligible files. Canonical SQLite archive pruning stops after a deletion
+error to retain its database recovery copy. If usage stays above the target,
 check filesystem permissions and retry after resolving the deletion failure.
 
 `openclaw sessions cleanup --all-agents --dry-run --json`:

--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -271,6 +271,11 @@ different model. Explicitly disabled or untrusted plugins are not run. If their
 resources may remain, cleanup prints a warning on stderr without changing the
 JSON result. Dry runs do not load harness plugins.
 
+Applied artifact cleanup counts only successful file removals. If a file cannot
+be deleted, it contributes no freed bytes and remains part of disk usage;
+cleanup continues with other eligible files. If usage stays above the target,
+check filesystem permissions and retry after resolving the deletion failure.
+
 `openclaw sessions cleanup --all-agents --dry-run --json`:
 
 ```json

--- a/src/config/sessions/disk-budget.removal-failures.test.ts
+++ b/src/config/sessions/disk-budget.removal-failures.test.ts
@@ -1,0 +1,382 @@
+import nodeFs from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { writeTextAtomic } from "../../infra/json-files.js";
+import { saveLegacySessionStore } from "../../infra/state-migrations.legacy-session-store.js";
+import { withTestDir } from "../../test-helpers/temp-dir.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { runSessionsCleanup } from "./cleanup-service.js";
+import {
+  enforceSessionDiskBudget,
+  measureSessionPhysicalDiskUsage,
+  pruneSessionTranscriptArchivesToHighWater,
+  pruneUnreferencedSessionArtifacts,
+} from "./disk-budget.js";
+import { replaceSessionEntry } from "./session-accessor.js";
+import { projectSessionStoreForPersistence } from "./skill-prompt-blobs.js";
+import type { SessionEntry } from "./types.js";
+
+function rejectRemoval(targetPath: string, code: "EPERM" | "EACCES") {
+  const originalRm = nodeFs.promises.rm.bind(nodeFs.promises);
+  return vi.spyOn(nodeFs.promises, "rm").mockImplementation(async (target, options) => {
+    if (target === targetPath) {
+      throw Object.assign(new Error(`injected ${code}`), { code });
+    }
+    return await originalRm(target, options);
+  });
+}
+
+describe("session artifact deletion failures", () => {
+  it.each([
+    { boundary: "archives", promptBlob: false, code: "EPERM" },
+    { boundary: "unreferenced", promptBlob: false, code: "EACCES" },
+    { boundary: "unreferenced", promptBlob: true, code: "EPERM" },
+    { boundary: "budget", promptBlob: false, code: "EPERM" },
+    { boundary: "budget", promptBlob: true, code: "EACCES" },
+  ] as const)(
+    "$boundary skips $code without counting failed deletions (promptBlob=$promptBlob)",
+    async ({ boundary, promptBlob, code }) => {
+      await withTestDir({ prefix: "openclaw-removal-failure-" }, async (dir) => {
+        const storePath = path.join(dir, "sessions.json");
+        await fs.writeFile(storePath, "{}");
+        const paths: string[] = [];
+        for (const [index, size] of [100, 60, 40].entries()) {
+          const hash = String(index).repeat(64);
+          const filePath = promptBlob
+            ? path.join(dir, "skills-prompts", "sha256", hash.slice(0, 2), `${hash}.txt`)
+            : path.join(
+                dir,
+                boundary === "archives"
+                  ? `old-${index}.jsonl.deleted.2026-01-01T00-00-00.000Z`
+                  : `old-${index}.jsonl`,
+              );
+          await fs.mkdir(path.dirname(filePath), { recursive: true });
+          await fs.writeFile(filePath, Buffer.alloc(size, index + 1));
+          const staleTime = new Date(Date.now() - (30 - index) * 60_000);
+          await fs.utimes(filePath, staleTime, staleTime);
+          paths.push(filePath);
+        }
+        const [blockedPath] = paths;
+        if (!blockedPath) {
+          throw new Error("expected oldest artifact path");
+        }
+        const onRemoveFile = vi.fn();
+        const rmSpy = rejectRemoval(blockedPath, code);
+        try {
+          if (boundary === "archives") {
+            const result = await pruneSessionTranscriptArchivesToHighWater({
+              storePath,
+              highWaterBytes: 102,
+            });
+            expect.soft(result.removedFiles).toBe(2);
+            expect.soft(result.usage.totalBytes).toBe(102);
+          } else if (boundary === "unreferenced") {
+            const result = await pruneUnreferencedSessionArtifacts({
+              store: {},
+              storePath,
+              olderThanMs: 60_000,
+            });
+            expect.soft(result).toMatchObject({ removedFiles: 2, freedBytes: 100 });
+          } else {
+            const result = await enforceSessionDiskBudget({
+              store: {},
+              storePath,
+              maintenance: { maxDiskBytes: 150, highWaterBytes: 102 },
+              warnOnly: false,
+              onRemoveFile,
+            });
+            expect.soft(result).toMatchObject({
+              removedFiles: 2,
+              removedEntries: 0,
+              freedBytes: 100,
+              totalBytesBefore: 202,
+              totalBytesAfter: 102,
+            });
+            expect.soft(onRemoveFile.mock.calls).toEqual(paths.slice(1).map((file) => [file]));
+          }
+          expect.soft(await fs.readFile(blockedPath)).toEqual(Buffer.alloc(100, 1));
+          for (const filePath of paths.slice(1)) {
+            expect.soft(nodeFs.existsSync(filePath)).toBe(false);
+          }
+          expect.soft((await measureSessionPhysicalDiskUsage(storePath)).totalBytes).toBe(102);
+        } finally {
+          rmSpy.mockRestore();
+        }
+      });
+    },
+  );
+
+  it.each([
+    { artifact: "transcript", code: "EPERM", mode: "enforce" },
+    { artifact: "promptBlob", code: "EACCES", mode: "enforce" },
+    { artifact: "all", code: "EPERM", mode: "enforce" },
+    { artifact: "transcript", code: "EPERM", mode: "dry-run" },
+    { artifact: "transcript", code: "EPERM", mode: "warn" },
+  ] as const)(
+    "continues eviction after $artifact deletion failure ($code, $mode)",
+    async ({ artifact, code, mode }) => {
+      await withTestDir({ prefix: "openclaw-deferred-removal-failure-" }, async (dir) => {
+        const storePath = path.join(dir, "sessions.json");
+        const hash = "a".repeat(64);
+        const oldKey = "agent:main:subagent:old";
+        const activeKey = "agent:main:active";
+        const preservedKey = "agent:main:preserved";
+        const laterKey = "agent:main:subagent:later";
+        const retainedStore = {
+          [activeKey]: { sessionId: "active", updatedAt: 1 },
+          [preservedKey]: { sessionId: "preserved", updatedAt: 1 },
+          [laterKey]: { sessionId: "later", updatedAt: 3 },
+        } satisfies Record<string, SessionEntry>;
+        const store: Record<string, SessionEntry> = {
+          [oldKey]: {
+            sessionId: "old",
+            updatedAt: 2,
+            skillsSnapshot: {
+              prompt: "",
+              skills: [],
+              promptRef: { algorithm: "sha256", version: 1, hash, bytes: 600 },
+            },
+          },
+          ...retainedStore,
+        };
+        const artifacts = [
+          {
+            kind: "promptBlob",
+            owner: oldKey,
+            file: path.join(dir, "skills-prompts", "sha256", "aa", `${hash}.txt`),
+            size: 600,
+          },
+          { kind: "transcript", owner: oldKey, file: path.join(dir, "old.jsonl"), size: 400 },
+          {
+            kind: "pointer",
+            owner: oldKey,
+            file: path.join(dir, "old.trajectory-path.json"),
+            size: 80,
+          },
+          {
+            kind: "trajectory",
+            owner: oldKey,
+            file: path.join(dir, "old.trajectory.jsonl"),
+            size: 120,
+          },
+          { kind: "later", owner: laterKey, file: path.join(dir, "later.jsonl"), size: 1000 },
+        ];
+        for (const { file, size } of artifacts) {
+          await fs.mkdir(path.dirname(file), { recursive: true });
+          await fs.writeFile(file, Buffer.alloc(size, 1));
+          await fs.utimes(file, new Date(0), new Date(0));
+        }
+        for (const entry of [retainedStore[activeKey], retainedStore[preservedKey]]) {
+          await fs.writeFile(path.join(dir, `${entry.sessionId}.jsonl`), Buffer.alloc(64));
+        }
+        const originalStoreJson = JSON.stringify(store, null, 2);
+        await fs.writeFile(storePath, originalStoreJson);
+        const highWaterBytes =
+          Buffer.byteLength(JSON.stringify(retainedStore, null, 2)) + 2 * 64 + 1000;
+        const blocked = artifacts.filter(({ kind }) => artifact === "all" || kind === artifact);
+        const onRemoveFile = vi.fn();
+        const log = { warn: vi.fn(), info: vi.fn() };
+        const commitEvictedIndex = vi.fn(async () => {
+          await writeTextAtomic(storePath, JSON.stringify(store, null, 2), { durable: true });
+        });
+        const originalRm = nodeFs.promises.rm.bind(nodeFs.promises);
+        const attempted: string[] = [];
+        const rmSpy = vi
+          .spyOn(nodeFs.promises, "rm")
+          .mockImplementation(async (target, options) => {
+            const candidate = artifacts.find(({ file }) => file === target);
+            if (candidate) {
+              const persisted = JSON.parse(await fs.readFile(storePath, "utf8"));
+              expect.soft(persisted[candidate.owner]).toBeUndefined();
+              expect.soft(persisted[activeKey]).toEqual(retainedStore[activeKey]);
+              expect.soft(persisted[preservedKey]).toEqual(retainedStore[preservedKey]);
+              attempted.push(candidate.file);
+            }
+            if (blocked.some(({ file }) => file === target)) {
+              throw Object.assign(new Error(`injected ${code}`), { code });
+            }
+            return await originalRm(target, options);
+          });
+        try {
+          const result = await enforceSessionDiskBudget({
+            store,
+            storePath,
+            activeSessionKey: activeKey,
+            preserveKeys: new Set([preservedKey]),
+            maintenance: { maxDiskBytes: highWaterBytes + 1, highWaterBytes },
+            warnOnly: mode === "warn",
+            dryRun: mode === "dry-run",
+            commitEvictedIndex,
+            onRemoveFile,
+            log,
+          });
+          if (mode !== "enforce") {
+            expect(commitEvictedIndex).not.toHaveBeenCalled();
+            expect(rmSpy).not.toHaveBeenCalled();
+            expect(onRemoveFile).not.toHaveBeenCalled();
+            expect(await fs.readFile(storePath, "utf8")).toBe(originalStoreJson);
+            for (const { file, size } of artifacts) {
+              expect(await fs.readFile(file)).toEqual(Buffer.alloc(size, 1));
+            }
+            const preview = mode === "dry-run";
+            expect(store).toEqual(preview ? retainedStore : JSON.parse(originalStoreJson));
+            expect(result).toMatchObject({
+              removedEntries: preview ? 1 : 0,
+              removedFiles: preview ? 4 : 0,
+              freedBytes: preview ? 1200 : 0,
+              totalBytesAfter: preview
+                ? highWaterBytes
+                : (await measureSessionPhysicalDiskUsage(storePath)).totalBytes,
+            });
+            return;
+          }
+          const expectedStore: Record<string, SessionEntry> = { ...retainedStore };
+          delete expectedStore[laterKey];
+          expect.soft(JSON.parse(await fs.readFile(storePath, "utf8"))).toEqual(expectedStore);
+          expect.soft(store).toEqual(expectedStore);
+          expect.soft(attempted).toEqual(artifacts.map(({ file }) => file));
+          const removed = artifacts.filter((candidate) => !blocked.includes(candidate));
+          for (const { file } of removed) {
+            expect.soft(nodeFs.existsSync(file)).toBe(false);
+          }
+          for (const { file, size } of blocked) {
+            expect(await fs.readFile(file)).toEqual(Buffer.alloc(size, 1));
+          }
+          const usage = await measureSessionPhysicalDiskUsage(storePath);
+          expect.soft(result).toMatchObject({
+            removedEntries: 2,
+            removedFiles: removed.length,
+            freedBytes: removed.reduce((sum, file) => sum + file.size, 0),
+            totalBytesAfter: usage.totalBytes,
+          });
+          expect.soft(onRemoveFile.mock.calls).toEqual(removed.map(({ file }) => [file]));
+          if (artifact === "all") {
+            expect.soft(usage.totalBytes).toBeGreaterThan(highWaterBytes);
+            expect
+              .soft(log.warn)
+              .toHaveBeenCalledWith(
+                "session disk budget still above high-water target after cleanup",
+                expect.objectContaining({ totalBytes: usage.totalBytes }),
+              );
+            expect.soft(log.info).not.toHaveBeenCalled();
+          } else {
+            expect.soft(usage.totalBytes).toBeLessThanOrEqual(highWaterBytes);
+            expect.soft(log.warn).not.toHaveBeenCalled();
+            expect
+              .soft(log.info)
+              .toHaveBeenCalledWith(
+                "applied session disk budget cleanup",
+                expect.objectContaining({ totalBytesAfter: usage.totalBytes }),
+              );
+          }
+        } finally {
+          rmSpy.mockRestore();
+        }
+      });
+    },
+  );
+
+  it("keeps newly persisted prompt bytes counted while continuing to the next victim", async () => {
+    await withTestDir({ prefix: "openclaw-budget-persisted-prompt-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const oldKey = "agent:main:subagent:old";
+      const laterKey = "agent:main:subagent:later";
+      const activeKey = "agent:main:main";
+      const prompt = "p".repeat(600);
+      const store: Record<string, SessionEntry> = {
+        [oldKey]: { sessionId: "old", updatedAt: 1, delivery: { kind: "none" } },
+        [laterKey]: {
+          sessionId: "later",
+          updatedAt: 2,
+          delivery: { kind: "none" },
+          skillsSnapshot: { prompt, skills: [] },
+        },
+        [activeKey]: { sessionId: "active", updatedAt: 3, delivery: { kind: "none" } },
+      };
+      const oldTranscript = path.join(dir, "old.jsonl");
+      const laterTranscript = path.join(dir, "later.jsonl");
+      await fs.writeFile(oldTranscript, Buffer.alloc(1000));
+      await fs.writeFile(laterTranscript, Buffer.alloc(1000));
+      await fs.writeFile(storePath, JSON.stringify(store, null, 2));
+      const projected = projectSessionStoreForPersistence({ storePath, store });
+      const blob = [...projected.promptBlobs.values()][0];
+      if (!blob?.path) {
+        throw new Error("expected projected prompt blob path");
+      }
+      const retained = { ...projected.store };
+      delete retained[oldKey];
+      const highWaterBytes = Buffer.byteLength(JSON.stringify(retained, null, 2)) + 1600;
+      const rmSpy = rejectRemoval(oldTranscript, "EPERM");
+      try {
+        const result = await enforceSessionDiskBudget({
+          store,
+          storePath,
+          maintenance: { maxDiskBytes: highWaterBytes + 1, highWaterBytes },
+          warnOnly: false,
+          commitEvictedIndex: () =>
+            saveLegacySessionStore(storePath, store, { skipMaintenance: true }),
+        });
+        expect.soft(Object.keys(store)).toEqual([activeKey]);
+        expect.soft(nodeFs.existsSync(laterTranscript)).toBe(false);
+        expect(await fs.readFile(oldTranscript)).toEqual(Buffer.alloc(1000));
+        expect(await fs.readFile(blob.path, "utf8")).toBe(prompt);
+        const usage = await measureSessionPhysicalDiskUsage(storePath);
+        // Legacy persistence appends a newline; the budget models the JSON payload.
+        expect.soft(result).toMatchObject({
+          removedEntries: 2,
+          removedFiles: 1,
+          freedBytes: 1000,
+          totalBytesAfter: usage.totalBytes - 1,
+        });
+        expect.soft(usage.totalBytes).toBeLessThanOrEqual(highWaterBytes);
+      } finally {
+        rmSpy.mockRestore();
+      }
+    });
+  });
+
+  it("reports only successful orphan removals in the applied cleanup-service summary", async () => {
+    await withOpenClawTestState({ label: "cleanup-removal-failure" }, async (state) => {
+      const cfg = { session: { maintenance: { maxDiskBytes: false, pruneAfter: "1d" } } } as const;
+      await state.writeConfig(cfg);
+      const storePath = path.join(state.sessionsDir(), "sessions.json");
+      await replaceSessionEntry(
+        { agentId: "main", sessionKey: "agent:main:main", storePath },
+        { sessionId: "active", updatedAt: Date.now() },
+      );
+      const blocked = path.join(state.sessionsDir(), "blocked.jsonl");
+      const removable = path.join(state.sessionsDir(), "removable.jsonl");
+      await fs.mkdir(state.sessionsDir(), { recursive: true });
+      for (const [file, size] of [
+        [blocked, 100],
+        [removable, 60],
+      ] as const) {
+        await fs.writeFile(file, Buffer.alloc(size));
+        await fs.utimes(file, new Date(0), new Date(0));
+      }
+      const rmSpy = rejectRemoval(blocked, "EACCES");
+      try {
+        const result = await runSessionsCleanup({
+          cfg,
+          opts: { enforce: true },
+          targets: [{ agentId: "main", storePath }],
+        });
+        expect(result.previewResults[0]?.summary.unreferencedArtifacts).toMatchObject({
+          removedFiles: 2,
+          freedBytes: 160,
+        });
+        expect(result.appliedSummaries[0]).toMatchObject({
+          applied: true,
+          beforeCount: 1,
+          afterCount: 1,
+          unreferencedArtifacts: { removedFiles: 1, freedBytes: 60 },
+        });
+        expect(await fs.readFile(blocked)).toEqual(Buffer.alloc(100));
+        expect(nodeFs.existsSync(removable)).toBe(false);
+      } finally {
+        rmSpy.mockRestore();
+      }
+    });
+  });
+});

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -464,8 +464,10 @@ async function removeFileIfExists(filePath: string): Promise<number> {
   if (!stat?.isFile()) {
     return 0;
   }
-  await fs.promises.rm(filePath, { force: true }).catch(() => undefined);
-  return stat.size;
+  return await fs.promises.rm(filePath, { force: true }).then(
+    () => stat.size,
+    () => 0,
+  );
 }
 
 async function removeFileForBudget(params: {
@@ -805,27 +807,6 @@ export async function enforceSessionDiskBudget(params: {
     removedFiles += 1;
   }
 
-  const deferredEvictedArtifactPaths: string[] = [];
-  const planEvictedArtifactRemoval = (rawPath: string, canonicalPathHint?: string): number => {
-    // An evicted artifact may only be unlinked after its reduced index is durable.
-    // Callers without that boundary retain the artifact as a reclaimable orphan.
-    if (!dryRun && !commitEvictedIndex) {
-      return 0;
-    }
-    const resolvedPath = path.resolve(rawPath);
-    const canonicalPath = canonicalPathHint ?? canonicalizePathForComparison(resolvedPath);
-    if (simulatedRemovedPaths.has(canonicalPath)) {
-      return 0;
-    }
-    const size = fileSizesByPath.get(canonicalPath) ?? 0;
-    if (size <= 0) {
-      return 0;
-    }
-    simulatedRemovedPaths.add(canonicalPath);
-    deferredEvictedArtifactPaths.push(resolvedPath);
-    return size;
-  };
-
   if (total > highWaterBytes) {
     const activeSessionKey = normalizeOptionalLowercaseString(params.activeSessionKey);
     const sessionIdRefCounts = buildSessionIdRefCounts(params.store);
@@ -871,6 +852,22 @@ export async function enforceSessionDiskBudget(params: {
         projectedStoreBytes = measureStoreBytes(projectedStore);
       }
       total += projectedStoreBytes - previousProjectedBytes;
+      removedEntries += 1;
+      // Commit each reduced index before unlinking its victim's artifacts. Only
+      // actual reclamation can stop eviction; a failed unlink leaves pressure.
+      if (!dryRun && commitEvictedIndex) {
+        await commitEvictedIndex();
+        if (projectedPromptBlobBytesByHash.size > 0) {
+          // Persistence can materialize remaining entries' projected blobs. Those
+          // bytes now belong to files and cannot later be credited as unwritten.
+          for (const file of await readSessionPromptBlobFiles(sessionsDir)) {
+            const hash = resolvePromptBlobFileHash(file);
+            if (hash && projectedPromptBlobBytesByHash.delete(hash)) {
+              existingPromptBlobFilesByHash.set(hash, file);
+            }
+          }
+        }
+      }
       if (promptBlobHash) {
         const nextRefCount = (projectedPromptBlobRefCounts.get(promptBlobHash) ?? 1) - 1;
         if (nextRefCount > 0) {
@@ -880,34 +877,29 @@ export async function enforceSessionDiskBudget(params: {
           const virtualBlobBytes = projectedPromptBlobBytesByHash.get(promptBlobHash) ?? 0;
           if (virtualBlobBytes > 0) {
             total -= virtualBlobBytes;
+            projectedPromptBlobBytesByHash.delete(promptBlobHash);
           } else {
             const blobFile = existingPromptBlobFilesByHash.get(promptBlobHash);
-            if (
-              blobFile &&
-              isPromptBlobArtifactRemovable(
-                blobFile,
+            if (blobFile && (dryRun || commitEvictedIndex)) {
+              const deletedBytes = await removePromptBlobFileForBudget({
+                file: blobFile,
                 projectedPromptBlobRefCounts,
-                promptBlobOrphanCutoffMs,
-                tempStaleCutoffMs,
-              )
-            ) {
-              const plannedBytes = planEvictedArtifactRemoval(
-                blobFile.path,
-                blobFile.canonicalPath,
-              );
-              if (plannedBytes > 0) {
-                total -= plannedBytes;
-                if (dryRun) {
-                  freedBytes += plannedBytes;
-                  removedFiles += 1;
-                }
+                promptBlobCutoffMs: promptBlobOrphanCutoffMs,
+                tempCutoffMs: tempStaleCutoffMs,
+                dryRun,
+                fileSizesByPath,
+                simulatedRemovedPaths,
+                onRemovedPath: dryRun ? undefined : params.onRemoveFile,
+              });
+              if (deletedBytes > 0) {
+                total -= deletedBytes;
+                freedBytes += deletedBytes;
+                removedFiles += 1;
               }
             }
           }
         }
       }
-      removedEntries += 1;
-
       const sessionId = entry.sessionId;
       if (!sessionId) {
         continue;
@@ -918,35 +910,25 @@ export async function enforceSessionDiskBudget(params: {
         continue;
       }
       sessionIdRefCounts.delete(sessionId);
-      for (const artifactPath of resolveSessionArtifactPathsForEntry({ sessionsDir, entry })) {
-        const plannedBytes = planEvictedArtifactRemoval(artifactPath);
-        if (plannedBytes <= 0) {
-          continue;
-        }
-        total -= plannedBytes;
-        if (dryRun) {
-          freedBytes += plannedBytes;
-          removedFiles += 1;
-        }
-      }
-    }
-  }
-
-  if (!dryRun && commitEvictedIndex && deferredEvictedArtifactPaths.length > 0) {
-    await commitEvictedIndex();
-    for (const filePath of deferredEvictedArtifactPaths) {
-      const deletedBytes = await removeFileForBudget({
-        filePath,
-        dryRun: false,
-        fileSizesByPath,
-        simulatedRemovedPaths,
-        onRemovedPath: params.onRemoveFile,
-      });
-      if (deletedBytes <= 0) {
+      // Without a durable commit boundary, retain evicted artifacts as orphans.
+      if (!dryRun && !commitEvictedIndex) {
         continue;
       }
-      freedBytes += deletedBytes;
-      removedFiles += 1;
+      for (const artifactPath of resolveSessionArtifactPathsForEntry({ sessionsDir, entry })) {
+        const deletedBytes = await removeFileForBudget({
+          filePath: artifactPath,
+          dryRun,
+          fileSizesByPath,
+          simulatedRemovedPaths,
+          onRemovedPath: dryRun ? undefined : params.onRemoveFile,
+        });
+        if (deletedBytes <= 0) {
+          continue;
+        }
+        total -= deletedBytes;
+        freedBytes += deletedBytes;
+        removedFiles += 1;
+      }
     }
   }
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators running session cleanup could see files reported as removed and space reported as reclaimed even when filesystem deletion failed. Disk-budget enforcement could stop before trying later eligible files while the undeleted file still occupied disk space.

This affects retained transcript archives, unreferenced session artifacts and prompt blobs, and the legacy session-store disk-budget path. It was discovered during read-only updater-recovery research; this PR does not add or change an upgrade-recovery cleanup CLI.

## Why This Change Was Made

The shared deletion helper returned the file's earlier size after swallowing an `rm` rejection. It now credits bytes only on successful removal. A helper-only correction was insufficient for evicted transcripts: the deferred plan still subtracted bytes before unlinking. This PR removes that speculative planner and queue, commits each reduced legacy index before unlinking that victim's artifacts, and bases subsequent eviction decisions on actual reclamation.

Per-victim persistence can materialize remaining entries' projected prompt blobs. Those files are moved out of virtual-byte accounting and use the existing freshness/refcount checks. Active and preserved sessions, commit-failure safety, no-commit retention, dry-run, and warn semantics remain protected. No schema, configuration, dependency, or protocol changes.

Production LOC: **+50/-68 (net -18)**. Tests: **+382**. Documentation: **+7**. The separate pre-existing omission of successful zero-byte deletions from file counts is recorded as a follow-up and is not expanded into this repair.

## User Impact

Failed file deletions no longer inflate removed-file counts, freed bytes, or removal callbacks. Unreferenced artifact cleanup and legacy disk-budget enforcement continue with eligible candidates instead of treating failed deletion attempts as reclaimed space. Canonical SQLite archive pruning keeps its existing stop-on-error behavior so its database recovery copy remains intact. If eligible candidates are exhausted, the remaining pressure is reported rather than hidden by optimistic totals.

The [session cleanup documentation](https://docs.openclaw.ai/cli/sessions#cleanup-maintenance) explains this accounting and the need to resolve filesystem deletion failures before retrying.

## Evidence

- **Before:** seven regression cases failed using real temporary files with path-specific `EPERM`/`EACCES` injection at `fs.promises.rm`. Archive cleanup reported three removals instead of two; orphan cleanup reported 200 freed bytes instead of 100. A budget case reported 102 bytes remaining while all 202 bytes still existed.
- **Continuation proof:** strengthened cases failed against the intermediate helper-only/final-reconciliation repair because a later eligible victim was left untouched. The final flow attempts later victims and preserves durable-index-before-unlink ordering for every victim.
- **After:** 117 tests passed across six owner/sibling files. All 12 new boundary cases passed again after strict fixture typing was corrected. Coverage includes transcript/prompt-blob failures, later successful reclamation, exhausted all-fail warnings, active/preserved rows, dry-run/warn behavior, prompt materialization through real legacy persistence, and authoritative `runSessionsCleanup` summaries.
- **Real filesystem/service proof:** the cleanup-service fixture previews two orphan removals/160 bytes, then correctly reports one actual removal/60 bytes after injected `EACCES`; the blocked file remains intact. All state is isolated and temporary. No operator state, live gateway, channel, or model provider is used. This deterministic filesystem defect is proved at the real deletion and cleanup-service boundaries, not through a mocked cleanup result.
- **Local checks:** selected `check:changed`, formatting, core/test types, lint, dead-export scan, storage guards, and runtime import-cycle checks passed. The initial changed gate caught three test-fixture typing errors, which were fixed before the passing rerun.

Focused proof:

```bash
node scripts/run-vitest.mjs src/config/sessions/disk-budget.removal-failures.test.ts src/config/sessions/disk-budget.test.ts src/config/sessions/store-maintenance-recent-preservation.test.ts src/config/sessions/store.pruning.test.ts src/config/sessions/cleanup-service.applied-summary.test.ts src/config/sessions/session-history-eviction.test.ts
```

```bash
node scripts/check-changed.mjs -- src/config/sessions/disk-budget.ts src/config/sessions/disk-budget.removal-failures.test.ts docs/cli/sessions.md
```

```bash
git diff --check
```

Source review traced all cleanup callers, the legacy durable writer, canonical SQLite archive cleanup, archive-age retention, trajectory cleanup, and Node's `rm` contract (`force` suppresses missing paths, not permission failures). Existing Node and repository helpers suffice; no new deletion abstraction or dependency was added.

Fresh isolated Codex autoreview of this exact precommit diff returned scoped-clean with no accepted/actionable findings at its default P0-only threshold. This is a scoped review result, not a claim of exhaustive defect absence. The original repair head passed [hosted CI 33345300513](https://github.com/openclaw/openclaw/actions/runs/33345300513). The documentation-only correction also passed a fresh isolated Codex autoreview at the default P0-only threshold. Final head `8e7d6a48496c121eec94177fcce4988a65d77973` passed [hosted CI 33346071879](https://github.com/openclaw/openclaw/actions/runs/33346071879), including the required `openclaw/ci-gate`.

ClawSweeper review correction: narrowed the cleanup continuation documentation to unreferenced/legacy paths and documented the canonical SQLite archive recovery-copy exception. `node scripts/check-changed.mjs -- docs/cli/sessions.md` and `git diff --check` passed for this documentation-only follow-up.

Fresh three-way merge proof against main `a4290a4a65e2afa00ae01710b46bb80146e5cf8e` is clean: exactly the three authorized paths change, and each resulting file blob equals the reviewed head. This resolves the refreshed ClawSweeper review’s stale supplied test-merge evidence gap.
