### PR TITLE
refactor(context-engine): simplify compaction and turn handoffs

### DIFF
--- a/qa/scenarios/goals/goal-context-survives-compaction.yaml
+++ b/qa/scenarios/goals/goal-context-survives-compaction.yaml
@@ -14,9 +14,10 @@ scenario:
   successCriteria:
     - An authorized channel turn starts a session goal through `/goal start`.
     - A separate conversation completes a turn before the original session is compacted.
-    - The same session completes a manual `/compact` operation.
-    - The first post-compaction inbound turn reaches the mock model with the exact active-goal context line.
-    - The assertion uses the captured post-compaction provider request.
+    - The same session records exactly one manual compaction, with stable identity and fresh context accounting.
+    - At least one successful summary request belongs to the manual compaction.
+    - The first post-compaction inbound turn includes the persisted summary and exact active-goal context, then delivers one successful final reply.
+    - The assertions use causal provider-request and transcript cursors.
   gatewayConfigPatch:
     agents:
       defaults:
@@ -41,7 +42,8 @@ scenario:
       expectedGoalContext: "Active goal: Preserve the deployment audit objective — advance; keep active until fully achieved; block only after the same blocker on 3 consecutive turns; after update_goal, provide the requested visible final."
       contextSeedMarker: GOAL-COMPACTION-CONTEXT-SEED
       otherConversationMarker: GOAL-COMPACTION-SECOND-SESSION-READY
-      postCompactionMessage: GOAL-CONTEXT-POST-COMPACTION unrelated lunch question
+      postCompactionMessage: "GOAL-CONTEXT-POST-COMPACTION unrelated lunch question. Reply exactly: GOAL-COMPACTION-RESUMED"
+      postCompactionReplyMarker: GOAL-COMPACTION-RESUMED
 
 flow:
   steps:
@@ -62,6 +64,12 @@ flow:
         - set: conversationId
           value:
             expr: "`${config.conversationId}-${randomUUID().slice(0, 8)}`"
+        - set: delivery
+          value:
+            expr: "transport.buildAgentDelivery({ target: `dm:${conversationId}` })"
+        - set: sessionKey
+          value:
+            expr: "buildAgentSessionKey({ agentId: 'qa', channel: delivery.channel, accountId: transport.accountId, peer: { kind: 'direct', id: delivery.replyTo }, mainKey: env.cfg.session?.mainKey, dmScope: env.cfg.session?.dmScope, identityLinks: env.cfg.session?.identityLinks })"
         - set: outboundIndex
           value:
             expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
@@ -84,28 +92,63 @@ flow:
               ref: outboundIndex
             timeoutMs:
               expr: liveTurnTimeoutMs(env, 60000)
-        - set: seedOutboundIndex
-          value:
-            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
-        - sendInbound:
-            conversation:
-              id:
-                ref: conversationId
-              kind: direct
-            senderId:
-              ref: config.senderId
-            senderName: QA Goal Operator
-            text:
-              expr: "`${config.contextSeedMarker} ${'retain this audit context '.repeat(80)}`"
-        - waitForOutbound:
-            conversation:
-              id:
-                ref: conversationId
-              kind: direct
-            sinceIndex:
-              ref: seedOutboundIndex
-            timeoutMs:
-              expr: liveTurnTimeoutMs(env, 60000)
+        - call: readSessionTranscriptSummary
+          args:
+            - ref: env
+            - ref: sessionKey
+            - allowEmpty: true
+          saveAs: transcriptBeforeSeeds
+        - forEach:
+            items:
+              expr: "Array.from({ length: 6 }, (_, index) => index + 1)"
+            item: seedTurn
+            actions:
+              - set: seedReplyMarker
+                value:
+                  expr: "`GOAL-COMPACTION-SEED-${seedTurn}-READY`"
+              - set: seedOutboundIndex
+                value:
+                  expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+              - sendInbound:
+                  conversation:
+                    id:
+                      ref: conversationId
+                    kind: direct
+                  senderId:
+                    ref: config.senderId
+                  senderName: QA Goal Operator
+                  text:
+                    expr: "`${config.contextSeedMarker}-${seedTurn} ${'retain this audit context '.repeat(80)} Reply exactly: ${seedReplyMarker}`"
+              - waitForOutbound:
+                  conversation:
+                    id:
+                      ref: conversationId
+                    kind: direct
+                  sinceIndex:
+                    ref: seedOutboundIndex
+                  textIncludes:
+                    ref: seedReplyMarker
+                  timeoutMs:
+                    expr: liveTurnTimeoutMs(env, 60000)
+                saveAs: seedReply
+              - assert:
+                  expr: "seedReply.isError !== true && seedReply.text === seedReplyMarker"
+                  message: seed turn did not complete successfully
+              - call: waitForCondition
+                args:
+                  - lambda:
+                      async: true
+                      expr: "env.gateway.call('sessions.list', {}, { timeoutMs: 30000 }).then((result) => result.sessions?.find((session) => session.key === sessionKey && session.hasActiveRun === false))"
+                  - expr: liveTurnTimeoutMs(env, 60000)
+                  - 100
+        - call: readSessionTranscriptSummary
+          args:
+            - ref: env
+            - ref: sessionKey
+          saveAs: seededTranscript
+        - assert:
+            expr: "seededTranscript.userMessageCount === transcriptBeforeSeeds.userMessageCount + 6"
+            message: every seed turn must reach the durable transcript
         - set: otherConversationId
           value:
             expr: "`${conversationId}-other`"
@@ -146,6 +189,23 @@ flow:
                 expr: "env.gateway.call('sessions.list', {}, { timeoutMs: 30000 }).then((result) => result.sessions?.find((session) => session.key === otherSessionKey && session.hasActiveRun === false))"
             - expr: liveTurnTimeoutMs(env, 60000)
             - 100
+        - set: sessionBeforeCompaction
+          value:
+            expr: "(await readRawQaSessionStore(env))[sessionKey]"
+        - assert:
+            expr: "typeof sessionBeforeCompaction?.sessionId === 'string' && sessionBeforeCompaction.agentHarnessId === 'openclaw'"
+            message: expected an existing embedded session before manual compaction
+        - call: readSessionTranscriptSummary
+          args:
+            - ref: env
+            - ref: sessionKey
+          saveAs: transcriptBeforeCompaction
+        - set: checkpointsBeforeCompaction
+          value:
+            expr: "(await env.gateway.call('sessions.compaction.list', { key: sessionKey }, { timeoutMs: 15000 })).checkpoints ?? []"
+        - set: requestCursorBeforeCompaction
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor"
         - set: compactOutboundIndex
           value:
             expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
@@ -165,14 +225,47 @@ flow:
               kind: direct
             sinceIndex:
               ref: compactOutboundIndex
-            textIncludes: Compact
+            textIncludes: Compacted
             timeoutMs:
               expr: liveTurnTimeoutMs(env, 60000)
           saveAs: compactReply
         - assert:
-            expr: "!normalizeLowercaseStringOrEmpty(compactReply.text).includes('skipped')"
+            expr: "!/(failed|unavailable|incomplete|skipped|aborted|cancelled|canceled)/iu.test(compactReply.text)"
             message:
               expr: "`manual compaction did not compact the seeded session: ${compactReply.text}`"
+        - call: waitForCondition
+          args:
+            - lambda:
+                async: true
+                expr: "readRawQaSessionStore(env).then((store) => { const entry = store[sessionKey]; return entry?.compactionCount === (sessionBeforeCompaction.compactionCount ?? 0) + 1 ? entry : undefined; })"
+            - expr: liveTurnTimeoutMs(env, 60000)
+            - 100
+          saveAs: compactedSession
+        - assert:
+            expr: "compactedSession.sessionId === sessionBeforeCompaction.sessionId && compactedSession.lifecycleRevision === sessionBeforeCompaction.lifecycleRevision && compactedSession.agentHarnessId === 'openclaw' && Number.isFinite(compactedSession.totalTokens) && compactedSession.totalTokens >= 0 && compactedSession.totalTokensFresh === true"
+            message: manual compaction changed session identity or failed to publish fresh context
+        - call: readSessionTranscriptSummary
+          args:
+            - ref: env
+            - ref: sessionKey
+            - afterEventCursor:
+                expr: transcriptBeforeCompaction.eventCursor
+          saveAs: compactedTranscript
+        - assert:
+            expr: "compactedTranscript.compactionSummaries.length === 1"
+            message: manual compaction must append exactly one durable summary
+        - set: newCheckpoints
+          value:
+            expr: "((await env.gateway.call('sessions.compaction.list', { key: sessionKey }, { timeoutMs: 15000 })).checkpoints ?? []).filter((checkpoint) => !checkpointsBeforeCompaction.some((previous) => previous.checkpointId === checkpoint.checkpointId))"
+        - assert:
+            expr: "newCheckpoints.length === 1 && Number.isFinite(newCheckpoints[0].tokensBefore) && Number.isFinite(newCheckpoints[0].tokensAfter) && newCheckpoints[0].tokensAfter === compactedSession.totalTokens"
+            message: manual compaction must publish one checkpoint with the same context snapshot
+        - set: summaryRequests
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBeforeCompaction}`)).filter((request) => request.requestKind === 'compaction-summary')"
+        - assert:
+            expr: "summaryRequests.length > 0 && summaryRequests.every((request) => request.outcome === 'success' && request.plannedToolName === undefined && request.toolOutputStructuredError !== true)"
+            message: manual compaction must complete a causal summary request without tool execution
         - set: requestCursorBeforePostCompactionTurn
           value:
             expr: "(await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor"
@@ -204,10 +297,41 @@ flow:
               kind: direct
             sinceIndex:
               ref: postCompactOutboundIndex
+            textIncludes:
+              ref: config.postCompactionReplyMarker
             timeoutMs:
               expr: liveTurnTimeoutMs(env, 60000)
           saveAs: postCompactionReply
         - assert:
-            expr: "String(postCompactionRequest.allInputText ?? '').includes(config.expectedGoalContext)"
-            message: post-compaction provider request input missed active goal context
-      detailsExpr: "`compact=${compactReply.text}; post-compaction=${postCompactionReply.text}`"
+            expr: "String(postCompactionRequest.allInputText ?? '').includes(config.expectedGoalContext) && String(postCompactionRequest.allInputText ?? '').includes(compactedTranscript.compactionSummaries[0])"
+            message: post-compaction provider request missed active goal context or the persisted summary
+        - assert:
+            expr: "postCompactionReply.text === config.postCompactionReplyMarker && postCompactionReply.isError !== true"
+            message: post-compaction turn did not deliver its successful final reply
+        - call: waitForCondition
+          args:
+            - lambda:
+                async: true
+                expr: "env.gateway.call('sessions.list', {}, { timeoutMs: 30000 }).then((result) => result.sessions?.find((session) => session.key === sessionKey && session.hasActiveRun === false))"
+            - expr: liveTurnTimeoutMs(env, 60000)
+            - 100
+        - set: sessionAfterTurn
+          value:
+            expr: "(await readRawQaSessionStore(env))[sessionKey]"
+        - assert:
+            expr: "sessionAfterTurn.sessionId === compactedSession.sessionId && sessionAfterTurn.lifecycleRevision === compactedSession.lifecycleRevision && sessionAfterTurn.compactionCount === compactedSession.compactionCount"
+            message: the next accepted turn must retain the compacted session without another compaction
+        - call: readSessionTranscriptSummary
+          args:
+            - ref: env
+            - ref: sessionKey
+            - afterEventCursor:
+                expr: compactedTranscript.eventCursor
+          saveAs: postCompactionTranscript
+        - assert:
+            expr: "postCompactionTranscript.userMessageCount === 1 && postCompactionTranscript.compactionSummaries.length === 0 && postCompactionTranscript.finalText === config.postCompactionReplyMarker && postCompactionTranscript.lastAssistantStopReason === 'stop' && !postCompactionTranscript.lastAssistantErrorMessage"
+            message: the accepted post-compaction turn must persist one user message and a successful terminal assistant
+        - assert:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').slice(postCompactOutboundIndex).filter((message) => message.conversation.id === conversationId && message.text === config.postCompactionReplyMarker).length === 1"
+            message: the post-compaction final reply must be delivered exactly once
+      detailsExpr: "JSON.stringify({ sessionKey, sessionId: compactedSession.sessionId, lifecycleRevision: compactedSession.lifecycleRevision, counts: [sessionBeforeCompaction.compactionCount ?? 0, compactedSession.compactionCount, sessionAfterTurn.compactionCount], contextAfterCompaction: compactedSession.totalTokens, contextFresh: compactedSession.totalTokensFresh, checkpointId: newCheckpoints[0].checkpointId, summaryRequests: summaryRequests.map((request) => ({ cursor: request.cursor, kind: request.requestKind, outcome: request.outcome })), postCompactionRequestCursor: postCompactionRequest.cursor, finalReply: postCompactionReply.text })"

--- a/src/agents/cli-runner.context-engine.test.ts
+++ b/src/agents/cli-runner.context-engine.test.ts
@@ -2,6 +2,7 @@
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ContextEngine } from "../context-engine/types.js";
+import { createUserTurnTranscriptRecorder } from "../sessions/user-turn-transcript.js";
 import { createTestAdmittedRunContext } from "./admitted-run-context.test-support.js";
 import type { PreparedCliRunContext } from "./cli-runner/types.js";
 
@@ -86,6 +87,23 @@ const CONTEXT_ENGINE_SESSION_TARGET = {
   sessionKey: "agent:main:main",
   storePath: "/tmp/openclaw-cli-context-engine-test/openclaw-agent.sqlite",
 } as const;
+
+function createAdmittedCliRecorder(entryId: string) {
+  const message = { role: "user" as const, content: "visible ask", timestamp: 1 };
+  const recorder = createUserTurnTranscriptRecorder({ message, target: async () => undefined });
+  const admission = {
+    ...CONTEXT_ENGINE_SESSION_TARGET,
+    generation: "generation-1",
+    entryId,
+    rawSeq: 1,
+    effectiveParentId: null,
+    activeMessagePosition: 0,
+    logicalTurnId: `${entryId}-turn`,
+    role: "user" as const,
+  };
+  recorder.markRuntimePersisted(message, admission);
+  return { recorder, admission };
+}
 
 function buildPreparedContext(contextEngine: ContextEngine): PreparedCliRunContext {
   // Prepared contexts mirror the shape produced by prepare.runtime without
@@ -377,24 +395,31 @@ describe("runPreparedCliAgent context engine lifecycle", () => {
     expect(dispose).not.toHaveBeenCalled();
   });
 
-  it("does not emit CLI turn facts without transcript admission", async () => {
-    const afterTurn = vi.fn<NonNullable<ContextEngine["afterTurn"]>>(async () => {});
-    const maintain = vi.fn<NonNullable<ContextEngine["maintain"]>>(async () =>
-      createMaintenanceResult(),
-    );
-    const dispose = vi.fn(async () => {});
-    const context = buildPreparedContext(createContextEngine({ afterTurn, maintain, dispose }));
-    const onContextEngineTurnCandidate = vi.fn();
-    context.params.onContextEngineTurnCandidate = onContextEngineTurnCandidate;
-    prepareCliRunContextMock.mockResolvedValue(context);
+  it.each(["admission", "terminal"] as const)(
+    "does not emit CLI turn facts without %s",
+    async (missing) => {
+      const afterTurn = vi.fn<NonNullable<ContextEngine["afterTurn"]>>(async () => {});
+      const maintain = vi.fn<NonNullable<ContextEngine["maintain"]>>(async () =>
+        createMaintenanceResult(),
+      );
+      const dispose = vi.fn(async () => {});
+      const context = buildPreparedContext(createContextEngine({ afterTurn, maintain, dispose }));
+      const onContextEngineTurnCandidate = vi.fn();
+      context.params.onContextEngineTurnCandidate = onContextEngineTurnCandidate;
+      if (missing === "terminal") {
+        context.params.userTurnTranscriptRecorder = createAdmittedCliRecorder("cli-user").recorder;
+        context.params.persistAssistantTranscript = false;
+      }
+      prepareCliRunContextMock.mockResolvedValue(context);
 
-    await runCliAgent(context.params);
+      await runCliAgent(context.params);
 
-    expect(onContextEngineTurnCandidate).not.toHaveBeenCalled();
-    expect(afterTurn).not.toHaveBeenCalled();
-    expect(maintain).toHaveBeenCalledTimes(1);
-    expect(dispose).not.toHaveBeenCalled();
-  });
+      expect(onContextEngineTurnCandidate).not.toHaveBeenCalled();
+      expect(afterTurn).not.toHaveBeenCalled();
+      expect(maintain).toHaveBeenCalledTimes(1);
+      expect(dispose).not.toHaveBeenCalled();
+    },
+  );
 
   it("uses the admitted user anchor for an accepted transcriptless CLI turn", async () => {
     const context = buildPreparedContext(createContextEngine());
@@ -407,36 +432,10 @@ describe("runPreparedCliAgent context engine lifecycle", () => {
       diagnosticUsage: { input: 21, output: 0, total: 21 },
       finalPromptText: "prompt sent to cli",
     });
-    const admission = {
-      agentId: "main",
-      sessionId: "openclaw-session-1",
-      sessionKey: "agent:main:main",
-      storePath: "/tmp/openclaw-cli-context-engine-test/sessions.json",
-      generation: "generation-1",
-      entryId: "cli-user",
-      rawSeq: 1,
-      effectiveParentId: null,
-      activeMessagePosition: 0,
-      logicalTurnId: "cli-turn",
-      role: "user" as const,
-    };
+    const { admission, recorder } = createAdmittedCliRecorder("cli-user");
     const onContextEngineTurnCandidate = vi.fn();
     context.params.onContextEngineTurnCandidate = onContextEngineTurnCandidate;
-    context.params.userTurnTranscriptRecorder = {
-      message: undefined,
-      resolveMessage: vi.fn(async () => undefined),
-      getAdmissionReceipt: () => admission,
-      markRuntimePersistencePending: vi.fn(),
-      markRuntimePersisted: vi.fn(),
-      markBlocked: vi.fn(),
-      hasPersisted: () => true,
-      isBlocked: () => false,
-      hasRuntimePersistencePending: () => false,
-      waitForRuntimePersistence: vi.fn(async () => {}),
-      persistApproved: vi.fn(async () => undefined),
-      persistBlocked: vi.fn(async () => undefined),
-      persistFallback: vi.fn(async () => undefined),
-    };
+    context.params.userTurnTranscriptRecorder = recorder;
 
     await runPreparedCliAgent(context);
 
@@ -449,38 +448,12 @@ describe("runPreparedCliAgent context engine lifecycle", () => {
 
   it("uses the admitted user anchor as the terminal for transcriptless room events", async () => {
     const context = buildPreparedContext(createContextEngine());
-    const admission = {
-      agentId: "main",
-      sessionId: "openclaw-session-1",
-      sessionKey: "agent:main:main",
-      storePath: "/tmp/openclaw-cli-context-engine-test/sessions.json",
-      generation: "generation-1",
-      entryId: "room-event-user",
-      rawSeq: 1,
-      effectiveParentId: null,
-      activeMessagePosition: 0,
-      logicalTurnId: "room-event-turn",
-      role: "user" as const,
-    };
+    const { admission, recorder } = createAdmittedCliRecorder("room-event-user");
     const onContextEngineTurnCandidate = vi.fn();
     context.params.currentInboundEventKind = "room_event";
     context.params.persistAssistantTranscript = false;
     context.params.onContextEngineTurnCandidate = onContextEngineTurnCandidate;
-    context.params.userTurnTranscriptRecorder = {
-      message: undefined,
-      resolveMessage: vi.fn(async () => undefined),
-      getAdmissionReceipt: () => admission,
-      markRuntimePersistencePending: vi.fn(),
-      markRuntimePersisted: vi.fn(),
-      markBlocked: vi.fn(),
-      hasPersisted: () => true,
-      isBlocked: () => false,
-      hasRuntimePersistencePending: () => false,
-      waitForRuntimePersistence: vi.fn(async () => {}),
-      persistApproved: vi.fn(async () => undefined),
-      persistBlocked: vi.fn(async () => undefined),
-      persistFallback: vi.fn(async () => undefined),
-    };
+    context.params.userTurnTranscriptRecorder = recorder;
 
     await runPreparedCliAgent(context);
 

--- a/src/agents/cli-runner/cli-run-transcript.ts
+++ b/src/agents/cli-runner/cli-run-transcript.ts
@@ -360,32 +360,43 @@ export async function finalizeCliContextEngineTurn(params: {
   }
 
   const { params: runParams } = context;
-  const prePromptMessages = params.historyMessages.filter(isAgentMessage);
-  const turnMessages: AgentMessage[] = [];
-  if (context.contextEngineTurnPrompt) {
-    turnMessages.push(buildCliContextEngineUserMessage(context.contextEngineTurnPrompt));
-  }
-  if (params.assistantText) {
-    turnMessages.push(
-      buildCliContextEngineAssistantMessage({
-        text: params.assistantText,
-        provider: runParams.provider,
-        model: context.modelId,
-        usage: params.output.usage,
-        stopReason: resolveCliAssistantStopReason(params.output),
-      }),
-    );
-  }
+  const admission = runParams.userTurnTranscriptRecorder?.getAdmissionReceipt();
+  if (runParams.onContextEngineTurnCandidate) {
+    if (admission && params.terminalAnchor) {
+      runParams.onContextEngineTurnCandidate({
+        boundary: { admission, terminal: params.terminalAnchor },
+        sessionIdUsed: runParams.sessionId,
+        sessionKey: runParams.sessionKey,
+        sessionTarget: runParams.sessionTarget,
+        promptError: false,
+        aborted:
+          params.output.terminalInterruption !== undefined ||
+          runParams.abortSignal?.aborted === true,
+        yieldAborted: false,
+        isHeartbeat: isHeartbeatLifecycleRunKind(runParams.bootstrapContextRunKind),
+      });
+    }
+  } else {
+    const prePromptMessages = params.historyMessages.filter(isAgentMessage);
+    const turnMessages: AgentMessage[] = [];
+    if (context.contextEngineTurnPrompt) {
+      turnMessages.push(buildCliContextEngineUserMessage(context.contextEngineTurnPrompt));
+    }
+    if (params.assistantText) {
+      turnMessages.push(
+        buildCliContextEngineAssistantMessage({
+          text: params.assistantText,
+          provider: runParams.provider,
+          model: context.modelId,
+          usage: params.output.usage,
+          stopReason: resolveCliAssistantStopReason(params.output),
+        }),
+      );
+    }
 
-  const contextEngineHostSupport = buildGenericCliContextEngineHostSupport({
-    backendId: context.backendResolved.id,
-  });
-  const finalizeTurn = async (transcript: {
-    messagesSnapshot: AgentMessage[];
-    prePromptMessageCount: number;
-    sessionManager?: SessionManager;
-    withSessionManagerRewriteLock: <T>(operation: () => Promise<T> | T) => Promise<T>;
-  }) => {
+    const contextEngineHostSupport = buildGenericCliContextEngineHostSupport({
+      backendId: context.backendResolved.id,
+    });
     let deferredTurnMaintenance: Promise<void> | undefined;
     const result = await finalizeHarnessContextEngineTurn({
       contextEngine: context.contextEngine,
@@ -398,9 +409,8 @@ export async function finalizeCliContextEngineTurn(params: {
       sessionTarget: runParams.sessionTarget,
       sessionFile: runParams.sessionFile,
       isHeartbeat: isHeartbeatLifecycleRunKind(runParams.bootstrapContextRunKind),
-      messagesSnapshot: transcript.messagesSnapshot,
-      prePromptMessageCount: transcript.prePromptMessageCount,
-      sessionManager: transcript.sessionManager,
+      messagesSnapshot: [...prePromptMessages, ...turnMessages],
+      prePromptMessageCount: prePromptMessages.length,
       config: context.contextEngineConfig,
       contextEngineHostSupport,
       providerId: runParams.provider,
@@ -408,7 +418,7 @@ export async function finalizeCliContextEngineTurn(params: {
       runMaintenance: async (maintenanceParams) =>
         await runHarnessContextEngineMaintenance({
           ...maintenanceParams,
-          withSessionManagerRewriteLock: transcript.withSessionManagerRewriteLock,
+          withSessionManagerRewriteLock: async (operation) => await operation(),
           onDeferredMaintenance: (promise) => {
             deferredTurnMaintenance = promise;
           },
@@ -418,33 +428,5 @@ export async function finalizeCliContextEngineTurn(params: {
     if (result.postTurnFinalizationSucceeded && deferredTurnMaintenance) {
       context.contextEngineDeferredTurnMaintenance = deferredTurnMaintenance;
     }
-  };
-  const admission = runParams.userTurnTranscriptRecorder?.getAdmissionReceipt();
-  if (runParams.onContextEngineTurnCandidate) {
-    if (admission && params.terminalAnchor) {
-      runParams.onContextEngineTurnCandidate({
-        boundary: { admission, terminal: params.terminalAnchor },
-        sessionIdUsed: runParams.sessionId,
-        sessionKey: runParams.sessionKey,
-        sessionTarget: runParams.sessionTarget,
-        sessionFile: runParams.sessionFile,
-        promptError: false,
-        aborted:
-          params.output.terminalInterruption !== undefined ||
-          runParams.abortSignal?.aborted === true,
-        yieldAborted: false,
-        contextEngineHostSupport,
-        providerId: runParams.provider,
-        modelId: context.modelId,
-        config: context.contextEngineConfig,
-        isHeartbeat: isHeartbeatLifecycleRunKind(runParams.bootstrapContextRunKind),
-      });
-    }
-  } else {
-    await finalizeTurn({
-      messagesSnapshot: [...prePromptMessages, ...turnMessages],
-      prePromptMessageCount: prePromptMessages.length,
-      withSessionManagerRewriteLock: async (operation) => await operation(),
-    });
   }
 }

--- a/src/agents/embedded-agent-runner/compact.delegate.test.ts
+++ b/src/agents/embedded-agent-runner/compact.delegate.test.ts
@@ -1,0 +1,342 @@
+import { join } from "node:path";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  createAssistant,
+  createAssistantResultStream,
+  testModel,
+} from "../sessions/agent-session-loop-correctness.test-support.js";
+import type { ProviderConfigInput } from "../sessions/model-registry.js";
+import {
+  applyExtraParamsToAgentMock,
+  hookRunner,
+  limitHistoryTurnsMock,
+  loadCompactHooksHarness,
+  resetCompactHooksHarnessMocks,
+  resolveModelMock,
+} from "./compact.hooks.harness.js";
+
+const { requestPreparedCompaction } = vi.hoisted(() => ({
+  requestPreparedCompaction:
+    vi.fn<typeof import("@openclaw/ai/transports").requestPreparedOpenAIResponsesCompaction>(),
+}));
+vi.mock("@openclaw/ai/transports", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@openclaw/ai/transports")>()),
+  requestPreparedOpenAIResponsesCompaction: requestPreparedCompaction,
+}));
+
+let delegate: typeof import("../../context-engine/delegate.js").delegateCompactionToRuntime;
+let sessions: typeof import("../sessions/index.js");
+let accessor: typeof import("../../config/sessions/session-accessor.js");
+let databases: typeof import("../../state/openclaw-agent-db.js");
+let streamResolution: typeof import("./stream-resolution.js");
+let replay: typeof import("../openai-transport-stream.test-support.js").testing;
+let accounting: typeof import("./run/compaction-accounting-bridge.js");
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterEach(() => {
+    databases.closeOpenClawAgentDatabasesForTest();
+    cleanup();
+  }),
+);
+let workspaceDir: string;
+const model = {
+  ...testModel,
+  id: "compaction-fixture",
+  provider: "openai",
+  baseUrl: "https://api.openai.com/v1",
+  contextWindow: 128_000,
+  maxTokens: 1_024,
+};
+const summary = "The deployment checklist was reviewed. Compare the remaining options.";
+
+beforeAll(async () => {
+  // Reuse the hook harness's provider setup with the real constructor, SQLite
+  // manager, transcript guard, and both compaction owners left intact.
+  await loadCompactHooksHarness({ durableSession: true });
+  [
+    { delegateCompactionToRuntime: delegate },
+    sessions,
+    accessor,
+    databases,
+    streamResolution,
+    { testing: replay },
+    accounting,
+  ] = await Promise.all([
+    import("../../context-engine/delegate.js"),
+    import("../sessions/index.js"),
+    import("../../config/sessions/session-accessor.js"),
+    import("../../state/openclaw-agent-db.js"),
+    import("./stream-resolution.js"),
+    import("../openai-transport-stream.test-support.js"),
+    import("./run/compaction-accounting-bridge.js"),
+  ]);
+});
+
+beforeEach(() => {
+  workspaceDir = tempDirs.make("openclaw-compaction-delegate-");
+  resetCompactHooksHarnessMocks(workspaceDir);
+  requestPreparedCompaction.mockReset();
+  limitHistoryTurnsMock.mockImplementation((messages) => messages);
+  hookRunner.hasHooks.mockImplementation(
+    (name) => name === "before_compaction" || name === "after_compaction",
+  );
+});
+
+async function createFixture(operation: "summary" | "endpoint", globalAlias = false) {
+  const target = {
+    agentId: "main",
+    sessionId: "compaction-session",
+    sessionKey: globalAlias ? "global" : "agent:main:compaction-session",
+    storePath: join(workspaceDir, "alternate", "openclaw-agent.sqlite"),
+  };
+  const configuredStore = join(workspaceDir, "configured", "openclaw-agent.sqlite");
+  await accessor.upsertSessionEntryCore(target, { sessionId: target.sessionId, updatedAt: 1 });
+  // The same physical id in another store must not redirect partial-target resolution.
+  const decoy = { ...target, storePath: configuredStore };
+  await accessor.upsertSessionEntryCore(decoy, { sessionId: target.sessionId, updatedAt: 1 });
+  const decoyManager = sessions.SessionManager.open(decoy, workspaceDir);
+  decoyManager.appendMessage({ role: "user", content: "Unrelated store history", timestamp: 1 });
+  decoyManager.flushPendingPersistence();
+  const sessionManager = sessions.SessionManager.open(target, workspaceDir);
+  sessionManager.appendModelChange(model.provider, model.id);
+  sessionManager.appendThinkingLevelChange("off");
+  for (const content of [
+    "Review the deployment checklist.",
+    "Compare the remaining options.",
+    "Keep the rollout notes.",
+  ]) {
+    sessionManager.appendMessage({ role: "user", content, timestamp: 1 });
+    sessionManager.appendMessage(
+      createAssistant(model, [{ type: "text", text: `Recorded: ${content}` }]),
+    );
+  }
+  sessionManager.flushPendingPersistence();
+  const originalMessages = sessionManager.buildSessionContext().messages;
+  const originalEntries = sessionManager.getEntries();
+  const stream = vi.fn<NonNullable<ProviderConfigInput["streamSimple"]>>((activeModel) =>
+    createAssistantResultStream(createAssistant(activeModel, [{ type: "text", text: summary }])),
+  );
+  const authStorage = sessions.AuthStorage.inMemory();
+  authStorage.setRuntimeApiKey(model.provider, "test-api-key");
+  const modelRegistry = sessions.ModelRegistry.inMemory(authStorage);
+  modelRegistry.registerProvider(model.provider, { api: model.api, streamSimple: stream });
+  resolveModelMock.mockReturnValue({ model, error: null, authStorage, modelRegistry });
+  vi.mocked(streamResolution.resolveEmbeddedAgentStreamFn).mockReturnValue(stream);
+  applyExtraParamsToAgentMock.mockReturnValue({
+    effectiveExtraParams: { responsesCompactEndpoint: operation === "endpoint" },
+  });
+  requestPreparedCompaction.mockResolvedValue({
+    item: { type: "compaction", id: "cmp_fixture", encrypted_content: "opaque-fixture" },
+    output: [{ type: "compaction", id: "cmp_fixture", encrypted_content: "opaque-fixture" }],
+    historyMode: "compacted-prefix",
+    usage: { input_tokens: 1_000, output_tokens: 200 },
+    model,
+    replayMetadata: replay.buildOpenAIResponsesReasoningReplayMetadata(model, {
+      sessionId: target.sessionId,
+    }),
+  });
+  const runtimeContext = {
+    workspaceDir,
+    provider: model.provider,
+    model: model.id,
+    trigger: "manual",
+    thinkLevel: "off",
+    config: {
+      session: { store: configuredStore },
+      agents: {
+        defaults: { compaction: { mode: "default", keepRecentTokens: 1, postIndexSync: "off" } },
+      },
+    },
+  };
+  const recordUsage = vi.fn();
+  const recordCompaction = vi.fn();
+  accounting.attachCompactionAccountingRecorder(runtimeContext, { recordUsage, recordCompaction });
+  return {
+    target,
+    decoy,
+    originalEntries,
+    originalMessages,
+    runtimeContext,
+    stream,
+    recordUsage,
+    recordCompaction,
+  };
+}
+
+describe("direct compactor through the context-engine delegate", () => {
+  it.each([
+    { operation: "summary", partial: false, threadId: "thread-route" },
+    { operation: "summary", partial: true, threadId: 0 },
+    { operation: "endpoint", partial: false, threadId: 0 },
+    { operation: "endpoint", partial: true, threadId: "thread-route" },
+    { operation: "summary", partial: false, threadId: undefined },
+  ] as const)(
+    "returns durable $operation identity (partial=$partial, thread=$threadId)",
+    async ({ operation, partial, threadId }) => {
+      const fixture = await createFixture(operation, partial);
+      const { target } = fixture;
+      const sessionTarget = {
+        ...(partial ? { agentId: target.agentId, storePath: target.storePath } : target),
+        ...(threadId !== undefined ? { threadId } : {}),
+        expectedWriterRunId: "caller-private-writer",
+        expectedLifecycleRevision: "caller-private-revision",
+        unrelatedCapability: "caller-private-capability",
+      };
+      const result = await delegate({
+        sessionId: target.sessionId,
+        sessionKey: target.sessionKey,
+        sessionTarget,
+        runtimeContext: fixture.runtimeContext,
+      });
+      expect(result, JSON.stringify(result)).toMatchObject({ ok: true, compacted: true });
+      const returned = result.result?.sessionTarget;
+      expect(returned).toEqual({ ...target, ...(threadId !== undefined ? { threadId } : {}) });
+      expect(result.result).not.toHaveProperty("sessionFile");
+      if (
+        !returned?.agentId ||
+        !returned.sessionId ||
+        !returned.sessionKey ||
+        !returned.storePath
+      ) {
+        throw new Error("Compactor must return its complete resolved identity");
+      }
+      // Close the actual DB handles before observing the returned identity and history.
+      databases.closeOpenClawAgentDatabasesForTest();
+      const reopened = sessions.SessionManager.open({
+        agentId: returned.agentId,
+        sessionId: returned.sessionId,
+        sessionKey: returned.sessionKey,
+        storePath: returned.storePath,
+      });
+      expect(reopened.getSessionId()).toBe(target.sessionId);
+      expect(accessor.loadSessionEntry(target)?.sessionId).toBe(target.sessionId);
+      const messages = reopened.buildSessionContext().messages;
+      if (operation === "summary") {
+        expect(result.result?.summary).toContain(summary);
+        expect(reopened.getBranch().filter((entry) => entry.type === "compaction")).toHaveLength(1);
+        const firstKeptIndex = fixture.originalEntries.findIndex(
+          (entry) => entry.id === result.result?.firstKeptEntryId,
+        );
+        expect(firstKeptIndex).toBeGreaterThan(0);
+        const retained = fixture.originalEntries
+          .slice(firstKeptIndex)
+          .filter((entry) => entry.type === "message")
+          .map((entry) => entry.message);
+        expect(retained.length).toBeGreaterThan(0);
+        expect(messages.slice(-retained.length)).toEqual(retained);
+        for (const entry of fixture.originalEntries) {
+          expect(reopened.getEntries()).toContainEqual(entry);
+        }
+        expect(fixture.stream).toHaveBeenCalled();
+        expect(requestPreparedCompaction).not.toHaveBeenCalled();
+      } else {
+        expect(result.result?.summary).toBeUndefined();
+        expect(result.result?.details).toMatchObject({ compactionKind: "server-endpoint" });
+        expect(messages).toMatchObject(fixture.originalMessages);
+        expect(messages.at(-1)).toMatchObject({
+          providerReplay: { data: "opaque-fixture", compactedWindow: { state: "ready" } },
+        });
+        expect(requestPreparedCompaction).toHaveBeenCalledOnce();
+        expect(fixture.stream).not.toHaveBeenCalled();
+      }
+      expect(fixture.recordUsage).toHaveBeenCalled();
+      expect(fixture.recordCompaction).toHaveBeenCalledOnce();
+      expect(hookRunner.runBeforeCompaction).toHaveBeenCalledOnce();
+      expect(hookRunner.runAfterCompaction).toHaveBeenCalledOnce();
+      expect(sessions.SessionManager.open(fixture.decoy).buildSessionContext().messages).toEqual([
+        { role: "user", content: "Unrelated store history", timestamp: 1 },
+      ]);
+    },
+  );
+
+  it.each(["summary", "endpoint"] as const)(
+    "cancels %s without publishing or rewriting history",
+    async (operation) => {
+      const fixture = await createFixture(operation);
+      const started = createDeferred();
+      const stopped = createDeferred();
+      const controller = new AbortController();
+      const abortReason = new Error("caller cancelled compaction");
+      if (operation === "endpoint") {
+        requestPreparedCompaction.mockImplementationOnce(
+          async (_stream, _model, _context, options) => {
+            started.resolve();
+            return await new Promise<never>((_, reject) => {
+              options.signal?.addEventListener(
+                "abort",
+                () => {
+                  stopped.resolve();
+                  reject(abortReason);
+                },
+                { once: true },
+              );
+            });
+          },
+        );
+      } else {
+        const { createAssistantMessageEventStream } = await import("openclaw/plugin-sdk/llm");
+        fixture.stream.mockImplementationOnce((activeModel, _context, options) => {
+          const stream = createAssistantMessageEventStream();
+          started.resolve();
+          options?.signal?.addEventListener(
+            "abort",
+            () => {
+              stream.push({
+                type: "error",
+                reason: "aborted",
+                error: createAssistant(activeModel, [], "aborted"),
+              });
+              stream.end();
+              stopped.resolve();
+            },
+            { once: true },
+          );
+          return stream;
+        });
+      }
+      const pending = delegate({
+        sessionId: fixture.target.sessionId,
+        sessionKey: fixture.target.sessionKey,
+        sessionTarget: { ...fixture.target, threadId: 0 },
+        runtimeContext: fixture.runtimeContext,
+        abortSignal: controller.signal,
+      });
+      await started.promise;
+      controller.abort(abortReason);
+      const result = await pending;
+      await stopped.promise;
+      expect(result).toMatchObject({ ok: false, compacted: false });
+      expect(result.result).toBeUndefined();
+      databases.closeOpenClawAgentDatabasesForTest();
+      const reopened = sessions.SessionManager.open(fixture.target);
+      expect(reopened.getSessionId()).toBe(fixture.target.sessionId);
+      expect(reopened.getEntries()).toEqual(fixture.originalEntries);
+      expect(reopened.buildSessionContext().messages).toEqual(fixture.originalMessages);
+      expect(fixture.recordCompaction).not.toHaveBeenCalled();
+      expect(hookRunner.runAfterCompaction).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects contradictory physical identity without touching either durable transcript", async () => {
+    const fixture = await createFixture("summary");
+    await expect(
+      delegate({
+        sessionId: "contradictory-session",
+        sessionKey: fixture.target.sessionKey,
+        sessionTarget: fixture.target,
+        runtimeContext: fixture.runtimeContext,
+      }),
+    ).rejects.toThrow("conflicts with the caller session identity");
+    expect(fixture.stream).not.toHaveBeenCalled();
+    expect(resolveModelMock).not.toHaveBeenCalled();
+    expect(hookRunner.runBeforeCompaction).not.toHaveBeenCalled();
+    databases.closeOpenClawAgentDatabasesForTest();
+    expect(sessions.SessionManager.open(fixture.target).getEntries()).toEqual(
+      fixture.originalEntries,
+    );
+    expect(sessions.SessionManager.open(fixture.decoy).buildSessionContext().messages).toEqual([
+      { role: "user", content: "Unrelated store history", timestamp: 1 },
+    ]);
+  });
+});

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -29,8 +29,8 @@ type MockResolvedModel = {
     requestTimeoutMs?: number;
   };
   error: null;
-  authStorage: { setRuntimeApiKey: Mock<(provider?: string, apiKey?: string) => void> };
-  modelRegistry: Record<string, never>;
+  authStorage: Pick<import("../sessions/auth-storage.js").AuthStorage, "setRuntimeApiKey">;
+  modelRegistry: Record<string, never> | import("../sessions/model-registry.js").ModelRegistry;
 };
 type MockMemorySearchManager = {
   manager: {
@@ -651,7 +651,7 @@ export function resetCompactHooksHarnessMocks(workspaceDir: string): void {
   });
 }
 
-export async function loadCompactHooksHarness(): Promise<{
+export async function loadCompactHooksHarness(options: { durableSession?: boolean } = {}): Promise<{
   compactEmbeddedAgentSessionDirect: typeof import("./compact.js").compactEmbeddedAgentSessionDirect;
   compactEmbeddedAgentSession: typeof import("./compact.queued.js").compactEmbeddedAgentSession;
   testing: typeof import("./compact.js").testing;
@@ -659,10 +659,22 @@ export async function loadCompactHooksHarness(): Promise<{
   onInternalSessionTranscriptUpdate: typeof import("../../sessions/transcript-events.js").onInternalSessionTranscriptUpdate;
 }> {
   vi.resetModules();
+  if (options.durableSession) {
+    vi.doUnmock("./server-endpoint-compaction.js");
+    vi.doUnmock("../sessions/model-registry-runtime.js");
+    vi.doUnmock("../sessions/resource-loader.js");
+    vi.doUnmock("../sessions/index.js");
+    vi.doUnmock("../sessions/sdk.js");
+    vi.doUnmock("../session-tool-result-guard-wrapper.js");
+    vi.doUnmock("../agent-settings.js");
+    vi.doUnmock("../agent-project-settings.js");
+  }
 
-  vi.doMock("./server-endpoint-compaction.js", () => ({
-    attemptServerEndpointCompaction: attemptServerEndpointCompactionMock,
-  }));
+  if (!options.durableSession) {
+    vi.doMock("./server-endpoint-compaction.js", () => ({
+      attemptServerEndpointCompaction: attemptServerEndpointCompactionMock,
+    }));
+  }
 
   vi.doMock("../../plugins/hook-runner-global.js", () => ({
     getGlobalHookRunner: () => hookRunner,
@@ -737,9 +749,11 @@ export async function loadCompactHooksHarness(): Promise<{
     registerProviderStreamForModel: registerProviderStreamForModelMock,
   }));
 
-  vi.doMock("../sessions/model-registry-runtime.js", () => ({
-    getModelRegistryRuntime: getModelRegistryRuntimeMock,
-  }));
+  if (!options.durableSession) {
+    vi.doMock("../sessions/model-registry-runtime.js", () => ({
+      getModelRegistryRuntime: getModelRegistryRuntimeMock,
+    }));
+  }
 
   vi.doMock("../../hooks/internal-hooks.js", async () => {
     const actual = await vi.importActual<typeof import("../../hooks/internal-hooks.js")>(
@@ -751,43 +765,45 @@ export async function loadCompactHooksHarness(): Promise<{
     };
   });
 
-  vi.doMock("../sessions/resource-loader.js", () => ({
-    DefaultResourceLoader: function DefaultResourceLoader() {
-      return {
-        reload: vi.fn(async () => undefined),
-      };
-    },
-  }));
+  if (!options.durableSession) {
+    vi.doMock("../sessions/resource-loader.js", () => ({
+      DefaultResourceLoader: function DefaultResourceLoader() {
+        return {
+          reload: vi.fn(async () => undefined),
+        };
+      },
+    }));
 
-  vi.doMock("../sessions/index.js", () => ({
-    AuthStorage: function AuthStorage() {},
-    ModelRegistry: function ModelRegistry() {},
-    SessionManager: {
-      open: vi.fn(() => ({
-        buildSessionContext: vi.fn(() => ({ messages: sessionMessages })),
-      })),
-    },
-    SettingsManager: {
-      create: vi.fn(() => ({})),
-    },
-    estimateTokens: estimateTokensMock,
-    generateSummary: vi.fn(async () => "summary"),
-  }));
+    vi.doMock("../sessions/index.js", () => ({
+      AuthStorage: function AuthStorage() {},
+      ModelRegistry: function ModelRegistry() {},
+      SessionManager: {
+        open: vi.fn(() => ({
+          buildSessionContext: vi.fn(() => ({ messages: sessionMessages })),
+        })),
+      },
+      SettingsManager: {
+        create: vi.fn(() => ({})),
+      },
+      estimateTokens: estimateTokensMock,
+      generateSummary: vi.fn(async () => "summary"),
+    }));
 
-  vi.doMock("../sessions/sdk.js", () => ({
-    createAgentSessionForEmbeddedRunner: createAgentSessionMock,
-  }));
+    vi.doMock("../sessions/sdk.js", () => ({
+      createAgentSessionForEmbeddedRunner: createAgentSessionMock,
+    }));
 
-  vi.doMock("../session-tool-result-guard-wrapper.js", () => ({
-    guardSessionManager: guardSessionManagerMock,
-  }));
+    vi.doMock("../session-tool-result-guard-wrapper.js", () => ({
+      guardSessionManager: guardSessionManagerMock,
+    }));
 
-  vi.doMock("../agent-settings.js", () => ({
-    applyAgentAutoCompactionGuard: vi.fn(() => ({ supported: true, disabled: false })),
-    applyAgentCompactionSettingsFromConfig: applyAgentCompactionSettingsFromConfigMock,
-    isSilentOverflowProneModel: vi.fn(() => false),
-    resolveEffectiveCompactionMode: resolveEffectiveCompactionModeMock,
-  }));
+    vi.doMock("../agent-settings.js", () => ({
+      applyAgentAutoCompactionGuard: vi.fn(() => ({ supported: true, disabled: false })),
+      applyAgentCompactionSettingsFromConfig: applyAgentCompactionSettingsFromConfigMock,
+      isSilentOverflowProneModel: vi.fn(() => false),
+      resolveEffectiveCompactionMode: resolveEffectiveCompactionModeMock,
+    }));
+  }
 
   vi.doMock("../models-config.js", () => ({
     ensureOpenClawModelsJson: vi.fn(async () => {}),
@@ -1075,9 +1091,11 @@ export async function loadCompactHooksHarness(): Promise<{
     };
   });
 
-  vi.doMock("../agent-project-settings.js", () => ({
-    createPreparedEmbeddedAgentSettingsManager: createPreparedEmbeddedAgentSettingsManagerMock,
-  }));
+  if (!options.durableSession) {
+    vi.doMock("../agent-project-settings.js", () => ({
+      createPreparedEmbeddedAgentSettingsManager: createPreparedEmbeddedAgentSettingsManagerMock,
+    }));
+  }
 
   vi.doMock("./sandbox-info.js", () => ({
     buildEmbeddedSandboxInfo: vi.fn(() => undefined),

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -258,7 +258,16 @@ export async function compactEmbeddedAgentSessionDirect(
     agentId: runSessionTarget.agentId,
     sessionId: runSessionTarget.sessionId,
     sessionKey: runSessionTarget.sessionKey,
-    sessionTarget: runSessionTarget,
+    // SQLite resolves storage identity; the request still owns thread routing.
+    sessionTarget: {
+      agentId: runSessionTarget.agentId,
+      sessionId: runSessionTarget.sessionId,
+      sessionKey: runSessionTarget.sessionKey,
+      storePath: runSessionTarget.storePath,
+      ...(paramsBase.sessionTarget?.threadId !== undefined
+        ? { threadId: paramsBase.sessionTarget.threadId }
+        : {}),
+    },
     sessionFile: runSessionTarget.sessionKey,
   };
   const requestedAgentIds = resolveSessionAgentIds({

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -8,6 +8,7 @@ import {
 } from "@openclaw/ai/transports";
 import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
 import { captureOwnedTranscriptWriteAssertion } from "../../config/sessions/transcript-write-context.js";
+import type { ContextEngineSessionTarget } from "../../context-engine/types.js";
 import type { CapturedCompactionCheckpointSnapshot } from "../../gateway/session-compaction-checkpoints.js";
 import { resolveDiagnosticModelContentCapturePolicy } from "../../infra/diagnostic-llm-content.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -614,11 +615,21 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             assertActive,
             onHookMessages: params.onCompactionHookMessages,
           });
+          const resultSessionTarget: ContextEngineSessionTarget = {
+            agentId: sessionTarget.agentId,
+            sessionId: sessionTarget.sessionId,
+            sessionKey: sessionTarget.sessionKey,
+            storePath: sessionTarget.storePath,
+          };
+          if (params.sessionTarget?.threadId !== undefined) {
+            resultSessionTarget.threadId = params.sessionTarget.threadId;
+          }
           return {
             ok: true,
             compacted: true,
             ...(serverResult ? { compactionKind: "server-endpoint" as const } : {}),
             result: {
+              sessionTarget: resultSessionTarget,
               ...(clientResult
                 ? {
                     summary: clientResult.summary,

--- a/src/agents/embedded-agent-runner/run-entry.test.ts
+++ b/src/agents/embedded-agent-runner/run-entry.test.ts
@@ -165,7 +165,6 @@ function recordTurnAttempt(
       },
     },
     sessionIdUsed: label,
-    sessionFile: `${label}.jsonl`,
     promptError: false,
     aborted: false,
     yieldAborted: false,

--- a/src/agents/embedded-agent-runner/run/attempt-finalize.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-finalize.ts
@@ -245,57 +245,6 @@ export async function completeEmbeddedAttemptAfterTurn(
   // rewrite callback reacquires the synchronous session write boundary.
   if (activeContextEngine && !state.beforeAgentFinalizeRevisionReason) {
     const lifecycleState = input.readLifecycleState();
-    const afterTurnRuntimeContext = buildAfterTurnRuntimeContextFromUsage({
-      attempt,
-      workspaceDir: runtime.effectiveWorkspace,
-      agentDir: runtime.agentDir,
-      tokenBudget: attempt.contextTokenBudget,
-      lastCallUsage: state.lastCallUsage,
-      promptCache: state.promptCache,
-      activeAgentId: runtime.sessionAgentId,
-      contextEnginePluginId: runtime.resolveActiveContextEnginePluginId(),
-    });
-    const finalizeTurn = async (transcript: {
-      messagesSnapshot: AgentMessage[];
-      prePromptMessageCount: number;
-      sessionManager?: SessionManager;
-      withSessionManagerRewriteLock: WithOwnedTranscriptWrite;
-    }) => {
-      await finalizeHarnessContextEngineTurn({
-        contextEngine: activeContextEngine,
-        promptError: Boolean(state.promptError),
-        aborted: lifecycleState.aborted,
-        yieldAborted: state.yieldAborted,
-        sessionIdUsed,
-        sessionKey: attempt.sessionKey,
-        sessionTarget: attempt.sessionTarget,
-        sessionFile: attempt.sessionFile,
-        messagesSnapshot: transcript.messagesSnapshot,
-        prePromptMessageCount: transcript.prePromptMessageCount,
-        tokenBudget: attempt.contextTokenBudget,
-        runtimeContext: afterTurnRuntimeContext,
-        contextEngineHostSupport: OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
-        providerId: attempt.provider,
-        requestedModelId: attempt.requestedModelId,
-        modelId: attempt.modelId,
-        fallbackReason: attempt.fallbackReason,
-        degradedReason: attempt.degradedReason,
-        runMaintenance: async (contextParams) =>
-          await runContextEngineMaintenance({
-            ...contextParams,
-            contextEngine: contextParams.contextEngine as never,
-            sessionManager: contextParams.sessionManager as never,
-            withSessionManagerRewriteLock: transcript.withSessionManagerRewriteLock,
-            config: attempt.config,
-            agentId: runtime.sessionAgentId,
-            contextEngineAgentId: attempt.contextEngineAgentId,
-          }),
-        sessionManager: transcript.sessionManager,
-        config: attempt.config,
-        warn: (message) => log.warn(message),
-        isHeartbeat: isHeartbeatLifecycleRunKind(attempt.bootstrapContextRunKind),
-      });
-    };
     if (attempt.onContextEngineTurnCandidate) {
       const admission = attempt.userTurnTranscriptRecorder?.getAdmissionReceipt();
       const terminalEntryId = sessionManager.getLeafId() ?? undefined;
@@ -315,29 +264,57 @@ export async function completeEmbeddedAttemptAfterTurn(
           sessionIdUsed,
           sessionKey: attempt.sessionKey,
           sessionTarget: attempt.sessionTarget,
-          sessionFile: attempt.sessionFile,
           promptError: Boolean(state.promptError),
           aborted: lifecycleState.aborted,
           yieldAborted: state.yieldAborted,
-          tokenBudget: attempt.contextTokenBudget,
-          runtimeContext: afterTurnRuntimeContext,
-          contextEngineHostSupport: OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
-          providerId: attempt.provider,
-          requestedModelId: attempt.requestedModelId,
-          modelId: attempt.modelId,
-          fallbackReason: attempt.fallbackReason,
-          degradedReason: attempt.degradedReason,
-          config: attempt.config,
           isHeartbeat: isHeartbeatLifecycleRunKind(attempt.bootstrapContextRunKind),
         });
       }
     } else {
-      await finalizeTurn({
+      const afterTurnRuntimeContext = buildAfterTurnRuntimeContextFromUsage({
+        attempt,
+        workspaceDir: runtime.effectiveWorkspace,
+        agentDir: runtime.agentDir,
+        tokenBudget: attempt.contextTokenBudget,
+        lastCallUsage: state.lastCallUsage,
+        promptCache: state.promptCache,
+        activeAgentId: runtime.sessionAgentId,
+        contextEnginePluginId: runtime.resolveActiveContextEnginePluginId(),
+      });
+      await finalizeHarnessContextEngineTurn({
+        contextEngine: activeContextEngine,
+        promptError: Boolean(state.promptError),
+        aborted: lifecycleState.aborted,
+        yieldAborted: state.yieldAborted,
+        sessionIdUsed,
+        sessionKey: attempt.sessionKey,
+        sessionTarget: attempt.sessionTarget,
+        sessionFile: attempt.sessionFile,
         messagesSnapshot: state.messagesSnapshot,
         prePromptMessageCount:
           state.contextEngineAfterTurnCheckpoint ?? state.prePromptMessageCount,
+        tokenBudget: attempt.contextTokenBudget,
+        runtimeContext: afterTurnRuntimeContext,
+        contextEngineHostSupport: OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
+        providerId: attempt.provider,
+        requestedModelId: attempt.requestedModelId,
+        modelId: attempt.modelId,
+        fallbackReason: attempt.fallbackReason,
+        degradedReason: attempt.degradedReason,
+        runMaintenance: async (contextParams) =>
+          await runContextEngineMaintenance({
+            ...contextParams,
+            contextEngine: contextParams.contextEngine as never,
+            sessionManager: contextParams.sessionManager as never,
+            withSessionManagerRewriteLock: input.withOwnedTranscriptWrite,
+            config: attempt.config,
+            agentId: runtime.sessionAgentId,
+            contextEngineAgentId: attempt.contextEngineAgentId,
+          }),
         sessionManager,
-        withSessionManagerRewriteLock: input.withOwnedTranscriptWrite,
+        config: attempt.config,
+        warn: (message) => log.warn(message),
+        isHeartbeat: isHeartbeatLifecycleRunKind(attempt.bootstrapContextRunKind),
       });
     }
   }

--- a/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
@@ -9,6 +9,7 @@ import {
 import { createNestedToolActivity } from "../../../sessions/nested-tool-activity.js";
 import { createUserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../../state/openclaw-agent-db.js";
+import { FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE } from "../../bootstrap-files.js";
 import { SessionManager } from "../../sessions/session-manager.js";
 
 const hoisted = vi.hoisted(() => ({
@@ -303,131 +304,150 @@ describe("embedded attempt phase lifecycle state", () => {
     expect(result.messagesSnapshot).toEqual(messages);
   });
 
-  it("emits the persisted terminal boundary to the outer fallback owner", async () => {
-    const dir = tempDirs.make("openclaw-attempt-terminal-anchor-");
-    const target = {
-      agentId: "main",
-      sessionId: "session-1",
-      sessionKey: "agent:main:main",
-      storePath: path.join(dir, "sessions.json"),
-    };
-    await upsertSessionEntryCore(target, { sessionId: target.sessionId, updatedAt: 1 });
-    const userMessage = { role: "user" as const, content: "hello", timestamp: 1 };
-    const persistedUser = await appendTranscriptMessage(target, {
-      cwd: dir,
-      eventId: "user-1",
-      message: userMessage,
-      now: 1,
-    });
-    if (!persistedUser?.anchor) {
-      throw new Error("expected persisted user anchor");
-    }
-    const recorder = createUserTurnTranscriptRecorder({
-      message: userMessage,
-      target: async () => undefined,
-    });
-    recorder.markRuntimePersisted(userMessage, persistedUser.anchor);
-    const sessionManager = SessionManager.open(target, dir);
-    const terminalEntryId = sessionManager.appendMessage({
-      role: "assistant",
-      content: [{ type: "text", text: "done" }],
-      api: "openai-responses",
-      provider: "openai",
-      model: "test-model",
-      usage: {
-        input: 1,
-        output: 1,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 2,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
-      stopReason: "stop",
-      timestamp: 2,
-    });
-    const expectedTerminalAnchor = readActiveTranscriptEntryAnchor({
-      agentId: persistedUser.anchor.agentId,
-      sessionId: persistedUser.anchor.sessionId,
-      sessionKey: persistedUser.anchor.sessionKey,
-      storePath: persistedUser.anchor.storePath,
-      entryId: terminalEntryId,
-    });
-    if (!expectedTerminalAnchor) {
-      throw new Error("expected persisted terminal anchor");
-    }
-    const afterTurn = vi.fn(async () => {});
-    const maintain = vi.fn(async () => ({
-      changed: false,
-      bytesFreed: 0,
-      rewrittenEntries: 0,
-    }));
-    const onContextEngineTurnCandidate = vi.fn();
-    await completeEmbeddedAttemptAfterTurn({
-      attempt: {
-        runId: "run-1",
-        sessionId: target.sessionId,
-        sessionKey: target.sessionKey,
-        sessionTarget: target,
-        sessionFile: target.sessionKey,
-        provider: "test",
-        modelId: "model",
-        model: { api: "openai-responses" },
-        userTurnTranscriptRecorder: recorder,
-        onContextEngineTurnCandidate,
-      } as never,
-      activeContextEngine: {
-        info: { id: "test", name: "Test" },
-        assemble: vi.fn(),
-        compact: vi.fn(),
-        ingest: vi.fn(),
-        afterTurn,
-        maintain,
-      } as never,
-      activeSession: {} as never,
-      sessionManager,
-      withOwnedTranscriptWrite: async (operation) => await operation(),
-      state: {
-        promptError: null,
-        yieldAborted: false,
-        sessionIdUsed: target.sessionId,
-        messagesSnapshot: [{ role: "assistant", content: "done" }] as never,
-        prePromptMessageCount: 0,
-        contextEngineAfterTurnCheckpoint: null,
-        compactionOccurredThisAttempt: false,
-      },
-      readLifecycleState: () => ({
-        aborted: false,
-        timedOut: false,
-        idleTimedOut: false,
-        timedOutDuringCompaction: false,
-      }),
-      runtime: {
-        effectiveWorkspace: "/tmp/workspace",
-        agentDir: "/tmp/agent",
-        sessionAgentId: "main",
-        resolveActiveContextEnginePluginId: () => "test",
-        shouldRecordCompletedBootstrapTurn: false,
-        cacheTrace: null,
-        anthropicPayloadLogger: null,
-        hookAgentId: "main",
-        diagnosticTrace: { traceId: "trace-1", spanId: "span-1" } as never,
-        skillWorkshopAvailable: false,
-        hookRunner: null,
-        promptStartedAt: Date.now(),
-      },
-    });
-
-    expect(onContextEngineTurnCandidate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        boundary: {
-          admission: recorder.getAdmissionReceipt(),
-          terminal: expectedTerminalAnchor,
+  it.each(["complete", "missing admission", "missing terminal"] as const)(
+    "handles %s candidate anchors without skipping later lifecycle work",
+    async (boundary) => {
+      const dir = tempDirs.make("openclaw-attempt-terminal-anchor-");
+      const target = {
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        storePath: path.join(dir, "sessions.json"),
+      };
+      await upsertSessionEntryCore(target, { sessionId: target.sessionId, updatedAt: 1 });
+      const userMessage = { role: "user" as const, content: "hello", timestamp: 1 };
+      const persistedUser = await appendTranscriptMessage(target, {
+        cwd: dir,
+        eventId: "user-1",
+        message: userMessage,
+        now: 1,
+      });
+      if (!persistedUser?.anchor) {
+        throw new Error("expected persisted user anchor");
+      }
+      const recorder = createUserTurnTranscriptRecorder({
+        message: userMessage,
+        target: async () => undefined,
+      });
+      if (boundary !== "missing admission") {
+        recorder.markRuntimePersisted(userMessage, persistedUser.anchor);
+      }
+      const sessionManager =
+        boundary === "missing terminal"
+          ? SessionManager.inMemory(dir)
+          : SessionManager.open(target, dir);
+      const terminalEntryId = sessionManager.appendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "done" }],
+        api: "openai-responses",
+        provider: "openai",
+        model: "test-model",
+        usage: {
+          input: 1,
+          output: 1,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 2,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
         },
-      }),
-    );
-    expect(afterTurn).not.toHaveBeenCalled();
-    expect(maintain).not.toHaveBeenCalled();
-  });
+        stopReason: "stop",
+        timestamp: 2,
+      });
+      const expectedTerminalAnchor = readActiveTranscriptEntryAnchor({
+        agentId: persistedUser.anchor.agentId,
+        sessionId: persistedUser.anchor.sessionId,
+        sessionKey: persistedUser.anchor.sessionKey,
+        storePath: persistedUser.anchor.storePath,
+        entryId: terminalEntryId,
+      });
+      if (boundary === "complete" && !expectedTerminalAnchor) {
+        throw new Error("expected persisted terminal anchor");
+      }
+      const afterTurn = vi.fn(async () => {});
+      const maintain = vi.fn(async () => ({
+        changed: false,
+        bytesFreed: 0,
+        rewrittenEntries: 0,
+      }));
+      const onContextEngineTurnCandidate = vi.fn();
+      await completeEmbeddedAttemptAfterTurn({
+        attempt: {
+          runId: "run-1",
+          sessionId: target.sessionId,
+          sessionKey: target.sessionKey,
+          sessionTarget: target,
+          sessionFile: target.sessionKey,
+          provider: "test",
+          modelId: "model",
+          model: { api: "openai-responses" },
+          userTurnTranscriptRecorder: recorder,
+          onContextEngineTurnCandidate,
+        } as never,
+        activeContextEngine: {
+          info: { id: "test", name: "Test" },
+          assemble: vi.fn(),
+          compact: vi.fn(),
+          ingest: vi.fn(),
+          afterTurn,
+          maintain,
+        } as never,
+        activeSession: {} as never,
+        sessionManager,
+        withOwnedTranscriptWrite: async (operation) => await operation(),
+        state: {
+          promptError: null,
+          yieldAborted: false,
+          sessionIdUsed: target.sessionId,
+          messagesSnapshot: [{ role: "assistant", content: "done" }] as never,
+          prePromptMessageCount: 0,
+          contextEngineAfterTurnCheckpoint: null,
+          compactionOccurredThisAttempt: false,
+        },
+        readLifecycleState: () => ({
+          aborted: false,
+          timedOut: false,
+          idleTimedOut: false,
+          timedOutDuringCompaction: false,
+        }),
+        runtime: {
+          effectiveWorkspace: "/tmp/workspace",
+          agentDir: "/tmp/agent",
+          sessionAgentId: "main",
+          resolveActiveContextEnginePluginId: () => "test",
+          shouldRecordCompletedBootstrapTurn: true,
+          cacheTrace: null,
+          anthropicPayloadLogger: null,
+          hookAgentId: "main",
+          diagnosticTrace: { traceId: "trace-1", spanId: "span-1" } as never,
+          skillWorkshopAvailable: false,
+          hookRunner: null,
+          promptStartedAt: Date.now(),
+        },
+      });
+
+      if (boundary === "complete") {
+        expect(onContextEngineTurnCandidate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            boundary: {
+              admission: recorder.getAdmissionReceipt(),
+              terminal: expectedTerminalAnchor,
+            },
+          }),
+        );
+      } else {
+        expect(onContextEngineTurnCandidate).not.toHaveBeenCalled();
+      }
+      expect(sessionManager.getEntries()).toContainEqual(
+        expect.objectContaining({
+          type: "custom",
+          customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
+        }),
+      );
+      expect(hoisted.runAgentEndSideEffects).toHaveBeenCalledOnce();
+      expect(afterTurn).not.toHaveBeenCalled();
+      expect(maintain).not.toHaveBeenCalled();
+    },
+  );
 
   it("emits an abort-classified agent_end event when a teardown error races the abort", async () => {
     const abortError = Object.assign(new Error("This operation was aborted"), {

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -7,6 +7,7 @@ import type {
   SessionContextBudgetStatus,
   SessionSystemPromptReport,
 } from "../../config/sessions/types.js";
+import type { ContextEngineSessionTarget } from "../../context-engine/types.js";
 import type { DiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
 import type { AcceptedSessionSpawn } from "../accepted-session-spawn.js";
 import type { AgentRunTerminalReceipt } from "../agent-run-terminal-receipt.js";
@@ -292,6 +293,7 @@ export type EmbeddedAgentCompactResult = {
   result?: {
     /** Identifies summaryless provider compaction in RPC and UI consumers. */
     kind?: "server-endpoint";
+    sessionTarget?: ContextEngineSessionTarget;
     /** Server-endpoint compaction has no transcript summary or first-kept entry. */
     summary?: string;
     firstKeptEntryId?: string;

--- a/src/agents/harness/context-engine-turn-attempt.test.ts
+++ b/src/agents/harness/context-engine-turn-attempt.test.ts
@@ -123,7 +123,6 @@ async function createAcceptedTurnFixture(params: {
       sessionIdUsed: target.sessionId,
       sessionKey: target.sessionKey,
       sessionTarget: target,
-      sessionFile: `sqlite://${target.sessionId}`,
       promptError: false,
       aborted: false,
       yieldAborted: false,
@@ -158,7 +157,6 @@ describe("accepted context-engine turn finalization", () => {
       },
       sessionIdUsed: admission.sessionId,
       sessionKey: admission.sessionKey,
-      sessionFile: admission.storePath,
       promptError: false,
       aborted: false,
       yieldAborted: false,
@@ -282,7 +280,6 @@ describe("accepted context-engine turn finalization", () => {
       sessionIdUsed: target.sessionId,
       sessionKey: target.sessionKey,
       sessionTarget: target,
-      sessionFile: "sqlite://accepted-turn",
       promptError: false,
       aborted: false,
       yieldAborted: false,
@@ -415,30 +412,62 @@ describe("accepted context-engine turn finalization", () => {
       ),
     ).toMatchObject({ state: "blocked", failure: "non-descendant" });
 
-    const abortedAdmission = {
-      ...admission,
-      logicalTurnId: "logical-turn-3",
-    };
-    enqueueContextEngineTurnIntent({
-      admission: abortedAdmission,
-      database,
-      engineId: "test",
-      isHeartbeat: false,
+    for (const flag of ["aborted", "promptError", "yieldAborted"] as const) {
+      const rejectedAdmission = { ...admission, logicalTurnId: `logical-turn-${flag}` };
+      enqueueContextEngineTurnIntent({
+        admission: rejectedAdmission,
+        database,
+        engineId: "test",
+        isHeartbeat: false,
+      });
+      await finalizeAcceptedContextEngineTurn({
+        facts: {
+          ...baseFacts,
+          [flag]: true,
+          boundary: { ...baseFacts.boundary, admission: rejectedAdmission },
+        },
+        lease,
+        warn,
+      });
+      expect(commitTurn, flag).toHaveBeenCalledOnce();
+      expect(
+        database.db
+          .prepare("SELECT 1 FROM context_engine_turn_outbox WHERE advancement_key = ?")
+          .get(rejectedAdmission.logicalTurnId),
+      ).toBeUndefined();
+    }
+  });
+
+  it.each([
+    { name: "physical session", change: { sessionIdUsed: "other-session" } },
+    { name: "caller key", change: { sessionKey: "other-key" } },
+    { name: "target agent", change: { sessionTarget: { agentId: "other-agent" } } },
+    { name: "target session", change: { sessionTarget: { sessionId: "other-session" } } },
+    { name: "target key", change: { sessionTarget: { sessionKey: "other-key" } } },
+    { name: "terminal session", terminal: { sessionId: "other-session" } },
+    { name: "terminal key", terminal: { sessionKey: "other-key" } },
+    { name: "terminal agent", terminal: { agentId: "other-agent" } },
+    { name: "terminal store", terminal: { storePath: "other-store" } },
+  ])("does not commit a candidate with mismatched $name", async ({ change, terminal }) => {
+    const { facts } = await createAcceptedTurnFixture({
+      answer: "answer",
+      logicalTurnId: "mismatched-turn",
+      prefix: [],
+      sessionId: "physical-session",
     });
+    const { commitTurn, lease } = createDurableLease();
+    const warn = vi.fn();
     await finalizeAcceptedContextEngineTurn({
       facts: {
-        ...baseFacts,
-        aborted: true,
-        boundary: { ...baseFacts.boundary, admission: abortedAdmission },
+        ...facts,
+        ...change,
+        boundary: { ...facts.boundary, terminal: { ...facts.boundary.terminal, ...terminal } },
       },
       lease,
       warn,
     });
-    expect(
-      database.db
-        .prepare("SELECT 1 FROM context_engine_turn_outbox WHERE advancement_key = ?")
-        .get(abortedAdmission.logicalTurnId),
-    ).toBeUndefined();
+    expect(commitTurn).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("target changed after admission"));
   });
 
   it("commits a small accepted turn when the historical prefix exceeds the accepted-turn cap", async () => {

--- a/src/agents/harness/context-engine-turn-attempt.ts
+++ b/src/agents/harness/context-engine-turn-attempt.ts
@@ -3,16 +3,8 @@ import {
   resolveSessionTranscriptDatabasePath,
   type TranscriptTurnBoundary,
 } from "../../config/sessions/session-accessor.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import {
-  supportsContextEngineDurableTurnAdvancement,
-  type ContextEngineHostSupport,
-} from "../../context-engine/host-compat.js";
-import type {
-  ContextEngineRuntimeContext,
-  ContextEngineRuntimeSettings,
-  ContextEngineSessionTarget,
-} from "../../context-engine/types.js";
+import { supportsContextEngineDurableTurnAdvancement } from "../../context-engine/host-compat.js";
+import type { ContextEngineSessionTarget } from "../../context-engine/types.js";
 import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.types.js";
 import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import type { ContextEngineLogicalTurnLease } from "./context-engine-logical-turn.js";
@@ -35,23 +27,9 @@ export type ContextEngineTurnAttemptFacts = {
   sessionIdUsed: string;
   sessionKey?: string;
   sessionTarget?: ContextEngineSessionTarget;
-  sessionFile: string;
   promptError: boolean;
   aborted: boolean;
   yieldAborted: boolean;
-  tokenBudget?: number;
-  runtimeContext?: ContextEngineRuntimeContext;
-  runtimeSettings?: ContextEngineRuntimeSettings;
-  contextEngineHostSupport?: ContextEngineHostSupport;
-  harnessId?: string | null;
-  runtimeId?: string | null;
-  providerId?: string | null;
-  requestedModelId?: string | null;
-  modelId?: string | null;
-  maxOutputTokens?: number | null;
-  fallbackReason?: string | null;
-  degradedReason?: string | null;
-  config?: OpenClawConfig;
   isHeartbeat?: boolean;
 };
 

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -889,9 +889,9 @@ describe("runAgentHarnessAttempt", () => {
     ]);
   });
 
-  it.each(["heartbeat"] as const)(
-    "records %s classification on the host-owned turn candidate",
-    async (bootstrapContextRunKind) => {
+  it.each(["complete", "missing admission", "missing terminal"] as const)(
+    "records native terminal facts only with complete anchors: %s",
+    async (boundary) => {
       const admission = {
         ...createTranscriptAnchor("user-1", 1, 0),
         logicalTurnId: "heartbeat-turn",
@@ -906,7 +906,7 @@ describe("runAgentHarnessAttempt", () => {
           supports: () => ({ supported: true, priority: 100 }),
           runAttempt: async () => ({
             ...createAttemptResult("session-1"),
-            contextEngineTerminalAnchor: terminal,
+            contextEngineTerminalAnchor: boundary === "missing terminal" ? undefined : terminal,
           }),
         },
         { ownerPluginId: "codex" },
@@ -920,22 +920,26 @@ describe("runAgentHarnessAttempt", () => {
         sessionKey: admission.sessionKey,
         storePath: admission.storePath,
       };
-      params.bootstrapContextRunKind = bootstrapContextRunKind;
-      params.userTurnTranscriptRecorder = createTranscriptRecorder(admission);
+      params.bootstrapContextRunKind = "heartbeat";
+      params.userTurnTranscriptRecorder =
+        boundary === "missing admission" ? undefined : createTranscriptRecorder(admission);
       params.onContextEngineTurnCandidate = onContextEngineTurnCandidate;
 
       await runAgentHarnessAttempt(params);
 
-      expect(onContextEngineTurnCandidate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          boundary: { admission, terminal },
-          harnessId: "codex",
-          isHeartbeat: true,
-          promptError: false,
-          aborted: false,
-          yieldAborted: false,
-        }),
-      );
+      if (boundary === "complete") {
+        expect(onContextEngineTurnCandidate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            boundary: { admission, terminal },
+            isHeartbeat: true,
+            promptError: false,
+            aborted: false,
+            yieldAborted: false,
+          }),
+        );
+      } else {
+        expect(onContextEngineTurnCandidate).not.toHaveBeenCalled();
+      }
     },
   );
 

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -496,7 +496,6 @@ async function runSelectedAgentHarnessAttempt(
       sessionIdUsed: result.sessionIdUsed,
       sessionKey: internalParams.sessionKey,
       sessionTarget: internalParams.sessionTarget,
-      sessionFile: result.sessionFileUsed ?? internalParams.sessionFile,
       promptError: result.terminal.kind === "failed",
       aborted:
         result.terminal.kind === "aborted" ||
@@ -506,19 +505,6 @@ async function runSelectedAgentHarnessAttempt(
       yieldAborted:
         result.terminal.kind === "aborted" && result.terminal.source === "yield_cleanup",
       isHeartbeat: isHeartbeatLifecycleRunKind(internalParams.bootstrapContextRunKind),
-      tokenBudget: internalParams.contextTokenBudget,
-      contextEngineHostSupport: {
-        id: `agent-harness:${harness.id}`,
-        label: `agent harness "${harness.id}"`,
-        capabilities: harness.contextEngineHostCapabilities ?? [],
-      },
-      harnessId: harness.id,
-      providerId: internalParams.provider,
-      requestedModelId: internalParams.requestedModelId,
-      modelId: internalParams.modelId,
-      fallbackReason: internalParams.fallbackReason,
-      degradedReason: internalParams.degradedReason,
-      config: internalParams.config,
     });
   }
   const { contextEngineTerminalAnchor: _contextEngineTerminalAnchor, ...publicResult } = result;

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -1,14 +1,10 @@
 // Context engine tests cover context extraction and prompt context assembly.
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createContextEngineLogicalTurnLease,
   selectContextEngineForTranscriptHost,
 } from "../agents/harness/context-engine-logical-turn.js";
-import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
 import { SessionTranscriptReadFenceError } from "../config/sessions/session-transcript-read-fence.js";
 import type { MemoryCitationsMode } from "../config/types.memory.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -24,7 +20,6 @@ import {
   withPluginRegistrationContext,
 } from "../plugins/runtime.js";
 import type { UserTurnTranscriptAdmissionReceipt } from "../sessions/user-turn-transcript.types.js";
-import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 // ---------------------------------------------------------------------------
 // We dynamically import the registry so we can get a fresh module per test
 // group when needed.  For most groups we use the shared singleton directly.
@@ -76,7 +71,7 @@ vi.mock("../agents/embedded-agent-runner/compact.runtime.js", () => ({
   compactEmbeddedAgentSessionOnDemand: compactEmbeddedAgentSessionOnDemandMock,
 }));
 
-function installCompactRuntimeSpy() {
+function installCompactRuntimeSpy(sessionTarget?: ContextEngineSessionTarget) {
   return compactEmbeddedAgentSessionOnDemandMock.mockResolvedValue({
     ok: true,
     compacted: false,
@@ -87,6 +82,7 @@ function installCompactRuntimeSpy() {
       tokensBefore: 0,
       tokensAfter: 0,
       details: undefined,
+      ...(sessionTarget ? { sessionTarget } : {}),
     },
   });
 }
@@ -280,13 +276,13 @@ describe("Engine contract tests", () => {
   });
 
   it("delegateCompactionToRuntime reuses the legacy runtime bridge", async () => {
-    const compactRuntimeSpy = installCompactRuntimeSpy();
     const sessionTarget = {
       agentId: "main",
       sessionId: "s2",
       sessionKey: "agent:main:s2",
       storePath: "/tmp/openclaw-agent.sqlite",
     };
+    const compactRuntimeSpy = installCompactRuntimeSpy(sessionTarget);
     const runtimeContext = {
       workspaceDir: "/tmp/workspace",
       currentTokenCount: 12345,
@@ -324,97 +320,6 @@ describe("Engine contract tests", () => {
     });
   });
 
-  it("delegateCompactionToRuntime returns successor sessionTarget without sessionFile", async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "context-successor-target-"));
-    const storePath = path.join(root, "openclaw-agent.sqlite");
-    try {
-      compactEmbeddedAgentSessionOnDemandMock.mockResolvedValueOnce({
-        ok: true,
-        compacted: true,
-        reason: undefined,
-        result: {
-          summary: "summary",
-          firstKeptEntryId: "entry-1",
-          tokensBefore: 100,
-          tokensAfter: 40,
-          details: undefined,
-          sessionId: "s3-successor",
-          sessionFile: `sqlite:main:s3-successor:${storePath}`,
-        },
-      });
-
-      const result = await delegateCompactionToRuntime({
-        sessionId: "s3",
-        sessionKey: "agent:main:s3",
-        tokenBudget: 4096,
-        runtimeContext: {
-          workspaceDir: "/tmp/workspace",
-        },
-      });
-
-      expect(result.result).toMatchObject({
-        sessionId: "s3-successor",
-        sessionTarget: {
-          agentId: "main",
-          sessionId: "s3-successor",
-          sessionKey: "agent:main:s3",
-          storePath,
-        },
-      });
-      expect(result.result).not.toHaveProperty("sessionFile");
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      fs.rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  it("allows the caller key to rebind to a legacy successor session", async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "context-successor-"));
-    const storePath = path.join(root, "agents", "main", "sessions", "sessions.json");
-    const sessionKey = "agent:main:successor";
-    try {
-      await upsertSessionEntryCore(
-        { agentId: "main", sessionKey, storePath },
-        { sessionId: "before-compaction", updatedAt: 1 },
-      );
-      await upsertSessionEntryCore(
-        { agentId: "main", sessionKey: "agent:main:aaa-successor-alias", storePath },
-        { sessionId: "after-compaction", updatedAt: 2 },
-      );
-      compactEmbeddedAgentSessionOnDemandMock.mockResolvedValueOnce({
-        ok: true,
-        compacted: true,
-        reason: undefined,
-        result: {
-          summary: "summary",
-          firstKeptEntryId: "entry-1",
-          tokensBefore: 100,
-          tokensAfter: 40,
-          details: undefined,
-          sessionId: "after-compaction",
-          sessionFile: `sqlite:main:after-compaction:${storePath}`,
-        },
-      });
-
-      const result = await delegateCompactionToRuntime({
-        agentId: "main",
-        sessionId: "before-compaction",
-        sessionKey,
-        tokenBudget: 4096,
-      });
-
-      expect(result.result?.sessionTarget).toMatchObject({
-        agentId: "main",
-        sessionId: "after-compaction",
-        sessionKey,
-        storePath,
-      });
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      fs.rmSync(root, { recursive: true, force: true });
-    }
-  });
-
   it("rejects a structured successor key from another agent", async () => {
     installCompactRuntimeSpy();
 
@@ -431,50 +336,7 @@ describe("Engine contract tests", () => {
         tokenBudget: 4096,
       }),
     ).rejects.toThrow("successor target conflicts with the caller session identity");
-  });
-
-  it("rejects a successor marker that changes the caller store", async () => {
-    compactEmbeddedAgentSessionOnDemandMock.mockResolvedValueOnce({
-      ok: true,
-      compacted: true,
-      result: {
-        tokensBefore: 100,
-        sessionId: "store-redirect-successor",
-        sessionFile: "sqlite:main:store-redirect-successor:/tmp/other.sqlite",
-      },
-    });
-
-    await expect(
-      delegateCompactionToRuntime({
-        sessionId: "store-redirect-source",
-        sessionKey: "agent:main:store-redirect",
-        sessionTarget: {
-          agentId: "main",
-          sessionId: "store-redirect-source",
-          sessionKey: "agent:main:store-redirect",
-          storePath: "/tmp/caller.sqlite",
-        },
-      }),
-    ).rejects.toThrow("successor target conflicts with the caller session identity");
-  });
-
-  it("rejects contradictory marker and top-level successor identities", async () => {
-    compactEmbeddedAgentSessionOnDemandMock.mockResolvedValueOnce({
-      ok: true,
-      compacted: true,
-      result: {
-        tokensBefore: 100,
-        sessionId: "top-level-successor",
-        sessionFile: "sqlite:main:marker-successor:/tmp/openclaw-agent.sqlite",
-      },
-    });
-
-    await expect(
-      delegateCompactionToRuntime({
-        sessionId: "source-session",
-        sessionKey: "agent:main:successor-conflict",
-      }),
-    ).rejects.toThrow("successor identity is inconsistent");
+    expect(compactEmbeddedAgentSessionOnDemandMock).not.toHaveBeenCalled();
   });
 
   it("rejects an internally consistent successor for another caller agent", async () => {
@@ -493,32 +355,115 @@ describe("Engine contract tests", () => {
         tokenBudget: 4096,
       }),
     ).rejects.toThrow("successor target conflicts with the caller session identity");
+    expect(compactEmbeddedAgentSessionOnDemandMock).not.toHaveBeenCalled();
   });
 
-  it("rejects a legacy successor marker for another caller agent", async () => {
-    compactEmbeddedAgentSessionOnDemandMock.mockResolvedValueOnce({
-      ok: true,
-      compacted: true,
-      reason: undefined,
-      result: {
-        summary: "summary",
-        firstKeptEntryId: "entry-1",
-        tokensBefore: 100,
-        tokensAfter: 40,
-        details: undefined,
-        sessionId: "worker-successor",
-        sessionFile: "sqlite:worker:worker-successor:/tmp/worker-sessions.json",
+  it.each([
+    { name: "caller agent", agentId: "worker" },
+    { name: "physical session", sessionId: "another-session" },
+    { name: "caller key", sessionKey: "agent:main:another-key" },
+    {
+      name: "runtime fallback agent",
+      agentId: undefined,
+      runtimeContext: { agentId: "worker" },
+    },
+    {
+      name: "runtime fallback key",
+      sessionKey: undefined,
+      runtimeContext: { sessionKey: "agent:main:another-key" },
+    },
+    {
+      name: "runtime fallback target",
+      sessionTarget: undefined,
+      runtimeContext: { sessionTarget: { sessionId: "another-session" } },
+    },
+    {
+      name: "target-only parsed key",
+      agentId: undefined,
+      sessionKey: undefined,
+      sessionTarget: { agentId: "worker", sessionKey: "agent:main:session" },
+    },
+    {
+      name: "agent and key without target",
+      agentId: "worker",
+      sessionTarget: undefined,
+    },
+  ])(
+    "rejects $name before a backend with no nested result can run",
+    async ({ name: _name, ...input }) => {
+      compactEmbeddedAgentSessionOnDemandMock.mockResolvedValue({ ok: true, compacted: true });
+      await expect(
+        delegateCompactionToRuntime({
+          agentId: "main",
+          sessionId: "session",
+          // @ts-expect-error Exercise JavaScript callers that omit the public contract's required key.
+          sessionKey: "agent:main:session",
+          sessionTarget: {
+            agentId: "main",
+            sessionId: "session",
+            sessionKey: "agent:main:session",
+          },
+          ...input,
+        }),
+      ).rejects.toThrow(/conflicts with/);
+      expect(compactEmbeddedAgentSessionOnDemandMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([false, true])(
+    "selects inputs before normalized comparisons (runtime fallback=%s)",
+    async (runtimeFallback) => {
+      const sessionTarget = {
+        agentId: " main ",
+        sessionId: " session ",
+        sessionKey: " agent:main:session ",
+      };
+      const runtimeContext = {
+        agentId: runtimeFallback ? "main" : "ignored",
+        sessionId: "ignored",
+        sessionKey: runtimeFallback ? "agent:main:session" : "agent:ignored:ignored",
+        sessionTarget: runtimeFallback ? sessionTarget : { agentId: "ignored" },
+      };
+      compactEmbeddedAgentSessionOnDemandMock.mockResolvedValue({ ok: true, compacted: true });
+      // @ts-expect-error Exercise JavaScript callers that supply identity only through runtimeContext.
+      const result = await delegateCompactionToRuntime({
+        sessionId: "session",
+        ...(runtimeFallback
+          ? {}
+          : { agentId: "main", sessionKey: "agent:main:session", sessionTarget }),
+        runtimeContext,
+      });
+      expect(result).toEqual({ ok: true, compacted: true, reason: undefined, result: undefined });
+      expect(requireCompactRuntimeParams(0)).toMatchObject({
+        agentId: "main",
+        sessionId: "session",
+        sessionKey: "agent:main:session",
+        sessionTarget,
+      });
+      expect(requireCompactRuntimeParams(0).contextEngineRuntimeContext).toBe(runtimeContext);
+    },
+  );
+
+  it("does not restore runtime identity over explicitly empty top-level inputs", async () => {
+    compactEmbeddedAgentSessionOnDemandMock.mockResolvedValue({ ok: true, compacted: false });
+    await delegateCompactionToRuntime({
+      agentId: "",
+      sessionId: "session",
+      sessionKey: "",
+      sessionTarget: {},
+      runtimeContext: {
+        agentId: "worker",
+        sessionId: "other-session",
+        sessionKey: "agent:worker:other",
+        sessionTarget: { agentId: "worker", sessionId: "other-session" },
       },
     });
-
-    await expect(
-      delegateCompactionToRuntime({
-        agentId: "main",
-        sessionId: "main-session",
-        sessionKey: "global",
-        tokenBudget: 4096,
-      }),
-    ).rejects.toThrow("successor target conflicts with the caller session identity");
+    expect(requireCompactRuntimeParams(0)).toMatchObject({
+      agentId: "",
+      sessionId: "session",
+      sessionKey: "",
+      sessionTarget: {},
+    });
   });
 
   it("delegateCompactionToRuntime forwards the caller abortSignal to the runtime (#89868)", async () => {

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -40,6 +40,7 @@ import {
   registerContextEngineInRegistry,
   resolveContextEngine,
   resolveContextEngineOwnerPluginId,
+  resolveLogicalTurnContextEngines,
 } from "./registry.js";
 import {
   captureContextEngineRegistryStateForTests,
@@ -140,6 +141,45 @@ let uniqueEngineIdCounter = 0;
 function uniqueEngineId(prefix: string): string {
   uniqueEngineIdCounter += 1;
   return `${prefix}-${uniqueEngineIdCounter}`;
+}
+
+async function withCompactionDelegateFixture(
+  acceptSessionKey: boolean,
+  run: (engine: ContextEngine) => Promise<void>,
+) {
+  registerLegacyContextEngine();
+  const engineId = uniqueEngineId("compaction-projection");
+  const compact = vi.fn<ContextEngine["compact"]>(delegateCompactionToRuntime);
+  registerTestContextEngine(engineId, () => ({
+    info: {
+      id: engineId,
+      name: "Compaction projection",
+      acceptedHostParams: acceptSessionKey
+        ? ["sessionKey", "runtimeContext", "sessionTarget"]
+        : ["runtimeContext", "sessionTarget"],
+    },
+    async ingest() {
+      return { ingested: false };
+    },
+    async assemble({ messages }) {
+      return { messages, estimatedTokens: 0 };
+    },
+    compact,
+  }));
+  const resolution = await resolveLogicalTurnContextEngines(configWithSlot(engineId));
+  try {
+    await run(resolution.configured.engine);
+    expect(compact).toHaveBeenCalledOnce();
+    if (!acceptSessionKey) {
+      // The registry, not an invalid typed call, owns host-field omission.
+      expect(compact.mock.calls[0]?.[0]).not.toHaveProperty("sessionKey");
+    }
+  } finally {
+    await Promise.allSettled([
+      resolution.configured.engine.dispose?.(),
+      resolution.fallback.engine.dispose?.(),
+    ]);
+  }
 }
 
 function registerPromptTrackingEngine(engineId: string) {
@@ -369,7 +409,7 @@ describe("Engine contract tests", () => {
     },
     {
       name: "runtime fallback key",
-      sessionKey: undefined,
+      projectSessionKey: true,
       runtimeContext: { sessionKey: "agent:main:another-key" },
     },
     {
@@ -380,7 +420,7 @@ describe("Engine contract tests", () => {
     {
       name: "target-only parsed key",
       agentId: undefined,
-      sessionKey: undefined,
+      projectSessionKey: true,
       sessionTarget: { agentId: "worker", sessionKey: "agent:main:session" },
     },
     {
@@ -390,23 +430,24 @@ describe("Engine contract tests", () => {
     },
   ])(
     "rejects $name before a backend with no nested result can run",
-    async ({ name: _name, ...input }) => {
+    async ({ name: _name, projectSessionKey, ...input }) => {
       compactEmbeddedAgentSessionOnDemandMock.mockResolvedValue({ ok: true, compacted: true });
-      await expect(
-        delegateCompactionToRuntime({
-          agentId: "main",
-          sessionId: "session",
-          // @ts-expect-error Exercise JavaScript callers that omit the public contract's required key.
-          sessionKey: "agent:main:session",
-          sessionTarget: {
+      await withCompactionDelegateFixture(!projectSessionKey, async (engine) => {
+        await expect(
+          engine.compact({
             agentId: "main",
             sessionId: "session",
             sessionKey: "agent:main:session",
-          },
-          ...input,
-        }),
-      ).rejects.toThrow(/conflicts with/);
-      expect(compactEmbeddedAgentSessionOnDemandMock).not.toHaveBeenCalled();
+            sessionTarget: {
+              agentId: "main",
+              sessionId: "session",
+              sessionKey: "agent:main:session",
+            },
+            ...input,
+          }),
+        ).rejects.toThrow(/conflicts with/);
+        expect(compactEmbeddedAgentSessionOnDemandMock).not.toHaveBeenCalled();
+      });
     },
   );
 
@@ -425,22 +466,22 @@ describe("Engine contract tests", () => {
         sessionTarget: runtimeFallback ? sessionTarget : { agentId: "ignored" },
       };
       compactEmbeddedAgentSessionOnDemandMock.mockResolvedValue({ ok: true, compacted: true });
-      // @ts-expect-error Exercise JavaScript callers that supply identity only through runtimeContext.
-      const result = await delegateCompactionToRuntime({
-        sessionId: "session",
-        ...(runtimeFallback
-          ? {}
-          : { agentId: "main", sessionKey: "agent:main:session", sessionTarget }),
-        runtimeContext,
+      await withCompactionDelegateFixture(!runtimeFallback, async (engine) => {
+        const result = await engine.compact({
+          sessionId: "session",
+          sessionKey: "agent:main:session",
+          ...(runtimeFallback ? {} : { agentId: "main", sessionTarget }),
+          runtimeContext,
+        });
+        expect(result).toEqual({ ok: true, compacted: true, reason: undefined, result: undefined });
+        expect(requireCompactRuntimeParams(0)).toMatchObject({
+          agentId: "main",
+          sessionId: "session",
+          sessionKey: "agent:main:session",
+          sessionTarget,
+        });
+        expect(requireCompactRuntimeParams(0).contextEngineRuntimeContext).toBe(runtimeContext);
       });
-      expect(result).toEqual({ ok: true, compacted: true, reason: undefined, result: undefined });
-      expect(requireCompactRuntimeParams(0)).toMatchObject({
-        agentId: "main",
-        sessionId: "session",
-        sessionKey: "agent:main:session",
-        sessionTarget,
-      });
-      expect(requireCompactRuntimeParams(0).contextEngineRuntimeContext).toBe(runtimeContext);
     },
   );
 

--- a/src/context-engine/delegate.ts
+++ b/src/context-engine/delegate.ts
@@ -1,9 +1,6 @@
 // Context-engine delegates bridge custom engines to built-in compaction and memory prompt paths.
-import path from "node:path";
 import { normalizeStructuredPromptSection } from "@openclaw/ai/internal/shared";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { parseSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
-import { listSessionEntriesCore, loadSessionEntry } from "../config/sessions/session-accessor.js";
 import {
   buildMemoryPromptSection,
   getActivePreparedMemoryPromptSection,
@@ -12,7 +9,6 @@ import {
   type PreparedMemoryPromptSection,
 } from "../plugins/memory-state.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
-import { resolvePreferredSessionKeyForSessionIdMatches } from "../sessions/session-id-resolution.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import {
   isRuntimeCompactionDelegate,
@@ -29,22 +25,17 @@ const loadCompactRuntime = createLazyRuntimeModule(
   () => import("../agents/embedded-agent-runner/compact.runtime.js"),
 );
 
-function buildCompactionResultSessionTarget(params: {
+function assertCompactionSessionIdentity(params: {
   agentId?: string;
-  callerSessionId?: string;
-  callerSessionTarget?: ContextEngineSessionTarget;
-  sessionFile?: string;
-  sessionId?: string;
+  sessionId: string;
   sessionKey?: string;
-}): ContextEngineSessionTarget | undefined {
-  const sessionFile = normalizeOptionalString(params.sessionFile);
-  const marker = parseSqliteSessionFileMarker(sessionFile);
-  const targetAgentId = normalizeOptionalString(params.callerSessionTarget?.agentId);
-  const targetSessionId = normalizeOptionalString(params.callerSessionTarget?.sessionId);
-  const targetSessionKey = normalizeOptionalString(params.callerSessionTarget?.sessionKey);
-  const targetStorePath = normalizeOptionalString(params.callerSessionTarget?.storePath);
+  sessionTarget?: ContextEngineSessionTarget;
+}): void {
+  const targetAgentId = normalizeOptionalString(params.sessionTarget?.agentId);
+  const targetSessionId = normalizeOptionalString(params.sessionTarget?.sessionId);
+  const targetSessionKey = normalizeOptionalString(params.sessionTarget?.sessionKey);
   const requestedAgentId = normalizeOptionalString(params.agentId);
-  const callerSessionId = normalizeOptionalString(params.callerSessionId);
+  const callerSessionId = normalizeOptionalString(params.sessionId);
   const requestedSessionKey = normalizeOptionalString(params.sessionKey);
   const requestedSessionKeyAgentId = parseAgentSessionKey(requestedSessionKey)?.agentId;
   if (
@@ -55,87 +46,11 @@ function buildCompactionResultSessionTarget(params: {
   ) {
     throw new Error("Context-engine successor target conflicts with the caller session identity");
   }
-  const suppliedAgentId = targetAgentId ?? requestedAgentId;
-  const suppliedSessionId = normalizeOptionalString(params.sessionId);
-  const suppliedSessionKey = targetSessionKey ?? requestedSessionKey;
-  const suppliedSessionKeyAgentId = parseAgentSessionKey(suppliedSessionKey)?.agentId;
-  const callerAgentId = suppliedAgentId ?? suppliedSessionKeyAgentId;
-  if (
-    (callerAgentId && marker && marker.agentId !== callerAgentId) ||
-    (targetStorePath && marker && path.resolve(marker.storePath) !== path.resolve(targetStorePath))
-  ) {
-    throw new Error("Context-engine successor target conflicts with the caller session identity");
-  }
-  if (marker && suppliedSessionId && marker.sessionId !== suppliedSessionId) {
-    throw new Error("Context-engine successor identity is inconsistent");
-  }
-  const candidateEntry =
-    marker && suppliedSessionKey
-      ? loadSessionEntry({
-          agentId: marker.agentId,
-          sessionKey: suppliedSessionKey,
-          storePath: marker.storePath,
-        })
-      : undefined;
-  const markerMatches = marker
-    ? listSessionEntriesCore({
-        agentId: marker.agentId,
-        storePath: marker.storePath,
-      }).filter(({ entry }) => entry.sessionId === marker.sessionId)
-    : [];
-  const preferredMarkerSessionKey = marker
-    ? resolvePreferredSessionKeyForSessionIdMatches(
-        markerMatches.map(({ sessionKey, entry }) => [sessionKey, entry]),
-        marker.sessionId,
-      )
-    : undefined;
-  const callerAuthorizedMarkerKey = Boolean(
-    suppliedSessionKey && (!candidateEntry || candidateEntry.sessionId === callerSessionId),
-  );
-  const markerSessionKey = marker
-    ? callerAuthorizedMarkerKey || candidateEntry?.sessionId === marker.sessionId
-      ? suppliedSessionKey
-      : (preferredMarkerSessionKey ?? (candidateEntry ? undefined : suppliedSessionKey))
-    : undefined;
-  if (sessionFile && !marker) {
-    throw new Error("Legacy context-engine file successors are unsupported");
-  }
-  if (marker && !markerSessionKey) {
-    throw new Error("Legacy context-engine successor identity is ambiguous");
-  }
-  if (
-    marker &&
-    suppliedSessionKey &&
-    ((candidateEntry &&
-      candidateEntry.sessionId !== marker.sessionId &&
-      !callerAuthorizedMarkerKey) ||
-      (!candidateEntry && markerMatches.length > 0))
-  ) {
-    throw new Error("Legacy context-engine successor session key is inconsistent");
-  }
-  if (marker && suppliedSessionKeyAgentId && suppliedSessionKeyAgentId !== marker.agentId) {
-    throw new Error("Legacy context-engine successor identity is inconsistent");
-  }
-  const sessionId = marker?.sessionId ?? suppliedSessionId ?? targetSessionId ?? callerSessionId;
-  if (!sessionId) {
-    return undefined;
-  }
-  const agentId = marker?.agentId ?? callerAgentId;
-  const sessionKey = marker ? markerSessionKey : suppliedSessionKey;
-  const sessionKeyAgentId = parseAgentSessionKey(sessionKey)?.agentId;
+  const agentId = targetAgentId ?? requestedAgentId;
+  const sessionKeyAgentId = parseAgentSessionKey(targetSessionKey ?? requestedSessionKey)?.agentId;
   if (sessionKeyAgentId && agentId && sessionKeyAgentId !== agentId) {
     throw new Error("Context-engine successor session key conflicts with its agent identity");
   }
-  const storePath = marker?.storePath ?? targetStorePath;
-  return {
-    ...(agentId ? { agentId } : {}),
-    sessionId,
-    ...(sessionKey ? { sessionKey } : {}),
-    ...(storePath ? { storePath } : {}),
-    ...(params.callerSessionTarget?.threadId !== undefined
-      ? { threadId: params.callerSessionTarget.threadId }
-      : {}),
-  };
 }
 
 /**
@@ -154,10 +69,9 @@ function buildCompactionResultSessionTarget(params: {
 export async function delegateCompactionToRuntime(
   params: Parameters<ContextEngine["compact"]>[0],
 ): Promise<CompactResult> {
-  // Load through the dedicated runtime boundary without introducing another
-  // source-level static edge into the embedded runner graph.
-  const { compactEmbeddedAgentSessionOnDemand } = await loadCompactRuntime();
-  type RuntimeCompactionParams = Parameters<typeof compactEmbeddedAgentSessionOnDemand>[0];
+  type RuntimeCompactionParams = Parameters<
+    Awaited<ReturnType<typeof loadCompactRuntime>>["compactEmbeddedAgentSessionOnDemand"]
+  >[0];
 
   // runtimeContext carries host-resolved runtime fields set by internal
   // callers. Keep the public delegate keyed by session identity, not by the
@@ -168,6 +82,15 @@ export async function delegateCompactionToRuntime(
   const sessionTarget = params.sessionTarget ?? runtimeContext.sessionTarget;
   const agentId = params.agentId ?? runtimeContext.agentId;
   const sessionKey = params.sessionKey ?? runtimeContext.sessionKey;
+  // Reject contradictory caller identity before loading or invoking the compactor:
+  // target precedence inside the runtime must not hide an invalid request.
+  assertCompactionSessionIdentity({
+    agentId,
+    sessionId: params.sessionId,
+    sessionKey,
+    sessionTarget,
+  });
+  const { compactEmbeddedAgentSessionOnDemand } = await loadCompactRuntime();
   const currentTokenCount =
     params.currentTokenCount ??
     (typeof runtimeContext.currentTokenCount === "number" &&
@@ -180,10 +103,10 @@ export async function delegateCompactionToRuntime(
     ...runtimeContextParams,
     // Preserve identity for the private recovery-accounting bridge.
     contextEngineRuntimeContext: runtimeContext,
-    ...(agentId ? { agentId } : {}),
+    agentId,
     sessionId: params.sessionId,
-    ...(sessionKey ? { sessionKey } : {}),
-    ...(sessionTarget ? { sessionTarget } : {}),
+    sessionKey,
+    sessionTarget,
     tokenBudget: params.tokenBudget,
     ...(currentTokenCount !== undefined ? { currentTokenCount } : {}),
     force: params.force,
@@ -192,16 +115,6 @@ export async function delegateCompactionToRuntime(
     workspaceDir:
       typeof runtimeContext.workspaceDir === "string" ? runtimeContext.workspaceDir : process.cwd(),
   });
-  const resultSessionTarget = result.result
-    ? buildCompactionResultSessionTarget({
-        agentId,
-        callerSessionId: params.sessionId,
-        callerSessionTarget: sessionTarget,
-        sessionFile: result.result.sessionFile,
-        sessionId: result.result.sessionId,
-        sessionKey,
-      })
-    : undefined;
 
   return {
     ok: result.ok,
@@ -214,13 +127,11 @@ export async function delegateCompactionToRuntime(
           tokensBefore: result.result.tokensBefore,
           tokensAfter: result.result.tokensAfter,
           details: result.result.details,
-          ...(result.result.sessionId
-            ? { sessionId: resultSessionTarget?.sessionId ?? result.result.sessionId }
-            : {}),
+          ...(result.result.sessionId ? { sessionId: result.result.sessionId } : {}),
           // Core reports successors only through the typed sessionTarget; the
           // deprecated raw sessionFile field is reserved for shipped engines
           // reporting rotation to core, and post-flip core has no file path.
-          ...(resultSessionTarget ? { sessionTarget: resultSessionTarget } : {}),
+          ...(result.result.sessionTarget ? { sessionTarget: result.result.sessionTarget } : {}),
         }
       : undefined,
   };

--- a/src/cron/isolated-agent/run.session-lifecycle.test.ts
+++ b/src/cron/isolated-agent/run.session-lifecycle.test.ts
@@ -1,13 +1,23 @@
 // Persistent cron session tests cover lifecycle admission and mutation races.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import * as logicalTurn from "../../agents/harness/context-engine-logical-turn.js";
+import {
+  drainPendingContextEngineTurnsBeforeRun,
+  type ContextEngineTurnAttemptFacts,
+} from "../../agents/harness/context-engine-turn-attempt.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import type { ContextEngine } from "../../context-engine/types.js";
 import * as diagnostic from "../../logging/diagnostic.js";
 import {
   interruptSessionWorkAdmissions,
   isSessionWorkAdmissionActive,
   runExclusiveSessionLifecycleMutation,
 } from "../../sessions/session-lifecycle-admission.js";
+import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.types.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import { makeIsolatedAgentJobFixture, makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
 import {
   dispatchCronDeliveryMock,
@@ -25,10 +35,17 @@ import {
   resolveCronPayloadOutcomeMock,
   resolveDeliveryTargetMock,
   runEmbeddedAgentMock,
+  runWithModelFallbackMock,
 } from "./run.test-harness.js";
 
 const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
 const inMemoryStorePath = "/tmp/store.json";
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    cleanup();
+  }),
+);
 
 function makePersistentCronParams(sessionKey: string) {
   return makeIsolatedAgentParamsFixture({
@@ -49,6 +66,155 @@ describe("runCronIsolatedAgentTurn session lifecycle", () => {
     resetRunCronIsolatedAgentTurnHarness();
     mockRunCronFallbackPassthrough();
   });
+
+  it.each(["completed", "exhausted", "aborted", "mismatched physical session"] as const)(
+    "advances the actual cron candidate only when accepted: %s",
+    async (outcome) => {
+      const accessor = await vi.importActual<
+        typeof import("../../config/sessions/session-accessor.js")
+      >("../../config/sessions/session-accessor.js");
+      const dir = tempDirs.make("openclaw-cron-turn-candidate-");
+      const target = {
+        agentId: "main",
+        sessionId: "cron-candidate",
+        sessionKey: "agent:main:cron:candidate",
+        storePath: path.join(dir, "openclaw-agent.sqlite"),
+      };
+      await accessor.replaceSessionEntry(target, {
+        sessionId: target.sessionId,
+        lifecycleRevision: "candidate-revision",
+        updatedAt: 1,
+        systemSent: false,
+      });
+      const initialSessionEntry = accessor.loadSessionEntry(target);
+      if (!initialSessionEntry) {
+        throw new Error("Expected the persisted cron session before admission");
+      }
+      patchSessionEntryMock.mockImplementation(accessor.patchSessionEntryCore);
+      resolveCronSessionMock.mockReturnValue(
+        makeCronSession({
+          storePath: target.storePath,
+          store: { [target.sessionKey]: { ...initialSessionEntry } },
+          initialSessionEntry,
+          isNewSession: false,
+          lifecycleRevision: "candidate-revision",
+          sessionEntry: { ...initialSessionEntry },
+        }),
+      );
+      loadSessionEntryMock.mockImplementation(() => accessor.loadSessionEntry(target));
+      const commitTurn = vi.fn<NonNullable<ContextEngine["commitTurn"]>>(async () => ({
+        status: "committed",
+      }));
+      const afterTurn = vi.fn<NonNullable<ContextEngine["afterTurn"]>>(async () => {});
+      const engine: ContextEngine = {
+        info: {
+          id: "cron-candidate-engine",
+          name: "Cron candidate engine",
+          transcriptSemantics: {
+            currentTurnFence: "before-current-turn-entry-v1",
+            turnAdvancementIdempotency: "atomic-idempotent-v1",
+          },
+        },
+        ingest: async () => ({ ingested: true }),
+        assemble: async ({ messages }) => ({ messages, estimatedTokens: 0 }),
+        compact: async () => ({ ok: true, compacted: false }),
+        commitTurn,
+        afterTurn,
+      };
+      const effective = { engine, registeredId: engine.info.id, mode: "configured" as const };
+      const dispose = vi.fn(async () => {});
+      const lease: logicalTurn.ContextEngineLogicalTurnLease = {
+        engine,
+        effectiveEngine: engine,
+        effectiveEngineId: engine.info.id,
+        degraded: false,
+        selectForHost: () => effective,
+        begin: () => effective,
+        degradeBeforeStart: vi.fn(() => effective),
+        deferDisposalUntil: () => {},
+        dispose,
+      };
+      const createLease = vi
+        .spyOn(logicalTurn, "createContextEngineLogicalTurnLease")
+        .mockResolvedValue(lease);
+      const candidates: ContextEngineTurnAttemptFacts[] = [];
+      runEmbeddedAgentMock.mockImplementationOnce(
+        async (runParams: {
+          onContextEngineTurnCandidate: (facts: ContextEngineTurnAttemptFacts) => void;
+          userTurnTranscriptRecorder: UserTurnTranscriptRecorder;
+        }) => {
+          // Keep cron's recorder and durable finalizer real while the backend
+          // emits a deterministic candidate for the outer acceptance decision.
+          await drainPendingContextEngineTurnsBeforeRun({
+            admission: runParams.userTurnTranscriptRecorder.getAdmissionReceipt(),
+            lease,
+            recorder: runParams.userTurnTranscriptRecorder,
+            sessionTarget: target,
+          });
+          await runParams.userTurnTranscriptRecorder.persistApproved({ cwd: dir });
+          const admission = runParams.userTurnTranscriptRecorder.getAdmissionReceipt();
+          const terminal = await accessor.appendTranscriptMessage(target, {
+            message: { role: "assistant", content: "Cron answer", timestamp: 2 },
+            parentId: admission?.entryId,
+          });
+          if (!admission || !terminal?.anchor) {
+            throw new Error("Expected cron's persisted admission and terminal anchors");
+          }
+          const facts: ContextEngineTurnAttemptFacts = {
+            boundary: { admission, terminal: terminal.anchor },
+            sessionIdUsed:
+              outcome === "mismatched physical session" ? "other-session" : target.sessionId,
+            sessionKey: target.sessionKey,
+            sessionTarget: target,
+            promptError: false,
+            aborted: false,
+            yieldAborted: false,
+            isHeartbeat: false,
+          };
+          runParams.onContextEngineTurnCandidate(facts);
+          candidates.push(facts);
+          return {
+            payloads: [{ text: "Cron answer" }],
+            meta: { agentMeta: {}, ...(outcome === "aborted" ? { aborted: true } : {}) },
+          };
+        },
+      );
+      runWithModelFallbackMock.mockImplementationOnce(async ({ provider, model, run }) => ({
+        result: await run(provider, model),
+        provider,
+        model,
+        attempts: [],
+        outcome: outcome === "exhausted" ? "exhausted" : "completed",
+      }));
+      try {
+        const result = await runCronIsolatedAgentTurn(makePersistentCronParams(target.sessionKey));
+        expect(candidates, JSON.stringify(result)).toHaveLength(1);
+        expect(lease.degradeBeforeStart).not.toHaveBeenCalled();
+        if (outcome === "completed") {
+          expect(commitTurn).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({
+              admission: candidates[0]?.boundary.admission,
+              terminal: candidates[0]?.boundary.terminal,
+              messages: [
+                expect.objectContaining({ role: "user" }),
+                expect.objectContaining({ role: "assistant", content: "Cron answer" }),
+              ],
+              isHeartbeat: false,
+            }),
+          );
+        } else {
+          expect(commitTurn).not.toHaveBeenCalled();
+        }
+        expect(afterTurn).not.toHaveBeenCalled();
+        expect(dispose).toHaveBeenCalledOnce();
+        expect(
+          isSessionWorkAdmissionActive(target.storePath, [target.sessionKey, target.sessionId]),
+        ).toBe(false);
+      } finally {
+        createLease.mockRestore();
+      }
+    },
+  );
 
   it("rejects a session that rotates before async setup", async () => {
     const sessionKey = "agent:main:main";


### PR DESCRIPTION
Related: [compaction-accounting cleanup](https://github.com/openclaw/openclaw/pull/133521).

## What Problem This Solves

Resolves a problem where a context-engine plugin's compaction request could run before OpenClaw reported that its session identity contradicted the caller. Invalid requests should fail before they can compact a conversation.

This maintainer-requested follow-up also simplifies compaction and accepted-turn processing by removing duplicate identity resolution and unused runtime metadata handoffs.

## Why This Change Was Made

The direct compactor now returns its canonical storage target; the delegate validates input first and forwards that target instead of decoding obsolete core marker outputs and scanning session aliases again. SQLite identity stays limited to agent, physical session, session key and store. The compaction operation separately preserves optional thread routing, including numeric zero, without exposing writer/lifecycle authority.

Accepted-turn candidates retain only the eight facts their acceptance owner consumes. Embedded, host-selected harness and CLI producers no longer construct legacy `afterTurn` inputs for this private candidate path. Missing anchors still produce no candidate, and later lifecycle work and the public legacy-hook path remain intact.

External context-engine successor compatibility, exact-writer fencing, native compaction behavior, outbox states, storage concurrency and retention are unchanged. This adds no configuration, schema, protocol or dependency change.

## User Impact

Valid compaction and turn behavior remain the same. Plugin callers with contradictory session identities fail before compaction begins, and selected top-level identity cannot silently fall back to different runtime-context identity after validation.

Production code is smaller by 144 lines (+131/−275). Tests, test support and QA grow by 661 lines (+1139/−478; `compact.hooks.harness.ts` is test support): real SQLite/delegate and accepted-turn boundary coverage replaces obsolete marker-output mocks, and the Gateway scenario now requires actual durable compaction rather than accepting any reply containing “Compact.” This is a production simplification, not an overall line-count reduction.

## Evidence

Validated final tree `49378dd8c11f842db31b0a7b02f624bf06c4f0aa`. Production is identical to the runtime-tested tree `9af03b3b8c21f6d4a6210758347e20c4a8355b43`: Linux / Node 24.19.0, Blacksmith Testbox `tbx_01m1aj9mkansqw5edat20ryc6r` ([runtime proof environment](https://github.com/openclaw/openclaw/actions/runs/33343645832)). The test-only registry-projection correction was verified on Testbox `tbx_01m1apxt0ptcygnjnakh3sqcn1` ([correction proof environment](https://github.com/openclaw/openclaw/actions/runs/33347695211)). Both final commands exited 0, with complete source identity and process-group closure checked throughout; both leases are stopped.

- **575 tests passed**, 18 files / nine owner shards on the final tree, with no failures or pending tests. Coverage includes actual SQLite-backed summary and endpoint compaction, alternate stores/global aliases, thread zero, cancellation, successor/writer fencing, overflow recovery, embedded/CLI/harness/cron accepted-turn handling, real host-parameter projection, and the actual type-suppression inventory.
- **All changed-code gates passed** on the production-identical runtime-proof tree, including all core/UI/plugin/script/root-test typechecks, every lint shard (zero warnings/errors), dead exports, architecture guards, and zero runtime import cycles. The subsequent test-only correction passed its matching tsgo/lint checks and `check-changed` gate as well.
- **Normal and private-QA builds passed; SDK surface passed.** Zero ineffective-dynamic-import warnings. Normal build/SDK proof used tree `36a036a1133150156e3a40e1a9626628f8df38c1`; private-QA build/Gateway proof used `9af03b3b8c21f6d4a6210758347e20c4a8355b43`. Subsequent differences are confined to test fixtures; production identity was verified by whole-tree comparisons.
- **Fresh independent Codex autoreview:** both the production refactor and final test-only correction are scoped-clean, with no accepted/actionable P0 findings. This is a scoped P0 review, not a claim about every possible lower-priority issue.

Final Gateway verdict, with a real Gateway, synthetic channel data and a mock HTTP provider:

```json
{"scenario":"goal-context-survives-compaction","status":"pass","passed":1,"failed":0,"skipped":0,"compactionCounts":[0,1,1],"sessionIdentityStable":true,"currentContextEstimate":1629,"contextFresh":true,"newSummaryRequests":1,"summaryRequestOutcome":"success","nextRequestContainsPersistedSummaryAndGoal":true,"finalReply":"GOAL-COMPACTION-RESUMED","providerLive":false,"channelLive":false}
```

The context value above is an estimate, not measured provider usage or cumulative billing. Earlier verification corrected canonical-row and typing mistakes in new fixtures plus an untyped cancellation rejection. Hosted CI then caught two new type suppressions. The repair preserves all omission cases through the real registry's documented `acceptedHostParams` projection: public calls supply the required key, and the host itself omits it before the delegate. No suppression inventory, public type, production guard, or assertion was weakened. An earlier Testbox ended during its two-hour workflow window; that interrupted gate was not counted as passing.

ClawSweeper's stored-data classifier note refers to the QA scenario YAML, not a runtime store. No database schema or persisted data-model change is present; no migration is needed. Its maintainer-choice/green-CI next step is handled by the requested maintainer landing flow.

<details>
<summary>Validation commands</summary>

Executed in the isolated remote source checkout with process-lifetime temporary HOME/state/config/native-home paths. The focused report was checked for all requested files and the required boundary assertions.

```bash
node scripts/run-vitest.mjs src/context-engine/context-engine.test.ts src/context-engine/host-param-projection.test.ts test/scripts/type-suppression-inventory.test.ts src/agents/embedded-agent-runner/compact.delegate.test.ts src/agents/embedded-agent-runner/run-entry.test.ts src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts src/agents/harness/context-engine-turn-attempt.test.ts src/agents/harness/selection.test.ts src/agents/cli-runner.context-engine.test.ts src/cron/isolated-agent/run.session-lifecycle.test.ts src/agents/embedded-agent-runner/compact.hooks.test.ts src/agents/embedded-agent-runner/compact.native-cli.test.ts src/agents/embedded-agent-runner/compact.abort-signal.test.ts src/agents/embedded-agent-runner/compact.queued-successor.test.ts src/agents/embedded-agent-runner/compaction-successor.test.ts src/agents/embedded-agent-runner/run.overflow-compaction.test.ts src/agents/harness/context-engine-turn-outbox.test.ts src/agents/harness/context-engine-lifecycle.test.ts --reporter=default --reporter=json --outputFile=.artifacts/context-engine-handoff-625078/projection-fix.json
```

```bash
node scripts/check-changed.mjs -- qa/scenarios/goals/goal-context-survives-compaction.yaml src/agents/cli-runner.context-engine.test.ts src/agents/cli-runner/cli-run-transcript.ts src/agents/embedded-agent-runner/compact.delegate.test.ts src/agents/embedded-agent-runner/compact.hooks.harness.ts src/agents/embedded-agent-runner/compact.ts src/agents/embedded-agent-runner/compaction-session-execution.ts src/agents/embedded-agent-runner/run-entry.test.ts src/agents/embedded-agent-runner/run/attempt-finalize.ts src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts src/agents/embedded-agent-runner/types.ts src/agents/harness/context-engine-turn-attempt.test.ts src/agents/harness/context-engine-turn-attempt.ts src/agents/harness/selection.test.ts src/agents/harness/selection.ts src/context-engine/context-engine.test.ts src/context-engine/delegate.ts src/cron/isolated-agent/run.session-lifecycle.test.ts
```

Test-only correction checks:

```bash
node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.other.json --builders 1
```

```bash
node scripts/run-oxlint.mjs --tsconfig test/tsconfig/tsconfig.core.test.other.json src/context-engine/context-engine.test.ts
```

```bash
node scripts/check-changed.mjs -- src/context-engine/context-engine.test.ts
```

Production build and Gateway proof commands:

```bash
corepack pnpm build
```

```bash
corepack pnpm plugin-sdk:surface:check
```

```bash
OPENCLAW_BUILD_PRIVATE_QA=1 corepack pnpm build
```

```bash
OPENCLAW_BUILD_PRIVATE_QA=1 corepack pnpm openclaw qa suite --runner host --provider-mode mock-openai --scenario goal-context-survives-compaction --concurrency 1 --output-dir .artifacts/qa-e2e/compaction-owner-corrected-625078
```

</details>

Pre-fix proof used unchanged production at `08d09c4d97044ead11aacbe1cc13d5dd7a02c0a3` plus two zero-backend-call assertions. Both failed because compaction was invoked exactly once before the conflicting identity was rejected. The two cases remain in the candidate.

The stronger Gateway scenario uses a real isolated Gateway and a deterministic mock HTTP provider—not a live authenticated model. It checks six completed seed turns, interleaving with a second session, manual compaction on the original session, one persisted summary and checkpoint with matching context estimates, and the next turn's preserved goal/summary context and exact terminal delivery. Private candidate acceptance/discard, cancellation and writer replacement are covered separately by owner tests.

Named follow-ups from the broader read remain separate: summary-scheduler consolidation and its partial-summary semantics; whole-auth-attempt preparation ownership; restricted-finalizer accounting; native committed-compaction versus interrupted-operation accounting; and Anthropic multi-delta/encrypted checkpoint replay. No unexecuted source hypothesis is claimed fixed here.
