### PR TITLE
fix(gateway): reduce control-plane stalls during concurrent turns

### DIFF
--- a/docs/diagnostics/flags.md
+++ b/docs/diagnostics/flags.md
@@ -150,6 +150,12 @@ counts, event-loop delay samples, provider operation names, child-process exit
 state, and startup error names/messages. Treat timeline files as local
 diagnostics artifacts; review before sharing them outside your machine.
 
+Timeline writes batch adjacent events with the same destination into a bounded
+64 KiB buffer, flushed on the next event-loop turn, at capacity, or on normal
+process exit. Event timestamps reflect emission time. Writes remain best-effort;
+a forced kill can lose pending output. External harnesses should read the final
+artifact after the process exits and must not truncate it while the process runs.
+
 ## Where logs go
 
 Flags emit logs into the standard diagnostics log file. By default:

--- a/scripts/bench-gateway-concurrency.ts
+++ b/scripts/bench-gateway-concurrency.ts
@@ -1002,369 +1002,373 @@ async function runGatewaySample(options: {
   const auxiliaryClients: Array<Awaited<ReturnType<typeof connectGateway>>> = [];
   let gatewayOutput = { readOutput: () => "", readStderrTail: () => "" };
   let mockOutput = { readOutput: () => "", readStderrTail: () => "" };
-  let result: BenchmarkRun | undefined;
+  let result: BenchmarkRun;
+  let gatewayExit: Awaited<ReturnType<typeof stopChild>> | undefined;
   let timelineWindow: { from: number; through: number } | undefined;
 
   try {
-    const configPath = buildConfig(root, mockPort, options.concurrency, options.pluginCount);
-    mockProvider = spawn(process.execPath, ["scripts/e2e/mock-openai-server.mjs"], {
-      cwd: process.cwd(),
-      detached: process.platform !== "win32",
-      env: {
-        LANG: process.env.LANG ?? "en_US.UTF-8",
-        PATH: process.env.PATH,
-        MOCK_PORT: String(mockPort),
-        MOCK_REQUEST_LOG: requestLogPath,
-        MOCK_RESPONSE_CHUNK_DELAY_MS: String(options.streamChunkDelayMs),
-        SUCCESS_MARKER: "OpenClaw gateway concurrency benchmark streaming response.",
-      },
-    });
-    mockOutput = captureChildOutput(mockProvider);
-    await waitForMockServer(mockPort, options.deadlineAt);
-
-    if (options.cpuProfDir) {
-      mkdirSync(options.cpuProfDir, { recursive: true });
-    }
-    const gatewayArgs = buildGatewayBenchChildArgs(options.entry, port);
-    gateway = spawn(
-      process.execPath,
-      options.cpuProfDir
-        ? ["--cpu-prof", `--cpu-prof-dir=${options.cpuProfDir}`, ...gatewayArgs]
-        : gatewayArgs,
-      {
+    try {
+      const configPath = buildConfig(root, mockPort, options.concurrency, options.pluginCount);
+      mockProvider = spawn(process.execPath, ["scripts/e2e/mock-openai-server.mjs"], {
         cwd: process.cwd(),
         detached: process.platform !== "win32",
         env: {
-          ...createGatewayBenchEnv(root, configPath, {
-            caseEnv: {
-              ...(options.diagnosticsTimeline
-                ? {
-                    OPENCLAW_DIAGNOSTICS: "timeline",
-                    OPENCLAW_DIAGNOSTICS_TIMELINE_PATH: timelinePath,
-                  }
-                : {}),
-              OPENCLAW_SKIP_CHANNELS: "1",
-            },
-          }),
-          OPENAI_API_KEY: "gateway-concurrency-benchmark",
+          LANG: process.env.LANG ?? "en_US.UTF-8",
+          PATH: process.env.PATH,
+          MOCK_PORT: String(mockPort),
+          MOCK_REQUEST_LOG: requestLogPath,
+          MOCK_RESPONSE_CHUNK_DELAY_MS: String(options.streamChunkDelayMs),
+          SUCCESS_MARKER: "OpenClaw gateway concurrency benchmark streaming response.",
         },
-      },
-    );
-    gatewayOutput = captureChildOutput(gateway);
-    const ready = await waitForInitialProbe({
-      deadlineAt: options.deadlineAt,
-      isDone: () => gateway?.exitCode != null || gateway?.signalCode != null,
-      path: "/readyz",
-      port,
-      startAt: runStartedAt,
-    });
-    if (ready.status !== 200) {
-      throw new Error(`gateway did not become ready\n${gatewayOutput.readOutput()}`);
-    }
-    await waitForGatewayDispatchReady(gatewayOutput.readOutput, options.deadlineAt);
-    client = await connectGateway(port, options.deadlineAt, protocolVersion);
-    const rpc = client.request;
-    if (options.visibleObserver) {
-      await rpc("sessions.observer.visibility", { visible: true });
-    }
-    // The first authenticated RPC lazily imports the server-method graph. It measured 6.9s
-    // on an idle M4 Pro (previously 18.4s) and crossed 20s on Linux; hot probes took 15-40ms.
-    // Keep that cold work out of the load-phase deadline and latency distributions.
-    const probeWarmupDeadlineAt = performance.now() + PROBE_WARMUP_TIMEOUT_MS;
-    client.setDeadlineAt(probeWarmupDeadlineAt);
-    const probeWarmup = await warmGatewayProbes({
-      deadlineAt: probeWarmupDeadlineAt,
-      sample: (deadlineAt) =>
-        sampleGateway({
-          deadlineAt,
-          port,
-          rpc,
-          runStartedAt,
-        }),
-    });
-    const setupDeadlineAt = performance.now() + options.timeoutMs;
-    const setupStartedAt = performance.now();
-    client.setDeadlineAt(setupDeadlineAt);
-    const sessionCount = Math.max(options.concurrency, options.sessionCount);
-    const prepareSessions =
-      options.workspaceFanout ||
-      options.sessionCount > 0 ||
-      options.historyClients > 0 ||
-      options.sessionUpdates > 0 ||
-      options.subscribers > 0;
-    const sessionKeys = Array.from(
-      { length: sessionCount },
-      (_, index) => `agent:main:gateway-concurrency-${index + 1}`,
-    );
-    const sessionSeedStartedAt = performance.now();
-    if (prepareSessions) {
-      let nextSessionIndex = 0;
-      let seededSessionCount = 0;
-      await Promise.all(
-        Array.from({ length: Math.min(MAX_SESSION_SEED_CONCURRENCY, sessionCount) }, async () => {
-          for (;;) {
-            const index = nextSessionIndex++;
-            const sessionKey = sessionKeys[index];
-            if (!sessionKey) {
-              return;
-            }
-            const workspaceDir = options.workspaceFanout
-              ? path.join(root, `workspace-${index + 1}`)
-              : undefined;
-            if (workspaceDir) {
-              mkdirSync(workspaceDir, { recursive: true });
-            }
-            await rpc("sessions.create", {
-              key: sessionKey,
-              agentId: "main",
-              ...(workspaceDir ? { cwd: workspaceDir } : {}),
-            });
-            seededSessionCount += 1;
-            if (sessionCount >= 250 && seededSessionCount % 250 === 0) {
-              console.error(
-                `[bench-gateway-concurrency] seeded ${seededSessionCount}/${sessionCount} sessions`,
-              );
-            }
-          }
-        }),
-      );
-    }
-    const sessionSeedDurationMs = performance.now() - sessionSeedStartedAt;
-    const messageSubscriptions: TimedProbe[] = [];
-    for (let index = 0; index < options.subscribers; index += 1) {
-      const subscriber = await connectGateway(port, setupDeadlineAt, protocolVersion, false);
-      auxiliaryClients.push(subscriber);
-      if (options.visibleObserver) {
-        await subscriber.request("sessions.observer.visibility", { visible: true });
+      });
+      mockOutput = captureChildOutput(mockProvider);
+      await waitForMockServer(mockPort, options.deadlineAt);
+
+      if (options.cpuProfDir) {
+        mkdirSync(options.cpuProfDir, { recursive: true });
       }
-      const subscription = await timeRpcProbe(
-        subscriber.request,
-        "sessions.messages.subscribe",
-        { key: sessionKeys[index % sessionKeys.length] },
-        runStartedAt,
-      );
-      messageSubscriptions.push(subscription);
-      if (!subscription.ok) {
-        throw new Error(`session message subscription failed: ${subscription.error}`);
-      }
-    }
-    const historyClients = await Promise.all(
-      Array.from({ length: options.historyClients }, async () => {
-        const historyClient = await connectGateway(port, setupDeadlineAt, protocolVersion, false);
-        auxiliaryClients.push(historyClient);
-        return historyClient;
-      }),
-    );
-    const sessionUpdateClients = await Promise.all(
-      Array.from(
-        { length: options.sessionUpdates > 0 ? options.sessionUpdateClients : 0 },
-        async () => {
-          const updateClient = await connectGateway(port, setupDeadlineAt, protocolVersion, false);
-          auxiliaryClients.push(updateClient);
-          return updateClient;
-        },
-      ),
-    );
-    const subscriptionProbeClient =
-      options.subscribers > 0
-        ? await connectGateway(port, setupDeadlineAt, protocolVersion, false)
-        : undefined;
-    if (subscriptionProbeClient) {
-      auxiliaryClients.push(subscriptionProbeClient);
-    }
-    const memoryBefore = await readGatewayMemory(rpc, runStartedAt);
-    const setupDurationMs = performance.now() - setupStartedAt;
-    // Large session fixtures are setup, not benchmarked load. Every measured
-    // run therefore gets its complete timeout after all clients are ready.
-    const loadDeadlineAt = performance.now() + options.timeoutMs;
-    client.setDeadlineAt(loadDeadlineAt);
-    for (const auxiliaryClient of auxiliaryClients) {
-      auxiliaryClient.setDeadlineAt(loadDeadlineAt);
-    }
-    const controlUi: ControlUiProbe[] = [];
-    const history: TimedProbe[] = [];
-    const messageSubscriptionsDuringLoad: TimedProbe[] = [];
-    const readyz: ReadyProbe[] = [];
-    const sessionsList: TimedProbe[] = [];
-    const sessionUpdates: TimedProbe[] = [];
-    let peakRssMb = memoryBefore.rssMb;
-    let lastRssSampleAt = performance.now();
-    let turnsDone = false;
-    let updatesDone = options.sessionUpdates === 0;
-    const workloadDone = () => turnsDone && updatesDone;
-    let startedTurnCount = 0;
-    let resolveAllTurnsStarted!: () => void;
-    const allTurnsStarted = new Promise<void>((resolve) => {
-      resolveAllTurnsStarted = resolve;
-    });
-    const turnsStartedAt = performance.now();
-    // Keep the live artifact intact: buffered setup writes can arrive after this boundary.
-    // Inclusive millisecond timestamps conservatively include events on the boundary.
-    const timelineFrom = Date.now();
-    const turns = Promise.all(
-      Array.from({ length: options.concurrency }, (_, index) =>
-        runTurn(rpc, index, loadDeadlineAt, options.toolEvents, {
-          onStarted: () => {
-            startedTurnCount += 1;
-            if (startedTurnCount === options.concurrency) {
-              resolveAllTurnsStarted();
-            }
+      const gatewayArgs = buildGatewayBenchChildArgs(options.entry, port);
+      gateway = spawn(
+        process.execPath,
+        options.cpuProfDir
+          ? ["--cpu-prof", `--cpu-prof-dir=${options.cpuProfDir}`, ...gatewayArgs]
+          : gatewayArgs,
+        {
+          cwd: process.cwd(),
+          detached: process.platform !== "win32",
+          env: {
+            ...createGatewayBenchEnv(root, configPath, {
+              caseEnv: {
+                ...(options.diagnosticsTimeline
+                  ? {
+                      OPENCLAW_DIAGNOSTICS: "timeline",
+                      OPENCLAW_DIAGNOSTICS_TIMELINE_PATH: timelinePath,
+                    }
+                  : {}),
+                OPENCLAW_SKIP_CHANNELS: "1",
+              },
+            }),
+            OPENAI_API_KEY: "gateway-concurrency-benchmark",
           },
-          ...(sessionKeys[index] ? { sessionKey: sessionKeys[index] } : {}),
-        }),
-      ),
-    ).finally(() => {
-      turnsDone = true;
-      resolveAllTurnsStarted();
-    });
-    const freshConnection = allTurnsStarted.then(async (): Promise<FreshConnectionProbe> => {
-      const startedAt = performance.now();
-      try {
-        const freshClient = await connectGateway(port, loadDeadlineAt, protocolVersion, false);
-        freshClient.close();
-        return { error: null, latencyMs: performance.now() - startedAt, ok: true };
-      } catch (error) {
-        return {
-          error: describeProbeError(error),
-          latencyMs: performance.now() - startedAt,
-          ok: false,
-        };
+        },
+      );
+      gatewayOutput = captureChildOutput(gateway);
+      const ready = await waitForInitialProbe({
+        deadlineAt: options.deadlineAt,
+        isDone: () => gateway?.exitCode != null || gateway?.signalCode != null,
+        path: "/readyz",
+        port,
+        startAt: runStartedAt,
+      });
+      if (ready.status !== 200) {
+        throw new Error(`gateway did not become ready\n${gatewayOutput.readOutput()}`);
       }
-    });
-    const sampler = (async () => {
-      for (;;) {
-        const sampleStartedAt = performance.now();
-        const subscriptionKey = sessionKeys[readyz.length % sessionKeys.length];
-        const [sample, subscription] = await Promise.all([
+      await waitForGatewayDispatchReady(gatewayOutput.readOutput, options.deadlineAt);
+      client = await connectGateway(port, options.deadlineAt, protocolVersion);
+      const rpc = client.request;
+      if (options.visibleObserver) {
+        await rpc("sessions.observer.visibility", { visible: true });
+      }
+      // The first authenticated RPC lazily imports the server-method graph. It measured 6.9s
+      // on an idle M4 Pro (previously 18.4s) and crossed 20s on Linux; hot probes took 15-40ms.
+      // Keep that cold work out of the load-phase deadline and latency distributions.
+      const probeWarmupDeadlineAt = performance.now() + PROBE_WARMUP_TIMEOUT_MS;
+      client.setDeadlineAt(probeWarmupDeadlineAt);
+      const probeWarmup = await warmGatewayProbes({
+        deadlineAt: probeWarmupDeadlineAt,
+        sample: (deadlineAt) =>
           sampleGateway({
-            deadlineAt: loadDeadlineAt,
+            deadlineAt,
             port,
             rpc,
             runStartedAt,
           }),
-          subscriptionProbeClient && subscriptionKey
-            ? timeRpcProbe(
-                subscriptionProbeClient.request,
-                "sessions.messages.subscribe",
-                { key: subscriptionKey },
-                runStartedAt,
-              )
-            : Promise.resolve(undefined),
-        ]);
-        if (subscription) {
-          messageSubscriptionsDuringLoad.push(subscription);
-          if (subscription.ok) {
-            await subscriptionProbeClient?.request("sessions.messages.unsubscribe", {
-              key: subscriptionKey,
-            });
-          }
-        }
-        readyz.push(sample.readyz);
-        sessionsList.push(sample.sessionsList);
-        controlUi.push(sample.controlUi);
-        if (performance.now() - lastRssSampleAt >= 1_000) {
-          // Linux reads procfs without spawning a process. Non-Linux hosts use
-          // the shared ps fallback at most once per second to bound perturbation.
-          peakRssMb = Math.max(peakRssMb, readGatewayProcessRssMb(gateway?.pid) ?? 0);
-          lastRssSampleAt = performance.now();
-        }
-        if (workloadDone() || readyz.length >= MAX_SAMPLES_PER_RUN) {
-          break;
-        }
-        await delay(
-          Math.min(
-            Math.max(0, options.cadenceMs - (performance.now() - sampleStartedAt)),
-            requireRemainingMs(loadDeadlineAt, "sampling gateway load"),
-          ),
+      });
+      const setupDeadlineAt = performance.now() + options.timeoutMs;
+      const setupStartedAt = performance.now();
+      client.setDeadlineAt(setupDeadlineAt);
+      const sessionCount = Math.max(options.concurrency, options.sessionCount);
+      const prepareSessions =
+        options.workspaceFanout ||
+        options.sessionCount > 0 ||
+        options.historyClients > 0 ||
+        options.sessionUpdates > 0 ||
+        options.subscribers > 0;
+      const sessionKeys = Array.from(
+        { length: sessionCount },
+        (_, index) => `agent:main:gateway-concurrency-${index + 1}`,
+      );
+      const sessionSeedStartedAt = performance.now();
+      if (prepareSessions) {
+        let nextSessionIndex = 0;
+        let seededSessionCount = 0;
+        await Promise.all(
+          Array.from({ length: Math.min(MAX_SESSION_SEED_CONCURRENCY, sessionCount) }, async () => {
+            for (;;) {
+              const index = nextSessionIndex++;
+              const sessionKey = sessionKeys[index];
+              if (!sessionKey) {
+                return;
+              }
+              const workspaceDir = options.workspaceFanout
+                ? path.join(root, `workspace-${index + 1}`)
+                : undefined;
+              if (workspaceDir) {
+                mkdirSync(workspaceDir, { recursive: true });
+              }
+              await rpc("sessions.create", {
+                key: sessionKey,
+                agentId: "main",
+                ...(workspaceDir ? { cwd: workspaceDir } : {}),
+              });
+              seededSessionCount += 1;
+              if (sessionCount >= 250 && seededSessionCount % 250 === 0) {
+                console.error(
+                  `[bench-gateway-concurrency] seeded ${seededSessionCount}/${sessionCount} sessions`,
+                );
+              }
+            }
+          }),
         );
       }
-    })();
-    const historyLoad = Promise.all(
-      historyClients.map(async (historyClient, clientIndex) => {
-        let offset = clientIndex * options.historyBurst;
-        while (!workloadDone() && history.length < MAX_SAMPLES_PER_RUN) {
-          const probes = await Promise.all(
-            Array.from({ length: options.historyBurst }, (_, index) =>
-              timeRpcProbe(
-                historyClient.request,
-                "chat.history",
-                { sessionKey: sessionKeys[(offset + index) % sessionKeys.length] },
-                runStartedAt,
-              ),
+      const sessionSeedDurationMs = performance.now() - sessionSeedStartedAt;
+      const messageSubscriptions: TimedProbe[] = [];
+      for (let index = 0; index < options.subscribers; index += 1) {
+        const subscriber = await connectGateway(port, setupDeadlineAt, protocolVersion, false);
+        auxiliaryClients.push(subscriber);
+        if (options.visibleObserver) {
+          await subscriber.request("sessions.observer.visibility", { visible: true });
+        }
+        const subscription = await timeRpcProbe(
+          subscriber.request,
+          "sessions.messages.subscribe",
+          { key: sessionKeys[index % sessionKeys.length] },
+          runStartedAt,
+        );
+        messageSubscriptions.push(subscription);
+        if (!subscription.ok) {
+          throw new Error(`session message subscription failed: ${subscription.error}`);
+        }
+      }
+      const historyClients = await Promise.all(
+        Array.from({ length: options.historyClients }, async () => {
+          const historyClient = await connectGateway(port, setupDeadlineAt, protocolVersion, false);
+          auxiliaryClients.push(historyClient);
+          return historyClient;
+        }),
+      );
+      const sessionUpdateClients = await Promise.all(
+        Array.from(
+          { length: options.sessionUpdates > 0 ? options.sessionUpdateClients : 0 },
+          async () => {
+            const updateClient = await connectGateway(
+              port,
+              setupDeadlineAt,
+              protocolVersion,
+              false,
+            );
+            auxiliaryClients.push(updateClient);
+            return updateClient;
+          },
+        ),
+      );
+      const subscriptionProbeClient =
+        options.subscribers > 0
+          ? await connectGateway(port, setupDeadlineAt, protocolVersion, false)
+          : undefined;
+      if (subscriptionProbeClient) {
+        auxiliaryClients.push(subscriptionProbeClient);
+      }
+      const memoryBefore = await readGatewayMemory(rpc, runStartedAt);
+      const setupDurationMs = performance.now() - setupStartedAt;
+      // Large session fixtures are setup, not benchmarked load. Every measured
+      // run therefore gets its complete timeout after all clients are ready.
+      const loadDeadlineAt = performance.now() + options.timeoutMs;
+      client.setDeadlineAt(loadDeadlineAt);
+      for (const auxiliaryClient of auxiliaryClients) {
+        auxiliaryClient.setDeadlineAt(loadDeadlineAt);
+      }
+      const controlUi: ControlUiProbe[] = [];
+      const history: TimedProbe[] = [];
+      const messageSubscriptionsDuringLoad: TimedProbe[] = [];
+      const readyz: ReadyProbe[] = [];
+      const sessionsList: TimedProbe[] = [];
+      const sessionUpdates: TimedProbe[] = [];
+      let peakRssMb = memoryBefore.rssMb;
+      let lastRssSampleAt = performance.now();
+      let turnsDone = false;
+      let updatesDone = options.sessionUpdates === 0;
+      const workloadDone = () => turnsDone && updatesDone;
+      let startedTurnCount = 0;
+      let resolveAllTurnsStarted!: () => void;
+      const allTurnsStarted = new Promise<void>((resolve) => {
+        resolveAllTurnsStarted = resolve;
+      });
+      const turnsStartedAt = performance.now();
+      // Keep the live artifact intact: buffered setup writes can arrive after this boundary.
+      // Inclusive millisecond timestamps conservatively include events on the boundary.
+      const timelineFrom = Date.now();
+      const turns = Promise.all(
+        Array.from({ length: options.concurrency }, (_, index) =>
+          runTurn(rpc, index, loadDeadlineAt, options.toolEvents, {
+            onStarted: () => {
+              startedTurnCount += 1;
+              if (startedTurnCount === options.concurrency) {
+                resolveAllTurnsStarted();
+              }
+            },
+            ...(sessionKeys[index] ? { sessionKey: sessionKeys[index] } : {}),
+          }),
+        ),
+      ).finally(() => {
+        turnsDone = true;
+        resolveAllTurnsStarted();
+      });
+      const freshConnection = allTurnsStarted.then(async (): Promise<FreshConnectionProbe> => {
+        const startedAt = performance.now();
+        try {
+          const freshClient = await connectGateway(port, loadDeadlineAt, protocolVersion, false);
+          freshClient.close();
+          return { error: null, latencyMs: performance.now() - startedAt, ok: true };
+        } catch (error) {
+          return {
+            error: describeProbeError(error),
+            latencyMs: performance.now() - startedAt,
+            ok: false,
+          };
+        }
+      });
+      const sampler = (async () => {
+        for (;;) {
+          const sampleStartedAt = performance.now();
+          const subscriptionKey = sessionKeys[readyz.length % sessionKeys.length];
+          const [sample, subscription] = await Promise.all([
+            sampleGateway({
+              deadlineAt: loadDeadlineAt,
+              port,
+              rpc,
+              runStartedAt,
+            }),
+            subscriptionProbeClient && subscriptionKey
+              ? timeRpcProbe(
+                  subscriptionProbeClient.request,
+                  "sessions.messages.subscribe",
+                  { key: subscriptionKey },
+                  runStartedAt,
+                )
+              : Promise.resolve(undefined),
+          ]);
+          if (subscription) {
+            messageSubscriptionsDuringLoad.push(subscription);
+            if (subscription.ok) {
+              await subscriptionProbeClient?.request("sessions.messages.unsubscribe", {
+                key: subscriptionKey,
+              });
+            }
+          }
+          readyz.push(sample.readyz);
+          sessionsList.push(sample.sessionsList);
+          controlUi.push(sample.controlUi);
+          if (performance.now() - lastRssSampleAt >= 1_000) {
+            // Linux reads procfs without spawning a process. Non-Linux hosts use
+            // the shared ps fallback at most once per second to bound perturbation.
+            peakRssMb = Math.max(peakRssMb, readGatewayProcessRssMb(gateway?.pid) ?? 0);
+            lastRssSampleAt = performance.now();
+          }
+          if (workloadDone() || readyz.length >= MAX_SAMPLES_PER_RUN) {
+            break;
+          }
+          await delay(
+            Math.min(
+              Math.max(0, options.cadenceMs - (performance.now() - sampleStartedAt)),
+              requireRemainingMs(loadDeadlineAt, "sampling gateway load"),
             ),
           );
-          history.push(...probes);
-          offset += options.historyBurst;
-          if (!workloadDone()) {
-            await delay(Math.min(options.cadenceMs, remainingMs(loadDeadlineAt)));
-          }
         }
-      }),
-    );
-    let nextUpdateIndex = 0;
-    const sessionUpdateLoad = Promise.all(
-      sessionUpdateClients.map(async (updateClient) => {
-        for (;;) {
-          const index = nextUpdateIndex++;
-          if (index >= options.sessionUpdates) {
-            return;
+      })();
+      const historyLoad = Promise.all(
+        historyClients.map(async (historyClient, clientIndex) => {
+          let offset = clientIndex * options.historyBurst;
+          while (!workloadDone() && history.length < MAX_SAMPLES_PER_RUN) {
+            const probes = await Promise.all(
+              Array.from({ length: options.historyBurst }, (_, index) =>
+                timeRpcProbe(
+                  historyClient.request,
+                  "chat.history",
+                  { sessionKey: sessionKeys[(offset + index) % sessionKeys.length] },
+                  runStartedAt,
+                ),
+              ),
+            );
+            history.push(...probes);
+            offset += options.historyBurst;
+            if (!workloadDone()) {
+              await delay(Math.min(options.cadenceMs, remainingMs(loadDeadlineAt)));
+            }
           }
-          const sessionKey = sessionKeys[index % sessionKeys.length];
-          const update = await timeRpcProbe(
-            updateClient.request,
-            "sessions.patch",
-            { key: sessionKey, label: `Benchmark update ${index + 1}` },
-            runStartedAt,
-          );
-          sessionUpdates.push(update);
-          if (!update.ok) {
-            throw new Error(`sessions.patch load probe failed: ${update.error}`);
+        }),
+      );
+      let nextUpdateIndex = 0;
+      const sessionUpdateLoad = Promise.all(
+        sessionUpdateClients.map(async (updateClient) => {
+          for (;;) {
+            const index = nextUpdateIndex++;
+            if (index >= options.sessionUpdates) {
+              return;
+            }
+            const sessionKey = sessionKeys[index % sessionKeys.length];
+            const update = await timeRpcProbe(
+              updateClient.request,
+              "sessions.patch",
+              { key: sessionKey, label: `Benchmark update ${index + 1}` },
+              runStartedAt,
+            );
+            sessionUpdates.push(update);
+            if (!update.ok) {
+              throw new Error(`sessions.patch load probe failed: ${update.error}`);
+            }
           }
-        }
-      }),
-    ).finally(() => {
-      updatesDone = true;
-    });
-    await Promise.all([turns, sampler, historyLoad, sessionUpdateLoad]);
-    if (options.historyClients > 0 && !history.some((sample) => sample.ok)) {
-      const failure = history[0]?.error ?? "no requests completed before turns finished";
-      throw new Error(`all configured chat.history load probes failed: ${failure}`);
-    }
-    const freshConnectionResult = await freshConnection;
-    const turnsDurationMs = performance.now() - turnsStartedAt;
-    const memoryAfter = await readGatewayMemory(rpc, runStartedAt);
-    peakRssMb = Math.max(peakRssMb, memoryAfter.rssMb);
-    const modelRequestCount = existsSync(requestLogPath)
-      ? readFileSync(requestLogPath, "utf8").split(/\r?\n/u).filter(Boolean).length
-      : 0;
+        }),
+      ).finally(() => {
+        updatesDone = true;
+      });
+      await Promise.all([turns, sampler, historyLoad, sessionUpdateLoad]);
+      if (options.historyClients > 0 && !history.some((sample) => sample.ok)) {
+        const failure = history[0]?.error ?? "no requests completed before turns finished";
+        throw new Error(`all configured chat.history load probes failed: ${failure}`);
+      }
+      const freshConnectionResult = await freshConnection;
+      const turnsDurationMs = performance.now() - turnsStartedAt;
+      const memoryAfter = await readGatewayMemory(rpc, runStartedAt);
+      peakRssMb = Math.max(peakRssMb, memoryAfter.rssMb);
+      const modelRequestCount = existsSync(requestLogPath)
+        ? readFileSync(requestLogPath, "utf8").split(/\r?\n/u).filter(Boolean).length
+        : 0;
 
-    timelineWindow = { from: timelineFrom, through: Date.now() };
-    result = {
-      controlUi,
-      durationMs: performance.now() - runStartedAt,
-      freshConnection: freshConnectionResult,
-      history,
-      memory: { after: memoryAfter, before: memoryBefore, peakRssMb },
-      messageSubscriptions,
-      messageSubscriptionsDuringLoad,
-      modelRequestCount,
-      probeWarmup,
-      pluginMetadataScans: summarizePluginMetadataScans([]),
-      readyz,
-      sessionSeedDurationMs,
-      sessionsList,
-      sessionUpdates,
-      setupDurationMs,
-      turnCount: options.concurrency,
-      turnsDurationMs,
-    };
-    // Finally fills the timeline summary after the child has drained its buffered output.
-    return result;
-  } catch (error) {
-    const detail = formatRunFailure(error, gatewayOutput, mockOutput);
-    throw new Error(detail, { cause: error });
-  } finally {
-    try {
+      timelineWindow = { from: timelineFrom, through: Date.now() };
+      result = {
+        controlUi,
+        durationMs: performance.now() - runStartedAt,
+        freshConnection: freshConnectionResult,
+        history,
+        memory: { after: memoryAfter, before: memoryBefore, peakRssMb },
+        messageSubscriptions,
+        messageSubscriptionsDuringLoad,
+        modelRequestCount,
+        probeWarmup,
+        pluginMetadataScans: summarizePluginMetadataScans([]),
+        readyz,
+        sessionSeedDurationMs,
+        sessionsList,
+        sessionUpdates,
+        setupDurationMs,
+        turnCount: options.concurrency,
+        turnsDurationMs,
+      };
+    } catch (error) {
+      const detail = formatRunFailure(error, gatewayOutput, mockOutput);
+      throw new Error(detail, { cause: error });
+    } finally {
       for (const auxiliaryClient of auxiliaryClients) {
         auxiliaryClient.close();
       }
@@ -1380,23 +1384,27 @@ async function runGatewaySample(options: {
           gateway.kill("SIGINT");
           await Promise.race([profileFlushed, delay(2_000)]);
         }
-        const stopped = await stopChild(gateway);
-        if (result && options.diagnosticsTimeline) {
-          if (stopped.exitCode !== 0 || stopped.signal !== null) {
-            throw new Error("Gateway did not exit cleanly; diagnostics timeline may be incomplete");
-          }
-          if (gatewayOutput.readOutput().includes("[diagnostics] failed to write timeline event")) {
-            throw new Error("Gateway reported a diagnostics timeline write failure");
-          }
-          result.pluginMetadataScans = summarizePluginMetadataScans(
-            readDiagnosticsTimelineSpans(timelinePath, timelineWindow),
-          );
-        }
+        gatewayExit = await stopChild(gateway);
       }
-    } finally {
+    }
+    if (options.diagnosticsTimeline) {
+      if (!gatewayExit || gatewayExit.exitCode !== 0 || gatewayExit.signal !== null) {
+        throw new Error("Gateway did not exit cleanly; diagnostics timeline may be incomplete");
+      }
+      if (gatewayOutput.readOutput().includes("[diagnostics] failed to write timeline event")) {
+        throw new Error("Gateway reported a diagnostics timeline write failure");
+      }
+      result.pluginMetadataScans = summarizePluginMetadataScans(
+        readDiagnosticsTimelineSpans(timelinePath, timelineWindow),
+      );
+    }
+    return result;
+  } finally {
+    try {
       if (mockProvider) {
         await stopChild(mockProvider);
       }
+    } finally {
       rmSync(root, { force: true, maxRetries: 3, recursive: true, retryDelay: 100 });
     }
   }

--- a/scripts/bench-gateway-concurrency.ts
+++ b/scripts/bench-gateway-concurrency.ts
@@ -16,6 +16,7 @@ import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { pathToFileURL } from "node:url";
 import { asFiniteNumber } from "../packages/normalization-core/src/number-coercion.ts";
+import { isRecord } from "../packages/normalization-core/src/record-coerce.ts";
 import { sliceUtf16Safe } from "../packages/normalization-core/src/utf16-slice.ts";
 import { applyMockOpenAiModelConfig } from "./e2e/lib/fixtures/mock-openai-config.mjs";
 import { delay, stopChild } from "./lib/gateway-bench-child.ts";
@@ -346,7 +347,7 @@ Options:
   --subscribers <n> Dedicated session-message subscription clients
   --stream-chunk-delay-ms <n> Mock-provider delay between stream chunks (default: ${MOCK_RESPONSE_CHUNK_DELAY_MS})
   --visible-observer Mark subscribed clients visible to exercise session observation
-  --no-diagnostics-timeline Disable synchronous diagnostics timeline file writes
+  --no-diagnostics-timeline Disable diagnostics timeline file writes
   --plugin-count <n> Configure synthetic plugins through plugins.load.paths (default: 0)
   --tool-events      Make every synthetic turn execute a tool before replying
   --workspace-fanout Bind each turn to a distinct workspace
@@ -395,34 +396,43 @@ function summarizePluginMetadataScans(events: readonly DiagnosticsTimelineSpan[]
   };
 }
 
-function readDiagnosticsTimelineSpans(timelinePath: string): DiagnosticsTimelineSpan[] {
-  try {
-    return readFileSync(timelinePath, "utf8")
-      .split(/\r?\n/u)
-      .filter(Boolean)
-      .flatMap((line) => {
-        try {
-          const event = JSON.parse(line) as {
-            durationMs?: unknown;
-            name?: unknown;
-            type?: unknown;
-          };
-          if (event.type !== "span.end" || typeof event.name !== "string") {
-            return [];
-          }
-          return [
-            {
-              name: event.name,
-              ...(typeof event.durationMs === "number" ? { durationMs: event.durationMs } : {}),
-            },
-          ];
-        } catch {
-          return [];
-        }
-      });
-  } catch {
-    return [];
+function readDiagnosticsTimelineSpans(
+  timelinePath: string,
+  window?: { from: number; through: number },
+): DiagnosticsTimelineSpan[] {
+  const contents = readFileSync(timelinePath, "utf8");
+  if (!contents.trim() || !contents.endsWith("\n")) {
+    throw new Error("diagnostics timeline is empty or incomplete");
   }
+  return contents
+    .split(/\r?\n/u)
+    .filter(Boolean)
+    .flatMap((line) => {
+      const event: unknown = JSON.parse(line);
+      if (
+        !isRecord(event) ||
+        event.schemaVersion !== "openclaw.diagnostics.v1" ||
+        typeof event.timestamp !== "string" ||
+        !Number.isFinite(Date.parse(event.timestamp))
+      ) {
+        throw new Error("invalid diagnostics timeline record");
+      }
+      const timestamp = Date.parse(event.timestamp);
+      if (window && (timestamp < window.from || timestamp > window.through)) {
+        return [];
+      }
+      if (event.type !== "span.end") {
+        return [];
+      }
+      if (
+        typeof event.name !== "string" ||
+        typeof event.durationMs !== "number" ||
+        !Number.isFinite(event.durationMs)
+      ) {
+        throw new Error("invalid diagnostics timeline span");
+      }
+      return [{ name: event.name, durationMs: event.durationMs }];
+    });
 }
 
 function remainingMs(deadlineAt: number): number {
@@ -992,6 +1002,8 @@ async function runGatewaySample(options: {
   const auxiliaryClients: Array<Awaited<ReturnType<typeof connectGateway>>> = [];
   let gatewayOutput = { readOutput: () => "", readStderrTail: () => "" };
   let mockOutput = { readOutput: () => "", readStderrTail: () => "" };
+  let result: BenchmarkRun | undefined;
+  let timelineWindow: { from: number; through: number } | undefined;
 
   try {
     const configPath = buildConfig(root, mockPort, options.concurrency, options.pluginCount);
@@ -1169,11 +1181,6 @@ async function runGatewaySample(options: {
     for (const auxiliaryClient of auxiliaryClients) {
       auxiliaryClient.setDeadlineAt(loadDeadlineAt);
     }
-    // The benchmark compares runtime event work, so discard startup and lazy-import spans.
-    if (options.diagnosticsTimeline) {
-      writeFileSync(timelinePath, "");
-    }
-
     const controlUi: ControlUiProbe[] = [];
     const history: TimedProbe[] = [];
     const messageSubscriptionsDuringLoad: TimedProbe[] = [];
@@ -1191,6 +1198,9 @@ async function runGatewaySample(options: {
       resolveAllTurnsStarted = resolve;
     });
     const turnsStartedAt = performance.now();
+    // Keep the live artifact intact: buffered setup writes can arrive after this boundary.
+    // Inclusive millisecond timestamps conservatively include events on the boundary.
+    const timelineFrom = Date.now();
     const turns = Promise.all(
       Array.from({ length: options.concurrency }, (_, index) =>
         runTurn(rpc, index, loadDeadlineAt, options.toolEvents, {
@@ -1328,7 +1338,8 @@ async function runGatewaySample(options: {
       ? readFileSync(requestLogPath, "utf8").split(/\r?\n/u).filter(Boolean).length
       : 0;
 
-    return {
+    timelineWindow = { from: timelineFrom, through: Date.now() };
+    result = {
       controlUi,
       durationMs: performance.now() - runStartedAt,
       freshConnection: freshConnectionResult,
@@ -1338,9 +1349,7 @@ async function runGatewaySample(options: {
       messageSubscriptionsDuringLoad,
       modelRequestCount,
       probeWarmup,
-      pluginMetadataScans: summarizePluginMetadataScans(
-        options.diagnosticsTimeline ? readDiagnosticsTimelineSpans(timelinePath) : [],
-      ),
+      pluginMetadataScans: summarizePluginMetadataScans([]),
       readyz,
       sessionSeedDurationMs,
       sessionsList,
@@ -1349,31 +1358,47 @@ async function runGatewaySample(options: {
       turnCount: options.concurrency,
       turnsDurationMs,
     };
+    // Finally fills the timeline summary after the child has drained its buffered output.
+    return result;
   } catch (error) {
     const detail = formatRunFailure(error, gatewayOutput, mockOutput);
     throw new Error(detail, { cause: error });
   } finally {
-    for (const auxiliaryClient of auxiliaryClients) {
-      auxiliaryClient.close();
-    }
-    client?.close();
-    if (gateway) {
-      if (options.cpuProfDir && gateway.exitCode === null && gateway.signalCode === null) {
-        // V8 flushes the main-isolate CPU profile on its normal interrupt path.
-        const profileFlushed = new Promise<void>((resolve) => {
-          gateway!.once("exit", () => {
-            resolve();
-          });
-        });
-        gateway.kill("SIGINT");
-        await Promise.race([profileFlushed, delay(2_000)]);
+    try {
+      for (const auxiliaryClient of auxiliaryClients) {
+        auxiliaryClient.close();
       }
-      await stopChild(gateway);
+      client?.close();
+      if (gateway) {
+        if (options.cpuProfDir && gateway.exitCode === null && gateway.signalCode === null) {
+          // V8 flushes the main-isolate CPU profile on its normal interrupt path.
+          const profileFlushed = new Promise<void>((resolve) => {
+            gateway!.once("exit", () => {
+              resolve();
+            });
+          });
+          gateway.kill("SIGINT");
+          await Promise.race([profileFlushed, delay(2_000)]);
+        }
+        const stopped = await stopChild(gateway);
+        if (result && options.diagnosticsTimeline) {
+          if (stopped.exitCode !== 0 || stopped.signal !== null) {
+            throw new Error("Gateway did not exit cleanly; diagnostics timeline may be incomplete");
+          }
+          if (gatewayOutput.readOutput().includes("[diagnostics] failed to write timeline event")) {
+            throw new Error("Gateway reported a diagnostics timeline write failure");
+          }
+          result.pluginMetadataScans = summarizePluginMetadataScans(
+            readDiagnosticsTimelineSpans(timelinePath, timelineWindow),
+          );
+        }
+      }
+    } finally {
+      if (mockProvider) {
+        await stopChild(mockProvider);
+      }
+      rmSync(root, { force: true, maxRetries: 3, recursive: true, retryDelay: 100 });
     }
-    if (mockProvider) {
-      await stopChild(mockProvider);
-    }
-    rmSync(root, { force: true, maxRetries: 3, recursive: true, retryDelay: 100 });
   }
 }
 
@@ -1553,6 +1578,7 @@ export const testing = {
   runBenchmarkSamples,
   runTurn,
   sampleGateway,
+  readDiagnosticsTimelineSpans,
   summarizePluginMetadataScans,
   summarizeNumbers,
   summarizeRuns,

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.test.ts
@@ -6,7 +6,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import { createTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import {
   onInternalDiagnosticEvent,
   resetDiagnosticEventsForTest,
@@ -14,6 +14,7 @@ import {
 } from "../../../infra/diagnostic-events.js";
 import { createDiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
 import { registerDiagnosticTracePropagationBridge } from "../../../infra/diagnostic-trace-propagation.js";
+import { flushDiagnosticsTimeline } from "../../../infra/diagnostics-timeline.js";
 import {
   resetDiagnosticRunActivityForTest,
   startDiagnosticRunActivityTracking,
@@ -26,7 +27,7 @@ import { createHookRunnerWithRegistry } from "../../../plugins/hooks.test-fixtur
 import { withEnvAsync } from "../../../test-utils/env.js";
 import { wrapStreamFnWithDiagnosticModelCallEvents } from "./attempt.model-diagnostic-events.js";
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const tempDirs = createTempDirTracker();
 
 async function collectModelCallEvents(run: () => Promise<void>): Promise<DiagnosticEventPayload[]> {
   // Diagnostics are emitted asynchronously; collect only public model-call
@@ -93,6 +94,7 @@ async function collectProviderTimelineEvents(run: () => Promise<void>) {
     },
     run,
   );
+  flushDiagnosticsTimeline();
   return readFileSync(timelinePath, "utf8")
     .trim()
     .split("\n")
@@ -110,6 +112,8 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents lifecycle", () => {
   });
 
   afterEach(() => {
+    flushDiagnosticsTimeline();
+    tempDirs.cleanup();
     resetDiagnosticEventsForTest();
     resetGlobalHookRunner();
     resetDiagnosticRunActivityForTest();

--- a/src/agents/embedded-agent-runner/run/preparation-timing.test.ts
+++ b/src/agents/embedded-agent-runner/run/preparation-timing.test.ts
@@ -4,11 +4,17 @@ import { join } from "node:path";
 import { setImmediate as yieldToEventLoop } from "node:timers/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
-import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import { createTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import { flushDiagnosticsTimeline } from "../../../infra/diagnostics-timeline.js";
 import { createEmbeddedAttemptPreparation } from "./attempt-preparation.js";
 import { measureEmbeddedAgentPreparation } from "./preparation-timing.js";
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const tempDirs = createTempDirTracker();
+
+afterEach(() => {
+  flushDiagnosticsTimeline();
+  tempDirs.cleanup();
+});
 
 async function createTimelineEnv() {
   const dir = tempDirs.make("openclaw-agent-preparation-");
@@ -22,6 +28,7 @@ async function createTimelineEnv() {
 }
 
 async function readTimeline(path: string) {
+  flushDiagnosticsTimeline();
   return (await readFile(path, "utf8"))
     .trim()
     .split("\n")

--- a/src/agents/startup-timing.test.ts
+++ b/src/agents/startup-timing.test.ts
@@ -2,11 +2,13 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { flushDiagnosticsTimeline } from "../infra/diagnostics-timeline.js";
 import { measureAgentStartup } from "./startup-timing.js";
 
 const tempDirs: string[] = [];
 
 afterEach(async () => {
+  flushDiagnosticsTimeline();
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
@@ -24,6 +26,7 @@ describe("measureAgentStartup", () => {
       "ready",
     );
 
+    flushDiagnosticsTimeline();
     const events = (await readFile(path, "utf8"))
       .trim()
       .split("\n")

--- a/src/cli/command-startup-timing.test.ts
+++ b/src/cli/command-startup-timing.test.ts
@@ -2,11 +2,13 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { flushDiagnosticsTimeline } from "../infra/diagnostics-timeline.js";
 import { measureCliCommandStartup } from "./command-startup-timing.js";
 
 const tempDirs: string[] = [];
 
 afterEach(async () => {
+  flushDiagnosticsTimeline();
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
@@ -34,6 +36,7 @@ describe("measureCliCommandStartup", () => {
       measureCliCommandStartup("config-ready", async () => "ready", { env }),
     ).resolves.toBe("ready");
 
+    flushDiagnosticsTimeline();
     const events = (await readFile(path, "utf8"))
       .trim()
       .split("\n")

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -1,5 +1,8 @@
 // Gateway run loop tests cover foreground gateway lifecycle and restart behavior.
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { GatewayServer } from "../../gateway/server-public.js";
 import type { GatewayBonjourBeacon } from "../../infra/bonjour-discovery.js";
 import type { GatewayActiveWorkSnapshot } from "../../infra/gateway-active-work.js";
@@ -685,24 +688,49 @@ describe("runGatewayLoop", () => {
     await withIsolatedSignals(async ({ captureSignal }) => {
       const { close, start, runtime, exited } = await createSignaledLoopHarness();
       const sigterm = captureSignal("SIGTERM");
+      const { emitDiagnosticsTimelineEvent, flushDiagnosticsTimeline } =
+        await import("../../infra/diagnostics-timeline.js");
+      const tempDirs = createTempDirTracker();
+      const timelinePath = join(tempDirs.make("openclaw-gateway-stop-"), "timeline.jsonl");
+      let timelineAtLogFlush: string | undefined;
+      close.mockImplementationOnce(async () => {
+        emitDiagnosticsTimelineEvent(
+          { type: "mark", name: "gateway.stop" },
+          {
+            env: {
+              OPENCLAW_DIAGNOSTICS: "timeline",
+              OPENCLAW_DIAGNOSTICS_TIMELINE_PATH: timelinePath,
+            },
+          },
+        );
+      });
       flushLogger.mockImplementationOnce(async () => {
         expect(runtime.exit).not.toHaveBeenCalled();
+        timelineAtLogFlush = existsSync(timelinePath)
+          ? readFileSync(timelinePath, "utf8")
+          : undefined;
       });
 
-      sigterm();
+      try {
+        sigterm();
 
-      await expect(exited).resolves.toBe(0);
-      expect(close).toHaveBeenCalledWith({
-        reason: "gateway stopping",
-        restartExpectedMs: null,
-      });
-      expect(start).toHaveBeenCalledWith({
-        startupStartedAt: expect.any(Number),
-        requestHotReloadRecovery: requestGatewayRestartWithSignalAdmission,
-      });
-      expect(runtime.exit).toHaveBeenCalledWith(0);
-      expect(flushLogger).toHaveBeenCalledOnce();
-      expect(armShutdownHardExitWatchdog).not.toHaveBeenCalled();
+        await expect(exited).resolves.toBe(0);
+        expect(close).toHaveBeenCalledWith({
+          reason: "gateway stopping",
+          restartExpectedMs: null,
+        });
+        expect(start).toHaveBeenCalledWith({
+          startupStartedAt: expect.any(Number),
+          requestHotReloadRecovery: requestGatewayRestartWithSignalAdmission,
+        });
+        expect(runtime.exit).toHaveBeenCalledWith(0);
+        expect(flushLogger).toHaveBeenCalledOnce();
+        expect(timelineAtLogFlush).toContain('"name":"gateway.stop"');
+        expect(armShutdownHardExitWatchdog).not.toHaveBeenCalled();
+      } finally {
+        flushDiagnosticsTimeline();
+        tempDirs.cleanup();
+      }
     });
   });
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -12,6 +12,7 @@ import {
   startGatewayRestartTrace,
 } from "../../gateway/restart-trace.js";
 import type { startGatewayServer } from "../../gateway/server.js";
+import { flushDiagnosticsTimeline } from "../../infra/diagnostics-timeline.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import {
   GATEWAY_BOOT_REASON_MAX_UTF16_CODE_UNITS,
@@ -175,6 +176,7 @@ export async function runGatewayLoop(params: {
     let ownerToCommit = initialOwner;
     let commitOutcome = initialOutcome;
     // Graceful signal/restart paths call process.exit(), which skips beforeExit.
+    flushDiagnosticsTimeline();
     let flushTimer: ReturnType<typeof setTimeout> | undefined;
     const flushed = await Promise.race([
       flushLogger().then(() => true),

--- a/src/cli/plugin-registry-loader.test.ts
+++ b/src/cli/plugin-registry-loader.test.ts
@@ -2,14 +2,15 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { flushDiagnosticsTimeline } from "../infra/diagnostics-timeline.js";
 import { measureCliCommandStartup } from "./command-startup-timing.js";
 
 const ensurePluginRegistryLoadedMock = vi.hoisted(() => vi.fn());
 const readRegistryMock = vi.hoisted(() =>
   vi.fn(async (): Promise<{ entries: Array<{ backendId?: string }> }> => ({ entries: [] })),
 );
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const tempDirs = createTempDirTracker();
 
 vi.mock("./plugin-registry.js", () => ({
   ensurePluginRegistryLoaded: ensurePluginRegistryLoadedMock,
@@ -37,6 +38,8 @@ describe("plugin-registry-loader", () => {
   });
 
   afterEach(() => {
+    flushDiagnosticsTimeline();
+    tempDirs.cleanup();
     loggingState.forceConsoleToStderr = originalForceStderr;
     vi.unstubAllEnvs();
   });
@@ -125,6 +128,7 @@ describe("plugin-registry-loader", () => {
       }),
     );
 
+    flushDiagnosticsTimeline();
     const events = (await readFile(timelinePath, "utf8"))
       .trim()
       .split("\n")

--- a/src/cli/plugins-cli.marketplace-entries.test.ts
+++ b/src/cli/plugins-cli.marketplace-entries.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flushDiagnosticsTimeline } from "../infra/diagnostics-timeline.js";
 import { ExpectedCliError, formatCliJsonFailure } from "./failure-output.js";
 import { createHostedMarketplaceFeedFixture } from "./plugins-marketplace-feed.test-support.js";
 
@@ -54,6 +55,7 @@ async function createTimelinePath(): Promise<string> {
 }
 
 async function readTimeline(pathname: string): Promise<Record<string, unknown>[]> {
+  flushDiagnosticsTimeline();
   const content = await readFile(pathname, "utf8");
   return content
     .trim()
@@ -73,6 +75,7 @@ describe("plugins marketplace entries", () => {
   });
 
   afterEach(() => {
+    flushDiagnosticsTimeline();
     vi.unstubAllEnvs();
   });
 

--- a/src/cli/plugins-cli.marketplace-refresh.test.ts
+++ b/src/cli/plugins-cli.marketplace-refresh.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flushDiagnosticsTimeline } from "../infra/diagnostics-timeline.js";
 import { createHostedMarketplaceFeedFixture } from "./plugins-marketplace-feed.test-support.js";
 
 const mocks = vi.hoisted(() => {
@@ -53,6 +54,7 @@ async function createTimelinePath(): Promise<string> {
 }
 
 async function readTimeline(pathname: string): Promise<Record<string, unknown>[]> {
+  flushDiagnosticsTimeline();
   const content = await readFile(pathname, "utf8");
   return content
     .trim()
@@ -74,6 +76,7 @@ describe("plugins marketplace refresh", () => {
   });
 
   afterEach(() => {
+    flushDiagnosticsTimeline();
     vi.unstubAllEnvs();
   });
 

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -8,6 +8,7 @@ import { CommanderError } from "commander";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { GATEWAY_SERVICE_RUNTIME_PID_ENV } from "../daemon/constants.js";
+import { flushDiagnosticsTimeline } from "../infra/diagnostics-timeline.js";
 import { createNewerSqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
 import { setLoggerOverride } from "../logging/logger.js";
 import { loggingState } from "../logging/state.js";
@@ -2639,8 +2640,10 @@ describe("runCli exit behavior", () => {
           },
         );
         expect(loadConfigMock).toHaveBeenCalledWith(readOptions);
+        flushDiagnosticsTimeline();
         expect(await fs.readFile(timelinePath, "utf8")).toContain("cli.main.argv");
       } finally {
+        flushDiagnosticsTimeline();
         await fs.rm(root, { recursive: true, force: true });
       }
     },

--- a/src/cli/startup-trace.test.ts
+++ b/src/cli/startup-trace.test.ts
@@ -3,9 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { flushDiagnosticsTimeline } from "../infra/diagnostics-timeline.js";
 import { createGatewayDispatchStartupTrace } from "./startup-trace.js";
 
 function readTimelineEvents(timelinePath: string): Record<string, unknown>[] {
+  flushDiagnosticsTimeline();
   return fs
     .readFileSync(timelinePath, "utf8")
     .trim()
@@ -15,6 +17,7 @@ function readTimelineEvents(timelinePath: string): Record<string, unknown>[] {
 
 describe("CLI startup trace", () => {
   afterEach(() => {
+    flushDiagnosticsTimeline();
     vi.unstubAllEnvs();
   });
 

--- a/src/config/sessions/targets-existing-store.test.ts
+++ b/src/config/sessions/targets-existing-store.test.ts
@@ -8,7 +8,43 @@ import type { OpenClawConfig } from "../config.js";
 import { resolveExistingAgentSessionStoreTargetsSync } from "./targets.js";
 import { countMatching, createAgentSessionStores } from "./targets.test-support.js";
 
-describe("resolveExistingAgentSessionStoreTargetsSync retired store", () => {
+describe("resolveExistingAgentSessionStoreTargetsSync", () => {
+  it("validates a configured canonical SQLite target once", async () => {
+    await withTempHome(async (home) => {
+      const stateDir = path.join(home, ".openclaw");
+      const storePaths = await createAgentSessionStores(stateDir, ["main"]);
+      const agentsRoot = path.join(stateDir, "agents");
+      const sqlitePath = path.join(agentsRoot, "main", "agent", "openclaw-agent.sqlite");
+      const cfg: OpenClawConfig = {
+        agents: { list: [{ id: "main", default: true }] },
+      };
+      const lstat = vi.spyOn(nodeFs, "lstatSync");
+      const realpath = vi.spyOn(nodeFs.realpathSync, "native");
+      syncBuiltinESMExports();
+      try {
+        expect(resolveExistingAgentSessionStoreTargetsSync(cfg, "main")).toEqual([
+          { agentId: "main", storePath: storePaths.main },
+        ]);
+
+        expect({
+          sqliteLstat: countMatching(lstat.mock.calls, ([candidate]) => candidate === sqlitePath),
+          sqliteRealpath: countMatching(
+            realpath.mock.calls,
+            ([candidate]) => candidate === sqlitePath,
+          ),
+          rootRealpath: countMatching(
+            realpath.mock.calls,
+            ([candidate]) => candidate === agentsRoot,
+          ),
+        }).toEqual({ sqliteLstat: 1, sqliteRealpath: 1, rootRealpath: 1 });
+      } finally {
+        lstat.mockRestore();
+        realpath.mockRestore();
+        syncBuiltinESMExports();
+      }
+    });
+  });
+
   it("does not resolve unrelated registered store identities", async () => {
     await withTempHome(async (home) => {
       const stateDir = path.join(home, ".openclaw");

--- a/src/config/sessions/targets.ts
+++ b/src/config/sessions/targets.ts
@@ -154,15 +154,18 @@ function resolveValidatedDiscoveredStorePathSync(params: {
   sessionsDir: string;
   agentsRoot: string;
   realAgentsRoot?: string;
+  sqliteOnly?: boolean;
 }): string | undefined {
   const storePath = path.join(params.sessionsDir, "sessions.json");
-  const validatedStorePath = resolveValidatedManagedFilePathSync({
-    agentsRoot: params.agentsRoot,
-    filePath: storePath,
-    realAgentsRoot: params.realAgentsRoot,
-  });
-  if (validatedStorePath) {
-    return validatedStorePath;
+  if (!params.sqliteOnly) {
+    const validatedStorePath = resolveValidatedManagedFilePathSync({
+      agentsRoot: params.agentsRoot,
+      filePath: storePath,
+      realAgentsRoot: params.realAgentsRoot,
+    });
+    if (validatedStorePath) {
+      return validatedStorePath;
+    }
   }
   const sqlitePath = resolveSqliteTargetFromSessionStorePath(storePath).path;
   if (!sqlitePath) {
@@ -174,29 +177,6 @@ function resolveValidatedDiscoveredStorePathSync(params: {
     realAgentsRoot: params.realAgentsRoot,
   })
     ? storePath
-    : undefined;
-}
-
-function resolveValidatedExistingSessionStoreTargetSync(
-  target: SessionStoreTarget,
-): SessionStoreTarget | undefined {
-  // Runtime existing-store lookups are SQLite-only; broad discovery remains
-  // available to Doctor/startup migration without making JSON authoritative.
-  const sqlitePath = resolveSqliteTargetFromSessionStorePath(target.storePath, {
-    agentId: target.agentId,
-  }).path;
-  if (!sqlitePath) {
-    return undefined;
-  }
-  const agentsRoot = resolveAgentsDirFromSessionStorePath(target.storePath);
-  if (!agentsRoot) {
-    return fsSync.existsSync(sqlitePath) ? target : undefined;
-  }
-  return resolveValidatedManagedFilePathSync({
-    agentsRoot,
-    filePath: sqlitePath,
-  })
-    ? target
     : undefined;
 }
 
@@ -424,10 +404,8 @@ export function resolveExistingAgentSessionStoreTargetsSync(
     }
     return [];
   }
-  const targets = resolveAgentSessionStoreTargetsSync(cfg, requested, { env }).flatMap((target) => {
-    const validated = resolveValidatedExistingSessionStoreTargetSync(target);
-    return validated ? [validated] : [];
-  });
+  // Validate the runtime SQLite artifact once; Doctor's broader discovery still accepts JSON.
+  const targets = resolveAgentSessionStoreTargets(cfg, requested, { env, sqliteOnly: true });
   if (isConfiguredSessionStoreAgentId(cfg, requested)) {
     return targets;
   }
@@ -524,6 +502,14 @@ export function resolveAgentSessionStoreTargetsSync(
   agentId: string,
   params: { env?: NodeJS.ProcessEnv } = {},
 ): SessionStoreTarget[] {
+  return resolveAgentSessionStoreTargets(cfg, agentId, params);
+}
+
+function resolveAgentSessionStoreTargets(
+  cfg: OpenClawConfig,
+  agentId: string,
+  params: { env?: NodeJS.ProcessEnv; sqliteOnly?: boolean },
+): SessionStoreTarget[] {
   const env = params.env ?? process.env;
   const requested = normalizeAgentId(agentId);
   const storePaths = new Set<string>([
@@ -552,6 +538,14 @@ export function resolveAgentSessionStoreTargetsSync(
   for (const storePath of storePaths) {
     const agentsRoot = resolveAgentsDirFromSessionStorePath(storePath);
     if (!agentsRoot) {
+      if (params.sqliteOnly) {
+        const sqlitePath = resolveSqliteTargetFromSessionStorePath(storePath, {
+          agentId: requested,
+        }).path;
+        if (!sqlitePath || !fsSync.existsSync(sqlitePath)) {
+          continue;
+        }
+      }
       targets.push({ agentId: requested, storePath });
       continue;
     }
@@ -563,6 +557,7 @@ export function resolveAgentSessionStoreTargetsSync(
       sessionsDir: path.dirname(storePath),
       agentsRoot,
       realAgentsRoot,
+      sqliteOnly: params.sqliteOnly,
     });
     if (validatedStorePath) {
       targets.push({ agentId: requested, storePath: validatedStorePath });
@@ -597,6 +592,7 @@ export function resolveAgentSessionStoreTargetsSync(
           sessionsDir,
           agentsRoot: agentsDir,
           realAgentsRoot,
+          sqliteOnly: params.sqliteOnly,
         });
         if (validatedStorePath) {
           targets.push({ ...target, storePath: validatedStorePath });

--- a/src/gateway/server-kernel.test.ts
+++ b/src/gateway/server-kernel.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import { flushDiagnosticsTimeline } from "../infra/diagnostics-timeline.js";
 import { createPluginRecord } from "../plugins/loader-records.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import {
@@ -376,6 +377,7 @@ describe("createGatewayKernel", () => {
       ).resolves.toEqual({ runId: "kernel-run", status: "ok", summary: "cached" });
       expect(getActiveGatewayRootWorkCount()).toBe(0);
 
+      flushDiagnosticsTimeline();
       const timeline = (await fs.readFile(timelinePath, "utf8"))
         .trim()
         .split("\n")
@@ -430,6 +432,7 @@ describe("createGatewayKernel", () => {
         await kernel?.closeOnStartupFailure();
       } finally {
         try {
+          flushDiagnosticsTimeline();
           await state.cleanup();
         } finally {
           if (capturedLoadedPluginRegistry) {

--- a/src/gateway/server-runtime-state.test.ts
+++ b/src/gateway/server-runtime-state.test.ts
@@ -1,8 +1,10 @@
 /**
  * Gateway runtime state construction tests.
  */
+import { once } from "node:events";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { connect } from "node:net";
+import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
@@ -96,6 +98,61 @@ describe("createGatewayRuntimeState", () => {
 
   afterEach(() => {
     resetPluginRuntimeStateForTest();
+  });
+
+  it("yields between buffered WebSocket messages without reordering them", async () => {
+    const runtimeState = await createGatewayRuntimeStateForTest();
+    const server = runtimeState.httpServers[0]!;
+    const events: string[] = [];
+    let sentinel: ReturnType<typeof setImmediate> | undefined;
+    const received = new Promise<void>((resolve, reject) => {
+      runtimeState.wss.once("connection", (socket, req) => {
+        socket.once("error", reject);
+        socket.on("message", (data) => {
+          const message = rawDataToString(data);
+          events.push(message);
+          if (message === "a") {
+            sentinel = setImmediate(() => events.push("yield"));
+          } else {
+            resolve();
+          }
+        });
+        // Feed both masked text frames as one receive chunk through the real
+        // upgraded socket, independent of TCP packet splitting/coalescing.
+        req.socket.pause();
+        req.socket.unshift(
+          Buffer.from([0x81, 0x81, 1, 2, 3, 4, 0x60, 0x81, 0x81, 1, 2, 3, 4, 0x63]),
+        );
+        req.socket.resume();
+      });
+    });
+    let client: WebSocket | undefined;
+    try {
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected TCP gateway address");
+      }
+      client = new WebSocket(`ws://127.0.0.1:${address.port}/`, {
+        handshakeTimeout: 2_000,
+      });
+      await once(client, "open");
+      await received;
+      expect(events).toEqual(["a", "yield", "b"]);
+    } finally {
+      clearImmediate(sentinel);
+      client?.terminate();
+      for (const socket of runtimeState.wss.clients) {
+        socket.terminate();
+      }
+      if (server.listening) {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+      runtimeState.wss.close();
+    }
   });
 
   it("keeps unrelated plugin HTTP routes cold for core HTTP and WebSocket requests", async () => {

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -297,6 +297,9 @@ export async function createGatewayHttpTransport(params: {
   const wss = new WebSocketServer({
     noServer: true,
     maxPayload: MAX_PREAUTH_PAYLOAD_BYTES,
+    // Yield between buffered frames so one RPC burst cannot monopolize the
+    // event loop before other connections and HTTP probes can run.
+    allowSynchronousEvents: false,
   });
   const preauthConnectionBudget = createPreauthConnectionBudget();
 

--- a/src/gateway/server-startup-config.secrets.test.ts
+++ b/src/gateway/server-startup-config.secrets.test.ts
@@ -14,7 +14,10 @@ import {
 } from "../agents/auth-profiles/runtime-snapshots.js";
 import { writePersistedAuthProfileStoreRaw } from "../agents/auth-profiles/sqlite.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.js";
-import { measureDiagnosticsTimelineSpan } from "../infra/diagnostics-timeline.js";
+import {
+  flushDiagnosticsTimeline,
+  measureDiagnosticsTimelineSpan,
+} from "../infra/diagnostics-timeline.js";
 import { providerResolutionError, refResolutionError } from "../secrets/resolve-errors.js";
 import { associateSecretResolutionErrorOwners } from "../secrets/runtime-degraded-state.js";
 import { activateProviderAuthRuntimeSnapshot } from "../secrets/runtime-provider-auth-activation.js";
@@ -198,6 +201,7 @@ function mockLogSecretsForTest(): GatewayStartupLogMock {
 }
 
 function readTimelineEvents(filePath: string): Array<Record<string, unknown>> {
+  flushDiagnosticsTimeline();
   return readFileSync(filePath, "utf8")
     .trim()
     .split(/\r?\n/u)
@@ -216,6 +220,7 @@ function installDiagnosticsTimelineEnv() {
   return {
     timelinePath,
     cleanup: () => {
+      flushDiagnosticsTimeline();
       if (previousDiagnostics === undefined) {
         delete process.env.OPENCLAW_DIAGNOSTICS;
       } else {

--- a/src/gateway/server-startup-secret-owner-isolation.test.ts
+++ b/src/gateway/server-startup-secret-owner-isolation.test.ts
@@ -3,6 +3,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { resolveDefaultAgentDir } from "../agents/agent-scope-config.js";
 import { getRuntimeAuthProfileStoreSnapshotCore } from "../agents/auth-profiles/runtime-snapshots.js";
@@ -205,10 +206,12 @@ describe("Gateway startup SecretRef owner isolation", () => {
             reason: string;
           }>;
         };
+        const accountStarted = new Map<string, () => void>();
         const startAccount = vi.fn(
-          async ({ abortSignal }: ChannelGatewayContext<TestAccount>) =>
+          async ({ accountId, abortSignal }: ChannelGatewayContext<TestAccount>) =>
             await new Promise<void>((resolve) => {
               abortSignal.addEventListener("abort", () => resolve(), { once: true });
+              accountStarted.get(accountId)?.();
             }),
         );
         const plugin: ChannelPlugin<TestAccount> = {
@@ -276,6 +279,8 @@ describe("Gateway startup SecretRef owner isolation", () => {
           });
           expect(brokenStart.ok).toBe(false);
           for (const accountId of ["healthy", "stopped"]) {
+            const pluginStarted = createDeferred();
+            accountStarted.set(accountId, pluginStarted.resolve);
             const started = await rpcReq<{ accountId: string; started: boolean }>(
               ws,
               "channels.start",
@@ -283,6 +288,8 @@ describe("Gateway startup SecretRef owner isolation", () => {
             );
             expect(started.ok, JSON.stringify(started)).toBe(true);
             expect(started.payload).toMatchObject({ accountId, started: true });
+            // The RPC acknowledges handoff; traced startup invokes the plugin on a later turn.
+            await pluginStarted.promise;
           }
           expect(startAccount).toHaveBeenCalledTimes(2);
           expect(startAccount.mock.calls.map(([context]) => context.accountId)).toEqual([
@@ -337,9 +344,12 @@ describe("Gateway startup SecretRef owner isolation", () => {
           writeFileSync(credentialPath, repairedToken, { mode: 0o600 });
           expect(readFileSync(configPath)).toEqual(originalConfig);
 
+          const repairedStarted = createDeferred();
+          accountStarted.set("broken", repairedStarted.resolve);
           const reload = await rpcReq<{ warningCount: number }>(ws, "secrets.reload", {});
           expect(reload.ok, JSON.stringify(reload)).toBe(true);
           expect(reload.payload).toMatchObject({ warningCount: 0 });
+          await repairedStarted.promise;
           expect(startAccount.mock.calls.map(([context]) => context.accountId)).toEqual([
             "healthy",
             "stopped",

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -39,6 +39,7 @@ import type { AgentModelConfig } from "../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { rotateAgentEventLifecycleGeneration } from "../infra/agent-events.js";
 import { onDiagnosticEvent, type DiagnosticPayloadLargeEvent } from "../infra/diagnostic-events.js";
+import { flushDiagnosticsTimeline } from "../infra/diagnostics-timeline.js";
 import { ExecApprovalsMigrationRequiredError } from "../infra/exec-approvals-migration-gate.js";
 import { getMediaDir } from "../media/store.js";
 import { installTemporaryCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
@@ -635,6 +636,7 @@ test("chat.send replays a cached result after the session is archived", async ()
 });
 
 async function readTimelineEvents(filePath: string): Promise<Array<Record<string, unknown>>> {
+  flushDiagnosticsTimeline();
   const raw = await fs.readFile(filePath, "utf-8");
   return raw
     .trim()
@@ -6263,6 +6265,7 @@ describe("gateway server chat", () => {
         },
       );
     } finally {
+      flushDiagnosticsTimeline();
       if (previousDiagnostics === undefined) {
         delete process.env.OPENCLAW_DIAGNOSTICS;
       } else {

--- a/src/infra/diagnostics-timeline.test.ts
+++ b/src/infra/diagnostics-timeline.test.ts
@@ -1,11 +1,16 @@
 // Covers diagnostics timeline event writing and spans.
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   emitDiagnosticsTimelineEvent,
+  flushDiagnosticsTimeline,
   isDiagnosticsTimelineEnabled,
   measureDiagnosticsTimelineSpan,
   measureDiagnosticsTimelineSpanSync,
@@ -28,7 +33,7 @@ async function createTimelineEnv() {
 }
 
 async function readTimeline(path: string) {
-  await Promise.resolve();
+  flushDiagnosticsTimeline();
   return (await readFile(path, "utf8"))
     .trim()
     .split("\n")
@@ -55,11 +60,113 @@ function attributesRecord(event: Record<string, unknown>): Record<string, unknow
 }
 
 afterEach(async () => {
+  flushDiagnosticsTimeline();
   vi.restoreAllMocks();
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
 describe("diagnostics timeline", () => {
+  it("defers a timeline burst and writes its ordered events in one safe append", async () => {
+    const { env, path } = await createTimelineEnv();
+    const open = vi.spyOn(fs, "openSync");
+    const names = Array.from({ length: 64 }, (_, index) => `event-${index}`);
+
+    for (const name of names) {
+      emitDiagnosticsTimelineEvent({ type: "mark", name }, { env });
+    }
+
+    expect(open.mock.calls.filter(([file]) => file === path)).toHaveLength(0);
+    await yieldToEventLoop();
+    expect(open.mock.calls.filter(([file]) => file === path)).toHaveLength(1);
+    expect((await readTimeline(path)).map((event) => event.name)).toEqual(names);
+    expect(fs.statSync(path).mode & 0o777).toBe(0o600);
+  });
+
+  it("captures emitted values and flushes earlier paths before switching destinations", async () => {
+    const first = await createTimelineEnv();
+    const second = await createTimelineEnv();
+    const attributes = { value: "before" };
+    emitDiagnosticsTimelineEvent({ type: "mark", name: "first", attributes }, { env: first.env });
+    attributes.value = "after";
+    first.env.OPENCLAW_DIAGNOSTICS_RUN_ID = "changed";
+    first.env.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH = second.path;
+    emitDiagnosticsTimelineEvent({ type: "mark", name: "second", attributes }, { env: first.env });
+
+    expect(JSON.parse(fs.readFileSync(first.path, "utf8"))).toMatchObject({
+      name: "first",
+      runId: "run-1",
+      attributes: { value: "before" },
+    });
+    expect(fs.existsSync(second.path)).toBe(false);
+    first.env.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH = first.path;
+    emitDiagnosticsTimelineEvent({ type: "mark", name: "third" }, { env: first.env });
+    expect(JSON.parse(fs.readFileSync(second.path, "utf8"))).toMatchObject({
+      name: "second",
+      runId: "changed",
+      attributes: { value: "after" },
+    });
+    expect((await readTimeline(first.path)).map((event) => event.name)).toEqual(["first", "third"]);
+  });
+
+  it("bounds queued UTF-8 bytes without dropping bursts or oversized events", async () => {
+    const { env, path } = await createTimelineEnv();
+    const write = vi.spyOn(fs, "writeSync");
+    const names = Array.from({ length: 6 }, (_, index) => `event-${index}`);
+    for (const name of names) {
+      emitDiagnosticsTimelineEvent(
+        { type: "mark", name, attributes: { text: "界".repeat(8192) } },
+        { env },
+      );
+    }
+    const chunks = () =>
+      write.mock.calls.flatMap(([, content]) => (Buffer.isBuffer(content) ? [content] : []));
+    expect(chunks().length).toBeGreaterThan(0);
+    expect(chunks().every((content) => content.byteLength <= 64 * 1024)).toBe(true);
+    const oversized = "界".repeat(32 * 1024);
+    emitDiagnosticsTimelineEvent(
+      { type: "mark", name: "oversized", attributes: { text: oversized } },
+      { env },
+    );
+    emitDiagnosticsTimelineEvent({ type: "mark", name: "last" }, { env });
+    flushDiagnosticsTimeline();
+
+    expect(chunks().filter((content) => content.byteLength > 64 * 1024)).toHaveLength(1);
+    const events = await readTimeline(path);
+    expect(events.map((event) => event.name)).toEqual([...names, "oversized", "last"]);
+    expect(attributesRecord(eventRecord(events, names.length)).text).toBe(oversized);
+  });
+
+  it.each(["natural", "immediate", "first-event-at-exit"])(
+    "retains queued and later exit-listener events on %s exit",
+    async (mode) => {
+      const { env, path } = await createTimelineEnv();
+      const script = `
+        import { emitDiagnosticsTimelineEvent } from ${JSON.stringify(new URL("./diagnostics-timeline.ts", import.meta.url).href)};
+        const env = ${JSON.stringify(env)};
+        process.on("exit", () => emitDiagnosticsTimelineEvent({ type: "mark", name: "last" }, { env }));
+        ${mode === "first-event-at-exit" ? "" : 'emitDiagnosticsTimelineEvent({ type: "mark", name: "first" }, { env });'}
+        ${mode === "natural" ? "" : "process.exit(0);"}
+      `;
+      const result = spawnSync(
+        process.execPath,
+        [
+          "--import",
+          fileURLToPath(new URL("../../scripts/tsx.mjs", import.meta.url)),
+          "--input-type=module",
+          "--eval",
+          script,
+        ],
+        { encoding: "utf8", env: { ...process.env, VITEST: "false" }, timeout: 10_000 },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status, result.stderr).toBe(0);
+      expect((await readTimeline(path)).map((event) => event.name)).toEqual(
+        mode === "first-event-at-exit" ? ["last"] : ["first", "last"],
+      );
+    },
+  );
+
   it("detects when timeline output is enabled", async () => {
     const { env } = await createTimelineEnv();
 
@@ -194,10 +301,38 @@ describe("diagnostics timeline", () => {
 
     emitDiagnosticsTimelineEvent({ type: "mark", name: "first" }, { env: failingEnv });
     emitDiagnosticsTimelineEvent({ type: "mark", name: "second" }, { env: failingEnv });
+    flushDiagnosticsTimeline();
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("failed to write timeline event"));
+    emitDiagnosticsTimelineEvent({ type: "mark", name: "recovered" }, { env });
+    expect((await readTimeline(path)).map((event) => event.name)).toEqual(["recovered"]);
   });
+
+  it.each(["symlink", "hardlink", "directory"])(
+    "keeps unsafe %s targets unchanged when a batch drains",
+    async (kind) => {
+      const { env, path } = await createTimelineEnv();
+      await mkdir(dirname(path), { recursive: true });
+      const target = join(dirname(path), "target");
+      await writeFile(target, "unchanged");
+      if (kind === "symlink") {
+        fs.symlinkSync(target, path);
+      } else if (kind === "hardlink") {
+        fs.linkSync(target, path);
+      } else {
+        await mkdir(path);
+      }
+      emitDiagnosticsTimelineEvent({ type: "mark", name: "first" }, { env });
+      emitDiagnosticsTimelineEvent({ type: "mark", name: "second" }, { env });
+      flushDiagnosticsTimeline();
+
+      expect(await readFile(target, "utf8")).toBe("unchanged");
+      if (kind === "directory") {
+        expect(fs.readdirSync(path)).toEqual([]);
+      }
+    },
+  );
 
   it("records span start and end events around successful work", async () => {
     const { env, path } = await createTimelineEnv();

--- a/src/infra/diagnostics-timeline.ts
+++ b/src/infra/diagnostics-timeline.ts
@@ -5,11 +5,13 @@ import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { performance } from "node:perf_hooks";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { isDiagnosticFlagEnabled } from "./diagnostic-flags.js";
 import { isTruthyEnvValue } from "./env.js";
 import { appendRegularFileSync } from "./regular-file.js";
 
 const OPENCLAW_DIAGNOSTICS_TIMELINE_SCHEMA_VERSION = "openclaw.diagnostics.v1";
+const MAX_PENDING_TIMELINE_BYTES = 64 * 1024;
 
 type DiagnosticsTimelineEventType =
   | "span.start"
@@ -80,22 +82,86 @@ type StartedDiagnosticsTimelineSpan = ActiveDiagnosticsTimelineSpan & {
   omitErrorMessage?: boolean;
 };
 
-let warnedAboutTimelineWrite = false;
-const createdTimelineDirs = new Set<string>();
 const activeDiagnosticsTimelineSpan = new AsyncLocalStorage<ActiveDiagnosticsTimelineSpan>();
+const timelineWriter = resolveGlobalSingleton(
+  Symbol.for("openclaw.diagnosticsTimelineWriter"),
+  () => {
+    let pending: { path: string; content: string; bytes: number } | undefined;
+    let scheduledFlush: NodeJS.Immediate | undefined;
+    let exiting = false;
+    let warnedAboutWrite = false;
+    const createdDirs = new Set<string>();
 
-function resolveDiagnosticsTimelineOptions(
-  options: DiagnosticsTimelineOptions = {},
-): Required<Pick<DiagnosticsTimelineOptions, "env">> & Pick<DiagnosticsTimelineOptions, "config"> {
-  return {
-    env: options.env ?? process.env,
-    ...(options.config ? { config: options.config } : {}),
-  };
+    function append(path: string, content: string): void {
+      try {
+        const dir = dirname(path);
+        if (!createdDirs.has(dir)) {
+          mkdirSync(dir, { recursive: true });
+          createdDirs.add(dir);
+        }
+        appendRegularFileSync({ filePath: path, content });
+      } catch (error) {
+        if (!warnedAboutWrite) {
+          warnedAboutWrite = true;
+          // Diagnostics stay best-effort; do not replay a possibly partially written batch.
+          console.warn(`[diagnostics] failed to write timeline event: ${String(error)}`);
+        }
+      }
+    }
+
+    function flush(): void {
+      if (scheduledFlush) {
+        clearImmediate(scheduledFlush);
+        scheduledFlush = undefined;
+      }
+      const batch = pending;
+      pending = undefined;
+      if (batch) {
+        append(batch.path, batch.content);
+      }
+    }
+
+    // Install before the first event, including events first emitted by later exit listeners.
+    process.once("exit", () => {
+      exiting = true;
+      flush();
+    });
+
+    return {
+      flush,
+      write(path: string, content: string): void {
+        const bytes = Buffer.byteLength(content, "utf8");
+        if (
+          pending &&
+          (pending.path !== path || pending.bytes + bytes > MAX_PENDING_TIMELINE_BYTES)
+        ) {
+          flush();
+        }
+        // Capacity applies to retained work; preserve an oversized event without queuing or dropping it.
+        if (exiting || bytes > MAX_PENDING_TIMELINE_BYTES) {
+          append(path, content);
+          return;
+        }
+        if (pending) {
+          pending.content += content;
+          pending.bytes += bytes;
+        } else {
+          pending = { path, content, bytes };
+        }
+        scheduledFlush ??= setImmediate(flush).unref();
+      },
+    };
+  },
+);
+
+/** Makes all previously emitted timeline events visible before reading or closing their files. */
+export function flushDiagnosticsTimeline(): void {
+  timelineWriter.flush();
 }
 
 /** Returns true when diagnostics flags and a JSONL output path both allow timeline writes. */
 export function isDiagnosticsTimelineEnabled(options: DiagnosticsTimelineOptions = {}): boolean {
-  const { config, env } = resolveDiagnosticsTimelineOptions(options);
+  const { config, env = process.env } = options;
   return (
     (isDiagnosticFlagEnabled("timeline", config, env) ||
       isDiagnosticFlagEnabled("diagnostics.timeline", config, env) ||
@@ -134,6 +200,7 @@ function normalizeAttributes(
 }
 
 function serializeTimelineEvent(event: DiagnosticsTimelineEvent, env: NodeJS.ProcessEnv): string {
+  const attributes = normalizeAttributes(event.attributes);
   const normalized = {
     schemaVersion: OPENCLAW_DIAGNOSTICS_TIMELINE_SCHEMA_VERSION,
     type: event.type,
@@ -165,19 +232,17 @@ function serializeTimelineEvent(event: DiagnosticsTimelineEvent, env: NodeJS.Pro
     ...(event.command ? { command: event.command } : {}),
     ...(event.exitCode !== undefined ? { exitCode: event.exitCode } : {}),
     ...(event.signal !== undefined ? { signal: event.signal } : {}),
-    ...(normalizeAttributes(event.attributes)
-      ? { attributes: normalizeAttributes(event.attributes) }
-      : {}),
+    ...(attributes ? { attributes } : {}),
   };
   return `${JSON.stringify(normalized)}\n`;
 }
 
-/** Appends one normalized diagnostics timeline event to the configured JSONL file. */
+/** Queues one normalized event; bounded batches append on the next event-loop turn. */
 export function emitDiagnosticsTimelineEvent(
   event: DiagnosticsTimelineEvent,
   options: DiagnosticsTimelineOptions = {},
 ): void {
-  const { env } = resolveDiagnosticsTimelineOptions(options);
+  const env = options.env ?? process.env;
   if (!isDiagnosticsTimelineEnabled(options)) {
     return;
   }
@@ -185,21 +250,7 @@ export function emitDiagnosticsTimelineEvent(
   if (!path) {
     return;
   }
-  const line = serializeTimelineEvent(event, env);
-  try {
-    const dir = dirname(path);
-    if (!createdTimelineDirs.has(dir)) {
-      mkdirSync(dir, { recursive: true });
-      createdTimelineDirs.add(dir);
-    }
-    appendRegularFileSync({ filePath: path, content: line });
-  } catch (error) {
-    if (!warnedAboutTimelineWrite) {
-      warnedAboutTimelineWrite = true;
-      // Diagnostics output is best-effort; one warning avoids recursive stderr spam.
-      console.warn(`[diagnostics] failed to write timeline event: ${String(error)}`);
-    }
-  }
+  timelineWriter.write(path, serializeTimelineEvent(event, env));
 }
 
 /** Replays a completed span after its activation config becomes available. */

--- a/test/scripts/bench-gateway-concurrency.test.ts
+++ b/test/scripts/bench-gateway-concurrency.test.ts
@@ -1,10 +1,12 @@
 // Gateway concurrency benchmark tests cover CLI controls, probe budgets, and summaries.
 import { spawnSync } from "node:child_process";
+import { writeFile } from "node:fs/promises";
 import { createServer as createHttpServer } from "node:http";
 import { createServer as createRawServer, type Socket } from "node:net";
 import { performance } from "node:perf_hooks";
 import { describe, expect, it } from "vitest";
 import { testing } from "../../scripts/bench-gateway-concurrency.ts";
+import { withTempDir } from "../../src/test-utils/temp-dir.js";
 
 type BenchmarkRun = Parameters<typeof testing.summarizeRuns>[0][number];
 
@@ -137,6 +139,39 @@ describe("gateway concurrency benchmark script", () => {
       count: 2,
       durationMs: { count: 2, max: 22, p50: 18, p95: 22, p99: 22 },
       totalDurationMs: 40,
+    });
+  });
+
+  it("does not report missing or incomplete timeline evidence as zero scans", async () => {
+    await withTempDir("openclaw-concurrency-timeline-", async (root) => {
+      const file = `${root}/timeline.jsonl`;
+      expect(() => testing.readDiagnosticsTimelineSpans(file)).toThrow();
+      await writeFile(file, "");
+      expect(() => testing.readDiagnosticsTimelineSpans(file)).toThrow();
+      await writeFile(file, '{"type":"span.end","name":"plugins.metadata.scan"');
+      expect(() => testing.readDiagnosticsTimelineSpans(file)).toThrow();
+    });
+  });
+
+  it("counts load spans by emission time even when buffered setup spans arrive later", async () => {
+    await withTempDir("openclaw-concurrency-timeline-", async (root) => {
+      const file = `${root}/timeline.jsonl`;
+      const spans = [999, 1_000, 1_500, 2_000, 2_001].map((timestamp) => ({
+        schemaVersion: "openclaw.diagnostics.v1",
+        type: "span.end",
+        name: "plugins.metadata.scan",
+        durationMs: 10,
+        timestamp: new Date(timestamp).toISOString(),
+      }));
+      await writeFile(file, spans.map((span) => JSON.stringify(span)).join("\n") + "\n");
+
+      expect(
+        testing.summarizePluginMetadataScans(
+          testing.readDiagnosticsTimelineSpans(file, { from: 1_000, through: 2_000 }),
+        ),
+      ).toMatchObject({ count: 3, totalDurationMs: 30 });
+      await writeFile(file, JSON.stringify({ ...spans[0], timestamp: "invalid" }) + "\n");
+      expect(() => testing.readDiagnosticsTimelineSpans(file)).toThrow("invalid diagnostics");
     });
   });
 


### PR DESCRIPTION
Related: #133477

## What Problem This Solves

Resolves avoidable Gateway control-plane stalls during bursts of concurrent agent turns, particularly with diagnostic timeline recording enabled. Readiness, Control UI requests, and session history can wait while synchronous work delays WebSocket dispatch. This is a measured latency improvement, not a claim that every saturation tail or a memory leak is fixed.

## Why This Change Was Made

Profiling separated time waiting before the Gateway message callback from time inside the RPC handler. It identified repeated diagnostic file operations, duplicate session-store path validation, and buffered WebSocket messages dispatched without yielding. These are cumulative costs, not one universal cause of every slow sample.

The repair stays with the owners of that work:

- The diagnostic writer serializes events at emission and retains one bounded 64 KiB UTF-8 batch. It appends on the next event-loop turn, at capacity/path changes, or at normal exit. Oversized individual events retain direct writes. The existing safe-file helper still owns filesystem validation; no retained descriptor, retry queue, or new persistence layer is added.
- Gateway transport uses the existing `ws` option to yield between buffered messages while preserving frame order and validation.
- Runtime session discovery validates the SQLite artifact once. Doctor retains legacy-file discovery; custom/shared stores, retired agents, containment checks, and unreadable-registry behavior remain covered.
- The benchmark keeps the active timeline intact, reads it after clean shutdown, and selects the measured emission window. Missing, malformed, incomplete, and failed-write evidence is rejected rather than becoming a false zero. Result validation follows Gateway cleanup, and outer cleanup retains ownership of the mock process and temporary state.

Production delta is **+52 lines**: bounded batching and explicit exit draining require a lifecycle owner; duplicate session validation and the redundant timeline-options helper are removed. Tests add 345 net lines, benchmark support 34, and documentation 6. Most benchmark diff churn is indentation from separating cleanup and result validation. No new config keys, environment variables, schema, or persistent-store semantics.

## User Impact

Concurrent turns leave more opportunity for control requests to run. Diagnostic events may become visible on the next event-loop turn rather than immediately. In-process readers can explicitly flush; external readers should inspect the final artifact after normal exit. Output remains best-effort: forced termination and filesystem failures can lose pending output. The existing file helper's separately reproduced short-write handling remains a dependency follow-up, not a claimed fix here.

## Evidence

Current head: `a5f72bc4172e4fc457bdd6ad2db5651953e799a6`. Runtime/browser proof was captured at `840024d41357ae0940d0c6033f513d847eabdf6f`, rebased onto `c753bbd1ced5395fb42c113cdabda5d69bdb75d4`; the final commit changes only the secret-owner isolation test. A full hash comparison confirms runtime/build/dependency parity. Both implementation commits were patch-identical across rebase. The native wrapper required the refresh; no guard was bypassed, and runtime/UI were rebuilt afterward.

All runtime proof used synthetic data, fresh isolated HOME/state, and owned loopback ports. No production Gateway was exercised. Workload: 32 turns, 48 seed sessions, 128 updates/four clients, three history clients with five-request bursts, six subscribers, visible observation, 100 ms cadence, and 1000 ms mock stream delay. Limits stayed **2000 ms** for control/handshake and **120000 ms** for completion.

| Observed maximum | Final commit, 3 runs | Real Control UI under the same load |
| --- | ---: | ---: |
| sessions.list | 748.1 ms | 1541.8 ms |
| history | 596.0 ms | 722.2 ms |
| Control UI HTTP | 395.6 ms | 300.3 ms |
| readiness | 162.2 ms | 193.0 ms |
| fresh handshake | 33.9 ms | 68.6 ms |

All final runs passed every budget with zero operation failures and zero measured plugin metadata rescans. Three repeats completed 96 turns, 384 updates, and 1205 history samples. The real browser connected, showed live session updates, and rendered the synthetic streaming reply without page errors. Full captures were inspected; the first capture caught a transitional blank render, while subsequent captures show the updates and reply. All **35,152 source/build/dependency hashes** matched after both proofs.

Before rebase, the WebSocket-only attempt failed `sessions.list` at 2116.7 ms. The combined change passed three runs (list 891.7 ms/history 645.2 ms) and a browser run (list 1950.9 ms). A complete lightweight native-write trace recorded **5236 events in 353 appends**, with 127.3 ms total append occupancy during 10.4 s of load; it passed the unchanged budget with zero trace losses. Counts cover complete load-window batches, not final shutdown writes. The slowest list request still waited about 1356 ms before dispatch and spent 12 ms inside its handler.

These sequential local runs are not a randomized throughput comparison, and intervening main changes also affect baseline cost. Event-loop utilization still reaches 1 and readiness frequently reports degraded health. No universal latency or memory-leak claim follows.

Validation:

- 226 distinct focused tests across 22 files passed before rebase. Deterministic pre-fix failures cover 64 per-event opens versus one batch, duplicate path validation, buffered-message starvation, and missing/incomplete timeline evidence.
- Rebased owner checks passed, including the timeline writer, runtime transport, existing-store discovery, run-loop shutdown, benchmark parser, and real chat timeline correlation. Additional main-interaction checks passed: six durable browser-input admission cases, three delete/archive/recover ordering cases, four current-session history receipt cases, and two durable-admission abort cases.
- `pnpm build sourcePerformance` and `pnpm ui:build` passed after rebase. Fresh Codex autoreviews passed their configured **P0-only** scope; this is not an all-priority review claim.
- The initial changed gate passed types, guards, and core lint but failed two explicit throws inside `finally`. Cleanup was restructured; the targeted changed gate then passed on [Testbox run 33347056069](https://github.com/openclaw/openclaw/actions/runs/33347056069), wrapper exit 0 and lease stopped. The first full [CI run 33347261488](https://github.com/openclaw/openclaw/actions/runs/33347261488) exposed the test-ordering defect described below; exact-head [CI run 33347957849](https://github.com/openclaw/openclaw/actions/runs/33347957849) is **SUCCESS**. Fresh PR rollup: 196 successful checks, 39 skips, one neutral, no failures; merge state CLEAN.
- CI also exposed a deterministic test-ordering race in secret-owner recovery, reproduced locally. The existing channel manager acknowledges startup handoff before invoking the plugin on a later turn (documented by its existing sibling test and commit `16e5d6692dc`). WebSocket fairness exposes that legal ordering. The fixture now awaits per-account plugin-start signals after start/reload ACKs, preserving every exact count, order, token-isolation, and lifetime assertion without retries or timeout changes. All 14 isolation tests, three handoff-contract tests, typed lint, and fresh P0 review pass.
- A CPU-profile attempt is retained as **failed measurement evidence**: post-load clock calibration took 1347 ms, exceeding its unchanged 1000 ms diagnostic cap, and threw during shutdown. The strict harness rejected the result; no benchmark summary was accepted. The successful lightweight append trace does not erase that failure. An earlier partial CPU trace also failed its calibration cap; only independently reconciled transport intervals were used.

Reproduction:

```sh
node scripts/bench-gateway-concurrency.ts --entry dist/entry.js --runs 3 --warmup 0 --concurrency 32 --session-count 48 --session-updates 128 --session-update-clients 4 --history-clients 3 --history-burst 5 --subscribers 6 --visible-observer --stream-chunk-delay-ms 1000 --cadence-ms 100 --timeout-ms 120000 --max-control-ms 2000 --max-handshake-ms 2000 --output .artifacts/gateway-mixed-32.json --json
```

Local proof additionally redirected Gateway logs into the task artifact directory. Browser proof used the same benchmark with the real built Control UI and a fresh browser context. Its first pre-rebase recorder invocation omitted the repository TypeScript loader and failed before starting a Gateway; the corrected invocations passed.

Named follow-ups: residual session-preparation/transaction work; duplicate Git revision preparation for unborn session workspaces; cold health-check package loading; the file-helper short-write defect; and the separately discovered model-alias raw-to-prepared ownership inconsistency. None is claimed fixed by this PR. Material SQLite redesign remains outside this change.

Latest ClawSweeper comment checked before landing: acknowledgement only, with no published Rank-up moves to apply. Fresh independent Codex reviews and exact-head CI are complete; no ClawSweeper approval is claimed.
