### PR TITLE
perf: load retained chat history faster

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-active-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.ts
@@ -16,9 +16,9 @@ import type {
 } from "./session-accessor.sqlite-contract.js";
 import {
   readTranscriptProjectionGeneration,
+  readVisibleMessageMetadata,
   readVisibleMessageRange,
   readVisibleTranscriptStats,
-  resolveVisibleMessagePositionRange,
   resolveVisibleMessagePositions,
 } from "./session-accessor.sqlite-reset-window.js";
 import {
@@ -456,45 +456,28 @@ export function readSessionTranscriptBoundedMessageTailPage(
     );
     const endExclusive = Math.max(0, totalMessages - offset);
     const start = Math.max(0, endExclusive - maxMessages);
-    const positions = resolveVisibleMessagePositionRange(projection, start, endExclusive);
-    if (positions.length === 0 || maxBytes === 0) {
+    const scannedMessages = endExclusive - start;
+    if (scannedMessages === 0 || maxBytes === 0) {
       return {
         activeLeafEntryId: projection.state.leafEventId,
         events: [],
         newestContiguousEventCount: 0,
-        scannedMessages: positions.length,
+        scannedMessages,
         serializedBytes: 0,
         snapshot,
         totalMessages,
       };
     }
     const db = getActiveTranscriptKysely(projection.database);
-    const metadata = executeSqliteQuerySync(
-      projection.database.db,
-      db
-        .selectFrom("session_transcript_active_events as active")
-        .innerJoin("transcript_events as event", (join) =>
-          join
-            .onRef("event.session_id", "=", "active.session_id")
-            .onRef("event.seq", "=", "active.event_seq"),
-        )
-        .select([
-          "active.message_position",
-          /* kysely-allow-raw: byte budget covers the exact newline-terminated JSON event. */
-          sql<number>`OCTET_LENGTH(event.event_json) + 1`.as("serialized_bytes"),
-        ])
-        .where("active.session_id", "=", projection.resolved.sessionId)
-        .where("active.message_position", "in", positions)
-        .orderBy("active.message_position", "desc"),
-    ).rows;
-    if (metadata.length !== positions.length) {
+    const metadata = readVisibleMessageMetadata(projection, start, endExclusive).toReversed();
+    if (metadata.length !== scannedMessages) {
       throw new Error("Active transcript bounded message page is incomplete");
     }
     const selectedPositions: number[] = [];
     let newestContiguousEventCount: number | undefined;
     let serializedBytes = 0;
     for (const row of metadata) {
-      if (row.message_position === null || serializedBytes + row.serialized_bytes > maxBytes) {
+      if (serializedBytes + row.serialized_bytes > maxBytes) {
         newestContiguousEventCount ??= selectedPositions.length;
         continue;
       }
@@ -522,7 +505,7 @@ export function readSessionTranscriptBoundedMessageTailPage(
       activeLeafEntryId: projection.state.leafEventId,
       events,
       newestContiguousEventCount: newestContiguousEventCount ?? selectedPositions.length,
-      scannedMessages: positions.length,
+      scannedMessages,
       serializedBytes,
       snapshot,
       totalMessages,

--- a/src/config/sessions/session-accessor.sqlite-history-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-history-events.test.ts
@@ -27,11 +27,14 @@ function historyEventId(entry: { event: unknown } | undefined): unknown {
   return event && typeof event === "object" && "id" in event ? event.id : undefined;
 }
 
-function enforceSqliteVariableLimit(database: OpenClawAgentDatabase): void {
+function enforceSqliteVariableLimit(
+  database: OpenClawAgentDatabase,
+  limit = REGRESSION_SQLITE_VARIABLE_LIMIT,
+): void {
   const prepare = database.db.prepare.bind(database.db);
   vi.spyOn(database.db, "prepare").mockImplementation((source) => {
     const variableCount = source.match(/\?/gu)?.length ?? 0;
-    if (variableCount > REGRESSION_SQLITE_VARIABLE_LIMIT) {
+    if (variableCount > limit) {
       throw new Error("too many SQL variables");
     }
     return prepare(source);
@@ -318,30 +321,84 @@ describe("SQLite transcript history events", () => {
     expect(events.map(historyEventId)).toEqual(["seed", "active-boundary-2", "active-boundary-4"]);
   });
 
-  it("bounds metadata bindings when the raw history window exceeds SQLite's limit", async () => {
+  it.each([REGRESSION_MAX_MESSAGES, REGRESSION_SQLITE_VARIABLE_LIMIT + 1])(
+    "reads %s recent messages with bounded metadata bindings",
+    async (maxMessages) => {
+      await persistSessionTranscriptTurn(scope, {
+        messages: [{ eventId: "seed", parentId: null, message: { role: "user", content: "seed" } }],
+        touchSessionEntry: false,
+      });
+      const database = openOpenClawAgentDatabase({ agentId: scope.agentId, env: scope.env });
+      const bindingCount = Math.max(REGRESSION_SQLITE_VARIABLE_LIMIT, maxMessages);
+      insertSyntheticHistory(database, scope.sessionId, bindingCount);
+      enforceSqliteVariableLimit(database);
+
+      const page = readRecentSessionTranscriptHistoryEvents(scope, {
+        maxBytes: 1_000_000,
+        maxLines: bindingCount + 1,
+        maxMessages,
+      });
+
+      expect(page.totalMessages).toBe(bindingCount + 1);
+      expect(page.events).toHaveLength(maxMessages);
+      expect(historyEventId(page.events[0])).toBe(
+        `synthetic-message-${String(bindingCount - maxMessages + 2)}`,
+      );
+      expect(historyEventId(page.events.at(-1))).toBe(
+        `synthetic-message-${String(bindingCount + 1)}`,
+      );
+    },
+  );
+
+  it("batches sparse reset history without reviving discarded tool results", async () => {
+    const keptIds = Array.from({ length: 1_001 }, (_, index) => `kept-${index}`);
     await persistSessionTranscriptTurn(scope, {
-      messages: [{ eventId: "seed", parentId: null, message: { role: "user", content: "seed" } }],
+      messages: keptIds.flatMap((eventId, index) => [
+        {
+          eventId,
+          parentId: index === 0 ? null : `tool-${index - 1}`,
+          message: { role: "user", content: eventId },
+        },
+        {
+          eventId: `tool-${index}`,
+          parentId: eventId,
+          message: { role: "toolResult", content: "discarded orphan result" },
+        },
+      ]),
+      touchSessionEntry: false,
+    });
+    await appendTranscriptEvent(scope, {
+      type: "reset",
+      id: "reset",
+      parentId: "tool-1000",
+      timestamp: "2026-08-30T00:00:00.000Z",
+      reason: "new",
+      firstKeptEntryId: keptIds[0],
+    });
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        { eventId: "fresh", parentId: "reset", message: { role: "user", content: "fresh" } },
+      ],
       touchSessionEntry: false,
     });
     const database = openOpenClawAgentDatabase({ agentId: scope.agentId, env: scope.env });
-    const bindingCount = REGRESSION_SQLITE_VARIABLE_LIMIT;
-    insertSyntheticHistory(database, scope.sessionId, bindingCount);
-    enforceSqliteVariableLimit(database);
+    enforceSqliteVariableLimit(database, 999);
 
     const page = readRecentSessionTranscriptHistoryEvents(scope, {
       maxBytes: 1_000_000,
-      maxLines: bindingCount + 1,
-      maxMessages: REGRESSION_MAX_MESSAGES,
+      maxLines: 2_010,
+      maxMessages: keptIds.length + 2,
     });
-
-    expect(page.totalMessages).toBe(bindingCount + 1);
-    expect(page.events).toHaveLength(REGRESSION_MAX_MESSAGES);
-    expect(historyEventId(page.events[0])).toBe(
-      `synthetic-message-${String(bindingCount - REGRESSION_MAX_MESSAGES + 2)}`,
+    expect(page.totalMessages).toBe(keptIds.length + 2);
+    expect(page.events.map(historyEventId)).toEqual([...keptIds, "reset", "fresh"]);
+    expect(page.events.map(({ seq }) => seq)).toEqual(
+      Array.from({ length: keptIds.length + 2 }, (_, index) => index + 1),
     );
-    expect(historyEventId(page.events.at(-1))).toBe(
-      `synthetic-message-${String(bindingCount + 1)}`,
-    );
+    expect(
+      readSessionTranscriptHistoryEventPage(scope, { offset: 500, maxMessages: 2 }).events.map(
+        historyEventId,
+      ),
+    ).toEqual(["kept-501", "kept-502"]);
   });
 
   it("reads more boundaries than SQLite permits as statement bindings", async () => {

--- a/src/config/sessions/session-accessor.sqlite-history-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-history-events.ts
@@ -30,8 +30,8 @@ import {
 } from "./session-accessor.sqlite-display-position.js";
 import {
   readTranscriptProjectionGeneration,
+  readVisibleMessageMetadata,
   readVisibleMessageRange,
-  resolveVisibleMessagePositionRange,
   resolveVisibleMessagePositions,
 } from "./session-accessor.sqlite-reset-window.js";
 import { MAX_VISIBLE_MESSAGE_MAX_MESSAGES } from "./session-accessor.sqlite-visible-cursor.js";
@@ -217,36 +217,15 @@ function resolveRecentHistoryStart(
   const { boundedEnd, boundedStart, boundaries, messageEnd, messageStart } =
     resolveVisibleHistoryRange(history, start, endExclusive);
   // No result can include more than maxMessages events, so older metadata would
-  // only add SQLite bindings and synchronous work before the backward scan stops.
+  // only add synchronous work before the backward scan stops.
   const metadataStart = Math.max(messageStart, messageEnd - maxMessages);
-  const positions = resolveVisibleMessagePositionRange(projection, metadataStart, messageEnd);
-  const db = getActiveTranscriptKysely(projection.database);
   const messageBytes = new Map(
-    positions.length === 0
-      ? []
-      : executeSqliteQuerySync(
-          projection.database.db,
-          db
-            .selectFrom("session_transcript_active_events as active")
-            .innerJoin("transcript_events as event", (join) =>
-              join
-                .onRef("event.session_id", "=", "active.session_id")
-                .onRef("event.seq", "=", "active.event_seq"),
-            )
-            .select([
-              "active.message_position",
-              /* kysely-allow-raw: excluded history payloads must not be fetched or parsed. */
-              sql<number>`OCTET_LENGTH(event.event_json) + 1`.as("serialized_bytes"),
-            ])
-            .where("active.session_id", "=", projection.resolved.sessionId)
-            .where("active.message_position", "in", positions),
-        ).rows.flatMap((row) =>
-          row.message_position === null
-            ? []
-            : [[row.message_position, row.serialized_bytes] as const],
-        ),
+    readVisibleMessageMetadata(projection, metadataStart, messageEnd).map((row) => [
+      row.logicalPosition,
+      row.serialized_bytes,
+    ]),
   );
-  let messageIndex = positions.length - 1;
+  let messageIndex = messageEnd - 1;
   let selectedStart = boundedEnd;
   let selectedCount = 0;
   let bytes = 0;
@@ -259,10 +238,10 @@ function resolveRecentHistoryStart(
       break;
     }
     const boundary = boundaries.get(displayPosition);
-    const messagePosition = boundary ? undefined : positions[messageIndex--];
+    const logicalPosition = boundary ? undefined : messageIndex--;
     const serializedBytes =
       boundary?.serializedBytes ??
-      (messagePosition === undefined ? undefined : messageBytes.get(messagePosition));
+      (logicalPosition === undefined ? undefined : messageBytes.get(logicalPosition));
     if (serializedBytes === undefined) {
       continue;
     }

--- a/src/config/sessions/session-accessor.sqlite-reset-window.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-window.ts
@@ -88,31 +88,17 @@ function parseMessageEventRow(row: {
   };
 }
 
-function readMessageRange(
-  projection: ResetWindowProjection,
-  start: number,
-  endExclusive: number,
-): ResetWindowMessageEvent[] {
-  if (endExclusive <= start) {
-    return [];
-  }
-  const db = getResetWindowKysely(projection.database);
-  return executeSqliteQuerySync(
-    projection.database.db,
-    db
-      .selectFrom("session_transcript_active_events as active")
-      .innerJoin("transcript_events as event", (join) =>
-        join
-          .onRef("event.session_id", "=", "active.session_id")
-          .onRef("event.seq", "=", "active.event_seq"),
-      )
-      .select(["active.event_seq", "active.message_position", "event.event_json"])
-      .where("active.session_id", "=", projection.resolved.sessionId)
-      .where("active.message_position", "is not", null)
-      .where("active.message_position", ">=", start)
-      .where("active.message_position", "<", endExclusive)
-      .orderBy("active.message_position", "asc"),
-  ).rows.map(parseMessageEventRow);
+function selectMessageRows(projection: ResetWindowProjection) {
+  return getResetWindowKysely(projection.database)
+    .selectFrom("session_transcript_active_events as active")
+    .innerJoin("transcript_events as event", (join) =>
+      join
+        .onRef("event.session_id", "=", "active.session_id")
+        .onRef("event.seq", "=", "active.event_seq"),
+    )
+    .where("active.session_id", "=", projection.resolved.sessionId)
+    .where("active.message_position", "is not", null)
+    .orderBy("active.message_position", "asc");
 }
 
 function resetMessageWindowCacheKey(projection: ResetWindowProjection): string {
@@ -345,54 +331,82 @@ export function resolveVisibleMessagePositions(
   };
 }
 
+function selectVisibleMessageRanges(
+  projection: ResetWindowProjection,
+  start: number,
+  endExclusive: number,
+) {
+  const ranges: Array<{
+    query: ReturnType<typeof selectMessageRows>;
+    logicalPosition: (position: number) => number;
+  }> = [];
+  if (endExclusive <= start) {
+    return ranges;
+  }
+  const visible = resolveVisibleMessagePositions(projection);
+  const boundedStart = Math.min(Math.max(0, start), visible.total);
+  const boundedEnd = Math.min(Math.max(boundedStart, endExclusive), visible.total);
+  const query = selectMessageRows(projection);
+  const keptEnd = Math.min(boundedEnd, visible.kept.length);
+  // Reset tails have holes where tool results were discarded. Batch exact retained
+  // positions below SQLite's binding limit; sparse tails must not become N+1 reads.
+  for (let offset = boundedStart; offset < keptEnd; offset += 500) {
+    const positions = visible.kept.slice(offset, Math.min(offset + 500, keptEnd));
+    const ordinals = new Map(positions.map((position, index) => [position, offset + index]));
+    ranges.push({
+      query: query.where("active.message_position", "in", positions),
+      logicalPosition: (position) => ordinals.get(position)!,
+    });
+  }
+  const logicalStart = Math.max(boundedStart, visible.kept.length);
+  if (boundedEnd > logicalStart) {
+    const rawStart = visible.postStart + logicalStart - visible.kept.length;
+    ranges.push({
+      query: query
+        .where("active.message_position", ">=", rawStart)
+        .where("active.message_position", "<", rawStart + boundedEnd - logicalStart),
+      logicalPosition: (position) => logicalStart + position - rawStart,
+    });
+  }
+  return ranges;
+}
+
 export function readVisibleMessageRange(
   projection: ResetWindowProjection,
   start: number,
   endExclusive: number,
 ): ResetWindowMessageEvent[] {
-  if (endExclusive <= start) {
-    return [];
-  }
-  const visible = resolveVisibleMessagePositions(projection);
-  const boundedStart = Math.min(Math.max(0, start), visible.total);
-  const boundedEnd = Math.min(Math.max(boundedStart, endExclusive), visible.total);
-  if (boundedEnd <= boundedStart) {
-    return [];
-  }
-  const keptEnd = Math.min(boundedEnd, visible.kept.length);
-  const keptEvents = visible.kept
-    .slice(boundedStart, keptEnd)
-    .flatMap((position) => readMessageRange(projection, position, position + 1));
-  const postVisibleStart = Math.max(boundedStart, visible.kept.length);
-  const postVisibleEnd = Math.max(postVisibleStart, boundedEnd);
-  const postEvents = readMessageRange(
-    projection,
-    visible.postStart + postVisibleStart - visible.kept.length,
-    visible.postStart + postVisibleEnd - visible.kept.length,
+  return selectVisibleMessageRanges(projection, start, endExclusive).flatMap((range) =>
+    executeSqliteQuerySync(
+      projection.database.db,
+      range.query.select(["active.event_seq", "active.message_position", "event.event_json"]),
+    ).rows.map(parseMessageEventRow),
   );
-  return [...keptEvents, ...postEvents];
 }
 
-/** Maps a logical visible-message range to its materialized message positions. */
-export function resolveVisibleMessagePositionRange(
+/** Sizes the same logical ranges without fetching or parsing excluded payloads. */
+export function readVisibleMessageMetadata(
   projection: ResetWindowProjection,
   start: number,
   endExclusive: number,
-): number[] {
-  if (endExclusive <= start) {
-    return [];
-  }
-  const visible = resolveVisibleMessagePositions(projection);
-  const boundedStart = Math.min(Math.max(0, start), visible.total);
-  const boundedEnd = Math.min(Math.max(boundedStart, endExclusive), visible.total);
-  const keptEnd = Math.min(boundedEnd, visible.kept.length);
-  const positions = visible.kept.slice(boundedStart, keptEnd);
-  const postVisibleStart = Math.max(boundedStart, visible.kept.length);
-  const postVisibleEnd = Math.max(postVisibleStart, boundedEnd);
-  for (let logical = postVisibleStart; logical < postVisibleEnd; logical += 1) {
-    positions.push(visible.postStart + logical - visible.kept.length);
-  }
-  return positions;
+) {
+  return selectVisibleMessageRanges(projection, start, endExclusive).flatMap((range) =>
+    executeSqliteQuerySync(
+      projection.database.db,
+      range.query
+        .select([
+          "active.message_position",
+          /* kysely-allow-raw: byte caps include each event's JSONL newline. */
+          sql<number>`OCTET_LENGTH(event.event_json) + 1`.as("serialized_bytes"),
+        ])
+        .$narrowType<{ message_position: number }>(),
+    ).rows.map((row) => ({
+      message_position: row.message_position,
+      serialized_bytes: row.serialized_bytes,
+      // Position-based mapping preserves logical holes if a joined row is absent.
+      logicalPosition: range.logicalPosition(row.message_position),
+    })),
+  );
 }
 
 /** Reads logical transcript bytes, reusing cached retained-tail facts after resets. */


### PR DESCRIPTION
Related: #133635 (earlier chat-history preparation optimizations).

## What Problem This Solves

Chat history can still pause while loading a large retained conversation after a session reset. Profiling showed the history reader issuing a separate payload query for each retained message and building large SQL binding lists for ordinary contiguous pages.

## Why This Change Was Made

The reset-window owner now prepares one shared selection for payload reads and byte sizing: indexed range predicates for the contiguous tail, and batches of 500 exact retained positions after a reset. Exact positions preserve gaps where tool results were discarded. Both history paging and bounded-tail salvage use this selection, removing duplicated query construction and the expanded-position helper.

Byte selection still happens before payload materialization. Reset boundaries, logical ordinals, ordering, snapshot ownership, and sparse salvage remain intact. There are no schema, index, persistence, cache-lifetime, protocol, or page-size changes.

Production: **+89/-113 (net -24 lines)**. Tests: **+74/-17 (net +57 lines)**.

## User Impact

Faster initial history loading and older-page loading after resets, with the same returned messages. Ordinary initial SQLite history reads also show a smaller improvement in paired measurements.

## Evidence

Node 26.8.1 on macOS arm64, using real isolated SQLite through `readChatHistoryPage`. Each fixture contains 3,000 visible messages; reset fixtures add a reset marker, and the sparse fixture also contains 2,999 discarded orphan tool results. Five warmups and 30 measured rounds per scenario, with rotated scenario order. These are Gateway preparation timings, excluding serialization, fixture setup, assertions, network, and browser paint.

| Fixture / request | Before median | After median | Reduction |
|---|---:|---:|---:|
| Rich reset history, initial 400 | 51.595 ms | 17.631 ms | 65.8% |
| Rich reset history, older 1,000 | 36.418 ms | 11.891 ms | 67.3% |
| Sparse reset history, initial 400 | 45.038 ms | 19.589 ms | 56.5% |
| Sparse reset history, older 1,000 | 34.423 ms | 13.213 ms | 61.6% |

Sampled Kysely self time across each complete fixture profile fell from 4,025.6 to 80.8 ms for dense reset history and from 3,008.5 to 71.2 ms for sparse reset history. Row iteration and JSON parsing remain the dominant costs.

The separate-process short-message Gateway timings were noisy and sometimes slower (initial 400: 8.938 → 12.355 ms; repeat 11.192 ms), so this PR does **not** claim an overall short-message Gateway speedup. A follow-up paired test ran the original and refactored readers against the same database in one process, alternating order, with 20 warmups and 100 measured rounds per case. Initial SQLite reads improved 6.9–12.1%; the initial-400 reader measured 4.256 → 3.894 ms. All 600 paired results, including warmups, were identical without normalization.

Validation:

- **69 tests passed across eight files**, covering history paging, reset/compaction markers, archived reads, byte caps, excluded corrupt JSON, concurrent snapshots, sparse salvage, and 100,000-message bounded reads.
- Both new binding-limit regression cases were run against the original production code and failed with `too many SQL variables`; both pass after the refactor. The sparse reset regression verifies 1,001 retained messages, discarded tool-result gaps, marker ordering, and an offset page across a batch boundary.
- **25 pages / 13,500 returned messages** compare deeply equal after normalizing only the per-database `__openclaw.transcriptPosition.source`. Source format and within-fixture consistency are checked before normalization; all other fields are compared. Requested counts and pagination totals are asserted during measurement.
- Targeted type-aware lint, formatting, and independent Codex autoreview passed; the review used the configured P0 threshold and reported no accepted/actionable findings.
- `check:changed` passed repository guards, formatting, export scans, plugin boundaries, and the core graph boundary. It stopped at six existing TS2339 errors in `src/logging/logger.ts` for `tslog`'s `attachTransport`/`settings` declarations in the shared local dependency install. No changed-file type errors were reported; later gate stages, including core test typechecking, did not run.

```sh
node scripts/run-vitest.mjs \
  src/config/sessions/session-accessor.sqlite-history-events.test.ts \
  src/config/sessions/session-accessor.sqlite-active-events.test.ts \
  src/config/sessions/session-accessor.sqlite-byte-size.test.ts \
  src/config/sessions/session-accessor.sqlite-bounded-context.test.ts \
  src/gateway/session-transcript-readers.test.ts \
  src/gateway/session-transcript-readers.markers.test.ts \
  src/gateway/server-methods/chat-history-pages.test.ts \
  src/gateway/server-methods/chat-history-handler.test.ts
```

Browser-proof limitation: the local runtime/UI build remains blocked by the missing `shiki/wasm` module in the shared worktree dependency installation (rechecked during landing). Earlier build output also showed unresolved `lit-html` imports. No new browser capture or browser-paint measurement is claimed; the profiling exercises the real SQLite-to-Gateway history reader and verifies complete returned pages.

Measurements and the full test run used base `cf25af4699bfcfdbebd0509b7756045767882714`. The four changed files were verified byte-identical after rebasing onto current main. The history-event suite was rerun after rebase.

<details>
<summary>Reproduce the Gateway benchmark</summary>

Save the following temporary file as `src/gateway/server-methods/chat-history-window.measurement.test.ts`, run it on the baseline and candidate, then remove it. It writes Node CPU profiles and the complete synthetic message arrays. The timing excludes response serialization; serialization is measured separately.

```sh
OPENCLAW_HISTORY_PROFILE_OUTPUT=.artifacts/history-profile/<run> node scripts/run-vitest.mjs src/gateway/server-methods/chat-history-window.measurement.test.ts
```

```ts
import { createHash } from "node:crypto";
import { mkdir, writeFile } from "node:fs/promises";
import { Session } from "node:inspector/promises";
// Temporary measurement harness; remove after recording the benchmark results.
import path from "node:path";
import { performance } from "node:perf_hooks";
import { expect, test } from "vitest";
import { INBOUND_CONTEXT_MARKER } from "../../auto-reply/reply/inbound-context-marker.js";
import {
  appendTranscriptEvent,
  persistSessionTranscriptTurn,
  upsertSessionEntryCore,
} from "../../config/sessions/session-accessor.js";
import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
import { getMaxChatHistoryMessagesBytes } from "../server-constants.js";
import { readChatHistoryPage } from "./chat-history-pages.js";

const WINDOW_SIZES = [100, 200, 400, 1000];
const SCENARIOS = [
  ...WINDOW_SIZES.map((limit) => ({ name: `initial-${limit}`, limit, offset: undefined })),
  { name: "older-1000", limit: 1000, offset: 1000 },
];
const TRANSCRIPT_MESSAGES = 3000;
const WARMUP_ROUNDS = 5;
const MEASUREMENT_ROUNDS = 30;

function summarize(samples: number[]) {
  const sorted = samples.toSorted((left, right) => left - right);
  const rounded = (value: number) => Math.round(value * 1000) / 1000;
  return {
    median: rounded(sorted[Math.floor(sorted.length / 2)]!),
    p95: rounded(sorted[Math.ceil(sorted.length * 0.95) - 1]!),
    min: rounded(sorted[0]!),
    max: rounded(sorted.at(-1)!),
  };
}

test("measures indexed initial history windows with real SQLite projection", async () => {
  await withStateDirEnv("openclaw-history-window-measurement-", async ({ stateDir }) => {
    for (const fixture of [
      { name: "short", textChars: 128, metadata: false },
      { name: "rich", textChars: 2048, metadata: false },
      { name: "metadata", textChars: 2048, metadata: true },
      { name: "reset-rich", textChars: 2048, metadata: false },
      { name: "reset-sparse", textChars: 2048, metadata: false },
    ]) {
      const sessionId = `history-window-${fixture.name}`;
      const sessionKey = `agent:main:${sessionId}`;
      const storePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
      const scope = { agentId: "main", sessionId, sessionKey, storePath };
      const entry = { sessionId, updatedAt: 1_780_000_000_000 };
      await upsertSessionEntryCore(scope, entry);
      const paragraph =
        "## Synthetic benchmark\n\nThe session stores a bounded history page. " +
        "**Visible output** includes ordinary markdown, a [documentation link](https://example.com), " +
        "and a short `code` span.\n\n- First step\n- Second step\n\n";
      const text = paragraph
        .repeat(Math.ceil(fixture.textChars / paragraph.length))
        .slice(0, fixture.textChars);
      const written = await persistSessionTranscriptTurn(scope, {
        expectedSessionId: sessionId,
        messages: Array.from({ length: TRANSCRIPT_MESSAGES }, (_, index) => ({
          eventId: `window-${fixture.name}-${index}`,
          parentId:
            index === 0
              ? null
              : fixture.name === "reset-sparse"
                ? `tool-${index - 1}`
                : `window-${fixture.name}-${index - 1}`,
          message: {
            role: index % 2 === 0 ? "user" : "assistant",
            content: [
              {
                type: "text",
                text:
                  (fixture.metadata && index % 2 === 0
                    ? `Conversation info: ${INBOUND_CONTEXT_MARKER}\n\`\`\`json\n{"topic":"synthetic"}\n\`\`\`\n\n`
                    : "") + `Message ${index}: ${text}`,
              },
            ],
            timestamp: entry.updatedAt + index,
          },
          now: entry.updatedAt + index,
        })).flatMap((message, index) =>
          fixture.name !== "reset-sparse" || index === TRANSCRIPT_MESSAGES - 1
            ? [message]
            : [
                message,
                {
                  eventId: `tool-${index}`,
                  parentId: message.eventId,
                  message: {
                    role: "toolResult",
                    content: [{ type: "text", text: "hidden orphan tool result" }],
                    timestamp: entry.updatedAt + index,
                  },
                  now: entry.updatedAt + index,
                },
              ],
        ),
        touchSessionEntry: false,
        updateMode: "none",
      });
      expect(written.appendedCount).toBe(
        TRANSCRIPT_MESSAGES + (fixture.name === "reset-sparse" ? TRANSCRIPT_MESSAGES - 1 : 0),
      );
      if (fixture.name.startsWith("reset-")) {
        await appendTranscriptEvent(scope, {
          type: "reset",
          id: "reset-boundary",
          parentId: `window-${fixture.name}-2999`,
          timestamp: "2026-08-30T00:00:00.000Z",
          reason: "new",
          firstKeptEntryId: `window-${fixture.name}-0`,
        });
      }
      const profiler = new Session();
      profiler.connect();
      await profiler.post("Profiler.enable");
      await profiler.post("Profiler.start");
      const samples = new Map(
        SCENARIOS.map((scenario) => [
          scenario.name,
          { readMs: [] as number[], jsonMs: [] as number[], bytes: 0, sha256: "", payload: "" },
        ]),
      );
      for (let round = 0; round < WARMUP_ROUNDS + MEASUREMENT_ROUNDS; round++) {
        // Rotate the order so the largest window does not always inherit the same cache order.
        const rotation = round % SCENARIOS.length;
        const scenarios = [...SCENARIOS.slice(rotation), ...SCENARIOS.slice(0, rotation)];
        for (const scenario of scenarios) {
          const { limit, offset } = scenario;
          const start = performance.now();
          const page = await readChatHistoryPage({
            entry,
            provider: undefined,
            sessionId,
            storePath,
            sessionAgentId: "main",
            canonicalKey: sessionKey,
            max: limit,
            maxHistoryBytes: getMaxChatHistoryMessagesBytes(),
            effectiveMaxChars: 12_000,
            offset,
            messageId: undefined,
          });
          const readMs = performance.now() - start;
          const serializeStart = performance.now();
          const serialized = JSON.stringify(page.messages);
          const jsonMs = performance.now() - serializeStart;
          expect(page.messages).toHaveLength(limit);
          expect(page.pagination?.totalMessages).toBe(
            TRANSCRIPT_MESSAGES + (fixture.name.startsWith("reset-") ? 1 : 0),
          );
          expect(serialized).toContain(`Message ${TRANSCRIPT_MESSAGES - 1 - (offset ?? 0)}:`);
          expect(serialized).not.toContain(INBOUND_CONTEXT_MARKER);
          if (round >= WARMUP_ROUNDS) {
            const sample = samples.get(scenario.name)!;
            sample.readMs.push(readMs);
            sample.jsonMs.push(jsonMs);
            sample.payload = serialized;
            sample.bytes = Buffer.byteLength(serialized, "utf8");
            sample.sha256 = createHash("sha256").update(serialized).digest("hex");
          }
        }
      }
      const { profile } = await profiler.post("Profiler.stop");
      profiler.disconnect();
      const profileDir =
        process.env.OPENCLAW_HISTORY_PROFILE_OUTPUT ??
        ".artifacts/control-ui-e2e/history-window-perf/node-before";
      await mkdir(profileDir, { recursive: true });
      await writeFile(path.join(profileDir, `${fixture.name}.cpuprofile`), JSON.stringify(profile));
      for (const scenario of SCENARIOS) {
        const sample = samples.get(scenario.name)!;
        await writeFile(
          path.join(profileDir, `${fixture.name}-${scenario.name}.json`),
          sample.payload,
        );
        console.log(
          "HISTORY_WINDOW_MEASUREMENT=" +
            JSON.stringify({
              fixture: fixture.name,
              textChars: fixture.textChars,
              transcriptMessages: TRANSCRIPT_MESSAGES,
              scenario: scenario.name,
              limit: scenario.limit,
              warmups: WARMUP_ROUNDS,
              iterations: MEASUREMENT_ROUNDS,
              messageJsonBytes: sample.bytes,
              messageJsonSha256: sample.sha256,
              readPageMs: summarize(sample.readMs),
              serializeMs: summarize(sample.jsonMs),
            }),
        );
      }
    }
  });
}, 180_000);
```

</details>

