### PR TITLE
fix(release): consume verified historical release evidence

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -1151,12 +1151,18 @@ jobs:
               echo "Protected release-publish tag moved after npm-release approval." >&2
               exit 1
             }
-            if [[ "$preflight_head_branch" == "$workflow_tag" && "$preflight_head_sha" == "$WORKFLOW_SHA" ]]; then
-              protected_release_publish_preflight=true
-            fi
+          fi
+          if [[ "$preflight_head_branch" == release-publish/* ]]; then
+            node trusted-workflow/scripts/npm-preflight-tooling-identity.mjs \
+              --repository "$GITHUB_REPOSITORY" \
+              --workflow-ref "$preflight_head_branch" \
+              --workflow-full-ref "refs/tags/${preflight_head_branch}" \
+              --workflow-sha "$preflight_head_sha" \
+              --publisher-sha "$WORKFLOW_SHA"
+            protected_release_publish_preflight=true
           fi
           if [[ "$preflight_head_branch" != "main" && "$active_branch_preflight" != "true" && "$extended_stable_preflight" != "true" && "$protected_release_publish_preflight" != "true" ]]; then
-            echo "OpenClaw npm preflight run must come from main, the active protected release branch, or the exact protected release-publish tag." >&2
+            echo "OpenClaw npm preflight run must come from main, the active protected release branch, or a verified protected release-publish tag." >&2
             exit 1
           fi
           if ! git -C trusted-workflow cat-file -e "${preflight_head_sha}^{commit}" 2>/dev/null; then

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -462,14 +462,23 @@ jobs:
             active_branch_preflight=true
           fi
           protected_release_publish_preflight=false
-          if [[ "$GITHUB_REF" =~ ^refs/tags/release-publish/[a-f0-9]{12}-[1-9][0-9]*$ ]]; then
-            workflow_tag="${GITHUB_REF#refs/tags/}"
-            if [[ "$preflight_head_branch" == "$workflow_tag" && "$preflight_head_sha" == "$WORKFLOW_SHA" ]]; then
-              protected_release_publish_preflight=true
-            fi
+          if [[ "$preflight_head_branch" == release-publish/* ]]; then
+            producer_tooling="${RUNNER_TEMP}/preflight-producer-tooling"
+            mkdir -p "${producer_tooling}/lib"
+            for source in npm-preflight-tooling-identity.mjs release-tooling-identity.mjs lib/record-shared.mjs; do
+              gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/${source}?ref=${WORKFLOW_SHA}" \
+                --jq .content | base64 --decode > "${producer_tooling}/${source}"
+            done
+            node "${producer_tooling}/npm-preflight-tooling-identity.mjs" \
+              --repository "$GITHUB_REPOSITORY" \
+              --workflow-ref "$preflight_head_branch" \
+              --workflow-full-ref "refs/tags/${preflight_head_branch}" \
+              --workflow-sha "$preflight_head_sha" \
+              --publisher-sha "$WORKFLOW_SHA"
+            protected_release_publish_preflight=true
           fi
           if [[ "$preflight_head_branch" != "main" && "$active_branch_preflight" != "true" && "$extended_stable_preflight" != "true" && "$protected_release_publish_preflight" != "true" ]]; then
-            echo "OpenClaw npm preflight run must come from main, the active protected release branch, or the exact protected release-publish tag." >&2
+            echo "OpenClaw npm preflight run must come from main, the active protected release branch, or a verified protected release-publish tag." >&2
             exit 1
           fi
           if [[ "$preflight_conclusion" != "success" || "$preflight_event" != "workflow_dispatch" || "$preflight_path" != ".github/workflows/openclaw-npm-release.yml" ]]; then

--- a/scripts/npm-preflight-tooling-identity.mjs
+++ b/scripts/npm-preflight-tooling-identity.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+import { isRecord } from "./lib/record-shared.mjs";
+import {
+  runReleaseToolingGh,
+  validateReleaseToolingIdentity,
+} from "./release-tooling-identity.mjs";
+
+function parseJson(raw, label) {
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`${label} returned invalid JSON.`, { cause: error });
+  }
+}
+
+// Actions exposes a short head branch for tags too; a matching branch makes
+// producer provenance ambiguous even if both refs currently point at one SHA.
+export function validateReleasePreflightTagIdentity({ branches, ...identity }) {
+  if (
+    !Array.isArray(branches) ||
+    branches.some(
+      (branch) =>
+        !isRecord(branch) ||
+        typeof branch.ref !== "string" ||
+        branch.ref === `refs/heads/${identity.workflowRef}`,
+    )
+  ) {
+    throw new Error("npm preflight has ambiguous protected tag provenance.");
+  }
+  const validated = validateReleaseToolingIdentity(identity);
+  if (validated.route !== "protected-tag") {
+    throw new Error("npm preflight producer must use a protected tag.");
+  }
+  return validated;
+}
+
+export function verifyReleasePreflightToolingIdentity({
+  repository,
+  publisherSha,
+  runGh = runReleaseToolingGh,
+  workflowFullRef,
+  workflowRef,
+  workflowSha,
+}) {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(repository ?? "")) {
+    throw new Error("npm preflight repository must be owner/name.");
+  }
+  if (!/^[a-f0-9]{40}$/u.test(publisherSha ?? "")) {
+    throw new Error("publisher workflow SHA must be a lowercase 40-character commit SHA.");
+  }
+  const normalizedRepository = repository;
+  const targetSha = publisherSha;
+  const identity = { workflowFullRef, workflowRef, workflowSha };
+  const tagRef = parseJson(
+    runGh(["api", `repos/${normalizedRepository}/git/ref/tags/${workflowRef}`, "--method", "GET"]),
+    "npm preflight producer tag",
+  );
+  const branches = parseJson(
+    runGh([
+      "api",
+      `repos/${normalizedRepository}/git/matching-refs/heads/${workflowRef}`,
+      "--method",
+      "GET",
+    ]),
+    "npm preflight producer branches",
+  );
+  const validated = validateReleasePreflightTagIdentity({ ...identity, tagRef, branches });
+  // Producer evidence and current publication authority are distinct. Require
+  // the producer on both trusted main and the current publisher's ancestry.
+  for (const target of ["main", targetSha]) {
+    const comparison = parseJson(
+      runGh([
+        "api",
+        `repos/${normalizedRepository}/compare/${validated.sha}...${target}`,
+        "--method",
+        "GET",
+        "--jq",
+        "{status}",
+      ]),
+      "npm preflight producer ancestry",
+    );
+    if (comparison?.status !== "ahead" && comparison?.status !== "identical") {
+      throw new Error(`npm preflight producer is not reachable from ${target}.`);
+    }
+  }
+  return validated;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    const { values } = parseArgs({
+      options: {
+        repository: { type: "string" },
+        "workflow-ref": { type: "string" },
+        "workflow-full-ref": { type: "string" },
+        "workflow-sha": { type: "string" },
+        "publisher-sha": { type: "string" },
+      },
+    });
+    const identity = verifyReleasePreflightToolingIdentity({
+      repository: values.repository,
+      workflowRef: values["workflow-ref"],
+      workflowFullRef: values["workflow-full-ref"],
+      workflowSha: values["workflow-sha"],
+      publisherSha: values["publisher-sha"],
+    });
+    process.stdout.write(`${JSON.stringify(identity)}\n`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/release-candidate-checklist.mts
+++ b/scripts/release-candidate-checklist.mts
@@ -27,8 +27,8 @@ import {
   stripLeadingPackageManagerSeparator,
 } from "./lib/arg-utils.mts";
 import { readBoundedResponseText } from "./lib/bounded-response.mjs";
+import { validateReleasePreflightTagIdentity } from "./npm-preflight-tooling-identity.mjs";
 import { validatePluginSdkApiReleaseEvidence } from "./plugin-sdk-api-release-evidence.mjs";
-import { validateReleaseToolingIdentity } from "./release-tooling-identity.mjs";
 import {
   dedicatedSectionVersionForTag,
   extractChangelogReleaseSections,
@@ -898,18 +898,8 @@ export async function validateNpmPreflightRunSource(
       githubApi(`repos/${repository}/git/ref/tags/${ref}`, apiOptions),
       githubApi(`repos/${repository}/git/matching-refs/heads/${ref}`, apiOptions),
     ]);
-    // Actions reports a short headBranch for tags too. A same-name branch cannot
-    // establish tag provenance, even when its commit happens to match.
-    if (
-      !Array.isArray(branches) ||
-      branches.some(
-        (branch) =>
-          !isRecord(branch) || typeof branch.ref !== "string" || branch.ref === `refs/heads/${ref}`,
-      )
-    ) {
-      throw new Error(`npm preflight run ${runId} has ambiguous protected tag provenance`);
-    }
-    validateReleaseToolingIdentity({
+    validateReleasePreflightTagIdentity({
+      branches,
       workflowRef: ref,
       workflowFullRef: expectedFullRef,
       workflowSha: workflowRun.headSha,

--- a/scripts/validate-full-release-validation-evidence.mjs
+++ b/scripts/validate-full-release-validation-evidence.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Binds Full Release Validation run metadata to its v3 evidence manifest.
+// Binds Full Release Validation run metadata to its supported evidence manifest.
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -172,9 +172,9 @@ export function validateFullReleaseValidationEvidence({
     );
   }
 
-  if (manifest.version !== 3) {
+  if (manifest.version !== 3 && manifest.version !== 4) {
     throw new Error(
-      `Full release validation manifest must use version 3, got ${displayValue(manifest.version)}.`,
+      `Full release validation manifest must use version 3 or 4, got ${displayValue(manifest.version)}.`,
     );
   }
   const manifestChecks = [
@@ -276,7 +276,7 @@ export function validateFullReleaseValidationEvidence({
       targetSha: expectedTargetSha,
     });
     if (
-      strictEvidence?.schema !== "openclaw.release-validation-evidence/v3" ||
+      strictEvidence?.schema !== `openclaw.release-validation-evidence/v${manifest.version}` ||
       strictEvidence.valid !== true ||
       scalarString(strictEvidence.current?.runId) !== String(expectedRunId) ||
       strictEvidence.current?.targetSha !== expectedTargetSha ||

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1281,7 +1281,59 @@ type ProtectedPreflightConsumerParams = {
   liveTagSha?: string;
   preflightHeadBranch: string;
   preflightHeadSha: string;
+  producerBranches?: unknown[];
+  producerTagSha?: string;
+  producerTagType?: string;
+  mainComparisonStatus?: string;
+  publisherComparisonStatus?: string;
 };
+
+const PREFLIGHT_PRODUCER_GH_CASES = `
+case "$2" in
+  */contents/scripts/*)
+    source="\${2#*/contents/scripts/}"
+    source="\${source%%\\?*}"
+    base64 < "$MOCK_REPO_ROOT/scripts/$source"
+    exit 0
+    ;;
+  */git/ref/tags/*)
+    if [[ "$*" == *"--jq .object"* ]]; then
+      printf '%s\\n' "$MOCK_REMOTE_TAG_SHA"
+    else
+      printf '%s\\n' "$MOCK_PRODUCER_TAG"
+    fi
+    exit 0
+    ;;
+  */git/matching-refs/heads/*)
+    printf '%s\\n' "$MOCK_PRODUCER_BRANCHES"
+    exit 0
+    ;;
+  */compare/*)
+    if [[ "$2" == *"...main" ]]; then
+      printf '{"status":"%s"}\\n' "$MOCK_MAIN_COMPARISON"
+    else
+      printf '{"status":"%s"}\\n' "$MOCK_PUBLISHER_COMPARISON"
+    fi
+    exit 0
+    ;;
+esac
+`;
+
+function preflightProducerFixtureEnv(params: ProtectedPreflightConsumerParams) {
+  return {
+    MOCK_REPO_ROOT: REPO_ROOT,
+    MOCK_PRODUCER_TAG: JSON.stringify({
+      ref: `refs/tags/${params.preflightHeadBranch}`,
+      object: {
+        sha: params.producerTagSha ?? params.preflightHeadSha,
+        type: params.producerTagType ?? "commit",
+      },
+    }),
+    MOCK_PRODUCER_BRANCHES: JSON.stringify(params.producerBranches ?? []),
+    MOCK_MAIN_COMPARISON: params.mainComparisonStatus ?? "ahead",
+    MOCK_PUBLISHER_COMPARISON: params.publisherComparisonStatus ?? "ahead",
+  };
+}
 
 function runReleasePublishPreflightConsumerGuard(params: ProtectedPreflightConsumerParams) {
   const job = workflowJob(RELEASE_PUBLISH_WORKFLOW, "resolve_release_target");
@@ -1302,6 +1354,7 @@ if [[ "$1" == "run" && "$2" == "download" ]]; then
   exit 0
 fi
 if [[ "$1" == "api" ]]; then
+  ${PREFLIGHT_PRODUCER_GH_CASES}
   printf '%s\\n' "$MOCK_PREFLIGHT_RUN"
   exit 0
 fi
@@ -1313,6 +1366,7 @@ exit 64
     cwd: workdir,
     encoding: "utf8",
     env: {
+      ...preflightProducerFixtureEnv(params),
       GITHUB_OUTPUT: resolve(workdir, "github-output"),
       GITHUB_REF: params.currentRef,
       GITHUB_REPOSITORY: "openclaw/openclaw",
@@ -1343,6 +1397,15 @@ function runOpenClawNpmPreflightConsumerGuard(params: ProtectedPreflightConsumer
   const workdir = tempDirs.make("openclaw-npm-preflight-consumer-");
   const binDir = resolve(workdir, "bin");
   mkdirSync(binDir);
+  const toolingDir = resolve(workdir, "trusted-workflow/scripts");
+  mkdirSync(resolve(toolingDir, "lib"), { recursive: true });
+  for (const source of [
+    "npm-preflight-tooling-identity.mjs",
+    "release-tooling-identity.mjs",
+    "lib/record-shared.mjs",
+  ]) {
+    copyFileSync(resolve(REPO_ROOT, "scripts", source), resolve(toolingDir, source));
+  }
   writeFileSync(
     resolve(binDir, "gh"),
     `#!/usr/bin/env bash
@@ -1352,10 +1415,7 @@ if [[ "$1" == "run" && "$2" == "view" ]]; then
   exit 0
 fi
 if [[ "$1" == "api" ]]; then
-  if [[ "$2" == *"/git/ref/tags/"* ]]; then
-    printf '%s\\n' "$MOCK_REMOTE_TAG_SHA"
-    exit 0
-  fi
+  ${PREFLIGHT_PRODUCER_GH_CASES}
   printf '1\\n'
   exit 0
 fi
@@ -1381,6 +1441,9 @@ exit 64
   writeFileSync(
     resolve(binDir, "node"),
     `#!/usr/bin/env bash
+if [[ "$1" == *"/npm-preflight-tooling-identity.mjs" ]]; then
+  exec "$MOCK_NODE_EXECUTABLE" "$@"
+fi
 cat >/dev/null
 `,
     { mode: 0o755 },
@@ -1389,6 +1452,8 @@ cat >/dev/null
     cwd: workdir,
     encoding: "utf8",
     env: {
+      ...preflightProducerFixtureEnv(params),
+      MOCK_NODE_EXECUTABLE: process.execPath,
       EXPECTED_EXTENDED_STABLE_BRANCH: "",
       GITHUB_OUTPUT: resolve(workdir, "github-output"),
       GITHUB_REPOSITORY: "openclaw/openclaw",
@@ -2039,79 +2104,39 @@ describe("package acceptance workflow", () => {
     }
   });
 
-  it("binds aggregate preflight consumption to the exact protected tooling tag and SHA", () => {
-    const workflowSha = "a".repeat(40);
-    const workflowTag = `release-publish/${workflowSha.slice(0, 12)}-123`;
-    const valid = runReleasePublishPreflightConsumerGuard({
-      currentRef: `refs/tags/${workflowTag}`,
-      currentWorkflowSha: workflowSha,
-      preflightHeadBranch: workflowTag,
-      preflightHeadSha: workflowSha,
-    });
-    expect(valid.status, valid.stderr).toBe(0);
+  it.each([
+    ["aggregate", runReleasePublishPreflightConsumerGuard],
+    ["core npm", runOpenClawNpmPreflightConsumerGuard],
+  ] as const)(
+    "binds %s historical preflight consumption to independent producer provenance",
+    (_name, run) => {
+      const producerSha = "a".repeat(40);
+      const producerTag = `release-publish/${producerSha.slice(0, 12)}-123`;
+      const publisherSha = "b".repeat(40);
+      const params = {
+        currentRef: `refs/tags/release-publish/${publisherSha.slice(0, 12)}-456`,
+        currentWorkflowSha: publisherSha,
+        preflightHeadBranch: producerTag,
+        preflightHeadSha: producerSha,
+      };
+      const valid = run(params);
+      expect(valid.status, valid.stderr).toBe(0);
 
-    for (const rejected of [
-      {
-        currentRef: `refs/tags/${workflowTag}`,
-        preflightHeadBranch: `${workflowTag}-wrong`,
-        preflightHeadSha: workflowSha,
-      },
-      {
-        currentRef: `refs/tags/${workflowTag}`,
-        preflightHeadBranch: workflowTag,
-        preflightHeadSha: "b".repeat(40),
-      },
-      {
-        currentRef: `refs/heads/${workflowTag}`,
-        preflightHeadBranch: workflowTag,
-        preflightHeadSha: workflowSha,
-      },
-    ]) {
-      const result = runReleasePublishPreflightConsumerGuard({
-        ...rejected,
-        currentWorkflowSha: workflowSha,
-      });
-      expect(result.status).toBe(1);
-      expect(result.stderr).toContain("exact protected release-publish tag");
-    }
-  });
-
-  it("binds core npm preflight consumption to the exact protected tooling tag and SHA", () => {
-    const workflowSha = "a".repeat(40);
-    const workflowTag = `release-publish/${workflowSha.slice(0, 12)}-123`;
-    const valid = runOpenClawNpmPreflightConsumerGuard({
-      currentRef: `refs/tags/${workflowTag}`,
-      currentWorkflowSha: workflowSha,
-      preflightHeadBranch: workflowTag,
-      preflightHeadSha: workflowSha,
-    });
-    expect(valid.status, valid.stderr).toBe(0);
-
-    for (const rejected of [
-      {
-        currentRef: `refs/tags/${workflowTag}`,
-        preflightHeadBranch: `${workflowTag}-wrong`,
-        preflightHeadSha: workflowSha,
-      },
-      {
-        currentRef: `refs/tags/${workflowTag}`,
-        preflightHeadBranch: workflowTag,
-        preflightHeadSha: "b".repeat(40),
-      },
-      {
-        currentRef: `refs/heads/${workflowTag}`,
-        preflightHeadBranch: workflowTag,
-        preflightHeadSha: workflowSha,
-      },
-    ]) {
-      const result = runOpenClawNpmPreflightConsumerGuard({
-        ...rejected,
-        currentWorkflowSha: workflowSha,
-      });
-      expect(result.status).toBe(1);
-      expect(result.stderr).toContain("exact protected release-publish tag");
-    }
-  });
+      for (const rejected of [
+        { preflightHeadBranch: `${producerTag}-wrong` },
+        { preflightHeadSha: "c".repeat(40) },
+        { producerTagSha: "c".repeat(40) },
+        { producerTagType: "tag" },
+        { producerBranches: [{ ref: `refs/heads/${producerTag}` }] },
+        { mainComparisonStatus: "diverged" },
+        { publisherComparisonStatus: "behind" },
+      ]) {
+        const result = run({ ...params, ...rejected });
+        expect(result.status, JSON.stringify(rejected)).toBe(1);
+        expect(result.stderr).toMatch(/protected|reachable/u);
+      }
+    },
+  );
 
   it("rejects a protected tooling tag moved after request validation and environment approval", () => {
     const workflowSha = "a".repeat(40);

--- a/test/scripts/release-tooling-identity.test.ts
+++ b/test/scripts/release-tooling-identity.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { verifyReleasePreflightToolingIdentity } from "../../scripts/npm-preflight-tooling-identity.mjs";
 import {
   resolveReleaseToolingIdentity,
   validateReleasePublishParentRun,
@@ -402,5 +403,78 @@ describe("release tooling identity", () => {
         },
       }),
     ).toThrow();
+  });
+});
+
+describe("historical npm preflight tooling", () => {
+  function proof(overrides: Record<string, unknown> = {}) {
+    const responses: Record<string, unknown> = {
+      [`git/ref/tags/${REF}`]: { ref: FULL_REF, object: { sha: SHA, type: "commit" } },
+      [`git/matching-refs/heads/${REF}`]: [],
+      [`compare/${SHA}...main`]: { status: "ahead" },
+      [`compare/${SHA}...${OTHER_SHA}`]: { status: "ahead" },
+      ...overrides,
+    };
+    const runGh = vi.fn((args: string[]) => {
+      const route = args[1]?.replace("repos/openclaw/openclaw/", "");
+      if (!route || !(route in responses)) throw new Error("unavailable provenance");
+      return JSON.stringify(responses[route]);
+    });
+    return { ...protectedIdentity(), publisherSha: OTHER_SHA, runGh };
+  }
+
+  it("accepts an unchanged historical producer under a distinct descendant publisher", () => {
+    const options = proof();
+    expect(verifyReleasePreflightToolingIdentity(options)).toMatchObject({
+      ref: REF,
+      sha: SHA,
+      route: "protected-tag",
+    });
+    expect(options.runGh.mock.calls.map(([args]) => args[1])).toEqual([
+      `repos/openclaw/openclaw/git/ref/tags/${REF}`,
+      `repos/openclaw/openclaw/git/matching-refs/heads/${REF}`,
+      `repos/openclaw/openclaw/compare/${SHA}...main`,
+      `repos/openclaw/openclaw/compare/${SHA}...${OTHER_SHA}`,
+    ]);
+  });
+
+  it.each([
+    ["missing tag", `git/ref/tags/${REF}`, null],
+    [
+      "moved tag",
+      `git/ref/tags/${REF}`,
+      { ref: FULL_REF, object: { sha: OTHER_SHA, type: "commit" } },
+    ],
+    ["annotated tag", `git/ref/tags/${REF}`, { ref: FULL_REF, object: { sha: SHA, type: "tag" } }],
+    ["ambiguous branch", `git/matching-refs/heads/${REF}`, [{ ref: `refs/heads/${REF}` }]],
+    ["malformed branches", `git/matching-refs/heads/${REF}`, {}],
+    ["malformed branch entry", `git/matching-refs/heads/${REF}`, [{}]],
+    ["producer outside main", `compare/${SHA}...main`, { status: "diverged" }],
+    ["producer newer than publisher", `compare/${SHA}...${OTHER_SHA}`, { status: "behind" }],
+    ["unrelated publisher", `compare/${SHA}...${OTHER_SHA}`, { status: "diverged" }],
+    ["missing ancestry", `compare/${SHA}...${OTHER_SHA}`, {}],
+  ])("rejects %s", (_name, route, response) => {
+    expect(() =>
+      verifyReleasePreflightToolingIdentity(proof({ [String(route)]: response })),
+    ).toThrow();
+  });
+
+  it("fails closed when provenance cannot be read", () => {
+    expect(() =>
+      verifyReleasePreflightToolingIdentity({
+        ...proof(),
+        runGh: () => {
+          throw new Error("HTTP 503");
+        },
+      }),
+    ).toThrow("HTTP 503");
+  });
+
+  it.each([
+    { publisherSha: "invalid" },
+    { workflowFullRef: `refs/heads/${REF}` },
+    { workflowSha: OTHER_SHA },
+  ])("rejects invalid producer or publisher identity %j", (override) => {
+    expect(() => verifyReleasePreflightToolingIdentity({ ...proof(), ...override })).toThrow();
   });
 });

--- a/test/scripts/validate-full-release-validation-evidence.test.ts
+++ b/test/scripts/validate-full-release-validation-evidence.test.ts
@@ -54,9 +54,9 @@ function exactTargetEvidenceReuse() {
   };
 }
 
-function strictEvidenceReuse() {
+function strictEvidenceReuse(version = 3) {
   return {
-    schema: "openclaw.release-validation-evidence/v3",
+    schema: `openclaw.release-validation-evidence/v${version}`,
     valid: true,
     current: { runId: "123", targetSha },
     root: { runId: "122", targetSha },
@@ -85,7 +85,8 @@ function validate(
     expectedTargetSha: targetSha,
     expectedWorkflowBranch: "release/2026.7.1",
     isTrustedMainAncestor,
-    validateEvidenceReuseStrictly: () => strictEvidenceReuse(),
+    validateEvidenceReuseStrictly: () =>
+      strictEvidenceReuse(Number(manifestOverrides.version ?? 3)),
   });
   return { isTrustedMainAncestor, result };
 }
@@ -118,8 +119,8 @@ describe("full release validation evidence", () => {
     });
   });
 
-  it("accepts canonical SHA-pinned evidence bound to current main", () => {
-    const { isTrustedMainAncestor, result } = validate();
+  it.each([3, 4])("accepts v%s SHA-pinned evidence bound to current main", (version) => {
+    const { isTrustedMainAncestor, result } = validate({}, { version });
 
     expect(result.source).toBe("sha-pinned-main");
     expect(isTrustedMainAncestor).toHaveBeenCalledWith(workflowSha);
@@ -144,30 +145,33 @@ describe("full release validation evidence", () => {
     expect(isTrustedMainAncestor).not.toHaveBeenCalled();
   });
 
-  it("accepts historical SHA-pinned evidence from trusted main under a protected publisher", () => {
-    const isTrustedMainAncestor = vi.fn(() => true);
-    const validateEvidenceReuseStrictly = vi.fn(() => strictEvidenceReuse());
-    const trustedWorkflowRef = `release-publish/${publisherWorkflowSha.slice(0, 12)}-123`;
-    const result = validateFullReleaseValidationEvidence({
-      run: releaseRun(),
-      manifest: releaseManifest({ evidenceReuse: exactTargetEvidenceReuse() }),
-      expectedRepository: "openclaw/openclaw",
-      expectedRunId: "123",
-      expectedTargetSha: targetSha,
-      expectedTrustedWorkflowFullRef: `refs/tags/${trustedWorkflowRef}`,
-      expectedTrustedWorkflowSha: publisherWorkflowSha,
-      isTrustedMainAncestor,
-      validateEvidenceReuseStrictly,
-    });
+  it.each([3, 4])(
+    "accepts historical v%s evidence from trusted main under a protected publisher",
+    (version) => {
+      const isTrustedMainAncestor = vi.fn(() => true);
+      const validateEvidenceReuseStrictly = vi.fn(() => strictEvidenceReuse(version));
+      const trustedWorkflowRef = `release-publish/${publisherWorkflowSha.slice(0, 12)}-123`;
+      const result = validateFullReleaseValidationEvidence({
+        run: releaseRun(),
+        manifest: releaseManifest({ version, evidenceReuse: exactTargetEvidenceReuse() }),
+        expectedRepository: "openclaw/openclaw",
+        expectedRunId: "123",
+        expectedTargetSha: targetSha,
+        expectedTrustedWorkflowFullRef: `refs/tags/${trustedWorkflowRef}`,
+        expectedTrustedWorkflowSha: publisherWorkflowSha,
+        isTrustedMainAncestor,
+        validateEvidenceReuseStrictly,
+      });
 
-    expect(result.source).toBe("sha-pinned-protected-tag-main-ancestor");
-    expect(isTrustedMainAncestor).toHaveBeenCalledWith(workflowSha);
-    expect(validateEvidenceReuseStrictly).toHaveBeenCalledWith({
-      repository: "openclaw/openclaw",
-      runId: "123",
-      targetSha,
-    });
-  });
+      expect(result.source).toBe("sha-pinned-protected-tag-main-ancestor");
+      expect(isTrustedMainAncestor).toHaveBeenCalledWith(workflowSha);
+      expect(validateEvidenceReuseStrictly).toHaveBeenCalledWith({
+        repository: "openclaw/openclaw",
+        runId: "123",
+        targetSha,
+      });
+    },
+  );
 
   it("rejects protected-tag evidence from a same-name branch or untrusted ancestor", () => {
     const trustedWorkflowRef = `release-publish/${workflowSha.slice(0, 12)}-123`;
@@ -284,6 +288,8 @@ describe("full release validation evidence", () => {
     ["target SHA", {}, { targetSha: "c".repeat(40) }, "targetSha"],
     ["target ref", {}, { targetRef: "v2026.7.1-beta.3" }, "target ref"],
     ["manifest version", {}, { version: 2 }, "version 3"],
+    ["future manifest version", {}, { version: 5 }, "version 3"],
+    ["string manifest version", {}, { version: "4" }, "version 3"],
   ])("rejects mismatched %s", (_name, runOverrides, manifestOverrides, message) => {
     expect(() => validate(runOverrides, manifestOverrides)).toThrow(message);
   });
@@ -302,13 +308,13 @@ describe("full release validation evidence", () => {
     expect(() => validate({}, {}, false)).toThrow("not reachable from current main");
   });
 
-  it("accepts exact-target evidence reuse on the SHA-pinned path", () => {
-    expect(validate({}, { evidenceReuse: exactTargetEvidenceReuse() }).result.source).toBe(
+  it.each([3, 4])("accepts v%s exact-target evidence reuse on the SHA-pinned path", (version) => {
+    expect(validate({}, { version, evidenceReuse: exactTargetEvidenceReuse() }).result.source).toBe(
       "sha-pinned-main",
     );
   });
 
-  it("accepts changelog-only release evidence reuse on the SHA-pinned path", () => {
+  it.each([3, 4])("accepts v%s changelog-only evidence reuse on the SHA-pinned path", (version) => {
     const codeSha = "c".repeat(40);
     const reuse = {
       changedPaths: ["CHANGELOG.md"],
@@ -319,14 +325,14 @@ describe("full release validation evidence", () => {
     };
     const result = validateFullReleaseValidationEvidence({
       run: releaseRun(),
-      manifest: releaseManifest({ evidenceReuse: reuse }),
+      manifest: releaseManifest({ version, evidenceReuse: reuse }),
       expectedRepository: "openclaw/openclaw",
       expectedRunId: "123",
       expectedTargetSha: targetSha,
       expectedWorkflowBranch: "release/2026.7.1",
       isTrustedMainAncestor: () => true,
       validateEvidenceReuseStrictly: () => ({
-        ...strictEvidenceReuse(),
+        ...strictEvidenceReuse(version),
         current: { runId: "123", targetSha },
         root: { runId: "122", targetSha: codeSha },
         evidenceReuse: {
@@ -371,6 +377,23 @@ describe("full release validation evidence", () => {
       }),
     ).toThrow("failed strict chain validation");
   });
+
+  it.each([3, 4])(
+    "rejects strict evidence with a different schema from the v%s manifest",
+    (version) => {
+      expect(() =>
+        validateFullReleaseValidationEvidence({
+          run: releaseRun(),
+          manifest: releaseManifest({ version, evidenceReuse: exactTargetEvidenceReuse() }),
+          expectedRepository: "openclaw/openclaw",
+          expectedRunId: "123",
+          expectedTargetSha: targetSha,
+          isTrustedMainAncestor: () => true,
+          validateEvidenceReuseStrictly: () => strictEvidenceReuse(version === 3 ? 4 : 3),
+        }),
+      ).toThrow("failed strict chain validation");
+    },
+  );
 
   it("rejects malformed evidence reuse on the SHA-pinned path", () => {
     expect(() =>


### PR DESCRIPTION
## What Problem This Solves

Release publication could reject already successful validation and npm preflight evidence after a trusted tooling repair: the shared validation consumer still required manifest version 3, and parent/core npm publication required a protected preflight to use the current publisher tag and SHA. The candidate already supported historical protected preflight producers.

## Why This Change Was Made

Accept numeric version 3 and version 4 validation manifests with the matching canonical strict evidence schema. Reuse the candidate's protected producer identity contract through one narrow npm helper: verify the exact live lightweight producer tag, reject an ambiguous same-name branch, and require the producer on both current main and current publisher ancestry.

Producer identity remains separate from publication authority. The current publisher tag is still rechecked after npm environment approval, and parent authority, successful run/attempt, target, immutable package hashes and SDK digest checks are retained. The generic release-tooling identity module stays byte-identical so plugin policy evidence is not invalidated.

## User Impact

Maintainers can publish the already prepared and reviewed npm bytes after a trusted tooling repair, without rebuilding the release. No product runtime, configuration or persistence behavior changes. The candidate's displayed command still identifies its producer; recovery dispatch explicitly selects the reviewed current publisher pin rather than executing that historical suggestion.

## Evidence

- The version matrix failed before repair: five version 4 cases failed while 33 controls passed. The final consumer and strict-validator suites passed 126 tests, including unsupported/string versions and mismatched schemas.
- The exact downloaded manifest from [successful Full Release Validation](https://github.com/openclaw/openclaw/actions/runs/33344016503) and its retained successful strict receipt failed before and passed after. No product validation was repeated.
- The unchanged parent admission block rejected [successful protected npm preflight 33343028766](https://github.com/openclaw/openclaw/actions/runs/33343028766) under a distinct publisher. The new CLI passed its actual live producer tag, branch-ambiguity and both ancestry checks. Its retained manifest, SDK archive and packed tarball identities were rechecked without modifying bytes.
- All 159 focused producer/candidate/workflow tests passed. Negative cases reject missing/moved/annotated tags, ambiguous or malformed branch data, unavailable provenance, invalid identities and unrelated/newer producer ancestry.
- Required canonical changed-file gates passed for both scopes, including script/root test types, script lint, formatting and selected guards. Independent review results and exact-head hosted CI are recorded before merge.

The new source is confined to the missing npm producer admission boundary; the generic plugin policy closure is unchanged. Current publisher approval and artifact validation remain mandatory.

LOC: release tooling +147/-27 (net +120); tests +130/-33 (net +97). The added helper supplies the missing shared historical-producer provenance check and standalone trusted-workflow CLI; candidate duplication is removed. This keeps package rebuilding and artifact transformation out of recovery.
