### PR TITLE
improve: reduce CPU overhead during session imports

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-checkpoint.ts
+++ b/src/config/sessions/session-accessor.sqlite-checkpoint.ts
@@ -13,6 +13,7 @@ import {
   writeSessionEntry,
 } from "./session-accessor.sqlite-entry-store.js";
 import { emitCommittedSessionIdentityDiff } from "./session-accessor.sqlite-identity.js";
+import { readTranscriptIdentityByEventId } from "./session-accessor.sqlite-read.js";
 import {
   formatSqliteSessionReferenceForScope,
   getSessionKysely,
@@ -22,10 +23,7 @@ import {
   toDatabaseOptions,
   type ResolvedSqliteScope,
 } from "./session-accessor.sqlite-scope.js";
-import {
-  appendTranscriptEventsInTransaction,
-  readTranscriptIdentityByEventId,
-} from "./session-accessor.sqlite-transcript-store.js";
+import { appendTranscriptEventsInTransaction } from "./session-accessor.sqlite-transcript-store.js";
 import { buildSessionCreationStamp } from "./session-entry-provenance.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import {

--- a/src/config/sessions/session-accessor.sqlite-read.ts
+++ b/src/config/sessions/session-accessor.sqlite-read.ts
@@ -3,6 +3,7 @@ import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   iterateSqliteQuerySync,
+  prepareSqliteQuerySync,
 } from "../../infra/kysely-sync.js";
 import { runSqliteDeferredTransactionSync } from "../../infra/sqlite-transaction.js";
 import { extractAssistantPhaseText } from "../../shared/chat-message-content.js";
@@ -37,6 +38,35 @@ export type SqliteTranscriptSnapshotRow = {
 export type SqliteTranscriptStorageRow = SqliteTranscriptSnapshotRow & {
   createdAt: number;
 };
+
+export function createTranscriptIdentityReader(database: OpenClawAgentDatabase, sessionId: string) {
+  const read = prepareSqliteQuerySync<
+    string,
+    { event_id: string; parent_id: string | null; seq: number }
+  >(database.db, (parameter) =>
+    getSessionKysely(database.db)
+      .selectFrom("transcript_event_identities")
+      .select(["event_id", "parent_id", "seq"])
+      .where("session_id", "=", sessionId)
+      .where(
+        "event_id",
+        "=",
+        parameter((eventId) => eventId),
+      ),
+  );
+  return (eventId: string) => {
+    const row = read(eventId).rows[0];
+    return row ? { eventId: row.event_id, parentId: row.parent_id, seq: row.seq } : undefined;
+  };
+}
+
+export function readTranscriptIdentityByEventId(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+  eventId: string,
+): { eventId: string; parentId: string | null; seq: number } | undefined {
+  return createTranscriptIdentityReader(database, sessionId)(eventId);
+}
 
 /** Loads raw transcript events from the additive SQLite transcript store. */
 export async function loadTranscriptEvents(

--- a/src/config/sessions/session-accessor.sqlite-transcript-message-append.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-message-append.ts
@@ -12,6 +12,7 @@ import {
   consumeSessionPendingInput,
   resolveSessionPendingInputAppend,
 } from "./session-accessor.sqlite-pending-inputs.js";
+import { readTranscriptIdentityByEventId } from "./session-accessor.sqlite-read.js";
 import type { ResolvedTranscriptScope } from "./session-accessor.sqlite-scope.js";
 import { readActiveTranscriptEntryAnchorInTransaction } from "./session-accessor.sqlite-transcript-anchor.js";
 import { resolveTranscriptMessageAppendParent } from "./session-accessor.sqlite-transcript-parent.js";
@@ -19,7 +20,6 @@ import {
   appendTranscriptEventInTransaction,
   ensureTranscriptHeader,
   readMessageIdempotencyKey,
-  readTranscriptIdentityByEventId,
   readTranscriptMessageByEventId,
   readTranscriptMessageByScopedIdempotencyKey,
   redactTranscriptMessageForStorage,

--- a/src/config/sessions/session-accessor.sqlite-transcript-sequences.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-sequences.ts
@@ -8,11 +8,11 @@ import type {
   SessionTranscriptTurnWriteContext,
   TranscriptMessageAppendResult,
 } from "./session-accessor.sqlite-contract.js";
+import { readTranscriptIdentityByEventId } from "./session-accessor.sqlite-read.js";
 import {
   resolveSqliteTranscriptScope,
   toDatabaseOptions,
 } from "./session-accessor.sqlite-scope.js";
-import { readTranscriptIdentityByEventId } from "./session-accessor.sqlite-transcript-store.js";
 
 // Append results are public SDK contracts. Keep commit-only cursor metadata
 // attached to their object lifetime without changing the returned message shape.

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -18,10 +18,12 @@ import type {
   TranscriptMessageAppendOptions,
 } from "./session-accessor.sqlite-contract.js";
 import {
+  createTranscriptIdentityReader,
   findTranscriptEventInDatabase,
   loadTranscriptEventsFromDatabase,
   readTranscriptEventId,
   readTranscriptEventMessage,
+  readTranscriptIdentityByEventId,
 } from "./session-accessor.sqlite-read.js";
 import { getSessionKysely, type ResolvedTranscriptScope } from "./session-accessor.sqlite-scope.js";
 import {
@@ -60,6 +62,7 @@ type TranscriptAppendOptions = {
 
 type TranscriptAppendCursor = {
   initialized?: boolean;
+  readIdentity?: ReturnType<typeof createTranscriptIdentityReader>;
   nextSeq?: number;
   appendToIndex?: ReturnType<typeof createTranscriptIndexAppenderInTransaction>;
   updateWindow?: (createdAt: number) => unknown;
@@ -118,8 +121,12 @@ function appendTranscriptEvent(
     cursor.initialized = true;
   }
   const identity = readTranscriptEventIdentity(persistedEvent);
-  if (identity && readTranscriptIdentityByEventId(database, scope.sessionId, identity.eventId)) {
-    return false;
+  if (identity) {
+    // Reuse compilation within this batch, but read fresh rows after every append.
+    cursor.readIdentity ??= createTranscriptIdentityReader(database, scope.sessionId);
+    if (cursor.readIdentity(identity.eventId)) {
+      return false;
+    }
   }
   const idempotencyKeyOwner = identity?.messageIdempotencyKey
     ? readIdempotencyKeyOwner(database, scope.sessionId, identity.messageIdempotencyKey)
@@ -573,23 +580,6 @@ export function updateSqliteTranscriptEventJsonInTransaction(
     });
   }
   scheduleTranscriptProjectionReconcile(database, sessionId, !rebuildSynchronously, {});
-}
-
-export function readTranscriptIdentityByEventId(
-  database: OpenClawAgentDatabase,
-  sessionId: string,
-  eventId: string,
-): { eventId: string; parentId: string | null; seq: number } | undefined {
-  const db = getSessionKysely(database.db);
-  const row = executeSqliteQueryTakeFirstSync(
-    database.db,
-    db
-      .selectFrom("transcript_event_identities")
-      .select(["event_id", "parent_id", "seq"])
-      .where("session_id", "=", sessionId)
-      .where("event_id", "=", eventId),
-  );
-  return row ? { eventId: row.event_id, parentId: row.parent_id, seq: row.seq } : undefined;
 }
 
 function readIdempotencyKeyOwner(


### PR DESCRIPTION
Related: #133641

## What Problem This Solves

Large session-history imports repeatedly rebuild and compile the same event-identity query, even though only the event ID changes within a session batch. This consumes CPU on top of the SQLite lookup itself.

## Why This Change Was Made

Compile the existing identity lookup once per synchronous append batch through `prepareSqliteQuerySync`, binding fresh event IDs and reading current database rows on every call. Move the canonical identity reader into the existing transcript-read module and update its internal callers; there is no second query path or result cache.

## User Impact

Lower CPU overhead for importing histories with event IDs. Duplicate detection, replay ownership, parent links, sequence numbers, opaque data and migration semantics stay unchanged. No schema, index, concurrency, configuration, dependency or public SDK change.

## Evidence

- All 236 focused tests pass across eight files: importer rollback/deduplication, generic append, context eligibility, session accessor, conformance, forks, message cuts and the prepared-query primitive. Command: `node scripts/run-vitest.mjs src/config/sessions/session-accessor.sqlite-import.test.ts src/config/sessions/session-accessor.sqlite-transcript-store.test.ts src/config/sessions/session-transcript-context-eligibility.test.ts src/config/sessions/session-accessor.test.ts src/infra/kysely-sync.test.ts src/config/sessions/session-accessor.conformance.test.ts src/config/sessions/session-accessor.parent-fork.test.ts src/config/sessions/session-accessor.sqlite-message-cut.test.ts`.
- Scoped lint and formatting pass. The initial single-file implementation exceeded the transcript-store line limit; moving identity reads to their existing read owner resolved it without a suppression.
- Independent Codex review of the final diff is scoped-clean through P3, confidence 0.95.
- Production +43/-25 (net +18), including moved code and internal import changes; no test growth or new module. The added state holds one batch-local compiled query, with fresh bindings and no retained result rows. Existing behavior tests cover the stale-binding and stale-result risks.
- Preliminary macOS Node 26 screening of 10,000-event full imports preserved exact stored-data digests. Both unprofiled pairs improved: CPU 1135.4 → 925.3 ms and 1002.4 → 896.8 ms. These are exploratory observations, not the final Linux performance claim.
- Paired Linux full-import measurements and timed-region CPU profiles passed. Exact-head CI and packaged stable-upgrade proof also passed. Structural local changed checks passed through the core tsgo graph boundary, including three dead-export scans. Local core typecheck stopped on six pre-existing errors in unchanged `src/logging/logger.ts`; shared `tslog` lacks `types/BaseLogger.d.ts`. Shared dependencies were not modified; exact-head CI passed.

The private JSONL line-wrapper cleanup was also inspected, but not included: it removes a small allocation while this query compilation has a measured CPU cost. Doctor pre-count removal remains a separate error/report-ownership refactor.

### Linux before/after imports

Candidate `bd2175131d4c9e1f6c8cd450eab6c4d11ce9ba39`; baseline `83b61257d6e328d904e7ed0c99ee50b661bbfe6d`. Linux Node 24.19.0 / SQLite 3.53.3. Five alternating before/after pairs per shape, each in a fresh process. Fixtures and parity verification are outside the timer. These are complete file-to-SQLite imports.

| Shape | Before | After | Time reduction |
| --- | ---: | ---: | ---: |
| single | 9.3 ms | 8.9 ms | 3.7% |
| deep | 5880.6 ms | 5403.8 ms | 8.1% |
| wide | 646.4 ms | 623.2 ms | 3.6% |
| branch | 997.7 ms | 967.3 ms | 3.0% |
| replay | 163.4 ms | 163.0 ms | 0.3% |
| legacy-v1 | 636.8 ms | 622.2 ms | 2.3% |
| legacy-v2 | 603.0 ms | 571.2 ms | 5.3% |
| legacy-metadata-v1 | 367.9 ms | 348.2 ms | 5.3% |
| legacy-hooks-v2 | 532.4 ms | 464.8 ms | 12.7% |

The clearest gains are 100,000-event deep histories (8.1% less wall time, 8.3% less CPU) and legacy hook histories (12.7% less wall time, 12.0% less CPU). Smaller multi-session/v1 cases were noisy; the table reports medians without claiming a uniform speedup. Already-imported replay is effectively neutral.

All 45 pairs preserve exact transcript JSON, identities, session windows, active positions, index state and FTS digests. SQL trace is identical: 100,034 calls across 34 shapes. Eight CPU profiles cover the timed import region; sampled Kysely self-time falls from 1387.5 to 1040.4 ms in the deep profile, consistent with removing repeated AST compilation. Profile sampling is supporting evidence, not the timing benchmark.

Deep-case median peak RSS is 492.7 → 492.9 MiB. The branch case is 371.8 → 395.6 MiB; no general memory reduction is claimed. All raw samples are retained.

The harness overrides every changed module reachable from the import entry point with its baseline source, leaving all other source/dependencies identical. Four changed modules are reachable; the checkpoint import-only change is not in that bundle and is covered by the passing checkpoint/branch tests. An initial harness assertion incorrectly required all five changed files to be reachable and stopped before timing; it now verifies the actual bundle inputs and records the unused file explicitly.

Raw results/profile archive SHA-256: `cc83f499372d77b827a4ab5bd04a575ac960d1aff9f7ab749ee4f36061b33afb`. [Dedicated Testbox workflow](https://github.com/openclaw/openclaw/actions/runs/33347205106); [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33347238785). The benchmark command exited 0 in 211 seconds.

Native review compared current main `5de1376b7f62`: none of the five changed files differ from the benchmark baseline. Its newer retained-history optimization touches separate modules.

### Packaged stable upgrade and landing gates

The existing `published-upgrade-survivor` Docker lane passed from stable `2026.7.1-2` to the candidate tarball; build info confirms exact commit `bd2175131d4c9e1f6c8cd450eab6c4d11ce9ba39`. It preserved **4,800 sessions, 1,227,946 events and 10,000 cron jobs**. Automatic migration passed immediately after the update, before the standalone Doctor check. All survival assertions passed; eight Gateway history samples (600 messages across two agents) remained identical after restart. Repeat Doctor completed in 38 seconds within its 60-second budget. The lane took 505 seconds; build/package/test command took 779 seconds.

The test uses an explicit candidate tarball, manual Gateway restart and expected synthetic plugin-capability consent. It verifies automatic data migration, not unattended update-channel switching. The volume fixture uses v3 transcript headers; legacy-format performance is proved separately by the paired imports.

Docker proof archive SHA-256: `a43f5670e25aac4d70511df27dd1d77b948cc0881c4a44b045b3185911b23942`. The dedicated worker has been stopped after artifact collection.

Exact-head CI is green, and native preparation accepted the same tested commit without a rebase or additional push. The latest ClawSweeper review (2026-08-31 01:36 UTC) has no source correctness/security finding or rank-up moves; its incomplete-CI concern is resolved by the completed exact-head run and native gates. Maintainer handling proceeds under the requested performance-pass-and-land workflow.
