### PR TITLE
fix(media): omit English prompts during audio language autodetection

### DIFF
--- a/docs/nodes/audio.md
+++ b/docs/nodes/audio.md
@@ -228,6 +228,7 @@ provider-wide rather than scoped to the audio model entry.
 - Mistral setup details: [Mistral](/providers/mistral).
 - SenseAudio picks up `SENSEAUDIO_API_KEY` when `provider: "senseaudio"` is used. Setup details: [SenseAudio](/providers/senseaudio).
 - Audio providers can use defaults under `tools.media.audio` or override `baseUrl`, `headers`, `providerOptions`, and limits on their `tools.media.models[]` entry.
+- Leave `tools.media.audio.language` unset for language autodetection. OpenAI-compatible transcription requests then omit the implicit English prompt; explicit custom prompts and language hints are preserved. Use transcription prompts for context or spelling in the audio's language, not instructions to the downstream agent.
 - The built-in audio size cap is 20MB. An entry-level `maxBytes` override can change it; oversize audio is skipped for that model and the next entry is tried.
 - Audio files below 1024 bytes are skipped before provider/CLI transcription.
 - Default `maxChars` for audio is **unset** (full transcript). Set `tools.media.audio.maxChars` or per-entry `maxChars` to trim output.

--- a/src/media-understanding/openai-compatible-audio.test.ts
+++ b/src/media-understanding/openai-compatible-audio.test.ts
@@ -75,28 +75,31 @@ describe("transcribeOpenAiCompatibleAudio", () => {
     expect((file as File).name).toBe("voice-note.m4a");
   });
 
-  it("omits the optional prompt field while preserving language hints", async () => {
-    const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "ok" });
+  it.each([undefined, "ru"])(
+    "omits the optional prompt field with language %j",
+    async (language) => {
+      const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "ok" });
 
-    await transcribeOpenAiCompatibleAudio({
-      buffer: Buffer.from("audio"),
-      fileName: "note.ogg",
-      mime: "audio/ogg",
-      apiKey: "test-key",
-      timeoutMs: 1000,
-      fetchFn,
-      provider: "groq",
-      baseUrl: "https://api.groq.com/openai/v1",
-      defaultBaseUrl: "https://api.groq.com/openai/v1",
-      defaultModel: "whisper-large-v3-turbo",
-      language: "ru",
-    });
+      await transcribeOpenAiCompatibleAudio({
+        buffer: Buffer.from("audio"),
+        fileName: "note.ogg",
+        mime: "audio/ogg",
+        apiKey: "test-key",
+        timeoutMs: 1000,
+        fetchFn,
+        provider: "groq",
+        baseUrl: "https://api.groq.com/openai/v1",
+        defaultBaseUrl: "https://api.groq.com/openai/v1",
+        defaultModel: "whisper-large-v3-turbo",
+        language,
+      });
 
-    const form = getRequest().init?.body;
-    expect(form).toBeInstanceOf(FormData);
-    expect((form as FormData).get("language")).toBe("ru");
-    expect((form as FormData).get("prompt")).toBeNull();
-  });
+      const form = getRequest().init?.body;
+      expect(form).toBeInstanceOf(FormData);
+      expect((form as FormData).get("language")).toBe(language ?? null);
+      expect((form as FormData).get("prompt")).toBeNull();
+    },
+  );
 
   it("omits bearer auth for explicit no-auth requests", async () => {
     const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "ok" });

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -433,6 +433,15 @@ describe("runCapability auto audio entries", () => {
       cfgExtra: {
         tools: {
           media: {
+            models: [
+              {
+                provider: "openai",
+                model: "whisper-1",
+                capabilities: ["audio"],
+                language: "pt",
+                prompt: "entry prompt",
+              },
+            ],
             audio: {
               enabled: true,
               prompt: "configured prompt",
@@ -501,7 +510,7 @@ describe("runCapability auto audio entries", () => {
       prompt: "Transcribe in Russian.",
       models: [{ provider: "openai", model: "whisper-1" }],
     });
-    for (const language of ["en-US", "eng", "english"]) {
+    for (const language of ["en", " en-US ", "eng", "english", "EN_us"]) {
       await runCase({
         enabled: true,
         language,
@@ -510,6 +519,7 @@ describe("runCapability auto audio entries", () => {
     }
     await runCase({
       enabled: true,
+      prompt: "OpenClaw, Whisper, and Groq.",
       models: [{ provider: "openai", model: "whisper-1" }],
     });
 
@@ -519,8 +529,35 @@ describe("runCapability auto audio entries", () => {
       "Transcribe the audio.",
       "Transcribe the audio.",
       "Transcribe the audio.",
+      "Transcribe the audio.",
+      "OpenClaw, Whisper, and Groq.",
     ]);
   });
+
+  it.each([undefined, "", " \t "])(
+    "omits the implicit audio prompt for autodetect language %j",
+    async (language) => {
+      const requests: AudioTranscriptionRequest[] = [];
+      const result = await runAutoAudioCase({
+        transcribeAudio: async (request) => {
+          requests.push(request);
+          return { text: "Bonjour.", model: request.model ?? "unknown" };
+        },
+        cfgExtra: {
+          tools: {
+            media: {
+              models: [{ provider: "openai", model: "whisper-1", capabilities: ["audio"] }],
+              audio: { enabled: true, language },
+            },
+          },
+        },
+      });
+      expect(requireCapabilityOutput(result, 0).text).toBe("Bonjour.");
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.prompt).toBeUndefined();
+      expect(requests[0]?.language).toBe(language);
+    },
+  );
 
   it("uses mistral when only mistral key is configured", async () => {
     const isolatedAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-audio-agent-"));

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -452,20 +452,19 @@ function resolveAudioProviderPrompt(params: {
   hasConfiguredPrompt: boolean;
   language?: string;
 }): string | undefined {
-  const language = params.language?.trim().toLowerCase();
-  const isEnglish =
-    !language ||
+  const language = normalizeLowercaseStringOrEmpty(params.language);
+  const isExplicitEnglish =
     language === "en" ||
     language === "eng" ||
     language === "english" ||
     language.startsWith("en-") ||
     language.startsWith("en_");
-  if (params.hasConfiguredPrompt || isEnglish) {
+  if (params.hasConfiguredPrompt || isExplicitEnglish) {
     return params.prompt;
   }
   // OpenAI-compatible transcription prompts guide style/context and should
-  // match the audio language; omit OpenClaw's English default for non-English
-  // language hints unless the user supplied an explicit prompt.
+  // match the audio language; omit OpenClaw's English default for autodetection
+  // and non-English hints unless the user supplied an explicit prompt.
   return undefined;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where incoming voice notes could include transcription-prompt text in the transcript when language autodetection was used. The request builder treated an absent language as English and sent an implicit English context hint to the transcription provider.

Fixes #123305. Supersedes #124434 with a trusted repair rebuilt on current main, expanded sibling coverage, and real provider proof. Thanks @aleps001 for reporting it and @synthalorian for the original repair; contributor credit is preserved in the commit.

## Why This Change Was Made

The shared audio request owner now sends the implicit default only with an explicit English language hint. Explicit custom prompts, non-English hints, and per-request overrides retain their precedence. The change reuses canonical string normalization and removes one production line overall; it does not strip returned transcript text or change provider endpoints, models, authentication, or configuration keys.

OpenAI, Groq, and Mistral share the multipart adapter, which already omits undefined fields. ElevenLabs also receives the generic prompt and is intentionally included in the default omission, with real Scribe proof below. Google retains its provider-owned audio task instruction, Deepgram does not serialize this prompt, and CLI transcription keeps its separate prompt-template contract. The docs now explain autodetection and prompt intent.

Bug provenance: the absent-language defect is present in stable v2026.7.1-2. This new repair was not part of that release. The earlier #99023 fix preserved the absent-language behavior while correcting explicit non-English hints; its raw-parent patch does not establish original introduction, which remains unknown.

## User Impact

Users can leave the audio language unset without sending OpenClaw's implicit English prompt. Explicit prompt and language choices continue to work. No new setup step is required.

## Evidence

Three owner regressions failed before the repair because absent, empty, and whitespace language hints sent the implicit English prompt. The repaired owner, multipart adapter, CLI sibling, and media-application suites pass 141 tests. Coverage preserves explicit prompts, English aliases, non-English hints, and request-over-entry precedence.

A real OpenAI Whisper transcription probe exercised the actual media request owner, public provider entry, and shared HTTP adapter with one public synthetic Portuguese WAV. One request per side returned HTTP 200 and the exact expected Portuguese transcript. Baseline sent the implicit prompt; the repaired request omitted it. Both left language unset. The same 250,142-byte WAV was used (SHA-256 `68f95659c2cc7f155a6d06c7e4a270d99d954e598159eaea6278f8f1dcf04fa8`), and both transcripts matched SHA-256 `1e4024e10a1f2da18517e7000159f095a93998340200370d4b30a7f35dd19af2`. Source hashes were stable during each run; only the repaired request owner differed. No private audio or API credentials are included in proof artifacts.

| Real provider request | Implicit prompt | Language hint | HTTP | Transcript |
| --- | --- | --- | --- | --- |
| OpenAI baseline | Present | Absent | 200 | Exact synthetic Portuguese sentence |
| OpenAI repaired owner | Absent | Absent | 200 | Exact same sentence |
| ElevenLabs baseline | Present | Absent | 200 | Same Portuguese words, without final punctuation |
| ElevenLabs repaired owner | Absent | Absent | 200 | Exact same ElevenLabs transcript |

This follows the documented [Groq transcription prompt contract](https://console.groq.com/docs/speech-to-text). It demonstrates correct field omission and successful real transcription; the synthetic clip did not reproduce the reporter's intermittent Groq prompt echo.

The intended scope is the shared implicit-prompt default, including ElevenLabs. The [official Scribe API](https://elevenlabs.io/docs/api-reference/speech-to-text/convert) documents omitted `language_code` as autodetection and does not document a free-form `prompt` field. A second real A/B used the actual owner → public ElevenLabs plugin registration → batch adapter → canonical runtime transport with `scribe_v2`. Both requests returned HTTP 200 and identical Portuguese transcripts, SHA-256 `00791f9face3769b69ce4e095fa9e577b6efd1692533c4274ac28f61350e8b44`, using the same WAV above. Nine runtime source hashes remained stable; only the prompt owner differed between sides. Explicit prompts are still preserved. This proves request acceptance and the observed transcript, not whether ElevenLabs interprets or ignores the old undocumented field.

The initial ElevenLabs probe incorrectly forwarded the guarded dispatcher through ambient native fetch and failed before an HTTP response. Correcting the probe to use the repository's canonical dispatcher-aware transport produced the successful results above; no production transport change or relaxed network policy was needed.

Independent Codex review is clean with no actionable P0–P2 findings. Required `pnpm check:changed` completed successfully on the candidate, including production/test type checks, scoped lint, dead exports, runtime cycles, and auth-boundary guards. Exact-head CI [33345738820](https://github.com/openclaw/openclaw/actions/runs/33345738820) passed. The prior review on #124434 requested a real provider trace and an updated evidence summary; both are supplied above. The latest review on this PR requested a clear ElevenLabs scope decision/proof and unambiguous release provenance; both are addressed here. The stronger claim of an improved transcript is intentionally not made because both real requests returned the exact expected transcript.

## Scope and Risk

This intentionally changes the default multipart request when language and prompt are omitted. It adds no configuration option or storage/protocol change. Real OpenAI proof is not a claim that Groq's reported echo frequency was reproduced or that all transcription output is error-free.

LOC: production +5/-6 (net -1); tests +62/-22 (net +40); docs +1. Verified against the candidate diff.
