### PR TITLE
perf(sessions): reuse opaque-key matchers and pruning cursors

### DIFF
--- a/src/infra/map-size.ts
+++ b/src/infra/map-size.ts
@@ -10,10 +10,13 @@ export function pruneMapToMaxSize<K, V>(map: Map<K, V>, maxSize: number): void {
     return;
   }
 
+  if (map.size <= limit) {
+    return;
+  }
+  // Reuse the insertion-order cursor so bulk pruning does not restart at deleted entries.
+  const keys = map.keys();
   while (map.size > limit) {
-    // Map iteration is insertion ordered; deleting the first key preserves the newest tracked
-    // entries for request/memory guard caches.
-    const oldest = map.keys().next();
+    const oldest = keys.next();
     if (oldest.done) {
       break;
     }

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -66,15 +66,22 @@ const CASE_PRESERVING_PEERS: readonly CasePreservingPeerDescriptor[] = [
   { channel: "matrix", peerKinds: new Set(["channel", "group"]), span: "tail", unscoped: true },
 ];
 
-/** True when (channel, peerKind) owns a case-sensitive opaque peer ID. */
-function isCasePreservingPeer(
-  channel: string | undefined | null,
-  peerKind: string | undefined | null,
-): boolean {
-  const c = normalizeLowercaseStringOrEmpty(channel);
-  const k = normalizeLowercaseStringOrEmpty(peerKind);
-  return findCasePreservingPeerDescriptor(c, k) !== undefined;
-}
+const CASE_PRESERVING_PEER_PATTERNS = CASE_PRESERVING_PEERS.flatMap((descriptor) =>
+  [...descriptor.peerKinds].map((peerKind) => {
+    const prefix = `${escapeRegExp(descriptor.channel)}:${escapeRegExp(peerKind)}:`;
+    return {
+      span: descriptor.span,
+      pattern: new RegExp(
+        descriptor.span === "segment" ? `(^|:)${prefix}([^:]+)` : `^(?:agent:[^:]*:)+:*${prefix}`,
+        descriptor.span === "segment" ? "gi" : "i",
+      ),
+      unscopedPattern:
+        descriptor.span === "tail" && descriptor.unscoped
+          ? new RegExp(`^${prefix}`, "i")
+          : undefined,
+    };
+  }),
+);
 
 function findCasePreservingPeerDescriptor(
   channel: string | undefined | null,
@@ -121,7 +128,7 @@ export function normalizeSessionPeerId(params: {
   if (!peerId) {
     return "";
   }
-  return isCasePreservingPeer(params.channel, params.peerKind)
+  return findCasePreservingPeerDescriptor(params.channel, params.peerKind) !== undefined
     ? peerId
     : normalizeLowercaseStringOrEmpty(peerId);
 }
@@ -159,56 +166,36 @@ function mayContainCasePreservingPeer(raw: string): boolean {
  */
 function collectCasePreservedSpans(raw: string): PreservedSpan[] {
   const spans: PreservedSpan[] = [];
-  for (const descriptor of CASE_PRESERVING_PEERS) {
-    const channel = escapeRegExp(descriptor.channel);
-    for (const peerKind of descriptor.peerKinds) {
-      const kind = escapeRegExp(peerKind);
-      if (descriptor.span === "segment") {
-        // Unscoped: `<channel>:<peerKind>:<segment>` at start or after any colon.
-        const re = new RegExp(`(^|:)${channel}:${kind}:([^:]+)`, "gi");
-        for (const match of raw.matchAll(re)) {
-          const matched = match[0] ?? "";
-          const segment = match[2] ?? "";
-          const segStart = (match.index ?? 0) + matched.length - segment.length;
-          // Segment spans match the legacy `peerId.trim()` behavior exactly.
-          spans.push({ start: segStart, end: segStart + segment.length, trim: true });
-        }
-      } else {
-        const collectTailSpan = (tailStart: number): void => {
-          if (tailStart >= raw.length) {
-            return;
-          }
-          // Preserve Matrix room/event IDs, but keep structural thread marker
-          // casing canonical so `:Thread:` cannot fork a session key.
-          const tail = raw.slice(tailStart);
-          const threadMarker = ":thread:";
-          const markerIndex = normalizeLowercaseStringOrEmpty(tail).lastIndexOf(threadMarker);
-          if (markerIndex === -1) {
-            spans.push({ start: tailStart, end: raw.length, trim: false });
-            return;
-          }
-          spans.push({ start: tailStart, end: tailStart + markerIndex, trim: false });
-          const threadIdStart = tailStart + markerIndex + threadMarker.length;
-          if (threadIdStart < raw.length) {
-            spans.push({ start: threadIdStart, end: raw.length, trim: false });
-          }
-        };
-        // Preserve tails behind nested or malformed ownership wrappers without
-        // treating an inner channel-shaped identity as a runtime route.
-        const scopedRe = new RegExp(`^(?:agent:[^:]*:)+:*${channel}:${kind}:`, "i");
-        const scopedMatch = scopedRe.exec(raw);
-        if (scopedMatch) {
-          collectTailSpan(scopedMatch[0].length);
-          continue;
-        }
-        if (descriptor.unscoped) {
-          const unscopedRe = new RegExp(`^${channel}:${kind}:`, "i");
-          const unscopedMatch = unscopedRe.exec(raw);
-          if (unscopedMatch) {
-            collectTailSpan(unscopedMatch[0].length);
-          }
-        }
+  for (const descriptor of CASE_PRESERVING_PEER_PATTERNS) {
+    if (descriptor.span === "segment") {
+      // matchAll clones the global matcher, so separate keys never share a cursor.
+      for (const match of raw.matchAll(descriptor.pattern)) {
+        const matched = match[0] ?? "";
+        const segment = match[2] ?? "";
+        const segStart = (match.index ?? 0) + matched.length - segment.length;
+        // Segment spans match the legacy peerId.trim() behavior exactly.
+        spans.push({ start: segStart, end: segStart + segment.length, trim: true });
       }
+      continue;
+    }
+    // Nested/malformed ownership wrappers remain opaque; only the matcher owns their shape.
+    const match = descriptor.pattern.exec(raw) ?? descriptor.unscopedPattern?.exec(raw);
+    if (!match || match[0].length >= raw.length) {
+      continue;
+    }
+    const tailStart = match[0].length;
+    const tail = raw.slice(tailStart);
+    const threadMarker = ":thread:";
+    const markerIndex = normalizeLowercaseStringOrEmpty(tail).lastIndexOf(threadMarker);
+    if (markerIndex === -1) {
+      spans.push({ start: tailStart, end: raw.length, trim: false });
+      continue;
+    }
+    // Room/event bytes stay opaque; only the structural thread marker is folded.
+    spans.push({ start: tailStart, end: tailStart + markerIndex, trim: false });
+    const threadIdStart = tailStart + markerIndex + threadMarker.length;
+    if (threadIdStart < raw.length) {
+      spans.push({ start: threadIdStart, end: raw.length, trim: false });
     }
   }
   return spans;


### PR DESCRIPTION
Session-key normalization rebuilt its fixed opaque-peer matchers for every uncached key, while bounded-map pruning restarted a keys iterator for each eviction. Both owners already have the information needed to avoid that work.

This prepares the existing matchers once, flattens their tail collector, removes a redundant normalization helper, and uses one insertion-order cursor for bulk eviction. The public normalizer and ordinary-key path stay unchanged, as do opaque Matrix/Signal bytes, thread suffixes, alias proof, cache bounds, TTL, and caller-owned Map lifecycle. There is no new cache, option, public API, persistence format, or authority policy. Production is +52/−62 lines (net −10); tests are unchanged.

All 176 existing session, routing, store-key, Map, dedupe, and directory-cache tests passed on current main and the candidate. Independent complete-owner review and managed Codex review found no actionable defects. The complete formatted production AST matches the measured proposal. Current-source review found only an unrelated redaction-pattern delimiter change among the 128 historical runtime inputs; package dependencies are unchanged since the previous source review. Historical measurements remain identified with their original base.

The retained differential proof covers 2,229 scenarios / 6,841 comparison units and 43 complete workload projections / 129 comparisons. Eight fresh forward/reverse processes retained all 3,784 timing samples. Uncached opaque-key normalization in an already loaded module improves about 2.1–2.3×, and pruning 2,048 entries while retaining 2,048 improves about 8.8×. Most callers evict only one entry. Costs remain explicit: ordinary mixed-case misses were 35/46 ns slower, empty dedupe insertion 9/24 ns slower, and one-item eviction at cap one 1/4 ns slower. Empty-store controls were order-sensitive. These are scoped owner measurements, not whole-Gateway, channel-delivery, provider, or memory gains.

Verification commands:

```sh
pnpm test src/sessions/session-key-case-preservation.test.ts src/routing/session-key.test.ts src/routing/session-key.continuity.test.ts src/config/sessions/session-key.test.ts src/config/sessions/explicit-session-key-normalization.test.ts src/infra/map-size.test.ts src/infra/dedupe.test.ts src/infra/outbound/directory-cache.test.ts -- --maxWorkers=1
pnpm check:changed --base d56aacd6991b4c552fe1bd71b3d061034a70906b
```

Full changed-file checks passed, including production/test typechecks, lint, unused-export analysis, database guards, and zero runtime import cycles. This internal refactor preserves documented behavior; no new live-channel claim or operator action is introduced.
