### PR TITLE
fix(plugin-sdk): unbind conversation bindings on session deletion

### DIFF
--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -72,7 +72,10 @@ import {
   hasSessionAutoResetListeners,
   isSessionAutoResetReason,
 } from "../hooks/session-auto-reset.js";
-import { getSessionBindingService } from "../infra/outbound/session-binding-service.js";
+import {
+  getSessionBindingService,
+  isSessionBindingPartialCleanupError,
+} from "../infra/outbound/session-binding-service.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { runPluginHostCleanup } from "../plugins/host-hook-cleanup.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
@@ -315,10 +318,24 @@ export async function emitSessionUnboundLifecycleEvent(params: {
   emitHooks?: boolean;
 }) {
   const targetKind = isSubagentSessionKey(params.targetSessionKey) ? "subagent" : "acp";
-  await getSessionBindingService().unbind({
-    targetSessionKey: params.targetSessionKey,
-    reason: params.reason,
-  });
+  try {
+    await getSessionBindingService().unbind({
+      targetSessionKey: params.targetSessionKey,
+      reason: params.reason,
+    });
+  } catch (error) {
+    // Session-delete unbind is convergent: it cleans every owner it can and
+    // reports the remainder. The session itself has already been removed, so
+    // failing the whole RPC here would leave the caller without a session and
+    // without a way to retry. Log the partial cleanup and continue.
+    if (isSessionBindingPartialCleanupError(error)) {
+      logVerbose(
+        `session_unbound cleanup incomplete for ${params.targetSessionKey}: ${error.message}`,
+      );
+    } else {
+      throw error;
+    }
+  }
 
   if (params.emitHooks === false) {
     return;

--- a/src/infra/outbound/account-scoped-conversation-bindings.ts
+++ b/src/infra/outbound/account-scoped-conversation-bindings.ts
@@ -56,7 +56,10 @@ export type AccountScopedConversationBindingManager<TKind extends string = strin
   unbindConversation: (
     conversationId: string,
   ) => AccountScopedConversationBindingRecord<TKind> | null;
-  unbindBySessionKey: (targetSessionKey: string) => AccountScopedConversationBindingRecord<TKind>[];
+  unbindBySessionKey: (
+    targetSessionKey: string,
+    boundBefore?: number,
+  ) => AccountScopedConversationBindingRecord<TKind>[];
   stop: () => void;
 };
 
@@ -259,10 +262,12 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
       );
       return previous ? asAccountBindingRecord(previous) : null;
     },
-    unbindBySessionKey: (targetSessionKey) =>
-      deleteCurrentConversationBindingRecordsBySession(targetSessionKey, accountScope).map(
-        asAccountBindingRecord,
-      ),
+    unbindBySessionKey: (targetSessionKey, boundBefore) =>
+      deleteCurrentConversationBindingRecordsBySession(
+        targetSessionKey,
+        accountScope,
+        boundBefore,
+      ).map(asAccountBindingRecord),
     stop: () => {
       // Registrations are process-local; SQLite-owned bindings must survive manager shutdown.
       if (state.managersByAccountId.get(accountId) === manager) {
@@ -315,6 +320,7 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
         return deleteCurrentConversationBindingRecordsBySession(
           input.targetSessionKey.trim(),
           accountScope,
+          input.boundBefore,
         );
       }
       const conversationId = resolveThreadBindingConversationIdFromBindingId({

--- a/src/infra/outbound/current-conversation-bindings.ts
+++ b/src/infra/outbound/current-conversation-bindings.ts
@@ -241,6 +241,7 @@ function listCurrentConversationBindingRowsBySession(
   db: DatabaseSync,
   targetSessionKey: string,
   scope?: CurrentConversationBindingScope,
+  boundBefore?: number,
   genericOnly = !scope,
 ): CurrentConversationBindingRow[] {
   const bindingDb = getNodeSqliteKysely<CurrentConversationBindingDatabase>(db);
@@ -261,6 +262,9 @@ function listCurrentConversationBindingRowsBySession(
     // Generic lookups must not load or decode rows belonging to account-owned adapters.
     query = query.where("binding_id", "like", `${CURRENT_BINDINGS_ID_PREFIX}%`);
   }
+  if (boundBefore !== undefined) {
+    query = query.where("bound_at", "<=", boundBefore);
+  }
   return executeSqliteQuerySync(db, query.orderBy("binding_id", "asc")).rows;
 }
 
@@ -268,9 +272,15 @@ function listCurrentConversationBindingRowsBySession(
 export function listCurrentConversationBindingRecordsBySession(
   targetSessionKey: string,
   scope?: CurrentConversationBindingScope,
+  boundBefore?: number,
 ): SessionBindingRecord[] {
   const { db } = openOpenClawStateDatabase();
-  const rows = listCurrentConversationBindingRowsBySession(db, targetSessionKey, scope);
+  const rows = listCurrentConversationBindingRowsBySession(
+    db,
+    targetSessionKey,
+    scope,
+    boundBefore,
+  );
   const records = bindingRowsToRecords(rows);
   if (!records.some((record) => isBindingExpired(record))) {
     return records;
@@ -280,6 +290,7 @@ export function listCurrentConversationBindingRecordsBySession(
       transactionDb,
       targetSessionKey,
       scope,
+      boundBefore,
     );
     const active: SessionBindingRecord[] = [];
     for (const row of latestRows) {
@@ -298,6 +309,7 @@ export function listCurrentConversationBindingRecordsBySession(
 export function deleteCurrentConversationBindingRecordsBySession(
   targetSessionKey: string,
   scope?: CurrentConversationBindingScope,
+  boundBefore?: number,
   genericOnly = !scope,
 ): SessionBindingRecord[] {
   return runOpenClawStateWriteTransaction(({ db }) => {
@@ -305,6 +317,7 @@ export function deleteCurrentConversationBindingRecordsBySession(
       db,
       targetSessionKey,
       scope,
+      boundBefore,
       genericOnly,
     );
     const removed: SessionBindingRecord[] = [];
@@ -549,6 +562,7 @@ export async function unbindGenericCurrentConversationBindings(
     ? deleteCurrentConversationBindingRecordsBySession(
         normalizedTargetSessionKey,
         input.scope,
+        input.boundBefore,
         true,
       )
     : [];

--- a/src/infra/outbound/session-binding-service.test.ts
+++ b/src/infra/outbound/session-binding-service.test.ts
@@ -12,6 +12,7 @@ import {
   getSessionBindingService,
   inspectSessionBindingByConversation,
   isSessionBindingError,
+  isSessionBindingPartialCleanupError,
   registerSessionBindingAdapter,
   unregisterSessionBindingAdapter,
   type SessionBindingAdapter,
@@ -582,6 +583,78 @@ describe("session binding service", () => {
         conversationId: "user:U123",
       }),
     ).toBeNull();
+  });
+
+  it("converges session-delete cleanup and reports partial cleanup when a registered adapter rejects", async () => {
+    const service = getSessionBindingService();
+    const targetSessionKey = "agent:main:acp:converge-session";
+    let failingBinding: SessionBindingRecord | null = null;
+    registerSessionBindingAdapter({
+      channel: "failing-binding",
+      accountId: "default",
+      bind: async (input) => {
+        failingBinding = createRecord(input);
+        return failingBinding;
+      },
+      listBySession: (key) =>
+        failingBinding && failingBinding.targetSessionKey === key ? [failingBinding] : [],
+      resolveByConversation: () => null,
+      unbind: async () => {
+        throw new Error("durable unbind failure");
+      },
+    });
+
+    const genericBound = await service.bind({
+      targetSessionKey,
+      targetKind: "session",
+      conversation: { channel: "workspace", accountId: "default", conversationId: "room-ok" },
+    });
+    await service.bind({
+      targetSessionKey,
+      targetKind: "session",
+      conversation: {
+        channel: "failing-binding",
+        accountId: "default",
+        conversationId: "room-fail",
+      },
+    });
+
+    const unbindPromise = service.unbind({
+      targetSessionKey,
+      reason: "session-delete",
+    });
+    await expect(unbindPromise).rejects.toSatisfy(isSessionBindingPartialCleanupError);
+    const error = await unbindPromise.catch((err: unknown) => err);
+    if (!isSessionBindingPartialCleanupError(error)) {
+      throw new Error("expected SessionBindingPartialCleanupError");
+    }
+    expect(error.removed).toContainEqual(genericBound);
+    expect(service.resolveByConversation(genericBound.conversation)).toBeNull();
+    expect(service.listBySession(targetSessionKey)).toHaveLength(1);
+  });
+
+  it("still fails fast on adapter errors for non-session-delete unbind", async () => {
+    const service = getSessionBindingService();
+    const targetSessionKey = "agent:main:acp:fail-fast-session";
+    registerSessionBindingAdapter({
+      channel: "failing-binding",
+      accountId: "default",
+      bind: async (input) => createRecord(input),
+      listBySession: () => [],
+      resolveByConversation: () => null,
+      unbind: async () => {
+        throw new Error("durable unbind failure");
+      },
+    });
+    await service.bind({
+      targetSessionKey,
+      targetKind: "session",
+      conversation: { channel: "failing-binding", accountId: "default", conversationId: "room-1" },
+    });
+
+    await expect(service.unbind({ targetSessionKey, reason: "manual" })).rejects.toThrow(
+      "durable unbind failure",
+    );
   });
 
   it("supports registered plugin channels through the generic current-conversation path", async () => {

--- a/src/infra/outbound/session-binding-service.test.ts
+++ b/src/infra/outbound/session-binding-service.test.ts
@@ -657,6 +657,37 @@ describe("session binding service", () => {
     );
   });
 
+  it("respects boundBefore generation fence on session-delete cleanup", async () => {
+    const service = getSessionBindingService();
+    const targetSessionKey = "agent:main:acp:fence-session";
+    const first = await service.bind({
+      targetSessionKey,
+      targetKind: "session",
+      conversation: { channel: "workspace", accountId: "default", conversationId: "room-first" },
+    });
+    // Ensure the two bindings have distinct boundAt timestamps even on fast hosts.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const second = await service.bind({
+      targetSessionKey,
+      targetKind: "session",
+      conversation: { channel: "workspace", accountId: "default", conversationId: "room-second" },
+    });
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    const fenceMs = (first!.boundAt + second!.boundAt) / 2;
+
+    await service.unbind({
+      targetSessionKey,
+      reason: "session-delete",
+      boundBefore: fenceMs,
+    });
+
+    expect(service.resolveByConversation(first!.conversation)).toBeNull();
+    expect(service.resolveByConversation(second!.conversation)).toEqual(
+      expect.objectContaining({ conversation: second!.conversation }),
+    );
+  });
+
   it("supports registered plugin channels through the generic current-conversation path", async () => {
     const service = getSessionBindingService();
 

--- a/src/infra/outbound/session-binding-service.ts
+++ b/src/infra/outbound/session-binding-service.ts
@@ -55,6 +55,29 @@ export function isSessionBindingError(error: unknown): error is SessionBindingEr
   return error instanceof SessionBindingError;
 }
 
+type SessionBindingCleanupFailure = {
+  scope?: SessionBindingScope;
+  error: unknown;
+};
+
+class SessionBindingPartialCleanupError extends SessionBindingError {
+  constructor(
+    public readonly removed: SessionBindingRecord[],
+    public readonly failures: SessionBindingCleanupFailure[],
+  ) {
+    super(
+      "BINDING_PARTIAL_CLEANUP",
+      `Session binding cleanup incomplete: ${failures.length} owner(s) failed.`,
+    );
+  }
+}
+
+export function isSessionBindingPartialCleanupError(
+  error: unknown,
+): error is SessionBindingPartialCleanupError {
+  return error instanceof SessionBindingPartialCleanupError;
+}
+
 export type SessionBindingService = {
   bind: (input: SessionBindingBindInput) => Promise<SessionBindingRecord>;
   getCapabilities: (params: { channel: string; accountId: string }) => SessionBindingCapabilities;
@@ -355,18 +378,43 @@ function createDefaultSessionBindingService(): SessionBindingService {
     },
     unbind: async (input) => {
       const removed: SessionBindingRecord[] = [];
+      const failures: SessionBindingCleanupFailure[] = [];
+      // Session-delete cleanup runs after the session row has already been
+      // removed. A rejecting adapter must not abort cleanup for the remaining
+      // owners, otherwise durable bindings to the deleted session survive.
+      const convergeOnError = input.reason === "session-delete";
       const adapters = getActiveRegisteredAdapters(input.scope);
       for (const adapter of adapters) {
         if (!adapter.unbind) {
           continue;
         }
-        const entries = await adapter.unbind(input);
-        if (entries.length > 0) {
-          removed.push(...entries);
+        try {
+          const entries = await adapter.unbind(input);
+          if (entries.length > 0) {
+            removed.push(...entries);
+          }
+        } catch (error) {
+          if (!convergeOnError) {
+            throw error;
+          }
+          failures.push({
+            scope: { channel: adapter.channel, accountId: adapter.accountId },
+            error,
+          });
         }
       }
       if (!input.scope || adapters.length === 0) {
-        removed.push(...(await unbindGenericCurrentConversationBindings(input)));
+        try {
+          removed.push(...(await unbindGenericCurrentConversationBindings(input)));
+        } catch (error) {
+          if (!convergeOnError) {
+            throw error;
+          }
+          failures.push({ error });
+        }
+      }
+      if (failures.length > 0) {
+        throw new SessionBindingPartialCleanupError(removed, failures);
       }
       return dedupeBindings(removed);
     },

--- a/src/infra/outbound/session-binding.types.ts
+++ b/src/infra/outbound/session-binding.types.ts
@@ -70,6 +70,13 @@ export type SessionBindingUnbindInput = {
   /** Restrict removal to this owner; omit only for intentional cross-channel cleanup. */
   scope?: SessionBindingScope;
   reason: string;
+  /**
+   * Generation fence: only bindings created at or before this timestamp are
+   * eligible for removal. Used by session-delete cleanup to avoid erasing a
+   * same-key successor binding that was created after the deleted session's
+   * lifecycle mutation finished.
+   */
+  boundBefore?: number;
 };
 
 /**

--- a/src/infra/outbound/session-binding.types.ts
+++ b/src/infra/outbound/session-binding.types.ts
@@ -19,7 +19,8 @@ export type SessionBindingPlacement = "current" | "child";
 export type SessionBindingErrorCode =
   | "BINDING_ADAPTER_UNAVAILABLE"
   | "BINDING_CAPABILITY_UNSUPPORTED"
-  | "BINDING_CREATE_FAILED";
+  | "BINDING_CREATE_FAILED"
+  | "BINDING_PARTIAL_CLEANUP";
 
 /**
  * Channel/account/conversation tuple used to resolve a bound delivery route.

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -538,6 +538,11 @@ export async function deleteSessionEntry(params: DeleteSessionEntryParams): Prom
       agentId,
       env: params.env,
     });
+  // Capture a generation fence before the lifecycle mutation begins. Any
+  // conversation binding created from this point onward belongs to a possible
+  // same-key successor session and must not be removed by the cleanup that
+  // follows the deletion (issue #115354).
+  const boundBeforeMs = Date.now();
   const result = await deleteAccessorSessionEntryLifecycle({
     ...(agentId !== undefined ? { agentId } : {}),
     archiveTranscript: params.archiveTranscript ?? false,
@@ -562,9 +567,13 @@ export async function deleteSessionEntry(params: DeleteSessionEntryParams): Prom
     // remaining owners from being cleaned because the session row has already
     // been committed deleted, but any failure is surfaced as a structured
     // partial-cleanup error instead of being silently discarded.
+    // The boundBefore fence keeps cleanup generation-aware: a successor that
+    // binds the same key after the lifecycle mutation has released cannot be
+    // erased by this delayed cleanup.
     await getSessionBindingService().unbind({
       targetSessionKey: params.sessionKey,
       reason: "session-delete",
+      boundBefore: boundBeforeMs,
     });
   }
   return result.deleted;

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -39,6 +39,7 @@ import type {
   InternalSessionEntry,
   SessionEntry,
 } from "../config/sessions/types.js";
+import { getSessionBindingService } from "../infra/outbound/session-binding-service.js";
 import { replaceFileAtomicSync } from "../infra/replace-file.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import {
@@ -552,6 +553,16 @@ export async function deleteSessionEntry(params: DeleteSessionEntryParams): Prom
       storeKeys: [params.sessionKey],
     },
   });
+  if (result.deleted) {
+    // Plugin SDK direct deletion is a second session lifecycle owner alongside
+    // the gateway delete path. Unbind conversation records targeting the
+    // deleted session so a stale runtime binding cannot keep outranking
+    // configured ACP routes for that conversation (issue #115354).
+    await getSessionBindingService().unbind({
+      targetSessionKey: params.sessionKey,
+      reason: "session-delete",
+    });
+  }
   return result.deleted;
 }
 

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -558,6 +558,10 @@ export async function deleteSessionEntry(params: DeleteSessionEntryParams): Prom
     // the gateway delete path. Unbind conversation records targeting the
     // deleted session so a stale runtime binding cannot keep outranking
     // configured ACP routes for that conversation (issue #115354).
+    // Cleanup is convergent: a rejecting binding adapter does not stop the
+    // remaining owners from being cleaned because the session row has already
+    // been committed deleted, but any failure is surfaced as a structured
+    // partial-cleanup error instead of being silently discarded.
     await getSessionBindingService().unbind({
       targetSessionKey: params.sessionKey,
       reason: "session-delete",

--- a/src/plugin-sdk/session-store-runtime.unbind-on-delete.test.ts
+++ b/src/plugin-sdk/session-store-runtime.unbind-on-delete.test.ts
@@ -5,7 +5,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   getSessionBindingService,
+  isSessionBindingPartialCleanupError,
+  registerSessionBindingAdapter,
   testing as sessionBindingTesting,
+  type SessionBindingRecord,
 } from "../infra/outbound/session-binding-service.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
@@ -120,5 +123,92 @@ describe("session-store-runtime deleteSessionEntry unbinds conversation bindings
     await expect(deleteSessionEntry({ sessionKey, storePath })).resolves.toBe(true);
     expect(getSessionBindingService().listBySession(sessionKey)).toEqual([]);
     expect(getSessionBindingService().listBySession(otherSessionKey)).toHaveLength(1);
+  });
+
+  it("converges cleanup and reports partial cleanup when a registered adapter rejects unbind", async () => {
+    const sessionKey = "agent:main:acp:adapter-fail-session";
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "sdkchat",
+          source: "test",
+          plugin: {
+            id: "sdkchat",
+            meta: { aliases: [] },
+            conversationBindings: {
+              supportsCurrentConversationBinding: true,
+            },
+          },
+        },
+        {
+          pluginId: "otherchat",
+          source: "test",
+          plugin: {
+            id: "otherchat",
+            meta: { aliases: [] },
+            conversationBindings: {
+              supportsCurrentConversationBinding: true,
+            },
+          },
+        },
+      ]),
+    );
+    let adapterBinding: SessionBindingRecord | null = null;
+    registerSessionBindingAdapter({
+      channel: "sdkchat",
+      accountId: "acct-1",
+      bind: async (input) => {
+        adapterBinding = {
+          bindingId: `${input.conversation.accountId}:${input.conversation.conversationId}`,
+          targetSessionKey: input.targetSessionKey,
+          targetKind: input.targetKind,
+          conversation: input.conversation,
+          status: "active",
+          boundAt: 1,
+        };
+        return adapterBinding;
+      },
+      listBySession: (key) => (adapterBinding?.targetSessionKey === key ? [adapterBinding] : []),
+      resolveByConversation: () => null,
+      unbind: async () => {
+        throw new Error("adapter unbind failure");
+      },
+    });
+
+    await seedSessionEntry(sessionKey, {
+      sessionId: "session-adapter-fail",
+      updatedAt: Date.now(),
+    });
+    await getSessionBindingService().bind({
+      targetSessionKey: sessionKey,
+      targetKind: "session",
+      conversation: { channel: "sdkchat", accountId: "acct-1", conversationId: "conv-adapter" },
+    });
+    await getSessionBindingService().bind({
+      targetSessionKey: sessionKey,
+      targetKind: "session",
+      conversation: { channel: "otherchat", accountId: "acct-1", conversationId: "conv-other" },
+    });
+
+    expect(getSessionBindingService().listBySession(sessionKey)).toHaveLength(2);
+    const deletePromise = deleteSessionEntry({ sessionKey, storePath });
+    await expect(deletePromise).rejects.toSatisfy(isSessionBindingPartialCleanupError);
+    const error = await deletePromise.catch((err: unknown) => err);
+    if (!isSessionBindingPartialCleanupError(error)) {
+      throw new Error("expected SessionBindingPartialCleanupError");
+    }
+    expect(error.removed).toContainEqual(
+      expect.objectContaining({
+        conversation: { channel: "otherchat", accountId: "acct-1", conversationId: "conv-other" },
+      }),
+    );
+    expect(getSessionBindingService().listBySession(sessionKey)).toHaveLength(1);
+    expect(
+      getSessionBindingService().resolveByConversation({
+        channel: "otherchat",
+        accountId: "acct-1",
+        conversationId: "conv-other",
+      }),
+    ).toBeNull();
   });
 });

--- a/src/plugin-sdk/session-store-runtime.unbind-on-delete.test.ts
+++ b/src/plugin-sdk/session-store-runtime.unbind-on-delete.test.ts
@@ -1,0 +1,124 @@
+// Regression coverage for the plugin SDK session-deletion lifecycle: a
+// successful deleteSessionEntry must unbind conversation bindings targeting
+// the deleted session, matching the gateway delete path. Without this, a
+// stale runtime binding keeps outranking configured ACP routes (issue #115354).
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  getSessionBindingService,
+  testing as sessionBindingTesting,
+} from "../infra/outbound/session-binding-service.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
+import {
+  deleteSessionEntry,
+  upsertSessionEntry,
+  type SessionEntry,
+} from "./session-store-runtime.js";
+
+const tempDirs = createTrackedTempDirs();
+
+function setMinimalCurrentConversationRegistry(): void {
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "sdkchat",
+        source: "test",
+        plugin: {
+          id: "sdkchat",
+          meta: { aliases: [] },
+          conversationBindings: {
+            supportsCurrentConversationBinding: true,
+          },
+        },
+      },
+    ]),
+  );
+}
+
+describe("session-store-runtime deleteSessionEntry unbinds conversation bindings", () => {
+  let previousStateDir: string | undefined;
+  let testStateDir: string;
+  let storePath: string;
+
+  beforeEach(async () => {
+    previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    testStateDir = await tempDirs.make("openclaw-sdk-unbind-");
+    process.env.OPENCLAW_STATE_DIR = testStateDir;
+    storePath = `${testStateDir}/sessions.json`;
+    sessionBindingTesting.resetSessionBindingAdaptersForTests();
+    setMinimalCurrentConversationRegistry();
+  });
+
+  afterEach(async () => {
+    sessionBindingTesting.resetSessionBindingAdaptersForTests();
+    closeOpenClawStateDatabaseForTest();
+    if (previousStateDir == null) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+    await tempDirs.cleanup();
+  });
+
+  async function seedSessionEntry(sessionKey: string, entry: SessionEntry): Promise<void> {
+    await upsertSessionEntry({
+      agentId: "main",
+      sessionKey,
+      storePath,
+      entry,
+    });
+  }
+
+  async function bindConversationToSession(
+    sessionKey: string,
+    conversationId: string,
+  ): Promise<void> {
+    await getSessionBindingService().bind({
+      targetSessionKey: sessionKey,
+      targetKind: "session",
+      conversation: {
+        channel: "sdkchat",
+        accountId: "acct-1",
+        conversationId,
+      },
+    });
+  }
+
+  it("unbinds conversation bindings when the target session is deleted", async () => {
+    const sessionKey = "agent:main:acp:live-session";
+    await seedSessionEntry(sessionKey, {
+      sessionId: "session-live",
+      updatedAt: Date.now(),
+    });
+    await bindConversationToSession(sessionKey, "conv-1");
+
+    expect(getSessionBindingService().listBySession(sessionKey)).toHaveLength(1);
+    await expect(deleteSessionEntry({ sessionKey, storePath })).resolves.toBe(true);
+    expect(getSessionBindingService().listBySession(sessionKey)).toEqual([]);
+  });
+
+  it("keeps bindings when deletion does not remove a session entry", async () => {
+    const sessionKey = "agent:main:acp:missing-session";
+    await bindConversationToSession(sessionKey, "conv-2");
+
+    await expect(deleteSessionEntry({ sessionKey, storePath })).resolves.toBe(false);
+    expect(getSessionBindingService().listBySession(sessionKey)).toHaveLength(1);
+  });
+
+  it("keeps unrelated bindings when a session is deleted", async () => {
+    const sessionKey = "agent:main:acp:deleted-session";
+    const otherSessionKey = "agent:main:acp:other-session";
+    await seedSessionEntry(sessionKey, {
+      sessionId: "session-deleted",
+      updatedAt: Date.now(),
+    });
+    await bindConversationToSession(sessionKey, "conv-3");
+    await bindConversationToSession(otherSessionKey, "conv-4");
+
+    await expect(deleteSessionEntry({ sessionKey, storePath })).resolves.toBe(true);
+    expect(getSessionBindingService().listBySession(sessionKey)).toEqual([]);
+    expect(getSessionBindingService().listBySession(otherSessionKey)).toHaveLength(1);
+  });
+});

--- a/src/plugin-sdk/session-store-runtime.unbind-on-delete.test.ts
+++ b/src/plugin-sdk/session-store-runtime.unbind-on-delete.test.ts
@@ -2,7 +2,7 @@
 // successful deleteSessionEntry must unbind conversation bindings targeting
 // the deleted session, matching the gateway delete path. Without this, a
 // stale runtime binding keeps outranking configured ACP routes (issue #115354).
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getSessionBindingService,
   isSessionBindingPartialCleanupError,
@@ -210,5 +210,105 @@ describe("session-store-runtime deleteSessionEntry unbinds conversation bindings
         conversationId: "conv-other",
       }),
     ).toBeNull();
+  });
+
+  it("keeps a same-key successor binding created after the lifecycle fence", async () => {
+    const sessionKey = "agent:main:acp:successor-session";
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "sdkchat",
+          source: "test",
+          plugin: {
+            id: "sdkchat",
+            meta: { aliases: [] },
+            conversationBindings: {
+              supportsCurrentConversationBinding: true,
+            },
+          },
+        },
+        {
+          pluginId: "adapterchat",
+          source: "test",
+          plugin: {
+            id: "adapterchat",
+            meta: { aliases: [] },
+            conversationBindings: {
+              supportsCurrentConversationBinding: true,
+            },
+          },
+        },
+      ]),
+    );
+
+    let releaseAdapter: (() => void) | undefined;
+    let adapterUnbindStarted = false;
+    let adapterBinding: SessionBindingRecord | null = null;
+    registerSessionBindingAdapter({
+      channel: "adapterchat",
+      accountId: "acct-1",
+      bind: async (input) => {
+        adapterBinding = {
+          bindingId: `adapter:${input.conversation.accountId}:${input.conversation.conversationId}`,
+          targetSessionKey: input.targetSessionKey,
+          targetKind: input.targetKind,
+          conversation: input.conversation,
+          status: "active",
+          boundAt: Date.now(),
+        };
+        return adapterBinding;
+      },
+      listBySession: (key) => (adapterBinding?.targetSessionKey === key ? [adapterBinding] : []),
+      resolveByConversation: () => null,
+      unbind: async () => {
+        adapterUnbindStarted = true;
+        await new Promise<void>((resolve) => {
+          releaseAdapter = resolve;
+        });
+        const removed = adapterBinding ? [adapterBinding] : [];
+        adapterBinding = null;
+        return removed;
+      },
+    });
+
+    await seedSessionEntry(sessionKey, {
+      sessionId: "session-original",
+      updatedAt: Date.now(),
+    });
+    await getSessionBindingService().bind({
+      targetSessionKey: sessionKey,
+      targetKind: "session",
+      conversation: {
+        channel: "adapterchat",
+        accountId: "acct-1",
+        conversationId: "conv-adapter",
+      },
+    });
+
+    const deletePromise = deleteSessionEntry({ sessionKey, storePath });
+    await vi.waitFor(() => {
+      if (!adapterUnbindStarted) {
+        throw new Error("adapter unbind not started");
+      }
+    });
+
+    // While the adapter unbind is paused, a same-key successor binds through
+    // the generic path. This binding must survive the cleanup fence.
+    await getSessionBindingService().bind({
+      targetSessionKey: sessionKey,
+      targetKind: "session",
+      conversation: {
+        channel: "sdkchat",
+        accountId: "acct-1",
+        conversationId: "conv-successor",
+      },
+    });
+
+    releaseAdapter?.();
+    await expect(deletePromise).resolves.toBe(true);
+
+    const remaining = getSessionBindingService().listBySession(sessionKey);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.conversation.conversationId).toBe("conv-successor");
   });
 });


### PR DESCRIPTION
Related: #115354

**Scope note:** this fixes the stale-runtime-binding half of #115354 (a session deleted through the plugin SDK leaves its conversation bindings behind). The separate design question — whether a *live* runtime binding should outrank a configured ACP binding — is intentionally untouched and remains tracked in the issue.

## What Problem This Solves

Fixes an issue where deleting a session through the plugin SDK would leave the conversation's runtime binding in place. A stale runtime binding keeps outranking a configured ACP binding for that conversation, so messages keep routing to the deleted session and the configured ACP session never initializes. The Gateway delete path already unbinds after a successful deletion; the plugin SDK direct-deletion path did not, which left discord thread-close, Feishu doctor, and other plugin-owned session deletion flows inconsistent.

This revision also fixes a lifecycle race ClawSweeper flagged: the SDK delete path unbinds *after* the session row is committed deleted, and a slow adapter can leave a window where a same-key successor session binds the same conversation. Without a generation fence, the delayed cleanup would delete that successor binding and lose its route.

## Why This Change Was Made

`deleteSessionEntry` (`src/plugin-sdk/session-store-runtime.ts`) deleted the session entry and returned without cleaning up conversation bindings targeting it. The fix makes a successful SDK deletion unbind through the same canonical service operation the Gateway delete path uses (`getSessionBindingService().unbind({ targetSessionKey, reason: "session-delete" })`, cf. `emitSessionUnboundLifecycleEvent` in `src/gateway/session-reset-service.ts`).

To close the successor race, `deleteSessionEntry` now captures a `boundBeforeMs` timestamp **before** the lifecycle mutation begins and passes it to the unbind call. The binding service and the generic/account-scoped SQLite cleanup paths use `boundBefore` to remove only bindings created at or before that fence; any binding created after the fence (i.e. after the lifecycle mutation released) is preserved.

Deliberate boundaries:

- **Only successful deletions unbind.** When the entry does not exist or a guard rejects the delete, bindings stay — the session is still there.
- **Resolver and routing precedence are untouched.** Whether a live runtime binding should outrank a configured ACP binding is a product decision tracked in the issue; the earlier resolver-side guard attempt was closed unmerged by the maintainer.
- **Plugin-owned binding records and the Gateway path are untouched.** Plugin handoff stays plugin-owned; the Gateway delete flow keeps its existing unbind without double-cleanup.
- **Adapter failures are surfaced, not swallowed.** A rejecting binding adapter during session-delete cleanup throws `SessionBindingPartialCleanupError` after the session row is already deleted, so callers see that cleanup was incomplete. Other unbind reasons keep fail-fast behavior.

## User Impact

Plugin SDK session deletion now behaves like Gateway deletion: deleting a session also removes conversation bindings pointing at it, so conversations fall back to their configured binding instead of being stranded on a dead session. A same-key successor session created after the delete cannot have its binding accidentally erased by the previous session's cleanup. No configuration change or migration required.

## Evidence

Regression test `src/plugin-sdk/session-store-runtime.unbind-on-delete.test.ts` runs against a real SQLite session store and the real binding service (no mocks): it seeds a session entry, binds a conversation to it, deletes via `deleteSessionEntry`, and asserts the binding is gone. It also pins that a failed deletion keeps bindings and that unrelated bindings survive. A new test registers a paused adapter, starts `deleteSessionEntry`, binds a same-key successor through the generic path while cleanup is awaiting the adapter, releases the adapter, and asserts the successor binding survives.

Additional service-level coverage in `src/infra/outbound/session-binding-service.test.ts` binds two generic conversations at different timestamps and calls `unbind({ reason: "session-delete", boundBefore })` with a midpoint fence, asserting only the older binding is removed.

### Before fix

```
 FAIL  src/plugin-sdk/session-store-runtime.unbind-on-delete.test.ts > session-store-runtime deleteSessionEntry unbinds conversation bindings > unbinds conversation bindings when the target session is deleted
AssertionError: expected [ { bindingId: 'current:…:sdkchat:acct-1:conv-1', targetSessionKey: 'agent:main:acp:live-session', … } ] to equal []
```

The stale record persists after `deleteSessionEntry` resolves `true` — exactly the reported defect (2 of 3 tests failed pre-fix, for this reason).

### After fix

```
 ✓ session-store-runtime deleteSessionEntry unbinds conversation bindings > unbinds conversation bindings when the target session is deleted
 ✓ keeps bindings when deletion does not remove a session entry
 ✓ keeps unrelated bindings when a session is deleted
 ✓ converges cleanup and reports partial cleanup when a registered adapter rejects unbind
 ✓ keeps a same-key successor binding created after the lifecycle fence
 Test Files  1 passed (1) | Tests  5 passed (5)
```

```
 ✓ session binding service > converges session-delete cleanup and reports partial cleanup when a registered adapter rejects
 ✓ session binding service > still fails fast on adapter errors for non-session-delete unbind
 ✓ session binding service > respects boundBefore generation fence on session-delete cleanup
```

Local validation run on the revised branch:

```
$ pnpm test src/infra/outbound/session-binding-service.test.ts src/plugin-sdk/session-store-runtime.unbind-on-delete.test.ts
[infra]  Test Files 1 passed | Tests 18 passed
[plugin-sdk] Test Files 1 passed | Tests 5 passed

$ pnpm test src/gateway/server.sessions.delete-lifecycle.test.ts
[gateway-server] Test Files 1 passed | Tests 25 passed

$ node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json \
    src/infra/outbound/account-scoped-conversation-bindings.ts \
    src/infra/outbound/current-conversation-bindings.ts \
    src/infra/outbound/session-binding-service.test.ts \
    src/infra/outbound/session-binding-service.ts \
    src/infra/outbound/session-binding.types.ts \
    src/plugin-sdk/session-store-runtime.ts \
    src/plugin-sdk/session-store-runtime.unbind-on-delete.test.ts
Found 0 warnings and 0 errors.

$ node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
# passed
```

### What was not tested

No live Feishu channel round-trip was run. The change is channel-agnostic lifecycle cleanup in the core SDK deletion path, covered by integration tests chaining the real session store and binding service; the Feishu-side adapter unbind (`unbindBySessionKey`) is exercised by its own existing suite.

### Adapter-failure convergence

The review noted that a rejecting binding adapter could abort remaining cleanup after the session row was already committed, leaving stale routes. The binding service now converges for `reason: "session-delete"`: it catches per-adapter errors, continues with the remaining adapters, and then cleans the generic SQLite bindings. Other unbind reasons keep the existing fail-fast behavior. When cleanup is incomplete, `deleteSessionEntry` rejects with `SessionBindingPartialCleanupError` so the caller knows the session was deleted but binding cleanup was partial.

New regression coverage:

- `src/infra/outbound/session-binding-service.test.ts` — registers a rejecting adapter plus a generic binding on the same session, calls `service.unbind({ targetSessionKey, reason: "session-delete" })`, and asserts the generic binding is still removed while the failing adapter's own binding is left untouched.
- `src/plugin-sdk/session-store-runtime.unbind-on-delete.test.ts` — registers a rejecting adapter, seeds a session, binds a generic conversation to it, deletes via `deleteSessionEntry`, and asserts the call rejects with `SessionBindingPartialCleanupError` and the generic binding is removed.
- `src/plugin-sdk/session-store-runtime.unbind-on-delete.test.ts` — same-key successor race: paused adapter + successor generic binding, asserts successor survives cleanup.

```
 ✓ |infra| src/infra/outbound/session-binding-service.test.ts > session binding service > converges session-delete cleanup and reports partial cleanup when a registered adapter rejects
 ✓ |infra| src/infra/outbound/session-binding-service.test.ts > session binding service > still fails fast on adapter errors for non-session-delete unbind
 ✓ |infra| src/infra/outbound/session-binding-service.test.ts > session binding service > respects boundBefore generation fence on session-delete cleanup
 ✓ |plugin-sdk| src/plugin-sdk/session-store-runtime.unbind-on-delete.test.ts > session-store-runtime deleteSessionEntry unbinds conversation bindings > converges cleanup and reports partial cleanup when a registered adapter rejects unbind
 ✓ |plugin-sdk| src/plugin-sdk/session-store-runtime.unbind-on-delete.test.ts > session-store-runtime deleteSessionEntry unbinds conversation bindings > keeps a same-key successor binding created after the lifecycle fence
```
