### PR TITLE
refactor(ui): consolidate forwarded message presentation

### DIFF
--- a/ui/src/pages/chat/chat-avatar.ts
+++ b/ui/src/pages/chat/chat-avatar.ts
@@ -9,6 +9,7 @@ import {
   resolveLocalUserAvatarUrl,
   resolveLocalUserName,
 } from "../../app/user-identity.ts";
+import { icons } from "../../components/icons.ts";
 import {
   identityAvatarClass,
   renderIdentityAvatarImage,
@@ -136,23 +137,35 @@ function renderAgentAvatar(
     : fallback;
 }
 
-export type SenderAgentAvatarOptions = {
+type ForwardedAvatarOptions = {
   agentId?: string;
   agents?: AgentsListResult["agents"];
   senderAgentAvatars?: ReadonlyMap<string, string | null>;
+  assistantName?: string;
+  assistantAvatar?: string | null;
+  resourceBasePath?: string;
   assistantAttachmentAuthToken?: string | null;
 };
 
-export function renderSenderAgentAvatar(
-  agentId: string | undefined,
-  opts: SenderAgentAvatarOptions,
-) {
-  const agent =
-    agentId && agentId !== opts.agentId
-      ? opts.agents?.find((candidate) => candidate.id === agentId)
-      : undefined;
+export function renderForwardedAvatar(agentId: string | undefined, opts: ForwardedAvatarOptions) {
+  // Forwarded rows carry the source agent's identity: another
+  // agent's avatar via the sender map, the current agent's own
+  // avatar for same-agent sessions, and the forward glyph only for
+  // unresolvable or legacy sources.
+  if (agentId && agentId === opts.agentId) {
+    return renderChatAvatar(
+      "assistant",
+      { name: opts.assistantName ?? "Assistant", avatar: opts.assistantAvatar ?? null },
+      undefined,
+      opts.resourceBasePath,
+      opts.assistantAttachmentAuthToken,
+    );
+  }
+  const agent = agentId ? opts.agents?.find((candidate) => candidate.id === agentId) : undefined;
   if (!agent) {
-    return undefined;
+    return html`<div class="chat-avatar chat-avatar--forwarded" aria-hidden="true">
+      ${icons.forward}
+    </div>`;
   }
   const name = agent.identity?.name?.trim() || agent.id;
   return renderAgentAvatar(
@@ -293,19 +306,11 @@ function buildAvatarMetaUrl(resourceBasePath: string, agentId: string): string {
   return `${buildControlUiResourcePath("agentAvatar", resourceBasePath, agentId)}?meta=1`;
 }
 
-function clearChatAvatarUrl(host: ChatAvatarHost) {
-  host.chatAvatarUrl = null;
-}
-
 function clearChatAvatarState(host: ChatAvatarHost) {
-  clearChatAvatarUrl(host);
+  host.chatAvatarUrl = null;
   host.chatAvatarSource = null;
   host.chatAvatarStatus = null;
   host.chatAvatarReason = null;
-}
-
-function setChatAvatarUrl(host: ChatAvatarHost, nextUrl: string | null) {
-  host.chatAvatarUrl = nextUrl;
 }
 
 function applyChatAvatarSnapshot(
@@ -316,7 +321,7 @@ function applyChatAvatarSnapshot(
   host.chatAvatarSource = snapshot.source;
   host.chatAvatarStatus = snapshot.status;
   host.chatAvatarReason = snapshot.reason;
-  setChatAvatarUrl(host, snapshot.url);
+  host.chatAvatarUrl = snapshot.url;
   chatAvatarDisplayedAgents.set(host as object, agentId);
 }
 

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -19,6 +19,7 @@ import {
 import {
   assistantGroupIsForwardedBoundary,
   chatItemStartsUserTurn,
+  hasForwardedSource,
   safeNormalizeMessage,
 } from "./chat-turn-boundary.ts";
 import { indexTurnContinuations, persistedSteerTargetRunId } from "./stream-causal-boundary.ts";
@@ -49,10 +50,7 @@ function stampReplyAttribution(
       // A sender-less user group clears attribution: no chip is safer than
       // mislabeling the reply as addressed to the previous participant.
       latestUserSender = item.sender;
-    } else if (
-      item.role === "assistant" &&
-      (item.senderSession || assistantGroupIsForwardedBoundary(item))
-    ) {
+    } else if (item.role === "assistant" && hasForwardedSource(item)) {
       // Forwarded input starts a turn without a local human reply recipient.
       latestUserSender = undefined;
     } else if (item.role === "assistant" && latestUserSender) {

--- a/ui/src/pages/chat/chat-turn-boundary.ts
+++ b/ui/src/pages/chat/chat-turn-boundary.ts
@@ -13,13 +13,17 @@ export function safeNormalizeMessage(message: unknown): NormalizedMessage | null
   }
 }
 
-function isForwardedSessionMessage(message: unknown): boolean {
-  const provenance = asRecord(asRecord(message)?.provenance);
-  return provenance?.kind === "inter_session" && provenance.sourceTool === "sessions_send";
+export function assistantGroupIsForwardedBoundary(group: MessageGroup): boolean {
+  return group.messages.some(({ message }) => {
+    const provenance = asRecord(asRecord(message)?.provenance);
+    return provenance?.kind === "inter_session" && provenance.sourceTool === "sessions_send";
+  });
 }
 
-export function assistantGroupIsForwardedBoundary(group: MessageGroup): boolean {
-  return group.messages.some(({ message }) => isForwardedSessionMessage(message));
+// Display attribution also accepts projected source metadata; turn ownership
+// above still requires the original sessions_send provenance.
+export function hasForwardedSource(group: MessageGroup): boolean {
+  return Boolean(group.senderSession) || assistantGroupIsForwardedBoundary(group);
 }
 
 function groupStartsProjectedTurnBoundary(group: MessageGroup): boolean {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -9049,11 +9049,12 @@ describe("right-click Reply", () => {
   });
 
   it("does not open Reply menu when onSetReply is absent", () => {
-    renderChatView({
+    const { bubble } = renderChatBubble({
       messages: [{ role: "user", content: "hello", timestamp: 1 }],
     });
 
     // Without onSetReply, the handler returns early and no menu is created
+    dispatchContextMenu(bubble);
     expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
   });
 

--- a/ui/src/pages/chat/components/chat-forwarded-attribution.ts
+++ b/ui/src/pages/chat/components/chat-forwarded-attribution.ts
@@ -1,12 +1,16 @@
 // Attribution row for cross-session (sessions_send) forwarded messages.
 import { html, nothing } from "lit";
+import type { AgentsListResult } from "../../../api/types.ts";
 import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import type { MessageGroup } from "../../../lib/chat/chat-types.ts";
 import { parseAgentSessionKey } from "../../../lib/sessions/session-key.ts";
-import type { SenderAgentAvatarOptions } from "../chat-avatar.ts";
 
-type ForwardedAttributionOptions = SenderAgentAvatarOptions & { mainKey?: string };
+type ForwardedAttributionOptions = {
+  agentId?: string;
+  agents?: AgentsListResult["agents"];
+  mainKey?: string;
+};
 
 /**
  * Label rules (operator decision, 2026-08-30): an agent's main session reads

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -20,18 +20,14 @@ import { summarizeToolGroup } from "../../../lib/chat/tool-call-grouping.ts";
 import { extractToolCardsCached } from "../../../lib/chat/tool-cards.ts";
 import { fnv1aUtf16 } from "../../../lib/fnv1a.ts";
 import { resolveIdentityHue } from "../../../lib/identity-avatar.ts";
-import {
-  renderChatAvatar,
-  renderSenderAgentAvatar,
-  type SenderAgentAvatarOptions,
-} from "../chat-avatar.ts";
+import { renderChatAvatar, renderForwardedAvatar } from "../chat-avatar.ts";
 import type { TurnRecap } from "../chat-progress.ts";
 import {
   persistedMessageEntryId,
   readPendingSendFailure,
   type AssistantMessageExpansionState,
 } from "../chat-thread.ts";
-import { assistantGroupIsForwardedBoundary } from "../chat-turn-boundary.ts";
+import { hasForwardedSource } from "../chat-turn-boundary.ts";
 import { workspaceResultConflictFromTranscript } from "../workspace-conflict.ts";
 import { renderChatAuthorAvatar } from "./chat-author-avatar.ts";
 import { renderForwardedAttribution } from "./chat-forwarded-attribution.ts";
@@ -83,7 +79,7 @@ type RenderMessageGroupOptions = Omit<
   | "resolveReplyPreview"
 > &
   ChatSendStatusActions &
-  SenderAgentAvatarOptions & {
+  Parameters<typeof renderForwardedAvatar>[1] & {
     latestBrowserTabs?: ReadonlyMap<string, BrowserTabSelection>;
     /** Configured main-session key; an agent's main source labels as the agent. */
     mainKey?: string;
@@ -93,8 +89,6 @@ type RenderMessageGroupOptions = Omit<
       messageId: string,
     ) => AssistantMessageExpansionState | undefined;
     onToggleAssistantMessageExpanded?: (messageId: string) => void;
-    assistantName?: string;
-    assistantAvatar?: string | null;
     userId?: string | null;
     userName?: string | null;
     /** Routing for peer sender names; absent leaves them plain text. */
@@ -358,13 +352,8 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
   );
   const assistantName = opts.assistantName ?? "Assistant";
   const isPeerGroup = normalizedRole === "user" && isPeerSenderGroup(group, opts.userId);
-  const isForwarded =
-    normalizedRole === "assistant" &&
-    (Boolean(group.senderSession) || assistantGroupIsForwardedBoundary(group));
+  const isForwarded = normalizedRole === "assistant" && hasForwardedSource(group);
   const sourceSessionKey = group.senderSession?.sessionKey;
-  // Only agent-prefixed keys are navigable: the titler, hovercard, and click
-  // handlers all reject other shapes, so a legacy key must stay plain text
-  // instead of becoming a focusable link that goes nowhere.
   const who = resolveMessageGroupSenderLabel(group, opts);
   const roleClass =
     normalizedRole === "user"
@@ -469,22 +458,7 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
       showAvatarGutter &&
       (isForwarded || normalizedRole !== "assistant" || opts.showAssistantAvatar !== false)
         ? isForwarded
-          ? // Forwarded rows carry the source agent's identity: another
-            // agent's avatar via the sender map, the current agent's own
-            // avatar for same-agent sessions, and the forward glyph only for
-            // unresolvable or legacy sources.
-            (renderSenderAgentAvatar(group.senderSession?.agentId, opts) ??
-            (group.senderSession?.agentId && group.senderSession.agentId === opts.agentId
-              ? renderChatAvatar(
-                  "assistant",
-                  assistantAvatarIdentity,
-                  undefined,
-                  opts.resourceBasePath,
-                  opts.assistantAttachmentAuthToken,
-                )
-              : html`<div class="chat-avatar chat-avatar--forwarded" aria-hidden="true">
-                  ${icons.forward}
-                </div>`))
+          ? renderForwardedAvatar(group.senderSession?.agentId, opts)
           : renderChatAvatar(
               group.role,
               assistantAvatarIdentity,
@@ -581,5 +555,3 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
     </div>
   `;
 }
-
-// ── Per-message metadata (tokens, cost, model, context %) ──

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -30,7 +30,7 @@ import {
   setExpansionState,
   syncToolCardExpansionState,
 } from "../chat-thread.ts";
-import { assistantGroupIsForwardedBoundary } from "../chat-turn-boundary.ts";
+import { hasForwardedSource } from "../chat-turn-boundary.ts";
 import { getToolTitlesVersion, scheduleToolTitlesForTranscript } from "../tool-titles.ts";
 import { renderAgentRunFrame } from "./chat-agent-run-frame.ts";
 import { renderBackgroundTasksStatusRow } from "./chat-background-tasks-status.ts";
@@ -224,9 +224,7 @@ export function projectChatTranscript(
   // A forwarded cross-session message is another voice in the room: the thread
   // stops rendering as a compact direct exchange and identity chrome returns.
   const hasForwardedGroups = chatItems.some(
-    (item) =>
-      item.kind === "group" &&
-      (Boolean(item.senderSession) || assistantGroupIsForwardedBoundary(item)),
+    (item) => item.kind === "group" && hasForwardedSource(item),
   );
   const isDirectThread =
     (sessionKind === "direct" || sessionKind === "cron" || sessionKind === "spawn-child") &&


### PR DESCRIPTION
## What Problem This Solves

The forwarded cross-session message surface accreted duplication across its two landings (#132054 speech bubbles, #133439 sender-agent avatars) while racing the rendering unification (#133474): the "is this group forwarded?" predicate existed in three inline copies (message-group, transcript projection, reply-attribution stamping), the forwarded avatar selection was a nested ternary chain living outside the avatar owner, and `chat-avatar.ts` carried assignment-only wrapper functions plus an exported options type with a single real consumer.

## Why This Change Was Made

Post-landing consolidation pass, zero behavior change. `hasForwardedSource` in `chat-turn-boundary.ts` is now the canonical display predicate (with a comment separating it from provenance-only turn ownership, which stays in `assistantGroupIsForwardedBoundary`); all three call sites use it. The full forwarded avatar-selection chain (same-agent → current assistant identity, cross-agent → roster avatar, unresolvable/legacy → forward glyph) moved into `renderForwardedAvatar` in the avatar owner `chat-avatar.ts`, carrying its identity-contract comment along; `chat-message-group.ts` now makes one boring call. The `SenderAgentAvatarOptions` export is gone — the attribution module declares its own narrow options, and the group-options type derives the avatar fields from the function signature, matching the file's existing `Parameters<typeof renderGroupedMessage>` idiom. Two assignment-only wrappers (`clearChatAvatarUrl`, `setChatAvatarUrl`) were inlined, and an orphaned comment plus a dangling section divider were removed (the legacy-key comment lives at its logic in `chat-forwarded-attribution.ts`).

One test repair in the same pass: the "does not open Reply menu when onSetReply is absent" case asserted no menu existed without ever dispatching `contextmenu`, so the early-return guard it names was never exercised; it now dispatches on a bubble like its siblings.

## User Impact

None visible — pure consolidation. Production LOC −19; startup JS gzip dropped 345,402 → 345,368 B.

## Evidence

Zero-behavior-change refactor with no UI delta, verified by:

- `node scripts/run-vitest.mjs ui/src/pages/chat ui/src/lib/chat src/gateway/chat-display-projection` — 12,670 tests passed.
- `node scripts/check-changed.mjs` — fully green (format, tsgo lanes, lint stripes, dead-export scan, import cycles).
- `node scripts/ui.js build` — budgets green, startup JS gzip 345,368 B (below the 346,777 B baseline).
- Codex autoreview on the branch diff — scoped-clean.
- Avatar-selection equivalence traced case-by-case (same-agent, roster cross-agent, unknown agent, missing agentId) against the prior `??` chain; behavior tests for all four shapes already exist in `chat-message.test.ts` and pass unchanged.
