### PR TITLE
refactor: use canonical installed-plugin index in post-upgrade doctor

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2480,7 +2480,7 @@ src/commands/doctor-main-session-recovery.ts	1
 src/commands/doctor-model-catalog-credentials.ts	1
 src/commands/doctor-plugin-model-catalog.ts	1
 src/commands/doctor-plugin-registry.ts	1
-src/commands/doctor-post-upgrade.ts	5
+src/commands/doctor-post-upgrade.ts	1
 src/commands/doctor-prompter.ts	1
 src/commands/doctor-retired-phone-control.ts	1
 src/commands/doctor-sandbox-legacy-registry.ts	8

--- a/src/commands/doctor-post-upgrade.test.ts
+++ b/src/commands/doctor-post-upgrade.test.ts
@@ -1,4 +1,3 @@
-// Doctor post-upgrade tests cover upgrade sentinel handling, config/state repair, and plugin record migration.
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -6,11 +5,50 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { resetLogger, setLoggerOverride } from "../logging.js";
 import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store-write.js";
+import { resolveInstalledPluginIndexStorePath } from "../plugins/installed-plugin-index-store.js";
 import type { InstalledPluginIndex } from "../plugins/installed-plugin-index.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import {
+  closeOpenClawStateDatabaseByPath,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
 import { runPostUpgradeProbes } from "./doctor-post-upgrade.js";
 
 async function makeFixtureRoot(prefix: string): Promise<string> {
   return await fs.mkdtemp(path.join(os.tmpdir(), `doctor-post-upgrade-${prefix}-`));
+}
+
+async function cleanupFixtureRoot(root: string): Promise<void> {
+  clearPluginMetadataLifecycleCaches();
+  closeOpenClawStateDatabaseByPath(resolveInstalledPluginIndexStorePath({ stateDir: root }));
+  await fs.rm(root, { recursive: true, force: true });
+}
+
+function createIndex(plugins: InstalledPluginIndex["plugins"]): InstalledPluginIndex {
+  return {
+    version: 1,
+    hostContractVersion: "test-host",
+    compatRegistryVersion: "test-compat",
+    migrationVersion: 1,
+    policyHash: "test-policy",
+    generatedAtMs: 1,
+    installRecords: {},
+    plugins,
+    diagnostics: [],
+  };
+}
+
+function writeRawIndexFixture(root: string, valueJson: string): void {
+  // Keep malformed JSON bytes intact so the canonical row parser owns rejection.
+  runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      db.prepare(
+        `INSERT OR REPLACE INTO config_machine_state (state_key, value_json, updated_at_ms)
+         VALUES ('plugins.installedIndex', ?, 1)`,
+      ).run(valueJson);
+    },
+    { env: { ...process.env, OPENCLAW_STATE_DIR: root } },
+  );
 }
 
 async function withFixtureRoot<T>(prefix: string, run: (root: string) => Promise<T>): Promise<T> {
@@ -18,7 +56,7 @@ async function withFixtureRoot<T>(prefix: string, run: (root: string) => Promise
   try {
     return await run(root);
   } finally {
-    await fs.rm(root, { recursive: true, force: true });
+    await cleanupFixtureRoot(root);
   }
 }
 
@@ -30,7 +68,7 @@ async function writePluginFixture(
     packageJson?: unknown;
     packageJsonRaw?: string;
     files?: Record<string, string>;
-    origin?: string;
+    origin?: InstalledPluginIndex["plugins"][number]["origin"];
     includePackageJsonRecord?: boolean;
     manifest?: Record<string, unknown> | false;
     manifestHash?: string;
@@ -56,47 +94,38 @@ async function writePluginFixture(
   if (params.manifest !== false) {
     await fs.writeFile(manifestPath, JSON.stringify(params.manifest ?? { id: params.id }), "utf-8");
   }
-  const installsPath = path.join(root, "plugins", "installs.json");
-  await fs.mkdir(path.dirname(installsPath), { recursive: true });
-  await fs.writeFile(
-    installsPath,
-    JSON.stringify({
-      version: 1,
-      plugins: [
-        {
-          pluginId: params.id,
-          rootDir: pluginDir,
-          enabled: true,
-          ...(params.origin ? { origin: params.origin } : {}),
-          ...(hasPackageJson && params.includePackageJsonRecord !== false
-            ? { packageJson: { path: "package.json" } }
-            : {}),
-          ...(params.manifest === false ? {} : { manifestPath }),
-          ...(params.manifestHash ? { manifestHash: params.manifestHash } : {}),
-        },
-      ],
-    }),
-    "utf-8",
+  await writePersistedInstalledPluginIndex(
+    createIndex([
+      {
+        pluginId: params.id,
+        rootDir: pluginDir,
+        enabled: true,
+        origin: params.origin ?? "global",
+        startup: { sidecar: false, memory: false, agentHarnesses: [] },
+        compat: [],
+        ...(hasPackageJson && params.includePackageJsonRecord !== false
+          ? { packageJson: { path: "package.json", hash: "package-hash" } }
+          : {}),
+        manifestPath: params.manifest === false ? "" : manifestPath,
+        manifestHash: params.manifestHash ?? "",
+      },
+    ]),
+    { stateDir: root },
   );
-  return { installsPath, pluginDir, manifestPath };
 }
 
-async function writeDeclaredPackageFixture(root: string, packageContents: string): Promise<string> {
-  return (
-    await writePluginFixture(root, {
-      id: "broken",
-      packageJsonRaw: packageContents,
-      manifest: false,
-    })
-  ).installsPath;
+async function writeDeclaredPackageFixture(root: string, packageContents: string): Promise<void> {
+  await writePluginFixture(root, {
+    id: "broken",
+    packageJsonRaw: packageContents,
+    manifest: false,
+  });
 }
 
 describe("runPostUpgradeProbes — plugin.index_unavailable", () => {
   it("returns a structured finding when the installed plugin index is missing", async () => {
     await withFixtureRoot("index-missing", async (root) => {
-      const report = await runPostUpgradeProbes({
-        installsPath: path.join(root, "plugins", "installs.json"),
-      });
+      const report = await runPostUpgradeProbes({ stateDir: root });
 
       expect(report.probesRun).toContain("plugin.index_unavailable");
       expect(report.findings).toEqual([
@@ -110,11 +139,9 @@ describe("runPostUpgradeProbes — plugin.index_unavailable", () => {
 
   it("returns a structured finding when the installed plugin index is malformed", async () => {
     await withFixtureRoot("index-malformed", async (root) => {
-      const installsPath = path.join(root, "plugins", "installs.json");
-      await fs.mkdir(path.dirname(installsPath), { recursive: true });
-      await fs.writeFile(installsPath, "{ not json", "utf-8");
+      writeRawIndexFixture(root, "{ not json");
 
-      const report = await runPostUpgradeProbes({ installsPath });
+      const report = await runPostUpgradeProbes({ stateDir: root });
 
       expect(report.probesRun).toContain("plugin.index_unavailable");
       expect(report.findings).toEqual([
@@ -128,11 +155,12 @@ describe("runPostUpgradeProbes — plugin.index_unavailable", () => {
 
   it("returns a structured finding when an installed plugin record is malformed", async () => {
     await withFixtureRoot("record-malformed", async (root) => {
-      const installsPath = path.join(root, "plugins", "installs.json");
-      await fs.mkdir(path.dirname(installsPath), { recursive: true });
-      await fs.writeFile(installsPath, JSON.stringify({ plugins: [{}] }), "utf-8");
+      writeRawIndexFixture(
+        root,
+        JSON.stringify({ revision: 1, index: { ...createIndex([]), plugins: [{}] } }),
+      );
 
-      const report = await runPostUpgradeProbes({ installsPath });
+      const report = await runPostUpgradeProbes({ stateDir: root });
 
       expect(report.findings).toEqual([
         expect.objectContaining({
@@ -151,25 +179,25 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
       .spyOn(process.stderr, "write")
       .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
     try {
-      const installsPath = path.join(root, "plugins", "installs.json");
-      await fs.mkdir(path.dirname(installsPath), { recursive: true });
-      await fs.writeFile(
-        installsPath,
-        JSON.stringify({
-          plugins: [
-            {
-              pluginId: "broken",
-              rootDir: path.join(root, "broken"),
-              enabled: true,
-              packageJson: { path: "missing-package.json" },
-            },
-          ],
-        }),
-        "utf-8",
+      await writePersistedInstalledPluginIndex(
+        createIndex([
+          {
+            pluginId: "broken",
+            rootDir: path.join(root, "broken"),
+            enabled: true,
+            origin: "global",
+            startup: { sidecar: false, memory: false, agentHarnesses: [] },
+            compat: [],
+            manifestPath: "",
+            manifestHash: "",
+            packageJson: { path: "missing-package.json", hash: "package-hash" },
+          },
+        ]),
+        { stateDir: root },
       );
       setLoggerOverride({ level: "silent", consoleLevel: "info", consoleStyle: "json" });
 
-      const report = await runPostUpgradeProbes({ installsPath });
+      const report = await runPostUpgradeProbes({ stateDir: root });
 
       expect(report.findings).toEqual([
         expect.objectContaining({
@@ -188,7 +216,7 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
     } finally {
       stderrSpy.mockRestore();
       resetLogger();
-      await fs.rm(root, { recursive: true, force: true });
+      await cleanupFixtureRoot(root);
     }
   });
 
@@ -198,8 +226,8 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
       .spyOn(process.stderr, "write")
       .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
     try {
-      const installsPath = await writeDeclaredPackageFixture(root, "{ not json");
-      const report = await runPostUpgradeProbes({ installsPath });
+      await writeDeclaredPackageFixture(root, "{ not json");
+      const report = await runPostUpgradeProbes({ stateDir: root });
 
       expect(report.findings).toEqual([
         expect.objectContaining({
@@ -213,7 +241,7 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
       expect(stderrSpy).toHaveBeenCalled();
     } finally {
       stderrSpy.mockRestore();
-      await fs.rm(root, { recursive: true, force: true });
+      await cleanupFixtureRoot(root);
     }
   });
 
@@ -227,8 +255,8 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
       .spyOn(process.stderr, "write")
       .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
     try {
-      const installsPath = await writeDeclaredPackageFixture(root, JSON.stringify(packageJson));
-      const report = await runPostUpgradeProbes({ installsPath });
+      await writeDeclaredPackageFixture(root, JSON.stringify(packageJson));
+      const report = await runPostUpgradeProbes({ stateDir: root });
 
       expect(report.findings).toEqual([
         expect.objectContaining({
@@ -241,7 +269,7 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
       ]);
     } finally {
       stderrSpy.mockRestore();
-      await fs.rm(root, { recursive: true, force: true });
+      await cleanupFixtureRoot(root);
     }
   });
 
@@ -271,11 +299,8 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
     async ({ label, openclaw, reason }) => {
       const root = await makeFixtureRoot(`entry-invalid-${label.replaceAll(" ", "-")}`);
       try {
-        const installsPath = await writeDeclaredPackageFixture(
-          root,
-          JSON.stringify({ name: "broken", openclaw }),
-        );
-        const report = await runPostUpgradeProbes({ installsPath });
+        await writeDeclaredPackageFixture(root, JSON.stringify({ name: "broken", openclaw }));
+        const report = await runPostUpgradeProbes({ stateDir: root });
 
         expect(report.findings).toEqual([
           expect.objectContaining({
@@ -287,55 +312,23 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
           }),
         ]);
       } finally {
-        await fs.rm(root, { recursive: true, force: true });
+        await cleanupFixtureRoot(root);
       }
     },
   );
 
   it("reads the canonical SQLite plugin index by default", async () => {
     await withFixtureRoot("entry-sqlite", async (root) => {
-      const pluginDir = path.join(root, "user-plugins", "sqlite-ghost");
-      await fs.mkdir(pluginDir, { recursive: true });
-      await fs.writeFile(
-        path.join(pluginDir, "package.json"),
-        JSON.stringify({
+      await writePluginFixture(root, {
+        id: "sqlite-ghost",
+        packageJson: {
           name: "sqlite-ghost",
           version: "0.0.1",
           type: "module",
           openclaw: { extensions: ["./dist/index.js"] },
-        }),
-        "utf-8",
-      );
-      const manifestPath = path.join(pluginDir, "openclaw.plugin.json");
-      await fs.writeFile(manifestPath, JSON.stringify({ id: "sqlite-ghost" }), "utf-8");
-      const index: InstalledPluginIndex = {
-        version: 1,
-        hostContractVersion: "test-host",
-        compatRegistryVersion: "test-compat",
-        migrationVersion: 1,
-        policyHash: "test-policy",
-        generatedAtMs: 1,
-        installRecords: {},
-        plugins: [
-          {
-            pluginId: "sqlite-ghost",
-            manifestPath,
-            manifestHash: "manifest-hash",
-            rootDir: pluginDir,
-            origin: "global",
-            enabled: true,
-            startup: {
-              sidecar: false,
-              memory: false,
-              agentHarnesses: [],
-            },
-            compat: [],
-            packageJson: { path: "package.json", hash: "package-hash" },
-          },
-        ],
-        diagnostics: [],
-      };
-      await writePersistedInstalledPluginIndex(index, { stateDir: root });
+        },
+        manifestHash: "manifest-hash",
+      });
 
       const report = await runPostUpgradeProbes({ stateDir: root });
 
@@ -350,7 +343,7 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
 
   it("flags an enabled plugin whose declared entry does not exist on disk", async () => {
     await withFixtureRoot("entry-unresolved", async (root) => {
-      const { installsPath } = await writePluginFixture(root, {
+      await writePluginFixture(root, {
         id: "ghost",
         packageJson: {
           name: "ghost",
@@ -360,7 +353,7 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
         },
       });
 
-      const report = await runPostUpgradeProbes({ installsPath });
+      const report = await runPostUpgradeProbes({ stateDir: root });
       const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
       expect(finding).toBeDefined();
       expect(finding?.level).toBe("error");
@@ -371,7 +364,7 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
 
   it("emits no entry_unresolved findings when the entry resolves", async () => {
     await withFixtureRoot("entry-ok", async (root) => {
-      const { installsPath } = await writePluginFixture(root, {
+      await writePluginFixture(root, {
         id: "good",
         packageJson: {
           name: "good",
@@ -382,28 +375,28 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
         files: { "dist/index.js": "export default {};" },
       });
 
-      const report = await runPostUpgradeProbes({ installsPath });
+      const report = await runPostUpgradeProbes({ stateDir: root });
       expect(report.findings.filter((f) => f.code === "plugin.entry_unresolved")).toHaveLength(0);
     });
   });
 
   it("skips package entry validation for non-package registry records", async () => {
     await withFixtureRoot("no-package-json-ref", async (root) => {
-      const { installsPath } = await writePluginFixture(root, {
+      await writePluginFixture(root, {
         id: "runtime-only",
         location: "dist/extensions",
         origin: "bundled",
         files: { "index.js": "export default {};" },
       });
 
-      const report = await runPostUpgradeProbes({ installsPath });
+      const report = await runPostUpgradeProbes({ stateDir: root });
       expect(report.findings).toHaveLength(0);
     });
   });
 
   it("validates legacy package records without packageJson metadata", async () => {
     await withFixtureRoot("legacy-package-json-ref", async (root) => {
-      const { installsPath } = await writePluginFixture(root, {
+      await writePluginFixture(root, {
         id: "legacy-package",
         packageJson: {
           name: "legacy-package",
@@ -415,7 +408,7 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
         includePackageJsonRecord: false,
       });
 
-      const report = await runPostUpgradeProbes({ installsPath });
+      const report = await runPostUpgradeProbes({ stateDir: root });
       const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
       expect(finding?.level).toBe("error");
       expect(finding?.plugin).toBe("legacy-package");
@@ -429,7 +422,7 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
       const outsideDir = path.join(root, "outside");
       await fs.mkdir(outsideDir, { recursive: true });
       await fs.writeFile(path.join(outsideDir, "leak.js"), "export default {};", "utf-8");
-      const { installsPath } = await writePluginFixture(root, {
+      await writePluginFixture(root, {
         id: "escape",
         packageJson: {
           name: "escape",
@@ -439,7 +432,7 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
         },
       });
 
-      const report = await runPostUpgradeProbes({ installsPath });
+      const report = await runPostUpgradeProbes({ stateDir: root });
       const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
       expect(finding).toBeDefined();
       expect(finding?.level).toBe("error");
@@ -451,7 +444,7 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
   it("accepts a TypeScript source entry that ships a compiled dist peer", async () => {
     await withFixtureRoot("ts-with-dist", async (root) => {
       // No explicit runtimeExtensions; the resolver should infer dist/index.js.
-      const { installsPath } = await writePluginFixture(root, {
+      await writePluginFixture(root, {
         id: "ts-dist",
         packageJson: {
           name: "ts-dist",
@@ -465,7 +458,7 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
         },
       });
 
-      const report = await runPostUpgradeProbes({ installsPath });
+      const report = await runPostUpgradeProbes({ stateDir: root });
       expect(report.findings.filter((f) => f.code === "plugin.entry_unresolved")).toHaveLength(0);
     });
   });
@@ -473,7 +466,7 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
   it("flags a TypeScript source-only entry with no compiled output", async () => {
     await withFixtureRoot("ts-source-only", async (root) => {
       // Source exists, no dist peer — installed plugins must ship compiled JS.
-      const { installsPath } = await writePluginFixture(root, {
+      await writePluginFixture(root, {
         id: "ts-only",
         packageJson: {
           name: "ts-only",
@@ -484,7 +477,7 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
         files: { "src/index.ts": "export default {};" },
       });
 
-      const report = await runPostUpgradeProbes({ installsPath });
+      const report = await runPostUpgradeProbes({ stateDir: root });
       const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
       expect(finding).toBeDefined();
       expect(finding?.level).toBe("error");
@@ -498,7 +491,7 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
       await fs.mkdir(path.join(root, ".git"), { recursive: true });
       await fs.writeFile(path.join(root, "pnpm-workspace.yaml"), "packages: []\n", "utf-8");
       await fs.mkdir(path.join(root, "src"), { recursive: true });
-      const { installsPath } = await writePluginFixture(root, {
+      await writePluginFixture(root, {
         id: "ts-source",
         location: "extensions",
         origin: "bundled",
@@ -511,14 +504,14 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
         files: { "src/index.ts": "export default {};" },
       });
 
-      const report = await runPostUpgradeProbes({ installsPath });
+      const report = await runPostUpgradeProbes({ stateDir: root });
       expect(report.findings.filter((f) => f.code === "plugin.entry_unresolved")).toHaveLength(0);
     });
   });
 
   it("flags TypeScript source-only entries for packaged bundled plugin records", async () => {
     await withFixtureRoot("ts-packaged-bundled", async (root) => {
-      const { installsPath } = await writePluginFixture(root, {
+      await writePluginFixture(root, {
         id: "ts-packaged",
         location: "dist/extensions",
         origin: "bundled",
@@ -531,7 +524,7 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
         files: { "src/index.ts": "export default {};" },
       });
 
-      const report = await runPostUpgradeProbes({ installsPath });
+      const report = await runPostUpgradeProbes({ stateDir: root });
       const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
       expect(finding?.level).toBe("error");
       expect(finding?.plugin).toBe("ts-packaged");
@@ -541,7 +534,7 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
 
   it("flags a runtimeExtensions length mismatch", async () => {
     await withFixtureRoot("runtime-len-mismatch", async (root) => {
-      const { installsPath } = await writePluginFixture(root, {
+      await writePluginFixture(root, {
         id: "len-mismatch",
         packageJson: {
           name: "len-mismatch",
@@ -558,7 +551,7 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
         },
       });
 
-      const report = await runPostUpgradeProbes({ installsPath });
+      const report = await runPostUpgradeProbes({ stateDir: root });
       const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
       expect(finding).toBeDefined();
       expect(finding?.level).toBe("error");
@@ -571,7 +564,7 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
     await withFixtureRoot("runtime-extensions", async (root) => {
       // Source entry (./src/index.ts) does NOT exist
       // But runtime entry (./dist/index.js) DOES exist
-      const { installsPath } = await writePluginFixture(root, {
+      await writePluginFixture(root, {
         id: "runtime-only",
         packageJson: {
           name: "runtime-only",
@@ -585,7 +578,7 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
         files: { "dist/index.js": "export default {};" },
       });
 
-      const report = await runPostUpgradeProbes({ installsPath });
+      const report = await runPostUpgradeProbes({ stateDir: root });
       expect(report.findings.filter((f) => f.code === "plugin.entry_unresolved")).toHaveLength(0);
     });
   });
@@ -596,8 +589,8 @@ describe("runPostUpgradeProbes — plugin.manifest_drift", () => {
     await withFixtureRoot("manifest-drift", async (root) => {
       const oldManifestRaw = JSON.stringify({ id: "drifted", version: 1 });
       const oldManifestHash = crypto.createHash("sha256").update(oldManifestRaw).digest("hex");
-      // Write a NEW manifest after installs.json was snapshotted.
-      const { installsPath } = await writePluginFixture(root, {
+      // Write a NEW manifest after the installed index was snapshotted.
+      await writePluginFixture(root, {
         id: "drifted",
         packageJson: {
           name: "drifted",
@@ -610,7 +603,7 @@ describe("runPostUpgradeProbes — plugin.manifest_drift", () => {
         manifestHash: oldManifestHash,
       });
 
-      const report = await runPostUpgradeProbes({ installsPath });
+      const report = await runPostUpgradeProbes({ stateDir: root });
       const finding = report.findings.find((f) => f.code === "plugin.manifest_drift");
       expect(finding).toBeDefined();
       expect(finding?.level).toBe("warn");

--- a/src/commands/doctor-post-upgrade.ts
+++ b/src/commands/doctor-post-upgrade.ts
@@ -6,6 +6,10 @@ import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { formatConsoleDiagnosticLine } from "../logging/json-console-line.js";
 import { readPersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store.js";
+import type {
+  InstalledPluginIndex,
+  InstalledPluginIndexRecord,
+} from "../plugins/installed-plugin-index-types.js";
 import { resolvePackageExtensionEntries, type PackageManifest } from "../plugins/manifest.js";
 import { validatePackageExtensionEntriesForInstall } from "../plugins/package-entry-resolution.js";
 import {
@@ -14,45 +18,11 @@ import {
   type PostUpgradeReport,
 } from "./doctor-post-upgrade.types.js";
 
-type InstalledPluginRecord = {
-  pluginId: string;
-  rootDir: string;
-  enabled: boolean;
-  origin?: string;
-  packageJson?: { path: string };
-  manifestPath?: string;
-  manifestHash?: string;
-};
-
-type InstallsJson = { plugins: InstalledPluginRecord[] };
-
 function buildReport(findings: PostUpgradeFinding[]): PostUpgradeReport {
   return { probesRun: [...POST_UPGRADE_PROBE_CODES], findings };
 }
 
-function isInstallsJson(value: unknown): value is InstallsJson {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    Array.isArray((value as { plugins?: unknown }).plugins) &&
-    (value as { plugins: unknown[] }).plugins.every(isInstalledPluginRecord)
-  );
-}
-
-function isOptionalString(value: unknown): value is string | undefined {
-  return value === undefined || typeof value === "string";
-}
-
-function isPackageJsonRef(value: unknown): value is InstalledPluginRecord["packageJson"] {
-  return (
-    value === undefined ||
-    (typeof value === "object" &&
-      value !== null &&
-      typeof (value as { path?: unknown }).path === "string")
-  );
-}
-
-function isSourceCheckoutPluginRecord(record: InstalledPluginRecord): boolean {
+function isSourceCheckoutPluginRecord(record: InstalledPluginIndexRecord): boolean {
   if (record.origin === "workspace" || record.origin === "config") {
     return true;
   }
@@ -79,43 +49,13 @@ function isBundledSourceCheckoutPluginRoot(pluginRootDir: string): boolean {
   }
 }
 
-function isInstalledPluginRecord(value: unknown): value is InstalledPluginRecord {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-  const record = value as InstalledPluginRecord;
-  return (
-    typeof record.pluginId === "string" &&
-    typeof record.rootDir === "string" &&
-    typeof record.enabled === "boolean" &&
-    isOptionalString(record.origin) &&
-    isPackageJsonRef(record.packageJson) &&
-    isOptionalString(record.manifestPath) &&
-    isOptionalString(record.manifestHash)
-  );
-}
-
-async function readInstallsJson(installsPath: string): Promise<InstallsJson | null> {
-  try {
-    const installsRaw = await fs.readFile(installsPath, "utf-8");
-    const installs = JSON.parse(installsRaw) as unknown;
-    return isInstallsJson(installs) ? installs : null;
-  } catch {
-    return null;
-  }
-}
-
 async function readInstalledPluginIndex(params: {
-  installsPath?: string;
   stateDir?: string;
-}): Promise<InstallsJson | null> {
-  if (params.installsPath) {
-    return await readInstallsJson(params.installsPath);
-  }
+}): Promise<Pick<InstalledPluginIndex, "plugins"> | null> {
   const index = await readPersistedInstalledPluginIndex(
     params.stateDir ? { stateDir: params.stateDir } : {},
   );
-  return index && isInstallsJson(index) ? { plugins: [...index.plugins] } : null;
+  return index ? { plugins: [...index.plugins] } : null;
 }
 
 async function readInstalledPackageJson(
@@ -132,7 +72,7 @@ async function readInstalledPackageJson(
 }
 
 async function resolvePackageJsonRelPath(
-  record: InstalledPluginRecord,
+  record: InstalledPluginIndexRecord,
 ): Promise<string | undefined> {
   if (record.packageJson) {
     return record.packageJson.path;
@@ -156,7 +96,6 @@ async function sha256OfFile(absPath: string): Promise<string | null> {
 
 /** Runs post-upgrade plugin probes and returns structured findings for the caller to render. */
 export async function runPostUpgradeProbes(params: {
-  installsPath?: string;
   stateDir?: string;
 }): Promise<PostUpgradeReport> {
   const findings: PostUpgradeFinding[] = [];


### PR DESCRIPTION
## What Problem This Solves

Post-upgrade Doctor had a second installed-plugin index reader that only its tests used. Those fixtures exercised an obsolete JSON-file path instead of the SQLite index that the real command reads, while production carried a duplicate record shape and validator.

## Why This Change Was Made

Use the existing installed-plugin index reader and canonical record types throughout post-upgrade validation. Remove the private `installsPath` injection, JSON-file reader, and redundant shallow validation. The probes retain their asynchronous boundary and copied plugin list, package-entry checks, source-checkout rules, manifest checks, diagnostics, and exit behavior.

The tests now write their fixtures through the existing SQLite index owner. Malformed-index cases insert the deliberately invalid row through the existing test transaction pattern, and cleanup closes the owned database before removing its temporary directory. No schema, migration, persistence policy, public flag, or SDK contract changes.

Stored-data clarification: the existing SQLite installed-index reader/writer, `config_machine_state` storage and `plugins.installedIndex` key, parser, and schema are unchanged. Only test fixtures moved from the private JSON seam to that existing owner; this PR performs no operator-data migration.

## User Impact

No intended user-visible behavior change. Doctor continues to report unavailable indexes, unresolved plugin entries, and manifest drift through the same human and JSON output paths.

Production: +8 / −69, **61 lines removed**. Tests: +129 / −136, 7 lines removed. Whole change: 68 lines removed; no assertions removed.

## Evidence

The same 121 cases passed against the original production code and the cleanup, with the same emitted case order: 25 post-upgrade cases, 8 Doctor cases, 3 CLI output-lifecycle cases, 35 installed-index store cases, and 50 package-manifest contract cases. The fixtures and assertions were identical on both sides. Source, runtime, dependency, and owned-process checks completed after both runs.

The first full changed-check run stopped at the assertion-safety ratchet: removing the duplicate validators reduced this file's count from five to one. The corresponding baseline entry is lowered from five to one; no allowance was added or check bypassed. The full rerun passed all 30 selected checks, including production and test types, core and script lint, and all three dead-export scans. Source and process checks completed afterward. One normal independent Codex review completed both evidence passes with no P0 findings; source and runtime inputs were unchanged across review. The ordinary 14-phase build passed within its original limit, followed by source, dependency, generated-output and owned-process verification.

The compiled `openclaw.mjs doctor --post-upgrade` and `--post-upgrade --json` commands were then run unmocked in separate temporary homes against valid empty SQLite databases. Both produced the exact existing missing-index diagnostic, empty stderr and normal exit 1; the JSON envelope was unchanged. Database/config bytes stayed unchanged, all four setup/command children exited, and only the owned fixtures were removed afterward. Full source, dependency and generated-output checks remained unchanged. This covers the missing-index CLI path, not a real upgrade, valid-index traversal or live-provider behavior. The three earlier CLI process tests substitute the report producer and remain separate output-drainage evidence. Exact-head [CI run 33345728525](https://github.com/openclaw/openclaw/actions/runs/33345728525) passed for `c6897072a32c9241b1505aac73ffc8a1b2d1258d`, including required `ci-gate` job `99351344444`.

Named follow-up: the existing manifest-drift diagnostic still says `installs.json snapshot`, even though its owner is now SQLite. Its wording is deliberately unchanged here; updating that operator-facing text is separate from removing the test-only loading path.
