### PR TITLE
fix: dependency audits miss published upstream advisories

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -503,6 +503,7 @@ jobs:
       - name: Generate dependency release evidence
         id: dependency_evidence
         env:
+          GH_TOKEN: ${{ github.token }}
           RELEASE_REF: ${{ inputs.tag }}
           RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
         run: |
@@ -804,6 +805,7 @@ jobs:
           node --import tsx scripts/openclaw-npm-prepublish-verify.ts "${verify_args[@]}"
 
       - name: Upload dependency release evidence
+        if: ${{ always() && steps.dependency_evidence.outputs.dir != '' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: openclaw-release-dependency-evidence-${{ inputs.tag }}

--- a/docs/gateway/security/dependency-locking.md
+++ b/docs/gateway/security/dependency-locking.md
@@ -15,9 +15,23 @@ The trusted ClawHub and Vercel release toolchains are separate exceptions: `.git
 
 These projects do not inherit root pnpm overrides. The Vercel project uses approved, version-scoped npm overrides for vulnerable upstream pins; remove each override when its owning dependency accepts a fixed version. Lock audits cover resolved package identities, not code already bundled into upstream CLI artifacts.
 
-`pnpm deps:vuln:gate` audits the product pnpm lock and both release-tool locks independently against npm advisory data. Within each lockfile, known malware and critical advisories block anywhere, and high advisories block in the production/runtime graph. Dev-only high advisories and moderate or lower non-malware advisories are reported without blocking. Reports retain the source lockfile, so a release-tool finding does not imply product runtime exposure. Missing or invalid expected locks fail the gate.
+## Check dependency advisories
 
-Release dependency evidence runs this gate. Ordinary CI's `security-fast` job and the production audit pre-commit hook still audit only the product production graph.
+The production audit pre-commit hook and ordinary CI's `security-fast` job remain zero-install, npm-only checks of the product production graph. They query npm bulk advisory data, not upstream repository advisories. A passing result is limited to that source and graph; it does not establish that dependencies are unaffected by all known vulnerabilities.
+
+`pnpm deps:vuln:gate`, used by release dependency evidence, audits the product pnpm lock and both release-tool locks independently. It checks npm advisory data and adds published security advisories from verified public GitHub repositories. Repository mappings come from the manifests for exact locked npm package versions, not a package's latest manifest. The gate verifies that each repository is public before requesting advisories with the explicit `state=published` filter. It does not scan private repositories or unpublished advisories.
+
+Within each lockfile, known malware and critical advisories block anywhere, and high advisories block in the production/runtime graph. Dev-only high advisories and moderate or lower non-malware advisories are reported without blocking. GitHub's `medium` severity maps to `moderate` in this policy. Upstream findings match the npm package identity and affected-version range against exact locked versions; only matches absent from the npm result for the corresponding lockfile and graph are added. Reports retain the source lockfile, so a release-tool finding does not imply product runtime exposure. Missing or invalid expected locks fail the gate.
+
+Release automation reuses its existing standard `GH_TOKEN` only for GitHub API requests, never for npm registry requests. Local runs without that token use anonymous GitHub requests and their rate limits. No new OpenClaw configuration or operator credential setup is required.
+
+### Interpret coverage
+
+Release artifacts and the GitHub Actions step summary show npm coverage as `checked`, upstream coverage as `checked` or `partial`, mapped package-version counts, checked repository counts, coverage issues, and upstream-only findings. Findings identify their source as `npm-bulk` or `github-repository`; upstream findings also record matched locked versions. Even `checked` coverage is limited to these advisory sources, not comprehensive vulnerability clearance.
+
+The upstream scan has fixed bounds: 2,500 exact package versions, 4,000 HTTP requests, and five minutes per run. It uses four concurrent requests, up to five pages of 100 advisories per repository, and at most 10,000 advisories per run. Each response is limited to 2 MiB and each request to 15 seconds. It does not retry or reuse stale cached results.
+
+Missing or unsupported repository metadata, malformed affected-version ranges, exhausted request or pagination budgets, and request or rate-limit failures produce `partial` upstream coverage, not an unaffected result. Confirmed findings remain in the report and enter the same severity policy. Inspect the coverage issue subjects and reasons before interpreting a zero-finding result.
 
 ## Published package behavior
 

--- a/scripts/dependency-vulnerability-gate.mts
+++ b/scripts/dependency-vulnerability-gate.mts
@@ -1,16 +1,21 @@
 #!/usr/bin/env node
 
-// Checks resolved dependencies against npm advisory data and gate policy.
+// Checks resolved dependencies against npm and public upstream advisories.
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { isRecord } from "../packages/normalization-core/src/record-coerce.ts";
 import { parseReportCliArgs, writeReportArtifact } from "./lib/report-cli-helpers.mts";
 import {
+  fetchPublishedRepositoryAdvisories,
+  type PublishedRepositoryAdvisory,
+} from "./lib/upstream-repository-advisories.mts";
+import {
   collectAllResolvedPackagesFromLockfile,
   collectProdResolvedPackagesFromLockfile,
   createBulkAdvisoryPayload,
   fetchBulkAdvisories,
+  resolveRegistryBaseUrl,
 } from "./pre-commit/pnpm-audit-prod.mjs";
 
 const SEVERITY_RANK = {
@@ -23,7 +28,7 @@ const SEVERITY_RANK = {
 
 type Advisory = Partial<
   Record<"overview" | "severity" | "title" | "url" | "vulnerable_versions", string>
-> & { id?: string | number };
+> & { id?: string | number; source?: "npm-bulk" | "github-repository"; matchedVersions?: string[] };
 type Graph = "all" | "production";
 type AdvisoryMap = Record<string, Advisory[]>;
 type AdvisoryPayload = Record<string, string[]>;
@@ -65,6 +70,8 @@ function findingFromAdvisory(
     url: advisory.url ?? null,
     vulnerableVersions: advisory.vulnerable_versions ?? null,
     malware: isMalwareAdvisory(advisory),
+    source: advisory.source ?? "npm-bulk",
+    ...(advisory.matchedVersions ? { matchedVersions: advisory.matchedVersions } : {}),
   };
 }
 
@@ -84,6 +91,37 @@ async function fetchBulkAdvisoriesForPayload(payload: AdvisoryPayload, fetchImpl
     );
   }
   return advisoryResults;
+}
+
+function includeRepositoryAdvisories(
+  npmAdvisories: AdvisoryMap,
+  payload: AdvisoryPayload,
+  upstream: PublishedRepositoryAdvisory[],
+) {
+  const combined = new Map(Object.entries(npmAdvisories));
+  for (const { packageName, ...advisory } of upstream) {
+    const matchedVersions = advisory.matchedVersions.filter((version) =>
+      payload[packageName]?.includes(version),
+    );
+    if (matchedVersions.length === 0) {
+      continue;
+    }
+    const existing = combined.get(packageName) ?? [];
+    // npm uses numeric IDs; the GHSA URL is the cross-source identity. Compare within
+    // this exact lock/graph so dev-only or release-tool evidence cannot clear runtime.
+    if (
+      existing.some(
+        (entry) => String(entry.id) === advisory.id || entry.url?.endsWith(`/${advisory.id}`),
+      )
+    ) {
+      continue;
+    }
+    combined.set(packageName, [
+      ...existing,
+      { ...advisory, matchedVersions, source: "github-repository" },
+    ]);
+  }
+  return Object.fromEntries(combined);
 }
 
 function flattenAdvisories(advisoriesByPackage: AdvisoryMap, graphName: Graph, lockfile: string) {
@@ -148,7 +186,7 @@ function sortFindings(findings: Finding[]) {
 }
 
 /**
- * Classifies npm advisory findings into report-only findings and hard blockers.
+ * Classifies source-attributed advisory findings into report-only findings and hard blockers.
  */
 function classifyVulnerabilityFindings({
   lockfile,
@@ -256,16 +294,40 @@ export async function runDependencyVulnerabilityGate({
     }),
   );
   // Query each source independently: a vulnerable tool version must not taint a safe product version.
-  const sources = await Promise.all(
+  const npmSources = await Promise.all(
     lockfiles.map(async ({ lockfile, allPayload, productionPayload }) => {
       const [allAdvisories, productionAdvisories] = await Promise.all([
         fetchBulkAdvisoriesForPayload(allPayload, fetchImpl),
         fetchBulkAdvisoriesForPayload(productionPayload, fetchImpl),
       ]);
+      return { lockfile, allPayload, productionPayload, allAdvisories, productionAdvisories };
+    }),
+  );
+  const upstreamPackages = new Map<string, Set<string>>();
+  for (const { allPayload } of lockfiles) {
+    for (const [packageName, versions] of Object.entries(allPayload)) {
+      const merged = upstreamPackages.get(packageName) ?? new Set<string>();
+      for (const version of versions) {
+        merged.add(version);
+      }
+      upstreamPackages.set(packageName, merged);
+    }
+  }
+  const upstream = await fetchPublishedRepositoryAdvisories({
+    payload: createBulkAdvisoryPayload(upstreamPackages),
+    registryBaseUrl: resolveRegistryBaseUrl(),
+    fetchImpl,
+  });
+  const sources = npmSources.map(
+    ({ lockfile, allPayload, productionPayload, allAdvisories, productionAdvisories }) => {
       const classified = classifyVulnerabilityFindings({
         lockfile,
-        allAdvisories,
-        productionAdvisories,
+        allAdvisories: includeRepositoryAdvisories(allAdvisories, allPayload, upstream.advisories),
+        productionAdvisories: includeRepositoryAdvisories(
+          productionAdvisories,
+          productionPayload,
+          upstream.advisories,
+        ),
       });
       return {
         graphs: {
@@ -282,10 +344,11 @@ export async function runDependencyVulnerabilityGate({
         blockers: classified.blockers,
         findings: classified.findings,
       };
-    }),
+    },
   );
   return {
     generatedAt: new Date().toISOString(),
+    coverage: { npm: "checked" as const, upstream: upstream.coverage },
     policy: {
       blocks: [
         "known malware advisories anywhere in the installed graph",
@@ -311,18 +374,26 @@ export function renderDependencyVulnerabilityGateMarkdownReport(
   report: Awaited<ReturnType<typeof runDependencyVulnerabilityGate>>,
 ) {
   const lines = [
-    "# npm Advisory Vulnerability Gate: Resolved Dependency Graph",
+    "# Dependency Vulnerability Gate: Resolved Dependency Graph",
     "",
     `Generated: ${report.generatedAt}`,
     "",
     "## Scope",
     "",
-    "This gate checks resolved package versions from pnpm-lock.yaml and the committed ClawHub and Vercel release-tool npm locks against npm advisory data. It includes transitive dependencies. Each lockfile is audited independently: known malware and critical advisories block anywhere; high advisories block in that source's production/runtime graph. Release-tool findings do not imply product runtime exposure.",
+    "This gate checks resolved package versions from pnpm-lock.yaml and the committed ClawHub and Vercel release-tool npm locks against npm bulk data and published advisories from verified public, registry-declared GitHub repositories. It includes transitive dependencies. Each lockfile is audited independently: known malware and critical advisories block anywhere; high advisories block in that source's production/runtime graph. Release-tool findings do not imply product runtime exposure.",
     "",
     "## Summary",
     "",
     `- Hard blockers: ${report.blockers.length}`,
     `- Total findings: ${report.findings.length}`,
+    `- Upstream-only findings missing from npm results: ${report.findings.filter((finding) => finding.source === "github-repository").length}`,
+    `- npm bulk: ${report.coverage.npm}`,
+    `- Public upstream coverage: ${report.coverage.upstream.status}`,
+    `- Package versions mapped to upstream repositories: ${report.coverage.upstream.mappedPackageVersions}/${report.coverage.upstream.packageVersions}`,
+    `- Repositories fully read: ${report.coverage.upstream.checkedRepositories}/${report.coverage.upstream.repositories}`,
+    `- Coverage issues: ${report.coverage.upstream.issues.length}`,
+    "",
+    "An empty source response is not comprehensive vulnerability clearance. Unsupported or incomplete upstream checks are not evidence that a package is unaffected.",
     "",
     ...report.graphs.flatMap((graph) => [
       `### ${graph.lockfile}`,
@@ -341,6 +412,19 @@ export function renderDependencyVulnerabilityGateMarkdownReport(
     "",
   ];
 
+  if (report.coverage.upstream.issues.length > 0) {
+    lines.push("## Incomplete Upstream Coverage", "");
+    for (const issue of report.coverage.upstream.issues.slice(0, 25)) {
+      lines.push(`- ${issue.subject}: ${issue.reason}`);
+    }
+    if (report.coverage.upstream.issues.length > 25) {
+      lines.push(
+        `- ${report.coverage.upstream.issues.length - 25} more coverage issues; see the JSON report.`,
+      );
+    }
+    lines.push("");
+  }
+
   for (const [title, findings] of [
     ["Hard Blockers", report.blockers],
     ["Findings", report.findings],
@@ -355,13 +439,16 @@ export function renderDependencyVulnerabilityGateMarkdownReport(
           `id=${finding.id} range=${finding.vulnerableVersions ?? "unknown"} ` +
           `${finding.malware ? "[malware] " : ""}${finding.url ?? ""}`,
       );
-      lines.push(`  - ${finding.title}`);
+      lines.push(`  - ${finding.title} [source: ${finding.source}]`);
+      if (finding.matchedVersions) {
+        lines.push(`  - Matched locked versions: ${finding.matchedVersions.join(", ")}`);
+      }
     }
     lines.push("");
   }
 
   if (report.findings.length === 0) {
-    lines.push("No advisories found.", "");
+    lines.push("No matching advisories returned by the checked sources.", "");
   }
 
   return `${lines.join("\n")}\n`;
@@ -376,27 +463,37 @@ export async function main(argv = process.argv.slice(2)) {
     renderDependencyVulnerabilityGateMarkdownReport(report),
   );
 
+  const upstream = report.coverage.upstream;
+  const coverage =
+    `npm bulk checked; public upstream ${upstream.status} ` +
+    `(${upstream.checkedRepositories}/${upstream.repositories} repositories fully read)`;
+  if (upstream.status === "partial") {
+    process.stderr.write(
+      `WARN incomplete upstream advisory coverage: ${upstream.issues.length} issues. Unchecked packages are not cleared; inspect the coverage section of the JSON/Markdown report.\n`,
+    );
+  }
   if (report.blockers.length === 0) {
     const packageVersions = report.graphs.reduce(
       (sum, graph) => sum + graph.all.packageVersions,
       0,
     );
     process.stdout.write(
-      `PASS npm advisory vulnerability gate: checked ${packageVersions} resolved ` +
+      `PASS dependency vulnerability gate: checked ${packageVersions} resolved ` +
         `package versions across ${report.graphs.length} separate lockfile graphs; 0 hard blockers, ` +
-        `${report.findings.length} total advisories.\n`,
+        `${report.findings.length} total advisories; ${coverage}. ` +
+        "This is not comprehensive vulnerability clearance.\n",
     );
     return 0;
   }
 
   process.stderr.write(
-    `FAIL npm advisory vulnerability gate: ${report.blockers.length} hard blockers in resolved ` +
-      `dependency graph; ${report.findings.length} total advisories.\n`,
+    `FAIL dependency vulnerability gate: ${report.blockers.length} hard blockers in resolved ` +
+      `dependency graph; ${report.findings.length} total advisories; ${coverage}.\n`,
   );
   for (const blocker of report.blockers.slice(0, 25)) {
     process.stderr.write(
       `- ${blocker.severity.toUpperCase()} ${blocker.packageName} (${blocker.lockfile}; ${blocker.graph}) ` +
-        `id=${blocker.id} title=${blocker.title}\n`,
+        `id=${blocker.id} source=${blocker.source} title=${blocker.title}\n`,
     );
   }
   return 1;
@@ -406,9 +503,14 @@ if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.met
   main().then(
     (exitCode) => {
       process.exitCode = exitCode;
+      if (exitCode !== 0) {
+        process.stderr.write(`[dependency-vulnerability-gate] FAILED (exit ${exitCode})\n`);
+      }
     },
     (error: unknown) => {
-      process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+      process.stderr.write(
+        `${error instanceof Error ? error.message : String(error)}\n[dependency-vulnerability-gate] FAILED (exit 1)\n`,
+      );
       process.exitCode = 1;
     },
   );

--- a/scripts/generate-dependency-release-evidence.mts
+++ b/scripts/generate-dependency-release-evidence.mts
@@ -5,6 +5,7 @@ import { execFileSync } from "node:child_process";
 import { appendFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
+import type { runDependencyVulnerabilityGate } from "./dependency-vulnerability-gate.mts";
 import { parseFlagArgs, stringFlag } from "./lib/arg-utils.mts";
 
 /**
@@ -12,7 +13,7 @@ import { parseFlagArgs, stringFlag } from "./lib/arg-utils.mts";
  */
 export const DEPENDENCY_EVIDENCE_REPORTS = [
   {
-    name: "npm advisory vulnerability gate",
+    name: "Dependency advisory vulnerability gate",
     command: "pnpm deps:vuln:gate",
     policy: "hard-blocking",
     json: "dependency-vulnerability-gate.json",
@@ -195,7 +196,7 @@ async function readJson<T>(filePath: string): Promise<T> {
  */
 export async function collectDependencyEvidenceSummaryCounts(evidenceDir: string) {
   const [vulnerability, transitiveRisk, ownershipSurface, dependencyChanges] = await Promise.all([
-    readJson<{ blockers: unknown[]; findings: unknown[] }>(
+    readJson<Awaited<ReturnType<typeof runDependencyVulnerabilityGate>>>(
       reportPath(evidenceDir, "dependency-vulnerability-gate.json"),
     ),
     readJson<{
@@ -218,6 +219,10 @@ export async function collectDependencyEvidenceSummaryCounts(evidenceDir: string
   return {
     vulnerabilityBlockers: vulnerability.blockers.length,
     vulnerabilityFindings: vulnerability.findings.length,
+    vulnerabilityCoverage: vulnerability.coverage,
+    upstreamOnlyVulnerabilityFindings: vulnerability.findings.filter(
+      (finding) => finding.source === "github-repository",
+    ).length,
     transitiveRiskSignals: transitiveRisk.findingCount,
     workspaceExcludedTransitiveSignals: transitiveRisk.workspaceExcludedFindingCount,
     transitiveMetadataFailures: transitiveRisk.metadataFailures.length,
@@ -232,6 +237,30 @@ export async function collectDependencyEvidenceSummaryCounts(evidenceDir: string
 
 type EvidenceSummaryCounts = Awaited<ReturnType<typeof collectDependencyEvidenceSummaryCounts>>;
 type EvidenceSummaryParams = { baseRef: string; counts: EvidenceSummaryCounts };
+
+function renderVulnerabilityEvidenceSummary(counts: EvidenceSummaryCounts) {
+  const { npm, upstream } = counts.vulnerabilityCoverage;
+  return [
+    `- npm advisory coverage: ${npm}`,
+    `- Upstream public repository advisory coverage: ${upstream.status}`,
+    `- Upstream source: \`${upstream.source}\``,
+    `- Upstream package versions mapped: ${upstream.mappedPackageVersions}/${upstream.packageVersions}`,
+    `- Upstream repositories checked: ${upstream.checkedRepositories}/${upstream.repositories}`,
+    `- Advisory vulnerability hard blockers: ${counts.vulnerabilityBlockers}`,
+    `- Advisory vulnerability total findings: ${counts.vulnerabilityFindings}`,
+    `- Upstream-only vulnerability findings: ${counts.upstreamOnlyVulnerabilityFindings}`,
+    `- Upstream coverage issues: ${upstream.issues.length}`,
+    ...upstream.issues.slice(0, 25).map(({ subject, reason }) => `  - ${subject}: ${reason}`),
+    ...(upstream.issues.length > 25
+      ? [
+          `  - ${upstream.issues.length - 25} more coverage issues; see dependency-vulnerability-gate.json.`,
+        ]
+      : []),
+    "",
+    "Coverage is limited to these advisory sources; zero findings do not prove that dependencies are unaffected.",
+    "",
+  ];
+}
 
 /**
  * Renders the dependency evidence Markdown summary.
@@ -249,8 +278,7 @@ export function renderDependencyEvidenceSummary({
     "",
     "## Summary",
     "",
-    `- npm advisory vulnerability hard blockers: ${counts.vulnerabilityBlockers}`,
-    `- npm advisory vulnerability total findings: ${counts.vulnerabilityFindings}`,
+    ...renderVulnerabilityEvidenceSummary(counts),
     `- Transitive manifest reported risk signals: ${counts.transitiveRiskSignals}`,
     `- Workspace-policy excluded transitive signals: ${counts.workspaceExcludedTransitiveSignals}`,
     `- Transitive manifest metadata failures: ${counts.transitiveMetadataFailures}`,
@@ -282,7 +310,7 @@ export function renderDependencyEvidenceStepSummary({
     "",
     `- Evidence artifact: \`${evidenceArtifactName}\``,
     `- Dependency change baseline: \`${baseRef}\``,
-    `- npm advisory vulnerability hard blockers: \`${counts.vulnerabilityBlockers}\``,
+    ...renderVulnerabilityEvidenceSummary(counts),
     `- Transitive manifest reported risk signals: \`${counts.transitiveRiskSignals}\``,
     `- Workspace-policy excluded transitive signals: \`${counts.workspaceExcludedTransitiveSignals}\``,
     `- Ownership/install surface lockfile packages: \`${counts.ownershipLockfilePackages}\``,
@@ -381,6 +409,10 @@ async function generateDependencyReleaseEvidence({
 
   await rm(outputDir, { recursive: true, force: true });
   await mkdir(outputDir, { recursive: true });
+  // Publish the artifact location before a blocking report exits so CI can retain its evidence.
+  if (githubOutput) {
+    await appendFile(githubOutput, `dir=${outputDir}\n`, "utf8");
+  }
 
   const releaseSha = commandOutput("git", ["rev-parse", "HEAD"], rootDir, execFileSyncImpl);
   if (!releaseSha) {
@@ -434,10 +466,6 @@ async function generateDependencyReleaseEvidence({
       "utf8",
     );
   }
-  if (githubOutput) {
-    await appendFile(githubOutput, `dir=${outputDir}\n`, "utf8");
-  }
-
   return { manifest, counts, outputDir };
 }
 
@@ -518,7 +546,9 @@ if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.met
       process.exitCode = exitCode;
     },
     (error: unknown) => {
-      process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+      process.stderr.write(
+        `${error instanceof Error ? error.message : String(error)}\n[dependency-release-evidence] FAILED (exit 1)\n`,
+      );
       process.exitCode = 1;
     },
   );

--- a/scripts/lib/upstream-repository-advisories.mts
+++ b/scripts/lib/upstream-repository-advisories.mts
@@ -1,0 +1,435 @@
+// Checks published public repository advisories independently of aggregate advisory feeds.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { Result } from "@openclaw/normalization-core/result";
+import semver from "semver";
+import { runTasksWithConcurrency } from "../../src/utils/run-with-concurrency.js";
+import { withAdvisoryRequestTimeout } from "../pre-commit/pnpm-audit-prod.mjs";
+import { readBoundedResponseText } from "./bounded-response.mjs";
+
+const GITHUB_API = "https://api.github.com";
+const MAX_PACKAGE_VERSIONS = 2500;
+const MAX_REQUESTS = 4000;
+const MAX_PAGES = 5;
+const PAGE_SIZE = 100;
+const MAX_ADVISORIES = 10_000;
+const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
+const REQUEST_TIMEOUT_MS = 15_000;
+const RUN_TIMEOUT_MS = 5 * 60_000;
+const CONCURRENCY = 4;
+const GHSA_ID = /^GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}$/u;
+const SEVERITIES = new Set(["low", "medium", "high", "critical"]);
+
+type CoverageReason =
+  | "budget-exhausted"
+  | "rate-limited"
+  | "request-failed"
+  | "invalid-response"
+  | "unsupported-version"
+  | "unsupported-repository"
+  | "repository-not-public"
+  | "invalid-advisory"
+  | "invalid-range"
+  | "invalid-pagination";
+type CoverageIssue = { subject: string; reason: CoverageReason };
+type PackageVersions = Record<string, string[]>;
+type RepositoryPackages = Map<string, Set<string>>;
+type JsonResponse = { data: unknown; link: string | null };
+
+export type PublishedRepositoryAdvisory = {
+  packageName: string;
+  id: string;
+  severity: string;
+  title: string;
+  url: string;
+  vulnerable_versions: string;
+  matchedVersions: string[];
+};
+
+function githubRepository(repository: unknown) {
+  const value = isRecord(repository) ? repository.url : repository;
+  if (typeof value !== "string") {
+    return null;
+  }
+  try {
+    const url = new URL(value.replace(/^github:/u, "https://github.com/").replace(/^git\+/u, ""));
+    if (
+      url.hostname !== "github.com" ||
+      !["https:", "ssh:", "git:"].includes(url.protocol) ||
+      url.port ||
+      url.password ||
+      url.search ||
+      url.hash ||
+      (url.username && !(url.protocol === "ssh:" && url.username === "git"))
+    ) {
+      return null;
+    }
+    const match = /^\/([\w-]+)\/([\w.-]+?)(?:\.git)?\/?$/u.exec(url.pathname);
+    return match && match[2] !== "." && match[2] !== ".."
+      ? `${match[1]}/${match[2]}`.toLowerCase()
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function githubRange(value: unknown) {
+  if (typeof value !== "string" || value.length > 256) {
+    return null;
+  }
+  // GitHub documents one comparator or a lower/upper pair separated by ", ".
+  // Do not guess at legacy prose or semicolon ranges: absence of a match is not clearance.
+  const bounds = value.split(", ");
+  const validBounds =
+    bounds.length <= 2 &&
+    bounds.every(
+      (bound, index) =>
+        /^(?:>=|>|=|<=|<) \d[^\s,]*$/u.test(bound) &&
+        (bounds.length === 1 || bound.startsWith(index === 0 ? ">" : "<")),
+    );
+  if (!validBounds) {
+    return null;
+  }
+  try {
+    return bounds.map((bound) => {
+      // GitHub's zero floor is not npm's partial-version ">0" (which means >=1.0.0).
+      const normalized = bound === ">= 0" ? ">= 0.0.0-0" : bound.replace(/ 0$/u, " 0.0.0");
+      return new semver.Comparator(normalized);
+    });
+  } catch {
+    return null;
+  }
+}
+
+function nextCursor(
+  link: string | null,
+  repository: string,
+  repositoryId: number,
+): Result<string | null, CoverageReason> {
+  const next = link?.split(",").find((part) => /;\s*rel="next"/u.test(part));
+  if (!next) {
+    return { ok: true, value: null };
+  }
+  try {
+    const url = new URL(/<([^>]+)>/u.exec(next)?.[1] ?? "");
+    const cursor = url.searchParams.get("after");
+    const sameRepository =
+      url.pathname === `/repos/${repository}/security-advisories` ||
+      url.pathname === `/repositories/${repositoryId}/security-advisories`;
+    if (
+      url.origin === GITHUB_API &&
+      !url.username &&
+      !url.password &&
+      !url.hash &&
+      sameRepository &&
+      url.searchParams.get("state") === "published" &&
+      cursor &&
+      cursor.length <= 2048
+    ) {
+      return { ok: true, value: cursor };
+    }
+  } catch {
+    // Invalid continuation is incomplete coverage, never permission to follow another host.
+  }
+  return { ok: false, error: "invalid-pagination" };
+}
+
+function collectRepositoryMatches(
+  rows: unknown[],
+  repository: string,
+  packages: RepositoryPackages,
+  advisories: PublishedRepositoryAdvisory[],
+  issues: CoverageIssue[],
+) {
+  for (const row of rows) {
+    if (!isRecord(row)) {
+      issues.push({ subject: repository, reason: "invalid-advisory" });
+      continue;
+    }
+    if (typeof row.withdrawn_at === "string") {
+      continue;
+    }
+    if (row.state !== "published" || row.withdrawn_at !== null) {
+      issues.push({ subject: repository, reason: "invalid-advisory" });
+      continue;
+    }
+    if (
+      typeof row.ghsa_id !== "string" ||
+      !GHSA_ID.test(row.ghsa_id) ||
+      typeof row.severity !== "string" ||
+      !SEVERITIES.has(row.severity) ||
+      typeof row.summary !== "string" ||
+      row.summary.length > 512 ||
+      !Array.isArray(row.vulnerabilities)
+    ) {
+      issues.push({ subject: repository, reason: "invalid-advisory" });
+      continue;
+    }
+    const matches = new Map<string, { ranges: Set<string>; versions: Set<string> }>();
+    for (const vulnerability of row.vulnerabilities) {
+      if (!isRecord(vulnerability) || !isRecord(vulnerability.package)) {
+        issues.push({ subject: `${repository}#${row.ghsa_id}`, reason: "invalid-advisory" });
+        continue;
+      }
+      const { ecosystem, name } = vulnerability.package;
+      if (typeof ecosystem !== "string" || (ecosystem === "npm" && typeof name !== "string")) {
+        issues.push({ subject: `${repository}#${row.ghsa_id}`, reason: "invalid-advisory" });
+        continue;
+      }
+      if (ecosystem !== "npm" || typeof name !== "string") {
+        continue;
+      }
+      const versions = packages.get(name);
+      if (!versions) {
+        continue;
+      }
+      const range = githubRange(vulnerability.vulnerable_version_range);
+      if (!range) {
+        issues.push({ subject: `${name}#${row.ghsa_id}`, reason: "invalid-range" });
+        continue;
+      }
+      const affected = [...versions].filter((version) =>
+        range.every((bound) => bound.test(version)),
+      );
+      if (affected.length === 0) {
+        continue;
+      }
+      const match = matches.get(name) ?? { ranges: new Set<string>(), versions: new Set<string>() };
+      match.ranges.add(range.map((bound) => bound.value).join(" "));
+      for (const version of affected) {
+        match.versions.add(version);
+      }
+      matches.set(name, match);
+    }
+    for (const [packageName, match] of matches) {
+      advisories.push({
+        packageName,
+        id: row.ghsa_id,
+        severity: row.severity === "medium" ? "moderate" : row.severity,
+        title: row.summary,
+        url: `https://github.com/${repository}/security/advisories/${row.ghsa_id}`,
+        vulnerable_versions: [...match.ranges].toSorted().join(" || "),
+        matchedVersions: [...match.versions].toSorted(),
+      });
+    }
+  }
+}
+
+export async function fetchPublishedRepositoryAdvisories({
+  payload,
+  registryBaseUrl,
+  fetchImpl,
+}: {
+  payload: PackageVersions;
+  registryBaseUrl: string;
+  fetchImpl: typeof fetch;
+}) {
+  const issues: CoverageIssue[] = [];
+  const advisories: PublishedRepositoryAdvisory[] = [];
+  const repositories = new Map<string, RepositoryPackages>();
+  const deadline = performance.now() + RUN_TIMEOUT_MS;
+  const token = process.env.GH_TOKEN;
+  let requests = 0;
+  let githubFailure: "rate-limited" | "request-failed" | null = null;
+  let advisoryCount = 0;
+  let mappedPackageVersions = 0;
+  let checkedRepositories = 0;
+
+  async function request(
+    url: string,
+    source: "registry" | "github",
+  ): Promise<Result<JsonResponse, CoverageReason>> {
+    const github = source === "github";
+    const remainingMs = deadline - performance.now();
+    if (github && githubFailure) {
+      return { ok: false, error: githubFailure };
+    }
+    if (remainingMs <= 0 || requests >= MAX_REQUESTS || advisoryCount >= MAX_ADVISORIES) {
+      return { ok: false, error: "budget-exhausted" };
+    }
+    requests += 1;
+    try {
+      return await withAdvisoryRequestTimeout({
+        label: "Upstream advisory request",
+        timeoutMs: Math.min(REQUEST_TIMEOUT_MS, remainingMs),
+        run: async ({ signal, timeoutPromise }): Promise<Result<JsonResponse, CoverageReason>> => {
+          // Source role owns credentials; registry metadata and redirects never receive the token.
+          const headers: Record<string, string> = { accept: "application/json" };
+          if (github) {
+            headers["x-github-api-version"] = "2022-11-28";
+            if (token) {
+              headers.authorization = `Bearer ${token}`;
+            }
+          }
+          const response = await fetchImpl(url, { headers, signal, redirect: "error" });
+          if (!response.ok) {
+            const rateLimited =
+              github &&
+              (response.status === 429 ||
+                (response.status === 403 && response.headers.get("x-ratelimit-remaining") === "0"));
+            const reason = rateLimited ? "rate-limited" : "request-failed";
+            // Secondary limits can return 403 with primary quota remaining. Do not
+            // continue through repositories after a throttle or credential denial.
+            if (github && [401, 403, 429].includes(response.status)) {
+              githubFailure = reason;
+            }
+            void response.body?.cancel().catch(() => undefined);
+            return { ok: false, error: reason };
+          }
+          const text = await readBoundedResponseText(
+            response,
+            "upstream advisory source",
+            MAX_RESPONSE_BYTES,
+            { signal, timeoutPromise },
+          );
+          return {
+            ok: true,
+            value: { data: JSON.parse(text), link: response.headers.get("link") },
+          };
+        },
+      });
+    } catch {
+      return {
+        ok: false,
+        error: performance.now() >= deadline ? "budget-exhausted" : "request-failed",
+      };
+    }
+  }
+
+  const entries = Object.entries(payload)
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .flatMap(([packageName, versions]) =>
+      [...new Set(versions)].toSorted().map((version) => ({ packageName, version })),
+    );
+  if (entries.length > MAX_PACKAGE_VERSIONS) {
+    issues.push({
+      subject: `${entries.length - MAX_PACKAGE_VERSIONS} package versions not inspected`,
+      reason: "budget-exhausted",
+    });
+  }
+  await runTasksWithConcurrency({
+    limit: CONCURRENCY,
+    throwOnError: true,
+    tasks: entries.slice(0, MAX_PACKAGE_VERSIONS).map(({ packageName, version }) => async () => {
+      const subject = `${packageName}@${version}`;
+      if (!semver.valid(version)) {
+        issues.push({ subject, reason: "unsupported-version" });
+        return;
+      }
+      const url = `${registryBaseUrl}/${encodeURIComponent(packageName)}/${encodeURIComponent(version)}`;
+      const response = await request(url, "registry");
+      if (!response.ok) {
+        issues.push({ subject, reason: response.error });
+        return;
+      }
+      const manifest = response.value.data;
+      if (!isRecord(manifest) || manifest.name !== packageName || manifest.version !== version) {
+        issues.push({ subject, reason: "invalid-response" });
+        return;
+      }
+      const repository = githubRepository(manifest.repository);
+      if (!repository) {
+        issues.push({ subject, reason: "unsupported-repository" });
+        return;
+      }
+      const packages = repositories.get(repository) ?? new Map<string, Set<string>>();
+      const versions = packages.get(packageName) ?? new Set<string>();
+      versions.add(version);
+      packages.set(packageName, versions);
+      repositories.set(repository, packages);
+      mappedPackageVersions += 1;
+    }),
+  });
+
+  await runTasksWithConcurrency({
+    limit: CONCURRENCY,
+    throwOnError: true,
+    tasks: [...repositories]
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(([repository, packages]) => async () => {
+        const base = `${GITHUB_API}/repos/${repository}`;
+        const metadata = await request(base, "github");
+        if (!metadata.ok) {
+          issues.push({ subject: repository, reason: metadata.error });
+          return;
+        }
+        // An authenticated token may see private repositories; their advisories are outside this check.
+        if (!isRecord(metadata.value.data) || metadata.value.data.private !== false) {
+          issues.push({ subject: repository, reason: "repository-not-public" });
+          return;
+        }
+        const repositoryId = metadata.value.data.id;
+        if (
+          typeof repositoryId !== "number" ||
+          !Number.isSafeInteger(repositoryId) ||
+          repositoryId <= 0
+        ) {
+          issues.push({ subject: repository, reason: "invalid-response" });
+          return;
+        }
+        let cursor: string | null = null;
+        for (let page = 0; page < MAX_PAGES; page += 1) {
+          const query = new URLSearchParams({ state: "published", per_page: String(PAGE_SIZE) });
+          if (cursor) {
+            query.set("after", cursor);
+          }
+          const response = await request(`${base}/security-advisories?${query}`, "github");
+          if (!response.ok) {
+            issues.push({ subject: repository, reason: response.error });
+            return;
+          }
+          const rows = response.value.data;
+          if (!Array.isArray(rows) || rows.length > PAGE_SIZE) {
+            issues.push({ subject: repository, reason: "invalid-response" });
+            return;
+          }
+          const remaining = MAX_ADVISORIES - advisoryCount;
+          advisoryCount += Math.min(rows.length, remaining);
+          collectRepositoryMatches(
+            rows.slice(0, remaining),
+            repository,
+            packages,
+            advisories,
+            issues,
+          );
+          if (rows.length > remaining) {
+            issues.push({ subject: repository, reason: "budget-exhausted" });
+            return;
+          }
+          const next = nextCursor(response.value.link, repository, repositoryId);
+          if (!next.ok) {
+            issues.push({ subject: repository, reason: next.error });
+            return;
+          }
+          if (!next.value) {
+            checkedRepositories += 1;
+            return;
+          }
+          if (next.value === cursor) {
+            issues.push({ subject: repository, reason: "invalid-pagination" });
+            return;
+          }
+          cursor = next.value;
+        }
+        issues.push({ subject: repository, reason: "budget-exhausted" });
+      }),
+  });
+
+  return {
+    advisories: advisories.toSorted(
+      (left, right) =>
+        left.packageName.localeCompare(right.packageName) || left.id.localeCompare(right.id),
+    ),
+    coverage: {
+      source: "github-public-repository-advisories" as const,
+      status: issues.length === 0 ? ("checked" as const) : ("partial" as const),
+      packageVersions: entries.length,
+      mappedPackageVersions,
+      repositories: repositories.size,
+      checkedRepositories,
+      issues: issues.toSorted(
+        (left, right) =>
+          left.subject.localeCompare(right.subject) || left.reason.localeCompare(right.reason),
+      ),
+    },
+  };
+}

--- a/scripts/pre-commit/pnpm-audit-prod.mjs
+++ b/scripts/pre-commit/pnpm-audit-prod.mjs
@@ -597,6 +597,10 @@ export function collectAllResolvedPackagesFromLockfile(lockfileText) {
   return versionsByPackage;
 }
 
+/**
+ * @param {Map<string, Set<string>>} versionsByPackage
+ * @returns {Record<string, string[]>}
+ */
 export function createBulkAdvisoryPayload(versionsByPackage) {
   return Object.fromEntries(
     [...versionsByPackage.entries()]
@@ -692,7 +696,7 @@ function chunkEntries(entries, size) {
   return chunks;
 }
 
-function resolveRegistryBaseUrl() {
+export function resolveRegistryBaseUrl() {
   const configured =
     process.env.npm_config_registry ??
     process.env.NPM_CONFIG_REGISTRY ??
@@ -734,10 +738,16 @@ function clampBulkAdvisoryTimeoutMs(valueMs) {
   return Math.min(Math.max(Math.floor(value), 1), MAX_TIMER_TIMEOUT_MS);
 }
 
-async function withBulkAdvisoryTimeout({ label, timeoutMs, run }) {
+/**
+ * @template T
+ * @param {{ label: string, timeoutMs: number, run: (options: { signal: AbortSignal, timeoutPromise: Promise<never> }) => Promise<T> }} options
+ * @returns {Promise<T>}
+ */
+export async function withAdvisoryRequestTimeout({ label, timeoutMs, run }) {
   const resolvedTimeoutMs = clampBulkAdvisoryTimeoutMs(timeoutMs);
   const controller = new AbortController();
   let timeout;
+  /** @type {Promise<never>} */
   const timeoutPromise = new Promise((_resolve, reject) => {
     timeout = setTimeout(() => {
       const error = new Error(`${label} exceeded timeout of ${resolvedTimeoutMs}ms`);
@@ -838,7 +848,7 @@ export async function fetchBulkAdvisories({
   timeoutMs = resolveBulkAdvisoryRequestTimeoutMs(),
 }) {
   const url = `${registryBaseUrl}${BULK_ADVISORY_PATH}`;
-  return await withBulkAdvisoryTimeout({
+  return await withAdvisoryRequestTimeout({
     label: "Bulk advisory request",
     timeoutMs,
     run: async ({ signal, timeoutPromise }) => {
@@ -906,13 +916,15 @@ export async function runPnpmAuditProd({
   );
   if (findings.length === 0) {
     stdout.write(
-      `No ${normalizedMinSeverity} or higher advisories found for production dependencies.\n`,
+      `No matching ${normalizedMinSeverity} or higher advisories returned by npm bulk for production dependencies. ` +
+        "Upstream repository advisories were not checked; this is not comprehensive vulnerability clearance.\n",
     );
     return 0;
   }
 
   stderr.write(
-    `Found ${findings.length} ${normalizedMinSeverity} or higher advisories in production dependencies:\n`,
+    `Found ${findings.length} ${normalizedMinSeverity} or higher advisories from npm bulk in production dependencies ` +
+      "(upstream repository advisories not checked):\n",
   );
   for (const finding of findings.slice(0, 25)) {
     const details = [
@@ -978,4 +990,7 @@ async function main() {
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   await main();
+  if (process.exitCode) {
+    process.stderr.write(`[pnpm-audit-prod] FAILED (exit ${process.exitCode})\n`);
+  }
 }

--- a/test/scripts/dependency-vulnerability-gate.test.ts
+++ b/test/scripts/dependency-vulnerability-gate.test.ts
@@ -69,6 +69,35 @@ snapshots:
   }
 }
 
+function publishedAdvisory(range = ">= 0.8.0, < 1.0.0") {
+  return {
+    ghsa_id: "GHSA-2222-3333-4444",
+    state: "published",
+    withdrawn_at: null,
+    severity: "high",
+    summary: "Upstream fixture vulnerability",
+    vulnerabilities: [
+      { package: { ecosystem: "npm", name: "runtime-high" }, vulnerable_version_range: range },
+    ],
+  };
+}
+
+function withPublicUpstream(npmFetch: typeof fetch, advisories: unknown[] = []): typeof fetch {
+  return async (input, init) => {
+    const url = new URL(String(input));
+    if (url.pathname.endsWith("/advisories/bulk")) {
+      return npmFetch(input, init);
+    }
+    if (url.hostname === "registry.npmjs.org") {
+      const [name, version] = url.pathname.slice(1).split("/").map(decodeURIComponent);
+      return Response.json({ name, version, repository: "https://github.com/fixture/packages" });
+    }
+    return Response.json(
+      url.pathname.endsWith("/security-advisories") ? advisories : { id: 42, private: false },
+    );
+  };
+}
+
 function requestPayload(init: RequestInit | undefined): Record<string, string[]> {
   if (typeof init?.body !== "string") {
     throw new Error("expected a JSON request body");
@@ -88,7 +117,9 @@ describe("dependency-vulnerability-gate", () => {
     );
     expect(result.status).toBe(1);
     expect(result.stdout).toBe("");
-    expect(result.stderr.trim()).toBe("Unsupported argument: --wat");
+    expect(result.stderr.trim()).toBe(
+      "Unsupported argument: --wat\n[dependency-vulnerability-gate] FAILED (exit 1)",
+    );
     expect(result.stderr).not.toContain("Node.js");
     expect(result.stderr).not.toContain("\n    at ");
   });
@@ -108,7 +139,7 @@ describe("dependency-vulnerability-gate", () => {
         const payloads: Record<string, string[]>[] = [];
         const report = await runDependencyVulnerabilityGate({
           rootDir,
-          fetchImpl: async (_url, init) => {
+          fetchImpl: withPublicUpstream(async (_url, init) => {
             const payload = requestPayload(init);
             payloads.push(payload);
             const advisories = {
@@ -123,7 +154,7 @@ describe("dependency-vulnerability-gate", () => {
                 .map(([name, finding]) => [name, [{ ...finding, vulnerable_versions: "<=1.0.0" }]]),
             );
             return new Response(JSON.stringify(body));
-          },
+          }),
         });
         expect(payloads.filter((payload) => "runtime-high" in payload)).toEqual([
           {
@@ -231,14 +262,16 @@ describe("dependency-vulnerability-gate", () => {
         await writeNpmLock(rootDir, lockfile, { [location]: { version: "0.9.0", ...metadata } });
         const report = await runDependencyVulnerabilityGate({
           rootDir,
-          fetchImpl: async (_url, init) =>
-            new Response(
-              JSON.stringify(
-                requestPayload(init)["runtime-high"]?.includes("0.9.0")
-                  ? { "runtime-high": [advisory(severity, title)] }
-                  : {},
+          fetchImpl: withPublicUpstream(
+            async (_url, init) =>
+              new Response(
+                JSON.stringify(
+                  requestPayload(init)["runtime-high"]?.includes("0.9.0")
+                    ? { "runtime-high": [advisory(severity, title)] }
+                    : {},
+                ),
               ),
-            ),
+          ),
         });
         expect(report.findings).toMatchObject([
           { lockfile, packageName: "runtime-high", graph, severity },
@@ -251,6 +284,107 @@ describe("dependency-vulnerability-gate", () => {
       });
     },
   );
+
+  it("blocks a published upstream advisory missing from npm without tainting the patched product", async () => {
+    await withLockfiles(async (rootDir) => {
+      await writeNpmLock(rootDir, releaseLocks[1], {
+        "node_modules/runtime-high": { version: "0.9.0" },
+      });
+      const report = await runDependencyVulnerabilityGate({
+        rootDir,
+        fetchImpl: withPublicUpstream(async () => Response.json({}), [publishedAdvisory()]),
+      });
+
+      expect(report.blockers).toMatchObject([
+        {
+          lockfile: releaseLocks[1],
+          packageName: "runtime-high",
+          graph: "production",
+          id: "GHSA-2222-3333-4444",
+          source: "github-repository",
+          matchedVersions: ["0.9.0"],
+        },
+      ]);
+      expect(report.findings).toHaveLength(1);
+    });
+  });
+
+  it.each([false, true])(
+    "correlates npm GHSA IDs only inside the same graph (runtime reported %s)",
+    async (runtimeReported) => {
+      await withLockfiles(async (rootDir) => {
+        const lockfile = path.join(rootDir, "pnpm-lock.yaml");
+        await writeFile(lockfile, `${await readFile(lockfile, "utf8")}  runtime-high@0.9.0: {}\n`);
+        const report = await runDependencyVulnerabilityGate({
+          rootDir,
+          fetchImpl: withPublicUpstream(
+            async (_url, init) => {
+              const versions = requestPayload(init)["runtime-high"];
+              return Response.json(
+                versions?.includes("0.9.0") || (runtimeReported && versions?.includes("1.0.0"))
+                  ? {
+                      "runtime-high": [
+                        {
+                          ...advisory("high"),
+                          id: 123456,
+                          url: "https://github.com/advisories/GHSA-2222-3333-4444",
+                        },
+                      ],
+                    }
+                  : {},
+              );
+            },
+            [publishedAdvisory(">= 0.8.0, <= 1.0.0")],
+          ),
+        });
+        expect(report.blockers).toHaveLength(1);
+        expect(report.blockers[0]).toMatchObject({
+          lockfile: "pnpm-lock.yaml",
+          graph: "production",
+          source: runtimeReported ? "npm-bulk" : "github-repository",
+        });
+        expect(report.findings).toHaveLength(runtimeReported ? 1 : 2);
+      });
+    },
+  );
+
+  it("writes partial coverage without claiming an unavailable upstream check passed", async () => {
+    await withLockfiles(async (rootDir) => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+        const url = new URL(String(input));
+        return url.pathname.endsWith("/advisories/bulk")
+          ? Response.json({})
+          : new Response("unavailable", { status: 503 });
+      });
+      const stdout = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+      const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+      try {
+        const jsonPath = path.join(rootDir, "report.json");
+        const markdownPath = path.join(rootDir, "report.md");
+        expect(
+          await main(["--root", rootDir, "--json", jsonPath, "--markdown", markdownPath]),
+        ).toBe(0);
+        const report = JSON.parse(await readFile(jsonPath, "utf8"));
+        expect(report.coverage.upstream).toMatchObject({
+          status: "partial",
+          checkedRepositories: 0,
+        });
+        expect(report.coverage.upstream.issues).toHaveLength(4);
+        expect(stdout.mock.calls.flat().join("")).toContain("public upstream partial");
+        expect(stdout.mock.calls.flat().join("")).toContain(
+          "not comprehensive vulnerability clearance",
+        );
+        expect(stderr.mock.calls.flat().join("")).toContain(
+          "WARN incomplete upstream advisory coverage",
+        );
+        expect(await readFile(markdownPath, "utf8")).toContain("Incomplete Upstream Coverage");
+      } finally {
+        fetchSpy.mockRestore();
+        stdout.mockRestore();
+        stderr.mockRestore();
+      }
+    });
+  });
 
   it("retains nested versions and findings in both release locks without auditing the root or links", async () => {
     await withLockfiles(async (rootDir) => {
@@ -266,13 +400,13 @@ describe("dependency-vulnerability-gate", () => {
       const payloads: Record<string, string[]>[] = [];
       const report = await runDependencyVulnerabilityGate({
         rootDir,
-        fetchImpl: async (_url, init) => {
+        fetchImpl: withPublicUpstream(async (_url, init) => {
           const payload = requestPayload(init);
           payloads.push(payload);
           return new Response(
             JSON.stringify(payload["@scope/leaf"] ? { "@scope/leaf": [advisory("high")] } : {}),
           );
-        },
+        }),
       });
       expect(payloads.filter((payload) => "@scope/leaf" in payload)).toEqual(
         Array.from({ length: 4 }, () => ({ "@scope/leaf": ["0.8.0", "0.9.0"] })),
@@ -351,14 +485,16 @@ describe("dependency-vulnerability-gate", () => {
         const fetchSpy = vi
           .spyOn(globalThis, "fetch")
           .mockImplementation(
-            async (_url, init) =>
-              new Response(
-                JSON.stringify(
-                  blocked && requestPayload(init)["runtime-high"]?.includes("0.9.0")
-                    ? { "runtime-high": [advisory("critical")] }
-                    : {},
+            withPublicUpstream(
+              async (_url, init) =>
+                new Response(
+                  JSON.stringify(
+                    blocked && requestPayload(init)["runtime-high"]?.includes("0.9.0")
+                      ? { "runtime-high": [advisory("critical")] }
+                      : {},
+                  ),
                 ),
-              ),
+            ),
           );
         const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
         const stdout = vi.spyOn(process.stdout, "write").mockReturnValue(true);
@@ -381,7 +517,12 @@ describe("dependency-vulnerability-gate", () => {
             expect(stderr.mock.calls.flat().join("")).toContain(lockfile);
             expect(stdout).not.toHaveBeenCalled();
           } else {
-            expect(markdown).toContain("No advisories found.");
+            expect(markdown).toContain("No matching advisories returned by the checked sources.");
+            expect(markdown).toContain("not comprehensive vulnerability clearance");
+            expect(report.coverage).toMatchObject({
+              npm: "checked",
+              upstream: { status: "checked" },
+            });
             expect(stdout.mock.calls.flat().join("")).toContain(
               "checked 5 resolved package versions across 3 separate lockfile graphs; 0 hard blockers",
             );

--- a/test/scripts/generate-dependency-release-evidence.test.ts
+++ b/test/scripts/generate-dependency-release-evidence.test.ts
@@ -1,6 +1,6 @@
 // Generate Dependency Release Evidence tests cover generate dependency release evidence script behavior.
 import { spawnSync } from "node:child_process";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
@@ -20,12 +20,13 @@ async function writeJson(dir: string, fileName: string, value: unknown) {
   await writeFile(path.join(dir, fileName), `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }
 
-function runCli(...args: string[]) {
+function runCli(args: string[], env = process.env) {
   return spawnSync(
     process.execPath,
     ["--import", "tsx", "scripts/generate-dependency-release-evidence.mts", ...args],
     {
       cwd: path.resolve("."),
+      env,
       encoding: "utf8",
     },
   );
@@ -198,7 +199,7 @@ describe("generate-dependency-release-evidence", () => {
   });
 
   it("prints CLI help without generating evidence", () => {
-    const result = runCli("--help");
+    const result = runCli(["--help"]);
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain(
@@ -209,14 +210,72 @@ describe("generate-dependency-release-evidence", () => {
 
   it("reports CLI argument errors without a Node stack trace", () => {
     for (const args of [["--wat"], ["wat", "--help"]]) {
-      const result = runCli(...args);
+      const result = runCli(args);
 
       expect(result.status).toBe(1);
       expect(result.stdout).toBe("");
-      expect(result.stderr.trim()).toBe(`Unsupported argument: ${args[0]}`);
+      expect(result.stderr.trim()).toBe(
+        `Unsupported argument: ${args[0]}\n[dependency-release-evidence] FAILED (exit 1)`,
+      );
       expectNoNodeStack(result.stderr);
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "retains gate artifacts and publishes their directory when the gate fails",
+    async () => {
+      const dir = await mkdtemp(path.join(tmpdir(), "openclaw-release-dependency-failure-test-"));
+      try {
+        const binDir = path.join(dir, "bin");
+        const outputDir = path.join(dir, "evidence");
+        const githubOutput = path.join(dir, "github-output");
+        await mkdir(binDir);
+        await writeFile(
+          path.join(binDir, "pnpm"),
+          [
+            "#!/usr/bin/env node",
+            'const { writeFileSync } = require("node:fs");',
+            "const args = process.argv.slice(2);",
+            'if (args[0] !== "deps:vuln:gate") throw new Error("Unexpected report command");',
+            'writeFileSync(args[args.indexOf("--json") + 1], JSON.stringify({ blockers: [{ id: "GHSA-fixture" }] }));',
+            'writeFileSync(args[args.indexOf("--markdown") + 1], "# Blocking advisory evidence\\n");',
+            "process.exitCode = 1;",
+          ].join("\n"),
+          { mode: 0o755 },
+        );
+
+        const result = runCli(
+          [
+            "--output-dir",
+            outputDir,
+            "--release-ref",
+            "v2026.5.13",
+            "--npm-dist-tag",
+            "latest",
+            "--base-ref",
+            "v2026.5.1",
+            "--github-output",
+            githubOutput,
+            "--github-step-summary",
+            "",
+          ],
+          { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
+        );
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain("Command failed: pnpm deps:vuln:gate");
+        await expect(readFile(githubOutput, "utf8")).resolves.toBe(`dir=${outputDir}\n`);
+        await expect(
+          readFile(path.join(outputDir, "dependency-vulnerability-gate.json"), "utf8"),
+        ).resolves.toBe(JSON.stringify({ blockers: [{ id: "GHSA-fixture" }] }));
+        await expect(
+          readFile(path.join(outputDir, "dependency-vulnerability-gate.md"), "utf8"),
+        ).resolves.toBe("# Blocking advisory evidence\n");
+      } finally {
+        await rm(dir, { force: true, recursive: true });
+      }
+    },
+  );
 
   it("falls back to fetching tags when local previous-release resolution misses", () => {
     const calls: Array<{ command: string; args: string[] }> = [];
@@ -254,81 +313,132 @@ describe("generate-dependency-release-evidence", () => {
     ]);
   });
 
-  it("collects report counts and renders human summaries", async () => {
-    const dir = await mkdtemp(path.join(tmpdir(), "openclaw-release-dependency-evidence-test-"));
-    try {
-      await writeJson(dir, "dependency-vulnerability-gate.json", {
-        blockers: [
-          { id: "GHSA-blocker", lockfile: "pnpm-lock.yaml" },
-          { id: "GHSA-blocker", lockfile: ".github/release/vercel-cli/package-lock.json" },
-        ],
-        findings: [
-          { id: "GHSA-blocker", lockfile: "pnpm-lock.yaml" },
-          { id: "GHSA-blocker", lockfile: ".github/release/vercel-cli/package-lock.json" },
-          { id: "GHSA-report", lockfile: ".github/release/clawhub-cli/package-lock.json" },
-        ],
-      });
-      await writeJson(dir, "transitive-manifest-risk-report.json", {
-        findingCount: 17,
-        workspaceExcludedFindingCount: 3,
-        metadataFailures: [{ packageName: "missing" }],
-      });
-      await writeJson(dir, "dependency-ownership-surface-report.json", {
-        summary: {
-          lockfilePackageCount: 101,
-          buildRiskPackageCount: 8,
-        },
-      });
-      await writeJson(dir, "dependency-changes-report.json", {
-        summary: {
+  it.each([
+    { status: "checked", mappedPackageVersions: 101, checkedRepositories: 2, issues: [] },
+    {
+      status: "partial",
+      mappedPackageVersions: 100,
+      checkedRepositories: 1,
+      issues: [
+        { subject: "unmapped-package@1.0.0", reason: "Unsupported repository URL" },
+        { subject: "example/tool", reason: "GitHub API rate limit exceeded" },
+      ],
+    },
+  ])(
+    "collects report counts and renders $status upstream coverage in both summaries",
+    async (upstream) => {
+      const dir = await mkdtemp(path.join(tmpdir(), "openclaw-release-dependency-evidence-test-"));
+      try {
+        const coverage = {
+          npm: "checked",
+          upstream: {
+            source: "github-public-repository-advisories",
+            packageVersions: 101,
+            repositories: 2,
+            ...upstream,
+          },
+        };
+        const findings = [
+          { id: "GHSA-blocker", lockfile: "pnpm-lock.yaml", source: "npm-bulk" },
+          {
+            id: "GHSA-blocker",
+            lockfile: ".github/release/vercel-cli/package-lock.json",
+            source: "github-repository",
+            matchedVersions: ["1.0.0", "1.1.0"],
+          },
+          {
+            id: "GHSA-report",
+            lockfile: ".github/release/clawhub-cli/package-lock.json",
+            source: "github-repository",
+            matchedVersions: ["2.0.0"],
+          },
+        ];
+        await writeJson(dir, "dependency-vulnerability-gate.json", {
+          blockers: findings.slice(0, 2),
+          findings,
+          coverage,
+        });
+        await writeJson(dir, "transitive-manifest-risk-report.json", {
+          findingCount: 17,
+          workspaceExcludedFindingCount: 3,
+          metadataFailures: [{ packageName: "missing" }],
+        });
+        await writeJson(dir, "dependency-ownership-surface-report.json", {
+          summary: {
+            lockfilePackageCount: 101,
+            buildRiskPackageCount: 8,
+          },
+        });
+        await writeJson(dir, "dependency-changes-report.json", {
+          summary: {
+            dependencyFileChanges: 4,
+            addedPackages: 5,
+            removedPackages: 6,
+            changedPackages: 7,
+          },
+        });
+
+        const counts = await collectDependencyEvidenceSummaryCounts(dir);
+        expect(counts).toEqual({
+          vulnerabilityBlockers: 2,
+          vulnerabilityFindings: 3,
+          vulnerabilityCoverage: coverage,
+          upstreamOnlyVulnerabilityFindings: 2,
+          transitiveRiskSignals: 17,
+          workspaceExcludedTransitiveSignals: 3,
+          transitiveMetadataFailures: 1,
+          ownershipLockfilePackages: 101,
+          ownershipBuildRiskPackages: 8,
           dependencyFileChanges: 4,
-          addedPackages: 5,
-          removedPackages: 6,
-          changedPackages: 7,
-        },
-      });
+          dependencyAddedPackages: 5,
+          dependencyRemovedPackages: 6,
+          dependencyChangedPackages: 7,
+        });
 
-      const counts = await collectDependencyEvidenceSummaryCounts(dir);
-      expect(counts).toEqual({
-        vulnerabilityBlockers: 2,
-        vulnerabilityFindings: 3,
-        transitiveRiskSignals: 17,
-        workspaceExcludedTransitiveSignals: 3,
-        transitiveMetadataFailures: 1,
-        ownershipLockfilePackages: 101,
-        ownershipBuildRiskPackages: 8,
-        dependencyFileChanges: 4,
-        dependencyAddedPackages: 5,
-        dependencyRemovedPackages: 6,
-        dependencyChangedPackages: 7,
-      });
+        const summary = renderDependencyEvidenceSummary({
+          releaseTag: "v2026.5.13",
+          releaseSha: "abc123",
+          baseRef: "v2026.5.1",
+          counts,
+        });
+        expect(summary).toContain("- Transitive manifest reported risk signals: 17");
+        expect(summary).toContain("- Dependency change baseline: `v2026.5.1`");
+        expect(summary).toContain("- Resolved package changes: +5 -6 changed 7");
 
-      const summary = renderDependencyEvidenceSummary({
-        releaseTag: "v2026.5.13",
-        releaseSha: "abc123",
-        baseRef: "v2026.5.1",
-        counts,
-      });
-      expect(summary).toContain("- npm advisory vulnerability hard blockers: 2");
-      expect(summary).toContain("- Transitive manifest reported risk signals: 17");
-      expect(summary).toContain("- Dependency change baseline: `v2026.5.1`");
-      expect(summary).toContain("- Resolved package changes: +5 -6 changed 7");
-
-      const stepSummary = renderDependencyEvidenceStepSummary({
-        evidenceArtifactName: "openclaw-release-dependency-evidence-v2026.5.13",
-        baseRef: "v2026.5.1",
-        counts,
-      });
-      expect(stepSummary).toContain(
-        "- Evidence artifact: `openclaw-release-dependency-evidence-v2026.5.13`",
-      );
-      expect(stepSummary).toContain("- npm advisory vulnerability hard blockers: `2`");
-
-      await expect(
-        readFile(path.join(dir, "dependency-vulnerability-gate.json"), "utf8"),
-      ).resolves.toContain("GHSA-blocker");
-    } finally {
-      await rm(dir, { force: true, recursive: true });
-    }
-  });
+        const stepSummary = renderDependencyEvidenceStepSummary({
+          evidenceArtifactName: "openclaw-release-dependency-evidence-v2026.5.13",
+          baseRef: "v2026.5.1",
+          counts,
+        });
+        expect(stepSummary).toContain(
+          "- Evidence artifact: `openclaw-release-dependency-evidence-v2026.5.13`",
+        );
+        for (const rendered of [summary, stepSummary]) {
+          expect(rendered).toContain("- npm advisory coverage: checked");
+          expect(rendered).toContain(
+            `- Upstream public repository advisory coverage: ${upstream.status}`,
+          );
+          expect(rendered).toContain("- Upstream source: `github-public-repository-advisories`");
+          expect(rendered).toContain(
+            `- Upstream package versions mapped: ${upstream.mappedPackageVersions}/101`,
+          );
+          expect(rendered).toContain(
+            `- Upstream repositories checked: ${upstream.checkedRepositories}/2`,
+          );
+          expect(rendered).toContain("- Advisory vulnerability hard blockers: 2");
+          expect(rendered).toContain("- Advisory vulnerability total findings: 3");
+          expect(rendered).toContain("- Upstream-only vulnerability findings: 2");
+          expect(rendered).toContain(`- Upstream coverage issues: ${upstream.issues.length}`);
+          for (const { subject, reason } of upstream.issues) {
+            expect(rendered).toContain(`  - ${subject}: ${reason}`);
+          }
+          expect(rendered).toContain(
+            "Coverage is limited to these advisory sources; zero findings do not prove that dependencies are unaffected.",
+          );
+        }
+      } finally {
+        await rm(dir, { force: true, recursive: true });
+      }
+    },
+  );
 });

--- a/test/scripts/pnpm-audit-prod.test.ts
+++ b/test/scripts/pnpm-audit-prod.test.ts
@@ -465,11 +465,13 @@ snapshots:
     await expect(request).rejects.toThrow(/Bulk advisory response body was empty/u);
   });
 
-  it("returns a failing exit code when bulk advisories include high severity findings", async () => {
-    const tempDir = await mkdtemp(path.join(tmpdir(), "openclaw-audit-prod-"));
-    await writeFile(
-      path.join(tempDir, "pnpm-lock.yaml"),
-      `lockfileVersion: '9.0'
+  it.each([false, true])(
+    "reports npm-only coverage with the audit outcome (blocked %s)",
+    async (blocked) => {
+      const tempDir = await mkdtemp(path.join(tmpdir(), "openclaw-audit-prod-"));
+      await writeFile(
+        path.join(tempDir, "pnpm-lock.yaml"),
+        `lockfileVersion: '9.0'
 
 importers:
   .:
@@ -480,53 +482,74 @@ importers:
 snapshots:
   axios@1.0.0: {}
 `,
-      "utf8",
-    );
+        "utf8",
+      );
 
-    try {
-      const stdoutChunks: string[] = [];
-      const stderrChunks: string[] = [];
-      const exitCode = await runPnpmAuditProd({
-        rootDir: tempDir,
-        fetchImpl: async () =>
-          new Response(
-            JSON.stringify({
-              axios: [
-                {
-                  id: "GHSA-test",
-                  severity: "high",
-                  title: "test issue",
-                  vulnerable_versions: "<=1.0.0",
-                  url: "https://github.com/advisories/GHSA-test",
+      try {
+        const stdoutChunks: string[] = [];
+        const stderrChunks: string[] = [];
+        const exitCode = await runPnpmAuditProd({
+          rootDir: tempDir,
+          fetchImpl: async (input) => {
+            expect(String(input)).toMatch(/\/-\/npm\/v1\/security\/advisories\/bulk$/u);
+            return new Response(
+              JSON.stringify(
+                blocked
+                  ? {
+                      axios: [
+                        {
+                          id: "GHSA-test",
+                          severity: "high",
+                          title: "test issue",
+                          vulnerable_versions: "<=1.0.0",
+                          url: "https://github.com/advisories/GHSA-test",
+                        },
+                      ],
+                    }
+                  : {},
+              ),
+              {
+                status: 200,
+                headers: {
+                  "content-type": "application/json",
                 },
-              ],
-            }),
-            {
-              status: 200,
-              headers: {
-                "content-type": "application/json",
               },
+            );
+          },
+          stdout: {
+            write(chunk: string) {
+              stdoutChunks.push(chunk);
+              return true;
             },
-          ),
-        stdout: {
-          write(chunk: string) {
-            stdoutChunks.push(chunk);
-            return true;
-          },
-        } as NodeJS.WriteStream,
-        stderr: {
-          write(chunk: string) {
-            stderrChunks.push(chunk);
-            return true;
-          },
-        } as NodeJS.WriteStream,
-      });
+          } as NodeJS.WriteStream,
+          stderr: {
+            write(chunk: string) {
+              stderrChunks.push(chunk);
+              return true;
+            },
+          } as NodeJS.WriteStream,
+        });
 
-      expect(exitCode).toBe(1);
-      expect(stdoutChunks).toStrictEqual([]);
-      expect(stderrChunks.join("")).toContain("Found 1 high or higher advisories");
-    } finally {
-      await rm(tempDir, { recursive: true, force: true });
-    }
-  });
+        expect(exitCode).toBe(blocked ? 1 : 0);
+        if (blocked) {
+          expect(stdoutChunks).toStrictEqual([]);
+          expect(stderrChunks.join("")).toContain(
+            "Found 1 high or higher advisories from npm bulk",
+          );
+          expect(stderrChunks.join("")).toContain("upstream repository advisories not checked");
+        } else {
+          expect(stderrChunks).toStrictEqual([]);
+          expect(stdoutChunks.join("")).toContain(
+            "No matching high or higher advisories returned by npm bulk",
+          );
+          expect(stdoutChunks.join("")).toContain(
+            "Upstream repository advisories were not checked",
+          );
+          expect(stdoutChunks.join("")).toContain("not comprehensive vulnerability clearance");
+        }
+      } finally {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/test/scripts/upstream-repository-advisories.test.ts
+++ b/test/scripts/upstream-repository-advisories.test.ts
@@ -1,0 +1,605 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchPublishedRepositoryAdvisories } from "../../scripts/lib/upstream-repository-advisories.mts";
+
+const REGISTRY = "https://registry.npmjs.org";
+const REPOSITORY = "fixture/packages";
+const ADVISORY_ID = "GHSA-2222-3333-4444";
+const NEXT_PAGE =
+  '<https://api.github.com/repositories/42/security-advisories?state=published&per_page=100&after=next%2Bcursor>; rel="next"';
+
+type Handler = (url: URL, init: RequestInit | undefined) => Response | Promise<Response>;
+
+function vulnerability(range: unknown, name: unknown = "fixture", ecosystem = "npm") {
+  return { package: { ecosystem, name }, vulnerable_version_range: range };
+}
+
+function advisory(range: unknown = "< 2.0.0", fields: Record<string, unknown> = {}) {
+  return {
+    ghsa_id: ADVISORY_ID,
+    state: "published",
+    withdrawn_at: null,
+    severity: "high",
+    summary: "Fixture vulnerability",
+    vulnerabilities: [vulnerability(range)],
+    ...fields,
+  };
+}
+
+function manifest(url: URL, repository: unknown = `git+https://github.com/${REPOSITORY}.git`) {
+  const [name, version] = url.pathname.slice(1).split("/").map(decodeURIComponent);
+  return Response.json({ name, version, repository });
+}
+
+function createSourceFetch(
+  handlers: {
+    manifest?: Handler;
+    repository?: Handler;
+    page?: Handler;
+  } = {},
+) {
+  const calls: Array<{ url: URL; init: RequestInit | undefined }> = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = new URL(String(input));
+    calls.push({ url, init });
+    if (url.origin === REGISTRY) {
+      return handlers.manifest ? handlers.manifest(url, init) : manifest(url);
+    }
+    if (url.origin !== "https://api.github.com") {
+      throw new Error(`Unexpected request origin: ${url.origin}`);
+    }
+    if (url.pathname.endsWith("/security-advisories")) {
+      return handlers.page ? handlers.page(url, init) : Response.json([]);
+    }
+    return handlers.repository
+      ? handlers.repository(url, init)
+      : Response.json({ id: 42, full_name: REPOSITORY, private: false, visibility: "public" });
+  };
+  return { calls, fetchImpl };
+}
+
+function scan(fetchImpl: typeof fetch, payload: Record<string, string[]> = { fixture: ["1.0.0"] }) {
+  return fetchPublishedRepositoryAdvisories({ payload, registryBaseUrl: REGISTRY, fetchImpl });
+}
+
+beforeEach(() => {
+  vi.stubEnv("GH_TOKEN", undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("published upstream repository advisories", () => {
+  it("discovers exact scoped versions once and verifies a shared repository before scanning", async () => {
+    const source = createSourceFetch({
+      manifest: (url) =>
+        manifest(
+          url,
+          url.pathname.includes("%2F")
+            ? { url: "git+https://github.com/FIXTURE/packages.git", directory: "packages/leaf" }
+            : "github:Fixture/Packages",
+        ),
+      page: () =>
+        Response.json([
+          advisory(">= 0", {
+            vulnerabilities: [vulnerability(">= 0"), vulnerability("= 1.2.3", "@scope/leaf")],
+          }),
+        ]),
+    });
+    const report = await scan(source.fetchImpl, {
+      "@scope/leaf": ["1.2.3", "1.2.3"],
+      fixture: ["1.0.0", "0.9.0"],
+    });
+
+    expect(source.calls.map(({ url }) => url.pathname)).toEqual([
+      "/%40scope%2Fleaf/1.2.3",
+      "/fixture/0.9.0",
+      "/fixture/1.0.0",
+      "/repos/fixture/packages",
+      "/repos/fixture/packages/security-advisories",
+    ]);
+    expect(report.advisories).toMatchObject([
+      { packageName: "@scope/leaf", matchedVersions: ["1.2.3"] },
+      { packageName: "fixture", matchedVersions: ["0.9.0", "1.0.0"] },
+    ]);
+    expect(report.coverage).toMatchObject({
+      status: "checked",
+      packageVersions: 3,
+      mappedPackageVersions: 3,
+      repositories: 1,
+      checkedRepositories: 1,
+      issues: [],
+    });
+  });
+
+  it("sends the token only to fixed GitHub requests and refuses redirects on every request", async () => {
+    vi.stubEnv("GH_TOKEN", "synthetic-upstream-test-token");
+    const source = createSourceFetch();
+    await scan(source.fetchImpl);
+
+    expect(source.calls).toHaveLength(3);
+    for (const { url, init } of source.calls) {
+      const headers = new Headers(init?.headers);
+      expect(init?.redirect).toBe("error");
+      expect(headers.get("authorization")).toBe(
+        url.origin === REGISTRY ? null : "Bearer synthetic-upstream-test-token",
+      );
+      if (url.origin !== REGISTRY) {
+        expect(url.origin).toBe("https://api.github.com");
+      }
+    }
+  });
+
+  it("does not attach the GitHub token to a registry lookup even when its origin is GitHub", async () => {
+    vi.stubEnv("GH_TOKEN", "synthetic-upstream-test-token");
+    const headers: Headers[] = [];
+    const report = await fetchPublishedRepositoryAdvisories({
+      payload: { fixture: ["1.0.0"] },
+      registryBaseUrl: "https://api.github.com",
+      fetchImpl: async (_input, init) => {
+        headers.push(new Headers(init?.headers));
+        return Response.json({ name: "fixture", version: "1.0.0" });
+      },
+    });
+    expect(headers).toHaveLength(1);
+    expect(expectDefined(headers[0], "registry request headers").has("authorization")).toBe(false);
+    expect(report.coverage.status).toBe("partial");
+  });
+
+  it("records unsupported locked versions without requesting registry metadata", async () => {
+    const source = createSourceFetch();
+    const report = await scan(source.fetchImpl, { fixture: ["git+https://example.invalid/pkg"] });
+    expect(source.calls).toEqual([]);
+    expect(report.coverage).toMatchObject({
+      status: "partial",
+      issues: [
+        { subject: "fixture@git+https://example.invalid/pkg", reason: "unsupported-version" },
+      ],
+    });
+  });
+
+  it.each([
+    {
+      name: "wrong package",
+      data: { name: "another", version: "1.0.0" },
+      reason: "invalid-response",
+    },
+    {
+      name: "latest instead of locked version",
+      data: { name: "fixture", version: "2.0.0" },
+      reason: "invalid-response",
+    },
+    {
+      name: "missing repository",
+      data: { name: "fixture", version: "1.0.0" },
+      reason: "unsupported-repository",
+    },
+    {
+      name: "non-GitHub",
+      repository: "https://gitlab.com/fixture/packages",
+      reason: "unsupported-repository",
+    },
+    {
+      name: "userinfo host confusion",
+      repository: "https://github.com@evil.example/fixture/packages",
+      reason: "unsupported-repository",
+    },
+    {
+      name: "credential-bearing URL",
+      repository: "https://user:password@github.com/fixture/packages",
+      reason: "unsupported-repository",
+    },
+    {
+      name: "branch URL",
+      repository: "https://github.com/fixture/packages/tree/main",
+      reason: "unsupported-repository",
+    },
+  ])("does not scan $name registry metadata", async (entry) => {
+    const source = createSourceFetch({
+      manifest: (url) =>
+        "data" in entry ? Response.json(entry.data) : manifest(url, entry.repository),
+    });
+    const report = await scan(source.fetchImpl);
+    expect(source.calls).toHaveLength(1);
+    expect(report.advisories).toEqual([]);
+    expect(report.coverage).toMatchObject({
+      status: "partial",
+      mappedPackageVersions: 0,
+      issues: [{ subject: "fixture@1.0.0", reason: entry.reason }],
+    });
+  });
+
+  it.each([
+    { name: "private", data: { id: 42, private: true }, reason: "repository-not-public" },
+    { name: "missing visibility", data: { id: 42 }, reason: "repository-not-public" },
+    { name: "malformed", data: [], reason: "repository-not-public" },
+    { name: "invalid ID", data: { id: "42", private: false }, reason: "invalid-response" },
+  ])("does not request advisories from $name repository metadata", async ({ data, reason }) => {
+    const source = createSourceFetch({ repository: () => Response.json(data) });
+    const report = await scan(source.fetchImpl);
+    expect(source.calls.map(({ url }) => url.pathname)).toEqual([
+      "/fixture/1.0.0",
+      "/repos/fixture/packages",
+    ]);
+    expect(report.coverage).toMatchObject({
+      status: "partial",
+      checkedRepositories: 0,
+      issues: [{ subject: REPOSITORY, reason }],
+    });
+  });
+
+  it("reports a redirect without requesting its destination", async () => {
+    const source = createSourceFetch({
+      repository: () =>
+        new Response(null, {
+          status: 302,
+          headers: { location: "https://evil.example/advisories" },
+        }),
+    });
+    const report = await scan(source.fetchImpl);
+    expect(source.calls).toHaveLength(2);
+    expect(source.calls.every(({ init }) => init?.redirect === "error")).toBe(true);
+    expect(report.coverage).toMatchObject({
+      status: "partial",
+      issues: [{ subject: REPOSITORY, reason: "request-failed" }],
+    });
+  });
+
+  it.each([
+    {
+      range: ">= 0",
+      versions: ["0.0.0-alpha", "0.0.0", "1.0.0"],
+      matched: ["0.0.0", "0.0.0-alpha", "1.0.0"],
+    },
+    { range: "> 0", versions: ["0.0.0", "0.0.1", "0.1.0"], matched: ["0.0.1", "0.1.0"] },
+    { range: "= 1.0.0", versions: ["1.0.0-rc.1", "1.0.0", "1.0.1"], matched: ["1.0.0"] },
+    { range: "= 1.0.0-rc.1", versions: ["1.0.0-rc.1", "1.0.0"], matched: ["1.0.0-rc.1"] },
+    {
+      range: ">= 1.0.0, < 2.0.0",
+      versions: ["0.9.0", "1.0.0", "1.5.0-beta.1", "2.0.0"],
+      matched: ["1.0.0", "1.5.0-beta.1"],
+    },
+    {
+      range: "> 1.0.0, <= 2.0.0",
+      versions: ["1.0.0", "1.0.1", "2.0.0", "2.0.1"],
+      matched: ["1.0.1", "2.0.0"],
+    },
+    { range: "< 1.0.0", versions: ["0.9.0-beta.1", "1.0.0"], matched: ["0.9.0-beta.1"] },
+  ])(
+    "compares documented $range bounds without installer prerelease exclusions",
+    async ({ range, versions, matched }) => {
+      const source = createSourceFetch({ page: () => Response.json([advisory(range)]) });
+      const report = await scan(source.fetchImpl, { fixture: versions });
+      expect(report.advisories).toMatchObject([{ id: ADVISORY_ID, matchedVersions: matched }]);
+      expect(report.advisories).toHaveLength(1);
+      expect(report.coverage.status).toBe("checked");
+    },
+  );
+
+  it("matches only the declared npm package, ignores withdrawn entries, and normalizes medium severity", async () => {
+    const source = createSourceFetch({
+      page: () =>
+        Response.json([
+          advisory("< 2.0.0", {
+            severity: "medium",
+            vulnerabilities: [
+              vulnerability("< 2.0.0"),
+              vulnerability("< 2.0.0", "Fixture"),
+              vulnerability("< 2.0.0", "fixture", "pip"),
+              vulnerability("< 2.0.0", "other"),
+            ],
+          }),
+          advisory("< 2.0.0", { withdrawn_at: "2026-01-01T00:00:00Z" }),
+        ]),
+    });
+    const report = await scan(source.fetchImpl);
+    expect(report.advisories).toMatchObject([
+      {
+        packageName: "fixture",
+        severity: "moderate",
+        matchedVersions: ["1.0.0"],
+        url: `https://github.com/${REPOSITORY}/security/advisories/${ADVISORY_ID}`,
+      },
+    ]);
+    expect(report.advisories).toHaveLength(1);
+    expect(report.coverage.status).toBe("checked");
+  });
+
+  it.each([
+    { name: "unpublished", fields: { state: "draft" } },
+    { name: "unknown severity", fields: { severity: null } },
+    {
+      name: "missing npm package identity",
+      fields: { vulnerabilities: [vulnerability("< 2.0.0", null)] },
+    },
+  ])("reports $name advisory evidence as incomplete rather than unaffected", async ({ fields }) => {
+    const source = createSourceFetch({ page: () => Response.json([advisory("< 2.0.0", fields)]) });
+    const report = await scan(source.fetchImpl);
+    expect(report.advisories).toEqual([]);
+    expect(report.coverage.status).toBe("partial");
+    expect(report.coverage.issues).toContainEqual(
+      expect.objectContaining({ reason: "invalid-advisory" }),
+    );
+  });
+
+  it.each([
+    null,
+    "",
+    ">= 1.0.0 < 2.0.0",
+    ">= 1.0.0, < 2.0.0; >= 3.0.0, < 4.0.0",
+    "^1.0.0",
+    ">= 1.0",
+    "< 2.0.0, > 1.0.0",
+    "= " + "1".repeat(257),
+  ])("retains a confirmed match when a sibling range is malformed (%s)", async (range) => {
+    const source = createSourceFetch({
+      page: () =>
+        Response.json([
+          advisory("< 2.0.0", {
+            vulnerabilities: [vulnerability("< 2.0.0"), vulnerability(range)],
+          }),
+        ]),
+    });
+    const report = await scan(source.fetchImpl);
+    expect(report.advisories).toMatchObject([{ id: ADVISORY_ID, matchedVersions: ["1.0.0"] }]);
+    expect(report.coverage).toMatchObject({
+      status: "partial",
+      issues: [{ subject: `fixture#${ADVISORY_ID}`, reason: "invalid-range" }],
+    });
+  });
+
+  it("uses repository-id pagination cursors without changing the verified target or published-state filter", async () => {
+    const source = createSourceFetch({
+      page: (url) =>
+        url.searchParams.has("after")
+          ? Response.json([])
+          : Response.json([advisory()], { headers: { link: NEXT_PAGE } }),
+    });
+    const report = await scan(source.fetchImpl);
+    const pages = source.calls.filter(({ url }) => url.pathname.endsWith("/security-advisories"));
+    expect(pages).toHaveLength(2);
+    const nextPage = expectDefined(pages[1], "next advisory page");
+    expect(nextPage.url.pathname).toBe("/repos/fixture/packages/security-advisories");
+    expect(Object.fromEntries(nextPage.url.searchParams)).toEqual({
+      state: "published",
+      per_page: "100",
+      after: "next+cursor",
+    });
+    expect(report.advisories).toHaveLength(1);
+    expect(report.coverage.status).toBe("checked");
+  });
+
+  it.each([
+    "https://evil.example/repositories/42/security-advisories?after=next",
+    "https://api.github.com/repos/another/package/security-advisories?state=published&after=next",
+    "https://api.github.com/repositories/999/security-advisories?state=published&after=next",
+    "https://api.github.com/repositories/42/security-advisories?state=draft&after=next",
+    "https://user:password@api.github.com/repositories/42/security-advisories?state=published&after=next",
+  ])("does not continue an untrusted pagination link (%s)", async (next) => {
+    const source = createSourceFetch({
+      page: (url) =>
+        Response.json(url.searchParams.has("after") ? [] : [advisory()], {
+          headers: url.searchParams.has("after") ? {} : { link: `<${next}>; rel="next"` },
+        }),
+    });
+    const report = await scan(source.fetchImpl);
+    expect(
+      source.calls.filter(({ url }) => url.pathname.endsWith("/security-advisories")),
+    ).toHaveLength(1);
+    expect(report.advisories).toHaveLength(1);
+    expect(report.coverage).toMatchObject({
+      status: "partial",
+      checkedRepositories: 0,
+      issues: [{ subject: REPOSITORY, reason: "invalid-pagination" }],
+    });
+  });
+
+  it.each(["unavailable", "oversized", "invalid-json"])(
+    "preserves earlier findings when a later page is %s",
+    async (failure) => {
+      const source = createSourceFetch({
+        page: (url) => {
+          if (!url.searchParams.has("after")) {
+            return Response.json([advisory()], { headers: { link: NEXT_PAGE } });
+          }
+          if (failure === "unavailable") {
+            return new Response(null, { status: 503 });
+          }
+          if (failure === "oversized") {
+            return Response.json(Array.from({ length: 101 }, () => advisory()));
+          }
+          return new Response("{");
+        },
+      });
+      const report = await scan(source.fetchImpl);
+      expect(report.advisories).toHaveLength(1);
+      expect(report.coverage.status).toBe("partial");
+      expect(report.coverage.checkedRepositories).toBe(0);
+      expect(report.coverage.issues).toHaveLength(1);
+    },
+  );
+
+  it.each(["repeated cursor", "page budget"])(
+    "stops at the %s without discarding findings",
+    async (limit) => {
+      let pages = 0;
+      const source = createSourceFetch({
+        page: () => {
+          pages += 1;
+          const cursor = limit === "repeated cursor" ? "same" : String(pages);
+          return Response.json(pages === 1 ? [advisory()] : [], {
+            headers: {
+              link: `<https://api.github.com/repositories/42/security-advisories?state=published&after=${cursor}>; rel="next"`,
+            },
+          });
+        },
+      });
+      const report = await scan(source.fetchImpl);
+      expect(pages).toBe(limit === "repeated cursor" ? 2 : 5);
+      expect(report.advisories).toHaveLength(1);
+      expect(report.coverage).toMatchObject({
+        status: "partial",
+        checkedRepositories: 0,
+        issues: [
+          {
+            subject: REPOSITORY,
+            reason: limit === "repeated cursor" ? "invalid-pagination" : "budget-exhausted",
+          },
+        ],
+      });
+    },
+  );
+
+  it("cancels an oversized streamed page and retains earlier findings", async () => {
+    const cancel = vi.fn();
+    const source = createSourceFetch({
+      page: (url) => {
+        if (!url.searchParams.has("after")) {
+          return Response.json([advisory()], { headers: { link: NEXT_PAGE } });
+        }
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new Uint8Array(2 * 1024 * 1024 + 1));
+            },
+            cancel,
+          }),
+        );
+      },
+    });
+    const report = await scan(source.fetchImpl);
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(report.advisories).toHaveLength(1);
+    expect(report.coverage.status).toBe("partial");
+    expect(report.coverage.checkedRepositories).toBe(0);
+  });
+
+  it.each(["request", "run"])(
+    "settles a stalled page at the %s deadline and preserves findings",
+    async (deadline) => {
+      let now = 0;
+      vi.spyOn(performance, "now").mockImplementation(() => now);
+      const realSetTimeout = globalThis.setTimeout;
+      const requestedTimeouts: Array<number | undefined> = [];
+      // Exercise the real timeout race without a 15-second wait or shared fake timers.
+      vi.spyOn(globalThis, "setTimeout").mockImplementation((callback, milliseconds, ...args) => {
+        requestedTimeouts.push(milliseconds);
+        return realSetTimeout(callback, milliseconds === 15_000 ? 1 : milliseconds, ...args);
+      });
+      const cancel = vi.fn();
+      const source = createSourceFetch({
+        page: (url) => {
+          if (!url.searchParams.has("after")) {
+            if (deadline === "run") {
+              now = 5 * 60_000 - 5;
+            }
+            return Response.json([advisory()], { headers: { link: NEXT_PAGE } });
+          }
+          if (deadline === "request") {
+            // A transport that ignores AbortSignal must not prevent the report from settling.
+            return new Promise<Response>(() => {});
+          }
+          now = 5 * 60_000;
+          return new Response(new ReadableStream<Uint8Array>({ cancel }));
+        },
+      });
+      const report = await scan(source.fetchImpl);
+      expect(requestedTimeouts.at(-1)).toBe(deadline === "run" ? 5 : 15_000);
+      expect(cancel).toHaveBeenCalledTimes(deadline === "run" ? 1 : 0);
+      expect(report.advisories).toHaveLength(1);
+      expect(report.coverage).toMatchObject({
+        status: "partial",
+        checkedRepositories: 0,
+        issues: [
+          {
+            subject: REPOSITORY,
+            reason: deadline === "run" ? "budget-exhausted" : "request-failed",
+          },
+        ],
+      });
+    },
+  );
+
+  it("bounds input and total requests instead of silently dropping uninspected packages", async () => {
+    const versions = Array.from({ length: 2501 }, (_, index) => `1.0.${index}`);
+    const source = createSourceFetch({
+      manifest: (url) =>
+        manifest(url, `https://github.com/fixture/package-${url.pathname.split("/").at(-1)}`),
+    });
+    const report = await scan(source.fetchImpl, { fixture: versions });
+    expect(source.calls.filter(({ url }) => url.origin === REGISTRY)).toHaveLength(2500);
+    expect(source.calls).toHaveLength(4000);
+    expect(report.coverage).toMatchObject({
+      status: "partial",
+      packageVersions: 2501,
+      mappedPackageVersions: 2500,
+    });
+    expect(report.coverage.issues).toContainEqual({
+      subject: "1 package versions not inspected",
+      reason: "budget-exhausted",
+    });
+    expect(
+      report.coverage.issues.some(
+        ({ subject, reason }) =>
+          subject.startsWith("fixture/package-") && reason === "budget-exhausted",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps metadata and repository requests within four concurrent operations", async () => {
+    let active = 0;
+    let peak = 0;
+    const source = createSourceFetch({
+      manifest: (url) => manifest(url, `https://github.com/fixture/${url.pathname.split("/")[1]}`),
+    });
+    const fetchImpl: typeof fetch = async (input, init) => {
+      active += 1;
+      peak = Math.max(peak, active);
+      try {
+        await Promise.resolve();
+        return await source.fetchImpl(input, init);
+      } finally {
+        active -= 1;
+      }
+    };
+    const payload = Object.fromEntries(
+      Array.from({ length: 8 }, (_, index) => [`package-${index}`, ["1.0.0"]]),
+    );
+    const report = await scan(fetchImpl, payload);
+    expect(peak).toBe(4);
+    expect(active).toBe(0);
+    expect(report.coverage.status).toBe("checked");
+    expect(report.coverage.checkedRepositories).toBe(8);
+  });
+
+  it.each([
+    { code: 403, remaining: "0", reason: "rate-limited" },
+    { code: 429, remaining: "0", reason: "rate-limited" },
+    { code: 403, remaining: "100", reason: "request-failed" },
+    { code: 401, remaining: "100", reason: "request-failed" },
+  ])(
+    "stops scheduling GitHub work after HTTP $code (remaining $remaining)",
+    async ({ code, remaining, reason: expectedReason }) => {
+      const source = createSourceFetch({
+        manifest: (url) =>
+          manifest(url, `https://github.com/fixture/${url.pathname.split("/")[1]}`),
+        page: () =>
+          new Response(null, { status: code, headers: { "x-ratelimit-remaining": remaining } }),
+      });
+      const payload = Object.fromEntries(
+        Array.from({ length: 8 }, (_, index) => [`package-${index}`, ["1.0.0"]]),
+      );
+      const report = await scan(source.fetchImpl, payload);
+      expect(source.calls.filter(({ url }) => url.origin === REGISTRY)).toHaveLength(8);
+      expect(
+        source.calls.some(({ url }) =>
+          /\/repos\/fixture\/package-[4-7](?:\/|$)/u.test(url.pathname),
+        ),
+      ).toBe(false);
+      expect(report.coverage.status).toBe("partial");
+      expect(report.coverage.issues.some(({ reason }) => reason === expectedReason)).toBe(true);
+    },
+  );
+});


### PR DESCRIPTION
Closes #133685 — dependency audits miss published upstream advisory sources.

Related: [the merged fast-uri dependency repair, #133572](https://github.com/openclaw/openclaw/pull/133572). This is the separate generic feed-coverage follow-up, not another dependency bump.

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer branch and is takeover-ready.

</details>

## What Problem This Solves

Resolves a problem where maintainers receive a green dependency audit despite published high-severity upstream advisories missing from npm's bulk feed. Fresh npm queries returned `{}` for affected fast-uri 4.1.2 and 3.1.5 while the upstream repository had four published high advisories. The dependency versions were repaired separately; the audit-source gap remained.

This is confirmed coverage/reporting behavior, not a claim of demonstrated OpenClaw exploitability or comprehensive vulnerability clearance.

## Why This Change Was Made

Keep the existing npm audit and add one bounded release-only adapter for published advisories from verified public GitHub repositories. Discover repositories from **exact locked version manifests**, match the declared npm package and affected ranges, and feed confirmed upstream-only matches into the existing per-lock/runtime severity policy. Do not substitute a package-specific rule or speculative fallback. OSV was checked live and missed the same version controls; its GHSA importer reads GitHub's reviewed database rather than enumerating repository advisories.

The production pre-commit hook and ordinary CI stay **zero-install and npm-only**, with explicit source-limited wording. Release evidence uses the existing job's approved `GH_TOKEN` only for fixed GitHub API requests; registry requests and redirects never receive it. Repository visibility is verified before advisory queries, so private-repository and unpublished advisories are not requested. Pagination is bound to the verified repository identity and published state. HTTP 401/403/429 stops subsequent GitHub work, including secondary limits with primary quota remaining.

The adapter reuses the existing timeout owner, bounded-response reader, concurrency helper, and installed semver implementation. Fixed bounds are four concurrent requests, 2,500 package versions, 4,000 requests, five minutes per run, 15 seconds and 2 MiB per request, five pages of 100 advisories per repository, and 10,000 advisories per run. Unsupported metadata, malformed ranges, unavailable sources, and exhausted budgets remain **partial coverage**, without erasing confirmed findings or inventing an unaffected result.

Source coverage propagates through JSON, Markdown, console output, and release summaries. The evidence-directory output is published before report execution and the artifact upload runs on failure, so a blocking advisory retains its evidence while the release still fails.

## User Impact

Release maintainers can see and block matching public-upstream advisories omitted by npm, with each finding attributed to its source and lockfile. Routine commits retain their fast npm-only check instead of acquiring a repository crawler. Zero findings, including a fully read repository with unparseable advisory ranges, no longer imply comprehensive clearance.

No dependency pins, overrides, new dependencies, application-runtime behavior, SDK work, OpenClaw configuration, or persistent stores change. The only environment wiring is the explicitly approved existing release-job token. No new secret or private advisory workflow is introduced. The [dependency-locking guide](https://docs.openclaw.ai/gateway/security/dependency-locking) documents scope, limits, and interpretation.

Production/tooling LOC: **+616/-32 (net +584)**. Tests: **+1,029/-150 (net +879)**. Documentation: **+16/-2**. Positive tooling growth implements the new independent source capability and bounded coverage reporting; it does not duplicate the severity engine or add a cache/store/fallback stack. The old private timeout function is replaced by its shared owner, not retained as an alias.

## Evidence

**Before/after regression:** an empty npm result plus a matching published upstream advisory failed before the repair because the gate returned no blocker. The repaired gate blocks the affected tool version without tainting a patched product version. Additional tests preserve graph-local GHSA identity, unknown/malformed data, earlier-page findings, exact scoped metadata, public visibility and pagination identity, credential isolation, request/page/input/byte/time/concurrency bounds, and throttling/credential-denial behavior.

**129 focused tests passed** on Node 24.20.0:

```bash
node scripts/run-vitest.mjs test/scripts/dependency-vulnerability-gate.test.ts test/scripts/pnpm-audit-prod.test.ts test/scripts/generate-dependency-release-evidence.test.ts test/scripts/upstream-repository-advisories.test.ts
```

**Complete changed-file gate passed**, including script/root-test typechecks, script lint, formatting, erasability, dependency-pin/patch guards, and coercion/boundary guards:

```bash
node scripts/check-changed.mjs -- scripts/lib/upstream-repository-advisories.mts scripts/dependency-vulnerability-gate.mts scripts/pre-commit/pnpm-audit-prod.mjs scripts/generate-dependency-release-evidence.mts test/scripts/dependency-vulnerability-gate.test.ts test/scripts/pnpm-audit-prod.test.ts test/scripts/generate-dependency-release-evidence.test.ts test/scripts/upstream-repository-advisories.test.ts .github/workflows/openclaw-npm-release.yml docs/gateway/security/dependency-locking.md
```

**Workflow validation passed:**

```bash
node --import ./scripts/tsx.mjs scripts/check-workflows.mts
```

Initial strict type/lint failures were fixed at their owners; no assertions, baselines, or guards were weakened. A further failing-before/passing-after regression proves secondary HTTP 403 limits and HTTP 401 credential failures stop subsequent repository requests instead of continuing through the graph.

**Live external-API and actual CLI proof:** at 2026-08-31 00:36 UTC, isolated three-lock fixtures using real npm and authenticated public GitHub APIs produced:

- Affected product 4.1.2 + Vercel-tool 3.1.5: **process exit 1**, eight lock-attributed blockers representing the four upstream GHSAs, all sourced from `github-repository` while npm returned no matching records.
- Patched product 4.1.3 + tool 3.1.6: **process exit 0**, zero confirmed blockers, and an explicit **partial** warning for five older malformed upstream ranges. This is not comprehensive clearance.

The production hook also ran in an isolated directory containing only its exact dependency-free source closure, **without node_modules**, and printed its npm-only coverage caveat. A real generator CLI regression with a failing report command proves both the nonzero exit and retained artifact-directory output; the same scenario against the original generator lost that output.

Fresh pre-commit **Codex autoreview: scoped-clean, no accepted/actionable P0 findings**. Security and release owner involvement was verified before editing and publication. The task-owner modules were unchanged on the inspected current-main baseline before synchronization. No hosted release or publication workflow was dispatched, and no full-graph upstream API scan or new package-installability claim is made.

### Pre-merge verification and owner decision

The listed-owner decision is **approve the bounded public-upstream source and existing-token wiring**, including using confirmed matches in the existing severity policy. This acceptance was explicit and owner authority was verified. It addresses the owner-decision and rank-up request in the [ClawSweeper review](https://github.com/openclaw/openclaw/pull/133688#issuecomment-5472597382), which found no code or security defects.

[Exact-head CI run 33347280346](https://github.com/openclaw/openclaw/actions/runs/33347280346) completed successfully for `685d70a83effd6dee9698353e076531019b358fa`, with `openclaw/ci-gate` SUCCESS. Frozen installation, all 129 focused tests, and the full changed-file gate passed again after branch synchronization. Native preparation completed in hosted-gate mode at 2026-08-31 01:56 UTC with the same head; it skipped pushing because the remote already matched. An initial shared-main-ref fetch race was recovered only after confirming the exact operation's processes had stopped; no code or CI failure was bypassed.

To close the review environment's DNS-limited API proof gap, the actual CLI/live npm and authenticated public GitHub scenarios were repeated on that exact head at **2026-08-31 01:41 UTC**: affected controls again exit 1 with the same four upstream GHSAs/eight lock-attributed blockers; patched controls exit 0 with zero confirmed blockers and the same explicit partial coverage for malformed historical ranges.

The serialized-data marker concerns **regenerated release evidence, not a runtime store**. The generator recreates the output directory and invokes/reads the gate from the same release target checkout. The previous parent reader was executed against a newly generated candidate report and preserved all blocker/finding counts; machine report selectors and manifest `schemaVersion: 1` are unchanged. The actual archive comparator accepted the candidate reports across ZIP encodings and still rejected changed report bytes, preserving immutable historical evidence. Downstream publication copies/archives the reports rather than re-rendering their JSON. No SQLite schema, doctor migration, or operational-state change is present.

Compatibility is claimed for that canonical paired flow and inspected consumers—not manually mixing a new renderer with old saved reports/another checkout's old gate, or unknown out-of-repo strict readers.
