### PR TITLE
fix(cli): recover invalidated control-only resumes

### DIFF
--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -35,6 +35,11 @@ import {
   setDiagnosticsEnabledForProcess,
   waitForDiagnosticEventsDrained,
 } from "../infra/diagnostic-events.js";
+import type {
+  CliBackendConfig,
+  CliBackendExecute,
+  CliBackendLiveSessionHandle,
+} from "../plugins/cli-backend.types.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { getProcessSupervisor } from "../process/supervisor/index.js";
 import type { RunExit } from "../process/supervisor/types.js";
@@ -46,6 +51,7 @@ import { createTestUserTurnTranscriptTarget } from "../sessions/user-turn-transc
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { prepareSystemAgentRunAdmission } from "./admitted-run-context.js";
 import { createTestAdmittedRunContext } from "./admitted-run-context.test-support.js";
 import { testing as cliBackendsTesting } from "./cli-backends.test-support.js";
 import {
@@ -233,6 +239,87 @@ function makeClaudePreparedContext(
 ): PreparedCliRunContext {
   return buildPreparedContext({ provider: "claude-cli", model: "opus", ...overrides });
 }
+
+async function usePluginLiveBackend(context: PreparedCliRunContext, execute: CliBackendExecute) {
+  const backend: CliBackendConfig = {
+    command: "/bin/sh",
+    args: [],
+    resumeArgs: ["--resume", "{sessionId}"],
+    output: "jsonl",
+    jsonlDialect: "claude-stream-json",
+    input: "stdin",
+    sessionMode: "existing",
+    liveSession: "claude-stdio",
+    freshSessionRecovery: "invalidated-only",
+  };
+  context.preparedBackend.backend = backend;
+  context.backendResolved.config = backend;
+  context.executionTarget = { kind: "plugin", execute };
+  const admission = prepareSystemAgentRunAdmission(
+    {},
+    context.params.runId,
+    "main",
+    "plugin-recovery-test",
+  );
+  context.params.admittedRunContext = await admission.admit("plugin-harness");
+  return { admission, context };
+}
+
+const failClosedPluginResumeCases: Array<{
+  name: string;
+  warm?: boolean;
+  invalidate?: boolean;
+  managed?: boolean;
+  resume?: boolean;
+  event?: Record<string, unknown>;
+}> = [
+  { name: "a valid required generation", warm: true, resume: true },
+  { name: "a fresh managed turn", managed: true },
+  { name: "an unbound managed resume", managed: true, resume: true },
+  { name: "a one-shot turn" },
+  {
+    name: "assistant output",
+    warm: true,
+    invalidate: true,
+    resume: true,
+    event: { type: "assistant", message: { content: [{ type: "text", text: "started" }] } },
+  },
+  {
+    name: "thinking output",
+    warm: true,
+    invalidate: true,
+    resume: true,
+    event: { type: "assistant", message: { content: [{ type: "thinking", thinking: "work" }] } },
+  },
+  {
+    name: "tool output with an active parsed tool",
+    warm: true,
+    invalidate: true,
+    resume: true,
+    event: {
+      type: "assistant",
+      message: { content: [{ type: "tool_use", id: "tool-1", name: "Read", input: {} }] },
+    },
+  },
+  {
+    name: "background work",
+    warm: true,
+    invalidate: true,
+    resume: true,
+    event: {
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "task-1", task_type: "local_agent" }],
+    },
+  },
+  {
+    name: "an unknown event",
+    warm: true,
+    invalidate: true,
+    resume: true,
+    event: { type: "future_event" },
+  },
+];
 
 function makeRunExit(overrides: Partial<RunExit> = {}): RunExit {
   return {
@@ -4138,6 +4225,210 @@ describe("runCliAgent reliability", () => {
       expect(firstHistoryMessage.content).toBe(`history-5`);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fresh-reseeds one invalidated control-only plugin resume without duplicate hooks", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) =>
+        ["llm_input", "llm_output", "agent_end"].includes(hookName),
+      ),
+      runLlmInput: vi.fn(async () => undefined),
+      runLlmOutput: vi.fn(async () => undefined),
+      runAgentEnd: vi.fn(async () => undefined),
+    };
+    setHookRunnerForTest(hookRunner);
+    let attempts = 0;
+    let liveHandle: CliBackendLiveSessionHandle | undefined;
+    const execute: CliBackendExecute = async function* (execution) {
+      attempts += 1;
+      const capability = execution.liveSession;
+      if (!capability) {
+        throw new Error("Expected a managed live-session capability.");
+      }
+      if (attempts === 1) {
+        const handle: CliBackendLiveSessionHandle = {
+          generation: "warm-generation",
+          fingerprint: capability.fingerprint,
+          isIdle: () => true,
+          close: () => capability.remove(handle),
+          waitForExit: async () => {},
+        };
+        liveHandle = handle;
+        capability.register(handle);
+        yield { type: "result", subtype: "success", is_error: false, result: "warm" };
+        return;
+      }
+      if (attempts === 2) {
+        expect(execution.useResume).toBe(true);
+        yield { type: "system", subtype: "init", session_id: "warm-session" };
+        capability.current()?.close("abort");
+        return;
+      }
+      expect(execution.useResume).toBe(false);
+      expect(execution.prompt).toContain("earlier context");
+      yield {
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        result: "recovered output",
+        session_id: "fresh-session",
+      };
+    };
+    const { admission, context } = await usePluginLiveBackend(
+      makeClaudePreparedContext({
+        sessionKey: "agent:main:plugin-resume-recovery",
+        runId: "run-plugin-resume-recovery",
+        cliSessionId: "warm-session",
+        openClawHistoryPrompt: CLI_RESEED_PROMPT,
+      }),
+      execute,
+    );
+    const clearBeforeRetry = vi.fn(async () => true);
+
+    try {
+      await executePreparedCliRun({ ...context, openClawHistoryPrompt: undefined }, undefined);
+      context.requiredClaudeLiveSessionGeneration = liveHandle?.generation;
+      const result = await runPreparedCliAgent({
+        ...context,
+        params: {
+          ...context.params,
+          onBeforeFreshCliSessionRetry: clearBeforeRetry,
+        },
+      });
+
+      expect(result.payloads).toEqual([{ text: "recovered output" }]);
+      expect(attempts).toBe(3);
+      expect(clearBeforeRetry).toHaveBeenCalledOnce();
+      expect(hookRunner.runLlmInput).toHaveBeenCalledOnce();
+      expect(hookRunner.runLlmOutput).toHaveBeenCalledOnce();
+      expect(hookRunner.runAgentEnd).toHaveBeenCalledOnce();
+    } finally {
+      liveHandle?.close("restart");
+      admission.close();
+    }
+  });
+
+  it.each(failClosedPluginResumeCases)(
+    "keeps the original failure after $name",
+    async ({ name, event, invalidate, managed, resume, warm }) => {
+      let attempts = 0;
+      let liveHandle: CliBackendLiveSessionHandle | undefined;
+      const streamError = new Error("plugin stream failed without a retry-safe termination");
+      const execute: CliBackendExecute = async function* (execution) {
+        attempts += 1;
+        const capability = execution.liveSession;
+        if (warm && attempts === 1) {
+          if (!capability) {
+            throw new Error("Expected a managed live-session capability.");
+          }
+          const handle: CliBackendLiveSessionHandle = {
+            generation: "warm-generation",
+            fingerprint: capability.fingerprint,
+            isIdle: () => true,
+            close: () => capability.remove(handle),
+            waitForExit: async () => {},
+          };
+          liveHandle = handle;
+          capability.register(handle);
+          yield { type: "result", subtype: "success", is_error: false, result: "warm" };
+          return;
+        }
+        yield { type: "system", subtype: "init", session_id: "warm-session" };
+        if (event) {
+          yield event;
+        }
+        if (invalidate) {
+          capability?.current()?.close("abort");
+        }
+        throw streamError;
+      };
+      const { admission, context } = await usePluginLiveBackend(
+        makeClaudePreparedContext({
+          runId: `run-plugin-fail-closed-${name.replaceAll(" ", "-")}`,
+          openClawHistoryPrompt: CLI_RESEED_PROMPT,
+        }),
+        execute,
+      );
+      if (!managed && !warm) {
+        delete context.preparedBackend.backend.liveSession;
+      }
+
+      try {
+        if (warm) {
+          await executePreparedCliRun({ ...context, openClawHistoryPrompt: undefined }, undefined);
+          context.requiredClaudeLiveSessionGeneration = liveHandle?.generation;
+        }
+        await expect(
+          executePreparedCliRun(context, resume ? "warm-session" : undefined),
+        ).rejects.toBe(streamError);
+        expect(attempts).toBe(warm ? 2 : 1);
+      } finally {
+        liveHandle?.close("restart");
+        admission.close();
+      }
+    },
+  );
+
+  it("does not retry again when the fresh plugin recovery attempt fails", async () => {
+    let attempts = 0;
+    let liveHandle: CliBackendLiveSessionHandle | undefined;
+    const freshError = new Error("fresh plugin attempt failed");
+    const execute: CliBackendExecute = async function* (execution) {
+      attempts += 1;
+      const capability = execution.liveSession;
+      if (!capability) {
+        throw new Error("Expected a managed live-session capability.");
+      }
+      if (attempts === 1) {
+        const handle: CliBackendLiveSessionHandle = {
+          generation: "warm-generation",
+          fingerprint: capability.fingerprint,
+          isIdle: () => true,
+          close: () => capability.remove(handle),
+          waitForExit: async () => {},
+        };
+        liveHandle = handle;
+        capability.register(handle);
+        yield { type: "result", subtype: "success", is_error: false, result: "warm" };
+        return;
+      }
+      if (attempts === 2) {
+        yield { type: "system", subtype: "init", session_id: "warm-session" };
+        capability.current()?.close("abort");
+        return;
+      }
+      throw freshError;
+    };
+    const { admission, context } = await usePluginLiveBackend(
+      makeClaudePreparedContext({
+        sessionKey: "agent:main:plugin-resume-recovery-failure",
+        runId: "run-plugin-resume-recovery-failure",
+        cliSessionId: "warm-session",
+        openClawHistoryPrompt: CLI_RESEED_PROMPT,
+      }),
+      execute,
+    );
+    const clearBeforeRetry = vi.fn(async () => true);
+
+    try {
+      await executePreparedCliRun({ ...context, openClawHistoryPrompt: undefined }, undefined);
+      context.requiredClaudeLiveSessionGeneration = liveHandle?.generation;
+      await expect(
+        runPreparedCliAgent({
+          ...context,
+          params: {
+            ...context.params,
+            onBeforeFreshCliSessionRetry: clearBeforeRetry,
+          },
+        }),
+      ).rejects.toBe(freshError);
+
+      expect(attempts).toBe(3);
+      expect(clearBeforeRetry).toHaveBeenCalledOnce();
+    } finally {
+      liveHandle?.close("restart");
+      admission.close();
     }
   });
 

--- a/src/agents/cli-runner/execute-plugin.test.ts
+++ b/src/agents/cli-runner/execute-plugin.test.ts
@@ -105,10 +105,10 @@ function runPlugin(
     env: { PATH: "/bin:/usr/bin", OPENCLAW_TEST_MARKER: "host-owned" },
     prompt: context.params.prompt,
     promptContext: context.promptContext,
-    useResume: options.useResume ?? false,
+    useResume: options.useResume ?? Boolean(options.requiredGeneration),
     sessionId: options.sessionId ?? "sdk-session",
     ...(options.forceNewSession ? { forceNewSession: true } : {}),
-    ...(options.liveSession
+    ...(options.liveSession || options.requiredGeneration
       ? {
           liveSession: {
             beginCapture: () => {},
@@ -401,6 +401,102 @@ describe("plugin-owned CLI execution host boundary", () => {
       }),
     ).resolves.toMatchObject({ reason: "exit" });
     expect(replacement.close).toHaveBeenCalledWith("restart");
+  });
+
+  it.each([undefined, new Error("SDK stream closed after init")])(
+    "recovers an invalidated control-only resume %#",
+    async (streamError) => {
+      const { context } = await createExecution();
+      const session = registerOwnerSession(context, "required-generation");
+      const run = runPlugin(
+        context,
+        async function* () {
+          yield { type: "system", subtype: "init", session_id: "sdk-session" };
+          session.handle.close("abort");
+          if (streamError) {
+            throw streamError;
+          }
+        },
+        {
+          requiredGeneration: "required-generation",
+        },
+      );
+
+      await expect(run).rejects.toMatchObject({
+        reason: "session_expired",
+        code: "cli_live_session_missing",
+        cause: streamError ?? expect.any(Error),
+      });
+    },
+  );
+
+  it("does not replay an invalidated resume while native approval is pending", async () => {
+    const { context } = await createExecution({
+      config: { tools: { exec: { security: "allowlist", ask: "on-miss" } } },
+      nativeTools: ["WebFetch"],
+    });
+    const session = registerOwnerSession(context, "required-generation");
+    const approval = createDeferred<{ id: string; decision: "deny" }>();
+    mockCallGatewayTool.mockReturnValueOnce(approval.promise);
+    const streamError = new Error("SDK stream failed during approval");
+    let pending: Promise<CliBackendToolPermissionResult> | undefined;
+
+    const run = runPlugin(
+      context,
+      async function* (execution) {
+        pending = requestNativeTool(execution, "WebFetch", { url: "https://example.com" });
+        await vi.waitFor(() => expect(mockCallGatewayTool).toHaveBeenCalledOnce());
+        yield { type: "system", subtype: "init", session_id: "sdk-session" };
+        session.handle.close("abort");
+        throw streamError;
+      },
+      {
+        requiredGeneration: "required-generation",
+      },
+    );
+
+    await expect(run).rejects.toBe(streamError);
+    approval.resolve({ id: "approval-pending", decision: "deny" });
+    await pending;
+  });
+
+  it("does not replay an invalidated resume while operator input is pending", async () => {
+    const { context } = await createExecution({ nativeTools: ["AskUserQuestion"] });
+    const session = registerOwnerSession(context, "required-generation");
+    const answer = createDeferred<{ status: "cancelled" }>();
+    mockCallGatewayTool.mockImplementation(async (method, _opts, rawParams) => {
+      const params = rawParams as { id: string };
+      if (method === "question.request") {
+        return { id: params.id };
+      }
+      if (method === "question.waitAnswer") {
+        return await answer.promise;
+      }
+      return { status: "cancelled" };
+    });
+    const streamError = new Error("SDK stream failed during operator input");
+    let pending: ReturnType<CliBackendExecuteContext["requestUserInput"]> | undefined;
+
+    const run = runPlugin(
+      context,
+      async function* (execution) {
+        pending = execution.requestUserInput({
+          toolName: "AskUserQuestion",
+          questions: [{ id: "choice", header: "Continue", question: "Continue?" }],
+        });
+        await vi.waitFor(() => expect(mockCallGatewayTool).toHaveBeenCalledTimes(2));
+        yield { type: "system", subtype: "init", session_id: "sdk-session" };
+        session.handle.close("abort");
+        throw streamError;
+      },
+      {
+        requiredGeneration: "required-generation",
+      },
+    );
+
+    await expect(run).rejects.toBe(streamError);
+    answer.resolve({ status: "cancelled" });
+    await pending;
   });
 
   it("claims prepared resources only for the original process and cleans after its exit", async () => {

--- a/src/agents/cli-runner/execute-plugin.test.ts
+++ b/src/agents/cli-runner/execute-plugin.test.ts
@@ -779,13 +779,14 @@ describe("plugin-owned CLI execution host boundary", () => {
         context,
         async function* () {
           yield terminal;
+          yield SUCCESS_RESULT;
           throw new Error("SDK stream closed after the provider error");
         },
         { consumeStdout: output.push.bind(output) },
       ),
     ).resolves.toMatchObject({ reason: "exit", exitCode: 0 });
 
-    expect(output.map((line) => JSON.parse(line))).toEqual([terminal]);
+    expect(output.map((line) => JSON.parse(line))).toEqual([terminal, SUCCESS_RESULT]);
   });
 
   it.each([

--- a/src/agents/cli-runner/execute-plugin.ts
+++ b/src/agents/cli-runner/execute-plugin.ts
@@ -569,6 +569,7 @@ export async function executePluginOwnedProcess(params: {
       }
       if (next.value.type === "result") {
         terminalResult =
+          terminalResult === "error" ||
           next.value.is_error === true ||
           (typeof next.value.subtype === "string" && next.value.subtype.startsWith("error_"))
             ? "error"

--- a/src/agents/cli-runner/execute-plugin.ts
+++ b/src/agents/cli-runner/execute-plugin.ts
@@ -16,7 +16,7 @@ import { resolveAdmittedRunActiveAssertion } from "../admitted-run-context.js";
 import { runBeforeToolCallHook } from "../agent-tools.before-tool-call.js";
 import type { CliTerminalInterruption } from "../cli-output-contracts.js";
 import { resolveExecDefaults } from "../exec-defaults.js";
-import { isSignalTimeoutReason, type FailoverError } from "../failover-error.js";
+import { FailoverError, isSignalTimeoutReason } from "../failover-error.js";
 import { runStructuredInput } from "../harness/structured-input-execution.js";
 import { compileStructuredInputQuestions } from "../harness/structured-input.js";
 import { resolveToolLoopDetectionConfig } from "../tool-loop-detection-config.js";
@@ -32,7 +32,8 @@ import {
   resolveCliNativeToolApprovalPlan,
 } from "./cli-native-tool-approval.js";
 import { createCliAbortError } from "./execute-node-claude.js";
-import { resolveCliNoOutputTimeoutDecision } from "./no-output-timeout-policy.js";
+import { createCliFailoverError as failover } from "./exit-error.js";
+import * as noOutputPolicy from "./no-output-timeout-policy.js";
 import type { PreparedCliRunContext } from "./types.js";
 
 const PLUGIN_ITERATOR_CLOSE_TIMEOUT_MS = 5_000;
@@ -432,6 +433,8 @@ export async function executePluginOwnedProcess(params: {
     observed: false,
     replayUnsafe: false,
   };
+  const updatePendingApproval = (delta: number) =>
+    (outstanding.approvals = Math.max(0, outstanding.approvals + delta));
   let noOutputTimer: ReturnType<typeof setTimeout> | undefined;
   const overallTimeoutMs = clampPositiveTimerTimeoutMs(run.timeoutMs);
   const noOutputTimeoutMs = clampPositiveTimerTimeoutMs(params.noOutputTimeoutMs);
@@ -449,7 +452,7 @@ export async function executePluginOwnedProcess(params: {
     }
     noOutputTimer = setTimeout(() => {
       const quietDurationMs = Date.now() - outstanding.lastOutputAt;
-      const decision = resolveCliNoOutputTimeoutDecision({
+      const decision = noOutputPolicy.resolveCliNoOutputTimeoutDecision({
         context: {
           provider: run.provider,
           model: params.context.modelId,
@@ -497,8 +500,8 @@ export async function executePluginOwnedProcess(params: {
   }
 
   let iterator: AsyncIterator<Record<string, unknown>> | undefined;
-  let terminalResultSeen = false;
-  let terminalErrorSeen = false;
+  let liveSession: ReturnType<typeof createCliLiveSessionCapability> | undefined;
+  let terminalResult: "none" | "success" | "error" = "none";
   try {
     resetNoOutputTimer();
     if (
@@ -516,6 +519,16 @@ export async function executePluginOwnedProcess(params: {
       }
       assertActive();
     }
+    if (params.liveSession) {
+      liveSession = createCliLiveSessionCapability({
+        context: params.context,
+        argv: [command, ...params.executionArgs],
+        env: params.env,
+        ...params.liveSession,
+        abortSignal: signal,
+        claimResources: params.context.preparedBackend.claimLiveSessionResources,
+      });
+    }
     const execution = params.execute({
       command,
       args: params.executionArgs,
@@ -531,33 +544,16 @@ export async function executePluginOwnedProcess(params: {
       timeoutMs: run.timeoutMs,
       ...(run.executionMode ? { executionMode: run.executionMode } : {}),
       ...(run.cliToolAvailability ? { toolAvailability: run.cliToolAvailability } : {}),
-      ...(params.liveSession
-        ? {
-            liveSession: createCliLiveSessionCapability({
-              context: params.context,
-              argv: [command, ...params.executionArgs],
-              env: params.env,
-              captureKey: params.liveSession.captureKey,
-              beginCapture: params.liveSession.beginCapture,
-              abortSignal: signal,
-              requiredGeneration: params.liveSession.requiredGeneration,
-              claimResources: params.context.preparedBackend.claimLiveSessionResources,
-            }),
-          }
-        : {}),
+      ...(liveSession ? { liveSession } : {}),
       requestToolPermission: createPluginToolPermissionHandler({
         context: params.context,
         abortSignal: signal,
-        onPendingApproval: (delta) => {
-          outstanding.approvals = Math.max(0, outstanding.approvals + delta);
-        },
+        onPendingApproval: updatePendingApproval,
       }),
       requestUserInput: createPluginUserInputHandler({
         context: params.context,
         abortSignal: signal,
-        onPendingInput: (delta) => {
-          outstanding.approvals = Math.max(0, outstanding.approvals + delta);
-        },
+        onPendingInput: updatePendingApproval,
       }),
     });
     iterator = execution[Symbol.asyncIterator]();
@@ -568,13 +564,15 @@ export async function executePluginOwnedProcess(params: {
         break;
       }
       if (!isRecord(next.value)) {
+        outstanding.replayUnsafe = true;
         throw new Error("CLI plugin runtime emitted an invalid structured stream event.");
       }
       if (next.value.type === "result") {
-        terminalResultSeen = true;
-        terminalErrorSeen ||=
+        terminalResult =
           next.value.is_error === true ||
-          (typeof next.value.subtype === "string" && next.value.subtype.startsWith("error_"));
+          (typeof next.value.subtype === "string" && next.value.subtype.startsWith("error_"))
+            ? "error"
+            : "success";
       }
       if (
         next.value.type === "system" &&
@@ -595,7 +593,7 @@ export async function executePluginOwnedProcess(params: {
       resetNoOutputTimer();
     }
 
-    if (!terminalResultSeen) {
+    if (terminalResult === "none") {
       throw new Error("CLI plugin runtime completed without a terminal result.");
     }
   } catch (error) {
@@ -606,9 +604,24 @@ export async function executePluginOwnedProcess(params: {
       }
       termination.reason = "manual-cancel";
     }
-    // SDKs can throw after emitting an authoritative failed terminal record.
-    // Preserve that record so the existing parser owns auth/rate-limit failover.
-    if (termination.reason === "exit" && !terminalErrorSeen) {
+    if (termination.reason === "exit" && terminalResult !== "error") {
+      if (
+        params.liveSession?.requiredGeneration &&
+        noOutputPolicy.isReplaySafeCliResumeControlOnly(
+          params.useResume,
+          outstanding.replayUnsafe,
+          Boolean(outstanding.approvals || outstanding.background || params.activeToolCount?.()),
+        )
+      ) {
+        try {
+          liveSession?.current();
+        } catch (sessionError) {
+          if (sessionError instanceof FailoverError && sessionError.reason === "session_expired") {
+            const { code, message, reason } = sessionError;
+            throw failover(message, reason, sessionError, { cause: error, code });
+          }
+        }
+      }
       throw error;
     }
   } finally {

--- a/src/agents/cli-runner/no-output-timeout-policy.ts
+++ b/src/agents/cli-runner/no-output-timeout-policy.ts
@@ -15,7 +15,6 @@ type CliNoOutputTimeoutPolicyParams = {
 
 export const isReplaySafeCliResumeControlOnly = (useResume: boolean, ...unsafe: boolean[]) =>
   useResume && !unsafe.some(Boolean);
-
 export function resolveCliNoOutputTimeoutDecision(params: CliNoOutputTimeoutPolicyParams): {
   deferMs?: number;
   error: FailoverError;

--- a/src/agents/cli-runner/no-output-timeout-policy.ts
+++ b/src/agents/cli-runner/no-output-timeout-policy.ts
@@ -13,26 +13,28 @@ type CliNoOutputTimeoutPolicyParams = {
   outstandingWorkGraceMs?: number;
 };
 
+export const isReplaySafeCliResumeControlOnly = (useResume: boolean, ...unsafe: boolean[]) =>
+  useResume && !unsafe.some(Boolean);
+
 export function resolveCliNoOutputTimeoutDecision(params: CliNoOutputTimeoutPolicyParams): {
   deferMs?: number;
   error: FailoverError;
 } {
   const outstandingWork =
-    params.cliTimeout.activeToolCount > 0 || params.cliTimeout.backgroundTaskCount > 0;
-  // Live-only: tracked work may extend the watchdog; spawn has already terminated its child.
+    params.cliTimeout.activeToolCount + params.cliTimeout.backgroundTaskCount > 0;
   const deferMs =
     outstandingWork && params.outstandingWorkGraceMs !== undefined
       ? Math.max(params.timeoutMs, params.outstandingWorkGraceMs) - params.quietDurationMs
       : undefined;
-  // Live-only: resume control traffic is distinguishable from replay-unsafe substantive output.
-  const retryableResumeStall =
-    params.allowResumeControlOnlyRetry === true &&
-    params.useResume &&
-    !params.hasOutputText &&
-    !params.hasReplayUnsafeActivity &&
-    !outstandingWork;
   const retryable =
-    (!params.cliTimeout.observedActivity && !params.hasOutputText) || retryableResumeStall;
+    (!params.cliTimeout.observedActivity && !params.hasOutputText) ||
+    (params.allowResumeControlOnlyRetry === true &&
+      isReplaySafeCliResumeControlOnly(
+        params.useResume,
+        params.hasOutputText,
+        params.hasReplayUnsafeActivity,
+        outstandingWork,
+      ));
   return {
     ...(deferMs !== undefined && deferMs > 0 ? { deferMs } : {}),
     error: createCliTimeoutError(


### PR DESCRIPTION
Fixes #133475

Reported by @jakestenger.

## What Problem This Solves

A resumed plugin-owned live CLI turn could receive only replay-safe init/control traffic, lose the exact live-session generation, and then end without a terminal result. The generic plugin host surfaced the ordinary EOF/iterator error, so the existing `invalidated-only` recovery path never received the authoritative `session_expired` signal and the agent turn could end with no reply.

This does not attribute the failure to real hot reload. The proven owner is the generic plugin host and its live-session capability boundary.

## Root Cause And Fix

- Owner: generic plugin-host execution in `src/agents/cli-runner/execute-plugin.ts`.
- Root cause: terminal completion and iterator-throw handling did not revalidate the required live-session generation after replay-safe control-only traffic.
- Canonical fix: export and reuse `isReplaySafeCliResumeControlOnly()` from the no-output watchdog policy, retain the live-session capability through completion, and revalidate `current()` only when no substantive/unknown activity or active tool/approval/input/background work was observed.
- Promotion rule: only a `session_expired` revalidation failure becomes a new `FailoverError`; `cli_live_session_missing` / `cli_live_session_changed` are retained and the original EOF/stream error is the direct `cause`.
- Existing terminal precedence remains intact: once an error-marked result is observed, later success records cannot replace it while the iterator drains.
- Recovery remains the existing single fresh attempt under `freshSessionRecovery: "invalidated-only"`.
- Normal EOF and iterator throw use the same path. A valid generation or any different revalidation failure preserves the original error.

## Regression Proof

Base-red, before production edits:

- warm required generation + init/control-only + generation removed + normal EOF: failed 1/1 because a plain terminal-result `Error` surfaced instead of `session_expired`;
- iterator sentinel after init + generation invalidation: failed 1/1 because the sentinel remained the top-level error instead of the repaired error's direct `cause`.

ClawSweeper P1 regression proof:

- error-marked terminal result + later success result + iterator throw: failed 2/2 without sticky error state because the iterator exception escaped instead of preserving the authoritative provider error;
- the same table-driven cases pass 2/2 with sticky error state restored.

Head-green:

- `src/agents/cli-runner/execute-plugin.test.ts`: 32/32
- `src/agents/cli-runner.reliability.test.ts`: 102/102
- focused total: 134/134
- unchanged `extensions/anthropic/agent-sdk.runtime.test.ts`: 31/31
- unchanged `pnpm test:extension anthropic`: 484/484
- `pnpm check:changed`: pass
- typed Oxlint, core/core-test typechecks, format, import cycles, architecture/security guards, and `git diff --check`: pass

Negative coverage keeps the original failure for a valid generation, fresh/cold/one-shot execution, assistant output, thinking output, tool activity, background work, active approval/input, and unknown events. Reliability coverage proves one history-reseeded success with hooks/reply once and no third attempt when the fresh retry fails.

## Gateway Proof

A deterministic temporary proof loaded a real registered fake CLI backend into an ephemeral Gateway and called the final `agent` RPC:

1. first RPC registered `warm-generation` and persisted `warm-session`;
2. second RPC resumed, emitted init-only traffic, and removed that exact generation;
3. the host promoted the EOF to `session_expired`;
4. `invalidated-only` cleared the stale binding and made exactly one fresh attempt with both prior and current user turns in the reseed prompt;
5. the RPC returned `RECOVERED_RPC_OK` and persisted `fresh-session`.

Observed attempt modes: `[fresh, resume, fresh]`. Gateway proof: 1/1 pass. The temporary fixture was removed before commit.

## LOC

- Production: +15 net
  - `execute-plugin.ts`: +14 net
  - `no-output-timeout-policy.ts`: +1 net
- Tests: +388 net
  - reliability: +291 net
  - plugin-host boundary: +97 net

The production growth is the minimum ownership capability needed to retain and revalidate the authoritative live-session generation at termination; duplicate control-only policy was absorbed into the shared predicate.

## Current And Shipped Behavior

- Current `origin/main` before this change surfaced the plain EOF/iterator error and skipped fresh recovery.
- Latest stable release `v2026.7.1-2` (published August 4, 2026) predates this plugin-host file/path, so this is not claimed as a shipped stable regression.

## Dependency And Source Checks

- Personally inspected OpenAI Codex `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`; neither section owns this failure or changes the generic host invariant.
- Inspected the Anthropic SDK terminal-result contract and ran its implementation/tests unchanged.
- Codebase-memory graph transport was unavailable because another pre-coordination or unverified CBM generation was active; no competing process was disturbed. Investigation fell back to direct source, callers, sibling paths, dependency types, and Git history.

## Review

- Test-audit: pass; regressions are observable owner-boundary behavior, failed on base for the intended reason, and require no test-only production seam.
- ClawSweeper exact-head re-review: no actionable findings; the prior P1 is fixed, narrow invalidated-only coverage is retained, and normal landing validation is complete.
- Autoreview: scoped-clean, 0 accepted/actionable findings, 0 suspected usable credentials, overall 0.99.
