### PR TITLE
fix(line): keep the typing indicator on replies the gateway drives

### DIFF
--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -257,9 +257,8 @@ as untrusted.
   cards when possible.
 - Streaming responses are buffered; LINE receives full chunks. The loading
   animation runs only in one-to-one chats — LINE's loading API accepts a user id
-  and rejects group and room ids — so a group reply arrives without one. It also
-  covers replies the Gateway drives rather than the plugin, such as a heartbeat
-  turn.
+  and rejects group and room ids — so a group reply arrives without one. Heartbeat
+  turns also show the loading animation while the reply is generated.
 - Media downloads are capped by `channels.line.mediaMaxMb` (default 10).
 - Inbound media is saved under `~/.openclaw/media/inbound/` before it is passed
   to the agent, matching the shared media store used by other channel plugins.

--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -257,7 +257,9 @@ as untrusted.
   cards when possible.
 - Streaming responses are buffered; LINE receives full chunks. The loading
   animation runs only in one-to-one chats — LINE's loading API accepts a user id
-  and rejects group and room ids — so a group reply arrives without one.
+  and rejects group and room ids — so a group reply arrives without one. It also
+  covers replies the Gateway drives rather than the plugin, such as a heartbeat
+  turn.
 - Media downloads are capped by `channels.line.mediaMaxMb` (default 10).
 - Inbound media is saved under `~/.openclaw/media/inbound/` before it is passed
   to the agent, matching the shared media store used by other channel plugins.

--- a/extensions/line/src/channel.heartbeat.test.ts
+++ b/extensions/line/src/channel.heartbeat.test.ts
@@ -1,0 +1,49 @@
+// Line tests cover heartbeat typing plugin behavior.
+import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { linePlugin } from "./channel.js";
+import { setLineRuntime } from "./runtime.js";
+
+const userId = `U${"a".repeat(32)}`;
+const groupId = `C${"b".repeat(32)}`;
+const roomId = `R${"c".repeat(32)}`;
+const cfg = {} as OpenClawConfig;
+
+const showLoadingAnimation = vi.fn(async () => {});
+
+async function sendTyping(to: string) {
+  await linePlugin.heartbeat?.sendTyping?.({ cfg, to, accountId: "default" });
+}
+
+describe("linePlugin heartbeat.sendTyping", () => {
+  beforeEach(() => {
+    showLoadingAnimation.mockClear();
+    setLineRuntime({
+      channel: { line: { showLoadingAnimation } },
+    } as unknown as PluginRuntime);
+  });
+
+  it.each([
+    { name: "a bare user id", to: userId },
+    { name: "a prefixed user id", to: `line:user:${userId}` },
+  ])("shows the loading animation for $name", async ({ to }) => {
+    await sendTyping(to);
+
+    expect(showLoadingAnimation).toHaveBeenCalledTimes(1);
+    expect(showLoadingAnimation).toHaveBeenCalledWith(userId, { cfg, accountId: "default" });
+  });
+
+  // LINE only shows the indicator in one-to-one chats, so anything else would be a
+  // call that can only fail; it is skipped instead of sent and logged as a failure.
+  it.each([
+    { name: "a group", to: groupId },
+    { name: "a room", to: roomId },
+    { name: "an unusable target", to: "not-a-line-id" },
+    { name: "an empty target", to: "   " },
+  ])("stays quiet for $name", async ({ to }) => {
+    await sendTyping(to);
+
+    expect(showLoadingAnimation).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/line/src/channel.heartbeat.test.ts
+++ b/extensions/line/src/channel.heartbeat.test.ts
@@ -1,49 +1,59 @@
-// Line tests cover heartbeat typing plugin behavior.
-import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../api.js";
 import { linePlugin } from "./channel.js";
-import { setLineRuntime } from "./runtime.js";
 
 const userId = `U${"a".repeat(32)}`;
-const groupId = `C${"b".repeat(32)}`;
-const roomId = `R${"c".repeat(32)}`;
-const cfg = {} as OpenClawConfig;
+const cfg: OpenClawConfig = {
+  channels: {
+    line: {
+      channelAccessToken: "heartbeat-default-fixture",
+      channelSecret: "heartbeat-secret-fixture",
+      accounts: {
+        secondary: {
+          channelAccessToken: "heartbeat-secondary-fixture",
+          channelSecret: "heartbeat-secondary-secret-fixture",
+        },
+      },
+    },
+  },
+};
 
-const showLoadingAnimation = vi.fn(async () => {});
+describe("LINE heartbeat typing", () => {
+  afterEach(() => vi.unstubAllGlobals());
 
-async function sendTyping(to: string) {
-  await linePlugin.heartbeat?.sendTyping?.({ cfg, to, accountId: "default" });
-}
+  it("sends the LINE loading request only for direct chats with the selected account", async () => {
+    const fetchMock = vi.fn(async () => new Response("{}", { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
 
-describe("linePlugin heartbeat.sendTyping", () => {
-  beforeEach(() => {
-    showLoadingAnimation.mockClear();
-    setLineRuntime({
-      channel: { line: { showLoadingAnimation } },
-    } as unknown as PluginRuntime);
-  });
+    for (const to of [`C${"b".repeat(32)}`, `line:room:R${"c".repeat(32)}`, "", "invalid"]) {
+      await linePlugin.heartbeat?.sendTyping?.({ cfg, to });
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
 
-  it.each([
-    { name: "a bare user id", to: userId },
-    { name: "a prefixed user id", to: `line:user:${userId}` },
-  ])("shows the loading animation for $name", async ({ to }) => {
-    await sendTyping(to);
+    await linePlugin.heartbeat?.sendTyping?.({ cfg, to: userId });
+    await linePlugin.heartbeat?.sendTyping?.({
+      cfg,
+      to: `line:user:${userId}`,
+      accountId: "secondary",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    for (const [index, token] of [
+      "heartbeat-default-fixture",
+      "heartbeat-secondary-fixture",
+    ].entries()) {
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        index + 1,
+        new URL("https://api.line.me/v2/bot/chat/loading/start"),
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({ authorization: `Bearer ${token}` }),
+          body: JSON.stringify({ chatId: userId, loadingSeconds: 20 }),
+        }),
+      );
+    }
 
-    expect(showLoadingAnimation).toHaveBeenCalledTimes(1);
-    expect(showLoadingAnimation).toHaveBeenCalledWith(userId, { cfg, accountId: "default" });
-  });
-
-  // LINE only shows the indicator in one-to-one chats, so anything else would be a
-  // call that can only fail; it is skipped instead of sent and logged as a failure.
-  it.each([
-    { name: "a group", to: groupId },
-    { name: "a room", to: roomId },
-    { name: "an unusable target", to: "not-a-line-id" },
-    { name: "an empty target", to: "   " },
-  ])("stays quiet for $name", async ({ to }) => {
-    await sendTyping(to);
-
-    expect(showLoadingAnimation).not.toHaveBeenCalled();
+    fetchMock.mockImplementationOnce(async () => new Response("{}", { status: 400 }));
+    await expect(linePlugin.heartbeat?.sendTyping?.({ cfg, to: userId })).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/extensions/line/src/channel.runtime.ts
+++ b/extensions/line/src/channel.runtime.ts
@@ -1,4 +1,4 @@
 // Line plugin module implements channel behavior.
 export { monitorLineProvider } from "./monitor.js";
 export { probeLineBot } from "./probe.js";
-export { pushMessageLine } from "./send.js";
+export { pushMessageLine, showLoadingAnimation } from "./send.js";

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -113,6 +113,22 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = createChatChannelP
     setupContract: lineSetupContract,
     status: lineStatusAdapter,
     gateway: lineGatewayAdapter,
+    heartbeat: {
+      // Core drives the typing indicator for replies the plugin does not deliver
+      // itself, such as a heartbeat turn. LINE rejects a group id outright here, and
+      // showLoadingAnimation swallows its own errors, so the target kind has to be
+      // decided before the call or every group heartbeat becomes a silent 400.
+      sendTyping: async ({ cfg, to, accountId }) => {
+        const chatId = normalizeLineMessagingTarget(to);
+        if (!chatId || inferLineTargetChatType(to) !== "direct") {
+          return;
+        }
+        const showLoadingAnimation =
+          getLineRuntime().channel.line?.showLoadingAnimation ??
+          (await loadLineChannelRuntime()).showLoadingAnimation;
+        await showLoadingAnimation(chatId, { cfg, ...(accountId ? { accountId } : {}) });
+      },
+    },
     message: lineMessageAdapter,
     actions: lineMessageActions,
     bindings: lineBindingsAdapter,

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -114,19 +114,14 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = createChatChannelP
     status: lineStatusAdapter,
     gateway: lineGatewayAdapter,
     heartbeat: {
-      // Core drives the typing indicator for replies the plugin does not deliver
-      // itself, such as a heartbeat turn. LINE rejects a group id outright here, and
-      // showLoadingAnimation swallows its own errors, so the target kind has to be
-      // decided before the call or every group heartbeat becomes a silent 400.
       sendTyping: async ({ cfg, to, accountId }) => {
         const chatId = normalizeLineMessagingTarget(to);
-        if (!chatId || inferLineTargetChatType(to) !== "direct") {
+        // LINE's loading indicator accepts user IDs only; group and room requests fail.
+        if (!chatId || inferLineTargetChatType(chatId) !== "direct") {
           return;
         }
-        const showLoadingAnimation =
-          getLineRuntime().channel.line?.showLoadingAnimation ??
-          (await loadLineChannelRuntime()).showLoadingAnimation;
-        await showLoadingAnimation(chatId, { cfg, ...(accountId ? { accountId } : {}) });
+        const { showLoadingAnimation } = await loadLineChannelRuntime();
+        await showLoadingAnimation(chatId, { cfg, accountId: accountId ?? undefined });
       },
     },
     message: lineMessageAdapter,

--- a/extensions/line/src/runtime.ts
+++ b/extensions/line/src/runtime.ts
@@ -14,7 +14,6 @@ type LineChannelRuntime = {
   pushTextMessageWithQuickReplies?: typeof import("./send.js").pushTextMessageWithQuickReplies;
   resolveLineAccount?: typeof import("./accounts.js").resolveLineAccount;
   sendMessageLine?: typeof import("./send.js").sendMessageLine;
-  showLoadingAnimation?: typeof import("./send.js").showLoadingAnimation;
 };
 
 type LineRuntime = PluginRuntime & {

--- a/extensions/line/src/runtime.ts
+++ b/extensions/line/src/runtime.ts
@@ -14,6 +14,7 @@ type LineChannelRuntime = {
   pushTextMessageWithQuickReplies?: typeof import("./send.js").pushTextMessageWithQuickReplies;
   resolveLineAccount?: typeof import("./accounts.js").resolveLineAccount;
   sendMessageLine?: typeof import("./send.js").sendMessageLine;
+  showLoadingAnimation?: typeof import("./send.js").showLoadingAnimation;
 };
 
 type LineRuntime = PluginRuntime & {


### PR DESCRIPTION
## What Problem This Solves

LINE's inbound reply path shows a loading indicator, but heartbeat replies had no typing adapter. A direct-chat heartbeat therefore remained visually idle while its reply was generated.

Closes #133677.

## Why This Change Was Made

Wire the existing heartbeat adapter to the plugin-owned loading sender through the existing lazy runtime. Reuse the target parser to call it only for valid direct user IDs; LINE rejects group and room IDs for this endpoint. Preserve account selection and the sender's existing nonfatal error behavior.

The contributor's runtime injection seam was unnecessary because core never produces it; the final adapter calls the canonical plugin sender directly. No new configuration, dependency, protocol, or storage surface is introduced. Original contributor history is preserved.

## User Impact

Direct-chat heartbeats use the existing loading indicator. Group and room heartbeats issue no loading request. Production +12/-1 (net +11) supplies the missing adapter and direct-target contract; tests add59 lines and documentation +2/-1.

## Evidence

Independent maintainer proof executed trusted main plus equivalent authored changes, without executing fork scripts or configuration locally. Baseline regressions failed; repaired coverage passed 79 LINE owner/sibling tests plus the core heartbeat cadence test, followed by 18 final target tests. Production/test typechecks, lint, relevant static guards, and the complete build passed. Fresh complete-candidate Codex reviews found no actionable P0 findings. Published head `0b24b5e84be95732439790f03ce2ce1a7fe962cd` passed [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33428555074). Hosted LINE suites passed 722 tests, including the changed regression.

The maintained test exercises the actual lazy runtime and LINE SDK request builder for default and named accounts, prefixed direct IDs, the20-second request body, invalid/group/room exclusions, and a nonfatal400 response. Core heartbeat cadence coverage verifies its existing repeated-callback behavior.

The contributor separately drove core's typing callback against a real LINE account: the direct request returned HTTP202, while the group target issued no request. This is attributed authenticated API evidence, not a new maintainer live run or proof that a client displayed the animation. The improved maintainer test replaces the submitted injected callback with actual SDK wire construction.

Installed LINE SDK11.2.0 source and official documentation confirm the one-to-one loading endpoint and user-ID request contract. The existing inbound path already uses that sender; the missing heartbeat adapter is the owner-level cause. Exact initial introduction is unknown. Latest ClawSweeper dependency/proof requests are addressed by these checks.

Thanks @edenfunf.
