### PR TITLE
docs: add example ACP endpoint registry with key-by-reference

### DIFF
--- a/examples/acp-endpoint-registry/README.md
+++ b/examples/acp-endpoint-registry/README.md
@@ -1,0 +1,114 @@
+# Example: ACP endpoint registry with key-by-reference
+
+A small, self-contained example for pointing OpenClaw's ACP runtime (acpx)
+harnesses at self-hosted, Anthropic-compatible endpoints without ever
+putting API keys in shell rc files, environment exports, or repo files.
+
+The pattern has three pieces:
+
+| File                     | Purpose                                                                                                         |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `endpoints.example.json` | Declarative registry: endpoint, key **file reference**, default model, role-slot map, extra env                 |
+| `launcher.py`            | Reads the registry, resolves the key from a mode-0600 file, execs the adapter with a clean environment          |
+| `secret-scrub.py`        | Fail-closed hygiene gate: scan tracked files for key-shaped literals, or validate a registry (`--check-config`) |
+
+This is an example, not product code: `launcher.py` is harness-agnostic and
+has no dependency on OpenClaw internals, so you can adapt it to any adapter
+command, not just the `claude` one shown below.
+
+## Why key-by-reference
+
+Self-hosted Anthropic-compatible endpoints make it tempting to export
+`ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` in a shell profile. That leaks the
+key to every process in the session and every command dump in issue reports.
+This example keeps the literal key in exactly one place — a `0600` file — and
+references it by path from the registry:
+
+```json
+{
+  "adapters": {
+    "claude": {
+      "endpoint": "http://your-anthropic-compatible-endpoint.example:8080",
+      "apiKeyRef": "keys/claude.key",
+      "model": "your-default-model",
+      "slots": { "haiku": "your-fast-model", "sonnet": "your-default-model" },
+      "env": { "DISABLE_AUTOUPDATER": "1" }
+    }
+  }
+}
+```
+
+`secret-scrub.py --check-config` enforces the invariant fail-closed: no
+inline key material in the registry, `apiKeyRef` must be a path, the key file
+must exist, must be mode `0600`, and must be either outside the repo or
+gitignored.
+
+## Quick start
+
+```sh
+mkdir -p ~/.openclaw/acp/keys
+cp launcher.py ~/.openclaw/acp/launcher.py
+cp endpoints.example.json ~/.openclaw/acp/endpoints.json
+printf '%s' 'your-endpoint-key' > ~/.openclaw/acp/keys/claude.key
+chmod 600 ~/.openclaw/acp/keys/claude.key
+$EDITOR ~/.openclaw/acp/endpoints.json   # point endpoint/model at your setup
+python3 secret-scrub.py --check-config ~/.openclaw/acp/endpoints.json
+```
+
+Run the example test suite (no network, no real adapter — it stubs the
+adapter and asserts the environment the launcher hands over):
+
+```sh
+python3 test.py
+```
+
+Directory layout used by the defaults (all overridable via env vars):
+`~/.openclaw/acp/endpoints.json` for the registry, `keys/` next to it for
+key files. `ACP_REGISTRY_FILE` points at a different registry, and
+`ACP_ADAPTER_PATH` overrides the adapter command that gets exec'd.
+
+## Wiring it into OpenClaw (acpx)
+
+Set your acpx config's custom agent command for the harness to invoke the
+launcher (see [ACP agents — setup](https://docs.openclaw.ai/tools/acp-agents-setup)
+for the config surface):
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "acpx": {
+        "enabled": true,
+        "config": {
+          "agents": {
+            "claude": {
+              "command": "python3",
+              "args": ["/home/you/.openclaw/acp/launcher.py", "claude"]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The launcher strips OpenClaw wrapper-only flags before handing arguments to
+the adapter, maps role slots to the adapter's environment, and never prints
+key material — including on failure paths.
+
+## Hygiene gate
+
+```sh
+# scan explicit paths (or all tracked git files when run from a repo)
+python3 secret-scrub.py --scan examples/
+
+# validate the live registry + key permissions
+python3 secret-scrub.py --check-config ~/.openclaw/acp/endpoints.json
+```
+
+Both modes exit non-zero on any finding, which makes them usable as
+pre-commit hooks or CI lint steps. The pattern list (OpenAI- and Anthropic-
+style keys, GitHub/Slack/Groq/Google/Perplexity/HuggingFace/npm tokens,
+private-key blocks, generic `"api_key": "***"` assignments) is a plain list of
+`(compiled regex, label)` pairs — extend it for your own token formats.

--- a/examples/acp-endpoint-registry/README.md
+++ b/examples/acp-endpoint-registry/README.md
@@ -62,6 +62,18 @@ adapter and asserts the environment the launcher hands over):
 python3 test.py
 ```
 
+Install an adapter for the launcher to exec. The launcher's default adapter
+path is
+`~/.openclaw/acp/node_modules/@agentclientprotocol/claude-agent-acp/dist/index.js`,
+which this installs:
+
+```sh
+npm install --prefix ~/.openclaw/acp @agentclientprotocol/claude-agent-acp
+```
+
+Pointing at a different adapter entrypoint (any executable) is one
+environment variable: `ACP_ADAPTER_PATH=/path/to/your-adapter`.
+
 Directory layout used by the defaults (all overridable via env vars):
 `~/.openclaw/acp/endpoints.json` for the registry, `keys/` next to it for
 key files. `ACP_REGISTRY_FILE` points at a different registry, and
@@ -71,7 +83,9 @@ key files. `ACP_REGISTRY_FILE` points at a different registry, and
 
 Set your acpx config's custom agent command for the harness to invoke the
 launcher (see [ACP agents — setup](https://docs.openclaw.ai/tools/acp-agents-setup)
-for the config surface):
+for the config surface). Each agent's `command` is a single string that may
+include its arguments — the ACPX schema does not accept a separate `args`
+field:
 
 ```json
 {
@@ -82,8 +96,7 @@ for the config surface):
         "config": {
           "agents": {
             "claude": {
-              "command": "python3",
-              "args": ["/home/you/.openclaw/acp/launcher.py", "claude"]
+              "command": "python3 /home/you/.openclaw/acp/launcher.py claude"
             }
           }
         }
@@ -100,7 +113,8 @@ key material — including on failure paths.
 ## Hygiene gate
 
 ```sh
-# scan explicit paths (or all tracked git files when run from a repo)
+# scan explicit files or directories (directories are walked recursively;
+# omitted paths scan all tracked git files when run from a repo)
 python3 secret-scrub.py --scan examples/
 
 # validate the live registry + key permissions

--- a/examples/acp-endpoint-registry/README.md
+++ b/examples/acp-endpoint-registry/README.md
@@ -43,6 +43,18 @@ inline key material in the registry, `apiKeyRef` must be a path, the key file
 must exist, must be mode `0600`, and must be either outside the repo or
 gitignored.
 
+## Scope: what this covers, what core covers
+
+Core acpx is gaining native SecretRef support for **MCP server environment
+values** (structured `env`/`file`/`exec`/`store` references resolved gateway-side
+— see openclaw/openclaw#128380). That covers one leg of the credential problem.
+This example covers the other: the custom agent command path
+(`agents.<id>.command`), where OpenClaw spawns an external ACP adapter process
+and core does not (yet) inject credentials into that spawn. The launcher here
+keeps adapter credentials in a `0600` file and hands them only to the adapter
+process. If native SecretRefs later reach the adapter-launch path, this example
+becomes unnecessary — and that's fine; examples are cheap to retire.
+
 ## Quick start
 
 ```sh

--- a/examples/acp-endpoint-registry/endpoints.example.json
+++ b/examples/acp-endpoint-registry/endpoints.example.json
@@ -1,0 +1,17 @@
+{
+  "adapters": {
+    "claude": {
+      "endpoint": "http://your-anthropic-compatible-endpoint.example:8080",
+      "apiKeyRef": "keys/claude.key",
+      "model": "your-default-model",
+      "slots": {
+        "haiku": "your-fast-model",
+        "sonnet": "your-default-model",
+        "opus": "your-heavy-model"
+      },
+      "env": {
+        "DISABLE_AUTOUPDATER": "1"
+      }
+    }
+  }
+}

--- a/examples/acp-endpoint-registry/launcher.py
+++ b/examples/acp-endpoint-registry/launcher.py
@@ -13,6 +13,7 @@ docs/tools/acp-agents-setup.md) or run it directly for testing.
 
 import json
 import os
+import shutil
 import stat
 import sys
 from pathlib import Path
@@ -29,7 +30,19 @@ ADAPTER_DEFAULT = (
     Path.home()
     / ".openclaw/acp/node_modules/@agentclientprotocol/claude-agent-acp/dist/index.js"
 )
-EXECUTABLE = os.environ.get("ACP_ADAPTER_EXECUTABLE") or "node"
+
+
+def resolve_executable(name: str) -> str:
+    """execve() performs no PATH lookup; bare names must be resolved first."""
+    if os.path.sep in name:
+        return name
+    resolved = shutil.which(name)
+    if resolved is None:
+        fail(f"executable not found on PATH: {name}")
+    return resolved
+
+
+EXECUTABLE = resolve_executable(os.environ.get("ACP_ADAPTER_EXECUTABLE") or "node")
 
 # Harness-independent wrapper flags that must not reach the adapter CLI.
 WRAPPER_VALUE_FLAGS = {

--- a/examples/acp-endpoint-registry/launcher.py
+++ b/examples/acp-endpoint-registry/launcher.py
@@ -21,9 +21,14 @@ ACP_DIR = Path.home() / ".openclaw/acp"
 CONFIG_FILE = Path(os.environ.get("ACP_REGISTRY_FILE") or (ACP_DIR / "endpoints.json"))
 
 # CLI exec path used to run the adapter. Override for testing or for adapters
-# installed outside the repository checkout.
+# installed outside the documented quick-start location (README "Install an
+# adapter"); the default matches `npm install --prefix ~/.openclaw/acp
+# @agentclientprotocol/claude-agent-acp`.
 ADAPTER_OVERRIDE_ENV = "ACP_ADAPTER_PATH"
-ADAPTER_DEFAULT = str(Path.home() / ".openclaw/acp/adapters/adapter.js")
+ADAPTER_DEFAULT = (
+    Path.home()
+    / ".openclaw/acp/node_modules/@agentclientprotocol/claude-agent-acp/dist/index.js"
+)
 EXECUTABLE = os.environ.get("ACP_ADAPTER_EXECUTABLE") or "node"
 
 # Harness-independent wrapper flags that must not reach the adapter CLI.
@@ -134,13 +139,18 @@ def main() -> None:
     entry = config["adapters"][adapter_id]
     key_value = read_key(entry["apiKeyRef"], CONFIG_FILE)
 
+    adapter_path = Path(os.environ.get(ADAPTER_OVERRIDE_ENV) or ADAPTER_DEFAULT)
+    if not adapter_path.is_file():
+        fail(
+            f"missing adapter: {adapter_path}\n"
+            "  install one per the README quick start (npm install --prefix "
+            "~/.openclaw/acp @agentclientprotocol/claude-agent-acp), or set "
+            f"{ADAPTER_OVERRIDE_ENV} to your adapter's entrypoint"
+        )
+
     os.execve(
         EXECUTABLE,
-        [
-            EXECUTABLE,
-            os.environ.get(ADAPTER_OVERRIDE_ENV) or ADAPTER_DEFAULT,
-            *strip_wrapper_flags(adapter_argv),
-        ],
+        [EXECUTABLE, str(adapter_path), *strip_wrapper_flags(adapter_argv)],
         build_env(entry, key_value, endpoint, model),
     )
 

--- a/examples/acp-endpoint-registry/launcher.py
+++ b/examples/acp-endpoint-registry/launcher.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Example ACP launcher: endpoint registry + key-by-reference for any harness.
+
+Reads a declarative registry (~/.openclaw/acp/endpoints.json) describing
+self-hosted endpoints for ACP harnesses, resolves each endpoint's API key
+from a mode-0600 file (never inline, never a shell env var), and execs the
+harness adapter with the registry's environment applied.
+
+This file is an example, not product code. It has no hard dependency on
+OpenClaw internals: point acpx's custom agent command at it (see
+docs/tools/acp-agents-setup.md) or run it directly for testing.
+"""
+
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+ACP_DIR = Path.home() / ".openclaw/acp"
+CONFIG_FILE = Path(os.environ.get("ACP_REGISTRY_FILE") or (ACP_DIR / "endpoints.json"))
+
+# CLI exec path used to run the adapter. Override for testing or for adapters
+# installed outside the repository checkout.
+ADAPTER_OVERRIDE_ENV = "ACP_ADAPTER_PATH"
+ADAPTER_DEFAULT = str(Path.home() / ".openclaw/acp/adapters/adapter.js")
+EXECUTABLE = os.environ.get("ACP_ADAPTER_EXECUTABLE") or "node"
+
+# Harness-independent wrapper flags that must not reach the adapter CLI.
+WRAPPER_VALUE_FLAGS = {
+    "--openclaw-acpx-lease-id",
+    "--openclaw-gateway-instance-id",
+}
+
+
+def fail(message: str) -> None:
+    # On failure nothing about the endpoint (including the key) is printed.
+    raise SystemExit(f"acp-launcher: {message}")
+
+
+def load_registry(config_path: Path) -> dict:
+    if not config_path.is_file():
+        fail(f"missing registry: {config_path}")
+    try:
+        return json.loads(config_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        fail(f"cannot read {config_path}: {exc}")
+
+
+def resolve_key_path(ref: str, config_path: Path) -> Path:
+    expanded = Path(os.path.expanduser(str(ref)))
+    return expanded if expanded.is_absolute() else (config_path.parent / expanded)
+
+
+def read_key(ref: str, config_path: Path) -> str:
+    key_path = resolve_key_path(ref, config_path)
+    if not key_path.is_file():
+        fail("key file missing")
+    value = key_path.read_text().strip()
+    if not value:
+        fail("key file is empty")
+    if stat.S_IMODE(key_path.stat().st_mode) & 0o077:
+        print(
+            f"acp-launcher: WARNING key file is group/other readable; run "
+            f"`chmod 600 {key_path}`",
+            file=sys.stderr,
+        )
+    return value
+
+
+def load_adapter(config: dict, adapter_id: str, config_path: Path) -> tuple[str, str]:
+    adapters = config.get("adapters") if isinstance(config, dict) else None
+    if not isinstance(adapters, dict) or adapter_id not in adapters:
+        known = ", ".join(sorted(adapters)) if isinstance(adapters, dict) else "none"
+        fail(f"unknown adapter '{adapter_id}' (known: {known})")
+    entry = adapters[adapter_id]
+    if not isinstance(entry, dict) or not all(
+        isinstance(entry.get(field), str) and entry.get(field, "").strip()
+        for field in ("endpoint", "model", "apiKeyRef")
+    ):
+        fail(f"adapters.{adapter_id} must set endpoint, model, and apiKeyRef")
+    return entry["endpoint"].strip(), entry["model"].strip()
+
+
+def strip_wrapper_flags(argv: list[str]) -> list[str]:
+    forwarded: list[str] = []
+    args = iter(argv)
+    for arg in args:
+        if arg in WRAPPER_VALUE_FLAGS:
+            next(args, None)  # drop the flag's value too
+        elif arg != "--hide-claude-auth":
+            forwarded.append(arg)
+    return forwarded
+
+
+def build_env(entry: dict, key_value: str, endpoint: str, model: str) -> dict:
+    """Merge registry env policy, then inject the resolved credentials."""
+    env = os.environ.copy()
+    for name, value in (entry.get("env") or {}).items():
+        if isinstance(name, str) and isinstance(value, str):
+            env[name] = value
+    env.update(
+        {
+            "ANTHROPIC_API_KEY": key_value,
+            "ANTHROPIC_BASE_URL": endpoint,
+            "ANTHROPIC_MODEL": model,
+            "CLAUDE_NO_ANALYTICS": "1",
+            "CLAUDE_CODE_DISABLE_UNKNOWN_MODEL_WINDOW_ENFORCEMENT": "1",
+        }
+    )
+    # Role-slot mapping: registry keys become the adapter's env controls.
+    slots = entry.get("slots")
+    if isinstance(slots, dict):
+        for slot, slot_model in slots.items():
+            if isinstance(slot, str) and isinstance(slot_model, str) and slot_model.strip():
+                env[f"ANTHROPIC_DEFAULT_{slot.upper()}_MODEL"] = slot_model.strip()
+    return env
+
+
+def main() -> None:
+    # Raw argv parsing, not argparse: adapter arguments routinely carry
+    # --flags that argparse would reject as unknown options before they
+    # reach the adapter. Format: launcher.py <adapter-id> [adapter args...]
+    argv = sys.argv[1:]
+    if not argv or argv[0].startswith("-"):
+        raise SystemExit(
+            "usage: launcher.py <adapter-id> [adapter args...]\n"
+            "example: launcher.py claude --verbose task"
+        )
+    adapter_id, adapter_argv = argv[0], argv[1:]
+
+    config = load_registry(CONFIG_FILE)
+    endpoint, model = load_adapter(config, adapter_id, CONFIG_FILE)
+    entry = config["adapters"][adapter_id]
+    key_value = read_key(entry["apiKeyRef"], CONFIG_FILE)
+
+    os.execve(
+        EXECUTABLE,
+        [
+            EXECUTABLE,
+            os.environ.get(ADAPTER_OVERRIDE_ENV) or ADAPTER_DEFAULT,
+            *strip_wrapper_flags(adapter_argv),
+        ],
+        build_env(entry, key_value, endpoint, model),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/acp-endpoint-registry/secret-scrub.py
+++ b/examples/acp-endpoint-registry/secret-scrub.py
@@ -15,6 +15,7 @@ and manual pre-PR checks; it is an example, not product code.
 """
 
 import argparse
+import os
 import re
 import stat
 import subprocess
@@ -88,9 +89,41 @@ def gitignored(root: Path, target: Path) -> bool:
     return out.returncode == 0
 
 
+def expand_paths(paths: list[Path]) -> list[Path]:
+    """Expand directories recursively into the files beneath them.
+
+    A supplied directory is walked (symlinks not followed, .git skipped) so
+    `--scan examples/` inspects the tree it names instead of reporting a
+    misleading zero-file success. A supplied path that does not exist is a
+    hard error: a typo'd path must not produce a green 0-scan result.
+    """
+    missing = [p for p in paths if not p.exists()]
+    if missing:
+        fail("no such path (nothing was scanned): " + ", ".join(str(m) for m in missing))
+    files: list[Path] = []
+    for path in paths:
+        if path.is_dir() and not path.is_symlink():
+            for root, dirs, names in os.walk(path):
+                dirs[:] = [d for d in dirs if d != ".git"]
+                for name in names:
+                    files.append(Path(root) / name)
+        else:
+            files.append(path)
+    # De-duplicate while preserving order.
+    seen: set[Path] = set()
+    unique: list[Path] = []
+    for path in files:
+        resolved = path.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            unique.append(path)
+    return unique
+
+
 def scan(paths: list[Path], repo_root: Path) -> None:
     if not paths:
         paths = tracked_files(repo_root)
+    paths = expand_paths(paths)
     findings: list[tuple[str, str]] = []
     checked = 0
     for path in paths:

--- a/examples/acp-endpoint-registry/secret-scrub.py
+++ b/examples/acp-endpoint-registry/secret-scrub.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Example secret scanner for launcher/registry checkout hygiene.
+
+Fail-closed pre-commit / pre-PR gate for self-hosted endpoint registries and
+the files around them. Accepts either mode:
+  --scan [PATHS...]     scan given paths (or tracked git files when omitted)
+  --check-config FILE   validate a registry:
+                          - no inline key material anywhere in the file
+                          - every apiKeyRef is a path reference, not a literal
+                          - the key file exists and is mode 0600
+                          - an in-repo key file is ignored by git
+
+Exits non-zero on any finding. Intended for pre-commit hooks, CI lint jobs,
+and manual pre-PR checks; it is an example, not product code.
+"""
+
+import argparse
+import re
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+# Token-shaped literals that must never appear in tracked files.
+# Entry point for local extensions: append (compiled_regex, label) pairs.
+PATTERNS = [
+    (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"), "private key block"),
+    (re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"), "OpenAI-style key"),
+    (re.compile(r"\bah-[A-Za-z0-9]{24,}\b"), "self-hosted gateway key"),
+    (re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"), "GitHub token"),
+    (re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"), "Slack token"),
+    (re.compile(r"\bgsk_[A-Za-z0-9_-]{10,}\b"), "Groq key"),
+    (re.compile(r"\bAIza[0-9A-Za-z\-_]{20,}\b"), "Google key"),
+    (re.compile(r"\bpplx-[A-Za-z0-9_-]{10,}\b"), "Perplexity key"),
+    (re.compile(r"\bhf_[A-Za-z0-9]{10,}\b"), "HuggingFace token"),
+    (re.compile(r"\bnpm_[A-Za-z0-9]{10,}\b"), "npm token"),
+    (
+        re.compile(
+            r"(?i)\b(?:api[_-]?key|auth[_-]?token|access[_-]?token|"
+            r"client[_-]?secret|token|secret|password|passwd|credential)"
+            r"[\"']?\s*[:=]\s*[\"'][^\"']{20,}[\"']"
+        ),
+        "generic credential literal",
+    ),
+]
+
+TEXT_SUFFIXES = {
+    ".py", ".js", ".mjs", ".ts", ".json", ".md", ".sh", ".bash", ".txt",
+    ".yaml", ".yml", ".toml", ".ini", ".cfg", ".conf", ".env", ".example",
+}
+
+
+def fail(message: str) -> None:
+    print(f"secret-scrub: FAIL {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def is_text(path: Path) -> bool:
+    if path.suffix.lower() in TEXT_SUFFIXES:
+        return True
+    try:
+        chunk = path.read_bytes()[:2048]
+        return b"\x00" not in chunk
+    except OSError:
+        return False
+
+
+def tracked_files(repo_root: Path) -> list[Path]:
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(repo_root), "ls-files"],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        return [repo_root / line for line in out.splitlines() if line.strip()]
+    except (subprocess.CalledProcessError, OSError):
+        return []
+
+
+def gitignored(root: Path, target: Path) -> bool:
+    try:
+        rel = target.resolve().relative_to(root.resolve())
+    except ValueError:
+        return True  # outside the repo cannot be tracked; safe by construction
+    out = subprocess.run(
+        ["git", "-C", str(root), "check-ignore", "-q", str(rel)],
+        capture_output=True,
+    )
+    return out.returncode == 0
+
+
+def scan(paths: list[Path], repo_root: Path) -> None:
+    if not paths:
+        paths = tracked_files(repo_root)
+    findings: list[tuple[str, str]] = []
+    checked = 0
+    for path in paths:
+        if not path.is_file() or not is_text(path):
+            continue
+        checked += 1
+        try:
+            text = path.read_text(errors="replace")
+        except OSError:
+            continue
+        for pattern, label in PATTERNS:
+            if pattern.search(text):
+                findings.append((str(path), label))
+    if findings:
+        for path, label in findings:
+            print(f"secret-scrub: FAIL {path}: {label}", file=sys.stderr)
+        raise SystemExit(1)
+    print(f"secret-scrub: OK ({checked} text files scanned, 0 findings)")
+
+
+def check_config(config_path: Path, repo_root: Path) -> None:
+    import json
+
+    if not config_path.is_file():
+        fail(f"missing config file: {config_path}")
+    try:
+        config = json.loads(config_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        fail(f"cannot parse {config_path}: {exc}")
+
+    adapters = config.get("adapters")
+    if not isinstance(adapters, dict) or not adapters:
+        fail("config has no adapters map")
+
+    for name, entry in sorted(adapters.items()):
+        if not isinstance(entry, dict):
+            fail(f"adapters.{name} must be an object")
+        # No key material anywhere in the config itself.
+        raw = json.dumps(entry)
+        for pattern, label in PATTERNS:
+            if pattern.search(raw):
+                fail(f"adapters.{name} contains inline {label}")
+        key_ref = entry.get("apiKeyRef")
+        if not isinstance(key_ref, str) or not key_ref.strip():
+            fail(f"adapters.{name}.apiKeyRef is missing")
+        # apiKeyRef must be a path reference, not a literal secret.
+        stripped = key_ref.strip()
+        if not (
+            "/" in stripped or stripped.startswith("~") or stripped.endswith(".key")
+        ):
+            fail(f"adapters.{name}.apiKeyRef ('{stripped}') does not look like a path")
+        key_path = Path(stripped).expanduser()
+        if not key_path.is_absolute():
+            key_path = (config_path.parent / key_path).resolve()
+        if not key_path.is_file():
+            fail(f"adapters.{name}: key file missing: {key_path}")
+        mode = stat.S_IMODE(key_path.stat().st_mode)
+        if mode & 0o077:
+            fail(
+                f"adapters.{name}: key {key_path} is group/other readable "
+                f"(mode {oct(mode)}; run chmod 600)"
+            )
+        if not gitignored(repo_root, key_path):
+            fail(
+                f"adapters.{name}: key {key_path} is inside the repo tree and NOT "
+                f"gitignored — it could be committed"
+            )
+        print(f"secret-scrub: adapters.{name} OK (key={key_path}, mode={oct(mode)})")
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--scan", nargs="*", default=None, metavar="PATH")
+    group.add_argument("--check-config", metavar="FILE")
+    args = parser.parse_args()
+    if args.scan is not None:
+        paths = [Path(p) for p in (args.scan or [])]
+        scan(paths, repo_root)
+    else:
+        check_config(Path(args.check_config).expanduser(), repo_root)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/acp-endpoint-registry/test-stub-adapter.py
+++ b/examples/acp-endpoint-registry/test-stub-adapter.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Stub adapter used by test.py: dumps env and args as parseable lines.
+
+Prints one STUB-ENV <name>=<value> line per environment variable and one
+STUB-ARGS <argv> line, so tests can assert exactly what the launcher handed
+to the adapter process without any real adapter or network access.
+"""
+
+import os
+import sys
+
+for name, value in sorted(os.environ.items()):
+    print(f"STUB-ENV {name}={value}")
+print(f"STUB-ARGS {' '.join(sys.argv[1:])}")

--- a/examples/acp-endpoint-registry/test.py
+++ b/examples/acp-endpoint-registry/test.py
@@ -205,6 +205,44 @@ def test_scrub_clean_examples() -> None:
         check(f"{name} scans clean", r.returncode == 0)
 
 
+def test_launcher_resolves_bare_executables() -> None:
+    """execve() performs no PATH lookup; a bare EXECUTABLE name must resolve.
+
+    The default EXECUTABLE is "node"; without resolution the launcher crashed
+    at os.execve (FileNotFoundError) with a valid adapter and registry — the
+    test suite missed it because every prior test set ACP_ADAPTER_EXECUTABLE
+    to an absolute path.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        make_key(root, "keys/claude.key", "test-key-material-not-a-real-secret-0007")
+        config = write_registry(root, {
+            "claude": {
+                "endpoint": "http://endpoint.local:8080",
+                "apiKeyRef": "keys/claude.key",
+                "model": "default-model",
+            }
+        })
+        # A "node" shim that exits 42: proves execve received an absolute path
+        # (a bare "node" would raise FileNotFoundError and exit with a traceback).
+        bindir = root / "bin"
+        bindir.mkdir()
+        shim = bindir / "node"
+        shim.write_text("#!/bin/sh\nexit 42\n", encoding="utf-8")
+        shim.chmod(0o755)
+        env = dict(os.environ)
+        env["ACP_REGISTRY_FILE"] = str(config)
+        env["ACP_ADAPTER_PATH"] = str(STUB)
+        env.pop("ACP_ADAPTER_EXECUTABLE", None)
+        env["PATH"] = str(bindir)
+        r = subprocess.run(
+            [sys.executable, str(LAUNCHER), "claude"],
+            capture_output=True, text=True, env=env,
+        )
+        check("bare executable name resolves via PATH (no execve crash)",
+              r.returncode == 42 and "Traceback" not in r.stderr)
+
+
 def test_scrub_scan_recurses_directories() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
@@ -336,6 +374,7 @@ if __name__ == "__main__":
     test_launcher_strips_wrapper_flags()
     test_launcher_config_errors()
     test_launcher_missing_adapter_fails_closed()
+    test_launcher_resolves_bare_executables()
     test_readme_wiring_matches_acpx_agent_shape()
     test_scrub_scan()
     test_scrub_scan_recurses_directories()

--- a/examples/acp-endpoint-registry/test.py
+++ b/examples/acp-endpoint-registry/test.py
@@ -16,6 +16,7 @@ Covers:
 
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -25,6 +26,7 @@ HERE = Path(__file__).resolve().parent
 LAUNCHER = HERE / "launcher.py"
 SCRUB = HERE / "secret-scrub.py"
 STUB = HERE / "test-stub-adapter.py"
+README = HERE / "README.md"
 
 PASS, FAIL = 0, 0
 
@@ -203,6 +205,78 @@ def test_scrub_clean_examples() -> None:
         check(f"{name} scans clean", r.returncode == 0)
 
 
+def test_scrub_scan_recurses_directories() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nested = root / "pkg" / "deep"
+        nested.mkdir(parents=True)
+        r = subprocess.run(
+            [sys.executable, str(SCRUB), "--scan", str(root / "no-such-dir")],
+            capture_output=True, text=True,
+        )
+        check("nonexistent scan path fails loudly", r.returncode != 0)
+        check("nonexistent path message says nothing was scanned",
+              "nothing was scanned" in r.stderr)
+
+        (nested / "secret.txt").write_text('api_key = "' + "A" * 40 + '"\n')
+        r = subprocess.run(
+            [sys.executable, str(SCRUB), "--scan", str(root)],
+            capture_output=True, text=True,
+        )
+        check("scan walks directories recursively", r.returncode != 0)
+        check("recursive scan names the nested file", "secret.txt" in r.stderr)
+
+        (nested / "secret.txt").write_text("just notes, nothing secret here\n")
+        r = subprocess.run(
+            [sys.executable, str(SCRUB), "--scan", str(root)],
+            capture_output=True, text=True,
+        )
+        check("recursive scan passes a clean directory", r.returncode == 0)
+        check("recursive scan counts the files it checked", "1 text files scanned" in r.stdout)
+
+
+def test_launcher_missing_adapter_fails_closed() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        make_key(root, "keys/claude.key", "test-key-material-not-a-real-secret-0006")
+        config = write_registry(root, {
+            "claude": {
+                "endpoint": "http://endpoint.local:8080",
+                "apiKeyRef": "keys/claude.key",
+                "model": "default-model",
+            }
+        })
+        env = dict(os.environ)
+        env["ACP_REGISTRY_FILE"] = str(config)
+        env["ACP_ADAPTER_PATH"] = str(root / "definitely-missing-adapter.js")
+        proc = subprocess.run(
+            [sys.executable, str(LAUNCHER), "claude"],
+            capture_output=True, text=True, env=env,
+        )
+        check("missing adapter exits non-zero before exec", proc.returncode != 0)
+        check("missing adapter names the gap", "missing adapter" in proc.stderr)
+        check("missing adapter keeps the key out of stderr", "0006" not in proc.stderr)
+
+
+def test_readme_wiring_matches_acpx_agent_shape() -> None:
+    text = README.read_text()
+    wiring = None
+    for match in re.finditer(r"```json\n(\{.*?\n\})\n```", text, re.S):
+        block = json.loads(match.group(1))
+        entry = (
+            block.get("plugins", {}).get("entries", {}).get("acpx")
+        )
+        if isinstance(entry, dict) and "agents" in (entry.get("config") or {}):
+            wiring = entry["config"]["agents"]["claude"]
+            break
+    check("README contains the acpx wiring block", wiring is not None)
+    if wiring is None:
+        return
+    check("README wiring uses a single command string",
+          isinstance(wiring.get("command"), str) and wiring["command"].strip() != "")
+    check("README wiring has no separate args field", "args" not in wiring)
+
+
 def test_scrub_check_config() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
@@ -261,7 +335,10 @@ if __name__ == "__main__":
     test_launcher_happy_path()
     test_launcher_strips_wrapper_flags()
     test_launcher_config_errors()
+    test_launcher_missing_adapter_fails_closed()
+    test_readme_wiring_matches_acpx_agent_shape()
     test_scrub_scan()
+    test_scrub_scan_recurses_directories()
     test_scrub_clean_examples()
     test_scrub_check_config()
     print(f"\n{PASS} passed, {FAIL} failed")

--- a/examples/acp-endpoint-registry/test.py
+++ b/examples/acp-endpoint-registry/test.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Tests for the acp-endpoint-registry example (launcher + secret-scrub).
+
+Run:  python3 examples/acp-endpoint-registry/test.py
+
+Covers:
+  - launcher happy path: key-by-reference, env merge, role-slot mapping,
+    argument forwarding
+  - wrapper-flag stripping (lease-id/value flags and --hide-claude-auth)
+  - config validation: unknown adapter, missing model, missing/empty key
+  - key permissions: loose mode warns but does not block
+  - secret scanner --scan: per-prefix detection + clean-file pass
+  - secret scanner --check-config: good config, inline secret, non-path
+    apiKeyRef, and key-file permission enforcement
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+LAUNCHER = HERE / "launcher.py"
+SCRUB = HERE / "secret-scrub.py"
+STUB = HERE / "test-stub-adapter.py"
+
+PASS, FAIL = 0, 0
+
+
+def check(label: str, condition: bool) -> None:
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print(f"ok - {label}")
+    else:
+        FAIL += 1
+        print(f"NOT OK - {label}")
+
+
+def write_registry(root: Path, adapters: dict) -> Path:
+    config = root / "endpoints.json"
+    config.write_text(json.dumps({"adapters": adapters}, indent=2))
+    return config
+
+
+def run_launcher(config: Path, argv: list[str]) -> dict:
+    """Run launcher.py against the stub adapter; parse its env dump."""
+    env = dict(os.environ)
+    env["ACP_REGISTRY_FILE"] = str(config)
+    env["ACP_ADAPTER_EXECUTABLE"] = sys.executable
+    env["ACP_ADAPTER_PATH"] = str(STUB)
+    proc = subprocess.run(
+        [sys.executable, str(LAUNCHER), *argv],
+        capture_output=True, text=True, env=env,
+    )
+    stub_env: dict[str, str] = {}
+    for line in proc.stdout.splitlines():
+        if line.startswith("STUB-ENV "):
+            key, _, value = line[len("STUB-ENV "):].partition("=")
+            stub_env[key] = value
+    return {
+        "returncode": proc.returncode,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+        "env": stub_env,
+    }
+
+
+def make_key(root: Path, name: str, material: str, mode: int = 0o600) -> Path:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(material)
+    os.chmod(path, mode)
+    return path
+
+
+# ---------------------------------------------------------------- happy path
+def test_launcher_happy_path() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        make_key(root, "keys/claude.key", "test-key-material-not-a-real-secret-0001")
+        config = write_registry(root, {
+            "claude": {
+                "endpoint": "http://endpoint.local:8080",
+                "apiKeyRef": "keys/claude.key",
+                "model": "default-model",
+                "slots": {"haiku": "fast-model", "opus": "heavy-model"},
+                "env": {"EXAMPLE_REGISTRY_POLICY": "on"},
+            }
+        })
+        result = run_launcher(config, ["claude", "task", "--verbose"])
+        check("launcher exits 0 on happy path", result["returncode"] == 0)
+        env = result["env"]
+        check("key resolved from file",
+              env.get("ANTHROPIC_API_KEY") == "test-key-material-not-a-real-secret-0001")
+        check("endpoint applied", env.get("ANTHROPIC_BASE_URL") == "http://endpoint.local:8080")
+        check("model applied", env.get("ANTHROPIC_MODEL") == "default-model")
+        check("role slot mapped",
+              env.get("ANTHROPIC_DEFAULT_HAIKU_MODEL") == "fast-model")
+        check("env policy merged", env.get("EXAMPLE_REGISTRY_POLICY") == "on")
+        check("args forwarded",
+              "task" in result["stdout"] and "--verbose" in result["stdout"])
+
+
+def test_launcher_strips_wrapper_flags() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        make_key(root, "keys/claude.key", "test-key-material-not-a-real-secret-0002")
+        config = write_registry(root, {
+            "claude": {
+                "endpoint": "http://endpoint.local:8080",
+                "apiKeyRef": "keys/claude.key",
+                "model": "m",
+            }
+        })
+        result = run_launcher(config, [
+            "claude",
+            "--hide-claude-auth",
+            "--openclaw-acpx-lease-id", "lease-123",
+            "--openclaw-gateway-instance-id", "inst-456",
+            "do-work",
+        ])
+        check("wrapper flags stripped, work arg kept", "do-work" in result["stdout"])
+        check("flag values stripped too",
+              "lease-123" not in result["stdout"] and "inst-456" not in result["stdout"])
+        check("--hide-claude-auth not forwarded",
+              "--hide-claude-auth" not in result["stdout"])
+
+
+# ------------------------------------------------------------ config errors
+def test_launcher_config_errors() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        make_key(root, "k.key", "test-key-material-not-a-real-secret-0003")
+
+        missing_adapter = write_registry(root, {"other": {
+            "endpoint": "http://e", "apiKeyRef": "k.key", "model": "m"}})
+        r = run_launcher(missing_adapter, ["claude"])
+        check("unknown adapter fails",
+              r["returncode"] != 0 and "unknown adapter" in r["stderr"])
+
+        no_model = write_registry(root, {"claude": {
+            "endpoint": "http://e", "apiKeyRef": "k.key"}})
+        r = run_launcher(no_model, ["claude"])
+        check("missing model fails", r["returncode"] != 0)
+
+        bad_key = write_registry(root, {"claude": {
+            "endpoint": "http://e", "apiKeyRef": "missing.key", "model": "m"}})
+        r = run_launcher(bad_key, ["claude"])
+        check("missing key file fails", r["returncode"] != 0)
+
+        make_key(root, "empty.key", "   \n")
+        empty_entry = write_registry(root, {"claude": {
+            "endpoint": "http://e", "apiKeyRef": "empty.key", "model": "m"}})
+        r = run_launcher(empty_entry, ["claude"])
+        check("empty key file fails", r["returncode"] != 0)
+
+        make_key(root, "loose.key", "test-key-material-not-a-real-secret-0004", mode=0o644)
+        loose_entry = write_registry(root, {"claude": {
+            "endpoint": "http://e", "apiKeyRef": "loose.key", "model": "m"}})
+        r = run_launcher(loose_entry, ["claude"])
+        check("loose key warns but still execs",
+              r["returncode"] == 0 and "group/other readable" in r["stderr"])
+
+
+# ------------------------------------------------------------- secret scrub
+def test_scrub_scan() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        for prefix in ("sk-", "ah-", "ghp_", "xoxb-", "hf_", "npm_", "gsk_", "pplx-"):
+            leak = Path(tmp) / f"leak-{prefix.strip('-_')}.txt"
+            leak.write_text("token " + prefix + "A" * 40)
+            r = subprocess.run(
+                [sys.executable, str(SCRUB), "--scan", str(leak)],
+                capture_output=True, text=True,
+            )
+            check(f"scan detects {prefix}literal", r.returncode != 0)
+
+        assignment = Path(tmp) / "leak-assign.txt"
+        assignment.write_text('api_key = "' + "x" * 40 + '"\n')
+        r = subprocess.run(
+            [sys.executable, str(SCRUB), "--scan", str(assignment)],
+            capture_output=True, text=True,
+        )
+        check("scan detects generic credential assignment", r.returncode != 0)
+
+        clean = Path(tmp) / "clean.txt"
+        clean.write_text("api_key_file = keys/claude.key\n")
+        r = subprocess.run(
+            [sys.executable, str(SCRUB), "--scan", str(clean)],
+            capture_output=True, text=True,
+        )
+        check("scan passes key reference", r.returncode == 0)
+
+
+def test_scrub_clean_examples() -> None:
+    for name in ("README.md", "endpoints.example.json", "launcher.py", "secret-scrub.py"):
+        r = subprocess.run(
+            [sys.executable, str(SCRUB), "--scan", str(HERE / name)],
+            capture_output=True, text=True,
+        )
+        check(f"{name} scans clean", r.returncode == 0)
+
+
+def test_scrub_check_config() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        make_key(root, "keys/claude.key", "test-key-material-not-a-real-secret-0005")
+
+        good = write_registry(root, {
+            "claude": {
+                "endpoint": "http://endpoint.local:8080",
+                "apiKeyRef": "keys/claude.key",
+                "model": "default-model",
+            }
+        })
+        r = subprocess.run(
+            [sys.executable, str(SCRUB), "--check-config", str(good)],
+            capture_output=True, text=True, cwd=str(root),
+        )
+        check("check-config accepts good registry", r.returncode == 0)
+
+        inline = write_registry(root, {
+            "claude": {
+                "endpoint": "http://endpoint.local:8080",
+                "apiKeyRef": "keys/claude.key",
+                "model": "m",
+                "apiKey": "***" + "B" * 40,
+            }
+        })
+        r = subprocess.run(
+            [sys.executable, str(SCRUB), "--check-config", str(inline)],
+            capture_output=True, text=True, cwd=str(root),
+        )
+        check("check-config rejects inline key", r.returncode != 0)
+
+        literal = write_registry(root, {
+            "claude": {
+                "endpoint": "http://e",
+                "apiKeyRef": "literal-secret-value-not-a-path",
+                "model": "m",
+            }
+        })
+        r = subprocess.run(
+            [sys.executable, str(SCRUB), "--check-config", str(literal)],
+            capture_output=True, text=True, cwd=str(root),
+        )
+        check("check-config rejects non-path apiKeyRef", r.returncode != 0)
+
+        os.chmod(root / "keys/claude.key", 0o644)
+        r = subprocess.run(
+            [sys.executable, str(SCRUB), "--check-config", str(good)],
+            capture_output=True, text=True, cwd=str(root),
+        )
+        check("check-config rejects loose key file", r.returncode != 0)
+        os.chmod(root / "keys/claude.key", 0o600)
+
+
+if __name__ == "__main__":
+    test_launcher_happy_path()
+    test_launcher_strips_wrapper_flags()
+    test_launcher_config_errors()
+    test_scrub_scan()
+    test_scrub_clean_examples()
+    test_scrub_check_config()
+    print(f"\n{PASS} passed, {FAIL} failed")
+    sys.exit(1 if FAIL else 0)


### PR DESCRIPTION
# Real behavior proof — authority chain (redacted)

Per Codex review (16:09 UTC) and the ClawSweeper gate: this run replaces the stub-only evidence with a real ACPX custom-command launch through the documented quick-start path. All fixes from the three P1s are included in fc8502f9eac (directory-scan recursion + nonexistent-path fail-closed, adapter provisioning at the documented default, single-string `command` wiring) and e1c8a94cd9c (bare-EXECUTABLE PATH resolution before execve). Example test suite: **46/46 green** (`python3 examples/acp-endpoint-registry/test.py`).

## Environment

- Production OpenClaw gateway (systemd user service, live config) routed its acpx `claude` agent through **this example's launcher** via the exact README single-string wiring:

```json
"agents": { "claude": { "command": "python3 /home/user001/.openclaw/acp/launcher.py claude" } }
```

- Registry at `~/.openclaw/acp/endpoints.json` (structure identical to `endpoints.example.json`), key file `~/.openclaw/acp/keys/claude.key` mode `0600`.
- Adapter installed with the README quick-start command: `npm install --prefix ~/.openclaw/acp @agentclientprotocol/claude-agent-acp` → `~/.openclaw/acp/node_modules/@agentclientprotocol/claude-agent-acp/dist/index.js` (the launcher's new default — no `ACP_ADAPTER_PATH` override used).
- `openclaw config validate` passed before and after; the swap was hot-reloaded by the gateway (journal: `config hot reload applied (plugins.entries.acpx.config.agents.claude.command)`), and production config was restored to its original launcher after the run.

## Real dispatch

An isolated ACP session was dispatched through the gateway (real ACP task, not the test-stub). The turn completed successfully with the exact expected reply.

## Observed process evidence (redacted; captured by an independent watcher)

Two real adapter invocations were observed during the dispatch window:

```
[19:27:42] ADAPTER pid 26787  /usr/bin/node /home/user001/.openclaw/acp/node_modules/@agentclientprotocol/claude-agent-acp/dist/index.js
  parent pid: 4494 (gateway node process — the launcher's os.execve replaced the launcher image in the same PID chain)
  gateway env ANTHROPIC_API_KEY count: **0**
  adapter env ANTHROPIC_API_KEY count: **1**
  adapter env ANTHROPIC_BASE_URL: http://100.96.49.42:4001  (injected from the registry, not ambient)
  adapter env key fingerprint (sha256, first 10): 13f0849f16…
  key-file fingerprint          (sha256, first 10): 13f0849f16…
  ⇒ FINGERPRINT MATCH: the launcher granted the persistent credential from the 0600 key file to the adapter process only
```

(Second adapter process 26848 at 19:27:44 — same capture, same boundary.)

Ancestry (bottom-up): `gateway node 4494 (openclaw dist/index.js gateway --port 18789) → systemd --user → systemd` — the adapter is a direct exec child chain of the gateway; no unrelated process on the box carried the key (gateway env count 0).

## Credential boundary summary

| Surface | ANTHROPIC_API_KEY present | Source |
| --- | --- | --- |
| Gateway process env | 0 | n/a (key never in gateway env) |
| Example launcher | reads key file in-process, **never written to its own env, never printed (fail paths included)** | `~/.openclaw/acp/keys/claude.key` (0600) |
| Real adapter process | 1 — exact value match to key file (fingerprint 13f0849f16…) | injected at exec by the launcher |

`secret-scrub.py --check-config` validated the live registry before dispatch (key file exists, mode 0600, path-ref only, no inline material).

## P1 resolution recap

- **P1 scan directories**: `--scan examples/` from the repo root now reports `OK (6 text files scanned, 0 findings)`; nested files are found (regression test); typo'd/nonexistent paths fail loudly (`FAIL no such path (nothing was scanned)`) instead of green-0.
- **P1 adapter path**: default `~/.openclaw/acp/node_modules/@agentclientprotocol/claude-agent-acp/dist/index.js`; missing-adapter fails closed with install guidance (regression test; key never reaches stderr).
- **P1 acpx wiring**: README documents the supported single command string; `args` removed (regression test parses the README wiring block and asserts shape).
- Bonus fix: bare `EXECUTABLE` names are PATH-resolved before `execve` (pre-fix crash without an absolute `ACP_ADAPTER_EXECUTABLE`; found and fixed during this real-dispatch work).

No key material appears in this PR, its tests, or its evidence output (values are fingerprinted, not printed).
Related: #133686

## What Problem This Solves

Fixes the missing worked example for pointing acpx ACP harnesses at self-hosted, Anthropic-compatible endpoints without handing every process in the shell an API key.

Today the acpx config surface supports custom agent commands (`agents.<id>.command` / `args`), and the natural setup most self-hosting operators reach for — exporting `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` in a shell profile — has recurring failure modes:

1. Every process in the session inherits the key, not just the adapter.
2. Environment dumps in terminal captures, issue reports, and support tooling leak the key alongside them.
3. Endpoint and model config drifts across rc files with no single file describing the endpoint, default model, and per-role-slot models.

## Why This Change Was Made

Adds `examples/acp-endpoint-registry`, a self-contained example with no dependency on OpenClaw internals, so it works with today's acpx config as-is:

- `endpoints.example.json` — declarative registry template: `endpoint`, key **file reference** (`apiKeyRef`), default `model`, per-role `slots`, extra adapter `env`. Keys are stored in exactly one place: a `0600` file.
- `launcher.py` — registry-driven, harness-agnostic. Resolves the key from the referenced file at startup, strips OpenClaw wrapper-only flags before forwarding, and `execve`s the adapter with the merged environment — so only the adapter process receives the key, never argv, never the ambient shell.
- `secret-scrub.py` — fail-closed hygiene gate in two modes: `--scan` (detects key-shaped literals across tracked files for pre-commit/CI use) and `--check-config` (validates a live registry: no inline key material, `apiKeyRef` must be a path, key file must exist at mode `0600`, in-repo key files must be gitignored).
- `test.py` + `test-stub-adapter.py` — pure-stdlib suite asserting the exact environment the launcher hands to the adapter: key resolution, endpoint/model injection, role-slot mapping, env merging, wrapper-flag stripping, config-error paths, key-permission warnings, and per-pattern scrubber detection.

Boundary: this is example code, not product surface — no core or plugin changes, and it makes no claim of being a supported feature. The acpx docs stay authoritative for config.

## User Impact

Operators routing ACP harnesses to self-hosted endpoints get a copy-paste-deployable pattern: the key lives in one `0600` file, endpoint and model routing is declared in one JSON file, and a `--check-config` invocation mechanically verifies the secret hygiene before anything runs. Users who don't self-host endpoints are unaffected; nothing in the product changes for them.

## Evidence

- Full local test run: `python3 examples/acp-endpoint-registry/test.py` → **33 passed, 0 failed** on Python 3.14 (pure stdlib, no network — the suite stubs the adapter process and asserts its environment)
- Scrubber behavior, observed in the same suite: per-prefix detection (`sk-`, `ah-`, `ghp_`, `xoxb-`, `hf_`, `npm_`, `gsk_`, `pplx-`, generic credential assignment) correctly fails; key-file references (`api_key_file = keys/claude.key`) correctly pass
- Launcher behavior, observed: stub adapter received `ANTHROPIC_API_KEY` resolved from the key file, `ANTHROPIC_BASE_URL`, `ANTHROPIC_MODEL`, role-slot `ANTHROPIC_DEFAULT_*_MODEL` vars, and registry `env` entries; wrapper flags (`--hide-claude-auth`, `--openclaw-acpx-lease-id <v>`, `--openclaw-gateway-instance-id <v>`) stripped from forwarded args
- Failure paths, observed: unknown adapter id, missing model, missing key file, empty key file, and `--check-config` rejections (inline key, non-path `apiKeyRef`, loose `0644` key file) all exit non-zero
- README formatted with the repo's `oxfmt` (pre-commit-formatted and verified with `oxfmt --check` against the committed tree)

## Scope vs core SecretRefs (openclaw/openclaw#128380)

Adjacent PR #128380 (maintainer) brings native SecretRef support to **MCP server environment values** — structured `env`/`file`/`exec`/`store` references resolved gateway-side, with only materialized strings crossing the ACP boundary. That covers one leg of the credential problem. This example covers the other: the **custom agent command path** (`agents.<id>.command`), where OpenClaw spawns an external ACP adapter process and core does not (yet) inject credentials into that spawn. The launcher keeps adapter credentials in a `0600` file and hands them only to the adapter process. The two are complementary, not competing — if native SecretRefs later reach the adapter-launch path, this example is cheap to retire. The README now carries this scoping note (51a2c0bb447).

## AI-assisted disclosure

🤖 This PR was built with AI assistance (OpenClaw agent) under the account owner's direction. The contents were reviewed, tested end-to-end on the contributing machine, and the author can walk through every line.


