### PR TITLE
perf(test): trim fixture subprocess overhead

### DIFF
--- a/test/scripts/build-artifact-cache.test.ts
+++ b/test/scripts/build-artifact-cache.test.ts
@@ -14,10 +14,12 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const roots = useAutoCleanupTempDirTracker(afterEach);
 const require = createRequire(import.meta.url);
-const native = path.join(
-  path.dirname(require.resolve("@typescript/native-preview/package.json")),
-  "lib/tsgo.js",
-);
+const native: string = require(
+  path.join(
+    path.dirname(require.resolve("@typescript/native-preview/package.json")),
+    "lib/getExePath.js",
+  ),
+).default();
 function fixture(noEmit = false, outputRoot = "dist") {
   const root = fs.realpathSync(roots.make("native-boundary-cache-"));
   const write = (file: string, bytes: string) => {
@@ -68,7 +70,7 @@ function fixture(noEmit = false, outputRoot = "dist") {
     before.signature(config, args, [], ownedOutputRoot);
     fs.rmSync(path.join(root, buildInfo), { force: true });
     const startedAt = Date.now();
-    const result = spawnSync(process.execPath, [native, ...args], { encoding: "utf8" });
+    const result = spawnSync(native, args, { encoding: "utf8" });
     expect(result.status, result.stdout + result.stderr).toBe(0);
     const files = result.stdout
       .split("\n")
@@ -180,7 +182,7 @@ describe("native owner content records", () => {
     ];
     shared.signature(config, args, []);
     const startedAt = Date.now();
-    const compiled = spawnSync(process.execPath, [native, ...args], { encoding: "utf8" });
+    const compiled = spawnSync(native, args, { encoding: "utf8" });
     expect(compiled.status, compiled.stdout + compiled.stderr).toBe(0);
     const record = new BoundaryInputSnapshot(f.root).record(
       config,
@@ -195,7 +197,7 @@ describe("native owner content records", () => {
     expect(matches()).toBe(true);
     f.write("packages/sdk/dist/nested/value.ts", 'export const value = "changed";');
     expect(matches()).toBe(false);
-    const changed = spawnSync(process.execPath, [native, ...args], { encoding: "utf8" });
+    const changed = spawnSync(native, args, { encoding: "utf8" });
     expect(changed.status, changed.stdout + changed.stderr).toBe(1);
     expect(changed.stdout).toContain("TS2322");
   });
@@ -244,7 +246,7 @@ describe("native owner content records", () => {
       expect(matches()).toBe(true);
       fs.writeFileSync(path.join(moduleRoot, "value.ts"), 'export const value = "changed";');
       const staleHit = matches();
-      const result = spawnSync(process.execPath, [native, ...f.args], { encoding: "utf8" });
+      const result = spawnSync(native, f.args, { encoding: "utf8" });
       expect(result.status, result.stdout + result.stderr).toBe(1);
       expect(result.stdout).toContain("TS2322");
       expect(result.stdout).toContain("Type '\"changed\"' is not assignable to type '1'");
@@ -328,7 +330,7 @@ describe("native owner content records", () => {
     const before = new BoundaryInputSnapshot(f.root);
     before.signature(config, args, []);
     const startedAt = Date.now();
-    const result = spawnSync(process.execPath, [native, ...args], { encoding: "utf8" });
+    const result = spawnSync(native, args, { encoding: "utf8" });
     expect(result.status, result.stdout + result.stderr).toBe(0);
     const consumer = new BoundaryInputSnapshot(f.root).record(
       config,

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -1163,7 +1163,7 @@ child.once('message', () => { ${normalExit ? "process.exit(0);" : ""} });
                 },
               })
             : runNodeStepsInParallel([
-                { label: "blocked", args, timeoutMs: 100 },
+                { label: "blocked", args, timeoutMs: 100, abortKillGraceMs: 100 },
                 {
                   label: "primary",
                   args: [


### PR DESCRIPTION
## What Problem This Solves

Compiler-record and escaped-output cancellation tests pay for repeated launcher startup and a default termination grace that are outside the behavior those fixtures check.

## Why This Change Was Made

Resolve the installed native compiler with the same `getExePath.js` helper already used by `BoundaryInputSnapshot`, then invoke it directly at the fixture's five launch sites. All 31 cases and 36 real native compilations remain; arguments, environment, working directory, emitted declarations/build-info and invalidation assertions are unchanged. The pinned package launcher only resolves that executable and forwards its arguments; wrapper-specific coverage remains in the existing tooling tests.

For the escaped-output sibling-failure row, select the existing 100 ms abort grace. It still uses real signals, the full five-second pipe-drain budget and the exact aggregate-error assertion. Dedicated default-grace, forced-cleanup and graceful-drain coverage stays unchanged. This follows the separately landed timeout-row improvement in #133634.

No production code, dependency version, sharding, concurrency, test selection, watchdog or assertion changes. Production LOC delta: 0; tests: +12/-10. No changelog entry is needed for these internal tests.

## User Impact

Faster test execution with the same real compiler and process-cleanup coverage. These measurements are affected test execution, not a prediction of total CI wall time.

## Evidence

Balanced baseline/candidate/candidate/baseline runs on one Blacksmith Testbox:

| Measurement | Baseline mean | Candidate mean | Saved |
| --- | ---: | ---: | ---: |
| Existing four-case escaped-output group | 6.056 s | 5.210 s | 0.846 s (14.0%) |
| Complete 31-case compiler-record suite | 4.346 s | 3.765 s | 0.582 s (13.4%) |

Local macOS focused tests pass. Local compiler timing was noisy and is not used to claim a gain. On both macOS and Linux, same-root launcher/direct comparisons match exit status, stdout/stderr, exact declaration bytes, emitted-file inventory and build-info for emit, noEmit and a TS2322 rejection.

All 105 Linux owner/sibling cases plus the real native-DTS failure-preservation sibling pass. All 14 changed checks pass; independent Codex review found no accepted/actionable findings. The existing sibling test fails when the production pipe-closure condition is temporarily removed. The three linked-resolution cases fail at their compiler-status assertion when their invalid source is temporarily made valid. All probe changes were restored before the full passing run; source fences and fixture-process cleanup were verified.

Commands used the repository runner:

```sh
node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts -t 'joins escaped output'
node scripts/run-vitest.mjs test/scripts/build-artifact-cache.test.ts
node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts test/scripts/build-artifact-cache.test.ts test/scripts/prepare-extension-package-boundary-artifacts.test.ts test/scripts/process-fixture-cleanup.test.ts
node scripts/run-vitest.mjs test/scripts/tsdown-build.test.ts -t 'preserves successful declarations when the native compiler fails'
node scripts/check-changed.mjs -- test/scripts/managed-child-process.test.ts test/scripts/build-artifact-cache.test.ts
```

Proof environment: Blacksmith Testbox `tbx_01m1akcycbvex26wzp8pk7hjkx`, [environment run](https://github.com/openclaw/openclaw/actions/runs/33344618903), stopped completed. Exact-head PR CI is required before landing.

## Final validation and review

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33345417941) completed successfully at `dbcfe4dfc851600c23d13847788a082524b6bcb7`, including `openclaw/ci-gate`; no CI rerun was needed. The completed ClawSweeper review found no correctness defect and requested direct-launch platform confirmation. The maintainer read the installed launcher and resolver directly: the resolver retains Windows `.exe`/long-path handling and is already used by the production artifact owner; the Windows launcher itself invokes that same executable with `execFileSync`. macOS and Linux launcher/direct parity and real fixture runs passed as described above. Normal PR CI skipped its Windows and macOS jobs; macOS proof was local, and no Windows runtime execution is claimed. The requested exact-head CI rank-up is satisfied, with no source change after review.
