### PR TITLE
fix(agents): retry a content-free CLI stream that ended without a result

### DIFF
--- a/src/agents/cli-output-contracts.ts
+++ b/src/agents/cli-output-contracts.ts
@@ -35,7 +35,9 @@ export type CliTerminalFailure =
   // The backend ended the turn on purpose without a reply (hook stop, aborted
   // tools, budget). Keeping the CLI's own `terminal_reason` here is what lets
   // consumers name the cause instead of reporting a transport-shaped failure.
-  | { reason: "turn_stopped"; terminalReason: string; stopReason?: string };
+  | { reason: "turn_stopped"; terminalReason: string; stopReason?: string }
+  /** Stream ended without a result event and without producing any turn content. */
+  | { reason: "missing_result" };
 
 export type CliTerminalInterruption = {
   reason: "aborted" | "timeout";

--- a/src/agents/cli-output-error.test.ts
+++ b/src/agents/cli-output-error.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { createCliJsonlStreamingParser } from "./cli-output-stream.js";
+import type { CliOutput } from "./cli-output-contracts.js";
+import {
+  CLI_STREAM_JSON_MISSING_RESULT_ERROR,
+  createCliJsonlStreamingParser,
+} from "./cli-output-stream.js";
 import { extractCliErrorMessage, formatCliOutputError, parseCliOutput } from "./cli-output.js";
+import { createCliOutputFailoverError } from "./cli-runner/output-error.js";
 import { createClaudeApiErrorFixture } from "./test-helpers/claude-api-error-fixture.js";
 
 type ParseCliOutputParams = Parameters<typeof parseCliOutput>[0];
@@ -61,6 +66,49 @@ describe("formatCliOutputError", () => {
       "Claude CLI ended the turn without a reply (terminal_reason: aborted_tools). " +
         "Tool actions may already have run; verify their effects before retrying.",
     );
+  });
+});
+
+describe("createCliOutputFailoverError", () => {
+  // Protocol-only orphaned exits must carry the fresh-session retry code, the
+  // same class the zero-output exit already reports.
+  it.each([
+    {
+      name: "missing-result terminal failure keeps the empty-failure retry code",
+      output: {
+        text: "",
+        sessionId: "orphaned-resume",
+        errorText: CLI_STREAM_JSON_MISSING_RESULT_ERROR,
+        terminalFailure: { reason: "missing_result" as const },
+      },
+      expectedReason: "unknown",
+      expectedCode: "cli_unknown_empty_failure",
+    },
+    {
+      name: "synthetic no-response keeps the format retry code",
+      output: {
+        text: "",
+        sessionId: "synthetic-empty",
+        errorText: "Claude CLI returned a synthetic no-response result.",
+        terminalFailure: { reason: "synthetic_no_response" as const },
+      },
+      expectedReason: "format",
+      expectedCode: "cli_synthetic_no_response",
+    },
+  ] as ReadonlyArray<{
+    name: string;
+    output: CliOutput;
+    expectedReason: string;
+    expectedCode: string;
+  }>)("classifies $name", ({ output, expectedReason, expectedCode }) => {
+    const error = createCliOutputFailoverError({
+      output,
+      provider: "claude-cli",
+      model: "claude-sonnet-4-6",
+    });
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toMatchObject({ reason: expectedReason, code: expectedCode });
   });
 });
 

--- a/src/agents/cli-output-events.ts
+++ b/src/agents/cli-output-events.ts
@@ -40,6 +40,10 @@ type ToolUseTracker = {
   nameById: Map<string, string>;
   startedIds: Set<string>;
   resultDeliveredIds: Set<string>;
+  // Cumulative whole-stream fact, kept in lockstep with the three collections
+  // above: the missing-result classifier reads it after pendingByIndex entries
+  // have been drained, so it must not depend on current key counts.
+  hasEmittedActivity: boolean;
 };
 
 export function createToolUseTracker(): ToolUseTracker {
@@ -48,6 +52,7 @@ export function createToolUseTracker(): ToolUseTracker {
     nameById: new Map(),
     startedIds: new Set(),
     resultDeliveredIds: new Set(),
+    hasEmittedActivity: false,
   };
 }
 
@@ -64,6 +69,7 @@ function emitToolStartOnce(
     return;
   }
   tracker.startedIds.add(toolCallId);
+  tracker.hasEmittedActivity = true;
   tracker.nameById.set(toolCallId, name);
   onToolUseStart?.({ toolCallId, name, kind, args });
 }
@@ -80,6 +86,7 @@ function emitToolResultOnce(
     return;
   }
   tracker.resultDeliveredIds.add(toolCallId);
+  tracker.hasEmittedActivity = true;
   onToolResult?.({
     toolCallId,
     name: tracker.nameById.get(toolCallId) ?? "",
@@ -276,6 +283,7 @@ export function dispatchClaudeCliStreamingToolEvent(params: {
         const toolCallId = typeof block.id === "string" ? block.id.trim() : "";
         const name = typeof block.name === "string" ? block.name.trim() : "";
         if (toolCallId && name) {
+          tracker.hasEmittedActivity = true;
           tracker.pendingByIndex.set(event.index, {
             toolCallId,
             name,
@@ -401,6 +409,10 @@ type ThinkingTracker = {
   currentSyntheticBlockIndex?: number;
   nextSyntheticBlockIndex: number;
   progressTokens: number;
+  // Cumulative across the whole stream, unlike the per-message fields above:
+  // the missing-result classifier reads it after a later message boundary has
+  // already reset emittedText/progressTokens, so it must survive those resets.
+  hasEmittedActivity: boolean;
 };
 
 export function createThinkingTracker(): ThinkingTracker {
@@ -409,6 +421,7 @@ export function createThinkingTracker(): ThinkingTracker {
     emittedText: "",
     nextSyntheticBlockIndex: 0,
     progressTokens: 0,
+    hasEmittedActivity: false,
   };
 }
 
@@ -482,6 +495,7 @@ function emitClaudeThinking(
 ): void {
   tracker.streamedByIndex.set(index, `${streamed}${delta}`);
   tracker.emittedText = assembleThinkingTextByIndex(tracker.streamedByIndex);
+  tracker.hasEmittedActivity = true;
   onThinkingDelta({ text: tracker.emittedText, delta, isReasoningSnapshot: true });
 }
 
@@ -498,6 +512,7 @@ function emitClaudeThinkingProgress(
   onThinkingProgress: (progress: CliThinkingProgress) => void,
 ): void {
   tracker.progressTokens += progressTokensDelta;
+  tracker.hasEmittedActivity = true;
   onThinkingProgress({ progressTokens: tracker.progressTokens });
 }
 
@@ -584,6 +599,7 @@ export function dispatchClaudeCliThinking(params: {
         continue;
       }
       tracker.emittedText = text;
+      tracker.hasEmittedActivity = true;
       params.onThinkingDelta({ text, delta: block.thinking, isReasoningSnapshot: true });
     }
   }

--- a/src/agents/cli-output-records.test.ts
+++ b/src/agents/cli-output-records.test.ts
@@ -686,6 +686,9 @@ describe("parseCliOutput", () => {
         sessionId: "session-empty",
         usage: undefined,
         errorText: "CLI stream-json output ended without a result event.",
+        // A content-free stream is the orphaned-exit empty-failure class, so it
+        // stays eligible for the fresh-session retry.
+        terminalFailure: { reason: "missing_result" },
       },
     },
   ])("$name", ({ raw, expected }) => {

--- a/src/agents/cli-output-stream.test.ts
+++ b/src/agents/cli-output-stream.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { createCliJsonlStreamingParser } from "./cli-output-stream.js";
+import {
+  CLI_STREAM_JSON_MISSING_RESULT_ERROR,
+  createCliJsonlStreamingParser,
+} from "./cli-output-stream.js";
 
 const OPENAI_COMPATIBLE_CLI_USAGE_CASES = [
   {
@@ -322,6 +325,59 @@ describe("createCliJsonlStreamingParser", () => {
       },
     });
   });
+
+  it.each([
+    {
+      name: "protocol-only init and system lines",
+      sessionId: "orphaned-resume",
+      frames: [
+        { type: "init", session_id: "orphaned-resume" },
+        { type: "system", subtype: "init", session_id: "orphaned-resume" },
+      ],
+      terminal: true,
+    },
+    {
+      name: "assistant tool activity without a result",
+      sessionId: "tool-activity",
+      frames: [
+        { type: "init", session_id: "tool-activity" },
+        {
+          type: "assistant",
+          message: {
+            model: "claude-sonnet-4-6",
+            role: "assistant",
+            content: [{ type: "tool_use", id: "tool-1", name: "Read", input: {} }],
+          },
+        },
+      ],
+      terminal: false,
+    },
+  ])(
+    "classifies a stream ending without a result after $name",
+    ({ frames, sessionId, terminal }) => {
+      const parser = createCliJsonlStreamingParser({
+        backend: {
+          command: "claude",
+          output: "jsonl",
+          jsonlDialect: "claude-stream-json",
+          sessionIdFields: ["session_id"],
+        },
+        providerId: "claude-cli",
+        onAssistantDelta: () => {},
+      });
+
+      parser.push(joinJsonlFrames(...frames, ""));
+      parser.finish();
+
+      expect(parser.getOutput()).toEqual({
+        text: "",
+        sessionId,
+        usage: undefined,
+        errorText: CLI_STREAM_JSON_MISSING_RESULT_ERROR,
+        ...(terminal ? { terminalFailure: { reason: "missing_result" } } : {}),
+      });
+    },
+  );
 
   it.each([
     {

--- a/src/agents/cli-output-stream.test.ts
+++ b/src/agents/cli-output-stream.test.ts
@@ -101,6 +101,22 @@ function claudeTextDelta(text: string, index?: number | string) {
   });
 }
 
+function claudeThinkingDelta(thinking: string, index?: number) {
+  return claudeStreamEvent({
+    type: "content_block_delta",
+    ...(index === undefined ? {} : { index }),
+    delta: { type: "thinking_delta", thinking },
+  });
+}
+
+function claudeThinkingProgress(index?: number, estimatedTokens = 12) {
+  return claudeStreamEvent({
+    type: "content_block_delta",
+    ...(index === undefined ? {} : { index }),
+    delta: { type: "thinking_delta", thinking: "", estimated_tokens: estimatedTokens },
+  });
+}
+
 function claudeSyntheticNoResponse(text = "No response requested.") {
   return {
     type: "assistant",
@@ -352,6 +368,28 @@ describe("createCliJsonlStreamingParser", () => {
       ],
       terminal: false,
     },
+    {
+      name: "streamed thinking text without a result",
+      sessionId: "thinking-only",
+      frames: [
+        { type: "init", session_id: "thinking-only" },
+        claudeMessageStart("msg-1"),
+        claudeBlockStart({ type: "thinking", thinking: "" }, 0),
+        claudeThinkingDelta("Working through the edit", 0),
+      ],
+      terminal: false,
+    },
+    {
+      name: "token-only thinking progress without a result",
+      sessionId: "thinking-progress",
+      frames: [
+        { type: "init", session_id: "thinking-progress" },
+        claudeMessageStart("msg-1"),
+        claudeBlockStart({ type: "thinking", thinking: "" }, 0),
+        claudeThinkingProgress(0),
+      ],
+      terminal: false,
+    },
   ])(
     "classifies a stream ending without a result after $name",
     ({ frames, sessionId, terminal }) => {
@@ -363,7 +401,11 @@ describe("createCliJsonlStreamingParser", () => {
           sessionIdFields: ["session_id"],
         },
         providerId: "claude-cli",
+        // Mirror the runtime composition: the runner always wires thinking
+        // callbacks, so thinking-only activity must reach this classifier.
         onAssistantDelta: () => {},
+        onThinkingDelta: () => {},
+        onThinkingProgress: () => {},
       });
 
       parser.push(joinJsonlFrames(...frames, ""));

--- a/src/agents/cli-output-stream.ts
+++ b/src/agents/cli-output-stream.ts
@@ -80,6 +80,7 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
   let rawLines = 0;
   const texts: string[] = [];
   let sawCustomJsonlEvent = false;
+  let sawCompactionActivity = false;
   let sawGeminiStructuredOutput = false;
   let sawTerminalResult = false;
   let sawClaudeSyntheticNoResponse = false;
@@ -245,6 +246,10 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
           observeSessionId(parsed);
         }
         for (const event of lifecycle.events) {
+          // Compaction metadata is a control operation, not turn content; its
+          // outcome belongs to the compaction owner, so it must not feed the
+          // orphaned-exit empty-failure classification in getOutput().
+          sawCompactionActivity = true;
           params.onCompaction?.(cliOutputLifecycle.projectCliBackendLifecycleEvent(event));
         }
       }
@@ -701,22 +706,22 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
       }
       if (isStreamJsonDialect(params)) {
         // A stream that ended without a result event but also without any turn
-        // content (assistant text or tool activity) is the orphaned-process
-        // signature of a mid-turn session rebuild. Marking it terminal records
-        // the empty-failure fact instead of a bare unknown reason; whether that
-        // clears the binding for a fresh retry stays with the backend's
-        // freshSessionRecovery policy.
-        const producedContent =
+        // activity (assistant text, thinking, tool activity, or compaction
+        // control metadata) is the orphaned-process signature of a mid-turn
+        // session rebuild. Marking it terminal records the empty-failure fact
+        // instead of a bare unknown reason; whether that clears the binding for
+        // a fresh retry stays with the backend's freshSessionRecovery policy.
+        const producedActivity =
           texts.length > 0 ||
-          toolTracker.pendingByIndex.size > 0 ||
-          toolTracker.startedIds.size > 0 ||
-          toolTracker.resultDeliveredIds.size > 0;
+          thinkingTracker.hasEmittedActivity ||
+          sawCompactionActivity ||
+          toolTracker.hasEmittedActivity;
         return {
           text: "",
           sessionId,
           usage,
           errorText: CLI_STREAM_JSON_MISSING_RESULT_ERROR,
-          ...(producedContent ? {} : { terminalFailure: { reason: "missing_result" as const } }),
+          ...(producedActivity ? {} : { terminalFailure: { reason: "missing_result" as const } }),
         };
       }
       const text = texts.join("\n").trim();

--- a/src/agents/cli-output-stream.ts
+++ b/src/agents/cli-output-stream.ts
@@ -700,11 +700,22 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
         return { text: "", sessionId, usage };
       }
       if (isStreamJsonDialect(params)) {
+        // A stream that ended without a result event but also without any turn
+        // content (assistant text or tool activity) is the orphaned-process
+        // signature of a mid-turn session rebuild. Marking it terminal keeps it
+        // eligible for the fresh-session retry a zero-line exit already gets;
+        // unmarked, the unknown reason silently fails the turn.
+        const producedContent =
+          texts.length > 0 ||
+          toolTracker.pendingByIndex.size > 0 ||
+          toolTracker.startedIds.size > 0 ||
+          toolTracker.resultDeliveredIds.size > 0;
         return {
           text: "",
           sessionId,
           usage,
           errorText: CLI_STREAM_JSON_MISSING_RESULT_ERROR,
+          ...(producedContent ? {} : { terminalFailure: { reason: "missing_result" as const } }),
         };
       }
       const text = texts.join("\n").trim();

--- a/src/agents/cli-output-stream.ts
+++ b/src/agents/cli-output-stream.ts
@@ -702,9 +702,10 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
       if (isStreamJsonDialect(params)) {
         // A stream that ended without a result event but also without any turn
         // content (assistant text or tool activity) is the orphaned-process
-        // signature of a mid-turn session rebuild. Marking it terminal keeps it
-        // eligible for the fresh-session retry a zero-line exit already gets;
-        // unmarked, the unknown reason silently fails the turn.
+        // signature of a mid-turn session rebuild. Marking it terminal records
+        // the empty-failure fact instead of a bare unknown reason; whether that
+        // clears the binding for a fresh retry stays with the backend's
+        // freshSessionRecovery policy.
         const producedContent =
           texts.length > 0 ||
           toolTracker.pendingByIndex.size > 0 ||

--- a/src/agents/cli-runner.fault-sequences.e2e.test.ts
+++ b/src/agents/cli-runner.fault-sequences.e2e.test.ts
@@ -313,6 +313,23 @@ describe("CLI runner fault sequences", () => {
       expectedChildren: 2,
       expectedCode: "cli_unknown_empty_failure",
     },
+    {
+      // A config hot-reload rebuild can orphan a resumed CLI child after it
+      // emitted only init/control lines: clean exit, no result event. Same
+      // empty-failure class as the zero-output exit, so the retry stays eligible.
+      label: "clean exit with protocol-only stdout",
+      install: () => {
+        supervisorSpawnMock
+          .mockResolvedValueOnce(
+            managedRun({
+              stdout: claudeJsonl([{ type: "system", subtype: "init", session_id: "cli-orphan" }]),
+            }),
+          )
+          .mockResolvedValueOnce(managedRun(successExit("fallback after orphaned resume")));
+      },
+      expectedChildren: 2,
+      expectedCode: "cli_unknown_empty_failure",
+    },
   ])(
     "classifies a pre-activity $label once before advancing the outer candidate",
     async (testCase) => {

--- a/src/agents/cli-runner.fault-sequences.e2e.test.ts
+++ b/src/agents/cli-runner.fault-sequences.e2e.test.ts
@@ -199,13 +199,18 @@ function buildProcessContext(params: CliBoundaryParams): PreparedCliRunContext {
   );
 }
 
-function buildReusableProcessContext(params: CliBoundaryParams): PreparedCliRunContext {
+function buildReusableProcessContext(
+  params: CliBoundaryParams & {
+    freshSessionRecovery?: "replace-binding" | "invalidated-only";
+  },
+): PreparedCliRunContext {
   const context = buildProcessContext(params);
   context.reusableCliSession = { mode: "reuse", sessionId: "source-cli-session" };
   context.openClawHistoryPrompt = RESEED_PROMPT;
   context.preparedBackend.backend = {
     ...context.preparedBackend.backend,
     resumeArgs: ["-p", "--resume", "{sessionId}", "--output-format", "stream-json"],
+    ...(params.freshSessionRecovery ? { freshSessionRecovery: params.freshSessionRecovery } : {}),
   };
   context.backendResolved.config = context.preparedBackend.backend;
   context.params.onBeforeFreshCliSessionRetry = vi.fn(async () => true);
@@ -517,6 +522,81 @@ describe("CLI runner fault sequences", () => {
     expect(supervisorSpawnMock).toHaveBeenCalledTimes(2);
     expectCounts({
       childProcesses: 2,
+      nativeRunBudgetAttempts: 0,
+      outerCandidates: 1,
+      runCliAgentCalls: 1,
+      wholeTurnRetries: 0,
+    });
+  });
+
+  it("fresh-retries a reused-session missing-result exit when the backend replaces bindings", async () => {
+    const clearBinding = vi.fn(async () => true);
+    harness.contextFor = (params) => {
+      const context = buildReusableProcessContext(params);
+      context.params.onBeforeFreshCliSessionRetry = clearBinding;
+      return context;
+    };
+    supervisorSpawnMock
+      .mockResolvedValueOnce(
+        managedRun({
+          stdout: claudeJsonl([{ type: "system", subtype: "init", session_id: "cli-orphan" }]),
+        }),
+      )
+      .mockResolvedValueOnce(managedRun(successExit("recovered after orphaned resume")));
+
+    const outcome = await runOuter();
+
+    expect(outcome.model).toBe(PRIMARY_MODEL);
+    expect(clearBinding).toHaveBeenCalledTimes(1);
+    expect(clearBinding).toHaveBeenCalledWith({
+      provider: "claude-cli",
+      reason: "unknown",
+      sessionId: "source-cli-session",
+    });
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(2);
+    expectCounts({
+      childProcesses: 2,
+      nativeRunBudgetAttempts: 0,
+      outerCandidates: 1,
+      runCliAgentCalls: 1,
+      wholeTurnRetries: 0,
+    });
+  });
+
+  it("keeps the stored binding and fails the turn for an invalidated-only missing-result exit", async () => {
+    const clearBinding = vi.fn(async () => true);
+    harness.contextFor = (params) => {
+      const context = buildReusableProcessContext({
+        ...params,
+        freshSessionRecovery: "invalidated-only",
+      });
+      context.params.onBeforeFreshCliSessionRetry = clearBinding;
+      return context;
+    };
+    supervisorSpawnMock.mockResolvedValueOnce(
+      managedRun({
+        stdout: claudeJsonl([{ type: "system", subtype: "init", session_id: "cli-orphan" }]),
+      }),
+    );
+
+    let error: unknown;
+    try {
+      await runOuter();
+    } catch (caught) {
+      error = caught;
+    }
+
+    // The invalidated-only contract is a backend-owned compatibility promise:
+    // a protocol-only exit proves nothing about the stored conversation, so
+    // the binding survives and the failure surfaces as a terminal outcome.
+    expect(error).toMatchObject({
+      reason: "unknown",
+      code: "cli_unknown_empty_failure",
+    });
+    expect(clearBinding).not.toHaveBeenCalled();
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
+    expectCounts({
+      childProcesses: 1,
       nativeRunBudgetAttempts: 0,
       outerCandidates: 1,
       runCliAgentCalls: 1,

--- a/src/agents/cli-runner/execute-process.ts
+++ b/src/agents/cli-runner/execute-process.ts
@@ -384,7 +384,11 @@ export async function executeCliProcess(params: {
       : null);
   // A completed terminal record is authoritative even if the CLI hangs
   // afterward. Reclassifying it as a timeout could replay completed tools.
-  if (parsedStructuredOutput?.terminalFailure) {
+  // Manual compaction is a control operation whose output contract belongs to
+  // the backend's validateOutput, not the model-turn classifier: a compaction
+  // stream legitimately ends without a model-turn result, so the terminal
+  // classification must not preempt that check.
+  if (parsedStructuredOutput?.terminalFailure && runParams.controlOperation !== "compact") {
     const terminalError = createCliOutputFailoverError({
       output: parsedStructuredOutput,
       ...outputErrorContext,

--- a/src/agents/cli-runner/output-error.ts
+++ b/src/agents/cli-runner/output-error.ts
@@ -27,8 +27,10 @@ export function createCliOutputFailoverError(params: {
       : "unknown"
     : (classifyFailoverReason(message, { provider: params.provider }) ?? "unknown");
   const code = terminalReason
-    ? // Same class as a zero-line exit: the CLI produced nothing to keep, so
-      // a fresh-session retry (not a provider failover) is the recovery.
+    ? // Same empty-failure class as a zero-line exit: the CLI kept nothing.
+      // Fresh-session retry eligibility stays with the backend's
+      // freshSessionRecovery policy; invalidated-only backends keep the
+      // binding and surface this as a terminal failure.
       terminalReason === "missing_result"
       ? "cli_unknown_empty_failure"
       : `cli_${terminalReason}`

--- a/src/agents/cli-runner/output-error.ts
+++ b/src/agents/cli-runner/output-error.ts
@@ -18,16 +18,20 @@ export function createCliOutputFailoverError(params: {
     runId: params.runId,
     sessionId: params.sessionId,
   });
-  const terminalFailure = params.output.terminalFailure?.reason;
+  const terminalReason = params.output.terminalFailure?.reason;
   // Record terminal facts before provider hooks can throw or reclassify them;
   // losing a max-turn stop here could replay tools in another model attempt.
-  const reason = terminalFailure
-    ? terminalFailure === "synthetic_no_response"
+  const reason = terminalReason
+    ? terminalReason === "synthetic_no_response"
       ? "format"
       : "unknown"
     : (classifyFailoverReason(message, { provider: params.provider }) ?? "unknown");
-  const code = terminalFailure
-    ? `cli_${terminalFailure}`
+  const code = terminalReason
+    ? // Same class as a zero-line exit: the CLI produced nothing to keep, so
+      // a fresh-session retry (not a provider failover) is the recovery.
+      terminalReason === "missing_result"
+      ? "cli_unknown_empty_failure"
+      : `cli_${terminalReason}`
     : reason === "context_overflow"
       ? "cli_context_overflow"
       : undefined;


### PR DESCRIPTION
## What Problem This Solves

Fixes #133475.

A config hot-reload that lands while another session's resume-turn is starting rebuilds the CLI session and orphans the resumed child. The dying Claude CLI process emits only init/control JSONL lines, then exits cleanly with no stderr and no assistant output. The stream parser reports the generic `CLI stream-json output ended without a result event.`, which classifies as an `unknown` failover reason with **no code** — so `shouldRetryFreshCliSessionAfterFailover` rejects the retry and the fresh-session reseed path (`cli_unknown_empty_failure`) never fires. The turn fails silently: exit 0, no output, no error surfaced to the user, and no recovery.

On the reported 2026.7.1-2 dist, the same turn with *zero* lines qualified for the retry; only init/control lines broke the eligibility check. Current `main` has the equivalent gap one layer down: `createCliOutputFailoverError` (`src/agents/cli-runner/output-error.ts`) only mints `cli_unknown_empty_failure` for a premature non-zero exit with fully empty output (`candidates.length === 0`), and a clean exit with protocol-only stdout reaches the missing-result error path, which sets no code at all.

## Why This Change Was Made

A stream that ends without a result event **and without any turn activity** (assistant text, thinking, tool activity, or compaction control metadata) is the same empty-failure class as a zero-line exit: there is nothing to keep, no tool ran, so a fresh-session retry carries no re-execution risk. The repair marks that activity-free stream as a `missing_result` terminal failure and maps it to the existing `cli_unknown_empty_failure` retry code, aligning it with the zero-output precedent (reason `unknown`, not the `format` channel used by Claude's own synthetic no-response envelope, and distinct from the deliberate `turn_stopped` reasons recorded for reply-less result events).

**Recovery stays policy-owned.** Whether `cli_unknown_empty_failure` clears the stored binding is decided by the backend's `freshSessionRecovery` contract (`docs/plugins/cli-backend-plugins.md`), not by this classification:

- `replace-binding` (the default, and every backend that does not opt out): the stored binding is cleared and the turn retries once against a freshly seeded session. This is the class of backends the reported orphaned-resume retry applies to.
- `invalidated-only` (the bundled Anthropic backend): the gate still refuses the retry, because a protocol-only exit proves nothing about the stored conversation — its Agent SDK contract does not treat non-expiration failures as proof that the session can no longer resume. The binding survives and the failure surfaces as a terminal outcome. This PR does not change that policy or claim a reseed on those backends; it only records the more precise empty-failure fact (`missing_result`) that the recovery owner can act on.

Streams that **did** produce activity stay unmarked: they may already have run tools and must not be silently replayed against a fresh session. Two properties make that guard sound rather than approximate:

- **Cumulative, not key-count.** The first cut read per-message tracker state (`pendingByIndex` size, thinking text/tokens) that message boundaries drain — a stream that had already emitted tool or thinking activity could be misread as content-free and marked for a fresh-session retry. The classifier now reads a `hasEmittedActivity` fact each tracker keeps for the whole stream, so nothing a later message boundary resets can change the answer.
- **Compaction metadata is not turn content.** Compaction lifecycle events are a control operation whose output contract belongs to the compaction owner (`manualCompaction.validateOutput`, exempted from the model-turn classifier in `execute-process.ts`), so they also count as activity for the empty-failure classification. Without this, a compaction-only stream was misclassified as content-free and preempted the backend's `validateOutput` — the main-side contract pinned by `keeps the missing-result failure after compaction-only metadata`.

Production delta is +52/−7 (net +45, tests +249/−3): a new closed-union `CliTerminalFailure` member, cumulative activity facts on the two trackers, a compaction-activity fact in the parser's missing-result branch, and the code mapping. Net-positive production growth is justified because the change restores the retry capability for the replace-binding backend class on a whole family of exits, and the terminal state must be representable in the `CliOutput` contract for the recovery owner to act on it.

## User Impact

- On backends that replace bindings (the default `freshSessionRecovery` contract): a resume turn orphaned by a config hot-reload now retries once against a freshly seeded session instead of silently producing nothing, keeping history continuity through the existing `reseedFromRawTranscriptWhenUncompacted` contract.
- On `invalidated-only` backends (bundled Anthropic): behavior is unchanged by contract — the stored binding is kept and the failed turn surfaces visibly rather than being reseeded. The failure now carries the precise `cli_unknown_empty_failure` classification instead of a bare unknown code.
- Activity-bearing streams (tool use, thinking, compaction control) keep their existing behavior on every backend (no code, no retry, no silent replay of executed tools or control operations).

## Evidence

**Root cause chain (source-verified on current `main`):**

1. Clean exit + protocol-only stdout reaches `createCliJsonlStreamingParser.getOutput()` (`src/agents/cli-output-stream.ts`): `rawLines > 0`, no terminal result → `errorText: CLI_STREAM_JSON_MISSING_RESULT_ERROR`, **no `terminalFailure`**.
2. `createCliOutputFailoverError` (`src/agents/cli-runner/output-error.ts`): `classifyFailoverReason` does not match the missing-result text → `reason: "unknown"`, `code: undefined`.
3. `shouldRetryFreshCliSessionAfterFailover` (`src/agents/cli-runner/cli-run-recovery.ts`): `case "unknown"` requires `code === "cli_unknown_empty_failure"` → retry refused → terminal silent failure.

**Pre-fix failing reproduction** (regression case `classifies a stream ending without a result after protocol-only init and system lines`, run against unpatched parser):

```
× createCliJsonlStreamingParser > classifies a stream ending without a result after 'protocol-only init and system lines'
```

**Post-fix (green):**

```
pnpm test src/agents/cli-output-stream.test.ts src/agents/cli-output-error.test.ts src/agents/cli-output-records.test.ts
  Test Files  3 passed   Tests  99 passed
node scripts/run-vitest.mjs src/agents/cli-runner/execute.supervisor-capture.test.ts
  Test Files  1 passed   Tests  61 passed
node scripts/run-vitest.mjs src/agents/cli-runner.fault-sequences.e2e.test.ts
  Test Files  1 passed   Tests  21 passed (863.94s, real child processes)
pnpm tsgo:core
  exit 0
node_modules/.bin/oxlint -c .oxlintrc.json --type-aware <touched files> / oxfmt --check
  clean
```

Added coverage:

- `cli-output-stream.test.ts`: protocol-only init/system lines → `terminalFailure: { reason: "missing_result" }`; the tool-activity-without-result control stays unmarked (no silent replay of executed tools); **new in the head commit**: streamed thinking text and token-only thinking progress without a result stay unmarked, with the parser wired exactly as the runner wires it (`onThinkingDelta`/`onThinkingProgress` are unconditional in `execute-process.ts`). Both new cases are red on the previous head, where the drained `emittedText`/`progressTokens` read as content-free.
- `cli-output-records.test.ts`: the main-side `keeps the missing-result failure after compaction-only metadata` contract is the case the first CI run caught — the compaction-activity fix is what keeps it green (red on `d230c17ee45` in `checks-node-compact-large-18`).
- `cli-output-error.test.ts`: `missing_result` → `reason: "unknown"` + `code: "cli_unknown_empty_failure"`; the synthetic no-response control keeps `format` + `cli_synthetic_no_response`.
- `cli-runner.fault-sequences.e2e.test.ts` (table case): "clean exit with protocol-only stdout" asserts the same `cli_unknown_empty_failure` classification as the existing "nonzero empty exit" case before advancing the outer candidate.
- `cli-runner.fault-sequences.e2e.test.ts` (reused-session recovery, both policy branches):
  - *replace-binding*: a reused-session missing-result exit fresh-retries once in-candidate — the stored binding is cleared through `onBeforeFreshCliSessionRetry` (`provider`/`reason`/`sessionId`), the replacement child answers, and the turn never crosses models.
  - *invalidated-only*: the same exit keeps the stored binding (the clear callback is never invoked), no second child spawns, and the turn fails as a visible terminal outcome with `reason: "unknown"` + `code: "cli_unknown_empty_failure"` — pinning the backend-owned compatibility contract instead of assuming it.

**Proof gap:** the fix is verified at the parser/classification/recovery-decision boundaries, and the recovery split above is proven at the process boundary for both policy values with mocked CLI children; a live orphaned-resume repro under a real config reload was not run in this environment.

**Branch history:** rebuilt onto `origin/main` (`993ad3048bf`) after `#136498` landed the adjacent `turn_stopped` union member in the same `CliTerminalFailure` union — the two reasons are merged, not re-derived. The rebuild also carries the CI fix for the compaction-only misclassification described above.

**CI:** the first run failed `checks-node-compact-large-18` / `ci-gate`: the new `missing_result` terminal mark preempted the backend's native-compaction `validateOutput` check, because the content check ignored compaction lifecycle activity and misclassified a compaction-only stream as content-free (main-side contract `keeps the missing-result failure after compaction-only metadata`). The execute-process-side `controlOperation === "compact"` exemption handled manual compaction; the parser-side compaction-activity fact closes the stream-level half so both layers agree. Rebuilt head `e5fd5851974` carries both halves.
